### PR TITLE
Adopt compound assignment across examples and std

### DIFF
--- a/examples/arrays.rue
+++ b/examples/arrays.rue
@@ -10,8 +10,8 @@ fn main() -> i32 {
     let mut sum = 0;
     let mut i = 0;
     while i < 5 {
-        sum = sum + numbers[i];
-        i = i + 1;
+        sum += numbers[i];
+        i += 1;
     }
     @dbg(sum);  // 157
 
@@ -22,7 +22,7 @@ fn main() -> i32 {
         if numbers[i] > max {
             max = numbers[i];
         }
-        i = i + 1;
+        i += 1;
     }
     @dbg(max);  // 64
 
@@ -33,7 +33,7 @@ fn main() -> i32 {
         if numbers[i] < min {
             min = numbers[i];
         }
-        i = i + 1;
+        i += 1;
     }
     @dbg(min);  // 12
 

--- a/examples/bignum/big.rue
+++ b/examples/bignum/big.rue
@@ -16,7 +16,7 @@ pub struct Big {
         }
         while rest > 0 {
             limbs.push(rest % 1000000000);
-            rest = rest / 1000000000;
+            rest /= 1000000000;
         }
         Self { limbs: limbs }
     }
@@ -34,11 +34,11 @@ pub struct Big {
             let prod = self.limbs.get_or(i, 0) * small + carry;
             out.push(prod % 1000000000);
             carry = prod / 1000000000;
-            i = i + 1;
+            i += 1;
         }
         while carry > 0 {
             out.push(carry % 1000000000);
-            carry = carry / 1000000000;
+            carry /= 1000000000;
         }
         Self { limbs: out }
     }
@@ -54,7 +54,7 @@ pub struct Big {
             let s = self.limbs.get_or(i, 0) + other.limb(i) + carry;
             out.push(s % 1000000000);
             carry = s / 1000000000;
-            i = i + 1;
+            i += 1;
         }
         if carry > 0 {
             out.push(carry);
@@ -72,7 +72,7 @@ pub struct Big {
             let mut i = n;
             let mut result: i64 = 0;
             while i > 0 {
-                i = i - 1;
+                i -= 1;
                 let a = self.limbs.get_or(i, 0);
                 let b = other.limb(i);
                 if result == 0 {
@@ -90,7 +90,7 @@ pub fn factorial(n: i64) -> Big {
     let mut k: i64 = 2;
     while k <= n {
         acc = acc.mul_small(k);
-        k = k + 1;
+        k += 1;
     }
     acc
 }

--- a/examples/bst.rue
+++ b/examples/bst.rue
@@ -73,7 +73,7 @@ struct Tree {
             let top = stack.pop_or(0);
             if top == 0 { break; }
             let node = self.nodes.get_or(top, Node { val: 0, left: 0, right: 0 });
-            total = total + node.val;
+            total += node.val;
             cur = node.right;
         }
         total

--- a/examples/calculator/calc/parser.rue
+++ b/examples/calculator/calc/parser.rue
@@ -14,7 +14,7 @@ pub struct Parser {
 
     fn next_tag(inout self) -> i64 {
         let t = self.toks.tag_at(self.pos);
-        self.pos = self.pos + 1;
+        self.pos += 1;
         t
     }
 
@@ -59,7 +59,7 @@ pub struct Parser {
             let bp = self.binding_power(tag);
             if bp == 0 { break; }
             if bp <= min_bp { break; }
-            self.pos = self.pos + 1;
+            self.pos += 1;
             let rhs = self.parse_expr(bp);
             let node = self.op_node(tag);
             lhs = self.arena.add(node, @intCast(lhs), @intCast(rhs));

--- a/examples/calculator/calc/parser.rue
+++ b/examples/calculator/calc/parser.rue
@@ -29,7 +29,7 @@ pub struct Parser {
             self.arena.add(ast.NEG, @intCast(inner), 0)
         } else if t == token.LPAREN {
             let inner = self.parse_expr(0);
-            self.pos = self.pos + 1;   // consume ')'
+            self.pos += 1;   // consume ')'
             inner
         } else {
             @panic("unexpected token in prefix position")

--- a/examples/caldera/ai.rue
+++ b/examples/caldera/ai.rue
@@ -19,7 +19,7 @@ pub fn update(inout world: model.World) -> u64 {
         let entity = world.entities.get_or(i, model.empty_entity());
         let decision = choose(borrow world, borrow entity);
         if entity.alive && decision != entity.state {
-            changed = changed + 1;
+            changed += 1;
             world.entities.set(i, model.Entity { id: entity.id, kind: entity.kind,
                 faction: entity.faction, x: entity.x, y: entity.y,
                 previous_x: entity.previous_x, previous_y: entity.previous_y,
@@ -32,7 +32,7 @@ pub fn update(inout world: model.World) -> u64 {
                 updated_tick: world.tick, alive: entity.alive });
             model.add_event(inout world, 10 + decision, entity.id, entity.goal, decision);
         }
-        i = i + 1;
+        i += 1;
     }
     changed
 }

--- a/examples/caldera/ai_oracle.rue
+++ b/examples/caldera/ai_oracle.rue
@@ -20,7 +20,7 @@ pub fn verify(borrow world: model.World) -> bool {
         if ai.choose(borrow world, borrow entity) != expected(borrow world, borrow entity) {
             return false;
         }
-        i = i + 1;
+        i += 1;
     }
     true
 }

--- a/examples/caldera/audit_ai_balance.rue
+++ b/examples/caldera/audit_ai_balance.rue
@@ -151,7 +151,7 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
                 tiles += 1;
-                if tile.walkable { walkable = walkable + 1; }
+                if tile.walkable { walkable += 1; }
                 resources += tile.resource;
                 elevation += tile.height;
             }

--- a/examples/caldera/audit_ai_balance.rue
+++ b/examples/caldera/audit_ai_balance.rue
@@ -63,7 +63,7 @@ fn observe_entities(inout out: metric.Metric, borrow world: model.World) {
         metric.observe(inout out, entity_projection(borrow world, i), (i % 11) + 1);
         metric.warn(inout out, item.alive && (item.x < 0 || item.y < 0 ||
             @intCast(item.x) >= world.width || @intCast(item.y) >= world.height));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -73,7 +73,7 @@ fn observe_tiles(inout out: metric.Metric, borrow world: model.World) {
         let item = world.tiles.get_or(i, model.empty_tile());
         metric.observe(inout out, tile_projection(borrow world, i), (i % 13) + 1);
         metric.warn(inout out, item.x >= world.width || item.y >= world.height);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -82,18 +82,18 @@ fn observe_timeline(inout out: metric.Metric, borrow world: model.World) {
     while i < world.events.len() {
         metric.observe(inout out, event_projection(borrow world, i), (i % 5) + 1);
         metric.warn(inout out, world.events.get_or(i, model.empty_event()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
         metric.observe(inout out, command_projection(borrow world, i), (i % 7) + 1);
         metric.warn(inout out, world.commands.get_or(i, model.empty_command()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.snapshots.len() {
         metric.observe(inout out, snapshot_projection(borrow world, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -108,9 +108,9 @@ fn observe_pairs(inout out: metric.Metric, borrow world: model.World) {
             let dy = if left.y > right.y { left.y - right.y } else { right.y - left.y };
             metric.observe(inout out, @intCast(dx + dy) +
                 left.faction * 3 + right.faction * 5 + MODE(), i + j + 1);
-            j = j + 1;
+            j += 1;
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -125,17 +125,17 @@ fn observe_factions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.entities.len() {
             let entity = world.entities.get_or(i, model.empty_entity());
             if entity.faction == faction && entity.alive {
-                agents = agents + 1;
-                health = health + entity.health;
-                energy = energy + entity.energy;
-                inventory = inventory + entity.inventory;
+                agents += 1;
+                health += entity.health;
+                energy += entity.energy;
+                inventory += entity.inventory;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = agents * (MODE() % 11 + 1) + health * 3 +
             energy * 5 + inventory * 7 + faction;
         metric.observe(inout out, projection, faction + MODE() % 5 + 1);
-        faction = faction + 1;
+        faction += 1;
     }
 }
 
@@ -150,17 +150,17 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
-                tiles = tiles + 1;
+                tiles += 1;
                 if tile.walkable { walkable = walkable + 1; }
-                resources = resources + tile.resource;
-                elevation = elevation + tile.height;
+                resources += tile.resource;
+                elevation += tile.height;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = tiles * (MODE() % 13 + 1) + walkable * 3 +
             resources * 5 + elevation * 7 + region;
         metric.observe(inout out, projection, region % 7 + 1);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/audit_ai_capacity.rue
+++ b/examples/caldera/audit_ai_capacity.rue
@@ -151,7 +151,7 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
                 tiles += 1;
-                if tile.walkable { walkable = walkable + 1; }
+                if tile.walkable { walkable += 1; }
                 resources += tile.resource;
                 elevation += tile.height;
             }

--- a/examples/caldera/audit_ai_capacity.rue
+++ b/examples/caldera/audit_ai_capacity.rue
@@ -63,7 +63,7 @@ fn observe_entities(inout out: metric.Metric, borrow world: model.World) {
         metric.observe(inout out, entity_projection(borrow world, i), (i % 11) + 1);
         metric.warn(inout out, item.alive && (item.x < 0 || item.y < 0 ||
             @intCast(item.x) >= world.width || @intCast(item.y) >= world.height));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -73,7 +73,7 @@ fn observe_tiles(inout out: metric.Metric, borrow world: model.World) {
         let item = world.tiles.get_or(i, model.empty_tile());
         metric.observe(inout out, tile_projection(borrow world, i), (i % 13) + 1);
         metric.warn(inout out, item.x >= world.width || item.y >= world.height);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -82,18 +82,18 @@ fn observe_timeline(inout out: metric.Metric, borrow world: model.World) {
     while i < world.events.len() {
         metric.observe(inout out, event_projection(borrow world, i), (i % 5) + 1);
         metric.warn(inout out, world.events.get_or(i, model.empty_event()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
         metric.observe(inout out, command_projection(borrow world, i), (i % 7) + 1);
         metric.warn(inout out, world.commands.get_or(i, model.empty_command()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.snapshots.len() {
         metric.observe(inout out, snapshot_projection(borrow world, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -108,9 +108,9 @@ fn observe_pairs(inout out: metric.Metric, borrow world: model.World) {
             let dy = if left.y > right.y { left.y - right.y } else { right.y - left.y };
             metric.observe(inout out, @intCast(dx + dy) +
                 left.faction * 3 + right.faction * 5 + MODE(), i + j + 1);
-            j = j + 1;
+            j += 1;
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -125,17 +125,17 @@ fn observe_factions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.entities.len() {
             let entity = world.entities.get_or(i, model.empty_entity());
             if entity.faction == faction && entity.alive {
-                agents = agents + 1;
-                health = health + entity.health;
-                energy = energy + entity.energy;
-                inventory = inventory + entity.inventory;
+                agents += 1;
+                health += entity.health;
+                energy += entity.energy;
+                inventory += entity.inventory;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = agents * (MODE() % 11 + 1) + health * 3 +
             energy * 5 + inventory * 7 + faction;
         metric.observe(inout out, projection, faction + MODE() % 5 + 1);
-        faction = faction + 1;
+        faction += 1;
     }
 }
 
@@ -150,17 +150,17 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
-                tiles = tiles + 1;
+                tiles += 1;
                 if tile.walkable { walkable = walkable + 1; }
-                resources = resources + tile.resource;
-                elevation = elevation + tile.height;
+                resources += tile.resource;
+                elevation += tile.height;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = tiles * (MODE() % 13 + 1) + walkable * 3 +
             resources * 5 + elevation * 7 + region;
         metric.observe(inout out, projection, region % 7 + 1);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/audit_ai_continuity.rue
+++ b/examples/caldera/audit_ai_continuity.rue
@@ -151,7 +151,7 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
                 tiles += 1;
-                if tile.walkable { walkable = walkable + 1; }
+                if tile.walkable { walkable += 1; }
                 resources += tile.resource;
                 elevation += tile.height;
             }

--- a/examples/caldera/audit_ai_continuity.rue
+++ b/examples/caldera/audit_ai_continuity.rue
@@ -63,7 +63,7 @@ fn observe_entities(inout out: metric.Metric, borrow world: model.World) {
         metric.observe(inout out, entity_projection(borrow world, i), (i % 11) + 1);
         metric.warn(inout out, item.alive && (item.x < 0 || item.y < 0 ||
             @intCast(item.x) >= world.width || @intCast(item.y) >= world.height));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -73,7 +73,7 @@ fn observe_tiles(inout out: metric.Metric, borrow world: model.World) {
         let item = world.tiles.get_or(i, model.empty_tile());
         metric.observe(inout out, tile_projection(borrow world, i), (i % 13) + 1);
         metric.warn(inout out, item.x >= world.width || item.y >= world.height);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -82,18 +82,18 @@ fn observe_timeline(inout out: metric.Metric, borrow world: model.World) {
     while i < world.events.len() {
         metric.observe(inout out, event_projection(borrow world, i), (i % 5) + 1);
         metric.warn(inout out, world.events.get_or(i, model.empty_event()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
         metric.observe(inout out, command_projection(borrow world, i), (i % 7) + 1);
         metric.warn(inout out, world.commands.get_or(i, model.empty_command()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.snapshots.len() {
         metric.observe(inout out, snapshot_projection(borrow world, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -108,9 +108,9 @@ fn observe_pairs(inout out: metric.Metric, borrow world: model.World) {
             let dy = if left.y > right.y { left.y - right.y } else { right.y - left.y };
             metric.observe(inout out, @intCast(dx + dy) +
                 left.faction * 3 + right.faction * 5 + MODE(), i + j + 1);
-            j = j + 1;
+            j += 1;
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -125,17 +125,17 @@ fn observe_factions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.entities.len() {
             let entity = world.entities.get_or(i, model.empty_entity());
             if entity.faction == faction && entity.alive {
-                agents = agents + 1;
-                health = health + entity.health;
-                energy = energy + entity.energy;
-                inventory = inventory + entity.inventory;
+                agents += 1;
+                health += entity.health;
+                energy += entity.energy;
+                inventory += entity.inventory;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = agents * (MODE() % 11 + 1) + health * 3 +
             energy * 5 + inventory * 7 + faction;
         metric.observe(inout out, projection, faction + MODE() % 5 + 1);
-        faction = faction + 1;
+        faction += 1;
     }
 }
 
@@ -150,17 +150,17 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
-                tiles = tiles + 1;
+                tiles += 1;
                 if tile.walkable { walkable = walkable + 1; }
-                resources = resources + tile.resource;
-                elevation = elevation + tile.height;
+                resources += tile.resource;
+                elevation += tile.height;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = tiles * (MODE() % 13 + 1) + walkable * 3 +
             resources * 5 + elevation * 7 + region;
         metric.observe(inout out, projection, region % 7 + 1);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/audit_ai_cost.rue
+++ b/examples/caldera/audit_ai_cost.rue
@@ -151,7 +151,7 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
                 tiles += 1;
-                if tile.walkable { walkable = walkable + 1; }
+                if tile.walkable { walkable += 1; }
                 resources += tile.resource;
                 elevation += tile.height;
             }

--- a/examples/caldera/audit_ai_cost.rue
+++ b/examples/caldera/audit_ai_cost.rue
@@ -63,7 +63,7 @@ fn observe_entities(inout out: metric.Metric, borrow world: model.World) {
         metric.observe(inout out, entity_projection(borrow world, i), (i % 11) + 1);
         metric.warn(inout out, item.alive && (item.x < 0 || item.y < 0 ||
             @intCast(item.x) >= world.width || @intCast(item.y) >= world.height));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -73,7 +73,7 @@ fn observe_tiles(inout out: metric.Metric, borrow world: model.World) {
         let item = world.tiles.get_or(i, model.empty_tile());
         metric.observe(inout out, tile_projection(borrow world, i), (i % 13) + 1);
         metric.warn(inout out, item.x >= world.width || item.y >= world.height);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -82,18 +82,18 @@ fn observe_timeline(inout out: metric.Metric, borrow world: model.World) {
     while i < world.events.len() {
         metric.observe(inout out, event_projection(borrow world, i), (i % 5) + 1);
         metric.warn(inout out, world.events.get_or(i, model.empty_event()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
         metric.observe(inout out, command_projection(borrow world, i), (i % 7) + 1);
         metric.warn(inout out, world.commands.get_or(i, model.empty_command()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.snapshots.len() {
         metric.observe(inout out, snapshot_projection(borrow world, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -108,9 +108,9 @@ fn observe_pairs(inout out: metric.Metric, borrow world: model.World) {
             let dy = if left.y > right.y { left.y - right.y } else { right.y - left.y };
             metric.observe(inout out, @intCast(dx + dy) +
                 left.faction * 3 + right.faction * 5 + MODE(), i + j + 1);
-            j = j + 1;
+            j += 1;
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -125,17 +125,17 @@ fn observe_factions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.entities.len() {
             let entity = world.entities.get_or(i, model.empty_entity());
             if entity.faction == faction && entity.alive {
-                agents = agents + 1;
-                health = health + entity.health;
-                energy = energy + entity.energy;
-                inventory = inventory + entity.inventory;
+                agents += 1;
+                health += entity.health;
+                energy += entity.energy;
+                inventory += entity.inventory;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = agents * (MODE() % 11 + 1) + health * 3 +
             energy * 5 + inventory * 7 + faction;
         metric.observe(inout out, projection, faction + MODE() % 5 + 1);
-        faction = faction + 1;
+        faction += 1;
     }
 }
 
@@ -150,17 +150,17 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
-                tiles = tiles + 1;
+                tiles += 1;
                 if tile.walkable { walkable = walkable + 1; }
-                resources = resources + tile.resource;
-                elevation = elevation + tile.height;
+                resources += tile.resource;
+                elevation += tile.height;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = tiles * (MODE() % 13 + 1) + walkable * 3 +
             resources * 5 + elevation * 7 + region;
         metric.observe(inout out, projection, region % 7 + 1);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/audit_ai_coverage.rue
+++ b/examples/caldera/audit_ai_coverage.rue
@@ -151,7 +151,7 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
                 tiles += 1;
-                if tile.walkable { walkable = walkable + 1; }
+                if tile.walkable { walkable += 1; }
                 resources += tile.resource;
                 elevation += tile.height;
             }

--- a/examples/caldera/audit_ai_coverage.rue
+++ b/examples/caldera/audit_ai_coverage.rue
@@ -63,7 +63,7 @@ fn observe_entities(inout out: metric.Metric, borrow world: model.World) {
         metric.observe(inout out, entity_projection(borrow world, i), (i % 11) + 1);
         metric.warn(inout out, item.alive && (item.x < 0 || item.y < 0 ||
             @intCast(item.x) >= world.width || @intCast(item.y) >= world.height));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -73,7 +73,7 @@ fn observe_tiles(inout out: metric.Metric, borrow world: model.World) {
         let item = world.tiles.get_or(i, model.empty_tile());
         metric.observe(inout out, tile_projection(borrow world, i), (i % 13) + 1);
         metric.warn(inout out, item.x >= world.width || item.y >= world.height);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -82,18 +82,18 @@ fn observe_timeline(inout out: metric.Metric, borrow world: model.World) {
     while i < world.events.len() {
         metric.observe(inout out, event_projection(borrow world, i), (i % 5) + 1);
         metric.warn(inout out, world.events.get_or(i, model.empty_event()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
         metric.observe(inout out, command_projection(borrow world, i), (i % 7) + 1);
         metric.warn(inout out, world.commands.get_or(i, model.empty_command()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.snapshots.len() {
         metric.observe(inout out, snapshot_projection(borrow world, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -108,9 +108,9 @@ fn observe_pairs(inout out: metric.Metric, borrow world: model.World) {
             let dy = if left.y > right.y { left.y - right.y } else { right.y - left.y };
             metric.observe(inout out, @intCast(dx + dy) +
                 left.faction * 3 + right.faction * 5 + MODE(), i + j + 1);
-            j = j + 1;
+            j += 1;
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -125,17 +125,17 @@ fn observe_factions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.entities.len() {
             let entity = world.entities.get_or(i, model.empty_entity());
             if entity.faction == faction && entity.alive {
-                agents = agents + 1;
-                health = health + entity.health;
-                energy = energy + entity.energy;
-                inventory = inventory + entity.inventory;
+                agents += 1;
+                health += entity.health;
+                energy += entity.energy;
+                inventory += entity.inventory;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = agents * (MODE() % 11 + 1) + health * 3 +
             energy * 5 + inventory * 7 + faction;
         metric.observe(inout out, projection, faction + MODE() % 5 + 1);
-        faction = faction + 1;
+        faction += 1;
     }
 }
 
@@ -150,17 +150,17 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
-                tiles = tiles + 1;
+                tiles += 1;
                 if tile.walkable { walkable = walkable + 1; }
-                resources = resources + tile.resource;
-                elevation = elevation + tile.height;
+                resources += tile.resource;
+                elevation += tile.height;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = tiles * (MODE() % 13 + 1) + walkable * 3 +
             resources * 5 + elevation * 7 + region;
         metric.observe(inout out, projection, region % 7 + 1);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/audit_ai_density.rue
+++ b/examples/caldera/audit_ai_density.rue
@@ -151,7 +151,7 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
                 tiles += 1;
-                if tile.walkable { walkable = walkable + 1; }
+                if tile.walkable { walkable += 1; }
                 resources += tile.resource;
                 elevation += tile.height;
             }

--- a/examples/caldera/audit_ai_density.rue
+++ b/examples/caldera/audit_ai_density.rue
@@ -63,7 +63,7 @@ fn observe_entities(inout out: metric.Metric, borrow world: model.World) {
         metric.observe(inout out, entity_projection(borrow world, i), (i % 11) + 1);
         metric.warn(inout out, item.alive && (item.x < 0 || item.y < 0 ||
             @intCast(item.x) >= world.width || @intCast(item.y) >= world.height));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -73,7 +73,7 @@ fn observe_tiles(inout out: metric.Metric, borrow world: model.World) {
         let item = world.tiles.get_or(i, model.empty_tile());
         metric.observe(inout out, tile_projection(borrow world, i), (i % 13) + 1);
         metric.warn(inout out, item.x >= world.width || item.y >= world.height);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -82,18 +82,18 @@ fn observe_timeline(inout out: metric.Metric, borrow world: model.World) {
     while i < world.events.len() {
         metric.observe(inout out, event_projection(borrow world, i), (i % 5) + 1);
         metric.warn(inout out, world.events.get_or(i, model.empty_event()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
         metric.observe(inout out, command_projection(borrow world, i), (i % 7) + 1);
         metric.warn(inout out, world.commands.get_or(i, model.empty_command()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.snapshots.len() {
         metric.observe(inout out, snapshot_projection(borrow world, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -108,9 +108,9 @@ fn observe_pairs(inout out: metric.Metric, borrow world: model.World) {
             let dy = if left.y > right.y { left.y - right.y } else { right.y - left.y };
             metric.observe(inout out, @intCast(dx + dy) +
                 left.faction * 3 + right.faction * 5 + MODE(), i + j + 1);
-            j = j + 1;
+            j += 1;
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -125,17 +125,17 @@ fn observe_factions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.entities.len() {
             let entity = world.entities.get_or(i, model.empty_entity());
             if entity.faction == faction && entity.alive {
-                agents = agents + 1;
-                health = health + entity.health;
-                energy = energy + entity.energy;
-                inventory = inventory + entity.inventory;
+                agents += 1;
+                health += entity.health;
+                energy += entity.energy;
+                inventory += entity.inventory;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = agents * (MODE() % 11 + 1) + health * 3 +
             energy * 5 + inventory * 7 + faction;
         metric.observe(inout out, projection, faction + MODE() % 5 + 1);
-        faction = faction + 1;
+        faction += 1;
     }
 }
 
@@ -150,17 +150,17 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
-                tiles = tiles + 1;
+                tiles += 1;
                 if tile.walkable { walkable = walkable + 1; }
-                resources = resources + tile.resource;
-                elevation = elevation + tile.height;
+                resources += tile.resource;
+                elevation += tile.height;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = tiles * (MODE() % 13 + 1) + walkable * 3 +
             resources * 5 + elevation * 7 + region;
         metric.observe(inout out, projection, region % 7 + 1);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/audit_ai_entropy.rue
+++ b/examples/caldera/audit_ai_entropy.rue
@@ -151,7 +151,7 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
                 tiles += 1;
-                if tile.walkable { walkable = walkable + 1; }
+                if tile.walkable { walkable += 1; }
                 resources += tile.resource;
                 elevation += tile.height;
             }

--- a/examples/caldera/audit_ai_entropy.rue
+++ b/examples/caldera/audit_ai_entropy.rue
@@ -63,7 +63,7 @@ fn observe_entities(inout out: metric.Metric, borrow world: model.World) {
         metric.observe(inout out, entity_projection(borrow world, i), (i % 11) + 1);
         metric.warn(inout out, item.alive && (item.x < 0 || item.y < 0 ||
             @intCast(item.x) >= world.width || @intCast(item.y) >= world.height));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -73,7 +73,7 @@ fn observe_tiles(inout out: metric.Metric, borrow world: model.World) {
         let item = world.tiles.get_or(i, model.empty_tile());
         metric.observe(inout out, tile_projection(borrow world, i), (i % 13) + 1);
         metric.warn(inout out, item.x >= world.width || item.y >= world.height);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -82,18 +82,18 @@ fn observe_timeline(inout out: metric.Metric, borrow world: model.World) {
     while i < world.events.len() {
         metric.observe(inout out, event_projection(borrow world, i), (i % 5) + 1);
         metric.warn(inout out, world.events.get_or(i, model.empty_event()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
         metric.observe(inout out, command_projection(borrow world, i), (i % 7) + 1);
         metric.warn(inout out, world.commands.get_or(i, model.empty_command()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.snapshots.len() {
         metric.observe(inout out, snapshot_projection(borrow world, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -108,9 +108,9 @@ fn observe_pairs(inout out: metric.Metric, borrow world: model.World) {
             let dy = if left.y > right.y { left.y - right.y } else { right.y - left.y };
             metric.observe(inout out, @intCast(dx + dy) +
                 left.faction * 3 + right.faction * 5 + MODE(), i + j + 1);
-            j = j + 1;
+            j += 1;
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -125,17 +125,17 @@ fn observe_factions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.entities.len() {
             let entity = world.entities.get_or(i, model.empty_entity());
             if entity.faction == faction && entity.alive {
-                agents = agents + 1;
-                health = health + entity.health;
-                energy = energy + entity.energy;
-                inventory = inventory + entity.inventory;
+                agents += 1;
+                health += entity.health;
+                energy += entity.energy;
+                inventory += entity.inventory;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = agents * (MODE() % 11 + 1) + health * 3 +
             energy * 5 + inventory * 7 + faction;
         metric.observe(inout out, projection, faction + MODE() % 5 + 1);
-        faction = faction + 1;
+        faction += 1;
     }
 }
 
@@ -150,17 +150,17 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
-                tiles = tiles + 1;
+                tiles += 1;
                 if tile.walkable { walkable = walkable + 1; }
-                resources = resources + tile.resource;
-                elevation = elevation + tile.height;
+                resources += tile.resource;
+                elevation += tile.height;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = tiles * (MODE() % 13 + 1) + walkable * 3 +
             resources * 5 + elevation * 7 + region;
         metric.observe(inout out, projection, region % 7 + 1);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/audit_ai_fanout.rue
+++ b/examples/caldera/audit_ai_fanout.rue
@@ -151,7 +151,7 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
                 tiles += 1;
-                if tile.walkable { walkable = walkable + 1; }
+                if tile.walkable { walkable += 1; }
                 resources += tile.resource;
                 elevation += tile.height;
             }

--- a/examples/caldera/audit_ai_fanout.rue
+++ b/examples/caldera/audit_ai_fanout.rue
@@ -63,7 +63,7 @@ fn observe_entities(inout out: metric.Metric, borrow world: model.World) {
         metric.observe(inout out, entity_projection(borrow world, i), (i % 11) + 1);
         metric.warn(inout out, item.alive && (item.x < 0 || item.y < 0 ||
             @intCast(item.x) >= world.width || @intCast(item.y) >= world.height));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -73,7 +73,7 @@ fn observe_tiles(inout out: metric.Metric, borrow world: model.World) {
         let item = world.tiles.get_or(i, model.empty_tile());
         metric.observe(inout out, tile_projection(borrow world, i), (i % 13) + 1);
         metric.warn(inout out, item.x >= world.width || item.y >= world.height);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -82,18 +82,18 @@ fn observe_timeline(inout out: metric.Metric, borrow world: model.World) {
     while i < world.events.len() {
         metric.observe(inout out, event_projection(borrow world, i), (i % 5) + 1);
         metric.warn(inout out, world.events.get_or(i, model.empty_event()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
         metric.observe(inout out, command_projection(borrow world, i), (i % 7) + 1);
         metric.warn(inout out, world.commands.get_or(i, model.empty_command()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.snapshots.len() {
         metric.observe(inout out, snapshot_projection(borrow world, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -108,9 +108,9 @@ fn observe_pairs(inout out: metric.Metric, borrow world: model.World) {
             let dy = if left.y > right.y { left.y - right.y } else { right.y - left.y };
             metric.observe(inout out, @intCast(dx + dy) +
                 left.faction * 3 + right.faction * 5 + MODE(), i + j + 1);
-            j = j + 1;
+            j += 1;
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -125,17 +125,17 @@ fn observe_factions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.entities.len() {
             let entity = world.entities.get_or(i, model.empty_entity());
             if entity.faction == faction && entity.alive {
-                agents = agents + 1;
-                health = health + entity.health;
-                energy = energy + entity.energy;
-                inventory = inventory + entity.inventory;
+                agents += 1;
+                health += entity.health;
+                energy += entity.energy;
+                inventory += entity.inventory;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = agents * (MODE() % 11 + 1) + health * 3 +
             energy * 5 + inventory * 7 + faction;
         metric.observe(inout out, projection, faction + MODE() % 5 + 1);
-        faction = faction + 1;
+        faction += 1;
     }
 }
 
@@ -150,17 +150,17 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
-                tiles = tiles + 1;
+                tiles += 1;
                 if tile.walkable { walkable = walkable + 1; }
-                resources = resources + tile.resource;
-                elevation = elevation + tile.height;
+                resources += tile.resource;
+                elevation += tile.height;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = tiles * (MODE() % 13 + 1) + walkable * 3 +
             resources * 5 + elevation * 7 + region;
         metric.observe(inout out, projection, region % 7 + 1);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/audit_ai_integrity.rue
+++ b/examples/caldera/audit_ai_integrity.rue
@@ -151,7 +151,7 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
                 tiles += 1;
-                if tile.walkable { walkable = walkable + 1; }
+                if tile.walkable { walkable += 1; }
                 resources += tile.resource;
                 elevation += tile.height;
             }

--- a/examples/caldera/audit_ai_integrity.rue
+++ b/examples/caldera/audit_ai_integrity.rue
@@ -63,7 +63,7 @@ fn observe_entities(inout out: metric.Metric, borrow world: model.World) {
         metric.observe(inout out, entity_projection(borrow world, i), (i % 11) + 1);
         metric.warn(inout out, item.alive && (item.x < 0 || item.y < 0 ||
             @intCast(item.x) >= world.width || @intCast(item.y) >= world.height));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -73,7 +73,7 @@ fn observe_tiles(inout out: metric.Metric, borrow world: model.World) {
         let item = world.tiles.get_or(i, model.empty_tile());
         metric.observe(inout out, tile_projection(borrow world, i), (i % 13) + 1);
         metric.warn(inout out, item.x >= world.width || item.y >= world.height);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -82,18 +82,18 @@ fn observe_timeline(inout out: metric.Metric, borrow world: model.World) {
     while i < world.events.len() {
         metric.observe(inout out, event_projection(borrow world, i), (i % 5) + 1);
         metric.warn(inout out, world.events.get_or(i, model.empty_event()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
         metric.observe(inout out, command_projection(borrow world, i), (i % 7) + 1);
         metric.warn(inout out, world.commands.get_or(i, model.empty_command()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.snapshots.len() {
         metric.observe(inout out, snapshot_projection(borrow world, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -108,9 +108,9 @@ fn observe_pairs(inout out: metric.Metric, borrow world: model.World) {
             let dy = if left.y > right.y { left.y - right.y } else { right.y - left.y };
             metric.observe(inout out, @intCast(dx + dy) +
                 left.faction * 3 + right.faction * 5 + MODE(), i + j + 1);
-            j = j + 1;
+            j += 1;
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -125,17 +125,17 @@ fn observe_factions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.entities.len() {
             let entity = world.entities.get_or(i, model.empty_entity());
             if entity.faction == faction && entity.alive {
-                agents = agents + 1;
-                health = health + entity.health;
-                energy = energy + entity.energy;
-                inventory = inventory + entity.inventory;
+                agents += 1;
+                health += entity.health;
+                energy += entity.energy;
+                inventory += entity.inventory;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = agents * (MODE() % 11 + 1) + health * 3 +
             energy * 5 + inventory * 7 + faction;
         metric.observe(inout out, projection, faction + MODE() % 5 + 1);
-        faction = faction + 1;
+        faction += 1;
     }
 }
 
@@ -150,17 +150,17 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
-                tiles = tiles + 1;
+                tiles += 1;
                 if tile.walkable { walkable = walkable + 1; }
-                resources = resources + tile.resource;
-                elevation = elevation + tile.height;
+                resources += tile.resource;
+                elevation += tile.height;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = tiles * (MODE() % 13 + 1) + walkable * 3 +
             resources * 5 + elevation * 7 + region;
         metric.observe(inout out, projection, region % 7 + 1);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/audit_ai_latency.rue
+++ b/examples/caldera/audit_ai_latency.rue
@@ -151,7 +151,7 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
                 tiles += 1;
-                if tile.walkable { walkable = walkable + 1; }
+                if tile.walkable { walkable += 1; }
                 resources += tile.resource;
                 elevation += tile.height;
             }

--- a/examples/caldera/audit_ai_latency.rue
+++ b/examples/caldera/audit_ai_latency.rue
@@ -63,7 +63,7 @@ fn observe_entities(inout out: metric.Metric, borrow world: model.World) {
         metric.observe(inout out, entity_projection(borrow world, i), (i % 11) + 1);
         metric.warn(inout out, item.alive && (item.x < 0 || item.y < 0 ||
             @intCast(item.x) >= world.width || @intCast(item.y) >= world.height));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -73,7 +73,7 @@ fn observe_tiles(inout out: metric.Metric, borrow world: model.World) {
         let item = world.tiles.get_or(i, model.empty_tile());
         metric.observe(inout out, tile_projection(borrow world, i), (i % 13) + 1);
         metric.warn(inout out, item.x >= world.width || item.y >= world.height);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -82,18 +82,18 @@ fn observe_timeline(inout out: metric.Metric, borrow world: model.World) {
     while i < world.events.len() {
         metric.observe(inout out, event_projection(borrow world, i), (i % 5) + 1);
         metric.warn(inout out, world.events.get_or(i, model.empty_event()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
         metric.observe(inout out, command_projection(borrow world, i), (i % 7) + 1);
         metric.warn(inout out, world.commands.get_or(i, model.empty_command()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.snapshots.len() {
         metric.observe(inout out, snapshot_projection(borrow world, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -108,9 +108,9 @@ fn observe_pairs(inout out: metric.Metric, borrow world: model.World) {
             let dy = if left.y > right.y { left.y - right.y } else { right.y - left.y };
             metric.observe(inout out, @intCast(dx + dy) +
                 left.faction * 3 + right.faction * 5 + MODE(), i + j + 1);
-            j = j + 1;
+            j += 1;
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -125,17 +125,17 @@ fn observe_factions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.entities.len() {
             let entity = world.entities.get_or(i, model.empty_entity());
             if entity.faction == faction && entity.alive {
-                agents = agents + 1;
-                health = health + entity.health;
-                energy = energy + entity.energy;
-                inventory = inventory + entity.inventory;
+                agents += 1;
+                health += entity.health;
+                energy += entity.energy;
+                inventory += entity.inventory;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = agents * (MODE() % 11 + 1) + health * 3 +
             energy * 5 + inventory * 7 + faction;
         metric.observe(inout out, projection, faction + MODE() % 5 + 1);
-        faction = faction + 1;
+        faction += 1;
     }
 }
 
@@ -150,17 +150,17 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
-                tiles = tiles + 1;
+                tiles += 1;
                 if tile.walkable { walkable = walkable + 1; }
-                resources = resources + tile.resource;
-                elevation = elevation + tile.height;
+                resources += tile.resource;
+                elevation += tile.height;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = tiles * (MODE() % 13 + 1) + walkable * 3 +
             resources * 5 + elevation * 7 + region;
         metric.observe(inout out, projection, region % 7 + 1);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/audit_ai_locality.rue
+++ b/examples/caldera/audit_ai_locality.rue
@@ -151,7 +151,7 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
                 tiles += 1;
-                if tile.walkable { walkable = walkable + 1; }
+                if tile.walkable { walkable += 1; }
                 resources += tile.resource;
                 elevation += tile.height;
             }

--- a/examples/caldera/audit_ai_locality.rue
+++ b/examples/caldera/audit_ai_locality.rue
@@ -63,7 +63,7 @@ fn observe_entities(inout out: metric.Metric, borrow world: model.World) {
         metric.observe(inout out, entity_projection(borrow world, i), (i % 11) + 1);
         metric.warn(inout out, item.alive && (item.x < 0 || item.y < 0 ||
             @intCast(item.x) >= world.width || @intCast(item.y) >= world.height));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -73,7 +73,7 @@ fn observe_tiles(inout out: metric.Metric, borrow world: model.World) {
         let item = world.tiles.get_or(i, model.empty_tile());
         metric.observe(inout out, tile_projection(borrow world, i), (i % 13) + 1);
         metric.warn(inout out, item.x >= world.width || item.y >= world.height);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -82,18 +82,18 @@ fn observe_timeline(inout out: metric.Metric, borrow world: model.World) {
     while i < world.events.len() {
         metric.observe(inout out, event_projection(borrow world, i), (i % 5) + 1);
         metric.warn(inout out, world.events.get_or(i, model.empty_event()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
         metric.observe(inout out, command_projection(borrow world, i), (i % 7) + 1);
         metric.warn(inout out, world.commands.get_or(i, model.empty_command()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.snapshots.len() {
         metric.observe(inout out, snapshot_projection(borrow world, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -108,9 +108,9 @@ fn observe_pairs(inout out: metric.Metric, borrow world: model.World) {
             let dy = if left.y > right.y { left.y - right.y } else { right.y - left.y };
             metric.observe(inout out, @intCast(dx + dy) +
                 left.faction * 3 + right.faction * 5 + MODE(), i + j + 1);
-            j = j + 1;
+            j += 1;
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -125,17 +125,17 @@ fn observe_factions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.entities.len() {
             let entity = world.entities.get_or(i, model.empty_entity());
             if entity.faction == faction && entity.alive {
-                agents = agents + 1;
-                health = health + entity.health;
-                energy = energy + entity.energy;
-                inventory = inventory + entity.inventory;
+                agents += 1;
+                health += entity.health;
+                energy += entity.energy;
+                inventory += entity.inventory;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = agents * (MODE() % 11 + 1) + health * 3 +
             energy * 5 + inventory * 7 + faction;
         metric.observe(inout out, projection, faction + MODE() % 5 + 1);
-        faction = faction + 1;
+        faction += 1;
     }
 }
 
@@ -150,17 +150,17 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
-                tiles = tiles + 1;
+                tiles += 1;
                 if tile.walkable { walkable = walkable + 1; }
-                resources = resources + tile.resource;
-                elevation = elevation + tile.height;
+                resources += tile.resource;
+                elevation += tile.height;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = tiles * (MODE() % 13 + 1) + walkable * 3 +
             resources * 5 + elevation * 7 + region;
         metric.observe(inout out, projection, region % 7 + 1);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/audit_ai_pressure.rue
+++ b/examples/caldera/audit_ai_pressure.rue
@@ -151,7 +151,7 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
                 tiles += 1;
-                if tile.walkable { walkable = walkable + 1; }
+                if tile.walkable { walkable += 1; }
                 resources += tile.resource;
                 elevation += tile.height;
             }

--- a/examples/caldera/audit_ai_pressure.rue
+++ b/examples/caldera/audit_ai_pressure.rue
@@ -63,7 +63,7 @@ fn observe_entities(inout out: metric.Metric, borrow world: model.World) {
         metric.observe(inout out, entity_projection(borrow world, i), (i % 11) + 1);
         metric.warn(inout out, item.alive && (item.x < 0 || item.y < 0 ||
             @intCast(item.x) >= world.width || @intCast(item.y) >= world.height));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -73,7 +73,7 @@ fn observe_tiles(inout out: metric.Metric, borrow world: model.World) {
         let item = world.tiles.get_or(i, model.empty_tile());
         metric.observe(inout out, tile_projection(borrow world, i), (i % 13) + 1);
         metric.warn(inout out, item.x >= world.width || item.y >= world.height);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -82,18 +82,18 @@ fn observe_timeline(inout out: metric.Metric, borrow world: model.World) {
     while i < world.events.len() {
         metric.observe(inout out, event_projection(borrow world, i), (i % 5) + 1);
         metric.warn(inout out, world.events.get_or(i, model.empty_event()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
         metric.observe(inout out, command_projection(borrow world, i), (i % 7) + 1);
         metric.warn(inout out, world.commands.get_or(i, model.empty_command()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.snapshots.len() {
         metric.observe(inout out, snapshot_projection(borrow world, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -108,9 +108,9 @@ fn observe_pairs(inout out: metric.Metric, borrow world: model.World) {
             let dy = if left.y > right.y { left.y - right.y } else { right.y - left.y };
             metric.observe(inout out, @intCast(dx + dy) +
                 left.faction * 3 + right.faction * 5 + MODE(), i + j + 1);
-            j = j + 1;
+            j += 1;
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -125,17 +125,17 @@ fn observe_factions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.entities.len() {
             let entity = world.entities.get_or(i, model.empty_entity());
             if entity.faction == faction && entity.alive {
-                agents = agents + 1;
-                health = health + entity.health;
-                energy = energy + entity.energy;
-                inventory = inventory + entity.inventory;
+                agents += 1;
+                health += entity.health;
+                energy += entity.energy;
+                inventory += entity.inventory;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = agents * (MODE() % 11 + 1) + health * 3 +
             energy * 5 + inventory * 7 + faction;
         metric.observe(inout out, projection, faction + MODE() % 5 + 1);
-        faction = faction + 1;
+        faction += 1;
     }
 }
 
@@ -150,17 +150,17 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
-                tiles = tiles + 1;
+                tiles += 1;
                 if tile.walkable { walkable = walkable + 1; }
-                resources = resources + tile.resource;
-                elevation = elevation + tile.height;
+                resources += tile.resource;
+                elevation += tile.height;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = tiles * (MODE() % 13 + 1) + walkable * 3 +
             resources * 5 + elevation * 7 + region;
         metric.observe(inout out, projection, region % 7 + 1);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/audit_ai_risk.rue
+++ b/examples/caldera/audit_ai_risk.rue
@@ -151,7 +151,7 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
                 tiles += 1;
-                if tile.walkable { walkable = walkable + 1; }
+                if tile.walkable { walkable += 1; }
                 resources += tile.resource;
                 elevation += tile.height;
             }

--- a/examples/caldera/audit_ai_risk.rue
+++ b/examples/caldera/audit_ai_risk.rue
@@ -63,7 +63,7 @@ fn observe_entities(inout out: metric.Metric, borrow world: model.World) {
         metric.observe(inout out, entity_projection(borrow world, i), (i % 11) + 1);
         metric.warn(inout out, item.alive && (item.x < 0 || item.y < 0 ||
             @intCast(item.x) >= world.width || @intCast(item.y) >= world.height));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -73,7 +73,7 @@ fn observe_tiles(inout out: metric.Metric, borrow world: model.World) {
         let item = world.tiles.get_or(i, model.empty_tile());
         metric.observe(inout out, tile_projection(borrow world, i), (i % 13) + 1);
         metric.warn(inout out, item.x >= world.width || item.y >= world.height);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -82,18 +82,18 @@ fn observe_timeline(inout out: metric.Metric, borrow world: model.World) {
     while i < world.events.len() {
         metric.observe(inout out, event_projection(borrow world, i), (i % 5) + 1);
         metric.warn(inout out, world.events.get_or(i, model.empty_event()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
         metric.observe(inout out, command_projection(borrow world, i), (i % 7) + 1);
         metric.warn(inout out, world.commands.get_or(i, model.empty_command()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.snapshots.len() {
         metric.observe(inout out, snapshot_projection(borrow world, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -108,9 +108,9 @@ fn observe_pairs(inout out: metric.Metric, borrow world: model.World) {
             let dy = if left.y > right.y { left.y - right.y } else { right.y - left.y };
             metric.observe(inout out, @intCast(dx + dy) +
                 left.faction * 3 + right.faction * 5 + MODE(), i + j + 1);
-            j = j + 1;
+            j += 1;
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -125,17 +125,17 @@ fn observe_factions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.entities.len() {
             let entity = world.entities.get_or(i, model.empty_entity());
             if entity.faction == faction && entity.alive {
-                agents = agents + 1;
-                health = health + entity.health;
-                energy = energy + entity.energy;
-                inventory = inventory + entity.inventory;
+                agents += 1;
+                health += entity.health;
+                energy += entity.energy;
+                inventory += entity.inventory;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = agents * (MODE() % 11 + 1) + health * 3 +
             energy * 5 + inventory * 7 + faction;
         metric.observe(inout out, projection, faction + MODE() % 5 + 1);
-        faction = faction + 1;
+        faction += 1;
     }
 }
 
@@ -150,17 +150,17 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
-                tiles = tiles + 1;
+                tiles += 1;
                 if tile.walkable { walkable = walkable + 1; }
-                resources = resources + tile.resource;
-                elevation = elevation + tile.height;
+                resources += tile.resource;
+                elevation += tile.height;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = tiles * (MODE() % 13 + 1) + walkable * 3 +
             resources * 5 + elevation * 7 + region;
         metric.observe(inout out, projection, region % 7 + 1);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/audit_ai_skew.rue
+++ b/examples/caldera/audit_ai_skew.rue
@@ -151,7 +151,7 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
                 tiles += 1;
-                if tile.walkable { walkable = walkable + 1; }
+                if tile.walkable { walkable += 1; }
                 resources += tile.resource;
                 elevation += tile.height;
             }

--- a/examples/caldera/audit_ai_skew.rue
+++ b/examples/caldera/audit_ai_skew.rue
@@ -63,7 +63,7 @@ fn observe_entities(inout out: metric.Metric, borrow world: model.World) {
         metric.observe(inout out, entity_projection(borrow world, i), (i % 11) + 1);
         metric.warn(inout out, item.alive && (item.x < 0 || item.y < 0 ||
             @intCast(item.x) >= world.width || @intCast(item.y) >= world.height));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -73,7 +73,7 @@ fn observe_tiles(inout out: metric.Metric, borrow world: model.World) {
         let item = world.tiles.get_or(i, model.empty_tile());
         metric.observe(inout out, tile_projection(borrow world, i), (i % 13) + 1);
         metric.warn(inout out, item.x >= world.width || item.y >= world.height);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -82,18 +82,18 @@ fn observe_timeline(inout out: metric.Metric, borrow world: model.World) {
     while i < world.events.len() {
         metric.observe(inout out, event_projection(borrow world, i), (i % 5) + 1);
         metric.warn(inout out, world.events.get_or(i, model.empty_event()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
         metric.observe(inout out, command_projection(borrow world, i), (i % 7) + 1);
         metric.warn(inout out, world.commands.get_or(i, model.empty_command()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.snapshots.len() {
         metric.observe(inout out, snapshot_projection(borrow world, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -108,9 +108,9 @@ fn observe_pairs(inout out: metric.Metric, borrow world: model.World) {
             let dy = if left.y > right.y { left.y - right.y } else { right.y - left.y };
             metric.observe(inout out, @intCast(dx + dy) +
                 left.faction * 3 + right.faction * 5 + MODE(), i + j + 1);
-            j = j + 1;
+            j += 1;
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -125,17 +125,17 @@ fn observe_factions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.entities.len() {
             let entity = world.entities.get_or(i, model.empty_entity());
             if entity.faction == faction && entity.alive {
-                agents = agents + 1;
-                health = health + entity.health;
-                energy = energy + entity.energy;
-                inventory = inventory + entity.inventory;
+                agents += 1;
+                health += entity.health;
+                energy += entity.energy;
+                inventory += entity.inventory;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = agents * (MODE() % 11 + 1) + health * 3 +
             energy * 5 + inventory * 7 + faction;
         metric.observe(inout out, projection, faction + MODE() % 5 + 1);
-        faction = faction + 1;
+        faction += 1;
     }
 }
 
@@ -150,17 +150,17 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
-                tiles = tiles + 1;
+                tiles += 1;
                 if tile.walkable { walkable = walkable + 1; }
-                resources = resources + tile.resource;
-                elevation = elevation + tile.height;
+                resources += tile.resource;
+                elevation += tile.height;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = tiles * (MODE() % 13 + 1) + walkable * 3 +
             resources * 5 + elevation * 7 + region;
         metric.observe(inout out, projection, region % 7 + 1);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/audit_ai_stability.rue
+++ b/examples/caldera/audit_ai_stability.rue
@@ -151,7 +151,7 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
                 tiles += 1;
-                if tile.walkable { walkable = walkable + 1; }
+                if tile.walkable { walkable += 1; }
                 resources += tile.resource;
                 elevation += tile.height;
             }

--- a/examples/caldera/audit_ai_stability.rue
+++ b/examples/caldera/audit_ai_stability.rue
@@ -63,7 +63,7 @@ fn observe_entities(inout out: metric.Metric, borrow world: model.World) {
         metric.observe(inout out, entity_projection(borrow world, i), (i % 11) + 1);
         metric.warn(inout out, item.alive && (item.x < 0 || item.y < 0 ||
             @intCast(item.x) >= world.width || @intCast(item.y) >= world.height));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -73,7 +73,7 @@ fn observe_tiles(inout out: metric.Metric, borrow world: model.World) {
         let item = world.tiles.get_or(i, model.empty_tile());
         metric.observe(inout out, tile_projection(borrow world, i), (i % 13) + 1);
         metric.warn(inout out, item.x >= world.width || item.y >= world.height);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -82,18 +82,18 @@ fn observe_timeline(inout out: metric.Metric, borrow world: model.World) {
     while i < world.events.len() {
         metric.observe(inout out, event_projection(borrow world, i), (i % 5) + 1);
         metric.warn(inout out, world.events.get_or(i, model.empty_event()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
         metric.observe(inout out, command_projection(borrow world, i), (i % 7) + 1);
         metric.warn(inout out, world.commands.get_or(i, model.empty_command()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.snapshots.len() {
         metric.observe(inout out, snapshot_projection(borrow world, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -108,9 +108,9 @@ fn observe_pairs(inout out: metric.Metric, borrow world: model.World) {
             let dy = if left.y > right.y { left.y - right.y } else { right.y - left.y };
             metric.observe(inout out, @intCast(dx + dy) +
                 left.faction * 3 + right.faction * 5 + MODE(), i + j + 1);
-            j = j + 1;
+            j += 1;
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -125,17 +125,17 @@ fn observe_factions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.entities.len() {
             let entity = world.entities.get_or(i, model.empty_entity());
             if entity.faction == faction && entity.alive {
-                agents = agents + 1;
-                health = health + entity.health;
-                energy = energy + entity.energy;
-                inventory = inventory + entity.inventory;
+                agents += 1;
+                health += entity.health;
+                energy += entity.energy;
+                inventory += entity.inventory;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = agents * (MODE() % 11 + 1) + health * 3 +
             energy * 5 + inventory * 7 + faction;
         metric.observe(inout out, projection, faction + MODE() % 5 + 1);
-        faction = faction + 1;
+        faction += 1;
     }
 }
 
@@ -150,17 +150,17 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
-                tiles = tiles + 1;
+                tiles += 1;
                 if tile.walkable { walkable = walkable + 1; }
-                resources = resources + tile.resource;
-                elevation = elevation + tile.height;
+                resources += tile.resource;
+                elevation += tile.height;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = tiles * (MODE() % 13 + 1) + walkable * 3 +
             resources * 5 + elevation * 7 + region;
         metric.observe(inout out, projection, region % 7 + 1);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/audit_ai_throughput.rue
+++ b/examples/caldera/audit_ai_throughput.rue
@@ -151,7 +151,7 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
                 tiles += 1;
-                if tile.walkable { walkable = walkable + 1; }
+                if tile.walkable { walkable += 1; }
                 resources += tile.resource;
                 elevation += tile.height;
             }

--- a/examples/caldera/audit_ai_throughput.rue
+++ b/examples/caldera/audit_ai_throughput.rue
@@ -63,7 +63,7 @@ fn observe_entities(inout out: metric.Metric, borrow world: model.World) {
         metric.observe(inout out, entity_projection(borrow world, i), (i % 11) + 1);
         metric.warn(inout out, item.alive && (item.x < 0 || item.y < 0 ||
             @intCast(item.x) >= world.width || @intCast(item.y) >= world.height));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -73,7 +73,7 @@ fn observe_tiles(inout out: metric.Metric, borrow world: model.World) {
         let item = world.tiles.get_or(i, model.empty_tile());
         metric.observe(inout out, tile_projection(borrow world, i), (i % 13) + 1);
         metric.warn(inout out, item.x >= world.width || item.y >= world.height);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -82,18 +82,18 @@ fn observe_timeline(inout out: metric.Metric, borrow world: model.World) {
     while i < world.events.len() {
         metric.observe(inout out, event_projection(borrow world, i), (i % 5) + 1);
         metric.warn(inout out, world.events.get_or(i, model.empty_event()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
         metric.observe(inout out, command_projection(borrow world, i), (i % 7) + 1);
         metric.warn(inout out, world.commands.get_or(i, model.empty_command()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.snapshots.len() {
         metric.observe(inout out, snapshot_projection(borrow world, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -108,9 +108,9 @@ fn observe_pairs(inout out: metric.Metric, borrow world: model.World) {
             let dy = if left.y > right.y { left.y - right.y } else { right.y - left.y };
             metric.observe(inout out, @intCast(dx + dy) +
                 left.faction * 3 + right.faction * 5 + MODE(), i + j + 1);
-            j = j + 1;
+            j += 1;
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -125,17 +125,17 @@ fn observe_factions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.entities.len() {
             let entity = world.entities.get_or(i, model.empty_entity());
             if entity.faction == faction && entity.alive {
-                agents = agents + 1;
-                health = health + entity.health;
-                energy = energy + entity.energy;
-                inventory = inventory + entity.inventory;
+                agents += 1;
+                health += entity.health;
+                energy += entity.energy;
+                inventory += entity.inventory;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = agents * (MODE() % 11 + 1) + health * 3 +
             energy * 5 + inventory * 7 + faction;
         metric.observe(inout out, projection, faction + MODE() % 5 + 1);
-        faction = faction + 1;
+        faction += 1;
     }
 }
 
@@ -150,17 +150,17 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
-                tiles = tiles + 1;
+                tiles += 1;
                 if tile.walkable { walkable = walkable + 1; }
-                resources = resources + tile.resource;
-                elevation = elevation + tile.height;
+                resources += tile.resource;
+                elevation += tile.height;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = tiles * (MODE() % 13 + 1) + walkable * 3 +
             resources * 5 + elevation * 7 + region;
         metric.observe(inout out, projection, region % 7 + 1);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/audit_component_balance.rue
+++ b/examples/caldera/audit_component_balance.rue
@@ -151,7 +151,7 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
                 tiles += 1;
-                if tile.walkable { walkable = walkable + 1; }
+                if tile.walkable { walkable += 1; }
                 resources += tile.resource;
                 elevation += tile.height;
             }

--- a/examples/caldera/audit_component_balance.rue
+++ b/examples/caldera/audit_component_balance.rue
@@ -63,7 +63,7 @@ fn observe_entities(inout out: metric.Metric, borrow world: model.World) {
         metric.observe(inout out, entity_projection(borrow world, i), (i % 11) + 1);
         metric.warn(inout out, item.alive && (item.x < 0 || item.y < 0 ||
             @intCast(item.x) >= world.width || @intCast(item.y) >= world.height));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -73,7 +73,7 @@ fn observe_tiles(inout out: metric.Metric, borrow world: model.World) {
         let item = world.tiles.get_or(i, model.empty_tile());
         metric.observe(inout out, tile_projection(borrow world, i), (i % 13) + 1);
         metric.warn(inout out, item.x >= world.width || item.y >= world.height);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -82,18 +82,18 @@ fn observe_timeline(inout out: metric.Metric, borrow world: model.World) {
     while i < world.events.len() {
         metric.observe(inout out, event_projection(borrow world, i), (i % 5) + 1);
         metric.warn(inout out, world.events.get_or(i, model.empty_event()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
         metric.observe(inout out, command_projection(borrow world, i), (i % 7) + 1);
         metric.warn(inout out, world.commands.get_or(i, model.empty_command()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.snapshots.len() {
         metric.observe(inout out, snapshot_projection(borrow world, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -108,9 +108,9 @@ fn observe_pairs(inout out: metric.Metric, borrow world: model.World) {
             let dy = if left.y > right.y { left.y - right.y } else { right.y - left.y };
             metric.observe(inout out, @intCast(dx + dy) +
                 left.faction * 3 + right.faction * 5 + MODE(), i + j + 1);
-            j = j + 1;
+            j += 1;
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -125,17 +125,17 @@ fn observe_factions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.entities.len() {
             let entity = world.entities.get_or(i, model.empty_entity());
             if entity.faction == faction && entity.alive {
-                agents = agents + 1;
-                health = health + entity.health;
-                energy = energy + entity.energy;
-                inventory = inventory + entity.inventory;
+                agents += 1;
+                health += entity.health;
+                energy += entity.energy;
+                inventory += entity.inventory;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = agents * (MODE() % 11 + 1) + health * 3 +
             energy * 5 + inventory * 7 + faction;
         metric.observe(inout out, projection, faction + MODE() % 5 + 1);
-        faction = faction + 1;
+        faction += 1;
     }
 }
 
@@ -150,17 +150,17 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
-                tiles = tiles + 1;
+                tiles += 1;
                 if tile.walkable { walkable = walkable + 1; }
-                resources = resources + tile.resource;
-                elevation = elevation + tile.height;
+                resources += tile.resource;
+                elevation += tile.height;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = tiles * (MODE() % 13 + 1) + walkable * 3 +
             resources * 5 + elevation * 7 + region;
         metric.observe(inout out, projection, region % 7 + 1);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/audit_component_capacity.rue
+++ b/examples/caldera/audit_component_capacity.rue
@@ -151,7 +151,7 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
                 tiles += 1;
-                if tile.walkable { walkable = walkable + 1; }
+                if tile.walkable { walkable += 1; }
                 resources += tile.resource;
                 elevation += tile.height;
             }

--- a/examples/caldera/audit_component_capacity.rue
+++ b/examples/caldera/audit_component_capacity.rue
@@ -63,7 +63,7 @@ fn observe_entities(inout out: metric.Metric, borrow world: model.World) {
         metric.observe(inout out, entity_projection(borrow world, i), (i % 11) + 1);
         metric.warn(inout out, item.alive && (item.x < 0 || item.y < 0 ||
             @intCast(item.x) >= world.width || @intCast(item.y) >= world.height));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -73,7 +73,7 @@ fn observe_tiles(inout out: metric.Metric, borrow world: model.World) {
         let item = world.tiles.get_or(i, model.empty_tile());
         metric.observe(inout out, tile_projection(borrow world, i), (i % 13) + 1);
         metric.warn(inout out, item.x >= world.width || item.y >= world.height);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -82,18 +82,18 @@ fn observe_timeline(inout out: metric.Metric, borrow world: model.World) {
     while i < world.events.len() {
         metric.observe(inout out, event_projection(borrow world, i), (i % 5) + 1);
         metric.warn(inout out, world.events.get_or(i, model.empty_event()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
         metric.observe(inout out, command_projection(borrow world, i), (i % 7) + 1);
         metric.warn(inout out, world.commands.get_or(i, model.empty_command()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.snapshots.len() {
         metric.observe(inout out, snapshot_projection(borrow world, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -108,9 +108,9 @@ fn observe_pairs(inout out: metric.Metric, borrow world: model.World) {
             let dy = if left.y > right.y { left.y - right.y } else { right.y - left.y };
             metric.observe(inout out, @intCast(dx + dy) +
                 left.faction * 3 + right.faction * 5 + MODE(), i + j + 1);
-            j = j + 1;
+            j += 1;
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -125,17 +125,17 @@ fn observe_factions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.entities.len() {
             let entity = world.entities.get_or(i, model.empty_entity());
             if entity.faction == faction && entity.alive {
-                agents = agents + 1;
-                health = health + entity.health;
-                energy = energy + entity.energy;
-                inventory = inventory + entity.inventory;
+                agents += 1;
+                health += entity.health;
+                energy += entity.energy;
+                inventory += entity.inventory;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = agents * (MODE() % 11 + 1) + health * 3 +
             energy * 5 + inventory * 7 + faction;
         metric.observe(inout out, projection, faction + MODE() % 5 + 1);
-        faction = faction + 1;
+        faction += 1;
     }
 }
 
@@ -150,17 +150,17 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
-                tiles = tiles + 1;
+                tiles += 1;
                 if tile.walkable { walkable = walkable + 1; }
-                resources = resources + tile.resource;
-                elevation = elevation + tile.height;
+                resources += tile.resource;
+                elevation += tile.height;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = tiles * (MODE() % 13 + 1) + walkable * 3 +
             resources * 5 + elevation * 7 + region;
         metric.observe(inout out, projection, region % 7 + 1);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/audit_component_continuity.rue
+++ b/examples/caldera/audit_component_continuity.rue
@@ -151,7 +151,7 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
                 tiles += 1;
-                if tile.walkable { walkable = walkable + 1; }
+                if tile.walkable { walkable += 1; }
                 resources += tile.resource;
                 elevation += tile.height;
             }

--- a/examples/caldera/audit_component_continuity.rue
+++ b/examples/caldera/audit_component_continuity.rue
@@ -63,7 +63,7 @@ fn observe_entities(inout out: metric.Metric, borrow world: model.World) {
         metric.observe(inout out, entity_projection(borrow world, i), (i % 11) + 1);
         metric.warn(inout out, item.alive && (item.x < 0 || item.y < 0 ||
             @intCast(item.x) >= world.width || @intCast(item.y) >= world.height));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -73,7 +73,7 @@ fn observe_tiles(inout out: metric.Metric, borrow world: model.World) {
         let item = world.tiles.get_or(i, model.empty_tile());
         metric.observe(inout out, tile_projection(borrow world, i), (i % 13) + 1);
         metric.warn(inout out, item.x >= world.width || item.y >= world.height);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -82,18 +82,18 @@ fn observe_timeline(inout out: metric.Metric, borrow world: model.World) {
     while i < world.events.len() {
         metric.observe(inout out, event_projection(borrow world, i), (i % 5) + 1);
         metric.warn(inout out, world.events.get_or(i, model.empty_event()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
         metric.observe(inout out, command_projection(borrow world, i), (i % 7) + 1);
         metric.warn(inout out, world.commands.get_or(i, model.empty_command()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.snapshots.len() {
         metric.observe(inout out, snapshot_projection(borrow world, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -108,9 +108,9 @@ fn observe_pairs(inout out: metric.Metric, borrow world: model.World) {
             let dy = if left.y > right.y { left.y - right.y } else { right.y - left.y };
             metric.observe(inout out, @intCast(dx + dy) +
                 left.faction * 3 + right.faction * 5 + MODE(), i + j + 1);
-            j = j + 1;
+            j += 1;
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -125,17 +125,17 @@ fn observe_factions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.entities.len() {
             let entity = world.entities.get_or(i, model.empty_entity());
             if entity.faction == faction && entity.alive {
-                agents = agents + 1;
-                health = health + entity.health;
-                energy = energy + entity.energy;
-                inventory = inventory + entity.inventory;
+                agents += 1;
+                health += entity.health;
+                energy += entity.energy;
+                inventory += entity.inventory;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = agents * (MODE() % 11 + 1) + health * 3 +
             energy * 5 + inventory * 7 + faction;
         metric.observe(inout out, projection, faction + MODE() % 5 + 1);
-        faction = faction + 1;
+        faction += 1;
     }
 }
 
@@ -150,17 +150,17 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
-                tiles = tiles + 1;
+                tiles += 1;
                 if tile.walkable { walkable = walkable + 1; }
-                resources = resources + tile.resource;
-                elevation = elevation + tile.height;
+                resources += tile.resource;
+                elevation += tile.height;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = tiles * (MODE() % 13 + 1) + walkable * 3 +
             resources * 5 + elevation * 7 + region;
         metric.observe(inout out, projection, region % 7 + 1);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/audit_component_cost.rue
+++ b/examples/caldera/audit_component_cost.rue
@@ -151,7 +151,7 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
                 tiles += 1;
-                if tile.walkable { walkable = walkable + 1; }
+                if tile.walkable { walkable += 1; }
                 resources += tile.resource;
                 elevation += tile.height;
             }

--- a/examples/caldera/audit_component_cost.rue
+++ b/examples/caldera/audit_component_cost.rue
@@ -63,7 +63,7 @@ fn observe_entities(inout out: metric.Metric, borrow world: model.World) {
         metric.observe(inout out, entity_projection(borrow world, i), (i % 11) + 1);
         metric.warn(inout out, item.alive && (item.x < 0 || item.y < 0 ||
             @intCast(item.x) >= world.width || @intCast(item.y) >= world.height));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -73,7 +73,7 @@ fn observe_tiles(inout out: metric.Metric, borrow world: model.World) {
         let item = world.tiles.get_or(i, model.empty_tile());
         metric.observe(inout out, tile_projection(borrow world, i), (i % 13) + 1);
         metric.warn(inout out, item.x >= world.width || item.y >= world.height);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -82,18 +82,18 @@ fn observe_timeline(inout out: metric.Metric, borrow world: model.World) {
     while i < world.events.len() {
         metric.observe(inout out, event_projection(borrow world, i), (i % 5) + 1);
         metric.warn(inout out, world.events.get_or(i, model.empty_event()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
         metric.observe(inout out, command_projection(borrow world, i), (i % 7) + 1);
         metric.warn(inout out, world.commands.get_or(i, model.empty_command()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.snapshots.len() {
         metric.observe(inout out, snapshot_projection(borrow world, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -108,9 +108,9 @@ fn observe_pairs(inout out: metric.Metric, borrow world: model.World) {
             let dy = if left.y > right.y { left.y - right.y } else { right.y - left.y };
             metric.observe(inout out, @intCast(dx + dy) +
                 left.faction * 3 + right.faction * 5 + MODE(), i + j + 1);
-            j = j + 1;
+            j += 1;
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -125,17 +125,17 @@ fn observe_factions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.entities.len() {
             let entity = world.entities.get_or(i, model.empty_entity());
             if entity.faction == faction && entity.alive {
-                agents = agents + 1;
-                health = health + entity.health;
-                energy = energy + entity.energy;
-                inventory = inventory + entity.inventory;
+                agents += 1;
+                health += entity.health;
+                energy += entity.energy;
+                inventory += entity.inventory;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = agents * (MODE() % 11 + 1) + health * 3 +
             energy * 5 + inventory * 7 + faction;
         metric.observe(inout out, projection, faction + MODE() % 5 + 1);
-        faction = faction + 1;
+        faction += 1;
     }
 }
 
@@ -150,17 +150,17 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
-                tiles = tiles + 1;
+                tiles += 1;
                 if tile.walkable { walkable = walkable + 1; }
-                resources = resources + tile.resource;
-                elevation = elevation + tile.height;
+                resources += tile.resource;
+                elevation += tile.height;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = tiles * (MODE() % 13 + 1) + walkable * 3 +
             resources * 5 + elevation * 7 + region;
         metric.observe(inout out, projection, region % 7 + 1);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/audit_component_coverage.rue
+++ b/examples/caldera/audit_component_coverage.rue
@@ -151,7 +151,7 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
                 tiles += 1;
-                if tile.walkable { walkable = walkable + 1; }
+                if tile.walkable { walkable += 1; }
                 resources += tile.resource;
                 elevation += tile.height;
             }

--- a/examples/caldera/audit_component_coverage.rue
+++ b/examples/caldera/audit_component_coverage.rue
@@ -63,7 +63,7 @@ fn observe_entities(inout out: metric.Metric, borrow world: model.World) {
         metric.observe(inout out, entity_projection(borrow world, i), (i % 11) + 1);
         metric.warn(inout out, item.alive && (item.x < 0 || item.y < 0 ||
             @intCast(item.x) >= world.width || @intCast(item.y) >= world.height));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -73,7 +73,7 @@ fn observe_tiles(inout out: metric.Metric, borrow world: model.World) {
         let item = world.tiles.get_or(i, model.empty_tile());
         metric.observe(inout out, tile_projection(borrow world, i), (i % 13) + 1);
         metric.warn(inout out, item.x >= world.width || item.y >= world.height);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -82,18 +82,18 @@ fn observe_timeline(inout out: metric.Metric, borrow world: model.World) {
     while i < world.events.len() {
         metric.observe(inout out, event_projection(borrow world, i), (i % 5) + 1);
         metric.warn(inout out, world.events.get_or(i, model.empty_event()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
         metric.observe(inout out, command_projection(borrow world, i), (i % 7) + 1);
         metric.warn(inout out, world.commands.get_or(i, model.empty_command()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.snapshots.len() {
         metric.observe(inout out, snapshot_projection(borrow world, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -108,9 +108,9 @@ fn observe_pairs(inout out: metric.Metric, borrow world: model.World) {
             let dy = if left.y > right.y { left.y - right.y } else { right.y - left.y };
             metric.observe(inout out, @intCast(dx + dy) +
                 left.faction * 3 + right.faction * 5 + MODE(), i + j + 1);
-            j = j + 1;
+            j += 1;
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -125,17 +125,17 @@ fn observe_factions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.entities.len() {
             let entity = world.entities.get_or(i, model.empty_entity());
             if entity.faction == faction && entity.alive {
-                agents = agents + 1;
-                health = health + entity.health;
-                energy = energy + entity.energy;
-                inventory = inventory + entity.inventory;
+                agents += 1;
+                health += entity.health;
+                energy += entity.energy;
+                inventory += entity.inventory;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = agents * (MODE() % 11 + 1) + health * 3 +
             energy * 5 + inventory * 7 + faction;
         metric.observe(inout out, projection, faction + MODE() % 5 + 1);
-        faction = faction + 1;
+        faction += 1;
     }
 }
 
@@ -150,17 +150,17 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
-                tiles = tiles + 1;
+                tiles += 1;
                 if tile.walkable { walkable = walkable + 1; }
-                resources = resources + tile.resource;
-                elevation = elevation + tile.height;
+                resources += tile.resource;
+                elevation += tile.height;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = tiles * (MODE() % 13 + 1) + walkable * 3 +
             resources * 5 + elevation * 7 + region;
         metric.observe(inout out, projection, region % 7 + 1);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/audit_component_density.rue
+++ b/examples/caldera/audit_component_density.rue
@@ -151,7 +151,7 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
                 tiles += 1;
-                if tile.walkable { walkable = walkable + 1; }
+                if tile.walkable { walkable += 1; }
                 resources += tile.resource;
                 elevation += tile.height;
             }

--- a/examples/caldera/audit_component_density.rue
+++ b/examples/caldera/audit_component_density.rue
@@ -63,7 +63,7 @@ fn observe_entities(inout out: metric.Metric, borrow world: model.World) {
         metric.observe(inout out, entity_projection(borrow world, i), (i % 11) + 1);
         metric.warn(inout out, item.alive && (item.x < 0 || item.y < 0 ||
             @intCast(item.x) >= world.width || @intCast(item.y) >= world.height));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -73,7 +73,7 @@ fn observe_tiles(inout out: metric.Metric, borrow world: model.World) {
         let item = world.tiles.get_or(i, model.empty_tile());
         metric.observe(inout out, tile_projection(borrow world, i), (i % 13) + 1);
         metric.warn(inout out, item.x >= world.width || item.y >= world.height);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -82,18 +82,18 @@ fn observe_timeline(inout out: metric.Metric, borrow world: model.World) {
     while i < world.events.len() {
         metric.observe(inout out, event_projection(borrow world, i), (i % 5) + 1);
         metric.warn(inout out, world.events.get_or(i, model.empty_event()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
         metric.observe(inout out, command_projection(borrow world, i), (i % 7) + 1);
         metric.warn(inout out, world.commands.get_or(i, model.empty_command()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.snapshots.len() {
         metric.observe(inout out, snapshot_projection(borrow world, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -108,9 +108,9 @@ fn observe_pairs(inout out: metric.Metric, borrow world: model.World) {
             let dy = if left.y > right.y { left.y - right.y } else { right.y - left.y };
             metric.observe(inout out, @intCast(dx + dy) +
                 left.faction * 3 + right.faction * 5 + MODE(), i + j + 1);
-            j = j + 1;
+            j += 1;
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -125,17 +125,17 @@ fn observe_factions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.entities.len() {
             let entity = world.entities.get_or(i, model.empty_entity());
             if entity.faction == faction && entity.alive {
-                agents = agents + 1;
-                health = health + entity.health;
-                energy = energy + entity.energy;
-                inventory = inventory + entity.inventory;
+                agents += 1;
+                health += entity.health;
+                energy += entity.energy;
+                inventory += entity.inventory;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = agents * (MODE() % 11 + 1) + health * 3 +
             energy * 5 + inventory * 7 + faction;
         metric.observe(inout out, projection, faction + MODE() % 5 + 1);
-        faction = faction + 1;
+        faction += 1;
     }
 }
 
@@ -150,17 +150,17 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
-                tiles = tiles + 1;
+                tiles += 1;
                 if tile.walkable { walkable = walkable + 1; }
-                resources = resources + tile.resource;
-                elevation = elevation + tile.height;
+                resources += tile.resource;
+                elevation += tile.height;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = tiles * (MODE() % 13 + 1) + walkable * 3 +
             resources * 5 + elevation * 7 + region;
         metric.observe(inout out, projection, region % 7 + 1);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/audit_component_entropy.rue
+++ b/examples/caldera/audit_component_entropy.rue
@@ -151,7 +151,7 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
                 tiles += 1;
-                if tile.walkable { walkable = walkable + 1; }
+                if tile.walkable { walkable += 1; }
                 resources += tile.resource;
                 elevation += tile.height;
             }

--- a/examples/caldera/audit_component_entropy.rue
+++ b/examples/caldera/audit_component_entropy.rue
@@ -63,7 +63,7 @@ fn observe_entities(inout out: metric.Metric, borrow world: model.World) {
         metric.observe(inout out, entity_projection(borrow world, i), (i % 11) + 1);
         metric.warn(inout out, item.alive && (item.x < 0 || item.y < 0 ||
             @intCast(item.x) >= world.width || @intCast(item.y) >= world.height));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -73,7 +73,7 @@ fn observe_tiles(inout out: metric.Metric, borrow world: model.World) {
         let item = world.tiles.get_or(i, model.empty_tile());
         metric.observe(inout out, tile_projection(borrow world, i), (i % 13) + 1);
         metric.warn(inout out, item.x >= world.width || item.y >= world.height);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -82,18 +82,18 @@ fn observe_timeline(inout out: metric.Metric, borrow world: model.World) {
     while i < world.events.len() {
         metric.observe(inout out, event_projection(borrow world, i), (i % 5) + 1);
         metric.warn(inout out, world.events.get_or(i, model.empty_event()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
         metric.observe(inout out, command_projection(borrow world, i), (i % 7) + 1);
         metric.warn(inout out, world.commands.get_or(i, model.empty_command()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.snapshots.len() {
         metric.observe(inout out, snapshot_projection(borrow world, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -108,9 +108,9 @@ fn observe_pairs(inout out: metric.Metric, borrow world: model.World) {
             let dy = if left.y > right.y { left.y - right.y } else { right.y - left.y };
             metric.observe(inout out, @intCast(dx + dy) +
                 left.faction * 3 + right.faction * 5 + MODE(), i + j + 1);
-            j = j + 1;
+            j += 1;
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -125,17 +125,17 @@ fn observe_factions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.entities.len() {
             let entity = world.entities.get_or(i, model.empty_entity());
             if entity.faction == faction && entity.alive {
-                agents = agents + 1;
-                health = health + entity.health;
-                energy = energy + entity.energy;
-                inventory = inventory + entity.inventory;
+                agents += 1;
+                health += entity.health;
+                energy += entity.energy;
+                inventory += entity.inventory;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = agents * (MODE() % 11 + 1) + health * 3 +
             energy * 5 + inventory * 7 + faction;
         metric.observe(inout out, projection, faction + MODE() % 5 + 1);
-        faction = faction + 1;
+        faction += 1;
     }
 }
 
@@ -150,17 +150,17 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
-                tiles = tiles + 1;
+                tiles += 1;
                 if tile.walkable { walkable = walkable + 1; }
-                resources = resources + tile.resource;
-                elevation = elevation + tile.height;
+                resources += tile.resource;
+                elevation += tile.height;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = tiles * (MODE() % 13 + 1) + walkable * 3 +
             resources * 5 + elevation * 7 + region;
         metric.observe(inout out, projection, region % 7 + 1);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/audit_component_fanout.rue
+++ b/examples/caldera/audit_component_fanout.rue
@@ -151,7 +151,7 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
                 tiles += 1;
-                if tile.walkable { walkable = walkable + 1; }
+                if tile.walkable { walkable += 1; }
                 resources += tile.resource;
                 elevation += tile.height;
             }

--- a/examples/caldera/audit_component_fanout.rue
+++ b/examples/caldera/audit_component_fanout.rue
@@ -63,7 +63,7 @@ fn observe_entities(inout out: metric.Metric, borrow world: model.World) {
         metric.observe(inout out, entity_projection(borrow world, i), (i % 11) + 1);
         metric.warn(inout out, item.alive && (item.x < 0 || item.y < 0 ||
             @intCast(item.x) >= world.width || @intCast(item.y) >= world.height));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -73,7 +73,7 @@ fn observe_tiles(inout out: metric.Metric, borrow world: model.World) {
         let item = world.tiles.get_or(i, model.empty_tile());
         metric.observe(inout out, tile_projection(borrow world, i), (i % 13) + 1);
         metric.warn(inout out, item.x >= world.width || item.y >= world.height);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -82,18 +82,18 @@ fn observe_timeline(inout out: metric.Metric, borrow world: model.World) {
     while i < world.events.len() {
         metric.observe(inout out, event_projection(borrow world, i), (i % 5) + 1);
         metric.warn(inout out, world.events.get_or(i, model.empty_event()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
         metric.observe(inout out, command_projection(borrow world, i), (i % 7) + 1);
         metric.warn(inout out, world.commands.get_or(i, model.empty_command()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.snapshots.len() {
         metric.observe(inout out, snapshot_projection(borrow world, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -108,9 +108,9 @@ fn observe_pairs(inout out: metric.Metric, borrow world: model.World) {
             let dy = if left.y > right.y { left.y - right.y } else { right.y - left.y };
             metric.observe(inout out, @intCast(dx + dy) +
                 left.faction * 3 + right.faction * 5 + MODE(), i + j + 1);
-            j = j + 1;
+            j += 1;
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -125,17 +125,17 @@ fn observe_factions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.entities.len() {
             let entity = world.entities.get_or(i, model.empty_entity());
             if entity.faction == faction && entity.alive {
-                agents = agents + 1;
-                health = health + entity.health;
-                energy = energy + entity.energy;
-                inventory = inventory + entity.inventory;
+                agents += 1;
+                health += entity.health;
+                energy += entity.energy;
+                inventory += entity.inventory;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = agents * (MODE() % 11 + 1) + health * 3 +
             energy * 5 + inventory * 7 + faction;
         metric.observe(inout out, projection, faction + MODE() % 5 + 1);
-        faction = faction + 1;
+        faction += 1;
     }
 }
 
@@ -150,17 +150,17 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
-                tiles = tiles + 1;
+                tiles += 1;
                 if tile.walkable { walkable = walkable + 1; }
-                resources = resources + tile.resource;
-                elevation = elevation + tile.height;
+                resources += tile.resource;
+                elevation += tile.height;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = tiles * (MODE() % 13 + 1) + walkable * 3 +
             resources * 5 + elevation * 7 + region;
         metric.observe(inout out, projection, region % 7 + 1);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/audit_component_integrity.rue
+++ b/examples/caldera/audit_component_integrity.rue
@@ -151,7 +151,7 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
                 tiles += 1;
-                if tile.walkable { walkable = walkable + 1; }
+                if tile.walkable { walkable += 1; }
                 resources += tile.resource;
                 elevation += tile.height;
             }

--- a/examples/caldera/audit_component_integrity.rue
+++ b/examples/caldera/audit_component_integrity.rue
@@ -63,7 +63,7 @@ fn observe_entities(inout out: metric.Metric, borrow world: model.World) {
         metric.observe(inout out, entity_projection(borrow world, i), (i % 11) + 1);
         metric.warn(inout out, item.alive && (item.x < 0 || item.y < 0 ||
             @intCast(item.x) >= world.width || @intCast(item.y) >= world.height));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -73,7 +73,7 @@ fn observe_tiles(inout out: metric.Metric, borrow world: model.World) {
         let item = world.tiles.get_or(i, model.empty_tile());
         metric.observe(inout out, tile_projection(borrow world, i), (i % 13) + 1);
         metric.warn(inout out, item.x >= world.width || item.y >= world.height);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -82,18 +82,18 @@ fn observe_timeline(inout out: metric.Metric, borrow world: model.World) {
     while i < world.events.len() {
         metric.observe(inout out, event_projection(borrow world, i), (i % 5) + 1);
         metric.warn(inout out, world.events.get_or(i, model.empty_event()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
         metric.observe(inout out, command_projection(borrow world, i), (i % 7) + 1);
         metric.warn(inout out, world.commands.get_or(i, model.empty_command()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.snapshots.len() {
         metric.observe(inout out, snapshot_projection(borrow world, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -108,9 +108,9 @@ fn observe_pairs(inout out: metric.Metric, borrow world: model.World) {
             let dy = if left.y > right.y { left.y - right.y } else { right.y - left.y };
             metric.observe(inout out, @intCast(dx + dy) +
                 left.faction * 3 + right.faction * 5 + MODE(), i + j + 1);
-            j = j + 1;
+            j += 1;
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -125,17 +125,17 @@ fn observe_factions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.entities.len() {
             let entity = world.entities.get_or(i, model.empty_entity());
             if entity.faction == faction && entity.alive {
-                agents = agents + 1;
-                health = health + entity.health;
-                energy = energy + entity.energy;
-                inventory = inventory + entity.inventory;
+                agents += 1;
+                health += entity.health;
+                energy += entity.energy;
+                inventory += entity.inventory;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = agents * (MODE() % 11 + 1) + health * 3 +
             energy * 5 + inventory * 7 + faction;
         metric.observe(inout out, projection, faction + MODE() % 5 + 1);
-        faction = faction + 1;
+        faction += 1;
     }
 }
 
@@ -150,17 +150,17 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
-                tiles = tiles + 1;
+                tiles += 1;
                 if tile.walkable { walkable = walkable + 1; }
-                resources = resources + tile.resource;
-                elevation = elevation + tile.height;
+                resources += tile.resource;
+                elevation += tile.height;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = tiles * (MODE() % 13 + 1) + walkable * 3 +
             resources * 5 + elevation * 7 + region;
         metric.observe(inout out, projection, region % 7 + 1);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/audit_component_latency.rue
+++ b/examples/caldera/audit_component_latency.rue
@@ -151,7 +151,7 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
                 tiles += 1;
-                if tile.walkable { walkable = walkable + 1; }
+                if tile.walkable { walkable += 1; }
                 resources += tile.resource;
                 elevation += tile.height;
             }

--- a/examples/caldera/audit_component_latency.rue
+++ b/examples/caldera/audit_component_latency.rue
@@ -63,7 +63,7 @@ fn observe_entities(inout out: metric.Metric, borrow world: model.World) {
         metric.observe(inout out, entity_projection(borrow world, i), (i % 11) + 1);
         metric.warn(inout out, item.alive && (item.x < 0 || item.y < 0 ||
             @intCast(item.x) >= world.width || @intCast(item.y) >= world.height));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -73,7 +73,7 @@ fn observe_tiles(inout out: metric.Metric, borrow world: model.World) {
         let item = world.tiles.get_or(i, model.empty_tile());
         metric.observe(inout out, tile_projection(borrow world, i), (i % 13) + 1);
         metric.warn(inout out, item.x >= world.width || item.y >= world.height);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -82,18 +82,18 @@ fn observe_timeline(inout out: metric.Metric, borrow world: model.World) {
     while i < world.events.len() {
         metric.observe(inout out, event_projection(borrow world, i), (i % 5) + 1);
         metric.warn(inout out, world.events.get_or(i, model.empty_event()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
         metric.observe(inout out, command_projection(borrow world, i), (i % 7) + 1);
         metric.warn(inout out, world.commands.get_or(i, model.empty_command()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.snapshots.len() {
         metric.observe(inout out, snapshot_projection(borrow world, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -108,9 +108,9 @@ fn observe_pairs(inout out: metric.Metric, borrow world: model.World) {
             let dy = if left.y > right.y { left.y - right.y } else { right.y - left.y };
             metric.observe(inout out, @intCast(dx + dy) +
                 left.faction * 3 + right.faction * 5 + MODE(), i + j + 1);
-            j = j + 1;
+            j += 1;
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -125,17 +125,17 @@ fn observe_factions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.entities.len() {
             let entity = world.entities.get_or(i, model.empty_entity());
             if entity.faction == faction && entity.alive {
-                agents = agents + 1;
-                health = health + entity.health;
-                energy = energy + entity.energy;
-                inventory = inventory + entity.inventory;
+                agents += 1;
+                health += entity.health;
+                energy += entity.energy;
+                inventory += entity.inventory;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = agents * (MODE() % 11 + 1) + health * 3 +
             energy * 5 + inventory * 7 + faction;
         metric.observe(inout out, projection, faction + MODE() % 5 + 1);
-        faction = faction + 1;
+        faction += 1;
     }
 }
 
@@ -150,17 +150,17 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
-                tiles = tiles + 1;
+                tiles += 1;
                 if tile.walkable { walkable = walkable + 1; }
-                resources = resources + tile.resource;
-                elevation = elevation + tile.height;
+                resources += tile.resource;
+                elevation += tile.height;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = tiles * (MODE() % 13 + 1) + walkable * 3 +
             resources * 5 + elevation * 7 + region;
         metric.observe(inout out, projection, region % 7 + 1);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/audit_component_locality.rue
+++ b/examples/caldera/audit_component_locality.rue
@@ -151,7 +151,7 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
                 tiles += 1;
-                if tile.walkable { walkable = walkable + 1; }
+                if tile.walkable { walkable += 1; }
                 resources += tile.resource;
                 elevation += tile.height;
             }

--- a/examples/caldera/audit_component_locality.rue
+++ b/examples/caldera/audit_component_locality.rue
@@ -63,7 +63,7 @@ fn observe_entities(inout out: metric.Metric, borrow world: model.World) {
         metric.observe(inout out, entity_projection(borrow world, i), (i % 11) + 1);
         metric.warn(inout out, item.alive && (item.x < 0 || item.y < 0 ||
             @intCast(item.x) >= world.width || @intCast(item.y) >= world.height));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -73,7 +73,7 @@ fn observe_tiles(inout out: metric.Metric, borrow world: model.World) {
         let item = world.tiles.get_or(i, model.empty_tile());
         metric.observe(inout out, tile_projection(borrow world, i), (i % 13) + 1);
         metric.warn(inout out, item.x >= world.width || item.y >= world.height);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -82,18 +82,18 @@ fn observe_timeline(inout out: metric.Metric, borrow world: model.World) {
     while i < world.events.len() {
         metric.observe(inout out, event_projection(borrow world, i), (i % 5) + 1);
         metric.warn(inout out, world.events.get_or(i, model.empty_event()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
         metric.observe(inout out, command_projection(borrow world, i), (i % 7) + 1);
         metric.warn(inout out, world.commands.get_or(i, model.empty_command()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.snapshots.len() {
         metric.observe(inout out, snapshot_projection(borrow world, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -108,9 +108,9 @@ fn observe_pairs(inout out: metric.Metric, borrow world: model.World) {
             let dy = if left.y > right.y { left.y - right.y } else { right.y - left.y };
             metric.observe(inout out, @intCast(dx + dy) +
                 left.faction * 3 + right.faction * 5 + MODE(), i + j + 1);
-            j = j + 1;
+            j += 1;
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -125,17 +125,17 @@ fn observe_factions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.entities.len() {
             let entity = world.entities.get_or(i, model.empty_entity());
             if entity.faction == faction && entity.alive {
-                agents = agents + 1;
-                health = health + entity.health;
-                energy = energy + entity.energy;
-                inventory = inventory + entity.inventory;
+                agents += 1;
+                health += entity.health;
+                energy += entity.energy;
+                inventory += entity.inventory;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = agents * (MODE() % 11 + 1) + health * 3 +
             energy * 5 + inventory * 7 + faction;
         metric.observe(inout out, projection, faction + MODE() % 5 + 1);
-        faction = faction + 1;
+        faction += 1;
     }
 }
 
@@ -150,17 +150,17 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
-                tiles = tiles + 1;
+                tiles += 1;
                 if tile.walkable { walkable = walkable + 1; }
-                resources = resources + tile.resource;
-                elevation = elevation + tile.height;
+                resources += tile.resource;
+                elevation += tile.height;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = tiles * (MODE() % 13 + 1) + walkable * 3 +
             resources * 5 + elevation * 7 + region;
         metric.observe(inout out, projection, region % 7 + 1);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/audit_component_pressure.rue
+++ b/examples/caldera/audit_component_pressure.rue
@@ -151,7 +151,7 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
                 tiles += 1;
-                if tile.walkable { walkable = walkable + 1; }
+                if tile.walkable { walkable += 1; }
                 resources += tile.resource;
                 elevation += tile.height;
             }

--- a/examples/caldera/audit_component_pressure.rue
+++ b/examples/caldera/audit_component_pressure.rue
@@ -63,7 +63,7 @@ fn observe_entities(inout out: metric.Metric, borrow world: model.World) {
         metric.observe(inout out, entity_projection(borrow world, i), (i % 11) + 1);
         metric.warn(inout out, item.alive && (item.x < 0 || item.y < 0 ||
             @intCast(item.x) >= world.width || @intCast(item.y) >= world.height));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -73,7 +73,7 @@ fn observe_tiles(inout out: metric.Metric, borrow world: model.World) {
         let item = world.tiles.get_or(i, model.empty_tile());
         metric.observe(inout out, tile_projection(borrow world, i), (i % 13) + 1);
         metric.warn(inout out, item.x >= world.width || item.y >= world.height);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -82,18 +82,18 @@ fn observe_timeline(inout out: metric.Metric, borrow world: model.World) {
     while i < world.events.len() {
         metric.observe(inout out, event_projection(borrow world, i), (i % 5) + 1);
         metric.warn(inout out, world.events.get_or(i, model.empty_event()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
         metric.observe(inout out, command_projection(borrow world, i), (i % 7) + 1);
         metric.warn(inout out, world.commands.get_or(i, model.empty_command()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.snapshots.len() {
         metric.observe(inout out, snapshot_projection(borrow world, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -108,9 +108,9 @@ fn observe_pairs(inout out: metric.Metric, borrow world: model.World) {
             let dy = if left.y > right.y { left.y - right.y } else { right.y - left.y };
             metric.observe(inout out, @intCast(dx + dy) +
                 left.faction * 3 + right.faction * 5 + MODE(), i + j + 1);
-            j = j + 1;
+            j += 1;
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -125,17 +125,17 @@ fn observe_factions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.entities.len() {
             let entity = world.entities.get_or(i, model.empty_entity());
             if entity.faction == faction && entity.alive {
-                agents = agents + 1;
-                health = health + entity.health;
-                energy = energy + entity.energy;
-                inventory = inventory + entity.inventory;
+                agents += 1;
+                health += entity.health;
+                energy += entity.energy;
+                inventory += entity.inventory;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = agents * (MODE() % 11 + 1) + health * 3 +
             energy * 5 + inventory * 7 + faction;
         metric.observe(inout out, projection, faction + MODE() % 5 + 1);
-        faction = faction + 1;
+        faction += 1;
     }
 }
 
@@ -150,17 +150,17 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
-                tiles = tiles + 1;
+                tiles += 1;
                 if tile.walkable { walkable = walkable + 1; }
-                resources = resources + tile.resource;
-                elevation = elevation + tile.height;
+                resources += tile.resource;
+                elevation += tile.height;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = tiles * (MODE() % 13 + 1) + walkable * 3 +
             resources * 5 + elevation * 7 + region;
         metric.observe(inout out, projection, region % 7 + 1);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/audit_component_risk.rue
+++ b/examples/caldera/audit_component_risk.rue
@@ -151,7 +151,7 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
                 tiles += 1;
-                if tile.walkable { walkable = walkable + 1; }
+                if tile.walkable { walkable += 1; }
                 resources += tile.resource;
                 elevation += tile.height;
             }

--- a/examples/caldera/audit_component_risk.rue
+++ b/examples/caldera/audit_component_risk.rue
@@ -63,7 +63,7 @@ fn observe_entities(inout out: metric.Metric, borrow world: model.World) {
         metric.observe(inout out, entity_projection(borrow world, i), (i % 11) + 1);
         metric.warn(inout out, item.alive && (item.x < 0 || item.y < 0 ||
             @intCast(item.x) >= world.width || @intCast(item.y) >= world.height));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -73,7 +73,7 @@ fn observe_tiles(inout out: metric.Metric, borrow world: model.World) {
         let item = world.tiles.get_or(i, model.empty_tile());
         metric.observe(inout out, tile_projection(borrow world, i), (i % 13) + 1);
         metric.warn(inout out, item.x >= world.width || item.y >= world.height);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -82,18 +82,18 @@ fn observe_timeline(inout out: metric.Metric, borrow world: model.World) {
     while i < world.events.len() {
         metric.observe(inout out, event_projection(borrow world, i), (i % 5) + 1);
         metric.warn(inout out, world.events.get_or(i, model.empty_event()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
         metric.observe(inout out, command_projection(borrow world, i), (i % 7) + 1);
         metric.warn(inout out, world.commands.get_or(i, model.empty_command()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.snapshots.len() {
         metric.observe(inout out, snapshot_projection(borrow world, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -108,9 +108,9 @@ fn observe_pairs(inout out: metric.Metric, borrow world: model.World) {
             let dy = if left.y > right.y { left.y - right.y } else { right.y - left.y };
             metric.observe(inout out, @intCast(dx + dy) +
                 left.faction * 3 + right.faction * 5 + MODE(), i + j + 1);
-            j = j + 1;
+            j += 1;
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -125,17 +125,17 @@ fn observe_factions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.entities.len() {
             let entity = world.entities.get_or(i, model.empty_entity());
             if entity.faction == faction && entity.alive {
-                agents = agents + 1;
-                health = health + entity.health;
-                energy = energy + entity.energy;
-                inventory = inventory + entity.inventory;
+                agents += 1;
+                health += entity.health;
+                energy += entity.energy;
+                inventory += entity.inventory;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = agents * (MODE() % 11 + 1) + health * 3 +
             energy * 5 + inventory * 7 + faction;
         metric.observe(inout out, projection, faction + MODE() % 5 + 1);
-        faction = faction + 1;
+        faction += 1;
     }
 }
 
@@ -150,17 +150,17 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
-                tiles = tiles + 1;
+                tiles += 1;
                 if tile.walkable { walkable = walkable + 1; }
-                resources = resources + tile.resource;
-                elevation = elevation + tile.height;
+                resources += tile.resource;
+                elevation += tile.height;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = tiles * (MODE() % 13 + 1) + walkable * 3 +
             resources * 5 + elevation * 7 + region;
         metric.observe(inout out, projection, region % 7 + 1);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/audit_component_skew.rue
+++ b/examples/caldera/audit_component_skew.rue
@@ -151,7 +151,7 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
                 tiles += 1;
-                if tile.walkable { walkable = walkable + 1; }
+                if tile.walkable { walkable += 1; }
                 resources += tile.resource;
                 elevation += tile.height;
             }

--- a/examples/caldera/audit_component_skew.rue
+++ b/examples/caldera/audit_component_skew.rue
@@ -63,7 +63,7 @@ fn observe_entities(inout out: metric.Metric, borrow world: model.World) {
         metric.observe(inout out, entity_projection(borrow world, i), (i % 11) + 1);
         metric.warn(inout out, item.alive && (item.x < 0 || item.y < 0 ||
             @intCast(item.x) >= world.width || @intCast(item.y) >= world.height));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -73,7 +73,7 @@ fn observe_tiles(inout out: metric.Metric, borrow world: model.World) {
         let item = world.tiles.get_or(i, model.empty_tile());
         metric.observe(inout out, tile_projection(borrow world, i), (i % 13) + 1);
         metric.warn(inout out, item.x >= world.width || item.y >= world.height);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -82,18 +82,18 @@ fn observe_timeline(inout out: metric.Metric, borrow world: model.World) {
     while i < world.events.len() {
         metric.observe(inout out, event_projection(borrow world, i), (i % 5) + 1);
         metric.warn(inout out, world.events.get_or(i, model.empty_event()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
         metric.observe(inout out, command_projection(borrow world, i), (i % 7) + 1);
         metric.warn(inout out, world.commands.get_or(i, model.empty_command()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.snapshots.len() {
         metric.observe(inout out, snapshot_projection(borrow world, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -108,9 +108,9 @@ fn observe_pairs(inout out: metric.Metric, borrow world: model.World) {
             let dy = if left.y > right.y { left.y - right.y } else { right.y - left.y };
             metric.observe(inout out, @intCast(dx + dy) +
                 left.faction * 3 + right.faction * 5 + MODE(), i + j + 1);
-            j = j + 1;
+            j += 1;
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -125,17 +125,17 @@ fn observe_factions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.entities.len() {
             let entity = world.entities.get_or(i, model.empty_entity());
             if entity.faction == faction && entity.alive {
-                agents = agents + 1;
-                health = health + entity.health;
-                energy = energy + entity.energy;
-                inventory = inventory + entity.inventory;
+                agents += 1;
+                health += entity.health;
+                energy += entity.energy;
+                inventory += entity.inventory;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = agents * (MODE() % 11 + 1) + health * 3 +
             energy * 5 + inventory * 7 + faction;
         metric.observe(inout out, projection, faction + MODE() % 5 + 1);
-        faction = faction + 1;
+        faction += 1;
     }
 }
 
@@ -150,17 +150,17 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
-                tiles = tiles + 1;
+                tiles += 1;
                 if tile.walkable { walkable = walkable + 1; }
-                resources = resources + tile.resource;
-                elevation = elevation + tile.height;
+                resources += tile.resource;
+                elevation += tile.height;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = tiles * (MODE() % 13 + 1) + walkable * 3 +
             resources * 5 + elevation * 7 + region;
         metric.observe(inout out, projection, region % 7 + 1);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/audit_component_stability.rue
+++ b/examples/caldera/audit_component_stability.rue
@@ -151,7 +151,7 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
                 tiles += 1;
-                if tile.walkable { walkable = walkable + 1; }
+                if tile.walkable { walkable += 1; }
                 resources += tile.resource;
                 elevation += tile.height;
             }

--- a/examples/caldera/audit_component_stability.rue
+++ b/examples/caldera/audit_component_stability.rue
@@ -63,7 +63,7 @@ fn observe_entities(inout out: metric.Metric, borrow world: model.World) {
         metric.observe(inout out, entity_projection(borrow world, i), (i % 11) + 1);
         metric.warn(inout out, item.alive && (item.x < 0 || item.y < 0 ||
             @intCast(item.x) >= world.width || @intCast(item.y) >= world.height));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -73,7 +73,7 @@ fn observe_tiles(inout out: metric.Metric, borrow world: model.World) {
         let item = world.tiles.get_or(i, model.empty_tile());
         metric.observe(inout out, tile_projection(borrow world, i), (i % 13) + 1);
         metric.warn(inout out, item.x >= world.width || item.y >= world.height);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -82,18 +82,18 @@ fn observe_timeline(inout out: metric.Metric, borrow world: model.World) {
     while i < world.events.len() {
         metric.observe(inout out, event_projection(borrow world, i), (i % 5) + 1);
         metric.warn(inout out, world.events.get_or(i, model.empty_event()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
         metric.observe(inout out, command_projection(borrow world, i), (i % 7) + 1);
         metric.warn(inout out, world.commands.get_or(i, model.empty_command()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.snapshots.len() {
         metric.observe(inout out, snapshot_projection(borrow world, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -108,9 +108,9 @@ fn observe_pairs(inout out: metric.Metric, borrow world: model.World) {
             let dy = if left.y > right.y { left.y - right.y } else { right.y - left.y };
             metric.observe(inout out, @intCast(dx + dy) +
                 left.faction * 3 + right.faction * 5 + MODE(), i + j + 1);
-            j = j + 1;
+            j += 1;
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -125,17 +125,17 @@ fn observe_factions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.entities.len() {
             let entity = world.entities.get_or(i, model.empty_entity());
             if entity.faction == faction && entity.alive {
-                agents = agents + 1;
-                health = health + entity.health;
-                energy = energy + entity.energy;
-                inventory = inventory + entity.inventory;
+                agents += 1;
+                health += entity.health;
+                energy += entity.energy;
+                inventory += entity.inventory;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = agents * (MODE() % 11 + 1) + health * 3 +
             energy * 5 + inventory * 7 + faction;
         metric.observe(inout out, projection, faction + MODE() % 5 + 1);
-        faction = faction + 1;
+        faction += 1;
     }
 }
 
@@ -150,17 +150,17 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
-                tiles = tiles + 1;
+                tiles += 1;
                 if tile.walkable { walkable = walkable + 1; }
-                resources = resources + tile.resource;
-                elevation = elevation + tile.height;
+                resources += tile.resource;
+                elevation += tile.height;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = tiles * (MODE() % 13 + 1) + walkable * 3 +
             resources * 5 + elevation * 7 + region;
         metric.observe(inout out, projection, region % 7 + 1);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/audit_component_throughput.rue
+++ b/examples/caldera/audit_component_throughput.rue
@@ -151,7 +151,7 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
                 tiles += 1;
-                if tile.walkable { walkable = walkable + 1; }
+                if tile.walkable { walkable += 1; }
                 resources += tile.resource;
                 elevation += tile.height;
             }

--- a/examples/caldera/audit_component_throughput.rue
+++ b/examples/caldera/audit_component_throughput.rue
@@ -63,7 +63,7 @@ fn observe_entities(inout out: metric.Metric, borrow world: model.World) {
         metric.observe(inout out, entity_projection(borrow world, i), (i % 11) + 1);
         metric.warn(inout out, item.alive && (item.x < 0 || item.y < 0 ||
             @intCast(item.x) >= world.width || @intCast(item.y) >= world.height));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -73,7 +73,7 @@ fn observe_tiles(inout out: metric.Metric, borrow world: model.World) {
         let item = world.tiles.get_or(i, model.empty_tile());
         metric.observe(inout out, tile_projection(borrow world, i), (i % 13) + 1);
         metric.warn(inout out, item.x >= world.width || item.y >= world.height);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -82,18 +82,18 @@ fn observe_timeline(inout out: metric.Metric, borrow world: model.World) {
     while i < world.events.len() {
         metric.observe(inout out, event_projection(borrow world, i), (i % 5) + 1);
         metric.warn(inout out, world.events.get_or(i, model.empty_event()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
         metric.observe(inout out, command_projection(borrow world, i), (i % 7) + 1);
         metric.warn(inout out, world.commands.get_or(i, model.empty_command()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.snapshots.len() {
         metric.observe(inout out, snapshot_projection(borrow world, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -108,9 +108,9 @@ fn observe_pairs(inout out: metric.Metric, borrow world: model.World) {
             let dy = if left.y > right.y { left.y - right.y } else { right.y - left.y };
             metric.observe(inout out, @intCast(dx + dy) +
                 left.faction * 3 + right.faction * 5 + MODE(), i + j + 1);
-            j = j + 1;
+            j += 1;
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -125,17 +125,17 @@ fn observe_factions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.entities.len() {
             let entity = world.entities.get_or(i, model.empty_entity());
             if entity.faction == faction && entity.alive {
-                agents = agents + 1;
-                health = health + entity.health;
-                energy = energy + entity.energy;
-                inventory = inventory + entity.inventory;
+                agents += 1;
+                health += entity.health;
+                energy += entity.energy;
+                inventory += entity.inventory;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = agents * (MODE() % 11 + 1) + health * 3 +
             energy * 5 + inventory * 7 + faction;
         metric.observe(inout out, projection, faction + MODE() % 5 + 1);
-        faction = faction + 1;
+        faction += 1;
     }
 }
 
@@ -150,17 +150,17 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
-                tiles = tiles + 1;
+                tiles += 1;
                 if tile.walkable { walkable = walkable + 1; }
-                resources = resources + tile.resource;
-                elevation = elevation + tile.height;
+                resources += tile.resource;
+                elevation += tile.height;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = tiles * (MODE() % 13 + 1) + walkable * 3 +
             resources * 5 + elevation * 7 + region;
         metric.observe(inout out, projection, region % 7 + 1);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/audit_economy_balance.rue
+++ b/examples/caldera/audit_economy_balance.rue
@@ -151,7 +151,7 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
                 tiles += 1;
-                if tile.walkable { walkable = walkable + 1; }
+                if tile.walkable { walkable += 1; }
                 resources += tile.resource;
                 elevation += tile.height;
             }

--- a/examples/caldera/audit_economy_balance.rue
+++ b/examples/caldera/audit_economy_balance.rue
@@ -63,7 +63,7 @@ fn observe_entities(inout out: metric.Metric, borrow world: model.World) {
         metric.observe(inout out, entity_projection(borrow world, i), (i % 11) + 1);
         metric.warn(inout out, item.alive && (item.x < 0 || item.y < 0 ||
             @intCast(item.x) >= world.width || @intCast(item.y) >= world.height));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -73,7 +73,7 @@ fn observe_tiles(inout out: metric.Metric, borrow world: model.World) {
         let item = world.tiles.get_or(i, model.empty_tile());
         metric.observe(inout out, tile_projection(borrow world, i), (i % 13) + 1);
         metric.warn(inout out, item.x >= world.width || item.y >= world.height);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -82,18 +82,18 @@ fn observe_timeline(inout out: metric.Metric, borrow world: model.World) {
     while i < world.events.len() {
         metric.observe(inout out, event_projection(borrow world, i), (i % 5) + 1);
         metric.warn(inout out, world.events.get_or(i, model.empty_event()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
         metric.observe(inout out, command_projection(borrow world, i), (i % 7) + 1);
         metric.warn(inout out, world.commands.get_or(i, model.empty_command()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.snapshots.len() {
         metric.observe(inout out, snapshot_projection(borrow world, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -108,9 +108,9 @@ fn observe_pairs(inout out: metric.Metric, borrow world: model.World) {
             let dy = if left.y > right.y { left.y - right.y } else { right.y - left.y };
             metric.observe(inout out, @intCast(dx + dy) +
                 left.faction * 3 + right.faction * 5 + MODE(), i + j + 1);
-            j = j + 1;
+            j += 1;
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -125,17 +125,17 @@ fn observe_factions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.entities.len() {
             let entity = world.entities.get_or(i, model.empty_entity());
             if entity.faction == faction && entity.alive {
-                agents = agents + 1;
-                health = health + entity.health;
-                energy = energy + entity.energy;
-                inventory = inventory + entity.inventory;
+                agents += 1;
+                health += entity.health;
+                energy += entity.energy;
+                inventory += entity.inventory;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = agents * (MODE() % 11 + 1) + health * 3 +
             energy * 5 + inventory * 7 + faction;
         metric.observe(inout out, projection, faction + MODE() % 5 + 1);
-        faction = faction + 1;
+        faction += 1;
     }
 }
 
@@ -150,17 +150,17 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
-                tiles = tiles + 1;
+                tiles += 1;
                 if tile.walkable { walkable = walkable + 1; }
-                resources = resources + tile.resource;
-                elevation = elevation + tile.height;
+                resources += tile.resource;
+                elevation += tile.height;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = tiles * (MODE() % 13 + 1) + walkable * 3 +
             resources * 5 + elevation * 7 + region;
         metric.observe(inout out, projection, region % 7 + 1);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/audit_economy_capacity.rue
+++ b/examples/caldera/audit_economy_capacity.rue
@@ -151,7 +151,7 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
                 tiles += 1;
-                if tile.walkable { walkable = walkable + 1; }
+                if tile.walkable { walkable += 1; }
                 resources += tile.resource;
                 elevation += tile.height;
             }

--- a/examples/caldera/audit_economy_capacity.rue
+++ b/examples/caldera/audit_economy_capacity.rue
@@ -63,7 +63,7 @@ fn observe_entities(inout out: metric.Metric, borrow world: model.World) {
         metric.observe(inout out, entity_projection(borrow world, i), (i % 11) + 1);
         metric.warn(inout out, item.alive && (item.x < 0 || item.y < 0 ||
             @intCast(item.x) >= world.width || @intCast(item.y) >= world.height));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -73,7 +73,7 @@ fn observe_tiles(inout out: metric.Metric, borrow world: model.World) {
         let item = world.tiles.get_or(i, model.empty_tile());
         metric.observe(inout out, tile_projection(borrow world, i), (i % 13) + 1);
         metric.warn(inout out, item.x >= world.width || item.y >= world.height);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -82,18 +82,18 @@ fn observe_timeline(inout out: metric.Metric, borrow world: model.World) {
     while i < world.events.len() {
         metric.observe(inout out, event_projection(borrow world, i), (i % 5) + 1);
         metric.warn(inout out, world.events.get_or(i, model.empty_event()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
         metric.observe(inout out, command_projection(borrow world, i), (i % 7) + 1);
         metric.warn(inout out, world.commands.get_or(i, model.empty_command()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.snapshots.len() {
         metric.observe(inout out, snapshot_projection(borrow world, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -108,9 +108,9 @@ fn observe_pairs(inout out: metric.Metric, borrow world: model.World) {
             let dy = if left.y > right.y { left.y - right.y } else { right.y - left.y };
             metric.observe(inout out, @intCast(dx + dy) +
                 left.faction * 3 + right.faction * 5 + MODE(), i + j + 1);
-            j = j + 1;
+            j += 1;
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -125,17 +125,17 @@ fn observe_factions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.entities.len() {
             let entity = world.entities.get_or(i, model.empty_entity());
             if entity.faction == faction && entity.alive {
-                agents = agents + 1;
-                health = health + entity.health;
-                energy = energy + entity.energy;
-                inventory = inventory + entity.inventory;
+                agents += 1;
+                health += entity.health;
+                energy += entity.energy;
+                inventory += entity.inventory;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = agents * (MODE() % 11 + 1) + health * 3 +
             energy * 5 + inventory * 7 + faction;
         metric.observe(inout out, projection, faction + MODE() % 5 + 1);
-        faction = faction + 1;
+        faction += 1;
     }
 }
 
@@ -150,17 +150,17 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
-                tiles = tiles + 1;
+                tiles += 1;
                 if tile.walkable { walkable = walkable + 1; }
-                resources = resources + tile.resource;
-                elevation = elevation + tile.height;
+                resources += tile.resource;
+                elevation += tile.height;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = tiles * (MODE() % 13 + 1) + walkable * 3 +
             resources * 5 + elevation * 7 + region;
         metric.observe(inout out, projection, region % 7 + 1);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/audit_economy_continuity.rue
+++ b/examples/caldera/audit_economy_continuity.rue
@@ -151,7 +151,7 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
                 tiles += 1;
-                if tile.walkable { walkable = walkable + 1; }
+                if tile.walkable { walkable += 1; }
                 resources += tile.resource;
                 elevation += tile.height;
             }

--- a/examples/caldera/audit_economy_continuity.rue
+++ b/examples/caldera/audit_economy_continuity.rue
@@ -63,7 +63,7 @@ fn observe_entities(inout out: metric.Metric, borrow world: model.World) {
         metric.observe(inout out, entity_projection(borrow world, i), (i % 11) + 1);
         metric.warn(inout out, item.alive && (item.x < 0 || item.y < 0 ||
             @intCast(item.x) >= world.width || @intCast(item.y) >= world.height));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -73,7 +73,7 @@ fn observe_tiles(inout out: metric.Metric, borrow world: model.World) {
         let item = world.tiles.get_or(i, model.empty_tile());
         metric.observe(inout out, tile_projection(borrow world, i), (i % 13) + 1);
         metric.warn(inout out, item.x >= world.width || item.y >= world.height);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -82,18 +82,18 @@ fn observe_timeline(inout out: metric.Metric, borrow world: model.World) {
     while i < world.events.len() {
         metric.observe(inout out, event_projection(borrow world, i), (i % 5) + 1);
         metric.warn(inout out, world.events.get_or(i, model.empty_event()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
         metric.observe(inout out, command_projection(borrow world, i), (i % 7) + 1);
         metric.warn(inout out, world.commands.get_or(i, model.empty_command()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.snapshots.len() {
         metric.observe(inout out, snapshot_projection(borrow world, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -108,9 +108,9 @@ fn observe_pairs(inout out: metric.Metric, borrow world: model.World) {
             let dy = if left.y > right.y { left.y - right.y } else { right.y - left.y };
             metric.observe(inout out, @intCast(dx + dy) +
                 left.faction * 3 + right.faction * 5 + MODE(), i + j + 1);
-            j = j + 1;
+            j += 1;
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -125,17 +125,17 @@ fn observe_factions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.entities.len() {
             let entity = world.entities.get_or(i, model.empty_entity());
             if entity.faction == faction && entity.alive {
-                agents = agents + 1;
-                health = health + entity.health;
-                energy = energy + entity.energy;
-                inventory = inventory + entity.inventory;
+                agents += 1;
+                health += entity.health;
+                energy += entity.energy;
+                inventory += entity.inventory;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = agents * (MODE() % 11 + 1) + health * 3 +
             energy * 5 + inventory * 7 + faction;
         metric.observe(inout out, projection, faction + MODE() % 5 + 1);
-        faction = faction + 1;
+        faction += 1;
     }
 }
 
@@ -150,17 +150,17 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
-                tiles = tiles + 1;
+                tiles += 1;
                 if tile.walkable { walkable = walkable + 1; }
-                resources = resources + tile.resource;
-                elevation = elevation + tile.height;
+                resources += tile.resource;
+                elevation += tile.height;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = tiles * (MODE() % 13 + 1) + walkable * 3 +
             resources * 5 + elevation * 7 + region;
         metric.observe(inout out, projection, region % 7 + 1);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/audit_economy_cost.rue
+++ b/examples/caldera/audit_economy_cost.rue
@@ -151,7 +151,7 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
                 tiles += 1;
-                if tile.walkable { walkable = walkable + 1; }
+                if tile.walkable { walkable += 1; }
                 resources += tile.resource;
                 elevation += tile.height;
             }

--- a/examples/caldera/audit_economy_cost.rue
+++ b/examples/caldera/audit_economy_cost.rue
@@ -63,7 +63,7 @@ fn observe_entities(inout out: metric.Metric, borrow world: model.World) {
         metric.observe(inout out, entity_projection(borrow world, i), (i % 11) + 1);
         metric.warn(inout out, item.alive && (item.x < 0 || item.y < 0 ||
             @intCast(item.x) >= world.width || @intCast(item.y) >= world.height));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -73,7 +73,7 @@ fn observe_tiles(inout out: metric.Metric, borrow world: model.World) {
         let item = world.tiles.get_or(i, model.empty_tile());
         metric.observe(inout out, tile_projection(borrow world, i), (i % 13) + 1);
         metric.warn(inout out, item.x >= world.width || item.y >= world.height);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -82,18 +82,18 @@ fn observe_timeline(inout out: metric.Metric, borrow world: model.World) {
     while i < world.events.len() {
         metric.observe(inout out, event_projection(borrow world, i), (i % 5) + 1);
         metric.warn(inout out, world.events.get_or(i, model.empty_event()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
         metric.observe(inout out, command_projection(borrow world, i), (i % 7) + 1);
         metric.warn(inout out, world.commands.get_or(i, model.empty_command()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.snapshots.len() {
         metric.observe(inout out, snapshot_projection(borrow world, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -108,9 +108,9 @@ fn observe_pairs(inout out: metric.Metric, borrow world: model.World) {
             let dy = if left.y > right.y { left.y - right.y } else { right.y - left.y };
             metric.observe(inout out, @intCast(dx + dy) +
                 left.faction * 3 + right.faction * 5 + MODE(), i + j + 1);
-            j = j + 1;
+            j += 1;
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -125,17 +125,17 @@ fn observe_factions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.entities.len() {
             let entity = world.entities.get_or(i, model.empty_entity());
             if entity.faction == faction && entity.alive {
-                agents = agents + 1;
-                health = health + entity.health;
-                energy = energy + entity.energy;
-                inventory = inventory + entity.inventory;
+                agents += 1;
+                health += entity.health;
+                energy += entity.energy;
+                inventory += entity.inventory;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = agents * (MODE() % 11 + 1) + health * 3 +
             energy * 5 + inventory * 7 + faction;
         metric.observe(inout out, projection, faction + MODE() % 5 + 1);
-        faction = faction + 1;
+        faction += 1;
     }
 }
 
@@ -150,17 +150,17 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
-                tiles = tiles + 1;
+                tiles += 1;
                 if tile.walkable { walkable = walkable + 1; }
-                resources = resources + tile.resource;
-                elevation = elevation + tile.height;
+                resources += tile.resource;
+                elevation += tile.height;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = tiles * (MODE() % 13 + 1) + walkable * 3 +
             resources * 5 + elevation * 7 + region;
         metric.observe(inout out, projection, region % 7 + 1);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/audit_economy_coverage.rue
+++ b/examples/caldera/audit_economy_coverage.rue
@@ -151,7 +151,7 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
                 tiles += 1;
-                if tile.walkable { walkable = walkable + 1; }
+                if tile.walkable { walkable += 1; }
                 resources += tile.resource;
                 elevation += tile.height;
             }

--- a/examples/caldera/audit_economy_coverage.rue
+++ b/examples/caldera/audit_economy_coverage.rue
@@ -63,7 +63,7 @@ fn observe_entities(inout out: metric.Metric, borrow world: model.World) {
         metric.observe(inout out, entity_projection(borrow world, i), (i % 11) + 1);
         metric.warn(inout out, item.alive && (item.x < 0 || item.y < 0 ||
             @intCast(item.x) >= world.width || @intCast(item.y) >= world.height));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -73,7 +73,7 @@ fn observe_tiles(inout out: metric.Metric, borrow world: model.World) {
         let item = world.tiles.get_or(i, model.empty_tile());
         metric.observe(inout out, tile_projection(borrow world, i), (i % 13) + 1);
         metric.warn(inout out, item.x >= world.width || item.y >= world.height);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -82,18 +82,18 @@ fn observe_timeline(inout out: metric.Metric, borrow world: model.World) {
     while i < world.events.len() {
         metric.observe(inout out, event_projection(borrow world, i), (i % 5) + 1);
         metric.warn(inout out, world.events.get_or(i, model.empty_event()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
         metric.observe(inout out, command_projection(borrow world, i), (i % 7) + 1);
         metric.warn(inout out, world.commands.get_or(i, model.empty_command()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.snapshots.len() {
         metric.observe(inout out, snapshot_projection(borrow world, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -108,9 +108,9 @@ fn observe_pairs(inout out: metric.Metric, borrow world: model.World) {
             let dy = if left.y > right.y { left.y - right.y } else { right.y - left.y };
             metric.observe(inout out, @intCast(dx + dy) +
                 left.faction * 3 + right.faction * 5 + MODE(), i + j + 1);
-            j = j + 1;
+            j += 1;
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -125,17 +125,17 @@ fn observe_factions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.entities.len() {
             let entity = world.entities.get_or(i, model.empty_entity());
             if entity.faction == faction && entity.alive {
-                agents = agents + 1;
-                health = health + entity.health;
-                energy = energy + entity.energy;
-                inventory = inventory + entity.inventory;
+                agents += 1;
+                health += entity.health;
+                energy += entity.energy;
+                inventory += entity.inventory;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = agents * (MODE() % 11 + 1) + health * 3 +
             energy * 5 + inventory * 7 + faction;
         metric.observe(inout out, projection, faction + MODE() % 5 + 1);
-        faction = faction + 1;
+        faction += 1;
     }
 }
 
@@ -150,17 +150,17 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
-                tiles = tiles + 1;
+                tiles += 1;
                 if tile.walkable { walkable = walkable + 1; }
-                resources = resources + tile.resource;
-                elevation = elevation + tile.height;
+                resources += tile.resource;
+                elevation += tile.height;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = tiles * (MODE() % 13 + 1) + walkable * 3 +
             resources * 5 + elevation * 7 + region;
         metric.observe(inout out, projection, region % 7 + 1);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/audit_economy_density.rue
+++ b/examples/caldera/audit_economy_density.rue
@@ -151,7 +151,7 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
                 tiles += 1;
-                if tile.walkable { walkable = walkable + 1; }
+                if tile.walkable { walkable += 1; }
                 resources += tile.resource;
                 elevation += tile.height;
             }

--- a/examples/caldera/audit_economy_density.rue
+++ b/examples/caldera/audit_economy_density.rue
@@ -63,7 +63,7 @@ fn observe_entities(inout out: metric.Metric, borrow world: model.World) {
         metric.observe(inout out, entity_projection(borrow world, i), (i % 11) + 1);
         metric.warn(inout out, item.alive && (item.x < 0 || item.y < 0 ||
             @intCast(item.x) >= world.width || @intCast(item.y) >= world.height));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -73,7 +73,7 @@ fn observe_tiles(inout out: metric.Metric, borrow world: model.World) {
         let item = world.tiles.get_or(i, model.empty_tile());
         metric.observe(inout out, tile_projection(borrow world, i), (i % 13) + 1);
         metric.warn(inout out, item.x >= world.width || item.y >= world.height);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -82,18 +82,18 @@ fn observe_timeline(inout out: metric.Metric, borrow world: model.World) {
     while i < world.events.len() {
         metric.observe(inout out, event_projection(borrow world, i), (i % 5) + 1);
         metric.warn(inout out, world.events.get_or(i, model.empty_event()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
         metric.observe(inout out, command_projection(borrow world, i), (i % 7) + 1);
         metric.warn(inout out, world.commands.get_or(i, model.empty_command()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.snapshots.len() {
         metric.observe(inout out, snapshot_projection(borrow world, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -108,9 +108,9 @@ fn observe_pairs(inout out: metric.Metric, borrow world: model.World) {
             let dy = if left.y > right.y { left.y - right.y } else { right.y - left.y };
             metric.observe(inout out, @intCast(dx + dy) +
                 left.faction * 3 + right.faction * 5 + MODE(), i + j + 1);
-            j = j + 1;
+            j += 1;
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -125,17 +125,17 @@ fn observe_factions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.entities.len() {
             let entity = world.entities.get_or(i, model.empty_entity());
             if entity.faction == faction && entity.alive {
-                agents = agents + 1;
-                health = health + entity.health;
-                energy = energy + entity.energy;
-                inventory = inventory + entity.inventory;
+                agents += 1;
+                health += entity.health;
+                energy += entity.energy;
+                inventory += entity.inventory;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = agents * (MODE() % 11 + 1) + health * 3 +
             energy * 5 + inventory * 7 + faction;
         metric.observe(inout out, projection, faction + MODE() % 5 + 1);
-        faction = faction + 1;
+        faction += 1;
     }
 }
 
@@ -150,17 +150,17 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
-                tiles = tiles + 1;
+                tiles += 1;
                 if tile.walkable { walkable = walkable + 1; }
-                resources = resources + tile.resource;
-                elevation = elevation + tile.height;
+                resources += tile.resource;
+                elevation += tile.height;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = tiles * (MODE() % 13 + 1) + walkable * 3 +
             resources * 5 + elevation * 7 + region;
         metric.observe(inout out, projection, region % 7 + 1);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/audit_economy_entropy.rue
+++ b/examples/caldera/audit_economy_entropy.rue
@@ -151,7 +151,7 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
                 tiles += 1;
-                if tile.walkable { walkable = walkable + 1; }
+                if tile.walkable { walkable += 1; }
                 resources += tile.resource;
                 elevation += tile.height;
             }

--- a/examples/caldera/audit_economy_entropy.rue
+++ b/examples/caldera/audit_economy_entropy.rue
@@ -63,7 +63,7 @@ fn observe_entities(inout out: metric.Metric, borrow world: model.World) {
         metric.observe(inout out, entity_projection(borrow world, i), (i % 11) + 1);
         metric.warn(inout out, item.alive && (item.x < 0 || item.y < 0 ||
             @intCast(item.x) >= world.width || @intCast(item.y) >= world.height));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -73,7 +73,7 @@ fn observe_tiles(inout out: metric.Metric, borrow world: model.World) {
         let item = world.tiles.get_or(i, model.empty_tile());
         metric.observe(inout out, tile_projection(borrow world, i), (i % 13) + 1);
         metric.warn(inout out, item.x >= world.width || item.y >= world.height);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -82,18 +82,18 @@ fn observe_timeline(inout out: metric.Metric, borrow world: model.World) {
     while i < world.events.len() {
         metric.observe(inout out, event_projection(borrow world, i), (i % 5) + 1);
         metric.warn(inout out, world.events.get_or(i, model.empty_event()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
         metric.observe(inout out, command_projection(borrow world, i), (i % 7) + 1);
         metric.warn(inout out, world.commands.get_or(i, model.empty_command()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.snapshots.len() {
         metric.observe(inout out, snapshot_projection(borrow world, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -108,9 +108,9 @@ fn observe_pairs(inout out: metric.Metric, borrow world: model.World) {
             let dy = if left.y > right.y { left.y - right.y } else { right.y - left.y };
             metric.observe(inout out, @intCast(dx + dy) +
                 left.faction * 3 + right.faction * 5 + MODE(), i + j + 1);
-            j = j + 1;
+            j += 1;
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -125,17 +125,17 @@ fn observe_factions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.entities.len() {
             let entity = world.entities.get_or(i, model.empty_entity());
             if entity.faction == faction && entity.alive {
-                agents = agents + 1;
-                health = health + entity.health;
-                energy = energy + entity.energy;
-                inventory = inventory + entity.inventory;
+                agents += 1;
+                health += entity.health;
+                energy += entity.energy;
+                inventory += entity.inventory;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = agents * (MODE() % 11 + 1) + health * 3 +
             energy * 5 + inventory * 7 + faction;
         metric.observe(inout out, projection, faction + MODE() % 5 + 1);
-        faction = faction + 1;
+        faction += 1;
     }
 }
 
@@ -150,17 +150,17 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
-                tiles = tiles + 1;
+                tiles += 1;
                 if tile.walkable { walkable = walkable + 1; }
-                resources = resources + tile.resource;
-                elevation = elevation + tile.height;
+                resources += tile.resource;
+                elevation += tile.height;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = tiles * (MODE() % 13 + 1) + walkable * 3 +
             resources * 5 + elevation * 7 + region;
         metric.observe(inout out, projection, region % 7 + 1);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/audit_economy_fanout.rue
+++ b/examples/caldera/audit_economy_fanout.rue
@@ -151,7 +151,7 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
                 tiles += 1;
-                if tile.walkable { walkable = walkable + 1; }
+                if tile.walkable { walkable += 1; }
                 resources += tile.resource;
                 elevation += tile.height;
             }

--- a/examples/caldera/audit_economy_fanout.rue
+++ b/examples/caldera/audit_economy_fanout.rue
@@ -63,7 +63,7 @@ fn observe_entities(inout out: metric.Metric, borrow world: model.World) {
         metric.observe(inout out, entity_projection(borrow world, i), (i % 11) + 1);
         metric.warn(inout out, item.alive && (item.x < 0 || item.y < 0 ||
             @intCast(item.x) >= world.width || @intCast(item.y) >= world.height));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -73,7 +73,7 @@ fn observe_tiles(inout out: metric.Metric, borrow world: model.World) {
         let item = world.tiles.get_or(i, model.empty_tile());
         metric.observe(inout out, tile_projection(borrow world, i), (i % 13) + 1);
         metric.warn(inout out, item.x >= world.width || item.y >= world.height);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -82,18 +82,18 @@ fn observe_timeline(inout out: metric.Metric, borrow world: model.World) {
     while i < world.events.len() {
         metric.observe(inout out, event_projection(borrow world, i), (i % 5) + 1);
         metric.warn(inout out, world.events.get_or(i, model.empty_event()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
         metric.observe(inout out, command_projection(borrow world, i), (i % 7) + 1);
         metric.warn(inout out, world.commands.get_or(i, model.empty_command()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.snapshots.len() {
         metric.observe(inout out, snapshot_projection(borrow world, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -108,9 +108,9 @@ fn observe_pairs(inout out: metric.Metric, borrow world: model.World) {
             let dy = if left.y > right.y { left.y - right.y } else { right.y - left.y };
             metric.observe(inout out, @intCast(dx + dy) +
                 left.faction * 3 + right.faction * 5 + MODE(), i + j + 1);
-            j = j + 1;
+            j += 1;
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -125,17 +125,17 @@ fn observe_factions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.entities.len() {
             let entity = world.entities.get_or(i, model.empty_entity());
             if entity.faction == faction && entity.alive {
-                agents = agents + 1;
-                health = health + entity.health;
-                energy = energy + entity.energy;
-                inventory = inventory + entity.inventory;
+                agents += 1;
+                health += entity.health;
+                energy += entity.energy;
+                inventory += entity.inventory;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = agents * (MODE() % 11 + 1) + health * 3 +
             energy * 5 + inventory * 7 + faction;
         metric.observe(inout out, projection, faction + MODE() % 5 + 1);
-        faction = faction + 1;
+        faction += 1;
     }
 }
 
@@ -150,17 +150,17 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
-                tiles = tiles + 1;
+                tiles += 1;
                 if tile.walkable { walkable = walkable + 1; }
-                resources = resources + tile.resource;
-                elevation = elevation + tile.height;
+                resources += tile.resource;
+                elevation += tile.height;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = tiles * (MODE() % 13 + 1) + walkable * 3 +
             resources * 5 + elevation * 7 + region;
         metric.observe(inout out, projection, region % 7 + 1);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/audit_economy_integrity.rue
+++ b/examples/caldera/audit_economy_integrity.rue
@@ -151,7 +151,7 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
                 tiles += 1;
-                if tile.walkable { walkable = walkable + 1; }
+                if tile.walkable { walkable += 1; }
                 resources += tile.resource;
                 elevation += tile.height;
             }

--- a/examples/caldera/audit_economy_integrity.rue
+++ b/examples/caldera/audit_economy_integrity.rue
@@ -63,7 +63,7 @@ fn observe_entities(inout out: metric.Metric, borrow world: model.World) {
         metric.observe(inout out, entity_projection(borrow world, i), (i % 11) + 1);
         metric.warn(inout out, item.alive && (item.x < 0 || item.y < 0 ||
             @intCast(item.x) >= world.width || @intCast(item.y) >= world.height));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -73,7 +73,7 @@ fn observe_tiles(inout out: metric.Metric, borrow world: model.World) {
         let item = world.tiles.get_or(i, model.empty_tile());
         metric.observe(inout out, tile_projection(borrow world, i), (i % 13) + 1);
         metric.warn(inout out, item.x >= world.width || item.y >= world.height);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -82,18 +82,18 @@ fn observe_timeline(inout out: metric.Metric, borrow world: model.World) {
     while i < world.events.len() {
         metric.observe(inout out, event_projection(borrow world, i), (i % 5) + 1);
         metric.warn(inout out, world.events.get_or(i, model.empty_event()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
         metric.observe(inout out, command_projection(borrow world, i), (i % 7) + 1);
         metric.warn(inout out, world.commands.get_or(i, model.empty_command()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.snapshots.len() {
         metric.observe(inout out, snapshot_projection(borrow world, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -108,9 +108,9 @@ fn observe_pairs(inout out: metric.Metric, borrow world: model.World) {
             let dy = if left.y > right.y { left.y - right.y } else { right.y - left.y };
             metric.observe(inout out, @intCast(dx + dy) +
                 left.faction * 3 + right.faction * 5 + MODE(), i + j + 1);
-            j = j + 1;
+            j += 1;
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -125,17 +125,17 @@ fn observe_factions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.entities.len() {
             let entity = world.entities.get_or(i, model.empty_entity());
             if entity.faction == faction && entity.alive {
-                agents = agents + 1;
-                health = health + entity.health;
-                energy = energy + entity.energy;
-                inventory = inventory + entity.inventory;
+                agents += 1;
+                health += entity.health;
+                energy += entity.energy;
+                inventory += entity.inventory;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = agents * (MODE() % 11 + 1) + health * 3 +
             energy * 5 + inventory * 7 + faction;
         metric.observe(inout out, projection, faction + MODE() % 5 + 1);
-        faction = faction + 1;
+        faction += 1;
     }
 }
 
@@ -150,17 +150,17 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
-                tiles = tiles + 1;
+                tiles += 1;
                 if tile.walkable { walkable = walkable + 1; }
-                resources = resources + tile.resource;
-                elevation = elevation + tile.height;
+                resources += tile.resource;
+                elevation += tile.height;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = tiles * (MODE() % 13 + 1) + walkable * 3 +
             resources * 5 + elevation * 7 + region;
         metric.observe(inout out, projection, region % 7 + 1);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/audit_economy_latency.rue
+++ b/examples/caldera/audit_economy_latency.rue
@@ -151,7 +151,7 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
                 tiles += 1;
-                if tile.walkable { walkable = walkable + 1; }
+                if tile.walkable { walkable += 1; }
                 resources += tile.resource;
                 elevation += tile.height;
             }

--- a/examples/caldera/audit_economy_latency.rue
+++ b/examples/caldera/audit_economy_latency.rue
@@ -63,7 +63,7 @@ fn observe_entities(inout out: metric.Metric, borrow world: model.World) {
         metric.observe(inout out, entity_projection(borrow world, i), (i % 11) + 1);
         metric.warn(inout out, item.alive && (item.x < 0 || item.y < 0 ||
             @intCast(item.x) >= world.width || @intCast(item.y) >= world.height));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -73,7 +73,7 @@ fn observe_tiles(inout out: metric.Metric, borrow world: model.World) {
         let item = world.tiles.get_or(i, model.empty_tile());
         metric.observe(inout out, tile_projection(borrow world, i), (i % 13) + 1);
         metric.warn(inout out, item.x >= world.width || item.y >= world.height);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -82,18 +82,18 @@ fn observe_timeline(inout out: metric.Metric, borrow world: model.World) {
     while i < world.events.len() {
         metric.observe(inout out, event_projection(borrow world, i), (i % 5) + 1);
         metric.warn(inout out, world.events.get_or(i, model.empty_event()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
         metric.observe(inout out, command_projection(borrow world, i), (i % 7) + 1);
         metric.warn(inout out, world.commands.get_or(i, model.empty_command()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.snapshots.len() {
         metric.observe(inout out, snapshot_projection(borrow world, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -108,9 +108,9 @@ fn observe_pairs(inout out: metric.Metric, borrow world: model.World) {
             let dy = if left.y > right.y { left.y - right.y } else { right.y - left.y };
             metric.observe(inout out, @intCast(dx + dy) +
                 left.faction * 3 + right.faction * 5 + MODE(), i + j + 1);
-            j = j + 1;
+            j += 1;
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -125,17 +125,17 @@ fn observe_factions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.entities.len() {
             let entity = world.entities.get_or(i, model.empty_entity());
             if entity.faction == faction && entity.alive {
-                agents = agents + 1;
-                health = health + entity.health;
-                energy = energy + entity.energy;
-                inventory = inventory + entity.inventory;
+                agents += 1;
+                health += entity.health;
+                energy += entity.energy;
+                inventory += entity.inventory;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = agents * (MODE() % 11 + 1) + health * 3 +
             energy * 5 + inventory * 7 + faction;
         metric.observe(inout out, projection, faction + MODE() % 5 + 1);
-        faction = faction + 1;
+        faction += 1;
     }
 }
 
@@ -150,17 +150,17 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
-                tiles = tiles + 1;
+                tiles += 1;
                 if tile.walkable { walkable = walkable + 1; }
-                resources = resources + tile.resource;
-                elevation = elevation + tile.height;
+                resources += tile.resource;
+                elevation += tile.height;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = tiles * (MODE() % 13 + 1) + walkable * 3 +
             resources * 5 + elevation * 7 + region;
         metric.observe(inout out, projection, region % 7 + 1);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/audit_economy_locality.rue
+++ b/examples/caldera/audit_economy_locality.rue
@@ -151,7 +151,7 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
                 tiles += 1;
-                if tile.walkable { walkable = walkable + 1; }
+                if tile.walkable { walkable += 1; }
                 resources += tile.resource;
                 elevation += tile.height;
             }

--- a/examples/caldera/audit_economy_locality.rue
+++ b/examples/caldera/audit_economy_locality.rue
@@ -63,7 +63,7 @@ fn observe_entities(inout out: metric.Metric, borrow world: model.World) {
         metric.observe(inout out, entity_projection(borrow world, i), (i % 11) + 1);
         metric.warn(inout out, item.alive && (item.x < 0 || item.y < 0 ||
             @intCast(item.x) >= world.width || @intCast(item.y) >= world.height));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -73,7 +73,7 @@ fn observe_tiles(inout out: metric.Metric, borrow world: model.World) {
         let item = world.tiles.get_or(i, model.empty_tile());
         metric.observe(inout out, tile_projection(borrow world, i), (i % 13) + 1);
         metric.warn(inout out, item.x >= world.width || item.y >= world.height);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -82,18 +82,18 @@ fn observe_timeline(inout out: metric.Metric, borrow world: model.World) {
     while i < world.events.len() {
         metric.observe(inout out, event_projection(borrow world, i), (i % 5) + 1);
         metric.warn(inout out, world.events.get_or(i, model.empty_event()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
         metric.observe(inout out, command_projection(borrow world, i), (i % 7) + 1);
         metric.warn(inout out, world.commands.get_or(i, model.empty_command()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.snapshots.len() {
         metric.observe(inout out, snapshot_projection(borrow world, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -108,9 +108,9 @@ fn observe_pairs(inout out: metric.Metric, borrow world: model.World) {
             let dy = if left.y > right.y { left.y - right.y } else { right.y - left.y };
             metric.observe(inout out, @intCast(dx + dy) +
                 left.faction * 3 + right.faction * 5 + MODE(), i + j + 1);
-            j = j + 1;
+            j += 1;
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -125,17 +125,17 @@ fn observe_factions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.entities.len() {
             let entity = world.entities.get_or(i, model.empty_entity());
             if entity.faction == faction && entity.alive {
-                agents = agents + 1;
-                health = health + entity.health;
-                energy = energy + entity.energy;
-                inventory = inventory + entity.inventory;
+                agents += 1;
+                health += entity.health;
+                energy += entity.energy;
+                inventory += entity.inventory;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = agents * (MODE() % 11 + 1) + health * 3 +
             energy * 5 + inventory * 7 + faction;
         metric.observe(inout out, projection, faction + MODE() % 5 + 1);
-        faction = faction + 1;
+        faction += 1;
     }
 }
 
@@ -150,17 +150,17 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
-                tiles = tiles + 1;
+                tiles += 1;
                 if tile.walkable { walkable = walkable + 1; }
-                resources = resources + tile.resource;
-                elevation = elevation + tile.height;
+                resources += tile.resource;
+                elevation += tile.height;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = tiles * (MODE() % 13 + 1) + walkable * 3 +
             resources * 5 + elevation * 7 + region;
         metric.observe(inout out, projection, region % 7 + 1);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/audit_economy_pressure.rue
+++ b/examples/caldera/audit_economy_pressure.rue
@@ -151,7 +151,7 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
                 tiles += 1;
-                if tile.walkable { walkable = walkable + 1; }
+                if tile.walkable { walkable += 1; }
                 resources += tile.resource;
                 elevation += tile.height;
             }

--- a/examples/caldera/audit_economy_pressure.rue
+++ b/examples/caldera/audit_economy_pressure.rue
@@ -63,7 +63,7 @@ fn observe_entities(inout out: metric.Metric, borrow world: model.World) {
         metric.observe(inout out, entity_projection(borrow world, i), (i % 11) + 1);
         metric.warn(inout out, item.alive && (item.x < 0 || item.y < 0 ||
             @intCast(item.x) >= world.width || @intCast(item.y) >= world.height));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -73,7 +73,7 @@ fn observe_tiles(inout out: metric.Metric, borrow world: model.World) {
         let item = world.tiles.get_or(i, model.empty_tile());
         metric.observe(inout out, tile_projection(borrow world, i), (i % 13) + 1);
         metric.warn(inout out, item.x >= world.width || item.y >= world.height);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -82,18 +82,18 @@ fn observe_timeline(inout out: metric.Metric, borrow world: model.World) {
     while i < world.events.len() {
         metric.observe(inout out, event_projection(borrow world, i), (i % 5) + 1);
         metric.warn(inout out, world.events.get_or(i, model.empty_event()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
         metric.observe(inout out, command_projection(borrow world, i), (i % 7) + 1);
         metric.warn(inout out, world.commands.get_or(i, model.empty_command()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.snapshots.len() {
         metric.observe(inout out, snapshot_projection(borrow world, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -108,9 +108,9 @@ fn observe_pairs(inout out: metric.Metric, borrow world: model.World) {
             let dy = if left.y > right.y { left.y - right.y } else { right.y - left.y };
             metric.observe(inout out, @intCast(dx + dy) +
                 left.faction * 3 + right.faction * 5 + MODE(), i + j + 1);
-            j = j + 1;
+            j += 1;
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -125,17 +125,17 @@ fn observe_factions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.entities.len() {
             let entity = world.entities.get_or(i, model.empty_entity());
             if entity.faction == faction && entity.alive {
-                agents = agents + 1;
-                health = health + entity.health;
-                energy = energy + entity.energy;
-                inventory = inventory + entity.inventory;
+                agents += 1;
+                health += entity.health;
+                energy += entity.energy;
+                inventory += entity.inventory;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = agents * (MODE() % 11 + 1) + health * 3 +
             energy * 5 + inventory * 7 + faction;
         metric.observe(inout out, projection, faction + MODE() % 5 + 1);
-        faction = faction + 1;
+        faction += 1;
     }
 }
 
@@ -150,17 +150,17 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
-                tiles = tiles + 1;
+                tiles += 1;
                 if tile.walkable { walkable = walkable + 1; }
-                resources = resources + tile.resource;
-                elevation = elevation + tile.height;
+                resources += tile.resource;
+                elevation += tile.height;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = tiles * (MODE() % 13 + 1) + walkable * 3 +
             resources * 5 + elevation * 7 + region;
         metric.observe(inout out, projection, region % 7 + 1);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/audit_economy_risk.rue
+++ b/examples/caldera/audit_economy_risk.rue
@@ -151,7 +151,7 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
                 tiles += 1;
-                if tile.walkable { walkable = walkable + 1; }
+                if tile.walkable { walkable += 1; }
                 resources += tile.resource;
                 elevation += tile.height;
             }

--- a/examples/caldera/audit_economy_risk.rue
+++ b/examples/caldera/audit_economy_risk.rue
@@ -63,7 +63,7 @@ fn observe_entities(inout out: metric.Metric, borrow world: model.World) {
         metric.observe(inout out, entity_projection(borrow world, i), (i % 11) + 1);
         metric.warn(inout out, item.alive && (item.x < 0 || item.y < 0 ||
             @intCast(item.x) >= world.width || @intCast(item.y) >= world.height));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -73,7 +73,7 @@ fn observe_tiles(inout out: metric.Metric, borrow world: model.World) {
         let item = world.tiles.get_or(i, model.empty_tile());
         metric.observe(inout out, tile_projection(borrow world, i), (i % 13) + 1);
         metric.warn(inout out, item.x >= world.width || item.y >= world.height);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -82,18 +82,18 @@ fn observe_timeline(inout out: metric.Metric, borrow world: model.World) {
     while i < world.events.len() {
         metric.observe(inout out, event_projection(borrow world, i), (i % 5) + 1);
         metric.warn(inout out, world.events.get_or(i, model.empty_event()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
         metric.observe(inout out, command_projection(borrow world, i), (i % 7) + 1);
         metric.warn(inout out, world.commands.get_or(i, model.empty_command()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.snapshots.len() {
         metric.observe(inout out, snapshot_projection(borrow world, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -108,9 +108,9 @@ fn observe_pairs(inout out: metric.Metric, borrow world: model.World) {
             let dy = if left.y > right.y { left.y - right.y } else { right.y - left.y };
             metric.observe(inout out, @intCast(dx + dy) +
                 left.faction * 3 + right.faction * 5 + MODE(), i + j + 1);
-            j = j + 1;
+            j += 1;
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -125,17 +125,17 @@ fn observe_factions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.entities.len() {
             let entity = world.entities.get_or(i, model.empty_entity());
             if entity.faction == faction && entity.alive {
-                agents = agents + 1;
-                health = health + entity.health;
-                energy = energy + entity.energy;
-                inventory = inventory + entity.inventory;
+                agents += 1;
+                health += entity.health;
+                energy += entity.energy;
+                inventory += entity.inventory;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = agents * (MODE() % 11 + 1) + health * 3 +
             energy * 5 + inventory * 7 + faction;
         metric.observe(inout out, projection, faction + MODE() % 5 + 1);
-        faction = faction + 1;
+        faction += 1;
     }
 }
 
@@ -150,17 +150,17 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
-                tiles = tiles + 1;
+                tiles += 1;
                 if tile.walkable { walkable = walkable + 1; }
-                resources = resources + tile.resource;
-                elevation = elevation + tile.height;
+                resources += tile.resource;
+                elevation += tile.height;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = tiles * (MODE() % 13 + 1) + walkable * 3 +
             resources * 5 + elevation * 7 + region;
         metric.observe(inout out, projection, region % 7 + 1);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/audit_economy_skew.rue
+++ b/examples/caldera/audit_economy_skew.rue
@@ -151,7 +151,7 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
                 tiles += 1;
-                if tile.walkable { walkable = walkable + 1; }
+                if tile.walkable { walkable += 1; }
                 resources += tile.resource;
                 elevation += tile.height;
             }

--- a/examples/caldera/audit_economy_skew.rue
+++ b/examples/caldera/audit_economy_skew.rue
@@ -63,7 +63,7 @@ fn observe_entities(inout out: metric.Metric, borrow world: model.World) {
         metric.observe(inout out, entity_projection(borrow world, i), (i % 11) + 1);
         metric.warn(inout out, item.alive && (item.x < 0 || item.y < 0 ||
             @intCast(item.x) >= world.width || @intCast(item.y) >= world.height));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -73,7 +73,7 @@ fn observe_tiles(inout out: metric.Metric, borrow world: model.World) {
         let item = world.tiles.get_or(i, model.empty_tile());
         metric.observe(inout out, tile_projection(borrow world, i), (i % 13) + 1);
         metric.warn(inout out, item.x >= world.width || item.y >= world.height);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -82,18 +82,18 @@ fn observe_timeline(inout out: metric.Metric, borrow world: model.World) {
     while i < world.events.len() {
         metric.observe(inout out, event_projection(borrow world, i), (i % 5) + 1);
         metric.warn(inout out, world.events.get_or(i, model.empty_event()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
         metric.observe(inout out, command_projection(borrow world, i), (i % 7) + 1);
         metric.warn(inout out, world.commands.get_or(i, model.empty_command()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.snapshots.len() {
         metric.observe(inout out, snapshot_projection(borrow world, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -108,9 +108,9 @@ fn observe_pairs(inout out: metric.Metric, borrow world: model.World) {
             let dy = if left.y > right.y { left.y - right.y } else { right.y - left.y };
             metric.observe(inout out, @intCast(dx + dy) +
                 left.faction * 3 + right.faction * 5 + MODE(), i + j + 1);
-            j = j + 1;
+            j += 1;
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -125,17 +125,17 @@ fn observe_factions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.entities.len() {
             let entity = world.entities.get_or(i, model.empty_entity());
             if entity.faction == faction && entity.alive {
-                agents = agents + 1;
-                health = health + entity.health;
-                energy = energy + entity.energy;
-                inventory = inventory + entity.inventory;
+                agents += 1;
+                health += entity.health;
+                energy += entity.energy;
+                inventory += entity.inventory;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = agents * (MODE() % 11 + 1) + health * 3 +
             energy * 5 + inventory * 7 + faction;
         metric.observe(inout out, projection, faction + MODE() % 5 + 1);
-        faction = faction + 1;
+        faction += 1;
     }
 }
 
@@ -150,17 +150,17 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
-                tiles = tiles + 1;
+                tiles += 1;
                 if tile.walkable { walkable = walkable + 1; }
-                resources = resources + tile.resource;
-                elevation = elevation + tile.height;
+                resources += tile.resource;
+                elevation += tile.height;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = tiles * (MODE() % 13 + 1) + walkable * 3 +
             resources * 5 + elevation * 7 + region;
         metric.observe(inout out, projection, region % 7 + 1);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/audit_economy_stability.rue
+++ b/examples/caldera/audit_economy_stability.rue
@@ -151,7 +151,7 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
                 tiles += 1;
-                if tile.walkable { walkable = walkable + 1; }
+                if tile.walkable { walkable += 1; }
                 resources += tile.resource;
                 elevation += tile.height;
             }

--- a/examples/caldera/audit_economy_stability.rue
+++ b/examples/caldera/audit_economy_stability.rue
@@ -63,7 +63,7 @@ fn observe_entities(inout out: metric.Metric, borrow world: model.World) {
         metric.observe(inout out, entity_projection(borrow world, i), (i % 11) + 1);
         metric.warn(inout out, item.alive && (item.x < 0 || item.y < 0 ||
             @intCast(item.x) >= world.width || @intCast(item.y) >= world.height));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -73,7 +73,7 @@ fn observe_tiles(inout out: metric.Metric, borrow world: model.World) {
         let item = world.tiles.get_or(i, model.empty_tile());
         metric.observe(inout out, tile_projection(borrow world, i), (i % 13) + 1);
         metric.warn(inout out, item.x >= world.width || item.y >= world.height);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -82,18 +82,18 @@ fn observe_timeline(inout out: metric.Metric, borrow world: model.World) {
     while i < world.events.len() {
         metric.observe(inout out, event_projection(borrow world, i), (i % 5) + 1);
         metric.warn(inout out, world.events.get_or(i, model.empty_event()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
         metric.observe(inout out, command_projection(borrow world, i), (i % 7) + 1);
         metric.warn(inout out, world.commands.get_or(i, model.empty_command()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.snapshots.len() {
         metric.observe(inout out, snapshot_projection(borrow world, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -108,9 +108,9 @@ fn observe_pairs(inout out: metric.Metric, borrow world: model.World) {
             let dy = if left.y > right.y { left.y - right.y } else { right.y - left.y };
             metric.observe(inout out, @intCast(dx + dy) +
                 left.faction * 3 + right.faction * 5 + MODE(), i + j + 1);
-            j = j + 1;
+            j += 1;
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -125,17 +125,17 @@ fn observe_factions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.entities.len() {
             let entity = world.entities.get_or(i, model.empty_entity());
             if entity.faction == faction && entity.alive {
-                agents = agents + 1;
-                health = health + entity.health;
-                energy = energy + entity.energy;
-                inventory = inventory + entity.inventory;
+                agents += 1;
+                health += entity.health;
+                energy += entity.energy;
+                inventory += entity.inventory;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = agents * (MODE() % 11 + 1) + health * 3 +
             energy * 5 + inventory * 7 + faction;
         metric.observe(inout out, projection, faction + MODE() % 5 + 1);
-        faction = faction + 1;
+        faction += 1;
     }
 }
 
@@ -150,17 +150,17 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
-                tiles = tiles + 1;
+                tiles += 1;
                 if tile.walkable { walkable = walkable + 1; }
-                resources = resources + tile.resource;
-                elevation = elevation + tile.height;
+                resources += tile.resource;
+                elevation += tile.height;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = tiles * (MODE() % 13 + 1) + walkable * 3 +
             resources * 5 + elevation * 7 + region;
         metric.observe(inout out, projection, region % 7 + 1);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/audit_economy_throughput.rue
+++ b/examples/caldera/audit_economy_throughput.rue
@@ -151,7 +151,7 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
                 tiles += 1;
-                if tile.walkable { walkable = walkable + 1; }
+                if tile.walkable { walkable += 1; }
                 resources += tile.resource;
                 elevation += tile.height;
             }

--- a/examples/caldera/audit_economy_throughput.rue
+++ b/examples/caldera/audit_economy_throughput.rue
@@ -63,7 +63,7 @@ fn observe_entities(inout out: metric.Metric, borrow world: model.World) {
         metric.observe(inout out, entity_projection(borrow world, i), (i % 11) + 1);
         metric.warn(inout out, item.alive && (item.x < 0 || item.y < 0 ||
             @intCast(item.x) >= world.width || @intCast(item.y) >= world.height));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -73,7 +73,7 @@ fn observe_tiles(inout out: metric.Metric, borrow world: model.World) {
         let item = world.tiles.get_or(i, model.empty_tile());
         metric.observe(inout out, tile_projection(borrow world, i), (i % 13) + 1);
         metric.warn(inout out, item.x >= world.width || item.y >= world.height);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -82,18 +82,18 @@ fn observe_timeline(inout out: metric.Metric, borrow world: model.World) {
     while i < world.events.len() {
         metric.observe(inout out, event_projection(borrow world, i), (i % 5) + 1);
         metric.warn(inout out, world.events.get_or(i, model.empty_event()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
         metric.observe(inout out, command_projection(borrow world, i), (i % 7) + 1);
         metric.warn(inout out, world.commands.get_or(i, model.empty_command()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.snapshots.len() {
         metric.observe(inout out, snapshot_projection(borrow world, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -108,9 +108,9 @@ fn observe_pairs(inout out: metric.Metric, borrow world: model.World) {
             let dy = if left.y > right.y { left.y - right.y } else { right.y - left.y };
             metric.observe(inout out, @intCast(dx + dy) +
                 left.faction * 3 + right.faction * 5 + MODE(), i + j + 1);
-            j = j + 1;
+            j += 1;
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -125,17 +125,17 @@ fn observe_factions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.entities.len() {
             let entity = world.entities.get_or(i, model.empty_entity());
             if entity.faction == faction && entity.alive {
-                agents = agents + 1;
-                health = health + entity.health;
-                energy = energy + entity.energy;
-                inventory = inventory + entity.inventory;
+                agents += 1;
+                health += entity.health;
+                energy += entity.energy;
+                inventory += entity.inventory;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = agents * (MODE() % 11 + 1) + health * 3 +
             energy * 5 + inventory * 7 + faction;
         metric.observe(inout out, projection, faction + MODE() % 5 + 1);
-        faction = faction + 1;
+        faction += 1;
     }
 }
 
@@ -150,17 +150,17 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
-                tiles = tiles + 1;
+                tiles += 1;
                 if tile.walkable { walkable = walkable + 1; }
-                resources = resources + tile.resource;
-                elevation = elevation + tile.height;
+                resources += tile.resource;
+                elevation += tile.height;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = tiles * (MODE() % 13 + 1) + walkable * 3 +
             resources * 5 + elevation * 7 + region;
         metric.observe(inout out, projection, region % 7 + 1);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/audit_entity_balance.rue
+++ b/examples/caldera/audit_entity_balance.rue
@@ -151,7 +151,7 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
                 tiles += 1;
-                if tile.walkable { walkable = walkable + 1; }
+                if tile.walkable { walkable += 1; }
                 resources += tile.resource;
                 elevation += tile.height;
             }

--- a/examples/caldera/audit_entity_balance.rue
+++ b/examples/caldera/audit_entity_balance.rue
@@ -63,7 +63,7 @@ fn observe_entities(inout out: metric.Metric, borrow world: model.World) {
         metric.observe(inout out, entity_projection(borrow world, i), (i % 11) + 1);
         metric.warn(inout out, item.alive && (item.x < 0 || item.y < 0 ||
             @intCast(item.x) >= world.width || @intCast(item.y) >= world.height));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -73,7 +73,7 @@ fn observe_tiles(inout out: metric.Metric, borrow world: model.World) {
         let item = world.tiles.get_or(i, model.empty_tile());
         metric.observe(inout out, tile_projection(borrow world, i), (i % 13) + 1);
         metric.warn(inout out, item.x >= world.width || item.y >= world.height);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -82,18 +82,18 @@ fn observe_timeline(inout out: metric.Metric, borrow world: model.World) {
     while i < world.events.len() {
         metric.observe(inout out, event_projection(borrow world, i), (i % 5) + 1);
         metric.warn(inout out, world.events.get_or(i, model.empty_event()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
         metric.observe(inout out, command_projection(borrow world, i), (i % 7) + 1);
         metric.warn(inout out, world.commands.get_or(i, model.empty_command()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.snapshots.len() {
         metric.observe(inout out, snapshot_projection(borrow world, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -108,9 +108,9 @@ fn observe_pairs(inout out: metric.Metric, borrow world: model.World) {
             let dy = if left.y > right.y { left.y - right.y } else { right.y - left.y };
             metric.observe(inout out, @intCast(dx + dy) +
                 left.faction * 3 + right.faction * 5 + MODE(), i + j + 1);
-            j = j + 1;
+            j += 1;
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -125,17 +125,17 @@ fn observe_factions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.entities.len() {
             let entity = world.entities.get_or(i, model.empty_entity());
             if entity.faction == faction && entity.alive {
-                agents = agents + 1;
-                health = health + entity.health;
-                energy = energy + entity.energy;
-                inventory = inventory + entity.inventory;
+                agents += 1;
+                health += entity.health;
+                energy += entity.energy;
+                inventory += entity.inventory;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = agents * (MODE() % 11 + 1) + health * 3 +
             energy * 5 + inventory * 7 + faction;
         metric.observe(inout out, projection, faction + MODE() % 5 + 1);
-        faction = faction + 1;
+        faction += 1;
     }
 }
 
@@ -150,17 +150,17 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
-                tiles = tiles + 1;
+                tiles += 1;
                 if tile.walkable { walkable = walkable + 1; }
-                resources = resources + tile.resource;
-                elevation = elevation + tile.height;
+                resources += tile.resource;
+                elevation += tile.height;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = tiles * (MODE() % 13 + 1) + walkable * 3 +
             resources * 5 + elevation * 7 + region;
         metric.observe(inout out, projection, region % 7 + 1);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/audit_entity_capacity.rue
+++ b/examples/caldera/audit_entity_capacity.rue
@@ -151,7 +151,7 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
                 tiles += 1;
-                if tile.walkable { walkable = walkable + 1; }
+                if tile.walkable { walkable += 1; }
                 resources += tile.resource;
                 elevation += tile.height;
             }

--- a/examples/caldera/audit_entity_capacity.rue
+++ b/examples/caldera/audit_entity_capacity.rue
@@ -63,7 +63,7 @@ fn observe_entities(inout out: metric.Metric, borrow world: model.World) {
         metric.observe(inout out, entity_projection(borrow world, i), (i % 11) + 1);
         metric.warn(inout out, item.alive && (item.x < 0 || item.y < 0 ||
             @intCast(item.x) >= world.width || @intCast(item.y) >= world.height));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -73,7 +73,7 @@ fn observe_tiles(inout out: metric.Metric, borrow world: model.World) {
         let item = world.tiles.get_or(i, model.empty_tile());
         metric.observe(inout out, tile_projection(borrow world, i), (i % 13) + 1);
         metric.warn(inout out, item.x >= world.width || item.y >= world.height);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -82,18 +82,18 @@ fn observe_timeline(inout out: metric.Metric, borrow world: model.World) {
     while i < world.events.len() {
         metric.observe(inout out, event_projection(borrow world, i), (i % 5) + 1);
         metric.warn(inout out, world.events.get_or(i, model.empty_event()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
         metric.observe(inout out, command_projection(borrow world, i), (i % 7) + 1);
         metric.warn(inout out, world.commands.get_or(i, model.empty_command()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.snapshots.len() {
         metric.observe(inout out, snapshot_projection(borrow world, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -108,9 +108,9 @@ fn observe_pairs(inout out: metric.Metric, borrow world: model.World) {
             let dy = if left.y > right.y { left.y - right.y } else { right.y - left.y };
             metric.observe(inout out, @intCast(dx + dy) +
                 left.faction * 3 + right.faction * 5 + MODE(), i + j + 1);
-            j = j + 1;
+            j += 1;
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -125,17 +125,17 @@ fn observe_factions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.entities.len() {
             let entity = world.entities.get_or(i, model.empty_entity());
             if entity.faction == faction && entity.alive {
-                agents = agents + 1;
-                health = health + entity.health;
-                energy = energy + entity.energy;
-                inventory = inventory + entity.inventory;
+                agents += 1;
+                health += entity.health;
+                energy += entity.energy;
+                inventory += entity.inventory;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = agents * (MODE() % 11 + 1) + health * 3 +
             energy * 5 + inventory * 7 + faction;
         metric.observe(inout out, projection, faction + MODE() % 5 + 1);
-        faction = faction + 1;
+        faction += 1;
     }
 }
 
@@ -150,17 +150,17 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
-                tiles = tiles + 1;
+                tiles += 1;
                 if tile.walkable { walkable = walkable + 1; }
-                resources = resources + tile.resource;
-                elevation = elevation + tile.height;
+                resources += tile.resource;
+                elevation += tile.height;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = tiles * (MODE() % 13 + 1) + walkable * 3 +
             resources * 5 + elevation * 7 + region;
         metric.observe(inout out, projection, region % 7 + 1);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/audit_entity_continuity.rue
+++ b/examples/caldera/audit_entity_continuity.rue
@@ -151,7 +151,7 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
                 tiles += 1;
-                if tile.walkable { walkable = walkable + 1; }
+                if tile.walkable { walkable += 1; }
                 resources += tile.resource;
                 elevation += tile.height;
             }

--- a/examples/caldera/audit_entity_continuity.rue
+++ b/examples/caldera/audit_entity_continuity.rue
@@ -63,7 +63,7 @@ fn observe_entities(inout out: metric.Metric, borrow world: model.World) {
         metric.observe(inout out, entity_projection(borrow world, i), (i % 11) + 1);
         metric.warn(inout out, item.alive && (item.x < 0 || item.y < 0 ||
             @intCast(item.x) >= world.width || @intCast(item.y) >= world.height));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -73,7 +73,7 @@ fn observe_tiles(inout out: metric.Metric, borrow world: model.World) {
         let item = world.tiles.get_or(i, model.empty_tile());
         metric.observe(inout out, tile_projection(borrow world, i), (i % 13) + 1);
         metric.warn(inout out, item.x >= world.width || item.y >= world.height);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -82,18 +82,18 @@ fn observe_timeline(inout out: metric.Metric, borrow world: model.World) {
     while i < world.events.len() {
         metric.observe(inout out, event_projection(borrow world, i), (i % 5) + 1);
         metric.warn(inout out, world.events.get_or(i, model.empty_event()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
         metric.observe(inout out, command_projection(borrow world, i), (i % 7) + 1);
         metric.warn(inout out, world.commands.get_or(i, model.empty_command()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.snapshots.len() {
         metric.observe(inout out, snapshot_projection(borrow world, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -108,9 +108,9 @@ fn observe_pairs(inout out: metric.Metric, borrow world: model.World) {
             let dy = if left.y > right.y { left.y - right.y } else { right.y - left.y };
             metric.observe(inout out, @intCast(dx + dy) +
                 left.faction * 3 + right.faction * 5 + MODE(), i + j + 1);
-            j = j + 1;
+            j += 1;
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -125,17 +125,17 @@ fn observe_factions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.entities.len() {
             let entity = world.entities.get_or(i, model.empty_entity());
             if entity.faction == faction && entity.alive {
-                agents = agents + 1;
-                health = health + entity.health;
-                energy = energy + entity.energy;
-                inventory = inventory + entity.inventory;
+                agents += 1;
+                health += entity.health;
+                energy += entity.energy;
+                inventory += entity.inventory;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = agents * (MODE() % 11 + 1) + health * 3 +
             energy * 5 + inventory * 7 + faction;
         metric.observe(inout out, projection, faction + MODE() % 5 + 1);
-        faction = faction + 1;
+        faction += 1;
     }
 }
 
@@ -150,17 +150,17 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
-                tiles = tiles + 1;
+                tiles += 1;
                 if tile.walkable { walkable = walkable + 1; }
-                resources = resources + tile.resource;
-                elevation = elevation + tile.height;
+                resources += tile.resource;
+                elevation += tile.height;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = tiles * (MODE() % 13 + 1) + walkable * 3 +
             resources * 5 + elevation * 7 + region;
         metric.observe(inout out, projection, region % 7 + 1);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/audit_entity_cost.rue
+++ b/examples/caldera/audit_entity_cost.rue
@@ -151,7 +151,7 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
                 tiles += 1;
-                if tile.walkable { walkable = walkable + 1; }
+                if tile.walkable { walkable += 1; }
                 resources += tile.resource;
                 elevation += tile.height;
             }

--- a/examples/caldera/audit_entity_cost.rue
+++ b/examples/caldera/audit_entity_cost.rue
@@ -63,7 +63,7 @@ fn observe_entities(inout out: metric.Metric, borrow world: model.World) {
         metric.observe(inout out, entity_projection(borrow world, i), (i % 11) + 1);
         metric.warn(inout out, item.alive && (item.x < 0 || item.y < 0 ||
             @intCast(item.x) >= world.width || @intCast(item.y) >= world.height));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -73,7 +73,7 @@ fn observe_tiles(inout out: metric.Metric, borrow world: model.World) {
         let item = world.tiles.get_or(i, model.empty_tile());
         metric.observe(inout out, tile_projection(borrow world, i), (i % 13) + 1);
         metric.warn(inout out, item.x >= world.width || item.y >= world.height);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -82,18 +82,18 @@ fn observe_timeline(inout out: metric.Metric, borrow world: model.World) {
     while i < world.events.len() {
         metric.observe(inout out, event_projection(borrow world, i), (i % 5) + 1);
         metric.warn(inout out, world.events.get_or(i, model.empty_event()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
         metric.observe(inout out, command_projection(borrow world, i), (i % 7) + 1);
         metric.warn(inout out, world.commands.get_or(i, model.empty_command()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.snapshots.len() {
         metric.observe(inout out, snapshot_projection(borrow world, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -108,9 +108,9 @@ fn observe_pairs(inout out: metric.Metric, borrow world: model.World) {
             let dy = if left.y > right.y { left.y - right.y } else { right.y - left.y };
             metric.observe(inout out, @intCast(dx + dy) +
                 left.faction * 3 + right.faction * 5 + MODE(), i + j + 1);
-            j = j + 1;
+            j += 1;
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -125,17 +125,17 @@ fn observe_factions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.entities.len() {
             let entity = world.entities.get_or(i, model.empty_entity());
             if entity.faction == faction && entity.alive {
-                agents = agents + 1;
-                health = health + entity.health;
-                energy = energy + entity.energy;
-                inventory = inventory + entity.inventory;
+                agents += 1;
+                health += entity.health;
+                energy += entity.energy;
+                inventory += entity.inventory;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = agents * (MODE() % 11 + 1) + health * 3 +
             energy * 5 + inventory * 7 + faction;
         metric.observe(inout out, projection, faction + MODE() % 5 + 1);
-        faction = faction + 1;
+        faction += 1;
     }
 }
 
@@ -150,17 +150,17 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
-                tiles = tiles + 1;
+                tiles += 1;
                 if tile.walkable { walkable = walkable + 1; }
-                resources = resources + tile.resource;
-                elevation = elevation + tile.height;
+                resources += tile.resource;
+                elevation += tile.height;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = tiles * (MODE() % 13 + 1) + walkable * 3 +
             resources * 5 + elevation * 7 + region;
         metric.observe(inout out, projection, region % 7 + 1);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/audit_entity_coverage.rue
+++ b/examples/caldera/audit_entity_coverage.rue
@@ -151,7 +151,7 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
                 tiles += 1;
-                if tile.walkable { walkable = walkable + 1; }
+                if tile.walkable { walkable += 1; }
                 resources += tile.resource;
                 elevation += tile.height;
             }

--- a/examples/caldera/audit_entity_coverage.rue
+++ b/examples/caldera/audit_entity_coverage.rue
@@ -63,7 +63,7 @@ fn observe_entities(inout out: metric.Metric, borrow world: model.World) {
         metric.observe(inout out, entity_projection(borrow world, i), (i % 11) + 1);
         metric.warn(inout out, item.alive && (item.x < 0 || item.y < 0 ||
             @intCast(item.x) >= world.width || @intCast(item.y) >= world.height));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -73,7 +73,7 @@ fn observe_tiles(inout out: metric.Metric, borrow world: model.World) {
         let item = world.tiles.get_or(i, model.empty_tile());
         metric.observe(inout out, tile_projection(borrow world, i), (i % 13) + 1);
         metric.warn(inout out, item.x >= world.width || item.y >= world.height);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -82,18 +82,18 @@ fn observe_timeline(inout out: metric.Metric, borrow world: model.World) {
     while i < world.events.len() {
         metric.observe(inout out, event_projection(borrow world, i), (i % 5) + 1);
         metric.warn(inout out, world.events.get_or(i, model.empty_event()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
         metric.observe(inout out, command_projection(borrow world, i), (i % 7) + 1);
         metric.warn(inout out, world.commands.get_or(i, model.empty_command()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.snapshots.len() {
         metric.observe(inout out, snapshot_projection(borrow world, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -108,9 +108,9 @@ fn observe_pairs(inout out: metric.Metric, borrow world: model.World) {
             let dy = if left.y > right.y { left.y - right.y } else { right.y - left.y };
             metric.observe(inout out, @intCast(dx + dy) +
                 left.faction * 3 + right.faction * 5 + MODE(), i + j + 1);
-            j = j + 1;
+            j += 1;
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -125,17 +125,17 @@ fn observe_factions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.entities.len() {
             let entity = world.entities.get_or(i, model.empty_entity());
             if entity.faction == faction && entity.alive {
-                agents = agents + 1;
-                health = health + entity.health;
-                energy = energy + entity.energy;
-                inventory = inventory + entity.inventory;
+                agents += 1;
+                health += entity.health;
+                energy += entity.energy;
+                inventory += entity.inventory;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = agents * (MODE() % 11 + 1) + health * 3 +
             energy * 5 + inventory * 7 + faction;
         metric.observe(inout out, projection, faction + MODE() % 5 + 1);
-        faction = faction + 1;
+        faction += 1;
     }
 }
 
@@ -150,17 +150,17 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
-                tiles = tiles + 1;
+                tiles += 1;
                 if tile.walkable { walkable = walkable + 1; }
-                resources = resources + tile.resource;
-                elevation = elevation + tile.height;
+                resources += tile.resource;
+                elevation += tile.height;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = tiles * (MODE() % 13 + 1) + walkable * 3 +
             resources * 5 + elevation * 7 + region;
         metric.observe(inout out, projection, region % 7 + 1);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/audit_entity_density.rue
+++ b/examples/caldera/audit_entity_density.rue
@@ -151,7 +151,7 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
                 tiles += 1;
-                if tile.walkable { walkable = walkable + 1; }
+                if tile.walkable { walkable += 1; }
                 resources += tile.resource;
                 elevation += tile.height;
             }

--- a/examples/caldera/audit_entity_density.rue
+++ b/examples/caldera/audit_entity_density.rue
@@ -63,7 +63,7 @@ fn observe_entities(inout out: metric.Metric, borrow world: model.World) {
         metric.observe(inout out, entity_projection(borrow world, i), (i % 11) + 1);
         metric.warn(inout out, item.alive && (item.x < 0 || item.y < 0 ||
             @intCast(item.x) >= world.width || @intCast(item.y) >= world.height));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -73,7 +73,7 @@ fn observe_tiles(inout out: metric.Metric, borrow world: model.World) {
         let item = world.tiles.get_or(i, model.empty_tile());
         metric.observe(inout out, tile_projection(borrow world, i), (i % 13) + 1);
         metric.warn(inout out, item.x >= world.width || item.y >= world.height);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -82,18 +82,18 @@ fn observe_timeline(inout out: metric.Metric, borrow world: model.World) {
     while i < world.events.len() {
         metric.observe(inout out, event_projection(borrow world, i), (i % 5) + 1);
         metric.warn(inout out, world.events.get_or(i, model.empty_event()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
         metric.observe(inout out, command_projection(borrow world, i), (i % 7) + 1);
         metric.warn(inout out, world.commands.get_or(i, model.empty_command()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.snapshots.len() {
         metric.observe(inout out, snapshot_projection(borrow world, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -108,9 +108,9 @@ fn observe_pairs(inout out: metric.Metric, borrow world: model.World) {
             let dy = if left.y > right.y { left.y - right.y } else { right.y - left.y };
             metric.observe(inout out, @intCast(dx + dy) +
                 left.faction * 3 + right.faction * 5 + MODE(), i + j + 1);
-            j = j + 1;
+            j += 1;
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -125,17 +125,17 @@ fn observe_factions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.entities.len() {
             let entity = world.entities.get_or(i, model.empty_entity());
             if entity.faction == faction && entity.alive {
-                agents = agents + 1;
-                health = health + entity.health;
-                energy = energy + entity.energy;
-                inventory = inventory + entity.inventory;
+                agents += 1;
+                health += entity.health;
+                energy += entity.energy;
+                inventory += entity.inventory;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = agents * (MODE() % 11 + 1) + health * 3 +
             energy * 5 + inventory * 7 + faction;
         metric.observe(inout out, projection, faction + MODE() % 5 + 1);
-        faction = faction + 1;
+        faction += 1;
     }
 }
 
@@ -150,17 +150,17 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
-                tiles = tiles + 1;
+                tiles += 1;
                 if tile.walkable { walkable = walkable + 1; }
-                resources = resources + tile.resource;
-                elevation = elevation + tile.height;
+                resources += tile.resource;
+                elevation += tile.height;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = tiles * (MODE() % 13 + 1) + walkable * 3 +
             resources * 5 + elevation * 7 + region;
         metric.observe(inout out, projection, region % 7 + 1);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/audit_entity_entropy.rue
+++ b/examples/caldera/audit_entity_entropy.rue
@@ -151,7 +151,7 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
                 tiles += 1;
-                if tile.walkable { walkable = walkable + 1; }
+                if tile.walkable { walkable += 1; }
                 resources += tile.resource;
                 elevation += tile.height;
             }

--- a/examples/caldera/audit_entity_entropy.rue
+++ b/examples/caldera/audit_entity_entropy.rue
@@ -63,7 +63,7 @@ fn observe_entities(inout out: metric.Metric, borrow world: model.World) {
         metric.observe(inout out, entity_projection(borrow world, i), (i % 11) + 1);
         metric.warn(inout out, item.alive && (item.x < 0 || item.y < 0 ||
             @intCast(item.x) >= world.width || @intCast(item.y) >= world.height));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -73,7 +73,7 @@ fn observe_tiles(inout out: metric.Metric, borrow world: model.World) {
         let item = world.tiles.get_or(i, model.empty_tile());
         metric.observe(inout out, tile_projection(borrow world, i), (i % 13) + 1);
         metric.warn(inout out, item.x >= world.width || item.y >= world.height);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -82,18 +82,18 @@ fn observe_timeline(inout out: metric.Metric, borrow world: model.World) {
     while i < world.events.len() {
         metric.observe(inout out, event_projection(borrow world, i), (i % 5) + 1);
         metric.warn(inout out, world.events.get_or(i, model.empty_event()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
         metric.observe(inout out, command_projection(borrow world, i), (i % 7) + 1);
         metric.warn(inout out, world.commands.get_or(i, model.empty_command()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.snapshots.len() {
         metric.observe(inout out, snapshot_projection(borrow world, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -108,9 +108,9 @@ fn observe_pairs(inout out: metric.Metric, borrow world: model.World) {
             let dy = if left.y > right.y { left.y - right.y } else { right.y - left.y };
             metric.observe(inout out, @intCast(dx + dy) +
                 left.faction * 3 + right.faction * 5 + MODE(), i + j + 1);
-            j = j + 1;
+            j += 1;
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -125,17 +125,17 @@ fn observe_factions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.entities.len() {
             let entity = world.entities.get_or(i, model.empty_entity());
             if entity.faction == faction && entity.alive {
-                agents = agents + 1;
-                health = health + entity.health;
-                energy = energy + entity.energy;
-                inventory = inventory + entity.inventory;
+                agents += 1;
+                health += entity.health;
+                energy += entity.energy;
+                inventory += entity.inventory;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = agents * (MODE() % 11 + 1) + health * 3 +
             energy * 5 + inventory * 7 + faction;
         metric.observe(inout out, projection, faction + MODE() % 5 + 1);
-        faction = faction + 1;
+        faction += 1;
     }
 }
 
@@ -150,17 +150,17 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
-                tiles = tiles + 1;
+                tiles += 1;
                 if tile.walkable { walkable = walkable + 1; }
-                resources = resources + tile.resource;
-                elevation = elevation + tile.height;
+                resources += tile.resource;
+                elevation += tile.height;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = tiles * (MODE() % 13 + 1) + walkable * 3 +
             resources * 5 + elevation * 7 + region;
         metric.observe(inout out, projection, region % 7 + 1);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/audit_entity_fanout.rue
+++ b/examples/caldera/audit_entity_fanout.rue
@@ -151,7 +151,7 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
                 tiles += 1;
-                if tile.walkable { walkable = walkable + 1; }
+                if tile.walkable { walkable += 1; }
                 resources += tile.resource;
                 elevation += tile.height;
             }

--- a/examples/caldera/audit_entity_fanout.rue
+++ b/examples/caldera/audit_entity_fanout.rue
@@ -63,7 +63,7 @@ fn observe_entities(inout out: metric.Metric, borrow world: model.World) {
         metric.observe(inout out, entity_projection(borrow world, i), (i % 11) + 1);
         metric.warn(inout out, item.alive && (item.x < 0 || item.y < 0 ||
             @intCast(item.x) >= world.width || @intCast(item.y) >= world.height));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -73,7 +73,7 @@ fn observe_tiles(inout out: metric.Metric, borrow world: model.World) {
         let item = world.tiles.get_or(i, model.empty_tile());
         metric.observe(inout out, tile_projection(borrow world, i), (i % 13) + 1);
         metric.warn(inout out, item.x >= world.width || item.y >= world.height);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -82,18 +82,18 @@ fn observe_timeline(inout out: metric.Metric, borrow world: model.World) {
     while i < world.events.len() {
         metric.observe(inout out, event_projection(borrow world, i), (i % 5) + 1);
         metric.warn(inout out, world.events.get_or(i, model.empty_event()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
         metric.observe(inout out, command_projection(borrow world, i), (i % 7) + 1);
         metric.warn(inout out, world.commands.get_or(i, model.empty_command()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.snapshots.len() {
         metric.observe(inout out, snapshot_projection(borrow world, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -108,9 +108,9 @@ fn observe_pairs(inout out: metric.Metric, borrow world: model.World) {
             let dy = if left.y > right.y { left.y - right.y } else { right.y - left.y };
             metric.observe(inout out, @intCast(dx + dy) +
                 left.faction * 3 + right.faction * 5 + MODE(), i + j + 1);
-            j = j + 1;
+            j += 1;
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -125,17 +125,17 @@ fn observe_factions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.entities.len() {
             let entity = world.entities.get_or(i, model.empty_entity());
             if entity.faction == faction && entity.alive {
-                agents = agents + 1;
-                health = health + entity.health;
-                energy = energy + entity.energy;
-                inventory = inventory + entity.inventory;
+                agents += 1;
+                health += entity.health;
+                energy += entity.energy;
+                inventory += entity.inventory;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = agents * (MODE() % 11 + 1) + health * 3 +
             energy * 5 + inventory * 7 + faction;
         metric.observe(inout out, projection, faction + MODE() % 5 + 1);
-        faction = faction + 1;
+        faction += 1;
     }
 }
 
@@ -150,17 +150,17 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
-                tiles = tiles + 1;
+                tiles += 1;
                 if tile.walkable { walkable = walkable + 1; }
-                resources = resources + tile.resource;
-                elevation = elevation + tile.height;
+                resources += tile.resource;
+                elevation += tile.height;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = tiles * (MODE() % 13 + 1) + walkable * 3 +
             resources * 5 + elevation * 7 + region;
         metric.observe(inout out, projection, region % 7 + 1);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/audit_entity_integrity.rue
+++ b/examples/caldera/audit_entity_integrity.rue
@@ -151,7 +151,7 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
                 tiles += 1;
-                if tile.walkable { walkable = walkable + 1; }
+                if tile.walkable { walkable += 1; }
                 resources += tile.resource;
                 elevation += tile.height;
             }

--- a/examples/caldera/audit_entity_integrity.rue
+++ b/examples/caldera/audit_entity_integrity.rue
@@ -63,7 +63,7 @@ fn observe_entities(inout out: metric.Metric, borrow world: model.World) {
         metric.observe(inout out, entity_projection(borrow world, i), (i % 11) + 1);
         metric.warn(inout out, item.alive && (item.x < 0 || item.y < 0 ||
             @intCast(item.x) >= world.width || @intCast(item.y) >= world.height));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -73,7 +73,7 @@ fn observe_tiles(inout out: metric.Metric, borrow world: model.World) {
         let item = world.tiles.get_or(i, model.empty_tile());
         metric.observe(inout out, tile_projection(borrow world, i), (i % 13) + 1);
         metric.warn(inout out, item.x >= world.width || item.y >= world.height);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -82,18 +82,18 @@ fn observe_timeline(inout out: metric.Metric, borrow world: model.World) {
     while i < world.events.len() {
         metric.observe(inout out, event_projection(borrow world, i), (i % 5) + 1);
         metric.warn(inout out, world.events.get_or(i, model.empty_event()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
         metric.observe(inout out, command_projection(borrow world, i), (i % 7) + 1);
         metric.warn(inout out, world.commands.get_or(i, model.empty_command()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.snapshots.len() {
         metric.observe(inout out, snapshot_projection(borrow world, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -108,9 +108,9 @@ fn observe_pairs(inout out: metric.Metric, borrow world: model.World) {
             let dy = if left.y > right.y { left.y - right.y } else { right.y - left.y };
             metric.observe(inout out, @intCast(dx + dy) +
                 left.faction * 3 + right.faction * 5 + MODE(), i + j + 1);
-            j = j + 1;
+            j += 1;
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -125,17 +125,17 @@ fn observe_factions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.entities.len() {
             let entity = world.entities.get_or(i, model.empty_entity());
             if entity.faction == faction && entity.alive {
-                agents = agents + 1;
-                health = health + entity.health;
-                energy = energy + entity.energy;
-                inventory = inventory + entity.inventory;
+                agents += 1;
+                health += entity.health;
+                energy += entity.energy;
+                inventory += entity.inventory;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = agents * (MODE() % 11 + 1) + health * 3 +
             energy * 5 + inventory * 7 + faction;
         metric.observe(inout out, projection, faction + MODE() % 5 + 1);
-        faction = faction + 1;
+        faction += 1;
     }
 }
 
@@ -150,17 +150,17 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
-                tiles = tiles + 1;
+                tiles += 1;
                 if tile.walkable { walkable = walkable + 1; }
-                resources = resources + tile.resource;
-                elevation = elevation + tile.height;
+                resources += tile.resource;
+                elevation += tile.height;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = tiles * (MODE() % 13 + 1) + walkable * 3 +
             resources * 5 + elevation * 7 + region;
         metric.observe(inout out, projection, region % 7 + 1);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/audit_entity_latency.rue
+++ b/examples/caldera/audit_entity_latency.rue
@@ -151,7 +151,7 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
                 tiles += 1;
-                if tile.walkable { walkable = walkable + 1; }
+                if tile.walkable { walkable += 1; }
                 resources += tile.resource;
                 elevation += tile.height;
             }

--- a/examples/caldera/audit_entity_latency.rue
+++ b/examples/caldera/audit_entity_latency.rue
@@ -63,7 +63,7 @@ fn observe_entities(inout out: metric.Metric, borrow world: model.World) {
         metric.observe(inout out, entity_projection(borrow world, i), (i % 11) + 1);
         metric.warn(inout out, item.alive && (item.x < 0 || item.y < 0 ||
             @intCast(item.x) >= world.width || @intCast(item.y) >= world.height));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -73,7 +73,7 @@ fn observe_tiles(inout out: metric.Metric, borrow world: model.World) {
         let item = world.tiles.get_or(i, model.empty_tile());
         metric.observe(inout out, tile_projection(borrow world, i), (i % 13) + 1);
         metric.warn(inout out, item.x >= world.width || item.y >= world.height);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -82,18 +82,18 @@ fn observe_timeline(inout out: metric.Metric, borrow world: model.World) {
     while i < world.events.len() {
         metric.observe(inout out, event_projection(borrow world, i), (i % 5) + 1);
         metric.warn(inout out, world.events.get_or(i, model.empty_event()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
         metric.observe(inout out, command_projection(borrow world, i), (i % 7) + 1);
         metric.warn(inout out, world.commands.get_or(i, model.empty_command()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.snapshots.len() {
         metric.observe(inout out, snapshot_projection(borrow world, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -108,9 +108,9 @@ fn observe_pairs(inout out: metric.Metric, borrow world: model.World) {
             let dy = if left.y > right.y { left.y - right.y } else { right.y - left.y };
             metric.observe(inout out, @intCast(dx + dy) +
                 left.faction * 3 + right.faction * 5 + MODE(), i + j + 1);
-            j = j + 1;
+            j += 1;
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -125,17 +125,17 @@ fn observe_factions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.entities.len() {
             let entity = world.entities.get_or(i, model.empty_entity());
             if entity.faction == faction && entity.alive {
-                agents = agents + 1;
-                health = health + entity.health;
-                energy = energy + entity.energy;
-                inventory = inventory + entity.inventory;
+                agents += 1;
+                health += entity.health;
+                energy += entity.energy;
+                inventory += entity.inventory;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = agents * (MODE() % 11 + 1) + health * 3 +
             energy * 5 + inventory * 7 + faction;
         metric.observe(inout out, projection, faction + MODE() % 5 + 1);
-        faction = faction + 1;
+        faction += 1;
     }
 }
 
@@ -150,17 +150,17 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
-                tiles = tiles + 1;
+                tiles += 1;
                 if tile.walkable { walkable = walkable + 1; }
-                resources = resources + tile.resource;
-                elevation = elevation + tile.height;
+                resources += tile.resource;
+                elevation += tile.height;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = tiles * (MODE() % 13 + 1) + walkable * 3 +
             resources * 5 + elevation * 7 + region;
         metric.observe(inout out, projection, region % 7 + 1);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/audit_entity_locality.rue
+++ b/examples/caldera/audit_entity_locality.rue
@@ -151,7 +151,7 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
                 tiles += 1;
-                if tile.walkable { walkable = walkable + 1; }
+                if tile.walkable { walkable += 1; }
                 resources += tile.resource;
                 elevation += tile.height;
             }

--- a/examples/caldera/audit_entity_locality.rue
+++ b/examples/caldera/audit_entity_locality.rue
@@ -63,7 +63,7 @@ fn observe_entities(inout out: metric.Metric, borrow world: model.World) {
         metric.observe(inout out, entity_projection(borrow world, i), (i % 11) + 1);
         metric.warn(inout out, item.alive && (item.x < 0 || item.y < 0 ||
             @intCast(item.x) >= world.width || @intCast(item.y) >= world.height));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -73,7 +73,7 @@ fn observe_tiles(inout out: metric.Metric, borrow world: model.World) {
         let item = world.tiles.get_or(i, model.empty_tile());
         metric.observe(inout out, tile_projection(borrow world, i), (i % 13) + 1);
         metric.warn(inout out, item.x >= world.width || item.y >= world.height);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -82,18 +82,18 @@ fn observe_timeline(inout out: metric.Metric, borrow world: model.World) {
     while i < world.events.len() {
         metric.observe(inout out, event_projection(borrow world, i), (i % 5) + 1);
         metric.warn(inout out, world.events.get_or(i, model.empty_event()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
         metric.observe(inout out, command_projection(borrow world, i), (i % 7) + 1);
         metric.warn(inout out, world.commands.get_or(i, model.empty_command()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.snapshots.len() {
         metric.observe(inout out, snapshot_projection(borrow world, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -108,9 +108,9 @@ fn observe_pairs(inout out: metric.Metric, borrow world: model.World) {
             let dy = if left.y > right.y { left.y - right.y } else { right.y - left.y };
             metric.observe(inout out, @intCast(dx + dy) +
                 left.faction * 3 + right.faction * 5 + MODE(), i + j + 1);
-            j = j + 1;
+            j += 1;
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -125,17 +125,17 @@ fn observe_factions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.entities.len() {
             let entity = world.entities.get_or(i, model.empty_entity());
             if entity.faction == faction && entity.alive {
-                agents = agents + 1;
-                health = health + entity.health;
-                energy = energy + entity.energy;
-                inventory = inventory + entity.inventory;
+                agents += 1;
+                health += entity.health;
+                energy += entity.energy;
+                inventory += entity.inventory;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = agents * (MODE() % 11 + 1) + health * 3 +
             energy * 5 + inventory * 7 + faction;
         metric.observe(inout out, projection, faction + MODE() % 5 + 1);
-        faction = faction + 1;
+        faction += 1;
     }
 }
 
@@ -150,17 +150,17 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
-                tiles = tiles + 1;
+                tiles += 1;
                 if tile.walkable { walkable = walkable + 1; }
-                resources = resources + tile.resource;
-                elevation = elevation + tile.height;
+                resources += tile.resource;
+                elevation += tile.height;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = tiles * (MODE() % 13 + 1) + walkable * 3 +
             resources * 5 + elevation * 7 + region;
         metric.observe(inout out, projection, region % 7 + 1);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/audit_entity_pressure.rue
+++ b/examples/caldera/audit_entity_pressure.rue
@@ -151,7 +151,7 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
                 tiles += 1;
-                if tile.walkable { walkable = walkable + 1; }
+                if tile.walkable { walkable += 1; }
                 resources += tile.resource;
                 elevation += tile.height;
             }

--- a/examples/caldera/audit_entity_pressure.rue
+++ b/examples/caldera/audit_entity_pressure.rue
@@ -63,7 +63,7 @@ fn observe_entities(inout out: metric.Metric, borrow world: model.World) {
         metric.observe(inout out, entity_projection(borrow world, i), (i % 11) + 1);
         metric.warn(inout out, item.alive && (item.x < 0 || item.y < 0 ||
             @intCast(item.x) >= world.width || @intCast(item.y) >= world.height));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -73,7 +73,7 @@ fn observe_tiles(inout out: metric.Metric, borrow world: model.World) {
         let item = world.tiles.get_or(i, model.empty_tile());
         metric.observe(inout out, tile_projection(borrow world, i), (i % 13) + 1);
         metric.warn(inout out, item.x >= world.width || item.y >= world.height);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -82,18 +82,18 @@ fn observe_timeline(inout out: metric.Metric, borrow world: model.World) {
     while i < world.events.len() {
         metric.observe(inout out, event_projection(borrow world, i), (i % 5) + 1);
         metric.warn(inout out, world.events.get_or(i, model.empty_event()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
         metric.observe(inout out, command_projection(borrow world, i), (i % 7) + 1);
         metric.warn(inout out, world.commands.get_or(i, model.empty_command()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.snapshots.len() {
         metric.observe(inout out, snapshot_projection(borrow world, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -108,9 +108,9 @@ fn observe_pairs(inout out: metric.Metric, borrow world: model.World) {
             let dy = if left.y > right.y { left.y - right.y } else { right.y - left.y };
             metric.observe(inout out, @intCast(dx + dy) +
                 left.faction * 3 + right.faction * 5 + MODE(), i + j + 1);
-            j = j + 1;
+            j += 1;
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -125,17 +125,17 @@ fn observe_factions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.entities.len() {
             let entity = world.entities.get_or(i, model.empty_entity());
             if entity.faction == faction && entity.alive {
-                agents = agents + 1;
-                health = health + entity.health;
-                energy = energy + entity.energy;
-                inventory = inventory + entity.inventory;
+                agents += 1;
+                health += entity.health;
+                energy += entity.energy;
+                inventory += entity.inventory;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = agents * (MODE() % 11 + 1) + health * 3 +
             energy * 5 + inventory * 7 + faction;
         metric.observe(inout out, projection, faction + MODE() % 5 + 1);
-        faction = faction + 1;
+        faction += 1;
     }
 }
 
@@ -150,17 +150,17 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
-                tiles = tiles + 1;
+                tiles += 1;
                 if tile.walkable { walkable = walkable + 1; }
-                resources = resources + tile.resource;
-                elevation = elevation + tile.height;
+                resources += tile.resource;
+                elevation += tile.height;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = tiles * (MODE() % 13 + 1) + walkable * 3 +
             resources * 5 + elevation * 7 + region;
         metric.observe(inout out, projection, region % 7 + 1);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/audit_entity_risk.rue
+++ b/examples/caldera/audit_entity_risk.rue
@@ -151,7 +151,7 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
                 tiles += 1;
-                if tile.walkable { walkable = walkable + 1; }
+                if tile.walkable { walkable += 1; }
                 resources += tile.resource;
                 elevation += tile.height;
             }

--- a/examples/caldera/audit_entity_risk.rue
+++ b/examples/caldera/audit_entity_risk.rue
@@ -63,7 +63,7 @@ fn observe_entities(inout out: metric.Metric, borrow world: model.World) {
         metric.observe(inout out, entity_projection(borrow world, i), (i % 11) + 1);
         metric.warn(inout out, item.alive && (item.x < 0 || item.y < 0 ||
             @intCast(item.x) >= world.width || @intCast(item.y) >= world.height));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -73,7 +73,7 @@ fn observe_tiles(inout out: metric.Metric, borrow world: model.World) {
         let item = world.tiles.get_or(i, model.empty_tile());
         metric.observe(inout out, tile_projection(borrow world, i), (i % 13) + 1);
         metric.warn(inout out, item.x >= world.width || item.y >= world.height);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -82,18 +82,18 @@ fn observe_timeline(inout out: metric.Metric, borrow world: model.World) {
     while i < world.events.len() {
         metric.observe(inout out, event_projection(borrow world, i), (i % 5) + 1);
         metric.warn(inout out, world.events.get_or(i, model.empty_event()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
         metric.observe(inout out, command_projection(borrow world, i), (i % 7) + 1);
         metric.warn(inout out, world.commands.get_or(i, model.empty_command()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.snapshots.len() {
         metric.observe(inout out, snapshot_projection(borrow world, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -108,9 +108,9 @@ fn observe_pairs(inout out: metric.Metric, borrow world: model.World) {
             let dy = if left.y > right.y { left.y - right.y } else { right.y - left.y };
             metric.observe(inout out, @intCast(dx + dy) +
                 left.faction * 3 + right.faction * 5 + MODE(), i + j + 1);
-            j = j + 1;
+            j += 1;
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -125,17 +125,17 @@ fn observe_factions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.entities.len() {
             let entity = world.entities.get_or(i, model.empty_entity());
             if entity.faction == faction && entity.alive {
-                agents = agents + 1;
-                health = health + entity.health;
-                energy = energy + entity.energy;
-                inventory = inventory + entity.inventory;
+                agents += 1;
+                health += entity.health;
+                energy += entity.energy;
+                inventory += entity.inventory;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = agents * (MODE() % 11 + 1) + health * 3 +
             energy * 5 + inventory * 7 + faction;
         metric.observe(inout out, projection, faction + MODE() % 5 + 1);
-        faction = faction + 1;
+        faction += 1;
     }
 }
 
@@ -150,17 +150,17 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
-                tiles = tiles + 1;
+                tiles += 1;
                 if tile.walkable { walkable = walkable + 1; }
-                resources = resources + tile.resource;
-                elevation = elevation + tile.height;
+                resources += tile.resource;
+                elevation += tile.height;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = tiles * (MODE() % 13 + 1) + walkable * 3 +
             resources * 5 + elevation * 7 + region;
         metric.observe(inout out, projection, region % 7 + 1);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/audit_entity_skew.rue
+++ b/examples/caldera/audit_entity_skew.rue
@@ -151,7 +151,7 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
                 tiles += 1;
-                if tile.walkable { walkable = walkable + 1; }
+                if tile.walkable { walkable += 1; }
                 resources += tile.resource;
                 elevation += tile.height;
             }

--- a/examples/caldera/audit_entity_skew.rue
+++ b/examples/caldera/audit_entity_skew.rue
@@ -63,7 +63,7 @@ fn observe_entities(inout out: metric.Metric, borrow world: model.World) {
         metric.observe(inout out, entity_projection(borrow world, i), (i % 11) + 1);
         metric.warn(inout out, item.alive && (item.x < 0 || item.y < 0 ||
             @intCast(item.x) >= world.width || @intCast(item.y) >= world.height));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -73,7 +73,7 @@ fn observe_tiles(inout out: metric.Metric, borrow world: model.World) {
         let item = world.tiles.get_or(i, model.empty_tile());
         metric.observe(inout out, tile_projection(borrow world, i), (i % 13) + 1);
         metric.warn(inout out, item.x >= world.width || item.y >= world.height);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -82,18 +82,18 @@ fn observe_timeline(inout out: metric.Metric, borrow world: model.World) {
     while i < world.events.len() {
         metric.observe(inout out, event_projection(borrow world, i), (i % 5) + 1);
         metric.warn(inout out, world.events.get_or(i, model.empty_event()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
         metric.observe(inout out, command_projection(borrow world, i), (i % 7) + 1);
         metric.warn(inout out, world.commands.get_or(i, model.empty_command()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.snapshots.len() {
         metric.observe(inout out, snapshot_projection(borrow world, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -108,9 +108,9 @@ fn observe_pairs(inout out: metric.Metric, borrow world: model.World) {
             let dy = if left.y > right.y { left.y - right.y } else { right.y - left.y };
             metric.observe(inout out, @intCast(dx + dy) +
                 left.faction * 3 + right.faction * 5 + MODE(), i + j + 1);
-            j = j + 1;
+            j += 1;
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -125,17 +125,17 @@ fn observe_factions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.entities.len() {
             let entity = world.entities.get_or(i, model.empty_entity());
             if entity.faction == faction && entity.alive {
-                agents = agents + 1;
-                health = health + entity.health;
-                energy = energy + entity.energy;
-                inventory = inventory + entity.inventory;
+                agents += 1;
+                health += entity.health;
+                energy += entity.energy;
+                inventory += entity.inventory;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = agents * (MODE() % 11 + 1) + health * 3 +
             energy * 5 + inventory * 7 + faction;
         metric.observe(inout out, projection, faction + MODE() % 5 + 1);
-        faction = faction + 1;
+        faction += 1;
     }
 }
 
@@ -150,17 +150,17 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
-                tiles = tiles + 1;
+                tiles += 1;
                 if tile.walkable { walkable = walkable + 1; }
-                resources = resources + tile.resource;
-                elevation = elevation + tile.height;
+                resources += tile.resource;
+                elevation += tile.height;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = tiles * (MODE() % 13 + 1) + walkable * 3 +
             resources * 5 + elevation * 7 + region;
         metric.observe(inout out, projection, region % 7 + 1);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/audit_entity_stability.rue
+++ b/examples/caldera/audit_entity_stability.rue
@@ -151,7 +151,7 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
                 tiles += 1;
-                if tile.walkable { walkable = walkable + 1; }
+                if tile.walkable { walkable += 1; }
                 resources += tile.resource;
                 elevation += tile.height;
             }

--- a/examples/caldera/audit_entity_stability.rue
+++ b/examples/caldera/audit_entity_stability.rue
@@ -63,7 +63,7 @@ fn observe_entities(inout out: metric.Metric, borrow world: model.World) {
         metric.observe(inout out, entity_projection(borrow world, i), (i % 11) + 1);
         metric.warn(inout out, item.alive && (item.x < 0 || item.y < 0 ||
             @intCast(item.x) >= world.width || @intCast(item.y) >= world.height));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -73,7 +73,7 @@ fn observe_tiles(inout out: metric.Metric, borrow world: model.World) {
         let item = world.tiles.get_or(i, model.empty_tile());
         metric.observe(inout out, tile_projection(borrow world, i), (i % 13) + 1);
         metric.warn(inout out, item.x >= world.width || item.y >= world.height);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -82,18 +82,18 @@ fn observe_timeline(inout out: metric.Metric, borrow world: model.World) {
     while i < world.events.len() {
         metric.observe(inout out, event_projection(borrow world, i), (i % 5) + 1);
         metric.warn(inout out, world.events.get_or(i, model.empty_event()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
         metric.observe(inout out, command_projection(borrow world, i), (i % 7) + 1);
         metric.warn(inout out, world.commands.get_or(i, model.empty_command()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.snapshots.len() {
         metric.observe(inout out, snapshot_projection(borrow world, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -108,9 +108,9 @@ fn observe_pairs(inout out: metric.Metric, borrow world: model.World) {
             let dy = if left.y > right.y { left.y - right.y } else { right.y - left.y };
             metric.observe(inout out, @intCast(dx + dy) +
                 left.faction * 3 + right.faction * 5 + MODE(), i + j + 1);
-            j = j + 1;
+            j += 1;
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -125,17 +125,17 @@ fn observe_factions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.entities.len() {
             let entity = world.entities.get_or(i, model.empty_entity());
             if entity.faction == faction && entity.alive {
-                agents = agents + 1;
-                health = health + entity.health;
-                energy = energy + entity.energy;
-                inventory = inventory + entity.inventory;
+                agents += 1;
+                health += entity.health;
+                energy += entity.energy;
+                inventory += entity.inventory;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = agents * (MODE() % 11 + 1) + health * 3 +
             energy * 5 + inventory * 7 + faction;
         metric.observe(inout out, projection, faction + MODE() % 5 + 1);
-        faction = faction + 1;
+        faction += 1;
     }
 }
 
@@ -150,17 +150,17 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
-                tiles = tiles + 1;
+                tiles += 1;
                 if tile.walkable { walkable = walkable + 1; }
-                resources = resources + tile.resource;
-                elevation = elevation + tile.height;
+                resources += tile.resource;
+                elevation += tile.height;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = tiles * (MODE() % 13 + 1) + walkable * 3 +
             resources * 5 + elevation * 7 + region;
         metric.observe(inout out, projection, region % 7 + 1);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/audit_entity_throughput.rue
+++ b/examples/caldera/audit_entity_throughput.rue
@@ -151,7 +151,7 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
                 tiles += 1;
-                if tile.walkable { walkable = walkable + 1; }
+                if tile.walkable { walkable += 1; }
                 resources += tile.resource;
                 elevation += tile.height;
             }

--- a/examples/caldera/audit_entity_throughput.rue
+++ b/examples/caldera/audit_entity_throughput.rue
@@ -63,7 +63,7 @@ fn observe_entities(inout out: metric.Metric, borrow world: model.World) {
         metric.observe(inout out, entity_projection(borrow world, i), (i % 11) + 1);
         metric.warn(inout out, item.alive && (item.x < 0 || item.y < 0 ||
             @intCast(item.x) >= world.width || @intCast(item.y) >= world.height));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -73,7 +73,7 @@ fn observe_tiles(inout out: metric.Metric, borrow world: model.World) {
         let item = world.tiles.get_or(i, model.empty_tile());
         metric.observe(inout out, tile_projection(borrow world, i), (i % 13) + 1);
         metric.warn(inout out, item.x >= world.width || item.y >= world.height);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -82,18 +82,18 @@ fn observe_timeline(inout out: metric.Metric, borrow world: model.World) {
     while i < world.events.len() {
         metric.observe(inout out, event_projection(borrow world, i), (i % 5) + 1);
         metric.warn(inout out, world.events.get_or(i, model.empty_event()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
         metric.observe(inout out, command_projection(borrow world, i), (i % 7) + 1);
         metric.warn(inout out, world.commands.get_or(i, model.empty_command()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.snapshots.len() {
         metric.observe(inout out, snapshot_projection(borrow world, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -108,9 +108,9 @@ fn observe_pairs(inout out: metric.Metric, borrow world: model.World) {
             let dy = if left.y > right.y { left.y - right.y } else { right.y - left.y };
             metric.observe(inout out, @intCast(dx + dy) +
                 left.faction * 3 + right.faction * 5 + MODE(), i + j + 1);
-            j = j + 1;
+            j += 1;
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -125,17 +125,17 @@ fn observe_factions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.entities.len() {
             let entity = world.entities.get_or(i, model.empty_entity());
             if entity.faction == faction && entity.alive {
-                agents = agents + 1;
-                health = health + entity.health;
-                energy = energy + entity.energy;
-                inventory = inventory + entity.inventory;
+                agents += 1;
+                health += entity.health;
+                energy += entity.energy;
+                inventory += entity.inventory;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = agents * (MODE() % 11 + 1) + health * 3 +
             energy * 5 + inventory * 7 + faction;
         metric.observe(inout out, projection, faction + MODE() % 5 + 1);
-        faction = faction + 1;
+        faction += 1;
     }
 }
 
@@ -150,17 +150,17 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
-                tiles = tiles + 1;
+                tiles += 1;
                 if tile.walkable { walkable = walkable + 1; }
-                resources = resources + tile.resource;
-                elevation = elevation + tile.height;
+                resources += tile.resource;
+                elevation += tile.height;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = tiles * (MODE() % 13 + 1) + walkable * 3 +
             resources * 5 + elevation * 7 + region;
         metric.observe(inout out, projection, region % 7 + 1);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/audit_faction_balance.rue
+++ b/examples/caldera/audit_faction_balance.rue
@@ -151,7 +151,7 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
                 tiles += 1;
-                if tile.walkable { walkable = walkable + 1; }
+                if tile.walkable { walkable += 1; }
                 resources += tile.resource;
                 elevation += tile.height;
             }

--- a/examples/caldera/audit_faction_balance.rue
+++ b/examples/caldera/audit_faction_balance.rue
@@ -63,7 +63,7 @@ fn observe_entities(inout out: metric.Metric, borrow world: model.World) {
         metric.observe(inout out, entity_projection(borrow world, i), (i % 11) + 1);
         metric.warn(inout out, item.alive && (item.x < 0 || item.y < 0 ||
             @intCast(item.x) >= world.width || @intCast(item.y) >= world.height));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -73,7 +73,7 @@ fn observe_tiles(inout out: metric.Metric, borrow world: model.World) {
         let item = world.tiles.get_or(i, model.empty_tile());
         metric.observe(inout out, tile_projection(borrow world, i), (i % 13) + 1);
         metric.warn(inout out, item.x >= world.width || item.y >= world.height);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -82,18 +82,18 @@ fn observe_timeline(inout out: metric.Metric, borrow world: model.World) {
     while i < world.events.len() {
         metric.observe(inout out, event_projection(borrow world, i), (i % 5) + 1);
         metric.warn(inout out, world.events.get_or(i, model.empty_event()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
         metric.observe(inout out, command_projection(borrow world, i), (i % 7) + 1);
         metric.warn(inout out, world.commands.get_or(i, model.empty_command()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.snapshots.len() {
         metric.observe(inout out, snapshot_projection(borrow world, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -108,9 +108,9 @@ fn observe_pairs(inout out: metric.Metric, borrow world: model.World) {
             let dy = if left.y > right.y { left.y - right.y } else { right.y - left.y };
             metric.observe(inout out, @intCast(dx + dy) +
                 left.faction * 3 + right.faction * 5 + MODE(), i + j + 1);
-            j = j + 1;
+            j += 1;
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -125,17 +125,17 @@ fn observe_factions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.entities.len() {
             let entity = world.entities.get_or(i, model.empty_entity());
             if entity.faction == faction && entity.alive {
-                agents = agents + 1;
-                health = health + entity.health;
-                energy = energy + entity.energy;
-                inventory = inventory + entity.inventory;
+                agents += 1;
+                health += entity.health;
+                energy += entity.energy;
+                inventory += entity.inventory;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = agents * (MODE() % 11 + 1) + health * 3 +
             energy * 5 + inventory * 7 + faction;
         metric.observe(inout out, projection, faction + MODE() % 5 + 1);
-        faction = faction + 1;
+        faction += 1;
     }
 }
 
@@ -150,17 +150,17 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
-                tiles = tiles + 1;
+                tiles += 1;
                 if tile.walkable { walkable = walkable + 1; }
-                resources = resources + tile.resource;
-                elevation = elevation + tile.height;
+                resources += tile.resource;
+                elevation += tile.height;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = tiles * (MODE() % 13 + 1) + walkable * 3 +
             resources * 5 + elevation * 7 + region;
         metric.observe(inout out, projection, region % 7 + 1);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/audit_faction_capacity.rue
+++ b/examples/caldera/audit_faction_capacity.rue
@@ -151,7 +151,7 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
                 tiles += 1;
-                if tile.walkable { walkable = walkable + 1; }
+                if tile.walkable { walkable += 1; }
                 resources += tile.resource;
                 elevation += tile.height;
             }

--- a/examples/caldera/audit_faction_capacity.rue
+++ b/examples/caldera/audit_faction_capacity.rue
@@ -63,7 +63,7 @@ fn observe_entities(inout out: metric.Metric, borrow world: model.World) {
         metric.observe(inout out, entity_projection(borrow world, i), (i % 11) + 1);
         metric.warn(inout out, item.alive && (item.x < 0 || item.y < 0 ||
             @intCast(item.x) >= world.width || @intCast(item.y) >= world.height));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -73,7 +73,7 @@ fn observe_tiles(inout out: metric.Metric, borrow world: model.World) {
         let item = world.tiles.get_or(i, model.empty_tile());
         metric.observe(inout out, tile_projection(borrow world, i), (i % 13) + 1);
         metric.warn(inout out, item.x >= world.width || item.y >= world.height);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -82,18 +82,18 @@ fn observe_timeline(inout out: metric.Metric, borrow world: model.World) {
     while i < world.events.len() {
         metric.observe(inout out, event_projection(borrow world, i), (i % 5) + 1);
         metric.warn(inout out, world.events.get_or(i, model.empty_event()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
         metric.observe(inout out, command_projection(borrow world, i), (i % 7) + 1);
         metric.warn(inout out, world.commands.get_or(i, model.empty_command()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.snapshots.len() {
         metric.observe(inout out, snapshot_projection(borrow world, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -108,9 +108,9 @@ fn observe_pairs(inout out: metric.Metric, borrow world: model.World) {
             let dy = if left.y > right.y { left.y - right.y } else { right.y - left.y };
             metric.observe(inout out, @intCast(dx + dy) +
                 left.faction * 3 + right.faction * 5 + MODE(), i + j + 1);
-            j = j + 1;
+            j += 1;
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -125,17 +125,17 @@ fn observe_factions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.entities.len() {
             let entity = world.entities.get_or(i, model.empty_entity());
             if entity.faction == faction && entity.alive {
-                agents = agents + 1;
-                health = health + entity.health;
-                energy = energy + entity.energy;
-                inventory = inventory + entity.inventory;
+                agents += 1;
+                health += entity.health;
+                energy += entity.energy;
+                inventory += entity.inventory;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = agents * (MODE() % 11 + 1) + health * 3 +
             energy * 5 + inventory * 7 + faction;
         metric.observe(inout out, projection, faction + MODE() % 5 + 1);
-        faction = faction + 1;
+        faction += 1;
     }
 }
 
@@ -150,17 +150,17 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
-                tiles = tiles + 1;
+                tiles += 1;
                 if tile.walkable { walkable = walkable + 1; }
-                resources = resources + tile.resource;
-                elevation = elevation + tile.height;
+                resources += tile.resource;
+                elevation += tile.height;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = tiles * (MODE() % 13 + 1) + walkable * 3 +
             resources * 5 + elevation * 7 + region;
         metric.observe(inout out, projection, region % 7 + 1);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/audit_faction_continuity.rue
+++ b/examples/caldera/audit_faction_continuity.rue
@@ -151,7 +151,7 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
                 tiles += 1;
-                if tile.walkable { walkable = walkable + 1; }
+                if tile.walkable { walkable += 1; }
                 resources += tile.resource;
                 elevation += tile.height;
             }

--- a/examples/caldera/audit_faction_continuity.rue
+++ b/examples/caldera/audit_faction_continuity.rue
@@ -63,7 +63,7 @@ fn observe_entities(inout out: metric.Metric, borrow world: model.World) {
         metric.observe(inout out, entity_projection(borrow world, i), (i % 11) + 1);
         metric.warn(inout out, item.alive && (item.x < 0 || item.y < 0 ||
             @intCast(item.x) >= world.width || @intCast(item.y) >= world.height));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -73,7 +73,7 @@ fn observe_tiles(inout out: metric.Metric, borrow world: model.World) {
         let item = world.tiles.get_or(i, model.empty_tile());
         metric.observe(inout out, tile_projection(borrow world, i), (i % 13) + 1);
         metric.warn(inout out, item.x >= world.width || item.y >= world.height);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -82,18 +82,18 @@ fn observe_timeline(inout out: metric.Metric, borrow world: model.World) {
     while i < world.events.len() {
         metric.observe(inout out, event_projection(borrow world, i), (i % 5) + 1);
         metric.warn(inout out, world.events.get_or(i, model.empty_event()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
         metric.observe(inout out, command_projection(borrow world, i), (i % 7) + 1);
         metric.warn(inout out, world.commands.get_or(i, model.empty_command()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.snapshots.len() {
         metric.observe(inout out, snapshot_projection(borrow world, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -108,9 +108,9 @@ fn observe_pairs(inout out: metric.Metric, borrow world: model.World) {
             let dy = if left.y > right.y { left.y - right.y } else { right.y - left.y };
             metric.observe(inout out, @intCast(dx + dy) +
                 left.faction * 3 + right.faction * 5 + MODE(), i + j + 1);
-            j = j + 1;
+            j += 1;
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -125,17 +125,17 @@ fn observe_factions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.entities.len() {
             let entity = world.entities.get_or(i, model.empty_entity());
             if entity.faction == faction && entity.alive {
-                agents = agents + 1;
-                health = health + entity.health;
-                energy = energy + entity.energy;
-                inventory = inventory + entity.inventory;
+                agents += 1;
+                health += entity.health;
+                energy += entity.energy;
+                inventory += entity.inventory;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = agents * (MODE() % 11 + 1) + health * 3 +
             energy * 5 + inventory * 7 + faction;
         metric.observe(inout out, projection, faction + MODE() % 5 + 1);
-        faction = faction + 1;
+        faction += 1;
     }
 }
 
@@ -150,17 +150,17 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
-                tiles = tiles + 1;
+                tiles += 1;
                 if tile.walkable { walkable = walkable + 1; }
-                resources = resources + tile.resource;
-                elevation = elevation + tile.height;
+                resources += tile.resource;
+                elevation += tile.height;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = tiles * (MODE() % 13 + 1) + walkable * 3 +
             resources * 5 + elevation * 7 + region;
         metric.observe(inout out, projection, region % 7 + 1);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/audit_faction_cost.rue
+++ b/examples/caldera/audit_faction_cost.rue
@@ -151,7 +151,7 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
                 tiles += 1;
-                if tile.walkable { walkable = walkable + 1; }
+                if tile.walkable { walkable += 1; }
                 resources += tile.resource;
                 elevation += tile.height;
             }

--- a/examples/caldera/audit_faction_cost.rue
+++ b/examples/caldera/audit_faction_cost.rue
@@ -63,7 +63,7 @@ fn observe_entities(inout out: metric.Metric, borrow world: model.World) {
         metric.observe(inout out, entity_projection(borrow world, i), (i % 11) + 1);
         metric.warn(inout out, item.alive && (item.x < 0 || item.y < 0 ||
             @intCast(item.x) >= world.width || @intCast(item.y) >= world.height));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -73,7 +73,7 @@ fn observe_tiles(inout out: metric.Metric, borrow world: model.World) {
         let item = world.tiles.get_or(i, model.empty_tile());
         metric.observe(inout out, tile_projection(borrow world, i), (i % 13) + 1);
         metric.warn(inout out, item.x >= world.width || item.y >= world.height);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -82,18 +82,18 @@ fn observe_timeline(inout out: metric.Metric, borrow world: model.World) {
     while i < world.events.len() {
         metric.observe(inout out, event_projection(borrow world, i), (i % 5) + 1);
         metric.warn(inout out, world.events.get_or(i, model.empty_event()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
         metric.observe(inout out, command_projection(borrow world, i), (i % 7) + 1);
         metric.warn(inout out, world.commands.get_or(i, model.empty_command()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.snapshots.len() {
         metric.observe(inout out, snapshot_projection(borrow world, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -108,9 +108,9 @@ fn observe_pairs(inout out: metric.Metric, borrow world: model.World) {
             let dy = if left.y > right.y { left.y - right.y } else { right.y - left.y };
             metric.observe(inout out, @intCast(dx + dy) +
                 left.faction * 3 + right.faction * 5 + MODE(), i + j + 1);
-            j = j + 1;
+            j += 1;
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -125,17 +125,17 @@ fn observe_factions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.entities.len() {
             let entity = world.entities.get_or(i, model.empty_entity());
             if entity.faction == faction && entity.alive {
-                agents = agents + 1;
-                health = health + entity.health;
-                energy = energy + entity.energy;
-                inventory = inventory + entity.inventory;
+                agents += 1;
+                health += entity.health;
+                energy += entity.energy;
+                inventory += entity.inventory;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = agents * (MODE() % 11 + 1) + health * 3 +
             energy * 5 + inventory * 7 + faction;
         metric.observe(inout out, projection, faction + MODE() % 5 + 1);
-        faction = faction + 1;
+        faction += 1;
     }
 }
 
@@ -150,17 +150,17 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
-                tiles = tiles + 1;
+                tiles += 1;
                 if tile.walkable { walkable = walkable + 1; }
-                resources = resources + tile.resource;
-                elevation = elevation + tile.height;
+                resources += tile.resource;
+                elevation += tile.height;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = tiles * (MODE() % 13 + 1) + walkable * 3 +
             resources * 5 + elevation * 7 + region;
         metric.observe(inout out, projection, region % 7 + 1);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/audit_faction_coverage.rue
+++ b/examples/caldera/audit_faction_coverage.rue
@@ -151,7 +151,7 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
                 tiles += 1;
-                if tile.walkable { walkable = walkable + 1; }
+                if tile.walkable { walkable += 1; }
                 resources += tile.resource;
                 elevation += tile.height;
             }

--- a/examples/caldera/audit_faction_coverage.rue
+++ b/examples/caldera/audit_faction_coverage.rue
@@ -63,7 +63,7 @@ fn observe_entities(inout out: metric.Metric, borrow world: model.World) {
         metric.observe(inout out, entity_projection(borrow world, i), (i % 11) + 1);
         metric.warn(inout out, item.alive && (item.x < 0 || item.y < 0 ||
             @intCast(item.x) >= world.width || @intCast(item.y) >= world.height));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -73,7 +73,7 @@ fn observe_tiles(inout out: metric.Metric, borrow world: model.World) {
         let item = world.tiles.get_or(i, model.empty_tile());
         metric.observe(inout out, tile_projection(borrow world, i), (i % 13) + 1);
         metric.warn(inout out, item.x >= world.width || item.y >= world.height);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -82,18 +82,18 @@ fn observe_timeline(inout out: metric.Metric, borrow world: model.World) {
     while i < world.events.len() {
         metric.observe(inout out, event_projection(borrow world, i), (i % 5) + 1);
         metric.warn(inout out, world.events.get_or(i, model.empty_event()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
         metric.observe(inout out, command_projection(borrow world, i), (i % 7) + 1);
         metric.warn(inout out, world.commands.get_or(i, model.empty_command()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.snapshots.len() {
         metric.observe(inout out, snapshot_projection(borrow world, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -108,9 +108,9 @@ fn observe_pairs(inout out: metric.Metric, borrow world: model.World) {
             let dy = if left.y > right.y { left.y - right.y } else { right.y - left.y };
             metric.observe(inout out, @intCast(dx + dy) +
                 left.faction * 3 + right.faction * 5 + MODE(), i + j + 1);
-            j = j + 1;
+            j += 1;
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -125,17 +125,17 @@ fn observe_factions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.entities.len() {
             let entity = world.entities.get_or(i, model.empty_entity());
             if entity.faction == faction && entity.alive {
-                agents = agents + 1;
-                health = health + entity.health;
-                energy = energy + entity.energy;
-                inventory = inventory + entity.inventory;
+                agents += 1;
+                health += entity.health;
+                energy += entity.energy;
+                inventory += entity.inventory;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = agents * (MODE() % 11 + 1) + health * 3 +
             energy * 5 + inventory * 7 + faction;
         metric.observe(inout out, projection, faction + MODE() % 5 + 1);
-        faction = faction + 1;
+        faction += 1;
     }
 }
 
@@ -150,17 +150,17 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
-                tiles = tiles + 1;
+                tiles += 1;
                 if tile.walkable { walkable = walkable + 1; }
-                resources = resources + tile.resource;
-                elevation = elevation + tile.height;
+                resources += tile.resource;
+                elevation += tile.height;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = tiles * (MODE() % 13 + 1) + walkable * 3 +
             resources * 5 + elevation * 7 + region;
         metric.observe(inout out, projection, region % 7 + 1);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/audit_faction_density.rue
+++ b/examples/caldera/audit_faction_density.rue
@@ -151,7 +151,7 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
                 tiles += 1;
-                if tile.walkable { walkable = walkable + 1; }
+                if tile.walkable { walkable += 1; }
                 resources += tile.resource;
                 elevation += tile.height;
             }

--- a/examples/caldera/audit_faction_density.rue
+++ b/examples/caldera/audit_faction_density.rue
@@ -63,7 +63,7 @@ fn observe_entities(inout out: metric.Metric, borrow world: model.World) {
         metric.observe(inout out, entity_projection(borrow world, i), (i % 11) + 1);
         metric.warn(inout out, item.alive && (item.x < 0 || item.y < 0 ||
             @intCast(item.x) >= world.width || @intCast(item.y) >= world.height));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -73,7 +73,7 @@ fn observe_tiles(inout out: metric.Metric, borrow world: model.World) {
         let item = world.tiles.get_or(i, model.empty_tile());
         metric.observe(inout out, tile_projection(borrow world, i), (i % 13) + 1);
         metric.warn(inout out, item.x >= world.width || item.y >= world.height);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -82,18 +82,18 @@ fn observe_timeline(inout out: metric.Metric, borrow world: model.World) {
     while i < world.events.len() {
         metric.observe(inout out, event_projection(borrow world, i), (i % 5) + 1);
         metric.warn(inout out, world.events.get_or(i, model.empty_event()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
         metric.observe(inout out, command_projection(borrow world, i), (i % 7) + 1);
         metric.warn(inout out, world.commands.get_or(i, model.empty_command()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.snapshots.len() {
         metric.observe(inout out, snapshot_projection(borrow world, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -108,9 +108,9 @@ fn observe_pairs(inout out: metric.Metric, borrow world: model.World) {
             let dy = if left.y > right.y { left.y - right.y } else { right.y - left.y };
             metric.observe(inout out, @intCast(dx + dy) +
                 left.faction * 3 + right.faction * 5 + MODE(), i + j + 1);
-            j = j + 1;
+            j += 1;
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -125,17 +125,17 @@ fn observe_factions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.entities.len() {
             let entity = world.entities.get_or(i, model.empty_entity());
             if entity.faction == faction && entity.alive {
-                agents = agents + 1;
-                health = health + entity.health;
-                energy = energy + entity.energy;
-                inventory = inventory + entity.inventory;
+                agents += 1;
+                health += entity.health;
+                energy += entity.energy;
+                inventory += entity.inventory;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = agents * (MODE() % 11 + 1) + health * 3 +
             energy * 5 + inventory * 7 + faction;
         metric.observe(inout out, projection, faction + MODE() % 5 + 1);
-        faction = faction + 1;
+        faction += 1;
     }
 }
 
@@ -150,17 +150,17 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
-                tiles = tiles + 1;
+                tiles += 1;
                 if tile.walkable { walkable = walkable + 1; }
-                resources = resources + tile.resource;
-                elevation = elevation + tile.height;
+                resources += tile.resource;
+                elevation += tile.height;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = tiles * (MODE() % 13 + 1) + walkable * 3 +
             resources * 5 + elevation * 7 + region;
         metric.observe(inout out, projection, region % 7 + 1);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/audit_faction_entropy.rue
+++ b/examples/caldera/audit_faction_entropy.rue
@@ -151,7 +151,7 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
                 tiles += 1;
-                if tile.walkable { walkable = walkable + 1; }
+                if tile.walkable { walkable += 1; }
                 resources += tile.resource;
                 elevation += tile.height;
             }

--- a/examples/caldera/audit_faction_entropy.rue
+++ b/examples/caldera/audit_faction_entropy.rue
@@ -63,7 +63,7 @@ fn observe_entities(inout out: metric.Metric, borrow world: model.World) {
         metric.observe(inout out, entity_projection(borrow world, i), (i % 11) + 1);
         metric.warn(inout out, item.alive && (item.x < 0 || item.y < 0 ||
             @intCast(item.x) >= world.width || @intCast(item.y) >= world.height));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -73,7 +73,7 @@ fn observe_tiles(inout out: metric.Metric, borrow world: model.World) {
         let item = world.tiles.get_or(i, model.empty_tile());
         metric.observe(inout out, tile_projection(borrow world, i), (i % 13) + 1);
         metric.warn(inout out, item.x >= world.width || item.y >= world.height);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -82,18 +82,18 @@ fn observe_timeline(inout out: metric.Metric, borrow world: model.World) {
     while i < world.events.len() {
         metric.observe(inout out, event_projection(borrow world, i), (i % 5) + 1);
         metric.warn(inout out, world.events.get_or(i, model.empty_event()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
         metric.observe(inout out, command_projection(borrow world, i), (i % 7) + 1);
         metric.warn(inout out, world.commands.get_or(i, model.empty_command()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.snapshots.len() {
         metric.observe(inout out, snapshot_projection(borrow world, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -108,9 +108,9 @@ fn observe_pairs(inout out: metric.Metric, borrow world: model.World) {
             let dy = if left.y > right.y { left.y - right.y } else { right.y - left.y };
             metric.observe(inout out, @intCast(dx + dy) +
                 left.faction * 3 + right.faction * 5 + MODE(), i + j + 1);
-            j = j + 1;
+            j += 1;
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -125,17 +125,17 @@ fn observe_factions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.entities.len() {
             let entity = world.entities.get_or(i, model.empty_entity());
             if entity.faction == faction && entity.alive {
-                agents = agents + 1;
-                health = health + entity.health;
-                energy = energy + entity.energy;
-                inventory = inventory + entity.inventory;
+                agents += 1;
+                health += entity.health;
+                energy += entity.energy;
+                inventory += entity.inventory;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = agents * (MODE() % 11 + 1) + health * 3 +
             energy * 5 + inventory * 7 + faction;
         metric.observe(inout out, projection, faction + MODE() % 5 + 1);
-        faction = faction + 1;
+        faction += 1;
     }
 }
 
@@ -150,17 +150,17 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
-                tiles = tiles + 1;
+                tiles += 1;
                 if tile.walkable { walkable = walkable + 1; }
-                resources = resources + tile.resource;
-                elevation = elevation + tile.height;
+                resources += tile.resource;
+                elevation += tile.height;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = tiles * (MODE() % 13 + 1) + walkable * 3 +
             resources * 5 + elevation * 7 + region;
         metric.observe(inout out, projection, region % 7 + 1);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/audit_faction_fanout.rue
+++ b/examples/caldera/audit_faction_fanout.rue
@@ -151,7 +151,7 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
                 tiles += 1;
-                if tile.walkable { walkable = walkable + 1; }
+                if tile.walkable { walkable += 1; }
                 resources += tile.resource;
                 elevation += tile.height;
             }

--- a/examples/caldera/audit_faction_fanout.rue
+++ b/examples/caldera/audit_faction_fanout.rue
@@ -63,7 +63,7 @@ fn observe_entities(inout out: metric.Metric, borrow world: model.World) {
         metric.observe(inout out, entity_projection(borrow world, i), (i % 11) + 1);
         metric.warn(inout out, item.alive && (item.x < 0 || item.y < 0 ||
             @intCast(item.x) >= world.width || @intCast(item.y) >= world.height));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -73,7 +73,7 @@ fn observe_tiles(inout out: metric.Metric, borrow world: model.World) {
         let item = world.tiles.get_or(i, model.empty_tile());
         metric.observe(inout out, tile_projection(borrow world, i), (i % 13) + 1);
         metric.warn(inout out, item.x >= world.width || item.y >= world.height);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -82,18 +82,18 @@ fn observe_timeline(inout out: metric.Metric, borrow world: model.World) {
     while i < world.events.len() {
         metric.observe(inout out, event_projection(borrow world, i), (i % 5) + 1);
         metric.warn(inout out, world.events.get_or(i, model.empty_event()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
         metric.observe(inout out, command_projection(borrow world, i), (i % 7) + 1);
         metric.warn(inout out, world.commands.get_or(i, model.empty_command()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.snapshots.len() {
         metric.observe(inout out, snapshot_projection(borrow world, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -108,9 +108,9 @@ fn observe_pairs(inout out: metric.Metric, borrow world: model.World) {
             let dy = if left.y > right.y { left.y - right.y } else { right.y - left.y };
             metric.observe(inout out, @intCast(dx + dy) +
                 left.faction * 3 + right.faction * 5 + MODE(), i + j + 1);
-            j = j + 1;
+            j += 1;
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -125,17 +125,17 @@ fn observe_factions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.entities.len() {
             let entity = world.entities.get_or(i, model.empty_entity());
             if entity.faction == faction && entity.alive {
-                agents = agents + 1;
-                health = health + entity.health;
-                energy = energy + entity.energy;
-                inventory = inventory + entity.inventory;
+                agents += 1;
+                health += entity.health;
+                energy += entity.energy;
+                inventory += entity.inventory;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = agents * (MODE() % 11 + 1) + health * 3 +
             energy * 5 + inventory * 7 + faction;
         metric.observe(inout out, projection, faction + MODE() % 5 + 1);
-        faction = faction + 1;
+        faction += 1;
     }
 }
 
@@ -150,17 +150,17 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
-                tiles = tiles + 1;
+                tiles += 1;
                 if tile.walkable { walkable = walkable + 1; }
-                resources = resources + tile.resource;
-                elevation = elevation + tile.height;
+                resources += tile.resource;
+                elevation += tile.height;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = tiles * (MODE() % 13 + 1) + walkable * 3 +
             resources * 5 + elevation * 7 + region;
         metric.observe(inout out, projection, region % 7 + 1);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/audit_faction_integrity.rue
+++ b/examples/caldera/audit_faction_integrity.rue
@@ -151,7 +151,7 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
                 tiles += 1;
-                if tile.walkable { walkable = walkable + 1; }
+                if tile.walkable { walkable += 1; }
                 resources += tile.resource;
                 elevation += tile.height;
             }

--- a/examples/caldera/audit_faction_integrity.rue
+++ b/examples/caldera/audit_faction_integrity.rue
@@ -63,7 +63,7 @@ fn observe_entities(inout out: metric.Metric, borrow world: model.World) {
         metric.observe(inout out, entity_projection(borrow world, i), (i % 11) + 1);
         metric.warn(inout out, item.alive && (item.x < 0 || item.y < 0 ||
             @intCast(item.x) >= world.width || @intCast(item.y) >= world.height));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -73,7 +73,7 @@ fn observe_tiles(inout out: metric.Metric, borrow world: model.World) {
         let item = world.tiles.get_or(i, model.empty_tile());
         metric.observe(inout out, tile_projection(borrow world, i), (i % 13) + 1);
         metric.warn(inout out, item.x >= world.width || item.y >= world.height);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -82,18 +82,18 @@ fn observe_timeline(inout out: metric.Metric, borrow world: model.World) {
     while i < world.events.len() {
         metric.observe(inout out, event_projection(borrow world, i), (i % 5) + 1);
         metric.warn(inout out, world.events.get_or(i, model.empty_event()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
         metric.observe(inout out, command_projection(borrow world, i), (i % 7) + 1);
         metric.warn(inout out, world.commands.get_or(i, model.empty_command()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.snapshots.len() {
         metric.observe(inout out, snapshot_projection(borrow world, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -108,9 +108,9 @@ fn observe_pairs(inout out: metric.Metric, borrow world: model.World) {
             let dy = if left.y > right.y { left.y - right.y } else { right.y - left.y };
             metric.observe(inout out, @intCast(dx + dy) +
                 left.faction * 3 + right.faction * 5 + MODE(), i + j + 1);
-            j = j + 1;
+            j += 1;
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -125,17 +125,17 @@ fn observe_factions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.entities.len() {
             let entity = world.entities.get_or(i, model.empty_entity());
             if entity.faction == faction && entity.alive {
-                agents = agents + 1;
-                health = health + entity.health;
-                energy = energy + entity.energy;
-                inventory = inventory + entity.inventory;
+                agents += 1;
+                health += entity.health;
+                energy += entity.energy;
+                inventory += entity.inventory;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = agents * (MODE() % 11 + 1) + health * 3 +
             energy * 5 + inventory * 7 + faction;
         metric.observe(inout out, projection, faction + MODE() % 5 + 1);
-        faction = faction + 1;
+        faction += 1;
     }
 }
 
@@ -150,17 +150,17 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
-                tiles = tiles + 1;
+                tiles += 1;
                 if tile.walkable { walkable = walkable + 1; }
-                resources = resources + tile.resource;
-                elevation = elevation + tile.height;
+                resources += tile.resource;
+                elevation += tile.height;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = tiles * (MODE() % 13 + 1) + walkable * 3 +
             resources * 5 + elevation * 7 + region;
         metric.observe(inout out, projection, region % 7 + 1);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/audit_faction_latency.rue
+++ b/examples/caldera/audit_faction_latency.rue
@@ -151,7 +151,7 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
                 tiles += 1;
-                if tile.walkable { walkable = walkable + 1; }
+                if tile.walkable { walkable += 1; }
                 resources += tile.resource;
                 elevation += tile.height;
             }

--- a/examples/caldera/audit_faction_latency.rue
+++ b/examples/caldera/audit_faction_latency.rue
@@ -63,7 +63,7 @@ fn observe_entities(inout out: metric.Metric, borrow world: model.World) {
         metric.observe(inout out, entity_projection(borrow world, i), (i % 11) + 1);
         metric.warn(inout out, item.alive && (item.x < 0 || item.y < 0 ||
             @intCast(item.x) >= world.width || @intCast(item.y) >= world.height));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -73,7 +73,7 @@ fn observe_tiles(inout out: metric.Metric, borrow world: model.World) {
         let item = world.tiles.get_or(i, model.empty_tile());
         metric.observe(inout out, tile_projection(borrow world, i), (i % 13) + 1);
         metric.warn(inout out, item.x >= world.width || item.y >= world.height);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -82,18 +82,18 @@ fn observe_timeline(inout out: metric.Metric, borrow world: model.World) {
     while i < world.events.len() {
         metric.observe(inout out, event_projection(borrow world, i), (i % 5) + 1);
         metric.warn(inout out, world.events.get_or(i, model.empty_event()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
         metric.observe(inout out, command_projection(borrow world, i), (i % 7) + 1);
         metric.warn(inout out, world.commands.get_or(i, model.empty_command()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.snapshots.len() {
         metric.observe(inout out, snapshot_projection(borrow world, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -108,9 +108,9 @@ fn observe_pairs(inout out: metric.Metric, borrow world: model.World) {
             let dy = if left.y > right.y { left.y - right.y } else { right.y - left.y };
             metric.observe(inout out, @intCast(dx + dy) +
                 left.faction * 3 + right.faction * 5 + MODE(), i + j + 1);
-            j = j + 1;
+            j += 1;
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -125,17 +125,17 @@ fn observe_factions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.entities.len() {
             let entity = world.entities.get_or(i, model.empty_entity());
             if entity.faction == faction && entity.alive {
-                agents = agents + 1;
-                health = health + entity.health;
-                energy = energy + entity.energy;
-                inventory = inventory + entity.inventory;
+                agents += 1;
+                health += entity.health;
+                energy += entity.energy;
+                inventory += entity.inventory;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = agents * (MODE() % 11 + 1) + health * 3 +
             energy * 5 + inventory * 7 + faction;
         metric.observe(inout out, projection, faction + MODE() % 5 + 1);
-        faction = faction + 1;
+        faction += 1;
     }
 }
 
@@ -150,17 +150,17 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
-                tiles = tiles + 1;
+                tiles += 1;
                 if tile.walkable { walkable = walkable + 1; }
-                resources = resources + tile.resource;
-                elevation = elevation + tile.height;
+                resources += tile.resource;
+                elevation += tile.height;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = tiles * (MODE() % 13 + 1) + walkable * 3 +
             resources * 5 + elevation * 7 + region;
         metric.observe(inout out, projection, region % 7 + 1);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/audit_faction_locality.rue
+++ b/examples/caldera/audit_faction_locality.rue
@@ -151,7 +151,7 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
                 tiles += 1;
-                if tile.walkable { walkable = walkable + 1; }
+                if tile.walkable { walkable += 1; }
                 resources += tile.resource;
                 elevation += tile.height;
             }

--- a/examples/caldera/audit_faction_locality.rue
+++ b/examples/caldera/audit_faction_locality.rue
@@ -63,7 +63,7 @@ fn observe_entities(inout out: metric.Metric, borrow world: model.World) {
         metric.observe(inout out, entity_projection(borrow world, i), (i % 11) + 1);
         metric.warn(inout out, item.alive && (item.x < 0 || item.y < 0 ||
             @intCast(item.x) >= world.width || @intCast(item.y) >= world.height));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -73,7 +73,7 @@ fn observe_tiles(inout out: metric.Metric, borrow world: model.World) {
         let item = world.tiles.get_or(i, model.empty_tile());
         metric.observe(inout out, tile_projection(borrow world, i), (i % 13) + 1);
         metric.warn(inout out, item.x >= world.width || item.y >= world.height);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -82,18 +82,18 @@ fn observe_timeline(inout out: metric.Metric, borrow world: model.World) {
     while i < world.events.len() {
         metric.observe(inout out, event_projection(borrow world, i), (i % 5) + 1);
         metric.warn(inout out, world.events.get_or(i, model.empty_event()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
         metric.observe(inout out, command_projection(borrow world, i), (i % 7) + 1);
         metric.warn(inout out, world.commands.get_or(i, model.empty_command()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.snapshots.len() {
         metric.observe(inout out, snapshot_projection(borrow world, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -108,9 +108,9 @@ fn observe_pairs(inout out: metric.Metric, borrow world: model.World) {
             let dy = if left.y > right.y { left.y - right.y } else { right.y - left.y };
             metric.observe(inout out, @intCast(dx + dy) +
                 left.faction * 3 + right.faction * 5 + MODE(), i + j + 1);
-            j = j + 1;
+            j += 1;
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -125,17 +125,17 @@ fn observe_factions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.entities.len() {
             let entity = world.entities.get_or(i, model.empty_entity());
             if entity.faction == faction && entity.alive {
-                agents = agents + 1;
-                health = health + entity.health;
-                energy = energy + entity.energy;
-                inventory = inventory + entity.inventory;
+                agents += 1;
+                health += entity.health;
+                energy += entity.energy;
+                inventory += entity.inventory;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = agents * (MODE() % 11 + 1) + health * 3 +
             energy * 5 + inventory * 7 + faction;
         metric.observe(inout out, projection, faction + MODE() % 5 + 1);
-        faction = faction + 1;
+        faction += 1;
     }
 }
 
@@ -150,17 +150,17 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
-                tiles = tiles + 1;
+                tiles += 1;
                 if tile.walkable { walkable = walkable + 1; }
-                resources = resources + tile.resource;
-                elevation = elevation + tile.height;
+                resources += tile.resource;
+                elevation += tile.height;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = tiles * (MODE() % 13 + 1) + walkable * 3 +
             resources * 5 + elevation * 7 + region;
         metric.observe(inout out, projection, region % 7 + 1);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/audit_faction_pressure.rue
+++ b/examples/caldera/audit_faction_pressure.rue
@@ -151,7 +151,7 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
                 tiles += 1;
-                if tile.walkable { walkable = walkable + 1; }
+                if tile.walkable { walkable += 1; }
                 resources += tile.resource;
                 elevation += tile.height;
             }

--- a/examples/caldera/audit_faction_pressure.rue
+++ b/examples/caldera/audit_faction_pressure.rue
@@ -63,7 +63,7 @@ fn observe_entities(inout out: metric.Metric, borrow world: model.World) {
         metric.observe(inout out, entity_projection(borrow world, i), (i % 11) + 1);
         metric.warn(inout out, item.alive && (item.x < 0 || item.y < 0 ||
             @intCast(item.x) >= world.width || @intCast(item.y) >= world.height));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -73,7 +73,7 @@ fn observe_tiles(inout out: metric.Metric, borrow world: model.World) {
         let item = world.tiles.get_or(i, model.empty_tile());
         metric.observe(inout out, tile_projection(borrow world, i), (i % 13) + 1);
         metric.warn(inout out, item.x >= world.width || item.y >= world.height);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -82,18 +82,18 @@ fn observe_timeline(inout out: metric.Metric, borrow world: model.World) {
     while i < world.events.len() {
         metric.observe(inout out, event_projection(borrow world, i), (i % 5) + 1);
         metric.warn(inout out, world.events.get_or(i, model.empty_event()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
         metric.observe(inout out, command_projection(borrow world, i), (i % 7) + 1);
         metric.warn(inout out, world.commands.get_or(i, model.empty_command()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.snapshots.len() {
         metric.observe(inout out, snapshot_projection(borrow world, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -108,9 +108,9 @@ fn observe_pairs(inout out: metric.Metric, borrow world: model.World) {
             let dy = if left.y > right.y { left.y - right.y } else { right.y - left.y };
             metric.observe(inout out, @intCast(dx + dy) +
                 left.faction * 3 + right.faction * 5 + MODE(), i + j + 1);
-            j = j + 1;
+            j += 1;
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -125,17 +125,17 @@ fn observe_factions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.entities.len() {
             let entity = world.entities.get_or(i, model.empty_entity());
             if entity.faction == faction && entity.alive {
-                agents = agents + 1;
-                health = health + entity.health;
-                energy = energy + entity.energy;
-                inventory = inventory + entity.inventory;
+                agents += 1;
+                health += entity.health;
+                energy += entity.energy;
+                inventory += entity.inventory;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = agents * (MODE() % 11 + 1) + health * 3 +
             energy * 5 + inventory * 7 + faction;
         metric.observe(inout out, projection, faction + MODE() % 5 + 1);
-        faction = faction + 1;
+        faction += 1;
     }
 }
 
@@ -150,17 +150,17 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
-                tiles = tiles + 1;
+                tiles += 1;
                 if tile.walkable { walkable = walkable + 1; }
-                resources = resources + tile.resource;
-                elevation = elevation + tile.height;
+                resources += tile.resource;
+                elevation += tile.height;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = tiles * (MODE() % 13 + 1) + walkable * 3 +
             resources * 5 + elevation * 7 + region;
         metric.observe(inout out, projection, region % 7 + 1);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/audit_faction_risk.rue
+++ b/examples/caldera/audit_faction_risk.rue
@@ -151,7 +151,7 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
                 tiles += 1;
-                if tile.walkable { walkable = walkable + 1; }
+                if tile.walkable { walkable += 1; }
                 resources += tile.resource;
                 elevation += tile.height;
             }

--- a/examples/caldera/audit_faction_risk.rue
+++ b/examples/caldera/audit_faction_risk.rue
@@ -63,7 +63,7 @@ fn observe_entities(inout out: metric.Metric, borrow world: model.World) {
         metric.observe(inout out, entity_projection(borrow world, i), (i % 11) + 1);
         metric.warn(inout out, item.alive && (item.x < 0 || item.y < 0 ||
             @intCast(item.x) >= world.width || @intCast(item.y) >= world.height));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -73,7 +73,7 @@ fn observe_tiles(inout out: metric.Metric, borrow world: model.World) {
         let item = world.tiles.get_or(i, model.empty_tile());
         metric.observe(inout out, tile_projection(borrow world, i), (i % 13) + 1);
         metric.warn(inout out, item.x >= world.width || item.y >= world.height);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -82,18 +82,18 @@ fn observe_timeline(inout out: metric.Metric, borrow world: model.World) {
     while i < world.events.len() {
         metric.observe(inout out, event_projection(borrow world, i), (i % 5) + 1);
         metric.warn(inout out, world.events.get_or(i, model.empty_event()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
         metric.observe(inout out, command_projection(borrow world, i), (i % 7) + 1);
         metric.warn(inout out, world.commands.get_or(i, model.empty_command()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.snapshots.len() {
         metric.observe(inout out, snapshot_projection(borrow world, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -108,9 +108,9 @@ fn observe_pairs(inout out: metric.Metric, borrow world: model.World) {
             let dy = if left.y > right.y { left.y - right.y } else { right.y - left.y };
             metric.observe(inout out, @intCast(dx + dy) +
                 left.faction * 3 + right.faction * 5 + MODE(), i + j + 1);
-            j = j + 1;
+            j += 1;
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -125,17 +125,17 @@ fn observe_factions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.entities.len() {
             let entity = world.entities.get_or(i, model.empty_entity());
             if entity.faction == faction && entity.alive {
-                agents = agents + 1;
-                health = health + entity.health;
-                energy = energy + entity.energy;
-                inventory = inventory + entity.inventory;
+                agents += 1;
+                health += entity.health;
+                energy += entity.energy;
+                inventory += entity.inventory;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = agents * (MODE() % 11 + 1) + health * 3 +
             energy * 5 + inventory * 7 + faction;
         metric.observe(inout out, projection, faction + MODE() % 5 + 1);
-        faction = faction + 1;
+        faction += 1;
     }
 }
 
@@ -150,17 +150,17 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
-                tiles = tiles + 1;
+                tiles += 1;
                 if tile.walkable { walkable = walkable + 1; }
-                resources = resources + tile.resource;
-                elevation = elevation + tile.height;
+                resources += tile.resource;
+                elevation += tile.height;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = tiles * (MODE() % 13 + 1) + walkable * 3 +
             resources * 5 + elevation * 7 + region;
         metric.observe(inout out, projection, region % 7 + 1);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/audit_faction_skew.rue
+++ b/examples/caldera/audit_faction_skew.rue
@@ -151,7 +151,7 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
                 tiles += 1;
-                if tile.walkable { walkable = walkable + 1; }
+                if tile.walkable { walkable += 1; }
                 resources += tile.resource;
                 elevation += tile.height;
             }

--- a/examples/caldera/audit_faction_skew.rue
+++ b/examples/caldera/audit_faction_skew.rue
@@ -63,7 +63,7 @@ fn observe_entities(inout out: metric.Metric, borrow world: model.World) {
         metric.observe(inout out, entity_projection(borrow world, i), (i % 11) + 1);
         metric.warn(inout out, item.alive && (item.x < 0 || item.y < 0 ||
             @intCast(item.x) >= world.width || @intCast(item.y) >= world.height));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -73,7 +73,7 @@ fn observe_tiles(inout out: metric.Metric, borrow world: model.World) {
         let item = world.tiles.get_or(i, model.empty_tile());
         metric.observe(inout out, tile_projection(borrow world, i), (i % 13) + 1);
         metric.warn(inout out, item.x >= world.width || item.y >= world.height);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -82,18 +82,18 @@ fn observe_timeline(inout out: metric.Metric, borrow world: model.World) {
     while i < world.events.len() {
         metric.observe(inout out, event_projection(borrow world, i), (i % 5) + 1);
         metric.warn(inout out, world.events.get_or(i, model.empty_event()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
         metric.observe(inout out, command_projection(borrow world, i), (i % 7) + 1);
         metric.warn(inout out, world.commands.get_or(i, model.empty_command()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.snapshots.len() {
         metric.observe(inout out, snapshot_projection(borrow world, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -108,9 +108,9 @@ fn observe_pairs(inout out: metric.Metric, borrow world: model.World) {
             let dy = if left.y > right.y { left.y - right.y } else { right.y - left.y };
             metric.observe(inout out, @intCast(dx + dy) +
                 left.faction * 3 + right.faction * 5 + MODE(), i + j + 1);
-            j = j + 1;
+            j += 1;
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -125,17 +125,17 @@ fn observe_factions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.entities.len() {
             let entity = world.entities.get_or(i, model.empty_entity());
             if entity.faction == faction && entity.alive {
-                agents = agents + 1;
-                health = health + entity.health;
-                energy = energy + entity.energy;
-                inventory = inventory + entity.inventory;
+                agents += 1;
+                health += entity.health;
+                energy += entity.energy;
+                inventory += entity.inventory;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = agents * (MODE() % 11 + 1) + health * 3 +
             energy * 5 + inventory * 7 + faction;
         metric.observe(inout out, projection, faction + MODE() % 5 + 1);
-        faction = faction + 1;
+        faction += 1;
     }
 }
 
@@ -150,17 +150,17 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
-                tiles = tiles + 1;
+                tiles += 1;
                 if tile.walkable { walkable = walkable + 1; }
-                resources = resources + tile.resource;
-                elevation = elevation + tile.height;
+                resources += tile.resource;
+                elevation += tile.height;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = tiles * (MODE() % 13 + 1) + walkable * 3 +
             resources * 5 + elevation * 7 + region;
         metric.observe(inout out, projection, region % 7 + 1);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/audit_faction_stability.rue
+++ b/examples/caldera/audit_faction_stability.rue
@@ -151,7 +151,7 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
                 tiles += 1;
-                if tile.walkable { walkable = walkable + 1; }
+                if tile.walkable { walkable += 1; }
                 resources += tile.resource;
                 elevation += tile.height;
             }

--- a/examples/caldera/audit_faction_stability.rue
+++ b/examples/caldera/audit_faction_stability.rue
@@ -63,7 +63,7 @@ fn observe_entities(inout out: metric.Metric, borrow world: model.World) {
         metric.observe(inout out, entity_projection(borrow world, i), (i % 11) + 1);
         metric.warn(inout out, item.alive && (item.x < 0 || item.y < 0 ||
             @intCast(item.x) >= world.width || @intCast(item.y) >= world.height));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -73,7 +73,7 @@ fn observe_tiles(inout out: metric.Metric, borrow world: model.World) {
         let item = world.tiles.get_or(i, model.empty_tile());
         metric.observe(inout out, tile_projection(borrow world, i), (i % 13) + 1);
         metric.warn(inout out, item.x >= world.width || item.y >= world.height);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -82,18 +82,18 @@ fn observe_timeline(inout out: metric.Metric, borrow world: model.World) {
     while i < world.events.len() {
         metric.observe(inout out, event_projection(borrow world, i), (i % 5) + 1);
         metric.warn(inout out, world.events.get_or(i, model.empty_event()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
         metric.observe(inout out, command_projection(borrow world, i), (i % 7) + 1);
         metric.warn(inout out, world.commands.get_or(i, model.empty_command()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.snapshots.len() {
         metric.observe(inout out, snapshot_projection(borrow world, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -108,9 +108,9 @@ fn observe_pairs(inout out: metric.Metric, borrow world: model.World) {
             let dy = if left.y > right.y { left.y - right.y } else { right.y - left.y };
             metric.observe(inout out, @intCast(dx + dy) +
                 left.faction * 3 + right.faction * 5 + MODE(), i + j + 1);
-            j = j + 1;
+            j += 1;
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -125,17 +125,17 @@ fn observe_factions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.entities.len() {
             let entity = world.entities.get_or(i, model.empty_entity());
             if entity.faction == faction && entity.alive {
-                agents = agents + 1;
-                health = health + entity.health;
-                energy = energy + entity.energy;
-                inventory = inventory + entity.inventory;
+                agents += 1;
+                health += entity.health;
+                energy += entity.energy;
+                inventory += entity.inventory;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = agents * (MODE() % 11 + 1) + health * 3 +
             energy * 5 + inventory * 7 + faction;
         metric.observe(inout out, projection, faction + MODE() % 5 + 1);
-        faction = faction + 1;
+        faction += 1;
     }
 }
 
@@ -150,17 +150,17 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
-                tiles = tiles + 1;
+                tiles += 1;
                 if tile.walkable { walkable = walkable + 1; }
-                resources = resources + tile.resource;
-                elevation = elevation + tile.height;
+                resources += tile.resource;
+                elevation += tile.height;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = tiles * (MODE() % 13 + 1) + walkable * 3 +
             resources * 5 + elevation * 7 + region;
         metric.observe(inout out, projection, region % 7 + 1);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/audit_faction_throughput.rue
+++ b/examples/caldera/audit_faction_throughput.rue
@@ -151,7 +151,7 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
                 tiles += 1;
-                if tile.walkable { walkable = walkable + 1; }
+                if tile.walkable { walkable += 1; }
                 resources += tile.resource;
                 elevation += tile.height;
             }

--- a/examples/caldera/audit_faction_throughput.rue
+++ b/examples/caldera/audit_faction_throughput.rue
@@ -63,7 +63,7 @@ fn observe_entities(inout out: metric.Metric, borrow world: model.World) {
         metric.observe(inout out, entity_projection(borrow world, i), (i % 11) + 1);
         metric.warn(inout out, item.alive && (item.x < 0 || item.y < 0 ||
             @intCast(item.x) >= world.width || @intCast(item.y) >= world.height));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -73,7 +73,7 @@ fn observe_tiles(inout out: metric.Metric, borrow world: model.World) {
         let item = world.tiles.get_or(i, model.empty_tile());
         metric.observe(inout out, tile_projection(borrow world, i), (i % 13) + 1);
         metric.warn(inout out, item.x >= world.width || item.y >= world.height);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -82,18 +82,18 @@ fn observe_timeline(inout out: metric.Metric, borrow world: model.World) {
     while i < world.events.len() {
         metric.observe(inout out, event_projection(borrow world, i), (i % 5) + 1);
         metric.warn(inout out, world.events.get_or(i, model.empty_event()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
         metric.observe(inout out, command_projection(borrow world, i), (i % 7) + 1);
         metric.warn(inout out, world.commands.get_or(i, model.empty_command()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.snapshots.len() {
         metric.observe(inout out, snapshot_projection(borrow world, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -108,9 +108,9 @@ fn observe_pairs(inout out: metric.Metric, borrow world: model.World) {
             let dy = if left.y > right.y { left.y - right.y } else { right.y - left.y };
             metric.observe(inout out, @intCast(dx + dy) +
                 left.faction * 3 + right.faction * 5 + MODE(), i + j + 1);
-            j = j + 1;
+            j += 1;
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -125,17 +125,17 @@ fn observe_factions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.entities.len() {
             let entity = world.entities.get_or(i, model.empty_entity());
             if entity.faction == faction && entity.alive {
-                agents = agents + 1;
-                health = health + entity.health;
-                energy = energy + entity.energy;
-                inventory = inventory + entity.inventory;
+                agents += 1;
+                health += entity.health;
+                energy += entity.energy;
+                inventory += entity.inventory;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = agents * (MODE() % 11 + 1) + health * 3 +
             energy * 5 + inventory * 7 + faction;
         metric.observe(inout out, projection, faction + MODE() % 5 + 1);
-        faction = faction + 1;
+        faction += 1;
     }
 }
 
@@ -150,17 +150,17 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
-                tiles = tiles + 1;
+                tiles += 1;
                 if tile.walkable { walkable = walkable + 1; }
-                resources = resources + tile.resource;
-                elevation = elevation + tile.height;
+                resources += tile.resource;
+                elevation += tile.height;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = tiles * (MODE() % 13 + 1) + walkable * 3 +
             resources * 5 + elevation * 7 + region;
         metric.observe(inout out, projection, region % 7 + 1);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/audit_inventory_balance.rue
+++ b/examples/caldera/audit_inventory_balance.rue
@@ -151,7 +151,7 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
                 tiles += 1;
-                if tile.walkable { walkable = walkable + 1; }
+                if tile.walkable { walkable += 1; }
                 resources += tile.resource;
                 elevation += tile.height;
             }

--- a/examples/caldera/audit_inventory_balance.rue
+++ b/examples/caldera/audit_inventory_balance.rue
@@ -63,7 +63,7 @@ fn observe_entities(inout out: metric.Metric, borrow world: model.World) {
         metric.observe(inout out, entity_projection(borrow world, i), (i % 11) + 1);
         metric.warn(inout out, item.alive && (item.x < 0 || item.y < 0 ||
             @intCast(item.x) >= world.width || @intCast(item.y) >= world.height));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -73,7 +73,7 @@ fn observe_tiles(inout out: metric.Metric, borrow world: model.World) {
         let item = world.tiles.get_or(i, model.empty_tile());
         metric.observe(inout out, tile_projection(borrow world, i), (i % 13) + 1);
         metric.warn(inout out, item.x >= world.width || item.y >= world.height);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -82,18 +82,18 @@ fn observe_timeline(inout out: metric.Metric, borrow world: model.World) {
     while i < world.events.len() {
         metric.observe(inout out, event_projection(borrow world, i), (i % 5) + 1);
         metric.warn(inout out, world.events.get_or(i, model.empty_event()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
         metric.observe(inout out, command_projection(borrow world, i), (i % 7) + 1);
         metric.warn(inout out, world.commands.get_or(i, model.empty_command()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.snapshots.len() {
         metric.observe(inout out, snapshot_projection(borrow world, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -108,9 +108,9 @@ fn observe_pairs(inout out: metric.Metric, borrow world: model.World) {
             let dy = if left.y > right.y { left.y - right.y } else { right.y - left.y };
             metric.observe(inout out, @intCast(dx + dy) +
                 left.faction * 3 + right.faction * 5 + MODE(), i + j + 1);
-            j = j + 1;
+            j += 1;
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -125,17 +125,17 @@ fn observe_factions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.entities.len() {
             let entity = world.entities.get_or(i, model.empty_entity());
             if entity.faction == faction && entity.alive {
-                agents = agents + 1;
-                health = health + entity.health;
-                energy = energy + entity.energy;
-                inventory = inventory + entity.inventory;
+                agents += 1;
+                health += entity.health;
+                energy += entity.energy;
+                inventory += entity.inventory;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = agents * (MODE() % 11 + 1) + health * 3 +
             energy * 5 + inventory * 7 + faction;
         metric.observe(inout out, projection, faction + MODE() % 5 + 1);
-        faction = faction + 1;
+        faction += 1;
     }
 }
 
@@ -150,17 +150,17 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
-                tiles = tiles + 1;
+                tiles += 1;
                 if tile.walkable { walkable = walkable + 1; }
-                resources = resources + tile.resource;
-                elevation = elevation + tile.height;
+                resources += tile.resource;
+                elevation += tile.height;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = tiles * (MODE() % 13 + 1) + walkable * 3 +
             resources * 5 + elevation * 7 + region;
         metric.observe(inout out, projection, region % 7 + 1);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/audit_inventory_capacity.rue
+++ b/examples/caldera/audit_inventory_capacity.rue
@@ -151,7 +151,7 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
                 tiles += 1;
-                if tile.walkable { walkable = walkable + 1; }
+                if tile.walkable { walkable += 1; }
                 resources += tile.resource;
                 elevation += tile.height;
             }

--- a/examples/caldera/audit_inventory_capacity.rue
+++ b/examples/caldera/audit_inventory_capacity.rue
@@ -63,7 +63,7 @@ fn observe_entities(inout out: metric.Metric, borrow world: model.World) {
         metric.observe(inout out, entity_projection(borrow world, i), (i % 11) + 1);
         metric.warn(inout out, item.alive && (item.x < 0 || item.y < 0 ||
             @intCast(item.x) >= world.width || @intCast(item.y) >= world.height));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -73,7 +73,7 @@ fn observe_tiles(inout out: metric.Metric, borrow world: model.World) {
         let item = world.tiles.get_or(i, model.empty_tile());
         metric.observe(inout out, tile_projection(borrow world, i), (i % 13) + 1);
         metric.warn(inout out, item.x >= world.width || item.y >= world.height);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -82,18 +82,18 @@ fn observe_timeline(inout out: metric.Metric, borrow world: model.World) {
     while i < world.events.len() {
         metric.observe(inout out, event_projection(borrow world, i), (i % 5) + 1);
         metric.warn(inout out, world.events.get_or(i, model.empty_event()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
         metric.observe(inout out, command_projection(borrow world, i), (i % 7) + 1);
         metric.warn(inout out, world.commands.get_or(i, model.empty_command()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.snapshots.len() {
         metric.observe(inout out, snapshot_projection(borrow world, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -108,9 +108,9 @@ fn observe_pairs(inout out: metric.Metric, borrow world: model.World) {
             let dy = if left.y > right.y { left.y - right.y } else { right.y - left.y };
             metric.observe(inout out, @intCast(dx + dy) +
                 left.faction * 3 + right.faction * 5 + MODE(), i + j + 1);
-            j = j + 1;
+            j += 1;
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -125,17 +125,17 @@ fn observe_factions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.entities.len() {
             let entity = world.entities.get_or(i, model.empty_entity());
             if entity.faction == faction && entity.alive {
-                agents = agents + 1;
-                health = health + entity.health;
-                energy = energy + entity.energy;
-                inventory = inventory + entity.inventory;
+                agents += 1;
+                health += entity.health;
+                energy += entity.energy;
+                inventory += entity.inventory;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = agents * (MODE() % 11 + 1) + health * 3 +
             energy * 5 + inventory * 7 + faction;
         metric.observe(inout out, projection, faction + MODE() % 5 + 1);
-        faction = faction + 1;
+        faction += 1;
     }
 }
 
@@ -150,17 +150,17 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
-                tiles = tiles + 1;
+                tiles += 1;
                 if tile.walkable { walkable = walkable + 1; }
-                resources = resources + tile.resource;
-                elevation = elevation + tile.height;
+                resources += tile.resource;
+                elevation += tile.height;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = tiles * (MODE() % 13 + 1) + walkable * 3 +
             resources * 5 + elevation * 7 + region;
         metric.observe(inout out, projection, region % 7 + 1);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/audit_inventory_continuity.rue
+++ b/examples/caldera/audit_inventory_continuity.rue
@@ -151,7 +151,7 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
                 tiles += 1;
-                if tile.walkable { walkable = walkable + 1; }
+                if tile.walkable { walkable += 1; }
                 resources += tile.resource;
                 elevation += tile.height;
             }

--- a/examples/caldera/audit_inventory_continuity.rue
+++ b/examples/caldera/audit_inventory_continuity.rue
@@ -63,7 +63,7 @@ fn observe_entities(inout out: metric.Metric, borrow world: model.World) {
         metric.observe(inout out, entity_projection(borrow world, i), (i % 11) + 1);
         metric.warn(inout out, item.alive && (item.x < 0 || item.y < 0 ||
             @intCast(item.x) >= world.width || @intCast(item.y) >= world.height));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -73,7 +73,7 @@ fn observe_tiles(inout out: metric.Metric, borrow world: model.World) {
         let item = world.tiles.get_or(i, model.empty_tile());
         metric.observe(inout out, tile_projection(borrow world, i), (i % 13) + 1);
         metric.warn(inout out, item.x >= world.width || item.y >= world.height);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -82,18 +82,18 @@ fn observe_timeline(inout out: metric.Metric, borrow world: model.World) {
     while i < world.events.len() {
         metric.observe(inout out, event_projection(borrow world, i), (i % 5) + 1);
         metric.warn(inout out, world.events.get_or(i, model.empty_event()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
         metric.observe(inout out, command_projection(borrow world, i), (i % 7) + 1);
         metric.warn(inout out, world.commands.get_or(i, model.empty_command()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.snapshots.len() {
         metric.observe(inout out, snapshot_projection(borrow world, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -108,9 +108,9 @@ fn observe_pairs(inout out: metric.Metric, borrow world: model.World) {
             let dy = if left.y > right.y { left.y - right.y } else { right.y - left.y };
             metric.observe(inout out, @intCast(dx + dy) +
                 left.faction * 3 + right.faction * 5 + MODE(), i + j + 1);
-            j = j + 1;
+            j += 1;
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -125,17 +125,17 @@ fn observe_factions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.entities.len() {
             let entity = world.entities.get_or(i, model.empty_entity());
             if entity.faction == faction && entity.alive {
-                agents = agents + 1;
-                health = health + entity.health;
-                energy = energy + entity.energy;
-                inventory = inventory + entity.inventory;
+                agents += 1;
+                health += entity.health;
+                energy += entity.energy;
+                inventory += entity.inventory;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = agents * (MODE() % 11 + 1) + health * 3 +
             energy * 5 + inventory * 7 + faction;
         metric.observe(inout out, projection, faction + MODE() % 5 + 1);
-        faction = faction + 1;
+        faction += 1;
     }
 }
 
@@ -150,17 +150,17 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
-                tiles = tiles + 1;
+                tiles += 1;
                 if tile.walkable { walkable = walkable + 1; }
-                resources = resources + tile.resource;
-                elevation = elevation + tile.height;
+                resources += tile.resource;
+                elevation += tile.height;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = tiles * (MODE() % 13 + 1) + walkable * 3 +
             resources * 5 + elevation * 7 + region;
         metric.observe(inout out, projection, region % 7 + 1);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/audit_inventory_cost.rue
+++ b/examples/caldera/audit_inventory_cost.rue
@@ -151,7 +151,7 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
                 tiles += 1;
-                if tile.walkable { walkable = walkable + 1; }
+                if tile.walkable { walkable += 1; }
                 resources += tile.resource;
                 elevation += tile.height;
             }

--- a/examples/caldera/audit_inventory_cost.rue
+++ b/examples/caldera/audit_inventory_cost.rue
@@ -63,7 +63,7 @@ fn observe_entities(inout out: metric.Metric, borrow world: model.World) {
         metric.observe(inout out, entity_projection(borrow world, i), (i % 11) + 1);
         metric.warn(inout out, item.alive && (item.x < 0 || item.y < 0 ||
             @intCast(item.x) >= world.width || @intCast(item.y) >= world.height));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -73,7 +73,7 @@ fn observe_tiles(inout out: metric.Metric, borrow world: model.World) {
         let item = world.tiles.get_or(i, model.empty_tile());
         metric.observe(inout out, tile_projection(borrow world, i), (i % 13) + 1);
         metric.warn(inout out, item.x >= world.width || item.y >= world.height);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -82,18 +82,18 @@ fn observe_timeline(inout out: metric.Metric, borrow world: model.World) {
     while i < world.events.len() {
         metric.observe(inout out, event_projection(borrow world, i), (i % 5) + 1);
         metric.warn(inout out, world.events.get_or(i, model.empty_event()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
         metric.observe(inout out, command_projection(borrow world, i), (i % 7) + 1);
         metric.warn(inout out, world.commands.get_or(i, model.empty_command()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.snapshots.len() {
         metric.observe(inout out, snapshot_projection(borrow world, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -108,9 +108,9 @@ fn observe_pairs(inout out: metric.Metric, borrow world: model.World) {
             let dy = if left.y > right.y { left.y - right.y } else { right.y - left.y };
             metric.observe(inout out, @intCast(dx + dy) +
                 left.faction * 3 + right.faction * 5 + MODE(), i + j + 1);
-            j = j + 1;
+            j += 1;
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -125,17 +125,17 @@ fn observe_factions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.entities.len() {
             let entity = world.entities.get_or(i, model.empty_entity());
             if entity.faction == faction && entity.alive {
-                agents = agents + 1;
-                health = health + entity.health;
-                energy = energy + entity.energy;
-                inventory = inventory + entity.inventory;
+                agents += 1;
+                health += entity.health;
+                energy += entity.energy;
+                inventory += entity.inventory;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = agents * (MODE() % 11 + 1) + health * 3 +
             energy * 5 + inventory * 7 + faction;
         metric.observe(inout out, projection, faction + MODE() % 5 + 1);
-        faction = faction + 1;
+        faction += 1;
     }
 }
 
@@ -150,17 +150,17 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
-                tiles = tiles + 1;
+                tiles += 1;
                 if tile.walkable { walkable = walkable + 1; }
-                resources = resources + tile.resource;
-                elevation = elevation + tile.height;
+                resources += tile.resource;
+                elevation += tile.height;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = tiles * (MODE() % 13 + 1) + walkable * 3 +
             resources * 5 + elevation * 7 + region;
         metric.observe(inout out, projection, region % 7 + 1);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/audit_inventory_coverage.rue
+++ b/examples/caldera/audit_inventory_coverage.rue
@@ -151,7 +151,7 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
                 tiles += 1;
-                if tile.walkable { walkable = walkable + 1; }
+                if tile.walkable { walkable += 1; }
                 resources += tile.resource;
                 elevation += tile.height;
             }

--- a/examples/caldera/audit_inventory_coverage.rue
+++ b/examples/caldera/audit_inventory_coverage.rue
@@ -63,7 +63,7 @@ fn observe_entities(inout out: metric.Metric, borrow world: model.World) {
         metric.observe(inout out, entity_projection(borrow world, i), (i % 11) + 1);
         metric.warn(inout out, item.alive && (item.x < 0 || item.y < 0 ||
             @intCast(item.x) >= world.width || @intCast(item.y) >= world.height));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -73,7 +73,7 @@ fn observe_tiles(inout out: metric.Metric, borrow world: model.World) {
         let item = world.tiles.get_or(i, model.empty_tile());
         metric.observe(inout out, tile_projection(borrow world, i), (i % 13) + 1);
         metric.warn(inout out, item.x >= world.width || item.y >= world.height);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -82,18 +82,18 @@ fn observe_timeline(inout out: metric.Metric, borrow world: model.World) {
     while i < world.events.len() {
         metric.observe(inout out, event_projection(borrow world, i), (i % 5) + 1);
         metric.warn(inout out, world.events.get_or(i, model.empty_event()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
         metric.observe(inout out, command_projection(borrow world, i), (i % 7) + 1);
         metric.warn(inout out, world.commands.get_or(i, model.empty_command()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.snapshots.len() {
         metric.observe(inout out, snapshot_projection(borrow world, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -108,9 +108,9 @@ fn observe_pairs(inout out: metric.Metric, borrow world: model.World) {
             let dy = if left.y > right.y { left.y - right.y } else { right.y - left.y };
             metric.observe(inout out, @intCast(dx + dy) +
                 left.faction * 3 + right.faction * 5 + MODE(), i + j + 1);
-            j = j + 1;
+            j += 1;
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -125,17 +125,17 @@ fn observe_factions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.entities.len() {
             let entity = world.entities.get_or(i, model.empty_entity());
             if entity.faction == faction && entity.alive {
-                agents = agents + 1;
-                health = health + entity.health;
-                energy = energy + entity.energy;
-                inventory = inventory + entity.inventory;
+                agents += 1;
+                health += entity.health;
+                energy += entity.energy;
+                inventory += entity.inventory;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = agents * (MODE() % 11 + 1) + health * 3 +
             energy * 5 + inventory * 7 + faction;
         metric.observe(inout out, projection, faction + MODE() % 5 + 1);
-        faction = faction + 1;
+        faction += 1;
     }
 }
 
@@ -150,17 +150,17 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
-                tiles = tiles + 1;
+                tiles += 1;
                 if tile.walkable { walkable = walkable + 1; }
-                resources = resources + tile.resource;
-                elevation = elevation + tile.height;
+                resources += tile.resource;
+                elevation += tile.height;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = tiles * (MODE() % 13 + 1) + walkable * 3 +
             resources * 5 + elevation * 7 + region;
         metric.observe(inout out, projection, region % 7 + 1);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/audit_inventory_density.rue
+++ b/examples/caldera/audit_inventory_density.rue
@@ -151,7 +151,7 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
                 tiles += 1;
-                if tile.walkable { walkable = walkable + 1; }
+                if tile.walkable { walkable += 1; }
                 resources += tile.resource;
                 elevation += tile.height;
             }

--- a/examples/caldera/audit_inventory_density.rue
+++ b/examples/caldera/audit_inventory_density.rue
@@ -63,7 +63,7 @@ fn observe_entities(inout out: metric.Metric, borrow world: model.World) {
         metric.observe(inout out, entity_projection(borrow world, i), (i % 11) + 1);
         metric.warn(inout out, item.alive && (item.x < 0 || item.y < 0 ||
             @intCast(item.x) >= world.width || @intCast(item.y) >= world.height));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -73,7 +73,7 @@ fn observe_tiles(inout out: metric.Metric, borrow world: model.World) {
         let item = world.tiles.get_or(i, model.empty_tile());
         metric.observe(inout out, tile_projection(borrow world, i), (i % 13) + 1);
         metric.warn(inout out, item.x >= world.width || item.y >= world.height);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -82,18 +82,18 @@ fn observe_timeline(inout out: metric.Metric, borrow world: model.World) {
     while i < world.events.len() {
         metric.observe(inout out, event_projection(borrow world, i), (i % 5) + 1);
         metric.warn(inout out, world.events.get_or(i, model.empty_event()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
         metric.observe(inout out, command_projection(borrow world, i), (i % 7) + 1);
         metric.warn(inout out, world.commands.get_or(i, model.empty_command()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.snapshots.len() {
         metric.observe(inout out, snapshot_projection(borrow world, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -108,9 +108,9 @@ fn observe_pairs(inout out: metric.Metric, borrow world: model.World) {
             let dy = if left.y > right.y { left.y - right.y } else { right.y - left.y };
             metric.observe(inout out, @intCast(dx + dy) +
                 left.faction * 3 + right.faction * 5 + MODE(), i + j + 1);
-            j = j + 1;
+            j += 1;
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -125,17 +125,17 @@ fn observe_factions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.entities.len() {
             let entity = world.entities.get_or(i, model.empty_entity());
             if entity.faction == faction && entity.alive {
-                agents = agents + 1;
-                health = health + entity.health;
-                energy = energy + entity.energy;
-                inventory = inventory + entity.inventory;
+                agents += 1;
+                health += entity.health;
+                energy += entity.energy;
+                inventory += entity.inventory;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = agents * (MODE() % 11 + 1) + health * 3 +
             energy * 5 + inventory * 7 + faction;
         metric.observe(inout out, projection, faction + MODE() % 5 + 1);
-        faction = faction + 1;
+        faction += 1;
     }
 }
 
@@ -150,17 +150,17 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
-                tiles = tiles + 1;
+                tiles += 1;
                 if tile.walkable { walkable = walkable + 1; }
-                resources = resources + tile.resource;
-                elevation = elevation + tile.height;
+                resources += tile.resource;
+                elevation += tile.height;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = tiles * (MODE() % 13 + 1) + walkable * 3 +
             resources * 5 + elevation * 7 + region;
         metric.observe(inout out, projection, region % 7 + 1);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/audit_inventory_entropy.rue
+++ b/examples/caldera/audit_inventory_entropy.rue
@@ -151,7 +151,7 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
                 tiles += 1;
-                if tile.walkable { walkable = walkable + 1; }
+                if tile.walkable { walkable += 1; }
                 resources += tile.resource;
                 elevation += tile.height;
             }

--- a/examples/caldera/audit_inventory_entropy.rue
+++ b/examples/caldera/audit_inventory_entropy.rue
@@ -63,7 +63,7 @@ fn observe_entities(inout out: metric.Metric, borrow world: model.World) {
         metric.observe(inout out, entity_projection(borrow world, i), (i % 11) + 1);
         metric.warn(inout out, item.alive && (item.x < 0 || item.y < 0 ||
             @intCast(item.x) >= world.width || @intCast(item.y) >= world.height));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -73,7 +73,7 @@ fn observe_tiles(inout out: metric.Metric, borrow world: model.World) {
         let item = world.tiles.get_or(i, model.empty_tile());
         metric.observe(inout out, tile_projection(borrow world, i), (i % 13) + 1);
         metric.warn(inout out, item.x >= world.width || item.y >= world.height);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -82,18 +82,18 @@ fn observe_timeline(inout out: metric.Metric, borrow world: model.World) {
     while i < world.events.len() {
         metric.observe(inout out, event_projection(borrow world, i), (i % 5) + 1);
         metric.warn(inout out, world.events.get_or(i, model.empty_event()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
         metric.observe(inout out, command_projection(borrow world, i), (i % 7) + 1);
         metric.warn(inout out, world.commands.get_or(i, model.empty_command()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.snapshots.len() {
         metric.observe(inout out, snapshot_projection(borrow world, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -108,9 +108,9 @@ fn observe_pairs(inout out: metric.Metric, borrow world: model.World) {
             let dy = if left.y > right.y { left.y - right.y } else { right.y - left.y };
             metric.observe(inout out, @intCast(dx + dy) +
                 left.faction * 3 + right.faction * 5 + MODE(), i + j + 1);
-            j = j + 1;
+            j += 1;
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -125,17 +125,17 @@ fn observe_factions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.entities.len() {
             let entity = world.entities.get_or(i, model.empty_entity());
             if entity.faction == faction && entity.alive {
-                agents = agents + 1;
-                health = health + entity.health;
-                energy = energy + entity.energy;
-                inventory = inventory + entity.inventory;
+                agents += 1;
+                health += entity.health;
+                energy += entity.energy;
+                inventory += entity.inventory;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = agents * (MODE() % 11 + 1) + health * 3 +
             energy * 5 + inventory * 7 + faction;
         metric.observe(inout out, projection, faction + MODE() % 5 + 1);
-        faction = faction + 1;
+        faction += 1;
     }
 }
 
@@ -150,17 +150,17 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
-                tiles = tiles + 1;
+                tiles += 1;
                 if tile.walkable { walkable = walkable + 1; }
-                resources = resources + tile.resource;
-                elevation = elevation + tile.height;
+                resources += tile.resource;
+                elevation += tile.height;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = tiles * (MODE() % 13 + 1) + walkable * 3 +
             resources * 5 + elevation * 7 + region;
         metric.observe(inout out, projection, region % 7 + 1);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/audit_inventory_fanout.rue
+++ b/examples/caldera/audit_inventory_fanout.rue
@@ -151,7 +151,7 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
                 tiles += 1;
-                if tile.walkable { walkable = walkable + 1; }
+                if tile.walkable { walkable += 1; }
                 resources += tile.resource;
                 elevation += tile.height;
             }

--- a/examples/caldera/audit_inventory_fanout.rue
+++ b/examples/caldera/audit_inventory_fanout.rue
@@ -63,7 +63,7 @@ fn observe_entities(inout out: metric.Metric, borrow world: model.World) {
         metric.observe(inout out, entity_projection(borrow world, i), (i % 11) + 1);
         metric.warn(inout out, item.alive && (item.x < 0 || item.y < 0 ||
             @intCast(item.x) >= world.width || @intCast(item.y) >= world.height));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -73,7 +73,7 @@ fn observe_tiles(inout out: metric.Metric, borrow world: model.World) {
         let item = world.tiles.get_or(i, model.empty_tile());
         metric.observe(inout out, tile_projection(borrow world, i), (i % 13) + 1);
         metric.warn(inout out, item.x >= world.width || item.y >= world.height);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -82,18 +82,18 @@ fn observe_timeline(inout out: metric.Metric, borrow world: model.World) {
     while i < world.events.len() {
         metric.observe(inout out, event_projection(borrow world, i), (i % 5) + 1);
         metric.warn(inout out, world.events.get_or(i, model.empty_event()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
         metric.observe(inout out, command_projection(borrow world, i), (i % 7) + 1);
         metric.warn(inout out, world.commands.get_or(i, model.empty_command()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.snapshots.len() {
         metric.observe(inout out, snapshot_projection(borrow world, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -108,9 +108,9 @@ fn observe_pairs(inout out: metric.Metric, borrow world: model.World) {
             let dy = if left.y > right.y { left.y - right.y } else { right.y - left.y };
             metric.observe(inout out, @intCast(dx + dy) +
                 left.faction * 3 + right.faction * 5 + MODE(), i + j + 1);
-            j = j + 1;
+            j += 1;
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -125,17 +125,17 @@ fn observe_factions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.entities.len() {
             let entity = world.entities.get_or(i, model.empty_entity());
             if entity.faction == faction && entity.alive {
-                agents = agents + 1;
-                health = health + entity.health;
-                energy = energy + entity.energy;
-                inventory = inventory + entity.inventory;
+                agents += 1;
+                health += entity.health;
+                energy += entity.energy;
+                inventory += entity.inventory;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = agents * (MODE() % 11 + 1) + health * 3 +
             energy * 5 + inventory * 7 + faction;
         metric.observe(inout out, projection, faction + MODE() % 5 + 1);
-        faction = faction + 1;
+        faction += 1;
     }
 }
 
@@ -150,17 +150,17 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
-                tiles = tiles + 1;
+                tiles += 1;
                 if tile.walkable { walkable = walkable + 1; }
-                resources = resources + tile.resource;
-                elevation = elevation + tile.height;
+                resources += tile.resource;
+                elevation += tile.height;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = tiles * (MODE() % 13 + 1) + walkable * 3 +
             resources * 5 + elevation * 7 + region;
         metric.observe(inout out, projection, region % 7 + 1);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/audit_inventory_integrity.rue
+++ b/examples/caldera/audit_inventory_integrity.rue
@@ -151,7 +151,7 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
                 tiles += 1;
-                if tile.walkable { walkable = walkable + 1; }
+                if tile.walkable { walkable += 1; }
                 resources += tile.resource;
                 elevation += tile.height;
             }

--- a/examples/caldera/audit_inventory_integrity.rue
+++ b/examples/caldera/audit_inventory_integrity.rue
@@ -63,7 +63,7 @@ fn observe_entities(inout out: metric.Metric, borrow world: model.World) {
         metric.observe(inout out, entity_projection(borrow world, i), (i % 11) + 1);
         metric.warn(inout out, item.alive && (item.x < 0 || item.y < 0 ||
             @intCast(item.x) >= world.width || @intCast(item.y) >= world.height));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -73,7 +73,7 @@ fn observe_tiles(inout out: metric.Metric, borrow world: model.World) {
         let item = world.tiles.get_or(i, model.empty_tile());
         metric.observe(inout out, tile_projection(borrow world, i), (i % 13) + 1);
         metric.warn(inout out, item.x >= world.width || item.y >= world.height);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -82,18 +82,18 @@ fn observe_timeline(inout out: metric.Metric, borrow world: model.World) {
     while i < world.events.len() {
         metric.observe(inout out, event_projection(borrow world, i), (i % 5) + 1);
         metric.warn(inout out, world.events.get_or(i, model.empty_event()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
         metric.observe(inout out, command_projection(borrow world, i), (i % 7) + 1);
         metric.warn(inout out, world.commands.get_or(i, model.empty_command()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.snapshots.len() {
         metric.observe(inout out, snapshot_projection(borrow world, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -108,9 +108,9 @@ fn observe_pairs(inout out: metric.Metric, borrow world: model.World) {
             let dy = if left.y > right.y { left.y - right.y } else { right.y - left.y };
             metric.observe(inout out, @intCast(dx + dy) +
                 left.faction * 3 + right.faction * 5 + MODE(), i + j + 1);
-            j = j + 1;
+            j += 1;
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -125,17 +125,17 @@ fn observe_factions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.entities.len() {
             let entity = world.entities.get_or(i, model.empty_entity());
             if entity.faction == faction && entity.alive {
-                agents = agents + 1;
-                health = health + entity.health;
-                energy = energy + entity.energy;
-                inventory = inventory + entity.inventory;
+                agents += 1;
+                health += entity.health;
+                energy += entity.energy;
+                inventory += entity.inventory;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = agents * (MODE() % 11 + 1) + health * 3 +
             energy * 5 + inventory * 7 + faction;
         metric.observe(inout out, projection, faction + MODE() % 5 + 1);
-        faction = faction + 1;
+        faction += 1;
     }
 }
 
@@ -150,17 +150,17 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
-                tiles = tiles + 1;
+                tiles += 1;
                 if tile.walkable { walkable = walkable + 1; }
-                resources = resources + tile.resource;
-                elevation = elevation + tile.height;
+                resources += tile.resource;
+                elevation += tile.height;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = tiles * (MODE() % 13 + 1) + walkable * 3 +
             resources * 5 + elevation * 7 + region;
         metric.observe(inout out, projection, region % 7 + 1);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/audit_inventory_latency.rue
+++ b/examples/caldera/audit_inventory_latency.rue
@@ -151,7 +151,7 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
                 tiles += 1;
-                if tile.walkable { walkable = walkable + 1; }
+                if tile.walkable { walkable += 1; }
                 resources += tile.resource;
                 elevation += tile.height;
             }

--- a/examples/caldera/audit_inventory_latency.rue
+++ b/examples/caldera/audit_inventory_latency.rue
@@ -63,7 +63,7 @@ fn observe_entities(inout out: metric.Metric, borrow world: model.World) {
         metric.observe(inout out, entity_projection(borrow world, i), (i % 11) + 1);
         metric.warn(inout out, item.alive && (item.x < 0 || item.y < 0 ||
             @intCast(item.x) >= world.width || @intCast(item.y) >= world.height));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -73,7 +73,7 @@ fn observe_tiles(inout out: metric.Metric, borrow world: model.World) {
         let item = world.tiles.get_or(i, model.empty_tile());
         metric.observe(inout out, tile_projection(borrow world, i), (i % 13) + 1);
         metric.warn(inout out, item.x >= world.width || item.y >= world.height);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -82,18 +82,18 @@ fn observe_timeline(inout out: metric.Metric, borrow world: model.World) {
     while i < world.events.len() {
         metric.observe(inout out, event_projection(borrow world, i), (i % 5) + 1);
         metric.warn(inout out, world.events.get_or(i, model.empty_event()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
         metric.observe(inout out, command_projection(borrow world, i), (i % 7) + 1);
         metric.warn(inout out, world.commands.get_or(i, model.empty_command()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.snapshots.len() {
         metric.observe(inout out, snapshot_projection(borrow world, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -108,9 +108,9 @@ fn observe_pairs(inout out: metric.Metric, borrow world: model.World) {
             let dy = if left.y > right.y { left.y - right.y } else { right.y - left.y };
             metric.observe(inout out, @intCast(dx + dy) +
                 left.faction * 3 + right.faction * 5 + MODE(), i + j + 1);
-            j = j + 1;
+            j += 1;
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -125,17 +125,17 @@ fn observe_factions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.entities.len() {
             let entity = world.entities.get_or(i, model.empty_entity());
             if entity.faction == faction && entity.alive {
-                agents = agents + 1;
-                health = health + entity.health;
-                energy = energy + entity.energy;
-                inventory = inventory + entity.inventory;
+                agents += 1;
+                health += entity.health;
+                energy += entity.energy;
+                inventory += entity.inventory;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = agents * (MODE() % 11 + 1) + health * 3 +
             energy * 5 + inventory * 7 + faction;
         metric.observe(inout out, projection, faction + MODE() % 5 + 1);
-        faction = faction + 1;
+        faction += 1;
     }
 }
 
@@ -150,17 +150,17 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
-                tiles = tiles + 1;
+                tiles += 1;
                 if tile.walkable { walkable = walkable + 1; }
-                resources = resources + tile.resource;
-                elevation = elevation + tile.height;
+                resources += tile.resource;
+                elevation += tile.height;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = tiles * (MODE() % 13 + 1) + walkable * 3 +
             resources * 5 + elevation * 7 + region;
         metric.observe(inout out, projection, region % 7 + 1);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/audit_inventory_locality.rue
+++ b/examples/caldera/audit_inventory_locality.rue
@@ -151,7 +151,7 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
                 tiles += 1;
-                if tile.walkable { walkable = walkable + 1; }
+                if tile.walkable { walkable += 1; }
                 resources += tile.resource;
                 elevation += tile.height;
             }

--- a/examples/caldera/audit_inventory_locality.rue
+++ b/examples/caldera/audit_inventory_locality.rue
@@ -63,7 +63,7 @@ fn observe_entities(inout out: metric.Metric, borrow world: model.World) {
         metric.observe(inout out, entity_projection(borrow world, i), (i % 11) + 1);
         metric.warn(inout out, item.alive && (item.x < 0 || item.y < 0 ||
             @intCast(item.x) >= world.width || @intCast(item.y) >= world.height));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -73,7 +73,7 @@ fn observe_tiles(inout out: metric.Metric, borrow world: model.World) {
         let item = world.tiles.get_or(i, model.empty_tile());
         metric.observe(inout out, tile_projection(borrow world, i), (i % 13) + 1);
         metric.warn(inout out, item.x >= world.width || item.y >= world.height);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -82,18 +82,18 @@ fn observe_timeline(inout out: metric.Metric, borrow world: model.World) {
     while i < world.events.len() {
         metric.observe(inout out, event_projection(borrow world, i), (i % 5) + 1);
         metric.warn(inout out, world.events.get_or(i, model.empty_event()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
         metric.observe(inout out, command_projection(borrow world, i), (i % 7) + 1);
         metric.warn(inout out, world.commands.get_or(i, model.empty_command()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.snapshots.len() {
         metric.observe(inout out, snapshot_projection(borrow world, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -108,9 +108,9 @@ fn observe_pairs(inout out: metric.Metric, borrow world: model.World) {
             let dy = if left.y > right.y { left.y - right.y } else { right.y - left.y };
             metric.observe(inout out, @intCast(dx + dy) +
                 left.faction * 3 + right.faction * 5 + MODE(), i + j + 1);
-            j = j + 1;
+            j += 1;
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -125,17 +125,17 @@ fn observe_factions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.entities.len() {
             let entity = world.entities.get_or(i, model.empty_entity());
             if entity.faction == faction && entity.alive {
-                agents = agents + 1;
-                health = health + entity.health;
-                energy = energy + entity.energy;
-                inventory = inventory + entity.inventory;
+                agents += 1;
+                health += entity.health;
+                energy += entity.energy;
+                inventory += entity.inventory;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = agents * (MODE() % 11 + 1) + health * 3 +
             energy * 5 + inventory * 7 + faction;
         metric.observe(inout out, projection, faction + MODE() % 5 + 1);
-        faction = faction + 1;
+        faction += 1;
     }
 }
 
@@ -150,17 +150,17 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
-                tiles = tiles + 1;
+                tiles += 1;
                 if tile.walkable { walkable = walkable + 1; }
-                resources = resources + tile.resource;
-                elevation = elevation + tile.height;
+                resources += tile.resource;
+                elevation += tile.height;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = tiles * (MODE() % 13 + 1) + walkable * 3 +
             resources * 5 + elevation * 7 + region;
         metric.observe(inout out, projection, region % 7 + 1);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/audit_inventory_pressure.rue
+++ b/examples/caldera/audit_inventory_pressure.rue
@@ -151,7 +151,7 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
                 tiles += 1;
-                if tile.walkable { walkable = walkable + 1; }
+                if tile.walkable { walkable += 1; }
                 resources += tile.resource;
                 elevation += tile.height;
             }

--- a/examples/caldera/audit_inventory_pressure.rue
+++ b/examples/caldera/audit_inventory_pressure.rue
@@ -63,7 +63,7 @@ fn observe_entities(inout out: metric.Metric, borrow world: model.World) {
         metric.observe(inout out, entity_projection(borrow world, i), (i % 11) + 1);
         metric.warn(inout out, item.alive && (item.x < 0 || item.y < 0 ||
             @intCast(item.x) >= world.width || @intCast(item.y) >= world.height));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -73,7 +73,7 @@ fn observe_tiles(inout out: metric.Metric, borrow world: model.World) {
         let item = world.tiles.get_or(i, model.empty_tile());
         metric.observe(inout out, tile_projection(borrow world, i), (i % 13) + 1);
         metric.warn(inout out, item.x >= world.width || item.y >= world.height);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -82,18 +82,18 @@ fn observe_timeline(inout out: metric.Metric, borrow world: model.World) {
     while i < world.events.len() {
         metric.observe(inout out, event_projection(borrow world, i), (i % 5) + 1);
         metric.warn(inout out, world.events.get_or(i, model.empty_event()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
         metric.observe(inout out, command_projection(borrow world, i), (i % 7) + 1);
         metric.warn(inout out, world.commands.get_or(i, model.empty_command()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.snapshots.len() {
         metric.observe(inout out, snapshot_projection(borrow world, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -108,9 +108,9 @@ fn observe_pairs(inout out: metric.Metric, borrow world: model.World) {
             let dy = if left.y > right.y { left.y - right.y } else { right.y - left.y };
             metric.observe(inout out, @intCast(dx + dy) +
                 left.faction * 3 + right.faction * 5 + MODE(), i + j + 1);
-            j = j + 1;
+            j += 1;
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -125,17 +125,17 @@ fn observe_factions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.entities.len() {
             let entity = world.entities.get_or(i, model.empty_entity());
             if entity.faction == faction && entity.alive {
-                agents = agents + 1;
-                health = health + entity.health;
-                energy = energy + entity.energy;
-                inventory = inventory + entity.inventory;
+                agents += 1;
+                health += entity.health;
+                energy += entity.energy;
+                inventory += entity.inventory;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = agents * (MODE() % 11 + 1) + health * 3 +
             energy * 5 + inventory * 7 + faction;
         metric.observe(inout out, projection, faction + MODE() % 5 + 1);
-        faction = faction + 1;
+        faction += 1;
     }
 }
 
@@ -150,17 +150,17 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
-                tiles = tiles + 1;
+                tiles += 1;
                 if tile.walkable { walkable = walkable + 1; }
-                resources = resources + tile.resource;
-                elevation = elevation + tile.height;
+                resources += tile.resource;
+                elevation += tile.height;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = tiles * (MODE() % 13 + 1) + walkable * 3 +
             resources * 5 + elevation * 7 + region;
         metric.observe(inout out, projection, region % 7 + 1);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/audit_inventory_risk.rue
+++ b/examples/caldera/audit_inventory_risk.rue
@@ -151,7 +151,7 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
                 tiles += 1;
-                if tile.walkable { walkable = walkable + 1; }
+                if tile.walkable { walkable += 1; }
                 resources += tile.resource;
                 elevation += tile.height;
             }

--- a/examples/caldera/audit_inventory_risk.rue
+++ b/examples/caldera/audit_inventory_risk.rue
@@ -63,7 +63,7 @@ fn observe_entities(inout out: metric.Metric, borrow world: model.World) {
         metric.observe(inout out, entity_projection(borrow world, i), (i % 11) + 1);
         metric.warn(inout out, item.alive && (item.x < 0 || item.y < 0 ||
             @intCast(item.x) >= world.width || @intCast(item.y) >= world.height));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -73,7 +73,7 @@ fn observe_tiles(inout out: metric.Metric, borrow world: model.World) {
         let item = world.tiles.get_or(i, model.empty_tile());
         metric.observe(inout out, tile_projection(borrow world, i), (i % 13) + 1);
         metric.warn(inout out, item.x >= world.width || item.y >= world.height);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -82,18 +82,18 @@ fn observe_timeline(inout out: metric.Metric, borrow world: model.World) {
     while i < world.events.len() {
         metric.observe(inout out, event_projection(borrow world, i), (i % 5) + 1);
         metric.warn(inout out, world.events.get_or(i, model.empty_event()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
         metric.observe(inout out, command_projection(borrow world, i), (i % 7) + 1);
         metric.warn(inout out, world.commands.get_or(i, model.empty_command()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.snapshots.len() {
         metric.observe(inout out, snapshot_projection(borrow world, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -108,9 +108,9 @@ fn observe_pairs(inout out: metric.Metric, borrow world: model.World) {
             let dy = if left.y > right.y { left.y - right.y } else { right.y - left.y };
             metric.observe(inout out, @intCast(dx + dy) +
                 left.faction * 3 + right.faction * 5 + MODE(), i + j + 1);
-            j = j + 1;
+            j += 1;
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -125,17 +125,17 @@ fn observe_factions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.entities.len() {
             let entity = world.entities.get_or(i, model.empty_entity());
             if entity.faction == faction && entity.alive {
-                agents = agents + 1;
-                health = health + entity.health;
-                energy = energy + entity.energy;
-                inventory = inventory + entity.inventory;
+                agents += 1;
+                health += entity.health;
+                energy += entity.energy;
+                inventory += entity.inventory;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = agents * (MODE() % 11 + 1) + health * 3 +
             energy * 5 + inventory * 7 + faction;
         metric.observe(inout out, projection, faction + MODE() % 5 + 1);
-        faction = faction + 1;
+        faction += 1;
     }
 }
 
@@ -150,17 +150,17 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
-                tiles = tiles + 1;
+                tiles += 1;
                 if tile.walkable { walkable = walkable + 1; }
-                resources = resources + tile.resource;
-                elevation = elevation + tile.height;
+                resources += tile.resource;
+                elevation += tile.height;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = tiles * (MODE() % 13 + 1) + walkable * 3 +
             resources * 5 + elevation * 7 + region;
         metric.observe(inout out, projection, region % 7 + 1);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/audit_inventory_skew.rue
+++ b/examples/caldera/audit_inventory_skew.rue
@@ -151,7 +151,7 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
                 tiles += 1;
-                if tile.walkable { walkable = walkable + 1; }
+                if tile.walkable { walkable += 1; }
                 resources += tile.resource;
                 elevation += tile.height;
             }

--- a/examples/caldera/audit_inventory_skew.rue
+++ b/examples/caldera/audit_inventory_skew.rue
@@ -63,7 +63,7 @@ fn observe_entities(inout out: metric.Metric, borrow world: model.World) {
         metric.observe(inout out, entity_projection(borrow world, i), (i % 11) + 1);
         metric.warn(inout out, item.alive && (item.x < 0 || item.y < 0 ||
             @intCast(item.x) >= world.width || @intCast(item.y) >= world.height));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -73,7 +73,7 @@ fn observe_tiles(inout out: metric.Metric, borrow world: model.World) {
         let item = world.tiles.get_or(i, model.empty_tile());
         metric.observe(inout out, tile_projection(borrow world, i), (i % 13) + 1);
         metric.warn(inout out, item.x >= world.width || item.y >= world.height);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -82,18 +82,18 @@ fn observe_timeline(inout out: metric.Metric, borrow world: model.World) {
     while i < world.events.len() {
         metric.observe(inout out, event_projection(borrow world, i), (i % 5) + 1);
         metric.warn(inout out, world.events.get_or(i, model.empty_event()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
         metric.observe(inout out, command_projection(borrow world, i), (i % 7) + 1);
         metric.warn(inout out, world.commands.get_or(i, model.empty_command()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.snapshots.len() {
         metric.observe(inout out, snapshot_projection(borrow world, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -108,9 +108,9 @@ fn observe_pairs(inout out: metric.Metric, borrow world: model.World) {
             let dy = if left.y > right.y { left.y - right.y } else { right.y - left.y };
             metric.observe(inout out, @intCast(dx + dy) +
                 left.faction * 3 + right.faction * 5 + MODE(), i + j + 1);
-            j = j + 1;
+            j += 1;
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -125,17 +125,17 @@ fn observe_factions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.entities.len() {
             let entity = world.entities.get_or(i, model.empty_entity());
             if entity.faction == faction && entity.alive {
-                agents = agents + 1;
-                health = health + entity.health;
-                energy = energy + entity.energy;
-                inventory = inventory + entity.inventory;
+                agents += 1;
+                health += entity.health;
+                energy += entity.energy;
+                inventory += entity.inventory;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = agents * (MODE() % 11 + 1) + health * 3 +
             energy * 5 + inventory * 7 + faction;
         metric.observe(inout out, projection, faction + MODE() % 5 + 1);
-        faction = faction + 1;
+        faction += 1;
     }
 }
 
@@ -150,17 +150,17 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
-                tiles = tiles + 1;
+                tiles += 1;
                 if tile.walkable { walkable = walkable + 1; }
-                resources = resources + tile.resource;
-                elevation = elevation + tile.height;
+                resources += tile.resource;
+                elevation += tile.height;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = tiles * (MODE() % 13 + 1) + walkable * 3 +
             resources * 5 + elevation * 7 + region;
         metric.observe(inout out, projection, region % 7 + 1);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/audit_inventory_stability.rue
+++ b/examples/caldera/audit_inventory_stability.rue
@@ -151,7 +151,7 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
                 tiles += 1;
-                if tile.walkable { walkable = walkable + 1; }
+                if tile.walkable { walkable += 1; }
                 resources += tile.resource;
                 elevation += tile.height;
             }

--- a/examples/caldera/audit_inventory_stability.rue
+++ b/examples/caldera/audit_inventory_stability.rue
@@ -63,7 +63,7 @@ fn observe_entities(inout out: metric.Metric, borrow world: model.World) {
         metric.observe(inout out, entity_projection(borrow world, i), (i % 11) + 1);
         metric.warn(inout out, item.alive && (item.x < 0 || item.y < 0 ||
             @intCast(item.x) >= world.width || @intCast(item.y) >= world.height));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -73,7 +73,7 @@ fn observe_tiles(inout out: metric.Metric, borrow world: model.World) {
         let item = world.tiles.get_or(i, model.empty_tile());
         metric.observe(inout out, tile_projection(borrow world, i), (i % 13) + 1);
         metric.warn(inout out, item.x >= world.width || item.y >= world.height);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -82,18 +82,18 @@ fn observe_timeline(inout out: metric.Metric, borrow world: model.World) {
     while i < world.events.len() {
         metric.observe(inout out, event_projection(borrow world, i), (i % 5) + 1);
         metric.warn(inout out, world.events.get_or(i, model.empty_event()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
         metric.observe(inout out, command_projection(borrow world, i), (i % 7) + 1);
         metric.warn(inout out, world.commands.get_or(i, model.empty_command()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.snapshots.len() {
         metric.observe(inout out, snapshot_projection(borrow world, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -108,9 +108,9 @@ fn observe_pairs(inout out: metric.Metric, borrow world: model.World) {
             let dy = if left.y > right.y { left.y - right.y } else { right.y - left.y };
             metric.observe(inout out, @intCast(dx + dy) +
                 left.faction * 3 + right.faction * 5 + MODE(), i + j + 1);
-            j = j + 1;
+            j += 1;
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -125,17 +125,17 @@ fn observe_factions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.entities.len() {
             let entity = world.entities.get_or(i, model.empty_entity());
             if entity.faction == faction && entity.alive {
-                agents = agents + 1;
-                health = health + entity.health;
-                energy = energy + entity.energy;
-                inventory = inventory + entity.inventory;
+                agents += 1;
+                health += entity.health;
+                energy += entity.energy;
+                inventory += entity.inventory;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = agents * (MODE() % 11 + 1) + health * 3 +
             energy * 5 + inventory * 7 + faction;
         metric.observe(inout out, projection, faction + MODE() % 5 + 1);
-        faction = faction + 1;
+        faction += 1;
     }
 }
 
@@ -150,17 +150,17 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
-                tiles = tiles + 1;
+                tiles += 1;
                 if tile.walkable { walkable = walkable + 1; }
-                resources = resources + tile.resource;
-                elevation = elevation + tile.height;
+                resources += tile.resource;
+                elevation += tile.height;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = tiles * (MODE() % 13 + 1) + walkable * 3 +
             resources * 5 + elevation * 7 + region;
         metric.observe(inout out, projection, region % 7 + 1);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/audit_inventory_throughput.rue
+++ b/examples/caldera/audit_inventory_throughput.rue
@@ -151,7 +151,7 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
                 tiles += 1;
-                if tile.walkable { walkable = walkable + 1; }
+                if tile.walkable { walkable += 1; }
                 resources += tile.resource;
                 elevation += tile.height;
             }

--- a/examples/caldera/audit_inventory_throughput.rue
+++ b/examples/caldera/audit_inventory_throughput.rue
@@ -63,7 +63,7 @@ fn observe_entities(inout out: metric.Metric, borrow world: model.World) {
         metric.observe(inout out, entity_projection(borrow world, i), (i % 11) + 1);
         metric.warn(inout out, item.alive && (item.x < 0 || item.y < 0 ||
             @intCast(item.x) >= world.width || @intCast(item.y) >= world.height));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -73,7 +73,7 @@ fn observe_tiles(inout out: metric.Metric, borrow world: model.World) {
         let item = world.tiles.get_or(i, model.empty_tile());
         metric.observe(inout out, tile_projection(borrow world, i), (i % 13) + 1);
         metric.warn(inout out, item.x >= world.width || item.y >= world.height);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -82,18 +82,18 @@ fn observe_timeline(inout out: metric.Metric, borrow world: model.World) {
     while i < world.events.len() {
         metric.observe(inout out, event_projection(borrow world, i), (i % 5) + 1);
         metric.warn(inout out, world.events.get_or(i, model.empty_event()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
         metric.observe(inout out, command_projection(borrow world, i), (i % 7) + 1);
         metric.warn(inout out, world.commands.get_or(i, model.empty_command()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.snapshots.len() {
         metric.observe(inout out, snapshot_projection(borrow world, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -108,9 +108,9 @@ fn observe_pairs(inout out: metric.Metric, borrow world: model.World) {
             let dy = if left.y > right.y { left.y - right.y } else { right.y - left.y };
             metric.observe(inout out, @intCast(dx + dy) +
                 left.faction * 3 + right.faction * 5 + MODE(), i + j + 1);
-            j = j + 1;
+            j += 1;
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -125,17 +125,17 @@ fn observe_factions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.entities.len() {
             let entity = world.entities.get_or(i, model.empty_entity());
             if entity.faction == faction && entity.alive {
-                agents = agents + 1;
-                health = health + entity.health;
-                energy = energy + entity.energy;
-                inventory = inventory + entity.inventory;
+                agents += 1;
+                health += entity.health;
+                energy += entity.energy;
+                inventory += entity.inventory;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = agents * (MODE() % 11 + 1) + health * 3 +
             energy * 5 + inventory * 7 + faction;
         metric.observe(inout out, projection, faction + MODE() % 5 + 1);
-        faction = faction + 1;
+        faction += 1;
     }
 }
 
@@ -150,17 +150,17 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
-                tiles = tiles + 1;
+                tiles += 1;
                 if tile.walkable { walkable = walkable + 1; }
-                resources = resources + tile.resource;
-                elevation = elevation + tile.height;
+                resources += tile.resource;
+                elevation += tile.height;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = tiles * (MODE() % 13 + 1) + walkable * 3 +
             resources * 5 + elevation * 7 + region;
         metric.observe(inout out, projection, region % 7 + 1);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/audit_navigation_balance.rue
+++ b/examples/caldera/audit_navigation_balance.rue
@@ -151,7 +151,7 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
                 tiles += 1;
-                if tile.walkable { walkable = walkable + 1; }
+                if tile.walkable { walkable += 1; }
                 resources += tile.resource;
                 elevation += tile.height;
             }

--- a/examples/caldera/audit_navigation_balance.rue
+++ b/examples/caldera/audit_navigation_balance.rue
@@ -63,7 +63,7 @@ fn observe_entities(inout out: metric.Metric, borrow world: model.World) {
         metric.observe(inout out, entity_projection(borrow world, i), (i % 11) + 1);
         metric.warn(inout out, item.alive && (item.x < 0 || item.y < 0 ||
             @intCast(item.x) >= world.width || @intCast(item.y) >= world.height));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -73,7 +73,7 @@ fn observe_tiles(inout out: metric.Metric, borrow world: model.World) {
         let item = world.tiles.get_or(i, model.empty_tile());
         metric.observe(inout out, tile_projection(borrow world, i), (i % 13) + 1);
         metric.warn(inout out, item.x >= world.width || item.y >= world.height);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -82,18 +82,18 @@ fn observe_timeline(inout out: metric.Metric, borrow world: model.World) {
     while i < world.events.len() {
         metric.observe(inout out, event_projection(borrow world, i), (i % 5) + 1);
         metric.warn(inout out, world.events.get_or(i, model.empty_event()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
         metric.observe(inout out, command_projection(borrow world, i), (i % 7) + 1);
         metric.warn(inout out, world.commands.get_or(i, model.empty_command()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.snapshots.len() {
         metric.observe(inout out, snapshot_projection(borrow world, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -108,9 +108,9 @@ fn observe_pairs(inout out: metric.Metric, borrow world: model.World) {
             let dy = if left.y > right.y { left.y - right.y } else { right.y - left.y };
             metric.observe(inout out, @intCast(dx + dy) +
                 left.faction * 3 + right.faction * 5 + MODE(), i + j + 1);
-            j = j + 1;
+            j += 1;
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -125,17 +125,17 @@ fn observe_factions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.entities.len() {
             let entity = world.entities.get_or(i, model.empty_entity());
             if entity.faction == faction && entity.alive {
-                agents = agents + 1;
-                health = health + entity.health;
-                energy = energy + entity.energy;
-                inventory = inventory + entity.inventory;
+                agents += 1;
+                health += entity.health;
+                energy += entity.energy;
+                inventory += entity.inventory;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = agents * (MODE() % 11 + 1) + health * 3 +
             energy * 5 + inventory * 7 + faction;
         metric.observe(inout out, projection, faction + MODE() % 5 + 1);
-        faction = faction + 1;
+        faction += 1;
     }
 }
 
@@ -150,17 +150,17 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
-                tiles = tiles + 1;
+                tiles += 1;
                 if tile.walkable { walkable = walkable + 1; }
-                resources = resources + tile.resource;
-                elevation = elevation + tile.height;
+                resources += tile.resource;
+                elevation += tile.height;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = tiles * (MODE() % 13 + 1) + walkable * 3 +
             resources * 5 + elevation * 7 + region;
         metric.observe(inout out, projection, region % 7 + 1);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/audit_navigation_capacity.rue
+++ b/examples/caldera/audit_navigation_capacity.rue
@@ -151,7 +151,7 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
                 tiles += 1;
-                if tile.walkable { walkable = walkable + 1; }
+                if tile.walkable { walkable += 1; }
                 resources += tile.resource;
                 elevation += tile.height;
             }

--- a/examples/caldera/audit_navigation_capacity.rue
+++ b/examples/caldera/audit_navigation_capacity.rue
@@ -63,7 +63,7 @@ fn observe_entities(inout out: metric.Metric, borrow world: model.World) {
         metric.observe(inout out, entity_projection(borrow world, i), (i % 11) + 1);
         metric.warn(inout out, item.alive && (item.x < 0 || item.y < 0 ||
             @intCast(item.x) >= world.width || @intCast(item.y) >= world.height));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -73,7 +73,7 @@ fn observe_tiles(inout out: metric.Metric, borrow world: model.World) {
         let item = world.tiles.get_or(i, model.empty_tile());
         metric.observe(inout out, tile_projection(borrow world, i), (i % 13) + 1);
         metric.warn(inout out, item.x >= world.width || item.y >= world.height);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -82,18 +82,18 @@ fn observe_timeline(inout out: metric.Metric, borrow world: model.World) {
     while i < world.events.len() {
         metric.observe(inout out, event_projection(borrow world, i), (i % 5) + 1);
         metric.warn(inout out, world.events.get_or(i, model.empty_event()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
         metric.observe(inout out, command_projection(borrow world, i), (i % 7) + 1);
         metric.warn(inout out, world.commands.get_or(i, model.empty_command()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.snapshots.len() {
         metric.observe(inout out, snapshot_projection(borrow world, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -108,9 +108,9 @@ fn observe_pairs(inout out: metric.Metric, borrow world: model.World) {
             let dy = if left.y > right.y { left.y - right.y } else { right.y - left.y };
             metric.observe(inout out, @intCast(dx + dy) +
                 left.faction * 3 + right.faction * 5 + MODE(), i + j + 1);
-            j = j + 1;
+            j += 1;
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -125,17 +125,17 @@ fn observe_factions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.entities.len() {
             let entity = world.entities.get_or(i, model.empty_entity());
             if entity.faction == faction && entity.alive {
-                agents = agents + 1;
-                health = health + entity.health;
-                energy = energy + entity.energy;
-                inventory = inventory + entity.inventory;
+                agents += 1;
+                health += entity.health;
+                energy += entity.energy;
+                inventory += entity.inventory;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = agents * (MODE() % 11 + 1) + health * 3 +
             energy * 5 + inventory * 7 + faction;
         metric.observe(inout out, projection, faction + MODE() % 5 + 1);
-        faction = faction + 1;
+        faction += 1;
     }
 }
 
@@ -150,17 +150,17 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
-                tiles = tiles + 1;
+                tiles += 1;
                 if tile.walkable { walkable = walkable + 1; }
-                resources = resources + tile.resource;
-                elevation = elevation + tile.height;
+                resources += tile.resource;
+                elevation += tile.height;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = tiles * (MODE() % 13 + 1) + walkable * 3 +
             resources * 5 + elevation * 7 + region;
         metric.observe(inout out, projection, region % 7 + 1);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/audit_navigation_continuity.rue
+++ b/examples/caldera/audit_navigation_continuity.rue
@@ -151,7 +151,7 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
                 tiles += 1;
-                if tile.walkable { walkable = walkable + 1; }
+                if tile.walkable { walkable += 1; }
                 resources += tile.resource;
                 elevation += tile.height;
             }

--- a/examples/caldera/audit_navigation_continuity.rue
+++ b/examples/caldera/audit_navigation_continuity.rue
@@ -63,7 +63,7 @@ fn observe_entities(inout out: metric.Metric, borrow world: model.World) {
         metric.observe(inout out, entity_projection(borrow world, i), (i % 11) + 1);
         metric.warn(inout out, item.alive && (item.x < 0 || item.y < 0 ||
             @intCast(item.x) >= world.width || @intCast(item.y) >= world.height));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -73,7 +73,7 @@ fn observe_tiles(inout out: metric.Metric, borrow world: model.World) {
         let item = world.tiles.get_or(i, model.empty_tile());
         metric.observe(inout out, tile_projection(borrow world, i), (i % 13) + 1);
         metric.warn(inout out, item.x >= world.width || item.y >= world.height);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -82,18 +82,18 @@ fn observe_timeline(inout out: metric.Metric, borrow world: model.World) {
     while i < world.events.len() {
         metric.observe(inout out, event_projection(borrow world, i), (i % 5) + 1);
         metric.warn(inout out, world.events.get_or(i, model.empty_event()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
         metric.observe(inout out, command_projection(borrow world, i), (i % 7) + 1);
         metric.warn(inout out, world.commands.get_or(i, model.empty_command()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.snapshots.len() {
         metric.observe(inout out, snapshot_projection(borrow world, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -108,9 +108,9 @@ fn observe_pairs(inout out: metric.Metric, borrow world: model.World) {
             let dy = if left.y > right.y { left.y - right.y } else { right.y - left.y };
             metric.observe(inout out, @intCast(dx + dy) +
                 left.faction * 3 + right.faction * 5 + MODE(), i + j + 1);
-            j = j + 1;
+            j += 1;
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -125,17 +125,17 @@ fn observe_factions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.entities.len() {
             let entity = world.entities.get_or(i, model.empty_entity());
             if entity.faction == faction && entity.alive {
-                agents = agents + 1;
-                health = health + entity.health;
-                energy = energy + entity.energy;
-                inventory = inventory + entity.inventory;
+                agents += 1;
+                health += entity.health;
+                energy += entity.energy;
+                inventory += entity.inventory;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = agents * (MODE() % 11 + 1) + health * 3 +
             energy * 5 + inventory * 7 + faction;
         metric.observe(inout out, projection, faction + MODE() % 5 + 1);
-        faction = faction + 1;
+        faction += 1;
     }
 }
 
@@ -150,17 +150,17 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
-                tiles = tiles + 1;
+                tiles += 1;
                 if tile.walkable { walkable = walkable + 1; }
-                resources = resources + tile.resource;
-                elevation = elevation + tile.height;
+                resources += tile.resource;
+                elevation += tile.height;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = tiles * (MODE() % 13 + 1) + walkable * 3 +
             resources * 5 + elevation * 7 + region;
         metric.observe(inout out, projection, region % 7 + 1);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/audit_navigation_cost.rue
+++ b/examples/caldera/audit_navigation_cost.rue
@@ -151,7 +151,7 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
                 tiles += 1;
-                if tile.walkable { walkable = walkable + 1; }
+                if tile.walkable { walkable += 1; }
                 resources += tile.resource;
                 elevation += tile.height;
             }

--- a/examples/caldera/audit_navigation_cost.rue
+++ b/examples/caldera/audit_navigation_cost.rue
@@ -63,7 +63,7 @@ fn observe_entities(inout out: metric.Metric, borrow world: model.World) {
         metric.observe(inout out, entity_projection(borrow world, i), (i % 11) + 1);
         metric.warn(inout out, item.alive && (item.x < 0 || item.y < 0 ||
             @intCast(item.x) >= world.width || @intCast(item.y) >= world.height));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -73,7 +73,7 @@ fn observe_tiles(inout out: metric.Metric, borrow world: model.World) {
         let item = world.tiles.get_or(i, model.empty_tile());
         metric.observe(inout out, tile_projection(borrow world, i), (i % 13) + 1);
         metric.warn(inout out, item.x >= world.width || item.y >= world.height);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -82,18 +82,18 @@ fn observe_timeline(inout out: metric.Metric, borrow world: model.World) {
     while i < world.events.len() {
         metric.observe(inout out, event_projection(borrow world, i), (i % 5) + 1);
         metric.warn(inout out, world.events.get_or(i, model.empty_event()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
         metric.observe(inout out, command_projection(borrow world, i), (i % 7) + 1);
         metric.warn(inout out, world.commands.get_or(i, model.empty_command()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.snapshots.len() {
         metric.observe(inout out, snapshot_projection(borrow world, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -108,9 +108,9 @@ fn observe_pairs(inout out: metric.Metric, borrow world: model.World) {
             let dy = if left.y > right.y { left.y - right.y } else { right.y - left.y };
             metric.observe(inout out, @intCast(dx + dy) +
                 left.faction * 3 + right.faction * 5 + MODE(), i + j + 1);
-            j = j + 1;
+            j += 1;
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -125,17 +125,17 @@ fn observe_factions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.entities.len() {
             let entity = world.entities.get_or(i, model.empty_entity());
             if entity.faction == faction && entity.alive {
-                agents = agents + 1;
-                health = health + entity.health;
-                energy = energy + entity.energy;
-                inventory = inventory + entity.inventory;
+                agents += 1;
+                health += entity.health;
+                energy += entity.energy;
+                inventory += entity.inventory;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = agents * (MODE() % 11 + 1) + health * 3 +
             energy * 5 + inventory * 7 + faction;
         metric.observe(inout out, projection, faction + MODE() % 5 + 1);
-        faction = faction + 1;
+        faction += 1;
     }
 }
 
@@ -150,17 +150,17 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
-                tiles = tiles + 1;
+                tiles += 1;
                 if tile.walkable { walkable = walkable + 1; }
-                resources = resources + tile.resource;
-                elevation = elevation + tile.height;
+                resources += tile.resource;
+                elevation += tile.height;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = tiles * (MODE() % 13 + 1) + walkable * 3 +
             resources * 5 + elevation * 7 + region;
         metric.observe(inout out, projection, region % 7 + 1);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/audit_navigation_coverage.rue
+++ b/examples/caldera/audit_navigation_coverage.rue
@@ -151,7 +151,7 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
                 tiles += 1;
-                if tile.walkable { walkable = walkable + 1; }
+                if tile.walkable { walkable += 1; }
                 resources += tile.resource;
                 elevation += tile.height;
             }

--- a/examples/caldera/audit_navigation_coverage.rue
+++ b/examples/caldera/audit_navigation_coverage.rue
@@ -63,7 +63,7 @@ fn observe_entities(inout out: metric.Metric, borrow world: model.World) {
         metric.observe(inout out, entity_projection(borrow world, i), (i % 11) + 1);
         metric.warn(inout out, item.alive && (item.x < 0 || item.y < 0 ||
             @intCast(item.x) >= world.width || @intCast(item.y) >= world.height));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -73,7 +73,7 @@ fn observe_tiles(inout out: metric.Metric, borrow world: model.World) {
         let item = world.tiles.get_or(i, model.empty_tile());
         metric.observe(inout out, tile_projection(borrow world, i), (i % 13) + 1);
         metric.warn(inout out, item.x >= world.width || item.y >= world.height);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -82,18 +82,18 @@ fn observe_timeline(inout out: metric.Metric, borrow world: model.World) {
     while i < world.events.len() {
         metric.observe(inout out, event_projection(borrow world, i), (i % 5) + 1);
         metric.warn(inout out, world.events.get_or(i, model.empty_event()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
         metric.observe(inout out, command_projection(borrow world, i), (i % 7) + 1);
         metric.warn(inout out, world.commands.get_or(i, model.empty_command()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.snapshots.len() {
         metric.observe(inout out, snapshot_projection(borrow world, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -108,9 +108,9 @@ fn observe_pairs(inout out: metric.Metric, borrow world: model.World) {
             let dy = if left.y > right.y { left.y - right.y } else { right.y - left.y };
             metric.observe(inout out, @intCast(dx + dy) +
                 left.faction * 3 + right.faction * 5 + MODE(), i + j + 1);
-            j = j + 1;
+            j += 1;
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -125,17 +125,17 @@ fn observe_factions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.entities.len() {
             let entity = world.entities.get_or(i, model.empty_entity());
             if entity.faction == faction && entity.alive {
-                agents = agents + 1;
-                health = health + entity.health;
-                energy = energy + entity.energy;
-                inventory = inventory + entity.inventory;
+                agents += 1;
+                health += entity.health;
+                energy += entity.energy;
+                inventory += entity.inventory;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = agents * (MODE() % 11 + 1) + health * 3 +
             energy * 5 + inventory * 7 + faction;
         metric.observe(inout out, projection, faction + MODE() % 5 + 1);
-        faction = faction + 1;
+        faction += 1;
     }
 }
 
@@ -150,17 +150,17 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
-                tiles = tiles + 1;
+                tiles += 1;
                 if tile.walkable { walkable = walkable + 1; }
-                resources = resources + tile.resource;
-                elevation = elevation + tile.height;
+                resources += tile.resource;
+                elevation += tile.height;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = tiles * (MODE() % 13 + 1) + walkable * 3 +
             resources * 5 + elevation * 7 + region;
         metric.observe(inout out, projection, region % 7 + 1);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/audit_navigation_density.rue
+++ b/examples/caldera/audit_navigation_density.rue
@@ -151,7 +151,7 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
                 tiles += 1;
-                if tile.walkable { walkable = walkable + 1; }
+                if tile.walkable { walkable += 1; }
                 resources += tile.resource;
                 elevation += tile.height;
             }

--- a/examples/caldera/audit_navigation_density.rue
+++ b/examples/caldera/audit_navigation_density.rue
@@ -63,7 +63,7 @@ fn observe_entities(inout out: metric.Metric, borrow world: model.World) {
         metric.observe(inout out, entity_projection(borrow world, i), (i % 11) + 1);
         metric.warn(inout out, item.alive && (item.x < 0 || item.y < 0 ||
             @intCast(item.x) >= world.width || @intCast(item.y) >= world.height));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -73,7 +73,7 @@ fn observe_tiles(inout out: metric.Metric, borrow world: model.World) {
         let item = world.tiles.get_or(i, model.empty_tile());
         metric.observe(inout out, tile_projection(borrow world, i), (i % 13) + 1);
         metric.warn(inout out, item.x >= world.width || item.y >= world.height);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -82,18 +82,18 @@ fn observe_timeline(inout out: metric.Metric, borrow world: model.World) {
     while i < world.events.len() {
         metric.observe(inout out, event_projection(borrow world, i), (i % 5) + 1);
         metric.warn(inout out, world.events.get_or(i, model.empty_event()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
         metric.observe(inout out, command_projection(borrow world, i), (i % 7) + 1);
         metric.warn(inout out, world.commands.get_or(i, model.empty_command()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.snapshots.len() {
         metric.observe(inout out, snapshot_projection(borrow world, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -108,9 +108,9 @@ fn observe_pairs(inout out: metric.Metric, borrow world: model.World) {
             let dy = if left.y > right.y { left.y - right.y } else { right.y - left.y };
             metric.observe(inout out, @intCast(dx + dy) +
                 left.faction * 3 + right.faction * 5 + MODE(), i + j + 1);
-            j = j + 1;
+            j += 1;
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -125,17 +125,17 @@ fn observe_factions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.entities.len() {
             let entity = world.entities.get_or(i, model.empty_entity());
             if entity.faction == faction && entity.alive {
-                agents = agents + 1;
-                health = health + entity.health;
-                energy = energy + entity.energy;
-                inventory = inventory + entity.inventory;
+                agents += 1;
+                health += entity.health;
+                energy += entity.energy;
+                inventory += entity.inventory;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = agents * (MODE() % 11 + 1) + health * 3 +
             energy * 5 + inventory * 7 + faction;
         metric.observe(inout out, projection, faction + MODE() % 5 + 1);
-        faction = faction + 1;
+        faction += 1;
     }
 }
 
@@ -150,17 +150,17 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
-                tiles = tiles + 1;
+                tiles += 1;
                 if tile.walkable { walkable = walkable + 1; }
-                resources = resources + tile.resource;
-                elevation = elevation + tile.height;
+                resources += tile.resource;
+                elevation += tile.height;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = tiles * (MODE() % 13 + 1) + walkable * 3 +
             resources * 5 + elevation * 7 + region;
         metric.observe(inout out, projection, region % 7 + 1);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/audit_navigation_entropy.rue
+++ b/examples/caldera/audit_navigation_entropy.rue
@@ -151,7 +151,7 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
                 tiles += 1;
-                if tile.walkable { walkable = walkable + 1; }
+                if tile.walkable { walkable += 1; }
                 resources += tile.resource;
                 elevation += tile.height;
             }

--- a/examples/caldera/audit_navigation_entropy.rue
+++ b/examples/caldera/audit_navigation_entropy.rue
@@ -63,7 +63,7 @@ fn observe_entities(inout out: metric.Metric, borrow world: model.World) {
         metric.observe(inout out, entity_projection(borrow world, i), (i % 11) + 1);
         metric.warn(inout out, item.alive && (item.x < 0 || item.y < 0 ||
             @intCast(item.x) >= world.width || @intCast(item.y) >= world.height));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -73,7 +73,7 @@ fn observe_tiles(inout out: metric.Metric, borrow world: model.World) {
         let item = world.tiles.get_or(i, model.empty_tile());
         metric.observe(inout out, tile_projection(borrow world, i), (i % 13) + 1);
         metric.warn(inout out, item.x >= world.width || item.y >= world.height);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -82,18 +82,18 @@ fn observe_timeline(inout out: metric.Metric, borrow world: model.World) {
     while i < world.events.len() {
         metric.observe(inout out, event_projection(borrow world, i), (i % 5) + 1);
         metric.warn(inout out, world.events.get_or(i, model.empty_event()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
         metric.observe(inout out, command_projection(borrow world, i), (i % 7) + 1);
         metric.warn(inout out, world.commands.get_or(i, model.empty_command()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.snapshots.len() {
         metric.observe(inout out, snapshot_projection(borrow world, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -108,9 +108,9 @@ fn observe_pairs(inout out: metric.Metric, borrow world: model.World) {
             let dy = if left.y > right.y { left.y - right.y } else { right.y - left.y };
             metric.observe(inout out, @intCast(dx + dy) +
                 left.faction * 3 + right.faction * 5 + MODE(), i + j + 1);
-            j = j + 1;
+            j += 1;
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -125,17 +125,17 @@ fn observe_factions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.entities.len() {
             let entity = world.entities.get_or(i, model.empty_entity());
             if entity.faction == faction && entity.alive {
-                agents = agents + 1;
-                health = health + entity.health;
-                energy = energy + entity.energy;
-                inventory = inventory + entity.inventory;
+                agents += 1;
+                health += entity.health;
+                energy += entity.energy;
+                inventory += entity.inventory;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = agents * (MODE() % 11 + 1) + health * 3 +
             energy * 5 + inventory * 7 + faction;
         metric.observe(inout out, projection, faction + MODE() % 5 + 1);
-        faction = faction + 1;
+        faction += 1;
     }
 }
 
@@ -150,17 +150,17 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
-                tiles = tiles + 1;
+                tiles += 1;
                 if tile.walkable { walkable = walkable + 1; }
-                resources = resources + tile.resource;
-                elevation = elevation + tile.height;
+                resources += tile.resource;
+                elevation += tile.height;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = tiles * (MODE() % 13 + 1) + walkable * 3 +
             resources * 5 + elevation * 7 + region;
         metric.observe(inout out, projection, region % 7 + 1);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/audit_navigation_fanout.rue
+++ b/examples/caldera/audit_navigation_fanout.rue
@@ -151,7 +151,7 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
                 tiles += 1;
-                if tile.walkable { walkable = walkable + 1; }
+                if tile.walkable { walkable += 1; }
                 resources += tile.resource;
                 elevation += tile.height;
             }

--- a/examples/caldera/audit_navigation_fanout.rue
+++ b/examples/caldera/audit_navigation_fanout.rue
@@ -63,7 +63,7 @@ fn observe_entities(inout out: metric.Metric, borrow world: model.World) {
         metric.observe(inout out, entity_projection(borrow world, i), (i % 11) + 1);
         metric.warn(inout out, item.alive && (item.x < 0 || item.y < 0 ||
             @intCast(item.x) >= world.width || @intCast(item.y) >= world.height));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -73,7 +73,7 @@ fn observe_tiles(inout out: metric.Metric, borrow world: model.World) {
         let item = world.tiles.get_or(i, model.empty_tile());
         metric.observe(inout out, tile_projection(borrow world, i), (i % 13) + 1);
         metric.warn(inout out, item.x >= world.width || item.y >= world.height);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -82,18 +82,18 @@ fn observe_timeline(inout out: metric.Metric, borrow world: model.World) {
     while i < world.events.len() {
         metric.observe(inout out, event_projection(borrow world, i), (i % 5) + 1);
         metric.warn(inout out, world.events.get_or(i, model.empty_event()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
         metric.observe(inout out, command_projection(borrow world, i), (i % 7) + 1);
         metric.warn(inout out, world.commands.get_or(i, model.empty_command()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.snapshots.len() {
         metric.observe(inout out, snapshot_projection(borrow world, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -108,9 +108,9 @@ fn observe_pairs(inout out: metric.Metric, borrow world: model.World) {
             let dy = if left.y > right.y { left.y - right.y } else { right.y - left.y };
             metric.observe(inout out, @intCast(dx + dy) +
                 left.faction * 3 + right.faction * 5 + MODE(), i + j + 1);
-            j = j + 1;
+            j += 1;
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -125,17 +125,17 @@ fn observe_factions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.entities.len() {
             let entity = world.entities.get_or(i, model.empty_entity());
             if entity.faction == faction && entity.alive {
-                agents = agents + 1;
-                health = health + entity.health;
-                energy = energy + entity.energy;
-                inventory = inventory + entity.inventory;
+                agents += 1;
+                health += entity.health;
+                energy += entity.energy;
+                inventory += entity.inventory;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = agents * (MODE() % 11 + 1) + health * 3 +
             energy * 5 + inventory * 7 + faction;
         metric.observe(inout out, projection, faction + MODE() % 5 + 1);
-        faction = faction + 1;
+        faction += 1;
     }
 }
 
@@ -150,17 +150,17 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
-                tiles = tiles + 1;
+                tiles += 1;
                 if tile.walkable { walkable = walkable + 1; }
-                resources = resources + tile.resource;
-                elevation = elevation + tile.height;
+                resources += tile.resource;
+                elevation += tile.height;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = tiles * (MODE() % 13 + 1) + walkable * 3 +
             resources * 5 + elevation * 7 + region;
         metric.observe(inout out, projection, region % 7 + 1);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/audit_navigation_integrity.rue
+++ b/examples/caldera/audit_navigation_integrity.rue
@@ -151,7 +151,7 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
                 tiles += 1;
-                if tile.walkable { walkable = walkable + 1; }
+                if tile.walkable { walkable += 1; }
                 resources += tile.resource;
                 elevation += tile.height;
             }

--- a/examples/caldera/audit_navigation_integrity.rue
+++ b/examples/caldera/audit_navigation_integrity.rue
@@ -63,7 +63,7 @@ fn observe_entities(inout out: metric.Metric, borrow world: model.World) {
         metric.observe(inout out, entity_projection(borrow world, i), (i % 11) + 1);
         metric.warn(inout out, item.alive && (item.x < 0 || item.y < 0 ||
             @intCast(item.x) >= world.width || @intCast(item.y) >= world.height));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -73,7 +73,7 @@ fn observe_tiles(inout out: metric.Metric, borrow world: model.World) {
         let item = world.tiles.get_or(i, model.empty_tile());
         metric.observe(inout out, tile_projection(borrow world, i), (i % 13) + 1);
         metric.warn(inout out, item.x >= world.width || item.y >= world.height);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -82,18 +82,18 @@ fn observe_timeline(inout out: metric.Metric, borrow world: model.World) {
     while i < world.events.len() {
         metric.observe(inout out, event_projection(borrow world, i), (i % 5) + 1);
         metric.warn(inout out, world.events.get_or(i, model.empty_event()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
         metric.observe(inout out, command_projection(borrow world, i), (i % 7) + 1);
         metric.warn(inout out, world.commands.get_or(i, model.empty_command()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.snapshots.len() {
         metric.observe(inout out, snapshot_projection(borrow world, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -108,9 +108,9 @@ fn observe_pairs(inout out: metric.Metric, borrow world: model.World) {
             let dy = if left.y > right.y { left.y - right.y } else { right.y - left.y };
             metric.observe(inout out, @intCast(dx + dy) +
                 left.faction * 3 + right.faction * 5 + MODE(), i + j + 1);
-            j = j + 1;
+            j += 1;
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -125,17 +125,17 @@ fn observe_factions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.entities.len() {
             let entity = world.entities.get_or(i, model.empty_entity());
             if entity.faction == faction && entity.alive {
-                agents = agents + 1;
-                health = health + entity.health;
-                energy = energy + entity.energy;
-                inventory = inventory + entity.inventory;
+                agents += 1;
+                health += entity.health;
+                energy += entity.energy;
+                inventory += entity.inventory;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = agents * (MODE() % 11 + 1) + health * 3 +
             energy * 5 + inventory * 7 + faction;
         metric.observe(inout out, projection, faction + MODE() % 5 + 1);
-        faction = faction + 1;
+        faction += 1;
     }
 }
 
@@ -150,17 +150,17 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
-                tiles = tiles + 1;
+                tiles += 1;
                 if tile.walkable { walkable = walkable + 1; }
-                resources = resources + tile.resource;
-                elevation = elevation + tile.height;
+                resources += tile.resource;
+                elevation += tile.height;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = tiles * (MODE() % 13 + 1) + walkable * 3 +
             resources * 5 + elevation * 7 + region;
         metric.observe(inout out, projection, region % 7 + 1);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/audit_navigation_latency.rue
+++ b/examples/caldera/audit_navigation_latency.rue
@@ -151,7 +151,7 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
                 tiles += 1;
-                if tile.walkable { walkable = walkable + 1; }
+                if tile.walkable { walkable += 1; }
                 resources += tile.resource;
                 elevation += tile.height;
             }

--- a/examples/caldera/audit_navigation_latency.rue
+++ b/examples/caldera/audit_navigation_latency.rue
@@ -63,7 +63,7 @@ fn observe_entities(inout out: metric.Metric, borrow world: model.World) {
         metric.observe(inout out, entity_projection(borrow world, i), (i % 11) + 1);
         metric.warn(inout out, item.alive && (item.x < 0 || item.y < 0 ||
             @intCast(item.x) >= world.width || @intCast(item.y) >= world.height));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -73,7 +73,7 @@ fn observe_tiles(inout out: metric.Metric, borrow world: model.World) {
         let item = world.tiles.get_or(i, model.empty_tile());
         metric.observe(inout out, tile_projection(borrow world, i), (i % 13) + 1);
         metric.warn(inout out, item.x >= world.width || item.y >= world.height);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -82,18 +82,18 @@ fn observe_timeline(inout out: metric.Metric, borrow world: model.World) {
     while i < world.events.len() {
         metric.observe(inout out, event_projection(borrow world, i), (i % 5) + 1);
         metric.warn(inout out, world.events.get_or(i, model.empty_event()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
         metric.observe(inout out, command_projection(borrow world, i), (i % 7) + 1);
         metric.warn(inout out, world.commands.get_or(i, model.empty_command()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.snapshots.len() {
         metric.observe(inout out, snapshot_projection(borrow world, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -108,9 +108,9 @@ fn observe_pairs(inout out: metric.Metric, borrow world: model.World) {
             let dy = if left.y > right.y { left.y - right.y } else { right.y - left.y };
             metric.observe(inout out, @intCast(dx + dy) +
                 left.faction * 3 + right.faction * 5 + MODE(), i + j + 1);
-            j = j + 1;
+            j += 1;
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -125,17 +125,17 @@ fn observe_factions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.entities.len() {
             let entity = world.entities.get_or(i, model.empty_entity());
             if entity.faction == faction && entity.alive {
-                agents = agents + 1;
-                health = health + entity.health;
-                energy = energy + entity.energy;
-                inventory = inventory + entity.inventory;
+                agents += 1;
+                health += entity.health;
+                energy += entity.energy;
+                inventory += entity.inventory;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = agents * (MODE() % 11 + 1) + health * 3 +
             energy * 5 + inventory * 7 + faction;
         metric.observe(inout out, projection, faction + MODE() % 5 + 1);
-        faction = faction + 1;
+        faction += 1;
     }
 }
 
@@ -150,17 +150,17 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
-                tiles = tiles + 1;
+                tiles += 1;
                 if tile.walkable { walkable = walkable + 1; }
-                resources = resources + tile.resource;
-                elevation = elevation + tile.height;
+                resources += tile.resource;
+                elevation += tile.height;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = tiles * (MODE() % 13 + 1) + walkable * 3 +
             resources * 5 + elevation * 7 + region;
         metric.observe(inout out, projection, region % 7 + 1);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/audit_navigation_locality.rue
+++ b/examples/caldera/audit_navigation_locality.rue
@@ -151,7 +151,7 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
                 tiles += 1;
-                if tile.walkable { walkable = walkable + 1; }
+                if tile.walkable { walkable += 1; }
                 resources += tile.resource;
                 elevation += tile.height;
             }

--- a/examples/caldera/audit_navigation_locality.rue
+++ b/examples/caldera/audit_navigation_locality.rue
@@ -63,7 +63,7 @@ fn observe_entities(inout out: metric.Metric, borrow world: model.World) {
         metric.observe(inout out, entity_projection(borrow world, i), (i % 11) + 1);
         metric.warn(inout out, item.alive && (item.x < 0 || item.y < 0 ||
             @intCast(item.x) >= world.width || @intCast(item.y) >= world.height));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -73,7 +73,7 @@ fn observe_tiles(inout out: metric.Metric, borrow world: model.World) {
         let item = world.tiles.get_or(i, model.empty_tile());
         metric.observe(inout out, tile_projection(borrow world, i), (i % 13) + 1);
         metric.warn(inout out, item.x >= world.width || item.y >= world.height);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -82,18 +82,18 @@ fn observe_timeline(inout out: metric.Metric, borrow world: model.World) {
     while i < world.events.len() {
         metric.observe(inout out, event_projection(borrow world, i), (i % 5) + 1);
         metric.warn(inout out, world.events.get_or(i, model.empty_event()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
         metric.observe(inout out, command_projection(borrow world, i), (i % 7) + 1);
         metric.warn(inout out, world.commands.get_or(i, model.empty_command()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.snapshots.len() {
         metric.observe(inout out, snapshot_projection(borrow world, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -108,9 +108,9 @@ fn observe_pairs(inout out: metric.Metric, borrow world: model.World) {
             let dy = if left.y > right.y { left.y - right.y } else { right.y - left.y };
             metric.observe(inout out, @intCast(dx + dy) +
                 left.faction * 3 + right.faction * 5 + MODE(), i + j + 1);
-            j = j + 1;
+            j += 1;
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -125,17 +125,17 @@ fn observe_factions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.entities.len() {
             let entity = world.entities.get_or(i, model.empty_entity());
             if entity.faction == faction && entity.alive {
-                agents = agents + 1;
-                health = health + entity.health;
-                energy = energy + entity.energy;
-                inventory = inventory + entity.inventory;
+                agents += 1;
+                health += entity.health;
+                energy += entity.energy;
+                inventory += entity.inventory;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = agents * (MODE() % 11 + 1) + health * 3 +
             energy * 5 + inventory * 7 + faction;
         metric.observe(inout out, projection, faction + MODE() % 5 + 1);
-        faction = faction + 1;
+        faction += 1;
     }
 }
 
@@ -150,17 +150,17 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
-                tiles = tiles + 1;
+                tiles += 1;
                 if tile.walkable { walkable = walkable + 1; }
-                resources = resources + tile.resource;
-                elevation = elevation + tile.height;
+                resources += tile.resource;
+                elevation += tile.height;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = tiles * (MODE() % 13 + 1) + walkable * 3 +
             resources * 5 + elevation * 7 + region;
         metric.observe(inout out, projection, region % 7 + 1);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/audit_navigation_pressure.rue
+++ b/examples/caldera/audit_navigation_pressure.rue
@@ -151,7 +151,7 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
                 tiles += 1;
-                if tile.walkable { walkable = walkable + 1; }
+                if tile.walkable { walkable += 1; }
                 resources += tile.resource;
                 elevation += tile.height;
             }

--- a/examples/caldera/audit_navigation_pressure.rue
+++ b/examples/caldera/audit_navigation_pressure.rue
@@ -63,7 +63,7 @@ fn observe_entities(inout out: metric.Metric, borrow world: model.World) {
         metric.observe(inout out, entity_projection(borrow world, i), (i % 11) + 1);
         metric.warn(inout out, item.alive && (item.x < 0 || item.y < 0 ||
             @intCast(item.x) >= world.width || @intCast(item.y) >= world.height));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -73,7 +73,7 @@ fn observe_tiles(inout out: metric.Metric, borrow world: model.World) {
         let item = world.tiles.get_or(i, model.empty_tile());
         metric.observe(inout out, tile_projection(borrow world, i), (i % 13) + 1);
         metric.warn(inout out, item.x >= world.width || item.y >= world.height);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -82,18 +82,18 @@ fn observe_timeline(inout out: metric.Metric, borrow world: model.World) {
     while i < world.events.len() {
         metric.observe(inout out, event_projection(borrow world, i), (i % 5) + 1);
         metric.warn(inout out, world.events.get_or(i, model.empty_event()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
         metric.observe(inout out, command_projection(borrow world, i), (i % 7) + 1);
         metric.warn(inout out, world.commands.get_or(i, model.empty_command()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.snapshots.len() {
         metric.observe(inout out, snapshot_projection(borrow world, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -108,9 +108,9 @@ fn observe_pairs(inout out: metric.Metric, borrow world: model.World) {
             let dy = if left.y > right.y { left.y - right.y } else { right.y - left.y };
             metric.observe(inout out, @intCast(dx + dy) +
                 left.faction * 3 + right.faction * 5 + MODE(), i + j + 1);
-            j = j + 1;
+            j += 1;
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -125,17 +125,17 @@ fn observe_factions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.entities.len() {
             let entity = world.entities.get_or(i, model.empty_entity());
             if entity.faction == faction && entity.alive {
-                agents = agents + 1;
-                health = health + entity.health;
-                energy = energy + entity.energy;
-                inventory = inventory + entity.inventory;
+                agents += 1;
+                health += entity.health;
+                energy += entity.energy;
+                inventory += entity.inventory;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = agents * (MODE() % 11 + 1) + health * 3 +
             energy * 5 + inventory * 7 + faction;
         metric.observe(inout out, projection, faction + MODE() % 5 + 1);
-        faction = faction + 1;
+        faction += 1;
     }
 }
 
@@ -150,17 +150,17 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
-                tiles = tiles + 1;
+                tiles += 1;
                 if tile.walkable { walkable = walkable + 1; }
-                resources = resources + tile.resource;
-                elevation = elevation + tile.height;
+                resources += tile.resource;
+                elevation += tile.height;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = tiles * (MODE() % 13 + 1) + walkable * 3 +
             resources * 5 + elevation * 7 + region;
         metric.observe(inout out, projection, region % 7 + 1);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/audit_navigation_risk.rue
+++ b/examples/caldera/audit_navigation_risk.rue
@@ -151,7 +151,7 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
                 tiles += 1;
-                if tile.walkable { walkable = walkable + 1; }
+                if tile.walkable { walkable += 1; }
                 resources += tile.resource;
                 elevation += tile.height;
             }

--- a/examples/caldera/audit_navigation_risk.rue
+++ b/examples/caldera/audit_navigation_risk.rue
@@ -63,7 +63,7 @@ fn observe_entities(inout out: metric.Metric, borrow world: model.World) {
         metric.observe(inout out, entity_projection(borrow world, i), (i % 11) + 1);
         metric.warn(inout out, item.alive && (item.x < 0 || item.y < 0 ||
             @intCast(item.x) >= world.width || @intCast(item.y) >= world.height));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -73,7 +73,7 @@ fn observe_tiles(inout out: metric.Metric, borrow world: model.World) {
         let item = world.tiles.get_or(i, model.empty_tile());
         metric.observe(inout out, tile_projection(borrow world, i), (i % 13) + 1);
         metric.warn(inout out, item.x >= world.width || item.y >= world.height);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -82,18 +82,18 @@ fn observe_timeline(inout out: metric.Metric, borrow world: model.World) {
     while i < world.events.len() {
         metric.observe(inout out, event_projection(borrow world, i), (i % 5) + 1);
         metric.warn(inout out, world.events.get_or(i, model.empty_event()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
         metric.observe(inout out, command_projection(borrow world, i), (i % 7) + 1);
         metric.warn(inout out, world.commands.get_or(i, model.empty_command()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.snapshots.len() {
         metric.observe(inout out, snapshot_projection(borrow world, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -108,9 +108,9 @@ fn observe_pairs(inout out: metric.Metric, borrow world: model.World) {
             let dy = if left.y > right.y { left.y - right.y } else { right.y - left.y };
             metric.observe(inout out, @intCast(dx + dy) +
                 left.faction * 3 + right.faction * 5 + MODE(), i + j + 1);
-            j = j + 1;
+            j += 1;
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -125,17 +125,17 @@ fn observe_factions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.entities.len() {
             let entity = world.entities.get_or(i, model.empty_entity());
             if entity.faction == faction && entity.alive {
-                agents = agents + 1;
-                health = health + entity.health;
-                energy = energy + entity.energy;
-                inventory = inventory + entity.inventory;
+                agents += 1;
+                health += entity.health;
+                energy += entity.energy;
+                inventory += entity.inventory;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = agents * (MODE() % 11 + 1) + health * 3 +
             energy * 5 + inventory * 7 + faction;
         metric.observe(inout out, projection, faction + MODE() % 5 + 1);
-        faction = faction + 1;
+        faction += 1;
     }
 }
 
@@ -150,17 +150,17 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
-                tiles = tiles + 1;
+                tiles += 1;
                 if tile.walkable { walkable = walkable + 1; }
-                resources = resources + tile.resource;
-                elevation = elevation + tile.height;
+                resources += tile.resource;
+                elevation += tile.height;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = tiles * (MODE() % 13 + 1) + walkable * 3 +
             resources * 5 + elevation * 7 + region;
         metric.observe(inout out, projection, region % 7 + 1);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/audit_navigation_skew.rue
+++ b/examples/caldera/audit_navigation_skew.rue
@@ -151,7 +151,7 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
                 tiles += 1;
-                if tile.walkable { walkable = walkable + 1; }
+                if tile.walkable { walkable += 1; }
                 resources += tile.resource;
                 elevation += tile.height;
             }

--- a/examples/caldera/audit_navigation_skew.rue
+++ b/examples/caldera/audit_navigation_skew.rue
@@ -63,7 +63,7 @@ fn observe_entities(inout out: metric.Metric, borrow world: model.World) {
         metric.observe(inout out, entity_projection(borrow world, i), (i % 11) + 1);
         metric.warn(inout out, item.alive && (item.x < 0 || item.y < 0 ||
             @intCast(item.x) >= world.width || @intCast(item.y) >= world.height));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -73,7 +73,7 @@ fn observe_tiles(inout out: metric.Metric, borrow world: model.World) {
         let item = world.tiles.get_or(i, model.empty_tile());
         metric.observe(inout out, tile_projection(borrow world, i), (i % 13) + 1);
         metric.warn(inout out, item.x >= world.width || item.y >= world.height);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -82,18 +82,18 @@ fn observe_timeline(inout out: metric.Metric, borrow world: model.World) {
     while i < world.events.len() {
         metric.observe(inout out, event_projection(borrow world, i), (i % 5) + 1);
         metric.warn(inout out, world.events.get_or(i, model.empty_event()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
         metric.observe(inout out, command_projection(borrow world, i), (i % 7) + 1);
         metric.warn(inout out, world.commands.get_or(i, model.empty_command()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.snapshots.len() {
         metric.observe(inout out, snapshot_projection(borrow world, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -108,9 +108,9 @@ fn observe_pairs(inout out: metric.Metric, borrow world: model.World) {
             let dy = if left.y > right.y { left.y - right.y } else { right.y - left.y };
             metric.observe(inout out, @intCast(dx + dy) +
                 left.faction * 3 + right.faction * 5 + MODE(), i + j + 1);
-            j = j + 1;
+            j += 1;
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -125,17 +125,17 @@ fn observe_factions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.entities.len() {
             let entity = world.entities.get_or(i, model.empty_entity());
             if entity.faction == faction && entity.alive {
-                agents = agents + 1;
-                health = health + entity.health;
-                energy = energy + entity.energy;
-                inventory = inventory + entity.inventory;
+                agents += 1;
+                health += entity.health;
+                energy += entity.energy;
+                inventory += entity.inventory;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = agents * (MODE() % 11 + 1) + health * 3 +
             energy * 5 + inventory * 7 + faction;
         metric.observe(inout out, projection, faction + MODE() % 5 + 1);
-        faction = faction + 1;
+        faction += 1;
     }
 }
 
@@ -150,17 +150,17 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
-                tiles = tiles + 1;
+                tiles += 1;
                 if tile.walkable { walkable = walkable + 1; }
-                resources = resources + tile.resource;
-                elevation = elevation + tile.height;
+                resources += tile.resource;
+                elevation += tile.height;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = tiles * (MODE() % 13 + 1) + walkable * 3 +
             resources * 5 + elevation * 7 + region;
         metric.observe(inout out, projection, region % 7 + 1);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/audit_navigation_stability.rue
+++ b/examples/caldera/audit_navigation_stability.rue
@@ -151,7 +151,7 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
                 tiles += 1;
-                if tile.walkable { walkable = walkable + 1; }
+                if tile.walkable { walkable += 1; }
                 resources += tile.resource;
                 elevation += tile.height;
             }

--- a/examples/caldera/audit_navigation_stability.rue
+++ b/examples/caldera/audit_navigation_stability.rue
@@ -63,7 +63,7 @@ fn observe_entities(inout out: metric.Metric, borrow world: model.World) {
         metric.observe(inout out, entity_projection(borrow world, i), (i % 11) + 1);
         metric.warn(inout out, item.alive && (item.x < 0 || item.y < 0 ||
             @intCast(item.x) >= world.width || @intCast(item.y) >= world.height));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -73,7 +73,7 @@ fn observe_tiles(inout out: metric.Metric, borrow world: model.World) {
         let item = world.tiles.get_or(i, model.empty_tile());
         metric.observe(inout out, tile_projection(borrow world, i), (i % 13) + 1);
         metric.warn(inout out, item.x >= world.width || item.y >= world.height);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -82,18 +82,18 @@ fn observe_timeline(inout out: metric.Metric, borrow world: model.World) {
     while i < world.events.len() {
         metric.observe(inout out, event_projection(borrow world, i), (i % 5) + 1);
         metric.warn(inout out, world.events.get_or(i, model.empty_event()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
         metric.observe(inout out, command_projection(borrow world, i), (i % 7) + 1);
         metric.warn(inout out, world.commands.get_or(i, model.empty_command()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.snapshots.len() {
         metric.observe(inout out, snapshot_projection(borrow world, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -108,9 +108,9 @@ fn observe_pairs(inout out: metric.Metric, borrow world: model.World) {
             let dy = if left.y > right.y { left.y - right.y } else { right.y - left.y };
             metric.observe(inout out, @intCast(dx + dy) +
                 left.faction * 3 + right.faction * 5 + MODE(), i + j + 1);
-            j = j + 1;
+            j += 1;
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -125,17 +125,17 @@ fn observe_factions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.entities.len() {
             let entity = world.entities.get_or(i, model.empty_entity());
             if entity.faction == faction && entity.alive {
-                agents = agents + 1;
-                health = health + entity.health;
-                energy = energy + entity.energy;
-                inventory = inventory + entity.inventory;
+                agents += 1;
+                health += entity.health;
+                energy += entity.energy;
+                inventory += entity.inventory;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = agents * (MODE() % 11 + 1) + health * 3 +
             energy * 5 + inventory * 7 + faction;
         metric.observe(inout out, projection, faction + MODE() % 5 + 1);
-        faction = faction + 1;
+        faction += 1;
     }
 }
 
@@ -150,17 +150,17 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
-                tiles = tiles + 1;
+                tiles += 1;
                 if tile.walkable { walkable = walkable + 1; }
-                resources = resources + tile.resource;
-                elevation = elevation + tile.height;
+                resources += tile.resource;
+                elevation += tile.height;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = tiles * (MODE() % 13 + 1) + walkable * 3 +
             resources * 5 + elevation * 7 + region;
         metric.observe(inout out, projection, region % 7 + 1);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/audit_navigation_throughput.rue
+++ b/examples/caldera/audit_navigation_throughput.rue
@@ -151,7 +151,7 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
                 tiles += 1;
-                if tile.walkable { walkable = walkable + 1; }
+                if tile.walkable { walkable += 1; }
                 resources += tile.resource;
                 elevation += tile.height;
             }

--- a/examples/caldera/audit_navigation_throughput.rue
+++ b/examples/caldera/audit_navigation_throughput.rue
@@ -63,7 +63,7 @@ fn observe_entities(inout out: metric.Metric, borrow world: model.World) {
         metric.observe(inout out, entity_projection(borrow world, i), (i % 11) + 1);
         metric.warn(inout out, item.alive && (item.x < 0 || item.y < 0 ||
             @intCast(item.x) >= world.width || @intCast(item.y) >= world.height));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -73,7 +73,7 @@ fn observe_tiles(inout out: metric.Metric, borrow world: model.World) {
         let item = world.tiles.get_or(i, model.empty_tile());
         metric.observe(inout out, tile_projection(borrow world, i), (i % 13) + 1);
         metric.warn(inout out, item.x >= world.width || item.y >= world.height);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -82,18 +82,18 @@ fn observe_timeline(inout out: metric.Metric, borrow world: model.World) {
     while i < world.events.len() {
         metric.observe(inout out, event_projection(borrow world, i), (i % 5) + 1);
         metric.warn(inout out, world.events.get_or(i, model.empty_event()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
         metric.observe(inout out, command_projection(borrow world, i), (i % 7) + 1);
         metric.warn(inout out, world.commands.get_or(i, model.empty_command()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.snapshots.len() {
         metric.observe(inout out, snapshot_projection(borrow world, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -108,9 +108,9 @@ fn observe_pairs(inout out: metric.Metric, borrow world: model.World) {
             let dy = if left.y > right.y { left.y - right.y } else { right.y - left.y };
             metric.observe(inout out, @intCast(dx + dy) +
                 left.faction * 3 + right.faction * 5 + MODE(), i + j + 1);
-            j = j + 1;
+            j += 1;
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -125,17 +125,17 @@ fn observe_factions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.entities.len() {
             let entity = world.entities.get_or(i, model.empty_entity());
             if entity.faction == faction && entity.alive {
-                agents = agents + 1;
-                health = health + entity.health;
-                energy = energy + entity.energy;
-                inventory = inventory + entity.inventory;
+                agents += 1;
+                health += entity.health;
+                energy += entity.energy;
+                inventory += entity.inventory;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = agents * (MODE() % 11 + 1) + health * 3 +
             energy * 5 + inventory * 7 + faction;
         metric.observe(inout out, projection, faction + MODE() % 5 + 1);
-        faction = faction + 1;
+        faction += 1;
     }
 }
 
@@ -150,17 +150,17 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
-                tiles = tiles + 1;
+                tiles += 1;
                 if tile.walkable { walkable = walkable + 1; }
-                resources = resources + tile.resource;
-                elevation = elevation + tile.height;
+                resources += tile.resource;
+                elevation += tile.height;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = tiles * (MODE() % 13 + 1) + walkable * 3 +
             resources * 5 + elevation * 7 + region;
         metric.observe(inout out, projection, region % 7 + 1);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/audit_network_balance.rue
+++ b/examples/caldera/audit_network_balance.rue
@@ -151,7 +151,7 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
                 tiles += 1;
-                if tile.walkable { walkable = walkable + 1; }
+                if tile.walkable { walkable += 1; }
                 resources += tile.resource;
                 elevation += tile.height;
             }

--- a/examples/caldera/audit_network_balance.rue
+++ b/examples/caldera/audit_network_balance.rue
@@ -63,7 +63,7 @@ fn observe_entities(inout out: metric.Metric, borrow world: model.World) {
         metric.observe(inout out, entity_projection(borrow world, i), (i % 11) + 1);
         metric.warn(inout out, item.alive && (item.x < 0 || item.y < 0 ||
             @intCast(item.x) >= world.width || @intCast(item.y) >= world.height));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -73,7 +73,7 @@ fn observe_tiles(inout out: metric.Metric, borrow world: model.World) {
         let item = world.tiles.get_or(i, model.empty_tile());
         metric.observe(inout out, tile_projection(borrow world, i), (i % 13) + 1);
         metric.warn(inout out, item.x >= world.width || item.y >= world.height);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -82,18 +82,18 @@ fn observe_timeline(inout out: metric.Metric, borrow world: model.World) {
     while i < world.events.len() {
         metric.observe(inout out, event_projection(borrow world, i), (i % 5) + 1);
         metric.warn(inout out, world.events.get_or(i, model.empty_event()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
         metric.observe(inout out, command_projection(borrow world, i), (i % 7) + 1);
         metric.warn(inout out, world.commands.get_or(i, model.empty_command()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.snapshots.len() {
         metric.observe(inout out, snapshot_projection(borrow world, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -108,9 +108,9 @@ fn observe_pairs(inout out: metric.Metric, borrow world: model.World) {
             let dy = if left.y > right.y { left.y - right.y } else { right.y - left.y };
             metric.observe(inout out, @intCast(dx + dy) +
                 left.faction * 3 + right.faction * 5 + MODE(), i + j + 1);
-            j = j + 1;
+            j += 1;
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -125,17 +125,17 @@ fn observe_factions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.entities.len() {
             let entity = world.entities.get_or(i, model.empty_entity());
             if entity.faction == faction && entity.alive {
-                agents = agents + 1;
-                health = health + entity.health;
-                energy = energy + entity.energy;
-                inventory = inventory + entity.inventory;
+                agents += 1;
+                health += entity.health;
+                energy += entity.energy;
+                inventory += entity.inventory;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = agents * (MODE() % 11 + 1) + health * 3 +
             energy * 5 + inventory * 7 + faction;
         metric.observe(inout out, projection, faction + MODE() % 5 + 1);
-        faction = faction + 1;
+        faction += 1;
     }
 }
 
@@ -150,17 +150,17 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
-                tiles = tiles + 1;
+                tiles += 1;
                 if tile.walkable { walkable = walkable + 1; }
-                resources = resources + tile.resource;
-                elevation = elevation + tile.height;
+                resources += tile.resource;
+                elevation += tile.height;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = tiles * (MODE() % 13 + 1) + walkable * 3 +
             resources * 5 + elevation * 7 + region;
         metric.observe(inout out, projection, region % 7 + 1);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/audit_network_capacity.rue
+++ b/examples/caldera/audit_network_capacity.rue
@@ -151,7 +151,7 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
                 tiles += 1;
-                if tile.walkable { walkable = walkable + 1; }
+                if tile.walkable { walkable += 1; }
                 resources += tile.resource;
                 elevation += tile.height;
             }

--- a/examples/caldera/audit_network_capacity.rue
+++ b/examples/caldera/audit_network_capacity.rue
@@ -63,7 +63,7 @@ fn observe_entities(inout out: metric.Metric, borrow world: model.World) {
         metric.observe(inout out, entity_projection(borrow world, i), (i % 11) + 1);
         metric.warn(inout out, item.alive && (item.x < 0 || item.y < 0 ||
             @intCast(item.x) >= world.width || @intCast(item.y) >= world.height));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -73,7 +73,7 @@ fn observe_tiles(inout out: metric.Metric, borrow world: model.World) {
         let item = world.tiles.get_or(i, model.empty_tile());
         metric.observe(inout out, tile_projection(borrow world, i), (i % 13) + 1);
         metric.warn(inout out, item.x >= world.width || item.y >= world.height);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -82,18 +82,18 @@ fn observe_timeline(inout out: metric.Metric, borrow world: model.World) {
     while i < world.events.len() {
         metric.observe(inout out, event_projection(borrow world, i), (i % 5) + 1);
         metric.warn(inout out, world.events.get_or(i, model.empty_event()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
         metric.observe(inout out, command_projection(borrow world, i), (i % 7) + 1);
         metric.warn(inout out, world.commands.get_or(i, model.empty_command()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.snapshots.len() {
         metric.observe(inout out, snapshot_projection(borrow world, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -108,9 +108,9 @@ fn observe_pairs(inout out: metric.Metric, borrow world: model.World) {
             let dy = if left.y > right.y { left.y - right.y } else { right.y - left.y };
             metric.observe(inout out, @intCast(dx + dy) +
                 left.faction * 3 + right.faction * 5 + MODE(), i + j + 1);
-            j = j + 1;
+            j += 1;
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -125,17 +125,17 @@ fn observe_factions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.entities.len() {
             let entity = world.entities.get_or(i, model.empty_entity());
             if entity.faction == faction && entity.alive {
-                agents = agents + 1;
-                health = health + entity.health;
-                energy = energy + entity.energy;
-                inventory = inventory + entity.inventory;
+                agents += 1;
+                health += entity.health;
+                energy += entity.energy;
+                inventory += entity.inventory;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = agents * (MODE() % 11 + 1) + health * 3 +
             energy * 5 + inventory * 7 + faction;
         metric.observe(inout out, projection, faction + MODE() % 5 + 1);
-        faction = faction + 1;
+        faction += 1;
     }
 }
 
@@ -150,17 +150,17 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
-                tiles = tiles + 1;
+                tiles += 1;
                 if tile.walkable { walkable = walkable + 1; }
-                resources = resources + tile.resource;
-                elevation = elevation + tile.height;
+                resources += tile.resource;
+                elevation += tile.height;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = tiles * (MODE() % 13 + 1) + walkable * 3 +
             resources * 5 + elevation * 7 + region;
         metric.observe(inout out, projection, region % 7 + 1);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/audit_network_continuity.rue
+++ b/examples/caldera/audit_network_continuity.rue
@@ -151,7 +151,7 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
                 tiles += 1;
-                if tile.walkable { walkable = walkable + 1; }
+                if tile.walkable { walkable += 1; }
                 resources += tile.resource;
                 elevation += tile.height;
             }

--- a/examples/caldera/audit_network_continuity.rue
+++ b/examples/caldera/audit_network_continuity.rue
@@ -63,7 +63,7 @@ fn observe_entities(inout out: metric.Metric, borrow world: model.World) {
         metric.observe(inout out, entity_projection(borrow world, i), (i % 11) + 1);
         metric.warn(inout out, item.alive && (item.x < 0 || item.y < 0 ||
             @intCast(item.x) >= world.width || @intCast(item.y) >= world.height));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -73,7 +73,7 @@ fn observe_tiles(inout out: metric.Metric, borrow world: model.World) {
         let item = world.tiles.get_or(i, model.empty_tile());
         metric.observe(inout out, tile_projection(borrow world, i), (i % 13) + 1);
         metric.warn(inout out, item.x >= world.width || item.y >= world.height);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -82,18 +82,18 @@ fn observe_timeline(inout out: metric.Metric, borrow world: model.World) {
     while i < world.events.len() {
         metric.observe(inout out, event_projection(borrow world, i), (i % 5) + 1);
         metric.warn(inout out, world.events.get_or(i, model.empty_event()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
         metric.observe(inout out, command_projection(borrow world, i), (i % 7) + 1);
         metric.warn(inout out, world.commands.get_or(i, model.empty_command()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.snapshots.len() {
         metric.observe(inout out, snapshot_projection(borrow world, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -108,9 +108,9 @@ fn observe_pairs(inout out: metric.Metric, borrow world: model.World) {
             let dy = if left.y > right.y { left.y - right.y } else { right.y - left.y };
             metric.observe(inout out, @intCast(dx + dy) +
                 left.faction * 3 + right.faction * 5 + MODE(), i + j + 1);
-            j = j + 1;
+            j += 1;
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -125,17 +125,17 @@ fn observe_factions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.entities.len() {
             let entity = world.entities.get_or(i, model.empty_entity());
             if entity.faction == faction && entity.alive {
-                agents = agents + 1;
-                health = health + entity.health;
-                energy = energy + entity.energy;
-                inventory = inventory + entity.inventory;
+                agents += 1;
+                health += entity.health;
+                energy += entity.energy;
+                inventory += entity.inventory;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = agents * (MODE() % 11 + 1) + health * 3 +
             energy * 5 + inventory * 7 + faction;
         metric.observe(inout out, projection, faction + MODE() % 5 + 1);
-        faction = faction + 1;
+        faction += 1;
     }
 }
 
@@ -150,17 +150,17 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
-                tiles = tiles + 1;
+                tiles += 1;
                 if tile.walkable { walkable = walkable + 1; }
-                resources = resources + tile.resource;
-                elevation = elevation + tile.height;
+                resources += tile.resource;
+                elevation += tile.height;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = tiles * (MODE() % 13 + 1) + walkable * 3 +
             resources * 5 + elevation * 7 + region;
         metric.observe(inout out, projection, region % 7 + 1);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/audit_network_cost.rue
+++ b/examples/caldera/audit_network_cost.rue
@@ -151,7 +151,7 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
                 tiles += 1;
-                if tile.walkable { walkable = walkable + 1; }
+                if tile.walkable { walkable += 1; }
                 resources += tile.resource;
                 elevation += tile.height;
             }

--- a/examples/caldera/audit_network_cost.rue
+++ b/examples/caldera/audit_network_cost.rue
@@ -63,7 +63,7 @@ fn observe_entities(inout out: metric.Metric, borrow world: model.World) {
         metric.observe(inout out, entity_projection(borrow world, i), (i % 11) + 1);
         metric.warn(inout out, item.alive && (item.x < 0 || item.y < 0 ||
             @intCast(item.x) >= world.width || @intCast(item.y) >= world.height));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -73,7 +73,7 @@ fn observe_tiles(inout out: metric.Metric, borrow world: model.World) {
         let item = world.tiles.get_or(i, model.empty_tile());
         metric.observe(inout out, tile_projection(borrow world, i), (i % 13) + 1);
         metric.warn(inout out, item.x >= world.width || item.y >= world.height);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -82,18 +82,18 @@ fn observe_timeline(inout out: metric.Metric, borrow world: model.World) {
     while i < world.events.len() {
         metric.observe(inout out, event_projection(borrow world, i), (i % 5) + 1);
         metric.warn(inout out, world.events.get_or(i, model.empty_event()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
         metric.observe(inout out, command_projection(borrow world, i), (i % 7) + 1);
         metric.warn(inout out, world.commands.get_or(i, model.empty_command()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.snapshots.len() {
         metric.observe(inout out, snapshot_projection(borrow world, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -108,9 +108,9 @@ fn observe_pairs(inout out: metric.Metric, borrow world: model.World) {
             let dy = if left.y > right.y { left.y - right.y } else { right.y - left.y };
             metric.observe(inout out, @intCast(dx + dy) +
                 left.faction * 3 + right.faction * 5 + MODE(), i + j + 1);
-            j = j + 1;
+            j += 1;
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -125,17 +125,17 @@ fn observe_factions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.entities.len() {
             let entity = world.entities.get_or(i, model.empty_entity());
             if entity.faction == faction && entity.alive {
-                agents = agents + 1;
-                health = health + entity.health;
-                energy = energy + entity.energy;
-                inventory = inventory + entity.inventory;
+                agents += 1;
+                health += entity.health;
+                energy += entity.energy;
+                inventory += entity.inventory;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = agents * (MODE() % 11 + 1) + health * 3 +
             energy * 5 + inventory * 7 + faction;
         metric.observe(inout out, projection, faction + MODE() % 5 + 1);
-        faction = faction + 1;
+        faction += 1;
     }
 }
 
@@ -150,17 +150,17 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
-                tiles = tiles + 1;
+                tiles += 1;
                 if tile.walkable { walkable = walkable + 1; }
-                resources = resources + tile.resource;
-                elevation = elevation + tile.height;
+                resources += tile.resource;
+                elevation += tile.height;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = tiles * (MODE() % 13 + 1) + walkable * 3 +
             resources * 5 + elevation * 7 + region;
         metric.observe(inout out, projection, region % 7 + 1);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/audit_network_coverage.rue
+++ b/examples/caldera/audit_network_coverage.rue
@@ -151,7 +151,7 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
                 tiles += 1;
-                if tile.walkable { walkable = walkable + 1; }
+                if tile.walkable { walkable += 1; }
                 resources += tile.resource;
                 elevation += tile.height;
             }

--- a/examples/caldera/audit_network_coverage.rue
+++ b/examples/caldera/audit_network_coverage.rue
@@ -63,7 +63,7 @@ fn observe_entities(inout out: metric.Metric, borrow world: model.World) {
         metric.observe(inout out, entity_projection(borrow world, i), (i % 11) + 1);
         metric.warn(inout out, item.alive && (item.x < 0 || item.y < 0 ||
             @intCast(item.x) >= world.width || @intCast(item.y) >= world.height));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -73,7 +73,7 @@ fn observe_tiles(inout out: metric.Metric, borrow world: model.World) {
         let item = world.tiles.get_or(i, model.empty_tile());
         metric.observe(inout out, tile_projection(borrow world, i), (i % 13) + 1);
         metric.warn(inout out, item.x >= world.width || item.y >= world.height);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -82,18 +82,18 @@ fn observe_timeline(inout out: metric.Metric, borrow world: model.World) {
     while i < world.events.len() {
         metric.observe(inout out, event_projection(borrow world, i), (i % 5) + 1);
         metric.warn(inout out, world.events.get_or(i, model.empty_event()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
         metric.observe(inout out, command_projection(borrow world, i), (i % 7) + 1);
         metric.warn(inout out, world.commands.get_or(i, model.empty_command()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.snapshots.len() {
         metric.observe(inout out, snapshot_projection(borrow world, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -108,9 +108,9 @@ fn observe_pairs(inout out: metric.Metric, borrow world: model.World) {
             let dy = if left.y > right.y { left.y - right.y } else { right.y - left.y };
             metric.observe(inout out, @intCast(dx + dy) +
                 left.faction * 3 + right.faction * 5 + MODE(), i + j + 1);
-            j = j + 1;
+            j += 1;
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -125,17 +125,17 @@ fn observe_factions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.entities.len() {
             let entity = world.entities.get_or(i, model.empty_entity());
             if entity.faction == faction && entity.alive {
-                agents = agents + 1;
-                health = health + entity.health;
-                energy = energy + entity.energy;
-                inventory = inventory + entity.inventory;
+                agents += 1;
+                health += entity.health;
+                energy += entity.energy;
+                inventory += entity.inventory;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = agents * (MODE() % 11 + 1) + health * 3 +
             energy * 5 + inventory * 7 + faction;
         metric.observe(inout out, projection, faction + MODE() % 5 + 1);
-        faction = faction + 1;
+        faction += 1;
     }
 }
 
@@ -150,17 +150,17 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
-                tiles = tiles + 1;
+                tiles += 1;
                 if tile.walkable { walkable = walkable + 1; }
-                resources = resources + tile.resource;
-                elevation = elevation + tile.height;
+                resources += tile.resource;
+                elevation += tile.height;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = tiles * (MODE() % 13 + 1) + walkable * 3 +
             resources * 5 + elevation * 7 + region;
         metric.observe(inout out, projection, region % 7 + 1);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/audit_network_density.rue
+++ b/examples/caldera/audit_network_density.rue
@@ -151,7 +151,7 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
                 tiles += 1;
-                if tile.walkable { walkable = walkable + 1; }
+                if tile.walkable { walkable += 1; }
                 resources += tile.resource;
                 elevation += tile.height;
             }

--- a/examples/caldera/audit_network_density.rue
+++ b/examples/caldera/audit_network_density.rue
@@ -63,7 +63,7 @@ fn observe_entities(inout out: metric.Metric, borrow world: model.World) {
         metric.observe(inout out, entity_projection(borrow world, i), (i % 11) + 1);
         metric.warn(inout out, item.alive && (item.x < 0 || item.y < 0 ||
             @intCast(item.x) >= world.width || @intCast(item.y) >= world.height));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -73,7 +73,7 @@ fn observe_tiles(inout out: metric.Metric, borrow world: model.World) {
         let item = world.tiles.get_or(i, model.empty_tile());
         metric.observe(inout out, tile_projection(borrow world, i), (i % 13) + 1);
         metric.warn(inout out, item.x >= world.width || item.y >= world.height);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -82,18 +82,18 @@ fn observe_timeline(inout out: metric.Metric, borrow world: model.World) {
     while i < world.events.len() {
         metric.observe(inout out, event_projection(borrow world, i), (i % 5) + 1);
         metric.warn(inout out, world.events.get_or(i, model.empty_event()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
         metric.observe(inout out, command_projection(borrow world, i), (i % 7) + 1);
         metric.warn(inout out, world.commands.get_or(i, model.empty_command()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.snapshots.len() {
         metric.observe(inout out, snapshot_projection(borrow world, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -108,9 +108,9 @@ fn observe_pairs(inout out: metric.Metric, borrow world: model.World) {
             let dy = if left.y > right.y { left.y - right.y } else { right.y - left.y };
             metric.observe(inout out, @intCast(dx + dy) +
                 left.faction * 3 + right.faction * 5 + MODE(), i + j + 1);
-            j = j + 1;
+            j += 1;
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -125,17 +125,17 @@ fn observe_factions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.entities.len() {
             let entity = world.entities.get_or(i, model.empty_entity());
             if entity.faction == faction && entity.alive {
-                agents = agents + 1;
-                health = health + entity.health;
-                energy = energy + entity.energy;
-                inventory = inventory + entity.inventory;
+                agents += 1;
+                health += entity.health;
+                energy += entity.energy;
+                inventory += entity.inventory;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = agents * (MODE() % 11 + 1) + health * 3 +
             energy * 5 + inventory * 7 + faction;
         metric.observe(inout out, projection, faction + MODE() % 5 + 1);
-        faction = faction + 1;
+        faction += 1;
     }
 }
 
@@ -150,17 +150,17 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
-                tiles = tiles + 1;
+                tiles += 1;
                 if tile.walkable { walkable = walkable + 1; }
-                resources = resources + tile.resource;
-                elevation = elevation + tile.height;
+                resources += tile.resource;
+                elevation += tile.height;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = tiles * (MODE() % 13 + 1) + walkable * 3 +
             resources * 5 + elevation * 7 + region;
         metric.observe(inout out, projection, region % 7 + 1);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/audit_network_entropy.rue
+++ b/examples/caldera/audit_network_entropy.rue
@@ -151,7 +151,7 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
                 tiles += 1;
-                if tile.walkable { walkable = walkable + 1; }
+                if tile.walkable { walkable += 1; }
                 resources += tile.resource;
                 elevation += tile.height;
             }

--- a/examples/caldera/audit_network_entropy.rue
+++ b/examples/caldera/audit_network_entropy.rue
@@ -63,7 +63,7 @@ fn observe_entities(inout out: metric.Metric, borrow world: model.World) {
         metric.observe(inout out, entity_projection(borrow world, i), (i % 11) + 1);
         metric.warn(inout out, item.alive && (item.x < 0 || item.y < 0 ||
             @intCast(item.x) >= world.width || @intCast(item.y) >= world.height));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -73,7 +73,7 @@ fn observe_tiles(inout out: metric.Metric, borrow world: model.World) {
         let item = world.tiles.get_or(i, model.empty_tile());
         metric.observe(inout out, tile_projection(borrow world, i), (i % 13) + 1);
         metric.warn(inout out, item.x >= world.width || item.y >= world.height);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -82,18 +82,18 @@ fn observe_timeline(inout out: metric.Metric, borrow world: model.World) {
     while i < world.events.len() {
         metric.observe(inout out, event_projection(borrow world, i), (i % 5) + 1);
         metric.warn(inout out, world.events.get_or(i, model.empty_event()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
         metric.observe(inout out, command_projection(borrow world, i), (i % 7) + 1);
         metric.warn(inout out, world.commands.get_or(i, model.empty_command()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.snapshots.len() {
         metric.observe(inout out, snapshot_projection(borrow world, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -108,9 +108,9 @@ fn observe_pairs(inout out: metric.Metric, borrow world: model.World) {
             let dy = if left.y > right.y { left.y - right.y } else { right.y - left.y };
             metric.observe(inout out, @intCast(dx + dy) +
                 left.faction * 3 + right.faction * 5 + MODE(), i + j + 1);
-            j = j + 1;
+            j += 1;
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -125,17 +125,17 @@ fn observe_factions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.entities.len() {
             let entity = world.entities.get_or(i, model.empty_entity());
             if entity.faction == faction && entity.alive {
-                agents = agents + 1;
-                health = health + entity.health;
-                energy = energy + entity.energy;
-                inventory = inventory + entity.inventory;
+                agents += 1;
+                health += entity.health;
+                energy += entity.energy;
+                inventory += entity.inventory;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = agents * (MODE() % 11 + 1) + health * 3 +
             energy * 5 + inventory * 7 + faction;
         metric.observe(inout out, projection, faction + MODE() % 5 + 1);
-        faction = faction + 1;
+        faction += 1;
     }
 }
 
@@ -150,17 +150,17 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
-                tiles = tiles + 1;
+                tiles += 1;
                 if tile.walkable { walkable = walkable + 1; }
-                resources = resources + tile.resource;
-                elevation = elevation + tile.height;
+                resources += tile.resource;
+                elevation += tile.height;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = tiles * (MODE() % 13 + 1) + walkable * 3 +
             resources * 5 + elevation * 7 + region;
         metric.observe(inout out, projection, region % 7 + 1);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/audit_network_fanout.rue
+++ b/examples/caldera/audit_network_fanout.rue
@@ -151,7 +151,7 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
                 tiles += 1;
-                if tile.walkable { walkable = walkable + 1; }
+                if tile.walkable { walkable += 1; }
                 resources += tile.resource;
                 elevation += tile.height;
             }

--- a/examples/caldera/audit_network_fanout.rue
+++ b/examples/caldera/audit_network_fanout.rue
@@ -63,7 +63,7 @@ fn observe_entities(inout out: metric.Metric, borrow world: model.World) {
         metric.observe(inout out, entity_projection(borrow world, i), (i % 11) + 1);
         metric.warn(inout out, item.alive && (item.x < 0 || item.y < 0 ||
             @intCast(item.x) >= world.width || @intCast(item.y) >= world.height));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -73,7 +73,7 @@ fn observe_tiles(inout out: metric.Metric, borrow world: model.World) {
         let item = world.tiles.get_or(i, model.empty_tile());
         metric.observe(inout out, tile_projection(borrow world, i), (i % 13) + 1);
         metric.warn(inout out, item.x >= world.width || item.y >= world.height);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -82,18 +82,18 @@ fn observe_timeline(inout out: metric.Metric, borrow world: model.World) {
     while i < world.events.len() {
         metric.observe(inout out, event_projection(borrow world, i), (i % 5) + 1);
         metric.warn(inout out, world.events.get_or(i, model.empty_event()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
         metric.observe(inout out, command_projection(borrow world, i), (i % 7) + 1);
         metric.warn(inout out, world.commands.get_or(i, model.empty_command()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.snapshots.len() {
         metric.observe(inout out, snapshot_projection(borrow world, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -108,9 +108,9 @@ fn observe_pairs(inout out: metric.Metric, borrow world: model.World) {
             let dy = if left.y > right.y { left.y - right.y } else { right.y - left.y };
             metric.observe(inout out, @intCast(dx + dy) +
                 left.faction * 3 + right.faction * 5 + MODE(), i + j + 1);
-            j = j + 1;
+            j += 1;
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -125,17 +125,17 @@ fn observe_factions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.entities.len() {
             let entity = world.entities.get_or(i, model.empty_entity());
             if entity.faction == faction && entity.alive {
-                agents = agents + 1;
-                health = health + entity.health;
-                energy = energy + entity.energy;
-                inventory = inventory + entity.inventory;
+                agents += 1;
+                health += entity.health;
+                energy += entity.energy;
+                inventory += entity.inventory;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = agents * (MODE() % 11 + 1) + health * 3 +
             energy * 5 + inventory * 7 + faction;
         metric.observe(inout out, projection, faction + MODE() % 5 + 1);
-        faction = faction + 1;
+        faction += 1;
     }
 }
 
@@ -150,17 +150,17 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
-                tiles = tiles + 1;
+                tiles += 1;
                 if tile.walkable { walkable = walkable + 1; }
-                resources = resources + tile.resource;
-                elevation = elevation + tile.height;
+                resources += tile.resource;
+                elevation += tile.height;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = tiles * (MODE() % 13 + 1) + walkable * 3 +
             resources * 5 + elevation * 7 + region;
         metric.observe(inout out, projection, region % 7 + 1);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/audit_network_integrity.rue
+++ b/examples/caldera/audit_network_integrity.rue
@@ -151,7 +151,7 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
                 tiles += 1;
-                if tile.walkable { walkable = walkable + 1; }
+                if tile.walkable { walkable += 1; }
                 resources += tile.resource;
                 elevation += tile.height;
             }

--- a/examples/caldera/audit_network_integrity.rue
+++ b/examples/caldera/audit_network_integrity.rue
@@ -63,7 +63,7 @@ fn observe_entities(inout out: metric.Metric, borrow world: model.World) {
         metric.observe(inout out, entity_projection(borrow world, i), (i % 11) + 1);
         metric.warn(inout out, item.alive && (item.x < 0 || item.y < 0 ||
             @intCast(item.x) >= world.width || @intCast(item.y) >= world.height));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -73,7 +73,7 @@ fn observe_tiles(inout out: metric.Metric, borrow world: model.World) {
         let item = world.tiles.get_or(i, model.empty_tile());
         metric.observe(inout out, tile_projection(borrow world, i), (i % 13) + 1);
         metric.warn(inout out, item.x >= world.width || item.y >= world.height);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -82,18 +82,18 @@ fn observe_timeline(inout out: metric.Metric, borrow world: model.World) {
     while i < world.events.len() {
         metric.observe(inout out, event_projection(borrow world, i), (i % 5) + 1);
         metric.warn(inout out, world.events.get_or(i, model.empty_event()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
         metric.observe(inout out, command_projection(borrow world, i), (i % 7) + 1);
         metric.warn(inout out, world.commands.get_or(i, model.empty_command()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.snapshots.len() {
         metric.observe(inout out, snapshot_projection(borrow world, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -108,9 +108,9 @@ fn observe_pairs(inout out: metric.Metric, borrow world: model.World) {
             let dy = if left.y > right.y { left.y - right.y } else { right.y - left.y };
             metric.observe(inout out, @intCast(dx + dy) +
                 left.faction * 3 + right.faction * 5 + MODE(), i + j + 1);
-            j = j + 1;
+            j += 1;
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -125,17 +125,17 @@ fn observe_factions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.entities.len() {
             let entity = world.entities.get_or(i, model.empty_entity());
             if entity.faction == faction && entity.alive {
-                agents = agents + 1;
-                health = health + entity.health;
-                energy = energy + entity.energy;
-                inventory = inventory + entity.inventory;
+                agents += 1;
+                health += entity.health;
+                energy += entity.energy;
+                inventory += entity.inventory;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = agents * (MODE() % 11 + 1) + health * 3 +
             energy * 5 + inventory * 7 + faction;
         metric.observe(inout out, projection, faction + MODE() % 5 + 1);
-        faction = faction + 1;
+        faction += 1;
     }
 }
 
@@ -150,17 +150,17 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
-                tiles = tiles + 1;
+                tiles += 1;
                 if tile.walkable { walkable = walkable + 1; }
-                resources = resources + tile.resource;
-                elevation = elevation + tile.height;
+                resources += tile.resource;
+                elevation += tile.height;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = tiles * (MODE() % 13 + 1) + walkable * 3 +
             resources * 5 + elevation * 7 + region;
         metric.observe(inout out, projection, region % 7 + 1);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/audit_network_latency.rue
+++ b/examples/caldera/audit_network_latency.rue
@@ -151,7 +151,7 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
                 tiles += 1;
-                if tile.walkable { walkable = walkable + 1; }
+                if tile.walkable { walkable += 1; }
                 resources += tile.resource;
                 elevation += tile.height;
             }

--- a/examples/caldera/audit_network_latency.rue
+++ b/examples/caldera/audit_network_latency.rue
@@ -63,7 +63,7 @@ fn observe_entities(inout out: metric.Metric, borrow world: model.World) {
         metric.observe(inout out, entity_projection(borrow world, i), (i % 11) + 1);
         metric.warn(inout out, item.alive && (item.x < 0 || item.y < 0 ||
             @intCast(item.x) >= world.width || @intCast(item.y) >= world.height));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -73,7 +73,7 @@ fn observe_tiles(inout out: metric.Metric, borrow world: model.World) {
         let item = world.tiles.get_or(i, model.empty_tile());
         metric.observe(inout out, tile_projection(borrow world, i), (i % 13) + 1);
         metric.warn(inout out, item.x >= world.width || item.y >= world.height);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -82,18 +82,18 @@ fn observe_timeline(inout out: metric.Metric, borrow world: model.World) {
     while i < world.events.len() {
         metric.observe(inout out, event_projection(borrow world, i), (i % 5) + 1);
         metric.warn(inout out, world.events.get_or(i, model.empty_event()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
         metric.observe(inout out, command_projection(borrow world, i), (i % 7) + 1);
         metric.warn(inout out, world.commands.get_or(i, model.empty_command()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.snapshots.len() {
         metric.observe(inout out, snapshot_projection(borrow world, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -108,9 +108,9 @@ fn observe_pairs(inout out: metric.Metric, borrow world: model.World) {
             let dy = if left.y > right.y { left.y - right.y } else { right.y - left.y };
             metric.observe(inout out, @intCast(dx + dy) +
                 left.faction * 3 + right.faction * 5 + MODE(), i + j + 1);
-            j = j + 1;
+            j += 1;
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -125,17 +125,17 @@ fn observe_factions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.entities.len() {
             let entity = world.entities.get_or(i, model.empty_entity());
             if entity.faction == faction && entity.alive {
-                agents = agents + 1;
-                health = health + entity.health;
-                energy = energy + entity.energy;
-                inventory = inventory + entity.inventory;
+                agents += 1;
+                health += entity.health;
+                energy += entity.energy;
+                inventory += entity.inventory;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = agents * (MODE() % 11 + 1) + health * 3 +
             energy * 5 + inventory * 7 + faction;
         metric.observe(inout out, projection, faction + MODE() % 5 + 1);
-        faction = faction + 1;
+        faction += 1;
     }
 }
 
@@ -150,17 +150,17 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
-                tiles = tiles + 1;
+                tiles += 1;
                 if tile.walkable { walkable = walkable + 1; }
-                resources = resources + tile.resource;
-                elevation = elevation + tile.height;
+                resources += tile.resource;
+                elevation += tile.height;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = tiles * (MODE() % 13 + 1) + walkable * 3 +
             resources * 5 + elevation * 7 + region;
         metric.observe(inout out, projection, region % 7 + 1);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/audit_network_locality.rue
+++ b/examples/caldera/audit_network_locality.rue
@@ -151,7 +151,7 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
                 tiles += 1;
-                if tile.walkable { walkable = walkable + 1; }
+                if tile.walkable { walkable += 1; }
                 resources += tile.resource;
                 elevation += tile.height;
             }

--- a/examples/caldera/audit_network_locality.rue
+++ b/examples/caldera/audit_network_locality.rue
@@ -63,7 +63,7 @@ fn observe_entities(inout out: metric.Metric, borrow world: model.World) {
         metric.observe(inout out, entity_projection(borrow world, i), (i % 11) + 1);
         metric.warn(inout out, item.alive && (item.x < 0 || item.y < 0 ||
             @intCast(item.x) >= world.width || @intCast(item.y) >= world.height));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -73,7 +73,7 @@ fn observe_tiles(inout out: metric.Metric, borrow world: model.World) {
         let item = world.tiles.get_or(i, model.empty_tile());
         metric.observe(inout out, tile_projection(borrow world, i), (i % 13) + 1);
         metric.warn(inout out, item.x >= world.width || item.y >= world.height);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -82,18 +82,18 @@ fn observe_timeline(inout out: metric.Metric, borrow world: model.World) {
     while i < world.events.len() {
         metric.observe(inout out, event_projection(borrow world, i), (i % 5) + 1);
         metric.warn(inout out, world.events.get_or(i, model.empty_event()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
         metric.observe(inout out, command_projection(borrow world, i), (i % 7) + 1);
         metric.warn(inout out, world.commands.get_or(i, model.empty_command()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.snapshots.len() {
         metric.observe(inout out, snapshot_projection(borrow world, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -108,9 +108,9 @@ fn observe_pairs(inout out: metric.Metric, borrow world: model.World) {
             let dy = if left.y > right.y { left.y - right.y } else { right.y - left.y };
             metric.observe(inout out, @intCast(dx + dy) +
                 left.faction * 3 + right.faction * 5 + MODE(), i + j + 1);
-            j = j + 1;
+            j += 1;
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -125,17 +125,17 @@ fn observe_factions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.entities.len() {
             let entity = world.entities.get_or(i, model.empty_entity());
             if entity.faction == faction && entity.alive {
-                agents = agents + 1;
-                health = health + entity.health;
-                energy = energy + entity.energy;
-                inventory = inventory + entity.inventory;
+                agents += 1;
+                health += entity.health;
+                energy += entity.energy;
+                inventory += entity.inventory;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = agents * (MODE() % 11 + 1) + health * 3 +
             energy * 5 + inventory * 7 + faction;
         metric.observe(inout out, projection, faction + MODE() % 5 + 1);
-        faction = faction + 1;
+        faction += 1;
     }
 }
 
@@ -150,17 +150,17 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
-                tiles = tiles + 1;
+                tiles += 1;
                 if tile.walkable { walkable = walkable + 1; }
-                resources = resources + tile.resource;
-                elevation = elevation + tile.height;
+                resources += tile.resource;
+                elevation += tile.height;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = tiles * (MODE() % 13 + 1) + walkable * 3 +
             resources * 5 + elevation * 7 + region;
         metric.observe(inout out, projection, region % 7 + 1);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/audit_network_pressure.rue
+++ b/examples/caldera/audit_network_pressure.rue
@@ -151,7 +151,7 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
                 tiles += 1;
-                if tile.walkable { walkable = walkable + 1; }
+                if tile.walkable { walkable += 1; }
                 resources += tile.resource;
                 elevation += tile.height;
             }

--- a/examples/caldera/audit_network_pressure.rue
+++ b/examples/caldera/audit_network_pressure.rue
@@ -63,7 +63,7 @@ fn observe_entities(inout out: metric.Metric, borrow world: model.World) {
         metric.observe(inout out, entity_projection(borrow world, i), (i % 11) + 1);
         metric.warn(inout out, item.alive && (item.x < 0 || item.y < 0 ||
             @intCast(item.x) >= world.width || @intCast(item.y) >= world.height));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -73,7 +73,7 @@ fn observe_tiles(inout out: metric.Metric, borrow world: model.World) {
         let item = world.tiles.get_or(i, model.empty_tile());
         metric.observe(inout out, tile_projection(borrow world, i), (i % 13) + 1);
         metric.warn(inout out, item.x >= world.width || item.y >= world.height);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -82,18 +82,18 @@ fn observe_timeline(inout out: metric.Metric, borrow world: model.World) {
     while i < world.events.len() {
         metric.observe(inout out, event_projection(borrow world, i), (i % 5) + 1);
         metric.warn(inout out, world.events.get_or(i, model.empty_event()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
         metric.observe(inout out, command_projection(borrow world, i), (i % 7) + 1);
         metric.warn(inout out, world.commands.get_or(i, model.empty_command()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.snapshots.len() {
         metric.observe(inout out, snapshot_projection(borrow world, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -108,9 +108,9 @@ fn observe_pairs(inout out: metric.Metric, borrow world: model.World) {
             let dy = if left.y > right.y { left.y - right.y } else { right.y - left.y };
             metric.observe(inout out, @intCast(dx + dy) +
                 left.faction * 3 + right.faction * 5 + MODE(), i + j + 1);
-            j = j + 1;
+            j += 1;
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -125,17 +125,17 @@ fn observe_factions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.entities.len() {
             let entity = world.entities.get_or(i, model.empty_entity());
             if entity.faction == faction && entity.alive {
-                agents = agents + 1;
-                health = health + entity.health;
-                energy = energy + entity.energy;
-                inventory = inventory + entity.inventory;
+                agents += 1;
+                health += entity.health;
+                energy += entity.energy;
+                inventory += entity.inventory;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = agents * (MODE() % 11 + 1) + health * 3 +
             energy * 5 + inventory * 7 + faction;
         metric.observe(inout out, projection, faction + MODE() % 5 + 1);
-        faction = faction + 1;
+        faction += 1;
     }
 }
 
@@ -150,17 +150,17 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
-                tiles = tiles + 1;
+                tiles += 1;
                 if tile.walkable { walkable = walkable + 1; }
-                resources = resources + tile.resource;
-                elevation = elevation + tile.height;
+                resources += tile.resource;
+                elevation += tile.height;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = tiles * (MODE() % 13 + 1) + walkable * 3 +
             resources * 5 + elevation * 7 + region;
         metric.observe(inout out, projection, region % 7 + 1);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/audit_network_risk.rue
+++ b/examples/caldera/audit_network_risk.rue
@@ -151,7 +151,7 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
                 tiles += 1;
-                if tile.walkable { walkable = walkable + 1; }
+                if tile.walkable { walkable += 1; }
                 resources += tile.resource;
                 elevation += tile.height;
             }

--- a/examples/caldera/audit_network_risk.rue
+++ b/examples/caldera/audit_network_risk.rue
@@ -63,7 +63,7 @@ fn observe_entities(inout out: metric.Metric, borrow world: model.World) {
         metric.observe(inout out, entity_projection(borrow world, i), (i % 11) + 1);
         metric.warn(inout out, item.alive && (item.x < 0 || item.y < 0 ||
             @intCast(item.x) >= world.width || @intCast(item.y) >= world.height));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -73,7 +73,7 @@ fn observe_tiles(inout out: metric.Metric, borrow world: model.World) {
         let item = world.tiles.get_or(i, model.empty_tile());
         metric.observe(inout out, tile_projection(borrow world, i), (i % 13) + 1);
         metric.warn(inout out, item.x >= world.width || item.y >= world.height);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -82,18 +82,18 @@ fn observe_timeline(inout out: metric.Metric, borrow world: model.World) {
     while i < world.events.len() {
         metric.observe(inout out, event_projection(borrow world, i), (i % 5) + 1);
         metric.warn(inout out, world.events.get_or(i, model.empty_event()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
         metric.observe(inout out, command_projection(borrow world, i), (i % 7) + 1);
         metric.warn(inout out, world.commands.get_or(i, model.empty_command()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.snapshots.len() {
         metric.observe(inout out, snapshot_projection(borrow world, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -108,9 +108,9 @@ fn observe_pairs(inout out: metric.Metric, borrow world: model.World) {
             let dy = if left.y > right.y { left.y - right.y } else { right.y - left.y };
             metric.observe(inout out, @intCast(dx + dy) +
                 left.faction * 3 + right.faction * 5 + MODE(), i + j + 1);
-            j = j + 1;
+            j += 1;
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -125,17 +125,17 @@ fn observe_factions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.entities.len() {
             let entity = world.entities.get_or(i, model.empty_entity());
             if entity.faction == faction && entity.alive {
-                agents = agents + 1;
-                health = health + entity.health;
-                energy = energy + entity.energy;
-                inventory = inventory + entity.inventory;
+                agents += 1;
+                health += entity.health;
+                energy += entity.energy;
+                inventory += entity.inventory;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = agents * (MODE() % 11 + 1) + health * 3 +
             energy * 5 + inventory * 7 + faction;
         metric.observe(inout out, projection, faction + MODE() % 5 + 1);
-        faction = faction + 1;
+        faction += 1;
     }
 }
 
@@ -150,17 +150,17 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
-                tiles = tiles + 1;
+                tiles += 1;
                 if tile.walkable { walkable = walkable + 1; }
-                resources = resources + tile.resource;
-                elevation = elevation + tile.height;
+                resources += tile.resource;
+                elevation += tile.height;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = tiles * (MODE() % 13 + 1) + walkable * 3 +
             resources * 5 + elevation * 7 + region;
         metric.observe(inout out, projection, region % 7 + 1);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/audit_network_skew.rue
+++ b/examples/caldera/audit_network_skew.rue
@@ -151,7 +151,7 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
                 tiles += 1;
-                if tile.walkable { walkable = walkable + 1; }
+                if tile.walkable { walkable += 1; }
                 resources += tile.resource;
                 elevation += tile.height;
             }

--- a/examples/caldera/audit_network_skew.rue
+++ b/examples/caldera/audit_network_skew.rue
@@ -63,7 +63,7 @@ fn observe_entities(inout out: metric.Metric, borrow world: model.World) {
         metric.observe(inout out, entity_projection(borrow world, i), (i % 11) + 1);
         metric.warn(inout out, item.alive && (item.x < 0 || item.y < 0 ||
             @intCast(item.x) >= world.width || @intCast(item.y) >= world.height));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -73,7 +73,7 @@ fn observe_tiles(inout out: metric.Metric, borrow world: model.World) {
         let item = world.tiles.get_or(i, model.empty_tile());
         metric.observe(inout out, tile_projection(borrow world, i), (i % 13) + 1);
         metric.warn(inout out, item.x >= world.width || item.y >= world.height);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -82,18 +82,18 @@ fn observe_timeline(inout out: metric.Metric, borrow world: model.World) {
     while i < world.events.len() {
         metric.observe(inout out, event_projection(borrow world, i), (i % 5) + 1);
         metric.warn(inout out, world.events.get_or(i, model.empty_event()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
         metric.observe(inout out, command_projection(borrow world, i), (i % 7) + 1);
         metric.warn(inout out, world.commands.get_or(i, model.empty_command()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.snapshots.len() {
         metric.observe(inout out, snapshot_projection(borrow world, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -108,9 +108,9 @@ fn observe_pairs(inout out: metric.Metric, borrow world: model.World) {
             let dy = if left.y > right.y { left.y - right.y } else { right.y - left.y };
             metric.observe(inout out, @intCast(dx + dy) +
                 left.faction * 3 + right.faction * 5 + MODE(), i + j + 1);
-            j = j + 1;
+            j += 1;
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -125,17 +125,17 @@ fn observe_factions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.entities.len() {
             let entity = world.entities.get_or(i, model.empty_entity());
             if entity.faction == faction && entity.alive {
-                agents = agents + 1;
-                health = health + entity.health;
-                energy = energy + entity.energy;
-                inventory = inventory + entity.inventory;
+                agents += 1;
+                health += entity.health;
+                energy += entity.energy;
+                inventory += entity.inventory;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = agents * (MODE() % 11 + 1) + health * 3 +
             energy * 5 + inventory * 7 + faction;
         metric.observe(inout out, projection, faction + MODE() % 5 + 1);
-        faction = faction + 1;
+        faction += 1;
     }
 }
 
@@ -150,17 +150,17 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
-                tiles = tiles + 1;
+                tiles += 1;
                 if tile.walkable { walkable = walkable + 1; }
-                resources = resources + tile.resource;
-                elevation = elevation + tile.height;
+                resources += tile.resource;
+                elevation += tile.height;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = tiles * (MODE() % 13 + 1) + walkable * 3 +
             resources * 5 + elevation * 7 + region;
         metric.observe(inout out, projection, region % 7 + 1);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/audit_network_stability.rue
+++ b/examples/caldera/audit_network_stability.rue
@@ -151,7 +151,7 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
                 tiles += 1;
-                if tile.walkable { walkable = walkable + 1; }
+                if tile.walkable { walkable += 1; }
                 resources += tile.resource;
                 elevation += tile.height;
             }

--- a/examples/caldera/audit_network_stability.rue
+++ b/examples/caldera/audit_network_stability.rue
@@ -63,7 +63,7 @@ fn observe_entities(inout out: metric.Metric, borrow world: model.World) {
         metric.observe(inout out, entity_projection(borrow world, i), (i % 11) + 1);
         metric.warn(inout out, item.alive && (item.x < 0 || item.y < 0 ||
             @intCast(item.x) >= world.width || @intCast(item.y) >= world.height));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -73,7 +73,7 @@ fn observe_tiles(inout out: metric.Metric, borrow world: model.World) {
         let item = world.tiles.get_or(i, model.empty_tile());
         metric.observe(inout out, tile_projection(borrow world, i), (i % 13) + 1);
         metric.warn(inout out, item.x >= world.width || item.y >= world.height);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -82,18 +82,18 @@ fn observe_timeline(inout out: metric.Metric, borrow world: model.World) {
     while i < world.events.len() {
         metric.observe(inout out, event_projection(borrow world, i), (i % 5) + 1);
         metric.warn(inout out, world.events.get_or(i, model.empty_event()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
         metric.observe(inout out, command_projection(borrow world, i), (i % 7) + 1);
         metric.warn(inout out, world.commands.get_or(i, model.empty_command()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.snapshots.len() {
         metric.observe(inout out, snapshot_projection(borrow world, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -108,9 +108,9 @@ fn observe_pairs(inout out: metric.Metric, borrow world: model.World) {
             let dy = if left.y > right.y { left.y - right.y } else { right.y - left.y };
             metric.observe(inout out, @intCast(dx + dy) +
                 left.faction * 3 + right.faction * 5 + MODE(), i + j + 1);
-            j = j + 1;
+            j += 1;
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -125,17 +125,17 @@ fn observe_factions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.entities.len() {
             let entity = world.entities.get_or(i, model.empty_entity());
             if entity.faction == faction && entity.alive {
-                agents = agents + 1;
-                health = health + entity.health;
-                energy = energy + entity.energy;
-                inventory = inventory + entity.inventory;
+                agents += 1;
+                health += entity.health;
+                energy += entity.energy;
+                inventory += entity.inventory;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = agents * (MODE() % 11 + 1) + health * 3 +
             energy * 5 + inventory * 7 + faction;
         metric.observe(inout out, projection, faction + MODE() % 5 + 1);
-        faction = faction + 1;
+        faction += 1;
     }
 }
 
@@ -150,17 +150,17 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
-                tiles = tiles + 1;
+                tiles += 1;
                 if tile.walkable { walkable = walkable + 1; }
-                resources = resources + tile.resource;
-                elevation = elevation + tile.height;
+                resources += tile.resource;
+                elevation += tile.height;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = tiles * (MODE() % 13 + 1) + walkable * 3 +
             resources * 5 + elevation * 7 + region;
         metric.observe(inout out, projection, region % 7 + 1);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/audit_network_throughput.rue
+++ b/examples/caldera/audit_network_throughput.rue
@@ -151,7 +151,7 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
                 tiles += 1;
-                if tile.walkable { walkable = walkable + 1; }
+                if tile.walkable { walkable += 1; }
                 resources += tile.resource;
                 elevation += tile.height;
             }

--- a/examples/caldera/audit_network_throughput.rue
+++ b/examples/caldera/audit_network_throughput.rue
@@ -63,7 +63,7 @@ fn observe_entities(inout out: metric.Metric, borrow world: model.World) {
         metric.observe(inout out, entity_projection(borrow world, i), (i % 11) + 1);
         metric.warn(inout out, item.alive && (item.x < 0 || item.y < 0 ||
             @intCast(item.x) >= world.width || @intCast(item.y) >= world.height));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -73,7 +73,7 @@ fn observe_tiles(inout out: metric.Metric, borrow world: model.World) {
         let item = world.tiles.get_or(i, model.empty_tile());
         metric.observe(inout out, tile_projection(borrow world, i), (i % 13) + 1);
         metric.warn(inout out, item.x >= world.width || item.y >= world.height);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -82,18 +82,18 @@ fn observe_timeline(inout out: metric.Metric, borrow world: model.World) {
     while i < world.events.len() {
         metric.observe(inout out, event_projection(borrow world, i), (i % 5) + 1);
         metric.warn(inout out, world.events.get_or(i, model.empty_event()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
         metric.observe(inout out, command_projection(borrow world, i), (i % 7) + 1);
         metric.warn(inout out, world.commands.get_or(i, model.empty_command()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.snapshots.len() {
         metric.observe(inout out, snapshot_projection(borrow world, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -108,9 +108,9 @@ fn observe_pairs(inout out: metric.Metric, borrow world: model.World) {
             let dy = if left.y > right.y { left.y - right.y } else { right.y - left.y };
             metric.observe(inout out, @intCast(dx + dy) +
                 left.faction * 3 + right.faction * 5 + MODE(), i + j + 1);
-            j = j + 1;
+            j += 1;
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -125,17 +125,17 @@ fn observe_factions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.entities.len() {
             let entity = world.entities.get_or(i, model.empty_entity());
             if entity.faction == faction && entity.alive {
-                agents = agents + 1;
-                health = health + entity.health;
-                energy = energy + entity.energy;
-                inventory = inventory + entity.inventory;
+                agents += 1;
+                health += entity.health;
+                energy += entity.energy;
+                inventory += entity.inventory;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = agents * (MODE() % 11 + 1) + health * 3 +
             energy * 5 + inventory * 7 + faction;
         metric.observe(inout out, projection, faction + MODE() % 5 + 1);
-        faction = faction + 1;
+        faction += 1;
     }
 }
 
@@ -150,17 +150,17 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
-                tiles = tiles + 1;
+                tiles += 1;
                 if tile.walkable { walkable = walkable + 1; }
-                resources = resources + tile.resource;
-                elevation = elevation + tile.height;
+                resources += tile.resource;
+                elevation += tile.height;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = tiles * (MODE() % 13 + 1) + walkable * 3 +
             resources * 5 + elevation * 7 + region;
         metric.observe(inout out, projection, region % 7 + 1);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/audit_physics_balance.rue
+++ b/examples/caldera/audit_physics_balance.rue
@@ -151,7 +151,7 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
                 tiles += 1;
-                if tile.walkable { walkable = walkable + 1; }
+                if tile.walkable { walkable += 1; }
                 resources += tile.resource;
                 elevation += tile.height;
             }

--- a/examples/caldera/audit_physics_balance.rue
+++ b/examples/caldera/audit_physics_balance.rue
@@ -63,7 +63,7 @@ fn observe_entities(inout out: metric.Metric, borrow world: model.World) {
         metric.observe(inout out, entity_projection(borrow world, i), (i % 11) + 1);
         metric.warn(inout out, item.alive && (item.x < 0 || item.y < 0 ||
             @intCast(item.x) >= world.width || @intCast(item.y) >= world.height));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -73,7 +73,7 @@ fn observe_tiles(inout out: metric.Metric, borrow world: model.World) {
         let item = world.tiles.get_or(i, model.empty_tile());
         metric.observe(inout out, tile_projection(borrow world, i), (i % 13) + 1);
         metric.warn(inout out, item.x >= world.width || item.y >= world.height);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -82,18 +82,18 @@ fn observe_timeline(inout out: metric.Metric, borrow world: model.World) {
     while i < world.events.len() {
         metric.observe(inout out, event_projection(borrow world, i), (i % 5) + 1);
         metric.warn(inout out, world.events.get_or(i, model.empty_event()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
         metric.observe(inout out, command_projection(borrow world, i), (i % 7) + 1);
         metric.warn(inout out, world.commands.get_or(i, model.empty_command()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.snapshots.len() {
         metric.observe(inout out, snapshot_projection(borrow world, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -108,9 +108,9 @@ fn observe_pairs(inout out: metric.Metric, borrow world: model.World) {
             let dy = if left.y > right.y { left.y - right.y } else { right.y - left.y };
             metric.observe(inout out, @intCast(dx + dy) +
                 left.faction * 3 + right.faction * 5 + MODE(), i + j + 1);
-            j = j + 1;
+            j += 1;
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -125,17 +125,17 @@ fn observe_factions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.entities.len() {
             let entity = world.entities.get_or(i, model.empty_entity());
             if entity.faction == faction && entity.alive {
-                agents = agents + 1;
-                health = health + entity.health;
-                energy = energy + entity.energy;
-                inventory = inventory + entity.inventory;
+                agents += 1;
+                health += entity.health;
+                energy += entity.energy;
+                inventory += entity.inventory;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = agents * (MODE() % 11 + 1) + health * 3 +
             energy * 5 + inventory * 7 + faction;
         metric.observe(inout out, projection, faction + MODE() % 5 + 1);
-        faction = faction + 1;
+        faction += 1;
     }
 }
 
@@ -150,17 +150,17 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
-                tiles = tiles + 1;
+                tiles += 1;
                 if tile.walkable { walkable = walkable + 1; }
-                resources = resources + tile.resource;
-                elevation = elevation + tile.height;
+                resources += tile.resource;
+                elevation += tile.height;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = tiles * (MODE() % 13 + 1) + walkable * 3 +
             resources * 5 + elevation * 7 + region;
         metric.observe(inout out, projection, region % 7 + 1);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/audit_physics_capacity.rue
+++ b/examples/caldera/audit_physics_capacity.rue
@@ -151,7 +151,7 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
                 tiles += 1;
-                if tile.walkable { walkable = walkable + 1; }
+                if tile.walkable { walkable += 1; }
                 resources += tile.resource;
                 elevation += tile.height;
             }

--- a/examples/caldera/audit_physics_capacity.rue
+++ b/examples/caldera/audit_physics_capacity.rue
@@ -63,7 +63,7 @@ fn observe_entities(inout out: metric.Metric, borrow world: model.World) {
         metric.observe(inout out, entity_projection(borrow world, i), (i % 11) + 1);
         metric.warn(inout out, item.alive && (item.x < 0 || item.y < 0 ||
             @intCast(item.x) >= world.width || @intCast(item.y) >= world.height));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -73,7 +73,7 @@ fn observe_tiles(inout out: metric.Metric, borrow world: model.World) {
         let item = world.tiles.get_or(i, model.empty_tile());
         metric.observe(inout out, tile_projection(borrow world, i), (i % 13) + 1);
         metric.warn(inout out, item.x >= world.width || item.y >= world.height);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -82,18 +82,18 @@ fn observe_timeline(inout out: metric.Metric, borrow world: model.World) {
     while i < world.events.len() {
         metric.observe(inout out, event_projection(borrow world, i), (i % 5) + 1);
         metric.warn(inout out, world.events.get_or(i, model.empty_event()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
         metric.observe(inout out, command_projection(borrow world, i), (i % 7) + 1);
         metric.warn(inout out, world.commands.get_or(i, model.empty_command()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.snapshots.len() {
         metric.observe(inout out, snapshot_projection(borrow world, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -108,9 +108,9 @@ fn observe_pairs(inout out: metric.Metric, borrow world: model.World) {
             let dy = if left.y > right.y { left.y - right.y } else { right.y - left.y };
             metric.observe(inout out, @intCast(dx + dy) +
                 left.faction * 3 + right.faction * 5 + MODE(), i + j + 1);
-            j = j + 1;
+            j += 1;
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -125,17 +125,17 @@ fn observe_factions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.entities.len() {
             let entity = world.entities.get_or(i, model.empty_entity());
             if entity.faction == faction && entity.alive {
-                agents = agents + 1;
-                health = health + entity.health;
-                energy = energy + entity.energy;
-                inventory = inventory + entity.inventory;
+                agents += 1;
+                health += entity.health;
+                energy += entity.energy;
+                inventory += entity.inventory;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = agents * (MODE() % 11 + 1) + health * 3 +
             energy * 5 + inventory * 7 + faction;
         metric.observe(inout out, projection, faction + MODE() % 5 + 1);
-        faction = faction + 1;
+        faction += 1;
     }
 }
 
@@ -150,17 +150,17 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
-                tiles = tiles + 1;
+                tiles += 1;
                 if tile.walkable { walkable = walkable + 1; }
-                resources = resources + tile.resource;
-                elevation = elevation + tile.height;
+                resources += tile.resource;
+                elevation += tile.height;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = tiles * (MODE() % 13 + 1) + walkable * 3 +
             resources * 5 + elevation * 7 + region;
         metric.observe(inout out, projection, region % 7 + 1);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/audit_physics_continuity.rue
+++ b/examples/caldera/audit_physics_continuity.rue
@@ -151,7 +151,7 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
                 tiles += 1;
-                if tile.walkable { walkable = walkable + 1; }
+                if tile.walkable { walkable += 1; }
                 resources += tile.resource;
                 elevation += tile.height;
             }

--- a/examples/caldera/audit_physics_continuity.rue
+++ b/examples/caldera/audit_physics_continuity.rue
@@ -63,7 +63,7 @@ fn observe_entities(inout out: metric.Metric, borrow world: model.World) {
         metric.observe(inout out, entity_projection(borrow world, i), (i % 11) + 1);
         metric.warn(inout out, item.alive && (item.x < 0 || item.y < 0 ||
             @intCast(item.x) >= world.width || @intCast(item.y) >= world.height));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -73,7 +73,7 @@ fn observe_tiles(inout out: metric.Metric, borrow world: model.World) {
         let item = world.tiles.get_or(i, model.empty_tile());
         metric.observe(inout out, tile_projection(borrow world, i), (i % 13) + 1);
         metric.warn(inout out, item.x >= world.width || item.y >= world.height);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -82,18 +82,18 @@ fn observe_timeline(inout out: metric.Metric, borrow world: model.World) {
     while i < world.events.len() {
         metric.observe(inout out, event_projection(borrow world, i), (i % 5) + 1);
         metric.warn(inout out, world.events.get_or(i, model.empty_event()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
         metric.observe(inout out, command_projection(borrow world, i), (i % 7) + 1);
         metric.warn(inout out, world.commands.get_or(i, model.empty_command()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.snapshots.len() {
         metric.observe(inout out, snapshot_projection(borrow world, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -108,9 +108,9 @@ fn observe_pairs(inout out: metric.Metric, borrow world: model.World) {
             let dy = if left.y > right.y { left.y - right.y } else { right.y - left.y };
             metric.observe(inout out, @intCast(dx + dy) +
                 left.faction * 3 + right.faction * 5 + MODE(), i + j + 1);
-            j = j + 1;
+            j += 1;
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -125,17 +125,17 @@ fn observe_factions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.entities.len() {
             let entity = world.entities.get_or(i, model.empty_entity());
             if entity.faction == faction && entity.alive {
-                agents = agents + 1;
-                health = health + entity.health;
-                energy = energy + entity.energy;
-                inventory = inventory + entity.inventory;
+                agents += 1;
+                health += entity.health;
+                energy += entity.energy;
+                inventory += entity.inventory;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = agents * (MODE() % 11 + 1) + health * 3 +
             energy * 5 + inventory * 7 + faction;
         metric.observe(inout out, projection, faction + MODE() % 5 + 1);
-        faction = faction + 1;
+        faction += 1;
     }
 }
 
@@ -150,17 +150,17 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
-                tiles = tiles + 1;
+                tiles += 1;
                 if tile.walkable { walkable = walkable + 1; }
-                resources = resources + tile.resource;
-                elevation = elevation + tile.height;
+                resources += tile.resource;
+                elevation += tile.height;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = tiles * (MODE() % 13 + 1) + walkable * 3 +
             resources * 5 + elevation * 7 + region;
         metric.observe(inout out, projection, region % 7 + 1);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/audit_physics_cost.rue
+++ b/examples/caldera/audit_physics_cost.rue
@@ -151,7 +151,7 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
                 tiles += 1;
-                if tile.walkable { walkable = walkable + 1; }
+                if tile.walkable { walkable += 1; }
                 resources += tile.resource;
                 elevation += tile.height;
             }

--- a/examples/caldera/audit_physics_cost.rue
+++ b/examples/caldera/audit_physics_cost.rue
@@ -63,7 +63,7 @@ fn observe_entities(inout out: metric.Metric, borrow world: model.World) {
         metric.observe(inout out, entity_projection(borrow world, i), (i % 11) + 1);
         metric.warn(inout out, item.alive && (item.x < 0 || item.y < 0 ||
             @intCast(item.x) >= world.width || @intCast(item.y) >= world.height));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -73,7 +73,7 @@ fn observe_tiles(inout out: metric.Metric, borrow world: model.World) {
         let item = world.tiles.get_or(i, model.empty_tile());
         metric.observe(inout out, tile_projection(borrow world, i), (i % 13) + 1);
         metric.warn(inout out, item.x >= world.width || item.y >= world.height);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -82,18 +82,18 @@ fn observe_timeline(inout out: metric.Metric, borrow world: model.World) {
     while i < world.events.len() {
         metric.observe(inout out, event_projection(borrow world, i), (i % 5) + 1);
         metric.warn(inout out, world.events.get_or(i, model.empty_event()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
         metric.observe(inout out, command_projection(borrow world, i), (i % 7) + 1);
         metric.warn(inout out, world.commands.get_or(i, model.empty_command()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.snapshots.len() {
         metric.observe(inout out, snapshot_projection(borrow world, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -108,9 +108,9 @@ fn observe_pairs(inout out: metric.Metric, borrow world: model.World) {
             let dy = if left.y > right.y { left.y - right.y } else { right.y - left.y };
             metric.observe(inout out, @intCast(dx + dy) +
                 left.faction * 3 + right.faction * 5 + MODE(), i + j + 1);
-            j = j + 1;
+            j += 1;
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -125,17 +125,17 @@ fn observe_factions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.entities.len() {
             let entity = world.entities.get_or(i, model.empty_entity());
             if entity.faction == faction && entity.alive {
-                agents = agents + 1;
-                health = health + entity.health;
-                energy = energy + entity.energy;
-                inventory = inventory + entity.inventory;
+                agents += 1;
+                health += entity.health;
+                energy += entity.energy;
+                inventory += entity.inventory;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = agents * (MODE() % 11 + 1) + health * 3 +
             energy * 5 + inventory * 7 + faction;
         metric.observe(inout out, projection, faction + MODE() % 5 + 1);
-        faction = faction + 1;
+        faction += 1;
     }
 }
 
@@ -150,17 +150,17 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
-                tiles = tiles + 1;
+                tiles += 1;
                 if tile.walkable { walkable = walkable + 1; }
-                resources = resources + tile.resource;
-                elevation = elevation + tile.height;
+                resources += tile.resource;
+                elevation += tile.height;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = tiles * (MODE() % 13 + 1) + walkable * 3 +
             resources * 5 + elevation * 7 + region;
         metric.observe(inout out, projection, region % 7 + 1);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/audit_physics_coverage.rue
+++ b/examples/caldera/audit_physics_coverage.rue
@@ -151,7 +151,7 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
                 tiles += 1;
-                if tile.walkable { walkable = walkable + 1; }
+                if tile.walkable { walkable += 1; }
                 resources += tile.resource;
                 elevation += tile.height;
             }

--- a/examples/caldera/audit_physics_coverage.rue
+++ b/examples/caldera/audit_physics_coverage.rue
@@ -63,7 +63,7 @@ fn observe_entities(inout out: metric.Metric, borrow world: model.World) {
         metric.observe(inout out, entity_projection(borrow world, i), (i % 11) + 1);
         metric.warn(inout out, item.alive && (item.x < 0 || item.y < 0 ||
             @intCast(item.x) >= world.width || @intCast(item.y) >= world.height));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -73,7 +73,7 @@ fn observe_tiles(inout out: metric.Metric, borrow world: model.World) {
         let item = world.tiles.get_or(i, model.empty_tile());
         metric.observe(inout out, tile_projection(borrow world, i), (i % 13) + 1);
         metric.warn(inout out, item.x >= world.width || item.y >= world.height);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -82,18 +82,18 @@ fn observe_timeline(inout out: metric.Metric, borrow world: model.World) {
     while i < world.events.len() {
         metric.observe(inout out, event_projection(borrow world, i), (i % 5) + 1);
         metric.warn(inout out, world.events.get_or(i, model.empty_event()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
         metric.observe(inout out, command_projection(borrow world, i), (i % 7) + 1);
         metric.warn(inout out, world.commands.get_or(i, model.empty_command()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.snapshots.len() {
         metric.observe(inout out, snapshot_projection(borrow world, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -108,9 +108,9 @@ fn observe_pairs(inout out: metric.Metric, borrow world: model.World) {
             let dy = if left.y > right.y { left.y - right.y } else { right.y - left.y };
             metric.observe(inout out, @intCast(dx + dy) +
                 left.faction * 3 + right.faction * 5 + MODE(), i + j + 1);
-            j = j + 1;
+            j += 1;
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -125,17 +125,17 @@ fn observe_factions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.entities.len() {
             let entity = world.entities.get_or(i, model.empty_entity());
             if entity.faction == faction && entity.alive {
-                agents = agents + 1;
-                health = health + entity.health;
-                energy = energy + entity.energy;
-                inventory = inventory + entity.inventory;
+                agents += 1;
+                health += entity.health;
+                energy += entity.energy;
+                inventory += entity.inventory;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = agents * (MODE() % 11 + 1) + health * 3 +
             energy * 5 + inventory * 7 + faction;
         metric.observe(inout out, projection, faction + MODE() % 5 + 1);
-        faction = faction + 1;
+        faction += 1;
     }
 }
 
@@ -150,17 +150,17 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
-                tiles = tiles + 1;
+                tiles += 1;
                 if tile.walkable { walkable = walkable + 1; }
-                resources = resources + tile.resource;
-                elevation = elevation + tile.height;
+                resources += tile.resource;
+                elevation += tile.height;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = tiles * (MODE() % 13 + 1) + walkable * 3 +
             resources * 5 + elevation * 7 + region;
         metric.observe(inout out, projection, region % 7 + 1);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/audit_physics_density.rue
+++ b/examples/caldera/audit_physics_density.rue
@@ -151,7 +151,7 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
                 tiles += 1;
-                if tile.walkable { walkable = walkable + 1; }
+                if tile.walkable { walkable += 1; }
                 resources += tile.resource;
                 elevation += tile.height;
             }

--- a/examples/caldera/audit_physics_density.rue
+++ b/examples/caldera/audit_physics_density.rue
@@ -63,7 +63,7 @@ fn observe_entities(inout out: metric.Metric, borrow world: model.World) {
         metric.observe(inout out, entity_projection(borrow world, i), (i % 11) + 1);
         metric.warn(inout out, item.alive && (item.x < 0 || item.y < 0 ||
             @intCast(item.x) >= world.width || @intCast(item.y) >= world.height));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -73,7 +73,7 @@ fn observe_tiles(inout out: metric.Metric, borrow world: model.World) {
         let item = world.tiles.get_or(i, model.empty_tile());
         metric.observe(inout out, tile_projection(borrow world, i), (i % 13) + 1);
         metric.warn(inout out, item.x >= world.width || item.y >= world.height);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -82,18 +82,18 @@ fn observe_timeline(inout out: metric.Metric, borrow world: model.World) {
     while i < world.events.len() {
         metric.observe(inout out, event_projection(borrow world, i), (i % 5) + 1);
         metric.warn(inout out, world.events.get_or(i, model.empty_event()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
         metric.observe(inout out, command_projection(borrow world, i), (i % 7) + 1);
         metric.warn(inout out, world.commands.get_or(i, model.empty_command()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.snapshots.len() {
         metric.observe(inout out, snapshot_projection(borrow world, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -108,9 +108,9 @@ fn observe_pairs(inout out: metric.Metric, borrow world: model.World) {
             let dy = if left.y > right.y { left.y - right.y } else { right.y - left.y };
             metric.observe(inout out, @intCast(dx + dy) +
                 left.faction * 3 + right.faction * 5 + MODE(), i + j + 1);
-            j = j + 1;
+            j += 1;
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -125,17 +125,17 @@ fn observe_factions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.entities.len() {
             let entity = world.entities.get_or(i, model.empty_entity());
             if entity.faction == faction && entity.alive {
-                agents = agents + 1;
-                health = health + entity.health;
-                energy = energy + entity.energy;
-                inventory = inventory + entity.inventory;
+                agents += 1;
+                health += entity.health;
+                energy += entity.energy;
+                inventory += entity.inventory;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = agents * (MODE() % 11 + 1) + health * 3 +
             energy * 5 + inventory * 7 + faction;
         metric.observe(inout out, projection, faction + MODE() % 5 + 1);
-        faction = faction + 1;
+        faction += 1;
     }
 }
 
@@ -150,17 +150,17 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
-                tiles = tiles + 1;
+                tiles += 1;
                 if tile.walkable { walkable = walkable + 1; }
-                resources = resources + tile.resource;
-                elevation = elevation + tile.height;
+                resources += tile.resource;
+                elevation += tile.height;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = tiles * (MODE() % 13 + 1) + walkable * 3 +
             resources * 5 + elevation * 7 + region;
         metric.observe(inout out, projection, region % 7 + 1);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/audit_physics_entropy.rue
+++ b/examples/caldera/audit_physics_entropy.rue
@@ -151,7 +151,7 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
                 tiles += 1;
-                if tile.walkable { walkable = walkable + 1; }
+                if tile.walkable { walkable += 1; }
                 resources += tile.resource;
                 elevation += tile.height;
             }

--- a/examples/caldera/audit_physics_entropy.rue
+++ b/examples/caldera/audit_physics_entropy.rue
@@ -63,7 +63,7 @@ fn observe_entities(inout out: metric.Metric, borrow world: model.World) {
         metric.observe(inout out, entity_projection(borrow world, i), (i % 11) + 1);
         metric.warn(inout out, item.alive && (item.x < 0 || item.y < 0 ||
             @intCast(item.x) >= world.width || @intCast(item.y) >= world.height));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -73,7 +73,7 @@ fn observe_tiles(inout out: metric.Metric, borrow world: model.World) {
         let item = world.tiles.get_or(i, model.empty_tile());
         metric.observe(inout out, tile_projection(borrow world, i), (i % 13) + 1);
         metric.warn(inout out, item.x >= world.width || item.y >= world.height);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -82,18 +82,18 @@ fn observe_timeline(inout out: metric.Metric, borrow world: model.World) {
     while i < world.events.len() {
         metric.observe(inout out, event_projection(borrow world, i), (i % 5) + 1);
         metric.warn(inout out, world.events.get_or(i, model.empty_event()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
         metric.observe(inout out, command_projection(borrow world, i), (i % 7) + 1);
         metric.warn(inout out, world.commands.get_or(i, model.empty_command()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.snapshots.len() {
         metric.observe(inout out, snapshot_projection(borrow world, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -108,9 +108,9 @@ fn observe_pairs(inout out: metric.Metric, borrow world: model.World) {
             let dy = if left.y > right.y { left.y - right.y } else { right.y - left.y };
             metric.observe(inout out, @intCast(dx + dy) +
                 left.faction * 3 + right.faction * 5 + MODE(), i + j + 1);
-            j = j + 1;
+            j += 1;
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -125,17 +125,17 @@ fn observe_factions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.entities.len() {
             let entity = world.entities.get_or(i, model.empty_entity());
             if entity.faction == faction && entity.alive {
-                agents = agents + 1;
-                health = health + entity.health;
-                energy = energy + entity.energy;
-                inventory = inventory + entity.inventory;
+                agents += 1;
+                health += entity.health;
+                energy += entity.energy;
+                inventory += entity.inventory;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = agents * (MODE() % 11 + 1) + health * 3 +
             energy * 5 + inventory * 7 + faction;
         metric.observe(inout out, projection, faction + MODE() % 5 + 1);
-        faction = faction + 1;
+        faction += 1;
     }
 }
 
@@ -150,17 +150,17 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
-                tiles = tiles + 1;
+                tiles += 1;
                 if tile.walkable { walkable = walkable + 1; }
-                resources = resources + tile.resource;
-                elevation = elevation + tile.height;
+                resources += tile.resource;
+                elevation += tile.height;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = tiles * (MODE() % 13 + 1) + walkable * 3 +
             resources * 5 + elevation * 7 + region;
         metric.observe(inout out, projection, region % 7 + 1);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/audit_physics_fanout.rue
+++ b/examples/caldera/audit_physics_fanout.rue
@@ -151,7 +151,7 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
                 tiles += 1;
-                if tile.walkable { walkable = walkable + 1; }
+                if tile.walkable { walkable += 1; }
                 resources += tile.resource;
                 elevation += tile.height;
             }

--- a/examples/caldera/audit_physics_fanout.rue
+++ b/examples/caldera/audit_physics_fanout.rue
@@ -63,7 +63,7 @@ fn observe_entities(inout out: metric.Metric, borrow world: model.World) {
         metric.observe(inout out, entity_projection(borrow world, i), (i % 11) + 1);
         metric.warn(inout out, item.alive && (item.x < 0 || item.y < 0 ||
             @intCast(item.x) >= world.width || @intCast(item.y) >= world.height));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -73,7 +73,7 @@ fn observe_tiles(inout out: metric.Metric, borrow world: model.World) {
         let item = world.tiles.get_or(i, model.empty_tile());
         metric.observe(inout out, tile_projection(borrow world, i), (i % 13) + 1);
         metric.warn(inout out, item.x >= world.width || item.y >= world.height);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -82,18 +82,18 @@ fn observe_timeline(inout out: metric.Metric, borrow world: model.World) {
     while i < world.events.len() {
         metric.observe(inout out, event_projection(borrow world, i), (i % 5) + 1);
         metric.warn(inout out, world.events.get_or(i, model.empty_event()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
         metric.observe(inout out, command_projection(borrow world, i), (i % 7) + 1);
         metric.warn(inout out, world.commands.get_or(i, model.empty_command()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.snapshots.len() {
         metric.observe(inout out, snapshot_projection(borrow world, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -108,9 +108,9 @@ fn observe_pairs(inout out: metric.Metric, borrow world: model.World) {
             let dy = if left.y > right.y { left.y - right.y } else { right.y - left.y };
             metric.observe(inout out, @intCast(dx + dy) +
                 left.faction * 3 + right.faction * 5 + MODE(), i + j + 1);
-            j = j + 1;
+            j += 1;
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -125,17 +125,17 @@ fn observe_factions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.entities.len() {
             let entity = world.entities.get_or(i, model.empty_entity());
             if entity.faction == faction && entity.alive {
-                agents = agents + 1;
-                health = health + entity.health;
-                energy = energy + entity.energy;
-                inventory = inventory + entity.inventory;
+                agents += 1;
+                health += entity.health;
+                energy += entity.energy;
+                inventory += entity.inventory;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = agents * (MODE() % 11 + 1) + health * 3 +
             energy * 5 + inventory * 7 + faction;
         metric.observe(inout out, projection, faction + MODE() % 5 + 1);
-        faction = faction + 1;
+        faction += 1;
     }
 }
 
@@ -150,17 +150,17 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
-                tiles = tiles + 1;
+                tiles += 1;
                 if tile.walkable { walkable = walkable + 1; }
-                resources = resources + tile.resource;
-                elevation = elevation + tile.height;
+                resources += tile.resource;
+                elevation += tile.height;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = tiles * (MODE() % 13 + 1) + walkable * 3 +
             resources * 5 + elevation * 7 + region;
         metric.observe(inout out, projection, region % 7 + 1);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/audit_physics_integrity.rue
+++ b/examples/caldera/audit_physics_integrity.rue
@@ -151,7 +151,7 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
                 tiles += 1;
-                if tile.walkable { walkable = walkable + 1; }
+                if tile.walkable { walkable += 1; }
                 resources += tile.resource;
                 elevation += tile.height;
             }

--- a/examples/caldera/audit_physics_integrity.rue
+++ b/examples/caldera/audit_physics_integrity.rue
@@ -63,7 +63,7 @@ fn observe_entities(inout out: metric.Metric, borrow world: model.World) {
         metric.observe(inout out, entity_projection(borrow world, i), (i % 11) + 1);
         metric.warn(inout out, item.alive && (item.x < 0 || item.y < 0 ||
             @intCast(item.x) >= world.width || @intCast(item.y) >= world.height));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -73,7 +73,7 @@ fn observe_tiles(inout out: metric.Metric, borrow world: model.World) {
         let item = world.tiles.get_or(i, model.empty_tile());
         metric.observe(inout out, tile_projection(borrow world, i), (i % 13) + 1);
         metric.warn(inout out, item.x >= world.width || item.y >= world.height);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -82,18 +82,18 @@ fn observe_timeline(inout out: metric.Metric, borrow world: model.World) {
     while i < world.events.len() {
         metric.observe(inout out, event_projection(borrow world, i), (i % 5) + 1);
         metric.warn(inout out, world.events.get_or(i, model.empty_event()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
         metric.observe(inout out, command_projection(borrow world, i), (i % 7) + 1);
         metric.warn(inout out, world.commands.get_or(i, model.empty_command()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.snapshots.len() {
         metric.observe(inout out, snapshot_projection(borrow world, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -108,9 +108,9 @@ fn observe_pairs(inout out: metric.Metric, borrow world: model.World) {
             let dy = if left.y > right.y { left.y - right.y } else { right.y - left.y };
             metric.observe(inout out, @intCast(dx + dy) +
                 left.faction * 3 + right.faction * 5 + MODE(), i + j + 1);
-            j = j + 1;
+            j += 1;
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -125,17 +125,17 @@ fn observe_factions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.entities.len() {
             let entity = world.entities.get_or(i, model.empty_entity());
             if entity.faction == faction && entity.alive {
-                agents = agents + 1;
-                health = health + entity.health;
-                energy = energy + entity.energy;
-                inventory = inventory + entity.inventory;
+                agents += 1;
+                health += entity.health;
+                energy += entity.energy;
+                inventory += entity.inventory;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = agents * (MODE() % 11 + 1) + health * 3 +
             energy * 5 + inventory * 7 + faction;
         metric.observe(inout out, projection, faction + MODE() % 5 + 1);
-        faction = faction + 1;
+        faction += 1;
     }
 }
 
@@ -150,17 +150,17 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
-                tiles = tiles + 1;
+                tiles += 1;
                 if tile.walkable { walkable = walkable + 1; }
-                resources = resources + tile.resource;
-                elevation = elevation + tile.height;
+                resources += tile.resource;
+                elevation += tile.height;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = tiles * (MODE() % 13 + 1) + walkable * 3 +
             resources * 5 + elevation * 7 + region;
         metric.observe(inout out, projection, region % 7 + 1);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/audit_physics_latency.rue
+++ b/examples/caldera/audit_physics_latency.rue
@@ -151,7 +151,7 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
                 tiles += 1;
-                if tile.walkable { walkable = walkable + 1; }
+                if tile.walkable { walkable += 1; }
                 resources += tile.resource;
                 elevation += tile.height;
             }

--- a/examples/caldera/audit_physics_latency.rue
+++ b/examples/caldera/audit_physics_latency.rue
@@ -63,7 +63,7 @@ fn observe_entities(inout out: metric.Metric, borrow world: model.World) {
         metric.observe(inout out, entity_projection(borrow world, i), (i % 11) + 1);
         metric.warn(inout out, item.alive && (item.x < 0 || item.y < 0 ||
             @intCast(item.x) >= world.width || @intCast(item.y) >= world.height));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -73,7 +73,7 @@ fn observe_tiles(inout out: metric.Metric, borrow world: model.World) {
         let item = world.tiles.get_or(i, model.empty_tile());
         metric.observe(inout out, tile_projection(borrow world, i), (i % 13) + 1);
         metric.warn(inout out, item.x >= world.width || item.y >= world.height);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -82,18 +82,18 @@ fn observe_timeline(inout out: metric.Metric, borrow world: model.World) {
     while i < world.events.len() {
         metric.observe(inout out, event_projection(borrow world, i), (i % 5) + 1);
         metric.warn(inout out, world.events.get_or(i, model.empty_event()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
         metric.observe(inout out, command_projection(borrow world, i), (i % 7) + 1);
         metric.warn(inout out, world.commands.get_or(i, model.empty_command()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.snapshots.len() {
         metric.observe(inout out, snapshot_projection(borrow world, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -108,9 +108,9 @@ fn observe_pairs(inout out: metric.Metric, borrow world: model.World) {
             let dy = if left.y > right.y { left.y - right.y } else { right.y - left.y };
             metric.observe(inout out, @intCast(dx + dy) +
                 left.faction * 3 + right.faction * 5 + MODE(), i + j + 1);
-            j = j + 1;
+            j += 1;
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -125,17 +125,17 @@ fn observe_factions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.entities.len() {
             let entity = world.entities.get_or(i, model.empty_entity());
             if entity.faction == faction && entity.alive {
-                agents = agents + 1;
-                health = health + entity.health;
-                energy = energy + entity.energy;
-                inventory = inventory + entity.inventory;
+                agents += 1;
+                health += entity.health;
+                energy += entity.energy;
+                inventory += entity.inventory;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = agents * (MODE() % 11 + 1) + health * 3 +
             energy * 5 + inventory * 7 + faction;
         metric.observe(inout out, projection, faction + MODE() % 5 + 1);
-        faction = faction + 1;
+        faction += 1;
     }
 }
 
@@ -150,17 +150,17 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
-                tiles = tiles + 1;
+                tiles += 1;
                 if tile.walkable { walkable = walkable + 1; }
-                resources = resources + tile.resource;
-                elevation = elevation + tile.height;
+                resources += tile.resource;
+                elevation += tile.height;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = tiles * (MODE() % 13 + 1) + walkable * 3 +
             resources * 5 + elevation * 7 + region;
         metric.observe(inout out, projection, region % 7 + 1);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/audit_physics_locality.rue
+++ b/examples/caldera/audit_physics_locality.rue
@@ -151,7 +151,7 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
                 tiles += 1;
-                if tile.walkable { walkable = walkable + 1; }
+                if tile.walkable { walkable += 1; }
                 resources += tile.resource;
                 elevation += tile.height;
             }

--- a/examples/caldera/audit_physics_locality.rue
+++ b/examples/caldera/audit_physics_locality.rue
@@ -63,7 +63,7 @@ fn observe_entities(inout out: metric.Metric, borrow world: model.World) {
         metric.observe(inout out, entity_projection(borrow world, i), (i % 11) + 1);
         metric.warn(inout out, item.alive && (item.x < 0 || item.y < 0 ||
             @intCast(item.x) >= world.width || @intCast(item.y) >= world.height));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -73,7 +73,7 @@ fn observe_tiles(inout out: metric.Metric, borrow world: model.World) {
         let item = world.tiles.get_or(i, model.empty_tile());
         metric.observe(inout out, tile_projection(borrow world, i), (i % 13) + 1);
         metric.warn(inout out, item.x >= world.width || item.y >= world.height);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -82,18 +82,18 @@ fn observe_timeline(inout out: metric.Metric, borrow world: model.World) {
     while i < world.events.len() {
         metric.observe(inout out, event_projection(borrow world, i), (i % 5) + 1);
         metric.warn(inout out, world.events.get_or(i, model.empty_event()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
         metric.observe(inout out, command_projection(borrow world, i), (i % 7) + 1);
         metric.warn(inout out, world.commands.get_or(i, model.empty_command()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.snapshots.len() {
         metric.observe(inout out, snapshot_projection(borrow world, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -108,9 +108,9 @@ fn observe_pairs(inout out: metric.Metric, borrow world: model.World) {
             let dy = if left.y > right.y { left.y - right.y } else { right.y - left.y };
             metric.observe(inout out, @intCast(dx + dy) +
                 left.faction * 3 + right.faction * 5 + MODE(), i + j + 1);
-            j = j + 1;
+            j += 1;
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -125,17 +125,17 @@ fn observe_factions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.entities.len() {
             let entity = world.entities.get_or(i, model.empty_entity());
             if entity.faction == faction && entity.alive {
-                agents = agents + 1;
-                health = health + entity.health;
-                energy = energy + entity.energy;
-                inventory = inventory + entity.inventory;
+                agents += 1;
+                health += entity.health;
+                energy += entity.energy;
+                inventory += entity.inventory;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = agents * (MODE() % 11 + 1) + health * 3 +
             energy * 5 + inventory * 7 + faction;
         metric.observe(inout out, projection, faction + MODE() % 5 + 1);
-        faction = faction + 1;
+        faction += 1;
     }
 }
 
@@ -150,17 +150,17 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
-                tiles = tiles + 1;
+                tiles += 1;
                 if tile.walkable { walkable = walkable + 1; }
-                resources = resources + tile.resource;
-                elevation = elevation + tile.height;
+                resources += tile.resource;
+                elevation += tile.height;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = tiles * (MODE() % 13 + 1) + walkable * 3 +
             resources * 5 + elevation * 7 + region;
         metric.observe(inout out, projection, region % 7 + 1);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/audit_physics_pressure.rue
+++ b/examples/caldera/audit_physics_pressure.rue
@@ -151,7 +151,7 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
                 tiles += 1;
-                if tile.walkable { walkable = walkable + 1; }
+                if tile.walkable { walkable += 1; }
                 resources += tile.resource;
                 elevation += tile.height;
             }

--- a/examples/caldera/audit_physics_pressure.rue
+++ b/examples/caldera/audit_physics_pressure.rue
@@ -63,7 +63,7 @@ fn observe_entities(inout out: metric.Metric, borrow world: model.World) {
         metric.observe(inout out, entity_projection(borrow world, i), (i % 11) + 1);
         metric.warn(inout out, item.alive && (item.x < 0 || item.y < 0 ||
             @intCast(item.x) >= world.width || @intCast(item.y) >= world.height));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -73,7 +73,7 @@ fn observe_tiles(inout out: metric.Metric, borrow world: model.World) {
         let item = world.tiles.get_or(i, model.empty_tile());
         metric.observe(inout out, tile_projection(borrow world, i), (i % 13) + 1);
         metric.warn(inout out, item.x >= world.width || item.y >= world.height);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -82,18 +82,18 @@ fn observe_timeline(inout out: metric.Metric, borrow world: model.World) {
     while i < world.events.len() {
         metric.observe(inout out, event_projection(borrow world, i), (i % 5) + 1);
         metric.warn(inout out, world.events.get_or(i, model.empty_event()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
         metric.observe(inout out, command_projection(borrow world, i), (i % 7) + 1);
         metric.warn(inout out, world.commands.get_or(i, model.empty_command()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.snapshots.len() {
         metric.observe(inout out, snapshot_projection(borrow world, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -108,9 +108,9 @@ fn observe_pairs(inout out: metric.Metric, borrow world: model.World) {
             let dy = if left.y > right.y { left.y - right.y } else { right.y - left.y };
             metric.observe(inout out, @intCast(dx + dy) +
                 left.faction * 3 + right.faction * 5 + MODE(), i + j + 1);
-            j = j + 1;
+            j += 1;
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -125,17 +125,17 @@ fn observe_factions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.entities.len() {
             let entity = world.entities.get_or(i, model.empty_entity());
             if entity.faction == faction && entity.alive {
-                agents = agents + 1;
-                health = health + entity.health;
-                energy = energy + entity.energy;
-                inventory = inventory + entity.inventory;
+                agents += 1;
+                health += entity.health;
+                energy += entity.energy;
+                inventory += entity.inventory;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = agents * (MODE() % 11 + 1) + health * 3 +
             energy * 5 + inventory * 7 + faction;
         metric.observe(inout out, projection, faction + MODE() % 5 + 1);
-        faction = faction + 1;
+        faction += 1;
     }
 }
 
@@ -150,17 +150,17 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
-                tiles = tiles + 1;
+                tiles += 1;
                 if tile.walkable { walkable = walkable + 1; }
-                resources = resources + tile.resource;
-                elevation = elevation + tile.height;
+                resources += tile.resource;
+                elevation += tile.height;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = tiles * (MODE() % 13 + 1) + walkable * 3 +
             resources * 5 + elevation * 7 + region;
         metric.observe(inout out, projection, region % 7 + 1);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/audit_physics_risk.rue
+++ b/examples/caldera/audit_physics_risk.rue
@@ -151,7 +151,7 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
                 tiles += 1;
-                if tile.walkable { walkable = walkable + 1; }
+                if tile.walkable { walkable += 1; }
                 resources += tile.resource;
                 elevation += tile.height;
             }

--- a/examples/caldera/audit_physics_risk.rue
+++ b/examples/caldera/audit_physics_risk.rue
@@ -63,7 +63,7 @@ fn observe_entities(inout out: metric.Metric, borrow world: model.World) {
         metric.observe(inout out, entity_projection(borrow world, i), (i % 11) + 1);
         metric.warn(inout out, item.alive && (item.x < 0 || item.y < 0 ||
             @intCast(item.x) >= world.width || @intCast(item.y) >= world.height));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -73,7 +73,7 @@ fn observe_tiles(inout out: metric.Metric, borrow world: model.World) {
         let item = world.tiles.get_or(i, model.empty_tile());
         metric.observe(inout out, tile_projection(borrow world, i), (i % 13) + 1);
         metric.warn(inout out, item.x >= world.width || item.y >= world.height);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -82,18 +82,18 @@ fn observe_timeline(inout out: metric.Metric, borrow world: model.World) {
     while i < world.events.len() {
         metric.observe(inout out, event_projection(borrow world, i), (i % 5) + 1);
         metric.warn(inout out, world.events.get_or(i, model.empty_event()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
         metric.observe(inout out, command_projection(borrow world, i), (i % 7) + 1);
         metric.warn(inout out, world.commands.get_or(i, model.empty_command()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.snapshots.len() {
         metric.observe(inout out, snapshot_projection(borrow world, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -108,9 +108,9 @@ fn observe_pairs(inout out: metric.Metric, borrow world: model.World) {
             let dy = if left.y > right.y { left.y - right.y } else { right.y - left.y };
             metric.observe(inout out, @intCast(dx + dy) +
                 left.faction * 3 + right.faction * 5 + MODE(), i + j + 1);
-            j = j + 1;
+            j += 1;
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -125,17 +125,17 @@ fn observe_factions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.entities.len() {
             let entity = world.entities.get_or(i, model.empty_entity());
             if entity.faction == faction && entity.alive {
-                agents = agents + 1;
-                health = health + entity.health;
-                energy = energy + entity.energy;
-                inventory = inventory + entity.inventory;
+                agents += 1;
+                health += entity.health;
+                energy += entity.energy;
+                inventory += entity.inventory;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = agents * (MODE() % 11 + 1) + health * 3 +
             energy * 5 + inventory * 7 + faction;
         metric.observe(inout out, projection, faction + MODE() % 5 + 1);
-        faction = faction + 1;
+        faction += 1;
     }
 }
 
@@ -150,17 +150,17 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
-                tiles = tiles + 1;
+                tiles += 1;
                 if tile.walkable { walkable = walkable + 1; }
-                resources = resources + tile.resource;
-                elevation = elevation + tile.height;
+                resources += tile.resource;
+                elevation += tile.height;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = tiles * (MODE() % 13 + 1) + walkable * 3 +
             resources * 5 + elevation * 7 + region;
         metric.observe(inout out, projection, region % 7 + 1);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/audit_physics_skew.rue
+++ b/examples/caldera/audit_physics_skew.rue
@@ -151,7 +151,7 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
                 tiles += 1;
-                if tile.walkable { walkable = walkable + 1; }
+                if tile.walkable { walkable += 1; }
                 resources += tile.resource;
                 elevation += tile.height;
             }

--- a/examples/caldera/audit_physics_skew.rue
+++ b/examples/caldera/audit_physics_skew.rue
@@ -63,7 +63,7 @@ fn observe_entities(inout out: metric.Metric, borrow world: model.World) {
         metric.observe(inout out, entity_projection(borrow world, i), (i % 11) + 1);
         metric.warn(inout out, item.alive && (item.x < 0 || item.y < 0 ||
             @intCast(item.x) >= world.width || @intCast(item.y) >= world.height));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -73,7 +73,7 @@ fn observe_tiles(inout out: metric.Metric, borrow world: model.World) {
         let item = world.tiles.get_or(i, model.empty_tile());
         metric.observe(inout out, tile_projection(borrow world, i), (i % 13) + 1);
         metric.warn(inout out, item.x >= world.width || item.y >= world.height);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -82,18 +82,18 @@ fn observe_timeline(inout out: metric.Metric, borrow world: model.World) {
     while i < world.events.len() {
         metric.observe(inout out, event_projection(borrow world, i), (i % 5) + 1);
         metric.warn(inout out, world.events.get_or(i, model.empty_event()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
         metric.observe(inout out, command_projection(borrow world, i), (i % 7) + 1);
         metric.warn(inout out, world.commands.get_or(i, model.empty_command()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.snapshots.len() {
         metric.observe(inout out, snapshot_projection(borrow world, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -108,9 +108,9 @@ fn observe_pairs(inout out: metric.Metric, borrow world: model.World) {
             let dy = if left.y > right.y { left.y - right.y } else { right.y - left.y };
             metric.observe(inout out, @intCast(dx + dy) +
                 left.faction * 3 + right.faction * 5 + MODE(), i + j + 1);
-            j = j + 1;
+            j += 1;
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -125,17 +125,17 @@ fn observe_factions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.entities.len() {
             let entity = world.entities.get_or(i, model.empty_entity());
             if entity.faction == faction && entity.alive {
-                agents = agents + 1;
-                health = health + entity.health;
-                energy = energy + entity.energy;
-                inventory = inventory + entity.inventory;
+                agents += 1;
+                health += entity.health;
+                energy += entity.energy;
+                inventory += entity.inventory;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = agents * (MODE() % 11 + 1) + health * 3 +
             energy * 5 + inventory * 7 + faction;
         metric.observe(inout out, projection, faction + MODE() % 5 + 1);
-        faction = faction + 1;
+        faction += 1;
     }
 }
 
@@ -150,17 +150,17 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
-                tiles = tiles + 1;
+                tiles += 1;
                 if tile.walkable { walkable = walkable + 1; }
-                resources = resources + tile.resource;
-                elevation = elevation + tile.height;
+                resources += tile.resource;
+                elevation += tile.height;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = tiles * (MODE() % 13 + 1) + walkable * 3 +
             resources * 5 + elevation * 7 + region;
         metric.observe(inout out, projection, region % 7 + 1);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/audit_physics_stability.rue
+++ b/examples/caldera/audit_physics_stability.rue
@@ -151,7 +151,7 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
                 tiles += 1;
-                if tile.walkable { walkable = walkable + 1; }
+                if tile.walkable { walkable += 1; }
                 resources += tile.resource;
                 elevation += tile.height;
             }

--- a/examples/caldera/audit_physics_stability.rue
+++ b/examples/caldera/audit_physics_stability.rue
@@ -63,7 +63,7 @@ fn observe_entities(inout out: metric.Metric, borrow world: model.World) {
         metric.observe(inout out, entity_projection(borrow world, i), (i % 11) + 1);
         metric.warn(inout out, item.alive && (item.x < 0 || item.y < 0 ||
             @intCast(item.x) >= world.width || @intCast(item.y) >= world.height));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -73,7 +73,7 @@ fn observe_tiles(inout out: metric.Metric, borrow world: model.World) {
         let item = world.tiles.get_or(i, model.empty_tile());
         metric.observe(inout out, tile_projection(borrow world, i), (i % 13) + 1);
         metric.warn(inout out, item.x >= world.width || item.y >= world.height);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -82,18 +82,18 @@ fn observe_timeline(inout out: metric.Metric, borrow world: model.World) {
     while i < world.events.len() {
         metric.observe(inout out, event_projection(borrow world, i), (i % 5) + 1);
         metric.warn(inout out, world.events.get_or(i, model.empty_event()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
         metric.observe(inout out, command_projection(borrow world, i), (i % 7) + 1);
         metric.warn(inout out, world.commands.get_or(i, model.empty_command()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.snapshots.len() {
         metric.observe(inout out, snapshot_projection(borrow world, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -108,9 +108,9 @@ fn observe_pairs(inout out: metric.Metric, borrow world: model.World) {
             let dy = if left.y > right.y { left.y - right.y } else { right.y - left.y };
             metric.observe(inout out, @intCast(dx + dy) +
                 left.faction * 3 + right.faction * 5 + MODE(), i + j + 1);
-            j = j + 1;
+            j += 1;
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -125,17 +125,17 @@ fn observe_factions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.entities.len() {
             let entity = world.entities.get_or(i, model.empty_entity());
             if entity.faction == faction && entity.alive {
-                agents = agents + 1;
-                health = health + entity.health;
-                energy = energy + entity.energy;
-                inventory = inventory + entity.inventory;
+                agents += 1;
+                health += entity.health;
+                energy += entity.energy;
+                inventory += entity.inventory;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = agents * (MODE() % 11 + 1) + health * 3 +
             energy * 5 + inventory * 7 + faction;
         metric.observe(inout out, projection, faction + MODE() % 5 + 1);
-        faction = faction + 1;
+        faction += 1;
     }
 }
 
@@ -150,17 +150,17 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
-                tiles = tiles + 1;
+                tiles += 1;
                 if tile.walkable { walkable = walkable + 1; }
-                resources = resources + tile.resource;
-                elevation = elevation + tile.height;
+                resources += tile.resource;
+                elevation += tile.height;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = tiles * (MODE() % 13 + 1) + walkable * 3 +
             resources * 5 + elevation * 7 + region;
         metric.observe(inout out, projection, region % 7 + 1);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/audit_physics_throughput.rue
+++ b/examples/caldera/audit_physics_throughput.rue
@@ -151,7 +151,7 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
                 tiles += 1;
-                if tile.walkable { walkable = walkable + 1; }
+                if tile.walkable { walkable += 1; }
                 resources += tile.resource;
                 elevation += tile.height;
             }

--- a/examples/caldera/audit_physics_throughput.rue
+++ b/examples/caldera/audit_physics_throughput.rue
@@ -63,7 +63,7 @@ fn observe_entities(inout out: metric.Metric, borrow world: model.World) {
         metric.observe(inout out, entity_projection(borrow world, i), (i % 11) + 1);
         metric.warn(inout out, item.alive && (item.x < 0 || item.y < 0 ||
             @intCast(item.x) >= world.width || @intCast(item.y) >= world.height));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -73,7 +73,7 @@ fn observe_tiles(inout out: metric.Metric, borrow world: model.World) {
         let item = world.tiles.get_or(i, model.empty_tile());
         metric.observe(inout out, tile_projection(borrow world, i), (i % 13) + 1);
         metric.warn(inout out, item.x >= world.width || item.y >= world.height);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -82,18 +82,18 @@ fn observe_timeline(inout out: metric.Metric, borrow world: model.World) {
     while i < world.events.len() {
         metric.observe(inout out, event_projection(borrow world, i), (i % 5) + 1);
         metric.warn(inout out, world.events.get_or(i, model.empty_event()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
         metric.observe(inout out, command_projection(borrow world, i), (i % 7) + 1);
         metric.warn(inout out, world.commands.get_or(i, model.empty_command()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.snapshots.len() {
         metric.observe(inout out, snapshot_projection(borrow world, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -108,9 +108,9 @@ fn observe_pairs(inout out: metric.Metric, borrow world: model.World) {
             let dy = if left.y > right.y { left.y - right.y } else { right.y - left.y };
             metric.observe(inout out, @intCast(dx + dy) +
                 left.faction * 3 + right.faction * 5 + MODE(), i + j + 1);
-            j = j + 1;
+            j += 1;
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -125,17 +125,17 @@ fn observe_factions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.entities.len() {
             let entity = world.entities.get_or(i, model.empty_entity());
             if entity.faction == faction && entity.alive {
-                agents = agents + 1;
-                health = health + entity.health;
-                energy = energy + entity.energy;
-                inventory = inventory + entity.inventory;
+                agents += 1;
+                health += entity.health;
+                energy += entity.energy;
+                inventory += entity.inventory;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = agents * (MODE() % 11 + 1) + health * 3 +
             energy * 5 + inventory * 7 + faction;
         metric.observe(inout out, projection, faction + MODE() % 5 + 1);
-        faction = faction + 1;
+        faction += 1;
     }
 }
 
@@ -150,17 +150,17 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
-                tiles = tiles + 1;
+                tiles += 1;
                 if tile.walkable { walkable = walkable + 1; }
-                resources = resources + tile.resource;
-                elevation = elevation + tile.height;
+                resources += tile.resource;
+                elevation += tile.height;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = tiles * (MODE() % 13 + 1) + walkable * 3 +
             resources * 5 + elevation * 7 + region;
         metric.observe(inout out, projection, region % 7 + 1);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/audit_quest_balance.rue
+++ b/examples/caldera/audit_quest_balance.rue
@@ -151,7 +151,7 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
                 tiles += 1;
-                if tile.walkable { walkable = walkable + 1; }
+                if tile.walkable { walkable += 1; }
                 resources += tile.resource;
                 elevation += tile.height;
             }

--- a/examples/caldera/audit_quest_balance.rue
+++ b/examples/caldera/audit_quest_balance.rue
@@ -63,7 +63,7 @@ fn observe_entities(inout out: metric.Metric, borrow world: model.World) {
         metric.observe(inout out, entity_projection(borrow world, i), (i % 11) + 1);
         metric.warn(inout out, item.alive && (item.x < 0 || item.y < 0 ||
             @intCast(item.x) >= world.width || @intCast(item.y) >= world.height));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -73,7 +73,7 @@ fn observe_tiles(inout out: metric.Metric, borrow world: model.World) {
         let item = world.tiles.get_or(i, model.empty_tile());
         metric.observe(inout out, tile_projection(borrow world, i), (i % 13) + 1);
         metric.warn(inout out, item.x >= world.width || item.y >= world.height);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -82,18 +82,18 @@ fn observe_timeline(inout out: metric.Metric, borrow world: model.World) {
     while i < world.events.len() {
         metric.observe(inout out, event_projection(borrow world, i), (i % 5) + 1);
         metric.warn(inout out, world.events.get_or(i, model.empty_event()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
         metric.observe(inout out, command_projection(borrow world, i), (i % 7) + 1);
         metric.warn(inout out, world.commands.get_or(i, model.empty_command()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.snapshots.len() {
         metric.observe(inout out, snapshot_projection(borrow world, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -108,9 +108,9 @@ fn observe_pairs(inout out: metric.Metric, borrow world: model.World) {
             let dy = if left.y > right.y { left.y - right.y } else { right.y - left.y };
             metric.observe(inout out, @intCast(dx + dy) +
                 left.faction * 3 + right.faction * 5 + MODE(), i + j + 1);
-            j = j + 1;
+            j += 1;
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -125,17 +125,17 @@ fn observe_factions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.entities.len() {
             let entity = world.entities.get_or(i, model.empty_entity());
             if entity.faction == faction && entity.alive {
-                agents = agents + 1;
-                health = health + entity.health;
-                energy = energy + entity.energy;
-                inventory = inventory + entity.inventory;
+                agents += 1;
+                health += entity.health;
+                energy += entity.energy;
+                inventory += entity.inventory;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = agents * (MODE() % 11 + 1) + health * 3 +
             energy * 5 + inventory * 7 + faction;
         metric.observe(inout out, projection, faction + MODE() % 5 + 1);
-        faction = faction + 1;
+        faction += 1;
     }
 }
 
@@ -150,17 +150,17 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
-                tiles = tiles + 1;
+                tiles += 1;
                 if tile.walkable { walkable = walkable + 1; }
-                resources = resources + tile.resource;
-                elevation = elevation + tile.height;
+                resources += tile.resource;
+                elevation += tile.height;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = tiles * (MODE() % 13 + 1) + walkable * 3 +
             resources * 5 + elevation * 7 + region;
         metric.observe(inout out, projection, region % 7 + 1);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/audit_quest_capacity.rue
+++ b/examples/caldera/audit_quest_capacity.rue
@@ -151,7 +151,7 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
                 tiles += 1;
-                if tile.walkable { walkable = walkable + 1; }
+                if tile.walkable { walkable += 1; }
                 resources += tile.resource;
                 elevation += tile.height;
             }

--- a/examples/caldera/audit_quest_capacity.rue
+++ b/examples/caldera/audit_quest_capacity.rue
@@ -63,7 +63,7 @@ fn observe_entities(inout out: metric.Metric, borrow world: model.World) {
         metric.observe(inout out, entity_projection(borrow world, i), (i % 11) + 1);
         metric.warn(inout out, item.alive && (item.x < 0 || item.y < 0 ||
             @intCast(item.x) >= world.width || @intCast(item.y) >= world.height));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -73,7 +73,7 @@ fn observe_tiles(inout out: metric.Metric, borrow world: model.World) {
         let item = world.tiles.get_or(i, model.empty_tile());
         metric.observe(inout out, tile_projection(borrow world, i), (i % 13) + 1);
         metric.warn(inout out, item.x >= world.width || item.y >= world.height);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -82,18 +82,18 @@ fn observe_timeline(inout out: metric.Metric, borrow world: model.World) {
     while i < world.events.len() {
         metric.observe(inout out, event_projection(borrow world, i), (i % 5) + 1);
         metric.warn(inout out, world.events.get_or(i, model.empty_event()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
         metric.observe(inout out, command_projection(borrow world, i), (i % 7) + 1);
         metric.warn(inout out, world.commands.get_or(i, model.empty_command()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.snapshots.len() {
         metric.observe(inout out, snapshot_projection(borrow world, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -108,9 +108,9 @@ fn observe_pairs(inout out: metric.Metric, borrow world: model.World) {
             let dy = if left.y > right.y { left.y - right.y } else { right.y - left.y };
             metric.observe(inout out, @intCast(dx + dy) +
                 left.faction * 3 + right.faction * 5 + MODE(), i + j + 1);
-            j = j + 1;
+            j += 1;
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -125,17 +125,17 @@ fn observe_factions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.entities.len() {
             let entity = world.entities.get_or(i, model.empty_entity());
             if entity.faction == faction && entity.alive {
-                agents = agents + 1;
-                health = health + entity.health;
-                energy = energy + entity.energy;
-                inventory = inventory + entity.inventory;
+                agents += 1;
+                health += entity.health;
+                energy += entity.energy;
+                inventory += entity.inventory;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = agents * (MODE() % 11 + 1) + health * 3 +
             energy * 5 + inventory * 7 + faction;
         metric.observe(inout out, projection, faction + MODE() % 5 + 1);
-        faction = faction + 1;
+        faction += 1;
     }
 }
 
@@ -150,17 +150,17 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
-                tiles = tiles + 1;
+                tiles += 1;
                 if tile.walkable { walkable = walkable + 1; }
-                resources = resources + tile.resource;
-                elevation = elevation + tile.height;
+                resources += tile.resource;
+                elevation += tile.height;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = tiles * (MODE() % 13 + 1) + walkable * 3 +
             resources * 5 + elevation * 7 + region;
         metric.observe(inout out, projection, region % 7 + 1);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/audit_quest_continuity.rue
+++ b/examples/caldera/audit_quest_continuity.rue
@@ -151,7 +151,7 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
                 tiles += 1;
-                if tile.walkable { walkable = walkable + 1; }
+                if tile.walkable { walkable += 1; }
                 resources += tile.resource;
                 elevation += tile.height;
             }

--- a/examples/caldera/audit_quest_continuity.rue
+++ b/examples/caldera/audit_quest_continuity.rue
@@ -63,7 +63,7 @@ fn observe_entities(inout out: metric.Metric, borrow world: model.World) {
         metric.observe(inout out, entity_projection(borrow world, i), (i % 11) + 1);
         metric.warn(inout out, item.alive && (item.x < 0 || item.y < 0 ||
             @intCast(item.x) >= world.width || @intCast(item.y) >= world.height));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -73,7 +73,7 @@ fn observe_tiles(inout out: metric.Metric, borrow world: model.World) {
         let item = world.tiles.get_or(i, model.empty_tile());
         metric.observe(inout out, tile_projection(borrow world, i), (i % 13) + 1);
         metric.warn(inout out, item.x >= world.width || item.y >= world.height);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -82,18 +82,18 @@ fn observe_timeline(inout out: metric.Metric, borrow world: model.World) {
     while i < world.events.len() {
         metric.observe(inout out, event_projection(borrow world, i), (i % 5) + 1);
         metric.warn(inout out, world.events.get_or(i, model.empty_event()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
         metric.observe(inout out, command_projection(borrow world, i), (i % 7) + 1);
         metric.warn(inout out, world.commands.get_or(i, model.empty_command()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.snapshots.len() {
         metric.observe(inout out, snapshot_projection(borrow world, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -108,9 +108,9 @@ fn observe_pairs(inout out: metric.Metric, borrow world: model.World) {
             let dy = if left.y > right.y { left.y - right.y } else { right.y - left.y };
             metric.observe(inout out, @intCast(dx + dy) +
                 left.faction * 3 + right.faction * 5 + MODE(), i + j + 1);
-            j = j + 1;
+            j += 1;
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -125,17 +125,17 @@ fn observe_factions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.entities.len() {
             let entity = world.entities.get_or(i, model.empty_entity());
             if entity.faction == faction && entity.alive {
-                agents = agents + 1;
-                health = health + entity.health;
-                energy = energy + entity.energy;
-                inventory = inventory + entity.inventory;
+                agents += 1;
+                health += entity.health;
+                energy += entity.energy;
+                inventory += entity.inventory;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = agents * (MODE() % 11 + 1) + health * 3 +
             energy * 5 + inventory * 7 + faction;
         metric.observe(inout out, projection, faction + MODE() % 5 + 1);
-        faction = faction + 1;
+        faction += 1;
     }
 }
 
@@ -150,17 +150,17 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
-                tiles = tiles + 1;
+                tiles += 1;
                 if tile.walkable { walkable = walkable + 1; }
-                resources = resources + tile.resource;
-                elevation = elevation + tile.height;
+                resources += tile.resource;
+                elevation += tile.height;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = tiles * (MODE() % 13 + 1) + walkable * 3 +
             resources * 5 + elevation * 7 + region;
         metric.observe(inout out, projection, region % 7 + 1);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/audit_quest_cost.rue
+++ b/examples/caldera/audit_quest_cost.rue
@@ -151,7 +151,7 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
                 tiles += 1;
-                if tile.walkable { walkable = walkable + 1; }
+                if tile.walkable { walkable += 1; }
                 resources += tile.resource;
                 elevation += tile.height;
             }

--- a/examples/caldera/audit_quest_cost.rue
+++ b/examples/caldera/audit_quest_cost.rue
@@ -63,7 +63,7 @@ fn observe_entities(inout out: metric.Metric, borrow world: model.World) {
         metric.observe(inout out, entity_projection(borrow world, i), (i % 11) + 1);
         metric.warn(inout out, item.alive && (item.x < 0 || item.y < 0 ||
             @intCast(item.x) >= world.width || @intCast(item.y) >= world.height));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -73,7 +73,7 @@ fn observe_tiles(inout out: metric.Metric, borrow world: model.World) {
         let item = world.tiles.get_or(i, model.empty_tile());
         metric.observe(inout out, tile_projection(borrow world, i), (i % 13) + 1);
         metric.warn(inout out, item.x >= world.width || item.y >= world.height);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -82,18 +82,18 @@ fn observe_timeline(inout out: metric.Metric, borrow world: model.World) {
     while i < world.events.len() {
         metric.observe(inout out, event_projection(borrow world, i), (i % 5) + 1);
         metric.warn(inout out, world.events.get_or(i, model.empty_event()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
         metric.observe(inout out, command_projection(borrow world, i), (i % 7) + 1);
         metric.warn(inout out, world.commands.get_or(i, model.empty_command()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.snapshots.len() {
         metric.observe(inout out, snapshot_projection(borrow world, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -108,9 +108,9 @@ fn observe_pairs(inout out: metric.Metric, borrow world: model.World) {
             let dy = if left.y > right.y { left.y - right.y } else { right.y - left.y };
             metric.observe(inout out, @intCast(dx + dy) +
                 left.faction * 3 + right.faction * 5 + MODE(), i + j + 1);
-            j = j + 1;
+            j += 1;
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -125,17 +125,17 @@ fn observe_factions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.entities.len() {
             let entity = world.entities.get_or(i, model.empty_entity());
             if entity.faction == faction && entity.alive {
-                agents = agents + 1;
-                health = health + entity.health;
-                energy = energy + entity.energy;
-                inventory = inventory + entity.inventory;
+                agents += 1;
+                health += entity.health;
+                energy += entity.energy;
+                inventory += entity.inventory;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = agents * (MODE() % 11 + 1) + health * 3 +
             energy * 5 + inventory * 7 + faction;
         metric.observe(inout out, projection, faction + MODE() % 5 + 1);
-        faction = faction + 1;
+        faction += 1;
     }
 }
 
@@ -150,17 +150,17 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
-                tiles = tiles + 1;
+                tiles += 1;
                 if tile.walkable { walkable = walkable + 1; }
-                resources = resources + tile.resource;
-                elevation = elevation + tile.height;
+                resources += tile.resource;
+                elevation += tile.height;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = tiles * (MODE() % 13 + 1) + walkable * 3 +
             resources * 5 + elevation * 7 + region;
         metric.observe(inout out, projection, region % 7 + 1);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/audit_quest_coverage.rue
+++ b/examples/caldera/audit_quest_coverage.rue
@@ -151,7 +151,7 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
                 tiles += 1;
-                if tile.walkable { walkable = walkable + 1; }
+                if tile.walkable { walkable += 1; }
                 resources += tile.resource;
                 elevation += tile.height;
             }

--- a/examples/caldera/audit_quest_coverage.rue
+++ b/examples/caldera/audit_quest_coverage.rue
@@ -63,7 +63,7 @@ fn observe_entities(inout out: metric.Metric, borrow world: model.World) {
         metric.observe(inout out, entity_projection(borrow world, i), (i % 11) + 1);
         metric.warn(inout out, item.alive && (item.x < 0 || item.y < 0 ||
             @intCast(item.x) >= world.width || @intCast(item.y) >= world.height));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -73,7 +73,7 @@ fn observe_tiles(inout out: metric.Metric, borrow world: model.World) {
         let item = world.tiles.get_or(i, model.empty_tile());
         metric.observe(inout out, tile_projection(borrow world, i), (i % 13) + 1);
         metric.warn(inout out, item.x >= world.width || item.y >= world.height);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -82,18 +82,18 @@ fn observe_timeline(inout out: metric.Metric, borrow world: model.World) {
     while i < world.events.len() {
         metric.observe(inout out, event_projection(borrow world, i), (i % 5) + 1);
         metric.warn(inout out, world.events.get_or(i, model.empty_event()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
         metric.observe(inout out, command_projection(borrow world, i), (i % 7) + 1);
         metric.warn(inout out, world.commands.get_or(i, model.empty_command()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.snapshots.len() {
         metric.observe(inout out, snapshot_projection(borrow world, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -108,9 +108,9 @@ fn observe_pairs(inout out: metric.Metric, borrow world: model.World) {
             let dy = if left.y > right.y { left.y - right.y } else { right.y - left.y };
             metric.observe(inout out, @intCast(dx + dy) +
                 left.faction * 3 + right.faction * 5 + MODE(), i + j + 1);
-            j = j + 1;
+            j += 1;
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -125,17 +125,17 @@ fn observe_factions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.entities.len() {
             let entity = world.entities.get_or(i, model.empty_entity());
             if entity.faction == faction && entity.alive {
-                agents = agents + 1;
-                health = health + entity.health;
-                energy = energy + entity.energy;
-                inventory = inventory + entity.inventory;
+                agents += 1;
+                health += entity.health;
+                energy += entity.energy;
+                inventory += entity.inventory;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = agents * (MODE() % 11 + 1) + health * 3 +
             energy * 5 + inventory * 7 + faction;
         metric.observe(inout out, projection, faction + MODE() % 5 + 1);
-        faction = faction + 1;
+        faction += 1;
     }
 }
 
@@ -150,17 +150,17 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
-                tiles = tiles + 1;
+                tiles += 1;
                 if tile.walkable { walkable = walkable + 1; }
-                resources = resources + tile.resource;
-                elevation = elevation + tile.height;
+                resources += tile.resource;
+                elevation += tile.height;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = tiles * (MODE() % 13 + 1) + walkable * 3 +
             resources * 5 + elevation * 7 + region;
         metric.observe(inout out, projection, region % 7 + 1);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/audit_quest_density.rue
+++ b/examples/caldera/audit_quest_density.rue
@@ -151,7 +151,7 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
                 tiles += 1;
-                if tile.walkable { walkable = walkable + 1; }
+                if tile.walkable { walkable += 1; }
                 resources += tile.resource;
                 elevation += tile.height;
             }

--- a/examples/caldera/audit_quest_density.rue
+++ b/examples/caldera/audit_quest_density.rue
@@ -63,7 +63,7 @@ fn observe_entities(inout out: metric.Metric, borrow world: model.World) {
         metric.observe(inout out, entity_projection(borrow world, i), (i % 11) + 1);
         metric.warn(inout out, item.alive && (item.x < 0 || item.y < 0 ||
             @intCast(item.x) >= world.width || @intCast(item.y) >= world.height));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -73,7 +73,7 @@ fn observe_tiles(inout out: metric.Metric, borrow world: model.World) {
         let item = world.tiles.get_or(i, model.empty_tile());
         metric.observe(inout out, tile_projection(borrow world, i), (i % 13) + 1);
         metric.warn(inout out, item.x >= world.width || item.y >= world.height);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -82,18 +82,18 @@ fn observe_timeline(inout out: metric.Metric, borrow world: model.World) {
     while i < world.events.len() {
         metric.observe(inout out, event_projection(borrow world, i), (i % 5) + 1);
         metric.warn(inout out, world.events.get_or(i, model.empty_event()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
         metric.observe(inout out, command_projection(borrow world, i), (i % 7) + 1);
         metric.warn(inout out, world.commands.get_or(i, model.empty_command()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.snapshots.len() {
         metric.observe(inout out, snapshot_projection(borrow world, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -108,9 +108,9 @@ fn observe_pairs(inout out: metric.Metric, borrow world: model.World) {
             let dy = if left.y > right.y { left.y - right.y } else { right.y - left.y };
             metric.observe(inout out, @intCast(dx + dy) +
                 left.faction * 3 + right.faction * 5 + MODE(), i + j + 1);
-            j = j + 1;
+            j += 1;
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -125,17 +125,17 @@ fn observe_factions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.entities.len() {
             let entity = world.entities.get_or(i, model.empty_entity());
             if entity.faction == faction && entity.alive {
-                agents = agents + 1;
-                health = health + entity.health;
-                energy = energy + entity.energy;
-                inventory = inventory + entity.inventory;
+                agents += 1;
+                health += entity.health;
+                energy += entity.energy;
+                inventory += entity.inventory;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = agents * (MODE() % 11 + 1) + health * 3 +
             energy * 5 + inventory * 7 + faction;
         metric.observe(inout out, projection, faction + MODE() % 5 + 1);
-        faction = faction + 1;
+        faction += 1;
     }
 }
 
@@ -150,17 +150,17 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
-                tiles = tiles + 1;
+                tiles += 1;
                 if tile.walkable { walkable = walkable + 1; }
-                resources = resources + tile.resource;
-                elevation = elevation + tile.height;
+                resources += tile.resource;
+                elevation += tile.height;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = tiles * (MODE() % 13 + 1) + walkable * 3 +
             resources * 5 + elevation * 7 + region;
         metric.observe(inout out, projection, region % 7 + 1);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/audit_quest_entropy.rue
+++ b/examples/caldera/audit_quest_entropy.rue
@@ -151,7 +151,7 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
                 tiles += 1;
-                if tile.walkable { walkable = walkable + 1; }
+                if tile.walkable { walkable += 1; }
                 resources += tile.resource;
                 elevation += tile.height;
             }

--- a/examples/caldera/audit_quest_entropy.rue
+++ b/examples/caldera/audit_quest_entropy.rue
@@ -63,7 +63,7 @@ fn observe_entities(inout out: metric.Metric, borrow world: model.World) {
         metric.observe(inout out, entity_projection(borrow world, i), (i % 11) + 1);
         metric.warn(inout out, item.alive && (item.x < 0 || item.y < 0 ||
             @intCast(item.x) >= world.width || @intCast(item.y) >= world.height));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -73,7 +73,7 @@ fn observe_tiles(inout out: metric.Metric, borrow world: model.World) {
         let item = world.tiles.get_or(i, model.empty_tile());
         metric.observe(inout out, tile_projection(borrow world, i), (i % 13) + 1);
         metric.warn(inout out, item.x >= world.width || item.y >= world.height);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -82,18 +82,18 @@ fn observe_timeline(inout out: metric.Metric, borrow world: model.World) {
     while i < world.events.len() {
         metric.observe(inout out, event_projection(borrow world, i), (i % 5) + 1);
         metric.warn(inout out, world.events.get_or(i, model.empty_event()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
         metric.observe(inout out, command_projection(borrow world, i), (i % 7) + 1);
         metric.warn(inout out, world.commands.get_or(i, model.empty_command()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.snapshots.len() {
         metric.observe(inout out, snapshot_projection(borrow world, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -108,9 +108,9 @@ fn observe_pairs(inout out: metric.Metric, borrow world: model.World) {
             let dy = if left.y > right.y { left.y - right.y } else { right.y - left.y };
             metric.observe(inout out, @intCast(dx + dy) +
                 left.faction * 3 + right.faction * 5 + MODE(), i + j + 1);
-            j = j + 1;
+            j += 1;
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -125,17 +125,17 @@ fn observe_factions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.entities.len() {
             let entity = world.entities.get_or(i, model.empty_entity());
             if entity.faction == faction && entity.alive {
-                agents = agents + 1;
-                health = health + entity.health;
-                energy = energy + entity.energy;
-                inventory = inventory + entity.inventory;
+                agents += 1;
+                health += entity.health;
+                energy += entity.energy;
+                inventory += entity.inventory;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = agents * (MODE() % 11 + 1) + health * 3 +
             energy * 5 + inventory * 7 + faction;
         metric.observe(inout out, projection, faction + MODE() % 5 + 1);
-        faction = faction + 1;
+        faction += 1;
     }
 }
 
@@ -150,17 +150,17 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
-                tiles = tiles + 1;
+                tiles += 1;
                 if tile.walkable { walkable = walkable + 1; }
-                resources = resources + tile.resource;
-                elevation = elevation + tile.height;
+                resources += tile.resource;
+                elevation += tile.height;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = tiles * (MODE() % 13 + 1) + walkable * 3 +
             resources * 5 + elevation * 7 + region;
         metric.observe(inout out, projection, region % 7 + 1);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/audit_quest_fanout.rue
+++ b/examples/caldera/audit_quest_fanout.rue
@@ -151,7 +151,7 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
                 tiles += 1;
-                if tile.walkable { walkable = walkable + 1; }
+                if tile.walkable { walkable += 1; }
                 resources += tile.resource;
                 elevation += tile.height;
             }

--- a/examples/caldera/audit_quest_fanout.rue
+++ b/examples/caldera/audit_quest_fanout.rue
@@ -63,7 +63,7 @@ fn observe_entities(inout out: metric.Metric, borrow world: model.World) {
         metric.observe(inout out, entity_projection(borrow world, i), (i % 11) + 1);
         metric.warn(inout out, item.alive && (item.x < 0 || item.y < 0 ||
             @intCast(item.x) >= world.width || @intCast(item.y) >= world.height));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -73,7 +73,7 @@ fn observe_tiles(inout out: metric.Metric, borrow world: model.World) {
         let item = world.tiles.get_or(i, model.empty_tile());
         metric.observe(inout out, tile_projection(borrow world, i), (i % 13) + 1);
         metric.warn(inout out, item.x >= world.width || item.y >= world.height);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -82,18 +82,18 @@ fn observe_timeline(inout out: metric.Metric, borrow world: model.World) {
     while i < world.events.len() {
         metric.observe(inout out, event_projection(borrow world, i), (i % 5) + 1);
         metric.warn(inout out, world.events.get_or(i, model.empty_event()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
         metric.observe(inout out, command_projection(borrow world, i), (i % 7) + 1);
         metric.warn(inout out, world.commands.get_or(i, model.empty_command()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.snapshots.len() {
         metric.observe(inout out, snapshot_projection(borrow world, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -108,9 +108,9 @@ fn observe_pairs(inout out: metric.Metric, borrow world: model.World) {
             let dy = if left.y > right.y { left.y - right.y } else { right.y - left.y };
             metric.observe(inout out, @intCast(dx + dy) +
                 left.faction * 3 + right.faction * 5 + MODE(), i + j + 1);
-            j = j + 1;
+            j += 1;
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -125,17 +125,17 @@ fn observe_factions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.entities.len() {
             let entity = world.entities.get_or(i, model.empty_entity());
             if entity.faction == faction && entity.alive {
-                agents = agents + 1;
-                health = health + entity.health;
-                energy = energy + entity.energy;
-                inventory = inventory + entity.inventory;
+                agents += 1;
+                health += entity.health;
+                energy += entity.energy;
+                inventory += entity.inventory;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = agents * (MODE() % 11 + 1) + health * 3 +
             energy * 5 + inventory * 7 + faction;
         metric.observe(inout out, projection, faction + MODE() % 5 + 1);
-        faction = faction + 1;
+        faction += 1;
     }
 }
 
@@ -150,17 +150,17 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
-                tiles = tiles + 1;
+                tiles += 1;
                 if tile.walkable { walkable = walkable + 1; }
-                resources = resources + tile.resource;
-                elevation = elevation + tile.height;
+                resources += tile.resource;
+                elevation += tile.height;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = tiles * (MODE() % 13 + 1) + walkable * 3 +
             resources * 5 + elevation * 7 + region;
         metric.observe(inout out, projection, region % 7 + 1);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/audit_quest_integrity.rue
+++ b/examples/caldera/audit_quest_integrity.rue
@@ -151,7 +151,7 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
                 tiles += 1;
-                if tile.walkable { walkable = walkable + 1; }
+                if tile.walkable { walkable += 1; }
                 resources += tile.resource;
                 elevation += tile.height;
             }

--- a/examples/caldera/audit_quest_integrity.rue
+++ b/examples/caldera/audit_quest_integrity.rue
@@ -63,7 +63,7 @@ fn observe_entities(inout out: metric.Metric, borrow world: model.World) {
         metric.observe(inout out, entity_projection(borrow world, i), (i % 11) + 1);
         metric.warn(inout out, item.alive && (item.x < 0 || item.y < 0 ||
             @intCast(item.x) >= world.width || @intCast(item.y) >= world.height));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -73,7 +73,7 @@ fn observe_tiles(inout out: metric.Metric, borrow world: model.World) {
         let item = world.tiles.get_or(i, model.empty_tile());
         metric.observe(inout out, tile_projection(borrow world, i), (i % 13) + 1);
         metric.warn(inout out, item.x >= world.width || item.y >= world.height);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -82,18 +82,18 @@ fn observe_timeline(inout out: metric.Metric, borrow world: model.World) {
     while i < world.events.len() {
         metric.observe(inout out, event_projection(borrow world, i), (i % 5) + 1);
         metric.warn(inout out, world.events.get_or(i, model.empty_event()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
         metric.observe(inout out, command_projection(borrow world, i), (i % 7) + 1);
         metric.warn(inout out, world.commands.get_or(i, model.empty_command()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.snapshots.len() {
         metric.observe(inout out, snapshot_projection(borrow world, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -108,9 +108,9 @@ fn observe_pairs(inout out: metric.Metric, borrow world: model.World) {
             let dy = if left.y > right.y { left.y - right.y } else { right.y - left.y };
             metric.observe(inout out, @intCast(dx + dy) +
                 left.faction * 3 + right.faction * 5 + MODE(), i + j + 1);
-            j = j + 1;
+            j += 1;
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -125,17 +125,17 @@ fn observe_factions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.entities.len() {
             let entity = world.entities.get_or(i, model.empty_entity());
             if entity.faction == faction && entity.alive {
-                agents = agents + 1;
-                health = health + entity.health;
-                energy = energy + entity.energy;
-                inventory = inventory + entity.inventory;
+                agents += 1;
+                health += entity.health;
+                energy += entity.energy;
+                inventory += entity.inventory;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = agents * (MODE() % 11 + 1) + health * 3 +
             energy * 5 + inventory * 7 + faction;
         metric.observe(inout out, projection, faction + MODE() % 5 + 1);
-        faction = faction + 1;
+        faction += 1;
     }
 }
 
@@ -150,17 +150,17 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
-                tiles = tiles + 1;
+                tiles += 1;
                 if tile.walkable { walkable = walkable + 1; }
-                resources = resources + tile.resource;
-                elevation = elevation + tile.height;
+                resources += tile.resource;
+                elevation += tile.height;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = tiles * (MODE() % 13 + 1) + walkable * 3 +
             resources * 5 + elevation * 7 + region;
         metric.observe(inout out, projection, region % 7 + 1);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/audit_quest_latency.rue
+++ b/examples/caldera/audit_quest_latency.rue
@@ -151,7 +151,7 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
                 tiles += 1;
-                if tile.walkable { walkable = walkable + 1; }
+                if tile.walkable { walkable += 1; }
                 resources += tile.resource;
                 elevation += tile.height;
             }

--- a/examples/caldera/audit_quest_latency.rue
+++ b/examples/caldera/audit_quest_latency.rue
@@ -63,7 +63,7 @@ fn observe_entities(inout out: metric.Metric, borrow world: model.World) {
         metric.observe(inout out, entity_projection(borrow world, i), (i % 11) + 1);
         metric.warn(inout out, item.alive && (item.x < 0 || item.y < 0 ||
             @intCast(item.x) >= world.width || @intCast(item.y) >= world.height));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -73,7 +73,7 @@ fn observe_tiles(inout out: metric.Metric, borrow world: model.World) {
         let item = world.tiles.get_or(i, model.empty_tile());
         metric.observe(inout out, tile_projection(borrow world, i), (i % 13) + 1);
         metric.warn(inout out, item.x >= world.width || item.y >= world.height);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -82,18 +82,18 @@ fn observe_timeline(inout out: metric.Metric, borrow world: model.World) {
     while i < world.events.len() {
         metric.observe(inout out, event_projection(borrow world, i), (i % 5) + 1);
         metric.warn(inout out, world.events.get_or(i, model.empty_event()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
         metric.observe(inout out, command_projection(borrow world, i), (i % 7) + 1);
         metric.warn(inout out, world.commands.get_or(i, model.empty_command()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.snapshots.len() {
         metric.observe(inout out, snapshot_projection(borrow world, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -108,9 +108,9 @@ fn observe_pairs(inout out: metric.Metric, borrow world: model.World) {
             let dy = if left.y > right.y { left.y - right.y } else { right.y - left.y };
             metric.observe(inout out, @intCast(dx + dy) +
                 left.faction * 3 + right.faction * 5 + MODE(), i + j + 1);
-            j = j + 1;
+            j += 1;
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -125,17 +125,17 @@ fn observe_factions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.entities.len() {
             let entity = world.entities.get_or(i, model.empty_entity());
             if entity.faction == faction && entity.alive {
-                agents = agents + 1;
-                health = health + entity.health;
-                energy = energy + entity.energy;
-                inventory = inventory + entity.inventory;
+                agents += 1;
+                health += entity.health;
+                energy += entity.energy;
+                inventory += entity.inventory;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = agents * (MODE() % 11 + 1) + health * 3 +
             energy * 5 + inventory * 7 + faction;
         metric.observe(inout out, projection, faction + MODE() % 5 + 1);
-        faction = faction + 1;
+        faction += 1;
     }
 }
 
@@ -150,17 +150,17 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
-                tiles = tiles + 1;
+                tiles += 1;
                 if tile.walkable { walkable = walkable + 1; }
-                resources = resources + tile.resource;
-                elevation = elevation + tile.height;
+                resources += tile.resource;
+                elevation += tile.height;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = tiles * (MODE() % 13 + 1) + walkable * 3 +
             resources * 5 + elevation * 7 + region;
         metric.observe(inout out, projection, region % 7 + 1);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/audit_quest_locality.rue
+++ b/examples/caldera/audit_quest_locality.rue
@@ -151,7 +151,7 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
                 tiles += 1;
-                if tile.walkable { walkable = walkable + 1; }
+                if tile.walkable { walkable += 1; }
                 resources += tile.resource;
                 elevation += tile.height;
             }

--- a/examples/caldera/audit_quest_locality.rue
+++ b/examples/caldera/audit_quest_locality.rue
@@ -63,7 +63,7 @@ fn observe_entities(inout out: metric.Metric, borrow world: model.World) {
         metric.observe(inout out, entity_projection(borrow world, i), (i % 11) + 1);
         metric.warn(inout out, item.alive && (item.x < 0 || item.y < 0 ||
             @intCast(item.x) >= world.width || @intCast(item.y) >= world.height));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -73,7 +73,7 @@ fn observe_tiles(inout out: metric.Metric, borrow world: model.World) {
         let item = world.tiles.get_or(i, model.empty_tile());
         metric.observe(inout out, tile_projection(borrow world, i), (i % 13) + 1);
         metric.warn(inout out, item.x >= world.width || item.y >= world.height);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -82,18 +82,18 @@ fn observe_timeline(inout out: metric.Metric, borrow world: model.World) {
     while i < world.events.len() {
         metric.observe(inout out, event_projection(borrow world, i), (i % 5) + 1);
         metric.warn(inout out, world.events.get_or(i, model.empty_event()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
         metric.observe(inout out, command_projection(borrow world, i), (i % 7) + 1);
         metric.warn(inout out, world.commands.get_or(i, model.empty_command()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.snapshots.len() {
         metric.observe(inout out, snapshot_projection(borrow world, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -108,9 +108,9 @@ fn observe_pairs(inout out: metric.Metric, borrow world: model.World) {
             let dy = if left.y > right.y { left.y - right.y } else { right.y - left.y };
             metric.observe(inout out, @intCast(dx + dy) +
                 left.faction * 3 + right.faction * 5 + MODE(), i + j + 1);
-            j = j + 1;
+            j += 1;
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -125,17 +125,17 @@ fn observe_factions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.entities.len() {
             let entity = world.entities.get_or(i, model.empty_entity());
             if entity.faction == faction && entity.alive {
-                agents = agents + 1;
-                health = health + entity.health;
-                energy = energy + entity.energy;
-                inventory = inventory + entity.inventory;
+                agents += 1;
+                health += entity.health;
+                energy += entity.energy;
+                inventory += entity.inventory;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = agents * (MODE() % 11 + 1) + health * 3 +
             energy * 5 + inventory * 7 + faction;
         metric.observe(inout out, projection, faction + MODE() % 5 + 1);
-        faction = faction + 1;
+        faction += 1;
     }
 }
 
@@ -150,17 +150,17 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
-                tiles = tiles + 1;
+                tiles += 1;
                 if tile.walkable { walkable = walkable + 1; }
-                resources = resources + tile.resource;
-                elevation = elevation + tile.height;
+                resources += tile.resource;
+                elevation += tile.height;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = tiles * (MODE() % 13 + 1) + walkable * 3 +
             resources * 5 + elevation * 7 + region;
         metric.observe(inout out, projection, region % 7 + 1);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/audit_quest_pressure.rue
+++ b/examples/caldera/audit_quest_pressure.rue
@@ -151,7 +151,7 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
                 tiles += 1;
-                if tile.walkable { walkable = walkable + 1; }
+                if tile.walkable { walkable += 1; }
                 resources += tile.resource;
                 elevation += tile.height;
             }

--- a/examples/caldera/audit_quest_pressure.rue
+++ b/examples/caldera/audit_quest_pressure.rue
@@ -63,7 +63,7 @@ fn observe_entities(inout out: metric.Metric, borrow world: model.World) {
         metric.observe(inout out, entity_projection(borrow world, i), (i % 11) + 1);
         metric.warn(inout out, item.alive && (item.x < 0 || item.y < 0 ||
             @intCast(item.x) >= world.width || @intCast(item.y) >= world.height));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -73,7 +73,7 @@ fn observe_tiles(inout out: metric.Metric, borrow world: model.World) {
         let item = world.tiles.get_or(i, model.empty_tile());
         metric.observe(inout out, tile_projection(borrow world, i), (i % 13) + 1);
         metric.warn(inout out, item.x >= world.width || item.y >= world.height);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -82,18 +82,18 @@ fn observe_timeline(inout out: metric.Metric, borrow world: model.World) {
     while i < world.events.len() {
         metric.observe(inout out, event_projection(borrow world, i), (i % 5) + 1);
         metric.warn(inout out, world.events.get_or(i, model.empty_event()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
         metric.observe(inout out, command_projection(borrow world, i), (i % 7) + 1);
         metric.warn(inout out, world.commands.get_or(i, model.empty_command()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.snapshots.len() {
         metric.observe(inout out, snapshot_projection(borrow world, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -108,9 +108,9 @@ fn observe_pairs(inout out: metric.Metric, borrow world: model.World) {
             let dy = if left.y > right.y { left.y - right.y } else { right.y - left.y };
             metric.observe(inout out, @intCast(dx + dy) +
                 left.faction * 3 + right.faction * 5 + MODE(), i + j + 1);
-            j = j + 1;
+            j += 1;
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -125,17 +125,17 @@ fn observe_factions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.entities.len() {
             let entity = world.entities.get_or(i, model.empty_entity());
             if entity.faction == faction && entity.alive {
-                agents = agents + 1;
-                health = health + entity.health;
-                energy = energy + entity.energy;
-                inventory = inventory + entity.inventory;
+                agents += 1;
+                health += entity.health;
+                energy += entity.energy;
+                inventory += entity.inventory;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = agents * (MODE() % 11 + 1) + health * 3 +
             energy * 5 + inventory * 7 + faction;
         metric.observe(inout out, projection, faction + MODE() % 5 + 1);
-        faction = faction + 1;
+        faction += 1;
     }
 }
 
@@ -150,17 +150,17 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
-                tiles = tiles + 1;
+                tiles += 1;
                 if tile.walkable { walkable = walkable + 1; }
-                resources = resources + tile.resource;
-                elevation = elevation + tile.height;
+                resources += tile.resource;
+                elevation += tile.height;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = tiles * (MODE() % 13 + 1) + walkable * 3 +
             resources * 5 + elevation * 7 + region;
         metric.observe(inout out, projection, region % 7 + 1);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/audit_quest_risk.rue
+++ b/examples/caldera/audit_quest_risk.rue
@@ -151,7 +151,7 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
                 tiles += 1;
-                if tile.walkable { walkable = walkable + 1; }
+                if tile.walkable { walkable += 1; }
                 resources += tile.resource;
                 elevation += tile.height;
             }

--- a/examples/caldera/audit_quest_risk.rue
+++ b/examples/caldera/audit_quest_risk.rue
@@ -63,7 +63,7 @@ fn observe_entities(inout out: metric.Metric, borrow world: model.World) {
         metric.observe(inout out, entity_projection(borrow world, i), (i % 11) + 1);
         metric.warn(inout out, item.alive && (item.x < 0 || item.y < 0 ||
             @intCast(item.x) >= world.width || @intCast(item.y) >= world.height));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -73,7 +73,7 @@ fn observe_tiles(inout out: metric.Metric, borrow world: model.World) {
         let item = world.tiles.get_or(i, model.empty_tile());
         metric.observe(inout out, tile_projection(borrow world, i), (i % 13) + 1);
         metric.warn(inout out, item.x >= world.width || item.y >= world.height);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -82,18 +82,18 @@ fn observe_timeline(inout out: metric.Metric, borrow world: model.World) {
     while i < world.events.len() {
         metric.observe(inout out, event_projection(borrow world, i), (i % 5) + 1);
         metric.warn(inout out, world.events.get_or(i, model.empty_event()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
         metric.observe(inout out, command_projection(borrow world, i), (i % 7) + 1);
         metric.warn(inout out, world.commands.get_or(i, model.empty_command()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.snapshots.len() {
         metric.observe(inout out, snapshot_projection(borrow world, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -108,9 +108,9 @@ fn observe_pairs(inout out: metric.Metric, borrow world: model.World) {
             let dy = if left.y > right.y { left.y - right.y } else { right.y - left.y };
             metric.observe(inout out, @intCast(dx + dy) +
                 left.faction * 3 + right.faction * 5 + MODE(), i + j + 1);
-            j = j + 1;
+            j += 1;
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -125,17 +125,17 @@ fn observe_factions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.entities.len() {
             let entity = world.entities.get_or(i, model.empty_entity());
             if entity.faction == faction && entity.alive {
-                agents = agents + 1;
-                health = health + entity.health;
-                energy = energy + entity.energy;
-                inventory = inventory + entity.inventory;
+                agents += 1;
+                health += entity.health;
+                energy += entity.energy;
+                inventory += entity.inventory;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = agents * (MODE() % 11 + 1) + health * 3 +
             energy * 5 + inventory * 7 + faction;
         metric.observe(inout out, projection, faction + MODE() % 5 + 1);
-        faction = faction + 1;
+        faction += 1;
     }
 }
 
@@ -150,17 +150,17 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
-                tiles = tiles + 1;
+                tiles += 1;
                 if tile.walkable { walkable = walkable + 1; }
-                resources = resources + tile.resource;
-                elevation = elevation + tile.height;
+                resources += tile.resource;
+                elevation += tile.height;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = tiles * (MODE() % 13 + 1) + walkable * 3 +
             resources * 5 + elevation * 7 + region;
         metric.observe(inout out, projection, region % 7 + 1);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/audit_quest_skew.rue
+++ b/examples/caldera/audit_quest_skew.rue
@@ -151,7 +151,7 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
                 tiles += 1;
-                if tile.walkable { walkable = walkable + 1; }
+                if tile.walkable { walkable += 1; }
                 resources += tile.resource;
                 elevation += tile.height;
             }

--- a/examples/caldera/audit_quest_skew.rue
+++ b/examples/caldera/audit_quest_skew.rue
@@ -63,7 +63,7 @@ fn observe_entities(inout out: metric.Metric, borrow world: model.World) {
         metric.observe(inout out, entity_projection(borrow world, i), (i % 11) + 1);
         metric.warn(inout out, item.alive && (item.x < 0 || item.y < 0 ||
             @intCast(item.x) >= world.width || @intCast(item.y) >= world.height));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -73,7 +73,7 @@ fn observe_tiles(inout out: metric.Metric, borrow world: model.World) {
         let item = world.tiles.get_or(i, model.empty_tile());
         metric.observe(inout out, tile_projection(borrow world, i), (i % 13) + 1);
         metric.warn(inout out, item.x >= world.width || item.y >= world.height);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -82,18 +82,18 @@ fn observe_timeline(inout out: metric.Metric, borrow world: model.World) {
     while i < world.events.len() {
         metric.observe(inout out, event_projection(borrow world, i), (i % 5) + 1);
         metric.warn(inout out, world.events.get_or(i, model.empty_event()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
         metric.observe(inout out, command_projection(borrow world, i), (i % 7) + 1);
         metric.warn(inout out, world.commands.get_or(i, model.empty_command()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.snapshots.len() {
         metric.observe(inout out, snapshot_projection(borrow world, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -108,9 +108,9 @@ fn observe_pairs(inout out: metric.Metric, borrow world: model.World) {
             let dy = if left.y > right.y { left.y - right.y } else { right.y - left.y };
             metric.observe(inout out, @intCast(dx + dy) +
                 left.faction * 3 + right.faction * 5 + MODE(), i + j + 1);
-            j = j + 1;
+            j += 1;
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -125,17 +125,17 @@ fn observe_factions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.entities.len() {
             let entity = world.entities.get_or(i, model.empty_entity());
             if entity.faction == faction && entity.alive {
-                agents = agents + 1;
-                health = health + entity.health;
-                energy = energy + entity.energy;
-                inventory = inventory + entity.inventory;
+                agents += 1;
+                health += entity.health;
+                energy += entity.energy;
+                inventory += entity.inventory;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = agents * (MODE() % 11 + 1) + health * 3 +
             energy * 5 + inventory * 7 + faction;
         metric.observe(inout out, projection, faction + MODE() % 5 + 1);
-        faction = faction + 1;
+        faction += 1;
     }
 }
 
@@ -150,17 +150,17 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
-                tiles = tiles + 1;
+                tiles += 1;
                 if tile.walkable { walkable = walkable + 1; }
-                resources = resources + tile.resource;
-                elevation = elevation + tile.height;
+                resources += tile.resource;
+                elevation += tile.height;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = tiles * (MODE() % 13 + 1) + walkable * 3 +
             resources * 5 + elevation * 7 + region;
         metric.observe(inout out, projection, region % 7 + 1);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/audit_quest_stability.rue
+++ b/examples/caldera/audit_quest_stability.rue
@@ -151,7 +151,7 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
                 tiles += 1;
-                if tile.walkable { walkable = walkable + 1; }
+                if tile.walkable { walkable += 1; }
                 resources += tile.resource;
                 elevation += tile.height;
             }

--- a/examples/caldera/audit_quest_stability.rue
+++ b/examples/caldera/audit_quest_stability.rue
@@ -63,7 +63,7 @@ fn observe_entities(inout out: metric.Metric, borrow world: model.World) {
         metric.observe(inout out, entity_projection(borrow world, i), (i % 11) + 1);
         metric.warn(inout out, item.alive && (item.x < 0 || item.y < 0 ||
             @intCast(item.x) >= world.width || @intCast(item.y) >= world.height));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -73,7 +73,7 @@ fn observe_tiles(inout out: metric.Metric, borrow world: model.World) {
         let item = world.tiles.get_or(i, model.empty_tile());
         metric.observe(inout out, tile_projection(borrow world, i), (i % 13) + 1);
         metric.warn(inout out, item.x >= world.width || item.y >= world.height);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -82,18 +82,18 @@ fn observe_timeline(inout out: metric.Metric, borrow world: model.World) {
     while i < world.events.len() {
         metric.observe(inout out, event_projection(borrow world, i), (i % 5) + 1);
         metric.warn(inout out, world.events.get_or(i, model.empty_event()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
         metric.observe(inout out, command_projection(borrow world, i), (i % 7) + 1);
         metric.warn(inout out, world.commands.get_or(i, model.empty_command()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.snapshots.len() {
         metric.observe(inout out, snapshot_projection(borrow world, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -108,9 +108,9 @@ fn observe_pairs(inout out: metric.Metric, borrow world: model.World) {
             let dy = if left.y > right.y { left.y - right.y } else { right.y - left.y };
             metric.observe(inout out, @intCast(dx + dy) +
                 left.faction * 3 + right.faction * 5 + MODE(), i + j + 1);
-            j = j + 1;
+            j += 1;
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -125,17 +125,17 @@ fn observe_factions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.entities.len() {
             let entity = world.entities.get_or(i, model.empty_entity());
             if entity.faction == faction && entity.alive {
-                agents = agents + 1;
-                health = health + entity.health;
-                energy = energy + entity.energy;
-                inventory = inventory + entity.inventory;
+                agents += 1;
+                health += entity.health;
+                energy += entity.energy;
+                inventory += entity.inventory;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = agents * (MODE() % 11 + 1) + health * 3 +
             energy * 5 + inventory * 7 + faction;
         metric.observe(inout out, projection, faction + MODE() % 5 + 1);
-        faction = faction + 1;
+        faction += 1;
     }
 }
 
@@ -150,17 +150,17 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
-                tiles = tiles + 1;
+                tiles += 1;
                 if tile.walkable { walkable = walkable + 1; }
-                resources = resources + tile.resource;
-                elevation = elevation + tile.height;
+                resources += tile.resource;
+                elevation += tile.height;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = tiles * (MODE() % 13 + 1) + walkable * 3 +
             resources * 5 + elevation * 7 + region;
         metric.observe(inout out, projection, region % 7 + 1);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/audit_quest_throughput.rue
+++ b/examples/caldera/audit_quest_throughput.rue
@@ -151,7 +151,7 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
                 tiles += 1;
-                if tile.walkable { walkable = walkable + 1; }
+                if tile.walkable { walkable += 1; }
                 resources += tile.resource;
                 elevation += tile.height;
             }

--- a/examples/caldera/audit_quest_throughput.rue
+++ b/examples/caldera/audit_quest_throughput.rue
@@ -63,7 +63,7 @@ fn observe_entities(inout out: metric.Metric, borrow world: model.World) {
         metric.observe(inout out, entity_projection(borrow world, i), (i % 11) + 1);
         metric.warn(inout out, item.alive && (item.x < 0 || item.y < 0 ||
             @intCast(item.x) >= world.width || @intCast(item.y) >= world.height));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -73,7 +73,7 @@ fn observe_tiles(inout out: metric.Metric, borrow world: model.World) {
         let item = world.tiles.get_or(i, model.empty_tile());
         metric.observe(inout out, tile_projection(borrow world, i), (i % 13) + 1);
         metric.warn(inout out, item.x >= world.width || item.y >= world.height);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -82,18 +82,18 @@ fn observe_timeline(inout out: metric.Metric, borrow world: model.World) {
     while i < world.events.len() {
         metric.observe(inout out, event_projection(borrow world, i), (i % 5) + 1);
         metric.warn(inout out, world.events.get_or(i, model.empty_event()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
         metric.observe(inout out, command_projection(borrow world, i), (i % 7) + 1);
         metric.warn(inout out, world.commands.get_or(i, model.empty_command()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.snapshots.len() {
         metric.observe(inout out, snapshot_projection(borrow world, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -108,9 +108,9 @@ fn observe_pairs(inout out: metric.Metric, borrow world: model.World) {
             let dy = if left.y > right.y { left.y - right.y } else { right.y - left.y };
             metric.observe(inout out, @intCast(dx + dy) +
                 left.faction * 3 + right.faction * 5 + MODE(), i + j + 1);
-            j = j + 1;
+            j += 1;
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -125,17 +125,17 @@ fn observe_factions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.entities.len() {
             let entity = world.entities.get_or(i, model.empty_entity());
             if entity.faction == faction && entity.alive {
-                agents = agents + 1;
-                health = health + entity.health;
-                energy = energy + entity.energy;
-                inventory = inventory + entity.inventory;
+                agents += 1;
+                health += entity.health;
+                energy += entity.energy;
+                inventory += entity.inventory;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = agents * (MODE() % 11 + 1) + health * 3 +
             energy * 5 + inventory * 7 + faction;
         metric.observe(inout out, projection, faction + MODE() % 5 + 1);
-        faction = faction + 1;
+        faction += 1;
     }
 }
 
@@ -150,17 +150,17 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
-                tiles = tiles + 1;
+                tiles += 1;
                 if tile.walkable { walkable = walkable + 1; }
-                resources = resources + tile.resource;
-                elevation = elevation + tile.height;
+                resources += tile.resource;
+                elevation += tile.height;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = tiles * (MODE() % 13 + 1) + walkable * 3 +
             resources * 5 + elevation * 7 + region;
         metric.observe(inout out, projection, region % 7 + 1);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/audit_render_balance.rue
+++ b/examples/caldera/audit_render_balance.rue
@@ -151,7 +151,7 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
                 tiles += 1;
-                if tile.walkable { walkable = walkable + 1; }
+                if tile.walkable { walkable += 1; }
                 resources += tile.resource;
                 elevation += tile.height;
             }

--- a/examples/caldera/audit_render_balance.rue
+++ b/examples/caldera/audit_render_balance.rue
@@ -63,7 +63,7 @@ fn observe_entities(inout out: metric.Metric, borrow world: model.World) {
         metric.observe(inout out, entity_projection(borrow world, i), (i % 11) + 1);
         metric.warn(inout out, item.alive && (item.x < 0 || item.y < 0 ||
             @intCast(item.x) >= world.width || @intCast(item.y) >= world.height));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -73,7 +73,7 @@ fn observe_tiles(inout out: metric.Metric, borrow world: model.World) {
         let item = world.tiles.get_or(i, model.empty_tile());
         metric.observe(inout out, tile_projection(borrow world, i), (i % 13) + 1);
         metric.warn(inout out, item.x >= world.width || item.y >= world.height);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -82,18 +82,18 @@ fn observe_timeline(inout out: metric.Metric, borrow world: model.World) {
     while i < world.events.len() {
         metric.observe(inout out, event_projection(borrow world, i), (i % 5) + 1);
         metric.warn(inout out, world.events.get_or(i, model.empty_event()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
         metric.observe(inout out, command_projection(borrow world, i), (i % 7) + 1);
         metric.warn(inout out, world.commands.get_or(i, model.empty_command()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.snapshots.len() {
         metric.observe(inout out, snapshot_projection(borrow world, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -108,9 +108,9 @@ fn observe_pairs(inout out: metric.Metric, borrow world: model.World) {
             let dy = if left.y > right.y { left.y - right.y } else { right.y - left.y };
             metric.observe(inout out, @intCast(dx + dy) +
                 left.faction * 3 + right.faction * 5 + MODE(), i + j + 1);
-            j = j + 1;
+            j += 1;
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -125,17 +125,17 @@ fn observe_factions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.entities.len() {
             let entity = world.entities.get_or(i, model.empty_entity());
             if entity.faction == faction && entity.alive {
-                agents = agents + 1;
-                health = health + entity.health;
-                energy = energy + entity.energy;
-                inventory = inventory + entity.inventory;
+                agents += 1;
+                health += entity.health;
+                energy += entity.energy;
+                inventory += entity.inventory;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = agents * (MODE() % 11 + 1) + health * 3 +
             energy * 5 + inventory * 7 + faction;
         metric.observe(inout out, projection, faction + MODE() % 5 + 1);
-        faction = faction + 1;
+        faction += 1;
     }
 }
 
@@ -150,17 +150,17 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
-                tiles = tiles + 1;
+                tiles += 1;
                 if tile.walkable { walkable = walkable + 1; }
-                resources = resources + tile.resource;
-                elevation = elevation + tile.height;
+                resources += tile.resource;
+                elevation += tile.height;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = tiles * (MODE() % 13 + 1) + walkable * 3 +
             resources * 5 + elevation * 7 + region;
         metric.observe(inout out, projection, region % 7 + 1);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/audit_render_capacity.rue
+++ b/examples/caldera/audit_render_capacity.rue
@@ -151,7 +151,7 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
                 tiles += 1;
-                if tile.walkable { walkable = walkable + 1; }
+                if tile.walkable { walkable += 1; }
                 resources += tile.resource;
                 elevation += tile.height;
             }

--- a/examples/caldera/audit_render_capacity.rue
+++ b/examples/caldera/audit_render_capacity.rue
@@ -63,7 +63,7 @@ fn observe_entities(inout out: metric.Metric, borrow world: model.World) {
         metric.observe(inout out, entity_projection(borrow world, i), (i % 11) + 1);
         metric.warn(inout out, item.alive && (item.x < 0 || item.y < 0 ||
             @intCast(item.x) >= world.width || @intCast(item.y) >= world.height));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -73,7 +73,7 @@ fn observe_tiles(inout out: metric.Metric, borrow world: model.World) {
         let item = world.tiles.get_or(i, model.empty_tile());
         metric.observe(inout out, tile_projection(borrow world, i), (i % 13) + 1);
         metric.warn(inout out, item.x >= world.width || item.y >= world.height);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -82,18 +82,18 @@ fn observe_timeline(inout out: metric.Metric, borrow world: model.World) {
     while i < world.events.len() {
         metric.observe(inout out, event_projection(borrow world, i), (i % 5) + 1);
         metric.warn(inout out, world.events.get_or(i, model.empty_event()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
         metric.observe(inout out, command_projection(borrow world, i), (i % 7) + 1);
         metric.warn(inout out, world.commands.get_or(i, model.empty_command()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.snapshots.len() {
         metric.observe(inout out, snapshot_projection(borrow world, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -108,9 +108,9 @@ fn observe_pairs(inout out: metric.Metric, borrow world: model.World) {
             let dy = if left.y > right.y { left.y - right.y } else { right.y - left.y };
             metric.observe(inout out, @intCast(dx + dy) +
                 left.faction * 3 + right.faction * 5 + MODE(), i + j + 1);
-            j = j + 1;
+            j += 1;
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -125,17 +125,17 @@ fn observe_factions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.entities.len() {
             let entity = world.entities.get_or(i, model.empty_entity());
             if entity.faction == faction && entity.alive {
-                agents = agents + 1;
-                health = health + entity.health;
-                energy = energy + entity.energy;
-                inventory = inventory + entity.inventory;
+                agents += 1;
+                health += entity.health;
+                energy += entity.energy;
+                inventory += entity.inventory;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = agents * (MODE() % 11 + 1) + health * 3 +
             energy * 5 + inventory * 7 + faction;
         metric.observe(inout out, projection, faction + MODE() % 5 + 1);
-        faction = faction + 1;
+        faction += 1;
     }
 }
 
@@ -150,17 +150,17 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
-                tiles = tiles + 1;
+                tiles += 1;
                 if tile.walkable { walkable = walkable + 1; }
-                resources = resources + tile.resource;
-                elevation = elevation + tile.height;
+                resources += tile.resource;
+                elevation += tile.height;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = tiles * (MODE() % 13 + 1) + walkable * 3 +
             resources * 5 + elevation * 7 + region;
         metric.observe(inout out, projection, region % 7 + 1);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/audit_render_continuity.rue
+++ b/examples/caldera/audit_render_continuity.rue
@@ -151,7 +151,7 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
                 tiles += 1;
-                if tile.walkable { walkable = walkable + 1; }
+                if tile.walkable { walkable += 1; }
                 resources += tile.resource;
                 elevation += tile.height;
             }

--- a/examples/caldera/audit_render_continuity.rue
+++ b/examples/caldera/audit_render_continuity.rue
@@ -63,7 +63,7 @@ fn observe_entities(inout out: metric.Metric, borrow world: model.World) {
         metric.observe(inout out, entity_projection(borrow world, i), (i % 11) + 1);
         metric.warn(inout out, item.alive && (item.x < 0 || item.y < 0 ||
             @intCast(item.x) >= world.width || @intCast(item.y) >= world.height));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -73,7 +73,7 @@ fn observe_tiles(inout out: metric.Metric, borrow world: model.World) {
         let item = world.tiles.get_or(i, model.empty_tile());
         metric.observe(inout out, tile_projection(borrow world, i), (i % 13) + 1);
         metric.warn(inout out, item.x >= world.width || item.y >= world.height);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -82,18 +82,18 @@ fn observe_timeline(inout out: metric.Metric, borrow world: model.World) {
     while i < world.events.len() {
         metric.observe(inout out, event_projection(borrow world, i), (i % 5) + 1);
         metric.warn(inout out, world.events.get_or(i, model.empty_event()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
         metric.observe(inout out, command_projection(borrow world, i), (i % 7) + 1);
         metric.warn(inout out, world.commands.get_or(i, model.empty_command()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.snapshots.len() {
         metric.observe(inout out, snapshot_projection(borrow world, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -108,9 +108,9 @@ fn observe_pairs(inout out: metric.Metric, borrow world: model.World) {
             let dy = if left.y > right.y { left.y - right.y } else { right.y - left.y };
             metric.observe(inout out, @intCast(dx + dy) +
                 left.faction * 3 + right.faction * 5 + MODE(), i + j + 1);
-            j = j + 1;
+            j += 1;
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -125,17 +125,17 @@ fn observe_factions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.entities.len() {
             let entity = world.entities.get_or(i, model.empty_entity());
             if entity.faction == faction && entity.alive {
-                agents = agents + 1;
-                health = health + entity.health;
-                energy = energy + entity.energy;
-                inventory = inventory + entity.inventory;
+                agents += 1;
+                health += entity.health;
+                energy += entity.energy;
+                inventory += entity.inventory;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = agents * (MODE() % 11 + 1) + health * 3 +
             energy * 5 + inventory * 7 + faction;
         metric.observe(inout out, projection, faction + MODE() % 5 + 1);
-        faction = faction + 1;
+        faction += 1;
     }
 }
 
@@ -150,17 +150,17 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
-                tiles = tiles + 1;
+                tiles += 1;
                 if tile.walkable { walkable = walkable + 1; }
-                resources = resources + tile.resource;
-                elevation = elevation + tile.height;
+                resources += tile.resource;
+                elevation += tile.height;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = tiles * (MODE() % 13 + 1) + walkable * 3 +
             resources * 5 + elevation * 7 + region;
         metric.observe(inout out, projection, region % 7 + 1);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/audit_render_cost.rue
+++ b/examples/caldera/audit_render_cost.rue
@@ -151,7 +151,7 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
                 tiles += 1;
-                if tile.walkable { walkable = walkable + 1; }
+                if tile.walkable { walkable += 1; }
                 resources += tile.resource;
                 elevation += tile.height;
             }

--- a/examples/caldera/audit_render_cost.rue
+++ b/examples/caldera/audit_render_cost.rue
@@ -63,7 +63,7 @@ fn observe_entities(inout out: metric.Metric, borrow world: model.World) {
         metric.observe(inout out, entity_projection(borrow world, i), (i % 11) + 1);
         metric.warn(inout out, item.alive && (item.x < 0 || item.y < 0 ||
             @intCast(item.x) >= world.width || @intCast(item.y) >= world.height));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -73,7 +73,7 @@ fn observe_tiles(inout out: metric.Metric, borrow world: model.World) {
         let item = world.tiles.get_or(i, model.empty_tile());
         metric.observe(inout out, tile_projection(borrow world, i), (i % 13) + 1);
         metric.warn(inout out, item.x >= world.width || item.y >= world.height);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -82,18 +82,18 @@ fn observe_timeline(inout out: metric.Metric, borrow world: model.World) {
     while i < world.events.len() {
         metric.observe(inout out, event_projection(borrow world, i), (i % 5) + 1);
         metric.warn(inout out, world.events.get_or(i, model.empty_event()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
         metric.observe(inout out, command_projection(borrow world, i), (i % 7) + 1);
         metric.warn(inout out, world.commands.get_or(i, model.empty_command()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.snapshots.len() {
         metric.observe(inout out, snapshot_projection(borrow world, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -108,9 +108,9 @@ fn observe_pairs(inout out: metric.Metric, borrow world: model.World) {
             let dy = if left.y > right.y { left.y - right.y } else { right.y - left.y };
             metric.observe(inout out, @intCast(dx + dy) +
                 left.faction * 3 + right.faction * 5 + MODE(), i + j + 1);
-            j = j + 1;
+            j += 1;
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -125,17 +125,17 @@ fn observe_factions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.entities.len() {
             let entity = world.entities.get_or(i, model.empty_entity());
             if entity.faction == faction && entity.alive {
-                agents = agents + 1;
-                health = health + entity.health;
-                energy = energy + entity.energy;
-                inventory = inventory + entity.inventory;
+                agents += 1;
+                health += entity.health;
+                energy += entity.energy;
+                inventory += entity.inventory;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = agents * (MODE() % 11 + 1) + health * 3 +
             energy * 5 + inventory * 7 + faction;
         metric.observe(inout out, projection, faction + MODE() % 5 + 1);
-        faction = faction + 1;
+        faction += 1;
     }
 }
 
@@ -150,17 +150,17 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
-                tiles = tiles + 1;
+                tiles += 1;
                 if tile.walkable { walkable = walkable + 1; }
-                resources = resources + tile.resource;
-                elevation = elevation + tile.height;
+                resources += tile.resource;
+                elevation += tile.height;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = tiles * (MODE() % 13 + 1) + walkable * 3 +
             resources * 5 + elevation * 7 + region;
         metric.observe(inout out, projection, region % 7 + 1);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/audit_render_coverage.rue
+++ b/examples/caldera/audit_render_coverage.rue
@@ -151,7 +151,7 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
                 tiles += 1;
-                if tile.walkable { walkable = walkable + 1; }
+                if tile.walkable { walkable += 1; }
                 resources += tile.resource;
                 elevation += tile.height;
             }

--- a/examples/caldera/audit_render_coverage.rue
+++ b/examples/caldera/audit_render_coverage.rue
@@ -63,7 +63,7 @@ fn observe_entities(inout out: metric.Metric, borrow world: model.World) {
         metric.observe(inout out, entity_projection(borrow world, i), (i % 11) + 1);
         metric.warn(inout out, item.alive && (item.x < 0 || item.y < 0 ||
             @intCast(item.x) >= world.width || @intCast(item.y) >= world.height));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -73,7 +73,7 @@ fn observe_tiles(inout out: metric.Metric, borrow world: model.World) {
         let item = world.tiles.get_or(i, model.empty_tile());
         metric.observe(inout out, tile_projection(borrow world, i), (i % 13) + 1);
         metric.warn(inout out, item.x >= world.width || item.y >= world.height);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -82,18 +82,18 @@ fn observe_timeline(inout out: metric.Metric, borrow world: model.World) {
     while i < world.events.len() {
         metric.observe(inout out, event_projection(borrow world, i), (i % 5) + 1);
         metric.warn(inout out, world.events.get_or(i, model.empty_event()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
         metric.observe(inout out, command_projection(borrow world, i), (i % 7) + 1);
         metric.warn(inout out, world.commands.get_or(i, model.empty_command()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.snapshots.len() {
         metric.observe(inout out, snapshot_projection(borrow world, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -108,9 +108,9 @@ fn observe_pairs(inout out: metric.Metric, borrow world: model.World) {
             let dy = if left.y > right.y { left.y - right.y } else { right.y - left.y };
             metric.observe(inout out, @intCast(dx + dy) +
                 left.faction * 3 + right.faction * 5 + MODE(), i + j + 1);
-            j = j + 1;
+            j += 1;
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -125,17 +125,17 @@ fn observe_factions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.entities.len() {
             let entity = world.entities.get_or(i, model.empty_entity());
             if entity.faction == faction && entity.alive {
-                agents = agents + 1;
-                health = health + entity.health;
-                energy = energy + entity.energy;
-                inventory = inventory + entity.inventory;
+                agents += 1;
+                health += entity.health;
+                energy += entity.energy;
+                inventory += entity.inventory;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = agents * (MODE() % 11 + 1) + health * 3 +
             energy * 5 + inventory * 7 + faction;
         metric.observe(inout out, projection, faction + MODE() % 5 + 1);
-        faction = faction + 1;
+        faction += 1;
     }
 }
 
@@ -150,17 +150,17 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
-                tiles = tiles + 1;
+                tiles += 1;
                 if tile.walkable { walkable = walkable + 1; }
-                resources = resources + tile.resource;
-                elevation = elevation + tile.height;
+                resources += tile.resource;
+                elevation += tile.height;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = tiles * (MODE() % 13 + 1) + walkable * 3 +
             resources * 5 + elevation * 7 + region;
         metric.observe(inout out, projection, region % 7 + 1);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/audit_render_density.rue
+++ b/examples/caldera/audit_render_density.rue
@@ -151,7 +151,7 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
                 tiles += 1;
-                if tile.walkable { walkable = walkable + 1; }
+                if tile.walkable { walkable += 1; }
                 resources += tile.resource;
                 elevation += tile.height;
             }

--- a/examples/caldera/audit_render_density.rue
+++ b/examples/caldera/audit_render_density.rue
@@ -63,7 +63,7 @@ fn observe_entities(inout out: metric.Metric, borrow world: model.World) {
         metric.observe(inout out, entity_projection(borrow world, i), (i % 11) + 1);
         metric.warn(inout out, item.alive && (item.x < 0 || item.y < 0 ||
             @intCast(item.x) >= world.width || @intCast(item.y) >= world.height));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -73,7 +73,7 @@ fn observe_tiles(inout out: metric.Metric, borrow world: model.World) {
         let item = world.tiles.get_or(i, model.empty_tile());
         metric.observe(inout out, tile_projection(borrow world, i), (i % 13) + 1);
         metric.warn(inout out, item.x >= world.width || item.y >= world.height);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -82,18 +82,18 @@ fn observe_timeline(inout out: metric.Metric, borrow world: model.World) {
     while i < world.events.len() {
         metric.observe(inout out, event_projection(borrow world, i), (i % 5) + 1);
         metric.warn(inout out, world.events.get_or(i, model.empty_event()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
         metric.observe(inout out, command_projection(borrow world, i), (i % 7) + 1);
         metric.warn(inout out, world.commands.get_or(i, model.empty_command()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.snapshots.len() {
         metric.observe(inout out, snapshot_projection(borrow world, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -108,9 +108,9 @@ fn observe_pairs(inout out: metric.Metric, borrow world: model.World) {
             let dy = if left.y > right.y { left.y - right.y } else { right.y - left.y };
             metric.observe(inout out, @intCast(dx + dy) +
                 left.faction * 3 + right.faction * 5 + MODE(), i + j + 1);
-            j = j + 1;
+            j += 1;
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -125,17 +125,17 @@ fn observe_factions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.entities.len() {
             let entity = world.entities.get_or(i, model.empty_entity());
             if entity.faction == faction && entity.alive {
-                agents = agents + 1;
-                health = health + entity.health;
-                energy = energy + entity.energy;
-                inventory = inventory + entity.inventory;
+                agents += 1;
+                health += entity.health;
+                energy += entity.energy;
+                inventory += entity.inventory;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = agents * (MODE() % 11 + 1) + health * 3 +
             energy * 5 + inventory * 7 + faction;
         metric.observe(inout out, projection, faction + MODE() % 5 + 1);
-        faction = faction + 1;
+        faction += 1;
     }
 }
 
@@ -150,17 +150,17 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
-                tiles = tiles + 1;
+                tiles += 1;
                 if tile.walkable { walkable = walkable + 1; }
-                resources = resources + tile.resource;
-                elevation = elevation + tile.height;
+                resources += tile.resource;
+                elevation += tile.height;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = tiles * (MODE() % 13 + 1) + walkable * 3 +
             resources * 5 + elevation * 7 + region;
         metric.observe(inout out, projection, region % 7 + 1);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/audit_render_entropy.rue
+++ b/examples/caldera/audit_render_entropy.rue
@@ -151,7 +151,7 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
                 tiles += 1;
-                if tile.walkable { walkable = walkable + 1; }
+                if tile.walkable { walkable += 1; }
                 resources += tile.resource;
                 elevation += tile.height;
             }

--- a/examples/caldera/audit_render_entropy.rue
+++ b/examples/caldera/audit_render_entropy.rue
@@ -63,7 +63,7 @@ fn observe_entities(inout out: metric.Metric, borrow world: model.World) {
         metric.observe(inout out, entity_projection(borrow world, i), (i % 11) + 1);
         metric.warn(inout out, item.alive && (item.x < 0 || item.y < 0 ||
             @intCast(item.x) >= world.width || @intCast(item.y) >= world.height));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -73,7 +73,7 @@ fn observe_tiles(inout out: metric.Metric, borrow world: model.World) {
         let item = world.tiles.get_or(i, model.empty_tile());
         metric.observe(inout out, tile_projection(borrow world, i), (i % 13) + 1);
         metric.warn(inout out, item.x >= world.width || item.y >= world.height);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -82,18 +82,18 @@ fn observe_timeline(inout out: metric.Metric, borrow world: model.World) {
     while i < world.events.len() {
         metric.observe(inout out, event_projection(borrow world, i), (i % 5) + 1);
         metric.warn(inout out, world.events.get_or(i, model.empty_event()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
         metric.observe(inout out, command_projection(borrow world, i), (i % 7) + 1);
         metric.warn(inout out, world.commands.get_or(i, model.empty_command()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.snapshots.len() {
         metric.observe(inout out, snapshot_projection(borrow world, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -108,9 +108,9 @@ fn observe_pairs(inout out: metric.Metric, borrow world: model.World) {
             let dy = if left.y > right.y { left.y - right.y } else { right.y - left.y };
             metric.observe(inout out, @intCast(dx + dy) +
                 left.faction * 3 + right.faction * 5 + MODE(), i + j + 1);
-            j = j + 1;
+            j += 1;
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -125,17 +125,17 @@ fn observe_factions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.entities.len() {
             let entity = world.entities.get_or(i, model.empty_entity());
             if entity.faction == faction && entity.alive {
-                agents = agents + 1;
-                health = health + entity.health;
-                energy = energy + entity.energy;
-                inventory = inventory + entity.inventory;
+                agents += 1;
+                health += entity.health;
+                energy += entity.energy;
+                inventory += entity.inventory;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = agents * (MODE() % 11 + 1) + health * 3 +
             energy * 5 + inventory * 7 + faction;
         metric.observe(inout out, projection, faction + MODE() % 5 + 1);
-        faction = faction + 1;
+        faction += 1;
     }
 }
 
@@ -150,17 +150,17 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
-                tiles = tiles + 1;
+                tiles += 1;
                 if tile.walkable { walkable = walkable + 1; }
-                resources = resources + tile.resource;
-                elevation = elevation + tile.height;
+                resources += tile.resource;
+                elevation += tile.height;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = tiles * (MODE() % 13 + 1) + walkable * 3 +
             resources * 5 + elevation * 7 + region;
         metric.observe(inout out, projection, region % 7 + 1);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/audit_render_fanout.rue
+++ b/examples/caldera/audit_render_fanout.rue
@@ -151,7 +151,7 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
                 tiles += 1;
-                if tile.walkable { walkable = walkable + 1; }
+                if tile.walkable { walkable += 1; }
                 resources += tile.resource;
                 elevation += tile.height;
             }

--- a/examples/caldera/audit_render_fanout.rue
+++ b/examples/caldera/audit_render_fanout.rue
@@ -63,7 +63,7 @@ fn observe_entities(inout out: metric.Metric, borrow world: model.World) {
         metric.observe(inout out, entity_projection(borrow world, i), (i % 11) + 1);
         metric.warn(inout out, item.alive && (item.x < 0 || item.y < 0 ||
             @intCast(item.x) >= world.width || @intCast(item.y) >= world.height));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -73,7 +73,7 @@ fn observe_tiles(inout out: metric.Metric, borrow world: model.World) {
         let item = world.tiles.get_or(i, model.empty_tile());
         metric.observe(inout out, tile_projection(borrow world, i), (i % 13) + 1);
         metric.warn(inout out, item.x >= world.width || item.y >= world.height);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -82,18 +82,18 @@ fn observe_timeline(inout out: metric.Metric, borrow world: model.World) {
     while i < world.events.len() {
         metric.observe(inout out, event_projection(borrow world, i), (i % 5) + 1);
         metric.warn(inout out, world.events.get_or(i, model.empty_event()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
         metric.observe(inout out, command_projection(borrow world, i), (i % 7) + 1);
         metric.warn(inout out, world.commands.get_or(i, model.empty_command()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.snapshots.len() {
         metric.observe(inout out, snapshot_projection(borrow world, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -108,9 +108,9 @@ fn observe_pairs(inout out: metric.Metric, borrow world: model.World) {
             let dy = if left.y > right.y { left.y - right.y } else { right.y - left.y };
             metric.observe(inout out, @intCast(dx + dy) +
                 left.faction * 3 + right.faction * 5 + MODE(), i + j + 1);
-            j = j + 1;
+            j += 1;
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -125,17 +125,17 @@ fn observe_factions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.entities.len() {
             let entity = world.entities.get_or(i, model.empty_entity());
             if entity.faction == faction && entity.alive {
-                agents = agents + 1;
-                health = health + entity.health;
-                energy = energy + entity.energy;
-                inventory = inventory + entity.inventory;
+                agents += 1;
+                health += entity.health;
+                energy += entity.energy;
+                inventory += entity.inventory;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = agents * (MODE() % 11 + 1) + health * 3 +
             energy * 5 + inventory * 7 + faction;
         metric.observe(inout out, projection, faction + MODE() % 5 + 1);
-        faction = faction + 1;
+        faction += 1;
     }
 }
 
@@ -150,17 +150,17 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
-                tiles = tiles + 1;
+                tiles += 1;
                 if tile.walkable { walkable = walkable + 1; }
-                resources = resources + tile.resource;
-                elevation = elevation + tile.height;
+                resources += tile.resource;
+                elevation += tile.height;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = tiles * (MODE() % 13 + 1) + walkable * 3 +
             resources * 5 + elevation * 7 + region;
         metric.observe(inout out, projection, region % 7 + 1);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/audit_render_integrity.rue
+++ b/examples/caldera/audit_render_integrity.rue
@@ -151,7 +151,7 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
                 tiles += 1;
-                if tile.walkable { walkable = walkable + 1; }
+                if tile.walkable { walkable += 1; }
                 resources += tile.resource;
                 elevation += tile.height;
             }

--- a/examples/caldera/audit_render_integrity.rue
+++ b/examples/caldera/audit_render_integrity.rue
@@ -63,7 +63,7 @@ fn observe_entities(inout out: metric.Metric, borrow world: model.World) {
         metric.observe(inout out, entity_projection(borrow world, i), (i % 11) + 1);
         metric.warn(inout out, item.alive && (item.x < 0 || item.y < 0 ||
             @intCast(item.x) >= world.width || @intCast(item.y) >= world.height));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -73,7 +73,7 @@ fn observe_tiles(inout out: metric.Metric, borrow world: model.World) {
         let item = world.tiles.get_or(i, model.empty_tile());
         metric.observe(inout out, tile_projection(borrow world, i), (i % 13) + 1);
         metric.warn(inout out, item.x >= world.width || item.y >= world.height);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -82,18 +82,18 @@ fn observe_timeline(inout out: metric.Metric, borrow world: model.World) {
     while i < world.events.len() {
         metric.observe(inout out, event_projection(borrow world, i), (i % 5) + 1);
         metric.warn(inout out, world.events.get_or(i, model.empty_event()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
         metric.observe(inout out, command_projection(borrow world, i), (i % 7) + 1);
         metric.warn(inout out, world.commands.get_or(i, model.empty_command()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.snapshots.len() {
         metric.observe(inout out, snapshot_projection(borrow world, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -108,9 +108,9 @@ fn observe_pairs(inout out: metric.Metric, borrow world: model.World) {
             let dy = if left.y > right.y { left.y - right.y } else { right.y - left.y };
             metric.observe(inout out, @intCast(dx + dy) +
                 left.faction * 3 + right.faction * 5 + MODE(), i + j + 1);
-            j = j + 1;
+            j += 1;
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -125,17 +125,17 @@ fn observe_factions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.entities.len() {
             let entity = world.entities.get_or(i, model.empty_entity());
             if entity.faction == faction && entity.alive {
-                agents = agents + 1;
-                health = health + entity.health;
-                energy = energy + entity.energy;
-                inventory = inventory + entity.inventory;
+                agents += 1;
+                health += entity.health;
+                energy += entity.energy;
+                inventory += entity.inventory;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = agents * (MODE() % 11 + 1) + health * 3 +
             energy * 5 + inventory * 7 + faction;
         metric.observe(inout out, projection, faction + MODE() % 5 + 1);
-        faction = faction + 1;
+        faction += 1;
     }
 }
 
@@ -150,17 +150,17 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
-                tiles = tiles + 1;
+                tiles += 1;
                 if tile.walkable { walkable = walkable + 1; }
-                resources = resources + tile.resource;
-                elevation = elevation + tile.height;
+                resources += tile.resource;
+                elevation += tile.height;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = tiles * (MODE() % 13 + 1) + walkable * 3 +
             resources * 5 + elevation * 7 + region;
         metric.observe(inout out, projection, region % 7 + 1);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/audit_render_latency.rue
+++ b/examples/caldera/audit_render_latency.rue
@@ -151,7 +151,7 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
                 tiles += 1;
-                if tile.walkable { walkable = walkable + 1; }
+                if tile.walkable { walkable += 1; }
                 resources += tile.resource;
                 elevation += tile.height;
             }

--- a/examples/caldera/audit_render_latency.rue
+++ b/examples/caldera/audit_render_latency.rue
@@ -63,7 +63,7 @@ fn observe_entities(inout out: metric.Metric, borrow world: model.World) {
         metric.observe(inout out, entity_projection(borrow world, i), (i % 11) + 1);
         metric.warn(inout out, item.alive && (item.x < 0 || item.y < 0 ||
             @intCast(item.x) >= world.width || @intCast(item.y) >= world.height));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -73,7 +73,7 @@ fn observe_tiles(inout out: metric.Metric, borrow world: model.World) {
         let item = world.tiles.get_or(i, model.empty_tile());
         metric.observe(inout out, tile_projection(borrow world, i), (i % 13) + 1);
         metric.warn(inout out, item.x >= world.width || item.y >= world.height);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -82,18 +82,18 @@ fn observe_timeline(inout out: metric.Metric, borrow world: model.World) {
     while i < world.events.len() {
         metric.observe(inout out, event_projection(borrow world, i), (i % 5) + 1);
         metric.warn(inout out, world.events.get_or(i, model.empty_event()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
         metric.observe(inout out, command_projection(borrow world, i), (i % 7) + 1);
         metric.warn(inout out, world.commands.get_or(i, model.empty_command()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.snapshots.len() {
         metric.observe(inout out, snapshot_projection(borrow world, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -108,9 +108,9 @@ fn observe_pairs(inout out: metric.Metric, borrow world: model.World) {
             let dy = if left.y > right.y { left.y - right.y } else { right.y - left.y };
             metric.observe(inout out, @intCast(dx + dy) +
                 left.faction * 3 + right.faction * 5 + MODE(), i + j + 1);
-            j = j + 1;
+            j += 1;
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -125,17 +125,17 @@ fn observe_factions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.entities.len() {
             let entity = world.entities.get_or(i, model.empty_entity());
             if entity.faction == faction && entity.alive {
-                agents = agents + 1;
-                health = health + entity.health;
-                energy = energy + entity.energy;
-                inventory = inventory + entity.inventory;
+                agents += 1;
+                health += entity.health;
+                energy += entity.energy;
+                inventory += entity.inventory;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = agents * (MODE() % 11 + 1) + health * 3 +
             energy * 5 + inventory * 7 + faction;
         metric.observe(inout out, projection, faction + MODE() % 5 + 1);
-        faction = faction + 1;
+        faction += 1;
     }
 }
 
@@ -150,17 +150,17 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
-                tiles = tiles + 1;
+                tiles += 1;
                 if tile.walkable { walkable = walkable + 1; }
-                resources = resources + tile.resource;
-                elevation = elevation + tile.height;
+                resources += tile.resource;
+                elevation += tile.height;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = tiles * (MODE() % 13 + 1) + walkable * 3 +
             resources * 5 + elevation * 7 + region;
         metric.observe(inout out, projection, region % 7 + 1);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/audit_render_locality.rue
+++ b/examples/caldera/audit_render_locality.rue
@@ -151,7 +151,7 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
                 tiles += 1;
-                if tile.walkable { walkable = walkable + 1; }
+                if tile.walkable { walkable += 1; }
                 resources += tile.resource;
                 elevation += tile.height;
             }

--- a/examples/caldera/audit_render_locality.rue
+++ b/examples/caldera/audit_render_locality.rue
@@ -63,7 +63,7 @@ fn observe_entities(inout out: metric.Metric, borrow world: model.World) {
         metric.observe(inout out, entity_projection(borrow world, i), (i % 11) + 1);
         metric.warn(inout out, item.alive && (item.x < 0 || item.y < 0 ||
             @intCast(item.x) >= world.width || @intCast(item.y) >= world.height));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -73,7 +73,7 @@ fn observe_tiles(inout out: metric.Metric, borrow world: model.World) {
         let item = world.tiles.get_or(i, model.empty_tile());
         metric.observe(inout out, tile_projection(borrow world, i), (i % 13) + 1);
         metric.warn(inout out, item.x >= world.width || item.y >= world.height);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -82,18 +82,18 @@ fn observe_timeline(inout out: metric.Metric, borrow world: model.World) {
     while i < world.events.len() {
         metric.observe(inout out, event_projection(borrow world, i), (i % 5) + 1);
         metric.warn(inout out, world.events.get_or(i, model.empty_event()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
         metric.observe(inout out, command_projection(borrow world, i), (i % 7) + 1);
         metric.warn(inout out, world.commands.get_or(i, model.empty_command()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.snapshots.len() {
         metric.observe(inout out, snapshot_projection(borrow world, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -108,9 +108,9 @@ fn observe_pairs(inout out: metric.Metric, borrow world: model.World) {
             let dy = if left.y > right.y { left.y - right.y } else { right.y - left.y };
             metric.observe(inout out, @intCast(dx + dy) +
                 left.faction * 3 + right.faction * 5 + MODE(), i + j + 1);
-            j = j + 1;
+            j += 1;
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -125,17 +125,17 @@ fn observe_factions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.entities.len() {
             let entity = world.entities.get_or(i, model.empty_entity());
             if entity.faction == faction && entity.alive {
-                agents = agents + 1;
-                health = health + entity.health;
-                energy = energy + entity.energy;
-                inventory = inventory + entity.inventory;
+                agents += 1;
+                health += entity.health;
+                energy += entity.energy;
+                inventory += entity.inventory;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = agents * (MODE() % 11 + 1) + health * 3 +
             energy * 5 + inventory * 7 + faction;
         metric.observe(inout out, projection, faction + MODE() % 5 + 1);
-        faction = faction + 1;
+        faction += 1;
     }
 }
 
@@ -150,17 +150,17 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
-                tiles = tiles + 1;
+                tiles += 1;
                 if tile.walkable { walkable = walkable + 1; }
-                resources = resources + tile.resource;
-                elevation = elevation + tile.height;
+                resources += tile.resource;
+                elevation += tile.height;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = tiles * (MODE() % 13 + 1) + walkable * 3 +
             resources * 5 + elevation * 7 + region;
         metric.observe(inout out, projection, region % 7 + 1);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/audit_render_pressure.rue
+++ b/examples/caldera/audit_render_pressure.rue
@@ -151,7 +151,7 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
                 tiles += 1;
-                if tile.walkable { walkable = walkable + 1; }
+                if tile.walkable { walkable += 1; }
                 resources += tile.resource;
                 elevation += tile.height;
             }

--- a/examples/caldera/audit_render_pressure.rue
+++ b/examples/caldera/audit_render_pressure.rue
@@ -63,7 +63,7 @@ fn observe_entities(inout out: metric.Metric, borrow world: model.World) {
         metric.observe(inout out, entity_projection(borrow world, i), (i % 11) + 1);
         metric.warn(inout out, item.alive && (item.x < 0 || item.y < 0 ||
             @intCast(item.x) >= world.width || @intCast(item.y) >= world.height));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -73,7 +73,7 @@ fn observe_tiles(inout out: metric.Metric, borrow world: model.World) {
         let item = world.tiles.get_or(i, model.empty_tile());
         metric.observe(inout out, tile_projection(borrow world, i), (i % 13) + 1);
         metric.warn(inout out, item.x >= world.width || item.y >= world.height);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -82,18 +82,18 @@ fn observe_timeline(inout out: metric.Metric, borrow world: model.World) {
     while i < world.events.len() {
         metric.observe(inout out, event_projection(borrow world, i), (i % 5) + 1);
         metric.warn(inout out, world.events.get_or(i, model.empty_event()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
         metric.observe(inout out, command_projection(borrow world, i), (i % 7) + 1);
         metric.warn(inout out, world.commands.get_or(i, model.empty_command()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.snapshots.len() {
         metric.observe(inout out, snapshot_projection(borrow world, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -108,9 +108,9 @@ fn observe_pairs(inout out: metric.Metric, borrow world: model.World) {
             let dy = if left.y > right.y { left.y - right.y } else { right.y - left.y };
             metric.observe(inout out, @intCast(dx + dy) +
                 left.faction * 3 + right.faction * 5 + MODE(), i + j + 1);
-            j = j + 1;
+            j += 1;
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -125,17 +125,17 @@ fn observe_factions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.entities.len() {
             let entity = world.entities.get_or(i, model.empty_entity());
             if entity.faction == faction && entity.alive {
-                agents = agents + 1;
-                health = health + entity.health;
-                energy = energy + entity.energy;
-                inventory = inventory + entity.inventory;
+                agents += 1;
+                health += entity.health;
+                energy += entity.energy;
+                inventory += entity.inventory;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = agents * (MODE() % 11 + 1) + health * 3 +
             energy * 5 + inventory * 7 + faction;
         metric.observe(inout out, projection, faction + MODE() % 5 + 1);
-        faction = faction + 1;
+        faction += 1;
     }
 }
 
@@ -150,17 +150,17 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
-                tiles = tiles + 1;
+                tiles += 1;
                 if tile.walkable { walkable = walkable + 1; }
-                resources = resources + tile.resource;
-                elevation = elevation + tile.height;
+                resources += tile.resource;
+                elevation += tile.height;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = tiles * (MODE() % 13 + 1) + walkable * 3 +
             resources * 5 + elevation * 7 + region;
         metric.observe(inout out, projection, region % 7 + 1);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/audit_render_risk.rue
+++ b/examples/caldera/audit_render_risk.rue
@@ -151,7 +151,7 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
                 tiles += 1;
-                if tile.walkable { walkable = walkable + 1; }
+                if tile.walkable { walkable += 1; }
                 resources += tile.resource;
                 elevation += tile.height;
             }

--- a/examples/caldera/audit_render_risk.rue
+++ b/examples/caldera/audit_render_risk.rue
@@ -63,7 +63,7 @@ fn observe_entities(inout out: metric.Metric, borrow world: model.World) {
         metric.observe(inout out, entity_projection(borrow world, i), (i % 11) + 1);
         metric.warn(inout out, item.alive && (item.x < 0 || item.y < 0 ||
             @intCast(item.x) >= world.width || @intCast(item.y) >= world.height));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -73,7 +73,7 @@ fn observe_tiles(inout out: metric.Metric, borrow world: model.World) {
         let item = world.tiles.get_or(i, model.empty_tile());
         metric.observe(inout out, tile_projection(borrow world, i), (i % 13) + 1);
         metric.warn(inout out, item.x >= world.width || item.y >= world.height);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -82,18 +82,18 @@ fn observe_timeline(inout out: metric.Metric, borrow world: model.World) {
     while i < world.events.len() {
         metric.observe(inout out, event_projection(borrow world, i), (i % 5) + 1);
         metric.warn(inout out, world.events.get_or(i, model.empty_event()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
         metric.observe(inout out, command_projection(borrow world, i), (i % 7) + 1);
         metric.warn(inout out, world.commands.get_or(i, model.empty_command()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.snapshots.len() {
         metric.observe(inout out, snapshot_projection(borrow world, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -108,9 +108,9 @@ fn observe_pairs(inout out: metric.Metric, borrow world: model.World) {
             let dy = if left.y > right.y { left.y - right.y } else { right.y - left.y };
             metric.observe(inout out, @intCast(dx + dy) +
                 left.faction * 3 + right.faction * 5 + MODE(), i + j + 1);
-            j = j + 1;
+            j += 1;
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -125,17 +125,17 @@ fn observe_factions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.entities.len() {
             let entity = world.entities.get_or(i, model.empty_entity());
             if entity.faction == faction && entity.alive {
-                agents = agents + 1;
-                health = health + entity.health;
-                energy = energy + entity.energy;
-                inventory = inventory + entity.inventory;
+                agents += 1;
+                health += entity.health;
+                energy += entity.energy;
+                inventory += entity.inventory;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = agents * (MODE() % 11 + 1) + health * 3 +
             energy * 5 + inventory * 7 + faction;
         metric.observe(inout out, projection, faction + MODE() % 5 + 1);
-        faction = faction + 1;
+        faction += 1;
     }
 }
 
@@ -150,17 +150,17 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
-                tiles = tiles + 1;
+                tiles += 1;
                 if tile.walkable { walkable = walkable + 1; }
-                resources = resources + tile.resource;
-                elevation = elevation + tile.height;
+                resources += tile.resource;
+                elevation += tile.height;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = tiles * (MODE() % 13 + 1) + walkable * 3 +
             resources * 5 + elevation * 7 + region;
         metric.observe(inout out, projection, region % 7 + 1);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/audit_render_skew.rue
+++ b/examples/caldera/audit_render_skew.rue
@@ -151,7 +151,7 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
                 tiles += 1;
-                if tile.walkable { walkable = walkable + 1; }
+                if tile.walkable { walkable += 1; }
                 resources += tile.resource;
                 elevation += tile.height;
             }

--- a/examples/caldera/audit_render_skew.rue
+++ b/examples/caldera/audit_render_skew.rue
@@ -63,7 +63,7 @@ fn observe_entities(inout out: metric.Metric, borrow world: model.World) {
         metric.observe(inout out, entity_projection(borrow world, i), (i % 11) + 1);
         metric.warn(inout out, item.alive && (item.x < 0 || item.y < 0 ||
             @intCast(item.x) >= world.width || @intCast(item.y) >= world.height));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -73,7 +73,7 @@ fn observe_tiles(inout out: metric.Metric, borrow world: model.World) {
         let item = world.tiles.get_or(i, model.empty_tile());
         metric.observe(inout out, tile_projection(borrow world, i), (i % 13) + 1);
         metric.warn(inout out, item.x >= world.width || item.y >= world.height);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -82,18 +82,18 @@ fn observe_timeline(inout out: metric.Metric, borrow world: model.World) {
     while i < world.events.len() {
         metric.observe(inout out, event_projection(borrow world, i), (i % 5) + 1);
         metric.warn(inout out, world.events.get_or(i, model.empty_event()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
         metric.observe(inout out, command_projection(borrow world, i), (i % 7) + 1);
         metric.warn(inout out, world.commands.get_or(i, model.empty_command()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.snapshots.len() {
         metric.observe(inout out, snapshot_projection(borrow world, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -108,9 +108,9 @@ fn observe_pairs(inout out: metric.Metric, borrow world: model.World) {
             let dy = if left.y > right.y { left.y - right.y } else { right.y - left.y };
             metric.observe(inout out, @intCast(dx + dy) +
                 left.faction * 3 + right.faction * 5 + MODE(), i + j + 1);
-            j = j + 1;
+            j += 1;
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -125,17 +125,17 @@ fn observe_factions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.entities.len() {
             let entity = world.entities.get_or(i, model.empty_entity());
             if entity.faction == faction && entity.alive {
-                agents = agents + 1;
-                health = health + entity.health;
-                energy = energy + entity.energy;
-                inventory = inventory + entity.inventory;
+                agents += 1;
+                health += entity.health;
+                energy += entity.energy;
+                inventory += entity.inventory;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = agents * (MODE() % 11 + 1) + health * 3 +
             energy * 5 + inventory * 7 + faction;
         metric.observe(inout out, projection, faction + MODE() % 5 + 1);
-        faction = faction + 1;
+        faction += 1;
     }
 }
 
@@ -150,17 +150,17 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
-                tiles = tiles + 1;
+                tiles += 1;
                 if tile.walkable { walkable = walkable + 1; }
-                resources = resources + tile.resource;
-                elevation = elevation + tile.height;
+                resources += tile.resource;
+                elevation += tile.height;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = tiles * (MODE() % 13 + 1) + walkable * 3 +
             resources * 5 + elevation * 7 + region;
         metric.observe(inout out, projection, region % 7 + 1);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/audit_render_stability.rue
+++ b/examples/caldera/audit_render_stability.rue
@@ -151,7 +151,7 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
                 tiles += 1;
-                if tile.walkable { walkable = walkable + 1; }
+                if tile.walkable { walkable += 1; }
                 resources += tile.resource;
                 elevation += tile.height;
             }

--- a/examples/caldera/audit_render_stability.rue
+++ b/examples/caldera/audit_render_stability.rue
@@ -63,7 +63,7 @@ fn observe_entities(inout out: metric.Metric, borrow world: model.World) {
         metric.observe(inout out, entity_projection(borrow world, i), (i % 11) + 1);
         metric.warn(inout out, item.alive && (item.x < 0 || item.y < 0 ||
             @intCast(item.x) >= world.width || @intCast(item.y) >= world.height));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -73,7 +73,7 @@ fn observe_tiles(inout out: metric.Metric, borrow world: model.World) {
         let item = world.tiles.get_or(i, model.empty_tile());
         metric.observe(inout out, tile_projection(borrow world, i), (i % 13) + 1);
         metric.warn(inout out, item.x >= world.width || item.y >= world.height);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -82,18 +82,18 @@ fn observe_timeline(inout out: metric.Metric, borrow world: model.World) {
     while i < world.events.len() {
         metric.observe(inout out, event_projection(borrow world, i), (i % 5) + 1);
         metric.warn(inout out, world.events.get_or(i, model.empty_event()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
         metric.observe(inout out, command_projection(borrow world, i), (i % 7) + 1);
         metric.warn(inout out, world.commands.get_or(i, model.empty_command()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.snapshots.len() {
         metric.observe(inout out, snapshot_projection(borrow world, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -108,9 +108,9 @@ fn observe_pairs(inout out: metric.Metric, borrow world: model.World) {
             let dy = if left.y > right.y { left.y - right.y } else { right.y - left.y };
             metric.observe(inout out, @intCast(dx + dy) +
                 left.faction * 3 + right.faction * 5 + MODE(), i + j + 1);
-            j = j + 1;
+            j += 1;
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -125,17 +125,17 @@ fn observe_factions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.entities.len() {
             let entity = world.entities.get_or(i, model.empty_entity());
             if entity.faction == faction && entity.alive {
-                agents = agents + 1;
-                health = health + entity.health;
-                energy = energy + entity.energy;
-                inventory = inventory + entity.inventory;
+                agents += 1;
+                health += entity.health;
+                energy += entity.energy;
+                inventory += entity.inventory;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = agents * (MODE() % 11 + 1) + health * 3 +
             energy * 5 + inventory * 7 + faction;
         metric.observe(inout out, projection, faction + MODE() % 5 + 1);
-        faction = faction + 1;
+        faction += 1;
     }
 }
 
@@ -150,17 +150,17 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
-                tiles = tiles + 1;
+                tiles += 1;
                 if tile.walkable { walkable = walkable + 1; }
-                resources = resources + tile.resource;
-                elevation = elevation + tile.height;
+                resources += tile.resource;
+                elevation += tile.height;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = tiles * (MODE() % 13 + 1) + walkable * 3 +
             resources * 5 + elevation * 7 + region;
         metric.observe(inout out, projection, region % 7 + 1);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/audit_render_throughput.rue
+++ b/examples/caldera/audit_render_throughput.rue
@@ -151,7 +151,7 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
                 tiles += 1;
-                if tile.walkable { walkable = walkable + 1; }
+                if tile.walkable { walkable += 1; }
                 resources += tile.resource;
                 elevation += tile.height;
             }

--- a/examples/caldera/audit_render_throughput.rue
+++ b/examples/caldera/audit_render_throughput.rue
@@ -63,7 +63,7 @@ fn observe_entities(inout out: metric.Metric, borrow world: model.World) {
         metric.observe(inout out, entity_projection(borrow world, i), (i % 11) + 1);
         metric.warn(inout out, item.alive && (item.x < 0 || item.y < 0 ||
             @intCast(item.x) >= world.width || @intCast(item.y) >= world.height));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -73,7 +73,7 @@ fn observe_tiles(inout out: metric.Metric, borrow world: model.World) {
         let item = world.tiles.get_or(i, model.empty_tile());
         metric.observe(inout out, tile_projection(borrow world, i), (i % 13) + 1);
         metric.warn(inout out, item.x >= world.width || item.y >= world.height);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -82,18 +82,18 @@ fn observe_timeline(inout out: metric.Metric, borrow world: model.World) {
     while i < world.events.len() {
         metric.observe(inout out, event_projection(borrow world, i), (i % 5) + 1);
         metric.warn(inout out, world.events.get_or(i, model.empty_event()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
         metric.observe(inout out, command_projection(borrow world, i), (i % 7) + 1);
         metric.warn(inout out, world.commands.get_or(i, model.empty_command()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.snapshots.len() {
         metric.observe(inout out, snapshot_projection(borrow world, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -108,9 +108,9 @@ fn observe_pairs(inout out: metric.Metric, borrow world: model.World) {
             let dy = if left.y > right.y { left.y - right.y } else { right.y - left.y };
             metric.observe(inout out, @intCast(dx + dy) +
                 left.faction * 3 + right.faction * 5 + MODE(), i + j + 1);
-            j = j + 1;
+            j += 1;
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -125,17 +125,17 @@ fn observe_factions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.entities.len() {
             let entity = world.entities.get_or(i, model.empty_entity());
             if entity.faction == faction && entity.alive {
-                agents = agents + 1;
-                health = health + entity.health;
-                energy = energy + entity.energy;
-                inventory = inventory + entity.inventory;
+                agents += 1;
+                health += entity.health;
+                energy += entity.energy;
+                inventory += entity.inventory;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = agents * (MODE() % 11 + 1) + health * 3 +
             energy * 5 + inventory * 7 + faction;
         metric.observe(inout out, projection, faction + MODE() % 5 + 1);
-        faction = faction + 1;
+        faction += 1;
     }
 }
 
@@ -150,17 +150,17 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
-                tiles = tiles + 1;
+                tiles += 1;
                 if tile.walkable { walkable = walkable + 1; }
-                resources = resources + tile.resource;
-                elevation = elevation + tile.height;
+                resources += tile.resource;
+                elevation += tile.height;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = tiles * (MODE() % 13 + 1) + walkable * 3 +
             resources * 5 + elevation * 7 + region;
         metric.observe(inout out, projection, region % 7 + 1);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/audit_replay_balance.rue
+++ b/examples/caldera/audit_replay_balance.rue
@@ -151,7 +151,7 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
                 tiles += 1;
-                if tile.walkable { walkable = walkable + 1; }
+                if tile.walkable { walkable += 1; }
                 resources += tile.resource;
                 elevation += tile.height;
             }

--- a/examples/caldera/audit_replay_balance.rue
+++ b/examples/caldera/audit_replay_balance.rue
@@ -63,7 +63,7 @@ fn observe_entities(inout out: metric.Metric, borrow world: model.World) {
         metric.observe(inout out, entity_projection(borrow world, i), (i % 11) + 1);
         metric.warn(inout out, item.alive && (item.x < 0 || item.y < 0 ||
             @intCast(item.x) >= world.width || @intCast(item.y) >= world.height));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -73,7 +73,7 @@ fn observe_tiles(inout out: metric.Metric, borrow world: model.World) {
         let item = world.tiles.get_or(i, model.empty_tile());
         metric.observe(inout out, tile_projection(borrow world, i), (i % 13) + 1);
         metric.warn(inout out, item.x >= world.width || item.y >= world.height);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -82,18 +82,18 @@ fn observe_timeline(inout out: metric.Metric, borrow world: model.World) {
     while i < world.events.len() {
         metric.observe(inout out, event_projection(borrow world, i), (i % 5) + 1);
         metric.warn(inout out, world.events.get_or(i, model.empty_event()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
         metric.observe(inout out, command_projection(borrow world, i), (i % 7) + 1);
         metric.warn(inout out, world.commands.get_or(i, model.empty_command()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.snapshots.len() {
         metric.observe(inout out, snapshot_projection(borrow world, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -108,9 +108,9 @@ fn observe_pairs(inout out: metric.Metric, borrow world: model.World) {
             let dy = if left.y > right.y { left.y - right.y } else { right.y - left.y };
             metric.observe(inout out, @intCast(dx + dy) +
                 left.faction * 3 + right.faction * 5 + MODE(), i + j + 1);
-            j = j + 1;
+            j += 1;
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -125,17 +125,17 @@ fn observe_factions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.entities.len() {
             let entity = world.entities.get_or(i, model.empty_entity());
             if entity.faction == faction && entity.alive {
-                agents = agents + 1;
-                health = health + entity.health;
-                energy = energy + entity.energy;
-                inventory = inventory + entity.inventory;
+                agents += 1;
+                health += entity.health;
+                energy += entity.energy;
+                inventory += entity.inventory;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = agents * (MODE() % 11 + 1) + health * 3 +
             energy * 5 + inventory * 7 + faction;
         metric.observe(inout out, projection, faction + MODE() % 5 + 1);
-        faction = faction + 1;
+        faction += 1;
     }
 }
 
@@ -150,17 +150,17 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
-                tiles = tiles + 1;
+                tiles += 1;
                 if tile.walkable { walkable = walkable + 1; }
-                resources = resources + tile.resource;
-                elevation = elevation + tile.height;
+                resources += tile.resource;
+                elevation += tile.height;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = tiles * (MODE() % 13 + 1) + walkable * 3 +
             resources * 5 + elevation * 7 + region;
         metric.observe(inout out, projection, region % 7 + 1);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/audit_replay_capacity.rue
+++ b/examples/caldera/audit_replay_capacity.rue
@@ -151,7 +151,7 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
                 tiles += 1;
-                if tile.walkable { walkable = walkable + 1; }
+                if tile.walkable { walkable += 1; }
                 resources += tile.resource;
                 elevation += tile.height;
             }

--- a/examples/caldera/audit_replay_capacity.rue
+++ b/examples/caldera/audit_replay_capacity.rue
@@ -63,7 +63,7 @@ fn observe_entities(inout out: metric.Metric, borrow world: model.World) {
         metric.observe(inout out, entity_projection(borrow world, i), (i % 11) + 1);
         metric.warn(inout out, item.alive && (item.x < 0 || item.y < 0 ||
             @intCast(item.x) >= world.width || @intCast(item.y) >= world.height));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -73,7 +73,7 @@ fn observe_tiles(inout out: metric.Metric, borrow world: model.World) {
         let item = world.tiles.get_or(i, model.empty_tile());
         metric.observe(inout out, tile_projection(borrow world, i), (i % 13) + 1);
         metric.warn(inout out, item.x >= world.width || item.y >= world.height);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -82,18 +82,18 @@ fn observe_timeline(inout out: metric.Metric, borrow world: model.World) {
     while i < world.events.len() {
         metric.observe(inout out, event_projection(borrow world, i), (i % 5) + 1);
         metric.warn(inout out, world.events.get_or(i, model.empty_event()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
         metric.observe(inout out, command_projection(borrow world, i), (i % 7) + 1);
         metric.warn(inout out, world.commands.get_or(i, model.empty_command()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.snapshots.len() {
         metric.observe(inout out, snapshot_projection(borrow world, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -108,9 +108,9 @@ fn observe_pairs(inout out: metric.Metric, borrow world: model.World) {
             let dy = if left.y > right.y { left.y - right.y } else { right.y - left.y };
             metric.observe(inout out, @intCast(dx + dy) +
                 left.faction * 3 + right.faction * 5 + MODE(), i + j + 1);
-            j = j + 1;
+            j += 1;
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -125,17 +125,17 @@ fn observe_factions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.entities.len() {
             let entity = world.entities.get_or(i, model.empty_entity());
             if entity.faction == faction && entity.alive {
-                agents = agents + 1;
-                health = health + entity.health;
-                energy = energy + entity.energy;
-                inventory = inventory + entity.inventory;
+                agents += 1;
+                health += entity.health;
+                energy += entity.energy;
+                inventory += entity.inventory;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = agents * (MODE() % 11 + 1) + health * 3 +
             energy * 5 + inventory * 7 + faction;
         metric.observe(inout out, projection, faction + MODE() % 5 + 1);
-        faction = faction + 1;
+        faction += 1;
     }
 }
 
@@ -150,17 +150,17 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
-                tiles = tiles + 1;
+                tiles += 1;
                 if tile.walkable { walkable = walkable + 1; }
-                resources = resources + tile.resource;
-                elevation = elevation + tile.height;
+                resources += tile.resource;
+                elevation += tile.height;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = tiles * (MODE() % 13 + 1) + walkable * 3 +
             resources * 5 + elevation * 7 + region;
         metric.observe(inout out, projection, region % 7 + 1);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/audit_replay_continuity.rue
+++ b/examples/caldera/audit_replay_continuity.rue
@@ -151,7 +151,7 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
                 tiles += 1;
-                if tile.walkable { walkable = walkable + 1; }
+                if tile.walkable { walkable += 1; }
                 resources += tile.resource;
                 elevation += tile.height;
             }

--- a/examples/caldera/audit_replay_continuity.rue
+++ b/examples/caldera/audit_replay_continuity.rue
@@ -63,7 +63,7 @@ fn observe_entities(inout out: metric.Metric, borrow world: model.World) {
         metric.observe(inout out, entity_projection(borrow world, i), (i % 11) + 1);
         metric.warn(inout out, item.alive && (item.x < 0 || item.y < 0 ||
             @intCast(item.x) >= world.width || @intCast(item.y) >= world.height));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -73,7 +73,7 @@ fn observe_tiles(inout out: metric.Metric, borrow world: model.World) {
         let item = world.tiles.get_or(i, model.empty_tile());
         metric.observe(inout out, tile_projection(borrow world, i), (i % 13) + 1);
         metric.warn(inout out, item.x >= world.width || item.y >= world.height);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -82,18 +82,18 @@ fn observe_timeline(inout out: metric.Metric, borrow world: model.World) {
     while i < world.events.len() {
         metric.observe(inout out, event_projection(borrow world, i), (i % 5) + 1);
         metric.warn(inout out, world.events.get_or(i, model.empty_event()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
         metric.observe(inout out, command_projection(borrow world, i), (i % 7) + 1);
         metric.warn(inout out, world.commands.get_or(i, model.empty_command()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.snapshots.len() {
         metric.observe(inout out, snapshot_projection(borrow world, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -108,9 +108,9 @@ fn observe_pairs(inout out: metric.Metric, borrow world: model.World) {
             let dy = if left.y > right.y { left.y - right.y } else { right.y - left.y };
             metric.observe(inout out, @intCast(dx + dy) +
                 left.faction * 3 + right.faction * 5 + MODE(), i + j + 1);
-            j = j + 1;
+            j += 1;
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -125,17 +125,17 @@ fn observe_factions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.entities.len() {
             let entity = world.entities.get_or(i, model.empty_entity());
             if entity.faction == faction && entity.alive {
-                agents = agents + 1;
-                health = health + entity.health;
-                energy = energy + entity.energy;
-                inventory = inventory + entity.inventory;
+                agents += 1;
+                health += entity.health;
+                energy += entity.energy;
+                inventory += entity.inventory;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = agents * (MODE() % 11 + 1) + health * 3 +
             energy * 5 + inventory * 7 + faction;
         metric.observe(inout out, projection, faction + MODE() % 5 + 1);
-        faction = faction + 1;
+        faction += 1;
     }
 }
 
@@ -150,17 +150,17 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
-                tiles = tiles + 1;
+                tiles += 1;
                 if tile.walkable { walkable = walkable + 1; }
-                resources = resources + tile.resource;
-                elevation = elevation + tile.height;
+                resources += tile.resource;
+                elevation += tile.height;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = tiles * (MODE() % 13 + 1) + walkable * 3 +
             resources * 5 + elevation * 7 + region;
         metric.observe(inout out, projection, region % 7 + 1);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/audit_replay_cost.rue
+++ b/examples/caldera/audit_replay_cost.rue
@@ -151,7 +151,7 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
                 tiles += 1;
-                if tile.walkable { walkable = walkable + 1; }
+                if tile.walkable { walkable += 1; }
                 resources += tile.resource;
                 elevation += tile.height;
             }

--- a/examples/caldera/audit_replay_cost.rue
+++ b/examples/caldera/audit_replay_cost.rue
@@ -63,7 +63,7 @@ fn observe_entities(inout out: metric.Metric, borrow world: model.World) {
         metric.observe(inout out, entity_projection(borrow world, i), (i % 11) + 1);
         metric.warn(inout out, item.alive && (item.x < 0 || item.y < 0 ||
             @intCast(item.x) >= world.width || @intCast(item.y) >= world.height));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -73,7 +73,7 @@ fn observe_tiles(inout out: metric.Metric, borrow world: model.World) {
         let item = world.tiles.get_or(i, model.empty_tile());
         metric.observe(inout out, tile_projection(borrow world, i), (i % 13) + 1);
         metric.warn(inout out, item.x >= world.width || item.y >= world.height);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -82,18 +82,18 @@ fn observe_timeline(inout out: metric.Metric, borrow world: model.World) {
     while i < world.events.len() {
         metric.observe(inout out, event_projection(borrow world, i), (i % 5) + 1);
         metric.warn(inout out, world.events.get_or(i, model.empty_event()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
         metric.observe(inout out, command_projection(borrow world, i), (i % 7) + 1);
         metric.warn(inout out, world.commands.get_or(i, model.empty_command()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.snapshots.len() {
         metric.observe(inout out, snapshot_projection(borrow world, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -108,9 +108,9 @@ fn observe_pairs(inout out: metric.Metric, borrow world: model.World) {
             let dy = if left.y > right.y { left.y - right.y } else { right.y - left.y };
             metric.observe(inout out, @intCast(dx + dy) +
                 left.faction * 3 + right.faction * 5 + MODE(), i + j + 1);
-            j = j + 1;
+            j += 1;
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -125,17 +125,17 @@ fn observe_factions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.entities.len() {
             let entity = world.entities.get_or(i, model.empty_entity());
             if entity.faction == faction && entity.alive {
-                agents = agents + 1;
-                health = health + entity.health;
-                energy = energy + entity.energy;
-                inventory = inventory + entity.inventory;
+                agents += 1;
+                health += entity.health;
+                energy += entity.energy;
+                inventory += entity.inventory;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = agents * (MODE() % 11 + 1) + health * 3 +
             energy * 5 + inventory * 7 + faction;
         metric.observe(inout out, projection, faction + MODE() % 5 + 1);
-        faction = faction + 1;
+        faction += 1;
     }
 }
 
@@ -150,17 +150,17 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
-                tiles = tiles + 1;
+                tiles += 1;
                 if tile.walkable { walkable = walkable + 1; }
-                resources = resources + tile.resource;
-                elevation = elevation + tile.height;
+                resources += tile.resource;
+                elevation += tile.height;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = tiles * (MODE() % 13 + 1) + walkable * 3 +
             resources * 5 + elevation * 7 + region;
         metric.observe(inout out, projection, region % 7 + 1);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/audit_replay_coverage.rue
+++ b/examples/caldera/audit_replay_coverage.rue
@@ -151,7 +151,7 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
                 tiles += 1;
-                if tile.walkable { walkable = walkable + 1; }
+                if tile.walkable { walkable += 1; }
                 resources += tile.resource;
                 elevation += tile.height;
             }

--- a/examples/caldera/audit_replay_coverage.rue
+++ b/examples/caldera/audit_replay_coverage.rue
@@ -63,7 +63,7 @@ fn observe_entities(inout out: metric.Metric, borrow world: model.World) {
         metric.observe(inout out, entity_projection(borrow world, i), (i % 11) + 1);
         metric.warn(inout out, item.alive && (item.x < 0 || item.y < 0 ||
             @intCast(item.x) >= world.width || @intCast(item.y) >= world.height));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -73,7 +73,7 @@ fn observe_tiles(inout out: metric.Metric, borrow world: model.World) {
         let item = world.tiles.get_or(i, model.empty_tile());
         metric.observe(inout out, tile_projection(borrow world, i), (i % 13) + 1);
         metric.warn(inout out, item.x >= world.width || item.y >= world.height);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -82,18 +82,18 @@ fn observe_timeline(inout out: metric.Metric, borrow world: model.World) {
     while i < world.events.len() {
         metric.observe(inout out, event_projection(borrow world, i), (i % 5) + 1);
         metric.warn(inout out, world.events.get_or(i, model.empty_event()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
         metric.observe(inout out, command_projection(borrow world, i), (i % 7) + 1);
         metric.warn(inout out, world.commands.get_or(i, model.empty_command()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.snapshots.len() {
         metric.observe(inout out, snapshot_projection(borrow world, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -108,9 +108,9 @@ fn observe_pairs(inout out: metric.Metric, borrow world: model.World) {
             let dy = if left.y > right.y { left.y - right.y } else { right.y - left.y };
             metric.observe(inout out, @intCast(dx + dy) +
                 left.faction * 3 + right.faction * 5 + MODE(), i + j + 1);
-            j = j + 1;
+            j += 1;
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -125,17 +125,17 @@ fn observe_factions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.entities.len() {
             let entity = world.entities.get_or(i, model.empty_entity());
             if entity.faction == faction && entity.alive {
-                agents = agents + 1;
-                health = health + entity.health;
-                energy = energy + entity.energy;
-                inventory = inventory + entity.inventory;
+                agents += 1;
+                health += entity.health;
+                energy += entity.energy;
+                inventory += entity.inventory;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = agents * (MODE() % 11 + 1) + health * 3 +
             energy * 5 + inventory * 7 + faction;
         metric.observe(inout out, projection, faction + MODE() % 5 + 1);
-        faction = faction + 1;
+        faction += 1;
     }
 }
 
@@ -150,17 +150,17 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
-                tiles = tiles + 1;
+                tiles += 1;
                 if tile.walkable { walkable = walkable + 1; }
-                resources = resources + tile.resource;
-                elevation = elevation + tile.height;
+                resources += tile.resource;
+                elevation += tile.height;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = tiles * (MODE() % 13 + 1) + walkable * 3 +
             resources * 5 + elevation * 7 + region;
         metric.observe(inout out, projection, region % 7 + 1);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/audit_replay_density.rue
+++ b/examples/caldera/audit_replay_density.rue
@@ -151,7 +151,7 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
                 tiles += 1;
-                if tile.walkable { walkable = walkable + 1; }
+                if tile.walkable { walkable += 1; }
                 resources += tile.resource;
                 elevation += tile.height;
             }

--- a/examples/caldera/audit_replay_density.rue
+++ b/examples/caldera/audit_replay_density.rue
@@ -63,7 +63,7 @@ fn observe_entities(inout out: metric.Metric, borrow world: model.World) {
         metric.observe(inout out, entity_projection(borrow world, i), (i % 11) + 1);
         metric.warn(inout out, item.alive && (item.x < 0 || item.y < 0 ||
             @intCast(item.x) >= world.width || @intCast(item.y) >= world.height));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -73,7 +73,7 @@ fn observe_tiles(inout out: metric.Metric, borrow world: model.World) {
         let item = world.tiles.get_or(i, model.empty_tile());
         metric.observe(inout out, tile_projection(borrow world, i), (i % 13) + 1);
         metric.warn(inout out, item.x >= world.width || item.y >= world.height);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -82,18 +82,18 @@ fn observe_timeline(inout out: metric.Metric, borrow world: model.World) {
     while i < world.events.len() {
         metric.observe(inout out, event_projection(borrow world, i), (i % 5) + 1);
         metric.warn(inout out, world.events.get_or(i, model.empty_event()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
         metric.observe(inout out, command_projection(borrow world, i), (i % 7) + 1);
         metric.warn(inout out, world.commands.get_or(i, model.empty_command()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.snapshots.len() {
         metric.observe(inout out, snapshot_projection(borrow world, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -108,9 +108,9 @@ fn observe_pairs(inout out: metric.Metric, borrow world: model.World) {
             let dy = if left.y > right.y { left.y - right.y } else { right.y - left.y };
             metric.observe(inout out, @intCast(dx + dy) +
                 left.faction * 3 + right.faction * 5 + MODE(), i + j + 1);
-            j = j + 1;
+            j += 1;
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -125,17 +125,17 @@ fn observe_factions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.entities.len() {
             let entity = world.entities.get_or(i, model.empty_entity());
             if entity.faction == faction && entity.alive {
-                agents = agents + 1;
-                health = health + entity.health;
-                energy = energy + entity.energy;
-                inventory = inventory + entity.inventory;
+                agents += 1;
+                health += entity.health;
+                energy += entity.energy;
+                inventory += entity.inventory;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = agents * (MODE() % 11 + 1) + health * 3 +
             energy * 5 + inventory * 7 + faction;
         metric.observe(inout out, projection, faction + MODE() % 5 + 1);
-        faction = faction + 1;
+        faction += 1;
     }
 }
 
@@ -150,17 +150,17 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
-                tiles = tiles + 1;
+                tiles += 1;
                 if tile.walkable { walkable = walkable + 1; }
-                resources = resources + tile.resource;
-                elevation = elevation + tile.height;
+                resources += tile.resource;
+                elevation += tile.height;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = tiles * (MODE() % 13 + 1) + walkable * 3 +
             resources * 5 + elevation * 7 + region;
         metric.observe(inout out, projection, region % 7 + 1);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/audit_replay_entropy.rue
+++ b/examples/caldera/audit_replay_entropy.rue
@@ -151,7 +151,7 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
                 tiles += 1;
-                if tile.walkable { walkable = walkable + 1; }
+                if tile.walkable { walkable += 1; }
                 resources += tile.resource;
                 elevation += tile.height;
             }

--- a/examples/caldera/audit_replay_entropy.rue
+++ b/examples/caldera/audit_replay_entropy.rue
@@ -63,7 +63,7 @@ fn observe_entities(inout out: metric.Metric, borrow world: model.World) {
         metric.observe(inout out, entity_projection(borrow world, i), (i % 11) + 1);
         metric.warn(inout out, item.alive && (item.x < 0 || item.y < 0 ||
             @intCast(item.x) >= world.width || @intCast(item.y) >= world.height));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -73,7 +73,7 @@ fn observe_tiles(inout out: metric.Metric, borrow world: model.World) {
         let item = world.tiles.get_or(i, model.empty_tile());
         metric.observe(inout out, tile_projection(borrow world, i), (i % 13) + 1);
         metric.warn(inout out, item.x >= world.width || item.y >= world.height);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -82,18 +82,18 @@ fn observe_timeline(inout out: metric.Metric, borrow world: model.World) {
     while i < world.events.len() {
         metric.observe(inout out, event_projection(borrow world, i), (i % 5) + 1);
         metric.warn(inout out, world.events.get_or(i, model.empty_event()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
         metric.observe(inout out, command_projection(borrow world, i), (i % 7) + 1);
         metric.warn(inout out, world.commands.get_or(i, model.empty_command()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.snapshots.len() {
         metric.observe(inout out, snapshot_projection(borrow world, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -108,9 +108,9 @@ fn observe_pairs(inout out: metric.Metric, borrow world: model.World) {
             let dy = if left.y > right.y { left.y - right.y } else { right.y - left.y };
             metric.observe(inout out, @intCast(dx + dy) +
                 left.faction * 3 + right.faction * 5 + MODE(), i + j + 1);
-            j = j + 1;
+            j += 1;
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -125,17 +125,17 @@ fn observe_factions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.entities.len() {
             let entity = world.entities.get_or(i, model.empty_entity());
             if entity.faction == faction && entity.alive {
-                agents = agents + 1;
-                health = health + entity.health;
-                energy = energy + entity.energy;
-                inventory = inventory + entity.inventory;
+                agents += 1;
+                health += entity.health;
+                energy += entity.energy;
+                inventory += entity.inventory;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = agents * (MODE() % 11 + 1) + health * 3 +
             energy * 5 + inventory * 7 + faction;
         metric.observe(inout out, projection, faction + MODE() % 5 + 1);
-        faction = faction + 1;
+        faction += 1;
     }
 }
 
@@ -150,17 +150,17 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
-                tiles = tiles + 1;
+                tiles += 1;
                 if tile.walkable { walkable = walkable + 1; }
-                resources = resources + tile.resource;
-                elevation = elevation + tile.height;
+                resources += tile.resource;
+                elevation += tile.height;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = tiles * (MODE() % 13 + 1) + walkable * 3 +
             resources * 5 + elevation * 7 + region;
         metric.observe(inout out, projection, region % 7 + 1);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/audit_replay_fanout.rue
+++ b/examples/caldera/audit_replay_fanout.rue
@@ -151,7 +151,7 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
                 tiles += 1;
-                if tile.walkable { walkable = walkable + 1; }
+                if tile.walkable { walkable += 1; }
                 resources += tile.resource;
                 elevation += tile.height;
             }

--- a/examples/caldera/audit_replay_fanout.rue
+++ b/examples/caldera/audit_replay_fanout.rue
@@ -63,7 +63,7 @@ fn observe_entities(inout out: metric.Metric, borrow world: model.World) {
         metric.observe(inout out, entity_projection(borrow world, i), (i % 11) + 1);
         metric.warn(inout out, item.alive && (item.x < 0 || item.y < 0 ||
             @intCast(item.x) >= world.width || @intCast(item.y) >= world.height));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -73,7 +73,7 @@ fn observe_tiles(inout out: metric.Metric, borrow world: model.World) {
         let item = world.tiles.get_or(i, model.empty_tile());
         metric.observe(inout out, tile_projection(borrow world, i), (i % 13) + 1);
         metric.warn(inout out, item.x >= world.width || item.y >= world.height);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -82,18 +82,18 @@ fn observe_timeline(inout out: metric.Metric, borrow world: model.World) {
     while i < world.events.len() {
         metric.observe(inout out, event_projection(borrow world, i), (i % 5) + 1);
         metric.warn(inout out, world.events.get_or(i, model.empty_event()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
         metric.observe(inout out, command_projection(borrow world, i), (i % 7) + 1);
         metric.warn(inout out, world.commands.get_or(i, model.empty_command()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.snapshots.len() {
         metric.observe(inout out, snapshot_projection(borrow world, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -108,9 +108,9 @@ fn observe_pairs(inout out: metric.Metric, borrow world: model.World) {
             let dy = if left.y > right.y { left.y - right.y } else { right.y - left.y };
             metric.observe(inout out, @intCast(dx + dy) +
                 left.faction * 3 + right.faction * 5 + MODE(), i + j + 1);
-            j = j + 1;
+            j += 1;
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -125,17 +125,17 @@ fn observe_factions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.entities.len() {
             let entity = world.entities.get_or(i, model.empty_entity());
             if entity.faction == faction && entity.alive {
-                agents = agents + 1;
-                health = health + entity.health;
-                energy = energy + entity.energy;
-                inventory = inventory + entity.inventory;
+                agents += 1;
+                health += entity.health;
+                energy += entity.energy;
+                inventory += entity.inventory;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = agents * (MODE() % 11 + 1) + health * 3 +
             energy * 5 + inventory * 7 + faction;
         metric.observe(inout out, projection, faction + MODE() % 5 + 1);
-        faction = faction + 1;
+        faction += 1;
     }
 }
 
@@ -150,17 +150,17 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
-                tiles = tiles + 1;
+                tiles += 1;
                 if tile.walkable { walkable = walkable + 1; }
-                resources = resources + tile.resource;
-                elevation = elevation + tile.height;
+                resources += tile.resource;
+                elevation += tile.height;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = tiles * (MODE() % 13 + 1) + walkable * 3 +
             resources * 5 + elevation * 7 + region;
         metric.observe(inout out, projection, region % 7 + 1);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/audit_replay_integrity.rue
+++ b/examples/caldera/audit_replay_integrity.rue
@@ -151,7 +151,7 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
                 tiles += 1;
-                if tile.walkable { walkable = walkable + 1; }
+                if tile.walkable { walkable += 1; }
                 resources += tile.resource;
                 elevation += tile.height;
             }

--- a/examples/caldera/audit_replay_integrity.rue
+++ b/examples/caldera/audit_replay_integrity.rue
@@ -63,7 +63,7 @@ fn observe_entities(inout out: metric.Metric, borrow world: model.World) {
         metric.observe(inout out, entity_projection(borrow world, i), (i % 11) + 1);
         metric.warn(inout out, item.alive && (item.x < 0 || item.y < 0 ||
             @intCast(item.x) >= world.width || @intCast(item.y) >= world.height));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -73,7 +73,7 @@ fn observe_tiles(inout out: metric.Metric, borrow world: model.World) {
         let item = world.tiles.get_or(i, model.empty_tile());
         metric.observe(inout out, tile_projection(borrow world, i), (i % 13) + 1);
         metric.warn(inout out, item.x >= world.width || item.y >= world.height);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -82,18 +82,18 @@ fn observe_timeline(inout out: metric.Metric, borrow world: model.World) {
     while i < world.events.len() {
         metric.observe(inout out, event_projection(borrow world, i), (i % 5) + 1);
         metric.warn(inout out, world.events.get_or(i, model.empty_event()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
         metric.observe(inout out, command_projection(borrow world, i), (i % 7) + 1);
         metric.warn(inout out, world.commands.get_or(i, model.empty_command()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.snapshots.len() {
         metric.observe(inout out, snapshot_projection(borrow world, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -108,9 +108,9 @@ fn observe_pairs(inout out: metric.Metric, borrow world: model.World) {
             let dy = if left.y > right.y { left.y - right.y } else { right.y - left.y };
             metric.observe(inout out, @intCast(dx + dy) +
                 left.faction * 3 + right.faction * 5 + MODE(), i + j + 1);
-            j = j + 1;
+            j += 1;
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -125,17 +125,17 @@ fn observe_factions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.entities.len() {
             let entity = world.entities.get_or(i, model.empty_entity());
             if entity.faction == faction && entity.alive {
-                agents = agents + 1;
-                health = health + entity.health;
-                energy = energy + entity.energy;
-                inventory = inventory + entity.inventory;
+                agents += 1;
+                health += entity.health;
+                energy += entity.energy;
+                inventory += entity.inventory;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = agents * (MODE() % 11 + 1) + health * 3 +
             energy * 5 + inventory * 7 + faction;
         metric.observe(inout out, projection, faction + MODE() % 5 + 1);
-        faction = faction + 1;
+        faction += 1;
     }
 }
 
@@ -150,17 +150,17 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
-                tiles = tiles + 1;
+                tiles += 1;
                 if tile.walkable { walkable = walkable + 1; }
-                resources = resources + tile.resource;
-                elevation = elevation + tile.height;
+                resources += tile.resource;
+                elevation += tile.height;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = tiles * (MODE() % 13 + 1) + walkable * 3 +
             resources * 5 + elevation * 7 + region;
         metric.observe(inout out, projection, region % 7 + 1);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/audit_replay_latency.rue
+++ b/examples/caldera/audit_replay_latency.rue
@@ -151,7 +151,7 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
                 tiles += 1;
-                if tile.walkable { walkable = walkable + 1; }
+                if tile.walkable { walkable += 1; }
                 resources += tile.resource;
                 elevation += tile.height;
             }

--- a/examples/caldera/audit_replay_latency.rue
+++ b/examples/caldera/audit_replay_latency.rue
@@ -63,7 +63,7 @@ fn observe_entities(inout out: metric.Metric, borrow world: model.World) {
         metric.observe(inout out, entity_projection(borrow world, i), (i % 11) + 1);
         metric.warn(inout out, item.alive && (item.x < 0 || item.y < 0 ||
             @intCast(item.x) >= world.width || @intCast(item.y) >= world.height));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -73,7 +73,7 @@ fn observe_tiles(inout out: metric.Metric, borrow world: model.World) {
         let item = world.tiles.get_or(i, model.empty_tile());
         metric.observe(inout out, tile_projection(borrow world, i), (i % 13) + 1);
         metric.warn(inout out, item.x >= world.width || item.y >= world.height);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -82,18 +82,18 @@ fn observe_timeline(inout out: metric.Metric, borrow world: model.World) {
     while i < world.events.len() {
         metric.observe(inout out, event_projection(borrow world, i), (i % 5) + 1);
         metric.warn(inout out, world.events.get_or(i, model.empty_event()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
         metric.observe(inout out, command_projection(borrow world, i), (i % 7) + 1);
         metric.warn(inout out, world.commands.get_or(i, model.empty_command()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.snapshots.len() {
         metric.observe(inout out, snapshot_projection(borrow world, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -108,9 +108,9 @@ fn observe_pairs(inout out: metric.Metric, borrow world: model.World) {
             let dy = if left.y > right.y { left.y - right.y } else { right.y - left.y };
             metric.observe(inout out, @intCast(dx + dy) +
                 left.faction * 3 + right.faction * 5 + MODE(), i + j + 1);
-            j = j + 1;
+            j += 1;
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -125,17 +125,17 @@ fn observe_factions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.entities.len() {
             let entity = world.entities.get_or(i, model.empty_entity());
             if entity.faction == faction && entity.alive {
-                agents = agents + 1;
-                health = health + entity.health;
-                energy = energy + entity.energy;
-                inventory = inventory + entity.inventory;
+                agents += 1;
+                health += entity.health;
+                energy += entity.energy;
+                inventory += entity.inventory;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = agents * (MODE() % 11 + 1) + health * 3 +
             energy * 5 + inventory * 7 + faction;
         metric.observe(inout out, projection, faction + MODE() % 5 + 1);
-        faction = faction + 1;
+        faction += 1;
     }
 }
 
@@ -150,17 +150,17 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
-                tiles = tiles + 1;
+                tiles += 1;
                 if tile.walkable { walkable = walkable + 1; }
-                resources = resources + tile.resource;
-                elevation = elevation + tile.height;
+                resources += tile.resource;
+                elevation += tile.height;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = tiles * (MODE() % 13 + 1) + walkable * 3 +
             resources * 5 + elevation * 7 + region;
         metric.observe(inout out, projection, region % 7 + 1);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/audit_replay_locality.rue
+++ b/examples/caldera/audit_replay_locality.rue
@@ -151,7 +151,7 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
                 tiles += 1;
-                if tile.walkable { walkable = walkable + 1; }
+                if tile.walkable { walkable += 1; }
                 resources += tile.resource;
                 elevation += tile.height;
             }

--- a/examples/caldera/audit_replay_locality.rue
+++ b/examples/caldera/audit_replay_locality.rue
@@ -63,7 +63,7 @@ fn observe_entities(inout out: metric.Metric, borrow world: model.World) {
         metric.observe(inout out, entity_projection(borrow world, i), (i % 11) + 1);
         metric.warn(inout out, item.alive && (item.x < 0 || item.y < 0 ||
             @intCast(item.x) >= world.width || @intCast(item.y) >= world.height));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -73,7 +73,7 @@ fn observe_tiles(inout out: metric.Metric, borrow world: model.World) {
         let item = world.tiles.get_or(i, model.empty_tile());
         metric.observe(inout out, tile_projection(borrow world, i), (i % 13) + 1);
         metric.warn(inout out, item.x >= world.width || item.y >= world.height);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -82,18 +82,18 @@ fn observe_timeline(inout out: metric.Metric, borrow world: model.World) {
     while i < world.events.len() {
         metric.observe(inout out, event_projection(borrow world, i), (i % 5) + 1);
         metric.warn(inout out, world.events.get_or(i, model.empty_event()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
         metric.observe(inout out, command_projection(borrow world, i), (i % 7) + 1);
         metric.warn(inout out, world.commands.get_or(i, model.empty_command()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.snapshots.len() {
         metric.observe(inout out, snapshot_projection(borrow world, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -108,9 +108,9 @@ fn observe_pairs(inout out: metric.Metric, borrow world: model.World) {
             let dy = if left.y > right.y { left.y - right.y } else { right.y - left.y };
             metric.observe(inout out, @intCast(dx + dy) +
                 left.faction * 3 + right.faction * 5 + MODE(), i + j + 1);
-            j = j + 1;
+            j += 1;
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -125,17 +125,17 @@ fn observe_factions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.entities.len() {
             let entity = world.entities.get_or(i, model.empty_entity());
             if entity.faction == faction && entity.alive {
-                agents = agents + 1;
-                health = health + entity.health;
-                energy = energy + entity.energy;
-                inventory = inventory + entity.inventory;
+                agents += 1;
+                health += entity.health;
+                energy += entity.energy;
+                inventory += entity.inventory;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = agents * (MODE() % 11 + 1) + health * 3 +
             energy * 5 + inventory * 7 + faction;
         metric.observe(inout out, projection, faction + MODE() % 5 + 1);
-        faction = faction + 1;
+        faction += 1;
     }
 }
 
@@ -150,17 +150,17 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
-                tiles = tiles + 1;
+                tiles += 1;
                 if tile.walkable { walkable = walkable + 1; }
-                resources = resources + tile.resource;
-                elevation = elevation + tile.height;
+                resources += tile.resource;
+                elevation += tile.height;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = tiles * (MODE() % 13 + 1) + walkable * 3 +
             resources * 5 + elevation * 7 + region;
         metric.observe(inout out, projection, region % 7 + 1);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/audit_replay_pressure.rue
+++ b/examples/caldera/audit_replay_pressure.rue
@@ -151,7 +151,7 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
                 tiles += 1;
-                if tile.walkable { walkable = walkable + 1; }
+                if tile.walkable { walkable += 1; }
                 resources += tile.resource;
                 elevation += tile.height;
             }

--- a/examples/caldera/audit_replay_pressure.rue
+++ b/examples/caldera/audit_replay_pressure.rue
@@ -63,7 +63,7 @@ fn observe_entities(inout out: metric.Metric, borrow world: model.World) {
         metric.observe(inout out, entity_projection(borrow world, i), (i % 11) + 1);
         metric.warn(inout out, item.alive && (item.x < 0 || item.y < 0 ||
             @intCast(item.x) >= world.width || @intCast(item.y) >= world.height));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -73,7 +73,7 @@ fn observe_tiles(inout out: metric.Metric, borrow world: model.World) {
         let item = world.tiles.get_or(i, model.empty_tile());
         metric.observe(inout out, tile_projection(borrow world, i), (i % 13) + 1);
         metric.warn(inout out, item.x >= world.width || item.y >= world.height);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -82,18 +82,18 @@ fn observe_timeline(inout out: metric.Metric, borrow world: model.World) {
     while i < world.events.len() {
         metric.observe(inout out, event_projection(borrow world, i), (i % 5) + 1);
         metric.warn(inout out, world.events.get_or(i, model.empty_event()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
         metric.observe(inout out, command_projection(borrow world, i), (i % 7) + 1);
         metric.warn(inout out, world.commands.get_or(i, model.empty_command()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.snapshots.len() {
         metric.observe(inout out, snapshot_projection(borrow world, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -108,9 +108,9 @@ fn observe_pairs(inout out: metric.Metric, borrow world: model.World) {
             let dy = if left.y > right.y { left.y - right.y } else { right.y - left.y };
             metric.observe(inout out, @intCast(dx + dy) +
                 left.faction * 3 + right.faction * 5 + MODE(), i + j + 1);
-            j = j + 1;
+            j += 1;
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -125,17 +125,17 @@ fn observe_factions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.entities.len() {
             let entity = world.entities.get_or(i, model.empty_entity());
             if entity.faction == faction && entity.alive {
-                agents = agents + 1;
-                health = health + entity.health;
-                energy = energy + entity.energy;
-                inventory = inventory + entity.inventory;
+                agents += 1;
+                health += entity.health;
+                energy += entity.energy;
+                inventory += entity.inventory;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = agents * (MODE() % 11 + 1) + health * 3 +
             energy * 5 + inventory * 7 + faction;
         metric.observe(inout out, projection, faction + MODE() % 5 + 1);
-        faction = faction + 1;
+        faction += 1;
     }
 }
 
@@ -150,17 +150,17 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
-                tiles = tiles + 1;
+                tiles += 1;
                 if tile.walkable { walkable = walkable + 1; }
-                resources = resources + tile.resource;
-                elevation = elevation + tile.height;
+                resources += tile.resource;
+                elevation += tile.height;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = tiles * (MODE() % 13 + 1) + walkable * 3 +
             resources * 5 + elevation * 7 + region;
         metric.observe(inout out, projection, region % 7 + 1);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/audit_replay_risk.rue
+++ b/examples/caldera/audit_replay_risk.rue
@@ -151,7 +151,7 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
                 tiles += 1;
-                if tile.walkable { walkable = walkable + 1; }
+                if tile.walkable { walkable += 1; }
                 resources += tile.resource;
                 elevation += tile.height;
             }

--- a/examples/caldera/audit_replay_risk.rue
+++ b/examples/caldera/audit_replay_risk.rue
@@ -63,7 +63,7 @@ fn observe_entities(inout out: metric.Metric, borrow world: model.World) {
         metric.observe(inout out, entity_projection(borrow world, i), (i % 11) + 1);
         metric.warn(inout out, item.alive && (item.x < 0 || item.y < 0 ||
             @intCast(item.x) >= world.width || @intCast(item.y) >= world.height));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -73,7 +73,7 @@ fn observe_tiles(inout out: metric.Metric, borrow world: model.World) {
         let item = world.tiles.get_or(i, model.empty_tile());
         metric.observe(inout out, tile_projection(borrow world, i), (i % 13) + 1);
         metric.warn(inout out, item.x >= world.width || item.y >= world.height);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -82,18 +82,18 @@ fn observe_timeline(inout out: metric.Metric, borrow world: model.World) {
     while i < world.events.len() {
         metric.observe(inout out, event_projection(borrow world, i), (i % 5) + 1);
         metric.warn(inout out, world.events.get_or(i, model.empty_event()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
         metric.observe(inout out, command_projection(borrow world, i), (i % 7) + 1);
         metric.warn(inout out, world.commands.get_or(i, model.empty_command()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.snapshots.len() {
         metric.observe(inout out, snapshot_projection(borrow world, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -108,9 +108,9 @@ fn observe_pairs(inout out: metric.Metric, borrow world: model.World) {
             let dy = if left.y > right.y { left.y - right.y } else { right.y - left.y };
             metric.observe(inout out, @intCast(dx + dy) +
                 left.faction * 3 + right.faction * 5 + MODE(), i + j + 1);
-            j = j + 1;
+            j += 1;
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -125,17 +125,17 @@ fn observe_factions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.entities.len() {
             let entity = world.entities.get_or(i, model.empty_entity());
             if entity.faction == faction && entity.alive {
-                agents = agents + 1;
-                health = health + entity.health;
-                energy = energy + entity.energy;
-                inventory = inventory + entity.inventory;
+                agents += 1;
+                health += entity.health;
+                energy += entity.energy;
+                inventory += entity.inventory;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = agents * (MODE() % 11 + 1) + health * 3 +
             energy * 5 + inventory * 7 + faction;
         metric.observe(inout out, projection, faction + MODE() % 5 + 1);
-        faction = faction + 1;
+        faction += 1;
     }
 }
 
@@ -150,17 +150,17 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
-                tiles = tiles + 1;
+                tiles += 1;
                 if tile.walkable { walkable = walkable + 1; }
-                resources = resources + tile.resource;
-                elevation = elevation + tile.height;
+                resources += tile.resource;
+                elevation += tile.height;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = tiles * (MODE() % 13 + 1) + walkable * 3 +
             resources * 5 + elevation * 7 + region;
         metric.observe(inout out, projection, region % 7 + 1);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/audit_replay_skew.rue
+++ b/examples/caldera/audit_replay_skew.rue
@@ -151,7 +151,7 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
                 tiles += 1;
-                if tile.walkable { walkable = walkable + 1; }
+                if tile.walkable { walkable += 1; }
                 resources += tile.resource;
                 elevation += tile.height;
             }

--- a/examples/caldera/audit_replay_skew.rue
+++ b/examples/caldera/audit_replay_skew.rue
@@ -63,7 +63,7 @@ fn observe_entities(inout out: metric.Metric, borrow world: model.World) {
         metric.observe(inout out, entity_projection(borrow world, i), (i % 11) + 1);
         metric.warn(inout out, item.alive && (item.x < 0 || item.y < 0 ||
             @intCast(item.x) >= world.width || @intCast(item.y) >= world.height));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -73,7 +73,7 @@ fn observe_tiles(inout out: metric.Metric, borrow world: model.World) {
         let item = world.tiles.get_or(i, model.empty_tile());
         metric.observe(inout out, tile_projection(borrow world, i), (i % 13) + 1);
         metric.warn(inout out, item.x >= world.width || item.y >= world.height);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -82,18 +82,18 @@ fn observe_timeline(inout out: metric.Metric, borrow world: model.World) {
     while i < world.events.len() {
         metric.observe(inout out, event_projection(borrow world, i), (i % 5) + 1);
         metric.warn(inout out, world.events.get_or(i, model.empty_event()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
         metric.observe(inout out, command_projection(borrow world, i), (i % 7) + 1);
         metric.warn(inout out, world.commands.get_or(i, model.empty_command()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.snapshots.len() {
         metric.observe(inout out, snapshot_projection(borrow world, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -108,9 +108,9 @@ fn observe_pairs(inout out: metric.Metric, borrow world: model.World) {
             let dy = if left.y > right.y { left.y - right.y } else { right.y - left.y };
             metric.observe(inout out, @intCast(dx + dy) +
                 left.faction * 3 + right.faction * 5 + MODE(), i + j + 1);
-            j = j + 1;
+            j += 1;
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -125,17 +125,17 @@ fn observe_factions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.entities.len() {
             let entity = world.entities.get_or(i, model.empty_entity());
             if entity.faction == faction && entity.alive {
-                agents = agents + 1;
-                health = health + entity.health;
-                energy = energy + entity.energy;
-                inventory = inventory + entity.inventory;
+                agents += 1;
+                health += entity.health;
+                energy += entity.energy;
+                inventory += entity.inventory;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = agents * (MODE() % 11 + 1) + health * 3 +
             energy * 5 + inventory * 7 + faction;
         metric.observe(inout out, projection, faction + MODE() % 5 + 1);
-        faction = faction + 1;
+        faction += 1;
     }
 }
 
@@ -150,17 +150,17 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
-                tiles = tiles + 1;
+                tiles += 1;
                 if tile.walkable { walkable = walkable + 1; }
-                resources = resources + tile.resource;
-                elevation = elevation + tile.height;
+                resources += tile.resource;
+                elevation += tile.height;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = tiles * (MODE() % 13 + 1) + walkable * 3 +
             resources * 5 + elevation * 7 + region;
         metric.observe(inout out, projection, region % 7 + 1);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/audit_replay_stability.rue
+++ b/examples/caldera/audit_replay_stability.rue
@@ -151,7 +151,7 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
                 tiles += 1;
-                if tile.walkable { walkable = walkable + 1; }
+                if tile.walkable { walkable += 1; }
                 resources += tile.resource;
                 elevation += tile.height;
             }

--- a/examples/caldera/audit_replay_stability.rue
+++ b/examples/caldera/audit_replay_stability.rue
@@ -63,7 +63,7 @@ fn observe_entities(inout out: metric.Metric, borrow world: model.World) {
         metric.observe(inout out, entity_projection(borrow world, i), (i % 11) + 1);
         metric.warn(inout out, item.alive && (item.x < 0 || item.y < 0 ||
             @intCast(item.x) >= world.width || @intCast(item.y) >= world.height));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -73,7 +73,7 @@ fn observe_tiles(inout out: metric.Metric, borrow world: model.World) {
         let item = world.tiles.get_or(i, model.empty_tile());
         metric.observe(inout out, tile_projection(borrow world, i), (i % 13) + 1);
         metric.warn(inout out, item.x >= world.width || item.y >= world.height);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -82,18 +82,18 @@ fn observe_timeline(inout out: metric.Metric, borrow world: model.World) {
     while i < world.events.len() {
         metric.observe(inout out, event_projection(borrow world, i), (i % 5) + 1);
         metric.warn(inout out, world.events.get_or(i, model.empty_event()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
         metric.observe(inout out, command_projection(borrow world, i), (i % 7) + 1);
         metric.warn(inout out, world.commands.get_or(i, model.empty_command()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.snapshots.len() {
         metric.observe(inout out, snapshot_projection(borrow world, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -108,9 +108,9 @@ fn observe_pairs(inout out: metric.Metric, borrow world: model.World) {
             let dy = if left.y > right.y { left.y - right.y } else { right.y - left.y };
             metric.observe(inout out, @intCast(dx + dy) +
                 left.faction * 3 + right.faction * 5 + MODE(), i + j + 1);
-            j = j + 1;
+            j += 1;
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -125,17 +125,17 @@ fn observe_factions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.entities.len() {
             let entity = world.entities.get_or(i, model.empty_entity());
             if entity.faction == faction && entity.alive {
-                agents = agents + 1;
-                health = health + entity.health;
-                energy = energy + entity.energy;
-                inventory = inventory + entity.inventory;
+                agents += 1;
+                health += entity.health;
+                energy += entity.energy;
+                inventory += entity.inventory;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = agents * (MODE() % 11 + 1) + health * 3 +
             energy * 5 + inventory * 7 + faction;
         metric.observe(inout out, projection, faction + MODE() % 5 + 1);
-        faction = faction + 1;
+        faction += 1;
     }
 }
 
@@ -150,17 +150,17 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
-                tiles = tiles + 1;
+                tiles += 1;
                 if tile.walkable { walkable = walkable + 1; }
-                resources = resources + tile.resource;
-                elevation = elevation + tile.height;
+                resources += tile.resource;
+                elevation += tile.height;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = tiles * (MODE() % 13 + 1) + walkable * 3 +
             resources * 5 + elevation * 7 + region;
         metric.observe(inout out, projection, region % 7 + 1);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/audit_replay_throughput.rue
+++ b/examples/caldera/audit_replay_throughput.rue
@@ -151,7 +151,7 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
                 tiles += 1;
-                if tile.walkable { walkable = walkable + 1; }
+                if tile.walkable { walkable += 1; }
                 resources += tile.resource;
                 elevation += tile.height;
             }

--- a/examples/caldera/audit_replay_throughput.rue
+++ b/examples/caldera/audit_replay_throughput.rue
@@ -63,7 +63,7 @@ fn observe_entities(inout out: metric.Metric, borrow world: model.World) {
         metric.observe(inout out, entity_projection(borrow world, i), (i % 11) + 1);
         metric.warn(inout out, item.alive && (item.x < 0 || item.y < 0 ||
             @intCast(item.x) >= world.width || @intCast(item.y) >= world.height));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -73,7 +73,7 @@ fn observe_tiles(inout out: metric.Metric, borrow world: model.World) {
         let item = world.tiles.get_or(i, model.empty_tile());
         metric.observe(inout out, tile_projection(borrow world, i), (i % 13) + 1);
         metric.warn(inout out, item.x >= world.width || item.y >= world.height);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -82,18 +82,18 @@ fn observe_timeline(inout out: metric.Metric, borrow world: model.World) {
     while i < world.events.len() {
         metric.observe(inout out, event_projection(borrow world, i), (i % 5) + 1);
         metric.warn(inout out, world.events.get_or(i, model.empty_event()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
         metric.observe(inout out, command_projection(borrow world, i), (i % 7) + 1);
         metric.warn(inout out, world.commands.get_or(i, model.empty_command()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.snapshots.len() {
         metric.observe(inout out, snapshot_projection(borrow world, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -108,9 +108,9 @@ fn observe_pairs(inout out: metric.Metric, borrow world: model.World) {
             let dy = if left.y > right.y { left.y - right.y } else { right.y - left.y };
             metric.observe(inout out, @intCast(dx + dy) +
                 left.faction * 3 + right.faction * 5 + MODE(), i + j + 1);
-            j = j + 1;
+            j += 1;
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -125,17 +125,17 @@ fn observe_factions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.entities.len() {
             let entity = world.entities.get_or(i, model.empty_entity());
             if entity.faction == faction && entity.alive {
-                agents = agents + 1;
-                health = health + entity.health;
-                energy = energy + entity.energy;
-                inventory = inventory + entity.inventory;
+                agents += 1;
+                health += entity.health;
+                energy += entity.energy;
+                inventory += entity.inventory;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = agents * (MODE() % 11 + 1) + health * 3 +
             energy * 5 + inventory * 7 + faction;
         metric.observe(inout out, projection, faction + MODE() % 5 + 1);
-        faction = faction + 1;
+        faction += 1;
     }
 }
 
@@ -150,17 +150,17 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
-                tiles = tiles + 1;
+                tiles += 1;
                 if tile.walkable { walkable = walkable + 1; }
-                resources = resources + tile.resource;
-                elevation = elevation + tile.height;
+                resources += tile.resource;
+                elevation += tile.height;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = tiles * (MODE() % 13 + 1) + walkable * 3 +
             resources * 5 + elevation * 7 + region;
         metric.observe(inout out, projection, region % 7 + 1);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/audit_script_balance.rue
+++ b/examples/caldera/audit_script_balance.rue
@@ -151,7 +151,7 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
                 tiles += 1;
-                if tile.walkable { walkable = walkable + 1; }
+                if tile.walkable { walkable += 1; }
                 resources += tile.resource;
                 elevation += tile.height;
             }

--- a/examples/caldera/audit_script_balance.rue
+++ b/examples/caldera/audit_script_balance.rue
@@ -63,7 +63,7 @@ fn observe_entities(inout out: metric.Metric, borrow world: model.World) {
         metric.observe(inout out, entity_projection(borrow world, i), (i % 11) + 1);
         metric.warn(inout out, item.alive && (item.x < 0 || item.y < 0 ||
             @intCast(item.x) >= world.width || @intCast(item.y) >= world.height));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -73,7 +73,7 @@ fn observe_tiles(inout out: metric.Metric, borrow world: model.World) {
         let item = world.tiles.get_or(i, model.empty_tile());
         metric.observe(inout out, tile_projection(borrow world, i), (i % 13) + 1);
         metric.warn(inout out, item.x >= world.width || item.y >= world.height);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -82,18 +82,18 @@ fn observe_timeline(inout out: metric.Metric, borrow world: model.World) {
     while i < world.events.len() {
         metric.observe(inout out, event_projection(borrow world, i), (i % 5) + 1);
         metric.warn(inout out, world.events.get_or(i, model.empty_event()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
         metric.observe(inout out, command_projection(borrow world, i), (i % 7) + 1);
         metric.warn(inout out, world.commands.get_or(i, model.empty_command()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.snapshots.len() {
         metric.observe(inout out, snapshot_projection(borrow world, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -108,9 +108,9 @@ fn observe_pairs(inout out: metric.Metric, borrow world: model.World) {
             let dy = if left.y > right.y { left.y - right.y } else { right.y - left.y };
             metric.observe(inout out, @intCast(dx + dy) +
                 left.faction * 3 + right.faction * 5 + MODE(), i + j + 1);
-            j = j + 1;
+            j += 1;
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -125,17 +125,17 @@ fn observe_factions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.entities.len() {
             let entity = world.entities.get_or(i, model.empty_entity());
             if entity.faction == faction && entity.alive {
-                agents = agents + 1;
-                health = health + entity.health;
-                energy = energy + entity.energy;
-                inventory = inventory + entity.inventory;
+                agents += 1;
+                health += entity.health;
+                energy += entity.energy;
+                inventory += entity.inventory;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = agents * (MODE() % 11 + 1) + health * 3 +
             energy * 5 + inventory * 7 + faction;
         metric.observe(inout out, projection, faction + MODE() % 5 + 1);
-        faction = faction + 1;
+        faction += 1;
     }
 }
 
@@ -150,17 +150,17 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
-                tiles = tiles + 1;
+                tiles += 1;
                 if tile.walkable { walkable = walkable + 1; }
-                resources = resources + tile.resource;
-                elevation = elevation + tile.height;
+                resources += tile.resource;
+                elevation += tile.height;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = tiles * (MODE() % 13 + 1) + walkable * 3 +
             resources * 5 + elevation * 7 + region;
         metric.observe(inout out, projection, region % 7 + 1);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/audit_script_capacity.rue
+++ b/examples/caldera/audit_script_capacity.rue
@@ -151,7 +151,7 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
                 tiles += 1;
-                if tile.walkable { walkable = walkable + 1; }
+                if tile.walkable { walkable += 1; }
                 resources += tile.resource;
                 elevation += tile.height;
             }

--- a/examples/caldera/audit_script_capacity.rue
+++ b/examples/caldera/audit_script_capacity.rue
@@ -63,7 +63,7 @@ fn observe_entities(inout out: metric.Metric, borrow world: model.World) {
         metric.observe(inout out, entity_projection(borrow world, i), (i % 11) + 1);
         metric.warn(inout out, item.alive && (item.x < 0 || item.y < 0 ||
             @intCast(item.x) >= world.width || @intCast(item.y) >= world.height));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -73,7 +73,7 @@ fn observe_tiles(inout out: metric.Metric, borrow world: model.World) {
         let item = world.tiles.get_or(i, model.empty_tile());
         metric.observe(inout out, tile_projection(borrow world, i), (i % 13) + 1);
         metric.warn(inout out, item.x >= world.width || item.y >= world.height);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -82,18 +82,18 @@ fn observe_timeline(inout out: metric.Metric, borrow world: model.World) {
     while i < world.events.len() {
         metric.observe(inout out, event_projection(borrow world, i), (i % 5) + 1);
         metric.warn(inout out, world.events.get_or(i, model.empty_event()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
         metric.observe(inout out, command_projection(borrow world, i), (i % 7) + 1);
         metric.warn(inout out, world.commands.get_or(i, model.empty_command()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.snapshots.len() {
         metric.observe(inout out, snapshot_projection(borrow world, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -108,9 +108,9 @@ fn observe_pairs(inout out: metric.Metric, borrow world: model.World) {
             let dy = if left.y > right.y { left.y - right.y } else { right.y - left.y };
             metric.observe(inout out, @intCast(dx + dy) +
                 left.faction * 3 + right.faction * 5 + MODE(), i + j + 1);
-            j = j + 1;
+            j += 1;
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -125,17 +125,17 @@ fn observe_factions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.entities.len() {
             let entity = world.entities.get_or(i, model.empty_entity());
             if entity.faction == faction && entity.alive {
-                agents = agents + 1;
-                health = health + entity.health;
-                energy = energy + entity.energy;
-                inventory = inventory + entity.inventory;
+                agents += 1;
+                health += entity.health;
+                energy += entity.energy;
+                inventory += entity.inventory;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = agents * (MODE() % 11 + 1) + health * 3 +
             energy * 5 + inventory * 7 + faction;
         metric.observe(inout out, projection, faction + MODE() % 5 + 1);
-        faction = faction + 1;
+        faction += 1;
     }
 }
 
@@ -150,17 +150,17 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
-                tiles = tiles + 1;
+                tiles += 1;
                 if tile.walkable { walkable = walkable + 1; }
-                resources = resources + tile.resource;
-                elevation = elevation + tile.height;
+                resources += tile.resource;
+                elevation += tile.height;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = tiles * (MODE() % 13 + 1) + walkable * 3 +
             resources * 5 + elevation * 7 + region;
         metric.observe(inout out, projection, region % 7 + 1);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/audit_script_continuity.rue
+++ b/examples/caldera/audit_script_continuity.rue
@@ -151,7 +151,7 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
                 tiles += 1;
-                if tile.walkable { walkable = walkable + 1; }
+                if tile.walkable { walkable += 1; }
                 resources += tile.resource;
                 elevation += tile.height;
             }

--- a/examples/caldera/audit_script_continuity.rue
+++ b/examples/caldera/audit_script_continuity.rue
@@ -63,7 +63,7 @@ fn observe_entities(inout out: metric.Metric, borrow world: model.World) {
         metric.observe(inout out, entity_projection(borrow world, i), (i % 11) + 1);
         metric.warn(inout out, item.alive && (item.x < 0 || item.y < 0 ||
             @intCast(item.x) >= world.width || @intCast(item.y) >= world.height));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -73,7 +73,7 @@ fn observe_tiles(inout out: metric.Metric, borrow world: model.World) {
         let item = world.tiles.get_or(i, model.empty_tile());
         metric.observe(inout out, tile_projection(borrow world, i), (i % 13) + 1);
         metric.warn(inout out, item.x >= world.width || item.y >= world.height);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -82,18 +82,18 @@ fn observe_timeline(inout out: metric.Metric, borrow world: model.World) {
     while i < world.events.len() {
         metric.observe(inout out, event_projection(borrow world, i), (i % 5) + 1);
         metric.warn(inout out, world.events.get_or(i, model.empty_event()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
         metric.observe(inout out, command_projection(borrow world, i), (i % 7) + 1);
         metric.warn(inout out, world.commands.get_or(i, model.empty_command()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.snapshots.len() {
         metric.observe(inout out, snapshot_projection(borrow world, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -108,9 +108,9 @@ fn observe_pairs(inout out: metric.Metric, borrow world: model.World) {
             let dy = if left.y > right.y { left.y - right.y } else { right.y - left.y };
             metric.observe(inout out, @intCast(dx + dy) +
                 left.faction * 3 + right.faction * 5 + MODE(), i + j + 1);
-            j = j + 1;
+            j += 1;
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -125,17 +125,17 @@ fn observe_factions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.entities.len() {
             let entity = world.entities.get_or(i, model.empty_entity());
             if entity.faction == faction && entity.alive {
-                agents = agents + 1;
-                health = health + entity.health;
-                energy = energy + entity.energy;
-                inventory = inventory + entity.inventory;
+                agents += 1;
+                health += entity.health;
+                energy += entity.energy;
+                inventory += entity.inventory;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = agents * (MODE() % 11 + 1) + health * 3 +
             energy * 5 + inventory * 7 + faction;
         metric.observe(inout out, projection, faction + MODE() % 5 + 1);
-        faction = faction + 1;
+        faction += 1;
     }
 }
 
@@ -150,17 +150,17 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
-                tiles = tiles + 1;
+                tiles += 1;
                 if tile.walkable { walkable = walkable + 1; }
-                resources = resources + tile.resource;
-                elevation = elevation + tile.height;
+                resources += tile.resource;
+                elevation += tile.height;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = tiles * (MODE() % 13 + 1) + walkable * 3 +
             resources * 5 + elevation * 7 + region;
         metric.observe(inout out, projection, region % 7 + 1);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/audit_script_cost.rue
+++ b/examples/caldera/audit_script_cost.rue
@@ -151,7 +151,7 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
                 tiles += 1;
-                if tile.walkable { walkable = walkable + 1; }
+                if tile.walkable { walkable += 1; }
                 resources += tile.resource;
                 elevation += tile.height;
             }

--- a/examples/caldera/audit_script_cost.rue
+++ b/examples/caldera/audit_script_cost.rue
@@ -63,7 +63,7 @@ fn observe_entities(inout out: metric.Metric, borrow world: model.World) {
         metric.observe(inout out, entity_projection(borrow world, i), (i % 11) + 1);
         metric.warn(inout out, item.alive && (item.x < 0 || item.y < 0 ||
             @intCast(item.x) >= world.width || @intCast(item.y) >= world.height));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -73,7 +73,7 @@ fn observe_tiles(inout out: metric.Metric, borrow world: model.World) {
         let item = world.tiles.get_or(i, model.empty_tile());
         metric.observe(inout out, tile_projection(borrow world, i), (i % 13) + 1);
         metric.warn(inout out, item.x >= world.width || item.y >= world.height);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -82,18 +82,18 @@ fn observe_timeline(inout out: metric.Metric, borrow world: model.World) {
     while i < world.events.len() {
         metric.observe(inout out, event_projection(borrow world, i), (i % 5) + 1);
         metric.warn(inout out, world.events.get_or(i, model.empty_event()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
         metric.observe(inout out, command_projection(borrow world, i), (i % 7) + 1);
         metric.warn(inout out, world.commands.get_or(i, model.empty_command()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.snapshots.len() {
         metric.observe(inout out, snapshot_projection(borrow world, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -108,9 +108,9 @@ fn observe_pairs(inout out: metric.Metric, borrow world: model.World) {
             let dy = if left.y > right.y { left.y - right.y } else { right.y - left.y };
             metric.observe(inout out, @intCast(dx + dy) +
                 left.faction * 3 + right.faction * 5 + MODE(), i + j + 1);
-            j = j + 1;
+            j += 1;
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -125,17 +125,17 @@ fn observe_factions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.entities.len() {
             let entity = world.entities.get_or(i, model.empty_entity());
             if entity.faction == faction && entity.alive {
-                agents = agents + 1;
-                health = health + entity.health;
-                energy = energy + entity.energy;
-                inventory = inventory + entity.inventory;
+                agents += 1;
+                health += entity.health;
+                energy += entity.energy;
+                inventory += entity.inventory;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = agents * (MODE() % 11 + 1) + health * 3 +
             energy * 5 + inventory * 7 + faction;
         metric.observe(inout out, projection, faction + MODE() % 5 + 1);
-        faction = faction + 1;
+        faction += 1;
     }
 }
 
@@ -150,17 +150,17 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
-                tiles = tiles + 1;
+                tiles += 1;
                 if tile.walkable { walkable = walkable + 1; }
-                resources = resources + tile.resource;
-                elevation = elevation + tile.height;
+                resources += tile.resource;
+                elevation += tile.height;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = tiles * (MODE() % 13 + 1) + walkable * 3 +
             resources * 5 + elevation * 7 + region;
         metric.observe(inout out, projection, region % 7 + 1);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/audit_script_coverage.rue
+++ b/examples/caldera/audit_script_coverage.rue
@@ -151,7 +151,7 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
                 tiles += 1;
-                if tile.walkable { walkable = walkable + 1; }
+                if tile.walkable { walkable += 1; }
                 resources += tile.resource;
                 elevation += tile.height;
             }

--- a/examples/caldera/audit_script_coverage.rue
+++ b/examples/caldera/audit_script_coverage.rue
@@ -63,7 +63,7 @@ fn observe_entities(inout out: metric.Metric, borrow world: model.World) {
         metric.observe(inout out, entity_projection(borrow world, i), (i % 11) + 1);
         metric.warn(inout out, item.alive && (item.x < 0 || item.y < 0 ||
             @intCast(item.x) >= world.width || @intCast(item.y) >= world.height));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -73,7 +73,7 @@ fn observe_tiles(inout out: metric.Metric, borrow world: model.World) {
         let item = world.tiles.get_or(i, model.empty_tile());
         metric.observe(inout out, tile_projection(borrow world, i), (i % 13) + 1);
         metric.warn(inout out, item.x >= world.width || item.y >= world.height);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -82,18 +82,18 @@ fn observe_timeline(inout out: metric.Metric, borrow world: model.World) {
     while i < world.events.len() {
         metric.observe(inout out, event_projection(borrow world, i), (i % 5) + 1);
         metric.warn(inout out, world.events.get_or(i, model.empty_event()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
         metric.observe(inout out, command_projection(borrow world, i), (i % 7) + 1);
         metric.warn(inout out, world.commands.get_or(i, model.empty_command()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.snapshots.len() {
         metric.observe(inout out, snapshot_projection(borrow world, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -108,9 +108,9 @@ fn observe_pairs(inout out: metric.Metric, borrow world: model.World) {
             let dy = if left.y > right.y { left.y - right.y } else { right.y - left.y };
             metric.observe(inout out, @intCast(dx + dy) +
                 left.faction * 3 + right.faction * 5 + MODE(), i + j + 1);
-            j = j + 1;
+            j += 1;
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -125,17 +125,17 @@ fn observe_factions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.entities.len() {
             let entity = world.entities.get_or(i, model.empty_entity());
             if entity.faction == faction && entity.alive {
-                agents = agents + 1;
-                health = health + entity.health;
-                energy = energy + entity.energy;
-                inventory = inventory + entity.inventory;
+                agents += 1;
+                health += entity.health;
+                energy += entity.energy;
+                inventory += entity.inventory;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = agents * (MODE() % 11 + 1) + health * 3 +
             energy * 5 + inventory * 7 + faction;
         metric.observe(inout out, projection, faction + MODE() % 5 + 1);
-        faction = faction + 1;
+        faction += 1;
     }
 }
 
@@ -150,17 +150,17 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
-                tiles = tiles + 1;
+                tiles += 1;
                 if tile.walkable { walkable = walkable + 1; }
-                resources = resources + tile.resource;
-                elevation = elevation + tile.height;
+                resources += tile.resource;
+                elevation += tile.height;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = tiles * (MODE() % 13 + 1) + walkable * 3 +
             resources * 5 + elevation * 7 + region;
         metric.observe(inout out, projection, region % 7 + 1);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/audit_script_density.rue
+++ b/examples/caldera/audit_script_density.rue
@@ -151,7 +151,7 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
                 tiles += 1;
-                if tile.walkable { walkable = walkable + 1; }
+                if tile.walkable { walkable += 1; }
                 resources += tile.resource;
                 elevation += tile.height;
             }

--- a/examples/caldera/audit_script_density.rue
+++ b/examples/caldera/audit_script_density.rue
@@ -63,7 +63,7 @@ fn observe_entities(inout out: metric.Metric, borrow world: model.World) {
         metric.observe(inout out, entity_projection(borrow world, i), (i % 11) + 1);
         metric.warn(inout out, item.alive && (item.x < 0 || item.y < 0 ||
             @intCast(item.x) >= world.width || @intCast(item.y) >= world.height));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -73,7 +73,7 @@ fn observe_tiles(inout out: metric.Metric, borrow world: model.World) {
         let item = world.tiles.get_or(i, model.empty_tile());
         metric.observe(inout out, tile_projection(borrow world, i), (i % 13) + 1);
         metric.warn(inout out, item.x >= world.width || item.y >= world.height);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -82,18 +82,18 @@ fn observe_timeline(inout out: metric.Metric, borrow world: model.World) {
     while i < world.events.len() {
         metric.observe(inout out, event_projection(borrow world, i), (i % 5) + 1);
         metric.warn(inout out, world.events.get_or(i, model.empty_event()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
         metric.observe(inout out, command_projection(borrow world, i), (i % 7) + 1);
         metric.warn(inout out, world.commands.get_or(i, model.empty_command()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.snapshots.len() {
         metric.observe(inout out, snapshot_projection(borrow world, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -108,9 +108,9 @@ fn observe_pairs(inout out: metric.Metric, borrow world: model.World) {
             let dy = if left.y > right.y { left.y - right.y } else { right.y - left.y };
             metric.observe(inout out, @intCast(dx + dy) +
                 left.faction * 3 + right.faction * 5 + MODE(), i + j + 1);
-            j = j + 1;
+            j += 1;
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -125,17 +125,17 @@ fn observe_factions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.entities.len() {
             let entity = world.entities.get_or(i, model.empty_entity());
             if entity.faction == faction && entity.alive {
-                agents = agents + 1;
-                health = health + entity.health;
-                energy = energy + entity.energy;
-                inventory = inventory + entity.inventory;
+                agents += 1;
+                health += entity.health;
+                energy += entity.energy;
+                inventory += entity.inventory;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = agents * (MODE() % 11 + 1) + health * 3 +
             energy * 5 + inventory * 7 + faction;
         metric.observe(inout out, projection, faction + MODE() % 5 + 1);
-        faction = faction + 1;
+        faction += 1;
     }
 }
 
@@ -150,17 +150,17 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
-                tiles = tiles + 1;
+                tiles += 1;
                 if tile.walkable { walkable = walkable + 1; }
-                resources = resources + tile.resource;
-                elevation = elevation + tile.height;
+                resources += tile.resource;
+                elevation += tile.height;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = tiles * (MODE() % 13 + 1) + walkable * 3 +
             resources * 5 + elevation * 7 + region;
         metric.observe(inout out, projection, region % 7 + 1);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/audit_script_entropy.rue
+++ b/examples/caldera/audit_script_entropy.rue
@@ -151,7 +151,7 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
                 tiles += 1;
-                if tile.walkable { walkable = walkable + 1; }
+                if tile.walkable { walkable += 1; }
                 resources += tile.resource;
                 elevation += tile.height;
             }

--- a/examples/caldera/audit_script_entropy.rue
+++ b/examples/caldera/audit_script_entropy.rue
@@ -63,7 +63,7 @@ fn observe_entities(inout out: metric.Metric, borrow world: model.World) {
         metric.observe(inout out, entity_projection(borrow world, i), (i % 11) + 1);
         metric.warn(inout out, item.alive && (item.x < 0 || item.y < 0 ||
             @intCast(item.x) >= world.width || @intCast(item.y) >= world.height));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -73,7 +73,7 @@ fn observe_tiles(inout out: metric.Metric, borrow world: model.World) {
         let item = world.tiles.get_or(i, model.empty_tile());
         metric.observe(inout out, tile_projection(borrow world, i), (i % 13) + 1);
         metric.warn(inout out, item.x >= world.width || item.y >= world.height);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -82,18 +82,18 @@ fn observe_timeline(inout out: metric.Metric, borrow world: model.World) {
     while i < world.events.len() {
         metric.observe(inout out, event_projection(borrow world, i), (i % 5) + 1);
         metric.warn(inout out, world.events.get_or(i, model.empty_event()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
         metric.observe(inout out, command_projection(borrow world, i), (i % 7) + 1);
         metric.warn(inout out, world.commands.get_or(i, model.empty_command()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.snapshots.len() {
         metric.observe(inout out, snapshot_projection(borrow world, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -108,9 +108,9 @@ fn observe_pairs(inout out: metric.Metric, borrow world: model.World) {
             let dy = if left.y > right.y { left.y - right.y } else { right.y - left.y };
             metric.observe(inout out, @intCast(dx + dy) +
                 left.faction * 3 + right.faction * 5 + MODE(), i + j + 1);
-            j = j + 1;
+            j += 1;
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -125,17 +125,17 @@ fn observe_factions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.entities.len() {
             let entity = world.entities.get_or(i, model.empty_entity());
             if entity.faction == faction && entity.alive {
-                agents = agents + 1;
-                health = health + entity.health;
-                energy = energy + entity.energy;
-                inventory = inventory + entity.inventory;
+                agents += 1;
+                health += entity.health;
+                energy += entity.energy;
+                inventory += entity.inventory;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = agents * (MODE() % 11 + 1) + health * 3 +
             energy * 5 + inventory * 7 + faction;
         metric.observe(inout out, projection, faction + MODE() % 5 + 1);
-        faction = faction + 1;
+        faction += 1;
     }
 }
 
@@ -150,17 +150,17 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
-                tiles = tiles + 1;
+                tiles += 1;
                 if tile.walkable { walkable = walkable + 1; }
-                resources = resources + tile.resource;
-                elevation = elevation + tile.height;
+                resources += tile.resource;
+                elevation += tile.height;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = tiles * (MODE() % 13 + 1) + walkable * 3 +
             resources * 5 + elevation * 7 + region;
         metric.observe(inout out, projection, region % 7 + 1);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/audit_script_fanout.rue
+++ b/examples/caldera/audit_script_fanout.rue
@@ -151,7 +151,7 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
                 tiles += 1;
-                if tile.walkable { walkable = walkable + 1; }
+                if tile.walkable { walkable += 1; }
                 resources += tile.resource;
                 elevation += tile.height;
             }

--- a/examples/caldera/audit_script_fanout.rue
+++ b/examples/caldera/audit_script_fanout.rue
@@ -63,7 +63,7 @@ fn observe_entities(inout out: metric.Metric, borrow world: model.World) {
         metric.observe(inout out, entity_projection(borrow world, i), (i % 11) + 1);
         metric.warn(inout out, item.alive && (item.x < 0 || item.y < 0 ||
             @intCast(item.x) >= world.width || @intCast(item.y) >= world.height));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -73,7 +73,7 @@ fn observe_tiles(inout out: metric.Metric, borrow world: model.World) {
         let item = world.tiles.get_or(i, model.empty_tile());
         metric.observe(inout out, tile_projection(borrow world, i), (i % 13) + 1);
         metric.warn(inout out, item.x >= world.width || item.y >= world.height);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -82,18 +82,18 @@ fn observe_timeline(inout out: metric.Metric, borrow world: model.World) {
     while i < world.events.len() {
         metric.observe(inout out, event_projection(borrow world, i), (i % 5) + 1);
         metric.warn(inout out, world.events.get_or(i, model.empty_event()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
         metric.observe(inout out, command_projection(borrow world, i), (i % 7) + 1);
         metric.warn(inout out, world.commands.get_or(i, model.empty_command()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.snapshots.len() {
         metric.observe(inout out, snapshot_projection(borrow world, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -108,9 +108,9 @@ fn observe_pairs(inout out: metric.Metric, borrow world: model.World) {
             let dy = if left.y > right.y { left.y - right.y } else { right.y - left.y };
             metric.observe(inout out, @intCast(dx + dy) +
                 left.faction * 3 + right.faction * 5 + MODE(), i + j + 1);
-            j = j + 1;
+            j += 1;
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -125,17 +125,17 @@ fn observe_factions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.entities.len() {
             let entity = world.entities.get_or(i, model.empty_entity());
             if entity.faction == faction && entity.alive {
-                agents = agents + 1;
-                health = health + entity.health;
-                energy = energy + entity.energy;
-                inventory = inventory + entity.inventory;
+                agents += 1;
+                health += entity.health;
+                energy += entity.energy;
+                inventory += entity.inventory;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = agents * (MODE() % 11 + 1) + health * 3 +
             energy * 5 + inventory * 7 + faction;
         metric.observe(inout out, projection, faction + MODE() % 5 + 1);
-        faction = faction + 1;
+        faction += 1;
     }
 }
 
@@ -150,17 +150,17 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
-                tiles = tiles + 1;
+                tiles += 1;
                 if tile.walkable { walkable = walkable + 1; }
-                resources = resources + tile.resource;
-                elevation = elevation + tile.height;
+                resources += tile.resource;
+                elevation += tile.height;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = tiles * (MODE() % 13 + 1) + walkable * 3 +
             resources * 5 + elevation * 7 + region;
         metric.observe(inout out, projection, region % 7 + 1);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/audit_script_integrity.rue
+++ b/examples/caldera/audit_script_integrity.rue
@@ -151,7 +151,7 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
                 tiles += 1;
-                if tile.walkable { walkable = walkable + 1; }
+                if tile.walkable { walkable += 1; }
                 resources += tile.resource;
                 elevation += tile.height;
             }

--- a/examples/caldera/audit_script_integrity.rue
+++ b/examples/caldera/audit_script_integrity.rue
@@ -63,7 +63,7 @@ fn observe_entities(inout out: metric.Metric, borrow world: model.World) {
         metric.observe(inout out, entity_projection(borrow world, i), (i % 11) + 1);
         metric.warn(inout out, item.alive && (item.x < 0 || item.y < 0 ||
             @intCast(item.x) >= world.width || @intCast(item.y) >= world.height));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -73,7 +73,7 @@ fn observe_tiles(inout out: metric.Metric, borrow world: model.World) {
         let item = world.tiles.get_or(i, model.empty_tile());
         metric.observe(inout out, tile_projection(borrow world, i), (i % 13) + 1);
         metric.warn(inout out, item.x >= world.width || item.y >= world.height);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -82,18 +82,18 @@ fn observe_timeline(inout out: metric.Metric, borrow world: model.World) {
     while i < world.events.len() {
         metric.observe(inout out, event_projection(borrow world, i), (i % 5) + 1);
         metric.warn(inout out, world.events.get_or(i, model.empty_event()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
         metric.observe(inout out, command_projection(borrow world, i), (i % 7) + 1);
         metric.warn(inout out, world.commands.get_or(i, model.empty_command()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.snapshots.len() {
         metric.observe(inout out, snapshot_projection(borrow world, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -108,9 +108,9 @@ fn observe_pairs(inout out: metric.Metric, borrow world: model.World) {
             let dy = if left.y > right.y { left.y - right.y } else { right.y - left.y };
             metric.observe(inout out, @intCast(dx + dy) +
                 left.faction * 3 + right.faction * 5 + MODE(), i + j + 1);
-            j = j + 1;
+            j += 1;
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -125,17 +125,17 @@ fn observe_factions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.entities.len() {
             let entity = world.entities.get_or(i, model.empty_entity());
             if entity.faction == faction && entity.alive {
-                agents = agents + 1;
-                health = health + entity.health;
-                energy = energy + entity.energy;
-                inventory = inventory + entity.inventory;
+                agents += 1;
+                health += entity.health;
+                energy += entity.energy;
+                inventory += entity.inventory;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = agents * (MODE() % 11 + 1) + health * 3 +
             energy * 5 + inventory * 7 + faction;
         metric.observe(inout out, projection, faction + MODE() % 5 + 1);
-        faction = faction + 1;
+        faction += 1;
     }
 }
 
@@ -150,17 +150,17 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
-                tiles = tiles + 1;
+                tiles += 1;
                 if tile.walkable { walkable = walkable + 1; }
-                resources = resources + tile.resource;
-                elevation = elevation + tile.height;
+                resources += tile.resource;
+                elevation += tile.height;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = tiles * (MODE() % 13 + 1) + walkable * 3 +
             resources * 5 + elevation * 7 + region;
         metric.observe(inout out, projection, region % 7 + 1);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/audit_script_latency.rue
+++ b/examples/caldera/audit_script_latency.rue
@@ -151,7 +151,7 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
                 tiles += 1;
-                if tile.walkable { walkable = walkable + 1; }
+                if tile.walkable { walkable += 1; }
                 resources += tile.resource;
                 elevation += tile.height;
             }

--- a/examples/caldera/audit_script_latency.rue
+++ b/examples/caldera/audit_script_latency.rue
@@ -63,7 +63,7 @@ fn observe_entities(inout out: metric.Metric, borrow world: model.World) {
         metric.observe(inout out, entity_projection(borrow world, i), (i % 11) + 1);
         metric.warn(inout out, item.alive && (item.x < 0 || item.y < 0 ||
             @intCast(item.x) >= world.width || @intCast(item.y) >= world.height));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -73,7 +73,7 @@ fn observe_tiles(inout out: metric.Metric, borrow world: model.World) {
         let item = world.tiles.get_or(i, model.empty_tile());
         metric.observe(inout out, tile_projection(borrow world, i), (i % 13) + 1);
         metric.warn(inout out, item.x >= world.width || item.y >= world.height);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -82,18 +82,18 @@ fn observe_timeline(inout out: metric.Metric, borrow world: model.World) {
     while i < world.events.len() {
         metric.observe(inout out, event_projection(borrow world, i), (i % 5) + 1);
         metric.warn(inout out, world.events.get_or(i, model.empty_event()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
         metric.observe(inout out, command_projection(borrow world, i), (i % 7) + 1);
         metric.warn(inout out, world.commands.get_or(i, model.empty_command()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.snapshots.len() {
         metric.observe(inout out, snapshot_projection(borrow world, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -108,9 +108,9 @@ fn observe_pairs(inout out: metric.Metric, borrow world: model.World) {
             let dy = if left.y > right.y { left.y - right.y } else { right.y - left.y };
             metric.observe(inout out, @intCast(dx + dy) +
                 left.faction * 3 + right.faction * 5 + MODE(), i + j + 1);
-            j = j + 1;
+            j += 1;
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -125,17 +125,17 @@ fn observe_factions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.entities.len() {
             let entity = world.entities.get_or(i, model.empty_entity());
             if entity.faction == faction && entity.alive {
-                agents = agents + 1;
-                health = health + entity.health;
-                energy = energy + entity.energy;
-                inventory = inventory + entity.inventory;
+                agents += 1;
+                health += entity.health;
+                energy += entity.energy;
+                inventory += entity.inventory;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = agents * (MODE() % 11 + 1) + health * 3 +
             energy * 5 + inventory * 7 + faction;
         metric.observe(inout out, projection, faction + MODE() % 5 + 1);
-        faction = faction + 1;
+        faction += 1;
     }
 }
 
@@ -150,17 +150,17 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
-                tiles = tiles + 1;
+                tiles += 1;
                 if tile.walkable { walkable = walkable + 1; }
-                resources = resources + tile.resource;
-                elevation = elevation + tile.height;
+                resources += tile.resource;
+                elevation += tile.height;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = tiles * (MODE() % 13 + 1) + walkable * 3 +
             resources * 5 + elevation * 7 + region;
         metric.observe(inout out, projection, region % 7 + 1);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/audit_script_locality.rue
+++ b/examples/caldera/audit_script_locality.rue
@@ -151,7 +151,7 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
                 tiles += 1;
-                if tile.walkable { walkable = walkable + 1; }
+                if tile.walkable { walkable += 1; }
                 resources += tile.resource;
                 elevation += tile.height;
             }

--- a/examples/caldera/audit_script_locality.rue
+++ b/examples/caldera/audit_script_locality.rue
@@ -63,7 +63,7 @@ fn observe_entities(inout out: metric.Metric, borrow world: model.World) {
         metric.observe(inout out, entity_projection(borrow world, i), (i % 11) + 1);
         metric.warn(inout out, item.alive && (item.x < 0 || item.y < 0 ||
             @intCast(item.x) >= world.width || @intCast(item.y) >= world.height));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -73,7 +73,7 @@ fn observe_tiles(inout out: metric.Metric, borrow world: model.World) {
         let item = world.tiles.get_or(i, model.empty_tile());
         metric.observe(inout out, tile_projection(borrow world, i), (i % 13) + 1);
         metric.warn(inout out, item.x >= world.width || item.y >= world.height);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -82,18 +82,18 @@ fn observe_timeline(inout out: metric.Metric, borrow world: model.World) {
     while i < world.events.len() {
         metric.observe(inout out, event_projection(borrow world, i), (i % 5) + 1);
         metric.warn(inout out, world.events.get_or(i, model.empty_event()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
         metric.observe(inout out, command_projection(borrow world, i), (i % 7) + 1);
         metric.warn(inout out, world.commands.get_or(i, model.empty_command()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.snapshots.len() {
         metric.observe(inout out, snapshot_projection(borrow world, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -108,9 +108,9 @@ fn observe_pairs(inout out: metric.Metric, borrow world: model.World) {
             let dy = if left.y > right.y { left.y - right.y } else { right.y - left.y };
             metric.observe(inout out, @intCast(dx + dy) +
                 left.faction * 3 + right.faction * 5 + MODE(), i + j + 1);
-            j = j + 1;
+            j += 1;
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -125,17 +125,17 @@ fn observe_factions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.entities.len() {
             let entity = world.entities.get_or(i, model.empty_entity());
             if entity.faction == faction && entity.alive {
-                agents = agents + 1;
-                health = health + entity.health;
-                energy = energy + entity.energy;
-                inventory = inventory + entity.inventory;
+                agents += 1;
+                health += entity.health;
+                energy += entity.energy;
+                inventory += entity.inventory;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = agents * (MODE() % 11 + 1) + health * 3 +
             energy * 5 + inventory * 7 + faction;
         metric.observe(inout out, projection, faction + MODE() % 5 + 1);
-        faction = faction + 1;
+        faction += 1;
     }
 }
 
@@ -150,17 +150,17 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
-                tiles = tiles + 1;
+                tiles += 1;
                 if tile.walkable { walkable = walkable + 1; }
-                resources = resources + tile.resource;
-                elevation = elevation + tile.height;
+                resources += tile.resource;
+                elevation += tile.height;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = tiles * (MODE() % 13 + 1) + walkable * 3 +
             resources * 5 + elevation * 7 + region;
         metric.observe(inout out, projection, region % 7 + 1);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/audit_script_pressure.rue
+++ b/examples/caldera/audit_script_pressure.rue
@@ -151,7 +151,7 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
                 tiles += 1;
-                if tile.walkable { walkable = walkable + 1; }
+                if tile.walkable { walkable += 1; }
                 resources += tile.resource;
                 elevation += tile.height;
             }

--- a/examples/caldera/audit_script_pressure.rue
+++ b/examples/caldera/audit_script_pressure.rue
@@ -63,7 +63,7 @@ fn observe_entities(inout out: metric.Metric, borrow world: model.World) {
         metric.observe(inout out, entity_projection(borrow world, i), (i % 11) + 1);
         metric.warn(inout out, item.alive && (item.x < 0 || item.y < 0 ||
             @intCast(item.x) >= world.width || @intCast(item.y) >= world.height));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -73,7 +73,7 @@ fn observe_tiles(inout out: metric.Metric, borrow world: model.World) {
         let item = world.tiles.get_or(i, model.empty_tile());
         metric.observe(inout out, tile_projection(borrow world, i), (i % 13) + 1);
         metric.warn(inout out, item.x >= world.width || item.y >= world.height);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -82,18 +82,18 @@ fn observe_timeline(inout out: metric.Metric, borrow world: model.World) {
     while i < world.events.len() {
         metric.observe(inout out, event_projection(borrow world, i), (i % 5) + 1);
         metric.warn(inout out, world.events.get_or(i, model.empty_event()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
         metric.observe(inout out, command_projection(borrow world, i), (i % 7) + 1);
         metric.warn(inout out, world.commands.get_or(i, model.empty_command()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.snapshots.len() {
         metric.observe(inout out, snapshot_projection(borrow world, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -108,9 +108,9 @@ fn observe_pairs(inout out: metric.Metric, borrow world: model.World) {
             let dy = if left.y > right.y { left.y - right.y } else { right.y - left.y };
             metric.observe(inout out, @intCast(dx + dy) +
                 left.faction * 3 + right.faction * 5 + MODE(), i + j + 1);
-            j = j + 1;
+            j += 1;
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -125,17 +125,17 @@ fn observe_factions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.entities.len() {
             let entity = world.entities.get_or(i, model.empty_entity());
             if entity.faction == faction && entity.alive {
-                agents = agents + 1;
-                health = health + entity.health;
-                energy = energy + entity.energy;
-                inventory = inventory + entity.inventory;
+                agents += 1;
+                health += entity.health;
+                energy += entity.energy;
+                inventory += entity.inventory;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = agents * (MODE() % 11 + 1) + health * 3 +
             energy * 5 + inventory * 7 + faction;
         metric.observe(inout out, projection, faction + MODE() % 5 + 1);
-        faction = faction + 1;
+        faction += 1;
     }
 }
 
@@ -150,17 +150,17 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
-                tiles = tiles + 1;
+                tiles += 1;
                 if tile.walkable { walkable = walkable + 1; }
-                resources = resources + tile.resource;
-                elevation = elevation + tile.height;
+                resources += tile.resource;
+                elevation += tile.height;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = tiles * (MODE() % 13 + 1) + walkable * 3 +
             resources * 5 + elevation * 7 + region;
         metric.observe(inout out, projection, region % 7 + 1);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/audit_script_risk.rue
+++ b/examples/caldera/audit_script_risk.rue
@@ -151,7 +151,7 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
                 tiles += 1;
-                if tile.walkable { walkable = walkable + 1; }
+                if tile.walkable { walkable += 1; }
                 resources += tile.resource;
                 elevation += tile.height;
             }

--- a/examples/caldera/audit_script_risk.rue
+++ b/examples/caldera/audit_script_risk.rue
@@ -63,7 +63,7 @@ fn observe_entities(inout out: metric.Metric, borrow world: model.World) {
         metric.observe(inout out, entity_projection(borrow world, i), (i % 11) + 1);
         metric.warn(inout out, item.alive && (item.x < 0 || item.y < 0 ||
             @intCast(item.x) >= world.width || @intCast(item.y) >= world.height));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -73,7 +73,7 @@ fn observe_tiles(inout out: metric.Metric, borrow world: model.World) {
         let item = world.tiles.get_or(i, model.empty_tile());
         metric.observe(inout out, tile_projection(borrow world, i), (i % 13) + 1);
         metric.warn(inout out, item.x >= world.width || item.y >= world.height);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -82,18 +82,18 @@ fn observe_timeline(inout out: metric.Metric, borrow world: model.World) {
     while i < world.events.len() {
         metric.observe(inout out, event_projection(borrow world, i), (i % 5) + 1);
         metric.warn(inout out, world.events.get_or(i, model.empty_event()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
         metric.observe(inout out, command_projection(borrow world, i), (i % 7) + 1);
         metric.warn(inout out, world.commands.get_or(i, model.empty_command()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.snapshots.len() {
         metric.observe(inout out, snapshot_projection(borrow world, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -108,9 +108,9 @@ fn observe_pairs(inout out: metric.Metric, borrow world: model.World) {
             let dy = if left.y > right.y { left.y - right.y } else { right.y - left.y };
             metric.observe(inout out, @intCast(dx + dy) +
                 left.faction * 3 + right.faction * 5 + MODE(), i + j + 1);
-            j = j + 1;
+            j += 1;
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -125,17 +125,17 @@ fn observe_factions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.entities.len() {
             let entity = world.entities.get_or(i, model.empty_entity());
             if entity.faction == faction && entity.alive {
-                agents = agents + 1;
-                health = health + entity.health;
-                energy = energy + entity.energy;
-                inventory = inventory + entity.inventory;
+                agents += 1;
+                health += entity.health;
+                energy += entity.energy;
+                inventory += entity.inventory;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = agents * (MODE() % 11 + 1) + health * 3 +
             energy * 5 + inventory * 7 + faction;
         metric.observe(inout out, projection, faction + MODE() % 5 + 1);
-        faction = faction + 1;
+        faction += 1;
     }
 }
 
@@ -150,17 +150,17 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
-                tiles = tiles + 1;
+                tiles += 1;
                 if tile.walkable { walkable = walkable + 1; }
-                resources = resources + tile.resource;
-                elevation = elevation + tile.height;
+                resources += tile.resource;
+                elevation += tile.height;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = tiles * (MODE() % 13 + 1) + walkable * 3 +
             resources * 5 + elevation * 7 + region;
         metric.observe(inout out, projection, region % 7 + 1);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/audit_script_skew.rue
+++ b/examples/caldera/audit_script_skew.rue
@@ -151,7 +151,7 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
                 tiles += 1;
-                if tile.walkable { walkable = walkable + 1; }
+                if tile.walkable { walkable += 1; }
                 resources += tile.resource;
                 elevation += tile.height;
             }

--- a/examples/caldera/audit_script_skew.rue
+++ b/examples/caldera/audit_script_skew.rue
@@ -63,7 +63,7 @@ fn observe_entities(inout out: metric.Metric, borrow world: model.World) {
         metric.observe(inout out, entity_projection(borrow world, i), (i % 11) + 1);
         metric.warn(inout out, item.alive && (item.x < 0 || item.y < 0 ||
             @intCast(item.x) >= world.width || @intCast(item.y) >= world.height));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -73,7 +73,7 @@ fn observe_tiles(inout out: metric.Metric, borrow world: model.World) {
         let item = world.tiles.get_or(i, model.empty_tile());
         metric.observe(inout out, tile_projection(borrow world, i), (i % 13) + 1);
         metric.warn(inout out, item.x >= world.width || item.y >= world.height);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -82,18 +82,18 @@ fn observe_timeline(inout out: metric.Metric, borrow world: model.World) {
     while i < world.events.len() {
         metric.observe(inout out, event_projection(borrow world, i), (i % 5) + 1);
         metric.warn(inout out, world.events.get_or(i, model.empty_event()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
         metric.observe(inout out, command_projection(borrow world, i), (i % 7) + 1);
         metric.warn(inout out, world.commands.get_or(i, model.empty_command()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.snapshots.len() {
         metric.observe(inout out, snapshot_projection(borrow world, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -108,9 +108,9 @@ fn observe_pairs(inout out: metric.Metric, borrow world: model.World) {
             let dy = if left.y > right.y { left.y - right.y } else { right.y - left.y };
             metric.observe(inout out, @intCast(dx + dy) +
                 left.faction * 3 + right.faction * 5 + MODE(), i + j + 1);
-            j = j + 1;
+            j += 1;
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -125,17 +125,17 @@ fn observe_factions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.entities.len() {
             let entity = world.entities.get_or(i, model.empty_entity());
             if entity.faction == faction && entity.alive {
-                agents = agents + 1;
-                health = health + entity.health;
-                energy = energy + entity.energy;
-                inventory = inventory + entity.inventory;
+                agents += 1;
+                health += entity.health;
+                energy += entity.energy;
+                inventory += entity.inventory;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = agents * (MODE() % 11 + 1) + health * 3 +
             energy * 5 + inventory * 7 + faction;
         metric.observe(inout out, projection, faction + MODE() % 5 + 1);
-        faction = faction + 1;
+        faction += 1;
     }
 }
 
@@ -150,17 +150,17 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
-                tiles = tiles + 1;
+                tiles += 1;
                 if tile.walkable { walkable = walkable + 1; }
-                resources = resources + tile.resource;
-                elevation = elevation + tile.height;
+                resources += tile.resource;
+                elevation += tile.height;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = tiles * (MODE() % 13 + 1) + walkable * 3 +
             resources * 5 + elevation * 7 + region;
         metric.observe(inout out, projection, region % 7 + 1);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/audit_script_stability.rue
+++ b/examples/caldera/audit_script_stability.rue
@@ -151,7 +151,7 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
                 tiles += 1;
-                if tile.walkable { walkable = walkable + 1; }
+                if tile.walkable { walkable += 1; }
                 resources += tile.resource;
                 elevation += tile.height;
             }

--- a/examples/caldera/audit_script_stability.rue
+++ b/examples/caldera/audit_script_stability.rue
@@ -63,7 +63,7 @@ fn observe_entities(inout out: metric.Metric, borrow world: model.World) {
         metric.observe(inout out, entity_projection(borrow world, i), (i % 11) + 1);
         metric.warn(inout out, item.alive && (item.x < 0 || item.y < 0 ||
             @intCast(item.x) >= world.width || @intCast(item.y) >= world.height));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -73,7 +73,7 @@ fn observe_tiles(inout out: metric.Metric, borrow world: model.World) {
         let item = world.tiles.get_or(i, model.empty_tile());
         metric.observe(inout out, tile_projection(borrow world, i), (i % 13) + 1);
         metric.warn(inout out, item.x >= world.width || item.y >= world.height);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -82,18 +82,18 @@ fn observe_timeline(inout out: metric.Metric, borrow world: model.World) {
     while i < world.events.len() {
         metric.observe(inout out, event_projection(borrow world, i), (i % 5) + 1);
         metric.warn(inout out, world.events.get_or(i, model.empty_event()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
         metric.observe(inout out, command_projection(borrow world, i), (i % 7) + 1);
         metric.warn(inout out, world.commands.get_or(i, model.empty_command()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.snapshots.len() {
         metric.observe(inout out, snapshot_projection(borrow world, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -108,9 +108,9 @@ fn observe_pairs(inout out: metric.Metric, borrow world: model.World) {
             let dy = if left.y > right.y { left.y - right.y } else { right.y - left.y };
             metric.observe(inout out, @intCast(dx + dy) +
                 left.faction * 3 + right.faction * 5 + MODE(), i + j + 1);
-            j = j + 1;
+            j += 1;
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -125,17 +125,17 @@ fn observe_factions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.entities.len() {
             let entity = world.entities.get_or(i, model.empty_entity());
             if entity.faction == faction && entity.alive {
-                agents = agents + 1;
-                health = health + entity.health;
-                energy = energy + entity.energy;
-                inventory = inventory + entity.inventory;
+                agents += 1;
+                health += entity.health;
+                energy += entity.energy;
+                inventory += entity.inventory;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = agents * (MODE() % 11 + 1) + health * 3 +
             energy * 5 + inventory * 7 + faction;
         metric.observe(inout out, projection, faction + MODE() % 5 + 1);
-        faction = faction + 1;
+        faction += 1;
     }
 }
 
@@ -150,17 +150,17 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
-                tiles = tiles + 1;
+                tiles += 1;
                 if tile.walkable { walkable = walkable + 1; }
-                resources = resources + tile.resource;
-                elevation = elevation + tile.height;
+                resources += tile.resource;
+                elevation += tile.height;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = tiles * (MODE() % 13 + 1) + walkable * 3 +
             resources * 5 + elevation * 7 + region;
         metric.observe(inout out, projection, region % 7 + 1);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/audit_script_throughput.rue
+++ b/examples/caldera/audit_script_throughput.rue
@@ -151,7 +151,7 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
                 tiles += 1;
-                if tile.walkable { walkable = walkable + 1; }
+                if tile.walkable { walkable += 1; }
                 resources += tile.resource;
                 elevation += tile.height;
             }

--- a/examples/caldera/audit_script_throughput.rue
+++ b/examples/caldera/audit_script_throughput.rue
@@ -63,7 +63,7 @@ fn observe_entities(inout out: metric.Metric, borrow world: model.World) {
         metric.observe(inout out, entity_projection(borrow world, i), (i % 11) + 1);
         metric.warn(inout out, item.alive && (item.x < 0 || item.y < 0 ||
             @intCast(item.x) >= world.width || @intCast(item.y) >= world.height));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -73,7 +73,7 @@ fn observe_tiles(inout out: metric.Metric, borrow world: model.World) {
         let item = world.tiles.get_or(i, model.empty_tile());
         metric.observe(inout out, tile_projection(borrow world, i), (i % 13) + 1);
         metric.warn(inout out, item.x >= world.width || item.y >= world.height);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -82,18 +82,18 @@ fn observe_timeline(inout out: metric.Metric, borrow world: model.World) {
     while i < world.events.len() {
         metric.observe(inout out, event_projection(borrow world, i), (i % 5) + 1);
         metric.warn(inout out, world.events.get_or(i, model.empty_event()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
         metric.observe(inout out, command_projection(borrow world, i), (i % 7) + 1);
         metric.warn(inout out, world.commands.get_or(i, model.empty_command()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.snapshots.len() {
         metric.observe(inout out, snapshot_projection(borrow world, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -108,9 +108,9 @@ fn observe_pairs(inout out: metric.Metric, borrow world: model.World) {
             let dy = if left.y > right.y { left.y - right.y } else { right.y - left.y };
             metric.observe(inout out, @intCast(dx + dy) +
                 left.faction * 3 + right.faction * 5 + MODE(), i + j + 1);
-            j = j + 1;
+            j += 1;
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -125,17 +125,17 @@ fn observe_factions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.entities.len() {
             let entity = world.entities.get_or(i, model.empty_entity());
             if entity.faction == faction && entity.alive {
-                agents = agents + 1;
-                health = health + entity.health;
-                energy = energy + entity.energy;
-                inventory = inventory + entity.inventory;
+                agents += 1;
+                health += entity.health;
+                energy += entity.energy;
+                inventory += entity.inventory;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = agents * (MODE() % 11 + 1) + health * 3 +
             energy * 5 + inventory * 7 + faction;
         metric.observe(inout out, projection, faction + MODE() % 5 + 1);
-        faction = faction + 1;
+        faction += 1;
     }
 }
 
@@ -150,17 +150,17 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
-                tiles = tiles + 1;
+                tiles += 1;
                 if tile.walkable { walkable = walkable + 1; }
-                resources = resources + tile.resource;
-                elevation = elevation + tile.height;
+                resources += tile.resource;
+                elevation += tile.height;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = tiles * (MODE() % 13 + 1) + walkable * 3 +
             resources * 5 + elevation * 7 + region;
         metric.observe(inout out, projection, region % 7 + 1);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/audit_spatial_balance.rue
+++ b/examples/caldera/audit_spatial_balance.rue
@@ -151,7 +151,7 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
                 tiles += 1;
-                if tile.walkable { walkable = walkable + 1; }
+                if tile.walkable { walkable += 1; }
                 resources += tile.resource;
                 elevation += tile.height;
             }

--- a/examples/caldera/audit_spatial_balance.rue
+++ b/examples/caldera/audit_spatial_balance.rue
@@ -63,7 +63,7 @@ fn observe_entities(inout out: metric.Metric, borrow world: model.World) {
         metric.observe(inout out, entity_projection(borrow world, i), (i % 11) + 1);
         metric.warn(inout out, item.alive && (item.x < 0 || item.y < 0 ||
             @intCast(item.x) >= world.width || @intCast(item.y) >= world.height));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -73,7 +73,7 @@ fn observe_tiles(inout out: metric.Metric, borrow world: model.World) {
         let item = world.tiles.get_or(i, model.empty_tile());
         metric.observe(inout out, tile_projection(borrow world, i), (i % 13) + 1);
         metric.warn(inout out, item.x >= world.width || item.y >= world.height);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -82,18 +82,18 @@ fn observe_timeline(inout out: metric.Metric, borrow world: model.World) {
     while i < world.events.len() {
         metric.observe(inout out, event_projection(borrow world, i), (i % 5) + 1);
         metric.warn(inout out, world.events.get_or(i, model.empty_event()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
         metric.observe(inout out, command_projection(borrow world, i), (i % 7) + 1);
         metric.warn(inout out, world.commands.get_or(i, model.empty_command()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.snapshots.len() {
         metric.observe(inout out, snapshot_projection(borrow world, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -108,9 +108,9 @@ fn observe_pairs(inout out: metric.Metric, borrow world: model.World) {
             let dy = if left.y > right.y { left.y - right.y } else { right.y - left.y };
             metric.observe(inout out, @intCast(dx + dy) +
                 left.faction * 3 + right.faction * 5 + MODE(), i + j + 1);
-            j = j + 1;
+            j += 1;
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -125,17 +125,17 @@ fn observe_factions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.entities.len() {
             let entity = world.entities.get_or(i, model.empty_entity());
             if entity.faction == faction && entity.alive {
-                agents = agents + 1;
-                health = health + entity.health;
-                energy = energy + entity.energy;
-                inventory = inventory + entity.inventory;
+                agents += 1;
+                health += entity.health;
+                energy += entity.energy;
+                inventory += entity.inventory;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = agents * (MODE() % 11 + 1) + health * 3 +
             energy * 5 + inventory * 7 + faction;
         metric.observe(inout out, projection, faction + MODE() % 5 + 1);
-        faction = faction + 1;
+        faction += 1;
     }
 }
 
@@ -150,17 +150,17 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
-                tiles = tiles + 1;
+                tiles += 1;
                 if tile.walkable { walkable = walkable + 1; }
-                resources = resources + tile.resource;
-                elevation = elevation + tile.height;
+                resources += tile.resource;
+                elevation += tile.height;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = tiles * (MODE() % 13 + 1) + walkable * 3 +
             resources * 5 + elevation * 7 + region;
         metric.observe(inout out, projection, region % 7 + 1);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/audit_spatial_capacity.rue
+++ b/examples/caldera/audit_spatial_capacity.rue
@@ -151,7 +151,7 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
                 tiles += 1;
-                if tile.walkable { walkable = walkable + 1; }
+                if tile.walkable { walkable += 1; }
                 resources += tile.resource;
                 elevation += tile.height;
             }

--- a/examples/caldera/audit_spatial_capacity.rue
+++ b/examples/caldera/audit_spatial_capacity.rue
@@ -63,7 +63,7 @@ fn observe_entities(inout out: metric.Metric, borrow world: model.World) {
         metric.observe(inout out, entity_projection(borrow world, i), (i % 11) + 1);
         metric.warn(inout out, item.alive && (item.x < 0 || item.y < 0 ||
             @intCast(item.x) >= world.width || @intCast(item.y) >= world.height));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -73,7 +73,7 @@ fn observe_tiles(inout out: metric.Metric, borrow world: model.World) {
         let item = world.tiles.get_or(i, model.empty_tile());
         metric.observe(inout out, tile_projection(borrow world, i), (i % 13) + 1);
         metric.warn(inout out, item.x >= world.width || item.y >= world.height);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -82,18 +82,18 @@ fn observe_timeline(inout out: metric.Metric, borrow world: model.World) {
     while i < world.events.len() {
         metric.observe(inout out, event_projection(borrow world, i), (i % 5) + 1);
         metric.warn(inout out, world.events.get_or(i, model.empty_event()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
         metric.observe(inout out, command_projection(borrow world, i), (i % 7) + 1);
         metric.warn(inout out, world.commands.get_or(i, model.empty_command()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.snapshots.len() {
         metric.observe(inout out, snapshot_projection(borrow world, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -108,9 +108,9 @@ fn observe_pairs(inout out: metric.Metric, borrow world: model.World) {
             let dy = if left.y > right.y { left.y - right.y } else { right.y - left.y };
             metric.observe(inout out, @intCast(dx + dy) +
                 left.faction * 3 + right.faction * 5 + MODE(), i + j + 1);
-            j = j + 1;
+            j += 1;
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -125,17 +125,17 @@ fn observe_factions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.entities.len() {
             let entity = world.entities.get_or(i, model.empty_entity());
             if entity.faction == faction && entity.alive {
-                agents = agents + 1;
-                health = health + entity.health;
-                energy = energy + entity.energy;
-                inventory = inventory + entity.inventory;
+                agents += 1;
+                health += entity.health;
+                energy += entity.energy;
+                inventory += entity.inventory;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = agents * (MODE() % 11 + 1) + health * 3 +
             energy * 5 + inventory * 7 + faction;
         metric.observe(inout out, projection, faction + MODE() % 5 + 1);
-        faction = faction + 1;
+        faction += 1;
     }
 }
 
@@ -150,17 +150,17 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
-                tiles = tiles + 1;
+                tiles += 1;
                 if tile.walkable { walkable = walkable + 1; }
-                resources = resources + tile.resource;
-                elevation = elevation + tile.height;
+                resources += tile.resource;
+                elevation += tile.height;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = tiles * (MODE() % 13 + 1) + walkable * 3 +
             resources * 5 + elevation * 7 + region;
         metric.observe(inout out, projection, region % 7 + 1);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/audit_spatial_continuity.rue
+++ b/examples/caldera/audit_spatial_continuity.rue
@@ -151,7 +151,7 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
                 tiles += 1;
-                if tile.walkable { walkable = walkable + 1; }
+                if tile.walkable { walkable += 1; }
                 resources += tile.resource;
                 elevation += tile.height;
             }

--- a/examples/caldera/audit_spatial_continuity.rue
+++ b/examples/caldera/audit_spatial_continuity.rue
@@ -63,7 +63,7 @@ fn observe_entities(inout out: metric.Metric, borrow world: model.World) {
         metric.observe(inout out, entity_projection(borrow world, i), (i % 11) + 1);
         metric.warn(inout out, item.alive && (item.x < 0 || item.y < 0 ||
             @intCast(item.x) >= world.width || @intCast(item.y) >= world.height));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -73,7 +73,7 @@ fn observe_tiles(inout out: metric.Metric, borrow world: model.World) {
         let item = world.tiles.get_or(i, model.empty_tile());
         metric.observe(inout out, tile_projection(borrow world, i), (i % 13) + 1);
         metric.warn(inout out, item.x >= world.width || item.y >= world.height);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -82,18 +82,18 @@ fn observe_timeline(inout out: metric.Metric, borrow world: model.World) {
     while i < world.events.len() {
         metric.observe(inout out, event_projection(borrow world, i), (i % 5) + 1);
         metric.warn(inout out, world.events.get_or(i, model.empty_event()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
         metric.observe(inout out, command_projection(borrow world, i), (i % 7) + 1);
         metric.warn(inout out, world.commands.get_or(i, model.empty_command()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.snapshots.len() {
         metric.observe(inout out, snapshot_projection(borrow world, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -108,9 +108,9 @@ fn observe_pairs(inout out: metric.Metric, borrow world: model.World) {
             let dy = if left.y > right.y { left.y - right.y } else { right.y - left.y };
             metric.observe(inout out, @intCast(dx + dy) +
                 left.faction * 3 + right.faction * 5 + MODE(), i + j + 1);
-            j = j + 1;
+            j += 1;
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -125,17 +125,17 @@ fn observe_factions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.entities.len() {
             let entity = world.entities.get_or(i, model.empty_entity());
             if entity.faction == faction && entity.alive {
-                agents = agents + 1;
-                health = health + entity.health;
-                energy = energy + entity.energy;
-                inventory = inventory + entity.inventory;
+                agents += 1;
+                health += entity.health;
+                energy += entity.energy;
+                inventory += entity.inventory;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = agents * (MODE() % 11 + 1) + health * 3 +
             energy * 5 + inventory * 7 + faction;
         metric.observe(inout out, projection, faction + MODE() % 5 + 1);
-        faction = faction + 1;
+        faction += 1;
     }
 }
 
@@ -150,17 +150,17 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
-                tiles = tiles + 1;
+                tiles += 1;
                 if tile.walkable { walkable = walkable + 1; }
-                resources = resources + tile.resource;
-                elevation = elevation + tile.height;
+                resources += tile.resource;
+                elevation += tile.height;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = tiles * (MODE() % 13 + 1) + walkable * 3 +
             resources * 5 + elevation * 7 + region;
         metric.observe(inout out, projection, region % 7 + 1);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/audit_spatial_cost.rue
+++ b/examples/caldera/audit_spatial_cost.rue
@@ -151,7 +151,7 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
                 tiles += 1;
-                if tile.walkable { walkable = walkable + 1; }
+                if tile.walkable { walkable += 1; }
                 resources += tile.resource;
                 elevation += tile.height;
             }

--- a/examples/caldera/audit_spatial_cost.rue
+++ b/examples/caldera/audit_spatial_cost.rue
@@ -63,7 +63,7 @@ fn observe_entities(inout out: metric.Metric, borrow world: model.World) {
         metric.observe(inout out, entity_projection(borrow world, i), (i % 11) + 1);
         metric.warn(inout out, item.alive && (item.x < 0 || item.y < 0 ||
             @intCast(item.x) >= world.width || @intCast(item.y) >= world.height));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -73,7 +73,7 @@ fn observe_tiles(inout out: metric.Metric, borrow world: model.World) {
         let item = world.tiles.get_or(i, model.empty_tile());
         metric.observe(inout out, tile_projection(borrow world, i), (i % 13) + 1);
         metric.warn(inout out, item.x >= world.width || item.y >= world.height);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -82,18 +82,18 @@ fn observe_timeline(inout out: metric.Metric, borrow world: model.World) {
     while i < world.events.len() {
         metric.observe(inout out, event_projection(borrow world, i), (i % 5) + 1);
         metric.warn(inout out, world.events.get_or(i, model.empty_event()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
         metric.observe(inout out, command_projection(borrow world, i), (i % 7) + 1);
         metric.warn(inout out, world.commands.get_or(i, model.empty_command()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.snapshots.len() {
         metric.observe(inout out, snapshot_projection(borrow world, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -108,9 +108,9 @@ fn observe_pairs(inout out: metric.Metric, borrow world: model.World) {
             let dy = if left.y > right.y { left.y - right.y } else { right.y - left.y };
             metric.observe(inout out, @intCast(dx + dy) +
                 left.faction * 3 + right.faction * 5 + MODE(), i + j + 1);
-            j = j + 1;
+            j += 1;
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -125,17 +125,17 @@ fn observe_factions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.entities.len() {
             let entity = world.entities.get_or(i, model.empty_entity());
             if entity.faction == faction && entity.alive {
-                agents = agents + 1;
-                health = health + entity.health;
-                energy = energy + entity.energy;
-                inventory = inventory + entity.inventory;
+                agents += 1;
+                health += entity.health;
+                energy += entity.energy;
+                inventory += entity.inventory;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = agents * (MODE() % 11 + 1) + health * 3 +
             energy * 5 + inventory * 7 + faction;
         metric.observe(inout out, projection, faction + MODE() % 5 + 1);
-        faction = faction + 1;
+        faction += 1;
     }
 }
 
@@ -150,17 +150,17 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
-                tiles = tiles + 1;
+                tiles += 1;
                 if tile.walkable { walkable = walkable + 1; }
-                resources = resources + tile.resource;
-                elevation = elevation + tile.height;
+                resources += tile.resource;
+                elevation += tile.height;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = tiles * (MODE() % 13 + 1) + walkable * 3 +
             resources * 5 + elevation * 7 + region;
         metric.observe(inout out, projection, region % 7 + 1);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/audit_spatial_coverage.rue
+++ b/examples/caldera/audit_spatial_coverage.rue
@@ -151,7 +151,7 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
                 tiles += 1;
-                if tile.walkable { walkable = walkable + 1; }
+                if tile.walkable { walkable += 1; }
                 resources += tile.resource;
                 elevation += tile.height;
             }

--- a/examples/caldera/audit_spatial_coverage.rue
+++ b/examples/caldera/audit_spatial_coverage.rue
@@ -63,7 +63,7 @@ fn observe_entities(inout out: metric.Metric, borrow world: model.World) {
         metric.observe(inout out, entity_projection(borrow world, i), (i % 11) + 1);
         metric.warn(inout out, item.alive && (item.x < 0 || item.y < 0 ||
             @intCast(item.x) >= world.width || @intCast(item.y) >= world.height));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -73,7 +73,7 @@ fn observe_tiles(inout out: metric.Metric, borrow world: model.World) {
         let item = world.tiles.get_or(i, model.empty_tile());
         metric.observe(inout out, tile_projection(borrow world, i), (i % 13) + 1);
         metric.warn(inout out, item.x >= world.width || item.y >= world.height);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -82,18 +82,18 @@ fn observe_timeline(inout out: metric.Metric, borrow world: model.World) {
     while i < world.events.len() {
         metric.observe(inout out, event_projection(borrow world, i), (i % 5) + 1);
         metric.warn(inout out, world.events.get_or(i, model.empty_event()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
         metric.observe(inout out, command_projection(borrow world, i), (i % 7) + 1);
         metric.warn(inout out, world.commands.get_or(i, model.empty_command()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.snapshots.len() {
         metric.observe(inout out, snapshot_projection(borrow world, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -108,9 +108,9 @@ fn observe_pairs(inout out: metric.Metric, borrow world: model.World) {
             let dy = if left.y > right.y { left.y - right.y } else { right.y - left.y };
             metric.observe(inout out, @intCast(dx + dy) +
                 left.faction * 3 + right.faction * 5 + MODE(), i + j + 1);
-            j = j + 1;
+            j += 1;
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -125,17 +125,17 @@ fn observe_factions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.entities.len() {
             let entity = world.entities.get_or(i, model.empty_entity());
             if entity.faction == faction && entity.alive {
-                agents = agents + 1;
-                health = health + entity.health;
-                energy = energy + entity.energy;
-                inventory = inventory + entity.inventory;
+                agents += 1;
+                health += entity.health;
+                energy += entity.energy;
+                inventory += entity.inventory;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = agents * (MODE() % 11 + 1) + health * 3 +
             energy * 5 + inventory * 7 + faction;
         metric.observe(inout out, projection, faction + MODE() % 5 + 1);
-        faction = faction + 1;
+        faction += 1;
     }
 }
 
@@ -150,17 +150,17 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
-                tiles = tiles + 1;
+                tiles += 1;
                 if tile.walkable { walkable = walkable + 1; }
-                resources = resources + tile.resource;
-                elevation = elevation + tile.height;
+                resources += tile.resource;
+                elevation += tile.height;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = tiles * (MODE() % 13 + 1) + walkable * 3 +
             resources * 5 + elevation * 7 + region;
         metric.observe(inout out, projection, region % 7 + 1);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/audit_spatial_density.rue
+++ b/examples/caldera/audit_spatial_density.rue
@@ -151,7 +151,7 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
                 tiles += 1;
-                if tile.walkable { walkable = walkable + 1; }
+                if tile.walkable { walkable += 1; }
                 resources += tile.resource;
                 elevation += tile.height;
             }

--- a/examples/caldera/audit_spatial_density.rue
+++ b/examples/caldera/audit_spatial_density.rue
@@ -63,7 +63,7 @@ fn observe_entities(inout out: metric.Metric, borrow world: model.World) {
         metric.observe(inout out, entity_projection(borrow world, i), (i % 11) + 1);
         metric.warn(inout out, item.alive && (item.x < 0 || item.y < 0 ||
             @intCast(item.x) >= world.width || @intCast(item.y) >= world.height));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -73,7 +73,7 @@ fn observe_tiles(inout out: metric.Metric, borrow world: model.World) {
         let item = world.tiles.get_or(i, model.empty_tile());
         metric.observe(inout out, tile_projection(borrow world, i), (i % 13) + 1);
         metric.warn(inout out, item.x >= world.width || item.y >= world.height);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -82,18 +82,18 @@ fn observe_timeline(inout out: metric.Metric, borrow world: model.World) {
     while i < world.events.len() {
         metric.observe(inout out, event_projection(borrow world, i), (i % 5) + 1);
         metric.warn(inout out, world.events.get_or(i, model.empty_event()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
         metric.observe(inout out, command_projection(borrow world, i), (i % 7) + 1);
         metric.warn(inout out, world.commands.get_or(i, model.empty_command()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.snapshots.len() {
         metric.observe(inout out, snapshot_projection(borrow world, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -108,9 +108,9 @@ fn observe_pairs(inout out: metric.Metric, borrow world: model.World) {
             let dy = if left.y > right.y { left.y - right.y } else { right.y - left.y };
             metric.observe(inout out, @intCast(dx + dy) +
                 left.faction * 3 + right.faction * 5 + MODE(), i + j + 1);
-            j = j + 1;
+            j += 1;
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -125,17 +125,17 @@ fn observe_factions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.entities.len() {
             let entity = world.entities.get_or(i, model.empty_entity());
             if entity.faction == faction && entity.alive {
-                agents = agents + 1;
-                health = health + entity.health;
-                energy = energy + entity.energy;
-                inventory = inventory + entity.inventory;
+                agents += 1;
+                health += entity.health;
+                energy += entity.energy;
+                inventory += entity.inventory;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = agents * (MODE() % 11 + 1) + health * 3 +
             energy * 5 + inventory * 7 + faction;
         metric.observe(inout out, projection, faction + MODE() % 5 + 1);
-        faction = faction + 1;
+        faction += 1;
     }
 }
 
@@ -150,17 +150,17 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
-                tiles = tiles + 1;
+                tiles += 1;
                 if tile.walkable { walkable = walkable + 1; }
-                resources = resources + tile.resource;
-                elevation = elevation + tile.height;
+                resources += tile.resource;
+                elevation += tile.height;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = tiles * (MODE() % 13 + 1) + walkable * 3 +
             resources * 5 + elevation * 7 + region;
         metric.observe(inout out, projection, region % 7 + 1);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/audit_spatial_entropy.rue
+++ b/examples/caldera/audit_spatial_entropy.rue
@@ -151,7 +151,7 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
                 tiles += 1;
-                if tile.walkable { walkable = walkable + 1; }
+                if tile.walkable { walkable += 1; }
                 resources += tile.resource;
                 elevation += tile.height;
             }

--- a/examples/caldera/audit_spatial_entropy.rue
+++ b/examples/caldera/audit_spatial_entropy.rue
@@ -63,7 +63,7 @@ fn observe_entities(inout out: metric.Metric, borrow world: model.World) {
         metric.observe(inout out, entity_projection(borrow world, i), (i % 11) + 1);
         metric.warn(inout out, item.alive && (item.x < 0 || item.y < 0 ||
             @intCast(item.x) >= world.width || @intCast(item.y) >= world.height));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -73,7 +73,7 @@ fn observe_tiles(inout out: metric.Metric, borrow world: model.World) {
         let item = world.tiles.get_or(i, model.empty_tile());
         metric.observe(inout out, tile_projection(borrow world, i), (i % 13) + 1);
         metric.warn(inout out, item.x >= world.width || item.y >= world.height);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -82,18 +82,18 @@ fn observe_timeline(inout out: metric.Metric, borrow world: model.World) {
     while i < world.events.len() {
         metric.observe(inout out, event_projection(borrow world, i), (i % 5) + 1);
         metric.warn(inout out, world.events.get_or(i, model.empty_event()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
         metric.observe(inout out, command_projection(borrow world, i), (i % 7) + 1);
         metric.warn(inout out, world.commands.get_or(i, model.empty_command()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.snapshots.len() {
         metric.observe(inout out, snapshot_projection(borrow world, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -108,9 +108,9 @@ fn observe_pairs(inout out: metric.Metric, borrow world: model.World) {
             let dy = if left.y > right.y { left.y - right.y } else { right.y - left.y };
             metric.observe(inout out, @intCast(dx + dy) +
                 left.faction * 3 + right.faction * 5 + MODE(), i + j + 1);
-            j = j + 1;
+            j += 1;
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -125,17 +125,17 @@ fn observe_factions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.entities.len() {
             let entity = world.entities.get_or(i, model.empty_entity());
             if entity.faction == faction && entity.alive {
-                agents = agents + 1;
-                health = health + entity.health;
-                energy = energy + entity.energy;
-                inventory = inventory + entity.inventory;
+                agents += 1;
+                health += entity.health;
+                energy += entity.energy;
+                inventory += entity.inventory;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = agents * (MODE() % 11 + 1) + health * 3 +
             energy * 5 + inventory * 7 + faction;
         metric.observe(inout out, projection, faction + MODE() % 5 + 1);
-        faction = faction + 1;
+        faction += 1;
     }
 }
 
@@ -150,17 +150,17 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
-                tiles = tiles + 1;
+                tiles += 1;
                 if tile.walkable { walkable = walkable + 1; }
-                resources = resources + tile.resource;
-                elevation = elevation + tile.height;
+                resources += tile.resource;
+                elevation += tile.height;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = tiles * (MODE() % 13 + 1) + walkable * 3 +
             resources * 5 + elevation * 7 + region;
         metric.observe(inout out, projection, region % 7 + 1);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/audit_spatial_fanout.rue
+++ b/examples/caldera/audit_spatial_fanout.rue
@@ -151,7 +151,7 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
                 tiles += 1;
-                if tile.walkable { walkable = walkable + 1; }
+                if tile.walkable { walkable += 1; }
                 resources += tile.resource;
                 elevation += tile.height;
             }

--- a/examples/caldera/audit_spatial_fanout.rue
+++ b/examples/caldera/audit_spatial_fanout.rue
@@ -63,7 +63,7 @@ fn observe_entities(inout out: metric.Metric, borrow world: model.World) {
         metric.observe(inout out, entity_projection(borrow world, i), (i % 11) + 1);
         metric.warn(inout out, item.alive && (item.x < 0 || item.y < 0 ||
             @intCast(item.x) >= world.width || @intCast(item.y) >= world.height));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -73,7 +73,7 @@ fn observe_tiles(inout out: metric.Metric, borrow world: model.World) {
         let item = world.tiles.get_or(i, model.empty_tile());
         metric.observe(inout out, tile_projection(borrow world, i), (i % 13) + 1);
         metric.warn(inout out, item.x >= world.width || item.y >= world.height);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -82,18 +82,18 @@ fn observe_timeline(inout out: metric.Metric, borrow world: model.World) {
     while i < world.events.len() {
         metric.observe(inout out, event_projection(borrow world, i), (i % 5) + 1);
         metric.warn(inout out, world.events.get_or(i, model.empty_event()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
         metric.observe(inout out, command_projection(borrow world, i), (i % 7) + 1);
         metric.warn(inout out, world.commands.get_or(i, model.empty_command()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.snapshots.len() {
         metric.observe(inout out, snapshot_projection(borrow world, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -108,9 +108,9 @@ fn observe_pairs(inout out: metric.Metric, borrow world: model.World) {
             let dy = if left.y > right.y { left.y - right.y } else { right.y - left.y };
             metric.observe(inout out, @intCast(dx + dy) +
                 left.faction * 3 + right.faction * 5 + MODE(), i + j + 1);
-            j = j + 1;
+            j += 1;
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -125,17 +125,17 @@ fn observe_factions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.entities.len() {
             let entity = world.entities.get_or(i, model.empty_entity());
             if entity.faction == faction && entity.alive {
-                agents = agents + 1;
-                health = health + entity.health;
-                energy = energy + entity.energy;
-                inventory = inventory + entity.inventory;
+                agents += 1;
+                health += entity.health;
+                energy += entity.energy;
+                inventory += entity.inventory;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = agents * (MODE() % 11 + 1) + health * 3 +
             energy * 5 + inventory * 7 + faction;
         metric.observe(inout out, projection, faction + MODE() % 5 + 1);
-        faction = faction + 1;
+        faction += 1;
     }
 }
 
@@ -150,17 +150,17 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
-                tiles = tiles + 1;
+                tiles += 1;
                 if tile.walkable { walkable = walkable + 1; }
-                resources = resources + tile.resource;
-                elevation = elevation + tile.height;
+                resources += tile.resource;
+                elevation += tile.height;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = tiles * (MODE() % 13 + 1) + walkable * 3 +
             resources * 5 + elevation * 7 + region;
         metric.observe(inout out, projection, region % 7 + 1);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/audit_spatial_integrity.rue
+++ b/examples/caldera/audit_spatial_integrity.rue
@@ -151,7 +151,7 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
                 tiles += 1;
-                if tile.walkable { walkable = walkable + 1; }
+                if tile.walkable { walkable += 1; }
                 resources += tile.resource;
                 elevation += tile.height;
             }

--- a/examples/caldera/audit_spatial_integrity.rue
+++ b/examples/caldera/audit_spatial_integrity.rue
@@ -63,7 +63,7 @@ fn observe_entities(inout out: metric.Metric, borrow world: model.World) {
         metric.observe(inout out, entity_projection(borrow world, i), (i % 11) + 1);
         metric.warn(inout out, item.alive && (item.x < 0 || item.y < 0 ||
             @intCast(item.x) >= world.width || @intCast(item.y) >= world.height));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -73,7 +73,7 @@ fn observe_tiles(inout out: metric.Metric, borrow world: model.World) {
         let item = world.tiles.get_or(i, model.empty_tile());
         metric.observe(inout out, tile_projection(borrow world, i), (i % 13) + 1);
         metric.warn(inout out, item.x >= world.width || item.y >= world.height);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -82,18 +82,18 @@ fn observe_timeline(inout out: metric.Metric, borrow world: model.World) {
     while i < world.events.len() {
         metric.observe(inout out, event_projection(borrow world, i), (i % 5) + 1);
         metric.warn(inout out, world.events.get_or(i, model.empty_event()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
         metric.observe(inout out, command_projection(borrow world, i), (i % 7) + 1);
         metric.warn(inout out, world.commands.get_or(i, model.empty_command()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.snapshots.len() {
         metric.observe(inout out, snapshot_projection(borrow world, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -108,9 +108,9 @@ fn observe_pairs(inout out: metric.Metric, borrow world: model.World) {
             let dy = if left.y > right.y { left.y - right.y } else { right.y - left.y };
             metric.observe(inout out, @intCast(dx + dy) +
                 left.faction * 3 + right.faction * 5 + MODE(), i + j + 1);
-            j = j + 1;
+            j += 1;
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -125,17 +125,17 @@ fn observe_factions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.entities.len() {
             let entity = world.entities.get_or(i, model.empty_entity());
             if entity.faction == faction && entity.alive {
-                agents = agents + 1;
-                health = health + entity.health;
-                energy = energy + entity.energy;
-                inventory = inventory + entity.inventory;
+                agents += 1;
+                health += entity.health;
+                energy += entity.energy;
+                inventory += entity.inventory;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = agents * (MODE() % 11 + 1) + health * 3 +
             energy * 5 + inventory * 7 + faction;
         metric.observe(inout out, projection, faction + MODE() % 5 + 1);
-        faction = faction + 1;
+        faction += 1;
     }
 }
 
@@ -150,17 +150,17 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
-                tiles = tiles + 1;
+                tiles += 1;
                 if tile.walkable { walkable = walkable + 1; }
-                resources = resources + tile.resource;
-                elevation = elevation + tile.height;
+                resources += tile.resource;
+                elevation += tile.height;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = tiles * (MODE() % 13 + 1) + walkable * 3 +
             resources * 5 + elevation * 7 + region;
         metric.observe(inout out, projection, region % 7 + 1);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/audit_spatial_latency.rue
+++ b/examples/caldera/audit_spatial_latency.rue
@@ -151,7 +151,7 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
                 tiles += 1;
-                if tile.walkable { walkable = walkable + 1; }
+                if tile.walkable { walkable += 1; }
                 resources += tile.resource;
                 elevation += tile.height;
             }

--- a/examples/caldera/audit_spatial_latency.rue
+++ b/examples/caldera/audit_spatial_latency.rue
@@ -63,7 +63,7 @@ fn observe_entities(inout out: metric.Metric, borrow world: model.World) {
         metric.observe(inout out, entity_projection(borrow world, i), (i % 11) + 1);
         metric.warn(inout out, item.alive && (item.x < 0 || item.y < 0 ||
             @intCast(item.x) >= world.width || @intCast(item.y) >= world.height));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -73,7 +73,7 @@ fn observe_tiles(inout out: metric.Metric, borrow world: model.World) {
         let item = world.tiles.get_or(i, model.empty_tile());
         metric.observe(inout out, tile_projection(borrow world, i), (i % 13) + 1);
         metric.warn(inout out, item.x >= world.width || item.y >= world.height);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -82,18 +82,18 @@ fn observe_timeline(inout out: metric.Metric, borrow world: model.World) {
     while i < world.events.len() {
         metric.observe(inout out, event_projection(borrow world, i), (i % 5) + 1);
         metric.warn(inout out, world.events.get_or(i, model.empty_event()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
         metric.observe(inout out, command_projection(borrow world, i), (i % 7) + 1);
         metric.warn(inout out, world.commands.get_or(i, model.empty_command()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.snapshots.len() {
         metric.observe(inout out, snapshot_projection(borrow world, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -108,9 +108,9 @@ fn observe_pairs(inout out: metric.Metric, borrow world: model.World) {
             let dy = if left.y > right.y { left.y - right.y } else { right.y - left.y };
             metric.observe(inout out, @intCast(dx + dy) +
                 left.faction * 3 + right.faction * 5 + MODE(), i + j + 1);
-            j = j + 1;
+            j += 1;
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -125,17 +125,17 @@ fn observe_factions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.entities.len() {
             let entity = world.entities.get_or(i, model.empty_entity());
             if entity.faction == faction && entity.alive {
-                agents = agents + 1;
-                health = health + entity.health;
-                energy = energy + entity.energy;
-                inventory = inventory + entity.inventory;
+                agents += 1;
+                health += entity.health;
+                energy += entity.energy;
+                inventory += entity.inventory;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = agents * (MODE() % 11 + 1) + health * 3 +
             energy * 5 + inventory * 7 + faction;
         metric.observe(inout out, projection, faction + MODE() % 5 + 1);
-        faction = faction + 1;
+        faction += 1;
     }
 }
 
@@ -150,17 +150,17 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
-                tiles = tiles + 1;
+                tiles += 1;
                 if tile.walkable { walkable = walkable + 1; }
-                resources = resources + tile.resource;
-                elevation = elevation + tile.height;
+                resources += tile.resource;
+                elevation += tile.height;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = tiles * (MODE() % 13 + 1) + walkable * 3 +
             resources * 5 + elevation * 7 + region;
         metric.observe(inout out, projection, region % 7 + 1);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/audit_spatial_locality.rue
+++ b/examples/caldera/audit_spatial_locality.rue
@@ -151,7 +151,7 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
                 tiles += 1;
-                if tile.walkable { walkable = walkable + 1; }
+                if tile.walkable { walkable += 1; }
                 resources += tile.resource;
                 elevation += tile.height;
             }

--- a/examples/caldera/audit_spatial_locality.rue
+++ b/examples/caldera/audit_spatial_locality.rue
@@ -63,7 +63,7 @@ fn observe_entities(inout out: metric.Metric, borrow world: model.World) {
         metric.observe(inout out, entity_projection(borrow world, i), (i % 11) + 1);
         metric.warn(inout out, item.alive && (item.x < 0 || item.y < 0 ||
             @intCast(item.x) >= world.width || @intCast(item.y) >= world.height));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -73,7 +73,7 @@ fn observe_tiles(inout out: metric.Metric, borrow world: model.World) {
         let item = world.tiles.get_or(i, model.empty_tile());
         metric.observe(inout out, tile_projection(borrow world, i), (i % 13) + 1);
         metric.warn(inout out, item.x >= world.width || item.y >= world.height);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -82,18 +82,18 @@ fn observe_timeline(inout out: metric.Metric, borrow world: model.World) {
     while i < world.events.len() {
         metric.observe(inout out, event_projection(borrow world, i), (i % 5) + 1);
         metric.warn(inout out, world.events.get_or(i, model.empty_event()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
         metric.observe(inout out, command_projection(borrow world, i), (i % 7) + 1);
         metric.warn(inout out, world.commands.get_or(i, model.empty_command()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.snapshots.len() {
         metric.observe(inout out, snapshot_projection(borrow world, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -108,9 +108,9 @@ fn observe_pairs(inout out: metric.Metric, borrow world: model.World) {
             let dy = if left.y > right.y { left.y - right.y } else { right.y - left.y };
             metric.observe(inout out, @intCast(dx + dy) +
                 left.faction * 3 + right.faction * 5 + MODE(), i + j + 1);
-            j = j + 1;
+            j += 1;
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -125,17 +125,17 @@ fn observe_factions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.entities.len() {
             let entity = world.entities.get_or(i, model.empty_entity());
             if entity.faction == faction && entity.alive {
-                agents = agents + 1;
-                health = health + entity.health;
-                energy = energy + entity.energy;
-                inventory = inventory + entity.inventory;
+                agents += 1;
+                health += entity.health;
+                energy += entity.energy;
+                inventory += entity.inventory;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = agents * (MODE() % 11 + 1) + health * 3 +
             energy * 5 + inventory * 7 + faction;
         metric.observe(inout out, projection, faction + MODE() % 5 + 1);
-        faction = faction + 1;
+        faction += 1;
     }
 }
 
@@ -150,17 +150,17 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
-                tiles = tiles + 1;
+                tiles += 1;
                 if tile.walkable { walkable = walkable + 1; }
-                resources = resources + tile.resource;
-                elevation = elevation + tile.height;
+                resources += tile.resource;
+                elevation += tile.height;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = tiles * (MODE() % 13 + 1) + walkable * 3 +
             resources * 5 + elevation * 7 + region;
         metric.observe(inout out, projection, region % 7 + 1);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/audit_spatial_pressure.rue
+++ b/examples/caldera/audit_spatial_pressure.rue
@@ -151,7 +151,7 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
                 tiles += 1;
-                if tile.walkable { walkable = walkable + 1; }
+                if tile.walkable { walkable += 1; }
                 resources += tile.resource;
                 elevation += tile.height;
             }

--- a/examples/caldera/audit_spatial_pressure.rue
+++ b/examples/caldera/audit_spatial_pressure.rue
@@ -63,7 +63,7 @@ fn observe_entities(inout out: metric.Metric, borrow world: model.World) {
         metric.observe(inout out, entity_projection(borrow world, i), (i % 11) + 1);
         metric.warn(inout out, item.alive && (item.x < 0 || item.y < 0 ||
             @intCast(item.x) >= world.width || @intCast(item.y) >= world.height));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -73,7 +73,7 @@ fn observe_tiles(inout out: metric.Metric, borrow world: model.World) {
         let item = world.tiles.get_or(i, model.empty_tile());
         metric.observe(inout out, tile_projection(borrow world, i), (i % 13) + 1);
         metric.warn(inout out, item.x >= world.width || item.y >= world.height);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -82,18 +82,18 @@ fn observe_timeline(inout out: metric.Metric, borrow world: model.World) {
     while i < world.events.len() {
         metric.observe(inout out, event_projection(borrow world, i), (i % 5) + 1);
         metric.warn(inout out, world.events.get_or(i, model.empty_event()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
         metric.observe(inout out, command_projection(borrow world, i), (i % 7) + 1);
         metric.warn(inout out, world.commands.get_or(i, model.empty_command()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.snapshots.len() {
         metric.observe(inout out, snapshot_projection(borrow world, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -108,9 +108,9 @@ fn observe_pairs(inout out: metric.Metric, borrow world: model.World) {
             let dy = if left.y > right.y { left.y - right.y } else { right.y - left.y };
             metric.observe(inout out, @intCast(dx + dy) +
                 left.faction * 3 + right.faction * 5 + MODE(), i + j + 1);
-            j = j + 1;
+            j += 1;
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -125,17 +125,17 @@ fn observe_factions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.entities.len() {
             let entity = world.entities.get_or(i, model.empty_entity());
             if entity.faction == faction && entity.alive {
-                agents = agents + 1;
-                health = health + entity.health;
-                energy = energy + entity.energy;
-                inventory = inventory + entity.inventory;
+                agents += 1;
+                health += entity.health;
+                energy += entity.energy;
+                inventory += entity.inventory;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = agents * (MODE() % 11 + 1) + health * 3 +
             energy * 5 + inventory * 7 + faction;
         metric.observe(inout out, projection, faction + MODE() % 5 + 1);
-        faction = faction + 1;
+        faction += 1;
     }
 }
 
@@ -150,17 +150,17 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
-                tiles = tiles + 1;
+                tiles += 1;
                 if tile.walkable { walkable = walkable + 1; }
-                resources = resources + tile.resource;
-                elevation = elevation + tile.height;
+                resources += tile.resource;
+                elevation += tile.height;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = tiles * (MODE() % 13 + 1) + walkable * 3 +
             resources * 5 + elevation * 7 + region;
         metric.observe(inout out, projection, region % 7 + 1);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/audit_spatial_risk.rue
+++ b/examples/caldera/audit_spatial_risk.rue
@@ -151,7 +151,7 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
                 tiles += 1;
-                if tile.walkable { walkable = walkable + 1; }
+                if tile.walkable { walkable += 1; }
                 resources += tile.resource;
                 elevation += tile.height;
             }

--- a/examples/caldera/audit_spatial_risk.rue
+++ b/examples/caldera/audit_spatial_risk.rue
@@ -63,7 +63,7 @@ fn observe_entities(inout out: metric.Metric, borrow world: model.World) {
         metric.observe(inout out, entity_projection(borrow world, i), (i % 11) + 1);
         metric.warn(inout out, item.alive && (item.x < 0 || item.y < 0 ||
             @intCast(item.x) >= world.width || @intCast(item.y) >= world.height));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -73,7 +73,7 @@ fn observe_tiles(inout out: metric.Metric, borrow world: model.World) {
         let item = world.tiles.get_or(i, model.empty_tile());
         metric.observe(inout out, tile_projection(borrow world, i), (i % 13) + 1);
         metric.warn(inout out, item.x >= world.width || item.y >= world.height);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -82,18 +82,18 @@ fn observe_timeline(inout out: metric.Metric, borrow world: model.World) {
     while i < world.events.len() {
         metric.observe(inout out, event_projection(borrow world, i), (i % 5) + 1);
         metric.warn(inout out, world.events.get_or(i, model.empty_event()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
         metric.observe(inout out, command_projection(borrow world, i), (i % 7) + 1);
         metric.warn(inout out, world.commands.get_or(i, model.empty_command()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.snapshots.len() {
         metric.observe(inout out, snapshot_projection(borrow world, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -108,9 +108,9 @@ fn observe_pairs(inout out: metric.Metric, borrow world: model.World) {
             let dy = if left.y > right.y { left.y - right.y } else { right.y - left.y };
             metric.observe(inout out, @intCast(dx + dy) +
                 left.faction * 3 + right.faction * 5 + MODE(), i + j + 1);
-            j = j + 1;
+            j += 1;
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -125,17 +125,17 @@ fn observe_factions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.entities.len() {
             let entity = world.entities.get_or(i, model.empty_entity());
             if entity.faction == faction && entity.alive {
-                agents = agents + 1;
-                health = health + entity.health;
-                energy = energy + entity.energy;
-                inventory = inventory + entity.inventory;
+                agents += 1;
+                health += entity.health;
+                energy += entity.energy;
+                inventory += entity.inventory;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = agents * (MODE() % 11 + 1) + health * 3 +
             energy * 5 + inventory * 7 + faction;
         metric.observe(inout out, projection, faction + MODE() % 5 + 1);
-        faction = faction + 1;
+        faction += 1;
     }
 }
 
@@ -150,17 +150,17 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
-                tiles = tiles + 1;
+                tiles += 1;
                 if tile.walkable { walkable = walkable + 1; }
-                resources = resources + tile.resource;
-                elevation = elevation + tile.height;
+                resources += tile.resource;
+                elevation += tile.height;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = tiles * (MODE() % 13 + 1) + walkable * 3 +
             resources * 5 + elevation * 7 + region;
         metric.observe(inout out, projection, region % 7 + 1);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/audit_spatial_skew.rue
+++ b/examples/caldera/audit_spatial_skew.rue
@@ -151,7 +151,7 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
                 tiles += 1;
-                if tile.walkable { walkable = walkable + 1; }
+                if tile.walkable { walkable += 1; }
                 resources += tile.resource;
                 elevation += tile.height;
             }

--- a/examples/caldera/audit_spatial_skew.rue
+++ b/examples/caldera/audit_spatial_skew.rue
@@ -63,7 +63,7 @@ fn observe_entities(inout out: metric.Metric, borrow world: model.World) {
         metric.observe(inout out, entity_projection(borrow world, i), (i % 11) + 1);
         metric.warn(inout out, item.alive && (item.x < 0 || item.y < 0 ||
             @intCast(item.x) >= world.width || @intCast(item.y) >= world.height));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -73,7 +73,7 @@ fn observe_tiles(inout out: metric.Metric, borrow world: model.World) {
         let item = world.tiles.get_or(i, model.empty_tile());
         metric.observe(inout out, tile_projection(borrow world, i), (i % 13) + 1);
         metric.warn(inout out, item.x >= world.width || item.y >= world.height);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -82,18 +82,18 @@ fn observe_timeline(inout out: metric.Metric, borrow world: model.World) {
     while i < world.events.len() {
         metric.observe(inout out, event_projection(borrow world, i), (i % 5) + 1);
         metric.warn(inout out, world.events.get_or(i, model.empty_event()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
         metric.observe(inout out, command_projection(borrow world, i), (i % 7) + 1);
         metric.warn(inout out, world.commands.get_or(i, model.empty_command()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.snapshots.len() {
         metric.observe(inout out, snapshot_projection(borrow world, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -108,9 +108,9 @@ fn observe_pairs(inout out: metric.Metric, borrow world: model.World) {
             let dy = if left.y > right.y { left.y - right.y } else { right.y - left.y };
             metric.observe(inout out, @intCast(dx + dy) +
                 left.faction * 3 + right.faction * 5 + MODE(), i + j + 1);
-            j = j + 1;
+            j += 1;
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -125,17 +125,17 @@ fn observe_factions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.entities.len() {
             let entity = world.entities.get_or(i, model.empty_entity());
             if entity.faction == faction && entity.alive {
-                agents = agents + 1;
-                health = health + entity.health;
-                energy = energy + entity.energy;
-                inventory = inventory + entity.inventory;
+                agents += 1;
+                health += entity.health;
+                energy += entity.energy;
+                inventory += entity.inventory;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = agents * (MODE() % 11 + 1) + health * 3 +
             energy * 5 + inventory * 7 + faction;
         metric.observe(inout out, projection, faction + MODE() % 5 + 1);
-        faction = faction + 1;
+        faction += 1;
     }
 }
 
@@ -150,17 +150,17 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
-                tiles = tiles + 1;
+                tiles += 1;
                 if tile.walkable { walkable = walkable + 1; }
-                resources = resources + tile.resource;
-                elevation = elevation + tile.height;
+                resources += tile.resource;
+                elevation += tile.height;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = tiles * (MODE() % 13 + 1) + walkable * 3 +
             resources * 5 + elevation * 7 + region;
         metric.observe(inout out, projection, region % 7 + 1);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/audit_spatial_stability.rue
+++ b/examples/caldera/audit_spatial_stability.rue
@@ -151,7 +151,7 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
                 tiles += 1;
-                if tile.walkable { walkable = walkable + 1; }
+                if tile.walkable { walkable += 1; }
                 resources += tile.resource;
                 elevation += tile.height;
             }

--- a/examples/caldera/audit_spatial_stability.rue
+++ b/examples/caldera/audit_spatial_stability.rue
@@ -63,7 +63,7 @@ fn observe_entities(inout out: metric.Metric, borrow world: model.World) {
         metric.observe(inout out, entity_projection(borrow world, i), (i % 11) + 1);
         metric.warn(inout out, item.alive && (item.x < 0 || item.y < 0 ||
             @intCast(item.x) >= world.width || @intCast(item.y) >= world.height));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -73,7 +73,7 @@ fn observe_tiles(inout out: metric.Metric, borrow world: model.World) {
         let item = world.tiles.get_or(i, model.empty_tile());
         metric.observe(inout out, tile_projection(borrow world, i), (i % 13) + 1);
         metric.warn(inout out, item.x >= world.width || item.y >= world.height);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -82,18 +82,18 @@ fn observe_timeline(inout out: metric.Metric, borrow world: model.World) {
     while i < world.events.len() {
         metric.observe(inout out, event_projection(borrow world, i), (i % 5) + 1);
         metric.warn(inout out, world.events.get_or(i, model.empty_event()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
         metric.observe(inout out, command_projection(borrow world, i), (i % 7) + 1);
         metric.warn(inout out, world.commands.get_or(i, model.empty_command()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.snapshots.len() {
         metric.observe(inout out, snapshot_projection(borrow world, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -108,9 +108,9 @@ fn observe_pairs(inout out: metric.Metric, borrow world: model.World) {
             let dy = if left.y > right.y { left.y - right.y } else { right.y - left.y };
             metric.observe(inout out, @intCast(dx + dy) +
                 left.faction * 3 + right.faction * 5 + MODE(), i + j + 1);
-            j = j + 1;
+            j += 1;
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -125,17 +125,17 @@ fn observe_factions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.entities.len() {
             let entity = world.entities.get_or(i, model.empty_entity());
             if entity.faction == faction && entity.alive {
-                agents = agents + 1;
-                health = health + entity.health;
-                energy = energy + entity.energy;
-                inventory = inventory + entity.inventory;
+                agents += 1;
+                health += entity.health;
+                energy += entity.energy;
+                inventory += entity.inventory;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = agents * (MODE() % 11 + 1) + health * 3 +
             energy * 5 + inventory * 7 + faction;
         metric.observe(inout out, projection, faction + MODE() % 5 + 1);
-        faction = faction + 1;
+        faction += 1;
     }
 }
 
@@ -150,17 +150,17 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
-                tiles = tiles + 1;
+                tiles += 1;
                 if tile.walkable { walkable = walkable + 1; }
-                resources = resources + tile.resource;
-                elevation = elevation + tile.height;
+                resources += tile.resource;
+                elevation += tile.height;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = tiles * (MODE() % 13 + 1) + walkable * 3 +
             resources * 5 + elevation * 7 + region;
         metric.observe(inout out, projection, region % 7 + 1);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/audit_spatial_throughput.rue
+++ b/examples/caldera/audit_spatial_throughput.rue
@@ -151,7 +151,7 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
                 tiles += 1;
-                if tile.walkable { walkable = walkable + 1; }
+                if tile.walkable { walkable += 1; }
                 resources += tile.resource;
                 elevation += tile.height;
             }

--- a/examples/caldera/audit_spatial_throughput.rue
+++ b/examples/caldera/audit_spatial_throughput.rue
@@ -63,7 +63,7 @@ fn observe_entities(inout out: metric.Metric, borrow world: model.World) {
         metric.observe(inout out, entity_projection(borrow world, i), (i % 11) + 1);
         metric.warn(inout out, item.alive && (item.x < 0 || item.y < 0 ||
             @intCast(item.x) >= world.width || @intCast(item.y) >= world.height));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -73,7 +73,7 @@ fn observe_tiles(inout out: metric.Metric, borrow world: model.World) {
         let item = world.tiles.get_or(i, model.empty_tile());
         metric.observe(inout out, tile_projection(borrow world, i), (i % 13) + 1);
         metric.warn(inout out, item.x >= world.width || item.y >= world.height);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -82,18 +82,18 @@ fn observe_timeline(inout out: metric.Metric, borrow world: model.World) {
     while i < world.events.len() {
         metric.observe(inout out, event_projection(borrow world, i), (i % 5) + 1);
         metric.warn(inout out, world.events.get_or(i, model.empty_event()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
         metric.observe(inout out, command_projection(borrow world, i), (i % 7) + 1);
         metric.warn(inout out, world.commands.get_or(i, model.empty_command()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.snapshots.len() {
         metric.observe(inout out, snapshot_projection(borrow world, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -108,9 +108,9 @@ fn observe_pairs(inout out: metric.Metric, borrow world: model.World) {
             let dy = if left.y > right.y { left.y - right.y } else { right.y - left.y };
             metric.observe(inout out, @intCast(dx + dy) +
                 left.faction * 3 + right.faction * 5 + MODE(), i + j + 1);
-            j = j + 1;
+            j += 1;
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -125,17 +125,17 @@ fn observe_factions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.entities.len() {
             let entity = world.entities.get_or(i, model.empty_entity());
             if entity.faction == faction && entity.alive {
-                agents = agents + 1;
-                health = health + entity.health;
-                energy = energy + entity.energy;
-                inventory = inventory + entity.inventory;
+                agents += 1;
+                health += entity.health;
+                energy += entity.energy;
+                inventory += entity.inventory;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = agents * (MODE() % 11 + 1) + health * 3 +
             energy * 5 + inventory * 7 + faction;
         metric.observe(inout out, projection, faction + MODE() % 5 + 1);
-        faction = faction + 1;
+        faction += 1;
     }
 }
 
@@ -150,17 +150,17 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
-                tiles = tiles + 1;
+                tiles += 1;
                 if tile.walkable { walkable = walkable + 1; }
-                resources = resources + tile.resource;
-                elevation = elevation + tile.height;
+                resources += tile.resource;
+                elevation += tile.height;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = tiles * (MODE() % 13 + 1) + walkable * 3 +
             resources * 5 + elevation * 7 + region;
         metric.observe(inout out, projection, region % 7 + 1);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/audit_suite.rue
+++ b/examples/caldera/audit_suite.rue
@@ -263,9 +263,9 @@ pub struct Summary { passes: u64, observations: u64, warnings: u64,
 
 fn include(inout out: Summary, borrow first: metric.Metric, borrow second: metric.Metric, verified: bool) {
     out.passes = out.passes + 1; out.observations = out.observations + first.observations;
-    out.warnings = out.warnings + first.warnings;
+    out.warnings += first.warnings;
     if first.digest != second.digest || first.total != second.total || !verified {
-        out.deterministic_mismatches = out.deterministic_mismatches + 1;
+        out.deterministic_mismatches += 1;
     }
     out.digest = metric.mix(out.digest, first.digest);
 }

--- a/examples/caldera/audit_suite.rue
+++ b/examples/caldera/audit_suite.rue
@@ -262,7 +262,7 @@ pub struct Summary { passes: u64, observations: u64, warnings: u64,
     deterministic_mismatches: u64, digest: u64, valid: bool }
 
 fn include(inout out: Summary, borrow first: metric.Metric, borrow second: metric.Metric, verified: bool) {
-    out.passes = out.passes + 1; out.observations = out.observations + first.observations;
+    out.passes += 1; out.observations += first.observations;
     out.warnings += first.warnings;
     if first.digest != second.digest || first.total != second.total || !verified {
         out.deterministic_mismatches += 1;

--- a/examples/caldera/audit_terrain_balance.rue
+++ b/examples/caldera/audit_terrain_balance.rue
@@ -151,7 +151,7 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
                 tiles += 1;
-                if tile.walkable { walkable = walkable + 1; }
+                if tile.walkable { walkable += 1; }
                 resources += tile.resource;
                 elevation += tile.height;
             }

--- a/examples/caldera/audit_terrain_balance.rue
+++ b/examples/caldera/audit_terrain_balance.rue
@@ -63,7 +63,7 @@ fn observe_entities(inout out: metric.Metric, borrow world: model.World) {
         metric.observe(inout out, entity_projection(borrow world, i), (i % 11) + 1);
         metric.warn(inout out, item.alive && (item.x < 0 || item.y < 0 ||
             @intCast(item.x) >= world.width || @intCast(item.y) >= world.height));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -73,7 +73,7 @@ fn observe_tiles(inout out: metric.Metric, borrow world: model.World) {
         let item = world.tiles.get_or(i, model.empty_tile());
         metric.observe(inout out, tile_projection(borrow world, i), (i % 13) + 1);
         metric.warn(inout out, item.x >= world.width || item.y >= world.height);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -82,18 +82,18 @@ fn observe_timeline(inout out: metric.Metric, borrow world: model.World) {
     while i < world.events.len() {
         metric.observe(inout out, event_projection(borrow world, i), (i % 5) + 1);
         metric.warn(inout out, world.events.get_or(i, model.empty_event()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
         metric.observe(inout out, command_projection(borrow world, i), (i % 7) + 1);
         metric.warn(inout out, world.commands.get_or(i, model.empty_command()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.snapshots.len() {
         metric.observe(inout out, snapshot_projection(borrow world, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -108,9 +108,9 @@ fn observe_pairs(inout out: metric.Metric, borrow world: model.World) {
             let dy = if left.y > right.y { left.y - right.y } else { right.y - left.y };
             metric.observe(inout out, @intCast(dx + dy) +
                 left.faction * 3 + right.faction * 5 + MODE(), i + j + 1);
-            j = j + 1;
+            j += 1;
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -125,17 +125,17 @@ fn observe_factions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.entities.len() {
             let entity = world.entities.get_or(i, model.empty_entity());
             if entity.faction == faction && entity.alive {
-                agents = agents + 1;
-                health = health + entity.health;
-                energy = energy + entity.energy;
-                inventory = inventory + entity.inventory;
+                agents += 1;
+                health += entity.health;
+                energy += entity.energy;
+                inventory += entity.inventory;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = agents * (MODE() % 11 + 1) + health * 3 +
             energy * 5 + inventory * 7 + faction;
         metric.observe(inout out, projection, faction + MODE() % 5 + 1);
-        faction = faction + 1;
+        faction += 1;
     }
 }
 
@@ -150,17 +150,17 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
-                tiles = tiles + 1;
+                tiles += 1;
                 if tile.walkable { walkable = walkable + 1; }
-                resources = resources + tile.resource;
-                elevation = elevation + tile.height;
+                resources += tile.resource;
+                elevation += tile.height;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = tiles * (MODE() % 13 + 1) + walkable * 3 +
             resources * 5 + elevation * 7 + region;
         metric.observe(inout out, projection, region % 7 + 1);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/audit_terrain_capacity.rue
+++ b/examples/caldera/audit_terrain_capacity.rue
@@ -151,7 +151,7 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
                 tiles += 1;
-                if tile.walkable { walkable = walkable + 1; }
+                if tile.walkable { walkable += 1; }
                 resources += tile.resource;
                 elevation += tile.height;
             }

--- a/examples/caldera/audit_terrain_capacity.rue
+++ b/examples/caldera/audit_terrain_capacity.rue
@@ -63,7 +63,7 @@ fn observe_entities(inout out: metric.Metric, borrow world: model.World) {
         metric.observe(inout out, entity_projection(borrow world, i), (i % 11) + 1);
         metric.warn(inout out, item.alive && (item.x < 0 || item.y < 0 ||
             @intCast(item.x) >= world.width || @intCast(item.y) >= world.height));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -73,7 +73,7 @@ fn observe_tiles(inout out: metric.Metric, borrow world: model.World) {
         let item = world.tiles.get_or(i, model.empty_tile());
         metric.observe(inout out, tile_projection(borrow world, i), (i % 13) + 1);
         metric.warn(inout out, item.x >= world.width || item.y >= world.height);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -82,18 +82,18 @@ fn observe_timeline(inout out: metric.Metric, borrow world: model.World) {
     while i < world.events.len() {
         metric.observe(inout out, event_projection(borrow world, i), (i % 5) + 1);
         metric.warn(inout out, world.events.get_or(i, model.empty_event()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
         metric.observe(inout out, command_projection(borrow world, i), (i % 7) + 1);
         metric.warn(inout out, world.commands.get_or(i, model.empty_command()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.snapshots.len() {
         metric.observe(inout out, snapshot_projection(borrow world, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -108,9 +108,9 @@ fn observe_pairs(inout out: metric.Metric, borrow world: model.World) {
             let dy = if left.y > right.y { left.y - right.y } else { right.y - left.y };
             metric.observe(inout out, @intCast(dx + dy) +
                 left.faction * 3 + right.faction * 5 + MODE(), i + j + 1);
-            j = j + 1;
+            j += 1;
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -125,17 +125,17 @@ fn observe_factions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.entities.len() {
             let entity = world.entities.get_or(i, model.empty_entity());
             if entity.faction == faction && entity.alive {
-                agents = agents + 1;
-                health = health + entity.health;
-                energy = energy + entity.energy;
-                inventory = inventory + entity.inventory;
+                agents += 1;
+                health += entity.health;
+                energy += entity.energy;
+                inventory += entity.inventory;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = agents * (MODE() % 11 + 1) + health * 3 +
             energy * 5 + inventory * 7 + faction;
         metric.observe(inout out, projection, faction + MODE() % 5 + 1);
-        faction = faction + 1;
+        faction += 1;
     }
 }
 
@@ -150,17 +150,17 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
-                tiles = tiles + 1;
+                tiles += 1;
                 if tile.walkable { walkable = walkable + 1; }
-                resources = resources + tile.resource;
-                elevation = elevation + tile.height;
+                resources += tile.resource;
+                elevation += tile.height;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = tiles * (MODE() % 13 + 1) + walkable * 3 +
             resources * 5 + elevation * 7 + region;
         metric.observe(inout out, projection, region % 7 + 1);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/audit_terrain_continuity.rue
+++ b/examples/caldera/audit_terrain_continuity.rue
@@ -151,7 +151,7 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
                 tiles += 1;
-                if tile.walkable { walkable = walkable + 1; }
+                if tile.walkable { walkable += 1; }
                 resources += tile.resource;
                 elevation += tile.height;
             }

--- a/examples/caldera/audit_terrain_continuity.rue
+++ b/examples/caldera/audit_terrain_continuity.rue
@@ -63,7 +63,7 @@ fn observe_entities(inout out: metric.Metric, borrow world: model.World) {
         metric.observe(inout out, entity_projection(borrow world, i), (i % 11) + 1);
         metric.warn(inout out, item.alive && (item.x < 0 || item.y < 0 ||
             @intCast(item.x) >= world.width || @intCast(item.y) >= world.height));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -73,7 +73,7 @@ fn observe_tiles(inout out: metric.Metric, borrow world: model.World) {
         let item = world.tiles.get_or(i, model.empty_tile());
         metric.observe(inout out, tile_projection(borrow world, i), (i % 13) + 1);
         metric.warn(inout out, item.x >= world.width || item.y >= world.height);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -82,18 +82,18 @@ fn observe_timeline(inout out: metric.Metric, borrow world: model.World) {
     while i < world.events.len() {
         metric.observe(inout out, event_projection(borrow world, i), (i % 5) + 1);
         metric.warn(inout out, world.events.get_or(i, model.empty_event()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
         metric.observe(inout out, command_projection(borrow world, i), (i % 7) + 1);
         metric.warn(inout out, world.commands.get_or(i, model.empty_command()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.snapshots.len() {
         metric.observe(inout out, snapshot_projection(borrow world, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -108,9 +108,9 @@ fn observe_pairs(inout out: metric.Metric, borrow world: model.World) {
             let dy = if left.y > right.y { left.y - right.y } else { right.y - left.y };
             metric.observe(inout out, @intCast(dx + dy) +
                 left.faction * 3 + right.faction * 5 + MODE(), i + j + 1);
-            j = j + 1;
+            j += 1;
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -125,17 +125,17 @@ fn observe_factions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.entities.len() {
             let entity = world.entities.get_or(i, model.empty_entity());
             if entity.faction == faction && entity.alive {
-                agents = agents + 1;
-                health = health + entity.health;
-                energy = energy + entity.energy;
-                inventory = inventory + entity.inventory;
+                agents += 1;
+                health += entity.health;
+                energy += entity.energy;
+                inventory += entity.inventory;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = agents * (MODE() % 11 + 1) + health * 3 +
             energy * 5 + inventory * 7 + faction;
         metric.observe(inout out, projection, faction + MODE() % 5 + 1);
-        faction = faction + 1;
+        faction += 1;
     }
 }
 
@@ -150,17 +150,17 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
-                tiles = tiles + 1;
+                tiles += 1;
                 if tile.walkable { walkable = walkable + 1; }
-                resources = resources + tile.resource;
-                elevation = elevation + tile.height;
+                resources += tile.resource;
+                elevation += tile.height;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = tiles * (MODE() % 13 + 1) + walkable * 3 +
             resources * 5 + elevation * 7 + region;
         metric.observe(inout out, projection, region % 7 + 1);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/audit_terrain_cost.rue
+++ b/examples/caldera/audit_terrain_cost.rue
@@ -151,7 +151,7 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
                 tiles += 1;
-                if tile.walkable { walkable = walkable + 1; }
+                if tile.walkable { walkable += 1; }
                 resources += tile.resource;
                 elevation += tile.height;
             }

--- a/examples/caldera/audit_terrain_cost.rue
+++ b/examples/caldera/audit_terrain_cost.rue
@@ -63,7 +63,7 @@ fn observe_entities(inout out: metric.Metric, borrow world: model.World) {
         metric.observe(inout out, entity_projection(borrow world, i), (i % 11) + 1);
         metric.warn(inout out, item.alive && (item.x < 0 || item.y < 0 ||
             @intCast(item.x) >= world.width || @intCast(item.y) >= world.height));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -73,7 +73,7 @@ fn observe_tiles(inout out: metric.Metric, borrow world: model.World) {
         let item = world.tiles.get_or(i, model.empty_tile());
         metric.observe(inout out, tile_projection(borrow world, i), (i % 13) + 1);
         metric.warn(inout out, item.x >= world.width || item.y >= world.height);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -82,18 +82,18 @@ fn observe_timeline(inout out: metric.Metric, borrow world: model.World) {
     while i < world.events.len() {
         metric.observe(inout out, event_projection(borrow world, i), (i % 5) + 1);
         metric.warn(inout out, world.events.get_or(i, model.empty_event()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
         metric.observe(inout out, command_projection(borrow world, i), (i % 7) + 1);
         metric.warn(inout out, world.commands.get_or(i, model.empty_command()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.snapshots.len() {
         metric.observe(inout out, snapshot_projection(borrow world, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -108,9 +108,9 @@ fn observe_pairs(inout out: metric.Metric, borrow world: model.World) {
             let dy = if left.y > right.y { left.y - right.y } else { right.y - left.y };
             metric.observe(inout out, @intCast(dx + dy) +
                 left.faction * 3 + right.faction * 5 + MODE(), i + j + 1);
-            j = j + 1;
+            j += 1;
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -125,17 +125,17 @@ fn observe_factions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.entities.len() {
             let entity = world.entities.get_or(i, model.empty_entity());
             if entity.faction == faction && entity.alive {
-                agents = agents + 1;
-                health = health + entity.health;
-                energy = energy + entity.energy;
-                inventory = inventory + entity.inventory;
+                agents += 1;
+                health += entity.health;
+                energy += entity.energy;
+                inventory += entity.inventory;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = agents * (MODE() % 11 + 1) + health * 3 +
             energy * 5 + inventory * 7 + faction;
         metric.observe(inout out, projection, faction + MODE() % 5 + 1);
-        faction = faction + 1;
+        faction += 1;
     }
 }
 
@@ -150,17 +150,17 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
-                tiles = tiles + 1;
+                tiles += 1;
                 if tile.walkable { walkable = walkable + 1; }
-                resources = resources + tile.resource;
-                elevation = elevation + tile.height;
+                resources += tile.resource;
+                elevation += tile.height;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = tiles * (MODE() % 13 + 1) + walkable * 3 +
             resources * 5 + elevation * 7 + region;
         metric.observe(inout out, projection, region % 7 + 1);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/audit_terrain_coverage.rue
+++ b/examples/caldera/audit_terrain_coverage.rue
@@ -151,7 +151,7 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
                 tiles += 1;
-                if tile.walkable { walkable = walkable + 1; }
+                if tile.walkable { walkable += 1; }
                 resources += tile.resource;
                 elevation += tile.height;
             }

--- a/examples/caldera/audit_terrain_coverage.rue
+++ b/examples/caldera/audit_terrain_coverage.rue
@@ -63,7 +63,7 @@ fn observe_entities(inout out: metric.Metric, borrow world: model.World) {
         metric.observe(inout out, entity_projection(borrow world, i), (i % 11) + 1);
         metric.warn(inout out, item.alive && (item.x < 0 || item.y < 0 ||
             @intCast(item.x) >= world.width || @intCast(item.y) >= world.height));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -73,7 +73,7 @@ fn observe_tiles(inout out: metric.Metric, borrow world: model.World) {
         let item = world.tiles.get_or(i, model.empty_tile());
         metric.observe(inout out, tile_projection(borrow world, i), (i % 13) + 1);
         metric.warn(inout out, item.x >= world.width || item.y >= world.height);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -82,18 +82,18 @@ fn observe_timeline(inout out: metric.Metric, borrow world: model.World) {
     while i < world.events.len() {
         metric.observe(inout out, event_projection(borrow world, i), (i % 5) + 1);
         metric.warn(inout out, world.events.get_or(i, model.empty_event()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
         metric.observe(inout out, command_projection(borrow world, i), (i % 7) + 1);
         metric.warn(inout out, world.commands.get_or(i, model.empty_command()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.snapshots.len() {
         metric.observe(inout out, snapshot_projection(borrow world, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -108,9 +108,9 @@ fn observe_pairs(inout out: metric.Metric, borrow world: model.World) {
             let dy = if left.y > right.y { left.y - right.y } else { right.y - left.y };
             metric.observe(inout out, @intCast(dx + dy) +
                 left.faction * 3 + right.faction * 5 + MODE(), i + j + 1);
-            j = j + 1;
+            j += 1;
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -125,17 +125,17 @@ fn observe_factions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.entities.len() {
             let entity = world.entities.get_or(i, model.empty_entity());
             if entity.faction == faction && entity.alive {
-                agents = agents + 1;
-                health = health + entity.health;
-                energy = energy + entity.energy;
-                inventory = inventory + entity.inventory;
+                agents += 1;
+                health += entity.health;
+                energy += entity.energy;
+                inventory += entity.inventory;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = agents * (MODE() % 11 + 1) + health * 3 +
             energy * 5 + inventory * 7 + faction;
         metric.observe(inout out, projection, faction + MODE() % 5 + 1);
-        faction = faction + 1;
+        faction += 1;
     }
 }
 
@@ -150,17 +150,17 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
-                tiles = tiles + 1;
+                tiles += 1;
                 if tile.walkable { walkable = walkable + 1; }
-                resources = resources + tile.resource;
-                elevation = elevation + tile.height;
+                resources += tile.resource;
+                elevation += tile.height;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = tiles * (MODE() % 13 + 1) + walkable * 3 +
             resources * 5 + elevation * 7 + region;
         metric.observe(inout out, projection, region % 7 + 1);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/audit_terrain_density.rue
+++ b/examples/caldera/audit_terrain_density.rue
@@ -151,7 +151,7 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
                 tiles += 1;
-                if tile.walkable { walkable = walkable + 1; }
+                if tile.walkable { walkable += 1; }
                 resources += tile.resource;
                 elevation += tile.height;
             }

--- a/examples/caldera/audit_terrain_density.rue
+++ b/examples/caldera/audit_terrain_density.rue
@@ -63,7 +63,7 @@ fn observe_entities(inout out: metric.Metric, borrow world: model.World) {
         metric.observe(inout out, entity_projection(borrow world, i), (i % 11) + 1);
         metric.warn(inout out, item.alive && (item.x < 0 || item.y < 0 ||
             @intCast(item.x) >= world.width || @intCast(item.y) >= world.height));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -73,7 +73,7 @@ fn observe_tiles(inout out: metric.Metric, borrow world: model.World) {
         let item = world.tiles.get_or(i, model.empty_tile());
         metric.observe(inout out, tile_projection(borrow world, i), (i % 13) + 1);
         metric.warn(inout out, item.x >= world.width || item.y >= world.height);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -82,18 +82,18 @@ fn observe_timeline(inout out: metric.Metric, borrow world: model.World) {
     while i < world.events.len() {
         metric.observe(inout out, event_projection(borrow world, i), (i % 5) + 1);
         metric.warn(inout out, world.events.get_or(i, model.empty_event()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
         metric.observe(inout out, command_projection(borrow world, i), (i % 7) + 1);
         metric.warn(inout out, world.commands.get_or(i, model.empty_command()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.snapshots.len() {
         metric.observe(inout out, snapshot_projection(borrow world, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -108,9 +108,9 @@ fn observe_pairs(inout out: metric.Metric, borrow world: model.World) {
             let dy = if left.y > right.y { left.y - right.y } else { right.y - left.y };
             metric.observe(inout out, @intCast(dx + dy) +
                 left.faction * 3 + right.faction * 5 + MODE(), i + j + 1);
-            j = j + 1;
+            j += 1;
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -125,17 +125,17 @@ fn observe_factions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.entities.len() {
             let entity = world.entities.get_or(i, model.empty_entity());
             if entity.faction == faction && entity.alive {
-                agents = agents + 1;
-                health = health + entity.health;
-                energy = energy + entity.energy;
-                inventory = inventory + entity.inventory;
+                agents += 1;
+                health += entity.health;
+                energy += entity.energy;
+                inventory += entity.inventory;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = agents * (MODE() % 11 + 1) + health * 3 +
             energy * 5 + inventory * 7 + faction;
         metric.observe(inout out, projection, faction + MODE() % 5 + 1);
-        faction = faction + 1;
+        faction += 1;
     }
 }
 
@@ -150,17 +150,17 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
-                tiles = tiles + 1;
+                tiles += 1;
                 if tile.walkable { walkable = walkable + 1; }
-                resources = resources + tile.resource;
-                elevation = elevation + tile.height;
+                resources += tile.resource;
+                elevation += tile.height;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = tiles * (MODE() % 13 + 1) + walkable * 3 +
             resources * 5 + elevation * 7 + region;
         metric.observe(inout out, projection, region % 7 + 1);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/audit_terrain_entropy.rue
+++ b/examples/caldera/audit_terrain_entropy.rue
@@ -151,7 +151,7 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
                 tiles += 1;
-                if tile.walkable { walkable = walkable + 1; }
+                if tile.walkable { walkable += 1; }
                 resources += tile.resource;
                 elevation += tile.height;
             }

--- a/examples/caldera/audit_terrain_entropy.rue
+++ b/examples/caldera/audit_terrain_entropy.rue
@@ -63,7 +63,7 @@ fn observe_entities(inout out: metric.Metric, borrow world: model.World) {
         metric.observe(inout out, entity_projection(borrow world, i), (i % 11) + 1);
         metric.warn(inout out, item.alive && (item.x < 0 || item.y < 0 ||
             @intCast(item.x) >= world.width || @intCast(item.y) >= world.height));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -73,7 +73,7 @@ fn observe_tiles(inout out: metric.Metric, borrow world: model.World) {
         let item = world.tiles.get_or(i, model.empty_tile());
         metric.observe(inout out, tile_projection(borrow world, i), (i % 13) + 1);
         metric.warn(inout out, item.x >= world.width || item.y >= world.height);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -82,18 +82,18 @@ fn observe_timeline(inout out: metric.Metric, borrow world: model.World) {
     while i < world.events.len() {
         metric.observe(inout out, event_projection(borrow world, i), (i % 5) + 1);
         metric.warn(inout out, world.events.get_or(i, model.empty_event()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
         metric.observe(inout out, command_projection(borrow world, i), (i % 7) + 1);
         metric.warn(inout out, world.commands.get_or(i, model.empty_command()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.snapshots.len() {
         metric.observe(inout out, snapshot_projection(borrow world, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -108,9 +108,9 @@ fn observe_pairs(inout out: metric.Metric, borrow world: model.World) {
             let dy = if left.y > right.y { left.y - right.y } else { right.y - left.y };
             metric.observe(inout out, @intCast(dx + dy) +
                 left.faction * 3 + right.faction * 5 + MODE(), i + j + 1);
-            j = j + 1;
+            j += 1;
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -125,17 +125,17 @@ fn observe_factions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.entities.len() {
             let entity = world.entities.get_or(i, model.empty_entity());
             if entity.faction == faction && entity.alive {
-                agents = agents + 1;
-                health = health + entity.health;
-                energy = energy + entity.energy;
-                inventory = inventory + entity.inventory;
+                agents += 1;
+                health += entity.health;
+                energy += entity.energy;
+                inventory += entity.inventory;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = agents * (MODE() % 11 + 1) + health * 3 +
             energy * 5 + inventory * 7 + faction;
         metric.observe(inout out, projection, faction + MODE() % 5 + 1);
-        faction = faction + 1;
+        faction += 1;
     }
 }
 
@@ -150,17 +150,17 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
-                tiles = tiles + 1;
+                tiles += 1;
                 if tile.walkable { walkable = walkable + 1; }
-                resources = resources + tile.resource;
-                elevation = elevation + tile.height;
+                resources += tile.resource;
+                elevation += tile.height;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = tiles * (MODE() % 13 + 1) + walkable * 3 +
             resources * 5 + elevation * 7 + region;
         metric.observe(inout out, projection, region % 7 + 1);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/audit_terrain_fanout.rue
+++ b/examples/caldera/audit_terrain_fanout.rue
@@ -151,7 +151,7 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
                 tiles += 1;
-                if tile.walkable { walkable = walkable + 1; }
+                if tile.walkable { walkable += 1; }
                 resources += tile.resource;
                 elevation += tile.height;
             }

--- a/examples/caldera/audit_terrain_fanout.rue
+++ b/examples/caldera/audit_terrain_fanout.rue
@@ -63,7 +63,7 @@ fn observe_entities(inout out: metric.Metric, borrow world: model.World) {
         metric.observe(inout out, entity_projection(borrow world, i), (i % 11) + 1);
         metric.warn(inout out, item.alive && (item.x < 0 || item.y < 0 ||
             @intCast(item.x) >= world.width || @intCast(item.y) >= world.height));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -73,7 +73,7 @@ fn observe_tiles(inout out: metric.Metric, borrow world: model.World) {
         let item = world.tiles.get_or(i, model.empty_tile());
         metric.observe(inout out, tile_projection(borrow world, i), (i % 13) + 1);
         metric.warn(inout out, item.x >= world.width || item.y >= world.height);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -82,18 +82,18 @@ fn observe_timeline(inout out: metric.Metric, borrow world: model.World) {
     while i < world.events.len() {
         metric.observe(inout out, event_projection(borrow world, i), (i % 5) + 1);
         metric.warn(inout out, world.events.get_or(i, model.empty_event()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
         metric.observe(inout out, command_projection(borrow world, i), (i % 7) + 1);
         metric.warn(inout out, world.commands.get_or(i, model.empty_command()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.snapshots.len() {
         metric.observe(inout out, snapshot_projection(borrow world, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -108,9 +108,9 @@ fn observe_pairs(inout out: metric.Metric, borrow world: model.World) {
             let dy = if left.y > right.y { left.y - right.y } else { right.y - left.y };
             metric.observe(inout out, @intCast(dx + dy) +
                 left.faction * 3 + right.faction * 5 + MODE(), i + j + 1);
-            j = j + 1;
+            j += 1;
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -125,17 +125,17 @@ fn observe_factions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.entities.len() {
             let entity = world.entities.get_or(i, model.empty_entity());
             if entity.faction == faction && entity.alive {
-                agents = agents + 1;
-                health = health + entity.health;
-                energy = energy + entity.energy;
-                inventory = inventory + entity.inventory;
+                agents += 1;
+                health += entity.health;
+                energy += entity.energy;
+                inventory += entity.inventory;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = agents * (MODE() % 11 + 1) + health * 3 +
             energy * 5 + inventory * 7 + faction;
         metric.observe(inout out, projection, faction + MODE() % 5 + 1);
-        faction = faction + 1;
+        faction += 1;
     }
 }
 
@@ -150,17 +150,17 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
-                tiles = tiles + 1;
+                tiles += 1;
                 if tile.walkable { walkable = walkable + 1; }
-                resources = resources + tile.resource;
-                elevation = elevation + tile.height;
+                resources += tile.resource;
+                elevation += tile.height;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = tiles * (MODE() % 13 + 1) + walkable * 3 +
             resources * 5 + elevation * 7 + region;
         metric.observe(inout out, projection, region % 7 + 1);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/audit_terrain_integrity.rue
+++ b/examples/caldera/audit_terrain_integrity.rue
@@ -151,7 +151,7 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
                 tiles += 1;
-                if tile.walkable { walkable = walkable + 1; }
+                if tile.walkable { walkable += 1; }
                 resources += tile.resource;
                 elevation += tile.height;
             }

--- a/examples/caldera/audit_terrain_integrity.rue
+++ b/examples/caldera/audit_terrain_integrity.rue
@@ -63,7 +63,7 @@ fn observe_entities(inout out: metric.Metric, borrow world: model.World) {
         metric.observe(inout out, entity_projection(borrow world, i), (i % 11) + 1);
         metric.warn(inout out, item.alive && (item.x < 0 || item.y < 0 ||
             @intCast(item.x) >= world.width || @intCast(item.y) >= world.height));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -73,7 +73,7 @@ fn observe_tiles(inout out: metric.Metric, borrow world: model.World) {
         let item = world.tiles.get_or(i, model.empty_tile());
         metric.observe(inout out, tile_projection(borrow world, i), (i % 13) + 1);
         metric.warn(inout out, item.x >= world.width || item.y >= world.height);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -82,18 +82,18 @@ fn observe_timeline(inout out: metric.Metric, borrow world: model.World) {
     while i < world.events.len() {
         metric.observe(inout out, event_projection(borrow world, i), (i % 5) + 1);
         metric.warn(inout out, world.events.get_or(i, model.empty_event()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
         metric.observe(inout out, command_projection(borrow world, i), (i % 7) + 1);
         metric.warn(inout out, world.commands.get_or(i, model.empty_command()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.snapshots.len() {
         metric.observe(inout out, snapshot_projection(borrow world, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -108,9 +108,9 @@ fn observe_pairs(inout out: metric.Metric, borrow world: model.World) {
             let dy = if left.y > right.y { left.y - right.y } else { right.y - left.y };
             metric.observe(inout out, @intCast(dx + dy) +
                 left.faction * 3 + right.faction * 5 + MODE(), i + j + 1);
-            j = j + 1;
+            j += 1;
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -125,17 +125,17 @@ fn observe_factions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.entities.len() {
             let entity = world.entities.get_or(i, model.empty_entity());
             if entity.faction == faction && entity.alive {
-                agents = agents + 1;
-                health = health + entity.health;
-                energy = energy + entity.energy;
-                inventory = inventory + entity.inventory;
+                agents += 1;
+                health += entity.health;
+                energy += entity.energy;
+                inventory += entity.inventory;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = agents * (MODE() % 11 + 1) + health * 3 +
             energy * 5 + inventory * 7 + faction;
         metric.observe(inout out, projection, faction + MODE() % 5 + 1);
-        faction = faction + 1;
+        faction += 1;
     }
 }
 
@@ -150,17 +150,17 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
-                tiles = tiles + 1;
+                tiles += 1;
                 if tile.walkable { walkable = walkable + 1; }
-                resources = resources + tile.resource;
-                elevation = elevation + tile.height;
+                resources += tile.resource;
+                elevation += tile.height;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = tiles * (MODE() % 13 + 1) + walkable * 3 +
             resources * 5 + elevation * 7 + region;
         metric.observe(inout out, projection, region % 7 + 1);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/audit_terrain_latency.rue
+++ b/examples/caldera/audit_terrain_latency.rue
@@ -151,7 +151,7 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
                 tiles += 1;
-                if tile.walkable { walkable = walkable + 1; }
+                if tile.walkable { walkable += 1; }
                 resources += tile.resource;
                 elevation += tile.height;
             }

--- a/examples/caldera/audit_terrain_latency.rue
+++ b/examples/caldera/audit_terrain_latency.rue
@@ -63,7 +63,7 @@ fn observe_entities(inout out: metric.Metric, borrow world: model.World) {
         metric.observe(inout out, entity_projection(borrow world, i), (i % 11) + 1);
         metric.warn(inout out, item.alive && (item.x < 0 || item.y < 0 ||
             @intCast(item.x) >= world.width || @intCast(item.y) >= world.height));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -73,7 +73,7 @@ fn observe_tiles(inout out: metric.Metric, borrow world: model.World) {
         let item = world.tiles.get_or(i, model.empty_tile());
         metric.observe(inout out, tile_projection(borrow world, i), (i % 13) + 1);
         metric.warn(inout out, item.x >= world.width || item.y >= world.height);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -82,18 +82,18 @@ fn observe_timeline(inout out: metric.Metric, borrow world: model.World) {
     while i < world.events.len() {
         metric.observe(inout out, event_projection(borrow world, i), (i % 5) + 1);
         metric.warn(inout out, world.events.get_or(i, model.empty_event()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
         metric.observe(inout out, command_projection(borrow world, i), (i % 7) + 1);
         metric.warn(inout out, world.commands.get_or(i, model.empty_command()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.snapshots.len() {
         metric.observe(inout out, snapshot_projection(borrow world, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -108,9 +108,9 @@ fn observe_pairs(inout out: metric.Metric, borrow world: model.World) {
             let dy = if left.y > right.y { left.y - right.y } else { right.y - left.y };
             metric.observe(inout out, @intCast(dx + dy) +
                 left.faction * 3 + right.faction * 5 + MODE(), i + j + 1);
-            j = j + 1;
+            j += 1;
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -125,17 +125,17 @@ fn observe_factions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.entities.len() {
             let entity = world.entities.get_or(i, model.empty_entity());
             if entity.faction == faction && entity.alive {
-                agents = agents + 1;
-                health = health + entity.health;
-                energy = energy + entity.energy;
-                inventory = inventory + entity.inventory;
+                agents += 1;
+                health += entity.health;
+                energy += entity.energy;
+                inventory += entity.inventory;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = agents * (MODE() % 11 + 1) + health * 3 +
             energy * 5 + inventory * 7 + faction;
         metric.observe(inout out, projection, faction + MODE() % 5 + 1);
-        faction = faction + 1;
+        faction += 1;
     }
 }
 
@@ -150,17 +150,17 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
-                tiles = tiles + 1;
+                tiles += 1;
                 if tile.walkable { walkable = walkable + 1; }
-                resources = resources + tile.resource;
-                elevation = elevation + tile.height;
+                resources += tile.resource;
+                elevation += tile.height;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = tiles * (MODE() % 13 + 1) + walkable * 3 +
             resources * 5 + elevation * 7 + region;
         metric.observe(inout out, projection, region % 7 + 1);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/audit_terrain_locality.rue
+++ b/examples/caldera/audit_terrain_locality.rue
@@ -151,7 +151,7 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
                 tiles += 1;
-                if tile.walkable { walkable = walkable + 1; }
+                if tile.walkable { walkable += 1; }
                 resources += tile.resource;
                 elevation += tile.height;
             }

--- a/examples/caldera/audit_terrain_locality.rue
+++ b/examples/caldera/audit_terrain_locality.rue
@@ -63,7 +63,7 @@ fn observe_entities(inout out: metric.Metric, borrow world: model.World) {
         metric.observe(inout out, entity_projection(borrow world, i), (i % 11) + 1);
         metric.warn(inout out, item.alive && (item.x < 0 || item.y < 0 ||
             @intCast(item.x) >= world.width || @intCast(item.y) >= world.height));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -73,7 +73,7 @@ fn observe_tiles(inout out: metric.Metric, borrow world: model.World) {
         let item = world.tiles.get_or(i, model.empty_tile());
         metric.observe(inout out, tile_projection(borrow world, i), (i % 13) + 1);
         metric.warn(inout out, item.x >= world.width || item.y >= world.height);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -82,18 +82,18 @@ fn observe_timeline(inout out: metric.Metric, borrow world: model.World) {
     while i < world.events.len() {
         metric.observe(inout out, event_projection(borrow world, i), (i % 5) + 1);
         metric.warn(inout out, world.events.get_or(i, model.empty_event()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
         metric.observe(inout out, command_projection(borrow world, i), (i % 7) + 1);
         metric.warn(inout out, world.commands.get_or(i, model.empty_command()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.snapshots.len() {
         metric.observe(inout out, snapshot_projection(borrow world, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -108,9 +108,9 @@ fn observe_pairs(inout out: metric.Metric, borrow world: model.World) {
             let dy = if left.y > right.y { left.y - right.y } else { right.y - left.y };
             metric.observe(inout out, @intCast(dx + dy) +
                 left.faction * 3 + right.faction * 5 + MODE(), i + j + 1);
-            j = j + 1;
+            j += 1;
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -125,17 +125,17 @@ fn observe_factions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.entities.len() {
             let entity = world.entities.get_or(i, model.empty_entity());
             if entity.faction == faction && entity.alive {
-                agents = agents + 1;
-                health = health + entity.health;
-                energy = energy + entity.energy;
-                inventory = inventory + entity.inventory;
+                agents += 1;
+                health += entity.health;
+                energy += entity.energy;
+                inventory += entity.inventory;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = agents * (MODE() % 11 + 1) + health * 3 +
             energy * 5 + inventory * 7 + faction;
         metric.observe(inout out, projection, faction + MODE() % 5 + 1);
-        faction = faction + 1;
+        faction += 1;
     }
 }
 
@@ -150,17 +150,17 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
-                tiles = tiles + 1;
+                tiles += 1;
                 if tile.walkable { walkable = walkable + 1; }
-                resources = resources + tile.resource;
-                elevation = elevation + tile.height;
+                resources += tile.resource;
+                elevation += tile.height;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = tiles * (MODE() % 13 + 1) + walkable * 3 +
             resources * 5 + elevation * 7 + region;
         metric.observe(inout out, projection, region % 7 + 1);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/audit_terrain_pressure.rue
+++ b/examples/caldera/audit_terrain_pressure.rue
@@ -151,7 +151,7 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
                 tiles += 1;
-                if tile.walkable { walkable = walkable + 1; }
+                if tile.walkable { walkable += 1; }
                 resources += tile.resource;
                 elevation += tile.height;
             }

--- a/examples/caldera/audit_terrain_pressure.rue
+++ b/examples/caldera/audit_terrain_pressure.rue
@@ -63,7 +63,7 @@ fn observe_entities(inout out: metric.Metric, borrow world: model.World) {
         metric.observe(inout out, entity_projection(borrow world, i), (i % 11) + 1);
         metric.warn(inout out, item.alive && (item.x < 0 || item.y < 0 ||
             @intCast(item.x) >= world.width || @intCast(item.y) >= world.height));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -73,7 +73,7 @@ fn observe_tiles(inout out: metric.Metric, borrow world: model.World) {
         let item = world.tiles.get_or(i, model.empty_tile());
         metric.observe(inout out, tile_projection(borrow world, i), (i % 13) + 1);
         metric.warn(inout out, item.x >= world.width || item.y >= world.height);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -82,18 +82,18 @@ fn observe_timeline(inout out: metric.Metric, borrow world: model.World) {
     while i < world.events.len() {
         metric.observe(inout out, event_projection(borrow world, i), (i % 5) + 1);
         metric.warn(inout out, world.events.get_or(i, model.empty_event()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
         metric.observe(inout out, command_projection(borrow world, i), (i % 7) + 1);
         metric.warn(inout out, world.commands.get_or(i, model.empty_command()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.snapshots.len() {
         metric.observe(inout out, snapshot_projection(borrow world, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -108,9 +108,9 @@ fn observe_pairs(inout out: metric.Metric, borrow world: model.World) {
             let dy = if left.y > right.y { left.y - right.y } else { right.y - left.y };
             metric.observe(inout out, @intCast(dx + dy) +
                 left.faction * 3 + right.faction * 5 + MODE(), i + j + 1);
-            j = j + 1;
+            j += 1;
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -125,17 +125,17 @@ fn observe_factions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.entities.len() {
             let entity = world.entities.get_or(i, model.empty_entity());
             if entity.faction == faction && entity.alive {
-                agents = agents + 1;
-                health = health + entity.health;
-                energy = energy + entity.energy;
-                inventory = inventory + entity.inventory;
+                agents += 1;
+                health += entity.health;
+                energy += entity.energy;
+                inventory += entity.inventory;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = agents * (MODE() % 11 + 1) + health * 3 +
             energy * 5 + inventory * 7 + faction;
         metric.observe(inout out, projection, faction + MODE() % 5 + 1);
-        faction = faction + 1;
+        faction += 1;
     }
 }
 
@@ -150,17 +150,17 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
-                tiles = tiles + 1;
+                tiles += 1;
                 if tile.walkable { walkable = walkable + 1; }
-                resources = resources + tile.resource;
-                elevation = elevation + tile.height;
+                resources += tile.resource;
+                elevation += tile.height;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = tiles * (MODE() % 13 + 1) + walkable * 3 +
             resources * 5 + elevation * 7 + region;
         metric.observe(inout out, projection, region % 7 + 1);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/audit_terrain_risk.rue
+++ b/examples/caldera/audit_terrain_risk.rue
@@ -151,7 +151,7 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
                 tiles += 1;
-                if tile.walkable { walkable = walkable + 1; }
+                if tile.walkable { walkable += 1; }
                 resources += tile.resource;
                 elevation += tile.height;
             }

--- a/examples/caldera/audit_terrain_risk.rue
+++ b/examples/caldera/audit_terrain_risk.rue
@@ -63,7 +63,7 @@ fn observe_entities(inout out: metric.Metric, borrow world: model.World) {
         metric.observe(inout out, entity_projection(borrow world, i), (i % 11) + 1);
         metric.warn(inout out, item.alive && (item.x < 0 || item.y < 0 ||
             @intCast(item.x) >= world.width || @intCast(item.y) >= world.height));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -73,7 +73,7 @@ fn observe_tiles(inout out: metric.Metric, borrow world: model.World) {
         let item = world.tiles.get_or(i, model.empty_tile());
         metric.observe(inout out, tile_projection(borrow world, i), (i % 13) + 1);
         metric.warn(inout out, item.x >= world.width || item.y >= world.height);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -82,18 +82,18 @@ fn observe_timeline(inout out: metric.Metric, borrow world: model.World) {
     while i < world.events.len() {
         metric.observe(inout out, event_projection(borrow world, i), (i % 5) + 1);
         metric.warn(inout out, world.events.get_or(i, model.empty_event()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
         metric.observe(inout out, command_projection(borrow world, i), (i % 7) + 1);
         metric.warn(inout out, world.commands.get_or(i, model.empty_command()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.snapshots.len() {
         metric.observe(inout out, snapshot_projection(borrow world, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -108,9 +108,9 @@ fn observe_pairs(inout out: metric.Metric, borrow world: model.World) {
             let dy = if left.y > right.y { left.y - right.y } else { right.y - left.y };
             metric.observe(inout out, @intCast(dx + dy) +
                 left.faction * 3 + right.faction * 5 + MODE(), i + j + 1);
-            j = j + 1;
+            j += 1;
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -125,17 +125,17 @@ fn observe_factions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.entities.len() {
             let entity = world.entities.get_or(i, model.empty_entity());
             if entity.faction == faction && entity.alive {
-                agents = agents + 1;
-                health = health + entity.health;
-                energy = energy + entity.energy;
-                inventory = inventory + entity.inventory;
+                agents += 1;
+                health += entity.health;
+                energy += entity.energy;
+                inventory += entity.inventory;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = agents * (MODE() % 11 + 1) + health * 3 +
             energy * 5 + inventory * 7 + faction;
         metric.observe(inout out, projection, faction + MODE() % 5 + 1);
-        faction = faction + 1;
+        faction += 1;
     }
 }
 
@@ -150,17 +150,17 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
-                tiles = tiles + 1;
+                tiles += 1;
                 if tile.walkable { walkable = walkable + 1; }
-                resources = resources + tile.resource;
-                elevation = elevation + tile.height;
+                resources += tile.resource;
+                elevation += tile.height;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = tiles * (MODE() % 13 + 1) + walkable * 3 +
             resources * 5 + elevation * 7 + region;
         metric.observe(inout out, projection, region % 7 + 1);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/audit_terrain_skew.rue
+++ b/examples/caldera/audit_terrain_skew.rue
@@ -151,7 +151,7 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
                 tiles += 1;
-                if tile.walkable { walkable = walkable + 1; }
+                if tile.walkable { walkable += 1; }
                 resources += tile.resource;
                 elevation += tile.height;
             }

--- a/examples/caldera/audit_terrain_skew.rue
+++ b/examples/caldera/audit_terrain_skew.rue
@@ -63,7 +63,7 @@ fn observe_entities(inout out: metric.Metric, borrow world: model.World) {
         metric.observe(inout out, entity_projection(borrow world, i), (i % 11) + 1);
         metric.warn(inout out, item.alive && (item.x < 0 || item.y < 0 ||
             @intCast(item.x) >= world.width || @intCast(item.y) >= world.height));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -73,7 +73,7 @@ fn observe_tiles(inout out: metric.Metric, borrow world: model.World) {
         let item = world.tiles.get_or(i, model.empty_tile());
         metric.observe(inout out, tile_projection(borrow world, i), (i % 13) + 1);
         metric.warn(inout out, item.x >= world.width || item.y >= world.height);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -82,18 +82,18 @@ fn observe_timeline(inout out: metric.Metric, borrow world: model.World) {
     while i < world.events.len() {
         metric.observe(inout out, event_projection(borrow world, i), (i % 5) + 1);
         metric.warn(inout out, world.events.get_or(i, model.empty_event()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
         metric.observe(inout out, command_projection(borrow world, i), (i % 7) + 1);
         metric.warn(inout out, world.commands.get_or(i, model.empty_command()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.snapshots.len() {
         metric.observe(inout out, snapshot_projection(borrow world, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -108,9 +108,9 @@ fn observe_pairs(inout out: metric.Metric, borrow world: model.World) {
             let dy = if left.y > right.y { left.y - right.y } else { right.y - left.y };
             metric.observe(inout out, @intCast(dx + dy) +
                 left.faction * 3 + right.faction * 5 + MODE(), i + j + 1);
-            j = j + 1;
+            j += 1;
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -125,17 +125,17 @@ fn observe_factions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.entities.len() {
             let entity = world.entities.get_or(i, model.empty_entity());
             if entity.faction == faction && entity.alive {
-                agents = agents + 1;
-                health = health + entity.health;
-                energy = energy + entity.energy;
-                inventory = inventory + entity.inventory;
+                agents += 1;
+                health += entity.health;
+                energy += entity.energy;
+                inventory += entity.inventory;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = agents * (MODE() % 11 + 1) + health * 3 +
             energy * 5 + inventory * 7 + faction;
         metric.observe(inout out, projection, faction + MODE() % 5 + 1);
-        faction = faction + 1;
+        faction += 1;
     }
 }
 
@@ -150,17 +150,17 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
-                tiles = tiles + 1;
+                tiles += 1;
                 if tile.walkable { walkable = walkable + 1; }
-                resources = resources + tile.resource;
-                elevation = elevation + tile.height;
+                resources += tile.resource;
+                elevation += tile.height;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = tiles * (MODE() % 13 + 1) + walkable * 3 +
             resources * 5 + elevation * 7 + region;
         metric.observe(inout out, projection, region % 7 + 1);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/audit_terrain_stability.rue
+++ b/examples/caldera/audit_terrain_stability.rue
@@ -151,7 +151,7 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
                 tiles += 1;
-                if tile.walkable { walkable = walkable + 1; }
+                if tile.walkable { walkable += 1; }
                 resources += tile.resource;
                 elevation += tile.height;
             }

--- a/examples/caldera/audit_terrain_stability.rue
+++ b/examples/caldera/audit_terrain_stability.rue
@@ -63,7 +63,7 @@ fn observe_entities(inout out: metric.Metric, borrow world: model.World) {
         metric.observe(inout out, entity_projection(borrow world, i), (i % 11) + 1);
         metric.warn(inout out, item.alive && (item.x < 0 || item.y < 0 ||
             @intCast(item.x) >= world.width || @intCast(item.y) >= world.height));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -73,7 +73,7 @@ fn observe_tiles(inout out: metric.Metric, borrow world: model.World) {
         let item = world.tiles.get_or(i, model.empty_tile());
         metric.observe(inout out, tile_projection(borrow world, i), (i % 13) + 1);
         metric.warn(inout out, item.x >= world.width || item.y >= world.height);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -82,18 +82,18 @@ fn observe_timeline(inout out: metric.Metric, borrow world: model.World) {
     while i < world.events.len() {
         metric.observe(inout out, event_projection(borrow world, i), (i % 5) + 1);
         metric.warn(inout out, world.events.get_or(i, model.empty_event()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
         metric.observe(inout out, command_projection(borrow world, i), (i % 7) + 1);
         metric.warn(inout out, world.commands.get_or(i, model.empty_command()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.snapshots.len() {
         metric.observe(inout out, snapshot_projection(borrow world, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -108,9 +108,9 @@ fn observe_pairs(inout out: metric.Metric, borrow world: model.World) {
             let dy = if left.y > right.y { left.y - right.y } else { right.y - left.y };
             metric.observe(inout out, @intCast(dx + dy) +
                 left.faction * 3 + right.faction * 5 + MODE(), i + j + 1);
-            j = j + 1;
+            j += 1;
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -125,17 +125,17 @@ fn observe_factions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.entities.len() {
             let entity = world.entities.get_or(i, model.empty_entity());
             if entity.faction == faction && entity.alive {
-                agents = agents + 1;
-                health = health + entity.health;
-                energy = energy + entity.energy;
-                inventory = inventory + entity.inventory;
+                agents += 1;
+                health += entity.health;
+                energy += entity.energy;
+                inventory += entity.inventory;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = agents * (MODE() % 11 + 1) + health * 3 +
             energy * 5 + inventory * 7 + faction;
         metric.observe(inout out, projection, faction + MODE() % 5 + 1);
-        faction = faction + 1;
+        faction += 1;
     }
 }
 
@@ -150,17 +150,17 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
-                tiles = tiles + 1;
+                tiles += 1;
                 if tile.walkable { walkable = walkable + 1; }
-                resources = resources + tile.resource;
-                elevation = elevation + tile.height;
+                resources += tile.resource;
+                elevation += tile.height;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = tiles * (MODE() % 13 + 1) + walkable * 3 +
             resources * 5 + elevation * 7 + region;
         metric.observe(inout out, projection, region % 7 + 1);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/audit_terrain_throughput.rue
+++ b/examples/caldera/audit_terrain_throughput.rue
@@ -151,7 +151,7 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
                 tiles += 1;
-                if tile.walkable { walkable = walkable + 1; }
+                if tile.walkable { walkable += 1; }
                 resources += tile.resource;
                 elevation += tile.height;
             }

--- a/examples/caldera/audit_terrain_throughput.rue
+++ b/examples/caldera/audit_terrain_throughput.rue
@@ -63,7 +63,7 @@ fn observe_entities(inout out: metric.Metric, borrow world: model.World) {
         metric.observe(inout out, entity_projection(borrow world, i), (i % 11) + 1);
         metric.warn(inout out, item.alive && (item.x < 0 || item.y < 0 ||
             @intCast(item.x) >= world.width || @intCast(item.y) >= world.height));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -73,7 +73,7 @@ fn observe_tiles(inout out: metric.Metric, borrow world: model.World) {
         let item = world.tiles.get_or(i, model.empty_tile());
         metric.observe(inout out, tile_projection(borrow world, i), (i % 13) + 1);
         metric.warn(inout out, item.x >= world.width || item.y >= world.height);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -82,18 +82,18 @@ fn observe_timeline(inout out: metric.Metric, borrow world: model.World) {
     while i < world.events.len() {
         metric.observe(inout out, event_projection(borrow world, i), (i % 5) + 1);
         metric.warn(inout out, world.events.get_or(i, model.empty_event()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
         metric.observe(inout out, command_projection(borrow world, i), (i % 7) + 1);
         metric.warn(inout out, world.commands.get_or(i, model.empty_command()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.snapshots.len() {
         metric.observe(inout out, snapshot_projection(borrow world, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -108,9 +108,9 @@ fn observe_pairs(inout out: metric.Metric, borrow world: model.World) {
             let dy = if left.y > right.y { left.y - right.y } else { right.y - left.y };
             metric.observe(inout out, @intCast(dx + dy) +
                 left.faction * 3 + right.faction * 5 + MODE(), i + j + 1);
-            j = j + 1;
+            j += 1;
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -125,17 +125,17 @@ fn observe_factions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.entities.len() {
             let entity = world.entities.get_or(i, model.empty_entity());
             if entity.faction == faction && entity.alive {
-                agents = agents + 1;
-                health = health + entity.health;
-                energy = energy + entity.energy;
-                inventory = inventory + entity.inventory;
+                agents += 1;
+                health += entity.health;
+                energy += entity.energy;
+                inventory += entity.inventory;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = agents * (MODE() % 11 + 1) + health * 3 +
             energy * 5 + inventory * 7 + faction;
         metric.observe(inout out, projection, faction + MODE() % 5 + 1);
-        faction = faction + 1;
+        faction += 1;
     }
 }
 
@@ -150,17 +150,17 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
-                tiles = tiles + 1;
+                tiles += 1;
                 if tile.walkable { walkable = walkable + 1; }
-                resources = resources + tile.resource;
-                elevation = elevation + tile.height;
+                resources += tile.resource;
+                elevation += tile.height;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = tiles * (MODE() % 13 + 1) + walkable * 3 +
             resources * 5 + elevation * 7 + region;
         metric.observe(inout out, projection, region % 7 + 1);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/audit_world_balance.rue
+++ b/examples/caldera/audit_world_balance.rue
@@ -151,7 +151,7 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
                 tiles += 1;
-                if tile.walkable { walkable = walkable + 1; }
+                if tile.walkable { walkable += 1; }
                 resources += tile.resource;
                 elevation += tile.height;
             }

--- a/examples/caldera/audit_world_balance.rue
+++ b/examples/caldera/audit_world_balance.rue
@@ -63,7 +63,7 @@ fn observe_entities(inout out: metric.Metric, borrow world: model.World) {
         metric.observe(inout out, entity_projection(borrow world, i), (i % 11) + 1);
         metric.warn(inout out, item.alive && (item.x < 0 || item.y < 0 ||
             @intCast(item.x) >= world.width || @intCast(item.y) >= world.height));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -73,7 +73,7 @@ fn observe_tiles(inout out: metric.Metric, borrow world: model.World) {
         let item = world.tiles.get_or(i, model.empty_tile());
         metric.observe(inout out, tile_projection(borrow world, i), (i % 13) + 1);
         metric.warn(inout out, item.x >= world.width || item.y >= world.height);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -82,18 +82,18 @@ fn observe_timeline(inout out: metric.Metric, borrow world: model.World) {
     while i < world.events.len() {
         metric.observe(inout out, event_projection(borrow world, i), (i % 5) + 1);
         metric.warn(inout out, world.events.get_or(i, model.empty_event()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
         metric.observe(inout out, command_projection(borrow world, i), (i % 7) + 1);
         metric.warn(inout out, world.commands.get_or(i, model.empty_command()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.snapshots.len() {
         metric.observe(inout out, snapshot_projection(borrow world, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -108,9 +108,9 @@ fn observe_pairs(inout out: metric.Metric, borrow world: model.World) {
             let dy = if left.y > right.y { left.y - right.y } else { right.y - left.y };
             metric.observe(inout out, @intCast(dx + dy) +
                 left.faction * 3 + right.faction * 5 + MODE(), i + j + 1);
-            j = j + 1;
+            j += 1;
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -125,17 +125,17 @@ fn observe_factions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.entities.len() {
             let entity = world.entities.get_or(i, model.empty_entity());
             if entity.faction == faction && entity.alive {
-                agents = agents + 1;
-                health = health + entity.health;
-                energy = energy + entity.energy;
-                inventory = inventory + entity.inventory;
+                agents += 1;
+                health += entity.health;
+                energy += entity.energy;
+                inventory += entity.inventory;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = agents * (MODE() % 11 + 1) + health * 3 +
             energy * 5 + inventory * 7 + faction;
         metric.observe(inout out, projection, faction + MODE() % 5 + 1);
-        faction = faction + 1;
+        faction += 1;
     }
 }
 
@@ -150,17 +150,17 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
-                tiles = tiles + 1;
+                tiles += 1;
                 if tile.walkable { walkable = walkable + 1; }
-                resources = resources + tile.resource;
-                elevation = elevation + tile.height;
+                resources += tile.resource;
+                elevation += tile.height;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = tiles * (MODE() % 13 + 1) + walkable * 3 +
             resources * 5 + elevation * 7 + region;
         metric.observe(inout out, projection, region % 7 + 1);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/audit_world_capacity.rue
+++ b/examples/caldera/audit_world_capacity.rue
@@ -151,7 +151,7 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
                 tiles += 1;
-                if tile.walkable { walkable = walkable + 1; }
+                if tile.walkable { walkable += 1; }
                 resources += tile.resource;
                 elevation += tile.height;
             }

--- a/examples/caldera/audit_world_capacity.rue
+++ b/examples/caldera/audit_world_capacity.rue
@@ -63,7 +63,7 @@ fn observe_entities(inout out: metric.Metric, borrow world: model.World) {
         metric.observe(inout out, entity_projection(borrow world, i), (i % 11) + 1);
         metric.warn(inout out, item.alive && (item.x < 0 || item.y < 0 ||
             @intCast(item.x) >= world.width || @intCast(item.y) >= world.height));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -73,7 +73,7 @@ fn observe_tiles(inout out: metric.Metric, borrow world: model.World) {
         let item = world.tiles.get_or(i, model.empty_tile());
         metric.observe(inout out, tile_projection(borrow world, i), (i % 13) + 1);
         metric.warn(inout out, item.x >= world.width || item.y >= world.height);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -82,18 +82,18 @@ fn observe_timeline(inout out: metric.Metric, borrow world: model.World) {
     while i < world.events.len() {
         metric.observe(inout out, event_projection(borrow world, i), (i % 5) + 1);
         metric.warn(inout out, world.events.get_or(i, model.empty_event()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
         metric.observe(inout out, command_projection(borrow world, i), (i % 7) + 1);
         metric.warn(inout out, world.commands.get_or(i, model.empty_command()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.snapshots.len() {
         metric.observe(inout out, snapshot_projection(borrow world, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -108,9 +108,9 @@ fn observe_pairs(inout out: metric.Metric, borrow world: model.World) {
             let dy = if left.y > right.y { left.y - right.y } else { right.y - left.y };
             metric.observe(inout out, @intCast(dx + dy) +
                 left.faction * 3 + right.faction * 5 + MODE(), i + j + 1);
-            j = j + 1;
+            j += 1;
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -125,17 +125,17 @@ fn observe_factions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.entities.len() {
             let entity = world.entities.get_or(i, model.empty_entity());
             if entity.faction == faction && entity.alive {
-                agents = agents + 1;
-                health = health + entity.health;
-                energy = energy + entity.energy;
-                inventory = inventory + entity.inventory;
+                agents += 1;
+                health += entity.health;
+                energy += entity.energy;
+                inventory += entity.inventory;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = agents * (MODE() % 11 + 1) + health * 3 +
             energy * 5 + inventory * 7 + faction;
         metric.observe(inout out, projection, faction + MODE() % 5 + 1);
-        faction = faction + 1;
+        faction += 1;
     }
 }
 
@@ -150,17 +150,17 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
-                tiles = tiles + 1;
+                tiles += 1;
                 if tile.walkable { walkable = walkable + 1; }
-                resources = resources + tile.resource;
-                elevation = elevation + tile.height;
+                resources += tile.resource;
+                elevation += tile.height;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = tiles * (MODE() % 13 + 1) + walkable * 3 +
             resources * 5 + elevation * 7 + region;
         metric.observe(inout out, projection, region % 7 + 1);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/audit_world_continuity.rue
+++ b/examples/caldera/audit_world_continuity.rue
@@ -151,7 +151,7 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
                 tiles += 1;
-                if tile.walkable { walkable = walkable + 1; }
+                if tile.walkable { walkable += 1; }
                 resources += tile.resource;
                 elevation += tile.height;
             }

--- a/examples/caldera/audit_world_continuity.rue
+++ b/examples/caldera/audit_world_continuity.rue
@@ -63,7 +63,7 @@ fn observe_entities(inout out: metric.Metric, borrow world: model.World) {
         metric.observe(inout out, entity_projection(borrow world, i), (i % 11) + 1);
         metric.warn(inout out, item.alive && (item.x < 0 || item.y < 0 ||
             @intCast(item.x) >= world.width || @intCast(item.y) >= world.height));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -73,7 +73,7 @@ fn observe_tiles(inout out: metric.Metric, borrow world: model.World) {
         let item = world.tiles.get_or(i, model.empty_tile());
         metric.observe(inout out, tile_projection(borrow world, i), (i % 13) + 1);
         metric.warn(inout out, item.x >= world.width || item.y >= world.height);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -82,18 +82,18 @@ fn observe_timeline(inout out: metric.Metric, borrow world: model.World) {
     while i < world.events.len() {
         metric.observe(inout out, event_projection(borrow world, i), (i % 5) + 1);
         metric.warn(inout out, world.events.get_or(i, model.empty_event()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
         metric.observe(inout out, command_projection(borrow world, i), (i % 7) + 1);
         metric.warn(inout out, world.commands.get_or(i, model.empty_command()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.snapshots.len() {
         metric.observe(inout out, snapshot_projection(borrow world, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -108,9 +108,9 @@ fn observe_pairs(inout out: metric.Metric, borrow world: model.World) {
             let dy = if left.y > right.y { left.y - right.y } else { right.y - left.y };
             metric.observe(inout out, @intCast(dx + dy) +
                 left.faction * 3 + right.faction * 5 + MODE(), i + j + 1);
-            j = j + 1;
+            j += 1;
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -125,17 +125,17 @@ fn observe_factions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.entities.len() {
             let entity = world.entities.get_or(i, model.empty_entity());
             if entity.faction == faction && entity.alive {
-                agents = agents + 1;
-                health = health + entity.health;
-                energy = energy + entity.energy;
-                inventory = inventory + entity.inventory;
+                agents += 1;
+                health += entity.health;
+                energy += entity.energy;
+                inventory += entity.inventory;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = agents * (MODE() % 11 + 1) + health * 3 +
             energy * 5 + inventory * 7 + faction;
         metric.observe(inout out, projection, faction + MODE() % 5 + 1);
-        faction = faction + 1;
+        faction += 1;
     }
 }
 
@@ -150,17 +150,17 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
-                tiles = tiles + 1;
+                tiles += 1;
                 if tile.walkable { walkable = walkable + 1; }
-                resources = resources + tile.resource;
-                elevation = elevation + tile.height;
+                resources += tile.resource;
+                elevation += tile.height;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = tiles * (MODE() % 13 + 1) + walkable * 3 +
             resources * 5 + elevation * 7 + region;
         metric.observe(inout out, projection, region % 7 + 1);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/audit_world_cost.rue
+++ b/examples/caldera/audit_world_cost.rue
@@ -151,7 +151,7 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
                 tiles += 1;
-                if tile.walkable { walkable = walkable + 1; }
+                if tile.walkable { walkable += 1; }
                 resources += tile.resource;
                 elevation += tile.height;
             }

--- a/examples/caldera/audit_world_cost.rue
+++ b/examples/caldera/audit_world_cost.rue
@@ -63,7 +63,7 @@ fn observe_entities(inout out: metric.Metric, borrow world: model.World) {
         metric.observe(inout out, entity_projection(borrow world, i), (i % 11) + 1);
         metric.warn(inout out, item.alive && (item.x < 0 || item.y < 0 ||
             @intCast(item.x) >= world.width || @intCast(item.y) >= world.height));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -73,7 +73,7 @@ fn observe_tiles(inout out: metric.Metric, borrow world: model.World) {
         let item = world.tiles.get_or(i, model.empty_tile());
         metric.observe(inout out, tile_projection(borrow world, i), (i % 13) + 1);
         metric.warn(inout out, item.x >= world.width || item.y >= world.height);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -82,18 +82,18 @@ fn observe_timeline(inout out: metric.Metric, borrow world: model.World) {
     while i < world.events.len() {
         metric.observe(inout out, event_projection(borrow world, i), (i % 5) + 1);
         metric.warn(inout out, world.events.get_or(i, model.empty_event()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
         metric.observe(inout out, command_projection(borrow world, i), (i % 7) + 1);
         metric.warn(inout out, world.commands.get_or(i, model.empty_command()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.snapshots.len() {
         metric.observe(inout out, snapshot_projection(borrow world, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -108,9 +108,9 @@ fn observe_pairs(inout out: metric.Metric, borrow world: model.World) {
             let dy = if left.y > right.y { left.y - right.y } else { right.y - left.y };
             metric.observe(inout out, @intCast(dx + dy) +
                 left.faction * 3 + right.faction * 5 + MODE(), i + j + 1);
-            j = j + 1;
+            j += 1;
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -125,17 +125,17 @@ fn observe_factions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.entities.len() {
             let entity = world.entities.get_or(i, model.empty_entity());
             if entity.faction == faction && entity.alive {
-                agents = agents + 1;
-                health = health + entity.health;
-                energy = energy + entity.energy;
-                inventory = inventory + entity.inventory;
+                agents += 1;
+                health += entity.health;
+                energy += entity.energy;
+                inventory += entity.inventory;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = agents * (MODE() % 11 + 1) + health * 3 +
             energy * 5 + inventory * 7 + faction;
         metric.observe(inout out, projection, faction + MODE() % 5 + 1);
-        faction = faction + 1;
+        faction += 1;
     }
 }
 
@@ -150,17 +150,17 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
-                tiles = tiles + 1;
+                tiles += 1;
                 if tile.walkable { walkable = walkable + 1; }
-                resources = resources + tile.resource;
-                elevation = elevation + tile.height;
+                resources += tile.resource;
+                elevation += tile.height;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = tiles * (MODE() % 13 + 1) + walkable * 3 +
             resources * 5 + elevation * 7 + region;
         metric.observe(inout out, projection, region % 7 + 1);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/audit_world_coverage.rue
+++ b/examples/caldera/audit_world_coverage.rue
@@ -151,7 +151,7 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
                 tiles += 1;
-                if tile.walkable { walkable = walkable + 1; }
+                if tile.walkable { walkable += 1; }
                 resources += tile.resource;
                 elevation += tile.height;
             }

--- a/examples/caldera/audit_world_coverage.rue
+++ b/examples/caldera/audit_world_coverage.rue
@@ -63,7 +63,7 @@ fn observe_entities(inout out: metric.Metric, borrow world: model.World) {
         metric.observe(inout out, entity_projection(borrow world, i), (i % 11) + 1);
         metric.warn(inout out, item.alive && (item.x < 0 || item.y < 0 ||
             @intCast(item.x) >= world.width || @intCast(item.y) >= world.height));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -73,7 +73,7 @@ fn observe_tiles(inout out: metric.Metric, borrow world: model.World) {
         let item = world.tiles.get_or(i, model.empty_tile());
         metric.observe(inout out, tile_projection(borrow world, i), (i % 13) + 1);
         metric.warn(inout out, item.x >= world.width || item.y >= world.height);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -82,18 +82,18 @@ fn observe_timeline(inout out: metric.Metric, borrow world: model.World) {
     while i < world.events.len() {
         metric.observe(inout out, event_projection(borrow world, i), (i % 5) + 1);
         metric.warn(inout out, world.events.get_or(i, model.empty_event()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
         metric.observe(inout out, command_projection(borrow world, i), (i % 7) + 1);
         metric.warn(inout out, world.commands.get_or(i, model.empty_command()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.snapshots.len() {
         metric.observe(inout out, snapshot_projection(borrow world, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -108,9 +108,9 @@ fn observe_pairs(inout out: metric.Metric, borrow world: model.World) {
             let dy = if left.y > right.y { left.y - right.y } else { right.y - left.y };
             metric.observe(inout out, @intCast(dx + dy) +
                 left.faction * 3 + right.faction * 5 + MODE(), i + j + 1);
-            j = j + 1;
+            j += 1;
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -125,17 +125,17 @@ fn observe_factions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.entities.len() {
             let entity = world.entities.get_or(i, model.empty_entity());
             if entity.faction == faction && entity.alive {
-                agents = agents + 1;
-                health = health + entity.health;
-                energy = energy + entity.energy;
-                inventory = inventory + entity.inventory;
+                agents += 1;
+                health += entity.health;
+                energy += entity.energy;
+                inventory += entity.inventory;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = agents * (MODE() % 11 + 1) + health * 3 +
             energy * 5 + inventory * 7 + faction;
         metric.observe(inout out, projection, faction + MODE() % 5 + 1);
-        faction = faction + 1;
+        faction += 1;
     }
 }
 
@@ -150,17 +150,17 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
-                tiles = tiles + 1;
+                tiles += 1;
                 if tile.walkable { walkable = walkable + 1; }
-                resources = resources + tile.resource;
-                elevation = elevation + tile.height;
+                resources += tile.resource;
+                elevation += tile.height;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = tiles * (MODE() % 13 + 1) + walkable * 3 +
             resources * 5 + elevation * 7 + region;
         metric.observe(inout out, projection, region % 7 + 1);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/audit_world_density.rue
+++ b/examples/caldera/audit_world_density.rue
@@ -151,7 +151,7 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
                 tiles += 1;
-                if tile.walkable { walkable = walkable + 1; }
+                if tile.walkable { walkable += 1; }
                 resources += tile.resource;
                 elevation += tile.height;
             }

--- a/examples/caldera/audit_world_density.rue
+++ b/examples/caldera/audit_world_density.rue
@@ -63,7 +63,7 @@ fn observe_entities(inout out: metric.Metric, borrow world: model.World) {
         metric.observe(inout out, entity_projection(borrow world, i), (i % 11) + 1);
         metric.warn(inout out, item.alive && (item.x < 0 || item.y < 0 ||
             @intCast(item.x) >= world.width || @intCast(item.y) >= world.height));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -73,7 +73,7 @@ fn observe_tiles(inout out: metric.Metric, borrow world: model.World) {
         let item = world.tiles.get_or(i, model.empty_tile());
         metric.observe(inout out, tile_projection(borrow world, i), (i % 13) + 1);
         metric.warn(inout out, item.x >= world.width || item.y >= world.height);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -82,18 +82,18 @@ fn observe_timeline(inout out: metric.Metric, borrow world: model.World) {
     while i < world.events.len() {
         metric.observe(inout out, event_projection(borrow world, i), (i % 5) + 1);
         metric.warn(inout out, world.events.get_or(i, model.empty_event()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
         metric.observe(inout out, command_projection(borrow world, i), (i % 7) + 1);
         metric.warn(inout out, world.commands.get_or(i, model.empty_command()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.snapshots.len() {
         metric.observe(inout out, snapshot_projection(borrow world, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -108,9 +108,9 @@ fn observe_pairs(inout out: metric.Metric, borrow world: model.World) {
             let dy = if left.y > right.y { left.y - right.y } else { right.y - left.y };
             metric.observe(inout out, @intCast(dx + dy) +
                 left.faction * 3 + right.faction * 5 + MODE(), i + j + 1);
-            j = j + 1;
+            j += 1;
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -125,17 +125,17 @@ fn observe_factions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.entities.len() {
             let entity = world.entities.get_or(i, model.empty_entity());
             if entity.faction == faction && entity.alive {
-                agents = agents + 1;
-                health = health + entity.health;
-                energy = energy + entity.energy;
-                inventory = inventory + entity.inventory;
+                agents += 1;
+                health += entity.health;
+                energy += entity.energy;
+                inventory += entity.inventory;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = agents * (MODE() % 11 + 1) + health * 3 +
             energy * 5 + inventory * 7 + faction;
         metric.observe(inout out, projection, faction + MODE() % 5 + 1);
-        faction = faction + 1;
+        faction += 1;
     }
 }
 
@@ -150,17 +150,17 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
-                tiles = tiles + 1;
+                tiles += 1;
                 if tile.walkable { walkable = walkable + 1; }
-                resources = resources + tile.resource;
-                elevation = elevation + tile.height;
+                resources += tile.resource;
+                elevation += tile.height;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = tiles * (MODE() % 13 + 1) + walkable * 3 +
             resources * 5 + elevation * 7 + region;
         metric.observe(inout out, projection, region % 7 + 1);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/audit_world_entropy.rue
+++ b/examples/caldera/audit_world_entropy.rue
@@ -151,7 +151,7 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
                 tiles += 1;
-                if tile.walkable { walkable = walkable + 1; }
+                if tile.walkable { walkable += 1; }
                 resources += tile.resource;
                 elevation += tile.height;
             }

--- a/examples/caldera/audit_world_entropy.rue
+++ b/examples/caldera/audit_world_entropy.rue
@@ -63,7 +63,7 @@ fn observe_entities(inout out: metric.Metric, borrow world: model.World) {
         metric.observe(inout out, entity_projection(borrow world, i), (i % 11) + 1);
         metric.warn(inout out, item.alive && (item.x < 0 || item.y < 0 ||
             @intCast(item.x) >= world.width || @intCast(item.y) >= world.height));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -73,7 +73,7 @@ fn observe_tiles(inout out: metric.Metric, borrow world: model.World) {
         let item = world.tiles.get_or(i, model.empty_tile());
         metric.observe(inout out, tile_projection(borrow world, i), (i % 13) + 1);
         metric.warn(inout out, item.x >= world.width || item.y >= world.height);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -82,18 +82,18 @@ fn observe_timeline(inout out: metric.Metric, borrow world: model.World) {
     while i < world.events.len() {
         metric.observe(inout out, event_projection(borrow world, i), (i % 5) + 1);
         metric.warn(inout out, world.events.get_or(i, model.empty_event()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
         metric.observe(inout out, command_projection(borrow world, i), (i % 7) + 1);
         metric.warn(inout out, world.commands.get_or(i, model.empty_command()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.snapshots.len() {
         metric.observe(inout out, snapshot_projection(borrow world, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -108,9 +108,9 @@ fn observe_pairs(inout out: metric.Metric, borrow world: model.World) {
             let dy = if left.y > right.y { left.y - right.y } else { right.y - left.y };
             metric.observe(inout out, @intCast(dx + dy) +
                 left.faction * 3 + right.faction * 5 + MODE(), i + j + 1);
-            j = j + 1;
+            j += 1;
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -125,17 +125,17 @@ fn observe_factions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.entities.len() {
             let entity = world.entities.get_or(i, model.empty_entity());
             if entity.faction == faction && entity.alive {
-                agents = agents + 1;
-                health = health + entity.health;
-                energy = energy + entity.energy;
-                inventory = inventory + entity.inventory;
+                agents += 1;
+                health += entity.health;
+                energy += entity.energy;
+                inventory += entity.inventory;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = agents * (MODE() % 11 + 1) + health * 3 +
             energy * 5 + inventory * 7 + faction;
         metric.observe(inout out, projection, faction + MODE() % 5 + 1);
-        faction = faction + 1;
+        faction += 1;
     }
 }
 
@@ -150,17 +150,17 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
-                tiles = tiles + 1;
+                tiles += 1;
                 if tile.walkable { walkable = walkable + 1; }
-                resources = resources + tile.resource;
-                elevation = elevation + tile.height;
+                resources += tile.resource;
+                elevation += tile.height;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = tiles * (MODE() % 13 + 1) + walkable * 3 +
             resources * 5 + elevation * 7 + region;
         metric.observe(inout out, projection, region % 7 + 1);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/audit_world_fanout.rue
+++ b/examples/caldera/audit_world_fanout.rue
@@ -151,7 +151,7 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
                 tiles += 1;
-                if tile.walkable { walkable = walkable + 1; }
+                if tile.walkable { walkable += 1; }
                 resources += tile.resource;
                 elevation += tile.height;
             }

--- a/examples/caldera/audit_world_fanout.rue
+++ b/examples/caldera/audit_world_fanout.rue
@@ -63,7 +63,7 @@ fn observe_entities(inout out: metric.Metric, borrow world: model.World) {
         metric.observe(inout out, entity_projection(borrow world, i), (i % 11) + 1);
         metric.warn(inout out, item.alive && (item.x < 0 || item.y < 0 ||
             @intCast(item.x) >= world.width || @intCast(item.y) >= world.height));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -73,7 +73,7 @@ fn observe_tiles(inout out: metric.Metric, borrow world: model.World) {
         let item = world.tiles.get_or(i, model.empty_tile());
         metric.observe(inout out, tile_projection(borrow world, i), (i % 13) + 1);
         metric.warn(inout out, item.x >= world.width || item.y >= world.height);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -82,18 +82,18 @@ fn observe_timeline(inout out: metric.Metric, borrow world: model.World) {
     while i < world.events.len() {
         metric.observe(inout out, event_projection(borrow world, i), (i % 5) + 1);
         metric.warn(inout out, world.events.get_or(i, model.empty_event()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
         metric.observe(inout out, command_projection(borrow world, i), (i % 7) + 1);
         metric.warn(inout out, world.commands.get_or(i, model.empty_command()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.snapshots.len() {
         metric.observe(inout out, snapshot_projection(borrow world, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -108,9 +108,9 @@ fn observe_pairs(inout out: metric.Metric, borrow world: model.World) {
             let dy = if left.y > right.y { left.y - right.y } else { right.y - left.y };
             metric.observe(inout out, @intCast(dx + dy) +
                 left.faction * 3 + right.faction * 5 + MODE(), i + j + 1);
-            j = j + 1;
+            j += 1;
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -125,17 +125,17 @@ fn observe_factions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.entities.len() {
             let entity = world.entities.get_or(i, model.empty_entity());
             if entity.faction == faction && entity.alive {
-                agents = agents + 1;
-                health = health + entity.health;
-                energy = energy + entity.energy;
-                inventory = inventory + entity.inventory;
+                agents += 1;
+                health += entity.health;
+                energy += entity.energy;
+                inventory += entity.inventory;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = agents * (MODE() % 11 + 1) + health * 3 +
             energy * 5 + inventory * 7 + faction;
         metric.observe(inout out, projection, faction + MODE() % 5 + 1);
-        faction = faction + 1;
+        faction += 1;
     }
 }
 
@@ -150,17 +150,17 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
-                tiles = tiles + 1;
+                tiles += 1;
                 if tile.walkable { walkable = walkable + 1; }
-                resources = resources + tile.resource;
-                elevation = elevation + tile.height;
+                resources += tile.resource;
+                elevation += tile.height;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = tiles * (MODE() % 13 + 1) + walkable * 3 +
             resources * 5 + elevation * 7 + region;
         metric.observe(inout out, projection, region % 7 + 1);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/audit_world_integrity.rue
+++ b/examples/caldera/audit_world_integrity.rue
@@ -151,7 +151,7 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
                 tiles += 1;
-                if tile.walkable { walkable = walkable + 1; }
+                if tile.walkable { walkable += 1; }
                 resources += tile.resource;
                 elevation += tile.height;
             }

--- a/examples/caldera/audit_world_integrity.rue
+++ b/examples/caldera/audit_world_integrity.rue
@@ -63,7 +63,7 @@ fn observe_entities(inout out: metric.Metric, borrow world: model.World) {
         metric.observe(inout out, entity_projection(borrow world, i), (i % 11) + 1);
         metric.warn(inout out, item.alive && (item.x < 0 || item.y < 0 ||
             @intCast(item.x) >= world.width || @intCast(item.y) >= world.height));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -73,7 +73,7 @@ fn observe_tiles(inout out: metric.Metric, borrow world: model.World) {
         let item = world.tiles.get_or(i, model.empty_tile());
         metric.observe(inout out, tile_projection(borrow world, i), (i % 13) + 1);
         metric.warn(inout out, item.x >= world.width || item.y >= world.height);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -82,18 +82,18 @@ fn observe_timeline(inout out: metric.Metric, borrow world: model.World) {
     while i < world.events.len() {
         metric.observe(inout out, event_projection(borrow world, i), (i % 5) + 1);
         metric.warn(inout out, world.events.get_or(i, model.empty_event()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
         metric.observe(inout out, command_projection(borrow world, i), (i % 7) + 1);
         metric.warn(inout out, world.commands.get_or(i, model.empty_command()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.snapshots.len() {
         metric.observe(inout out, snapshot_projection(borrow world, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -108,9 +108,9 @@ fn observe_pairs(inout out: metric.Metric, borrow world: model.World) {
             let dy = if left.y > right.y { left.y - right.y } else { right.y - left.y };
             metric.observe(inout out, @intCast(dx + dy) +
                 left.faction * 3 + right.faction * 5 + MODE(), i + j + 1);
-            j = j + 1;
+            j += 1;
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -125,17 +125,17 @@ fn observe_factions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.entities.len() {
             let entity = world.entities.get_or(i, model.empty_entity());
             if entity.faction == faction && entity.alive {
-                agents = agents + 1;
-                health = health + entity.health;
-                energy = energy + entity.energy;
-                inventory = inventory + entity.inventory;
+                agents += 1;
+                health += entity.health;
+                energy += entity.energy;
+                inventory += entity.inventory;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = agents * (MODE() % 11 + 1) + health * 3 +
             energy * 5 + inventory * 7 + faction;
         metric.observe(inout out, projection, faction + MODE() % 5 + 1);
-        faction = faction + 1;
+        faction += 1;
     }
 }
 
@@ -150,17 +150,17 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
-                tiles = tiles + 1;
+                tiles += 1;
                 if tile.walkable { walkable = walkable + 1; }
-                resources = resources + tile.resource;
-                elevation = elevation + tile.height;
+                resources += tile.resource;
+                elevation += tile.height;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = tiles * (MODE() % 13 + 1) + walkable * 3 +
             resources * 5 + elevation * 7 + region;
         metric.observe(inout out, projection, region % 7 + 1);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/audit_world_latency.rue
+++ b/examples/caldera/audit_world_latency.rue
@@ -151,7 +151,7 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
                 tiles += 1;
-                if tile.walkable { walkable = walkable + 1; }
+                if tile.walkable { walkable += 1; }
                 resources += tile.resource;
                 elevation += tile.height;
             }

--- a/examples/caldera/audit_world_latency.rue
+++ b/examples/caldera/audit_world_latency.rue
@@ -63,7 +63,7 @@ fn observe_entities(inout out: metric.Metric, borrow world: model.World) {
         metric.observe(inout out, entity_projection(borrow world, i), (i % 11) + 1);
         metric.warn(inout out, item.alive && (item.x < 0 || item.y < 0 ||
             @intCast(item.x) >= world.width || @intCast(item.y) >= world.height));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -73,7 +73,7 @@ fn observe_tiles(inout out: metric.Metric, borrow world: model.World) {
         let item = world.tiles.get_or(i, model.empty_tile());
         metric.observe(inout out, tile_projection(borrow world, i), (i % 13) + 1);
         metric.warn(inout out, item.x >= world.width || item.y >= world.height);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -82,18 +82,18 @@ fn observe_timeline(inout out: metric.Metric, borrow world: model.World) {
     while i < world.events.len() {
         metric.observe(inout out, event_projection(borrow world, i), (i % 5) + 1);
         metric.warn(inout out, world.events.get_or(i, model.empty_event()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
         metric.observe(inout out, command_projection(borrow world, i), (i % 7) + 1);
         metric.warn(inout out, world.commands.get_or(i, model.empty_command()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.snapshots.len() {
         metric.observe(inout out, snapshot_projection(borrow world, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -108,9 +108,9 @@ fn observe_pairs(inout out: metric.Metric, borrow world: model.World) {
             let dy = if left.y > right.y { left.y - right.y } else { right.y - left.y };
             metric.observe(inout out, @intCast(dx + dy) +
                 left.faction * 3 + right.faction * 5 + MODE(), i + j + 1);
-            j = j + 1;
+            j += 1;
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -125,17 +125,17 @@ fn observe_factions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.entities.len() {
             let entity = world.entities.get_or(i, model.empty_entity());
             if entity.faction == faction && entity.alive {
-                agents = agents + 1;
-                health = health + entity.health;
-                energy = energy + entity.energy;
-                inventory = inventory + entity.inventory;
+                agents += 1;
+                health += entity.health;
+                energy += entity.energy;
+                inventory += entity.inventory;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = agents * (MODE() % 11 + 1) + health * 3 +
             energy * 5 + inventory * 7 + faction;
         metric.observe(inout out, projection, faction + MODE() % 5 + 1);
-        faction = faction + 1;
+        faction += 1;
     }
 }
 
@@ -150,17 +150,17 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
-                tiles = tiles + 1;
+                tiles += 1;
                 if tile.walkable { walkable = walkable + 1; }
-                resources = resources + tile.resource;
-                elevation = elevation + tile.height;
+                resources += tile.resource;
+                elevation += tile.height;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = tiles * (MODE() % 13 + 1) + walkable * 3 +
             resources * 5 + elevation * 7 + region;
         metric.observe(inout out, projection, region % 7 + 1);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/audit_world_locality.rue
+++ b/examples/caldera/audit_world_locality.rue
@@ -151,7 +151,7 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
                 tiles += 1;
-                if tile.walkable { walkable = walkable + 1; }
+                if tile.walkable { walkable += 1; }
                 resources += tile.resource;
                 elevation += tile.height;
             }

--- a/examples/caldera/audit_world_locality.rue
+++ b/examples/caldera/audit_world_locality.rue
@@ -63,7 +63,7 @@ fn observe_entities(inout out: metric.Metric, borrow world: model.World) {
         metric.observe(inout out, entity_projection(borrow world, i), (i % 11) + 1);
         metric.warn(inout out, item.alive && (item.x < 0 || item.y < 0 ||
             @intCast(item.x) >= world.width || @intCast(item.y) >= world.height));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -73,7 +73,7 @@ fn observe_tiles(inout out: metric.Metric, borrow world: model.World) {
         let item = world.tiles.get_or(i, model.empty_tile());
         metric.observe(inout out, tile_projection(borrow world, i), (i % 13) + 1);
         metric.warn(inout out, item.x >= world.width || item.y >= world.height);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -82,18 +82,18 @@ fn observe_timeline(inout out: metric.Metric, borrow world: model.World) {
     while i < world.events.len() {
         metric.observe(inout out, event_projection(borrow world, i), (i % 5) + 1);
         metric.warn(inout out, world.events.get_or(i, model.empty_event()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
         metric.observe(inout out, command_projection(borrow world, i), (i % 7) + 1);
         metric.warn(inout out, world.commands.get_or(i, model.empty_command()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.snapshots.len() {
         metric.observe(inout out, snapshot_projection(borrow world, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -108,9 +108,9 @@ fn observe_pairs(inout out: metric.Metric, borrow world: model.World) {
             let dy = if left.y > right.y { left.y - right.y } else { right.y - left.y };
             metric.observe(inout out, @intCast(dx + dy) +
                 left.faction * 3 + right.faction * 5 + MODE(), i + j + 1);
-            j = j + 1;
+            j += 1;
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -125,17 +125,17 @@ fn observe_factions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.entities.len() {
             let entity = world.entities.get_or(i, model.empty_entity());
             if entity.faction == faction && entity.alive {
-                agents = agents + 1;
-                health = health + entity.health;
-                energy = energy + entity.energy;
-                inventory = inventory + entity.inventory;
+                agents += 1;
+                health += entity.health;
+                energy += entity.energy;
+                inventory += entity.inventory;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = agents * (MODE() % 11 + 1) + health * 3 +
             energy * 5 + inventory * 7 + faction;
         metric.observe(inout out, projection, faction + MODE() % 5 + 1);
-        faction = faction + 1;
+        faction += 1;
     }
 }
 
@@ -150,17 +150,17 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
-                tiles = tiles + 1;
+                tiles += 1;
                 if tile.walkable { walkable = walkable + 1; }
-                resources = resources + tile.resource;
-                elevation = elevation + tile.height;
+                resources += tile.resource;
+                elevation += tile.height;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = tiles * (MODE() % 13 + 1) + walkable * 3 +
             resources * 5 + elevation * 7 + region;
         metric.observe(inout out, projection, region % 7 + 1);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/audit_world_pressure.rue
+++ b/examples/caldera/audit_world_pressure.rue
@@ -151,7 +151,7 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
                 tiles += 1;
-                if tile.walkable { walkable = walkable + 1; }
+                if tile.walkable { walkable += 1; }
                 resources += tile.resource;
                 elevation += tile.height;
             }

--- a/examples/caldera/audit_world_pressure.rue
+++ b/examples/caldera/audit_world_pressure.rue
@@ -63,7 +63,7 @@ fn observe_entities(inout out: metric.Metric, borrow world: model.World) {
         metric.observe(inout out, entity_projection(borrow world, i), (i % 11) + 1);
         metric.warn(inout out, item.alive && (item.x < 0 || item.y < 0 ||
             @intCast(item.x) >= world.width || @intCast(item.y) >= world.height));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -73,7 +73,7 @@ fn observe_tiles(inout out: metric.Metric, borrow world: model.World) {
         let item = world.tiles.get_or(i, model.empty_tile());
         metric.observe(inout out, tile_projection(borrow world, i), (i % 13) + 1);
         metric.warn(inout out, item.x >= world.width || item.y >= world.height);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -82,18 +82,18 @@ fn observe_timeline(inout out: metric.Metric, borrow world: model.World) {
     while i < world.events.len() {
         metric.observe(inout out, event_projection(borrow world, i), (i % 5) + 1);
         metric.warn(inout out, world.events.get_or(i, model.empty_event()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
         metric.observe(inout out, command_projection(borrow world, i), (i % 7) + 1);
         metric.warn(inout out, world.commands.get_or(i, model.empty_command()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.snapshots.len() {
         metric.observe(inout out, snapshot_projection(borrow world, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -108,9 +108,9 @@ fn observe_pairs(inout out: metric.Metric, borrow world: model.World) {
             let dy = if left.y > right.y { left.y - right.y } else { right.y - left.y };
             metric.observe(inout out, @intCast(dx + dy) +
                 left.faction * 3 + right.faction * 5 + MODE(), i + j + 1);
-            j = j + 1;
+            j += 1;
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -125,17 +125,17 @@ fn observe_factions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.entities.len() {
             let entity = world.entities.get_or(i, model.empty_entity());
             if entity.faction == faction && entity.alive {
-                agents = agents + 1;
-                health = health + entity.health;
-                energy = energy + entity.energy;
-                inventory = inventory + entity.inventory;
+                agents += 1;
+                health += entity.health;
+                energy += entity.energy;
+                inventory += entity.inventory;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = agents * (MODE() % 11 + 1) + health * 3 +
             energy * 5 + inventory * 7 + faction;
         metric.observe(inout out, projection, faction + MODE() % 5 + 1);
-        faction = faction + 1;
+        faction += 1;
     }
 }
 
@@ -150,17 +150,17 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
-                tiles = tiles + 1;
+                tiles += 1;
                 if tile.walkable { walkable = walkable + 1; }
-                resources = resources + tile.resource;
-                elevation = elevation + tile.height;
+                resources += tile.resource;
+                elevation += tile.height;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = tiles * (MODE() % 13 + 1) + walkable * 3 +
             resources * 5 + elevation * 7 + region;
         metric.observe(inout out, projection, region % 7 + 1);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/audit_world_risk.rue
+++ b/examples/caldera/audit_world_risk.rue
@@ -151,7 +151,7 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
                 tiles += 1;
-                if tile.walkable { walkable = walkable + 1; }
+                if tile.walkable { walkable += 1; }
                 resources += tile.resource;
                 elevation += tile.height;
             }

--- a/examples/caldera/audit_world_risk.rue
+++ b/examples/caldera/audit_world_risk.rue
@@ -63,7 +63,7 @@ fn observe_entities(inout out: metric.Metric, borrow world: model.World) {
         metric.observe(inout out, entity_projection(borrow world, i), (i % 11) + 1);
         metric.warn(inout out, item.alive && (item.x < 0 || item.y < 0 ||
             @intCast(item.x) >= world.width || @intCast(item.y) >= world.height));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -73,7 +73,7 @@ fn observe_tiles(inout out: metric.Metric, borrow world: model.World) {
         let item = world.tiles.get_or(i, model.empty_tile());
         metric.observe(inout out, tile_projection(borrow world, i), (i % 13) + 1);
         metric.warn(inout out, item.x >= world.width || item.y >= world.height);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -82,18 +82,18 @@ fn observe_timeline(inout out: metric.Metric, borrow world: model.World) {
     while i < world.events.len() {
         metric.observe(inout out, event_projection(borrow world, i), (i % 5) + 1);
         metric.warn(inout out, world.events.get_or(i, model.empty_event()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
         metric.observe(inout out, command_projection(borrow world, i), (i % 7) + 1);
         metric.warn(inout out, world.commands.get_or(i, model.empty_command()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.snapshots.len() {
         metric.observe(inout out, snapshot_projection(borrow world, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -108,9 +108,9 @@ fn observe_pairs(inout out: metric.Metric, borrow world: model.World) {
             let dy = if left.y > right.y { left.y - right.y } else { right.y - left.y };
             metric.observe(inout out, @intCast(dx + dy) +
                 left.faction * 3 + right.faction * 5 + MODE(), i + j + 1);
-            j = j + 1;
+            j += 1;
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -125,17 +125,17 @@ fn observe_factions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.entities.len() {
             let entity = world.entities.get_or(i, model.empty_entity());
             if entity.faction == faction && entity.alive {
-                agents = agents + 1;
-                health = health + entity.health;
-                energy = energy + entity.energy;
-                inventory = inventory + entity.inventory;
+                agents += 1;
+                health += entity.health;
+                energy += entity.energy;
+                inventory += entity.inventory;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = agents * (MODE() % 11 + 1) + health * 3 +
             energy * 5 + inventory * 7 + faction;
         metric.observe(inout out, projection, faction + MODE() % 5 + 1);
-        faction = faction + 1;
+        faction += 1;
     }
 }
 
@@ -150,17 +150,17 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
-                tiles = tiles + 1;
+                tiles += 1;
                 if tile.walkable { walkable = walkable + 1; }
-                resources = resources + tile.resource;
-                elevation = elevation + tile.height;
+                resources += tile.resource;
+                elevation += tile.height;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = tiles * (MODE() % 13 + 1) + walkable * 3 +
             resources * 5 + elevation * 7 + region;
         metric.observe(inout out, projection, region % 7 + 1);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/audit_world_skew.rue
+++ b/examples/caldera/audit_world_skew.rue
@@ -151,7 +151,7 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
                 tiles += 1;
-                if tile.walkable { walkable = walkable + 1; }
+                if tile.walkable { walkable += 1; }
                 resources += tile.resource;
                 elevation += tile.height;
             }

--- a/examples/caldera/audit_world_skew.rue
+++ b/examples/caldera/audit_world_skew.rue
@@ -63,7 +63,7 @@ fn observe_entities(inout out: metric.Metric, borrow world: model.World) {
         metric.observe(inout out, entity_projection(borrow world, i), (i % 11) + 1);
         metric.warn(inout out, item.alive && (item.x < 0 || item.y < 0 ||
             @intCast(item.x) >= world.width || @intCast(item.y) >= world.height));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -73,7 +73,7 @@ fn observe_tiles(inout out: metric.Metric, borrow world: model.World) {
         let item = world.tiles.get_or(i, model.empty_tile());
         metric.observe(inout out, tile_projection(borrow world, i), (i % 13) + 1);
         metric.warn(inout out, item.x >= world.width || item.y >= world.height);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -82,18 +82,18 @@ fn observe_timeline(inout out: metric.Metric, borrow world: model.World) {
     while i < world.events.len() {
         metric.observe(inout out, event_projection(borrow world, i), (i % 5) + 1);
         metric.warn(inout out, world.events.get_or(i, model.empty_event()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
         metric.observe(inout out, command_projection(borrow world, i), (i % 7) + 1);
         metric.warn(inout out, world.commands.get_or(i, model.empty_command()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.snapshots.len() {
         metric.observe(inout out, snapshot_projection(borrow world, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -108,9 +108,9 @@ fn observe_pairs(inout out: metric.Metric, borrow world: model.World) {
             let dy = if left.y > right.y { left.y - right.y } else { right.y - left.y };
             metric.observe(inout out, @intCast(dx + dy) +
                 left.faction * 3 + right.faction * 5 + MODE(), i + j + 1);
-            j = j + 1;
+            j += 1;
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -125,17 +125,17 @@ fn observe_factions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.entities.len() {
             let entity = world.entities.get_or(i, model.empty_entity());
             if entity.faction == faction && entity.alive {
-                agents = agents + 1;
-                health = health + entity.health;
-                energy = energy + entity.energy;
-                inventory = inventory + entity.inventory;
+                agents += 1;
+                health += entity.health;
+                energy += entity.energy;
+                inventory += entity.inventory;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = agents * (MODE() % 11 + 1) + health * 3 +
             energy * 5 + inventory * 7 + faction;
         metric.observe(inout out, projection, faction + MODE() % 5 + 1);
-        faction = faction + 1;
+        faction += 1;
     }
 }
 
@@ -150,17 +150,17 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
-                tiles = tiles + 1;
+                tiles += 1;
                 if tile.walkable { walkable = walkable + 1; }
-                resources = resources + tile.resource;
-                elevation = elevation + tile.height;
+                resources += tile.resource;
+                elevation += tile.height;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = tiles * (MODE() % 13 + 1) + walkable * 3 +
             resources * 5 + elevation * 7 + region;
         metric.observe(inout out, projection, region % 7 + 1);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/audit_world_stability.rue
+++ b/examples/caldera/audit_world_stability.rue
@@ -151,7 +151,7 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
                 tiles += 1;
-                if tile.walkable { walkable = walkable + 1; }
+                if tile.walkable { walkable += 1; }
                 resources += tile.resource;
                 elevation += tile.height;
             }

--- a/examples/caldera/audit_world_stability.rue
+++ b/examples/caldera/audit_world_stability.rue
@@ -63,7 +63,7 @@ fn observe_entities(inout out: metric.Metric, borrow world: model.World) {
         metric.observe(inout out, entity_projection(borrow world, i), (i % 11) + 1);
         metric.warn(inout out, item.alive && (item.x < 0 || item.y < 0 ||
             @intCast(item.x) >= world.width || @intCast(item.y) >= world.height));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -73,7 +73,7 @@ fn observe_tiles(inout out: metric.Metric, borrow world: model.World) {
         let item = world.tiles.get_or(i, model.empty_tile());
         metric.observe(inout out, tile_projection(borrow world, i), (i % 13) + 1);
         metric.warn(inout out, item.x >= world.width || item.y >= world.height);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -82,18 +82,18 @@ fn observe_timeline(inout out: metric.Metric, borrow world: model.World) {
     while i < world.events.len() {
         metric.observe(inout out, event_projection(borrow world, i), (i % 5) + 1);
         metric.warn(inout out, world.events.get_or(i, model.empty_event()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
         metric.observe(inout out, command_projection(borrow world, i), (i % 7) + 1);
         metric.warn(inout out, world.commands.get_or(i, model.empty_command()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.snapshots.len() {
         metric.observe(inout out, snapshot_projection(borrow world, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -108,9 +108,9 @@ fn observe_pairs(inout out: metric.Metric, borrow world: model.World) {
             let dy = if left.y > right.y { left.y - right.y } else { right.y - left.y };
             metric.observe(inout out, @intCast(dx + dy) +
                 left.faction * 3 + right.faction * 5 + MODE(), i + j + 1);
-            j = j + 1;
+            j += 1;
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -125,17 +125,17 @@ fn observe_factions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.entities.len() {
             let entity = world.entities.get_or(i, model.empty_entity());
             if entity.faction == faction && entity.alive {
-                agents = agents + 1;
-                health = health + entity.health;
-                energy = energy + entity.energy;
-                inventory = inventory + entity.inventory;
+                agents += 1;
+                health += entity.health;
+                energy += entity.energy;
+                inventory += entity.inventory;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = agents * (MODE() % 11 + 1) + health * 3 +
             energy * 5 + inventory * 7 + faction;
         metric.observe(inout out, projection, faction + MODE() % 5 + 1);
-        faction = faction + 1;
+        faction += 1;
     }
 }
 
@@ -150,17 +150,17 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
-                tiles = tiles + 1;
+                tiles += 1;
                 if tile.walkable { walkable = walkable + 1; }
-                resources = resources + tile.resource;
-                elevation = elevation + tile.height;
+                resources += tile.resource;
+                elevation += tile.height;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = tiles * (MODE() % 13 + 1) + walkable * 3 +
             resources * 5 + elevation * 7 + region;
         metric.observe(inout out, projection, region % 7 + 1);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/audit_world_throughput.rue
+++ b/examples/caldera/audit_world_throughput.rue
@@ -151,7 +151,7 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
                 tiles += 1;
-                if tile.walkable { walkable = walkable + 1; }
+                if tile.walkable { walkable += 1; }
                 resources += tile.resource;
                 elevation += tile.height;
             }

--- a/examples/caldera/audit_world_throughput.rue
+++ b/examples/caldera/audit_world_throughput.rue
@@ -63,7 +63,7 @@ fn observe_entities(inout out: metric.Metric, borrow world: model.World) {
         metric.observe(inout out, entity_projection(borrow world, i), (i % 11) + 1);
         metric.warn(inout out, item.alive && (item.x < 0 || item.y < 0 ||
             @intCast(item.x) >= world.width || @intCast(item.y) >= world.height));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -73,7 +73,7 @@ fn observe_tiles(inout out: metric.Metric, borrow world: model.World) {
         let item = world.tiles.get_or(i, model.empty_tile());
         metric.observe(inout out, tile_projection(borrow world, i), (i % 13) + 1);
         metric.warn(inout out, item.x >= world.width || item.y >= world.height);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -82,18 +82,18 @@ fn observe_timeline(inout out: metric.Metric, borrow world: model.World) {
     while i < world.events.len() {
         metric.observe(inout out, event_projection(borrow world, i), (i % 5) + 1);
         metric.warn(inout out, world.events.get_or(i, model.empty_event()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
         metric.observe(inout out, command_projection(borrow world, i), (i % 7) + 1);
         metric.warn(inout out, world.commands.get_or(i, model.empty_command()).tick > world.tick);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.snapshots.len() {
         metric.observe(inout out, snapshot_projection(borrow world, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -108,9 +108,9 @@ fn observe_pairs(inout out: metric.Metric, borrow world: model.World) {
             let dy = if left.y > right.y { left.y - right.y } else { right.y - left.y };
             metric.observe(inout out, @intCast(dx + dy) +
                 left.faction * 3 + right.faction * 5 + MODE(), i + j + 1);
-            j = j + 1;
+            j += 1;
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -125,17 +125,17 @@ fn observe_factions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.entities.len() {
             let entity = world.entities.get_or(i, model.empty_entity());
             if entity.faction == faction && entity.alive {
-                agents = agents + 1;
-                health = health + entity.health;
-                energy = energy + entity.energy;
-                inventory = inventory + entity.inventory;
+                agents += 1;
+                health += entity.health;
+                energy += entity.energy;
+                inventory += entity.inventory;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = agents * (MODE() % 11 + 1) + health * 3 +
             energy * 5 + inventory * 7 + faction;
         metric.observe(inout out, projection, faction + MODE() % 5 + 1);
-        faction = faction + 1;
+        faction += 1;
     }
 }
 
@@ -150,17 +150,17 @@ fn observe_regions(inout out: metric.Metric, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region {
-                tiles = tiles + 1;
+                tiles += 1;
                 if tile.walkable { walkable = walkable + 1; }
-                resources = resources + tile.resource;
-                elevation = elevation + tile.height;
+                resources += tile.resource;
+                elevation += tile.height;
             }
-            i = i + 1;
+            i += 1;
         }
         let projection = tiles * (MODE() % 13 + 1) + walkable * 3 +
             resources * 5 + elevation * 7 + region;
         metric.observe(inout out, projection, region % 7 + 1);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/behavior_builder_assist.rue
+++ b/examples/caldera/behavior_builder_assist.rue
@@ -58,13 +58,13 @@ pub fn evaluate(borrow world: model.World) -> result.Result {
             score >= (PROFILE() % 13) + entity.kind;
         result.record(inout out, selected, score,
             selected && transition(borrow world, borrow entity, score));
-        i = i + 1;
+        i += 1;
     }
     let mut faction: u64 = 1;
     while faction <= 3 {
         let proxy = world.resources / faction + world.treasury / (faction + 1) + PROFILE();
         result.record(inout out, proxy % 2 == 0, proxy, proxy % 5 == 0);
-        faction = faction + 1;
+        faction += 1;
     }
     result.finish(inout out); out
 }

--- a/examples/caldera/behavior_builder_celebrate.rue
+++ b/examples/caldera/behavior_builder_celebrate.rue
@@ -58,13 +58,13 @@ pub fn evaluate(borrow world: model.World) -> result.Result {
             score >= (PROFILE() % 13) + entity.kind;
         result.record(inout out, selected, score,
             selected && transition(borrow world, borrow entity, score));
-        i = i + 1;
+        i += 1;
     }
     let mut faction: u64 = 1;
     while faction <= 3 {
         let proxy = world.resources / faction + world.treasury / (faction + 1) + PROFILE();
         result.record(inout out, proxy % 2 == 0, proxy, proxy % 5 == 0);
-        faction = faction + 1;
+        faction += 1;
     }
     result.finish(inout out); out
 }

--- a/examples/caldera/behavior_builder_construct.rue
+++ b/examples/caldera/behavior_builder_construct.rue
@@ -58,13 +58,13 @@ pub fn evaluate(borrow world: model.World) -> result.Result {
             score >= (PROFILE() % 13) + entity.kind;
         result.record(inout out, selected, score,
             selected && transition(borrow world, borrow entity, score));
-        i = i + 1;
+        i += 1;
     }
     let mut faction: u64 = 1;
     while faction <= 3 {
         let proxy = world.resources / faction + world.treasury / (faction + 1) + PROFILE();
         result.record(inout out, proxy % 2 == 0, proxy, proxy % 5 == 0);
-        faction = faction + 1;
+        faction += 1;
     }
     result.finish(inout out); out
 }

--- a/examples/caldera/behavior_builder_coordinate.rue
+++ b/examples/caldera/behavior_builder_coordinate.rue
@@ -58,13 +58,13 @@ pub fn evaluate(borrow world: model.World) -> result.Result {
             score >= (PROFILE() % 13) + entity.kind;
         result.record(inout out, selected, score,
             selected && transition(borrow world, borrow entity, score));
-        i = i + 1;
+        i += 1;
     }
     let mut faction: u64 = 1;
     while faction <= 3 {
         let proxy = world.resources / faction + world.treasury / (faction + 1) + PROFILE();
         result.record(inout out, proxy % 2 == 0, proxy, proxy % 5 == 0);
-        faction = faction + 1;
+        faction += 1;
     }
     result.finish(inout out); out
 }

--- a/examples/caldera/behavior_builder_craft.rue
+++ b/examples/caldera/behavior_builder_craft.rue
@@ -58,13 +58,13 @@ pub fn evaluate(borrow world: model.World) -> result.Result {
             score >= (PROFILE() % 13) + entity.kind;
         result.record(inout out, selected, score,
             selected && transition(borrow world, borrow entity, score));
-        i = i + 1;
+        i += 1;
     }
     let mut faction: u64 = 1;
     while faction <= 3 {
         let proxy = world.resources / faction + world.treasury / (faction + 1) + PROFILE();
         result.record(inout out, proxy % 2 == 0, proxy, proxy % 5 == 0);
-        faction = faction + 1;
+        faction += 1;
     }
     result.finish(inout out); out
 }

--- a/examples/caldera/behavior_builder_defend.rue
+++ b/examples/caldera/behavior_builder_defend.rue
@@ -58,13 +58,13 @@ pub fn evaluate(borrow world: model.World) -> result.Result {
             score >= (PROFILE() % 13) + entity.kind;
         result.record(inout out, selected, score,
             selected && transition(borrow world, borrow entity, score));
-        i = i + 1;
+        i += 1;
     }
     let mut faction: u64 = 1;
     while faction <= 3 {
         let proxy = world.resources / faction + world.treasury / (faction + 1) + PROFILE();
         result.record(inout out, proxy % 2 == 0, proxy, proxy % 5 == 0);
-        faction = faction + 1;
+        faction += 1;
     }
     result.finish(inout out); out
 }

--- a/examples/caldera/behavior_builder_deliver.rue
+++ b/examples/caldera/behavior_builder_deliver.rue
@@ -58,13 +58,13 @@ pub fn evaluate(borrow world: model.World) -> result.Result {
             score >= (PROFILE() % 13) + entity.kind;
         result.record(inout out, selected, score,
             selected && transition(borrow world, borrow entity, score));
-        i = i + 1;
+        i += 1;
     }
     let mut faction: u64 = 1;
     while faction <= 3 {
         let proxy = world.resources / faction + world.treasury / (faction + 1) + PROFILE();
         result.record(inout out, proxy % 2 == 0, proxy, proxy % 5 == 0);
-        faction = faction + 1;
+        faction += 1;
     }
     result.finish(inout out); out
 }

--- a/examples/caldera/behavior_builder_evade.rue
+++ b/examples/caldera/behavior_builder_evade.rue
@@ -58,13 +58,13 @@ pub fn evaluate(borrow world: model.World) -> result.Result {
             score >= (PROFILE() % 13) + entity.kind;
         result.record(inout out, selected, score,
             selected && transition(borrow world, borrow entity, score));
-        i = i + 1;
+        i += 1;
     }
     let mut faction: u64 = 1;
     while faction <= 3 {
         let proxy = world.resources / faction + world.treasury / (faction + 1) + PROFILE();
         result.record(inout out, proxy % 2 == 0, proxy, proxy % 5 == 0);
-        faction = faction + 1;
+        faction += 1;
     }
     result.finish(inout out); out
 }

--- a/examples/caldera/behavior_builder_explore.rue
+++ b/examples/caldera/behavior_builder_explore.rue
@@ -58,13 +58,13 @@ pub fn evaluate(borrow world: model.World) -> result.Result {
             score >= (PROFILE() % 13) + entity.kind;
         result.record(inout out, selected, score,
             selected && transition(borrow world, borrow entity, score));
-        i = i + 1;
+        i += 1;
     }
     let mut faction: u64 = 1;
     while faction <= 3 {
         let proxy = world.resources / faction + world.treasury / (faction + 1) + PROFILE();
         result.record(inout out, proxy % 2 == 0, proxy, proxy % 5 == 0);
-        faction = faction + 1;
+        faction += 1;
     }
     result.finish(inout out); out
 }

--- a/examples/caldera/behavior_builder_gather.rue
+++ b/examples/caldera/behavior_builder_gather.rue
@@ -58,13 +58,13 @@ pub fn evaluate(borrow world: model.World) -> result.Result {
             score >= (PROFILE() % 13) + entity.kind;
         result.record(inout out, selected, score,
             selected && transition(borrow world, borrow entity, score));
-        i = i + 1;
+        i += 1;
     }
     let mut faction: u64 = 1;
     while faction <= 3 {
         let proxy = world.resources / faction + world.treasury / (faction + 1) + PROFILE();
         result.record(inout out, proxy % 2 == 0, proxy, proxy % 5 == 0);
-        faction = faction + 1;
+        faction += 1;
     }
     result.finish(inout out); out
 }

--- a/examples/caldera/behavior_builder_idle.rue
+++ b/examples/caldera/behavior_builder_idle.rue
@@ -58,13 +58,13 @@ pub fn evaluate(borrow world: model.World) -> result.Result {
             score >= (PROFILE() % 13) + entity.kind;
         result.record(inout out, selected, score,
             selected && transition(borrow world, borrow entity, score));
-        i = i + 1;
+        i += 1;
     }
     let mut faction: u64 = 1;
     while faction <= 3 {
         let proxy = world.resources / faction + world.treasury / (faction + 1) + PROFILE();
         result.record(inout out, proxy % 2 == 0, proxy, proxy % 5 == 0);
-        faction = faction + 1;
+        faction += 1;
     }
     result.finish(inout out); out
 }

--- a/examples/caldera/behavior_builder_learn.rue
+++ b/examples/caldera/behavior_builder_learn.rue
@@ -58,13 +58,13 @@ pub fn evaluate(borrow world: model.World) -> result.Result {
             score >= (PROFILE() % 13) + entity.kind;
         result.record(inout out, selected, score,
             selected && transition(borrow world, borrow entity, score));
-        i = i + 1;
+        i += 1;
     }
     let mut faction: u64 = 1;
     while faction <= 3 {
         let proxy = world.resources / faction + world.treasury / (faction + 1) + PROFILE();
         result.record(inout out, proxy % 2 == 0, proxy, proxy % 5 == 0);
-        faction = faction + 1;
+        faction += 1;
     }
     result.finish(inout out); out
 }

--- a/examples/caldera/behavior_builder_pursue.rue
+++ b/examples/caldera/behavior_builder_pursue.rue
@@ -58,13 +58,13 @@ pub fn evaluate(borrow world: model.World) -> result.Result {
             score >= (PROFILE() % 13) + entity.kind;
         result.record(inout out, selected, score,
             selected && transition(borrow world, borrow entity, score));
-        i = i + 1;
+        i += 1;
     }
     let mut faction: u64 = 1;
     while faction <= 3 {
         let proxy = world.resources / faction + world.treasury / (faction + 1) + PROFILE();
         result.record(inout out, proxy % 2 == 0, proxy, proxy % 5 == 0);
-        faction = faction + 1;
+        faction += 1;
     }
     result.finish(inout out); out
 }

--- a/examples/caldera/behavior_builder_repair.rue
+++ b/examples/caldera/behavior_builder_repair.rue
@@ -58,13 +58,13 @@ pub fn evaluate(borrow world: model.World) -> result.Result {
             score >= (PROFILE() % 13) + entity.kind;
         result.record(inout out, selected, score,
             selected && transition(borrow world, borrow entity, score));
-        i = i + 1;
+        i += 1;
     }
     let mut faction: u64 = 1;
     while faction <= 3 {
         let proxy = world.resources / faction + world.treasury / (faction + 1) + PROFILE();
         result.record(inout out, proxy % 2 == 0, proxy, proxy % 5 == 0);
-        faction = faction + 1;
+        faction += 1;
     }
     result.finish(inout out); out
 }

--- a/examples/caldera/behavior_builder_rest.rue
+++ b/examples/caldera/behavior_builder_rest.rue
@@ -58,13 +58,13 @@ pub fn evaluate(borrow world: model.World) -> result.Result {
             score >= (PROFILE() % 13) + entity.kind;
         result.record(inout out, selected, score,
             selected && transition(borrow world, borrow entity, score));
-        i = i + 1;
+        i += 1;
     }
     let mut faction: u64 = 1;
     while faction <= 3 {
         let proxy = world.resources / faction + world.treasury / (faction + 1) + PROFILE();
         result.record(inout out, proxy % 2 == 0, proxy, proxy % 5 == 0);
-        faction = faction + 1;
+        faction += 1;
     }
     result.finish(inout out); out
 }

--- a/examples/caldera/behavior_builder_trade.rue
+++ b/examples/caldera/behavior_builder_trade.rue
@@ -58,13 +58,13 @@ pub fn evaluate(borrow world: model.World) -> result.Result {
             score >= (PROFILE() % 13) + entity.kind;
         result.record(inout out, selected, score,
             selected && transition(borrow world, borrow entity, score));
-        i = i + 1;
+        i += 1;
     }
     let mut faction: u64 = 1;
     while faction <= 3 {
         let proxy = world.resources / faction + world.treasury / (faction + 1) + PROFILE();
         result.record(inout out, proxy % 2 == 0, proxy, proxy % 5 == 0);
-        faction = faction + 1;
+        faction += 1;
     }
     result.finish(inout out); out
 }

--- a/examples/caldera/behavior_citizen_assist.rue
+++ b/examples/caldera/behavior_citizen_assist.rue
@@ -58,13 +58,13 @@ pub fn evaluate(borrow world: model.World) -> result.Result {
             score >= (PROFILE() % 13) + entity.kind;
         result.record(inout out, selected, score,
             selected && transition(borrow world, borrow entity, score));
-        i = i + 1;
+        i += 1;
     }
     let mut faction: u64 = 1;
     while faction <= 3 {
         let proxy = world.resources / faction + world.treasury / (faction + 1) + PROFILE();
         result.record(inout out, proxy % 2 == 0, proxy, proxy % 5 == 0);
-        faction = faction + 1;
+        faction += 1;
     }
     result.finish(inout out); out
 }

--- a/examples/caldera/behavior_citizen_celebrate.rue
+++ b/examples/caldera/behavior_citizen_celebrate.rue
@@ -58,13 +58,13 @@ pub fn evaluate(borrow world: model.World) -> result.Result {
             score >= (PROFILE() % 13) + entity.kind;
         result.record(inout out, selected, score,
             selected && transition(borrow world, borrow entity, score));
-        i = i + 1;
+        i += 1;
     }
     let mut faction: u64 = 1;
     while faction <= 3 {
         let proxy = world.resources / faction + world.treasury / (faction + 1) + PROFILE();
         result.record(inout out, proxy % 2 == 0, proxy, proxy % 5 == 0);
-        faction = faction + 1;
+        faction += 1;
     }
     result.finish(inout out); out
 }

--- a/examples/caldera/behavior_citizen_construct.rue
+++ b/examples/caldera/behavior_citizen_construct.rue
@@ -58,13 +58,13 @@ pub fn evaluate(borrow world: model.World) -> result.Result {
             score >= (PROFILE() % 13) + entity.kind;
         result.record(inout out, selected, score,
             selected && transition(borrow world, borrow entity, score));
-        i = i + 1;
+        i += 1;
     }
     let mut faction: u64 = 1;
     while faction <= 3 {
         let proxy = world.resources / faction + world.treasury / (faction + 1) + PROFILE();
         result.record(inout out, proxy % 2 == 0, proxy, proxy % 5 == 0);
-        faction = faction + 1;
+        faction += 1;
     }
     result.finish(inout out); out
 }

--- a/examples/caldera/behavior_citizen_coordinate.rue
+++ b/examples/caldera/behavior_citizen_coordinate.rue
@@ -58,13 +58,13 @@ pub fn evaluate(borrow world: model.World) -> result.Result {
             score >= (PROFILE() % 13) + entity.kind;
         result.record(inout out, selected, score,
             selected && transition(borrow world, borrow entity, score));
-        i = i + 1;
+        i += 1;
     }
     let mut faction: u64 = 1;
     while faction <= 3 {
         let proxy = world.resources / faction + world.treasury / (faction + 1) + PROFILE();
         result.record(inout out, proxy % 2 == 0, proxy, proxy % 5 == 0);
-        faction = faction + 1;
+        faction += 1;
     }
     result.finish(inout out); out
 }

--- a/examples/caldera/behavior_citizen_craft.rue
+++ b/examples/caldera/behavior_citizen_craft.rue
@@ -58,13 +58,13 @@ pub fn evaluate(borrow world: model.World) -> result.Result {
             score >= (PROFILE() % 13) + entity.kind;
         result.record(inout out, selected, score,
             selected && transition(borrow world, borrow entity, score));
-        i = i + 1;
+        i += 1;
     }
     let mut faction: u64 = 1;
     while faction <= 3 {
         let proxy = world.resources / faction + world.treasury / (faction + 1) + PROFILE();
         result.record(inout out, proxy % 2 == 0, proxy, proxy % 5 == 0);
-        faction = faction + 1;
+        faction += 1;
     }
     result.finish(inout out); out
 }

--- a/examples/caldera/behavior_citizen_defend.rue
+++ b/examples/caldera/behavior_citizen_defend.rue
@@ -58,13 +58,13 @@ pub fn evaluate(borrow world: model.World) -> result.Result {
             score >= (PROFILE() % 13) + entity.kind;
         result.record(inout out, selected, score,
             selected && transition(borrow world, borrow entity, score));
-        i = i + 1;
+        i += 1;
     }
     let mut faction: u64 = 1;
     while faction <= 3 {
         let proxy = world.resources / faction + world.treasury / (faction + 1) + PROFILE();
         result.record(inout out, proxy % 2 == 0, proxy, proxy % 5 == 0);
-        faction = faction + 1;
+        faction += 1;
     }
     result.finish(inout out); out
 }

--- a/examples/caldera/behavior_citizen_deliver.rue
+++ b/examples/caldera/behavior_citizen_deliver.rue
@@ -58,13 +58,13 @@ pub fn evaluate(borrow world: model.World) -> result.Result {
             score >= (PROFILE() % 13) + entity.kind;
         result.record(inout out, selected, score,
             selected && transition(borrow world, borrow entity, score));
-        i = i + 1;
+        i += 1;
     }
     let mut faction: u64 = 1;
     while faction <= 3 {
         let proxy = world.resources / faction + world.treasury / (faction + 1) + PROFILE();
         result.record(inout out, proxy % 2 == 0, proxy, proxy % 5 == 0);
-        faction = faction + 1;
+        faction += 1;
     }
     result.finish(inout out); out
 }

--- a/examples/caldera/behavior_citizen_evade.rue
+++ b/examples/caldera/behavior_citizen_evade.rue
@@ -58,13 +58,13 @@ pub fn evaluate(borrow world: model.World) -> result.Result {
             score >= (PROFILE() % 13) + entity.kind;
         result.record(inout out, selected, score,
             selected && transition(borrow world, borrow entity, score));
-        i = i + 1;
+        i += 1;
     }
     let mut faction: u64 = 1;
     while faction <= 3 {
         let proxy = world.resources / faction + world.treasury / (faction + 1) + PROFILE();
         result.record(inout out, proxy % 2 == 0, proxy, proxy % 5 == 0);
-        faction = faction + 1;
+        faction += 1;
     }
     result.finish(inout out); out
 }

--- a/examples/caldera/behavior_citizen_explore.rue
+++ b/examples/caldera/behavior_citizen_explore.rue
@@ -58,13 +58,13 @@ pub fn evaluate(borrow world: model.World) -> result.Result {
             score >= (PROFILE() % 13) + entity.kind;
         result.record(inout out, selected, score,
             selected && transition(borrow world, borrow entity, score));
-        i = i + 1;
+        i += 1;
     }
     let mut faction: u64 = 1;
     while faction <= 3 {
         let proxy = world.resources / faction + world.treasury / (faction + 1) + PROFILE();
         result.record(inout out, proxy % 2 == 0, proxy, proxy % 5 == 0);
-        faction = faction + 1;
+        faction += 1;
     }
     result.finish(inout out); out
 }

--- a/examples/caldera/behavior_citizen_gather.rue
+++ b/examples/caldera/behavior_citizen_gather.rue
@@ -58,13 +58,13 @@ pub fn evaluate(borrow world: model.World) -> result.Result {
             score >= (PROFILE() % 13) + entity.kind;
         result.record(inout out, selected, score,
             selected && transition(borrow world, borrow entity, score));
-        i = i + 1;
+        i += 1;
     }
     let mut faction: u64 = 1;
     while faction <= 3 {
         let proxy = world.resources / faction + world.treasury / (faction + 1) + PROFILE();
         result.record(inout out, proxy % 2 == 0, proxy, proxy % 5 == 0);
-        faction = faction + 1;
+        faction += 1;
     }
     result.finish(inout out); out
 }

--- a/examples/caldera/behavior_citizen_idle.rue
+++ b/examples/caldera/behavior_citizen_idle.rue
@@ -58,13 +58,13 @@ pub fn evaluate(borrow world: model.World) -> result.Result {
             score >= (PROFILE() % 13) + entity.kind;
         result.record(inout out, selected, score,
             selected && transition(borrow world, borrow entity, score));
-        i = i + 1;
+        i += 1;
     }
     let mut faction: u64 = 1;
     while faction <= 3 {
         let proxy = world.resources / faction + world.treasury / (faction + 1) + PROFILE();
         result.record(inout out, proxy % 2 == 0, proxy, proxy % 5 == 0);
-        faction = faction + 1;
+        faction += 1;
     }
     result.finish(inout out); out
 }

--- a/examples/caldera/behavior_citizen_learn.rue
+++ b/examples/caldera/behavior_citizen_learn.rue
@@ -58,13 +58,13 @@ pub fn evaluate(borrow world: model.World) -> result.Result {
             score >= (PROFILE() % 13) + entity.kind;
         result.record(inout out, selected, score,
             selected && transition(borrow world, borrow entity, score));
-        i = i + 1;
+        i += 1;
     }
     let mut faction: u64 = 1;
     while faction <= 3 {
         let proxy = world.resources / faction + world.treasury / (faction + 1) + PROFILE();
         result.record(inout out, proxy % 2 == 0, proxy, proxy % 5 == 0);
-        faction = faction + 1;
+        faction += 1;
     }
     result.finish(inout out); out
 }

--- a/examples/caldera/behavior_citizen_pursue.rue
+++ b/examples/caldera/behavior_citizen_pursue.rue
@@ -58,13 +58,13 @@ pub fn evaluate(borrow world: model.World) -> result.Result {
             score >= (PROFILE() % 13) + entity.kind;
         result.record(inout out, selected, score,
             selected && transition(borrow world, borrow entity, score));
-        i = i + 1;
+        i += 1;
     }
     let mut faction: u64 = 1;
     while faction <= 3 {
         let proxy = world.resources / faction + world.treasury / (faction + 1) + PROFILE();
         result.record(inout out, proxy % 2 == 0, proxy, proxy % 5 == 0);
-        faction = faction + 1;
+        faction += 1;
     }
     result.finish(inout out); out
 }

--- a/examples/caldera/behavior_citizen_repair.rue
+++ b/examples/caldera/behavior_citizen_repair.rue
@@ -58,13 +58,13 @@ pub fn evaluate(borrow world: model.World) -> result.Result {
             score >= (PROFILE() % 13) + entity.kind;
         result.record(inout out, selected, score,
             selected && transition(borrow world, borrow entity, score));
-        i = i + 1;
+        i += 1;
     }
     let mut faction: u64 = 1;
     while faction <= 3 {
         let proxy = world.resources / faction + world.treasury / (faction + 1) + PROFILE();
         result.record(inout out, proxy % 2 == 0, proxy, proxy % 5 == 0);
-        faction = faction + 1;
+        faction += 1;
     }
     result.finish(inout out); out
 }

--- a/examples/caldera/behavior_citizen_rest.rue
+++ b/examples/caldera/behavior_citizen_rest.rue
@@ -58,13 +58,13 @@ pub fn evaluate(borrow world: model.World) -> result.Result {
             score >= (PROFILE() % 13) + entity.kind;
         result.record(inout out, selected, score,
             selected && transition(borrow world, borrow entity, score));
-        i = i + 1;
+        i += 1;
     }
     let mut faction: u64 = 1;
     while faction <= 3 {
         let proxy = world.resources / faction + world.treasury / (faction + 1) + PROFILE();
         result.record(inout out, proxy % 2 == 0, proxy, proxy % 5 == 0);
-        faction = faction + 1;
+        faction += 1;
     }
     result.finish(inout out); out
 }

--- a/examples/caldera/behavior_citizen_trade.rue
+++ b/examples/caldera/behavior_citizen_trade.rue
@@ -58,13 +58,13 @@ pub fn evaluate(borrow world: model.World) -> result.Result {
             score >= (PROFILE() % 13) + entity.kind;
         result.record(inout out, selected, score,
             selected && transition(borrow world, borrow entity, score));
-        i = i + 1;
+        i += 1;
     }
     let mut faction: u64 = 1;
     while faction <= 3 {
         let proxy = world.resources / faction + world.treasury / (faction + 1) + PROFILE();
         result.record(inout out, proxy % 2 == 0, proxy, proxy % 5 == 0);
-        faction = faction + 1;
+        faction += 1;
     }
     result.finish(inout out); out
 }

--- a/examples/caldera/behavior_guard_assist.rue
+++ b/examples/caldera/behavior_guard_assist.rue
@@ -58,13 +58,13 @@ pub fn evaluate(borrow world: model.World) -> result.Result {
             score >= (PROFILE() % 13) + entity.kind;
         result.record(inout out, selected, score,
             selected && transition(borrow world, borrow entity, score));
-        i = i + 1;
+        i += 1;
     }
     let mut faction: u64 = 1;
     while faction <= 3 {
         let proxy = world.resources / faction + world.treasury / (faction + 1) + PROFILE();
         result.record(inout out, proxy % 2 == 0, proxy, proxy % 5 == 0);
-        faction = faction + 1;
+        faction += 1;
     }
     result.finish(inout out); out
 }

--- a/examples/caldera/behavior_guard_celebrate.rue
+++ b/examples/caldera/behavior_guard_celebrate.rue
@@ -58,13 +58,13 @@ pub fn evaluate(borrow world: model.World) -> result.Result {
             score >= (PROFILE() % 13) + entity.kind;
         result.record(inout out, selected, score,
             selected && transition(borrow world, borrow entity, score));
-        i = i + 1;
+        i += 1;
     }
     let mut faction: u64 = 1;
     while faction <= 3 {
         let proxy = world.resources / faction + world.treasury / (faction + 1) + PROFILE();
         result.record(inout out, proxy % 2 == 0, proxy, proxy % 5 == 0);
-        faction = faction + 1;
+        faction += 1;
     }
     result.finish(inout out); out
 }

--- a/examples/caldera/behavior_guard_construct.rue
+++ b/examples/caldera/behavior_guard_construct.rue
@@ -58,13 +58,13 @@ pub fn evaluate(borrow world: model.World) -> result.Result {
             score >= (PROFILE() % 13) + entity.kind;
         result.record(inout out, selected, score,
             selected && transition(borrow world, borrow entity, score));
-        i = i + 1;
+        i += 1;
     }
     let mut faction: u64 = 1;
     while faction <= 3 {
         let proxy = world.resources / faction + world.treasury / (faction + 1) + PROFILE();
         result.record(inout out, proxy % 2 == 0, proxy, proxy % 5 == 0);
-        faction = faction + 1;
+        faction += 1;
     }
     result.finish(inout out); out
 }

--- a/examples/caldera/behavior_guard_coordinate.rue
+++ b/examples/caldera/behavior_guard_coordinate.rue
@@ -58,13 +58,13 @@ pub fn evaluate(borrow world: model.World) -> result.Result {
             score >= (PROFILE() % 13) + entity.kind;
         result.record(inout out, selected, score,
             selected && transition(borrow world, borrow entity, score));
-        i = i + 1;
+        i += 1;
     }
     let mut faction: u64 = 1;
     while faction <= 3 {
         let proxy = world.resources / faction + world.treasury / (faction + 1) + PROFILE();
         result.record(inout out, proxy % 2 == 0, proxy, proxy % 5 == 0);
-        faction = faction + 1;
+        faction += 1;
     }
     result.finish(inout out); out
 }

--- a/examples/caldera/behavior_guard_craft.rue
+++ b/examples/caldera/behavior_guard_craft.rue
@@ -58,13 +58,13 @@ pub fn evaluate(borrow world: model.World) -> result.Result {
             score >= (PROFILE() % 13) + entity.kind;
         result.record(inout out, selected, score,
             selected && transition(borrow world, borrow entity, score));
-        i = i + 1;
+        i += 1;
     }
     let mut faction: u64 = 1;
     while faction <= 3 {
         let proxy = world.resources / faction + world.treasury / (faction + 1) + PROFILE();
         result.record(inout out, proxy % 2 == 0, proxy, proxy % 5 == 0);
-        faction = faction + 1;
+        faction += 1;
     }
     result.finish(inout out); out
 }

--- a/examples/caldera/behavior_guard_defend.rue
+++ b/examples/caldera/behavior_guard_defend.rue
@@ -58,13 +58,13 @@ pub fn evaluate(borrow world: model.World) -> result.Result {
             score >= (PROFILE() % 13) + entity.kind;
         result.record(inout out, selected, score,
             selected && transition(borrow world, borrow entity, score));
-        i = i + 1;
+        i += 1;
     }
     let mut faction: u64 = 1;
     while faction <= 3 {
         let proxy = world.resources / faction + world.treasury / (faction + 1) + PROFILE();
         result.record(inout out, proxy % 2 == 0, proxy, proxy % 5 == 0);
-        faction = faction + 1;
+        faction += 1;
     }
     result.finish(inout out); out
 }

--- a/examples/caldera/behavior_guard_deliver.rue
+++ b/examples/caldera/behavior_guard_deliver.rue
@@ -58,13 +58,13 @@ pub fn evaluate(borrow world: model.World) -> result.Result {
             score >= (PROFILE() % 13) + entity.kind;
         result.record(inout out, selected, score,
             selected && transition(borrow world, borrow entity, score));
-        i = i + 1;
+        i += 1;
     }
     let mut faction: u64 = 1;
     while faction <= 3 {
         let proxy = world.resources / faction + world.treasury / (faction + 1) + PROFILE();
         result.record(inout out, proxy % 2 == 0, proxy, proxy % 5 == 0);
-        faction = faction + 1;
+        faction += 1;
     }
     result.finish(inout out); out
 }

--- a/examples/caldera/behavior_guard_evade.rue
+++ b/examples/caldera/behavior_guard_evade.rue
@@ -58,13 +58,13 @@ pub fn evaluate(borrow world: model.World) -> result.Result {
             score >= (PROFILE() % 13) + entity.kind;
         result.record(inout out, selected, score,
             selected && transition(borrow world, borrow entity, score));
-        i = i + 1;
+        i += 1;
     }
     let mut faction: u64 = 1;
     while faction <= 3 {
         let proxy = world.resources / faction + world.treasury / (faction + 1) + PROFILE();
         result.record(inout out, proxy % 2 == 0, proxy, proxy % 5 == 0);
-        faction = faction + 1;
+        faction += 1;
     }
     result.finish(inout out); out
 }

--- a/examples/caldera/behavior_guard_explore.rue
+++ b/examples/caldera/behavior_guard_explore.rue
@@ -58,13 +58,13 @@ pub fn evaluate(borrow world: model.World) -> result.Result {
             score >= (PROFILE() % 13) + entity.kind;
         result.record(inout out, selected, score,
             selected && transition(borrow world, borrow entity, score));
-        i = i + 1;
+        i += 1;
     }
     let mut faction: u64 = 1;
     while faction <= 3 {
         let proxy = world.resources / faction + world.treasury / (faction + 1) + PROFILE();
         result.record(inout out, proxy % 2 == 0, proxy, proxy % 5 == 0);
-        faction = faction + 1;
+        faction += 1;
     }
     result.finish(inout out); out
 }

--- a/examples/caldera/behavior_guard_gather.rue
+++ b/examples/caldera/behavior_guard_gather.rue
@@ -58,13 +58,13 @@ pub fn evaluate(borrow world: model.World) -> result.Result {
             score >= (PROFILE() % 13) + entity.kind;
         result.record(inout out, selected, score,
             selected && transition(borrow world, borrow entity, score));
-        i = i + 1;
+        i += 1;
     }
     let mut faction: u64 = 1;
     while faction <= 3 {
         let proxy = world.resources / faction + world.treasury / (faction + 1) + PROFILE();
         result.record(inout out, proxy % 2 == 0, proxy, proxy % 5 == 0);
-        faction = faction + 1;
+        faction += 1;
     }
     result.finish(inout out); out
 }

--- a/examples/caldera/behavior_guard_idle.rue
+++ b/examples/caldera/behavior_guard_idle.rue
@@ -58,13 +58,13 @@ pub fn evaluate(borrow world: model.World) -> result.Result {
             score >= (PROFILE() % 13) + entity.kind;
         result.record(inout out, selected, score,
             selected && transition(borrow world, borrow entity, score));
-        i = i + 1;
+        i += 1;
     }
     let mut faction: u64 = 1;
     while faction <= 3 {
         let proxy = world.resources / faction + world.treasury / (faction + 1) + PROFILE();
         result.record(inout out, proxy % 2 == 0, proxy, proxy % 5 == 0);
-        faction = faction + 1;
+        faction += 1;
     }
     result.finish(inout out); out
 }

--- a/examples/caldera/behavior_guard_learn.rue
+++ b/examples/caldera/behavior_guard_learn.rue
@@ -58,13 +58,13 @@ pub fn evaluate(borrow world: model.World) -> result.Result {
             score >= (PROFILE() % 13) + entity.kind;
         result.record(inout out, selected, score,
             selected && transition(borrow world, borrow entity, score));
-        i = i + 1;
+        i += 1;
     }
     let mut faction: u64 = 1;
     while faction <= 3 {
         let proxy = world.resources / faction + world.treasury / (faction + 1) + PROFILE();
         result.record(inout out, proxy % 2 == 0, proxy, proxy % 5 == 0);
-        faction = faction + 1;
+        faction += 1;
     }
     result.finish(inout out); out
 }

--- a/examples/caldera/behavior_guard_pursue.rue
+++ b/examples/caldera/behavior_guard_pursue.rue
@@ -58,13 +58,13 @@ pub fn evaluate(borrow world: model.World) -> result.Result {
             score >= (PROFILE() % 13) + entity.kind;
         result.record(inout out, selected, score,
             selected && transition(borrow world, borrow entity, score));
-        i = i + 1;
+        i += 1;
     }
     let mut faction: u64 = 1;
     while faction <= 3 {
         let proxy = world.resources / faction + world.treasury / (faction + 1) + PROFILE();
         result.record(inout out, proxy % 2 == 0, proxy, proxy % 5 == 0);
-        faction = faction + 1;
+        faction += 1;
     }
     result.finish(inout out); out
 }

--- a/examples/caldera/behavior_guard_repair.rue
+++ b/examples/caldera/behavior_guard_repair.rue
@@ -58,13 +58,13 @@ pub fn evaluate(borrow world: model.World) -> result.Result {
             score >= (PROFILE() % 13) + entity.kind;
         result.record(inout out, selected, score,
             selected && transition(borrow world, borrow entity, score));
-        i = i + 1;
+        i += 1;
     }
     let mut faction: u64 = 1;
     while faction <= 3 {
         let proxy = world.resources / faction + world.treasury / (faction + 1) + PROFILE();
         result.record(inout out, proxy % 2 == 0, proxy, proxy % 5 == 0);
-        faction = faction + 1;
+        faction += 1;
     }
     result.finish(inout out); out
 }

--- a/examples/caldera/behavior_guard_rest.rue
+++ b/examples/caldera/behavior_guard_rest.rue
@@ -58,13 +58,13 @@ pub fn evaluate(borrow world: model.World) -> result.Result {
             score >= (PROFILE() % 13) + entity.kind;
         result.record(inout out, selected, score,
             selected && transition(borrow world, borrow entity, score));
-        i = i + 1;
+        i += 1;
     }
     let mut faction: u64 = 1;
     while faction <= 3 {
         let proxy = world.resources / faction + world.treasury / (faction + 1) + PROFILE();
         result.record(inout out, proxy % 2 == 0, proxy, proxy % 5 == 0);
-        faction = faction + 1;
+        faction += 1;
     }
     result.finish(inout out); out
 }

--- a/examples/caldera/behavior_guard_trade.rue
+++ b/examples/caldera/behavior_guard_trade.rue
@@ -58,13 +58,13 @@ pub fn evaluate(borrow world: model.World) -> result.Result {
             score >= (PROFILE() % 13) + entity.kind;
         result.record(inout out, selected, score,
             selected && transition(borrow world, borrow entity, score));
-        i = i + 1;
+        i += 1;
     }
     let mut faction: u64 = 1;
     while faction <= 3 {
         let proxy = world.resources / faction + world.treasury / (faction + 1) + PROFILE();
         result.record(inout out, proxy % 2 == 0, proxy, proxy % 5 == 0);
-        faction = faction + 1;
+        faction += 1;
     }
     result.finish(inout out); out
 }

--- a/examples/caldera/behavior_healer_assist.rue
+++ b/examples/caldera/behavior_healer_assist.rue
@@ -58,13 +58,13 @@ pub fn evaluate(borrow world: model.World) -> result.Result {
             score >= (PROFILE() % 13) + entity.kind;
         result.record(inout out, selected, score,
             selected && transition(borrow world, borrow entity, score));
-        i = i + 1;
+        i += 1;
     }
     let mut faction: u64 = 1;
     while faction <= 3 {
         let proxy = world.resources / faction + world.treasury / (faction + 1) + PROFILE();
         result.record(inout out, proxy % 2 == 0, proxy, proxy % 5 == 0);
-        faction = faction + 1;
+        faction += 1;
     }
     result.finish(inout out); out
 }

--- a/examples/caldera/behavior_healer_celebrate.rue
+++ b/examples/caldera/behavior_healer_celebrate.rue
@@ -58,13 +58,13 @@ pub fn evaluate(borrow world: model.World) -> result.Result {
             score >= (PROFILE() % 13) + entity.kind;
         result.record(inout out, selected, score,
             selected && transition(borrow world, borrow entity, score));
-        i = i + 1;
+        i += 1;
     }
     let mut faction: u64 = 1;
     while faction <= 3 {
         let proxy = world.resources / faction + world.treasury / (faction + 1) + PROFILE();
         result.record(inout out, proxy % 2 == 0, proxy, proxy % 5 == 0);
-        faction = faction + 1;
+        faction += 1;
     }
     result.finish(inout out); out
 }

--- a/examples/caldera/behavior_healer_construct.rue
+++ b/examples/caldera/behavior_healer_construct.rue
@@ -58,13 +58,13 @@ pub fn evaluate(borrow world: model.World) -> result.Result {
             score >= (PROFILE() % 13) + entity.kind;
         result.record(inout out, selected, score,
             selected && transition(borrow world, borrow entity, score));
-        i = i + 1;
+        i += 1;
     }
     let mut faction: u64 = 1;
     while faction <= 3 {
         let proxy = world.resources / faction + world.treasury / (faction + 1) + PROFILE();
         result.record(inout out, proxy % 2 == 0, proxy, proxy % 5 == 0);
-        faction = faction + 1;
+        faction += 1;
     }
     result.finish(inout out); out
 }

--- a/examples/caldera/behavior_healer_coordinate.rue
+++ b/examples/caldera/behavior_healer_coordinate.rue
@@ -58,13 +58,13 @@ pub fn evaluate(borrow world: model.World) -> result.Result {
             score >= (PROFILE() % 13) + entity.kind;
         result.record(inout out, selected, score,
             selected && transition(borrow world, borrow entity, score));
-        i = i + 1;
+        i += 1;
     }
     let mut faction: u64 = 1;
     while faction <= 3 {
         let proxy = world.resources / faction + world.treasury / (faction + 1) + PROFILE();
         result.record(inout out, proxy % 2 == 0, proxy, proxy % 5 == 0);
-        faction = faction + 1;
+        faction += 1;
     }
     result.finish(inout out); out
 }

--- a/examples/caldera/behavior_healer_craft.rue
+++ b/examples/caldera/behavior_healer_craft.rue
@@ -58,13 +58,13 @@ pub fn evaluate(borrow world: model.World) -> result.Result {
             score >= (PROFILE() % 13) + entity.kind;
         result.record(inout out, selected, score,
             selected && transition(borrow world, borrow entity, score));
-        i = i + 1;
+        i += 1;
     }
     let mut faction: u64 = 1;
     while faction <= 3 {
         let proxy = world.resources / faction + world.treasury / (faction + 1) + PROFILE();
         result.record(inout out, proxy % 2 == 0, proxy, proxy % 5 == 0);
-        faction = faction + 1;
+        faction += 1;
     }
     result.finish(inout out); out
 }

--- a/examples/caldera/behavior_healer_defend.rue
+++ b/examples/caldera/behavior_healer_defend.rue
@@ -58,13 +58,13 @@ pub fn evaluate(borrow world: model.World) -> result.Result {
             score >= (PROFILE() % 13) + entity.kind;
         result.record(inout out, selected, score,
             selected && transition(borrow world, borrow entity, score));
-        i = i + 1;
+        i += 1;
     }
     let mut faction: u64 = 1;
     while faction <= 3 {
         let proxy = world.resources / faction + world.treasury / (faction + 1) + PROFILE();
         result.record(inout out, proxy % 2 == 0, proxy, proxy % 5 == 0);
-        faction = faction + 1;
+        faction += 1;
     }
     result.finish(inout out); out
 }

--- a/examples/caldera/behavior_healer_deliver.rue
+++ b/examples/caldera/behavior_healer_deliver.rue
@@ -58,13 +58,13 @@ pub fn evaluate(borrow world: model.World) -> result.Result {
             score >= (PROFILE() % 13) + entity.kind;
         result.record(inout out, selected, score,
             selected && transition(borrow world, borrow entity, score));
-        i = i + 1;
+        i += 1;
     }
     let mut faction: u64 = 1;
     while faction <= 3 {
         let proxy = world.resources / faction + world.treasury / (faction + 1) + PROFILE();
         result.record(inout out, proxy % 2 == 0, proxy, proxy % 5 == 0);
-        faction = faction + 1;
+        faction += 1;
     }
     result.finish(inout out); out
 }

--- a/examples/caldera/behavior_healer_evade.rue
+++ b/examples/caldera/behavior_healer_evade.rue
@@ -58,13 +58,13 @@ pub fn evaluate(borrow world: model.World) -> result.Result {
             score >= (PROFILE() % 13) + entity.kind;
         result.record(inout out, selected, score,
             selected && transition(borrow world, borrow entity, score));
-        i = i + 1;
+        i += 1;
     }
     let mut faction: u64 = 1;
     while faction <= 3 {
         let proxy = world.resources / faction + world.treasury / (faction + 1) + PROFILE();
         result.record(inout out, proxy % 2 == 0, proxy, proxy % 5 == 0);
-        faction = faction + 1;
+        faction += 1;
     }
     result.finish(inout out); out
 }

--- a/examples/caldera/behavior_healer_explore.rue
+++ b/examples/caldera/behavior_healer_explore.rue
@@ -58,13 +58,13 @@ pub fn evaluate(borrow world: model.World) -> result.Result {
             score >= (PROFILE() % 13) + entity.kind;
         result.record(inout out, selected, score,
             selected && transition(borrow world, borrow entity, score));
-        i = i + 1;
+        i += 1;
     }
     let mut faction: u64 = 1;
     while faction <= 3 {
         let proxy = world.resources / faction + world.treasury / (faction + 1) + PROFILE();
         result.record(inout out, proxy % 2 == 0, proxy, proxy % 5 == 0);
-        faction = faction + 1;
+        faction += 1;
     }
     result.finish(inout out); out
 }

--- a/examples/caldera/behavior_healer_gather.rue
+++ b/examples/caldera/behavior_healer_gather.rue
@@ -58,13 +58,13 @@ pub fn evaluate(borrow world: model.World) -> result.Result {
             score >= (PROFILE() % 13) + entity.kind;
         result.record(inout out, selected, score,
             selected && transition(borrow world, borrow entity, score));
-        i = i + 1;
+        i += 1;
     }
     let mut faction: u64 = 1;
     while faction <= 3 {
         let proxy = world.resources / faction + world.treasury / (faction + 1) + PROFILE();
         result.record(inout out, proxy % 2 == 0, proxy, proxy % 5 == 0);
-        faction = faction + 1;
+        faction += 1;
     }
     result.finish(inout out); out
 }

--- a/examples/caldera/behavior_healer_idle.rue
+++ b/examples/caldera/behavior_healer_idle.rue
@@ -58,13 +58,13 @@ pub fn evaluate(borrow world: model.World) -> result.Result {
             score >= (PROFILE() % 13) + entity.kind;
         result.record(inout out, selected, score,
             selected && transition(borrow world, borrow entity, score));
-        i = i + 1;
+        i += 1;
     }
     let mut faction: u64 = 1;
     while faction <= 3 {
         let proxy = world.resources / faction + world.treasury / (faction + 1) + PROFILE();
         result.record(inout out, proxy % 2 == 0, proxy, proxy % 5 == 0);
-        faction = faction + 1;
+        faction += 1;
     }
     result.finish(inout out); out
 }

--- a/examples/caldera/behavior_healer_learn.rue
+++ b/examples/caldera/behavior_healer_learn.rue
@@ -58,13 +58,13 @@ pub fn evaluate(borrow world: model.World) -> result.Result {
             score >= (PROFILE() % 13) + entity.kind;
         result.record(inout out, selected, score,
             selected && transition(borrow world, borrow entity, score));
-        i = i + 1;
+        i += 1;
     }
     let mut faction: u64 = 1;
     while faction <= 3 {
         let proxy = world.resources / faction + world.treasury / (faction + 1) + PROFILE();
         result.record(inout out, proxy % 2 == 0, proxy, proxy % 5 == 0);
-        faction = faction + 1;
+        faction += 1;
     }
     result.finish(inout out); out
 }

--- a/examples/caldera/behavior_healer_pursue.rue
+++ b/examples/caldera/behavior_healer_pursue.rue
@@ -58,13 +58,13 @@ pub fn evaluate(borrow world: model.World) -> result.Result {
             score >= (PROFILE() % 13) + entity.kind;
         result.record(inout out, selected, score,
             selected && transition(borrow world, borrow entity, score));
-        i = i + 1;
+        i += 1;
     }
     let mut faction: u64 = 1;
     while faction <= 3 {
         let proxy = world.resources / faction + world.treasury / (faction + 1) + PROFILE();
         result.record(inout out, proxy % 2 == 0, proxy, proxy % 5 == 0);
-        faction = faction + 1;
+        faction += 1;
     }
     result.finish(inout out); out
 }

--- a/examples/caldera/behavior_healer_repair.rue
+++ b/examples/caldera/behavior_healer_repair.rue
@@ -58,13 +58,13 @@ pub fn evaluate(borrow world: model.World) -> result.Result {
             score >= (PROFILE() % 13) + entity.kind;
         result.record(inout out, selected, score,
             selected && transition(borrow world, borrow entity, score));
-        i = i + 1;
+        i += 1;
     }
     let mut faction: u64 = 1;
     while faction <= 3 {
         let proxy = world.resources / faction + world.treasury / (faction + 1) + PROFILE();
         result.record(inout out, proxy % 2 == 0, proxy, proxy % 5 == 0);
-        faction = faction + 1;
+        faction += 1;
     }
     result.finish(inout out); out
 }

--- a/examples/caldera/behavior_healer_rest.rue
+++ b/examples/caldera/behavior_healer_rest.rue
@@ -58,13 +58,13 @@ pub fn evaluate(borrow world: model.World) -> result.Result {
             score >= (PROFILE() % 13) + entity.kind;
         result.record(inout out, selected, score,
             selected && transition(borrow world, borrow entity, score));
-        i = i + 1;
+        i += 1;
     }
     let mut faction: u64 = 1;
     while faction <= 3 {
         let proxy = world.resources / faction + world.treasury / (faction + 1) + PROFILE();
         result.record(inout out, proxy % 2 == 0, proxy, proxy % 5 == 0);
-        faction = faction + 1;
+        faction += 1;
     }
     result.finish(inout out); out
 }

--- a/examples/caldera/behavior_healer_trade.rue
+++ b/examples/caldera/behavior_healer_trade.rue
@@ -58,13 +58,13 @@ pub fn evaluate(borrow world: model.World) -> result.Result {
             score >= (PROFILE() % 13) + entity.kind;
         result.record(inout out, selected, score,
             selected && transition(borrow world, borrow entity, score));
-        i = i + 1;
+        i += 1;
     }
     let mut faction: u64 = 1;
     while faction <= 3 {
         let proxy = world.resources / faction + world.treasury / (faction + 1) + PROFILE();
         result.record(inout out, proxy % 2 == 0, proxy, proxy % 5 == 0);
-        faction = faction + 1;
+        faction += 1;
     }
     result.finish(inout out); out
 }

--- a/examples/caldera/behavior_leader_assist.rue
+++ b/examples/caldera/behavior_leader_assist.rue
@@ -58,13 +58,13 @@ pub fn evaluate(borrow world: model.World) -> result.Result {
             score >= (PROFILE() % 13) + entity.kind;
         result.record(inout out, selected, score,
             selected && transition(borrow world, borrow entity, score));
-        i = i + 1;
+        i += 1;
     }
     let mut faction: u64 = 1;
     while faction <= 3 {
         let proxy = world.resources / faction + world.treasury / (faction + 1) + PROFILE();
         result.record(inout out, proxy % 2 == 0, proxy, proxy % 5 == 0);
-        faction = faction + 1;
+        faction += 1;
     }
     result.finish(inout out); out
 }

--- a/examples/caldera/behavior_leader_celebrate.rue
+++ b/examples/caldera/behavior_leader_celebrate.rue
@@ -58,13 +58,13 @@ pub fn evaluate(borrow world: model.World) -> result.Result {
             score >= (PROFILE() % 13) + entity.kind;
         result.record(inout out, selected, score,
             selected && transition(borrow world, borrow entity, score));
-        i = i + 1;
+        i += 1;
     }
     let mut faction: u64 = 1;
     while faction <= 3 {
         let proxy = world.resources / faction + world.treasury / (faction + 1) + PROFILE();
         result.record(inout out, proxy % 2 == 0, proxy, proxy % 5 == 0);
-        faction = faction + 1;
+        faction += 1;
     }
     result.finish(inout out); out
 }

--- a/examples/caldera/behavior_leader_construct.rue
+++ b/examples/caldera/behavior_leader_construct.rue
@@ -58,13 +58,13 @@ pub fn evaluate(borrow world: model.World) -> result.Result {
             score >= (PROFILE() % 13) + entity.kind;
         result.record(inout out, selected, score,
             selected && transition(borrow world, borrow entity, score));
-        i = i + 1;
+        i += 1;
     }
     let mut faction: u64 = 1;
     while faction <= 3 {
         let proxy = world.resources / faction + world.treasury / (faction + 1) + PROFILE();
         result.record(inout out, proxy % 2 == 0, proxy, proxy % 5 == 0);
-        faction = faction + 1;
+        faction += 1;
     }
     result.finish(inout out); out
 }

--- a/examples/caldera/behavior_leader_coordinate.rue
+++ b/examples/caldera/behavior_leader_coordinate.rue
@@ -58,13 +58,13 @@ pub fn evaluate(borrow world: model.World) -> result.Result {
             score >= (PROFILE() % 13) + entity.kind;
         result.record(inout out, selected, score,
             selected && transition(borrow world, borrow entity, score));
-        i = i + 1;
+        i += 1;
     }
     let mut faction: u64 = 1;
     while faction <= 3 {
         let proxy = world.resources / faction + world.treasury / (faction + 1) + PROFILE();
         result.record(inout out, proxy % 2 == 0, proxy, proxy % 5 == 0);
-        faction = faction + 1;
+        faction += 1;
     }
     result.finish(inout out); out
 }

--- a/examples/caldera/behavior_leader_craft.rue
+++ b/examples/caldera/behavior_leader_craft.rue
@@ -58,13 +58,13 @@ pub fn evaluate(borrow world: model.World) -> result.Result {
             score >= (PROFILE() % 13) + entity.kind;
         result.record(inout out, selected, score,
             selected && transition(borrow world, borrow entity, score));
-        i = i + 1;
+        i += 1;
     }
     let mut faction: u64 = 1;
     while faction <= 3 {
         let proxy = world.resources / faction + world.treasury / (faction + 1) + PROFILE();
         result.record(inout out, proxy % 2 == 0, proxy, proxy % 5 == 0);
-        faction = faction + 1;
+        faction += 1;
     }
     result.finish(inout out); out
 }

--- a/examples/caldera/behavior_leader_defend.rue
+++ b/examples/caldera/behavior_leader_defend.rue
@@ -58,13 +58,13 @@ pub fn evaluate(borrow world: model.World) -> result.Result {
             score >= (PROFILE() % 13) + entity.kind;
         result.record(inout out, selected, score,
             selected && transition(borrow world, borrow entity, score));
-        i = i + 1;
+        i += 1;
     }
     let mut faction: u64 = 1;
     while faction <= 3 {
         let proxy = world.resources / faction + world.treasury / (faction + 1) + PROFILE();
         result.record(inout out, proxy % 2 == 0, proxy, proxy % 5 == 0);
-        faction = faction + 1;
+        faction += 1;
     }
     result.finish(inout out); out
 }

--- a/examples/caldera/behavior_leader_deliver.rue
+++ b/examples/caldera/behavior_leader_deliver.rue
@@ -58,13 +58,13 @@ pub fn evaluate(borrow world: model.World) -> result.Result {
             score >= (PROFILE() % 13) + entity.kind;
         result.record(inout out, selected, score,
             selected && transition(borrow world, borrow entity, score));
-        i = i + 1;
+        i += 1;
     }
     let mut faction: u64 = 1;
     while faction <= 3 {
         let proxy = world.resources / faction + world.treasury / (faction + 1) + PROFILE();
         result.record(inout out, proxy % 2 == 0, proxy, proxy % 5 == 0);
-        faction = faction + 1;
+        faction += 1;
     }
     result.finish(inout out); out
 }

--- a/examples/caldera/behavior_leader_evade.rue
+++ b/examples/caldera/behavior_leader_evade.rue
@@ -58,13 +58,13 @@ pub fn evaluate(borrow world: model.World) -> result.Result {
             score >= (PROFILE() % 13) + entity.kind;
         result.record(inout out, selected, score,
             selected && transition(borrow world, borrow entity, score));
-        i = i + 1;
+        i += 1;
     }
     let mut faction: u64 = 1;
     while faction <= 3 {
         let proxy = world.resources / faction + world.treasury / (faction + 1) + PROFILE();
         result.record(inout out, proxy % 2 == 0, proxy, proxy % 5 == 0);
-        faction = faction + 1;
+        faction += 1;
     }
     result.finish(inout out); out
 }

--- a/examples/caldera/behavior_leader_explore.rue
+++ b/examples/caldera/behavior_leader_explore.rue
@@ -58,13 +58,13 @@ pub fn evaluate(borrow world: model.World) -> result.Result {
             score >= (PROFILE() % 13) + entity.kind;
         result.record(inout out, selected, score,
             selected && transition(borrow world, borrow entity, score));
-        i = i + 1;
+        i += 1;
     }
     let mut faction: u64 = 1;
     while faction <= 3 {
         let proxy = world.resources / faction + world.treasury / (faction + 1) + PROFILE();
         result.record(inout out, proxy % 2 == 0, proxy, proxy % 5 == 0);
-        faction = faction + 1;
+        faction += 1;
     }
     result.finish(inout out); out
 }

--- a/examples/caldera/behavior_leader_gather.rue
+++ b/examples/caldera/behavior_leader_gather.rue
@@ -58,13 +58,13 @@ pub fn evaluate(borrow world: model.World) -> result.Result {
             score >= (PROFILE() % 13) + entity.kind;
         result.record(inout out, selected, score,
             selected && transition(borrow world, borrow entity, score));
-        i = i + 1;
+        i += 1;
     }
     let mut faction: u64 = 1;
     while faction <= 3 {
         let proxy = world.resources / faction + world.treasury / (faction + 1) + PROFILE();
         result.record(inout out, proxy % 2 == 0, proxy, proxy % 5 == 0);
-        faction = faction + 1;
+        faction += 1;
     }
     result.finish(inout out); out
 }

--- a/examples/caldera/behavior_leader_idle.rue
+++ b/examples/caldera/behavior_leader_idle.rue
@@ -58,13 +58,13 @@ pub fn evaluate(borrow world: model.World) -> result.Result {
             score >= (PROFILE() % 13) + entity.kind;
         result.record(inout out, selected, score,
             selected && transition(borrow world, borrow entity, score));
-        i = i + 1;
+        i += 1;
     }
     let mut faction: u64 = 1;
     while faction <= 3 {
         let proxy = world.resources / faction + world.treasury / (faction + 1) + PROFILE();
         result.record(inout out, proxy % 2 == 0, proxy, proxy % 5 == 0);
-        faction = faction + 1;
+        faction += 1;
     }
     result.finish(inout out); out
 }

--- a/examples/caldera/behavior_leader_learn.rue
+++ b/examples/caldera/behavior_leader_learn.rue
@@ -58,13 +58,13 @@ pub fn evaluate(borrow world: model.World) -> result.Result {
             score >= (PROFILE() % 13) + entity.kind;
         result.record(inout out, selected, score,
             selected && transition(borrow world, borrow entity, score));
-        i = i + 1;
+        i += 1;
     }
     let mut faction: u64 = 1;
     while faction <= 3 {
         let proxy = world.resources / faction + world.treasury / (faction + 1) + PROFILE();
         result.record(inout out, proxy % 2 == 0, proxy, proxy % 5 == 0);
-        faction = faction + 1;
+        faction += 1;
     }
     result.finish(inout out); out
 }

--- a/examples/caldera/behavior_leader_pursue.rue
+++ b/examples/caldera/behavior_leader_pursue.rue
@@ -58,13 +58,13 @@ pub fn evaluate(borrow world: model.World) -> result.Result {
             score >= (PROFILE() % 13) + entity.kind;
         result.record(inout out, selected, score,
             selected && transition(borrow world, borrow entity, score));
-        i = i + 1;
+        i += 1;
     }
     let mut faction: u64 = 1;
     while faction <= 3 {
         let proxy = world.resources / faction + world.treasury / (faction + 1) + PROFILE();
         result.record(inout out, proxy % 2 == 0, proxy, proxy % 5 == 0);
-        faction = faction + 1;
+        faction += 1;
     }
     result.finish(inout out); out
 }

--- a/examples/caldera/behavior_leader_repair.rue
+++ b/examples/caldera/behavior_leader_repair.rue
@@ -58,13 +58,13 @@ pub fn evaluate(borrow world: model.World) -> result.Result {
             score >= (PROFILE() % 13) + entity.kind;
         result.record(inout out, selected, score,
             selected && transition(borrow world, borrow entity, score));
-        i = i + 1;
+        i += 1;
     }
     let mut faction: u64 = 1;
     while faction <= 3 {
         let proxy = world.resources / faction + world.treasury / (faction + 1) + PROFILE();
         result.record(inout out, proxy % 2 == 0, proxy, proxy % 5 == 0);
-        faction = faction + 1;
+        faction += 1;
     }
     result.finish(inout out); out
 }

--- a/examples/caldera/behavior_leader_rest.rue
+++ b/examples/caldera/behavior_leader_rest.rue
@@ -58,13 +58,13 @@ pub fn evaluate(borrow world: model.World) -> result.Result {
             score >= (PROFILE() % 13) + entity.kind;
         result.record(inout out, selected, score,
             selected && transition(borrow world, borrow entity, score));
-        i = i + 1;
+        i += 1;
     }
     let mut faction: u64 = 1;
     while faction <= 3 {
         let proxy = world.resources / faction + world.treasury / (faction + 1) + PROFILE();
         result.record(inout out, proxy % 2 == 0, proxy, proxy % 5 == 0);
-        faction = faction + 1;
+        faction += 1;
     }
     result.finish(inout out); out
 }

--- a/examples/caldera/behavior_leader_trade.rue
+++ b/examples/caldera/behavior_leader_trade.rue
@@ -58,13 +58,13 @@ pub fn evaluate(borrow world: model.World) -> result.Result {
             score >= (PROFILE() % 13) + entity.kind;
         result.record(inout out, selected, score,
             selected && transition(borrow world, borrow entity, score));
-        i = i + 1;
+        i += 1;
     }
     let mut faction: u64 = 1;
     while faction <= 3 {
         let proxy = world.resources / faction + world.treasury / (faction + 1) + PROFILE();
         result.record(inout out, proxy % 2 == 0, proxy, proxy % 5 == 0);
-        faction = faction + 1;
+        faction += 1;
     }
     result.finish(inout out); out
 }

--- a/examples/caldera/behavior_result.rue
+++ b/examples/caldera/behavior_result.rue
@@ -6,7 +6,7 @@ pub fn new(behavior: u64) -> Result {
         transitions: 0, digest: metric.mix(14695981039346656037, behavior), valid: false }
 }
 pub fn record(inout out: Result, selected: bool, utility: u64, transition: bool) {
-    out.agents = out.agents + 1;
+    out.agents += 1;
     if selected { out.selected = out.selected + 1; }
     if transition { out.transitions = out.transitions + 1; }
     out.utility = @wrapping_add(out.utility, utility);

--- a/examples/caldera/behavior_result.rue
+++ b/examples/caldera/behavior_result.rue
@@ -7,8 +7,8 @@ pub fn new(behavior: u64) -> Result {
 }
 pub fn record(inout out: Result, selected: bool, utility: u64, transition: bool) {
     out.agents += 1;
-    if selected { out.selected = out.selected + 1; }
-    if transition { out.transitions = out.transitions + 1; }
+    if selected { out.selected += 1; }
+    if transition { out.transitions += 1; }
     out.utility = @wrapping_add(out.utility, utility);
     out.digest = metric.mix(out.digest, utility + out.agents * 31);
 }

--- a/examples/caldera/behavior_scout_assist.rue
+++ b/examples/caldera/behavior_scout_assist.rue
@@ -58,13 +58,13 @@ pub fn evaluate(borrow world: model.World) -> result.Result {
             score >= (PROFILE() % 13) + entity.kind;
         result.record(inout out, selected, score,
             selected && transition(borrow world, borrow entity, score));
-        i = i + 1;
+        i += 1;
     }
     let mut faction: u64 = 1;
     while faction <= 3 {
         let proxy = world.resources / faction + world.treasury / (faction + 1) + PROFILE();
         result.record(inout out, proxy % 2 == 0, proxy, proxy % 5 == 0);
-        faction = faction + 1;
+        faction += 1;
     }
     result.finish(inout out); out
 }

--- a/examples/caldera/behavior_scout_celebrate.rue
+++ b/examples/caldera/behavior_scout_celebrate.rue
@@ -58,13 +58,13 @@ pub fn evaluate(borrow world: model.World) -> result.Result {
             score >= (PROFILE() % 13) + entity.kind;
         result.record(inout out, selected, score,
             selected && transition(borrow world, borrow entity, score));
-        i = i + 1;
+        i += 1;
     }
     let mut faction: u64 = 1;
     while faction <= 3 {
         let proxy = world.resources / faction + world.treasury / (faction + 1) + PROFILE();
         result.record(inout out, proxy % 2 == 0, proxy, proxy % 5 == 0);
-        faction = faction + 1;
+        faction += 1;
     }
     result.finish(inout out); out
 }

--- a/examples/caldera/behavior_scout_construct.rue
+++ b/examples/caldera/behavior_scout_construct.rue
@@ -58,13 +58,13 @@ pub fn evaluate(borrow world: model.World) -> result.Result {
             score >= (PROFILE() % 13) + entity.kind;
         result.record(inout out, selected, score,
             selected && transition(borrow world, borrow entity, score));
-        i = i + 1;
+        i += 1;
     }
     let mut faction: u64 = 1;
     while faction <= 3 {
         let proxy = world.resources / faction + world.treasury / (faction + 1) + PROFILE();
         result.record(inout out, proxy % 2 == 0, proxy, proxy % 5 == 0);
-        faction = faction + 1;
+        faction += 1;
     }
     result.finish(inout out); out
 }

--- a/examples/caldera/behavior_scout_coordinate.rue
+++ b/examples/caldera/behavior_scout_coordinate.rue
@@ -58,13 +58,13 @@ pub fn evaluate(borrow world: model.World) -> result.Result {
             score >= (PROFILE() % 13) + entity.kind;
         result.record(inout out, selected, score,
             selected && transition(borrow world, borrow entity, score));
-        i = i + 1;
+        i += 1;
     }
     let mut faction: u64 = 1;
     while faction <= 3 {
         let proxy = world.resources / faction + world.treasury / (faction + 1) + PROFILE();
         result.record(inout out, proxy % 2 == 0, proxy, proxy % 5 == 0);
-        faction = faction + 1;
+        faction += 1;
     }
     result.finish(inout out); out
 }

--- a/examples/caldera/behavior_scout_craft.rue
+++ b/examples/caldera/behavior_scout_craft.rue
@@ -58,13 +58,13 @@ pub fn evaluate(borrow world: model.World) -> result.Result {
             score >= (PROFILE() % 13) + entity.kind;
         result.record(inout out, selected, score,
             selected && transition(borrow world, borrow entity, score));
-        i = i + 1;
+        i += 1;
     }
     let mut faction: u64 = 1;
     while faction <= 3 {
         let proxy = world.resources / faction + world.treasury / (faction + 1) + PROFILE();
         result.record(inout out, proxy % 2 == 0, proxy, proxy % 5 == 0);
-        faction = faction + 1;
+        faction += 1;
     }
     result.finish(inout out); out
 }

--- a/examples/caldera/behavior_scout_defend.rue
+++ b/examples/caldera/behavior_scout_defend.rue
@@ -58,13 +58,13 @@ pub fn evaluate(borrow world: model.World) -> result.Result {
             score >= (PROFILE() % 13) + entity.kind;
         result.record(inout out, selected, score,
             selected && transition(borrow world, borrow entity, score));
-        i = i + 1;
+        i += 1;
     }
     let mut faction: u64 = 1;
     while faction <= 3 {
         let proxy = world.resources / faction + world.treasury / (faction + 1) + PROFILE();
         result.record(inout out, proxy % 2 == 0, proxy, proxy % 5 == 0);
-        faction = faction + 1;
+        faction += 1;
     }
     result.finish(inout out); out
 }

--- a/examples/caldera/behavior_scout_deliver.rue
+++ b/examples/caldera/behavior_scout_deliver.rue
@@ -58,13 +58,13 @@ pub fn evaluate(borrow world: model.World) -> result.Result {
             score >= (PROFILE() % 13) + entity.kind;
         result.record(inout out, selected, score,
             selected && transition(borrow world, borrow entity, score));
-        i = i + 1;
+        i += 1;
     }
     let mut faction: u64 = 1;
     while faction <= 3 {
         let proxy = world.resources / faction + world.treasury / (faction + 1) + PROFILE();
         result.record(inout out, proxy % 2 == 0, proxy, proxy % 5 == 0);
-        faction = faction + 1;
+        faction += 1;
     }
     result.finish(inout out); out
 }

--- a/examples/caldera/behavior_scout_evade.rue
+++ b/examples/caldera/behavior_scout_evade.rue
@@ -58,13 +58,13 @@ pub fn evaluate(borrow world: model.World) -> result.Result {
             score >= (PROFILE() % 13) + entity.kind;
         result.record(inout out, selected, score,
             selected && transition(borrow world, borrow entity, score));
-        i = i + 1;
+        i += 1;
     }
     let mut faction: u64 = 1;
     while faction <= 3 {
         let proxy = world.resources / faction + world.treasury / (faction + 1) + PROFILE();
         result.record(inout out, proxy % 2 == 0, proxy, proxy % 5 == 0);
-        faction = faction + 1;
+        faction += 1;
     }
     result.finish(inout out); out
 }

--- a/examples/caldera/behavior_scout_explore.rue
+++ b/examples/caldera/behavior_scout_explore.rue
@@ -58,13 +58,13 @@ pub fn evaluate(borrow world: model.World) -> result.Result {
             score >= (PROFILE() % 13) + entity.kind;
         result.record(inout out, selected, score,
             selected && transition(borrow world, borrow entity, score));
-        i = i + 1;
+        i += 1;
     }
     let mut faction: u64 = 1;
     while faction <= 3 {
         let proxy = world.resources / faction + world.treasury / (faction + 1) + PROFILE();
         result.record(inout out, proxy % 2 == 0, proxy, proxy % 5 == 0);
-        faction = faction + 1;
+        faction += 1;
     }
     result.finish(inout out); out
 }

--- a/examples/caldera/behavior_scout_gather.rue
+++ b/examples/caldera/behavior_scout_gather.rue
@@ -58,13 +58,13 @@ pub fn evaluate(borrow world: model.World) -> result.Result {
             score >= (PROFILE() % 13) + entity.kind;
         result.record(inout out, selected, score,
             selected && transition(borrow world, borrow entity, score));
-        i = i + 1;
+        i += 1;
     }
     let mut faction: u64 = 1;
     while faction <= 3 {
         let proxy = world.resources / faction + world.treasury / (faction + 1) + PROFILE();
         result.record(inout out, proxy % 2 == 0, proxy, proxy % 5 == 0);
-        faction = faction + 1;
+        faction += 1;
     }
     result.finish(inout out); out
 }

--- a/examples/caldera/behavior_scout_idle.rue
+++ b/examples/caldera/behavior_scout_idle.rue
@@ -58,13 +58,13 @@ pub fn evaluate(borrow world: model.World) -> result.Result {
             score >= (PROFILE() % 13) + entity.kind;
         result.record(inout out, selected, score,
             selected && transition(borrow world, borrow entity, score));
-        i = i + 1;
+        i += 1;
     }
     let mut faction: u64 = 1;
     while faction <= 3 {
         let proxy = world.resources / faction + world.treasury / (faction + 1) + PROFILE();
         result.record(inout out, proxy % 2 == 0, proxy, proxy % 5 == 0);
-        faction = faction + 1;
+        faction += 1;
     }
     result.finish(inout out); out
 }

--- a/examples/caldera/behavior_scout_learn.rue
+++ b/examples/caldera/behavior_scout_learn.rue
@@ -58,13 +58,13 @@ pub fn evaluate(borrow world: model.World) -> result.Result {
             score >= (PROFILE() % 13) + entity.kind;
         result.record(inout out, selected, score,
             selected && transition(borrow world, borrow entity, score));
-        i = i + 1;
+        i += 1;
     }
     let mut faction: u64 = 1;
     while faction <= 3 {
         let proxy = world.resources / faction + world.treasury / (faction + 1) + PROFILE();
         result.record(inout out, proxy % 2 == 0, proxy, proxy % 5 == 0);
-        faction = faction + 1;
+        faction += 1;
     }
     result.finish(inout out); out
 }

--- a/examples/caldera/behavior_scout_pursue.rue
+++ b/examples/caldera/behavior_scout_pursue.rue
@@ -58,13 +58,13 @@ pub fn evaluate(borrow world: model.World) -> result.Result {
             score >= (PROFILE() % 13) + entity.kind;
         result.record(inout out, selected, score,
             selected && transition(borrow world, borrow entity, score));
-        i = i + 1;
+        i += 1;
     }
     let mut faction: u64 = 1;
     while faction <= 3 {
         let proxy = world.resources / faction + world.treasury / (faction + 1) + PROFILE();
         result.record(inout out, proxy % 2 == 0, proxy, proxy % 5 == 0);
-        faction = faction + 1;
+        faction += 1;
     }
     result.finish(inout out); out
 }

--- a/examples/caldera/behavior_scout_repair.rue
+++ b/examples/caldera/behavior_scout_repair.rue
@@ -58,13 +58,13 @@ pub fn evaluate(borrow world: model.World) -> result.Result {
             score >= (PROFILE() % 13) + entity.kind;
         result.record(inout out, selected, score,
             selected && transition(borrow world, borrow entity, score));
-        i = i + 1;
+        i += 1;
     }
     let mut faction: u64 = 1;
     while faction <= 3 {
         let proxy = world.resources / faction + world.treasury / (faction + 1) + PROFILE();
         result.record(inout out, proxy % 2 == 0, proxy, proxy % 5 == 0);
-        faction = faction + 1;
+        faction += 1;
     }
     result.finish(inout out); out
 }

--- a/examples/caldera/behavior_scout_rest.rue
+++ b/examples/caldera/behavior_scout_rest.rue
@@ -58,13 +58,13 @@ pub fn evaluate(borrow world: model.World) -> result.Result {
             score >= (PROFILE() % 13) + entity.kind;
         result.record(inout out, selected, score,
             selected && transition(borrow world, borrow entity, score));
-        i = i + 1;
+        i += 1;
     }
     let mut faction: u64 = 1;
     while faction <= 3 {
         let proxy = world.resources / faction + world.treasury / (faction + 1) + PROFILE();
         result.record(inout out, proxy % 2 == 0, proxy, proxy % 5 == 0);
-        faction = faction + 1;
+        faction += 1;
     }
     result.finish(inout out); out
 }

--- a/examples/caldera/behavior_scout_trade.rue
+++ b/examples/caldera/behavior_scout_trade.rue
@@ -58,13 +58,13 @@ pub fn evaluate(borrow world: model.World) -> result.Result {
             score >= (PROFILE() % 13) + entity.kind;
         result.record(inout out, selected, score,
             selected && transition(borrow world, borrow entity, score));
-        i = i + 1;
+        i += 1;
     }
     let mut faction: u64 = 1;
     while faction <= 3 {
         let proxy = world.resources / faction + world.treasury / (faction + 1) + PROFILE();
         result.record(inout out, proxy % 2 == 0, proxy, proxy % 5 == 0);
-        faction = faction + 1;
+        faction += 1;
     }
     result.finish(inout out); out
 }

--- a/examples/caldera/behavior_suite.rue
+++ b/examples/caldera/behavior_suite.rue
@@ -136,7 +136,7 @@ fn include(inout out: Summary, borrow first: result.Result, borrow second: resul
     out.behaviors = out.behaviors + 1; out.agents = out.agents + first.agents;
     out.selected = out.selected + first.selected; out.transitions = out.transitions + first.transitions;
     if first.digest != second.digest || first.utility != second.utility || !verified {
-        out.deterministic_mismatches = out.deterministic_mismatches + 1;
+        out.deterministic_mismatches += 1;
     }
     out.digest = metric.mix(out.digest, first.digest);
 }

--- a/examples/caldera/behavior_suite.rue
+++ b/examples/caldera/behavior_suite.rue
@@ -133,8 +133,8 @@ const behavior_citizen_celebrate = @import("behavior_citizen_celebrate.rue");
 pub struct Summary { behaviors: u64, agents: u64, selected: u64, transitions: u64,
     deterministic_mismatches: u64, digest: u64, valid: bool }
 fn include(inout out: Summary, borrow first: result.Result, borrow second: result.Result, verified: bool) {
-    out.behaviors = out.behaviors + 1; out.agents = out.agents + first.agents;
-    out.selected = out.selected + first.selected; out.transitions = out.transitions + first.transitions;
+    out.behaviors += 1; out.agents += first.agents;
+    out.selected += first.selected; out.transitions += first.transitions;
     if first.digest != second.digest || first.utility != second.utility || !verified {
         out.deterministic_mismatches += 1;
     }

--- a/examples/caldera/behavior_trader_assist.rue
+++ b/examples/caldera/behavior_trader_assist.rue
@@ -58,13 +58,13 @@ pub fn evaluate(borrow world: model.World) -> result.Result {
             score >= (PROFILE() % 13) + entity.kind;
         result.record(inout out, selected, score,
             selected && transition(borrow world, borrow entity, score));
-        i = i + 1;
+        i += 1;
     }
     let mut faction: u64 = 1;
     while faction <= 3 {
         let proxy = world.resources / faction + world.treasury / (faction + 1) + PROFILE();
         result.record(inout out, proxy % 2 == 0, proxy, proxy % 5 == 0);
-        faction = faction + 1;
+        faction += 1;
     }
     result.finish(inout out); out
 }

--- a/examples/caldera/behavior_trader_celebrate.rue
+++ b/examples/caldera/behavior_trader_celebrate.rue
@@ -58,13 +58,13 @@ pub fn evaluate(borrow world: model.World) -> result.Result {
             score >= (PROFILE() % 13) + entity.kind;
         result.record(inout out, selected, score,
             selected && transition(borrow world, borrow entity, score));
-        i = i + 1;
+        i += 1;
     }
     let mut faction: u64 = 1;
     while faction <= 3 {
         let proxy = world.resources / faction + world.treasury / (faction + 1) + PROFILE();
         result.record(inout out, proxy % 2 == 0, proxy, proxy % 5 == 0);
-        faction = faction + 1;
+        faction += 1;
     }
     result.finish(inout out); out
 }

--- a/examples/caldera/behavior_trader_construct.rue
+++ b/examples/caldera/behavior_trader_construct.rue
@@ -58,13 +58,13 @@ pub fn evaluate(borrow world: model.World) -> result.Result {
             score >= (PROFILE() % 13) + entity.kind;
         result.record(inout out, selected, score,
             selected && transition(borrow world, borrow entity, score));
-        i = i + 1;
+        i += 1;
     }
     let mut faction: u64 = 1;
     while faction <= 3 {
         let proxy = world.resources / faction + world.treasury / (faction + 1) + PROFILE();
         result.record(inout out, proxy % 2 == 0, proxy, proxy % 5 == 0);
-        faction = faction + 1;
+        faction += 1;
     }
     result.finish(inout out); out
 }

--- a/examples/caldera/behavior_trader_coordinate.rue
+++ b/examples/caldera/behavior_trader_coordinate.rue
@@ -58,13 +58,13 @@ pub fn evaluate(borrow world: model.World) -> result.Result {
             score >= (PROFILE() % 13) + entity.kind;
         result.record(inout out, selected, score,
             selected && transition(borrow world, borrow entity, score));
-        i = i + 1;
+        i += 1;
     }
     let mut faction: u64 = 1;
     while faction <= 3 {
         let proxy = world.resources / faction + world.treasury / (faction + 1) + PROFILE();
         result.record(inout out, proxy % 2 == 0, proxy, proxy % 5 == 0);
-        faction = faction + 1;
+        faction += 1;
     }
     result.finish(inout out); out
 }

--- a/examples/caldera/behavior_trader_craft.rue
+++ b/examples/caldera/behavior_trader_craft.rue
@@ -58,13 +58,13 @@ pub fn evaluate(borrow world: model.World) -> result.Result {
             score >= (PROFILE() % 13) + entity.kind;
         result.record(inout out, selected, score,
             selected && transition(borrow world, borrow entity, score));
-        i = i + 1;
+        i += 1;
     }
     let mut faction: u64 = 1;
     while faction <= 3 {
         let proxy = world.resources / faction + world.treasury / (faction + 1) + PROFILE();
         result.record(inout out, proxy % 2 == 0, proxy, proxy % 5 == 0);
-        faction = faction + 1;
+        faction += 1;
     }
     result.finish(inout out); out
 }

--- a/examples/caldera/behavior_trader_defend.rue
+++ b/examples/caldera/behavior_trader_defend.rue
@@ -58,13 +58,13 @@ pub fn evaluate(borrow world: model.World) -> result.Result {
             score >= (PROFILE() % 13) + entity.kind;
         result.record(inout out, selected, score,
             selected && transition(borrow world, borrow entity, score));
-        i = i + 1;
+        i += 1;
     }
     let mut faction: u64 = 1;
     while faction <= 3 {
         let proxy = world.resources / faction + world.treasury / (faction + 1) + PROFILE();
         result.record(inout out, proxy % 2 == 0, proxy, proxy % 5 == 0);
-        faction = faction + 1;
+        faction += 1;
     }
     result.finish(inout out); out
 }

--- a/examples/caldera/behavior_trader_deliver.rue
+++ b/examples/caldera/behavior_trader_deliver.rue
@@ -58,13 +58,13 @@ pub fn evaluate(borrow world: model.World) -> result.Result {
             score >= (PROFILE() % 13) + entity.kind;
         result.record(inout out, selected, score,
             selected && transition(borrow world, borrow entity, score));
-        i = i + 1;
+        i += 1;
     }
     let mut faction: u64 = 1;
     while faction <= 3 {
         let proxy = world.resources / faction + world.treasury / (faction + 1) + PROFILE();
         result.record(inout out, proxy % 2 == 0, proxy, proxy % 5 == 0);
-        faction = faction + 1;
+        faction += 1;
     }
     result.finish(inout out); out
 }

--- a/examples/caldera/behavior_trader_evade.rue
+++ b/examples/caldera/behavior_trader_evade.rue
@@ -58,13 +58,13 @@ pub fn evaluate(borrow world: model.World) -> result.Result {
             score >= (PROFILE() % 13) + entity.kind;
         result.record(inout out, selected, score,
             selected && transition(borrow world, borrow entity, score));
-        i = i + 1;
+        i += 1;
     }
     let mut faction: u64 = 1;
     while faction <= 3 {
         let proxy = world.resources / faction + world.treasury / (faction + 1) + PROFILE();
         result.record(inout out, proxy % 2 == 0, proxy, proxy % 5 == 0);
-        faction = faction + 1;
+        faction += 1;
     }
     result.finish(inout out); out
 }

--- a/examples/caldera/behavior_trader_explore.rue
+++ b/examples/caldera/behavior_trader_explore.rue
@@ -58,13 +58,13 @@ pub fn evaluate(borrow world: model.World) -> result.Result {
             score >= (PROFILE() % 13) + entity.kind;
         result.record(inout out, selected, score,
             selected && transition(borrow world, borrow entity, score));
-        i = i + 1;
+        i += 1;
     }
     let mut faction: u64 = 1;
     while faction <= 3 {
         let proxy = world.resources / faction + world.treasury / (faction + 1) + PROFILE();
         result.record(inout out, proxy % 2 == 0, proxy, proxy % 5 == 0);
-        faction = faction + 1;
+        faction += 1;
     }
     result.finish(inout out); out
 }

--- a/examples/caldera/behavior_trader_gather.rue
+++ b/examples/caldera/behavior_trader_gather.rue
@@ -58,13 +58,13 @@ pub fn evaluate(borrow world: model.World) -> result.Result {
             score >= (PROFILE() % 13) + entity.kind;
         result.record(inout out, selected, score,
             selected && transition(borrow world, borrow entity, score));
-        i = i + 1;
+        i += 1;
     }
     let mut faction: u64 = 1;
     while faction <= 3 {
         let proxy = world.resources / faction + world.treasury / (faction + 1) + PROFILE();
         result.record(inout out, proxy % 2 == 0, proxy, proxy % 5 == 0);
-        faction = faction + 1;
+        faction += 1;
     }
     result.finish(inout out); out
 }

--- a/examples/caldera/behavior_trader_idle.rue
+++ b/examples/caldera/behavior_trader_idle.rue
@@ -58,13 +58,13 @@ pub fn evaluate(borrow world: model.World) -> result.Result {
             score >= (PROFILE() % 13) + entity.kind;
         result.record(inout out, selected, score,
             selected && transition(borrow world, borrow entity, score));
-        i = i + 1;
+        i += 1;
     }
     let mut faction: u64 = 1;
     while faction <= 3 {
         let proxy = world.resources / faction + world.treasury / (faction + 1) + PROFILE();
         result.record(inout out, proxy % 2 == 0, proxy, proxy % 5 == 0);
-        faction = faction + 1;
+        faction += 1;
     }
     result.finish(inout out); out
 }

--- a/examples/caldera/behavior_trader_learn.rue
+++ b/examples/caldera/behavior_trader_learn.rue
@@ -58,13 +58,13 @@ pub fn evaluate(borrow world: model.World) -> result.Result {
             score >= (PROFILE() % 13) + entity.kind;
         result.record(inout out, selected, score,
             selected && transition(borrow world, borrow entity, score));
-        i = i + 1;
+        i += 1;
     }
     let mut faction: u64 = 1;
     while faction <= 3 {
         let proxy = world.resources / faction + world.treasury / (faction + 1) + PROFILE();
         result.record(inout out, proxy % 2 == 0, proxy, proxy % 5 == 0);
-        faction = faction + 1;
+        faction += 1;
     }
     result.finish(inout out); out
 }

--- a/examples/caldera/behavior_trader_pursue.rue
+++ b/examples/caldera/behavior_trader_pursue.rue
@@ -58,13 +58,13 @@ pub fn evaluate(borrow world: model.World) -> result.Result {
             score >= (PROFILE() % 13) + entity.kind;
         result.record(inout out, selected, score,
             selected && transition(borrow world, borrow entity, score));
-        i = i + 1;
+        i += 1;
     }
     let mut faction: u64 = 1;
     while faction <= 3 {
         let proxy = world.resources / faction + world.treasury / (faction + 1) + PROFILE();
         result.record(inout out, proxy % 2 == 0, proxy, proxy % 5 == 0);
-        faction = faction + 1;
+        faction += 1;
     }
     result.finish(inout out); out
 }

--- a/examples/caldera/behavior_trader_repair.rue
+++ b/examples/caldera/behavior_trader_repair.rue
@@ -58,13 +58,13 @@ pub fn evaluate(borrow world: model.World) -> result.Result {
             score >= (PROFILE() % 13) + entity.kind;
         result.record(inout out, selected, score,
             selected && transition(borrow world, borrow entity, score));
-        i = i + 1;
+        i += 1;
     }
     let mut faction: u64 = 1;
     while faction <= 3 {
         let proxy = world.resources / faction + world.treasury / (faction + 1) + PROFILE();
         result.record(inout out, proxy % 2 == 0, proxy, proxy % 5 == 0);
-        faction = faction + 1;
+        faction += 1;
     }
     result.finish(inout out); out
 }

--- a/examples/caldera/behavior_trader_rest.rue
+++ b/examples/caldera/behavior_trader_rest.rue
@@ -58,13 +58,13 @@ pub fn evaluate(borrow world: model.World) -> result.Result {
             score >= (PROFILE() % 13) + entity.kind;
         result.record(inout out, selected, score,
             selected && transition(borrow world, borrow entity, score));
-        i = i + 1;
+        i += 1;
     }
     let mut faction: u64 = 1;
     while faction <= 3 {
         let proxy = world.resources / faction + world.treasury / (faction + 1) + PROFILE();
         result.record(inout out, proxy % 2 == 0, proxy, proxy % 5 == 0);
-        faction = faction + 1;
+        faction += 1;
     }
     result.finish(inout out); out
 }

--- a/examples/caldera/behavior_trader_trade.rue
+++ b/examples/caldera/behavior_trader_trade.rue
@@ -58,13 +58,13 @@ pub fn evaluate(borrow world: model.World) -> result.Result {
             score >= (PROFILE() % 13) + entity.kind;
         result.record(inout out, selected, score,
             selected && transition(borrow world, borrow entity, score));
-        i = i + 1;
+        i += 1;
     }
     let mut faction: u64 = 1;
     while faction <= 3 {
         let proxy = world.resources / faction + world.treasury / (faction + 1) + PROFILE();
         result.record(inout out, proxy % 2 == 0, proxy, proxy % 5 == 0);
-        faction = faction + 1;
+        faction += 1;
     }
     result.finish(inout out); out
 }

--- a/examples/caldera/behavior_worker_assist.rue
+++ b/examples/caldera/behavior_worker_assist.rue
@@ -58,13 +58,13 @@ pub fn evaluate(borrow world: model.World) -> result.Result {
             score >= (PROFILE() % 13) + entity.kind;
         result.record(inout out, selected, score,
             selected && transition(borrow world, borrow entity, score));
-        i = i + 1;
+        i += 1;
     }
     let mut faction: u64 = 1;
     while faction <= 3 {
         let proxy = world.resources / faction + world.treasury / (faction + 1) + PROFILE();
         result.record(inout out, proxy % 2 == 0, proxy, proxy % 5 == 0);
-        faction = faction + 1;
+        faction += 1;
     }
     result.finish(inout out); out
 }

--- a/examples/caldera/behavior_worker_celebrate.rue
+++ b/examples/caldera/behavior_worker_celebrate.rue
@@ -58,13 +58,13 @@ pub fn evaluate(borrow world: model.World) -> result.Result {
             score >= (PROFILE() % 13) + entity.kind;
         result.record(inout out, selected, score,
             selected && transition(borrow world, borrow entity, score));
-        i = i + 1;
+        i += 1;
     }
     let mut faction: u64 = 1;
     while faction <= 3 {
         let proxy = world.resources / faction + world.treasury / (faction + 1) + PROFILE();
         result.record(inout out, proxy % 2 == 0, proxy, proxy % 5 == 0);
-        faction = faction + 1;
+        faction += 1;
     }
     result.finish(inout out); out
 }

--- a/examples/caldera/behavior_worker_construct.rue
+++ b/examples/caldera/behavior_worker_construct.rue
@@ -58,13 +58,13 @@ pub fn evaluate(borrow world: model.World) -> result.Result {
             score >= (PROFILE() % 13) + entity.kind;
         result.record(inout out, selected, score,
             selected && transition(borrow world, borrow entity, score));
-        i = i + 1;
+        i += 1;
     }
     let mut faction: u64 = 1;
     while faction <= 3 {
         let proxy = world.resources / faction + world.treasury / (faction + 1) + PROFILE();
         result.record(inout out, proxy % 2 == 0, proxy, proxy % 5 == 0);
-        faction = faction + 1;
+        faction += 1;
     }
     result.finish(inout out); out
 }

--- a/examples/caldera/behavior_worker_coordinate.rue
+++ b/examples/caldera/behavior_worker_coordinate.rue
@@ -58,13 +58,13 @@ pub fn evaluate(borrow world: model.World) -> result.Result {
             score >= (PROFILE() % 13) + entity.kind;
         result.record(inout out, selected, score,
             selected && transition(borrow world, borrow entity, score));
-        i = i + 1;
+        i += 1;
     }
     let mut faction: u64 = 1;
     while faction <= 3 {
         let proxy = world.resources / faction + world.treasury / (faction + 1) + PROFILE();
         result.record(inout out, proxy % 2 == 0, proxy, proxy % 5 == 0);
-        faction = faction + 1;
+        faction += 1;
     }
     result.finish(inout out); out
 }

--- a/examples/caldera/behavior_worker_craft.rue
+++ b/examples/caldera/behavior_worker_craft.rue
@@ -58,13 +58,13 @@ pub fn evaluate(borrow world: model.World) -> result.Result {
             score >= (PROFILE() % 13) + entity.kind;
         result.record(inout out, selected, score,
             selected && transition(borrow world, borrow entity, score));
-        i = i + 1;
+        i += 1;
     }
     let mut faction: u64 = 1;
     while faction <= 3 {
         let proxy = world.resources / faction + world.treasury / (faction + 1) + PROFILE();
         result.record(inout out, proxy % 2 == 0, proxy, proxy % 5 == 0);
-        faction = faction + 1;
+        faction += 1;
     }
     result.finish(inout out); out
 }

--- a/examples/caldera/behavior_worker_defend.rue
+++ b/examples/caldera/behavior_worker_defend.rue
@@ -58,13 +58,13 @@ pub fn evaluate(borrow world: model.World) -> result.Result {
             score >= (PROFILE() % 13) + entity.kind;
         result.record(inout out, selected, score,
             selected && transition(borrow world, borrow entity, score));
-        i = i + 1;
+        i += 1;
     }
     let mut faction: u64 = 1;
     while faction <= 3 {
         let proxy = world.resources / faction + world.treasury / (faction + 1) + PROFILE();
         result.record(inout out, proxy % 2 == 0, proxy, proxy % 5 == 0);
-        faction = faction + 1;
+        faction += 1;
     }
     result.finish(inout out); out
 }

--- a/examples/caldera/behavior_worker_deliver.rue
+++ b/examples/caldera/behavior_worker_deliver.rue
@@ -58,13 +58,13 @@ pub fn evaluate(borrow world: model.World) -> result.Result {
             score >= (PROFILE() % 13) + entity.kind;
         result.record(inout out, selected, score,
             selected && transition(borrow world, borrow entity, score));
-        i = i + 1;
+        i += 1;
     }
     let mut faction: u64 = 1;
     while faction <= 3 {
         let proxy = world.resources / faction + world.treasury / (faction + 1) + PROFILE();
         result.record(inout out, proxy % 2 == 0, proxy, proxy % 5 == 0);
-        faction = faction + 1;
+        faction += 1;
     }
     result.finish(inout out); out
 }

--- a/examples/caldera/behavior_worker_evade.rue
+++ b/examples/caldera/behavior_worker_evade.rue
@@ -58,13 +58,13 @@ pub fn evaluate(borrow world: model.World) -> result.Result {
             score >= (PROFILE() % 13) + entity.kind;
         result.record(inout out, selected, score,
             selected && transition(borrow world, borrow entity, score));
-        i = i + 1;
+        i += 1;
     }
     let mut faction: u64 = 1;
     while faction <= 3 {
         let proxy = world.resources / faction + world.treasury / (faction + 1) + PROFILE();
         result.record(inout out, proxy % 2 == 0, proxy, proxy % 5 == 0);
-        faction = faction + 1;
+        faction += 1;
     }
     result.finish(inout out); out
 }

--- a/examples/caldera/behavior_worker_explore.rue
+++ b/examples/caldera/behavior_worker_explore.rue
@@ -58,13 +58,13 @@ pub fn evaluate(borrow world: model.World) -> result.Result {
             score >= (PROFILE() % 13) + entity.kind;
         result.record(inout out, selected, score,
             selected && transition(borrow world, borrow entity, score));
-        i = i + 1;
+        i += 1;
     }
     let mut faction: u64 = 1;
     while faction <= 3 {
         let proxy = world.resources / faction + world.treasury / (faction + 1) + PROFILE();
         result.record(inout out, proxy % 2 == 0, proxy, proxy % 5 == 0);
-        faction = faction + 1;
+        faction += 1;
     }
     result.finish(inout out); out
 }

--- a/examples/caldera/behavior_worker_gather.rue
+++ b/examples/caldera/behavior_worker_gather.rue
@@ -58,13 +58,13 @@ pub fn evaluate(borrow world: model.World) -> result.Result {
             score >= (PROFILE() % 13) + entity.kind;
         result.record(inout out, selected, score,
             selected && transition(borrow world, borrow entity, score));
-        i = i + 1;
+        i += 1;
     }
     let mut faction: u64 = 1;
     while faction <= 3 {
         let proxy = world.resources / faction + world.treasury / (faction + 1) + PROFILE();
         result.record(inout out, proxy % 2 == 0, proxy, proxy % 5 == 0);
-        faction = faction + 1;
+        faction += 1;
     }
     result.finish(inout out); out
 }

--- a/examples/caldera/behavior_worker_idle.rue
+++ b/examples/caldera/behavior_worker_idle.rue
@@ -58,13 +58,13 @@ pub fn evaluate(borrow world: model.World) -> result.Result {
             score >= (PROFILE() % 13) + entity.kind;
         result.record(inout out, selected, score,
             selected && transition(borrow world, borrow entity, score));
-        i = i + 1;
+        i += 1;
     }
     let mut faction: u64 = 1;
     while faction <= 3 {
         let proxy = world.resources / faction + world.treasury / (faction + 1) + PROFILE();
         result.record(inout out, proxy % 2 == 0, proxy, proxy % 5 == 0);
-        faction = faction + 1;
+        faction += 1;
     }
     result.finish(inout out); out
 }

--- a/examples/caldera/behavior_worker_learn.rue
+++ b/examples/caldera/behavior_worker_learn.rue
@@ -58,13 +58,13 @@ pub fn evaluate(borrow world: model.World) -> result.Result {
             score >= (PROFILE() % 13) + entity.kind;
         result.record(inout out, selected, score,
             selected && transition(borrow world, borrow entity, score));
-        i = i + 1;
+        i += 1;
     }
     let mut faction: u64 = 1;
     while faction <= 3 {
         let proxy = world.resources / faction + world.treasury / (faction + 1) + PROFILE();
         result.record(inout out, proxy % 2 == 0, proxy, proxy % 5 == 0);
-        faction = faction + 1;
+        faction += 1;
     }
     result.finish(inout out); out
 }

--- a/examples/caldera/behavior_worker_pursue.rue
+++ b/examples/caldera/behavior_worker_pursue.rue
@@ -58,13 +58,13 @@ pub fn evaluate(borrow world: model.World) -> result.Result {
             score >= (PROFILE() % 13) + entity.kind;
         result.record(inout out, selected, score,
             selected && transition(borrow world, borrow entity, score));
-        i = i + 1;
+        i += 1;
     }
     let mut faction: u64 = 1;
     while faction <= 3 {
         let proxy = world.resources / faction + world.treasury / (faction + 1) + PROFILE();
         result.record(inout out, proxy % 2 == 0, proxy, proxy % 5 == 0);
-        faction = faction + 1;
+        faction += 1;
     }
     result.finish(inout out); out
 }

--- a/examples/caldera/behavior_worker_repair.rue
+++ b/examples/caldera/behavior_worker_repair.rue
@@ -58,13 +58,13 @@ pub fn evaluate(borrow world: model.World) -> result.Result {
             score >= (PROFILE() % 13) + entity.kind;
         result.record(inout out, selected, score,
             selected && transition(borrow world, borrow entity, score));
-        i = i + 1;
+        i += 1;
     }
     let mut faction: u64 = 1;
     while faction <= 3 {
         let proxy = world.resources / faction + world.treasury / (faction + 1) + PROFILE();
         result.record(inout out, proxy % 2 == 0, proxy, proxy % 5 == 0);
-        faction = faction + 1;
+        faction += 1;
     }
     result.finish(inout out); out
 }

--- a/examples/caldera/behavior_worker_rest.rue
+++ b/examples/caldera/behavior_worker_rest.rue
@@ -58,13 +58,13 @@ pub fn evaluate(borrow world: model.World) -> result.Result {
             score >= (PROFILE() % 13) + entity.kind;
         result.record(inout out, selected, score,
             selected && transition(borrow world, borrow entity, score));
-        i = i + 1;
+        i += 1;
     }
     let mut faction: u64 = 1;
     while faction <= 3 {
         let proxy = world.resources / faction + world.treasury / (faction + 1) + PROFILE();
         result.record(inout out, proxy % 2 == 0, proxy, proxy % 5 == 0);
-        faction = faction + 1;
+        faction += 1;
     }
     result.finish(inout out); out
 }

--- a/examples/caldera/behavior_worker_trade.rue
+++ b/examples/caldera/behavior_worker_trade.rue
@@ -58,13 +58,13 @@ pub fn evaluate(borrow world: model.World) -> result.Result {
             score >= (PROFILE() % 13) + entity.kind;
         result.record(inout out, selected, score,
             selected && transition(borrow world, borrow entity, score));
-        i = i + 1;
+        i += 1;
     }
     let mut faction: u64 = 1;
     while faction <= 3 {
         let proxy = world.resources / faction + world.treasury / (faction + 1) + PROFILE();
         result.record(inout out, proxy % 2 == 0, proxy, proxy % 5 == 0);
-        faction = faction + 1;
+        faction += 1;
     }
     result.finish(inout out); out
 }

--- a/examples/caldera/checksum.rue
+++ b/examples/caldera/checksum.rue
@@ -28,7 +28,7 @@ pub fn world(borrow value: model.World) -> u64 {
         hash = metric.mix(hash, entity.credits);
         hash = metric.mix(hash, entity.experience);
         hash = metric.mix(hash, if entity.alive { 1 } else { 0 });
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < value.tiles.len() {
@@ -40,7 +40,7 @@ pub fn world(borrow value: model.World) -> u64 {
         hash = metric.mix(hash, tile.resource);
         hash = metric.mix(hash, tile.region);
         hash = metric.mix(hash, if tile.walkable { 1 } else { 0 });
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < value.events.len() {
@@ -51,7 +51,7 @@ pub fn world(borrow value: model.World) -> u64 {
         hash = metric.mix(hash, event.target);
         hash = metric.mix(hash, event.value);
         hash = metric.mix(hash, event.sequence);
-        i = i + 1;
+        i += 1;
     }
     hash
 }

--- a/examples/caldera/collision.rue
+++ b/examples/caldera/collision.rue
@@ -12,20 +12,20 @@ pub fn audit(borrow world: model.World) -> Audit {
     while i < world.entities.len() {
         let entity = world.entities.get_or(i, model.empty_entity());
         if entity.alive && !model.walkable(borrow world, entity.x, entity.y) {
-            out.tile_hits = out.tile_hits + 1;
+            out.tile_hits += 1;
             out.digest = metric.mix(out.digest, entity.id);
         }
         let mut j = i + 1;
         while j < world.entities.len() {
             let other = world.entities.get_or(j, model.empty_entity());
-            out.pairs = out.pairs + 1;
+            out.pairs += 1;
             if entity.alive && other.alive && entity.x == other.x && entity.y == other.y {
-                out.entity_hits = out.entity_hits + 1;
+                out.entity_hits += 1;
                 out.digest = metric.mix(out.digest, entity.id ^ other.id);
             }
-            j = j + 1;
+            j += 1;
         }
-        i = i + 1;
+        i += 1;
     }
     out.valid = out.pairs == (world.entities.len() *
         (if world.entities.len() == 0 { 0 } else { world.entities.len() - 1 })) / 2;

--- a/examples/caldera/commands.rue
+++ b/examples/caldera/commands.rue
@@ -21,7 +21,7 @@ pub fn accepted(borrow world: model.World) -> u64 {
     let mut i: u64 = 0;
     while i < world.commands.len() {
         if world.commands.get_or(i, model.empty_command()).accepted { count = count + 1; }
-        i = i + 1;
+        i += 1;
     }
     count
 }

--- a/examples/caldera/commands.rue
+++ b/examples/caldera/commands.rue
@@ -20,7 +20,7 @@ pub fn accepted(borrow world: model.World) -> u64 {
     let mut count: u64 = 0;
     let mut i: u64 = 0;
     while i < world.commands.len() {
-        if world.commands.get_or(i, model.empty_command()).accepted { count = count + 1; }
+        if world.commands.get_or(i, model.empty_command()).accepted { count += 1; }
         i += 1;
     }
     count

--- a/examples/caldera/crafting.rue
+++ b/examples/caldera/crafting.rue
@@ -8,10 +8,10 @@ pub fn audit(borrow world: model.World) -> Craft {
     let mut recipe: u64 = 0;
     while recipe < out.recipes {
         let cost = 2 + recipe * 3;
-        out.cost = out.cost + cost;
+        out.cost += cost;
         if world.resources >= cost { out.craftable = out.craftable + 1; }
         out.digest = metric.mix(out.digest, cost + world.seed % 97);
-        recipe = recipe + 1;
+        recipe += 1;
     }
     out.valid = out.craftable <= out.recipes; out
 }

--- a/examples/caldera/crafting.rue
+++ b/examples/caldera/crafting.rue
@@ -9,7 +9,7 @@ pub fn audit(borrow world: model.World) -> Craft {
     while recipe < out.recipes {
         let cost = 2 + recipe * 3;
         out.cost += cost;
-        if world.resources >= cost { out.craftable = out.craftable + 1; }
+        if world.resources >= cost { out.craftable += 1; }
         out.digest = metric.mix(out.digest, cost + world.seed % 97);
         recipe += 1;
     }

--- a/examples/caldera/delta.rue
+++ b/examples/caldera/delta.rue
@@ -14,7 +14,7 @@ pub fn compare(borrow a: model.World, borrow b: model.World) -> Delta {
         let right = b.entities.get_or(i, model.empty_entity());
         if left.x != right.x || left.y != right.y || left.health != right.health ||
             left.inventory != right.inventory || left.state != right.state { entities = entities + 1; }
-        i = i + 1;
+        i += 1;
     }
     entities = entities + if a.entities.len() > b.entities.len() {
         a.entities.len() - b.entities.len() } else { b.entities.len() - a.entities.len() };

--- a/examples/caldera/delta.rue
+++ b/examples/caldera/delta.rue
@@ -13,7 +13,7 @@ pub fn compare(borrow a: model.World, borrow b: model.World) -> Delta {
         let left = a.entities.get_or(i, model.empty_entity());
         let right = b.entities.get_or(i, model.empty_entity());
         if left.x != right.x || left.y != right.y || left.health != right.health ||
-            left.inventory != right.inventory || left.state != right.state { entities = entities + 1; }
+            left.inventory != right.inventory || left.state != right.state { entities += 1; }
         i += 1;
     }
     entities = entities + if a.entities.len() > b.entities.len() {

--- a/examples/caldera/desync.rue
+++ b/examples/caldera/desync.rue
@@ -12,7 +12,7 @@ pub fn compare(borrow a: model.World, borrow b: model.World) -> Audit {
         let x = a.entities.get_or(i, model.empty_entity());
         let y = b.entities.get_or(i, model.empty_entity());
         if first == model.NONE() && (x.x != y.x || x.y != y.y || x.health != y.health) { first = i; }
-        i = i + 1;
+        i += 1;
     }
     Audit { left: left, right: right, mismatch: left != right,
         first_entity: first, digest: metric.mix(left, right),

--- a/examples/caldera/diagnostics.rue
+++ b/examples/caldera/diagnostics.rue
@@ -9,7 +9,7 @@ pub fn render(borrow world: model.World) -> StrBuf {
         text.append_literal(inout out, "caldera[world] code="); text.append_u64(inout out, item.code);
         text.append_literal(inout out, " subject="); text.append_u64(inout out, item.subject);
         text.append_literal(inout out, " detail="); text.append_u64(inout out, item.detail); out.push(10);
-        i = i + 1;
+        i += 1;
     }
     out
 }

--- a/examples/caldera/economy.rue
+++ b/examples/caldera/economy.rue
@@ -16,18 +16,18 @@ pub fn step(inout world: model.World) -> Ledger {
             let produced = if entity.kind == model.WORKER() { 3 }
                 else if entity.kind == model.BUILDER() { 1 } else { 0 };
             let consumed = if entity.kind == model.GUARD() { 2 } else { 1 };
-            out.produced = out.produced + produced;
-            out.consumed = out.consumed + consumed;
+            out.produced += produced;
+            out.consumed += consumed;
             let next_inventory = entity.inventory + produced;
             let transfer = if next_inventory >= 8 { 4 } else { 0 };
-            out.transfers = out.transfers + transfer;
-            world.resources = world.resources + produced;
+            out.transfers += transfer;
+            world.resources += produced;
             if world.resources >= consumed + transfer {
                 world.resources = world.resources - consumed - transfer;
-                world.treasury = world.treasury + transfer;
+                world.treasury += transfer;
             }
             let credit = transfer / 2;
-            out.credits = out.credits + credit;
+            out.credits += credit;
             world.entities.set(i, model.Entity { id: entity.id, kind: entity.kind,
                 faction: entity.faction, x: entity.x, y: entity.y,
                 previous_x: entity.previous_x, previous_y: entity.previous_y,
@@ -38,7 +38,7 @@ pub fn step(inout world: model.World) -> Ledger {
                 born_tick: entity.born_tick, updated_tick: world.tick, alive: entity.alive });
             out.digest = metric.mix(out.digest, entity.id + produced * 17 + transfer * 31);
         }
-        i = i + 1;
+        i += 1;
     }
     out.valid = world.resources + world.treasury + out.consumed + out.credits >= before;
     out

--- a/examples/caldera/events.rue
+++ b/examples/caldera/events.rue
@@ -15,7 +15,7 @@ pub fn audit(borrow world: model.World) -> Audit {
         out.digest = metric.mix(out.digest, event.sequence);
         out.digest = metric.mix(out.digest, event.kind);
         out.digest = metric.mix(out.digest, event.actor);
-        i = i + 1;
+        i += 1;
     }
     out.valid = out.monotonic && (out.events == 0 || previous < world.next_sequence);
     out

--- a/examples/caldera/factions.rue
+++ b/examples/caldera/factions.rue
@@ -18,9 +18,9 @@ pub fn audit(borrow world: model.World) -> Relations {
         let mut b = a;
         while b <= max_faction {
             let relation = if a == b { 1 } else if (a + b + world.tick) % 3 == 0 { 2 } else { 3 };
-            if relation == 1 { out.allied = out.allied + 1; }
-            else if relation == 2 { out.hostile = out.hostile + 1; }
-            else { out.neutral = out.neutral + 1; }
+            if relation == 1 { out.allied += 1; }
+            else if relation == 2 { out.hostile += 1; }
+            else { out.neutral += 1; }
             out.digest = metric.mix(out.digest, a * 101 + b * 17 + relation);
             b += 1;
         }

--- a/examples/caldera/factions.rue
+++ b/examples/caldera/factions.rue
@@ -9,7 +9,7 @@ pub fn audit(borrow world: model.World) -> Relations {
     while i < world.entities.len() {
         let value = world.entities.get_or(i, model.empty_entity()).faction;
         if value > max_faction { max_faction = value; }
-        i = i + 1;
+        i += 1;
     }
     let mut out = Relations { factions: max_faction, allied: 0, hostile: 0,
         neutral: 0, digest: 14695981039346656037, valid: false };
@@ -22,9 +22,9 @@ pub fn audit(borrow world: model.World) -> Relations {
             else if relation == 2 { out.hostile = out.hostile + 1; }
             else { out.neutral = out.neutral + 1; }
             out.digest = metric.mix(out.digest, a * 101 + b * 17 + relation);
-            b = b + 1;
+            b += 1;
         }
-        a = a + 1;
+        a += 1;
     }
     out.valid = out.allied + out.hostile + out.neutral ==
         (max_faction * (max_faction + 1)) / 2;

--- a/examples/caldera/inventory.rue
+++ b/examples/caldera/inventory.rue
@@ -8,7 +8,7 @@ pub fn audit(borrow world: model.World) -> metric.Metric {
         let entity = world.entities.get_or(i, model.empty_entity());
         metric.observe(inout out, entity.inventory, entity.kind + 1);
         metric.warn(inout out, entity.inventory > 1000000);
-        i = i + 1;
+        i += 1;
     }
     metric.finish(inout out); out
 }

--- a/examples/caldera/lexer.rue
+++ b/examples/caldera/lexer.rue
@@ -47,7 +47,7 @@ pub fn scan(source: Bytes) -> Scan {
         if byte == 32 || byte == 9 || byte == 10 || byte == 13 {
             i += 1;
         } else if byte == 35 {
-            while i < source.len() && source.get_or(i, 0) != 10 { i = i + 1; }
+            while i < source.len() && source.get_or(i, 0) != 10 { i += 1; }
         } else if byte == 59 {
             out.tokens.push(token.Token { kind: token.SEMI(), number: 0, offset: i });
             i += 1;
@@ -61,9 +61,9 @@ pub fn scan(source: Bytes) -> Scan {
             out.tokens.push(token.Token { kind: token.NUMBER(), number: number, offset: start });
         } else if alpha(byte) {
             let start = i;
-            while i < source.len() && alpha(source.get_or(i, 0)) { i = i + 1; }
+            while i < source.len() && alpha(source.get_or(i, 0)) { i += 1; }
             let kind = word_kind(borrow source, start, i);
-            if kind == token.INVALID() { out.errors = out.errors + 1; }
+            if kind == token.INVALID() { out.errors += 1; }
             out.tokens.push(token.Token { kind: kind, number: 0, offset: start });
         } else {
             out.errors += 1;

--- a/examples/caldera/lexer.rue
+++ b/examples/caldera/lexer.rue
@@ -16,7 +16,7 @@ fn word_eq(borrow source: Bytes, start: u64, end: u64, value: str) -> bool {
     let mut i: u64 = 0;
     while i < value.len() {
         if upper(source.get_or(start + i, 0)) != value[i] { return false; }
-        i = i + 1;
+        i += 1;
     }
     true
 }
@@ -45,18 +45,18 @@ pub fn scan(source: Bytes) -> Scan {
     while i < source.len() {
         let byte = source.get_or(i, 0);
         if byte == 32 || byte == 9 || byte == 10 || byte == 13 {
-            i = i + 1;
+            i += 1;
         } else if byte == 35 {
             while i < source.len() && source.get_or(i, 0) != 10 { i = i + 1; }
         } else if byte == 59 {
             out.tokens.push(token.Token { kind: token.SEMI(), number: 0, offset: i });
-            i = i + 1;
+            i += 1;
         } else if digit(byte) {
             let start = i;
             let mut number: u64 = 0;
             while i < source.len() && digit(source.get_or(i, 0)) {
                 number = number * 10 + @intCast(source.get_or(i, 0) - 48);
-                i = i + 1;
+                i += 1;
             }
             out.tokens.push(token.Token { kind: token.NUMBER(), number: number, offset: start });
         } else if alpha(byte) {
@@ -66,9 +66,9 @@ pub fn scan(source: Bytes) -> Scan {
             if kind == token.INVALID() { out.errors = out.errors + 1; }
             out.tokens.push(token.Token { kind: kind, number: 0, offset: start });
         } else {
-            out.errors = out.errors + 1;
+            out.errors += 1;
             out.tokens.push(token.Token { kind: token.INVALID(), number: 0, offset: i });
-            i = i + 1;
+            i += 1;
         }
     }
     out.tokens.push(token.Token { kind: token.EOF(), number: 0, offset: source.len() });

--- a/examples/caldera/lockstep.rue
+++ b/examples/caldera/lockstep.rue
@@ -11,8 +11,8 @@ pub fn run(borrow baseline: model.World, count: u64) -> Result {
     let mut i: u64 = 0;
     while i < count {
         let a = tick.step(inout left); let b = tick.step(inout right);
-        if a.checksum != b.checksum { out.mismatches = out.mismatches + 1; }
-        out.ticks = out.ticks + 1; i = i + 1;
+        if a.checksum != b.checksum { out.mismatches += 1; }
+        out.ticks += 1; i += 1;
     }
     out.checksum = checksum.world(borrow left);
     out.valid = out.mismatches == 0 && out.checksum == checksum.world(borrow right);

--- a/examples/caldera/metric.rue
+++ b/examples/caldera/metric.rue
@@ -24,7 +24,7 @@ pub fn new(tag: u64) -> Metric {
 }
 
 pub fn observe(inout value: Metric, sample: u64, weight: u64) {
-    value.observations = value.observations + 1;
+    value.observations += 1;
     value.total = @wrapping_add(value.total, @wrapping_mul(sample, weight));
     if sample < value.minimum { value.minimum = sample; }
     if sample > value.maximum { value.maximum = sample; }
@@ -34,7 +34,7 @@ pub fn observe(inout value: Metric, sample: u64, weight: u64) {
 
 pub fn warn(inout value: Metric, condition: bool) {
     if condition {
-        value.warnings = value.warnings + 1;
+        value.warnings += 1;
         value.digest = mix(value.digest, 18446744073709551557);
     }
 }

--- a/examples/caldera/model.rue
+++ b/examples/caldera/model.rue
@@ -119,7 +119,7 @@ pub fn alive_count(borrow world: World) -> u64 {
     let mut count: u64 = 0;
     let mut i: u64 = 0;
     while i < world.entities.len() {
-        if world.entities.get_or(i, empty_entity()).alive { count = count + 1; }
+        if world.entities.get_or(i, empty_entity()).alive { count += 1; }
         i += 1;
     }
     count

--- a/examples/caldera/model.rue
+++ b/examples/caldera/model.rue
@@ -110,7 +110,7 @@ pub fn find_entity(borrow world: World, id: u64) -> u64 {
     let mut i: u64 = 0;
     while i < world.entities.len() {
         if world.entities.get_or(i, empty_entity()).id == id { return i; }
-        i = i + 1;
+        i += 1;
     }
     NONE()
 }
@@ -120,7 +120,7 @@ pub fn alive_count(borrow world: World) -> u64 {
     let mut i: u64 = 0;
     while i < world.entities.len() {
         if world.entities.get_or(i, empty_entity()).alive { count = count + 1; }
-        i = i + 1;
+        i += 1;
     }
     count
 }
@@ -137,7 +137,7 @@ pub fn add_event(inout world: World, kind: u64, actor: u64,
     target: u64, value: u64) {
     world.events.push(Event { tick: world.tick, kind: kind, actor: actor,
         target: target, value: value, sequence: world.next_sequence });
-    world.next_sequence = world.next_sequence + 1;
+    world.next_sequence += 1;
 }
 
 pub fn add_diagnostic(inout world: World, code: u64, subject: u64, detail: u64) {

--- a/examples/caldera/navigation.rue
+++ b/examples/caldera/navigation.rue
@@ -34,7 +34,7 @@ pub fn find(borrow world: model.World, sx: u64, sy: u64, gx: u64, gy: u64) -> Pa
         let index = queue.get_or(head, model.NONE()); head = head + 1;
         let tile = world.tiles.get_or(index, model.empty_tile());
         let distance = distances.get_or(index, model.NONE());
-        out.visited = out.visited + 1;
+        out.visited += 1;
         out.digest = metric.mix(out.digest, index);
         if index == goal { out.reached = true; out.distance = distance; break; }
         visit(borrow world, inout queue, inout distances,

--- a/examples/caldera/navigation.rue
+++ b/examples/caldera/navigation.rue
@@ -26,12 +26,12 @@ pub fn find(borrow world: model.World, sx: u64, sy: u64, gx: u64, gy: u64) -> Pa
     if start == model.NONE() || goal == model.NONE() { return out; }
     let mut distances = model.U64s.new();
     let mut i: u64 = 0;
-    while i < world.tiles.len() { distances.push(model.NONE()); i = i + 1; }
+    while i < world.tiles.len() { distances.push(model.NONE()); i += 1; }
     let mut queue = model.U64s.new();
     distances.set(start, 0); queue.push(start);
     let mut head: u64 = 0;
     while head < queue.len() {
-        let index = queue.get_or(head, model.NONE()); head = head + 1;
+        let index = queue.get_or(head, model.NONE()); head += 1;
         let tile = world.tiles.get_or(index, model.empty_tile());
         let distance = distances.get_or(index, model.NONE());
         out.visited += 1;

--- a/examples/caldera/navigation_oracle.rue
+++ b/examples/caldera/navigation_oracle.rue
@@ -22,7 +22,7 @@ pub fn distance(borrow world: model.World, sx: u64, sy: u64, gx: u64, gy: u64) -
     if start == model.NONE() || goal == model.NONE() { return model.NONE(); }
     let mut distances = model.U64s.new();
     let mut i: u64 = 0;
-    while i < world.tiles.len() { distances.push(model.NONE()); i = i + 1; }
+    while i < world.tiles.len() { distances.push(model.NONE()); i += 1; }
     distances.set(start, 0);
     let mut pass: u64 = 0;
     while pass < world.tiles.len() {

--- a/examples/caldera/navigation_oracle.rue
+++ b/examples/caldera/navigation_oracle.rue
@@ -34,10 +34,10 @@ pub fn distance(borrow world: model.World, sx: u64, sy: u64, gx: u64, gy: u64) -
             if relax(borrow world, inout distances, i, @intCast(tile.x), @intCast(tile.y) + 1) { changed = true; }
             if relax(borrow world, inout distances, i, @intCast(tile.x) - 1, @intCast(tile.y)) { changed = true; }
             if relax(borrow world, inout distances, i, @intCast(tile.x), @intCast(tile.y) - 1) { changed = true; }
-            i = i + 1;
+            i += 1;
         }
         if !changed { break; }
-        pass = pass + 1;
+        pass += 1;
     }
     distances.get_or(goal, model.NONE())
 }

--- a/examples/caldera/parser.rue
+++ b/examples/caldera/parser.rue
@@ -67,7 +67,7 @@ pub fn parse(tokens: token.Tokens) -> scenario.Scenario {
             out.expected_entities = take(inout state, token.NUMBER()).number;
             let _ = take(inout state, token.SEMI());
         } else {
-            state.errors = state.errors + 1;
+            state.errors += 1;
             while peek(borrow state).kind != token.SEMI() &&
                 peek(borrow state).kind != token.EOF() { let _ = advance(inout state); }
             if peek(borrow state).kind == token.SEMI() { let _ = advance(inout state); }

--- a/examples/caldera/parser.rue
+++ b/examples/caldera/parser.rue
@@ -10,12 +10,12 @@ fn peek(borrow state: State) -> token.Token {
 }
 fn advance(inout state: State) -> token.Token {
     let value = peek(borrow state);
-    if state.cursor < state.tokens.len() { state.cursor = state.cursor + 1; }
+    if state.cursor < state.tokens.len() { state.cursor += 1; }
     value
 }
 fn take(inout state: State, kind: u64) -> token.Token {
     let value = advance(inout state);
-    if value.kind != kind { state.errors = state.errors + 1; }
+    if value.kind != kind { state.errors += 1; }
     value
 }
 fn entity_kind(kind: u64) -> u64 {
@@ -49,7 +49,7 @@ pub fn parse(tokens: token.Tokens) -> scenario.Scenario {
             let y = take(inout state, token.NUMBER()).number;
             let _ = take(inout state, token.SEMI());
             let kind = entity_kind(kind_token.kind);
-            if kind == 0 { state.errors = state.errors + 1; }
+            if kind == 0 { state.errors += 1; }
             out.entities.push(scenario.EntitySpec { kind: kind, faction: faction, x: x, y: y });
         } else if statement.kind == token.TILE() {
             let x = take(inout state, token.NUMBER()).number;
@@ -57,7 +57,7 @@ pub fn parse(tokens: token.Tokens) -> scenario.Scenario {
             let terrain_token = advance(inout state);
             let _ = take(inout state, token.SEMI());
             let terrain = terrain_kind(terrain_token.kind);
-            if terrain == 0 { state.errors = state.errors + 1; }
+            if terrain == 0 { state.errors += 1; }
             out.tiles.push(scenario.TileSpec { x: x, y: y, terrain: terrain });
         } else if statement.kind == token.TICK() {
             out.ticks = take(inout state, token.NUMBER()).number;

--- a/examples/caldera/physics.rue
+++ b/examples/caldera/physics.rue
@@ -21,7 +21,7 @@ pub fn prepare(inout world: model.World) {
                 experience: entity.experience, born_tick: entity.born_tick,
                 updated_tick: world.tick, alive: entity.alive });
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -47,7 +47,7 @@ pub fn integrate(inout world: model.World) -> u64 {
                 credits: entity.credits, experience: entity.experience + if allowed { 1 } else { 0 },
                 born_tick: entity.born_tick, updated_tick: world.tick, alive: entity.alive });
         }
-        i = i + 1;
+        i += 1;
     }
     moved
 }

--- a/examples/caldera/physics.rue
+++ b/examples/caldera/physics.rue
@@ -36,7 +36,7 @@ pub fn integrate(inout world: model.World) -> u64 {
             let allowed = model.walkable(borrow world, nx, ny);
             let next_x = if allowed { nx } else { entity.x };
             let next_y = if allowed { ny } else { entity.y };
-            if next_x != entity.x || next_y != entity.y { moved = moved + 1; }
+            if next_x != entity.x || next_y != entity.y { moved += 1; }
             if !allowed { model.add_event(inout world, 2, entity.id, model.NONE(), 1); }
             world.entities.set(i, model.Entity { id: entity.id, kind: entity.kind,
                 faction: entity.faction, x: next_x, y: next_y,

--- a/examples/caldera/replay.rue
+++ b/examples/caldera/replay.rue
@@ -15,10 +15,10 @@ pub fn run(borrow baseline: model.World, count: u64) -> Result {
     let mut i: u64 = 0;
     while i < count {
         let result = tick.step(inout world);
-        out.ticks = out.ticks + 1;
+        out.ticks += 1;
         out.timeline_digest = metric.mix(out.timeline_digest, result.checksum);
         if !result.valid { out.valid = false; }
-        i = i + 1;
+        i += 1;
     }
     out.final_checksum = checksum.world(borrow world);
     out.valid = out.valid && out.ticks == count; out

--- a/examples/caldera/report_ai_csv.rue
+++ b/examples/caldera/report_ai_csv.rue
@@ -45,7 +45,7 @@ pub fn render(borrow world: model.World, suite_digest: u64) -> StrBuf {
         text.append_i64(inout out, entity.y); separator(inout out);
         text.append_u64(inout out, entity.health); separator(inout out);
         text.append_u64(inout out, entity.state); out.push(10);
-        i = i + 1;
+        i += 1;
     }
     field(inout out, "world_checksum", checksum.world(borrow world));
     field(inout out, "suite_digest", suite_digest);

--- a/examples/caldera/report_ai_graph.rue
+++ b/examples/caldera/report_ai_graph.rue
@@ -45,7 +45,7 @@ pub fn render(borrow world: model.World, suite_digest: u64) -> StrBuf {
         text.append_i64(inout out, entity.y); separator(inout out);
         text.append_u64(inout out, entity.health); separator(inout out);
         text.append_u64(inout out, entity.state); out.push(10);
-        i = i + 1;
+        i += 1;
     }
     field(inout out, "world_checksum", checksum.world(borrow world));
     field(inout out, "suite_digest", suite_digest);

--- a/examples/caldera/report_ai_human.rue
+++ b/examples/caldera/report_ai_human.rue
@@ -45,7 +45,7 @@ pub fn render(borrow world: model.World, suite_digest: u64) -> StrBuf {
         text.append_i64(inout out, entity.y); separator(inout out);
         text.append_u64(inout out, entity.health); separator(inout out);
         text.append_u64(inout out, entity.state); out.push(10);
-        i = i + 1;
+        i += 1;
     }
     field(inout out, "world_checksum", checksum.world(borrow world));
     field(inout out, "suite_digest", suite_digest);

--- a/examples/caldera/report_ai_json.rue
+++ b/examples/caldera/report_ai_json.rue
@@ -45,7 +45,7 @@ pub fn render(borrow world: model.World, suite_digest: u64) -> StrBuf {
         text.append_i64(inout out, entity.y); separator(inout out);
         text.append_u64(inout out, entity.health); separator(inout out);
         text.append_u64(inout out, entity.state); out.push(10);
-        i = i + 1;
+        i += 1;
     }
     field(inout out, "world_checksum", checksum.world(borrow world));
     field(inout out, "suite_digest", suite_digest);

--- a/examples/caldera/report_ai_markdown.rue
+++ b/examples/caldera/report_ai_markdown.rue
@@ -45,7 +45,7 @@ pub fn render(borrow world: model.World, suite_digest: u64) -> StrBuf {
         text.append_i64(inout out, entity.y); separator(inout out);
         text.append_u64(inout out, entity.health); separator(inout out);
         text.append_u64(inout out, entity.state); out.push(10);
-        i = i + 1;
+        i += 1;
     }
     field(inout out, "world_checksum", checksum.world(borrow world));
     field(inout out, "suite_digest", suite_digest);

--- a/examples/caldera/report_ai_ndjson.rue
+++ b/examples/caldera/report_ai_ndjson.rue
@@ -45,7 +45,7 @@ pub fn render(borrow world: model.World, suite_digest: u64) -> StrBuf {
         text.append_i64(inout out, entity.y); separator(inout out);
         text.append_u64(inout out, entity.health); separator(inout out);
         text.append_u64(inout out, entity.state); out.push(10);
-        i = i + 1;
+        i += 1;
     }
     field(inout out, "world_checksum", checksum.world(borrow world));
     field(inout out, "suite_digest", suite_digest);

--- a/examples/caldera/report_ai_prometheus.rue
+++ b/examples/caldera/report_ai_prometheus.rue
@@ -45,7 +45,7 @@ pub fn render(borrow world: model.World, suite_digest: u64) -> StrBuf {
         text.append_i64(inout out, entity.y); separator(inout out);
         text.append_u64(inout out, entity.health); separator(inout out);
         text.append_u64(inout out, entity.state); out.push(10);
-        i = i + 1;
+        i += 1;
     }
     field(inout out, "world_checksum", checksum.world(borrow world));
     field(inout out, "suite_digest", suite_digest);

--- a/examples/caldera/report_ai_trace.rue
+++ b/examples/caldera/report_ai_trace.rue
@@ -45,7 +45,7 @@ pub fn render(borrow world: model.World, suite_digest: u64) -> StrBuf {
         text.append_i64(inout out, entity.y); separator(inout out);
         text.append_u64(inout out, entity.health); separator(inout out);
         text.append_u64(inout out, entity.state); out.push(10);
-        i = i + 1;
+        i += 1;
     }
     field(inout out, "world_checksum", checksum.world(borrow world));
     field(inout out, "suite_digest", suite_digest);

--- a/examples/caldera/report_economy_csv.rue
+++ b/examples/caldera/report_economy_csv.rue
@@ -45,7 +45,7 @@ pub fn render(borrow world: model.World, suite_digest: u64) -> StrBuf {
         text.append_i64(inout out, entity.y); separator(inout out);
         text.append_u64(inout out, entity.health); separator(inout out);
         text.append_u64(inout out, entity.state); out.push(10);
-        i = i + 1;
+        i += 1;
     }
     field(inout out, "world_checksum", checksum.world(borrow world));
     field(inout out, "suite_digest", suite_digest);

--- a/examples/caldera/report_economy_graph.rue
+++ b/examples/caldera/report_economy_graph.rue
@@ -45,7 +45,7 @@ pub fn render(borrow world: model.World, suite_digest: u64) -> StrBuf {
         text.append_i64(inout out, entity.y); separator(inout out);
         text.append_u64(inout out, entity.health); separator(inout out);
         text.append_u64(inout out, entity.state); out.push(10);
-        i = i + 1;
+        i += 1;
     }
     field(inout out, "world_checksum", checksum.world(borrow world));
     field(inout out, "suite_digest", suite_digest);

--- a/examples/caldera/report_economy_human.rue
+++ b/examples/caldera/report_economy_human.rue
@@ -45,7 +45,7 @@ pub fn render(borrow world: model.World, suite_digest: u64) -> StrBuf {
         text.append_i64(inout out, entity.y); separator(inout out);
         text.append_u64(inout out, entity.health); separator(inout out);
         text.append_u64(inout out, entity.state); out.push(10);
-        i = i + 1;
+        i += 1;
     }
     field(inout out, "world_checksum", checksum.world(borrow world));
     field(inout out, "suite_digest", suite_digest);

--- a/examples/caldera/report_economy_json.rue
+++ b/examples/caldera/report_economy_json.rue
@@ -45,7 +45,7 @@ pub fn render(borrow world: model.World, suite_digest: u64) -> StrBuf {
         text.append_i64(inout out, entity.y); separator(inout out);
         text.append_u64(inout out, entity.health); separator(inout out);
         text.append_u64(inout out, entity.state); out.push(10);
-        i = i + 1;
+        i += 1;
     }
     field(inout out, "world_checksum", checksum.world(borrow world));
     field(inout out, "suite_digest", suite_digest);

--- a/examples/caldera/report_economy_markdown.rue
+++ b/examples/caldera/report_economy_markdown.rue
@@ -45,7 +45,7 @@ pub fn render(borrow world: model.World, suite_digest: u64) -> StrBuf {
         text.append_i64(inout out, entity.y); separator(inout out);
         text.append_u64(inout out, entity.health); separator(inout out);
         text.append_u64(inout out, entity.state); out.push(10);
-        i = i + 1;
+        i += 1;
     }
     field(inout out, "world_checksum", checksum.world(borrow world));
     field(inout out, "suite_digest", suite_digest);

--- a/examples/caldera/report_economy_ndjson.rue
+++ b/examples/caldera/report_economy_ndjson.rue
@@ -45,7 +45,7 @@ pub fn render(borrow world: model.World, suite_digest: u64) -> StrBuf {
         text.append_i64(inout out, entity.y); separator(inout out);
         text.append_u64(inout out, entity.health); separator(inout out);
         text.append_u64(inout out, entity.state); out.push(10);
-        i = i + 1;
+        i += 1;
     }
     field(inout out, "world_checksum", checksum.world(borrow world));
     field(inout out, "suite_digest", suite_digest);

--- a/examples/caldera/report_economy_prometheus.rue
+++ b/examples/caldera/report_economy_prometheus.rue
@@ -45,7 +45,7 @@ pub fn render(borrow world: model.World, suite_digest: u64) -> StrBuf {
         text.append_i64(inout out, entity.y); separator(inout out);
         text.append_u64(inout out, entity.health); separator(inout out);
         text.append_u64(inout out, entity.state); out.push(10);
-        i = i + 1;
+        i += 1;
     }
     field(inout out, "world_checksum", checksum.world(borrow world));
     field(inout out, "suite_digest", suite_digest);

--- a/examples/caldera/report_economy_trace.rue
+++ b/examples/caldera/report_economy_trace.rue
@@ -45,7 +45,7 @@ pub fn render(borrow world: model.World, suite_digest: u64) -> StrBuf {
         text.append_i64(inout out, entity.y); separator(inout out);
         text.append_u64(inout out, entity.health); separator(inout out);
         text.append_u64(inout out, entity.state); out.push(10);
-        i = i + 1;
+        i += 1;
     }
     field(inout out, "world_checksum", checksum.world(borrow world));
     field(inout out, "suite_digest", suite_digest);

--- a/examples/caldera/report_entity_csv.rue
+++ b/examples/caldera/report_entity_csv.rue
@@ -45,7 +45,7 @@ pub fn render(borrow world: model.World, suite_digest: u64) -> StrBuf {
         text.append_i64(inout out, entity.y); separator(inout out);
         text.append_u64(inout out, entity.health); separator(inout out);
         text.append_u64(inout out, entity.state); out.push(10);
-        i = i + 1;
+        i += 1;
     }
     field(inout out, "world_checksum", checksum.world(borrow world));
     field(inout out, "suite_digest", suite_digest);

--- a/examples/caldera/report_entity_graph.rue
+++ b/examples/caldera/report_entity_graph.rue
@@ -45,7 +45,7 @@ pub fn render(borrow world: model.World, suite_digest: u64) -> StrBuf {
         text.append_i64(inout out, entity.y); separator(inout out);
         text.append_u64(inout out, entity.health); separator(inout out);
         text.append_u64(inout out, entity.state); out.push(10);
-        i = i + 1;
+        i += 1;
     }
     field(inout out, "world_checksum", checksum.world(borrow world));
     field(inout out, "suite_digest", suite_digest);

--- a/examples/caldera/report_entity_human.rue
+++ b/examples/caldera/report_entity_human.rue
@@ -45,7 +45,7 @@ pub fn render(borrow world: model.World, suite_digest: u64) -> StrBuf {
         text.append_i64(inout out, entity.y); separator(inout out);
         text.append_u64(inout out, entity.health); separator(inout out);
         text.append_u64(inout out, entity.state); out.push(10);
-        i = i + 1;
+        i += 1;
     }
     field(inout out, "world_checksum", checksum.world(borrow world));
     field(inout out, "suite_digest", suite_digest);

--- a/examples/caldera/report_entity_json.rue
+++ b/examples/caldera/report_entity_json.rue
@@ -45,7 +45,7 @@ pub fn render(borrow world: model.World, suite_digest: u64) -> StrBuf {
         text.append_i64(inout out, entity.y); separator(inout out);
         text.append_u64(inout out, entity.health); separator(inout out);
         text.append_u64(inout out, entity.state); out.push(10);
-        i = i + 1;
+        i += 1;
     }
     field(inout out, "world_checksum", checksum.world(borrow world));
     field(inout out, "suite_digest", suite_digest);

--- a/examples/caldera/report_entity_markdown.rue
+++ b/examples/caldera/report_entity_markdown.rue
@@ -45,7 +45,7 @@ pub fn render(borrow world: model.World, suite_digest: u64) -> StrBuf {
         text.append_i64(inout out, entity.y); separator(inout out);
         text.append_u64(inout out, entity.health); separator(inout out);
         text.append_u64(inout out, entity.state); out.push(10);
-        i = i + 1;
+        i += 1;
     }
     field(inout out, "world_checksum", checksum.world(borrow world));
     field(inout out, "suite_digest", suite_digest);

--- a/examples/caldera/report_entity_ndjson.rue
+++ b/examples/caldera/report_entity_ndjson.rue
@@ -45,7 +45,7 @@ pub fn render(borrow world: model.World, suite_digest: u64) -> StrBuf {
         text.append_i64(inout out, entity.y); separator(inout out);
         text.append_u64(inout out, entity.health); separator(inout out);
         text.append_u64(inout out, entity.state); out.push(10);
-        i = i + 1;
+        i += 1;
     }
     field(inout out, "world_checksum", checksum.world(borrow world));
     field(inout out, "suite_digest", suite_digest);

--- a/examples/caldera/report_entity_prometheus.rue
+++ b/examples/caldera/report_entity_prometheus.rue
@@ -45,7 +45,7 @@ pub fn render(borrow world: model.World, suite_digest: u64) -> StrBuf {
         text.append_i64(inout out, entity.y); separator(inout out);
         text.append_u64(inout out, entity.health); separator(inout out);
         text.append_u64(inout out, entity.state); out.push(10);
-        i = i + 1;
+        i += 1;
     }
     field(inout out, "world_checksum", checksum.world(borrow world));
     field(inout out, "suite_digest", suite_digest);

--- a/examples/caldera/report_entity_trace.rue
+++ b/examples/caldera/report_entity_trace.rue
@@ -45,7 +45,7 @@ pub fn render(borrow world: model.World, suite_digest: u64) -> StrBuf {
         text.append_i64(inout out, entity.y); separator(inout out);
         text.append_u64(inout out, entity.health); separator(inout out);
         text.append_u64(inout out, entity.state); out.push(10);
-        i = i + 1;
+        i += 1;
     }
     field(inout out, "world_checksum", checksum.world(borrow world));
     field(inout out, "suite_digest", suite_digest);

--- a/examples/caldera/report_network_csv.rue
+++ b/examples/caldera/report_network_csv.rue
@@ -45,7 +45,7 @@ pub fn render(borrow world: model.World, suite_digest: u64) -> StrBuf {
         text.append_i64(inout out, entity.y); separator(inout out);
         text.append_u64(inout out, entity.health); separator(inout out);
         text.append_u64(inout out, entity.state); out.push(10);
-        i = i + 1;
+        i += 1;
     }
     field(inout out, "world_checksum", checksum.world(borrow world));
     field(inout out, "suite_digest", suite_digest);

--- a/examples/caldera/report_network_graph.rue
+++ b/examples/caldera/report_network_graph.rue
@@ -45,7 +45,7 @@ pub fn render(borrow world: model.World, suite_digest: u64) -> StrBuf {
         text.append_i64(inout out, entity.y); separator(inout out);
         text.append_u64(inout out, entity.health); separator(inout out);
         text.append_u64(inout out, entity.state); out.push(10);
-        i = i + 1;
+        i += 1;
     }
     field(inout out, "world_checksum", checksum.world(borrow world));
     field(inout out, "suite_digest", suite_digest);

--- a/examples/caldera/report_network_human.rue
+++ b/examples/caldera/report_network_human.rue
@@ -45,7 +45,7 @@ pub fn render(borrow world: model.World, suite_digest: u64) -> StrBuf {
         text.append_i64(inout out, entity.y); separator(inout out);
         text.append_u64(inout out, entity.health); separator(inout out);
         text.append_u64(inout out, entity.state); out.push(10);
-        i = i + 1;
+        i += 1;
     }
     field(inout out, "world_checksum", checksum.world(borrow world));
     field(inout out, "suite_digest", suite_digest);

--- a/examples/caldera/report_network_json.rue
+++ b/examples/caldera/report_network_json.rue
@@ -45,7 +45,7 @@ pub fn render(borrow world: model.World, suite_digest: u64) -> StrBuf {
         text.append_i64(inout out, entity.y); separator(inout out);
         text.append_u64(inout out, entity.health); separator(inout out);
         text.append_u64(inout out, entity.state); out.push(10);
-        i = i + 1;
+        i += 1;
     }
     field(inout out, "world_checksum", checksum.world(borrow world));
     field(inout out, "suite_digest", suite_digest);

--- a/examples/caldera/report_network_markdown.rue
+++ b/examples/caldera/report_network_markdown.rue
@@ -45,7 +45,7 @@ pub fn render(borrow world: model.World, suite_digest: u64) -> StrBuf {
         text.append_i64(inout out, entity.y); separator(inout out);
         text.append_u64(inout out, entity.health); separator(inout out);
         text.append_u64(inout out, entity.state); out.push(10);
-        i = i + 1;
+        i += 1;
     }
     field(inout out, "world_checksum", checksum.world(borrow world));
     field(inout out, "suite_digest", suite_digest);

--- a/examples/caldera/report_network_ndjson.rue
+++ b/examples/caldera/report_network_ndjson.rue
@@ -45,7 +45,7 @@ pub fn render(borrow world: model.World, suite_digest: u64) -> StrBuf {
         text.append_i64(inout out, entity.y); separator(inout out);
         text.append_u64(inout out, entity.health); separator(inout out);
         text.append_u64(inout out, entity.state); out.push(10);
-        i = i + 1;
+        i += 1;
     }
     field(inout out, "world_checksum", checksum.world(borrow world));
     field(inout out, "suite_digest", suite_digest);

--- a/examples/caldera/report_network_prometheus.rue
+++ b/examples/caldera/report_network_prometheus.rue
@@ -45,7 +45,7 @@ pub fn render(borrow world: model.World, suite_digest: u64) -> StrBuf {
         text.append_i64(inout out, entity.y); separator(inout out);
         text.append_u64(inout out, entity.health); separator(inout out);
         text.append_u64(inout out, entity.state); out.push(10);
-        i = i + 1;
+        i += 1;
     }
     field(inout out, "world_checksum", checksum.world(borrow world));
     field(inout out, "suite_digest", suite_digest);

--- a/examples/caldera/report_network_trace.rue
+++ b/examples/caldera/report_network_trace.rue
@@ -45,7 +45,7 @@ pub fn render(borrow world: model.World, suite_digest: u64) -> StrBuf {
         text.append_i64(inout out, entity.y); separator(inout out);
         text.append_u64(inout out, entity.health); separator(inout out);
         text.append_u64(inout out, entity.state); out.push(10);
-        i = i + 1;
+        i += 1;
     }
     field(inout out, "world_checksum", checksum.world(borrow world));
     field(inout out, "suite_digest", suite_digest);

--- a/examples/caldera/report_physics_csv.rue
+++ b/examples/caldera/report_physics_csv.rue
@@ -45,7 +45,7 @@ pub fn render(borrow world: model.World, suite_digest: u64) -> StrBuf {
         text.append_i64(inout out, entity.y); separator(inout out);
         text.append_u64(inout out, entity.health); separator(inout out);
         text.append_u64(inout out, entity.state); out.push(10);
-        i = i + 1;
+        i += 1;
     }
     field(inout out, "world_checksum", checksum.world(borrow world));
     field(inout out, "suite_digest", suite_digest);

--- a/examples/caldera/report_physics_graph.rue
+++ b/examples/caldera/report_physics_graph.rue
@@ -45,7 +45,7 @@ pub fn render(borrow world: model.World, suite_digest: u64) -> StrBuf {
         text.append_i64(inout out, entity.y); separator(inout out);
         text.append_u64(inout out, entity.health); separator(inout out);
         text.append_u64(inout out, entity.state); out.push(10);
-        i = i + 1;
+        i += 1;
     }
     field(inout out, "world_checksum", checksum.world(borrow world));
     field(inout out, "suite_digest", suite_digest);

--- a/examples/caldera/report_physics_human.rue
+++ b/examples/caldera/report_physics_human.rue
@@ -45,7 +45,7 @@ pub fn render(borrow world: model.World, suite_digest: u64) -> StrBuf {
         text.append_i64(inout out, entity.y); separator(inout out);
         text.append_u64(inout out, entity.health); separator(inout out);
         text.append_u64(inout out, entity.state); out.push(10);
-        i = i + 1;
+        i += 1;
     }
     field(inout out, "world_checksum", checksum.world(borrow world));
     field(inout out, "suite_digest", suite_digest);

--- a/examples/caldera/report_physics_json.rue
+++ b/examples/caldera/report_physics_json.rue
@@ -45,7 +45,7 @@ pub fn render(borrow world: model.World, suite_digest: u64) -> StrBuf {
         text.append_i64(inout out, entity.y); separator(inout out);
         text.append_u64(inout out, entity.health); separator(inout out);
         text.append_u64(inout out, entity.state); out.push(10);
-        i = i + 1;
+        i += 1;
     }
     field(inout out, "world_checksum", checksum.world(borrow world));
     field(inout out, "suite_digest", suite_digest);

--- a/examples/caldera/report_physics_markdown.rue
+++ b/examples/caldera/report_physics_markdown.rue
@@ -45,7 +45,7 @@ pub fn render(borrow world: model.World, suite_digest: u64) -> StrBuf {
         text.append_i64(inout out, entity.y); separator(inout out);
         text.append_u64(inout out, entity.health); separator(inout out);
         text.append_u64(inout out, entity.state); out.push(10);
-        i = i + 1;
+        i += 1;
     }
     field(inout out, "world_checksum", checksum.world(borrow world));
     field(inout out, "suite_digest", suite_digest);

--- a/examples/caldera/report_physics_ndjson.rue
+++ b/examples/caldera/report_physics_ndjson.rue
@@ -45,7 +45,7 @@ pub fn render(borrow world: model.World, suite_digest: u64) -> StrBuf {
         text.append_i64(inout out, entity.y); separator(inout out);
         text.append_u64(inout out, entity.health); separator(inout out);
         text.append_u64(inout out, entity.state); out.push(10);
-        i = i + 1;
+        i += 1;
     }
     field(inout out, "world_checksum", checksum.world(borrow world));
     field(inout out, "suite_digest", suite_digest);

--- a/examples/caldera/report_physics_prometheus.rue
+++ b/examples/caldera/report_physics_prometheus.rue
@@ -45,7 +45,7 @@ pub fn render(borrow world: model.World, suite_digest: u64) -> StrBuf {
         text.append_i64(inout out, entity.y); separator(inout out);
         text.append_u64(inout out, entity.health); separator(inout out);
         text.append_u64(inout out, entity.state); out.push(10);
-        i = i + 1;
+        i += 1;
     }
     field(inout out, "world_checksum", checksum.world(borrow world));
     field(inout out, "suite_digest", suite_digest);

--- a/examples/caldera/report_physics_trace.rue
+++ b/examples/caldera/report_physics_trace.rue
@@ -45,7 +45,7 @@ pub fn render(borrow world: model.World, suite_digest: u64) -> StrBuf {
         text.append_i64(inout out, entity.y); separator(inout out);
         text.append_u64(inout out, entity.health); separator(inout out);
         text.append_u64(inout out, entity.state); out.push(10);
-        i = i + 1;
+        i += 1;
     }
     field(inout out, "world_checksum", checksum.world(borrow world));
     field(inout out, "suite_digest", suite_digest);

--- a/examples/caldera/report_replay_csv.rue
+++ b/examples/caldera/report_replay_csv.rue
@@ -45,7 +45,7 @@ pub fn render(borrow world: model.World, suite_digest: u64) -> StrBuf {
         text.append_i64(inout out, entity.y); separator(inout out);
         text.append_u64(inout out, entity.health); separator(inout out);
         text.append_u64(inout out, entity.state); out.push(10);
-        i = i + 1;
+        i += 1;
     }
     field(inout out, "world_checksum", checksum.world(borrow world));
     field(inout out, "suite_digest", suite_digest);

--- a/examples/caldera/report_replay_graph.rue
+++ b/examples/caldera/report_replay_graph.rue
@@ -45,7 +45,7 @@ pub fn render(borrow world: model.World, suite_digest: u64) -> StrBuf {
         text.append_i64(inout out, entity.y); separator(inout out);
         text.append_u64(inout out, entity.health); separator(inout out);
         text.append_u64(inout out, entity.state); out.push(10);
-        i = i + 1;
+        i += 1;
     }
     field(inout out, "world_checksum", checksum.world(borrow world));
     field(inout out, "suite_digest", suite_digest);

--- a/examples/caldera/report_replay_human.rue
+++ b/examples/caldera/report_replay_human.rue
@@ -45,7 +45,7 @@ pub fn render(borrow world: model.World, suite_digest: u64) -> StrBuf {
         text.append_i64(inout out, entity.y); separator(inout out);
         text.append_u64(inout out, entity.health); separator(inout out);
         text.append_u64(inout out, entity.state); out.push(10);
-        i = i + 1;
+        i += 1;
     }
     field(inout out, "world_checksum", checksum.world(borrow world));
     field(inout out, "suite_digest", suite_digest);

--- a/examples/caldera/report_replay_json.rue
+++ b/examples/caldera/report_replay_json.rue
@@ -45,7 +45,7 @@ pub fn render(borrow world: model.World, suite_digest: u64) -> StrBuf {
         text.append_i64(inout out, entity.y); separator(inout out);
         text.append_u64(inout out, entity.health); separator(inout out);
         text.append_u64(inout out, entity.state); out.push(10);
-        i = i + 1;
+        i += 1;
     }
     field(inout out, "world_checksum", checksum.world(borrow world));
     field(inout out, "suite_digest", suite_digest);

--- a/examples/caldera/report_replay_markdown.rue
+++ b/examples/caldera/report_replay_markdown.rue
@@ -45,7 +45,7 @@ pub fn render(borrow world: model.World, suite_digest: u64) -> StrBuf {
         text.append_i64(inout out, entity.y); separator(inout out);
         text.append_u64(inout out, entity.health); separator(inout out);
         text.append_u64(inout out, entity.state); out.push(10);
-        i = i + 1;
+        i += 1;
     }
     field(inout out, "world_checksum", checksum.world(borrow world));
     field(inout out, "suite_digest", suite_digest);

--- a/examples/caldera/report_replay_ndjson.rue
+++ b/examples/caldera/report_replay_ndjson.rue
@@ -45,7 +45,7 @@ pub fn render(borrow world: model.World, suite_digest: u64) -> StrBuf {
         text.append_i64(inout out, entity.y); separator(inout out);
         text.append_u64(inout out, entity.health); separator(inout out);
         text.append_u64(inout out, entity.state); out.push(10);
-        i = i + 1;
+        i += 1;
     }
     field(inout out, "world_checksum", checksum.world(borrow world));
     field(inout out, "suite_digest", suite_digest);

--- a/examples/caldera/report_replay_prometheus.rue
+++ b/examples/caldera/report_replay_prometheus.rue
@@ -45,7 +45,7 @@ pub fn render(borrow world: model.World, suite_digest: u64) -> StrBuf {
         text.append_i64(inout out, entity.y); separator(inout out);
         text.append_u64(inout out, entity.health); separator(inout out);
         text.append_u64(inout out, entity.state); out.push(10);
-        i = i + 1;
+        i += 1;
     }
     field(inout out, "world_checksum", checksum.world(borrow world));
     field(inout out, "suite_digest", suite_digest);

--- a/examples/caldera/report_replay_trace.rue
+++ b/examples/caldera/report_replay_trace.rue
@@ -45,7 +45,7 @@ pub fn render(borrow world: model.World, suite_digest: u64) -> StrBuf {
         text.append_i64(inout out, entity.y); separator(inout out);
         text.append_u64(inout out, entity.health); separator(inout out);
         text.append_u64(inout out, entity.state); out.push(10);
-        i = i + 1;
+        i += 1;
     }
     field(inout out, "world_checksum", checksum.world(borrow world));
     field(inout out, "suite_digest", suite_digest);

--- a/examples/caldera/report_script_csv.rue
+++ b/examples/caldera/report_script_csv.rue
@@ -45,7 +45,7 @@ pub fn render(borrow world: model.World, suite_digest: u64) -> StrBuf {
         text.append_i64(inout out, entity.y); separator(inout out);
         text.append_u64(inout out, entity.health); separator(inout out);
         text.append_u64(inout out, entity.state); out.push(10);
-        i = i + 1;
+        i += 1;
     }
     field(inout out, "world_checksum", checksum.world(borrow world));
     field(inout out, "suite_digest", suite_digest);

--- a/examples/caldera/report_script_graph.rue
+++ b/examples/caldera/report_script_graph.rue
@@ -45,7 +45,7 @@ pub fn render(borrow world: model.World, suite_digest: u64) -> StrBuf {
         text.append_i64(inout out, entity.y); separator(inout out);
         text.append_u64(inout out, entity.health); separator(inout out);
         text.append_u64(inout out, entity.state); out.push(10);
-        i = i + 1;
+        i += 1;
     }
     field(inout out, "world_checksum", checksum.world(borrow world));
     field(inout out, "suite_digest", suite_digest);

--- a/examples/caldera/report_script_human.rue
+++ b/examples/caldera/report_script_human.rue
@@ -45,7 +45,7 @@ pub fn render(borrow world: model.World, suite_digest: u64) -> StrBuf {
         text.append_i64(inout out, entity.y); separator(inout out);
         text.append_u64(inout out, entity.health); separator(inout out);
         text.append_u64(inout out, entity.state); out.push(10);
-        i = i + 1;
+        i += 1;
     }
     field(inout out, "world_checksum", checksum.world(borrow world));
     field(inout out, "suite_digest", suite_digest);

--- a/examples/caldera/report_script_json.rue
+++ b/examples/caldera/report_script_json.rue
@@ -45,7 +45,7 @@ pub fn render(borrow world: model.World, suite_digest: u64) -> StrBuf {
         text.append_i64(inout out, entity.y); separator(inout out);
         text.append_u64(inout out, entity.health); separator(inout out);
         text.append_u64(inout out, entity.state); out.push(10);
-        i = i + 1;
+        i += 1;
     }
     field(inout out, "world_checksum", checksum.world(borrow world));
     field(inout out, "suite_digest", suite_digest);

--- a/examples/caldera/report_script_markdown.rue
+++ b/examples/caldera/report_script_markdown.rue
@@ -45,7 +45,7 @@ pub fn render(borrow world: model.World, suite_digest: u64) -> StrBuf {
         text.append_i64(inout out, entity.y); separator(inout out);
         text.append_u64(inout out, entity.health); separator(inout out);
         text.append_u64(inout out, entity.state); out.push(10);
-        i = i + 1;
+        i += 1;
     }
     field(inout out, "world_checksum", checksum.world(borrow world));
     field(inout out, "suite_digest", suite_digest);

--- a/examples/caldera/report_script_ndjson.rue
+++ b/examples/caldera/report_script_ndjson.rue
@@ -45,7 +45,7 @@ pub fn render(borrow world: model.World, suite_digest: u64) -> StrBuf {
         text.append_i64(inout out, entity.y); separator(inout out);
         text.append_u64(inout out, entity.health); separator(inout out);
         text.append_u64(inout out, entity.state); out.push(10);
-        i = i + 1;
+        i += 1;
     }
     field(inout out, "world_checksum", checksum.world(borrow world));
     field(inout out, "suite_digest", suite_digest);

--- a/examples/caldera/report_script_prometheus.rue
+++ b/examples/caldera/report_script_prometheus.rue
@@ -45,7 +45,7 @@ pub fn render(borrow world: model.World, suite_digest: u64) -> StrBuf {
         text.append_i64(inout out, entity.y); separator(inout out);
         text.append_u64(inout out, entity.health); separator(inout out);
         text.append_u64(inout out, entity.state); out.push(10);
-        i = i + 1;
+        i += 1;
     }
     field(inout out, "world_checksum", checksum.world(borrow world));
     field(inout out, "suite_digest", suite_digest);

--- a/examples/caldera/report_script_trace.rue
+++ b/examples/caldera/report_script_trace.rue
@@ -45,7 +45,7 @@ pub fn render(borrow world: model.World, suite_digest: u64) -> StrBuf {
         text.append_i64(inout out, entity.y); separator(inout out);
         text.append_u64(inout out, entity.health); separator(inout out);
         text.append_u64(inout out, entity.state); out.push(10);
-        i = i + 1;
+        i += 1;
     }
     field(inout out, "world_checksum", checksum.world(borrow world));
     field(inout out, "suite_digest", suite_digest);

--- a/examples/caldera/report_suite.rue
+++ b/examples/caldera/report_suite.rue
@@ -71,10 +71,10 @@ const report_replay_graph = @import("report_replay_graph.rue");
 pub struct Summary { documents: u64, bytes: u64, deterministic_mismatches: u64,
     failures: u64, digest: u64, valid: bool }
 fn include(inout out: Summary, borrow first: StrBuf, borrow second: StrBuf, verified: bool) {
-    out.documents = out.documents + 1; out.bytes = out.bytes + first.len();
+    out.documents += 1; out.bytes += first.len();
     let a = text.fnv1a(borrow first); let b = text.fnv1a(borrow second);
-    if a != b { out.deterministic_mismatches = out.deterministic_mismatches + 1; }
-    if !verified { out.failures = out.failures + 1; }
+    if a != b { out.deterministic_mismatches += 1; }
+    if !verified { out.failures += 1; }
     out.digest = metric.mix(out.digest, a);
 }
 pub fn run(borrow world: model.World, suite_digest: u64) -> Summary {

--- a/examples/caldera/report_world_csv.rue
+++ b/examples/caldera/report_world_csv.rue
@@ -45,7 +45,7 @@ pub fn render(borrow world: model.World, suite_digest: u64) -> StrBuf {
         text.append_i64(inout out, entity.y); separator(inout out);
         text.append_u64(inout out, entity.health); separator(inout out);
         text.append_u64(inout out, entity.state); out.push(10);
-        i = i + 1;
+        i += 1;
     }
     field(inout out, "world_checksum", checksum.world(borrow world));
     field(inout out, "suite_digest", suite_digest);

--- a/examples/caldera/report_world_graph.rue
+++ b/examples/caldera/report_world_graph.rue
@@ -45,7 +45,7 @@ pub fn render(borrow world: model.World, suite_digest: u64) -> StrBuf {
         text.append_i64(inout out, entity.y); separator(inout out);
         text.append_u64(inout out, entity.health); separator(inout out);
         text.append_u64(inout out, entity.state); out.push(10);
-        i = i + 1;
+        i += 1;
     }
     field(inout out, "world_checksum", checksum.world(borrow world));
     field(inout out, "suite_digest", suite_digest);

--- a/examples/caldera/report_world_human.rue
+++ b/examples/caldera/report_world_human.rue
@@ -45,7 +45,7 @@ pub fn render(borrow world: model.World, suite_digest: u64) -> StrBuf {
         text.append_i64(inout out, entity.y); separator(inout out);
         text.append_u64(inout out, entity.health); separator(inout out);
         text.append_u64(inout out, entity.state); out.push(10);
-        i = i + 1;
+        i += 1;
     }
     field(inout out, "world_checksum", checksum.world(borrow world));
     field(inout out, "suite_digest", suite_digest);

--- a/examples/caldera/report_world_json.rue
+++ b/examples/caldera/report_world_json.rue
@@ -45,7 +45,7 @@ pub fn render(borrow world: model.World, suite_digest: u64) -> StrBuf {
         text.append_i64(inout out, entity.y); separator(inout out);
         text.append_u64(inout out, entity.health); separator(inout out);
         text.append_u64(inout out, entity.state); out.push(10);
-        i = i + 1;
+        i += 1;
     }
     field(inout out, "world_checksum", checksum.world(borrow world));
     field(inout out, "suite_digest", suite_digest);

--- a/examples/caldera/report_world_markdown.rue
+++ b/examples/caldera/report_world_markdown.rue
@@ -45,7 +45,7 @@ pub fn render(borrow world: model.World, suite_digest: u64) -> StrBuf {
         text.append_i64(inout out, entity.y); separator(inout out);
         text.append_u64(inout out, entity.health); separator(inout out);
         text.append_u64(inout out, entity.state); out.push(10);
-        i = i + 1;
+        i += 1;
     }
     field(inout out, "world_checksum", checksum.world(borrow world));
     field(inout out, "suite_digest", suite_digest);

--- a/examples/caldera/report_world_ndjson.rue
+++ b/examples/caldera/report_world_ndjson.rue
@@ -45,7 +45,7 @@ pub fn render(borrow world: model.World, suite_digest: u64) -> StrBuf {
         text.append_i64(inout out, entity.y); separator(inout out);
         text.append_u64(inout out, entity.health); separator(inout out);
         text.append_u64(inout out, entity.state); out.push(10);
-        i = i + 1;
+        i += 1;
     }
     field(inout out, "world_checksum", checksum.world(borrow world));
     field(inout out, "suite_digest", suite_digest);

--- a/examples/caldera/report_world_prometheus.rue
+++ b/examples/caldera/report_world_prometheus.rue
@@ -45,7 +45,7 @@ pub fn render(borrow world: model.World, suite_digest: u64) -> StrBuf {
         text.append_i64(inout out, entity.y); separator(inout out);
         text.append_u64(inout out, entity.health); separator(inout out);
         text.append_u64(inout out, entity.state); out.push(10);
-        i = i + 1;
+        i += 1;
     }
     field(inout out, "world_checksum", checksum.world(borrow world));
     field(inout out, "suite_digest", suite_digest);

--- a/examples/caldera/report_world_trace.rue
+++ b/examples/caldera/report_world_trace.rue
@@ -45,7 +45,7 @@ pub fn render(borrow world: model.World, suite_digest: u64) -> StrBuf {
         text.append_i64(inout out, entity.y); separator(inout out);
         text.append_u64(inout out, entity.health); separator(inout out);
         text.append_u64(inout out, entity.state); out.push(10);
-        i = i + 1;
+        i += 1;
     }
     field(inout out, "world_checksum", checksum.world(borrow world));
     field(inout out, "suite_digest", suite_digest);

--- a/examples/caldera/rollback.rue
+++ b/examples/caldera/rollback.rue
@@ -9,7 +9,7 @@ pub struct Result { target_tick: u64, resimulated: u64,
 
 pub fn restore(borrow baseline: model.World, target_tick: u64) -> Result {
     let mut world = world_clone.clone(borrow baseline);
-    world.rollback_count = world.rollback_count + 1;
+    world.rollback_count += 1;
     let count = if target_tick > world.tick { target_tick - world.tick } else { 0 };
     let run = simulation.run(inout world, count);
     Result { target_tick: target_tick, resimulated: count,

--- a/examples/caldera/rule_combat_bound.rue
+++ b/examples/caldera/rule_combat_bound.rue
@@ -31,7 +31,7 @@ fn inspect_entities(inout out: result.Result, borrow world: model.World) {
         let matched = entity_match(borrow world, borrow entity);
         let benefit = entity_benefit(borrow world, borrow entity);
         result.record(inout out, matched, matched && benefit > POLICY() % 40, benefit);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -45,7 +45,7 @@ fn inspect_tiles(inout out: result.Result, borrow world: model.World) {
             else { tile.resource > POLICY() % 29 };
         let benefit = tile.resource + tile.height * 3 + tile.region + POLICY();
         result.record(inout out, matched, matched && benefit % 3 != 0, benefit);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -56,7 +56,7 @@ fn inspect_events(inout out: result.Result, borrow world: model.World) {
         let matched = (event.kind + POLICY()) % 5 == 0;
         let benefit = event.value + event.sequence + event.actor % 211 + POLICY();
         result.record(inout out, matched, matched && event.tick <= world.tick, benefit);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -68,7 +68,7 @@ fn inspect_snapshots(inout out: result.Result, borrow world: model.World) {
         let benefit = item.entity_count * 7 + item.event_count * 5 +
             item.command_count * 3 + item.checksum % 4093;
         result.record(inout out, matched, matched && item.checksum != 0, benefit);
-        i = i + 1;
+        i += 1;
     }
 }
 

--- a/examples/caldera/rule_combat_defer.rue
+++ b/examples/caldera/rule_combat_defer.rue
@@ -31,7 +31,7 @@ fn inspect_entities(inout out: result.Result, borrow world: model.World) {
         let matched = entity_match(borrow world, borrow entity);
         let benefit = entity_benefit(borrow world, borrow entity);
         result.record(inout out, matched, matched && benefit > POLICY() % 40, benefit);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -45,7 +45,7 @@ fn inspect_tiles(inout out: result.Result, borrow world: model.World) {
             else { tile.resource > POLICY() % 29 };
         let benefit = tile.resource + tile.height * 3 + tile.region + POLICY();
         result.record(inout out, matched, matched && benefit % 3 != 0, benefit);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -56,7 +56,7 @@ fn inspect_events(inout out: result.Result, borrow world: model.World) {
         let matched = (event.kind + POLICY()) % 5 == 0;
         let benefit = event.value + event.sequence + event.actor % 211 + POLICY();
         result.record(inout out, matched, matched && event.tick <= world.tick, benefit);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -68,7 +68,7 @@ fn inspect_snapshots(inout out: result.Result, borrow world: model.World) {
         let benefit = item.entity_count * 7 + item.event_count * 5 +
             item.command_count * 3 + item.checksum % 4093;
         result.record(inout out, matched, matched && item.checksum != 0, benefit);
-        i = i + 1;
+        i += 1;
     }
 }
 

--- a/examples/caldera/rule_combat_explain.rue
+++ b/examples/caldera/rule_combat_explain.rue
@@ -31,7 +31,7 @@ fn inspect_entities(inout out: result.Result, borrow world: model.World) {
         let matched = entity_match(borrow world, borrow entity);
         let benefit = entity_benefit(borrow world, borrow entity);
         result.record(inout out, matched, matched && benefit > POLICY() % 40, benefit);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -45,7 +45,7 @@ fn inspect_tiles(inout out: result.Result, borrow world: model.World) {
             else { tile.resource > POLICY() % 29 };
         let benefit = tile.resource + tile.height * 3 + tile.region + POLICY();
         result.record(inout out, matched, matched && benefit % 3 != 0, benefit);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -56,7 +56,7 @@ fn inspect_events(inout out: result.Result, borrow world: model.World) {
         let matched = (event.kind + POLICY()) % 5 == 0;
         let benefit = event.value + event.sequence + event.actor % 211 + POLICY();
         result.record(inout out, matched, matched && event.tick <= world.tick, benefit);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -68,7 +68,7 @@ fn inspect_snapshots(inout out: result.Result, borrow world: model.World) {
         let benefit = item.entity_count * 7 + item.event_count * 5 +
             item.command_count * 3 + item.checksum % 4093;
         result.record(inout out, matched, matched && item.checksum != 0, benefit);
-        i = i + 1;
+        i += 1;
     }
 }
 

--- a/examples/caldera/rule_combat_merge.rue
+++ b/examples/caldera/rule_combat_merge.rue
@@ -31,7 +31,7 @@ fn inspect_entities(inout out: result.Result, borrow world: model.World) {
         let matched = entity_match(borrow world, borrow entity);
         let benefit = entity_benefit(borrow world, borrow entity);
         result.record(inout out, matched, matched && benefit > POLICY() % 40, benefit);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -45,7 +45,7 @@ fn inspect_tiles(inout out: result.Result, borrow world: model.World) {
             else { tile.resource > POLICY() % 29 };
         let benefit = tile.resource + tile.height * 3 + tile.region + POLICY();
         result.record(inout out, matched, matched && benefit % 3 != 0, benefit);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -56,7 +56,7 @@ fn inspect_events(inout out: result.Result, borrow world: model.World) {
         let matched = (event.kind + POLICY()) % 5 == 0;
         let benefit = event.value + event.sequence + event.actor % 211 + POLICY();
         result.record(inout out, matched, matched && event.tick <= world.tick, benefit);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -68,7 +68,7 @@ fn inspect_snapshots(inout out: result.Result, borrow world: model.World) {
         let benefit = item.entity_count * 7 + item.event_count * 5 +
             item.command_count * 3 + item.checksum % 4093;
         result.record(inout out, matched, matched && item.checksum != 0, benefit);
-        i = i + 1;
+        i += 1;
     }
 }
 

--- a/examples/caldera/rule_combat_normalize.rue
+++ b/examples/caldera/rule_combat_normalize.rue
@@ -31,7 +31,7 @@ fn inspect_entities(inout out: result.Result, borrow world: model.World) {
         let matched = entity_match(borrow world, borrow entity);
         let benefit = entity_benefit(borrow world, borrow entity);
         result.record(inout out, matched, matched && benefit > POLICY() % 40, benefit);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -45,7 +45,7 @@ fn inspect_tiles(inout out: result.Result, borrow world: model.World) {
             else { tile.resource > POLICY() % 29 };
         let benefit = tile.resource + tile.height * 3 + tile.region + POLICY();
         result.record(inout out, matched, matched && benefit % 3 != 0, benefit);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -56,7 +56,7 @@ fn inspect_events(inout out: result.Result, borrow world: model.World) {
         let matched = (event.kind + POLICY()) % 5 == 0;
         let benefit = event.value + event.sequence + event.actor % 211 + POLICY();
         result.record(inout out, matched, matched && event.tick <= world.tick, benefit);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -68,7 +68,7 @@ fn inspect_snapshots(inout out: result.Result, borrow world: model.World) {
         let benefit = item.entity_count * 7 + item.event_count * 5 +
             item.command_count * 3 + item.checksum % 4093;
         result.record(inout out, matched, matched && item.checksum != 0, benefit);
-        i = i + 1;
+        i += 1;
     }
 }
 

--- a/examples/caldera/rule_combat_prioritize.rue
+++ b/examples/caldera/rule_combat_prioritize.rue
@@ -31,7 +31,7 @@ fn inspect_entities(inout out: result.Result, borrow world: model.World) {
         let matched = entity_match(borrow world, borrow entity);
         let benefit = entity_benefit(borrow world, borrow entity);
         result.record(inout out, matched, matched && benefit > POLICY() % 40, benefit);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -45,7 +45,7 @@ fn inspect_tiles(inout out: result.Result, borrow world: model.World) {
             else { tile.resource > POLICY() % 29 };
         let benefit = tile.resource + tile.height * 3 + tile.region + POLICY();
         result.record(inout out, matched, matched && benefit % 3 != 0, benefit);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -56,7 +56,7 @@ fn inspect_events(inout out: result.Result, borrow world: model.World) {
         let matched = (event.kind + POLICY()) % 5 == 0;
         let benefit = event.value + event.sequence + event.actor % 211 + POLICY();
         result.record(inout out, matched, matched && event.tick <= world.tick, benefit);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -68,7 +68,7 @@ fn inspect_snapshots(inout out: result.Result, borrow world: model.World) {
         let benefit = item.entity_count * 7 + item.event_count * 5 +
             item.command_count * 3 + item.checksum % 4093;
         result.record(inout out, matched, matched && item.checksum != 0, benefit);
-        i = i + 1;
+        i += 1;
     }
 }
 

--- a/examples/caldera/rule_combat_recover.rue
+++ b/examples/caldera/rule_combat_recover.rue
@@ -31,7 +31,7 @@ fn inspect_entities(inout out: result.Result, borrow world: model.World) {
         let matched = entity_match(borrow world, borrow entity);
         let benefit = entity_benefit(borrow world, borrow entity);
         result.record(inout out, matched, matched && benefit > POLICY() % 40, benefit);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -45,7 +45,7 @@ fn inspect_tiles(inout out: result.Result, borrow world: model.World) {
             else { tile.resource > POLICY() % 29 };
         let benefit = tile.resource + tile.height * 3 + tile.region + POLICY();
         result.record(inout out, matched, matched && benefit % 3 != 0, benefit);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -56,7 +56,7 @@ fn inspect_events(inout out: result.Result, borrow world: model.World) {
         let matched = (event.kind + POLICY()) % 5 == 0;
         let benefit = event.value + event.sequence + event.actor % 211 + POLICY();
         result.record(inout out, matched, matched && event.tick <= world.tick, benefit);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -68,7 +68,7 @@ fn inspect_snapshots(inout out: result.Result, borrow world: model.World) {
         let benefit = item.entity_count * 7 + item.event_count * 5 +
             item.command_count * 3 + item.checksum % 4093;
         result.record(inout out, matched, matched && item.checksum != 0, benefit);
-        i = i + 1;
+        i += 1;
     }
 }
 

--- a/examples/caldera/rule_combat_release.rue
+++ b/examples/caldera/rule_combat_release.rue
@@ -31,7 +31,7 @@ fn inspect_entities(inout out: result.Result, borrow world: model.World) {
         let matched = entity_match(borrow world, borrow entity);
         let benefit = entity_benefit(borrow world, borrow entity);
         result.record(inout out, matched, matched && benefit > POLICY() % 40, benefit);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -45,7 +45,7 @@ fn inspect_tiles(inout out: result.Result, borrow world: model.World) {
             else { tile.resource > POLICY() % 29 };
         let benefit = tile.resource + tile.height * 3 + tile.region + POLICY();
         result.record(inout out, matched, matched && benefit % 3 != 0, benefit);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -56,7 +56,7 @@ fn inspect_events(inout out: result.Result, borrow world: model.World) {
         let matched = (event.kind + POLICY()) % 5 == 0;
         let benefit = event.value + event.sequence + event.actor % 211 + POLICY();
         result.record(inout out, matched, matched && event.tick <= world.tick, benefit);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -68,7 +68,7 @@ fn inspect_snapshots(inout out: result.Result, borrow world: model.World) {
         let benefit = item.entity_count * 7 + item.event_count * 5 +
             item.command_count * 3 + item.checksum % 4093;
         result.record(inout out, matched, matched && item.checksum != 0, benefit);
-        i = i + 1;
+        i += 1;
     }
 }
 

--- a/examples/caldera/rule_combat_replicate.rue
+++ b/examples/caldera/rule_combat_replicate.rue
@@ -31,7 +31,7 @@ fn inspect_entities(inout out: result.Result, borrow world: model.World) {
         let matched = entity_match(borrow world, borrow entity);
         let benefit = entity_benefit(borrow world, borrow entity);
         result.record(inout out, matched, matched && benefit > POLICY() % 40, benefit);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -45,7 +45,7 @@ fn inspect_tiles(inout out: result.Result, borrow world: model.World) {
             else { tile.resource > POLICY() % 29 };
         let benefit = tile.resource + tile.height * 3 + tile.region + POLICY();
         result.record(inout out, matched, matched && benefit % 3 != 0, benefit);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -56,7 +56,7 @@ fn inspect_events(inout out: result.Result, borrow world: model.World) {
         let matched = (event.kind + POLICY()) % 5 == 0;
         let benefit = event.value + event.sequence + event.actor % 211 + POLICY();
         result.record(inout out, matched, matched && event.tick <= world.tick, benefit);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -68,7 +68,7 @@ fn inspect_snapshots(inout out: result.Result, borrow world: model.World) {
         let benefit = item.entity_count * 7 + item.event_count * 5 +
             item.command_count * 3 + item.checksum % 4093;
         result.record(inout out, matched, matched && item.checksum != 0, benefit);
-        i = i + 1;
+        i += 1;
     }
 }
 

--- a/examples/caldera/rule_combat_reserve.rue
+++ b/examples/caldera/rule_combat_reserve.rue
@@ -31,7 +31,7 @@ fn inspect_entities(inout out: result.Result, borrow world: model.World) {
         let matched = entity_match(borrow world, borrow entity);
         let benefit = entity_benefit(borrow world, borrow entity);
         result.record(inout out, matched, matched && benefit > POLICY() % 40, benefit);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -45,7 +45,7 @@ fn inspect_tiles(inout out: result.Result, borrow world: model.World) {
             else { tile.resource > POLICY() % 29 };
         let benefit = tile.resource + tile.height * 3 + tile.region + POLICY();
         result.record(inout out, matched, matched && benefit % 3 != 0, benefit);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -56,7 +56,7 @@ fn inspect_events(inout out: result.Result, borrow world: model.World) {
         let matched = (event.kind + POLICY()) % 5 == 0;
         let benefit = event.value + event.sequence + event.actor % 211 + POLICY();
         result.record(inout out, matched, matched && event.tick <= world.tick, benefit);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -68,7 +68,7 @@ fn inspect_snapshots(inout out: result.Result, borrow world: model.World) {
         let benefit = item.entity_count * 7 + item.event_count * 5 +
             item.command_count * 3 + item.checksum % 4093;
         result.record(inout out, matched, matched && item.checksum != 0, benefit);
-        i = i + 1;
+        i += 1;
     }
 }
 

--- a/examples/caldera/rule_combat_split.rue
+++ b/examples/caldera/rule_combat_split.rue
@@ -31,7 +31,7 @@ fn inspect_entities(inout out: result.Result, borrow world: model.World) {
         let matched = entity_match(borrow world, borrow entity);
         let benefit = entity_benefit(borrow world, borrow entity);
         result.record(inout out, matched, matched && benefit > POLICY() % 40, benefit);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -45,7 +45,7 @@ fn inspect_tiles(inout out: result.Result, borrow world: model.World) {
             else { tile.resource > POLICY() % 29 };
         let benefit = tile.resource + tile.height * 3 + tile.region + POLICY();
         result.record(inout out, matched, matched && benefit % 3 != 0, benefit);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -56,7 +56,7 @@ fn inspect_events(inout out: result.Result, borrow world: model.World) {
         let matched = (event.kind + POLICY()) % 5 == 0;
         let benefit = event.value + event.sequence + event.actor % 211 + POLICY();
         result.record(inout out, matched, matched && event.tick <= world.tick, benefit);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -68,7 +68,7 @@ fn inspect_snapshots(inout out: result.Result, borrow world: model.World) {
         let benefit = item.entity_count * 7 + item.event_count * 5 +
             item.command_count * 3 + item.checksum % 4093;
         result.record(inout out, matched, matched && item.checksum != 0, benefit);
-        i = i + 1;
+        i += 1;
     }
 }
 

--- a/examples/caldera/rule_combat_validate.rue
+++ b/examples/caldera/rule_combat_validate.rue
@@ -31,7 +31,7 @@ fn inspect_entities(inout out: result.Result, borrow world: model.World) {
         let matched = entity_match(borrow world, borrow entity);
         let benefit = entity_benefit(borrow world, borrow entity);
         result.record(inout out, matched, matched && benefit > POLICY() % 40, benefit);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -45,7 +45,7 @@ fn inspect_tiles(inout out: result.Result, borrow world: model.World) {
             else { tile.resource > POLICY() % 29 };
         let benefit = tile.resource + tile.height * 3 + tile.region + POLICY();
         result.record(inout out, matched, matched && benefit % 3 != 0, benefit);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -56,7 +56,7 @@ fn inspect_events(inout out: result.Result, borrow world: model.World) {
         let matched = (event.kind + POLICY()) % 5 == 0;
         let benefit = event.value + event.sequence + event.actor % 211 + POLICY();
         result.record(inout out, matched, matched && event.tick <= world.tick, benefit);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -68,7 +68,7 @@ fn inspect_snapshots(inout out: result.Result, borrow world: model.World) {
         let benefit = item.entity_count * 7 + item.event_count * 5 +
             item.command_count * 3 + item.checksum % 4093;
         result.record(inout out, matched, matched && item.checksum != 0, benefit);
-        i = i + 1;
+        i += 1;
     }
 }
 

--- a/examples/caldera/rule_economy_bound.rue
+++ b/examples/caldera/rule_economy_bound.rue
@@ -31,7 +31,7 @@ fn inspect_entities(inout out: result.Result, borrow world: model.World) {
         let matched = entity_match(borrow world, borrow entity);
         let benefit = entity_benefit(borrow world, borrow entity);
         result.record(inout out, matched, matched && benefit > POLICY() % 40, benefit);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -45,7 +45,7 @@ fn inspect_tiles(inout out: result.Result, borrow world: model.World) {
             else { tile.resource > POLICY() % 29 };
         let benefit = tile.resource + tile.height * 3 + tile.region + POLICY();
         result.record(inout out, matched, matched && benefit % 3 != 0, benefit);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -56,7 +56,7 @@ fn inspect_events(inout out: result.Result, borrow world: model.World) {
         let matched = (event.kind + POLICY()) % 5 == 0;
         let benefit = event.value + event.sequence + event.actor % 211 + POLICY();
         result.record(inout out, matched, matched && event.tick <= world.tick, benefit);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -68,7 +68,7 @@ fn inspect_snapshots(inout out: result.Result, borrow world: model.World) {
         let benefit = item.entity_count * 7 + item.event_count * 5 +
             item.command_count * 3 + item.checksum % 4093;
         result.record(inout out, matched, matched && item.checksum != 0, benefit);
-        i = i + 1;
+        i += 1;
     }
 }
 

--- a/examples/caldera/rule_economy_defer.rue
+++ b/examples/caldera/rule_economy_defer.rue
@@ -31,7 +31,7 @@ fn inspect_entities(inout out: result.Result, borrow world: model.World) {
         let matched = entity_match(borrow world, borrow entity);
         let benefit = entity_benefit(borrow world, borrow entity);
         result.record(inout out, matched, matched && benefit > POLICY() % 40, benefit);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -45,7 +45,7 @@ fn inspect_tiles(inout out: result.Result, borrow world: model.World) {
             else { tile.resource > POLICY() % 29 };
         let benefit = tile.resource + tile.height * 3 + tile.region + POLICY();
         result.record(inout out, matched, matched && benefit % 3 != 0, benefit);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -56,7 +56,7 @@ fn inspect_events(inout out: result.Result, borrow world: model.World) {
         let matched = (event.kind + POLICY()) % 5 == 0;
         let benefit = event.value + event.sequence + event.actor % 211 + POLICY();
         result.record(inout out, matched, matched && event.tick <= world.tick, benefit);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -68,7 +68,7 @@ fn inspect_snapshots(inout out: result.Result, borrow world: model.World) {
         let benefit = item.entity_count * 7 + item.event_count * 5 +
             item.command_count * 3 + item.checksum % 4093;
         result.record(inout out, matched, matched && item.checksum != 0, benefit);
-        i = i + 1;
+        i += 1;
     }
 }
 

--- a/examples/caldera/rule_economy_explain.rue
+++ b/examples/caldera/rule_economy_explain.rue
@@ -31,7 +31,7 @@ fn inspect_entities(inout out: result.Result, borrow world: model.World) {
         let matched = entity_match(borrow world, borrow entity);
         let benefit = entity_benefit(borrow world, borrow entity);
         result.record(inout out, matched, matched && benefit > POLICY() % 40, benefit);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -45,7 +45,7 @@ fn inspect_tiles(inout out: result.Result, borrow world: model.World) {
             else { tile.resource > POLICY() % 29 };
         let benefit = tile.resource + tile.height * 3 + tile.region + POLICY();
         result.record(inout out, matched, matched && benefit % 3 != 0, benefit);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -56,7 +56,7 @@ fn inspect_events(inout out: result.Result, borrow world: model.World) {
         let matched = (event.kind + POLICY()) % 5 == 0;
         let benefit = event.value + event.sequence + event.actor % 211 + POLICY();
         result.record(inout out, matched, matched && event.tick <= world.tick, benefit);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -68,7 +68,7 @@ fn inspect_snapshots(inout out: result.Result, borrow world: model.World) {
         let benefit = item.entity_count * 7 + item.event_count * 5 +
             item.command_count * 3 + item.checksum % 4093;
         result.record(inout out, matched, matched && item.checksum != 0, benefit);
-        i = i + 1;
+        i += 1;
     }
 }
 

--- a/examples/caldera/rule_economy_merge.rue
+++ b/examples/caldera/rule_economy_merge.rue
@@ -31,7 +31,7 @@ fn inspect_entities(inout out: result.Result, borrow world: model.World) {
         let matched = entity_match(borrow world, borrow entity);
         let benefit = entity_benefit(borrow world, borrow entity);
         result.record(inout out, matched, matched && benefit > POLICY() % 40, benefit);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -45,7 +45,7 @@ fn inspect_tiles(inout out: result.Result, borrow world: model.World) {
             else { tile.resource > POLICY() % 29 };
         let benefit = tile.resource + tile.height * 3 + tile.region + POLICY();
         result.record(inout out, matched, matched && benefit % 3 != 0, benefit);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -56,7 +56,7 @@ fn inspect_events(inout out: result.Result, borrow world: model.World) {
         let matched = (event.kind + POLICY()) % 5 == 0;
         let benefit = event.value + event.sequence + event.actor % 211 + POLICY();
         result.record(inout out, matched, matched && event.tick <= world.tick, benefit);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -68,7 +68,7 @@ fn inspect_snapshots(inout out: result.Result, borrow world: model.World) {
         let benefit = item.entity_count * 7 + item.event_count * 5 +
             item.command_count * 3 + item.checksum % 4093;
         result.record(inout out, matched, matched && item.checksum != 0, benefit);
-        i = i + 1;
+        i += 1;
     }
 }
 

--- a/examples/caldera/rule_economy_normalize.rue
+++ b/examples/caldera/rule_economy_normalize.rue
@@ -31,7 +31,7 @@ fn inspect_entities(inout out: result.Result, borrow world: model.World) {
         let matched = entity_match(borrow world, borrow entity);
         let benefit = entity_benefit(borrow world, borrow entity);
         result.record(inout out, matched, matched && benefit > POLICY() % 40, benefit);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -45,7 +45,7 @@ fn inspect_tiles(inout out: result.Result, borrow world: model.World) {
             else { tile.resource > POLICY() % 29 };
         let benefit = tile.resource + tile.height * 3 + tile.region + POLICY();
         result.record(inout out, matched, matched && benefit % 3 != 0, benefit);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -56,7 +56,7 @@ fn inspect_events(inout out: result.Result, borrow world: model.World) {
         let matched = (event.kind + POLICY()) % 5 == 0;
         let benefit = event.value + event.sequence + event.actor % 211 + POLICY();
         result.record(inout out, matched, matched && event.tick <= world.tick, benefit);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -68,7 +68,7 @@ fn inspect_snapshots(inout out: result.Result, borrow world: model.World) {
         let benefit = item.entity_count * 7 + item.event_count * 5 +
             item.command_count * 3 + item.checksum % 4093;
         result.record(inout out, matched, matched && item.checksum != 0, benefit);
-        i = i + 1;
+        i += 1;
     }
 }
 

--- a/examples/caldera/rule_economy_prioritize.rue
+++ b/examples/caldera/rule_economy_prioritize.rue
@@ -31,7 +31,7 @@ fn inspect_entities(inout out: result.Result, borrow world: model.World) {
         let matched = entity_match(borrow world, borrow entity);
         let benefit = entity_benefit(borrow world, borrow entity);
         result.record(inout out, matched, matched && benefit > POLICY() % 40, benefit);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -45,7 +45,7 @@ fn inspect_tiles(inout out: result.Result, borrow world: model.World) {
             else { tile.resource > POLICY() % 29 };
         let benefit = tile.resource + tile.height * 3 + tile.region + POLICY();
         result.record(inout out, matched, matched && benefit % 3 != 0, benefit);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -56,7 +56,7 @@ fn inspect_events(inout out: result.Result, borrow world: model.World) {
         let matched = (event.kind + POLICY()) % 5 == 0;
         let benefit = event.value + event.sequence + event.actor % 211 + POLICY();
         result.record(inout out, matched, matched && event.tick <= world.tick, benefit);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -68,7 +68,7 @@ fn inspect_snapshots(inout out: result.Result, borrow world: model.World) {
         let benefit = item.entity_count * 7 + item.event_count * 5 +
             item.command_count * 3 + item.checksum % 4093;
         result.record(inout out, matched, matched && item.checksum != 0, benefit);
-        i = i + 1;
+        i += 1;
     }
 }
 

--- a/examples/caldera/rule_economy_recover.rue
+++ b/examples/caldera/rule_economy_recover.rue
@@ -31,7 +31,7 @@ fn inspect_entities(inout out: result.Result, borrow world: model.World) {
         let matched = entity_match(borrow world, borrow entity);
         let benefit = entity_benefit(borrow world, borrow entity);
         result.record(inout out, matched, matched && benefit > POLICY() % 40, benefit);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -45,7 +45,7 @@ fn inspect_tiles(inout out: result.Result, borrow world: model.World) {
             else { tile.resource > POLICY() % 29 };
         let benefit = tile.resource + tile.height * 3 + tile.region + POLICY();
         result.record(inout out, matched, matched && benefit % 3 != 0, benefit);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -56,7 +56,7 @@ fn inspect_events(inout out: result.Result, borrow world: model.World) {
         let matched = (event.kind + POLICY()) % 5 == 0;
         let benefit = event.value + event.sequence + event.actor % 211 + POLICY();
         result.record(inout out, matched, matched && event.tick <= world.tick, benefit);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -68,7 +68,7 @@ fn inspect_snapshots(inout out: result.Result, borrow world: model.World) {
         let benefit = item.entity_count * 7 + item.event_count * 5 +
             item.command_count * 3 + item.checksum % 4093;
         result.record(inout out, matched, matched && item.checksum != 0, benefit);
-        i = i + 1;
+        i += 1;
     }
 }
 

--- a/examples/caldera/rule_economy_release.rue
+++ b/examples/caldera/rule_economy_release.rue
@@ -31,7 +31,7 @@ fn inspect_entities(inout out: result.Result, borrow world: model.World) {
         let matched = entity_match(borrow world, borrow entity);
         let benefit = entity_benefit(borrow world, borrow entity);
         result.record(inout out, matched, matched && benefit > POLICY() % 40, benefit);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -45,7 +45,7 @@ fn inspect_tiles(inout out: result.Result, borrow world: model.World) {
             else { tile.resource > POLICY() % 29 };
         let benefit = tile.resource + tile.height * 3 + tile.region + POLICY();
         result.record(inout out, matched, matched && benefit % 3 != 0, benefit);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -56,7 +56,7 @@ fn inspect_events(inout out: result.Result, borrow world: model.World) {
         let matched = (event.kind + POLICY()) % 5 == 0;
         let benefit = event.value + event.sequence + event.actor % 211 + POLICY();
         result.record(inout out, matched, matched && event.tick <= world.tick, benefit);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -68,7 +68,7 @@ fn inspect_snapshots(inout out: result.Result, borrow world: model.World) {
         let benefit = item.entity_count * 7 + item.event_count * 5 +
             item.command_count * 3 + item.checksum % 4093;
         result.record(inout out, matched, matched && item.checksum != 0, benefit);
-        i = i + 1;
+        i += 1;
     }
 }
 

--- a/examples/caldera/rule_economy_replicate.rue
+++ b/examples/caldera/rule_economy_replicate.rue
@@ -31,7 +31,7 @@ fn inspect_entities(inout out: result.Result, borrow world: model.World) {
         let matched = entity_match(borrow world, borrow entity);
         let benefit = entity_benefit(borrow world, borrow entity);
         result.record(inout out, matched, matched && benefit > POLICY() % 40, benefit);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -45,7 +45,7 @@ fn inspect_tiles(inout out: result.Result, borrow world: model.World) {
             else { tile.resource > POLICY() % 29 };
         let benefit = tile.resource + tile.height * 3 + tile.region + POLICY();
         result.record(inout out, matched, matched && benefit % 3 != 0, benefit);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -56,7 +56,7 @@ fn inspect_events(inout out: result.Result, borrow world: model.World) {
         let matched = (event.kind + POLICY()) % 5 == 0;
         let benefit = event.value + event.sequence + event.actor % 211 + POLICY();
         result.record(inout out, matched, matched && event.tick <= world.tick, benefit);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -68,7 +68,7 @@ fn inspect_snapshots(inout out: result.Result, borrow world: model.World) {
         let benefit = item.entity_count * 7 + item.event_count * 5 +
             item.command_count * 3 + item.checksum % 4093;
         result.record(inout out, matched, matched && item.checksum != 0, benefit);
-        i = i + 1;
+        i += 1;
     }
 }
 

--- a/examples/caldera/rule_economy_reserve.rue
+++ b/examples/caldera/rule_economy_reserve.rue
@@ -31,7 +31,7 @@ fn inspect_entities(inout out: result.Result, borrow world: model.World) {
         let matched = entity_match(borrow world, borrow entity);
         let benefit = entity_benefit(borrow world, borrow entity);
         result.record(inout out, matched, matched && benefit > POLICY() % 40, benefit);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -45,7 +45,7 @@ fn inspect_tiles(inout out: result.Result, borrow world: model.World) {
             else { tile.resource > POLICY() % 29 };
         let benefit = tile.resource + tile.height * 3 + tile.region + POLICY();
         result.record(inout out, matched, matched && benefit % 3 != 0, benefit);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -56,7 +56,7 @@ fn inspect_events(inout out: result.Result, borrow world: model.World) {
         let matched = (event.kind + POLICY()) % 5 == 0;
         let benefit = event.value + event.sequence + event.actor % 211 + POLICY();
         result.record(inout out, matched, matched && event.tick <= world.tick, benefit);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -68,7 +68,7 @@ fn inspect_snapshots(inout out: result.Result, borrow world: model.World) {
         let benefit = item.entity_count * 7 + item.event_count * 5 +
             item.command_count * 3 + item.checksum % 4093;
         result.record(inout out, matched, matched && item.checksum != 0, benefit);
-        i = i + 1;
+        i += 1;
     }
 }
 

--- a/examples/caldera/rule_economy_split.rue
+++ b/examples/caldera/rule_economy_split.rue
@@ -31,7 +31,7 @@ fn inspect_entities(inout out: result.Result, borrow world: model.World) {
         let matched = entity_match(borrow world, borrow entity);
         let benefit = entity_benefit(borrow world, borrow entity);
         result.record(inout out, matched, matched && benefit > POLICY() % 40, benefit);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -45,7 +45,7 @@ fn inspect_tiles(inout out: result.Result, borrow world: model.World) {
             else { tile.resource > POLICY() % 29 };
         let benefit = tile.resource + tile.height * 3 + tile.region + POLICY();
         result.record(inout out, matched, matched && benefit % 3 != 0, benefit);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -56,7 +56,7 @@ fn inspect_events(inout out: result.Result, borrow world: model.World) {
         let matched = (event.kind + POLICY()) % 5 == 0;
         let benefit = event.value + event.sequence + event.actor % 211 + POLICY();
         result.record(inout out, matched, matched && event.tick <= world.tick, benefit);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -68,7 +68,7 @@ fn inspect_snapshots(inout out: result.Result, borrow world: model.World) {
         let benefit = item.entity_count * 7 + item.event_count * 5 +
             item.command_count * 3 + item.checksum % 4093;
         result.record(inout out, matched, matched && item.checksum != 0, benefit);
-        i = i + 1;
+        i += 1;
     }
 }
 

--- a/examples/caldera/rule_economy_validate.rue
+++ b/examples/caldera/rule_economy_validate.rue
@@ -31,7 +31,7 @@ fn inspect_entities(inout out: result.Result, borrow world: model.World) {
         let matched = entity_match(borrow world, borrow entity);
         let benefit = entity_benefit(borrow world, borrow entity);
         result.record(inout out, matched, matched && benefit > POLICY() % 40, benefit);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -45,7 +45,7 @@ fn inspect_tiles(inout out: result.Result, borrow world: model.World) {
             else { tile.resource > POLICY() % 29 };
         let benefit = tile.resource + tile.height * 3 + tile.region + POLICY();
         result.record(inout out, matched, matched && benefit % 3 != 0, benefit);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -56,7 +56,7 @@ fn inspect_events(inout out: result.Result, borrow world: model.World) {
         let matched = (event.kind + POLICY()) % 5 == 0;
         let benefit = event.value + event.sequence + event.actor % 211 + POLICY();
         result.record(inout out, matched, matched && event.tick <= world.tick, benefit);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -68,7 +68,7 @@ fn inspect_snapshots(inout out: result.Result, borrow world: model.World) {
         let benefit = item.entity_count * 7 + item.event_count * 5 +
             item.command_count * 3 + item.checksum % 4093;
         result.record(inout out, matched, matched && item.checksum != 0, benefit);
-        i = i + 1;
+        i += 1;
     }
 }
 

--- a/examples/caldera/rule_network_bound.rue
+++ b/examples/caldera/rule_network_bound.rue
@@ -31,7 +31,7 @@ fn inspect_entities(inout out: result.Result, borrow world: model.World) {
         let matched = entity_match(borrow world, borrow entity);
         let benefit = entity_benefit(borrow world, borrow entity);
         result.record(inout out, matched, matched && benefit > POLICY() % 40, benefit);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -45,7 +45,7 @@ fn inspect_tiles(inout out: result.Result, borrow world: model.World) {
             else { tile.resource > POLICY() % 29 };
         let benefit = tile.resource + tile.height * 3 + tile.region + POLICY();
         result.record(inout out, matched, matched && benefit % 3 != 0, benefit);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -56,7 +56,7 @@ fn inspect_events(inout out: result.Result, borrow world: model.World) {
         let matched = (event.kind + POLICY()) % 5 == 0;
         let benefit = event.value + event.sequence + event.actor % 211 + POLICY();
         result.record(inout out, matched, matched && event.tick <= world.tick, benefit);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -68,7 +68,7 @@ fn inspect_snapshots(inout out: result.Result, borrow world: model.World) {
         let benefit = item.entity_count * 7 + item.event_count * 5 +
             item.command_count * 3 + item.checksum % 4093;
         result.record(inout out, matched, matched && item.checksum != 0, benefit);
-        i = i + 1;
+        i += 1;
     }
 }
 

--- a/examples/caldera/rule_network_defer.rue
+++ b/examples/caldera/rule_network_defer.rue
@@ -31,7 +31,7 @@ fn inspect_entities(inout out: result.Result, borrow world: model.World) {
         let matched = entity_match(borrow world, borrow entity);
         let benefit = entity_benefit(borrow world, borrow entity);
         result.record(inout out, matched, matched && benefit > POLICY() % 40, benefit);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -45,7 +45,7 @@ fn inspect_tiles(inout out: result.Result, borrow world: model.World) {
             else { tile.resource > POLICY() % 29 };
         let benefit = tile.resource + tile.height * 3 + tile.region + POLICY();
         result.record(inout out, matched, matched && benefit % 3 != 0, benefit);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -56,7 +56,7 @@ fn inspect_events(inout out: result.Result, borrow world: model.World) {
         let matched = (event.kind + POLICY()) % 5 == 0;
         let benefit = event.value + event.sequence + event.actor % 211 + POLICY();
         result.record(inout out, matched, matched && event.tick <= world.tick, benefit);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -68,7 +68,7 @@ fn inspect_snapshots(inout out: result.Result, borrow world: model.World) {
         let benefit = item.entity_count * 7 + item.event_count * 5 +
             item.command_count * 3 + item.checksum % 4093;
         result.record(inout out, matched, matched && item.checksum != 0, benefit);
-        i = i + 1;
+        i += 1;
     }
 }
 

--- a/examples/caldera/rule_network_explain.rue
+++ b/examples/caldera/rule_network_explain.rue
@@ -31,7 +31,7 @@ fn inspect_entities(inout out: result.Result, borrow world: model.World) {
         let matched = entity_match(borrow world, borrow entity);
         let benefit = entity_benefit(borrow world, borrow entity);
         result.record(inout out, matched, matched && benefit > POLICY() % 40, benefit);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -45,7 +45,7 @@ fn inspect_tiles(inout out: result.Result, borrow world: model.World) {
             else { tile.resource > POLICY() % 29 };
         let benefit = tile.resource + tile.height * 3 + tile.region + POLICY();
         result.record(inout out, matched, matched && benefit % 3 != 0, benefit);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -56,7 +56,7 @@ fn inspect_events(inout out: result.Result, borrow world: model.World) {
         let matched = (event.kind + POLICY()) % 5 == 0;
         let benefit = event.value + event.sequence + event.actor % 211 + POLICY();
         result.record(inout out, matched, matched && event.tick <= world.tick, benefit);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -68,7 +68,7 @@ fn inspect_snapshots(inout out: result.Result, borrow world: model.World) {
         let benefit = item.entity_count * 7 + item.event_count * 5 +
             item.command_count * 3 + item.checksum % 4093;
         result.record(inout out, matched, matched && item.checksum != 0, benefit);
-        i = i + 1;
+        i += 1;
     }
 }
 

--- a/examples/caldera/rule_network_merge.rue
+++ b/examples/caldera/rule_network_merge.rue
@@ -31,7 +31,7 @@ fn inspect_entities(inout out: result.Result, borrow world: model.World) {
         let matched = entity_match(borrow world, borrow entity);
         let benefit = entity_benefit(borrow world, borrow entity);
         result.record(inout out, matched, matched && benefit > POLICY() % 40, benefit);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -45,7 +45,7 @@ fn inspect_tiles(inout out: result.Result, borrow world: model.World) {
             else { tile.resource > POLICY() % 29 };
         let benefit = tile.resource + tile.height * 3 + tile.region + POLICY();
         result.record(inout out, matched, matched && benefit % 3 != 0, benefit);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -56,7 +56,7 @@ fn inspect_events(inout out: result.Result, borrow world: model.World) {
         let matched = (event.kind + POLICY()) % 5 == 0;
         let benefit = event.value + event.sequence + event.actor % 211 + POLICY();
         result.record(inout out, matched, matched && event.tick <= world.tick, benefit);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -68,7 +68,7 @@ fn inspect_snapshots(inout out: result.Result, borrow world: model.World) {
         let benefit = item.entity_count * 7 + item.event_count * 5 +
             item.command_count * 3 + item.checksum % 4093;
         result.record(inout out, matched, matched && item.checksum != 0, benefit);
-        i = i + 1;
+        i += 1;
     }
 }
 

--- a/examples/caldera/rule_network_normalize.rue
+++ b/examples/caldera/rule_network_normalize.rue
@@ -31,7 +31,7 @@ fn inspect_entities(inout out: result.Result, borrow world: model.World) {
         let matched = entity_match(borrow world, borrow entity);
         let benefit = entity_benefit(borrow world, borrow entity);
         result.record(inout out, matched, matched && benefit > POLICY() % 40, benefit);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -45,7 +45,7 @@ fn inspect_tiles(inout out: result.Result, borrow world: model.World) {
             else { tile.resource > POLICY() % 29 };
         let benefit = tile.resource + tile.height * 3 + tile.region + POLICY();
         result.record(inout out, matched, matched && benefit % 3 != 0, benefit);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -56,7 +56,7 @@ fn inspect_events(inout out: result.Result, borrow world: model.World) {
         let matched = (event.kind + POLICY()) % 5 == 0;
         let benefit = event.value + event.sequence + event.actor % 211 + POLICY();
         result.record(inout out, matched, matched && event.tick <= world.tick, benefit);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -68,7 +68,7 @@ fn inspect_snapshots(inout out: result.Result, borrow world: model.World) {
         let benefit = item.entity_count * 7 + item.event_count * 5 +
             item.command_count * 3 + item.checksum % 4093;
         result.record(inout out, matched, matched && item.checksum != 0, benefit);
-        i = i + 1;
+        i += 1;
     }
 }
 

--- a/examples/caldera/rule_network_prioritize.rue
+++ b/examples/caldera/rule_network_prioritize.rue
@@ -31,7 +31,7 @@ fn inspect_entities(inout out: result.Result, borrow world: model.World) {
         let matched = entity_match(borrow world, borrow entity);
         let benefit = entity_benefit(borrow world, borrow entity);
         result.record(inout out, matched, matched && benefit > POLICY() % 40, benefit);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -45,7 +45,7 @@ fn inspect_tiles(inout out: result.Result, borrow world: model.World) {
             else { tile.resource > POLICY() % 29 };
         let benefit = tile.resource + tile.height * 3 + tile.region + POLICY();
         result.record(inout out, matched, matched && benefit % 3 != 0, benefit);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -56,7 +56,7 @@ fn inspect_events(inout out: result.Result, borrow world: model.World) {
         let matched = (event.kind + POLICY()) % 5 == 0;
         let benefit = event.value + event.sequence + event.actor % 211 + POLICY();
         result.record(inout out, matched, matched && event.tick <= world.tick, benefit);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -68,7 +68,7 @@ fn inspect_snapshots(inout out: result.Result, borrow world: model.World) {
         let benefit = item.entity_count * 7 + item.event_count * 5 +
             item.command_count * 3 + item.checksum % 4093;
         result.record(inout out, matched, matched && item.checksum != 0, benefit);
-        i = i + 1;
+        i += 1;
     }
 }
 

--- a/examples/caldera/rule_network_recover.rue
+++ b/examples/caldera/rule_network_recover.rue
@@ -31,7 +31,7 @@ fn inspect_entities(inout out: result.Result, borrow world: model.World) {
         let matched = entity_match(borrow world, borrow entity);
         let benefit = entity_benefit(borrow world, borrow entity);
         result.record(inout out, matched, matched && benefit > POLICY() % 40, benefit);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -45,7 +45,7 @@ fn inspect_tiles(inout out: result.Result, borrow world: model.World) {
             else { tile.resource > POLICY() % 29 };
         let benefit = tile.resource + tile.height * 3 + tile.region + POLICY();
         result.record(inout out, matched, matched && benefit % 3 != 0, benefit);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -56,7 +56,7 @@ fn inspect_events(inout out: result.Result, borrow world: model.World) {
         let matched = (event.kind + POLICY()) % 5 == 0;
         let benefit = event.value + event.sequence + event.actor % 211 + POLICY();
         result.record(inout out, matched, matched && event.tick <= world.tick, benefit);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -68,7 +68,7 @@ fn inspect_snapshots(inout out: result.Result, borrow world: model.World) {
         let benefit = item.entity_count * 7 + item.event_count * 5 +
             item.command_count * 3 + item.checksum % 4093;
         result.record(inout out, matched, matched && item.checksum != 0, benefit);
-        i = i + 1;
+        i += 1;
     }
 }
 

--- a/examples/caldera/rule_network_release.rue
+++ b/examples/caldera/rule_network_release.rue
@@ -31,7 +31,7 @@ fn inspect_entities(inout out: result.Result, borrow world: model.World) {
         let matched = entity_match(borrow world, borrow entity);
         let benefit = entity_benefit(borrow world, borrow entity);
         result.record(inout out, matched, matched && benefit > POLICY() % 40, benefit);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -45,7 +45,7 @@ fn inspect_tiles(inout out: result.Result, borrow world: model.World) {
             else { tile.resource > POLICY() % 29 };
         let benefit = tile.resource + tile.height * 3 + tile.region + POLICY();
         result.record(inout out, matched, matched && benefit % 3 != 0, benefit);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -56,7 +56,7 @@ fn inspect_events(inout out: result.Result, borrow world: model.World) {
         let matched = (event.kind + POLICY()) % 5 == 0;
         let benefit = event.value + event.sequence + event.actor % 211 + POLICY();
         result.record(inout out, matched, matched && event.tick <= world.tick, benefit);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -68,7 +68,7 @@ fn inspect_snapshots(inout out: result.Result, borrow world: model.World) {
         let benefit = item.entity_count * 7 + item.event_count * 5 +
             item.command_count * 3 + item.checksum % 4093;
         result.record(inout out, matched, matched && item.checksum != 0, benefit);
-        i = i + 1;
+        i += 1;
     }
 }
 

--- a/examples/caldera/rule_network_replicate.rue
+++ b/examples/caldera/rule_network_replicate.rue
@@ -31,7 +31,7 @@ fn inspect_entities(inout out: result.Result, borrow world: model.World) {
         let matched = entity_match(borrow world, borrow entity);
         let benefit = entity_benefit(borrow world, borrow entity);
         result.record(inout out, matched, matched && benefit > POLICY() % 40, benefit);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -45,7 +45,7 @@ fn inspect_tiles(inout out: result.Result, borrow world: model.World) {
             else { tile.resource > POLICY() % 29 };
         let benefit = tile.resource + tile.height * 3 + tile.region + POLICY();
         result.record(inout out, matched, matched && benefit % 3 != 0, benefit);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -56,7 +56,7 @@ fn inspect_events(inout out: result.Result, borrow world: model.World) {
         let matched = (event.kind + POLICY()) % 5 == 0;
         let benefit = event.value + event.sequence + event.actor % 211 + POLICY();
         result.record(inout out, matched, matched && event.tick <= world.tick, benefit);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -68,7 +68,7 @@ fn inspect_snapshots(inout out: result.Result, borrow world: model.World) {
         let benefit = item.entity_count * 7 + item.event_count * 5 +
             item.command_count * 3 + item.checksum % 4093;
         result.record(inout out, matched, matched && item.checksum != 0, benefit);
-        i = i + 1;
+        i += 1;
     }
 }
 

--- a/examples/caldera/rule_network_reserve.rue
+++ b/examples/caldera/rule_network_reserve.rue
@@ -31,7 +31,7 @@ fn inspect_entities(inout out: result.Result, borrow world: model.World) {
         let matched = entity_match(borrow world, borrow entity);
         let benefit = entity_benefit(borrow world, borrow entity);
         result.record(inout out, matched, matched && benefit > POLICY() % 40, benefit);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -45,7 +45,7 @@ fn inspect_tiles(inout out: result.Result, borrow world: model.World) {
             else { tile.resource > POLICY() % 29 };
         let benefit = tile.resource + tile.height * 3 + tile.region + POLICY();
         result.record(inout out, matched, matched && benefit % 3 != 0, benefit);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -56,7 +56,7 @@ fn inspect_events(inout out: result.Result, borrow world: model.World) {
         let matched = (event.kind + POLICY()) % 5 == 0;
         let benefit = event.value + event.sequence + event.actor % 211 + POLICY();
         result.record(inout out, matched, matched && event.tick <= world.tick, benefit);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -68,7 +68,7 @@ fn inspect_snapshots(inout out: result.Result, borrow world: model.World) {
         let benefit = item.entity_count * 7 + item.event_count * 5 +
             item.command_count * 3 + item.checksum % 4093;
         result.record(inout out, matched, matched && item.checksum != 0, benefit);
-        i = i + 1;
+        i += 1;
     }
 }
 

--- a/examples/caldera/rule_network_split.rue
+++ b/examples/caldera/rule_network_split.rue
@@ -31,7 +31,7 @@ fn inspect_entities(inout out: result.Result, borrow world: model.World) {
         let matched = entity_match(borrow world, borrow entity);
         let benefit = entity_benefit(borrow world, borrow entity);
         result.record(inout out, matched, matched && benefit > POLICY() % 40, benefit);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -45,7 +45,7 @@ fn inspect_tiles(inout out: result.Result, borrow world: model.World) {
             else { tile.resource > POLICY() % 29 };
         let benefit = tile.resource + tile.height * 3 + tile.region + POLICY();
         result.record(inout out, matched, matched && benefit % 3 != 0, benefit);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -56,7 +56,7 @@ fn inspect_events(inout out: result.Result, borrow world: model.World) {
         let matched = (event.kind + POLICY()) % 5 == 0;
         let benefit = event.value + event.sequence + event.actor % 211 + POLICY();
         result.record(inout out, matched, matched && event.tick <= world.tick, benefit);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -68,7 +68,7 @@ fn inspect_snapshots(inout out: result.Result, borrow world: model.World) {
         let benefit = item.entity_count * 7 + item.event_count * 5 +
             item.command_count * 3 + item.checksum % 4093;
         result.record(inout out, matched, matched && item.checksum != 0, benefit);
-        i = i + 1;
+        i += 1;
     }
 }
 

--- a/examples/caldera/rule_network_validate.rue
+++ b/examples/caldera/rule_network_validate.rue
@@ -31,7 +31,7 @@ fn inspect_entities(inout out: result.Result, borrow world: model.World) {
         let matched = entity_match(borrow world, borrow entity);
         let benefit = entity_benefit(borrow world, borrow entity);
         result.record(inout out, matched, matched && benefit > POLICY() % 40, benefit);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -45,7 +45,7 @@ fn inspect_tiles(inout out: result.Result, borrow world: model.World) {
             else { tile.resource > POLICY() % 29 };
         let benefit = tile.resource + tile.height * 3 + tile.region + POLICY();
         result.record(inout out, matched, matched && benefit % 3 != 0, benefit);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -56,7 +56,7 @@ fn inspect_events(inout out: result.Result, borrow world: model.World) {
         let matched = (event.kind + POLICY()) % 5 == 0;
         let benefit = event.value + event.sequence + event.actor % 211 + POLICY();
         result.record(inout out, matched, matched && event.tick <= world.tick, benefit);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -68,7 +68,7 @@ fn inspect_snapshots(inout out: result.Result, borrow world: model.World) {
         let benefit = item.entity_count * 7 + item.event_count * 5 +
             item.command_count * 3 + item.checksum % 4093;
         result.record(inout out, matched, matched && item.checksum != 0, benefit);
-        i = i + 1;
+        i += 1;
     }
 }
 

--- a/examples/caldera/rule_quest_bound.rue
+++ b/examples/caldera/rule_quest_bound.rue
@@ -31,7 +31,7 @@ fn inspect_entities(inout out: result.Result, borrow world: model.World) {
         let matched = entity_match(borrow world, borrow entity);
         let benefit = entity_benefit(borrow world, borrow entity);
         result.record(inout out, matched, matched && benefit > POLICY() % 40, benefit);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -45,7 +45,7 @@ fn inspect_tiles(inout out: result.Result, borrow world: model.World) {
             else { tile.resource > POLICY() % 29 };
         let benefit = tile.resource + tile.height * 3 + tile.region + POLICY();
         result.record(inout out, matched, matched && benefit % 3 != 0, benefit);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -56,7 +56,7 @@ fn inspect_events(inout out: result.Result, borrow world: model.World) {
         let matched = (event.kind + POLICY()) % 5 == 0;
         let benefit = event.value + event.sequence + event.actor % 211 + POLICY();
         result.record(inout out, matched, matched && event.tick <= world.tick, benefit);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -68,7 +68,7 @@ fn inspect_snapshots(inout out: result.Result, borrow world: model.World) {
         let benefit = item.entity_count * 7 + item.event_count * 5 +
             item.command_count * 3 + item.checksum % 4093;
         result.record(inout out, matched, matched && item.checksum != 0, benefit);
-        i = i + 1;
+        i += 1;
     }
 }
 

--- a/examples/caldera/rule_quest_defer.rue
+++ b/examples/caldera/rule_quest_defer.rue
@@ -31,7 +31,7 @@ fn inspect_entities(inout out: result.Result, borrow world: model.World) {
         let matched = entity_match(borrow world, borrow entity);
         let benefit = entity_benefit(borrow world, borrow entity);
         result.record(inout out, matched, matched && benefit > POLICY() % 40, benefit);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -45,7 +45,7 @@ fn inspect_tiles(inout out: result.Result, borrow world: model.World) {
             else { tile.resource > POLICY() % 29 };
         let benefit = tile.resource + tile.height * 3 + tile.region + POLICY();
         result.record(inout out, matched, matched && benefit % 3 != 0, benefit);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -56,7 +56,7 @@ fn inspect_events(inout out: result.Result, borrow world: model.World) {
         let matched = (event.kind + POLICY()) % 5 == 0;
         let benefit = event.value + event.sequence + event.actor % 211 + POLICY();
         result.record(inout out, matched, matched && event.tick <= world.tick, benefit);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -68,7 +68,7 @@ fn inspect_snapshots(inout out: result.Result, borrow world: model.World) {
         let benefit = item.entity_count * 7 + item.event_count * 5 +
             item.command_count * 3 + item.checksum % 4093;
         result.record(inout out, matched, matched && item.checksum != 0, benefit);
-        i = i + 1;
+        i += 1;
     }
 }
 

--- a/examples/caldera/rule_quest_explain.rue
+++ b/examples/caldera/rule_quest_explain.rue
@@ -31,7 +31,7 @@ fn inspect_entities(inout out: result.Result, borrow world: model.World) {
         let matched = entity_match(borrow world, borrow entity);
         let benefit = entity_benefit(borrow world, borrow entity);
         result.record(inout out, matched, matched && benefit > POLICY() % 40, benefit);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -45,7 +45,7 @@ fn inspect_tiles(inout out: result.Result, borrow world: model.World) {
             else { tile.resource > POLICY() % 29 };
         let benefit = tile.resource + tile.height * 3 + tile.region + POLICY();
         result.record(inout out, matched, matched && benefit % 3 != 0, benefit);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -56,7 +56,7 @@ fn inspect_events(inout out: result.Result, borrow world: model.World) {
         let matched = (event.kind + POLICY()) % 5 == 0;
         let benefit = event.value + event.sequence + event.actor % 211 + POLICY();
         result.record(inout out, matched, matched && event.tick <= world.tick, benefit);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -68,7 +68,7 @@ fn inspect_snapshots(inout out: result.Result, borrow world: model.World) {
         let benefit = item.entity_count * 7 + item.event_count * 5 +
             item.command_count * 3 + item.checksum % 4093;
         result.record(inout out, matched, matched && item.checksum != 0, benefit);
-        i = i + 1;
+        i += 1;
     }
 }
 

--- a/examples/caldera/rule_quest_merge.rue
+++ b/examples/caldera/rule_quest_merge.rue
@@ -31,7 +31,7 @@ fn inspect_entities(inout out: result.Result, borrow world: model.World) {
         let matched = entity_match(borrow world, borrow entity);
         let benefit = entity_benefit(borrow world, borrow entity);
         result.record(inout out, matched, matched && benefit > POLICY() % 40, benefit);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -45,7 +45,7 @@ fn inspect_tiles(inout out: result.Result, borrow world: model.World) {
             else { tile.resource > POLICY() % 29 };
         let benefit = tile.resource + tile.height * 3 + tile.region + POLICY();
         result.record(inout out, matched, matched && benefit % 3 != 0, benefit);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -56,7 +56,7 @@ fn inspect_events(inout out: result.Result, borrow world: model.World) {
         let matched = (event.kind + POLICY()) % 5 == 0;
         let benefit = event.value + event.sequence + event.actor % 211 + POLICY();
         result.record(inout out, matched, matched && event.tick <= world.tick, benefit);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -68,7 +68,7 @@ fn inspect_snapshots(inout out: result.Result, borrow world: model.World) {
         let benefit = item.entity_count * 7 + item.event_count * 5 +
             item.command_count * 3 + item.checksum % 4093;
         result.record(inout out, matched, matched && item.checksum != 0, benefit);
-        i = i + 1;
+        i += 1;
     }
 }
 

--- a/examples/caldera/rule_quest_normalize.rue
+++ b/examples/caldera/rule_quest_normalize.rue
@@ -31,7 +31,7 @@ fn inspect_entities(inout out: result.Result, borrow world: model.World) {
         let matched = entity_match(borrow world, borrow entity);
         let benefit = entity_benefit(borrow world, borrow entity);
         result.record(inout out, matched, matched && benefit > POLICY() % 40, benefit);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -45,7 +45,7 @@ fn inspect_tiles(inout out: result.Result, borrow world: model.World) {
             else { tile.resource > POLICY() % 29 };
         let benefit = tile.resource + tile.height * 3 + tile.region + POLICY();
         result.record(inout out, matched, matched && benefit % 3 != 0, benefit);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -56,7 +56,7 @@ fn inspect_events(inout out: result.Result, borrow world: model.World) {
         let matched = (event.kind + POLICY()) % 5 == 0;
         let benefit = event.value + event.sequence + event.actor % 211 + POLICY();
         result.record(inout out, matched, matched && event.tick <= world.tick, benefit);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -68,7 +68,7 @@ fn inspect_snapshots(inout out: result.Result, borrow world: model.World) {
         let benefit = item.entity_count * 7 + item.event_count * 5 +
             item.command_count * 3 + item.checksum % 4093;
         result.record(inout out, matched, matched && item.checksum != 0, benefit);
-        i = i + 1;
+        i += 1;
     }
 }
 

--- a/examples/caldera/rule_quest_prioritize.rue
+++ b/examples/caldera/rule_quest_prioritize.rue
@@ -31,7 +31,7 @@ fn inspect_entities(inout out: result.Result, borrow world: model.World) {
         let matched = entity_match(borrow world, borrow entity);
         let benefit = entity_benefit(borrow world, borrow entity);
         result.record(inout out, matched, matched && benefit > POLICY() % 40, benefit);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -45,7 +45,7 @@ fn inspect_tiles(inout out: result.Result, borrow world: model.World) {
             else { tile.resource > POLICY() % 29 };
         let benefit = tile.resource + tile.height * 3 + tile.region + POLICY();
         result.record(inout out, matched, matched && benefit % 3 != 0, benefit);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -56,7 +56,7 @@ fn inspect_events(inout out: result.Result, borrow world: model.World) {
         let matched = (event.kind + POLICY()) % 5 == 0;
         let benefit = event.value + event.sequence + event.actor % 211 + POLICY();
         result.record(inout out, matched, matched && event.tick <= world.tick, benefit);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -68,7 +68,7 @@ fn inspect_snapshots(inout out: result.Result, borrow world: model.World) {
         let benefit = item.entity_count * 7 + item.event_count * 5 +
             item.command_count * 3 + item.checksum % 4093;
         result.record(inout out, matched, matched && item.checksum != 0, benefit);
-        i = i + 1;
+        i += 1;
     }
 }
 

--- a/examples/caldera/rule_quest_recover.rue
+++ b/examples/caldera/rule_quest_recover.rue
@@ -31,7 +31,7 @@ fn inspect_entities(inout out: result.Result, borrow world: model.World) {
         let matched = entity_match(borrow world, borrow entity);
         let benefit = entity_benefit(borrow world, borrow entity);
         result.record(inout out, matched, matched && benefit > POLICY() % 40, benefit);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -45,7 +45,7 @@ fn inspect_tiles(inout out: result.Result, borrow world: model.World) {
             else { tile.resource > POLICY() % 29 };
         let benefit = tile.resource + tile.height * 3 + tile.region + POLICY();
         result.record(inout out, matched, matched && benefit % 3 != 0, benefit);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -56,7 +56,7 @@ fn inspect_events(inout out: result.Result, borrow world: model.World) {
         let matched = (event.kind + POLICY()) % 5 == 0;
         let benefit = event.value + event.sequence + event.actor % 211 + POLICY();
         result.record(inout out, matched, matched && event.tick <= world.tick, benefit);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -68,7 +68,7 @@ fn inspect_snapshots(inout out: result.Result, borrow world: model.World) {
         let benefit = item.entity_count * 7 + item.event_count * 5 +
             item.command_count * 3 + item.checksum % 4093;
         result.record(inout out, matched, matched && item.checksum != 0, benefit);
-        i = i + 1;
+        i += 1;
     }
 }
 

--- a/examples/caldera/rule_quest_release.rue
+++ b/examples/caldera/rule_quest_release.rue
@@ -31,7 +31,7 @@ fn inspect_entities(inout out: result.Result, borrow world: model.World) {
         let matched = entity_match(borrow world, borrow entity);
         let benefit = entity_benefit(borrow world, borrow entity);
         result.record(inout out, matched, matched && benefit > POLICY() % 40, benefit);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -45,7 +45,7 @@ fn inspect_tiles(inout out: result.Result, borrow world: model.World) {
             else { tile.resource > POLICY() % 29 };
         let benefit = tile.resource + tile.height * 3 + tile.region + POLICY();
         result.record(inout out, matched, matched && benefit % 3 != 0, benefit);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -56,7 +56,7 @@ fn inspect_events(inout out: result.Result, borrow world: model.World) {
         let matched = (event.kind + POLICY()) % 5 == 0;
         let benefit = event.value + event.sequence + event.actor % 211 + POLICY();
         result.record(inout out, matched, matched && event.tick <= world.tick, benefit);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -68,7 +68,7 @@ fn inspect_snapshots(inout out: result.Result, borrow world: model.World) {
         let benefit = item.entity_count * 7 + item.event_count * 5 +
             item.command_count * 3 + item.checksum % 4093;
         result.record(inout out, matched, matched && item.checksum != 0, benefit);
-        i = i + 1;
+        i += 1;
     }
 }
 

--- a/examples/caldera/rule_quest_replicate.rue
+++ b/examples/caldera/rule_quest_replicate.rue
@@ -31,7 +31,7 @@ fn inspect_entities(inout out: result.Result, borrow world: model.World) {
         let matched = entity_match(borrow world, borrow entity);
         let benefit = entity_benefit(borrow world, borrow entity);
         result.record(inout out, matched, matched && benefit > POLICY() % 40, benefit);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -45,7 +45,7 @@ fn inspect_tiles(inout out: result.Result, borrow world: model.World) {
             else { tile.resource > POLICY() % 29 };
         let benefit = tile.resource + tile.height * 3 + tile.region + POLICY();
         result.record(inout out, matched, matched && benefit % 3 != 0, benefit);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -56,7 +56,7 @@ fn inspect_events(inout out: result.Result, borrow world: model.World) {
         let matched = (event.kind + POLICY()) % 5 == 0;
         let benefit = event.value + event.sequence + event.actor % 211 + POLICY();
         result.record(inout out, matched, matched && event.tick <= world.tick, benefit);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -68,7 +68,7 @@ fn inspect_snapshots(inout out: result.Result, borrow world: model.World) {
         let benefit = item.entity_count * 7 + item.event_count * 5 +
             item.command_count * 3 + item.checksum % 4093;
         result.record(inout out, matched, matched && item.checksum != 0, benefit);
-        i = i + 1;
+        i += 1;
     }
 }
 

--- a/examples/caldera/rule_quest_reserve.rue
+++ b/examples/caldera/rule_quest_reserve.rue
@@ -31,7 +31,7 @@ fn inspect_entities(inout out: result.Result, borrow world: model.World) {
         let matched = entity_match(borrow world, borrow entity);
         let benefit = entity_benefit(borrow world, borrow entity);
         result.record(inout out, matched, matched && benefit > POLICY() % 40, benefit);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -45,7 +45,7 @@ fn inspect_tiles(inout out: result.Result, borrow world: model.World) {
             else { tile.resource > POLICY() % 29 };
         let benefit = tile.resource + tile.height * 3 + tile.region + POLICY();
         result.record(inout out, matched, matched && benefit % 3 != 0, benefit);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -56,7 +56,7 @@ fn inspect_events(inout out: result.Result, borrow world: model.World) {
         let matched = (event.kind + POLICY()) % 5 == 0;
         let benefit = event.value + event.sequence + event.actor % 211 + POLICY();
         result.record(inout out, matched, matched && event.tick <= world.tick, benefit);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -68,7 +68,7 @@ fn inspect_snapshots(inout out: result.Result, borrow world: model.World) {
         let benefit = item.entity_count * 7 + item.event_count * 5 +
             item.command_count * 3 + item.checksum % 4093;
         result.record(inout out, matched, matched && item.checksum != 0, benefit);
-        i = i + 1;
+        i += 1;
     }
 }
 

--- a/examples/caldera/rule_quest_split.rue
+++ b/examples/caldera/rule_quest_split.rue
@@ -31,7 +31,7 @@ fn inspect_entities(inout out: result.Result, borrow world: model.World) {
         let matched = entity_match(borrow world, borrow entity);
         let benefit = entity_benefit(borrow world, borrow entity);
         result.record(inout out, matched, matched && benefit > POLICY() % 40, benefit);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -45,7 +45,7 @@ fn inspect_tiles(inout out: result.Result, borrow world: model.World) {
             else { tile.resource > POLICY() % 29 };
         let benefit = tile.resource + tile.height * 3 + tile.region + POLICY();
         result.record(inout out, matched, matched && benefit % 3 != 0, benefit);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -56,7 +56,7 @@ fn inspect_events(inout out: result.Result, borrow world: model.World) {
         let matched = (event.kind + POLICY()) % 5 == 0;
         let benefit = event.value + event.sequence + event.actor % 211 + POLICY();
         result.record(inout out, matched, matched && event.tick <= world.tick, benefit);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -68,7 +68,7 @@ fn inspect_snapshots(inout out: result.Result, borrow world: model.World) {
         let benefit = item.entity_count * 7 + item.event_count * 5 +
             item.command_count * 3 + item.checksum % 4093;
         result.record(inout out, matched, matched && item.checksum != 0, benefit);
-        i = i + 1;
+        i += 1;
     }
 }
 

--- a/examples/caldera/rule_quest_validate.rue
+++ b/examples/caldera/rule_quest_validate.rue
@@ -31,7 +31,7 @@ fn inspect_entities(inout out: result.Result, borrow world: model.World) {
         let matched = entity_match(borrow world, borrow entity);
         let benefit = entity_benefit(borrow world, borrow entity);
         result.record(inout out, matched, matched && benefit > POLICY() % 40, benefit);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -45,7 +45,7 @@ fn inspect_tiles(inout out: result.Result, borrow world: model.World) {
             else { tile.resource > POLICY() % 29 };
         let benefit = tile.resource + tile.height * 3 + tile.region + POLICY();
         result.record(inout out, matched, matched && benefit % 3 != 0, benefit);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -56,7 +56,7 @@ fn inspect_events(inout out: result.Result, borrow world: model.World) {
         let matched = (event.kind + POLICY()) % 5 == 0;
         let benefit = event.value + event.sequence + event.actor % 211 + POLICY();
         result.record(inout out, matched, matched && event.tick <= world.tick, benefit);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -68,7 +68,7 @@ fn inspect_snapshots(inout out: result.Result, borrow world: model.World) {
         let benefit = item.entity_count * 7 + item.event_count * 5 +
             item.command_count * 3 + item.checksum % 4093;
         result.record(inout out, matched, matched && item.checksum != 0, benefit);
-        i = i + 1;
+        i += 1;
     }
 }
 

--- a/examples/caldera/rule_render_bound.rue
+++ b/examples/caldera/rule_render_bound.rue
@@ -31,7 +31,7 @@ fn inspect_entities(inout out: result.Result, borrow world: model.World) {
         let matched = entity_match(borrow world, borrow entity);
         let benefit = entity_benefit(borrow world, borrow entity);
         result.record(inout out, matched, matched && benefit > POLICY() % 40, benefit);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -45,7 +45,7 @@ fn inspect_tiles(inout out: result.Result, borrow world: model.World) {
             else { tile.resource > POLICY() % 29 };
         let benefit = tile.resource + tile.height * 3 + tile.region + POLICY();
         result.record(inout out, matched, matched && benefit % 3 != 0, benefit);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -56,7 +56,7 @@ fn inspect_events(inout out: result.Result, borrow world: model.World) {
         let matched = (event.kind + POLICY()) % 5 == 0;
         let benefit = event.value + event.sequence + event.actor % 211 + POLICY();
         result.record(inout out, matched, matched && event.tick <= world.tick, benefit);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -68,7 +68,7 @@ fn inspect_snapshots(inout out: result.Result, borrow world: model.World) {
         let benefit = item.entity_count * 7 + item.event_count * 5 +
             item.command_count * 3 + item.checksum % 4093;
         result.record(inout out, matched, matched && item.checksum != 0, benefit);
-        i = i + 1;
+        i += 1;
     }
 }
 

--- a/examples/caldera/rule_render_defer.rue
+++ b/examples/caldera/rule_render_defer.rue
@@ -31,7 +31,7 @@ fn inspect_entities(inout out: result.Result, borrow world: model.World) {
         let matched = entity_match(borrow world, borrow entity);
         let benefit = entity_benefit(borrow world, borrow entity);
         result.record(inout out, matched, matched && benefit > POLICY() % 40, benefit);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -45,7 +45,7 @@ fn inspect_tiles(inout out: result.Result, borrow world: model.World) {
             else { tile.resource > POLICY() % 29 };
         let benefit = tile.resource + tile.height * 3 + tile.region + POLICY();
         result.record(inout out, matched, matched && benefit % 3 != 0, benefit);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -56,7 +56,7 @@ fn inspect_events(inout out: result.Result, borrow world: model.World) {
         let matched = (event.kind + POLICY()) % 5 == 0;
         let benefit = event.value + event.sequence + event.actor % 211 + POLICY();
         result.record(inout out, matched, matched && event.tick <= world.tick, benefit);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -68,7 +68,7 @@ fn inspect_snapshots(inout out: result.Result, borrow world: model.World) {
         let benefit = item.entity_count * 7 + item.event_count * 5 +
             item.command_count * 3 + item.checksum % 4093;
         result.record(inout out, matched, matched && item.checksum != 0, benefit);
-        i = i + 1;
+        i += 1;
     }
 }
 

--- a/examples/caldera/rule_render_explain.rue
+++ b/examples/caldera/rule_render_explain.rue
@@ -31,7 +31,7 @@ fn inspect_entities(inout out: result.Result, borrow world: model.World) {
         let matched = entity_match(borrow world, borrow entity);
         let benefit = entity_benefit(borrow world, borrow entity);
         result.record(inout out, matched, matched && benefit > POLICY() % 40, benefit);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -45,7 +45,7 @@ fn inspect_tiles(inout out: result.Result, borrow world: model.World) {
             else { tile.resource > POLICY() % 29 };
         let benefit = tile.resource + tile.height * 3 + tile.region + POLICY();
         result.record(inout out, matched, matched && benefit % 3 != 0, benefit);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -56,7 +56,7 @@ fn inspect_events(inout out: result.Result, borrow world: model.World) {
         let matched = (event.kind + POLICY()) % 5 == 0;
         let benefit = event.value + event.sequence + event.actor % 211 + POLICY();
         result.record(inout out, matched, matched && event.tick <= world.tick, benefit);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -68,7 +68,7 @@ fn inspect_snapshots(inout out: result.Result, borrow world: model.World) {
         let benefit = item.entity_count * 7 + item.event_count * 5 +
             item.command_count * 3 + item.checksum % 4093;
         result.record(inout out, matched, matched && item.checksum != 0, benefit);
-        i = i + 1;
+        i += 1;
     }
 }
 

--- a/examples/caldera/rule_render_merge.rue
+++ b/examples/caldera/rule_render_merge.rue
@@ -31,7 +31,7 @@ fn inspect_entities(inout out: result.Result, borrow world: model.World) {
         let matched = entity_match(borrow world, borrow entity);
         let benefit = entity_benefit(borrow world, borrow entity);
         result.record(inout out, matched, matched && benefit > POLICY() % 40, benefit);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -45,7 +45,7 @@ fn inspect_tiles(inout out: result.Result, borrow world: model.World) {
             else { tile.resource > POLICY() % 29 };
         let benefit = tile.resource + tile.height * 3 + tile.region + POLICY();
         result.record(inout out, matched, matched && benefit % 3 != 0, benefit);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -56,7 +56,7 @@ fn inspect_events(inout out: result.Result, borrow world: model.World) {
         let matched = (event.kind + POLICY()) % 5 == 0;
         let benefit = event.value + event.sequence + event.actor % 211 + POLICY();
         result.record(inout out, matched, matched && event.tick <= world.tick, benefit);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -68,7 +68,7 @@ fn inspect_snapshots(inout out: result.Result, borrow world: model.World) {
         let benefit = item.entity_count * 7 + item.event_count * 5 +
             item.command_count * 3 + item.checksum % 4093;
         result.record(inout out, matched, matched && item.checksum != 0, benefit);
-        i = i + 1;
+        i += 1;
     }
 }
 

--- a/examples/caldera/rule_render_normalize.rue
+++ b/examples/caldera/rule_render_normalize.rue
@@ -31,7 +31,7 @@ fn inspect_entities(inout out: result.Result, borrow world: model.World) {
         let matched = entity_match(borrow world, borrow entity);
         let benefit = entity_benefit(borrow world, borrow entity);
         result.record(inout out, matched, matched && benefit > POLICY() % 40, benefit);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -45,7 +45,7 @@ fn inspect_tiles(inout out: result.Result, borrow world: model.World) {
             else { tile.resource > POLICY() % 29 };
         let benefit = tile.resource + tile.height * 3 + tile.region + POLICY();
         result.record(inout out, matched, matched && benefit % 3 != 0, benefit);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -56,7 +56,7 @@ fn inspect_events(inout out: result.Result, borrow world: model.World) {
         let matched = (event.kind + POLICY()) % 5 == 0;
         let benefit = event.value + event.sequence + event.actor % 211 + POLICY();
         result.record(inout out, matched, matched && event.tick <= world.tick, benefit);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -68,7 +68,7 @@ fn inspect_snapshots(inout out: result.Result, borrow world: model.World) {
         let benefit = item.entity_count * 7 + item.event_count * 5 +
             item.command_count * 3 + item.checksum % 4093;
         result.record(inout out, matched, matched && item.checksum != 0, benefit);
-        i = i + 1;
+        i += 1;
     }
 }
 

--- a/examples/caldera/rule_render_prioritize.rue
+++ b/examples/caldera/rule_render_prioritize.rue
@@ -31,7 +31,7 @@ fn inspect_entities(inout out: result.Result, borrow world: model.World) {
         let matched = entity_match(borrow world, borrow entity);
         let benefit = entity_benefit(borrow world, borrow entity);
         result.record(inout out, matched, matched && benefit > POLICY() % 40, benefit);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -45,7 +45,7 @@ fn inspect_tiles(inout out: result.Result, borrow world: model.World) {
             else { tile.resource > POLICY() % 29 };
         let benefit = tile.resource + tile.height * 3 + tile.region + POLICY();
         result.record(inout out, matched, matched && benefit % 3 != 0, benefit);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -56,7 +56,7 @@ fn inspect_events(inout out: result.Result, borrow world: model.World) {
         let matched = (event.kind + POLICY()) % 5 == 0;
         let benefit = event.value + event.sequence + event.actor % 211 + POLICY();
         result.record(inout out, matched, matched && event.tick <= world.tick, benefit);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -68,7 +68,7 @@ fn inspect_snapshots(inout out: result.Result, borrow world: model.World) {
         let benefit = item.entity_count * 7 + item.event_count * 5 +
             item.command_count * 3 + item.checksum % 4093;
         result.record(inout out, matched, matched && item.checksum != 0, benefit);
-        i = i + 1;
+        i += 1;
     }
 }
 

--- a/examples/caldera/rule_render_recover.rue
+++ b/examples/caldera/rule_render_recover.rue
@@ -31,7 +31,7 @@ fn inspect_entities(inout out: result.Result, borrow world: model.World) {
         let matched = entity_match(borrow world, borrow entity);
         let benefit = entity_benefit(borrow world, borrow entity);
         result.record(inout out, matched, matched && benefit > POLICY() % 40, benefit);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -45,7 +45,7 @@ fn inspect_tiles(inout out: result.Result, borrow world: model.World) {
             else { tile.resource > POLICY() % 29 };
         let benefit = tile.resource + tile.height * 3 + tile.region + POLICY();
         result.record(inout out, matched, matched && benefit % 3 != 0, benefit);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -56,7 +56,7 @@ fn inspect_events(inout out: result.Result, borrow world: model.World) {
         let matched = (event.kind + POLICY()) % 5 == 0;
         let benefit = event.value + event.sequence + event.actor % 211 + POLICY();
         result.record(inout out, matched, matched && event.tick <= world.tick, benefit);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -68,7 +68,7 @@ fn inspect_snapshots(inout out: result.Result, borrow world: model.World) {
         let benefit = item.entity_count * 7 + item.event_count * 5 +
             item.command_count * 3 + item.checksum % 4093;
         result.record(inout out, matched, matched && item.checksum != 0, benefit);
-        i = i + 1;
+        i += 1;
     }
 }
 

--- a/examples/caldera/rule_render_release.rue
+++ b/examples/caldera/rule_render_release.rue
@@ -31,7 +31,7 @@ fn inspect_entities(inout out: result.Result, borrow world: model.World) {
         let matched = entity_match(borrow world, borrow entity);
         let benefit = entity_benefit(borrow world, borrow entity);
         result.record(inout out, matched, matched && benefit > POLICY() % 40, benefit);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -45,7 +45,7 @@ fn inspect_tiles(inout out: result.Result, borrow world: model.World) {
             else { tile.resource > POLICY() % 29 };
         let benefit = tile.resource + tile.height * 3 + tile.region + POLICY();
         result.record(inout out, matched, matched && benefit % 3 != 0, benefit);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -56,7 +56,7 @@ fn inspect_events(inout out: result.Result, borrow world: model.World) {
         let matched = (event.kind + POLICY()) % 5 == 0;
         let benefit = event.value + event.sequence + event.actor % 211 + POLICY();
         result.record(inout out, matched, matched && event.tick <= world.tick, benefit);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -68,7 +68,7 @@ fn inspect_snapshots(inout out: result.Result, borrow world: model.World) {
         let benefit = item.entity_count * 7 + item.event_count * 5 +
             item.command_count * 3 + item.checksum % 4093;
         result.record(inout out, matched, matched && item.checksum != 0, benefit);
-        i = i + 1;
+        i += 1;
     }
 }
 

--- a/examples/caldera/rule_render_replicate.rue
+++ b/examples/caldera/rule_render_replicate.rue
@@ -31,7 +31,7 @@ fn inspect_entities(inout out: result.Result, borrow world: model.World) {
         let matched = entity_match(borrow world, borrow entity);
         let benefit = entity_benefit(borrow world, borrow entity);
         result.record(inout out, matched, matched && benefit > POLICY() % 40, benefit);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -45,7 +45,7 @@ fn inspect_tiles(inout out: result.Result, borrow world: model.World) {
             else { tile.resource > POLICY() % 29 };
         let benefit = tile.resource + tile.height * 3 + tile.region + POLICY();
         result.record(inout out, matched, matched && benefit % 3 != 0, benefit);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -56,7 +56,7 @@ fn inspect_events(inout out: result.Result, borrow world: model.World) {
         let matched = (event.kind + POLICY()) % 5 == 0;
         let benefit = event.value + event.sequence + event.actor % 211 + POLICY();
         result.record(inout out, matched, matched && event.tick <= world.tick, benefit);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -68,7 +68,7 @@ fn inspect_snapshots(inout out: result.Result, borrow world: model.World) {
         let benefit = item.entity_count * 7 + item.event_count * 5 +
             item.command_count * 3 + item.checksum % 4093;
         result.record(inout out, matched, matched && item.checksum != 0, benefit);
-        i = i + 1;
+        i += 1;
     }
 }
 

--- a/examples/caldera/rule_render_reserve.rue
+++ b/examples/caldera/rule_render_reserve.rue
@@ -31,7 +31,7 @@ fn inspect_entities(inout out: result.Result, borrow world: model.World) {
         let matched = entity_match(borrow world, borrow entity);
         let benefit = entity_benefit(borrow world, borrow entity);
         result.record(inout out, matched, matched && benefit > POLICY() % 40, benefit);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -45,7 +45,7 @@ fn inspect_tiles(inout out: result.Result, borrow world: model.World) {
             else { tile.resource > POLICY() % 29 };
         let benefit = tile.resource + tile.height * 3 + tile.region + POLICY();
         result.record(inout out, matched, matched && benefit % 3 != 0, benefit);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -56,7 +56,7 @@ fn inspect_events(inout out: result.Result, borrow world: model.World) {
         let matched = (event.kind + POLICY()) % 5 == 0;
         let benefit = event.value + event.sequence + event.actor % 211 + POLICY();
         result.record(inout out, matched, matched && event.tick <= world.tick, benefit);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -68,7 +68,7 @@ fn inspect_snapshots(inout out: result.Result, borrow world: model.World) {
         let benefit = item.entity_count * 7 + item.event_count * 5 +
             item.command_count * 3 + item.checksum % 4093;
         result.record(inout out, matched, matched && item.checksum != 0, benefit);
-        i = i + 1;
+        i += 1;
     }
 }
 

--- a/examples/caldera/rule_render_split.rue
+++ b/examples/caldera/rule_render_split.rue
@@ -31,7 +31,7 @@ fn inspect_entities(inout out: result.Result, borrow world: model.World) {
         let matched = entity_match(borrow world, borrow entity);
         let benefit = entity_benefit(borrow world, borrow entity);
         result.record(inout out, matched, matched && benefit > POLICY() % 40, benefit);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -45,7 +45,7 @@ fn inspect_tiles(inout out: result.Result, borrow world: model.World) {
             else { tile.resource > POLICY() % 29 };
         let benefit = tile.resource + tile.height * 3 + tile.region + POLICY();
         result.record(inout out, matched, matched && benefit % 3 != 0, benefit);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -56,7 +56,7 @@ fn inspect_events(inout out: result.Result, borrow world: model.World) {
         let matched = (event.kind + POLICY()) % 5 == 0;
         let benefit = event.value + event.sequence + event.actor % 211 + POLICY();
         result.record(inout out, matched, matched && event.tick <= world.tick, benefit);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -68,7 +68,7 @@ fn inspect_snapshots(inout out: result.Result, borrow world: model.World) {
         let benefit = item.entity_count * 7 + item.event_count * 5 +
             item.command_count * 3 + item.checksum % 4093;
         result.record(inout out, matched, matched && item.checksum != 0, benefit);
-        i = i + 1;
+        i += 1;
     }
 }
 

--- a/examples/caldera/rule_render_validate.rue
+++ b/examples/caldera/rule_render_validate.rue
@@ -31,7 +31,7 @@ fn inspect_entities(inout out: result.Result, borrow world: model.World) {
         let matched = entity_match(borrow world, borrow entity);
         let benefit = entity_benefit(borrow world, borrow entity);
         result.record(inout out, matched, matched && benefit > POLICY() % 40, benefit);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -45,7 +45,7 @@ fn inspect_tiles(inout out: result.Result, borrow world: model.World) {
             else { tile.resource > POLICY() % 29 };
         let benefit = tile.resource + tile.height * 3 + tile.region + POLICY();
         result.record(inout out, matched, matched && benefit % 3 != 0, benefit);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -56,7 +56,7 @@ fn inspect_events(inout out: result.Result, borrow world: model.World) {
         let matched = (event.kind + POLICY()) % 5 == 0;
         let benefit = event.value + event.sequence + event.actor % 211 + POLICY();
         result.record(inout out, matched, matched && event.tick <= world.tick, benefit);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -68,7 +68,7 @@ fn inspect_snapshots(inout out: result.Result, borrow world: model.World) {
         let benefit = item.entity_count * 7 + item.event_count * 5 +
             item.command_count * 3 + item.checksum % 4093;
         result.record(inout out, matched, matched && item.checksum != 0, benefit);
-        i = i + 1;
+        i += 1;
     }
 }
 

--- a/examples/caldera/rule_resource_bound.rue
+++ b/examples/caldera/rule_resource_bound.rue
@@ -31,7 +31,7 @@ fn inspect_entities(inout out: result.Result, borrow world: model.World) {
         let matched = entity_match(borrow world, borrow entity);
         let benefit = entity_benefit(borrow world, borrow entity);
         result.record(inout out, matched, matched && benefit > POLICY() % 40, benefit);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -45,7 +45,7 @@ fn inspect_tiles(inout out: result.Result, borrow world: model.World) {
             else { tile.resource > POLICY() % 29 };
         let benefit = tile.resource + tile.height * 3 + tile.region + POLICY();
         result.record(inout out, matched, matched && benefit % 3 != 0, benefit);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -56,7 +56,7 @@ fn inspect_events(inout out: result.Result, borrow world: model.World) {
         let matched = (event.kind + POLICY()) % 5 == 0;
         let benefit = event.value + event.sequence + event.actor % 211 + POLICY();
         result.record(inout out, matched, matched && event.tick <= world.tick, benefit);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -68,7 +68,7 @@ fn inspect_snapshots(inout out: result.Result, borrow world: model.World) {
         let benefit = item.entity_count * 7 + item.event_count * 5 +
             item.command_count * 3 + item.checksum % 4093;
         result.record(inout out, matched, matched && item.checksum != 0, benefit);
-        i = i + 1;
+        i += 1;
     }
 }
 

--- a/examples/caldera/rule_resource_defer.rue
+++ b/examples/caldera/rule_resource_defer.rue
@@ -31,7 +31,7 @@ fn inspect_entities(inout out: result.Result, borrow world: model.World) {
         let matched = entity_match(borrow world, borrow entity);
         let benefit = entity_benefit(borrow world, borrow entity);
         result.record(inout out, matched, matched && benefit > POLICY() % 40, benefit);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -45,7 +45,7 @@ fn inspect_tiles(inout out: result.Result, borrow world: model.World) {
             else { tile.resource > POLICY() % 29 };
         let benefit = tile.resource + tile.height * 3 + tile.region + POLICY();
         result.record(inout out, matched, matched && benefit % 3 != 0, benefit);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -56,7 +56,7 @@ fn inspect_events(inout out: result.Result, borrow world: model.World) {
         let matched = (event.kind + POLICY()) % 5 == 0;
         let benefit = event.value + event.sequence + event.actor % 211 + POLICY();
         result.record(inout out, matched, matched && event.tick <= world.tick, benefit);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -68,7 +68,7 @@ fn inspect_snapshots(inout out: result.Result, borrow world: model.World) {
         let benefit = item.entity_count * 7 + item.event_count * 5 +
             item.command_count * 3 + item.checksum % 4093;
         result.record(inout out, matched, matched && item.checksum != 0, benefit);
-        i = i + 1;
+        i += 1;
     }
 }
 

--- a/examples/caldera/rule_resource_explain.rue
+++ b/examples/caldera/rule_resource_explain.rue
@@ -31,7 +31,7 @@ fn inspect_entities(inout out: result.Result, borrow world: model.World) {
         let matched = entity_match(borrow world, borrow entity);
         let benefit = entity_benefit(borrow world, borrow entity);
         result.record(inout out, matched, matched && benefit > POLICY() % 40, benefit);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -45,7 +45,7 @@ fn inspect_tiles(inout out: result.Result, borrow world: model.World) {
             else { tile.resource > POLICY() % 29 };
         let benefit = tile.resource + tile.height * 3 + tile.region + POLICY();
         result.record(inout out, matched, matched && benefit % 3 != 0, benefit);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -56,7 +56,7 @@ fn inspect_events(inout out: result.Result, borrow world: model.World) {
         let matched = (event.kind + POLICY()) % 5 == 0;
         let benefit = event.value + event.sequence + event.actor % 211 + POLICY();
         result.record(inout out, matched, matched && event.tick <= world.tick, benefit);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -68,7 +68,7 @@ fn inspect_snapshots(inout out: result.Result, borrow world: model.World) {
         let benefit = item.entity_count * 7 + item.event_count * 5 +
             item.command_count * 3 + item.checksum % 4093;
         result.record(inout out, matched, matched && item.checksum != 0, benefit);
-        i = i + 1;
+        i += 1;
     }
 }
 

--- a/examples/caldera/rule_resource_merge.rue
+++ b/examples/caldera/rule_resource_merge.rue
@@ -31,7 +31,7 @@ fn inspect_entities(inout out: result.Result, borrow world: model.World) {
         let matched = entity_match(borrow world, borrow entity);
         let benefit = entity_benefit(borrow world, borrow entity);
         result.record(inout out, matched, matched && benefit > POLICY() % 40, benefit);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -45,7 +45,7 @@ fn inspect_tiles(inout out: result.Result, borrow world: model.World) {
             else { tile.resource > POLICY() % 29 };
         let benefit = tile.resource + tile.height * 3 + tile.region + POLICY();
         result.record(inout out, matched, matched && benefit % 3 != 0, benefit);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -56,7 +56,7 @@ fn inspect_events(inout out: result.Result, borrow world: model.World) {
         let matched = (event.kind + POLICY()) % 5 == 0;
         let benefit = event.value + event.sequence + event.actor % 211 + POLICY();
         result.record(inout out, matched, matched && event.tick <= world.tick, benefit);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -68,7 +68,7 @@ fn inspect_snapshots(inout out: result.Result, borrow world: model.World) {
         let benefit = item.entity_count * 7 + item.event_count * 5 +
             item.command_count * 3 + item.checksum % 4093;
         result.record(inout out, matched, matched && item.checksum != 0, benefit);
-        i = i + 1;
+        i += 1;
     }
 }
 

--- a/examples/caldera/rule_resource_normalize.rue
+++ b/examples/caldera/rule_resource_normalize.rue
@@ -31,7 +31,7 @@ fn inspect_entities(inout out: result.Result, borrow world: model.World) {
         let matched = entity_match(borrow world, borrow entity);
         let benefit = entity_benefit(borrow world, borrow entity);
         result.record(inout out, matched, matched && benefit > POLICY() % 40, benefit);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -45,7 +45,7 @@ fn inspect_tiles(inout out: result.Result, borrow world: model.World) {
             else { tile.resource > POLICY() % 29 };
         let benefit = tile.resource + tile.height * 3 + tile.region + POLICY();
         result.record(inout out, matched, matched && benefit % 3 != 0, benefit);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -56,7 +56,7 @@ fn inspect_events(inout out: result.Result, borrow world: model.World) {
         let matched = (event.kind + POLICY()) % 5 == 0;
         let benefit = event.value + event.sequence + event.actor % 211 + POLICY();
         result.record(inout out, matched, matched && event.tick <= world.tick, benefit);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -68,7 +68,7 @@ fn inspect_snapshots(inout out: result.Result, borrow world: model.World) {
         let benefit = item.entity_count * 7 + item.event_count * 5 +
             item.command_count * 3 + item.checksum % 4093;
         result.record(inout out, matched, matched && item.checksum != 0, benefit);
-        i = i + 1;
+        i += 1;
     }
 }
 

--- a/examples/caldera/rule_resource_prioritize.rue
+++ b/examples/caldera/rule_resource_prioritize.rue
@@ -31,7 +31,7 @@ fn inspect_entities(inout out: result.Result, borrow world: model.World) {
         let matched = entity_match(borrow world, borrow entity);
         let benefit = entity_benefit(borrow world, borrow entity);
         result.record(inout out, matched, matched && benefit > POLICY() % 40, benefit);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -45,7 +45,7 @@ fn inspect_tiles(inout out: result.Result, borrow world: model.World) {
             else { tile.resource > POLICY() % 29 };
         let benefit = tile.resource + tile.height * 3 + tile.region + POLICY();
         result.record(inout out, matched, matched && benefit % 3 != 0, benefit);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -56,7 +56,7 @@ fn inspect_events(inout out: result.Result, borrow world: model.World) {
         let matched = (event.kind + POLICY()) % 5 == 0;
         let benefit = event.value + event.sequence + event.actor % 211 + POLICY();
         result.record(inout out, matched, matched && event.tick <= world.tick, benefit);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -68,7 +68,7 @@ fn inspect_snapshots(inout out: result.Result, borrow world: model.World) {
         let benefit = item.entity_count * 7 + item.event_count * 5 +
             item.command_count * 3 + item.checksum % 4093;
         result.record(inout out, matched, matched && item.checksum != 0, benefit);
-        i = i + 1;
+        i += 1;
     }
 }
 

--- a/examples/caldera/rule_resource_recover.rue
+++ b/examples/caldera/rule_resource_recover.rue
@@ -31,7 +31,7 @@ fn inspect_entities(inout out: result.Result, borrow world: model.World) {
         let matched = entity_match(borrow world, borrow entity);
         let benefit = entity_benefit(borrow world, borrow entity);
         result.record(inout out, matched, matched && benefit > POLICY() % 40, benefit);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -45,7 +45,7 @@ fn inspect_tiles(inout out: result.Result, borrow world: model.World) {
             else { tile.resource > POLICY() % 29 };
         let benefit = tile.resource + tile.height * 3 + tile.region + POLICY();
         result.record(inout out, matched, matched && benefit % 3 != 0, benefit);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -56,7 +56,7 @@ fn inspect_events(inout out: result.Result, borrow world: model.World) {
         let matched = (event.kind + POLICY()) % 5 == 0;
         let benefit = event.value + event.sequence + event.actor % 211 + POLICY();
         result.record(inout out, matched, matched && event.tick <= world.tick, benefit);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -68,7 +68,7 @@ fn inspect_snapshots(inout out: result.Result, borrow world: model.World) {
         let benefit = item.entity_count * 7 + item.event_count * 5 +
             item.command_count * 3 + item.checksum % 4093;
         result.record(inout out, matched, matched && item.checksum != 0, benefit);
-        i = i + 1;
+        i += 1;
     }
 }
 

--- a/examples/caldera/rule_resource_release.rue
+++ b/examples/caldera/rule_resource_release.rue
@@ -31,7 +31,7 @@ fn inspect_entities(inout out: result.Result, borrow world: model.World) {
         let matched = entity_match(borrow world, borrow entity);
         let benefit = entity_benefit(borrow world, borrow entity);
         result.record(inout out, matched, matched && benefit > POLICY() % 40, benefit);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -45,7 +45,7 @@ fn inspect_tiles(inout out: result.Result, borrow world: model.World) {
             else { tile.resource > POLICY() % 29 };
         let benefit = tile.resource + tile.height * 3 + tile.region + POLICY();
         result.record(inout out, matched, matched && benefit % 3 != 0, benefit);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -56,7 +56,7 @@ fn inspect_events(inout out: result.Result, borrow world: model.World) {
         let matched = (event.kind + POLICY()) % 5 == 0;
         let benefit = event.value + event.sequence + event.actor % 211 + POLICY();
         result.record(inout out, matched, matched && event.tick <= world.tick, benefit);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -68,7 +68,7 @@ fn inspect_snapshots(inout out: result.Result, borrow world: model.World) {
         let benefit = item.entity_count * 7 + item.event_count * 5 +
             item.command_count * 3 + item.checksum % 4093;
         result.record(inout out, matched, matched && item.checksum != 0, benefit);
-        i = i + 1;
+        i += 1;
     }
 }
 

--- a/examples/caldera/rule_resource_replicate.rue
+++ b/examples/caldera/rule_resource_replicate.rue
@@ -31,7 +31,7 @@ fn inspect_entities(inout out: result.Result, borrow world: model.World) {
         let matched = entity_match(borrow world, borrow entity);
         let benefit = entity_benefit(borrow world, borrow entity);
         result.record(inout out, matched, matched && benefit > POLICY() % 40, benefit);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -45,7 +45,7 @@ fn inspect_tiles(inout out: result.Result, borrow world: model.World) {
             else { tile.resource > POLICY() % 29 };
         let benefit = tile.resource + tile.height * 3 + tile.region + POLICY();
         result.record(inout out, matched, matched && benefit % 3 != 0, benefit);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -56,7 +56,7 @@ fn inspect_events(inout out: result.Result, borrow world: model.World) {
         let matched = (event.kind + POLICY()) % 5 == 0;
         let benefit = event.value + event.sequence + event.actor % 211 + POLICY();
         result.record(inout out, matched, matched && event.tick <= world.tick, benefit);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -68,7 +68,7 @@ fn inspect_snapshots(inout out: result.Result, borrow world: model.World) {
         let benefit = item.entity_count * 7 + item.event_count * 5 +
             item.command_count * 3 + item.checksum % 4093;
         result.record(inout out, matched, matched && item.checksum != 0, benefit);
-        i = i + 1;
+        i += 1;
     }
 }
 

--- a/examples/caldera/rule_resource_reserve.rue
+++ b/examples/caldera/rule_resource_reserve.rue
@@ -31,7 +31,7 @@ fn inspect_entities(inout out: result.Result, borrow world: model.World) {
         let matched = entity_match(borrow world, borrow entity);
         let benefit = entity_benefit(borrow world, borrow entity);
         result.record(inout out, matched, matched && benefit > POLICY() % 40, benefit);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -45,7 +45,7 @@ fn inspect_tiles(inout out: result.Result, borrow world: model.World) {
             else { tile.resource > POLICY() % 29 };
         let benefit = tile.resource + tile.height * 3 + tile.region + POLICY();
         result.record(inout out, matched, matched && benefit % 3 != 0, benefit);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -56,7 +56,7 @@ fn inspect_events(inout out: result.Result, borrow world: model.World) {
         let matched = (event.kind + POLICY()) % 5 == 0;
         let benefit = event.value + event.sequence + event.actor % 211 + POLICY();
         result.record(inout out, matched, matched && event.tick <= world.tick, benefit);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -68,7 +68,7 @@ fn inspect_snapshots(inout out: result.Result, borrow world: model.World) {
         let benefit = item.entity_count * 7 + item.event_count * 5 +
             item.command_count * 3 + item.checksum % 4093;
         result.record(inout out, matched, matched && item.checksum != 0, benefit);
-        i = i + 1;
+        i += 1;
     }
 }
 

--- a/examples/caldera/rule_resource_split.rue
+++ b/examples/caldera/rule_resource_split.rue
@@ -31,7 +31,7 @@ fn inspect_entities(inout out: result.Result, borrow world: model.World) {
         let matched = entity_match(borrow world, borrow entity);
         let benefit = entity_benefit(borrow world, borrow entity);
         result.record(inout out, matched, matched && benefit > POLICY() % 40, benefit);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -45,7 +45,7 @@ fn inspect_tiles(inout out: result.Result, borrow world: model.World) {
             else { tile.resource > POLICY() % 29 };
         let benefit = tile.resource + tile.height * 3 + tile.region + POLICY();
         result.record(inout out, matched, matched && benefit % 3 != 0, benefit);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -56,7 +56,7 @@ fn inspect_events(inout out: result.Result, borrow world: model.World) {
         let matched = (event.kind + POLICY()) % 5 == 0;
         let benefit = event.value + event.sequence + event.actor % 211 + POLICY();
         result.record(inout out, matched, matched && event.tick <= world.tick, benefit);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -68,7 +68,7 @@ fn inspect_snapshots(inout out: result.Result, borrow world: model.World) {
         let benefit = item.entity_count * 7 + item.event_count * 5 +
             item.command_count * 3 + item.checksum % 4093;
         result.record(inout out, matched, matched && item.checksum != 0, benefit);
-        i = i + 1;
+        i += 1;
     }
 }
 

--- a/examples/caldera/rule_resource_validate.rue
+++ b/examples/caldera/rule_resource_validate.rue
@@ -31,7 +31,7 @@ fn inspect_entities(inout out: result.Result, borrow world: model.World) {
         let matched = entity_match(borrow world, borrow entity);
         let benefit = entity_benefit(borrow world, borrow entity);
         result.record(inout out, matched, matched && benefit > POLICY() % 40, benefit);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -45,7 +45,7 @@ fn inspect_tiles(inout out: result.Result, borrow world: model.World) {
             else { tile.resource > POLICY() % 29 };
         let benefit = tile.resource + tile.height * 3 + tile.region + POLICY();
         result.record(inout out, matched, matched && benefit % 3 != 0, benefit);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -56,7 +56,7 @@ fn inspect_events(inout out: result.Result, borrow world: model.World) {
         let matched = (event.kind + POLICY()) % 5 == 0;
         let benefit = event.value + event.sequence + event.actor % 211 + POLICY();
         result.record(inout out, matched, matched && event.tick <= world.tick, benefit);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -68,7 +68,7 @@ fn inspect_snapshots(inout out: result.Result, borrow world: model.World) {
         let benefit = item.entity_count * 7 + item.event_count * 5 +
             item.command_count * 3 + item.checksum % 4093;
         result.record(inout out, matched, matched && item.checksum != 0, benefit);
-        i = i + 1;
+        i += 1;
     }
 }
 

--- a/examples/caldera/rule_result.rue
+++ b/examples/caldera/rule_result.rue
@@ -6,7 +6,7 @@ pub fn new(rule: u64) -> Result {
         benefit: 0, digest: metric.mix(14695981039346656037, rule), valid: false }
 }
 pub fn record(inout out: Result, matched: bool, acted: bool, benefit: u64) {
-    out.inspected = out.inspected + 1;
+    out.inspected += 1;
     if matched { out.matches = out.matches + 1; }
     if acted { out.actions = out.actions + 1; }
     out.benefit = @wrapping_add(out.benefit, benefit);

--- a/examples/caldera/rule_result.rue
+++ b/examples/caldera/rule_result.rue
@@ -7,8 +7,8 @@ pub fn new(rule: u64) -> Result {
 }
 pub fn record(inout out: Result, matched: bool, acted: bool, benefit: u64) {
     out.inspected += 1;
-    if matched { out.matches = out.matches + 1; }
-    if acted { out.actions = out.actions + 1; }
+    if matched { out.matches += 1; }
+    if acted { out.actions += 1; }
     out.benefit = @wrapping_add(out.benefit, benefit);
     out.digest = metric.mix(out.digest, benefit + out.inspected * 43);
 }

--- a/examples/caldera/rule_spawn_bound.rue
+++ b/examples/caldera/rule_spawn_bound.rue
@@ -31,7 +31,7 @@ fn inspect_entities(inout out: result.Result, borrow world: model.World) {
         let matched = entity_match(borrow world, borrow entity);
         let benefit = entity_benefit(borrow world, borrow entity);
         result.record(inout out, matched, matched && benefit > POLICY() % 40, benefit);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -45,7 +45,7 @@ fn inspect_tiles(inout out: result.Result, borrow world: model.World) {
             else { tile.resource > POLICY() % 29 };
         let benefit = tile.resource + tile.height * 3 + tile.region + POLICY();
         result.record(inout out, matched, matched && benefit % 3 != 0, benefit);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -56,7 +56,7 @@ fn inspect_events(inout out: result.Result, borrow world: model.World) {
         let matched = (event.kind + POLICY()) % 5 == 0;
         let benefit = event.value + event.sequence + event.actor % 211 + POLICY();
         result.record(inout out, matched, matched && event.tick <= world.tick, benefit);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -68,7 +68,7 @@ fn inspect_snapshots(inout out: result.Result, borrow world: model.World) {
         let benefit = item.entity_count * 7 + item.event_count * 5 +
             item.command_count * 3 + item.checksum % 4093;
         result.record(inout out, matched, matched && item.checksum != 0, benefit);
-        i = i + 1;
+        i += 1;
     }
 }
 

--- a/examples/caldera/rule_spawn_defer.rue
+++ b/examples/caldera/rule_spawn_defer.rue
@@ -31,7 +31,7 @@ fn inspect_entities(inout out: result.Result, borrow world: model.World) {
         let matched = entity_match(borrow world, borrow entity);
         let benefit = entity_benefit(borrow world, borrow entity);
         result.record(inout out, matched, matched && benefit > POLICY() % 40, benefit);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -45,7 +45,7 @@ fn inspect_tiles(inout out: result.Result, borrow world: model.World) {
             else { tile.resource > POLICY() % 29 };
         let benefit = tile.resource + tile.height * 3 + tile.region + POLICY();
         result.record(inout out, matched, matched && benefit % 3 != 0, benefit);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -56,7 +56,7 @@ fn inspect_events(inout out: result.Result, borrow world: model.World) {
         let matched = (event.kind + POLICY()) % 5 == 0;
         let benefit = event.value + event.sequence + event.actor % 211 + POLICY();
         result.record(inout out, matched, matched && event.tick <= world.tick, benefit);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -68,7 +68,7 @@ fn inspect_snapshots(inout out: result.Result, borrow world: model.World) {
         let benefit = item.entity_count * 7 + item.event_count * 5 +
             item.command_count * 3 + item.checksum % 4093;
         result.record(inout out, matched, matched && item.checksum != 0, benefit);
-        i = i + 1;
+        i += 1;
     }
 }
 

--- a/examples/caldera/rule_spawn_explain.rue
+++ b/examples/caldera/rule_spawn_explain.rue
@@ -31,7 +31,7 @@ fn inspect_entities(inout out: result.Result, borrow world: model.World) {
         let matched = entity_match(borrow world, borrow entity);
         let benefit = entity_benefit(borrow world, borrow entity);
         result.record(inout out, matched, matched && benefit > POLICY() % 40, benefit);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -45,7 +45,7 @@ fn inspect_tiles(inout out: result.Result, borrow world: model.World) {
             else { tile.resource > POLICY() % 29 };
         let benefit = tile.resource + tile.height * 3 + tile.region + POLICY();
         result.record(inout out, matched, matched && benefit % 3 != 0, benefit);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -56,7 +56,7 @@ fn inspect_events(inout out: result.Result, borrow world: model.World) {
         let matched = (event.kind + POLICY()) % 5 == 0;
         let benefit = event.value + event.sequence + event.actor % 211 + POLICY();
         result.record(inout out, matched, matched && event.tick <= world.tick, benefit);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -68,7 +68,7 @@ fn inspect_snapshots(inout out: result.Result, borrow world: model.World) {
         let benefit = item.entity_count * 7 + item.event_count * 5 +
             item.command_count * 3 + item.checksum % 4093;
         result.record(inout out, matched, matched && item.checksum != 0, benefit);
-        i = i + 1;
+        i += 1;
     }
 }
 

--- a/examples/caldera/rule_spawn_merge.rue
+++ b/examples/caldera/rule_spawn_merge.rue
@@ -31,7 +31,7 @@ fn inspect_entities(inout out: result.Result, borrow world: model.World) {
         let matched = entity_match(borrow world, borrow entity);
         let benefit = entity_benefit(borrow world, borrow entity);
         result.record(inout out, matched, matched && benefit > POLICY() % 40, benefit);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -45,7 +45,7 @@ fn inspect_tiles(inout out: result.Result, borrow world: model.World) {
             else { tile.resource > POLICY() % 29 };
         let benefit = tile.resource + tile.height * 3 + tile.region + POLICY();
         result.record(inout out, matched, matched && benefit % 3 != 0, benefit);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -56,7 +56,7 @@ fn inspect_events(inout out: result.Result, borrow world: model.World) {
         let matched = (event.kind + POLICY()) % 5 == 0;
         let benefit = event.value + event.sequence + event.actor % 211 + POLICY();
         result.record(inout out, matched, matched && event.tick <= world.tick, benefit);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -68,7 +68,7 @@ fn inspect_snapshots(inout out: result.Result, borrow world: model.World) {
         let benefit = item.entity_count * 7 + item.event_count * 5 +
             item.command_count * 3 + item.checksum % 4093;
         result.record(inout out, matched, matched && item.checksum != 0, benefit);
-        i = i + 1;
+        i += 1;
     }
 }
 

--- a/examples/caldera/rule_spawn_normalize.rue
+++ b/examples/caldera/rule_spawn_normalize.rue
@@ -31,7 +31,7 @@ fn inspect_entities(inout out: result.Result, borrow world: model.World) {
         let matched = entity_match(borrow world, borrow entity);
         let benefit = entity_benefit(borrow world, borrow entity);
         result.record(inout out, matched, matched && benefit > POLICY() % 40, benefit);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -45,7 +45,7 @@ fn inspect_tiles(inout out: result.Result, borrow world: model.World) {
             else { tile.resource > POLICY() % 29 };
         let benefit = tile.resource + tile.height * 3 + tile.region + POLICY();
         result.record(inout out, matched, matched && benefit % 3 != 0, benefit);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -56,7 +56,7 @@ fn inspect_events(inout out: result.Result, borrow world: model.World) {
         let matched = (event.kind + POLICY()) % 5 == 0;
         let benefit = event.value + event.sequence + event.actor % 211 + POLICY();
         result.record(inout out, matched, matched && event.tick <= world.tick, benefit);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -68,7 +68,7 @@ fn inspect_snapshots(inout out: result.Result, borrow world: model.World) {
         let benefit = item.entity_count * 7 + item.event_count * 5 +
             item.command_count * 3 + item.checksum % 4093;
         result.record(inout out, matched, matched && item.checksum != 0, benefit);
-        i = i + 1;
+        i += 1;
     }
 }
 

--- a/examples/caldera/rule_spawn_prioritize.rue
+++ b/examples/caldera/rule_spawn_prioritize.rue
@@ -31,7 +31,7 @@ fn inspect_entities(inout out: result.Result, borrow world: model.World) {
         let matched = entity_match(borrow world, borrow entity);
         let benefit = entity_benefit(borrow world, borrow entity);
         result.record(inout out, matched, matched && benefit > POLICY() % 40, benefit);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -45,7 +45,7 @@ fn inspect_tiles(inout out: result.Result, borrow world: model.World) {
             else { tile.resource > POLICY() % 29 };
         let benefit = tile.resource + tile.height * 3 + tile.region + POLICY();
         result.record(inout out, matched, matched && benefit % 3 != 0, benefit);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -56,7 +56,7 @@ fn inspect_events(inout out: result.Result, borrow world: model.World) {
         let matched = (event.kind + POLICY()) % 5 == 0;
         let benefit = event.value + event.sequence + event.actor % 211 + POLICY();
         result.record(inout out, matched, matched && event.tick <= world.tick, benefit);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -68,7 +68,7 @@ fn inspect_snapshots(inout out: result.Result, borrow world: model.World) {
         let benefit = item.entity_count * 7 + item.event_count * 5 +
             item.command_count * 3 + item.checksum % 4093;
         result.record(inout out, matched, matched && item.checksum != 0, benefit);
-        i = i + 1;
+        i += 1;
     }
 }
 

--- a/examples/caldera/rule_spawn_recover.rue
+++ b/examples/caldera/rule_spawn_recover.rue
@@ -31,7 +31,7 @@ fn inspect_entities(inout out: result.Result, borrow world: model.World) {
         let matched = entity_match(borrow world, borrow entity);
         let benefit = entity_benefit(borrow world, borrow entity);
         result.record(inout out, matched, matched && benefit > POLICY() % 40, benefit);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -45,7 +45,7 @@ fn inspect_tiles(inout out: result.Result, borrow world: model.World) {
             else { tile.resource > POLICY() % 29 };
         let benefit = tile.resource + tile.height * 3 + tile.region + POLICY();
         result.record(inout out, matched, matched && benefit % 3 != 0, benefit);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -56,7 +56,7 @@ fn inspect_events(inout out: result.Result, borrow world: model.World) {
         let matched = (event.kind + POLICY()) % 5 == 0;
         let benefit = event.value + event.sequence + event.actor % 211 + POLICY();
         result.record(inout out, matched, matched && event.tick <= world.tick, benefit);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -68,7 +68,7 @@ fn inspect_snapshots(inout out: result.Result, borrow world: model.World) {
         let benefit = item.entity_count * 7 + item.event_count * 5 +
             item.command_count * 3 + item.checksum % 4093;
         result.record(inout out, matched, matched && item.checksum != 0, benefit);
-        i = i + 1;
+        i += 1;
     }
 }
 

--- a/examples/caldera/rule_spawn_release.rue
+++ b/examples/caldera/rule_spawn_release.rue
@@ -31,7 +31,7 @@ fn inspect_entities(inout out: result.Result, borrow world: model.World) {
         let matched = entity_match(borrow world, borrow entity);
         let benefit = entity_benefit(borrow world, borrow entity);
         result.record(inout out, matched, matched && benefit > POLICY() % 40, benefit);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -45,7 +45,7 @@ fn inspect_tiles(inout out: result.Result, borrow world: model.World) {
             else { tile.resource > POLICY() % 29 };
         let benefit = tile.resource + tile.height * 3 + tile.region + POLICY();
         result.record(inout out, matched, matched && benefit % 3 != 0, benefit);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -56,7 +56,7 @@ fn inspect_events(inout out: result.Result, borrow world: model.World) {
         let matched = (event.kind + POLICY()) % 5 == 0;
         let benefit = event.value + event.sequence + event.actor % 211 + POLICY();
         result.record(inout out, matched, matched && event.tick <= world.tick, benefit);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -68,7 +68,7 @@ fn inspect_snapshots(inout out: result.Result, borrow world: model.World) {
         let benefit = item.entity_count * 7 + item.event_count * 5 +
             item.command_count * 3 + item.checksum % 4093;
         result.record(inout out, matched, matched && item.checksum != 0, benefit);
-        i = i + 1;
+        i += 1;
     }
 }
 

--- a/examples/caldera/rule_spawn_replicate.rue
+++ b/examples/caldera/rule_spawn_replicate.rue
@@ -31,7 +31,7 @@ fn inspect_entities(inout out: result.Result, borrow world: model.World) {
         let matched = entity_match(borrow world, borrow entity);
         let benefit = entity_benefit(borrow world, borrow entity);
         result.record(inout out, matched, matched && benefit > POLICY() % 40, benefit);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -45,7 +45,7 @@ fn inspect_tiles(inout out: result.Result, borrow world: model.World) {
             else { tile.resource > POLICY() % 29 };
         let benefit = tile.resource + tile.height * 3 + tile.region + POLICY();
         result.record(inout out, matched, matched && benefit % 3 != 0, benefit);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -56,7 +56,7 @@ fn inspect_events(inout out: result.Result, borrow world: model.World) {
         let matched = (event.kind + POLICY()) % 5 == 0;
         let benefit = event.value + event.sequence + event.actor % 211 + POLICY();
         result.record(inout out, matched, matched && event.tick <= world.tick, benefit);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -68,7 +68,7 @@ fn inspect_snapshots(inout out: result.Result, borrow world: model.World) {
         let benefit = item.entity_count * 7 + item.event_count * 5 +
             item.command_count * 3 + item.checksum % 4093;
         result.record(inout out, matched, matched && item.checksum != 0, benefit);
-        i = i + 1;
+        i += 1;
     }
 }
 

--- a/examples/caldera/rule_spawn_reserve.rue
+++ b/examples/caldera/rule_spawn_reserve.rue
@@ -31,7 +31,7 @@ fn inspect_entities(inout out: result.Result, borrow world: model.World) {
         let matched = entity_match(borrow world, borrow entity);
         let benefit = entity_benefit(borrow world, borrow entity);
         result.record(inout out, matched, matched && benefit > POLICY() % 40, benefit);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -45,7 +45,7 @@ fn inspect_tiles(inout out: result.Result, borrow world: model.World) {
             else { tile.resource > POLICY() % 29 };
         let benefit = tile.resource + tile.height * 3 + tile.region + POLICY();
         result.record(inout out, matched, matched && benefit % 3 != 0, benefit);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -56,7 +56,7 @@ fn inspect_events(inout out: result.Result, borrow world: model.World) {
         let matched = (event.kind + POLICY()) % 5 == 0;
         let benefit = event.value + event.sequence + event.actor % 211 + POLICY();
         result.record(inout out, matched, matched && event.tick <= world.tick, benefit);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -68,7 +68,7 @@ fn inspect_snapshots(inout out: result.Result, borrow world: model.World) {
         let benefit = item.entity_count * 7 + item.event_count * 5 +
             item.command_count * 3 + item.checksum % 4093;
         result.record(inout out, matched, matched && item.checksum != 0, benefit);
-        i = i + 1;
+        i += 1;
     }
 }
 

--- a/examples/caldera/rule_spawn_split.rue
+++ b/examples/caldera/rule_spawn_split.rue
@@ -31,7 +31,7 @@ fn inspect_entities(inout out: result.Result, borrow world: model.World) {
         let matched = entity_match(borrow world, borrow entity);
         let benefit = entity_benefit(borrow world, borrow entity);
         result.record(inout out, matched, matched && benefit > POLICY() % 40, benefit);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -45,7 +45,7 @@ fn inspect_tiles(inout out: result.Result, borrow world: model.World) {
             else { tile.resource > POLICY() % 29 };
         let benefit = tile.resource + tile.height * 3 + tile.region + POLICY();
         result.record(inout out, matched, matched && benefit % 3 != 0, benefit);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -56,7 +56,7 @@ fn inspect_events(inout out: result.Result, borrow world: model.World) {
         let matched = (event.kind + POLICY()) % 5 == 0;
         let benefit = event.value + event.sequence + event.actor % 211 + POLICY();
         result.record(inout out, matched, matched && event.tick <= world.tick, benefit);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -68,7 +68,7 @@ fn inspect_snapshots(inout out: result.Result, borrow world: model.World) {
         let benefit = item.entity_count * 7 + item.event_count * 5 +
             item.command_count * 3 + item.checksum % 4093;
         result.record(inout out, matched, matched && item.checksum != 0, benefit);
-        i = i + 1;
+        i += 1;
     }
 }
 

--- a/examples/caldera/rule_spawn_validate.rue
+++ b/examples/caldera/rule_spawn_validate.rue
@@ -31,7 +31,7 @@ fn inspect_entities(inout out: result.Result, borrow world: model.World) {
         let matched = entity_match(borrow world, borrow entity);
         let benefit = entity_benefit(borrow world, borrow entity);
         result.record(inout out, matched, matched && benefit > POLICY() % 40, benefit);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -45,7 +45,7 @@ fn inspect_tiles(inout out: result.Result, borrow world: model.World) {
             else { tile.resource > POLICY() % 29 };
         let benefit = tile.resource + tile.height * 3 + tile.region + POLICY();
         result.record(inout out, matched, matched && benefit % 3 != 0, benefit);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -56,7 +56,7 @@ fn inspect_events(inout out: result.Result, borrow world: model.World) {
         let matched = (event.kind + POLICY()) % 5 == 0;
         let benefit = event.value + event.sequence + event.actor % 211 + POLICY();
         result.record(inout out, matched, matched && event.tick <= world.tick, benefit);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -68,7 +68,7 @@ fn inspect_snapshots(inout out: result.Result, borrow world: model.World) {
         let benefit = item.entity_count * 7 + item.event_count * 5 +
             item.command_count * 3 + item.checksum % 4093;
         result.record(inout out, matched, matched && item.checksum != 0, benefit);
-        i = i + 1;
+        i += 1;
     }
 }
 

--- a/examples/caldera/rule_suite.rue
+++ b/examples/caldera/rule_suite.rue
@@ -104,7 +104,7 @@ fn include(inout out: Summary, borrow first: result.Result, borrow second: resul
     out.rules = out.rules + 1; out.inspected = out.inspected + first.inspected;
     out.matches = out.matches + first.matches; out.actions = out.actions + first.actions;
     if first.digest != second.digest || first.benefit != second.benefit || !verified {
-        out.deterministic_mismatches = out.deterministic_mismatches + 1;
+        out.deterministic_mismatches += 1;
     }
     out.digest = metric.mix(out.digest, first.digest);
 }

--- a/examples/caldera/rule_suite.rue
+++ b/examples/caldera/rule_suite.rue
@@ -101,8 +101,8 @@ const rule_render_explain = @import("rule_render_explain.rue");
 pub struct Summary { rules: u64, inspected: u64, matches: u64, actions: u64,
     deterministic_mismatches: u64, digest: u64, valid: bool }
 fn include(inout out: Summary, borrow first: result.Result, borrow second: result.Result, verified: bool) {
-    out.rules = out.rules + 1; out.inspected = out.inspected + first.inspected;
-    out.matches = out.matches + first.matches; out.actions = out.actions + first.actions;
+    out.rules += 1; out.inspected += first.inspected;
+    out.matches += first.matches; out.actions += first.actions;
     if first.digest != second.digest || first.benefit != second.benefit || !verified {
         out.deterministic_mismatches += 1;
     }

--- a/examples/caldera/rule_terrain_bound.rue
+++ b/examples/caldera/rule_terrain_bound.rue
@@ -31,7 +31,7 @@ fn inspect_entities(inout out: result.Result, borrow world: model.World) {
         let matched = entity_match(borrow world, borrow entity);
         let benefit = entity_benefit(borrow world, borrow entity);
         result.record(inout out, matched, matched && benefit > POLICY() % 40, benefit);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -45,7 +45,7 @@ fn inspect_tiles(inout out: result.Result, borrow world: model.World) {
             else { tile.resource > POLICY() % 29 };
         let benefit = tile.resource + tile.height * 3 + tile.region + POLICY();
         result.record(inout out, matched, matched && benefit % 3 != 0, benefit);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -56,7 +56,7 @@ fn inspect_events(inout out: result.Result, borrow world: model.World) {
         let matched = (event.kind + POLICY()) % 5 == 0;
         let benefit = event.value + event.sequence + event.actor % 211 + POLICY();
         result.record(inout out, matched, matched && event.tick <= world.tick, benefit);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -68,7 +68,7 @@ fn inspect_snapshots(inout out: result.Result, borrow world: model.World) {
         let benefit = item.entity_count * 7 + item.event_count * 5 +
             item.command_count * 3 + item.checksum % 4093;
         result.record(inout out, matched, matched && item.checksum != 0, benefit);
-        i = i + 1;
+        i += 1;
     }
 }
 

--- a/examples/caldera/rule_terrain_defer.rue
+++ b/examples/caldera/rule_terrain_defer.rue
@@ -31,7 +31,7 @@ fn inspect_entities(inout out: result.Result, borrow world: model.World) {
         let matched = entity_match(borrow world, borrow entity);
         let benefit = entity_benefit(borrow world, borrow entity);
         result.record(inout out, matched, matched && benefit > POLICY() % 40, benefit);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -45,7 +45,7 @@ fn inspect_tiles(inout out: result.Result, borrow world: model.World) {
             else { tile.resource > POLICY() % 29 };
         let benefit = tile.resource + tile.height * 3 + tile.region + POLICY();
         result.record(inout out, matched, matched && benefit % 3 != 0, benefit);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -56,7 +56,7 @@ fn inspect_events(inout out: result.Result, borrow world: model.World) {
         let matched = (event.kind + POLICY()) % 5 == 0;
         let benefit = event.value + event.sequence + event.actor % 211 + POLICY();
         result.record(inout out, matched, matched && event.tick <= world.tick, benefit);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -68,7 +68,7 @@ fn inspect_snapshots(inout out: result.Result, borrow world: model.World) {
         let benefit = item.entity_count * 7 + item.event_count * 5 +
             item.command_count * 3 + item.checksum % 4093;
         result.record(inout out, matched, matched && item.checksum != 0, benefit);
-        i = i + 1;
+        i += 1;
     }
 }
 

--- a/examples/caldera/rule_terrain_explain.rue
+++ b/examples/caldera/rule_terrain_explain.rue
@@ -31,7 +31,7 @@ fn inspect_entities(inout out: result.Result, borrow world: model.World) {
         let matched = entity_match(borrow world, borrow entity);
         let benefit = entity_benefit(borrow world, borrow entity);
         result.record(inout out, matched, matched && benefit > POLICY() % 40, benefit);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -45,7 +45,7 @@ fn inspect_tiles(inout out: result.Result, borrow world: model.World) {
             else { tile.resource > POLICY() % 29 };
         let benefit = tile.resource + tile.height * 3 + tile.region + POLICY();
         result.record(inout out, matched, matched && benefit % 3 != 0, benefit);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -56,7 +56,7 @@ fn inspect_events(inout out: result.Result, borrow world: model.World) {
         let matched = (event.kind + POLICY()) % 5 == 0;
         let benefit = event.value + event.sequence + event.actor % 211 + POLICY();
         result.record(inout out, matched, matched && event.tick <= world.tick, benefit);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -68,7 +68,7 @@ fn inspect_snapshots(inout out: result.Result, borrow world: model.World) {
         let benefit = item.entity_count * 7 + item.event_count * 5 +
             item.command_count * 3 + item.checksum % 4093;
         result.record(inout out, matched, matched && item.checksum != 0, benefit);
-        i = i + 1;
+        i += 1;
     }
 }
 

--- a/examples/caldera/rule_terrain_merge.rue
+++ b/examples/caldera/rule_terrain_merge.rue
@@ -31,7 +31,7 @@ fn inspect_entities(inout out: result.Result, borrow world: model.World) {
         let matched = entity_match(borrow world, borrow entity);
         let benefit = entity_benefit(borrow world, borrow entity);
         result.record(inout out, matched, matched && benefit > POLICY() % 40, benefit);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -45,7 +45,7 @@ fn inspect_tiles(inout out: result.Result, borrow world: model.World) {
             else { tile.resource > POLICY() % 29 };
         let benefit = tile.resource + tile.height * 3 + tile.region + POLICY();
         result.record(inout out, matched, matched && benefit % 3 != 0, benefit);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -56,7 +56,7 @@ fn inspect_events(inout out: result.Result, borrow world: model.World) {
         let matched = (event.kind + POLICY()) % 5 == 0;
         let benefit = event.value + event.sequence + event.actor % 211 + POLICY();
         result.record(inout out, matched, matched && event.tick <= world.tick, benefit);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -68,7 +68,7 @@ fn inspect_snapshots(inout out: result.Result, borrow world: model.World) {
         let benefit = item.entity_count * 7 + item.event_count * 5 +
             item.command_count * 3 + item.checksum % 4093;
         result.record(inout out, matched, matched && item.checksum != 0, benefit);
-        i = i + 1;
+        i += 1;
     }
 }
 

--- a/examples/caldera/rule_terrain_normalize.rue
+++ b/examples/caldera/rule_terrain_normalize.rue
@@ -31,7 +31,7 @@ fn inspect_entities(inout out: result.Result, borrow world: model.World) {
         let matched = entity_match(borrow world, borrow entity);
         let benefit = entity_benefit(borrow world, borrow entity);
         result.record(inout out, matched, matched && benefit > POLICY() % 40, benefit);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -45,7 +45,7 @@ fn inspect_tiles(inout out: result.Result, borrow world: model.World) {
             else { tile.resource > POLICY() % 29 };
         let benefit = tile.resource + tile.height * 3 + tile.region + POLICY();
         result.record(inout out, matched, matched && benefit % 3 != 0, benefit);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -56,7 +56,7 @@ fn inspect_events(inout out: result.Result, borrow world: model.World) {
         let matched = (event.kind + POLICY()) % 5 == 0;
         let benefit = event.value + event.sequence + event.actor % 211 + POLICY();
         result.record(inout out, matched, matched && event.tick <= world.tick, benefit);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -68,7 +68,7 @@ fn inspect_snapshots(inout out: result.Result, borrow world: model.World) {
         let benefit = item.entity_count * 7 + item.event_count * 5 +
             item.command_count * 3 + item.checksum % 4093;
         result.record(inout out, matched, matched && item.checksum != 0, benefit);
-        i = i + 1;
+        i += 1;
     }
 }
 

--- a/examples/caldera/rule_terrain_prioritize.rue
+++ b/examples/caldera/rule_terrain_prioritize.rue
@@ -31,7 +31,7 @@ fn inspect_entities(inout out: result.Result, borrow world: model.World) {
         let matched = entity_match(borrow world, borrow entity);
         let benefit = entity_benefit(borrow world, borrow entity);
         result.record(inout out, matched, matched && benefit > POLICY() % 40, benefit);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -45,7 +45,7 @@ fn inspect_tiles(inout out: result.Result, borrow world: model.World) {
             else { tile.resource > POLICY() % 29 };
         let benefit = tile.resource + tile.height * 3 + tile.region + POLICY();
         result.record(inout out, matched, matched && benefit % 3 != 0, benefit);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -56,7 +56,7 @@ fn inspect_events(inout out: result.Result, borrow world: model.World) {
         let matched = (event.kind + POLICY()) % 5 == 0;
         let benefit = event.value + event.sequence + event.actor % 211 + POLICY();
         result.record(inout out, matched, matched && event.tick <= world.tick, benefit);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -68,7 +68,7 @@ fn inspect_snapshots(inout out: result.Result, borrow world: model.World) {
         let benefit = item.entity_count * 7 + item.event_count * 5 +
             item.command_count * 3 + item.checksum % 4093;
         result.record(inout out, matched, matched && item.checksum != 0, benefit);
-        i = i + 1;
+        i += 1;
     }
 }
 

--- a/examples/caldera/rule_terrain_recover.rue
+++ b/examples/caldera/rule_terrain_recover.rue
@@ -31,7 +31,7 @@ fn inspect_entities(inout out: result.Result, borrow world: model.World) {
         let matched = entity_match(borrow world, borrow entity);
         let benefit = entity_benefit(borrow world, borrow entity);
         result.record(inout out, matched, matched && benefit > POLICY() % 40, benefit);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -45,7 +45,7 @@ fn inspect_tiles(inout out: result.Result, borrow world: model.World) {
             else { tile.resource > POLICY() % 29 };
         let benefit = tile.resource + tile.height * 3 + tile.region + POLICY();
         result.record(inout out, matched, matched && benefit % 3 != 0, benefit);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -56,7 +56,7 @@ fn inspect_events(inout out: result.Result, borrow world: model.World) {
         let matched = (event.kind + POLICY()) % 5 == 0;
         let benefit = event.value + event.sequence + event.actor % 211 + POLICY();
         result.record(inout out, matched, matched && event.tick <= world.tick, benefit);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -68,7 +68,7 @@ fn inspect_snapshots(inout out: result.Result, borrow world: model.World) {
         let benefit = item.entity_count * 7 + item.event_count * 5 +
             item.command_count * 3 + item.checksum % 4093;
         result.record(inout out, matched, matched && item.checksum != 0, benefit);
-        i = i + 1;
+        i += 1;
     }
 }
 

--- a/examples/caldera/rule_terrain_release.rue
+++ b/examples/caldera/rule_terrain_release.rue
@@ -31,7 +31,7 @@ fn inspect_entities(inout out: result.Result, borrow world: model.World) {
         let matched = entity_match(borrow world, borrow entity);
         let benefit = entity_benefit(borrow world, borrow entity);
         result.record(inout out, matched, matched && benefit > POLICY() % 40, benefit);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -45,7 +45,7 @@ fn inspect_tiles(inout out: result.Result, borrow world: model.World) {
             else { tile.resource > POLICY() % 29 };
         let benefit = tile.resource + tile.height * 3 + tile.region + POLICY();
         result.record(inout out, matched, matched && benefit % 3 != 0, benefit);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -56,7 +56,7 @@ fn inspect_events(inout out: result.Result, borrow world: model.World) {
         let matched = (event.kind + POLICY()) % 5 == 0;
         let benefit = event.value + event.sequence + event.actor % 211 + POLICY();
         result.record(inout out, matched, matched && event.tick <= world.tick, benefit);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -68,7 +68,7 @@ fn inspect_snapshots(inout out: result.Result, borrow world: model.World) {
         let benefit = item.entity_count * 7 + item.event_count * 5 +
             item.command_count * 3 + item.checksum % 4093;
         result.record(inout out, matched, matched && item.checksum != 0, benefit);
-        i = i + 1;
+        i += 1;
     }
 }
 

--- a/examples/caldera/rule_terrain_replicate.rue
+++ b/examples/caldera/rule_terrain_replicate.rue
@@ -31,7 +31,7 @@ fn inspect_entities(inout out: result.Result, borrow world: model.World) {
         let matched = entity_match(borrow world, borrow entity);
         let benefit = entity_benefit(borrow world, borrow entity);
         result.record(inout out, matched, matched && benefit > POLICY() % 40, benefit);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -45,7 +45,7 @@ fn inspect_tiles(inout out: result.Result, borrow world: model.World) {
             else { tile.resource > POLICY() % 29 };
         let benefit = tile.resource + tile.height * 3 + tile.region + POLICY();
         result.record(inout out, matched, matched && benefit % 3 != 0, benefit);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -56,7 +56,7 @@ fn inspect_events(inout out: result.Result, borrow world: model.World) {
         let matched = (event.kind + POLICY()) % 5 == 0;
         let benefit = event.value + event.sequence + event.actor % 211 + POLICY();
         result.record(inout out, matched, matched && event.tick <= world.tick, benefit);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -68,7 +68,7 @@ fn inspect_snapshots(inout out: result.Result, borrow world: model.World) {
         let benefit = item.entity_count * 7 + item.event_count * 5 +
             item.command_count * 3 + item.checksum % 4093;
         result.record(inout out, matched, matched && item.checksum != 0, benefit);
-        i = i + 1;
+        i += 1;
     }
 }
 

--- a/examples/caldera/rule_terrain_reserve.rue
+++ b/examples/caldera/rule_terrain_reserve.rue
@@ -31,7 +31,7 @@ fn inspect_entities(inout out: result.Result, borrow world: model.World) {
         let matched = entity_match(borrow world, borrow entity);
         let benefit = entity_benefit(borrow world, borrow entity);
         result.record(inout out, matched, matched && benefit > POLICY() % 40, benefit);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -45,7 +45,7 @@ fn inspect_tiles(inout out: result.Result, borrow world: model.World) {
             else { tile.resource > POLICY() % 29 };
         let benefit = tile.resource + tile.height * 3 + tile.region + POLICY();
         result.record(inout out, matched, matched && benefit % 3 != 0, benefit);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -56,7 +56,7 @@ fn inspect_events(inout out: result.Result, borrow world: model.World) {
         let matched = (event.kind + POLICY()) % 5 == 0;
         let benefit = event.value + event.sequence + event.actor % 211 + POLICY();
         result.record(inout out, matched, matched && event.tick <= world.tick, benefit);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -68,7 +68,7 @@ fn inspect_snapshots(inout out: result.Result, borrow world: model.World) {
         let benefit = item.entity_count * 7 + item.event_count * 5 +
             item.command_count * 3 + item.checksum % 4093;
         result.record(inout out, matched, matched && item.checksum != 0, benefit);
-        i = i + 1;
+        i += 1;
     }
 }
 

--- a/examples/caldera/rule_terrain_split.rue
+++ b/examples/caldera/rule_terrain_split.rue
@@ -31,7 +31,7 @@ fn inspect_entities(inout out: result.Result, borrow world: model.World) {
         let matched = entity_match(borrow world, borrow entity);
         let benefit = entity_benefit(borrow world, borrow entity);
         result.record(inout out, matched, matched && benefit > POLICY() % 40, benefit);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -45,7 +45,7 @@ fn inspect_tiles(inout out: result.Result, borrow world: model.World) {
             else { tile.resource > POLICY() % 29 };
         let benefit = tile.resource + tile.height * 3 + tile.region + POLICY();
         result.record(inout out, matched, matched && benefit % 3 != 0, benefit);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -56,7 +56,7 @@ fn inspect_events(inout out: result.Result, borrow world: model.World) {
         let matched = (event.kind + POLICY()) % 5 == 0;
         let benefit = event.value + event.sequence + event.actor % 211 + POLICY();
         result.record(inout out, matched, matched && event.tick <= world.tick, benefit);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -68,7 +68,7 @@ fn inspect_snapshots(inout out: result.Result, borrow world: model.World) {
         let benefit = item.entity_count * 7 + item.event_count * 5 +
             item.command_count * 3 + item.checksum % 4093;
         result.record(inout out, matched, matched && item.checksum != 0, benefit);
-        i = i + 1;
+        i += 1;
     }
 }
 

--- a/examples/caldera/rule_terrain_validate.rue
+++ b/examples/caldera/rule_terrain_validate.rue
@@ -31,7 +31,7 @@ fn inspect_entities(inout out: result.Result, borrow world: model.World) {
         let matched = entity_match(borrow world, borrow entity);
         let benefit = entity_benefit(borrow world, borrow entity);
         result.record(inout out, matched, matched && benefit > POLICY() % 40, benefit);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -45,7 +45,7 @@ fn inspect_tiles(inout out: result.Result, borrow world: model.World) {
             else { tile.resource > POLICY() % 29 };
         let benefit = tile.resource + tile.height * 3 + tile.region + POLICY();
         result.record(inout out, matched, matched && benefit % 3 != 0, benefit);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -56,7 +56,7 @@ fn inspect_events(inout out: result.Result, borrow world: model.World) {
         let matched = (event.kind + POLICY()) % 5 == 0;
         let benefit = event.value + event.sequence + event.actor % 211 + POLICY();
         result.record(inout out, matched, matched && event.tick <= world.tick, benefit);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -68,7 +68,7 @@ fn inspect_snapshots(inout out: result.Result, borrow world: model.World) {
         let benefit = item.entity_count * 7 + item.event_count * 5 +
             item.command_count * 3 + item.checksum % 4093;
         result.record(inout out, matched, matched && item.checksum != 0, benefit);
-        i = i + 1;
+        i += 1;
     }
 }
 

--- a/examples/caldera/scenario_source.rue
+++ b/examples/caldera/scenario_source.rue
@@ -2,7 +2,7 @@ const std = @import("std");
 pub const Bytes = std.arraybuf.ArrayBuf(u8);
 pub fn bytes(value: str) -> Bytes {
     let mut out = Bytes.new(); let mut i: u64 = 0;
-    while i < value.len() { out.push(value[i]); i = i + 1; }
+    while i < value.len() { out.push(value[i]); i += 1; }
     out
 }
 pub fn demo() -> Bytes {

--- a/examples/caldera/scheduler.rue
+++ b/examples/caldera/scheduler.rue
@@ -29,9 +29,9 @@ pub fn build(borrow world: model.World) -> Schedule {
             let previous_priority = priority(borrow previous_entity);
             if previous_priority < key_priority ||
                 (previous_priority == key_priority && previous < key) { break; }
-            out.order.set(j, previous); j = j - 1;
+            out.order.set(j, previous); j -= 1;
         }
-        out.order.set(j, key); i = i + 1;
+        out.order.set(j, key); i += 1;
     }
     i = 0;
     let mut last: u64 = 0;

--- a/examples/caldera/scheduler.rue
+++ b/examples/caldera/scheduler.rue
@@ -15,7 +15,7 @@ pub fn build(borrow world: model.World) -> Schedule {
     let mut i: u64 = 0;
     while i < world.entities.len() {
         if world.entities.get_or(i, model.empty_entity()).alive { out.order.push(i); }
-        i = i + 1;
+        i += 1;
     }
     i = 1;
     while i < out.order.len() {
@@ -41,7 +41,7 @@ pub fn build(borrow world: model.World) -> Schedule {
         let current = priority(borrow current_entity);
         if i > 0 && current < last { out.valid = false; return out; }
         last = current; out.digest = metric.mix(out.digest, index);
-        i = i + 1;
+        i += 1;
     }
     out.valid = out.order.len() == model.alive_count(borrow world);
     out

--- a/examples/caldera/scheduler_oracle.rue
+++ b/examples/caldera/scheduler_oracle.rue
@@ -20,7 +20,7 @@ pub fn build(borrow world: model.World) -> model.U64s {
                     best = i; best_priority = current;
                 }
             }
-            i = i + 1;
+            i += 1;
         }
         if best == model.NONE() { break; }
         used.set(best, true); order.push(best);
@@ -34,7 +34,7 @@ pub fn agrees(borrow world: model.World, borrow actual: scheduler.Schedule) -> b
     let mut i: u64 = 0;
     while i < expected.len() {
         if expected.get_or(i, model.NONE()) != actual.order.get_or(i, model.NONE()) { return false; }
-        i = i + 1;
+        i += 1;
     }
     true
 }

--- a/examples/caldera/scheduler_oracle.rue
+++ b/examples/caldera/scheduler_oracle.rue
@@ -5,7 +5,7 @@ const scheduler = @import("scheduler.rue");
 pub fn build(borrow world: model.World) -> model.U64s {
     let mut used = model.Bools.new();
     let mut i: u64 = 0;
-    while i < world.entities.len() { used.push(false); i = i + 1; }
+    while i < world.entities.len() { used.push(false); i += 1; }
     let mut order = model.U64s.new();
     while order.len() < model.alive_count(borrow world) {
         let mut best = model.NONE();

--- a/examples/caldera/script_disasm.rue
+++ b/examples/caldera/script_disasm.rue
@@ -13,7 +13,7 @@ pub fn render(borrow program: bytecode.Program) -> StrBuf {
         else if op.kind == bytecode.MUL() { text.append_literal(inout out, "MUL"); }
         else if op.kind == bytecode.MIX() { text.append_literal(inout out, "MIX"); }
         else { text.append_literal(inout out, "HALT"); }
-        out.push(10); i = i + 1;
+        out.push(10); i += 1;
     }
     out
 }

--- a/examples/caldera/script_interpreter.rue
+++ b/examples/caldera/script_interpreter.rue
@@ -9,9 +9,9 @@ pub fn execute(borrow input: scenario.Scenario) -> Result {
     let mut i: u64 = 0;
     while i < input.entities.len() {
         let item = input.entities.get_or(i, scenario.empty_entity());
-        value = value + item.kind * item.faction;
+        value += item.kind * item.faction;
         value = metric.mix(value, item.x + item.y);
-        i = i + 1;
+        i += 1;
     }
     value = metric.mix(value, input.ticks);
     Result { value: value, entities: input.entities.len(), valid: input.valid }

--- a/examples/caldera/script_lower.rue
+++ b/examples/caldera/script_lower.rue
@@ -16,7 +16,7 @@ pub fn lower(borrow input: scenario.Scenario) -> bytecode.Program {
         out.ops.push(bytecode.Op { kind: bytecode.ADD(), operand: 0 });
         out.ops.push(bytecode.Op { kind: bytecode.PUSH(), operand: item.x + item.y });
         out.ops.push(bytecode.Op { kind: bytecode.MIX(), operand: 0 });
-        out.entities = out.entities + 1; i = i + 1;
+        out.entities += 1; i += 1;
     }
     out.ops.push(bytecode.Op { kind: bytecode.PUSH(), operand: input.ticks });
     out.ops.push(bytecode.Op { kind: bytecode.MIX(), operand: 0 });

--- a/examples/caldera/script_vm.rue
+++ b/examples/caldera/script_vm.rue
@@ -13,7 +13,7 @@ pub fn execute(borrow program: bytecode.Program) -> Result {
     let mut pc: u64 = 0;
     while pc < program.ops.len() {
         let op = program.ops.get_or(pc, bytecode.empty());
-        out.steps = out.steps + 1;
+        out.steps += 1;
         out.digest = metric.mix(out.digest, op.kind * 257 + op.operand);
         if op.kind == bytecode.PUSH() { stack.push(op.operand); }
         else if op.kind == bytecode.ADD() || op.kind == bytecode.MUL() || op.kind == bytecode.MIX() {
@@ -25,7 +25,7 @@ pub fn execute(borrow program: bytecode.Program) -> Result {
         } else if op.kind == bytecode.HALT() { break; }
         else { out.valid = false; break; }
         if stack.len() > out.maximum_stack { out.maximum_stack = stack.len(); }
-        pc = pc + 1;
+        pc += 1;
     }
     if stack.len() != 1 { out.valid = false; }
     out.value = stack.get_or(0, 0); out

--- a/examples/caldera/selftest.rue
+++ b/examples/caldera/selftest.rue
@@ -54,7 +54,7 @@ pub struct Result {
 
 fn check(inout out: Result, condition: bool, fingerprint: u64) {
     out.checks += 1; out.digest = metric.mix(out.digest, fingerprint);
-    if !condition { out.failures = out.failures + 1; }
+    if !condition { out.failures += 1; }
 }
 
 pub fn run() -> Result {
@@ -93,7 +93,7 @@ pub fn run() -> Result {
     check(inout out, run_result.valid && world.tick == 4, run_result.checksum);
     let replayed = replay.run(borrow baseline, 4);
     let replay_ok = replay_oracle.agrees(borrow baseline, 4, borrow replayed);
-    if !replay_ok { out.oracle_mismatches = out.oracle_mismatches + 1; }
+    if !replay_ok { out.oracle_mismatches += 1; }
     check(inout out, replay_ok && replayed.final_checksum == checksum.world(borrow world), replayed.timeline_digest);
     check(inout out, rollback.agrees(borrow baseline, 4, checksum.world(borrow world)), replayed.final_checksum);
     let synchronized = lockstep.run(borrow baseline, 4);

--- a/examples/caldera/selftest.rue
+++ b/examples/caldera/selftest.rue
@@ -53,7 +53,7 @@ pub struct Result {
 }
 
 fn check(inout out: Result, condition: bool, fingerprint: u64) {
-    out.checks = out.checks + 1; out.digest = metric.mix(out.digest, fingerprint);
+    out.checks += 1; out.digest = metric.mix(out.digest, fingerprint);
     if !condition { out.failures = out.failures + 1; }
 }
 

--- a/examples/caldera/simulation.rue
+++ b/examples/caldera/simulation.rue
@@ -15,7 +15,7 @@ pub fn run(inout world: model.World, count: u64) -> Result {
     let mut i: u64 = 0;
     while i < count {
         let value = tick.step(inout world);
-        out.ticks = out.ticks + 1; out.moved = out.moved + value.moved;
+        out.ticks += 1; out.moved += value.moved;
         out.ai_changes += value.ai_changes;
         out.produced += value.produced;
         if !value.valid { out.valid = false; }

--- a/examples/caldera/simulation.rue
+++ b/examples/caldera/simulation.rue
@@ -16,10 +16,10 @@ pub fn run(inout world: model.World, count: u64) -> Result {
     while i < count {
         let value = tick.step(inout world);
         out.ticks = out.ticks + 1; out.moved = out.moved + value.moved;
-        out.ai_changes = out.ai_changes + value.ai_changes;
-        out.produced = out.produced + value.produced;
+        out.ai_changes += value.ai_changes;
+        out.produced += value.produced;
         if !value.valid { out.valid = false; }
-        i = i + 1;
+        i += 1;
     }
     let collision_audit = collision.audit(borrow world);
     let event_audit = events.audit(borrow world);

--- a/examples/caldera/snapshot.rue
+++ b/examples/caldera/snapshot.rue
@@ -23,7 +23,7 @@ pub fn audit(borrow world: model.World) -> Audit {
         if i > 0 && item.tick <= previous { out.monotonic = false; }
         previous = item.tick;
         out.digest = metric.mix(out.digest, item.checksum);
-        i = i + 1;
+        i += 1;
     }
     out.valid = out.monotonic && out.snapshots <= world.tick + 1; out
 }

--- a/examples/caldera/spatial.rue
+++ b/examples/caldera/spatial.rue
@@ -10,14 +10,14 @@ pub fn region(borrow world: model.World, x: i64, y: i64, radius: u64) -> Query {
     let mut i: u64 = 0;
     while i < world.entities.len() {
         let entity = world.entities.get_or(i, model.empty_entity());
-        out.candidates = out.candidates + 1;
+        out.candidates += 1;
         let dx = if entity.x > x { entity.x - x } else { x - entity.x };
         let dy = if entity.y > y { entity.y - y } else { y - entity.y };
         if entity.alive && @intCast(dx + dy) <= radius {
-            out.matches = out.matches + 1;
+            out.matches += 1;
             out.digest = metric.mix(out.digest, entity.id);
         }
-        i = i + 1;
+        i += 1;
     }
     out.valid = out.matches <= out.candidates;
     out
@@ -36,7 +36,7 @@ pub fn nearest(borrow world: model.World, x: i64, y: i64) -> u64 {
             (current == distance && entity.id < best)) {
             best = entity.id; distance = current;
         }
-        i = i + 1;
+        i += 1;
     }
     best
 }

--- a/examples/caldera/system_collision_apply.rue
+++ b/examples/caldera/system_collision_apply.rue
@@ -39,7 +39,7 @@ fn inspect_entities(inout out: result.Result, borrow world: model.World) {
         let eligible = eligible_entity(borrow world, borrow entity);
         let command = eligible && (entity.id + FOCUS() + world.tick) % 2 == 0;
         result.record(inout out, eligible, command, entity_value(borrow world, borrow entity));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -51,7 +51,7 @@ fn inspect_tiles(inout out: result.Result, borrow world: model.World) {
         let command = eligible && tile.resource > FOCUS() % 17;
         result.record(inout out, eligible, command,
             tile.height + tile.resource + tile.terrain * 11 + i % 97);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -62,7 +62,7 @@ fn inspect_timeline(inout out: result.Result, borrow world: model.World) {
         let eligible = (event.kind + FOCUS()) % 4 == 0;
         result.record(inout out, eligible, eligible && event.value > 0,
             event.sequence + event.actor % 257 + event.value);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
@@ -70,7 +70,7 @@ fn inspect_timeline(inout out: result.Result, borrow world: model.World) {
         let eligible = command.accepted && (command.kind + FOCUS()) % 3 == 0;
         result.record(inout out, eligible, eligible,
             command.tick + command.actor % 251 + command.value);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -83,12 +83,12 @@ fn inspect_regions(inout out: result.Result, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region { tiles = tiles + 1; resources = resources + tile.resource; }
-            i = i + 1;
+            i += 1;
         }
         let eligible = tiles > 0 && (region + FOCUS()) % 4 == 0;
         result.record(inout out, eligible, eligible && resources > tiles,
             resources + tiles * 13 + region);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/system_collision_apply.rue
+++ b/examples/caldera/system_collision_apply.rue
@@ -82,7 +82,7 @@ fn inspect_regions(inout out: result.Result, borrow world: model.World) {
         let mut i: u64 = 0;
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
-            if tile.region == region { tiles = tiles + 1; resources = resources + tile.resource; }
+            if tile.region == region { tiles += 1; resources += tile.resource; }
             i += 1;
         }
         let eligible = tiles > 0 && (region + FOCUS()) % 4 == 0;

--- a/examples/caldera/system_collision_audit.rue
+++ b/examples/caldera/system_collision_audit.rue
@@ -39,7 +39,7 @@ fn inspect_entities(inout out: result.Result, borrow world: model.World) {
         let eligible = eligible_entity(borrow world, borrow entity);
         let command = eligible && (entity.id + FOCUS() + world.tick) % 2 == 0;
         result.record(inout out, eligible, command, entity_value(borrow world, borrow entity));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -51,7 +51,7 @@ fn inspect_tiles(inout out: result.Result, borrow world: model.World) {
         let command = eligible && tile.resource > FOCUS() % 17;
         result.record(inout out, eligible, command,
             tile.height + tile.resource + tile.terrain * 11 + i % 97);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -62,7 +62,7 @@ fn inspect_timeline(inout out: result.Result, borrow world: model.World) {
         let eligible = (event.kind + FOCUS()) % 4 == 0;
         result.record(inout out, eligible, eligible && event.value > 0,
             event.sequence + event.actor % 257 + event.value);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
@@ -70,7 +70,7 @@ fn inspect_timeline(inout out: result.Result, borrow world: model.World) {
         let eligible = command.accepted && (command.kind + FOCUS()) % 3 == 0;
         result.record(inout out, eligible, eligible,
             command.tick + command.actor % 251 + command.value);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -83,12 +83,12 @@ fn inspect_regions(inout out: result.Result, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region { tiles = tiles + 1; resources = resources + tile.resource; }
-            i = i + 1;
+            i += 1;
         }
         let eligible = tiles > 0 && (region + FOCUS()) % 4 == 0;
         result.record(inout out, eligible, eligible && resources > tiles,
             resources + tiles * 13 + region);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/system_collision_audit.rue
+++ b/examples/caldera/system_collision_audit.rue
@@ -82,7 +82,7 @@ fn inspect_regions(inout out: result.Result, borrow world: model.World) {
         let mut i: u64 = 0;
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
-            if tile.region == region { tiles = tiles + 1; resources = resources + tile.resource; }
+            if tile.region == region { tiles += 1; resources += tile.resource; }
             i += 1;
         }
         let eligible = tiles > 0 && (region + FOCUS()) % 4 == 0;

--- a/examples/caldera/system_collision_bootstrap.rue
+++ b/examples/caldera/system_collision_bootstrap.rue
@@ -39,7 +39,7 @@ fn inspect_entities(inout out: result.Result, borrow world: model.World) {
         let eligible = eligible_entity(borrow world, borrow entity);
         let command = eligible && (entity.id + FOCUS() + world.tick) % 2 == 0;
         result.record(inout out, eligible, command, entity_value(borrow world, borrow entity));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -51,7 +51,7 @@ fn inspect_tiles(inout out: result.Result, borrow world: model.World) {
         let command = eligible && tile.resource > FOCUS() % 17;
         result.record(inout out, eligible, command,
             tile.height + tile.resource + tile.terrain * 11 + i % 97);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -62,7 +62,7 @@ fn inspect_timeline(inout out: result.Result, borrow world: model.World) {
         let eligible = (event.kind + FOCUS()) % 4 == 0;
         result.record(inout out, eligible, eligible && event.value > 0,
             event.sequence + event.actor % 257 + event.value);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
@@ -70,7 +70,7 @@ fn inspect_timeline(inout out: result.Result, borrow world: model.World) {
         let eligible = command.accepted && (command.kind + FOCUS()) % 3 == 0;
         result.record(inout out, eligible, eligible,
             command.tick + command.actor % 251 + command.value);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -83,12 +83,12 @@ fn inspect_regions(inout out: result.Result, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region { tiles = tiles + 1; resources = resources + tile.resource; }
-            i = i + 1;
+            i += 1;
         }
         let eligible = tiles > 0 && (region + FOCUS()) % 4 == 0;
         result.record(inout out, eligible, eligible && resources > tiles,
             resources + tiles * 13 + region);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/system_collision_bootstrap.rue
+++ b/examples/caldera/system_collision_bootstrap.rue
@@ -82,7 +82,7 @@ fn inspect_regions(inout out: result.Result, borrow world: model.World) {
         let mut i: u64 = 0;
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
-            if tile.region == region { tiles = tiles + 1; resources = resources + tile.resource; }
+            if tile.region == region { tiles += 1; resources += tile.resource; }
             i += 1;
         }
         let eligible = tiles > 0 && (region + FOCUS()) % 4 == 0;

--- a/examples/caldera/system_collision_checkpoint.rue
+++ b/examples/caldera/system_collision_checkpoint.rue
@@ -39,7 +39,7 @@ fn inspect_entities(inout out: result.Result, borrow world: model.World) {
         let eligible = eligible_entity(borrow world, borrow entity);
         let command = eligible && (entity.id + FOCUS() + world.tick) % 2 == 0;
         result.record(inout out, eligible, command, entity_value(borrow world, borrow entity));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -51,7 +51,7 @@ fn inspect_tiles(inout out: result.Result, borrow world: model.World) {
         let command = eligible && tile.resource > FOCUS() % 17;
         result.record(inout out, eligible, command,
             tile.height + tile.resource + tile.terrain * 11 + i % 97);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -62,7 +62,7 @@ fn inspect_timeline(inout out: result.Result, borrow world: model.World) {
         let eligible = (event.kind + FOCUS()) % 4 == 0;
         result.record(inout out, eligible, eligible && event.value > 0,
             event.sequence + event.actor % 257 + event.value);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
@@ -70,7 +70,7 @@ fn inspect_timeline(inout out: result.Result, borrow world: model.World) {
         let eligible = command.accepted && (command.kind + FOCUS()) % 3 == 0;
         result.record(inout out, eligible, eligible,
             command.tick + command.actor % 251 + command.value);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -83,12 +83,12 @@ fn inspect_regions(inout out: result.Result, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region { tiles = tiles + 1; resources = resources + tile.resource; }
-            i = i + 1;
+            i += 1;
         }
         let eligible = tiles > 0 && (region + FOCUS()) % 4 == 0;
         result.record(inout out, eligible, eligible && resources > tiles,
             resources + tiles * 13 + region);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/system_collision_checkpoint.rue
+++ b/examples/caldera/system_collision_checkpoint.rue
@@ -82,7 +82,7 @@ fn inspect_regions(inout out: result.Result, borrow world: model.World) {
         let mut i: u64 = 0;
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
-            if tile.region == region { tiles = tiles + 1; resources = resources + tile.resource; }
+            if tile.region == region { tiles += 1; resources += tile.resource; }
             i += 1;
         }
         let eligible = tiles > 0 && (region + FOCUS()) % 4 == 0;

--- a/examples/caldera/system_collision_compact.rue
+++ b/examples/caldera/system_collision_compact.rue
@@ -39,7 +39,7 @@ fn inspect_entities(inout out: result.Result, borrow world: model.World) {
         let eligible = eligible_entity(borrow world, borrow entity);
         let command = eligible && (entity.id + FOCUS() + world.tick) % 2 == 0;
         result.record(inout out, eligible, command, entity_value(borrow world, borrow entity));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -51,7 +51,7 @@ fn inspect_tiles(inout out: result.Result, borrow world: model.World) {
         let command = eligible && tile.resource > FOCUS() % 17;
         result.record(inout out, eligible, command,
             tile.height + tile.resource + tile.terrain * 11 + i % 97);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -62,7 +62,7 @@ fn inspect_timeline(inout out: result.Result, borrow world: model.World) {
         let eligible = (event.kind + FOCUS()) % 4 == 0;
         result.record(inout out, eligible, eligible && event.value > 0,
             event.sequence + event.actor % 257 + event.value);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
@@ -70,7 +70,7 @@ fn inspect_timeline(inout out: result.Result, borrow world: model.World) {
         let eligible = command.accepted && (command.kind + FOCUS()) % 3 == 0;
         result.record(inout out, eligible, eligible,
             command.tick + command.actor % 251 + command.value);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -83,12 +83,12 @@ fn inspect_regions(inout out: result.Result, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region { tiles = tiles + 1; resources = resources + tile.resource; }
-            i = i + 1;
+            i += 1;
         }
         let eligible = tiles > 0 && (region + FOCUS()) % 4 == 0;
         result.record(inout out, eligible, eligible && resources > tiles,
             resources + tiles * 13 + region);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/system_collision_compact.rue
+++ b/examples/caldera/system_collision_compact.rue
@@ -82,7 +82,7 @@ fn inspect_regions(inout out: result.Result, borrow world: model.World) {
         let mut i: u64 = 0;
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
-            if tile.region == region { tiles = tiles + 1; resources = resources + tile.resource; }
+            if tile.region == region { tiles += 1; resources += tile.resource; }
             i += 1;
         }
         let eligible = tiles > 0 && (region + FOCUS()) % 4 == 0;

--- a/examples/caldera/system_collision_discover.rue
+++ b/examples/caldera/system_collision_discover.rue
@@ -39,7 +39,7 @@ fn inspect_entities(inout out: result.Result, borrow world: model.World) {
         let eligible = eligible_entity(borrow world, borrow entity);
         let command = eligible && (entity.id + FOCUS() + world.tick) % 2 == 0;
         result.record(inout out, eligible, command, entity_value(borrow world, borrow entity));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -51,7 +51,7 @@ fn inspect_tiles(inout out: result.Result, borrow world: model.World) {
         let command = eligible && tile.resource > FOCUS() % 17;
         result.record(inout out, eligible, command,
             tile.height + tile.resource + tile.terrain * 11 + i % 97);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -62,7 +62,7 @@ fn inspect_timeline(inout out: result.Result, borrow world: model.World) {
         let eligible = (event.kind + FOCUS()) % 4 == 0;
         result.record(inout out, eligible, eligible && event.value > 0,
             event.sequence + event.actor % 257 + event.value);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
@@ -70,7 +70,7 @@ fn inspect_timeline(inout out: result.Result, borrow world: model.World) {
         let eligible = command.accepted && (command.kind + FOCUS()) % 3 == 0;
         result.record(inout out, eligible, eligible,
             command.tick + command.actor % 251 + command.value);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -83,12 +83,12 @@ fn inspect_regions(inout out: result.Result, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region { tiles = tiles + 1; resources = resources + tile.resource; }
-            i = i + 1;
+            i += 1;
         }
         let eligible = tiles > 0 && (region + FOCUS()) % 4 == 0;
         result.record(inout out, eligible, eligible && resources > tiles,
             resources + tiles * 13 + region);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/system_collision_discover.rue
+++ b/examples/caldera/system_collision_discover.rue
@@ -82,7 +82,7 @@ fn inspect_regions(inout out: result.Result, borrow world: model.World) {
         let mut i: u64 = 0;
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
-            if tile.region == region { tiles = tiles + 1; resources = resources + tile.resource; }
+            if tile.region == region { tiles += 1; resources += tile.resource; }
             i += 1;
         }
         let eligible = tiles > 0 && (region + FOCUS()) % 4 == 0;

--- a/examples/caldera/system_collision_dispatch.rue
+++ b/examples/caldera/system_collision_dispatch.rue
@@ -39,7 +39,7 @@ fn inspect_entities(inout out: result.Result, borrow world: model.World) {
         let eligible = eligible_entity(borrow world, borrow entity);
         let command = eligible && (entity.id + FOCUS() + world.tick) % 2 == 0;
         result.record(inout out, eligible, command, entity_value(borrow world, borrow entity));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -51,7 +51,7 @@ fn inspect_tiles(inout out: result.Result, borrow world: model.World) {
         let command = eligible && tile.resource > FOCUS() % 17;
         result.record(inout out, eligible, command,
             tile.height + tile.resource + tile.terrain * 11 + i % 97);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -62,7 +62,7 @@ fn inspect_timeline(inout out: result.Result, borrow world: model.World) {
         let eligible = (event.kind + FOCUS()) % 4 == 0;
         result.record(inout out, eligible, eligible && event.value > 0,
             event.sequence + event.actor % 257 + event.value);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
@@ -70,7 +70,7 @@ fn inspect_timeline(inout out: result.Result, borrow world: model.World) {
         let eligible = command.accepted && (command.kind + FOCUS()) % 3 == 0;
         result.record(inout out, eligible, eligible,
             command.tick + command.actor % 251 + command.value);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -83,12 +83,12 @@ fn inspect_regions(inout out: result.Result, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region { tiles = tiles + 1; resources = resources + tile.resource; }
-            i = i + 1;
+            i += 1;
         }
         let eligible = tiles > 0 && (region + FOCUS()) % 4 == 0;
         result.record(inout out, eligible, eligible && resources > tiles,
             resources + tiles * 13 + region);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/system_collision_dispatch.rue
+++ b/examples/caldera/system_collision_dispatch.rue
@@ -82,7 +82,7 @@ fn inspect_regions(inout out: result.Result, borrow world: model.World) {
         let mut i: u64 = 0;
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
-            if tile.region == region { tiles = tiles + 1; resources = resources + tile.resource; }
+            if tile.region == region { tiles += 1; resources += tile.resource; }
             i += 1;
         }
         let eligible = tiles > 0 && (region + FOCUS()) % 4 == 0;

--- a/examples/caldera/system_collision_finalize.rue
+++ b/examples/caldera/system_collision_finalize.rue
@@ -39,7 +39,7 @@ fn inspect_entities(inout out: result.Result, borrow world: model.World) {
         let eligible = eligible_entity(borrow world, borrow entity);
         let command = eligible && (entity.id + FOCUS() + world.tick) % 2 == 0;
         result.record(inout out, eligible, command, entity_value(borrow world, borrow entity));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -51,7 +51,7 @@ fn inspect_tiles(inout out: result.Result, borrow world: model.World) {
         let command = eligible && tile.resource > FOCUS() % 17;
         result.record(inout out, eligible, command,
             tile.height + tile.resource + tile.terrain * 11 + i % 97);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -62,7 +62,7 @@ fn inspect_timeline(inout out: result.Result, borrow world: model.World) {
         let eligible = (event.kind + FOCUS()) % 4 == 0;
         result.record(inout out, eligible, eligible && event.value > 0,
             event.sequence + event.actor % 257 + event.value);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
@@ -70,7 +70,7 @@ fn inspect_timeline(inout out: result.Result, borrow world: model.World) {
         let eligible = command.accepted && (command.kind + FOCUS()) % 3 == 0;
         result.record(inout out, eligible, eligible,
             command.tick + command.actor % 251 + command.value);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -83,12 +83,12 @@ fn inspect_regions(inout out: result.Result, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region { tiles = tiles + 1; resources = resources + tile.resource; }
-            i = i + 1;
+            i += 1;
         }
         let eligible = tiles > 0 && (region + FOCUS()) % 4 == 0;
         result.record(inout out, eligible, eligible && resources > tiles,
             resources + tiles * 13 + region);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/system_collision_finalize.rue
+++ b/examples/caldera/system_collision_finalize.rue
@@ -82,7 +82,7 @@ fn inspect_regions(inout out: result.Result, borrow world: model.World) {
         let mut i: u64 = 0;
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
-            if tile.region == region { tiles = tiles + 1; resources = resources + tile.resource; }
+            if tile.region == region { tiles += 1; resources += tile.resource; }
             i += 1;
         }
         let eligible = tiles > 0 && (region + FOCUS()) % 4 == 0;

--- a/examples/caldera/system_collision_observe.rue
+++ b/examples/caldera/system_collision_observe.rue
@@ -39,7 +39,7 @@ fn inspect_entities(inout out: result.Result, borrow world: model.World) {
         let eligible = eligible_entity(borrow world, borrow entity);
         let command = eligible && (entity.id + FOCUS() + world.tick) % 2 == 0;
         result.record(inout out, eligible, command, entity_value(borrow world, borrow entity));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -51,7 +51,7 @@ fn inspect_tiles(inout out: result.Result, borrow world: model.World) {
         let command = eligible && tile.resource > FOCUS() % 17;
         result.record(inout out, eligible, command,
             tile.height + tile.resource + tile.terrain * 11 + i % 97);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -62,7 +62,7 @@ fn inspect_timeline(inout out: result.Result, borrow world: model.World) {
         let eligible = (event.kind + FOCUS()) % 4 == 0;
         result.record(inout out, eligible, eligible && event.value > 0,
             event.sequence + event.actor % 257 + event.value);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
@@ -70,7 +70,7 @@ fn inspect_timeline(inout out: result.Result, borrow world: model.World) {
         let eligible = command.accepted && (command.kind + FOCUS()) % 3 == 0;
         result.record(inout out, eligible, eligible,
             command.tick + command.actor % 251 + command.value);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -83,12 +83,12 @@ fn inspect_regions(inout out: result.Result, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region { tiles = tiles + 1; resources = resources + tile.resource; }
-            i = i + 1;
+            i += 1;
         }
         let eligible = tiles > 0 && (region + FOCUS()) % 4 == 0;
         result.record(inout out, eligible, eligible && resources > tiles,
             resources + tiles * 13 + region);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/system_collision_observe.rue
+++ b/examples/caldera/system_collision_observe.rue
@@ -82,7 +82,7 @@ fn inspect_regions(inout out: result.Result, borrow world: model.World) {
         let mut i: u64 = 0;
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
-            if tile.region == region { tiles = tiles + 1; resources = resources + tile.resource; }
+            if tile.region == region { tiles += 1; resources += tile.resource; }
             i += 1;
         }
         let eligible = tiles > 0 && (region + FOCUS()) % 4 == 0;

--- a/examples/caldera/system_collision_prepare.rue
+++ b/examples/caldera/system_collision_prepare.rue
@@ -39,7 +39,7 @@ fn inspect_entities(inout out: result.Result, borrow world: model.World) {
         let eligible = eligible_entity(borrow world, borrow entity);
         let command = eligible && (entity.id + FOCUS() + world.tick) % 2 == 0;
         result.record(inout out, eligible, command, entity_value(borrow world, borrow entity));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -51,7 +51,7 @@ fn inspect_tiles(inout out: result.Result, borrow world: model.World) {
         let command = eligible && tile.resource > FOCUS() % 17;
         result.record(inout out, eligible, command,
             tile.height + tile.resource + tile.terrain * 11 + i % 97);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -62,7 +62,7 @@ fn inspect_timeline(inout out: result.Result, borrow world: model.World) {
         let eligible = (event.kind + FOCUS()) % 4 == 0;
         result.record(inout out, eligible, eligible && event.value > 0,
             event.sequence + event.actor % 257 + event.value);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
@@ -70,7 +70,7 @@ fn inspect_timeline(inout out: result.Result, borrow world: model.World) {
         let eligible = command.accepted && (command.kind + FOCUS()) % 3 == 0;
         result.record(inout out, eligible, eligible,
             command.tick + command.actor % 251 + command.value);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -83,12 +83,12 @@ fn inspect_regions(inout out: result.Result, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region { tiles = tiles + 1; resources = resources + tile.resource; }
-            i = i + 1;
+            i += 1;
         }
         let eligible = tiles > 0 && (region + FOCUS()) % 4 == 0;
         result.record(inout out, eligible, eligible && resources > tiles,
             resources + tiles * 13 + region);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/system_collision_prepare.rue
+++ b/examples/caldera/system_collision_prepare.rue
@@ -82,7 +82,7 @@ fn inspect_regions(inout out: result.Result, borrow world: model.World) {
         let mut i: u64 = 0;
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
-            if tile.region == region { tiles = tiles + 1; resources = resources + tile.resource; }
+            if tile.region == region { tiles += 1; resources += tile.resource; }
             i += 1;
         }
         let eligible = tiles > 0 && (region + FOCUS()) % 4 == 0;

--- a/examples/caldera/system_collision_reconcile.rue
+++ b/examples/caldera/system_collision_reconcile.rue
@@ -39,7 +39,7 @@ fn inspect_entities(inout out: result.Result, borrow world: model.World) {
         let eligible = eligible_entity(borrow world, borrow entity);
         let command = eligible && (entity.id + FOCUS() + world.tick) % 2 == 0;
         result.record(inout out, eligible, command, entity_value(borrow world, borrow entity));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -51,7 +51,7 @@ fn inspect_tiles(inout out: result.Result, borrow world: model.World) {
         let command = eligible && tile.resource > FOCUS() % 17;
         result.record(inout out, eligible, command,
             tile.height + tile.resource + tile.terrain * 11 + i % 97);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -62,7 +62,7 @@ fn inspect_timeline(inout out: result.Result, borrow world: model.World) {
         let eligible = (event.kind + FOCUS()) % 4 == 0;
         result.record(inout out, eligible, eligible && event.value > 0,
             event.sequence + event.actor % 257 + event.value);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
@@ -70,7 +70,7 @@ fn inspect_timeline(inout out: result.Result, borrow world: model.World) {
         let eligible = command.accepted && (command.kind + FOCUS()) % 3 == 0;
         result.record(inout out, eligible, eligible,
             command.tick + command.actor % 251 + command.value);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -83,12 +83,12 @@ fn inspect_regions(inout out: result.Result, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region { tiles = tiles + 1; resources = resources + tile.resource; }
-            i = i + 1;
+            i += 1;
         }
         let eligible = tiles > 0 && (region + FOCUS()) % 4 == 0;
         result.record(inout out, eligible, eligible && resources > tiles,
             resources + tiles * 13 + region);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/system_collision_reconcile.rue
+++ b/examples/caldera/system_collision_reconcile.rue
@@ -82,7 +82,7 @@ fn inspect_regions(inout out: result.Result, borrow world: model.World) {
         let mut i: u64 = 0;
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
-            if tile.region == region { tiles = tiles + 1; resources = resources + tile.resource; }
+            if tile.region == region { tiles += 1; resources += tile.resource; }
             i += 1;
         }
         let eligible = tiles > 0 && (region + FOCUS()) % 4 == 0;

--- a/examples/caldera/system_collision_recover.rue
+++ b/examples/caldera/system_collision_recover.rue
@@ -39,7 +39,7 @@ fn inspect_entities(inout out: result.Result, borrow world: model.World) {
         let eligible = eligible_entity(borrow world, borrow entity);
         let command = eligible && (entity.id + FOCUS() + world.tick) % 2 == 0;
         result.record(inout out, eligible, command, entity_value(borrow world, borrow entity));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -51,7 +51,7 @@ fn inspect_tiles(inout out: result.Result, borrow world: model.World) {
         let command = eligible && tile.resource > FOCUS() % 17;
         result.record(inout out, eligible, command,
             tile.height + tile.resource + tile.terrain * 11 + i % 97);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -62,7 +62,7 @@ fn inspect_timeline(inout out: result.Result, borrow world: model.World) {
         let eligible = (event.kind + FOCUS()) % 4 == 0;
         result.record(inout out, eligible, eligible && event.value > 0,
             event.sequence + event.actor % 257 + event.value);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
@@ -70,7 +70,7 @@ fn inspect_timeline(inout out: result.Result, borrow world: model.World) {
         let eligible = command.accepted && (command.kind + FOCUS()) % 3 == 0;
         result.record(inout out, eligible, eligible,
             command.tick + command.actor % 251 + command.value);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -83,12 +83,12 @@ fn inspect_regions(inout out: result.Result, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region { tiles = tiles + 1; resources = resources + tile.resource; }
-            i = i + 1;
+            i += 1;
         }
         let eligible = tiles > 0 && (region + FOCUS()) % 4 == 0;
         result.record(inout out, eligible, eligible && resources > tiles,
             resources + tiles * 13 + region);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/system_collision_recover.rue
+++ b/examples/caldera/system_collision_recover.rue
@@ -82,7 +82,7 @@ fn inspect_regions(inout out: result.Result, borrow world: model.World) {
         let mut i: u64 = 0;
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
-            if tile.region == region { tiles = tiles + 1; resources = resources + tile.resource; }
+            if tile.region == region { tiles += 1; resources += tile.resource; }
             i += 1;
         }
         let eligible = tiles > 0 && (region + FOCUS()) % 4 == 0;

--- a/examples/caldera/system_collision_replicate.rue
+++ b/examples/caldera/system_collision_replicate.rue
@@ -39,7 +39,7 @@ fn inspect_entities(inout out: result.Result, borrow world: model.World) {
         let eligible = eligible_entity(borrow world, borrow entity);
         let command = eligible && (entity.id + FOCUS() + world.tick) % 2 == 0;
         result.record(inout out, eligible, command, entity_value(borrow world, borrow entity));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -51,7 +51,7 @@ fn inspect_tiles(inout out: result.Result, borrow world: model.World) {
         let command = eligible && tile.resource > FOCUS() % 17;
         result.record(inout out, eligible, command,
             tile.height + tile.resource + tile.terrain * 11 + i % 97);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -62,7 +62,7 @@ fn inspect_timeline(inout out: result.Result, borrow world: model.World) {
         let eligible = (event.kind + FOCUS()) % 4 == 0;
         result.record(inout out, eligible, eligible && event.value > 0,
             event.sequence + event.actor % 257 + event.value);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
@@ -70,7 +70,7 @@ fn inspect_timeline(inout out: result.Result, borrow world: model.World) {
         let eligible = command.accepted && (command.kind + FOCUS()) % 3 == 0;
         result.record(inout out, eligible, eligible,
             command.tick + command.actor % 251 + command.value);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -83,12 +83,12 @@ fn inspect_regions(inout out: result.Result, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region { tiles = tiles + 1; resources = resources + tile.resource; }
-            i = i + 1;
+            i += 1;
         }
         let eligible = tiles > 0 && (region + FOCUS()) % 4 == 0;
         result.record(inout out, eligible, eligible && resources > tiles,
             resources + tiles * 13 + region);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/system_collision_replicate.rue
+++ b/examples/caldera/system_collision_replicate.rue
@@ -82,7 +82,7 @@ fn inspect_regions(inout out: result.Result, borrow world: model.World) {
         let mut i: u64 = 0;
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
-            if tile.region == region { tiles = tiles + 1; resources = resources + tile.resource; }
+            if tile.region == region { tiles += 1; resources += tile.resource; }
             i += 1;
         }
         let eligible = tiles > 0 && (region + FOCUS()) % 4 == 0;

--- a/examples/caldera/system_collision_resolve.rue
+++ b/examples/caldera/system_collision_resolve.rue
@@ -39,7 +39,7 @@ fn inspect_entities(inout out: result.Result, borrow world: model.World) {
         let eligible = eligible_entity(borrow world, borrow entity);
         let command = eligible && (entity.id + FOCUS() + world.tick) % 2 == 0;
         result.record(inout out, eligible, command, entity_value(borrow world, borrow entity));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -51,7 +51,7 @@ fn inspect_tiles(inout out: result.Result, borrow world: model.World) {
         let command = eligible && tile.resource > FOCUS() % 17;
         result.record(inout out, eligible, command,
             tile.height + tile.resource + tile.terrain * 11 + i % 97);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -62,7 +62,7 @@ fn inspect_timeline(inout out: result.Result, borrow world: model.World) {
         let eligible = (event.kind + FOCUS()) % 4 == 0;
         result.record(inout out, eligible, eligible && event.value > 0,
             event.sequence + event.actor % 257 + event.value);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
@@ -70,7 +70,7 @@ fn inspect_timeline(inout out: result.Result, borrow world: model.World) {
         let eligible = command.accepted && (command.kind + FOCUS()) % 3 == 0;
         result.record(inout out, eligible, eligible,
             command.tick + command.actor % 251 + command.value);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -83,12 +83,12 @@ fn inspect_regions(inout out: result.Result, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region { tiles = tiles + 1; resources = resources + tile.resource; }
-            i = i + 1;
+            i += 1;
         }
         let eligible = tiles > 0 && (region + FOCUS()) % 4 == 0;
         result.record(inout out, eligible, eligible && resources > tiles,
             resources + tiles * 13 + region);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/system_collision_resolve.rue
+++ b/examples/caldera/system_collision_resolve.rue
@@ -82,7 +82,7 @@ fn inspect_regions(inout out: result.Result, borrow world: model.World) {
         let mut i: u64 = 0;
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
-            if tile.region == region { tiles = tiles + 1; resources = resources + tile.resource; }
+            if tile.region == region { tiles += 1; resources += tile.resource; }
             i += 1;
         }
         let eligible = tiles > 0 && (region + FOCUS()) % 4 == 0;

--- a/examples/caldera/system_collision_schedule.rue
+++ b/examples/caldera/system_collision_schedule.rue
@@ -39,7 +39,7 @@ fn inspect_entities(inout out: result.Result, borrow world: model.World) {
         let eligible = eligible_entity(borrow world, borrow entity);
         let command = eligible && (entity.id + FOCUS() + world.tick) % 2 == 0;
         result.record(inout out, eligible, command, entity_value(borrow world, borrow entity));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -51,7 +51,7 @@ fn inspect_tiles(inout out: result.Result, borrow world: model.World) {
         let command = eligible && tile.resource > FOCUS() % 17;
         result.record(inout out, eligible, command,
             tile.height + tile.resource + tile.terrain * 11 + i % 97);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -62,7 +62,7 @@ fn inspect_timeline(inout out: result.Result, borrow world: model.World) {
         let eligible = (event.kind + FOCUS()) % 4 == 0;
         result.record(inout out, eligible, eligible && event.value > 0,
             event.sequence + event.actor % 257 + event.value);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
@@ -70,7 +70,7 @@ fn inspect_timeline(inout out: result.Result, borrow world: model.World) {
         let eligible = command.accepted && (command.kind + FOCUS()) % 3 == 0;
         result.record(inout out, eligible, eligible,
             command.tick + command.actor % 251 + command.value);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -83,12 +83,12 @@ fn inspect_regions(inout out: result.Result, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region { tiles = tiles + 1; resources = resources + tile.resource; }
-            i = i + 1;
+            i += 1;
         }
         let eligible = tiles > 0 && (region + FOCUS()) % 4 == 0;
         result.record(inout out, eligible, eligible && resources > tiles,
             resources + tiles * 13 + region);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/system_collision_schedule.rue
+++ b/examples/caldera/system_collision_schedule.rue
@@ -82,7 +82,7 @@ fn inspect_regions(inout out: result.Result, borrow world: model.World) {
         let mut i: u64 = 0;
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
-            if tile.region == region { tiles = tiles + 1; resources = resources + tile.resource; }
+            if tile.region == region { tiles += 1; resources += tile.resource; }
             i += 1;
         }
         let eligible = tiles > 0 && (region + FOCUS()) % 4 == 0;

--- a/examples/caldera/system_collision_validate.rue
+++ b/examples/caldera/system_collision_validate.rue
@@ -39,7 +39,7 @@ fn inspect_entities(inout out: result.Result, borrow world: model.World) {
         let eligible = eligible_entity(borrow world, borrow entity);
         let command = eligible && (entity.id + FOCUS() + world.tick) % 2 == 0;
         result.record(inout out, eligible, command, entity_value(borrow world, borrow entity));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -51,7 +51,7 @@ fn inspect_tiles(inout out: result.Result, borrow world: model.World) {
         let command = eligible && tile.resource > FOCUS() % 17;
         result.record(inout out, eligible, command,
             tile.height + tile.resource + tile.terrain * 11 + i % 97);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -62,7 +62,7 @@ fn inspect_timeline(inout out: result.Result, borrow world: model.World) {
         let eligible = (event.kind + FOCUS()) % 4 == 0;
         result.record(inout out, eligible, eligible && event.value > 0,
             event.sequence + event.actor % 257 + event.value);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
@@ -70,7 +70,7 @@ fn inspect_timeline(inout out: result.Result, borrow world: model.World) {
         let eligible = command.accepted && (command.kind + FOCUS()) % 3 == 0;
         result.record(inout out, eligible, eligible,
             command.tick + command.actor % 251 + command.value);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -83,12 +83,12 @@ fn inspect_regions(inout out: result.Result, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region { tiles = tiles + 1; resources = resources + tile.resource; }
-            i = i + 1;
+            i += 1;
         }
         let eligible = tiles > 0 && (region + FOCUS()) % 4 == 0;
         result.record(inout out, eligible, eligible && resources > tiles,
             resources + tiles * 13 + region);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/system_collision_validate.rue
+++ b/examples/caldera/system_collision_validate.rue
@@ -82,7 +82,7 @@ fn inspect_regions(inout out: result.Result, borrow world: model.World) {
         let mut i: u64 = 0;
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
-            if tile.region == region { tiles = tiles + 1; resources = resources + tile.resource; }
+            if tile.region == region { tiles += 1; resources += tile.resource; }
             i += 1;
         }
         let eligible = tiles > 0 && (region + FOCUS()) % 4 == 0;

--- a/examples/caldera/system_combat_apply.rue
+++ b/examples/caldera/system_combat_apply.rue
@@ -39,7 +39,7 @@ fn inspect_entities(inout out: result.Result, borrow world: model.World) {
         let eligible = eligible_entity(borrow world, borrow entity);
         let command = eligible && (entity.id + FOCUS() + world.tick) % 2 == 0;
         result.record(inout out, eligible, command, entity_value(borrow world, borrow entity));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -51,7 +51,7 @@ fn inspect_tiles(inout out: result.Result, borrow world: model.World) {
         let command = eligible && tile.resource > FOCUS() % 17;
         result.record(inout out, eligible, command,
             tile.height + tile.resource + tile.terrain * 11 + i % 97);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -62,7 +62,7 @@ fn inspect_timeline(inout out: result.Result, borrow world: model.World) {
         let eligible = (event.kind + FOCUS()) % 4 == 0;
         result.record(inout out, eligible, eligible && event.value > 0,
             event.sequence + event.actor % 257 + event.value);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
@@ -70,7 +70,7 @@ fn inspect_timeline(inout out: result.Result, borrow world: model.World) {
         let eligible = command.accepted && (command.kind + FOCUS()) % 3 == 0;
         result.record(inout out, eligible, eligible,
             command.tick + command.actor % 251 + command.value);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -83,12 +83,12 @@ fn inspect_regions(inout out: result.Result, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region { tiles = tiles + 1; resources = resources + tile.resource; }
-            i = i + 1;
+            i += 1;
         }
         let eligible = tiles > 0 && (region + FOCUS()) % 4 == 0;
         result.record(inout out, eligible, eligible && resources > tiles,
             resources + tiles * 13 + region);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/system_combat_apply.rue
+++ b/examples/caldera/system_combat_apply.rue
@@ -82,7 +82,7 @@ fn inspect_regions(inout out: result.Result, borrow world: model.World) {
         let mut i: u64 = 0;
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
-            if tile.region == region { tiles = tiles + 1; resources = resources + tile.resource; }
+            if tile.region == region { tiles += 1; resources += tile.resource; }
             i += 1;
         }
         let eligible = tiles > 0 && (region + FOCUS()) % 4 == 0;

--- a/examples/caldera/system_combat_audit.rue
+++ b/examples/caldera/system_combat_audit.rue
@@ -39,7 +39,7 @@ fn inspect_entities(inout out: result.Result, borrow world: model.World) {
         let eligible = eligible_entity(borrow world, borrow entity);
         let command = eligible && (entity.id + FOCUS() + world.tick) % 2 == 0;
         result.record(inout out, eligible, command, entity_value(borrow world, borrow entity));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -51,7 +51,7 @@ fn inspect_tiles(inout out: result.Result, borrow world: model.World) {
         let command = eligible && tile.resource > FOCUS() % 17;
         result.record(inout out, eligible, command,
             tile.height + tile.resource + tile.terrain * 11 + i % 97);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -62,7 +62,7 @@ fn inspect_timeline(inout out: result.Result, borrow world: model.World) {
         let eligible = (event.kind + FOCUS()) % 4 == 0;
         result.record(inout out, eligible, eligible && event.value > 0,
             event.sequence + event.actor % 257 + event.value);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
@@ -70,7 +70,7 @@ fn inspect_timeline(inout out: result.Result, borrow world: model.World) {
         let eligible = command.accepted && (command.kind + FOCUS()) % 3 == 0;
         result.record(inout out, eligible, eligible,
             command.tick + command.actor % 251 + command.value);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -83,12 +83,12 @@ fn inspect_regions(inout out: result.Result, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region { tiles = tiles + 1; resources = resources + tile.resource; }
-            i = i + 1;
+            i += 1;
         }
         let eligible = tiles > 0 && (region + FOCUS()) % 4 == 0;
         result.record(inout out, eligible, eligible && resources > tiles,
             resources + tiles * 13 + region);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/system_combat_audit.rue
+++ b/examples/caldera/system_combat_audit.rue
@@ -82,7 +82,7 @@ fn inspect_regions(inout out: result.Result, borrow world: model.World) {
         let mut i: u64 = 0;
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
-            if tile.region == region { tiles = tiles + 1; resources = resources + tile.resource; }
+            if tile.region == region { tiles += 1; resources += tile.resource; }
             i += 1;
         }
         let eligible = tiles > 0 && (region + FOCUS()) % 4 == 0;

--- a/examples/caldera/system_combat_bootstrap.rue
+++ b/examples/caldera/system_combat_bootstrap.rue
@@ -39,7 +39,7 @@ fn inspect_entities(inout out: result.Result, borrow world: model.World) {
         let eligible = eligible_entity(borrow world, borrow entity);
         let command = eligible && (entity.id + FOCUS() + world.tick) % 2 == 0;
         result.record(inout out, eligible, command, entity_value(borrow world, borrow entity));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -51,7 +51,7 @@ fn inspect_tiles(inout out: result.Result, borrow world: model.World) {
         let command = eligible && tile.resource > FOCUS() % 17;
         result.record(inout out, eligible, command,
             tile.height + tile.resource + tile.terrain * 11 + i % 97);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -62,7 +62,7 @@ fn inspect_timeline(inout out: result.Result, borrow world: model.World) {
         let eligible = (event.kind + FOCUS()) % 4 == 0;
         result.record(inout out, eligible, eligible && event.value > 0,
             event.sequence + event.actor % 257 + event.value);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
@@ -70,7 +70,7 @@ fn inspect_timeline(inout out: result.Result, borrow world: model.World) {
         let eligible = command.accepted && (command.kind + FOCUS()) % 3 == 0;
         result.record(inout out, eligible, eligible,
             command.tick + command.actor % 251 + command.value);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -83,12 +83,12 @@ fn inspect_regions(inout out: result.Result, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region { tiles = tiles + 1; resources = resources + tile.resource; }
-            i = i + 1;
+            i += 1;
         }
         let eligible = tiles > 0 && (region + FOCUS()) % 4 == 0;
         result.record(inout out, eligible, eligible && resources > tiles,
             resources + tiles * 13 + region);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/system_combat_bootstrap.rue
+++ b/examples/caldera/system_combat_bootstrap.rue
@@ -82,7 +82,7 @@ fn inspect_regions(inout out: result.Result, borrow world: model.World) {
         let mut i: u64 = 0;
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
-            if tile.region == region { tiles = tiles + 1; resources = resources + tile.resource; }
+            if tile.region == region { tiles += 1; resources += tile.resource; }
             i += 1;
         }
         let eligible = tiles > 0 && (region + FOCUS()) % 4 == 0;

--- a/examples/caldera/system_combat_checkpoint.rue
+++ b/examples/caldera/system_combat_checkpoint.rue
@@ -39,7 +39,7 @@ fn inspect_entities(inout out: result.Result, borrow world: model.World) {
         let eligible = eligible_entity(borrow world, borrow entity);
         let command = eligible && (entity.id + FOCUS() + world.tick) % 2 == 0;
         result.record(inout out, eligible, command, entity_value(borrow world, borrow entity));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -51,7 +51,7 @@ fn inspect_tiles(inout out: result.Result, borrow world: model.World) {
         let command = eligible && tile.resource > FOCUS() % 17;
         result.record(inout out, eligible, command,
             tile.height + tile.resource + tile.terrain * 11 + i % 97);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -62,7 +62,7 @@ fn inspect_timeline(inout out: result.Result, borrow world: model.World) {
         let eligible = (event.kind + FOCUS()) % 4 == 0;
         result.record(inout out, eligible, eligible && event.value > 0,
             event.sequence + event.actor % 257 + event.value);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
@@ -70,7 +70,7 @@ fn inspect_timeline(inout out: result.Result, borrow world: model.World) {
         let eligible = command.accepted && (command.kind + FOCUS()) % 3 == 0;
         result.record(inout out, eligible, eligible,
             command.tick + command.actor % 251 + command.value);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -83,12 +83,12 @@ fn inspect_regions(inout out: result.Result, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region { tiles = tiles + 1; resources = resources + tile.resource; }
-            i = i + 1;
+            i += 1;
         }
         let eligible = tiles > 0 && (region + FOCUS()) % 4 == 0;
         result.record(inout out, eligible, eligible && resources > tiles,
             resources + tiles * 13 + region);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/system_combat_checkpoint.rue
+++ b/examples/caldera/system_combat_checkpoint.rue
@@ -82,7 +82,7 @@ fn inspect_regions(inout out: result.Result, borrow world: model.World) {
         let mut i: u64 = 0;
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
-            if tile.region == region { tiles = tiles + 1; resources = resources + tile.resource; }
+            if tile.region == region { tiles += 1; resources += tile.resource; }
             i += 1;
         }
         let eligible = tiles > 0 && (region + FOCUS()) % 4 == 0;

--- a/examples/caldera/system_combat_compact.rue
+++ b/examples/caldera/system_combat_compact.rue
@@ -39,7 +39,7 @@ fn inspect_entities(inout out: result.Result, borrow world: model.World) {
         let eligible = eligible_entity(borrow world, borrow entity);
         let command = eligible && (entity.id + FOCUS() + world.tick) % 2 == 0;
         result.record(inout out, eligible, command, entity_value(borrow world, borrow entity));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -51,7 +51,7 @@ fn inspect_tiles(inout out: result.Result, borrow world: model.World) {
         let command = eligible && tile.resource > FOCUS() % 17;
         result.record(inout out, eligible, command,
             tile.height + tile.resource + tile.terrain * 11 + i % 97);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -62,7 +62,7 @@ fn inspect_timeline(inout out: result.Result, borrow world: model.World) {
         let eligible = (event.kind + FOCUS()) % 4 == 0;
         result.record(inout out, eligible, eligible && event.value > 0,
             event.sequence + event.actor % 257 + event.value);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
@@ -70,7 +70,7 @@ fn inspect_timeline(inout out: result.Result, borrow world: model.World) {
         let eligible = command.accepted && (command.kind + FOCUS()) % 3 == 0;
         result.record(inout out, eligible, eligible,
             command.tick + command.actor % 251 + command.value);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -83,12 +83,12 @@ fn inspect_regions(inout out: result.Result, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region { tiles = tiles + 1; resources = resources + tile.resource; }
-            i = i + 1;
+            i += 1;
         }
         let eligible = tiles > 0 && (region + FOCUS()) % 4 == 0;
         result.record(inout out, eligible, eligible && resources > tiles,
             resources + tiles * 13 + region);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/system_combat_compact.rue
+++ b/examples/caldera/system_combat_compact.rue
@@ -82,7 +82,7 @@ fn inspect_regions(inout out: result.Result, borrow world: model.World) {
         let mut i: u64 = 0;
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
-            if tile.region == region { tiles = tiles + 1; resources = resources + tile.resource; }
+            if tile.region == region { tiles += 1; resources += tile.resource; }
             i += 1;
         }
         let eligible = tiles > 0 && (region + FOCUS()) % 4 == 0;

--- a/examples/caldera/system_combat_discover.rue
+++ b/examples/caldera/system_combat_discover.rue
@@ -39,7 +39,7 @@ fn inspect_entities(inout out: result.Result, borrow world: model.World) {
         let eligible = eligible_entity(borrow world, borrow entity);
         let command = eligible && (entity.id + FOCUS() + world.tick) % 2 == 0;
         result.record(inout out, eligible, command, entity_value(borrow world, borrow entity));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -51,7 +51,7 @@ fn inspect_tiles(inout out: result.Result, borrow world: model.World) {
         let command = eligible && tile.resource > FOCUS() % 17;
         result.record(inout out, eligible, command,
             tile.height + tile.resource + tile.terrain * 11 + i % 97);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -62,7 +62,7 @@ fn inspect_timeline(inout out: result.Result, borrow world: model.World) {
         let eligible = (event.kind + FOCUS()) % 4 == 0;
         result.record(inout out, eligible, eligible && event.value > 0,
             event.sequence + event.actor % 257 + event.value);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
@@ -70,7 +70,7 @@ fn inspect_timeline(inout out: result.Result, borrow world: model.World) {
         let eligible = command.accepted && (command.kind + FOCUS()) % 3 == 0;
         result.record(inout out, eligible, eligible,
             command.tick + command.actor % 251 + command.value);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -83,12 +83,12 @@ fn inspect_regions(inout out: result.Result, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region { tiles = tiles + 1; resources = resources + tile.resource; }
-            i = i + 1;
+            i += 1;
         }
         let eligible = tiles > 0 && (region + FOCUS()) % 4 == 0;
         result.record(inout out, eligible, eligible && resources > tiles,
             resources + tiles * 13 + region);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/system_combat_discover.rue
+++ b/examples/caldera/system_combat_discover.rue
@@ -82,7 +82,7 @@ fn inspect_regions(inout out: result.Result, borrow world: model.World) {
         let mut i: u64 = 0;
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
-            if tile.region == region { tiles = tiles + 1; resources = resources + tile.resource; }
+            if tile.region == region { tiles += 1; resources += tile.resource; }
             i += 1;
         }
         let eligible = tiles > 0 && (region + FOCUS()) % 4 == 0;

--- a/examples/caldera/system_combat_dispatch.rue
+++ b/examples/caldera/system_combat_dispatch.rue
@@ -39,7 +39,7 @@ fn inspect_entities(inout out: result.Result, borrow world: model.World) {
         let eligible = eligible_entity(borrow world, borrow entity);
         let command = eligible && (entity.id + FOCUS() + world.tick) % 2 == 0;
         result.record(inout out, eligible, command, entity_value(borrow world, borrow entity));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -51,7 +51,7 @@ fn inspect_tiles(inout out: result.Result, borrow world: model.World) {
         let command = eligible && tile.resource > FOCUS() % 17;
         result.record(inout out, eligible, command,
             tile.height + tile.resource + tile.terrain * 11 + i % 97);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -62,7 +62,7 @@ fn inspect_timeline(inout out: result.Result, borrow world: model.World) {
         let eligible = (event.kind + FOCUS()) % 4 == 0;
         result.record(inout out, eligible, eligible && event.value > 0,
             event.sequence + event.actor % 257 + event.value);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
@@ -70,7 +70,7 @@ fn inspect_timeline(inout out: result.Result, borrow world: model.World) {
         let eligible = command.accepted && (command.kind + FOCUS()) % 3 == 0;
         result.record(inout out, eligible, eligible,
             command.tick + command.actor % 251 + command.value);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -83,12 +83,12 @@ fn inspect_regions(inout out: result.Result, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region { tiles = tiles + 1; resources = resources + tile.resource; }
-            i = i + 1;
+            i += 1;
         }
         let eligible = tiles > 0 && (region + FOCUS()) % 4 == 0;
         result.record(inout out, eligible, eligible && resources > tiles,
             resources + tiles * 13 + region);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/system_combat_dispatch.rue
+++ b/examples/caldera/system_combat_dispatch.rue
@@ -82,7 +82,7 @@ fn inspect_regions(inout out: result.Result, borrow world: model.World) {
         let mut i: u64 = 0;
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
-            if tile.region == region { tiles = tiles + 1; resources = resources + tile.resource; }
+            if tile.region == region { tiles += 1; resources += tile.resource; }
             i += 1;
         }
         let eligible = tiles > 0 && (region + FOCUS()) % 4 == 0;

--- a/examples/caldera/system_combat_finalize.rue
+++ b/examples/caldera/system_combat_finalize.rue
@@ -39,7 +39,7 @@ fn inspect_entities(inout out: result.Result, borrow world: model.World) {
         let eligible = eligible_entity(borrow world, borrow entity);
         let command = eligible && (entity.id + FOCUS() + world.tick) % 2 == 0;
         result.record(inout out, eligible, command, entity_value(borrow world, borrow entity));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -51,7 +51,7 @@ fn inspect_tiles(inout out: result.Result, borrow world: model.World) {
         let command = eligible && tile.resource > FOCUS() % 17;
         result.record(inout out, eligible, command,
             tile.height + tile.resource + tile.terrain * 11 + i % 97);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -62,7 +62,7 @@ fn inspect_timeline(inout out: result.Result, borrow world: model.World) {
         let eligible = (event.kind + FOCUS()) % 4 == 0;
         result.record(inout out, eligible, eligible && event.value > 0,
             event.sequence + event.actor % 257 + event.value);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
@@ -70,7 +70,7 @@ fn inspect_timeline(inout out: result.Result, borrow world: model.World) {
         let eligible = command.accepted && (command.kind + FOCUS()) % 3 == 0;
         result.record(inout out, eligible, eligible,
             command.tick + command.actor % 251 + command.value);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -83,12 +83,12 @@ fn inspect_regions(inout out: result.Result, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region { tiles = tiles + 1; resources = resources + tile.resource; }
-            i = i + 1;
+            i += 1;
         }
         let eligible = tiles > 0 && (region + FOCUS()) % 4 == 0;
         result.record(inout out, eligible, eligible && resources > tiles,
             resources + tiles * 13 + region);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/system_combat_finalize.rue
+++ b/examples/caldera/system_combat_finalize.rue
@@ -82,7 +82,7 @@ fn inspect_regions(inout out: result.Result, borrow world: model.World) {
         let mut i: u64 = 0;
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
-            if tile.region == region { tiles = tiles + 1; resources = resources + tile.resource; }
+            if tile.region == region { tiles += 1; resources += tile.resource; }
             i += 1;
         }
         let eligible = tiles > 0 && (region + FOCUS()) % 4 == 0;

--- a/examples/caldera/system_combat_observe.rue
+++ b/examples/caldera/system_combat_observe.rue
@@ -39,7 +39,7 @@ fn inspect_entities(inout out: result.Result, borrow world: model.World) {
         let eligible = eligible_entity(borrow world, borrow entity);
         let command = eligible && (entity.id + FOCUS() + world.tick) % 2 == 0;
         result.record(inout out, eligible, command, entity_value(borrow world, borrow entity));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -51,7 +51,7 @@ fn inspect_tiles(inout out: result.Result, borrow world: model.World) {
         let command = eligible && tile.resource > FOCUS() % 17;
         result.record(inout out, eligible, command,
             tile.height + tile.resource + tile.terrain * 11 + i % 97);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -62,7 +62,7 @@ fn inspect_timeline(inout out: result.Result, borrow world: model.World) {
         let eligible = (event.kind + FOCUS()) % 4 == 0;
         result.record(inout out, eligible, eligible && event.value > 0,
             event.sequence + event.actor % 257 + event.value);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
@@ -70,7 +70,7 @@ fn inspect_timeline(inout out: result.Result, borrow world: model.World) {
         let eligible = command.accepted && (command.kind + FOCUS()) % 3 == 0;
         result.record(inout out, eligible, eligible,
             command.tick + command.actor % 251 + command.value);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -83,12 +83,12 @@ fn inspect_regions(inout out: result.Result, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region { tiles = tiles + 1; resources = resources + tile.resource; }
-            i = i + 1;
+            i += 1;
         }
         let eligible = tiles > 0 && (region + FOCUS()) % 4 == 0;
         result.record(inout out, eligible, eligible && resources > tiles,
             resources + tiles * 13 + region);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/system_combat_observe.rue
+++ b/examples/caldera/system_combat_observe.rue
@@ -82,7 +82,7 @@ fn inspect_regions(inout out: result.Result, borrow world: model.World) {
         let mut i: u64 = 0;
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
-            if tile.region == region { tiles = tiles + 1; resources = resources + tile.resource; }
+            if tile.region == region { tiles += 1; resources += tile.resource; }
             i += 1;
         }
         let eligible = tiles > 0 && (region + FOCUS()) % 4 == 0;

--- a/examples/caldera/system_combat_prepare.rue
+++ b/examples/caldera/system_combat_prepare.rue
@@ -39,7 +39,7 @@ fn inspect_entities(inout out: result.Result, borrow world: model.World) {
         let eligible = eligible_entity(borrow world, borrow entity);
         let command = eligible && (entity.id + FOCUS() + world.tick) % 2 == 0;
         result.record(inout out, eligible, command, entity_value(borrow world, borrow entity));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -51,7 +51,7 @@ fn inspect_tiles(inout out: result.Result, borrow world: model.World) {
         let command = eligible && tile.resource > FOCUS() % 17;
         result.record(inout out, eligible, command,
             tile.height + tile.resource + tile.terrain * 11 + i % 97);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -62,7 +62,7 @@ fn inspect_timeline(inout out: result.Result, borrow world: model.World) {
         let eligible = (event.kind + FOCUS()) % 4 == 0;
         result.record(inout out, eligible, eligible && event.value > 0,
             event.sequence + event.actor % 257 + event.value);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
@@ -70,7 +70,7 @@ fn inspect_timeline(inout out: result.Result, borrow world: model.World) {
         let eligible = command.accepted && (command.kind + FOCUS()) % 3 == 0;
         result.record(inout out, eligible, eligible,
             command.tick + command.actor % 251 + command.value);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -83,12 +83,12 @@ fn inspect_regions(inout out: result.Result, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region { tiles = tiles + 1; resources = resources + tile.resource; }
-            i = i + 1;
+            i += 1;
         }
         let eligible = tiles > 0 && (region + FOCUS()) % 4 == 0;
         result.record(inout out, eligible, eligible && resources > tiles,
             resources + tiles * 13 + region);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/system_combat_prepare.rue
+++ b/examples/caldera/system_combat_prepare.rue
@@ -82,7 +82,7 @@ fn inspect_regions(inout out: result.Result, borrow world: model.World) {
         let mut i: u64 = 0;
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
-            if tile.region == region { tiles = tiles + 1; resources = resources + tile.resource; }
+            if tile.region == region { tiles += 1; resources += tile.resource; }
             i += 1;
         }
         let eligible = tiles > 0 && (region + FOCUS()) % 4 == 0;

--- a/examples/caldera/system_combat_reconcile.rue
+++ b/examples/caldera/system_combat_reconcile.rue
@@ -39,7 +39,7 @@ fn inspect_entities(inout out: result.Result, borrow world: model.World) {
         let eligible = eligible_entity(borrow world, borrow entity);
         let command = eligible && (entity.id + FOCUS() + world.tick) % 2 == 0;
         result.record(inout out, eligible, command, entity_value(borrow world, borrow entity));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -51,7 +51,7 @@ fn inspect_tiles(inout out: result.Result, borrow world: model.World) {
         let command = eligible && tile.resource > FOCUS() % 17;
         result.record(inout out, eligible, command,
             tile.height + tile.resource + tile.terrain * 11 + i % 97);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -62,7 +62,7 @@ fn inspect_timeline(inout out: result.Result, borrow world: model.World) {
         let eligible = (event.kind + FOCUS()) % 4 == 0;
         result.record(inout out, eligible, eligible && event.value > 0,
             event.sequence + event.actor % 257 + event.value);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
@@ -70,7 +70,7 @@ fn inspect_timeline(inout out: result.Result, borrow world: model.World) {
         let eligible = command.accepted && (command.kind + FOCUS()) % 3 == 0;
         result.record(inout out, eligible, eligible,
             command.tick + command.actor % 251 + command.value);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -83,12 +83,12 @@ fn inspect_regions(inout out: result.Result, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region { tiles = tiles + 1; resources = resources + tile.resource; }
-            i = i + 1;
+            i += 1;
         }
         let eligible = tiles > 0 && (region + FOCUS()) % 4 == 0;
         result.record(inout out, eligible, eligible && resources > tiles,
             resources + tiles * 13 + region);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/system_combat_reconcile.rue
+++ b/examples/caldera/system_combat_reconcile.rue
@@ -82,7 +82,7 @@ fn inspect_regions(inout out: result.Result, borrow world: model.World) {
         let mut i: u64 = 0;
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
-            if tile.region == region { tiles = tiles + 1; resources = resources + tile.resource; }
+            if tile.region == region { tiles += 1; resources += tile.resource; }
             i += 1;
         }
         let eligible = tiles > 0 && (region + FOCUS()) % 4 == 0;

--- a/examples/caldera/system_combat_recover.rue
+++ b/examples/caldera/system_combat_recover.rue
@@ -39,7 +39,7 @@ fn inspect_entities(inout out: result.Result, borrow world: model.World) {
         let eligible = eligible_entity(borrow world, borrow entity);
         let command = eligible && (entity.id + FOCUS() + world.tick) % 2 == 0;
         result.record(inout out, eligible, command, entity_value(borrow world, borrow entity));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -51,7 +51,7 @@ fn inspect_tiles(inout out: result.Result, borrow world: model.World) {
         let command = eligible && tile.resource > FOCUS() % 17;
         result.record(inout out, eligible, command,
             tile.height + tile.resource + tile.terrain * 11 + i % 97);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -62,7 +62,7 @@ fn inspect_timeline(inout out: result.Result, borrow world: model.World) {
         let eligible = (event.kind + FOCUS()) % 4 == 0;
         result.record(inout out, eligible, eligible && event.value > 0,
             event.sequence + event.actor % 257 + event.value);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
@@ -70,7 +70,7 @@ fn inspect_timeline(inout out: result.Result, borrow world: model.World) {
         let eligible = command.accepted && (command.kind + FOCUS()) % 3 == 0;
         result.record(inout out, eligible, eligible,
             command.tick + command.actor % 251 + command.value);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -83,12 +83,12 @@ fn inspect_regions(inout out: result.Result, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region { tiles = tiles + 1; resources = resources + tile.resource; }
-            i = i + 1;
+            i += 1;
         }
         let eligible = tiles > 0 && (region + FOCUS()) % 4 == 0;
         result.record(inout out, eligible, eligible && resources > tiles,
             resources + tiles * 13 + region);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/system_combat_recover.rue
+++ b/examples/caldera/system_combat_recover.rue
@@ -82,7 +82,7 @@ fn inspect_regions(inout out: result.Result, borrow world: model.World) {
         let mut i: u64 = 0;
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
-            if tile.region == region { tiles = tiles + 1; resources = resources + tile.resource; }
+            if tile.region == region { tiles += 1; resources += tile.resource; }
             i += 1;
         }
         let eligible = tiles > 0 && (region + FOCUS()) % 4 == 0;

--- a/examples/caldera/system_combat_replicate.rue
+++ b/examples/caldera/system_combat_replicate.rue
@@ -39,7 +39,7 @@ fn inspect_entities(inout out: result.Result, borrow world: model.World) {
         let eligible = eligible_entity(borrow world, borrow entity);
         let command = eligible && (entity.id + FOCUS() + world.tick) % 2 == 0;
         result.record(inout out, eligible, command, entity_value(borrow world, borrow entity));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -51,7 +51,7 @@ fn inspect_tiles(inout out: result.Result, borrow world: model.World) {
         let command = eligible && tile.resource > FOCUS() % 17;
         result.record(inout out, eligible, command,
             tile.height + tile.resource + tile.terrain * 11 + i % 97);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -62,7 +62,7 @@ fn inspect_timeline(inout out: result.Result, borrow world: model.World) {
         let eligible = (event.kind + FOCUS()) % 4 == 0;
         result.record(inout out, eligible, eligible && event.value > 0,
             event.sequence + event.actor % 257 + event.value);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
@@ -70,7 +70,7 @@ fn inspect_timeline(inout out: result.Result, borrow world: model.World) {
         let eligible = command.accepted && (command.kind + FOCUS()) % 3 == 0;
         result.record(inout out, eligible, eligible,
             command.tick + command.actor % 251 + command.value);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -83,12 +83,12 @@ fn inspect_regions(inout out: result.Result, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region { tiles = tiles + 1; resources = resources + tile.resource; }
-            i = i + 1;
+            i += 1;
         }
         let eligible = tiles > 0 && (region + FOCUS()) % 4 == 0;
         result.record(inout out, eligible, eligible && resources > tiles,
             resources + tiles * 13 + region);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/system_combat_replicate.rue
+++ b/examples/caldera/system_combat_replicate.rue
@@ -82,7 +82,7 @@ fn inspect_regions(inout out: result.Result, borrow world: model.World) {
         let mut i: u64 = 0;
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
-            if tile.region == region { tiles = tiles + 1; resources = resources + tile.resource; }
+            if tile.region == region { tiles += 1; resources += tile.resource; }
             i += 1;
         }
         let eligible = tiles > 0 && (region + FOCUS()) % 4 == 0;

--- a/examples/caldera/system_combat_resolve.rue
+++ b/examples/caldera/system_combat_resolve.rue
@@ -39,7 +39,7 @@ fn inspect_entities(inout out: result.Result, borrow world: model.World) {
         let eligible = eligible_entity(borrow world, borrow entity);
         let command = eligible && (entity.id + FOCUS() + world.tick) % 2 == 0;
         result.record(inout out, eligible, command, entity_value(borrow world, borrow entity));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -51,7 +51,7 @@ fn inspect_tiles(inout out: result.Result, borrow world: model.World) {
         let command = eligible && tile.resource > FOCUS() % 17;
         result.record(inout out, eligible, command,
             tile.height + tile.resource + tile.terrain * 11 + i % 97);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -62,7 +62,7 @@ fn inspect_timeline(inout out: result.Result, borrow world: model.World) {
         let eligible = (event.kind + FOCUS()) % 4 == 0;
         result.record(inout out, eligible, eligible && event.value > 0,
             event.sequence + event.actor % 257 + event.value);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
@@ -70,7 +70,7 @@ fn inspect_timeline(inout out: result.Result, borrow world: model.World) {
         let eligible = command.accepted && (command.kind + FOCUS()) % 3 == 0;
         result.record(inout out, eligible, eligible,
             command.tick + command.actor % 251 + command.value);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -83,12 +83,12 @@ fn inspect_regions(inout out: result.Result, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region { tiles = tiles + 1; resources = resources + tile.resource; }
-            i = i + 1;
+            i += 1;
         }
         let eligible = tiles > 0 && (region + FOCUS()) % 4 == 0;
         result.record(inout out, eligible, eligible && resources > tiles,
             resources + tiles * 13 + region);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/system_combat_resolve.rue
+++ b/examples/caldera/system_combat_resolve.rue
@@ -82,7 +82,7 @@ fn inspect_regions(inout out: result.Result, borrow world: model.World) {
         let mut i: u64 = 0;
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
-            if tile.region == region { tiles = tiles + 1; resources = resources + tile.resource; }
+            if tile.region == region { tiles += 1; resources += tile.resource; }
             i += 1;
         }
         let eligible = tiles > 0 && (region + FOCUS()) % 4 == 0;

--- a/examples/caldera/system_combat_schedule.rue
+++ b/examples/caldera/system_combat_schedule.rue
@@ -39,7 +39,7 @@ fn inspect_entities(inout out: result.Result, borrow world: model.World) {
         let eligible = eligible_entity(borrow world, borrow entity);
         let command = eligible && (entity.id + FOCUS() + world.tick) % 2 == 0;
         result.record(inout out, eligible, command, entity_value(borrow world, borrow entity));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -51,7 +51,7 @@ fn inspect_tiles(inout out: result.Result, borrow world: model.World) {
         let command = eligible && tile.resource > FOCUS() % 17;
         result.record(inout out, eligible, command,
             tile.height + tile.resource + tile.terrain * 11 + i % 97);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -62,7 +62,7 @@ fn inspect_timeline(inout out: result.Result, borrow world: model.World) {
         let eligible = (event.kind + FOCUS()) % 4 == 0;
         result.record(inout out, eligible, eligible && event.value > 0,
             event.sequence + event.actor % 257 + event.value);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
@@ -70,7 +70,7 @@ fn inspect_timeline(inout out: result.Result, borrow world: model.World) {
         let eligible = command.accepted && (command.kind + FOCUS()) % 3 == 0;
         result.record(inout out, eligible, eligible,
             command.tick + command.actor % 251 + command.value);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -83,12 +83,12 @@ fn inspect_regions(inout out: result.Result, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region { tiles = tiles + 1; resources = resources + tile.resource; }
-            i = i + 1;
+            i += 1;
         }
         let eligible = tiles > 0 && (region + FOCUS()) % 4 == 0;
         result.record(inout out, eligible, eligible && resources > tiles,
             resources + tiles * 13 + region);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/system_combat_schedule.rue
+++ b/examples/caldera/system_combat_schedule.rue
@@ -82,7 +82,7 @@ fn inspect_regions(inout out: result.Result, borrow world: model.World) {
         let mut i: u64 = 0;
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
-            if tile.region == region { tiles = tiles + 1; resources = resources + tile.resource; }
+            if tile.region == region { tiles += 1; resources += tile.resource; }
             i += 1;
         }
         let eligible = tiles > 0 && (region + FOCUS()) % 4 == 0;

--- a/examples/caldera/system_combat_validate.rue
+++ b/examples/caldera/system_combat_validate.rue
@@ -39,7 +39,7 @@ fn inspect_entities(inout out: result.Result, borrow world: model.World) {
         let eligible = eligible_entity(borrow world, borrow entity);
         let command = eligible && (entity.id + FOCUS() + world.tick) % 2 == 0;
         result.record(inout out, eligible, command, entity_value(borrow world, borrow entity));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -51,7 +51,7 @@ fn inspect_tiles(inout out: result.Result, borrow world: model.World) {
         let command = eligible && tile.resource > FOCUS() % 17;
         result.record(inout out, eligible, command,
             tile.height + tile.resource + tile.terrain * 11 + i % 97);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -62,7 +62,7 @@ fn inspect_timeline(inout out: result.Result, borrow world: model.World) {
         let eligible = (event.kind + FOCUS()) % 4 == 0;
         result.record(inout out, eligible, eligible && event.value > 0,
             event.sequence + event.actor % 257 + event.value);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
@@ -70,7 +70,7 @@ fn inspect_timeline(inout out: result.Result, borrow world: model.World) {
         let eligible = command.accepted && (command.kind + FOCUS()) % 3 == 0;
         result.record(inout out, eligible, eligible,
             command.tick + command.actor % 251 + command.value);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -83,12 +83,12 @@ fn inspect_regions(inout out: result.Result, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region { tiles = tiles + 1; resources = resources + tile.resource; }
-            i = i + 1;
+            i += 1;
         }
         let eligible = tiles > 0 && (region + FOCUS()) % 4 == 0;
         result.record(inout out, eligible, eligible && resources > tiles,
             resources + tiles * 13 + region);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/system_combat_validate.rue
+++ b/examples/caldera/system_combat_validate.rue
@@ -82,7 +82,7 @@ fn inspect_regions(inout out: result.Result, borrow world: model.World) {
         let mut i: u64 = 0;
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
-            if tile.region == region { tiles = tiles + 1; resources = resources + tile.resource; }
+            if tile.region == region { tiles += 1; resources += tile.resource; }
             i += 1;
         }
         let eligible = tiles > 0 && (region + FOCUS()) % 4 == 0;

--- a/examples/caldera/system_decision_apply.rue
+++ b/examples/caldera/system_decision_apply.rue
@@ -39,7 +39,7 @@ fn inspect_entities(inout out: result.Result, borrow world: model.World) {
         let eligible = eligible_entity(borrow world, borrow entity);
         let command = eligible && (entity.id + FOCUS() + world.tick) % 2 == 0;
         result.record(inout out, eligible, command, entity_value(borrow world, borrow entity));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -51,7 +51,7 @@ fn inspect_tiles(inout out: result.Result, borrow world: model.World) {
         let command = eligible && tile.resource > FOCUS() % 17;
         result.record(inout out, eligible, command,
             tile.height + tile.resource + tile.terrain * 11 + i % 97);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -62,7 +62,7 @@ fn inspect_timeline(inout out: result.Result, borrow world: model.World) {
         let eligible = (event.kind + FOCUS()) % 4 == 0;
         result.record(inout out, eligible, eligible && event.value > 0,
             event.sequence + event.actor % 257 + event.value);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
@@ -70,7 +70,7 @@ fn inspect_timeline(inout out: result.Result, borrow world: model.World) {
         let eligible = command.accepted && (command.kind + FOCUS()) % 3 == 0;
         result.record(inout out, eligible, eligible,
             command.tick + command.actor % 251 + command.value);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -83,12 +83,12 @@ fn inspect_regions(inout out: result.Result, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region { tiles = tiles + 1; resources = resources + tile.resource; }
-            i = i + 1;
+            i += 1;
         }
         let eligible = tiles > 0 && (region + FOCUS()) % 4 == 0;
         result.record(inout out, eligible, eligible && resources > tiles,
             resources + tiles * 13 + region);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/system_decision_apply.rue
+++ b/examples/caldera/system_decision_apply.rue
@@ -82,7 +82,7 @@ fn inspect_regions(inout out: result.Result, borrow world: model.World) {
         let mut i: u64 = 0;
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
-            if tile.region == region { tiles = tiles + 1; resources = resources + tile.resource; }
+            if tile.region == region { tiles += 1; resources += tile.resource; }
             i += 1;
         }
         let eligible = tiles > 0 && (region + FOCUS()) % 4 == 0;

--- a/examples/caldera/system_decision_audit.rue
+++ b/examples/caldera/system_decision_audit.rue
@@ -39,7 +39,7 @@ fn inspect_entities(inout out: result.Result, borrow world: model.World) {
         let eligible = eligible_entity(borrow world, borrow entity);
         let command = eligible && (entity.id + FOCUS() + world.tick) % 2 == 0;
         result.record(inout out, eligible, command, entity_value(borrow world, borrow entity));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -51,7 +51,7 @@ fn inspect_tiles(inout out: result.Result, borrow world: model.World) {
         let command = eligible && tile.resource > FOCUS() % 17;
         result.record(inout out, eligible, command,
             tile.height + tile.resource + tile.terrain * 11 + i % 97);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -62,7 +62,7 @@ fn inspect_timeline(inout out: result.Result, borrow world: model.World) {
         let eligible = (event.kind + FOCUS()) % 4 == 0;
         result.record(inout out, eligible, eligible && event.value > 0,
             event.sequence + event.actor % 257 + event.value);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
@@ -70,7 +70,7 @@ fn inspect_timeline(inout out: result.Result, borrow world: model.World) {
         let eligible = command.accepted && (command.kind + FOCUS()) % 3 == 0;
         result.record(inout out, eligible, eligible,
             command.tick + command.actor % 251 + command.value);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -83,12 +83,12 @@ fn inspect_regions(inout out: result.Result, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region { tiles = tiles + 1; resources = resources + tile.resource; }
-            i = i + 1;
+            i += 1;
         }
         let eligible = tiles > 0 && (region + FOCUS()) % 4 == 0;
         result.record(inout out, eligible, eligible && resources > tiles,
             resources + tiles * 13 + region);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/system_decision_audit.rue
+++ b/examples/caldera/system_decision_audit.rue
@@ -82,7 +82,7 @@ fn inspect_regions(inout out: result.Result, borrow world: model.World) {
         let mut i: u64 = 0;
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
-            if tile.region == region { tiles = tiles + 1; resources = resources + tile.resource; }
+            if tile.region == region { tiles += 1; resources += tile.resource; }
             i += 1;
         }
         let eligible = tiles > 0 && (region + FOCUS()) % 4 == 0;

--- a/examples/caldera/system_decision_bootstrap.rue
+++ b/examples/caldera/system_decision_bootstrap.rue
@@ -39,7 +39,7 @@ fn inspect_entities(inout out: result.Result, borrow world: model.World) {
         let eligible = eligible_entity(borrow world, borrow entity);
         let command = eligible && (entity.id + FOCUS() + world.tick) % 2 == 0;
         result.record(inout out, eligible, command, entity_value(borrow world, borrow entity));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -51,7 +51,7 @@ fn inspect_tiles(inout out: result.Result, borrow world: model.World) {
         let command = eligible && tile.resource > FOCUS() % 17;
         result.record(inout out, eligible, command,
             tile.height + tile.resource + tile.terrain * 11 + i % 97);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -62,7 +62,7 @@ fn inspect_timeline(inout out: result.Result, borrow world: model.World) {
         let eligible = (event.kind + FOCUS()) % 4 == 0;
         result.record(inout out, eligible, eligible && event.value > 0,
             event.sequence + event.actor % 257 + event.value);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
@@ -70,7 +70,7 @@ fn inspect_timeline(inout out: result.Result, borrow world: model.World) {
         let eligible = command.accepted && (command.kind + FOCUS()) % 3 == 0;
         result.record(inout out, eligible, eligible,
             command.tick + command.actor % 251 + command.value);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -83,12 +83,12 @@ fn inspect_regions(inout out: result.Result, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region { tiles = tiles + 1; resources = resources + tile.resource; }
-            i = i + 1;
+            i += 1;
         }
         let eligible = tiles > 0 && (region + FOCUS()) % 4 == 0;
         result.record(inout out, eligible, eligible && resources > tiles,
             resources + tiles * 13 + region);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/system_decision_bootstrap.rue
+++ b/examples/caldera/system_decision_bootstrap.rue
@@ -82,7 +82,7 @@ fn inspect_regions(inout out: result.Result, borrow world: model.World) {
         let mut i: u64 = 0;
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
-            if tile.region == region { tiles = tiles + 1; resources = resources + tile.resource; }
+            if tile.region == region { tiles += 1; resources += tile.resource; }
             i += 1;
         }
         let eligible = tiles > 0 && (region + FOCUS()) % 4 == 0;

--- a/examples/caldera/system_decision_checkpoint.rue
+++ b/examples/caldera/system_decision_checkpoint.rue
@@ -39,7 +39,7 @@ fn inspect_entities(inout out: result.Result, borrow world: model.World) {
         let eligible = eligible_entity(borrow world, borrow entity);
         let command = eligible && (entity.id + FOCUS() + world.tick) % 2 == 0;
         result.record(inout out, eligible, command, entity_value(borrow world, borrow entity));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -51,7 +51,7 @@ fn inspect_tiles(inout out: result.Result, borrow world: model.World) {
         let command = eligible && tile.resource > FOCUS() % 17;
         result.record(inout out, eligible, command,
             tile.height + tile.resource + tile.terrain * 11 + i % 97);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -62,7 +62,7 @@ fn inspect_timeline(inout out: result.Result, borrow world: model.World) {
         let eligible = (event.kind + FOCUS()) % 4 == 0;
         result.record(inout out, eligible, eligible && event.value > 0,
             event.sequence + event.actor % 257 + event.value);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
@@ -70,7 +70,7 @@ fn inspect_timeline(inout out: result.Result, borrow world: model.World) {
         let eligible = command.accepted && (command.kind + FOCUS()) % 3 == 0;
         result.record(inout out, eligible, eligible,
             command.tick + command.actor % 251 + command.value);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -83,12 +83,12 @@ fn inspect_regions(inout out: result.Result, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region { tiles = tiles + 1; resources = resources + tile.resource; }
-            i = i + 1;
+            i += 1;
         }
         let eligible = tiles > 0 && (region + FOCUS()) % 4 == 0;
         result.record(inout out, eligible, eligible && resources > tiles,
             resources + tiles * 13 + region);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/system_decision_checkpoint.rue
+++ b/examples/caldera/system_decision_checkpoint.rue
@@ -82,7 +82,7 @@ fn inspect_regions(inout out: result.Result, borrow world: model.World) {
         let mut i: u64 = 0;
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
-            if tile.region == region { tiles = tiles + 1; resources = resources + tile.resource; }
+            if tile.region == region { tiles += 1; resources += tile.resource; }
             i += 1;
         }
         let eligible = tiles > 0 && (region + FOCUS()) % 4 == 0;

--- a/examples/caldera/system_decision_compact.rue
+++ b/examples/caldera/system_decision_compact.rue
@@ -39,7 +39,7 @@ fn inspect_entities(inout out: result.Result, borrow world: model.World) {
         let eligible = eligible_entity(borrow world, borrow entity);
         let command = eligible && (entity.id + FOCUS() + world.tick) % 2 == 0;
         result.record(inout out, eligible, command, entity_value(borrow world, borrow entity));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -51,7 +51,7 @@ fn inspect_tiles(inout out: result.Result, borrow world: model.World) {
         let command = eligible && tile.resource > FOCUS() % 17;
         result.record(inout out, eligible, command,
             tile.height + tile.resource + tile.terrain * 11 + i % 97);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -62,7 +62,7 @@ fn inspect_timeline(inout out: result.Result, borrow world: model.World) {
         let eligible = (event.kind + FOCUS()) % 4 == 0;
         result.record(inout out, eligible, eligible && event.value > 0,
             event.sequence + event.actor % 257 + event.value);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
@@ -70,7 +70,7 @@ fn inspect_timeline(inout out: result.Result, borrow world: model.World) {
         let eligible = command.accepted && (command.kind + FOCUS()) % 3 == 0;
         result.record(inout out, eligible, eligible,
             command.tick + command.actor % 251 + command.value);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -83,12 +83,12 @@ fn inspect_regions(inout out: result.Result, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region { tiles = tiles + 1; resources = resources + tile.resource; }
-            i = i + 1;
+            i += 1;
         }
         let eligible = tiles > 0 && (region + FOCUS()) % 4 == 0;
         result.record(inout out, eligible, eligible && resources > tiles,
             resources + tiles * 13 + region);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/system_decision_compact.rue
+++ b/examples/caldera/system_decision_compact.rue
@@ -82,7 +82,7 @@ fn inspect_regions(inout out: result.Result, borrow world: model.World) {
         let mut i: u64 = 0;
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
-            if tile.region == region { tiles = tiles + 1; resources = resources + tile.resource; }
+            if tile.region == region { tiles += 1; resources += tile.resource; }
             i += 1;
         }
         let eligible = tiles > 0 && (region + FOCUS()) % 4 == 0;

--- a/examples/caldera/system_decision_discover.rue
+++ b/examples/caldera/system_decision_discover.rue
@@ -39,7 +39,7 @@ fn inspect_entities(inout out: result.Result, borrow world: model.World) {
         let eligible = eligible_entity(borrow world, borrow entity);
         let command = eligible && (entity.id + FOCUS() + world.tick) % 2 == 0;
         result.record(inout out, eligible, command, entity_value(borrow world, borrow entity));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -51,7 +51,7 @@ fn inspect_tiles(inout out: result.Result, borrow world: model.World) {
         let command = eligible && tile.resource > FOCUS() % 17;
         result.record(inout out, eligible, command,
             tile.height + tile.resource + tile.terrain * 11 + i % 97);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -62,7 +62,7 @@ fn inspect_timeline(inout out: result.Result, borrow world: model.World) {
         let eligible = (event.kind + FOCUS()) % 4 == 0;
         result.record(inout out, eligible, eligible && event.value > 0,
             event.sequence + event.actor % 257 + event.value);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
@@ -70,7 +70,7 @@ fn inspect_timeline(inout out: result.Result, borrow world: model.World) {
         let eligible = command.accepted && (command.kind + FOCUS()) % 3 == 0;
         result.record(inout out, eligible, eligible,
             command.tick + command.actor % 251 + command.value);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -83,12 +83,12 @@ fn inspect_regions(inout out: result.Result, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region { tiles = tiles + 1; resources = resources + tile.resource; }
-            i = i + 1;
+            i += 1;
         }
         let eligible = tiles > 0 && (region + FOCUS()) % 4 == 0;
         result.record(inout out, eligible, eligible && resources > tiles,
             resources + tiles * 13 + region);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/system_decision_discover.rue
+++ b/examples/caldera/system_decision_discover.rue
@@ -82,7 +82,7 @@ fn inspect_regions(inout out: result.Result, borrow world: model.World) {
         let mut i: u64 = 0;
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
-            if tile.region == region { tiles = tiles + 1; resources = resources + tile.resource; }
+            if tile.region == region { tiles += 1; resources += tile.resource; }
             i += 1;
         }
         let eligible = tiles > 0 && (region + FOCUS()) % 4 == 0;

--- a/examples/caldera/system_decision_dispatch.rue
+++ b/examples/caldera/system_decision_dispatch.rue
@@ -39,7 +39,7 @@ fn inspect_entities(inout out: result.Result, borrow world: model.World) {
         let eligible = eligible_entity(borrow world, borrow entity);
         let command = eligible && (entity.id + FOCUS() + world.tick) % 2 == 0;
         result.record(inout out, eligible, command, entity_value(borrow world, borrow entity));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -51,7 +51,7 @@ fn inspect_tiles(inout out: result.Result, borrow world: model.World) {
         let command = eligible && tile.resource > FOCUS() % 17;
         result.record(inout out, eligible, command,
             tile.height + tile.resource + tile.terrain * 11 + i % 97);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -62,7 +62,7 @@ fn inspect_timeline(inout out: result.Result, borrow world: model.World) {
         let eligible = (event.kind + FOCUS()) % 4 == 0;
         result.record(inout out, eligible, eligible && event.value > 0,
             event.sequence + event.actor % 257 + event.value);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
@@ -70,7 +70,7 @@ fn inspect_timeline(inout out: result.Result, borrow world: model.World) {
         let eligible = command.accepted && (command.kind + FOCUS()) % 3 == 0;
         result.record(inout out, eligible, eligible,
             command.tick + command.actor % 251 + command.value);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -83,12 +83,12 @@ fn inspect_regions(inout out: result.Result, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region { tiles = tiles + 1; resources = resources + tile.resource; }
-            i = i + 1;
+            i += 1;
         }
         let eligible = tiles > 0 && (region + FOCUS()) % 4 == 0;
         result.record(inout out, eligible, eligible && resources > tiles,
             resources + tiles * 13 + region);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/system_decision_dispatch.rue
+++ b/examples/caldera/system_decision_dispatch.rue
@@ -82,7 +82,7 @@ fn inspect_regions(inout out: result.Result, borrow world: model.World) {
         let mut i: u64 = 0;
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
-            if tile.region == region { tiles = tiles + 1; resources = resources + tile.resource; }
+            if tile.region == region { tiles += 1; resources += tile.resource; }
             i += 1;
         }
         let eligible = tiles > 0 && (region + FOCUS()) % 4 == 0;

--- a/examples/caldera/system_decision_finalize.rue
+++ b/examples/caldera/system_decision_finalize.rue
@@ -39,7 +39,7 @@ fn inspect_entities(inout out: result.Result, borrow world: model.World) {
         let eligible = eligible_entity(borrow world, borrow entity);
         let command = eligible && (entity.id + FOCUS() + world.tick) % 2 == 0;
         result.record(inout out, eligible, command, entity_value(borrow world, borrow entity));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -51,7 +51,7 @@ fn inspect_tiles(inout out: result.Result, borrow world: model.World) {
         let command = eligible && tile.resource > FOCUS() % 17;
         result.record(inout out, eligible, command,
             tile.height + tile.resource + tile.terrain * 11 + i % 97);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -62,7 +62,7 @@ fn inspect_timeline(inout out: result.Result, borrow world: model.World) {
         let eligible = (event.kind + FOCUS()) % 4 == 0;
         result.record(inout out, eligible, eligible && event.value > 0,
             event.sequence + event.actor % 257 + event.value);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
@@ -70,7 +70,7 @@ fn inspect_timeline(inout out: result.Result, borrow world: model.World) {
         let eligible = command.accepted && (command.kind + FOCUS()) % 3 == 0;
         result.record(inout out, eligible, eligible,
             command.tick + command.actor % 251 + command.value);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -83,12 +83,12 @@ fn inspect_regions(inout out: result.Result, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region { tiles = tiles + 1; resources = resources + tile.resource; }
-            i = i + 1;
+            i += 1;
         }
         let eligible = tiles > 0 && (region + FOCUS()) % 4 == 0;
         result.record(inout out, eligible, eligible && resources > tiles,
             resources + tiles * 13 + region);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/system_decision_finalize.rue
+++ b/examples/caldera/system_decision_finalize.rue
@@ -82,7 +82,7 @@ fn inspect_regions(inout out: result.Result, borrow world: model.World) {
         let mut i: u64 = 0;
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
-            if tile.region == region { tiles = tiles + 1; resources = resources + tile.resource; }
+            if tile.region == region { tiles += 1; resources += tile.resource; }
             i += 1;
         }
         let eligible = tiles > 0 && (region + FOCUS()) % 4 == 0;

--- a/examples/caldera/system_decision_observe.rue
+++ b/examples/caldera/system_decision_observe.rue
@@ -39,7 +39,7 @@ fn inspect_entities(inout out: result.Result, borrow world: model.World) {
         let eligible = eligible_entity(borrow world, borrow entity);
         let command = eligible && (entity.id + FOCUS() + world.tick) % 2 == 0;
         result.record(inout out, eligible, command, entity_value(borrow world, borrow entity));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -51,7 +51,7 @@ fn inspect_tiles(inout out: result.Result, borrow world: model.World) {
         let command = eligible && tile.resource > FOCUS() % 17;
         result.record(inout out, eligible, command,
             tile.height + tile.resource + tile.terrain * 11 + i % 97);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -62,7 +62,7 @@ fn inspect_timeline(inout out: result.Result, borrow world: model.World) {
         let eligible = (event.kind + FOCUS()) % 4 == 0;
         result.record(inout out, eligible, eligible && event.value > 0,
             event.sequence + event.actor % 257 + event.value);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
@@ -70,7 +70,7 @@ fn inspect_timeline(inout out: result.Result, borrow world: model.World) {
         let eligible = command.accepted && (command.kind + FOCUS()) % 3 == 0;
         result.record(inout out, eligible, eligible,
             command.tick + command.actor % 251 + command.value);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -83,12 +83,12 @@ fn inspect_regions(inout out: result.Result, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region { tiles = tiles + 1; resources = resources + tile.resource; }
-            i = i + 1;
+            i += 1;
         }
         let eligible = tiles > 0 && (region + FOCUS()) % 4 == 0;
         result.record(inout out, eligible, eligible && resources > tiles,
             resources + tiles * 13 + region);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/system_decision_observe.rue
+++ b/examples/caldera/system_decision_observe.rue
@@ -82,7 +82,7 @@ fn inspect_regions(inout out: result.Result, borrow world: model.World) {
         let mut i: u64 = 0;
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
-            if tile.region == region { tiles = tiles + 1; resources = resources + tile.resource; }
+            if tile.region == region { tiles += 1; resources += tile.resource; }
             i += 1;
         }
         let eligible = tiles > 0 && (region + FOCUS()) % 4 == 0;

--- a/examples/caldera/system_decision_prepare.rue
+++ b/examples/caldera/system_decision_prepare.rue
@@ -39,7 +39,7 @@ fn inspect_entities(inout out: result.Result, borrow world: model.World) {
         let eligible = eligible_entity(borrow world, borrow entity);
         let command = eligible && (entity.id + FOCUS() + world.tick) % 2 == 0;
         result.record(inout out, eligible, command, entity_value(borrow world, borrow entity));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -51,7 +51,7 @@ fn inspect_tiles(inout out: result.Result, borrow world: model.World) {
         let command = eligible && tile.resource > FOCUS() % 17;
         result.record(inout out, eligible, command,
             tile.height + tile.resource + tile.terrain * 11 + i % 97);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -62,7 +62,7 @@ fn inspect_timeline(inout out: result.Result, borrow world: model.World) {
         let eligible = (event.kind + FOCUS()) % 4 == 0;
         result.record(inout out, eligible, eligible && event.value > 0,
             event.sequence + event.actor % 257 + event.value);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
@@ -70,7 +70,7 @@ fn inspect_timeline(inout out: result.Result, borrow world: model.World) {
         let eligible = command.accepted && (command.kind + FOCUS()) % 3 == 0;
         result.record(inout out, eligible, eligible,
             command.tick + command.actor % 251 + command.value);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -83,12 +83,12 @@ fn inspect_regions(inout out: result.Result, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region { tiles = tiles + 1; resources = resources + tile.resource; }
-            i = i + 1;
+            i += 1;
         }
         let eligible = tiles > 0 && (region + FOCUS()) % 4 == 0;
         result.record(inout out, eligible, eligible && resources > tiles,
             resources + tiles * 13 + region);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/system_decision_prepare.rue
+++ b/examples/caldera/system_decision_prepare.rue
@@ -82,7 +82,7 @@ fn inspect_regions(inout out: result.Result, borrow world: model.World) {
         let mut i: u64 = 0;
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
-            if tile.region == region { tiles = tiles + 1; resources = resources + tile.resource; }
+            if tile.region == region { tiles += 1; resources += tile.resource; }
             i += 1;
         }
         let eligible = tiles > 0 && (region + FOCUS()) % 4 == 0;

--- a/examples/caldera/system_decision_reconcile.rue
+++ b/examples/caldera/system_decision_reconcile.rue
@@ -39,7 +39,7 @@ fn inspect_entities(inout out: result.Result, borrow world: model.World) {
         let eligible = eligible_entity(borrow world, borrow entity);
         let command = eligible && (entity.id + FOCUS() + world.tick) % 2 == 0;
         result.record(inout out, eligible, command, entity_value(borrow world, borrow entity));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -51,7 +51,7 @@ fn inspect_tiles(inout out: result.Result, borrow world: model.World) {
         let command = eligible && tile.resource > FOCUS() % 17;
         result.record(inout out, eligible, command,
             tile.height + tile.resource + tile.terrain * 11 + i % 97);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -62,7 +62,7 @@ fn inspect_timeline(inout out: result.Result, borrow world: model.World) {
         let eligible = (event.kind + FOCUS()) % 4 == 0;
         result.record(inout out, eligible, eligible && event.value > 0,
             event.sequence + event.actor % 257 + event.value);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
@@ -70,7 +70,7 @@ fn inspect_timeline(inout out: result.Result, borrow world: model.World) {
         let eligible = command.accepted && (command.kind + FOCUS()) % 3 == 0;
         result.record(inout out, eligible, eligible,
             command.tick + command.actor % 251 + command.value);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -83,12 +83,12 @@ fn inspect_regions(inout out: result.Result, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region { tiles = tiles + 1; resources = resources + tile.resource; }
-            i = i + 1;
+            i += 1;
         }
         let eligible = tiles > 0 && (region + FOCUS()) % 4 == 0;
         result.record(inout out, eligible, eligible && resources > tiles,
             resources + tiles * 13 + region);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/system_decision_reconcile.rue
+++ b/examples/caldera/system_decision_reconcile.rue
@@ -82,7 +82,7 @@ fn inspect_regions(inout out: result.Result, borrow world: model.World) {
         let mut i: u64 = 0;
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
-            if tile.region == region { tiles = tiles + 1; resources = resources + tile.resource; }
+            if tile.region == region { tiles += 1; resources += tile.resource; }
             i += 1;
         }
         let eligible = tiles > 0 && (region + FOCUS()) % 4 == 0;

--- a/examples/caldera/system_decision_recover.rue
+++ b/examples/caldera/system_decision_recover.rue
@@ -39,7 +39,7 @@ fn inspect_entities(inout out: result.Result, borrow world: model.World) {
         let eligible = eligible_entity(borrow world, borrow entity);
         let command = eligible && (entity.id + FOCUS() + world.tick) % 2 == 0;
         result.record(inout out, eligible, command, entity_value(borrow world, borrow entity));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -51,7 +51,7 @@ fn inspect_tiles(inout out: result.Result, borrow world: model.World) {
         let command = eligible && tile.resource > FOCUS() % 17;
         result.record(inout out, eligible, command,
             tile.height + tile.resource + tile.terrain * 11 + i % 97);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -62,7 +62,7 @@ fn inspect_timeline(inout out: result.Result, borrow world: model.World) {
         let eligible = (event.kind + FOCUS()) % 4 == 0;
         result.record(inout out, eligible, eligible && event.value > 0,
             event.sequence + event.actor % 257 + event.value);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
@@ -70,7 +70,7 @@ fn inspect_timeline(inout out: result.Result, borrow world: model.World) {
         let eligible = command.accepted && (command.kind + FOCUS()) % 3 == 0;
         result.record(inout out, eligible, eligible,
             command.tick + command.actor % 251 + command.value);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -83,12 +83,12 @@ fn inspect_regions(inout out: result.Result, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region { tiles = tiles + 1; resources = resources + tile.resource; }
-            i = i + 1;
+            i += 1;
         }
         let eligible = tiles > 0 && (region + FOCUS()) % 4 == 0;
         result.record(inout out, eligible, eligible && resources > tiles,
             resources + tiles * 13 + region);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/system_decision_recover.rue
+++ b/examples/caldera/system_decision_recover.rue
@@ -82,7 +82,7 @@ fn inspect_regions(inout out: result.Result, borrow world: model.World) {
         let mut i: u64 = 0;
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
-            if tile.region == region { tiles = tiles + 1; resources = resources + tile.resource; }
+            if tile.region == region { tiles += 1; resources += tile.resource; }
             i += 1;
         }
         let eligible = tiles > 0 && (region + FOCUS()) % 4 == 0;

--- a/examples/caldera/system_decision_replicate.rue
+++ b/examples/caldera/system_decision_replicate.rue
@@ -39,7 +39,7 @@ fn inspect_entities(inout out: result.Result, borrow world: model.World) {
         let eligible = eligible_entity(borrow world, borrow entity);
         let command = eligible && (entity.id + FOCUS() + world.tick) % 2 == 0;
         result.record(inout out, eligible, command, entity_value(borrow world, borrow entity));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -51,7 +51,7 @@ fn inspect_tiles(inout out: result.Result, borrow world: model.World) {
         let command = eligible && tile.resource > FOCUS() % 17;
         result.record(inout out, eligible, command,
             tile.height + tile.resource + tile.terrain * 11 + i % 97);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -62,7 +62,7 @@ fn inspect_timeline(inout out: result.Result, borrow world: model.World) {
         let eligible = (event.kind + FOCUS()) % 4 == 0;
         result.record(inout out, eligible, eligible && event.value > 0,
             event.sequence + event.actor % 257 + event.value);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
@@ -70,7 +70,7 @@ fn inspect_timeline(inout out: result.Result, borrow world: model.World) {
         let eligible = command.accepted && (command.kind + FOCUS()) % 3 == 0;
         result.record(inout out, eligible, eligible,
             command.tick + command.actor % 251 + command.value);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -83,12 +83,12 @@ fn inspect_regions(inout out: result.Result, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region { tiles = tiles + 1; resources = resources + tile.resource; }
-            i = i + 1;
+            i += 1;
         }
         let eligible = tiles > 0 && (region + FOCUS()) % 4 == 0;
         result.record(inout out, eligible, eligible && resources > tiles,
             resources + tiles * 13 + region);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/system_decision_replicate.rue
+++ b/examples/caldera/system_decision_replicate.rue
@@ -82,7 +82,7 @@ fn inspect_regions(inout out: result.Result, borrow world: model.World) {
         let mut i: u64 = 0;
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
-            if tile.region == region { tiles = tiles + 1; resources = resources + tile.resource; }
+            if tile.region == region { tiles += 1; resources += tile.resource; }
             i += 1;
         }
         let eligible = tiles > 0 && (region + FOCUS()) % 4 == 0;

--- a/examples/caldera/system_decision_resolve.rue
+++ b/examples/caldera/system_decision_resolve.rue
@@ -39,7 +39,7 @@ fn inspect_entities(inout out: result.Result, borrow world: model.World) {
         let eligible = eligible_entity(borrow world, borrow entity);
         let command = eligible && (entity.id + FOCUS() + world.tick) % 2 == 0;
         result.record(inout out, eligible, command, entity_value(borrow world, borrow entity));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -51,7 +51,7 @@ fn inspect_tiles(inout out: result.Result, borrow world: model.World) {
         let command = eligible && tile.resource > FOCUS() % 17;
         result.record(inout out, eligible, command,
             tile.height + tile.resource + tile.terrain * 11 + i % 97);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -62,7 +62,7 @@ fn inspect_timeline(inout out: result.Result, borrow world: model.World) {
         let eligible = (event.kind + FOCUS()) % 4 == 0;
         result.record(inout out, eligible, eligible && event.value > 0,
             event.sequence + event.actor % 257 + event.value);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
@@ -70,7 +70,7 @@ fn inspect_timeline(inout out: result.Result, borrow world: model.World) {
         let eligible = command.accepted && (command.kind + FOCUS()) % 3 == 0;
         result.record(inout out, eligible, eligible,
             command.tick + command.actor % 251 + command.value);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -83,12 +83,12 @@ fn inspect_regions(inout out: result.Result, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region { tiles = tiles + 1; resources = resources + tile.resource; }
-            i = i + 1;
+            i += 1;
         }
         let eligible = tiles > 0 && (region + FOCUS()) % 4 == 0;
         result.record(inout out, eligible, eligible && resources > tiles,
             resources + tiles * 13 + region);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/system_decision_resolve.rue
+++ b/examples/caldera/system_decision_resolve.rue
@@ -82,7 +82,7 @@ fn inspect_regions(inout out: result.Result, borrow world: model.World) {
         let mut i: u64 = 0;
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
-            if tile.region == region { tiles = tiles + 1; resources = resources + tile.resource; }
+            if tile.region == region { tiles += 1; resources += tile.resource; }
             i += 1;
         }
         let eligible = tiles > 0 && (region + FOCUS()) % 4 == 0;

--- a/examples/caldera/system_decision_schedule.rue
+++ b/examples/caldera/system_decision_schedule.rue
@@ -39,7 +39,7 @@ fn inspect_entities(inout out: result.Result, borrow world: model.World) {
         let eligible = eligible_entity(borrow world, borrow entity);
         let command = eligible && (entity.id + FOCUS() + world.tick) % 2 == 0;
         result.record(inout out, eligible, command, entity_value(borrow world, borrow entity));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -51,7 +51,7 @@ fn inspect_tiles(inout out: result.Result, borrow world: model.World) {
         let command = eligible && tile.resource > FOCUS() % 17;
         result.record(inout out, eligible, command,
             tile.height + tile.resource + tile.terrain * 11 + i % 97);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -62,7 +62,7 @@ fn inspect_timeline(inout out: result.Result, borrow world: model.World) {
         let eligible = (event.kind + FOCUS()) % 4 == 0;
         result.record(inout out, eligible, eligible && event.value > 0,
             event.sequence + event.actor % 257 + event.value);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
@@ -70,7 +70,7 @@ fn inspect_timeline(inout out: result.Result, borrow world: model.World) {
         let eligible = command.accepted && (command.kind + FOCUS()) % 3 == 0;
         result.record(inout out, eligible, eligible,
             command.tick + command.actor % 251 + command.value);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -83,12 +83,12 @@ fn inspect_regions(inout out: result.Result, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region { tiles = tiles + 1; resources = resources + tile.resource; }
-            i = i + 1;
+            i += 1;
         }
         let eligible = tiles > 0 && (region + FOCUS()) % 4 == 0;
         result.record(inout out, eligible, eligible && resources > tiles,
             resources + tiles * 13 + region);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/system_decision_schedule.rue
+++ b/examples/caldera/system_decision_schedule.rue
@@ -82,7 +82,7 @@ fn inspect_regions(inout out: result.Result, borrow world: model.World) {
         let mut i: u64 = 0;
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
-            if tile.region == region { tiles = tiles + 1; resources = resources + tile.resource; }
+            if tile.region == region { tiles += 1; resources += tile.resource; }
             i += 1;
         }
         let eligible = tiles > 0 && (region + FOCUS()) % 4 == 0;

--- a/examples/caldera/system_decision_validate.rue
+++ b/examples/caldera/system_decision_validate.rue
@@ -39,7 +39,7 @@ fn inspect_entities(inout out: result.Result, borrow world: model.World) {
         let eligible = eligible_entity(borrow world, borrow entity);
         let command = eligible && (entity.id + FOCUS() + world.tick) % 2 == 0;
         result.record(inout out, eligible, command, entity_value(borrow world, borrow entity));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -51,7 +51,7 @@ fn inspect_tiles(inout out: result.Result, borrow world: model.World) {
         let command = eligible && tile.resource > FOCUS() % 17;
         result.record(inout out, eligible, command,
             tile.height + tile.resource + tile.terrain * 11 + i % 97);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -62,7 +62,7 @@ fn inspect_timeline(inout out: result.Result, borrow world: model.World) {
         let eligible = (event.kind + FOCUS()) % 4 == 0;
         result.record(inout out, eligible, eligible && event.value > 0,
             event.sequence + event.actor % 257 + event.value);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
@@ -70,7 +70,7 @@ fn inspect_timeline(inout out: result.Result, borrow world: model.World) {
         let eligible = command.accepted && (command.kind + FOCUS()) % 3 == 0;
         result.record(inout out, eligible, eligible,
             command.tick + command.actor % 251 + command.value);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -83,12 +83,12 @@ fn inspect_regions(inout out: result.Result, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region { tiles = tiles + 1; resources = resources + tile.resource; }
-            i = i + 1;
+            i += 1;
         }
         let eligible = tiles > 0 && (region + FOCUS()) % 4 == 0;
         result.record(inout out, eligible, eligible && resources > tiles,
             resources + tiles * 13 + region);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/system_decision_validate.rue
+++ b/examples/caldera/system_decision_validate.rue
@@ -82,7 +82,7 @@ fn inspect_regions(inout out: result.Result, borrow world: model.World) {
         let mut i: u64 = 0;
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
-            if tile.region == region { tiles = tiles + 1; resources = resources + tile.resource; }
+            if tile.region == region { tiles += 1; resources += tile.resource; }
             i += 1;
         }
         let eligible = tiles > 0 && (region + FOCUS()) % 4 == 0;

--- a/examples/caldera/system_economy_apply.rue
+++ b/examples/caldera/system_economy_apply.rue
@@ -39,7 +39,7 @@ fn inspect_entities(inout out: result.Result, borrow world: model.World) {
         let eligible = eligible_entity(borrow world, borrow entity);
         let command = eligible && (entity.id + FOCUS() + world.tick) % 2 == 0;
         result.record(inout out, eligible, command, entity_value(borrow world, borrow entity));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -51,7 +51,7 @@ fn inspect_tiles(inout out: result.Result, borrow world: model.World) {
         let command = eligible && tile.resource > FOCUS() % 17;
         result.record(inout out, eligible, command,
             tile.height + tile.resource + tile.terrain * 11 + i % 97);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -62,7 +62,7 @@ fn inspect_timeline(inout out: result.Result, borrow world: model.World) {
         let eligible = (event.kind + FOCUS()) % 4 == 0;
         result.record(inout out, eligible, eligible && event.value > 0,
             event.sequence + event.actor % 257 + event.value);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
@@ -70,7 +70,7 @@ fn inspect_timeline(inout out: result.Result, borrow world: model.World) {
         let eligible = command.accepted && (command.kind + FOCUS()) % 3 == 0;
         result.record(inout out, eligible, eligible,
             command.tick + command.actor % 251 + command.value);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -83,12 +83,12 @@ fn inspect_regions(inout out: result.Result, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region { tiles = tiles + 1; resources = resources + tile.resource; }
-            i = i + 1;
+            i += 1;
         }
         let eligible = tiles > 0 && (region + FOCUS()) % 4 == 0;
         result.record(inout out, eligible, eligible && resources > tiles,
             resources + tiles * 13 + region);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/system_economy_apply.rue
+++ b/examples/caldera/system_economy_apply.rue
@@ -82,7 +82,7 @@ fn inspect_regions(inout out: result.Result, borrow world: model.World) {
         let mut i: u64 = 0;
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
-            if tile.region == region { tiles = tiles + 1; resources = resources + tile.resource; }
+            if tile.region == region { tiles += 1; resources += tile.resource; }
             i += 1;
         }
         let eligible = tiles > 0 && (region + FOCUS()) % 4 == 0;

--- a/examples/caldera/system_economy_audit.rue
+++ b/examples/caldera/system_economy_audit.rue
@@ -39,7 +39,7 @@ fn inspect_entities(inout out: result.Result, borrow world: model.World) {
         let eligible = eligible_entity(borrow world, borrow entity);
         let command = eligible && (entity.id + FOCUS() + world.tick) % 2 == 0;
         result.record(inout out, eligible, command, entity_value(borrow world, borrow entity));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -51,7 +51,7 @@ fn inspect_tiles(inout out: result.Result, borrow world: model.World) {
         let command = eligible && tile.resource > FOCUS() % 17;
         result.record(inout out, eligible, command,
             tile.height + tile.resource + tile.terrain * 11 + i % 97);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -62,7 +62,7 @@ fn inspect_timeline(inout out: result.Result, borrow world: model.World) {
         let eligible = (event.kind + FOCUS()) % 4 == 0;
         result.record(inout out, eligible, eligible && event.value > 0,
             event.sequence + event.actor % 257 + event.value);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
@@ -70,7 +70,7 @@ fn inspect_timeline(inout out: result.Result, borrow world: model.World) {
         let eligible = command.accepted && (command.kind + FOCUS()) % 3 == 0;
         result.record(inout out, eligible, eligible,
             command.tick + command.actor % 251 + command.value);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -83,12 +83,12 @@ fn inspect_regions(inout out: result.Result, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region { tiles = tiles + 1; resources = resources + tile.resource; }
-            i = i + 1;
+            i += 1;
         }
         let eligible = tiles > 0 && (region + FOCUS()) % 4 == 0;
         result.record(inout out, eligible, eligible && resources > tiles,
             resources + tiles * 13 + region);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/system_economy_audit.rue
+++ b/examples/caldera/system_economy_audit.rue
@@ -82,7 +82,7 @@ fn inspect_regions(inout out: result.Result, borrow world: model.World) {
         let mut i: u64 = 0;
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
-            if tile.region == region { tiles = tiles + 1; resources = resources + tile.resource; }
+            if tile.region == region { tiles += 1; resources += tile.resource; }
             i += 1;
         }
         let eligible = tiles > 0 && (region + FOCUS()) % 4 == 0;

--- a/examples/caldera/system_economy_bootstrap.rue
+++ b/examples/caldera/system_economy_bootstrap.rue
@@ -39,7 +39,7 @@ fn inspect_entities(inout out: result.Result, borrow world: model.World) {
         let eligible = eligible_entity(borrow world, borrow entity);
         let command = eligible && (entity.id + FOCUS() + world.tick) % 2 == 0;
         result.record(inout out, eligible, command, entity_value(borrow world, borrow entity));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -51,7 +51,7 @@ fn inspect_tiles(inout out: result.Result, borrow world: model.World) {
         let command = eligible && tile.resource > FOCUS() % 17;
         result.record(inout out, eligible, command,
             tile.height + tile.resource + tile.terrain * 11 + i % 97);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -62,7 +62,7 @@ fn inspect_timeline(inout out: result.Result, borrow world: model.World) {
         let eligible = (event.kind + FOCUS()) % 4 == 0;
         result.record(inout out, eligible, eligible && event.value > 0,
             event.sequence + event.actor % 257 + event.value);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
@@ -70,7 +70,7 @@ fn inspect_timeline(inout out: result.Result, borrow world: model.World) {
         let eligible = command.accepted && (command.kind + FOCUS()) % 3 == 0;
         result.record(inout out, eligible, eligible,
             command.tick + command.actor % 251 + command.value);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -83,12 +83,12 @@ fn inspect_regions(inout out: result.Result, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region { tiles = tiles + 1; resources = resources + tile.resource; }
-            i = i + 1;
+            i += 1;
         }
         let eligible = tiles > 0 && (region + FOCUS()) % 4 == 0;
         result.record(inout out, eligible, eligible && resources > tiles,
             resources + tiles * 13 + region);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/system_economy_bootstrap.rue
+++ b/examples/caldera/system_economy_bootstrap.rue
@@ -82,7 +82,7 @@ fn inspect_regions(inout out: result.Result, borrow world: model.World) {
         let mut i: u64 = 0;
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
-            if tile.region == region { tiles = tiles + 1; resources = resources + tile.resource; }
+            if tile.region == region { tiles += 1; resources += tile.resource; }
             i += 1;
         }
         let eligible = tiles > 0 && (region + FOCUS()) % 4 == 0;

--- a/examples/caldera/system_economy_checkpoint.rue
+++ b/examples/caldera/system_economy_checkpoint.rue
@@ -39,7 +39,7 @@ fn inspect_entities(inout out: result.Result, borrow world: model.World) {
         let eligible = eligible_entity(borrow world, borrow entity);
         let command = eligible && (entity.id + FOCUS() + world.tick) % 2 == 0;
         result.record(inout out, eligible, command, entity_value(borrow world, borrow entity));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -51,7 +51,7 @@ fn inspect_tiles(inout out: result.Result, borrow world: model.World) {
         let command = eligible && tile.resource > FOCUS() % 17;
         result.record(inout out, eligible, command,
             tile.height + tile.resource + tile.terrain * 11 + i % 97);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -62,7 +62,7 @@ fn inspect_timeline(inout out: result.Result, borrow world: model.World) {
         let eligible = (event.kind + FOCUS()) % 4 == 0;
         result.record(inout out, eligible, eligible && event.value > 0,
             event.sequence + event.actor % 257 + event.value);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
@@ -70,7 +70,7 @@ fn inspect_timeline(inout out: result.Result, borrow world: model.World) {
         let eligible = command.accepted && (command.kind + FOCUS()) % 3 == 0;
         result.record(inout out, eligible, eligible,
             command.tick + command.actor % 251 + command.value);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -83,12 +83,12 @@ fn inspect_regions(inout out: result.Result, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region { tiles = tiles + 1; resources = resources + tile.resource; }
-            i = i + 1;
+            i += 1;
         }
         let eligible = tiles > 0 && (region + FOCUS()) % 4 == 0;
         result.record(inout out, eligible, eligible && resources > tiles,
             resources + tiles * 13 + region);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/system_economy_checkpoint.rue
+++ b/examples/caldera/system_economy_checkpoint.rue
@@ -82,7 +82,7 @@ fn inspect_regions(inout out: result.Result, borrow world: model.World) {
         let mut i: u64 = 0;
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
-            if tile.region == region { tiles = tiles + 1; resources = resources + tile.resource; }
+            if tile.region == region { tiles += 1; resources += tile.resource; }
             i += 1;
         }
         let eligible = tiles > 0 && (region + FOCUS()) % 4 == 0;

--- a/examples/caldera/system_economy_compact.rue
+++ b/examples/caldera/system_economy_compact.rue
@@ -39,7 +39,7 @@ fn inspect_entities(inout out: result.Result, borrow world: model.World) {
         let eligible = eligible_entity(borrow world, borrow entity);
         let command = eligible && (entity.id + FOCUS() + world.tick) % 2 == 0;
         result.record(inout out, eligible, command, entity_value(borrow world, borrow entity));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -51,7 +51,7 @@ fn inspect_tiles(inout out: result.Result, borrow world: model.World) {
         let command = eligible && tile.resource > FOCUS() % 17;
         result.record(inout out, eligible, command,
             tile.height + tile.resource + tile.terrain * 11 + i % 97);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -62,7 +62,7 @@ fn inspect_timeline(inout out: result.Result, borrow world: model.World) {
         let eligible = (event.kind + FOCUS()) % 4 == 0;
         result.record(inout out, eligible, eligible && event.value > 0,
             event.sequence + event.actor % 257 + event.value);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
@@ -70,7 +70,7 @@ fn inspect_timeline(inout out: result.Result, borrow world: model.World) {
         let eligible = command.accepted && (command.kind + FOCUS()) % 3 == 0;
         result.record(inout out, eligible, eligible,
             command.tick + command.actor % 251 + command.value);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -83,12 +83,12 @@ fn inspect_regions(inout out: result.Result, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region { tiles = tiles + 1; resources = resources + tile.resource; }
-            i = i + 1;
+            i += 1;
         }
         let eligible = tiles > 0 && (region + FOCUS()) % 4 == 0;
         result.record(inout out, eligible, eligible && resources > tiles,
             resources + tiles * 13 + region);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/system_economy_compact.rue
+++ b/examples/caldera/system_economy_compact.rue
@@ -82,7 +82,7 @@ fn inspect_regions(inout out: result.Result, borrow world: model.World) {
         let mut i: u64 = 0;
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
-            if tile.region == region { tiles = tiles + 1; resources = resources + tile.resource; }
+            if tile.region == region { tiles += 1; resources += tile.resource; }
             i += 1;
         }
         let eligible = tiles > 0 && (region + FOCUS()) % 4 == 0;

--- a/examples/caldera/system_economy_discover.rue
+++ b/examples/caldera/system_economy_discover.rue
@@ -39,7 +39,7 @@ fn inspect_entities(inout out: result.Result, borrow world: model.World) {
         let eligible = eligible_entity(borrow world, borrow entity);
         let command = eligible && (entity.id + FOCUS() + world.tick) % 2 == 0;
         result.record(inout out, eligible, command, entity_value(borrow world, borrow entity));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -51,7 +51,7 @@ fn inspect_tiles(inout out: result.Result, borrow world: model.World) {
         let command = eligible && tile.resource > FOCUS() % 17;
         result.record(inout out, eligible, command,
             tile.height + tile.resource + tile.terrain * 11 + i % 97);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -62,7 +62,7 @@ fn inspect_timeline(inout out: result.Result, borrow world: model.World) {
         let eligible = (event.kind + FOCUS()) % 4 == 0;
         result.record(inout out, eligible, eligible && event.value > 0,
             event.sequence + event.actor % 257 + event.value);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
@@ -70,7 +70,7 @@ fn inspect_timeline(inout out: result.Result, borrow world: model.World) {
         let eligible = command.accepted && (command.kind + FOCUS()) % 3 == 0;
         result.record(inout out, eligible, eligible,
             command.tick + command.actor % 251 + command.value);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -83,12 +83,12 @@ fn inspect_regions(inout out: result.Result, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region { tiles = tiles + 1; resources = resources + tile.resource; }
-            i = i + 1;
+            i += 1;
         }
         let eligible = tiles > 0 && (region + FOCUS()) % 4 == 0;
         result.record(inout out, eligible, eligible && resources > tiles,
             resources + tiles * 13 + region);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/system_economy_discover.rue
+++ b/examples/caldera/system_economy_discover.rue
@@ -82,7 +82,7 @@ fn inspect_regions(inout out: result.Result, borrow world: model.World) {
         let mut i: u64 = 0;
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
-            if tile.region == region { tiles = tiles + 1; resources = resources + tile.resource; }
+            if tile.region == region { tiles += 1; resources += tile.resource; }
             i += 1;
         }
         let eligible = tiles > 0 && (region + FOCUS()) % 4 == 0;

--- a/examples/caldera/system_economy_dispatch.rue
+++ b/examples/caldera/system_economy_dispatch.rue
@@ -39,7 +39,7 @@ fn inspect_entities(inout out: result.Result, borrow world: model.World) {
         let eligible = eligible_entity(borrow world, borrow entity);
         let command = eligible && (entity.id + FOCUS() + world.tick) % 2 == 0;
         result.record(inout out, eligible, command, entity_value(borrow world, borrow entity));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -51,7 +51,7 @@ fn inspect_tiles(inout out: result.Result, borrow world: model.World) {
         let command = eligible && tile.resource > FOCUS() % 17;
         result.record(inout out, eligible, command,
             tile.height + tile.resource + tile.terrain * 11 + i % 97);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -62,7 +62,7 @@ fn inspect_timeline(inout out: result.Result, borrow world: model.World) {
         let eligible = (event.kind + FOCUS()) % 4 == 0;
         result.record(inout out, eligible, eligible && event.value > 0,
             event.sequence + event.actor % 257 + event.value);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
@@ -70,7 +70,7 @@ fn inspect_timeline(inout out: result.Result, borrow world: model.World) {
         let eligible = command.accepted && (command.kind + FOCUS()) % 3 == 0;
         result.record(inout out, eligible, eligible,
             command.tick + command.actor % 251 + command.value);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -83,12 +83,12 @@ fn inspect_regions(inout out: result.Result, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region { tiles = tiles + 1; resources = resources + tile.resource; }
-            i = i + 1;
+            i += 1;
         }
         let eligible = tiles > 0 && (region + FOCUS()) % 4 == 0;
         result.record(inout out, eligible, eligible && resources > tiles,
             resources + tiles * 13 + region);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/system_economy_dispatch.rue
+++ b/examples/caldera/system_economy_dispatch.rue
@@ -82,7 +82,7 @@ fn inspect_regions(inout out: result.Result, borrow world: model.World) {
         let mut i: u64 = 0;
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
-            if tile.region == region { tiles = tiles + 1; resources = resources + tile.resource; }
+            if tile.region == region { tiles += 1; resources += tile.resource; }
             i += 1;
         }
         let eligible = tiles > 0 && (region + FOCUS()) % 4 == 0;

--- a/examples/caldera/system_economy_finalize.rue
+++ b/examples/caldera/system_economy_finalize.rue
@@ -39,7 +39,7 @@ fn inspect_entities(inout out: result.Result, borrow world: model.World) {
         let eligible = eligible_entity(borrow world, borrow entity);
         let command = eligible && (entity.id + FOCUS() + world.tick) % 2 == 0;
         result.record(inout out, eligible, command, entity_value(borrow world, borrow entity));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -51,7 +51,7 @@ fn inspect_tiles(inout out: result.Result, borrow world: model.World) {
         let command = eligible && tile.resource > FOCUS() % 17;
         result.record(inout out, eligible, command,
             tile.height + tile.resource + tile.terrain * 11 + i % 97);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -62,7 +62,7 @@ fn inspect_timeline(inout out: result.Result, borrow world: model.World) {
         let eligible = (event.kind + FOCUS()) % 4 == 0;
         result.record(inout out, eligible, eligible && event.value > 0,
             event.sequence + event.actor % 257 + event.value);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
@@ -70,7 +70,7 @@ fn inspect_timeline(inout out: result.Result, borrow world: model.World) {
         let eligible = command.accepted && (command.kind + FOCUS()) % 3 == 0;
         result.record(inout out, eligible, eligible,
             command.tick + command.actor % 251 + command.value);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -83,12 +83,12 @@ fn inspect_regions(inout out: result.Result, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region { tiles = tiles + 1; resources = resources + tile.resource; }
-            i = i + 1;
+            i += 1;
         }
         let eligible = tiles > 0 && (region + FOCUS()) % 4 == 0;
         result.record(inout out, eligible, eligible && resources > tiles,
             resources + tiles * 13 + region);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/system_economy_finalize.rue
+++ b/examples/caldera/system_economy_finalize.rue
@@ -82,7 +82,7 @@ fn inspect_regions(inout out: result.Result, borrow world: model.World) {
         let mut i: u64 = 0;
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
-            if tile.region == region { tiles = tiles + 1; resources = resources + tile.resource; }
+            if tile.region == region { tiles += 1; resources += tile.resource; }
             i += 1;
         }
         let eligible = tiles > 0 && (region + FOCUS()) % 4 == 0;

--- a/examples/caldera/system_economy_observe.rue
+++ b/examples/caldera/system_economy_observe.rue
@@ -39,7 +39,7 @@ fn inspect_entities(inout out: result.Result, borrow world: model.World) {
         let eligible = eligible_entity(borrow world, borrow entity);
         let command = eligible && (entity.id + FOCUS() + world.tick) % 2 == 0;
         result.record(inout out, eligible, command, entity_value(borrow world, borrow entity));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -51,7 +51,7 @@ fn inspect_tiles(inout out: result.Result, borrow world: model.World) {
         let command = eligible && tile.resource > FOCUS() % 17;
         result.record(inout out, eligible, command,
             tile.height + tile.resource + tile.terrain * 11 + i % 97);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -62,7 +62,7 @@ fn inspect_timeline(inout out: result.Result, borrow world: model.World) {
         let eligible = (event.kind + FOCUS()) % 4 == 0;
         result.record(inout out, eligible, eligible && event.value > 0,
             event.sequence + event.actor % 257 + event.value);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
@@ -70,7 +70,7 @@ fn inspect_timeline(inout out: result.Result, borrow world: model.World) {
         let eligible = command.accepted && (command.kind + FOCUS()) % 3 == 0;
         result.record(inout out, eligible, eligible,
             command.tick + command.actor % 251 + command.value);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -83,12 +83,12 @@ fn inspect_regions(inout out: result.Result, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region { tiles = tiles + 1; resources = resources + tile.resource; }
-            i = i + 1;
+            i += 1;
         }
         let eligible = tiles > 0 && (region + FOCUS()) % 4 == 0;
         result.record(inout out, eligible, eligible && resources > tiles,
             resources + tiles * 13 + region);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/system_economy_observe.rue
+++ b/examples/caldera/system_economy_observe.rue
@@ -82,7 +82,7 @@ fn inspect_regions(inout out: result.Result, borrow world: model.World) {
         let mut i: u64 = 0;
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
-            if tile.region == region { tiles = tiles + 1; resources = resources + tile.resource; }
+            if tile.region == region { tiles += 1; resources += tile.resource; }
             i += 1;
         }
         let eligible = tiles > 0 && (region + FOCUS()) % 4 == 0;

--- a/examples/caldera/system_economy_prepare.rue
+++ b/examples/caldera/system_economy_prepare.rue
@@ -39,7 +39,7 @@ fn inspect_entities(inout out: result.Result, borrow world: model.World) {
         let eligible = eligible_entity(borrow world, borrow entity);
         let command = eligible && (entity.id + FOCUS() + world.tick) % 2 == 0;
         result.record(inout out, eligible, command, entity_value(borrow world, borrow entity));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -51,7 +51,7 @@ fn inspect_tiles(inout out: result.Result, borrow world: model.World) {
         let command = eligible && tile.resource > FOCUS() % 17;
         result.record(inout out, eligible, command,
             tile.height + tile.resource + tile.terrain * 11 + i % 97);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -62,7 +62,7 @@ fn inspect_timeline(inout out: result.Result, borrow world: model.World) {
         let eligible = (event.kind + FOCUS()) % 4 == 0;
         result.record(inout out, eligible, eligible && event.value > 0,
             event.sequence + event.actor % 257 + event.value);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
@@ -70,7 +70,7 @@ fn inspect_timeline(inout out: result.Result, borrow world: model.World) {
         let eligible = command.accepted && (command.kind + FOCUS()) % 3 == 0;
         result.record(inout out, eligible, eligible,
             command.tick + command.actor % 251 + command.value);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -83,12 +83,12 @@ fn inspect_regions(inout out: result.Result, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region { tiles = tiles + 1; resources = resources + tile.resource; }
-            i = i + 1;
+            i += 1;
         }
         let eligible = tiles > 0 && (region + FOCUS()) % 4 == 0;
         result.record(inout out, eligible, eligible && resources > tiles,
             resources + tiles * 13 + region);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/system_economy_prepare.rue
+++ b/examples/caldera/system_economy_prepare.rue
@@ -82,7 +82,7 @@ fn inspect_regions(inout out: result.Result, borrow world: model.World) {
         let mut i: u64 = 0;
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
-            if tile.region == region { tiles = tiles + 1; resources = resources + tile.resource; }
+            if tile.region == region { tiles += 1; resources += tile.resource; }
             i += 1;
         }
         let eligible = tiles > 0 && (region + FOCUS()) % 4 == 0;

--- a/examples/caldera/system_economy_reconcile.rue
+++ b/examples/caldera/system_economy_reconcile.rue
@@ -39,7 +39,7 @@ fn inspect_entities(inout out: result.Result, borrow world: model.World) {
         let eligible = eligible_entity(borrow world, borrow entity);
         let command = eligible && (entity.id + FOCUS() + world.tick) % 2 == 0;
         result.record(inout out, eligible, command, entity_value(borrow world, borrow entity));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -51,7 +51,7 @@ fn inspect_tiles(inout out: result.Result, borrow world: model.World) {
         let command = eligible && tile.resource > FOCUS() % 17;
         result.record(inout out, eligible, command,
             tile.height + tile.resource + tile.terrain * 11 + i % 97);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -62,7 +62,7 @@ fn inspect_timeline(inout out: result.Result, borrow world: model.World) {
         let eligible = (event.kind + FOCUS()) % 4 == 0;
         result.record(inout out, eligible, eligible && event.value > 0,
             event.sequence + event.actor % 257 + event.value);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
@@ -70,7 +70,7 @@ fn inspect_timeline(inout out: result.Result, borrow world: model.World) {
         let eligible = command.accepted && (command.kind + FOCUS()) % 3 == 0;
         result.record(inout out, eligible, eligible,
             command.tick + command.actor % 251 + command.value);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -83,12 +83,12 @@ fn inspect_regions(inout out: result.Result, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region { tiles = tiles + 1; resources = resources + tile.resource; }
-            i = i + 1;
+            i += 1;
         }
         let eligible = tiles > 0 && (region + FOCUS()) % 4 == 0;
         result.record(inout out, eligible, eligible && resources > tiles,
             resources + tiles * 13 + region);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/system_economy_reconcile.rue
+++ b/examples/caldera/system_economy_reconcile.rue
@@ -82,7 +82,7 @@ fn inspect_regions(inout out: result.Result, borrow world: model.World) {
         let mut i: u64 = 0;
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
-            if tile.region == region { tiles = tiles + 1; resources = resources + tile.resource; }
+            if tile.region == region { tiles += 1; resources += tile.resource; }
             i += 1;
         }
         let eligible = tiles > 0 && (region + FOCUS()) % 4 == 0;

--- a/examples/caldera/system_economy_recover.rue
+++ b/examples/caldera/system_economy_recover.rue
@@ -39,7 +39,7 @@ fn inspect_entities(inout out: result.Result, borrow world: model.World) {
         let eligible = eligible_entity(borrow world, borrow entity);
         let command = eligible && (entity.id + FOCUS() + world.tick) % 2 == 0;
         result.record(inout out, eligible, command, entity_value(borrow world, borrow entity));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -51,7 +51,7 @@ fn inspect_tiles(inout out: result.Result, borrow world: model.World) {
         let command = eligible && tile.resource > FOCUS() % 17;
         result.record(inout out, eligible, command,
             tile.height + tile.resource + tile.terrain * 11 + i % 97);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -62,7 +62,7 @@ fn inspect_timeline(inout out: result.Result, borrow world: model.World) {
         let eligible = (event.kind + FOCUS()) % 4 == 0;
         result.record(inout out, eligible, eligible && event.value > 0,
             event.sequence + event.actor % 257 + event.value);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
@@ -70,7 +70,7 @@ fn inspect_timeline(inout out: result.Result, borrow world: model.World) {
         let eligible = command.accepted && (command.kind + FOCUS()) % 3 == 0;
         result.record(inout out, eligible, eligible,
             command.tick + command.actor % 251 + command.value);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -83,12 +83,12 @@ fn inspect_regions(inout out: result.Result, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region { tiles = tiles + 1; resources = resources + tile.resource; }
-            i = i + 1;
+            i += 1;
         }
         let eligible = tiles > 0 && (region + FOCUS()) % 4 == 0;
         result.record(inout out, eligible, eligible && resources > tiles,
             resources + tiles * 13 + region);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/system_economy_recover.rue
+++ b/examples/caldera/system_economy_recover.rue
@@ -82,7 +82,7 @@ fn inspect_regions(inout out: result.Result, borrow world: model.World) {
         let mut i: u64 = 0;
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
-            if tile.region == region { tiles = tiles + 1; resources = resources + tile.resource; }
+            if tile.region == region { tiles += 1; resources += tile.resource; }
             i += 1;
         }
         let eligible = tiles > 0 && (region + FOCUS()) % 4 == 0;

--- a/examples/caldera/system_economy_replicate.rue
+++ b/examples/caldera/system_economy_replicate.rue
@@ -39,7 +39,7 @@ fn inspect_entities(inout out: result.Result, borrow world: model.World) {
         let eligible = eligible_entity(borrow world, borrow entity);
         let command = eligible && (entity.id + FOCUS() + world.tick) % 2 == 0;
         result.record(inout out, eligible, command, entity_value(borrow world, borrow entity));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -51,7 +51,7 @@ fn inspect_tiles(inout out: result.Result, borrow world: model.World) {
         let command = eligible && tile.resource > FOCUS() % 17;
         result.record(inout out, eligible, command,
             tile.height + tile.resource + tile.terrain * 11 + i % 97);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -62,7 +62,7 @@ fn inspect_timeline(inout out: result.Result, borrow world: model.World) {
         let eligible = (event.kind + FOCUS()) % 4 == 0;
         result.record(inout out, eligible, eligible && event.value > 0,
             event.sequence + event.actor % 257 + event.value);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
@@ -70,7 +70,7 @@ fn inspect_timeline(inout out: result.Result, borrow world: model.World) {
         let eligible = command.accepted && (command.kind + FOCUS()) % 3 == 0;
         result.record(inout out, eligible, eligible,
             command.tick + command.actor % 251 + command.value);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -83,12 +83,12 @@ fn inspect_regions(inout out: result.Result, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region { tiles = tiles + 1; resources = resources + tile.resource; }
-            i = i + 1;
+            i += 1;
         }
         let eligible = tiles > 0 && (region + FOCUS()) % 4 == 0;
         result.record(inout out, eligible, eligible && resources > tiles,
             resources + tiles * 13 + region);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/system_economy_replicate.rue
+++ b/examples/caldera/system_economy_replicate.rue
@@ -82,7 +82,7 @@ fn inspect_regions(inout out: result.Result, borrow world: model.World) {
         let mut i: u64 = 0;
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
-            if tile.region == region { tiles = tiles + 1; resources = resources + tile.resource; }
+            if tile.region == region { tiles += 1; resources += tile.resource; }
             i += 1;
         }
         let eligible = tiles > 0 && (region + FOCUS()) % 4 == 0;

--- a/examples/caldera/system_economy_resolve.rue
+++ b/examples/caldera/system_economy_resolve.rue
@@ -39,7 +39,7 @@ fn inspect_entities(inout out: result.Result, borrow world: model.World) {
         let eligible = eligible_entity(borrow world, borrow entity);
         let command = eligible && (entity.id + FOCUS() + world.tick) % 2 == 0;
         result.record(inout out, eligible, command, entity_value(borrow world, borrow entity));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -51,7 +51,7 @@ fn inspect_tiles(inout out: result.Result, borrow world: model.World) {
         let command = eligible && tile.resource > FOCUS() % 17;
         result.record(inout out, eligible, command,
             tile.height + tile.resource + tile.terrain * 11 + i % 97);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -62,7 +62,7 @@ fn inspect_timeline(inout out: result.Result, borrow world: model.World) {
         let eligible = (event.kind + FOCUS()) % 4 == 0;
         result.record(inout out, eligible, eligible && event.value > 0,
             event.sequence + event.actor % 257 + event.value);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
@@ -70,7 +70,7 @@ fn inspect_timeline(inout out: result.Result, borrow world: model.World) {
         let eligible = command.accepted && (command.kind + FOCUS()) % 3 == 0;
         result.record(inout out, eligible, eligible,
             command.tick + command.actor % 251 + command.value);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -83,12 +83,12 @@ fn inspect_regions(inout out: result.Result, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region { tiles = tiles + 1; resources = resources + tile.resource; }
-            i = i + 1;
+            i += 1;
         }
         let eligible = tiles > 0 && (region + FOCUS()) % 4 == 0;
         result.record(inout out, eligible, eligible && resources > tiles,
             resources + tiles * 13 + region);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/system_economy_resolve.rue
+++ b/examples/caldera/system_economy_resolve.rue
@@ -82,7 +82,7 @@ fn inspect_regions(inout out: result.Result, borrow world: model.World) {
         let mut i: u64 = 0;
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
-            if tile.region == region { tiles = tiles + 1; resources = resources + tile.resource; }
+            if tile.region == region { tiles += 1; resources += tile.resource; }
             i += 1;
         }
         let eligible = tiles > 0 && (region + FOCUS()) % 4 == 0;

--- a/examples/caldera/system_economy_schedule.rue
+++ b/examples/caldera/system_economy_schedule.rue
@@ -39,7 +39,7 @@ fn inspect_entities(inout out: result.Result, borrow world: model.World) {
         let eligible = eligible_entity(borrow world, borrow entity);
         let command = eligible && (entity.id + FOCUS() + world.tick) % 2 == 0;
         result.record(inout out, eligible, command, entity_value(borrow world, borrow entity));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -51,7 +51,7 @@ fn inspect_tiles(inout out: result.Result, borrow world: model.World) {
         let command = eligible && tile.resource > FOCUS() % 17;
         result.record(inout out, eligible, command,
             tile.height + tile.resource + tile.terrain * 11 + i % 97);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -62,7 +62,7 @@ fn inspect_timeline(inout out: result.Result, borrow world: model.World) {
         let eligible = (event.kind + FOCUS()) % 4 == 0;
         result.record(inout out, eligible, eligible && event.value > 0,
             event.sequence + event.actor % 257 + event.value);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
@@ -70,7 +70,7 @@ fn inspect_timeline(inout out: result.Result, borrow world: model.World) {
         let eligible = command.accepted && (command.kind + FOCUS()) % 3 == 0;
         result.record(inout out, eligible, eligible,
             command.tick + command.actor % 251 + command.value);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -83,12 +83,12 @@ fn inspect_regions(inout out: result.Result, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region { tiles = tiles + 1; resources = resources + tile.resource; }
-            i = i + 1;
+            i += 1;
         }
         let eligible = tiles > 0 && (region + FOCUS()) % 4 == 0;
         result.record(inout out, eligible, eligible && resources > tiles,
             resources + tiles * 13 + region);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/system_economy_schedule.rue
+++ b/examples/caldera/system_economy_schedule.rue
@@ -82,7 +82,7 @@ fn inspect_regions(inout out: result.Result, borrow world: model.World) {
         let mut i: u64 = 0;
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
-            if tile.region == region { tiles = tiles + 1; resources = resources + tile.resource; }
+            if tile.region == region { tiles += 1; resources += tile.resource; }
             i += 1;
         }
         let eligible = tiles > 0 && (region + FOCUS()) % 4 == 0;

--- a/examples/caldera/system_economy_validate.rue
+++ b/examples/caldera/system_economy_validate.rue
@@ -39,7 +39,7 @@ fn inspect_entities(inout out: result.Result, borrow world: model.World) {
         let eligible = eligible_entity(borrow world, borrow entity);
         let command = eligible && (entity.id + FOCUS() + world.tick) % 2 == 0;
         result.record(inout out, eligible, command, entity_value(borrow world, borrow entity));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -51,7 +51,7 @@ fn inspect_tiles(inout out: result.Result, borrow world: model.World) {
         let command = eligible && tile.resource > FOCUS() % 17;
         result.record(inout out, eligible, command,
             tile.height + tile.resource + tile.terrain * 11 + i % 97);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -62,7 +62,7 @@ fn inspect_timeline(inout out: result.Result, borrow world: model.World) {
         let eligible = (event.kind + FOCUS()) % 4 == 0;
         result.record(inout out, eligible, eligible && event.value > 0,
             event.sequence + event.actor % 257 + event.value);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
@@ -70,7 +70,7 @@ fn inspect_timeline(inout out: result.Result, borrow world: model.World) {
         let eligible = command.accepted && (command.kind + FOCUS()) % 3 == 0;
         result.record(inout out, eligible, eligible,
             command.tick + command.actor % 251 + command.value);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -83,12 +83,12 @@ fn inspect_regions(inout out: result.Result, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region { tiles = tiles + 1; resources = resources + tile.resource; }
-            i = i + 1;
+            i += 1;
         }
         let eligible = tiles > 0 && (region + FOCUS()) % 4 == 0;
         result.record(inout out, eligible, eligible && resources > tiles,
             resources + tiles * 13 + region);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/system_economy_validate.rue
+++ b/examples/caldera/system_economy_validate.rue
@@ -82,7 +82,7 @@ fn inspect_regions(inout out: result.Result, borrow world: model.World) {
         let mut i: u64 = 0;
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
-            if tile.region == region { tiles = tiles + 1; resources = resources + tile.resource; }
+            if tile.region == region { tiles += 1; resources += tile.resource; }
             i += 1;
         }
         let eligible = tiles > 0 && (region + FOCUS()) % 4 == 0;

--- a/examples/caldera/system_lifecycle_apply.rue
+++ b/examples/caldera/system_lifecycle_apply.rue
@@ -39,7 +39,7 @@ fn inspect_entities(inout out: result.Result, borrow world: model.World) {
         let eligible = eligible_entity(borrow world, borrow entity);
         let command = eligible && (entity.id + FOCUS() + world.tick) % 2 == 0;
         result.record(inout out, eligible, command, entity_value(borrow world, borrow entity));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -51,7 +51,7 @@ fn inspect_tiles(inout out: result.Result, borrow world: model.World) {
         let command = eligible && tile.resource > FOCUS() % 17;
         result.record(inout out, eligible, command,
             tile.height + tile.resource + tile.terrain * 11 + i % 97);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -62,7 +62,7 @@ fn inspect_timeline(inout out: result.Result, borrow world: model.World) {
         let eligible = (event.kind + FOCUS()) % 4 == 0;
         result.record(inout out, eligible, eligible && event.value > 0,
             event.sequence + event.actor % 257 + event.value);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
@@ -70,7 +70,7 @@ fn inspect_timeline(inout out: result.Result, borrow world: model.World) {
         let eligible = command.accepted && (command.kind + FOCUS()) % 3 == 0;
         result.record(inout out, eligible, eligible,
             command.tick + command.actor % 251 + command.value);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -83,12 +83,12 @@ fn inspect_regions(inout out: result.Result, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region { tiles = tiles + 1; resources = resources + tile.resource; }
-            i = i + 1;
+            i += 1;
         }
         let eligible = tiles > 0 && (region + FOCUS()) % 4 == 0;
         result.record(inout out, eligible, eligible && resources > tiles,
             resources + tiles * 13 + region);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/system_lifecycle_apply.rue
+++ b/examples/caldera/system_lifecycle_apply.rue
@@ -82,7 +82,7 @@ fn inspect_regions(inout out: result.Result, borrow world: model.World) {
         let mut i: u64 = 0;
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
-            if tile.region == region { tiles = tiles + 1; resources = resources + tile.resource; }
+            if tile.region == region { tiles += 1; resources += tile.resource; }
             i += 1;
         }
         let eligible = tiles > 0 && (region + FOCUS()) % 4 == 0;

--- a/examples/caldera/system_lifecycle_audit.rue
+++ b/examples/caldera/system_lifecycle_audit.rue
@@ -39,7 +39,7 @@ fn inspect_entities(inout out: result.Result, borrow world: model.World) {
         let eligible = eligible_entity(borrow world, borrow entity);
         let command = eligible && (entity.id + FOCUS() + world.tick) % 2 == 0;
         result.record(inout out, eligible, command, entity_value(borrow world, borrow entity));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -51,7 +51,7 @@ fn inspect_tiles(inout out: result.Result, borrow world: model.World) {
         let command = eligible && tile.resource > FOCUS() % 17;
         result.record(inout out, eligible, command,
             tile.height + tile.resource + tile.terrain * 11 + i % 97);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -62,7 +62,7 @@ fn inspect_timeline(inout out: result.Result, borrow world: model.World) {
         let eligible = (event.kind + FOCUS()) % 4 == 0;
         result.record(inout out, eligible, eligible && event.value > 0,
             event.sequence + event.actor % 257 + event.value);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
@@ -70,7 +70,7 @@ fn inspect_timeline(inout out: result.Result, borrow world: model.World) {
         let eligible = command.accepted && (command.kind + FOCUS()) % 3 == 0;
         result.record(inout out, eligible, eligible,
             command.tick + command.actor % 251 + command.value);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -83,12 +83,12 @@ fn inspect_regions(inout out: result.Result, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region { tiles = tiles + 1; resources = resources + tile.resource; }
-            i = i + 1;
+            i += 1;
         }
         let eligible = tiles > 0 && (region + FOCUS()) % 4 == 0;
         result.record(inout out, eligible, eligible && resources > tiles,
             resources + tiles * 13 + region);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/system_lifecycle_audit.rue
+++ b/examples/caldera/system_lifecycle_audit.rue
@@ -82,7 +82,7 @@ fn inspect_regions(inout out: result.Result, borrow world: model.World) {
         let mut i: u64 = 0;
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
-            if tile.region == region { tiles = tiles + 1; resources = resources + tile.resource; }
+            if tile.region == region { tiles += 1; resources += tile.resource; }
             i += 1;
         }
         let eligible = tiles > 0 && (region + FOCUS()) % 4 == 0;

--- a/examples/caldera/system_lifecycle_bootstrap.rue
+++ b/examples/caldera/system_lifecycle_bootstrap.rue
@@ -39,7 +39,7 @@ fn inspect_entities(inout out: result.Result, borrow world: model.World) {
         let eligible = eligible_entity(borrow world, borrow entity);
         let command = eligible && (entity.id + FOCUS() + world.tick) % 2 == 0;
         result.record(inout out, eligible, command, entity_value(borrow world, borrow entity));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -51,7 +51,7 @@ fn inspect_tiles(inout out: result.Result, borrow world: model.World) {
         let command = eligible && tile.resource > FOCUS() % 17;
         result.record(inout out, eligible, command,
             tile.height + tile.resource + tile.terrain * 11 + i % 97);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -62,7 +62,7 @@ fn inspect_timeline(inout out: result.Result, borrow world: model.World) {
         let eligible = (event.kind + FOCUS()) % 4 == 0;
         result.record(inout out, eligible, eligible && event.value > 0,
             event.sequence + event.actor % 257 + event.value);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
@@ -70,7 +70,7 @@ fn inspect_timeline(inout out: result.Result, borrow world: model.World) {
         let eligible = command.accepted && (command.kind + FOCUS()) % 3 == 0;
         result.record(inout out, eligible, eligible,
             command.tick + command.actor % 251 + command.value);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -83,12 +83,12 @@ fn inspect_regions(inout out: result.Result, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region { tiles = tiles + 1; resources = resources + tile.resource; }
-            i = i + 1;
+            i += 1;
         }
         let eligible = tiles > 0 && (region + FOCUS()) % 4 == 0;
         result.record(inout out, eligible, eligible && resources > tiles,
             resources + tiles * 13 + region);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/system_lifecycle_bootstrap.rue
+++ b/examples/caldera/system_lifecycle_bootstrap.rue
@@ -82,7 +82,7 @@ fn inspect_regions(inout out: result.Result, borrow world: model.World) {
         let mut i: u64 = 0;
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
-            if tile.region == region { tiles = tiles + 1; resources = resources + tile.resource; }
+            if tile.region == region { tiles += 1; resources += tile.resource; }
             i += 1;
         }
         let eligible = tiles > 0 && (region + FOCUS()) % 4 == 0;

--- a/examples/caldera/system_lifecycle_checkpoint.rue
+++ b/examples/caldera/system_lifecycle_checkpoint.rue
@@ -39,7 +39,7 @@ fn inspect_entities(inout out: result.Result, borrow world: model.World) {
         let eligible = eligible_entity(borrow world, borrow entity);
         let command = eligible && (entity.id + FOCUS() + world.tick) % 2 == 0;
         result.record(inout out, eligible, command, entity_value(borrow world, borrow entity));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -51,7 +51,7 @@ fn inspect_tiles(inout out: result.Result, borrow world: model.World) {
         let command = eligible && tile.resource > FOCUS() % 17;
         result.record(inout out, eligible, command,
             tile.height + tile.resource + tile.terrain * 11 + i % 97);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -62,7 +62,7 @@ fn inspect_timeline(inout out: result.Result, borrow world: model.World) {
         let eligible = (event.kind + FOCUS()) % 4 == 0;
         result.record(inout out, eligible, eligible && event.value > 0,
             event.sequence + event.actor % 257 + event.value);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
@@ -70,7 +70,7 @@ fn inspect_timeline(inout out: result.Result, borrow world: model.World) {
         let eligible = command.accepted && (command.kind + FOCUS()) % 3 == 0;
         result.record(inout out, eligible, eligible,
             command.tick + command.actor % 251 + command.value);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -83,12 +83,12 @@ fn inspect_regions(inout out: result.Result, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region { tiles = tiles + 1; resources = resources + tile.resource; }
-            i = i + 1;
+            i += 1;
         }
         let eligible = tiles > 0 && (region + FOCUS()) % 4 == 0;
         result.record(inout out, eligible, eligible && resources > tiles,
             resources + tiles * 13 + region);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/system_lifecycle_checkpoint.rue
+++ b/examples/caldera/system_lifecycle_checkpoint.rue
@@ -82,7 +82,7 @@ fn inspect_regions(inout out: result.Result, borrow world: model.World) {
         let mut i: u64 = 0;
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
-            if tile.region == region { tiles = tiles + 1; resources = resources + tile.resource; }
+            if tile.region == region { tiles += 1; resources += tile.resource; }
             i += 1;
         }
         let eligible = tiles > 0 && (region + FOCUS()) % 4 == 0;

--- a/examples/caldera/system_lifecycle_compact.rue
+++ b/examples/caldera/system_lifecycle_compact.rue
@@ -39,7 +39,7 @@ fn inspect_entities(inout out: result.Result, borrow world: model.World) {
         let eligible = eligible_entity(borrow world, borrow entity);
         let command = eligible && (entity.id + FOCUS() + world.tick) % 2 == 0;
         result.record(inout out, eligible, command, entity_value(borrow world, borrow entity));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -51,7 +51,7 @@ fn inspect_tiles(inout out: result.Result, borrow world: model.World) {
         let command = eligible && tile.resource > FOCUS() % 17;
         result.record(inout out, eligible, command,
             tile.height + tile.resource + tile.terrain * 11 + i % 97);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -62,7 +62,7 @@ fn inspect_timeline(inout out: result.Result, borrow world: model.World) {
         let eligible = (event.kind + FOCUS()) % 4 == 0;
         result.record(inout out, eligible, eligible && event.value > 0,
             event.sequence + event.actor % 257 + event.value);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
@@ -70,7 +70,7 @@ fn inspect_timeline(inout out: result.Result, borrow world: model.World) {
         let eligible = command.accepted && (command.kind + FOCUS()) % 3 == 0;
         result.record(inout out, eligible, eligible,
             command.tick + command.actor % 251 + command.value);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -83,12 +83,12 @@ fn inspect_regions(inout out: result.Result, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region { tiles = tiles + 1; resources = resources + tile.resource; }
-            i = i + 1;
+            i += 1;
         }
         let eligible = tiles > 0 && (region + FOCUS()) % 4 == 0;
         result.record(inout out, eligible, eligible && resources > tiles,
             resources + tiles * 13 + region);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/system_lifecycle_compact.rue
+++ b/examples/caldera/system_lifecycle_compact.rue
@@ -82,7 +82,7 @@ fn inspect_regions(inout out: result.Result, borrow world: model.World) {
         let mut i: u64 = 0;
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
-            if tile.region == region { tiles = tiles + 1; resources = resources + tile.resource; }
+            if tile.region == region { tiles += 1; resources += tile.resource; }
             i += 1;
         }
         let eligible = tiles > 0 && (region + FOCUS()) % 4 == 0;

--- a/examples/caldera/system_lifecycle_discover.rue
+++ b/examples/caldera/system_lifecycle_discover.rue
@@ -39,7 +39,7 @@ fn inspect_entities(inout out: result.Result, borrow world: model.World) {
         let eligible = eligible_entity(borrow world, borrow entity);
         let command = eligible && (entity.id + FOCUS() + world.tick) % 2 == 0;
         result.record(inout out, eligible, command, entity_value(borrow world, borrow entity));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -51,7 +51,7 @@ fn inspect_tiles(inout out: result.Result, borrow world: model.World) {
         let command = eligible && tile.resource > FOCUS() % 17;
         result.record(inout out, eligible, command,
             tile.height + tile.resource + tile.terrain * 11 + i % 97);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -62,7 +62,7 @@ fn inspect_timeline(inout out: result.Result, borrow world: model.World) {
         let eligible = (event.kind + FOCUS()) % 4 == 0;
         result.record(inout out, eligible, eligible && event.value > 0,
             event.sequence + event.actor % 257 + event.value);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
@@ -70,7 +70,7 @@ fn inspect_timeline(inout out: result.Result, borrow world: model.World) {
         let eligible = command.accepted && (command.kind + FOCUS()) % 3 == 0;
         result.record(inout out, eligible, eligible,
             command.tick + command.actor % 251 + command.value);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -83,12 +83,12 @@ fn inspect_regions(inout out: result.Result, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region { tiles = tiles + 1; resources = resources + tile.resource; }
-            i = i + 1;
+            i += 1;
         }
         let eligible = tiles > 0 && (region + FOCUS()) % 4 == 0;
         result.record(inout out, eligible, eligible && resources > tiles,
             resources + tiles * 13 + region);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/system_lifecycle_discover.rue
+++ b/examples/caldera/system_lifecycle_discover.rue
@@ -82,7 +82,7 @@ fn inspect_regions(inout out: result.Result, borrow world: model.World) {
         let mut i: u64 = 0;
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
-            if tile.region == region { tiles = tiles + 1; resources = resources + tile.resource; }
+            if tile.region == region { tiles += 1; resources += tile.resource; }
             i += 1;
         }
         let eligible = tiles > 0 && (region + FOCUS()) % 4 == 0;

--- a/examples/caldera/system_lifecycle_dispatch.rue
+++ b/examples/caldera/system_lifecycle_dispatch.rue
@@ -39,7 +39,7 @@ fn inspect_entities(inout out: result.Result, borrow world: model.World) {
         let eligible = eligible_entity(borrow world, borrow entity);
         let command = eligible && (entity.id + FOCUS() + world.tick) % 2 == 0;
         result.record(inout out, eligible, command, entity_value(borrow world, borrow entity));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -51,7 +51,7 @@ fn inspect_tiles(inout out: result.Result, borrow world: model.World) {
         let command = eligible && tile.resource > FOCUS() % 17;
         result.record(inout out, eligible, command,
             tile.height + tile.resource + tile.terrain * 11 + i % 97);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -62,7 +62,7 @@ fn inspect_timeline(inout out: result.Result, borrow world: model.World) {
         let eligible = (event.kind + FOCUS()) % 4 == 0;
         result.record(inout out, eligible, eligible && event.value > 0,
             event.sequence + event.actor % 257 + event.value);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
@@ -70,7 +70,7 @@ fn inspect_timeline(inout out: result.Result, borrow world: model.World) {
         let eligible = command.accepted && (command.kind + FOCUS()) % 3 == 0;
         result.record(inout out, eligible, eligible,
             command.tick + command.actor % 251 + command.value);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -83,12 +83,12 @@ fn inspect_regions(inout out: result.Result, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region { tiles = tiles + 1; resources = resources + tile.resource; }
-            i = i + 1;
+            i += 1;
         }
         let eligible = tiles > 0 && (region + FOCUS()) % 4 == 0;
         result.record(inout out, eligible, eligible && resources > tiles,
             resources + tiles * 13 + region);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/system_lifecycle_dispatch.rue
+++ b/examples/caldera/system_lifecycle_dispatch.rue
@@ -82,7 +82,7 @@ fn inspect_regions(inout out: result.Result, borrow world: model.World) {
         let mut i: u64 = 0;
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
-            if tile.region == region { tiles = tiles + 1; resources = resources + tile.resource; }
+            if tile.region == region { tiles += 1; resources += tile.resource; }
             i += 1;
         }
         let eligible = tiles > 0 && (region + FOCUS()) % 4 == 0;

--- a/examples/caldera/system_lifecycle_finalize.rue
+++ b/examples/caldera/system_lifecycle_finalize.rue
@@ -39,7 +39,7 @@ fn inspect_entities(inout out: result.Result, borrow world: model.World) {
         let eligible = eligible_entity(borrow world, borrow entity);
         let command = eligible && (entity.id + FOCUS() + world.tick) % 2 == 0;
         result.record(inout out, eligible, command, entity_value(borrow world, borrow entity));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -51,7 +51,7 @@ fn inspect_tiles(inout out: result.Result, borrow world: model.World) {
         let command = eligible && tile.resource > FOCUS() % 17;
         result.record(inout out, eligible, command,
             tile.height + tile.resource + tile.terrain * 11 + i % 97);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -62,7 +62,7 @@ fn inspect_timeline(inout out: result.Result, borrow world: model.World) {
         let eligible = (event.kind + FOCUS()) % 4 == 0;
         result.record(inout out, eligible, eligible && event.value > 0,
             event.sequence + event.actor % 257 + event.value);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
@@ -70,7 +70,7 @@ fn inspect_timeline(inout out: result.Result, borrow world: model.World) {
         let eligible = command.accepted && (command.kind + FOCUS()) % 3 == 0;
         result.record(inout out, eligible, eligible,
             command.tick + command.actor % 251 + command.value);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -83,12 +83,12 @@ fn inspect_regions(inout out: result.Result, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region { tiles = tiles + 1; resources = resources + tile.resource; }
-            i = i + 1;
+            i += 1;
         }
         let eligible = tiles > 0 && (region + FOCUS()) % 4 == 0;
         result.record(inout out, eligible, eligible && resources > tiles,
             resources + tiles * 13 + region);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/system_lifecycle_finalize.rue
+++ b/examples/caldera/system_lifecycle_finalize.rue
@@ -82,7 +82,7 @@ fn inspect_regions(inout out: result.Result, borrow world: model.World) {
         let mut i: u64 = 0;
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
-            if tile.region == region { tiles = tiles + 1; resources = resources + tile.resource; }
+            if tile.region == region { tiles += 1; resources += tile.resource; }
             i += 1;
         }
         let eligible = tiles > 0 && (region + FOCUS()) % 4 == 0;

--- a/examples/caldera/system_lifecycle_observe.rue
+++ b/examples/caldera/system_lifecycle_observe.rue
@@ -39,7 +39,7 @@ fn inspect_entities(inout out: result.Result, borrow world: model.World) {
         let eligible = eligible_entity(borrow world, borrow entity);
         let command = eligible && (entity.id + FOCUS() + world.tick) % 2 == 0;
         result.record(inout out, eligible, command, entity_value(borrow world, borrow entity));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -51,7 +51,7 @@ fn inspect_tiles(inout out: result.Result, borrow world: model.World) {
         let command = eligible && tile.resource > FOCUS() % 17;
         result.record(inout out, eligible, command,
             tile.height + tile.resource + tile.terrain * 11 + i % 97);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -62,7 +62,7 @@ fn inspect_timeline(inout out: result.Result, borrow world: model.World) {
         let eligible = (event.kind + FOCUS()) % 4 == 0;
         result.record(inout out, eligible, eligible && event.value > 0,
             event.sequence + event.actor % 257 + event.value);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
@@ -70,7 +70,7 @@ fn inspect_timeline(inout out: result.Result, borrow world: model.World) {
         let eligible = command.accepted && (command.kind + FOCUS()) % 3 == 0;
         result.record(inout out, eligible, eligible,
             command.tick + command.actor % 251 + command.value);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -83,12 +83,12 @@ fn inspect_regions(inout out: result.Result, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region { tiles = tiles + 1; resources = resources + tile.resource; }
-            i = i + 1;
+            i += 1;
         }
         let eligible = tiles > 0 && (region + FOCUS()) % 4 == 0;
         result.record(inout out, eligible, eligible && resources > tiles,
             resources + tiles * 13 + region);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/system_lifecycle_observe.rue
+++ b/examples/caldera/system_lifecycle_observe.rue
@@ -82,7 +82,7 @@ fn inspect_regions(inout out: result.Result, borrow world: model.World) {
         let mut i: u64 = 0;
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
-            if tile.region == region { tiles = tiles + 1; resources = resources + tile.resource; }
+            if tile.region == region { tiles += 1; resources += tile.resource; }
             i += 1;
         }
         let eligible = tiles > 0 && (region + FOCUS()) % 4 == 0;

--- a/examples/caldera/system_lifecycle_prepare.rue
+++ b/examples/caldera/system_lifecycle_prepare.rue
@@ -39,7 +39,7 @@ fn inspect_entities(inout out: result.Result, borrow world: model.World) {
         let eligible = eligible_entity(borrow world, borrow entity);
         let command = eligible && (entity.id + FOCUS() + world.tick) % 2 == 0;
         result.record(inout out, eligible, command, entity_value(borrow world, borrow entity));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -51,7 +51,7 @@ fn inspect_tiles(inout out: result.Result, borrow world: model.World) {
         let command = eligible && tile.resource > FOCUS() % 17;
         result.record(inout out, eligible, command,
             tile.height + tile.resource + tile.terrain * 11 + i % 97);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -62,7 +62,7 @@ fn inspect_timeline(inout out: result.Result, borrow world: model.World) {
         let eligible = (event.kind + FOCUS()) % 4 == 0;
         result.record(inout out, eligible, eligible && event.value > 0,
             event.sequence + event.actor % 257 + event.value);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
@@ -70,7 +70,7 @@ fn inspect_timeline(inout out: result.Result, borrow world: model.World) {
         let eligible = command.accepted && (command.kind + FOCUS()) % 3 == 0;
         result.record(inout out, eligible, eligible,
             command.tick + command.actor % 251 + command.value);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -83,12 +83,12 @@ fn inspect_regions(inout out: result.Result, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region { tiles = tiles + 1; resources = resources + tile.resource; }
-            i = i + 1;
+            i += 1;
         }
         let eligible = tiles > 0 && (region + FOCUS()) % 4 == 0;
         result.record(inout out, eligible, eligible && resources > tiles,
             resources + tiles * 13 + region);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/system_lifecycle_prepare.rue
+++ b/examples/caldera/system_lifecycle_prepare.rue
@@ -82,7 +82,7 @@ fn inspect_regions(inout out: result.Result, borrow world: model.World) {
         let mut i: u64 = 0;
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
-            if tile.region == region { tiles = tiles + 1; resources = resources + tile.resource; }
+            if tile.region == region { tiles += 1; resources += tile.resource; }
             i += 1;
         }
         let eligible = tiles > 0 && (region + FOCUS()) % 4 == 0;

--- a/examples/caldera/system_lifecycle_reconcile.rue
+++ b/examples/caldera/system_lifecycle_reconcile.rue
@@ -39,7 +39,7 @@ fn inspect_entities(inout out: result.Result, borrow world: model.World) {
         let eligible = eligible_entity(borrow world, borrow entity);
         let command = eligible && (entity.id + FOCUS() + world.tick) % 2 == 0;
         result.record(inout out, eligible, command, entity_value(borrow world, borrow entity));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -51,7 +51,7 @@ fn inspect_tiles(inout out: result.Result, borrow world: model.World) {
         let command = eligible && tile.resource > FOCUS() % 17;
         result.record(inout out, eligible, command,
             tile.height + tile.resource + tile.terrain * 11 + i % 97);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -62,7 +62,7 @@ fn inspect_timeline(inout out: result.Result, borrow world: model.World) {
         let eligible = (event.kind + FOCUS()) % 4 == 0;
         result.record(inout out, eligible, eligible && event.value > 0,
             event.sequence + event.actor % 257 + event.value);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
@@ -70,7 +70,7 @@ fn inspect_timeline(inout out: result.Result, borrow world: model.World) {
         let eligible = command.accepted && (command.kind + FOCUS()) % 3 == 0;
         result.record(inout out, eligible, eligible,
             command.tick + command.actor % 251 + command.value);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -83,12 +83,12 @@ fn inspect_regions(inout out: result.Result, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region { tiles = tiles + 1; resources = resources + tile.resource; }
-            i = i + 1;
+            i += 1;
         }
         let eligible = tiles > 0 && (region + FOCUS()) % 4 == 0;
         result.record(inout out, eligible, eligible && resources > tiles,
             resources + tiles * 13 + region);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/system_lifecycle_reconcile.rue
+++ b/examples/caldera/system_lifecycle_reconcile.rue
@@ -82,7 +82,7 @@ fn inspect_regions(inout out: result.Result, borrow world: model.World) {
         let mut i: u64 = 0;
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
-            if tile.region == region { tiles = tiles + 1; resources = resources + tile.resource; }
+            if tile.region == region { tiles += 1; resources += tile.resource; }
             i += 1;
         }
         let eligible = tiles > 0 && (region + FOCUS()) % 4 == 0;

--- a/examples/caldera/system_lifecycle_recover.rue
+++ b/examples/caldera/system_lifecycle_recover.rue
@@ -39,7 +39,7 @@ fn inspect_entities(inout out: result.Result, borrow world: model.World) {
         let eligible = eligible_entity(borrow world, borrow entity);
         let command = eligible && (entity.id + FOCUS() + world.tick) % 2 == 0;
         result.record(inout out, eligible, command, entity_value(borrow world, borrow entity));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -51,7 +51,7 @@ fn inspect_tiles(inout out: result.Result, borrow world: model.World) {
         let command = eligible && tile.resource > FOCUS() % 17;
         result.record(inout out, eligible, command,
             tile.height + tile.resource + tile.terrain * 11 + i % 97);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -62,7 +62,7 @@ fn inspect_timeline(inout out: result.Result, borrow world: model.World) {
         let eligible = (event.kind + FOCUS()) % 4 == 0;
         result.record(inout out, eligible, eligible && event.value > 0,
             event.sequence + event.actor % 257 + event.value);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
@@ -70,7 +70,7 @@ fn inspect_timeline(inout out: result.Result, borrow world: model.World) {
         let eligible = command.accepted && (command.kind + FOCUS()) % 3 == 0;
         result.record(inout out, eligible, eligible,
             command.tick + command.actor % 251 + command.value);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -83,12 +83,12 @@ fn inspect_regions(inout out: result.Result, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region { tiles = tiles + 1; resources = resources + tile.resource; }
-            i = i + 1;
+            i += 1;
         }
         let eligible = tiles > 0 && (region + FOCUS()) % 4 == 0;
         result.record(inout out, eligible, eligible && resources > tiles,
             resources + tiles * 13 + region);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/system_lifecycle_recover.rue
+++ b/examples/caldera/system_lifecycle_recover.rue
@@ -82,7 +82,7 @@ fn inspect_regions(inout out: result.Result, borrow world: model.World) {
         let mut i: u64 = 0;
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
-            if tile.region == region { tiles = tiles + 1; resources = resources + tile.resource; }
+            if tile.region == region { tiles += 1; resources += tile.resource; }
             i += 1;
         }
         let eligible = tiles > 0 && (region + FOCUS()) % 4 == 0;

--- a/examples/caldera/system_lifecycle_replicate.rue
+++ b/examples/caldera/system_lifecycle_replicate.rue
@@ -39,7 +39,7 @@ fn inspect_entities(inout out: result.Result, borrow world: model.World) {
         let eligible = eligible_entity(borrow world, borrow entity);
         let command = eligible && (entity.id + FOCUS() + world.tick) % 2 == 0;
         result.record(inout out, eligible, command, entity_value(borrow world, borrow entity));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -51,7 +51,7 @@ fn inspect_tiles(inout out: result.Result, borrow world: model.World) {
         let command = eligible && tile.resource > FOCUS() % 17;
         result.record(inout out, eligible, command,
             tile.height + tile.resource + tile.terrain * 11 + i % 97);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -62,7 +62,7 @@ fn inspect_timeline(inout out: result.Result, borrow world: model.World) {
         let eligible = (event.kind + FOCUS()) % 4 == 0;
         result.record(inout out, eligible, eligible && event.value > 0,
             event.sequence + event.actor % 257 + event.value);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
@@ -70,7 +70,7 @@ fn inspect_timeline(inout out: result.Result, borrow world: model.World) {
         let eligible = command.accepted && (command.kind + FOCUS()) % 3 == 0;
         result.record(inout out, eligible, eligible,
             command.tick + command.actor % 251 + command.value);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -83,12 +83,12 @@ fn inspect_regions(inout out: result.Result, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region { tiles = tiles + 1; resources = resources + tile.resource; }
-            i = i + 1;
+            i += 1;
         }
         let eligible = tiles > 0 && (region + FOCUS()) % 4 == 0;
         result.record(inout out, eligible, eligible && resources > tiles,
             resources + tiles * 13 + region);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/system_lifecycle_replicate.rue
+++ b/examples/caldera/system_lifecycle_replicate.rue
@@ -82,7 +82,7 @@ fn inspect_regions(inout out: result.Result, borrow world: model.World) {
         let mut i: u64 = 0;
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
-            if tile.region == region { tiles = tiles + 1; resources = resources + tile.resource; }
+            if tile.region == region { tiles += 1; resources += tile.resource; }
             i += 1;
         }
         let eligible = tiles > 0 && (region + FOCUS()) % 4 == 0;

--- a/examples/caldera/system_lifecycle_resolve.rue
+++ b/examples/caldera/system_lifecycle_resolve.rue
@@ -39,7 +39,7 @@ fn inspect_entities(inout out: result.Result, borrow world: model.World) {
         let eligible = eligible_entity(borrow world, borrow entity);
         let command = eligible && (entity.id + FOCUS() + world.tick) % 2 == 0;
         result.record(inout out, eligible, command, entity_value(borrow world, borrow entity));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -51,7 +51,7 @@ fn inspect_tiles(inout out: result.Result, borrow world: model.World) {
         let command = eligible && tile.resource > FOCUS() % 17;
         result.record(inout out, eligible, command,
             tile.height + tile.resource + tile.terrain * 11 + i % 97);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -62,7 +62,7 @@ fn inspect_timeline(inout out: result.Result, borrow world: model.World) {
         let eligible = (event.kind + FOCUS()) % 4 == 0;
         result.record(inout out, eligible, eligible && event.value > 0,
             event.sequence + event.actor % 257 + event.value);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
@@ -70,7 +70,7 @@ fn inspect_timeline(inout out: result.Result, borrow world: model.World) {
         let eligible = command.accepted && (command.kind + FOCUS()) % 3 == 0;
         result.record(inout out, eligible, eligible,
             command.tick + command.actor % 251 + command.value);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -83,12 +83,12 @@ fn inspect_regions(inout out: result.Result, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region { tiles = tiles + 1; resources = resources + tile.resource; }
-            i = i + 1;
+            i += 1;
         }
         let eligible = tiles > 0 && (region + FOCUS()) % 4 == 0;
         result.record(inout out, eligible, eligible && resources > tiles,
             resources + tiles * 13 + region);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/system_lifecycle_resolve.rue
+++ b/examples/caldera/system_lifecycle_resolve.rue
@@ -82,7 +82,7 @@ fn inspect_regions(inout out: result.Result, borrow world: model.World) {
         let mut i: u64 = 0;
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
-            if tile.region == region { tiles = tiles + 1; resources = resources + tile.resource; }
+            if tile.region == region { tiles += 1; resources += tile.resource; }
             i += 1;
         }
         let eligible = tiles > 0 && (region + FOCUS()) % 4 == 0;

--- a/examples/caldera/system_lifecycle_schedule.rue
+++ b/examples/caldera/system_lifecycle_schedule.rue
@@ -39,7 +39,7 @@ fn inspect_entities(inout out: result.Result, borrow world: model.World) {
         let eligible = eligible_entity(borrow world, borrow entity);
         let command = eligible && (entity.id + FOCUS() + world.tick) % 2 == 0;
         result.record(inout out, eligible, command, entity_value(borrow world, borrow entity));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -51,7 +51,7 @@ fn inspect_tiles(inout out: result.Result, borrow world: model.World) {
         let command = eligible && tile.resource > FOCUS() % 17;
         result.record(inout out, eligible, command,
             tile.height + tile.resource + tile.terrain * 11 + i % 97);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -62,7 +62,7 @@ fn inspect_timeline(inout out: result.Result, borrow world: model.World) {
         let eligible = (event.kind + FOCUS()) % 4 == 0;
         result.record(inout out, eligible, eligible && event.value > 0,
             event.sequence + event.actor % 257 + event.value);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
@@ -70,7 +70,7 @@ fn inspect_timeline(inout out: result.Result, borrow world: model.World) {
         let eligible = command.accepted && (command.kind + FOCUS()) % 3 == 0;
         result.record(inout out, eligible, eligible,
             command.tick + command.actor % 251 + command.value);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -83,12 +83,12 @@ fn inspect_regions(inout out: result.Result, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region { tiles = tiles + 1; resources = resources + tile.resource; }
-            i = i + 1;
+            i += 1;
         }
         let eligible = tiles > 0 && (region + FOCUS()) % 4 == 0;
         result.record(inout out, eligible, eligible && resources > tiles,
             resources + tiles * 13 + region);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/system_lifecycle_schedule.rue
+++ b/examples/caldera/system_lifecycle_schedule.rue
@@ -82,7 +82,7 @@ fn inspect_regions(inout out: result.Result, borrow world: model.World) {
         let mut i: u64 = 0;
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
-            if tile.region == region { tiles = tiles + 1; resources = resources + tile.resource; }
+            if tile.region == region { tiles += 1; resources += tile.resource; }
             i += 1;
         }
         let eligible = tiles > 0 && (region + FOCUS()) % 4 == 0;

--- a/examples/caldera/system_lifecycle_validate.rue
+++ b/examples/caldera/system_lifecycle_validate.rue
@@ -39,7 +39,7 @@ fn inspect_entities(inout out: result.Result, borrow world: model.World) {
         let eligible = eligible_entity(borrow world, borrow entity);
         let command = eligible && (entity.id + FOCUS() + world.tick) % 2 == 0;
         result.record(inout out, eligible, command, entity_value(borrow world, borrow entity));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -51,7 +51,7 @@ fn inspect_tiles(inout out: result.Result, borrow world: model.World) {
         let command = eligible && tile.resource > FOCUS() % 17;
         result.record(inout out, eligible, command,
             tile.height + tile.resource + tile.terrain * 11 + i % 97);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -62,7 +62,7 @@ fn inspect_timeline(inout out: result.Result, borrow world: model.World) {
         let eligible = (event.kind + FOCUS()) % 4 == 0;
         result.record(inout out, eligible, eligible && event.value > 0,
             event.sequence + event.actor % 257 + event.value);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
@@ -70,7 +70,7 @@ fn inspect_timeline(inout out: result.Result, borrow world: model.World) {
         let eligible = command.accepted && (command.kind + FOCUS()) % 3 == 0;
         result.record(inout out, eligible, eligible,
             command.tick + command.actor % 251 + command.value);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -83,12 +83,12 @@ fn inspect_regions(inout out: result.Result, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region { tiles = tiles + 1; resources = resources + tile.resource; }
-            i = i + 1;
+            i += 1;
         }
         let eligible = tiles > 0 && (region + FOCUS()) % 4 == 0;
         result.record(inout out, eligible, eligible && resources > tiles,
             resources + tiles * 13 + region);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/system_lifecycle_validate.rue
+++ b/examples/caldera/system_lifecycle_validate.rue
@@ -82,7 +82,7 @@ fn inspect_regions(inout out: result.Result, borrow world: model.World) {
         let mut i: u64 = 0;
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
-            if tile.region == region { tiles = tiles + 1; resources = resources + tile.resource; }
+            if tile.region == region { tiles += 1; resources += tile.resource; }
             i += 1;
         }
         let eligible = tiles > 0 && (region + FOCUS()) % 4 == 0;

--- a/examples/caldera/system_logistics_apply.rue
+++ b/examples/caldera/system_logistics_apply.rue
@@ -39,7 +39,7 @@ fn inspect_entities(inout out: result.Result, borrow world: model.World) {
         let eligible = eligible_entity(borrow world, borrow entity);
         let command = eligible && (entity.id + FOCUS() + world.tick) % 2 == 0;
         result.record(inout out, eligible, command, entity_value(borrow world, borrow entity));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -51,7 +51,7 @@ fn inspect_tiles(inout out: result.Result, borrow world: model.World) {
         let command = eligible && tile.resource > FOCUS() % 17;
         result.record(inout out, eligible, command,
             tile.height + tile.resource + tile.terrain * 11 + i % 97);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -62,7 +62,7 @@ fn inspect_timeline(inout out: result.Result, borrow world: model.World) {
         let eligible = (event.kind + FOCUS()) % 4 == 0;
         result.record(inout out, eligible, eligible && event.value > 0,
             event.sequence + event.actor % 257 + event.value);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
@@ -70,7 +70,7 @@ fn inspect_timeline(inout out: result.Result, borrow world: model.World) {
         let eligible = command.accepted && (command.kind + FOCUS()) % 3 == 0;
         result.record(inout out, eligible, eligible,
             command.tick + command.actor % 251 + command.value);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -83,12 +83,12 @@ fn inspect_regions(inout out: result.Result, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region { tiles = tiles + 1; resources = resources + tile.resource; }
-            i = i + 1;
+            i += 1;
         }
         let eligible = tiles > 0 && (region + FOCUS()) % 4 == 0;
         result.record(inout out, eligible, eligible && resources > tiles,
             resources + tiles * 13 + region);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/system_logistics_apply.rue
+++ b/examples/caldera/system_logistics_apply.rue
@@ -82,7 +82,7 @@ fn inspect_regions(inout out: result.Result, borrow world: model.World) {
         let mut i: u64 = 0;
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
-            if tile.region == region { tiles = tiles + 1; resources = resources + tile.resource; }
+            if tile.region == region { tiles += 1; resources += tile.resource; }
             i += 1;
         }
         let eligible = tiles > 0 && (region + FOCUS()) % 4 == 0;

--- a/examples/caldera/system_logistics_audit.rue
+++ b/examples/caldera/system_logistics_audit.rue
@@ -39,7 +39,7 @@ fn inspect_entities(inout out: result.Result, borrow world: model.World) {
         let eligible = eligible_entity(borrow world, borrow entity);
         let command = eligible && (entity.id + FOCUS() + world.tick) % 2 == 0;
         result.record(inout out, eligible, command, entity_value(borrow world, borrow entity));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -51,7 +51,7 @@ fn inspect_tiles(inout out: result.Result, borrow world: model.World) {
         let command = eligible && tile.resource > FOCUS() % 17;
         result.record(inout out, eligible, command,
             tile.height + tile.resource + tile.terrain * 11 + i % 97);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -62,7 +62,7 @@ fn inspect_timeline(inout out: result.Result, borrow world: model.World) {
         let eligible = (event.kind + FOCUS()) % 4 == 0;
         result.record(inout out, eligible, eligible && event.value > 0,
             event.sequence + event.actor % 257 + event.value);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
@@ -70,7 +70,7 @@ fn inspect_timeline(inout out: result.Result, borrow world: model.World) {
         let eligible = command.accepted && (command.kind + FOCUS()) % 3 == 0;
         result.record(inout out, eligible, eligible,
             command.tick + command.actor % 251 + command.value);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -83,12 +83,12 @@ fn inspect_regions(inout out: result.Result, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region { tiles = tiles + 1; resources = resources + tile.resource; }
-            i = i + 1;
+            i += 1;
         }
         let eligible = tiles > 0 && (region + FOCUS()) % 4 == 0;
         result.record(inout out, eligible, eligible && resources > tiles,
             resources + tiles * 13 + region);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/system_logistics_audit.rue
+++ b/examples/caldera/system_logistics_audit.rue
@@ -82,7 +82,7 @@ fn inspect_regions(inout out: result.Result, borrow world: model.World) {
         let mut i: u64 = 0;
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
-            if tile.region == region { tiles = tiles + 1; resources = resources + tile.resource; }
+            if tile.region == region { tiles += 1; resources += tile.resource; }
             i += 1;
         }
         let eligible = tiles > 0 && (region + FOCUS()) % 4 == 0;

--- a/examples/caldera/system_logistics_bootstrap.rue
+++ b/examples/caldera/system_logistics_bootstrap.rue
@@ -39,7 +39,7 @@ fn inspect_entities(inout out: result.Result, borrow world: model.World) {
         let eligible = eligible_entity(borrow world, borrow entity);
         let command = eligible && (entity.id + FOCUS() + world.tick) % 2 == 0;
         result.record(inout out, eligible, command, entity_value(borrow world, borrow entity));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -51,7 +51,7 @@ fn inspect_tiles(inout out: result.Result, borrow world: model.World) {
         let command = eligible && tile.resource > FOCUS() % 17;
         result.record(inout out, eligible, command,
             tile.height + tile.resource + tile.terrain * 11 + i % 97);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -62,7 +62,7 @@ fn inspect_timeline(inout out: result.Result, borrow world: model.World) {
         let eligible = (event.kind + FOCUS()) % 4 == 0;
         result.record(inout out, eligible, eligible && event.value > 0,
             event.sequence + event.actor % 257 + event.value);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
@@ -70,7 +70,7 @@ fn inspect_timeline(inout out: result.Result, borrow world: model.World) {
         let eligible = command.accepted && (command.kind + FOCUS()) % 3 == 0;
         result.record(inout out, eligible, eligible,
             command.tick + command.actor % 251 + command.value);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -83,12 +83,12 @@ fn inspect_regions(inout out: result.Result, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region { tiles = tiles + 1; resources = resources + tile.resource; }
-            i = i + 1;
+            i += 1;
         }
         let eligible = tiles > 0 && (region + FOCUS()) % 4 == 0;
         result.record(inout out, eligible, eligible && resources > tiles,
             resources + tiles * 13 + region);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/system_logistics_bootstrap.rue
+++ b/examples/caldera/system_logistics_bootstrap.rue
@@ -82,7 +82,7 @@ fn inspect_regions(inout out: result.Result, borrow world: model.World) {
         let mut i: u64 = 0;
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
-            if tile.region == region { tiles = tiles + 1; resources = resources + tile.resource; }
+            if tile.region == region { tiles += 1; resources += tile.resource; }
             i += 1;
         }
         let eligible = tiles > 0 && (region + FOCUS()) % 4 == 0;

--- a/examples/caldera/system_logistics_checkpoint.rue
+++ b/examples/caldera/system_logistics_checkpoint.rue
@@ -39,7 +39,7 @@ fn inspect_entities(inout out: result.Result, borrow world: model.World) {
         let eligible = eligible_entity(borrow world, borrow entity);
         let command = eligible && (entity.id + FOCUS() + world.tick) % 2 == 0;
         result.record(inout out, eligible, command, entity_value(borrow world, borrow entity));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -51,7 +51,7 @@ fn inspect_tiles(inout out: result.Result, borrow world: model.World) {
         let command = eligible && tile.resource > FOCUS() % 17;
         result.record(inout out, eligible, command,
             tile.height + tile.resource + tile.terrain * 11 + i % 97);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -62,7 +62,7 @@ fn inspect_timeline(inout out: result.Result, borrow world: model.World) {
         let eligible = (event.kind + FOCUS()) % 4 == 0;
         result.record(inout out, eligible, eligible && event.value > 0,
             event.sequence + event.actor % 257 + event.value);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
@@ -70,7 +70,7 @@ fn inspect_timeline(inout out: result.Result, borrow world: model.World) {
         let eligible = command.accepted && (command.kind + FOCUS()) % 3 == 0;
         result.record(inout out, eligible, eligible,
             command.tick + command.actor % 251 + command.value);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -83,12 +83,12 @@ fn inspect_regions(inout out: result.Result, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region { tiles = tiles + 1; resources = resources + tile.resource; }
-            i = i + 1;
+            i += 1;
         }
         let eligible = tiles > 0 && (region + FOCUS()) % 4 == 0;
         result.record(inout out, eligible, eligible && resources > tiles,
             resources + tiles * 13 + region);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/system_logistics_checkpoint.rue
+++ b/examples/caldera/system_logistics_checkpoint.rue
@@ -82,7 +82,7 @@ fn inspect_regions(inout out: result.Result, borrow world: model.World) {
         let mut i: u64 = 0;
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
-            if tile.region == region { tiles = tiles + 1; resources = resources + tile.resource; }
+            if tile.region == region { tiles += 1; resources += tile.resource; }
             i += 1;
         }
         let eligible = tiles > 0 && (region + FOCUS()) % 4 == 0;

--- a/examples/caldera/system_logistics_compact.rue
+++ b/examples/caldera/system_logistics_compact.rue
@@ -39,7 +39,7 @@ fn inspect_entities(inout out: result.Result, borrow world: model.World) {
         let eligible = eligible_entity(borrow world, borrow entity);
         let command = eligible && (entity.id + FOCUS() + world.tick) % 2 == 0;
         result.record(inout out, eligible, command, entity_value(borrow world, borrow entity));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -51,7 +51,7 @@ fn inspect_tiles(inout out: result.Result, borrow world: model.World) {
         let command = eligible && tile.resource > FOCUS() % 17;
         result.record(inout out, eligible, command,
             tile.height + tile.resource + tile.terrain * 11 + i % 97);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -62,7 +62,7 @@ fn inspect_timeline(inout out: result.Result, borrow world: model.World) {
         let eligible = (event.kind + FOCUS()) % 4 == 0;
         result.record(inout out, eligible, eligible && event.value > 0,
             event.sequence + event.actor % 257 + event.value);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
@@ -70,7 +70,7 @@ fn inspect_timeline(inout out: result.Result, borrow world: model.World) {
         let eligible = command.accepted && (command.kind + FOCUS()) % 3 == 0;
         result.record(inout out, eligible, eligible,
             command.tick + command.actor % 251 + command.value);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -83,12 +83,12 @@ fn inspect_regions(inout out: result.Result, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region { tiles = tiles + 1; resources = resources + tile.resource; }
-            i = i + 1;
+            i += 1;
         }
         let eligible = tiles > 0 && (region + FOCUS()) % 4 == 0;
         result.record(inout out, eligible, eligible && resources > tiles,
             resources + tiles * 13 + region);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/system_logistics_compact.rue
+++ b/examples/caldera/system_logistics_compact.rue
@@ -82,7 +82,7 @@ fn inspect_regions(inout out: result.Result, borrow world: model.World) {
         let mut i: u64 = 0;
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
-            if tile.region == region { tiles = tiles + 1; resources = resources + tile.resource; }
+            if tile.region == region { tiles += 1; resources += tile.resource; }
             i += 1;
         }
         let eligible = tiles > 0 && (region + FOCUS()) % 4 == 0;

--- a/examples/caldera/system_logistics_discover.rue
+++ b/examples/caldera/system_logistics_discover.rue
@@ -39,7 +39,7 @@ fn inspect_entities(inout out: result.Result, borrow world: model.World) {
         let eligible = eligible_entity(borrow world, borrow entity);
         let command = eligible && (entity.id + FOCUS() + world.tick) % 2 == 0;
         result.record(inout out, eligible, command, entity_value(borrow world, borrow entity));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -51,7 +51,7 @@ fn inspect_tiles(inout out: result.Result, borrow world: model.World) {
         let command = eligible && tile.resource > FOCUS() % 17;
         result.record(inout out, eligible, command,
             tile.height + tile.resource + tile.terrain * 11 + i % 97);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -62,7 +62,7 @@ fn inspect_timeline(inout out: result.Result, borrow world: model.World) {
         let eligible = (event.kind + FOCUS()) % 4 == 0;
         result.record(inout out, eligible, eligible && event.value > 0,
             event.sequence + event.actor % 257 + event.value);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
@@ -70,7 +70,7 @@ fn inspect_timeline(inout out: result.Result, borrow world: model.World) {
         let eligible = command.accepted && (command.kind + FOCUS()) % 3 == 0;
         result.record(inout out, eligible, eligible,
             command.tick + command.actor % 251 + command.value);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -83,12 +83,12 @@ fn inspect_regions(inout out: result.Result, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region { tiles = tiles + 1; resources = resources + tile.resource; }
-            i = i + 1;
+            i += 1;
         }
         let eligible = tiles > 0 && (region + FOCUS()) % 4 == 0;
         result.record(inout out, eligible, eligible && resources > tiles,
             resources + tiles * 13 + region);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/system_logistics_discover.rue
+++ b/examples/caldera/system_logistics_discover.rue
@@ -82,7 +82,7 @@ fn inspect_regions(inout out: result.Result, borrow world: model.World) {
         let mut i: u64 = 0;
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
-            if tile.region == region { tiles = tiles + 1; resources = resources + tile.resource; }
+            if tile.region == region { tiles += 1; resources += tile.resource; }
             i += 1;
         }
         let eligible = tiles > 0 && (region + FOCUS()) % 4 == 0;

--- a/examples/caldera/system_logistics_dispatch.rue
+++ b/examples/caldera/system_logistics_dispatch.rue
@@ -39,7 +39,7 @@ fn inspect_entities(inout out: result.Result, borrow world: model.World) {
         let eligible = eligible_entity(borrow world, borrow entity);
         let command = eligible && (entity.id + FOCUS() + world.tick) % 2 == 0;
         result.record(inout out, eligible, command, entity_value(borrow world, borrow entity));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -51,7 +51,7 @@ fn inspect_tiles(inout out: result.Result, borrow world: model.World) {
         let command = eligible && tile.resource > FOCUS() % 17;
         result.record(inout out, eligible, command,
             tile.height + tile.resource + tile.terrain * 11 + i % 97);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -62,7 +62,7 @@ fn inspect_timeline(inout out: result.Result, borrow world: model.World) {
         let eligible = (event.kind + FOCUS()) % 4 == 0;
         result.record(inout out, eligible, eligible && event.value > 0,
             event.sequence + event.actor % 257 + event.value);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
@@ -70,7 +70,7 @@ fn inspect_timeline(inout out: result.Result, borrow world: model.World) {
         let eligible = command.accepted && (command.kind + FOCUS()) % 3 == 0;
         result.record(inout out, eligible, eligible,
             command.tick + command.actor % 251 + command.value);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -83,12 +83,12 @@ fn inspect_regions(inout out: result.Result, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region { tiles = tiles + 1; resources = resources + tile.resource; }
-            i = i + 1;
+            i += 1;
         }
         let eligible = tiles > 0 && (region + FOCUS()) % 4 == 0;
         result.record(inout out, eligible, eligible && resources > tiles,
             resources + tiles * 13 + region);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/system_logistics_dispatch.rue
+++ b/examples/caldera/system_logistics_dispatch.rue
@@ -82,7 +82,7 @@ fn inspect_regions(inout out: result.Result, borrow world: model.World) {
         let mut i: u64 = 0;
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
-            if tile.region == region { tiles = tiles + 1; resources = resources + tile.resource; }
+            if tile.region == region { tiles += 1; resources += tile.resource; }
             i += 1;
         }
         let eligible = tiles > 0 && (region + FOCUS()) % 4 == 0;

--- a/examples/caldera/system_logistics_finalize.rue
+++ b/examples/caldera/system_logistics_finalize.rue
@@ -39,7 +39,7 @@ fn inspect_entities(inout out: result.Result, borrow world: model.World) {
         let eligible = eligible_entity(borrow world, borrow entity);
         let command = eligible && (entity.id + FOCUS() + world.tick) % 2 == 0;
         result.record(inout out, eligible, command, entity_value(borrow world, borrow entity));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -51,7 +51,7 @@ fn inspect_tiles(inout out: result.Result, borrow world: model.World) {
         let command = eligible && tile.resource > FOCUS() % 17;
         result.record(inout out, eligible, command,
             tile.height + tile.resource + tile.terrain * 11 + i % 97);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -62,7 +62,7 @@ fn inspect_timeline(inout out: result.Result, borrow world: model.World) {
         let eligible = (event.kind + FOCUS()) % 4 == 0;
         result.record(inout out, eligible, eligible && event.value > 0,
             event.sequence + event.actor % 257 + event.value);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
@@ -70,7 +70,7 @@ fn inspect_timeline(inout out: result.Result, borrow world: model.World) {
         let eligible = command.accepted && (command.kind + FOCUS()) % 3 == 0;
         result.record(inout out, eligible, eligible,
             command.tick + command.actor % 251 + command.value);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -83,12 +83,12 @@ fn inspect_regions(inout out: result.Result, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region { tiles = tiles + 1; resources = resources + tile.resource; }
-            i = i + 1;
+            i += 1;
         }
         let eligible = tiles > 0 && (region + FOCUS()) % 4 == 0;
         result.record(inout out, eligible, eligible && resources > tiles,
             resources + tiles * 13 + region);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/system_logistics_finalize.rue
+++ b/examples/caldera/system_logistics_finalize.rue
@@ -82,7 +82,7 @@ fn inspect_regions(inout out: result.Result, borrow world: model.World) {
         let mut i: u64 = 0;
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
-            if tile.region == region { tiles = tiles + 1; resources = resources + tile.resource; }
+            if tile.region == region { tiles += 1; resources += tile.resource; }
             i += 1;
         }
         let eligible = tiles > 0 && (region + FOCUS()) % 4 == 0;

--- a/examples/caldera/system_logistics_observe.rue
+++ b/examples/caldera/system_logistics_observe.rue
@@ -39,7 +39,7 @@ fn inspect_entities(inout out: result.Result, borrow world: model.World) {
         let eligible = eligible_entity(borrow world, borrow entity);
         let command = eligible && (entity.id + FOCUS() + world.tick) % 2 == 0;
         result.record(inout out, eligible, command, entity_value(borrow world, borrow entity));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -51,7 +51,7 @@ fn inspect_tiles(inout out: result.Result, borrow world: model.World) {
         let command = eligible && tile.resource > FOCUS() % 17;
         result.record(inout out, eligible, command,
             tile.height + tile.resource + tile.terrain * 11 + i % 97);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -62,7 +62,7 @@ fn inspect_timeline(inout out: result.Result, borrow world: model.World) {
         let eligible = (event.kind + FOCUS()) % 4 == 0;
         result.record(inout out, eligible, eligible && event.value > 0,
             event.sequence + event.actor % 257 + event.value);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
@@ -70,7 +70,7 @@ fn inspect_timeline(inout out: result.Result, borrow world: model.World) {
         let eligible = command.accepted && (command.kind + FOCUS()) % 3 == 0;
         result.record(inout out, eligible, eligible,
             command.tick + command.actor % 251 + command.value);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -83,12 +83,12 @@ fn inspect_regions(inout out: result.Result, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region { tiles = tiles + 1; resources = resources + tile.resource; }
-            i = i + 1;
+            i += 1;
         }
         let eligible = tiles > 0 && (region + FOCUS()) % 4 == 0;
         result.record(inout out, eligible, eligible && resources > tiles,
             resources + tiles * 13 + region);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/system_logistics_observe.rue
+++ b/examples/caldera/system_logistics_observe.rue
@@ -82,7 +82,7 @@ fn inspect_regions(inout out: result.Result, borrow world: model.World) {
         let mut i: u64 = 0;
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
-            if tile.region == region { tiles = tiles + 1; resources = resources + tile.resource; }
+            if tile.region == region { tiles += 1; resources += tile.resource; }
             i += 1;
         }
         let eligible = tiles > 0 && (region + FOCUS()) % 4 == 0;

--- a/examples/caldera/system_logistics_prepare.rue
+++ b/examples/caldera/system_logistics_prepare.rue
@@ -39,7 +39,7 @@ fn inspect_entities(inout out: result.Result, borrow world: model.World) {
         let eligible = eligible_entity(borrow world, borrow entity);
         let command = eligible && (entity.id + FOCUS() + world.tick) % 2 == 0;
         result.record(inout out, eligible, command, entity_value(borrow world, borrow entity));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -51,7 +51,7 @@ fn inspect_tiles(inout out: result.Result, borrow world: model.World) {
         let command = eligible && tile.resource > FOCUS() % 17;
         result.record(inout out, eligible, command,
             tile.height + tile.resource + tile.terrain * 11 + i % 97);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -62,7 +62,7 @@ fn inspect_timeline(inout out: result.Result, borrow world: model.World) {
         let eligible = (event.kind + FOCUS()) % 4 == 0;
         result.record(inout out, eligible, eligible && event.value > 0,
             event.sequence + event.actor % 257 + event.value);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
@@ -70,7 +70,7 @@ fn inspect_timeline(inout out: result.Result, borrow world: model.World) {
         let eligible = command.accepted && (command.kind + FOCUS()) % 3 == 0;
         result.record(inout out, eligible, eligible,
             command.tick + command.actor % 251 + command.value);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -83,12 +83,12 @@ fn inspect_regions(inout out: result.Result, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region { tiles = tiles + 1; resources = resources + tile.resource; }
-            i = i + 1;
+            i += 1;
         }
         let eligible = tiles > 0 && (region + FOCUS()) % 4 == 0;
         result.record(inout out, eligible, eligible && resources > tiles,
             resources + tiles * 13 + region);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/system_logistics_prepare.rue
+++ b/examples/caldera/system_logistics_prepare.rue
@@ -82,7 +82,7 @@ fn inspect_regions(inout out: result.Result, borrow world: model.World) {
         let mut i: u64 = 0;
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
-            if tile.region == region { tiles = tiles + 1; resources = resources + tile.resource; }
+            if tile.region == region { tiles += 1; resources += tile.resource; }
             i += 1;
         }
         let eligible = tiles > 0 && (region + FOCUS()) % 4 == 0;

--- a/examples/caldera/system_logistics_reconcile.rue
+++ b/examples/caldera/system_logistics_reconcile.rue
@@ -39,7 +39,7 @@ fn inspect_entities(inout out: result.Result, borrow world: model.World) {
         let eligible = eligible_entity(borrow world, borrow entity);
         let command = eligible && (entity.id + FOCUS() + world.tick) % 2 == 0;
         result.record(inout out, eligible, command, entity_value(borrow world, borrow entity));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -51,7 +51,7 @@ fn inspect_tiles(inout out: result.Result, borrow world: model.World) {
         let command = eligible && tile.resource > FOCUS() % 17;
         result.record(inout out, eligible, command,
             tile.height + tile.resource + tile.terrain * 11 + i % 97);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -62,7 +62,7 @@ fn inspect_timeline(inout out: result.Result, borrow world: model.World) {
         let eligible = (event.kind + FOCUS()) % 4 == 0;
         result.record(inout out, eligible, eligible && event.value > 0,
             event.sequence + event.actor % 257 + event.value);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
@@ -70,7 +70,7 @@ fn inspect_timeline(inout out: result.Result, borrow world: model.World) {
         let eligible = command.accepted && (command.kind + FOCUS()) % 3 == 0;
         result.record(inout out, eligible, eligible,
             command.tick + command.actor % 251 + command.value);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -83,12 +83,12 @@ fn inspect_regions(inout out: result.Result, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region { tiles = tiles + 1; resources = resources + tile.resource; }
-            i = i + 1;
+            i += 1;
         }
         let eligible = tiles > 0 && (region + FOCUS()) % 4 == 0;
         result.record(inout out, eligible, eligible && resources > tiles,
             resources + tiles * 13 + region);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/system_logistics_reconcile.rue
+++ b/examples/caldera/system_logistics_reconcile.rue
@@ -82,7 +82,7 @@ fn inspect_regions(inout out: result.Result, borrow world: model.World) {
         let mut i: u64 = 0;
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
-            if tile.region == region { tiles = tiles + 1; resources = resources + tile.resource; }
+            if tile.region == region { tiles += 1; resources += tile.resource; }
             i += 1;
         }
         let eligible = tiles > 0 && (region + FOCUS()) % 4 == 0;

--- a/examples/caldera/system_logistics_recover.rue
+++ b/examples/caldera/system_logistics_recover.rue
@@ -39,7 +39,7 @@ fn inspect_entities(inout out: result.Result, borrow world: model.World) {
         let eligible = eligible_entity(borrow world, borrow entity);
         let command = eligible && (entity.id + FOCUS() + world.tick) % 2 == 0;
         result.record(inout out, eligible, command, entity_value(borrow world, borrow entity));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -51,7 +51,7 @@ fn inspect_tiles(inout out: result.Result, borrow world: model.World) {
         let command = eligible && tile.resource > FOCUS() % 17;
         result.record(inout out, eligible, command,
             tile.height + tile.resource + tile.terrain * 11 + i % 97);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -62,7 +62,7 @@ fn inspect_timeline(inout out: result.Result, borrow world: model.World) {
         let eligible = (event.kind + FOCUS()) % 4 == 0;
         result.record(inout out, eligible, eligible && event.value > 0,
             event.sequence + event.actor % 257 + event.value);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
@@ -70,7 +70,7 @@ fn inspect_timeline(inout out: result.Result, borrow world: model.World) {
         let eligible = command.accepted && (command.kind + FOCUS()) % 3 == 0;
         result.record(inout out, eligible, eligible,
             command.tick + command.actor % 251 + command.value);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -83,12 +83,12 @@ fn inspect_regions(inout out: result.Result, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region { tiles = tiles + 1; resources = resources + tile.resource; }
-            i = i + 1;
+            i += 1;
         }
         let eligible = tiles > 0 && (region + FOCUS()) % 4 == 0;
         result.record(inout out, eligible, eligible && resources > tiles,
             resources + tiles * 13 + region);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/system_logistics_recover.rue
+++ b/examples/caldera/system_logistics_recover.rue
@@ -82,7 +82,7 @@ fn inspect_regions(inout out: result.Result, borrow world: model.World) {
         let mut i: u64 = 0;
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
-            if tile.region == region { tiles = tiles + 1; resources = resources + tile.resource; }
+            if tile.region == region { tiles += 1; resources += tile.resource; }
             i += 1;
         }
         let eligible = tiles > 0 && (region + FOCUS()) % 4 == 0;

--- a/examples/caldera/system_logistics_replicate.rue
+++ b/examples/caldera/system_logistics_replicate.rue
@@ -39,7 +39,7 @@ fn inspect_entities(inout out: result.Result, borrow world: model.World) {
         let eligible = eligible_entity(borrow world, borrow entity);
         let command = eligible && (entity.id + FOCUS() + world.tick) % 2 == 0;
         result.record(inout out, eligible, command, entity_value(borrow world, borrow entity));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -51,7 +51,7 @@ fn inspect_tiles(inout out: result.Result, borrow world: model.World) {
         let command = eligible && tile.resource > FOCUS() % 17;
         result.record(inout out, eligible, command,
             tile.height + tile.resource + tile.terrain * 11 + i % 97);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -62,7 +62,7 @@ fn inspect_timeline(inout out: result.Result, borrow world: model.World) {
         let eligible = (event.kind + FOCUS()) % 4 == 0;
         result.record(inout out, eligible, eligible && event.value > 0,
             event.sequence + event.actor % 257 + event.value);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
@@ -70,7 +70,7 @@ fn inspect_timeline(inout out: result.Result, borrow world: model.World) {
         let eligible = command.accepted && (command.kind + FOCUS()) % 3 == 0;
         result.record(inout out, eligible, eligible,
             command.tick + command.actor % 251 + command.value);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -83,12 +83,12 @@ fn inspect_regions(inout out: result.Result, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region { tiles = tiles + 1; resources = resources + tile.resource; }
-            i = i + 1;
+            i += 1;
         }
         let eligible = tiles > 0 && (region + FOCUS()) % 4 == 0;
         result.record(inout out, eligible, eligible && resources > tiles,
             resources + tiles * 13 + region);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/system_logistics_replicate.rue
+++ b/examples/caldera/system_logistics_replicate.rue
@@ -82,7 +82,7 @@ fn inspect_regions(inout out: result.Result, borrow world: model.World) {
         let mut i: u64 = 0;
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
-            if tile.region == region { tiles = tiles + 1; resources = resources + tile.resource; }
+            if tile.region == region { tiles += 1; resources += tile.resource; }
             i += 1;
         }
         let eligible = tiles > 0 && (region + FOCUS()) % 4 == 0;

--- a/examples/caldera/system_logistics_resolve.rue
+++ b/examples/caldera/system_logistics_resolve.rue
@@ -39,7 +39,7 @@ fn inspect_entities(inout out: result.Result, borrow world: model.World) {
         let eligible = eligible_entity(borrow world, borrow entity);
         let command = eligible && (entity.id + FOCUS() + world.tick) % 2 == 0;
         result.record(inout out, eligible, command, entity_value(borrow world, borrow entity));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -51,7 +51,7 @@ fn inspect_tiles(inout out: result.Result, borrow world: model.World) {
         let command = eligible && tile.resource > FOCUS() % 17;
         result.record(inout out, eligible, command,
             tile.height + tile.resource + tile.terrain * 11 + i % 97);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -62,7 +62,7 @@ fn inspect_timeline(inout out: result.Result, borrow world: model.World) {
         let eligible = (event.kind + FOCUS()) % 4 == 0;
         result.record(inout out, eligible, eligible && event.value > 0,
             event.sequence + event.actor % 257 + event.value);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
@@ -70,7 +70,7 @@ fn inspect_timeline(inout out: result.Result, borrow world: model.World) {
         let eligible = command.accepted && (command.kind + FOCUS()) % 3 == 0;
         result.record(inout out, eligible, eligible,
             command.tick + command.actor % 251 + command.value);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -83,12 +83,12 @@ fn inspect_regions(inout out: result.Result, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region { tiles = tiles + 1; resources = resources + tile.resource; }
-            i = i + 1;
+            i += 1;
         }
         let eligible = tiles > 0 && (region + FOCUS()) % 4 == 0;
         result.record(inout out, eligible, eligible && resources > tiles,
             resources + tiles * 13 + region);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/system_logistics_resolve.rue
+++ b/examples/caldera/system_logistics_resolve.rue
@@ -82,7 +82,7 @@ fn inspect_regions(inout out: result.Result, borrow world: model.World) {
         let mut i: u64 = 0;
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
-            if tile.region == region { tiles = tiles + 1; resources = resources + tile.resource; }
+            if tile.region == region { tiles += 1; resources += tile.resource; }
             i += 1;
         }
         let eligible = tiles > 0 && (region + FOCUS()) % 4 == 0;

--- a/examples/caldera/system_logistics_schedule.rue
+++ b/examples/caldera/system_logistics_schedule.rue
@@ -39,7 +39,7 @@ fn inspect_entities(inout out: result.Result, borrow world: model.World) {
         let eligible = eligible_entity(borrow world, borrow entity);
         let command = eligible && (entity.id + FOCUS() + world.tick) % 2 == 0;
         result.record(inout out, eligible, command, entity_value(borrow world, borrow entity));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -51,7 +51,7 @@ fn inspect_tiles(inout out: result.Result, borrow world: model.World) {
         let command = eligible && tile.resource > FOCUS() % 17;
         result.record(inout out, eligible, command,
             tile.height + tile.resource + tile.terrain * 11 + i % 97);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -62,7 +62,7 @@ fn inspect_timeline(inout out: result.Result, borrow world: model.World) {
         let eligible = (event.kind + FOCUS()) % 4 == 0;
         result.record(inout out, eligible, eligible && event.value > 0,
             event.sequence + event.actor % 257 + event.value);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
@@ -70,7 +70,7 @@ fn inspect_timeline(inout out: result.Result, borrow world: model.World) {
         let eligible = command.accepted && (command.kind + FOCUS()) % 3 == 0;
         result.record(inout out, eligible, eligible,
             command.tick + command.actor % 251 + command.value);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -83,12 +83,12 @@ fn inspect_regions(inout out: result.Result, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region { tiles = tiles + 1; resources = resources + tile.resource; }
-            i = i + 1;
+            i += 1;
         }
         let eligible = tiles > 0 && (region + FOCUS()) % 4 == 0;
         result.record(inout out, eligible, eligible && resources > tiles,
             resources + tiles * 13 + region);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/system_logistics_schedule.rue
+++ b/examples/caldera/system_logistics_schedule.rue
@@ -82,7 +82,7 @@ fn inspect_regions(inout out: result.Result, borrow world: model.World) {
         let mut i: u64 = 0;
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
-            if tile.region == region { tiles = tiles + 1; resources = resources + tile.resource; }
+            if tile.region == region { tiles += 1; resources += tile.resource; }
             i += 1;
         }
         let eligible = tiles > 0 && (region + FOCUS()) % 4 == 0;

--- a/examples/caldera/system_logistics_validate.rue
+++ b/examples/caldera/system_logistics_validate.rue
@@ -39,7 +39,7 @@ fn inspect_entities(inout out: result.Result, borrow world: model.World) {
         let eligible = eligible_entity(borrow world, borrow entity);
         let command = eligible && (entity.id + FOCUS() + world.tick) % 2 == 0;
         result.record(inout out, eligible, command, entity_value(borrow world, borrow entity));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -51,7 +51,7 @@ fn inspect_tiles(inout out: result.Result, borrow world: model.World) {
         let command = eligible && tile.resource > FOCUS() % 17;
         result.record(inout out, eligible, command,
             tile.height + tile.resource + tile.terrain * 11 + i % 97);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -62,7 +62,7 @@ fn inspect_timeline(inout out: result.Result, borrow world: model.World) {
         let eligible = (event.kind + FOCUS()) % 4 == 0;
         result.record(inout out, eligible, eligible && event.value > 0,
             event.sequence + event.actor % 257 + event.value);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
@@ -70,7 +70,7 @@ fn inspect_timeline(inout out: result.Result, borrow world: model.World) {
         let eligible = command.accepted && (command.kind + FOCUS()) % 3 == 0;
         result.record(inout out, eligible, eligible,
             command.tick + command.actor % 251 + command.value);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -83,12 +83,12 @@ fn inspect_regions(inout out: result.Result, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region { tiles = tiles + 1; resources = resources + tile.resource; }
-            i = i + 1;
+            i += 1;
         }
         let eligible = tiles > 0 && (region + FOCUS()) % 4 == 0;
         result.record(inout out, eligible, eligible && resources > tiles,
             resources + tiles * 13 + region);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/system_logistics_validate.rue
+++ b/examples/caldera/system_logistics_validate.rue
@@ -82,7 +82,7 @@ fn inspect_regions(inout out: result.Result, borrow world: model.World) {
         let mut i: u64 = 0;
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
-            if tile.region == region { tiles = tiles + 1; resources = resources + tile.resource; }
+            if tile.region == region { tiles += 1; resources += tile.resource; }
             i += 1;
         }
         let eligible = tiles > 0 && (region + FOCUS()) % 4 == 0;

--- a/examples/caldera/system_movement_apply.rue
+++ b/examples/caldera/system_movement_apply.rue
@@ -39,7 +39,7 @@ fn inspect_entities(inout out: result.Result, borrow world: model.World) {
         let eligible = eligible_entity(borrow world, borrow entity);
         let command = eligible && (entity.id + FOCUS() + world.tick) % 2 == 0;
         result.record(inout out, eligible, command, entity_value(borrow world, borrow entity));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -51,7 +51,7 @@ fn inspect_tiles(inout out: result.Result, borrow world: model.World) {
         let command = eligible && tile.resource > FOCUS() % 17;
         result.record(inout out, eligible, command,
             tile.height + tile.resource + tile.terrain * 11 + i % 97);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -62,7 +62,7 @@ fn inspect_timeline(inout out: result.Result, borrow world: model.World) {
         let eligible = (event.kind + FOCUS()) % 4 == 0;
         result.record(inout out, eligible, eligible && event.value > 0,
             event.sequence + event.actor % 257 + event.value);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
@@ -70,7 +70,7 @@ fn inspect_timeline(inout out: result.Result, borrow world: model.World) {
         let eligible = command.accepted && (command.kind + FOCUS()) % 3 == 0;
         result.record(inout out, eligible, eligible,
             command.tick + command.actor % 251 + command.value);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -83,12 +83,12 @@ fn inspect_regions(inout out: result.Result, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region { tiles = tiles + 1; resources = resources + tile.resource; }
-            i = i + 1;
+            i += 1;
         }
         let eligible = tiles > 0 && (region + FOCUS()) % 4 == 0;
         result.record(inout out, eligible, eligible && resources > tiles,
             resources + tiles * 13 + region);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/system_movement_apply.rue
+++ b/examples/caldera/system_movement_apply.rue
@@ -82,7 +82,7 @@ fn inspect_regions(inout out: result.Result, borrow world: model.World) {
         let mut i: u64 = 0;
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
-            if tile.region == region { tiles = tiles + 1; resources = resources + tile.resource; }
+            if tile.region == region { tiles += 1; resources += tile.resource; }
             i += 1;
         }
         let eligible = tiles > 0 && (region + FOCUS()) % 4 == 0;

--- a/examples/caldera/system_movement_audit.rue
+++ b/examples/caldera/system_movement_audit.rue
@@ -39,7 +39,7 @@ fn inspect_entities(inout out: result.Result, borrow world: model.World) {
         let eligible = eligible_entity(borrow world, borrow entity);
         let command = eligible && (entity.id + FOCUS() + world.tick) % 2 == 0;
         result.record(inout out, eligible, command, entity_value(borrow world, borrow entity));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -51,7 +51,7 @@ fn inspect_tiles(inout out: result.Result, borrow world: model.World) {
         let command = eligible && tile.resource > FOCUS() % 17;
         result.record(inout out, eligible, command,
             tile.height + tile.resource + tile.terrain * 11 + i % 97);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -62,7 +62,7 @@ fn inspect_timeline(inout out: result.Result, borrow world: model.World) {
         let eligible = (event.kind + FOCUS()) % 4 == 0;
         result.record(inout out, eligible, eligible && event.value > 0,
             event.sequence + event.actor % 257 + event.value);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
@@ -70,7 +70,7 @@ fn inspect_timeline(inout out: result.Result, borrow world: model.World) {
         let eligible = command.accepted && (command.kind + FOCUS()) % 3 == 0;
         result.record(inout out, eligible, eligible,
             command.tick + command.actor % 251 + command.value);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -83,12 +83,12 @@ fn inspect_regions(inout out: result.Result, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region { tiles = tiles + 1; resources = resources + tile.resource; }
-            i = i + 1;
+            i += 1;
         }
         let eligible = tiles > 0 && (region + FOCUS()) % 4 == 0;
         result.record(inout out, eligible, eligible && resources > tiles,
             resources + tiles * 13 + region);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/system_movement_audit.rue
+++ b/examples/caldera/system_movement_audit.rue
@@ -82,7 +82,7 @@ fn inspect_regions(inout out: result.Result, borrow world: model.World) {
         let mut i: u64 = 0;
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
-            if tile.region == region { tiles = tiles + 1; resources = resources + tile.resource; }
+            if tile.region == region { tiles += 1; resources += tile.resource; }
             i += 1;
         }
         let eligible = tiles > 0 && (region + FOCUS()) % 4 == 0;

--- a/examples/caldera/system_movement_bootstrap.rue
+++ b/examples/caldera/system_movement_bootstrap.rue
@@ -39,7 +39,7 @@ fn inspect_entities(inout out: result.Result, borrow world: model.World) {
         let eligible = eligible_entity(borrow world, borrow entity);
         let command = eligible && (entity.id + FOCUS() + world.tick) % 2 == 0;
         result.record(inout out, eligible, command, entity_value(borrow world, borrow entity));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -51,7 +51,7 @@ fn inspect_tiles(inout out: result.Result, borrow world: model.World) {
         let command = eligible && tile.resource > FOCUS() % 17;
         result.record(inout out, eligible, command,
             tile.height + tile.resource + tile.terrain * 11 + i % 97);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -62,7 +62,7 @@ fn inspect_timeline(inout out: result.Result, borrow world: model.World) {
         let eligible = (event.kind + FOCUS()) % 4 == 0;
         result.record(inout out, eligible, eligible && event.value > 0,
             event.sequence + event.actor % 257 + event.value);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
@@ -70,7 +70,7 @@ fn inspect_timeline(inout out: result.Result, borrow world: model.World) {
         let eligible = command.accepted && (command.kind + FOCUS()) % 3 == 0;
         result.record(inout out, eligible, eligible,
             command.tick + command.actor % 251 + command.value);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -83,12 +83,12 @@ fn inspect_regions(inout out: result.Result, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region { tiles = tiles + 1; resources = resources + tile.resource; }
-            i = i + 1;
+            i += 1;
         }
         let eligible = tiles > 0 && (region + FOCUS()) % 4 == 0;
         result.record(inout out, eligible, eligible && resources > tiles,
             resources + tiles * 13 + region);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/system_movement_bootstrap.rue
+++ b/examples/caldera/system_movement_bootstrap.rue
@@ -82,7 +82,7 @@ fn inspect_regions(inout out: result.Result, borrow world: model.World) {
         let mut i: u64 = 0;
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
-            if tile.region == region { tiles = tiles + 1; resources = resources + tile.resource; }
+            if tile.region == region { tiles += 1; resources += tile.resource; }
             i += 1;
         }
         let eligible = tiles > 0 && (region + FOCUS()) % 4 == 0;

--- a/examples/caldera/system_movement_checkpoint.rue
+++ b/examples/caldera/system_movement_checkpoint.rue
@@ -39,7 +39,7 @@ fn inspect_entities(inout out: result.Result, borrow world: model.World) {
         let eligible = eligible_entity(borrow world, borrow entity);
         let command = eligible && (entity.id + FOCUS() + world.tick) % 2 == 0;
         result.record(inout out, eligible, command, entity_value(borrow world, borrow entity));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -51,7 +51,7 @@ fn inspect_tiles(inout out: result.Result, borrow world: model.World) {
         let command = eligible && tile.resource > FOCUS() % 17;
         result.record(inout out, eligible, command,
             tile.height + tile.resource + tile.terrain * 11 + i % 97);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -62,7 +62,7 @@ fn inspect_timeline(inout out: result.Result, borrow world: model.World) {
         let eligible = (event.kind + FOCUS()) % 4 == 0;
         result.record(inout out, eligible, eligible && event.value > 0,
             event.sequence + event.actor % 257 + event.value);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
@@ -70,7 +70,7 @@ fn inspect_timeline(inout out: result.Result, borrow world: model.World) {
         let eligible = command.accepted && (command.kind + FOCUS()) % 3 == 0;
         result.record(inout out, eligible, eligible,
             command.tick + command.actor % 251 + command.value);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -83,12 +83,12 @@ fn inspect_regions(inout out: result.Result, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region { tiles = tiles + 1; resources = resources + tile.resource; }
-            i = i + 1;
+            i += 1;
         }
         let eligible = tiles > 0 && (region + FOCUS()) % 4 == 0;
         result.record(inout out, eligible, eligible && resources > tiles,
             resources + tiles * 13 + region);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/system_movement_checkpoint.rue
+++ b/examples/caldera/system_movement_checkpoint.rue
@@ -82,7 +82,7 @@ fn inspect_regions(inout out: result.Result, borrow world: model.World) {
         let mut i: u64 = 0;
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
-            if tile.region == region { tiles = tiles + 1; resources = resources + tile.resource; }
+            if tile.region == region { tiles += 1; resources += tile.resource; }
             i += 1;
         }
         let eligible = tiles > 0 && (region + FOCUS()) % 4 == 0;

--- a/examples/caldera/system_movement_compact.rue
+++ b/examples/caldera/system_movement_compact.rue
@@ -39,7 +39,7 @@ fn inspect_entities(inout out: result.Result, borrow world: model.World) {
         let eligible = eligible_entity(borrow world, borrow entity);
         let command = eligible && (entity.id + FOCUS() + world.tick) % 2 == 0;
         result.record(inout out, eligible, command, entity_value(borrow world, borrow entity));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -51,7 +51,7 @@ fn inspect_tiles(inout out: result.Result, borrow world: model.World) {
         let command = eligible && tile.resource > FOCUS() % 17;
         result.record(inout out, eligible, command,
             tile.height + tile.resource + tile.terrain * 11 + i % 97);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -62,7 +62,7 @@ fn inspect_timeline(inout out: result.Result, borrow world: model.World) {
         let eligible = (event.kind + FOCUS()) % 4 == 0;
         result.record(inout out, eligible, eligible && event.value > 0,
             event.sequence + event.actor % 257 + event.value);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
@@ -70,7 +70,7 @@ fn inspect_timeline(inout out: result.Result, borrow world: model.World) {
         let eligible = command.accepted && (command.kind + FOCUS()) % 3 == 0;
         result.record(inout out, eligible, eligible,
             command.tick + command.actor % 251 + command.value);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -83,12 +83,12 @@ fn inspect_regions(inout out: result.Result, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region { tiles = tiles + 1; resources = resources + tile.resource; }
-            i = i + 1;
+            i += 1;
         }
         let eligible = tiles > 0 && (region + FOCUS()) % 4 == 0;
         result.record(inout out, eligible, eligible && resources > tiles,
             resources + tiles * 13 + region);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/system_movement_compact.rue
+++ b/examples/caldera/system_movement_compact.rue
@@ -82,7 +82,7 @@ fn inspect_regions(inout out: result.Result, borrow world: model.World) {
         let mut i: u64 = 0;
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
-            if tile.region == region { tiles = tiles + 1; resources = resources + tile.resource; }
+            if tile.region == region { tiles += 1; resources += tile.resource; }
             i += 1;
         }
         let eligible = tiles > 0 && (region + FOCUS()) % 4 == 0;

--- a/examples/caldera/system_movement_discover.rue
+++ b/examples/caldera/system_movement_discover.rue
@@ -39,7 +39,7 @@ fn inspect_entities(inout out: result.Result, borrow world: model.World) {
         let eligible = eligible_entity(borrow world, borrow entity);
         let command = eligible && (entity.id + FOCUS() + world.tick) % 2 == 0;
         result.record(inout out, eligible, command, entity_value(borrow world, borrow entity));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -51,7 +51,7 @@ fn inspect_tiles(inout out: result.Result, borrow world: model.World) {
         let command = eligible && tile.resource > FOCUS() % 17;
         result.record(inout out, eligible, command,
             tile.height + tile.resource + tile.terrain * 11 + i % 97);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -62,7 +62,7 @@ fn inspect_timeline(inout out: result.Result, borrow world: model.World) {
         let eligible = (event.kind + FOCUS()) % 4 == 0;
         result.record(inout out, eligible, eligible && event.value > 0,
             event.sequence + event.actor % 257 + event.value);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
@@ -70,7 +70,7 @@ fn inspect_timeline(inout out: result.Result, borrow world: model.World) {
         let eligible = command.accepted && (command.kind + FOCUS()) % 3 == 0;
         result.record(inout out, eligible, eligible,
             command.tick + command.actor % 251 + command.value);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -83,12 +83,12 @@ fn inspect_regions(inout out: result.Result, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region { tiles = tiles + 1; resources = resources + tile.resource; }
-            i = i + 1;
+            i += 1;
         }
         let eligible = tiles > 0 && (region + FOCUS()) % 4 == 0;
         result.record(inout out, eligible, eligible && resources > tiles,
             resources + tiles * 13 + region);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/system_movement_discover.rue
+++ b/examples/caldera/system_movement_discover.rue
@@ -82,7 +82,7 @@ fn inspect_regions(inout out: result.Result, borrow world: model.World) {
         let mut i: u64 = 0;
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
-            if tile.region == region { tiles = tiles + 1; resources = resources + tile.resource; }
+            if tile.region == region { tiles += 1; resources += tile.resource; }
             i += 1;
         }
         let eligible = tiles > 0 && (region + FOCUS()) % 4 == 0;

--- a/examples/caldera/system_movement_dispatch.rue
+++ b/examples/caldera/system_movement_dispatch.rue
@@ -39,7 +39,7 @@ fn inspect_entities(inout out: result.Result, borrow world: model.World) {
         let eligible = eligible_entity(borrow world, borrow entity);
         let command = eligible && (entity.id + FOCUS() + world.tick) % 2 == 0;
         result.record(inout out, eligible, command, entity_value(borrow world, borrow entity));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -51,7 +51,7 @@ fn inspect_tiles(inout out: result.Result, borrow world: model.World) {
         let command = eligible && tile.resource > FOCUS() % 17;
         result.record(inout out, eligible, command,
             tile.height + tile.resource + tile.terrain * 11 + i % 97);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -62,7 +62,7 @@ fn inspect_timeline(inout out: result.Result, borrow world: model.World) {
         let eligible = (event.kind + FOCUS()) % 4 == 0;
         result.record(inout out, eligible, eligible && event.value > 0,
             event.sequence + event.actor % 257 + event.value);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
@@ -70,7 +70,7 @@ fn inspect_timeline(inout out: result.Result, borrow world: model.World) {
         let eligible = command.accepted && (command.kind + FOCUS()) % 3 == 0;
         result.record(inout out, eligible, eligible,
             command.tick + command.actor % 251 + command.value);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -83,12 +83,12 @@ fn inspect_regions(inout out: result.Result, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region { tiles = tiles + 1; resources = resources + tile.resource; }
-            i = i + 1;
+            i += 1;
         }
         let eligible = tiles > 0 && (region + FOCUS()) % 4 == 0;
         result.record(inout out, eligible, eligible && resources > tiles,
             resources + tiles * 13 + region);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/system_movement_dispatch.rue
+++ b/examples/caldera/system_movement_dispatch.rue
@@ -82,7 +82,7 @@ fn inspect_regions(inout out: result.Result, borrow world: model.World) {
         let mut i: u64 = 0;
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
-            if tile.region == region { tiles = tiles + 1; resources = resources + tile.resource; }
+            if tile.region == region { tiles += 1; resources += tile.resource; }
             i += 1;
         }
         let eligible = tiles > 0 && (region + FOCUS()) % 4 == 0;

--- a/examples/caldera/system_movement_finalize.rue
+++ b/examples/caldera/system_movement_finalize.rue
@@ -39,7 +39,7 @@ fn inspect_entities(inout out: result.Result, borrow world: model.World) {
         let eligible = eligible_entity(borrow world, borrow entity);
         let command = eligible && (entity.id + FOCUS() + world.tick) % 2 == 0;
         result.record(inout out, eligible, command, entity_value(borrow world, borrow entity));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -51,7 +51,7 @@ fn inspect_tiles(inout out: result.Result, borrow world: model.World) {
         let command = eligible && tile.resource > FOCUS() % 17;
         result.record(inout out, eligible, command,
             tile.height + tile.resource + tile.terrain * 11 + i % 97);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -62,7 +62,7 @@ fn inspect_timeline(inout out: result.Result, borrow world: model.World) {
         let eligible = (event.kind + FOCUS()) % 4 == 0;
         result.record(inout out, eligible, eligible && event.value > 0,
             event.sequence + event.actor % 257 + event.value);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
@@ -70,7 +70,7 @@ fn inspect_timeline(inout out: result.Result, borrow world: model.World) {
         let eligible = command.accepted && (command.kind + FOCUS()) % 3 == 0;
         result.record(inout out, eligible, eligible,
             command.tick + command.actor % 251 + command.value);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -83,12 +83,12 @@ fn inspect_regions(inout out: result.Result, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region { tiles = tiles + 1; resources = resources + tile.resource; }
-            i = i + 1;
+            i += 1;
         }
         let eligible = tiles > 0 && (region + FOCUS()) % 4 == 0;
         result.record(inout out, eligible, eligible && resources > tiles,
             resources + tiles * 13 + region);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/system_movement_finalize.rue
+++ b/examples/caldera/system_movement_finalize.rue
@@ -82,7 +82,7 @@ fn inspect_regions(inout out: result.Result, borrow world: model.World) {
         let mut i: u64 = 0;
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
-            if tile.region == region { tiles = tiles + 1; resources = resources + tile.resource; }
+            if tile.region == region { tiles += 1; resources += tile.resource; }
             i += 1;
         }
         let eligible = tiles > 0 && (region + FOCUS()) % 4 == 0;

--- a/examples/caldera/system_movement_observe.rue
+++ b/examples/caldera/system_movement_observe.rue
@@ -39,7 +39,7 @@ fn inspect_entities(inout out: result.Result, borrow world: model.World) {
         let eligible = eligible_entity(borrow world, borrow entity);
         let command = eligible && (entity.id + FOCUS() + world.tick) % 2 == 0;
         result.record(inout out, eligible, command, entity_value(borrow world, borrow entity));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -51,7 +51,7 @@ fn inspect_tiles(inout out: result.Result, borrow world: model.World) {
         let command = eligible && tile.resource > FOCUS() % 17;
         result.record(inout out, eligible, command,
             tile.height + tile.resource + tile.terrain * 11 + i % 97);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -62,7 +62,7 @@ fn inspect_timeline(inout out: result.Result, borrow world: model.World) {
         let eligible = (event.kind + FOCUS()) % 4 == 0;
         result.record(inout out, eligible, eligible && event.value > 0,
             event.sequence + event.actor % 257 + event.value);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
@@ -70,7 +70,7 @@ fn inspect_timeline(inout out: result.Result, borrow world: model.World) {
         let eligible = command.accepted && (command.kind + FOCUS()) % 3 == 0;
         result.record(inout out, eligible, eligible,
             command.tick + command.actor % 251 + command.value);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -83,12 +83,12 @@ fn inspect_regions(inout out: result.Result, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region { tiles = tiles + 1; resources = resources + tile.resource; }
-            i = i + 1;
+            i += 1;
         }
         let eligible = tiles > 0 && (region + FOCUS()) % 4 == 0;
         result.record(inout out, eligible, eligible && resources > tiles,
             resources + tiles * 13 + region);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/system_movement_observe.rue
+++ b/examples/caldera/system_movement_observe.rue
@@ -82,7 +82,7 @@ fn inspect_regions(inout out: result.Result, borrow world: model.World) {
         let mut i: u64 = 0;
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
-            if tile.region == region { tiles = tiles + 1; resources = resources + tile.resource; }
+            if tile.region == region { tiles += 1; resources += tile.resource; }
             i += 1;
         }
         let eligible = tiles > 0 && (region + FOCUS()) % 4 == 0;

--- a/examples/caldera/system_movement_prepare.rue
+++ b/examples/caldera/system_movement_prepare.rue
@@ -39,7 +39,7 @@ fn inspect_entities(inout out: result.Result, borrow world: model.World) {
         let eligible = eligible_entity(borrow world, borrow entity);
         let command = eligible && (entity.id + FOCUS() + world.tick) % 2 == 0;
         result.record(inout out, eligible, command, entity_value(borrow world, borrow entity));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -51,7 +51,7 @@ fn inspect_tiles(inout out: result.Result, borrow world: model.World) {
         let command = eligible && tile.resource > FOCUS() % 17;
         result.record(inout out, eligible, command,
             tile.height + tile.resource + tile.terrain * 11 + i % 97);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -62,7 +62,7 @@ fn inspect_timeline(inout out: result.Result, borrow world: model.World) {
         let eligible = (event.kind + FOCUS()) % 4 == 0;
         result.record(inout out, eligible, eligible && event.value > 0,
             event.sequence + event.actor % 257 + event.value);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
@@ -70,7 +70,7 @@ fn inspect_timeline(inout out: result.Result, borrow world: model.World) {
         let eligible = command.accepted && (command.kind + FOCUS()) % 3 == 0;
         result.record(inout out, eligible, eligible,
             command.tick + command.actor % 251 + command.value);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -83,12 +83,12 @@ fn inspect_regions(inout out: result.Result, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region { tiles = tiles + 1; resources = resources + tile.resource; }
-            i = i + 1;
+            i += 1;
         }
         let eligible = tiles > 0 && (region + FOCUS()) % 4 == 0;
         result.record(inout out, eligible, eligible && resources > tiles,
             resources + tiles * 13 + region);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/system_movement_prepare.rue
+++ b/examples/caldera/system_movement_prepare.rue
@@ -82,7 +82,7 @@ fn inspect_regions(inout out: result.Result, borrow world: model.World) {
         let mut i: u64 = 0;
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
-            if tile.region == region { tiles = tiles + 1; resources = resources + tile.resource; }
+            if tile.region == region { tiles += 1; resources += tile.resource; }
             i += 1;
         }
         let eligible = tiles > 0 && (region + FOCUS()) % 4 == 0;

--- a/examples/caldera/system_movement_reconcile.rue
+++ b/examples/caldera/system_movement_reconcile.rue
@@ -39,7 +39,7 @@ fn inspect_entities(inout out: result.Result, borrow world: model.World) {
         let eligible = eligible_entity(borrow world, borrow entity);
         let command = eligible && (entity.id + FOCUS() + world.tick) % 2 == 0;
         result.record(inout out, eligible, command, entity_value(borrow world, borrow entity));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -51,7 +51,7 @@ fn inspect_tiles(inout out: result.Result, borrow world: model.World) {
         let command = eligible && tile.resource > FOCUS() % 17;
         result.record(inout out, eligible, command,
             tile.height + tile.resource + tile.terrain * 11 + i % 97);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -62,7 +62,7 @@ fn inspect_timeline(inout out: result.Result, borrow world: model.World) {
         let eligible = (event.kind + FOCUS()) % 4 == 0;
         result.record(inout out, eligible, eligible && event.value > 0,
             event.sequence + event.actor % 257 + event.value);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
@@ -70,7 +70,7 @@ fn inspect_timeline(inout out: result.Result, borrow world: model.World) {
         let eligible = command.accepted && (command.kind + FOCUS()) % 3 == 0;
         result.record(inout out, eligible, eligible,
             command.tick + command.actor % 251 + command.value);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -83,12 +83,12 @@ fn inspect_regions(inout out: result.Result, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region { tiles = tiles + 1; resources = resources + tile.resource; }
-            i = i + 1;
+            i += 1;
         }
         let eligible = tiles > 0 && (region + FOCUS()) % 4 == 0;
         result.record(inout out, eligible, eligible && resources > tiles,
             resources + tiles * 13 + region);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/system_movement_reconcile.rue
+++ b/examples/caldera/system_movement_reconcile.rue
@@ -82,7 +82,7 @@ fn inspect_regions(inout out: result.Result, borrow world: model.World) {
         let mut i: u64 = 0;
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
-            if tile.region == region { tiles = tiles + 1; resources = resources + tile.resource; }
+            if tile.region == region { tiles += 1; resources += tile.resource; }
             i += 1;
         }
         let eligible = tiles > 0 && (region + FOCUS()) % 4 == 0;

--- a/examples/caldera/system_movement_recover.rue
+++ b/examples/caldera/system_movement_recover.rue
@@ -39,7 +39,7 @@ fn inspect_entities(inout out: result.Result, borrow world: model.World) {
         let eligible = eligible_entity(borrow world, borrow entity);
         let command = eligible && (entity.id + FOCUS() + world.tick) % 2 == 0;
         result.record(inout out, eligible, command, entity_value(borrow world, borrow entity));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -51,7 +51,7 @@ fn inspect_tiles(inout out: result.Result, borrow world: model.World) {
         let command = eligible && tile.resource > FOCUS() % 17;
         result.record(inout out, eligible, command,
             tile.height + tile.resource + tile.terrain * 11 + i % 97);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -62,7 +62,7 @@ fn inspect_timeline(inout out: result.Result, borrow world: model.World) {
         let eligible = (event.kind + FOCUS()) % 4 == 0;
         result.record(inout out, eligible, eligible && event.value > 0,
             event.sequence + event.actor % 257 + event.value);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
@@ -70,7 +70,7 @@ fn inspect_timeline(inout out: result.Result, borrow world: model.World) {
         let eligible = command.accepted && (command.kind + FOCUS()) % 3 == 0;
         result.record(inout out, eligible, eligible,
             command.tick + command.actor % 251 + command.value);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -83,12 +83,12 @@ fn inspect_regions(inout out: result.Result, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region { tiles = tiles + 1; resources = resources + tile.resource; }
-            i = i + 1;
+            i += 1;
         }
         let eligible = tiles > 0 && (region + FOCUS()) % 4 == 0;
         result.record(inout out, eligible, eligible && resources > tiles,
             resources + tiles * 13 + region);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/system_movement_recover.rue
+++ b/examples/caldera/system_movement_recover.rue
@@ -82,7 +82,7 @@ fn inspect_regions(inout out: result.Result, borrow world: model.World) {
         let mut i: u64 = 0;
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
-            if tile.region == region { tiles = tiles + 1; resources = resources + tile.resource; }
+            if tile.region == region { tiles += 1; resources += tile.resource; }
             i += 1;
         }
         let eligible = tiles > 0 && (region + FOCUS()) % 4 == 0;

--- a/examples/caldera/system_movement_replicate.rue
+++ b/examples/caldera/system_movement_replicate.rue
@@ -39,7 +39,7 @@ fn inspect_entities(inout out: result.Result, borrow world: model.World) {
         let eligible = eligible_entity(borrow world, borrow entity);
         let command = eligible && (entity.id + FOCUS() + world.tick) % 2 == 0;
         result.record(inout out, eligible, command, entity_value(borrow world, borrow entity));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -51,7 +51,7 @@ fn inspect_tiles(inout out: result.Result, borrow world: model.World) {
         let command = eligible && tile.resource > FOCUS() % 17;
         result.record(inout out, eligible, command,
             tile.height + tile.resource + tile.terrain * 11 + i % 97);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -62,7 +62,7 @@ fn inspect_timeline(inout out: result.Result, borrow world: model.World) {
         let eligible = (event.kind + FOCUS()) % 4 == 0;
         result.record(inout out, eligible, eligible && event.value > 0,
             event.sequence + event.actor % 257 + event.value);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
@@ -70,7 +70,7 @@ fn inspect_timeline(inout out: result.Result, borrow world: model.World) {
         let eligible = command.accepted && (command.kind + FOCUS()) % 3 == 0;
         result.record(inout out, eligible, eligible,
             command.tick + command.actor % 251 + command.value);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -83,12 +83,12 @@ fn inspect_regions(inout out: result.Result, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region { tiles = tiles + 1; resources = resources + tile.resource; }
-            i = i + 1;
+            i += 1;
         }
         let eligible = tiles > 0 && (region + FOCUS()) % 4 == 0;
         result.record(inout out, eligible, eligible && resources > tiles,
             resources + tiles * 13 + region);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/system_movement_replicate.rue
+++ b/examples/caldera/system_movement_replicate.rue
@@ -82,7 +82,7 @@ fn inspect_regions(inout out: result.Result, borrow world: model.World) {
         let mut i: u64 = 0;
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
-            if tile.region == region { tiles = tiles + 1; resources = resources + tile.resource; }
+            if tile.region == region { tiles += 1; resources += tile.resource; }
             i += 1;
         }
         let eligible = tiles > 0 && (region + FOCUS()) % 4 == 0;

--- a/examples/caldera/system_movement_resolve.rue
+++ b/examples/caldera/system_movement_resolve.rue
@@ -39,7 +39,7 @@ fn inspect_entities(inout out: result.Result, borrow world: model.World) {
         let eligible = eligible_entity(borrow world, borrow entity);
         let command = eligible && (entity.id + FOCUS() + world.tick) % 2 == 0;
         result.record(inout out, eligible, command, entity_value(borrow world, borrow entity));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -51,7 +51,7 @@ fn inspect_tiles(inout out: result.Result, borrow world: model.World) {
         let command = eligible && tile.resource > FOCUS() % 17;
         result.record(inout out, eligible, command,
             tile.height + tile.resource + tile.terrain * 11 + i % 97);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -62,7 +62,7 @@ fn inspect_timeline(inout out: result.Result, borrow world: model.World) {
         let eligible = (event.kind + FOCUS()) % 4 == 0;
         result.record(inout out, eligible, eligible && event.value > 0,
             event.sequence + event.actor % 257 + event.value);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
@@ -70,7 +70,7 @@ fn inspect_timeline(inout out: result.Result, borrow world: model.World) {
         let eligible = command.accepted && (command.kind + FOCUS()) % 3 == 0;
         result.record(inout out, eligible, eligible,
             command.tick + command.actor % 251 + command.value);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -83,12 +83,12 @@ fn inspect_regions(inout out: result.Result, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region { tiles = tiles + 1; resources = resources + tile.resource; }
-            i = i + 1;
+            i += 1;
         }
         let eligible = tiles > 0 && (region + FOCUS()) % 4 == 0;
         result.record(inout out, eligible, eligible && resources > tiles,
             resources + tiles * 13 + region);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/system_movement_resolve.rue
+++ b/examples/caldera/system_movement_resolve.rue
@@ -82,7 +82,7 @@ fn inspect_regions(inout out: result.Result, borrow world: model.World) {
         let mut i: u64 = 0;
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
-            if tile.region == region { tiles = tiles + 1; resources = resources + tile.resource; }
+            if tile.region == region { tiles += 1; resources += tile.resource; }
             i += 1;
         }
         let eligible = tiles > 0 && (region + FOCUS()) % 4 == 0;

--- a/examples/caldera/system_movement_schedule.rue
+++ b/examples/caldera/system_movement_schedule.rue
@@ -39,7 +39,7 @@ fn inspect_entities(inout out: result.Result, borrow world: model.World) {
         let eligible = eligible_entity(borrow world, borrow entity);
         let command = eligible && (entity.id + FOCUS() + world.tick) % 2 == 0;
         result.record(inout out, eligible, command, entity_value(borrow world, borrow entity));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -51,7 +51,7 @@ fn inspect_tiles(inout out: result.Result, borrow world: model.World) {
         let command = eligible && tile.resource > FOCUS() % 17;
         result.record(inout out, eligible, command,
             tile.height + tile.resource + tile.terrain * 11 + i % 97);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -62,7 +62,7 @@ fn inspect_timeline(inout out: result.Result, borrow world: model.World) {
         let eligible = (event.kind + FOCUS()) % 4 == 0;
         result.record(inout out, eligible, eligible && event.value > 0,
             event.sequence + event.actor % 257 + event.value);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
@@ -70,7 +70,7 @@ fn inspect_timeline(inout out: result.Result, borrow world: model.World) {
         let eligible = command.accepted && (command.kind + FOCUS()) % 3 == 0;
         result.record(inout out, eligible, eligible,
             command.tick + command.actor % 251 + command.value);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -83,12 +83,12 @@ fn inspect_regions(inout out: result.Result, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region { tiles = tiles + 1; resources = resources + tile.resource; }
-            i = i + 1;
+            i += 1;
         }
         let eligible = tiles > 0 && (region + FOCUS()) % 4 == 0;
         result.record(inout out, eligible, eligible && resources > tiles,
             resources + tiles * 13 + region);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/system_movement_schedule.rue
+++ b/examples/caldera/system_movement_schedule.rue
@@ -82,7 +82,7 @@ fn inspect_regions(inout out: result.Result, borrow world: model.World) {
         let mut i: u64 = 0;
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
-            if tile.region == region { tiles = tiles + 1; resources = resources + tile.resource; }
+            if tile.region == region { tiles += 1; resources += tile.resource; }
             i += 1;
         }
         let eligible = tiles > 0 && (region + FOCUS()) % 4 == 0;

--- a/examples/caldera/system_movement_validate.rue
+++ b/examples/caldera/system_movement_validate.rue
@@ -39,7 +39,7 @@ fn inspect_entities(inout out: result.Result, borrow world: model.World) {
         let eligible = eligible_entity(borrow world, borrow entity);
         let command = eligible && (entity.id + FOCUS() + world.tick) % 2 == 0;
         result.record(inout out, eligible, command, entity_value(borrow world, borrow entity));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -51,7 +51,7 @@ fn inspect_tiles(inout out: result.Result, borrow world: model.World) {
         let command = eligible && tile.resource > FOCUS() % 17;
         result.record(inout out, eligible, command,
             tile.height + tile.resource + tile.terrain * 11 + i % 97);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -62,7 +62,7 @@ fn inspect_timeline(inout out: result.Result, borrow world: model.World) {
         let eligible = (event.kind + FOCUS()) % 4 == 0;
         result.record(inout out, eligible, eligible && event.value > 0,
             event.sequence + event.actor % 257 + event.value);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
@@ -70,7 +70,7 @@ fn inspect_timeline(inout out: result.Result, borrow world: model.World) {
         let eligible = command.accepted && (command.kind + FOCUS()) % 3 == 0;
         result.record(inout out, eligible, eligible,
             command.tick + command.actor % 251 + command.value);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -83,12 +83,12 @@ fn inspect_regions(inout out: result.Result, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region { tiles = tiles + 1; resources = resources + tile.resource; }
-            i = i + 1;
+            i += 1;
         }
         let eligible = tiles > 0 && (region + FOCUS()) % 4 == 0;
         result.record(inout out, eligible, eligible && resources > tiles,
             resources + tiles * 13 + region);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/system_movement_validate.rue
+++ b/examples/caldera/system_movement_validate.rue
@@ -82,7 +82,7 @@ fn inspect_regions(inout out: result.Result, borrow world: model.World) {
         let mut i: u64 = 0;
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
-            if tile.region == region { tiles = tiles + 1; resources = resources + tile.resource; }
+            if tile.region == region { tiles += 1; resources += tile.resource; }
             i += 1;
         }
         let eligible = tiles > 0 && (region + FOCUS()) % 4 == 0;

--- a/examples/caldera/system_network_apply.rue
+++ b/examples/caldera/system_network_apply.rue
@@ -39,7 +39,7 @@ fn inspect_entities(inout out: result.Result, borrow world: model.World) {
         let eligible = eligible_entity(borrow world, borrow entity);
         let command = eligible && (entity.id + FOCUS() + world.tick) % 2 == 0;
         result.record(inout out, eligible, command, entity_value(borrow world, borrow entity));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -51,7 +51,7 @@ fn inspect_tiles(inout out: result.Result, borrow world: model.World) {
         let command = eligible && tile.resource > FOCUS() % 17;
         result.record(inout out, eligible, command,
             tile.height + tile.resource + tile.terrain * 11 + i % 97);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -62,7 +62,7 @@ fn inspect_timeline(inout out: result.Result, borrow world: model.World) {
         let eligible = (event.kind + FOCUS()) % 4 == 0;
         result.record(inout out, eligible, eligible && event.value > 0,
             event.sequence + event.actor % 257 + event.value);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
@@ -70,7 +70,7 @@ fn inspect_timeline(inout out: result.Result, borrow world: model.World) {
         let eligible = command.accepted && (command.kind + FOCUS()) % 3 == 0;
         result.record(inout out, eligible, eligible,
             command.tick + command.actor % 251 + command.value);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -83,12 +83,12 @@ fn inspect_regions(inout out: result.Result, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region { tiles = tiles + 1; resources = resources + tile.resource; }
-            i = i + 1;
+            i += 1;
         }
         let eligible = tiles > 0 && (region + FOCUS()) % 4 == 0;
         result.record(inout out, eligible, eligible && resources > tiles,
             resources + tiles * 13 + region);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/system_network_apply.rue
+++ b/examples/caldera/system_network_apply.rue
@@ -82,7 +82,7 @@ fn inspect_regions(inout out: result.Result, borrow world: model.World) {
         let mut i: u64 = 0;
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
-            if tile.region == region { tiles = tiles + 1; resources = resources + tile.resource; }
+            if tile.region == region { tiles += 1; resources += tile.resource; }
             i += 1;
         }
         let eligible = tiles > 0 && (region + FOCUS()) % 4 == 0;

--- a/examples/caldera/system_network_audit.rue
+++ b/examples/caldera/system_network_audit.rue
@@ -39,7 +39,7 @@ fn inspect_entities(inout out: result.Result, borrow world: model.World) {
         let eligible = eligible_entity(borrow world, borrow entity);
         let command = eligible && (entity.id + FOCUS() + world.tick) % 2 == 0;
         result.record(inout out, eligible, command, entity_value(borrow world, borrow entity));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -51,7 +51,7 @@ fn inspect_tiles(inout out: result.Result, borrow world: model.World) {
         let command = eligible && tile.resource > FOCUS() % 17;
         result.record(inout out, eligible, command,
             tile.height + tile.resource + tile.terrain * 11 + i % 97);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -62,7 +62,7 @@ fn inspect_timeline(inout out: result.Result, borrow world: model.World) {
         let eligible = (event.kind + FOCUS()) % 4 == 0;
         result.record(inout out, eligible, eligible && event.value > 0,
             event.sequence + event.actor % 257 + event.value);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
@@ -70,7 +70,7 @@ fn inspect_timeline(inout out: result.Result, borrow world: model.World) {
         let eligible = command.accepted && (command.kind + FOCUS()) % 3 == 0;
         result.record(inout out, eligible, eligible,
             command.tick + command.actor % 251 + command.value);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -83,12 +83,12 @@ fn inspect_regions(inout out: result.Result, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region { tiles = tiles + 1; resources = resources + tile.resource; }
-            i = i + 1;
+            i += 1;
         }
         let eligible = tiles > 0 && (region + FOCUS()) % 4 == 0;
         result.record(inout out, eligible, eligible && resources > tiles,
             resources + tiles * 13 + region);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/system_network_audit.rue
+++ b/examples/caldera/system_network_audit.rue
@@ -82,7 +82,7 @@ fn inspect_regions(inout out: result.Result, borrow world: model.World) {
         let mut i: u64 = 0;
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
-            if tile.region == region { tiles = tiles + 1; resources = resources + tile.resource; }
+            if tile.region == region { tiles += 1; resources += tile.resource; }
             i += 1;
         }
         let eligible = tiles > 0 && (region + FOCUS()) % 4 == 0;

--- a/examples/caldera/system_network_bootstrap.rue
+++ b/examples/caldera/system_network_bootstrap.rue
@@ -39,7 +39,7 @@ fn inspect_entities(inout out: result.Result, borrow world: model.World) {
         let eligible = eligible_entity(borrow world, borrow entity);
         let command = eligible && (entity.id + FOCUS() + world.tick) % 2 == 0;
         result.record(inout out, eligible, command, entity_value(borrow world, borrow entity));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -51,7 +51,7 @@ fn inspect_tiles(inout out: result.Result, borrow world: model.World) {
         let command = eligible && tile.resource > FOCUS() % 17;
         result.record(inout out, eligible, command,
             tile.height + tile.resource + tile.terrain * 11 + i % 97);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -62,7 +62,7 @@ fn inspect_timeline(inout out: result.Result, borrow world: model.World) {
         let eligible = (event.kind + FOCUS()) % 4 == 0;
         result.record(inout out, eligible, eligible && event.value > 0,
             event.sequence + event.actor % 257 + event.value);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
@@ -70,7 +70,7 @@ fn inspect_timeline(inout out: result.Result, borrow world: model.World) {
         let eligible = command.accepted && (command.kind + FOCUS()) % 3 == 0;
         result.record(inout out, eligible, eligible,
             command.tick + command.actor % 251 + command.value);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -83,12 +83,12 @@ fn inspect_regions(inout out: result.Result, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region { tiles = tiles + 1; resources = resources + tile.resource; }
-            i = i + 1;
+            i += 1;
         }
         let eligible = tiles > 0 && (region + FOCUS()) % 4 == 0;
         result.record(inout out, eligible, eligible && resources > tiles,
             resources + tiles * 13 + region);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/system_network_bootstrap.rue
+++ b/examples/caldera/system_network_bootstrap.rue
@@ -82,7 +82,7 @@ fn inspect_regions(inout out: result.Result, borrow world: model.World) {
         let mut i: u64 = 0;
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
-            if tile.region == region { tiles = tiles + 1; resources = resources + tile.resource; }
+            if tile.region == region { tiles += 1; resources += tile.resource; }
             i += 1;
         }
         let eligible = tiles > 0 && (region + FOCUS()) % 4 == 0;

--- a/examples/caldera/system_network_checkpoint.rue
+++ b/examples/caldera/system_network_checkpoint.rue
@@ -39,7 +39,7 @@ fn inspect_entities(inout out: result.Result, borrow world: model.World) {
         let eligible = eligible_entity(borrow world, borrow entity);
         let command = eligible && (entity.id + FOCUS() + world.tick) % 2 == 0;
         result.record(inout out, eligible, command, entity_value(borrow world, borrow entity));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -51,7 +51,7 @@ fn inspect_tiles(inout out: result.Result, borrow world: model.World) {
         let command = eligible && tile.resource > FOCUS() % 17;
         result.record(inout out, eligible, command,
             tile.height + tile.resource + tile.terrain * 11 + i % 97);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -62,7 +62,7 @@ fn inspect_timeline(inout out: result.Result, borrow world: model.World) {
         let eligible = (event.kind + FOCUS()) % 4 == 0;
         result.record(inout out, eligible, eligible && event.value > 0,
             event.sequence + event.actor % 257 + event.value);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
@@ -70,7 +70,7 @@ fn inspect_timeline(inout out: result.Result, borrow world: model.World) {
         let eligible = command.accepted && (command.kind + FOCUS()) % 3 == 0;
         result.record(inout out, eligible, eligible,
             command.tick + command.actor % 251 + command.value);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -83,12 +83,12 @@ fn inspect_regions(inout out: result.Result, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region { tiles = tiles + 1; resources = resources + tile.resource; }
-            i = i + 1;
+            i += 1;
         }
         let eligible = tiles > 0 && (region + FOCUS()) % 4 == 0;
         result.record(inout out, eligible, eligible && resources > tiles,
             resources + tiles * 13 + region);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/system_network_checkpoint.rue
+++ b/examples/caldera/system_network_checkpoint.rue
@@ -82,7 +82,7 @@ fn inspect_regions(inout out: result.Result, borrow world: model.World) {
         let mut i: u64 = 0;
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
-            if tile.region == region { tiles = tiles + 1; resources = resources + tile.resource; }
+            if tile.region == region { tiles += 1; resources += tile.resource; }
             i += 1;
         }
         let eligible = tiles > 0 && (region + FOCUS()) % 4 == 0;

--- a/examples/caldera/system_network_compact.rue
+++ b/examples/caldera/system_network_compact.rue
@@ -39,7 +39,7 @@ fn inspect_entities(inout out: result.Result, borrow world: model.World) {
         let eligible = eligible_entity(borrow world, borrow entity);
         let command = eligible && (entity.id + FOCUS() + world.tick) % 2 == 0;
         result.record(inout out, eligible, command, entity_value(borrow world, borrow entity));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -51,7 +51,7 @@ fn inspect_tiles(inout out: result.Result, borrow world: model.World) {
         let command = eligible && tile.resource > FOCUS() % 17;
         result.record(inout out, eligible, command,
             tile.height + tile.resource + tile.terrain * 11 + i % 97);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -62,7 +62,7 @@ fn inspect_timeline(inout out: result.Result, borrow world: model.World) {
         let eligible = (event.kind + FOCUS()) % 4 == 0;
         result.record(inout out, eligible, eligible && event.value > 0,
             event.sequence + event.actor % 257 + event.value);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
@@ -70,7 +70,7 @@ fn inspect_timeline(inout out: result.Result, borrow world: model.World) {
         let eligible = command.accepted && (command.kind + FOCUS()) % 3 == 0;
         result.record(inout out, eligible, eligible,
             command.tick + command.actor % 251 + command.value);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -83,12 +83,12 @@ fn inspect_regions(inout out: result.Result, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region { tiles = tiles + 1; resources = resources + tile.resource; }
-            i = i + 1;
+            i += 1;
         }
         let eligible = tiles > 0 && (region + FOCUS()) % 4 == 0;
         result.record(inout out, eligible, eligible && resources > tiles,
             resources + tiles * 13 + region);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/system_network_compact.rue
+++ b/examples/caldera/system_network_compact.rue
@@ -82,7 +82,7 @@ fn inspect_regions(inout out: result.Result, borrow world: model.World) {
         let mut i: u64 = 0;
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
-            if tile.region == region { tiles = tiles + 1; resources = resources + tile.resource; }
+            if tile.region == region { tiles += 1; resources += tile.resource; }
             i += 1;
         }
         let eligible = tiles > 0 && (region + FOCUS()) % 4 == 0;

--- a/examples/caldera/system_network_discover.rue
+++ b/examples/caldera/system_network_discover.rue
@@ -39,7 +39,7 @@ fn inspect_entities(inout out: result.Result, borrow world: model.World) {
         let eligible = eligible_entity(borrow world, borrow entity);
         let command = eligible && (entity.id + FOCUS() + world.tick) % 2 == 0;
         result.record(inout out, eligible, command, entity_value(borrow world, borrow entity));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -51,7 +51,7 @@ fn inspect_tiles(inout out: result.Result, borrow world: model.World) {
         let command = eligible && tile.resource > FOCUS() % 17;
         result.record(inout out, eligible, command,
             tile.height + tile.resource + tile.terrain * 11 + i % 97);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -62,7 +62,7 @@ fn inspect_timeline(inout out: result.Result, borrow world: model.World) {
         let eligible = (event.kind + FOCUS()) % 4 == 0;
         result.record(inout out, eligible, eligible && event.value > 0,
             event.sequence + event.actor % 257 + event.value);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
@@ -70,7 +70,7 @@ fn inspect_timeline(inout out: result.Result, borrow world: model.World) {
         let eligible = command.accepted && (command.kind + FOCUS()) % 3 == 0;
         result.record(inout out, eligible, eligible,
             command.tick + command.actor % 251 + command.value);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -83,12 +83,12 @@ fn inspect_regions(inout out: result.Result, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region { tiles = tiles + 1; resources = resources + tile.resource; }
-            i = i + 1;
+            i += 1;
         }
         let eligible = tiles > 0 && (region + FOCUS()) % 4 == 0;
         result.record(inout out, eligible, eligible && resources > tiles,
             resources + tiles * 13 + region);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/system_network_discover.rue
+++ b/examples/caldera/system_network_discover.rue
@@ -82,7 +82,7 @@ fn inspect_regions(inout out: result.Result, borrow world: model.World) {
         let mut i: u64 = 0;
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
-            if tile.region == region { tiles = tiles + 1; resources = resources + tile.resource; }
+            if tile.region == region { tiles += 1; resources += tile.resource; }
             i += 1;
         }
         let eligible = tiles > 0 && (region + FOCUS()) % 4 == 0;

--- a/examples/caldera/system_network_dispatch.rue
+++ b/examples/caldera/system_network_dispatch.rue
@@ -39,7 +39,7 @@ fn inspect_entities(inout out: result.Result, borrow world: model.World) {
         let eligible = eligible_entity(borrow world, borrow entity);
         let command = eligible && (entity.id + FOCUS() + world.tick) % 2 == 0;
         result.record(inout out, eligible, command, entity_value(borrow world, borrow entity));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -51,7 +51,7 @@ fn inspect_tiles(inout out: result.Result, borrow world: model.World) {
         let command = eligible && tile.resource > FOCUS() % 17;
         result.record(inout out, eligible, command,
             tile.height + tile.resource + tile.terrain * 11 + i % 97);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -62,7 +62,7 @@ fn inspect_timeline(inout out: result.Result, borrow world: model.World) {
         let eligible = (event.kind + FOCUS()) % 4 == 0;
         result.record(inout out, eligible, eligible && event.value > 0,
             event.sequence + event.actor % 257 + event.value);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
@@ -70,7 +70,7 @@ fn inspect_timeline(inout out: result.Result, borrow world: model.World) {
         let eligible = command.accepted && (command.kind + FOCUS()) % 3 == 0;
         result.record(inout out, eligible, eligible,
             command.tick + command.actor % 251 + command.value);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -83,12 +83,12 @@ fn inspect_regions(inout out: result.Result, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region { tiles = tiles + 1; resources = resources + tile.resource; }
-            i = i + 1;
+            i += 1;
         }
         let eligible = tiles > 0 && (region + FOCUS()) % 4 == 0;
         result.record(inout out, eligible, eligible && resources > tiles,
             resources + tiles * 13 + region);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/system_network_dispatch.rue
+++ b/examples/caldera/system_network_dispatch.rue
@@ -82,7 +82,7 @@ fn inspect_regions(inout out: result.Result, borrow world: model.World) {
         let mut i: u64 = 0;
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
-            if tile.region == region { tiles = tiles + 1; resources = resources + tile.resource; }
+            if tile.region == region { tiles += 1; resources += tile.resource; }
             i += 1;
         }
         let eligible = tiles > 0 && (region + FOCUS()) % 4 == 0;

--- a/examples/caldera/system_network_finalize.rue
+++ b/examples/caldera/system_network_finalize.rue
@@ -39,7 +39,7 @@ fn inspect_entities(inout out: result.Result, borrow world: model.World) {
         let eligible = eligible_entity(borrow world, borrow entity);
         let command = eligible && (entity.id + FOCUS() + world.tick) % 2 == 0;
         result.record(inout out, eligible, command, entity_value(borrow world, borrow entity));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -51,7 +51,7 @@ fn inspect_tiles(inout out: result.Result, borrow world: model.World) {
         let command = eligible && tile.resource > FOCUS() % 17;
         result.record(inout out, eligible, command,
             tile.height + tile.resource + tile.terrain * 11 + i % 97);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -62,7 +62,7 @@ fn inspect_timeline(inout out: result.Result, borrow world: model.World) {
         let eligible = (event.kind + FOCUS()) % 4 == 0;
         result.record(inout out, eligible, eligible && event.value > 0,
             event.sequence + event.actor % 257 + event.value);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
@@ -70,7 +70,7 @@ fn inspect_timeline(inout out: result.Result, borrow world: model.World) {
         let eligible = command.accepted && (command.kind + FOCUS()) % 3 == 0;
         result.record(inout out, eligible, eligible,
             command.tick + command.actor % 251 + command.value);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -83,12 +83,12 @@ fn inspect_regions(inout out: result.Result, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region { tiles = tiles + 1; resources = resources + tile.resource; }
-            i = i + 1;
+            i += 1;
         }
         let eligible = tiles > 0 && (region + FOCUS()) % 4 == 0;
         result.record(inout out, eligible, eligible && resources > tiles,
             resources + tiles * 13 + region);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/system_network_finalize.rue
+++ b/examples/caldera/system_network_finalize.rue
@@ -82,7 +82,7 @@ fn inspect_regions(inout out: result.Result, borrow world: model.World) {
         let mut i: u64 = 0;
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
-            if tile.region == region { tiles = tiles + 1; resources = resources + tile.resource; }
+            if tile.region == region { tiles += 1; resources += tile.resource; }
             i += 1;
         }
         let eligible = tiles > 0 && (region + FOCUS()) % 4 == 0;

--- a/examples/caldera/system_network_observe.rue
+++ b/examples/caldera/system_network_observe.rue
@@ -39,7 +39,7 @@ fn inspect_entities(inout out: result.Result, borrow world: model.World) {
         let eligible = eligible_entity(borrow world, borrow entity);
         let command = eligible && (entity.id + FOCUS() + world.tick) % 2 == 0;
         result.record(inout out, eligible, command, entity_value(borrow world, borrow entity));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -51,7 +51,7 @@ fn inspect_tiles(inout out: result.Result, borrow world: model.World) {
         let command = eligible && tile.resource > FOCUS() % 17;
         result.record(inout out, eligible, command,
             tile.height + tile.resource + tile.terrain * 11 + i % 97);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -62,7 +62,7 @@ fn inspect_timeline(inout out: result.Result, borrow world: model.World) {
         let eligible = (event.kind + FOCUS()) % 4 == 0;
         result.record(inout out, eligible, eligible && event.value > 0,
             event.sequence + event.actor % 257 + event.value);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
@@ -70,7 +70,7 @@ fn inspect_timeline(inout out: result.Result, borrow world: model.World) {
         let eligible = command.accepted && (command.kind + FOCUS()) % 3 == 0;
         result.record(inout out, eligible, eligible,
             command.tick + command.actor % 251 + command.value);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -83,12 +83,12 @@ fn inspect_regions(inout out: result.Result, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region { tiles = tiles + 1; resources = resources + tile.resource; }
-            i = i + 1;
+            i += 1;
         }
         let eligible = tiles > 0 && (region + FOCUS()) % 4 == 0;
         result.record(inout out, eligible, eligible && resources > tiles,
             resources + tiles * 13 + region);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/system_network_observe.rue
+++ b/examples/caldera/system_network_observe.rue
@@ -82,7 +82,7 @@ fn inspect_regions(inout out: result.Result, borrow world: model.World) {
         let mut i: u64 = 0;
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
-            if tile.region == region { tiles = tiles + 1; resources = resources + tile.resource; }
+            if tile.region == region { tiles += 1; resources += tile.resource; }
             i += 1;
         }
         let eligible = tiles > 0 && (region + FOCUS()) % 4 == 0;

--- a/examples/caldera/system_network_prepare.rue
+++ b/examples/caldera/system_network_prepare.rue
@@ -39,7 +39,7 @@ fn inspect_entities(inout out: result.Result, borrow world: model.World) {
         let eligible = eligible_entity(borrow world, borrow entity);
         let command = eligible && (entity.id + FOCUS() + world.tick) % 2 == 0;
         result.record(inout out, eligible, command, entity_value(borrow world, borrow entity));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -51,7 +51,7 @@ fn inspect_tiles(inout out: result.Result, borrow world: model.World) {
         let command = eligible && tile.resource > FOCUS() % 17;
         result.record(inout out, eligible, command,
             tile.height + tile.resource + tile.terrain * 11 + i % 97);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -62,7 +62,7 @@ fn inspect_timeline(inout out: result.Result, borrow world: model.World) {
         let eligible = (event.kind + FOCUS()) % 4 == 0;
         result.record(inout out, eligible, eligible && event.value > 0,
             event.sequence + event.actor % 257 + event.value);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
@@ -70,7 +70,7 @@ fn inspect_timeline(inout out: result.Result, borrow world: model.World) {
         let eligible = command.accepted && (command.kind + FOCUS()) % 3 == 0;
         result.record(inout out, eligible, eligible,
             command.tick + command.actor % 251 + command.value);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -83,12 +83,12 @@ fn inspect_regions(inout out: result.Result, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region { tiles = tiles + 1; resources = resources + tile.resource; }
-            i = i + 1;
+            i += 1;
         }
         let eligible = tiles > 0 && (region + FOCUS()) % 4 == 0;
         result.record(inout out, eligible, eligible && resources > tiles,
             resources + tiles * 13 + region);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/system_network_prepare.rue
+++ b/examples/caldera/system_network_prepare.rue
@@ -82,7 +82,7 @@ fn inspect_regions(inout out: result.Result, borrow world: model.World) {
         let mut i: u64 = 0;
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
-            if tile.region == region { tiles = tiles + 1; resources = resources + tile.resource; }
+            if tile.region == region { tiles += 1; resources += tile.resource; }
             i += 1;
         }
         let eligible = tiles > 0 && (region + FOCUS()) % 4 == 0;

--- a/examples/caldera/system_network_reconcile.rue
+++ b/examples/caldera/system_network_reconcile.rue
@@ -39,7 +39,7 @@ fn inspect_entities(inout out: result.Result, borrow world: model.World) {
         let eligible = eligible_entity(borrow world, borrow entity);
         let command = eligible && (entity.id + FOCUS() + world.tick) % 2 == 0;
         result.record(inout out, eligible, command, entity_value(borrow world, borrow entity));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -51,7 +51,7 @@ fn inspect_tiles(inout out: result.Result, borrow world: model.World) {
         let command = eligible && tile.resource > FOCUS() % 17;
         result.record(inout out, eligible, command,
             tile.height + tile.resource + tile.terrain * 11 + i % 97);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -62,7 +62,7 @@ fn inspect_timeline(inout out: result.Result, borrow world: model.World) {
         let eligible = (event.kind + FOCUS()) % 4 == 0;
         result.record(inout out, eligible, eligible && event.value > 0,
             event.sequence + event.actor % 257 + event.value);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
@@ -70,7 +70,7 @@ fn inspect_timeline(inout out: result.Result, borrow world: model.World) {
         let eligible = command.accepted && (command.kind + FOCUS()) % 3 == 0;
         result.record(inout out, eligible, eligible,
             command.tick + command.actor % 251 + command.value);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -83,12 +83,12 @@ fn inspect_regions(inout out: result.Result, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region { tiles = tiles + 1; resources = resources + tile.resource; }
-            i = i + 1;
+            i += 1;
         }
         let eligible = tiles > 0 && (region + FOCUS()) % 4 == 0;
         result.record(inout out, eligible, eligible && resources > tiles,
             resources + tiles * 13 + region);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/system_network_reconcile.rue
+++ b/examples/caldera/system_network_reconcile.rue
@@ -82,7 +82,7 @@ fn inspect_regions(inout out: result.Result, borrow world: model.World) {
         let mut i: u64 = 0;
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
-            if tile.region == region { tiles = tiles + 1; resources = resources + tile.resource; }
+            if tile.region == region { tiles += 1; resources += tile.resource; }
             i += 1;
         }
         let eligible = tiles > 0 && (region + FOCUS()) % 4 == 0;

--- a/examples/caldera/system_network_recover.rue
+++ b/examples/caldera/system_network_recover.rue
@@ -39,7 +39,7 @@ fn inspect_entities(inout out: result.Result, borrow world: model.World) {
         let eligible = eligible_entity(borrow world, borrow entity);
         let command = eligible && (entity.id + FOCUS() + world.tick) % 2 == 0;
         result.record(inout out, eligible, command, entity_value(borrow world, borrow entity));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -51,7 +51,7 @@ fn inspect_tiles(inout out: result.Result, borrow world: model.World) {
         let command = eligible && tile.resource > FOCUS() % 17;
         result.record(inout out, eligible, command,
             tile.height + tile.resource + tile.terrain * 11 + i % 97);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -62,7 +62,7 @@ fn inspect_timeline(inout out: result.Result, borrow world: model.World) {
         let eligible = (event.kind + FOCUS()) % 4 == 0;
         result.record(inout out, eligible, eligible && event.value > 0,
             event.sequence + event.actor % 257 + event.value);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
@@ -70,7 +70,7 @@ fn inspect_timeline(inout out: result.Result, borrow world: model.World) {
         let eligible = command.accepted && (command.kind + FOCUS()) % 3 == 0;
         result.record(inout out, eligible, eligible,
             command.tick + command.actor % 251 + command.value);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -83,12 +83,12 @@ fn inspect_regions(inout out: result.Result, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region { tiles = tiles + 1; resources = resources + tile.resource; }
-            i = i + 1;
+            i += 1;
         }
         let eligible = tiles > 0 && (region + FOCUS()) % 4 == 0;
         result.record(inout out, eligible, eligible && resources > tiles,
             resources + tiles * 13 + region);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/system_network_recover.rue
+++ b/examples/caldera/system_network_recover.rue
@@ -82,7 +82,7 @@ fn inspect_regions(inout out: result.Result, borrow world: model.World) {
         let mut i: u64 = 0;
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
-            if tile.region == region { tiles = tiles + 1; resources = resources + tile.resource; }
+            if tile.region == region { tiles += 1; resources += tile.resource; }
             i += 1;
         }
         let eligible = tiles > 0 && (region + FOCUS()) % 4 == 0;

--- a/examples/caldera/system_network_replicate.rue
+++ b/examples/caldera/system_network_replicate.rue
@@ -39,7 +39,7 @@ fn inspect_entities(inout out: result.Result, borrow world: model.World) {
         let eligible = eligible_entity(borrow world, borrow entity);
         let command = eligible && (entity.id + FOCUS() + world.tick) % 2 == 0;
         result.record(inout out, eligible, command, entity_value(borrow world, borrow entity));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -51,7 +51,7 @@ fn inspect_tiles(inout out: result.Result, borrow world: model.World) {
         let command = eligible && tile.resource > FOCUS() % 17;
         result.record(inout out, eligible, command,
             tile.height + tile.resource + tile.terrain * 11 + i % 97);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -62,7 +62,7 @@ fn inspect_timeline(inout out: result.Result, borrow world: model.World) {
         let eligible = (event.kind + FOCUS()) % 4 == 0;
         result.record(inout out, eligible, eligible && event.value > 0,
             event.sequence + event.actor % 257 + event.value);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
@@ -70,7 +70,7 @@ fn inspect_timeline(inout out: result.Result, borrow world: model.World) {
         let eligible = command.accepted && (command.kind + FOCUS()) % 3 == 0;
         result.record(inout out, eligible, eligible,
             command.tick + command.actor % 251 + command.value);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -83,12 +83,12 @@ fn inspect_regions(inout out: result.Result, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region { tiles = tiles + 1; resources = resources + tile.resource; }
-            i = i + 1;
+            i += 1;
         }
         let eligible = tiles > 0 && (region + FOCUS()) % 4 == 0;
         result.record(inout out, eligible, eligible && resources > tiles,
             resources + tiles * 13 + region);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/system_network_replicate.rue
+++ b/examples/caldera/system_network_replicate.rue
@@ -82,7 +82,7 @@ fn inspect_regions(inout out: result.Result, borrow world: model.World) {
         let mut i: u64 = 0;
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
-            if tile.region == region { tiles = tiles + 1; resources = resources + tile.resource; }
+            if tile.region == region { tiles += 1; resources += tile.resource; }
             i += 1;
         }
         let eligible = tiles > 0 && (region + FOCUS()) % 4 == 0;

--- a/examples/caldera/system_network_resolve.rue
+++ b/examples/caldera/system_network_resolve.rue
@@ -39,7 +39,7 @@ fn inspect_entities(inout out: result.Result, borrow world: model.World) {
         let eligible = eligible_entity(borrow world, borrow entity);
         let command = eligible && (entity.id + FOCUS() + world.tick) % 2 == 0;
         result.record(inout out, eligible, command, entity_value(borrow world, borrow entity));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -51,7 +51,7 @@ fn inspect_tiles(inout out: result.Result, borrow world: model.World) {
         let command = eligible && tile.resource > FOCUS() % 17;
         result.record(inout out, eligible, command,
             tile.height + tile.resource + tile.terrain * 11 + i % 97);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -62,7 +62,7 @@ fn inspect_timeline(inout out: result.Result, borrow world: model.World) {
         let eligible = (event.kind + FOCUS()) % 4 == 0;
         result.record(inout out, eligible, eligible && event.value > 0,
             event.sequence + event.actor % 257 + event.value);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
@@ -70,7 +70,7 @@ fn inspect_timeline(inout out: result.Result, borrow world: model.World) {
         let eligible = command.accepted && (command.kind + FOCUS()) % 3 == 0;
         result.record(inout out, eligible, eligible,
             command.tick + command.actor % 251 + command.value);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -83,12 +83,12 @@ fn inspect_regions(inout out: result.Result, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region { tiles = tiles + 1; resources = resources + tile.resource; }
-            i = i + 1;
+            i += 1;
         }
         let eligible = tiles > 0 && (region + FOCUS()) % 4 == 0;
         result.record(inout out, eligible, eligible && resources > tiles,
             resources + tiles * 13 + region);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/system_network_resolve.rue
+++ b/examples/caldera/system_network_resolve.rue
@@ -82,7 +82,7 @@ fn inspect_regions(inout out: result.Result, borrow world: model.World) {
         let mut i: u64 = 0;
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
-            if tile.region == region { tiles = tiles + 1; resources = resources + tile.resource; }
+            if tile.region == region { tiles += 1; resources += tile.resource; }
             i += 1;
         }
         let eligible = tiles > 0 && (region + FOCUS()) % 4 == 0;

--- a/examples/caldera/system_network_schedule.rue
+++ b/examples/caldera/system_network_schedule.rue
@@ -39,7 +39,7 @@ fn inspect_entities(inout out: result.Result, borrow world: model.World) {
         let eligible = eligible_entity(borrow world, borrow entity);
         let command = eligible && (entity.id + FOCUS() + world.tick) % 2 == 0;
         result.record(inout out, eligible, command, entity_value(borrow world, borrow entity));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -51,7 +51,7 @@ fn inspect_tiles(inout out: result.Result, borrow world: model.World) {
         let command = eligible && tile.resource > FOCUS() % 17;
         result.record(inout out, eligible, command,
             tile.height + tile.resource + tile.terrain * 11 + i % 97);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -62,7 +62,7 @@ fn inspect_timeline(inout out: result.Result, borrow world: model.World) {
         let eligible = (event.kind + FOCUS()) % 4 == 0;
         result.record(inout out, eligible, eligible && event.value > 0,
             event.sequence + event.actor % 257 + event.value);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
@@ -70,7 +70,7 @@ fn inspect_timeline(inout out: result.Result, borrow world: model.World) {
         let eligible = command.accepted && (command.kind + FOCUS()) % 3 == 0;
         result.record(inout out, eligible, eligible,
             command.tick + command.actor % 251 + command.value);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -83,12 +83,12 @@ fn inspect_regions(inout out: result.Result, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region { tiles = tiles + 1; resources = resources + tile.resource; }
-            i = i + 1;
+            i += 1;
         }
         let eligible = tiles > 0 && (region + FOCUS()) % 4 == 0;
         result.record(inout out, eligible, eligible && resources > tiles,
             resources + tiles * 13 + region);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/system_network_schedule.rue
+++ b/examples/caldera/system_network_schedule.rue
@@ -82,7 +82,7 @@ fn inspect_regions(inout out: result.Result, borrow world: model.World) {
         let mut i: u64 = 0;
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
-            if tile.region == region { tiles = tiles + 1; resources = resources + tile.resource; }
+            if tile.region == region { tiles += 1; resources += tile.resource; }
             i += 1;
         }
         let eligible = tiles > 0 && (region + FOCUS()) % 4 == 0;

--- a/examples/caldera/system_network_validate.rue
+++ b/examples/caldera/system_network_validate.rue
@@ -39,7 +39,7 @@ fn inspect_entities(inout out: result.Result, borrow world: model.World) {
         let eligible = eligible_entity(borrow world, borrow entity);
         let command = eligible && (entity.id + FOCUS() + world.tick) % 2 == 0;
         result.record(inout out, eligible, command, entity_value(borrow world, borrow entity));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -51,7 +51,7 @@ fn inspect_tiles(inout out: result.Result, borrow world: model.World) {
         let command = eligible && tile.resource > FOCUS() % 17;
         result.record(inout out, eligible, command,
             tile.height + tile.resource + tile.terrain * 11 + i % 97);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -62,7 +62,7 @@ fn inspect_timeline(inout out: result.Result, borrow world: model.World) {
         let eligible = (event.kind + FOCUS()) % 4 == 0;
         result.record(inout out, eligible, eligible && event.value > 0,
             event.sequence + event.actor % 257 + event.value);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
@@ -70,7 +70,7 @@ fn inspect_timeline(inout out: result.Result, borrow world: model.World) {
         let eligible = command.accepted && (command.kind + FOCUS()) % 3 == 0;
         result.record(inout out, eligible, eligible,
             command.tick + command.actor % 251 + command.value);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -83,12 +83,12 @@ fn inspect_regions(inout out: result.Result, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region { tiles = tiles + 1; resources = resources + tile.resource; }
-            i = i + 1;
+            i += 1;
         }
         let eligible = tiles > 0 && (region + FOCUS()) % 4 == 0;
         result.record(inout out, eligible, eligible && resources > tiles,
             resources + tiles * 13 + region);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/system_network_validate.rue
+++ b/examples/caldera/system_network_validate.rue
@@ -82,7 +82,7 @@ fn inspect_regions(inout out: result.Result, borrow world: model.World) {
         let mut i: u64 = 0;
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
-            if tile.region == region { tiles = tiles + 1; resources = resources + tile.resource; }
+            if tile.region == region { tiles += 1; resources += tile.resource; }
             i += 1;
         }
         let eligible = tiles > 0 && (region + FOCUS()) % 4 == 0;

--- a/examples/caldera/system_perception_apply.rue
+++ b/examples/caldera/system_perception_apply.rue
@@ -39,7 +39,7 @@ fn inspect_entities(inout out: result.Result, borrow world: model.World) {
         let eligible = eligible_entity(borrow world, borrow entity);
         let command = eligible && (entity.id + FOCUS() + world.tick) % 2 == 0;
         result.record(inout out, eligible, command, entity_value(borrow world, borrow entity));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -51,7 +51,7 @@ fn inspect_tiles(inout out: result.Result, borrow world: model.World) {
         let command = eligible && tile.resource > FOCUS() % 17;
         result.record(inout out, eligible, command,
             tile.height + tile.resource + tile.terrain * 11 + i % 97);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -62,7 +62,7 @@ fn inspect_timeline(inout out: result.Result, borrow world: model.World) {
         let eligible = (event.kind + FOCUS()) % 4 == 0;
         result.record(inout out, eligible, eligible && event.value > 0,
             event.sequence + event.actor % 257 + event.value);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
@@ -70,7 +70,7 @@ fn inspect_timeline(inout out: result.Result, borrow world: model.World) {
         let eligible = command.accepted && (command.kind + FOCUS()) % 3 == 0;
         result.record(inout out, eligible, eligible,
             command.tick + command.actor % 251 + command.value);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -83,12 +83,12 @@ fn inspect_regions(inout out: result.Result, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region { tiles = tiles + 1; resources = resources + tile.resource; }
-            i = i + 1;
+            i += 1;
         }
         let eligible = tiles > 0 && (region + FOCUS()) % 4 == 0;
         result.record(inout out, eligible, eligible && resources > tiles,
             resources + tiles * 13 + region);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/system_perception_apply.rue
+++ b/examples/caldera/system_perception_apply.rue
@@ -82,7 +82,7 @@ fn inspect_regions(inout out: result.Result, borrow world: model.World) {
         let mut i: u64 = 0;
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
-            if tile.region == region { tiles = tiles + 1; resources = resources + tile.resource; }
+            if tile.region == region { tiles += 1; resources += tile.resource; }
             i += 1;
         }
         let eligible = tiles > 0 && (region + FOCUS()) % 4 == 0;

--- a/examples/caldera/system_perception_audit.rue
+++ b/examples/caldera/system_perception_audit.rue
@@ -39,7 +39,7 @@ fn inspect_entities(inout out: result.Result, borrow world: model.World) {
         let eligible = eligible_entity(borrow world, borrow entity);
         let command = eligible && (entity.id + FOCUS() + world.tick) % 2 == 0;
         result.record(inout out, eligible, command, entity_value(borrow world, borrow entity));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -51,7 +51,7 @@ fn inspect_tiles(inout out: result.Result, borrow world: model.World) {
         let command = eligible && tile.resource > FOCUS() % 17;
         result.record(inout out, eligible, command,
             tile.height + tile.resource + tile.terrain * 11 + i % 97);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -62,7 +62,7 @@ fn inspect_timeline(inout out: result.Result, borrow world: model.World) {
         let eligible = (event.kind + FOCUS()) % 4 == 0;
         result.record(inout out, eligible, eligible && event.value > 0,
             event.sequence + event.actor % 257 + event.value);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
@@ -70,7 +70,7 @@ fn inspect_timeline(inout out: result.Result, borrow world: model.World) {
         let eligible = command.accepted && (command.kind + FOCUS()) % 3 == 0;
         result.record(inout out, eligible, eligible,
             command.tick + command.actor % 251 + command.value);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -83,12 +83,12 @@ fn inspect_regions(inout out: result.Result, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region { tiles = tiles + 1; resources = resources + tile.resource; }
-            i = i + 1;
+            i += 1;
         }
         let eligible = tiles > 0 && (region + FOCUS()) % 4 == 0;
         result.record(inout out, eligible, eligible && resources > tiles,
             resources + tiles * 13 + region);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/system_perception_audit.rue
+++ b/examples/caldera/system_perception_audit.rue
@@ -82,7 +82,7 @@ fn inspect_regions(inout out: result.Result, borrow world: model.World) {
         let mut i: u64 = 0;
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
-            if tile.region == region { tiles = tiles + 1; resources = resources + tile.resource; }
+            if tile.region == region { tiles += 1; resources += tile.resource; }
             i += 1;
         }
         let eligible = tiles > 0 && (region + FOCUS()) % 4 == 0;

--- a/examples/caldera/system_perception_bootstrap.rue
+++ b/examples/caldera/system_perception_bootstrap.rue
@@ -39,7 +39,7 @@ fn inspect_entities(inout out: result.Result, borrow world: model.World) {
         let eligible = eligible_entity(borrow world, borrow entity);
         let command = eligible && (entity.id + FOCUS() + world.tick) % 2 == 0;
         result.record(inout out, eligible, command, entity_value(borrow world, borrow entity));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -51,7 +51,7 @@ fn inspect_tiles(inout out: result.Result, borrow world: model.World) {
         let command = eligible && tile.resource > FOCUS() % 17;
         result.record(inout out, eligible, command,
             tile.height + tile.resource + tile.terrain * 11 + i % 97);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -62,7 +62,7 @@ fn inspect_timeline(inout out: result.Result, borrow world: model.World) {
         let eligible = (event.kind + FOCUS()) % 4 == 0;
         result.record(inout out, eligible, eligible && event.value > 0,
             event.sequence + event.actor % 257 + event.value);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
@@ -70,7 +70,7 @@ fn inspect_timeline(inout out: result.Result, borrow world: model.World) {
         let eligible = command.accepted && (command.kind + FOCUS()) % 3 == 0;
         result.record(inout out, eligible, eligible,
             command.tick + command.actor % 251 + command.value);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -83,12 +83,12 @@ fn inspect_regions(inout out: result.Result, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region { tiles = tiles + 1; resources = resources + tile.resource; }
-            i = i + 1;
+            i += 1;
         }
         let eligible = tiles > 0 && (region + FOCUS()) % 4 == 0;
         result.record(inout out, eligible, eligible && resources > tiles,
             resources + tiles * 13 + region);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/system_perception_bootstrap.rue
+++ b/examples/caldera/system_perception_bootstrap.rue
@@ -82,7 +82,7 @@ fn inspect_regions(inout out: result.Result, borrow world: model.World) {
         let mut i: u64 = 0;
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
-            if tile.region == region { tiles = tiles + 1; resources = resources + tile.resource; }
+            if tile.region == region { tiles += 1; resources += tile.resource; }
             i += 1;
         }
         let eligible = tiles > 0 && (region + FOCUS()) % 4 == 0;

--- a/examples/caldera/system_perception_checkpoint.rue
+++ b/examples/caldera/system_perception_checkpoint.rue
@@ -39,7 +39,7 @@ fn inspect_entities(inout out: result.Result, borrow world: model.World) {
         let eligible = eligible_entity(borrow world, borrow entity);
         let command = eligible && (entity.id + FOCUS() + world.tick) % 2 == 0;
         result.record(inout out, eligible, command, entity_value(borrow world, borrow entity));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -51,7 +51,7 @@ fn inspect_tiles(inout out: result.Result, borrow world: model.World) {
         let command = eligible && tile.resource > FOCUS() % 17;
         result.record(inout out, eligible, command,
             tile.height + tile.resource + tile.terrain * 11 + i % 97);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -62,7 +62,7 @@ fn inspect_timeline(inout out: result.Result, borrow world: model.World) {
         let eligible = (event.kind + FOCUS()) % 4 == 0;
         result.record(inout out, eligible, eligible && event.value > 0,
             event.sequence + event.actor % 257 + event.value);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
@@ -70,7 +70,7 @@ fn inspect_timeline(inout out: result.Result, borrow world: model.World) {
         let eligible = command.accepted && (command.kind + FOCUS()) % 3 == 0;
         result.record(inout out, eligible, eligible,
             command.tick + command.actor % 251 + command.value);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -83,12 +83,12 @@ fn inspect_regions(inout out: result.Result, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region { tiles = tiles + 1; resources = resources + tile.resource; }
-            i = i + 1;
+            i += 1;
         }
         let eligible = tiles > 0 && (region + FOCUS()) % 4 == 0;
         result.record(inout out, eligible, eligible && resources > tiles,
             resources + tiles * 13 + region);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/system_perception_checkpoint.rue
+++ b/examples/caldera/system_perception_checkpoint.rue
@@ -82,7 +82,7 @@ fn inspect_regions(inout out: result.Result, borrow world: model.World) {
         let mut i: u64 = 0;
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
-            if tile.region == region { tiles = tiles + 1; resources = resources + tile.resource; }
+            if tile.region == region { tiles += 1; resources += tile.resource; }
             i += 1;
         }
         let eligible = tiles > 0 && (region + FOCUS()) % 4 == 0;

--- a/examples/caldera/system_perception_compact.rue
+++ b/examples/caldera/system_perception_compact.rue
@@ -39,7 +39,7 @@ fn inspect_entities(inout out: result.Result, borrow world: model.World) {
         let eligible = eligible_entity(borrow world, borrow entity);
         let command = eligible && (entity.id + FOCUS() + world.tick) % 2 == 0;
         result.record(inout out, eligible, command, entity_value(borrow world, borrow entity));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -51,7 +51,7 @@ fn inspect_tiles(inout out: result.Result, borrow world: model.World) {
         let command = eligible && tile.resource > FOCUS() % 17;
         result.record(inout out, eligible, command,
             tile.height + tile.resource + tile.terrain * 11 + i % 97);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -62,7 +62,7 @@ fn inspect_timeline(inout out: result.Result, borrow world: model.World) {
         let eligible = (event.kind + FOCUS()) % 4 == 0;
         result.record(inout out, eligible, eligible && event.value > 0,
             event.sequence + event.actor % 257 + event.value);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
@@ -70,7 +70,7 @@ fn inspect_timeline(inout out: result.Result, borrow world: model.World) {
         let eligible = command.accepted && (command.kind + FOCUS()) % 3 == 0;
         result.record(inout out, eligible, eligible,
             command.tick + command.actor % 251 + command.value);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -83,12 +83,12 @@ fn inspect_regions(inout out: result.Result, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region { tiles = tiles + 1; resources = resources + tile.resource; }
-            i = i + 1;
+            i += 1;
         }
         let eligible = tiles > 0 && (region + FOCUS()) % 4 == 0;
         result.record(inout out, eligible, eligible && resources > tiles,
             resources + tiles * 13 + region);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/system_perception_compact.rue
+++ b/examples/caldera/system_perception_compact.rue
@@ -82,7 +82,7 @@ fn inspect_regions(inout out: result.Result, borrow world: model.World) {
         let mut i: u64 = 0;
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
-            if tile.region == region { tiles = tiles + 1; resources = resources + tile.resource; }
+            if tile.region == region { tiles += 1; resources += tile.resource; }
             i += 1;
         }
         let eligible = tiles > 0 && (region + FOCUS()) % 4 == 0;

--- a/examples/caldera/system_perception_discover.rue
+++ b/examples/caldera/system_perception_discover.rue
@@ -39,7 +39,7 @@ fn inspect_entities(inout out: result.Result, borrow world: model.World) {
         let eligible = eligible_entity(borrow world, borrow entity);
         let command = eligible && (entity.id + FOCUS() + world.tick) % 2 == 0;
         result.record(inout out, eligible, command, entity_value(borrow world, borrow entity));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -51,7 +51,7 @@ fn inspect_tiles(inout out: result.Result, borrow world: model.World) {
         let command = eligible && tile.resource > FOCUS() % 17;
         result.record(inout out, eligible, command,
             tile.height + tile.resource + tile.terrain * 11 + i % 97);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -62,7 +62,7 @@ fn inspect_timeline(inout out: result.Result, borrow world: model.World) {
         let eligible = (event.kind + FOCUS()) % 4 == 0;
         result.record(inout out, eligible, eligible && event.value > 0,
             event.sequence + event.actor % 257 + event.value);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
@@ -70,7 +70,7 @@ fn inspect_timeline(inout out: result.Result, borrow world: model.World) {
         let eligible = command.accepted && (command.kind + FOCUS()) % 3 == 0;
         result.record(inout out, eligible, eligible,
             command.tick + command.actor % 251 + command.value);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -83,12 +83,12 @@ fn inspect_regions(inout out: result.Result, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region { tiles = tiles + 1; resources = resources + tile.resource; }
-            i = i + 1;
+            i += 1;
         }
         let eligible = tiles > 0 && (region + FOCUS()) % 4 == 0;
         result.record(inout out, eligible, eligible && resources > tiles,
             resources + tiles * 13 + region);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/system_perception_discover.rue
+++ b/examples/caldera/system_perception_discover.rue
@@ -82,7 +82,7 @@ fn inspect_regions(inout out: result.Result, borrow world: model.World) {
         let mut i: u64 = 0;
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
-            if tile.region == region { tiles = tiles + 1; resources = resources + tile.resource; }
+            if tile.region == region { tiles += 1; resources += tile.resource; }
             i += 1;
         }
         let eligible = tiles > 0 && (region + FOCUS()) % 4 == 0;

--- a/examples/caldera/system_perception_dispatch.rue
+++ b/examples/caldera/system_perception_dispatch.rue
@@ -39,7 +39,7 @@ fn inspect_entities(inout out: result.Result, borrow world: model.World) {
         let eligible = eligible_entity(borrow world, borrow entity);
         let command = eligible && (entity.id + FOCUS() + world.tick) % 2 == 0;
         result.record(inout out, eligible, command, entity_value(borrow world, borrow entity));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -51,7 +51,7 @@ fn inspect_tiles(inout out: result.Result, borrow world: model.World) {
         let command = eligible && tile.resource > FOCUS() % 17;
         result.record(inout out, eligible, command,
             tile.height + tile.resource + tile.terrain * 11 + i % 97);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -62,7 +62,7 @@ fn inspect_timeline(inout out: result.Result, borrow world: model.World) {
         let eligible = (event.kind + FOCUS()) % 4 == 0;
         result.record(inout out, eligible, eligible && event.value > 0,
             event.sequence + event.actor % 257 + event.value);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
@@ -70,7 +70,7 @@ fn inspect_timeline(inout out: result.Result, borrow world: model.World) {
         let eligible = command.accepted && (command.kind + FOCUS()) % 3 == 0;
         result.record(inout out, eligible, eligible,
             command.tick + command.actor % 251 + command.value);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -83,12 +83,12 @@ fn inspect_regions(inout out: result.Result, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region { tiles = tiles + 1; resources = resources + tile.resource; }
-            i = i + 1;
+            i += 1;
         }
         let eligible = tiles > 0 && (region + FOCUS()) % 4 == 0;
         result.record(inout out, eligible, eligible && resources > tiles,
             resources + tiles * 13 + region);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/system_perception_dispatch.rue
+++ b/examples/caldera/system_perception_dispatch.rue
@@ -82,7 +82,7 @@ fn inspect_regions(inout out: result.Result, borrow world: model.World) {
         let mut i: u64 = 0;
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
-            if tile.region == region { tiles = tiles + 1; resources = resources + tile.resource; }
+            if tile.region == region { tiles += 1; resources += tile.resource; }
             i += 1;
         }
         let eligible = tiles > 0 && (region + FOCUS()) % 4 == 0;

--- a/examples/caldera/system_perception_finalize.rue
+++ b/examples/caldera/system_perception_finalize.rue
@@ -39,7 +39,7 @@ fn inspect_entities(inout out: result.Result, borrow world: model.World) {
         let eligible = eligible_entity(borrow world, borrow entity);
         let command = eligible && (entity.id + FOCUS() + world.tick) % 2 == 0;
         result.record(inout out, eligible, command, entity_value(borrow world, borrow entity));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -51,7 +51,7 @@ fn inspect_tiles(inout out: result.Result, borrow world: model.World) {
         let command = eligible && tile.resource > FOCUS() % 17;
         result.record(inout out, eligible, command,
             tile.height + tile.resource + tile.terrain * 11 + i % 97);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -62,7 +62,7 @@ fn inspect_timeline(inout out: result.Result, borrow world: model.World) {
         let eligible = (event.kind + FOCUS()) % 4 == 0;
         result.record(inout out, eligible, eligible && event.value > 0,
             event.sequence + event.actor % 257 + event.value);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
@@ -70,7 +70,7 @@ fn inspect_timeline(inout out: result.Result, borrow world: model.World) {
         let eligible = command.accepted && (command.kind + FOCUS()) % 3 == 0;
         result.record(inout out, eligible, eligible,
             command.tick + command.actor % 251 + command.value);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -83,12 +83,12 @@ fn inspect_regions(inout out: result.Result, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region { tiles = tiles + 1; resources = resources + tile.resource; }
-            i = i + 1;
+            i += 1;
         }
         let eligible = tiles > 0 && (region + FOCUS()) % 4 == 0;
         result.record(inout out, eligible, eligible && resources > tiles,
             resources + tiles * 13 + region);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/system_perception_finalize.rue
+++ b/examples/caldera/system_perception_finalize.rue
@@ -82,7 +82,7 @@ fn inspect_regions(inout out: result.Result, borrow world: model.World) {
         let mut i: u64 = 0;
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
-            if tile.region == region { tiles = tiles + 1; resources = resources + tile.resource; }
+            if tile.region == region { tiles += 1; resources += tile.resource; }
             i += 1;
         }
         let eligible = tiles > 0 && (region + FOCUS()) % 4 == 0;

--- a/examples/caldera/system_perception_observe.rue
+++ b/examples/caldera/system_perception_observe.rue
@@ -39,7 +39,7 @@ fn inspect_entities(inout out: result.Result, borrow world: model.World) {
         let eligible = eligible_entity(borrow world, borrow entity);
         let command = eligible && (entity.id + FOCUS() + world.tick) % 2 == 0;
         result.record(inout out, eligible, command, entity_value(borrow world, borrow entity));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -51,7 +51,7 @@ fn inspect_tiles(inout out: result.Result, borrow world: model.World) {
         let command = eligible && tile.resource > FOCUS() % 17;
         result.record(inout out, eligible, command,
             tile.height + tile.resource + tile.terrain * 11 + i % 97);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -62,7 +62,7 @@ fn inspect_timeline(inout out: result.Result, borrow world: model.World) {
         let eligible = (event.kind + FOCUS()) % 4 == 0;
         result.record(inout out, eligible, eligible && event.value > 0,
             event.sequence + event.actor % 257 + event.value);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
@@ -70,7 +70,7 @@ fn inspect_timeline(inout out: result.Result, borrow world: model.World) {
         let eligible = command.accepted && (command.kind + FOCUS()) % 3 == 0;
         result.record(inout out, eligible, eligible,
             command.tick + command.actor % 251 + command.value);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -83,12 +83,12 @@ fn inspect_regions(inout out: result.Result, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region { tiles = tiles + 1; resources = resources + tile.resource; }
-            i = i + 1;
+            i += 1;
         }
         let eligible = tiles > 0 && (region + FOCUS()) % 4 == 0;
         result.record(inout out, eligible, eligible && resources > tiles,
             resources + tiles * 13 + region);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/system_perception_observe.rue
+++ b/examples/caldera/system_perception_observe.rue
@@ -82,7 +82,7 @@ fn inspect_regions(inout out: result.Result, borrow world: model.World) {
         let mut i: u64 = 0;
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
-            if tile.region == region { tiles = tiles + 1; resources = resources + tile.resource; }
+            if tile.region == region { tiles += 1; resources += tile.resource; }
             i += 1;
         }
         let eligible = tiles > 0 && (region + FOCUS()) % 4 == 0;

--- a/examples/caldera/system_perception_prepare.rue
+++ b/examples/caldera/system_perception_prepare.rue
@@ -39,7 +39,7 @@ fn inspect_entities(inout out: result.Result, borrow world: model.World) {
         let eligible = eligible_entity(borrow world, borrow entity);
         let command = eligible && (entity.id + FOCUS() + world.tick) % 2 == 0;
         result.record(inout out, eligible, command, entity_value(borrow world, borrow entity));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -51,7 +51,7 @@ fn inspect_tiles(inout out: result.Result, borrow world: model.World) {
         let command = eligible && tile.resource > FOCUS() % 17;
         result.record(inout out, eligible, command,
             tile.height + tile.resource + tile.terrain * 11 + i % 97);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -62,7 +62,7 @@ fn inspect_timeline(inout out: result.Result, borrow world: model.World) {
         let eligible = (event.kind + FOCUS()) % 4 == 0;
         result.record(inout out, eligible, eligible && event.value > 0,
             event.sequence + event.actor % 257 + event.value);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
@@ -70,7 +70,7 @@ fn inspect_timeline(inout out: result.Result, borrow world: model.World) {
         let eligible = command.accepted && (command.kind + FOCUS()) % 3 == 0;
         result.record(inout out, eligible, eligible,
             command.tick + command.actor % 251 + command.value);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -83,12 +83,12 @@ fn inspect_regions(inout out: result.Result, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region { tiles = tiles + 1; resources = resources + tile.resource; }
-            i = i + 1;
+            i += 1;
         }
         let eligible = tiles > 0 && (region + FOCUS()) % 4 == 0;
         result.record(inout out, eligible, eligible && resources > tiles,
             resources + tiles * 13 + region);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/system_perception_prepare.rue
+++ b/examples/caldera/system_perception_prepare.rue
@@ -82,7 +82,7 @@ fn inspect_regions(inout out: result.Result, borrow world: model.World) {
         let mut i: u64 = 0;
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
-            if tile.region == region { tiles = tiles + 1; resources = resources + tile.resource; }
+            if tile.region == region { tiles += 1; resources += tile.resource; }
             i += 1;
         }
         let eligible = tiles > 0 && (region + FOCUS()) % 4 == 0;

--- a/examples/caldera/system_perception_reconcile.rue
+++ b/examples/caldera/system_perception_reconcile.rue
@@ -39,7 +39,7 @@ fn inspect_entities(inout out: result.Result, borrow world: model.World) {
         let eligible = eligible_entity(borrow world, borrow entity);
         let command = eligible && (entity.id + FOCUS() + world.tick) % 2 == 0;
         result.record(inout out, eligible, command, entity_value(borrow world, borrow entity));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -51,7 +51,7 @@ fn inspect_tiles(inout out: result.Result, borrow world: model.World) {
         let command = eligible && tile.resource > FOCUS() % 17;
         result.record(inout out, eligible, command,
             tile.height + tile.resource + tile.terrain * 11 + i % 97);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -62,7 +62,7 @@ fn inspect_timeline(inout out: result.Result, borrow world: model.World) {
         let eligible = (event.kind + FOCUS()) % 4 == 0;
         result.record(inout out, eligible, eligible && event.value > 0,
             event.sequence + event.actor % 257 + event.value);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
@@ -70,7 +70,7 @@ fn inspect_timeline(inout out: result.Result, borrow world: model.World) {
         let eligible = command.accepted && (command.kind + FOCUS()) % 3 == 0;
         result.record(inout out, eligible, eligible,
             command.tick + command.actor % 251 + command.value);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -83,12 +83,12 @@ fn inspect_regions(inout out: result.Result, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region { tiles = tiles + 1; resources = resources + tile.resource; }
-            i = i + 1;
+            i += 1;
         }
         let eligible = tiles > 0 && (region + FOCUS()) % 4 == 0;
         result.record(inout out, eligible, eligible && resources > tiles,
             resources + tiles * 13 + region);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/system_perception_reconcile.rue
+++ b/examples/caldera/system_perception_reconcile.rue
@@ -82,7 +82,7 @@ fn inspect_regions(inout out: result.Result, borrow world: model.World) {
         let mut i: u64 = 0;
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
-            if tile.region == region { tiles = tiles + 1; resources = resources + tile.resource; }
+            if tile.region == region { tiles += 1; resources += tile.resource; }
             i += 1;
         }
         let eligible = tiles > 0 && (region + FOCUS()) % 4 == 0;

--- a/examples/caldera/system_perception_recover.rue
+++ b/examples/caldera/system_perception_recover.rue
@@ -39,7 +39,7 @@ fn inspect_entities(inout out: result.Result, borrow world: model.World) {
         let eligible = eligible_entity(borrow world, borrow entity);
         let command = eligible && (entity.id + FOCUS() + world.tick) % 2 == 0;
         result.record(inout out, eligible, command, entity_value(borrow world, borrow entity));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -51,7 +51,7 @@ fn inspect_tiles(inout out: result.Result, borrow world: model.World) {
         let command = eligible && tile.resource > FOCUS() % 17;
         result.record(inout out, eligible, command,
             tile.height + tile.resource + tile.terrain * 11 + i % 97);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -62,7 +62,7 @@ fn inspect_timeline(inout out: result.Result, borrow world: model.World) {
         let eligible = (event.kind + FOCUS()) % 4 == 0;
         result.record(inout out, eligible, eligible && event.value > 0,
             event.sequence + event.actor % 257 + event.value);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
@@ -70,7 +70,7 @@ fn inspect_timeline(inout out: result.Result, borrow world: model.World) {
         let eligible = command.accepted && (command.kind + FOCUS()) % 3 == 0;
         result.record(inout out, eligible, eligible,
             command.tick + command.actor % 251 + command.value);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -83,12 +83,12 @@ fn inspect_regions(inout out: result.Result, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region { tiles = tiles + 1; resources = resources + tile.resource; }
-            i = i + 1;
+            i += 1;
         }
         let eligible = tiles > 0 && (region + FOCUS()) % 4 == 0;
         result.record(inout out, eligible, eligible && resources > tiles,
             resources + tiles * 13 + region);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/system_perception_recover.rue
+++ b/examples/caldera/system_perception_recover.rue
@@ -82,7 +82,7 @@ fn inspect_regions(inout out: result.Result, borrow world: model.World) {
         let mut i: u64 = 0;
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
-            if tile.region == region { tiles = tiles + 1; resources = resources + tile.resource; }
+            if tile.region == region { tiles += 1; resources += tile.resource; }
             i += 1;
         }
         let eligible = tiles > 0 && (region + FOCUS()) % 4 == 0;

--- a/examples/caldera/system_perception_replicate.rue
+++ b/examples/caldera/system_perception_replicate.rue
@@ -39,7 +39,7 @@ fn inspect_entities(inout out: result.Result, borrow world: model.World) {
         let eligible = eligible_entity(borrow world, borrow entity);
         let command = eligible && (entity.id + FOCUS() + world.tick) % 2 == 0;
         result.record(inout out, eligible, command, entity_value(borrow world, borrow entity));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -51,7 +51,7 @@ fn inspect_tiles(inout out: result.Result, borrow world: model.World) {
         let command = eligible && tile.resource > FOCUS() % 17;
         result.record(inout out, eligible, command,
             tile.height + tile.resource + tile.terrain * 11 + i % 97);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -62,7 +62,7 @@ fn inspect_timeline(inout out: result.Result, borrow world: model.World) {
         let eligible = (event.kind + FOCUS()) % 4 == 0;
         result.record(inout out, eligible, eligible && event.value > 0,
             event.sequence + event.actor % 257 + event.value);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
@@ -70,7 +70,7 @@ fn inspect_timeline(inout out: result.Result, borrow world: model.World) {
         let eligible = command.accepted && (command.kind + FOCUS()) % 3 == 0;
         result.record(inout out, eligible, eligible,
             command.tick + command.actor % 251 + command.value);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -83,12 +83,12 @@ fn inspect_regions(inout out: result.Result, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region { tiles = tiles + 1; resources = resources + tile.resource; }
-            i = i + 1;
+            i += 1;
         }
         let eligible = tiles > 0 && (region + FOCUS()) % 4 == 0;
         result.record(inout out, eligible, eligible && resources > tiles,
             resources + tiles * 13 + region);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/system_perception_replicate.rue
+++ b/examples/caldera/system_perception_replicate.rue
@@ -82,7 +82,7 @@ fn inspect_regions(inout out: result.Result, borrow world: model.World) {
         let mut i: u64 = 0;
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
-            if tile.region == region { tiles = tiles + 1; resources = resources + tile.resource; }
+            if tile.region == region { tiles += 1; resources += tile.resource; }
             i += 1;
         }
         let eligible = tiles > 0 && (region + FOCUS()) % 4 == 0;

--- a/examples/caldera/system_perception_resolve.rue
+++ b/examples/caldera/system_perception_resolve.rue
@@ -39,7 +39,7 @@ fn inspect_entities(inout out: result.Result, borrow world: model.World) {
         let eligible = eligible_entity(borrow world, borrow entity);
         let command = eligible && (entity.id + FOCUS() + world.tick) % 2 == 0;
         result.record(inout out, eligible, command, entity_value(borrow world, borrow entity));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -51,7 +51,7 @@ fn inspect_tiles(inout out: result.Result, borrow world: model.World) {
         let command = eligible && tile.resource > FOCUS() % 17;
         result.record(inout out, eligible, command,
             tile.height + tile.resource + tile.terrain * 11 + i % 97);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -62,7 +62,7 @@ fn inspect_timeline(inout out: result.Result, borrow world: model.World) {
         let eligible = (event.kind + FOCUS()) % 4 == 0;
         result.record(inout out, eligible, eligible && event.value > 0,
             event.sequence + event.actor % 257 + event.value);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
@@ -70,7 +70,7 @@ fn inspect_timeline(inout out: result.Result, borrow world: model.World) {
         let eligible = command.accepted && (command.kind + FOCUS()) % 3 == 0;
         result.record(inout out, eligible, eligible,
             command.tick + command.actor % 251 + command.value);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -83,12 +83,12 @@ fn inspect_regions(inout out: result.Result, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region { tiles = tiles + 1; resources = resources + tile.resource; }
-            i = i + 1;
+            i += 1;
         }
         let eligible = tiles > 0 && (region + FOCUS()) % 4 == 0;
         result.record(inout out, eligible, eligible && resources > tiles,
             resources + tiles * 13 + region);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/system_perception_resolve.rue
+++ b/examples/caldera/system_perception_resolve.rue
@@ -82,7 +82,7 @@ fn inspect_regions(inout out: result.Result, borrow world: model.World) {
         let mut i: u64 = 0;
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
-            if tile.region == region { tiles = tiles + 1; resources = resources + tile.resource; }
+            if tile.region == region { tiles += 1; resources += tile.resource; }
             i += 1;
         }
         let eligible = tiles > 0 && (region + FOCUS()) % 4 == 0;

--- a/examples/caldera/system_perception_schedule.rue
+++ b/examples/caldera/system_perception_schedule.rue
@@ -39,7 +39,7 @@ fn inspect_entities(inout out: result.Result, borrow world: model.World) {
         let eligible = eligible_entity(borrow world, borrow entity);
         let command = eligible && (entity.id + FOCUS() + world.tick) % 2 == 0;
         result.record(inout out, eligible, command, entity_value(borrow world, borrow entity));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -51,7 +51,7 @@ fn inspect_tiles(inout out: result.Result, borrow world: model.World) {
         let command = eligible && tile.resource > FOCUS() % 17;
         result.record(inout out, eligible, command,
             tile.height + tile.resource + tile.terrain * 11 + i % 97);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -62,7 +62,7 @@ fn inspect_timeline(inout out: result.Result, borrow world: model.World) {
         let eligible = (event.kind + FOCUS()) % 4 == 0;
         result.record(inout out, eligible, eligible && event.value > 0,
             event.sequence + event.actor % 257 + event.value);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
@@ -70,7 +70,7 @@ fn inspect_timeline(inout out: result.Result, borrow world: model.World) {
         let eligible = command.accepted && (command.kind + FOCUS()) % 3 == 0;
         result.record(inout out, eligible, eligible,
             command.tick + command.actor % 251 + command.value);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -83,12 +83,12 @@ fn inspect_regions(inout out: result.Result, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region { tiles = tiles + 1; resources = resources + tile.resource; }
-            i = i + 1;
+            i += 1;
         }
         let eligible = tiles > 0 && (region + FOCUS()) % 4 == 0;
         result.record(inout out, eligible, eligible && resources > tiles,
             resources + tiles * 13 + region);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/system_perception_schedule.rue
+++ b/examples/caldera/system_perception_schedule.rue
@@ -82,7 +82,7 @@ fn inspect_regions(inout out: result.Result, borrow world: model.World) {
         let mut i: u64 = 0;
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
-            if tile.region == region { tiles = tiles + 1; resources = resources + tile.resource; }
+            if tile.region == region { tiles += 1; resources += tile.resource; }
             i += 1;
         }
         let eligible = tiles > 0 && (region + FOCUS()) % 4 == 0;

--- a/examples/caldera/system_perception_validate.rue
+++ b/examples/caldera/system_perception_validate.rue
@@ -39,7 +39,7 @@ fn inspect_entities(inout out: result.Result, borrow world: model.World) {
         let eligible = eligible_entity(borrow world, borrow entity);
         let command = eligible && (entity.id + FOCUS() + world.tick) % 2 == 0;
         result.record(inout out, eligible, command, entity_value(borrow world, borrow entity));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -51,7 +51,7 @@ fn inspect_tiles(inout out: result.Result, borrow world: model.World) {
         let command = eligible && tile.resource > FOCUS() % 17;
         result.record(inout out, eligible, command,
             tile.height + tile.resource + tile.terrain * 11 + i % 97);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -62,7 +62,7 @@ fn inspect_timeline(inout out: result.Result, borrow world: model.World) {
         let eligible = (event.kind + FOCUS()) % 4 == 0;
         result.record(inout out, eligible, eligible && event.value > 0,
             event.sequence + event.actor % 257 + event.value);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
@@ -70,7 +70,7 @@ fn inspect_timeline(inout out: result.Result, borrow world: model.World) {
         let eligible = command.accepted && (command.kind + FOCUS()) % 3 == 0;
         result.record(inout out, eligible, eligible,
             command.tick + command.actor % 251 + command.value);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -83,12 +83,12 @@ fn inspect_regions(inout out: result.Result, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region { tiles = tiles + 1; resources = resources + tile.resource; }
-            i = i + 1;
+            i += 1;
         }
         let eligible = tiles > 0 && (region + FOCUS()) % 4 == 0;
         result.record(inout out, eligible, eligible && resources > tiles,
             resources + tiles * 13 + region);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/system_perception_validate.rue
+++ b/examples/caldera/system_perception_validate.rue
@@ -82,7 +82,7 @@ fn inspect_regions(inout out: result.Result, borrow world: model.World) {
         let mut i: u64 = 0;
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
-            if tile.region == region { tiles = tiles + 1; resources = resources + tile.resource; }
+            if tile.region == region { tiles += 1; resources += tile.resource; }
             i += 1;
         }
         let eligible = tiles > 0 && (region + FOCUS()) % 4 == 0;

--- a/examples/caldera/system_production_apply.rue
+++ b/examples/caldera/system_production_apply.rue
@@ -39,7 +39,7 @@ fn inspect_entities(inout out: result.Result, borrow world: model.World) {
         let eligible = eligible_entity(borrow world, borrow entity);
         let command = eligible && (entity.id + FOCUS() + world.tick) % 2 == 0;
         result.record(inout out, eligible, command, entity_value(borrow world, borrow entity));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -51,7 +51,7 @@ fn inspect_tiles(inout out: result.Result, borrow world: model.World) {
         let command = eligible && tile.resource > FOCUS() % 17;
         result.record(inout out, eligible, command,
             tile.height + tile.resource + tile.terrain * 11 + i % 97);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -62,7 +62,7 @@ fn inspect_timeline(inout out: result.Result, borrow world: model.World) {
         let eligible = (event.kind + FOCUS()) % 4 == 0;
         result.record(inout out, eligible, eligible && event.value > 0,
             event.sequence + event.actor % 257 + event.value);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
@@ -70,7 +70,7 @@ fn inspect_timeline(inout out: result.Result, borrow world: model.World) {
         let eligible = command.accepted && (command.kind + FOCUS()) % 3 == 0;
         result.record(inout out, eligible, eligible,
             command.tick + command.actor % 251 + command.value);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -83,12 +83,12 @@ fn inspect_regions(inout out: result.Result, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region { tiles = tiles + 1; resources = resources + tile.resource; }
-            i = i + 1;
+            i += 1;
         }
         let eligible = tiles > 0 && (region + FOCUS()) % 4 == 0;
         result.record(inout out, eligible, eligible && resources > tiles,
             resources + tiles * 13 + region);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/system_production_apply.rue
+++ b/examples/caldera/system_production_apply.rue
@@ -82,7 +82,7 @@ fn inspect_regions(inout out: result.Result, borrow world: model.World) {
         let mut i: u64 = 0;
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
-            if tile.region == region { tiles = tiles + 1; resources = resources + tile.resource; }
+            if tile.region == region { tiles += 1; resources += tile.resource; }
             i += 1;
         }
         let eligible = tiles > 0 && (region + FOCUS()) % 4 == 0;

--- a/examples/caldera/system_production_audit.rue
+++ b/examples/caldera/system_production_audit.rue
@@ -39,7 +39,7 @@ fn inspect_entities(inout out: result.Result, borrow world: model.World) {
         let eligible = eligible_entity(borrow world, borrow entity);
         let command = eligible && (entity.id + FOCUS() + world.tick) % 2 == 0;
         result.record(inout out, eligible, command, entity_value(borrow world, borrow entity));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -51,7 +51,7 @@ fn inspect_tiles(inout out: result.Result, borrow world: model.World) {
         let command = eligible && tile.resource > FOCUS() % 17;
         result.record(inout out, eligible, command,
             tile.height + tile.resource + tile.terrain * 11 + i % 97);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -62,7 +62,7 @@ fn inspect_timeline(inout out: result.Result, borrow world: model.World) {
         let eligible = (event.kind + FOCUS()) % 4 == 0;
         result.record(inout out, eligible, eligible && event.value > 0,
             event.sequence + event.actor % 257 + event.value);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
@@ -70,7 +70,7 @@ fn inspect_timeline(inout out: result.Result, borrow world: model.World) {
         let eligible = command.accepted && (command.kind + FOCUS()) % 3 == 0;
         result.record(inout out, eligible, eligible,
             command.tick + command.actor % 251 + command.value);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -83,12 +83,12 @@ fn inspect_regions(inout out: result.Result, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region { tiles = tiles + 1; resources = resources + tile.resource; }
-            i = i + 1;
+            i += 1;
         }
         let eligible = tiles > 0 && (region + FOCUS()) % 4 == 0;
         result.record(inout out, eligible, eligible && resources > tiles,
             resources + tiles * 13 + region);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/system_production_audit.rue
+++ b/examples/caldera/system_production_audit.rue
@@ -82,7 +82,7 @@ fn inspect_regions(inout out: result.Result, borrow world: model.World) {
         let mut i: u64 = 0;
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
-            if tile.region == region { tiles = tiles + 1; resources = resources + tile.resource; }
+            if tile.region == region { tiles += 1; resources += tile.resource; }
             i += 1;
         }
         let eligible = tiles > 0 && (region + FOCUS()) % 4 == 0;

--- a/examples/caldera/system_production_bootstrap.rue
+++ b/examples/caldera/system_production_bootstrap.rue
@@ -39,7 +39,7 @@ fn inspect_entities(inout out: result.Result, borrow world: model.World) {
         let eligible = eligible_entity(borrow world, borrow entity);
         let command = eligible && (entity.id + FOCUS() + world.tick) % 2 == 0;
         result.record(inout out, eligible, command, entity_value(borrow world, borrow entity));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -51,7 +51,7 @@ fn inspect_tiles(inout out: result.Result, borrow world: model.World) {
         let command = eligible && tile.resource > FOCUS() % 17;
         result.record(inout out, eligible, command,
             tile.height + tile.resource + tile.terrain * 11 + i % 97);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -62,7 +62,7 @@ fn inspect_timeline(inout out: result.Result, borrow world: model.World) {
         let eligible = (event.kind + FOCUS()) % 4 == 0;
         result.record(inout out, eligible, eligible && event.value > 0,
             event.sequence + event.actor % 257 + event.value);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
@@ -70,7 +70,7 @@ fn inspect_timeline(inout out: result.Result, borrow world: model.World) {
         let eligible = command.accepted && (command.kind + FOCUS()) % 3 == 0;
         result.record(inout out, eligible, eligible,
             command.tick + command.actor % 251 + command.value);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -83,12 +83,12 @@ fn inspect_regions(inout out: result.Result, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region { tiles = tiles + 1; resources = resources + tile.resource; }
-            i = i + 1;
+            i += 1;
         }
         let eligible = tiles > 0 && (region + FOCUS()) % 4 == 0;
         result.record(inout out, eligible, eligible && resources > tiles,
             resources + tiles * 13 + region);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/system_production_bootstrap.rue
+++ b/examples/caldera/system_production_bootstrap.rue
@@ -82,7 +82,7 @@ fn inspect_regions(inout out: result.Result, borrow world: model.World) {
         let mut i: u64 = 0;
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
-            if tile.region == region { tiles = tiles + 1; resources = resources + tile.resource; }
+            if tile.region == region { tiles += 1; resources += tile.resource; }
             i += 1;
         }
         let eligible = tiles > 0 && (region + FOCUS()) % 4 == 0;

--- a/examples/caldera/system_production_checkpoint.rue
+++ b/examples/caldera/system_production_checkpoint.rue
@@ -39,7 +39,7 @@ fn inspect_entities(inout out: result.Result, borrow world: model.World) {
         let eligible = eligible_entity(borrow world, borrow entity);
         let command = eligible && (entity.id + FOCUS() + world.tick) % 2 == 0;
         result.record(inout out, eligible, command, entity_value(borrow world, borrow entity));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -51,7 +51,7 @@ fn inspect_tiles(inout out: result.Result, borrow world: model.World) {
         let command = eligible && tile.resource > FOCUS() % 17;
         result.record(inout out, eligible, command,
             tile.height + tile.resource + tile.terrain * 11 + i % 97);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -62,7 +62,7 @@ fn inspect_timeline(inout out: result.Result, borrow world: model.World) {
         let eligible = (event.kind + FOCUS()) % 4 == 0;
         result.record(inout out, eligible, eligible && event.value > 0,
             event.sequence + event.actor % 257 + event.value);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
@@ -70,7 +70,7 @@ fn inspect_timeline(inout out: result.Result, borrow world: model.World) {
         let eligible = command.accepted && (command.kind + FOCUS()) % 3 == 0;
         result.record(inout out, eligible, eligible,
             command.tick + command.actor % 251 + command.value);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -83,12 +83,12 @@ fn inspect_regions(inout out: result.Result, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region { tiles = tiles + 1; resources = resources + tile.resource; }
-            i = i + 1;
+            i += 1;
         }
         let eligible = tiles > 0 && (region + FOCUS()) % 4 == 0;
         result.record(inout out, eligible, eligible && resources > tiles,
             resources + tiles * 13 + region);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/system_production_checkpoint.rue
+++ b/examples/caldera/system_production_checkpoint.rue
@@ -82,7 +82,7 @@ fn inspect_regions(inout out: result.Result, borrow world: model.World) {
         let mut i: u64 = 0;
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
-            if tile.region == region { tiles = tiles + 1; resources = resources + tile.resource; }
+            if tile.region == region { tiles += 1; resources += tile.resource; }
             i += 1;
         }
         let eligible = tiles > 0 && (region + FOCUS()) % 4 == 0;

--- a/examples/caldera/system_production_compact.rue
+++ b/examples/caldera/system_production_compact.rue
@@ -39,7 +39,7 @@ fn inspect_entities(inout out: result.Result, borrow world: model.World) {
         let eligible = eligible_entity(borrow world, borrow entity);
         let command = eligible && (entity.id + FOCUS() + world.tick) % 2 == 0;
         result.record(inout out, eligible, command, entity_value(borrow world, borrow entity));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -51,7 +51,7 @@ fn inspect_tiles(inout out: result.Result, borrow world: model.World) {
         let command = eligible && tile.resource > FOCUS() % 17;
         result.record(inout out, eligible, command,
             tile.height + tile.resource + tile.terrain * 11 + i % 97);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -62,7 +62,7 @@ fn inspect_timeline(inout out: result.Result, borrow world: model.World) {
         let eligible = (event.kind + FOCUS()) % 4 == 0;
         result.record(inout out, eligible, eligible && event.value > 0,
             event.sequence + event.actor % 257 + event.value);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
@@ -70,7 +70,7 @@ fn inspect_timeline(inout out: result.Result, borrow world: model.World) {
         let eligible = command.accepted && (command.kind + FOCUS()) % 3 == 0;
         result.record(inout out, eligible, eligible,
             command.tick + command.actor % 251 + command.value);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -83,12 +83,12 @@ fn inspect_regions(inout out: result.Result, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region { tiles = tiles + 1; resources = resources + tile.resource; }
-            i = i + 1;
+            i += 1;
         }
         let eligible = tiles > 0 && (region + FOCUS()) % 4 == 0;
         result.record(inout out, eligible, eligible && resources > tiles,
             resources + tiles * 13 + region);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/system_production_compact.rue
+++ b/examples/caldera/system_production_compact.rue
@@ -82,7 +82,7 @@ fn inspect_regions(inout out: result.Result, borrow world: model.World) {
         let mut i: u64 = 0;
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
-            if tile.region == region { tiles = tiles + 1; resources = resources + tile.resource; }
+            if tile.region == region { tiles += 1; resources += tile.resource; }
             i += 1;
         }
         let eligible = tiles > 0 && (region + FOCUS()) % 4 == 0;

--- a/examples/caldera/system_production_discover.rue
+++ b/examples/caldera/system_production_discover.rue
@@ -39,7 +39,7 @@ fn inspect_entities(inout out: result.Result, borrow world: model.World) {
         let eligible = eligible_entity(borrow world, borrow entity);
         let command = eligible && (entity.id + FOCUS() + world.tick) % 2 == 0;
         result.record(inout out, eligible, command, entity_value(borrow world, borrow entity));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -51,7 +51,7 @@ fn inspect_tiles(inout out: result.Result, borrow world: model.World) {
         let command = eligible && tile.resource > FOCUS() % 17;
         result.record(inout out, eligible, command,
             tile.height + tile.resource + tile.terrain * 11 + i % 97);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -62,7 +62,7 @@ fn inspect_timeline(inout out: result.Result, borrow world: model.World) {
         let eligible = (event.kind + FOCUS()) % 4 == 0;
         result.record(inout out, eligible, eligible && event.value > 0,
             event.sequence + event.actor % 257 + event.value);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
@@ -70,7 +70,7 @@ fn inspect_timeline(inout out: result.Result, borrow world: model.World) {
         let eligible = command.accepted && (command.kind + FOCUS()) % 3 == 0;
         result.record(inout out, eligible, eligible,
             command.tick + command.actor % 251 + command.value);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -83,12 +83,12 @@ fn inspect_regions(inout out: result.Result, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region { tiles = tiles + 1; resources = resources + tile.resource; }
-            i = i + 1;
+            i += 1;
         }
         let eligible = tiles > 0 && (region + FOCUS()) % 4 == 0;
         result.record(inout out, eligible, eligible && resources > tiles,
             resources + tiles * 13 + region);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/system_production_discover.rue
+++ b/examples/caldera/system_production_discover.rue
@@ -82,7 +82,7 @@ fn inspect_regions(inout out: result.Result, borrow world: model.World) {
         let mut i: u64 = 0;
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
-            if tile.region == region { tiles = tiles + 1; resources = resources + tile.resource; }
+            if tile.region == region { tiles += 1; resources += tile.resource; }
             i += 1;
         }
         let eligible = tiles > 0 && (region + FOCUS()) % 4 == 0;

--- a/examples/caldera/system_production_dispatch.rue
+++ b/examples/caldera/system_production_dispatch.rue
@@ -39,7 +39,7 @@ fn inspect_entities(inout out: result.Result, borrow world: model.World) {
         let eligible = eligible_entity(borrow world, borrow entity);
         let command = eligible && (entity.id + FOCUS() + world.tick) % 2 == 0;
         result.record(inout out, eligible, command, entity_value(borrow world, borrow entity));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -51,7 +51,7 @@ fn inspect_tiles(inout out: result.Result, borrow world: model.World) {
         let command = eligible && tile.resource > FOCUS() % 17;
         result.record(inout out, eligible, command,
             tile.height + tile.resource + tile.terrain * 11 + i % 97);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -62,7 +62,7 @@ fn inspect_timeline(inout out: result.Result, borrow world: model.World) {
         let eligible = (event.kind + FOCUS()) % 4 == 0;
         result.record(inout out, eligible, eligible && event.value > 0,
             event.sequence + event.actor % 257 + event.value);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
@@ -70,7 +70,7 @@ fn inspect_timeline(inout out: result.Result, borrow world: model.World) {
         let eligible = command.accepted && (command.kind + FOCUS()) % 3 == 0;
         result.record(inout out, eligible, eligible,
             command.tick + command.actor % 251 + command.value);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -83,12 +83,12 @@ fn inspect_regions(inout out: result.Result, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region { tiles = tiles + 1; resources = resources + tile.resource; }
-            i = i + 1;
+            i += 1;
         }
         let eligible = tiles > 0 && (region + FOCUS()) % 4 == 0;
         result.record(inout out, eligible, eligible && resources > tiles,
             resources + tiles * 13 + region);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/system_production_dispatch.rue
+++ b/examples/caldera/system_production_dispatch.rue
@@ -82,7 +82,7 @@ fn inspect_regions(inout out: result.Result, borrow world: model.World) {
         let mut i: u64 = 0;
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
-            if tile.region == region { tiles = tiles + 1; resources = resources + tile.resource; }
+            if tile.region == region { tiles += 1; resources += tile.resource; }
             i += 1;
         }
         let eligible = tiles > 0 && (region + FOCUS()) % 4 == 0;

--- a/examples/caldera/system_production_finalize.rue
+++ b/examples/caldera/system_production_finalize.rue
@@ -39,7 +39,7 @@ fn inspect_entities(inout out: result.Result, borrow world: model.World) {
         let eligible = eligible_entity(borrow world, borrow entity);
         let command = eligible && (entity.id + FOCUS() + world.tick) % 2 == 0;
         result.record(inout out, eligible, command, entity_value(borrow world, borrow entity));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -51,7 +51,7 @@ fn inspect_tiles(inout out: result.Result, borrow world: model.World) {
         let command = eligible && tile.resource > FOCUS() % 17;
         result.record(inout out, eligible, command,
             tile.height + tile.resource + tile.terrain * 11 + i % 97);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -62,7 +62,7 @@ fn inspect_timeline(inout out: result.Result, borrow world: model.World) {
         let eligible = (event.kind + FOCUS()) % 4 == 0;
         result.record(inout out, eligible, eligible && event.value > 0,
             event.sequence + event.actor % 257 + event.value);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
@@ -70,7 +70,7 @@ fn inspect_timeline(inout out: result.Result, borrow world: model.World) {
         let eligible = command.accepted && (command.kind + FOCUS()) % 3 == 0;
         result.record(inout out, eligible, eligible,
             command.tick + command.actor % 251 + command.value);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -83,12 +83,12 @@ fn inspect_regions(inout out: result.Result, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region { tiles = tiles + 1; resources = resources + tile.resource; }
-            i = i + 1;
+            i += 1;
         }
         let eligible = tiles > 0 && (region + FOCUS()) % 4 == 0;
         result.record(inout out, eligible, eligible && resources > tiles,
             resources + tiles * 13 + region);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/system_production_finalize.rue
+++ b/examples/caldera/system_production_finalize.rue
@@ -82,7 +82,7 @@ fn inspect_regions(inout out: result.Result, borrow world: model.World) {
         let mut i: u64 = 0;
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
-            if tile.region == region { tiles = tiles + 1; resources = resources + tile.resource; }
+            if tile.region == region { tiles += 1; resources += tile.resource; }
             i += 1;
         }
         let eligible = tiles > 0 && (region + FOCUS()) % 4 == 0;

--- a/examples/caldera/system_production_observe.rue
+++ b/examples/caldera/system_production_observe.rue
@@ -39,7 +39,7 @@ fn inspect_entities(inout out: result.Result, borrow world: model.World) {
         let eligible = eligible_entity(borrow world, borrow entity);
         let command = eligible && (entity.id + FOCUS() + world.tick) % 2 == 0;
         result.record(inout out, eligible, command, entity_value(borrow world, borrow entity));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -51,7 +51,7 @@ fn inspect_tiles(inout out: result.Result, borrow world: model.World) {
         let command = eligible && tile.resource > FOCUS() % 17;
         result.record(inout out, eligible, command,
             tile.height + tile.resource + tile.terrain * 11 + i % 97);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -62,7 +62,7 @@ fn inspect_timeline(inout out: result.Result, borrow world: model.World) {
         let eligible = (event.kind + FOCUS()) % 4 == 0;
         result.record(inout out, eligible, eligible && event.value > 0,
             event.sequence + event.actor % 257 + event.value);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
@@ -70,7 +70,7 @@ fn inspect_timeline(inout out: result.Result, borrow world: model.World) {
         let eligible = command.accepted && (command.kind + FOCUS()) % 3 == 0;
         result.record(inout out, eligible, eligible,
             command.tick + command.actor % 251 + command.value);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -83,12 +83,12 @@ fn inspect_regions(inout out: result.Result, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region { tiles = tiles + 1; resources = resources + tile.resource; }
-            i = i + 1;
+            i += 1;
         }
         let eligible = tiles > 0 && (region + FOCUS()) % 4 == 0;
         result.record(inout out, eligible, eligible && resources > tiles,
             resources + tiles * 13 + region);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/system_production_observe.rue
+++ b/examples/caldera/system_production_observe.rue
@@ -82,7 +82,7 @@ fn inspect_regions(inout out: result.Result, borrow world: model.World) {
         let mut i: u64 = 0;
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
-            if tile.region == region { tiles = tiles + 1; resources = resources + tile.resource; }
+            if tile.region == region { tiles += 1; resources += tile.resource; }
             i += 1;
         }
         let eligible = tiles > 0 && (region + FOCUS()) % 4 == 0;

--- a/examples/caldera/system_production_prepare.rue
+++ b/examples/caldera/system_production_prepare.rue
@@ -39,7 +39,7 @@ fn inspect_entities(inout out: result.Result, borrow world: model.World) {
         let eligible = eligible_entity(borrow world, borrow entity);
         let command = eligible && (entity.id + FOCUS() + world.tick) % 2 == 0;
         result.record(inout out, eligible, command, entity_value(borrow world, borrow entity));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -51,7 +51,7 @@ fn inspect_tiles(inout out: result.Result, borrow world: model.World) {
         let command = eligible && tile.resource > FOCUS() % 17;
         result.record(inout out, eligible, command,
             tile.height + tile.resource + tile.terrain * 11 + i % 97);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -62,7 +62,7 @@ fn inspect_timeline(inout out: result.Result, borrow world: model.World) {
         let eligible = (event.kind + FOCUS()) % 4 == 0;
         result.record(inout out, eligible, eligible && event.value > 0,
             event.sequence + event.actor % 257 + event.value);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
@@ -70,7 +70,7 @@ fn inspect_timeline(inout out: result.Result, borrow world: model.World) {
         let eligible = command.accepted && (command.kind + FOCUS()) % 3 == 0;
         result.record(inout out, eligible, eligible,
             command.tick + command.actor % 251 + command.value);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -83,12 +83,12 @@ fn inspect_regions(inout out: result.Result, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region { tiles = tiles + 1; resources = resources + tile.resource; }
-            i = i + 1;
+            i += 1;
         }
         let eligible = tiles > 0 && (region + FOCUS()) % 4 == 0;
         result.record(inout out, eligible, eligible && resources > tiles,
             resources + tiles * 13 + region);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/system_production_prepare.rue
+++ b/examples/caldera/system_production_prepare.rue
@@ -82,7 +82,7 @@ fn inspect_regions(inout out: result.Result, borrow world: model.World) {
         let mut i: u64 = 0;
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
-            if tile.region == region { tiles = tiles + 1; resources = resources + tile.resource; }
+            if tile.region == region { tiles += 1; resources += tile.resource; }
             i += 1;
         }
         let eligible = tiles > 0 && (region + FOCUS()) % 4 == 0;

--- a/examples/caldera/system_production_reconcile.rue
+++ b/examples/caldera/system_production_reconcile.rue
@@ -39,7 +39,7 @@ fn inspect_entities(inout out: result.Result, borrow world: model.World) {
         let eligible = eligible_entity(borrow world, borrow entity);
         let command = eligible && (entity.id + FOCUS() + world.tick) % 2 == 0;
         result.record(inout out, eligible, command, entity_value(borrow world, borrow entity));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -51,7 +51,7 @@ fn inspect_tiles(inout out: result.Result, borrow world: model.World) {
         let command = eligible && tile.resource > FOCUS() % 17;
         result.record(inout out, eligible, command,
             tile.height + tile.resource + tile.terrain * 11 + i % 97);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -62,7 +62,7 @@ fn inspect_timeline(inout out: result.Result, borrow world: model.World) {
         let eligible = (event.kind + FOCUS()) % 4 == 0;
         result.record(inout out, eligible, eligible && event.value > 0,
             event.sequence + event.actor % 257 + event.value);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
@@ -70,7 +70,7 @@ fn inspect_timeline(inout out: result.Result, borrow world: model.World) {
         let eligible = command.accepted && (command.kind + FOCUS()) % 3 == 0;
         result.record(inout out, eligible, eligible,
             command.tick + command.actor % 251 + command.value);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -83,12 +83,12 @@ fn inspect_regions(inout out: result.Result, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region { tiles = tiles + 1; resources = resources + tile.resource; }
-            i = i + 1;
+            i += 1;
         }
         let eligible = tiles > 0 && (region + FOCUS()) % 4 == 0;
         result.record(inout out, eligible, eligible && resources > tiles,
             resources + tiles * 13 + region);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/system_production_reconcile.rue
+++ b/examples/caldera/system_production_reconcile.rue
@@ -82,7 +82,7 @@ fn inspect_regions(inout out: result.Result, borrow world: model.World) {
         let mut i: u64 = 0;
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
-            if tile.region == region { tiles = tiles + 1; resources = resources + tile.resource; }
+            if tile.region == region { tiles += 1; resources += tile.resource; }
             i += 1;
         }
         let eligible = tiles > 0 && (region + FOCUS()) % 4 == 0;

--- a/examples/caldera/system_production_recover.rue
+++ b/examples/caldera/system_production_recover.rue
@@ -39,7 +39,7 @@ fn inspect_entities(inout out: result.Result, borrow world: model.World) {
         let eligible = eligible_entity(borrow world, borrow entity);
         let command = eligible && (entity.id + FOCUS() + world.tick) % 2 == 0;
         result.record(inout out, eligible, command, entity_value(borrow world, borrow entity));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -51,7 +51,7 @@ fn inspect_tiles(inout out: result.Result, borrow world: model.World) {
         let command = eligible && tile.resource > FOCUS() % 17;
         result.record(inout out, eligible, command,
             tile.height + tile.resource + tile.terrain * 11 + i % 97);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -62,7 +62,7 @@ fn inspect_timeline(inout out: result.Result, borrow world: model.World) {
         let eligible = (event.kind + FOCUS()) % 4 == 0;
         result.record(inout out, eligible, eligible && event.value > 0,
             event.sequence + event.actor % 257 + event.value);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
@@ -70,7 +70,7 @@ fn inspect_timeline(inout out: result.Result, borrow world: model.World) {
         let eligible = command.accepted && (command.kind + FOCUS()) % 3 == 0;
         result.record(inout out, eligible, eligible,
             command.tick + command.actor % 251 + command.value);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -83,12 +83,12 @@ fn inspect_regions(inout out: result.Result, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region { tiles = tiles + 1; resources = resources + tile.resource; }
-            i = i + 1;
+            i += 1;
         }
         let eligible = tiles > 0 && (region + FOCUS()) % 4 == 0;
         result.record(inout out, eligible, eligible && resources > tiles,
             resources + tiles * 13 + region);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/system_production_recover.rue
+++ b/examples/caldera/system_production_recover.rue
@@ -82,7 +82,7 @@ fn inspect_regions(inout out: result.Result, borrow world: model.World) {
         let mut i: u64 = 0;
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
-            if tile.region == region { tiles = tiles + 1; resources = resources + tile.resource; }
+            if tile.region == region { tiles += 1; resources += tile.resource; }
             i += 1;
         }
         let eligible = tiles > 0 && (region + FOCUS()) % 4 == 0;

--- a/examples/caldera/system_production_replicate.rue
+++ b/examples/caldera/system_production_replicate.rue
@@ -39,7 +39,7 @@ fn inspect_entities(inout out: result.Result, borrow world: model.World) {
         let eligible = eligible_entity(borrow world, borrow entity);
         let command = eligible && (entity.id + FOCUS() + world.tick) % 2 == 0;
         result.record(inout out, eligible, command, entity_value(borrow world, borrow entity));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -51,7 +51,7 @@ fn inspect_tiles(inout out: result.Result, borrow world: model.World) {
         let command = eligible && tile.resource > FOCUS() % 17;
         result.record(inout out, eligible, command,
             tile.height + tile.resource + tile.terrain * 11 + i % 97);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -62,7 +62,7 @@ fn inspect_timeline(inout out: result.Result, borrow world: model.World) {
         let eligible = (event.kind + FOCUS()) % 4 == 0;
         result.record(inout out, eligible, eligible && event.value > 0,
             event.sequence + event.actor % 257 + event.value);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
@@ -70,7 +70,7 @@ fn inspect_timeline(inout out: result.Result, borrow world: model.World) {
         let eligible = command.accepted && (command.kind + FOCUS()) % 3 == 0;
         result.record(inout out, eligible, eligible,
             command.tick + command.actor % 251 + command.value);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -83,12 +83,12 @@ fn inspect_regions(inout out: result.Result, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region { tiles = tiles + 1; resources = resources + tile.resource; }
-            i = i + 1;
+            i += 1;
         }
         let eligible = tiles > 0 && (region + FOCUS()) % 4 == 0;
         result.record(inout out, eligible, eligible && resources > tiles,
             resources + tiles * 13 + region);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/system_production_replicate.rue
+++ b/examples/caldera/system_production_replicate.rue
@@ -82,7 +82,7 @@ fn inspect_regions(inout out: result.Result, borrow world: model.World) {
         let mut i: u64 = 0;
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
-            if tile.region == region { tiles = tiles + 1; resources = resources + tile.resource; }
+            if tile.region == region { tiles += 1; resources += tile.resource; }
             i += 1;
         }
         let eligible = tiles > 0 && (region + FOCUS()) % 4 == 0;

--- a/examples/caldera/system_production_resolve.rue
+++ b/examples/caldera/system_production_resolve.rue
@@ -39,7 +39,7 @@ fn inspect_entities(inout out: result.Result, borrow world: model.World) {
         let eligible = eligible_entity(borrow world, borrow entity);
         let command = eligible && (entity.id + FOCUS() + world.tick) % 2 == 0;
         result.record(inout out, eligible, command, entity_value(borrow world, borrow entity));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -51,7 +51,7 @@ fn inspect_tiles(inout out: result.Result, borrow world: model.World) {
         let command = eligible && tile.resource > FOCUS() % 17;
         result.record(inout out, eligible, command,
             tile.height + tile.resource + tile.terrain * 11 + i % 97);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -62,7 +62,7 @@ fn inspect_timeline(inout out: result.Result, borrow world: model.World) {
         let eligible = (event.kind + FOCUS()) % 4 == 0;
         result.record(inout out, eligible, eligible && event.value > 0,
             event.sequence + event.actor % 257 + event.value);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
@@ -70,7 +70,7 @@ fn inspect_timeline(inout out: result.Result, borrow world: model.World) {
         let eligible = command.accepted && (command.kind + FOCUS()) % 3 == 0;
         result.record(inout out, eligible, eligible,
             command.tick + command.actor % 251 + command.value);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -83,12 +83,12 @@ fn inspect_regions(inout out: result.Result, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region { tiles = tiles + 1; resources = resources + tile.resource; }
-            i = i + 1;
+            i += 1;
         }
         let eligible = tiles > 0 && (region + FOCUS()) % 4 == 0;
         result.record(inout out, eligible, eligible && resources > tiles,
             resources + tiles * 13 + region);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/system_production_resolve.rue
+++ b/examples/caldera/system_production_resolve.rue
@@ -82,7 +82,7 @@ fn inspect_regions(inout out: result.Result, borrow world: model.World) {
         let mut i: u64 = 0;
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
-            if tile.region == region { tiles = tiles + 1; resources = resources + tile.resource; }
+            if tile.region == region { tiles += 1; resources += tile.resource; }
             i += 1;
         }
         let eligible = tiles > 0 && (region + FOCUS()) % 4 == 0;

--- a/examples/caldera/system_production_schedule.rue
+++ b/examples/caldera/system_production_schedule.rue
@@ -39,7 +39,7 @@ fn inspect_entities(inout out: result.Result, borrow world: model.World) {
         let eligible = eligible_entity(borrow world, borrow entity);
         let command = eligible && (entity.id + FOCUS() + world.tick) % 2 == 0;
         result.record(inout out, eligible, command, entity_value(borrow world, borrow entity));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -51,7 +51,7 @@ fn inspect_tiles(inout out: result.Result, borrow world: model.World) {
         let command = eligible && tile.resource > FOCUS() % 17;
         result.record(inout out, eligible, command,
             tile.height + tile.resource + tile.terrain * 11 + i % 97);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -62,7 +62,7 @@ fn inspect_timeline(inout out: result.Result, borrow world: model.World) {
         let eligible = (event.kind + FOCUS()) % 4 == 0;
         result.record(inout out, eligible, eligible && event.value > 0,
             event.sequence + event.actor % 257 + event.value);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
@@ -70,7 +70,7 @@ fn inspect_timeline(inout out: result.Result, borrow world: model.World) {
         let eligible = command.accepted && (command.kind + FOCUS()) % 3 == 0;
         result.record(inout out, eligible, eligible,
             command.tick + command.actor % 251 + command.value);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -83,12 +83,12 @@ fn inspect_regions(inout out: result.Result, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region { tiles = tiles + 1; resources = resources + tile.resource; }
-            i = i + 1;
+            i += 1;
         }
         let eligible = tiles > 0 && (region + FOCUS()) % 4 == 0;
         result.record(inout out, eligible, eligible && resources > tiles,
             resources + tiles * 13 + region);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/system_production_schedule.rue
+++ b/examples/caldera/system_production_schedule.rue
@@ -82,7 +82,7 @@ fn inspect_regions(inout out: result.Result, borrow world: model.World) {
         let mut i: u64 = 0;
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
-            if tile.region == region { tiles = tiles + 1; resources = resources + tile.resource; }
+            if tile.region == region { tiles += 1; resources += tile.resource; }
             i += 1;
         }
         let eligible = tiles > 0 && (region + FOCUS()) % 4 == 0;

--- a/examples/caldera/system_production_validate.rue
+++ b/examples/caldera/system_production_validate.rue
@@ -39,7 +39,7 @@ fn inspect_entities(inout out: result.Result, borrow world: model.World) {
         let eligible = eligible_entity(borrow world, borrow entity);
         let command = eligible && (entity.id + FOCUS() + world.tick) % 2 == 0;
         result.record(inout out, eligible, command, entity_value(borrow world, borrow entity));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -51,7 +51,7 @@ fn inspect_tiles(inout out: result.Result, borrow world: model.World) {
         let command = eligible && tile.resource > FOCUS() % 17;
         result.record(inout out, eligible, command,
             tile.height + tile.resource + tile.terrain * 11 + i % 97);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -62,7 +62,7 @@ fn inspect_timeline(inout out: result.Result, borrow world: model.World) {
         let eligible = (event.kind + FOCUS()) % 4 == 0;
         result.record(inout out, eligible, eligible && event.value > 0,
             event.sequence + event.actor % 257 + event.value);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
@@ -70,7 +70,7 @@ fn inspect_timeline(inout out: result.Result, borrow world: model.World) {
         let eligible = command.accepted && (command.kind + FOCUS()) % 3 == 0;
         result.record(inout out, eligible, eligible,
             command.tick + command.actor % 251 + command.value);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -83,12 +83,12 @@ fn inspect_regions(inout out: result.Result, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region { tiles = tiles + 1; resources = resources + tile.resource; }
-            i = i + 1;
+            i += 1;
         }
         let eligible = tiles > 0 && (region + FOCUS()) % 4 == 0;
         result.record(inout out, eligible, eligible && resources > tiles,
             resources + tiles * 13 + region);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/system_production_validate.rue
+++ b/examples/caldera/system_production_validate.rue
@@ -82,7 +82,7 @@ fn inspect_regions(inout out: result.Result, borrow world: model.World) {
         let mut i: u64 = 0;
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
-            if tile.region == region { tiles = tiles + 1; resources = resources + tile.resource; }
+            if tile.region == region { tiles += 1; resources += tile.resource; }
             i += 1;
         }
         let eligible = tiles > 0 && (region + FOCUS()) % 4 == 0;

--- a/examples/caldera/system_quest_apply.rue
+++ b/examples/caldera/system_quest_apply.rue
@@ -39,7 +39,7 @@ fn inspect_entities(inout out: result.Result, borrow world: model.World) {
         let eligible = eligible_entity(borrow world, borrow entity);
         let command = eligible && (entity.id + FOCUS() + world.tick) % 2 == 0;
         result.record(inout out, eligible, command, entity_value(borrow world, borrow entity));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -51,7 +51,7 @@ fn inspect_tiles(inout out: result.Result, borrow world: model.World) {
         let command = eligible && tile.resource > FOCUS() % 17;
         result.record(inout out, eligible, command,
             tile.height + tile.resource + tile.terrain * 11 + i % 97);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -62,7 +62,7 @@ fn inspect_timeline(inout out: result.Result, borrow world: model.World) {
         let eligible = (event.kind + FOCUS()) % 4 == 0;
         result.record(inout out, eligible, eligible && event.value > 0,
             event.sequence + event.actor % 257 + event.value);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
@@ -70,7 +70,7 @@ fn inspect_timeline(inout out: result.Result, borrow world: model.World) {
         let eligible = command.accepted && (command.kind + FOCUS()) % 3 == 0;
         result.record(inout out, eligible, eligible,
             command.tick + command.actor % 251 + command.value);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -83,12 +83,12 @@ fn inspect_regions(inout out: result.Result, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region { tiles = tiles + 1; resources = resources + tile.resource; }
-            i = i + 1;
+            i += 1;
         }
         let eligible = tiles > 0 && (region + FOCUS()) % 4 == 0;
         result.record(inout out, eligible, eligible && resources > tiles,
             resources + tiles * 13 + region);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/system_quest_apply.rue
+++ b/examples/caldera/system_quest_apply.rue
@@ -82,7 +82,7 @@ fn inspect_regions(inout out: result.Result, borrow world: model.World) {
         let mut i: u64 = 0;
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
-            if tile.region == region { tiles = tiles + 1; resources = resources + tile.resource; }
+            if tile.region == region { tiles += 1; resources += tile.resource; }
             i += 1;
         }
         let eligible = tiles > 0 && (region + FOCUS()) % 4 == 0;

--- a/examples/caldera/system_quest_audit.rue
+++ b/examples/caldera/system_quest_audit.rue
@@ -39,7 +39,7 @@ fn inspect_entities(inout out: result.Result, borrow world: model.World) {
         let eligible = eligible_entity(borrow world, borrow entity);
         let command = eligible && (entity.id + FOCUS() + world.tick) % 2 == 0;
         result.record(inout out, eligible, command, entity_value(borrow world, borrow entity));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -51,7 +51,7 @@ fn inspect_tiles(inout out: result.Result, borrow world: model.World) {
         let command = eligible && tile.resource > FOCUS() % 17;
         result.record(inout out, eligible, command,
             tile.height + tile.resource + tile.terrain * 11 + i % 97);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -62,7 +62,7 @@ fn inspect_timeline(inout out: result.Result, borrow world: model.World) {
         let eligible = (event.kind + FOCUS()) % 4 == 0;
         result.record(inout out, eligible, eligible && event.value > 0,
             event.sequence + event.actor % 257 + event.value);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
@@ -70,7 +70,7 @@ fn inspect_timeline(inout out: result.Result, borrow world: model.World) {
         let eligible = command.accepted && (command.kind + FOCUS()) % 3 == 0;
         result.record(inout out, eligible, eligible,
             command.tick + command.actor % 251 + command.value);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -83,12 +83,12 @@ fn inspect_regions(inout out: result.Result, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region { tiles = tiles + 1; resources = resources + tile.resource; }
-            i = i + 1;
+            i += 1;
         }
         let eligible = tiles > 0 && (region + FOCUS()) % 4 == 0;
         result.record(inout out, eligible, eligible && resources > tiles,
             resources + tiles * 13 + region);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/system_quest_audit.rue
+++ b/examples/caldera/system_quest_audit.rue
@@ -82,7 +82,7 @@ fn inspect_regions(inout out: result.Result, borrow world: model.World) {
         let mut i: u64 = 0;
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
-            if tile.region == region { tiles = tiles + 1; resources = resources + tile.resource; }
+            if tile.region == region { tiles += 1; resources += tile.resource; }
             i += 1;
         }
         let eligible = tiles > 0 && (region + FOCUS()) % 4 == 0;

--- a/examples/caldera/system_quest_bootstrap.rue
+++ b/examples/caldera/system_quest_bootstrap.rue
@@ -39,7 +39,7 @@ fn inspect_entities(inout out: result.Result, borrow world: model.World) {
         let eligible = eligible_entity(borrow world, borrow entity);
         let command = eligible && (entity.id + FOCUS() + world.tick) % 2 == 0;
         result.record(inout out, eligible, command, entity_value(borrow world, borrow entity));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -51,7 +51,7 @@ fn inspect_tiles(inout out: result.Result, borrow world: model.World) {
         let command = eligible && tile.resource > FOCUS() % 17;
         result.record(inout out, eligible, command,
             tile.height + tile.resource + tile.terrain * 11 + i % 97);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -62,7 +62,7 @@ fn inspect_timeline(inout out: result.Result, borrow world: model.World) {
         let eligible = (event.kind + FOCUS()) % 4 == 0;
         result.record(inout out, eligible, eligible && event.value > 0,
             event.sequence + event.actor % 257 + event.value);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
@@ -70,7 +70,7 @@ fn inspect_timeline(inout out: result.Result, borrow world: model.World) {
         let eligible = command.accepted && (command.kind + FOCUS()) % 3 == 0;
         result.record(inout out, eligible, eligible,
             command.tick + command.actor % 251 + command.value);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -83,12 +83,12 @@ fn inspect_regions(inout out: result.Result, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region { tiles = tiles + 1; resources = resources + tile.resource; }
-            i = i + 1;
+            i += 1;
         }
         let eligible = tiles > 0 && (region + FOCUS()) % 4 == 0;
         result.record(inout out, eligible, eligible && resources > tiles,
             resources + tiles * 13 + region);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/system_quest_bootstrap.rue
+++ b/examples/caldera/system_quest_bootstrap.rue
@@ -82,7 +82,7 @@ fn inspect_regions(inout out: result.Result, borrow world: model.World) {
         let mut i: u64 = 0;
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
-            if tile.region == region { tiles = tiles + 1; resources = resources + tile.resource; }
+            if tile.region == region { tiles += 1; resources += tile.resource; }
             i += 1;
         }
         let eligible = tiles > 0 && (region + FOCUS()) % 4 == 0;

--- a/examples/caldera/system_quest_checkpoint.rue
+++ b/examples/caldera/system_quest_checkpoint.rue
@@ -39,7 +39,7 @@ fn inspect_entities(inout out: result.Result, borrow world: model.World) {
         let eligible = eligible_entity(borrow world, borrow entity);
         let command = eligible && (entity.id + FOCUS() + world.tick) % 2 == 0;
         result.record(inout out, eligible, command, entity_value(borrow world, borrow entity));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -51,7 +51,7 @@ fn inspect_tiles(inout out: result.Result, borrow world: model.World) {
         let command = eligible && tile.resource > FOCUS() % 17;
         result.record(inout out, eligible, command,
             tile.height + tile.resource + tile.terrain * 11 + i % 97);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -62,7 +62,7 @@ fn inspect_timeline(inout out: result.Result, borrow world: model.World) {
         let eligible = (event.kind + FOCUS()) % 4 == 0;
         result.record(inout out, eligible, eligible && event.value > 0,
             event.sequence + event.actor % 257 + event.value);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
@@ -70,7 +70,7 @@ fn inspect_timeline(inout out: result.Result, borrow world: model.World) {
         let eligible = command.accepted && (command.kind + FOCUS()) % 3 == 0;
         result.record(inout out, eligible, eligible,
             command.tick + command.actor % 251 + command.value);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -83,12 +83,12 @@ fn inspect_regions(inout out: result.Result, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region { tiles = tiles + 1; resources = resources + tile.resource; }
-            i = i + 1;
+            i += 1;
         }
         let eligible = tiles > 0 && (region + FOCUS()) % 4 == 0;
         result.record(inout out, eligible, eligible && resources > tiles,
             resources + tiles * 13 + region);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/system_quest_checkpoint.rue
+++ b/examples/caldera/system_quest_checkpoint.rue
@@ -82,7 +82,7 @@ fn inspect_regions(inout out: result.Result, borrow world: model.World) {
         let mut i: u64 = 0;
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
-            if tile.region == region { tiles = tiles + 1; resources = resources + tile.resource; }
+            if tile.region == region { tiles += 1; resources += tile.resource; }
             i += 1;
         }
         let eligible = tiles > 0 && (region + FOCUS()) % 4 == 0;

--- a/examples/caldera/system_quest_compact.rue
+++ b/examples/caldera/system_quest_compact.rue
@@ -39,7 +39,7 @@ fn inspect_entities(inout out: result.Result, borrow world: model.World) {
         let eligible = eligible_entity(borrow world, borrow entity);
         let command = eligible && (entity.id + FOCUS() + world.tick) % 2 == 0;
         result.record(inout out, eligible, command, entity_value(borrow world, borrow entity));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -51,7 +51,7 @@ fn inspect_tiles(inout out: result.Result, borrow world: model.World) {
         let command = eligible && tile.resource > FOCUS() % 17;
         result.record(inout out, eligible, command,
             tile.height + tile.resource + tile.terrain * 11 + i % 97);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -62,7 +62,7 @@ fn inspect_timeline(inout out: result.Result, borrow world: model.World) {
         let eligible = (event.kind + FOCUS()) % 4 == 0;
         result.record(inout out, eligible, eligible && event.value > 0,
             event.sequence + event.actor % 257 + event.value);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
@@ -70,7 +70,7 @@ fn inspect_timeline(inout out: result.Result, borrow world: model.World) {
         let eligible = command.accepted && (command.kind + FOCUS()) % 3 == 0;
         result.record(inout out, eligible, eligible,
             command.tick + command.actor % 251 + command.value);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -83,12 +83,12 @@ fn inspect_regions(inout out: result.Result, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region { tiles = tiles + 1; resources = resources + tile.resource; }
-            i = i + 1;
+            i += 1;
         }
         let eligible = tiles > 0 && (region + FOCUS()) % 4 == 0;
         result.record(inout out, eligible, eligible && resources > tiles,
             resources + tiles * 13 + region);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/system_quest_compact.rue
+++ b/examples/caldera/system_quest_compact.rue
@@ -82,7 +82,7 @@ fn inspect_regions(inout out: result.Result, borrow world: model.World) {
         let mut i: u64 = 0;
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
-            if tile.region == region { tiles = tiles + 1; resources = resources + tile.resource; }
+            if tile.region == region { tiles += 1; resources += tile.resource; }
             i += 1;
         }
         let eligible = tiles > 0 && (region + FOCUS()) % 4 == 0;

--- a/examples/caldera/system_quest_discover.rue
+++ b/examples/caldera/system_quest_discover.rue
@@ -39,7 +39,7 @@ fn inspect_entities(inout out: result.Result, borrow world: model.World) {
         let eligible = eligible_entity(borrow world, borrow entity);
         let command = eligible && (entity.id + FOCUS() + world.tick) % 2 == 0;
         result.record(inout out, eligible, command, entity_value(borrow world, borrow entity));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -51,7 +51,7 @@ fn inspect_tiles(inout out: result.Result, borrow world: model.World) {
         let command = eligible && tile.resource > FOCUS() % 17;
         result.record(inout out, eligible, command,
             tile.height + tile.resource + tile.terrain * 11 + i % 97);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -62,7 +62,7 @@ fn inspect_timeline(inout out: result.Result, borrow world: model.World) {
         let eligible = (event.kind + FOCUS()) % 4 == 0;
         result.record(inout out, eligible, eligible && event.value > 0,
             event.sequence + event.actor % 257 + event.value);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
@@ -70,7 +70,7 @@ fn inspect_timeline(inout out: result.Result, borrow world: model.World) {
         let eligible = command.accepted && (command.kind + FOCUS()) % 3 == 0;
         result.record(inout out, eligible, eligible,
             command.tick + command.actor % 251 + command.value);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -83,12 +83,12 @@ fn inspect_regions(inout out: result.Result, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region { tiles = tiles + 1; resources = resources + tile.resource; }
-            i = i + 1;
+            i += 1;
         }
         let eligible = tiles > 0 && (region + FOCUS()) % 4 == 0;
         result.record(inout out, eligible, eligible && resources > tiles,
             resources + tiles * 13 + region);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/system_quest_discover.rue
+++ b/examples/caldera/system_quest_discover.rue
@@ -82,7 +82,7 @@ fn inspect_regions(inout out: result.Result, borrow world: model.World) {
         let mut i: u64 = 0;
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
-            if tile.region == region { tiles = tiles + 1; resources = resources + tile.resource; }
+            if tile.region == region { tiles += 1; resources += tile.resource; }
             i += 1;
         }
         let eligible = tiles > 0 && (region + FOCUS()) % 4 == 0;

--- a/examples/caldera/system_quest_dispatch.rue
+++ b/examples/caldera/system_quest_dispatch.rue
@@ -39,7 +39,7 @@ fn inspect_entities(inout out: result.Result, borrow world: model.World) {
         let eligible = eligible_entity(borrow world, borrow entity);
         let command = eligible && (entity.id + FOCUS() + world.tick) % 2 == 0;
         result.record(inout out, eligible, command, entity_value(borrow world, borrow entity));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -51,7 +51,7 @@ fn inspect_tiles(inout out: result.Result, borrow world: model.World) {
         let command = eligible && tile.resource > FOCUS() % 17;
         result.record(inout out, eligible, command,
             tile.height + tile.resource + tile.terrain * 11 + i % 97);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -62,7 +62,7 @@ fn inspect_timeline(inout out: result.Result, borrow world: model.World) {
         let eligible = (event.kind + FOCUS()) % 4 == 0;
         result.record(inout out, eligible, eligible && event.value > 0,
             event.sequence + event.actor % 257 + event.value);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
@@ -70,7 +70,7 @@ fn inspect_timeline(inout out: result.Result, borrow world: model.World) {
         let eligible = command.accepted && (command.kind + FOCUS()) % 3 == 0;
         result.record(inout out, eligible, eligible,
             command.tick + command.actor % 251 + command.value);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -83,12 +83,12 @@ fn inspect_regions(inout out: result.Result, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region { tiles = tiles + 1; resources = resources + tile.resource; }
-            i = i + 1;
+            i += 1;
         }
         let eligible = tiles > 0 && (region + FOCUS()) % 4 == 0;
         result.record(inout out, eligible, eligible && resources > tiles,
             resources + tiles * 13 + region);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/system_quest_dispatch.rue
+++ b/examples/caldera/system_quest_dispatch.rue
@@ -82,7 +82,7 @@ fn inspect_regions(inout out: result.Result, borrow world: model.World) {
         let mut i: u64 = 0;
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
-            if tile.region == region { tiles = tiles + 1; resources = resources + tile.resource; }
+            if tile.region == region { tiles += 1; resources += tile.resource; }
             i += 1;
         }
         let eligible = tiles > 0 && (region + FOCUS()) % 4 == 0;

--- a/examples/caldera/system_quest_finalize.rue
+++ b/examples/caldera/system_quest_finalize.rue
@@ -39,7 +39,7 @@ fn inspect_entities(inout out: result.Result, borrow world: model.World) {
         let eligible = eligible_entity(borrow world, borrow entity);
         let command = eligible && (entity.id + FOCUS() + world.tick) % 2 == 0;
         result.record(inout out, eligible, command, entity_value(borrow world, borrow entity));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -51,7 +51,7 @@ fn inspect_tiles(inout out: result.Result, borrow world: model.World) {
         let command = eligible && tile.resource > FOCUS() % 17;
         result.record(inout out, eligible, command,
             tile.height + tile.resource + tile.terrain * 11 + i % 97);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -62,7 +62,7 @@ fn inspect_timeline(inout out: result.Result, borrow world: model.World) {
         let eligible = (event.kind + FOCUS()) % 4 == 0;
         result.record(inout out, eligible, eligible && event.value > 0,
             event.sequence + event.actor % 257 + event.value);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
@@ -70,7 +70,7 @@ fn inspect_timeline(inout out: result.Result, borrow world: model.World) {
         let eligible = command.accepted && (command.kind + FOCUS()) % 3 == 0;
         result.record(inout out, eligible, eligible,
             command.tick + command.actor % 251 + command.value);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -83,12 +83,12 @@ fn inspect_regions(inout out: result.Result, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region { tiles = tiles + 1; resources = resources + tile.resource; }
-            i = i + 1;
+            i += 1;
         }
         let eligible = tiles > 0 && (region + FOCUS()) % 4 == 0;
         result.record(inout out, eligible, eligible && resources > tiles,
             resources + tiles * 13 + region);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/system_quest_finalize.rue
+++ b/examples/caldera/system_quest_finalize.rue
@@ -82,7 +82,7 @@ fn inspect_regions(inout out: result.Result, borrow world: model.World) {
         let mut i: u64 = 0;
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
-            if tile.region == region { tiles = tiles + 1; resources = resources + tile.resource; }
+            if tile.region == region { tiles += 1; resources += tile.resource; }
             i += 1;
         }
         let eligible = tiles > 0 && (region + FOCUS()) % 4 == 0;

--- a/examples/caldera/system_quest_observe.rue
+++ b/examples/caldera/system_quest_observe.rue
@@ -39,7 +39,7 @@ fn inspect_entities(inout out: result.Result, borrow world: model.World) {
         let eligible = eligible_entity(borrow world, borrow entity);
         let command = eligible && (entity.id + FOCUS() + world.tick) % 2 == 0;
         result.record(inout out, eligible, command, entity_value(borrow world, borrow entity));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -51,7 +51,7 @@ fn inspect_tiles(inout out: result.Result, borrow world: model.World) {
         let command = eligible && tile.resource > FOCUS() % 17;
         result.record(inout out, eligible, command,
             tile.height + tile.resource + tile.terrain * 11 + i % 97);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -62,7 +62,7 @@ fn inspect_timeline(inout out: result.Result, borrow world: model.World) {
         let eligible = (event.kind + FOCUS()) % 4 == 0;
         result.record(inout out, eligible, eligible && event.value > 0,
             event.sequence + event.actor % 257 + event.value);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
@@ -70,7 +70,7 @@ fn inspect_timeline(inout out: result.Result, borrow world: model.World) {
         let eligible = command.accepted && (command.kind + FOCUS()) % 3 == 0;
         result.record(inout out, eligible, eligible,
             command.tick + command.actor % 251 + command.value);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -83,12 +83,12 @@ fn inspect_regions(inout out: result.Result, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region { tiles = tiles + 1; resources = resources + tile.resource; }
-            i = i + 1;
+            i += 1;
         }
         let eligible = tiles > 0 && (region + FOCUS()) % 4 == 0;
         result.record(inout out, eligible, eligible && resources > tiles,
             resources + tiles * 13 + region);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/system_quest_observe.rue
+++ b/examples/caldera/system_quest_observe.rue
@@ -82,7 +82,7 @@ fn inspect_regions(inout out: result.Result, borrow world: model.World) {
         let mut i: u64 = 0;
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
-            if tile.region == region { tiles = tiles + 1; resources = resources + tile.resource; }
+            if tile.region == region { tiles += 1; resources += tile.resource; }
             i += 1;
         }
         let eligible = tiles > 0 && (region + FOCUS()) % 4 == 0;

--- a/examples/caldera/system_quest_prepare.rue
+++ b/examples/caldera/system_quest_prepare.rue
@@ -39,7 +39,7 @@ fn inspect_entities(inout out: result.Result, borrow world: model.World) {
         let eligible = eligible_entity(borrow world, borrow entity);
         let command = eligible && (entity.id + FOCUS() + world.tick) % 2 == 0;
         result.record(inout out, eligible, command, entity_value(borrow world, borrow entity));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -51,7 +51,7 @@ fn inspect_tiles(inout out: result.Result, borrow world: model.World) {
         let command = eligible && tile.resource > FOCUS() % 17;
         result.record(inout out, eligible, command,
             tile.height + tile.resource + tile.terrain * 11 + i % 97);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -62,7 +62,7 @@ fn inspect_timeline(inout out: result.Result, borrow world: model.World) {
         let eligible = (event.kind + FOCUS()) % 4 == 0;
         result.record(inout out, eligible, eligible && event.value > 0,
             event.sequence + event.actor % 257 + event.value);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
@@ -70,7 +70,7 @@ fn inspect_timeline(inout out: result.Result, borrow world: model.World) {
         let eligible = command.accepted && (command.kind + FOCUS()) % 3 == 0;
         result.record(inout out, eligible, eligible,
             command.tick + command.actor % 251 + command.value);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -83,12 +83,12 @@ fn inspect_regions(inout out: result.Result, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region { tiles = tiles + 1; resources = resources + tile.resource; }
-            i = i + 1;
+            i += 1;
         }
         let eligible = tiles > 0 && (region + FOCUS()) % 4 == 0;
         result.record(inout out, eligible, eligible && resources > tiles,
             resources + tiles * 13 + region);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/system_quest_prepare.rue
+++ b/examples/caldera/system_quest_prepare.rue
@@ -82,7 +82,7 @@ fn inspect_regions(inout out: result.Result, borrow world: model.World) {
         let mut i: u64 = 0;
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
-            if tile.region == region { tiles = tiles + 1; resources = resources + tile.resource; }
+            if tile.region == region { tiles += 1; resources += tile.resource; }
             i += 1;
         }
         let eligible = tiles > 0 && (region + FOCUS()) % 4 == 0;

--- a/examples/caldera/system_quest_reconcile.rue
+++ b/examples/caldera/system_quest_reconcile.rue
@@ -39,7 +39,7 @@ fn inspect_entities(inout out: result.Result, borrow world: model.World) {
         let eligible = eligible_entity(borrow world, borrow entity);
         let command = eligible && (entity.id + FOCUS() + world.tick) % 2 == 0;
         result.record(inout out, eligible, command, entity_value(borrow world, borrow entity));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -51,7 +51,7 @@ fn inspect_tiles(inout out: result.Result, borrow world: model.World) {
         let command = eligible && tile.resource > FOCUS() % 17;
         result.record(inout out, eligible, command,
             tile.height + tile.resource + tile.terrain * 11 + i % 97);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -62,7 +62,7 @@ fn inspect_timeline(inout out: result.Result, borrow world: model.World) {
         let eligible = (event.kind + FOCUS()) % 4 == 0;
         result.record(inout out, eligible, eligible && event.value > 0,
             event.sequence + event.actor % 257 + event.value);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
@@ -70,7 +70,7 @@ fn inspect_timeline(inout out: result.Result, borrow world: model.World) {
         let eligible = command.accepted && (command.kind + FOCUS()) % 3 == 0;
         result.record(inout out, eligible, eligible,
             command.tick + command.actor % 251 + command.value);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -83,12 +83,12 @@ fn inspect_regions(inout out: result.Result, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region { tiles = tiles + 1; resources = resources + tile.resource; }
-            i = i + 1;
+            i += 1;
         }
         let eligible = tiles > 0 && (region + FOCUS()) % 4 == 0;
         result.record(inout out, eligible, eligible && resources > tiles,
             resources + tiles * 13 + region);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/system_quest_reconcile.rue
+++ b/examples/caldera/system_quest_reconcile.rue
@@ -82,7 +82,7 @@ fn inspect_regions(inout out: result.Result, borrow world: model.World) {
         let mut i: u64 = 0;
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
-            if tile.region == region { tiles = tiles + 1; resources = resources + tile.resource; }
+            if tile.region == region { tiles += 1; resources += tile.resource; }
             i += 1;
         }
         let eligible = tiles > 0 && (region + FOCUS()) % 4 == 0;

--- a/examples/caldera/system_quest_recover.rue
+++ b/examples/caldera/system_quest_recover.rue
@@ -39,7 +39,7 @@ fn inspect_entities(inout out: result.Result, borrow world: model.World) {
         let eligible = eligible_entity(borrow world, borrow entity);
         let command = eligible && (entity.id + FOCUS() + world.tick) % 2 == 0;
         result.record(inout out, eligible, command, entity_value(borrow world, borrow entity));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -51,7 +51,7 @@ fn inspect_tiles(inout out: result.Result, borrow world: model.World) {
         let command = eligible && tile.resource > FOCUS() % 17;
         result.record(inout out, eligible, command,
             tile.height + tile.resource + tile.terrain * 11 + i % 97);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -62,7 +62,7 @@ fn inspect_timeline(inout out: result.Result, borrow world: model.World) {
         let eligible = (event.kind + FOCUS()) % 4 == 0;
         result.record(inout out, eligible, eligible && event.value > 0,
             event.sequence + event.actor % 257 + event.value);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
@@ -70,7 +70,7 @@ fn inspect_timeline(inout out: result.Result, borrow world: model.World) {
         let eligible = command.accepted && (command.kind + FOCUS()) % 3 == 0;
         result.record(inout out, eligible, eligible,
             command.tick + command.actor % 251 + command.value);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -83,12 +83,12 @@ fn inspect_regions(inout out: result.Result, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region { tiles = tiles + 1; resources = resources + tile.resource; }
-            i = i + 1;
+            i += 1;
         }
         let eligible = tiles > 0 && (region + FOCUS()) % 4 == 0;
         result.record(inout out, eligible, eligible && resources > tiles,
             resources + tiles * 13 + region);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/system_quest_recover.rue
+++ b/examples/caldera/system_quest_recover.rue
@@ -82,7 +82,7 @@ fn inspect_regions(inout out: result.Result, borrow world: model.World) {
         let mut i: u64 = 0;
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
-            if tile.region == region { tiles = tiles + 1; resources = resources + tile.resource; }
+            if tile.region == region { tiles += 1; resources += tile.resource; }
             i += 1;
         }
         let eligible = tiles > 0 && (region + FOCUS()) % 4 == 0;

--- a/examples/caldera/system_quest_replicate.rue
+++ b/examples/caldera/system_quest_replicate.rue
@@ -39,7 +39,7 @@ fn inspect_entities(inout out: result.Result, borrow world: model.World) {
         let eligible = eligible_entity(borrow world, borrow entity);
         let command = eligible && (entity.id + FOCUS() + world.tick) % 2 == 0;
         result.record(inout out, eligible, command, entity_value(borrow world, borrow entity));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -51,7 +51,7 @@ fn inspect_tiles(inout out: result.Result, borrow world: model.World) {
         let command = eligible && tile.resource > FOCUS() % 17;
         result.record(inout out, eligible, command,
             tile.height + tile.resource + tile.terrain * 11 + i % 97);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -62,7 +62,7 @@ fn inspect_timeline(inout out: result.Result, borrow world: model.World) {
         let eligible = (event.kind + FOCUS()) % 4 == 0;
         result.record(inout out, eligible, eligible && event.value > 0,
             event.sequence + event.actor % 257 + event.value);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
@@ -70,7 +70,7 @@ fn inspect_timeline(inout out: result.Result, borrow world: model.World) {
         let eligible = command.accepted && (command.kind + FOCUS()) % 3 == 0;
         result.record(inout out, eligible, eligible,
             command.tick + command.actor % 251 + command.value);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -83,12 +83,12 @@ fn inspect_regions(inout out: result.Result, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region { tiles = tiles + 1; resources = resources + tile.resource; }
-            i = i + 1;
+            i += 1;
         }
         let eligible = tiles > 0 && (region + FOCUS()) % 4 == 0;
         result.record(inout out, eligible, eligible && resources > tiles,
             resources + tiles * 13 + region);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/system_quest_replicate.rue
+++ b/examples/caldera/system_quest_replicate.rue
@@ -82,7 +82,7 @@ fn inspect_regions(inout out: result.Result, borrow world: model.World) {
         let mut i: u64 = 0;
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
-            if tile.region == region { tiles = tiles + 1; resources = resources + tile.resource; }
+            if tile.region == region { tiles += 1; resources += tile.resource; }
             i += 1;
         }
         let eligible = tiles > 0 && (region + FOCUS()) % 4 == 0;

--- a/examples/caldera/system_quest_resolve.rue
+++ b/examples/caldera/system_quest_resolve.rue
@@ -39,7 +39,7 @@ fn inspect_entities(inout out: result.Result, borrow world: model.World) {
         let eligible = eligible_entity(borrow world, borrow entity);
         let command = eligible && (entity.id + FOCUS() + world.tick) % 2 == 0;
         result.record(inout out, eligible, command, entity_value(borrow world, borrow entity));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -51,7 +51,7 @@ fn inspect_tiles(inout out: result.Result, borrow world: model.World) {
         let command = eligible && tile.resource > FOCUS() % 17;
         result.record(inout out, eligible, command,
             tile.height + tile.resource + tile.terrain * 11 + i % 97);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -62,7 +62,7 @@ fn inspect_timeline(inout out: result.Result, borrow world: model.World) {
         let eligible = (event.kind + FOCUS()) % 4 == 0;
         result.record(inout out, eligible, eligible && event.value > 0,
             event.sequence + event.actor % 257 + event.value);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
@@ -70,7 +70,7 @@ fn inspect_timeline(inout out: result.Result, borrow world: model.World) {
         let eligible = command.accepted && (command.kind + FOCUS()) % 3 == 0;
         result.record(inout out, eligible, eligible,
             command.tick + command.actor % 251 + command.value);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -83,12 +83,12 @@ fn inspect_regions(inout out: result.Result, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region { tiles = tiles + 1; resources = resources + tile.resource; }
-            i = i + 1;
+            i += 1;
         }
         let eligible = tiles > 0 && (region + FOCUS()) % 4 == 0;
         result.record(inout out, eligible, eligible && resources > tiles,
             resources + tiles * 13 + region);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/system_quest_resolve.rue
+++ b/examples/caldera/system_quest_resolve.rue
@@ -82,7 +82,7 @@ fn inspect_regions(inout out: result.Result, borrow world: model.World) {
         let mut i: u64 = 0;
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
-            if tile.region == region { tiles = tiles + 1; resources = resources + tile.resource; }
+            if tile.region == region { tiles += 1; resources += tile.resource; }
             i += 1;
         }
         let eligible = tiles > 0 && (region + FOCUS()) % 4 == 0;

--- a/examples/caldera/system_quest_schedule.rue
+++ b/examples/caldera/system_quest_schedule.rue
@@ -39,7 +39,7 @@ fn inspect_entities(inout out: result.Result, borrow world: model.World) {
         let eligible = eligible_entity(borrow world, borrow entity);
         let command = eligible && (entity.id + FOCUS() + world.tick) % 2 == 0;
         result.record(inout out, eligible, command, entity_value(borrow world, borrow entity));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -51,7 +51,7 @@ fn inspect_tiles(inout out: result.Result, borrow world: model.World) {
         let command = eligible && tile.resource > FOCUS() % 17;
         result.record(inout out, eligible, command,
             tile.height + tile.resource + tile.terrain * 11 + i % 97);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -62,7 +62,7 @@ fn inspect_timeline(inout out: result.Result, borrow world: model.World) {
         let eligible = (event.kind + FOCUS()) % 4 == 0;
         result.record(inout out, eligible, eligible && event.value > 0,
             event.sequence + event.actor % 257 + event.value);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
@@ -70,7 +70,7 @@ fn inspect_timeline(inout out: result.Result, borrow world: model.World) {
         let eligible = command.accepted && (command.kind + FOCUS()) % 3 == 0;
         result.record(inout out, eligible, eligible,
             command.tick + command.actor % 251 + command.value);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -83,12 +83,12 @@ fn inspect_regions(inout out: result.Result, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region { tiles = tiles + 1; resources = resources + tile.resource; }
-            i = i + 1;
+            i += 1;
         }
         let eligible = tiles > 0 && (region + FOCUS()) % 4 == 0;
         result.record(inout out, eligible, eligible && resources > tiles,
             resources + tiles * 13 + region);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/system_quest_schedule.rue
+++ b/examples/caldera/system_quest_schedule.rue
@@ -82,7 +82,7 @@ fn inspect_regions(inout out: result.Result, borrow world: model.World) {
         let mut i: u64 = 0;
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
-            if tile.region == region { tiles = tiles + 1; resources = resources + tile.resource; }
+            if tile.region == region { tiles += 1; resources += tile.resource; }
             i += 1;
         }
         let eligible = tiles > 0 && (region + FOCUS()) % 4 == 0;

--- a/examples/caldera/system_quest_validate.rue
+++ b/examples/caldera/system_quest_validate.rue
@@ -39,7 +39,7 @@ fn inspect_entities(inout out: result.Result, borrow world: model.World) {
         let eligible = eligible_entity(borrow world, borrow entity);
         let command = eligible && (entity.id + FOCUS() + world.tick) % 2 == 0;
         result.record(inout out, eligible, command, entity_value(borrow world, borrow entity));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -51,7 +51,7 @@ fn inspect_tiles(inout out: result.Result, borrow world: model.World) {
         let command = eligible && tile.resource > FOCUS() % 17;
         result.record(inout out, eligible, command,
             tile.height + tile.resource + tile.terrain * 11 + i % 97);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -62,7 +62,7 @@ fn inspect_timeline(inout out: result.Result, borrow world: model.World) {
         let eligible = (event.kind + FOCUS()) % 4 == 0;
         result.record(inout out, eligible, eligible && event.value > 0,
             event.sequence + event.actor % 257 + event.value);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
@@ -70,7 +70,7 @@ fn inspect_timeline(inout out: result.Result, borrow world: model.World) {
         let eligible = command.accepted && (command.kind + FOCUS()) % 3 == 0;
         result.record(inout out, eligible, eligible,
             command.tick + command.actor % 251 + command.value);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -83,12 +83,12 @@ fn inspect_regions(inout out: result.Result, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region { tiles = tiles + 1; resources = resources + tile.resource; }
-            i = i + 1;
+            i += 1;
         }
         let eligible = tiles > 0 && (region + FOCUS()) % 4 == 0;
         result.record(inout out, eligible, eligible && resources > tiles,
             resources + tiles * 13 + region);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/system_quest_validate.rue
+++ b/examples/caldera/system_quest_validate.rue
@@ -82,7 +82,7 @@ fn inspect_regions(inout out: result.Result, borrow world: model.World) {
         let mut i: u64 = 0;
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
-            if tile.region == region { tiles = tiles + 1; resources = resources + tile.resource; }
+            if tile.region == region { tiles += 1; resources += tile.resource; }
             i += 1;
         }
         let eligible = tiles > 0 && (region + FOCUS()) % 4 == 0;

--- a/examples/caldera/system_result.rue
+++ b/examples/caldera/system_result.rue
@@ -6,7 +6,7 @@ pub fn new(system: u64) -> Result {
         energy: 0, digest: metric.mix(14695981039346656037, system), valid: false }
 }
 pub fn record(inout out: Result, eligible: bool, command: bool, value: u64) {
-    out.inspected = out.inspected + 1;
+    out.inspected += 1;
     if eligible { out.eligible = out.eligible + 1; }
     if command { out.commands = out.commands + 1; }
     out.energy = @wrapping_add(out.energy, value);

--- a/examples/caldera/system_result.rue
+++ b/examples/caldera/system_result.rue
@@ -7,8 +7,8 @@ pub fn new(system: u64) -> Result {
 }
 pub fn record(inout out: Result, eligible: bool, command: bool, value: u64) {
     out.inspected += 1;
-    if eligible { out.eligible = out.eligible + 1; }
-    if command { out.commands = out.commands + 1; }
+    if eligible { out.eligible += 1; }
+    if command { out.commands += 1; }
     out.energy = @wrapping_add(out.energy, value);
     out.digest = metric.mix(out.digest, value + out.inspected * 17);
 }

--- a/examples/caldera/system_suite.rue
+++ b/examples/caldera/system_suite.rue
@@ -201,7 +201,7 @@ fn include(inout out: Summary, borrow first: result.Result, borrow second: resul
     out.systems = out.systems + 1; out.inspected = out.inspected + first.inspected;
     out.eligible = out.eligible + first.eligible; out.commands = out.commands + first.commands;
     if first.digest != second.digest || first.energy != second.energy || !verified {
-        out.deterministic_mismatches = out.deterministic_mismatches + 1;
+        out.deterministic_mismatches += 1;
     }
     out.digest = metric.mix(out.digest, first.digest);
 }

--- a/examples/caldera/system_suite.rue
+++ b/examples/caldera/system_suite.rue
@@ -198,8 +198,8 @@ const system_network_audit = @import("system_network_audit.rue");
 pub struct Summary { systems: u64, inspected: u64, eligible: u64, commands: u64,
     deterministic_mismatches: u64, digest: u64, valid: bool }
 fn include(inout out: Summary, borrow first: result.Result, borrow second: result.Result, verified: bool) {
-    out.systems = out.systems + 1; out.inspected = out.inspected + first.inspected;
-    out.eligible = out.eligible + first.eligible; out.commands = out.commands + first.commands;
+    out.systems += 1; out.inspected += first.inspected;
+    out.eligible += first.eligible; out.commands += first.commands;
     if first.digest != second.digest || first.energy != second.energy || !verified {
         out.deterministic_mismatches += 1;
     }

--- a/examples/caldera/system_visibility_apply.rue
+++ b/examples/caldera/system_visibility_apply.rue
@@ -39,7 +39,7 @@ fn inspect_entities(inout out: result.Result, borrow world: model.World) {
         let eligible = eligible_entity(borrow world, borrow entity);
         let command = eligible && (entity.id + FOCUS() + world.tick) % 2 == 0;
         result.record(inout out, eligible, command, entity_value(borrow world, borrow entity));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -51,7 +51,7 @@ fn inspect_tiles(inout out: result.Result, borrow world: model.World) {
         let command = eligible && tile.resource > FOCUS() % 17;
         result.record(inout out, eligible, command,
             tile.height + tile.resource + tile.terrain * 11 + i % 97);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -62,7 +62,7 @@ fn inspect_timeline(inout out: result.Result, borrow world: model.World) {
         let eligible = (event.kind + FOCUS()) % 4 == 0;
         result.record(inout out, eligible, eligible && event.value > 0,
             event.sequence + event.actor % 257 + event.value);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
@@ -70,7 +70,7 @@ fn inspect_timeline(inout out: result.Result, borrow world: model.World) {
         let eligible = command.accepted && (command.kind + FOCUS()) % 3 == 0;
         result.record(inout out, eligible, eligible,
             command.tick + command.actor % 251 + command.value);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -83,12 +83,12 @@ fn inspect_regions(inout out: result.Result, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region { tiles = tiles + 1; resources = resources + tile.resource; }
-            i = i + 1;
+            i += 1;
         }
         let eligible = tiles > 0 && (region + FOCUS()) % 4 == 0;
         result.record(inout out, eligible, eligible && resources > tiles,
             resources + tiles * 13 + region);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/system_visibility_apply.rue
+++ b/examples/caldera/system_visibility_apply.rue
@@ -82,7 +82,7 @@ fn inspect_regions(inout out: result.Result, borrow world: model.World) {
         let mut i: u64 = 0;
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
-            if tile.region == region { tiles = tiles + 1; resources = resources + tile.resource; }
+            if tile.region == region { tiles += 1; resources += tile.resource; }
             i += 1;
         }
         let eligible = tiles > 0 && (region + FOCUS()) % 4 == 0;

--- a/examples/caldera/system_visibility_audit.rue
+++ b/examples/caldera/system_visibility_audit.rue
@@ -39,7 +39,7 @@ fn inspect_entities(inout out: result.Result, borrow world: model.World) {
         let eligible = eligible_entity(borrow world, borrow entity);
         let command = eligible && (entity.id + FOCUS() + world.tick) % 2 == 0;
         result.record(inout out, eligible, command, entity_value(borrow world, borrow entity));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -51,7 +51,7 @@ fn inspect_tiles(inout out: result.Result, borrow world: model.World) {
         let command = eligible && tile.resource > FOCUS() % 17;
         result.record(inout out, eligible, command,
             tile.height + tile.resource + tile.terrain * 11 + i % 97);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -62,7 +62,7 @@ fn inspect_timeline(inout out: result.Result, borrow world: model.World) {
         let eligible = (event.kind + FOCUS()) % 4 == 0;
         result.record(inout out, eligible, eligible && event.value > 0,
             event.sequence + event.actor % 257 + event.value);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
@@ -70,7 +70,7 @@ fn inspect_timeline(inout out: result.Result, borrow world: model.World) {
         let eligible = command.accepted && (command.kind + FOCUS()) % 3 == 0;
         result.record(inout out, eligible, eligible,
             command.tick + command.actor % 251 + command.value);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -83,12 +83,12 @@ fn inspect_regions(inout out: result.Result, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region { tiles = tiles + 1; resources = resources + tile.resource; }
-            i = i + 1;
+            i += 1;
         }
         let eligible = tiles > 0 && (region + FOCUS()) % 4 == 0;
         result.record(inout out, eligible, eligible && resources > tiles,
             resources + tiles * 13 + region);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/system_visibility_audit.rue
+++ b/examples/caldera/system_visibility_audit.rue
@@ -82,7 +82,7 @@ fn inspect_regions(inout out: result.Result, borrow world: model.World) {
         let mut i: u64 = 0;
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
-            if tile.region == region { tiles = tiles + 1; resources = resources + tile.resource; }
+            if tile.region == region { tiles += 1; resources += tile.resource; }
             i += 1;
         }
         let eligible = tiles > 0 && (region + FOCUS()) % 4 == 0;

--- a/examples/caldera/system_visibility_bootstrap.rue
+++ b/examples/caldera/system_visibility_bootstrap.rue
@@ -39,7 +39,7 @@ fn inspect_entities(inout out: result.Result, borrow world: model.World) {
         let eligible = eligible_entity(borrow world, borrow entity);
         let command = eligible && (entity.id + FOCUS() + world.tick) % 2 == 0;
         result.record(inout out, eligible, command, entity_value(borrow world, borrow entity));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -51,7 +51,7 @@ fn inspect_tiles(inout out: result.Result, borrow world: model.World) {
         let command = eligible && tile.resource > FOCUS() % 17;
         result.record(inout out, eligible, command,
             tile.height + tile.resource + tile.terrain * 11 + i % 97);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -62,7 +62,7 @@ fn inspect_timeline(inout out: result.Result, borrow world: model.World) {
         let eligible = (event.kind + FOCUS()) % 4 == 0;
         result.record(inout out, eligible, eligible && event.value > 0,
             event.sequence + event.actor % 257 + event.value);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
@@ -70,7 +70,7 @@ fn inspect_timeline(inout out: result.Result, borrow world: model.World) {
         let eligible = command.accepted && (command.kind + FOCUS()) % 3 == 0;
         result.record(inout out, eligible, eligible,
             command.tick + command.actor % 251 + command.value);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -83,12 +83,12 @@ fn inspect_regions(inout out: result.Result, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region { tiles = tiles + 1; resources = resources + tile.resource; }
-            i = i + 1;
+            i += 1;
         }
         let eligible = tiles > 0 && (region + FOCUS()) % 4 == 0;
         result.record(inout out, eligible, eligible && resources > tiles,
             resources + tiles * 13 + region);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/system_visibility_bootstrap.rue
+++ b/examples/caldera/system_visibility_bootstrap.rue
@@ -82,7 +82,7 @@ fn inspect_regions(inout out: result.Result, borrow world: model.World) {
         let mut i: u64 = 0;
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
-            if tile.region == region { tiles = tiles + 1; resources = resources + tile.resource; }
+            if tile.region == region { tiles += 1; resources += tile.resource; }
             i += 1;
         }
         let eligible = tiles > 0 && (region + FOCUS()) % 4 == 0;

--- a/examples/caldera/system_visibility_checkpoint.rue
+++ b/examples/caldera/system_visibility_checkpoint.rue
@@ -39,7 +39,7 @@ fn inspect_entities(inout out: result.Result, borrow world: model.World) {
         let eligible = eligible_entity(borrow world, borrow entity);
         let command = eligible && (entity.id + FOCUS() + world.tick) % 2 == 0;
         result.record(inout out, eligible, command, entity_value(borrow world, borrow entity));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -51,7 +51,7 @@ fn inspect_tiles(inout out: result.Result, borrow world: model.World) {
         let command = eligible && tile.resource > FOCUS() % 17;
         result.record(inout out, eligible, command,
             tile.height + tile.resource + tile.terrain * 11 + i % 97);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -62,7 +62,7 @@ fn inspect_timeline(inout out: result.Result, borrow world: model.World) {
         let eligible = (event.kind + FOCUS()) % 4 == 0;
         result.record(inout out, eligible, eligible && event.value > 0,
             event.sequence + event.actor % 257 + event.value);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
@@ -70,7 +70,7 @@ fn inspect_timeline(inout out: result.Result, borrow world: model.World) {
         let eligible = command.accepted && (command.kind + FOCUS()) % 3 == 0;
         result.record(inout out, eligible, eligible,
             command.tick + command.actor % 251 + command.value);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -83,12 +83,12 @@ fn inspect_regions(inout out: result.Result, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region { tiles = tiles + 1; resources = resources + tile.resource; }
-            i = i + 1;
+            i += 1;
         }
         let eligible = tiles > 0 && (region + FOCUS()) % 4 == 0;
         result.record(inout out, eligible, eligible && resources > tiles,
             resources + tiles * 13 + region);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/system_visibility_checkpoint.rue
+++ b/examples/caldera/system_visibility_checkpoint.rue
@@ -82,7 +82,7 @@ fn inspect_regions(inout out: result.Result, borrow world: model.World) {
         let mut i: u64 = 0;
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
-            if tile.region == region { tiles = tiles + 1; resources = resources + tile.resource; }
+            if tile.region == region { tiles += 1; resources += tile.resource; }
             i += 1;
         }
         let eligible = tiles > 0 && (region + FOCUS()) % 4 == 0;

--- a/examples/caldera/system_visibility_compact.rue
+++ b/examples/caldera/system_visibility_compact.rue
@@ -39,7 +39,7 @@ fn inspect_entities(inout out: result.Result, borrow world: model.World) {
         let eligible = eligible_entity(borrow world, borrow entity);
         let command = eligible && (entity.id + FOCUS() + world.tick) % 2 == 0;
         result.record(inout out, eligible, command, entity_value(borrow world, borrow entity));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -51,7 +51,7 @@ fn inspect_tiles(inout out: result.Result, borrow world: model.World) {
         let command = eligible && tile.resource > FOCUS() % 17;
         result.record(inout out, eligible, command,
             tile.height + tile.resource + tile.terrain * 11 + i % 97);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -62,7 +62,7 @@ fn inspect_timeline(inout out: result.Result, borrow world: model.World) {
         let eligible = (event.kind + FOCUS()) % 4 == 0;
         result.record(inout out, eligible, eligible && event.value > 0,
             event.sequence + event.actor % 257 + event.value);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
@@ -70,7 +70,7 @@ fn inspect_timeline(inout out: result.Result, borrow world: model.World) {
         let eligible = command.accepted && (command.kind + FOCUS()) % 3 == 0;
         result.record(inout out, eligible, eligible,
             command.tick + command.actor % 251 + command.value);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -83,12 +83,12 @@ fn inspect_regions(inout out: result.Result, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region { tiles = tiles + 1; resources = resources + tile.resource; }
-            i = i + 1;
+            i += 1;
         }
         let eligible = tiles > 0 && (region + FOCUS()) % 4 == 0;
         result.record(inout out, eligible, eligible && resources > tiles,
             resources + tiles * 13 + region);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/system_visibility_compact.rue
+++ b/examples/caldera/system_visibility_compact.rue
@@ -82,7 +82,7 @@ fn inspect_regions(inout out: result.Result, borrow world: model.World) {
         let mut i: u64 = 0;
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
-            if tile.region == region { tiles = tiles + 1; resources = resources + tile.resource; }
+            if tile.region == region { tiles += 1; resources += tile.resource; }
             i += 1;
         }
         let eligible = tiles > 0 && (region + FOCUS()) % 4 == 0;

--- a/examples/caldera/system_visibility_discover.rue
+++ b/examples/caldera/system_visibility_discover.rue
@@ -39,7 +39,7 @@ fn inspect_entities(inout out: result.Result, borrow world: model.World) {
         let eligible = eligible_entity(borrow world, borrow entity);
         let command = eligible && (entity.id + FOCUS() + world.tick) % 2 == 0;
         result.record(inout out, eligible, command, entity_value(borrow world, borrow entity));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -51,7 +51,7 @@ fn inspect_tiles(inout out: result.Result, borrow world: model.World) {
         let command = eligible && tile.resource > FOCUS() % 17;
         result.record(inout out, eligible, command,
             tile.height + tile.resource + tile.terrain * 11 + i % 97);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -62,7 +62,7 @@ fn inspect_timeline(inout out: result.Result, borrow world: model.World) {
         let eligible = (event.kind + FOCUS()) % 4 == 0;
         result.record(inout out, eligible, eligible && event.value > 0,
             event.sequence + event.actor % 257 + event.value);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
@@ -70,7 +70,7 @@ fn inspect_timeline(inout out: result.Result, borrow world: model.World) {
         let eligible = command.accepted && (command.kind + FOCUS()) % 3 == 0;
         result.record(inout out, eligible, eligible,
             command.tick + command.actor % 251 + command.value);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -83,12 +83,12 @@ fn inspect_regions(inout out: result.Result, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region { tiles = tiles + 1; resources = resources + tile.resource; }
-            i = i + 1;
+            i += 1;
         }
         let eligible = tiles > 0 && (region + FOCUS()) % 4 == 0;
         result.record(inout out, eligible, eligible && resources > tiles,
             resources + tiles * 13 + region);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/system_visibility_discover.rue
+++ b/examples/caldera/system_visibility_discover.rue
@@ -82,7 +82,7 @@ fn inspect_regions(inout out: result.Result, borrow world: model.World) {
         let mut i: u64 = 0;
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
-            if tile.region == region { tiles = tiles + 1; resources = resources + tile.resource; }
+            if tile.region == region { tiles += 1; resources += tile.resource; }
             i += 1;
         }
         let eligible = tiles > 0 && (region + FOCUS()) % 4 == 0;

--- a/examples/caldera/system_visibility_dispatch.rue
+++ b/examples/caldera/system_visibility_dispatch.rue
@@ -39,7 +39,7 @@ fn inspect_entities(inout out: result.Result, borrow world: model.World) {
         let eligible = eligible_entity(borrow world, borrow entity);
         let command = eligible && (entity.id + FOCUS() + world.tick) % 2 == 0;
         result.record(inout out, eligible, command, entity_value(borrow world, borrow entity));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -51,7 +51,7 @@ fn inspect_tiles(inout out: result.Result, borrow world: model.World) {
         let command = eligible && tile.resource > FOCUS() % 17;
         result.record(inout out, eligible, command,
             tile.height + tile.resource + tile.terrain * 11 + i % 97);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -62,7 +62,7 @@ fn inspect_timeline(inout out: result.Result, borrow world: model.World) {
         let eligible = (event.kind + FOCUS()) % 4 == 0;
         result.record(inout out, eligible, eligible && event.value > 0,
             event.sequence + event.actor % 257 + event.value);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
@@ -70,7 +70,7 @@ fn inspect_timeline(inout out: result.Result, borrow world: model.World) {
         let eligible = command.accepted && (command.kind + FOCUS()) % 3 == 0;
         result.record(inout out, eligible, eligible,
             command.tick + command.actor % 251 + command.value);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -83,12 +83,12 @@ fn inspect_regions(inout out: result.Result, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region { tiles = tiles + 1; resources = resources + tile.resource; }
-            i = i + 1;
+            i += 1;
         }
         let eligible = tiles > 0 && (region + FOCUS()) % 4 == 0;
         result.record(inout out, eligible, eligible && resources > tiles,
             resources + tiles * 13 + region);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/system_visibility_dispatch.rue
+++ b/examples/caldera/system_visibility_dispatch.rue
@@ -82,7 +82,7 @@ fn inspect_regions(inout out: result.Result, borrow world: model.World) {
         let mut i: u64 = 0;
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
-            if tile.region == region { tiles = tiles + 1; resources = resources + tile.resource; }
+            if tile.region == region { tiles += 1; resources += tile.resource; }
             i += 1;
         }
         let eligible = tiles > 0 && (region + FOCUS()) % 4 == 0;

--- a/examples/caldera/system_visibility_finalize.rue
+++ b/examples/caldera/system_visibility_finalize.rue
@@ -39,7 +39,7 @@ fn inspect_entities(inout out: result.Result, borrow world: model.World) {
         let eligible = eligible_entity(borrow world, borrow entity);
         let command = eligible && (entity.id + FOCUS() + world.tick) % 2 == 0;
         result.record(inout out, eligible, command, entity_value(borrow world, borrow entity));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -51,7 +51,7 @@ fn inspect_tiles(inout out: result.Result, borrow world: model.World) {
         let command = eligible && tile.resource > FOCUS() % 17;
         result.record(inout out, eligible, command,
             tile.height + tile.resource + tile.terrain * 11 + i % 97);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -62,7 +62,7 @@ fn inspect_timeline(inout out: result.Result, borrow world: model.World) {
         let eligible = (event.kind + FOCUS()) % 4 == 0;
         result.record(inout out, eligible, eligible && event.value > 0,
             event.sequence + event.actor % 257 + event.value);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
@@ -70,7 +70,7 @@ fn inspect_timeline(inout out: result.Result, borrow world: model.World) {
         let eligible = command.accepted && (command.kind + FOCUS()) % 3 == 0;
         result.record(inout out, eligible, eligible,
             command.tick + command.actor % 251 + command.value);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -83,12 +83,12 @@ fn inspect_regions(inout out: result.Result, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region { tiles = tiles + 1; resources = resources + tile.resource; }
-            i = i + 1;
+            i += 1;
         }
         let eligible = tiles > 0 && (region + FOCUS()) % 4 == 0;
         result.record(inout out, eligible, eligible && resources > tiles,
             resources + tiles * 13 + region);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/system_visibility_finalize.rue
+++ b/examples/caldera/system_visibility_finalize.rue
@@ -82,7 +82,7 @@ fn inspect_regions(inout out: result.Result, borrow world: model.World) {
         let mut i: u64 = 0;
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
-            if tile.region == region { tiles = tiles + 1; resources = resources + tile.resource; }
+            if tile.region == region { tiles += 1; resources += tile.resource; }
             i += 1;
         }
         let eligible = tiles > 0 && (region + FOCUS()) % 4 == 0;

--- a/examples/caldera/system_visibility_observe.rue
+++ b/examples/caldera/system_visibility_observe.rue
@@ -39,7 +39,7 @@ fn inspect_entities(inout out: result.Result, borrow world: model.World) {
         let eligible = eligible_entity(borrow world, borrow entity);
         let command = eligible && (entity.id + FOCUS() + world.tick) % 2 == 0;
         result.record(inout out, eligible, command, entity_value(borrow world, borrow entity));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -51,7 +51,7 @@ fn inspect_tiles(inout out: result.Result, borrow world: model.World) {
         let command = eligible && tile.resource > FOCUS() % 17;
         result.record(inout out, eligible, command,
             tile.height + tile.resource + tile.terrain * 11 + i % 97);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -62,7 +62,7 @@ fn inspect_timeline(inout out: result.Result, borrow world: model.World) {
         let eligible = (event.kind + FOCUS()) % 4 == 0;
         result.record(inout out, eligible, eligible && event.value > 0,
             event.sequence + event.actor % 257 + event.value);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
@@ -70,7 +70,7 @@ fn inspect_timeline(inout out: result.Result, borrow world: model.World) {
         let eligible = command.accepted && (command.kind + FOCUS()) % 3 == 0;
         result.record(inout out, eligible, eligible,
             command.tick + command.actor % 251 + command.value);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -83,12 +83,12 @@ fn inspect_regions(inout out: result.Result, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region { tiles = tiles + 1; resources = resources + tile.resource; }
-            i = i + 1;
+            i += 1;
         }
         let eligible = tiles > 0 && (region + FOCUS()) % 4 == 0;
         result.record(inout out, eligible, eligible && resources > tiles,
             resources + tiles * 13 + region);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/system_visibility_observe.rue
+++ b/examples/caldera/system_visibility_observe.rue
@@ -82,7 +82,7 @@ fn inspect_regions(inout out: result.Result, borrow world: model.World) {
         let mut i: u64 = 0;
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
-            if tile.region == region { tiles = tiles + 1; resources = resources + tile.resource; }
+            if tile.region == region { tiles += 1; resources += tile.resource; }
             i += 1;
         }
         let eligible = tiles > 0 && (region + FOCUS()) % 4 == 0;

--- a/examples/caldera/system_visibility_prepare.rue
+++ b/examples/caldera/system_visibility_prepare.rue
@@ -39,7 +39,7 @@ fn inspect_entities(inout out: result.Result, borrow world: model.World) {
         let eligible = eligible_entity(borrow world, borrow entity);
         let command = eligible && (entity.id + FOCUS() + world.tick) % 2 == 0;
         result.record(inout out, eligible, command, entity_value(borrow world, borrow entity));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -51,7 +51,7 @@ fn inspect_tiles(inout out: result.Result, borrow world: model.World) {
         let command = eligible && tile.resource > FOCUS() % 17;
         result.record(inout out, eligible, command,
             tile.height + tile.resource + tile.terrain * 11 + i % 97);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -62,7 +62,7 @@ fn inspect_timeline(inout out: result.Result, borrow world: model.World) {
         let eligible = (event.kind + FOCUS()) % 4 == 0;
         result.record(inout out, eligible, eligible && event.value > 0,
             event.sequence + event.actor % 257 + event.value);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
@@ -70,7 +70,7 @@ fn inspect_timeline(inout out: result.Result, borrow world: model.World) {
         let eligible = command.accepted && (command.kind + FOCUS()) % 3 == 0;
         result.record(inout out, eligible, eligible,
             command.tick + command.actor % 251 + command.value);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -83,12 +83,12 @@ fn inspect_regions(inout out: result.Result, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region { tiles = tiles + 1; resources = resources + tile.resource; }
-            i = i + 1;
+            i += 1;
         }
         let eligible = tiles > 0 && (region + FOCUS()) % 4 == 0;
         result.record(inout out, eligible, eligible && resources > tiles,
             resources + tiles * 13 + region);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/system_visibility_prepare.rue
+++ b/examples/caldera/system_visibility_prepare.rue
@@ -82,7 +82,7 @@ fn inspect_regions(inout out: result.Result, borrow world: model.World) {
         let mut i: u64 = 0;
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
-            if tile.region == region { tiles = tiles + 1; resources = resources + tile.resource; }
+            if tile.region == region { tiles += 1; resources += tile.resource; }
             i += 1;
         }
         let eligible = tiles > 0 && (region + FOCUS()) % 4 == 0;

--- a/examples/caldera/system_visibility_reconcile.rue
+++ b/examples/caldera/system_visibility_reconcile.rue
@@ -39,7 +39,7 @@ fn inspect_entities(inout out: result.Result, borrow world: model.World) {
         let eligible = eligible_entity(borrow world, borrow entity);
         let command = eligible && (entity.id + FOCUS() + world.tick) % 2 == 0;
         result.record(inout out, eligible, command, entity_value(borrow world, borrow entity));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -51,7 +51,7 @@ fn inspect_tiles(inout out: result.Result, borrow world: model.World) {
         let command = eligible && tile.resource > FOCUS() % 17;
         result.record(inout out, eligible, command,
             tile.height + tile.resource + tile.terrain * 11 + i % 97);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -62,7 +62,7 @@ fn inspect_timeline(inout out: result.Result, borrow world: model.World) {
         let eligible = (event.kind + FOCUS()) % 4 == 0;
         result.record(inout out, eligible, eligible && event.value > 0,
             event.sequence + event.actor % 257 + event.value);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
@@ -70,7 +70,7 @@ fn inspect_timeline(inout out: result.Result, borrow world: model.World) {
         let eligible = command.accepted && (command.kind + FOCUS()) % 3 == 0;
         result.record(inout out, eligible, eligible,
             command.tick + command.actor % 251 + command.value);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -83,12 +83,12 @@ fn inspect_regions(inout out: result.Result, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region { tiles = tiles + 1; resources = resources + tile.resource; }
-            i = i + 1;
+            i += 1;
         }
         let eligible = tiles > 0 && (region + FOCUS()) % 4 == 0;
         result.record(inout out, eligible, eligible && resources > tiles,
             resources + tiles * 13 + region);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/system_visibility_reconcile.rue
+++ b/examples/caldera/system_visibility_reconcile.rue
@@ -82,7 +82,7 @@ fn inspect_regions(inout out: result.Result, borrow world: model.World) {
         let mut i: u64 = 0;
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
-            if tile.region == region { tiles = tiles + 1; resources = resources + tile.resource; }
+            if tile.region == region { tiles += 1; resources += tile.resource; }
             i += 1;
         }
         let eligible = tiles > 0 && (region + FOCUS()) % 4 == 0;

--- a/examples/caldera/system_visibility_recover.rue
+++ b/examples/caldera/system_visibility_recover.rue
@@ -39,7 +39,7 @@ fn inspect_entities(inout out: result.Result, borrow world: model.World) {
         let eligible = eligible_entity(borrow world, borrow entity);
         let command = eligible && (entity.id + FOCUS() + world.tick) % 2 == 0;
         result.record(inout out, eligible, command, entity_value(borrow world, borrow entity));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -51,7 +51,7 @@ fn inspect_tiles(inout out: result.Result, borrow world: model.World) {
         let command = eligible && tile.resource > FOCUS() % 17;
         result.record(inout out, eligible, command,
             tile.height + tile.resource + tile.terrain * 11 + i % 97);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -62,7 +62,7 @@ fn inspect_timeline(inout out: result.Result, borrow world: model.World) {
         let eligible = (event.kind + FOCUS()) % 4 == 0;
         result.record(inout out, eligible, eligible && event.value > 0,
             event.sequence + event.actor % 257 + event.value);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
@@ -70,7 +70,7 @@ fn inspect_timeline(inout out: result.Result, borrow world: model.World) {
         let eligible = command.accepted && (command.kind + FOCUS()) % 3 == 0;
         result.record(inout out, eligible, eligible,
             command.tick + command.actor % 251 + command.value);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -83,12 +83,12 @@ fn inspect_regions(inout out: result.Result, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region { tiles = tiles + 1; resources = resources + tile.resource; }
-            i = i + 1;
+            i += 1;
         }
         let eligible = tiles > 0 && (region + FOCUS()) % 4 == 0;
         result.record(inout out, eligible, eligible && resources > tiles,
             resources + tiles * 13 + region);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/system_visibility_recover.rue
+++ b/examples/caldera/system_visibility_recover.rue
@@ -82,7 +82,7 @@ fn inspect_regions(inout out: result.Result, borrow world: model.World) {
         let mut i: u64 = 0;
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
-            if tile.region == region { tiles = tiles + 1; resources = resources + tile.resource; }
+            if tile.region == region { tiles += 1; resources += tile.resource; }
             i += 1;
         }
         let eligible = tiles > 0 && (region + FOCUS()) % 4 == 0;

--- a/examples/caldera/system_visibility_replicate.rue
+++ b/examples/caldera/system_visibility_replicate.rue
@@ -39,7 +39,7 @@ fn inspect_entities(inout out: result.Result, borrow world: model.World) {
         let eligible = eligible_entity(borrow world, borrow entity);
         let command = eligible && (entity.id + FOCUS() + world.tick) % 2 == 0;
         result.record(inout out, eligible, command, entity_value(borrow world, borrow entity));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -51,7 +51,7 @@ fn inspect_tiles(inout out: result.Result, borrow world: model.World) {
         let command = eligible && tile.resource > FOCUS() % 17;
         result.record(inout out, eligible, command,
             tile.height + tile.resource + tile.terrain * 11 + i % 97);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -62,7 +62,7 @@ fn inspect_timeline(inout out: result.Result, borrow world: model.World) {
         let eligible = (event.kind + FOCUS()) % 4 == 0;
         result.record(inout out, eligible, eligible && event.value > 0,
             event.sequence + event.actor % 257 + event.value);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
@@ -70,7 +70,7 @@ fn inspect_timeline(inout out: result.Result, borrow world: model.World) {
         let eligible = command.accepted && (command.kind + FOCUS()) % 3 == 0;
         result.record(inout out, eligible, eligible,
             command.tick + command.actor % 251 + command.value);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -83,12 +83,12 @@ fn inspect_regions(inout out: result.Result, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region { tiles = tiles + 1; resources = resources + tile.resource; }
-            i = i + 1;
+            i += 1;
         }
         let eligible = tiles > 0 && (region + FOCUS()) % 4 == 0;
         result.record(inout out, eligible, eligible && resources > tiles,
             resources + tiles * 13 + region);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/system_visibility_replicate.rue
+++ b/examples/caldera/system_visibility_replicate.rue
@@ -82,7 +82,7 @@ fn inspect_regions(inout out: result.Result, borrow world: model.World) {
         let mut i: u64 = 0;
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
-            if tile.region == region { tiles = tiles + 1; resources = resources + tile.resource; }
+            if tile.region == region { tiles += 1; resources += tile.resource; }
             i += 1;
         }
         let eligible = tiles > 0 && (region + FOCUS()) % 4 == 0;

--- a/examples/caldera/system_visibility_resolve.rue
+++ b/examples/caldera/system_visibility_resolve.rue
@@ -39,7 +39,7 @@ fn inspect_entities(inout out: result.Result, borrow world: model.World) {
         let eligible = eligible_entity(borrow world, borrow entity);
         let command = eligible && (entity.id + FOCUS() + world.tick) % 2 == 0;
         result.record(inout out, eligible, command, entity_value(borrow world, borrow entity));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -51,7 +51,7 @@ fn inspect_tiles(inout out: result.Result, borrow world: model.World) {
         let command = eligible && tile.resource > FOCUS() % 17;
         result.record(inout out, eligible, command,
             tile.height + tile.resource + tile.terrain * 11 + i % 97);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -62,7 +62,7 @@ fn inspect_timeline(inout out: result.Result, borrow world: model.World) {
         let eligible = (event.kind + FOCUS()) % 4 == 0;
         result.record(inout out, eligible, eligible && event.value > 0,
             event.sequence + event.actor % 257 + event.value);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
@@ -70,7 +70,7 @@ fn inspect_timeline(inout out: result.Result, borrow world: model.World) {
         let eligible = command.accepted && (command.kind + FOCUS()) % 3 == 0;
         result.record(inout out, eligible, eligible,
             command.tick + command.actor % 251 + command.value);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -83,12 +83,12 @@ fn inspect_regions(inout out: result.Result, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region { tiles = tiles + 1; resources = resources + tile.resource; }
-            i = i + 1;
+            i += 1;
         }
         let eligible = tiles > 0 && (region + FOCUS()) % 4 == 0;
         result.record(inout out, eligible, eligible && resources > tiles,
             resources + tiles * 13 + region);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/system_visibility_resolve.rue
+++ b/examples/caldera/system_visibility_resolve.rue
@@ -82,7 +82,7 @@ fn inspect_regions(inout out: result.Result, borrow world: model.World) {
         let mut i: u64 = 0;
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
-            if tile.region == region { tiles = tiles + 1; resources = resources + tile.resource; }
+            if tile.region == region { tiles += 1; resources += tile.resource; }
             i += 1;
         }
         let eligible = tiles > 0 && (region + FOCUS()) % 4 == 0;

--- a/examples/caldera/system_visibility_schedule.rue
+++ b/examples/caldera/system_visibility_schedule.rue
@@ -39,7 +39,7 @@ fn inspect_entities(inout out: result.Result, borrow world: model.World) {
         let eligible = eligible_entity(borrow world, borrow entity);
         let command = eligible && (entity.id + FOCUS() + world.tick) % 2 == 0;
         result.record(inout out, eligible, command, entity_value(borrow world, borrow entity));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -51,7 +51,7 @@ fn inspect_tiles(inout out: result.Result, borrow world: model.World) {
         let command = eligible && tile.resource > FOCUS() % 17;
         result.record(inout out, eligible, command,
             tile.height + tile.resource + tile.terrain * 11 + i % 97);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -62,7 +62,7 @@ fn inspect_timeline(inout out: result.Result, borrow world: model.World) {
         let eligible = (event.kind + FOCUS()) % 4 == 0;
         result.record(inout out, eligible, eligible && event.value > 0,
             event.sequence + event.actor % 257 + event.value);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
@@ -70,7 +70,7 @@ fn inspect_timeline(inout out: result.Result, borrow world: model.World) {
         let eligible = command.accepted && (command.kind + FOCUS()) % 3 == 0;
         result.record(inout out, eligible, eligible,
             command.tick + command.actor % 251 + command.value);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -83,12 +83,12 @@ fn inspect_regions(inout out: result.Result, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region { tiles = tiles + 1; resources = resources + tile.resource; }
-            i = i + 1;
+            i += 1;
         }
         let eligible = tiles > 0 && (region + FOCUS()) % 4 == 0;
         result.record(inout out, eligible, eligible && resources > tiles,
             resources + tiles * 13 + region);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/system_visibility_schedule.rue
+++ b/examples/caldera/system_visibility_schedule.rue
@@ -82,7 +82,7 @@ fn inspect_regions(inout out: result.Result, borrow world: model.World) {
         let mut i: u64 = 0;
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
-            if tile.region == region { tiles = tiles + 1; resources = resources + tile.resource; }
+            if tile.region == region { tiles += 1; resources += tile.resource; }
             i += 1;
         }
         let eligible = tiles > 0 && (region + FOCUS()) % 4 == 0;

--- a/examples/caldera/system_visibility_validate.rue
+++ b/examples/caldera/system_visibility_validate.rue
@@ -39,7 +39,7 @@ fn inspect_entities(inout out: result.Result, borrow world: model.World) {
         let eligible = eligible_entity(borrow world, borrow entity);
         let command = eligible && (entity.id + FOCUS() + world.tick) % 2 == 0;
         result.record(inout out, eligible, command, entity_value(borrow world, borrow entity));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -51,7 +51,7 @@ fn inspect_tiles(inout out: result.Result, borrow world: model.World) {
         let command = eligible && tile.resource > FOCUS() % 17;
         result.record(inout out, eligible, command,
             tile.height + tile.resource + tile.terrain * 11 + i % 97);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -62,7 +62,7 @@ fn inspect_timeline(inout out: result.Result, borrow world: model.World) {
         let eligible = (event.kind + FOCUS()) % 4 == 0;
         result.record(inout out, eligible, eligible && event.value > 0,
             event.sequence + event.actor % 257 + event.value);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < world.commands.len() {
@@ -70,7 +70,7 @@ fn inspect_timeline(inout out: result.Result, borrow world: model.World) {
         let eligible = command.accepted && (command.kind + FOCUS()) % 3 == 0;
         result.record(inout out, eligible, eligible,
             command.tick + command.actor % 251 + command.value);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -83,12 +83,12 @@ fn inspect_regions(inout out: result.Result, borrow world: model.World) {
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
             if tile.region == region { tiles = tiles + 1; resources = resources + tile.resource; }
-            i = i + 1;
+            i += 1;
         }
         let eligible = tiles > 0 && (region + FOCUS()) % 4 == 0;
         result.record(inout out, eligible, eligible && resources > tiles,
             resources + tiles * 13 + region);
-        region = region + 1;
+        region += 1;
     }
 }
 

--- a/examples/caldera/system_visibility_validate.rue
+++ b/examples/caldera/system_visibility_validate.rue
@@ -82,7 +82,7 @@ fn inspect_regions(inout out: result.Result, borrow world: model.World) {
         let mut i: u64 = 0;
         while i < world.tiles.len() {
             let tile = world.tiles.get_or(i, model.empty_tile());
-            if tile.region == region { tiles = tiles + 1; resources = resources + tile.resource; }
+            if tile.region == region { tiles += 1; resources += tile.resource; }
             i += 1;
         }
         let eligible = tiles > 0 && (region + FOCUS()) % 4 == 0;

--- a/examples/caldera/text.rue
+++ b/examples/caldera/text.rue
@@ -11,7 +11,7 @@ pub fn append_string(inout out: StrBuf, borrow value: StrBuf) {
     let mut i: u64 = 0;
     while i < value.len() {
         out.push(StrBuf.byte_at_borrowed(borrow value, i));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -46,9 +46,9 @@ pub fn fnv1a(borrow value: StrBuf) -> u64 {
     let mut hash: u64 = 14695981039346656037;
     let mut i: u64 = 0;
     while i < value.len() {
-        hash = hash ^ @intCast(StrBuf.byte_at_borrowed(borrow value, i));
+        hash ^= @intCast(StrBuf.byte_at_borrowed(borrow value, i));
         hash = @wrapping_mul(hash, 1099511628211);
-        i = i + 1;
+        i += 1;
     }
     hash
 }

--- a/examples/caldera/text.rue
+++ b/examples/caldera/text.rue
@@ -4,7 +4,7 @@ const StrBuf = std.strbuf.StrBuf;
 
 pub fn append_literal(inout out: StrBuf, value: str) {
     let mut i: u64 = 0;
-    while i < value.len() { out.push(value[i]); i = i + 1; }
+    while i < value.len() { out.push(value[i]); i += 1; }
 }
 
 pub fn append_string(inout out: StrBuf, borrow value: StrBuf) {

--- a/examples/caldera/tick.rue
+++ b/examples/caldera/tick.rue
@@ -9,7 +9,7 @@ pub struct Result { tick: u64, ai_changes: u64, moved: u64,
     produced: u64, events: u64, checksum: u64, valid: bool }
 
 pub fn step(inout world: model.World) -> Result {
-    world.tick = world.tick + 1;
+    world.tick += 1;
     let ai_changes = ai.update(inout world);
     let moved = physics.step(inout world);
     let ledger = economy.step(inout world);

--- a/examples/caldera/tick.rue
+++ b/examples/caldera/tick.rue
@@ -13,7 +13,7 @@ pub fn step(inout world: model.World) -> Result {
     let ai_changes = ai.update(inout world);
     let moved = physics.step(inout world);
     let ledger = economy.step(inout world);
-    if world.tick % 3 == 0 { world.quests_completed = world.quests_completed + 1; }
+    if world.tick % 3 == 0 { world.quests_completed += 1; }
     let captured = snapshot.capture(inout world);
     Result { tick: world.tick, ai_changes: ai_changes, moved: moved,
         produced: ledger.produced, events: world.events.len(),

--- a/examples/caldera/world_clone.rue
+++ b/examples/caldera/world_clone.rue
@@ -9,19 +9,19 @@ pub fn clone(borrow source: model.World) -> model.World {
     out.next_entity = source.next_entity; out.next_sequence = source.next_sequence;
     out.valid = source.valid;
     let mut i: u64 = 0;
-    while i < source.entities.len() { out.entities.push(source.entities.get_or(i, model.empty_entity())); i = i + 1; }
+    while i < source.entities.len() { out.entities.push(source.entities.get_or(i, model.empty_entity())); i += 1; }
     i = 0;
-    while i < source.tiles.len() { out.tiles.push(source.tiles.get_or(i, model.empty_tile())); i = i + 1; }
+    while i < source.tiles.len() { out.tiles.push(source.tiles.get_or(i, model.empty_tile())); i += 1; }
     i = 0;
-    while i < source.events.len() { out.events.push(source.events.get_or(i, model.empty_event())); i = i + 1; }
+    while i < source.events.len() { out.events.push(source.events.get_or(i, model.empty_event())); i += 1; }
     i = 0;
-    while i < source.commands.len() { out.commands.push(source.commands.get_or(i, model.empty_command())); i = i + 1; }
+    while i < source.commands.len() { out.commands.push(source.commands.get_or(i, model.empty_command())); i += 1; }
     i = 0;
-    while i < source.snapshots.len() { out.snapshots.push(source.snapshots.get_or(i, model.empty_snapshot())); i = i + 1; }
+    while i < source.snapshots.len() { out.snapshots.push(source.snapshots.get_or(i, model.empty_snapshot())); i += 1; }
     i = 0;
     while i < source.diagnostics.len() {
         let item = source.diagnostics.get_or(i, model.Diagnostic { code: 0, subject: 0, detail: 0 });
-        out.diagnostics.push(item); i = i + 1;
+        out.diagnostics.push(item); i += 1;
     }
     out
 }

--- a/examples/caldera/worldgen.rue
+++ b/examples/caldera/worldgen.rue
@@ -21,16 +21,16 @@ fn add_tiles(inout world: model.World) {
                 occupant: model.NONE(), region: (x / 4) + (y / 4) * 8,
                 walkable: kind != model.WATER() && kind != model.WALL(),
                 visible: false });
-            x = x + 1;
+            x += 1;
         }
-        y = y + 1;
+        y += 1;
     }
 }
 
 pub fn add_entity(inout world: model.World, kind: u64, faction: u64,
     x: u64, y: u64) -> u64 {
     let id = world.next_entity;
-    world.next_entity = world.next_entity + 1;
+    world.next_entity += 1;
     world.entities.push(model.Entity { id: id, kind: kind, faction: faction,
         x: @intCast(x), y: @intCast(y), previous_x: @intCast(x), previous_y: @intCast(y),
         velocity_x: 0, velocity_y: 0, health: 100, energy: 100,
@@ -59,7 +59,7 @@ pub fn demo(scale: u64) -> model.World {
         let x = 1 + (i * 3) % (size - 2);
         let y = 1 + (i * 5) % (size - 2);
         let _ = add_entity(inout world, kind, faction, x, y);
-        i = i + 1;
+        i += 1;
     }
     world.resources = 400 * scale;
     world.treasury = 250 * scale;
@@ -82,7 +82,7 @@ pub fn from_scenario(borrow input: scenario.Scenario) -> model.World {
                 walkable: spec.terrain != model.WALL() && spec.terrain != model.WATER(),
                 visible: old.visible });
         }
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < input.entities.len() {
@@ -92,7 +92,7 @@ pub fn from_scenario(borrow input: scenario.Scenario) -> model.World {
         } else {
             let _ = add_entity(inout world, spec.kind, spec.faction, spec.x, spec.y);
         }
-        i = i + 1;
+        i += 1;
     }
     world.resources = input.entities.len() * 50;
     world.treasury = input.entities.len() * 25;

--- a/examples/collatz.rue
+++ b/examples/collatz.rue
@@ -20,7 +20,7 @@ fn collatz_length(start: i32) -> i32 {
     let mut steps = 0;
     while n != 1 {
         n = collatz_step(n);
-        steps = steps + 1;
+        steps += 1;
     }
     steps
 }
@@ -50,7 +50,7 @@ fn main() -> i32 {
             max_length = len;
             max_start = i;
         }
-        i = i + 1;
+        i += 1;
     }
 
     // Return the starting number with longest sequence

--- a/examples/dbg.rue
+++ b/examples/dbg.rue
@@ -34,7 +34,7 @@ fn main() -> i32 {
     let mut i = 0;
     while i < 5 {
         @dbg(i);
-        i = i + 1;
+        i += 1;
     }
 
     0

--- a/examples/dijkstra/graphs/dijkstra.rue
+++ b/examples/dijkstra/graphs/dijkstra.rue
@@ -11,7 +11,7 @@ pub fn shortest(borrow g: graph.Graph, src: u64) -> Ints {
     let mut i: u64 = 0;
     while i < n {
         dist.push(INF);
-        i = i + 1;
+        i += 1;
     }
     dist.set(src, 0);
 

--- a/examples/dijkstra/graphs/graph.rue
+++ b/examples/dijkstra/graphs/graph.rue
@@ -14,7 +14,7 @@ pub struct Graph {
         let mut i: u64 = 0;
         while i < n {
             head.push(0 - 1);
-            i = i + 1;
+            i += 1;
         }
         Self { n: n, head: head, to: Ints.new(), weight: Ints.new(), next: Ints.new() }
     }

--- a/examples/fibonacci.rue
+++ b/examples/fibonacci.rue
@@ -14,7 +14,7 @@ fn fib(n: i32) -> i32 {
             let next = a + b;
             a = b;
             b = next;
-            i = i + 1;
+            i += 1;
         }
         b
     }
@@ -34,7 +34,7 @@ fn main() -> i32 {
     let mut i = 0;
     while i < 20 {
         @dbg(fib(i));
-        i = i + 1;
+        i += 1;
     }
 
     // Return fib(10) = 55

--- a/examples/first/stats.rue
+++ b/examples/first/stats.rue
@@ -47,8 +47,8 @@ fn main() -> i32 {
     loop {
         match read_num() {
             OptInt.Some(x) => {
-                count = count + 1;
-                sum = sum + x;
+                count += 1;
+                sum += x;
                 max = match max {
                     OptInt.None => OptInt.Some(x),
                     OptInt.Some(m) => if x > m { OptInt.Some(x) } else { OptInt.Some(m) },

--- a/examples/fizzbuzz.rue
+++ b/examples/fizzbuzz.rue
@@ -29,7 +29,7 @@ fn main() -> i32 {
     let mut i = 1;
     while i <= 30 {
         @dbg(fizzbuzz(i));
-        i = i + 1;
+        i += 1;
     }
     0
 }

--- a/examples/generic_stack.rue
+++ b/examples/generic_stack.rue
@@ -2,8 +2,8 @@ fn Stack(comptime T: type, comptime CAP: i32) -> type {
     struct {
         items: [T; CAP],
         top: i32,
-        fn push(inout self, x: T) { self.items[self.top] = x; self.top = self.top + 1; }
-        fn pop(inout self) -> T { self.top = self.top - 1; self.items[self.top] }
+        fn push(inout self, x: T) { self.items[self.top] = x; self.top += 1; }
+        fn pop(inout self) -> T { self.top -= 1; self.items[self.top] }
         fn size(borrow self) -> i32 { self.top }
     }
 }

--- a/examples/harbor/accounting.rue
+++ b/examples/harbor/accounting.rue
@@ -17,7 +17,7 @@ pub struct Ledger {
 
 fn cast(value: u64, inout overflows: u64) -> i64 {
     if value > 9223372036854775807 {
-        overflows = overflows + 1;
+        overflows += 1;
         9223372036854775807
     } else { @intCast(value) }
 }
@@ -40,7 +40,7 @@ fn mul(a: i64, b: i64, inout overflows: u64) -> i64 {
     match std.math.checked_mul(a, b) {
         OptI64.Some(v) => v,
         OptI64.None => {
-            overflows = overflows + 1;
+            overflows += 1;
             if (a < 0 && b > 0) || (a > 0 && b < 0) { -9223372036854775807 - 1 }
             else { 9223372036854775807 }
         },
@@ -61,7 +61,7 @@ pub fn calculate(borrow scenario: model.Scenario, borrow sim: state.State) -> Le
         let remaining = sim.demand_remaining.get_or(i, 0);
         revenue = add(revenue, mul(cast(delivered, inout overflows), cast(cargo.unit_value, inout overflows), inout overflows), inout overflows);
         unmet_penalty = add(unmet_penalty, mul(cast(remaining, inout overflows), cast(demand.priority, inout overflows), inout overflows), inout overflows);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < sim.log.len() {
@@ -74,13 +74,13 @@ pub fn calculate(borrow scenario: model.Scenario, borrow sim: state.State) -> Le
                 lateness_penalty = add(lateness_penalty, mul(units, cast(demand.priority, inout overflows), inout overflows), inout overflows);
             }
         }
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < scenario.cargoes.len() {
         let cargo = scenario.cargoes.get_or(i, model.empty_cargo());
         spoilage_loss = add(spoilage_loss, mul(cast(sim.expired.get_or(i, 0), inout overflows), cast(cargo.unit_value, inout overflows), inout overflows), inout overflows);
-        i = i + 1;
+        i += 1;
     }
     let operating_cost = cast(sim.total_cost, inout overflows);
     let mut profit = sub(revenue, operating_cost, inout overflows);

--- a/examples/harbor/accounting.rue
+++ b/examples/harbor/accounting.rue
@@ -25,14 +25,14 @@ fn cast(value: u64, inout overflows: u64) -> i64 {
 fn add(a: i64, b: i64, inout overflows: u64) -> i64 {
     match std.math.checked_add(a, b) {
         OptI64.Some(v) => v,
-        OptI64.None => { overflows = overflows + 1; if b >= 0 { 9223372036854775807 } else { -9223372036854775807 - 1 } },
+        OptI64.None => { overflows += 1; if b >= 0 { 9223372036854775807 } else { -9223372036854775807 - 1 } },
     }
 }
 
 fn sub(a: i64, b: i64, inout overflows: u64) -> i64 {
     match std.math.checked_sub(a, b) {
         OptI64.Some(v) => v,
-        OptI64.None => { overflows = overflows + 1; if b < 0 { 9223372036854775807 } else { -9223372036854775807 - 1 } },
+        OptI64.None => { overflows += 1; if b < 0 { 9223372036854775807 } else { -9223372036854775807 - 1 } },
     }
 }
 

--- a/examples/harbor/assurance_export.rue
+++ b/examples/harbor/assurance_export.rue
@@ -48,7 +48,7 @@ fn route_rows(inout out: StrBuf, borrow audit: route_audit.Audit) {
         number(inout out, item.endpoint_errors); comma(inout out); number(inout out, item.continuity_errors); comma(inout out);
         number(inout out, item.direction_errors); comma(inout out); number(inout out, item.capacity_errors); comma(inout out);
         number(inout out, item.weight_errors); comma(inout out); number(inout out, item.cycle_errors); newline(inout out);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -69,7 +69,7 @@ fn contingency_rows(inout out: StrBuf, borrow plan: contingency.Plan) {
         if item.cost == routing.INF() { text.append_literal(inout out, "unreachable"); } else { number(inout out, item.cost); }
         comma(inout out); number(inout out, item.travel); comma(inout out); number(inout out, item.distance); comma(inout out);
         number(inout out, item.hops); comma(inout out); number(inout out, item.bottleneck); newline(inout out);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -95,7 +95,7 @@ fn comparison_rows(inout out: StrBuf, borrow comparison: scenario_compare.Compar
         number(inout out, item.during_total); comma(inout out); number(inout out, item.added_weight); comma(inout out);
         number(inout out, item.largest_increase); comma(inout out); number(inout out, item.largest_from); comma(inout out);
         number(inout out, item.largest_to); newline(inout out);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -113,7 +113,7 @@ fn risk_rows(inout out: StrBuf, borrow risks: risk_register.Register) {
         number(inout out, item.likelihood); comma(inout out); number(inout out, item.exposure); comma(inout out);
         number(inout out, item.score); comma(inout out); number(inout out, item.evidence); comma(inout out);
         number(inout out, item.mitigation); newline(inout out);
-        i = i + 1;
+        i += 1;
     }
 }
 

--- a/examples/harbor/capacity_profile.rue
+++ b/examples/harbor/capacity_profile.rue
@@ -31,7 +31,7 @@ pub struct Summary {
 
 fn fill(inout values: U64s, count: u64, value: u64) {
     let mut i: u64 = 0;
-    while i < count { values.push(value); i = i + 1; }
+    while i < count { values.push(value); i += 1; }
 }
 
 fn add(a: u64, b: u64) -> u64 {
@@ -72,7 +72,7 @@ pub fn summarize(borrow scenario: model.Scenario, borrow sim: state.State) -> Su
         let event = sim.log.get_or(i, state.empty_event());
         if event.time != current_time {
             let mut l: u64 = 0;
-            while l < handling.len() { handling.set(l, 0); l = l + 1; }
+            while l < handling.len() { handling.set(l, 0); l += 1; }
             current_time = event.time;
         }
         if event.tag == state.EVENT_SUPPLY() || event.tag == state.EVENT_PRODUCTION() {
@@ -110,8 +110,8 @@ pub fn summarize(borrow scenario: model.Scenario, borrow sim: state.State) -> Su
         let location = scenario.locations.get_or(i, model.empty_location());
         let storage_overflow = peaks.get_or(i, 0) > location.capacity;
         let handling_overflow = handling_peaks.get_or(i, 0) > location.handling;
-        if storage_overflow { storage_overflows = storage_overflows + 1; }
-        if handling_overflow { handling_overflows = handling_overflows + 1; }
+        if storage_overflow { storage_overflows += 1; }
+        if handling_overflow { handling_overflows += 1; }
         if peaks.get_or(i, 0) > global_peak { global_peak = peaks.get_or(i, 0); }
         rejected_units = add(rejected_units, rejected.get_or(i, 0));
         locations.push(LocationCapacity {

--- a/examples/harbor/capacity_profile.rue
+++ b/examples/harbor/capacity_profile.rue
@@ -96,9 +96,9 @@ pub fn summarize(borrow scenario: model.Scenario, borrow sim: state.State) -> Su
                 handling_peaks.set(location, handling.get_or(location, 0));
                 handling_times.set(location, current_time);
             }
-            location = location + 1;
+            location += 1;
         }
-        i = i + 1;
+        i += 1;
     }
     let mut locations = LocationCapacities.new();
     let mut global_peak: u64 = 0;
@@ -122,7 +122,7 @@ pub fn summarize(borrow scenario: model.Scenario, borrow sim: state.State) -> Su
             handling_peak_time: handling_times.get_or(i, 0),
             storage_overflow: storage_overflow, handling_overflow: handling_overflow,
         });
-        i = i + 1;
+        i += 1;
     }
     Summary {
         locations: locations, peak_inventory: global_peak,

--- a/examples/harbor/conservation.rue
+++ b/examples/harbor/conservation.rue
@@ -75,7 +75,7 @@ pub fn audit(borrow scenario: model.Scenario, borrow sim: state.State) -> Audit 
         source_total = add(source_total, balance.source_total);
         sink_total = add(sink_total, balance.sink_total);
         balances.push(balance);
-        i = i + 1;
+        i += 1;
     }
     let mut demand_total: u64 = 0;
     let mut delivered_total: u64 = 0;
@@ -87,9 +87,9 @@ pub fn audit(borrow scenario: model.Scenario, borrow sim: state.State) -> Audit 
         delivered_total = add(delivered_total, sim.demand_delivered.get_or(i, 0));
         unmet_total = add(unmet_total, sim.demand_remaining.get_or(i, 0));
         if demand.quantity != add(sim.demand_delivered.get_or(i, 0), sim.demand_remaining.get_or(i, 0)) {
-            mismatches = mismatches + 1;
+            mismatches += 1;
         }
-        i = i + 1;
+        i += 1;
     }
     Audit {
         balances: balances,

--- a/examples/harbor/conservation.rue
+++ b/examples/harbor/conservation.rue
@@ -71,7 +71,7 @@ pub fn audit(borrow scenario: model.Scenario, borrow sim: state.State) -> Audit 
     let mut i: u64 = 0;
     while i < scenario.cargoes.len() {
         let balance = cargo(borrow scenario, borrow sim, i);
-        if !balance.balanced { mismatches = mismatches + 1; }
+        if !balance.balanced { mismatches += 1; }
         source_total = add(source_total, balance.source_total);
         sink_total = add(sink_total, balance.sink_total);
         balances.push(balance);

--- a/examples/harbor/contingency.rue
+++ b/examples/harbor/contingency.rue
@@ -125,7 +125,7 @@ pub fn build(borrow scenario: model.Scenario) -> Plan {
                             if item.reachable {
                                 reachable += 1;
                                 total_cost = add(total_cost, item.cost);
-                                if base != routing.INF() && item.cost > base { degraded = degraded + 1; }
+                                if base != routing.INF() && item.cost > base { degraded += 1; }
                             } else {
                                 isolated += 1;
                                 local_isolated += 1;

--- a/examples/harbor/contingency.rue
+++ b/examples/harbor/contingency.rue
@@ -123,30 +123,30 @@ pub fn build(borrow scenario: model.Scenario) -> Plan {
                             );
                             let base = baseline_cost(borrow scenario, from, to, before, capacity);
                             if item.reachable {
-                                reachable = reachable + 1;
+                                reachable += 1;
                                 total_cost = add(total_cost, item.cost);
                                 if base != routing.INF() && item.cost > base { degraded = degraded + 1; }
                             } else {
-                                isolated = isolated + 1;
-                                local_isolated = local_isolated + 1;
+                                isolated += 1;
+                                local_isolated += 1;
                             }
                             digest = mix(digest, item.cost);
                             digest = mix(digest, item.bottleneck);
                             options.push(item);
                         }
-                        to = to + 1;
+                        to += 1;
                     }
-                    from = from + 1;
+                    from += 1;
                 }
-                capacity_index = capacity_index + 1;
+                capacity_index += 1;
             }
-            time_index = time_index + 1;
+            time_index += 1;
         }
         if worst_disruption == model.NONE() || local_isolated > worst_isolated {
             worst_disruption = disruption_index;
             worst_isolated = local_isolated;
         }
-        disruption_index = disruption_index + 1;
+        disruption_index += 1;
     }
     Plan {
         options: options, windows: scenario.disruptions.len(),
@@ -187,9 +187,9 @@ pub fn render(borrow scenario: model.Scenario, borrow plan: Plan) -> StrBuf {
             text.append_literal(inout out, " capacity="); text.append_u64(inout out, item.minimum_capacity);
             text.append_literal(inout out, " from="); append_location(inout out, borrow scenario, item.from);
             text.append_literal(inout out, " to="); append_location(inout out, borrow scenario, item.to); out.push(10);
-            shown = shown + 1;
+            shown += 1;
         }
-        i = i + 1;
+        i += 1;
     }
     if shown == 0 { text.append_literal(inout out, "  none\n"); }
     out

--- a/examples/harbor/cost_analysis.rue
+++ b/examples/harbor/cost_analysis.rue
@@ -65,7 +65,7 @@ fn add_event(inout centers: CostCenters, index: u64, borrow event: state.Event) 
 fn finalize(inout centers: CostCenters, overhead: u64) -> u64 {
     let mut direct_total: u64 = 0;
     let mut i: u64 = 0;
-    while i < centers.len() { direct_total = add(direct_total, centers.get_or(i, CostCenter { index: i, events: 0, units: 0, distance: 0, direct_cost: 0, allocated_cost: 0, cost_per_unit: 0, cost_per_distance: 0 }).direct_cost); i = i + 1; }
+    while i < centers.len() { direct_total = add(direct_total, centers.get_or(i, CostCenter { index: i, events: 0, units: 0, distance: 0, direct_cost: 0, allocated_cost: 0, cost_per_unit: 0, cost_per_distance: 0 }).direct_cost); i += 1; }
     let mut most = model.NONE(); let mut most_cost: u64 = 0;
     i = 0;
     while i < centers.len() {
@@ -76,7 +76,7 @@ fn finalize(inout centers: CostCenters, overhead: u64) -> u64 {
         item.cost_per_unit = if item.units == 0 { 0 } else { item.allocated_cost / item.units };
         item.cost_per_distance = if item.distance == 0 { 0 } else { item.allocated_cost / item.distance };
         if item.allocated_cost > most_cost { most = i; most_cost = item.allocated_cost; }
-        centers.set(i, item); i = i + 1;
+        centers.set(i, item); i += 1;
     }
     most
 }
@@ -87,7 +87,7 @@ pub fn summarize(borrow scenario: model.Scenario, borrow sim: state.State) -> Su
     let mut demands = blanks(scenario.demands.len());
     let mut cost_by_tag = U64s.new();
     let mut i: u64 = 0;
-    while i <= state.EVENT_UNMET() { cost_by_tag.push(0); i = i + 1; }
+    while i <= state.EVENT_UNMET() { cost_by_tag.push(0); i += 1; }
     let mut total_direct_cost: u64 = 0;
     i = 0;
     while i < sim.log.len() {

--- a/examples/harbor/cost_analysis.rue
+++ b/examples/harbor/cost_analysis.rue
@@ -44,7 +44,7 @@ fn blanks(count: u64) -> CostCenters {
             index: i, events: 0, units: 0, distance: 0, direct_cost: 0,
             allocated_cost: 0, cost_per_unit: 0, cost_per_distance: 0,
         });
-        i = i + 1;
+        i += 1;
     }
     values
 }
@@ -55,7 +55,7 @@ fn add_event(inout centers: CostCenters, index: u64, borrow event: state.Event) 
         index: index, events: 0, units: 0, distance: 0, direct_cost: 0,
         allocated_cost: 0, cost_per_unit: 0, cost_per_distance: 0,
     });
-    item.events = item.events + 1;
+    item.events += 1;
     item.units = add(item.units, event.quantity);
     item.distance = add(item.distance, event.distance);
     item.direct_cost = add(item.direct_cost, event.cost);
@@ -97,7 +97,7 @@ pub fn summarize(borrow scenario: model.Scenario, borrow sim: state.State) -> Su
         add_event(inout demands, event.demand, borrow event);
         if event.tag < cost_by_tag.len() { cost_by_tag.set(event.tag, add(cost_by_tag.get_or(event.tag, 0), event.cost)); }
         total_direct_cost = add(total_direct_cost, event.cost);
-        i = i + 1;
+        i += 1;
     }
     let overhead = if sim.total_cost > total_direct_cost { sim.total_cost - total_direct_cost } else { 0 };
     let most_expensive_vehicle = finalize(inout vehicles, overhead);

--- a/examples/harbor/csv_report.rue
+++ b/examples/harbor/csv_report.rue
@@ -33,7 +33,7 @@ fn demands(inout out: StrBuf, borrow scenario: model.Scenario, borrow sim: state
         number(inout out, item.requested); comma(inout out); number(inout out, item.delivered); comma(inout out);
         number(inout out, item.on_time); comma(inout out); number(inout out, item.late); comma(inout out);
         number(inout out, item.unmet); newline(inout out);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -54,7 +54,7 @@ fn fleet(inout out: StrBuf, borrow scenario: model.Scenario, borrow sim: state.S
         number(inout out, item.cargo_units); comma(inout out); number(inout out, item.loaded_distance); comma(inout out);
         number(inout out, item.empty_distance); comma(inout out); number(inout out, item.travel_time); comma(inout out);
         number(inout out, item.operating_cost); newline(inout out);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -70,7 +70,7 @@ fn events(inout out: StrBuf, borrow scenario: model.Scenario, borrow sim: state.
         number(inout out, event.to); comma(inout out); number(inout out, event.demand); comma(inout out);
         number(inout out, event.cost); comma(inout out); number(inout out, event.distance); comma(inout out);
         number(inout out, event.travel); newline(inout out);
-        i = i + 1;
+        i += 1;
     }
 }
 

--- a/examples/harbor/demand_analysis.rue
+++ b/examples/harbor/demand_analysis.rue
@@ -167,9 +167,9 @@ pub fn summarize(borrow scenario: model.Scenario, borrow sim: state.State, band_
             unmet: 0, first_arrival: 0, last_arrival: 0,
             weighted_requested: 0, weighted_delivered: 0,
         });
-        if item.delivered == item.requested { complete_demands = complete_demands + 1; }
-        else if item.delivered == 0 { empty_demands = empty_demands + 1; }
-        else { partial_demands = partial_demands + 1; }
+        if item.delivered == item.requested { complete_demands += 1; }
+        else if item.delivered == 0 { empty_demands += 1; }
+        else { partial_demands += 1; }
         let demand = scenario.demands.get_or(i, model.empty_demand());
         deadline_total = add(deadline_total, demand.deadline);
         i += 1;

--- a/examples/harbor/demand_analysis.rue
+++ b/examples/harbor/demand_analysis.rue
@@ -71,7 +71,7 @@ fn max_priority(borrow scenario: model.Scenario) -> u64 {
     while i < scenario.demands.len() {
         let demand = scenario.demands.get_or(i, model.empty_demand());
         if demand.priority > result { result = demand.priority; }
-        i = i + 1;
+        i += 1;
     }
     result
 }
@@ -91,7 +91,7 @@ fn priority_bands(borrow scenario: model.Scenario, borrow served: service.Summar
                     late: 0, unmet: demand.quantity, first_arrival: 0, last_arrival: 0,
                     weighted_requested: 0, weighted_delivered: 0,
                 });
-                band.demands = band.demands + 1;
+                band.demands += 1;
                 band.requested = add(band.requested, item.requested);
                 band.delivered = add(band.delivered, item.delivered);
                 band.on_time = add(band.on_time, item.on_time);
@@ -99,10 +99,10 @@ fn priority_bands(borrow scenario: model.Scenario, borrow served: service.Summar
                 band.weighted_requested = add(band.weighted_requested, mul(item.requested, priority));
                 band.weighted_delivered = add(band.weighted_delivered, mul(item.delivered, priority));
             }
-            i = i + 1;
+            i += 1;
         }
         result.push(band);
-        priority = priority + 1;
+        priority += 1;
     }
     result
 }
@@ -126,14 +126,14 @@ fn deadline_bands(borrow scenario: model.Scenario, borrow served: service.Summar
                     late: 0, unmet: demand.quantity, first_arrival: 0, last_arrival: 0,
                     weighted_requested: 0, weighted_delivered: 0,
                 });
-                band.demands = band.demands + 1;
+                band.demands += 1;
                 band.requested = add(band.requested, item.requested);
                 band.delivered = add(band.delivered, item.delivered);
                 band.on_time = add(band.on_time, item.on_time);
                 band.late = add(band.late, item.late);
                 band.unmet = add(band.unmet, item.unmet);
             }
-            i = i + 1;
+            i += 1;
         }
         result.push(band);
         if end == scenario.duration { break; }
@@ -147,7 +147,7 @@ fn sorted_deadlines(borrow scenario: model.Scenario) -> U64s {
     let mut i: u64 = 0;
     while i < scenario.demands.len() {
         values.push(scenario.demands.get_or(i, model.empty_demand()).deadline);
-        i = i + 1;
+        i += 1;
     }
     std.sort.insertion_sort(u64, inout values);
     values
@@ -172,7 +172,7 @@ pub fn summarize(borrow scenario: model.Scenario, borrow sim: state.State, band_
         else { partial_demands = partial_demands + 1; }
         let demand = scenario.demands.get_or(i, model.empty_demand());
         deadline_total = add(deadline_total, demand.deadline);
-        i = i + 1;
+        i += 1;
     }
     let count = deadlines.len();
     Summary {

--- a/examples/harbor/diagnostics.rue
+++ b/examples/harbor/diagnostics.rue
@@ -34,7 +34,7 @@ pub fn count_code(borrow scenario: model.Scenario, code: u64) -> u64 {
     let mut i: u64 = 0;
     while i < scenario.diagnostics.len() {
         let diagnostic = scenario.diagnostics.get_or(i, model.Diagnostic { code: 0, subject: 0, detail: 0 });
-        if diagnostic.code == code { count = count + 1; }
+        if diagnostic.code == code { count += 1; }
         i += 1;
     }
     count

--- a/examples/harbor/diagnostics.rue
+++ b/examples/harbor/diagnostics.rue
@@ -24,7 +24,7 @@ pub fn render(borrow scenario: model.Scenario) -> StrBuf {
         let diagnostic = scenario.diagnostics.get_or(i, model.Diagnostic { code: 0, subject: model.NONE(), detail: model.NONE() });
         let line = render_one(borrow scenario, diagnostic);
         text.append_string(inout out, borrow line);
-        i = i + 1;
+        i += 1;
     }
     out
 }
@@ -35,7 +35,7 @@ pub fn count_code(borrow scenario: model.Scenario, code: u64) -> u64 {
     while i < scenario.diagnostics.len() {
         let diagnostic = scenario.diagnostics.get_or(i, model.Diagnostic { code: 0, subject: 0, detail: 0 });
         if diagnostic.code == code { count = count + 1; }
-        i = i + 1;
+        i += 1;
     }
     count
 }

--- a/examples/harbor/disruption_analysis.rue
+++ b/examples/harbor/disruption_analysis.rue
@@ -49,19 +49,19 @@ fn one(borrow scenario: model.Scenario, index: u64) -> Impact {
         let mut to: u64 = 0;
         while to < scenario.locations.len() {
             if from != to {
-                pairs = pairs + 1;
+                pairs += 1;
                 let before = path_cost(borrow scenario, from, to, baseline_at);
                 let during = path_cost(borrow scenario, from, to, active_at);
                 if before != routing.INF() { baseline_cost = add(baseline_cost, before); }
                 if during != routing.INF() { disrupted_cost = add(disrupted_cost, during); }
                 if during != before {
-                    affected_pairs = affected_pairs + 1;
+                    affected_pairs += 1;
                     if during == routing.INF() { disconnected_pairs = disconnected_pairs + 1; }
                 }
             }
-            to = to + 1;
+            to += 1;
         }
-        from = from + 1;
+        from += 1;
     }
     let added_cost = if disrupted_cost > baseline_cost { disrupted_cost - baseline_cost } else { 0 };
     Impact {
@@ -90,7 +90,7 @@ pub fn summarize(borrow scenario: model.Scenario) -> Summary {
             worst_disruption = i;
         }
         impacts.push(impact);
-        i = i + 1;
+        i += 1;
     }
     Summary {
         impacts: impacts, affected_pairs: affected_pairs,

--- a/examples/harbor/disruption_analysis.rue
+++ b/examples/harbor/disruption_analysis.rue
@@ -56,7 +56,7 @@ fn one(borrow scenario: model.Scenario, index: u64) -> Impact {
                 if during != routing.INF() { disrupted_cost = add(disrupted_cost, during); }
                 if during != before {
                     affected_pairs += 1;
-                    if during == routing.INF() { disconnected_pairs = disconnected_pairs + 1; }
+                    if during == routing.INF() { disconnected_pairs += 1; }
                 }
             }
             to += 1;

--- a/examples/harbor/dot_report.rue
+++ b/examples/harbor/dot_report.rue
@@ -24,7 +24,7 @@ fn disrupted(borrow scenario: model.Scenario, route: u64) -> bool {
     let mut i: u64 = 0;
     while i < scenario.disruptions.len() {
         if scenario.disruptions.get_or(i, model.empty_disruption()).route == route { return true; }
-        i = i + 1;
+        i += 1;
     }
     false
 }
@@ -51,7 +51,7 @@ pub fn render(borrow scenario: model.Scenario) -> StrBuf {
         text.append_json_string(inout out, borrow label);
         if location_stats.critical { text.append_literal(inout out, ", color=red, penwidth=2"); }
         text.append_literal(inout out, "];\n");
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < scenario.routes.len() {
@@ -64,7 +64,7 @@ pub fn render(borrow scenario: model.Scenario) -> StrBuf {
         if route.bidirectional { text.append_literal(inout out, ", dir=both"); }
         if disrupted(borrow scenario, i) { text.append_literal(inout out, ", color=orange, style=dashed"); }
         text.append_literal(inout out, "];\n");
-        i = i + 1;
+        i += 1;
     }
     text.append_literal(inout out, "}\n");
     out

--- a/examples/harbor/event_analysis.rue
+++ b/examples/harbor/event_analysis.rue
@@ -73,28 +73,28 @@ fn fill_tags() -> U64s {
 }
 
 fn apply_event(inout hour: Hour, borrow event: state.Event) {
-    hour.events = hour.events + 1;
+    hour.events += 1;
     hour.cost = add(hour.cost, event.cost);
     hour.distance = add(hour.distance, event.distance);
     if event.tag == state.EVENT_SUPPLY() {
-        hour.supplies = hour.supplies + 1;
+        hour.supplies += 1;
         hour.inbound_units = add(hour.inbound_units, event.quantity);
     } else if event.tag == state.EVENT_PRODUCTION() {
-        hour.productions = hour.productions + 1;
+        hour.productions += 1;
         hour.inbound_units = add(hour.inbound_units, event.quantity);
     } else if event.tag == state.EVENT_DEPARTURE() {
-        hour.departures = hour.departures + 1;
+        hour.departures += 1;
         hour.outbound_units = add(hour.outbound_units, event.quantity);
     } else if event.tag == state.EVENT_ARRIVAL() {
-        hour.arrivals = hour.arrivals + 1;
+        hour.arrivals += 1;
         hour.inbound_units = add(hour.inbound_units, event.quantity);
     } else if event.tag == state.EVENT_REPOSITION() {
-        hour.repositions = hour.repositions + 1;
+        hour.repositions += 1;
     } else if event.tag == state.EVENT_EXPIRED() {
-        hour.expired = hour.expired + 1;
+        hour.expired += 1;
         hour.outbound_units = add(hour.outbound_units, event.quantity);
     } else if event.tag == state.EVENT_UNMET() {
-        hour.unmet = hour.unmet + 1;
+        hour.unmet += 1;
     }
 }
 
@@ -103,7 +103,7 @@ fn transition_index(borrow transitions: Transitions, from_tag: u64, to_tag: u64)
     while i < transitions.len() {
         let item = transitions.get_or(i, Transition { from_tag: 0, to_tag: 0, count: 0 });
         if item.from_tag == from_tag && item.to_tag == to_tag { return i; }
-        i = i + 1;
+        i += 1;
     }
     transitions.len()
 }
@@ -112,7 +112,7 @@ fn record_transition(inout transitions: Transitions, from_tag: u64, to_tag: u64)
     let index = transition_index(borrow transitions, from_tag, to_tag);
     if index < transitions.len() {
         let mut item = transitions.get_or(index, Transition { from_tag: from_tag, to_tag: to_tag, count: 0 });
-        item.count = item.count + 1;
+        item.count += 1;
         transitions.set(index, item);
     } else {
         transitions.push(Transition { from_tag: from_tag, to_tag: to_tag, count: 1 });
@@ -143,7 +143,7 @@ pub fn summarize(borrow scenario: model.Scenario, borrow sim: state.State) -> Su
         }
         previous_time = event.time;
         previous_tag = event.tag;
-        i = i + 1;
+        i += 1;
     }
     let mut active_hours: u64 = 0;
     let mut quiet_hours: u64 = 0;
@@ -159,7 +159,7 @@ pub fn summarize(borrow scenario: model.Scenario, borrow sim: state.State) -> Su
         if hour.events > peak_events { peak_events = hour.events; peak_event_hour = i; }
         let throughput = add(hour.outbound_units, hour.inbound_units);
         if throughput > peak_throughput { peak_throughput = throughput; peak_throughput_hour = i; }
-        i = i + 1;
+        i += 1;
     }
     Summary {
         hours: hours, transitions: transitions, counts_by_tag: counts_by_tag,

--- a/examples/harbor/event_analysis.rue
+++ b/examples/harbor/event_analysis.rue
@@ -61,14 +61,14 @@ fn blank_hour(time: u64) -> Hour {
 fn fill_hours(duration: u64) -> Hours {
     let mut result = Hours.new();
     let mut time: u64 = 0;
-    while time <= duration { result.push(blank_hour(time)); time = time + 1; }
+    while time <= duration { result.push(blank_hour(time)); time += 1; }
     result
 }
 
 fn fill_tags() -> U64s {
     let mut values = U64s.new();
     let mut i: u64 = 0;
-    while i <= state.EVENT_UNMET() { values.push(0); i = i + 1; }
+    while i <= state.EVENT_UNMET() { values.push(0); i += 1; }
     values
 }
 
@@ -130,7 +130,7 @@ pub fn summarize(borrow scenario: model.Scenario, borrow sim: state.State) -> Su
     while i < sim.log.len() {
         let event = sim.log.get_or(i, state.empty_event());
         if i > 0 {
-            if event.time < previous_time { ordering_errors = ordering_errors + 1; }
+            if event.time < previous_time { ordering_errors += 1; }
             record_transition(inout transitions, previous_tag, event.tag);
         }
         if event.time < hours.len() {
@@ -154,8 +154,8 @@ pub fn summarize(borrow scenario: model.Scenario, borrow sim: state.State) -> Su
     i = 0;
     while i < hours.len() {
         let hour = hours.get_or(i, blank_hour(i));
-        if hour.events == 0 { quiet_hours = quiet_hours + 1; }
-        else { active_hours = active_hours + 1; }
+        if hour.events == 0 { quiet_hours += 1; }
+        else { active_hours += 1; }
         if hour.events > peak_events { peak_events = hour.events; peak_event_hour = i; }
         let throughput = add(hour.outbound_units, hour.inbound_units);
         if throughput > peak_throughput { peak_throughput = throughput; peak_throughput_hour = i; }

--- a/examples/harbor/eventlog.rue
+++ b/examples/harbor/eventlog.rue
@@ -57,7 +57,7 @@ pub fn render(borrow scenario: model.Scenario, borrow sim: state.State) -> StrBu
     while i < sim.log.len() {
         let line = render_event(borrow scenario, sim.log.get_or(i, state.empty_event()));
         text.append_string(inout out, borrow line);
-        i = i + 1;
+        i += 1;
     }
     out
 }

--- a/examples/harbor/fingerprint.rue
+++ b/examples/harbor/fingerprint.rue
@@ -51,25 +51,25 @@ pub fn scenario(borrow value: model.Scenario) -> u64 {
     while i < value.supplies.len() {
         let v = value.supplies.get_or(i, model.empty_supply());
         hash = mix(hash, value.strings.hash(v.location_id)); hash = mix(hash, value.strings.hash(v.cargo_id));
-        hash = mix(hash, v.quantity); hash = mix(hash, v.available); i = i + 1;
+        hash = mix(hash, v.quantity); hash = mix(hash, v.available); i += 1;
     }
     i = 0;
     while i < value.demands.len() {
         let v = value.demands.get_or(i, model.empty_demand());
         hash = mix(hash, value.strings.hash(v.location_id)); hash = mix(hash, value.strings.hash(v.cargo_id));
-        hash = mix(hash, v.quantity); hash = mix(hash, v.deadline); hash = mix(hash, v.priority); i = i + 1;
+        hash = mix(hash, v.quantity); hash = mix(hash, v.deadline); hash = mix(hash, v.priority); i += 1;
     }
     i = 0;
     while i < value.productions.len() {
         let v = value.productions.get_or(i, model.empty_production());
         hash = mix(hash, value.strings.hash(v.location_id)); hash = mix(hash, value.strings.hash(v.cargo_id));
-        hash = mix(hash, v.quantity); hash = mix(hash, v.every); hash = mix(hash, v.start); hash = mix(hash, v.end); i = i + 1;
+        hash = mix(hash, v.quantity); hash = mix(hash, v.every); hash = mix(hash, v.start); hash = mix(hash, v.end); i += 1;
     }
     i = 0;
     while i < value.disruptions.len() {
         let v = value.disruptions.get_or(i, model.empty_disruption());
         hash = mix(hash, v.route); hash = mix(hash, v.start); hash = mix(hash, v.end);
-        hash = mix(hash, v.capacity_percent); hash = mix(hash, v.cost_percent); i = i + 1;
+        hash = mix(hash, v.capacity_percent); hash = mix(hash, v.cost_percent); i += 1;
     }
     hash
 }
@@ -77,7 +77,7 @@ pub fn scenario(borrow value: model.Scenario) -> u64 {
 fn mix_array(hash: u64, borrow values: U64s) -> u64 {
     let mut result = mix(hash, values.len());
     let mut i: u64 = 0;
-    while i < values.len() { result = mix(result, values.get_or(i, 0)); i = i + 1; }
+    while i < values.len() { result = mix(result, values.get_or(i, 0)); i += 1; }
     result
 }
 

--- a/examples/harbor/fingerprint.rue
+++ b/examples/harbor/fingerprint.rue
@@ -24,7 +24,7 @@ pub fn scenario(borrow value: model.Scenario) -> u64 {
         let v = value.locations.get_or(i, model.empty_location());
         hash = mix(hash, value.strings.hash(v.id)); hash = mix(hash, value.strings.hash(v.kind)); hash = mix(hash, v.capacity);
         hash = mix(hash, v.handling); hash = mix(hash, signed(v.x)); hash = mix(hash, signed(v.y));
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < value.routes.len() {
@@ -32,20 +32,20 @@ pub fn scenario(borrow value: model.Scenario) -> u64 {
         hash = mix(hash, value.strings.hash(v.from_id)); hash = mix(hash, value.strings.hash(v.to_id)); hash = mix(hash, v.distance);
         hash = mix(hash, v.capacity); hash = mix(hash, v.cost); hash = mix(hash, v.travel);
         hash = mix(hash, if v.bidirectional { 1 } else { 0 });
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < value.cargoes.len() {
         let v = value.cargoes.get_or(i, model.empty_cargo());
         hash = mix(hash, value.strings.hash(v.id)); hash = mix(hash, v.unit_value); hash = mix(hash, v.shelf_life); hash = mix(hash, v.weight);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < value.vehicles.len() {
         let v = value.vehicles.get_or(i, model.empty_vehicle());
         hash = mix(hash, value.strings.hash(v.id)); hash = mix(hash, value.strings.hash(v.at_id));
         hash = mix(hash, v.capacity); hash = mix(hash, v.speed); hash = mix(hash, v.cost); hash = mix(hash, v.available);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < value.supplies.len() {
@@ -100,7 +100,7 @@ pub fn simulation(borrow value: state.State) -> u64 {
         hash = mix(hash, event.cargo); hash = mix(hash, event.quantity); hash = mix(hash, event.from);
         hash = mix(hash, event.to); hash = mix(hash, event.demand); hash = mix(hash, event.cost);
         hash = mix(hash, event.distance); hash = mix(hash, event.travel);
-        i = i + 1;
+        i += 1;
     }
     hash = mix(hash, value.total_cost);
     hash = mix(hash, value.total_distance);

--- a/examples/harbor/forecast.rue
+++ b/examples/harbor/forecast.rue
@@ -122,7 +122,7 @@ pub fn summarize(borrow scenario: model.Scenario) -> Summary {
         total_production = add(total_production, item.projected_production);
         total_requested = add(total_requested, item.requested);
         total_shortage = add(total_shortage, item.shortage);
-        if item.shortage > 0 { scarce_cargoes = scarce_cargoes + 1; }
+        if item.shortage > 0 { scarce_cargoes += 1; }
         cargoes.push(item);
         cargo += 1;
     }

--- a/examples/harbor/forecast.rue
+++ b/examples/harbor/forecast.rue
@@ -70,7 +70,7 @@ fn one(borrow scenario: model.Scenario, cargo: u64) -> CargoForecast {
             if first_supply == model.NONE() || item.available < first_supply { first_supply = item.available; }
             if item.available > last_supply { last_supply = item.available; }
         }
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < scenario.productions.len() {
@@ -84,7 +84,7 @@ fn one(borrow scenario: model.Scenario, cargo: u64) -> CargoForecast {
                 if final_time > last_supply { last_supply = final_time; }
             }
         }
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < scenario.demands.len() {
@@ -94,7 +94,7 @@ fn one(borrow scenario: model.Scenario, cargo: u64) -> CargoForecast {
             if first_deadline == model.NONE() || item.deadline < first_deadline { first_deadline = item.deadline; }
             if item.deadline > last_deadline { last_deadline = item.deadline; }
         }
-        i = i + 1;
+        i += 1;
     }
     let available = add(initial_supply, projected_production);
     CargoForecast {
@@ -124,7 +124,7 @@ pub fn summarize(borrow scenario: model.Scenario) -> Summary {
         total_shortage = add(total_shortage, item.shortage);
         if item.shortage > 0 { scarce_cargoes = scarce_cargoes + 1; }
         cargoes.push(item);
-        cargo = cargo + 1;
+        cargo += 1;
     }
     Summary {
         cargoes: cargoes, total_supply: total_supply,
@@ -139,7 +139,7 @@ fn supply_at(borrow scenario: model.Scenario, cargo: u64, time: u64) -> u64 {
     while i < scenario.supplies.len() {
         let item = scenario.supplies.get_or(i, model.empty_supply());
         if item.cargo == cargo && item.available == time { total = add(total, item.quantity); }
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < scenario.productions.len() {
@@ -147,7 +147,7 @@ fn supply_at(borrow scenario: model.Scenario, cargo: u64, time: u64) -> u64 {
         if item.cargo == cargo && item.every > 0 && time >= item.start && time <= item.end && (time - item.start) % item.every == 0 {
             total = add(total, item.quantity);
         }
-        i = i + 1;
+        i += 1;
     }
     total
 }
@@ -158,7 +158,7 @@ fn demand_at(borrow scenario: model.Scenario, cargo: u64, time: u64) -> u64 {
     while i < scenario.demands.len() {
         let item = scenario.demands.get_or(i, model.empty_demand());
         if item.cargo == cargo && item.deadline == time { total = add(total, item.quantity); }
-        i = i + 1;
+        i += 1;
     }
     total
 }
@@ -177,7 +177,7 @@ pub fn timeline(borrow scenario: model.Scenario, cargo: u64, step: u64) -> Hours
         while at <= end {
             bucket_supply = add(bucket_supply, supply_at(borrow scenario, cargo, at));
             bucket_demand = add(bucket_demand, demand_at(borrow scenario, cargo, at));
-            at = at + 1;
+            at += 1;
         }
         cumulative_supply = add(cumulative_supply, bucket_supply);
         cumulative_demand = add(cumulative_demand, bucket_demand);
@@ -227,7 +227,7 @@ pub fn render(borrow scenario: model.Scenario) -> StrBuf {
         text.append_literal(inout out, " shortage=");
         text.append_u64(inout out, item.shortage);
         out.push(10);
-        i = i + 1;
+        i += 1;
     }
     out
 }

--- a/examples/harbor/geography.rue
+++ b/examples/harbor/geography.rue
@@ -110,9 +110,9 @@ pub fn summarize(borrow scenario: model.Scenario) -> Summary {
                     network_distance: network, detour: detour, reachable: reachable,
                 });
             }
-            to = to + 1;
+            to += 1;
         }
-        from = from + 1;
+        from += 1;
     }
     let mut min_x: i64 = 0; let mut max_x: i64 = 0; let mut min_y: i64 = 0; let mut max_y: i64 = 0;
     i = 0;
@@ -122,7 +122,7 @@ pub fn summarize(borrow scenario: model.Scenario) -> Summary {
         if i == 0 || item.x > max_x { max_x = item.x; }
         if i == 0 || item.y < min_y { min_y = item.y; }
         if i == 0 || item.y > max_y { max_y = item.y; }
-        i = i + 1;
+        i += 1;
     }
     Summary {
         routes: routes, pairs: pairs, route_distance: route_distance,

--- a/examples/harbor/geography.rue
+++ b/examples/harbor/geography.rue
@@ -81,7 +81,7 @@ pub fn summarize(borrow scenario: model.Scenario) -> Summary {
         route_distance = add(route_distance, item.configured_distance);
         geometric_distance = add(geometric_distance, item.direct_distance);
         route_detour = add(route_detour, item.detour);
-        routes.push(item); i = i + 1;
+        routes.push(item); i += 1;
     }
     let mut total_pair_detour: u64 = 0;
     let mut pair_count: u64 = 0;
@@ -100,7 +100,7 @@ pub fn summarize(borrow scenario: model.Scenario) -> Summary {
                 let reachable = network != routing.INF();
                 let detour = if reachable && network > geometric { network - geometric } else { 0 };
                 if reachable {
-                    total_pair_detour = add(total_pair_detour, detour); pair_count = pair_count + 1;
+                    total_pair_detour = add(total_pair_detour, detour); pair_count += 1;
                     if detour > maximum_pair_detour {
                         maximum_pair_detour = detour; maximum_pair_from = from; maximum_pair_to = to;
                     }

--- a/examples/harbor/inventory_analysis.rue
+++ b/examples/harbor/inventory_analysis.rue
@@ -60,9 +60,9 @@ fn blank_cells(borrow scenario: model.Scenario) -> Cells {
                 peak: 0, peak_time: 0, final_quantity: 0, underflows: 0,
                 turns_numerator: 0, turns_denominator: 0,
             });
-            cargo = cargo + 1;
+            cargo += 1;
         }
-        location = location + 1;
+        location += 1;
     }
     cells
 }
@@ -91,14 +91,14 @@ fn capture(borrow scenario: model.Scenario, borrow quantities: U64s, time: u64) 
             let value = quantities.get_or(index(borrow scenario, location, cargo), 0);
             at_location = add(at_location, value);
             if value > 0 { occupied_cells = occupied_cells + 1; }
-            cargo = cargo + 1;
+            cargo += 1;
         }
         total_inventory = add(total_inventory, at_location);
         if at_location > 0 { occupied_locations = occupied_locations + 1; }
         if at_location > max_location_inventory {
             max_location_inventory = at_location; max_location = location;
         }
-        location = location + 1;
+        location += 1;
     }
     Snapshot {
         time: time, total_inventory: total_inventory,
@@ -159,12 +159,12 @@ pub fn summarize(borrow scenario: model.Scenario, borrow sim: state.State) -> Su
             underflows = add(underflows, apply_event(borrow scenario, inout quantities, inout cells, borrow event));
             if event.tag == state.EVENT_SUPPLY() || event.tag == state.EVENT_PRODUCTION() { total_inbound = add(total_inbound, event.quantity); }
             if event.tag == state.EVENT_DEPARTURE() { total_outbound = add(total_outbound, event.quantity); }
-            cursor = cursor + 1;
+            cursor += 1;
         }
         let snapshot = capture(borrow scenario, borrow quantities, time);
         if snapshot.total_inventory > global_peak { global_peak = snapshot.total_inventory; global_peak_time = time; }
         snapshots.push(snapshot);
-        time = time + 1;
+        time += 1;
     }
     let mut final_inventory: u64 = 0;
     i = 0;

--- a/examples/harbor/inventory_analysis.rue
+++ b/examples/harbor/inventory_analysis.rue
@@ -90,11 +90,11 @@ fn capture(borrow scenario: model.Scenario, borrow quantities: U64s, time: u64) 
         while cargo < scenario.cargoes.len() {
             let value = quantities.get_or(index(borrow scenario, location, cargo), 0);
             at_location = add(at_location, value);
-            if value > 0 { occupied_cells = occupied_cells + 1; }
+            if value > 0 { occupied_cells += 1; }
             cargo += 1;
         }
         total_inventory = add(total_inventory, at_location);
-        if at_location > 0 { occupied_locations = occupied_locations + 1; }
+        if at_location > 0 { occupied_locations += 1; }
         if at_location > max_location_inventory {
             max_location_inventory = at_location; max_location = location;
         }
@@ -132,7 +132,7 @@ fn apply_event(borrow scenario: model.Scenario, inout quantities: U64s, inout ce
             turns_numerator: 0, turns_denominator: 0,
         });
         cell.outbound = add(cell.outbound, event.quantity - missing);
-        if missing > 0 { cell.underflows = cell.underflows + 1; }
+        if missing > 0 { cell.underflows += 1; }
         cells.set(at, cell);
         return missing;
     }
@@ -142,7 +142,7 @@ fn apply_event(borrow scenario: model.Scenario, inout quantities: U64s, inout ce
 pub fn summarize(borrow scenario: model.Scenario, borrow sim: state.State) -> Summary {
     let mut quantities = U64s.new();
     let mut i: u64 = 0;
-    while i < scenario.locations.len() * scenario.cargoes.len() { quantities.push(0); i = i + 1; }
+    while i < scenario.locations.len() * scenario.cargoes.len() { quantities.push(0); i += 1; }
     let mut cells = blank_cells(borrow scenario);
     let mut snapshots = Snapshots.new();
     let mut total_inbound: u64 = 0;
@@ -178,7 +178,7 @@ pub fn summarize(borrow scenario: model.Scenario, borrow sim: state.State) -> Su
         cell.turns_numerator = cell.outbound;
         cell.turns_denominator = if cell.peak == 0 { 1 } else { cell.peak };
         final_inventory = add(final_inventory, cell.final_quantity);
-        cells.set(i, cell); i = i + 1;
+        cells.set(i, cell); i += 1;
     }
     Summary {
         cells: cells, snapshots: snapshots, total_inbound: total_inbound,

--- a/examples/harbor/inventory_policy.rue
+++ b/examples/harbor/inventory_policy.rue
@@ -74,7 +74,7 @@ fn demand_at(borrow scenario: model.Scenario, location: u64, cargo: u64) -> u64 
     while i < scenario.demands.len() {
         let item = scenario.demands.get_or(i, model.empty_demand());
         if item.location == location && item.cargo == cargo { total = add(total, item.quantity); }
-        i = i + 1;
+        i += 1;
     }
     total
 }
@@ -87,7 +87,7 @@ fn inbound_at(borrow sim: state.State, location: u64, cargo: u64) -> u64 {
         if event.tag == state.EVENT_ARRIVAL() && event.to == location && event.cargo == cargo {
             total = add(total, event.quantity);
         }
-        i = i + 1;
+        i += 1;
     }
     total
 }
@@ -97,12 +97,12 @@ fn source_count(borrow scenario: model.Scenario, cargo: u64) -> u64 {
     let mut i: u64 = 0;
     while i < scenario.supplies.len() {
         if scenario.supplies.get_or(i, model.empty_supply()).cargo == cargo { count = count + 1; }
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < scenario.productions.len() {
         if scenario.productions.get_or(i, model.empty_production()).cargo == cargo { count = count + 1; }
-        i = i + 1;
+        i += 1;
     }
     count
 }
@@ -116,7 +116,7 @@ fn lead_time(borrow scenario: model.Scenario, borrow matrix: route_matrix.Matrix
             let value = route_matrix.travel(borrow matrix, supply.location, location);
             if value != routing.INF() { total = add(total, value); count = count + 1; }
         }
-        i = i + 1;
+        i += 1;
     }
     if count == 0 { scenario.duration } else { total / count }
 }
@@ -183,7 +183,7 @@ pub fn build(borrow scenario: model.Scenario, borrow sim: state.State) -> Book {
             digest = mix(digest, item.target_stock); digest = mix(digest, item.order_quantity); digest = mix(digest, item.action);
             policies.push(item); cargo = cargo + 1;
         }
-        location = location + 1;
+        location += 1;
     }
     Book { policies: policies, locations: scenario.locations.len(), cargoes: scenario.cargoes.len(),
         reorder: reorder, expedite: expedite, redistribute: redistribute, hold: hold,

--- a/examples/harbor/inventory_policy.rue
+++ b/examples/harbor/inventory_policy.rue
@@ -96,12 +96,12 @@ fn source_count(borrow scenario: model.Scenario, cargo: u64) -> u64 {
     let mut count: u64 = 0;
     let mut i: u64 = 0;
     while i < scenario.supplies.len() {
-        if scenario.supplies.get_or(i, model.empty_supply()).cargo == cargo { count = count + 1; }
+        if scenario.supplies.get_or(i, model.empty_supply()).cargo == cargo { count += 1; }
         i += 1;
     }
     i = 0;
     while i < scenario.productions.len() {
-        if scenario.productions.get_or(i, model.empty_production()).cargo == cargo { count = count + 1; }
+        if scenario.productions.get_or(i, model.empty_production()).cargo == cargo { count += 1; }
         i += 1;
     }
     count
@@ -114,7 +114,7 @@ fn lead_time(borrow scenario: model.Scenario, borrow matrix: route_matrix.Matrix
         let supply = scenario.supplies.get_or(i, model.empty_supply());
         if supply.cargo == cargo {
             let value = route_matrix.travel(borrow matrix, supply.location, location);
-            if value != routing.INF() { total = add(total, value); count = count + 1; }
+            if value != routing.INF() { total = add(total, value); count += 1; }
         }
         i += 1;
     }
@@ -174,14 +174,14 @@ pub fn build(borrow scenario: model.Scenario, borrow sim: state.State) -> Book {
         let mut cargo: u64 = 0;
         while cargo < scenario.cargoes.len() {
             let item = make_policy(borrow scenario, borrow sim, borrow times, location, cargo);
-            if item.action == ACTION_REORDER() { reorder = reorder + 1; }
-            else if item.action == ACTION_EXPEDITE() { expedite = expedite + 1; }
-            else if item.action == ACTION_REDISTRIBUTE() { redistribute = redistribute + 1; }
-            else { hold = hold + 1; }
+            if item.action == ACTION_REORDER() { reorder += 1; }
+            else if item.action == ACTION_EXPEDITE() { expedite += 1; }
+            else if item.action == ACTION_REDISTRIBUTE() { redistribute += 1; }
+            else { hold += 1; }
             total_order_quantity = add(total_order_quantity, item.order_quantity);
             if item.urgency > maximum_urgency { maximum_urgency = item.urgency; maximum_location = location; maximum_cargo = cargo; }
             digest = mix(digest, item.target_stock); digest = mix(digest, item.order_quantity); digest = mix(digest, item.action);
-            policies.push(item); cargo = cargo + 1;
+            policies.push(item); cargo += 1;
         }
         location += 1;
     }
@@ -213,7 +213,7 @@ pub fn render(borrow scenario: model.Scenario, borrow value: Book) -> StrBuf {
         text.append_u64(inout out, item.average_lead_time); out.push(32); text.append_u64(inout out, item.safety_stock); out.push(32);
         text.append_u64(inout out, item.reorder_point); out.push(32); text.append_u64(inout out, item.target_stock); out.push(32);
         text.append_u64(inout out, item.order_quantity); out.push(32); action_name(inout out, item.action); out.push(32);
-        text.append_u64(inout out, item.urgency); out.push(10); i = i + 1;
+        text.append_u64(inout out, item.urgency); out.push(10); i += 1;
     }
     text.append_literal(inout out, "hold="); text.append_u64(inout out, value.hold);
     text.append_literal(inout out, " reorder="); text.append_u64(inout out, value.reorder);

--- a/examples/harbor/io.rue
+++ b/examples/harbor/io.rue
@@ -31,7 +31,7 @@ pub fn bytes_to_text(borrow bytes: Bytes) -> StrBuf {
     let mut i: u64 = 0;
     while i < bytes.len() {
         out.push(bytes.get_or(i, 0));
-        i = i + 1;
+        i += 1;
     }
     out
 }
@@ -49,7 +49,7 @@ fn text_to_bytes(borrow text: StrBuf) -> Bytes {
     let mut i: u64 = 0;
     while i < text.len() {
         out.push(StrBuf.byte_at_borrowed(borrow text, i));
-        i = i + 1;
+        i += 1;
     }
     out
 }

--- a/examples/harbor/json_report.rue
+++ b/examples/harbor/json_report.rue
@@ -95,7 +95,7 @@ fn cargo_array(inout out: StrBuf, borrow scenario: model.Scenario, borrow sim: s
         u64_field(inout out, inout first, "inventory", state.cargo_total_inventory(borrow scenario, borrow sim, i));
         u64_field(inout out, inout first, "expired", sim.expired.get_or(i, 0));
         out.push(125);
-        i = i + 1;
+        i += 1;
     }
     out.push(93);
 }
@@ -124,7 +124,7 @@ fn demand_array(inout out: StrBuf, borrow scenario: model.Scenario, borrow sim: 
         u64_field(inout out, inout first, "on_time", item.on_time);
         u64_field(inout out, inout first, "unmet", item.unmet);
         out.push(125);
-        i = i + 1;
+        i += 1;
     }
     out.push(93);
 }
@@ -151,7 +151,7 @@ fn vehicle_array(inout out: StrBuf, borrow scenario: model.Scenario, borrow sim:
         u64_field(inout out, inout first, "empty_distance", item.empty_distance);
         u64_field(inout out, inout first, "cost", item.operating_cost);
         out.push(125);
-        i = i + 1;
+        i += 1;
     }
     out.push(93);
 }

--- a/examples/harbor/network.rue
+++ b/examples/harbor/network.rue
@@ -41,7 +41,7 @@ fn can_cross(borrow route: model.Route, from: u64, to: u64) -> bool {
 fn reachable_without(borrow scenario: model.Scenario, removed: u64) -> u64 {
     if scenario.locations.len() <= 1 { return 0; }
     let mut start: u64 = 0;
-    while start < scenario.locations.len() && start == removed { start = start + 1; }
+    while start < scenario.locations.len() && start == removed { start += 1; }
     if start >= scenario.locations.len() { return 0; }
     let mut seen = BitSet.new();
     let mut queue = Queue.new();
@@ -119,8 +119,8 @@ pub fn summarize(borrow scenario: model.Scenario) -> Summary {
     while i < scenario.locations.len() {
         let stats = location_stats(borrow scenario, i);
         directed_edges = add(directed_edges, stats.outgoing);
-        if stats.critical { critical_locations = critical_locations + 1; }
-        if stats.neighbors == 0 { isolated_locations = isolated_locations + 1; }
+        if stats.critical { critical_locations += 1; }
+        if stats.neighbors == 0 { isolated_locations += 1; }
         locations.push(stats);
         i += 1;
     }

--- a/examples/harbor/network.rue
+++ b/examples/harbor/network.rue
@@ -58,9 +58,9 @@ fn reachable_without(borrow scenario: model.Scenario, removed: u64) -> u64 {
                     seen.set(candidate);
                     queue.enqueue(candidate);
                 }
-                candidate = candidate + 1;
+                candidate += 1;
             }
-            route_index = route_index + 1;
+            route_index += 1;
         }
     }
     seen.count()
@@ -77,26 +77,26 @@ fn location_stats(borrow scenario: model.Scenario, location: u64) -> LocationSta
     while i < scenario.routes.len() {
         let route = scenario.routes.get_or(i, model.empty_route());
         if route.from == location {
-            outgoing = outgoing + 1;
+            outgoing += 1;
             outbound_capacity = add(outbound_capacity, route.capacity);
             distance_sum = add(distance_sum, route.distance);
             if route.to < scenario.locations.len() { neighbors.set(route.to); }
         }
         if route.to == location {
-            incoming = incoming + 1;
+            incoming += 1;
             inbound_capacity = add(inbound_capacity, route.capacity);
             if route.from < scenario.locations.len() { neighbors.set(route.from); }
             if route.bidirectional {
-                outgoing = outgoing + 1;
+                outgoing += 1;
                 outbound_capacity = add(outbound_capacity, route.capacity);
                 distance_sum = add(distance_sum, route.distance);
             }
         }
         if route.bidirectional && route.from == location {
-            incoming = incoming + 1;
+            incoming += 1;
             inbound_capacity = add(inbound_capacity, route.capacity);
         }
-        i = i + 1;
+        i += 1;
     }
     let connected_without = reachable_without(borrow scenario, location);
     let expected = if scenario.locations.len() > 0 { scenario.locations.len() - 1 } else { 0 };
@@ -122,14 +122,14 @@ pub fn summarize(borrow scenario: model.Scenario) -> Summary {
         if stats.critical { critical_locations = critical_locations + 1; }
         if stats.neighbors == 0 { isolated_locations = isolated_locations + 1; }
         locations.push(stats);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < scenario.routes.len() {
         let route = scenario.routes.get_or(i, model.empty_route());
         total_capacity = add(total_capacity, route.capacity);
         total_distance = add(total_distance, route.distance);
-        i = i + 1;
+        i += 1;
     }
     Summary {
         locations: locations, directed_edges: directed_edges,

--- a/examples/harbor/operator_checklist.rue
+++ b/examples/harbor/operator_checklist.rue
@@ -153,11 +153,11 @@ pub fn build(borrow scenario: model.Scenario, borrow sim: state.State) -> Checkl
     let mut i: u64 = 0;
     while i < items.len() {
         let value = items.get_or(i, empty_item());
-        if value.blocking { blocking = blocking + 1; }
-        if value.priority == 1 { urgent = urgent + 1; }
-        else if value.priority == 2 { high = high + 1; }
-        else { normal = normal + 1; }
-        if value.complete { complete = complete + 1; } else { open = open + 1; }
+        if value.blocking { blocking += 1; }
+        if value.priority == 1 { urgent += 1; }
+        else if value.priority == 2 { high += 1; }
+        else { normal += 1; }
+        if value.complete { complete += 1; } else { open += 1; }
         evidence_total = add(evidence_total, value.evidence);
         digest = mix(digest, value.area); digest = mix(digest, value.subject);
         digest = mix(digest, value.evidence); digest = mix(digest, value.target);
@@ -182,7 +182,7 @@ fn owner_open(borrow value: Checklist, owner: u64) -> u64 {
     let mut i: u64 = 0;
     while i < value.items.len() {
         let item_value = value.items.get_or(i, empty_item());
-        if item_value.owner == owner && !item_value.complete { count = count + 1; }
+        if item_value.owner == owner && !item_value.complete { count += 1; }
         i += 1;
     }
     count
@@ -193,7 +193,7 @@ fn owner_blocking(borrow value: Checklist, owner: u64) -> u64 {
     let mut i: u64 = 0;
     while i < value.items.len() {
         let item_value = value.items.get_or(i, empty_item());
-        if item_value.owner == owner && item_value.blocking && !item_value.complete { count = count + 1; }
+        if item_value.owner == owner && item_value.blocking && !item_value.complete { count += 1; }
         i += 1;
     }
     count
@@ -215,7 +215,7 @@ fn due_open(borrow value: Checklist, due: u64) -> u64 {
     let mut i: u64 = 0;
     while i < value.items.len() {
         let item_value = value.items.get_or(i, empty_item());
-        if item_value.due_hour <= due && !item_value.complete { count = count + 1; }
+        if item_value.due_hour <= due && !item_value.complete { count += 1; }
         i += 1;
     }
     count
@@ -257,7 +257,7 @@ pub fn render(borrow value: Checklist) -> StrBuf {
         text.append_u64(inout out, item_value.owner); out.push(32);
         text.append_u64(inout out, item_value.due_hour); out.push(32);
         text.append_bool(inout out, item_value.blocking); out.push(32);
-        text.append_bool(inout out, item_value.complete); out.push(10); i = i + 1;
+        text.append_bool(inout out, item_value.complete); out.push(10); i += 1;
     }
     text.append_literal(inout out, "blocking="); text.append_u64(inout out, value.blocking);
     text.append_literal(inout out, " urgent="); text.append_u64(inout out, value.urgent);

--- a/examples/harbor/operator_checklist.rue
+++ b/examples/harbor/operator_checklist.rue
@@ -161,7 +161,7 @@ pub fn build(borrow scenario: model.Scenario, borrow sim: state.State) -> Checkl
         evidence_total = add(evidence_total, value.evidence);
         digest = mix(digest, value.area); digest = mix(digest, value.subject);
         digest = mix(digest, value.evidence); digest = mix(digest, value.target);
-        i = i + 1;
+        i += 1;
     }
     Checklist { items: items, blocking: blocking, urgent: urgent, high: high,
         normal: normal, complete: complete, open: open,
@@ -183,7 +183,7 @@ fn owner_open(borrow value: Checklist, owner: u64) -> u64 {
     while i < value.items.len() {
         let item_value = value.items.get_or(i, empty_item());
         if item_value.owner == owner && !item_value.complete { count = count + 1; }
-        i = i + 1;
+        i += 1;
     }
     count
 }
@@ -194,7 +194,7 @@ fn owner_blocking(borrow value: Checklist, owner: u64) -> u64 {
     while i < value.items.len() {
         let item_value = value.items.get_or(i, empty_item());
         if item_value.owner == owner && item_value.blocking && !item_value.complete { count = count + 1; }
-        i = i + 1;
+        i += 1;
     }
     count
 }
@@ -205,7 +205,7 @@ fn owner_evidence(borrow value: Checklist, owner: u64) -> u64 {
     while i < value.items.len() {
         let item_value = value.items.get_or(i, empty_item());
         if item_value.owner == owner { total = add(total, item_value.evidence); }
-        i = i + 1;
+        i += 1;
     }
     total
 }
@@ -216,7 +216,7 @@ fn due_open(borrow value: Checklist, due: u64) -> u64 {
     while i < value.items.len() {
         let item_value = value.items.get_or(i, empty_item());
         if item_value.due_hour <= due && !item_value.complete { count = count + 1; }
-        i = i + 1;
+        i += 1;
     }
     count
 }
@@ -229,7 +229,7 @@ fn render_owner_summary(inout out: StrBuf, borrow value: Checklist) {
         text.append_u64(inout out, owner_open(borrow value, owner)); out.push(32);
         text.append_u64(inout out, owner_blocking(borrow value, owner)); out.push(32);
         text.append_u64(inout out, owner_evidence(borrow value, owner)); out.push(10);
-        owner = owner + 1;
+        owner += 1;
     }
 }
 
@@ -239,7 +239,7 @@ fn render_due_summary(inout out: StrBuf, borrow value: Checklist) {
     while due <= 4 {
         text.append_u64(inout out, due); out.push(32);
         text.append_u64(inout out, due_open(borrow value, due)); out.push(10);
-        due = due + 1;
+        due += 1;
     }
 }
 

--- a/examples/harbor/planner.rue
+++ b/examples/harbor/planner.rue
@@ -140,10 +140,10 @@ pub fn choose(
             while vehicle < scenario.vehicles.len() {
                 let candidate = evaluate_vehicle(borrow scenario, borrow sim, demand_index, source, vehicle, now);
                 if better(borrow candidate, borrow best) { best = candidate; }
-                vehicle = vehicle + 1;
+                vehicle += 1;
             }
         }
-        source = source + 1;
+        source += 1;
     }
     best
 }

--- a/examples/harbor/pool.rue
+++ b/examples/harbor/pool.rue
@@ -26,7 +26,7 @@ pub struct Pool {
         while i < value.len() {
             let b = match value.byte_at(i) { OptU8.Some(x) => x, OptU8.None => 0 };
             self.bytes.push(b);
-            i = i + 1;
+            i += 1;
         }
         id
     }
@@ -37,7 +37,7 @@ pub struct Pool {
         let mut id: u64 = 0;
         while id < self.len() {
             if self.equals(id, borrow value) { return id; }
-            id = id + 1;
+            id += 1;
         }
         self.len()
     }
@@ -60,7 +60,7 @@ pub struct Pool {
         while i < value.len() {
             let b = match value.byte_at(i) { OptU8.Some(x) => x, OptU8.None => 0 };
             if self.byte_at(id, i) != b { return false; }
-            i = i + 1;
+            i += 1;
         }
         true
     }
@@ -70,7 +70,7 @@ pub struct Pool {
         let mut i: u64 = 0;
         while i < self.string_len(a) {
             if self.byte_at(a, i) != self.byte_at(b, i) { return false; }
-            i = i + 1;
+            i += 1;
         }
         true
     }
@@ -79,7 +79,7 @@ pub struct Pool {
         let mut i: u64 = 0;
         while i < self.string_len(id) {
             out.push(self.byte_at(id, i));
-            i = i + 1;
+            i += 1;
         }
     }
 
@@ -93,9 +93,9 @@ pub struct Pool {
         let mut h: u64 = 14695981039346656037;
         let mut i: u64 = 0;
         while i < self.string_len(id) {
-            h = h ^ @intCast(self.byte_at(id, i));
+            h ^= @intCast(self.byte_at(id, i));
             h = @wrapping_mul(h, 1099511628211);
-            i = i + 1;
+            i += 1;
         }
         h
     }

--- a/examples/harbor/readiness_dashboard.rue
+++ b/examples/harbor/readiness_dashboard.rue
@@ -134,7 +134,7 @@ pub fn build(borrow scenario: model.Scenario, borrow sim: state.State) -> Dashbo
         if item.warning { warnings = warnings + 1; }
         if item.gate { if item.failures == 0 { gates_passed = gates_passed + 1; } else { gates_failed = gates_failed + 1; } }
         digest = mix(digest, item.id); digest = mix(digest, item.score); digest = mix(digest, item.failures);
-        i = i + 1;
+        i += 1;
     }
     let score = if weight_total == 0 { 0 } else { weighted_score / weight_total };
     Dashboard { dimensions: dimensions, score: score, weighted_score: weighted_score,
@@ -170,7 +170,7 @@ fn minimum_dimension(borrow value: Dashboard) -> Dimension {
             worst = item;
             found = true;
         }
-        i = i + 1;
+        i += 1;
     }
     worst
 }

--- a/examples/harbor/readiness_dashboard.rue
+++ b/examples/harbor/readiness_dashboard.rue
@@ -131,8 +131,8 @@ pub fn build(borrow scenario: model.Scenario, borrow sim: state.State) -> Dashbo
         weighted_score = add(weighted_score, item.score * item.weight);
         weight_total = add(weight_total, item.weight);
         observations = add(observations, item.observations); failures = add(failures, item.failures);
-        if item.warning { warnings = warnings + 1; }
-        if item.gate { if item.failures == 0 { gates_passed = gates_passed + 1; } else { gates_failed = gates_failed + 1; } }
+        if item.warning { warnings += 1; }
+        if item.gate { if item.failures == 0 { gates_passed += 1; } else { gates_failed += 1; } }
         digest = mix(digest, item.id); digest = mix(digest, item.score); digest = mix(digest, item.failures);
         i += 1;
     }
@@ -185,7 +185,7 @@ pub fn render(borrow value: Dashboard) -> StrBuf {
         append_name(inout out, item.id); out.push(32); text.append_u64(inout out, item.score); out.push(32);
         text.append_u64(inout out, item.weight); out.push(32); text.append_u64(inout out, item.observations); out.push(32);
         text.append_u64(inout out, item.failures); out.push(32); text.append_bool(inout out, item.warning); out.push(32);
-        text.append_bool(inout out, item.gate); out.push(10); i = i + 1;
+        text.append_bool(inout out, item.gate); out.push(10); i += 1;
     }
     text.append_literal(inout out, "score="); text.append_u64(inout out, value.score);
     text.append_literal(inout out, " grade="); append_grade(inout out, value.score);

--- a/examples/harbor/replay.rue
+++ b/examples/harbor/replay.rue
@@ -55,7 +55,7 @@ fn inventory_take(borrow scenario: model.Scenario, inout snapshot: Snapshot, loc
     let index = inventory_index(borrow scenario, location, cargo);
     let current = snapshot.inventory.get_or(index, 0);
     if quantity > current {
-        snapshot.underflows = snapshot.underflows + 1;
+        snapshot.underflows += 1;
         snapshot.inventory.set(index, 0);
     } else { snapshot.inventory.set(index, current - quantity); }
 }
@@ -80,7 +80,7 @@ fn new_snapshot(borrow scenario: model.Scenario) -> Snapshot {
         let demand = scenario.demands.get_or(i, model.empty_demand());
         demand_remaining.push(demand.quantity);
         demand_delivered.push(0);
-        i = i + 1;
+        i += 1;
     }
     Snapshot {
         inventory: inventory, transit: transit, supplied: supplied, produced: produced,
@@ -144,8 +144,8 @@ pub fn reduce(borrow scenario: model.Scenario, borrow log: state.Events) -> Snap
         } else if event.tag == state.EVENT_EXPIRED() && event.cargo < snapshot.expired.len() {
             snapshot.expired.set(event.cargo, add(snapshot.expired.get_or(event.cargo, 0), event.quantity));
         }
-        snapshot.events = snapshot.events + 1;
-        i = i + 1;
+        snapshot.events += 1;
+        i += 1;
     }
     snapshot
 }
@@ -156,7 +156,7 @@ fn array_mismatches(borrow a: U64s, borrow b: U64s) -> u64 {
     let mut i: u64 = 0;
     while i < n {
         if a.get_or(i, 18446744073709551615) != b.get_or(i, 18446744073709551615) { mismatches = mismatches + 1; }
-        i = i + 1;
+        i += 1;
     }
     mismatches
 }
@@ -165,8 +165,8 @@ pub fn audit(borrow scenario: model.Scenario, borrow sim: state.State) -> Audit 
     let snapshot = reduce(borrow scenario, borrow sim.log);
     let inventory_mismatches = array_mismatches(borrow snapshot.inventory, borrow sim.inventory);
     let mut cargo_mismatches = array_mismatches(borrow snapshot.transit, borrow sim.in_transit);
-    cargo_mismatches = cargo_mismatches + array_mismatches(borrow snapshot.delivered, borrow sim.delivered);
-    cargo_mismatches = cargo_mismatches + array_mismatches(borrow snapshot.expired, borrow sim.expired);
+    cargo_mismatches += array_mismatches(borrow snapshot.delivered, borrow sim.delivered);
+    cargo_mismatches += array_mismatches(borrow snapshot.expired, borrow sim.expired);
     // Source metrics include capacity-rejected source units; replay sees those
     // in separate expired events, so accepted + rejected is compared here.
     let mut i: u64 = 0;
@@ -174,7 +174,7 @@ pub fn audit(borrow scenario: model.Scenario, borrow sim: state.State) -> Audit 
         let replay_source = add(add(snapshot.supplied.get_or(i, 0), snapshot.produced.get_or(i, 0)), snapshot.expired.get_or(i, 0));
         let state_source = add(sim.supplied.get_or(i, 0), sim.produced.get_or(i, 0));
         if replay_source != state_source { cargo_mismatches = cargo_mismatches + 1; }
-        i = i + 1;
+        i += 1;
     }
     let demand_mismatches = array_mismatches(borrow snapshot.demand_remaining, borrow sim.demand_remaining)
         + array_mismatches(borrow snapshot.demand_delivered, borrow sim.demand_delivered);

--- a/examples/harbor/replay.rue
+++ b/examples/harbor/replay.rue
@@ -33,7 +33,7 @@ pub struct Audit {
 
 fn fill(inout values: U64s, count: u64, value: u64) {
     let mut i: u64 = 0;
-    while i < count { values.push(value); i = i + 1; }
+    while i < count { values.push(value); i += 1; }
 }
 
 fn add(a: u64, b: u64) -> u64 {
@@ -45,13 +45,13 @@ fn inventory_index(borrow scenario: model.Scenario, location: u64, cargo: u64) -
 }
 
 fn inventory_add(borrow scenario: model.Scenario, inout snapshot: Snapshot, location: u64, cargo: u64, quantity: u64) {
-    if location >= scenario.locations.len() || cargo >= scenario.cargoes.len() { snapshot.underflows = snapshot.underflows + 1; return; }
+    if location >= scenario.locations.len() || cargo >= scenario.cargoes.len() { snapshot.underflows += 1; return; }
     let index = inventory_index(borrow scenario, location, cargo);
     snapshot.inventory.set(index, add(snapshot.inventory.get_or(index, 0), quantity));
 }
 
 fn inventory_take(borrow scenario: model.Scenario, inout snapshot: Snapshot, location: u64, cargo: u64, quantity: u64) {
-    if location >= scenario.locations.len() || cargo >= scenario.cargoes.len() { snapshot.underflows = snapshot.underflows + 1; return; }
+    if location >= scenario.locations.len() || cargo >= scenario.cargoes.len() { snapshot.underflows += 1; return; }
     let index = inventory_index(borrow scenario, location, cargo);
     let current = snapshot.inventory.get_or(index, 0);
     if quantity > current {
@@ -113,13 +113,13 @@ fn departure_event(borrow scenario: model.Scenario, inout snapshot: Snapshot, ev
 fn arrival_event(inout snapshot: Snapshot, event: state.Event) {
     if event.cargo < snapshot.transit.len() {
         let current = snapshot.transit.get_or(event.cargo, 0);
-        if event.quantity > current { snapshot.underflows = snapshot.underflows + 1; snapshot.transit.set(event.cargo, 0); }
+        if event.quantity > current { snapshot.underflows += 1; snapshot.transit.set(event.cargo, 0); }
         else { snapshot.transit.set(event.cargo, current - event.quantity); }
         snapshot.delivered.set(event.cargo, add(snapshot.delivered.get_or(event.cargo, 0), event.quantity));
     }
     if event.demand < snapshot.demand_remaining.len() {
         let remaining = snapshot.demand_remaining.get_or(event.demand, 0);
-        if event.quantity > remaining { snapshot.underflows = snapshot.underflows + 1; }
+        if event.quantity > remaining { snapshot.underflows += 1; }
         let accepted = if event.quantity < remaining { event.quantity } else { remaining };
         snapshot.demand_remaining.set(event.demand, remaining - accepted);
         snapshot.demand_delivered.set(event.demand, add(snapshot.demand_delivered.get_or(event.demand, 0), accepted));
@@ -132,7 +132,7 @@ pub fn reduce(borrow scenario: model.Scenario, borrow log: state.Events) -> Snap
     let mut i: u64 = 0;
     while i < log.len() {
         let event = log.get_or(i, state.empty_event());
-        if i > 0 && event.time < previous_time { snapshot.ordering_errors = snapshot.ordering_errors + 1; }
+        if i > 0 && event.time < previous_time { snapshot.ordering_errors += 1; }
         previous_time = event.time;
         if event.tag == state.EVENT_SUPPLY() { source_event(borrow scenario, inout snapshot, event, false); }
         else if event.tag == state.EVENT_PRODUCTION() { source_event(borrow scenario, inout snapshot, event, true); }
@@ -155,7 +155,7 @@ fn array_mismatches(borrow a: U64s, borrow b: U64s) -> u64 {
     let n = if a.len() > b.len() { a.len() } else { b.len() };
     let mut i: u64 = 0;
     while i < n {
-        if a.get_or(i, 18446744073709551615) != b.get_or(i, 18446744073709551615) { mismatches = mismatches + 1; }
+        if a.get_or(i, 18446744073709551615) != b.get_or(i, 18446744073709551615) { mismatches += 1; }
         i += 1;
     }
     mismatches
@@ -173,14 +173,14 @@ pub fn audit(borrow scenario: model.Scenario, borrow sim: state.State) -> Audit 
     while i < scenario.cargoes.len() {
         let replay_source = add(add(snapshot.supplied.get_or(i, 0), snapshot.produced.get_or(i, 0)), snapshot.expired.get_or(i, 0));
         let state_source = add(sim.supplied.get_or(i, 0), sim.produced.get_or(i, 0));
-        if replay_source != state_source { cargo_mismatches = cargo_mismatches + 1; }
+        if replay_source != state_source { cargo_mismatches += 1; }
         i += 1;
     }
     let demand_mismatches = array_mismatches(borrow snapshot.demand_remaining, borrow sim.demand_remaining)
         + array_mismatches(borrow snapshot.demand_delivered, borrow sim.demand_delivered);
     let mut metric_mismatches: u64 = 0;
-    if snapshot.total_cost != sim.total_cost { metric_mismatches = metric_mismatches + 1; }
-    if snapshot.total_distance != sim.total_distance { metric_mismatches = metric_mismatches + 1; }
+    if snapshot.total_cost != sim.total_cost { metric_mismatches += 1; }
+    if snapshot.total_distance != sim.total_distance { metric_mismatches += 1; }
     let mismatches = inventory_mismatches + cargo_mismatches + demand_mismatches + metric_mismatches
         + snapshot.ordering_errors + snapshot.underflows;
     Audit {

--- a/examples/harbor/report.rue
+++ b/examples/harbor/report.rue
@@ -110,7 +110,7 @@ fn demand_section(inout out: StrBuf, borrow scenario: model.Scenario, borrow sim
         text.append_literal(inout out, " unmet=");
         text.append_u64(inout out, item.unmet);
         out.push(10);
-        i = i + 1;
+        i += 1;
     }
     out.push(10);
 }
@@ -187,7 +187,7 @@ fn fleet_section(inout out: StrBuf, borrow scenario: model.Scenario, borrow sim:
         text.append_literal(inout out, " fill=");
         text.append_percent(inout out, item.fill_numerator, item.fill_denominator);
         out.push(10);
-        i = i + 1;
+        i += 1;
     }
     out.push(10);
 }
@@ -254,7 +254,7 @@ fn capacity_section(inout out: StrBuf, borrow scenario: model.Scenario, borrow s
         text.append_literal(inout out, " handling_peak=");
         text.append_u64(inout out, item.handling_peak);
         out.push(10);
-        i = i + 1;
+        i += 1;
     }
     out.push(10);
 }

--- a/examples/harbor/resilience.rue
+++ b/examples/harbor/resilience.rue
@@ -54,15 +54,15 @@ fn compare(borrow baseline: route_matrix.Matrix, borrow current: route_matrix.Ma
                 let before = route_matrix.weight(borrow baseline, from, to);
                 let after = route_matrix.weight(borrow current, from, to);
                 if before != after {
-                    degradation_pairs = degradation_pairs + 1;
+                    degradation_pairs += 1;
                     if before != routing.INF() && after != routing.INF() && after > before {
                         added_weight = add(added_weight, after - before);
                     }
                 }
             }
-            to = to + 1;
+            to += 1;
         }
-        from = from + 1;
+        from += 1;
     }
     Snapshot {
         time: current.at, minimum_capacity: 1,
@@ -84,7 +84,7 @@ fn event_times(borrow scenario: model.Scenario) -> std.arraybuf.ArrayBuf(u64) {
         let item = scenario.disruptions.get_or(i, model.empty_disruption());
         times.push(item.start);
         if item.end <= scenario.duration { times.push(item.end); }
-        i = i + 1;
+        i += 1;
     }
     times.push(scenario.duration);
     std.sort.insertion_sort(u64, inout times);
@@ -93,7 +93,7 @@ fn event_times(borrow scenario: model.Scenario) -> std.arraybuf.ArrayBuf(u64) {
     while i < times.len() {
         let value = times.get_or(i, 0);
         if unique.len() == 0 || unique.get_or(unique.len() - 1, 0) != value { unique.push(value); }
-        i = i + 1;
+        i += 1;
     }
     unique
 }
@@ -108,14 +108,14 @@ fn route_exposure(borrow scenario: model.Scenario, route: u64) -> RouteExposure 
     while i < scenario.disruptions.len() {
         let item = scenario.disruptions.get_or(i, model.empty_disruption());
         if item.route == route {
-            windows = windows + 1;
+            windows += 1;
             disruption_hours = add(disruption_hours, item.end - item.start);
             let capacity = routing.effective_capacity(borrow scenario, route, item.start);
             let cost = routing.effective_cost(borrow scenario, route, item.start);
             if capacity < minimum_capacity { minimum_capacity = capacity; }
             if cost > maximum_cost { maximum_cost = cost; }
         }
-        i = i + 1;
+        i += 1;
     }
     RouteExposure {
         route: route, disruption_hours: disruption_hours,
@@ -142,7 +142,7 @@ pub fn summarize(borrow scenario: model.Scenario) -> Summary {
             if snapshot.added_weight > worst_added_weight { worst_added_weight = snapshot.added_weight; }
         }
         snapshots.push(snapshot);
-        i = i + 1;
+        i += 1;
     }
     let mut routes = RouteExposures.new();
     i = 0;
@@ -154,7 +154,7 @@ pub fn summarize(borrow scenario: model.Scenario) -> Summary {
         let matrix = route_matrix.compute(borrow scenario, 0, level, routing.MODE_COST());
         if matrix.unreachable_pairs == 0 { fully_connected_levels = fully_connected_levels + 1; }
         else if fragile_capacity == 0 { fragile_capacity = level; }
-        level = level + 10;
+        level += 10;
     }
     Summary {
         snapshots: snapshots, routes: routes,

--- a/examples/harbor/resilience.rue
+++ b/examples/harbor/resilience.rue
@@ -146,13 +146,13 @@ pub fn summarize(borrow scenario: model.Scenario) -> Summary {
     }
     let mut routes = RouteExposures.new();
     i = 0;
-    while i < scenario.routes.len() { routes.push(route_exposure(borrow scenario, i)); i = i + 1; }
+    while i < scenario.routes.len() { routes.push(route_exposure(borrow scenario, i)); i += 1; }
     let mut fragile_capacity: u64 = 0;
     let mut fully_connected_levels: u64 = 0;
     let mut level: u64 = 1;
     while level <= 100 {
         let matrix = route_matrix.compute(borrow scenario, 0, level, routing.MODE_COST());
-        if matrix.unreachable_pairs == 0 { fully_connected_levels = fully_connected_levels + 1; }
+        if matrix.unreachable_pairs == 0 { fully_connected_levels += 1; }
         else if fragile_capacity == 0 { fragile_capacity = level; }
         level += 10;
     }

--- a/examples/harbor/risk_register.rue
+++ b/examples/harbor/risk_register.rue
@@ -67,7 +67,7 @@ fn disruption_overlap(borrow scenario: model.Scenario, route: u64) -> u64 {
     while i < scenario.disruptions.len() {
         let item = scenario.disruptions.get_or(i, model.empty_disruption());
         if item.route == route && item.end > item.start { hours = add(hours, item.end - item.start); }
-        i = i + 1;
+        i += 1;
     }
     hours
 }
@@ -82,7 +82,7 @@ fn alternate_count(borrow scenario: model.Scenario, route_index: u64) -> u64 {
             if other.from == route.from || other.to == route.from ||
                other.from == route.to || other.to == route.to { count = count + 1; }
         }
-        i = i + 1;
+        i += 1;
     }
     count
 }
@@ -99,7 +99,7 @@ fn add_route_risks(borrow scenario: model.Scenario, inout risks: Risks) {
         if severity >= 4 || likelihood >= 3 || exposure >= 4 {
             risks.push(make(KIND_ROUTE(), i, severity, likelihood, exposure, disrupted_hours, alternatives));
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -115,7 +115,7 @@ fn add_demand_risks(borrow scenario: model.Scenario, borrow sim: state.State, in
         if remaining > 0 || severity >= 4 {
             risks.push(make(KIND_DEMAND(), i, severity, likelihood, exposure, remaining, delivered));
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -125,7 +125,7 @@ fn cargo_requested(borrow scenario: model.Scenario, cargo: u64) -> u64 {
     while i < scenario.demands.len() {
         let demand = scenario.demands.get_or(i, model.empty_demand());
         if demand.cargo == cargo { total = add(total, demand.quantity); }
-        i = i + 1;
+        i += 1;
     }
     total
 }
@@ -135,12 +135,12 @@ fn cargo_sources(borrow scenario: model.Scenario, cargo: u64) -> u64 {
     let mut i: u64 = 0;
     while i < scenario.supplies.len() {
         if scenario.supplies.get_or(i, model.empty_supply()).cargo == cargo { count = count + 1; }
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < scenario.productions.len() {
         if scenario.productions.get_or(i, model.empty_production()).cargo == cargo { count = count + 1; }
-        i = i + 1;
+        i += 1;
     }
     count
 }
@@ -158,7 +158,7 @@ fn add_cargo_risks(borrow scenario: model.Scenario, borrow sim: state.State, ino
         if requested > 0 && (exposure >= 3 || likelihood >= 4 || expired > 0) {
             risks.push(make(KIND_CARGO(), cargo_index, severity, likelihood, exposure, expired, sources));
         }
-        cargo_index = cargo_index + 1;
+        cargo_index += 1;
     }
 }
 
@@ -167,7 +167,7 @@ fn vehicles_at(borrow scenario: model.Scenario, location: u64) -> u64 {
     let mut i: u64 = 0;
     while i < scenario.vehicles.len() {
         if scenario.vehicles.get_or(i, model.empty_vehicle()).at == location { count = count + 1; }
-        i = i + 1;
+        i += 1;
     }
     count
 }
@@ -183,7 +183,7 @@ fn add_fleet_risks(borrow scenario: model.Scenario, inout risks: Risks) {
             let exposure = if count == 1 { 2 } else { count };
             if severity >= 4 || likelihood >= 3 { risks.push(make(KIND_FLEET(), location, severity, likelihood, exposure, count, path.routes.len())); }
         }
-        location = location + 1;
+        location += 1;
     }
 }
 
@@ -207,7 +207,7 @@ pub fn build(borrow scenario: model.Scenario, borrow sim: state.State) -> Regist
         total_score = add(total_score, item.score);
         if item.score > maximum_score { maximum_score = item.score; maximum_kind = item.kind; maximum_subject = item.subject; }
         digest = mix(digest, item.kind); digest = mix(digest, item.subject); digest = mix(digest, item.score);
-        i = i + 1;
+        i += 1;
     }
     Register { risks: risks, critical: critical, high: high, medium: medium, low: low,
         total_score: total_score, maximum_score: maximum_score, maximum_kind: maximum_kind,

--- a/examples/harbor/risk_register.rue
+++ b/examples/harbor/risk_register.rue
@@ -80,7 +80,7 @@ fn alternate_count(borrow scenario: model.Scenario, route_index: u64) -> u64 {
         if i != route_index {
             let other = scenario.routes.get_or(i, model.empty_route());
             if other.from == route.from || other.to == route.from ||
-               other.from == route.to || other.to == route.to { count = count + 1; }
+               other.from == route.to || other.to == route.to { count += 1; }
         }
         i += 1;
     }
@@ -134,12 +134,12 @@ fn cargo_sources(borrow scenario: model.Scenario, cargo: u64) -> u64 {
     let mut count: u64 = 0;
     let mut i: u64 = 0;
     while i < scenario.supplies.len() {
-        if scenario.supplies.get_or(i, model.empty_supply()).cargo == cargo { count = count + 1; }
+        if scenario.supplies.get_or(i, model.empty_supply()).cargo == cargo { count += 1; }
         i += 1;
     }
     i = 0;
     while i < scenario.productions.len() {
-        if scenario.productions.get_or(i, model.empty_production()).cargo == cargo { count = count + 1; }
+        if scenario.productions.get_or(i, model.empty_production()).cargo == cargo { count += 1; }
         i += 1;
     }
     count
@@ -166,7 +166,7 @@ fn vehicles_at(borrow scenario: model.Scenario, location: u64) -> u64 {
     let mut count: u64 = 0;
     let mut i: u64 = 0;
     while i < scenario.vehicles.len() {
-        if scenario.vehicles.get_or(i, model.empty_vehicle()).at == location { count = count + 1; }
+        if scenario.vehicles.get_or(i, model.empty_vehicle()).at == location { count += 1; }
         i += 1;
     }
     count
@@ -200,10 +200,10 @@ pub fn build(borrow scenario: model.Scenario, borrow sim: state.State) -> Regist
     let mut i: u64 = 0;
     while i < risks.len() {
         let item = risks.get_or(i, empty_risk());
-        if item.score >= 80 { critical = critical + 1; }
-        else if item.score >= 45 { high = high + 1; }
-        else if item.score >= 20 { medium = medium + 1; }
-        else { low = low + 1; }
+        if item.score >= 80 { critical += 1; }
+        else if item.score >= 45 { high += 1; }
+        else if item.score >= 20 { medium += 1; }
+        else { low += 1; }
         total_score = add(total_score, item.score);
         if item.score > maximum_score { maximum_score = item.score; maximum_kind = item.kind; maximum_subject = item.subject; }
         digest = mix(digest, item.kind); digest = mix(digest, item.subject); digest = mix(digest, item.score);
@@ -238,7 +238,7 @@ pub fn render(borrow value: Register) -> StrBuf {
         text.append_u64(inout out, item.subject); out.push(32); text.append_u64(inout out, item.score); out.push(32);
         text.append_u64(inout out, item.severity); out.push(32); text.append_u64(inout out, item.likelihood); out.push(32);
         text.append_u64(inout out, item.exposure); out.push(32); text.append_u64(inout out, item.evidence); out.push(32);
-        text.append_u64(inout out, item.mitigation); out.push(10); i = i + 1;
+        text.append_u64(inout out, item.mitigation); out.push(10); i += 1;
     }
     text.append_literal(inout out, "total_score="); text.append_u64(inout out, value.total_score);
     text.append_literal(inout out, " maximum_score="); text.append_u64(inout out, value.maximum_score);

--- a/examples/harbor/route_audit.rue
+++ b/examples/harbor/route_audit.rue
@@ -62,7 +62,7 @@ fn node_repeated(borrow path: routing.Path, position: u64) -> bool {
     let mut i: u64 = 0;
     while i < position {
         if path.nodes.get_or(i, model.NONE()) == node { return true; }
-        i = i + 1;
+        i += 1;
     }
     false
 }
@@ -78,32 +78,32 @@ fn audit_path(
     inout result: ModeAudit,
 ) -> u64 {
     let mut digest: u64 = 14695981039346656037;
-    result.pairs = result.pairs + 1;
+    result.pairs += 1;
     digest = mix(digest, from); digest = mix(digest, to);
     if !path.reachable {
-        result.unreachable = result.unreachable + 1;
+        result.unreachable += 1;
         if path.nodes.len() != 0 || path.routes.len() != 0 {
-            result.continuity_errors = result.continuity_errors + 1;
+            result.continuity_errors += 1;
         }
         return digest;
     }
-    result.reachable = result.reachable + 1;
+    result.reachable += 1;
     result.total_hops = add(result.total_hops, path.routes.len());
     if path.routes.len() > result.maximum_hops { result.maximum_hops = path.routes.len(); }
     let expected_weight = routing.path_weight(borrow scenario, borrow path, at, mode);
     result.total_weight = add(result.total_weight, expected_weight);
     if path.nodes.len() == 0 || path.nodes.get_or(0, model.NONE()) != from ||
        path.nodes.get_or(path.nodes.len() - 1, model.NONE()) != to {
-        result.endpoint_errors = result.endpoint_errors + 1;
+        result.endpoint_errors += 1;
     }
     if path.nodes.len() != path.routes.len() + 1 {
-        result.continuity_errors = result.continuity_errors + 1;
+        result.continuity_errors += 1;
     }
     let mut i: u64 = 0;
     while i < path.nodes.len() {
         digest = mix(digest, path.nodes.get_or(i, model.NONE()));
         if node_repeated(borrow path, i) { result.cycle_errors = result.cycle_errors + 1; }
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     let mut direct_weight: u64 = 0;
@@ -115,11 +115,11 @@ fn audit_path(
         digest = mix(digest, route_index);
         if !route_connects(route, a, b) { result.direction_errors = result.direction_errors + 1; }
         if routing.effective_capacity(borrow scenario, route_index, at) < minimum_capacity {
-            result.capacity_errors = result.capacity_errors + 1;
+            result.capacity_errors += 1;
         }
         let edge = routing.edge_weight(borrow scenario, route_index, at, mode);
         direct_weight = add(direct_weight, edge);
-        i = i + 1;
+        i += 1;
     }
     if direct_weight != expected_weight { result.weight_errors = result.weight_errors + 1; }
     digest
@@ -150,9 +150,9 @@ fn audit_mode(
                 );
                 digest = mix(digest, path_hash);
             }
-            to = to + 1;
+            to += 1;
         }
-        from = from + 1;
+        from += 1;
     }
     result
 }
@@ -202,7 +202,7 @@ pub fn render(borrow value: Audit) -> StrBuf {
         text.append_literal(inout out, " capacity="); text.append_u64(inout out, item.capacity_errors);
         text.append_literal(inout out, " weight="); text.append_u64(inout out, item.weight_errors);
         text.append_literal(inout out, " cycles="); text.append_u64(inout out, item.cycle_errors); out.push(10);
-        i = i + 1;
+        i += 1;
     }
     text.append_literal(inout out, "digest="); text.append_u64(inout out, value.path_digest);
     text.append_literal(inout out, " valid="); text.append_bool(inout out, value.errors == 0); out.push(10);

--- a/examples/harbor/route_audit.rue
+++ b/examples/harbor/route_audit.rue
@@ -102,7 +102,7 @@ fn audit_path(
     let mut i: u64 = 0;
     while i < path.nodes.len() {
         digest = mix(digest, path.nodes.get_or(i, model.NONE()));
-        if node_repeated(borrow path, i) { result.cycle_errors = result.cycle_errors + 1; }
+        if node_repeated(borrow path, i) { result.cycle_errors += 1; }
         i += 1;
     }
     i = 0;
@@ -113,7 +113,7 @@ fn audit_path(
         let a = path.nodes.get_or(i, model.NONE());
         let b = path.nodes.get_or(i + 1, model.NONE());
         digest = mix(digest, route_index);
-        if !route_connects(route, a, b) { result.direction_errors = result.direction_errors + 1; }
+        if !route_connects(route, a, b) { result.direction_errors += 1; }
         if routing.effective_capacity(borrow scenario, route_index, at) < minimum_capacity {
             result.capacity_errors += 1;
         }
@@ -121,7 +121,7 @@ fn audit_path(
         direct_weight = add(direct_weight, edge);
         i += 1;
     }
-    if direct_weight != expected_weight { result.weight_errors = result.weight_errors + 1; }
+    if direct_weight != expected_weight { result.weight_errors += 1; }
     digest
 }
 

--- a/examples/harbor/route_matrix.rue
+++ b/examples/harbor/route_matrix.rue
@@ -51,7 +51,7 @@ fn push_path(inout matrix: Matrix, from: u64, to: u64, borrow path: routing.Path
     matrix.bottlenecks.push(if path.reachable { path.bottleneck } else { 0 });
     if from != to {
         if path.reachable {
-            matrix.reachable_pairs = matrix.reachable_pairs + 1;
+            matrix.reachable_pairs += 1;
             matrix.total_weight = add(matrix.total_weight, weight);
             if weight > matrix.diameter {
                 matrix.diameter = weight;
@@ -59,7 +59,7 @@ fn push_path(inout matrix: Matrix, from: u64, to: u64, borrow path: routing.Path
                 matrix.diameter_to = to;
             }
         } else {
-            matrix.unreachable_pairs = matrix.unreachable_pairs + 1;
+            matrix.unreachable_pairs += 1;
         }
     }
 }
@@ -76,9 +76,9 @@ pub fn compute(borrow scenario: model.Scenario, at: u64, minimum_capacity: u64, 
             let path = routing.shortest(borrow scenario, from, to, at, minimum_capacity, mode);
             let weight = routing.path_weight(borrow scenario, borrow path, at, mode);
             push_path(inout matrix, from, to, borrow path, weight);
-            to = to + 1;
+            to += 1;
         }
-        from = from + 1;
+        from += 1;
     }
     matrix
 }
@@ -118,7 +118,7 @@ pub fn row_reachable(borrow matrix: Matrix, from: u64) -> u64 {
     let mut to: u64 = 0;
     while to < matrix.size {
         if from != to && weight(borrow matrix, from, to) != routing.INF() { count = count + 1; }
-        to = to + 1;
+        to += 1;
     }
     count
 }
@@ -132,9 +132,9 @@ pub fn row_average(borrow matrix: Matrix, from: u64) -> u64 {
         let value = weight(borrow matrix, from, to);
         if from != to && value != routing.INF() {
             total = add(total, value);
-            count = count + 1;
+            count += 1;
         }
-        to = to + 1;
+        to += 1;
     }
     if count == 0 { 0 } else { total / count }
 }
@@ -152,7 +152,7 @@ pub fn central_location(borrow matrix: Matrix) -> u64 {
             best_reachable = reachable;
             best_average = average;
         }
-        from = from + 1;
+        from += 1;
     }
     best
 }
@@ -173,7 +173,7 @@ pub fn render(borrow scenario: model.Scenario, borrow matrix: Matrix) -> StrBuf 
         out.push(9);
         let location = scenario.locations.get_or(to, model.empty_location());
         text.append_id(inout out, borrow scenario, location.id);
-        to = to + 1;
+        to += 1;
     }
     out.push(10);
     let mut from: u64 = 0;
@@ -184,10 +184,10 @@ pub fn render(borrow scenario: model.Scenario, borrow matrix: Matrix) -> StrBuf 
         while to < matrix.size {
             out.push(9);
             append_cell(inout out, weight(borrow matrix, from, to));
-            to = to + 1;
+            to += 1;
         }
         out.push(10);
-        from = from + 1;
+        from += 1;
     }
     text.append_literal(inout out, "reachable_pairs=");
     text.append_u64(inout out, matrix.reachable_pairs);

--- a/examples/harbor/route_matrix.rue
+++ b/examples/harbor/route_matrix.rue
@@ -117,7 +117,7 @@ pub fn row_reachable(borrow matrix: Matrix, from: u64) -> u64 {
     let mut count: u64 = 0;
     let mut to: u64 = 0;
     while to < matrix.size {
-        if from != to && weight(borrow matrix, from, to) != routing.INF() { count = count + 1; }
+        if from != to && weight(borrow matrix, from, to) != routing.INF() { count += 1; }
         to += 1;
     }
     count

--- a/examples/harbor/route_oracle.rue
+++ b/examples/harbor/route_oracle.rue
@@ -11,7 +11,7 @@ fn add_saturating(a: u64, b: u64) -> u64 {
 
 fn fill(inout values: U64s, count: u64, value: u64) {
     let mut i: u64 = 0;
-    while i < count { values.push(value); i = i + 1; }
+    while i < count { values.push(value); i += 1; }
 }
 
 fn relax(
@@ -74,7 +74,7 @@ pub fn audit_all_pairs(borrow scenario: model.Scenario, now: u64, minimum_capaci
             let path = routing.shortest(borrow scenario, from, to, now, minimum_capacity, mode);
             let actual = routing.path_weight(borrow scenario, borrow path, now, mode);
             let expected = distance(borrow scenario, from, to, now, minimum_capacity, mode);
-            if actual != expected { mismatches = mismatches + 1; }
+            if actual != expected { mismatches += 1; }
             to += 1;
         }
         from += 1;

--- a/examples/harbor/route_oracle.rue
+++ b/examples/harbor/route_oracle.rue
@@ -57,10 +57,10 @@ pub fn distance(
             if route.bidirectional {
                 if relax(borrow scenario, i, route.to, route.from, now, minimum_capacity, mode, inout distances) { changed = true; }
             }
-            i = i + 1;
+            i += 1;
         }
         if !changed { break; }
-        pass = pass + 1;
+        pass += 1;
     }
     distances.get_or(target, routing.INF())
 }
@@ -75,9 +75,9 @@ pub fn audit_all_pairs(borrow scenario: model.Scenario, now: u64, minimum_capaci
             let actual = routing.path_weight(borrow scenario, borrow path, now, mode);
             let expected = distance(borrow scenario, from, to, now, minimum_capacity, mode);
             if actual != expected { mismatches = mismatches + 1; }
-            to = to + 1;
+            to += 1;
         }
-        from = from + 1;
+        from += 1;
     }
     mismatches
 }

--- a/examples/harbor/routing.rue
+++ b/examples/harbor/routing.rue
@@ -93,7 +93,7 @@ fn neighbor(route: model.Route, at: u64) -> u64 {
 
 fn fill(inout values: U64s, count: u64, value: u64) {
     let mut i: u64 = 0;
-    while i < count { values.push(value); i = i + 1; }
+    while i < count { values.push(value); i += 1; }
 }
 
 fn prefer(candidate_route: u64, old_route: u64) -> bool {
@@ -227,7 +227,7 @@ pub fn shortest(
             // to the same logical vector across calls, but not within one call.
             let mut next_distances = U64s.new();
             let mut i: u64 = 0;
-            while i < distances.len() { next_distances.push(distances.get_or(i, INF())); i = i + 1; }
+            while i < distances.len() { next_distances.push(distances.get_or(i, INF())); i += 1; }
             relax_from(
                 borrow scenario, at, now, minimum_capacity, mode,
                 borrow distances, inout next_distances,

--- a/examples/harbor/routing.rue
+++ b/examples/harbor/routing.rue
@@ -59,7 +59,7 @@ pub fn effective_capacity(borrow scenario: model.Scenario, route_index: u64, at:
         if item.route == route_index && disruption_active(borrow item, at) {
             capacity = mul_percent(capacity, item.capacity_percent);
         }
-        i = i + 1;
+        i += 1;
     }
     capacity
 }
@@ -73,7 +73,7 @@ pub fn effective_cost(borrow scenario: model.Scenario, route_index: u64, at: u64
         if item.route == route_index && disruption_active(borrow item, at) {
             cost = mul_percent(cost, item.cost_percent);
         }
-        i = i + 1;
+        i += 1;
     }
     cost
 }
@@ -130,7 +130,7 @@ fn relax_from(
                 queue.push(candidate, next);
             }
         }
-        route_index = route_index + 1;
+        route_index += 1;
     }
 }
 
@@ -147,7 +147,7 @@ fn summarize(borrow scenario: model.Scenario, inout path: Path) {
         path.distance = add_saturating(path.distance, route.distance);
         path.travel = add_saturating(path.travel, route.travel);
         if route.capacity < path.bottleneck { path.bottleneck = route.capacity; }
-        i = i + 1;
+        i += 1;
     }
     if path.routes.len() == 0 { path.bottleneck = 0; }
 }
@@ -172,7 +172,7 @@ fn reconstruct(
         routes.push_front(route);
         cursor = parent;
         nodes.push_front(cursor);
-        guard = guard + 1;
+        guard += 1;
     }
     if cursor != from { return path; }
     while !nodes.is_empty() {
@@ -246,7 +246,7 @@ pub fn path_weight(borrow scenario: model.Scenario, borrow path: Path, now: u64,
     let mut i: u64 = 0;
     while i < path.routes.len() {
         total = add_saturating(total, edge_weight(borrow scenario, path.routes.get_or(i, model.NONE()), now, mode));
-        i = i + 1;
+        i += 1;
     }
     total
 }

--- a/examples/harbor/scenario_compare.rue
+++ b/examples/harbor/scenario_compare.rue
@@ -88,16 +88,16 @@ fn compare_matrices(
                 let a = route_matrix.weight(borrow before, from, to);
                 let b = route_matrix.weight(borrow during, from, to);
                 if a == routing.INF() && b != routing.INF() {
-                    result.newly_reachable = result.newly_reachable + 1;
+                    result.newly_reachable += 1;
                     result.during_total = add(result.during_total, b);
                 } else if a != routing.INF() && b == routing.INF() {
-                    result.newly_unreachable = result.newly_unreachable + 1;
+                    result.newly_unreachable += 1;
                     result.before_total = add(result.before_total, a);
                 } else if a != routing.INF() && b != routing.INF() {
                     result.before_total = add(result.before_total, a);
                     result.during_total = add(result.during_total, b);
                     if b > a {
-                        result.increased = result.increased + 1;
+                        result.increased += 1;
                         let increase = b - a;
                         if increase > result.largest_increase {
                             result.largest_increase = increase;
@@ -105,17 +105,17 @@ fn compare_matrices(
                             result.largest_to = to;
                         }
                     } else if b < a {
-                        result.decreased = result.decreased + 1;
+                        result.decreased += 1;
                     } else {
-                        result.unchanged = result.unchanged + 1;
+                        result.unchanged += 1;
                     }
                 } else {
-                    result.unchanged = result.unchanged + 1;
+                    result.unchanged += 1;
                 }
             }
-            to = to + 1;
+            to += 1;
         }
-        from = from + 1;
+        from += 1;
     }
     if result.during_total > result.before_total {
         result.added_weight = result.during_total - result.before_total;
@@ -159,9 +159,9 @@ pub fn compare(borrow scenario: model.Scenario) -> Comparison {
                 worst_added_weight = delta.added_weight;
             }
             deltas.push(delta);
-            mode_index = mode_index + 1;
+            mode_index += 1;
         }
-        disruption_index = disruption_index + 1;
+        disruption_index += 1;
     }
     Comparison {
         deltas: deltas, variants: scenario.disruptions.len(),
@@ -204,7 +204,7 @@ pub fn render(borrow scenario: model.Scenario, borrow value: Comparison) -> StrB
             text.append_literal(inout out, ")");
         }
         out.push(10);
-        i = i + 1;
+        i += 1;
     }
     text.append_literal(inout out, "total_added_weight="); text.append_u64(inout out, value.total_added_weight);
     text.append_literal(inout out, " digest="); text.append_u64(inout out, value.digest); out.push(10);

--- a/examples/harbor/scenario_json.rue
+++ b/examples/harbor/scenario_json.rue
@@ -49,7 +49,7 @@ fn locations(inout out: StrBuf, borrow scenario: model.Scenario) {
         number(inout out, inout first, "handling", item.handling);
         signed(inout out, inout first, "x", item.x);
         signed(inout out, inout first, "y", item.y);
-        out.push(125); i = i + 1;
+        out.push(125); i += 1;
     }
     out.push(93);
 }
@@ -68,7 +68,7 @@ fn routes(inout out: StrBuf, borrow scenario: model.Scenario) {
         number(inout out, inout first, "cost", item.cost);
         number(inout out, inout first, "travel", item.travel);
         boolean(inout out, inout first, "bidirectional", item.bidirectional);
-        out.push(125); i = i + 1;
+        out.push(125); i += 1;
     }
     out.push(93);
 }
@@ -84,7 +84,7 @@ fn cargoes(inout out: StrBuf, borrow scenario: model.Scenario) {
         number(inout out, inout first, "unit_value", item.unit_value);
         number(inout out, inout first, "shelf_life", item.shelf_life);
         number(inout out, inout first, "weight", item.weight);
-        out.push(125); i = i + 1;
+        out.push(125); i += 1;
     }
     out.push(93);
 }
@@ -102,7 +102,7 @@ fn vehicles(inout out: StrBuf, borrow scenario: model.Scenario) {
         number(inout out, inout first, "speed", item.speed);
         number(inout out, inout first, "cost", item.cost);
         number(inout out, inout first, "available", item.available);
-        out.push(125); i = i + 1;
+        out.push(125); i += 1;
     }
     out.push(93);
 }
@@ -118,7 +118,7 @@ fn supplies(inout out: StrBuf, borrow scenario: model.Scenario) {
         id(inout out, inout first, borrow scenario, "cargo", item.cargo_id);
         number(inout out, inout first, "quantity", item.quantity);
         number(inout out, inout first, "available", item.available);
-        out.push(125); i = i + 1;
+        out.push(125); i += 1;
     }
     out.push(93);
 }
@@ -135,7 +135,7 @@ fn demands(inout out: StrBuf, borrow scenario: model.Scenario) {
         number(inout out, inout first, "quantity", item.quantity);
         number(inout out, inout first, "deadline", item.deadline);
         number(inout out, inout first, "priority", item.priority);
-        out.push(125); i = i + 1;
+        out.push(125); i += 1;
     }
     out.push(93);
 }
@@ -153,7 +153,7 @@ fn productions(inout out: StrBuf, borrow scenario: model.Scenario) {
         number(inout out, inout first, "every", item.every);
         number(inout out, inout first, "start", item.start);
         number(inout out, inout first, "end", item.end);
-        out.push(125); i = i + 1;
+        out.push(125); i += 1;
     }
     out.push(93);
 }
@@ -170,7 +170,7 @@ fn disruptions(inout out: StrBuf, borrow scenario: model.Scenario) {
         number(inout out, inout first, "end", item.end);
         number(inout out, inout first, "capacity_percent", item.capacity_percent);
         number(inout out, inout first, "cost_percent", item.cost_percent);
-        out.push(125); i = i + 1;
+        out.push(125); i += 1;
     }
     out.push(93);
 }

--- a/examples/harbor/scorecard.rue
+++ b/examples/harbor/scorecard.rue
@@ -109,11 +109,11 @@ pub fn calculate(borrow scenario: model.Scenario, borrow sim: state.State) -> Sc
     let financial = financial_score(borrow ledger);
     let total = (service * 25 + punctuality * 20 + efficiency * 15 + resilience * 15 + integrity * 15 + financial * 10) / 100;
     let mut warnings: u64 = 0;
-    if demands.unmet > 0 { warnings = warnings + 1; }
-    if resilient.worst_unreachable_pairs > 0 { warnings = warnings + 1; }
-    if inventory.underflows > 0 { warnings = warnings + 1; }
-    if ledger.profit < 0 { warnings = warnings + 1; }
-    if integrity < 100 { warnings = warnings + 1; }
+    if demands.unmet > 0 { warnings += 1; }
+    if resilient.worst_unreachable_pairs > 0 { warnings += 1; }
+    if inventory.underflows > 0 { warnings += 1; }
+    if ledger.profit < 0 { warnings += 1; }
+    if integrity < 100 { warnings += 1; }
     Score {
         service: service, punctuality: punctuality, efficiency: efficiency,
         resilience: resilience, integrity: integrity, financial: financial,

--- a/examples/harbor/selftest.rue
+++ b/examples/harbor/selftest.rue
@@ -37,9 +37,9 @@ pub struct Result {
 }
 
 fn record(inout result: Result, condition: bool) {
-    result.checks = result.checks + 1;
+    result.checks += 1;
     if !condition {
-        result.failures = result.failures + 1;
+        result.failures += 1;
         result.last_failed_check = result.checks;
     }
 }
@@ -48,7 +48,7 @@ fn mix(value: u64, next: u64) -> u64 { @wrapping_mul(value ^ next, 1099511628211
 
 fn run_one(inout result: Result, config: stress.Config) {
     let scenario = stress.generate(config);
-    result.scenarios = result.scenarios + 1;
+    result.scenarios += 1;
     record(inout result, scenario.diagnostics.len() == 0);
     record(inout result, scenario.locations.len() >= 4);
     record(inout result, scenario.routes.len() >= scenario.locations.len());
@@ -81,14 +81,14 @@ fn run_one(inout result: Result, config: stress.Config) {
         record(inout result, route_matrix.weight(borrow cost_matrix, i, i) == 0);
         record(inout result, route_matrix.travel(borrow time_matrix, i, i) == 0);
         record(inout result, route_matrix.distance(borrow distance_matrix, i, i) == 0);
-        i = i + 1;
+        i += 1;
     }
 
     let projection = forecast.summarize(borrow scenario);
     record(inout result, projection.cargoes.len() == scenario.cargoes.len());
     let first = simulate.run(borrow scenario);
-    result.simulations = result.simulations + 1;
-    result.events = result.events + first.log.len();
+    result.simulations += 1;
+    result.events += first.log.len();
     let balance = conservation.audit(borrow scenario, borrow first);
     let replayed = replay.audit(borrow scenario, borrow first);
     let served = service.summarize(borrow scenario, borrow first);
@@ -120,8 +120,8 @@ fn run_one(inout result: Result, config: stress.Config) {
     result.digest = mix(result.digest, first_hash);
 
     let second = simulate.run(borrow scenario);
-    result.simulations = result.simulations + 1;
-    result.events = result.events + second.log.len();
+    result.simulations += 1;
+    result.events += second.log.len();
     let second_hash = fingerprint.simulation(borrow second);
     record(inout result, first_hash == second_hash);
     record(inout result, first.log.len() == second.log.len());

--- a/examples/harbor/sensitivity_analysis.rue
+++ b/examples/harbor/sensitivity_analysis.rue
@@ -85,7 +85,7 @@ fn compare_pair(
     let before = route_matrix.weight(borrow baseline, from, to);
     let after = route_matrix.weight(borrow candidate, from, to);
     if before != after {
-        changed = changed + 1;
+        changed += 1;
         if before != routing.INF() && after == routing.INF() {
             total_penalty = add(total_penalty, baseline.diameter + 1);
         } else {
@@ -112,9 +112,9 @@ fn make_cell(
             if from != to {
                 compare_pair(borrow baseline, borrow cost, from, to, inout changed, inout total_penalty);
             }
-            to = to + 1;
+            to += 1;
         }
-        from = from + 1;
+        from += 1;
     }
     Cell {
         hour: at, minimum_capacity: capacity,
@@ -158,9 +158,9 @@ pub fn run(borrow scenario: model.Scenario) -> Analysis {
             digest = mix(digest, cell.changed_from_baseline);
             digest = mix(digest, cell.total_penalty);
             cells.push(cell);
-            threshold_index = threshold_index + 1;
+            threshold_index += 1;
         }
-        hour_index = hour_index + 1;
+        hour_index += 1;
     }
     Analysis {
         cells: cells, hours: 5, thresholds: 5,
@@ -200,7 +200,7 @@ pub fn render(borrow value: Analysis) -> StrBuf {
         text.append_u64(inout out, cell.diameter); out.push(32);
         text.append_u64(inout out, cell.changed_from_baseline); out.push(32);
         text.append_u64(inout out, cell.total_penalty); out.push(10);
-        i = i + 1;
+        i += 1;
     }
     text.append_literal(inout out, "most_sensitive_hour="); text.append_u64(inout out, value.most_sensitive_hour);
     text.append_literal(inout out, " capacity="); text.append_u64(inout out, value.most_sensitive_capacity);

--- a/examples/harbor/service.rue
+++ b/examples/harbor/service.rue
@@ -60,7 +60,7 @@ fn arrivals_for(borrow scenario: model.Scenario, borrow sim: state.State, demand
             if event.time < first { first = event.time; }
             if event.time > last { last = event.time; }
         }
-        i = i + 1;
+        i += 1;
     }
     let unmet = if delivered < demand.quantity { demand.quantity - delivered } else { 0 };
     DemandService {
@@ -95,7 +95,7 @@ pub fn summarize(borrow scenario: model.Scenario, borrow sim: state.State) -> Su
         if item.unmet == 0 { complete_demands = complete_demands + 1; }
         if item.unmet == 0 && item.late == 0 { on_time_demands = on_time_demands + 1; }
         demands.push(item);
-        i = i + 1;
+        i += 1;
     }
     Summary {
         demands: demands, requested: requested, delivered: delivered,
@@ -121,7 +121,7 @@ pub fn cargo_totals(borrow scenario: model.Scenario, borrow sim: state.State, ca
             on_time = add(on_time, item.on_time);
             unmet = add(unmet, item.unmet);
         }
-        i = i + 1;
+        i += 1;
     }
     totals.push(requested);
     totals.push(delivered);

--- a/examples/harbor/service.rue
+++ b/examples/harbor/service.rue
@@ -92,8 +92,8 @@ pub fn summarize(borrow scenario: model.Scenario, borrow sim: state.State) -> Su
         unmet = add(unmet, item.unmet);
         weighted_requested = add(weighted_requested, item.weighted_requested);
         weighted_delivered = add(weighted_delivered, item.weighted_delivered);
-        if item.unmet == 0 { complete_demands = complete_demands + 1; }
-        if item.unmet == 0 && item.late == 0 { on_time_demands = on_time_demands + 1; }
+        if item.unmet == 0 { complete_demands += 1; }
+        if item.unmet == 0 && item.late == 0 { on_time_demands += 1; }
         demands.push(item);
         i += 1;
     }

--- a/examples/harbor/shipment_manifest.rue
+++ b/examples/harbor/shipment_manifest.rue
@@ -73,7 +73,7 @@ fn find_arrival(borrow sim: state.State, departure_index: u64, borrow departure:
     while i < sim.log.len() {
         let candidate = sim.log.get_or(i, state.empty_event());
         if is_same_shipment(borrow departure, borrow candidate) { return i; }
-        i = i + 1;
+        i += 1;
     }
     model.NONE()
 }
@@ -128,10 +128,10 @@ pub fn build(borrow scenario: model.Scenario, borrow sim: state.State) -> Manife
         let event = sim.log.get_or(i, state.empty_event());
         if event.tag == state.EVENT_ARRIVAL() { arrivals = arrivals + 1; }
         if event.tag == state.EVENT_DEPARTURE() {
-            departures = departures + 1;
+            departures += 1;
             let item = from_departure(borrow scenario, borrow sim, i, event);
             if item.matched {
-                matched = matched + 1;
+                matched += 1;
                 if item.on_time { on_time = on_time + 1; } else { late = late + 1; }
                 if item.arrive < item.depart { ordering_errors = ordering_errors + 1; }
             } else { unmatched = unmatched + 1; }
@@ -144,7 +144,7 @@ pub fn build(borrow scenario: model.Scenario, borrow sim: state.State) -> Manife
             digest = mix(digest, item.quantity); digest = mix(digest, item.arrive);
             shipments.push(item);
         }
-        i = i + 1;
+        i += 1;
     }
     Manifest {
         shipments: shipments, departures: departures, arrivals: arrivals,

--- a/examples/harbor/shipment_manifest.rue
+++ b/examples/harbor/shipment_manifest.rue
@@ -126,15 +126,15 @@ pub fn build(borrow scenario: model.Scenario, borrow sim: state.State) -> Manife
     let mut i: u64 = 0;
     while i < sim.log.len() {
         let event = sim.log.get_or(i, state.empty_event());
-        if event.tag == state.EVENT_ARRIVAL() { arrivals = arrivals + 1; }
+        if event.tag == state.EVENT_ARRIVAL() { arrivals += 1; }
         if event.tag == state.EVENT_DEPARTURE() {
             departures += 1;
             let item = from_departure(borrow scenario, borrow sim, i, event);
             if item.matched {
                 matched += 1;
-                if item.on_time { on_time = on_time + 1; } else { late = late + 1; }
-                if item.arrive < item.depart { ordering_errors = ordering_errors + 1; }
-            } else { unmatched = unmatched + 1; }
+                if item.on_time { on_time += 1; } else { late += 1; }
+                if item.arrive < item.depart { ordering_errors += 1; }
+            } else { unmatched += 1; }
             cargo_units = add(cargo_units, item.quantity);
             total_cost = add(total_cost, item.cost);
             total_distance = add(total_distance, item.distance);
@@ -207,7 +207,7 @@ pub fn render(borrow scenario: model.Scenario, borrow value: Manifest) -> StrBuf
         if !item.matched { text.append_literal(inout out, "unmatched"); }
         else if item.on_time { text.append_literal(inout out, "on-time"); }
         else { text.append_literal(inout out, "late"); }
-        out.push(10); i = i + 1;
+        out.push(10); i += 1;
     }
     text.append_literal(inout out, "cargo_units="); text.append_u64(inout out, value.cargo_units);
     text.append_literal(inout out, " total_cost="); text.append_u64(inout out, value.total_cost);

--- a/examples/harbor/simulate.rue
+++ b/examples/harbor/simulate.rue
@@ -54,7 +54,7 @@ fn apply_sources(borrow scenario: model.Scenario, inout sim: state.State, now: u
         if source.available == now {
             record_source(borrow scenario, inout sim, state.EVENT_SUPPLY(), source.location, source.cargo, source.quantity, now, false);
         }
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < scenario.productions.len() {
@@ -62,7 +62,7 @@ fn apply_sources(borrow scenario: model.Scenario, inout sim: state.State, now: u
         if source.every > 0 && now >= source.start && now <= source.end && (now - source.start) % source.every == 0 {
             record_source(borrow scenario, inout sim, state.EVENT_PRODUCTION(), source.location, source.cargo, source.quantity, now, true);
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -72,7 +72,7 @@ fn apply_arrival(inout sim: state.State, event: state.Event) {
     let mut actual = event;
     actual.quantity = delivered;
     state.log(inout sim, actual);
-    sim.arrivals = sim.arrivals + 1;
+    sim.arrivals += 1;
 }
 
 fn process_arrivals(inout sim: state.State, inout queue: EventQueue, now: u64) {
@@ -115,7 +115,7 @@ fn dispatch(
             demand: model.NONE(), cost: decision.reposition_cost,
             distance: decision.reposition_distance, travel: decision.reposition_travel,
         });
-        sim.repositions = sim.repositions + 1;
+        sim.repositions += 1;
     }
     state.log(inout sim, state.Event {
         tag: state.EVENT_DEPARTURE(), time: decision.depart,
@@ -134,7 +134,7 @@ fn dispatch(
     sim.vehicle_available.set(decision.vehicle, decision.arrival);
     state.mark_transit(inout sim, decision.cargo, reserved);
     state.add_vehicle_work(inout sim, decision.vehicle, planner.decision_distance(borrow decision), planner.decision_cost(borrow decision));
-    sim.dispatches = sim.dispatches + 1;
+    sim.dispatches += 1;
     true
 }
 
@@ -146,7 +146,7 @@ fn rank_demands(borrow scenario: model.Scenario, borrow sim: state.State, now: u
         if state.demand_open(borrow sim, i) > 0 && now <= demand.deadline {
             queue.push(demand_rank(demand), i);
         }
-        i = i + 1;
+        i += 1;
     }
     queue
 }
@@ -174,7 +174,7 @@ fn plan_hour(
                 }
             }
         }
-        attempts = attempts + 1;
+        attempts += 1;
     }
 }
 
@@ -190,7 +190,7 @@ fn mark_unmet(borrow scenario: model.Scenario, inout sim: state.State) {
                 to: demand.location, demand: i, cost: 0, distance: 0, travel: 0,
             });
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -203,7 +203,7 @@ pub fn run(borrow scenario: model.Scenario) -> state.State {
         process_arrivals(inout sim, inout events, now);
         apply_sources(borrow scenario, inout sim, now);
         if now < scenario.duration { plan_hour(borrow scenario, inout sim, inout events, now); }
-        now = now + 1;
+        now += 1;
     }
     mark_unmet(borrow scenario, inout sim);
     sim

--- a/examples/harbor/state.rue
+++ b/examples/harbor/state.rue
@@ -96,7 +96,7 @@ pub fn new(borrow scenario: model.Scenario) -> State {
     while i < scenario.demands.len() {
         let demand = scenario.demands.get_or(i, model.empty_demand());
         demand_remaining.set(i, demand.quantity);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < scenario.vehicles.len() {
@@ -105,7 +105,7 @@ pub fn new(borrow scenario: model.Scenario) -> State {
         vehicle_available.push(vehicle.available);
         vehicle_distance.push(0);
         vehicle_cost.push(0);
-        i = i + 1;
+        i += 1;
     }
     State {
         now: 0,
@@ -155,7 +155,7 @@ pub fn inventory_add(
     let mut c: u64 = 0;
     while c < scenario.cargoes.len() {
         total_at_location = saturating_add(total_at_location, inventory_get(borrow scenario, borrow value, location, c));
-        c = c + 1;
+        c += 1;
     }
     let room = if total_at_location >= location_record.capacity { 0 } else { location_record.capacity - total_at_location };
     let accepted = if quantity < room { quantity } else { room };
@@ -183,7 +183,7 @@ pub fn cargo_total_inventory(borrow scenario: model.Scenario, borrow value: Stat
     let mut location: u64 = 0;
     while location < scenario.locations.len() {
         total = saturating_add(total, inventory_get(borrow scenario, borrow value, location, cargo));
-        location = location + 1;
+        location += 1;
     }
     total
 }

--- a/examples/harbor/state.rue
+++ b/examples/harbor/state.rue
@@ -62,7 +62,7 @@ pub fn empty_event() -> Event {
 
 fn fill(inout values: U64s, count: u64, value: u64) {
     let mut i: u64 = 0;
-    while i < count { values.push(value); i = i + 1; }
+    while i < count { values.push(value); i += 1; }
 }
 
 fn saturating_add(a: u64, b: u64) -> u64 {

--- a/examples/harbor/stress.rue
+++ b/examples/harbor/stress.rue
@@ -88,7 +88,7 @@ fn add_locations(inout scenario: model.Scenario, count: u64) {
             handling: 200 + (i % 5) * 40,
             x: @intCast((i % 8) * 11), y: @intCast((i / 8) * 13),
         });
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -108,7 +108,7 @@ fn add_routes(inout scenario: model.Scenario, count: u64) {
     let mut i: u64 = 0;
     while i < count {
         push_route(inout scenario, i, (i + 1) % count, i * 3 + 1, true);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < count {
@@ -116,12 +116,12 @@ fn add_routes(inout scenario: model.Scenario, count: u64) {
         if across != i && across != (i + 1) % count {
             push_route(inout scenario, i, across, i * 7 + 2, i % 2 == 0);
         }
-        i = i + 2;
+        i += 2;
     }
     i = 1;
     while i + 3 < count {
         push_route(inout scenario, i, i + 3, i * 11 + 3, true);
-        i = i + 3;
+        i += 3;
     }
 }
 
@@ -134,7 +134,7 @@ fn add_cargoes(inout scenario: model.Scenario, count: u64) {
             id: id, unit_value: 4 + (i % 11), shelf_life: 12 + (i % 5) * 12,
             weight: 1 + (i % 4),
         });
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -149,7 +149,7 @@ fn add_vehicles(inout scenario: model.Scenario, count: u64) {
             id: id, at_id: location.id, at: at, capacity: 25 + (i % 5) * 10,
             speed: 1 + (i % 3), cost: 1 + (i % 4), available: i % 3,
         });
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -171,7 +171,7 @@ fn add_supplies(inout scenario: model.Scenario) {
             location: second_location, cargo: cargo,
             quantity: 180 + cargo * 20, available: 6 + cargo % 5,
         });
-        cargo = cargo + 1;
+        cargo += 1;
     }
 }
 
@@ -189,7 +189,7 @@ fn add_demands(inout scenario: model.Scenario, count: u64) {
             deadline: 4 + (i * 3) % (scenario.duration - 4),
             priority: 1 + (i % 5),
         });
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -205,7 +205,7 @@ fn add_production(inout scenario: model.Scenario) {
             quantity: 10 + (cargo % 5) * 3, every: 6 + cargo % 4,
             start: 3 + cargo % 3, end: scenario.duration - 1,
         });
-        cargo = cargo + 2;
+        cargo += 2;
     }
 }
 
@@ -220,7 +220,7 @@ fn add_disruptions(inout scenario: model.Scenario) {
                 cost_percent: 110 + route % 90,
             });
         }
-        route = route + 1;
+        route += 1;
     }
 }
 

--- a/examples/harbor/text.rue
+++ b/examples/harbor/text.rue
@@ -12,7 +12,7 @@ pub fn append_string(inout out: StrBuf, borrow value: StrBuf) {
     let mut i: u64 = 0;
     while i < value.len() {
         out.push(StrBuf.byte_at_borrowed(borrow value, i));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -64,9 +64,9 @@ pub fn fnv1a(borrow value: StrBuf) -> u64 {
     let mut hash: u64 = 14695981039346656037;
     let mut i: u64 = 0;
     while i < value.len() {
-        hash = hash ^ @intCast(StrBuf.byte_at_borrowed(borrow value, i));
+        hash ^= @intCast(StrBuf.byte_at_borrowed(borrow value, i));
         hash = @wrapping_mul(hash, 1099511628211);
-        i = i + 1;
+        i += 1;
     }
     hash
 }
@@ -89,7 +89,7 @@ pub fn append_json_string(inout out: StrBuf, borrow value: StrBuf) {
             out.push(StrBuf.byte_at_borrowed(borrow digits, @intCast(b >> 4)));
             out.push(StrBuf.byte_at_borrowed(borrow digits, @intCast(b & 15)));
         } else { out.push(b); }
-        i = i + 1;
+        i += 1;
     }
     out.push(34);
 }

--- a/examples/harbor/text.rue
+++ b/examples/harbor/text.rue
@@ -5,7 +5,7 @@ const StrBuf = std.strbuf.StrBuf;
 
 pub fn append_literal(inout out: StrBuf, value: str) {
     let mut i: u64 = 0;
-    while i < value.len() { out.push(value[i]); i = i + 1; }
+    while i < value.len() { out.push(value[i]); i += 1; }
 }
 
 pub fn append_string(inout out: StrBuf, borrow value: StrBuf) {
@@ -56,7 +56,7 @@ pub fn heading(inout out: StrBuf, title: str) {
     append_literal(inout out, title);
     out.push(10);
     let mut i: u64 = 0;
-    while i < title.len() { out.push(45); i = i + 1; }
+    while i < title.len() { out.push(45); i += 1; }
     out.push(10);
 }
 

--- a/examples/harbor/timeline_report.rue
+++ b/examples/harbor/timeline_report.rue
@@ -44,7 +44,7 @@ fn cargo_forecast(inout out: StrBuf, borrow scenario: model.Scenario, cargo: u64
         text.append_u64(inout out, value.cumulative_supply); out.push(44);
         text.append_u64(inout out, value.cumulative_demand); out.push(44);
         text.append_i64(inout out, value.net); out.push(10);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -59,7 +59,7 @@ pub fn render(borrow scenario: model.Scenario, borrow sim: state.State) -> StrBu
             arrivals: 0, repositions: 0, expired: 0, unmet: 0,
             outbound_units: 0, inbound_units: 0, cost: 0, distance: 0,
         }));
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < scenario.cargoes.len() { cargo_forecast(inout out, borrow scenario, i); i = i + 1; }

--- a/examples/harbor/timeline_report.rue
+++ b/examples/harbor/timeline_report.rue
@@ -62,6 +62,6 @@ pub fn render(borrow scenario: model.Scenario, borrow sim: state.State) -> StrBu
         i += 1;
     }
     i = 0;
-    while i < scenario.cargoes.len() { cargo_forecast(inout out, borrow scenario, i); i = i + 1; }
+    while i < scenario.cargoes.len() { cargo_forecast(inout out, borrow scenario, i); i += 1; }
     out
 }

--- a/examples/harbor/utilization.rue
+++ b/examples/harbor/utilization.rue
@@ -102,8 +102,8 @@ pub fn summarize(borrow scenario: model.Scenario, borrow sim: state.State) -> Su
     let mut i: u64 = 0;
     while i < scenario.vehicles.len() {
         let item = one(borrow scenario, borrow sim, i);
-        if item.dispatches > 0 || item.repositions > 0 { active_vehicles = active_vehicles + 1; }
-        else { idle_vehicles = idle_vehicles + 1; }
+        if item.dispatches > 0 || item.repositions > 0 { active_vehicles += 1; }
+        else { idle_vehicles += 1; }
         dispatches = add(dispatches, item.dispatches);
         cargo_units = add(cargo_units, item.cargo_units);
         loaded_distance = add(loaded_distance, item.loaded_distance);

--- a/examples/harbor/utilization.rue
+++ b/examples/harbor/utilization.rue
@@ -60,13 +60,13 @@ fn one(borrow scenario: model.Scenario, borrow sim: state.State, vehicle_index: 
         let event = sim.log.get_or(i, state.empty_event());
         if event.vehicle == vehicle_index {
             if event.tag == state.EVENT_REPOSITION() {
-                repositions = repositions + 1;
+                repositions += 1;
                 empty_distance = add(empty_distance, event.distance);
                 travel_time = add(travel_time, event.travel);
                 operating_cost = add(operating_cost, event.cost);
                 busy_until = if add(event.time, event.travel) > busy_until { add(event.time, event.travel) } else { busy_until };
             } else if event.tag == state.EVENT_DEPARTURE() {
-                dispatches = dispatches + 1;
+                dispatches += 1;
                 cargo_units = add(cargo_units, event.quantity);
                 loaded_distance = add(loaded_distance, event.distance);
                 travel_time = add(travel_time, event.travel);
@@ -76,7 +76,7 @@ fn one(borrow scenario: model.Scenario, borrow sim: state.State, vehicle_index: 
                 busy_until = if add(event.time, event.travel) > busy_until { add(event.time, event.travel) } else { busy_until };
             }
         }
-        i = i + 1;
+        i += 1;
     }
     VehicleUse {
         vehicle: vehicle_index, dispatches: dispatches, repositions: repositions,
@@ -112,7 +112,7 @@ pub fn summarize(borrow scenario: model.Scenario, borrow sim: state.State) -> Su
         fill_numerator = add(fill_numerator, item.fill_numerator);
         fill_denominator = add(fill_denominator, item.fill_denominator);
         vehicles.push(item);
-        i = i + 1;
+        i += 1;
     }
     Summary {
         vehicles: vehicles, active_vehicles: active_vehicles, idle_vehicles: idle_vehicles,

--- a/examples/harbor/validate.rue
+++ b/examples/harbor/validate.rue
@@ -52,7 +52,7 @@ fn location_index(inout scenario: model.Scenario) -> IdMap {
         if model.location_kind(borrow scenario, v.kind) == 0 { error(inout scenario, 202, v.id, "kind must be port, hub, factory, or market"); }
         if v.capacity == 0 { error(inout scenario, 202, v.id, "location capacity must be positive"); }
         if v.handling == 0 { error(inout scenario, 202, v.id, "handling capacity must be positive"); }
-        i = i + 1;
+        i += 1;
     }
     map
 }
@@ -65,7 +65,7 @@ fn cargo_index(inout scenario: model.Scenario) -> IdMap {
         duplicate(inout scenario, inout map, v.id, i);
         if v.id >= scenario.strings.len() || scenario.strings.string_len(v.id) == 0 { error(inout scenario, 101, v.id, "cargo id is required"); }
         if v.weight == 0 { error(inout scenario, 202, v.id, "cargo weight must be positive"); }
-        i = i + 1;
+        i += 1;
     }
     map
 }
@@ -80,7 +80,7 @@ fn check_vehicle_ids(inout scenario: model.Scenario) {
         if v.capacity == 0 { error(inout scenario, 202, v.id, "vehicle capacity must be positive"); }
         if v.speed == 0 { error(inout scenario, 202, v.id, "vehicle speed must be positive"); }
         if v.available > scenario.duration { error(inout scenario, 202, v.id, "vehicle availability exceeds duration"); }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -97,7 +97,7 @@ fn routes(inout scenario: model.Scenario, borrow locations: IdMap) {
         if v.capacity == 0 { error(inout scenario, 202, v.from_id, "route capacity must be positive"); }
         if v.travel == 0 { error(inout scenario, 202, v.from_id, "route travel time must be positive"); }
         scenario.routes.set(i, v);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < scenario.routes.len() {
@@ -108,9 +108,9 @@ fn routes(inout scenario: model.Scenario, borrow locations: IdMap) {
             if a.from < scenario.locations.len() && a.to < scenario.locations.len() && a.from == b.from && a.to == b.to {
                 error(inout scenario, 200, a.from_id, "duplicate directed route");
             }
-            j = j + 1;
+            j += 1;
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -121,7 +121,7 @@ fn vehicles(inout scenario: model.Scenario, borrow locations: IdMap) {
         v.at = lookup(borrow scenario, borrow locations, v.at_id);
         if v.at == model.NONE() { error(inout scenario, 201, v.id, "vehicle location does not exist"); }
         scenario.vehicles.set(i, v);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -136,7 +136,7 @@ fn supplies(inout scenario: model.Scenario, borrow locations: IdMap, borrow carg
         if v.quantity == 0 { error(inout scenario, 202, v.cargo_id, "supply quantity must be positive"); }
         if v.available > scenario.duration { error(inout scenario, 202, v.cargo_id, "supply availability exceeds duration"); }
         scenario.supplies.set(i, v);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -152,7 +152,7 @@ fn demands(inout scenario: model.Scenario, borrow locations: IdMap, borrow cargo
         if v.deadline == 0 || v.deadline > scenario.duration { error(inout scenario, 202, v.cargo_id, "demand deadline must be within duration"); }
         if v.priority == 0 { error(inout scenario, 202, v.cargo_id, "demand priority must be positive"); }
         scenario.demands.set(i, v);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -168,7 +168,7 @@ fn production(inout scenario: model.Scenario, borrow locations: IdMap, borrow ca
         if v.every == 0 { error(inout scenario, 202, v.cargo_id, "production interval must be positive"); }
         if v.start > v.end || v.end > scenario.duration { error(inout scenario, 202, v.cargo_id, "production window is invalid"); }
         scenario.productions.set(i, v);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -180,7 +180,7 @@ fn disruptions(inout scenario: model.Scenario) {
         if v.start >= v.end || v.end > scenario.duration { model.add_error(inout scenario, 202, "disruption", "time window is invalid"); }
         if v.capacity_percent > 100 { model.add_error(inout scenario, 202, "disruption", "capacity_percent must be at most 100"); }
         if v.cost_percent == 0 || v.cost_percent > 10000 { model.add_error(inout scenario, 202, "disruption", "cost_percent must be in 1..10000"); }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -199,7 +199,7 @@ fn connected(inout scenario: model.Scenario) {
             if route.from == at { next = route.to; }
             else if route.to == at { next = route.from; }
             if next < scenario.locations.len() && !seen.test(next) { seen.set(next); queue.enqueue(next); }
-            i = i + 1;
+            i += 1;
         }
     }
     if seen.count() != scenario.locations.len() { model.add_error(inout scenario, 203, "network", "location graph is not weakly connected"); }

--- a/examples/harbor/workload.rue
+++ b/examples/harbor/workload.rue
@@ -126,10 +126,10 @@ pub fn run(max_tier: u64, repetitions: u64) -> Suite {
             digest = mix(digest, next.scenario_fingerprint);
             digest = mix(digest, next.simulation_fingerprint);
             samples.push(next);
-            repetition = repetition + 1;
+            repetition += 1;
         }
         samples.push(baseline);
-        tier_value = tier_value + 1;
+        tier_value += 1;
     }
     Suite {
         samples: samples, repetitions: repeat_count, tiers: tier_count,
@@ -150,7 +150,7 @@ fn tier_baseline(borrow suite: Suite, tier_value: u64) -> Sample {
     while i < suite.samples.len() {
         let item = suite.samples.get_or(i, empty_sample());
         if item.tier == tier_value && item.repetition == 0 { return item; }
-        i = i + 1;
+        i += 1;
     }
     empty_sample()
 }
@@ -177,7 +177,7 @@ pub fn render(borrow suite: Suite) -> StrBuf {
         text.append_u64(inout out, item.dispatches); out.push(32);
         text.append_u64(inout out, item.work_units); out.push(32);
         text.append_u64(inout out, ratio(item.work_units, first.work_units)); out.push(10);
-        tier_value = tier_value + 1;
+        tier_value += 1;
     }
     text.append_literal(inout out, "total_route_pairs="); text.append_u64(inout out, suite.route_pairs);
     text.append_literal(inout out, " total_events="); text.append_u64(inout out, suite.events);

--- a/examples/harbor/workload.rue
+++ b/examples/harbor/workload.rue
@@ -111,7 +111,7 @@ pub fn run(max_tier: u64, repetitions: u64) -> Suite {
         events = add(events, baseline.events);
         dispatches = add(dispatches, baseline.dispatches);
         work_units = add(work_units, baseline.work_units);
-        if !baseline.ok { failures = failures + 1; }
+        if !baseline.ok { failures += 1; }
         digest = mix(digest, baseline.scenario_fingerprint);
         digest = mix(digest, baseline.simulation_fingerprint);
         let mut repetition: u64 = 1;
@@ -121,8 +121,8 @@ pub fn run(max_tier: u64, repetitions: u64) -> Suite {
             events = add(events, next.events);
             dispatches = add(dispatches, next.dispatches);
             work_units = add(work_units, next.work_units);
-            if !next.ok { failures = failures + 1; }
-            if !same_result(borrow baseline, borrow next) { nondeterministic = nondeterministic + 1; }
+            if !next.ok { failures += 1; }
+            if !same_result(borrow baseline, borrow next) { nondeterministic += 1; }
             digest = mix(digest, next.scenario_fingerprint);
             digest = mix(digest, next.simulation_fingerprint);
             samples.push(next);

--- a/examples/hashmap/main.rue
+++ b/examples/hashmap/main.rue
@@ -8,21 +8,21 @@ fn main() -> i32 {
     let mut k: i64 = 0;
     while k < 200 {
         m.insert(k * 7 - 300, k * k);
-        k = k + 1;
+        k += 1;
     }
     @assert(m.len() == 200, "len after inserts");
     // Overwrite half
     k = 0;
     while k < 100 {
         m.insert(k * 7 - 300, k);
-        k = k + 1;
+        k += 1;
     }
     @assert(m.len() == 200, "len after overwrites");
     // Remove a third
     k = 0;
     while k < 66 {
         m.remove(k * 3 * 7 - 300);
-        k = k + 1;
+        k += 1;
     }
     // Spot checks
     match m.get(0 - 300) {

--- a/examples/hashmap/map.rue
+++ b/examples/hashmap/map.rue
@@ -51,7 +51,7 @@ pub struct Map {
                 i = (i + 1) % self.cap;
             } else {
                 // empty or tombstone: claim it
-                if s == 0 { self.used = self.used + 1; }
+                if s == 0 { self.used += 1; }
                 self.keys.set(i, key);
                 self.vals.set(i, val);
                 self.state.set(i, 1);

--- a/examples/hashmap/map.rue
+++ b/examples/hashmap/map.rue
@@ -22,7 +22,7 @@ pub struct Map {
             keys.push(0);
             vals.push(0);
             state.push(0);
-            i = i + 1;
+            i += 1;
         }
         Self { keys: keys, vals: vals, state: state, live: 0, used: 0, cap: cap }
     }
@@ -55,7 +55,7 @@ pub struct Map {
                 self.keys.set(i, key);
                 self.vals.set(i, val);
                 self.state.set(i, 1);
-                self.live = self.live + 1;
+                self.live += 1;
                 break;
             }
         }
@@ -73,7 +73,7 @@ pub struct Map {
                 }
             }
             i = (i + 1) % self.cap;
-            probes = probes + 1;
+            probes += 1;
         }
         OptI64.None
     }
@@ -95,13 +95,13 @@ pub struct Map {
             if s == 1 {
                 if self.keys.get_or(i, 0) == key {
                     self.state.set(i, 2);   // tombstone
-                    self.live = self.live - 1;
+                    self.live -= 1;
                     removed = true;
                     break;
                 }
             }
             i = (i + 1) % self.cap;
-            probes = probes + 1;
+            probes += 1;
         }
         removed
     }
@@ -116,7 +116,7 @@ pub struct Map {
             if self.state.get_or(j, 0) == 1 {
                 bigger.insert(self.keys.get_or(j, 0), self.vals.get_or(j, 0));
             }
-            j = j + 1;
+            j += 1;
         }
         // Field-by-field move of the local into self: each assignment
         // overwrite-drops the old buffer and partially moves `bigger`.

--- a/examples/lattice/analysis_cache_coverage.rue
+++ b/examples/lattice/analysis_cache_coverage.rue
@@ -61,7 +61,7 @@ fn observe_tasks(inout result: metric.Metric, borrow workflow: model.Workflow) {
         let task = workflow.tasks.get_or(i, model.empty_task());
         metric.observe(inout result, value, task.priority + 1);
         metric.warn(inout result, task.duration == 0 || task.cpu == 0 || task.memory == 0);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -72,7 +72,7 @@ fn observe_edges(inout result: metric.Metric, borrow workflow: model.Workflow) {
         let value = edge_projection(borrow workflow, i);
         metric.observe(inout result, value, i + 1);
         metric.warn(inout result, edge.before >= workflow.tasks.len() || edge.after >= workflow.tasks.len());
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -83,7 +83,7 @@ fn observe_pools(inout result: metric.Metric, borrow workflow: model.Workflow) {
         let pool = workflow.pools.get_or(i, model.empty_pool());
         metric.observe(inout result, value, pool.slots + 1);
         metric.warn(inout result, pool.slots == 0 || pool.cpu == 0 || pool.memory == 0);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -95,11 +95,11 @@ fn observe_pairs(inout result: metric.Metric, borrow workflow: model.Workflow) -
         while second < workflow.tasks.len() {
             if related_pair(borrow workflow, first, second) {
                 metric.observe(inout result, pair_projection(borrow workflow, first, second), first + second + 1);
-                pairs = pairs + 1;
+                pairs += 1;
             }
-            second = second + 1;
+            second += 1;
         }
-        first = first + 1;
+        first += 1;
     }
     pairs
 }

--- a/examples/lattice/analysis_cache_risk.rue
+++ b/examples/lattice/analysis_cache_risk.rue
@@ -61,7 +61,7 @@ fn observe_tasks(inout result: metric.Metric, borrow workflow: model.Workflow) {
         let task = workflow.tasks.get_or(i, model.empty_task());
         metric.observe(inout result, value, task.priority + 1);
         metric.warn(inout result, task.duration == 0 || task.cpu == 0 || task.memory == 0);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -72,7 +72,7 @@ fn observe_edges(inout result: metric.Metric, borrow workflow: model.Workflow) {
         let value = edge_projection(borrow workflow, i);
         metric.observe(inout result, value, i + 1);
         metric.warn(inout result, edge.before >= workflow.tasks.len() || edge.after >= workflow.tasks.len());
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -83,7 +83,7 @@ fn observe_pools(inout result: metric.Metric, borrow workflow: model.Workflow) {
         let pool = workflow.pools.get_or(i, model.empty_pool());
         metric.observe(inout result, value, pool.slots + 1);
         metric.warn(inout result, pool.slots == 0 || pool.cpu == 0 || pool.memory == 0);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -95,11 +95,11 @@ fn observe_pairs(inout result: metric.Metric, borrow workflow: model.Workflow) -
         while second < workflow.tasks.len() {
             if related_pair(borrow workflow, first, second) {
                 metric.observe(inout result, pair_projection(borrow workflow, first, second), first + second + 1);
-                pairs = pairs + 1;
+                pairs += 1;
             }
-            second = second + 1;
+            second += 1;
         }
-        first = first + 1;
+        first += 1;
     }
     pairs
 }

--- a/examples/lattice/analysis_cacheable_work.rue
+++ b/examples/lattice/analysis_cacheable_work.rue
@@ -61,7 +61,7 @@ fn observe_tasks(inout result: metric.Metric, borrow workflow: model.Workflow) {
         let task = workflow.tasks.get_or(i, model.empty_task());
         metric.observe(inout result, value, task.priority + 1);
         metric.warn(inout result, task.duration == 0 || task.cpu == 0 || task.memory == 0);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -72,7 +72,7 @@ fn observe_edges(inout result: metric.Metric, borrow workflow: model.Workflow) {
         let value = edge_projection(borrow workflow, i);
         metric.observe(inout result, value, i + 1);
         metric.warn(inout result, edge.before >= workflow.tasks.len() || edge.after >= workflow.tasks.len());
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -83,7 +83,7 @@ fn observe_pools(inout result: metric.Metric, borrow workflow: model.Workflow) {
         let pool = workflow.pools.get_or(i, model.empty_pool());
         metric.observe(inout result, value, pool.slots + 1);
         metric.warn(inout result, pool.slots == 0 || pool.cpu == 0 || pool.memory == 0);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -95,11 +95,11 @@ fn observe_pairs(inout result: metric.Metric, borrow workflow: model.Workflow) -
         while second < workflow.tasks.len() {
             if related_pair(borrow workflow, first, second) {
                 metric.observe(inout result, pair_projection(borrow workflow, first, second), first + second + 1);
-                pairs = pairs + 1;
+                pairs += 1;
             }
-            second = second + 1;
+            second += 1;
         }
-        first = first + 1;
+        first += 1;
     }
     pairs
 }

--- a/examples/lattice/analysis_contention_index.rue
+++ b/examples/lattice/analysis_contention_index.rue
@@ -61,7 +61,7 @@ fn observe_tasks(inout result: metric.Metric, borrow workflow: model.Workflow) {
         let task = workflow.tasks.get_or(i, model.empty_task());
         metric.observe(inout result, value, task.priority + 1);
         metric.warn(inout result, task.duration == 0 || task.cpu == 0 || task.memory == 0);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -72,7 +72,7 @@ fn observe_edges(inout result: metric.Metric, borrow workflow: model.Workflow) {
         let value = edge_projection(borrow workflow, i);
         metric.observe(inout result, value, i + 1);
         metric.warn(inout result, edge.before >= workflow.tasks.len() || edge.after >= workflow.tasks.len());
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -83,7 +83,7 @@ fn observe_pools(inout result: metric.Metric, borrow workflow: model.Workflow) {
         let pool = workflow.pools.get_or(i, model.empty_pool());
         metric.observe(inout result, value, pool.slots + 1);
         metric.warn(inout result, pool.slots == 0 || pool.cpu == 0 || pool.memory == 0);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -95,11 +95,11 @@ fn observe_pairs(inout result: metric.Metric, borrow workflow: model.Workflow) -
         while second < workflow.tasks.len() {
             if related_pair(borrow workflow, first, second) {
                 metric.observe(inout result, pair_projection(borrow workflow, first, second), first + second + 1);
-                pairs = pairs + 1;
+                pairs += 1;
             }
-            second = second + 1;
+            second += 1;
         }
-        first = first + 1;
+        first += 1;
     }
     pairs
 }

--- a/examples/lattice/analysis_cpu_variance_proxy.rue
+++ b/examples/lattice/analysis_cpu_variance_proxy.rue
@@ -61,7 +61,7 @@ fn observe_tasks(inout result: metric.Metric, borrow workflow: model.Workflow) {
         let task = workflow.tasks.get_or(i, model.empty_task());
         metric.observe(inout result, value, task.priority + 1);
         metric.warn(inout result, task.duration == 0 || task.cpu == 0 || task.memory == 0);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -72,7 +72,7 @@ fn observe_edges(inout result: metric.Metric, borrow workflow: model.Workflow) {
         let value = edge_projection(borrow workflow, i);
         metric.observe(inout result, value, i + 1);
         metric.warn(inout result, edge.before >= workflow.tasks.len() || edge.after >= workflow.tasks.len());
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -83,7 +83,7 @@ fn observe_pools(inout result: metric.Metric, borrow workflow: model.Workflow) {
         let pool = workflow.pools.get_or(i, model.empty_pool());
         metric.observe(inout result, value, pool.slots + 1);
         metric.warn(inout result, pool.slots == 0 || pool.cpu == 0 || pool.memory == 0);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -95,11 +95,11 @@ fn observe_pairs(inout result: metric.Metric, borrow workflow: model.Workflow) -
         while second < workflow.tasks.len() {
             if related_pair(borrow workflow, first, second) {
                 metric.observe(inout result, pair_projection(borrow workflow, first, second), first + second + 1);
-                pairs = pairs + 1;
+                pairs += 1;
             }
-            second = second + 1;
+            second += 1;
         }
-        first = first + 1;
+        first += 1;
     }
     pairs
 }

--- a/examples/lattice/analysis_cpu_work.rue
+++ b/examples/lattice/analysis_cpu_work.rue
@@ -61,7 +61,7 @@ fn observe_tasks(inout result: metric.Metric, borrow workflow: model.Workflow) {
         let task = workflow.tasks.get_or(i, model.empty_task());
         metric.observe(inout result, value, task.priority + 1);
         metric.warn(inout result, task.duration == 0 || task.cpu == 0 || task.memory == 0);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -72,7 +72,7 @@ fn observe_edges(inout result: metric.Metric, borrow workflow: model.Workflow) {
         let value = edge_projection(borrow workflow, i);
         metric.observe(inout result, value, i + 1);
         metric.warn(inout result, edge.before >= workflow.tasks.len() || edge.after >= workflow.tasks.len());
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -83,7 +83,7 @@ fn observe_pools(inout result: metric.Metric, borrow workflow: model.Workflow) {
         let pool = workflow.pools.get_or(i, model.empty_pool());
         metric.observe(inout result, value, pool.slots + 1);
         metric.warn(inout result, pool.slots == 0 || pool.cpu == 0 || pool.memory == 0);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -95,11 +95,11 @@ fn observe_pairs(inout result: metric.Metric, borrow workflow: model.Workflow) -
         while second < workflow.tasks.len() {
             if related_pair(borrow workflow, first, second) {
                 metric.observe(inout result, pair_projection(borrow workflow, first, second), first + second + 1);
-                pairs = pairs + 1;
+                pairs += 1;
             }
-            second = second + 1;
+            second += 1;
         }
-        first = first + 1;
+        first += 1;
     }
     pairs
 }

--- a/examples/lattice/analysis_criticality_proxy.rue
+++ b/examples/lattice/analysis_criticality_proxy.rue
@@ -61,7 +61,7 @@ fn observe_tasks(inout result: metric.Metric, borrow workflow: model.Workflow) {
         let task = workflow.tasks.get_or(i, model.empty_task());
         metric.observe(inout result, value, task.priority + 1);
         metric.warn(inout result, task.duration == 0 || task.cpu == 0 || task.memory == 0);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -72,7 +72,7 @@ fn observe_edges(inout result: metric.Metric, borrow workflow: model.Workflow) {
         let value = edge_projection(borrow workflow, i);
         metric.observe(inout result, value, i + 1);
         metric.warn(inout result, edge.before >= workflow.tasks.len() || edge.after >= workflow.tasks.len());
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -83,7 +83,7 @@ fn observe_pools(inout result: metric.Metric, borrow workflow: model.Workflow) {
         let pool = workflow.pools.get_or(i, model.empty_pool());
         metric.observe(inout result, value, pool.slots + 1);
         metric.warn(inout result, pool.slots == 0 || pool.cpu == 0 || pool.memory == 0);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -95,11 +95,11 @@ fn observe_pairs(inout result: metric.Metric, borrow workflow: model.Workflow) -
         while second < workflow.tasks.len() {
             if related_pair(borrow workflow, first, second) {
                 metric.observe(inout result, pair_projection(borrow workflow, first, second), first + second + 1);
-                pairs = pairs + 1;
+                pairs += 1;
             }
-            second = second + 1;
+            second += 1;
         }
-        first = first + 1;
+        first += 1;
     }
     pairs
 }

--- a/examples/lattice/analysis_cross_pool_edges.rue
+++ b/examples/lattice/analysis_cross_pool_edges.rue
@@ -61,7 +61,7 @@ fn observe_tasks(inout result: metric.Metric, borrow workflow: model.Workflow) {
         let task = workflow.tasks.get_or(i, model.empty_task());
         metric.observe(inout result, value, task.priority + 1);
         metric.warn(inout result, task.duration == 0 || task.cpu == 0 || task.memory == 0);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -72,7 +72,7 @@ fn observe_edges(inout result: metric.Metric, borrow workflow: model.Workflow) {
         let value = edge_projection(borrow workflow, i);
         metric.observe(inout result, value, i + 1);
         metric.warn(inout result, edge.before >= workflow.tasks.len() || edge.after >= workflow.tasks.len());
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -83,7 +83,7 @@ fn observe_pools(inout result: metric.Metric, borrow workflow: model.Workflow) {
         let pool = workflow.pools.get_or(i, model.empty_pool());
         metric.observe(inout result, value, pool.slots + 1);
         metric.warn(inout result, pool.slots == 0 || pool.cpu == 0 || pool.memory == 0);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -95,11 +95,11 @@ fn observe_pairs(inout result: metric.Metric, borrow workflow: model.Workflow) -
         while second < workflow.tasks.len() {
             if related_pair(borrow workflow, first, second) {
                 metric.observe(inout result, pair_projection(borrow workflow, first, second), first + second + 1);
-                pairs = pairs + 1;
+                pairs += 1;
             }
-            second = second + 1;
+            second += 1;
         }
-        first = first + 1;
+        first += 1;
     }
     pairs
 }

--- a/examples/lattice/analysis_dependency_density.rue
+++ b/examples/lattice/analysis_dependency_density.rue
@@ -61,7 +61,7 @@ fn observe_tasks(inout result: metric.Metric, borrow workflow: model.Workflow) {
         let task = workflow.tasks.get_or(i, model.empty_task());
         metric.observe(inout result, value, task.priority + 1);
         metric.warn(inout result, task.duration == 0 || task.cpu == 0 || task.memory == 0);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -72,7 +72,7 @@ fn observe_edges(inout result: metric.Metric, borrow workflow: model.Workflow) {
         let value = edge_projection(borrow workflow, i);
         metric.observe(inout result, value, i + 1);
         metric.warn(inout result, edge.before >= workflow.tasks.len() || edge.after >= workflow.tasks.len());
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -83,7 +83,7 @@ fn observe_pools(inout result: metric.Metric, borrow workflow: model.Workflow) {
         let pool = workflow.pools.get_or(i, model.empty_pool());
         metric.observe(inout result, value, pool.slots + 1);
         metric.warn(inout result, pool.slots == 0 || pool.cpu == 0 || pool.memory == 0);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -95,11 +95,11 @@ fn observe_pairs(inout result: metric.Metric, borrow workflow: model.Workflow) -
         while second < workflow.tasks.len() {
             if related_pair(borrow workflow, first, second) {
                 metric.observe(inout result, pair_projection(borrow workflow, first, second), first + second + 1);
-                pairs = pairs + 1;
+                pairs += 1;
             }
-            second = second + 1;
+            second += 1;
         }
-        first = first + 1;
+        first += 1;
     }
     pairs
 }

--- a/examples/lattice/analysis_dependency_distance.rue
+++ b/examples/lattice/analysis_dependency_distance.rue
@@ -61,7 +61,7 @@ fn observe_tasks(inout result: metric.Metric, borrow workflow: model.Workflow) {
         let task = workflow.tasks.get_or(i, model.empty_task());
         metric.observe(inout result, value, task.priority + 1);
         metric.warn(inout result, task.duration == 0 || task.cpu == 0 || task.memory == 0);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -72,7 +72,7 @@ fn observe_edges(inout result: metric.Metric, borrow workflow: model.Workflow) {
         let value = edge_projection(borrow workflow, i);
         metric.observe(inout result, value, i + 1);
         metric.warn(inout result, edge.before >= workflow.tasks.len() || edge.after >= workflow.tasks.len());
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -83,7 +83,7 @@ fn observe_pools(inout result: metric.Metric, borrow workflow: model.Workflow) {
         let pool = workflow.pools.get_or(i, model.empty_pool());
         metric.observe(inout result, value, pool.slots + 1);
         metric.warn(inout result, pool.slots == 0 || pool.cpu == 0 || pool.memory == 0);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -95,11 +95,11 @@ fn observe_pairs(inout result: metric.Metric, borrow workflow: model.Workflow) -
         while second < workflow.tasks.len() {
             if related_pair(borrow workflow, first, second) {
                 metric.observe(inout result, pair_projection(borrow workflow, first, second), first + second + 1);
-                pairs = pairs + 1;
+                pairs += 1;
             }
-            second = second + 1;
+            second += 1;
         }
-        first = first + 1;
+        first += 1;
     }
     pairs
 }

--- a/examples/lattice/analysis_deterministic_keys.rue
+++ b/examples/lattice/analysis_deterministic_keys.rue
@@ -61,7 +61,7 @@ fn observe_tasks(inout result: metric.Metric, borrow workflow: model.Workflow) {
         let task = workflow.tasks.get_or(i, model.empty_task());
         metric.observe(inout result, value, task.priority + 1);
         metric.warn(inout result, task.duration == 0 || task.cpu == 0 || task.memory == 0);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -72,7 +72,7 @@ fn observe_edges(inout result: metric.Metric, borrow workflow: model.Workflow) {
         let value = edge_projection(borrow workflow, i);
         metric.observe(inout result, value, i + 1);
         metric.warn(inout result, edge.before >= workflow.tasks.len() || edge.after >= workflow.tasks.len());
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -83,7 +83,7 @@ fn observe_pools(inout result: metric.Metric, borrow workflow: model.Workflow) {
         let pool = workflow.pools.get_or(i, model.empty_pool());
         metric.observe(inout result, value, pool.slots + 1);
         metric.warn(inout result, pool.slots == 0 || pool.cpu == 0 || pool.memory == 0);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -95,11 +95,11 @@ fn observe_pairs(inout result: metric.Metric, borrow workflow: model.Workflow) -
         while second < workflow.tasks.len() {
             if related_pair(borrow workflow, first, second) {
                 metric.observe(inout result, pair_projection(borrow workflow, first, second), first + second + 1);
-                pairs = pairs + 1;
+                pairs += 1;
             }
-            second = second + 1;
+            second += 1;
         }
-        first = first + 1;
+        first += 1;
     }
     pairs
 }

--- a/examples/lattice/analysis_duration_profile.rue
+++ b/examples/lattice/analysis_duration_profile.rue
@@ -61,7 +61,7 @@ fn observe_tasks(inout result: metric.Metric, borrow workflow: model.Workflow) {
         let task = workflow.tasks.get_or(i, model.empty_task());
         metric.observe(inout result, value, task.priority + 1);
         metric.warn(inout result, task.duration == 0 || task.cpu == 0 || task.memory == 0);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -72,7 +72,7 @@ fn observe_edges(inout result: metric.Metric, borrow workflow: model.Workflow) {
         let value = edge_projection(borrow workflow, i);
         metric.observe(inout result, value, i + 1);
         metric.warn(inout result, edge.before >= workflow.tasks.len() || edge.after >= workflow.tasks.len());
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -83,7 +83,7 @@ fn observe_pools(inout result: metric.Metric, borrow workflow: model.Workflow) {
         let pool = workflow.pools.get_or(i, model.empty_pool());
         metric.observe(inout result, value, pool.slots + 1);
         metric.warn(inout result, pool.slots == 0 || pool.cpu == 0 || pool.memory == 0);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -95,11 +95,11 @@ fn observe_pairs(inout result: metric.Metric, borrow workflow: model.Workflow) -
         while second < workflow.tasks.len() {
             if related_pair(borrow workflow, first, second) {
                 metric.observe(inout result, pair_projection(borrow workflow, first, second), first + second + 1);
-                pairs = pairs + 1;
+                pairs += 1;
             }
-            second = second + 1;
+            second += 1;
         }
-        first = first + 1;
+        first += 1;
     }
     pairs
 }

--- a/examples/lattice/analysis_duration_variance_proxy.rue
+++ b/examples/lattice/analysis_duration_variance_proxy.rue
@@ -61,7 +61,7 @@ fn observe_tasks(inout result: metric.Metric, borrow workflow: model.Workflow) {
         let task = workflow.tasks.get_or(i, model.empty_task());
         metric.observe(inout result, value, task.priority + 1);
         metric.warn(inout result, task.duration == 0 || task.cpu == 0 || task.memory == 0);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -72,7 +72,7 @@ fn observe_edges(inout result: metric.Metric, borrow workflow: model.Workflow) {
         let value = edge_projection(borrow workflow, i);
         metric.observe(inout result, value, i + 1);
         metric.warn(inout result, edge.before >= workflow.tasks.len() || edge.after >= workflow.tasks.len());
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -83,7 +83,7 @@ fn observe_pools(inout result: metric.Metric, borrow workflow: model.Workflow) {
         let pool = workflow.pools.get_or(i, model.empty_pool());
         metric.observe(inout result, value, pool.slots + 1);
         metric.warn(inout result, pool.slots == 0 || pool.cpu == 0 || pool.memory == 0);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -95,11 +95,11 @@ fn observe_pairs(inout result: metric.Metric, borrow workflow: model.Workflow) -
         while second < workflow.tasks.len() {
             if related_pair(borrow workflow, first, second) {
                 metric.observe(inout result, pair_projection(borrow workflow, first, second), first + second + 1);
-                pairs = pairs + 1;
+                pairs += 1;
             }
-            second = second + 1;
+            second += 1;
         }
-        first = first + 1;
+        first += 1;
     }
     pairs
 }

--- a/examples/lattice/analysis_edge_work.rue
+++ b/examples/lattice/analysis_edge_work.rue
@@ -61,7 +61,7 @@ fn observe_tasks(inout result: metric.Metric, borrow workflow: model.Workflow) {
         let task = workflow.tasks.get_or(i, model.empty_task());
         metric.observe(inout result, value, task.priority + 1);
         metric.warn(inout result, task.duration == 0 || task.cpu == 0 || task.memory == 0);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -72,7 +72,7 @@ fn observe_edges(inout result: metric.Metric, borrow workflow: model.Workflow) {
         let value = edge_projection(borrow workflow, i);
         metric.observe(inout result, value, i + 1);
         metric.warn(inout result, edge.before >= workflow.tasks.len() || edge.after >= workflow.tasks.len());
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -83,7 +83,7 @@ fn observe_pools(inout result: metric.Metric, borrow workflow: model.Workflow) {
         let pool = workflow.pools.get_or(i, model.empty_pool());
         metric.observe(inout result, value, pool.slots + 1);
         metric.warn(inout result, pool.slots == 0 || pool.cpu == 0 || pool.memory == 0);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -95,11 +95,11 @@ fn observe_pairs(inout result: metric.Metric, borrow workflow: model.Workflow) -
         while second < workflow.tasks.len() {
             if related_pair(borrow workflow, first, second) {
                 metric.observe(inout result, pair_projection(borrow workflow, first, second), first + second + 1);
-                pairs = pairs + 1;
+                pairs += 1;
             }
-            second = second + 1;
+            second += 1;
         }
-        first = first + 1;
+        first += 1;
     }
     pairs
 }

--- a/examples/lattice/analysis_failure_exposure.rue
+++ b/examples/lattice/analysis_failure_exposure.rue
@@ -61,7 +61,7 @@ fn observe_tasks(inout result: metric.Metric, borrow workflow: model.Workflow) {
         let task = workflow.tasks.get_or(i, model.empty_task());
         metric.observe(inout result, value, task.priority + 1);
         metric.warn(inout result, task.duration == 0 || task.cpu == 0 || task.memory == 0);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -72,7 +72,7 @@ fn observe_edges(inout result: metric.Metric, borrow workflow: model.Workflow) {
         let value = edge_projection(borrow workflow, i);
         metric.observe(inout result, value, i + 1);
         metric.warn(inout result, edge.before >= workflow.tasks.len() || edge.after >= workflow.tasks.len());
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -83,7 +83,7 @@ fn observe_pools(inout result: metric.Metric, borrow workflow: model.Workflow) {
         let pool = workflow.pools.get_or(i, model.empty_pool());
         metric.observe(inout result, value, pool.slots + 1);
         metric.warn(inout result, pool.slots == 0 || pool.cpu == 0 || pool.memory == 0);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -95,11 +95,11 @@ fn observe_pairs(inout result: metric.Metric, borrow workflow: model.Workflow) -
         while second < workflow.tasks.len() {
             if related_pair(borrow workflow, first, second) {
                 metric.observe(inout result, pair_projection(borrow workflow, first, second), first + second + 1);
-                pairs = pairs + 1;
+                pairs += 1;
             }
-            second = second + 1;
+            second += 1;
         }
-        first = first + 1;
+        first += 1;
     }
     pairs
 }

--- a/examples/lattice/analysis_failure_recovery.rue
+++ b/examples/lattice/analysis_failure_recovery.rue
@@ -61,7 +61,7 @@ fn observe_tasks(inout result: metric.Metric, borrow workflow: model.Workflow) {
         let task = workflow.tasks.get_or(i, model.empty_task());
         metric.observe(inout result, value, task.priority + 1);
         metric.warn(inout result, task.duration == 0 || task.cpu == 0 || task.memory == 0);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -72,7 +72,7 @@ fn observe_edges(inout result: metric.Metric, borrow workflow: model.Workflow) {
         let value = edge_projection(borrow workflow, i);
         metric.observe(inout result, value, i + 1);
         metric.warn(inout result, edge.before >= workflow.tasks.len() || edge.after >= workflow.tasks.len());
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -83,7 +83,7 @@ fn observe_pools(inout result: metric.Metric, borrow workflow: model.Workflow) {
         let pool = workflow.pools.get_or(i, model.empty_pool());
         metric.observe(inout result, value, pool.slots + 1);
         metric.warn(inout result, pool.slots == 0 || pool.cpu == 0 || pool.memory == 0);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -95,11 +95,11 @@ fn observe_pairs(inout result: metric.Metric, borrow workflow: model.Workflow) -
         while second < workflow.tasks.len() {
             if related_pair(borrow workflow, first, second) {
                 metric.observe(inout result, pair_projection(borrow workflow, first, second), first + second + 1);
-                pairs = pairs + 1;
+                pairs += 1;
             }
-            second = second + 1;
+            second += 1;
         }
-        first = first + 1;
+        first += 1;
     }
     pairs
 }

--- a/examples/lattice/analysis_fanin_weight.rue
+++ b/examples/lattice/analysis_fanin_weight.rue
@@ -61,7 +61,7 @@ fn observe_tasks(inout result: metric.Metric, borrow workflow: model.Workflow) {
         let task = workflow.tasks.get_or(i, model.empty_task());
         metric.observe(inout result, value, task.priority + 1);
         metric.warn(inout result, task.duration == 0 || task.cpu == 0 || task.memory == 0);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -72,7 +72,7 @@ fn observe_edges(inout result: metric.Metric, borrow workflow: model.Workflow) {
         let value = edge_projection(borrow workflow, i);
         metric.observe(inout result, value, i + 1);
         metric.warn(inout result, edge.before >= workflow.tasks.len() || edge.after >= workflow.tasks.len());
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -83,7 +83,7 @@ fn observe_pools(inout result: metric.Metric, borrow workflow: model.Workflow) {
         let pool = workflow.pools.get_or(i, model.empty_pool());
         metric.observe(inout result, value, pool.slots + 1);
         metric.warn(inout result, pool.slots == 0 || pool.cpu == 0 || pool.memory == 0);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -95,11 +95,11 @@ fn observe_pairs(inout result: metric.Metric, borrow workflow: model.Workflow) -
         while second < workflow.tasks.len() {
             if related_pair(borrow workflow, first, second) {
                 metric.observe(inout result, pair_projection(borrow workflow, first, second), first + second + 1);
-                pairs = pairs + 1;
+                pairs += 1;
             }
-            second = second + 1;
+            second += 1;
         }
-        first = first + 1;
+        first += 1;
     }
     pairs
 }

--- a/examples/lattice/analysis_fanout_weight.rue
+++ b/examples/lattice/analysis_fanout_weight.rue
@@ -61,7 +61,7 @@ fn observe_tasks(inout result: metric.Metric, borrow workflow: model.Workflow) {
         let task = workflow.tasks.get_or(i, model.empty_task());
         metric.observe(inout result, value, task.priority + 1);
         metric.warn(inout result, task.duration == 0 || task.cpu == 0 || task.memory == 0);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -72,7 +72,7 @@ fn observe_edges(inout result: metric.Metric, borrow workflow: model.Workflow) {
         let value = edge_projection(borrow workflow, i);
         metric.observe(inout result, value, i + 1);
         metric.warn(inout result, edge.before >= workflow.tasks.len() || edge.after >= workflow.tasks.len());
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -83,7 +83,7 @@ fn observe_pools(inout result: metric.Metric, borrow workflow: model.Workflow) {
         let pool = workflow.pools.get_or(i, model.empty_pool());
         metric.observe(inout result, value, pool.slots + 1);
         metric.warn(inout result, pool.slots == 0 || pool.cpu == 0 || pool.memory == 0);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -95,11 +95,11 @@ fn observe_pairs(inout result: metric.Metric, borrow workflow: model.Workflow) -
         while second < workflow.tasks.len() {
             if related_pair(borrow workflow, first, second) {
                 metric.observe(inout result, pair_projection(borrow workflow, first, second), first + second + 1);
-                pairs = pairs + 1;
+                pairs += 1;
             }
-            second = second + 1;
+            second += 1;
         }
-        first = first + 1;
+        first += 1;
     }
     pairs
 }

--- a/examples/lattice/analysis_graph_locality.rue
+++ b/examples/lattice/analysis_graph_locality.rue
@@ -61,7 +61,7 @@ fn observe_tasks(inout result: metric.Metric, borrow workflow: model.Workflow) {
         let task = workflow.tasks.get_or(i, model.empty_task());
         metric.observe(inout result, value, task.priority + 1);
         metric.warn(inout result, task.duration == 0 || task.cpu == 0 || task.memory == 0);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -72,7 +72,7 @@ fn observe_edges(inout result: metric.Metric, borrow workflow: model.Workflow) {
         let value = edge_projection(borrow workflow, i);
         metric.observe(inout result, value, i + 1);
         metric.warn(inout result, edge.before >= workflow.tasks.len() || edge.after >= workflow.tasks.len());
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -83,7 +83,7 @@ fn observe_pools(inout result: metric.Metric, borrow workflow: model.Workflow) {
         let pool = workflow.pools.get_or(i, model.empty_pool());
         metric.observe(inout result, value, pool.slots + 1);
         metric.warn(inout result, pool.slots == 0 || pool.cpu == 0 || pool.memory == 0);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -95,11 +95,11 @@ fn observe_pairs(inout result: metric.Metric, borrow workflow: model.Workflow) -
         while second < workflow.tasks.len() {
             if related_pair(borrow workflow, first, second) {
                 metric.observe(inout result, pair_projection(borrow workflow, first, second), first + second + 1);
-                pairs = pairs + 1;
+                pairs += 1;
             }
-            second = second + 1;
+            second += 1;
         }
-        first = first + 1;
+        first += 1;
     }
     pairs
 }

--- a/examples/lattice/analysis_high_priority_work.rue
+++ b/examples/lattice/analysis_high_priority_work.rue
@@ -61,7 +61,7 @@ fn observe_tasks(inout result: metric.Metric, borrow workflow: model.Workflow) {
         let task = workflow.tasks.get_or(i, model.empty_task());
         metric.observe(inout result, value, task.priority + 1);
         metric.warn(inout result, task.duration == 0 || task.cpu == 0 || task.memory == 0);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -72,7 +72,7 @@ fn observe_edges(inout result: metric.Metric, borrow workflow: model.Workflow) {
         let value = edge_projection(borrow workflow, i);
         metric.observe(inout result, value, i + 1);
         metric.warn(inout result, edge.before >= workflow.tasks.len() || edge.after >= workflow.tasks.len());
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -83,7 +83,7 @@ fn observe_pools(inout result: metric.Metric, borrow workflow: model.Workflow) {
         let pool = workflow.pools.get_or(i, model.empty_pool());
         metric.observe(inout result, value, pool.slots + 1);
         metric.warn(inout result, pool.slots == 0 || pool.cpu == 0 || pool.memory == 0);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -95,11 +95,11 @@ fn observe_pairs(inout result: metric.Metric, borrow workflow: model.Workflow) -
         while second < workflow.tasks.len() {
             if related_pair(borrow workflow, first, second) {
                 metric.observe(inout result, pair_projection(borrow workflow, first, second), first + second + 1);
-                pairs = pairs + 1;
+                pairs += 1;
             }
-            second = second + 1;
+            second += 1;
         }
-        first = first + 1;
+        first += 1;
     }
     pairs
 }

--- a/examples/lattice/analysis_layer_proxy.rue
+++ b/examples/lattice/analysis_layer_proxy.rue
@@ -61,7 +61,7 @@ fn observe_tasks(inout result: metric.Metric, borrow workflow: model.Workflow) {
         let task = workflow.tasks.get_or(i, model.empty_task());
         metric.observe(inout result, value, task.priority + 1);
         metric.warn(inout result, task.duration == 0 || task.cpu == 0 || task.memory == 0);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -72,7 +72,7 @@ fn observe_edges(inout result: metric.Metric, borrow workflow: model.Workflow) {
         let value = edge_projection(borrow workflow, i);
         metric.observe(inout result, value, i + 1);
         metric.warn(inout result, edge.before >= workflow.tasks.len() || edge.after >= workflow.tasks.len());
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -83,7 +83,7 @@ fn observe_pools(inout result: metric.Metric, borrow workflow: model.Workflow) {
         let pool = workflow.pools.get_or(i, model.empty_pool());
         metric.observe(inout result, value, pool.slots + 1);
         metric.warn(inout result, pool.slots == 0 || pool.cpu == 0 || pool.memory == 0);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -95,11 +95,11 @@ fn observe_pairs(inout result: metric.Metric, borrow workflow: model.Workflow) -
         while second < workflow.tasks.len() {
             if related_pair(borrow workflow, first, second) {
                 metric.observe(inout result, pair_projection(borrow workflow, first, second), first + second + 1);
-                pairs = pairs + 1;
+                pairs += 1;
             }
-            second = second + 1;
+            second += 1;
         }
-        first = first + 1;
+        first += 1;
     }
     pairs
 }

--- a/examples/lattice/analysis_leaf_cost.rue
+++ b/examples/lattice/analysis_leaf_cost.rue
@@ -61,7 +61,7 @@ fn observe_tasks(inout result: metric.Metric, borrow workflow: model.Workflow) {
         let task = workflow.tasks.get_or(i, model.empty_task());
         metric.observe(inout result, value, task.priority + 1);
         metric.warn(inout result, task.duration == 0 || task.cpu == 0 || task.memory == 0);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -72,7 +72,7 @@ fn observe_edges(inout result: metric.Metric, borrow workflow: model.Workflow) {
         let value = edge_projection(borrow workflow, i);
         metric.observe(inout result, value, i + 1);
         metric.warn(inout result, edge.before >= workflow.tasks.len() || edge.after >= workflow.tasks.len());
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -83,7 +83,7 @@ fn observe_pools(inout result: metric.Metric, borrow workflow: model.Workflow) {
         let pool = workflow.pools.get_or(i, model.empty_pool());
         metric.observe(inout result, value, pool.slots + 1);
         metric.warn(inout result, pool.slots == 0 || pool.cpu == 0 || pool.memory == 0);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -95,11 +95,11 @@ fn observe_pairs(inout result: metric.Metric, borrow workflow: model.Workflow) -
         while second < workflow.tasks.len() {
             if related_pair(borrow workflow, first, second) {
                 metric.observe(inout result, pair_projection(borrow workflow, first, second), first + second + 1);
-                pairs = pairs + 1;
+                pairs += 1;
             }
-            second = second + 1;
+            second += 1;
         }
-        first = first + 1;
+        first += 1;
     }
     pairs
 }

--- a/examples/lattice/analysis_long_edges.rue
+++ b/examples/lattice/analysis_long_edges.rue
@@ -61,7 +61,7 @@ fn observe_tasks(inout result: metric.Metric, borrow workflow: model.Workflow) {
         let task = workflow.tasks.get_or(i, model.empty_task());
         metric.observe(inout result, value, task.priority + 1);
         metric.warn(inout result, task.duration == 0 || task.cpu == 0 || task.memory == 0);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -72,7 +72,7 @@ fn observe_edges(inout result: metric.Metric, borrow workflow: model.Workflow) {
         let value = edge_projection(borrow workflow, i);
         metric.observe(inout result, value, i + 1);
         metric.warn(inout result, edge.before >= workflow.tasks.len() || edge.after >= workflow.tasks.len());
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -83,7 +83,7 @@ fn observe_pools(inout result: metric.Metric, borrow workflow: model.Workflow) {
         let pool = workflow.pools.get_or(i, model.empty_pool());
         metric.observe(inout result, value, pool.slots + 1);
         metric.warn(inout result, pool.slots == 0 || pool.cpu == 0 || pool.memory == 0);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -95,11 +95,11 @@ fn observe_pairs(inout result: metric.Metric, borrow workflow: model.Workflow) -
         while second < workflow.tasks.len() {
             if related_pair(borrow workflow, first, second) {
                 metric.observe(inout result, pair_projection(borrow workflow, first, second), first + second + 1);
-                pairs = pairs + 1;
+                pairs += 1;
             }
-            second = second + 1;
+            second += 1;
         }
-        first = first + 1;
+        first += 1;
     }
     pairs
 }

--- a/examples/lattice/analysis_low_priority_work.rue
+++ b/examples/lattice/analysis_low_priority_work.rue
@@ -61,7 +61,7 @@ fn observe_tasks(inout result: metric.Metric, borrow workflow: model.Workflow) {
         let task = workflow.tasks.get_or(i, model.empty_task());
         metric.observe(inout result, value, task.priority + 1);
         metric.warn(inout result, task.duration == 0 || task.cpu == 0 || task.memory == 0);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -72,7 +72,7 @@ fn observe_edges(inout result: metric.Metric, borrow workflow: model.Workflow) {
         let value = edge_projection(borrow workflow, i);
         metric.observe(inout result, value, i + 1);
         metric.warn(inout result, edge.before >= workflow.tasks.len() || edge.after >= workflow.tasks.len());
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -83,7 +83,7 @@ fn observe_pools(inout result: metric.Metric, borrow workflow: model.Workflow) {
         let pool = workflow.pools.get_or(i, model.empty_pool());
         metric.observe(inout result, value, pool.slots + 1);
         metric.warn(inout result, pool.slots == 0 || pool.cpu == 0 || pool.memory == 0);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -95,11 +95,11 @@ fn observe_pairs(inout result: metric.Metric, borrow workflow: model.Workflow) -
         while second < workflow.tasks.len() {
             if related_pair(borrow workflow, first, second) {
                 metric.observe(inout result, pair_projection(borrow workflow, first, second), first + second + 1);
-                pairs = pairs + 1;
+                pairs += 1;
             }
-            second = second + 1;
+            second += 1;
         }
-        first = first + 1;
+        first += 1;
     }
     pairs
 }

--- a/examples/lattice/analysis_memory_variance_proxy.rue
+++ b/examples/lattice/analysis_memory_variance_proxy.rue
@@ -61,7 +61,7 @@ fn observe_tasks(inout result: metric.Metric, borrow workflow: model.Workflow) {
         let task = workflow.tasks.get_or(i, model.empty_task());
         metric.observe(inout result, value, task.priority + 1);
         metric.warn(inout result, task.duration == 0 || task.cpu == 0 || task.memory == 0);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -72,7 +72,7 @@ fn observe_edges(inout result: metric.Metric, borrow workflow: model.Workflow) {
         let value = edge_projection(borrow workflow, i);
         metric.observe(inout result, value, i + 1);
         metric.warn(inout result, edge.before >= workflow.tasks.len() || edge.after >= workflow.tasks.len());
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -83,7 +83,7 @@ fn observe_pools(inout result: metric.Metric, borrow workflow: model.Workflow) {
         let pool = workflow.pools.get_or(i, model.empty_pool());
         metric.observe(inout result, value, pool.slots + 1);
         metric.warn(inout result, pool.slots == 0 || pool.cpu == 0 || pool.memory == 0);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -95,11 +95,11 @@ fn observe_pairs(inout result: metric.Metric, borrow workflow: model.Workflow) -
         while second < workflow.tasks.len() {
             if related_pair(borrow workflow, first, second) {
                 metric.observe(inout result, pair_projection(borrow workflow, first, second), first + second + 1);
-                pairs = pairs + 1;
+                pairs += 1;
             }
-            second = second + 1;
+            second += 1;
         }
-        first = first + 1;
+        first += 1;
     }
     pairs
 }

--- a/examples/lattice/analysis_memory_work.rue
+++ b/examples/lattice/analysis_memory_work.rue
@@ -61,7 +61,7 @@ fn observe_tasks(inout result: metric.Metric, borrow workflow: model.Workflow) {
         let task = workflow.tasks.get_or(i, model.empty_task());
         metric.observe(inout result, value, task.priority + 1);
         metric.warn(inout result, task.duration == 0 || task.cpu == 0 || task.memory == 0);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -72,7 +72,7 @@ fn observe_edges(inout result: metric.Metric, borrow workflow: model.Workflow) {
         let value = edge_projection(borrow workflow, i);
         metric.observe(inout result, value, i + 1);
         metric.warn(inout result, edge.before >= workflow.tasks.len() || edge.after >= workflow.tasks.len());
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -83,7 +83,7 @@ fn observe_pools(inout result: metric.Metric, borrow workflow: model.Workflow) {
         let pool = workflow.pools.get_or(i, model.empty_pool());
         metric.observe(inout result, value, pool.slots + 1);
         metric.warn(inout result, pool.slots == 0 || pool.cpu == 0 || pool.memory == 0);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -95,11 +95,11 @@ fn observe_pairs(inout result: metric.Metric, borrow workflow: model.Workflow) -
         while second < workflow.tasks.len() {
             if related_pair(borrow workflow, first, second) {
                 metric.observe(inout result, pair_projection(borrow workflow, first, second), first + second + 1);
-                pairs = pairs + 1;
+                pairs += 1;
             }
-            second = second + 1;
+            second += 1;
         }
-        first = first + 1;
+        first += 1;
     }
     pairs
 }

--- a/examples/lattice/analysis_parallelism_pressure.rue
+++ b/examples/lattice/analysis_parallelism_pressure.rue
@@ -61,7 +61,7 @@ fn observe_tasks(inout result: metric.Metric, borrow workflow: model.Workflow) {
         let task = workflow.tasks.get_or(i, model.empty_task());
         metric.observe(inout result, value, task.priority + 1);
         metric.warn(inout result, task.duration == 0 || task.cpu == 0 || task.memory == 0);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -72,7 +72,7 @@ fn observe_edges(inout result: metric.Metric, borrow workflow: model.Workflow) {
         let value = edge_projection(borrow workflow, i);
         metric.observe(inout result, value, i + 1);
         metric.warn(inout result, edge.before >= workflow.tasks.len() || edge.after >= workflow.tasks.len());
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -83,7 +83,7 @@ fn observe_pools(inout result: metric.Metric, borrow workflow: model.Workflow) {
         let pool = workflow.pools.get_or(i, model.empty_pool());
         metric.observe(inout result, value, pool.slots + 1);
         metric.warn(inout result, pool.slots == 0 || pool.cpu == 0 || pool.memory == 0);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -95,11 +95,11 @@ fn observe_pairs(inout result: metric.Metric, borrow workflow: model.Workflow) -
         while second < workflow.tasks.len() {
             if related_pair(borrow workflow, first, second) {
                 metric.observe(inout result, pair_projection(borrow workflow, first, second), first + second + 1);
-                pairs = pairs + 1;
+                pairs += 1;
             }
-            second = second + 1;
+            second += 1;
         }
-        first = first + 1;
+        first += 1;
     }
     pairs
 }

--- a/examples/lattice/analysis_path_branching.rue
+++ b/examples/lattice/analysis_path_branching.rue
@@ -61,7 +61,7 @@ fn observe_tasks(inout result: metric.Metric, borrow workflow: model.Workflow) {
         let task = workflow.tasks.get_or(i, model.empty_task());
         metric.observe(inout result, value, task.priority + 1);
         metric.warn(inout result, task.duration == 0 || task.cpu == 0 || task.memory == 0);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -72,7 +72,7 @@ fn observe_edges(inout result: metric.Metric, borrow workflow: model.Workflow) {
         let value = edge_projection(borrow workflow, i);
         metric.observe(inout result, value, i + 1);
         metric.warn(inout result, edge.before >= workflow.tasks.len() || edge.after >= workflow.tasks.len());
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -83,7 +83,7 @@ fn observe_pools(inout result: metric.Metric, borrow workflow: model.Workflow) {
         let pool = workflow.pools.get_or(i, model.empty_pool());
         metric.observe(inout result, value, pool.slots + 1);
         metric.warn(inout result, pool.slots == 0 || pool.cpu == 0 || pool.memory == 0);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -95,11 +95,11 @@ fn observe_pairs(inout result: metric.Metric, borrow workflow: model.Workflow) -
         while second < workflow.tasks.len() {
             if related_pair(borrow workflow, first, second) {
                 metric.observe(inout result, pair_projection(borrow workflow, first, second), first + second + 1);
-                pairs = pairs + 1;
+                pairs += 1;
             }
-            second = second + 1;
+            second += 1;
         }
-        first = first + 1;
+        first += 1;
     }
     pairs
 }

--- a/examples/lattice/analysis_path_merging.rue
+++ b/examples/lattice/analysis_path_merging.rue
@@ -61,7 +61,7 @@ fn observe_tasks(inout result: metric.Metric, borrow workflow: model.Workflow) {
         let task = workflow.tasks.get_or(i, model.empty_task());
         metric.observe(inout result, value, task.priority + 1);
         metric.warn(inout result, task.duration == 0 || task.cpu == 0 || task.memory == 0);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -72,7 +72,7 @@ fn observe_edges(inout result: metric.Metric, borrow workflow: model.Workflow) {
         let value = edge_projection(borrow workflow, i);
         metric.observe(inout result, value, i + 1);
         metric.warn(inout result, edge.before >= workflow.tasks.len() || edge.after >= workflow.tasks.len());
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -83,7 +83,7 @@ fn observe_pools(inout result: metric.Metric, borrow workflow: model.Workflow) {
         let pool = workflow.pools.get_or(i, model.empty_pool());
         metric.observe(inout result, value, pool.slots + 1);
         metric.warn(inout result, pool.slots == 0 || pool.cpu == 0 || pool.memory == 0);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -95,11 +95,11 @@ fn observe_pairs(inout result: metric.Metric, borrow workflow: model.Workflow) -
         while second < workflow.tasks.len() {
             if related_pair(borrow workflow, first, second) {
                 metric.observe(inout result, pair_projection(borrow workflow, first, second), first + second + 1);
-                pairs = pairs + 1;
+                pairs += 1;
             }
-            second = second + 1;
+            second += 1;
         }
-        first = first + 1;
+        first += 1;
     }
     pairs
 }

--- a/examples/lattice/analysis_pool_affinity.rue
+++ b/examples/lattice/analysis_pool_affinity.rue
@@ -61,7 +61,7 @@ fn observe_tasks(inout result: metric.Metric, borrow workflow: model.Workflow) {
         let task = workflow.tasks.get_or(i, model.empty_task());
         metric.observe(inout result, value, task.priority + 1);
         metric.warn(inout result, task.duration == 0 || task.cpu == 0 || task.memory == 0);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -72,7 +72,7 @@ fn observe_edges(inout result: metric.Metric, borrow workflow: model.Workflow) {
         let value = edge_projection(borrow workflow, i);
         metric.observe(inout result, value, i + 1);
         metric.warn(inout result, edge.before >= workflow.tasks.len() || edge.after >= workflow.tasks.len());
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -83,7 +83,7 @@ fn observe_pools(inout result: metric.Metric, borrow workflow: model.Workflow) {
         let pool = workflow.pools.get_or(i, model.empty_pool());
         metric.observe(inout result, value, pool.slots + 1);
         metric.warn(inout result, pool.slots == 0 || pool.cpu == 0 || pool.memory == 0);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -95,11 +95,11 @@ fn observe_pairs(inout result: metric.Metric, borrow workflow: model.Workflow) -
         while second < workflow.tasks.len() {
             if related_pair(borrow workflow, first, second) {
                 metric.observe(inout result, pair_projection(borrow workflow, first, second), first + second + 1);
-                pairs = pairs + 1;
+                pairs += 1;
             }
-            second = second + 1;
+            second += 1;
         }
-        first = first + 1;
+        first += 1;
     }
     pairs
 }

--- a/examples/lattice/analysis_pool_cpu_share.rue
+++ b/examples/lattice/analysis_pool_cpu_share.rue
@@ -61,7 +61,7 @@ fn observe_tasks(inout result: metric.Metric, borrow workflow: model.Workflow) {
         let task = workflow.tasks.get_or(i, model.empty_task());
         metric.observe(inout result, value, task.priority + 1);
         metric.warn(inout result, task.duration == 0 || task.cpu == 0 || task.memory == 0);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -72,7 +72,7 @@ fn observe_edges(inout result: metric.Metric, borrow workflow: model.Workflow) {
         let value = edge_projection(borrow workflow, i);
         metric.observe(inout result, value, i + 1);
         metric.warn(inout result, edge.before >= workflow.tasks.len() || edge.after >= workflow.tasks.len());
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -83,7 +83,7 @@ fn observe_pools(inout result: metric.Metric, borrow workflow: model.Workflow) {
         let pool = workflow.pools.get_or(i, model.empty_pool());
         metric.observe(inout result, value, pool.slots + 1);
         metric.warn(inout result, pool.slots == 0 || pool.cpu == 0 || pool.memory == 0);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -95,11 +95,11 @@ fn observe_pairs(inout result: metric.Metric, borrow workflow: model.Workflow) -
         while second < workflow.tasks.len() {
             if related_pair(borrow workflow, first, second) {
                 metric.observe(inout result, pair_projection(borrow workflow, first, second), first + second + 1);
-                pairs = pairs + 1;
+                pairs += 1;
             }
-            second = second + 1;
+            second += 1;
         }
-        first = first + 1;
+        first += 1;
     }
     pairs
 }

--- a/examples/lattice/analysis_pool_memory_share.rue
+++ b/examples/lattice/analysis_pool_memory_share.rue
@@ -61,7 +61,7 @@ fn observe_tasks(inout result: metric.Metric, borrow workflow: model.Workflow) {
         let task = workflow.tasks.get_or(i, model.empty_task());
         metric.observe(inout result, value, task.priority + 1);
         metric.warn(inout result, task.duration == 0 || task.cpu == 0 || task.memory == 0);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -72,7 +72,7 @@ fn observe_edges(inout result: metric.Metric, borrow workflow: model.Workflow) {
         let value = edge_projection(borrow workflow, i);
         metric.observe(inout result, value, i + 1);
         metric.warn(inout result, edge.before >= workflow.tasks.len() || edge.after >= workflow.tasks.len());
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -83,7 +83,7 @@ fn observe_pools(inout result: metric.Metric, borrow workflow: model.Workflow) {
         let pool = workflow.pools.get_or(i, model.empty_pool());
         metric.observe(inout result, value, pool.slots + 1);
         metric.warn(inout result, pool.slots == 0 || pool.cpu == 0 || pool.memory == 0);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -95,11 +95,11 @@ fn observe_pairs(inout result: metric.Metric, borrow workflow: model.Workflow) -
         while second < workflow.tasks.len() {
             if related_pair(borrow workflow, first, second) {
                 metric.observe(inout result, pair_projection(borrow workflow, first, second), first + second + 1);
-                pairs = pairs + 1;
+                pairs += 1;
             }
-            second = second + 1;
+            second += 1;
         }
-        first = first + 1;
+        first += 1;
     }
     pairs
 }

--- a/examples/lattice/analysis_pool_skew.rue
+++ b/examples/lattice/analysis_pool_skew.rue
@@ -61,7 +61,7 @@ fn observe_tasks(inout result: metric.Metric, borrow workflow: model.Workflow) {
         let task = workflow.tasks.get_or(i, model.empty_task());
         metric.observe(inout result, value, task.priority + 1);
         metric.warn(inout result, task.duration == 0 || task.cpu == 0 || task.memory == 0);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -72,7 +72,7 @@ fn observe_edges(inout result: metric.Metric, borrow workflow: model.Workflow) {
         let value = edge_projection(borrow workflow, i);
         metric.observe(inout result, value, i + 1);
         metric.warn(inout result, edge.before >= workflow.tasks.len() || edge.after >= workflow.tasks.len());
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -83,7 +83,7 @@ fn observe_pools(inout result: metric.Metric, borrow workflow: model.Workflow) {
         let pool = workflow.pools.get_or(i, model.empty_pool());
         metric.observe(inout result, value, pool.slots + 1);
         metric.warn(inout result, pool.slots == 0 || pool.cpu == 0 || pool.memory == 0);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -95,11 +95,11 @@ fn observe_pairs(inout result: metric.Metric, borrow workflow: model.Workflow) -
         while second < workflow.tasks.len() {
             if related_pair(borrow workflow, first, second) {
                 metric.observe(inout result, pair_projection(borrow workflow, first, second), first + second + 1);
-                pairs = pairs + 1;
+                pairs += 1;
             }
-            second = second + 1;
+            second += 1;
         }
-        first = first + 1;
+        first += 1;
     }
     pairs
 }

--- a/examples/lattice/analysis_predecessor_load.rue
+++ b/examples/lattice/analysis_predecessor_load.rue
@@ -61,7 +61,7 @@ fn observe_tasks(inout result: metric.Metric, borrow workflow: model.Workflow) {
         let task = workflow.tasks.get_or(i, model.empty_task());
         metric.observe(inout result, value, task.priority + 1);
         metric.warn(inout result, task.duration == 0 || task.cpu == 0 || task.memory == 0);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -72,7 +72,7 @@ fn observe_edges(inout result: metric.Metric, borrow workflow: model.Workflow) {
         let value = edge_projection(borrow workflow, i);
         metric.observe(inout result, value, i + 1);
         metric.warn(inout result, edge.before >= workflow.tasks.len() || edge.after >= workflow.tasks.len());
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -83,7 +83,7 @@ fn observe_pools(inout result: metric.Metric, borrow workflow: model.Workflow) {
         let pool = workflow.pools.get_or(i, model.empty_pool());
         metric.observe(inout result, value, pool.slots + 1);
         metric.warn(inout result, pool.slots == 0 || pool.cpu == 0 || pool.memory == 0);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -95,11 +95,11 @@ fn observe_pairs(inout result: metric.Metric, borrow workflow: model.Workflow) -
         while second < workflow.tasks.len() {
             if related_pair(borrow workflow, first, second) {
                 metric.observe(inout result, pair_projection(borrow workflow, first, second), first + second + 1);
-                pairs = pairs + 1;
+                pairs += 1;
             }
-            second = second + 1;
+            second += 1;
         }
-        first = first + 1;
+        first += 1;
     }
     pairs
 }

--- a/examples/lattice/analysis_priority_pressure.rue
+++ b/examples/lattice/analysis_priority_pressure.rue
@@ -61,7 +61,7 @@ fn observe_tasks(inout result: metric.Metric, borrow workflow: model.Workflow) {
         let task = workflow.tasks.get_or(i, model.empty_task());
         metric.observe(inout result, value, task.priority + 1);
         metric.warn(inout result, task.duration == 0 || task.cpu == 0 || task.memory == 0);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -72,7 +72,7 @@ fn observe_edges(inout result: metric.Metric, borrow workflow: model.Workflow) {
         let value = edge_projection(borrow workflow, i);
         metric.observe(inout result, value, i + 1);
         metric.warn(inout result, edge.before >= workflow.tasks.len() || edge.after >= workflow.tasks.len());
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -83,7 +83,7 @@ fn observe_pools(inout result: metric.Metric, borrow workflow: model.Workflow) {
         let pool = workflow.pools.get_or(i, model.empty_pool());
         metric.observe(inout result, value, pool.slots + 1);
         metric.warn(inout result, pool.slots == 0 || pool.cpu == 0 || pool.memory == 0);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -95,11 +95,11 @@ fn observe_pairs(inout result: metric.Metric, borrow workflow: model.Workflow) -
         while second < workflow.tasks.len() {
             if related_pair(borrow workflow, first, second) {
                 metric.observe(inout result, pair_projection(borrow workflow, first, second), first + second + 1);
-                pairs = pairs + 1;
+                pairs += 1;
             }
-            second = second + 1;
+            second += 1;
         }
-        first = first + 1;
+        first += 1;
     }
     pairs
 }

--- a/examples/lattice/analysis_priority_variance_proxy.rue
+++ b/examples/lattice/analysis_priority_variance_proxy.rue
@@ -61,7 +61,7 @@ fn observe_tasks(inout result: metric.Metric, borrow workflow: model.Workflow) {
         let task = workflow.tasks.get_or(i, model.empty_task());
         metric.observe(inout result, value, task.priority + 1);
         metric.warn(inout result, task.duration == 0 || task.cpu == 0 || task.memory == 0);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -72,7 +72,7 @@ fn observe_edges(inout result: metric.Metric, borrow workflow: model.Workflow) {
         let value = edge_projection(borrow workflow, i);
         metric.observe(inout result, value, i + 1);
         metric.warn(inout result, edge.before >= workflow.tasks.len() || edge.after >= workflow.tasks.len());
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -83,7 +83,7 @@ fn observe_pools(inout result: metric.Metric, borrow workflow: model.Workflow) {
         let pool = workflow.pools.get_or(i, model.empty_pool());
         metric.observe(inout result, value, pool.slots + 1);
         metric.warn(inout result, pool.slots == 0 || pool.cpu == 0 || pool.memory == 0);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -95,11 +95,11 @@ fn observe_pairs(inout result: metric.Metric, borrow workflow: model.Workflow) -
         while second < workflow.tasks.len() {
             if related_pair(borrow workflow, first, second) {
                 metric.observe(inout result, pair_projection(borrow workflow, first, second), first + second + 1);
-                pairs = pairs + 1;
+                pairs += 1;
             }
-            second = second + 1;
+            second += 1;
         }
-        first = first + 1;
+        first += 1;
     }
     pairs
 }

--- a/examples/lattice/analysis_queue_priority.rue
+++ b/examples/lattice/analysis_queue_priority.rue
@@ -61,7 +61,7 @@ fn observe_tasks(inout result: metric.Metric, borrow workflow: model.Workflow) {
         let task = workflow.tasks.get_or(i, model.empty_task());
         metric.observe(inout result, value, task.priority + 1);
         metric.warn(inout result, task.duration == 0 || task.cpu == 0 || task.memory == 0);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -72,7 +72,7 @@ fn observe_edges(inout result: metric.Metric, borrow workflow: model.Workflow) {
         let value = edge_projection(borrow workflow, i);
         metric.observe(inout result, value, i + 1);
         metric.warn(inout result, edge.before >= workflow.tasks.len() || edge.after >= workflow.tasks.len());
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -83,7 +83,7 @@ fn observe_pools(inout result: metric.Metric, borrow workflow: model.Workflow) {
         let pool = workflow.pools.get_or(i, model.empty_pool());
         metric.observe(inout result, value, pool.slots + 1);
         metric.warn(inout result, pool.slots == 0 || pool.cpu == 0 || pool.memory == 0);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -95,11 +95,11 @@ fn observe_pairs(inout result: metric.Metric, borrow workflow: model.Workflow) -
         while second < workflow.tasks.len() {
             if related_pair(borrow workflow, first, second) {
                 metric.observe(inout result, pair_projection(borrow workflow, first, second), first + second + 1);
-                pairs = pairs + 1;
+                pairs += 1;
             }
-            second = second + 1;
+            second += 1;
         }
-        first = first + 1;
+        first += 1;
     }
     pairs
 }

--- a/examples/lattice/analysis_resource_balance.rue
+++ b/examples/lattice/analysis_resource_balance.rue
@@ -61,7 +61,7 @@ fn observe_tasks(inout result: metric.Metric, borrow workflow: model.Workflow) {
         let task = workflow.tasks.get_or(i, model.empty_task());
         metric.observe(inout result, value, task.priority + 1);
         metric.warn(inout result, task.duration == 0 || task.cpu == 0 || task.memory == 0);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -72,7 +72,7 @@ fn observe_edges(inout result: metric.Metric, borrow workflow: model.Workflow) {
         let value = edge_projection(borrow workflow, i);
         metric.observe(inout result, value, i + 1);
         metric.warn(inout result, edge.before >= workflow.tasks.len() || edge.after >= workflow.tasks.len());
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -83,7 +83,7 @@ fn observe_pools(inout result: metric.Metric, borrow workflow: model.Workflow) {
         let pool = workflow.pools.get_or(i, model.empty_pool());
         metric.observe(inout result, value, pool.slots + 1);
         metric.warn(inout result, pool.slots == 0 || pool.cpu == 0 || pool.memory == 0);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -95,11 +95,11 @@ fn observe_pairs(inout result: metric.Metric, borrow workflow: model.Workflow) -
         while second < workflow.tasks.len() {
             if related_pair(borrow workflow, first, second) {
                 metric.observe(inout result, pair_projection(borrow workflow, first, second), first + second + 1);
-                pairs = pairs + 1;
+                pairs += 1;
             }
-            second = second + 1;
+            second += 1;
         }
-        first = first + 1;
+        first += 1;
     }
     pairs
 }

--- a/examples/lattice/analysis_resource_product.rue
+++ b/examples/lattice/analysis_resource_product.rue
@@ -61,7 +61,7 @@ fn observe_tasks(inout result: metric.Metric, borrow workflow: model.Workflow) {
         let task = workflow.tasks.get_or(i, model.empty_task());
         metric.observe(inout result, value, task.priority + 1);
         metric.warn(inout result, task.duration == 0 || task.cpu == 0 || task.memory == 0);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -72,7 +72,7 @@ fn observe_edges(inout result: metric.Metric, borrow workflow: model.Workflow) {
         let value = edge_projection(borrow workflow, i);
         metric.observe(inout result, value, i + 1);
         metric.warn(inout result, edge.before >= workflow.tasks.len() || edge.after >= workflow.tasks.len());
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -83,7 +83,7 @@ fn observe_pools(inout result: metric.Metric, borrow workflow: model.Workflow) {
         let pool = workflow.pools.get_or(i, model.empty_pool());
         metric.observe(inout result, value, pool.slots + 1);
         metric.warn(inout result, pool.slots == 0 || pool.cpu == 0 || pool.memory == 0);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -95,11 +95,11 @@ fn observe_pairs(inout result: metric.Metric, borrow workflow: model.Workflow) -
         while second < workflow.tasks.len() {
             if related_pair(borrow workflow, first, second) {
                 metric.observe(inout result, pair_projection(borrow workflow, first, second), first + second + 1);
-                pairs = pairs + 1;
+                pairs += 1;
             }
-            second = second + 1;
+            second += 1;
         }
-        first = first + 1;
+        first += 1;
     }
     pairs
 }

--- a/examples/lattice/analysis_retry_exposure.rue
+++ b/examples/lattice/analysis_retry_exposure.rue
@@ -61,7 +61,7 @@ fn observe_tasks(inout result: metric.Metric, borrow workflow: model.Workflow) {
         let task = workflow.tasks.get_or(i, model.empty_task());
         metric.observe(inout result, value, task.priority + 1);
         metric.warn(inout result, task.duration == 0 || task.cpu == 0 || task.memory == 0);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -72,7 +72,7 @@ fn observe_edges(inout result: metric.Metric, borrow workflow: model.Workflow) {
         let value = edge_projection(borrow workflow, i);
         metric.observe(inout result, value, i + 1);
         metric.warn(inout result, edge.before >= workflow.tasks.len() || edge.after >= workflow.tasks.len());
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -83,7 +83,7 @@ fn observe_pools(inout result: metric.Metric, borrow workflow: model.Workflow) {
         let pool = workflow.pools.get_or(i, model.empty_pool());
         metric.observe(inout result, value, pool.slots + 1);
         metric.warn(inout result, pool.slots == 0 || pool.cpu == 0 || pool.memory == 0);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -95,11 +95,11 @@ fn observe_pairs(inout result: metric.Metric, borrow workflow: model.Workflow) -
         while second < workflow.tasks.len() {
             if related_pair(borrow workflow, first, second) {
                 metric.observe(inout result, pair_projection(borrow workflow, first, second), first + second + 1);
-                pairs = pairs + 1;
+                pairs += 1;
             }
-            second = second + 1;
+            second += 1;
         }
-        first = first + 1;
+        first += 1;
     }
     pairs
 }

--- a/examples/lattice/analysis_retry_work.rue
+++ b/examples/lattice/analysis_retry_work.rue
@@ -61,7 +61,7 @@ fn observe_tasks(inout result: metric.Metric, borrow workflow: model.Workflow) {
         let task = workflow.tasks.get_or(i, model.empty_task());
         metric.observe(inout result, value, task.priority + 1);
         metric.warn(inout result, task.duration == 0 || task.cpu == 0 || task.memory == 0);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -72,7 +72,7 @@ fn observe_edges(inout result: metric.Metric, borrow workflow: model.Workflow) {
         let value = edge_projection(borrow workflow, i);
         metric.observe(inout result, value, i + 1);
         metric.warn(inout result, edge.before >= workflow.tasks.len() || edge.after >= workflow.tasks.len());
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -83,7 +83,7 @@ fn observe_pools(inout result: metric.Metric, borrow workflow: model.Workflow) {
         let pool = workflow.pools.get_or(i, model.empty_pool());
         metric.observe(inout result, value, pool.slots + 1);
         metric.warn(inout result, pool.slots == 0 || pool.cpu == 0 || pool.memory == 0);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -95,11 +95,11 @@ fn observe_pairs(inout result: metric.Metric, borrow workflow: model.Workflow) -
         while second < workflow.tasks.len() {
             if related_pair(borrow workflow, first, second) {
                 metric.observe(inout result, pair_projection(borrow workflow, first, second), first + second + 1);
-                pairs = pairs + 1;
+                pairs += 1;
             }
-            second = second + 1;
+            second += 1;
         }
-        first = first + 1;
+        first += 1;
     }
     pairs
 }

--- a/examples/lattice/analysis_root_cost.rue
+++ b/examples/lattice/analysis_root_cost.rue
@@ -61,7 +61,7 @@ fn observe_tasks(inout result: metric.Metric, borrow workflow: model.Workflow) {
         let task = workflow.tasks.get_or(i, model.empty_task());
         metric.observe(inout result, value, task.priority + 1);
         metric.warn(inout result, task.duration == 0 || task.cpu == 0 || task.memory == 0);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -72,7 +72,7 @@ fn observe_edges(inout result: metric.Metric, borrow workflow: model.Workflow) {
         let value = edge_projection(borrow workflow, i);
         metric.observe(inout result, value, i + 1);
         metric.warn(inout result, edge.before >= workflow.tasks.len() || edge.after >= workflow.tasks.len());
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -83,7 +83,7 @@ fn observe_pools(inout result: metric.Metric, borrow workflow: model.Workflow) {
         let pool = workflow.pools.get_or(i, model.empty_pool());
         metric.observe(inout result, value, pool.slots + 1);
         metric.warn(inout result, pool.slots == 0 || pool.cpu == 0 || pool.memory == 0);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -95,11 +95,11 @@ fn observe_pairs(inout result: metric.Metric, borrow workflow: model.Workflow) -
         while second < workflow.tasks.len() {
             if related_pair(borrow workflow, first, second) {
                 metric.observe(inout result, pair_projection(borrow workflow, first, second), first + second + 1);
-                pairs = pairs + 1;
+                pairs += 1;
             }
-            second = second + 1;
+            second += 1;
         }
-        first = first + 1;
+        first += 1;
     }
     pairs
 }

--- a/examples/lattice/analysis_same_pool_edges.rue
+++ b/examples/lattice/analysis_same_pool_edges.rue
@@ -61,7 +61,7 @@ fn observe_tasks(inout result: metric.Metric, borrow workflow: model.Workflow) {
         let task = workflow.tasks.get_or(i, model.empty_task());
         metric.observe(inout result, value, task.priority + 1);
         metric.warn(inout result, task.duration == 0 || task.cpu == 0 || task.memory == 0);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -72,7 +72,7 @@ fn observe_edges(inout result: metric.Metric, borrow workflow: model.Workflow) {
         let value = edge_projection(borrow workflow, i);
         metric.observe(inout result, value, i + 1);
         metric.warn(inout result, edge.before >= workflow.tasks.len() || edge.after >= workflow.tasks.len());
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -83,7 +83,7 @@ fn observe_pools(inout result: metric.Metric, borrow workflow: model.Workflow) {
         let pool = workflow.pools.get_or(i, model.empty_pool());
         metric.observe(inout result, value, pool.slots + 1);
         metric.warn(inout result, pool.slots == 0 || pool.cpu == 0 || pool.memory == 0);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -95,11 +95,11 @@ fn observe_pairs(inout result: metric.Metric, borrow workflow: model.Workflow) -
         while second < workflow.tasks.len() {
             if related_pair(borrow workflow, first, second) {
                 metric.observe(inout result, pair_projection(borrow workflow, first, second), first + second + 1);
-                pairs = pairs + 1;
+                pairs += 1;
             }
-            second = second + 1;
+            second += 1;
         }
-        first = first + 1;
+        first += 1;
     }
     pairs
 }

--- a/examples/lattice/analysis_schedule_weight.rue
+++ b/examples/lattice/analysis_schedule_weight.rue
@@ -61,7 +61,7 @@ fn observe_tasks(inout result: metric.Metric, borrow workflow: model.Workflow) {
         let task = workflow.tasks.get_or(i, model.empty_task());
         metric.observe(inout result, value, task.priority + 1);
         metric.warn(inout result, task.duration == 0 || task.cpu == 0 || task.memory == 0);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -72,7 +72,7 @@ fn observe_edges(inout result: metric.Metric, borrow workflow: model.Workflow) {
         let value = edge_projection(borrow workflow, i);
         metric.observe(inout result, value, i + 1);
         metric.warn(inout result, edge.before >= workflow.tasks.len() || edge.after >= workflow.tasks.len());
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -83,7 +83,7 @@ fn observe_pools(inout result: metric.Metric, borrow workflow: model.Workflow) {
         let pool = workflow.pools.get_or(i, model.empty_pool());
         metric.observe(inout result, value, pool.slots + 1);
         metric.warn(inout result, pool.slots == 0 || pool.cpu == 0 || pool.memory == 0);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -95,11 +95,11 @@ fn observe_pairs(inout result: metric.Metric, borrow workflow: model.Workflow) -
         while second < workflow.tasks.len() {
             if related_pair(borrow workflow, first, second) {
                 metric.observe(inout result, pair_projection(borrow workflow, first, second), first + second + 1);
-                pairs = pairs + 1;
+                pairs += 1;
             }
-            second = second + 1;
+            second += 1;
         }
-        first = first + 1;
+        first += 1;
     }
     pairs
 }

--- a/examples/lattice/analysis_short_edges.rue
+++ b/examples/lattice/analysis_short_edges.rue
@@ -61,7 +61,7 @@ fn observe_tasks(inout result: metric.Metric, borrow workflow: model.Workflow) {
         let task = workflow.tasks.get_or(i, model.empty_task());
         metric.observe(inout result, value, task.priority + 1);
         metric.warn(inout result, task.duration == 0 || task.cpu == 0 || task.memory == 0);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -72,7 +72,7 @@ fn observe_edges(inout result: metric.Metric, borrow workflow: model.Workflow) {
         let value = edge_projection(borrow workflow, i);
         metric.observe(inout result, value, i + 1);
         metric.warn(inout result, edge.before >= workflow.tasks.len() || edge.after >= workflow.tasks.len());
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -83,7 +83,7 @@ fn observe_pools(inout result: metric.Metric, borrow workflow: model.Workflow) {
         let pool = workflow.pools.get_or(i, model.empty_pool());
         metric.observe(inout result, value, pool.slots + 1);
         metric.warn(inout result, pool.slots == 0 || pool.cpu == 0 || pool.memory == 0);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -95,11 +95,11 @@ fn observe_pairs(inout result: metric.Metric, borrow workflow: model.Workflow) -
         while second < workflow.tasks.len() {
             if related_pair(borrow workflow, first, second) {
                 metric.observe(inout result, pair_projection(borrow workflow, first, second), first + second + 1);
-                pairs = pairs + 1;
+                pairs += 1;
             }
-            second = second + 1;
+            second += 1;
         }
-        first = first + 1;
+        first += 1;
     }
     pairs
 }

--- a/examples/lattice/analysis_slot_demand.rue
+++ b/examples/lattice/analysis_slot_demand.rue
@@ -61,7 +61,7 @@ fn observe_tasks(inout result: metric.Metric, borrow workflow: model.Workflow) {
         let task = workflow.tasks.get_or(i, model.empty_task());
         metric.observe(inout result, value, task.priority + 1);
         metric.warn(inout result, task.duration == 0 || task.cpu == 0 || task.memory == 0);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -72,7 +72,7 @@ fn observe_edges(inout result: metric.Metric, borrow workflow: model.Workflow) {
         let value = edge_projection(borrow workflow, i);
         metric.observe(inout result, value, i + 1);
         metric.warn(inout result, edge.before >= workflow.tasks.len() || edge.after >= workflow.tasks.len());
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -83,7 +83,7 @@ fn observe_pools(inout result: metric.Metric, borrow workflow: model.Workflow) {
         let pool = workflow.pools.get_or(i, model.empty_pool());
         metric.observe(inout result, value, pool.slots + 1);
         metric.warn(inout result, pool.slots == 0 || pool.cpu == 0 || pool.memory == 0);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -95,11 +95,11 @@ fn observe_pairs(inout result: metric.Metric, borrow workflow: model.Workflow) -
         while second < workflow.tasks.len() {
             if related_pair(borrow workflow, first, second) {
                 metric.observe(inout result, pair_projection(borrow workflow, first, second), first + second + 1);
-                pairs = pairs + 1;
+                pairs += 1;
             }
-            second = second + 1;
+            second += 1;
         }
-        first = first + 1;
+        first += 1;
     }
     pairs
 }

--- a/examples/lattice/analysis_successor_load.rue
+++ b/examples/lattice/analysis_successor_load.rue
@@ -61,7 +61,7 @@ fn observe_tasks(inout result: metric.Metric, borrow workflow: model.Workflow) {
         let task = workflow.tasks.get_or(i, model.empty_task());
         metric.observe(inout result, value, task.priority + 1);
         metric.warn(inout result, task.duration == 0 || task.cpu == 0 || task.memory == 0);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -72,7 +72,7 @@ fn observe_edges(inout result: metric.Metric, borrow workflow: model.Workflow) {
         let value = edge_projection(borrow workflow, i);
         metric.observe(inout result, value, i + 1);
         metric.warn(inout result, edge.before >= workflow.tasks.len() || edge.after >= workflow.tasks.len());
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -83,7 +83,7 @@ fn observe_pools(inout result: metric.Metric, borrow workflow: model.Workflow) {
         let pool = workflow.pools.get_or(i, model.empty_pool());
         metric.observe(inout result, value, pool.slots + 1);
         metric.warn(inout result, pool.slots == 0 || pool.cpu == 0 || pool.memory == 0);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -95,11 +95,11 @@ fn observe_pairs(inout result: metric.Metric, borrow workflow: model.Workflow) -
         while second < workflow.tasks.len() {
             if related_pair(borrow workflow, first, second) {
                 metric.observe(inout result, pair_projection(borrow workflow, first, second), first + second + 1);
-                pairs = pairs + 1;
+                pairs += 1;
             }
-            second = second + 1;
+            second += 1;
         }
-        first = first + 1;
+        first += 1;
     }
     pairs
 }

--- a/examples/lattice/analysis_uncached_work.rue
+++ b/examples/lattice/analysis_uncached_work.rue
@@ -61,7 +61,7 @@ fn observe_tasks(inout result: metric.Metric, borrow workflow: model.Workflow) {
         let task = workflow.tasks.get_or(i, model.empty_task());
         metric.observe(inout result, value, task.priority + 1);
         metric.warn(inout result, task.duration == 0 || task.cpu == 0 || task.memory == 0);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -72,7 +72,7 @@ fn observe_edges(inout result: metric.Metric, borrow workflow: model.Workflow) {
         let value = edge_projection(borrow workflow, i);
         metric.observe(inout result, value, i + 1);
         metric.warn(inout result, edge.before >= workflow.tasks.len() || edge.after >= workflow.tasks.len());
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -83,7 +83,7 @@ fn observe_pools(inout result: metric.Metric, borrow workflow: model.Workflow) {
         let pool = workflow.pools.get_or(i, model.empty_pool());
         metric.observe(inout result, value, pool.slots + 1);
         metric.warn(inout result, pool.slots == 0 || pool.cpu == 0 || pool.memory == 0);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -95,11 +95,11 @@ fn observe_pairs(inout result: metric.Metric, borrow workflow: model.Workflow) -
         while second < workflow.tasks.len() {
             if related_pair(borrow workflow, first, second) {
                 metric.observe(inout result, pair_projection(borrow workflow, first, second), first + second + 1);
-                pairs = pairs + 1;
+                pairs += 1;
             }
-            second = second + 1;
+            second += 1;
         }
-        first = first + 1;
+        first += 1;
     }
     pairs
 }

--- a/examples/lattice/cache_analysis.rue
+++ b/examples/lattice/cache_analysis.rue
@@ -21,7 +21,7 @@ pub struct Analysis {
 fn zeroes(count: u64) -> model.U64s {
     let mut out = model.U64s.with_capacity(count);
     let mut i: u64 = 0;
-    while i < count { out.push(0); i = i + 1; }
+    while i < count { out.push(0); i += 1; }
     out
 }
 

--- a/examples/lattice/cache_analysis.rue
+++ b/examples/lattice/cache_analysis.rue
@@ -48,24 +48,24 @@ pub fn compute(borrow workflow: model.Workflow, borrow run: state.Run) -> Analys
         let task = workflow.tasks.get_or(i, model.empty_task());
         let status = run.status.get_or(i, state.FAILED());
         if task.cacheable {
-            declared_cacheable = declared_cacheable + 1;
+            declared_cacheable += 1;
             add(inout cacheable_by_pool, task.pool);
             if status == state.CACHED() {
-                observed_hits = observed_hits + 1;
+                observed_hits += 1;
                 add(inout hits_by_pool, task.pool);
-                saved_duration = saved_duration + task.duration;
-                saved_cpu_ticks = saved_cpu_ticks + task.duration * task.cpu;
-                saved_memory_ticks = saved_memory_ticks + task.duration * task.memory;
+                saved_duration += task.duration;
+                saved_cpu_ticks += task.duration * task.cpu;
+                saved_memory_ticks += task.duration * task.memory;
             } else {
-                observed_misses = observed_misses + 1;
+                observed_misses += 1;
                 add(inout misses_by_pool, task.pool);
             }
         } else if status == state.CACHED() {
-            invalid_hits = invalid_hits + 1;
+            invalid_hits += 1;
         }
         digest = mix(digest, i); digest = mix(digest, status);
         digest = mix(digest, if task.cacheable { 1 } else { 0 });
-        i = i + 1;
+        i += 1;
     }
     let hit_rate_millis = if declared_cacheable == 0 { 0 }
         else { (observed_hits * 1000) / declared_cacheable };

--- a/examples/lattice/capacity_plan.rue
+++ b/examples/lattice/capacity_plan.rue
@@ -65,15 +65,15 @@ pub fn compute(borrow workflow: model.Workflow, borrow run: state.Run) -> Plan {
         slot_headroom.set(i, difference(pool.slots, peak_slots));
         cpu_headroom.set(i, difference(pool.cpu, peak_cpu));
         memory_headroom.set(i, difference(pool.memory, peak_memory));
-        total_slot_increase = total_slot_increase + difference(slots, pool.slots);
-        total_cpu_increase = total_cpu_increase + difference(cpu, pool.cpu);
-        total_memory_increase = total_memory_increase + difference(memory, pool.memory);
+        total_slot_increase += difference(slots, pool.slots);
+        total_cpu_increase += difference(cpu, pool.cpu);
+        total_memory_increase += difference(memory, pool.memory);
         if peak_slots == pool.slots || peak_cpu == pool.cpu || peak_memory == pool.memory {
-            saturated_pools = saturated_pools + 1;
+            saturated_pools += 1;
             constrained_pools.push(i);
         }
         digest = mix(digest, slots); digest = mix(digest, cpu); digest = mix(digest, memory);
-        i = i + 1;
+        i += 1;
     }
     let valid = audit.ok && constrained_pools.len() == saturated_pools;
     Plan {

--- a/examples/lattice/capacity_plan.rue
+++ b/examples/lattice/capacity_plan.rue
@@ -22,7 +22,7 @@ pub struct Plan {
 fn zeroes(count: u64) -> model.U64s {
     let mut values = model.U64s.with_capacity(count);
     let mut i: u64 = 0;
-    while i < count { values.push(0); i = i + 1; }
+    while i < count { values.push(0); i += 1; }
     values
 }
 

--- a/examples/lattice/critical_path.rue
+++ b/examples/lattice/critical_path.rue
@@ -40,7 +40,7 @@ fn predecessor_finish(borrow workflow: model.Workflow, borrow finish: U64s, task
             let candidate = finish.get_or(edge.before, 0);
             if candidate > value { value = candidate; }
         }
-        i = i + 1;
+        i += 1;
     }
     value
 }
@@ -55,7 +55,7 @@ fn successor_start(borrow workflow: model.Workflow, borrow latest_start: U64s, t
             let candidate = latest_start.get_or(edge.after, makespan);
             if !found || candidate < value { value = candidate; found = true; }
         }
-        i = i + 1;
+        i += 1;
     }
     value
 }
@@ -77,7 +77,7 @@ fn critical_predecessor(
         if edge.after == task && earliest_finish.get_or(edge.before, 0) == start && slack.get_or(edge.before, 1) == 0 {
             if best == model.NONE() || edge.before < best { best = edge.before; }
         }
-        i = i + 1;
+        i += 1;
     }
     best
 }
@@ -104,14 +104,14 @@ pub fn compute(borrow workflow: model.Workflow) -> Analysis {
         earliest_start.set(task_index, start);
         earliest_finish.set(task_index, finish);
         if finish > makespan { makespan = finish; }
-        i = i + 1;
+        i += 1;
     }
 
     let mut latest_start = filled(workflow.tasks.len(), makespan);
     let mut latest_finish = filled(workflow.tasks.len(), makespan);
     i = order.tasks.len();
     while i > 0 {
-        i = i - 1;
+        i -= 1;
         let task_index = order.tasks.get_or(i, model.NONE());
         let task = workflow.tasks.get_or(task_index, model.empty_task());
         let finish = successor_start(borrow workflow, borrow latest_start, task_index, makespan);
@@ -131,12 +131,12 @@ pub fn compute(borrow workflow: model.Workflow) -> Analysis {
         let late = latest_start.get_or(i, early);
         let value = if late >= early { late - early } else { 0 };
         slack.set(i, value);
-        total_slack = total_slack + value;
+        total_slack += value;
         if value > maximum_slack { maximum_slack = value; }
         if value == 0 { critical_tasks.push(i); }
         digest = mix(digest, early); digest = mix(digest, earliest_finish.get_or(i, 0));
         digest = mix(digest, late); digest = mix(digest, value);
-        i = i + 1;
+        i += 1;
     }
 
     let mut leaf = model.NONE();
@@ -145,7 +145,7 @@ pub fn compute(borrow workflow: model.Workflow) -> Analysis {
         if earliest_finish.get_or(i, 0) == makespan && slack.get_or(i, 1) == 0 {
             if leaf == model.NONE() || i < leaf { leaf = i; }
         }
-        i = i + 1;
+        i += 1;
     }
     let mut backward = U64s.new();
     let mut cursor = leaf;
@@ -172,14 +172,14 @@ pub fn verify(borrow workflow: model.Workflow, borrow analysis: Analysis) -> boo
     while i < workflow.edges.len() {
         let edge = workflow.edges.get_or(i, model.empty_edge());
         if analysis.earliest_finish.get_or(edge.before, 0) > analysis.earliest_start.get_or(edge.after, 0) { return false; }
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < workflow.tasks.len() {
         let task = workflow.tasks.get_or(i, model.empty_task());
         if analysis.earliest_start.get_or(i, 0) + task.duration != analysis.earliest_finish.get_or(i, 0) { return false; }
         if analysis.latest_start.get_or(i, 0) + task.duration != analysis.latest_finish.get_or(i, 0) { return false; }
-        i = i + 1;
+        i += 1;
     }
     true
 }

--- a/examples/lattice/critical_path.rue
+++ b/examples/lattice/critical_path.rue
@@ -23,7 +23,7 @@ pub struct Analysis {
 fn filled(count: u64, value: u64) -> U64s {
     let mut result = U64s.with_capacity(count);
     let mut i: u64 = 0;
-    while i < count { result.push(value); i = i + 1; }
+    while i < count { result.push(value); i += 1; }
     result
 }
 
@@ -85,7 +85,7 @@ fn critical_predecessor(
 fn reverse(values: U64s) -> U64s {
     let mut result = U64s.with_capacity(values.len());
     let mut i = values.len();
-    while i > 0 { i = i - 1; result.push(values.get_or(i, model.NONE())); }
+    while i > 0 { i -= 1; result.push(values.get_or(i, model.NONE())); }
     result
 }
 

--- a/examples/lattice/cut_analysis.rue
+++ b/examples/lattice/cut_analysis.rue
@@ -29,7 +29,7 @@ fn leaf_count(borrow workflow: model.Workflow) -> u64 {
     let mut result: u64 = 0;
     let mut i: u64 = 0;
     while i < workflow.tasks.len() {
-        if model.dependent_count(borrow workflow, i) == 0 { result = result + 1; }
+        if model.dependent_count(borrow workflow, i) == 0 { result += 1; }
         i += 1;
     }
     result

--- a/examples/lattice/cut_analysis.rue
+++ b/examples/lattice/cut_analysis.rue
@@ -30,7 +30,7 @@ fn leaf_count(borrow workflow: model.Workflow) -> u64 {
     let mut i: u64 = 0;
     while i < workflow.tasks.len() {
         if model.dependent_count(borrow workflow, i) == 0 { result = result + 1; }
-        i = i + 1;
+        i += 1;
     }
     result
 }
@@ -46,9 +46,9 @@ fn dominates_all_leaves(
     let mut i: u64 = 0;
     while i < workflow.tasks.len() {
         if model.dependent_count(borrow workflow, i) == 0 && dominators.dominates(borrow dominance, task, i) {
-            dominated = dominated + 1;
+            dominated += 1;
         }
-        i = i + 1;
+        i += 1;
     }
     dominated == leaves
 }
@@ -79,7 +79,7 @@ pub fn compute(borrow workflow: model.Workflow) -> Analysis {
         if outgoing > maximum_out_degree { maximum_out_degree = outgoing; }
         digest = mix(digest, incoming); digest = mix(digest, outgoing);
         digest = mix(digest, paths.paths_through_task.get_or(i, 0));
-        i = i + 1;
+        i += 1;
     }
     let mut bridge_edges = model.U64s.new();
     i = 0;
@@ -90,7 +90,7 @@ pub fn compute(borrow workflow: model.Workflow) -> Analysis {
             model.dependency_count(borrow workflow, edge.after) == 1 {
             bridge_edges.push(edge_index);
         }
-        i = i + 1;
+        i += 1;
     }
     let gateway_count = gateways.len();
     let funnel_count = funnels.len();

--- a/examples/lattice/cycle_oracle.rue
+++ b/examples/lattice/cycle_oracle.rue
@@ -7,7 +7,7 @@ const Bools = std.arraybuf.ArrayBuf(bool);
 fn matrix(count: u64) -> Bools {
     let mut values = Bools.with_capacity(count * count);
     let mut i: u64 = 0;
-    while i < count * count { values.push(false); i = i + 1; }
+    while i < count * count { values.push(false); i += 1; }
     values
 }
 
@@ -50,7 +50,7 @@ pub fn compute(borrow workflow: model.Workflow) -> Closure {
     let mut comparable_pairs: u64 = 0;
     i = 0;
     while i < count {
-        if reachable.get_or(i * count + i, false) { cycle_vertices = cycle_vertices + 1; }
+        if reachable.get_or(i * count + i, false) { cycle_vertices += 1; }
         let mut j: u64 = i + 1;
         while j < count {
             if reachable.get_or(i * count + j, false) || reachable.get_or(j * count + i, false) {

--- a/examples/lattice/cycle_oracle.rue
+++ b/examples/lattice/cycle_oracle.rue
@@ -27,7 +27,7 @@ pub fn compute(borrow workflow: model.Workflow) -> Closure {
         if edge.before < count && edge.after < count {
             reachable.set(edge.before * count + edge.after, true);
         }
-        i = i + 1;
+        i += 1;
     }
     let mut middle: u64 = 0;
     while middle < count {
@@ -39,12 +39,12 @@ pub fn compute(borrow workflow: model.Workflow) -> Closure {
                     if reachable.get_or(middle * count + to, false) {
                         reachable.set(from * count + to, true);
                     }
-                    to = to + 1;
+                    to += 1;
                 }
             }
-            from = from + 1;
+            from += 1;
         }
-        middle = middle + 1;
+        middle += 1;
     }
     let mut cycle_vertices: u64 = 0;
     let mut comparable_pairs: u64 = 0;
@@ -54,11 +54,11 @@ pub fn compute(borrow workflow: model.Workflow) -> Closure {
         let mut j: u64 = i + 1;
         while j < count {
             if reachable.get_or(i * count + j, false) || reachable.get_or(j * count + i, false) {
-                comparable_pairs = comparable_pairs + 1;
+                comparable_pairs += 1;
             }
-            j = j + 1;
+            j += 1;
         }
-        i = i + 1;
+        i += 1;
     }
     Closure {
         reachable: reachable,

--- a/examples/lattice/diagnostics.rue
+++ b/examples/lattice/diagnostics.rue
@@ -22,7 +22,7 @@ pub fn render(borrow workflow: model.Workflow) -> StrBuf {
         text.append_literal(inout out, ": ");
         text.append_id(inout out, borrow workflow, item.detail);
         out.push(10);
-        i = i + 1;
+        i += 1;
     }
     out
 }

--- a/examples/lattice/dominators.rue
+++ b/examples/lattice/dominators.rue
@@ -18,7 +18,7 @@ pub struct Dominators {
 fn filled(count: u64, value: bool) -> Bools {
     let mut result = Bools.with_capacity(count);
     let mut i: u64 = 0;
-    while i < count { result.push(value); i = i + 1; }
+    while i < count { result.push(value); i += 1; }
     result
 }
 
@@ -100,7 +100,7 @@ pub fn compute(borrow workflow: model.Workflow) -> Dominators {
         while candidate < size {
             if matrix.get_or(at(size, task, candidate), false) {
                 chain += 1;
-                if candidate != task { strict_pairs = strict_pairs + 1; }
+                if candidate != task { strict_pairs += 1; }
                 digest = @wrapping_mul(digest ^ (task * size + candidate), 1099511628211);
             }
             candidate += 1;

--- a/examples/lattice/dominators.rue
+++ b/examples/lattice/dominators.rue
@@ -43,7 +43,7 @@ fn predecessor_allows(
             found = true;
             if !matrix.get_or(at(size, edge.before, candidate), false) { return false; }
         }
-        i = i + 1;
+        i += 1;
     }
     found
 }
@@ -56,21 +56,21 @@ pub fn compute(borrow workflow: model.Workflow) -> Dominators {
     let mut task: u64 = 0;
     while task < size {
         if is_root(borrow workflow, task) {
-            roots = roots + 1;
+            roots += 1;
             let mut candidate: u64 = 0;
             while candidate < size {
                 matrix.set(at(size, task, candidate), candidate == task);
-                candidate = candidate + 1;
+                candidate += 1;
             }
         }
-        task = task + 1;
+        task += 1;
     }
 
     let mut changed = true;
     let mut iterations: u64 = 0;
     while changed && iterations <= size + 1 {
         changed = false;
-        iterations = iterations + 1;
+        iterations += 1;
         let mut position: u64 = 0;
         while position < order.tasks.len() {
             task = order.tasks.get_or(position, model.NONE());
@@ -83,10 +83,10 @@ pub fn compute(borrow workflow: model.Workflow) -> Dominators {
                         matrix.set(index, next);
                         changed = true;
                     }
-                    candidate = candidate + 1;
+                    candidate += 1;
                 }
             }
-            position = position + 1;
+            position += 1;
         }
     }
 
@@ -99,14 +99,14 @@ pub fn compute(borrow workflow: model.Workflow) -> Dominators {
         let mut candidate: u64 = 0;
         while candidate < size {
             if matrix.get_or(at(size, task, candidate), false) {
-                chain = chain + 1;
+                chain += 1;
                 if candidate != task { strict_pairs = strict_pairs + 1; }
                 digest = @wrapping_mul(digest ^ (task * size + candidate), 1099511628211);
             }
-            candidate = candidate + 1;
+            candidate += 1;
         }
         if chain > maximum_chain { maximum_chain = chain; }
-        task = task + 1;
+        task += 1;
     }
     Dominators {
         matrix: matrix, size: size, iterations: iterations, roots: roots,
@@ -125,7 +125,7 @@ pub fn verify(borrow workflow: model.Workflow, borrow value: Dominators) -> bool
     let mut task: u64 = 0;
     while task < value.size {
         if !dominates(borrow value, task, task) { return false; }
-        task = task + 1;
+        task += 1;
     }
     true
 }

--- a/examples/lattice/event_analysis.rue
+++ b/examples/lattice/event_analysis.rue
@@ -39,7 +39,7 @@ fn maximum(borrow values: model.U64s) -> u64 {
     while i < values.len() {
         let value = values.get_or(i, 0);
         if value > result { result = value; }
-        i = i + 1;
+        i += 1;
     }
     result
 }
@@ -75,7 +75,7 @@ pub fn summarize(borrow workflow: model.Workflow, borrow run: state.Run) -> Summ
         digest = mix(digest, event.kind); digest = mix(digest, event.time);
         digest = mix(digest, event.task); digest = mix(digest, event.attempt);
         last_time = event.time;
-        i = i + 1;
+        i += 1;
     }
     if current_count > 1 { simultaneous_events = simultaneous_events + current_count; }
     if current_count > maximum_events_at_time { maximum_events_at_time = current_count; }

--- a/examples/lattice/event_analysis.rue
+++ b/examples/lattice/event_analysis.rue
@@ -25,7 +25,7 @@ pub struct Summary {
 fn zeroes(count: u64) -> model.U64s {
     let mut out = model.U64s.with_capacity(count);
     let mut i: u64 = 0;
-    while i < count { out.push(0); i = i + 1; }
+    while i < count { out.push(0); i += 1; }
     out
 }
 
@@ -62,9 +62,9 @@ pub fn summarize(borrow workflow: model.Workflow, borrow run: state.Run) -> Summ
     while i < run.events.len() {
         let event = run.events.get_or(i, state.empty_event());
         if i > 0 && event.time < last_time { valid = false; }
-        if event.time == current_time { current_count = current_count + 1; }
+        if event.time == current_time { current_count += 1; }
         else {
-            if current_count > 1 { simultaneous_events = simultaneous_events + current_count; }
+            if current_count > 1 { simultaneous_events += current_count; }
             if current_count > maximum_events_at_time { maximum_events_at_time = current_count; }
             current_time = event.time;
             current_count = 1;
@@ -77,7 +77,7 @@ pub fn summarize(borrow workflow: model.Workflow, borrow run: state.Run) -> Summ
         last_time = event.time;
         i += 1;
     }
-    if current_count > 1 { simultaneous_events = simultaneous_events + current_count; }
+    if current_count > 1 { simultaneous_events += current_count; }
     if current_count > maximum_events_at_time { maximum_events_at_time = current_count; }
     let maximum_task_events = maximum(borrow by_task);
     let maximum_pool_events = maximum(borrow by_pool);

--- a/examples/lattice/event_windows.rue
+++ b/examples/lattice/event_windows.rue
@@ -21,7 +21,7 @@ pub struct Analysis {
 fn zeroes(count: u64) -> model.U64s {
     let mut values = model.U64s.with_capacity(count);
     let mut i: u64 = 0;
-    while i < count { values.push(0); i = i + 1; }
+    while i < count { values.push(0); i += 1; }
     values
 }
 
@@ -63,7 +63,7 @@ pub fn compute(borrow run: state.Run, requested_windows: u64) -> Analysis {
     while i < windows {
         let count = events_by_window.get_or(i, 0);
         counted_events += count;
-        if count == 0 { quiet_windows = quiet_windows + 1; }
+        if count == 0 { quiet_windows += 1; }
         if count > busiest_events { busiest_events = count; busiest_window = i; }
         digest = mix(digest, count);
         i += 1;

--- a/examples/lattice/event_windows.rue
+++ b/examples/lattice/event_windows.rue
@@ -53,7 +53,7 @@ pub fn compute(borrow run: state.Run, requested_windows: u64) -> Analysis {
         else if event.kind == state.EVENT_RETRY() { increment(inout retries_by_window, window); }
         else if event.kind == state.EVENT_CACHE() { increment(inout cache_hits_by_window, window); }
         digest = mix(digest, window); digest = mix(digest, event.kind);
-        i = i + 1;
+        i += 1;
     }
     let mut busiest_window: u64 = 0;
     let mut busiest_events: u64 = 0;
@@ -62,11 +62,11 @@ pub fn compute(borrow run: state.Run, requested_windows: u64) -> Analysis {
     i = 0;
     while i < windows {
         let count = events_by_window.get_or(i, 0);
-        counted_events = counted_events + count;
+        counted_events += count;
         if count == 0 { quiet_windows = quiet_windows + 1; }
         if count > busiest_events { busiest_events = count; busiest_window = i; }
         digest = mix(digest, count);
-        i = i + 1;
+        i += 1;
     }
     Analysis {
         events_by_window: events_by_window, starts_by_window: starts_by_window,

--- a/examples/lattice/explain.rue
+++ b/examples/lattice/explain.rue
@@ -67,7 +67,7 @@ fn event_counts(borrow run: state.Run, task: u64) -> model.U64s {
         if event.task == task && event.kind < counts.len() {
             counts.set(event.kind, counts.get_or(event.kind, 0) + 1);
         }
-        i = i + 1;
+        i += 1;
     }
     counts
 }
@@ -85,12 +85,12 @@ fn one(
     while i < workflow.edges.len() {
         let edge = workflow.edges.get_or(i, model.empty_edge());
         if edge.after == task {
-            dependencies = dependencies + 1;
+            dependencies += 1;
             let dependency_status = run.status.get_or(edge.before, state.FAILED());
             if state.successful(dependency_status) { successful_dependencies = successful_dependencies + 1; }
             else if dependency_status == state.FAILED() { failed_dependencies = failed_dependencies + 1; }
         }
-        i = i + 1;
+        i += 1;
     }
     let counts = event_counts(borrow run, task);
     let status = run.status.get_or(task, state.FAILED());

--- a/examples/lattice/explain.rue
+++ b/examples/lattice/explain.rue
@@ -60,7 +60,7 @@ fn classify(status: u64, attempts: u64, failed_dependencies: u64) -> u64 {
 fn event_counts(borrow run: state.Run, task: u64) -> model.U64s {
     let mut counts = model.U64s.with_capacity(7);
     let mut i: u64 = 0;
-    while i < 7 { counts.push(0); i = i + 1; }
+    while i < 7 { counts.push(0); i += 1; }
     i = 0;
     while i < run.events.len() {
         let event = run.events.get_or(i, state.empty_event());
@@ -87,8 +87,8 @@ fn one(
         if edge.after == task {
             dependencies += 1;
             let dependency_status = run.status.get_or(edge.before, state.FAILED());
-            if state.successful(dependency_status) { successful_dependencies = successful_dependencies + 1; }
-            else if dependency_status == state.FAILED() { failed_dependencies = failed_dependencies + 1; }
+            if state.successful(dependency_status) { successful_dependencies += 1; }
+            else if dependency_status == state.FAILED() { failed_dependencies += 1; }
         }
         i += 1;
     }
@@ -133,15 +133,15 @@ pub fn compute(borrow workflow: model.Workflow, borrow run: state.Run) -> Analys
     let mut i: u64 = 0;
     while i < workflow.tasks.len() {
         let value = one(borrow workflow, borrow run, borrow queue, i);
-        if value.classification == COMPLETED() { completed = completed + 1; }
-        else if value.classification == CACHE_HIT() { cached = cached + 1; }
-        else if value.classification == RETRIED() { retried = retried + 1; }
-        else if value.classification == EXHAUSTED() { exhausted = exhausted + 1; }
-        else if value.classification == BLOCKED() { blocked = blocked + 1; }
-        else { pending = pending + 1; }
-        if !value.consistent { inconsistencies = inconsistencies + 1; }
+        if value.classification == COMPLETED() { completed += 1; }
+        else if value.classification == CACHE_HIT() { cached += 1; }
+        else if value.classification == RETRIED() { retried += 1; }
+        else if value.classification == EXHAUSTED() { exhausted += 1; }
+        else if value.classification == BLOCKED() { blocked += 1; }
+        else { pending += 1; }
+        if !value.consistent { inconsistencies += 1; }
         digest = mix(digest, value.digest);
-        tasks.push(value); i = i + 1;
+        tasks.push(value); i += 1;
     }
     Analysis {
         tasks: tasks, completed: completed, cached: cached, retried: retried,

--- a/examples/lattice/fingerprint.rue
+++ b/examples/lattice/fingerprint.rue
@@ -12,7 +12,7 @@ pub fn workflow(borrow value: model.Workflow) -> u64 {
         let item = value.pools.get_or(i, model.empty_pool());
         hash = mix(hash, value.strings.hash(item.id));
         hash = mix(hash, item.slots); hash = mix(hash, item.cpu); hash = mix(hash, item.memory);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < value.tasks.len() {
@@ -21,7 +21,7 @@ pub fn workflow(borrow value: model.Workflow) -> u64 {
         hash = mix(hash, item.duration); hash = mix(hash, item.cpu); hash = mix(hash, item.memory);
         hash = mix(hash, item.priority); hash = mix(hash, item.retries);
         hash = mix(hash, if item.cacheable { 1 } else { 0 }); hash = mix(hash, item.fail_attempt);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < value.edges.len() {
@@ -38,7 +38,7 @@ pub fn run(borrow value: state.Run) -> u64 {
         let event = value.events.get_or(i, state.empty_event());
         hash = mix(hash, event.kind); hash = mix(hash, event.time); hash = mix(hash, event.task);
         hash = mix(hash, event.pool); hash = mix(hash, event.attempt); hash = mix(hash, event.cpu); hash = mix(hash, event.memory);
-        i = i + 1;
+        i += 1;
     }
     hash = mix(hash, value.makespan); hash = mix(hash, value.succeeded);
     hash = mix(hash, value.failed); hash = mix(hash, value.cached); hash = mix(hash, value.retries);

--- a/examples/lattice/fingerprint.rue
+++ b/examples/lattice/fingerprint.rue
@@ -26,7 +26,7 @@ pub fn workflow(borrow value: model.Workflow) -> u64 {
     i = 0;
     while i < value.edges.len() {
         let edge = value.edges.get_or(i, model.empty_edge());
-        hash = mix(hash, edge.before); hash = mix(hash, edge.after); i = i + 1;
+        hash = mix(hash, edge.before); hash = mix(hash, edge.after); i += 1;
     }
     hash
 }

--- a/examples/lattice/forecast.rue
+++ b/examples/lattice/forecast.rue
@@ -27,7 +27,7 @@ fn seen(borrow fingerprints: model.U64s, value: u64) -> bool {
     let mut i: u64 = 0;
     while i < fingerprints.len() {
         if fingerprints.get_or(i, 0) == value { return true; }
-        i = i + 1;
+        i += 1;
     }
     false
 }
@@ -57,13 +57,13 @@ pub fn compute(borrow workflow: model.Workflow, base_seed: u64, samples: u64) ->
         fingerprints.push(run.fingerprint);
         if i == 0 || run.makespan < minimum_makespan { minimum_makespan = run.makespan; }
         if i == 0 || run.makespan > maximum_makespan { maximum_makespan = run.makespan; }
-        total_makespan = total_makespan + run.makespan;
-        total_cache_hits = total_cache_hits + run.cached;
-        total_retries = total_retries + run.retries;
+        total_makespan += run.makespan;
+        total_cache_hits += run.cached;
+        total_retries += run.retries;
         if run.failed > 0 { failed_samples = failed_samples + 1; }
         digest = mix(digest, seed); digest = mix(digest, run.makespan);
         digest = mix(digest, run.cached); digest = mix(digest, run.fingerprint);
-        i = i + 1;
+        i += 1;
     }
     Forecast {
         seeds: seeds, makespans: makespans, cache_hits: cache_hits,

--- a/examples/lattice/forecast.rue
+++ b/examples/lattice/forecast.rue
@@ -53,14 +53,14 @@ pub fn compute(borrow workflow: model.Workflow, base_seed: u64, samples: u64) ->
         let run = schedule.run(borrow workflow, seed);
         seeds.push(seed); makespans.push(run.makespan);
         cache_hits.push(run.cached); retries.push(run.retries);
-        if seen(borrow fingerprints, run.fingerprint) { duplicate_fingerprints = duplicate_fingerprints + 1; }
+        if seen(borrow fingerprints, run.fingerprint) { duplicate_fingerprints += 1; }
         fingerprints.push(run.fingerprint);
         if i == 0 || run.makespan < minimum_makespan { minimum_makespan = run.makespan; }
         if i == 0 || run.makespan > maximum_makespan { maximum_makespan = run.makespan; }
         total_makespan += run.makespan;
         total_cache_hits += run.cached;
         total_retries += run.retries;
-        if run.failed > 0 { failed_samples = failed_samples + 1; }
+        if run.failed > 0 { failed_samples += 1; }
         digest = mix(digest, seed); digest = mix(digest, run.makespan);
         digest = mix(digest, run.cached); digest = mix(digest, run.fingerprint);
         i += 1;

--- a/examples/lattice/format.rue
+++ b/examples/lattice/format.rue
@@ -45,7 +45,7 @@ pub fn csv_id(inout out: StrBuf, borrow workflow: model.Workflow, id: u64) {
         let byte = workflow.strings.byte_at(id, i);
         if byte == 34 { out.push(34); out.push(34); }
         else { out.push(byte); }
-        i = i + 1;
+        i += 1;
     }
     out.push(34);
 }
@@ -59,7 +59,7 @@ pub fn dot_id(inout out: StrBuf, borrow workflow: model.Workflow, id: u64) {
         else if byte == 92 { text.append_literal(inout out, "\\\\"); }
         else if byte == 10 { text.append_literal(inout out, "\\n"); }
         else { out.push(byte); }
-        i = i + 1;
+        i += 1;
     }
     out.push(34);
 }
@@ -71,7 +71,7 @@ pub fn markdown_id(inout out: StrBuf, borrow workflow: model.Workflow, id: u64) 
         if byte == 124 { text.append_literal(inout out, "\\|"); }
         else if byte == 10 { text.append_literal(inout out, "<br>"); }
         else { out.push(byte); }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -80,6 +80,6 @@ pub fn append_bar(inout out: StrBuf, numerator: u64, denominator: u64, width: u6
     let mut i: u64 = 0;
     while i < width {
         if i < filled { out.push(35); } else { out.push(46); }
-        i = i + 1;
+        i += 1;
     }
 }

--- a/examples/lattice/generate.rue
+++ b/examples/lattice/generate.rue
@@ -27,7 +27,7 @@ pub fn workflow(tasks: u64, pools: u64, width: u64, seed: u64) -> model.Workflow
             id: id, slots: 2 + (i % 4), cpu: 4 + (i % 3) * 2,
             memory: 8 + (i % 5) * 4,
         });
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < tasks {
@@ -45,7 +45,7 @@ pub fn workflow(tasks: u64, pools: u64, width: u64, seed: u64) -> model.Workflow
             // downstream blocking have separate fixture coverage.
             fail_attempt: if i % 17 == 8 && i % 3 > 0 { 1 } else { 0 },
         });
-        i = i + 1;
+        i += 1;
     }
     let span = if width < 2 { 2 } else { width };
     i = 1;
@@ -72,7 +72,7 @@ pub fn workflow(tasks: u64, pools: u64, width: u64, seed: u64) -> model.Workflow
                 });
             }
         }
-        i = i + 1;
+        i += 1;
     }
     result
 }

--- a/examples/lattice/insights.rue
+++ b/examples/lattice/insights.rue
@@ -38,7 +38,7 @@ fn mix(hash: u64, value: u64) -> u64 { @wrapping_mul(hash ^ value, 1099511628211
 
 fn check(inout checks: u64, inout failures: u64, condition: bool) {
     checks += 1;
-    if !condition { failures = failures + 1; }
+    if !condition { failures += 1; }
 }
 
 pub fn compute(borrow workflow: model.Workflow, borrow run: state.Run, seed: u64) -> Insights {

--- a/examples/lattice/insights.rue
+++ b/examples/lattice/insights.rue
@@ -37,7 +37,7 @@ pub struct Insights {
 fn mix(hash: u64, value: u64) -> u64 { @wrapping_mul(hash ^ value, 1099511628211) }
 
 fn check(inout checks: u64, inout failures: u64, condition: bool) {
-    checks = checks + 1;
+    checks += 1;
     if !condition { failures = failures + 1; }
 }
 

--- a/examples/lattice/levels.rue
+++ b/examples/lattice/levels.rue
@@ -19,7 +19,7 @@ pub struct Layers {
 fn zeroes(count: u64) -> U64s {
     let mut values = U64s.with_capacity(count);
     let mut i: u64 = 0;
-    while i < count { values.push(0); i = i + 1; }
+    while i < count { values.push(0); i += 1; }
     values
 }
 

--- a/examples/lattice/levels.rue
+++ b/examples/lattice/levels.rue
@@ -36,7 +36,7 @@ fn predecessor_level(borrow workflow: model.Workflow, borrow levels: U64s, task:
             let candidate = levels.get_or(edge.before, 0) + 1;
             if candidate > result { result = candidate; }
         }
-        i = i + 1;
+        i += 1;
     }
     result
 }
@@ -54,7 +54,7 @@ pub fn compute(borrow workflow: model.Workflow) -> Layers {
         if level + 1 > depth { depth = level + 1; }
         digest = mix(digest, task);
         digest = mix(digest, level);
-        i = i + 1;
+        i += 1;
     }
     let mut tasks_by_level = zeroes(depth);
     i = 0;
@@ -63,7 +63,7 @@ pub fn compute(borrow workflow: model.Workflow) -> Layers {
         if level < tasks_by_level.len() {
             tasks_by_level.set(level, tasks_by_level.get_or(level, 0) + 1);
         }
-        i = i + 1;
+        i += 1;
     }
     let mut maximum_width: u64 = 0;
     let mut widest_level: u64 = 0;
@@ -72,7 +72,7 @@ pub fn compute(borrow workflow: model.Workflow) -> Layers {
         let width = tasks_by_level.get_or(i, 0);
         if width > maximum_width { maximum_width = width; widest_level = i; }
         digest = mix(digest, width);
-        i = i + 1;
+        i += 1;
     }
     Layers {
         level_by_task: level_by_task,
@@ -101,13 +101,13 @@ pub fn verify(borrow workflow: model.Workflow, borrow layers: Layers) -> bool {
     while i < workflow.edges.len() {
         let edge = workflow.edges.get_or(i, model.empty_edge());
         if level(borrow layers, edge.before) >= level(borrow layers, edge.after) { return false; }
-        i = i + 1;
+        i += 1;
     }
     let mut total: u64 = 0;
     i = 0;
     while i < layers.tasks_by_level.len() {
-        total = total + width(borrow layers, i);
-        i = i + 1;
+        total += width(borrow layers, i);
+        i += 1;
     }
     total == workflow.tasks.len()
 }

--- a/examples/lattice/lexer.rue
+++ b/examples/lattice/lexer.rue
@@ -40,7 +40,7 @@ struct Lexer {
 
     fn advance(inout self) -> u8 {
         let value = self.byte(self.at);
-        self.at = self.at + 1;
+        self.at += 1;
         value
     }
 

--- a/examples/lattice/lint.rue
+++ b/examples/lattice/lint.rue
@@ -149,7 +149,7 @@ fn pool_rules(inout findings: Findings, borrow workflow: model.Workflow) {
         let mut tasks: u64 = 0;
         let mut i: u64 = 0;
         while i < workflow.tasks.len() {
-            if workflow.tasks.get_or(i, model.empty_task()).pool == pool_index { tasks = tasks + 1; }
+            if workflow.tasks.get_or(i, model.empty_task()).pool == pool_index { tasks += 1; }
             i += 1;
         }
         if pool.slots == 1 && tasks > 5 {
@@ -185,13 +185,13 @@ pub fn compute(borrow workflow: model.Workflow, borrow run: state.Run) -> Report
     i = 0;
     while i < findings.len() {
         let finding = findings.get_or(i, empty_finding());
-        if finding.severity == ERROR() { errors = errors + 1; }
-        else if finding.severity == WARNING() { warnings = warnings + 1; }
-        else { infos = infos + 1; }
-        if finding.task != model.NONE() { task_findings = task_findings + 1; }
-        else if finding.pool != model.NONE() { pool_findings = pool_findings + 1; }
-        else if finding.edge != model.NONE() { edge_findings = edge_findings + 1; }
-        else { global_findings = global_findings + 1; }
+        if finding.severity == ERROR() { errors += 1; }
+        else if finding.severity == WARNING() { warnings += 1; }
+        else { infos += 1; }
+        if finding.task != model.NONE() { task_findings += 1; }
+        else if finding.pool != model.NONE() { pool_findings += 1; }
+        else if finding.edge != model.NONE() { edge_findings += 1; }
+        else { global_findings += 1; }
         digest = mix(digest, finding.rule); digest = mix(digest, finding.severity);
         digest = mix(digest, finding.actual); digest = mix(digest, finding.threshold);
         i += 1;

--- a/examples/lattice/lint.rue
+++ b/examples/lattice/lint.rue
@@ -127,7 +127,7 @@ fn edge_rules(
     while i < reduction.redundant.len() {
         let edge_index = reduction.redundant.get_or(i, model.NONE());
         add(inout findings, REDUNDANT_DEPENDENCY(), INFO(), model.NONE(), model.NONE(), edge_index, 1, 0);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < reduction.essential.len() {
@@ -138,7 +138,7 @@ fn edge_rules(
         if before.pool != after.pool {
             add(inout findings, CROSS_POOL_DEPENDENCY(), INFO(), model.NONE(), model.NONE(), edge_index, before.pool, after.pool);
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -150,12 +150,12 @@ fn pool_rules(inout findings: Findings, borrow workflow: model.Workflow) {
         let mut i: u64 = 0;
         while i < workflow.tasks.len() {
             if workflow.tasks.get_or(i, model.empty_task()).pool == pool_index { tasks = tasks + 1; }
-            i = i + 1;
+            i += 1;
         }
         if pool.slots == 1 && tasks > 5 {
             add(inout findings, SINGLE_SLOT_HOT_POOL(), WARNING(), model.NONE(), pool_index, model.NONE(), tasks, 5);
         }
-        pool_index = pool_index + 1;
+        pool_index += 1;
     }
 }
 
@@ -166,7 +166,7 @@ pub fn compute(borrow workflow: model.Workflow, borrow run: state.Run) -> Report
     let mut i: u64 = 0;
     while i < workflow.tasks.len() {
         task_rules(inout findings, borrow workflow, borrow run, borrow queue, i);
-        i = i + 1;
+        i += 1;
     }
     edge_rules(inout findings, borrow workflow, borrow reduction);
     pool_rules(inout findings, borrow workflow);
@@ -194,7 +194,7 @@ pub fn compute(borrow workflow: model.Workflow, borrow run: state.Run) -> Report
         else { global_findings = global_findings + 1; }
         digest = mix(digest, finding.rule); digest = mix(digest, finding.severity);
         digest = mix(digest, finding.actual); digest = mix(digest, finding.threshold);
-        i = i + 1;
+        i += 1;
     }
     let count = findings.len();
     Report {

--- a/examples/lattice/metric.rue
+++ b/examples/lattice/metric.rue
@@ -45,15 +45,15 @@ pub fn observe(inout metric: Metric, value: u64, weight: u64) {
     metric.weighted = add(metric.weighted, multiply(value, weight));
     if value < metric.minimum { metric.minimum = value; }
     if value > metric.maximum { metric.maximum = value; }
-    if value == 0 { metric.zeroes = metric.zeroes + 1; }
-    if value % 2 == 0 { metric.even = metric.even + 1; }
-    else { metric.odd = metric.odd + 1; }
+    if value == 0 { metric.zeroes += 1; }
+    if value % 2 == 0 { metric.even += 1; }
+    else { metric.odd += 1; }
     metric.digest = mix(metric.digest, value);
     metric.digest = mix(metric.digest, weight);
 }
 
 pub fn warn(inout metric: Metric, condition: bool) {
-    if condition { metric.warnings = metric.warnings + 1; }
+    if condition { metric.warnings += 1; }
 }
 
 pub fn finish(inout metric: Metric) {

--- a/examples/lattice/metric.rue
+++ b/examples/lattice/metric.rue
@@ -40,7 +40,7 @@ pub fn multiply(a: u64, b: u64) -> u64 {
 }
 
 pub fn observe(inout metric: Metric, value: u64, weight: u64) {
-    metric.observations = metric.observations + 1;
+    metric.observations += 1;
     metric.sum = add(metric.sum, value);
     metric.weighted = add(metric.weighted, multiply(value, weight));
     if value < metric.minimum { metric.minimum = value; }

--- a/examples/lattice/model.rue
+++ b/examples/lattice/model.rue
@@ -125,7 +125,7 @@ pub fn dependency_count(borrow workflow: Workflow, task: u64) -> u64 {
     let mut count: u64 = 0;
     let mut i: u64 = 0;
     while i < workflow.edges.len() {
-        if workflow.edges.get_or(i, empty_edge()).after == task { count = count + 1; }
+        if workflow.edges.get_or(i, empty_edge()).after == task { count += 1; }
         i += 1;
     }
     count
@@ -135,7 +135,7 @@ pub fn dependent_count(borrow workflow: Workflow, task: u64) -> u64 {
     let mut count: u64 = 0;
     let mut i: u64 = 0;
     while i < workflow.edges.len() {
-        if workflow.edges.get_or(i, empty_edge()).before == task { count = count + 1; }
+        if workflow.edges.get_or(i, empty_edge()).before == task { count += 1; }
         i += 1;
     }
     count

--- a/examples/lattice/model.rue
+++ b/examples/lattice/model.rue
@@ -106,7 +106,7 @@ pub fn find_pool(borrow workflow: Workflow, id: u64) -> u64 {
     while i < workflow.pools.len() {
         let item = workflow.pools.get_or(i, empty_pool());
         if workflow.strings.ids_equal(item.id, id) { return i; }
-        i = i + 1;
+        i += 1;
     }
     NONE()
 }
@@ -116,7 +116,7 @@ pub fn find_task(borrow workflow: Workflow, id: u64) -> u64 {
     while i < workflow.tasks.len() {
         let item = workflow.tasks.get_or(i, empty_task());
         if workflow.strings.ids_equal(item.id, id) { return i; }
-        i = i + 1;
+        i += 1;
     }
     NONE()
 }
@@ -126,7 +126,7 @@ pub fn dependency_count(borrow workflow: Workflow, task: u64) -> u64 {
     let mut i: u64 = 0;
     while i < workflow.edges.len() {
         if workflow.edges.get_or(i, empty_edge()).after == task { count = count + 1; }
-        i = i + 1;
+        i += 1;
     }
     count
 }
@@ -136,7 +136,7 @@ pub fn dependent_count(borrow workflow: Workflow, task: u64) -> u64 {
     let mut i: u64 = 0;
     while i < workflow.edges.len() {
         if workflow.edges.get_or(i, empty_edge()).before == task { count = count + 1; }
-        i = i + 1;
+        i += 1;
     }
     count
 }
@@ -146,7 +146,7 @@ pub fn has_edge(borrow workflow: Workflow, before: u64, after: u64) -> bool {
     while i < workflow.edges.len() {
         let edge = workflow.edges.get_or(i, empty_edge());
         if edge.before == before && edge.after == after { return true; }
-        i = i + 1;
+        i += 1;
     }
     false
 }

--- a/examples/lattice/parser.rue
+++ b/examples/lattice/parser.rue
@@ -26,7 +26,7 @@ struct Parser {
 
     fn advance(inout self) -> token.Token {
         let value = self.peek();
-        if value.kind != token.EOF { self.at = self.at + 1; }
+        if value.kind != token.EOF { self.at += 1; }
         value
     }
 

--- a/examples/lattice/path_catalog.rue
+++ b/examples/lattice/path_catalog.rue
@@ -26,7 +26,7 @@ fn zeroes(count: u64) -> model.U64s {
 fn saturating_add(left: u64, right: u64, inout saturated: u64) -> u64 {
     let sum = @wrapping_add(left, right);
     if sum < left || sum < right {
-        saturated = saturated + 1;
+        saturated += 1;
         18446744073709551615
     } else { sum }
 }
@@ -35,7 +35,7 @@ fn saturating_multiply(left: u64, right: u64, inout saturated: u64) -> u64 {
     if left == 0 || right == 0 { return 0; }
     let product = @wrapping_mul(left, right);
     if product / left != right {
-        saturated = saturated + 1;
+        saturated += 1;
         18446744073709551615
     } else { product }
 }
@@ -56,19 +56,19 @@ pub fn compute(borrow workflow: model.Workflow) -> Catalog {
         while edge_index < workflow.edges.len() {
             let edge = workflow.edges.get_or(edge_index, model.empty_edge());
             if edge.after == task {
-                predecessors = predecessors + 1;
+                predecessors += 1;
                 paths = saturating_add(paths, paths_from_roots.get_or(edge.before, 0), inout saturated_additions);
             }
-            edge_index = edge_index + 1;
+            edge_index += 1;
         }
         if predecessors == 0 { paths = 1; }
         paths_from_roots.set(task, paths);
-        position = position + 1;
+        position += 1;
     }
 
     position = order.tasks.len();
     while position > 0 {
-        position = position - 1;
+        position -= 1;
         let task = order.tasks.get_or(position, model.NONE());
         let mut paths: u64 = 0;
         let mut successors: u64 = 0;
@@ -76,10 +76,10 @@ pub fn compute(borrow workflow: model.Workflow) -> Catalog {
         while edge_index < workflow.edges.len() {
             let edge = workflow.edges.get_or(edge_index, model.empty_edge());
             if edge.before == task {
-                successors = successors + 1;
+                successors += 1;
                 paths = saturating_add(paths, paths_to_leaves.get_or(edge.after, 0), inout saturated_additions);
             }
-            edge_index = edge_index + 1;
+            edge_index += 1;
         }
         if successors == 0 { paths = 1; }
         paths_to_leaves.set(task, paths);
@@ -100,14 +100,14 @@ pub fn compute(borrow workflow: model.Workflow) -> Catalog {
         paths_through_task.set(i, through);
         if model.dependency_count(borrow workflow, i) == 0 { roots = roots + 1; }
         if model.dependent_count(borrow workflow, i) == 0 {
-            leaves = leaves + 1;
+            leaves += 1;
             total_paths = saturating_add(total_paths, from, inout saturated_additions);
         }
         if maximum_through_task == model.NONE() || through > maximum_through {
             maximum_through = through; maximum_through_task = i;
         }
         digest = mix(digest, from); digest = mix(digest, to); digest = mix(digest, through);
-        i = i + 1;
+        i += 1;
     }
     Catalog {
         paths_from_roots: paths_from_roots, paths_to_leaves: paths_to_leaves,

--- a/examples/lattice/path_catalog.rue
+++ b/examples/lattice/path_catalog.rue
@@ -19,7 +19,7 @@ pub struct Catalog {
 fn zeroes(count: u64) -> model.U64s {
     let mut result = model.U64s.with_capacity(count);
     let mut i: u64 = 0;
-    while i < count { result.push(0); i = i + 1; }
+    while i < count { result.push(0); i += 1; }
     result
 }
 
@@ -98,7 +98,7 @@ pub fn compute(borrow workflow: model.Workflow) -> Catalog {
         let to = paths_to_leaves.get_or(i, 0);
         let through = saturating_multiply(from, to, inout saturated_additions);
         paths_through_task.set(i, through);
-        if model.dependency_count(borrow workflow, i) == 0 { roots = roots + 1; }
+        if model.dependency_count(borrow workflow, i) == 0 { roots += 1; }
         if model.dependent_count(borrow workflow, i) == 0 {
             leaves += 1;
             total_paths = saturating_add(total_paths, from, inout saturated_additions);

--- a/examples/lattice/policy.rue
+++ b/examples/lattice/policy.rue
@@ -98,7 +98,7 @@ fn uncacheable_long_tasks(borrow workflow: model.Workflow, threshold: u64) -> u6
     let mut i: u64 = 0;
     while i < workflow.tasks.len() {
         let task = workflow.tasks.get_or(i, model.empty_task());
-        if task.duration >= threshold && !task.cacheable { count = count + 1; }
+        if task.duration >= threshold && !task.cacheable { count += 1; }
         i += 1;
     }
     count

--- a/examples/lattice/policy.rue
+++ b/examples/lattice/policy.rue
@@ -78,17 +78,17 @@ pub fn production() -> Policy {
 fn mix(hash: u64, value: u64) -> u64 { @wrapping_mul(hash ^ value, 1099511628211) }
 
 fn maximum(inout result: Evaluation, code: u64, actual: u64, expected: u64, task: u64) {
-    result.checks = result.checks + 1;
+    result.checks += 1;
     if expected != model.NONE() && actual > expected {
-        result.failures = result.failures + 1;
+        result.failures += 1;
         result.violations.push(Violation { code: code, actual: actual, expected: expected, task: task, pool: model.NONE() });
     }
 }
 
 fn minimum(inout result: Evaluation, code: u64, actual: u64, expected: u64) {
-    result.checks = result.checks + 1;
+    result.checks += 1;
     if actual < expected {
-        result.failures = result.failures + 1;
+        result.failures += 1;
         result.violations.push(Violation { code: code, actual: actual, expected: expected, task: model.NONE(), pool: model.NONE() });
     }
 }
@@ -99,7 +99,7 @@ fn uncacheable_long_tasks(borrow workflow: model.Workflow, threshold: u64) -> u6
     while i < workflow.tasks.len() {
         let task = workflow.tasks.get_or(i, model.empty_task());
         if task.duration >= threshold && !task.cacheable { count = count + 1; }
-        i = i + 1;
+        i += 1;
     }
     count
 }

--- a/examples/lattice/pool.rue
+++ b/examples/lattice/pool.rue
@@ -45,7 +45,7 @@ pub struct Pool {
         let mut i: u64 = 0;
         while i < value.len() {
             if self.byte_at(id, i) != Self.byte_of(borrow value, i) { return false; }
-            i = i + 1;
+            i += 1;
         }
         true
     }
@@ -55,7 +55,7 @@ pub struct Pool {
         let mut i: u64 = 0;
         while i < self.string_len(first) {
             if self.byte_at(first, i) != self.byte_at(second, i) { return false; }
-            i = i + 1;
+            i += 1;
         }
         true
     }
@@ -77,7 +77,7 @@ pub struct Pool {
         let mut i: u64 = 0;
         while i < value.len() {
             self.bytes.push(Self.byte_of(borrow value, i));
-            i = i + 1;
+            i += 1;
         }
         id
     }
@@ -90,7 +90,7 @@ pub struct Pool {
         let mut i: u64 = 0;
         while i < self.string_len(id) {
             out.push(self.byte_at(id, i));
-            i = i + 1;
+            i += 1;
         }
     }
 
@@ -104,9 +104,9 @@ pub struct Pool {
         let mut value: u64 = 14695981039346656037;
         let mut i: u64 = 0;
         while i < self.string_len(id) {
-            value = value ^ @intCast(self.byte_at(id, i));
+            value ^= @intCast(self.byte_at(id, i));
             value = @wrapping_mul(value, 1099511628211);
-            i = i + 1;
+            i += 1;
         }
         value
     }

--- a/examples/lattice/pool_analysis.rue
+++ b/examples/lattice/pool_analysis.rue
@@ -59,7 +59,7 @@ pub fn compute(borrow workflow: model.Workflow, borrow run: state.Run) -> Analys
         add(inout declared_work, task.pool, task.duration);
         add(inout cpu_ticks, task.pool, task.duration * task.cpu);
         add(inout memory_ticks, task.pool, task.duration * task.memory);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < run.events.len() {
@@ -67,7 +67,7 @@ pub fn compute(borrow workflow: model.Workflow, borrow run: state.Run) -> Analys
         if event.kind == state.EVENT_START() { add(inout starts, event.pool, 1); }
         else if event.kind == state.EVENT_SUCCESS() { add(inout completed, event.pool, 1); }
         else if event.kind == state.EVENT_FAILURE() { add(inout failed, event.pool, 1); }
-        i = i + 1;
+        i += 1;
     }
     let mut slot_pressure = zeroes(count);
     let mut cpu_pressure = zeroes(count);
@@ -94,7 +94,7 @@ pub fn compute(borrow workflow: model.Workflow, borrow run: state.Run) -> Analys
         }
         digest = mix(digest, assigned_tasks.get_or(i, 0)); digest = mix(digest, declared_work.get_or(i, 0));
         digest = mix(digest, slot_value); digest = mix(digest, cpu_value); digest = mix(digest, memory_value);
-        i = i + 1;
+        i += 1;
     }
     let mut cross_pool_edges: u64 = 0;
     let mut same_pool_edges: u64 = 0;
@@ -105,7 +105,7 @@ pub fn compute(borrow workflow: model.Workflow, borrow run: state.Run) -> Analys
         let after = workflow.tasks.get_or(edge.after, model.empty_task());
         if before.pool == after.pool { same_pool_edges = same_pool_edges + 1; }
         else { cross_pool_edges = cross_pool_edges + 1; }
-        i = i + 1;
+        i += 1;
     }
     Analysis {
         assigned_tasks: assigned_tasks, declared_work: declared_work,

--- a/examples/lattice/pool_analysis.rue
+++ b/examples/lattice/pool_analysis.rue
@@ -28,7 +28,7 @@ pub struct Analysis {
 fn zeroes(count: u64) -> model.U64s {
     let mut values = model.U64s.with_capacity(count);
     let mut i: u64 = 0;
-    while i < count { values.push(0); i = i + 1; }
+    while i < count { values.push(0); i += 1; }
     values
 }
 
@@ -103,8 +103,8 @@ pub fn compute(borrow workflow: model.Workflow, borrow run: state.Run) -> Analys
         let edge = workflow.edges.get_or(i, model.empty_edge());
         let before = workflow.tasks.get_or(edge.before, model.empty_task());
         let after = workflow.tasks.get_or(edge.after, model.empty_task());
-        if before.pool == after.pool { same_pool_edges = same_pool_edges + 1; }
-        else { cross_pool_edges = cross_pool_edges + 1; }
+        if before.pool == after.pool { same_pool_edges += 1; }
+        else { cross_pool_edges += 1; }
         i += 1;
     }
     Analysis {

--- a/examples/lattice/portfolio.rue
+++ b/examples/lattice/portfolio.rue
@@ -61,7 +61,7 @@ pub struct Summary {
 }
 
 fn record(inout summary: Summary, value: metric.Metric, verified: bool) {
-    summary.passes = summary.passes + 1;
+    summary.passes += 1;
     summary.observations = metric.add(summary.observations, value.observations);
     summary.warnings = metric.add(summary.warnings, value.warnings);
     summary.sum = metric.add(summary.sum, value.sum);

--- a/examples/lattice/portfolio.rue
+++ b/examples/lattice/portfolio.rue
@@ -68,7 +68,7 @@ fn record(inout summary: Summary, value: metric.Metric, verified: bool) {
     summary.weighted = metric.add(summary.weighted, value.weighted);
     summary.digest = metric.mix(summary.digest, value.tag);
     summary.digest = metric.mix(summary.digest, value.digest);
-    if !verified { summary.verification_failures = summary.verification_failures + 1; }
+    if !verified { summary.verification_failures += 1; }
 }
 
 pub fn analyze(borrow workflow: model.Workflow) -> Summary {

--- a/examples/lattice/priority_analysis.rue
+++ b/examples/lattice/priority_analysis.rue
@@ -49,7 +49,7 @@ pub fn compute(borrow workflow: model.Workflow, borrow run: state.Run) -> Analys
         let start = run.starts.get_or(i, 0);
         if start != model.NONE() { weighted_wait = weighted_wait + start * (task.priority + 1); }
         digest = mix(digest, task.priority); digest = mix(digest, start);
-        i = i + 1;
+        i += 1;
     }
     let mut edge_inversions: u64 = 0;
     let mut edge_ties: u64 = 0;
@@ -68,7 +68,7 @@ pub fn compute(borrow workflow: model.Workflow, borrow run: state.Run) -> Analys
         if before.priority < after.priority && before_start != model.NONE() && after_start != model.NONE() &&
             before_start < after_start { start_inversions = start_inversions + 1; }
         digest = mix(digest, edge.before); digest = mix(digest, edge.after);
-        i = i + 1;
+        i += 1;
     }
     Analysis {
         buckets: buckets, edge_inversions: edge_inversions, edge_ties: edge_ties,

--- a/examples/lattice/priority_analysis.rue
+++ b/examples/lattice/priority_analysis.rue
@@ -20,7 +20,7 @@ pub struct Analysis {
 fn zeroes(count: u64) -> model.U64s {
     let mut values = model.U64s.with_capacity(count);
     let mut i: u64 = 0;
-    while i < count { values.push(0); i = i + 1; }
+    while i < count { values.push(0); i += 1; }
     values
 }
 
@@ -47,7 +47,7 @@ pub fn compute(borrow workflow: model.Workflow, borrow run: state.Run) -> Analys
             lowest_priority = task.priority; lowest_priority_task = i;
         }
         let start = run.starts.get_or(i, 0);
-        if start != model.NONE() { weighted_wait = weighted_wait + start * (task.priority + 1); }
+        if start != model.NONE() { weighted_wait += start * (task.priority + 1); }
         digest = mix(digest, task.priority); digest = mix(digest, start);
         i += 1;
     }
@@ -60,13 +60,13 @@ pub fn compute(borrow workflow: model.Workflow, borrow run: state.Run) -> Analys
         let edge = workflow.edges.get_or(i, model.empty_edge());
         let before = workflow.tasks.get_or(edge.before, model.empty_task());
         let after = workflow.tasks.get_or(edge.after, model.empty_task());
-        if before.priority < after.priority { edge_inversions = edge_inversions + 1; }
-        else if before.priority == after.priority { edge_ties = edge_ties + 1; }
-        else { edge_descents = edge_descents + 1; }
+        if before.priority < after.priority { edge_inversions += 1; }
+        else if before.priority == after.priority { edge_ties += 1; }
+        else { edge_descents += 1; }
         let before_start = run.starts.get_or(edge.before, model.NONE());
         let after_start = run.starts.get_or(edge.after, model.NONE());
         if before.priority < after.priority && before_start != model.NONE() && after_start != model.NONE() &&
-            before_start < after_start { start_inversions = start_inversions + 1; }
+            before_start < after_start { start_inversions += 1; }
         digest = mix(digest, edge.before); digest = mix(digest, edge.after);
         i += 1;
     }

--- a/examples/lattice/query.rue
+++ b/examples/lattice/query.rue
@@ -140,7 +140,7 @@ pub fn execute(borrow workflow: model.Workflow, borrow run: state.Run, borrow qu
     sort(inout tasks, borrow workflow);
     let mut digest: u64 = 14695981039346656037;
     i = 0;
-    while i < tasks.len() { digest = mix(digest, tasks.get_or(i, model.NONE())); i = i + 1; }
+    while i < tasks.len() { digest = mix(digest, tasks.get_or(i, model.NONE())); i += 1; }
     let count = tasks.len();
     Result {
         tasks: tasks, matches: count, total_duration: total_duration,

--- a/examples/lattice/query.rue
+++ b/examples/lattice/query.rue
@@ -96,14 +96,14 @@ fn sort(inout tasks: model.U64s, borrow workflow: model.Workflow) {
                 tasks.get_or(candidate, model.NONE()),
                 tasks.get_or(best, model.NONE()),
             ) { best = candidate; }
-            candidate = candidate + 1;
+            candidate += 1;
         }
         if best != position {
             let old = tasks.get_or(position, model.NONE());
             tasks.set(position, tasks.get_or(best, model.NONE()));
             tasks.set(best, old);
         }
-        position = position + 1;
+        position += 1;
     }
 }
 
@@ -124,10 +124,10 @@ pub fn execute(borrow workflow: model.Workflow, borrow run: state.Run, borrow qu
         if matches(borrow workflow, borrow run, borrow query, i) {
             let task = workflow.tasks.get_or(i, model.empty_task());
             tasks.push(i);
-            total_duration = total_duration + task.duration;
-            total_cpu_ticks = total_cpu_ticks + task.duration * task.cpu;
-            total_memory_ticks = total_memory_ticks + task.duration * task.memory;
-            total_priority = total_priority + task.priority;
+            total_duration += task.duration;
+            total_cpu_ticks += task.duration * task.cpu;
+            total_memory_ticks += task.duration * task.memory;
+            total_priority += task.priority;
             if maximum_duration_task == model.NONE() || task.duration > maximum_duration {
                 maximum_duration = task.duration; maximum_duration_task = i;
             }
@@ -135,7 +135,7 @@ pub fn execute(borrow workflow: model.Workflow, borrow run: state.Run, borrow qu
                 maximum_priority = task.priority; maximum_priority_task = i;
             }
         }
-        i = i + 1;
+        i += 1;
     }
     sort(inout tasks, borrow workflow);
     let mut digest: u64 = 14695981039346656037;

--- a/examples/lattice/queue_analysis.rue
+++ b/examples/lattice/queue_analysis.rue
@@ -33,7 +33,7 @@ fn ready_time(borrow workflow: model.Workflow, borrow run: state.Run, task: u64)
             let finish = run.ends.get_or(edge.before, 0);
             if finish != model.NONE() && finish > result { result = finish; }
         }
-        i = i + 1;
+        i += 1;
     }
     result
 }
@@ -59,11 +59,11 @@ pub fn compute(borrow workflow: model.Workflow, borrow run: state.Run) -> Analys
         let end = run.ends.get_or(i, model.NONE());
         dependency_ready.set(i, ready);
         if start == model.NONE() {
-            unstarted_tasks = unstarted_tasks + 1;
+            unstarted_tasks += 1;
         } else {
             let delay = if start >= ready { start - ready } else { timing_mismatches = timing_mismatches + 1; 0 };
             queue_delay.set(i, delay);
-            total_queue_delay = total_queue_delay + delay;
+            total_queue_delay += delay;
             if delay == 0 { zero_delay_tasks = zero_delay_tasks + 1; }
             else { delayed_tasks = delayed_tasks + 1; }
             if maximum_queue_task == model.NONE() || delay > maximum_queue_delay {
@@ -76,7 +76,7 @@ pub fn compute(borrow workflow: model.Workflow, borrow run: state.Run) -> Analys
         }
         digest = mix(digest, ready); digest = mix(digest, start);
         digest = mix(digest, end); digest = mix(digest, queue_delay.get_or(i, 0));
-        i = i + 1;
+        i += 1;
     }
     Analysis {
         dependency_ready: dependency_ready, queue_delay: queue_delay, runtime: runtime,

--- a/examples/lattice/queue_analysis.rue
+++ b/examples/lattice/queue_analysis.rue
@@ -20,7 +20,7 @@ pub struct Analysis {
 fn zeroes(count: u64) -> model.U64s {
     let mut values = model.U64s.with_capacity(count);
     let mut i: u64 = 0;
-    while i < count { values.push(0); i = i + 1; }
+    while i < count { values.push(0); i += 1; }
     values
 }
 
@@ -61,17 +61,17 @@ pub fn compute(borrow workflow: model.Workflow, borrow run: state.Run) -> Analys
         if start == model.NONE() {
             unstarted_tasks += 1;
         } else {
-            let delay = if start >= ready { start - ready } else { timing_mismatches = timing_mismatches + 1; 0 };
+            let delay = if start >= ready { start - ready } else { timing_mismatches += 1; 0 };
             queue_delay.set(i, delay);
             total_queue_delay += delay;
-            if delay == 0 { zero_delay_tasks = zero_delay_tasks + 1; }
-            else { delayed_tasks = delayed_tasks + 1; }
+            if delay == 0 { zero_delay_tasks += 1; }
+            else { delayed_tasks += 1; }
             if maximum_queue_task == model.NONE() || delay > maximum_queue_delay {
                 maximum_queue_delay = delay; maximum_queue_task = i;
             }
             if end != model.NONE() {
                 if end >= start { runtime.set(i, end - start); }
-                else { timing_mismatches = timing_mismatches + 1; }
+                else { timing_mismatches += 1; }
             }
         }
         digest = mix(digest, ready); digest = mix(digest, start);

--- a/examples/lattice/replay.rue
+++ b/examples/lattice/replay.rue
@@ -19,7 +19,7 @@ pub struct Audit {
 fn zeros(count: u64) -> model.U64s {
     let mut out = model.U64s.with_capacity(count);
     let mut i: u64 = 0;
-    while i < count { out.push(0); i = i + 1; }
+    while i < count { out.push(0); i += 1; }
     out
 }
 
@@ -37,32 +37,32 @@ pub fn audit(borrow workflow: model.Workflow, borrow run: state.Run) -> Audit {
     let mut i: u64 = 0;
     while i < run.events.len() {
         let event = run.events.get_or(i, state.empty_event());
-        if i > 0 && event.time < previous_time { ordering_errors = ordering_errors + 1; }
+        if i > 0 && event.time < previous_time { ordering_errors += 1; }
         previous_time = event.time;
-        if event.task >= workflow.tasks.len() { transition_errors = transition_errors + 1; }
+        if event.task >= workflow.tasks.len() { transition_errors += 1; }
         else {
             let old = status.get_or(event.task, 0);
             if event.kind == state.EVENT_START() {
-                if old != state.PENDING() { transition_errors = transition_errors + 1; }
+                if old != state.PENDING() { transition_errors += 1; }
                 let expected = attempts.get_or(event.task, 0) + 1;
-                if event.attempt != expected { attempt_errors = attempt_errors + 1; }
+                if event.attempt != expected { attempt_errors += 1; }
                 attempts.set(event.task, event.attempt);
                 status.set(event.task, state.RUNNING());
             } else if event.kind == state.EVENT_SUCCESS() {
-                if old != state.RUNNING() { transition_errors = transition_errors + 1; }
-                status.set(event.task, state.SUCCEEDED()); succeeded = succeeded + 1;
+                if old != state.RUNNING() { transition_errors += 1; }
+                status.set(event.task, state.SUCCEEDED()); succeeded += 1;
             } else if event.kind == state.EVENT_FAILURE() {
-                if old != state.RUNNING() { transition_errors = transition_errors + 1; }
+                if old != state.RUNNING() { transition_errors += 1; }
             } else if event.kind == state.EVENT_RETRY() {
-                if old != state.RUNNING() { transition_errors = transition_errors + 1; }
-                status.set(event.task, state.PENDING()); retries = retries + 1;
+                if old != state.RUNNING() { transition_errors += 1; }
+                status.set(event.task, state.PENDING()); retries += 1;
             } else if event.kind == state.EVENT_CACHE() {
-                if old != state.PENDING() { transition_errors = transition_errors + 1; }
-                status.set(event.task, state.CACHED()); cached = cached + 1;
+                if old != state.PENDING() { transition_errors += 1; }
+                status.set(event.task, state.CACHED()); cached += 1;
             } else if event.kind == state.EVENT_BLOCKED() {
-                if old != state.PENDING() { transition_errors = transition_errors + 1; }
-                status.set(event.task, state.FAILED()); failed = failed + 1;
-            } else { transition_errors = transition_errors + 1; }
+                if old != state.PENDING() { transition_errors += 1; }
+                status.set(event.task, state.FAILED()); failed += 1;
+            } else { transition_errors += 1; }
         }
         i += 1;
     }
@@ -71,7 +71,7 @@ pub fn audit(borrow workflow: model.Workflow, borrow run: state.Run) -> Audit {
     while i < workflow.tasks.len() {
         let expected = run.status.get_or(i, state.FAILED());
         let actual = status.get_or(i, state.FAILED());
-        if expected != actual { terminal_mismatches = terminal_mismatches + 1; }
+        if expected != actual { terminal_mismatches += 1; }
         if actual == state.FAILED() && expected == state.FAILED() {
             // A failed task may come from exhaustion rather than BLOCKED.
             failed += 1;

--- a/examples/lattice/replay.rue
+++ b/examples/lattice/replay.rue
@@ -64,7 +64,7 @@ pub fn audit(borrow workflow: model.Workflow, borrow run: state.Run) -> Audit {
                 status.set(event.task, state.FAILED()); failed = failed + 1;
             } else { transition_errors = transition_errors + 1; }
         }
-        i = i + 1;
+        i += 1;
     }
     let mut terminal_mismatches: u64 = 0;
     i = 0;
@@ -74,9 +74,9 @@ pub fn audit(borrow workflow: model.Workflow, borrow run: state.Run) -> Audit {
         if expected != actual { terminal_mismatches = terminal_mismatches + 1; }
         if actual == state.FAILED() && expected == state.FAILED() {
             // A failed task may come from exhaustion rather than BLOCKED.
-            failed = failed + 1;
+            failed += 1;
         }
-        i = i + 1;
+        i += 1;
     }
     let ok = ordering_errors == 0 && transition_errors == 0 &&
         attempt_errors == 0 && terminal_mismatches == 0;

--- a/examples/lattice/report_cache.rue
+++ b/examples/lattice/report_cache.rue
@@ -23,7 +23,7 @@ pub fn render(borrow workflow: model.Workflow, borrow run: state.Run) -> StrBuf 
         text.append_literal(inout out, " eligible="); text.append_u64(inout out, cache.cacheable_by_pool.get_or(i, 0));
         text.append_literal(inout out, " hits="); text.append_u64(inout out, cache.hits_by_pool.get_or(i, 0));
         text.append_literal(inout out, " misses="); text.append_u64(inout out, cache.misses_by_pool.get_or(i, 0)); out.push(10);
-        i = i + 1;
+        i += 1;
     }
     out
 }

--- a/examples/lattice/report_capacity.rue
+++ b/examples/lattice/report_capacity.rue
@@ -17,7 +17,7 @@ pub fn render(borrow workflow: model.Workflow, borrow run: state.Run) -> StrBuf 
         text.append_u64(inout out, pool.slots); out.push(44); text.append_u64(inout out, plan.recommended_slots.get_or(i, 0)); out.push(44);
         text.append_u64(inout out, pool.cpu); out.push(44); text.append_u64(inout out, plan.recommended_cpu.get_or(i, 0)); out.push(44);
         text.append_u64(inout out, pool.memory); out.push(44); text.append_u64(inout out, plan.recommended_memory.get_or(i, 0)); out.push(10);
-        i = i + 1;
+        i += 1;
     }
     out
 }

--- a/examples/lattice/report_chrome_trace.rue
+++ b/examples/lattice/report_chrome_trace.rue
@@ -23,9 +23,9 @@ pub fn render(borrow workflow: model.Workflow, borrow run: state.Run) -> StrBuf 
             text.append_literal(inout out, ",\"pid\":1,\"tid\":"); text.append_u64(inout out, task.pool);
             text.append_literal(inout out, ",\"args\":{\"priority\":"); text.append_u64(inout out, task.priority);
             text.append_literal(inout out, ",\"attempts\":"); text.append_u64(inout out, run.attempts.get_or(i, 0)); text.append_literal(inout out, "}}");
-            emitted = emitted + 1;
+            emitted += 1;
         }
-        i = i + 1;
+        i += 1;
     }
     text.append_literal(inout out, "]}\n");
     out

--- a/examples/lattice/report_comparison.rue
+++ b/examples/lattice/report_comparison.rue
@@ -24,7 +24,7 @@ pub fn render(borrow workflow: model.Workflow, borrow first: state.Run, alternat
         text.append_literal(inout out, " second="); format.append_status(inout out, second.status.get_or(index, state.FAILED()));
         text.append_literal(inout out, " first_end="); format.append_optional_u64(inout out, first.ends.get_or(index, model.NONE()));
         text.append_literal(inout out, " second_end="); format.append_optional_u64(inout out, second.ends.get_or(index, model.NONE())); out.push(10);
-        i = i + 1;
+        i += 1;
     }
     out
 }

--- a/examples/lattice/report_critical.rue
+++ b/examples/lattice/report_critical.rue
@@ -21,7 +21,7 @@ pub fn render(borrow workflow: model.Workflow) -> StrBuf {
         let task_index = critical.canonical_path.get_or(i, model.NONE());
         let task = workflow.tasks.get_or(task_index, model.empty_task());
         text.append_id(inout out, borrow workflow, task.id);
-        i = i + 1;
+        i += 1;
     }
     out.push(10);
     text.append_literal(inout out, "task                 early late slack paths-through critical\n");
@@ -34,7 +34,7 @@ pub fn render(borrow workflow: model.Workflow) -> StrBuf {
         text.append_u64(inout out, critical.slack.get_or(i, 0)); out.push(32);
         text.append_u64(inout out, paths.paths_through_task.get_or(i, 0)); out.push(32);
         text.append_bool(inout out, critical.slack.get_or(i, 1) == 0); out.push(10);
-        i = i + 1;
+        i += 1;
     }
     text.append_literal(inout out, "total_paths="); text.append_u64(inout out, paths.total_paths);
     text.append_literal(inout out, " total_slack="); text.append_u64(inout out, critical.total_slack);

--- a/examples/lattice/report_dot.rue
+++ b/examples/lattice/report_dot.rue
@@ -28,14 +28,14 @@ pub fn render(borrow workflow: model.Workflow, borrow run: state.Run) -> StrBuf 
         else if task.cacheable { text.append_literal(inout out, "box,color=blue"); }
         else { text.append_literal(inout out, "ellipse,color=black"); }
         text.append_literal(inout out, "];\n");
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < workflow.edges.len() {
         let edge = workflow.edges.get_or(i, model.empty_edge());
         text.append_literal(inout out, "  t"); text.append_u64(inout out, edge.before);
         text.append_literal(inout out, " -> t"); text.append_u64(inout out, edge.after); text.append_literal(inout out, ";\n");
-        i = i + 1;
+        i += 1;
     }
     text.append_literal(inout out, "}\n");
     out

--- a/examples/lattice/report_events_csv.rue
+++ b/examples/lattice/report_events_csv.rue
@@ -26,7 +26,7 @@ pub fn render(borrow workflow: model.Workflow, borrow run: state.Run) -> StrBuf 
         out.push(44); text.append_u64(inout out, event.attempt); out.push(44);
         text.append_u64(inout out, event.cpu); out.push(44); text.append_u64(inout out, event.memory);
         text.append_literal(inout out, "\r\n");
-        i = i + 1;
+        i += 1;
     }
     out
 }

--- a/examples/lattice/report_explain.rue
+++ b/examples/lattice/report_explain.rue
@@ -27,7 +27,7 @@ pub fn render(borrow workflow: model.Workflow, borrow run: state.Run) -> StrBuf 
         text.append_literal(inout out, " queue_delay="); text.append_u64(inout out, value.queue_delay);
         text.append_literal(inout out, " attempts="); text.append_u64(inout out, value.attempts);
         text.append_literal(inout out, " consistent="); text.append_bool(inout out, value.consistent); out.push(10);
-        i = i + 1;
+        i += 1;
     }
     out
 }

--- a/examples/lattice/report_forecast.rue
+++ b/examples/lattice/report_forecast.rue
@@ -20,7 +20,7 @@ pub fn render(borrow workflow: model.Workflow, seed: u64) -> StrBuf {
         text.append_u64(inout out, value.makespans.get_or(i, 0)); out.push(44);
         text.append_u64(inout out, value.cache_hits.get_or(i, 0)); out.push(44);
         text.append_u64(inout out, value.retries.get_or(i, 0)); out.push(44);
-        text.append_u64(inout out, value.fingerprints.get_or(i, 0)); out.push(10); i = i + 1;
+        text.append_u64(inout out, value.fingerprints.get_or(i, 0)); out.push(10); i += 1;
     }
     out
 }

--- a/examples/lattice/report_html.rue
+++ b/examples/lattice/report_html.rue
@@ -36,7 +36,7 @@ pub fn render(borrow workflow: model.Workflow, borrow run: state.Run) -> StrBuf 
         cell(inout out, task.duration); cell(inout out, task.priority); cell(inout out, run.attempts.get_or(i, 0));
         text.append_literal(inout out, "<td>"); format.append_optional_u64(inout out, run.starts.get_or(i, model.NONE())); text.append_literal(inout out, "</td><td>");
         format.append_optional_u64(inout out, run.ends.get_or(i, model.NONE())); text.append_literal(inout out, "</td></tr>");
-        i = i + 1;
+        i += 1;
     }
     text.append_literal(inout out, "</tbody></table></section><footer><p>fingerprint <code>"); text.append_u64(inout out, run.fingerprint);
     text.append_literal(inout out, "</code></p></footer></body></html>\n");

--- a/examples/lattice/report_json.rue
+++ b/examples/lattice/report_json.rue
@@ -55,7 +55,7 @@ pub fn render(borrow workflow: model.Workflow, borrow run: state.Run) -> StrBuf 
         let edge = workflow.edges.get_or(i, model.empty_edge());
         out.push(123); key(inout out, "before"); text.json_id(inout out, borrow workflow, edge.before_id);
         out.push(44); key(inout out, "after"); text.json_id(inout out, borrow workflow, edge.after_id); out.push(125);
-        i = i + 1;
+        i += 1;
     }
     text.append_literal(inout out, "],\"events\":[");
     i = 0;
@@ -67,7 +67,7 @@ pub fn render(borrow workflow: model.Workflow, borrow run: state.Run) -> StrBuf 
         key(inout out, "task"); text.append_u64(inout out, event.task); out.push(44);
         key(inout out, "pool"); text.append_u64(inout out, event.pool); out.push(44);
         key(inout out, "attempt"); text.append_u64(inout out, event.attempt); out.push(125);
-        i = i + 1;
+        i += 1;
     }
     text.append_literal(inout out, "],\"summary\":{");
     key(inout out, "makespan"); text.append_u64(inout out, run.makespan); out.push(44);

--- a/examples/lattice/report_json.rue
+++ b/examples/lattice/report_json.rue
@@ -26,7 +26,7 @@ pub fn render(borrow workflow: model.Workflow, borrow run: state.Run) -> StrBuf 
         key(inout out, "slots"); text.append_u64(inout out, pool.slots); out.push(44);
         key(inout out, "cpu"); text.append_u64(inout out, pool.cpu); out.push(44);
         key(inout out, "memory"); text.append_u64(inout out, pool.memory);
-        out.push(125); i = i + 1;
+        out.push(125); i += 1;
     }
     text.append_literal(inout out, "],\"tasks\":[");
     i = 0;
@@ -46,7 +46,7 @@ pub fn render(borrow workflow: model.Workflow, borrow run: state.Run) -> StrBuf 
         key(inout out, "start"); format.append_optional_u64(inout out, run.starts.get_or(i, model.NONE())); out.push(44);
         key(inout out, "end"); format.append_optional_u64(inout out, run.ends.get_or(i, model.NONE())); out.push(44);
         key(inout out, "attempts"); text.append_u64(inout out, run.attempts.get_or(i, 0));
-        out.push(125); i = i + 1;
+        out.push(125); i += 1;
     }
     text.append_literal(inout out, "],\"edges\":[");
     i = 0;

--- a/examples/lattice/report_junit.rue
+++ b/examples/lattice/report_junit.rue
@@ -21,7 +21,7 @@ pub fn render(borrow workflow: model.Workflow, borrow run: state.Run) -> StrBuf 
         text.append_literal(inout out, "\" time=\""); text.append_u64(inout out, task.duration); text.append_literal(inout out, "\">");
         if status == state.FAILED() { text.append_literal(inout out, "<failure message=\"task failed\"/>"); }
         else if status == state.CACHED() { text.append_literal(inout out, "<system-out>cache hit</system-out>"); }
-        text.append_literal(inout out, "</testcase>\n"); i = i + 1;
+        text.append_literal(inout out, "</testcase>\n"); i += 1;
     }
     text.append_literal(inout out, "</testsuite>\n");
     out

--- a/examples/lattice/report_lint.rue
+++ b/examples/lattice/report_lint.rue
@@ -31,7 +31,7 @@ pub fn render(borrow workflow: model.Workflow, borrow run: state.Run) -> StrBuf 
         if finding.edge < workflow.edges.len() {
             text.append_literal(inout out, " edge="); text.append_u64(inout out, finding.edge);
         }
-        out.push(10); i = i + 1;
+        out.push(10); i += 1;
     }
     out
 }

--- a/examples/lattice/report_manifest.rue
+++ b/examples/lattice/report_manifest.rue
@@ -19,7 +19,7 @@ pub fn render(borrow workflow: model.Workflow, borrow run: state.Run) -> StrBuf 
         text.append_literal(inout out, "pool "); text.append_u64(inout out, i); out.push(32);
         text.append_id(inout out, borrow workflow, pool.id); out.push(32);
         text.append_u64(inout out, pool.slots); out.push(32); text.append_u64(inout out, pool.cpu); out.push(32);
-        text.append_u64(inout out, pool.memory); out.push(10); i = i + 1;
+        text.append_u64(inout out, pool.memory); out.push(10); i += 1;
     }
     i = 0;
     while i < workflow.tasks.len() {
@@ -29,13 +29,13 @@ pub fn render(borrow workflow: model.Workflow, borrow run: state.Run) -> StrBuf 
         text.append_u64(inout out, task.duration); out.push(32); text.append_u64(inout out, task.cpu); out.push(32);
         text.append_u64(inout out, task.memory); out.push(32); text.append_u64(inout out, task.priority); out.push(32);
         text.append_u64(inout out, run.status.get_or(i, state.FAILED())); out.push(32);
-        text.append_u64(inout out, run.attempts.get_or(i, 0)); out.push(10); i = i + 1;
+        text.append_u64(inout out, run.attempts.get_or(i, 0)); out.push(10); i += 1;
     }
     i = 0;
     while i < workflow.edges.len() {
         let edge = workflow.edges.get_or(i, model.empty_edge());
         text.append_literal(inout out, "edge "); text.append_u64(inout out, edge.before);
-        out.push(32); text.append_u64(inout out, edge.after); out.push(10); i = i + 1;
+        out.push(32); text.append_u64(inout out, edge.after); out.push(10); i += 1;
     }
     out
 }

--- a/examples/lattice/report_markdown.rue
+++ b/examples/lattice/report_markdown.rue
@@ -34,7 +34,7 @@ pub fn render(borrow workflow: model.Workflow, borrow run: state.Run) -> StrBuf 
         text.append_u64(inout out, run.attempts.get_or(i, 0)); out.push(124);
         format.append_optional_u64(inout out, run.starts.get_or(i, model.NONE())); out.push(124);
         format.append_optional_u64(inout out, run.ends.get_or(i, model.NONE())); text.append_literal(inout out, "|\n");
-        i = i + 1;
+        i += 1;
     }
     text.append_literal(inout out, "\n## Scheduler counters\n\n| Counter | Value |\n|---|---:|\n");
     text.append_literal(inout out, "| Succeeded |"); text.append_u64(inout out, run.succeeded); text.append_literal(inout out, "|\n");

--- a/examples/lattice/report_matrix.rue
+++ b/examples/lattice/report_matrix.rue
@@ -25,7 +25,7 @@ pub fn render(borrow workflow: model.Workflow) -> StrBuf {
         }
         let task = workflow.tasks.get_or(row, model.empty_task());
         text.append_id(inout out, borrow workflow, task.id); out.push(10);
-        row = row + 1;
+        row += 1;
     }
     out
 }

--- a/examples/lattice/report_matrix.rue
+++ b/examples/lattice/report_matrix.rue
@@ -9,7 +9,7 @@ pub fn render(borrow workflow: model.Workflow) -> StrBuf {
     text.append_literal(inout out, "ADJACENCY MATRIX\n    ");
     let mut column: u64 = 0;
     while column < workflow.tasks.len() {
-        text.append_u64(inout out, column % 10); out.push(32); column = column + 1;
+        text.append_u64(inout out, column % 10); out.push(32); column += 1;
     }
     out.push(10);
     let mut row: u64 = 0;
@@ -21,7 +21,7 @@ pub fn render(borrow workflow: model.Workflow) -> StrBuf {
         while column < workflow.tasks.len() {
             if model.has_edge(borrow workflow, row, column) { out.push(49); }
             else { out.push(46); }
-            out.push(32); column = column + 1;
+            out.push(32); column += 1;
         }
         let task = workflow.tasks.get_or(row, model.empty_task());
         text.append_id(inout out, borrow workflow, task.id); out.push(10);

--- a/examples/lattice/report_mermaid.rue
+++ b/examples/lattice/report_mermaid.rue
@@ -19,7 +19,7 @@ pub fn render(borrow workflow: model.Workflow) -> StrBuf {
             text.append_literal(inout out, "  style T"); text.append_u64(inout out, i);
             text.append_literal(inout out, " stroke:#d92d20,stroke-width:3px\n");
         }
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < workflow.edges.len() {

--- a/examples/lattice/report_mermaid.rue
+++ b/examples/lattice/report_mermaid.rue
@@ -25,7 +25,7 @@ pub fn render(borrow workflow: model.Workflow) -> StrBuf {
     while i < workflow.edges.len() {
         let edge = workflow.edges.get_or(i, model.empty_edge());
         text.append_literal(inout out, "  T"); text.append_u64(inout out, edge.before);
-        text.append_literal(inout out, " --> T"); text.append_u64(inout out, edge.after); out.push(10); i = i + 1;
+        text.append_literal(inout out, " --> T"); text.append_u64(inout out, edge.after); out.push(10); i += 1;
     }
     out
 }

--- a/examples/lattice/report_ndjson.rue
+++ b/examples/lattice/report_ndjson.rue
@@ -25,7 +25,7 @@ pub fn render(borrow workflow: model.Workflow, borrow run: state.Run) -> StrBuf 
         text.append_literal(inout out, ",\"attempt\":"); text.append_u64(inout out, event.attempt);
         text.append_literal(inout out, ",\"cpu\":"); text.append_u64(inout out, event.cpu);
         text.append_literal(inout out, ",\"memory\":"); text.append_u64(inout out, event.memory);
-        text.append_literal(inout out, "}\n"); i = i + 1;
+        text.append_literal(inout out, "}\n"); i += 1;
     }
     out
 }

--- a/examples/lattice/report_otel.rue
+++ b/examples/lattice/report_otel.rue
@@ -16,7 +16,7 @@ fn links(inout out: StrBuf, borrow workflow: model.Workflow, task: u64) {
             text.append_literal(inout out, "{\"spanId\":\""); text.append_u64(inout out, edge.before + 1);
             text.append_literal(inout out, "\"}"); emitted = emitted + 1;
         }
-        i = i + 1;
+        i += 1;
     }
     out.push(93);
 }
@@ -44,7 +44,7 @@ pub fn render(borrow workflow: model.Workflow, borrow run: state.Run) -> StrBuf 
             text.append_u64(inout out, run.attempts.get_or(i, 0)); text.append_literal(inout out, "\"}}],\"links\":");
             links(inout out, borrow workflow, i); out.push(125); emitted = emitted + 1;
         }
-        i = i + 1;
+        i += 1;
     }
     text.append_literal(inout out, "]}]}]}\n");
     out

--- a/examples/lattice/report_otel.rue
+++ b/examples/lattice/report_otel.rue
@@ -14,7 +14,7 @@ fn links(inout out: StrBuf, borrow workflow: model.Workflow, task: u64) {
         if edge.after == task {
             if emitted > 0 { out.push(44); }
             text.append_literal(inout out, "{\"spanId\":\""); text.append_u64(inout out, edge.before + 1);
-            text.append_literal(inout out, "\"}"); emitted = emitted + 1;
+            text.append_literal(inout out, "\"}"); emitted += 1;
         }
         i += 1;
     }
@@ -42,7 +42,7 @@ pub fn render(borrow workflow: model.Workflow, borrow run: state.Run) -> StrBuf 
             text.append_literal(inout out, "}},{\"key\":\"lattice.priority\",\"value\":{\"intValue\":\"");
             text.append_u64(inout out, task.priority); text.append_literal(inout out, "\"}},{\"key\":\"lattice.attempts\",\"value\":{\"intValue\":\"");
             text.append_u64(inout out, run.attempts.get_or(i, 0)); text.append_literal(inout out, "\"}}],\"links\":");
-            links(inout out, borrow workflow, i); out.push(125); emitted = emitted + 1;
+            links(inout out, borrow workflow, i); out.push(125); emitted += 1;
         }
         i += 1;
     }

--- a/examples/lattice/report_paths.rue
+++ b/examples/lattice/report_paths.rue
@@ -19,7 +19,7 @@ pub fn render(borrow workflow: model.Workflow) -> StrBuf {
         text.append_literal(inout out, " from_roots="); text.append_u64(inout out, paths.paths_from_roots.get_or(i, 0));
         text.append_literal(inout out, " to_leaves="); text.append_u64(inout out, paths.paths_to_leaves.get_or(i, 0));
         text.append_literal(inout out, " through="); text.append_u64(inout out, paths.paths_through_task.get_or(i, 0)); out.push(10);
-        i = i + 1;
+        i += 1;
     }
     out
 }

--- a/examples/lattice/report_policy.rue
+++ b/examples/lattice/report_policy.rue
@@ -25,7 +25,7 @@ pub fn render(borrow workflow: model.Workflow, borrow run: state.Run) -> StrBuf 
         if value.task < workflow.tasks.len() {
             text.append_id(inout out, borrow workflow, workflow.tasks.get_or(value.task, model.empty_task()).id);
         } else { text.append_literal(inout out, "<none>"); }
-        out.push(10); i = i + 1;
+        out.push(10); i += 1;
     }
     out
 }

--- a/examples/lattice/report_query.rue
+++ b/examples/lattice/report_query.rue
@@ -17,7 +17,7 @@ fn section(inout out: StrBuf, label: str, borrow workflow: model.Workflow, borro
         text.append_literal(inout out, "  "); text.append_id(inout out, borrow workflow, task.id);
         text.append_literal(inout out, " priority="); text.append_u64(inout out, task.priority);
         text.append_literal(inout out, " duration="); text.append_u64(inout out, task.duration); out.push(10);
-        i = i + 1;
+        i += 1;
     }
 }
 

--- a/examples/lattice/report_resources.rue
+++ b/examples/lattice/report_resources.rue
@@ -37,7 +37,7 @@ pub fn render(borrow workflow: model.Workflow, borrow run: state.Run) -> StrBuf 
         metric(inout out, "slots", pool.slots, pools.peak_slots.get_or(i, 0), plan.recommended_slots.get_or(i, 0));
         metric(inout out, "cpu", pool.cpu, pools.peak_cpu.get_or(i, 0), plan.recommended_cpu.get_or(i, 0));
         metric(inout out, "memory", pool.memory, pools.peak_memory.get_or(i, 0), plan.recommended_memory.get_or(i, 0));
-        i = i + 1;
+        i += 1;
     }
     text.append_literal(inout out, "saturated_pools="); text.append_u64(inout out, plan.saturated_pools);
     text.append_literal(inout out, " slot_increase="); text.append_u64(inout out, plan.total_slot_increase);

--- a/examples/lattice/report_retries.rue
+++ b/examples/lattice/report_retries.rue
@@ -22,7 +22,7 @@ pub fn render(borrow workflow: model.Workflow, borrow run: state.Run) -> StrBuf 
         text.append_literal(inout out, " budget="); text.append_u64(inout out, retries.budget_by_pool.get_or(i, 0));
         text.append_literal(inout out, " attempts="); text.append_u64(inout out, retries.attempts_by_pool.get_or(i, 0));
         text.append_literal(inout out, " retries="); text.append_u64(inout out, retries.retries_by_pool.get_or(i, 0)); out.push(10);
-        i = i + 1;
+        i += 1;
     }
     out
 }

--- a/examples/lattice/report_risk.rue
+++ b/examples/lattice/report_risk.rue
@@ -32,7 +32,7 @@ pub fn render(borrow workflow: model.Workflow) -> StrBuf {
         text.append_literal(inout out, " paths="); text.append_u64(inout out, paths.paths_through_task.get_or(i, 0));
         text.append_literal(inout out, " fallible="); text.append_bool(inout out, task.fail_attempt > 0);
         text.append_literal(inout out, " cacheable="); text.append_bool(inout out, task.cacheable); out.push(10);
-        i = i + 1;
+        i += 1;
     }
     text.append_literal(inout out, "mandatory_tasks="); text.append_u64(inout out, cuts.mandatory_count);
     text.append_literal(inout out, " bridge_edges="); text.append_u64(inout out, cuts.bridge_count);

--- a/examples/lattice/report_sarif.rue
+++ b/examples/lattice/report_sarif.rue
@@ -26,7 +26,7 @@ pub fn render(borrow workflow: model.Workflow, borrow run: state.Run) -> StrBuf 
             text.append_literal(inout out, ",\"locations\":[{\"logicalLocations\":[{\"name\":");
             text.json_id(inout out, borrow workflow, task.id); text.append_literal(inout out, "}]}]");
         }
-        out.push(125); i = i + 1;
+        out.push(125); i += 1;
     }
     text.append_literal(inout out, "]}]}\n");
     out

--- a/examples/lattice/report_sql.rue
+++ b/examples/lattice/report_sql.rue
@@ -11,7 +11,7 @@ fn quoted_id(inout out: StrBuf, borrow workflow: model.Workflow, id: u64) {
     while i < workflow.strings.string_len(id) {
         let byte = workflow.strings.byte_at(id, i);
         if byte == 39 { out.push(39); out.push(39); } else { out.push(byte); }
-        i = i + 1;
+        i += 1;
     }
     out.push(39);
 }

--- a/examples/lattice/report_sql.rue
+++ b/examples/lattice/report_sql.rue
@@ -28,13 +28,13 @@ pub fn render(borrow workflow: model.Workflow, borrow run: state.Run) -> StrBuf 
         quoted_id(inout out, borrow workflow, task.pool_id); out.push(44); text.append_u64(inout out, task.duration); out.push(44);
         text.append_u64(inout out, task.priority); out.push(44); text.append_u64(inout out, run.status.get_or(i, state.FAILED())); out.push(44);
         text.append_u64(inout out, run.attempts.get_or(i, 0)); out.push(44); text.append_u64(inout out, run.starts.get_or(i, 0)); out.push(44);
-        text.append_u64(inout out, run.ends.get_or(i, 0)); text.append_literal(inout out, ");\n"); i = i + 1;
+        text.append_u64(inout out, run.ends.get_or(i, 0)); text.append_literal(inout out, ");\n"); i += 1;
     }
     i = 0;
     while i < workflow.edges.len() {
         let edge = workflow.edges.get_or(i, model.empty_edge());
         text.append_literal(inout out, "INSERT INTO lattice_edge VALUES("); quoted_id(inout out, borrow workflow, edge.before_id);
-        out.push(44); quoted_id(inout out, borrow workflow, edge.after_id); text.append_literal(inout out, ");\n"); i = i + 1;
+        out.push(44); quoted_id(inout out, borrow workflow, edge.after_id); text.append_literal(inout out, ");\n"); i += 1;
     }
     i = 0;
     while i < run.events.len() {
@@ -42,7 +42,7 @@ pub fn render(borrow workflow: model.Workflow, borrow run: state.Run) -> StrBuf 
         text.append_literal(inout out, "INSERT INTO lattice_event VALUES("); text.append_u64(inout out, i); out.push(44);
         text.append_u64(inout out, event.time); out.push(44); text.append_u64(inout out, event.kind); out.push(44);
         text.append_u64(inout out, event.task); out.push(44); text.append_u64(inout out, event.pool); out.push(44);
-        text.append_u64(inout out, event.attempt); text.append_literal(inout out, ");\n"); i = i + 1;
+        text.append_u64(inout out, event.attempt); text.append_literal(inout out, ");\n"); i += 1;
     }
     text.append_literal(inout out, "COMMIT;\n");
     out

--- a/examples/lattice/report_suite.rue
+++ b/examples/lattice/report_suite.rue
@@ -56,7 +56,7 @@ fn mix(hash: u64, value: u64) -> u64 { @wrapping_mul(hash ^ value, 1099511628211
 fn include(inout result: Result, document: StrBuf, expected_prefix: u8) {
     result.documents += 1;
     result.bytes += document.len();
-    if document.len() == 0 { result.empty_documents = result.empty_documents + 1; }
+    if document.len() == 0 { result.empty_documents += 1; }
     else if StrBuf.byte_at_borrowed(borrow document, 0) != expected_prefix {
         result.prefix_mismatches += 1;
     }

--- a/examples/lattice/report_suite.rue
+++ b/examples/lattice/report_suite.rue
@@ -54,11 +54,11 @@ pub struct Result {
 fn mix(hash: u64, value: u64) -> u64 { @wrapping_mul(hash ^ value, 1099511628211) }
 
 fn include(inout result: Result, document: StrBuf, expected_prefix: u8) {
-    result.documents = result.documents + 1;
-    result.bytes = result.bytes + document.len();
+    result.documents += 1;
+    result.bytes += document.len();
     if document.len() == 0 { result.empty_documents = result.empty_documents + 1; }
     else if StrBuf.byte_at_borrowed(borrow document, 0) != expected_prefix {
-        result.prefix_mismatches = result.prefix_mismatches + 1;
+        result.prefix_mismatches += 1;
     }
     result.digest = mix(result.digest, text.fnv1a(borrow document));
     result.digest = mix(result.digest, document.len());

--- a/examples/lattice/report_tasks_csv.rue
+++ b/examples/lattice/report_tasks_csv.rue
@@ -25,7 +25,7 @@ pub fn render(borrow workflow: model.Workflow, borrow run: state.Run) -> StrBuf 
         format.append_optional_u64(inout out, run.starts.get_or(i, model.NONE())); out.push(44);
         format.append_optional_u64(inout out, run.ends.get_or(i, model.NONE()));
         text.append_literal(inout out, "\r\n");
-        i = i + 1;
+        i += 1;
     }
     out
 }

--- a/examples/lattice/report_timeline.rue
+++ b/examples/lattice/report_timeline.rue
@@ -29,7 +29,7 @@ fn append_gantt(inout out: StrBuf, start: u64, end: u64, makespan: u64, width: u
     while i < width {
         if i >= first && i < last { out.push(61); }
         else { out.push(46); }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -52,7 +52,7 @@ pub fn render(borrow workflow: model.Workflow, borrow run: state.Run) -> StrBuf 
         format.append_optional_u64(inout out, end); out.push(32);
         text.append_u64(inout out, queue.queue_delay.get_or(i, 0)); out.push(32);
         format.append_status(inout out, run.status.get_or(i, state.FAILED())); out.push(10);
-        i = i + 1;
+        i += 1;
     }
     text.append_literal(inout out, "total_queue_delay="); text.append_u64(inout out, queue.total_queue_delay);
     text.append_literal(inout out, " maximum_queue_delay="); text.append_u64(inout out, queue.maximum_queue_delay); out.push(10);

--- a/examples/lattice/report_timeline.rue
+++ b/examples/lattice/report_timeline.rue
@@ -9,14 +9,14 @@ const StrBuf = std.strbuf.StrBuf;
 
 fn append_padding(inout out: StrBuf, used: u64, width: u64) {
     let mut i = used;
-    while i < width { out.push(32); i = i + 1; }
+    while i < width { out.push(32); i += 1; }
 }
 
 fn append_task_label(inout out: StrBuf, borrow workflow: model.Workflow, id: u64, width: u64) {
     let length = workflow.strings.string_len(id);
     let limit = if length < width { length } else { width };
     let mut i: u64 = 0;
-    while i < limit { out.push(workflow.strings.byte_at(id, i)); i = i + 1; }
+    while i < limit { out.push(workflow.strings.byte_at(id, i)); i += 1; }
     append_padding(inout out, limit, width);
 }
 

--- a/examples/lattice/report_trace.rue
+++ b/examples/lattice/report_trace.rue
@@ -28,7 +28,7 @@ pub fn render(borrow workflow: model.Workflow, borrow run: state.Run) -> StrBuf 
         text.append_literal(inout out, " attempt="); text.append_u64(inout out, event.attempt);
         text.append_literal(inout out, " cpu="); text.append_u64(inout out, event.cpu);
         text.append_literal(inout out, " memory="); text.append_u64(inout out, event.memory); out.push(10);
-        i = i + 1;
+        i += 1;
     }
     out
 }

--- a/examples/lattice/report_yaml.rue
+++ b/examples/lattice/report_yaml.rue
@@ -26,7 +26,7 @@ pub fn render(borrow workflow: model.Workflow, borrow run: state.Run) -> StrBuf 
         text.append_literal(inout out, "\n    attempts: "); text.append_u64(inout out, run.attempts.get_or(i, 0));
         text.append_literal(inout out, "\n    start: "); format.append_optional_u64(inout out, run.starts.get_or(i, model.NONE()));
         text.append_literal(inout out, "\n    end: "); format.append_optional_u64(inout out, run.ends.get_or(i, model.NONE())); out.push(10);
-        i = i + 1;
+        i += 1;
     }
     out
 }

--- a/examples/lattice/resource_audit.rue
+++ b/examples/lattice/resource_audit.rue
@@ -22,7 +22,7 @@ pub struct Audit {
 fn zeroes(count: u64) -> model.U64s {
     let mut result = model.U64s.with_capacity(count);
     let mut i: u64 = 0;
-    while i < count { result.push(0); i = i + 1; }
+    while i < count { result.push(0); i += 1; }
     result
 }
 
@@ -68,13 +68,13 @@ pub fn audit(borrow workflow: model.Workflow, borrow run: state.Run) -> Audit {
                 update_max(inout maximum_cpu, borrow active_cpu, event.pool);
                 update_max(inout maximum_memory, borrow active_memory, event.pool);
                 let pool = workflow.pools.get_or(event.pool, model.empty_pool());
-                if active_slots.get_or(event.pool, 0) > pool.slots { slot_violations = slot_violations + 1; }
-                if active_cpu.get_or(event.pool, 0) > pool.cpu { cpu_violations = cpu_violations + 1; }
-                if active_memory.get_or(event.pool, 0) > pool.memory { memory_violations = memory_violations + 1; }
+                if active_slots.get_or(event.pool, 0) > pool.slots { slot_violations += 1; }
+                if active_cpu.get_or(event.pool, 0) > pool.cpu { cpu_violations += 1; }
+                if active_memory.get_or(event.pool, 0) > pool.memory { memory_violations += 1; }
             } else if event.kind == state.EVENT_SUCCESS() || event.kind == state.EVENT_FAILURE() {
-                if subtract(inout active_slots, event.pool, 1) { underflows = underflows + 1; }
-                if subtract(inout active_cpu, event.pool, event.cpu) { underflows = underflows + 1; }
-                if subtract(inout active_memory, event.pool, event.memory) { underflows = underflows + 1; }
+                if subtract(inout active_slots, event.pool, 1) { underflows += 1; }
+                if subtract(inout active_cpu, event.pool, event.cpu) { underflows += 1; }
+                if subtract(inout active_memory, event.pool, event.memory) { underflows += 1; }
             }
         }
         digest = mix(digest, event.kind); digest = mix(digest, event.time);

--- a/examples/lattice/resource_audit.rue
+++ b/examples/lattice/resource_audit.rue
@@ -79,18 +79,18 @@ pub fn audit(borrow workflow: model.Workflow, borrow run: state.Run) -> Audit {
         }
         digest = mix(digest, event.kind); digest = mix(digest, event.time);
         digest = mix(digest, event.pool); digest = mix(digest, event.cpu); digest = mix(digest, event.memory);
-        i = i + 1;
+        i += 1;
     }
     let mut terminal_active: u64 = 0;
     i = 0;
     while i < count {
-        terminal_active = terminal_active + active_slots.get_or(i, 0);
-        terminal_active = terminal_active + active_cpu.get_or(i, 0);
-        terminal_active = terminal_active + active_memory.get_or(i, 0);
+        terminal_active += active_slots.get_or(i, 0);
+        terminal_active += active_cpu.get_or(i, 0);
+        terminal_active += active_memory.get_or(i, 0);
         digest = mix(digest, maximum_slots.get_or(i, 0));
         digest = mix(digest, maximum_cpu.get_or(i, 0));
         digest = mix(digest, maximum_memory.get_or(i, 0));
-        i = i + 1;
+        i += 1;
     }
     let ok = underflows == 0 && slot_violations == 0 && cpu_violations == 0 &&
         memory_violations == 0 && terminal_active == 0;
@@ -112,7 +112,7 @@ pub fn verify(borrow workflow: model.Workflow, borrow audit: Audit) -> bool {
         if audit.maximum_slots.get_or(i, 0) > pool.slots { return false; }
         if audit.maximum_cpu.get_or(i, 0) > pool.cpu { return false; }
         if audit.maximum_memory.get_or(i, 0) > pool.memory { return false; }
-        i = i + 1;
+        i += 1;
     }
     true
 }

--- a/examples/lattice/retry_analysis.rue
+++ b/examples/lattice/retry_analysis.rue
@@ -51,25 +51,25 @@ pub fn compute(borrow workflow: model.Workflow, borrow run: state.Run) -> Analys
         let task = workflow.tasks.get_or(i, model.empty_task());
         let attempts = run.attempts.get_or(i, 0);
         let retries = if attempts > 0 { attempts - 1 } else { 0 };
-        configured_budget = configured_budget + task.retries;
-        total_attempts = total_attempts + attempts;
-        observed_retries = observed_retries + retries;
+        configured_budget += task.retries;
+        total_attempts += attempts;
+        observed_retries += retries;
         add(inout attempts_by_pool, task.pool, attempts);
         add(inout retries_by_pool, task.pool, retries);
         add(inout budget_by_pool, task.pool, task.retries);
         if attempts > task.retries + 1 { budget_violations = budget_violations + 1; }
         if attempts > 1 && run.status.get_or(i, state.FAILED()) == state.SUCCEEDED() {
-            recovered_tasks = recovered_tasks + 1;
+            recovered_tasks += 1;
         }
         if run.status.get_or(i, state.PENDING()) == state.FAILED() && attempts > 0 {
-            exhausted_tasks = exhausted_tasks + 1;
+            exhausted_tasks += 1;
         }
         if task.fail_attempt > 0 && attempts == 0 { untouched_fallible_tasks = untouched_fallible_tasks + 1; }
         if maximum_attempt_task == model.NONE() || attempts > maximum_attempts {
             maximum_attempts = attempts; maximum_attempt_task = i;
         }
         digest = mix(digest, i); digest = mix(digest, attempts); digest = mix(digest, task.retries);
-        i = i + 1;
+        i += 1;
     }
     Analysis {
         attempts_by_pool: attempts_by_pool, retries_by_pool: retries_by_pool,

--- a/examples/lattice/retry_analysis.rue
+++ b/examples/lattice/retry_analysis.rue
@@ -22,7 +22,7 @@ pub struct Analysis {
 fn zeroes(count: u64) -> model.U64s {
     let mut values = model.U64s.with_capacity(count);
     let mut i: u64 = 0;
-    while i < count { values.push(0); i = i + 1; }
+    while i < count { values.push(0); i += 1; }
     values
 }
 
@@ -57,14 +57,14 @@ pub fn compute(borrow workflow: model.Workflow, borrow run: state.Run) -> Analys
         add(inout attempts_by_pool, task.pool, attempts);
         add(inout retries_by_pool, task.pool, retries);
         add(inout budget_by_pool, task.pool, task.retries);
-        if attempts > task.retries + 1 { budget_violations = budget_violations + 1; }
+        if attempts > task.retries + 1 { budget_violations += 1; }
         if attempts > 1 && run.status.get_or(i, state.FAILED()) == state.SUCCEEDED() {
             recovered_tasks += 1;
         }
         if run.status.get_or(i, state.PENDING()) == state.FAILED() && attempts > 0 {
             exhausted_tasks += 1;
         }
-        if task.fail_attempt > 0 && attempts == 0 { untouched_fallible_tasks = untouched_fallible_tasks + 1; }
+        if task.fail_attempt > 0 && attempts == 0 { untouched_fallible_tasks += 1; }
         if maximum_attempt_task == model.NONE() || attempts > maximum_attempts {
             maximum_attempts = attempts; maximum_attempt_task = i;
         }

--- a/examples/lattice/run_comparison.rue
+++ b/examples/lattice/run_comparison.rue
@@ -55,11 +55,11 @@ pub fn compare(borrow workflow: model.Workflow, borrow first: state.Run, borrow 
         }
         if first_status == state.CACHED() && second_status != state.CACHED() { cached_only_first.push(i); }
         if second_status == state.CACHED() && first_status != state.CACHED() { cached_only_second.push(i); }
-        total_start_delta = total_start_delta + delta(first.starts.get_or(i, model.NONE()), second.starts.get_or(i, model.NONE()));
-        total_end_delta = total_end_delta + delta(first_end, second_end);
+        total_start_delta += delta(first.starts.get_or(i, model.NONE()), second.starts.get_or(i, model.NONE()));
+        total_end_delta += delta(first_end, second_end);
         digest = mix(digest, first_status); digest = mix(digest, second_status);
         digest = mix(digest, first_end); digest = mix(digest, second_end);
-        i = i + 1;
+        i += 1;
     }
     let changed_task_count = changed_tasks.len();
     let faster_count = faster_tasks.len();

--- a/examples/lattice/run_comparison.rue
+++ b/examples/lattice/run_comparison.rue
@@ -48,7 +48,7 @@ pub fn compare(borrow workflow: model.Workflow, borrow first: state.Run, borrow 
         let second_end = second.ends.get_or(i, model.NONE());
         let changed = first_status != second_status || first.starts.get_or(i, model.NONE()) != second.starts.get_or(i, model.NONE()) ||
             first_end != second_end || first.attempts.get_or(i, 0) != second.attempts.get_or(i, 0);
-        if changed { changed_tasks.push(i); } else { unchanged_count = unchanged_count + 1; }
+        if changed { changed_tasks.push(i); } else { unchanged_count += 1; }
         if first_end != model.NONE() && second_end != model.NONE() {
             if first_end < second_end { faster_tasks.push(i); }
             else if second_end < first_end { slower_tasks.push(i); }

--- a/examples/lattice/schedule.rue
+++ b/examples/lattice/schedule.rue
@@ -9,7 +9,7 @@ fn dependencies_done(borrow workflow: model.Workflow, borrow run: state.Run, tas
     while i < workflow.edges.len() {
         let edge = workflow.edges.get_or(i, model.empty_edge());
         if edge.after == task && !state.successful(run.status.get_or(edge.before, state.FAILED())) { return false; }
-        i = i + 1;
+        i += 1;
     }
     true
 }
@@ -19,7 +19,7 @@ fn dependency_failed(borrow workflow: model.Workflow, borrow run: state.Run, tas
     while i < workflow.edges.len() {
         let edge = workflow.edges.get_or(i, model.empty_edge());
         if edge.after == task && run.status.get_or(edge.before, state.FAILED()) == state.FAILED() { return true; }
-        i = i + 1;
+        i += 1;
     }
     false
 }
@@ -36,7 +36,7 @@ fn pool_usage(borrow workflow: model.Workflow, borrow run: state.Run, pool: u64,
                 else { value = value + task.memory; }
             }
         }
-        i = i + 1;
+        i += 1;
     }
     value
 }
@@ -77,19 +77,19 @@ fn complete(inout run: state.Run, borrow workflow: model.Workflow, time: u64) {
                 if attempt <= task.retries {
                     run.status.set(i, state.PENDING());
                     run.next_ready.set(i, time + attempt);
-                    run.retries = run.retries + 1;
+                    run.retries += 1;
                     emit(inout run, state.EVENT_RETRY(), time, i, task.pool, attempt, task.cpu, task.memory);
                 } else {
                     run.status.set(i, state.FAILED());
-                    run.failed = run.failed + 1;
+                    run.failed += 1;
                 }
             } else {
                 run.status.set(i, state.SUCCEEDED());
-                run.succeeded = run.succeeded + 1;
+                run.succeeded += 1;
                 emit(inout run, state.EVENT_SUCCESS(), time, i, task.pool, attempt, task.cpu, task.memory);
             }
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -102,11 +102,11 @@ fn block_failed_dependents(inout run: state.Run, borrow workflow: model.Workflow
             if run.status.get_or(i, state.FAILED()) == state.PENDING() && dependency_failed(borrow workflow, borrow run, i) {
                 let task = workflow.tasks.get_or(i, model.empty_task());
                 run.status.set(i, state.FAILED());
-                run.failed = run.failed + 1;
+                run.failed += 1;
                 emit(inout run, state.EVENT_BLOCKED(), time, i, task.pool, 0, task.cpu, task.memory);
                 changed = true;
             }
-            i = i + 1;
+            i += 1;
         }
     }
 }
@@ -131,7 +131,7 @@ fn pick_ready(borrow workflow: model.Workflow, borrow run: state.Run, time: u64)
             better(borrow workflow, i, best) {
             best = i;
         }
-        i = i + 1;
+        i += 1;
     }
     best
 }
@@ -140,7 +140,7 @@ fn has_running(borrow run: state.Run) -> bool {
     let mut i: u64 = 0;
     while i < run.status.len() {
         if run.status.get_or(i, state.FAILED()) == state.RUNNING() { return true; }
-        i = i + 1;
+        i += 1;
     }
     false
 }
@@ -149,7 +149,7 @@ fn all_terminal(borrow run: state.Run) -> bool {
     let mut i: u64 = 0;
     while i < run.status.len() {
         if !state.terminal(run.status.get_or(i, state.FAILED())) { return false; }
-        i = i + 1;
+        i += 1;
     }
     true
 }
@@ -161,7 +161,7 @@ fn count_waits(inout run: state.Run, borrow workflow: model.Workflow, time: u64)
             if !dependencies_done(borrow workflow, borrow run, i) { run.dependency_waits = run.dependency_waits + 1; }
             else if !fits(borrow workflow, borrow run, i) { run.resource_waits = run.resource_waits + 1; }
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -180,7 +180,7 @@ pub fn run(borrow workflow: model.Workflow, cache_seed: u64) -> state.Run {
                 result.status.set(task_index, state.CACHED());
                 result.starts.set(task_index, time);
                 result.ends.set(task_index, time);
-                result.cached = result.cached + 1;
+                result.cached += 1;
                 emit(inout result, state.EVENT_CACHE(), time, task_index, task.pool, 0, task.cpu, task.memory);
             } else {
                 let attempt = result.attempts.get_or(task_index, 0) + 1;
@@ -188,7 +188,7 @@ pub fn run(borrow workflow: model.Workflow, cache_seed: u64) -> state.Run {
                 result.status.set(task_index, state.RUNNING());
                 if result.starts.get_or(task_index, model.NONE()) == model.NONE() { result.starts.set(task_index, time); }
                 result.ends.set(task_index, time + task.duration);
-                result.starts_count = result.starts_count + 1;
+                result.starts_count += 1;
                 emit(inout result, state.EVENT_START(), time, task_index, task.pool, attempt, task.cpu, task.memory);
                 started = true;
             }

--- a/examples/lattice/schedule.rue
+++ b/examples/lattice/schedule.rue
@@ -31,9 +31,9 @@ fn pool_usage(borrow workflow: model.Workflow, borrow run: state.Run, pool: u64,
         if run.status.get_or(i, state.FAILED()) == state.RUNNING() {
             let task = workflow.tasks.get_or(i, model.empty_task());
             if task.pool == pool {
-                if field == 0 { value = value + 1; }
-                else if field == 1 { value = value + task.cpu; }
-                else { value = value + task.memory; }
+                if field == 0 { value += 1; }
+                else if field == 1 { value += task.cpu; }
+                else { value += task.memory; }
             }
         }
         i += 1;
@@ -158,8 +158,8 @@ fn count_waits(inout run: state.Run, borrow workflow: model.Workflow, time: u64)
     let mut i: u64 = 0;
     while i < workflow.tasks.len() {
         if run.status.get_or(i, state.FAILED()) == state.PENDING() && run.next_ready.get_or(i, 0) <= time {
-            if !dependencies_done(borrow workflow, borrow run, i) { run.dependency_waits = run.dependency_waits + 1; }
-            else if !fits(borrow workflow, borrow run, i) { run.resource_waits = run.resource_waits + 1; }
+            if !dependencies_done(borrow workflow, borrow run, i) { run.dependency_waits += 1; }
+            else if !fits(borrow workflow, borrow run, i) { run.resource_waits += 1; }
         }
         i += 1;
     }
@@ -194,8 +194,8 @@ pub fn run(borrow workflow: model.Workflow, cache_seed: u64) -> state.Run {
             }
         }
         count_waits(inout result, borrow workflow, time);
-        if !started && !has_running(borrow result) && !all_terminal(borrow result) { result.idle_ticks = result.idle_ticks + 1; }
-        if !all_terminal(borrow result) { time = time + 1; }
+        if !started && !has_running(borrow result) && !all_terminal(borrow result) { result.idle_ticks += 1; }
+        if !all_terminal(borrow result) { time += 1; }
     }
     result.makespan = time;
     result

--- a/examples/lattice/schedule_diff.rue
+++ b/examples/lattice/schedule_diff.rue
@@ -40,7 +40,7 @@ pub fn compare(borrow workflow: model.Workflow, borrow first: state.Run, borrow 
         if first.attempts.get_or(i, 0) != second.attempts.get_or(i, 0) { attempt_changes = attempt_changes + 1; }
         digest = mix(digest, first.status.get_or(i, 0)); digest = mix(digest, second.status.get_or(i, 0));
         digest = mix(digest, first.starts.get_or(i, 0)); digest = mix(digest, second.starts.get_or(i, 0));
-        i = i + 1;
+        i += 1;
     }
     let limit = if first.events.len() < second.events.len() { first.events.len() } else { second.events.len() };
     let mut common_event_prefix: u64 = 0;

--- a/examples/lattice/schedule_diff.rue
+++ b/examples/lattice/schedule_diff.rue
@@ -34,10 +34,10 @@ pub fn compare(borrow workflow: model.Workflow, borrow first: state.Run, borrow 
     let mut digest: u64 = 14695981039346656037;
     let mut i: u64 = 0;
     while i < workflow.tasks.len() {
-        if first.status.get_or(i, 0) != second.status.get_or(i, 0) { status_changes = status_changes + 1; }
-        if first.starts.get_or(i, 0) != second.starts.get_or(i, 0) { start_changes = start_changes + 1; }
-        if first.ends.get_or(i, 0) != second.ends.get_or(i, 0) { end_changes = end_changes + 1; }
-        if first.attempts.get_or(i, 0) != second.attempts.get_or(i, 0) { attempt_changes = attempt_changes + 1; }
+        if first.status.get_or(i, 0) != second.status.get_or(i, 0) { status_changes += 1; }
+        if first.starts.get_or(i, 0) != second.starts.get_or(i, 0) { start_changes += 1; }
+        if first.ends.get_or(i, 0) != second.ends.get_or(i, 0) { end_changes += 1; }
+        if first.attempts.get_or(i, 0) != second.attempts.get_or(i, 0) { attempt_changes += 1; }
         digest = mix(digest, first.status.get_or(i, 0)); digest = mix(digest, second.status.get_or(i, 0));
         digest = mix(digest, first.starts.get_or(i, 0)); digest = mix(digest, second.starts.get_or(i, 0));
         i += 1;
@@ -47,7 +47,7 @@ pub fn compare(borrow workflow: model.Workflow, borrow first: state.Run, borrow 
     while common_event_prefix < limit && same_event(
         first.events.get_or(common_event_prefix, state.empty_event()),
         second.events.get_or(common_event_prefix, state.empty_event()),
-    ) { common_event_prefix = common_event_prefix + 1; }
+    ) { common_event_prefix += 1; }
     Difference {
         status_changes: status_changes, start_changes: start_changes,
         end_changes: end_changes, attempt_changes: attempt_changes,

--- a/examples/lattice/schedule_quality.rue
+++ b/examples/lattice/schedule_quality.rue
@@ -29,7 +29,7 @@ fn maximum(borrow values: model.U64s) -> u64 {
     let mut i: u64 = 0;
     while i < values.len() {
         if values.get_or(i, 0) > result { result = values.get_or(i, 0); }
-        i = i + 1;
+        i += 1;
     }
     result
 }

--- a/examples/lattice/selftest.rue
+++ b/examples/lattice/selftest.rue
@@ -38,9 +38,9 @@ pub struct Result {
 }
 
 fn record(inout result: Result, condition: bool) {
-    result.checks = result.checks + 1;
+    result.checks += 1;
     if !condition {
-        result.failures = result.failures + 1;
+        result.failures += 1;
         result.last_failed_check = result.checks;
     }
 }
@@ -50,9 +50,9 @@ fn mix(hash: u64, value: u64) -> u64 { @wrapping_mul(hash ^ value, 1099511628211
 fn one(inout result: Result, tasks: u64, pools: u64, width: u64, seed: u64) {
     let mut workflow = generate.workflow(tasks, pools, width, seed);
     validate.workflow(inout workflow);
-    result.workflows = result.workflows + 1;
-    result.tasks = result.tasks + workflow.tasks.len();
-    result.edges = result.edges + workflow.edges.len();
+    result.workflows += 1;
+    result.tasks += workflow.tasks.len();
+    result.edges += workflow.edges.len();
     record(inout result, workflow.diagnostics.len() == 0);
     let order = topology.sort(borrow workflow);
     let closure = cycle_oracle.compute(borrow workflow);
@@ -77,7 +77,7 @@ fn one(inout result: Result, tasks: u64, pools: u64, width: u64, seed: u64) {
     let events = event_analysis.summarize(borrow workflow, borrow first);
     let serial = serial_oracle.compute(borrow workflow, borrow first);
     let difference = schedule_diff.compare(borrow workflow, borrow first, borrow second);
-    result.events = result.events + first.events.len();
+    result.events += first.events.len();
     record(inout result, audit.ok);
     record(inout result, first.failed == 0);
     record(inout result, first.succeeded + first.cached == workflow.tasks.len());
@@ -104,9 +104,9 @@ fn one(inout result: Result, tasks: u64, pools: u64, width: u64, seed: u64) {
     result.digest = mix(result.digest, events.digest);
     result.digest = mix(result.digest, serial.digest);
     result.digest = mix(result.digest, difference.digest);
-    result.analysis_passes = result.analysis_passes + analyses.passes;
-    result.analysis_observations = result.analysis_observations + analyses.observations;
-    result.analysis_warnings = result.analysis_warnings + analyses.warnings;
+    result.analysis_passes += analyses.passes;
+    result.analysis_observations += analyses.observations;
+    result.analysis_warnings += analyses.warnings;
 }
 
 pub fn run() -> Result {

--- a/examples/lattice/serial_oracle.rue
+++ b/examples/lattice/serial_oracle.rue
@@ -34,10 +34,10 @@ pub fn compute(borrow workflow: model.Workflow, borrow run: state.Run) -> Oracle
         let attempts = run.attempts.get_or(i, 0);
         let work = task.duration * attempts;
         executed_work += work;
-        if attempts > 0 { started_tasks = started_tasks + 1; }
-        if run.status.get_or(i, state.FAILED()) == state.CACHED() { cached_tasks = cached_tasks + 1; }
-        else if run.status.get_or(i, state.FAILED()) == state.SUCCEEDED() { successful_work = successful_work + task.duration; }
-        else if run.status.get_or(i, state.FAILED()) == state.FAILED() { failed_work = failed_work + work; }
+        if attempts > 0 { started_tasks += 1; }
+        if run.status.get_or(i, state.FAILED()) == state.CACHED() { cached_tasks += 1; }
+        else if run.status.get_or(i, state.FAILED()) == state.SUCCEEDED() { successful_work += task.duration; }
+        else if run.status.get_or(i, state.FAILED()) == state.FAILED() { failed_work += work; }
         if work > maximum_single_task { maximum_single_task = work; }
         digest = mix(digest, i); digest = mix(digest, attempts); digest = mix(digest, work);
         i += 1;

--- a/examples/lattice/serial_oracle.rue
+++ b/examples/lattice/serial_oracle.rue
@@ -33,14 +33,14 @@ pub fn compute(borrow workflow: model.Workflow, borrow run: state.Run) -> Oracle
         let task = workflow.tasks.get_or(i, model.empty_task());
         let attempts = run.attempts.get_or(i, 0);
         let work = task.duration * attempts;
-        executed_work = executed_work + work;
+        executed_work += work;
         if attempts > 0 { started_tasks = started_tasks + 1; }
         if run.status.get_or(i, state.FAILED()) == state.CACHED() { cached_tasks = cached_tasks + 1; }
         else if run.status.get_or(i, state.FAILED()) == state.SUCCEEDED() { successful_work = successful_work + task.duration; }
         else if run.status.get_or(i, state.FAILED()) == state.FAILED() { failed_work = failed_work + work; }
         if work > maximum_single_task { maximum_single_task = work; }
         digest = mix(digest, i); digest = mix(digest, attempts); digest = mix(digest, work);
-        i = i + 1;
+        i += 1;
     }
     let lower_bound = maximum_single_task;
     let upper_bound = executed_work + run.idle_ticks + run.retries;

--- a/examples/lattice/state.rue
+++ b/examples/lattice/state.rue
@@ -49,7 +49,7 @@ pub struct Run {
 fn filled(count: u64, value: u64) -> model.U64s {
     let mut out = model.U64s.with_capacity(count);
     let mut i: u64 = 0;
-    while i < count { out.push(value); i = i + 1; }
+    while i < count { out.push(value); i += 1; }
     out
 }
 

--- a/examples/lattice/statistics.rue
+++ b/examples/lattice/statistics.rue
@@ -44,8 +44,8 @@ fn mix(hash: u64, value: u64) -> u64 { @wrapping_mul(hash ^ value, 1099511628211
 fn observe(inout value: Distribution, sample: u64, low_limit: u64, high_limit: u64) {
     if value.count == 0 || sample < value.minimum { value.minimum = sample; }
     if value.count == 0 || sample > value.maximum { value.maximum = sample; }
-    value.count = value.count + 1;
-    value.sum = value.sum + sample;
+    value.count += 1;
+    value.sum += sample;
     if sample == 0 { value.zeroes = value.zeroes + 1; }
     if sample < low_limit { value.low = value.low + 1; }
     else if sample < high_limit { value.medium = value.medium + 1; }
@@ -92,10 +92,10 @@ pub fn compute(borrow workflow: model.Workflow) -> Summary {
         observe(inout dependents, model.dependent_count(borrow workflow, i), 1, 3);
         if task.cacheable { cacheable = cacheable + 1; }
         if task.fail_attempt > 0 { fallible = fallible + 1; }
-        total_work = total_work + task.duration;
-        total_cpu_ticks = total_cpu_ticks + task.duration * task.cpu;
-        total_memory_ticks = total_memory_ticks + task.duration * task.memory;
-        i = i + 1;
+        total_work += task.duration;
+        total_cpu_ticks += task.duration * task.cpu;
+        total_memory_ticks += task.duration * task.memory;
+        i += 1;
     }
     finish(inout duration); finish(inout cpu); finish(inout memory);
     finish(inout priority); finish(inout retries);

--- a/examples/lattice/statistics.rue
+++ b/examples/lattice/statistics.rue
@@ -46,10 +46,10 @@ fn observe(inout value: Distribution, sample: u64, low_limit: u64, high_limit: u
     if value.count == 0 || sample > value.maximum { value.maximum = sample; }
     value.count += 1;
     value.sum += sample;
-    if sample == 0 { value.zeroes = value.zeroes + 1; }
-    if sample < low_limit { value.low = value.low + 1; }
-    else if sample < high_limit { value.medium = value.medium + 1; }
-    else { value.high = value.high + 1; }
+    if sample == 0 { value.zeroes += 1; }
+    if sample < low_limit { value.low += 1; }
+    else if sample < high_limit { value.medium += 1; }
+    else { value.high += 1; }
     value.digest = mix(value.digest, sample);
 }
 
@@ -90,8 +90,8 @@ pub fn compute(borrow workflow: model.Workflow) -> Summary {
         observe(inout retries, task.retries, 1, 3);
         observe(inout dependencies, model.dependency_count(borrow workflow, i), 1, 3);
         observe(inout dependents, model.dependent_count(borrow workflow, i), 1, 3);
-        if task.cacheable { cacheable = cacheable + 1; }
-        if task.fail_attempt > 0 { fallible = fallible + 1; }
+        if task.cacheable { cacheable += 1; }
+        if task.fail_attempt > 0 { fallible += 1; }
         total_work += task.duration;
         total_cpu_ticks += task.duration * task.cpu;
         total_memory_ticks += task.duration * task.memory;

--- a/examples/lattice/text.rue
+++ b/examples/lattice/text.rue
@@ -5,7 +5,7 @@ const StrBuf = std.strbuf.StrBuf;
 
 pub fn append_literal(inout out: StrBuf, value: str) {
     let mut i: u64 = 0;
-    while i < value.len() { out.push(value[i]); i = i + 1; }
+    while i < value.len() { out.push(value[i]); i += 1; }
 }
 
 pub fn append_string(inout out: StrBuf, borrow value: StrBuf) {

--- a/examples/lattice/text.rue
+++ b/examples/lattice/text.rue
@@ -12,7 +12,7 @@ pub fn append_string(inout out: StrBuf, borrow value: StrBuf) {
     let mut i: u64 = 0;
     while i < value.len() {
         out.push(StrBuf.byte_at_borrowed(borrow value, i));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -49,9 +49,9 @@ pub fn fnv1a(borrow value: StrBuf) -> u64 {
     let mut hash: u64 = 14695981039346656037;
     let mut i: u64 = 0;
     while i < value.len() {
-        hash = hash ^ @intCast(StrBuf.byte_at_borrowed(borrow value, i));
+        hash ^= @intCast(StrBuf.byte_at_borrowed(borrow value, i));
         hash = @wrapping_mul(hash, 1099511628211);
-        i = i + 1;
+        i += 1;
     }
     hash
 }
@@ -65,7 +65,7 @@ pub fn json_id(inout out: StrBuf, borrow workflow: model.Workflow, id: u64) {
         else if byte == 92 { append_literal(inout out, "\\\\"); }
         else if byte == 10 { append_literal(inout out, "\\n"); }
         else { out.push(byte); }
-        i = i + 1;
+        i += 1;
     }
     out.push(34);
 }

--- a/examples/lattice/topology.rue
+++ b/examples/lattice/topology.rue
@@ -17,7 +17,7 @@ pub struct Order {
 fn zeroes(count: u64) -> U64s {
     let mut values = U64s.with_capacity(count);
     let mut i: u64 = 0;
-    while i < count { values.push(0); i = i + 1; }
+    while i < count { values.push(0); i += 1; }
     values
 }
 
@@ -38,7 +38,7 @@ fn outdegree(borrow workflow: model.Workflow, task: u64) -> u64 {
     let mut value: u64 = 0;
     let mut i: u64 = 0;
     while i < workflow.edges.len() {
-        if workflow.edges.get_or(i, model.empty_edge()).before == task { value = value + 1; }
+        if workflow.edges.get_or(i, model.empty_edge()).before == task { value += 1; }
         i += 1;
     }
     value
@@ -49,7 +49,7 @@ pub fn sort(borrow workflow: model.Workflow) -> Order {
     let mut remaining = compute_indegrees(borrow workflow);
     let mut emitted = model.Bools.with_capacity(workflow.tasks.len());
     let mut i: u64 = 0;
-    while i < workflow.tasks.len() { emitted.push(false); i = i + 1; }
+    while i < workflow.tasks.len() { emitted.push(false); i += 1; }
     let mut tasks = U64s.with_capacity(workflow.tasks.len());
 
     while tasks.len() < workflow.tasks.len() {
@@ -91,8 +91,8 @@ pub fn sort(borrow workflow: model.Workflow) -> Order {
     while i < workflow.tasks.len() {
         let inside = original.get_or(i, 0);
         let outside = outdegree(borrow workflow, i);
-        if inside == 0 { roots = roots + 1; }
-        if outside == 0 { leaves = leaves + 1; }
+        if inside == 0 { roots += 1; }
+        if outside == 0 { leaves += 1; }
         if inside > maximum_indegree { maximum_indegree = inside; }
         if outside > maximum_outdegree { maximum_outdegree = outside; }
         i += 1;

--- a/examples/lattice/topology.rue
+++ b/examples/lattice/topology.rue
@@ -29,7 +29,7 @@ fn compute_indegrees(borrow workflow: model.Workflow) -> U64s {
         if edge.after < values.len() {
             values.set(edge.after, values.get_or(edge.after, 0) + 1);
         }
-        i = i + 1;
+        i += 1;
     }
     values
 }
@@ -39,7 +39,7 @@ fn outdegree(borrow workflow: model.Workflow, task: u64) -> u64 {
     let mut i: u64 = 0;
     while i < workflow.edges.len() {
         if workflow.edges.get_or(i, model.empty_edge()).before == task { value = value + 1; }
-        i = i + 1;
+        i += 1;
     }
     value
 }
@@ -67,7 +67,7 @@ pub fn sort(borrow workflow: model.Workflow) -> Order {
                     }
                 }
             }
-            i = i + 1;
+            i += 1;
         }
         if best == model.NONE() { break; }
         emitted.set(best, true);
@@ -79,7 +79,7 @@ pub fn sort(borrow workflow: model.Workflow) -> Order {
                 let old = remaining.get_or(edge.after, 0);
                 if old > 0 { remaining.set(edge.after, old - 1); }
             }
-            i = i + 1;
+            i += 1;
         }
     }
 
@@ -95,7 +95,7 @@ pub fn sort(borrow workflow: model.Workflow) -> Order {
         if outside == 0 { leaves = leaves + 1; }
         if inside > maximum_indegree { maximum_indegree = inside; }
         if outside > maximum_outdegree { maximum_outdegree = outside; }
-        i = i + 1;
+        i += 1;
     }
     let has_cycle = tasks.len() != workflow.tasks.len();
     Order {
@@ -113,7 +113,7 @@ pub fn position(borrow order: Order, task: u64) -> u64 {
     let mut i: u64 = 0;
     while i < order.tasks.len() {
         if order.tasks.get_or(i, model.NONE()) == task { return i; }
-        i = i + 1;
+        i += 1;
     }
     model.NONE()
 }
@@ -124,7 +124,7 @@ pub fn valid(borrow workflow: model.Workflow, borrow order: Order) -> bool {
     while i < workflow.edges.len() {
         let edge = workflow.edges.get_or(i, model.empty_edge());
         if position(borrow order, edge.before) >= position(borrow order, edge.after) { return false; }
-        i = i + 1;
+        i += 1;
     }
     true
 }

--- a/examples/lattice/transitive_reduction.rue
+++ b/examples/lattice/transitive_reduction.rue
@@ -29,7 +29,7 @@ fn alternate_path(
             cycle_oracle.reaches(borrow closure, middle, target.after) {
             return true;
         }
-        middle = middle + 1;
+        middle += 1;
     }
     false
 }
@@ -57,7 +57,7 @@ pub fn compute(borrow workflow: model.Workflow) -> Reduction {
         }
         digest = mix(digest, edge.before);
         digest = mix(digest, edge.after);
-        i = i + 1;
+        i += 1;
     }
     let essential_count = essential.len();
     let redundant_count = redundant.len();
@@ -77,12 +77,12 @@ pub fn verify(borrow workflow: model.Workflow, borrow reduction: Reduction) -> b
     let mut i: u64 = 0;
     while i < reduction.essential.len() {
         if reduction.essential.get_or(i, model.NONE()) >= workflow.edges.len() { return false; }
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < reduction.redundant.len() {
         if reduction.redundant.get_or(i, model.NONE()) >= workflow.edges.len() { return false; }
-        i = i + 1;
+        i += 1;
     }
     true
 }

--- a/examples/lattice/transitive_reduction.rue
+++ b/examples/lattice/transitive_reduction.rue
@@ -51,8 +51,8 @@ pub fn compute(borrow workflow: model.Workflow) -> Reduction {
             essential.push(i);
             let before = workflow.tasks.get_or(edge.before, model.empty_task());
             let after = workflow.tasks.get_or(edge.after, model.empty_task());
-            if before.pool == after.pool { same_pool_essential = same_pool_essential + 1; }
-            else { cross_pool_essential = cross_pool_essential + 1; }
+            if before.pool == after.pool { same_pool_essential += 1; }
+            else { cross_pool_essential += 1; }
             digest = mix(digest, i + 0x1000);
         }
         digest = mix(digest, edge.before);

--- a/examples/lattice/validate.rue
+++ b/examples/lattice/validate.rue
@@ -8,7 +8,7 @@ fn duplicate_pool(borrow workflow: model.Workflow, at: u64) -> bool {
     let mut i: u64 = 0;
     while i < at {
         if workflow.strings.ids_equal(candidate.id, workflow.pools.get_or(i, model.empty_pool()).id) { return true; }
-        i = i + 1;
+        i += 1;
     }
     false
 }
@@ -18,7 +18,7 @@ fn duplicate_task(borrow workflow: model.Workflow, at: u64) -> bool {
     let mut i: u64 = 0;
     while i < at {
         if workflow.strings.ids_equal(candidate.id, workflow.tasks.get_or(i, model.empty_task()).id) { return true; }
-        i = i + 1;
+        i += 1;
     }
     false
 }
@@ -31,7 +31,7 @@ fn validate_pools(inout workflow: model.Workflow) {
         if item.slots == 0 { model.add_error(inout workflow, 202, item.id, "pool slots must be positive"); }
         if item.cpu == 0 { model.add_error(inout workflow, 202, item.id, "pool cpu must be positive"); }
         if item.memory == 0 { model.add_error(inout workflow, 202, item.id, "pool memory must be positive"); }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -54,7 +54,7 @@ fn validate_tasks(inout workflow: model.Workflow) {
         if item.priority > 100 { model.add_error(inout workflow, 202, item.id, "priority must be at most 100"); }
         if item.retries > 20 { model.add_error(inout workflow, 202, item.id, "retries must be at most 20"); }
         workflow.tasks.set(i, item);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -75,10 +75,10 @@ fn validate_edges(inout workflow: model.Workflow) {
             if other.before_id == edge.before_id && other.after_id == edge.after_id {
                 model.add_error(inout workflow, 200, edge.after_id, "duplicate dependency");
             }
-            earlier = earlier + 1;
+            earlier += 1;
         }
         workflow.edges.set(i, edge);
-        i = i + 1;
+        i += 1;
     }
 }
 

--- a/examples/lattice/workload.rue
+++ b/examples/lattice/workload.rue
@@ -31,8 +31,8 @@ fn include(inout result: Result, borrow value: stress.Result) {
     result.makespan_sum += value.makespan;
     if value.makespan > result.maximum_makespan { result.maximum_makespan = value.makespan; }
     result.digest = mix(result.digest, value.digest);
-    if !value.valid { result.invalid_runs = result.invalid_runs + 1; }
-    if !value.deterministic { result.nondeterministic_runs = result.nondeterministic_runs + 1; }
+    if !value.valid { result.invalid_runs += 1; }
+    if !value.deterministic { result.nondeterministic_runs += 1; }
 }
 
 fn pair(inout result: Result, scale: u64) {

--- a/examples/lattice/workload.rue
+++ b/examples/lattice/workload.rue
@@ -23,12 +23,12 @@ pub struct Result {
 fn mix(hash: u64, value: u64) -> u64 { @wrapping_mul(hash ^ value, 1099511628211) }
 
 fn include(inout result: Result, borrow value: stress.Result) {
-    result.runs = result.runs + 1;
-    result.tasks = result.tasks + value.tasks;
-    result.edges = result.edges + value.edges;
-    result.events = result.events + value.events;
-    result.observations = result.observations + value.observations;
-    result.makespan_sum = result.makespan_sum + value.makespan;
+    result.runs += 1;
+    result.tasks += value.tasks;
+    result.edges += value.edges;
+    result.events += value.events;
+    result.observations += value.observations;
+    result.makespan_sum += value.makespan;
     if value.makespan > result.maximum_makespan { result.maximum_makespan = value.makespan; }
     result.digest = mix(result.digest, value.digest);
     if !value.valid { result.invalid_runs = result.invalid_runs + 1; }
@@ -40,9 +40,9 @@ fn pair(inout result: Result, scale: u64) {
     let second = stress.run(stress.tier(scale));
     include(inout result, borrow first);
     include(inout result, borrow second);
-    result.tiers = result.tiers + 1;
+    result.tiers += 1;
     if first.digest != second.digest || first.fingerprint != second.fingerprint {
-        result.nondeterministic_runs = result.nondeterministic_runs + 1;
+        result.nondeterministic_runs += 1;
     }
 }
 

--- a/examples/life.rue
+++ b/examples/life.rue
@@ -24,11 +24,11 @@ fn count_neighbors(g: [[i32; W]; H], y: i32, x: i32) -> i32 {
         let mut dx = -1;
         while dx <= 1 {
             if dy != 0 || dx != 0 {
-                total = total + alive_at(g, y + dy, x + dx);
+                total += alive_at(g, y + dy, x + dx);
             }
-            dx = dx + 1;
+            dx += 1;
         }
-        dy = dy + 1;
+        dy += 1;
     }
     total
 }
@@ -48,9 +48,9 @@ fn step(g: [[i32; W]; H]) -> [[i32; W]; H] {
             } else {
                 if n == 3 { next[y][x] = 1; }
             }
-            x = x + 1;
+            x += 1;
         }
-        y = y + 1;
+        y += 1;
     }
     next
 }
@@ -61,10 +61,10 @@ fn population(g: [[i32; W]; H]) -> i32 {
     while y < H {
         let mut x = 0;
         while x < W {
-            total = total + g[y][x];
-            x = x + 1;
+            total += g[y][x];
+            x += 1;
         }
-        y = y + 1;
+        y += 1;
     }
     total
 }
@@ -85,7 +85,7 @@ fn main() -> i32 {
     while gen < 8 {
         @dbg(population(g));
         g = step(g);
-        gen = gen + 1;
+        gen += 1;
     }
 
     population(g)

--- a/examples/linear_pool.rue
+++ b/examples/linear_pool.rue
@@ -14,13 +14,13 @@ struct Pool {
 
     fn acquire(inout self) -> Token {
         let id = self.next;
-        self.next = self.next + 1;
-        self.outstanding = self.outstanding + 1;
+        self.next += 1;
+        self.outstanding += 1;
         Token { id: id }
     }
 
     fn release(inout self, t: Token) -> i64 {
-        self.outstanding = self.outstanding - 1;
+        self.outstanding -= 1;
         t.id
     }
 }

--- a/examples/match.rue
+++ b/examples/match.rue
@@ -29,9 +29,9 @@ fn count_weekdays(start: i32, end: i32) -> i32 {
     let mut day = start;
     while day <= end {
         if is_weekday(day) {
-            count = count + 1;
+            count += 1;
         }
-        day = day + 1;
+        day += 1;
     }
     count
 }

--- a/examples/matrix.rue
+++ b/examples/matrix.rue
@@ -33,9 +33,9 @@ fn multiply(a: Matrix, b: Matrix) -> Matrix {
             let mut k = 0;
             while k < N { acc = acc + a.get(r, k) * b.get(k, c); k = k + 1; }
             out.set(r, c, acc);
-            c = c + 1;
+            c += 1;
         }
-        r = r + 1;
+        r += 1;
     }
     out
 }
@@ -48,7 +48,7 @@ fn main() -> i32 {
     while r < N {
         let mut c = 0;
         while c < N { a.set(r, c, v); v = v + 1; c = c + 1; }
-        r = r + 1;
+        r += 1;
     }
     // a * identity == a, so trace(a*id) == trace(a) == 1 + 5 + 9 == 15
     let prod = multiply(a, id);

--- a/examples/matrix.rue
+++ b/examples/matrix.rue
@@ -11,7 +11,7 @@ struct Matrix {
     fn trace(borrow self) -> i32 {
         let mut t = 0;
         let mut i = 0;
-        while i < N { t = t + self.data[i][i]; i = i + 1; }
+        while i < N { t += self.data[i][i]; i += 1; }
         t
     }
 }
@@ -19,7 +19,7 @@ struct Matrix {
 fn identity() -> Matrix {
     let mut m = Matrix { data: [[0; N]; N] };
     let mut i = 0;
-    while i < N { m.set(i, i, 1); i = i + 1; }
+    while i < N { m.set(i, i, 1); i += 1; }
     m
 }
 
@@ -31,7 +31,7 @@ fn multiply(a: Matrix, b: Matrix) -> Matrix {
         while c < N {
             let mut acc = 0;
             let mut k = 0;
-            while k < N { acc = acc + a.get(r, k) * b.get(k, c); k = k + 1; }
+            while k < N { acc += a.get(r, k) * b.get(k, c); k += 1; }
             out.set(r, c, acc);
             c += 1;
         }
@@ -47,7 +47,7 @@ fn main() -> i32 {
     let mut r = 0;
     while r < N {
         let mut c = 0;
-        while c < N { a.set(r, c, v); v = v + 1; c = c + 1; }
+        while c < N { a.set(r, c, v); v += 1; c += 1; }
         r += 1;
     }
     // a * identity == a, so trace(a*id) == trace(a) == 1 + 5 + 9 == 15

--- a/examples/maze/grid.rue
+++ b/examples/maze/grid.rue
@@ -21,7 +21,7 @@ pub struct Maze {
         while i < total {
             cells.push(0);
             visited.push(0);
-            i = i + 1;
+            i += 1;
         }
         Self { w: w, h: h, cells: cells, visited: visited }
     }
@@ -54,7 +54,7 @@ pub struct Maze {
         let mut i: u64 = 0;
         while i < @intCast(total) {
             self.visited.set(i, 0);
-            i = i + 1;
+            i += 1;
         }
     }
 }

--- a/examples/maze/main.rue
+++ b/examples/maze/main.rue
@@ -56,7 +56,7 @@ fn solve(inout m: grid.Maze) -> i64 {
         let x = qx.get_or(head, 0);
         let y = qy.get_or(head, 0);
         let d = qd.get_or(head, 0);
-        head = head + 1;
+        head += 1;
         if x == w - 1 {
             if y == h - 1 {
                 result = d;
@@ -86,12 +86,12 @@ fn main() -> i32 {
         while x < 16 {
             let mut p = m.passages(x, y);
             while p != 0 {
-                bits = bits + (p & 1);
-                p = p >> 1;
+                bits += (p & 1);
+                p >>= 1;
             }
-            x = x + 1;
+            x += 1;
         }
-        y = y + 1;
+        y += 1;
     }
     @assert(bits == 510, "tree edges * 2");   // (256-1)*2
 

--- a/examples/meridian/analysis_catalog_column_width.rue
+++ b/examples/meridian/analysis_catalog_column_width.rue
@@ -77,19 +77,19 @@ fn observe_catalog(inout out: metric.Metric, borrow database: model.Database) {
     let mut i: u64 = 0;
     while i < database.tables.len() {
         metric.observe(inout out, table_projection(borrow database, i), i + MODE());
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.columns.len() {
         metric.observe(inout out, column_projection(borrow database, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.indexes.len() {
         let item = database.indexes.get_or(i, model.empty_index());
         metric.observe(inout out, item.entries + item.column + MODE(), if item.unique { 5 } else { 2 });
         metric.warn(inout out, item.table >= database.tables.len());
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -98,12 +98,12 @@ fn observe_storage(inout out: metric.Metric, borrow database: model.Database) {
     while i < database.rows.len() {
         metric.observe(inout out, row_projection(borrow database, i), (i % 7) + 1);
         metric.warn(inout out, database.rows.get_or(i, model.empty_row()).table >= database.tables.len());
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.cells.len() {
         metric.observe(inout out, cell_projection(borrow database, i), (i % 11) + 1);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -111,22 +111,22 @@ fn observe_operations(inout out: metric.Metric, borrow database: model.Database)
     let mut i: u64 = 0;
     while i < database.queries.len() {
         metric.observe(inout out, query_projection(borrow database, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.transactions.len() {
         metric.observe(inout out, transaction_projection(borrow database, i), i + 2);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.wal.len() {
         metric.observe(inout out, wal_projection(borrow database, i), i + 3);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.replicas.len() {
         metric.observe(inout out, replica_projection(borrow database, i), i + 4);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -141,9 +141,9 @@ fn observe_pairs(inout out: metric.Metric, borrow database: model.Database) {
                 metric.observe(inout out,
                     (table.row_count + 1) * (index.entries + 1) + MODE(), t + x + 1);
             }
-            x = x + 1;
+            x += 1;
         }
-        t = t + 1;
+        t += 1;
     }
 }
 

--- a/examples/meridian/analysis_catalog_constraint_surface.rue
+++ b/examples/meridian/analysis_catalog_constraint_surface.rue
@@ -77,19 +77,19 @@ fn observe_catalog(inout out: metric.Metric, borrow database: model.Database) {
     let mut i: u64 = 0;
     while i < database.tables.len() {
         metric.observe(inout out, table_projection(borrow database, i), i + MODE());
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.columns.len() {
         metric.observe(inout out, column_projection(borrow database, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.indexes.len() {
         let item = database.indexes.get_or(i, model.empty_index());
         metric.observe(inout out, item.entries + item.column + MODE(), if item.unique { 5 } else { 2 });
         metric.warn(inout out, item.table >= database.tables.len());
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -98,12 +98,12 @@ fn observe_storage(inout out: metric.Metric, borrow database: model.Database) {
     while i < database.rows.len() {
         metric.observe(inout out, row_projection(borrow database, i), (i % 7) + 1);
         metric.warn(inout out, database.rows.get_or(i, model.empty_row()).table >= database.tables.len());
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.cells.len() {
         metric.observe(inout out, cell_projection(borrow database, i), (i % 11) + 1);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -111,22 +111,22 @@ fn observe_operations(inout out: metric.Metric, borrow database: model.Database)
     let mut i: u64 = 0;
     while i < database.queries.len() {
         metric.observe(inout out, query_projection(borrow database, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.transactions.len() {
         metric.observe(inout out, transaction_projection(borrow database, i), i + 2);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.wal.len() {
         metric.observe(inout out, wal_projection(borrow database, i), i + 3);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.replicas.len() {
         metric.observe(inout out, replica_projection(borrow database, i), i + 4);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -141,9 +141,9 @@ fn observe_pairs(inout out: metric.Metric, borrow database: model.Database) {
                 metric.observe(inout out,
                     (table.row_count + 1) * (index.entries + 1) + MODE(), t + x + 1);
             }
-            x = x + 1;
+            x += 1;
         }
-        t = t + 1;
+        t += 1;
     }
 }
 

--- a/examples/meridian/analysis_catalog_index_coverage.rue
+++ b/examples/meridian/analysis_catalog_index_coverage.rue
@@ -77,19 +77,19 @@ fn observe_catalog(inout out: metric.Metric, borrow database: model.Database) {
     let mut i: u64 = 0;
     while i < database.tables.len() {
         metric.observe(inout out, table_projection(borrow database, i), i + MODE());
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.columns.len() {
         metric.observe(inout out, column_projection(borrow database, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.indexes.len() {
         let item = database.indexes.get_or(i, model.empty_index());
         metric.observe(inout out, item.entries + item.column + MODE(), if item.unique { 5 } else { 2 });
         metric.warn(inout out, item.table >= database.tables.len());
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -98,12 +98,12 @@ fn observe_storage(inout out: metric.Metric, borrow database: model.Database) {
     while i < database.rows.len() {
         metric.observe(inout out, row_projection(borrow database, i), (i % 7) + 1);
         metric.warn(inout out, database.rows.get_or(i, model.empty_row()).table >= database.tables.len());
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.cells.len() {
         metric.observe(inout out, cell_projection(borrow database, i), (i % 11) + 1);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -111,22 +111,22 @@ fn observe_operations(inout out: metric.Metric, borrow database: model.Database)
     let mut i: u64 = 0;
     while i < database.queries.len() {
         metric.observe(inout out, query_projection(borrow database, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.transactions.len() {
         metric.observe(inout out, transaction_projection(borrow database, i), i + 2);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.wal.len() {
         metric.observe(inout out, wal_projection(borrow database, i), i + 3);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.replicas.len() {
         metric.observe(inout out, replica_projection(borrow database, i), i + 4);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -141,9 +141,9 @@ fn observe_pairs(inout out: metric.Metric, borrow database: model.Database) {
                 metric.observe(inout out,
                     (table.row_count + 1) * (index.entries + 1) + MODE(), t + x + 1);
             }
-            x = x + 1;
+            x += 1;
         }
-        t = t + 1;
+        t += 1;
     }
 }
 

--- a/examples/meridian/analysis_catalog_index_fanout.rue
+++ b/examples/meridian/analysis_catalog_index_fanout.rue
@@ -77,19 +77,19 @@ fn observe_catalog(inout out: metric.Metric, borrow database: model.Database) {
     let mut i: u64 = 0;
     while i < database.tables.len() {
         metric.observe(inout out, table_projection(borrow database, i), i + MODE());
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.columns.len() {
         metric.observe(inout out, column_projection(borrow database, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.indexes.len() {
         let item = database.indexes.get_or(i, model.empty_index());
         metric.observe(inout out, item.entries + item.column + MODE(), if item.unique { 5 } else { 2 });
         metric.warn(inout out, item.table >= database.tables.len());
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -98,12 +98,12 @@ fn observe_storage(inout out: metric.Metric, borrow database: model.Database) {
     while i < database.rows.len() {
         metric.observe(inout out, row_projection(borrow database, i), (i % 7) + 1);
         metric.warn(inout out, database.rows.get_or(i, model.empty_row()).table >= database.tables.len());
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.cells.len() {
         metric.observe(inout out, cell_projection(borrow database, i), (i % 11) + 1);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -111,22 +111,22 @@ fn observe_operations(inout out: metric.Metric, borrow database: model.Database)
     let mut i: u64 = 0;
     while i < database.queries.len() {
         metric.observe(inout out, query_projection(borrow database, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.transactions.len() {
         metric.observe(inout out, transaction_projection(borrow database, i), i + 2);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.wal.len() {
         metric.observe(inout out, wal_projection(borrow database, i), i + 3);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.replicas.len() {
         metric.observe(inout out, replica_projection(borrow database, i), i + 4);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -141,9 +141,9 @@ fn observe_pairs(inout out: metric.Metric, borrow database: model.Database) {
                 metric.observe(inout out,
                     (table.row_count + 1) * (index.entries + 1) + MODE(), t + x + 1);
             }
-            x = x + 1;
+            x += 1;
         }
-        t = t + 1;
+        t += 1;
     }
 }
 

--- a/examples/meridian/analysis_catalog_key_selectivity.rue
+++ b/examples/meridian/analysis_catalog_key_selectivity.rue
@@ -77,19 +77,19 @@ fn observe_catalog(inout out: metric.Metric, borrow database: model.Database) {
     let mut i: u64 = 0;
     while i < database.tables.len() {
         metric.observe(inout out, table_projection(borrow database, i), i + MODE());
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.columns.len() {
         metric.observe(inout out, column_projection(borrow database, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.indexes.len() {
         let item = database.indexes.get_or(i, model.empty_index());
         metric.observe(inout out, item.entries + item.column + MODE(), if item.unique { 5 } else { 2 });
         metric.warn(inout out, item.table >= database.tables.len());
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -98,12 +98,12 @@ fn observe_storage(inout out: metric.Metric, borrow database: model.Database) {
     while i < database.rows.len() {
         metric.observe(inout out, row_projection(borrow database, i), (i % 7) + 1);
         metric.warn(inout out, database.rows.get_or(i, model.empty_row()).table >= database.tables.len());
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.cells.len() {
         metric.observe(inout out, cell_projection(borrow database, i), (i % 11) + 1);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -111,22 +111,22 @@ fn observe_operations(inout out: metric.Metric, borrow database: model.Database)
     let mut i: u64 = 0;
     while i < database.queries.len() {
         metric.observe(inout out, query_projection(borrow database, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.transactions.len() {
         metric.observe(inout out, transaction_projection(borrow database, i), i + 2);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.wal.len() {
         metric.observe(inout out, wal_projection(borrow database, i), i + 3);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.replicas.len() {
         metric.observe(inout out, replica_projection(borrow database, i), i + 4);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -141,9 +141,9 @@ fn observe_pairs(inout out: metric.Metric, borrow database: model.Database) {
                 metric.observe(inout out,
                     (table.row_count + 1) * (index.entries + 1) + MODE(), t + x + 1);
             }
-            x = x + 1;
+            x += 1;
         }
-        t = t + 1;
+        t += 1;
     }
 }
 

--- a/examples/meridian/analysis_catalog_metadata_locality.rue
+++ b/examples/meridian/analysis_catalog_metadata_locality.rue
@@ -77,19 +77,19 @@ fn observe_catalog(inout out: metric.Metric, borrow database: model.Database) {
     let mut i: u64 = 0;
     while i < database.tables.len() {
         metric.observe(inout out, table_projection(borrow database, i), i + MODE());
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.columns.len() {
         metric.observe(inout out, column_projection(borrow database, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.indexes.len() {
         let item = database.indexes.get_or(i, model.empty_index());
         metric.observe(inout out, item.entries + item.column + MODE(), if item.unique { 5 } else { 2 });
         metric.warn(inout out, item.table >= database.tables.len());
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -98,12 +98,12 @@ fn observe_storage(inout out: metric.Metric, borrow database: model.Database) {
     while i < database.rows.len() {
         metric.observe(inout out, row_projection(borrow database, i), (i % 7) + 1);
         metric.warn(inout out, database.rows.get_or(i, model.empty_row()).table >= database.tables.len());
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.cells.len() {
         metric.observe(inout out, cell_projection(borrow database, i), (i % 11) + 1);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -111,22 +111,22 @@ fn observe_operations(inout out: metric.Metric, borrow database: model.Database)
     let mut i: u64 = 0;
     while i < database.queries.len() {
         metric.observe(inout out, query_projection(borrow database, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.transactions.len() {
         metric.observe(inout out, transaction_projection(borrow database, i), i + 2);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.wal.len() {
         metric.observe(inout out, wal_projection(borrow database, i), i + 3);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.replicas.len() {
         metric.observe(inout out, replica_projection(borrow database, i), i + 4);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -141,9 +141,9 @@ fn observe_pairs(inout out: metric.Metric, borrow database: model.Database) {
                 metric.observe(inout out,
                     (table.row_count + 1) * (index.entries + 1) + MODE(), t + x + 1);
             }
-            x = x + 1;
+            x += 1;
         }
-        t = t + 1;
+        t += 1;
     }
 }
 

--- a/examples/meridian/analysis_catalog_name_entropy.rue
+++ b/examples/meridian/analysis_catalog_name_entropy.rue
@@ -77,19 +77,19 @@ fn observe_catalog(inout out: metric.Metric, borrow database: model.Database) {
     let mut i: u64 = 0;
     while i < database.tables.len() {
         metric.observe(inout out, table_projection(borrow database, i), i + MODE());
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.columns.len() {
         metric.observe(inout out, column_projection(borrow database, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.indexes.len() {
         let item = database.indexes.get_or(i, model.empty_index());
         metric.observe(inout out, item.entries + item.column + MODE(), if item.unique { 5 } else { 2 });
         metric.warn(inout out, item.table >= database.tables.len());
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -98,12 +98,12 @@ fn observe_storage(inout out: metric.Metric, borrow database: model.Database) {
     while i < database.rows.len() {
         metric.observe(inout out, row_projection(borrow database, i), (i % 7) + 1);
         metric.warn(inout out, database.rows.get_or(i, model.empty_row()).table >= database.tables.len());
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.cells.len() {
         metric.observe(inout out, cell_projection(borrow database, i), (i % 11) + 1);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -111,22 +111,22 @@ fn observe_operations(inout out: metric.Metric, borrow database: model.Database)
     let mut i: u64 = 0;
     while i < database.queries.len() {
         metric.observe(inout out, query_projection(borrow database, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.transactions.len() {
         metric.observe(inout out, transaction_projection(borrow database, i), i + 2);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.wal.len() {
         metric.observe(inout out, wal_projection(borrow database, i), i + 3);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.replicas.len() {
         metric.observe(inout out, replica_projection(borrow database, i), i + 4);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -141,9 +141,9 @@ fn observe_pairs(inout out: metric.Metric, borrow database: model.Database) {
                 metric.observe(inout out,
                     (table.row_count + 1) * (index.entries + 1) + MODE(), t + x + 1);
             }
-            x = x + 1;
+            x += 1;
         }
-        t = t + 1;
+        t += 1;
     }
 }
 

--- a/examples/meridian/analysis_catalog_nullable_ratio.rue
+++ b/examples/meridian/analysis_catalog_nullable_ratio.rue
@@ -77,19 +77,19 @@ fn observe_catalog(inout out: metric.Metric, borrow database: model.Database) {
     let mut i: u64 = 0;
     while i < database.tables.len() {
         metric.observe(inout out, table_projection(borrow database, i), i + MODE());
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.columns.len() {
         metric.observe(inout out, column_projection(borrow database, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.indexes.len() {
         let item = database.indexes.get_or(i, model.empty_index());
         metric.observe(inout out, item.entries + item.column + MODE(), if item.unique { 5 } else { 2 });
         metric.warn(inout out, item.table >= database.tables.len());
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -98,12 +98,12 @@ fn observe_storage(inout out: metric.Metric, borrow database: model.Database) {
     while i < database.rows.len() {
         metric.observe(inout out, row_projection(borrow database, i), (i % 7) + 1);
         metric.warn(inout out, database.rows.get_or(i, model.empty_row()).table >= database.tables.len());
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.cells.len() {
         metric.observe(inout out, cell_projection(borrow database, i), (i % 11) + 1);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -111,22 +111,22 @@ fn observe_operations(inout out: metric.Metric, borrow database: model.Database)
     let mut i: u64 = 0;
     while i < database.queries.len() {
         metric.observe(inout out, query_projection(borrow database, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.transactions.len() {
         metric.observe(inout out, transaction_projection(borrow database, i), i + 2);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.wal.len() {
         metric.observe(inout out, wal_projection(borrow database, i), i + 3);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.replicas.len() {
         metric.observe(inout out, replica_projection(borrow database, i), i + 4);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -141,9 +141,9 @@ fn observe_pairs(inout out: metric.Metric, borrow database: model.Database) {
                 metric.observe(inout out,
                     (table.row_count + 1) * (index.entries + 1) + MODE(), t + x + 1);
             }
-            x = x + 1;
+            x += 1;
         }
-        t = t + 1;
+        t += 1;
     }
 }
 

--- a/examples/meridian/analysis_catalog_ordinal_spread.rue
+++ b/examples/meridian/analysis_catalog_ordinal_spread.rue
@@ -77,19 +77,19 @@ fn observe_catalog(inout out: metric.Metric, borrow database: model.Database) {
     let mut i: u64 = 0;
     while i < database.tables.len() {
         metric.observe(inout out, table_projection(borrow database, i), i + MODE());
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.columns.len() {
         metric.observe(inout out, column_projection(borrow database, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.indexes.len() {
         let item = database.indexes.get_or(i, model.empty_index());
         metric.observe(inout out, item.entries + item.column + MODE(), if item.unique { 5 } else { 2 });
         metric.warn(inout out, item.table >= database.tables.len());
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -98,12 +98,12 @@ fn observe_storage(inout out: metric.Metric, borrow database: model.Database) {
     while i < database.rows.len() {
         metric.observe(inout out, row_projection(borrow database, i), (i % 7) + 1);
         metric.warn(inout out, database.rows.get_or(i, model.empty_row()).table >= database.tables.len());
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.cells.len() {
         metric.observe(inout out, cell_projection(borrow database, i), (i % 11) + 1);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -111,22 +111,22 @@ fn observe_operations(inout out: metric.Metric, borrow database: model.Database)
     let mut i: u64 = 0;
     while i < database.queries.len() {
         metric.observe(inout out, query_projection(borrow database, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.transactions.len() {
         metric.observe(inout out, transaction_projection(borrow database, i), i + 2);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.wal.len() {
         metric.observe(inout out, wal_projection(borrow database, i), i + 3);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.replicas.len() {
         metric.observe(inout out, replica_projection(borrow database, i), i + 4);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -141,9 +141,9 @@ fn observe_pairs(inout out: metric.Metric, borrow database: model.Database) {
                 metric.observe(inout out,
                     (table.row_count + 1) * (index.entries + 1) + MODE(), t + x + 1);
             }
-            x = x + 1;
+            x += 1;
         }
-        t = t + 1;
+        t += 1;
     }
 }
 

--- a/examples/meridian/analysis_catalog_reference_pressure.rue
+++ b/examples/meridian/analysis_catalog_reference_pressure.rue
@@ -77,19 +77,19 @@ fn observe_catalog(inout out: metric.Metric, borrow database: model.Database) {
     let mut i: u64 = 0;
     while i < database.tables.len() {
         metric.observe(inout out, table_projection(borrow database, i), i + MODE());
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.columns.len() {
         metric.observe(inout out, column_projection(borrow database, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.indexes.len() {
         let item = database.indexes.get_or(i, model.empty_index());
         metric.observe(inout out, item.entries + item.column + MODE(), if item.unique { 5 } else { 2 });
         metric.warn(inout out, item.table >= database.tables.len());
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -98,12 +98,12 @@ fn observe_storage(inout out: metric.Metric, borrow database: model.Database) {
     while i < database.rows.len() {
         metric.observe(inout out, row_projection(borrow database, i), (i % 7) + 1);
         metric.warn(inout out, database.rows.get_or(i, model.empty_row()).table >= database.tables.len());
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.cells.len() {
         metric.observe(inout out, cell_projection(borrow database, i), (i % 11) + 1);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -111,22 +111,22 @@ fn observe_operations(inout out: metric.Metric, borrow database: model.Database)
     let mut i: u64 = 0;
     while i < database.queries.len() {
         metric.observe(inout out, query_projection(borrow database, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.transactions.len() {
         metric.observe(inout out, transaction_projection(borrow database, i), i + 2);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.wal.len() {
         metric.observe(inout out, wal_projection(borrow database, i), i + 3);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.replicas.len() {
         metric.observe(inout out, replica_projection(borrow database, i), i + 4);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -141,9 +141,9 @@ fn observe_pairs(inout out: metric.Metric, borrow database: model.Database) {
                 metric.observe(inout out,
                     (table.row_count + 1) * (index.entries + 1) + MODE(), t + x + 1);
             }
-            x = x + 1;
+            x += 1;
         }
-        t = t + 1;
+        t += 1;
     }
 }
 

--- a/examples/meridian/analysis_catalog_row_capacity.rue
+++ b/examples/meridian/analysis_catalog_row_capacity.rue
@@ -77,19 +77,19 @@ fn observe_catalog(inout out: metric.Metric, borrow database: model.Database) {
     let mut i: u64 = 0;
     while i < database.tables.len() {
         metric.observe(inout out, table_projection(borrow database, i), i + MODE());
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.columns.len() {
         metric.observe(inout out, column_projection(borrow database, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.indexes.len() {
         let item = database.indexes.get_or(i, model.empty_index());
         metric.observe(inout out, item.entries + item.column + MODE(), if item.unique { 5 } else { 2 });
         metric.warn(inout out, item.table >= database.tables.len());
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -98,12 +98,12 @@ fn observe_storage(inout out: metric.Metric, borrow database: model.Database) {
     while i < database.rows.len() {
         metric.observe(inout out, row_projection(borrow database, i), (i % 7) + 1);
         metric.warn(inout out, database.rows.get_or(i, model.empty_row()).table >= database.tables.len());
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.cells.len() {
         metric.observe(inout out, cell_projection(borrow database, i), (i % 11) + 1);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -111,22 +111,22 @@ fn observe_operations(inout out: metric.Metric, borrow database: model.Database)
     let mut i: u64 = 0;
     while i < database.queries.len() {
         metric.observe(inout out, query_projection(borrow database, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.transactions.len() {
         metric.observe(inout out, transaction_projection(borrow database, i), i + 2);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.wal.len() {
         metric.observe(inout out, wal_projection(borrow database, i), i + 3);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.replicas.len() {
         metric.observe(inout out, replica_projection(borrow database, i), i + 4);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -141,9 +141,9 @@ fn observe_pairs(inout out: metric.Metric, borrow database: model.Database) {
                 metric.observe(inout out,
                     (table.row_count + 1) * (index.entries + 1) + MODE(), t + x + 1);
             }
-            x = x + 1;
+            x += 1;
         }
-        t = t + 1;
+        t += 1;
     }
 }
 

--- a/examples/meridian/analysis_catalog_schema_fanout.rue
+++ b/examples/meridian/analysis_catalog_schema_fanout.rue
@@ -77,19 +77,19 @@ fn observe_catalog(inout out: metric.Metric, borrow database: model.Database) {
     let mut i: u64 = 0;
     while i < database.tables.len() {
         metric.observe(inout out, table_projection(borrow database, i), i + MODE());
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.columns.len() {
         metric.observe(inout out, column_projection(borrow database, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.indexes.len() {
         let item = database.indexes.get_or(i, model.empty_index());
         metric.observe(inout out, item.entries + item.column + MODE(), if item.unique { 5 } else { 2 });
         metric.warn(inout out, item.table >= database.tables.len());
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -98,12 +98,12 @@ fn observe_storage(inout out: metric.Metric, borrow database: model.Database) {
     while i < database.rows.len() {
         metric.observe(inout out, row_projection(borrow database, i), (i % 7) + 1);
         metric.warn(inout out, database.rows.get_or(i, model.empty_row()).table >= database.tables.len());
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.cells.len() {
         metric.observe(inout out, cell_projection(borrow database, i), (i % 11) + 1);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -111,22 +111,22 @@ fn observe_operations(inout out: metric.Metric, borrow database: model.Database)
     let mut i: u64 = 0;
     while i < database.queries.len() {
         metric.observe(inout out, query_projection(borrow database, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.transactions.len() {
         metric.observe(inout out, transaction_projection(borrow database, i), i + 2);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.wal.len() {
         metric.observe(inout out, wal_projection(borrow database, i), i + 3);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.replicas.len() {
         metric.observe(inout out, replica_projection(borrow database, i), i + 4);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -141,9 +141,9 @@ fn observe_pairs(inout out: metric.Metric, borrow database: model.Database) {
                 metric.observe(inout out,
                     (table.row_count + 1) * (index.entries + 1) + MODE(), t + x + 1);
             }
-            x = x + 1;
+            x += 1;
         }
-        t = t + 1;
+        t += 1;
     }
 }
 

--- a/examples/meridian/analysis_catalog_table_density.rue
+++ b/examples/meridian/analysis_catalog_table_density.rue
@@ -77,19 +77,19 @@ fn observe_catalog(inout out: metric.Metric, borrow database: model.Database) {
     let mut i: u64 = 0;
     while i < database.tables.len() {
         metric.observe(inout out, table_projection(borrow database, i), i + MODE());
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.columns.len() {
         metric.observe(inout out, column_projection(borrow database, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.indexes.len() {
         let item = database.indexes.get_or(i, model.empty_index());
         metric.observe(inout out, item.entries + item.column + MODE(), if item.unique { 5 } else { 2 });
         metric.warn(inout out, item.table >= database.tables.len());
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -98,12 +98,12 @@ fn observe_storage(inout out: metric.Metric, borrow database: model.Database) {
     while i < database.rows.len() {
         metric.observe(inout out, row_projection(borrow database, i), (i % 7) + 1);
         metric.warn(inout out, database.rows.get_or(i, model.empty_row()).table >= database.tables.len());
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.cells.len() {
         metric.observe(inout out, cell_projection(borrow database, i), (i % 11) + 1);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -111,22 +111,22 @@ fn observe_operations(inout out: metric.Metric, borrow database: model.Database)
     let mut i: u64 = 0;
     while i < database.queries.len() {
         metric.observe(inout out, query_projection(borrow database, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.transactions.len() {
         metric.observe(inout out, transaction_projection(borrow database, i), i + 2);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.wal.len() {
         metric.observe(inout out, wal_projection(borrow database, i), i + 3);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.replicas.len() {
         metric.observe(inout out, replica_projection(borrow database, i), i + 4);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -141,9 +141,9 @@ fn observe_pairs(inout out: metric.Metric, borrow database: model.Database) {
                 metric.observe(inout out,
                     (table.row_count + 1) * (index.entries + 1) + MODE(), t + x + 1);
             }
-            x = x + 1;
+            x += 1;
         }
-        t = t + 1;
+        t += 1;
     }
 }
 

--- a/examples/meridian/analysis_catalog_type_balance.rue
+++ b/examples/meridian/analysis_catalog_type_balance.rue
@@ -77,19 +77,19 @@ fn observe_catalog(inout out: metric.Metric, borrow database: model.Database) {
     let mut i: u64 = 0;
     while i < database.tables.len() {
         metric.observe(inout out, table_projection(borrow database, i), i + MODE());
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.columns.len() {
         metric.observe(inout out, column_projection(borrow database, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.indexes.len() {
         let item = database.indexes.get_or(i, model.empty_index());
         metric.observe(inout out, item.entries + item.column + MODE(), if item.unique { 5 } else { 2 });
         metric.warn(inout out, item.table >= database.tables.len());
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -98,12 +98,12 @@ fn observe_storage(inout out: metric.Metric, borrow database: model.Database) {
     while i < database.rows.len() {
         metric.observe(inout out, row_projection(borrow database, i), (i % 7) + 1);
         metric.warn(inout out, database.rows.get_or(i, model.empty_row()).table >= database.tables.len());
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.cells.len() {
         metric.observe(inout out, cell_projection(borrow database, i), (i % 11) + 1);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -111,22 +111,22 @@ fn observe_operations(inout out: metric.Metric, borrow database: model.Database)
     let mut i: u64 = 0;
     while i < database.queries.len() {
         metric.observe(inout out, query_projection(borrow database, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.transactions.len() {
         metric.observe(inout out, transaction_projection(borrow database, i), i + 2);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.wal.len() {
         metric.observe(inout out, wal_projection(borrow database, i), i + 3);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.replicas.len() {
         metric.observe(inout out, replica_projection(borrow database, i), i + 4);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -141,9 +141,9 @@ fn observe_pairs(inout out: metric.Metric, borrow database: model.Database) {
                 metric.observe(inout out,
                     (table.row_count + 1) * (index.entries + 1) + MODE(), t + x + 1);
             }
-            x = x + 1;
+            x += 1;
         }
-        t = t + 1;
+        t += 1;
     }
 }
 

--- a/examples/meridian/analysis_catalog_unique_ratio.rue
+++ b/examples/meridian/analysis_catalog_unique_ratio.rue
@@ -77,19 +77,19 @@ fn observe_catalog(inout out: metric.Metric, borrow database: model.Database) {
     let mut i: u64 = 0;
     while i < database.tables.len() {
         metric.observe(inout out, table_projection(borrow database, i), i + MODE());
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.columns.len() {
         metric.observe(inout out, column_projection(borrow database, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.indexes.len() {
         let item = database.indexes.get_or(i, model.empty_index());
         metric.observe(inout out, item.entries + item.column + MODE(), if item.unique { 5 } else { 2 });
         metric.warn(inout out, item.table >= database.tables.len());
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -98,12 +98,12 @@ fn observe_storage(inout out: metric.Metric, borrow database: model.Database) {
     while i < database.rows.len() {
         metric.observe(inout out, row_projection(borrow database, i), (i % 7) + 1);
         metric.warn(inout out, database.rows.get_or(i, model.empty_row()).table >= database.tables.len());
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.cells.len() {
         metric.observe(inout out, cell_projection(borrow database, i), (i % 11) + 1);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -111,22 +111,22 @@ fn observe_operations(inout out: metric.Metric, borrow database: model.Database)
     let mut i: u64 = 0;
     while i < database.queries.len() {
         metric.observe(inout out, query_projection(borrow database, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.transactions.len() {
         metric.observe(inout out, transaction_projection(borrow database, i), i + 2);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.wal.len() {
         metric.observe(inout out, wal_projection(borrow database, i), i + 3);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.replicas.len() {
         metric.observe(inout out, replica_projection(borrow database, i), i + 4);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -141,9 +141,9 @@ fn observe_pairs(inout out: metric.Metric, borrow database: model.Database) {
                 metric.observe(inout out,
                     (table.row_count + 1) * (index.entries + 1) + MODE(), t + x + 1);
             }
-            x = x + 1;
+            x += 1;
         }
-        t = t + 1;
+        t += 1;
     }
 }
 

--- a/examples/meridian/analysis_catalog_version_skew.rue
+++ b/examples/meridian/analysis_catalog_version_skew.rue
@@ -77,19 +77,19 @@ fn observe_catalog(inout out: metric.Metric, borrow database: model.Database) {
     let mut i: u64 = 0;
     while i < database.tables.len() {
         metric.observe(inout out, table_projection(borrow database, i), i + MODE());
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.columns.len() {
         metric.observe(inout out, column_projection(borrow database, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.indexes.len() {
         let item = database.indexes.get_or(i, model.empty_index());
         metric.observe(inout out, item.entries + item.column + MODE(), if item.unique { 5 } else { 2 });
         metric.warn(inout out, item.table >= database.tables.len());
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -98,12 +98,12 @@ fn observe_storage(inout out: metric.Metric, borrow database: model.Database) {
     while i < database.rows.len() {
         metric.observe(inout out, row_projection(borrow database, i), (i % 7) + 1);
         metric.warn(inout out, database.rows.get_or(i, model.empty_row()).table >= database.tables.len());
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.cells.len() {
         metric.observe(inout out, cell_projection(borrow database, i), (i % 11) + 1);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -111,22 +111,22 @@ fn observe_operations(inout out: metric.Metric, borrow database: model.Database)
     let mut i: u64 = 0;
     while i < database.queries.len() {
         metric.observe(inout out, query_projection(borrow database, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.transactions.len() {
         metric.observe(inout out, transaction_projection(borrow database, i), i + 2);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.wal.len() {
         metric.observe(inout out, wal_projection(borrow database, i), i + 3);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.replicas.len() {
         metric.observe(inout out, replica_projection(borrow database, i), i + 4);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -141,9 +141,9 @@ fn observe_pairs(inout out: metric.Metric, borrow database: model.Database) {
                 metric.observe(inout out,
                     (table.row_count + 1) * (index.entries + 1) + MODE(), t + x + 1);
             }
-            x = x + 1;
+            x += 1;
         }
-        t = t + 1;
+        t += 1;
     }
 }
 

--- a/examples/meridian/analysis_query_cacheability.rue
+++ b/examples/meridian/analysis_query_cacheability.rue
@@ -77,19 +77,19 @@ fn observe_catalog(inout out: metric.Metric, borrow database: model.Database) {
     let mut i: u64 = 0;
     while i < database.tables.len() {
         metric.observe(inout out, table_projection(borrow database, i), i + MODE());
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.columns.len() {
         metric.observe(inout out, column_projection(borrow database, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.indexes.len() {
         let item = database.indexes.get_or(i, model.empty_index());
         metric.observe(inout out, item.entries + item.column + MODE(), if item.unique { 5 } else { 2 });
         metric.warn(inout out, item.table >= database.tables.len());
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -98,12 +98,12 @@ fn observe_storage(inout out: metric.Metric, borrow database: model.Database) {
     while i < database.rows.len() {
         metric.observe(inout out, row_projection(borrow database, i), (i % 7) + 1);
         metric.warn(inout out, database.rows.get_or(i, model.empty_row()).table >= database.tables.len());
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.cells.len() {
         metric.observe(inout out, cell_projection(borrow database, i), (i % 11) + 1);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -111,22 +111,22 @@ fn observe_operations(inout out: metric.Metric, borrow database: model.Database)
     let mut i: u64 = 0;
     while i < database.queries.len() {
         metric.observe(inout out, query_projection(borrow database, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.transactions.len() {
         metric.observe(inout out, transaction_projection(borrow database, i), i + 2);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.wal.len() {
         metric.observe(inout out, wal_projection(borrow database, i), i + 3);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.replicas.len() {
         metric.observe(inout out, replica_projection(borrow database, i), i + 4);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -141,9 +141,9 @@ fn observe_pairs(inout out: metric.Metric, borrow database: model.Database) {
                 metric.observe(inout out,
                     (table.row_count + 1) * (index.entries + 1) + MODE(), t + x + 1);
             }
-            x = x + 1;
+            x += 1;
         }
-        t = t + 1;
+        t += 1;
     }
 }
 

--- a/examples/meridian/analysis_query_estimate_error.rue
+++ b/examples/meridian/analysis_query_estimate_error.rue
@@ -77,19 +77,19 @@ fn observe_catalog(inout out: metric.Metric, borrow database: model.Database) {
     let mut i: u64 = 0;
     while i < database.tables.len() {
         metric.observe(inout out, table_projection(borrow database, i), i + MODE());
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.columns.len() {
         metric.observe(inout out, column_projection(borrow database, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.indexes.len() {
         let item = database.indexes.get_or(i, model.empty_index());
         metric.observe(inout out, item.entries + item.column + MODE(), if item.unique { 5 } else { 2 });
         metric.warn(inout out, item.table >= database.tables.len());
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -98,12 +98,12 @@ fn observe_storage(inout out: metric.Metric, borrow database: model.Database) {
     while i < database.rows.len() {
         metric.observe(inout out, row_projection(borrow database, i), (i % 7) + 1);
         metric.warn(inout out, database.rows.get_or(i, model.empty_row()).table >= database.tables.len());
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.cells.len() {
         metric.observe(inout out, cell_projection(borrow database, i), (i % 11) + 1);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -111,22 +111,22 @@ fn observe_operations(inout out: metric.Metric, borrow database: model.Database)
     let mut i: u64 = 0;
     while i < database.queries.len() {
         metric.observe(inout out, query_projection(borrow database, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.transactions.len() {
         metric.observe(inout out, transaction_projection(borrow database, i), i + 2);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.wal.len() {
         metric.observe(inout out, wal_projection(borrow database, i), i + 3);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.replicas.len() {
         metric.observe(inout out, replica_projection(borrow database, i), i + 4);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -141,9 +141,9 @@ fn observe_pairs(inout out: metric.Metric, borrow database: model.Database) {
                 metric.observe(inout out,
                     (table.row_count + 1) * (index.entries + 1) + MODE(), t + x + 1);
             }
-            x = x + 1;
+            x += 1;
         }
-        t = t + 1;
+        t += 1;
     }
 }
 

--- a/examples/meridian/analysis_query_filter_selectivity.rue
+++ b/examples/meridian/analysis_query_filter_selectivity.rue
@@ -77,19 +77,19 @@ fn observe_catalog(inout out: metric.Metric, borrow database: model.Database) {
     let mut i: u64 = 0;
     while i < database.tables.len() {
         metric.observe(inout out, table_projection(borrow database, i), i + MODE());
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.columns.len() {
         metric.observe(inout out, column_projection(borrow database, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.indexes.len() {
         let item = database.indexes.get_or(i, model.empty_index());
         metric.observe(inout out, item.entries + item.column + MODE(), if item.unique { 5 } else { 2 });
         metric.warn(inout out, item.table >= database.tables.len());
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -98,12 +98,12 @@ fn observe_storage(inout out: metric.Metric, borrow database: model.Database) {
     while i < database.rows.len() {
         metric.observe(inout out, row_projection(borrow database, i), (i % 7) + 1);
         metric.warn(inout out, database.rows.get_or(i, model.empty_row()).table >= database.tables.len());
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.cells.len() {
         metric.observe(inout out, cell_projection(borrow database, i), (i % 11) + 1);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -111,22 +111,22 @@ fn observe_operations(inout out: metric.Metric, borrow database: model.Database)
     let mut i: u64 = 0;
     while i < database.queries.len() {
         metric.observe(inout out, query_projection(borrow database, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.transactions.len() {
         metric.observe(inout out, transaction_projection(borrow database, i), i + 2);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.wal.len() {
         metric.observe(inout out, wal_projection(borrow database, i), i + 3);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.replicas.len() {
         metric.observe(inout out, replica_projection(borrow database, i), i + 4);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -141,9 +141,9 @@ fn observe_pairs(inout out: metric.Metric, borrow database: model.Database) {
                 metric.observe(inout out,
                     (table.row_count + 1) * (index.entries + 1) + MODE(), t + x + 1);
             }
-            x = x + 1;
+            x += 1;
         }
-        t = t + 1;
+        t += 1;
     }
 }
 

--- a/examples/meridian/analysis_query_group_cardinality.rue
+++ b/examples/meridian/analysis_query_group_cardinality.rue
@@ -77,19 +77,19 @@ fn observe_catalog(inout out: metric.Metric, borrow database: model.Database) {
     let mut i: u64 = 0;
     while i < database.tables.len() {
         metric.observe(inout out, table_projection(borrow database, i), i + MODE());
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.columns.len() {
         metric.observe(inout out, column_projection(borrow database, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.indexes.len() {
         let item = database.indexes.get_or(i, model.empty_index());
         metric.observe(inout out, item.entries + item.column + MODE(), if item.unique { 5 } else { 2 });
         metric.warn(inout out, item.table >= database.tables.len());
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -98,12 +98,12 @@ fn observe_storage(inout out: metric.Metric, borrow database: model.Database) {
     while i < database.rows.len() {
         metric.observe(inout out, row_projection(borrow database, i), (i % 7) + 1);
         metric.warn(inout out, database.rows.get_or(i, model.empty_row()).table >= database.tables.len());
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.cells.len() {
         metric.observe(inout out, cell_projection(borrow database, i), (i % 11) + 1);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -111,22 +111,22 @@ fn observe_operations(inout out: metric.Metric, borrow database: model.Database)
     let mut i: u64 = 0;
     while i < database.queries.len() {
         metric.observe(inout out, query_projection(borrow database, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.transactions.len() {
         metric.observe(inout out, transaction_projection(borrow database, i), i + 2);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.wal.len() {
         metric.observe(inout out, wal_projection(borrow database, i), i + 3);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.replicas.len() {
         metric.observe(inout out, replica_projection(borrow database, i), i + 4);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -141,9 +141,9 @@ fn observe_pairs(inout out: metric.Metric, borrow database: model.Database) {
                 metric.observe(inout out,
                     (table.row_count + 1) * (index.entries + 1) + MODE(), t + x + 1);
             }
-            x = x + 1;
+            x += 1;
         }
-        t = t + 1;
+        t += 1;
     }
 }
 

--- a/examples/meridian/analysis_query_index_opportunity.rue
+++ b/examples/meridian/analysis_query_index_opportunity.rue
@@ -77,19 +77,19 @@ fn observe_catalog(inout out: metric.Metric, borrow database: model.Database) {
     let mut i: u64 = 0;
     while i < database.tables.len() {
         metric.observe(inout out, table_projection(borrow database, i), i + MODE());
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.columns.len() {
         metric.observe(inout out, column_projection(borrow database, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.indexes.len() {
         let item = database.indexes.get_or(i, model.empty_index());
         metric.observe(inout out, item.entries + item.column + MODE(), if item.unique { 5 } else { 2 });
         metric.warn(inout out, item.table >= database.tables.len());
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -98,12 +98,12 @@ fn observe_storage(inout out: metric.Metric, borrow database: model.Database) {
     while i < database.rows.len() {
         metric.observe(inout out, row_projection(borrow database, i), (i % 7) + 1);
         metric.warn(inout out, database.rows.get_or(i, model.empty_row()).table >= database.tables.len());
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.cells.len() {
         metric.observe(inout out, cell_projection(borrow database, i), (i % 11) + 1);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -111,22 +111,22 @@ fn observe_operations(inout out: metric.Metric, borrow database: model.Database)
     let mut i: u64 = 0;
     while i < database.queries.len() {
         metric.observe(inout out, query_projection(borrow database, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.transactions.len() {
         metric.observe(inout out, transaction_projection(borrow database, i), i + 2);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.wal.len() {
         metric.observe(inout out, wal_projection(borrow database, i), i + 3);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.replicas.len() {
         metric.observe(inout out, replica_projection(borrow database, i), i + 4);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -141,9 +141,9 @@ fn observe_pairs(inout out: metric.Metric, borrow database: model.Database) {
                 metric.observe(inout out,
                     (table.row_count + 1) * (index.entries + 1) + MODE(), t + x + 1);
             }
-            x = x + 1;
+            x += 1;
         }
-        t = t + 1;
+        t += 1;
     }
 }
 

--- a/examples/meridian/analysis_query_join_fanout.rue
+++ b/examples/meridian/analysis_query_join_fanout.rue
@@ -77,19 +77,19 @@ fn observe_catalog(inout out: metric.Metric, borrow database: model.Database) {
     let mut i: u64 = 0;
     while i < database.tables.len() {
         metric.observe(inout out, table_projection(borrow database, i), i + MODE());
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.columns.len() {
         metric.observe(inout out, column_projection(borrow database, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.indexes.len() {
         let item = database.indexes.get_or(i, model.empty_index());
         metric.observe(inout out, item.entries + item.column + MODE(), if item.unique { 5 } else { 2 });
         metric.warn(inout out, item.table >= database.tables.len());
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -98,12 +98,12 @@ fn observe_storage(inout out: metric.Metric, borrow database: model.Database) {
     while i < database.rows.len() {
         metric.observe(inout out, row_projection(borrow database, i), (i % 7) + 1);
         metric.warn(inout out, database.rows.get_or(i, model.empty_row()).table >= database.tables.len());
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.cells.len() {
         metric.observe(inout out, cell_projection(borrow database, i), (i % 11) + 1);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -111,22 +111,22 @@ fn observe_operations(inout out: metric.Metric, borrow database: model.Database)
     let mut i: u64 = 0;
     while i < database.queries.len() {
         metric.observe(inout out, query_projection(borrow database, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.transactions.len() {
         metric.observe(inout out, transaction_projection(borrow database, i), i + 2);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.wal.len() {
         metric.observe(inout out, wal_projection(borrow database, i), i + 3);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.replicas.len() {
         metric.observe(inout out, replica_projection(borrow database, i), i + 4);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -141,9 +141,9 @@ fn observe_pairs(inout out: metric.Metric, borrow database: model.Database) {
                 metric.observe(inout out,
                     (table.row_count + 1) * (index.entries + 1) + MODE(), t + x + 1);
             }
-            x = x + 1;
+            x += 1;
         }
-        t = t + 1;
+        t += 1;
     }
 }
 

--- a/examples/meridian/analysis_query_join_selectivity.rue
+++ b/examples/meridian/analysis_query_join_selectivity.rue
@@ -77,19 +77,19 @@ fn observe_catalog(inout out: metric.Metric, borrow database: model.Database) {
     let mut i: u64 = 0;
     while i < database.tables.len() {
         metric.observe(inout out, table_projection(borrow database, i), i + MODE());
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.columns.len() {
         metric.observe(inout out, column_projection(borrow database, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.indexes.len() {
         let item = database.indexes.get_or(i, model.empty_index());
         metric.observe(inout out, item.entries + item.column + MODE(), if item.unique { 5 } else { 2 });
         metric.warn(inout out, item.table >= database.tables.len());
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -98,12 +98,12 @@ fn observe_storage(inout out: metric.Metric, borrow database: model.Database) {
     while i < database.rows.len() {
         metric.observe(inout out, row_projection(borrow database, i), (i % 7) + 1);
         metric.warn(inout out, database.rows.get_or(i, model.empty_row()).table >= database.tables.len());
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.cells.len() {
         metric.observe(inout out, cell_projection(borrow database, i), (i % 11) + 1);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -111,22 +111,22 @@ fn observe_operations(inout out: metric.Metric, borrow database: model.Database)
     let mut i: u64 = 0;
     while i < database.queries.len() {
         metric.observe(inout out, query_projection(borrow database, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.transactions.len() {
         metric.observe(inout out, transaction_projection(borrow database, i), i + 2);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.wal.len() {
         metric.observe(inout out, wal_projection(borrow database, i), i + 3);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.replicas.len() {
         metric.observe(inout out, replica_projection(borrow database, i), i + 4);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -141,9 +141,9 @@ fn observe_pairs(inout out: metric.Metric, borrow database: model.Database) {
                 metric.observe(inout out,
                     (table.row_count + 1) * (index.entries + 1) + MODE(), t + x + 1);
             }
-            x = x + 1;
+            x += 1;
         }
-        t = t + 1;
+        t += 1;
     }
 }
 

--- a/examples/meridian/analysis_query_limit_pressure.rue
+++ b/examples/meridian/analysis_query_limit_pressure.rue
@@ -77,19 +77,19 @@ fn observe_catalog(inout out: metric.Metric, borrow database: model.Database) {
     let mut i: u64 = 0;
     while i < database.tables.len() {
         metric.observe(inout out, table_projection(borrow database, i), i + MODE());
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.columns.len() {
         metric.observe(inout out, column_projection(borrow database, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.indexes.len() {
         let item = database.indexes.get_or(i, model.empty_index());
         metric.observe(inout out, item.entries + item.column + MODE(), if item.unique { 5 } else { 2 });
         metric.warn(inout out, item.table >= database.tables.len());
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -98,12 +98,12 @@ fn observe_storage(inout out: metric.Metric, borrow database: model.Database) {
     while i < database.rows.len() {
         metric.observe(inout out, row_projection(borrow database, i), (i % 7) + 1);
         metric.warn(inout out, database.rows.get_or(i, model.empty_row()).table >= database.tables.len());
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.cells.len() {
         metric.observe(inout out, cell_projection(borrow database, i), (i % 11) + 1);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -111,22 +111,22 @@ fn observe_operations(inout out: metric.Metric, borrow database: model.Database)
     let mut i: u64 = 0;
     while i < database.queries.len() {
         metric.observe(inout out, query_projection(borrow database, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.transactions.len() {
         metric.observe(inout out, transaction_projection(borrow database, i), i + 2);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.wal.len() {
         metric.observe(inout out, wal_projection(borrow database, i), i + 3);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.replicas.len() {
         metric.observe(inout out, replica_projection(borrow database, i), i + 4);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -141,9 +141,9 @@ fn observe_pairs(inout out: metric.Metric, borrow database: model.Database) {
                 metric.observe(inout out,
                     (table.row_count + 1) * (index.entries + 1) + MODE(), t + x + 1);
             }
-            x = x + 1;
+            x += 1;
         }
-        t = t + 1;
+        t += 1;
     }
 }
 

--- a/examples/meridian/analysis_query_order_cost.rue
+++ b/examples/meridian/analysis_query_order_cost.rue
@@ -77,19 +77,19 @@ fn observe_catalog(inout out: metric.Metric, borrow database: model.Database) {
     let mut i: u64 = 0;
     while i < database.tables.len() {
         metric.observe(inout out, table_projection(borrow database, i), i + MODE());
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.columns.len() {
         metric.observe(inout out, column_projection(borrow database, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.indexes.len() {
         let item = database.indexes.get_or(i, model.empty_index());
         metric.observe(inout out, item.entries + item.column + MODE(), if item.unique { 5 } else { 2 });
         metric.warn(inout out, item.table >= database.tables.len());
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -98,12 +98,12 @@ fn observe_storage(inout out: metric.Metric, borrow database: model.Database) {
     while i < database.rows.len() {
         metric.observe(inout out, row_projection(borrow database, i), (i % 7) + 1);
         metric.warn(inout out, database.rows.get_or(i, model.empty_row()).table >= database.tables.len());
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.cells.len() {
         metric.observe(inout out, cell_projection(borrow database, i), (i % 11) + 1);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -111,22 +111,22 @@ fn observe_operations(inout out: metric.Metric, borrow database: model.Database)
     let mut i: u64 = 0;
     while i < database.queries.len() {
         metric.observe(inout out, query_projection(borrow database, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.transactions.len() {
         metric.observe(inout out, transaction_projection(borrow database, i), i + 2);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.wal.len() {
         metric.observe(inout out, wal_projection(borrow database, i), i + 3);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.replicas.len() {
         metric.observe(inout out, replica_projection(borrow database, i), i + 4);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -141,9 +141,9 @@ fn observe_pairs(inout out: metric.Metric, borrow database: model.Database) {
                 metric.observe(inout out,
                     (table.row_count + 1) * (index.entries + 1) + MODE(), t + x + 1);
             }
-            x = x + 1;
+            x += 1;
         }
-        t = t + 1;
+        t += 1;
     }
 }
 

--- a/examples/meridian/analysis_query_parallelism.rue
+++ b/examples/meridian/analysis_query_parallelism.rue
@@ -77,19 +77,19 @@ fn observe_catalog(inout out: metric.Metric, borrow database: model.Database) {
     let mut i: u64 = 0;
     while i < database.tables.len() {
         metric.observe(inout out, table_projection(borrow database, i), i + MODE());
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.columns.len() {
         metric.observe(inout out, column_projection(borrow database, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.indexes.len() {
         let item = database.indexes.get_or(i, model.empty_index());
         metric.observe(inout out, item.entries + item.column + MODE(), if item.unique { 5 } else { 2 });
         metric.warn(inout out, item.table >= database.tables.len());
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -98,12 +98,12 @@ fn observe_storage(inout out: metric.Metric, borrow database: model.Database) {
     while i < database.rows.len() {
         metric.observe(inout out, row_projection(borrow database, i), (i % 7) + 1);
         metric.warn(inout out, database.rows.get_or(i, model.empty_row()).table >= database.tables.len());
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.cells.len() {
         metric.observe(inout out, cell_projection(borrow database, i), (i % 11) + 1);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -111,22 +111,22 @@ fn observe_operations(inout out: metric.Metric, borrow database: model.Database)
     let mut i: u64 = 0;
     while i < database.queries.len() {
         metric.observe(inout out, query_projection(borrow database, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.transactions.len() {
         metric.observe(inout out, transaction_projection(borrow database, i), i + 2);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.wal.len() {
         metric.observe(inout out, wal_projection(borrow database, i), i + 3);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.replicas.len() {
         metric.observe(inout out, replica_projection(borrow database, i), i + 4);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -141,9 +141,9 @@ fn observe_pairs(inout out: metric.Metric, borrow database: model.Database) {
                 metric.observe(inout out,
                     (table.row_count + 1) * (index.entries + 1) + MODE(), t + x + 1);
             }
-            x = x + 1;
+            x += 1;
         }
-        t = t + 1;
+        t += 1;
     }
 }
 

--- a/examples/meridian/analysis_query_plan_depth.rue
+++ b/examples/meridian/analysis_query_plan_depth.rue
@@ -77,19 +77,19 @@ fn observe_catalog(inout out: metric.Metric, borrow database: model.Database) {
     let mut i: u64 = 0;
     while i < database.tables.len() {
         metric.observe(inout out, table_projection(borrow database, i), i + MODE());
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.columns.len() {
         metric.observe(inout out, column_projection(borrow database, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.indexes.len() {
         let item = database.indexes.get_or(i, model.empty_index());
         metric.observe(inout out, item.entries + item.column + MODE(), if item.unique { 5 } else { 2 });
         metric.warn(inout out, item.table >= database.tables.len());
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -98,12 +98,12 @@ fn observe_storage(inout out: metric.Metric, borrow database: model.Database) {
     while i < database.rows.len() {
         metric.observe(inout out, row_projection(borrow database, i), (i % 7) + 1);
         metric.warn(inout out, database.rows.get_or(i, model.empty_row()).table >= database.tables.len());
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.cells.len() {
         metric.observe(inout out, cell_projection(borrow database, i), (i % 11) + 1);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -111,22 +111,22 @@ fn observe_operations(inout out: metric.Metric, borrow database: model.Database)
     let mut i: u64 = 0;
     while i < database.queries.len() {
         metric.observe(inout out, query_projection(borrow database, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.transactions.len() {
         metric.observe(inout out, transaction_projection(borrow database, i), i + 2);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.wal.len() {
         metric.observe(inout out, wal_projection(borrow database, i), i + 3);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.replicas.len() {
         metric.observe(inout out, replica_projection(borrow database, i), i + 4);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -141,9 +141,9 @@ fn observe_pairs(inout out: metric.Metric, borrow database: model.Database) {
                 metric.observe(inout out,
                     (table.row_count + 1) * (index.entries + 1) + MODE(), t + x + 1);
             }
-            x = x + 1;
+            x += 1;
         }
-        t = t + 1;
+        t += 1;
     }
 }
 

--- a/examples/meridian/analysis_query_plan_width.rue
+++ b/examples/meridian/analysis_query_plan_width.rue
@@ -77,19 +77,19 @@ fn observe_catalog(inout out: metric.Metric, borrow database: model.Database) {
     let mut i: u64 = 0;
     while i < database.tables.len() {
         metric.observe(inout out, table_projection(borrow database, i), i + MODE());
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.columns.len() {
         metric.observe(inout out, column_projection(borrow database, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.indexes.len() {
         let item = database.indexes.get_or(i, model.empty_index());
         metric.observe(inout out, item.entries + item.column + MODE(), if item.unique { 5 } else { 2 });
         metric.warn(inout out, item.table >= database.tables.len());
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -98,12 +98,12 @@ fn observe_storage(inout out: metric.Metric, borrow database: model.Database) {
     while i < database.rows.len() {
         metric.observe(inout out, row_projection(borrow database, i), (i % 7) + 1);
         metric.warn(inout out, database.rows.get_or(i, model.empty_row()).table >= database.tables.len());
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.cells.len() {
         metric.observe(inout out, cell_projection(borrow database, i), (i % 11) + 1);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -111,22 +111,22 @@ fn observe_operations(inout out: metric.Metric, borrow database: model.Database)
     let mut i: u64 = 0;
     while i < database.queries.len() {
         metric.observe(inout out, query_projection(borrow database, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.transactions.len() {
         metric.observe(inout out, transaction_projection(borrow database, i), i + 2);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.wal.len() {
         metric.observe(inout out, wal_projection(borrow database, i), i + 3);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.replicas.len() {
         metric.observe(inout out, replica_projection(borrow database, i), i + 4);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -141,9 +141,9 @@ fn observe_pairs(inout out: metric.Metric, borrow database: model.Database) {
                 metric.observe(inout out,
                     (table.row_count + 1) * (index.entries + 1) + MODE(), t + x + 1);
             }
-            x = x + 1;
+            x += 1;
         }
-        t = t + 1;
+        t += 1;
     }
 }
 

--- a/examples/meridian/analysis_query_predicate_complexity.rue
+++ b/examples/meridian/analysis_query_predicate_complexity.rue
@@ -77,19 +77,19 @@ fn observe_catalog(inout out: metric.Metric, borrow database: model.Database) {
     let mut i: u64 = 0;
     while i < database.tables.len() {
         metric.observe(inout out, table_projection(borrow database, i), i + MODE());
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.columns.len() {
         metric.observe(inout out, column_projection(borrow database, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.indexes.len() {
         let item = database.indexes.get_or(i, model.empty_index());
         metric.observe(inout out, item.entries + item.column + MODE(), if item.unique { 5 } else { 2 });
         metric.warn(inout out, item.table >= database.tables.len());
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -98,12 +98,12 @@ fn observe_storage(inout out: metric.Metric, borrow database: model.Database) {
     while i < database.rows.len() {
         metric.observe(inout out, row_projection(borrow database, i), (i % 7) + 1);
         metric.warn(inout out, database.rows.get_or(i, model.empty_row()).table >= database.tables.len());
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.cells.len() {
         metric.observe(inout out, cell_projection(borrow database, i), (i % 11) + 1);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -111,22 +111,22 @@ fn observe_operations(inout out: metric.Metric, borrow database: model.Database)
     let mut i: u64 = 0;
     while i < database.queries.len() {
         metric.observe(inout out, query_projection(borrow database, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.transactions.len() {
         metric.observe(inout out, transaction_projection(borrow database, i), i + 2);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.wal.len() {
         metric.observe(inout out, wal_projection(borrow database, i), i + 3);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.replicas.len() {
         metric.observe(inout out, replica_projection(borrow database, i), i + 4);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -141,9 +141,9 @@ fn observe_pairs(inout out: metric.Metric, borrow database: model.Database) {
                 metric.observe(inout out,
                     (table.row_count + 1) * (index.entries + 1) + MODE(), t + x + 1);
             }
-            x = x + 1;
+            x += 1;
         }
-        t = t + 1;
+        t += 1;
     }
 }
 

--- a/examples/meridian/analysis_query_result_density.rue
+++ b/examples/meridian/analysis_query_result_density.rue
@@ -77,19 +77,19 @@ fn observe_catalog(inout out: metric.Metric, borrow database: model.Database) {
     let mut i: u64 = 0;
     while i < database.tables.len() {
         metric.observe(inout out, table_projection(borrow database, i), i + MODE());
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.columns.len() {
         metric.observe(inout out, column_projection(borrow database, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.indexes.len() {
         let item = database.indexes.get_or(i, model.empty_index());
         metric.observe(inout out, item.entries + item.column + MODE(), if item.unique { 5 } else { 2 });
         metric.warn(inout out, item.table >= database.tables.len());
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -98,12 +98,12 @@ fn observe_storage(inout out: metric.Metric, borrow database: model.Database) {
     while i < database.rows.len() {
         metric.observe(inout out, row_projection(borrow database, i), (i % 7) + 1);
         metric.warn(inout out, database.rows.get_or(i, model.empty_row()).table >= database.tables.len());
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.cells.len() {
         metric.observe(inout out, cell_projection(borrow database, i), (i % 11) + 1);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -111,22 +111,22 @@ fn observe_operations(inout out: metric.Metric, borrow database: model.Database)
     let mut i: u64 = 0;
     while i < database.queries.len() {
         metric.observe(inout out, query_projection(borrow database, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.transactions.len() {
         metric.observe(inout out, transaction_projection(borrow database, i), i + 2);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.wal.len() {
         metric.observe(inout out, wal_projection(borrow database, i), i + 3);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.replicas.len() {
         metric.observe(inout out, replica_projection(borrow database, i), i + 4);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -141,9 +141,9 @@ fn observe_pairs(inout out: metric.Metric, borrow database: model.Database) {
                 metric.observe(inout out,
                     (table.row_count + 1) * (index.entries + 1) + MODE(), t + x + 1);
             }
-            x = x + 1;
+            x += 1;
         }
-        t = t + 1;
+        t += 1;
     }
 }
 

--- a/examples/meridian/analysis_query_scan_cost.rue
+++ b/examples/meridian/analysis_query_scan_cost.rue
@@ -77,19 +77,19 @@ fn observe_catalog(inout out: metric.Metric, borrow database: model.Database) {
     let mut i: u64 = 0;
     while i < database.tables.len() {
         metric.observe(inout out, table_projection(borrow database, i), i + MODE());
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.columns.len() {
         metric.observe(inout out, column_projection(borrow database, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.indexes.len() {
         let item = database.indexes.get_or(i, model.empty_index());
         metric.observe(inout out, item.entries + item.column + MODE(), if item.unique { 5 } else { 2 });
         metric.warn(inout out, item.table >= database.tables.len());
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -98,12 +98,12 @@ fn observe_storage(inout out: metric.Metric, borrow database: model.Database) {
     while i < database.rows.len() {
         metric.observe(inout out, row_projection(borrow database, i), (i % 7) + 1);
         metric.warn(inout out, database.rows.get_or(i, model.empty_row()).table >= database.tables.len());
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.cells.len() {
         metric.observe(inout out, cell_projection(borrow database, i), (i % 11) + 1);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -111,22 +111,22 @@ fn observe_operations(inout out: metric.Metric, borrow database: model.Database)
     let mut i: u64 = 0;
     while i < database.queries.len() {
         metric.observe(inout out, query_projection(borrow database, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.transactions.len() {
         metric.observe(inout out, transaction_projection(borrow database, i), i + 2);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.wal.len() {
         metric.observe(inout out, wal_projection(borrow database, i), i + 3);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.replicas.len() {
         metric.observe(inout out, replica_projection(borrow database, i), i + 4);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -141,9 +141,9 @@ fn observe_pairs(inout out: metric.Metric, borrow database: model.Database) {
                 metric.observe(inout out,
                     (table.row_count + 1) * (index.entries + 1) + MODE(), t + x + 1);
             }
-            x = x + 1;
+            x += 1;
         }
-        t = t + 1;
+        t += 1;
     }
 }
 

--- a/examples/meridian/analysis_query_spill_risk.rue
+++ b/examples/meridian/analysis_query_spill_risk.rue
@@ -77,19 +77,19 @@ fn observe_catalog(inout out: metric.Metric, borrow database: model.Database) {
     let mut i: u64 = 0;
     while i < database.tables.len() {
         metric.observe(inout out, table_projection(borrow database, i), i + MODE());
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.columns.len() {
         metric.observe(inout out, column_projection(borrow database, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.indexes.len() {
         let item = database.indexes.get_or(i, model.empty_index());
         metric.observe(inout out, item.entries + item.column + MODE(), if item.unique { 5 } else { 2 });
         metric.warn(inout out, item.table >= database.tables.len());
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -98,12 +98,12 @@ fn observe_storage(inout out: metric.Metric, borrow database: model.Database) {
     while i < database.rows.len() {
         metric.observe(inout out, row_projection(borrow database, i), (i % 7) + 1);
         metric.warn(inout out, database.rows.get_or(i, model.empty_row()).table >= database.tables.len());
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.cells.len() {
         metric.observe(inout out, cell_projection(borrow database, i), (i % 11) + 1);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -111,22 +111,22 @@ fn observe_operations(inout out: metric.Metric, borrow database: model.Database)
     let mut i: u64 = 0;
     while i < database.queries.len() {
         metric.observe(inout out, query_projection(borrow database, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.transactions.len() {
         metric.observe(inout out, transaction_projection(borrow database, i), i + 2);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.wal.len() {
         metric.observe(inout out, wal_projection(borrow database, i), i + 3);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.replicas.len() {
         metric.observe(inout out, replica_projection(borrow database, i), i + 4);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -141,9 +141,9 @@ fn observe_pairs(inout out: metric.Metric, borrow database: model.Database) {
                 metric.observe(inout out,
                     (table.row_count + 1) * (index.entries + 1) + MODE(), t + x + 1);
             }
-            x = x + 1;
+            x += 1;
         }
-        t = t + 1;
+        t += 1;
     }
 }
 

--- a/examples/meridian/analysis_replication_apply_rate.rue
+++ b/examples/meridian/analysis_replication_apply_rate.rue
@@ -77,19 +77,19 @@ fn observe_catalog(inout out: metric.Metric, borrow database: model.Database) {
     let mut i: u64 = 0;
     while i < database.tables.len() {
         metric.observe(inout out, table_projection(borrow database, i), i + MODE());
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.columns.len() {
         metric.observe(inout out, column_projection(borrow database, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.indexes.len() {
         let item = database.indexes.get_or(i, model.empty_index());
         metric.observe(inout out, item.entries + item.column + MODE(), if item.unique { 5 } else { 2 });
         metric.warn(inout out, item.table >= database.tables.len());
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -98,12 +98,12 @@ fn observe_storage(inout out: metric.Metric, borrow database: model.Database) {
     while i < database.rows.len() {
         metric.observe(inout out, row_projection(borrow database, i), (i % 7) + 1);
         metric.warn(inout out, database.rows.get_or(i, model.empty_row()).table >= database.tables.len());
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.cells.len() {
         metric.observe(inout out, cell_projection(borrow database, i), (i % 11) + 1);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -111,22 +111,22 @@ fn observe_operations(inout out: metric.Metric, borrow database: model.Database)
     let mut i: u64 = 0;
     while i < database.queries.len() {
         metric.observe(inout out, query_projection(borrow database, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.transactions.len() {
         metric.observe(inout out, transaction_projection(borrow database, i), i + 2);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.wal.len() {
         metric.observe(inout out, wal_projection(borrow database, i), i + 3);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.replicas.len() {
         metric.observe(inout out, replica_projection(borrow database, i), i + 4);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -141,9 +141,9 @@ fn observe_pairs(inout out: metric.Metric, borrow database: model.Database) {
                 metric.observe(inout out,
                     (table.row_count + 1) * (index.entries + 1) + MODE(), t + x + 1);
             }
-            x = x + 1;
+            x += 1;
         }
-        t = t + 1;
+        t += 1;
     }
 }
 

--- a/examples/meridian/analysis_replication_catchup_cost.rue
+++ b/examples/meridian/analysis_replication_catchup_cost.rue
@@ -77,19 +77,19 @@ fn observe_catalog(inout out: metric.Metric, borrow database: model.Database) {
     let mut i: u64 = 0;
     while i < database.tables.len() {
         metric.observe(inout out, table_projection(borrow database, i), i + MODE());
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.columns.len() {
         metric.observe(inout out, column_projection(borrow database, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.indexes.len() {
         let item = database.indexes.get_or(i, model.empty_index());
         metric.observe(inout out, item.entries + item.column + MODE(), if item.unique { 5 } else { 2 });
         metric.warn(inout out, item.table >= database.tables.len());
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -98,12 +98,12 @@ fn observe_storage(inout out: metric.Metric, borrow database: model.Database) {
     while i < database.rows.len() {
         metric.observe(inout out, row_projection(borrow database, i), (i % 7) + 1);
         metric.warn(inout out, database.rows.get_or(i, model.empty_row()).table >= database.tables.len());
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.cells.len() {
         metric.observe(inout out, cell_projection(borrow database, i), (i % 11) + 1);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -111,22 +111,22 @@ fn observe_operations(inout out: metric.Metric, borrow database: model.Database)
     let mut i: u64 = 0;
     while i < database.queries.len() {
         metric.observe(inout out, query_projection(borrow database, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.transactions.len() {
         metric.observe(inout out, transaction_projection(borrow database, i), i + 2);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.wal.len() {
         metric.observe(inout out, wal_projection(borrow database, i), i + 3);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.replicas.len() {
         metric.observe(inout out, replica_projection(borrow database, i), i + 4);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -141,9 +141,9 @@ fn observe_pairs(inout out: metric.Metric, borrow database: model.Database) {
                 metric.observe(inout out,
                     (table.row_count + 1) * (index.entries + 1) + MODE(), t + x + 1);
             }
-            x = x + 1;
+            x += 1;
         }
-        t = t + 1;
+        t += 1;
     }
 }
 

--- a/examples/meridian/analysis_replication_consistency_gap.rue
+++ b/examples/meridian/analysis_replication_consistency_gap.rue
@@ -77,19 +77,19 @@ fn observe_catalog(inout out: metric.Metric, borrow database: model.Database) {
     let mut i: u64 = 0;
     while i < database.tables.len() {
         metric.observe(inout out, table_projection(borrow database, i), i + MODE());
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.columns.len() {
         metric.observe(inout out, column_projection(borrow database, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.indexes.len() {
         let item = database.indexes.get_or(i, model.empty_index());
         metric.observe(inout out, item.entries + item.column + MODE(), if item.unique { 5 } else { 2 });
         metric.warn(inout out, item.table >= database.tables.len());
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -98,12 +98,12 @@ fn observe_storage(inout out: metric.Metric, borrow database: model.Database) {
     while i < database.rows.len() {
         metric.observe(inout out, row_projection(borrow database, i), (i % 7) + 1);
         metric.warn(inout out, database.rows.get_or(i, model.empty_row()).table >= database.tables.len());
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.cells.len() {
         metric.observe(inout out, cell_projection(borrow database, i), (i % 11) + 1);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -111,22 +111,22 @@ fn observe_operations(inout out: metric.Metric, borrow database: model.Database)
     let mut i: u64 = 0;
     while i < database.queries.len() {
         metric.observe(inout out, query_projection(borrow database, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.transactions.len() {
         metric.observe(inout out, transaction_projection(borrow database, i), i + 2);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.wal.len() {
         metric.observe(inout out, wal_projection(borrow database, i), i + 3);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.replicas.len() {
         metric.observe(inout out, replica_projection(borrow database, i), i + 4);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -141,9 +141,9 @@ fn observe_pairs(inout out: metric.Metric, borrow database: model.Database) {
                 metric.observe(inout out,
                     (table.row_count + 1) * (index.entries + 1) + MODE(), t + x + 1);
             }
-            x = x + 1;
+            x += 1;
         }
-        t = t + 1;
+        t += 1;
     }
 }
 

--- a/examples/meridian/analysis_replication_durability_window.rue
+++ b/examples/meridian/analysis_replication_durability_window.rue
@@ -77,19 +77,19 @@ fn observe_catalog(inout out: metric.Metric, borrow database: model.Database) {
     let mut i: u64 = 0;
     while i < database.tables.len() {
         metric.observe(inout out, table_projection(borrow database, i), i + MODE());
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.columns.len() {
         metric.observe(inout out, column_projection(borrow database, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.indexes.len() {
         let item = database.indexes.get_or(i, model.empty_index());
         metric.observe(inout out, item.entries + item.column + MODE(), if item.unique { 5 } else { 2 });
         metric.warn(inout out, item.table >= database.tables.len());
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -98,12 +98,12 @@ fn observe_storage(inout out: metric.Metric, borrow database: model.Database) {
     while i < database.rows.len() {
         metric.observe(inout out, row_projection(borrow database, i), (i % 7) + 1);
         metric.warn(inout out, database.rows.get_or(i, model.empty_row()).table >= database.tables.len());
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.cells.len() {
         metric.observe(inout out, cell_projection(borrow database, i), (i % 11) + 1);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -111,22 +111,22 @@ fn observe_operations(inout out: metric.Metric, borrow database: model.Database)
     let mut i: u64 = 0;
     while i < database.queries.len() {
         metric.observe(inout out, query_projection(borrow database, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.transactions.len() {
         metric.observe(inout out, transaction_projection(borrow database, i), i + 2);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.wal.len() {
         metric.observe(inout out, wal_projection(borrow database, i), i + 3);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.replicas.len() {
         metric.observe(inout out, replica_projection(borrow database, i), i + 4);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -141,9 +141,9 @@ fn observe_pairs(inout out: metric.Metric, borrow database: model.Database) {
                 metric.observe(inout out,
                     (table.row_count + 1) * (index.entries + 1) + MODE(), t + x + 1);
             }
-            x = x + 1;
+            x += 1;
         }
-        t = t + 1;
+        t += 1;
     }
 }
 

--- a/examples/meridian/analysis_replication_failover_readiness.rue
+++ b/examples/meridian/analysis_replication_failover_readiness.rue
@@ -77,19 +77,19 @@ fn observe_catalog(inout out: metric.Metric, borrow database: model.Database) {
     let mut i: u64 = 0;
     while i < database.tables.len() {
         metric.observe(inout out, table_projection(borrow database, i), i + MODE());
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.columns.len() {
         metric.observe(inout out, column_projection(borrow database, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.indexes.len() {
         let item = database.indexes.get_or(i, model.empty_index());
         metric.observe(inout out, item.entries + item.column + MODE(), if item.unique { 5 } else { 2 });
         metric.warn(inout out, item.table >= database.tables.len());
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -98,12 +98,12 @@ fn observe_storage(inout out: metric.Metric, borrow database: model.Database) {
     while i < database.rows.len() {
         metric.observe(inout out, row_projection(borrow database, i), (i % 7) + 1);
         metric.warn(inout out, database.rows.get_or(i, model.empty_row()).table >= database.tables.len());
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.cells.len() {
         metric.observe(inout out, cell_projection(borrow database, i), (i % 11) + 1);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -111,22 +111,22 @@ fn observe_operations(inout out: metric.Metric, borrow database: model.Database)
     let mut i: u64 = 0;
     while i < database.queries.len() {
         metric.observe(inout out, query_projection(borrow database, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.transactions.len() {
         metric.observe(inout out, transaction_projection(borrow database, i), i + 2);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.wal.len() {
         metric.observe(inout out, wal_projection(borrow database, i), i + 3);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.replicas.len() {
         metric.observe(inout out, replica_projection(borrow database, i), i + 4);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -141,9 +141,9 @@ fn observe_pairs(inout out: metric.Metric, borrow database: model.Database) {
                 metric.observe(inout out,
                     (table.row_count + 1) * (index.entries + 1) + MODE(), t + x + 1);
             }
-            x = x + 1;
+            x += 1;
         }
-        t = t + 1;
+        t += 1;
     }
 }
 

--- a/examples/meridian/analysis_replication_follower_skew.rue
+++ b/examples/meridian/analysis_replication_follower_skew.rue
@@ -77,19 +77,19 @@ fn observe_catalog(inout out: metric.Metric, borrow database: model.Database) {
     let mut i: u64 = 0;
     while i < database.tables.len() {
         metric.observe(inout out, table_projection(borrow database, i), i + MODE());
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.columns.len() {
         metric.observe(inout out, column_projection(borrow database, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.indexes.len() {
         let item = database.indexes.get_or(i, model.empty_index());
         metric.observe(inout out, item.entries + item.column + MODE(), if item.unique { 5 } else { 2 });
         metric.warn(inout out, item.table >= database.tables.len());
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -98,12 +98,12 @@ fn observe_storage(inout out: metric.Metric, borrow database: model.Database) {
     while i < database.rows.len() {
         metric.observe(inout out, row_projection(borrow database, i), (i % 7) + 1);
         metric.warn(inout out, database.rows.get_or(i, model.empty_row()).table >= database.tables.len());
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.cells.len() {
         metric.observe(inout out, cell_projection(borrow database, i), (i % 11) + 1);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -111,22 +111,22 @@ fn observe_operations(inout out: metric.Metric, borrow database: model.Database)
     let mut i: u64 = 0;
     while i < database.queries.len() {
         metric.observe(inout out, query_projection(borrow database, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.transactions.len() {
         metric.observe(inout out, transaction_projection(borrow database, i), i + 2);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.wal.len() {
         metric.observe(inout out, wal_projection(borrow database, i), i + 3);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.replicas.len() {
         metric.observe(inout out, replica_projection(borrow database, i), i + 4);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -141,9 +141,9 @@ fn observe_pairs(inout out: metric.Metric, borrow database: model.Database) {
                 metric.observe(inout out,
                     (table.row_count + 1) * (index.entries + 1) + MODE(), t + x + 1);
             }
-            x = x + 1;
+            x += 1;
         }
-        t = t + 1;
+        t += 1;
     }
 }
 

--- a/examples/meridian/analysis_replication_health.rue
+++ b/examples/meridian/analysis_replication_health.rue
@@ -77,19 +77,19 @@ fn observe_catalog(inout out: metric.Metric, borrow database: model.Database) {
     let mut i: u64 = 0;
     while i < database.tables.len() {
         metric.observe(inout out, table_projection(borrow database, i), i + MODE());
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.columns.len() {
         metric.observe(inout out, column_projection(borrow database, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.indexes.len() {
         let item = database.indexes.get_or(i, model.empty_index());
         metric.observe(inout out, item.entries + item.column + MODE(), if item.unique { 5 } else { 2 });
         metric.warn(inout out, item.table >= database.tables.len());
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -98,12 +98,12 @@ fn observe_storage(inout out: metric.Metric, borrow database: model.Database) {
     while i < database.rows.len() {
         metric.observe(inout out, row_projection(borrow database, i), (i % 7) + 1);
         metric.warn(inout out, database.rows.get_or(i, model.empty_row()).table >= database.tables.len());
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.cells.len() {
         metric.observe(inout out, cell_projection(borrow database, i), (i % 11) + 1);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -111,22 +111,22 @@ fn observe_operations(inout out: metric.Metric, borrow database: model.Database)
     let mut i: u64 = 0;
     while i < database.queries.len() {
         metric.observe(inout out, query_projection(borrow database, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.transactions.len() {
         metric.observe(inout out, transaction_projection(borrow database, i), i + 2);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.wal.len() {
         metric.observe(inout out, wal_projection(borrow database, i), i + 3);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.replicas.len() {
         metric.observe(inout out, replica_projection(borrow database, i), i + 4);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -141,9 +141,9 @@ fn observe_pairs(inout out: metric.Metric, borrow database: model.Database) {
                 metric.observe(inout out,
                     (table.row_count + 1) * (index.entries + 1) + MODE(), t + x + 1);
             }
-            x = x + 1;
+            x += 1;
         }
-        t = t + 1;
+        t += 1;
     }
 }
 

--- a/examples/meridian/analysis_replication_lag.rue
+++ b/examples/meridian/analysis_replication_lag.rue
@@ -77,19 +77,19 @@ fn observe_catalog(inout out: metric.Metric, borrow database: model.Database) {
     let mut i: u64 = 0;
     while i < database.tables.len() {
         metric.observe(inout out, table_projection(borrow database, i), i + MODE());
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.columns.len() {
         metric.observe(inout out, column_projection(borrow database, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.indexes.len() {
         let item = database.indexes.get_or(i, model.empty_index());
         metric.observe(inout out, item.entries + item.column + MODE(), if item.unique { 5 } else { 2 });
         metric.warn(inout out, item.table >= database.tables.len());
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -98,12 +98,12 @@ fn observe_storage(inout out: metric.Metric, borrow database: model.Database) {
     while i < database.rows.len() {
         metric.observe(inout out, row_projection(borrow database, i), (i % 7) + 1);
         metric.warn(inout out, database.rows.get_or(i, model.empty_row()).table >= database.tables.len());
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.cells.len() {
         metric.observe(inout out, cell_projection(borrow database, i), (i % 11) + 1);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -111,22 +111,22 @@ fn observe_operations(inout out: metric.Metric, borrow database: model.Database)
     let mut i: u64 = 0;
     while i < database.queries.len() {
         metric.observe(inout out, query_projection(borrow database, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.transactions.len() {
         metric.observe(inout out, transaction_projection(borrow database, i), i + 2);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.wal.len() {
         metric.observe(inout out, wal_projection(borrow database, i), i + 3);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.replicas.len() {
         metric.observe(inout out, replica_projection(borrow database, i), i + 4);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -141,9 +141,9 @@ fn observe_pairs(inout out: metric.Metric, borrow database: model.Database) {
                 metric.observe(inout out,
                     (table.row_count + 1) * (index.entries + 1) + MODE(), t + x + 1);
             }
-            x = x + 1;
+            x += 1;
         }
-        t = t + 1;
+        t += 1;
     }
 }
 

--- a/examples/meridian/analysis_replication_log_gap.rue
+++ b/examples/meridian/analysis_replication_log_gap.rue
@@ -77,19 +77,19 @@ fn observe_catalog(inout out: metric.Metric, borrow database: model.Database) {
     let mut i: u64 = 0;
     while i < database.tables.len() {
         metric.observe(inout out, table_projection(borrow database, i), i + MODE());
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.columns.len() {
         metric.observe(inout out, column_projection(borrow database, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.indexes.len() {
         let item = database.indexes.get_or(i, model.empty_index());
         metric.observe(inout out, item.entries + item.column + MODE(), if item.unique { 5 } else { 2 });
         metric.warn(inout out, item.table >= database.tables.len());
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -98,12 +98,12 @@ fn observe_storage(inout out: metric.Metric, borrow database: model.Database) {
     while i < database.rows.len() {
         metric.observe(inout out, row_projection(borrow database, i), (i % 7) + 1);
         metric.warn(inout out, database.rows.get_or(i, model.empty_row()).table >= database.tables.len());
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.cells.len() {
         metric.observe(inout out, cell_projection(borrow database, i), (i % 11) + 1);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -111,22 +111,22 @@ fn observe_operations(inout out: metric.Metric, borrow database: model.Database)
     let mut i: u64 = 0;
     while i < database.queries.len() {
         metric.observe(inout out, query_projection(borrow database, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.transactions.len() {
         metric.observe(inout out, transaction_projection(borrow database, i), i + 2);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.wal.len() {
         metric.observe(inout out, wal_projection(borrow database, i), i + 3);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.replicas.len() {
         metric.observe(inout out, replica_projection(borrow database, i), i + 4);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -141,9 +141,9 @@ fn observe_pairs(inout out: metric.Metric, borrow database: model.Database) {
                 metric.observe(inout out,
                     (table.row_count + 1) * (index.entries + 1) + MODE(), t + x + 1);
             }
-            x = x + 1;
+            x += 1;
         }
-        t = t + 1;
+        t += 1;
     }
 }
 

--- a/examples/meridian/analysis_replication_partition_risk.rue
+++ b/examples/meridian/analysis_replication_partition_risk.rue
@@ -77,19 +77,19 @@ fn observe_catalog(inout out: metric.Metric, borrow database: model.Database) {
     let mut i: u64 = 0;
     while i < database.tables.len() {
         metric.observe(inout out, table_projection(borrow database, i), i + MODE());
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.columns.len() {
         metric.observe(inout out, column_projection(borrow database, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.indexes.len() {
         let item = database.indexes.get_or(i, model.empty_index());
         metric.observe(inout out, item.entries + item.column + MODE(), if item.unique { 5 } else { 2 });
         metric.warn(inout out, item.table >= database.tables.len());
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -98,12 +98,12 @@ fn observe_storage(inout out: metric.Metric, borrow database: model.Database) {
     while i < database.rows.len() {
         metric.observe(inout out, row_projection(borrow database, i), (i % 7) + 1);
         metric.warn(inout out, database.rows.get_or(i, model.empty_row()).table >= database.tables.len());
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.cells.len() {
         metric.observe(inout out, cell_projection(borrow database, i), (i % 11) + 1);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -111,22 +111,22 @@ fn observe_operations(inout out: metric.Metric, borrow database: model.Database)
     let mut i: u64 = 0;
     while i < database.queries.len() {
         metric.observe(inout out, query_projection(borrow database, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.transactions.len() {
         metric.observe(inout out, transaction_projection(borrow database, i), i + 2);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.wal.len() {
         metric.observe(inout out, wal_projection(borrow database, i), i + 3);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.replicas.len() {
         metric.observe(inout out, replica_projection(borrow database, i), i + 4);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -141,9 +141,9 @@ fn observe_pairs(inout out: metric.Metric, borrow database: model.Database) {
                 metric.observe(inout out,
                     (table.row_count + 1) * (index.entries + 1) + MODE(), t + x + 1);
             }
-            x = x + 1;
+            x += 1;
         }
-        t = t + 1;
+        t += 1;
     }
 }
 

--- a/examples/meridian/analysis_replication_primary_pressure.rue
+++ b/examples/meridian/analysis_replication_primary_pressure.rue
@@ -77,19 +77,19 @@ fn observe_catalog(inout out: metric.Metric, borrow database: model.Database) {
     let mut i: u64 = 0;
     while i < database.tables.len() {
         metric.observe(inout out, table_projection(borrow database, i), i + MODE());
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.columns.len() {
         metric.observe(inout out, column_projection(borrow database, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.indexes.len() {
         let item = database.indexes.get_or(i, model.empty_index());
         metric.observe(inout out, item.entries + item.column + MODE(), if item.unique { 5 } else { 2 });
         metric.warn(inout out, item.table >= database.tables.len());
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -98,12 +98,12 @@ fn observe_storage(inout out: metric.Metric, borrow database: model.Database) {
     while i < database.rows.len() {
         metric.observe(inout out, row_projection(borrow database, i), (i % 7) + 1);
         metric.warn(inout out, database.rows.get_or(i, model.empty_row()).table >= database.tables.len());
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.cells.len() {
         metric.observe(inout out, cell_projection(borrow database, i), (i % 11) + 1);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -111,22 +111,22 @@ fn observe_operations(inout out: metric.Metric, borrow database: model.Database)
     let mut i: u64 = 0;
     while i < database.queries.len() {
         metric.observe(inout out, query_projection(borrow database, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.transactions.len() {
         metric.observe(inout out, transaction_projection(borrow database, i), i + 2);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.wal.len() {
         metric.observe(inout out, wal_projection(borrow database, i), i + 3);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.replicas.len() {
         metric.observe(inout out, replica_projection(borrow database, i), i + 4);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -141,9 +141,9 @@ fn observe_pairs(inout out: metric.Metric, borrow database: model.Database) {
                 metric.observe(inout out,
                     (table.row_count + 1) * (index.entries + 1) + MODE(), t + x + 1);
             }
-            x = x + 1;
+            x += 1;
         }
-        t = t + 1;
+        t += 1;
     }
 }
 

--- a/examples/meridian/analysis_replication_quorum.rue
+++ b/examples/meridian/analysis_replication_quorum.rue
@@ -77,19 +77,19 @@ fn observe_catalog(inout out: metric.Metric, borrow database: model.Database) {
     let mut i: u64 = 0;
     while i < database.tables.len() {
         metric.observe(inout out, table_projection(borrow database, i), i + MODE());
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.columns.len() {
         metric.observe(inout out, column_projection(borrow database, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.indexes.len() {
         let item = database.indexes.get_or(i, model.empty_index());
         metric.observe(inout out, item.entries + item.column + MODE(), if item.unique { 5 } else { 2 });
         metric.warn(inout out, item.table >= database.tables.len());
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -98,12 +98,12 @@ fn observe_storage(inout out: metric.Metric, borrow database: model.Database) {
     while i < database.rows.len() {
         metric.observe(inout out, row_projection(borrow database, i), (i % 7) + 1);
         metric.warn(inout out, database.rows.get_or(i, model.empty_row()).table >= database.tables.len());
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.cells.len() {
         metric.observe(inout out, cell_projection(borrow database, i), (i % 11) + 1);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -111,22 +111,22 @@ fn observe_operations(inout out: metric.Metric, borrow database: model.Database)
     let mut i: u64 = 0;
     while i < database.queries.len() {
         metric.observe(inout out, query_projection(borrow database, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.transactions.len() {
         metric.observe(inout out, transaction_projection(borrow database, i), i + 2);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.wal.len() {
         metric.observe(inout out, wal_projection(borrow database, i), i + 3);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.replicas.len() {
         metric.observe(inout out, replica_projection(borrow database, i), i + 4);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -141,9 +141,9 @@ fn observe_pairs(inout out: metric.Metric, borrow database: model.Database) {
                 metric.observe(inout out,
                     (table.row_count + 1) * (index.entries + 1) + MODE(), t + x + 1);
             }
-            x = x + 1;
+            x += 1;
         }
-        t = t + 1;
+        t += 1;
     }
 }
 

--- a/examples/meridian/analysis_replication_read_scaling.rue
+++ b/examples/meridian/analysis_replication_read_scaling.rue
@@ -77,19 +77,19 @@ fn observe_catalog(inout out: metric.Metric, borrow database: model.Database) {
     let mut i: u64 = 0;
     while i < database.tables.len() {
         metric.observe(inout out, table_projection(borrow database, i), i + MODE());
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.columns.len() {
         metric.observe(inout out, column_projection(borrow database, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.indexes.len() {
         let item = database.indexes.get_or(i, model.empty_index());
         metric.observe(inout out, item.entries + item.column + MODE(), if item.unique { 5 } else { 2 });
         metric.warn(inout out, item.table >= database.tables.len());
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -98,12 +98,12 @@ fn observe_storage(inout out: metric.Metric, borrow database: model.Database) {
     while i < database.rows.len() {
         metric.observe(inout out, row_projection(borrow database, i), (i % 7) + 1);
         metric.warn(inout out, database.rows.get_or(i, model.empty_row()).table >= database.tables.len());
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.cells.len() {
         metric.observe(inout out, cell_projection(borrow database, i), (i % 11) + 1);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -111,22 +111,22 @@ fn observe_operations(inout out: metric.Metric, borrow database: model.Database)
     let mut i: u64 = 0;
     while i < database.queries.len() {
         metric.observe(inout out, query_projection(borrow database, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.transactions.len() {
         metric.observe(inout out, transaction_projection(borrow database, i), i + 2);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.wal.len() {
         metric.observe(inout out, wal_projection(borrow database, i), i + 3);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.replicas.len() {
         metric.observe(inout out, replica_projection(borrow database, i), i + 4);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -141,9 +141,9 @@ fn observe_pairs(inout out: metric.Metric, borrow database: model.Database) {
                 metric.observe(inout out,
                     (table.row_count + 1) * (index.entries + 1) + MODE(), t + x + 1);
             }
-            x = x + 1;
+            x += 1;
         }
-        t = t + 1;
+        t += 1;
     }
 }
 

--- a/examples/meridian/analysis_replication_snapshot_distance.rue
+++ b/examples/meridian/analysis_replication_snapshot_distance.rue
@@ -77,19 +77,19 @@ fn observe_catalog(inout out: metric.Metric, borrow database: model.Database) {
     let mut i: u64 = 0;
     while i < database.tables.len() {
         metric.observe(inout out, table_projection(borrow database, i), i + MODE());
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.columns.len() {
         metric.observe(inout out, column_projection(borrow database, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.indexes.len() {
         let item = database.indexes.get_or(i, model.empty_index());
         metric.observe(inout out, item.entries + item.column + MODE(), if item.unique { 5 } else { 2 });
         metric.warn(inout out, item.table >= database.tables.len());
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -98,12 +98,12 @@ fn observe_storage(inout out: metric.Metric, borrow database: model.Database) {
     while i < database.rows.len() {
         metric.observe(inout out, row_projection(borrow database, i), (i % 7) + 1);
         metric.warn(inout out, database.rows.get_or(i, model.empty_row()).table >= database.tables.len());
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.cells.len() {
         metric.observe(inout out, cell_projection(borrow database, i), (i % 11) + 1);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -111,22 +111,22 @@ fn observe_operations(inout out: metric.Metric, borrow database: model.Database)
     let mut i: u64 = 0;
     while i < database.queries.len() {
         metric.observe(inout out, query_projection(borrow database, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.transactions.len() {
         metric.observe(inout out, transaction_projection(borrow database, i), i + 2);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.wal.len() {
         metric.observe(inout out, wal_projection(borrow database, i), i + 3);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.replicas.len() {
         metric.observe(inout out, replica_projection(borrow database, i), i + 4);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -141,9 +141,9 @@ fn observe_pairs(inout out: metric.Metric, borrow database: model.Database) {
                 metric.observe(inout out,
                     (table.row_count + 1) * (index.entries + 1) + MODE(), t + x + 1);
             }
-            x = x + 1;
+            x += 1;
         }
-        t = t + 1;
+        t += 1;
     }
 }
 

--- a/examples/meridian/analysis_replication_topology_balance.rue
+++ b/examples/meridian/analysis_replication_topology_balance.rue
@@ -77,19 +77,19 @@ fn observe_catalog(inout out: metric.Metric, borrow database: model.Database) {
     let mut i: u64 = 0;
     while i < database.tables.len() {
         metric.observe(inout out, table_projection(borrow database, i), i + MODE());
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.columns.len() {
         metric.observe(inout out, column_projection(borrow database, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.indexes.len() {
         let item = database.indexes.get_or(i, model.empty_index());
         metric.observe(inout out, item.entries + item.column + MODE(), if item.unique { 5 } else { 2 });
         metric.warn(inout out, item.table >= database.tables.len());
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -98,12 +98,12 @@ fn observe_storage(inout out: metric.Metric, borrow database: model.Database) {
     while i < database.rows.len() {
         metric.observe(inout out, row_projection(borrow database, i), (i % 7) + 1);
         metric.warn(inout out, database.rows.get_or(i, model.empty_row()).table >= database.tables.len());
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.cells.len() {
         metric.observe(inout out, cell_projection(borrow database, i), (i % 11) + 1);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -111,22 +111,22 @@ fn observe_operations(inout out: metric.Metric, borrow database: model.Database)
     let mut i: u64 = 0;
     while i < database.queries.len() {
         metric.observe(inout out, query_projection(borrow database, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.transactions.len() {
         metric.observe(inout out, transaction_projection(borrow database, i), i + 2);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.wal.len() {
         metric.observe(inout out, wal_projection(borrow database, i), i + 3);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.replicas.len() {
         metric.observe(inout out, replica_projection(borrow database, i), i + 4);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -141,9 +141,9 @@ fn observe_pairs(inout out: metric.Metric, borrow database: model.Database) {
                 metric.observe(inout out,
                     (table.row_count + 1) * (index.entries + 1) + MODE(), t + x + 1);
             }
-            x = x + 1;
+            x += 1;
         }
-        t = t + 1;
+        t += 1;
     }
 }
 

--- a/examples/meridian/analysis_replication_write_amplification.rue
+++ b/examples/meridian/analysis_replication_write_amplification.rue
@@ -77,19 +77,19 @@ fn observe_catalog(inout out: metric.Metric, borrow database: model.Database) {
     let mut i: u64 = 0;
     while i < database.tables.len() {
         metric.observe(inout out, table_projection(borrow database, i), i + MODE());
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.columns.len() {
         metric.observe(inout out, column_projection(borrow database, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.indexes.len() {
         let item = database.indexes.get_or(i, model.empty_index());
         metric.observe(inout out, item.entries + item.column + MODE(), if item.unique { 5 } else { 2 });
         metric.warn(inout out, item.table >= database.tables.len());
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -98,12 +98,12 @@ fn observe_storage(inout out: metric.Metric, borrow database: model.Database) {
     while i < database.rows.len() {
         metric.observe(inout out, row_projection(borrow database, i), (i % 7) + 1);
         metric.warn(inout out, database.rows.get_or(i, model.empty_row()).table >= database.tables.len());
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.cells.len() {
         metric.observe(inout out, cell_projection(borrow database, i), (i % 11) + 1);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -111,22 +111,22 @@ fn observe_operations(inout out: metric.Metric, borrow database: model.Database)
     let mut i: u64 = 0;
     while i < database.queries.len() {
         metric.observe(inout out, query_projection(borrow database, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.transactions.len() {
         metric.observe(inout out, transaction_projection(borrow database, i), i + 2);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.wal.len() {
         metric.observe(inout out, wal_projection(borrow database, i), i + 3);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.replicas.len() {
         metric.observe(inout out, replica_projection(borrow database, i), i + 4);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -141,9 +141,9 @@ fn observe_pairs(inout out: metric.Metric, borrow database: model.Database) {
                 metric.observe(inout out,
                     (table.row_count + 1) * (index.entries + 1) + MODE(), t + x + 1);
             }
-            x = x + 1;
+            x += 1;
         }
-        t = t + 1;
+        t += 1;
     }
 }
 

--- a/examples/meridian/analysis_storage_cell_density.rue
+++ b/examples/meridian/analysis_storage_cell_density.rue
@@ -77,19 +77,19 @@ fn observe_catalog(inout out: metric.Metric, borrow database: model.Database) {
     let mut i: u64 = 0;
     while i < database.tables.len() {
         metric.observe(inout out, table_projection(borrow database, i), i + MODE());
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.columns.len() {
         metric.observe(inout out, column_projection(borrow database, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.indexes.len() {
         let item = database.indexes.get_or(i, model.empty_index());
         metric.observe(inout out, item.entries + item.column + MODE(), if item.unique { 5 } else { 2 });
         metric.warn(inout out, item.table >= database.tables.len());
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -98,12 +98,12 @@ fn observe_storage(inout out: metric.Metric, borrow database: model.Database) {
     while i < database.rows.len() {
         metric.observe(inout out, row_projection(borrow database, i), (i % 7) + 1);
         metric.warn(inout out, database.rows.get_or(i, model.empty_row()).table >= database.tables.len());
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.cells.len() {
         metric.observe(inout out, cell_projection(borrow database, i), (i % 11) + 1);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -111,22 +111,22 @@ fn observe_operations(inout out: metric.Metric, borrow database: model.Database)
     let mut i: u64 = 0;
     while i < database.queries.len() {
         metric.observe(inout out, query_projection(borrow database, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.transactions.len() {
         metric.observe(inout out, transaction_projection(borrow database, i), i + 2);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.wal.len() {
         metric.observe(inout out, wal_projection(borrow database, i), i + 3);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.replicas.len() {
         metric.observe(inout out, replica_projection(borrow database, i), i + 4);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -141,9 +141,9 @@ fn observe_pairs(inout out: metric.Metric, borrow database: model.Database) {
                 metric.observe(inout out,
                     (table.row_count + 1) * (index.entries + 1) + MODE(), t + x + 1);
             }
-            x = x + 1;
+            x += 1;
         }
-        t = t + 1;
+        t += 1;
     }
 }
 

--- a/examples/meridian/analysis_storage_cell_locality.rue
+++ b/examples/meridian/analysis_storage_cell_locality.rue
@@ -77,19 +77,19 @@ fn observe_catalog(inout out: metric.Metric, borrow database: model.Database) {
     let mut i: u64 = 0;
     while i < database.tables.len() {
         metric.observe(inout out, table_projection(borrow database, i), i + MODE());
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.columns.len() {
         metric.observe(inout out, column_projection(borrow database, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.indexes.len() {
         let item = database.indexes.get_or(i, model.empty_index());
         metric.observe(inout out, item.entries + item.column + MODE(), if item.unique { 5 } else { 2 });
         metric.warn(inout out, item.table >= database.tables.len());
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -98,12 +98,12 @@ fn observe_storage(inout out: metric.Metric, borrow database: model.Database) {
     while i < database.rows.len() {
         metric.observe(inout out, row_projection(borrow database, i), (i % 7) + 1);
         metric.warn(inout out, database.rows.get_or(i, model.empty_row()).table >= database.tables.len());
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.cells.len() {
         metric.observe(inout out, cell_projection(borrow database, i), (i % 11) + 1);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -111,22 +111,22 @@ fn observe_operations(inout out: metric.Metric, borrow database: model.Database)
     let mut i: u64 = 0;
     while i < database.queries.len() {
         metric.observe(inout out, query_projection(borrow database, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.transactions.len() {
         metric.observe(inout out, transaction_projection(borrow database, i), i + 2);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.wal.len() {
         metric.observe(inout out, wal_projection(borrow database, i), i + 3);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.replicas.len() {
         metric.observe(inout out, replica_projection(borrow database, i), i + 4);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -141,9 +141,9 @@ fn observe_pairs(inout out: metric.Metric, borrow database: model.Database) {
                 metric.observe(inout out,
                     (table.row_count + 1) * (index.entries + 1) + MODE(), t + x + 1);
             }
-            x = x + 1;
+            x += 1;
         }
-        t = t + 1;
+        t += 1;
     }
 }
 

--- a/examples/meridian/analysis_storage_cold_row_pressure.rue
+++ b/examples/meridian/analysis_storage_cold_row_pressure.rue
@@ -77,19 +77,19 @@ fn observe_catalog(inout out: metric.Metric, borrow database: model.Database) {
     let mut i: u64 = 0;
     while i < database.tables.len() {
         metric.observe(inout out, table_projection(borrow database, i), i + MODE());
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.columns.len() {
         metric.observe(inout out, column_projection(borrow database, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.indexes.len() {
         let item = database.indexes.get_or(i, model.empty_index());
         metric.observe(inout out, item.entries + item.column + MODE(), if item.unique { 5 } else { 2 });
         metric.warn(inout out, item.table >= database.tables.len());
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -98,12 +98,12 @@ fn observe_storage(inout out: metric.Metric, borrow database: model.Database) {
     while i < database.rows.len() {
         metric.observe(inout out, row_projection(borrow database, i), (i % 7) + 1);
         metric.warn(inout out, database.rows.get_or(i, model.empty_row()).table >= database.tables.len());
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.cells.len() {
         metric.observe(inout out, cell_projection(borrow database, i), (i % 11) + 1);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -111,22 +111,22 @@ fn observe_operations(inout out: metric.Metric, borrow database: model.Database)
     let mut i: u64 = 0;
     while i < database.queries.len() {
         metric.observe(inout out, query_projection(borrow database, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.transactions.len() {
         metric.observe(inout out, transaction_projection(borrow database, i), i + 2);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.wal.len() {
         metric.observe(inout out, wal_projection(borrow database, i), i + 3);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.replicas.len() {
         metric.observe(inout out, replica_projection(borrow database, i), i + 4);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -141,9 +141,9 @@ fn observe_pairs(inout out: metric.Metric, borrow database: model.Database) {
                 metric.observe(inout out,
                     (table.row_count + 1) * (index.entries + 1) + MODE(), t + x + 1);
             }
-            x = x + 1;
+            x += 1;
         }
-        t = t + 1;
+        t += 1;
     }
 }
 

--- a/examples/meridian/analysis_storage_compaction_gain.rue
+++ b/examples/meridian/analysis_storage_compaction_gain.rue
@@ -77,19 +77,19 @@ fn observe_catalog(inout out: metric.Metric, borrow database: model.Database) {
     let mut i: u64 = 0;
     while i < database.tables.len() {
         metric.observe(inout out, table_projection(borrow database, i), i + MODE());
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.columns.len() {
         metric.observe(inout out, column_projection(borrow database, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.indexes.len() {
         let item = database.indexes.get_or(i, model.empty_index());
         metric.observe(inout out, item.entries + item.column + MODE(), if item.unique { 5 } else { 2 });
         metric.warn(inout out, item.table >= database.tables.len());
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -98,12 +98,12 @@ fn observe_storage(inout out: metric.Metric, borrow database: model.Database) {
     while i < database.rows.len() {
         metric.observe(inout out, row_projection(borrow database, i), (i % 7) + 1);
         metric.warn(inout out, database.rows.get_or(i, model.empty_row()).table >= database.tables.len());
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.cells.len() {
         metric.observe(inout out, cell_projection(borrow database, i), (i % 11) + 1);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -111,22 +111,22 @@ fn observe_operations(inout out: metric.Metric, borrow database: model.Database)
     let mut i: u64 = 0;
     while i < database.queries.len() {
         metric.observe(inout out, query_projection(borrow database, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.transactions.len() {
         metric.observe(inout out, transaction_projection(borrow database, i), i + 2);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.wal.len() {
         metric.observe(inout out, wal_projection(borrow database, i), i + 3);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.replicas.len() {
         metric.observe(inout out, replica_projection(borrow database, i), i + 4);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -141,9 +141,9 @@ fn observe_pairs(inout out: metric.Metric, borrow database: model.Database) {
                 metric.observe(inout out,
                     (table.row_count + 1) * (index.entries + 1) + MODE(), t + x + 1);
             }
-            x = x + 1;
+            x += 1;
         }
-        t = t + 1;
+        t += 1;
     }
 }
 

--- a/examples/meridian/analysis_storage_fragmentation.rue
+++ b/examples/meridian/analysis_storage_fragmentation.rue
@@ -77,19 +77,19 @@ fn observe_catalog(inout out: metric.Metric, borrow database: model.Database) {
     let mut i: u64 = 0;
     while i < database.tables.len() {
         metric.observe(inout out, table_projection(borrow database, i), i + MODE());
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.columns.len() {
         metric.observe(inout out, column_projection(borrow database, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.indexes.len() {
         let item = database.indexes.get_or(i, model.empty_index());
         metric.observe(inout out, item.entries + item.column + MODE(), if item.unique { 5 } else { 2 });
         metric.warn(inout out, item.table >= database.tables.len());
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -98,12 +98,12 @@ fn observe_storage(inout out: metric.Metric, borrow database: model.Database) {
     while i < database.rows.len() {
         metric.observe(inout out, row_projection(borrow database, i), (i % 7) + 1);
         metric.warn(inout out, database.rows.get_or(i, model.empty_row()).table >= database.tables.len());
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.cells.len() {
         metric.observe(inout out, cell_projection(borrow database, i), (i % 11) + 1);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -111,22 +111,22 @@ fn observe_operations(inout out: metric.Metric, borrow database: model.Database)
     let mut i: u64 = 0;
     while i < database.queries.len() {
         metric.observe(inout out, query_projection(borrow database, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.transactions.len() {
         metric.observe(inout out, transaction_projection(borrow database, i), i + 2);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.wal.len() {
         metric.observe(inout out, wal_projection(borrow database, i), i + 3);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.replicas.len() {
         metric.observe(inout out, replica_projection(borrow database, i), i + 4);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -141,9 +141,9 @@ fn observe_pairs(inout out: metric.Metric, borrow database: model.Database) {
                 metric.observe(inout out,
                     (table.row_count + 1) * (index.entries + 1) + MODE(), t + x + 1);
             }
-            x = x + 1;
+            x += 1;
         }
-        t = t + 1;
+        t += 1;
     }
 }
 

--- a/examples/meridian/analysis_storage_hot_row_pressure.rue
+++ b/examples/meridian/analysis_storage_hot_row_pressure.rue
@@ -77,19 +77,19 @@ fn observe_catalog(inout out: metric.Metric, borrow database: model.Database) {
     let mut i: u64 = 0;
     while i < database.tables.len() {
         metric.observe(inout out, table_projection(borrow database, i), i + MODE());
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.columns.len() {
         metric.observe(inout out, column_projection(borrow database, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.indexes.len() {
         let item = database.indexes.get_or(i, model.empty_index());
         metric.observe(inout out, item.entries + item.column + MODE(), if item.unique { 5 } else { 2 });
         metric.warn(inout out, item.table >= database.tables.len());
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -98,12 +98,12 @@ fn observe_storage(inout out: metric.Metric, borrow database: model.Database) {
     while i < database.rows.len() {
         metric.observe(inout out, row_projection(borrow database, i), (i % 7) + 1);
         metric.warn(inout out, database.rows.get_or(i, model.empty_row()).table >= database.tables.len());
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.cells.len() {
         metric.observe(inout out, cell_projection(borrow database, i), (i % 11) + 1);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -111,22 +111,22 @@ fn observe_operations(inout out: metric.Metric, borrow database: model.Database)
     let mut i: u64 = 0;
     while i < database.queries.len() {
         metric.observe(inout out, query_projection(borrow database, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.transactions.len() {
         metric.observe(inout out, transaction_projection(borrow database, i), i + 2);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.wal.len() {
         metric.observe(inout out, wal_projection(borrow database, i), i + 3);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.replicas.len() {
         metric.observe(inout out, replica_projection(borrow database, i), i + 4);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -141,9 +141,9 @@ fn observe_pairs(inout out: metric.Metric, borrow database: model.Database) {
                 metric.observe(inout out,
                     (table.row_count + 1) * (index.entries + 1) + MODE(), t + x + 1);
             }
-            x = x + 1;
+            x += 1;
         }
-        t = t + 1;
+        t += 1;
     }
 }
 

--- a/examples/meridian/analysis_storage_null_fraction.rue
+++ b/examples/meridian/analysis_storage_null_fraction.rue
@@ -77,19 +77,19 @@ fn observe_catalog(inout out: metric.Metric, borrow database: model.Database) {
     let mut i: u64 = 0;
     while i < database.tables.len() {
         metric.observe(inout out, table_projection(borrow database, i), i + MODE());
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.columns.len() {
         metric.observe(inout out, column_projection(borrow database, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.indexes.len() {
         let item = database.indexes.get_or(i, model.empty_index());
         metric.observe(inout out, item.entries + item.column + MODE(), if item.unique { 5 } else { 2 });
         metric.warn(inout out, item.table >= database.tables.len());
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -98,12 +98,12 @@ fn observe_storage(inout out: metric.Metric, borrow database: model.Database) {
     while i < database.rows.len() {
         metric.observe(inout out, row_projection(borrow database, i), (i % 7) + 1);
         metric.warn(inout out, database.rows.get_or(i, model.empty_row()).table >= database.tables.len());
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.cells.len() {
         metric.observe(inout out, cell_projection(borrow database, i), (i % 11) + 1);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -111,22 +111,22 @@ fn observe_operations(inout out: metric.Metric, borrow database: model.Database)
     let mut i: u64 = 0;
     while i < database.queries.len() {
         metric.observe(inout out, query_projection(borrow database, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.transactions.len() {
         metric.observe(inout out, transaction_projection(borrow database, i), i + 2);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.wal.len() {
         metric.observe(inout out, wal_projection(borrow database, i), i + 3);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.replicas.len() {
         metric.observe(inout out, replica_projection(borrow database, i), i + 4);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -141,9 +141,9 @@ fn observe_pairs(inout out: metric.Metric, borrow database: model.Database) {
                 metric.observe(inout out,
                     (table.row_count + 1) * (index.entries + 1) + MODE(), t + x + 1);
             }
-            x = x + 1;
+            x += 1;
         }
-        t = t + 1;
+        t += 1;
     }
 }
 

--- a/examples/meridian/analysis_storage_page_fill.rue
+++ b/examples/meridian/analysis_storage_page_fill.rue
@@ -77,19 +77,19 @@ fn observe_catalog(inout out: metric.Metric, borrow database: model.Database) {
     let mut i: u64 = 0;
     while i < database.tables.len() {
         metric.observe(inout out, table_projection(borrow database, i), i + MODE());
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.columns.len() {
         metric.observe(inout out, column_projection(borrow database, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.indexes.len() {
         let item = database.indexes.get_or(i, model.empty_index());
         metric.observe(inout out, item.entries + item.column + MODE(), if item.unique { 5 } else { 2 });
         metric.warn(inout out, item.table >= database.tables.len());
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -98,12 +98,12 @@ fn observe_storage(inout out: metric.Metric, borrow database: model.Database) {
     while i < database.rows.len() {
         metric.observe(inout out, row_projection(borrow database, i), (i % 7) + 1);
         metric.warn(inout out, database.rows.get_or(i, model.empty_row()).table >= database.tables.len());
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.cells.len() {
         metric.observe(inout out, cell_projection(borrow database, i), (i % 11) + 1);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -111,22 +111,22 @@ fn observe_operations(inout out: metric.Metric, borrow database: model.Database)
     let mut i: u64 = 0;
     while i < database.queries.len() {
         metric.observe(inout out, query_projection(borrow database, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.transactions.len() {
         metric.observe(inout out, transaction_projection(borrow database, i), i + 2);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.wal.len() {
         metric.observe(inout out, wal_projection(borrow database, i), i + 3);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.replicas.len() {
         metric.observe(inout out, replica_projection(borrow database, i), i + 4);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -141,9 +141,9 @@ fn observe_pairs(inout out: metric.Metric, borrow database: model.Database) {
                 metric.observe(inout out,
                     (table.row_count + 1) * (index.entries + 1) + MODE(), t + x + 1);
             }
-            x = x + 1;
+            x += 1;
         }
-        t = t + 1;
+        t += 1;
     }
 }
 

--- a/examples/meridian/analysis_storage_payload_width.rue
+++ b/examples/meridian/analysis_storage_payload_width.rue
@@ -77,19 +77,19 @@ fn observe_catalog(inout out: metric.Metric, borrow database: model.Database) {
     let mut i: u64 = 0;
     while i < database.tables.len() {
         metric.observe(inout out, table_projection(borrow database, i), i + MODE());
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.columns.len() {
         metric.observe(inout out, column_projection(borrow database, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.indexes.len() {
         let item = database.indexes.get_or(i, model.empty_index());
         metric.observe(inout out, item.entries + item.column + MODE(), if item.unique { 5 } else { 2 });
         metric.warn(inout out, item.table >= database.tables.len());
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -98,12 +98,12 @@ fn observe_storage(inout out: metric.Metric, borrow database: model.Database) {
     while i < database.rows.len() {
         metric.observe(inout out, row_projection(borrow database, i), (i % 7) + 1);
         metric.warn(inout out, database.rows.get_or(i, model.empty_row()).table >= database.tables.len());
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.cells.len() {
         metric.observe(inout out, cell_projection(borrow database, i), (i % 11) + 1);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -111,22 +111,22 @@ fn observe_operations(inout out: metric.Metric, borrow database: model.Database)
     let mut i: u64 = 0;
     while i < database.queries.len() {
         metric.observe(inout out, query_projection(borrow database, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.transactions.len() {
         metric.observe(inout out, transaction_projection(borrow database, i), i + 2);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.wal.len() {
         metric.observe(inout out, wal_projection(borrow database, i), i + 3);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.replicas.len() {
         metric.observe(inout out, replica_projection(borrow database, i), i + 4);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -141,9 +141,9 @@ fn observe_pairs(inout out: metric.Metric, borrow database: model.Database) {
                 metric.observe(inout out,
                     (table.row_count + 1) * (index.entries + 1) + MODE(), t + x + 1);
             }
-            x = x + 1;
+            x += 1;
         }
-        t = t + 1;
+        t += 1;
     }
 }
 

--- a/examples/meridian/analysis_storage_row_density.rue
+++ b/examples/meridian/analysis_storage_row_density.rue
@@ -77,19 +77,19 @@ fn observe_catalog(inout out: metric.Metric, borrow database: model.Database) {
     let mut i: u64 = 0;
     while i < database.tables.len() {
         metric.observe(inout out, table_projection(borrow database, i), i + MODE());
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.columns.len() {
         metric.observe(inout out, column_projection(borrow database, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.indexes.len() {
         let item = database.indexes.get_or(i, model.empty_index());
         metric.observe(inout out, item.entries + item.column + MODE(), if item.unique { 5 } else { 2 });
         metric.warn(inout out, item.table >= database.tables.len());
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -98,12 +98,12 @@ fn observe_storage(inout out: metric.Metric, borrow database: model.Database) {
     while i < database.rows.len() {
         metric.observe(inout out, row_projection(borrow database, i), (i % 7) + 1);
         metric.warn(inout out, database.rows.get_or(i, model.empty_row()).table >= database.tables.len());
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.cells.len() {
         metric.observe(inout out, cell_projection(borrow database, i), (i % 11) + 1);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -111,22 +111,22 @@ fn observe_operations(inout out: metric.Metric, borrow database: model.Database)
     let mut i: u64 = 0;
     while i < database.queries.len() {
         metric.observe(inout out, query_projection(borrow database, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.transactions.len() {
         metric.observe(inout out, transaction_projection(borrow database, i), i + 2);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.wal.len() {
         metric.observe(inout out, wal_projection(borrow database, i), i + 3);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.replicas.len() {
         metric.observe(inout out, replica_projection(borrow database, i), i + 4);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -141,9 +141,9 @@ fn observe_pairs(inout out: metric.Metric, borrow database: model.Database) {
                 metric.observe(inout out,
                     (table.row_count + 1) * (index.entries + 1) + MODE(), t + x + 1);
             }
-            x = x + 1;
+            x += 1;
         }
-        t = t + 1;
+        t += 1;
     }
 }
 

--- a/examples/meridian/analysis_storage_scan_amplification.rue
+++ b/examples/meridian/analysis_storage_scan_amplification.rue
@@ -77,19 +77,19 @@ fn observe_catalog(inout out: metric.Metric, borrow database: model.Database) {
     let mut i: u64 = 0;
     while i < database.tables.len() {
         metric.observe(inout out, table_projection(borrow database, i), i + MODE());
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.columns.len() {
         metric.observe(inout out, column_projection(borrow database, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.indexes.len() {
         let item = database.indexes.get_or(i, model.empty_index());
         metric.observe(inout out, item.entries + item.column + MODE(), if item.unique { 5 } else { 2 });
         metric.warn(inout out, item.table >= database.tables.len());
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -98,12 +98,12 @@ fn observe_storage(inout out: metric.Metric, borrow database: model.Database) {
     while i < database.rows.len() {
         metric.observe(inout out, row_projection(borrow database, i), (i % 7) + 1);
         metric.warn(inout out, database.rows.get_or(i, model.empty_row()).table >= database.tables.len());
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.cells.len() {
         metric.observe(inout out, cell_projection(borrow database, i), (i % 11) + 1);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -111,22 +111,22 @@ fn observe_operations(inout out: metric.Metric, borrow database: model.Database)
     let mut i: u64 = 0;
     while i < database.queries.len() {
         metric.observe(inout out, query_projection(borrow database, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.transactions.len() {
         metric.observe(inout out, transaction_projection(borrow database, i), i + 2);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.wal.len() {
         metric.observe(inout out, wal_projection(borrow database, i), i + 3);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.replicas.len() {
         metric.observe(inout out, replica_projection(borrow database, i), i + 4);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -141,9 +141,9 @@ fn observe_pairs(inout out: metric.Metric, borrow database: model.Database) {
                 metric.observe(inout out,
                     (table.row_count + 1) * (index.entries + 1) + MODE(), t + x + 1);
             }
-            x = x + 1;
+            x += 1;
         }
-        t = t + 1;
+        t += 1;
     }
 }
 

--- a/examples/meridian/analysis_storage_table_clustering.rue
+++ b/examples/meridian/analysis_storage_table_clustering.rue
@@ -77,19 +77,19 @@ fn observe_catalog(inout out: metric.Metric, borrow database: model.Database) {
     let mut i: u64 = 0;
     while i < database.tables.len() {
         metric.observe(inout out, table_projection(borrow database, i), i + MODE());
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.columns.len() {
         metric.observe(inout out, column_projection(borrow database, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.indexes.len() {
         let item = database.indexes.get_or(i, model.empty_index());
         metric.observe(inout out, item.entries + item.column + MODE(), if item.unique { 5 } else { 2 });
         metric.warn(inout out, item.table >= database.tables.len());
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -98,12 +98,12 @@ fn observe_storage(inout out: metric.Metric, borrow database: model.Database) {
     while i < database.rows.len() {
         metric.observe(inout out, row_projection(borrow database, i), (i % 7) + 1);
         metric.warn(inout out, database.rows.get_or(i, model.empty_row()).table >= database.tables.len());
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.cells.len() {
         metric.observe(inout out, cell_projection(borrow database, i), (i % 11) + 1);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -111,22 +111,22 @@ fn observe_operations(inout out: metric.Metric, borrow database: model.Database)
     let mut i: u64 = 0;
     while i < database.queries.len() {
         metric.observe(inout out, query_projection(borrow database, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.transactions.len() {
         metric.observe(inout out, transaction_projection(borrow database, i), i + 2);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.wal.len() {
         metric.observe(inout out, wal_projection(borrow database, i), i + 3);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.replicas.len() {
         metric.observe(inout out, replica_projection(borrow database, i), i + 4);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -141,9 +141,9 @@ fn observe_pairs(inout out: metric.Metric, borrow database: model.Database) {
                 metric.observe(inout out,
                     (table.row_count + 1) * (index.entries + 1) + MODE(), t + x + 1);
             }
-            x = x + 1;
+            x += 1;
         }
-        t = t + 1;
+        t += 1;
     }
 }
 

--- a/examples/meridian/analysis_storage_tombstone_ratio.rue
+++ b/examples/meridian/analysis_storage_tombstone_ratio.rue
@@ -77,19 +77,19 @@ fn observe_catalog(inout out: metric.Metric, borrow database: model.Database) {
     let mut i: u64 = 0;
     while i < database.tables.len() {
         metric.observe(inout out, table_projection(borrow database, i), i + MODE());
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.columns.len() {
         metric.observe(inout out, column_projection(borrow database, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.indexes.len() {
         let item = database.indexes.get_or(i, model.empty_index());
         metric.observe(inout out, item.entries + item.column + MODE(), if item.unique { 5 } else { 2 });
         metric.warn(inout out, item.table >= database.tables.len());
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -98,12 +98,12 @@ fn observe_storage(inout out: metric.Metric, borrow database: model.Database) {
     while i < database.rows.len() {
         metric.observe(inout out, row_projection(borrow database, i), (i % 7) + 1);
         metric.warn(inout out, database.rows.get_or(i, model.empty_row()).table >= database.tables.len());
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.cells.len() {
         metric.observe(inout out, cell_projection(borrow database, i), (i % 11) + 1);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -111,22 +111,22 @@ fn observe_operations(inout out: metric.Metric, borrow database: model.Database)
     let mut i: u64 = 0;
     while i < database.queries.len() {
         metric.observe(inout out, query_projection(borrow database, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.transactions.len() {
         metric.observe(inout out, transaction_projection(borrow database, i), i + 2);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.wal.len() {
         metric.observe(inout out, wal_projection(borrow database, i), i + 3);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.replicas.len() {
         metric.observe(inout out, replica_projection(borrow database, i), i + 4);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -141,9 +141,9 @@ fn observe_pairs(inout out: metric.Metric, borrow database: model.Database) {
                 metric.observe(inout out,
                     (table.row_count + 1) * (index.entries + 1) + MODE(), t + x + 1);
             }
-            x = x + 1;
+            x += 1;
         }
-        t = t + 1;
+        t += 1;
     }
 }
 

--- a/examples/meridian/analysis_storage_version_span.rue
+++ b/examples/meridian/analysis_storage_version_span.rue
@@ -77,19 +77,19 @@ fn observe_catalog(inout out: metric.Metric, borrow database: model.Database) {
     let mut i: u64 = 0;
     while i < database.tables.len() {
         metric.observe(inout out, table_projection(borrow database, i), i + MODE());
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.columns.len() {
         metric.observe(inout out, column_projection(borrow database, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.indexes.len() {
         let item = database.indexes.get_or(i, model.empty_index());
         metric.observe(inout out, item.entries + item.column + MODE(), if item.unique { 5 } else { 2 });
         metric.warn(inout out, item.table >= database.tables.len());
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -98,12 +98,12 @@ fn observe_storage(inout out: metric.Metric, borrow database: model.Database) {
     while i < database.rows.len() {
         metric.observe(inout out, row_projection(borrow database, i), (i % 7) + 1);
         metric.warn(inout out, database.rows.get_or(i, model.empty_row()).table >= database.tables.len());
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.cells.len() {
         metric.observe(inout out, cell_projection(borrow database, i), (i % 11) + 1);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -111,22 +111,22 @@ fn observe_operations(inout out: metric.Metric, borrow database: model.Database)
     let mut i: u64 = 0;
     while i < database.queries.len() {
         metric.observe(inout out, query_projection(borrow database, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.transactions.len() {
         metric.observe(inout out, transaction_projection(borrow database, i), i + 2);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.wal.len() {
         metric.observe(inout out, wal_projection(borrow database, i), i + 3);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.replicas.len() {
         metric.observe(inout out, replica_projection(borrow database, i), i + 4);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -141,9 +141,9 @@ fn observe_pairs(inout out: metric.Metric, borrow database: model.Database) {
                 metric.observe(inout out,
                     (table.row_count + 1) * (index.entries + 1) + MODE(), t + x + 1);
             }
-            x = x + 1;
+            x += 1;
         }
-        t = t + 1;
+        t += 1;
     }
 }
 

--- a/examples/meridian/analysis_storage_visibility.rue
+++ b/examples/meridian/analysis_storage_visibility.rue
@@ -77,19 +77,19 @@ fn observe_catalog(inout out: metric.Metric, borrow database: model.Database) {
     let mut i: u64 = 0;
     while i < database.tables.len() {
         metric.observe(inout out, table_projection(borrow database, i), i + MODE());
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.columns.len() {
         metric.observe(inout out, column_projection(borrow database, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.indexes.len() {
         let item = database.indexes.get_or(i, model.empty_index());
         metric.observe(inout out, item.entries + item.column + MODE(), if item.unique { 5 } else { 2 });
         metric.warn(inout out, item.table >= database.tables.len());
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -98,12 +98,12 @@ fn observe_storage(inout out: metric.Metric, borrow database: model.Database) {
     while i < database.rows.len() {
         metric.observe(inout out, row_projection(borrow database, i), (i % 7) + 1);
         metric.warn(inout out, database.rows.get_or(i, model.empty_row()).table >= database.tables.len());
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.cells.len() {
         metric.observe(inout out, cell_projection(borrow database, i), (i % 11) + 1);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -111,22 +111,22 @@ fn observe_operations(inout out: metric.Metric, borrow database: model.Database)
     let mut i: u64 = 0;
     while i < database.queries.len() {
         metric.observe(inout out, query_projection(borrow database, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.transactions.len() {
         metric.observe(inout out, transaction_projection(borrow database, i), i + 2);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.wal.len() {
         metric.observe(inout out, wal_projection(borrow database, i), i + 3);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.replicas.len() {
         metric.observe(inout out, replica_projection(borrow database, i), i + 4);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -141,9 +141,9 @@ fn observe_pairs(inout out: metric.Metric, borrow database: model.Database) {
                 metric.observe(inout out,
                     (table.row_count + 1) * (index.entries + 1) + MODE(), t + x + 1);
             }
-            x = x + 1;
+            x += 1;
         }
-        t = t + 1;
+        t += 1;
     }
 }
 

--- a/examples/meridian/analysis_storage_write_amplification.rue
+++ b/examples/meridian/analysis_storage_write_amplification.rue
@@ -77,19 +77,19 @@ fn observe_catalog(inout out: metric.Metric, borrow database: model.Database) {
     let mut i: u64 = 0;
     while i < database.tables.len() {
         metric.observe(inout out, table_projection(borrow database, i), i + MODE());
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.columns.len() {
         metric.observe(inout out, column_projection(borrow database, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.indexes.len() {
         let item = database.indexes.get_or(i, model.empty_index());
         metric.observe(inout out, item.entries + item.column + MODE(), if item.unique { 5 } else { 2 });
         metric.warn(inout out, item.table >= database.tables.len());
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -98,12 +98,12 @@ fn observe_storage(inout out: metric.Metric, borrow database: model.Database) {
     while i < database.rows.len() {
         metric.observe(inout out, row_projection(borrow database, i), (i % 7) + 1);
         metric.warn(inout out, database.rows.get_or(i, model.empty_row()).table >= database.tables.len());
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.cells.len() {
         metric.observe(inout out, cell_projection(borrow database, i), (i % 11) + 1);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -111,22 +111,22 @@ fn observe_operations(inout out: metric.Metric, borrow database: model.Database)
     let mut i: u64 = 0;
     while i < database.queries.len() {
         metric.observe(inout out, query_projection(borrow database, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.transactions.len() {
         metric.observe(inout out, transaction_projection(borrow database, i), i + 2);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.wal.len() {
         metric.observe(inout out, wal_projection(borrow database, i), i + 3);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.replicas.len() {
         metric.observe(inout out, replica_projection(borrow database, i), i + 4);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -141,9 +141,9 @@ fn observe_pairs(inout out: metric.Metric, borrow database: model.Database) {
                 metric.observe(inout out,
                     (table.row_count + 1) * (index.entries + 1) + MODE(), t + x + 1);
             }
-            x = x + 1;
+            x += 1;
         }
-        t = t + 1;
+        t += 1;
     }
 }
 

--- a/examples/meridian/analysis_suite.rue
+++ b/examples/meridian/analysis_suite.rue
@@ -130,16 +130,16 @@ fn empty() -> Result {
 }
 
 fn include(inout out: Result, borrow first: metric.Metric, borrow second: metric.Metric, verified: bool) {
-    out.passes = out.passes + 1;
-    out.observations = out.observations + first.observations;
-    out.warnings = out.warnings + first.warnings;
+    out.passes += 1;
+    out.observations += first.observations;
+    out.warnings += first.warnings;
     out.digest = metric.mix(out.digest, first.tag);
     out.digest = metric.mix(out.digest, first.digest);
     if !verified || !metric.valid(borrow first) { out.failures = out.failures + 1; }
     if first.digest != second.digest || first.observations != second.observations ||
         first.warnings != second.warnings {
         out.deterministic = false;
-        out.failures = out.failures + 1;
+        out.failures += 1;
     }
 }
 

--- a/examples/meridian/analysis_suite.rue
+++ b/examples/meridian/analysis_suite.rue
@@ -135,7 +135,7 @@ fn include(inout out: Result, borrow first: metric.Metric, borrow second: metric
     out.warnings += first.warnings;
     out.digest = metric.mix(out.digest, first.tag);
     out.digest = metric.mix(out.digest, first.digest);
-    if !verified || !metric.valid(borrow first) { out.failures = out.failures + 1; }
+    if !verified || !metric.valid(borrow first) { out.failures += 1; }
     if first.digest != second.digest || first.observations != second.observations ||
         first.warnings != second.warnings {
         out.deterministic = false;

--- a/examples/meridian/analysis_transaction_abort_cost.rue
+++ b/examples/meridian/analysis_transaction_abort_cost.rue
@@ -77,19 +77,19 @@ fn observe_catalog(inout out: metric.Metric, borrow database: model.Database) {
     let mut i: u64 = 0;
     while i < database.tables.len() {
         metric.observe(inout out, table_projection(borrow database, i), i + MODE());
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.columns.len() {
         metric.observe(inout out, column_projection(borrow database, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.indexes.len() {
         let item = database.indexes.get_or(i, model.empty_index());
         metric.observe(inout out, item.entries + item.column + MODE(), if item.unique { 5 } else { 2 });
         metric.warn(inout out, item.table >= database.tables.len());
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -98,12 +98,12 @@ fn observe_storage(inout out: metric.Metric, borrow database: model.Database) {
     while i < database.rows.len() {
         metric.observe(inout out, row_projection(borrow database, i), (i % 7) + 1);
         metric.warn(inout out, database.rows.get_or(i, model.empty_row()).table >= database.tables.len());
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.cells.len() {
         metric.observe(inout out, cell_projection(borrow database, i), (i % 11) + 1);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -111,22 +111,22 @@ fn observe_operations(inout out: metric.Metric, borrow database: model.Database)
     let mut i: u64 = 0;
     while i < database.queries.len() {
         metric.observe(inout out, query_projection(borrow database, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.transactions.len() {
         metric.observe(inout out, transaction_projection(borrow database, i), i + 2);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.wal.len() {
         metric.observe(inout out, wal_projection(borrow database, i), i + 3);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.replicas.len() {
         metric.observe(inout out, replica_projection(borrow database, i), i + 4);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -141,9 +141,9 @@ fn observe_pairs(inout out: metric.Metric, borrow database: model.Database) {
                 metric.observe(inout out,
                     (table.row_count + 1) * (index.entries + 1) + MODE(), t + x + 1);
             }
-            x = x + 1;
+            x += 1;
         }
-        t = t + 1;
+        t += 1;
     }
 }
 

--- a/examples/meridian/analysis_transaction_batch_efficiency.rue
+++ b/examples/meridian/analysis_transaction_batch_efficiency.rue
@@ -77,19 +77,19 @@ fn observe_catalog(inout out: metric.Metric, borrow database: model.Database) {
     let mut i: u64 = 0;
     while i < database.tables.len() {
         metric.observe(inout out, table_projection(borrow database, i), i + MODE());
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.columns.len() {
         metric.observe(inout out, column_projection(borrow database, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.indexes.len() {
         let item = database.indexes.get_or(i, model.empty_index());
         metric.observe(inout out, item.entries + item.column + MODE(), if item.unique { 5 } else { 2 });
         metric.warn(inout out, item.table >= database.tables.len());
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -98,12 +98,12 @@ fn observe_storage(inout out: metric.Metric, borrow database: model.Database) {
     while i < database.rows.len() {
         metric.observe(inout out, row_projection(borrow database, i), (i % 7) + 1);
         metric.warn(inout out, database.rows.get_or(i, model.empty_row()).table >= database.tables.len());
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.cells.len() {
         metric.observe(inout out, cell_projection(borrow database, i), (i % 11) + 1);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -111,22 +111,22 @@ fn observe_operations(inout out: metric.Metric, borrow database: model.Database)
     let mut i: u64 = 0;
     while i < database.queries.len() {
         metric.observe(inout out, query_projection(borrow database, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.transactions.len() {
         metric.observe(inout out, transaction_projection(borrow database, i), i + 2);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.wal.len() {
         metric.observe(inout out, wal_projection(borrow database, i), i + 3);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.replicas.len() {
         metric.observe(inout out, replica_projection(borrow database, i), i + 4);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -141,9 +141,9 @@ fn observe_pairs(inout out: metric.Metric, borrow database: model.Database) {
                 metric.observe(inout out,
                     (table.row_count + 1) * (index.entries + 1) + MODE(), t + x + 1);
             }
-            x = x + 1;
+            x += 1;
         }
-        t = t + 1;
+        t += 1;
     }
 }
 

--- a/examples/meridian/analysis_transaction_commit_ratio.rue
+++ b/examples/meridian/analysis_transaction_commit_ratio.rue
@@ -77,19 +77,19 @@ fn observe_catalog(inout out: metric.Metric, borrow database: model.Database) {
     let mut i: u64 = 0;
     while i < database.tables.len() {
         metric.observe(inout out, table_projection(borrow database, i), i + MODE());
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.columns.len() {
         metric.observe(inout out, column_projection(borrow database, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.indexes.len() {
         let item = database.indexes.get_or(i, model.empty_index());
         metric.observe(inout out, item.entries + item.column + MODE(), if item.unique { 5 } else { 2 });
         metric.warn(inout out, item.table >= database.tables.len());
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -98,12 +98,12 @@ fn observe_storage(inout out: metric.Metric, borrow database: model.Database) {
     while i < database.rows.len() {
         metric.observe(inout out, row_projection(borrow database, i), (i % 7) + 1);
         metric.warn(inout out, database.rows.get_or(i, model.empty_row()).table >= database.tables.len());
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.cells.len() {
         metric.observe(inout out, cell_projection(borrow database, i), (i % 11) + 1);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -111,22 +111,22 @@ fn observe_operations(inout out: metric.Metric, borrow database: model.Database)
     let mut i: u64 = 0;
     while i < database.queries.len() {
         metric.observe(inout out, query_projection(borrow database, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.transactions.len() {
         metric.observe(inout out, transaction_projection(borrow database, i), i + 2);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.wal.len() {
         metric.observe(inout out, wal_projection(borrow database, i), i + 3);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.replicas.len() {
         metric.observe(inout out, replica_projection(borrow database, i), i + 4);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -141,9 +141,9 @@ fn observe_pairs(inout out: metric.Metric, borrow database: model.Database) {
                 metric.observe(inout out,
                     (table.row_count + 1) * (index.entries + 1) + MODE(), t + x + 1);
             }
-            x = x + 1;
+            x += 1;
         }
-        t = t + 1;
+        t += 1;
     }
 }
 

--- a/examples/meridian/analysis_transaction_conflict_surface.rue
+++ b/examples/meridian/analysis_transaction_conflict_surface.rue
@@ -77,19 +77,19 @@ fn observe_catalog(inout out: metric.Metric, borrow database: model.Database) {
     let mut i: u64 = 0;
     while i < database.tables.len() {
         metric.observe(inout out, table_projection(borrow database, i), i + MODE());
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.columns.len() {
         metric.observe(inout out, column_projection(borrow database, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.indexes.len() {
         let item = database.indexes.get_or(i, model.empty_index());
         metric.observe(inout out, item.entries + item.column + MODE(), if item.unique { 5 } else { 2 });
         metric.warn(inout out, item.table >= database.tables.len());
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -98,12 +98,12 @@ fn observe_storage(inout out: metric.Metric, borrow database: model.Database) {
     while i < database.rows.len() {
         metric.observe(inout out, row_projection(borrow database, i), (i % 7) + 1);
         metric.warn(inout out, database.rows.get_or(i, model.empty_row()).table >= database.tables.len());
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.cells.len() {
         metric.observe(inout out, cell_projection(borrow database, i), (i % 11) + 1);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -111,22 +111,22 @@ fn observe_operations(inout out: metric.Metric, borrow database: model.Database)
     let mut i: u64 = 0;
     while i < database.queries.len() {
         metric.observe(inout out, query_projection(borrow database, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.transactions.len() {
         metric.observe(inout out, transaction_projection(borrow database, i), i + 2);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.wal.len() {
         metric.observe(inout out, wal_projection(borrow database, i), i + 3);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.replicas.len() {
         metric.observe(inout out, replica_projection(borrow database, i), i + 4);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -141,9 +141,9 @@ fn observe_pairs(inout out: metric.Metric, borrow database: model.Database) {
                 metric.observe(inout out,
                     (table.row_count + 1) * (index.entries + 1) + MODE(), t + x + 1);
             }
-            x = x + 1;
+            x += 1;
         }
-        t = t + 1;
+        t += 1;
     }
 }
 

--- a/examples/meridian/analysis_transaction_deadlock_risk.rue
+++ b/examples/meridian/analysis_transaction_deadlock_risk.rue
@@ -77,19 +77,19 @@ fn observe_catalog(inout out: metric.Metric, borrow database: model.Database) {
     let mut i: u64 = 0;
     while i < database.tables.len() {
         metric.observe(inout out, table_projection(borrow database, i), i + MODE());
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.columns.len() {
         metric.observe(inout out, column_projection(borrow database, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.indexes.len() {
         let item = database.indexes.get_or(i, model.empty_index());
         metric.observe(inout out, item.entries + item.column + MODE(), if item.unique { 5 } else { 2 });
         metric.warn(inout out, item.table >= database.tables.len());
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -98,12 +98,12 @@ fn observe_storage(inout out: metric.Metric, borrow database: model.Database) {
     while i < database.rows.len() {
         metric.observe(inout out, row_projection(borrow database, i), (i % 7) + 1);
         metric.warn(inout out, database.rows.get_or(i, model.empty_row()).table >= database.tables.len());
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.cells.len() {
         metric.observe(inout out, cell_projection(borrow database, i), (i % 11) + 1);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -111,22 +111,22 @@ fn observe_operations(inout out: metric.Metric, borrow database: model.Database)
     let mut i: u64 = 0;
     while i < database.queries.len() {
         metric.observe(inout out, query_projection(borrow database, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.transactions.len() {
         metric.observe(inout out, transaction_projection(borrow database, i), i + 2);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.wal.len() {
         metric.observe(inout out, wal_projection(borrow database, i), i + 3);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.replicas.len() {
         metric.observe(inout out, replica_projection(borrow database, i), i + 4);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -141,9 +141,9 @@ fn observe_pairs(inout out: metric.Metric, borrow database: model.Database) {
                 metric.observe(inout out,
                     (table.row_count + 1) * (index.entries + 1) + MODE(), t + x + 1);
             }
-            x = x + 1;
+            x += 1;
         }
-        t = t + 1;
+        t += 1;
     }
 }
 

--- a/examples/meridian/analysis_transaction_durability_gap.rue
+++ b/examples/meridian/analysis_transaction_durability_gap.rue
@@ -77,19 +77,19 @@ fn observe_catalog(inout out: metric.Metric, borrow database: model.Database) {
     let mut i: u64 = 0;
     while i < database.tables.len() {
         metric.observe(inout out, table_projection(borrow database, i), i + MODE());
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.columns.len() {
         metric.observe(inout out, column_projection(borrow database, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.indexes.len() {
         let item = database.indexes.get_or(i, model.empty_index());
         metric.observe(inout out, item.entries + item.column + MODE(), if item.unique { 5 } else { 2 });
         metric.warn(inout out, item.table >= database.tables.len());
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -98,12 +98,12 @@ fn observe_storage(inout out: metric.Metric, borrow database: model.Database) {
     while i < database.rows.len() {
         metric.observe(inout out, row_projection(borrow database, i), (i % 7) + 1);
         metric.warn(inout out, database.rows.get_or(i, model.empty_row()).table >= database.tables.len());
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.cells.len() {
         metric.observe(inout out, cell_projection(borrow database, i), (i % 11) + 1);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -111,22 +111,22 @@ fn observe_operations(inout out: metric.Metric, borrow database: model.Database)
     let mut i: u64 = 0;
     while i < database.queries.len() {
         metric.observe(inout out, query_projection(borrow database, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.transactions.len() {
         metric.observe(inout out, transaction_projection(borrow database, i), i + 2);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.wal.len() {
         metric.observe(inout out, wal_projection(borrow database, i), i + 3);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.replicas.len() {
         metric.observe(inout out, replica_projection(borrow database, i), i + 4);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -141,9 +141,9 @@ fn observe_pairs(inout out: metric.Metric, borrow database: model.Database) {
                 metric.observe(inout out,
                     (table.row_count + 1) * (index.entries + 1) + MODE(), t + x + 1);
             }
-            x = x + 1;
+            x += 1;
         }
-        t = t + 1;
+        t += 1;
     }
 }
 

--- a/examples/meridian/analysis_transaction_isolation_gap.rue
+++ b/examples/meridian/analysis_transaction_isolation_gap.rue
@@ -77,19 +77,19 @@ fn observe_catalog(inout out: metric.Metric, borrow database: model.Database) {
     let mut i: u64 = 0;
     while i < database.tables.len() {
         metric.observe(inout out, table_projection(borrow database, i), i + MODE());
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.columns.len() {
         metric.observe(inout out, column_projection(borrow database, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.indexes.len() {
         let item = database.indexes.get_or(i, model.empty_index());
         metric.observe(inout out, item.entries + item.column + MODE(), if item.unique { 5 } else { 2 });
         metric.warn(inout out, item.table >= database.tables.len());
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -98,12 +98,12 @@ fn observe_storage(inout out: metric.Metric, borrow database: model.Database) {
     while i < database.rows.len() {
         metric.observe(inout out, row_projection(borrow database, i), (i % 7) + 1);
         metric.warn(inout out, database.rows.get_or(i, model.empty_row()).table >= database.tables.len());
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.cells.len() {
         metric.observe(inout out, cell_projection(borrow database, i), (i % 11) + 1);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -111,22 +111,22 @@ fn observe_operations(inout out: metric.Metric, borrow database: model.Database)
     let mut i: u64 = 0;
     while i < database.queries.len() {
         metric.observe(inout out, query_projection(borrow database, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.transactions.len() {
         metric.observe(inout out, transaction_projection(borrow database, i), i + 2);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.wal.len() {
         metric.observe(inout out, wal_projection(borrow database, i), i + 3);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.replicas.len() {
         metric.observe(inout out, replica_projection(borrow database, i), i + 4);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -141,9 +141,9 @@ fn observe_pairs(inout out: metric.Metric, borrow database: model.Database) {
                 metric.observe(inout out,
                     (table.row_count + 1) * (index.entries + 1) + MODE(), t + x + 1);
             }
-            x = x + 1;
+            x += 1;
         }
-        t = t + 1;
+        t += 1;
     }
 }
 

--- a/examples/meridian/analysis_transaction_lock_pressure.rue
+++ b/examples/meridian/analysis_transaction_lock_pressure.rue
@@ -77,19 +77,19 @@ fn observe_catalog(inout out: metric.Metric, borrow database: model.Database) {
     let mut i: u64 = 0;
     while i < database.tables.len() {
         metric.observe(inout out, table_projection(borrow database, i), i + MODE());
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.columns.len() {
         metric.observe(inout out, column_projection(borrow database, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.indexes.len() {
         let item = database.indexes.get_or(i, model.empty_index());
         metric.observe(inout out, item.entries + item.column + MODE(), if item.unique { 5 } else { 2 });
         metric.warn(inout out, item.table >= database.tables.len());
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -98,12 +98,12 @@ fn observe_storage(inout out: metric.Metric, borrow database: model.Database) {
     while i < database.rows.len() {
         metric.observe(inout out, row_projection(borrow database, i), (i % 7) + 1);
         metric.warn(inout out, database.rows.get_or(i, model.empty_row()).table >= database.tables.len());
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.cells.len() {
         metric.observe(inout out, cell_projection(borrow database, i), (i % 11) + 1);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -111,22 +111,22 @@ fn observe_operations(inout out: metric.Metric, borrow database: model.Database)
     let mut i: u64 = 0;
     while i < database.queries.len() {
         metric.observe(inout out, query_projection(borrow database, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.transactions.len() {
         metric.observe(inout out, transaction_projection(borrow database, i), i + 2);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.wal.len() {
         metric.observe(inout out, wal_projection(borrow database, i), i + 3);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.replicas.len() {
         metric.observe(inout out, replica_projection(borrow database, i), i + 4);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -141,9 +141,9 @@ fn observe_pairs(inout out: metric.Metric, borrow database: model.Database) {
                 metric.observe(inout out,
                     (table.row_count + 1) * (index.entries + 1) + MODE(), t + x + 1);
             }
-            x = x + 1;
+            x += 1;
         }
-        t = t + 1;
+        t += 1;
     }
 }
 

--- a/examples/meridian/analysis_transaction_long_runner.rue
+++ b/examples/meridian/analysis_transaction_long_runner.rue
@@ -77,19 +77,19 @@ fn observe_catalog(inout out: metric.Metric, borrow database: model.Database) {
     let mut i: u64 = 0;
     while i < database.tables.len() {
         metric.observe(inout out, table_projection(borrow database, i), i + MODE());
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.columns.len() {
         metric.observe(inout out, column_projection(borrow database, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.indexes.len() {
         let item = database.indexes.get_or(i, model.empty_index());
         metric.observe(inout out, item.entries + item.column + MODE(), if item.unique { 5 } else { 2 });
         metric.warn(inout out, item.table >= database.tables.len());
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -98,12 +98,12 @@ fn observe_storage(inout out: metric.Metric, borrow database: model.Database) {
     while i < database.rows.len() {
         metric.observe(inout out, row_projection(borrow database, i), (i % 7) + 1);
         metric.warn(inout out, database.rows.get_or(i, model.empty_row()).table >= database.tables.len());
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.cells.len() {
         metric.observe(inout out, cell_projection(borrow database, i), (i % 11) + 1);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -111,22 +111,22 @@ fn observe_operations(inout out: metric.Metric, borrow database: model.Database)
     let mut i: u64 = 0;
     while i < database.queries.len() {
         metric.observe(inout out, query_projection(borrow database, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.transactions.len() {
         metric.observe(inout out, transaction_projection(borrow database, i), i + 2);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.wal.len() {
         metric.observe(inout out, wal_projection(borrow database, i), i + 3);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.replicas.len() {
         metric.observe(inout out, replica_projection(borrow database, i), i + 4);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -141,9 +141,9 @@ fn observe_pairs(inout out: metric.Metric, borrow database: model.Database) {
                 metric.observe(inout out,
                     (table.row_count + 1) * (index.entries + 1) + MODE(), t + x + 1);
             }
-            x = x + 1;
+            x += 1;
         }
-        t = t + 1;
+        t += 1;
     }
 }
 

--- a/examples/meridian/analysis_transaction_read_set_size.rue
+++ b/examples/meridian/analysis_transaction_read_set_size.rue
@@ -77,19 +77,19 @@ fn observe_catalog(inout out: metric.Metric, borrow database: model.Database) {
     let mut i: u64 = 0;
     while i < database.tables.len() {
         metric.observe(inout out, table_projection(borrow database, i), i + MODE());
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.columns.len() {
         metric.observe(inout out, column_projection(borrow database, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.indexes.len() {
         let item = database.indexes.get_or(i, model.empty_index());
         metric.observe(inout out, item.entries + item.column + MODE(), if item.unique { 5 } else { 2 });
         metric.warn(inout out, item.table >= database.tables.len());
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -98,12 +98,12 @@ fn observe_storage(inout out: metric.Metric, borrow database: model.Database) {
     while i < database.rows.len() {
         metric.observe(inout out, row_projection(borrow database, i), (i % 7) + 1);
         metric.warn(inout out, database.rows.get_or(i, model.empty_row()).table >= database.tables.len());
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.cells.len() {
         metric.observe(inout out, cell_projection(borrow database, i), (i % 11) + 1);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -111,22 +111,22 @@ fn observe_operations(inout out: metric.Metric, borrow database: model.Database)
     let mut i: u64 = 0;
     while i < database.queries.len() {
         metric.observe(inout out, query_projection(borrow database, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.transactions.len() {
         metric.observe(inout out, transaction_projection(borrow database, i), i + 2);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.wal.len() {
         metric.observe(inout out, wal_projection(borrow database, i), i + 3);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.replicas.len() {
         metric.observe(inout out, replica_projection(borrow database, i), i + 4);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -141,9 +141,9 @@ fn observe_pairs(inout out: metric.Metric, borrow database: model.Database) {
                 metric.observe(inout out,
                     (table.row_count + 1) * (index.entries + 1) + MODE(), t + x + 1);
             }
-            x = x + 1;
+            x += 1;
         }
-        t = t + 1;
+        t += 1;
     }
 }
 

--- a/examples/meridian/analysis_transaction_read_write_ratio.rue
+++ b/examples/meridian/analysis_transaction_read_write_ratio.rue
@@ -77,19 +77,19 @@ fn observe_catalog(inout out: metric.Metric, borrow database: model.Database) {
     let mut i: u64 = 0;
     while i < database.tables.len() {
         metric.observe(inout out, table_projection(borrow database, i), i + MODE());
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.columns.len() {
         metric.observe(inout out, column_projection(borrow database, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.indexes.len() {
         let item = database.indexes.get_or(i, model.empty_index());
         metric.observe(inout out, item.entries + item.column + MODE(), if item.unique { 5 } else { 2 });
         metric.warn(inout out, item.table >= database.tables.len());
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -98,12 +98,12 @@ fn observe_storage(inout out: metric.Metric, borrow database: model.Database) {
     while i < database.rows.len() {
         metric.observe(inout out, row_projection(borrow database, i), (i % 7) + 1);
         metric.warn(inout out, database.rows.get_or(i, model.empty_row()).table >= database.tables.len());
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.cells.len() {
         metric.observe(inout out, cell_projection(borrow database, i), (i % 11) + 1);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -111,22 +111,22 @@ fn observe_operations(inout out: metric.Metric, borrow database: model.Database)
     let mut i: u64 = 0;
     while i < database.queries.len() {
         metric.observe(inout out, query_projection(borrow database, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.transactions.len() {
         metric.observe(inout out, transaction_projection(borrow database, i), i + 2);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.wal.len() {
         metric.observe(inout out, wal_projection(borrow database, i), i + 3);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.replicas.len() {
         metric.observe(inout out, replica_projection(borrow database, i), i + 4);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -141,9 +141,9 @@ fn observe_pairs(inout out: metric.Metric, borrow database: model.Database) {
                 metric.observe(inout out,
                     (table.row_count + 1) * (index.entries + 1) + MODE(), t + x + 1);
             }
-            x = x + 1;
+            x += 1;
         }
-        t = t + 1;
+        t += 1;
     }
 }
 

--- a/examples/meridian/analysis_transaction_retry_cost.rue
+++ b/examples/meridian/analysis_transaction_retry_cost.rue
@@ -77,19 +77,19 @@ fn observe_catalog(inout out: metric.Metric, borrow database: model.Database) {
     let mut i: u64 = 0;
     while i < database.tables.len() {
         metric.observe(inout out, table_projection(borrow database, i), i + MODE());
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.columns.len() {
         metric.observe(inout out, column_projection(borrow database, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.indexes.len() {
         let item = database.indexes.get_or(i, model.empty_index());
         metric.observe(inout out, item.entries + item.column + MODE(), if item.unique { 5 } else { 2 });
         metric.warn(inout out, item.table >= database.tables.len());
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -98,12 +98,12 @@ fn observe_storage(inout out: metric.Metric, borrow database: model.Database) {
     while i < database.rows.len() {
         metric.observe(inout out, row_projection(borrow database, i), (i % 7) + 1);
         metric.warn(inout out, database.rows.get_or(i, model.empty_row()).table >= database.tables.len());
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.cells.len() {
         metric.observe(inout out, cell_projection(borrow database, i), (i % 11) + 1);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -111,22 +111,22 @@ fn observe_operations(inout out: metric.Metric, borrow database: model.Database)
     let mut i: u64 = 0;
     while i < database.queries.len() {
         metric.observe(inout out, query_projection(borrow database, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.transactions.len() {
         metric.observe(inout out, transaction_projection(borrow database, i), i + 2);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.wal.len() {
         metric.observe(inout out, wal_projection(borrow database, i), i + 3);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.replicas.len() {
         metric.observe(inout out, replica_projection(borrow database, i), i + 4);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -141,9 +141,9 @@ fn observe_pairs(inout out: metric.Metric, borrow database: model.Database) {
                 metric.observe(inout out,
                     (table.row_count + 1) * (index.entries + 1) + MODE(), t + x + 1);
             }
-            x = x + 1;
+            x += 1;
         }
-        t = t + 1;
+        t += 1;
     }
 }
 

--- a/examples/meridian/analysis_transaction_rollback_ratio.rue
+++ b/examples/meridian/analysis_transaction_rollback_ratio.rue
@@ -77,19 +77,19 @@ fn observe_catalog(inout out: metric.Metric, borrow database: model.Database) {
     let mut i: u64 = 0;
     while i < database.tables.len() {
         metric.observe(inout out, table_projection(borrow database, i), i + MODE());
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.columns.len() {
         metric.observe(inout out, column_projection(borrow database, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.indexes.len() {
         let item = database.indexes.get_or(i, model.empty_index());
         metric.observe(inout out, item.entries + item.column + MODE(), if item.unique { 5 } else { 2 });
         metric.warn(inout out, item.table >= database.tables.len());
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -98,12 +98,12 @@ fn observe_storage(inout out: metric.Metric, borrow database: model.Database) {
     while i < database.rows.len() {
         metric.observe(inout out, row_projection(borrow database, i), (i % 7) + 1);
         metric.warn(inout out, database.rows.get_or(i, model.empty_row()).table >= database.tables.len());
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.cells.len() {
         metric.observe(inout out, cell_projection(borrow database, i), (i % 11) + 1);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -111,22 +111,22 @@ fn observe_operations(inout out: metric.Metric, borrow database: model.Database)
     let mut i: u64 = 0;
     while i < database.queries.len() {
         metric.observe(inout out, query_projection(borrow database, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.transactions.len() {
         metric.observe(inout out, transaction_projection(borrow database, i), i + 2);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.wal.len() {
         metric.observe(inout out, wal_projection(borrow database, i), i + 3);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.replicas.len() {
         metric.observe(inout out, replica_projection(borrow database, i), i + 4);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -141,9 +141,9 @@ fn observe_pairs(inout out: metric.Metric, borrow database: model.Database) {
                 metric.observe(inout out,
                     (table.row_count + 1) * (index.entries + 1) + MODE(), t + x + 1);
             }
-            x = x + 1;
+            x += 1;
         }
-        t = t + 1;
+        t += 1;
     }
 }
 

--- a/examples/meridian/analysis_transaction_snapshot_age.rue
+++ b/examples/meridian/analysis_transaction_snapshot_age.rue
@@ -77,19 +77,19 @@ fn observe_catalog(inout out: metric.Metric, borrow database: model.Database) {
     let mut i: u64 = 0;
     while i < database.tables.len() {
         metric.observe(inout out, table_projection(borrow database, i), i + MODE());
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.columns.len() {
         metric.observe(inout out, column_projection(borrow database, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.indexes.len() {
         let item = database.indexes.get_or(i, model.empty_index());
         metric.observe(inout out, item.entries + item.column + MODE(), if item.unique { 5 } else { 2 });
         metric.warn(inout out, item.table >= database.tables.len());
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -98,12 +98,12 @@ fn observe_storage(inout out: metric.Metric, borrow database: model.Database) {
     while i < database.rows.len() {
         metric.observe(inout out, row_projection(borrow database, i), (i % 7) + 1);
         metric.warn(inout out, database.rows.get_or(i, model.empty_row()).table >= database.tables.len());
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.cells.len() {
         metric.observe(inout out, cell_projection(borrow database, i), (i % 11) + 1);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -111,22 +111,22 @@ fn observe_operations(inout out: metric.Metric, borrow database: model.Database)
     let mut i: u64 = 0;
     while i < database.queries.len() {
         metric.observe(inout out, query_projection(borrow database, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.transactions.len() {
         metric.observe(inout out, transaction_projection(borrow database, i), i + 2);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.wal.len() {
         metric.observe(inout out, wal_projection(borrow database, i), i + 3);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.replicas.len() {
         metric.observe(inout out, replica_projection(borrow database, i), i + 4);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -141,9 +141,9 @@ fn observe_pairs(inout out: metric.Metric, borrow database: model.Database) {
                 metric.observe(inout out,
                     (table.row_count + 1) * (index.entries + 1) + MODE(), t + x + 1);
             }
-            x = x + 1;
+            x += 1;
         }
-        t = t + 1;
+        t += 1;
     }
 }
 

--- a/examples/meridian/analysis_transaction_version_churn.rue
+++ b/examples/meridian/analysis_transaction_version_churn.rue
@@ -77,19 +77,19 @@ fn observe_catalog(inout out: metric.Metric, borrow database: model.Database) {
     let mut i: u64 = 0;
     while i < database.tables.len() {
         metric.observe(inout out, table_projection(borrow database, i), i + MODE());
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.columns.len() {
         metric.observe(inout out, column_projection(borrow database, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.indexes.len() {
         let item = database.indexes.get_or(i, model.empty_index());
         metric.observe(inout out, item.entries + item.column + MODE(), if item.unique { 5 } else { 2 });
         metric.warn(inout out, item.table >= database.tables.len());
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -98,12 +98,12 @@ fn observe_storage(inout out: metric.Metric, borrow database: model.Database) {
     while i < database.rows.len() {
         metric.observe(inout out, row_projection(borrow database, i), (i % 7) + 1);
         metric.warn(inout out, database.rows.get_or(i, model.empty_row()).table >= database.tables.len());
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.cells.len() {
         metric.observe(inout out, cell_projection(borrow database, i), (i % 11) + 1);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -111,22 +111,22 @@ fn observe_operations(inout out: metric.Metric, borrow database: model.Database)
     let mut i: u64 = 0;
     while i < database.queries.len() {
         metric.observe(inout out, query_projection(borrow database, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.transactions.len() {
         metric.observe(inout out, transaction_projection(borrow database, i), i + 2);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.wal.len() {
         metric.observe(inout out, wal_projection(borrow database, i), i + 3);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.replicas.len() {
         metric.observe(inout out, replica_projection(borrow database, i), i + 4);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -141,9 +141,9 @@ fn observe_pairs(inout out: metric.Metric, borrow database: model.Database) {
                 metric.observe(inout out,
                     (table.row_count + 1) * (index.entries + 1) + MODE(), t + x + 1);
             }
-            x = x + 1;
+            x += 1;
         }
-        t = t + 1;
+        t += 1;
     }
 }
 

--- a/examples/meridian/analysis_transaction_write_set_size.rue
+++ b/examples/meridian/analysis_transaction_write_set_size.rue
@@ -77,19 +77,19 @@ fn observe_catalog(inout out: metric.Metric, borrow database: model.Database) {
     let mut i: u64 = 0;
     while i < database.tables.len() {
         metric.observe(inout out, table_projection(borrow database, i), i + MODE());
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.columns.len() {
         metric.observe(inout out, column_projection(borrow database, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.indexes.len() {
         let item = database.indexes.get_or(i, model.empty_index());
         metric.observe(inout out, item.entries + item.column + MODE(), if item.unique { 5 } else { 2 });
         metric.warn(inout out, item.table >= database.tables.len());
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -98,12 +98,12 @@ fn observe_storage(inout out: metric.Metric, borrow database: model.Database) {
     while i < database.rows.len() {
         metric.observe(inout out, row_projection(borrow database, i), (i % 7) + 1);
         metric.warn(inout out, database.rows.get_or(i, model.empty_row()).table >= database.tables.len());
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.cells.len() {
         metric.observe(inout out, cell_projection(borrow database, i), (i % 11) + 1);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -111,22 +111,22 @@ fn observe_operations(inout out: metric.Metric, borrow database: model.Database)
     let mut i: u64 = 0;
     while i < database.queries.len() {
         metric.observe(inout out, query_projection(borrow database, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.transactions.len() {
         metric.observe(inout out, transaction_projection(borrow database, i), i + 2);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.wal.len() {
         metric.observe(inout out, wal_projection(borrow database, i), i + 3);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.replicas.len() {
         metric.observe(inout out, replica_projection(borrow database, i), i + 4);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -141,9 +141,9 @@ fn observe_pairs(inout out: metric.Metric, borrow database: model.Database) {
                 metric.observe(inout out,
                     (table.row_count + 1) * (index.entries + 1) + MODE(), t + x + 1);
             }
-            x = x + 1;
+            x += 1;
         }
-        t = t + 1;
+        t += 1;
     }
 }
 

--- a/examples/meridian/analysis_wal_checkpoint_distance.rue
+++ b/examples/meridian/analysis_wal_checkpoint_distance.rue
@@ -77,19 +77,19 @@ fn observe_catalog(inout out: metric.Metric, borrow database: model.Database) {
     let mut i: u64 = 0;
     while i < database.tables.len() {
         metric.observe(inout out, table_projection(borrow database, i), i + MODE());
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.columns.len() {
         metric.observe(inout out, column_projection(borrow database, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.indexes.len() {
         let item = database.indexes.get_or(i, model.empty_index());
         metric.observe(inout out, item.entries + item.column + MODE(), if item.unique { 5 } else { 2 });
         metric.warn(inout out, item.table >= database.tables.len());
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -98,12 +98,12 @@ fn observe_storage(inout out: metric.Metric, borrow database: model.Database) {
     while i < database.rows.len() {
         metric.observe(inout out, row_projection(borrow database, i), (i % 7) + 1);
         metric.warn(inout out, database.rows.get_or(i, model.empty_row()).table >= database.tables.len());
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.cells.len() {
         metric.observe(inout out, cell_projection(borrow database, i), (i % 11) + 1);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -111,22 +111,22 @@ fn observe_operations(inout out: metric.Metric, borrow database: model.Database)
     let mut i: u64 = 0;
     while i < database.queries.len() {
         metric.observe(inout out, query_projection(borrow database, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.transactions.len() {
         metric.observe(inout out, transaction_projection(borrow database, i), i + 2);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.wal.len() {
         metric.observe(inout out, wal_projection(borrow database, i), i + 3);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.replicas.len() {
         metric.observe(inout out, replica_projection(borrow database, i), i + 4);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -141,9 +141,9 @@ fn observe_pairs(inout out: metric.Metric, borrow database: model.Database) {
                 metric.observe(inout out,
                     (table.row_count + 1) * (index.entries + 1) + MODE(), t + x + 1);
             }
-            x = x + 1;
+            x += 1;
         }
-        t = t + 1;
+        t += 1;
     }
 }
 

--- a/examples/meridian/analysis_wal_commit_coverage.rue
+++ b/examples/meridian/analysis_wal_commit_coverage.rue
@@ -77,19 +77,19 @@ fn observe_catalog(inout out: metric.Metric, borrow database: model.Database) {
     let mut i: u64 = 0;
     while i < database.tables.len() {
         metric.observe(inout out, table_projection(borrow database, i), i + MODE());
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.columns.len() {
         metric.observe(inout out, column_projection(borrow database, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.indexes.len() {
         let item = database.indexes.get_or(i, model.empty_index());
         metric.observe(inout out, item.entries + item.column + MODE(), if item.unique { 5 } else { 2 });
         metric.warn(inout out, item.table >= database.tables.len());
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -98,12 +98,12 @@ fn observe_storage(inout out: metric.Metric, borrow database: model.Database) {
     while i < database.rows.len() {
         metric.observe(inout out, row_projection(borrow database, i), (i % 7) + 1);
         metric.warn(inout out, database.rows.get_or(i, model.empty_row()).table >= database.tables.len());
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.cells.len() {
         metric.observe(inout out, cell_projection(borrow database, i), (i % 11) + 1);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -111,22 +111,22 @@ fn observe_operations(inout out: metric.Metric, borrow database: model.Database)
     let mut i: u64 = 0;
     while i < database.queries.len() {
         metric.observe(inout out, query_projection(borrow database, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.transactions.len() {
         metric.observe(inout out, transaction_projection(borrow database, i), i + 2);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.wal.len() {
         metric.observe(inout out, wal_projection(borrow database, i), i + 3);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.replicas.len() {
         metric.observe(inout out, replica_projection(borrow database, i), i + 4);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -141,9 +141,9 @@ fn observe_pairs(inout out: metric.Metric, borrow database: model.Database) {
                 metric.observe(inout out,
                     (table.row_count + 1) * (index.entries + 1) + MODE(), t + x + 1);
             }
-            x = x + 1;
+            x += 1;
         }
-        t = t + 1;
+        t += 1;
     }
 }
 

--- a/examples/meridian/analysis_wal_flush_pressure.rue
+++ b/examples/meridian/analysis_wal_flush_pressure.rue
@@ -77,19 +77,19 @@ fn observe_catalog(inout out: metric.Metric, borrow database: model.Database) {
     let mut i: u64 = 0;
     while i < database.tables.len() {
         metric.observe(inout out, table_projection(borrow database, i), i + MODE());
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.columns.len() {
         metric.observe(inout out, column_projection(borrow database, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.indexes.len() {
         let item = database.indexes.get_or(i, model.empty_index());
         metric.observe(inout out, item.entries + item.column + MODE(), if item.unique { 5 } else { 2 });
         metric.warn(inout out, item.table >= database.tables.len());
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -98,12 +98,12 @@ fn observe_storage(inout out: metric.Metric, borrow database: model.Database) {
     while i < database.rows.len() {
         metric.observe(inout out, row_projection(borrow database, i), (i % 7) + 1);
         metric.warn(inout out, database.rows.get_or(i, model.empty_row()).table >= database.tables.len());
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.cells.len() {
         metric.observe(inout out, cell_projection(borrow database, i), (i % 11) + 1);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -111,22 +111,22 @@ fn observe_operations(inout out: metric.Metric, borrow database: model.Database)
     let mut i: u64 = 0;
     while i < database.queries.len() {
         metric.observe(inout out, query_projection(borrow database, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.transactions.len() {
         metric.observe(inout out, transaction_projection(borrow database, i), i + 2);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.wal.len() {
         metric.observe(inout out, wal_projection(borrow database, i), i + 3);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.replicas.len() {
         metric.observe(inout out, replica_projection(borrow database, i), i + 4);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -141,9 +141,9 @@ fn observe_pairs(inout out: metric.Metric, borrow database: model.Database) {
                 metric.observe(inout out,
                     (table.row_count + 1) * (index.entries + 1) + MODE(), t + x + 1);
             }
-            x = x + 1;
+            x += 1;
         }
-        t = t + 1;
+        t += 1;
     }
 }
 

--- a/examples/meridian/analysis_wal_group_commit_gain.rue
+++ b/examples/meridian/analysis_wal_group_commit_gain.rue
@@ -77,19 +77,19 @@ fn observe_catalog(inout out: metric.Metric, borrow database: model.Database) {
     let mut i: u64 = 0;
     while i < database.tables.len() {
         metric.observe(inout out, table_projection(borrow database, i), i + MODE());
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.columns.len() {
         metric.observe(inout out, column_projection(borrow database, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.indexes.len() {
         let item = database.indexes.get_or(i, model.empty_index());
         metric.observe(inout out, item.entries + item.column + MODE(), if item.unique { 5 } else { 2 });
         metric.warn(inout out, item.table >= database.tables.len());
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -98,12 +98,12 @@ fn observe_storage(inout out: metric.Metric, borrow database: model.Database) {
     while i < database.rows.len() {
         metric.observe(inout out, row_projection(borrow database, i), (i % 7) + 1);
         metric.warn(inout out, database.rows.get_or(i, model.empty_row()).table >= database.tables.len());
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.cells.len() {
         metric.observe(inout out, cell_projection(borrow database, i), (i % 11) + 1);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -111,22 +111,22 @@ fn observe_operations(inout out: metric.Metric, borrow database: model.Database)
     let mut i: u64 = 0;
     while i < database.queries.len() {
         metric.observe(inout out, query_projection(borrow database, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.transactions.len() {
         metric.observe(inout out, transaction_projection(borrow database, i), i + 2);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.wal.len() {
         metric.observe(inout out, wal_projection(borrow database, i), i + 3);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.replicas.len() {
         metric.observe(inout out, replica_projection(borrow database, i), i + 4);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -141,9 +141,9 @@ fn observe_pairs(inout out: metric.Metric, borrow database: model.Database) {
                 metric.observe(inout out,
                     (table.row_count + 1) * (index.entries + 1) + MODE(), t + x + 1);
             }
-            x = x + 1;
+            x += 1;
         }
-        t = t + 1;
+        t += 1;
     }
 }
 

--- a/examples/meridian/analysis_wal_integrity.rue
+++ b/examples/meridian/analysis_wal_integrity.rue
@@ -77,19 +77,19 @@ fn observe_catalog(inout out: metric.Metric, borrow database: model.Database) {
     let mut i: u64 = 0;
     while i < database.tables.len() {
         metric.observe(inout out, table_projection(borrow database, i), i + MODE());
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.columns.len() {
         metric.observe(inout out, column_projection(borrow database, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.indexes.len() {
         let item = database.indexes.get_or(i, model.empty_index());
         metric.observe(inout out, item.entries + item.column + MODE(), if item.unique { 5 } else { 2 });
         metric.warn(inout out, item.table >= database.tables.len());
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -98,12 +98,12 @@ fn observe_storage(inout out: metric.Metric, borrow database: model.Database) {
     while i < database.rows.len() {
         metric.observe(inout out, row_projection(borrow database, i), (i % 7) + 1);
         metric.warn(inout out, database.rows.get_or(i, model.empty_row()).table >= database.tables.len());
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.cells.len() {
         metric.observe(inout out, cell_projection(borrow database, i), (i % 11) + 1);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -111,22 +111,22 @@ fn observe_operations(inout out: metric.Metric, borrow database: model.Database)
     let mut i: u64 = 0;
     while i < database.queries.len() {
         metric.observe(inout out, query_projection(borrow database, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.transactions.len() {
         metric.observe(inout out, transaction_projection(borrow database, i), i + 2);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.wal.len() {
         metric.observe(inout out, wal_projection(borrow database, i), i + 3);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.replicas.len() {
         metric.observe(inout out, replica_projection(borrow database, i), i + 4);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -141,9 +141,9 @@ fn observe_pairs(inout out: metric.Metric, borrow database: model.Database) {
                 metric.observe(inout out,
                     (table.row_count + 1) * (index.entries + 1) + MODE(), t + x + 1);
             }
-            x = x + 1;
+            x += 1;
         }
-        t = t + 1;
+        t += 1;
     }
 }
 

--- a/examples/meridian/analysis_wal_lsn_continuity.rue
+++ b/examples/meridian/analysis_wal_lsn_continuity.rue
@@ -77,19 +77,19 @@ fn observe_catalog(inout out: metric.Metric, borrow database: model.Database) {
     let mut i: u64 = 0;
     while i < database.tables.len() {
         metric.observe(inout out, table_projection(borrow database, i), i + MODE());
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.columns.len() {
         metric.observe(inout out, column_projection(borrow database, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.indexes.len() {
         let item = database.indexes.get_or(i, model.empty_index());
         metric.observe(inout out, item.entries + item.column + MODE(), if item.unique { 5 } else { 2 });
         metric.warn(inout out, item.table >= database.tables.len());
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -98,12 +98,12 @@ fn observe_storage(inout out: metric.Metric, borrow database: model.Database) {
     while i < database.rows.len() {
         metric.observe(inout out, row_projection(borrow database, i), (i % 7) + 1);
         metric.warn(inout out, database.rows.get_or(i, model.empty_row()).table >= database.tables.len());
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.cells.len() {
         metric.observe(inout out, cell_projection(borrow database, i), (i % 11) + 1);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -111,22 +111,22 @@ fn observe_operations(inout out: metric.Metric, borrow database: model.Database)
     let mut i: u64 = 0;
     while i < database.queries.len() {
         metric.observe(inout out, query_projection(borrow database, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.transactions.len() {
         metric.observe(inout out, transaction_projection(borrow database, i), i + 2);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.wal.len() {
         metric.observe(inout out, wal_projection(borrow database, i), i + 3);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.replicas.len() {
         metric.observe(inout out, replica_projection(borrow database, i), i + 4);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -141,9 +141,9 @@ fn observe_pairs(inout out: metric.Metric, borrow database: model.Database) {
                 metric.observe(inout out,
                     (table.row_count + 1) * (index.entries + 1) + MODE(), t + x + 1);
             }
-            x = x + 1;
+            x += 1;
         }
-        t = t + 1;
+        t += 1;
     }
 }
 

--- a/examples/meridian/analysis_wal_payload_delta.rue
+++ b/examples/meridian/analysis_wal_payload_delta.rue
@@ -77,19 +77,19 @@ fn observe_catalog(inout out: metric.Metric, borrow database: model.Database) {
     let mut i: u64 = 0;
     while i < database.tables.len() {
         metric.observe(inout out, table_projection(borrow database, i), i + MODE());
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.columns.len() {
         metric.observe(inout out, column_projection(borrow database, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.indexes.len() {
         let item = database.indexes.get_or(i, model.empty_index());
         metric.observe(inout out, item.entries + item.column + MODE(), if item.unique { 5 } else { 2 });
         metric.warn(inout out, item.table >= database.tables.len());
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -98,12 +98,12 @@ fn observe_storage(inout out: metric.Metric, borrow database: model.Database) {
     while i < database.rows.len() {
         metric.observe(inout out, row_projection(borrow database, i), (i % 7) + 1);
         metric.warn(inout out, database.rows.get_or(i, model.empty_row()).table >= database.tables.len());
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.cells.len() {
         metric.observe(inout out, cell_projection(borrow database, i), (i % 11) + 1);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -111,22 +111,22 @@ fn observe_operations(inout out: metric.Metric, borrow database: model.Database)
     let mut i: u64 = 0;
     while i < database.queries.len() {
         metric.observe(inout out, query_projection(borrow database, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.transactions.len() {
         metric.observe(inout out, transaction_projection(borrow database, i), i + 2);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.wal.len() {
         metric.observe(inout out, wal_projection(borrow database, i), i + 3);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.replicas.len() {
         metric.observe(inout out, replica_projection(borrow database, i), i + 4);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -141,9 +141,9 @@ fn observe_pairs(inout out: metric.Metric, borrow database: model.Database) {
                 metric.observe(inout out,
                     (table.row_count + 1) * (index.entries + 1) + MODE(), t + x + 1);
             }
-            x = x + 1;
+            x += 1;
         }
-        t = t + 1;
+        t += 1;
     }
 }
 

--- a/examples/meridian/analysis_wal_record_density.rue
+++ b/examples/meridian/analysis_wal_record_density.rue
@@ -77,19 +77,19 @@ fn observe_catalog(inout out: metric.Metric, borrow database: model.Database) {
     let mut i: u64 = 0;
     while i < database.tables.len() {
         metric.observe(inout out, table_projection(borrow database, i), i + MODE());
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.columns.len() {
         metric.observe(inout out, column_projection(borrow database, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.indexes.len() {
         let item = database.indexes.get_or(i, model.empty_index());
         metric.observe(inout out, item.entries + item.column + MODE(), if item.unique { 5 } else { 2 });
         metric.warn(inout out, item.table >= database.tables.len());
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -98,12 +98,12 @@ fn observe_storage(inout out: metric.Metric, borrow database: model.Database) {
     while i < database.rows.len() {
         metric.observe(inout out, row_projection(borrow database, i), (i % 7) + 1);
         metric.warn(inout out, database.rows.get_or(i, model.empty_row()).table >= database.tables.len());
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.cells.len() {
         metric.observe(inout out, cell_projection(borrow database, i), (i % 11) + 1);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -111,22 +111,22 @@ fn observe_operations(inout out: metric.Metric, borrow database: model.Database)
     let mut i: u64 = 0;
     while i < database.queries.len() {
         metric.observe(inout out, query_projection(borrow database, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.transactions.len() {
         metric.observe(inout out, transaction_projection(borrow database, i), i + 2);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.wal.len() {
         metric.observe(inout out, wal_projection(borrow database, i), i + 3);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.replicas.len() {
         metric.observe(inout out, replica_projection(borrow database, i), i + 4);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -141,9 +141,9 @@ fn observe_pairs(inout out: metric.Metric, borrow database: model.Database) {
                 metric.observe(inout out,
                     (table.row_count + 1) * (index.entries + 1) + MODE(), t + x + 1);
             }
-            x = x + 1;
+            x += 1;
         }
-        t = t + 1;
+        t += 1;
     }
 }
 

--- a/examples/meridian/analysis_wal_recovery_span.rue
+++ b/examples/meridian/analysis_wal_recovery_span.rue
@@ -77,19 +77,19 @@ fn observe_catalog(inout out: metric.Metric, borrow database: model.Database) {
     let mut i: u64 = 0;
     while i < database.tables.len() {
         metric.observe(inout out, table_projection(borrow database, i), i + MODE());
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.columns.len() {
         metric.observe(inout out, column_projection(borrow database, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.indexes.len() {
         let item = database.indexes.get_or(i, model.empty_index());
         metric.observe(inout out, item.entries + item.column + MODE(), if item.unique { 5 } else { 2 });
         metric.warn(inout out, item.table >= database.tables.len());
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -98,12 +98,12 @@ fn observe_storage(inout out: metric.Metric, borrow database: model.Database) {
     while i < database.rows.len() {
         metric.observe(inout out, row_projection(borrow database, i), (i % 7) + 1);
         metric.warn(inout out, database.rows.get_or(i, model.empty_row()).table >= database.tables.len());
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.cells.len() {
         metric.observe(inout out, cell_projection(borrow database, i), (i % 11) + 1);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -111,22 +111,22 @@ fn observe_operations(inout out: metric.Metric, borrow database: model.Database)
     let mut i: u64 = 0;
     while i < database.queries.len() {
         metric.observe(inout out, query_projection(borrow database, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.transactions.len() {
         metric.observe(inout out, transaction_projection(borrow database, i), i + 2);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.wal.len() {
         metric.observe(inout out, wal_projection(borrow database, i), i + 3);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.replicas.len() {
         metric.observe(inout out, replica_projection(borrow database, i), i + 4);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -141,9 +141,9 @@ fn observe_pairs(inout out: metric.Metric, borrow database: model.Database) {
                 metric.observe(inout out,
                     (table.row_count + 1) * (index.entries + 1) + MODE(), t + x + 1);
             }
-            x = x + 1;
+            x += 1;
         }
-        t = t + 1;
+        t += 1;
     }
 }
 

--- a/examples/meridian/analysis_wal_redo_pressure.rue
+++ b/examples/meridian/analysis_wal_redo_pressure.rue
@@ -77,19 +77,19 @@ fn observe_catalog(inout out: metric.Metric, borrow database: model.Database) {
     let mut i: u64 = 0;
     while i < database.tables.len() {
         metric.observe(inout out, table_projection(borrow database, i), i + MODE());
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.columns.len() {
         metric.observe(inout out, column_projection(borrow database, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.indexes.len() {
         let item = database.indexes.get_or(i, model.empty_index());
         metric.observe(inout out, item.entries + item.column + MODE(), if item.unique { 5 } else { 2 });
         metric.warn(inout out, item.table >= database.tables.len());
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -98,12 +98,12 @@ fn observe_storage(inout out: metric.Metric, borrow database: model.Database) {
     while i < database.rows.len() {
         metric.observe(inout out, row_projection(borrow database, i), (i % 7) + 1);
         metric.warn(inout out, database.rows.get_or(i, model.empty_row()).table >= database.tables.len());
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.cells.len() {
         metric.observe(inout out, cell_projection(borrow database, i), (i % 11) + 1);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -111,22 +111,22 @@ fn observe_operations(inout out: metric.Metric, borrow database: model.Database)
     let mut i: u64 = 0;
     while i < database.queries.len() {
         metric.observe(inout out, query_projection(borrow database, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.transactions.len() {
         metric.observe(inout out, transaction_projection(borrow database, i), i + 2);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.wal.len() {
         metric.observe(inout out, wal_projection(borrow database, i), i + 3);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.replicas.len() {
         metric.observe(inout out, replica_projection(borrow database, i), i + 4);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -141,9 +141,9 @@ fn observe_pairs(inout out: metric.Metric, borrow database: model.Database) {
                 metric.observe(inout out,
                     (table.row_count + 1) * (index.entries + 1) + MODE(), t + x + 1);
             }
-            x = x + 1;
+            x += 1;
         }
-        t = t + 1;
+        t += 1;
     }
 }
 

--- a/examples/meridian/analysis_wal_replication_volume.rue
+++ b/examples/meridian/analysis_wal_replication_volume.rue
@@ -77,19 +77,19 @@ fn observe_catalog(inout out: metric.Metric, borrow database: model.Database) {
     let mut i: u64 = 0;
     while i < database.tables.len() {
         metric.observe(inout out, table_projection(borrow database, i), i + MODE());
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.columns.len() {
         metric.observe(inout out, column_projection(borrow database, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.indexes.len() {
         let item = database.indexes.get_or(i, model.empty_index());
         metric.observe(inout out, item.entries + item.column + MODE(), if item.unique { 5 } else { 2 });
         metric.warn(inout out, item.table >= database.tables.len());
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -98,12 +98,12 @@ fn observe_storage(inout out: metric.Metric, borrow database: model.Database) {
     while i < database.rows.len() {
         metric.observe(inout out, row_projection(borrow database, i), (i % 7) + 1);
         metric.warn(inout out, database.rows.get_or(i, model.empty_row()).table >= database.tables.len());
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.cells.len() {
         metric.observe(inout out, cell_projection(borrow database, i), (i % 11) + 1);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -111,22 +111,22 @@ fn observe_operations(inout out: metric.Metric, borrow database: model.Database)
     let mut i: u64 = 0;
     while i < database.queries.len() {
         metric.observe(inout out, query_projection(borrow database, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.transactions.len() {
         metric.observe(inout out, transaction_projection(borrow database, i), i + 2);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.wal.len() {
         metric.observe(inout out, wal_projection(borrow database, i), i + 3);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.replicas.len() {
         metric.observe(inout out, replica_projection(borrow database, i), i + 4);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -141,9 +141,9 @@ fn observe_pairs(inout out: metric.Metric, borrow database: model.Database) {
                 metric.observe(inout out,
                     (table.row_count + 1) * (index.entries + 1) + MODE(), t + x + 1);
             }
-            x = x + 1;
+            x += 1;
         }
-        t = t + 1;
+        t += 1;
     }
 }
 

--- a/examples/meridian/analysis_wal_retention_cost.rue
+++ b/examples/meridian/analysis_wal_retention_cost.rue
@@ -77,19 +77,19 @@ fn observe_catalog(inout out: metric.Metric, borrow database: model.Database) {
     let mut i: u64 = 0;
     while i < database.tables.len() {
         metric.observe(inout out, table_projection(borrow database, i), i + MODE());
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.columns.len() {
         metric.observe(inout out, column_projection(borrow database, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.indexes.len() {
         let item = database.indexes.get_or(i, model.empty_index());
         metric.observe(inout out, item.entries + item.column + MODE(), if item.unique { 5 } else { 2 });
         metric.warn(inout out, item.table >= database.tables.len());
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -98,12 +98,12 @@ fn observe_storage(inout out: metric.Metric, borrow database: model.Database) {
     while i < database.rows.len() {
         metric.observe(inout out, row_projection(borrow database, i), (i % 7) + 1);
         metric.warn(inout out, database.rows.get_or(i, model.empty_row()).table >= database.tables.len());
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.cells.len() {
         metric.observe(inout out, cell_projection(borrow database, i), (i % 11) + 1);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -111,22 +111,22 @@ fn observe_operations(inout out: metric.Metric, borrow database: model.Database)
     let mut i: u64 = 0;
     while i < database.queries.len() {
         metric.observe(inout out, query_projection(borrow database, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.transactions.len() {
         metric.observe(inout out, transaction_projection(borrow database, i), i + 2);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.wal.len() {
         metric.observe(inout out, wal_projection(borrow database, i), i + 3);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.replicas.len() {
         metric.observe(inout out, replica_projection(borrow database, i), i + 4);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -141,9 +141,9 @@ fn observe_pairs(inout out: metric.Metric, borrow database: model.Database) {
                 metric.observe(inout out,
                     (table.row_count + 1) * (index.entries + 1) + MODE(), t + x + 1);
             }
-            x = x + 1;
+            x += 1;
         }
-        t = t + 1;
+        t += 1;
     }
 }
 

--- a/examples/meridian/analysis_wal_row_hotspot.rue
+++ b/examples/meridian/analysis_wal_row_hotspot.rue
@@ -77,19 +77,19 @@ fn observe_catalog(inout out: metric.Metric, borrow database: model.Database) {
     let mut i: u64 = 0;
     while i < database.tables.len() {
         metric.observe(inout out, table_projection(borrow database, i), i + MODE());
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.columns.len() {
         metric.observe(inout out, column_projection(borrow database, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.indexes.len() {
         let item = database.indexes.get_or(i, model.empty_index());
         metric.observe(inout out, item.entries + item.column + MODE(), if item.unique { 5 } else { 2 });
         metric.warn(inout out, item.table >= database.tables.len());
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -98,12 +98,12 @@ fn observe_storage(inout out: metric.Metric, borrow database: model.Database) {
     while i < database.rows.len() {
         metric.observe(inout out, row_projection(borrow database, i), (i % 7) + 1);
         metric.warn(inout out, database.rows.get_or(i, model.empty_row()).table >= database.tables.len());
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.cells.len() {
         metric.observe(inout out, cell_projection(borrow database, i), (i % 11) + 1);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -111,22 +111,22 @@ fn observe_operations(inout out: metric.Metric, borrow database: model.Database)
     let mut i: u64 = 0;
     while i < database.queries.len() {
         metric.observe(inout out, query_projection(borrow database, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.transactions.len() {
         metric.observe(inout out, transaction_projection(borrow database, i), i + 2);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.wal.len() {
         metric.observe(inout out, wal_projection(borrow database, i), i + 3);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.replicas.len() {
         metric.observe(inout out, replica_projection(borrow database, i), i + 4);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -141,9 +141,9 @@ fn observe_pairs(inout out: metric.Metric, borrow database: model.Database) {
                 metric.observe(inout out,
                     (table.row_count + 1) * (index.entries + 1) + MODE(), t + x + 1);
             }
-            x = x + 1;
+            x += 1;
         }
-        t = t + 1;
+        t += 1;
     }
 }
 

--- a/examples/meridian/analysis_wal_table_hotspot.rue
+++ b/examples/meridian/analysis_wal_table_hotspot.rue
@@ -77,19 +77,19 @@ fn observe_catalog(inout out: metric.Metric, borrow database: model.Database) {
     let mut i: u64 = 0;
     while i < database.tables.len() {
         metric.observe(inout out, table_projection(borrow database, i), i + MODE());
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.columns.len() {
         metric.observe(inout out, column_projection(borrow database, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.indexes.len() {
         let item = database.indexes.get_or(i, model.empty_index());
         metric.observe(inout out, item.entries + item.column + MODE(), if item.unique { 5 } else { 2 });
         metric.warn(inout out, item.table >= database.tables.len());
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -98,12 +98,12 @@ fn observe_storage(inout out: metric.Metric, borrow database: model.Database) {
     while i < database.rows.len() {
         metric.observe(inout out, row_projection(borrow database, i), (i % 7) + 1);
         metric.warn(inout out, database.rows.get_or(i, model.empty_row()).table >= database.tables.len());
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.cells.len() {
         metric.observe(inout out, cell_projection(borrow database, i), (i % 11) + 1);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -111,22 +111,22 @@ fn observe_operations(inout out: metric.Metric, borrow database: model.Database)
     let mut i: u64 = 0;
     while i < database.queries.len() {
         metric.observe(inout out, query_projection(borrow database, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.transactions.len() {
         metric.observe(inout out, transaction_projection(borrow database, i), i + 2);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.wal.len() {
         metric.observe(inout out, wal_projection(borrow database, i), i + 3);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.replicas.len() {
         metric.observe(inout out, replica_projection(borrow database, i), i + 4);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -141,9 +141,9 @@ fn observe_pairs(inout out: metric.Metric, borrow database: model.Database) {
                 metric.observe(inout out,
                     (table.row_count + 1) * (index.entries + 1) + MODE(), t + x + 1);
             }
-            x = x + 1;
+            x += 1;
         }
-        t = t + 1;
+        t += 1;
     }
 }
 

--- a/examples/meridian/analysis_wal_transaction_fanout.rue
+++ b/examples/meridian/analysis_wal_transaction_fanout.rue
@@ -77,19 +77,19 @@ fn observe_catalog(inout out: metric.Metric, borrow database: model.Database) {
     let mut i: u64 = 0;
     while i < database.tables.len() {
         metric.observe(inout out, table_projection(borrow database, i), i + MODE());
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.columns.len() {
         metric.observe(inout out, column_projection(borrow database, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.indexes.len() {
         let item = database.indexes.get_or(i, model.empty_index());
         metric.observe(inout out, item.entries + item.column + MODE(), if item.unique { 5 } else { 2 });
         metric.warn(inout out, item.table >= database.tables.len());
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -98,12 +98,12 @@ fn observe_storage(inout out: metric.Metric, borrow database: model.Database) {
     while i < database.rows.len() {
         metric.observe(inout out, row_projection(borrow database, i), (i % 7) + 1);
         metric.warn(inout out, database.rows.get_or(i, model.empty_row()).table >= database.tables.len());
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.cells.len() {
         metric.observe(inout out, cell_projection(borrow database, i), (i % 11) + 1);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -111,22 +111,22 @@ fn observe_operations(inout out: metric.Metric, borrow database: model.Database)
     let mut i: u64 = 0;
     while i < database.queries.len() {
         metric.observe(inout out, query_projection(borrow database, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.transactions.len() {
         metric.observe(inout out, transaction_projection(borrow database, i), i + 2);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.wal.len() {
         metric.observe(inout out, wal_projection(borrow database, i), i + 3);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.replicas.len() {
         metric.observe(inout out, replica_projection(borrow database, i), i + 4);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -141,9 +141,9 @@ fn observe_pairs(inout out: metric.Metric, borrow database: model.Database) {
                 metric.observe(inout out,
                     (table.row_count + 1) * (index.entries + 1) + MODE(), t + x + 1);
             }
-            x = x + 1;
+            x += 1;
         }
-        t = t + 1;
+        t += 1;
     }
 }
 

--- a/examples/meridian/analysis_wal_undo_pressure.rue
+++ b/examples/meridian/analysis_wal_undo_pressure.rue
@@ -77,19 +77,19 @@ fn observe_catalog(inout out: metric.Metric, borrow database: model.Database) {
     let mut i: u64 = 0;
     while i < database.tables.len() {
         metric.observe(inout out, table_projection(borrow database, i), i + MODE());
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.columns.len() {
         metric.observe(inout out, column_projection(borrow database, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.indexes.len() {
         let item = database.indexes.get_or(i, model.empty_index());
         metric.observe(inout out, item.entries + item.column + MODE(), if item.unique { 5 } else { 2 });
         metric.warn(inout out, item.table >= database.tables.len());
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -98,12 +98,12 @@ fn observe_storage(inout out: metric.Metric, borrow database: model.Database) {
     while i < database.rows.len() {
         metric.observe(inout out, row_projection(borrow database, i), (i % 7) + 1);
         metric.warn(inout out, database.rows.get_or(i, model.empty_row()).table >= database.tables.len());
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.cells.len() {
         metric.observe(inout out, cell_projection(borrow database, i), (i % 11) + 1);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -111,22 +111,22 @@ fn observe_operations(inout out: metric.Metric, borrow database: model.Database)
     let mut i: u64 = 0;
     while i < database.queries.len() {
         metric.observe(inout out, query_projection(borrow database, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.transactions.len() {
         metric.observe(inout out, transaction_projection(borrow database, i), i + 2);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.wal.len() {
         metric.observe(inout out, wal_projection(borrow database, i), i + 3);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.replicas.len() {
         metric.observe(inout out, replica_projection(borrow database, i), i + 4);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -141,9 +141,9 @@ fn observe_pairs(inout out: metric.Metric, borrow database: model.Database) {
                 metric.observe(inout out,
                     (table.row_count + 1) * (index.entries + 1) + MODE(), t + x + 1);
             }
-            x = x + 1;
+            x += 1;
         }
-        t = t + 1;
+        t += 1;
     }
 }
 

--- a/examples/meridian/analysis_workload_aggregate_intensity.rue
+++ b/examples/meridian/analysis_workload_aggregate_intensity.rue
@@ -77,19 +77,19 @@ fn observe_catalog(inout out: metric.Metric, borrow database: model.Database) {
     let mut i: u64 = 0;
     while i < database.tables.len() {
         metric.observe(inout out, table_projection(borrow database, i), i + MODE());
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.columns.len() {
         metric.observe(inout out, column_projection(borrow database, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.indexes.len() {
         let item = database.indexes.get_or(i, model.empty_index());
         metric.observe(inout out, item.entries + item.column + MODE(), if item.unique { 5 } else { 2 });
         metric.warn(inout out, item.table >= database.tables.len());
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -98,12 +98,12 @@ fn observe_storage(inout out: metric.Metric, borrow database: model.Database) {
     while i < database.rows.len() {
         metric.observe(inout out, row_projection(borrow database, i), (i % 7) + 1);
         metric.warn(inout out, database.rows.get_or(i, model.empty_row()).table >= database.tables.len());
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.cells.len() {
         metric.observe(inout out, cell_projection(borrow database, i), (i % 11) + 1);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -111,22 +111,22 @@ fn observe_operations(inout out: metric.Metric, borrow database: model.Database)
     let mut i: u64 = 0;
     while i < database.queries.len() {
         metric.observe(inout out, query_projection(borrow database, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.transactions.len() {
         metric.observe(inout out, transaction_projection(borrow database, i), i + 2);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.wal.len() {
         metric.observe(inout out, wal_projection(borrow database, i), i + 3);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.replicas.len() {
         metric.observe(inout out, replica_projection(borrow database, i), i + 4);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -141,9 +141,9 @@ fn observe_pairs(inout out: metric.Metric, borrow database: model.Database) {
                 metric.observe(inout out,
                     (table.row_count + 1) * (index.entries + 1) + MODE(), t + x + 1);
             }
-            x = x + 1;
+            x += 1;
         }
-        t = t + 1;
+        t += 1;
     }
 }
 

--- a/examples/meridian/analysis_workload_cache_pressure.rue
+++ b/examples/meridian/analysis_workload_cache_pressure.rue
@@ -77,19 +77,19 @@ fn observe_catalog(inout out: metric.Metric, borrow database: model.Database) {
     let mut i: u64 = 0;
     while i < database.tables.len() {
         metric.observe(inout out, table_projection(borrow database, i), i + MODE());
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.columns.len() {
         metric.observe(inout out, column_projection(borrow database, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.indexes.len() {
         let item = database.indexes.get_or(i, model.empty_index());
         metric.observe(inout out, item.entries + item.column + MODE(), if item.unique { 5 } else { 2 });
         metric.warn(inout out, item.table >= database.tables.len());
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -98,12 +98,12 @@ fn observe_storage(inout out: metric.Metric, borrow database: model.Database) {
     while i < database.rows.len() {
         metric.observe(inout out, row_projection(borrow database, i), (i % 7) + 1);
         metric.warn(inout out, database.rows.get_or(i, model.empty_row()).table >= database.tables.len());
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.cells.len() {
         metric.observe(inout out, cell_projection(borrow database, i), (i % 11) + 1);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -111,22 +111,22 @@ fn observe_operations(inout out: metric.Metric, borrow database: model.Database)
     let mut i: u64 = 0;
     while i < database.queries.len() {
         metric.observe(inout out, query_projection(borrow database, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.transactions.len() {
         metric.observe(inout out, transaction_projection(borrow database, i), i + 2);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.wal.len() {
         metric.observe(inout out, wal_projection(borrow database, i), i + 3);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.replicas.len() {
         metric.observe(inout out, replica_projection(borrow database, i), i + 4);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -141,9 +141,9 @@ fn observe_pairs(inout out: metric.Metric, borrow database: model.Database) {
                 metric.observe(inout out,
                     (table.row_count + 1) * (index.entries + 1) + MODE(), t + x + 1);
             }
-            x = x + 1;
+            x += 1;
         }
-        t = t + 1;
+        t += 1;
     }
 }
 

--- a/examples/meridian/analysis_workload_concurrency.rue
+++ b/examples/meridian/analysis_workload_concurrency.rue
@@ -77,19 +77,19 @@ fn observe_catalog(inout out: metric.Metric, borrow database: model.Database) {
     let mut i: u64 = 0;
     while i < database.tables.len() {
         metric.observe(inout out, table_projection(borrow database, i), i + MODE());
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.columns.len() {
         metric.observe(inout out, column_projection(borrow database, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.indexes.len() {
         let item = database.indexes.get_or(i, model.empty_index());
         metric.observe(inout out, item.entries + item.column + MODE(), if item.unique { 5 } else { 2 });
         metric.warn(inout out, item.table >= database.tables.len());
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -98,12 +98,12 @@ fn observe_storage(inout out: metric.Metric, borrow database: model.Database) {
     while i < database.rows.len() {
         metric.observe(inout out, row_projection(borrow database, i), (i % 7) + 1);
         metric.warn(inout out, database.rows.get_or(i, model.empty_row()).table >= database.tables.len());
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.cells.len() {
         metric.observe(inout out, cell_projection(borrow database, i), (i % 11) + 1);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -111,22 +111,22 @@ fn observe_operations(inout out: metric.Metric, borrow database: model.Database)
     let mut i: u64 = 0;
     while i < database.queries.len() {
         metric.observe(inout out, query_projection(borrow database, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.transactions.len() {
         metric.observe(inout out, transaction_projection(borrow database, i), i + 2);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.wal.len() {
         metric.observe(inout out, wal_projection(borrow database, i), i + 3);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.replicas.len() {
         metric.observe(inout out, replica_projection(borrow database, i), i + 4);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -141,9 +141,9 @@ fn observe_pairs(inout out: metric.Metric, borrow database: model.Database) {
                 metric.observe(inout out,
                     (table.row_count + 1) * (index.entries + 1) + MODE(), t + x + 1);
             }
-            x = x + 1;
+            x += 1;
         }
-        t = t + 1;
+        t += 1;
     }
 }
 

--- a/examples/meridian/analysis_workload_cpu_proxy.rue
+++ b/examples/meridian/analysis_workload_cpu_proxy.rue
@@ -77,19 +77,19 @@ fn observe_catalog(inout out: metric.Metric, borrow database: model.Database) {
     let mut i: u64 = 0;
     while i < database.tables.len() {
         metric.observe(inout out, table_projection(borrow database, i), i + MODE());
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.columns.len() {
         metric.observe(inout out, column_projection(borrow database, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.indexes.len() {
         let item = database.indexes.get_or(i, model.empty_index());
         metric.observe(inout out, item.entries + item.column + MODE(), if item.unique { 5 } else { 2 });
         metric.warn(inout out, item.table >= database.tables.len());
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -98,12 +98,12 @@ fn observe_storage(inout out: metric.Metric, borrow database: model.Database) {
     while i < database.rows.len() {
         metric.observe(inout out, row_projection(borrow database, i), (i % 7) + 1);
         metric.warn(inout out, database.rows.get_or(i, model.empty_row()).table >= database.tables.len());
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.cells.len() {
         metric.observe(inout out, cell_projection(borrow database, i), (i % 11) + 1);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -111,22 +111,22 @@ fn observe_operations(inout out: metric.Metric, borrow database: model.Database)
     let mut i: u64 = 0;
     while i < database.queries.len() {
         metric.observe(inout out, query_projection(borrow database, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.transactions.len() {
         metric.observe(inout out, transaction_projection(borrow database, i), i + 2);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.wal.len() {
         metric.observe(inout out, wal_projection(borrow database, i), i + 3);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.replicas.len() {
         metric.observe(inout out, replica_projection(borrow database, i), i + 4);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -141,9 +141,9 @@ fn observe_pairs(inout out: metric.Metric, borrow database: model.Database) {
                 metric.observe(inout out,
                     (table.row_count + 1) * (index.entries + 1) + MODE(), t + x + 1);
             }
-            x = x + 1;
+            x += 1;
         }
-        t = t + 1;
+        t += 1;
     }
 }
 

--- a/examples/meridian/analysis_workload_index_hit_rate.rue
+++ b/examples/meridian/analysis_workload_index_hit_rate.rue
@@ -77,19 +77,19 @@ fn observe_catalog(inout out: metric.Metric, borrow database: model.Database) {
     let mut i: u64 = 0;
     while i < database.tables.len() {
         metric.observe(inout out, table_projection(borrow database, i), i + MODE());
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.columns.len() {
         metric.observe(inout out, column_projection(borrow database, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.indexes.len() {
         let item = database.indexes.get_or(i, model.empty_index());
         metric.observe(inout out, item.entries + item.column + MODE(), if item.unique { 5 } else { 2 });
         metric.warn(inout out, item.table >= database.tables.len());
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -98,12 +98,12 @@ fn observe_storage(inout out: metric.Metric, borrow database: model.Database) {
     while i < database.rows.len() {
         metric.observe(inout out, row_projection(borrow database, i), (i % 7) + 1);
         metric.warn(inout out, database.rows.get_or(i, model.empty_row()).table >= database.tables.len());
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.cells.len() {
         metric.observe(inout out, cell_projection(borrow database, i), (i % 11) + 1);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -111,22 +111,22 @@ fn observe_operations(inout out: metric.Metric, borrow database: model.Database)
     let mut i: u64 = 0;
     while i < database.queries.len() {
         metric.observe(inout out, query_projection(borrow database, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.transactions.len() {
         metric.observe(inout out, transaction_projection(borrow database, i), i + 2);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.wal.len() {
         metric.observe(inout out, wal_projection(borrow database, i), i + 3);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.replicas.len() {
         metric.observe(inout out, replica_projection(borrow database, i), i + 4);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -141,9 +141,9 @@ fn observe_pairs(inout out: metric.Metric, borrow database: model.Database) {
                 metric.observe(inout out,
                     (table.row_count + 1) * (index.entries + 1) + MODE(), t + x + 1);
             }
-            x = x + 1;
+            x += 1;
         }
-        t = t + 1;
+        t += 1;
     }
 }
 

--- a/examples/meridian/analysis_workload_io_proxy.rue
+++ b/examples/meridian/analysis_workload_io_proxy.rue
@@ -77,19 +77,19 @@ fn observe_catalog(inout out: metric.Metric, borrow database: model.Database) {
     let mut i: u64 = 0;
     while i < database.tables.len() {
         metric.observe(inout out, table_projection(borrow database, i), i + MODE());
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.columns.len() {
         metric.observe(inout out, column_projection(borrow database, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.indexes.len() {
         let item = database.indexes.get_or(i, model.empty_index());
         metric.observe(inout out, item.entries + item.column + MODE(), if item.unique { 5 } else { 2 });
         metric.warn(inout out, item.table >= database.tables.len());
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -98,12 +98,12 @@ fn observe_storage(inout out: metric.Metric, borrow database: model.Database) {
     while i < database.rows.len() {
         metric.observe(inout out, row_projection(borrow database, i), (i % 7) + 1);
         metric.warn(inout out, database.rows.get_or(i, model.empty_row()).table >= database.tables.len());
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.cells.len() {
         metric.observe(inout out, cell_projection(borrow database, i), (i % 11) + 1);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -111,22 +111,22 @@ fn observe_operations(inout out: metric.Metric, borrow database: model.Database)
     let mut i: u64 = 0;
     while i < database.queries.len() {
         metric.observe(inout out, query_projection(borrow database, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.transactions.len() {
         metric.observe(inout out, transaction_projection(borrow database, i), i + 2);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.wal.len() {
         metric.observe(inout out, wal_projection(borrow database, i), i + 3);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.replicas.len() {
         metric.observe(inout out, replica_projection(borrow database, i), i + 4);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -141,9 +141,9 @@ fn observe_pairs(inout out: metric.Metric, borrow database: model.Database) {
                 metric.observe(inout out,
                     (table.row_count + 1) * (index.entries + 1) + MODE(), t + x + 1);
             }
-            x = x + 1;
+            x += 1;
         }
-        t = t + 1;
+        t += 1;
     }
 }
 

--- a/examples/meridian/analysis_workload_join_intensity.rue
+++ b/examples/meridian/analysis_workload_join_intensity.rue
@@ -77,19 +77,19 @@ fn observe_catalog(inout out: metric.Metric, borrow database: model.Database) {
     let mut i: u64 = 0;
     while i < database.tables.len() {
         metric.observe(inout out, table_projection(borrow database, i), i + MODE());
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.columns.len() {
         metric.observe(inout out, column_projection(borrow database, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.indexes.len() {
         let item = database.indexes.get_or(i, model.empty_index());
         metric.observe(inout out, item.entries + item.column + MODE(), if item.unique { 5 } else { 2 });
         metric.warn(inout out, item.table >= database.tables.len());
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -98,12 +98,12 @@ fn observe_storage(inout out: metric.Metric, borrow database: model.Database) {
     while i < database.rows.len() {
         metric.observe(inout out, row_projection(borrow database, i), (i % 7) + 1);
         metric.warn(inout out, database.rows.get_or(i, model.empty_row()).table >= database.tables.len());
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.cells.len() {
         metric.observe(inout out, cell_projection(borrow database, i), (i % 11) + 1);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -111,22 +111,22 @@ fn observe_operations(inout out: metric.Metric, borrow database: model.Database)
     let mut i: u64 = 0;
     while i < database.queries.len() {
         metric.observe(inout out, query_projection(borrow database, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.transactions.len() {
         metric.observe(inout out, transaction_projection(borrow database, i), i + 2);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.wal.len() {
         metric.observe(inout out, wal_projection(borrow database, i), i + 3);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.replicas.len() {
         metric.observe(inout out, replica_projection(borrow database, i), i + 4);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -141,9 +141,9 @@ fn observe_pairs(inout out: metric.Metric, borrow database: model.Database) {
                 metric.observe(inout out,
                     (table.row_count + 1) * (index.entries + 1) + MODE(), t + x + 1);
             }
-            x = x + 1;
+            x += 1;
         }
-        t = t + 1;
+        t += 1;
     }
 }
 

--- a/examples/meridian/analysis_workload_key_skew.rue
+++ b/examples/meridian/analysis_workload_key_skew.rue
@@ -77,19 +77,19 @@ fn observe_catalog(inout out: metric.Metric, borrow database: model.Database) {
     let mut i: u64 = 0;
     while i < database.tables.len() {
         metric.observe(inout out, table_projection(borrow database, i), i + MODE());
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.columns.len() {
         metric.observe(inout out, column_projection(borrow database, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.indexes.len() {
         let item = database.indexes.get_or(i, model.empty_index());
         metric.observe(inout out, item.entries + item.column + MODE(), if item.unique { 5 } else { 2 });
         metric.warn(inout out, item.table >= database.tables.len());
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -98,12 +98,12 @@ fn observe_storage(inout out: metric.Metric, borrow database: model.Database) {
     while i < database.rows.len() {
         metric.observe(inout out, row_projection(borrow database, i), (i % 7) + 1);
         metric.warn(inout out, database.rows.get_or(i, model.empty_row()).table >= database.tables.len());
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.cells.len() {
         metric.observe(inout out, cell_projection(borrow database, i), (i % 11) + 1);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -111,22 +111,22 @@ fn observe_operations(inout out: metric.Metric, borrow database: model.Database)
     let mut i: u64 = 0;
     while i < database.queries.len() {
         metric.observe(inout out, query_projection(borrow database, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.transactions.len() {
         metric.observe(inout out, transaction_projection(borrow database, i), i + 2);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.wal.len() {
         metric.observe(inout out, wal_projection(borrow database, i), i + 3);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.replicas.len() {
         metric.observe(inout out, replica_projection(borrow database, i), i + 4);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -141,9 +141,9 @@ fn observe_pairs(inout out: metric.Metric, borrow database: model.Database) {
                 metric.observe(inout out,
                     (table.row_count + 1) * (index.entries + 1) + MODE(), t + x + 1);
             }
-            x = x + 1;
+            x += 1;
         }
-        t = t + 1;
+        t += 1;
     }
 }
 

--- a/examples/meridian/analysis_workload_memory_proxy.rue
+++ b/examples/meridian/analysis_workload_memory_proxy.rue
@@ -77,19 +77,19 @@ fn observe_catalog(inout out: metric.Metric, borrow database: model.Database) {
     let mut i: u64 = 0;
     while i < database.tables.len() {
         metric.observe(inout out, table_projection(borrow database, i), i + MODE());
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.columns.len() {
         metric.observe(inout out, column_projection(borrow database, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.indexes.len() {
         let item = database.indexes.get_or(i, model.empty_index());
         metric.observe(inout out, item.entries + item.column + MODE(), if item.unique { 5 } else { 2 });
         metric.warn(inout out, item.table >= database.tables.len());
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -98,12 +98,12 @@ fn observe_storage(inout out: metric.Metric, borrow database: model.Database) {
     while i < database.rows.len() {
         metric.observe(inout out, row_projection(borrow database, i), (i % 7) + 1);
         metric.warn(inout out, database.rows.get_or(i, model.empty_row()).table >= database.tables.len());
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.cells.len() {
         metric.observe(inout out, cell_projection(borrow database, i), (i % 11) + 1);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -111,22 +111,22 @@ fn observe_operations(inout out: metric.Metric, borrow database: model.Database)
     let mut i: u64 = 0;
     while i < database.queries.len() {
         metric.observe(inout out, query_projection(borrow database, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.transactions.len() {
         metric.observe(inout out, transaction_projection(borrow database, i), i + 2);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.wal.len() {
         metric.observe(inout out, wal_projection(borrow database, i), i + 3);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.replicas.len() {
         metric.observe(inout out, replica_projection(borrow database, i), i + 4);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -141,9 +141,9 @@ fn observe_pairs(inout out: metric.Metric, borrow database: model.Database) {
                 metric.observe(inout out,
                     (table.row_count + 1) * (index.entries + 1) + MODE(), t + x + 1);
             }
-            x = x + 1;
+            x += 1;
         }
-        t = t + 1;
+        t += 1;
     }
 }
 

--- a/examples/meridian/analysis_workload_read_intensity.rue
+++ b/examples/meridian/analysis_workload_read_intensity.rue
@@ -77,19 +77,19 @@ fn observe_catalog(inout out: metric.Metric, borrow database: model.Database) {
     let mut i: u64 = 0;
     while i < database.tables.len() {
         metric.observe(inout out, table_projection(borrow database, i), i + MODE());
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.columns.len() {
         metric.observe(inout out, column_projection(borrow database, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.indexes.len() {
         let item = database.indexes.get_or(i, model.empty_index());
         metric.observe(inout out, item.entries + item.column + MODE(), if item.unique { 5 } else { 2 });
         metric.warn(inout out, item.table >= database.tables.len());
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -98,12 +98,12 @@ fn observe_storage(inout out: metric.Metric, borrow database: model.Database) {
     while i < database.rows.len() {
         metric.observe(inout out, row_projection(borrow database, i), (i % 7) + 1);
         metric.warn(inout out, database.rows.get_or(i, model.empty_row()).table >= database.tables.len());
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.cells.len() {
         metric.observe(inout out, cell_projection(borrow database, i), (i % 11) + 1);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -111,22 +111,22 @@ fn observe_operations(inout out: metric.Metric, borrow database: model.Database)
     let mut i: u64 = 0;
     while i < database.queries.len() {
         metric.observe(inout out, query_projection(borrow database, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.transactions.len() {
         metric.observe(inout out, transaction_projection(borrow database, i), i + 2);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.wal.len() {
         metric.observe(inout out, wal_projection(borrow database, i), i + 3);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.replicas.len() {
         metric.observe(inout out, replica_projection(borrow database, i), i + 4);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -141,9 +141,9 @@ fn observe_pairs(inout out: metric.Metric, borrow database: model.Database) {
                 metric.observe(inout out,
                     (table.row_count + 1) * (index.entries + 1) + MODE(), t + x + 1);
             }
-            x = x + 1;
+            x += 1;
         }
-        t = t + 1;
+        t += 1;
     }
 }
 

--- a/examples/meridian/analysis_workload_row_growth.rue
+++ b/examples/meridian/analysis_workload_row_growth.rue
@@ -77,19 +77,19 @@ fn observe_catalog(inout out: metric.Metric, borrow database: model.Database) {
     let mut i: u64 = 0;
     while i < database.tables.len() {
         metric.observe(inout out, table_projection(borrow database, i), i + MODE());
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.columns.len() {
         metric.observe(inout out, column_projection(borrow database, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.indexes.len() {
         let item = database.indexes.get_or(i, model.empty_index());
         metric.observe(inout out, item.entries + item.column + MODE(), if item.unique { 5 } else { 2 });
         metric.warn(inout out, item.table >= database.tables.len());
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -98,12 +98,12 @@ fn observe_storage(inout out: metric.Metric, borrow database: model.Database) {
     while i < database.rows.len() {
         metric.observe(inout out, row_projection(borrow database, i), (i % 7) + 1);
         metric.warn(inout out, database.rows.get_or(i, model.empty_row()).table >= database.tables.len());
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.cells.len() {
         metric.observe(inout out, cell_projection(borrow database, i), (i % 11) + 1);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -111,22 +111,22 @@ fn observe_operations(inout out: metric.Metric, borrow database: model.Database)
     let mut i: u64 = 0;
     while i < database.queries.len() {
         metric.observe(inout out, query_projection(borrow database, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.transactions.len() {
         metric.observe(inout out, transaction_projection(borrow database, i), i + 2);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.wal.len() {
         metric.observe(inout out, wal_projection(borrow database, i), i + 3);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.replicas.len() {
         metric.observe(inout out, replica_projection(borrow database, i), i + 4);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -141,9 +141,9 @@ fn observe_pairs(inout out: metric.Metric, borrow database: model.Database) {
                 metric.observe(inout out,
                     (table.row_count + 1) * (index.entries + 1) + MODE(), t + x + 1);
             }
-            x = x + 1;
+            x += 1;
         }
-        t = t + 1;
+        t += 1;
     }
 }
 

--- a/examples/meridian/analysis_workload_sort_intensity.rue
+++ b/examples/meridian/analysis_workload_sort_intensity.rue
@@ -77,19 +77,19 @@ fn observe_catalog(inout out: metric.Metric, borrow database: model.Database) {
     let mut i: u64 = 0;
     while i < database.tables.len() {
         metric.observe(inout out, table_projection(borrow database, i), i + MODE());
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.columns.len() {
         metric.observe(inout out, column_projection(borrow database, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.indexes.len() {
         let item = database.indexes.get_or(i, model.empty_index());
         metric.observe(inout out, item.entries + item.column + MODE(), if item.unique { 5 } else { 2 });
         metric.warn(inout out, item.table >= database.tables.len());
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -98,12 +98,12 @@ fn observe_storage(inout out: metric.Metric, borrow database: model.Database) {
     while i < database.rows.len() {
         metric.observe(inout out, row_projection(borrow database, i), (i % 7) + 1);
         metric.warn(inout out, database.rows.get_or(i, model.empty_row()).table >= database.tables.len());
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.cells.len() {
         metric.observe(inout out, cell_projection(borrow database, i), (i % 11) + 1);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -111,22 +111,22 @@ fn observe_operations(inout out: metric.Metric, borrow database: model.Database)
     let mut i: u64 = 0;
     while i < database.queries.len() {
         metric.observe(inout out, query_projection(borrow database, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.transactions.len() {
         metric.observe(inout out, transaction_projection(borrow database, i), i + 2);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.wal.len() {
         metric.observe(inout out, wal_projection(borrow database, i), i + 3);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.replicas.len() {
         metric.observe(inout out, replica_projection(borrow database, i), i + 4);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -141,9 +141,9 @@ fn observe_pairs(inout out: metric.Metric, borrow database: model.Database) {
                 metric.observe(inout out,
                     (table.row_count + 1) * (index.entries + 1) + MODE(), t + x + 1);
             }
-            x = x + 1;
+            x += 1;
         }
-        t = t + 1;
+        t += 1;
     }
 }
 

--- a/examples/meridian/analysis_workload_table_skew.rue
+++ b/examples/meridian/analysis_workload_table_skew.rue
@@ -77,19 +77,19 @@ fn observe_catalog(inout out: metric.Metric, borrow database: model.Database) {
     let mut i: u64 = 0;
     while i < database.tables.len() {
         metric.observe(inout out, table_projection(borrow database, i), i + MODE());
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.columns.len() {
         metric.observe(inout out, column_projection(borrow database, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.indexes.len() {
         let item = database.indexes.get_or(i, model.empty_index());
         metric.observe(inout out, item.entries + item.column + MODE(), if item.unique { 5 } else { 2 });
         metric.warn(inout out, item.table >= database.tables.len());
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -98,12 +98,12 @@ fn observe_storage(inout out: metric.Metric, borrow database: model.Database) {
     while i < database.rows.len() {
         metric.observe(inout out, row_projection(borrow database, i), (i % 7) + 1);
         metric.warn(inout out, database.rows.get_or(i, model.empty_row()).table >= database.tables.len());
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.cells.len() {
         metric.observe(inout out, cell_projection(borrow database, i), (i % 11) + 1);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -111,22 +111,22 @@ fn observe_operations(inout out: metric.Metric, borrow database: model.Database)
     let mut i: u64 = 0;
     while i < database.queries.len() {
         metric.observe(inout out, query_projection(borrow database, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.transactions.len() {
         metric.observe(inout out, transaction_projection(borrow database, i), i + 2);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.wal.len() {
         metric.observe(inout out, wal_projection(borrow database, i), i + 3);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.replicas.len() {
         metric.observe(inout out, replica_projection(borrow database, i), i + 4);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -141,9 +141,9 @@ fn observe_pairs(inout out: metric.Metric, borrow database: model.Database) {
                 metric.observe(inout out,
                     (table.row_count + 1) * (index.entries + 1) + MODE(), t + x + 1);
             }
-            x = x + 1;
+            x += 1;
         }
-        t = t + 1;
+        t += 1;
     }
 }
 

--- a/examples/meridian/analysis_workload_tail_latency.rue
+++ b/examples/meridian/analysis_workload_tail_latency.rue
@@ -77,19 +77,19 @@ fn observe_catalog(inout out: metric.Metric, borrow database: model.Database) {
     let mut i: u64 = 0;
     while i < database.tables.len() {
         metric.observe(inout out, table_projection(borrow database, i), i + MODE());
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.columns.len() {
         metric.observe(inout out, column_projection(borrow database, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.indexes.len() {
         let item = database.indexes.get_or(i, model.empty_index());
         metric.observe(inout out, item.entries + item.column + MODE(), if item.unique { 5 } else { 2 });
         metric.warn(inout out, item.table >= database.tables.len());
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -98,12 +98,12 @@ fn observe_storage(inout out: metric.Metric, borrow database: model.Database) {
     while i < database.rows.len() {
         metric.observe(inout out, row_projection(borrow database, i), (i % 7) + 1);
         metric.warn(inout out, database.rows.get_or(i, model.empty_row()).table >= database.tables.len());
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.cells.len() {
         metric.observe(inout out, cell_projection(borrow database, i), (i % 11) + 1);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -111,22 +111,22 @@ fn observe_operations(inout out: metric.Metric, borrow database: model.Database)
     let mut i: u64 = 0;
     while i < database.queries.len() {
         metric.observe(inout out, query_projection(borrow database, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.transactions.len() {
         metric.observe(inout out, transaction_projection(borrow database, i), i + 2);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.wal.len() {
         metric.observe(inout out, wal_projection(borrow database, i), i + 3);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.replicas.len() {
         metric.observe(inout out, replica_projection(borrow database, i), i + 4);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -141,9 +141,9 @@ fn observe_pairs(inout out: metric.Metric, borrow database: model.Database) {
                 metric.observe(inout out,
                     (table.row_count + 1) * (index.entries + 1) + MODE(), t + x + 1);
             }
-            x = x + 1;
+            x += 1;
         }
-        t = t + 1;
+        t += 1;
     }
 }
 

--- a/examples/meridian/analysis_workload_version_growth.rue
+++ b/examples/meridian/analysis_workload_version_growth.rue
@@ -77,19 +77,19 @@ fn observe_catalog(inout out: metric.Metric, borrow database: model.Database) {
     let mut i: u64 = 0;
     while i < database.tables.len() {
         metric.observe(inout out, table_projection(borrow database, i), i + MODE());
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.columns.len() {
         metric.observe(inout out, column_projection(borrow database, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.indexes.len() {
         let item = database.indexes.get_or(i, model.empty_index());
         metric.observe(inout out, item.entries + item.column + MODE(), if item.unique { 5 } else { 2 });
         metric.warn(inout out, item.table >= database.tables.len());
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -98,12 +98,12 @@ fn observe_storage(inout out: metric.Metric, borrow database: model.Database) {
     while i < database.rows.len() {
         metric.observe(inout out, row_projection(borrow database, i), (i % 7) + 1);
         metric.warn(inout out, database.rows.get_or(i, model.empty_row()).table >= database.tables.len());
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.cells.len() {
         metric.observe(inout out, cell_projection(borrow database, i), (i % 11) + 1);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -111,22 +111,22 @@ fn observe_operations(inout out: metric.Metric, borrow database: model.Database)
     let mut i: u64 = 0;
     while i < database.queries.len() {
         metric.observe(inout out, query_projection(borrow database, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.transactions.len() {
         metric.observe(inout out, transaction_projection(borrow database, i), i + 2);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.wal.len() {
         metric.observe(inout out, wal_projection(borrow database, i), i + 3);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.replicas.len() {
         metric.observe(inout out, replica_projection(borrow database, i), i + 4);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -141,9 +141,9 @@ fn observe_pairs(inout out: metric.Metric, borrow database: model.Database) {
                 metric.observe(inout out,
                     (table.row_count + 1) * (index.entries + 1) + MODE(), t + x + 1);
             }
-            x = x + 1;
+            x += 1;
         }
-        t = t + 1;
+        t += 1;
     }
 }
 

--- a/examples/meridian/analysis_workload_write_intensity.rue
+++ b/examples/meridian/analysis_workload_write_intensity.rue
@@ -77,19 +77,19 @@ fn observe_catalog(inout out: metric.Metric, borrow database: model.Database) {
     let mut i: u64 = 0;
     while i < database.tables.len() {
         metric.observe(inout out, table_projection(borrow database, i), i + MODE());
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.columns.len() {
         metric.observe(inout out, column_projection(borrow database, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.indexes.len() {
         let item = database.indexes.get_or(i, model.empty_index());
         metric.observe(inout out, item.entries + item.column + MODE(), if item.unique { 5 } else { 2 });
         metric.warn(inout out, item.table >= database.tables.len());
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -98,12 +98,12 @@ fn observe_storage(inout out: metric.Metric, borrow database: model.Database) {
     while i < database.rows.len() {
         metric.observe(inout out, row_projection(borrow database, i), (i % 7) + 1);
         metric.warn(inout out, database.rows.get_or(i, model.empty_row()).table >= database.tables.len());
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.cells.len() {
         metric.observe(inout out, cell_projection(borrow database, i), (i % 11) + 1);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -111,22 +111,22 @@ fn observe_operations(inout out: metric.Metric, borrow database: model.Database)
     let mut i: u64 = 0;
     while i < database.queries.len() {
         metric.observe(inout out, query_projection(borrow database, i), i + 1);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.transactions.len() {
         metric.observe(inout out, transaction_projection(borrow database, i), i + 2);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.wal.len() {
         metric.observe(inout out, wal_projection(borrow database, i), i + 3);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.replicas.len() {
         metric.observe(inout out, replica_projection(borrow database, i), i + 4);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -141,9 +141,9 @@ fn observe_pairs(inout out: metric.Metric, borrow database: model.Database) {
                 metric.observe(inout out,
                     (table.row_count + 1) * (index.entries + 1) + MODE(), t + x + 1);
             }
-            x = x + 1;
+            x += 1;
         }
-        t = t + 1;
+        t += 1;
     }
 }
 

--- a/examples/meridian/catalog_oracle.rue
+++ b/examples/meridian/catalog_oracle.rue
@@ -18,19 +18,19 @@ pub fn audit(borrow database: model.Database) -> Audit {
     let mut t: u64 = 0;
     while t < database.tables.len() {
         let table = database.tables.get_or(t, model.empty_table());
-        out.columns = out.columns + table.column_count;
+        out.columns += table.column_count;
         let rows = model.table_rows(borrow database, t, database.version);
-        out.rows = out.rows + rows;
-        out.cells = out.cells + model.table_cells(borrow database, t);
+        out.rows += rows;
+        out.cells += model.table_cells(borrow database, t);
         out.checksum = metric.mix(out.checksum, database.strings.hash(table.name));
         out.checksum = metric.mix(out.checksum, rows);
-        t = t + 1;
+        t += 1;
     }
     let mut i: u64 = 0;
     while i < database.indexes.len() {
         out.index_entries = out.index_entries +
             database.indexes.get_or(i, model.empty_index()).entries;
-        i = i + 1;
+        i += 1;
     }
     out.valid = out.columns == database.columns.len() &&
         out.rows <= database.rows.len() && out.cells == database.cells.len();

--- a/examples/meridian/checkpoint.rue
+++ b/examples/meridian/checkpoint.rue
@@ -18,9 +18,9 @@ pub fn create(borrow database: model.Database) -> Checkpoint {
     let mut i: u64 = 0;
     while i < database.transactions.len() {
         if database.transactions.get_or(i, model.empty_transaction()).state == 1 {
-            active = active + 1;
+            active += 1;
         }
-        i = i + 1;
+        i += 1;
     }
     let mut retained: u64 = 0;
     let mut dirty: u64 = 0;
@@ -29,7 +29,7 @@ pub fn create(borrow database: model.Database) -> Checkpoint {
         let entry = database.wal.get_or(i, model.empty_wal());
         if entry.lsn > lsn { retained = retained + 1; }
         if entry.kind == 1 || entry.kind == 2 { dirty = dirty + 1; }
-        i = i + 1;
+        i += 1;
     }
     let mut checksum = metric.mix(14695981039346656037, lsn);
     checksum = metric.mix(checksum, active);

--- a/examples/meridian/checkpoint.rue
+++ b/examples/meridian/checkpoint.rue
@@ -27,8 +27,8 @@ pub fn create(borrow database: model.Database) -> Checkpoint {
     i = 0;
     while i < database.wal.len() {
         let entry = database.wal.get_or(i, model.empty_wal());
-        if entry.lsn > lsn { retained = retained + 1; }
-        if entry.kind == 1 || entry.kind == 2 { dirty = dirty + 1; }
+        if entry.lsn > lsn { retained += 1; }
+        if entry.kind == 1 || entry.kind == 2 { dirty += 1; }
         i += 1;
     }
     let mut checksum = metric.mix(14695981039346656037, lsn);

--- a/examples/meridian/constraints.rue
+++ b/examples/meridian/constraints.rue
@@ -24,7 +24,7 @@ pub fn audit(borrow database: model.Database) -> metric.Metric {
                     }
                     earlier += 1;
                 }
-                if seen { duplicates = duplicates + 1; } else { distinct = distinct + 1; }
+                if seen { duplicates += 1; } else { distinct += 1; }
             }
             r += 1;
         }

--- a/examples/meridian/constraints.rue
+++ b/examples/meridian/constraints.rue
@@ -22,16 +22,16 @@ pub fn audit(borrow database: model.Database) -> metric.Metric {
                         model.cell_number(borrow database, earlier, c) == value {
                         seen = true;
                     }
-                    earlier = earlier + 1;
+                    earlier += 1;
                 }
                 if seen { duplicates = duplicates + 1; } else { distinct = distinct + 1; }
             }
-            r = r + 1;
+            r += 1;
         }
         metric.observe(inout out, distinct, c + 1);
         metric.warn(inout out, column.unique && duplicates > 0);
         metric.warn(inout out, !column.nullable && column.kind == 0);
-        c = c + 1;
+        c += 1;
     }
     metric.finish(inout out);
     out

--- a/examples/meridian/diagnostics.rue
+++ b/examples/meridian/diagnostics.rue
@@ -19,7 +19,7 @@ pub fn render(borrow database: model.Database) -> StrBuf {
         text.append_literal(inout out, ": ");
         text.append_id(inout out, borrow database, item.detail);
         out.push(10);
-        i = i + 1;
+        i += 1;
     }
     out
 }

--- a/examples/meridian/engine.rue
+++ b/examples/meridian/engine.rue
@@ -19,9 +19,9 @@ fn join_matches(borrow database: model.Database, borrow query: model.Query, row_
         let row = database.rows.get_or(j, model.empty_row());
         if row.table == query.join_table && model.visible(borrow row, database.version) &&
             model.cell_number(borrow database, j, query.join_right) == key {
-            matches = matches + 1;
+            matches += 1;
         }
-        j = j + 1;
+        j += 1;
     }
     matches
 }
@@ -30,7 +30,7 @@ fn group_seen(borrow value: result.Result, item: u64) -> bool {
     let mut i: u64 = 0;
     while i < value.values.len() {
         if value.values.get_or(i, model.NONE()) == item { return true; }
-        i = i + 1;
+        i += 1;
     }
     false
 }
@@ -42,10 +42,10 @@ fn sort(inout values: model.U64s) {
         let mut j = i;
         while j > 0 && values.get_or(j - 1, 0) > value {
             values.set(j, values.get_or(j - 1, 0));
-            j = j - 1;
+            j -= 1;
         }
         values.set(j, value);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -67,7 +67,7 @@ pub fn execute(borrow database: model.Database, borrow query: model.Query) -> re
                 while m < matches {
                     result.observe(inout out, value);
                     out.joined_rows = out.joined_rows + if query.join_table != model.NONE() { 1 } else { 0 };
-                    m = m + 1;
+                    m += 1;
                 }
                 if query.group_column != model.NONE() {
                     let group = model.cell_number(borrow database, i, query.group_column);
@@ -75,7 +75,7 @@ pub fn execute(borrow database: model.Database, borrow query: model.Query) -> re
                 }
             }
         }
-        i = i + 1;
+        i += 1;
     }
     if query.order_column != model.NONE() { sort(inout out.values); }
     out.groups = groups.len();

--- a/examples/meridian/failover.rue
+++ b/examples/meridian/failover.rue
@@ -16,13 +16,13 @@ pub fn elect(borrow database: model.Database) -> Election {
     while i < database.replicas.len() {
         let replica = database.replicas.get_or(i, model.empty_replica());
         if replica.healthy {
-            out.candidates = out.candidates + 1;
+            out.candidates += 1;
             if out.winner == model.NONE() || replica.applied_lsn > out.winning_lsn {
                 out.winner = i;
                 out.winning_lsn = replica.applied_lsn;
             }
         } else { out.rejected = out.rejected + 1; }
-        i = i + 1;
+        i += 1;
     }
     out.valid = out.winner != model.NONE() && out.winner < database.replicas.len();
     out

--- a/examples/meridian/failover.rue
+++ b/examples/meridian/failover.rue
@@ -21,7 +21,7 @@ pub fn elect(borrow database: model.Database) -> Election {
                 out.winner = i;
                 out.winning_lsn = replica.applied_lsn;
             }
-        } else { out.rejected = out.rejected + 1; }
+        } else { out.rejected += 1; }
         i += 1;
     }
     out.valid = out.winner != model.NONE() && out.winner < database.replicas.len();

--- a/examples/meridian/generate.rue
+++ b/examples/meridian/generate.rue
@@ -71,7 +71,7 @@ fn add_wal(inout database: model.Database, transaction: u64, kind: u64,
         lsn: database.next_lsn, transaction: transaction, kind: kind,
         table: table, row: row, before: before, after: after, committed: committed,
     });
-    database.next_lsn = database.next_lsn + 1;
+    database.next_lsn += 1;
 }
 
 pub fn database(scale: u64) -> model.Database {
@@ -96,17 +96,17 @@ pub fn database(scale: u64) -> model.Database {
     let mut i: u64 = 0;
     while i < 4 * scale {
         let _ = add_row3(inout value, teams, i + 1, (i % 3) + 1, 1000 + i * 250);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < 12 * scale {
         let _ = add_row3(inout value, users, i + 1, (i % (4 * scale)) + 1, 40 + ((i * 17) % 61));
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < 30 * scale {
         let _ = add_row3(inout value, orders, i + 1, (i % (12 * scale)) + 1, 10 + ((i * 29) % 240));
-        i = i + 1;
+        i += 1;
     }
 
     add_index(inout value, "teams_pk", teams, team_id, true);

--- a/examples/meridian/lexer.rue
+++ b/examples/meridian/lexer.rue
@@ -38,7 +38,7 @@ struct Lexer {
 
     fn advance(inout self) -> u8 {
         let value = self.byte(self.at);
-        self.at = self.at + 1;
+        self.at += 1;
         value
     }
 
@@ -61,7 +61,7 @@ struct Lexer {
             let actual = StrBuf.byte_at_borrowed(borrow word, i);
             let folded = if actual >= 97 && actual <= 122 { actual - 32 } else { actual };
             if folded != value[i] { return false; }
-            i = i + 1;
+            i += 1;
         }
         true
     }

--- a/examples/meridian/lineage.rue
+++ b/examples/meridian/lineage.rue
@@ -23,7 +23,7 @@ pub fn audit(borrow database: model.Database) -> metric.Metric {
             metric.observe(inout out, query.order_column, 13);
         }
         metric.warn(inout out, query.table >= database.tables.len());
-        i = i + 1;
+        i += 1;
     }
     metric.finish(inout out);
     out

--- a/examples/meridian/locks.rue
+++ b/examples/meridian/locks.rue
@@ -25,7 +25,7 @@ fn reaches(borrow database: model.Database, start: u64, target: u64, depth: u64)
             if i == target { return true; }
             if reaches(borrow database, i, target, depth + 1) { return true; }
         }
-        i = i + 1;
+        i += 1;
     }
     false
 }
@@ -40,14 +40,14 @@ pub fn audit(borrow database: model.Database) -> Audit {
         while j < database.transactions.len() {
             let right = database.transactions.get_or(j, model.empty_transaction());
             if waits_for(borrow left, borrow right) {
-                out.waits = out.waits + 1;
+                out.waits += 1;
                 out.checksum = metric.mix(out.checksum, left.id);
                 out.checksum = metric.mix(out.checksum, right.id);
             }
-            j = j + 1;
+            j += 1;
         }
         if reaches(borrow database, i, i, 0) { out.cycles = out.cycles + 1; }
-        i = i + 1;
+        i += 1;
     }
     out.valid = out.cycles <= out.transactions;
     out

--- a/examples/meridian/locks.rue
+++ b/examples/meridian/locks.rue
@@ -46,7 +46,7 @@ pub fn audit(borrow database: model.Database) -> Audit {
             }
             j += 1;
         }
-        if reaches(borrow database, i, i, 0) { out.cycles = out.cycles + 1; }
+        if reaches(borrow database, i, i, 0) { out.cycles += 1; }
         i += 1;
     }
     out.valid = out.cycles <= out.transactions;

--- a/examples/meridian/metric.rue
+++ b/examples/meridian/metric.rue
@@ -40,7 +40,7 @@ pub fn multiply(a: u64, b: u64) -> u64 {
 }
 
 pub fn observe(inout value: Metric, observation: u64, weight: u64) {
-    value.observations = value.observations + 1;
+    value.observations += 1;
     value.sum = add(value.sum, observation);
     value.weighted = add(value.weighted, multiply(observation, weight));
     if observation < value.minimum { value.minimum = observation; }

--- a/examples/meridian/metric.rue
+++ b/examples/meridian/metric.rue
@@ -45,15 +45,15 @@ pub fn observe(inout value: Metric, observation: u64, weight: u64) {
     value.weighted = add(value.weighted, multiply(observation, weight));
     if observation < value.minimum { value.minimum = observation; }
     if observation > value.maximum { value.maximum = observation; }
-    if observation == 0 { value.zeroes = value.zeroes + 1; }
-    if observation % 2 == 0 { value.even = value.even + 1; }
-    else { value.odd = value.odd + 1; }
+    if observation == 0 { value.zeroes += 1; }
+    if observation % 2 == 0 { value.even += 1; }
+    else { value.odd += 1; }
     value.digest = mix(value.digest, observation);
     value.digest = mix(value.digest, weight);
 }
 
 pub fn warn(inout value: Metric, condition: bool) {
-    if condition { value.warnings = value.warnings + 1; }
+    if condition { value.warnings += 1; }
 }
 
 pub fn finish(inout value: Metric) {

--- a/examples/meridian/model.rue
+++ b/examples/meridian/model.rue
@@ -209,7 +209,7 @@ pub fn find_table(borrow database: Database, name: u64) -> u64 {
         if database.strings.ids_equal(database.tables.get_or(i, empty_table()).name, name) {
             return i;
         }
-        i = i + 1;
+        i += 1;
     }
     NONE()
 }
@@ -219,7 +219,7 @@ pub fn find_column(borrow database: Database, table: u64, name: u64) -> u64 {
     while i < database.columns.len() {
         let column = database.columns.get_or(i, empty_column());
         if column.table == table && database.strings.ids_equal(column.name, name) { return i; }
-        i = i + 1;
+        i += 1;
     }
     NONE()
 }
@@ -235,7 +235,7 @@ pub fn cell_number(borrow database: Database, row: u64, column: u64) -> u64 {
     while i < item.cell_count {
         let cell = database.cells.get_or(item.first_cell + i, empty_cell());
         if cell.column == column && !cell.is_null { return cell.number; }
-        i = i + 1;
+        i += 1;
     }
     0
 }
@@ -246,7 +246,7 @@ pub fn table_rows(borrow database: Database, table: u64, snapshot: u64) -> u64 {
     while i < database.rows.len() {
         let row = database.rows.get_or(i, empty_row());
         if row.table == table && visible(borrow row, snapshot) { count = count + 1; }
-        i = i + 1;
+        i += 1;
     }
     count
 }
@@ -256,7 +256,7 @@ pub fn table_cells(borrow database: Database, table: u64) -> u64 {
     let mut i: u64 = 0;
     while i < database.cells.len() {
         if database.cells.get_or(i, empty_cell()).table == table { count = count + 1; }
-        i = i + 1;
+        i += 1;
     }
     count
 }
@@ -266,7 +266,7 @@ pub fn has_index(borrow database: Database, table: u64, column: u64) -> bool {
     while i < database.indexes.len() {
         let index = database.indexes.get_or(i, empty_index());
         if index.table == table && index.column == column { return true; }
-        i = i + 1;
+        i += 1;
     }
     false
 }

--- a/examples/meridian/model.rue
+++ b/examples/meridian/model.rue
@@ -245,7 +245,7 @@ pub fn table_rows(borrow database: Database, table: u64, snapshot: u64) -> u64 {
     let mut i: u64 = 0;
     while i < database.rows.len() {
         let row = database.rows.get_or(i, empty_row());
-        if row.table == table && visible(borrow row, snapshot) { count = count + 1; }
+        if row.table == table && visible(borrow row, snapshot) { count += 1; }
         i += 1;
     }
     count
@@ -255,7 +255,7 @@ pub fn table_cells(borrow database: Database, table: u64) -> u64 {
     let mut count: u64 = 0;
     let mut i: u64 = 0;
     while i < database.cells.len() {
-        if database.cells.get_or(i, empty_cell()).table == table { count = count + 1; }
+        if database.cells.get_or(i, empty_cell()).table == table { count += 1; }
         i += 1;
     }
     count

--- a/examples/meridian/mvcc.rue
+++ b/examples/meridian/mvcc.rue
@@ -13,10 +13,10 @@ pub fn audit(borrow database: model.Database) -> metric.Metric {
             if model.visible(borrow row, snapshot) { visible_rows = visible_rows + 1; }
             metric.warn(inout out, row.version_deleted != model.NONE() &&
                 row.version_deleted < row.version_created);
-            i = i + 1;
+            i += 1;
         }
         metric.observe(inout out, visible_rows, snapshot + 1);
-        snapshot = snapshot + 1;
+        snapshot += 1;
     }
     metric.finish(inout out);
     out

--- a/examples/meridian/mvcc.rue
+++ b/examples/meridian/mvcc.rue
@@ -10,7 +10,7 @@ pub fn audit(borrow database: model.Database) -> metric.Metric {
         let mut i: u64 = 0;
         while i < database.rows.len() {
             let row = database.rows.get_or(i, model.empty_row());
-            if model.visible(borrow row, snapshot) { visible_rows = visible_rows + 1; }
+            if model.visible(borrow row, snapshot) { visible_rows += 1; }
             metric.warn(inout out, row.version_deleted != model.NONE() &&
                 row.version_deleted < row.version_created);
             i += 1;

--- a/examples/meridian/parser.rue
+++ b/examples/meridian/parser.rue
@@ -28,7 +28,7 @@ struct Parser {
 
     fn advance(inout self) -> token.Token {
         let value = self.peek();
-        if value.kind != token.EOF { self.at = self.at + 1; }
+        if value.kind != token.EOF { self.at += 1; }
         value
     }
 
@@ -204,7 +204,7 @@ struct Parser {
             }
             i += 1;
         }
-        if state == 2 { self.database.version = self.database.version + 1; }
+        if state == 2 { self.database.version += 1; }
     }
 
     fn recover(inout self) {

--- a/examples/meridian/parser.rue
+++ b/examples/meridian/parser.rue
@@ -128,7 +128,7 @@ struct Parser {
                     table: table, row: row_index, column: column, number: value,
                     text: model.NONE(), is_text: false, is_null: false,
                 });
-                count = count + 1;
+                count += 1;
             } else {
                 self.error("INSERT values must be integers in the compact surface");
                 let _ = self.advance();
@@ -202,7 +202,7 @@ struct Parser {
                     writes: item.writes, reads: item.reads,
                 });
             }
-            i = i + 1;
+            i += 1;
         }
         if state == 2 { self.database.version = self.database.version + 1; }
     }

--- a/examples/meridian/partition.rue
+++ b/examples/meridian/partition.rue
@@ -10,7 +10,7 @@ pub fn audit(borrow database: model.Database, partitions: u64) -> metric.Metric 
     let mut out = metric.new(4601);
     let mut counts = model.U64s.new();
     let mut p: u64 = 0;
-    while p < partitions { counts.push(0); p = p + 1; }
+    while p < partitions { counts.push(0); p += 1; }
     let mut i: u64 = 0;
     while i < database.rows.len() {
         let row = database.rows.get_or(i, model.empty_row());

--- a/examples/meridian/partition.rue
+++ b/examples/meridian/partition.rue
@@ -18,12 +18,12 @@ pub fn audit(borrow database: model.Database, partitions: u64) -> metric.Metric 
         let key = model.cell_number(borrow database, i, table.first_column);
         let selected = partition_for(key, partitions);
         counts.set(selected, counts.get_or(selected, 0) + 1);
-        i = i + 1;
+        i += 1;
     }
     p = 0;
     while p < counts.len() {
         metric.observe(inout out, counts.get_or(p, 0), p + 1);
-        p = p + 1;
+        p += 1;
     }
     metric.warn(inout out, partitions == 0);
     metric.finish(inout out);

--- a/examples/meridian/plan.rue
+++ b/examples/meridian/plan.rue
@@ -70,7 +70,7 @@ pub fn build(borrow database: model.Database, borrow query: model.Query) -> Plan
     let mut cost = scan_cost;
     if query.filter_column != model.NONE() {
         rows = (rows + 1) / 2;
-        cost = cost + base_rows;
+        cost += base_rows;
         root = add(inout value, FILTER(), root, model.NONE(), query.table,
             query.filter_column, rows, cost, 0);
     }
@@ -87,18 +87,18 @@ pub fn build(borrow database: model.Database, borrow query: model.Query) -> Plan
     }
     if query.group_column != model.NONE() {
         rows = if rows > 4 { 4 } else { rows };
-        cost = cost + rows * 2;
+        cost += rows * 2;
         root = add(inout value, GROUP(), root, model.NONE(), query.table,
             query.group_column, rows, cost, 0);
     }
     if query.order_column != model.NONE() {
-        cost = cost + rows * (rows + 1);
+        cost += rows * (rows + 1);
         root = add(inout value, SORT(), root, model.NONE(), query.table,
             query.order_column, rows, cost, 0);
     }
     if query.limit != model.NONE() {
         if rows > query.limit { rows = query.limit; }
-        cost = cost + 1;
+        cost += 1;
         root = add(inout value, LIMIT(), root, model.NONE(), query.table,
             model.NONE(), rows, cost, 0);
     }
@@ -119,7 +119,7 @@ pub fn verify(borrow value: Plan) -> bool {
         if node.kind == 0 || node.cost == 0 { return false; }
         if node.left != model.NONE() && node.left >= i { return false; }
         if node.right != model.NONE() && node.right >= i { return false; }
-        i = i + 1;
+        i += 1;
     }
     let root = value.nodes.get_or(value.root, empty_node());
     root.estimated_rows == value.estimated_rows && root.cost == value.cost

--- a/examples/meridian/pool.rue
+++ b/examples/meridian/pool.rue
@@ -45,7 +45,7 @@ pub struct Pool {
         let mut i: u64 = 0;
         while i < value.len() {
             if self.byte_at(id, i) != Self.byte_of(borrow value, i) { return false; }
-            i = i + 1;
+            i += 1;
         }
         true
     }
@@ -55,7 +55,7 @@ pub struct Pool {
         let mut i: u64 = 0;
         while i < self.string_len(first) {
             if self.byte_at(first, i) != self.byte_at(second, i) { return false; }
-            i = i + 1;
+            i += 1;
         }
         true
     }
@@ -77,7 +77,7 @@ pub struct Pool {
         let mut i: u64 = 0;
         while i < value.len() {
             self.bytes.push(Self.byte_of(borrow value, i));
-            i = i + 1;
+            i += 1;
         }
         id
     }
@@ -90,7 +90,7 @@ pub struct Pool {
         let mut i: u64 = 0;
         while i < self.string_len(id) {
             out.push(self.byte_at(id, i));
-            i = i + 1;
+            i += 1;
         }
     }
 
@@ -104,9 +104,9 @@ pub struct Pool {
         let mut value: u64 = 14695981039346656037;
         let mut i: u64 = 0;
         while i < self.string_len(id) {
-            value = value ^ @intCast(self.byte_at(id, i));
+            value ^= @intCast(self.byte_at(id, i));
             value = @wrapping_mul(value, 1099511628211);
-            i = i + 1;
+            i += 1;
         }
         value
     }

--- a/examples/meridian/recovery.rue
+++ b/examples/meridian/recovery.rue
@@ -19,7 +19,7 @@ pub fn run(borrow database: model.Database, checkpoint_lsn: u64) -> Recovery {
     while i < database.wal.len() {
         let entry = database.wal.get_or(i, model.empty_wal());
         out.scanned += 1;
-        if entry.lsn <= checkpoint_lsn { out.skipped = out.skipped + 1; }
+        if entry.lsn <= checkpoint_lsn { out.skipped += 1; }
         else if entry.committed {
             out.redone += 1;
             out.checksum = metric.mix(out.checksum, entry.after);

--- a/examples/meridian/recovery.rue
+++ b/examples/meridian/recovery.rue
@@ -18,18 +18,18 @@ pub fn run(borrow database: model.Database, checkpoint_lsn: u64) -> Recovery {
     let mut previous: u64 = 0;
     while i < database.wal.len() {
         let entry = database.wal.get_or(i, model.empty_wal());
-        out.scanned = out.scanned + 1;
+        out.scanned += 1;
         if entry.lsn <= checkpoint_lsn { out.skipped = out.skipped + 1; }
         else if entry.committed {
-            out.redone = out.redone + 1;
+            out.redone += 1;
             out.checksum = metric.mix(out.checksum, entry.after);
         } else {
-            out.undone = out.undone + 1;
+            out.undone += 1;
             out.checksum = metric.mix(out.checksum, entry.before);
         }
         if entry.lsn <= previous { out.valid = false; }
         previous = entry.lsn;
-        i = i + 1;
+        i += 1;
     }
     out.checksum = metric.mix(out.checksum, out.redone);
     out.checksum = metric.mix(out.checksum, out.undone);

--- a/examples/meridian/replication.rue
+++ b/examples/meridian/replication.rue
@@ -14,7 +14,7 @@ pub fn audit(borrow database: model.Database) -> metric.Metric {
         metric.warn(inout out, replica.applied_lsn > latest);
         metric.warn(inout out, replica.lag != latest - replica.applied_lsn);
         metric.warn(inout out, replica.primary && !replica.healthy);
-        i = i + 1;
+        i += 1;
     }
     metric.warn(inout out, primaries != 1);
     metric.finish(inout out);

--- a/examples/meridian/replication.rue
+++ b/examples/meridian/replication.rue
@@ -9,7 +9,7 @@ pub fn audit(borrow database: model.Database) -> metric.Metric {
     let mut i: u64 = 0;
     while i < database.replicas.len() {
         let replica = database.replicas.get_or(i, model.empty_replica());
-        if replica.primary { primaries = primaries + 1; }
+        if replica.primary { primaries += 1; }
         metric.observe(inout out, latest - replica.applied_lsn, replica.lag + 1);
         metric.warn(inout out, replica.applied_lsn > latest);
         metric.warn(inout out, replica.lag != latest - replica.applied_lsn);

--- a/examples/meridian/report_audit.rue
+++ b/examples/meridian/report_audit.rue
@@ -55,7 +55,7 @@ pub fn render(borrow database: model.Database, borrow query: model.Query,
         separator(inout out);
         text.append_u64(inout out, table.row_count);
         out.push(10);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < query_plan.nodes.len() {
@@ -68,7 +68,7 @@ pub fn render(borrow database: model.Database, borrow query: model.Query,
         separator(inout out);
         text.append_u64(inout out, node.cost);
         out.push(10);
-        i = i + 1;
+        i += 1;
     }
     field(inout out, "digest", metric.mix(query_plan.digest, output.checksum));
     out

--- a/examples/meridian/report_benchmark.rue
+++ b/examples/meridian/report_benchmark.rue
@@ -55,7 +55,7 @@ pub fn render(borrow database: model.Database, borrow query: model.Query,
         separator(inout out);
         text.append_u64(inout out, table.row_count);
         out.push(10);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < query_plan.nodes.len() {
@@ -68,7 +68,7 @@ pub fn render(borrow database: model.Database, borrow query: model.Query,
         separator(inout out);
         text.append_u64(inout out, node.cost);
         out.push(10);
-        i = i + 1;
+        i += 1;
     }
     field(inout out, "digest", metric.mix(query_plan.digest, output.checksum));
     out

--- a/examples/meridian/report_catalog.rue
+++ b/examples/meridian/report_catalog.rue
@@ -55,7 +55,7 @@ pub fn render(borrow database: model.Database, borrow query: model.Query,
         separator(inout out);
         text.append_u64(inout out, table.row_count);
         out.push(10);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < query_plan.nodes.len() {
@@ -68,7 +68,7 @@ pub fn render(borrow database: model.Database, borrow query: model.Query,
         separator(inout out);
         text.append_u64(inout out, node.cost);
         out.push(10);
-        i = i + 1;
+        i += 1;
     }
     field(inout out, "digest", metric.mix(query_plan.digest, output.checksum));
     out

--- a/examples/meridian/report_cells.rue
+++ b/examples/meridian/report_cells.rue
@@ -55,7 +55,7 @@ pub fn render(borrow database: model.Database, borrow query: model.Query,
         separator(inout out);
         text.append_u64(inout out, table.row_count);
         out.push(10);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < query_plan.nodes.len() {
@@ -68,7 +68,7 @@ pub fn render(borrow database: model.Database, borrow query: model.Query,
         separator(inout out);
         text.append_u64(inout out, node.cost);
         out.push(10);
-        i = i + 1;
+        i += 1;
     }
     field(inout out, "digest", metric.mix(query_plan.digest, output.checksum));
     out

--- a/examples/meridian/report_checkpoint.rue
+++ b/examples/meridian/report_checkpoint.rue
@@ -55,7 +55,7 @@ pub fn render(borrow database: model.Database, borrow query: model.Query,
         separator(inout out);
         text.append_u64(inout out, table.row_count);
         out.push(10);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < query_plan.nodes.len() {
@@ -68,7 +68,7 @@ pub fn render(borrow database: model.Database, borrow query: model.Query,
         separator(inout out);
         text.append_u64(inout out, node.cost);
         out.push(10);
-        i = i + 1;
+        i += 1;
     }
     field(inout out, "digest", metric.mix(query_plan.digest, output.checksum));
     out

--- a/examples/meridian/report_chrome_trace.rue
+++ b/examples/meridian/report_chrome_trace.rue
@@ -55,7 +55,7 @@ pub fn render(borrow database: model.Database, borrow query: model.Query,
         separator(inout out);
         text.append_u64(inout out, table.row_count);
         out.push(10);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < query_plan.nodes.len() {
@@ -68,7 +68,7 @@ pub fn render(borrow database: model.Database, borrow query: model.Query,
         separator(inout out);
         text.append_u64(inout out, node.cost);
         out.push(10);
-        i = i + 1;
+        i += 1;
     }
     field(inout out, "digest", metric.mix(query_plan.digest, output.checksum));
     out

--- a/examples/meridian/report_columns.rue
+++ b/examples/meridian/report_columns.rue
@@ -55,7 +55,7 @@ pub fn render(borrow database: model.Database, borrow query: model.Query,
         separator(inout out);
         text.append_u64(inout out, table.row_count);
         out.push(10);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < query_plan.nodes.len() {
@@ -68,7 +68,7 @@ pub fn render(borrow database: model.Database, borrow query: model.Query,
         separator(inout out);
         text.append_u64(inout out, node.cost);
         out.push(10);
-        i = i + 1;
+        i += 1;
     }
     field(inout out, "digest", metric.mix(query_plan.digest, output.checksum));
     out

--- a/examples/meridian/report_constraints.rue
+++ b/examples/meridian/report_constraints.rue
@@ -55,7 +55,7 @@ pub fn render(borrow database: model.Database, borrow query: model.Query,
         separator(inout out);
         text.append_u64(inout out, table.row_count);
         out.push(10);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < query_plan.nodes.len() {
@@ -68,7 +68,7 @@ pub fn render(borrow database: model.Database, borrow query: model.Query,
         separator(inout out);
         text.append_u64(inout out, node.cost);
         out.push(10);
-        i = i + 1;
+        i += 1;
     }
     field(inout out, "digest", metric.mix(query_plan.digest, output.checksum));
     out

--- a/examples/meridian/report_cost.rue
+++ b/examples/meridian/report_cost.rue
@@ -55,7 +55,7 @@ pub fn render(borrow database: model.Database, borrow query: model.Query,
         separator(inout out);
         text.append_u64(inout out, table.row_count);
         out.push(10);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < query_plan.nodes.len() {
@@ -68,7 +68,7 @@ pub fn render(borrow database: model.Database, borrow query: model.Query,
         separator(inout out);
         text.append_u64(inout out, node.cost);
         out.push(10);
-        i = i + 1;
+        i += 1;
     }
     field(inout out, "digest", metric.mix(query_plan.digest, output.checksum));
     out

--- a/examples/meridian/report_csv.rue
+++ b/examples/meridian/report_csv.rue
@@ -55,7 +55,7 @@ pub fn render(borrow database: model.Database, borrow query: model.Query,
         separator(inout out);
         text.append_u64(inout out, table.row_count);
         out.push(10);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < query_plan.nodes.len() {
@@ -68,7 +68,7 @@ pub fn render(borrow database: model.Database, borrow query: model.Query,
         separator(inout out);
         text.append_u64(inout out, node.cost);
         out.push(10);
-        i = i + 1;
+        i += 1;
     }
     field(inout out, "digest", metric.mix(query_plan.digest, output.checksum));
     out

--- a/examples/meridian/report_deadlocks.rue
+++ b/examples/meridian/report_deadlocks.rue
@@ -55,7 +55,7 @@ pub fn render(borrow database: model.Database, borrow query: model.Query,
         separator(inout out);
         text.append_u64(inout out, table.row_count);
         out.push(10);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < query_plan.nodes.len() {
@@ -68,7 +68,7 @@ pub fn render(borrow database: model.Database, borrow query: model.Query,
         separator(inout out);
         text.append_u64(inout out, node.cost);
         out.push(10);
-        i = i + 1;
+        i += 1;
     }
     field(inout out, "digest", metric.mix(query_plan.digest, output.checksum));
     out

--- a/examples/meridian/report_dot.rue
+++ b/examples/meridian/report_dot.rue
@@ -55,7 +55,7 @@ pub fn render(borrow database: model.Database, borrow query: model.Query,
         separator(inout out);
         text.append_u64(inout out, table.row_count);
         out.push(10);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < query_plan.nodes.len() {
@@ -68,7 +68,7 @@ pub fn render(borrow database: model.Database, borrow query: model.Query,
         separator(inout out);
         text.append_u64(inout out, node.cost);
         out.push(10);
-        i = i + 1;
+        i += 1;
     }
     field(inout out, "digest", metric.mix(query_plan.digest, output.checksum));
     out

--- a/examples/meridian/report_explain.rue
+++ b/examples/meridian/report_explain.rue
@@ -55,7 +55,7 @@ pub fn render(borrow database: model.Database, borrow query: model.Query,
         separator(inout out);
         text.append_u64(inout out, table.row_count);
         out.push(10);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < query_plan.nodes.len() {
@@ -68,7 +68,7 @@ pub fn render(borrow database: model.Database, borrow query: model.Query,
         separator(inout out);
         text.append_u64(inout out, node.cost);
         out.push(10);
-        i = i + 1;
+        i += 1;
     }
     field(inout out, "digest", metric.mix(query_plan.digest, output.checksum));
     out

--- a/examples/meridian/report_failover.rue
+++ b/examples/meridian/report_failover.rue
@@ -55,7 +55,7 @@ pub fn render(borrow database: model.Database, borrow query: model.Query,
         separator(inout out);
         text.append_u64(inout out, table.row_count);
         out.push(10);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < query_plan.nodes.len() {
@@ -68,7 +68,7 @@ pub fn render(borrow database: model.Database, borrow query: model.Query,
         separator(inout out);
         text.append_u64(inout out, node.cost);
         out.push(10);
-        i = i + 1;
+        i += 1;
     }
     field(inout out, "digest", metric.mix(query_plan.digest, output.checksum));
     out

--- a/examples/meridian/report_html.rue
+++ b/examples/meridian/report_html.rue
@@ -55,7 +55,7 @@ pub fn render(borrow database: model.Database, borrow query: model.Query,
         separator(inout out);
         text.append_u64(inout out, table.row_count);
         out.push(10);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < query_plan.nodes.len() {
@@ -68,7 +68,7 @@ pub fn render(borrow database: model.Database, borrow query: model.Query,
         separator(inout out);
         text.append_u64(inout out, node.cost);
         out.push(10);
-        i = i + 1;
+        i += 1;
     }
     field(inout out, "digest", metric.mix(query_plan.digest, output.checksum));
     out

--- a/examples/meridian/report_human.rue
+++ b/examples/meridian/report_human.rue
@@ -55,7 +55,7 @@ pub fn render(borrow database: model.Database, borrow query: model.Query,
         separator(inout out);
         text.append_u64(inout out, table.row_count);
         out.push(10);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < query_plan.nodes.len() {
@@ -68,7 +68,7 @@ pub fn render(borrow database: model.Database, borrow query: model.Query,
         separator(inout out);
         text.append_u64(inout out, node.cost);
         out.push(10);
-        i = i + 1;
+        i += 1;
     }
     field(inout out, "digest", metric.mix(query_plan.digest, output.checksum));
     out

--- a/examples/meridian/report_indexes.rue
+++ b/examples/meridian/report_indexes.rue
@@ -55,7 +55,7 @@ pub fn render(borrow database: model.Database, borrow query: model.Query,
         separator(inout out);
         text.append_u64(inout out, table.row_count);
         out.push(10);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < query_plan.nodes.len() {
@@ -68,7 +68,7 @@ pub fn render(borrow database: model.Database, borrow query: model.Query,
         separator(inout out);
         text.append_u64(inout out, node.cost);
         out.push(10);
-        i = i + 1;
+        i += 1;
     }
     field(inout out, "digest", metric.mix(query_plan.digest, output.checksum));
     out

--- a/examples/meridian/report_json.rue
+++ b/examples/meridian/report_json.rue
@@ -55,7 +55,7 @@ pub fn render(borrow database: model.Database, borrow query: model.Query,
         separator(inout out);
         text.append_u64(inout out, table.row_count);
         out.push(10);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < query_plan.nodes.len() {
@@ -68,7 +68,7 @@ pub fn render(borrow database: model.Database, borrow query: model.Query,
         separator(inout out);
         text.append_u64(inout out, node.cost);
         out.push(10);
-        i = i + 1;
+        i += 1;
     }
     field(inout out, "digest", metric.mix(query_plan.digest, output.checksum));
     out

--- a/examples/meridian/report_junit.rue
+++ b/examples/meridian/report_junit.rue
@@ -55,7 +55,7 @@ pub fn render(borrow database: model.Database, borrow query: model.Query,
         separator(inout out);
         text.append_u64(inout out, table.row_count);
         out.push(10);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < query_plan.nodes.len() {
@@ -68,7 +68,7 @@ pub fn render(borrow database: model.Database, borrow query: model.Query,
         separator(inout out);
         text.append_u64(inout out, node.cost);
         out.push(10);
-        i = i + 1;
+        i += 1;
     }
     field(inout out, "digest", metric.mix(query_plan.digest, output.checksum));
     out

--- a/examples/meridian/report_lineage.rue
+++ b/examples/meridian/report_lineage.rue
@@ -55,7 +55,7 @@ pub fn render(borrow database: model.Database, borrow query: model.Query,
         separator(inout out);
         text.append_u64(inout out, table.row_count);
         out.push(10);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < query_plan.nodes.len() {
@@ -68,7 +68,7 @@ pub fn render(borrow database: model.Database, borrow query: model.Query,
         separator(inout out);
         text.append_u64(inout out, node.cost);
         out.push(10);
-        i = i + 1;
+        i += 1;
     }
     field(inout out, "digest", metric.mix(query_plan.digest, output.checksum));
     out

--- a/examples/meridian/report_locks.rue
+++ b/examples/meridian/report_locks.rue
@@ -55,7 +55,7 @@ pub fn render(borrow database: model.Database, borrow query: model.Query,
         separator(inout out);
         text.append_u64(inout out, table.row_count);
         out.push(10);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < query_plan.nodes.len() {
@@ -68,7 +68,7 @@ pub fn render(borrow database: model.Database, borrow query: model.Query,
         separator(inout out);
         text.append_u64(inout out, node.cost);
         out.push(10);
-        i = i + 1;
+        i += 1;
     }
     field(inout out, "digest", metric.mix(query_plan.digest, output.checksum));
     out

--- a/examples/meridian/report_markdown.rue
+++ b/examples/meridian/report_markdown.rue
@@ -55,7 +55,7 @@ pub fn render(borrow database: model.Database, borrow query: model.Query,
         separator(inout out);
         text.append_u64(inout out, table.row_count);
         out.push(10);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < query_plan.nodes.len() {
@@ -68,7 +68,7 @@ pub fn render(borrow database: model.Database, borrow query: model.Query,
         separator(inout out);
         text.append_u64(inout out, node.cost);
         out.push(10);
-        i = i + 1;
+        i += 1;
     }
     field(inout out, "digest", metric.mix(query_plan.digest, output.checksum));
     out

--- a/examples/meridian/report_mermaid.rue
+++ b/examples/meridian/report_mermaid.rue
@@ -55,7 +55,7 @@ pub fn render(borrow database: model.Database, borrow query: model.Query,
         separator(inout out);
         text.append_u64(inout out, table.row_count);
         out.push(10);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < query_plan.nodes.len() {
@@ -68,7 +68,7 @@ pub fn render(borrow database: model.Database, borrow query: model.Query,
         separator(inout out);
         text.append_u64(inout out, node.cost);
         out.push(10);
-        i = i + 1;
+        i += 1;
     }
     field(inout out, "digest", metric.mix(query_plan.digest, output.checksum));
     out

--- a/examples/meridian/report_mvcc.rue
+++ b/examples/meridian/report_mvcc.rue
@@ -55,7 +55,7 @@ pub fn render(borrow database: model.Database, borrow query: model.Query,
         separator(inout out);
         text.append_u64(inout out, table.row_count);
         out.push(10);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < query_plan.nodes.len() {
@@ -68,7 +68,7 @@ pub fn render(borrow database: model.Database, borrow query: model.Query,
         separator(inout out);
         text.append_u64(inout out, node.cost);
         out.push(10);
-        i = i + 1;
+        i += 1;
     }
     field(inout out, "digest", metric.mix(query_plan.digest, output.checksum));
     out

--- a/examples/meridian/report_ndjson.rue
+++ b/examples/meridian/report_ndjson.rue
@@ -55,7 +55,7 @@ pub fn render(borrow database: model.Database, borrow query: model.Query,
         separator(inout out);
         text.append_u64(inout out, table.row_count);
         out.push(10);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < query_plan.nodes.len() {
@@ -68,7 +68,7 @@ pub fn render(borrow database: model.Database, borrow query: model.Query,
         separator(inout out);
         text.append_u64(inout out, node.cost);
         out.push(10);
-        i = i + 1;
+        i += 1;
     }
     field(inout out, "digest", metric.mix(query_plan.digest, output.checksum));
     out

--- a/examples/meridian/report_otel.rue
+++ b/examples/meridian/report_otel.rue
@@ -55,7 +55,7 @@ pub fn render(borrow database: model.Database, borrow query: model.Query,
         separator(inout out);
         text.append_u64(inout out, table.row_count);
         out.push(10);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < query_plan.nodes.len() {
@@ -68,7 +68,7 @@ pub fn render(borrow database: model.Database, borrow query: model.Query,
         separator(inout out);
         text.append_u64(inout out, node.cost);
         out.push(10);
-        i = i + 1;
+        i += 1;
     }
     field(inout out, "digest", metric.mix(query_plan.digest, output.checksum));
     out

--- a/examples/meridian/report_partitions.rue
+++ b/examples/meridian/report_partitions.rue
@@ -55,7 +55,7 @@ pub fn render(borrow database: model.Database, borrow query: model.Query,
         separator(inout out);
         text.append_u64(inout out, table.row_count);
         out.push(10);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < query_plan.nodes.len() {
@@ -68,7 +68,7 @@ pub fn render(borrow database: model.Database, borrow query: model.Query,
         separator(inout out);
         text.append_u64(inout out, node.cost);
         out.push(10);
-        i = i + 1;
+        i += 1;
     }
     field(inout out, "digest", metric.mix(query_plan.digest, output.checksum));
     out

--- a/examples/meridian/report_plan.rue
+++ b/examples/meridian/report_plan.rue
@@ -55,7 +55,7 @@ pub fn render(borrow database: model.Database, borrow query: model.Query,
         separator(inout out);
         text.append_u64(inout out, table.row_count);
         out.push(10);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < query_plan.nodes.len() {
@@ -68,7 +68,7 @@ pub fn render(borrow database: model.Database, borrow query: model.Query,
         separator(inout out);
         text.append_u64(inout out, node.cost);
         out.push(10);
-        i = i + 1;
+        i += 1;
     }
     field(inout out, "digest", metric.mix(query_plan.digest, output.checksum));
     out

--- a/examples/meridian/report_prometheus.rue
+++ b/examples/meridian/report_prometheus.rue
@@ -55,7 +55,7 @@ pub fn render(borrow database: model.Database, borrow query: model.Query,
         separator(inout out);
         text.append_u64(inout out, table.row_count);
         out.push(10);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < query_plan.nodes.len() {
@@ -68,7 +68,7 @@ pub fn render(borrow database: model.Database, borrow query: model.Query,
         separator(inout out);
         text.append_u64(inout out, node.cost);
         out.push(10);
-        i = i + 1;
+        i += 1;
     }
     field(inout out, "digest", metric.mix(query_plan.digest, output.checksum));
     out

--- a/examples/meridian/report_query.rue
+++ b/examples/meridian/report_query.rue
@@ -55,7 +55,7 @@ pub fn render(borrow database: model.Database, borrow query: model.Query,
         separator(inout out);
         text.append_u64(inout out, table.row_count);
         out.push(10);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < query_plan.nodes.len() {
@@ -68,7 +68,7 @@ pub fn render(borrow database: model.Database, borrow query: model.Query,
         separator(inout out);
         text.append_u64(inout out, node.cost);
         out.push(10);
-        i = i + 1;
+        i += 1;
     }
     field(inout out, "digest", metric.mix(query_plan.digest, output.checksum));
     out

--- a/examples/meridian/report_recovery.rue
+++ b/examples/meridian/report_recovery.rue
@@ -55,7 +55,7 @@ pub fn render(borrow database: model.Database, borrow query: model.Query,
         separator(inout out);
         text.append_u64(inout out, table.row_count);
         out.push(10);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < query_plan.nodes.len() {
@@ -68,7 +68,7 @@ pub fn render(borrow database: model.Database, borrow query: model.Query,
         separator(inout out);
         text.append_u64(inout out, node.cost);
         out.push(10);
-        i = i + 1;
+        i += 1;
     }
     field(inout out, "digest", metric.mix(query_plan.digest, output.checksum));
     out

--- a/examples/meridian/report_replicas.rue
+++ b/examples/meridian/report_replicas.rue
@@ -55,7 +55,7 @@ pub fn render(borrow database: model.Database, borrow query: model.Query,
         separator(inout out);
         text.append_u64(inout out, table.row_count);
         out.push(10);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < query_plan.nodes.len() {
@@ -68,7 +68,7 @@ pub fn render(borrow database: model.Database, borrow query: model.Query,
         separator(inout out);
         text.append_u64(inout out, node.cost);
         out.push(10);
-        i = i + 1;
+        i += 1;
     }
     field(inout out, "digest", metric.mix(query_plan.digest, output.checksum));
     out

--- a/examples/meridian/report_rows.rue
+++ b/examples/meridian/report_rows.rue
@@ -55,7 +55,7 @@ pub fn render(borrow database: model.Database, borrow query: model.Query,
         separator(inout out);
         text.append_u64(inout out, table.row_count);
         out.push(10);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < query_plan.nodes.len() {
@@ -68,7 +68,7 @@ pub fn render(borrow database: model.Database, borrow query: model.Query,
         separator(inout out);
         text.append_u64(inout out, node.cost);
         out.push(10);
-        i = i + 1;
+        i += 1;
     }
     field(inout out, "digest", metric.mix(query_plan.digest, output.checksum));
     out

--- a/examples/meridian/report_sarif.rue
+++ b/examples/meridian/report_sarif.rue
@@ -55,7 +55,7 @@ pub fn render(borrow database: model.Database, borrow query: model.Query,
         separator(inout out);
         text.append_u64(inout out, table.row_count);
         out.push(10);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < query_plan.nodes.len() {
@@ -68,7 +68,7 @@ pub fn render(borrow database: model.Database, borrow query: model.Query,
         separator(inout out);
         text.append_u64(inout out, node.cost);
         out.push(10);
-        i = i + 1;
+        i += 1;
     }
     field(inout out, "digest", metric.mix(query_plan.digest, output.checksum));
     out

--- a/examples/meridian/report_schema.rue
+++ b/examples/meridian/report_schema.rue
@@ -55,7 +55,7 @@ pub fn render(borrow database: model.Database, borrow query: model.Query,
         separator(inout out);
         text.append_u64(inout out, table.row_count);
         out.push(10);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < query_plan.nodes.len() {
@@ -68,7 +68,7 @@ pub fn render(borrow database: model.Database, borrow query: model.Query,
         separator(inout out);
         text.append_u64(inout out, node.cost);
         out.push(10);
-        i = i + 1;
+        i += 1;
     }
     field(inout out, "digest", metric.mix(query_plan.digest, output.checksum));
     out

--- a/examples/meridian/report_shards.rue
+++ b/examples/meridian/report_shards.rue
@@ -55,7 +55,7 @@ pub fn render(borrow database: model.Database, borrow query: model.Query,
         separator(inout out);
         text.append_u64(inout out, table.row_count);
         out.push(10);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < query_plan.nodes.len() {
@@ -68,7 +68,7 @@ pub fn render(borrow database: model.Database, borrow query: model.Query,
         separator(inout out);
         text.append_u64(inout out, node.cost);
         out.push(10);
-        i = i + 1;
+        i += 1;
     }
     field(inout out, "digest", metric.mix(query_plan.digest, output.checksum));
     out

--- a/examples/meridian/report_sql.rue
+++ b/examples/meridian/report_sql.rue
@@ -55,7 +55,7 @@ pub fn render(borrow database: model.Database, borrow query: model.Query,
         separator(inout out);
         text.append_u64(inout out, table.row_count);
         out.push(10);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < query_plan.nodes.len() {
@@ -68,7 +68,7 @@ pub fn render(borrow database: model.Database, borrow query: model.Query,
         separator(inout out);
         text.append_u64(inout out, node.cost);
         out.push(10);
-        i = i + 1;
+        i += 1;
     }
     field(inout out, "digest", metric.mix(query_plan.digest, output.checksum));
     out

--- a/examples/meridian/report_statistics.rue
+++ b/examples/meridian/report_statistics.rue
@@ -55,7 +55,7 @@ pub fn render(borrow database: model.Database, borrow query: model.Query,
         separator(inout out);
         text.append_u64(inout out, table.row_count);
         out.push(10);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < query_plan.nodes.len() {
@@ -68,7 +68,7 @@ pub fn render(borrow database: model.Database, borrow query: model.Query,
         separator(inout out);
         text.append_u64(inout out, node.cost);
         out.push(10);
-        i = i + 1;
+        i += 1;
     }
     field(inout out, "digest", metric.mix(query_plan.digest, output.checksum));
     out

--- a/examples/meridian/report_suite.rue
+++ b/examples/meridian/report_suite.rue
@@ -69,7 +69,7 @@ fn include(inout audit: Audit, borrow first: StrBuf, borrow second: StrBuf, veri
     audit.documents += 1;
     audit.bytes += first.len();
     audit.digest = metric.mix(audit.digest, text.fnv1a(borrow first));
-    if !verified || first.len() == 0 { audit.failures = audit.failures + 1; }
+    if !verified || first.len() == 0 { audit.failures += 1; }
     if first.len() != second.len() ||
         text.fnv1a(borrow first) != text.fnv1a(borrow second) {
         audit.deterministic_mismatches += 1;

--- a/examples/meridian/report_suite.rue
+++ b/examples/meridian/report_suite.rue
@@ -66,14 +66,14 @@ fn empty() -> Audit {
 }
 
 fn include(inout audit: Audit, borrow first: StrBuf, borrow second: StrBuf, verified: bool) {
-    audit.documents = audit.documents + 1;
-    audit.bytes = audit.bytes + first.len();
+    audit.documents += 1;
+    audit.bytes += first.len();
     audit.digest = metric.mix(audit.digest, text.fnv1a(borrow first));
     if !verified || first.len() == 0 { audit.failures = audit.failures + 1; }
     if first.len() != second.len() ||
         text.fnv1a(borrow first) != text.fnv1a(borrow second) {
-        audit.deterministic_mismatches = audit.deterministic_mismatches + 1;
-        audit.failures = audit.failures + 1;
+        audit.deterministic_mismatches += 1;
+        audit.failures += 1;
     }
 }
 

--- a/examples/meridian/report_table.rue
+++ b/examples/meridian/report_table.rue
@@ -55,7 +55,7 @@ pub fn render(borrow database: model.Database, borrow query: model.Query,
         separator(inout out);
         text.append_u64(inout out, table.row_count);
         out.push(10);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < query_plan.nodes.len() {
@@ -68,7 +68,7 @@ pub fn render(borrow database: model.Database, borrow query: model.Query,
         separator(inout out);
         text.append_u64(inout out, node.cost);
         out.push(10);
-        i = i + 1;
+        i += 1;
     }
     field(inout out, "digest", metric.mix(query_plan.digest, output.checksum));
     out

--- a/examples/meridian/report_toml.rue
+++ b/examples/meridian/report_toml.rue
@@ -55,7 +55,7 @@ pub fn render(borrow database: model.Database, borrow query: model.Query,
         separator(inout out);
         text.append_u64(inout out, table.row_count);
         out.push(10);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < query_plan.nodes.len() {
@@ -68,7 +68,7 @@ pub fn render(borrow database: model.Database, borrow query: model.Query,
         separator(inout out);
         text.append_u64(inout out, node.cost);
         out.push(10);
-        i = i + 1;
+        i += 1;
     }
     field(inout out, "digest", metric.mix(query_plan.digest, output.checksum));
     out

--- a/examples/meridian/report_transactions.rue
+++ b/examples/meridian/report_transactions.rue
@@ -55,7 +55,7 @@ pub fn render(borrow database: model.Database, borrow query: model.Query,
         separator(inout out);
         text.append_u64(inout out, table.row_count);
         out.push(10);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < query_plan.nodes.len() {
@@ -68,7 +68,7 @@ pub fn render(borrow database: model.Database, borrow query: model.Query,
         separator(inout out);
         text.append_u64(inout out, node.cost);
         out.push(10);
-        i = i + 1;
+        i += 1;
     }
     field(inout out, "digest", metric.mix(query_plan.digest, output.checksum));
     out

--- a/examples/meridian/report_wal.rue
+++ b/examples/meridian/report_wal.rue
@@ -55,7 +55,7 @@ pub fn render(borrow database: model.Database, borrow query: model.Query,
         separator(inout out);
         text.append_u64(inout out, table.row_count);
         out.push(10);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < query_plan.nodes.len() {
@@ -68,7 +68,7 @@ pub fn render(borrow database: model.Database, borrow query: model.Query,
         separator(inout out);
         text.append_u64(inout out, node.cost);
         out.push(10);
-        i = i + 1;
+        i += 1;
     }
     field(inout out, "digest", metric.mix(query_plan.digest, output.checksum));
     out

--- a/examples/meridian/report_xml.rue
+++ b/examples/meridian/report_xml.rue
@@ -55,7 +55,7 @@ pub fn render(borrow database: model.Database, borrow query: model.Query,
         separator(inout out);
         text.append_u64(inout out, table.row_count);
         out.push(10);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < query_plan.nodes.len() {
@@ -68,7 +68,7 @@ pub fn render(borrow database: model.Database, borrow query: model.Query,
         separator(inout out);
         text.append_u64(inout out, node.cost);
         out.push(10);
-        i = i + 1;
+        i += 1;
     }
     field(inout out, "digest", metric.mix(query_plan.digest, output.checksum));
     out

--- a/examples/meridian/report_yaml.rue
+++ b/examples/meridian/report_yaml.rue
@@ -55,7 +55,7 @@ pub fn render(borrow database: model.Database, borrow query: model.Query,
         separator(inout out);
         text.append_u64(inout out, table.row_count);
         out.push(10);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < query_plan.nodes.len() {
@@ -68,7 +68,7 @@ pub fn render(borrow database: model.Database, borrow query: model.Query,
         separator(inout out);
         text.append_u64(inout out, node.cost);
         out.push(10);
-        i = i + 1;
+        i += 1;
     }
     field(inout out, "digest", metric.mix(query_plan.digest, output.checksum));
     out

--- a/examples/meridian/result.rue
+++ b/examples/meridian/result.rue
@@ -31,8 +31,8 @@ pub fn mix(hash: u64, value: u64) -> u64 {
 }
 
 pub fn observe(inout value: Result, item: u64) {
-    value.rows = value.rows + 1;
-    value.sum = value.sum + item;
+    value.rows += 1;
+    value.sum += item;
     if item < value.minimum { value.minimum = item; }
     if item > value.maximum { value.maximum = item; }
     value.checksum = mix(value.checksum, item);

--- a/examples/meridian/row_oracle.rue
+++ b/examples/meridian/row_oracle.rue
@@ -33,7 +33,7 @@ pub fn execute(borrow database: model.Database, borrow query: model.Query) -> re
                 let mut n: u64 = 0;
                 while n < matches {
                     result.observe(inout out, value);
-                    if query.join_table != model.NONE() { out.joined_rows = out.joined_rows + 1; }
+                    if query.join_table != model.NONE() { out.joined_rows += 1; }
                     n += 1;
                 }
             }

--- a/examples/meridian/row_oracle.rue
+++ b/examples/meridian/row_oracle.rue
@@ -21,9 +21,9 @@ pub fn execute(borrow database: model.Database, borrow query: model.Query) -> re
                         if other.table == query.join_table &&
                             model.visible(borrow other, database.version) &&
                             model.cell_number(borrow database, j, query.join_right) == key {
-                            matches = matches + 1;
+                            matches += 1;
                         }
-                        j = j + 1;
+                        j += 1;
                     }
                 }
                 let column = if query.order_column != model.NONE() { query.order_column }
@@ -34,11 +34,11 @@ pub fn execute(borrow database: model.Database, borrow query: model.Query) -> re
                 while n < matches {
                     result.observe(inout out, value);
                     if query.join_table != model.NONE() { out.joined_rows = out.joined_rows + 1; }
-                    n = n + 1;
+                    n += 1;
                 }
             }
         }
-        i = i + 1;
+        i += 1;
     }
     if query.limit != model.NONE() && out.rows > query.limit {
         out.rows = query.limit;

--- a/examples/meridian/rule_distributed_balance_fragments.rue
+++ b/examples/meridian/rule_distributed_balance_fragments.rue
@@ -53,13 +53,13 @@ fn inspect_indexes(inout out: rule_result.Decision, borrow database: model.Datab
     let mut i: u64 = 0;
     while i < database.indexes.len() {
         let index = database.indexes.get_or(i, model.empty_index());
-        out.inspected = out.inspected + 1;
+        out.inspected += 1;
         if index.table == query.table &&
             (index.column == query.filter_column || index.column == query.order_column) {
             let benefit = if index.unique { (FOCUS() % 7) + 1 } else { (FOCUS() % 3) + 1 };
             rule_result.record(inout out, benefit, index.entries + index.column + FOCUS());
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -69,7 +69,7 @@ fn inspect_columns(inout out: rule_result.Decision, borrow database: model.Datab
     let mut i: u64 = 0;
     while i < table.column_count {
         let column = database.columns.get_or(table.first_column + i, model.empty_column());
-        out.inspected = out.inspected + 1;
+        out.inspected += 1;
         let selected = (column.ordinal + FOCUS()) % 5 == 0 ||
             column.name == query.filter_column_name ||
             column.name == query.group_column_name ||
@@ -79,7 +79,7 @@ fn inspect_columns(inout out: rule_result.Decision, borrow database: model.Datab
             rule_result.record(inout out, benefit,
                 database.strings.hash(column.name) + column.kind + column.ordinal);
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -90,12 +90,12 @@ pub fn evaluate(borrow database: model.Database, borrow query: model.Query,
     let mut i: u64 = 0;
     while i < input.nodes.len() {
         let node = input.nodes.get_or(i, plan.empty_node());
-        out.inspected = out.inspected + 1;
+        out.inspected += 1;
         if eligible(borrow node, borrow query) {
             rule_result.record(inout out, node_benefit(borrow node),
                 fingerprint + node.kind * 17 + node.estimated_rows + i);
         }
-        i = i + 1;
+        i += 1;
     }
     inspect_indexes(inout out, borrow database, borrow query);
     inspect_columns(inout out, borrow database, borrow query);

--- a/examples/meridian/rule_distributed_broadcast_small.rue
+++ b/examples/meridian/rule_distributed_broadcast_small.rue
@@ -53,13 +53,13 @@ fn inspect_indexes(inout out: rule_result.Decision, borrow database: model.Datab
     let mut i: u64 = 0;
     while i < database.indexes.len() {
         let index = database.indexes.get_or(i, model.empty_index());
-        out.inspected = out.inspected + 1;
+        out.inspected += 1;
         if index.table == query.table &&
             (index.column == query.filter_column || index.column == query.order_column) {
             let benefit = if index.unique { (FOCUS() % 7) + 1 } else { (FOCUS() % 3) + 1 };
             rule_result.record(inout out, benefit, index.entries + index.column + FOCUS());
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -69,7 +69,7 @@ fn inspect_columns(inout out: rule_result.Decision, borrow database: model.Datab
     let mut i: u64 = 0;
     while i < table.column_count {
         let column = database.columns.get_or(table.first_column + i, model.empty_column());
-        out.inspected = out.inspected + 1;
+        out.inspected += 1;
         let selected = (column.ordinal + FOCUS()) % 5 == 0 ||
             column.name == query.filter_column_name ||
             column.name == query.group_column_name ||
@@ -79,7 +79,7 @@ fn inspect_columns(inout out: rule_result.Decision, borrow database: model.Datab
             rule_result.record(inout out, benefit,
                 database.strings.hash(column.name) + column.kind + column.ordinal);
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -90,12 +90,12 @@ pub fn evaluate(borrow database: model.Database, borrow query: model.Query,
     let mut i: u64 = 0;
     while i < input.nodes.len() {
         let node = input.nodes.get_or(i, plan.empty_node());
-        out.inspected = out.inspected + 1;
+        out.inspected += 1;
         if eligible(borrow node, borrow query) {
             rule_result.record(inout out, node_benefit(borrow node),
                 fingerprint + node.kind * 17 + node.estimated_rows + i);
         }
-        i = i + 1;
+        i += 1;
     }
     inspect_indexes(inout out, borrow database, borrow query);
     inspect_columns(inout out, borrow database, borrow query);

--- a/examples/meridian/rule_distributed_colocate_join.rue
+++ b/examples/meridian/rule_distributed_colocate_join.rue
@@ -53,13 +53,13 @@ fn inspect_indexes(inout out: rule_result.Decision, borrow database: model.Datab
     let mut i: u64 = 0;
     while i < database.indexes.len() {
         let index = database.indexes.get_or(i, model.empty_index());
-        out.inspected = out.inspected + 1;
+        out.inspected += 1;
         if index.table == query.table &&
             (index.column == query.filter_column || index.column == query.order_column) {
             let benefit = if index.unique { (FOCUS() % 7) + 1 } else { (FOCUS() % 3) + 1 };
             rule_result.record(inout out, benefit, index.entries + index.column + FOCUS());
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -69,7 +69,7 @@ fn inspect_columns(inout out: rule_result.Decision, borrow database: model.Datab
     let mut i: u64 = 0;
     while i < table.column_count {
         let column = database.columns.get_or(table.first_column + i, model.empty_column());
-        out.inspected = out.inspected + 1;
+        out.inspected += 1;
         let selected = (column.ordinal + FOCUS()) % 5 == 0 ||
             column.name == query.filter_column_name ||
             column.name == query.group_column_name ||
@@ -79,7 +79,7 @@ fn inspect_columns(inout out: rule_result.Decision, borrow database: model.Datab
             rule_result.record(inout out, benefit,
                 database.strings.hash(column.name) + column.kind + column.ordinal);
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -90,12 +90,12 @@ pub fn evaluate(borrow database: model.Database, borrow query: model.Query,
     let mut i: u64 = 0;
     while i < input.nodes.len() {
         let node = input.nodes.get_or(i, plan.empty_node());
-        out.inspected = out.inspected + 1;
+        out.inspected += 1;
         if eligible(borrow node, borrow query) {
             rule_result.record(inout out, node_benefit(borrow node),
                 fingerprint + node.kind * 17 + node.estimated_rows + i);
         }
-        i = i + 1;
+        i += 1;
     }
     inspect_indexes(inout out, borrow database, borrow query);
     inspect_columns(inout out, borrow database, borrow query);

--- a/examples/meridian/rule_distributed_compress_exchange.rue
+++ b/examples/meridian/rule_distributed_compress_exchange.rue
@@ -53,13 +53,13 @@ fn inspect_indexes(inout out: rule_result.Decision, borrow database: model.Datab
     let mut i: u64 = 0;
     while i < database.indexes.len() {
         let index = database.indexes.get_or(i, model.empty_index());
-        out.inspected = out.inspected + 1;
+        out.inspected += 1;
         if index.table == query.table &&
             (index.column == query.filter_column || index.column == query.order_column) {
             let benefit = if index.unique { (FOCUS() % 7) + 1 } else { (FOCUS() % 3) + 1 };
             rule_result.record(inout out, benefit, index.entries + index.column + FOCUS());
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -69,7 +69,7 @@ fn inspect_columns(inout out: rule_result.Decision, borrow database: model.Datab
     let mut i: u64 = 0;
     while i < table.column_count {
         let column = database.columns.get_or(table.first_column + i, model.empty_column());
-        out.inspected = out.inspected + 1;
+        out.inspected += 1;
         let selected = (column.ordinal + FOCUS()) % 5 == 0 ||
             column.name == query.filter_column_name ||
             column.name == query.group_column_name ||
@@ -79,7 +79,7 @@ fn inspect_columns(inout out: rule_result.Decision, borrow database: model.Datab
             rule_result.record(inout out, benefit,
                 database.strings.hash(column.name) + column.kind + column.ordinal);
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -90,12 +90,12 @@ pub fn evaluate(borrow database: model.Database, borrow query: model.Query,
     let mut i: u64 = 0;
     while i < input.nodes.len() {
         let node = input.nodes.get_or(i, plan.empty_node());
-        out.inspected = out.inspected + 1;
+        out.inspected += 1;
         if eligible(borrow node, borrow query) {
             rule_result.record(inout out, node_benefit(borrow node),
                 fingerprint + node.kind * 17 + node.estimated_rows + i);
         }
-        i = i + 1;
+        i += 1;
     }
     inspect_indexes(inout out, borrow database, borrow query);
     inspect_columns(inout out, borrow database, borrow query);

--- a/examples/meridian/rule_distributed_limit_exchange.rue
+++ b/examples/meridian/rule_distributed_limit_exchange.rue
@@ -53,13 +53,13 @@ fn inspect_indexes(inout out: rule_result.Decision, borrow database: model.Datab
     let mut i: u64 = 0;
     while i < database.indexes.len() {
         let index = database.indexes.get_or(i, model.empty_index());
-        out.inspected = out.inspected + 1;
+        out.inspected += 1;
         if index.table == query.table &&
             (index.column == query.filter_column || index.column == query.order_column) {
             let benefit = if index.unique { (FOCUS() % 7) + 1 } else { (FOCUS() % 3) + 1 };
             rule_result.record(inout out, benefit, index.entries + index.column + FOCUS());
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -69,7 +69,7 @@ fn inspect_columns(inout out: rule_result.Decision, borrow database: model.Datab
     let mut i: u64 = 0;
     while i < table.column_count {
         let column = database.columns.get_or(table.first_column + i, model.empty_column());
-        out.inspected = out.inspected + 1;
+        out.inspected += 1;
         let selected = (column.ordinal + FOCUS()) % 5 == 0 ||
             column.name == query.filter_column_name ||
             column.name == query.group_column_name ||
@@ -79,7 +79,7 @@ fn inspect_columns(inout out: rule_result.Decision, borrow database: model.Datab
             rule_result.record(inout out, benefit,
                 database.strings.hash(column.name) + column.kind + column.ordinal);
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -90,12 +90,12 @@ pub fn evaluate(borrow database: model.Database, borrow query: model.Query,
     let mut i: u64 = 0;
     while i < input.nodes.len() {
         let node = input.nodes.get_or(i, plan.empty_node());
-        out.inspected = out.inspected + 1;
+        out.inspected += 1;
         if eligible(borrow node, borrow query) {
             rule_result.record(inout out, node_benefit(borrow node),
                 fingerprint + node.kind * 17 + node.estimated_rows + i);
         }
-        i = i + 1;
+        i += 1;
     }
     inspect_indexes(inout out, borrow database, borrow query);
     inspect_columns(inout out, borrow database, borrow query);

--- a/examples/meridian/rule_distributed_merge_exchange.rue
+++ b/examples/meridian/rule_distributed_merge_exchange.rue
@@ -53,13 +53,13 @@ fn inspect_indexes(inout out: rule_result.Decision, borrow database: model.Datab
     let mut i: u64 = 0;
     while i < database.indexes.len() {
         let index = database.indexes.get_or(i, model.empty_index());
-        out.inspected = out.inspected + 1;
+        out.inspected += 1;
         if index.table == query.table &&
             (index.column == query.filter_column || index.column == query.order_column) {
             let benefit = if index.unique { (FOCUS() % 7) + 1 } else { (FOCUS() % 3) + 1 };
             rule_result.record(inout out, benefit, index.entries + index.column + FOCUS());
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -69,7 +69,7 @@ fn inspect_columns(inout out: rule_result.Decision, borrow database: model.Datab
     let mut i: u64 = 0;
     while i < table.column_count {
         let column = database.columns.get_or(table.first_column + i, model.empty_column());
-        out.inspected = out.inspected + 1;
+        out.inspected += 1;
         let selected = (column.ordinal + FOCUS()) % 5 == 0 ||
             column.name == query.filter_column_name ||
             column.name == query.group_column_name ||
@@ -79,7 +79,7 @@ fn inspect_columns(inout out: rule_result.Decision, borrow database: model.Datab
             rule_result.record(inout out, benefit,
                 database.strings.hash(column.name) + column.kind + column.ordinal);
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -90,12 +90,12 @@ pub fn evaluate(borrow database: model.Database, borrow query: model.Query,
     let mut i: u64 = 0;
     while i < input.nodes.len() {
         let node = input.nodes.get_or(i, plan.empty_node());
-        out.inspected = out.inspected + 1;
+        out.inspected += 1;
         if eligible(borrow node, borrow query) {
             rule_result.record(inout out, node_benefit(borrow node),
                 fingerprint + node.kind * 17 + node.estimated_rows + i);
         }
-        i = i + 1;
+        i += 1;
     }
     inspect_indexes(inout out, borrow database, borrow query);
     inspect_columns(inout out, borrow database, borrow query);

--- a/examples/meridian/rule_distributed_order_exchange.rue
+++ b/examples/meridian/rule_distributed_order_exchange.rue
@@ -53,13 +53,13 @@ fn inspect_indexes(inout out: rule_result.Decision, borrow database: model.Datab
     let mut i: u64 = 0;
     while i < database.indexes.len() {
         let index = database.indexes.get_or(i, model.empty_index());
-        out.inspected = out.inspected + 1;
+        out.inspected += 1;
         if index.table == query.table &&
             (index.column == query.filter_column || index.column == query.order_column) {
             let benefit = if index.unique { (FOCUS() % 7) + 1 } else { (FOCUS() % 3) + 1 };
             rule_result.record(inout out, benefit, index.entries + index.column + FOCUS());
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -69,7 +69,7 @@ fn inspect_columns(inout out: rule_result.Decision, borrow database: model.Datab
     let mut i: u64 = 0;
     while i < table.column_count {
         let column = database.columns.get_or(table.first_column + i, model.empty_column());
-        out.inspected = out.inspected + 1;
+        out.inspected += 1;
         let selected = (column.ordinal + FOCUS()) % 5 == 0 ||
             column.name == query.filter_column_name ||
             column.name == query.group_column_name ||
@@ -79,7 +79,7 @@ fn inspect_columns(inout out: rule_result.Decision, borrow database: model.Datab
             rule_result.record(inout out, benefit,
                 database.strings.hash(column.name) + column.kind + column.ordinal);
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -90,12 +90,12 @@ pub fn evaluate(borrow database: model.Database, borrow query: model.Query,
     let mut i: u64 = 0;
     while i < input.nodes.len() {
         let node = input.nodes.get_or(i, plan.empty_node());
-        out.inspected = out.inspected + 1;
+        out.inspected += 1;
         if eligible(borrow node, borrow query) {
             rule_result.record(inout out, node_benefit(borrow node),
                 fingerprint + node.kind * 17 + node.estimated_rows + i);
         }
-        i = i + 1;
+        i += 1;
     }
     inspect_indexes(inout out, borrow database, borrow query);
     inspect_columns(inout out, borrow database, borrow query);

--- a/examples/meridian/rule_distributed_pipeline_fragment.rue
+++ b/examples/meridian/rule_distributed_pipeline_fragment.rue
@@ -53,13 +53,13 @@ fn inspect_indexes(inout out: rule_result.Decision, borrow database: model.Datab
     let mut i: u64 = 0;
     while i < database.indexes.len() {
         let index = database.indexes.get_or(i, model.empty_index());
-        out.inspected = out.inspected + 1;
+        out.inspected += 1;
         if index.table == query.table &&
             (index.column == query.filter_column || index.column == query.order_column) {
             let benefit = if index.unique { (FOCUS() % 7) + 1 } else { (FOCUS() % 3) + 1 };
             rule_result.record(inout out, benefit, index.entries + index.column + FOCUS());
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -69,7 +69,7 @@ fn inspect_columns(inout out: rule_result.Decision, borrow database: model.Datab
     let mut i: u64 = 0;
     while i < table.column_count {
         let column = database.columns.get_or(table.first_column + i, model.empty_column());
-        out.inspected = out.inspected + 1;
+        out.inspected += 1;
         let selected = (column.ordinal + FOCUS()) % 5 == 0 ||
             column.name == query.filter_column_name ||
             column.name == query.group_column_name ||
@@ -79,7 +79,7 @@ fn inspect_columns(inout out: rule_result.Decision, borrow database: model.Datab
             rule_result.record(inout out, benefit,
                 database.strings.hash(column.name) + column.kind + column.ordinal);
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -90,12 +90,12 @@ pub fn evaluate(borrow database: model.Database, borrow query: model.Query,
     let mut i: u64 = 0;
     while i < input.nodes.len() {
         let node = input.nodes.get_or(i, plan.empty_node());
-        out.inspected = out.inspected + 1;
+        out.inspected += 1;
         if eligible(borrow node, borrow query) {
             rule_result.record(inout out, node_benefit(borrow node),
                 fingerprint + node.kind * 17 + node.estimated_rows + i);
         }
-        i = i + 1;
+        i += 1;
     }
     inspect_indexes(inout out, borrow database, borrow query);
     inspect_columns(inout out, borrow database, borrow query);

--- a/examples/meridian/rule_distributed_primary_write.rue
+++ b/examples/meridian/rule_distributed_primary_write.rue
@@ -53,13 +53,13 @@ fn inspect_indexes(inout out: rule_result.Decision, borrow database: model.Datab
     let mut i: u64 = 0;
     while i < database.indexes.len() {
         let index = database.indexes.get_or(i, model.empty_index());
-        out.inspected = out.inspected + 1;
+        out.inspected += 1;
         if index.table == query.table &&
             (index.column == query.filter_column || index.column == query.order_column) {
             let benefit = if index.unique { (FOCUS() % 7) + 1 } else { (FOCUS() % 3) + 1 };
             rule_result.record(inout out, benefit, index.entries + index.column + FOCUS());
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -69,7 +69,7 @@ fn inspect_columns(inout out: rule_result.Decision, borrow database: model.Datab
     let mut i: u64 = 0;
     while i < table.column_count {
         let column = database.columns.get_or(table.first_column + i, model.empty_column());
-        out.inspected = out.inspected + 1;
+        out.inspected += 1;
         let selected = (column.ordinal + FOCUS()) % 5 == 0 ||
             column.name == query.filter_column_name ||
             column.name == query.group_column_name ||
@@ -79,7 +79,7 @@ fn inspect_columns(inout out: rule_result.Decision, borrow database: model.Datab
             rule_result.record(inout out, benefit,
                 database.strings.hash(column.name) + column.kind + column.ordinal);
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -90,12 +90,12 @@ pub fn evaluate(borrow database: model.Database, borrow query: model.Query,
     let mut i: u64 = 0;
     while i < input.nodes.len() {
         let node = input.nodes.get_or(i, plan.empty_node());
-        out.inspected = out.inspected + 1;
+        out.inspected += 1;
         if eligible(borrow node, borrow query) {
             rule_result.record(inout out, node_benefit(borrow node),
                 fingerprint + node.kind * 17 + node.estimated_rows + i);
         }
-        i = i + 1;
+        i += 1;
     }
     inspect_indexes(inout out, borrow database, borrow query);
     inspect_columns(inout out, borrow database, borrow query);

--- a/examples/meridian/rule_distributed_prune_shards.rue
+++ b/examples/meridian/rule_distributed_prune_shards.rue
@@ -53,13 +53,13 @@ fn inspect_indexes(inout out: rule_result.Decision, borrow database: model.Datab
     let mut i: u64 = 0;
     while i < database.indexes.len() {
         let index = database.indexes.get_or(i, model.empty_index());
-        out.inspected = out.inspected + 1;
+        out.inspected += 1;
         if index.table == query.table &&
             (index.column == query.filter_column || index.column == query.order_column) {
             let benefit = if index.unique { (FOCUS() % 7) + 1 } else { (FOCUS() % 3) + 1 };
             rule_result.record(inout out, benefit, index.entries + index.column + FOCUS());
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -69,7 +69,7 @@ fn inspect_columns(inout out: rule_result.Decision, borrow database: model.Datab
     let mut i: u64 = 0;
     while i < table.column_count {
         let column = database.columns.get_or(table.first_column + i, model.empty_column());
-        out.inspected = out.inspected + 1;
+        out.inspected += 1;
         let selected = (column.ordinal + FOCUS()) % 5 == 0 ||
             column.name == query.filter_column_name ||
             column.name == query.group_column_name ||
@@ -79,7 +79,7 @@ fn inspect_columns(inout out: rule_result.Decision, borrow database: model.Datab
             rule_result.record(inout out, benefit,
                 database.strings.hash(column.name) + column.kind + column.ordinal);
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -90,12 +90,12 @@ pub fn evaluate(borrow database: model.Database, borrow query: model.Query,
     let mut i: u64 = 0;
     while i < input.nodes.len() {
         let node = input.nodes.get_or(i, plan.empty_node());
-        out.inspected = out.inspected + 1;
+        out.inspected += 1;
         if eligible(borrow node, borrow query) {
             rule_result.record(inout out, node_benefit(borrow node),
                 fingerprint + node.kind * 17 + node.estimated_rows + i);
         }
-        i = i + 1;
+        i += 1;
     }
     inspect_indexes(inout out, borrow database, borrow query);
     inspect_columns(inout out, borrow database, borrow query);

--- a/examples/meridian/rule_distributed_push_aggregate.rue
+++ b/examples/meridian/rule_distributed_push_aggregate.rue
@@ -53,13 +53,13 @@ fn inspect_indexes(inout out: rule_result.Decision, borrow database: model.Datab
     let mut i: u64 = 0;
     while i < database.indexes.len() {
         let index = database.indexes.get_or(i, model.empty_index());
-        out.inspected = out.inspected + 1;
+        out.inspected += 1;
         if index.table == query.table &&
             (index.column == query.filter_column || index.column == query.order_column) {
             let benefit = if index.unique { (FOCUS() % 7) + 1 } else { (FOCUS() % 3) + 1 };
             rule_result.record(inout out, benefit, index.entries + index.column + FOCUS());
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -69,7 +69,7 @@ fn inspect_columns(inout out: rule_result.Decision, borrow database: model.Datab
     let mut i: u64 = 0;
     while i < table.column_count {
         let column = database.columns.get_or(table.first_column + i, model.empty_column());
-        out.inspected = out.inspected + 1;
+        out.inspected += 1;
         let selected = (column.ordinal + FOCUS()) % 5 == 0 ||
             column.name == query.filter_column_name ||
             column.name == query.group_column_name ||
@@ -79,7 +79,7 @@ fn inspect_columns(inout out: rule_result.Decision, borrow database: model.Datab
             rule_result.record(inout out, benefit,
                 database.strings.hash(column.name) + column.kind + column.ordinal);
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -90,12 +90,12 @@ pub fn evaluate(borrow database: model.Database, borrow query: model.Query,
     let mut i: u64 = 0;
     while i < input.nodes.len() {
         let node = input.nodes.get_or(i, plan.empty_node());
-        out.inspected = out.inspected + 1;
+        out.inspected += 1;
         if eligible(borrow node, borrow query) {
             rule_result.record(inout out, node_benefit(borrow node),
                 fingerprint + node.kind * 17 + node.estimated_rows + i);
         }
-        i = i + 1;
+        i += 1;
     }
     inspect_indexes(inout out, borrow database, borrow query);
     inspect_columns(inout out, borrow database, borrow query);

--- a/examples/meridian/rule_distributed_push_filter.rue
+++ b/examples/meridian/rule_distributed_push_filter.rue
@@ -53,13 +53,13 @@ fn inspect_indexes(inout out: rule_result.Decision, borrow database: model.Datab
     let mut i: u64 = 0;
     while i < database.indexes.len() {
         let index = database.indexes.get_or(i, model.empty_index());
-        out.inspected = out.inspected + 1;
+        out.inspected += 1;
         if index.table == query.table &&
             (index.column == query.filter_column || index.column == query.order_column) {
             let benefit = if index.unique { (FOCUS() % 7) + 1 } else { (FOCUS() % 3) + 1 };
             rule_result.record(inout out, benefit, index.entries + index.column + FOCUS());
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -69,7 +69,7 @@ fn inspect_columns(inout out: rule_result.Decision, borrow database: model.Datab
     let mut i: u64 = 0;
     while i < table.column_count {
         let column = database.columns.get_or(table.first_column + i, model.empty_column());
-        out.inspected = out.inspected + 1;
+        out.inspected += 1;
         let selected = (column.ordinal + FOCUS()) % 5 == 0 ||
             column.name == query.filter_column_name ||
             column.name == query.group_column_name ||
@@ -79,7 +79,7 @@ fn inspect_columns(inout out: rule_result.Decision, borrow database: model.Datab
             rule_result.record(inout out, benefit,
                 database.strings.hash(column.name) + column.kind + column.ordinal);
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -90,12 +90,12 @@ pub fn evaluate(borrow database: model.Database, borrow query: model.Query,
     let mut i: u64 = 0;
     while i < input.nodes.len() {
         let node = input.nodes.get_or(i, plan.empty_node());
-        out.inspected = out.inspected + 1;
+        out.inspected += 1;
         if eligible(borrow node, borrow query) {
             rule_result.record(inout out, node_benefit(borrow node),
                 fingerprint + node.kind * 17 + node.estimated_rows + i);
         }
-        i = i + 1;
+        i += 1;
     }
     inspect_indexes(inout out, borrow database, borrow query);
     inspect_columns(inout out, borrow database, borrow query);

--- a/examples/meridian/rule_distributed_repartition_large.rue
+++ b/examples/meridian/rule_distributed_repartition_large.rue
@@ -53,13 +53,13 @@ fn inspect_indexes(inout out: rule_result.Decision, borrow database: model.Datab
     let mut i: u64 = 0;
     while i < database.indexes.len() {
         let index = database.indexes.get_or(i, model.empty_index());
-        out.inspected = out.inspected + 1;
+        out.inspected += 1;
         if index.table == query.table &&
             (index.column == query.filter_column || index.column == query.order_column) {
             let benefit = if index.unique { (FOCUS() % 7) + 1 } else { (FOCUS() % 3) + 1 };
             rule_result.record(inout out, benefit, index.entries + index.column + FOCUS());
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -69,7 +69,7 @@ fn inspect_columns(inout out: rule_result.Decision, borrow database: model.Datab
     let mut i: u64 = 0;
     while i < table.column_count {
         let column = database.columns.get_or(table.first_column + i, model.empty_column());
-        out.inspected = out.inspected + 1;
+        out.inspected += 1;
         let selected = (column.ordinal + FOCUS()) % 5 == 0 ||
             column.name == query.filter_column_name ||
             column.name == query.group_column_name ||
@@ -79,7 +79,7 @@ fn inspect_columns(inout out: rule_result.Decision, borrow database: model.Datab
             rule_result.record(inout out, benefit,
                 database.strings.hash(column.name) + column.kind + column.ordinal);
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -90,12 +90,12 @@ pub fn evaluate(borrow database: model.Database, borrow query: model.Query,
     let mut i: u64 = 0;
     while i < input.nodes.len() {
         let node = input.nodes.get_or(i, plan.empty_node());
-        out.inspected = out.inspected + 1;
+        out.inspected += 1;
         if eligible(borrow node, borrow query) {
             rule_result.record(inout out, node_benefit(borrow node),
                 fingerprint + node.kind * 17 + node.estimated_rows + i);
         }
-        i = i + 1;
+        i += 1;
     }
     inspect_indexes(inout out, borrow database, borrow query);
     inspect_columns(inout out, borrow database, borrow query);

--- a/examples/meridian/rule_distributed_replica_read.rue
+++ b/examples/meridian/rule_distributed_replica_read.rue
@@ -53,13 +53,13 @@ fn inspect_indexes(inout out: rule_result.Decision, borrow database: model.Datab
     let mut i: u64 = 0;
     while i < database.indexes.len() {
         let index = database.indexes.get_or(i, model.empty_index());
-        out.inspected = out.inspected + 1;
+        out.inspected += 1;
         if index.table == query.table &&
             (index.column == query.filter_column || index.column == query.order_column) {
             let benefit = if index.unique { (FOCUS() % 7) + 1 } else { (FOCUS() % 3) + 1 };
             rule_result.record(inout out, benefit, index.entries + index.column + FOCUS());
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -69,7 +69,7 @@ fn inspect_columns(inout out: rule_result.Decision, borrow database: model.Datab
     let mut i: u64 = 0;
     while i < table.column_count {
         let column = database.columns.get_or(table.first_column + i, model.empty_column());
-        out.inspected = out.inspected + 1;
+        out.inspected += 1;
         let selected = (column.ordinal + FOCUS()) % 5 == 0 ||
             column.name == query.filter_column_name ||
             column.name == query.group_column_name ||
@@ -79,7 +79,7 @@ fn inspect_columns(inout out: rule_result.Decision, borrow database: model.Datab
             rule_result.record(inout out, benefit,
                 database.strings.hash(column.name) + column.kind + column.ordinal);
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -90,12 +90,12 @@ pub fn evaluate(borrow database: model.Database, borrow query: model.Query,
     let mut i: u64 = 0;
     while i < input.nodes.len() {
         let node = input.nodes.get_or(i, plan.empty_node());
-        out.inspected = out.inspected + 1;
+        out.inspected += 1;
         if eligible(borrow node, borrow query) {
             rule_result.record(inout out, node_benefit(borrow node),
                 fingerprint + node.kind * 17 + node.estimated_rows + i);
         }
-        i = i + 1;
+        i += 1;
     }
     inspect_indexes(inout out, borrow database, borrow query);
     inspect_columns(inout out, borrow database, borrow query);

--- a/examples/meridian/rule_distributed_retry_fragment.rue
+++ b/examples/meridian/rule_distributed_retry_fragment.rue
@@ -53,13 +53,13 @@ fn inspect_indexes(inout out: rule_result.Decision, borrow database: model.Datab
     let mut i: u64 = 0;
     while i < database.indexes.len() {
         let index = database.indexes.get_or(i, model.empty_index());
-        out.inspected = out.inspected + 1;
+        out.inspected += 1;
         if index.table == query.table &&
             (index.column == query.filter_column || index.column == query.order_column) {
             let benefit = if index.unique { (FOCUS() % 7) + 1 } else { (FOCUS() % 3) + 1 };
             rule_result.record(inout out, benefit, index.entries + index.column + FOCUS());
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -69,7 +69,7 @@ fn inspect_columns(inout out: rule_result.Decision, borrow database: model.Datab
     let mut i: u64 = 0;
     while i < table.column_count {
         let column = database.columns.get_or(table.first_column + i, model.empty_column());
-        out.inspected = out.inspected + 1;
+        out.inspected += 1;
         let selected = (column.ordinal + FOCUS()) % 5 == 0 ||
             column.name == query.filter_column_name ||
             column.name == query.group_column_name ||
@@ -79,7 +79,7 @@ fn inspect_columns(inout out: rule_result.Decision, borrow database: model.Datab
             rule_result.record(inout out, benefit,
                 database.strings.hash(column.name) + column.kind + column.ordinal);
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -90,12 +90,12 @@ pub fn evaluate(borrow database: model.Database, borrow query: model.Query,
     let mut i: u64 = 0;
     while i < input.nodes.len() {
         let node = input.nodes.get_or(i, plan.empty_node());
-        out.inspected = out.inspected + 1;
+        out.inspected += 1;
         if eligible(borrow node, borrow query) {
             rule_result.record(inout out, node_benefit(borrow node),
                 fingerprint + node.kind * 17 + node.estimated_rows + i);
         }
-        i = i + 1;
+        i += 1;
     }
     inspect_indexes(inout out, borrow database, borrow query);
     inspect_columns(inout out, borrow database, borrow query);

--- a/examples/meridian/rule_distributed_route_single_shard.rue
+++ b/examples/meridian/rule_distributed_route_single_shard.rue
@@ -53,13 +53,13 @@ fn inspect_indexes(inout out: rule_result.Decision, borrow database: model.Datab
     let mut i: u64 = 0;
     while i < database.indexes.len() {
         let index = database.indexes.get_or(i, model.empty_index());
-        out.inspected = out.inspected + 1;
+        out.inspected += 1;
         if index.table == query.table &&
             (index.column == query.filter_column || index.column == query.order_column) {
             let benefit = if index.unique { (FOCUS() % 7) + 1 } else { (FOCUS() % 3) + 1 };
             rule_result.record(inout out, benefit, index.entries + index.column + FOCUS());
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -69,7 +69,7 @@ fn inspect_columns(inout out: rule_result.Decision, borrow database: model.Datab
     let mut i: u64 = 0;
     while i < table.column_count {
         let column = database.columns.get_or(table.first_column + i, model.empty_column());
-        out.inspected = out.inspected + 1;
+        out.inspected += 1;
         let selected = (column.ordinal + FOCUS()) % 5 == 0 ||
             column.name == query.filter_column_name ||
             column.name == query.group_column_name ||
@@ -79,7 +79,7 @@ fn inspect_columns(inout out: rule_result.Decision, borrow database: model.Datab
             rule_result.record(inout out, benefit,
                 database.strings.hash(column.name) + column.kind + column.ordinal);
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -90,12 +90,12 @@ pub fn evaluate(borrow database: model.Database, borrow query: model.Query,
     let mut i: u64 = 0;
     while i < input.nodes.len() {
         let node = input.nodes.get_or(i, plan.empty_node());
-        out.inspected = out.inspected + 1;
+        out.inspected += 1;
         if eligible(borrow node, borrow query) {
             rule_result.record(inout out, node_benefit(borrow node),
                 fingerprint + node.kind * 17 + node.estimated_rows + i);
         }
-        i = i + 1;
+        i += 1;
     }
     inspect_indexes(inout out, borrow database, borrow query);
     inspect_columns(inout out, borrow database, borrow query);

--- a/examples/meridian/rule_join_associate_left.rue
+++ b/examples/meridian/rule_join_associate_left.rue
@@ -53,13 +53,13 @@ fn inspect_indexes(inout out: rule_result.Decision, borrow database: model.Datab
     let mut i: u64 = 0;
     while i < database.indexes.len() {
         let index = database.indexes.get_or(i, model.empty_index());
-        out.inspected = out.inspected + 1;
+        out.inspected += 1;
         if index.table == query.table &&
             (index.column == query.filter_column || index.column == query.order_column) {
             let benefit = if index.unique { (FOCUS() % 7) + 1 } else { (FOCUS() % 3) + 1 };
             rule_result.record(inout out, benefit, index.entries + index.column + FOCUS());
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -69,7 +69,7 @@ fn inspect_columns(inout out: rule_result.Decision, borrow database: model.Datab
     let mut i: u64 = 0;
     while i < table.column_count {
         let column = database.columns.get_or(table.first_column + i, model.empty_column());
-        out.inspected = out.inspected + 1;
+        out.inspected += 1;
         let selected = (column.ordinal + FOCUS()) % 5 == 0 ||
             column.name == query.filter_column_name ||
             column.name == query.group_column_name ||
@@ -79,7 +79,7 @@ fn inspect_columns(inout out: rule_result.Decision, borrow database: model.Datab
             rule_result.record(inout out, benefit,
                 database.strings.hash(column.name) + column.kind + column.ordinal);
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -90,12 +90,12 @@ pub fn evaluate(borrow database: model.Database, borrow query: model.Query,
     let mut i: u64 = 0;
     while i < input.nodes.len() {
         let node = input.nodes.get_or(i, plan.empty_node());
-        out.inspected = out.inspected + 1;
+        out.inspected += 1;
         if eligible(borrow node, borrow query) {
             rule_result.record(inout out, node_benefit(borrow node),
                 fingerprint + node.kind * 17 + node.estimated_rows + i);
         }
-        i = i + 1;
+        i += 1;
     }
     inspect_indexes(inout out, borrow database, borrow query);
     inspect_columns(inout out, borrow database, borrow query);

--- a/examples/meridian/rule_join_associate_right.rue
+++ b/examples/meridian/rule_join_associate_right.rue
@@ -53,13 +53,13 @@ fn inspect_indexes(inout out: rule_result.Decision, borrow database: model.Datab
     let mut i: u64 = 0;
     while i < database.indexes.len() {
         let index = database.indexes.get_or(i, model.empty_index());
-        out.inspected = out.inspected + 1;
+        out.inspected += 1;
         if index.table == query.table &&
             (index.column == query.filter_column || index.column == query.order_column) {
             let benefit = if index.unique { (FOCUS() % 7) + 1 } else { (FOCUS() % 3) + 1 };
             rule_result.record(inout out, benefit, index.entries + index.column + FOCUS());
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -69,7 +69,7 @@ fn inspect_columns(inout out: rule_result.Decision, borrow database: model.Datab
     let mut i: u64 = 0;
     while i < table.column_count {
         let column = database.columns.get_or(table.first_column + i, model.empty_column());
-        out.inspected = out.inspected + 1;
+        out.inspected += 1;
         let selected = (column.ordinal + FOCUS()) % 5 == 0 ||
             column.name == query.filter_column_name ||
             column.name == query.group_column_name ||
@@ -79,7 +79,7 @@ fn inspect_columns(inout out: rule_result.Decision, borrow database: model.Datab
             rule_result.record(inout out, benefit,
                 database.strings.hash(column.name) + column.kind + column.ordinal);
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -90,12 +90,12 @@ pub fn evaluate(borrow database: model.Database, borrow query: model.Query,
     let mut i: u64 = 0;
     while i < input.nodes.len() {
         let node = input.nodes.get_or(i, plan.empty_node());
-        out.inspected = out.inspected + 1;
+        out.inspected += 1;
         if eligible(borrow node, borrow query) {
             rule_result.record(inout out, node_benefit(borrow node),
                 fingerprint + node.kind * 17 + node.estimated_rows + i);
         }
-        i = i + 1;
+        i += 1;
     }
     inspect_indexes(inout out, borrow database, borrow query);
     inspect_columns(inout out, borrow database, borrow query);

--- a/examples/meridian/rule_join_bloom_prefilter.rue
+++ b/examples/meridian/rule_join_bloom_prefilter.rue
@@ -53,13 +53,13 @@ fn inspect_indexes(inout out: rule_result.Decision, borrow database: model.Datab
     let mut i: u64 = 0;
     while i < database.indexes.len() {
         let index = database.indexes.get_or(i, model.empty_index());
-        out.inspected = out.inspected + 1;
+        out.inspected += 1;
         if index.table == query.table &&
             (index.column == query.filter_column || index.column == query.order_column) {
             let benefit = if index.unique { (FOCUS() % 7) + 1 } else { (FOCUS() % 3) + 1 };
             rule_result.record(inout out, benefit, index.entries + index.column + FOCUS());
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -69,7 +69,7 @@ fn inspect_columns(inout out: rule_result.Decision, borrow database: model.Datab
     let mut i: u64 = 0;
     while i < table.column_count {
         let column = database.columns.get_or(table.first_column + i, model.empty_column());
-        out.inspected = out.inspected + 1;
+        out.inspected += 1;
         let selected = (column.ordinal + FOCUS()) % 5 == 0 ||
             column.name == query.filter_column_name ||
             column.name == query.group_column_name ||
@@ -79,7 +79,7 @@ fn inspect_columns(inout out: rule_result.Decision, borrow database: model.Datab
             rule_result.record(inout out, benefit,
                 database.strings.hash(column.name) + column.kind + column.ordinal);
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -90,12 +90,12 @@ pub fn evaluate(borrow database: model.Database, borrow query: model.Query,
     let mut i: u64 = 0;
     while i < input.nodes.len() {
         let node = input.nodes.get_or(i, plan.empty_node());
-        out.inspected = out.inspected + 1;
+        out.inspected += 1;
         if eligible(borrow node, borrow query) {
             rule_result.record(inout out, node_benefit(borrow node),
                 fingerprint + node.kind * 17 + node.estimated_rows + i);
         }
-        i = i + 1;
+        i += 1;
     }
     inspect_indexes(inout out, borrow database, borrow query);
     inspect_columns(inout out, borrow database, borrow query);

--- a/examples/meridian/rule_join_choose_build_side.rue
+++ b/examples/meridian/rule_join_choose_build_side.rue
@@ -53,13 +53,13 @@ fn inspect_indexes(inout out: rule_result.Decision, borrow database: model.Datab
     let mut i: u64 = 0;
     while i < database.indexes.len() {
         let index = database.indexes.get_or(i, model.empty_index());
-        out.inspected = out.inspected + 1;
+        out.inspected += 1;
         if index.table == query.table &&
             (index.column == query.filter_column || index.column == query.order_column) {
             let benefit = if index.unique { (FOCUS() % 7) + 1 } else { (FOCUS() % 3) + 1 };
             rule_result.record(inout out, benefit, index.entries + index.column + FOCUS());
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -69,7 +69,7 @@ fn inspect_columns(inout out: rule_result.Decision, borrow database: model.Datab
     let mut i: u64 = 0;
     while i < table.column_count {
         let column = database.columns.get_or(table.first_column + i, model.empty_column());
-        out.inspected = out.inspected + 1;
+        out.inspected += 1;
         let selected = (column.ordinal + FOCUS()) % 5 == 0 ||
             column.name == query.filter_column_name ||
             column.name == query.group_column_name ||
@@ -79,7 +79,7 @@ fn inspect_columns(inout out: rule_result.Decision, borrow database: model.Datab
             rule_result.record(inout out, benefit,
                 database.strings.hash(column.name) + column.kind + column.ordinal);
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -90,12 +90,12 @@ pub fn evaluate(borrow database: model.Database, borrow query: model.Query,
     let mut i: u64 = 0;
     while i < input.nodes.len() {
         let node = input.nodes.get_or(i, plan.empty_node());
-        out.inspected = out.inspected + 1;
+        out.inspected += 1;
         if eligible(borrow node, borrow query) {
             rule_result.record(inout out, node_benefit(borrow node),
                 fingerprint + node.kind * 17 + node.estimated_rows + i);
         }
-        i = i + 1;
+        i += 1;
     }
     inspect_indexes(inout out, borrow database, borrow query);
     inspect_columns(inout out, borrow database, borrow query);

--- a/examples/meridian/rule_join_commute_inner.rue
+++ b/examples/meridian/rule_join_commute_inner.rue
@@ -53,13 +53,13 @@ fn inspect_indexes(inout out: rule_result.Decision, borrow database: model.Datab
     let mut i: u64 = 0;
     while i < database.indexes.len() {
         let index = database.indexes.get_or(i, model.empty_index());
-        out.inspected = out.inspected + 1;
+        out.inspected += 1;
         if index.table == query.table &&
             (index.column == query.filter_column || index.column == query.order_column) {
             let benefit = if index.unique { (FOCUS() % 7) + 1 } else { (FOCUS() % 3) + 1 };
             rule_result.record(inout out, benefit, index.entries + index.column + FOCUS());
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -69,7 +69,7 @@ fn inspect_columns(inout out: rule_result.Decision, borrow database: model.Datab
     let mut i: u64 = 0;
     while i < table.column_count {
         let column = database.columns.get_or(table.first_column + i, model.empty_column());
-        out.inspected = out.inspected + 1;
+        out.inspected += 1;
         let selected = (column.ordinal + FOCUS()) % 5 == 0 ||
             column.name == query.filter_column_name ||
             column.name == query.group_column_name ||
@@ -79,7 +79,7 @@ fn inspect_columns(inout out: rule_result.Decision, borrow database: model.Datab
             rule_result.record(inout out, benefit,
                 database.strings.hash(column.name) + column.kind + column.ordinal);
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -90,12 +90,12 @@ pub fn evaluate(borrow database: model.Database, borrow query: model.Query,
     let mut i: u64 = 0;
     while i < input.nodes.len() {
         let node = input.nodes.get_or(i, plan.empty_node());
-        out.inspected = out.inspected + 1;
+        out.inspected += 1;
         if eligible(borrow node, borrow query) {
             rule_result.record(inout out, node_benefit(borrow node),
                 fingerprint + node.kind * 17 + node.estimated_rows + i);
         }
-        i = i + 1;
+        i += 1;
     }
     inspect_indexes(inout out, borrow database, borrow query);
     inspect_columns(inout out, borrow database, borrow query);

--- a/examples/meridian/rule_join_delay_payload.rue
+++ b/examples/meridian/rule_join_delay_payload.rue
@@ -53,13 +53,13 @@ fn inspect_indexes(inout out: rule_result.Decision, borrow database: model.Datab
     let mut i: u64 = 0;
     while i < database.indexes.len() {
         let index = database.indexes.get_or(i, model.empty_index());
-        out.inspected = out.inspected + 1;
+        out.inspected += 1;
         if index.table == query.table &&
             (index.column == query.filter_column || index.column == query.order_column) {
             let benefit = if index.unique { (FOCUS() % 7) + 1 } else { (FOCUS() % 3) + 1 };
             rule_result.record(inout out, benefit, index.entries + index.column + FOCUS());
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -69,7 +69,7 @@ fn inspect_columns(inout out: rule_result.Decision, borrow database: model.Datab
     let mut i: u64 = 0;
     while i < table.column_count {
         let column = database.columns.get_or(table.first_column + i, model.empty_column());
-        out.inspected = out.inspected + 1;
+        out.inspected += 1;
         let selected = (column.ordinal + FOCUS()) % 5 == 0 ||
             column.name == query.filter_column_name ||
             column.name == query.group_column_name ||
@@ -79,7 +79,7 @@ fn inspect_columns(inout out: rule_result.Decision, borrow database: model.Datab
             rule_result.record(inout out, benefit,
                 database.strings.hash(column.name) + column.kind + column.ordinal);
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -90,12 +90,12 @@ pub fn evaluate(borrow database: model.Database, borrow query: model.Query,
     let mut i: u64 = 0;
     while i < input.nodes.len() {
         let node = input.nodes.get_or(i, plan.empty_node());
-        out.inspected = out.inspected + 1;
+        out.inspected += 1;
         if eligible(borrow node, borrow query) {
             rule_result.record(inout out, node_benefit(borrow node),
                 fingerprint + node.kind * 17 + node.estimated_rows + i);
         }
-        i = i + 1;
+        i += 1;
     }
     inspect_indexes(inout out, borrow database, borrow query);
     inspect_columns(inout out, borrow database, borrow query);

--- a/examples/meridian/rule_join_eliminate_unused.rue
+++ b/examples/meridian/rule_join_eliminate_unused.rue
@@ -53,13 +53,13 @@ fn inspect_indexes(inout out: rule_result.Decision, borrow database: model.Datab
     let mut i: u64 = 0;
     while i < database.indexes.len() {
         let index = database.indexes.get_or(i, model.empty_index());
-        out.inspected = out.inspected + 1;
+        out.inspected += 1;
         if index.table == query.table &&
             (index.column == query.filter_column || index.column == query.order_column) {
             let benefit = if index.unique { (FOCUS() % 7) + 1 } else { (FOCUS() % 3) + 1 };
             rule_result.record(inout out, benefit, index.entries + index.column + FOCUS());
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -69,7 +69,7 @@ fn inspect_columns(inout out: rule_result.Decision, borrow database: model.Datab
     let mut i: u64 = 0;
     while i < table.column_count {
         let column = database.columns.get_or(table.first_column + i, model.empty_column());
-        out.inspected = out.inspected + 1;
+        out.inspected += 1;
         let selected = (column.ordinal + FOCUS()) % 5 == 0 ||
             column.name == query.filter_column_name ||
             column.name == query.group_column_name ||
@@ -79,7 +79,7 @@ fn inspect_columns(inout out: rule_result.Decision, borrow database: model.Datab
             rule_result.record(inout out, benefit,
                 database.strings.hash(column.name) + column.kind + column.ordinal);
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -90,12 +90,12 @@ pub fn evaluate(borrow database: model.Database, borrow query: model.Query,
     let mut i: u64 = 0;
     while i < input.nodes.len() {
         let node = input.nodes.get_or(i, plan.empty_node());
-        out.inspected = out.inspected + 1;
+        out.inspected += 1;
         if eligible(borrow node, borrow query) {
             rule_result.record(inout out, node_benefit(borrow node),
                 fingerprint + node.kind * 17 + node.estimated_rows + i);
         }
-        i = i + 1;
+        i += 1;
     }
     inspect_indexes(inout out, borrow database, borrow query);
     inspect_columns(inout out, borrow database, borrow query);

--- a/examples/meridian/rule_join_infer_transitive_filter.rue
+++ b/examples/meridian/rule_join_infer_transitive_filter.rue
@@ -53,13 +53,13 @@ fn inspect_indexes(inout out: rule_result.Decision, borrow database: model.Datab
     let mut i: u64 = 0;
     while i < database.indexes.len() {
         let index = database.indexes.get_or(i, model.empty_index());
-        out.inspected = out.inspected + 1;
+        out.inspected += 1;
         if index.table == query.table &&
             (index.column == query.filter_column || index.column == query.order_column) {
             let benefit = if index.unique { (FOCUS() % 7) + 1 } else { (FOCUS() % 3) + 1 };
             rule_result.record(inout out, benefit, index.entries + index.column + FOCUS());
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -69,7 +69,7 @@ fn inspect_columns(inout out: rule_result.Decision, borrow database: model.Datab
     let mut i: u64 = 0;
     while i < table.column_count {
         let column = database.columns.get_or(table.first_column + i, model.empty_column());
-        out.inspected = out.inspected + 1;
+        out.inspected += 1;
         let selected = (column.ordinal + FOCUS()) % 5 == 0 ||
             column.name == query.filter_column_name ||
             column.name == query.group_column_name ||
@@ -79,7 +79,7 @@ fn inspect_columns(inout out: rule_result.Decision, borrow database: model.Datab
             rule_result.record(inout out, benefit,
                 database.strings.hash(column.name) + column.kind + column.ordinal);
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -90,12 +90,12 @@ pub fn evaluate(borrow database: model.Database, borrow query: model.Query,
     let mut i: u64 = 0;
     while i < input.nodes.len() {
         let node = input.nodes.get_or(i, plan.empty_node());
-        out.inspected = out.inspected + 1;
+        out.inspected += 1;
         if eligible(borrow node, borrow query) {
             rule_result.record(inout out, node_benefit(borrow node),
                 fingerprint + node.kind * 17 + node.estimated_rows + i);
         }
-        i = i + 1;
+        i += 1;
     }
     inspect_indexes(inout out, borrow database, borrow query);
     inspect_columns(inout out, borrow database, borrow query);

--- a/examples/meridian/rule_join_partition_keys.rue
+++ b/examples/meridian/rule_join_partition_keys.rue
@@ -53,13 +53,13 @@ fn inspect_indexes(inout out: rule_result.Decision, borrow database: model.Datab
     let mut i: u64 = 0;
     while i < database.indexes.len() {
         let index = database.indexes.get_or(i, model.empty_index());
-        out.inspected = out.inspected + 1;
+        out.inspected += 1;
         if index.table == query.table &&
             (index.column == query.filter_column || index.column == query.order_column) {
             let benefit = if index.unique { (FOCUS() % 7) + 1 } else { (FOCUS() % 3) + 1 };
             rule_result.record(inout out, benefit, index.entries + index.column + FOCUS());
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -69,7 +69,7 @@ fn inspect_columns(inout out: rule_result.Decision, borrow database: model.Datab
     let mut i: u64 = 0;
     while i < table.column_count {
         let column = database.columns.get_or(table.first_column + i, model.empty_column());
-        out.inspected = out.inspected + 1;
+        out.inspected += 1;
         let selected = (column.ordinal + FOCUS()) % 5 == 0 ||
             column.name == query.filter_column_name ||
             column.name == query.group_column_name ||
@@ -79,7 +79,7 @@ fn inspect_columns(inout out: rule_result.Decision, borrow database: model.Datab
             rule_result.record(inout out, benefit,
                 database.strings.hash(column.name) + column.kind + column.ordinal);
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -90,12 +90,12 @@ pub fn evaluate(borrow database: model.Database, borrow query: model.Query,
     let mut i: u64 = 0;
     while i < input.nodes.len() {
         let node = input.nodes.get_or(i, plan.empty_node());
-        out.inspected = out.inspected + 1;
+        out.inspected += 1;
         if eligible(borrow node, borrow query) {
             rule_result.record(inout out, node_benefit(borrow node),
                 fingerprint + node.kind * 17 + node.estimated_rows + i);
         }
-        i = i + 1;
+        i += 1;
     }
     inspect_indexes(inout out, borrow database, borrow query);
     inspect_columns(inout out, borrow database, borrow query);

--- a/examples/meridian/rule_join_prune_columns.rue
+++ b/examples/meridian/rule_join_prune_columns.rue
@@ -53,13 +53,13 @@ fn inspect_indexes(inout out: rule_result.Decision, borrow database: model.Datab
     let mut i: u64 = 0;
     while i < database.indexes.len() {
         let index = database.indexes.get_or(i, model.empty_index());
-        out.inspected = out.inspected + 1;
+        out.inspected += 1;
         if index.table == query.table &&
             (index.column == query.filter_column || index.column == query.order_column) {
             let benefit = if index.unique { (FOCUS() % 7) + 1 } else { (FOCUS() % 3) + 1 };
             rule_result.record(inout out, benefit, index.entries + index.column + FOCUS());
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -69,7 +69,7 @@ fn inspect_columns(inout out: rule_result.Decision, borrow database: model.Datab
     let mut i: u64 = 0;
     while i < table.column_count {
         let column = database.columns.get_or(table.first_column + i, model.empty_column());
-        out.inspected = out.inspected + 1;
+        out.inspected += 1;
         let selected = (column.ordinal + FOCUS()) % 5 == 0 ||
             column.name == query.filter_column_name ||
             column.name == query.group_column_name ||
@@ -79,7 +79,7 @@ fn inspect_columns(inout out: rule_result.Decision, borrow database: model.Datab
             rule_result.record(inout out, benefit,
                 database.strings.hash(column.name) + column.kind + column.ordinal);
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -90,12 +90,12 @@ pub fn evaluate(borrow database: model.Database, borrow query: model.Query,
     let mut i: u64 = 0;
     while i < input.nodes.len() {
         let node = input.nodes.get_or(i, plan.empty_node());
-        out.inspected = out.inspected + 1;
+        out.inspected += 1;
         if eligible(borrow node, borrow query) {
             rule_result.record(inout out, node_benefit(borrow node),
                 fingerprint + node.kind * 17 + node.estimated_rows + i);
         }
-        i = i + 1;
+        i += 1;
     }
     inspect_indexes(inout out, borrow database, borrow query);
     inspect_columns(inout out, borrow database, borrow query);

--- a/examples/meridian/rule_join_push_left_filter.rue
+++ b/examples/meridian/rule_join_push_left_filter.rue
@@ -53,13 +53,13 @@ fn inspect_indexes(inout out: rule_result.Decision, borrow database: model.Datab
     let mut i: u64 = 0;
     while i < database.indexes.len() {
         let index = database.indexes.get_or(i, model.empty_index());
-        out.inspected = out.inspected + 1;
+        out.inspected += 1;
         if index.table == query.table &&
             (index.column == query.filter_column || index.column == query.order_column) {
             let benefit = if index.unique { (FOCUS() % 7) + 1 } else { (FOCUS() % 3) + 1 };
             rule_result.record(inout out, benefit, index.entries + index.column + FOCUS());
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -69,7 +69,7 @@ fn inspect_columns(inout out: rule_result.Decision, borrow database: model.Datab
     let mut i: u64 = 0;
     while i < table.column_count {
         let column = database.columns.get_or(table.first_column + i, model.empty_column());
-        out.inspected = out.inspected + 1;
+        out.inspected += 1;
         let selected = (column.ordinal + FOCUS()) % 5 == 0 ||
             column.name == query.filter_column_name ||
             column.name == query.group_column_name ||
@@ -79,7 +79,7 @@ fn inspect_columns(inout out: rule_result.Decision, borrow database: model.Datab
             rule_result.record(inout out, benefit,
                 database.strings.hash(column.name) + column.kind + column.ordinal);
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -90,12 +90,12 @@ pub fn evaluate(borrow database: model.Database, borrow query: model.Query,
     let mut i: u64 = 0;
     while i < input.nodes.len() {
         let node = input.nodes.get_or(i, plan.empty_node());
-        out.inspected = out.inspected + 1;
+        out.inspected += 1;
         if eligible(borrow node, borrow query) {
             rule_result.record(inout out, node_benefit(borrow node),
                 fingerprint + node.kind * 17 + node.estimated_rows + i);
         }
-        i = i + 1;
+        i += 1;
     }
     inspect_indexes(inout out, borrow database, borrow query);
     inspect_columns(inout out, borrow database, borrow query);

--- a/examples/meridian/rule_join_push_right_filter.rue
+++ b/examples/meridian/rule_join_push_right_filter.rue
@@ -53,13 +53,13 @@ fn inspect_indexes(inout out: rule_result.Decision, borrow database: model.Datab
     let mut i: u64 = 0;
     while i < database.indexes.len() {
         let index = database.indexes.get_or(i, model.empty_index());
-        out.inspected = out.inspected + 1;
+        out.inspected += 1;
         if index.table == query.table &&
             (index.column == query.filter_column || index.column == query.order_column) {
             let benefit = if index.unique { (FOCUS() % 7) + 1 } else { (FOCUS() % 3) + 1 };
             rule_result.record(inout out, benefit, index.entries + index.column + FOCUS());
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -69,7 +69,7 @@ fn inspect_columns(inout out: rule_result.Decision, borrow database: model.Datab
     let mut i: u64 = 0;
     while i < table.column_count {
         let column = database.columns.get_or(table.first_column + i, model.empty_column());
-        out.inspected = out.inspected + 1;
+        out.inspected += 1;
         let selected = (column.ordinal + FOCUS()) % 5 == 0 ||
             column.name == query.filter_column_name ||
             column.name == query.group_column_name ||
@@ -79,7 +79,7 @@ fn inspect_columns(inout out: rule_result.Decision, borrow database: model.Datab
             rule_result.record(inout out, benefit,
                 database.strings.hash(column.name) + column.kind + column.ordinal);
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -90,12 +90,12 @@ pub fn evaluate(borrow database: model.Database, borrow query: model.Query,
     let mut i: u64 = 0;
     while i < input.nodes.len() {
         let node = input.nodes.get_or(i, plan.empty_node());
-        out.inspected = out.inspected + 1;
+        out.inspected += 1;
         if eligible(borrow node, borrow query) {
             rule_result.record(inout out, node_benefit(borrow node),
                 fingerprint + node.kind * 17 + node.estimated_rows + i);
         }
-        i = i + 1;
+        i += 1;
     }
     inspect_indexes(inout out, borrow database, borrow query);
     inspect_columns(inout out, borrow database, borrow query);

--- a/examples/meridian/rule_join_reduce_cartesian.rue
+++ b/examples/meridian/rule_join_reduce_cartesian.rue
@@ -53,13 +53,13 @@ fn inspect_indexes(inout out: rule_result.Decision, borrow database: model.Datab
     let mut i: u64 = 0;
     while i < database.indexes.len() {
         let index = database.indexes.get_or(i, model.empty_index());
-        out.inspected = out.inspected + 1;
+        out.inspected += 1;
         if index.table == query.table &&
             (index.column == query.filter_column || index.column == query.order_column) {
             let benefit = if index.unique { (FOCUS() % 7) + 1 } else { (FOCUS() % 3) + 1 };
             rule_result.record(inout out, benefit, index.entries + index.column + FOCUS());
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -69,7 +69,7 @@ fn inspect_columns(inout out: rule_result.Decision, borrow database: model.Datab
     let mut i: u64 = 0;
     while i < table.column_count {
         let column = database.columns.get_or(table.first_column + i, model.empty_column());
-        out.inspected = out.inspected + 1;
+        out.inspected += 1;
         let selected = (column.ordinal + FOCUS()) % 5 == 0 ||
             column.name == query.filter_column_name ||
             column.name == query.group_column_name ||
@@ -79,7 +79,7 @@ fn inspect_columns(inout out: rule_result.Decision, borrow database: model.Datab
             rule_result.record(inout out, benefit,
                 database.strings.hash(column.name) + column.kind + column.ordinal);
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -90,12 +90,12 @@ pub fn evaluate(borrow database: model.Database, borrow query: model.Query,
     let mut i: u64 = 0;
     while i < input.nodes.len() {
         let node = input.nodes.get_or(i, plan.empty_node());
-        out.inspected = out.inspected + 1;
+        out.inspected += 1;
         if eligible(borrow node, borrow query) {
             rule_result.record(inout out, node_benefit(borrow node),
                 fingerprint + node.kind * 17 + node.estimated_rows + i);
         }
-        i = i + 1;
+        i += 1;
     }
     inspect_indexes(inout out, borrow database, borrow query);
     inspect_columns(inout out, borrow database, borrow query);

--- a/examples/meridian/rule_join_reuse_hash.rue
+++ b/examples/meridian/rule_join_reuse_hash.rue
@@ -53,13 +53,13 @@ fn inspect_indexes(inout out: rule_result.Decision, borrow database: model.Datab
     let mut i: u64 = 0;
     while i < database.indexes.len() {
         let index = database.indexes.get_or(i, model.empty_index());
-        out.inspected = out.inspected + 1;
+        out.inspected += 1;
         if index.table == query.table &&
             (index.column == query.filter_column || index.column == query.order_column) {
             let benefit = if index.unique { (FOCUS() % 7) + 1 } else { (FOCUS() % 3) + 1 };
             rule_result.record(inout out, benefit, index.entries + index.column + FOCUS());
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -69,7 +69,7 @@ fn inspect_columns(inout out: rule_result.Decision, borrow database: model.Datab
     let mut i: u64 = 0;
     while i < table.column_count {
         let column = database.columns.get_or(table.first_column + i, model.empty_column());
-        out.inspected = out.inspected + 1;
+        out.inspected += 1;
         let selected = (column.ordinal + FOCUS()) % 5 == 0 ||
             column.name == query.filter_column_name ||
             column.name == query.group_column_name ||
@@ -79,7 +79,7 @@ fn inspect_columns(inout out: rule_result.Decision, borrow database: model.Datab
             rule_result.record(inout out, benefit,
                 database.strings.hash(column.name) + column.kind + column.ordinal);
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -90,12 +90,12 @@ pub fn evaluate(borrow database: model.Database, borrow query: model.Query,
     let mut i: u64 = 0;
     while i < input.nodes.len() {
         let node = input.nodes.get_or(i, plan.empty_node());
-        out.inspected = out.inspected + 1;
+        out.inspected += 1;
         if eligible(borrow node, borrow query) {
             rule_result.record(inout out, node_benefit(borrow node),
                 fingerprint + node.kind * 17 + node.estimated_rows + i);
         }
-        i = i + 1;
+        i += 1;
     }
     inspect_indexes(inout out, borrow database, borrow query);
     inspect_columns(inout out, borrow database, borrow query);

--- a/examples/meridian/rule_join_select_star_schema.rue
+++ b/examples/meridian/rule_join_select_star_schema.rue
@@ -53,13 +53,13 @@ fn inspect_indexes(inout out: rule_result.Decision, borrow database: model.Datab
     let mut i: u64 = 0;
     while i < database.indexes.len() {
         let index = database.indexes.get_or(i, model.empty_index());
-        out.inspected = out.inspected + 1;
+        out.inspected += 1;
         if index.table == query.table &&
             (index.column == query.filter_column || index.column == query.order_column) {
             let benefit = if index.unique { (FOCUS() % 7) + 1 } else { (FOCUS() % 3) + 1 };
             rule_result.record(inout out, benefit, index.entries + index.column + FOCUS());
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -69,7 +69,7 @@ fn inspect_columns(inout out: rule_result.Decision, borrow database: model.Datab
     let mut i: u64 = 0;
     while i < table.column_count {
         let column = database.columns.get_or(table.first_column + i, model.empty_column());
-        out.inspected = out.inspected + 1;
+        out.inspected += 1;
         let selected = (column.ordinal + FOCUS()) % 5 == 0 ||
             column.name == query.filter_column_name ||
             column.name == query.group_column_name ||
@@ -79,7 +79,7 @@ fn inspect_columns(inout out: rule_result.Decision, borrow database: model.Datab
             rule_result.record(inout out, benefit,
                 database.strings.hash(column.name) + column.kind + column.ordinal);
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -90,12 +90,12 @@ pub fn evaluate(borrow database: model.Database, borrow query: model.Query,
     let mut i: u64 = 0;
     while i < input.nodes.len() {
         let node = input.nodes.get_or(i, plan.empty_node());
-        out.inspected = out.inspected + 1;
+        out.inspected += 1;
         if eligible(borrow node, borrow query) {
             rule_result.record(inout out, node_benefit(borrow node),
                 fingerprint + node.kind * 17 + node.estimated_rows + i);
         }
-        i = i + 1;
+        i += 1;
     }
     inspect_indexes(inout out, borrow database, borrow query);
     inspect_columns(inout out, borrow database, borrow query);

--- a/examples/meridian/rule_join_use_unique_key.rue
+++ b/examples/meridian/rule_join_use_unique_key.rue
@@ -53,13 +53,13 @@ fn inspect_indexes(inout out: rule_result.Decision, borrow database: model.Datab
     let mut i: u64 = 0;
     while i < database.indexes.len() {
         let index = database.indexes.get_or(i, model.empty_index());
-        out.inspected = out.inspected + 1;
+        out.inspected += 1;
         if index.table == query.table &&
             (index.column == query.filter_column || index.column == query.order_column) {
             let benefit = if index.unique { (FOCUS() % 7) + 1 } else { (FOCUS() % 3) + 1 };
             rule_result.record(inout out, benefit, index.entries + index.column + FOCUS());
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -69,7 +69,7 @@ fn inspect_columns(inout out: rule_result.Decision, borrow database: model.Datab
     let mut i: u64 = 0;
     while i < table.column_count {
         let column = database.columns.get_or(table.first_column + i, model.empty_column());
-        out.inspected = out.inspected + 1;
+        out.inspected += 1;
         let selected = (column.ordinal + FOCUS()) % 5 == 0 ||
             column.name == query.filter_column_name ||
             column.name == query.group_column_name ||
@@ -79,7 +79,7 @@ fn inspect_columns(inout out: rule_result.Decision, borrow database: model.Datab
             rule_result.record(inout out, benefit,
                 database.strings.hash(column.name) + column.kind + column.ordinal);
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -90,12 +90,12 @@ pub fn evaluate(borrow database: model.Database, borrow query: model.Query,
     let mut i: u64 = 0;
     while i < input.nodes.len() {
         let node = input.nodes.get_or(i, plan.empty_node());
-        out.inspected = out.inspected + 1;
+        out.inspected += 1;
         if eligible(borrow node, borrow query) {
             rule_result.record(inout out, node_benefit(borrow node),
                 fingerprint + node.kind * 17 + node.estimated_rows + i);
         }
-        i = i + 1;
+        i += 1;
     }
     inspect_indexes(inout out, borrow database, borrow query);
     inspect_columns(inout out, borrow database, borrow query);

--- a/examples/meridian/rule_logical_canonicalize_order.rue
+++ b/examples/meridian/rule_logical_canonicalize_order.rue
@@ -53,13 +53,13 @@ fn inspect_indexes(inout out: rule_result.Decision, borrow database: model.Datab
     let mut i: u64 = 0;
     while i < database.indexes.len() {
         let index = database.indexes.get_or(i, model.empty_index());
-        out.inspected = out.inspected + 1;
+        out.inspected += 1;
         if index.table == query.table &&
             (index.column == query.filter_column || index.column == query.order_column) {
             let benefit = if index.unique { (FOCUS() % 7) + 1 } else { (FOCUS() % 3) + 1 };
             rule_result.record(inout out, benefit, index.entries + index.column + FOCUS());
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -69,7 +69,7 @@ fn inspect_columns(inout out: rule_result.Decision, borrow database: model.Datab
     let mut i: u64 = 0;
     while i < table.column_count {
         let column = database.columns.get_or(table.first_column + i, model.empty_column());
-        out.inspected = out.inspected + 1;
+        out.inspected += 1;
         let selected = (column.ordinal + FOCUS()) % 5 == 0 ||
             column.name == query.filter_column_name ||
             column.name == query.group_column_name ||
@@ -79,7 +79,7 @@ fn inspect_columns(inout out: rule_result.Decision, borrow database: model.Datab
             rule_result.record(inout out, benefit,
                 database.strings.hash(column.name) + column.kind + column.ordinal);
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -90,12 +90,12 @@ pub fn evaluate(borrow database: model.Database, borrow query: model.Query,
     let mut i: u64 = 0;
     while i < input.nodes.len() {
         let node = input.nodes.get_or(i, plan.empty_node());
-        out.inspected = out.inspected + 1;
+        out.inspected += 1;
         if eligible(borrow node, borrow query) {
             rule_result.record(inout out, node_benefit(borrow node),
                 fingerprint + node.kind * 17 + node.estimated_rows + i);
         }
-        i = i + 1;
+        i += 1;
     }
     inspect_indexes(inout out, borrow database, borrow query);
     inspect_columns(inout out, borrow database, borrow query);

--- a/examples/meridian/rule_logical_collapse_projection.rue
+++ b/examples/meridian/rule_logical_collapse_projection.rue
@@ -53,13 +53,13 @@ fn inspect_indexes(inout out: rule_result.Decision, borrow database: model.Datab
     let mut i: u64 = 0;
     while i < database.indexes.len() {
         let index = database.indexes.get_or(i, model.empty_index());
-        out.inspected = out.inspected + 1;
+        out.inspected += 1;
         if index.table == query.table &&
             (index.column == query.filter_column || index.column == query.order_column) {
             let benefit = if index.unique { (FOCUS() % 7) + 1 } else { (FOCUS() % 3) + 1 };
             rule_result.record(inout out, benefit, index.entries + index.column + FOCUS());
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -69,7 +69,7 @@ fn inspect_columns(inout out: rule_result.Decision, borrow database: model.Datab
     let mut i: u64 = 0;
     while i < table.column_count {
         let column = database.columns.get_or(table.first_column + i, model.empty_column());
-        out.inspected = out.inspected + 1;
+        out.inspected += 1;
         let selected = (column.ordinal + FOCUS()) % 5 == 0 ||
             column.name == query.filter_column_name ||
             column.name == query.group_column_name ||
@@ -79,7 +79,7 @@ fn inspect_columns(inout out: rule_result.Decision, borrow database: model.Datab
             rule_result.record(inout out, benefit,
                 database.strings.hash(column.name) + column.kind + column.ordinal);
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -90,12 +90,12 @@ pub fn evaluate(borrow database: model.Database, borrow query: model.Query,
     let mut i: u64 = 0;
     while i < input.nodes.len() {
         let node = input.nodes.get_or(i, plan.empty_node());
-        out.inspected = out.inspected + 1;
+        out.inspected += 1;
         if eligible(borrow node, borrow query) {
             rule_result.record(inout out, node_benefit(borrow node),
                 fingerprint + node.kind * 17 + node.estimated_rows + i);
         }
-        i = i + 1;
+        i += 1;
     }
     inspect_indexes(inout out, borrow database, borrow query);
     inspect_columns(inout out, borrow database, borrow query);

--- a/examples/meridian/rule_logical_deduplicate_keys.rue
+++ b/examples/meridian/rule_logical_deduplicate_keys.rue
@@ -53,13 +53,13 @@ fn inspect_indexes(inout out: rule_result.Decision, borrow database: model.Datab
     let mut i: u64 = 0;
     while i < database.indexes.len() {
         let index = database.indexes.get_or(i, model.empty_index());
-        out.inspected = out.inspected + 1;
+        out.inspected += 1;
         if index.table == query.table &&
             (index.column == query.filter_column || index.column == query.order_column) {
             let benefit = if index.unique { (FOCUS() % 7) + 1 } else { (FOCUS() % 3) + 1 };
             rule_result.record(inout out, benefit, index.entries + index.column + FOCUS());
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -69,7 +69,7 @@ fn inspect_columns(inout out: rule_result.Decision, borrow database: model.Datab
     let mut i: u64 = 0;
     while i < table.column_count {
         let column = database.columns.get_or(table.first_column + i, model.empty_column());
-        out.inspected = out.inspected + 1;
+        out.inspected += 1;
         let selected = (column.ordinal + FOCUS()) % 5 == 0 ||
             column.name == query.filter_column_name ||
             column.name == query.group_column_name ||
@@ -79,7 +79,7 @@ fn inspect_columns(inout out: rule_result.Decision, borrow database: model.Datab
             rule_result.record(inout out, benefit,
                 database.strings.hash(column.name) + column.kind + column.ordinal);
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -90,12 +90,12 @@ pub fn evaluate(borrow database: model.Database, borrow query: model.Query,
     let mut i: u64 = 0;
     while i < input.nodes.len() {
         let node = input.nodes.get_or(i, plan.empty_node());
-        out.inspected = out.inspected + 1;
+        out.inspected += 1;
         if eligible(borrow node, borrow query) {
             rule_result.record(inout out, node_benefit(borrow node),
                 fingerprint + node.kind * 17 + node.estimated_rows + i);
         }
-        i = i + 1;
+        i += 1;
     }
     inspect_indexes(inout out, borrow database, borrow query);
     inspect_columns(inout out, borrow database, borrow query);

--- a/examples/meridian/rule_logical_eliminate_constant_filter.rue
+++ b/examples/meridian/rule_logical_eliminate_constant_filter.rue
@@ -53,13 +53,13 @@ fn inspect_indexes(inout out: rule_result.Decision, borrow database: model.Datab
     let mut i: u64 = 0;
     while i < database.indexes.len() {
         let index = database.indexes.get_or(i, model.empty_index());
-        out.inspected = out.inspected + 1;
+        out.inspected += 1;
         if index.table == query.table &&
             (index.column == query.filter_column || index.column == query.order_column) {
             let benefit = if index.unique { (FOCUS() % 7) + 1 } else { (FOCUS() % 3) + 1 };
             rule_result.record(inout out, benefit, index.entries + index.column + FOCUS());
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -69,7 +69,7 @@ fn inspect_columns(inout out: rule_result.Decision, borrow database: model.Datab
     let mut i: u64 = 0;
     while i < table.column_count {
         let column = database.columns.get_or(table.first_column + i, model.empty_column());
-        out.inspected = out.inspected + 1;
+        out.inspected += 1;
         let selected = (column.ordinal + FOCUS()) % 5 == 0 ||
             column.name == query.filter_column_name ||
             column.name == query.group_column_name ||
@@ -79,7 +79,7 @@ fn inspect_columns(inout out: rule_result.Decision, borrow database: model.Datab
             rule_result.record(inout out, benefit,
                 database.strings.hash(column.name) + column.kind + column.ordinal);
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -90,12 +90,12 @@ pub fn evaluate(borrow database: model.Database, borrow query: model.Query,
     let mut i: u64 = 0;
     while i < input.nodes.len() {
         let node = input.nodes.get_or(i, plan.empty_node());
-        out.inspected = out.inspected + 1;
+        out.inspected += 1;
         if eligible(borrow node, borrow query) {
             rule_result.record(inout out, node_benefit(borrow node),
                 fingerprint + node.kind * 17 + node.estimated_rows + i);
         }
-        i = i + 1;
+        i += 1;
     }
     inspect_indexes(inout out, borrow database, borrow query);
     inspect_columns(inout out, borrow database, borrow query);

--- a/examples/meridian/rule_logical_eliminate_empty_branch.rue
+++ b/examples/meridian/rule_logical_eliminate_empty_branch.rue
@@ -53,13 +53,13 @@ fn inspect_indexes(inout out: rule_result.Decision, borrow database: model.Datab
     let mut i: u64 = 0;
     while i < database.indexes.len() {
         let index = database.indexes.get_or(i, model.empty_index());
-        out.inspected = out.inspected + 1;
+        out.inspected += 1;
         if index.table == query.table &&
             (index.column == query.filter_column || index.column == query.order_column) {
             let benefit = if index.unique { (FOCUS() % 7) + 1 } else { (FOCUS() % 3) + 1 };
             rule_result.record(inout out, benefit, index.entries + index.column + FOCUS());
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -69,7 +69,7 @@ fn inspect_columns(inout out: rule_result.Decision, borrow database: model.Datab
     let mut i: u64 = 0;
     while i < table.column_count {
         let column = database.columns.get_or(table.first_column + i, model.empty_column());
-        out.inspected = out.inspected + 1;
+        out.inspected += 1;
         let selected = (column.ordinal + FOCUS()) % 5 == 0 ||
             column.name == query.filter_column_name ||
             column.name == query.group_column_name ||
@@ -79,7 +79,7 @@ fn inspect_columns(inout out: rule_result.Decision, borrow database: model.Datab
             rule_result.record(inout out, benefit,
                 database.strings.hash(column.name) + column.kind + column.ordinal);
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -90,12 +90,12 @@ pub fn evaluate(borrow database: model.Database, borrow query: model.Query,
     let mut i: u64 = 0;
     while i < input.nodes.len() {
         let node = input.nodes.get_or(i, plan.empty_node());
-        out.inspected = out.inspected + 1;
+        out.inspected += 1;
         if eligible(borrow node, borrow query) {
             rule_result.record(inout out, node_benefit(borrow node),
                 fingerprint + node.kind * 17 + node.estimated_rows + i);
         }
-        i = i + 1;
+        i += 1;
     }
     inspect_indexes(inout out, borrow database, borrow query);
     inspect_columns(inout out, borrow database, borrow query);

--- a/examples/meridian/rule_logical_eliminate_identity_join.rue
+++ b/examples/meridian/rule_logical_eliminate_identity_join.rue
@@ -53,13 +53,13 @@ fn inspect_indexes(inout out: rule_result.Decision, borrow database: model.Datab
     let mut i: u64 = 0;
     while i < database.indexes.len() {
         let index = database.indexes.get_or(i, model.empty_index());
-        out.inspected = out.inspected + 1;
+        out.inspected += 1;
         if index.table == query.table &&
             (index.column == query.filter_column || index.column == query.order_column) {
             let benefit = if index.unique { (FOCUS() % 7) + 1 } else { (FOCUS() % 3) + 1 };
             rule_result.record(inout out, benefit, index.entries + index.column + FOCUS());
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -69,7 +69,7 @@ fn inspect_columns(inout out: rule_result.Decision, borrow database: model.Datab
     let mut i: u64 = 0;
     while i < table.column_count {
         let column = database.columns.get_or(table.first_column + i, model.empty_column());
-        out.inspected = out.inspected + 1;
+        out.inspected += 1;
         let selected = (column.ordinal + FOCUS()) % 5 == 0 ||
             column.name == query.filter_column_name ||
             column.name == query.group_column_name ||
@@ -79,7 +79,7 @@ fn inspect_columns(inout out: rule_result.Decision, borrow database: model.Datab
             rule_result.record(inout out, benefit,
                 database.strings.hash(column.name) + column.kind + column.ordinal);
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -90,12 +90,12 @@ pub fn evaluate(borrow database: model.Database, borrow query: model.Query,
     let mut i: u64 = 0;
     while i < input.nodes.len() {
         let node = input.nodes.get_or(i, plan.empty_node());
-        out.inspected = out.inspected + 1;
+        out.inspected += 1;
         if eligible(borrow node, borrow query) {
             rule_result.record(inout out, node_benefit(borrow node),
                 fingerprint + node.kind * 17 + node.estimated_rows + i);
         }
-        i = i + 1;
+        i += 1;
     }
     inspect_indexes(inout out, borrow database, borrow query);
     inspect_columns(inout out, borrow database, borrow query);

--- a/examples/meridian/rule_logical_fold_limit.rue
+++ b/examples/meridian/rule_logical_fold_limit.rue
@@ -53,13 +53,13 @@ fn inspect_indexes(inout out: rule_result.Decision, borrow database: model.Datab
     let mut i: u64 = 0;
     while i < database.indexes.len() {
         let index = database.indexes.get_or(i, model.empty_index());
-        out.inspected = out.inspected + 1;
+        out.inspected += 1;
         if index.table == query.table &&
             (index.column == query.filter_column || index.column == query.order_column) {
             let benefit = if index.unique { (FOCUS() % 7) + 1 } else { (FOCUS() % 3) + 1 };
             rule_result.record(inout out, benefit, index.entries + index.column + FOCUS());
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -69,7 +69,7 @@ fn inspect_columns(inout out: rule_result.Decision, borrow database: model.Datab
     let mut i: u64 = 0;
     while i < table.column_count {
         let column = database.columns.get_or(table.first_column + i, model.empty_column());
-        out.inspected = out.inspected + 1;
+        out.inspected += 1;
         let selected = (column.ordinal + FOCUS()) % 5 == 0 ||
             column.name == query.filter_column_name ||
             column.name == query.group_column_name ||
@@ -79,7 +79,7 @@ fn inspect_columns(inout out: rule_result.Decision, borrow database: model.Datab
             rule_result.record(inout out, benefit,
                 database.strings.hash(column.name) + column.kind + column.ordinal);
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -90,12 +90,12 @@ pub fn evaluate(borrow database: model.Database, borrow query: model.Query,
     let mut i: u64 = 0;
     while i < input.nodes.len() {
         let node = input.nodes.get_or(i, plan.empty_node());
-        out.inspected = out.inspected + 1;
+        out.inspected += 1;
         if eligible(borrow node, borrow query) {
             rule_result.record(inout out, node_benefit(borrow node),
                 fingerprint + node.kind * 17 + node.estimated_rows + i);
         }
-        i = i + 1;
+        i += 1;
     }
     inspect_indexes(inout out, borrow database, borrow query);
     inspect_columns(inout out, borrow database, borrow query);

--- a/examples/meridian/rule_logical_infer_key_filter.rue
+++ b/examples/meridian/rule_logical_infer_key_filter.rue
@@ -53,13 +53,13 @@ fn inspect_indexes(inout out: rule_result.Decision, borrow database: model.Datab
     let mut i: u64 = 0;
     while i < database.indexes.len() {
         let index = database.indexes.get_or(i, model.empty_index());
-        out.inspected = out.inspected + 1;
+        out.inspected += 1;
         if index.table == query.table &&
             (index.column == query.filter_column || index.column == query.order_column) {
             let benefit = if index.unique { (FOCUS() % 7) + 1 } else { (FOCUS() % 3) + 1 };
             rule_result.record(inout out, benefit, index.entries + index.column + FOCUS());
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -69,7 +69,7 @@ fn inspect_columns(inout out: rule_result.Decision, borrow database: model.Datab
     let mut i: u64 = 0;
     while i < table.column_count {
         let column = database.columns.get_or(table.first_column + i, model.empty_column());
-        out.inspected = out.inspected + 1;
+        out.inspected += 1;
         let selected = (column.ordinal + FOCUS()) % 5 == 0 ||
             column.name == query.filter_column_name ||
             column.name == query.group_column_name ||
@@ -79,7 +79,7 @@ fn inspect_columns(inout out: rule_result.Decision, borrow database: model.Datab
             rule_result.record(inout out, benefit,
                 database.strings.hash(column.name) + column.kind + column.ordinal);
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -90,12 +90,12 @@ pub fn evaluate(borrow database: model.Database, borrow query: model.Query,
     let mut i: u64 = 0;
     while i < input.nodes.len() {
         let node = input.nodes.get_or(i, plan.empty_node());
-        out.inspected = out.inspected + 1;
+        out.inspected += 1;
         if eligible(borrow node, borrow query) {
             rule_result.record(inout out, node_benefit(borrow node),
                 fingerprint + node.kind * 17 + node.estimated_rows + i);
         }
-        i = i + 1;
+        i += 1;
     }
     inspect_indexes(inout out, borrow database, borrow query);
     inspect_columns(inout out, borrow database, borrow query);

--- a/examples/meridian/rule_logical_merge_aggregates.rue
+++ b/examples/meridian/rule_logical_merge_aggregates.rue
@@ -53,13 +53,13 @@ fn inspect_indexes(inout out: rule_result.Decision, borrow database: model.Datab
     let mut i: u64 = 0;
     while i < database.indexes.len() {
         let index = database.indexes.get_or(i, model.empty_index());
-        out.inspected = out.inspected + 1;
+        out.inspected += 1;
         if index.table == query.table &&
             (index.column == query.filter_column || index.column == query.order_column) {
             let benefit = if index.unique { (FOCUS() % 7) + 1 } else { (FOCUS() % 3) + 1 };
             rule_result.record(inout out, benefit, index.entries + index.column + FOCUS());
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -69,7 +69,7 @@ fn inspect_columns(inout out: rule_result.Decision, borrow database: model.Datab
     let mut i: u64 = 0;
     while i < table.column_count {
         let column = database.columns.get_or(table.first_column + i, model.empty_column());
-        out.inspected = out.inspected + 1;
+        out.inspected += 1;
         let selected = (column.ordinal + FOCUS()) % 5 == 0 ||
             column.name == query.filter_column_name ||
             column.name == query.group_column_name ||
@@ -79,7 +79,7 @@ fn inspect_columns(inout out: rule_result.Decision, borrow database: model.Datab
             rule_result.record(inout out, benefit,
                 database.strings.hash(column.name) + column.kind + column.ordinal);
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -90,12 +90,12 @@ pub fn evaluate(borrow database: model.Database, borrow query: model.Query,
     let mut i: u64 = 0;
     while i < input.nodes.len() {
         let node = input.nodes.get_or(i, plan.empty_node());
-        out.inspected = out.inspected + 1;
+        out.inspected += 1;
         if eligible(borrow node, borrow query) {
             rule_result.record(inout out, node_benefit(borrow node),
                 fingerprint + node.kind * 17 + node.estimated_rows + i);
         }
-        i = i + 1;
+        i += 1;
     }
     inspect_indexes(inout out, borrow database, borrow query);
     inspect_columns(inout out, borrow database, borrow query);

--- a/examples/meridian/rule_logical_merge_filters.rue
+++ b/examples/meridian/rule_logical_merge_filters.rue
@@ -53,13 +53,13 @@ fn inspect_indexes(inout out: rule_result.Decision, borrow database: model.Datab
     let mut i: u64 = 0;
     while i < database.indexes.len() {
         let index = database.indexes.get_or(i, model.empty_index());
-        out.inspected = out.inspected + 1;
+        out.inspected += 1;
         if index.table == query.table &&
             (index.column == query.filter_column || index.column == query.order_column) {
             let benefit = if index.unique { (FOCUS() % 7) + 1 } else { (FOCUS() % 3) + 1 };
             rule_result.record(inout out, benefit, index.entries + index.column + FOCUS());
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -69,7 +69,7 @@ fn inspect_columns(inout out: rule_result.Decision, borrow database: model.Datab
     let mut i: u64 = 0;
     while i < table.column_count {
         let column = database.columns.get_or(table.first_column + i, model.empty_column());
-        out.inspected = out.inspected + 1;
+        out.inspected += 1;
         let selected = (column.ordinal + FOCUS()) % 5 == 0 ||
             column.name == query.filter_column_name ||
             column.name == query.group_column_name ||
@@ -79,7 +79,7 @@ fn inspect_columns(inout out: rule_result.Decision, borrow database: model.Datab
             rule_result.record(inout out, benefit,
                 database.strings.hash(column.name) + column.kind + column.ordinal);
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -90,12 +90,12 @@ pub fn evaluate(borrow database: model.Database, borrow query: model.Query,
     let mut i: u64 = 0;
     while i < input.nodes.len() {
         let node = input.nodes.get_or(i, plan.empty_node());
-        out.inspected = out.inspected + 1;
+        out.inspected += 1;
         if eligible(borrow node, borrow query) {
             rule_result.record(inout out, node_benefit(borrow node),
                 fingerprint + node.kind * 17 + node.estimated_rows + i);
         }
-        i = i + 1;
+        i += 1;
     }
     inspect_indexes(inout out, borrow database, borrow query);
     inspect_columns(inout out, borrow database, borrow query);

--- a/examples/meridian/rule_logical_normalize_group.rue
+++ b/examples/meridian/rule_logical_normalize_group.rue
@@ -53,13 +53,13 @@ fn inspect_indexes(inout out: rule_result.Decision, borrow database: model.Datab
     let mut i: u64 = 0;
     while i < database.indexes.len() {
         let index = database.indexes.get_or(i, model.empty_index());
-        out.inspected = out.inspected + 1;
+        out.inspected += 1;
         if index.table == query.table &&
             (index.column == query.filter_column || index.column == query.order_column) {
             let benefit = if index.unique { (FOCUS() % 7) + 1 } else { (FOCUS() % 3) + 1 };
             rule_result.record(inout out, benefit, index.entries + index.column + FOCUS());
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -69,7 +69,7 @@ fn inspect_columns(inout out: rule_result.Decision, borrow database: model.Datab
     let mut i: u64 = 0;
     while i < table.column_count {
         let column = database.columns.get_or(table.first_column + i, model.empty_column());
-        out.inspected = out.inspected + 1;
+        out.inspected += 1;
         let selected = (column.ordinal + FOCUS()) % 5 == 0 ||
             column.name == query.filter_column_name ||
             column.name == query.group_column_name ||
@@ -79,7 +79,7 @@ fn inspect_columns(inout out: rule_result.Decision, borrow database: model.Datab
             rule_result.record(inout out, benefit,
                 database.strings.hash(column.name) + column.kind + column.ordinal);
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -90,12 +90,12 @@ pub fn evaluate(borrow database: model.Database, borrow query: model.Query,
     let mut i: u64 = 0;
     while i < input.nodes.len() {
         let node = input.nodes.get_or(i, plan.empty_node());
-        out.inspected = out.inspected + 1;
+        out.inspected += 1;
         if eligible(borrow node, borrow query) {
             rule_result.record(inout out, node_benefit(borrow node),
                 fingerprint + node.kind * 17 + node.estimated_rows + i);
         }
-        i = i + 1;
+        i += 1;
     }
     inspect_indexes(inout out, borrow database, borrow query);
     inspect_columns(inout out, borrow database, borrow query);

--- a/examples/meridian/rule_logical_prune_distinct.rue
+++ b/examples/meridian/rule_logical_prune_distinct.rue
@@ -53,13 +53,13 @@ fn inspect_indexes(inout out: rule_result.Decision, borrow database: model.Datab
     let mut i: u64 = 0;
     while i < database.indexes.len() {
         let index = database.indexes.get_or(i, model.empty_index());
-        out.inspected = out.inspected + 1;
+        out.inspected += 1;
         if index.table == query.table &&
             (index.column == query.filter_column || index.column == query.order_column) {
             let benefit = if index.unique { (FOCUS() % 7) + 1 } else { (FOCUS() % 3) + 1 };
             rule_result.record(inout out, benefit, index.entries + index.column + FOCUS());
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -69,7 +69,7 @@ fn inspect_columns(inout out: rule_result.Decision, borrow database: model.Datab
     let mut i: u64 = 0;
     while i < table.column_count {
         let column = database.columns.get_or(table.first_column + i, model.empty_column());
-        out.inspected = out.inspected + 1;
+        out.inspected += 1;
         let selected = (column.ordinal + FOCUS()) % 5 == 0 ||
             column.name == query.filter_column_name ||
             column.name == query.group_column_name ||
@@ -79,7 +79,7 @@ fn inspect_columns(inout out: rule_result.Decision, borrow database: model.Datab
             rule_result.record(inout out, benefit,
                 database.strings.hash(column.name) + column.kind + column.ordinal);
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -90,12 +90,12 @@ pub fn evaluate(borrow database: model.Database, borrow query: model.Query,
     let mut i: u64 = 0;
     while i < input.nodes.len() {
         let node = input.nodes.get_or(i, plan.empty_node());
-        out.inspected = out.inspected + 1;
+        out.inspected += 1;
         if eligible(borrow node, borrow query) {
             rule_result.record(inout out, node_benefit(borrow node),
                 fingerprint + node.kind * 17 + node.estimated_rows + i);
         }
-        i = i + 1;
+        i += 1;
     }
     inspect_indexes(inout out, borrow database, borrow query);
     inspect_columns(inout out, borrow database, borrow query);

--- a/examples/meridian/rule_logical_prune_projection.rue
+++ b/examples/meridian/rule_logical_prune_projection.rue
@@ -53,13 +53,13 @@ fn inspect_indexes(inout out: rule_result.Decision, borrow database: model.Datab
     let mut i: u64 = 0;
     while i < database.indexes.len() {
         let index = database.indexes.get_or(i, model.empty_index());
-        out.inspected = out.inspected + 1;
+        out.inspected += 1;
         if index.table == query.table &&
             (index.column == query.filter_column || index.column == query.order_column) {
             let benefit = if index.unique { (FOCUS() % 7) + 1 } else { (FOCUS() % 3) + 1 };
             rule_result.record(inout out, benefit, index.entries + index.column + FOCUS());
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -69,7 +69,7 @@ fn inspect_columns(inout out: rule_result.Decision, borrow database: model.Datab
     let mut i: u64 = 0;
     while i < table.column_count {
         let column = database.columns.get_or(table.first_column + i, model.empty_column());
-        out.inspected = out.inspected + 1;
+        out.inspected += 1;
         let selected = (column.ordinal + FOCUS()) % 5 == 0 ||
             column.name == query.filter_column_name ||
             column.name == query.group_column_name ||
@@ -79,7 +79,7 @@ fn inspect_columns(inout out: rule_result.Decision, borrow database: model.Datab
             rule_result.record(inout out, benefit,
                 database.strings.hash(column.name) + column.kind + column.ordinal);
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -90,12 +90,12 @@ pub fn evaluate(borrow database: model.Database, borrow query: model.Query,
     let mut i: u64 = 0;
     while i < input.nodes.len() {
         let node = input.nodes.get_or(i, plan.empty_node());
-        out.inspected = out.inspected + 1;
+        out.inspected += 1;
         if eligible(borrow node, borrow query) {
             rule_result.record(inout out, node_benefit(borrow node),
                 fingerprint + node.kind * 17 + node.estimated_rows + i);
         }
-        i = i + 1;
+        i += 1;
     }
     inspect_indexes(inout out, borrow database, borrow query);
     inspect_columns(inout out, borrow database, borrow query);

--- a/examples/meridian/rule_logical_pull_common_filter.rue
+++ b/examples/meridian/rule_logical_pull_common_filter.rue
@@ -53,13 +53,13 @@ fn inspect_indexes(inout out: rule_result.Decision, borrow database: model.Datab
     let mut i: u64 = 0;
     while i < database.indexes.len() {
         let index = database.indexes.get_or(i, model.empty_index());
-        out.inspected = out.inspected + 1;
+        out.inspected += 1;
         if index.table == query.table &&
             (index.column == query.filter_column || index.column == query.order_column) {
             let benefit = if index.unique { (FOCUS() % 7) + 1 } else { (FOCUS() % 3) + 1 };
             rule_result.record(inout out, benefit, index.entries + index.column + FOCUS());
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -69,7 +69,7 @@ fn inspect_columns(inout out: rule_result.Decision, borrow database: model.Datab
     let mut i: u64 = 0;
     while i < table.column_count {
         let column = database.columns.get_or(table.first_column + i, model.empty_column());
-        out.inspected = out.inspected + 1;
+        out.inspected += 1;
         let selected = (column.ordinal + FOCUS()) % 5 == 0 ||
             column.name == query.filter_column_name ||
             column.name == query.group_column_name ||
@@ -79,7 +79,7 @@ fn inspect_columns(inout out: rule_result.Decision, borrow database: model.Datab
             rule_result.record(inout out, benefit,
                 database.strings.hash(column.name) + column.kind + column.ordinal);
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -90,12 +90,12 @@ pub fn evaluate(borrow database: model.Database, borrow query: model.Query,
     let mut i: u64 = 0;
     while i < input.nodes.len() {
         let node = input.nodes.get_or(i, plan.empty_node());
-        out.inspected = out.inspected + 1;
+        out.inspected += 1;
         if eligible(borrow node, borrow query) {
             rule_result.record(inout out, node_benefit(borrow node),
                 fingerprint + node.kind * 17 + node.estimated_rows + i);
         }
-        i = i + 1;
+        i += 1;
     }
     inspect_indexes(inout out, borrow database, borrow query);
     inspect_columns(inout out, borrow database, borrow query);

--- a/examples/meridian/rule_logical_pull_projection.rue
+++ b/examples/meridian/rule_logical_pull_projection.rue
@@ -53,13 +53,13 @@ fn inspect_indexes(inout out: rule_result.Decision, borrow database: model.Datab
     let mut i: u64 = 0;
     while i < database.indexes.len() {
         let index = database.indexes.get_or(i, model.empty_index());
-        out.inspected = out.inspected + 1;
+        out.inspected += 1;
         if index.table == query.table &&
             (index.column == query.filter_column || index.column == query.order_column) {
             let benefit = if index.unique { (FOCUS() % 7) + 1 } else { (FOCUS() % 3) + 1 };
             rule_result.record(inout out, benefit, index.entries + index.column + FOCUS());
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -69,7 +69,7 @@ fn inspect_columns(inout out: rule_result.Decision, borrow database: model.Datab
     let mut i: u64 = 0;
     while i < table.column_count {
         let column = database.columns.get_or(table.first_column + i, model.empty_column());
-        out.inspected = out.inspected + 1;
+        out.inspected += 1;
         let selected = (column.ordinal + FOCUS()) % 5 == 0 ||
             column.name == query.filter_column_name ||
             column.name == query.group_column_name ||
@@ -79,7 +79,7 @@ fn inspect_columns(inout out: rule_result.Decision, borrow database: model.Datab
             rule_result.record(inout out, benefit,
                 database.strings.hash(column.name) + column.kind + column.ordinal);
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -90,12 +90,12 @@ pub fn evaluate(borrow database: model.Database, borrow query: model.Query,
     let mut i: u64 = 0;
     while i < input.nodes.len() {
         let node = input.nodes.get_or(i, plan.empty_node());
-        out.inspected = out.inspected + 1;
+        out.inspected += 1;
         if eligible(borrow node, borrow query) {
             rule_result.record(inout out, node_benefit(borrow node),
                 fingerprint + node.kind * 17 + node.estimated_rows + i);
         }
-        i = i + 1;
+        i += 1;
     }
     inspect_indexes(inout out, borrow database, borrow query);
     inspect_columns(inout out, borrow database, borrow query);

--- a/examples/meridian/rule_logical_push_filter.rue
+++ b/examples/meridian/rule_logical_push_filter.rue
@@ -53,13 +53,13 @@ fn inspect_indexes(inout out: rule_result.Decision, borrow database: model.Datab
     let mut i: u64 = 0;
     while i < database.indexes.len() {
         let index = database.indexes.get_or(i, model.empty_index());
-        out.inspected = out.inspected + 1;
+        out.inspected += 1;
         if index.table == query.table &&
             (index.column == query.filter_column || index.column == query.order_column) {
             let benefit = if index.unique { (FOCUS() % 7) + 1 } else { (FOCUS() % 3) + 1 };
             rule_result.record(inout out, benefit, index.entries + index.column + FOCUS());
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -69,7 +69,7 @@ fn inspect_columns(inout out: rule_result.Decision, borrow database: model.Datab
     let mut i: u64 = 0;
     while i < table.column_count {
         let column = database.columns.get_or(table.first_column + i, model.empty_column());
-        out.inspected = out.inspected + 1;
+        out.inspected += 1;
         let selected = (column.ordinal + FOCUS()) % 5 == 0 ||
             column.name == query.filter_column_name ||
             column.name == query.group_column_name ||
@@ -79,7 +79,7 @@ fn inspect_columns(inout out: rule_result.Decision, borrow database: model.Datab
             rule_result.record(inout out, benefit,
                 database.strings.hash(column.name) + column.kind + column.ordinal);
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -90,12 +90,12 @@ pub fn evaluate(borrow database: model.Database, borrow query: model.Query,
     let mut i: u64 = 0;
     while i < input.nodes.len() {
         let node = input.nodes.get_or(i, plan.empty_node());
-        out.inspected = out.inspected + 1;
+        out.inspected += 1;
         if eligible(borrow node, borrow query) {
             rule_result.record(inout out, node_benefit(borrow node),
                 fingerprint + node.kind * 17 + node.estimated_rows + i);
         }
-        i = i + 1;
+        i += 1;
     }
     inspect_indexes(inout out, borrow database, borrow query);
     inspect_columns(inout out, borrow database, borrow query);

--- a/examples/meridian/rule_logical_push_group.rue
+++ b/examples/meridian/rule_logical_push_group.rue
@@ -53,13 +53,13 @@ fn inspect_indexes(inout out: rule_result.Decision, borrow database: model.Datab
     let mut i: u64 = 0;
     while i < database.indexes.len() {
         let index = database.indexes.get_or(i, model.empty_index());
-        out.inspected = out.inspected + 1;
+        out.inspected += 1;
         if index.table == query.table &&
             (index.column == query.filter_column || index.column == query.order_column) {
             let benefit = if index.unique { (FOCUS() % 7) + 1 } else { (FOCUS() % 3) + 1 };
             rule_result.record(inout out, benefit, index.entries + index.column + FOCUS());
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -69,7 +69,7 @@ fn inspect_columns(inout out: rule_result.Decision, borrow database: model.Datab
     let mut i: u64 = 0;
     while i < table.column_count {
         let column = database.columns.get_or(table.first_column + i, model.empty_column());
-        out.inspected = out.inspected + 1;
+        out.inspected += 1;
         let selected = (column.ordinal + FOCUS()) % 5 == 0 ||
             column.name == query.filter_column_name ||
             column.name == query.group_column_name ||
@@ -79,7 +79,7 @@ fn inspect_columns(inout out: rule_result.Decision, borrow database: model.Datab
             rule_result.record(inout out, benefit,
                 database.strings.hash(column.name) + column.kind + column.ordinal);
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -90,12 +90,12 @@ pub fn evaluate(borrow database: model.Database, borrow query: model.Query,
     let mut i: u64 = 0;
     while i < input.nodes.len() {
         let node = input.nodes.get_or(i, plan.empty_node());
-        out.inspected = out.inspected + 1;
+        out.inspected += 1;
         if eligible(borrow node, borrow query) {
             rule_result.record(inout out, node_benefit(borrow node),
                 fingerprint + node.kind * 17 + node.estimated_rows + i);
         }
-        i = i + 1;
+        i += 1;
     }
     inspect_indexes(inout out, borrow database, borrow query);
     inspect_columns(inout out, borrow database, borrow query);

--- a/examples/meridian/rule_logical_push_limit.rue
+++ b/examples/meridian/rule_logical_push_limit.rue
@@ -53,13 +53,13 @@ fn inspect_indexes(inout out: rule_result.Decision, borrow database: model.Datab
     let mut i: u64 = 0;
     while i < database.indexes.len() {
         let index = database.indexes.get_or(i, model.empty_index());
-        out.inspected = out.inspected + 1;
+        out.inspected += 1;
         if index.table == query.table &&
             (index.column == query.filter_column || index.column == query.order_column) {
             let benefit = if index.unique { (FOCUS() % 7) + 1 } else { (FOCUS() % 3) + 1 };
             rule_result.record(inout out, benefit, index.entries + index.column + FOCUS());
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -69,7 +69,7 @@ fn inspect_columns(inout out: rule_result.Decision, borrow database: model.Datab
     let mut i: u64 = 0;
     while i < table.column_count {
         let column = database.columns.get_or(table.first_column + i, model.empty_column());
-        out.inspected = out.inspected + 1;
+        out.inspected += 1;
         let selected = (column.ordinal + FOCUS()) % 5 == 0 ||
             column.name == query.filter_column_name ||
             column.name == query.group_column_name ||
@@ -79,7 +79,7 @@ fn inspect_columns(inout out: rule_result.Decision, borrow database: model.Datab
             rule_result.record(inout out, benefit,
                 database.strings.hash(column.name) + column.kind + column.ordinal);
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -90,12 +90,12 @@ pub fn evaluate(borrow database: model.Database, borrow query: model.Query,
     let mut i: u64 = 0;
     while i < input.nodes.len() {
         let node = input.nodes.get_or(i, plan.empty_node());
-        out.inspected = out.inspected + 1;
+        out.inspected += 1;
         if eligible(borrow node, borrow query) {
             rule_result.record(inout out, node_benefit(borrow node),
                 fingerprint + node.kind * 17 + node.estimated_rows + i);
         }
-        i = i + 1;
+        i += 1;
     }
     inspect_indexes(inout out, borrow database, borrow query);
     inspect_columns(inout out, borrow database, borrow query);

--- a/examples/meridian/rule_logical_reduce_join_columns.rue
+++ b/examples/meridian/rule_logical_reduce_join_columns.rue
@@ -53,13 +53,13 @@ fn inspect_indexes(inout out: rule_result.Decision, borrow database: model.Datab
     let mut i: u64 = 0;
     while i < database.indexes.len() {
         let index = database.indexes.get_or(i, model.empty_index());
-        out.inspected = out.inspected + 1;
+        out.inspected += 1;
         if index.table == query.table &&
             (index.column == query.filter_column || index.column == query.order_column) {
             let benefit = if index.unique { (FOCUS() % 7) + 1 } else { (FOCUS() % 3) + 1 };
             rule_result.record(inout out, benefit, index.entries + index.column + FOCUS());
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -69,7 +69,7 @@ fn inspect_columns(inout out: rule_result.Decision, borrow database: model.Datab
     let mut i: u64 = 0;
     while i < table.column_count {
         let column = database.columns.get_or(table.first_column + i, model.empty_column());
-        out.inspected = out.inspected + 1;
+        out.inspected += 1;
         let selected = (column.ordinal + FOCUS()) % 5 == 0 ||
             column.name == query.filter_column_name ||
             column.name == query.group_column_name ||
@@ -79,7 +79,7 @@ fn inspect_columns(inout out: rule_result.Decision, borrow database: model.Datab
             rule_result.record(inout out, benefit,
                 database.strings.hash(column.name) + column.kind + column.ordinal);
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -90,12 +90,12 @@ pub fn evaluate(borrow database: model.Database, borrow query: model.Query,
     let mut i: u64 = 0;
     while i < input.nodes.len() {
         let node = input.nodes.get_or(i, plan.empty_node());
-        out.inspected = out.inspected + 1;
+        out.inspected += 1;
         if eligible(borrow node, borrow query) {
             rule_result.record(inout out, node_benefit(borrow node),
                 fingerprint + node.kind * 17 + node.estimated_rows + i);
         }
-        i = i + 1;
+        i += 1;
     }
     inspect_indexes(inout out, borrow database, borrow query);
     inspect_columns(inout out, borrow database, borrow query);

--- a/examples/meridian/rule_logical_remove_redundant_sort.rue
+++ b/examples/meridian/rule_logical_remove_redundant_sort.rue
@@ -53,13 +53,13 @@ fn inspect_indexes(inout out: rule_result.Decision, borrow database: model.Datab
     let mut i: u64 = 0;
     while i < database.indexes.len() {
         let index = database.indexes.get_or(i, model.empty_index());
-        out.inspected = out.inspected + 1;
+        out.inspected += 1;
         if index.table == query.table &&
             (index.column == query.filter_column || index.column == query.order_column) {
             let benefit = if index.unique { (FOCUS() % 7) + 1 } else { (FOCUS() % 3) + 1 };
             rule_result.record(inout out, benefit, index.entries + index.column + FOCUS());
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -69,7 +69,7 @@ fn inspect_columns(inout out: rule_result.Decision, borrow database: model.Datab
     let mut i: u64 = 0;
     while i < table.column_count {
         let column = database.columns.get_or(table.first_column + i, model.empty_column());
-        out.inspected = out.inspected + 1;
+        out.inspected += 1;
         let selected = (column.ordinal + FOCUS()) % 5 == 0 ||
             column.name == query.filter_column_name ||
             column.name == query.group_column_name ||
@@ -79,7 +79,7 @@ fn inspect_columns(inout out: rule_result.Decision, borrow database: model.Datab
             rule_result.record(inout out, benefit,
                 database.strings.hash(column.name) + column.kind + column.ordinal);
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -90,12 +90,12 @@ pub fn evaluate(borrow database: model.Database, borrow query: model.Query,
     let mut i: u64 = 0;
     while i < input.nodes.len() {
         let node = input.nodes.get_or(i, plan.empty_node());
-        out.inspected = out.inspected + 1;
+        out.inspected += 1;
         if eligible(borrow node, borrow query) {
             rule_result.record(inout out, node_benefit(borrow node),
                 fingerprint + node.kind * 17 + node.estimated_rows + i);
         }
-        i = i + 1;
+        i += 1;
     }
     inspect_indexes(inout out, borrow database, borrow query);
     inspect_columns(inout out, borrow database, borrow query);

--- a/examples/meridian/rule_logical_reorder_conjunction.rue
+++ b/examples/meridian/rule_logical_reorder_conjunction.rue
@@ -53,13 +53,13 @@ fn inspect_indexes(inout out: rule_result.Decision, borrow database: model.Datab
     let mut i: u64 = 0;
     while i < database.indexes.len() {
         let index = database.indexes.get_or(i, model.empty_index());
-        out.inspected = out.inspected + 1;
+        out.inspected += 1;
         if index.table == query.table &&
             (index.column == query.filter_column || index.column == query.order_column) {
             let benefit = if index.unique { (FOCUS() % 7) + 1 } else { (FOCUS() % 3) + 1 };
             rule_result.record(inout out, benefit, index.entries + index.column + FOCUS());
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -69,7 +69,7 @@ fn inspect_columns(inout out: rule_result.Decision, borrow database: model.Datab
     let mut i: u64 = 0;
     while i < table.column_count {
         let column = database.columns.get_or(table.first_column + i, model.empty_column());
-        out.inspected = out.inspected + 1;
+        out.inspected += 1;
         let selected = (column.ordinal + FOCUS()) % 5 == 0 ||
             column.name == query.filter_column_name ||
             column.name == query.group_column_name ||
@@ -79,7 +79,7 @@ fn inspect_columns(inout out: rule_result.Decision, borrow database: model.Datab
             rule_result.record(inout out, benefit,
                 database.strings.hash(column.name) + column.kind + column.ordinal);
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -90,12 +90,12 @@ pub fn evaluate(borrow database: model.Database, borrow query: model.Query,
     let mut i: u64 = 0;
     while i < input.nodes.len() {
         let node = input.nodes.get_or(i, plan.empty_node());
-        out.inspected = out.inspected + 1;
+        out.inspected += 1;
         if eligible(borrow node, borrow query) {
             rule_result.record(inout out, node_benefit(borrow node),
                 fingerprint + node.kind * 17 + node.estimated_rows + i);
         }
-        i = i + 1;
+        i += 1;
     }
     inspect_indexes(inout out, borrow database, borrow query);
     inspect_columns(inout out, borrow database, borrow query);

--- a/examples/meridian/rule_logical_reuse_subplan.rue
+++ b/examples/meridian/rule_logical_reuse_subplan.rue
@@ -53,13 +53,13 @@ fn inspect_indexes(inout out: rule_result.Decision, borrow database: model.Datab
     let mut i: u64 = 0;
     while i < database.indexes.len() {
         let index = database.indexes.get_or(i, model.empty_index());
-        out.inspected = out.inspected + 1;
+        out.inspected += 1;
         if index.table == query.table &&
             (index.column == query.filter_column || index.column == query.order_column) {
             let benefit = if index.unique { (FOCUS() % 7) + 1 } else { (FOCUS() % 3) + 1 };
             rule_result.record(inout out, benefit, index.entries + index.column + FOCUS());
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -69,7 +69,7 @@ fn inspect_columns(inout out: rule_result.Decision, borrow database: model.Datab
     let mut i: u64 = 0;
     while i < table.column_count {
         let column = database.columns.get_or(table.first_column + i, model.empty_column());
-        out.inspected = out.inspected + 1;
+        out.inspected += 1;
         let selected = (column.ordinal + FOCUS()) % 5 == 0 ||
             column.name == query.filter_column_name ||
             column.name == query.group_column_name ||
@@ -79,7 +79,7 @@ fn inspect_columns(inout out: rule_result.Decision, borrow database: model.Datab
             rule_result.record(inout out, benefit,
                 database.strings.hash(column.name) + column.kind + column.ordinal);
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -90,12 +90,12 @@ pub fn evaluate(borrow database: model.Database, borrow query: model.Query,
     let mut i: u64 = 0;
     while i < input.nodes.len() {
         let node = input.nodes.get_or(i, plan.empty_node());
-        out.inspected = out.inspected + 1;
+        out.inspected += 1;
         if eligible(borrow node, borrow query) {
             rule_result.record(inout out, node_benefit(borrow node),
                 fingerprint + node.kind * 17 + node.estimated_rows + i);
         }
-        i = i + 1;
+        i += 1;
     }
     inspect_indexes(inout out, borrow database, borrow query);
     inspect_columns(inout out, borrow database, borrow query);

--- a/examples/meridian/rule_logical_rewrite_count.rue
+++ b/examples/meridian/rule_logical_rewrite_count.rue
@@ -53,13 +53,13 @@ fn inspect_indexes(inout out: rule_result.Decision, borrow database: model.Datab
     let mut i: u64 = 0;
     while i < database.indexes.len() {
         let index = database.indexes.get_or(i, model.empty_index());
-        out.inspected = out.inspected + 1;
+        out.inspected += 1;
         if index.table == query.table &&
             (index.column == query.filter_column || index.column == query.order_column) {
             let benefit = if index.unique { (FOCUS() % 7) + 1 } else { (FOCUS() % 3) + 1 };
             rule_result.record(inout out, benefit, index.entries + index.column + FOCUS());
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -69,7 +69,7 @@ fn inspect_columns(inout out: rule_result.Decision, borrow database: model.Datab
     let mut i: u64 = 0;
     while i < table.column_count {
         let column = database.columns.get_or(table.first_column + i, model.empty_column());
-        out.inspected = out.inspected + 1;
+        out.inspected += 1;
         let selected = (column.ordinal + FOCUS()) % 5 == 0 ||
             column.name == query.filter_column_name ||
             column.name == query.group_column_name ||
@@ -79,7 +79,7 @@ fn inspect_columns(inout out: rule_result.Decision, borrow database: model.Datab
             rule_result.record(inout out, benefit,
                 database.strings.hash(column.name) + column.kind + column.ordinal);
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -90,12 +90,12 @@ pub fn evaluate(borrow database: model.Database, borrow query: model.Query,
     let mut i: u64 = 0;
     while i < input.nodes.len() {
         let node = input.nodes.get_or(i, plan.empty_node());
-        out.inspected = out.inspected + 1;
+        out.inspected += 1;
         if eligible(borrow node, borrow query) {
             rule_result.record(inout out, node_benefit(borrow node),
                 fingerprint + node.kind * 17 + node.estimated_rows + i);
         }
-        i = i + 1;
+        i += 1;
     }
     inspect_indexes(inout out, borrow database, borrow query);
     inspect_columns(inout out, borrow database, borrow query);

--- a/examples/meridian/rule_logical_simplify_predicate.rue
+++ b/examples/meridian/rule_logical_simplify_predicate.rue
@@ -53,13 +53,13 @@ fn inspect_indexes(inout out: rule_result.Decision, borrow database: model.Datab
     let mut i: u64 = 0;
     while i < database.indexes.len() {
         let index = database.indexes.get_or(i, model.empty_index());
-        out.inspected = out.inspected + 1;
+        out.inspected += 1;
         if index.table == query.table &&
             (index.column == query.filter_column || index.column == query.order_column) {
             let benefit = if index.unique { (FOCUS() % 7) + 1 } else { (FOCUS() % 3) + 1 };
             rule_result.record(inout out, benefit, index.entries + index.column + FOCUS());
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -69,7 +69,7 @@ fn inspect_columns(inout out: rule_result.Decision, borrow database: model.Datab
     let mut i: u64 = 0;
     while i < table.column_count {
         let column = database.columns.get_or(table.first_column + i, model.empty_column());
-        out.inspected = out.inspected + 1;
+        out.inspected += 1;
         let selected = (column.ordinal + FOCUS()) % 5 == 0 ||
             column.name == query.filter_column_name ||
             column.name == query.group_column_name ||
@@ -79,7 +79,7 @@ fn inspect_columns(inout out: rule_result.Decision, borrow database: model.Datab
             rule_result.record(inout out, benefit,
                 database.strings.hash(column.name) + column.kind + column.ordinal);
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -90,12 +90,12 @@ pub fn evaluate(borrow database: model.Database, borrow query: model.Query,
     let mut i: u64 = 0;
     while i < input.nodes.len() {
         let node = input.nodes.get_or(i, plan.empty_node());
-        out.inspected = out.inspected + 1;
+        out.inspected += 1;
         if eligible(borrow node, borrow query) {
             rule_result.record(inout out, node_benefit(borrow node),
                 fingerprint + node.kind * 17 + node.estimated_rows + i);
         }
-        i = i + 1;
+        i += 1;
     }
     inspect_indexes(inout out, borrow database, borrow query);
     inspect_columns(inout out, borrow database, borrow query);

--- a/examples/meridian/rule_physical_batch_lookup.rue
+++ b/examples/meridian/rule_physical_batch_lookup.rue
@@ -53,13 +53,13 @@ fn inspect_indexes(inout out: rule_result.Decision, borrow database: model.Datab
     let mut i: u64 = 0;
     while i < database.indexes.len() {
         let index = database.indexes.get_or(i, model.empty_index());
-        out.inspected = out.inspected + 1;
+        out.inspected += 1;
         if index.table == query.table &&
             (index.column == query.filter_column || index.column == query.order_column) {
             let benefit = if index.unique { (FOCUS() % 7) + 1 } else { (FOCUS() % 3) + 1 };
             rule_result.record(inout out, benefit, index.entries + index.column + FOCUS());
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -69,7 +69,7 @@ fn inspect_columns(inout out: rule_result.Decision, borrow database: model.Datab
     let mut i: u64 = 0;
     while i < table.column_count {
         let column = database.columns.get_or(table.first_column + i, model.empty_column());
-        out.inspected = out.inspected + 1;
+        out.inspected += 1;
         let selected = (column.ordinal + FOCUS()) % 5 == 0 ||
             column.name == query.filter_column_name ||
             column.name == query.group_column_name ||
@@ -79,7 +79,7 @@ fn inspect_columns(inout out: rule_result.Decision, borrow database: model.Datab
             rule_result.record(inout out, benefit,
                 database.strings.hash(column.name) + column.kind + column.ordinal);
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -90,12 +90,12 @@ pub fn evaluate(borrow database: model.Database, borrow query: model.Query,
     let mut i: u64 = 0;
     while i < input.nodes.len() {
         let node = input.nodes.get_or(i, plan.empty_node());
-        out.inspected = out.inspected + 1;
+        out.inspected += 1;
         if eligible(borrow node, borrow query) {
             rule_result.record(inout out, node_benefit(borrow node),
                 fingerprint + node.kind * 17 + node.estimated_rows + i);
         }
-        i = i + 1;
+        i += 1;
     }
     inspect_indexes(inout out, borrow database, borrow query);
     inspect_columns(inout out, borrow database, borrow query);

--- a/examples/meridian/rule_physical_choose_full_sort.rue
+++ b/examples/meridian/rule_physical_choose_full_sort.rue
@@ -53,13 +53,13 @@ fn inspect_indexes(inout out: rule_result.Decision, borrow database: model.Datab
     let mut i: u64 = 0;
     while i < database.indexes.len() {
         let index = database.indexes.get_or(i, model.empty_index());
-        out.inspected = out.inspected + 1;
+        out.inspected += 1;
         if index.table == query.table &&
             (index.column == query.filter_column || index.column == query.order_column) {
             let benefit = if index.unique { (FOCUS() % 7) + 1 } else { (FOCUS() % 3) + 1 };
             rule_result.record(inout out, benefit, index.entries + index.column + FOCUS());
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -69,7 +69,7 @@ fn inspect_columns(inout out: rule_result.Decision, borrow database: model.Datab
     let mut i: u64 = 0;
     while i < table.column_count {
         let column = database.columns.get_or(table.first_column + i, model.empty_column());
-        out.inspected = out.inspected + 1;
+        out.inspected += 1;
         let selected = (column.ordinal + FOCUS()) % 5 == 0 ||
             column.name == query.filter_column_name ||
             column.name == query.group_column_name ||
@@ -79,7 +79,7 @@ fn inspect_columns(inout out: rule_result.Decision, borrow database: model.Datab
             rule_result.record(inout out, benefit,
                 database.strings.hash(column.name) + column.kind + column.ordinal);
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -90,12 +90,12 @@ pub fn evaluate(borrow database: model.Database, borrow query: model.Query,
     let mut i: u64 = 0;
     while i < input.nodes.len() {
         let node = input.nodes.get_or(i, plan.empty_node());
-        out.inspected = out.inspected + 1;
+        out.inspected += 1;
         if eligible(borrow node, borrow query) {
             rule_result.record(inout out, node_benefit(borrow node),
                 fingerprint + node.kind * 17 + node.estimated_rows + i);
         }
-        i = i + 1;
+        i += 1;
     }
     inspect_indexes(inout out, borrow database, borrow query);
     inspect_columns(inout out, borrow database, borrow query);

--- a/examples/meridian/rule_physical_choose_hash_group.rue
+++ b/examples/meridian/rule_physical_choose_hash_group.rue
@@ -53,13 +53,13 @@ fn inspect_indexes(inout out: rule_result.Decision, borrow database: model.Datab
     let mut i: u64 = 0;
     while i < database.indexes.len() {
         let index = database.indexes.get_or(i, model.empty_index());
-        out.inspected = out.inspected + 1;
+        out.inspected += 1;
         if index.table == query.table &&
             (index.column == query.filter_column || index.column == query.order_column) {
             let benefit = if index.unique { (FOCUS() % 7) + 1 } else { (FOCUS() % 3) + 1 };
             rule_result.record(inout out, benefit, index.entries + index.column + FOCUS());
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -69,7 +69,7 @@ fn inspect_columns(inout out: rule_result.Decision, borrow database: model.Datab
     let mut i: u64 = 0;
     while i < table.column_count {
         let column = database.columns.get_or(table.first_column + i, model.empty_column());
-        out.inspected = out.inspected + 1;
+        out.inspected += 1;
         let selected = (column.ordinal + FOCUS()) % 5 == 0 ||
             column.name == query.filter_column_name ||
             column.name == query.group_column_name ||
@@ -79,7 +79,7 @@ fn inspect_columns(inout out: rule_result.Decision, borrow database: model.Datab
             rule_result.record(inout out, benefit,
                 database.strings.hash(column.name) + column.kind + column.ordinal);
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -90,12 +90,12 @@ pub fn evaluate(borrow database: model.Database, borrow query: model.Query,
     let mut i: u64 = 0;
     while i < input.nodes.len() {
         let node = input.nodes.get_or(i, plan.empty_node());
-        out.inspected = out.inspected + 1;
+        out.inspected += 1;
         if eligible(borrow node, borrow query) {
             rule_result.record(inout out, node_benefit(borrow node),
                 fingerprint + node.kind * 17 + node.estimated_rows + i);
         }
-        i = i + 1;
+        i += 1;
     }
     inspect_indexes(inout out, borrow database, borrow query);
     inspect_columns(inout out, borrow database, borrow query);

--- a/examples/meridian/rule_physical_choose_hash_join.rue
+++ b/examples/meridian/rule_physical_choose_hash_join.rue
@@ -53,13 +53,13 @@ fn inspect_indexes(inout out: rule_result.Decision, borrow database: model.Datab
     let mut i: u64 = 0;
     while i < database.indexes.len() {
         let index = database.indexes.get_or(i, model.empty_index());
-        out.inspected = out.inspected + 1;
+        out.inspected += 1;
         if index.table == query.table &&
             (index.column == query.filter_column || index.column == query.order_column) {
             let benefit = if index.unique { (FOCUS() % 7) + 1 } else { (FOCUS() % 3) + 1 };
             rule_result.record(inout out, benefit, index.entries + index.column + FOCUS());
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -69,7 +69,7 @@ fn inspect_columns(inout out: rule_result.Decision, borrow database: model.Datab
     let mut i: u64 = 0;
     while i < table.column_count {
         let column = database.columns.get_or(table.first_column + i, model.empty_column());
-        out.inspected = out.inspected + 1;
+        out.inspected += 1;
         let selected = (column.ordinal + FOCUS()) % 5 == 0 ||
             column.name == query.filter_column_name ||
             column.name == query.group_column_name ||
@@ -79,7 +79,7 @@ fn inspect_columns(inout out: rule_result.Decision, borrow database: model.Datab
             rule_result.record(inout out, benefit,
                 database.strings.hash(column.name) + column.kind + column.ordinal);
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -90,12 +90,12 @@ pub fn evaluate(borrow database: model.Database, borrow query: model.Query,
     let mut i: u64 = 0;
     while i < input.nodes.len() {
         let node = input.nodes.get_or(i, plan.empty_node());
-        out.inspected = out.inspected + 1;
+        out.inspected += 1;
         if eligible(borrow node, borrow query) {
             rule_result.record(inout out, node_benefit(borrow node),
                 fingerprint + node.kind * 17 + node.estimated_rows + i);
         }
-        i = i + 1;
+        i += 1;
     }
     inspect_indexes(inout out, borrow database, borrow query);
     inspect_columns(inout out, borrow database, borrow query);

--- a/examples/meridian/rule_physical_choose_index_scan.rue
+++ b/examples/meridian/rule_physical_choose_index_scan.rue
@@ -53,13 +53,13 @@ fn inspect_indexes(inout out: rule_result.Decision, borrow database: model.Datab
     let mut i: u64 = 0;
     while i < database.indexes.len() {
         let index = database.indexes.get_or(i, model.empty_index());
-        out.inspected = out.inspected + 1;
+        out.inspected += 1;
         if index.table == query.table &&
             (index.column == query.filter_column || index.column == query.order_column) {
             let benefit = if index.unique { (FOCUS() % 7) + 1 } else { (FOCUS() % 3) + 1 };
             rule_result.record(inout out, benefit, index.entries + index.column + FOCUS());
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -69,7 +69,7 @@ fn inspect_columns(inout out: rule_result.Decision, borrow database: model.Datab
     let mut i: u64 = 0;
     while i < table.column_count {
         let column = database.columns.get_or(table.first_column + i, model.empty_column());
-        out.inspected = out.inspected + 1;
+        out.inspected += 1;
         let selected = (column.ordinal + FOCUS()) % 5 == 0 ||
             column.name == query.filter_column_name ||
             column.name == query.group_column_name ||
@@ -79,7 +79,7 @@ fn inspect_columns(inout out: rule_result.Decision, borrow database: model.Datab
             rule_result.record(inout out, benefit,
                 database.strings.hash(column.name) + column.kind + column.ordinal);
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -90,12 +90,12 @@ pub fn evaluate(borrow database: model.Database, borrow query: model.Query,
     let mut i: u64 = 0;
     while i < input.nodes.len() {
         let node = input.nodes.get_or(i, plan.empty_node());
-        out.inspected = out.inspected + 1;
+        out.inspected += 1;
         if eligible(borrow node, borrow query) {
             rule_result.record(inout out, node_benefit(borrow node),
                 fingerprint + node.kind * 17 + node.estimated_rows + i);
         }
-        i = i + 1;
+        i += 1;
     }
     inspect_indexes(inout out, borrow database, borrow query);
     inspect_columns(inout out, borrow database, borrow query);

--- a/examples/meridian/rule_physical_choose_merge_join.rue
+++ b/examples/meridian/rule_physical_choose_merge_join.rue
@@ -53,13 +53,13 @@ fn inspect_indexes(inout out: rule_result.Decision, borrow database: model.Datab
     let mut i: u64 = 0;
     while i < database.indexes.len() {
         let index = database.indexes.get_or(i, model.empty_index());
-        out.inspected = out.inspected + 1;
+        out.inspected += 1;
         if index.table == query.table &&
             (index.column == query.filter_column || index.column == query.order_column) {
             let benefit = if index.unique { (FOCUS() % 7) + 1 } else { (FOCUS() % 3) + 1 };
             rule_result.record(inout out, benefit, index.entries + index.column + FOCUS());
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -69,7 +69,7 @@ fn inspect_columns(inout out: rule_result.Decision, borrow database: model.Datab
     let mut i: u64 = 0;
     while i < table.column_count {
         let column = database.columns.get_or(table.first_column + i, model.empty_column());
-        out.inspected = out.inspected + 1;
+        out.inspected += 1;
         let selected = (column.ordinal + FOCUS()) % 5 == 0 ||
             column.name == query.filter_column_name ||
             column.name == query.group_column_name ||
@@ -79,7 +79,7 @@ fn inspect_columns(inout out: rule_result.Decision, borrow database: model.Datab
             rule_result.record(inout out, benefit,
                 database.strings.hash(column.name) + column.kind + column.ordinal);
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -90,12 +90,12 @@ pub fn evaluate(borrow database: model.Database, borrow query: model.Query,
     let mut i: u64 = 0;
     while i < input.nodes.len() {
         let node = input.nodes.get_or(i, plan.empty_node());
-        out.inspected = out.inspected + 1;
+        out.inspected += 1;
         if eligible(borrow node, borrow query) {
             rule_result.record(inout out, node_benefit(borrow node),
                 fingerprint + node.kind * 17 + node.estimated_rows + i);
         }
-        i = i + 1;
+        i += 1;
     }
     inspect_indexes(inout out, borrow database, borrow query);
     inspect_columns(inout out, borrow database, borrow query);

--- a/examples/meridian/rule_physical_choose_nested_join.rue
+++ b/examples/meridian/rule_physical_choose_nested_join.rue
@@ -53,13 +53,13 @@ fn inspect_indexes(inout out: rule_result.Decision, borrow database: model.Datab
     let mut i: u64 = 0;
     while i < database.indexes.len() {
         let index = database.indexes.get_or(i, model.empty_index());
-        out.inspected = out.inspected + 1;
+        out.inspected += 1;
         if index.table == query.table &&
             (index.column == query.filter_column || index.column == query.order_column) {
             let benefit = if index.unique { (FOCUS() % 7) + 1 } else { (FOCUS() % 3) + 1 };
             rule_result.record(inout out, benefit, index.entries + index.column + FOCUS());
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -69,7 +69,7 @@ fn inspect_columns(inout out: rule_result.Decision, borrow database: model.Datab
     let mut i: u64 = 0;
     while i < table.column_count {
         let column = database.columns.get_or(table.first_column + i, model.empty_column());
-        out.inspected = out.inspected + 1;
+        out.inspected += 1;
         let selected = (column.ordinal + FOCUS()) % 5 == 0 ||
             column.name == query.filter_column_name ||
             column.name == query.group_column_name ||
@@ -79,7 +79,7 @@ fn inspect_columns(inout out: rule_result.Decision, borrow database: model.Datab
             rule_result.record(inout out, benefit,
                 database.strings.hash(column.name) + column.kind + column.ordinal);
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -90,12 +90,12 @@ pub fn evaluate(borrow database: model.Database, borrow query: model.Query,
     let mut i: u64 = 0;
     while i < input.nodes.len() {
         let node = input.nodes.get_or(i, plan.empty_node());
-        out.inspected = out.inspected + 1;
+        out.inspected += 1;
         if eligible(borrow node, borrow query) {
             rule_result.record(inout out, node_benefit(borrow node),
                 fingerprint + node.kind * 17 + node.estimated_rows + i);
         }
-        i = i + 1;
+        i += 1;
     }
     inspect_indexes(inout out, borrow database, borrow query);
     inspect_columns(inout out, borrow database, borrow query);

--- a/examples/meridian/rule_physical_choose_stream_group.rue
+++ b/examples/meridian/rule_physical_choose_stream_group.rue
@@ -53,13 +53,13 @@ fn inspect_indexes(inout out: rule_result.Decision, borrow database: model.Datab
     let mut i: u64 = 0;
     while i < database.indexes.len() {
         let index = database.indexes.get_or(i, model.empty_index());
-        out.inspected = out.inspected + 1;
+        out.inspected += 1;
         if index.table == query.table &&
             (index.column == query.filter_column || index.column == query.order_column) {
             let benefit = if index.unique { (FOCUS() % 7) + 1 } else { (FOCUS() % 3) + 1 };
             rule_result.record(inout out, benefit, index.entries + index.column + FOCUS());
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -69,7 +69,7 @@ fn inspect_columns(inout out: rule_result.Decision, borrow database: model.Datab
     let mut i: u64 = 0;
     while i < table.column_count {
         let column = database.columns.get_or(table.first_column + i, model.empty_column());
-        out.inspected = out.inspected + 1;
+        out.inspected += 1;
         let selected = (column.ordinal + FOCUS()) % 5 == 0 ||
             column.name == query.filter_column_name ||
             column.name == query.group_column_name ||
@@ -79,7 +79,7 @@ fn inspect_columns(inout out: rule_result.Decision, borrow database: model.Datab
             rule_result.record(inout out, benefit,
                 database.strings.hash(column.name) + column.kind + column.ordinal);
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -90,12 +90,12 @@ pub fn evaluate(borrow database: model.Database, borrow query: model.Query,
     let mut i: u64 = 0;
     while i < input.nodes.len() {
         let node = input.nodes.get_or(i, plan.empty_node());
-        out.inspected = out.inspected + 1;
+        out.inspected += 1;
         if eligible(borrow node, borrow query) {
             rule_result.record(inout out, node_benefit(borrow node),
                 fingerprint + node.kind * 17 + node.estimated_rows + i);
         }
-        i = i + 1;
+        i += 1;
     }
     inspect_indexes(inout out, borrow database, borrow query);
     inspect_columns(inout out, borrow database, borrow query);

--- a/examples/meridian/rule_physical_choose_table_scan.rue
+++ b/examples/meridian/rule_physical_choose_table_scan.rue
@@ -53,13 +53,13 @@ fn inspect_indexes(inout out: rule_result.Decision, borrow database: model.Datab
     let mut i: u64 = 0;
     while i < database.indexes.len() {
         let index = database.indexes.get_or(i, model.empty_index());
-        out.inspected = out.inspected + 1;
+        out.inspected += 1;
         if index.table == query.table &&
             (index.column == query.filter_column || index.column == query.order_column) {
             let benefit = if index.unique { (FOCUS() % 7) + 1 } else { (FOCUS() % 3) + 1 };
             rule_result.record(inout out, benefit, index.entries + index.column + FOCUS());
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -69,7 +69,7 @@ fn inspect_columns(inout out: rule_result.Decision, borrow database: model.Datab
     let mut i: u64 = 0;
     while i < table.column_count {
         let column = database.columns.get_or(table.first_column + i, model.empty_column());
-        out.inspected = out.inspected + 1;
+        out.inspected += 1;
         let selected = (column.ordinal + FOCUS()) % 5 == 0 ||
             column.name == query.filter_column_name ||
             column.name == query.group_column_name ||
@@ -79,7 +79,7 @@ fn inspect_columns(inout out: rule_result.Decision, borrow database: model.Datab
             rule_result.record(inout out, benefit,
                 database.strings.hash(column.name) + column.kind + column.ordinal);
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -90,12 +90,12 @@ pub fn evaluate(borrow database: model.Database, borrow query: model.Query,
     let mut i: u64 = 0;
     while i < input.nodes.len() {
         let node = input.nodes.get_or(i, plan.empty_node());
-        out.inspected = out.inspected + 1;
+        out.inspected += 1;
         if eligible(borrow node, borrow query) {
             rule_result.record(inout out, node_benefit(borrow node),
                 fingerprint + node.kind * 17 + node.estimated_rows + i);
         }
-        i = i + 1;
+        i += 1;
     }
     inspect_indexes(inout out, borrow database, borrow query);
     inspect_columns(inout out, borrow database, borrow query);

--- a/examples/meridian/rule_physical_choose_topn.rue
+++ b/examples/meridian/rule_physical_choose_topn.rue
@@ -53,13 +53,13 @@ fn inspect_indexes(inout out: rule_result.Decision, borrow database: model.Datab
     let mut i: u64 = 0;
     while i < database.indexes.len() {
         let index = database.indexes.get_or(i, model.empty_index());
-        out.inspected = out.inspected + 1;
+        out.inspected += 1;
         if index.table == query.table &&
             (index.column == query.filter_column || index.column == query.order_column) {
             let benefit = if index.unique { (FOCUS() % 7) + 1 } else { (FOCUS() % 3) + 1 };
             rule_result.record(inout out, benefit, index.entries + index.column + FOCUS());
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -69,7 +69,7 @@ fn inspect_columns(inout out: rule_result.Decision, borrow database: model.Datab
     let mut i: u64 = 0;
     while i < table.column_count {
         let column = database.columns.get_or(table.first_column + i, model.empty_column());
-        out.inspected = out.inspected + 1;
+        out.inspected += 1;
         let selected = (column.ordinal + FOCUS()) % 5 == 0 ||
             column.name == query.filter_column_name ||
             column.name == query.group_column_name ||
@@ -79,7 +79,7 @@ fn inspect_columns(inout out: rule_result.Decision, borrow database: model.Datab
             rule_result.record(inout out, benefit,
                 database.strings.hash(column.name) + column.kind + column.ordinal);
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -90,12 +90,12 @@ pub fn evaluate(borrow database: model.Database, borrow query: model.Query,
     let mut i: u64 = 0;
     while i < input.nodes.len() {
         let node = input.nodes.get_or(i, plan.empty_node());
-        out.inspected = out.inspected + 1;
+        out.inspected += 1;
         if eligible(borrow node, borrow query) {
             rule_result.record(inout out, node_benefit(borrow node),
                 fingerprint + node.kind * 17 + node.estimated_rows + i);
         }
-        i = i + 1;
+        i += 1;
     }
     inspect_indexes(inout out, borrow database, borrow query);
     inspect_columns(inout out, borrow database, borrow query);

--- a/examples/meridian/rule_physical_fuse_filter_scan.rue
+++ b/examples/meridian/rule_physical_fuse_filter_scan.rue
@@ -53,13 +53,13 @@ fn inspect_indexes(inout out: rule_result.Decision, borrow database: model.Datab
     let mut i: u64 = 0;
     while i < database.indexes.len() {
         let index = database.indexes.get_or(i, model.empty_index());
-        out.inspected = out.inspected + 1;
+        out.inspected += 1;
         if index.table == query.table &&
             (index.column == query.filter_column || index.column == query.order_column) {
             let benefit = if index.unique { (FOCUS() % 7) + 1 } else { (FOCUS() % 3) + 1 };
             rule_result.record(inout out, benefit, index.entries + index.column + FOCUS());
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -69,7 +69,7 @@ fn inspect_columns(inout out: rule_result.Decision, borrow database: model.Datab
     let mut i: u64 = 0;
     while i < table.column_count {
         let column = database.columns.get_or(table.first_column + i, model.empty_column());
-        out.inspected = out.inspected + 1;
+        out.inspected += 1;
         let selected = (column.ordinal + FOCUS()) % 5 == 0 ||
             column.name == query.filter_column_name ||
             column.name == query.group_column_name ||
@@ -79,7 +79,7 @@ fn inspect_columns(inout out: rule_result.Decision, borrow database: model.Datab
             rule_result.record(inout out, benefit,
                 database.strings.hash(column.name) + column.kind + column.ordinal);
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -90,12 +90,12 @@ pub fn evaluate(borrow database: model.Database, borrow query: model.Query,
     let mut i: u64 = 0;
     while i < input.nodes.len() {
         let node = input.nodes.get_or(i, plan.empty_node());
-        out.inspected = out.inspected + 1;
+        out.inspected += 1;
         if eligible(borrow node, borrow query) {
             rule_result.record(inout out, node_benefit(borrow node),
                 fingerprint + node.kind * 17 + node.estimated_rows + i);
         }
-        i = i + 1;
+        i += 1;
     }
     inspect_indexes(inout out, borrow database, borrow query);
     inspect_columns(inout out, borrow database, borrow query);

--- a/examples/meridian/rule_physical_fuse_project_scan.rue
+++ b/examples/meridian/rule_physical_fuse_project_scan.rue
@@ -53,13 +53,13 @@ fn inspect_indexes(inout out: rule_result.Decision, borrow database: model.Datab
     let mut i: u64 = 0;
     while i < database.indexes.len() {
         let index = database.indexes.get_or(i, model.empty_index());
-        out.inspected = out.inspected + 1;
+        out.inspected += 1;
         if index.table == query.table &&
             (index.column == query.filter_column || index.column == query.order_column) {
             let benefit = if index.unique { (FOCUS() % 7) + 1 } else { (FOCUS() % 3) + 1 };
             rule_result.record(inout out, benefit, index.entries + index.column + FOCUS());
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -69,7 +69,7 @@ fn inspect_columns(inout out: rule_result.Decision, borrow database: model.Datab
     let mut i: u64 = 0;
     while i < table.column_count {
         let column = database.columns.get_or(table.first_column + i, model.empty_column());
-        out.inspected = out.inspected + 1;
+        out.inspected += 1;
         let selected = (column.ordinal + FOCUS()) % 5 == 0 ||
             column.name == query.filter_column_name ||
             column.name == query.group_column_name ||
@@ -79,7 +79,7 @@ fn inspect_columns(inout out: rule_result.Decision, borrow database: model.Datab
             rule_result.record(inout out, benefit,
                 database.strings.hash(column.name) + column.kind + column.ordinal);
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -90,12 +90,12 @@ pub fn evaluate(borrow database: model.Database, borrow query: model.Query,
     let mut i: u64 = 0;
     while i < input.nodes.len() {
         let node = input.nodes.get_or(i, plan.empty_node());
-        out.inspected = out.inspected + 1;
+        out.inspected += 1;
         if eligible(borrow node, borrow query) {
             rule_result.record(inout out, node_benefit(borrow node),
                 fingerprint + node.kind * 17 + node.estimated_rows + i);
         }
-        i = i + 1;
+        i += 1;
     }
     inspect_indexes(inout out, borrow database, borrow query);
     inspect_columns(inout out, borrow database, borrow query);

--- a/examples/meridian/rule_physical_parallel_scan.rue
+++ b/examples/meridian/rule_physical_parallel_scan.rue
@@ -53,13 +53,13 @@ fn inspect_indexes(inout out: rule_result.Decision, borrow database: model.Datab
     let mut i: u64 = 0;
     while i < database.indexes.len() {
         let index = database.indexes.get_or(i, model.empty_index());
-        out.inspected = out.inspected + 1;
+        out.inspected += 1;
         if index.table == query.table &&
             (index.column == query.filter_column || index.column == query.order_column) {
             let benefit = if index.unique { (FOCUS() % 7) + 1 } else { (FOCUS() % 3) + 1 };
             rule_result.record(inout out, benefit, index.entries + index.column + FOCUS());
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -69,7 +69,7 @@ fn inspect_columns(inout out: rule_result.Decision, borrow database: model.Datab
     let mut i: u64 = 0;
     while i < table.column_count {
         let column = database.columns.get_or(table.first_column + i, model.empty_column());
-        out.inspected = out.inspected + 1;
+        out.inspected += 1;
         let selected = (column.ordinal + FOCUS()) % 5 == 0 ||
             column.name == query.filter_column_name ||
             column.name == query.group_column_name ||
@@ -79,7 +79,7 @@ fn inspect_columns(inout out: rule_result.Decision, borrow database: model.Datab
             rule_result.record(inout out, benefit,
                 database.strings.hash(column.name) + column.kind + column.ordinal);
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -90,12 +90,12 @@ pub fn evaluate(borrow database: model.Database, borrow query: model.Query,
     let mut i: u64 = 0;
     while i < input.nodes.len() {
         let node = input.nodes.get_or(i, plan.empty_node());
-        out.inspected = out.inspected + 1;
+        out.inspected += 1;
         if eligible(borrow node, borrow query) {
             rule_result.record(inout out, node_benefit(borrow node),
                 fingerprint + node.kind * 17 + node.estimated_rows + i);
         }
-        i = i + 1;
+        i += 1;
     }
     inspect_indexes(inout out, borrow database, borrow query);
     inspect_columns(inout out, borrow database, borrow query);

--- a/examples/meridian/rule_physical_prefetch_index.rue
+++ b/examples/meridian/rule_physical_prefetch_index.rue
@@ -53,13 +53,13 @@ fn inspect_indexes(inout out: rule_result.Decision, borrow database: model.Datab
     let mut i: u64 = 0;
     while i < database.indexes.len() {
         let index = database.indexes.get_or(i, model.empty_index());
-        out.inspected = out.inspected + 1;
+        out.inspected += 1;
         if index.table == query.table &&
             (index.column == query.filter_column || index.column == query.order_column) {
             let benefit = if index.unique { (FOCUS() % 7) + 1 } else { (FOCUS() % 3) + 1 };
             rule_result.record(inout out, benefit, index.entries + index.column + FOCUS());
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -69,7 +69,7 @@ fn inspect_columns(inout out: rule_result.Decision, borrow database: model.Datab
     let mut i: u64 = 0;
     while i < table.column_count {
         let column = database.columns.get_or(table.first_column + i, model.empty_column());
-        out.inspected = out.inspected + 1;
+        out.inspected += 1;
         let selected = (column.ordinal + FOCUS()) % 5 == 0 ||
             column.name == query.filter_column_name ||
             column.name == query.group_column_name ||
@@ -79,7 +79,7 @@ fn inspect_columns(inout out: rule_result.Decision, borrow database: model.Datab
             rule_result.record(inout out, benefit,
                 database.strings.hash(column.name) + column.kind + column.ordinal);
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -90,12 +90,12 @@ pub fn evaluate(borrow database: model.Database, borrow query: model.Query,
     let mut i: u64 = 0;
     while i < input.nodes.len() {
         let node = input.nodes.get_or(i, plan.empty_node());
-        out.inspected = out.inspected + 1;
+        out.inspected += 1;
         if eligible(borrow node, borrow query) {
             rule_result.record(inout out, node_benefit(borrow node),
                 fingerprint + node.kind * 17 + node.estimated_rows + i);
         }
-        i = i + 1;
+        i += 1;
     }
     inspect_indexes(inout out, borrow database, borrow query);
     inspect_columns(inout out, borrow database, borrow query);

--- a/examples/meridian/rule_physical_spill_hash.rue
+++ b/examples/meridian/rule_physical_spill_hash.rue
@@ -53,13 +53,13 @@ fn inspect_indexes(inout out: rule_result.Decision, borrow database: model.Datab
     let mut i: u64 = 0;
     while i < database.indexes.len() {
         let index = database.indexes.get_or(i, model.empty_index());
-        out.inspected = out.inspected + 1;
+        out.inspected += 1;
         if index.table == query.table &&
             (index.column == query.filter_column || index.column == query.order_column) {
             let benefit = if index.unique { (FOCUS() % 7) + 1 } else { (FOCUS() % 3) + 1 };
             rule_result.record(inout out, benefit, index.entries + index.column + FOCUS());
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -69,7 +69,7 @@ fn inspect_columns(inout out: rule_result.Decision, borrow database: model.Datab
     let mut i: u64 = 0;
     while i < table.column_count {
         let column = database.columns.get_or(table.first_column + i, model.empty_column());
-        out.inspected = out.inspected + 1;
+        out.inspected += 1;
         let selected = (column.ordinal + FOCUS()) % 5 == 0 ||
             column.name == query.filter_column_name ||
             column.name == query.group_column_name ||
@@ -79,7 +79,7 @@ fn inspect_columns(inout out: rule_result.Decision, borrow database: model.Datab
             rule_result.record(inout out, benefit,
                 database.strings.hash(column.name) + column.kind + column.ordinal);
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -90,12 +90,12 @@ pub fn evaluate(borrow database: model.Database, borrow query: model.Query,
     let mut i: u64 = 0;
     while i < input.nodes.len() {
         let node = input.nodes.get_or(i, plan.empty_node());
-        out.inspected = out.inspected + 1;
+        out.inspected += 1;
         if eligible(borrow node, borrow query) {
             rule_result.record(inout out, node_benefit(borrow node),
                 fingerprint + node.kind * 17 + node.estimated_rows + i);
         }
-        i = i + 1;
+        i += 1;
     }
     inspect_indexes(inout out, borrow database, borrow query);
     inspect_columns(inout out, borrow database, borrow query);

--- a/examples/meridian/rule_physical_vectorize_scan.rue
+++ b/examples/meridian/rule_physical_vectorize_scan.rue
@@ -53,13 +53,13 @@ fn inspect_indexes(inout out: rule_result.Decision, borrow database: model.Datab
     let mut i: u64 = 0;
     while i < database.indexes.len() {
         let index = database.indexes.get_or(i, model.empty_index());
-        out.inspected = out.inspected + 1;
+        out.inspected += 1;
         if index.table == query.table &&
             (index.column == query.filter_column || index.column == query.order_column) {
             let benefit = if index.unique { (FOCUS() % 7) + 1 } else { (FOCUS() % 3) + 1 };
             rule_result.record(inout out, benefit, index.entries + index.column + FOCUS());
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -69,7 +69,7 @@ fn inspect_columns(inout out: rule_result.Decision, borrow database: model.Datab
     let mut i: u64 = 0;
     while i < table.column_count {
         let column = database.columns.get_or(table.first_column + i, model.empty_column());
-        out.inspected = out.inspected + 1;
+        out.inspected += 1;
         let selected = (column.ordinal + FOCUS()) % 5 == 0 ||
             column.name == query.filter_column_name ||
             column.name == query.group_column_name ||
@@ -79,7 +79,7 @@ fn inspect_columns(inout out: rule_result.Decision, borrow database: model.Datab
             rule_result.record(inout out, benefit,
                 database.strings.hash(column.name) + column.kind + column.ordinal);
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -90,12 +90,12 @@ pub fn evaluate(borrow database: model.Database, borrow query: model.Query,
     let mut i: u64 = 0;
     while i < input.nodes.len() {
         let node = input.nodes.get_or(i, plan.empty_node());
-        out.inspected = out.inspected + 1;
+        out.inspected += 1;
         if eligible(borrow node, borrow query) {
             rule_result.record(inout out, node_benefit(borrow node),
                 fingerprint + node.kind * 17 + node.estimated_rows + i);
         }
-        i = i + 1;
+        i += 1;
     }
     inspect_indexes(inout out, borrow database, borrow query);
     inspect_columns(inout out, borrow database, borrow query);

--- a/examples/meridian/rule_result.rue
+++ b/examples/meridian/rule_result.rue
@@ -20,12 +20,12 @@ pub fn empty(rule: u64, cost: u64) -> Decision {
 }
 
 pub fn record(inout value: Decision, benefit: u64, fingerprint: u64) {
-    value.matches = value.matches + 1;
+    value.matches += 1;
     value.digest = metric.mix(value.digest, fingerprint);
     if benefit > 0 && benefit <= value.cost_after {
-        value.rewrites = value.rewrites + 1;
-        value.benefit = value.benefit + benefit;
-        value.cost_after = value.cost_after - benefit;
+        value.rewrites += 1;
+        value.benefit += benefit;
+        value.cost_after -= benefit;
     }
 }
 

--- a/examples/meridian/rule_suite.rue
+++ b/examples/meridian/rule_suite.rue
@@ -98,20 +98,20 @@ fn empty() -> Result {
 fn include(inout out: Result, borrow input: plan.Plan,
     borrow first: rule_result.Decision, borrow second: rule_result.Decision,
     verified: bool) {
-    out.evaluations = out.evaluations + 1;
-    out.inspected = out.inspected + first.inspected;
-    out.matches = out.matches + first.matches;
-    out.rewrites = out.rewrites + first.rewrites;
-    out.benefit = out.benefit + first.benefit;
+    out.evaluations += 1;
+    out.inspected += first.inspected;
+    out.matches += first.matches;
+    out.rewrites += first.rewrites;
+    out.benefit += first.benefit;
     out.digest = metric.mix(out.digest, first.rule);
     out.digest = metric.mix(out.digest, first.digest);
     if !verified || !first.valid || first.cost_before != input.cost {
-        out.failures = out.failures + 1;
+        out.failures += 1;
     }
     if first.digest != second.digest || first.matches != second.matches ||
         first.rewrites != second.rewrites || first.cost_after != second.cost_after {
         out.deterministic = false;
-        out.failures = out.failures + 1;
+        out.failures += 1;
     }
 }
 
@@ -409,7 +409,7 @@ pub fn run(borrow database: model.Database) -> Result {
         let distributed_balance_fragments_b = rule_distributed_balance_fragments.evaluate(borrow database, borrow query, borrow input);
         include(inout out, borrow input, borrow distributed_balance_fragments_a, borrow distributed_balance_fragments_b,
             rule_distributed_balance_fragments.verify(borrow input, borrow distributed_balance_fragments_a));
-        q = q + 1;
+        q += 1;
     }
     out.rules = 72;
     out.valid = out.rules == 72 &&

--- a/examples/meridian/selftest.rue
+++ b/examples/meridian/selftest.rue
@@ -45,7 +45,7 @@ pub struct Result {
 fn check(inout out: Result, condition: bool, fingerprint: u64) {
     out.checks += 1;
     out.digest = metric.mix(out.digest, fingerprint);
-    if !condition { out.failures = out.failures + 1; }
+    if !condition { out.failures += 1; }
 }
 
 pub fn run() -> Result {

--- a/examples/meridian/selftest.rue
+++ b/examples/meridian/selftest.rue
@@ -43,7 +43,7 @@ pub struct Result {
 }
 
 fn check(inout out: Result, condition: bool, fingerprint: u64) {
-    out.checks = out.checks + 1;
+    out.checks += 1;
     out.digest = metric.mix(out.digest, fingerprint);
     if !condition { out.failures = out.failures + 1; }
 }
@@ -99,13 +99,13 @@ pub fn run() -> Result {
         let query_plan = plan.build(borrow database, borrow query);
         let actual = engine.execute(borrow database, borrow query);
         let expected = row_oracle.execute(borrow database, borrow query);
-        out.plans = out.plans + 1;
-        out.executions = out.executions + 2;
+        out.plans += 1;
+        out.executions += 2;
         check(inout out, plan.verify(borrow query_plan), query_plan.digest);
         check(inout out, actual.valid, actual.checksum);
         check(inout out, row_oracle.agrees(borrow actual, borrow expected),
             metric.mix(actual.checksum, expected.checksum));
-        q = q + 1;
+        q += 1;
     }
 
     let analyses = analysis_suite.run(borrow database);

--- a/examples/meridian/shard.rue
+++ b/examples/meridian/shard.rue
@@ -18,12 +18,12 @@ pub fn audit(borrow database: model.Database, shards: u64) -> metric.Metric {
             database.tables.get_or(row.table, model.empty_table()).first_column);
         let shard = shard_for(key, shards);
         counts.set(shard, counts.get_or(shard, 0) + 1);
-        i = i + 1;
+        i += 1;
     }
     s = 0;
     while s < counts.len() {
         metric.observe(inout out, counts.get_or(s, 0), s + 1);
-        s = s + 1;
+        s += 1;
     }
     metric.warn(inout out, shards == 0);
     metric.finish(inout out);

--- a/examples/meridian/shard.rue
+++ b/examples/meridian/shard.rue
@@ -10,7 +10,7 @@ pub fn audit(borrow database: model.Database, shards: u64) -> metric.Metric {
     let mut out = metric.new(4401);
     let mut counts = model.U64s.new();
     let mut s: u64 = 0;
-    while s < shards { counts.push(0); s = s + 1; }
+    while s < shards { counts.push(0); s += 1; }
     let mut i: u64 = 0;
     while i < database.rows.len() {
         let row = database.rows.get_or(i, model.empty_row());

--- a/examples/meridian/statistics.rue
+++ b/examples/meridian/statistics.rue
@@ -9,21 +9,21 @@ pub fn analyze(borrow database: model.Database) -> metric.Metric {
         let table = database.tables.get_or(i, model.empty_table());
         metric.observe(inout out, table.row_count, table.column_count + 1);
         metric.warn(inout out, table.column_count == 0);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.columns.len() {
         let column = database.columns.get_or(i, model.empty_column());
         metric.observe(inout out, column.ordinal + column.kind, if column.unique { 3 } else { 1 });
         metric.warn(inout out, column.kind != model.INT_KIND() && column.kind != model.TEXT_KIND());
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < database.indexes.len() {
         let index = database.indexes.get_or(i, model.empty_index());
         metric.observe(inout out, index.entries, if index.unique { 5 } else { 2 });
         metric.warn(inout out, index.table == model.NONE() || index.column == model.NONE());
-        i = i + 1;
+        i += 1;
     }
     metric.finish(inout out);
     out

--- a/examples/meridian/stress.rue
+++ b/examples/meridian/stress.rue
@@ -50,13 +50,13 @@ fn once(scale: u64) -> Result {
         let query_plan = plan.build(borrow database, borrow query);
         let actual = engine.execute(borrow database, borrow query);
         let expected = row_oracle.execute(borrow database, borrow query);
-        out.result_rows = out.result_rows + actual.rows;
-        out.plan_nodes = out.plan_nodes + query_plan.nodes.len();
+        out.result_rows += actual.rows;
+        out.plan_nodes += query_plan.nodes.len();
         out.digest = metric.mix(out.digest, query_plan.digest);
         out.digest = metric.mix(out.digest, actual.checksum);
         if !plan.verify(borrow query_plan) ||
             !row_oracle.agrees(borrow actual, borrow expected) {
-            out.oracle_mismatches = out.oracle_mismatches + 1;
+            out.oracle_mismatches += 1;
         }
         if q == 0 {
             let reports = report_suite.run(borrow database, borrow query,
@@ -65,7 +65,7 @@ fn once(scale: u64) -> Result {
             out.digest = metric.mix(out.digest, reports.digest);
             if !reports.valid { out.oracle_mismatches = out.oracle_mismatches + 1; }
         }
-        q = q + 1;
+        q += 1;
     }
     let recovered = recovery.run(borrow database, 2);
     out.digest = metric.mix(out.digest, recovered.checksum);

--- a/examples/meridian/stress.rue
+++ b/examples/meridian/stress.rue
@@ -63,7 +63,7 @@ fn once(scale: u64) -> Result {
                 borrow query_plan, borrow actual);
             out.report_documents = reports.documents;
             out.digest = metric.mix(out.digest, reports.digest);
-            if !reports.valid { out.oracle_mismatches = out.oracle_mismatches + 1; }
+            if !reports.valid { out.oracle_mismatches += 1; }
         }
         q += 1;
     }

--- a/examples/meridian/text.rue
+++ b/examples/meridian/text.rue
@@ -12,7 +12,7 @@ pub fn append_string(inout out: StrBuf, borrow value: StrBuf) {
     let mut i: u64 = 0;
     while i < value.len() {
         out.push(StrBuf.byte_at_borrowed(borrow value, i));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -55,9 +55,9 @@ pub fn fnv1a(borrow value: StrBuf) -> u64 {
     let mut hash: u64 = 14695981039346656037;
     let mut i: u64 = 0;
     while i < value.len() {
-        hash = hash ^ @intCast(StrBuf.byte_at_borrowed(borrow value, i));
+        hash ^= @intCast(StrBuf.byte_at_borrowed(borrow value, i));
         hash = @wrapping_mul(hash, 1099511628211);
-        i = i + 1;
+        i += 1;
     }
     hash
 }
@@ -71,7 +71,7 @@ pub fn json_id(inout out: StrBuf, borrow database: model.Database, id: u64) {
         else if byte == 92 { append_literal(inout out, "\\\\"); }
         else if byte == 10 { append_literal(inout out, "\\n"); }
         else { out.push(byte); }
-        i = i + 1;
+        i += 1;
     }
     out.push(34);
 }

--- a/examples/meridian/text.rue
+++ b/examples/meridian/text.rue
@@ -5,7 +5,7 @@ const StrBuf = std.strbuf.StrBuf;
 
 pub fn append_literal(inout out: StrBuf, value: str) {
     let mut i: u64 = 0;
-    while i < value.len() { out.push(value[i]); i = i + 1; }
+    while i < value.len() { out.push(value[i]); i += 1; }
 }
 
 pub fn append_string(inout out: StrBuf, borrow value: StrBuf) {

--- a/examples/meridian/undo.rue
+++ b/examples/meridian/undo.rue
@@ -16,14 +16,14 @@ pub fn run(borrow database: model.Database) -> Undo {
     let mut at = database.wal.len();
     let mut previous = database.next_lsn;
     while at > 0 {
-        at = at - 1;
+        at -= 1;
         let entry = database.wal.get_or(at, model.empty_wal());
-        out.visited = out.visited + 1;
+        out.visited += 1;
         if entry.lsn >= previous { out.valid = false; }
         previous = entry.lsn;
         if entry.committed { out.skipped = out.skipped + 1; }
         else {
-            out.applied = out.applied + 1;
+            out.applied += 1;
             out.checksum = metric.mix(out.checksum, entry.before);
             out.checksum = metric.mix(out.checksum, entry.row);
         }

--- a/examples/meridian/undo.rue
+++ b/examples/meridian/undo.rue
@@ -21,7 +21,7 @@ pub fn run(borrow database: model.Database) -> Undo {
         out.visited += 1;
         if entry.lsn >= previous { out.valid = false; }
         previous = entry.lsn;
-        if entry.committed { out.skipped = out.skipped + 1; }
+        if entry.committed { out.skipped += 1; }
         else {
             out.applied += 1;
             out.checksum = metric.mix(out.checksum, entry.before);

--- a/examples/meridian/validate.rue
+++ b/examples/meridian/validate.rue
@@ -16,9 +16,9 @@ fn validate_tables(inout database: model.Database) {
                     ordinal: actual,
                 };
                 database.columns.set(c, resolved);
-                actual = actual + 1;
+                actual += 1;
             }
-            c = c + 1;
+            c += 1;
         }
         if actual != table.column_count {
             model.add_error(inout database, 202, table.name, "declared column count does not match COLUMN statements");
@@ -28,9 +28,9 @@ fn validate_tables(inout database: model.Database) {
             if database.strings.ids_equal(table.name, database.tables.get_or(j, model.empty_table()).name) {
                 model.add_error(inout database, 200, table.name, "duplicate table name");
             }
-            j = j + 1;
+            j += 1;
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -48,9 +48,9 @@ fn validate_columns(inout database: model.Database) {
                 database.strings.ids_equal(column.name, other.name) {
                 model.add_error(inout database, 200, column.name, "duplicate column name");
             }
-            j = j + 1;
+            j += 1;
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -66,7 +66,7 @@ fn validate_rows(inout database: model.Database) {
                 model.add_error(inout database, 203, table.name, "INSERT value count does not match table schema");
             }
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -85,7 +85,7 @@ fn validate_indexes(inout database: model.Database) {
         if table == model.NONE() || column == model.NONE() {
             model.add_error(inout database, 201, index.name, "index references unknown table or column");
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -123,7 +123,7 @@ fn resolve_queries(inout database: model.Database) {
             }
         }
         database.queries.set(i, query);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -139,9 +139,9 @@ fn validate_transactions(inout database: model.Database) {
             if item.id == database.transactions.get_or(j, model.empty_transaction()).id {
                 model.add_error(inout database, 300, item.id, "duplicate transaction id");
             }
-            j = j + 1;
+            j += 1;
         }
-        i = i + 1;
+        i += 1;
     }
 }
 

--- a/examples/meridian/wal.rue
+++ b/examples/meridian/wal.rue
@@ -15,7 +15,7 @@ pub fn audit(borrow database: model.Database) -> metric.Metric {
         if entry.committed { metric.observe(inout out, entry.after, 3); }
         else { metric.observe(inout out, entry.before, 2); }
         expected = entry.lsn + 1;
-        i = i + 1;
+        i += 1;
     }
     metric.finish(inout out);
     out

--- a/examples/mosaic/arena_check.rue
+++ b/examples/mosaic/arena_check.rue
@@ -41,7 +41,7 @@ fn check_page_ranges(inout site: model.Site) {
         if !valid_range(page.link_start, page.link_count, site.links.len()) {
             page_error(inout site, i, "page link range is outside the link arena");
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -52,7 +52,7 @@ fn owner_of_block(borrow site: model.Site, block_index: u64) -> u64 {
         if block_index >= page.block_start && block_index < page.block_start + page.block_count {
             return i;
         }
-        i = i + 1;
+        i += 1;
     }
     model.NONE()
 }
@@ -85,7 +85,7 @@ fn check_blocks(inout site: model.Site) {
                 }
             }
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -102,7 +102,7 @@ fn check_inlines(inout site: model.Site) {
         if node.tag == model.INLINE_LINK() && node.target_id == model.NONE() {
             model.add_error(inout site, 204, site.manifest_path_id, node.line, "link inline has no target");
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -123,7 +123,7 @@ fn check_anchors(inout site: model.Site) {
                 page_error(inout site, anchor.page, "anchor has an invalid or empty name");
             }
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -152,7 +152,7 @@ fn check_links(inout site: model.Site) {
                 page_error(inout site, link.source_page, "link resolved anchor is outside the anchor arena");
             }
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -172,7 +172,7 @@ fn check_navigation(inout site: model.Site) {
                 page_error(inout site, page, "draft page appears in navigation");
             }
         }
-        i = i + 1;
+        i += 1;
     }
 }
 

--- a/examples/mosaic/artifactcheck.rue
+++ b/examples/mosaic/artifactcheck.rue
@@ -32,13 +32,13 @@ fn contains(borrow value: StrBuf, needle: StrBuf) -> bool {
                 matched = false;
                 j = needle.len();
             } else {
-                j = j + 1;
+                j += 1;
             }
         }
         if matched {
             return true;
         }
-        i = i + 1;
+        i += 1;
     }
     false
 }
@@ -57,14 +57,14 @@ fn count(borrow value: StrBuf, needle: StrBuf) -> u64 {
                 matched = false;
                 j = needle.len();
             } else {
-                j = j + 1;
+                j += 1;
             }
         }
         if matched {
-            total = total + 1;
-            i = i + needle.len();
+            total += 1;
+            i += needle.len();
         } else {
-            i = i + 1;
+            i += 1;
         }
     }
     total
@@ -88,14 +88,14 @@ fn balanced_bytes(borrow value: StrBuf, open: u8, close: u8) -> bool {
         } else if b == 34 {
             in_string = true;
         } else if b == open {
-            depth = depth + 1;
+            depth += 1;
         } else if b == close {
-            depth = depth - 1;
+            depth -= 1;
             if depth < 0 {
                 return false;
             }
         }
-        i = i + 1;
+        i += 1;
     }
     depth == 0 && !in_string && !escaped
 }

--- a/examples/mosaic/buildplan.rue
+++ b/examples/mosaic/buildplan.rue
@@ -43,7 +43,7 @@ fn add(inout plan: Plan, borrow site: model.Site, entry: Entry) {
             fail(inout plan, "two build outputs have the same path");
             return;
         }
-        i = i + 1;
+        i += 1;
     }
     plan.entries.push(entry);
 }
@@ -61,7 +61,7 @@ pub fn create(inout site: model.Site) -> Plan {
         if !page.draft {
             add(inout plan, borrow site, Entry { kind: KIND_PAGE(), page: i, path_id: page.output_id });
         }
-        i = i + 1;
+        i += 1;
     }
     shared(inout site, inout plan, "search-index.json", KIND_SEARCH());
     shared(inout site, inout plan, "sitemap.xml", KIND_SITEMAP());
@@ -75,9 +75,9 @@ pub fn page_outputs(borrow plan: Plan) -> u64 {
     let mut i: u64 = 0;
     while i < plan.entries.len() {
         if plan.entries.get_or(i, Entry { kind: 0, page: 0, path_id: 0 }).kind == KIND_PAGE() {
-            count = count + 1;
+            count += 1;
         }
-        i = i + 1;
+        i += 1;
     }
     count
 }
@@ -87,11 +87,11 @@ pub fn fingerprint(borrow plan: Plan, borrow site: model.Site) -> u64 {
     let mut i: u64 = 0;
     while i < plan.entries.len() {
         let entry = plan.entries.get_or(i, Entry { kind: 0, page: 0, path_id: 0 });
-        hash = hash ^ entry.kind;
+        hash ^= entry.kind;
         hash = @wrapping_mul(hash, 1099511628211);
-        hash = hash ^ site.strings.hash(entry.path_id);
+        hash ^= site.strings.hash(entry.path_id);
         hash = @wrapping_mul(hash, 1099511628211);
-        i = i + 1;
+        i += 1;
     }
     hash
 }

--- a/examples/mosaic/complexity.rue
+++ b/examples/mosaic/complexity.rue
@@ -54,7 +54,7 @@ pub fn estimate(borrow site: model.Site) -> Complexity {
     let mut i: u64 = 0;
     while i < site.pages.len() {
         words = saturated_add(words, site.pages.get_or(i, model.empty_page()).word_count);
-        i = i + 1;
+        i += 1;
     }
     let search_units = saturated_add(words, strings);
     let mut total_units: u64 = 0;

--- a/examples/mosaic/contentcheck.rue
+++ b/examples/mosaic/contentcheck.rue
@@ -29,14 +29,14 @@ fn check_headings(inout site: model.Site, page_index: u64) {
         let block = site.blocks.get_or(i, model.Block { tag: 0, text_id: 0, level: 0, first: 0, count: 0, line: 0, aux: 0 });
         if block.tag == model.BLOCK_HEADING() {
             if block.level == 1 {
-                h1_count = h1_count + 1;
+                h1_count += 1;
             }
             if previous > 0 && block.level > previous + 1 {
                 page_error(inout site, page_index, block.line, "heading level skips an intermediate level");
             }
             previous = block.level;
         }
-        i = i + 1;
+        i += 1;
     }
     if h1_count == 0 {
         page_error(inout site, page_index, 0, "published page needs a level-one heading");
@@ -60,10 +60,10 @@ fn check_tables(inout site: model.Site, page_index: u64) {
                 if cell_count(borrow site, borrow row) != columns {
                     page_error(inout site, page_index, row.line, "table row has a different column count from its header");
                 }
-                row_index = row_index + 1;
+                row_index += 1;
             }
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -94,7 +94,7 @@ fn check_links(inout site: model.Site, page_index: u64) {
         if !link.external && url.has_query(borrow target) {
             page_error(inout site, page_index, link.line, "local links cannot contain query strings");
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -112,11 +112,11 @@ fn check_code_languages(inout site: model.Site, page_index: u64) {
                     page_error(inout site, page_index, block.line, "fenced code language contains unsafe punctuation");
                     j = language.len();
                 } else {
-                    j = j + 1;
+                    j += 1;
                 }
             }
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -138,6 +138,6 @@ pub fn validate(inout site: model.Site) {
     let mut i: u64 = 0;
     while i < site.pages.len() {
         validate_page(inout site, i);
-        i = i + 1;
+        i += 1;
     }
 }

--- a/examples/mosaic/coverage.rue
+++ b/examples/mosaic/coverage.rue
@@ -59,25 +59,25 @@ pub fn collect(borrow site: model.Site) -> Coverage {
         });
         block_kinds.set(block.tag);
         if block.tag == model.BLOCK_PARAGRAPH() {
-            value.paragraphs = value.paragraphs + 1;
+            value.paragraphs += 1;
         } else if block.tag == model.BLOCK_HEADING() {
-            value.headings = value.headings + 1;
+            value.headings += 1;
         } else if block.tag == model.BLOCK_CODE() {
-            value.code_blocks = value.code_blocks + 1;
+            value.code_blocks += 1;
         } else if block.tag == model.BLOCK_LIST() {
-            value.lists = value.lists + 1;
+            value.lists += 1;
         } else if block.tag == model.BLOCK_ITEM() {
-            value.list_items = value.list_items + 1;
+            value.list_items += 1;
         } else if block.tag == model.BLOCK_QUOTE() {
-            value.quotes = value.quotes + 1;
+            value.quotes += 1;
         } else if block.tag == model.BLOCK_RULE() {
-            value.rules = value.rules + 1;
+            value.rules += 1;
         } else if block.tag == model.BLOCK_TABLE() {
-            value.tables = value.tables + 1;
+            value.tables += 1;
         } else if block.tag == model.BLOCK_TABLE_ROW() {
-            value.table_rows = value.table_rows + 1;
+            value.table_rows += 1;
         }
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < site.inlines.len() {
@@ -89,19 +89,19 @@ pub fn collect(borrow site: model.Site) -> Coverage {
         });
         inline_kinds.set(node.tag);
         if node.tag == model.INLINE_TEXT() {
-            value.text_inlines = value.text_inlines + 1;
+            value.text_inlines += 1;
         } else if node.tag == model.INLINE_EMPHASIS() {
-            value.emphasis = value.emphasis + 1;
+            value.emphasis += 1;
         } else if node.tag == model.INLINE_STRONG() {
-            value.strong = value.strong + 1;
+            value.strong += 1;
         } else if node.tag == model.INLINE_CODE() {
-            value.code_inlines = value.code_inlines + 1;
+            value.code_inlines += 1;
         } else if node.tag == model.INLINE_LINK() {
-            value.link_inlines = value.link_inlines + 1;
+            value.link_inlines += 1;
         } else if node.tag == model.INLINE_ESCAPE() {
-            value.escapes = value.escapes + 1;
+            value.escapes += 1;
         }
-        i = i + 1;
+        i += 1;
     }
     value.exercised_block_kinds = block_kinds.count();
     value.exercised_inline_kinds = inline_kinds.count();

--- a/examples/mosaic/determinism.rue
+++ b/examples/mosaic/determinism.rue
@@ -24,7 +24,7 @@ pub fn model_fingerprint(borrow site: model.Site) -> u64 {
         hash = mix(hash, page.block_start);
         hash = mix(hash, page.block_count);
         hash = mix(hash, page.word_count);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < site.blocks.len() {
@@ -44,7 +44,7 @@ pub fn model_fingerprint(borrow site: model.Site) -> u64 {
         if block.text_id != model.NONE() {
             hash = mix(hash, site.strings.hash(block.text_id));
         }
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < site.links.len() {
@@ -61,7 +61,7 @@ pub fn model_fingerprint(borrow site: model.Site) -> u64 {
         hash = mix(hash, site.strings.hash(link.target_id));
         hash = mix(hash, link.resolved_page);
         hash = mix(hash, link.resolved_anchor);
-        i = i + 1;
+        i += 1;
     }
     hash
 }

--- a/examples/mosaic/diagnostics.rue
+++ b/examples/mosaic/diagnostics.rue
@@ -16,7 +16,7 @@ pub fn format(borrow site: model.Site) -> StrBuf {
     while i < site.diagnostics.len() {
         let d = site.diagnostics.get_or(i, model.Diagnostic { code: 0, path_id: 0, line: 0, detail_id: 0 });
         keys.push(key(d, i));
-        i = i + 1;
+        i += 1;
     }
     std.sort.insertion_sort(u64, inout keys);
     let mut out = StrBuf.new();
@@ -28,7 +28,7 @@ pub fn format(borrow site: model.Site) -> StrBuf {
         site.strings.append(d.path_id, inout out);
         if d.line > 0 { out.push(58); out.push_str(@to_string(d.line)); }
         out.push_str(": "); site.strings.append(d.detail_id, inout out); out.push(10);
-        i = i + 1;
+        i += 1;
     }
     out
 }

--- a/examples/mosaic/dump.rue
+++ b/examples/mosaic/dump.rue
@@ -88,7 +88,7 @@ pub fn site(borrow value: model.Site) -> StrBuf {
     out.push_str("site title="); quoted_pool(borrow value, value.title_id, inout out);
     out.push_str(" pages="); out.push_str(@to_string(value.pages.len())); out.push(10);
     let mut i: u64 = 0;
-    while i < value.pages.len() { dump_page(borrow value, i, inout out); i = i + 1; }
+    while i < value.pages.len() { dump_page(borrow value, i, inout out); i += 1; }
     dump_inlines(borrow value, inout out);
     dump_links(borrow value, inout out);
     out

--- a/examples/mosaic/dump.rue
+++ b/examples/mosaic/dump.rue
@@ -49,7 +49,7 @@ fn dump_page(borrow site: model.Site, index: u64, inout out: StrBuf) {
         if block.level > 0 { out.push_str(" level="); out.push_str(@to_string(block.level)); }
         if block.text_id != model.NONE() { out.push_str(" text="); quoted_pool(borrow site, block.text_id, inout out); }
         out.push(10);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -61,7 +61,7 @@ fn dump_inlines(borrow site: model.Site, inout out: StrBuf) {
         out.push_str(" text="); quoted_pool(borrow site, node.text_id, inout out);
         if node.tag == model.INLINE_LINK() { out.push_str(" target="); quoted_pool(borrow site, node.target_id, inout out); }
         out.push(10);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -79,7 +79,7 @@ fn dump_links(borrow site: model.Site, inout out: StrBuf) {
         else if link.resolved_page == model.NONE() { out.push_str("none"); }
         else { out.push_str(@to_string(link.resolved_page)); }
         out.push(10);
-        i = i + 1;
+        i += 1;
     }
 }
 

--- a/examples/mosaic/escape.rue
+++ b/examples/mosaic/escape.rue
@@ -12,7 +12,7 @@ pub fn html_text(borrow value: StrBuf, inout out: StrBuf) {
         else if b == 60 { out.push_str("&lt;"); }
         else if b == 62 { out.push_str("&gt;"); }
         else { out.push(b); }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -26,7 +26,7 @@ pub fn html_attribute(borrow value: StrBuf, inout out: StrBuf) {
         else if b == 60 { out.push_str("&lt;"); }
         else if b == 62 { out.push_str("&gt;"); }
         else { out.push(b); }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -41,7 +41,7 @@ pub fn url_attribute(borrow value: StrBuf, inout out: StrBuf) {
         else if b == 62 { out.push_str("%3E"); }
         else if b == 38 { out.push_str("&amp;"); }
         else { out.push(b); }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -62,6 +62,6 @@ pub fn plain_text(borrow value: StrBuf, inout out: StrBuf) {
             out.push(b);
             last_space = false;
         }
-        i = i + 1;
+        i += 1;
     }
 }

--- a/examples/mosaic/frontmatter.rue
+++ b/examples/mosaic/frontmatter.rue
@@ -26,7 +26,7 @@ fn parse_u64(borrow value: StrBuf) -> u64 {
         let b = text.byte_of(borrow value, i);
         if !text.is_digit(b) { return model.NONE(); }
         n = n * 10 + @intCast(b - 48);
-        i = i + 1;
+        i += 1;
     }
     n
 }
@@ -99,7 +99,7 @@ pub fn parse(inout site: model.Site, page_index: u64, borrow source: StrBuf) -> 
             }
         }
         offset = text.next_line(borrow source, offset);
-        line = line + 1;
+        line += 1;
     }
     let page = site.pages.get_or(page_index, model.empty_page());
     model.add_error(inout site, 201, page.source_id, 1, "unterminated front matter");

--- a/examples/mosaic/graph.rue
+++ b/examples/mosaic/graph.rue
@@ -123,7 +123,7 @@ pub fn validate(inout site: model.Site) {
         i += 1;
     }
     i = 0;
-    while i < site.links.len() { resolve_one(inout site, borrow paths, i); i = i + 1; }
+    while i < site.links.len() { resolve_one(inout site, borrow paths, i); i += 1; }
     build_navigation(inout site);
     mark_reachable(inout site);
 }
@@ -136,7 +136,7 @@ pub fn resolved_internal_count(borrow site: model.Site) -> u64 {
             source_page: 0, target_id: 0, label_id: 0, line: 0,
             resolved_page: model.NONE(), resolved_anchor: model.NONE(), external: false,
         });
-        if !link.external && link.resolved_page != model.NONE() { count = count + 1; }
+        if !link.external && link.resolved_page != model.NONE() { count += 1; }
         i += 1;
     }
     count

--- a/examples/mosaic/graph.rue
+++ b/examples/mosaic/graph.rue
@@ -16,7 +16,7 @@ fn anchor_for(borrow site: model.Site, page: u64, borrow name: StrBuf) -> u64 {
     while i < site.anchors.len() {
         let anchor = site.anchors.get_or(i, model.Anchor { page: 0, name_id: 0, line: 0, heading_block: 0 });
         if anchor.page == page && site.strings.equals(anchor.name_id, borrow name) { return i; }
-        i = i + 1;
+        i += 1;
     }
     model.NONE()
 }
@@ -67,13 +67,13 @@ fn build_navigation(inout site: model.Site) {
             let order = if page.nav_order == model.NONE() { 1000000 + i } else { page.nav_order };
             keys.push(order * 100000 + i);
         }
-        i = i + 1;
+        i += 1;
     }
     std.sort.quicksort(u64, inout keys);
     i = 0;
     while i < keys.len() {
         site.navigation.push(keys.get_or(i, 0) % 100000);
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -97,7 +97,7 @@ fn mark_reachable(inout site: model.Site) {
                 visited.set(link.resolved_page);
                 queue.enqueue(link.resolved_page);
             }
-            i = i + 1;
+            i += 1;
         }
     }
     let mut i: u64 = 1;
@@ -106,7 +106,7 @@ fn mark_reachable(inout site: model.Site) {
         if !page.draft && !visited.test(i) {
             model.add_error(inout site, 301, page.source_id, 0, "page is unreachable from the first manifest page");
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -120,7 +120,7 @@ pub fn validate(inout site: model.Site) {
         let output = site.strings.copy(page.output_id);
         paths.insert(borrow source, i);
         paths.insert(borrow output, i);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < site.links.len() { resolve_one(inout site, borrow paths, i); i = i + 1; }
@@ -137,7 +137,7 @@ pub fn resolved_internal_count(borrow site: model.Site) -> u64 {
             resolved_page: model.NONE(), resolved_anchor: model.NONE(), external: false,
         });
         if !link.external && link.resolved_page != model.NONE() { count = count + 1; }
-        i = i + 1;
+        i += 1;
     }
     count
 }

--- a/examples/mosaic/health.rue
+++ b/examples/mosaic/health.rue
@@ -25,15 +25,15 @@ pub fn inspect(borrow site: model.Site) -> Health {
     while i < site.pages.len() {
         let page = site.pages.get_or(i, model.empty_page());
         if !page.draft {
-            published = published + 1;
+            published += 1;
             if page.title_id != model.NONE() && site.strings.string_len(page.title_id) > 0 {
-                titled = titled + 1;
+                titled += 1;
             }
             if page.description_id != model.NONE() && site.strings.string_len(page.description_id) > 0 {
-                described = described + 1;
+                described += 1;
             }
         }
-        i = i + 1;
+        i += 1;
     }
     let valid = site.diagnostics.len() == 0;
     let feature_complete = coverage.complete(borrow features);
@@ -41,22 +41,22 @@ pub fn inspect(borrow site: model.Site) -> Health {
     let every_link_resolved = links.unresolved == 0;
     let mut score: u64 = 0;
     if valid {
-        score = score + 40;
+        score += 40;
     }
     if feature_complete {
-        score = score + 20;
+        score += 20;
     }
     if every_page_navigable {
-        score = score + 10;
+        score += 10;
     }
     if every_link_resolved {
-        score = score + 10;
+        score += 10;
     }
     if titled == published {
-        score = score + 10;
+        score += 10;
     }
     if described == published {
-        score = score + 10;
+        score += 10;
     }
     Health {
         valid: valid,

--- a/examples/mosaic/htmlcheck.rue
+++ b/examples/mosaic/htmlcheck.rue
@@ -29,13 +29,13 @@ fn contains(borrow value: StrBuf, needle: StrBuf) -> bool {
                 matched = false;
                 j = needle.len();
             } else {
-                j = j + 1;
+                j += 1;
             }
         }
         if matched {
             return true;
         }
-        i = i + 1;
+        i += 1;
     }
     false
 }
@@ -51,14 +51,14 @@ fn count_prefix(borrow value: StrBuf, prefix: StrBuf) -> u64 {
                 matched = false;
                 j = prefix.len();
             } else {
-                j = j + 1;
+                j += 1;
             }
         }
         if matched {
-            count = count + 1;
-            i = i + prefix.len();
+            count += 1;
+            i += prefix.len();
         } else {
-            i = i + 1;
+            i += 1;
         }
     }
     count
@@ -79,7 +79,7 @@ fn no_raw_controls(borrow html: StrBuf) -> bool {
         if b < 32 && b != 9 && b != 10 && b != 13 {
             return false;
         }
-        i = i + 1;
+        i += 1;
     }
     true
 }

--- a/examples/mosaic/inline.rue
+++ b/examples/mosaic/inline.rue
@@ -78,9 +78,9 @@ fn parse_link(
 fn find_closing(borrow value: StrBuf, byte: u8, start: u64) -> u64 {
     let mut i = start;
     while i < value.len() {
-        if text.byte_of(borrow value, i) == 92 { i = i + 2; }
+        if text.byte_of(borrow value, i) == 92 { i += 2; }
         else if text.byte_of(borrow value, i) == byte { return i; }
-        else { i = i + 1; }
+        else { i += 1; }
     }
     value.len()
 }
@@ -88,9 +88,9 @@ fn find_closing(borrow value: StrBuf, byte: u8, start: u64) -> u64 {
 fn find_double_closing(borrow value: StrBuf, byte: u8, start: u64) -> u64 {
     let mut i = start;
     while i + 1 < value.len() {
-        if text.byte_of(borrow value, i) == 92 { i = i + 2; }
+        if text.byte_of(borrow value, i) == 92 { i += 2; }
         else if text.byte_of(borrow value, i) == byte && text.byte_of(borrow value, i + 1) == byte { return i; }
-        else { i = i + 1; }
+        else { i += 1; }
     }
     value.len()
 }
@@ -115,7 +115,7 @@ pub fn parse(inout site: model.Site, page_index: u64, borrow value: StrBuf, line
                 flush_text(inout site, borrow value, plain_start, i, line);
                 i = after;
                 plain_start = i;
-            } else { i = i + 1; }
+            } else { i += 1; }
         } else if b == 96 {
             let close = find_closing(borrow value, 96, i + 1);
             if close < value.len() {
@@ -123,7 +123,7 @@ pub fn parse(inout site: model.Site, page_index: u64, borrow value: StrBuf, line
                 push_tagged(inout site, model.INLINE_CODE(), borrow value, i + 1, close, line);
                 i = close + 1;
                 plain_start = i;
-            } else { i = i + 1; }
+            } else { i += 1; }
         } else if (b == 42 || b == 95) && i + 1 < value.len() && text.byte_of(borrow value, i + 1) == b {
             let close = find_double_closing(borrow value, b, i + 2);
             if close < value.len() {
@@ -131,7 +131,7 @@ pub fn parse(inout site: model.Site, page_index: u64, borrow value: StrBuf, line
                 push_tagged(inout site, model.INLINE_STRONG(), borrow value, i + 2, close, line);
                 i = close + 2;
                 plain_start = i;
-            } else { i = i + 1; }
+            } else { i += 1; }
         } else if b == 42 || b == 95 {
             let close = find_closing(borrow value, b, i + 1);
             if close < value.len() {
@@ -139,14 +139,14 @@ pub fn parse(inout site: model.Site, page_index: u64, borrow value: StrBuf, line
                 push_tagged(inout site, model.INLINE_EMPHASIS(), borrow value, i + 1, close, line);
                 i = close + 1;
                 plain_start = i;
-            } else { i = i + 1; }
+            } else { i += 1; }
         } else {
             i += 1;
         }
     }
     flush_text(inout site, borrow value, plain_start, value.len(), line);
     let mut n = first;
-    while n < site.inlines.len() { created.push(n); n = n + 1; }
+    while n < site.inlines.len() { created.push(n); n += 1; }
     created
 }
 
@@ -157,7 +157,7 @@ pub fn word_count(borrow value: StrBuf) -> u64 {
     while i < value.len() {
         let b = text.byte_of(borrow value, i);
         if text.is_alnum(b) {
-            if !inside { words = words + 1; inside = true; }
+            if !inside { words += 1; inside = true; }
         } else { inside = false; }
         i += 1;
     }

--- a/examples/mosaic/inline.rue
+++ b/examples/mosaic/inline.rue
@@ -107,7 +107,7 @@ pub fn parse(inout site: model.Site, page_index: u64, borrow value: StrBuf, line
             let escaped = text.slice(borrow value, i + 1, i + 2);
             let id = site.strings.intern(borrow escaped);
             site.inlines.push(model.Inline { tag: model.INLINE_ESCAPE(), text_id: id, target_id: model.NONE(), line: line });
-            i = i + 2;
+            i += 2;
             plain_start = i;
         } else if b == 91 {
             let after = parse_link(inout site, page_index, borrow value, i, line);
@@ -141,7 +141,7 @@ pub fn parse(inout site: model.Site, page_index: u64, borrow value: StrBuf, line
                 plain_start = i;
             } else { i = i + 1; }
         } else {
-            i = i + 1;
+            i += 1;
         }
     }
     flush_text(inout site, borrow value, plain_start, value.len(), line);
@@ -159,7 +159,7 @@ pub fn word_count(borrow value: StrBuf) -> u64 {
         if text.is_alnum(b) {
             if !inside { words = words + 1; inside = true; }
         } else { inside = false; }
-        i = i + 1;
+        i += 1;
     }
     words
 }

--- a/examples/mosaic/inventory.rue
+++ b/examples/mosaic/inventory.rue
@@ -33,7 +33,7 @@ fn page_has_block(borrow site: model.Site, borrow page: model.Page, tag: u64) ->
         if block.tag == tag {
             return true;
         }
-        i = i + 1;
+        i += 1;
     }
     false
 }
@@ -53,7 +53,7 @@ fn page_has_external(borrow site: model.Site, borrow page: model.Page) -> bool {
         if link.external {
             return true;
         }
-        i = i + 1;
+        i += 1;
     }
     false
 }
@@ -78,32 +78,32 @@ pub fn collect(borrow site: model.Site) -> Inventory {
     while i < site.pages.len() {
         let page = site.pages.get_or(i, model.empty_page());
         if page.draft {
-            value.draft_blocks = value.draft_blocks + page.block_count;
-            value.draft_inlines = value.draft_inlines + page.inline_count;
-            value.draft_links = value.draft_links + page.link_count;
-            value.draft_anchors = value.draft_anchors + page.anchor_count;
+            value.draft_blocks += page.block_count;
+            value.draft_inlines += page.inline_count;
+            value.draft_links += page.link_count;
+            value.draft_anchors += page.anchor_count;
         } else {
-            value.published_blocks = value.published_blocks + page.block_count;
-            value.published_inlines = value.published_inlines + page.inline_count;
-            value.published_links = value.published_links + page.link_count;
-            value.published_anchors = value.published_anchors + page.anchor_count;
+            value.published_blocks += page.block_count;
+            value.published_inlines += page.inline_count;
+            value.published_links += page.link_count;
+            value.published_anchors += page.anchor_count;
             if page_has_block(borrow site, borrow page, model.BLOCK_CODE()) {
-                value.pages_with_code = value.pages_with_code + 1;
+                value.pages_with_code += 1;
             }
             if page_has_block(borrow site, borrow page, model.BLOCK_TABLE()) {
-                value.pages_with_tables = value.pages_with_tables + 1;
+                value.pages_with_tables += 1;
             }
             if page_has_block(borrow site, borrow page, model.BLOCK_LIST()) {
-                value.pages_with_lists = value.pages_with_lists + 1;
+                value.pages_with_lists += 1;
             }
             if page_has_block(borrow site, borrow page, model.BLOCK_QUOTE()) {
-                value.pages_with_quotes = value.pages_with_quotes + 1;
+                value.pages_with_quotes += 1;
             }
             if page_has_external(borrow site, borrow page) {
-                value.pages_with_external_links = value.pages_with_external_links + 1;
+                value.pages_with_external_links += 1;
             }
         }
-        i = i + 1;
+        i += 1;
     }
     value
 }

--- a/examples/mosaic/linkanalysis.rue
+++ b/examples/mosaic/linkanalysis.rue
@@ -29,7 +29,7 @@ pub fn collect(borrow site: model.Site) -> Analysis {
     while i < site.pages.len() {
         inbound.push(0);
         outbound.push(0);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < site.links.len() {
@@ -43,22 +43,22 @@ pub fn collect(borrow site: model.Site) -> Analysis {
             external: false,
         });
         if link.external {
-            value.external = value.external + 1;
+            value.external += 1;
         } else if link.resolved_page == model.NONE() {
-            value.unresolved = value.unresolved + 1;
+            value.unresolved += 1;
         } else {
-            value.internal = value.internal + 1;
+            value.internal += 1;
             inbound.set(link.resolved_page, inbound.get_or(link.resolved_page, 0) + 1);
             outbound.set(link.source_page, outbound.get_or(link.source_page, 0) + 1);
             if link.source_page == link.resolved_page {
-                value.self_links = value.self_links + 1;
+                value.self_links += 1;
             }
             let target = site.strings.copy(link.target_id);
             if text.find_byte(borrow target, 35, 0) < target.len() {
-                value.fragments = value.fragments + 1;
+                value.fragments += 1;
             }
         }
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < site.pages.len() {
@@ -70,7 +70,7 @@ pub fn collect(borrow site: model.Site) -> Analysis {
         if outgoing > value.max_outbound {
             value.max_outbound = outgoing;
         }
-        i = i + 1;
+        i += 1;
     }
     value
 }

--- a/examples/mosaic/manifest.rue
+++ b/examples/mosaic/manifest.rue
@@ -34,7 +34,7 @@ fn field(borrow value: StrBuf, index: u64) -> StrBuf {
         let bar = text.find_byte(borrow value, 124, start);
         if bar >= value.len() { return StrBuf.new(); }
         start = bar + 1;
-        current = current + 1;
+        current += 1;
     }
     let end = text.find_byte(borrow value, 124, start);
     let raw = text.slice(borrow value, start, end);
@@ -49,7 +49,7 @@ fn parse_u64(borrow value: StrBuf) -> u64 {
         let b = text.byte_of(borrow value, i);
         if !text.is_digit(b) { return model.NONE(); }
         total = total * 10 + @intCast(b - 48);
-        i = i + 1;
+        i += 1;
     }
     total
 }
@@ -61,7 +61,7 @@ fn derive_output(borrow source: StrBuf) -> StrBuf {
     while i < source.len() {
         let b = text.byte_of(borrow source, i);
         if b == 46 { dot = i; }
-        i = i + 1;
+        i += 1;
     }
     let stem = text.slice(borrow source, 0, dot);
     out.push_str(stem);
@@ -108,7 +108,7 @@ fn add_page(inout site: model.Site, borrow value: StrBuf, line: u64) {
             model.add_error(inout site, 102, site.manifest_path_id, line, "duplicate page source or output path");
             return;
         }
-        i = i + 1;
+        i += 1;
     }
     site.pages.push(page);
 }
@@ -135,7 +135,7 @@ pub fn parse(source: StrBuf, manifest_path: StrBuf) -> model.Site {
             }
         }
         offset = text.next_line(borrow source, offset);
-        line_number = line_number + 1;
+        line_number += 1;
     }
     if site.title_id == 0 {
         model.add_error(inout site, 101, site.manifest_path_id, 0, "site.title is required");

--- a/examples/mosaic/markup.rue
+++ b/examples/mosaic/markup.rue
@@ -10,7 +10,7 @@ const StrBuf = std.strbuf.StrBuf;
 
 fn heading_level(borrow line: StrBuf) -> u64 {
     let mut level: u64 = 0;
-    while level < line.len() && level < 6 && text.byte_of(borrow line, level) == 35 { level = level + 1; }
+    while level < line.len() && level < 6 && text.byte_of(borrow line, level) == 35 { level += 1; }
     if level > 0 && level < line.len() && text.byte_of(borrow line, level) == 32 { level } else { 0 }
 }
 
@@ -22,7 +22,7 @@ fn is_rule(borrow line: StrBuf) -> bool {
     let mut i: u64 = 0;
     while i < line.len() {
         let b = text.byte_of(borrow line, i);
-        if b == first { marks = marks + 1; }
+        if b == first { marks += 1; }
         else if !text.is_space(b) { return false; }
         i += 1;
     }
@@ -39,7 +39,7 @@ fn list_prefix(borrow line: StrBuf) -> u64 {
         if (b == 45 || b == 42 || b == 43) && text.byte_of(borrow line, 1) == 32 { return 2; }
     }
     let mut i: u64 = 0;
-    while i < line.len() && text.is_digit(text.byte_of(borrow line, i)) { i = i + 1; }
+    while i < line.len() && text.is_digit(text.byte_of(borrow line, i)) { i += 1; }
     if i > 0 && i + 1 < line.len() && text.byte_of(borrow line, i) == 46 && text.byte_of(borrow line, i + 1) == 32 { i + 2 } else { 0 }
 }
 
@@ -203,7 +203,7 @@ fn is_table_separator(borrow line: StrBuf) -> bool {
     let mut i: u64 = 0;
     while i < line.len() {
         let b = text.byte_of(borrow line, i);
-        if b == 45 { dashes = dashes + 1; }
+        if b == 45 { dashes += 1; }
         else if b != 124 && b != 58 && !text.is_space(b) { return false; }
         i += 1;
     }
@@ -218,7 +218,7 @@ fn add_table_row(inout site: model.Site, page_index: u64, borrow line_text: StrB
         let bar = text.find_byte(borrow line_text, 124, start);
         let raw = text.slice(borrow line_text, start, bar);
         let cell = text.trim(borrow raw);
-        if cell.len() > 0 { let _ = inline.parse(inout site, page_index, borrow cell, line); cells = cells + 1; }
+        if cell.len() > 0 { let _ = inline.parse(inout site, page_index, borrow cell, line); cells += 1; }
         if bar >= line_text.len() { break; }
         start = bar + 1;
     }
@@ -291,10 +291,10 @@ pub fn parse_page(inout site: model.Site, page_index: u64, source: StrBuf) {
                 line += 1;
             } else if is_fence(borrow current) {
                 let next = parse_fence(inout site, page_index, borrow source, offset, line);
-                while offset < next { offset = text.next_line(borrow source, offset); line = line + 1; }
+                while offset < next { offset = text.next_line(borrow source, offset); line += 1; }
             } else if list_prefix(borrow current) > 0 {
                 let next = parse_list(inout site, page_index, borrow source, offset, line);
-                while offset < next { offset = text.next_line(borrow source, offset); line = line + 1; }
+                while offset < next { offset = text.next_line(borrow source, offset); line += 1; }
             } else if is_rule(borrow current) {
                 site.blocks.push(model.Block { tag: model.BLOCK_RULE(), text_id: model.NONE(), level: 0, first: 0, count: 0, line: line, aux: model.NONE() });
                 offset = text.next_line(borrow source, offset);
@@ -310,10 +310,10 @@ pub fn parse_page(inout site: model.Site, page_index: u64, source: StrBuf) {
                 let next = if next_offset < source.len() { text.line_at(borrow source, next_offset) } else { StrBuf.new() };
                 if text.count_byte(borrow current, 124) > 0 && is_table_separator(borrow next) {
                     let after = parse_table(inout site, page_index, borrow source, offset, line);
-                    while offset < after { offset = text.next_line(borrow source, offset); line = line + 1; }
+                    while offset < after { offset = text.next_line(borrow source, offset); line += 1; }
                 } else {
                     let after = parse_paragraph(inout site, page_index, borrow source, offset, line);
-                    while offset < after { offset = text.next_line(borrow source, offset); line = line + 1; }
+                    while offset < after { offset = text.next_line(borrow source, offset); line += 1; }
                 }
             }
         }

--- a/examples/mosaic/markup.rue
+++ b/examples/mosaic/markup.rue
@@ -24,7 +24,7 @@ fn is_rule(borrow line: StrBuf) -> bool {
         let b = text.byte_of(borrow line, i);
         if b == first { marks = marks + 1; }
         else if !text.is_space(b) { return false; }
-        i = i + 1;
+        i += 1;
     }
     marks >= 3
 }
@@ -47,7 +47,7 @@ fn explicit_anchor(borrow heading: StrBuf) -> StrBuf {
     if heading.len() < 4 || text.byte_of(borrow heading, heading.len() - 1) != 125 { return StrBuf.new(); }
     let mut i = heading.len() - 1;
     while i > 1 {
-        i = i - 1;
+        i -= 1;
         if text.byte_of(borrow heading, i) == 123 && text.byte_of(borrow heading, i + 1) == 35 {
             return text.slice(borrow heading, i + 2, heading.len() - 1);
         }
@@ -80,7 +80,7 @@ fn add_anchor(inout site: model.Site, page_index: u64, block_index: u64, borrow 
             model.add_error(inout site, 202, page.source_id, line, "duplicate heading anchor");
             return;
         }
-        i = i + 1;
+        i += 1;
     }
     site.anchors.push(model.Anchor { page: page_index, name_id: id, line: line, heading_block: block_index });
 }
@@ -187,9 +187,9 @@ fn parse_list(
         let raw_item = text.slice(borrow current, prefix, current.len());
         let item = text.trim(borrow raw_item);
         add_text_block(inout site, page_index, model.BLOCK_ITEM(), 0, borrow item, current_line);
-        count = count + 1;
+        count += 1;
         offset = text.next_line(borrow source, offset);
-        current_line = current_line + 1;
+        current_line += 1;
     }
     let mut list = site.blocks.get_or(list_index, model.Block { tag: 0, text_id: 0, level: 0, first: 0, count: 0, line: 0, aux: 0 });
     list.count = count;
@@ -205,7 +205,7 @@ fn is_table_separator(borrow line: StrBuf) -> bool {
         let b = text.byte_of(borrow line, i);
         if b == 45 { dashes = dashes + 1; }
         else if b != 124 && b != 58 && !text.is_space(b) { return false; }
-        i = i + 1;
+        i += 1;
     }
     dashes >= 3
 }
@@ -253,9 +253,9 @@ fn parse_table(
         let row = text.line_at(borrow source, offset);
         if row.len() == 0 || text.count_byte(borrow row, 124) == 0 { break; }
         add_table_row(inout site, page_index, borrow row, current_line);
-        count = count + 1;
+        count += 1;
         offset = text.next_line(borrow source, offset);
-        current_line = current_line + 1;
+        current_line += 1;
     }
     let mut table = site.blocks.get_or(table_index, model.Block { tag: 0, text_id: 0, level: 0, first: 0, count: 0, line: 0, aux: 0 });
     table.count = count;
@@ -277,7 +277,7 @@ pub fn parse_page(inout site: model.Site, page_index: u64, source: StrBuf) {
         let current = text.line_at(borrow source, offset);
         if current.len() == 0 {
             offset = text.next_line(borrow source, offset);
-            line = line + 1;
+            line += 1;
         } else {
             let level = heading_level(borrow current);
             if level > 0 {
@@ -288,7 +288,7 @@ pub fn parse_page(inout site: model.Site, page_index: u64, source: StrBuf) {
                 add_text_block(inout site, page_index, model.BLOCK_HEADING(), level, borrow clean_heading, line);
                 add_anchor(inout site, page_index, heading_block, borrow heading, line);
                 offset = text.next_line(borrow source, offset);
-                line = line + 1;
+                line += 1;
             } else if is_fence(borrow current) {
                 let next = parse_fence(inout site, page_index, borrow source, offset, line);
                 while offset < next { offset = text.next_line(borrow source, offset); line = line + 1; }
@@ -298,13 +298,13 @@ pub fn parse_page(inout site: model.Site, page_index: u64, source: StrBuf) {
             } else if is_rule(borrow current) {
                 site.blocks.push(model.Block { tag: model.BLOCK_RULE(), text_id: model.NONE(), level: 0, first: 0, count: 0, line: line, aux: model.NONE() });
                 offset = text.next_line(borrow source, offset);
-                line = line + 1;
+                line += 1;
             } else if text.byte_of(borrow current, 0) == 62 {
                 let raw = text.slice(borrow current, 1, current.len());
                 let quote = text.trim(borrow raw);
                 add_text_block(inout site, page_index, model.BLOCK_QUOTE(), 0, borrow quote, line);
                 offset = text.next_line(borrow source, offset);
-                line = line + 1;
+                line += 1;
             } else {
                 let next_offset = text.next_line(borrow source, offset);
                 let next = if next_offset < source.len() { text.line_at(borrow source, next_offset) } else { StrBuf.new() };
@@ -329,9 +329,9 @@ pub fn parse_page(inout site: model.Site, page_index: u64, source: StrBuf) {
         let block = site.blocks.get_or(b, model.Block { tag: 0, text_id: 0, level: 0, first: 0, count: 0, line: 0, aux: 0 });
         if block.text_id != model.NONE() {
             let value = site.strings.copy(block.text_id);
-            words = words + inline.word_count(borrow value);
+            words += inline.word_count(borrow value);
         }
-        b = b + 1;
+        b += 1;
     }
     page.word_count = words;
     if page.title_id == model.NONE() {

--- a/examples/mosaic/metrics.rue
+++ b/examples/mosaic/metrics.rue
@@ -32,18 +32,18 @@ pub fn collect(borrow site: model.Site) -> Metrics {
     };
     let mut id: u64 = 0;
     while id < site.strings.len() {
-        value.pooled_bytes = value.pooled_bytes + site.strings.string_len(id);
-        id = id + 1;
+        value.pooled_bytes += site.strings.string_len(id);
+        id += 1;
     }
     let mut i: u64 = 0;
     while i < site.pages.len() {
         let page = site.pages.get_or(i, model.empty_page());
         if page.draft {
-            value.drafts = value.drafts + 1;
+            value.drafts += 1;
         } else {
-            value.published = value.published + 1;
+            value.published += 1;
         }
-        value.words = value.words + page.word_count;
+        value.words += page.word_count;
         if page.word_count > value.max_words {
             value.max_words = page.word_count;
         }
@@ -73,9 +73,9 @@ pub fn collect(borrow site: model.Site) -> Metrics {
             if block.tag == model.BLOCK_HEADING() && block.level > value.heading_depth {
                 value.heading_depth = block.level;
             }
-            b = b + 1;
+            b += 1;
         }
-        i = i + 1;
+        i += 1;
     }
     value
 }

--- a/examples/mosaic/navigation.rue
+++ b/examples/mosaic/navigation.rue
@@ -49,7 +49,7 @@ pub fn primary(borrow site: model.Site, current: u64) -> StrBuf {
     let mut i: u64 = 0;
     while i < count {
         append_page_link(borrow site, site.navigation.get_or(start + i, 0), current, inout out);
-        i = i + 1;
+        i += 1;
     }
     out.push_str("</ul></nav>");
     out
@@ -59,7 +59,7 @@ fn position(borrow site: model.Site, page_index: u64) -> u64 {
     let mut i: u64 = 0;
     while i < site.navigation.len() {
         if site.navigation.get_or(i, model.NONE()) == page_index { return i; }
-        i = i + 1;
+        i += 1;
     }
     model.NONE()
 }

--- a/examples/mosaic/oracle.rue
+++ b/examples/mosaic/oracle.rue
@@ -38,7 +38,7 @@ fn blank_inventory() -> Inventory {
 fn line_heading(borrow line: StrBuf) -> bool {
     let mut i: u64 = 0;
     while i < line.len() && i < 6 && text.byte_of(borrow line, i) == 35 {
-        i = i + 1;
+        i += 1;
     }
     i > 0 && i < line.len() && text.byte_of(borrow line, i) == 32
 }
@@ -59,7 +59,7 @@ fn line_list_item(borrow line: StrBuf) -> bool {
     }
     let mut i: u64 = 0;
     while i < line.len() && text.is_digit(text.byte_of(borrow line, i)) {
-        i = i + 1;
+        i += 1;
     }
     i > 0 && i + 1 < line.len() && text.byte_of(borrow line, i) == 46 && text.byte_of(borrow line, i + 1) == 32
 }
@@ -77,11 +77,11 @@ fn line_rule(borrow line: StrBuf) -> bool {
     while i < line.len() {
         let b = text.byte_of(borrow line, i);
         if b == marker {
-            count = count + 1;
+            count += 1;
         } else if !text.is_space(b) {
             return false;
         }
-        i = i + 1;
+        i += 1;
     }
     count >= 3
 }
@@ -91,22 +91,22 @@ fn links_on_line(borrow line: StrBuf) -> u64 {
     let mut i: u64 = 0;
     while i < line.len() {
         if text.byte_of(borrow line, i) == 92 {
-            i = i + 2;
+            i += 2;
         } else if text.byte_of(borrow line, i) == 91 {
             let close = text.find_byte(borrow line, 93, i + 1);
             if close + 1 < line.len() && text.byte_of(borrow line, close + 1) == 40 {
                 let target_close = text.find_byte(borrow line, 41, close + 2);
                 if target_close < line.len() {
-                    count = count + 1;
+                    count += 1;
                     i = target_close + 1;
                 } else {
-                    i = i + 1;
+                    i += 1;
                 }
             } else {
-                i = i + 1;
+                i += 1;
             }
         } else {
-            i = i + 1;
+            i += 1;
         }
     }
     count
@@ -119,13 +119,13 @@ fn words_on_line(borrow line: StrBuf) -> u64 {
     while i < line.len() {
         if text.is_alnum(text.byte_of(borrow line, i)) {
             if !inside {
-                count = count + 1;
+                count += 1;
                 inside = true;
             }
         } else {
             inside = false;
         }
-        i = i + 1;
+        i += 1;
     }
     count
 }
@@ -153,34 +153,34 @@ pub fn scan(borrow source: StrBuf) -> Inventory {
     let mut previous_had_pipes = false;
     while offset < source.len() {
         let line = text.line_at(borrow source, offset);
-        result.lines = result.lines + 1;
+        result.lines += 1;
         if line_fence(borrow line) {
             if in_fence {
                 in_fence = false;
             } else {
                 in_fence = true;
-                result.fences = result.fences + 1;
+                result.fences += 1;
             }
         } else if !in_fence {
             if line_heading(borrow line) {
-                result.headings = result.headings + 1;
+                result.headings += 1;
             }
             if line_list_item(borrow line) {
-                result.list_items = result.list_items + 1;
+                result.list_items += 1;
             }
             if line.len() > 0 && text.byte_of(borrow line, 0) == 62 {
-                result.quotes = result.quotes + 1;
+                result.quotes += 1;
             }
             if line_rule(borrow line) {
-                result.rules = result.rules + 1;
+                result.rules += 1;
             }
             let pipes = text.count_byte(borrow line, 124) > 0;
             if previous_had_pipes && pipes && text.count_byte(borrow line, 45) >= 3 {
-                result.tables = result.tables + 1;
+                result.tables += 1;
             }
             previous_had_pipes = pipes;
-            result.links = result.links + links_on_line(borrow line);
-            result.words = result.words + words_on_line(borrow line);
+            result.links += links_on_line(borrow line);
+            result.words += words_on_line(borrow line);
         }
         offset = text.next_line(borrow source, offset);
     }
@@ -194,9 +194,9 @@ fn actual_blocks(borrow site: model.Site, page_index: u64, tag: u64) -> u64 {
     let mut i = page.block_start;
     while i < page.block_start + page.block_count {
         if site.blocks.get_or(i, model.Block { tag: 0, text_id: 0, level: 0, first: 0, count: 0, line: 0, aux: 0 }).tag == tag {
-            count = count + 1;
+            count += 1;
         }
-        i = i + 1;
+        i += 1;
     }
     count
 }

--- a/examples/mosaic/outputaudit.rue
+++ b/examples/mosaic/outputaudit.rue
@@ -32,14 +32,14 @@ fn count(borrow value: StrBuf, needle: StrBuf) -> u64 {
                 yes = false;
                 j = needle.len();
             } else {
-                j = j + 1;
+                j += 1;
             }
         }
         if yes {
-            total = total + 1;
-            i = i + needle.len();
+            total += 1;
+            i += needle.len();
         } else {
-            i = i + 1;
+            i += 1;
         }
     }
     total
@@ -60,9 +60,9 @@ fn expected_block_count(borrow site: model.Site, page_index: u64, tag: u64) -> u
             aux: 0,
         });
         if block.tag == tag {
-            total = total + 1;
+            total += 1;
         }
-        i = i + 1;
+        i += 1;
     }
     total
 }
@@ -82,9 +82,9 @@ fn expected_toc_count(borrow site: model.Site, page_index: u64) -> u64 {
             aux: 0,
         });
         if block.tag == model.BLOCK_HEADING() && block.level >= 2 {
-            total = total + 1;
+            total += 1;
         }
-        i = i + 1;
+        i += 1;
     }
     total
 }
@@ -100,14 +100,14 @@ fn expected_rendered_links(borrow site: model.Site, page_index: u64) -> u64 {
     while pos < site.navigation.len() {
         if site.navigation.get_or(pos, model.NONE()) == page_index {
             if pos > 0 {
-                pager = pager + 1;
+                pager += 1;
             }
             if pos + 1 < site.navigation.len() {
-                pager = pager + 1;
+                pager += 1;
             }
             pos = site.navigation.len();
         } else {
-            pos = pos + 1;
+            pos += 1;
         }
     }
     let toc_links = expected_toc_count(borrow site, page_index);

--- a/examples/mosaic/pipeline.rue
+++ b/examples/mosaic/pipeline.rue
@@ -45,7 +45,7 @@ fn read_pages(inout site: model.Site, borrow base_dir: StrBuf) {
             },
             OptStr.None => { model.add_error(inout site, 400, page.source_id, 0, "cannot read page source"); },
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -96,7 +96,7 @@ pub fn build(borrow loaded: LoadResult) -> bool {
     let mut i: u64 = 0;
     while i < loaded.site.pages.len() {
         if !write_page(borrow loaded.site, i, borrow loaded.base_dir) { return false; }
-        i = i + 1;
+        i += 1;
     }
     let index_name: StrBuf = "search-index.json";
     let index_path = text.join_path(borrow loaded.base_dir, borrow index_name);
@@ -130,12 +130,12 @@ pub fn output_fingerprint(borrow site: model.Site) -> u64 {
             let html = template.page(borrow site, i);
             let mut j: u64 = 0;
             while j < html.len() {
-                hash = hash ^ @intCast(text.byte_of(borrow html, j));
+                hash ^= @intCast(text.byte_of(borrow html, j));
                 hash = @wrapping_mul(hash, 1099511628211);
-                j = j + 1;
+                j += 1;
             }
         }
-        i = i + 1;
+        i += 1;
     }
     hash
 }

--- a/examples/mosaic/pool.rue
+++ b/examples/mosaic/pool.rue
@@ -40,9 +40,9 @@ pub struct Pool {
         let mut i: u64 = 0;
         while i < value.len() {
             let b = match value.byte_at(i) { OptU8.Some(x) => x, OptU8.None => 0 };
-            h = h ^ @intCast(b);
+            h ^= @intCast(b);
             h = @wrapping_mul(h, 1099511628211);
-            i = i + 1;
+            i += 1;
         }
         h
     }
@@ -57,7 +57,7 @@ pub struct Pool {
             let mut slot = self.hash(id) % new_cap;
             while fresh.get_or(slot, 0) != 0 { slot = (slot + 1) % new_cap; }
             fresh.set(slot, id + 1);
-            id = id + 1;
+            id += 1;
         }
         self.slots = fresh;
         self.slot_cap = new_cap;
@@ -82,7 +82,7 @@ pub struct Pool {
                 OptU8.Some(b) => { self.bytes.push(b); },
                 OptU8.None => {},
             }
-            i = i + 1;
+            i += 1;
         }
         id
     }
@@ -131,7 +131,7 @@ pub struct Pool {
         while i < n {
             let b = match value.byte_at(i) { OptU8.Some(x) => x, OptU8.None => 0 };
             if self.byte_at(id, i) != b { return false; }
-            i = i + 1;
+            i += 1;
         }
         true
     }
@@ -142,7 +142,7 @@ pub struct Pool {
         let mut i: u64 = 0;
         while i < n {
             if self.byte_at(a, i) != self.byte_at(b, i) { return false; }
-            i = i + 1;
+            i += 1;
         }
         true
     }
@@ -153,7 +153,7 @@ pub struct Pool {
         while i < prefix.len() {
             let b = match prefix.byte_at(i) { OptU8.Some(x) => x, OptU8.None => 0 };
             if self.byte_at(id, i) != b { return false; }
-            i = i + 1;
+            i += 1;
         }
         true
     }
@@ -162,9 +162,9 @@ pub struct Pool {
         let mut h: u64 = 14695981039346656037;
         let mut i: u64 = 0;
         while i < self.string_len(id) {
-            h = h ^ @intCast(self.byte_at(id, i));
+            h ^= @intCast(self.byte_at(id, i));
             h = @wrapping_mul(h, 1099511628211);
-            i = i + 1;
+            i += 1;
         }
         h
     }

--- a/examples/mosaic/pool.rue
+++ b/examples/mosaic/pool.rue
@@ -51,7 +51,7 @@ pub struct Pool {
     fn grow_slots(inout self, new_cap: u64) {
         let mut fresh = U64s.new();
         let mut i: u64 = 0;
-        while i < new_cap { fresh.push(0); i = i + 1; }
+        while i < new_cap { fresh.push(0); i += 1; }
         let mut id: u64 = 0;
         while id < self.len() {
             let mut slot = self.hash(id) % new_cap;
@@ -115,7 +115,7 @@ pub struct Pool {
     fn append(borrow self, id: u64, inout out: StrBuf) {
         let n = self.string_len(id);
         let mut i: u64 = 0;
-        while i < n { out.push(self.byte_at(id, i)); i = i + 1; }
+        while i < n { out.push(self.byte_at(id, i)); i += 1; }
     }
 
     fn copy(borrow self, id: u64) -> StrBuf {

--- a/examples/mosaic/ratios.rue
+++ b/examples/mosaic/ratios.rue
@@ -33,10 +33,10 @@ pub fn collect(borrow site: model.Site) -> Ratios {
     while i < site.pages.len() {
         let page = site.pages.get_or(i, model.empty_page());
         if !page.draft {
-            published = published + 1;
+            published += 1;
         }
-        words = words + page.word_count;
-        i = i + 1;
+        words += page.word_count;
+        i += 1;
     }
     i = 0;
     while i < site.links.len() {
@@ -50,14 +50,14 @@ pub fn collect(borrow site: model.Site) -> Ratios {
             external: false,
         });
         if !link.external && link.resolved_page != model.NONE() {
-            internal_links = internal_links + 1;
+            internal_links += 1;
         }
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < site.strings.len() {
-        pooled_bytes = pooled_bytes + site.strings.string_len(i);
-        i = i + 1;
+        pooled_bytes += site.strings.string_len(i);
+        i += 1;
     }
     Ratios {
         blocks_per_page_x100: ratio_x100(site.blocks.len(), published),

--- a/examples/mosaic/render.rue
+++ b/examples/mosaic/render.rue
@@ -34,7 +34,7 @@ fn anchor_for_heading(borrow site: model.Site, page_index: u64, block_index: u64
     while i < site.anchors.len() {
         let anchor = site.anchors.get_or(i, model.Anchor { page: 0, name_id: 0, line: 0, heading_block: 0 });
         if anchor.page == page_index && anchor.heading_block == block_index { return anchor.name_id; }
-        i = i + 1;
+        i += 1;
     }
     model.NONE()
 }
@@ -87,7 +87,7 @@ fn render_list(borrow site: model.Site, page_index: u64, block_index: u64, inout
     let item_close: StrBuf = "</li>\n";
     while i < block.first + block.count {
         render_text_block(borrow site, page_index, i, borrow item_open, borrow item_close, inout out);
-        i = i + 1;
+        i += 1;
     }
     if block.level == 1 { out.push_str("</ol>\n"); } else { out.push_str("</ul>\n"); }
     block.count + 1
@@ -142,15 +142,15 @@ pub fn body(borrow site: model.Site, page_index: u64) -> StrBuf {
         } else if block.tag == model.BLOCK_CODE() {
             render_code(borrow site, i, inout out); i = i + 1;
         } else if block.tag == model.BLOCK_LIST() {
-            i = i + render_list(borrow site, page_index, i, inout out);
+            i += render_list(borrow site, page_index, i, inout out);
         } else if block.tag == model.BLOCK_QUOTE() {
             render_text_block(borrow site, page_index, i, borrow quote_open, borrow quote_close, inout out); i = i + 1;
         } else if block.tag == model.BLOCK_RULE() {
             out.push_str("<hr>\n"); i = i + 1;
         } else if block.tag == model.BLOCK_TABLE() {
-            i = i + render_table(borrow site, i, inout out);
+            i += render_table(borrow site, i, inout out);
         } else {
-            i = i + 1;
+            i += 1;
         }
     }
     out

--- a/examples/mosaic/render.rue
+++ b/examples/mosaic/render.rue
@@ -26,7 +26,7 @@ fn render_inline(borrow site: model.Site, inline_index: u64, inout out: StrBuf) 
 
 fn render_inline_range(borrow site: model.Site, first: u64, count: u64, inout out: StrBuf) {
     let mut i = first;
-    while i < first + count { render_inline(borrow site, i, inout out); i = i + 1; }
+    while i < first + count { render_inline(borrow site, i, inout out); i += 1; }
 }
 
 fn anchor_for_heading(borrow site: model.Site, page_index: u64, block_index: u64) -> u64 {
@@ -120,7 +120,7 @@ fn render_table(borrow site: model.Site, block_index: u64, inout out: StrBuf) ->
     if block.count > 0 { render_table_row(borrow site, block.first, true, inout out); }
     out.push_str("</thead>\n<tbody>\n");
     let mut i = block.first + 1;
-    while i < block.first + block.count { render_table_row(borrow site, i, false, inout out); i = i + 1; }
+    while i < block.first + block.count { render_table_row(borrow site, i, false, inout out); i += 1; }
     out.push_str("</tbody>\n</table>\n");
     block.count + 1
 }
@@ -136,17 +136,17 @@ pub fn body(borrow site: model.Site, page_index: u64) -> StrBuf {
     while i < page.block_start + page.block_count {
         let block = site.blocks.get_or(i, model.Block { tag: 0, text_id: 0, level: 0, first: 0, count: 0, line: 0, aux: 0 });
         if block.tag == model.BLOCK_PARAGRAPH() {
-            render_text_block(borrow site, page_index, i, borrow paragraph_open, borrow paragraph_close, inout out); i = i + 1;
+            render_text_block(borrow site, page_index, i, borrow paragraph_open, borrow paragraph_close, inout out); i += 1;
         } else if block.tag == model.BLOCK_HEADING() {
-            render_heading(borrow site, page_index, i, inout out); i = i + 1;
+            render_heading(borrow site, page_index, i, inout out); i += 1;
         } else if block.tag == model.BLOCK_CODE() {
-            render_code(borrow site, i, inout out); i = i + 1;
+            render_code(borrow site, i, inout out); i += 1;
         } else if block.tag == model.BLOCK_LIST() {
             i += render_list(borrow site, page_index, i, inout out);
         } else if block.tag == model.BLOCK_QUOTE() {
-            render_text_block(borrow site, page_index, i, borrow quote_open, borrow quote_close, inout out); i = i + 1;
+            render_text_block(borrow site, page_index, i, borrow quote_open, borrow quote_close, inout out); i += 1;
         } else if block.tag == model.BLOCK_RULE() {
-            out.push_str("<hr>\n"); i = i + 1;
+            out.push_str("<hr>\n"); i += 1;
         } else if block.tag == model.BLOCK_TABLE() {
             i += render_table(borrow site, i, inout out);
         } else {

--- a/examples/mosaic/renderprofile.rue
+++ b/examples/mosaic/renderprofile.rue
@@ -25,8 +25,8 @@ pub fn collect(borrow site: model.Site) -> Profile {
         let page = site.pages.get_or(i, model.empty_page());
         if !page.draft {
             let html = template.page(borrow site, i);
-            value.pages = value.pages + 1;
-            value.bytes = value.bytes + html.len();
+            value.pages += 1;
+            value.bytes += html.len();
             if html.len() < value.smallest {
                 value.smallest = html.len();
             }
@@ -35,12 +35,12 @@ pub fn collect(borrow site: model.Site) -> Profile {
             }
             let mut j: u64 = 0;
             while j < html.len() {
-                value.fingerprint = value.fingerprint ^ @intCast(text.byte_of(borrow html, j));
+                value.fingerprint ^= @intCast(text.byte_of(borrow html, j));
                 value.fingerprint = @wrapping_mul(value.fingerprint, 1099511628211);
-                j = j + 1;
+                j += 1;
             }
         }
-        i = i + 1;
+        i += 1;
     }
     if value.pages == 0 {
         value.smallest = 0;

--- a/examples/mosaic/schema.rue
+++ b/examples/mosaic/schema.rue
@@ -38,7 +38,7 @@ fn safe_relative_path(borrow value: StrBuf) -> bool {
                 return false;
             }
         }
-        i = i + 1;
+        i += 1;
     }
     true
 }
@@ -53,7 +53,7 @@ fn valid_language(borrow value: StrBuf) -> bool {
         if !text.is_alpha(b) && b != 45 {
             return false;
         }
-        i = i + 1;
+        i += 1;
     }
     true
 }
@@ -134,10 +134,10 @@ fn check_navigation_orders(inout site: model.Site) {
                 if b.nav_order == a.nav_order {
                     page_error(inout site, j, "published navigation orders must be unique");
                 }
-                j = j + 1;
+                j += 1;
             }
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -146,7 +146,7 @@ pub fn validate(inout site: model.Site) {
     let mut i: u64 = 0;
     while i < site.pages.len() {
         check_page(inout site, i);
-        i = i + 1;
+        i += 1;
     }
     check_navigation_orders(inout site);
 }

--- a/examples/mosaic/search.rue
+++ b/examples/mosaic/search.rue
@@ -24,7 +24,7 @@ fn append_headings(borrow site: model.Site, page_index: u64, inout out: StrBuf) 
             append_pool_json(borrow site, block.text_id, inout out);
             first = false;
         }
-        i = i + 1;
+        i += 1;
     }
     out.push(93);
 }
@@ -47,9 +47,9 @@ pub fn build(borrow site: model.Site) -> StrBuf {
             out.push_str(",\"words\":"); out.push_str(@to_string(page.word_count));
             out.push_str(",\"headings\":"); append_headings(borrow site, i, inout out);
             out.push(125);
-            emitted = emitted + 1;
+            emitted += 1;
         }
-        i = i + 1;
+        i += 1;
     }
     out.push_str("]}\n");
     out
@@ -60,7 +60,7 @@ pub fn expected_page_count(borrow site: model.Site) -> u64 {
     let mut i: u64 = 0;
     while i < site.pages.len() {
         if !site.pages.get_or(i, model.empty_page()).draft { n = n + 1; }
-        i = i + 1;
+        i += 1;
     }
     n
 }

--- a/examples/mosaic/search.rue
+++ b/examples/mosaic/search.rue
@@ -59,7 +59,7 @@ pub fn expected_page_count(borrow site: model.Site) -> u64 {
     let mut n: u64 = 0;
     let mut i: u64 = 0;
     while i < site.pages.len() {
-        if !site.pages.get_or(i, model.empty_page()).draft { n = n + 1; }
+        if !site.pages.get_or(i, model.empty_page()).draft { n += 1; }
         i += 1;
     }
     n

--- a/examples/mosaic/selftest.rue
+++ b/examples/mosaic/selftest.rue
@@ -15,9 +15,9 @@ pub struct Result {
 }
 
 fn expect(condition: bool, inout result: Result) {
-    result.checks = result.checks + 1;
+    result.checks += 1;
     if !condition {
-        result.failures = result.failures + 1;
+        result.failures += 1;
     }
 }
 

--- a/examples/mosaic/sitemap.rue
+++ b/examples/mosaic/sitemap.rue
@@ -20,7 +20,7 @@ pub fn build(borrow site: model.Site) -> StrBuf {
             escape.html_text(borrow path, inout out);
             out.push_str("</loc></url>\n");
         }
-        i = i + 1;
+        i += 1;
     }
     out.push_str("</urlset>\n");
     out

--- a/examples/mosaic/sourcecheck.rue
+++ b/examples/mosaic/sourcecheck.rue
@@ -25,13 +25,13 @@ fn check_control_bytes(inout site: model.Site, page_index: u64, borrow source: S
     while i < source.len() {
         let b = text.byte_of(borrow source, i);
         if b == 10 {
-            line = line + 1;
+            line += 1;
         } else if b < 32 && b != 9 && b != 13 {
             error(inout site, page_index, line, "document contains an unsupported control byte");
         } else if b == 127 {
             error(inout site, page_index, line, "document contains the delete control byte");
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -46,9 +46,9 @@ fn check_newlines(inout site: model.Site, page_index: u64, borrow source: StrBuf
             }
         }
         if b == 10 {
-            line = line + 1;
+            line += 1;
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -61,7 +61,7 @@ fn check_line_width(inout site: model.Site, page_index: u64, borrow source: StrB
             error(inout site, page_index, line, "source line exceeds the 4096-byte safety limit");
         }
         start = if end < source.len() { end + 1 } else { source.len() };
-        line = line + 1;
+        line += 1;
     }
 }
 
@@ -78,7 +78,7 @@ fn check_trailing_space(inout site: model.Site, page_index: u64, borrow source: 
             }
         }
         start = if end < source.len() { end + 1 } else { source.len() };
-        line = line + 1;
+        line += 1;
     }
 }
 
@@ -98,7 +98,7 @@ fn check_front_matter_position(inout site: model.Site, page_index: u64, borrow s
             return;
         }
         offset = text.next_line(borrow source, offset);
-        line = line + 1;
+        line += 1;
     }
 }
 

--- a/examples/mosaic/stats.rue
+++ b/examples/mosaic/stats.rue
@@ -30,7 +30,7 @@ pub fn summarize(borrow site: model.Site) -> StrBuf {
         else if block.tag == model.BLOCK_CODE() { code_blocks = code_blocks + 1; }
         else if block.tag == model.BLOCK_LIST() { lists = lists + 1; }
         else if block.tag == model.BLOCK_TABLE() { tables = tables + 1; }
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < site.pages.len() { words = words + site.pages.get_or(i, model.empty_page()).word_count; i = i + 1; }

--- a/examples/mosaic/stats.rue
+++ b/examples/mosaic/stats.rue
@@ -25,15 +25,15 @@ pub fn summarize(borrow site: model.Site) -> StrBuf {
     let mut i: u64 = 0;
     while i < site.blocks.len() {
         let block = site.blocks.get_or(i, model.Block { tag: 0, text_id: 0, level: 0, first: 0, count: 0, line: 0, aux: 0 });
-        if block.tag == model.BLOCK_HEADING() { headings = headings + 1; }
-        else if block.tag == model.BLOCK_PARAGRAPH() { paragraphs = paragraphs + 1; }
-        else if block.tag == model.BLOCK_CODE() { code_blocks = code_blocks + 1; }
-        else if block.tag == model.BLOCK_LIST() { lists = lists + 1; }
-        else if block.tag == model.BLOCK_TABLE() { tables = tables + 1; }
+        if block.tag == model.BLOCK_HEADING() { headings += 1; }
+        else if block.tag == model.BLOCK_PARAGRAPH() { paragraphs += 1; }
+        else if block.tag == model.BLOCK_CODE() { code_blocks += 1; }
+        else if block.tag == model.BLOCK_LIST() { lists += 1; }
+        else if block.tag == model.BLOCK_TABLE() { tables += 1; }
         i += 1;
     }
     i = 0;
-    while i < site.pages.len() { words = words + site.pages.get_or(i, model.empty_page()).word_count; i = i + 1; }
+    while i < site.pages.len() { words += site.pages.get_or(i, model.empty_page()).word_count; i += 1; }
     let mut out = StrBuf.new();
     out.push_str("pages="); out.push_str(@to_string(site.pages.len())); out.push(10);
     out.push_str("published="); out.push_str(@to_string(search.expected_page_count(borrow site))); out.push(10);

--- a/examples/mosaic/stress.rue
+++ b/examples/mosaic/stress.rue
@@ -45,13 +45,13 @@ pub fn run(count: u64) -> StrBuf {
         page.output_id = site.strings.intern(borrow output_name);
         page.template_id = site.default_template_id;
         site.pages.push(page);
-        i = i + 1;
+        i += 1;
     }
     i = 0;
     while i < count {
         let source = page_source(i, count);
         markup.parse_page(inout site, i, source);
-        i = i + 1;
+        i += 1;
     }
     graph.validate(inout site);
     let first = pipeline.output_fingerprint(borrow site);

--- a/examples/mosaic/template_eval.rue
+++ b/examples/mosaic/template_eval.rue
@@ -27,7 +27,7 @@ fn append_source(borrow source: StrBuf, start: u64, end: u64, inout out: StrBuf)
     let mut i = start;
     while i < end && i < source.len() {
         out.push(text.byte_of(borrow source, i));
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -90,7 +90,7 @@ pub fn evaluate(source: StrBuf, env: Environment) -> Result {
             let value = variable(borrow source, borrow node, borrow env);
             append_value(borrow value, node.filter, inout out);
         }
-        i = i + 1;
+        i += 1;
     }
     Result { output: out, ok: true, error_offset: 0 }
 }

--- a/examples/mosaic/template_lexer.rue
+++ b/examples/mosaic/template_lexer.rue
@@ -16,7 +16,7 @@ fn identifier_continue(b: u8) -> bool {
 fn skip_space(borrow source: StrBuf, start: u64) -> u64 {
     let mut i = start;
     while i < source.len() && text.is_space(text.byte_of(borrow source, i)) {
-        i = i + 1;
+        i += 1;
     }
     i
 }
@@ -40,9 +40,9 @@ pub fn lex(borrow source: StrBuf) -> ast.Lexed {
                 return ast.Lexed { tokens: tokens, ok: false, error_offset: i };
             }
             let name_start = i;
-            i = i + 1;
+            i += 1;
             while i < source.len() && identifier_continue(text.byte_of(borrow source, i)) {
-                i = i + 1;
+                i += 1;
             }
             push(inout tokens, ast.TOKEN_IDENT(), name_start, i);
             i = skip_space(borrow source, i);
@@ -53,9 +53,9 @@ pub fn lex(borrow source: StrBuf) -> ast.Lexed {
                     return ast.Lexed { tokens: tokens, ok: false, error_offset: i };
                 }
                 let filter_start = i;
-                i = i + 1;
+                i += 1;
                 while i < source.len() && identifier_continue(text.byte_of(borrow source, i)) {
-                    i = i + 1;
+                    i += 1;
                 }
                 push(inout tokens, ast.TOKEN_IDENT(), filter_start, i);
                 i = skip_space(borrow source, i);
@@ -64,10 +64,10 @@ pub fn lex(borrow source: StrBuf) -> ast.Lexed {
                 return ast.Lexed { tokens: tokens, ok: false, error_offset: i };
             }
             push(inout tokens, ast.TOKEN_CLOSE(), i, i + 2);
-            i = i + 2;
+            i += 2;
             text_start = i;
         } else {
-            i = i + 1;
+            i += 1;
         }
     }
     if text_start < source.len() {

--- a/examples/mosaic/template_parser.rue
+++ b/examples/mosaic/template_parser.rue
@@ -44,7 +44,7 @@ pub fn parse(borrow source: StrBuf, lexed: ast.Lexed) -> ast.Parsed {
                 name_end: 0,
                 filter: ast.FILTER_NONE(),
             });
-            i = i + 1;
+            i += 1;
         } else if current.tag == ast.TOKEN_OPEN() {
             let name = token(borrow lexed.tokens, i + 1);
             if name.tag != ast.TOKEN_IDENT() {
@@ -61,7 +61,7 @@ pub fn parse(borrow source: StrBuf, lexed: ast.Lexed) -> ast.Parsed {
                 if filter == 999 {
                     return ast.Parsed { nodes: nodes, ok: false, error_offset: filter_token.start };
                 }
-                close_index = close_index + 2;
+                close_index += 2;
             }
             let close = token(borrow lexed.tokens, close_index);
             if close.tag != ast.TOKEN_CLOSE() {

--- a/examples/mosaic/text.rue
+++ b/examples/mosaic/text.rue
@@ -20,13 +20,13 @@ pub fn lowercase(b: u8) -> u8 {
 
 pub fn trim_start(borrow value: StrBuf) -> u64 {
     let mut i: u64 = 0;
-    while i < value.len() && is_space(byte_of(borrow value, i)) { i = i + 1; }
+    while i < value.len() && is_space(byte_of(borrow value, i)) { i += 1; }
     i
 }
 
 pub fn trim_end(borrow value: StrBuf) -> u64 {
     let mut i = value.len();
-    while i > 0 && is_space(byte_of(borrow value, i - 1)) { i = i - 1; }
+    while i > 0 && is_space(byte_of(borrow value, i - 1)) { i -= 1; }
     i
 }
 
@@ -34,7 +34,7 @@ pub fn slice(borrow value: StrBuf, start: u64, end: u64) -> StrBuf {
     let mut out = StrBuf.new();
     let stop = if end < value.len() { end } else { value.len() };
     let mut i = if start < stop { start } else { stop };
-    while i < stop { out.push(byte_of(borrow value, i)); i = i + 1; }
+    while i < stop { out.push(byte_of(borrow value, i)); i += 1; }
     out
 }
 
@@ -95,7 +95,7 @@ pub fn count_byte(borrow value: StrBuf, needle: u8) -> u64 {
     let mut total: u64 = 0;
     let mut i: u64 = 0;
     while i < value.len() {
-        if byte_of(borrow value, i) == needle { total = total + 1; }
+        if byte_of(borrow value, i) == needle { total += 1; }
         i += 1;
     }
     total

--- a/examples/mosaic/text.rue
+++ b/examples/mosaic/text.rue
@@ -57,7 +57,7 @@ pub fn starts_with(borrow value: StrBuf, borrow prefix: StrBuf) -> bool {
     let mut i: u64 = 0;
     while i < prefix.len() {
         if byte_of(borrow value, i) != byte_of(borrow prefix, i) { return false; }
-        i = i + 1;
+        i += 1;
     }
     true
 }
@@ -68,7 +68,7 @@ pub fn ends_with(borrow value: StrBuf, borrow suffix: StrBuf) -> bool {
     let mut i: u64 = 0;
     while i < suffix.len() {
         if byte_of(borrow value, off + i) != byte_of(borrow suffix, i) { return false; }
-        i = i + 1;
+        i += 1;
     }
     true
 }
@@ -77,7 +77,7 @@ pub fn find_byte(borrow value: StrBuf, needle: u8, start: u64) -> u64 {
     let mut i = start;
     while i < value.len() {
         if byte_of(borrow value, i) == needle { return i; }
-        i = i + 1;
+        i += 1;
     }
     value.len()
 }
@@ -86,7 +86,7 @@ pub fn find_pair(borrow value: StrBuf, a: u8, b: u8, start: u64) -> u64 {
     let mut i = start;
     while i + 1 < value.len() {
         if byte_of(borrow value, i) == a && byte_of(borrow value, i + 1) == b { return i; }
-        i = i + 1;
+        i += 1;
     }
     value.len()
 }
@@ -96,7 +96,7 @@ pub fn count_byte(borrow value: StrBuf, needle: u8) -> u64 {
     let mut i: u64 = 0;
     while i < value.len() {
         if byte_of(borrow value, i) == needle { total = total + 1; }
-        i = i + 1;
+        i += 1;
     }
     total
 }
@@ -129,7 +129,7 @@ pub fn slugify(borrow value: StrBuf) -> StrBuf {
         } else if out.len() > 0 {
             pending_dash = true;
         }
-        i = i + 1;
+        i += 1;
     }
     out
 }
@@ -147,7 +147,7 @@ pub fn normalize_path(borrow value: StrBuf) -> StrBuf {
             out.push(b);
             last_slash = false;
         }
-        i = i + 1;
+        i += 1;
     }
     out
 }
@@ -157,7 +157,7 @@ pub fn dirname(borrow value: StrBuf) -> StrBuf {
     let mut i: u64 = 0;
     while i < value.len() {
         if byte_of(borrow value, i) == 47 { last = i; }
-        i = i + 1;
+        i += 1;
     }
     if last == value.len() { StrBuf.new() } else { slice(borrow value, 0, last + 1) }
 }
@@ -182,6 +182,6 @@ pub fn append_escaped_json(borrow value: StrBuf, inout out: StrBuf) {
         else if b == 13 { out.push_str("\\r"); }
         else if b == 9 { out.push_str("\\t"); }
         else { out.push(b); }
-        i = i + 1;
+        i += 1;
     }
 }

--- a/examples/mosaic/toc.rue
+++ b/examples/mosaic/toc.rue
@@ -10,7 +10,7 @@ fn anchor_for_block(borrow site: model.Site, page_index: u64, block_index: u64) 
     while i < site.anchors.len() {
         let a = site.anchors.get_or(i, model.Anchor { page: 0, name_id: 0, line: 0, heading_block: 0 });
         if a.page == page_index && a.heading_block == block_index { return a.name_id; }
-        i = i + 1;
+        i += 1;
     }
     model.NONE()
 }
@@ -42,7 +42,7 @@ pub fn render(borrow site: model.Site, page_index: u64) -> StrBuf {
             escape.html_text(borrow title, inout out);
             out.push_str("</a>");
         }
-        i = i + 1;
+        i += 1;
     }
     close_to(inout out, inout level, 0);
     if any { out.push_str("</nav>"); }

--- a/examples/mosaic/toc.rue
+++ b/examples/mosaic/toc.rue
@@ -16,7 +16,7 @@ fn anchor_for_block(borrow site: model.Site, page_index: u64, block_index: u64) 
 }
 
 fn close_to(inout out: StrBuf, inout level: u64, target: u64) {
-    while level > target { out.push_str("</li></ul>"); level = level - 1; }
+    while level > target { out.push_str("</li></ul>"); level -= 1; }
 }
 
 pub fn render(borrow site: model.Site, page_index: u64) -> StrBuf {
@@ -30,7 +30,7 @@ pub fn render(borrow site: model.Site, page_index: u64) -> StrBuf {
         if block.tag == model.BLOCK_HEADING() && block.level >= 2 {
             if !any { out.push_str("<nav class=\"toc\" aria-label=\"Table of contents\"><h2>Contents</h2>"); any = true; }
             let wanted = block.level - 1;
-            while level < wanted { out.push_str("<ul><li>"); level = level + 1; }
+            while level < wanted { out.push_str("<ul><li>"); level += 1; }
             if level > wanted { close_to(inout out, inout level, wanted); out.push_str("<li>"); }
             else if level == wanted && level > 0 { out.push_str("</li><li>"); }
             out.push_str("<a href=\"#");

--- a/examples/mosaic/url.rue
+++ b/examples/mosaic/url.rue
@@ -78,7 +78,7 @@ fn segment_count(borrow path: StrBuf) -> u64 {
     let mut count: u64 = 1;
     let mut i: u64 = 0;
     while i < path.len() {
-        if text.byte_of(borrow path, i) == 47 { count = count + 1; }
+        if text.byte_of(borrow path, i) == 47 { count += 1; }
         i += 1;
     }
     count

--- a/examples/mosaic/url.rue
+++ b/examples/mosaic/url.rue
@@ -79,7 +79,7 @@ fn segment_count(borrow path: StrBuf) -> u64 {
     let mut i: u64 = 0;
     while i < path.len() {
         if text.byte_of(borrow path, i) == 47 { count = count + 1; }
-        i = i + 1;
+        i += 1;
     }
     count
 }
@@ -91,7 +91,7 @@ fn segment_at(borrow path: StrBuf, wanted: u64) -> StrBuf {
         let slash = text.find_byte(borrow path, 47, start);
         if slash >= path.len() { return StrBuf.new(); }
         start = slash + 1;
-        current = current + 1;
+        current += 1;
     }
     let end = text.find_byte(borrow path, 47, start);
     text.slice(borrow path, start, end)
@@ -111,7 +111,7 @@ pub fn normalize_local(borrow path: StrBuf) -> StrBuf {
         } else {
             kept.push(i);
         }
-        i = i + 1;
+        i += 1;
     }
     let mut out = StrBuf.new();
     i = 0;
@@ -121,9 +121,9 @@ pub fn normalize_local(borrow path: StrBuf) -> StrBuf {
         let mut j: u64 = 0;
         while j < segment.len() {
             out.push(text.byte_of(borrow segment, j));
-            j = j + 1;
+            j += 1;
         }
-        i = i + 1;
+        i += 1;
     }
     out
 }
@@ -139,7 +139,7 @@ pub fn safe_for_html(borrow value: StrBuf) -> bool {
         if b < 32 || b == 127 {
             return false;
         }
-        i = i + 1;
+        i += 1;
     }
     true
 }

--- a/examples/mosaic/utf8.rue
+++ b/examples/mosaic/utf8.rue
@@ -35,9 +35,9 @@ pub fn validate(borrow source: StrBuf) -> Result {
     while i < source.len() {
         let first = text.byte_of(borrow source, i);
         if first <= 127 {
-            ascii = ascii + 1;
-            codepoints = codepoints + 1;
-            i = i + 1;
+            ascii += 1;
+            codepoints += 1;
+            i += 1;
         } else if first >= 194 && first <= 223 {
             if i + 1 >= source.len() {
                 return fail(i, codepoints, ascii, multibyte);
@@ -46,9 +46,9 @@ pub fn validate(borrow source: StrBuf) -> Result {
             if !continuation(second) {
                 return fail(i, codepoints, ascii, multibyte);
             }
-            multibyte = multibyte + 1;
-            codepoints = codepoints + 1;
-            i = i + 2;
+            multibyte += 1;
+            codepoints += 1;
+            i += 2;
         } else if first >= 224 && first <= 239 {
             if i + 2 >= source.len() {
                 return fail(i, codepoints, ascii, multibyte);
@@ -64,9 +64,9 @@ pub fn validate(borrow source: StrBuf) -> Result {
             if first == 237 && second > 159 {
                 return fail(i, codepoints, ascii, multibyte);
             }
-            multibyte = multibyte + 1;
-            codepoints = codepoints + 1;
-            i = i + 3;
+            multibyte += 1;
+            codepoints += 1;
+            i += 3;
         } else if first >= 240 && first <= 244 {
             if i + 3 >= source.len() {
                 return fail(i, codepoints, ascii, multibyte);
@@ -83,9 +83,9 @@ pub fn validate(borrow source: StrBuf) -> Result {
             if first == 244 && second > 143 {
                 return fail(i, codepoints, ascii, multibyte);
             }
-            multibyte = multibyte + 1;
-            codepoints = codepoints + 1;
-            i = i + 4;
+            multibyte += 1;
+            codepoints += 1;
+            i += 4;
         } else {
             return fail(i, codepoints, ascii, multibyte);
         }

--- a/examples/mosaic/wordindex.rue
+++ b/examples/mosaic/wordindex.rue
@@ -57,7 +57,7 @@ fn normalize_word(borrow value: StrBuf, start: u64, end: u64) -> StrBuf {
         if text.is_alnum(b) {
             out.push(text.lowercase(b));
         }
-        i = i + 1;
+        i += 1;
     }
     out
 }
@@ -71,7 +71,7 @@ fn add_term(
     if word.len() < 2 || stop_word(borrow word) {
         return;
     }
-    index.total_tokens = index.total_tokens + 1;
+    index.total_tokens += 1;
     match lookup.get(borrow word) {
         OptU64.Some(id) => {
             let count = index.counts.get_or(id, 0);
@@ -113,7 +113,7 @@ fn scan_text(
             add_term(inout index, inout lookup, borrow word, page_index);
             inside = false;
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -146,10 +146,10 @@ pub fn build(borrow site: model.Site) -> Index {
                     let value = site.strings.copy(block.text_id);
                     scan_text(inout index, inout lookup, borrow value, page_index);
                 }
-                block_index = block_index + 1;
+                block_index += 1;
             }
         }
-        page_index = page_index + 1;
+        page_index += 1;
     }
     index
 }
@@ -164,14 +164,14 @@ fn ranked_ids(borrow index: Index) -> model.U64s {
     let mut i: u64 = 0;
     while i < index.terms.len() {
         keys.push(ranking_key(index.counts.get_or(i, 0), i));
-        i = i + 1;
+        i += 1;
     }
     std.sort.quicksort(u64, inout keys);
     let mut ids = model.U64s.new();
     i = 0;
     while i < keys.len() {
         ids.push(keys.get_or(i, 0) % 1000000);
-        i = i + 1;
+        i += 1;
     }
     ids
 }
@@ -192,7 +192,7 @@ pub fn append_top_json(borrow index: Index, limit: u64, inout out: StrBuf) {
         out.push_str(",\"count\":");
         out.push_str(@to_string(index.counts.get_or(id, 0)));
         out.push(125);
-        i = i + 1;
+        i += 1;
     }
     out.push(93);
 }

--- a/examples/power.rue
+++ b/examples/power.rue
@@ -15,11 +15,11 @@ fn power(base: i32, exp: i32) -> i32 {
     while e > 0 {
         // If the current bit is set, multiply result by current power
         if e % 2 == 1 {
-            result = result * b;
+            result *= b;
         }
         // Square the base and halve the exponent
-        b = b * b;
-        e = e / 2;
+        b *= b;
+        e /= 2;
     }
 
     result

--- a/examples/primes.rue
+++ b/examples/primes.rue
@@ -20,7 +20,7 @@ fn is_prime(n: i32) -> bool {
         if n % i == 0 {
             return false;
         }
-        i = i + 2;
+        i += 2;
     }
     true
 }
@@ -30,9 +30,9 @@ fn count_primes(limit: i32) -> i32 {
     let mut n = 2;
     while n <= limit {
         if is_prime(n) {
-            count = count + 1;
+            count += 1;
         }
-        n = n + 1;
+        n += 1;
     }
     count
 }
@@ -44,7 +44,7 @@ fn main() -> i32 {
         if is_prime(n) {
             @dbg(n);
         }
-        n = n + 1;
+        n += 1;
     }
 
     // Return the count of primes up to 100 (should be 25)

--- a/examples/quicksort.rue
+++ b/examples/quicksort.rue
@@ -20,9 +20,9 @@ fn partition(inout arr: [i32; 10], low: u64, high: u64) -> u64 {
             let temp = arr[i];
             arr[i] = arr[j];
             arr[j] = temp;
-            i = i + 1;
+            i += 1;
         }
-        j = j + 1;
+        j += 1;
     }
 
     // Move pivot to its correct position
@@ -53,7 +53,7 @@ fn print_array(borrow arr: [i32; 10]) {
     let mut i: u64 = 0;
     while i < 10 {
         @dbg(arr[i]);
-        i = i + 1;
+        i += 1;
     }
 }
 

--- a/examples/rill/astcheck.rue
+++ b/examples/rill/astcheck.rue
@@ -102,7 +102,7 @@ struct Checker {
         let mut i: u64 = 0;
         while i < self.states.len() {
             if self.states.get_or(i, 0) == 0 { self.report(i, "node is unreachable from program root"); }
-            i = i + 1;
+            i += 1;
         }
     }
 }

--- a/examples/rill/astcheck.rue
+++ b/examples/rill/astcheck.rue
@@ -17,7 +17,7 @@ struct Checker {
     fn new(arena: ast.Arena) -> Self {
         let mut states = States.new();
         let mut i: u64 = 0;
-        while i < arena.nodes.len() { states.push(0); i = i + 1; }
+        while i < arena.nodes.len() { states.push(0); i += 1; }
         Self { arena: arena, states: states, errors: StrBuf.new() }
     }
 

--- a/examples/rill/astdump.rue
+++ b/examples/rill/astdump.rue
@@ -54,7 +54,7 @@ fn operator_name(kind: u64) -> StrBuf {
 
 fn indent(inout out: StrBuf, depth: u64) {
     let mut i: u64 = 0;
-    while i < depth { out.push_str("  "); i = i + 1; }
+    while i < depth { out.push_str("  "); i += 1; }
 }
 
 fn append_span(inout out: StrBuf, borrow node: ast.Node) {

--- a/examples/rill/bytecode.rue
+++ b/examples/rill/bytecode.rue
@@ -94,7 +94,7 @@ pub struct Program {
         let mut i: u64 = 0;
         while i < self.fn_names.len() {
             if self.fn_names.get_or(i, 18446744073709551615) == name { return i; }
-            i = i + 1;
+            i += 1;
         }
         18446744073709551615
     }
@@ -111,7 +111,7 @@ pub struct Program {
         let mut i: u64 = 0;
         while i < self.global_names.len() {
             if self.global_names.get_or(i, 18446744073709551615) == name { return i; }
-            i = i + 1;
+            i += 1;
         }
         18446744073709551615
     }

--- a/examples/rill/compiler.rue
+++ b/examples/rill/compiler.rue
@@ -44,7 +44,7 @@ struct Compiler {
     }
     fn advance(inout self) -> token.Token {
         let t = self.peek();
-        if t.kind != token.EOF { self.at = self.at + 1; }
+        if t.kind != token.EOF { self.at += 1; }
         t
     }
     fn check(borrow self, kind: u64) -> bool { self.peek().kind == kind }

--- a/examples/rill/compiler.rue
+++ b/examples/rill/compiler.rue
@@ -69,7 +69,7 @@ struct Compiler {
     fn local_slot(borrow self, symbol: u64) -> u64 {
         let mut i = self.locals.len();
         while i > 0 {
-            i = i - 1;
+            i -= 1;
             if self.locals.get_or(i, 18446744073709551615) == symbol { return i; }
         }
         18446744073709551615
@@ -83,7 +83,7 @@ struct Compiler {
         };
         let mut i = self.locals.len();
         while i > scope_start {
-            i = i - 1;
+            i -= 1;
             if self.locals.get_or(i, 18446744073709551615) == symbol {
                 self.error_here("duplicate local binding in the same scope");
                 return i;
@@ -116,7 +116,7 @@ struct Compiler {
             if !self.check(token.RBRACKET) {
                 loop {
                     self.expression();
-                    count = count + 1;
+                    count += 1;
                     if !self.take(token.COMMA) { break; }
                 }
             }
@@ -147,7 +147,7 @@ struct Compiler {
                 if !self.check(token.RPAREN) {
                     loop {
                         self.expression();
-                        argc = argc + 1;
+                        argc += 1;
                         if !self.take(token.COMMA) { break; }
                     }
                 }
@@ -344,7 +344,7 @@ struct Compiler {
             loop {
                 let param = self.expect(token.IDENT, "expected parameter name");
                 let _ = self.declare_local(param.value);
-                arity = arity + 1;
+                arity += 1;
                 if !self.take(token.COMMA) { break; }
             }
         }

--- a/examples/rill/disasm.rue
+++ b/examples/rill/disasm.rue
@@ -61,7 +61,7 @@ fn append_quoted(inout out: StrBuf, borrow value: StrBuf) {
         else if b == 34 { out.push_str("\\\""); }
         else if b == 92 { out.push_str("\\\\"); }
         else { out.push(b); }
-        i = i + 1;
+        i += 1;
     }
     out.push_str("\"");
 }
@@ -86,7 +86,7 @@ fn function_at(borrow program: bytecode.Program, pc: u64) -> u64 {
     let mut i: u64 = 0;
     while i < program.fn_starts.len() {
         if program.fn_starts.get_or(i, 18446744073709551615) == pc { return i; }
-        i = i + 1;
+        i += 1;
     }
     18446744073709551615
 }
@@ -127,7 +127,7 @@ pub fn disassemble(borrow program: bytecode.Program) -> StrBuf {
             }
         }
         out.push_str("\n");
-        pc = pc + 1;
+        pc += 1;
     }
     out
 }

--- a/examples/rill/disasm.rue
+++ b/examples/rill/disasm.rue
@@ -94,7 +94,7 @@ fn function_at(borrow program: bytecode.Program, pc: u64) -> u64 {
 pub fn disassemble(borrow program: bytecode.Program) -> StrBuf {
     let mut out = StrBuf.new();
     let mut g: u64 = 0;
-    while g < program.global_names.len() { append_global(inout out, borrow program, g); g = g + 1; }
+    while g < program.global_names.len() { append_global(inout out, borrow program, g); g += 1; }
     if g > 0 { out.push_str("\n"); }
     let mut pc: u64 = 0;
     while pc < program.code.len() {

--- a/examples/rill/lexer.rue
+++ b/examples/rill/lexer.rue
@@ -39,7 +39,7 @@ struct Lexer {
     fn done(borrow self) -> bool { self.at >= self.source.len() }
     fn advance(inout self) -> u8 {
         let b = self.byte(self.at);
-        self.at = self.at + 1;
+        self.at += 1;
         b
     }
     fn add(inout self, kind: u64, start: u64, value: u64) {

--- a/examples/rill/lexer.rue
+++ b/examples/rill/lexer.rue
@@ -76,7 +76,7 @@ struct Lexer {
     fn identifier(inout self, start: u64) {
         let mut text = StrBuf.new();
         let mut i = start;
-        while i < self.at { text.push(self.byte(i)); i = i + 1; }
+        while i < self.at { text.push(self.byte(i)); i += 1; }
         while !self.done() && is_alnum(self.byte(self.at)) {
             text.push(self.advance());
         }

--- a/examples/rill/lower.rue
+++ b/examples/rill/lower.rue
@@ -41,7 +41,7 @@ struct Lowerer {
     fn local_slot(borrow self, symbol: u64) -> u64 {
         let mut i = self.locals.len();
         while i > 0 {
-            i = i - 1;
+            i -= 1;
             if self.locals.get_or(i, ast.NONE) == symbol { return i; }
         }
         ast.NONE
@@ -51,7 +51,7 @@ struct Lowerer {
         else { self.scopes.get_or(self.scopes.len() - 1, 0) };
         let mut i = self.locals.len();
         while i > start {
-            i = i - 1;
+            i -= 1;
             if self.locals.get_or(i, ast.NONE) == symbol {
                 self.report(node, "duplicate local binding in the same scope");
                 return i;
@@ -72,7 +72,7 @@ struct Lowerer {
         let mut count: u64 = 0;
         let mut id = first;
         while id != ast.NONE {
-            count = count + 1;
+            count += 1;
             id = self.arena.get(id).next;
         }
         count
@@ -252,7 +252,7 @@ struct Lowerer {
             let symbol = param.value;
             let next = param.next;
             let _ = self.declare(param, symbol);
-            arity = arity + 1;
+            arity += 1;
             parameter = next;
         }
         let id = self.program.add_function(node.value, self.program.code.len(), arity);

--- a/examples/rill/optimize.rue
+++ b/examples/rill/optimize.rue
@@ -36,10 +36,10 @@ fn fold_triples(inout program: bytecode.Program) -> u64 {
             program.code.set(pc, fold_comparison(op.op, a.a, b.a));
             program.code.set(pc + 1, nop());
             program.code.set(pc + 2, nop());
-            folded = folded + 1;
-            pc = pc + 3;
+            folded += 1;
+            pc += 3;
         } else {
-            pc = pc + 1;
+            pc += 1;
         }
     }
     folded
@@ -54,12 +54,12 @@ fn fold_pairs(inout program: bytecode.Program) -> u64 {
         if value.op == bytecode.CONST_BOOL && op.op == bytecode.NOT {
             program.code.set(pc, boolean(value.a == 0));
             program.code.set(pc + 1, nop());
-            folded = folded + 1;
+            folded += 1;
         } else if op.op == bytecode.JUMP && op.a >= 0 && @intCast(op.a) == pc + 2 {
             program.code.set(pc + 1, nop());
-            folded = folded + 1;
+            folded += 1;
         }
-        pc = pc + 1;
+        pc += 1;
     }
     folded
 }
@@ -67,6 +67,6 @@ fn fold_pairs(inout program: bytecode.Program) -> u64 {
 pub fn optimize(program: bytecode.Program) -> OptimizeResult {
     let mut result = program;
     let mut folded = fold_triples(inout result);
-    folded = folded + fold_pairs(inout result);
+    folded += fold_pairs(inout result);
     OptimizeResult { program: result, folded: folded }
 }

--- a/examples/rill/parser.rue
+++ b/examples/rill/parser.rue
@@ -30,7 +30,7 @@ struct Parser {
     fn check(borrow self, kind: u64) -> bool { self.peek().kind == kind }
     fn advance(inout self) -> token.Token {
         let result = self.peek();
-        if result.kind != token.EOF { self.at = self.at + 1; }
+        if result.kind != token.EOF { self.at += 1; }
         result
     }
     fn take(inout self, kind: u64) -> bool {

--- a/examples/rill/pool.rue
+++ b/examples/rill/pool.rue
@@ -42,7 +42,7 @@ pub struct Pool {
         let mut i: u64 = 0;
         while i < n {
             if self.entry_byte(id, i) != Self.byte_of(borrow text, i) { return false; }
-            i = i + 1;
+            i += 1;
         }
         true
     }
@@ -53,7 +53,7 @@ pub struct Pool {
         let mut i: u64 = 0;
         while i < n {
             if self.entry_byte(a, i) != self.entry_byte(b, i) { return false; }
-            i = i + 1;
+            i += 1;
         }
         true
     }
@@ -68,7 +68,7 @@ pub struct Pool {
         let mut j: u64 = 0;
         while j < len {
             self.bytes.push(Self.byte_of(borrow text, j));
-            j = j + 1;
+            j += 1;
         }
         self.offs.push(off);
         self.lens.push(len);

--- a/examples/rill/pool.rue
+++ b/examples/rill/pool.rue
@@ -90,9 +90,9 @@ pub struct Pool {
     fn concat(inout self, a: u64, b: u64) -> u64 {
         let mut out = StrBuf.new();
         let mut i: u64 = 0;
-        while i < self.entry_len(a) { out.push(self.entry_byte(a, i)); i = i + 1; }
+        while i < self.entry_len(a) { out.push(self.entry_byte(a, i)); i += 1; }
         i = 0;
-        while i < self.entry_len(b) { out.push(self.entry_byte(b, i)); i = i + 1; }
+        while i < self.entry_len(b) { out.push(self.entry_byte(b, i)); i += 1; }
         self.intern(borrow out)
     }
 
@@ -100,7 +100,7 @@ pub struct Pool {
         let mut out = StrBuf.new();
         let n = self.entry_len(id);
         let mut i: u64 = 0;
-        while i < n { out.push(self.entry_byte(id, i)); i = i + 1; }
+        while i < n { out.push(self.entry_byte(id, i)); i += 1; }
         out
     }
 }

--- a/examples/rill/stats.rue
+++ b/examples/rill/stats.rue
@@ -33,13 +33,13 @@ struct Inventory {
             self.counts.set(ins.op, self.counts.get_or(ins.op, 0) + 1);
         }
         if ins.op == bytecode.JUMP || ins.op == bytecode.JUMP_FALSE {
-            self.jumps = self.jumps + 1;
+            self.jumps += 1;
             if ins.a >= 0 && @intCast(ins.a) <= pc {
-                self.backward_jumps = self.backward_jumps + 1;
+                self.backward_jumps += 1;
             }
         }
         if ins.op == bytecode.CALL {
-            self.calls = self.calls + 1;
+            self.calls += 1;
             if ins.b >= 0 && @intCast(ins.b) > self.max_call_arity {
                 self.max_call_arity = @intCast(ins.b);
             }
@@ -60,7 +60,7 @@ pub fn summarize(borrow program: bytecode.Program) -> StrBuf {
     let mut pc: u64 = 0;
     while pc < program.code.len() {
         inventory.observe(pc, program.code.get_or(pc, bytecode.Instruction { op: 0, a: 0, b: 0 }));
-        pc = pc + 1;
+        pc += 1;
     }
     let mut out = StrBuf.new();
     append_metric(inout out, "functions", program.fn_names.len());

--- a/examples/rill/stats.rue
+++ b/examples/rill/stats.rue
@@ -17,7 +17,7 @@ struct Inventory {
     fn new() -> Self {
         let mut counts = U64s.new();
         let mut i: u64 = 0;
-        while i < 40 { counts.push(0); i = i + 1; }
+        while i < 40 { counts.push(0); i += 1; }
         Self {
             counts: counts,
             jumps: 0,
@@ -44,7 +44,7 @@ struct Inventory {
                 self.max_call_arity = @intCast(ins.b);
             }
         }
-        if ins.op == bytecode.RETURN { self.returns = self.returns + 1; }
+        if ins.op == bytecode.RETURN { self.returns += 1; }
     }
 }
 

--- a/examples/rill/stress.rue
+++ b/examples/rill/stress.rue
@@ -37,7 +37,7 @@ pub fn generate(count: u64) -> StrBuf {
     let mut i: u64 = 0;
     while i < count {
         append_function(inout out, i, count);
-        i = i + 1;
+        i += 1;
     }
     out.push_str("fn main() {\n");
     out.push_str("  let answer = step0(0);\n");

--- a/examples/rill/verify.rue
+++ b/examples/rill/verify.rue
@@ -163,7 +163,7 @@ struct Verifier {
     fn check_function_flow(inout self, id: u64) {
         let mut heights = I64s.new();
         let mut i: u64 = 0;
-        while i < self.program.code.len() { heights.push(-2); i = i + 1; }
+        while i < self.program.code.len() { heights.push(-2); i += 1; }
         let mut work = U64s.new();
         self.enqueue(inout work, inout heights, self.program.fn_starts.get_or(id, 0), 0);
         while work.len() > 0 {
@@ -195,7 +195,7 @@ struct Verifier {
         self.check_metadata();
         self.check_operands();
         let mut i: u64 = 0;
-        while i < self.program.fn_names.len() { self.check_function_flow(i); i = i + 1; }
+        while i < self.program.fn_names.len() { self.check_function_flow(i); i += 1; }
     }
 }
 

--- a/examples/rill/verify.rue
+++ b/examples/rill/verify.rue
@@ -90,9 +90,9 @@ struct Verifier {
                 if self.program.fn_names.get_or(i, 0) == self.program.fn_names.get_or(j, 1) {
                     self.report(start, "duplicate function name");
                 }
-                j = j + 1;
+                j += 1;
             }
-            i = i + 1;
+            i += 1;
         }
         if self.program.global_names.len() != self.program.global_tags.len() ||
             self.program.global_names.len() != self.program.global_data.len() {
@@ -107,9 +107,9 @@ struct Verifier {
                 if self.program.global_names.get_or(i, 0) == self.program.global_names.get_or(j, 1) {
                     self.report(0, "duplicate global name");
                 }
-                j = j + 1;
+                j += 1;
             }
-            i = i + 1;
+            i += 1;
         }
     }
 
@@ -145,7 +145,7 @@ struct Verifier {
                     }
                 }
             }
-            i = i + 1;
+            i += 1;
         }
     }
 

--- a/examples/rill/vm.rue
+++ b/examples/rill/vm.rue
@@ -46,7 +46,7 @@ struct ListHeap {
         self.offs.push(self.values.len());
         self.lens.push(len + 1);
         let mut i: u64 = 0;
-        while i < len { self.values.push(self.get(id, i)); i = i + 1; }
+        while i < len { self.values.push(self.get(id, i)); i += 1; }
         self.values.push(value);
         result
     }
@@ -125,7 +125,7 @@ struct VM {
     }
     fn allocate_locals(inout self, count: u64) {
         let mut i: u64 = 0;
-        while i < count { self.stack.push(Self.false_value()); i = i + 1; }
+        while i < count { self.stack.push(Self.false_value()); i += 1; }
     }
 
     fn value_equal(borrow self, a: Value, b: Value) -> bool {
@@ -284,7 +284,7 @@ struct VM {
                     let count: u64 = @intCast(ins.a);
                     let mut elements = Values.new();
                     let mut i: u64 = 0;
-                    while i < count { elements.push(self.pop()); i = i + 1; }
+                    while i < count { elements.push(self.pop()); i += 1; }
                     elements.reverse();
                     let id = self.lists.from_stack(borrow elements, 0, count);
                     self.push(Value { tag: LIST_VALUE, data: @intCast(id) });

--- a/examples/rill/vm.rue
+++ b/examples/rill/vm.rue
@@ -36,7 +36,7 @@ struct ListHeap {
         let mut i: u64 = 0;
         while i < count {
             self.values.push(stack.get_or(start + i, Value { tag: 0, data: 0 }));
-            i = i + 1;
+            i += 1;
         }
         id
     }
@@ -78,7 +78,7 @@ struct VM {
                 tag: program.global_tags.get_or(i, BOOL),
                 data: program.global_data.get_or(i, 0),
             });
-            i = i + 1;
+            i += 1;
         }
         Self {
             program: program,
@@ -189,7 +189,7 @@ struct VM {
             while i < n {
                 if i > 0 { self.output.push_str(", "); }
                 self.append_value(self.lists.get(id, i));
-                i = i + 1;
+                i += 1;
             }
             self.output.push_str("]");
         }
@@ -229,10 +229,10 @@ struct VM {
         loop {
             if self.failed { return Self.false_value(); }
             if self.steps >= 10000000 { self.fail("instruction limit exceeded"); return Self.false_value(); }
-            self.steps = self.steps + 1;
+            self.steps += 1;
             if self.pc >= self.program.code.len() { self.fail("instruction pointer out of bounds"); return Self.false_value(); }
             let ins = self.program.code.get_or(self.pc, bytecode.Instruction { op: bytecode.HALT, a: 0, b: 0 });
-            self.pc = self.pc + 1;
+            self.pc += 1;
             if ins.op == bytecode.NOP {}
             else if ins.op == bytecode.CONST_INT { self.push(Value { tag: INT, data: ins.a }); }
             else if ins.op == bytecode.CONST_BOOL { self.push(Value { tag: BOOL, data: ins.a }); }

--- a/examples/ruelex/fmtutil.rue
+++ b/examples/ruelex/fmtutil.rue
@@ -32,7 +32,7 @@ pub fn pad_left(n: u64, width: u64) -> StrBuf {
         let mut i = len;
         while i < width {
             b.push(32);
-            i = i + 1;
+            i += 1;
         }
     }
     b.push_str(ds);
@@ -50,7 +50,7 @@ pub fn pad_right(n: u64, width: u64) -> StrBuf {
         let mut i = len;
         while i < width {
             b.push(32);
-            i = i + 1;
+            i += 1;
         }
     }
     b

--- a/examples/ruelex/interner.rue
+++ b/examples/ruelex/interner.rue
@@ -51,7 +51,7 @@ pub struct Interner {
             if a != b {
                 return false;
             }
-            j = j + 1;
+            j += 1;
         }
         true
     }
@@ -64,7 +64,7 @@ pub struct Interner {
             if self.entry_eq(i, borrow key) {
                 return i;
             }
-            i = i + 1;
+            i += 1;
         }
         let off = self.pool.len();
         let len = key.len();
@@ -72,7 +72,7 @@ pub struct Interner {
         while j < len {
             let b = Self.byte_of(borrow key, j);
             self.pool.push(b);
-            j = j + 1;
+            j += 1;
         }
         self.offs.push(off);
         self.lens.push(len);

--- a/examples/ruelex/lex.rue
+++ b/examples/ruelex/lex.rue
@@ -124,12 +124,12 @@ pub struct Lexer {
     // Consume one byte, maintaining 1-based line/column (columns count bytes).
     fn advance(inout self) {
         let c = self.at(self.pos);
-        self.pos = self.pos + 1;
+        self.pos += 1;
         if c == 10 {
-            self.line = self.line + 1;
+            self.line += 1;
             self.col = 1;
         } else {
-            self.col = self.col + 1;
+            self.col += 1;
         }
     }
 

--- a/examples/ruelex/main.rue
+++ b/examples/ruelex/main.rue
@@ -147,12 +147,12 @@ fn main() -> i32 {
                 } else if str_eq(borrow a, "--ast-shape") {
                     shape_mode = true;
                 } else {
-                    nfiles = nfiles + 1;
+                    nfiles += 1;
                 }
             },
             OptStr.None => {},
         }
-        i = i + 1;
+        i += 1;
     }
 
     if nfiles == 0 {
@@ -185,7 +185,7 @@ fn main() -> i32 {
             },
             OptStr.None => {},
         }
-        i = i + 1;
+        i += 1;
     }
 
     if ok { 0 } else { 1 }

--- a/examples/ruelex/parse.rue
+++ b/examples/ruelex/parse.rue
@@ -56,7 +56,7 @@ pub struct Parser {
 
     fn bump(inout self) -> token.Token {
         let t = self.current();
-        if t.kind != token.EOF { self.pos = self.pos + 1; }
+        if t.kind != token.EOF { self.pos += 1; }
         t
     }
 
@@ -447,7 +447,7 @@ pub struct Parser {
         loop {
             let k = self.kind_at(p);
             if k == token.EOF { return false; }
-            if k == token.LPAREN { depth = depth + 1; }
+            if k == token.LPAREN { depth += 1; }
             else if k == token.RPAREN {
                 depth -= 1;
                 if depth == 0 { return self.kind_at(p + 1) == token.DOT; }
@@ -589,12 +589,12 @@ pub struct Parser {
         loop {
             let k = self.kind_at(p);
             if k == token.EOF { return false; }
-            if k == token.LBRACKET || k == token.LPAREN || k == token.LBRACE { depth = depth + 1; }
+            if k == token.LBRACKET || k == token.LPAREN || k == token.LBRACE { depth += 1; }
             else if k == token.RBRACKET {
                 if depth == 1 { return false; }
                 depth -= 1;
             } else if k == token.RPAREN || k == token.RBRACE {
-                if depth != 0 { depth = depth - 1; }
+                if depth != 0 { depth -= 1; }
             } else if k == token.SEMI && depth == 1 { return true; }
             p += 1;
         }
@@ -834,9 +834,9 @@ pub struct Parser {
     fn parse_item(inout self) -> u64 {
         let directives = self.parse_directives();
         let mut flags: u64 = 0;
-        if self.eat(token.PUB) { flags = flags + 1; }
-        if self.eat(token.UNCHECKED) { flags = flags + 2; }
-        if self.eat(token.LINEAR) { flags = flags + 4; }
+        if self.eat(token.PUB) { flags += 1; }
+        if self.eat(token.UNCHECKED) { flags += 2; }
+        if self.eat(token.LINEAR) { flags += 4; }
         if self.at(token.FN) { self.parse_function(directives, flags, false) }
         else if self.at(token.STRUCT) { self.parse_struct(directives, flags) }
         else if self.at(token.ENUM) { self.parse_enum(flags) }

--- a/examples/ruelex/parse.rue
+++ b/examples/ruelex/parse.rue
@@ -73,7 +73,7 @@ pub struct Parser {
         self.errors.push_str(", got ");
         self.errors.push_str(@to_string(got.kind));
         self.errors.push_str("\n");
-        self.error_count = self.error_count + 1;
+        self.error_count += 1;
     }
 
     fn expect(inout self, kind: u64) -> token.Token {
@@ -345,7 +345,7 @@ pub struct Parser {
                 self.parse_expr(0, true)
             };
             args = self.append(args, self.add(ast.ARG, 0, self.arena.at(value).start, self.arena.at(value).end, value, 0, 0));
-            position = position + 1;
+            position += 1;
             if !self.eat(token.COMMA) { break; }
         }
         let _ = self.expect(token.RPAREN);
@@ -449,10 +449,10 @@ pub struct Parser {
             if k == token.EOF { return false; }
             if k == token.LPAREN { depth = depth + 1; }
             else if k == token.RPAREN {
-                depth = depth - 1;
+                depth -= 1;
                 if depth == 0 { return self.kind_at(p + 1) == token.DOT; }
             }
-            p = p + 1;
+            p += 1;
         }
     }
 
@@ -554,16 +554,16 @@ pub struct Parser {
         let mut p = self.pos;
         loop {
             if self.kind_at(p) != token.AT { break; }
-            p = p + 1;
+            p += 1;
             if self.kind_at(p) != token.IDENT { return false; }
-            p = p + 1;
+            p += 1;
             if self.kind_at(p) == token.LPAREN {
-                p = p + 1;
+                p += 1;
                 while self.kind_at(p) != token.RPAREN && self.kind_at(p) != token.EOF {
-                    p = p + 1;
+                    p += 1;
                 }
                 if self.kind_at(p) != token.RPAREN { return false; }
-                p = p + 1;
+                p += 1;
             }
         }
         self.kind_at(p) == token.LET
@@ -592,11 +592,11 @@ pub struct Parser {
             if k == token.LBRACKET || k == token.LPAREN || k == token.LBRACE { depth = depth + 1; }
             else if k == token.RBRACKET {
                 if depth == 1 { return false; }
-                depth = depth - 1;
+                depth -= 1;
             } else if k == token.RPAREN || k == token.RBRACE {
                 if depth != 0 { depth = depth - 1; }
             } else if k == token.SEMI && depth == 1 { return true; }
-            p = p + 1;
+            p += 1;
         }
     }
 

--- a/examples/second/calculator.rue
+++ b/examples/second/calculator.rue
@@ -53,7 +53,7 @@ fn tokenize(input: StrBuf, inout tokens: std.arraybuf.ArrayBuf(Token)) -> LexErr
         let byte = input[index];
 
         if is_ascii_whitespace(byte) {
-            index = index + 1;
+            index += 1;
         } else if is_ascii_digit(byte) {
             let start = index;
             let mut value: i64 = 0;
@@ -70,28 +70,28 @@ fn tokenize(input: StrBuf, inout tokens: std.arraybuf.ArrayBuf(Token)) -> LexErr
                 }
 
                 value = value * 10 + digit;
-                index = index + 1;
+                index += 1;
             }
 
             tokens.push(Token.Number(value, start + 1));
         } else if byte == 43 {
             tokens.push(Token.Plus(index + 1));
-            index = index + 1;
+            index += 1;
         } else if byte == 45 {
             tokens.push(Token.Minus(index + 1));
-            index = index + 1;
+            index += 1;
         } else if byte == 42 {
             tokens.push(Token.Star(index + 1));
-            index = index + 1;
+            index += 1;
         } else if byte == 47 {
             tokens.push(Token.Slash(index + 1));
-            index = index + 1;
+            index += 1;
         } else if byte == 40 {
             tokens.push(Token.LParen(index + 1));
-            index = index + 1;
+            index += 1;
         } else if byte == 41 {
             tokens.push(Token.RParen(index + 1));
-            index = index + 1;
+            index += 1;
         } else {
             return LexError.UnexpectedByte(index + 1, byte);
         }
@@ -149,17 +149,17 @@ struct Parser {
 
         match token {
             Token.Number(value, _position) => {
-                self.index = self.index + 1;
+                self.index += 1;
                 OptInt.Some(value)
             },
             Token.LParen(_position) => {
-                self.index = self.index + 1;
+                self.index += 1;
                 let value = self.parse_expression()?;
                 let close = self.current();
 
                 match close {
                     Token.RParen(_close_position) => {
-                        self.index = self.index + 1;
+                        self.index += 1;
                         OptInt.Some(value)
                     },
                     _ => self.fail(ParseError.ExpectedRParen(token_position(close))),
@@ -176,17 +176,17 @@ struct Parser {
         loop {
             match self.current() {
                 Token.Star(_position) => {
-                    self.index = self.index + 1;
+                    self.index += 1;
                     let right = self.parse_primary()?;
-                    value = value * right;
+                    value *= right;
                 },
                 Token.Slash(position) => {
-                    self.index = self.index + 1;
+                    self.index += 1;
                     let right = self.parse_primary()?;
                     if right == 0 {
                         return self.fail(ParseError.DivisionByZero(position));
                     }
-                    value = value / right;
+                    value /= right;
                 },
                 _ => break,
             }
@@ -202,14 +202,14 @@ struct Parser {
         loop {
             match self.current() {
                 Token.Plus(_position) => {
-                    self.index = self.index + 1;
+                    self.index += 1;
                     let right = self.parse_product()?;
-                    value = value + right;
+                    value += right;
                 },
                 Token.Minus(_position) => {
-                    self.index = self.index + 1;
+                    self.index += 1;
                     let right = self.parse_product()?;
-                    value = value - right;
+                    value -= right;
                 },
                 _ => break,
             }

--- a/examples/shapes.rue
+++ b/examples/shapes.rue
@@ -27,8 +27,8 @@ fn main() -> i32 {
     while i < 4 {
         let a = area(shapes[i]);
         @dbg(a);
-        total = total + a;
-        i = i + 1;
+        total += a;
+        i += 1;
     }
     total
 }

--- a/examples/std/arraybuf_demo.rue
+++ b/examples/std/arraybuf_demo.rue
@@ -37,8 +37,8 @@ fn main() -> i32 {
     let mut i: u64 = 0;
     let mut sum: i32 = 0;
     while i < v.len() {
-        sum = sum + v.get_or(i, 0);
-        i = i + 1;
+        sum += v.get_or(i, 0);
+        i += 1;
     }
     @dbg(sum);              // 99 + 20 = 119
 

--- a/examples/sudoku/board.rue
+++ b/examples/sudoku/board.rue
@@ -13,7 +13,7 @@ fn allowed(borrow b: Board, row: u64, col: u64, val: i64) -> bool {
     while i < 9 {
         if b.cells[row][i] == val { ok = false; }
         if b.cells[i][col] == val { ok = false; }
-        i = i + 1;
+        i += 1;
     }
     // 3x3 box.
     let box_r = (row / 3) * 3;
@@ -23,9 +23,9 @@ fn allowed(borrow b: Board, row: u64, col: u64, val: i64) -> bool {
         let mut c: u64 = 0;
         while c < 3 {
             if b.cells[box_r + r][box_c + c] == val { ok = false; }
-            c = c + 1;
+            c += 1;
         }
-        r = r + 1;
+        r += 1;
     }
     ok
 }
@@ -50,7 +50,7 @@ pub fn solve(inout b: Board, pos: u64) -> bool {
                     }
                     b.cells[row][col] = 0;
                 }
-                val = val + 1;
+                val += 1;
             }
             solved
         }
@@ -74,17 +74,17 @@ pub fn is_valid(borrow b: Board) -> bool {
         let mut col_prod: i64 = 1;
         let mut v: u64 = 0;
         while v < 9 {
-            row_sum = row_sum + b.cells[u][v];
-            col_sum = col_sum + b.cells[v][u];
-            row_prod = row_prod * b.cells[u][v];
-            col_prod = col_prod * b.cells[v][u];
-            v = v + 1;
+            row_sum += b.cells[u][v];
+            col_sum += b.cells[v][u];
+            row_prod *= b.cells[u][v];
+            col_prod *= b.cells[v][u];
+            v += 1;
         }
         if row_sum != 45 { ok = false; }
         if col_sum != 45 { ok = false; }
         if row_prod != 362880 { ok = false; }
         if col_prod != 362880 { ok = false; }
-        u = u + 1;
+        u += 1;
     }
     ok
 }

--- a/examples/tinydb/db/query.rue
+++ b/examples/tinydb/db/query.rue
@@ -24,9 +24,9 @@ pub fn sum_salaries(borrow t: table.Table, p: Pred) -> i64 {
     while i < n {
         let row = t.row_at(i);
         if matches(borrow row, borrow p) {
-            total = total + row.salary;
+            total += row.salary;
         }
-        i = i + 1;
+        i += 1;
     }
     total
 }
@@ -44,7 +44,7 @@ pub fn top_earner(borrow t: table.Table, p: Pred) -> i64 {
                 best_id = row.id;
             }
         }
-        i = i + 1;
+        i += 1;
     }
     best_id
 }

--- a/examples/tinydb/db/table.rue
+++ b/examples/tinydb/db/table.rue
@@ -16,7 +16,7 @@ pub struct Table {
 
     fn insert(inout self, dept: record.Dept, salary: i64) -> i64 {
         let id = self.next_id;
-        self.next_id = self.next_id + 1;
+        self.next_id += 1;
         self.rows.push(record.Row.new(id, dept, salary));
         id
     }

--- a/examples/vm.rue
+++ b/examples/vm.rue
@@ -33,13 +33,13 @@ struct VM {
     // Fetch the immediate operand following the current opcode.
     fn imm(inout self) -> i64 {
         let v = self.code.get_or(self.pc, 0);
-        self.pc = self.pc + 1;
+        self.pc += 1;
         v
     }
 
     fn step(inout self) -> Step {
         let op = self.code.get_or(self.pc, 4);
-        self.pc = self.pc + 1;
+        self.pc += 1;
         if op == 0 {
             let v = self.imm();
             self.stack.push(v);

--- a/examples/wordfreq/firstseen.rue
+++ b/examples/wordfreq/firstseen.rue
@@ -48,7 +48,7 @@ pub struct FirstSeen {
         let mut j: u64 = 0;
         while j < len {
             self.pool.push(_byte_of(borrow w, j));
-            j = j + 1;
+            j += 1;
         }
         self.offs.push(off);
         self.lens.push(len);
@@ -61,7 +61,7 @@ pub struct FirstSeen {
         let mut j: u64 = 0;
         while j < len {
             out.push(_byte_of(borrow self.pool, off + j));
-            j = j + 1;
+            j += 1;
         }
     }
 }

--- a/examples/wordfreq/main.rue
+++ b/examples/wordfreq/main.rue
@@ -125,15 +125,15 @@ fn main() -> i32 {
             word.push(to_lower(b));
         } else if word.len() > 0 {
             count_word(borrow word, inout counts, inout order);
-            words_total = words_total + 1;
+            words_total += 1;
             word.clear();
         }
-        i = i + 1;
+        i += 1;
     }
     // Flush a trailing word not terminated by a separator.
     if word.len() > 0 {
         count_word(borrow word, inout counts, inout order);
-        words_total = words_total + 1;
+        words_total += 1;
     }
 
     let distinct = order.len();
@@ -159,7 +159,7 @@ fn main() -> i32 {
                 best_count = c;
                 best_idx = k;
             }
-            k = k + 1;
+            k += 1;
         }
         let mut line = StrBuf.new();
         line.push_str("top=");

--- a/std/arraybuf.rue
+++ b/std/arraybuf.rue
@@ -214,7 +214,7 @@ pub fn ArrayBuf(comptime T: type) -> type {
                 if new_cap > 9223372036854775807 {
                     new_cap = required;
                 } else {
-                    new_cap = new_cap * 2;
+                    new_cap *= 2;
                 }
             }
             self.core.grow_to(new_cap);
@@ -224,7 +224,7 @@ pub fn ArrayBuf(comptime T: type) -> type {
         fn push(inout self, x: T) {
             self.reserve(1);
             self.core.write_at(self.len, x);
-            self.len = self.len + 1;
+            self.len += 1;
         }
 
         // Append a by-copy collection in one capacity operation. Reading a
@@ -239,8 +239,8 @@ pub fn ArrayBuf(comptime T: type) -> type {
             while i < other.len {
                 let value = other.core.read_at(i);
                 self.core.write_at(self.len, value);
-                self.len = self.len + 1;
-                i = i + 1;
+                self.len += 1;
+                i += 1;
             }
         }
 
@@ -252,7 +252,7 @@ pub fn ArrayBuf(comptime T: type) -> type {
             let mut i: u64 = 0;
             while i < value.len() {
                 self.push(value[i]);
-                i = i + 1;
+                i += 1;
             }
         }
 
@@ -263,7 +263,7 @@ pub fn ArrayBuf(comptime T: type) -> type {
             if self.len == 0 {
                 O.None
             } else {
-                self.len = self.len - 1;
+                self.len -= 1;
                 O.Some(self.core.read_at(self.len))
             }
         }
@@ -275,7 +275,7 @@ pub fn ArrayBuf(comptime T: type) -> type {
             if self.len == 0 {
                 default
             } else {
-                self.len = self.len - 1;
+                self.len -= 1;
                 self.core.read_at(self.len)
             }
         }
@@ -313,8 +313,8 @@ pub fn ArrayBuf(comptime T: type) -> type {
                 let mut j: u64 = self.len - 1;
                 while i < j {
                     self.swap(i, j);
-                    i = i + 1;
-                    j = j - 1;
+                    i += 1;
+                    j -= 1;
                 }
             }
         }
@@ -342,7 +342,7 @@ pub fn ArrayBuf(comptime T: type) -> type {
                 if e == x {
                     return O.Some(i);
                 }
-                i = i + 1;
+                i += 1;
             }
             O.None
         }
@@ -363,7 +363,7 @@ pub fn ArrayBuf(comptime T: type) -> type {
             let mut i: u64 = 0;
             while i < self.len {
                 @drop(self.core.read_at(i));
-                i = i + 1;
+                i += 1;
             }
             self.len = 0;
         }
@@ -378,7 +378,7 @@ pub fn ArrayBuf(comptime T: type) -> type {
             let mut i: u64 = 0;
             while i < self.len {
                 @drop(self.core.read_at(i));
-                i = i + 1;
+                i += 1;
             }
             self.core.free();
             self.len = 0;
@@ -400,7 +400,7 @@ pub fn ArrayBuf(comptime T: type) -> type {
             let mut i: u64 = 0;
             while i < self.len {
                 @drop(self.core.read_at(i));
-                i = i + 1;
+                i += 1;
             }
         }
     }

--- a/std/bitset.rue
+++ b/std/bitset.rue
@@ -77,10 +77,10 @@ pub fn BitSet() -> type {
             while w < self.words.len() {
                 let mut v = self.words.get_or(w, 0);
                 while v != 0 {
-                    total = total + (v & 1);
-                    v = v >> 1;
+                    total += (v & 1);
+                    v >>= 1;
                 }
-                w = w + 1;
+                w += 1;
             }
             total
         }

--- a/std/c.rue
+++ b/std/c.rue
@@ -164,7 +164,7 @@ pub const c_bool = bool;
 pub fn c_strlen(cstr: ptr mut u8) -> u64 {
     let mut len: u64 = 0;
     while checked { @byte_read(cstr, len) } != 0 {
-        len = len + 1;
+        len += 1;
     }
     len
 }
@@ -193,7 +193,7 @@ pub fn owned_c_string(borrow source: strbuf.StrBuf) -> ptr mut u8 {
     while i < len {
         let byte = strbuf.StrBuf.byte_at_borrowed(borrow source, i);
         checked { @byte_write(buf, i, byte); };
-        i = i + 1;
+        i += 1;
     }
     checked { @byte_write(buf, len, 0); };
     buf
@@ -213,7 +213,7 @@ pub fn strbuf_from_c_string(cstr: ptr mut u8) -> strbuf.StrBuf {
     let mut i: u64 = 0;
     while i < len {
         out.push(checked { @byte_read(cstr, i) });
-        i = i + 1;
+        i += 1;
     }
     out
 }
@@ -228,7 +228,7 @@ pub fn strbuf_from_c_string(cstr: ptr mut u8) -> strbuf.StrBuf {
 pub fn free_c_string(cstr: ptr mut u8) {
     let mut len: u64 = 0;
     while checked { @byte_read(cstr, len) } != 0 {
-        len = len + 1;
+        len += 1;
     }
     checked { @free_bytes(cstr, len + 1, 1); };
 }

--- a/std/deque.rue
+++ b/std/deque.rue
@@ -54,7 +54,7 @@ pub fn Deque(comptime T: type) -> type {
                 // `cap > 0` here whenever `count > 0`, so no divide-by-zero.
                 let idx = (self.head + i) % self.cap;
                 nb.push(self.buf.get_or(idx, self.filler));
-                i = i + 1;
+                i += 1;
             }
             while nb.len() < new_cap {
                 nb.push(self.filler);
@@ -78,7 +78,7 @@ pub fn Deque(comptime T: type) -> type {
             self._ensure_room();
             let idx = (self.head + self.count) % self.cap;
             self.buf.set(idx, x);
-            self.count = self.count + 1;
+            self.count += 1;
         }
 
         // Prepend `x` at the front.
@@ -86,7 +86,7 @@ pub fn Deque(comptime T: type) -> type {
             self._ensure_room();
             self.head = (self.head + self.cap - 1) % self.cap;
             self.buf.set(self.head, x);
-            self.count = self.count + 1;
+            self.count += 1;
         }
 
         // Remove and return the front element, or `None` when empty.
@@ -97,7 +97,7 @@ pub fn Deque(comptime T: type) -> type {
             } else {
                 let v = self.buf.get_or(self.head, self.filler);
                 self.head = (self.head + 1) % self.cap;
-                self.count = self.count - 1;
+                self.count -= 1;
                 O.Some(v)
             }
         }
@@ -108,7 +108,7 @@ pub fn Deque(comptime T: type) -> type {
             if self.count == 0 {
                 O.None
             } else {
-                self.count = self.count - 1;
+                self.count -= 1;
                 let idx = (self.head + self.count) % self.cap;
                 O.Some(self.buf.get_or(idx, self.filler))
             }

--- a/std/env.rue
+++ b/std/env.rue
@@ -42,7 +42,7 @@ fn copy_range(source: ptr mut u8, start: u64, count: u64) -> StrBuf {
     while i < count {
         let byte: u8 = checked { @byte_read(source, start + i) };
         out.push(byte);
-        i = i + 1;
+        i += 1;
     }
     out
 }
@@ -75,7 +75,7 @@ pub fn args() -> arraybuf.ArrayBuf(StrBuf) {
         let entry_ptr: ptr mut u8 = checked { @arg_ptr(i) };
         let len: u64 = checked { @arg_len(i) };
         out.push(copy_range(entry_ptr, 0, len));
-        i = i + 1;
+        i += 1;
     }
     out
 }
@@ -103,7 +103,7 @@ fn key_matches(entry_ptr: ptr mut u8, len: u64, borrow name: StrBuf, name_len: u
         if entry_byte != name_byte {
             return false;
         }
-        i = i + 1;
+        i += 1;
     }
     let separator: u8 = checked { @byte_read(entry_ptr, name_len) };
     separator == 61
@@ -126,7 +126,7 @@ pub fn var(borrow name: StrBuf) -> option.Option(StrBuf) {
             let value_len = len - value_start;
             return O.Some(copy_range(entry_ptr, value_start, value_len));
         }
-        i = i + 1;
+        i += 1;
     }
     O.None
 }

--- a/std/fmt.rue
+++ b/std/fmt.rue
@@ -35,13 +35,13 @@ pub fn to_radix(n: u64, base: u64) -> StrBuf {
     while m > 0 {
         let d = m % base;
         buf.push(digits[d]);
-        m = m / base;
+        m /= base;
     }
     // Digits were produced least-significant first; emit them reversed.
     let mut out = StrBuf.new();
     let mut i = buf.len();
     while i > 0 {
-        i = i - 1;
+        i -= 1;
         out.push(buf.get_or(i, 48));
     }
     out

--- a/std/fs.rue
+++ b/std/fs.rue
@@ -539,7 +539,7 @@ fn _path_to_cbuf(borrow path: strbuf.StrBuf) -> ptr mut u8 {
             O.None => 0,
         };
         checked { @byte_write(buf, i, b); };
-        i = i + 1;
+        i += 1;
     }
     checked { @byte_write(buf, n, 0); };
     buf
@@ -622,7 +622,7 @@ pub struct File {
         while i < n {
             let b = checked { @byte_read(tmp, i) };
             buf.push(b);
-            i = i + 1;
+            i += 1;
         }
         checked { @free_bytes(tmp, want, 1); };
         R.Ok(n)
@@ -645,7 +645,7 @@ pub struct File {
         let mut i: u64 = 0;
         while i < n {
             checked { @byte_write(tmp, i, buf.get_or(i, 0)); };
-            i = i + 1;
+            i += 1;
         }
         let addr: u64 = checked { @ptr_to_int(tmp) };
         let fd_u: u64 = @intCast(self.fd);
@@ -672,7 +672,7 @@ pub struct File {
         let mut i: u64 = 0;
         while i < n {
             checked { @byte_write(tmp, i, buf.get_or(i, 0)); };
-            i = i + 1;
+            i += 1;
         }
         let base: u64 = checked { @ptr_to_int(tmp) };
         let fd_u: u64 = @intCast(self.fd);
@@ -696,7 +696,7 @@ pub struct File {
                     checked { @free_bytes(tmp, n, 1); };
                     return R.Err(FileError.Other(0));
                 }
-                off = off + wrote;
+                off += wrote;
             }
         }
         checked { @free_bytes(tmp, n, 1); };

--- a/std/grid.rue
+++ b/std/grid.rue
@@ -29,7 +29,7 @@ pub fn Grid2D(comptime T: type) -> type {
             let mut i: u64 = 0;
             while i < total {
                 cells.push(fill);
-                i = i + 1;
+                i += 1;
             }
             Self { cells: cells, rows: rows, cols: cols }
         }

--- a/std/intmap.rue
+++ b/std/intmap.rue
@@ -70,9 +70,9 @@ pub fn IntMap(comptime V: type) -> type {
             } else {
                 @intCast(k)
             };
-            h = h ^ (h >> 33);
-            h = h ^ (h >> 17);
-            h = h ^ (h >> 29);
+            h ^= (h >> 33);
+            h ^= (h >> 17);
+            h ^= (h >> 29);
             h % self.cap
         }
 
@@ -89,7 +89,7 @@ pub fn IntMap(comptime V: type) -> type {
                 nk.push(0);
                 nv.push(self.filler);
                 ns.push(_EMPTY());
-                i = i + 1;
+                i += 1;
             }
             // Move existing entries over.
             let old_cap = self.cap;
@@ -104,9 +104,9 @@ pub fn IntMap(comptime V: type) -> type {
                     } else {
                         @intCast(k)
                     };
-                    h = h ^ (h >> 33);
-                    h = h ^ (h >> 17);
-                    h = h ^ (h >> 29);
+                    h ^= (h >> 33);
+                    h ^= (h >> 17);
+                    h ^= (h >> 29);
                     let mut idx = h % new_cap;
                     while ns.get_or(idx, _EMPTY()) == _OCCUPIED() {
                         idx = (idx + 1) % new_cap;
@@ -115,7 +115,7 @@ pub fn IntMap(comptime V: type) -> type {
                     nv.set(idx, v);
                     ns.set(idx, _OCCUPIED());
                 }
-                j = j + 1;
+                j += 1;
             }
             self.keys = nk;
             self.vals = nv;
@@ -150,7 +150,7 @@ pub fn IntMap(comptime V: type) -> type {
                     self.keys.set(target, k);
                     self.vals.set(target, v);
                     self.states.set(target, _OCCUPIED());
-                    self.count = self.count + 1;
+                    self.count += 1;
                     return;
                 } else if st == _OCCUPIED() {
                     if self.keys.get_or(idx, 0) == k {
@@ -163,14 +163,14 @@ pub fn IntMap(comptime V: type) -> type {
                     }
                 }
                 idx = (idx + 1) % self.cap;
-                probes = probes + 1;
+                probes += 1;
             }
             // Every slot was probed without finding an EMPTY slot or matching
             // key. Growth keeps `count` below `cap`, so reuse the first tombstone.
             self.keys.set(first_tomb, k);
             self.vals.set(first_tomb, v);
             self.states.set(first_tomb, _OCCUPIED());
-            self.count = self.count + 1;
+            self.count += 1;
         }
 
         // The value for `k`, or `None`.
@@ -188,7 +188,7 @@ pub fn IntMap(comptime V: type) -> type {
                     }
                 }
                 idx = (idx + 1) % self.cap;
-                probes = probes + 1;
+                probes += 1;
             }
             O.None
         }
@@ -212,12 +212,12 @@ pub fn IntMap(comptime V: type) -> type {
                 } else if st == _OCCUPIED() {
                     if self.keys.get_or(idx, 0) == k {
                         self.states.set(idx, _TOMBSTONE());
-                        self.count = self.count - 1;
+                        self.count -= 1;
                         return true;
                     }
                 }
                 idx = (idx + 1) % self.cap;
-                probes = probes + 1;
+                probes += 1;
             }
             false
         }

--- a/std/json.rue
+++ b/std/json.rue
@@ -47,7 +47,7 @@ fn skip_space(borrow input: StrBuf, inout at: u64) {
     while at < input.len() {
         let b = byte(borrow input, at);
         if b == 32 || b == 9 || b == 10 || b == 13 {
-            at = at + 1;
+            at += 1;
         } else {
             return;
         }
@@ -69,8 +69,8 @@ fn parse_literal(
         if byte(borrow input, at) != expected[i] {
             return R.Err(ParseError.UnexpectedByte(at));
         }
-        at = at + 1;
-        i = i + 1;
+        at += 1;
+        i += 1;
     }
     R.Ok(value)
 }
@@ -101,8 +101,8 @@ fn parse_hex4(borrow input: StrBuf, inout at: u64) -> result.Result(u64, ParseEr
             return R.Err(ParseError.InvalidUnicode(start));
         }
         value = value * 16 + @intCast(digit);
-        at = at + 1;
-        i = i + 1;
+        at += 1;
+        i += 1;
     }
     R.Ok(value)
 }
@@ -144,7 +144,7 @@ fn parse_unicode_escape(
         if at + 2 > input.len() || byte(borrow input, at) != 92 || byte(borrow input, at + 1) != 117 {
             return R.Err(ParseError.InvalidUnicode(position));
         }
-        at = at + 2;
+        at += 2;
         let second = match parse_hex4(borrow input, inout at) {
             result.Result(u64, ParseError).Ok(v) => v,
             result.Result(u64, ParseError).Err(e) => return R.Err(e),
@@ -210,14 +210,14 @@ fn copy_utf8(
         if !continuation(byte(borrow input, at + i)) {
             return R.Err(ParseError.InvalidUnicode(at + i));
         }
-        i = i + 1;
+        i += 1;
     }
     out.push(lead);
     i = 0;
     while i < needed {
         out.push(byte(borrow input, at));
-        at = at + 1;
-        i = i + 1;
+        at += 1;
+        i += 1;
     }
     R.Ok(())
 }
@@ -228,11 +228,11 @@ fn parse_string(borrow input: StrBuf, inout at: u64) -> StringResult {
     if at >= input.len() || byte(borrow input, at) != 34 {
         return R.Err(ParseError.UnexpectedByte(at));
     }
-    at = at + 1;
+    at += 1;
     let mut out = StrBuf.new();
     while at < input.len() {
         let b = byte(borrow input, at);
-        at = at + 1;
+        at += 1;
         if b == 34 {
             return R.Ok(out);
         }
@@ -252,7 +252,7 @@ fn parse_string(borrow input: StrBuf, inout at: u64) -> StringResult {
             }
             let escape_at = at - 1;
             let e = byte(borrow input, at);
-            at = at + 1;
+            at += 1;
             if e == 34 || e == 92 || e == 47 {
                 out.push(e);
             } else if e == 98 {
@@ -281,7 +281,7 @@ fn parse_string(borrow input: StrBuf, inout at: u64) -> StringResult {
 fn consume_digits(borrow input: StrBuf, inout at: u64) -> u64 {
     let start = at;
     while at < input.len() && is_digit(byte(borrow input, at)) {
-        at = at + 1;
+        at += 1;
     }
     at - start
 }
@@ -290,13 +290,13 @@ fn parse_number(borrow input: StrBuf, inout at: u64) -> ParseResult {
     let R = ParseResult;
     let start = at;
     if byte(borrow input, at) == 45 {
-        at = at + 1;
+        at += 1;
         if at >= input.len() {
             return R.Err(ParseError.InvalidNumber(start));
         }
     }
     if byte(borrow input, at) == 48 {
-        at = at + 1;
+        at += 1;
         if at < input.len() && is_digit(byte(borrow input, at)) {
             return R.Err(ParseError.InvalidNumber(at));
         }
@@ -306,7 +306,7 @@ fn parse_number(borrow input: StrBuf, inout at: u64) -> ParseResult {
         return R.Err(ParseError.InvalidNumber(at));
     }
     if at < input.len() && byte(borrow input, at) == 46 {
-        at = at + 1;
+        at += 1;
         if consume_digits(borrow input, inout at) == 0 {
             return R.Err(ParseError.InvalidNumber(at));
         }
@@ -314,11 +314,11 @@ fn parse_number(borrow input: StrBuf, inout at: u64) -> ParseResult {
     if at < input.len() {
         let e = byte(borrow input, at);
         if e == 101 || e == 69 {
-            at = at + 1;
+            at += 1;
             if at < input.len() {
                 let sign = byte(borrow input, at);
                 if sign == 43 || sign == 45 {
-                    at = at + 1;
+                    at += 1;
                 }
             }
             if consume_digits(borrow input, inout at) == 0 {
@@ -333,10 +333,10 @@ fn parse_array(borrow input: StrBuf, inout at: u64, depth: u64) -> ParseResult {
     let R = ParseResult;
     let Items = arraybuf.ArrayBuf(Json);
     let mut items = Items.new();
-    at = at + 1;
+    at += 1;
     skip_space(borrow input, inout at);
     if at < input.len() && byte(borrow input, at) == 93 {
-        at = at + 1;
+        at += 1;
         return R.Ok(Json.Array(items));
     }
     loop {
@@ -350,7 +350,7 @@ fn parse_array(borrow input: StrBuf, inout at: u64, depth: u64) -> ParseResult {
             return R.Err(ParseError.UnexpectedEnd(at));
         }
         let delimiter = byte(borrow input, at);
-        at = at + 1;
+        at += 1;
         if delimiter == 93 {
             return R.Ok(Json.Array(items));
         }
@@ -367,10 +367,10 @@ fn parse_object(borrow input: StrBuf, inout at: u64, depth: u64) -> ParseResult 
     let Values = arraybuf.ArrayBuf(Json);
     let mut keys = Keys.new();
     let mut values = Values.new();
-    at = at + 1;
+    at += 1;
     skip_space(borrow input, inout at);
     if at < input.len() && byte(borrow input, at) == 125 {
-        at = at + 1;
+        at += 1;
         return R.Ok(Json.Object(Object { keys: keys, values: values }));
     }
     loop {
@@ -388,7 +388,7 @@ fn parse_object(borrow input: StrBuf, inout at: u64, depth: u64) -> ParseResult 
         if byte(borrow input, at) != 58 {
             return R.Err(ParseError.UnexpectedByte(at));
         }
-        at = at + 1;
+        at += 1;
         let value = match parse_value(borrow input, inout at, depth + 1) {
             ParseResult.Ok(v) => v,
             ParseResult.Err(e) => return R.Err(e),
@@ -400,7 +400,7 @@ fn parse_object(borrow input: StrBuf, inout at: u64, depth: u64) -> ParseResult 
             return R.Err(ParseError.UnexpectedEnd(at));
         }
         let delimiter = byte(borrow input, at);
-        at = at + 1;
+        at += 1;
         if delimiter == 125 {
             return R.Ok(Json.Object(Object { keys: keys, values: values }));
         }
@@ -490,7 +490,7 @@ fn write_string(value: StrBuf, inout out: StrBuf) {
         } else {
             out.push(b);
         }
-        i = i + 1;
+        i += 1;
     }
     out.push(34);
 }

--- a/std/math.rue
+++ b/std/math.rue
@@ -86,11 +86,11 @@ pub fn pow(comptime T: type, base: T, exp: u64) -> T {
     let mut e = exp;
     while e > 0 {
         if e % 2 == 1 {
-            result = result * b;
+            result *= b;
         }
-        e = e / 2;
+        e /= 2;
         if e > 0 {
-            b = b * b;
+            b *= b;
         }
     }
     result
@@ -132,7 +132,7 @@ pub fn is_prime(comptime T: type, n: T) -> bool {
         if n % i == 0 {
             return false;
         }
-        i = i + 1;
+        i += 1;
     }
     true
 }

--- a/std/mem.rue
+++ b/std/mem.rue
@@ -30,7 +30,7 @@ pub fn swap(comptime T: type, inout a: T, inout b: T) {
         let tb = checked { @byte_read(pb, i) };
         checked { @byte_write(pa, i, tb); };
         checked { @byte_write(pb, i, ta); };
-        i = i + 1;
+        i += 1;
     }
 }
 

--- a/std/net.rue
+++ b/std/net.rue
@@ -308,7 +308,7 @@ fn _sockaddr_to_kernel_buf(b: [u8; 16]) -> ptr mut u8 {
     let mut i: u64 = 0;
     while i < 16 {
         checked { @byte_write(buf, i, b[i]); };
-        i = i + 1;
+        i += 1;
     }
     buf
 }
@@ -394,7 +394,7 @@ pub struct TcpStream {
         while i < n {
             let b = checked { @byte_read(tmp, i) };
             buf.push(b);
-            i = i + 1;
+            i += 1;
         }
         checked { @free_bytes(tmp, want, 1); };
         R.Ok(n)
@@ -416,7 +416,7 @@ pub struct TcpStream {
         let mut i: u64 = 0;
         while i < n {
             checked { @byte_write(tmp, i, buf.get_or(i, 0)); };
-            i = i + 1;
+            i += 1;
         }
         let addr: u64 = checked { @ptr_to_int(tmp) };
         let fd_u: u64 = @intCast(self.fd);
@@ -443,7 +443,7 @@ pub struct TcpStream {
         let mut i: u64 = 0;
         while i < n {
             checked { @byte_write(tmp, i, buf.get_or(i, 0)); };
-            i = i + 1;
+            i += 1;
         }
         let base: u64 = checked { @ptr_to_int(tmp) };
         let fd_u: u64 = @intCast(self.fd);
@@ -467,7 +467,7 @@ pub struct TcpStream {
                     checked { @free_bytes(tmp, n, 1); };
                     return R.Err(NetworkError.Other(0));
                 }
-                off = off + wrote;
+                off += wrote;
             }
         }
         checked { @free_bytes(tmp, n, 1); };

--- a/std/queue.rue
+++ b/std/queue.rue
@@ -47,7 +47,7 @@ pub fn Queue(comptime T: type) -> type {
                 O.None
             } else {
                 let front = self.buf.get(self.head);
-                self.head = self.head + 1;
+                self.head += 1;
                 // Reset to empty once fully drained, reclaiming the buffer.
                 if self.head >= self.buf.len() {
                     self.buf.clear();

--- a/std/sort.rue
+++ b/std/sort.rue
@@ -51,12 +51,12 @@ pub fn insertion_sort(comptime T: type, inout xs: arraybuf.ArrayBuf(T)) {
             let cur = xs.get_or(j, 0);
             if cur < prev {
                 swap_at(T, inout xs, j - 1, j);
-                j = j - 1;
+                j -= 1;
             } else {
                 j = 0;
             }
         }
-        i = i + 1;
+        i += 1;
     }
 }
 
@@ -73,9 +73,9 @@ fn qsort_range(comptime T: type, inout xs: arraybuf.ArrayBuf(T), lo: u64, hi: u6
         let vj = xs.get_or(j, 0);
         if vj < pivot {
             swap_at(T, inout xs, store, j);
-            store = store + 1;
+            store += 1;
         }
-        j = j + 1;
+        j += 1;
     }
     swap_at(T, inout xs, store, hi);
     if store > lo {
@@ -105,7 +105,7 @@ pub fn is_sorted(comptime T: type, borrow xs: arraybuf.ArrayBuf(T)) -> bool {
         if cur < prev {
             return false;
         }
-        i = i + 1;
+        i += 1;
     }
     true
 }

--- a/std/strbuf.rue
+++ b/std/strbuf.rue
@@ -76,7 +76,7 @@ pub struct StrBuf {
         let mut i: u64 = 0;
         while i < source.len() {
             write_packed_byte(out.core.buf, i, source[i]);
-            i = i + 1;
+            i += 1;
         }
         out.len = source.len();
         out
@@ -100,7 +100,7 @@ pub struct StrBuf {
         let mut i: u64 = 0;
         while i < count {
             write_packed_byte(out.core.buf, i, source.get_or(start + i, 0));
-            i = i + 1;
+            i += 1;
         }
         out.len = count;
         out
@@ -143,7 +143,7 @@ pub struct StrBuf {
             if candidate > 9223372036854775807 {
                 candidate = required;
             } else {
-                candidate = candidate * 2;
+                candidate *= 2;
             }
         }
         candidate
@@ -194,7 +194,7 @@ pub struct StrBuf {
     fn append_byte(inout self, byte: u8) {
         self.grow(1);
         write_packed_byte(self.core.buf, self.len, byte);
-        self.len = self.len + 1;
+        self.len += 1;
     }
 
     fn push_str(inout self, other: Self) {
@@ -224,7 +224,7 @@ pub struct StrBuf {
         let mut i: u64 = 0;
         while i < source.len() {
             write_packed_byte(self.core.buf, destination_start + i, source[i]);
-            i = i + 1;
+            i += 1;
         }
         self.len = destination_start + source.len();
     }
@@ -250,7 +250,7 @@ pub struct StrBuf {
         let mut i: u64 = 0;
         while i < count {
             write_packed_byte(self.core.buf, destination_start + i, source.get_or(start + i, 0));
-            i = i + 1;
+            i += 1;
         }
         self.len = destination_start + count;
     }
@@ -303,7 +303,7 @@ pub struct StrBuf {
         let mut i: u64 = 0;
         while i < self.len {
             out.push(read_packed_byte(self.core.buf, i));
-            i = i + 1;
+            i += 1;
         }
         out
     }
@@ -340,7 +340,7 @@ pub struct StrBuf {
             if read_packed_byte(self.core.buf, i) != prefix[i] {
                 return false;
             }
-            i = i + 1;
+            i += 1;
         }
         true
     }
@@ -358,12 +358,12 @@ pub struct StrBuf {
                 if read_packed_byte(self.core.buf, start + i) != needle[i] {
                     equal = false;
                 }
-                i = i + 1;
+                i += 1;
             }
             if equal {
                 return true;
             }
-            start = start + 1;
+            start += 1;
         }
         false
     }
@@ -396,7 +396,7 @@ pub struct StrBuf {
             if read_packed_byte(first.core.buf, i) != read_packed_byte(second.core.buf, i) {
                 return false;
             }
-            i = i + 1;
+            i += 1;
         }
         true
     }

--- a/std/strings.rue
+++ b/std/strings.rue
@@ -73,7 +73,7 @@ pub fn parse_int(s: StrBuf) -> option.Option(i64) {
                 return O.None;
             },
         }
-        i = i + 1;
+        i += 1;
     }
     if neg {
         O.Some(-acc)
@@ -92,7 +92,7 @@ pub fn find(s: StrBuf, byte: u8) -> option.Option(u64) {
         if c == byte {
             return O.Some(i);
         }
-        i = i + 1;
+        i += 1;
     }
     O.None
 }
@@ -102,7 +102,7 @@ pub fn rfind(s: StrBuf, byte: u8) -> option.Option(u64) {
     let O = option.Option(u64);
     let mut i = s.len();
     while i > 0 {
-        i = i - 1;
+        i -= 1;
         let c = bounded_byte_at(borrow s, i);
         if c == byte {
             return O.Some(i);
@@ -119,9 +119,9 @@ pub fn count(s: StrBuf, byte: u8) -> u64 {
     while i < n {
         let cur = bounded_byte_at(borrow s, i);
         if cur == byte {
-            c = c + 1;
+            c += 1;
         }
-        i = i + 1;
+        i += 1;
     }
     c
 }
@@ -144,7 +144,7 @@ pub fn trim_start(s: StrBuf) -> StrBuf {
     while scanning && start < n {
         let c = bounded_byte_at(borrow s, start);
         if ascii.is_whitespace(c) {
-            start = start + 1;
+            start += 1;
         } else {
             scanning = false;
         }
@@ -154,7 +154,7 @@ pub fn trim_start(s: StrBuf) -> StrBuf {
     while i < n {
         let c = bounded_byte_at(borrow s, i);
         out.push(c);
-        i = i + 1;
+        i += 1;
     }
     out
 }
@@ -167,7 +167,7 @@ pub fn trim_end(s: StrBuf) -> StrBuf {
     while scanning && end > 0 {
         let c = bounded_byte_at(borrow s, end - 1);
         if ascii.is_whitespace(c) {
-            end = end - 1;
+            end -= 1;
         } else {
             scanning = false;
         }
@@ -177,7 +177,7 @@ pub fn trim_end(s: StrBuf) -> StrBuf {
     while i < end {
         let c = bounded_byte_at(borrow s, i);
         out.push(c);
-        i = i + 1;
+        i += 1;
     }
     out
 }
@@ -190,7 +190,7 @@ pub fn trim(s: StrBuf) -> StrBuf {
     while sc && start < n {
         let c = bounded_byte_at(borrow s, start);
         if ascii.is_whitespace(c) {
-            start = start + 1;
+            start += 1;
         } else {
             sc = false;
         }
@@ -200,7 +200,7 @@ pub fn trim(s: StrBuf) -> StrBuf {
     while ec && end > start {
         let c = bounded_byte_at(borrow s, end - 1);
         if ascii.is_whitespace(c) {
-            end = end - 1;
+            end -= 1;
         } else {
             ec = false;
         }
@@ -210,7 +210,7 @@ pub fn trim(s: StrBuf) -> StrBuf {
     while i < end {
         let c = bounded_byte_at(borrow s, i);
         out.push(c);
-        i = i + 1;
+        i += 1;
     }
     out
 }
@@ -225,9 +225,9 @@ pub fn repeat(s: StrBuf, n: u64) -> StrBuf {
         while i < len {
             let c = bounded_byte_at(borrow s, i);
             out.push(c);
-            i = i + 1;
+            i += 1;
         }
-        k = k + 1;
+        k += 1;
     }
     out
 }
@@ -236,7 +236,7 @@ pub fn repeat(s: StrBuf, n: u64) -> StrBuf {
 pub fn count_chars(s: StrBuf) -> u64 {
     let mut count: u64 = 0;
     for _scalar in s.chars() {
-        count = count + 1;
+        count += 1;
     }
     count
 }
@@ -246,7 +246,7 @@ pub fn count_chars(s: StrBuf) -> u64 {
 pub fn count_chars_lossy(s: StrBuf) -> u64 {
     let mut count: u64 = 0;
     for _scalar in s.chars_lossy() {
-        count = count + 1;
+        count += 1;
     }
     count
 }

--- a/std/strmap.rue
+++ b/std/strmap.rue
@@ -64,9 +64,9 @@ fn _fnv1a(borrow key: StrBuf) -> u64 {
     let mut i: u64 = 0;
     while i < n {
         let b: u64 = @intCast(_byte_of(borrow key, i));
-        h = h ^ b;
+        h ^= b;
         h = @wrapping_mul(h, 1099511628211);
-        i = i + 1;
+        i += 1;
     }
     h
 }
@@ -131,7 +131,7 @@ pub fn StrMap(comptime V: type) -> type {
                 if a != b {
                     return false;
                 }
-                j = j + 1;
+                j += 1;
             }
             true
         }
@@ -155,7 +155,7 @@ pub fn StrMap(comptime V: type) -> type {
                 nh.push(0);
                 nv.push(self.filler);
                 ns.push(_EMPTY());
-                i = i + 1;
+                i += 1;
             }
             // Move existing entries over, copying only live key bytes into the
             // fresh pool (this is the compaction step).
@@ -172,7 +172,7 @@ pub fn StrMap(comptime V: type) -> type {
                     let mut b: u64 = 0;
                     while b < len {
                         np.push(_byte_of(borrow self.pool, old_off + b));
-                        b = b + 1;
+                        b += 1;
                     }
                     // Insert into the new table by linear probing.
                     let mut idx = h % new_cap;
@@ -185,7 +185,7 @@ pub fn StrMap(comptime V: type) -> type {
                     nv.set(idx, v);
                     ns.set(idx, _OCCUPIED());
                 }
-                j = j + 1;
+                j += 1;
             }
             self.pool = np;
             self.offs = no;
@@ -202,14 +202,14 @@ pub fn StrMap(comptime V: type) -> type {
             let mut j: u64 = 0;
             while j < klen {
                 self.pool.push(_byte_of(borrow k, j));
-                j = j + 1;
+                j += 1;
             }
             self.offs.set(target, off);
             self.lens.set(target, klen);
             self.hashes.set(target, khash);
             self.vals.set(target, v);
             self.states.set(target, _OCCUPIED());
-            self.count = self.count + 1;
+            self.count += 1;
         }
 
         // Insert or overwrite `k -> v`.
@@ -251,7 +251,7 @@ pub fn StrMap(comptime V: type) -> type {
                     }
                 }
                 idx = (idx + 1) % self.cap;
-                probes = probes + 1;
+                probes += 1;
             }
             // Every slot probed, none EMPTY and no key match. Growth keeps
             // `count` below `cap`, so some slot is a tombstone; reuse the first.
@@ -275,7 +275,7 @@ pub fn StrMap(comptime V: type) -> type {
                     }
                 }
                 idx = (idx + 1) % self.cap;
-                probes = probes + 1;
+                probes += 1;
             }
             O.None
         }
@@ -303,12 +303,12 @@ pub fn StrMap(comptime V: type) -> type {
                 } else if st == _OCCUPIED() {
                     if self._key_eq(idx, borrow k, khash, klen) {
                         self.states.set(idx, _TOMBSTONE());
-                        self.count = self.count - 1;
+                        self.count -= 1;
                         return true;
                     }
                 }
                 idx = (idx + 1) % self.cap;
-                probes = probes + 1;
+                probes += 1;
             }
             false
         }


### PR DESCRIPTION
Refs RUE-1043.

RUE-1043 added the compound assignment operators; this applies them to the
corpus that motivated the issue, where every in-place update restated its
target. 10,667 statements across 1,308 files (1,290 in `examples/`, 18 in
`std/`): 10,468 `+=`, and the rest `-=`, `^=`, `*=`, `/=`, `>>=`.

```rue
-        sum = sum + numbers[i];
-        i = i + 1;
+        sum += numbers[i];
+        i += 1;
```

Pure spelling — no behavior change is intended anywhere in the diff, and the
rules below are what make that a property of the rewrite rather than a hope.

## What is rewritten, and why it is sound

A statement is rewritten only when all of the following hold:

- **Both sides name the same place**, spelled identically modulo whitespace.
- **The place contains no call.** This is the one place the two forms genuinely
  differ: the compound form evaluates the place once, the expanded form twice
  (spec 5.2:18). `a[f()] = a[f()] + 1` therefore stays as it is — rewriting it
  would drop a call.
- **Every top-level operator left on the right-hand side binds strictly tighter
  than the compound operator**, so the rewrite cannot regroup the expression.
  This is what keeps `value = value * 16 + digit` intact: `value *= 16 + digit`
  regroups it as `value * (16 + digit)`, changing both the result and where an
  overflow trap fires.
- **It is a statement**, not a `let` binding (which introduces a new name) and
  not a block tail (no terminating `;`).

Literals and comments are masked rather than skipped, so a `;`, `{`, or `=`
inside a string is never mistaken for punctuation — which is also how the two
embedded Rill programs in `examples/rill/main.rue` come through untouched.

25 restatements remain, each deliberately: eight `value = value * 10 + digit`
regrouping cases, `world.resources = world.resources - consumed - transfer`,
six multi-line statements, and the two inside string literals.

## Verification

`scripts/rue premerge` passes in full — the corpus harnesses are the point
here, since the diff is almost entirely corpus: CLI tests, the caldera and
meridian canaries, the oracle differential, the generated-oracle smoke gate,
reproducible programs, and the frontend differential (which re-parses every
rewritten file with `examples/ruelex`, itself among them).


---
_Generated by [Claude Code](https://claude.ai/code/session_01BDrWhBKtUtLY8LWM83tnaT)_