### PR TITLE
Move test orchestration from shell into Buck

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -205,11 +205,12 @@ jobs:
         run: scripts/ci-timed "linux-x64 build" -- ./buck2 build //crates/...
 
       - name: Run complete target-independent premerge suite
-        # CLI and spec are sharded onto explicit Linux jobs. The omission audit
-        # proves those are the only deferred targets.
+        # RUE-1163: the corpora with their own platform-corpus job carry the
+        # `rue_ci_dedicated_lane` label in BUCK, and test.sh subtracts that label
+        # when CI=true. This step no longer names them: the CI-contract job
+        # fails if the labeled set and the platform-corpus matrix disagree.
         env:
           RUE_TEST_TIER: premerge
-          RUE_CI_DEFER_HEAVY_SUITES: '//:cli-tests //:spec-tests'
         run: scripts/ci-timed "linux-x64 premerge" -- ./test.sh
 
       - name: Run explicit cross-backend compilation and encoding coverage

--- a/BUCK
+++ b/BUCK
@@ -78,6 +78,7 @@ filegroup(
 filegroup(
     name = "examples",
     srcs = glob(["examples/**"]),
+    visibility = ["PUBLIC"],
 )
 
 # Syntax-valid, checked-in Rue programs compared by the independent stage-1
@@ -97,6 +98,10 @@ filegroup(
 filegroup(
     name = "cli-test-fixtures",
     srcs = glob(["cli-test-fixtures/**"]),
+    # RUE-1163: also reached by the //crates/rue-cli-tests:cli developer entry
+    # point, which carries the corpus's declared inputs so a filtered run needs
+    # no shell to plumb them.
+    visibility = ["PUBLIC"],
 )
 
 # A deliberately adversarial multi-module project used to assert that Rue's
@@ -117,6 +122,9 @@ filegroup(
 filegroup(
     name = "tutorial-snippet-tool-inputs",
     srcs = [
+        # RUE-1163: BUCK is an input because the gate membership the tool test
+        # checks lives in //:repository-quality-gates now, not in a bash array.
+        "BUCK",
         "scripts/check-tutorial-snippets.py",
         "test.sh",
     ],
@@ -521,6 +529,20 @@ rue_sh_test(
         "PYTHONDONTWRITEBYTECODE": "1",
         "RUE_TUTORIAL_TEST_ROOT": "$(location :tutorial-snippet-tool-inputs)",
     },
+)
+
+# RUE-1163: the lightweight repository gates a filtered `./test.sh <pattern>`
+# run executes after the corpora. This used to be a bash array of four target
+# names; as a test_suite the membership is a Buck fact, and adding a gate here
+# reaches every caller without editing a script.
+rue_test_suite(
+    name = "repository-quality-gates",
+    tests = [
+        ":adr-registry-validation",
+        ":spec-traceability",
+        ":tutorial-snippet-tests",
+        ":tutorial-snippet-tool-tests",
+    ],
 )
 
 rue_sh_test(

--- a/BUCK
+++ b/BUCK
@@ -233,7 +233,14 @@ _CLI_TEST_ABSOLUTIZE = [
 # test executor's timeout, which scripts/ci-heavy-suite used to pass and a build
 # action does not get; the per-case contracts in execution_contracts.toml remain
 # the honest gates. Re-tighten when the per-case budgets come back down.
-_CLI_TESTS_TIMEOUT_SECONDS = 1800
+#
+# RUE-1163: these must cover the correctness deadline
+# scripts/cli-timeout-policy.py derives from the same measured weights, on every
+# platform in shard-weights.json — an action bound that cuts inside it kills
+# healthy runs. //:cli-tests sat at 1800s against a 3600s derived deadline (and
+# a 2203s measured expected cost) until //:cli-timeout-policy-validation started
+# comparing the two.
+_CLI_TESTS_TIMEOUT_SECONDS = 3700
 _CLI_SHARD_TIMEOUT_SECONDS = 1200
 
 # The bounded premerge CLI corpus in one invocation: the canonical target that a
@@ -707,6 +714,13 @@ rue_sh_test(
         "$(location //crates/rue-cli-tests:cases)/cases/execution_contracts.toml",
         "--weights",
         "$(location //crates/rue-cli-tests:shard-weights)",
+        # RUE-1163: a corpus action gets no test-executor timeout, so the
+        # `timeout_seconds` spelled here is the only bound on a wedged harness.
+        # Declaring this file as an input makes the two sources of truth fail
+        # closed when they disagree, instead of a static number silently
+        # tightening below the deadline the policy derives.
+        "--buck",
+        "$(location :root-buck-file)/BUCK",
     ],
 )
 

--- a/BUCK
+++ b/BUCK
@@ -39,6 +39,9 @@ load(":corpus.bzl", "cached_corpus_suite")
 sh_binary(
     name = "corpus-action",
     main = "scripts/corpus-action",
+    # RUE-1163: corpora outside the root package (the RUE-205/RUE-204 oracle
+    # differentials) run through the same wrapper.
+    visibility = ["PUBLIC"],
 )
 
 sh_binary(
@@ -250,15 +253,23 @@ cached_corpus_suite(
 # Exhaustive behavior for declarative `tier = "slow"` CLI sections. This is a
 # separate real Buck target, not a skipped body: standard/full local runs and
 # scheduled release coverage execute it, while required premerge shards do not.
-rue_sh_test(
+# RUE-1163: the last corpus still carrying a test-executor timeout. Its bound
+# came from `scripts/cli-timeout-policy.py` invoked at run time inside
+# scripts/ci-heavy-suite; for this target the tool returns a fixed slow-suite
+# guard rather than a weight-derived value, so stating it here loses no
+# derivation and removes the last per-target branch from that script. The
+# per-case budgets in execution_contracts.toml remain the honest gates.
+cached_corpus_suite(
     name = "cli-tests-slow",
     tier = "slow",
     labels = ["rue_heavy_suite"],
-    test = "//crates/rue-cli-tests:rue-cli-tests",
+    harness = "//crates/rue-cli-tests:rue-cli-tests",
     args = ["--quiet"],
     env = dict(_CLI_TEST_BASE_ENV.items() + [
         ("RUE_CLI_CASE_TIER", "slow"),
     ]),
+    absolutize = _CLI_TEST_ABSOLUTIZE,
+    timeout_seconds = 7200,
 )
 
 # Required release coverage is deliberately bounded: compile the real driver
@@ -371,22 +382,41 @@ CLI_TEST_SHARD_COUNT = 4
 # RUE-1083: `examples/` is a declared input because this suite now also checks a
 # real maintained program (rill) for byte-stable output, not just the
 # purpose-built fixture. An edit under examples/ must therefore re-run it.
-rue_sh_test(
-    # RUE-1118: still a plain sh_test, so it re-runs on every invocation. Its
-    # harness is a shell script rather than a target, and unlike the corpus
-    # harnesses it reads repository paths directly rather than through declared
-    # env inputs — the input contract cached_corpus_suite depends on has to be
-    # established before caching this one would be sound rather than a false
-    # pass. It is also off the merge queue's critical path.
+#
+# RUE-1163: converted to a cached action. RUE-1118 left it out on the grounds
+# that it "reads repository paths directly rather than through declared env
+# inputs"; that is no longer true of the current script, which guards all four
+# of its inputs with `${VAR:?}` and reads nothing else from the checkout. Its
+# only relative path (`../sources.manifest`) resolves inside the temporary copy
+# of RUE_REPRO_FIXTURE.
+#
+# Caching a suite whose subject IS determinism deserves a note: a cache hit
+# replays a proof rather than re-running it, so a compiler that became
+# nondeterministic only intermittently would not be caught by a replayed run.
+# That is the same bargain every corpus here takes, and RUE-1159's repetition
+# workflow — which exists for exactly that class — already runs cache-free.
+sh_binary(
+    name = "reproducible-programs-harness",
+    main = "scripts/test-reproducible-output.sh",
+)
+
+cached_corpus_suite(
     name = "reproducible-programs",
     labels = ["rue_heavy_suite"],
-    test = "scripts/test-reproducible-output.sh",
+    harness = ":reproducible-programs-harness",
     env = {
         "RUE_BINARY": "$(exe_target //crates/rue:rue)",
         "RUE_EXAMPLES_DIR": "$(location :examples)/examples",
         "RUE_REPRO_FIXTURE": "$(location :reproducibility-fixture)/reproducibility/fixture",
         "RUE_STD_DIR": "$(location :std)/std",
     },
+    absolutize = [
+        "RUE_BINARY",
+        "RUE_EXAMPLES_DIR",
+        "RUE_REPRO_FIXTURE",
+        "RUE_STD_DIR",
+    ],
+    timeout_seconds = 1800,
 )
 
 # The independent stage-1 frontend differential: compile `examples/ruelex` with
@@ -401,15 +431,26 @@ rue_sh_test(
 # and inside the broad `--exclude rue_heavy_suite` pass, contending with every
 # other test on the runner. Heavy-labeled at the root, it runs alone through
 # scripts/ci-heavy-suite like every peer corpus harness.
-rue_sh_test(
+# RUE-1163: converted to a cached action. Every path this harness reads arrives
+# through a declared env input (`RUE_BINARY`, `RUE_FRONTEND_DIFF_CORPUS`,
+# `RUE_STD_PATH`); the source-relative fallbacks in its `main` apply only when a
+# variable is unset, which cannot happen here. The corpus filegroup enumerates
+# its members explicitly, so a new corpus file changes the action's digest.
+cached_corpus_suite(
     name = "frontend-diff-test",
     labels = ["rue_heavy_suite"],
-    test = "//crates/rue-frontend-diff:rue-frontend-diff",
+    harness = "//crates/rue-frontend-diff:rue-frontend-diff",
     env = {
         "RUE_BINARY": "$(exe_target //crates/rue:rue)",
         "RUE_FRONTEND_DIFF_CORPUS": "$(location :frontend-diff-corpus)",
         "RUE_STD_PATH": "$(location :std)/std",
     },
+    absolutize = [
+        "RUE_BINARY",
+        "RUE_FRONTEND_DIFF_CORPUS",
+        "RUE_STD_PATH",
+    ],
+    timeout_seconds = 900,
 )
 
 # A fixed generated differential corpus in every full test run. The generator
@@ -417,19 +458,32 @@ rue_sh_test(
 # shape; this target then compiles and runs those programs through both the
 # reference oracle and native codegen. It lives at the root so full/no-argument
 # `test.sh` and CI include it while `quick-test.sh` remains unit-only.
-rue_sh_test(
-    # RUE-1118: still a plain sh_test, for the same reason as
-    # //:reproducible-programs above.
+sh_binary(
+    name = "oracle-diff-generated-smoke-harness",
+    main = "scripts/oracle-diff-generated-smoke.sh",
+)
+
+# RUE-1163: a cached action. Both binaries arrive through declared `$(exe_target
+# ...)` inputs and the script reads nothing else; the seed range is fixed, so
+# the run is a pure function of its inputs. Caching also stops the fixed
+# two-second per-child budget from being re-rolled on every invocation — a
+# timeout-only flake under parallel load no longer recurs once the tree has
+# passed (AGENTS.md documents that failure mode).
+cached_corpus_suite(
     name = "oracle-diff-generated-smoke",
     labels = ["rue_heavy_suite"],
-    test = "scripts/oracle-diff-generated-smoke.sh",
+    harness = ":oracle-diff-generated-smoke-harness",
     env = {
         "RUE_BINARY": "$(exe_target //crates/rue:rue)",
         "RUE_ORACLE_DIFF_BINARY": "$(exe_target //crates/rue-oracle-diff:rue-oracle-diff)",
     },
+    absolutize = [
+        "RUE_BINARY",
+        "RUE_ORACLE_DIFF_BINARY",
+    ],
     # Preserve enough outer margin for the harness to print all structured
     # findings even if every compiler and native phase consumes its 2s budget.
-    test_rule_timeout_ms = 600000,
+    timeout_seconds = 600,
 )
 
 rue_sh_test(

--- a/BUCK
+++ b/BUCK
@@ -141,9 +141,17 @@ filegroup(
     srcs = [".github/workflows/ci.yml"],
 )
 
+# RUE-1163: `rue_ci_dedicated_lane` marks a corpus that required CI schedules in
+# its own platform-corpus job, so the linux-premerge job's ./test.sh must not
+# also run it. It replaces the RUE_CI_DEFER_HEAVY_SUITES environment protocol,
+# which named the same two targets in ci.yml and made test.sh re-derive and
+# cross-check them against a label query in bash. The set is a Buck fact now,
+# and scripts/validate-ci-gate.py fails if it and the workflow's matrix disagree
+# — in either direction, so a corpus given the label without a job would be
+# caught as surely as one dropped from the matrix.
 cached_corpus_suite(
     name = "spec-tests",
-    labels = ["rue_heavy_suite"],
+    labels = ["rue_heavy_suite", "rue_ci_dedicated_lane"],
     harness = "//crates/rue-spec:rue-spec",
     args = ["--quiet"],
     env = {
@@ -249,7 +257,7 @@ _CLI_SHARD_TIMEOUT_SECONDS = 1200
 # automatic examples are registered by //:cli-tests-slow instead.
 cached_corpus_suite(
     name = "cli-tests",
-    labels = ["rue_heavy_suite"],
+    labels = ["rue_heavy_suite", "rue_ci_dedicated_lane"],
     harness = "//crates/rue-cli-tests:rue-cli-tests",
     args = _CLI_TEST_ARGS,
     env = _CLI_TEST_ENV,
@@ -665,6 +673,11 @@ rue_sh_test(
         # coverage to cases no lane executes.
         "--test-runner-source",
         "$(location //crates/rue-test-runner:platform-responsibility-source)/src/lib.rs",
+        # RUE-1163: which corpora own a required-CI job is a BUCK label now, so
+        # the gate reads BUCK to prove each labeled corpus is actually run by a
+        # platform-corpus entry.
+        "--buck",
+        "$(location :root-buck-file)/BUCK",
     ],
     resources = [
         "scripts/ci-required-results.py",
@@ -684,6 +697,7 @@ rue_sh_test(
         "PYTHONDONTWRITEBYTECODE": "1",
         "RUE_CI_WORKFLOW": "$(location :required-ci-workflows)/.github/workflows/ci.yml",
         "RUE_TEST_RUNNER_SOURCE": "$(location //crates/rue-test-runner:platform-responsibility-source)/src/lib.rs",
+        "RUE_ROOT_BUCK": "$(location :root-buck-file)/BUCK",
     },
 )
 

--- a/crates/rue-cli-tests/BUCK
+++ b/crates/rue-cli-tests/BUCK
@@ -36,3 +36,20 @@ filegroup(
     srcs = ["cases/deep_nesting.toml"],
     visibility = ["PUBLIC"],
 )
+
+# RUE-1163: the developer entry point. RUE_CLI_CASE_TIER is deliberately unset,
+# which the harness reads as `all`: a developer filtering by name wants every
+# tier's cases, where //:cli-tests bounds itself to the premerge inventory.
+command_alias(
+    name = "cli",
+    exe = ":rue-cli-tests",
+    env = {
+        "RUE_BINARY": "$(exe_target //crates/rue:rue)",
+        "RUE_CLI_CASES": "$(location :cases)/cases",
+        "RUE_EXAMPLES_DIR": "$(location root//:examples)/examples",
+        "RUE_REPO_DIR": "$(location root//:cli-test-fixtures)",
+        "RUE_STD_DIR": "$(location root//:std)/std",
+    },
+    visibility = ["PUBLIC"],
+)
+

--- a/crates/rue-oracle-diff/BUCK
+++ b/crates/rue-oracle-diff/BUCK
@@ -1,5 +1,5 @@
 load("//crates:defs.bzl", "rue_binary")
-load("//:test_defs.bzl", "rue_sh_test")
+load("//:corpus.bzl", "cached_corpus_suite")
 
 # The differential harness. Two modes:
 #  * default: runs the concrete rue-cli-tests corpus through the rue-oracle
@@ -48,7 +48,11 @@ rue_binary(
 # violations fail the harness; only typed model gaps remain coverage debt.
 # Preview-gated cases run when their declared preview flags can be mapped onto
 # the single-source oracle.
-rue_sh_test(
+# RUE-1163: a cached action like its peer corpora. Both inputs reach the harness
+# through declared env paths, and it drives the reference interpreter in-process
+# rather than spawning the compiler, so the cases filegroup and std/ are the
+# whole contract.
+cached_corpus_suite(
     name = "oracle-diff-test",
     tier = "slow",
     # RUE-1117: `rue_heavy_suite` gives the differential the same execution
@@ -56,11 +60,16 @@ rue_sh_test(
     # `scripts/ci-heavy-suite` (which fails closed if Buck reports no result for
     # it), and exclusion from any broad pass that would otherwise absorb it.
     labels = ["rue_not_quick", "rue_heavy_suite"],
-    test = ":rue-oracle-diff",
+    harness = ":rue-oracle-diff",
     env = {
         "RUE_ORACLE_DIFF_CASES": "$(location //crates/rue-cli-tests:cases)/cases",
         "RUE_ORACLE_DIFF_STD": "$(location root//:std)/std",
     },
+    absolutize = [
+        "RUE_ORACLE_DIFF_CASES",
+        "RUE_ORACLE_DIFF_STD",
+    ],
+    timeout_seconds = 3600,
 )
 
 # The same differential over the rue-spec corpus (RUE-204). Runs the harness in
@@ -69,14 +78,19 @@ rue_sh_test(
 # are expanded via rue-test-runner; golden-IR-only / compile-fail cases are
 # skipped by the harness, not counted as disagreements. Preview-gated cases run
 # with their declared preview feature.
-rue_sh_test(
+cached_corpus_suite(
     name = "oracle-diff-spec-test",
     tier = "slow",
     labels = ["rue_not_quick", "rue_heavy_suite"],
-    test = ":rue-oracle-diff",
+    harness = ":rue-oracle-diff",
     args = ["spec"],
     env = {
         "RUE_ORACLE_DIFF_SPEC_CASES": "$(location //crates/rue-spec:cases)/cases",
         "RUE_ORACLE_DIFF_STD": "$(location root//:std)/std",
     },
+    absolutize = [
+        "RUE_ORACLE_DIFF_SPEC_CASES",
+        "RUE_ORACLE_DIFF_STD",
+    ],
+    timeout_seconds = 3600,
 )

--- a/crates/rue-spec/BUCK
+++ b/crates/rue-spec/BUCK
@@ -16,3 +16,18 @@ filegroup(
     srcs = glob(["cases/**"]),
     visibility = ["PUBLIC"],
 )
+
+# RUE-1163: the developer entry point. Carrying the corpus's declared inputs as
+# `env` here means a filtered run needs no shell to plumb them, and cannot drift
+# from what //:spec-tests runs — `./test.sh <pattern>` used to set a different
+# (smaller) set by hand.
+command_alias(
+    name = "spec",
+    exe = ":rue-spec",
+    env = {
+        "RUE_BINARY": "$(exe_target //crates/rue:rue)",
+        "RUE_REAL_STD_PATH": "$(location root//:std)/std",
+        "RUE_SPEC_CASES": "$(location :cases)/cases",
+    },
+    visibility = ["PUBLIC"],
+)

--- a/crates/rue-ui-tests/BUCK
+++ b/crates/rue-ui-tests/BUCK
@@ -18,3 +18,16 @@ filegroup(
     srcs = glob(["cases/**"]),
     visibility = ["PUBLIC"],
 )
+
+# RUE-1163: the developer entry point, carrying the same declared inputs as
+# //:ui-tests so a filtered run cannot drift from the corpus.
+command_alias(
+    name = "ui",
+    exe = ":rue-ui-tests",
+    env = {
+        "RUE_BINARY": "$(exe_target //crates/rue:rue)",
+        "RUE_REAL_STD_PATH": "$(location root//:std)/std",
+        "RUE_UI_CASES": "$(location :cases)/cases",
+    },
+    visibility = ["PUBLIC"],
+)

--- a/scripts/ci-heavy-suite
+++ b/scripts/ci-heavy-suite
@@ -1,38 +1,36 @@
 #!/usr/bin/env bash
-# Run one explicitly assigned CI heavy suite and fail if Buck omits its result.
+# Run one named corpus suite.
 set -uo pipefail
 
 # Heavy suites live at the repository root (//:cli-tests) and, since RUE-1117,
-# in owning crate packages (//crates/rue-oracle-diff:oracle-diff-test). The
-# `rue_heavy_suite` label below — not the package path — is what decides whether
-# a target may run here, so this check only rejects a spelling Buck cannot
-# resolve to a single target in this cell.
+# in owning crate packages (//crates/rue-oracle-diff:oracle-diff-test), so this
+# only rejects a spelling that is not a target label at all.
 if [[ $# -ne 1 || "$1" != //*:* ]]; then
     echo "usage: scripts/ci-heavy-suite //PACKAGE:TARGET" >&2
     exit 2
 fi
 target="$1"
 
-if ! heavy_suites="$(./buck2 uquery 'attrfilter(labels, rue_heavy_suite, //...)')"; then
-    echo "error: failed to query rue_heavy_suite targets" >&2
-    exit 1
-fi
-if ! grep -Fxq "root$target" <<<"$heavy_suites"; then
-    echo "error: CI shard target is not labeled rue_heavy_suite: $target" >&2
-    exit 1
-fi
+# RUE-1163 removed two checks that used to live here, both of which had shell
+# deciding what Buck already decides:
+#
+#   * a `buck2 uquery` of the rue_heavy_suite label, grepped to confirm the
+#     argument was a heavy suite. Membership now comes from
+#     //test_tiers.bxl:heavy_suites, which is what produces this argument in the
+#     first place, and an argument naming no target fails in buck2 below.
+#   * a grep of the run's output for a `<Status>: root<target>` line, to catch a
+#     suite that silently never ran. Every corpus is a build action whose stamp
+#     its test asserts, so buck2 exiting 0 for a named target means that corpus
+#     passed; there is no longer a path where it exits 0 having run nothing.
+#
+# What remains is genuinely per-run plumbing that Buck has no opinion about.
 
-log="$(mktemp "${RUNNER_TEMP:-${TMPDIR:-/tmp}}/rue-ci-heavy-suite.XXXXXX")"
-cleanup() {
-    rm -f "$log"
-}
-trap cleanup EXIT
-
-# RUE-1118/RUE-1163: every corpus now runs as a cacheable build action, and the
-# test executor only asserts the action's stamp — a sub-second check whatever
-# the corpus costs. An executor `--timeout` would bound the wrong thing, so
-# each suite's timeout_seconds in BUCK bounds the action that does the work.
-# The per-case budgets in execution_contracts.toml remain the honest gates.
+# RUE-1118/RUE-1163: every corpus runs as a cacheable build action, and the test
+# executor only asserts the action's stamp — a sub-second check whatever the
+# corpus costs. An executor `--timeout` would bound the wrong thing, so each
+# suite's timeout_seconds in BUCK bounds the action that does the work, checked
+# against the declarative policy by //:cli-timeout-policy-validation. The
+# per-case budgets in execution_contracts.toml remain the honest gates.
 test_args=("$target")
 
 # RUE-1158 shard weights. The measurements are a declared output of the corpus
@@ -54,8 +52,8 @@ if [[ -n "${RUE_CORRECTNESS_REPETITION:-}" ]]; then
     test_args+=(--env "RUE_CORRECTNESS_REPETITION=$RUE_CORRECTNESS_REPETITION")
 fi
 
-./buck2 test "${test_args[@]}" 2>&1 | tee "$log"
-status=${PIPESTATUS[0]}
+./buck2 test "${test_args[@]}"
+status=$?
 if [[ "$status" -ne 0 ]]; then
     exit "$status"
 fi
@@ -71,12 +69,7 @@ if [[ -n "$timings" ]]; then
         echo "cli-tests: measured $timing_cases cases in $timings"
     else
         # Not fatal: the artifact upload is `if-no-files-found: ignore`, and the
-        # suite's own Buck result below remains the required signal.
+        # suite's own Buck result remains the required signal.
         echo "cli-tests: no case timings produced for $target" >&2
     fi
-fi
-
-if ! grep -qE "(Pass|Fail|Skip|Timeout|Fatal|Omit|Flaky): root${target} " "$log"; then
-    echo "error: explicit CI shard produced no result for $target" >&2
-    exit 1
 fi

--- a/scripts/ci-heavy-suite
+++ b/scripts/ci-heavy-suite
@@ -28,13 +28,11 @@ cleanup() {
 }
 trap cleanup EXIT
 
-# RUE-1118: the converted corpora run as cacheable build actions, and the test
-# executor only asserts the action's stamp — a sub-second check whatever the
-# corpus costs. An executor `--timeout` would therefore bound the wrong thing;
+# RUE-1118/RUE-1163: every corpus now runs as a cacheable build action, and the
+# test executor only asserts the action's stamp — a sub-second check whatever
+# the corpus costs. An executor `--timeout` would bound the wrong thing, so
 # each suite's timeout_seconds in BUCK bounds the action that does the work.
-# //:cli-tests-slow is NOT converted, so it keeps the declarative policy from
-# RUE-1159. The per-case budgets in execution_contracts.toml remain the honest
-# gates for both.
+# The per-case budgets in execution_contracts.toml remain the honest gates.
 test_args=("$target")
 
 # RUE-1158 shard weights. The measurements are a declared output of the corpus
@@ -45,17 +43,6 @@ timings=""
 if [[ "$target" == //:cli-tests-shard-* ]]; then
     timings="${RUNNER_TEMP:-${TMPDIR:-/tmp}}/rue-cli-case-timings.jsonl"
 fi
-
-case "$target" in
-    //:cli-tests-slow)
-        timeout_tool="${RUE_CLI_TIMEOUT_POLICY_TOOL:-scripts/cli-timeout-policy.py}"
-        timeout="$("$timeout_tool" \
-            --policy "${RUE_CLI_TIMEOUT_POLICY:-crates/rue-cli-tests/cases/execution_contracts.toml}" \
-            --weights "${RUE_CLI_SHARD_WEIGHTS:-crates/rue-cli-tests/shard-weights.json}" \
-            --target "$target")" || exit $?
-        test_args+=(-- --timeout "$timeout")
-        ;;
-esac
 
 # RUE-1159 repeats a shard to expose flakes, which only works if each repetition
 # actually executes. A cached corpus action would serve repetitions 2..N from the

--- a/scripts/cli-timeout-policy.py
+++ b/scripts/cli-timeout-policy.py
@@ -127,6 +127,62 @@ def timeout_for_target(
     raise ValueError(f"no CLI timeout policy for target {target}")
 
 
+# RUE-1163: the corpus actions' outer bounds, as spelled in the root BUCK file.
+# A corpus runs as a build action now, which gets no test-executor timeout, so
+# `timeout_seconds` is the only thing that stops a wedged harness — and it must
+# not cut inside the declarative correctness deadline this tool derives. Nothing
+# connected the two until this check: RUE-1118 gave //:cli-tests a 1800s action
+# bound while the policy allowed 3600s, so a healthy run could be killed.
+BUCK_TIMEOUT_PATTERNS = {
+    "//:cli-tests": re.compile(r"^_CLI_TESTS_TIMEOUT_SECONDS = (\d+)$", re.MULTILINE),
+    "//:cli-tests-shard-0": re.compile(
+        r"^_CLI_SHARD_TIMEOUT_SECONDS = (\d+)$", re.MULTILINE
+    ),
+    "//:cli-tests-slow": re.compile(
+        r'name = "cli-tests-slow".*?timeout_seconds = (\d+)', re.DOTALL
+    ),
+}
+
+
+def buck_timeouts(buck_path: Path) -> dict[str, int]:
+    """The action bounds the root BUCK file declares, keyed by target."""
+    text = buck_path.read_text()
+    found = {}
+    for target, pattern in BUCK_TIMEOUT_PATTERNS.items():
+        match = pattern.search(text)
+        if not match:
+            raise ValueError(f"{buck_path}: no action timeout found for {target}")
+        found[target] = int(match.group(1))
+    return found
+
+
+def check_buck_timeouts(
+    buck_path: Path, weights_path: Path, policy: dict[str, int]
+) -> list[str]:
+    """Report action bounds that cut inside the derived correctness deadline.
+
+    Every platform in the weights file is checked, because the BUCK value is one
+    static number while the derived deadline is per-platform: a bound that is
+    generous on the fastest runner and short on the slowest is still a bound
+    that kills healthy runs.
+    """
+    platforms = sorted(json.loads(weights_path.read_text()).get("platforms", {}))
+    errors = []
+    for target, declared_seconds in buck_timeouts(buck_path).items():
+        for platform_name in platforms:
+            required_ms, _ = timeout_for_target(
+                target, weights_path, platform_name, policy
+            )
+            required_seconds = math.ceil(required_ms / 1000)
+            if declared_seconds < required_seconds:
+                errors.append(
+                    f"{target}: BUCK bounds the corpus action at {declared_seconds}s, "
+                    f"inside the {required_seconds}s correctness deadline the policy "
+                    f"derives for {platform_name}. A healthy run would be killed."
+                )
+    return errors
+
+
 def main() -> int:
     parser = argparse.ArgumentParser()
     parser.add_argument(
@@ -139,10 +195,24 @@ def main() -> int:
     )
     parser.add_argument("--platform", default=host_platform())
     parser.add_argument("--target")
+    parser.add_argument(
+        "--buck",
+        type=Path,
+        help="root BUCK file whose corpus action bounds must cover the "
+        "derived correctness deadlines",
+    )
     args = parser.parse_args()
     try:
         _, policy = load_policy(args.policy)
         if args.target is None:
+            if args.buck is not None:
+                errors = check_buck_timeouts(args.buck, args.weights, policy)
+                if errors:
+                    for error in errors:
+                        print(f"error: {error}", file=sys.stderr)
+                    return 1
+                print("CLI timeout policy valid; corpus action bounds cover it")
+                return 0
             print("CLI timeout policy valid")
             return 0
         timeout_ms, expected_ms = timeout_for_target(

--- a/scripts/rue
+++ b/scripts/rue
@@ -159,22 +159,20 @@ case "$cmd" in
         ./buck2 run "$target" -- "$@" || rc=$?
         exit $rc
         ;;
+    # RUE-1163: each harness's declared inputs live on a command_alias in its
+    # own BUCK file, so these are passthroughs. They used to set a hand-written
+    # subset of the corpus environment here, which had already drifted: neither
+    # spec nor ui passed RUE_REAL_STD_PATH, so `real_std` cases resolved the
+    # standard library through a cwd-relative fallback rather than the declared
+    # input the equivalent Buck target uses.
     spec)
-        RUE_BINARY="$(scripts/rue-bin)" \
-        RUE_SPEC_CASES="crates/rue-spec/cases" \
-        ./buck2 run //crates/rue-spec:rue-spec -- "$@"
+        ./buck2 run //crates/rue-spec:spec -- "$@"
         ;;
     cli)
-        RUE_BINARY="$(scripts/rue-bin)" \
-        RUE_CLI_CASES="crates/rue-cli-tests/cases" \
-        RUE_EXAMPLES_DIR="$repo_root/examples" \
-        RUE_STD_DIR="std" \
-        ./buck2 run //crates/rue-cli-tests:rue-cli-tests -- "$@"
+        ./buck2 run //crates/rue-cli-tests:cli -- "$@"
         ;;
     ui)
-        RUE_BINARY="$(scripts/rue-bin)" \
-        RUE_UI_CASES="crates/rue-ui-tests/cases" \
-        ./buck2 run //crates/rue-ui-tests:rue-ui-tests -- "$@"
+        ./buck2 run //crates/rue-ui-tests:ui -- "$@"
         ;;
     frontend-manifest)
         corpus_output="$(./buck2 build root//:frontend-diff-corpus --show-simple-output)"

--- a/scripts/test-build-sharing.sh
+++ b/scripts/test-build-sharing.sh
@@ -265,44 +265,33 @@ EOF
     cat >"$sb/buck2" <<'EOF'
 #!/usr/bin/env bash
 printf '%s\n' "$*" >>"$BUCK_LOG"
-if [[ "${1:-}" == "uquery" ]]; then
-    # RUE-1116: test.sh subtracts the rue_cli_shard set from heavy-suite
-    # discovery; this baseline fixture defines no CLI shards.
-    if [[ "$*" == *rue_cli_shard* ]]; then
-        :
-    else
-        printf '%s\n' \
-            root//:cli-tests \
-            root//:cli-tests-slow \
-            root//crates/rue-oracle-diff:oracle-diff-test \
-            root//crates/rue-oracle-diff:oracle-diff-spec-test \
-            root//:frontend-diff-test \
-            root//:oracle-diff-generated-smoke \
-            root//:reproducible-programs \
-            root//:spec-tests \
-            root//:ui-tests
-    fi
+if [[ "${1:-}" == "bxl" ]]; then
+    # RUE-1163: heavy-suite membership comes from the BXL selector, not from a
+    # label uquery filtered in bash.
+    case "${2:-}" in
+        *:validate) printf 'Rue test tiers valid\n' ;;
+        *:heavy_suites)
+            printf '%s\n' \
+                //:cli-tests \
+                //:cli-tests-slow \
+                //crates/rue-oracle-diff:oracle-diff-test \
+                //crates/rue-oracle-diff:oracle-diff-spec-test \
+                //:frontend-diff-test \
+                //:oracle-diff-generated-smoke \
+                //:reproducible-programs \
+                //:spec-tests \
+                //:ui-tests
+            ;;
+    esac
 elif [[ "${1:-}" == "test" ]]; then
-    # Emit buck2's per-test result line so the RUE-924 corpus-omission audit
-    # in test.sh sees each required harness actually ran. The heavy-labeled
-    # corpus suites arrive one at a time through ci-heavy-suite; the
-    # non-heavy tutorial-snippet-tests runs inside the broad "test //..." pass.
-    if [[ "${2:-}" == "//..." ]]; then
-        printf 'Pass: root//:tutorial-snippet-tests (0.0s)\n'
-        printf 'Pass: root//:large-example-caldera-canary (0.0s)\n'
-        printf 'Pass: root//:large-example-meridian-canary (0.0s)\n'
-    elif [[ "${2:-}" == //*:* ]]; then
-        printf 'Pass: root%s (0.0s)\n' "${2:-}"
-    else
-        printf 'Pass: %s (0.0s)\n' "${2:-}"
-    fi
+    printf 'Pass: %s (0.0s)\n' "${2:-}"
 fi
 EOF
     chmod +x "$sb/buck2"
     # The required macOS job sets this variable for its outer test.sh. Keep
     # this fixture's baseline full-suite contract independent of that caller
     # environment; deferral behavior has its own focused tests.
-    out="$(BUCK_LOG="$sb/calls" RUE_CI_DEFER_HEAVY_SUITES= \
+    out="$(BUCK_LOG="$sb/calls" \
         RUE_FULL_SUITE_LOCK_DIR="$sb/lock" "$sb/test.sh" 2>&1)" || rc=$?
     if [[ "$rc" -ne 0 ]]; then
         printf '%s\n' "$out" >&2
@@ -310,8 +299,8 @@ EOF
     check "suite: unfiltered orchestration succeeds" "$([ "$rc" -eq 0 ] && echo 0 || echo 1)"
     check "suite: broad discovery excludes opaque heavy tests" \
         "$(grep -Fxq 'test //... toolchains//... --exclude rue_heavy_suite --always-exclude --ignore-tests-attribute --exclude rue_test_tier_stress' "$sb/calls" && echo 0 || echo 1)"
-    check "suite: heavy targets are discovered from the live graph" \
-        "$(grep -Fxq 'uquery attrfilter(labels, rue_heavy_suite, //...)' "$sb/calls" && echo 0 || echo 1)"
+    check "suite: heavy targets come from the canonical Buck selector" \
+        "$(grep -Fq 'bxl //test_tiers.bxl:heavy_suites' "$sb/calls" && echo 0 || echo 1)"
     # RUE-1118/RUE-1163: every corpus is now invoked bare. Each runs as a
     # cacheable build action and the test executor only asserts its stamp, so an
     # executor timeout here would bound a sub-second check while reading as if

--- a/scripts/test-build-sharing.sh
+++ b/scripts/test-build-sharing.sh
@@ -312,18 +312,17 @@ EOF
         "$(grep -Fxq 'test //... toolchains//... --exclude rue_heavy_suite --always-exclude --ignore-tests-attribute --exclude rue_test_tier_stress' "$sb/calls" && echo 0 || echo 1)"
     check "suite: heavy targets are discovered from the live graph" \
         "$(grep -Fxq 'uquery attrfilter(labels, rue_heavy_suite, //...)' "$sb/calls" && echo 0 || echo 1)"
-    # RUE-1118: every converted corpus is now invoked bare. The corpus runs as a
+    # RUE-1118/RUE-1163: every corpus is now invoked bare. Each runs as a
     # cacheable build action and the test executor only asserts its stamp, so an
     # executor timeout here would bound a sub-second check while reading as if
     # the corpus were still bounded; the real outer bound is each suite's
-    # timeout_seconds in BUCK. //:cli-tests-slow is not converted, so it keeps
-    # the RUE-1159 declarative timeout and is the only target that carries one.
-    check "suite: slow CLI corpus receives the declarative executor timeout" \
-        "$(grep -Fxq 'test //:cli-tests-slow -- --timeout 7200' "$sb/calls" && echo 0 || echo 1)"
-    check "suite: no converted corpus receives an executor timeout" \
-        "$([ "$(grep -Ec -- '^test //:(cli-tests|spec-tests|ui-tests|cli-tests-shard-[0-9]+) -- --timeout' "$sb/calls")" -eq 0 ] && echo 0 || echo 1)"
-    check "suite: every other heavy target is invoked bare, exactly once" \
-        "$([ "$(grep -Ec '^test //:(cli-tests|spec-tests|ui-tests|oracle-diff-generated-smoke|reproducible-programs|frontend-diff-test)$' "$sb/calls")" -eq 6 ] && echo 0 || echo 1)"
+    # timeout_seconds in BUCK. No corpus is exempt any more, so this asserts the
+    # absence of an executor timeout on every one of them rather than naming the
+    # converted subset.
+    check "suite: no corpus receives an executor timeout" \
+        "$([ "$(grep -Ec -- '^test //(crates/[a-z-]+)?:[a-z0-9-]+ -- --timeout' "$sb/calls")" -eq 0 ] && echo 0 || echo 1)"
+    check "suite: every heavy target is invoked bare, exactly once" \
+        "$([ "$(grep -Ec '^test //:(cli-tests|cli-tests-slow|spec-tests|ui-tests|oracle-diff-generated-smoke|reproducible-programs|frontend-diff-test)$' "$sb/calls")" -eq 7 ] && echo 0 || echo 1)"
     # RUE-1117: the codegen differentials are heavy suites in their owning
     # crate package, so a local full run executes them one at a time too.
     check "suite: crate-package heavy suites are executed individually" \

--- a/scripts/test-cli-timeout-policy.py
+++ b/scripts/test-cli-timeout-policy.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 import importlib.util
+import json
 import os
 import tempfile
 import tomllib
@@ -84,6 +85,61 @@ compile_timeout_ms=10
             path.write_text(text)
             with self.assertRaisesRegex(ValueError, "raw deadlines are forbidden"):
                 MODULE.load_policy(path)
+
+
+class BuckActionBoundTests(unittest.TestCase):
+    """RUE-1163: the BUCK action bounds must cover the derived deadlines."""
+
+    POLICY = {
+        "expected_cost_multiplier_percent": 100,
+        "fixed_headroom_ms": 0,
+        "minimum_shard_timeout_ms": 1000,
+        "minimum_monolith_timeout_ms": 2000,
+        "minimum_slow_suite_timeout_ms": 3000,
+    }
+
+    def fixture(self, directory, cli_seconds):
+        weights = Path(directory) / "shard-weights.json"
+        weights.write_text(
+            json.dumps(
+                {
+                    "version": 1,
+                    "default_ms": 1,
+                    "common": {"a": 1000, "b": 1000},
+                    "platforms": {"linux-x64": {}},
+                }
+            )
+        )
+        buck = Path(directory) / "BUCK"
+        buck.write_text(
+            f"_CLI_TESTS_TIMEOUT_SECONDS = {cli_seconds}\n"
+            "_CLI_SHARD_TIMEOUT_SECONDS = 9999\n"
+            'cached_corpus_suite(\n    name = "cli-tests-slow",\n'
+            "    timeout_seconds = 9999,\n)\n"
+        )
+        return buck, weights
+
+    def test_bound_covering_the_deadline_passes(self):
+        with tempfile.TemporaryDirectory() as directory:
+            buck, weights = self.fixture(directory, 9999)
+            self.assertEqual(
+                MODULE.check_buck_timeouts(buck, weights, self.POLICY), []
+            )
+
+    def test_bound_inside_the_deadline_is_reported(self):
+        with tempfile.TemporaryDirectory() as directory:
+            buck, weights = self.fixture(directory, 1)
+            errors = MODULE.check_buck_timeouts(buck, weights, self.POLICY)
+            self.assertEqual(len(errors), 1, errors)
+            self.assertIn("//:cli-tests", errors[0])
+            self.assertIn("A healthy run would be killed", errors[0])
+
+    def test_missing_bound_is_an_error_not_a_silent_pass(self):
+        with tempfile.TemporaryDirectory() as directory:
+            buck, weights = self.fixture(directory, 9999)
+            buck.write_text("# no timeouts here\n")
+            with self.assertRaisesRegex(ValueError, "no action timeout found"):
+                MODULE.check_buck_timeouts(buck, weights, self.POLICY)
 
 
 if __name__ == "__main__":

--- a/scripts/test-tutorial-snippets.py
+++ b/scripts/test-tutorial-snippets.py
@@ -199,10 +199,20 @@ class GateWiringTests(unittest.TestCase):
         self.assertEqual(process.returncode, 1)
         self.assertIn("could not start compiler", process.stderr)
 
-    def test_filtered_wrapper_lists_repository_quality_gates(self):
+    def test_filtered_wrapper_runs_the_repository_quality_gates(self):
+        # RUE-1163: the four gates moved from a bash array in test.sh into the
+        # //:repository-quality-gates test_suite. The contract is unchanged — a
+        # filtered run must still execute the tutorial gates — but it is now
+        # BUCK that says which targets those are, so assert both halves rather
+        # than grepping the script for target names.
         wrapper = (INPUT_ROOT / "test.sh").read_text()
-        self.assertIn("//:tutorial-snippet-tool-tests", wrapper)
-        self.assertIn("//:tutorial-snippet-tests", wrapper)
+        self.assertIn("//:repository-quality-gates", wrapper)
+
+        buck = (INPUT_ROOT / "BUCK").read_text()
+        suite = buck[buck.index('name = "repository-quality-gates"') :]
+        suite = suite[: suite.index(")")]
+        self.assertIn(":tutorial-snippet-tool-tests", suite)
+        self.assertIn(":tutorial-snippet-tests", suite)
 
 
 if __name__ == "__main__":

--- a/scripts/test-validate-ci-gate.py
+++ b/scripts/test-validate-ci-gate.py
@@ -15,10 +15,11 @@ SOURCE = Path(os.environ["RUE_CI_WORKFLOW"])
 TEST_RUNNER_SOURCE = Path(
     os.environ.get("RUE_TEST_RUNNER_SOURCE", MODULE.TEST_RUNNER_SOURCE)
 )
+ROOT_BUCK = Path(os.environ.get("RUE_ROOT_BUCK", MODULE.ROOT_BUCK))
 
 
 class GateValidatorTests(unittest.TestCase):
-    def validate_text(self, text, native_runner=None, test_runner=None):
+    def validate_text(self, text, native_runner=None, test_runner=None, buck=None):
         with tempfile.TemporaryDirectory() as directory:
             path = Path(directory) / "ci.yml"
             path.write_text(text)
@@ -34,11 +35,18 @@ class GateValidatorTests(unittest.TestCase):
                 if test_runner is not None
                 else TEST_RUNNER_SOURCE.read_text()
             )
-            return MODULE.validate(path, runner_path, test_runner_path)
+            buck_path = Path(directory) / "BUCK"
+            buck_path.write_text(
+                buck if buck is not None else ROOT_BUCK.read_text()
+            )
+            return MODULE.validate(path, runner_path, test_runner_path, buck_path)
 
     def test_current_workflow_is_valid(self):
         self.assertEqual(
-            MODULE.validate(SOURCE, MODULE.NATIVE_RUNNER_SCRIPT, TEST_RUNNER_SOURCE), []
+            MODULE.validate(
+                SOURCE, MODULE.NATIVE_RUNNER_SCRIPT, TEST_RUNNER_SOURCE, ROOT_BUCK
+            ),
+            [],
         )
 
     def test_removing_or_renaming_job_fails_inventory(self):
@@ -105,10 +113,47 @@ class GateValidatorTests(unittest.TestCase):
     def test_unreadable_platform_matrix_is_reported(self):
         with tempfile.TemporaryDirectory() as directory:
             missing = Path(directory) / "absent.rs"
-            errors = MODULE.validate(SOURCE, MODULE.NATIVE_RUNNER_SCRIPT, missing)
+            errors = MODULE.validate(
+                SOURCE, MODULE.NATIVE_RUNNER_SCRIPT, missing, ROOT_BUCK
+            )
         self.assertTrue(
             any("platform responsibility matrix unreadable" in error for error in errors),
             errors,
+        )
+
+
+    # RUE-1163: the label that replaced RUE_CI_DEFER_HEAVY_SUITES.
+    def test_reintroducing_the_defer_protocol_fails(self):
+        changed = SOURCE.read_text().replace(
+            "          RUE_TEST_TIER: premerge\n",
+            "          RUE_TEST_TIER: premerge\n"
+            "          RUE_CI_DEFER_HEAVY_SUITES: '//:cli-tests'\n",
+            1,
+        )
+        errors = "\n".join(self.validate_text(changed))
+        self.assertIn("RUE_CI_DEFER_HEAVY_SUITES is retired", errors)
+
+    def test_dedicated_lane_corpus_without_a_job_fails(self):
+        # spec-tests is skipped by the premerge suite because it carries the
+        # label, so dropping its platform-corpus entry would drop it entirely.
+        changed = SOURCE.read_text().replace("            target: //:spec-tests\n", "", 1)
+        errors = "\n".join(self.validate_text(changed))
+        self.assertIn("//:spec-tests is marked rue_ci_dedicated_lane", errors)
+
+    def test_unlabeled_buck_fails_closed(self):
+        buck = ROOT_BUCK.read_text().replace('"rue_ci_dedicated_lane"', '"unused"')
+        errors = "\n".join(self.validate_text(SOURCE.read_text(), buck=buck))
+        self.assertIn("no corpus carries rue_ci_dedicated_lane", errors)
+
+    def test_sharded_corpus_counts_as_covered(self):
+        # //:cli-tests is labeled but never appears in the matrix by name; its
+        # four shards are what run it, and that must satisfy the check.
+        self.assertEqual(
+            MODULE.uncovered_dedicated_lanes(
+                'name = "cli-tests",\n    labels = ["rue_ci_dedicated_lane"]',
+                "target: //:cli-tests-shard-0\ntarget: //:cli-tests-shard-1\n",
+            ),
+            [],
         )
 
 

--- a/scripts/test-wrapper-scripts.sh
+++ b/scripts/test-wrapper-scripts.sh
@@ -835,14 +835,6 @@ EOF
   check "ci-heavy-suite: labeled target with a result succeeds" \
     "$([ "$rc" -eq 0 ] && echo 0 || echo 1)"
 
-  # //:cli-tests-slow is the one CLI corpus RUE-1118 does not convert, so it is
-  # also the only one that still takes a declarative executor timeout.
-  : >"$sb/calls.log"
-  rc=0
-  (cd "$sb" && FAKE_LABELED_TARGET=//:cli-tests-slow FAKE_CALL_LOG="$sb/calls.log" ./ci-heavy-suite //:cli-tests-slow) >/dev/null 2>&1 || rc=$?
-  check "ci-heavy-suite: slow CLI corpus receives the declarative executor timeout" \
-    "$([ "$rc" -eq 0 ] && grep -Fxq 'test //:cli-tests-slow -- --timeout 7200' "$sb/calls.log" && echo 0 || echo 1)"
-
   # RUE-1159 flake detection only means anything if each repetition executes, so
   # a repetition run must defeat the corpus action's cache.
   : >"$sb/calls.log"
@@ -851,20 +843,26 @@ EOF
   check "ci-heavy-suite: a correctness repetition runs cache-free" \
     "$([ "$rc" -eq 0 ] && grep -Fq -- '--no-remote-cache' "$sb/calls.log" && grep -Fq 'RUE_CORRECTNESS_REPETITION=2' "$sb/calls.log" && echo 0 || echo 1)"
 
-  # RUE-1118: ci-heavy-suite no longer carries per-target executor timeouts for
-  # the converted corpora. Each runs as a cacheable build action and the test
-  # executor only asserts its stamp, so the outer bound belongs on the action —
-  # it is each suite's timeout_seconds in BUCK. A stray `--timeout` here would
-  # bound the wrong thing (a sub-second stamp check) and read as if the corpus
-  # were still bounded, so pin that every target is invoked identically and bare.
+  # RUE-1118/RUE-1163: ci-heavy-suite carries no per-target executor timeouts at
+  # all. Every corpus runs as a cacheable build action and the test executor
+  # only asserts its stamp, so the outer bound belongs on the action — it is
+  # each suite's timeout_seconds in BUCK. A stray `--timeout` here would bound
+  # the wrong thing (a sub-second stamp check) and read as if the corpus were
+  # still bounded, so pin that every target is invoked identically and bare.
+  # This is the whole per-target contract now: the script has no `case` on the
+  # target, so a new corpus needs no edit here.
   local heavy_target
   for heavy_target in \
     //:cli-tests \
     //:cli-tests-shard-1 \
+    //:cli-tests-slow \
     //:spec-tests \
     //:ui-tests \
+    //:frontend-diff-test \
     //:oracle-diff-generated-smoke \
     //:reproducible-programs \
+    //crates/rue-oracle-diff:oracle-diff-test \
+    //crates/rue-oracle-diff:oracle-diff-spec-test \
     //:tutorial-snippet-tests; do
     : >"$sb/calls.log"
     rc=0
@@ -1046,7 +1044,7 @@ EOF
       RUE_FULL_SUITE_LOCK_HELD=1 FAKE_SLOW_SUITES="$slow" FAKE_HEAVY_SUITES="$all" \
       FAKE_PASS_TARGETS="$slow" FAKE_CALL_LOG="$sb/calls.log" ./test.sh 2>&1)" || rc=$?
   check "test.sh: slow selection audits its real CLI corpus target" \
-    "$([ "$rc" -eq 0 ] && grep -Fq -- '--include rue_test_tier_slow' "$sb/calls.log" && grep -Fq 'test //:cli-tests-slow -- --timeout 7200' "$sb/calls.log" && echo 0 || echo 1)"
+    "$([ "$rc" -eq 0 ] && grep -Fq -- '--include rue_test_tier_slow' "$sb/calls.log" && grep -Fxq 'test //:cli-tests-slow' "$sb/calls.log" && echo 0 || echo 1)"
   # RUE-1117: a slow run that omits the codegen differential is the same
   # false-green as an omitted CLI corpus, and must fail rather than tally.
   rc=0

--- a/scripts/test-wrapper-scripts.sh
+++ b/scripts/test-wrapper-scripts.sh
@@ -922,15 +922,15 @@ EOF
   check "ci-heavy-suite: a target pattern is still rejected as usage" \
     "$([ "$rc" -eq 2 ] && grep -Fq 'usage: scripts/ci-heavy-suite' <<<"$out" && echo 0 || echo 1)"
 
+  # RUE-1163: a failing corpus fails through buck2's exit code. The old check
+  # here asserted a grep for a `<Status>: root<target>` result line, which was
+  # shell deciding whether the suite had really run; every corpus is now a build
+  # action whose stamp its test asserts, so buck2 exiting 0 for a named target
+  # means that corpus passed.
   rc=0
-  out="$(cd "$sb" && ./ci-heavy-suite //:spec-tests 2>&1)" || rc=$?
-  check "ci-heavy-suite: unlabeled shard target fails closed" \
-    "$([ "$rc" -ne 0 ] && grep -Fq 'not labeled rue_heavy_suite' <<<"$out" && echo 0 || echo 1)"
-
-  rc=0
-  out="$(cd "$sb" && FAKE_OMIT=1 ./ci-heavy-suite //:cli-tests 2>&1)" || rc=$?
-  check "ci-heavy-suite: omitted explicit result fails closed" \
-    "$([ "$rc" -ne 0 ] && grep -Fq 'produced no result' <<<"$out" && echo 0 || echo 1)"
+  out="$(cd "$sb" && FAKE_EXIT=1 ./ci-heavy-suite //:cli-tests 2>&1)" || rc=$?
+  check "ci-heavy-suite: a failing corpus propagates its exit code" \
+    "$([ "$rc" -ne 0 ] && echo 0 || echo 1)"
 
   rc=0
   (cd "$sb" && FAKE_EXIT=29 ./ci-heavy-suite //:cli-tests) >/dev/null 2>&1 || rc=$?
@@ -947,204 +947,143 @@ EOF
 # CLI-case failures CI later caught).
 # ===========================================================================
 
-# Drive a copy of the real test.sh (no filter) against a fake `./buck2` so the
-# corpus-omission audit is exercised without a real (~10-minute) suite. The
-# fake serves all three unfiltered-path invocations: the rue_heavy_suite
-# uquery (returns FAKE_HEAVY_SUITES), the broad `test //...` pass (one
-# unrelated pass line, exits FAKE_BUCK_EXIT), and each per-suite `test
-# <target>` run (a result line only when the target is in FAKE_PASS_TARGETS).
-test_testsh_unfiltered_audits_corpus_presence() {
+# RUE-1163: test.sh's unfiltered path delegates to Buck. Heavy-suite membership
+# comes from //test_tiers.bxl:heavy_suites, each selected corpus is run as a
+# NAMED target, and buck2's exit code is the verdict. These checks pin that
+# delegation — the tier and exclusion flags handed to the selector, and the
+# targets run afterwards — rather than the log-grepping audit and env-var
+# deferral protocol they replaced.
+test_testsh_delegates_selection_to_buck() {
   local sb; sb="$(mktemp -d)"
   mkdir -p "$sb/scripts"
   cp "$SRC_ROOT/test.sh" "$sb/test.sh"
   cp "$SRC_ROOT/scripts/ci-heavy-suite" "$sb/scripts/ci-heavy-suite"
-  cat >"$sb/scripts/cli-timeout-policy.py" <<'EOF'
-#!/usr/bin/env bash
-target=""
-while [ "$#" -gt 0 ]; do
-  if [ "$1" = "--target" ]; then target="$2"; shift 2; else shift; fi
-done
-case "$target" in
-  //:cli-tests) echo 3600 ;;
-  //:cli-tests-slow) echo 7200 ;;
-  //:cli-tests-shard-*) echo 1234 ;;
-  *) exit 2 ;;
-esac
-EOF
-  chmod +x "$sb/test.sh" "$sb/scripts/ci-heavy-suite" "$sb/scripts/cli-timeout-policy.py"
+  chmod +x "$sb/test.sh" "$sb/scripts/ci-heavy-suite"
   cat >"$sb/buck2" <<'EOF'
 #!/usr/bin/env bash
-if [ "$1" = "uquery" ]; then
-  # RUE-1116: test.sh issues a second uquery for the rue_cli_shard set and
-  # subtracts it from heavy-suite discovery. RUE-1157 adds a dedicated-suite
-  # ownership query when required CI defers those tests to explicit jobs.
-  case "$*" in
-    *rue_cli_shard*) for t in ${FAKE_CLI_SHARDS:-}; do printf 'root%s\n' "$t"; done ;;
-    *rue_dedicated_suite*) for t in ${FAKE_DEDICATED_SUITES:-}; do printf 'root%s\n' "$t"; done ;;
-    *rue_test_tier_slow*)
-      for t in ${FAKE_SLOW_SUITES:-//:cli-tests-slow}; do printf 'root%s\n' "$t"; done
-      ;;
-    *rue_test_tier_premerge*)
-      for t in $FAKE_HEAVY_SUITES; do
-        case " ${FAKE_SLOW_SUITES:-//:cli-tests-slow} " in
-          *" $t "*) ;;
-          *) printf 'root%s\n' "$t" ;;
-        esac
-      done
-      ;;
-    *) for t in $FAKE_HEAVY_SUITES; do printf 'root%s\n' "$t"; done ;;
-  esac
-  exit 0
-fi
 if [ "$1" = "bxl" ]; then
-  printf 'Rue test tiers valid\n'
+  if [ -n "${FAKE_CALL_LOG:-}" ]; then printf '%s\n' "$*" >>"$FAKE_CALL_LOG"; fi
+  case "$2" in
+    *:validate) printf 'Rue test tiers valid\n'; exit 0 ;;
+  esac
+  # A stale exclusion or unknown tier fails in BXL, and must abort test.sh
+  # rather than yield an empty selection that runs no corpus.
+  if [ "${FAKE_BXL_EXIT:-0}" != 0 ]; then
+    printf 'error: fail: excluded target(s) are not heavy suites\n' >&2
+    exit "$FAKE_BXL_EXIT"
+  fi
+  tier=""
+  for a in "$@"; do
+    case "$prev" in --tier) tier="$a" ;; esac
+    prev="$a"
+  done
+  case " $* " in
+    *" --exclude_label rue_ci_dedicated_lane "*) dedicated=1 ;;
+    *) dedicated=0 ;;
+  esac
+  for t in ${FAKE_HEAVY_SUITES:-}; do
+    case " ${FAKE_SLOW_SUITES:-} " in
+      *" $t "*) [ "$tier" = slow ] || [ "$tier" = standard ] || [ "$tier" = all ] || continue ;;
+      *) [ "$tier" = slow ] && continue ;;
+    esac
+    if [ "$dedicated" = 1 ]; then
+      case " ${FAKE_DEDICATED_LANE:-} " in *" $t "*) continue ;; esac
+    fi
+    printf '%s\n' "$t"
+  done
   exit 0
 fi
 if [ "$1" = "test" ]; then
   if [ -n "${FAKE_CALL_LOG:-}" ]; then printf '%s\n' "$*" >>"$FAKE_CALL_LOG"; fi
   tgt="$2"
   if [ "$tgt" = "//..." ]; then
-    printf 'Pass: root//crates/rue-lexer:rue-lexer-test (0.1s)\n'
     printf 'Tests finished: Pass 1. Fail 0. Skip 0.\n'
     exit "${FAKE_BUCK_EXIT:-0}"
   fi
-  for t in $FAKE_PASS_TARGETS; do
-    if [ "$t" = "${tgt#root}" ]; then printf 'Pass: root%s (0.1s)\n' "$t"; fi
+  for t in ${FAKE_FAIL_TARGETS:-}; do
+    if [ "$t" = "$tgt" ]; then printf 'Fail: root%s (0.1s)\n' "$t"; exit 1; fi
   done
-  printf 'Tests finished: Pass 1. Fail 0. Skip 0.\n'
+  printf 'Pass: root%s (0.1s)\n' "$tgt"
   exit 0
 fi
 exit 90
 EOF
   chmod +x "$sb/buck2"
 
-  # RUE-1117: the oracle differentials are slow-tier heavy suites and required
-  # slow corpus, so the fixture must carry them alongside //:cli-tests-slow.
   local slow="//:cli-tests-slow //crates/rue-oracle-diff:oracle-diff-test //crates/rue-oracle-diff:oracle-diff-spec-test"
-  local all="//:cli-tests $slow //:large-example-caldera-canary //:large-example-meridian-canary //:spec-tests //:ui-tests //:oracle-diff-generated-smoke //:reproducible-programs //:tutorial-snippet-tests //:frontend-diff-test"
-
-  # (1) Full corpus present + buck2 green -> test.sh reports success.
+  local all="//:cli-tests $slow //:spec-tests //:ui-tests //:oracle-diff-generated-smoke //:reproducible-programs //:frontend-diff-test"
+  local base="RUE_FULL_SUITE_LOCK_HELD=1"
   local rc=0 out
-  out="$(cd "$sb" && RUE_CI_DEFER_HEAVY_SUITES= RUE_FULL_SUITE_LOCK_HELD=1 FAKE_SLOW_SUITES="$slow" FAKE_HEAVY_SUITES="$all" FAKE_PASS_TARGETS="$all" ./test.sh 2>&1)" || rc=$?
-  check "test.sh: unfiltered run with the full corpus reports success" \
+
+  # (1) A green selection runs every named corpus and reports success.
+  : >"$sb/calls.log"; rc=0
+  out="$(cd "$sb" && env $base FAKE_SLOW_SUITES="$slow" FAKE_HEAVY_SUITES="$all" \
+      FAKE_CALL_LOG="$sb/calls.log" ./test.sh 2>&1)" || rc=$?
+  check "test.sh: unfiltered run reports success" \
     "$([ "$rc" -eq 0 ] && grep -Fxq '=== TEST SUITE: PASSED ===' <<< "$out" && echo 0 || echo 1)"
+  check "test.sh: heavy membership comes from the Buck selector" \
+    "$(grep -Fq 'bxl //test_tiers.bxl:heavy_suites' "$sb/calls.log" && echo 0 || echo 1)"
+  check "test.sh: the CLI shards are subtracted from a local full run" \
+    "$(grep -Fq -- '--exclude_label rue_cli_shard' "$sb/calls.log" && echo 0 || echo 1)"
+  check "test.sh: every selected corpus is run as a named target" \
+    "$([ "$(grep -Ec '^test //[a-z0-9/-]*:[a-z0-9-]+$' "$sb/calls.log")" -eq 9 ] && echo 0 || echo 1)"
+  check "test.sh: the broad pass still excludes heavy suites" \
+    "$(grep -Fq -- '--exclude rue_heavy_suite' "$sb/calls.log" && echo 0 || echo 1)"
 
-  # The required-CI spelling selects premerge from canonical Buck metadata,
-  # while slow selections audit their own real corpus target without claiming
-  # the premerge omission sentinels executed.
+  # (2) The tier reaches the selector rather than being re-derived in shell.
   : >"$sb/calls.log"; rc=0
-  out="$(cd "$sb" && RUE_TEST_TIER=premerge RUE_CI_DEFER_HEAVY_SUITES= \
-      RUE_FULL_SUITE_LOCK_HELD=1 FAKE_SLOW_SUITES="$slow" FAKE_HEAVY_SUITES="$all" \
-      FAKE_PASS_TARGETS="$all" FAKE_CALL_LOG="$sb/calls.log" ./test.sh 2>&1)" || rc=$?
-  check "test.sh: premerge selection uses the canonical Buck tier label" \
-    "$([ "$rc" -eq 0 ] && grep -Fq -- '--include rue_test_tier_premerge' "$sb/calls.log" && echo 0 || echo 1)"
+  out="$(cd "$sb" && env $base RUE_TEST_TIER=premerge FAKE_SLOW_SUITES="$slow" \
+      FAKE_HEAVY_SUITES="$all" FAKE_CALL_LOG="$sb/calls.log" ./test.sh 2>&1)" || rc=$?
+  check "test.sh: premerge selection asks Buck for the premerge tier" \
+    "$([ "$rc" -eq 0 ] && grep -Fq -- '--tier premerge' "$sb/calls.log" \
+      && grep -Fq -- '--include rue_test_tier_premerge' "$sb/calls.log" && echo 0 || echo 1)"
 
   : >"$sb/calls.log"; rc=0
-  out="$(cd "$sb" && RUE_TEST_TIER=slow RUE_CI_DEFER_HEAVY_SUITES= \
-      RUE_FULL_SUITE_LOCK_HELD=1 FAKE_SLOW_SUITES="$slow" FAKE_HEAVY_SUITES="$all" \
-      FAKE_PASS_TARGETS="$slow" FAKE_CALL_LOG="$sb/calls.log" ./test.sh 2>&1)" || rc=$?
-  check "test.sh: slow selection audits its real CLI corpus target" \
-    "$([ "$rc" -eq 0 ] && grep -Fq -- '--include rue_test_tier_slow' "$sb/calls.log" && grep -Fxq 'test //:cli-tests-slow' "$sb/calls.log" && echo 0 || echo 1)"
-  # RUE-1117: a slow run that omits the codegen differential is the same
-  # false-green as an omitted CLI corpus, and must fail rather than tally.
-  rc=0
-  out="$(cd "$sb" && RUE_TEST_TIER=slow RUE_CI_DEFER_HEAVY_SUITES= \
-      RUE_FULL_SUITE_LOCK_HELD=1 FAKE_SLOW_SUITES="$slow" FAKE_HEAVY_SUITES="$all" \
-      FAKE_PASS_TARGETS='//:cli-tests-slow' ./test.sh 2>&1)" || rc=$?
-  check "test.sh: an omitted oracle differential fails the slow run" \
-    "$([ "$rc" -ne 0 ] && grep -Fq 'CORPUS OMITTED' <<< "$out" \
-      && grep -Fq '//crates/rue-oracle-diff:oracle-diff-test' <<< "$out" && echo 0 || echo 1)"
+  out="$(cd "$sb" && env $base RUE_TEST_TIER=slow FAKE_SLOW_SUITES="$slow" \
+      FAKE_HEAVY_SUITES="$all" FAKE_CALL_LOG="$sb/calls.log" ./test.sh 2>&1)" || rc=$?
+  check "test.sh: slow selection runs its real corpus targets" \
+    "$([ "$rc" -eq 0 ] && grep -Fq -- '--tier slow' "$sb/calls.log" \
+      && grep -Fxq 'test //:cli-tests-slow' "$sb/calls.log" \
+      && grep -Fxq 'test //crates/rue-oracle-diff:oracle-diff-test' "$sb/calls.log" && echo 0 || echo 1)"
 
-  # (2) A corpus harness OMITTED while every buck2 invocation still exits 0 is
-  #     the RUE-924 false-green: it must become a hard failure naming the suite.
-  local partial="$slow //:large-example-caldera-canary //:large-example-meridian-canary //:spec-tests //:ui-tests //:oracle-diff-generated-smoke //:reproducible-programs //:tutorial-snippet-tests //:frontend-diff-test"
+  # (3) A failing corpus fails the run. This is the whole completeness contract
+  #     now: exit codes, not a grep for a result line.
   rc=0
-  out="$(cd "$sb" && RUE_CI_DEFER_HEAVY_SUITES= RUE_FULL_SUITE_LOCK_HELD=1 FAKE_SLOW_SUITES="$slow" FAKE_HEAVY_SUITES="$all" FAKE_PASS_TARGETS="$partial" ./test.sh 2>&1)" || rc=$?
-  check "test.sh: a silently omitted corpus harness fails the run" \
-    "$([ "$rc" -ne 0 ] && echo 0 || echo 1)"
-  check "test.sh: the omission message names the missing harness" \
-    "$(grep -Fq 'CORPUS OMITTED' <<< "$out" && grep -Fq '//:cli-tests' <<< "$out" && echo 0 || echo 1)"
-  check "test.sh: an omitted-corpus run prints the failed sentinel" \
-    "$(grep -Fq '=== TEST SUITE: FAILED' <<< "$out" && echo 0 || echo 1)"
+  out="$(cd "$sb" && env $base FAKE_SLOW_SUITES="$slow" FAKE_HEAVY_SUITES="$all" \
+      FAKE_FAIL_TARGETS='//:spec-tests' ./test.sh 2>&1)" || rc=$?
+  check "test.sh: a failing corpus fails the run" \
+    "$([ "$rc" -ne 0 ] && grep -Fq '=== TEST SUITE: FAILED' <<<"$out" && echo 0 || echo 1)"
 
-  # (3) A genuine buck2 failure with the full corpus present is still
-  #     propagated verbatim (the audit must not mask real failures).
+  # (4) A selector failure — a stale exclusion, an unknown tier, an unowned
+  #     target — aborts instead of running an empty corpus.
   rc=0
-  out="$(cd "$sb" && RUE_CI_DEFER_HEAVY_SUITES= RUE_FULL_SUITE_LOCK_HELD=1 FAKE_SLOW_SUITES="$slow" FAKE_HEAVY_SUITES="$all" FAKE_PASS_TARGETS="$all" FAKE_BUCK_EXIT=17 ./test.sh 2>&1)" || rc=$?
-  check "test.sh: unfiltered buck2 failure exit code is propagated" \
-    "$([ "$rc" -eq 17 ] && echo 0 || echo 1)"
+  out="$(cd "$sb" && env $base FAKE_SLOW_SUITES="$slow" FAKE_HEAVY_SUITES="$all" \
+      FAKE_BXL_EXIT=1 ./test.sh 2>&1)" || rc=$?
+  check "test.sh: a failed Buck selection aborts the run" \
+    "$([ "$rc" -ne 0 ] && ! grep -Fq '=== TEST SUITE: PASSED ===' <<<"$out" && echo 0 || echo 1)"
 
-  # (4) Required CI may explicitly defer known live heavy targets to separate
-  # jobs. The owning invocation must skip and stop auditing exactly those
-  # targets while retaining every other corpus assertion.
-  local owned="//:large-example-caldera-canary //:large-example-meridian-canary //:ui-tests //:oracle-diff-generated-smoke //:reproducible-programs //:tutorial-snippet-tests //:frontend-diff-test"
+  # (5) An empty selection is a failure, not a silent no-op success.
+  rc=0
+  out="$(cd "$sb" && env $base FAKE_HEAVY_SUITES= ./test.sh 2>&1)" || rc=$?
+  check "test.sh: an empty heavy selection fails closed" \
+    "$([ "$rc" -ne 0 ] && grep -Fq 'selected no heavy suites' <<<"$out" && echo 0 || echo 1)"
+
+  # (6) RUE-1163: required CI subtracts the corpora that own a platform-corpus
+  #     job by LABEL, not by an environment variable naming them. A local run
+  #     must still cover them.
   : >"$sb/calls.log"; rc=0
-  out="$(cd "$sb" && CI=true RUE_TEST_TIER=premerge RUE_FULL_SUITE_LOCK_HELD=1 \
-      RUE_CI_DEFER_HEAVY_SUITES='//:cli-tests //:spec-tests' \
-      FAKE_SLOW_SUITES="$slow" FAKE_HEAVY_SUITES="$all" FAKE_PASS_TARGETS="$owned" \
-      FAKE_CALL_LOG="$sb/calls.log" ./test.sh 2>&1)" || rc=$?
-  check "test.sh: required CI may defer live heavy suites" \
-    "$([ "$rc" -eq 0 ] && grep -Fq 'Deferring heavy suite root//:cli-tests' <<<"$out" && echo 0 || echo 1)"
-  check "test.sh: deferred suites are not executed by the owning shard" \
-    "$(! grep -Eq '^test (root)?//:(cli-tests|spec-tests)' "$sb/calls.log" && echo 0 || echo 1)"
+  out="$(cd "$sb" && env $base CI=true FAKE_SLOW_SUITES="$slow" FAKE_HEAVY_SUITES="$all" \
+      FAKE_DEDICATED_LANE='//:cli-tests //:spec-tests' FAKE_CALL_LOG="$sb/calls.log" ./test.sh 2>&1)" || rc=$?
+  check "test.sh: required CI subtracts the dedicated-lane label" \
+    "$([ "$rc" -eq 0 ] && grep -Fq -- '--exclude_label rue_ci_dedicated_lane' "$sb/calls.log" \
+      && ! grep -Fxq 'test //:cli-tests' "$sb/calls.log" && echo 0 || echo 1)"
 
-  # (5) Dedicated pre-merge coverage may leave the broad CI pass only when the
-  # workflow-owned set exactly matches Buck's live scheduling metadata.
   : >"$sb/calls.log"; rc=0
-  out="$(cd "$sb" && CI=true RUE_TEST_TIER=premerge RUE_FULL_SUITE_LOCK_HELD=1 \
-      RUE_CI_DEFER_HEAVY_SUITES= \
-      RUE_CI_DEFER_DEDICATED_SUITES='//crates/rue-compiler:scaling-matrix-test' \
-      FAKE_DEDICATED_SUITES='//crates/rue-compiler:scaling-matrix-test' \
-      FAKE_SLOW_SUITES="$slow" FAKE_HEAVY_SUITES="$all" FAKE_PASS_TARGETS="$all" \
-      FAKE_CALL_LOG="$sb/calls.log" ./test.sh 2>&1)" || rc=$?
-  check "test.sh: required CI may defer the exact live dedicated-suite set" \
-    "$([ "$rc" -eq 0 ] && grep -Fq -- '--exclude rue_dedicated_suite' "$sb/calls.log" && echo 0 || echo 1)"
-
-  rc=0
-  out="$(cd "$sb" && CI=true RUE_TEST_TIER=premerge RUE_FULL_SUITE_LOCK_HELD=1 \
-      RUE_CI_DEFER_HEAVY_SUITES= \
-      RUE_CI_DEFER_DEDICATED_SUITES='//crates/rue-compiler:scaling-matrix-test' \
-      FAKE_DEDICATED_SUITES='//crates/rue-compiler:scaling-matrix-test //:unowned-dedicated' \
-      FAKE_SLOW_SUITES="$slow" FAKE_HEAVY_SUITES="$all" FAKE_PASS_TARGETS="$all" ./test.sh 2>&1)" || rc=$?
-  check "test.sh: a live dedicated target without a CI owner fails closed" \
-    "$([ "$rc" -ne 0 ] && grep -Fq 'has no explicit CI owner' <<<"$out" && echo 0 || echo 1)"
-
-  # (6) A stale shard name or local attempt to suppress coverage fails closed.
-  rc=0
-  out="$(cd "$sb" && CI=true RUE_TEST_TIER=premerge RUE_FULL_SUITE_LOCK_HELD=1 \
-      RUE_CI_DEFER_HEAVY_SUITES='//:missing-suite' \
-      FAKE_SLOW_SUITES="$slow" FAKE_HEAVY_SUITES="$all" FAKE_PASS_TARGETS="$all" ./test.sh 2>&1)" || rc=$?
-  check "test.sh: unknown deferred CI suite fails closed" \
-    "$([ "$rc" -ne 0 ] && grep -Fq 'not labeled rue_heavy_suite' <<<"$out" && echo 0 || echo 1)"
-
-  rc=0
-  out="$(cd "$sb" && CI= RUE_FULL_SUITE_LOCK_HELD=1 \
-      RUE_CI_DEFER_HEAVY_SUITES='//:cli-tests' \
-      FAKE_SLOW_SUITES="$slow" FAKE_HEAVY_SUITES="$all" FAKE_PASS_TARGETS="$all" ./test.sh 2>&1)" || rc=$?
-  check "test.sh: local callers cannot defer corpus coverage" \
-    "$([ "$rc" -ne 0 ] && grep -Fq 'reserved for required CI' <<<"$out" && echo 0 || echo 1)"
-
-  rc=0
-  out="$(cd "$sb" && CI= RUE_FULL_SUITE_LOCK_HELD=1 \
-      RUE_CI_DEFER_HEAVY_SUITES= \
-      RUE_CI_DEFER_DEDICATED_SUITES='//crates/rue-compiler:scaling-matrix-test' \
-      FAKE_DEDICATED_SUITES='//crates/rue-compiler:scaling-matrix-test' \
-      FAKE_SLOW_SUITES="$slow" FAKE_HEAVY_SUITES="$all" FAKE_PASS_TARGETS="$all" ./test.sh 2>&1)" || rc=$?
-  check "test.sh: local callers cannot defer dedicated coverage" \
-    "$([ "$rc" -ne 0 ] && grep -Fq 'reserved for required CI' <<<"$out" && echo 0 || echo 1)"
-
-  # (7) RUE-1116: the CI-only CLI shards are labeled rue_heavy_suite but must be
-  #     excluded from a local full run, which covers their union once via the
-  #     premerge //:cli-tests. The slow target independently owns its cases,
-  #     and the standard run still succeeds with the full union present.
-  local with_shards="$all //:cli-tests-shard-0 //:cli-tests-shard-1"
-  : >"$sb/calls.log"; rc=0
-  out="$(cd "$sb" && RUE_CI_DEFER_HEAVY_SUITES= RUE_FULL_SUITE_LOCK_HELD=1 \
-      FAKE_HEAVY_SUITES="$with_shards" \
-      FAKE_CLI_SHARDS='//:cli-tests-shard-0 //:cli-tests-shard-1' \
-      FAKE_PASS_TARGETS="$all" FAKE_CALL_LOG="$sb/calls.log" ./test.sh 2>&1)" || rc=$?
-  check "test.sh: local full run runs the premerge CLI target, not the shards" \
-    "$([ "$rc" -eq 0 ] && ! grep -Eq '(^| )//:cli-tests-shard-' "$sb/calls.log" && echo 0 || echo 1)"
+  out="$(cd "$sb" && env $base FAKE_SLOW_SUITES="$slow" FAKE_HEAVY_SUITES="$all" \
+      FAKE_DEDICATED_LANE='//:cli-tests //:spec-tests' FAKE_CALL_LOG="$sb/calls.log" ./test.sh 2>&1)" || rc=$?
+  check "test.sh: a local run still covers the dedicated-lane corpora" \
+    "$([ "$rc" -eq 0 ] && ! grep -Fq -- '--exclude_label rue_ci_dedicated_lane' "$sb/calls.log" \
+      && grep -Fxq 'test //:cli-tests' "$sb/calls.log" && echo 0 || echo 1)"
 
   rm -rf "$sb"
 }
@@ -1167,7 +1106,7 @@ test_rue_unit_unknown_crate_errors_cleanly
 test_ci_timed_preserves_status_and_summarizes_actions
 test_cache_probe_counter_validation
 test_ci_heavy_suite_audits_its_target
-test_testsh_unfiltered_audits_corpus_presence
+test_testsh_delegates_selection_to_buck
 test_sanitizer_defaults_std_path
 test_sanitizer_recursive_discovery_contract
 test_sanitizer_status_contracts

--- a/scripts/test-wrapper-scripts.sh
+++ b/scripts/test-wrapper-scripts.sh
@@ -227,11 +227,14 @@ install_cli_path_probe_buck() {
   local sb="$1"
   cat >"$sb/buck2" <<'EOF'
 #!/usr/bin/env bash
-if [ -n "${RUE_EXAMPLES_DIR:-}" ]; then
-  printf 'examples=%s\n' "$RUE_EXAMPLES_DIR" >>"$CLI_LOG"
+# RUE-1163: the corpus environment moved onto the //crates/rue-cli-tests:cli
+# command_alias, so the wrappers hand buck2 nothing but the target and the
+# filter. `$(location root//:examples)` expands to an absolute path there, which
+# is what keeps a filtered examples case readable after the harness chdirs (the
+# RUE-537/RUE-550 property); that is now Buck's guarantee rather than a
+# `$repo_root/...` string built in shell, and //:cli-tests exercises it.
+if [ "${1:-}" = "run" ]; then
   printf 'args=%s\n' "$*" >>"$CLI_LOG"
-  cd "$FAKE_PROBE_DIR"
-  [ -f "$RUE_EXAMPLES_DIR/hello.rue" ] || exit 91
   exit "${FAKE_CLI_EXIT:-0}"
 fi
 exit 0
@@ -251,8 +254,10 @@ test_rue_cli_examples_survive_case_chdir() {
       "$sb/scripts/rue" cli 'cli.examples::hello' ) >/dev/null 2>&1 || rc=$?
   check "scripts/rue cli: filtered run survives the harness cwd change" \
     "$([ "$rc" -eq 0 ] && echo 0 || echo 1)"
-  check "scripts/rue cli: examples path is anchored at the repository" \
-    "$(grep -Fxq "examples=$sb/examples" "$sb/cli.log" 2>/dev/null && echo 0 || echo 1)"
+  check "scripts/rue cli: delegates to the Buck entry point" \
+    "$(grep -Fq 'run //crates/rue-cli-tests:cli' "$sb/cli.log" 2>/dev/null && echo 0 || echo 1)"
+  check "scripts/rue cli: sets no corpus environment of its own" \
+    "$(! grep -Fq 'RUE_EXAMPLES_DIR' "$sb/scripts/rue" && echo 0 || echo 1)"
   check "scripts/rue cli: filter is forwarded" \
     "$(grep -Fq 'cli.examples::hello' "$sb/cli.log" 2>/dev/null && echo 0 || echo 1)"
 
@@ -306,8 +311,10 @@ test_testsh_cli_examples_survive_case_chdir() {
       "$sb/test.sh" 'cli.examples::hello' 2>&1)" || rc=$?
   check "test.sh: filtered run survives the harness cwd change" \
     "$([ "$rc" -eq 0 ] && echo 0 || echo 1)"
-  check "test.sh: examples path is anchored at the repository" \
-    "$(grep -Fxq "examples=$sb/examples" "$sb/cli.log" 2>/dev/null && echo 0 || echo 1)"
+  check "test.sh: delegates to the Buck entry point" \
+    "$(grep -Fq 'run //crates/rue-cli-tests:cli' "$sb/cli.log" 2>/dev/null && echo 0 || echo 1)"
+  check "test.sh: sets no corpus environment of its own" \
+    "$(! grep -Fq 'RUE_EXAMPLES_DIR' "$sb/test.sh" && echo 0 || echo 1)"
   check "test.sh: CLI filter is forwarded" \
     "$(grep -Fq 'cli.examples::hello' "$sb/cli.log" 2>/dev/null && echo 0 || echo 1)"
   check "test.sh: successful filtered run prints the passed sentinel" \

--- a/scripts/validate-ci-gate.py
+++ b/scripts/validate-ci-gate.py
@@ -13,6 +13,7 @@ NATIVE_RUNNER_SCRIPT = Path(__file__).with_name("run-native-platform-corpus.sh")
 TEST_RUNNER_SOURCE = (
     Path(__file__).resolve().parents[1] / "crates/rue-test-runner/src/lib.rs"
 )
+ROOT_BUCK = Path(__file__).resolve().parents[1] / "BUCK"
 
 # RUE-1161: the platform each entry of the harness's CI_EXECUTED_TARGETS claims
 # a required lane for, and the workflow text that proves that lane exists. The
@@ -29,6 +30,40 @@ CI_EXECUTED_TARGETS_RE = re.compile(
     r"pub const CI_EXECUTED_TARGETS: &\[&str\] = &\[(?P<body>.*?)\];", re.DOTALL
 )
 
+DEDICATED_LANE_LABEL = "rue_ci_dedicated_lane"
+DEDICATED_LANE_RE = re.compile(
+    r'name = "(?P<name>[a-z0-9-]+)",\s*\n\s*labels = \[[^\]]*"'
+    + DEDICATED_LANE_LABEL
+    + r'"',
+    re.MULTILINE,
+)
+
+
+def dedicated_lane_targets(buck_source: str) -> list[str]:
+    """Corpora BUCK marks as owning their own required-CI job."""
+    return [f"//:{match.group('name')}" for match in DEDICATED_LANE_RE.finditer(buck_source)]
+
+
+def uncovered_dedicated_lanes(buck_source: str, corpus_block: str) -> list[str]:
+    """Labeled corpora that no platform-corpus matrix entry actually runs.
+
+    A corpus carrying the label is skipped by the linux-premerge suite, so if
+    the matrix does not run it — directly or through its shards — it stops being
+    covered at all. That is the RUE-924 false-green shape, reached by way of a
+    label instead of a log line, so it fails the CI contract.
+    """
+    matrix_targets = set(re.findall(r"target: (\S+)", corpus_block))
+    uncovered = []
+    for target in dedicated_lane_targets(buck_source):
+        sharded = {
+            candidate
+            for candidate in matrix_targets
+            if candidate.startswith(f"{target}-shard-")
+        }
+        if target not in matrix_targets and not sharded:
+            uncovered.append(target)
+    return uncovered
+
 
 def ci_executed_targets(runner_source: str) -> list[str]:
     """The platform names the shared test harness believes required CI runs."""
@@ -36,6 +71,8 @@ def ci_executed_targets(runner_source: str) -> list[str]:
     if not match:
         raise ValueError("CI_EXECUTED_TARGETS not found in the test-runner source")
     return re.findall(r'"([^"]+)"', match.group("body"))
+
+
 SPEC = importlib.util.spec_from_file_location("ci_required_results", RESULTS_SCRIPT)
 RESULTS = importlib.util.module_from_spec(SPEC)
 assert SPEC.loader is not None
@@ -72,6 +109,7 @@ def validate(
     ci_path: Path,
     native_runner_path: Path = NATIVE_RUNNER_SCRIPT,
     test_runner_path: Path = TEST_RUNNER_SOURCE,
+    buck_path: Path = ROOT_BUCK,
 ) -> list[str]:
     workflow = ci_path.read_text()
     native_runner = native_runner_path.read_text()
@@ -137,6 +175,16 @@ def validate(
     ):
         if required not in linux:
             errors.append(f"linux-premerge responsibility missing {required!r}")
+
+    # RUE-1163: the corpora that own a platform-corpus job are marked in BUCK
+    # with `rue_ci_dedicated_lane`, and test.sh subtracts that label on CI. The
+    # workflow must not also name them in an environment variable — that was the
+    # protocol the label replaced, and two sources would drift.
+    if "RUE_CI_DEFER_HEAVY_SUITES" in workflow:
+        errors.append(
+            "RUE_CI_DEFER_HEAVY_SUITES is retired; mark the corpus "
+            "`rue_ci_dedicated_lane` in BUCK instead"
+        )
 
     native = jobs.get("native-platforms", "")
     for required in (
@@ -213,6 +261,25 @@ def validate(
                     f"no longer contains {marker!r}"
                 )
 
+    # RUE-1163: every corpus the linux-premerge suite skips by label must be run
+    # by a platform-corpus entry, directly or through its shards.
+    try:
+        buck_source = buck_path.read_text()
+    except OSError as error:
+        errors.append(f"root BUCK file unreadable: {error}")
+    else:
+        labeled = dedicated_lane_targets(buck_source)
+        if not labeled:
+            errors.append(
+                "no corpus carries rue_ci_dedicated_lane; linux-premerge would "
+                "re-run the corpora that have their own jobs"
+            )
+        for target in uncovered_dedicated_lanes(buck_source, corpus):
+            errors.append(
+                f"{target} is marked {DEDICATED_LANE_LABEL} (so the premerge "
+                "suite skips it) but no platform-corpus entry runs it"
+            )
+
     for sanitizer in ("valgrind", "asan"):
         block = jobs.get(sanitizer, "")
         if "runs-on: ubuntu-latest" not in block:
@@ -229,13 +296,21 @@ def main() -> int:
     parser = argparse.ArgumentParser()
     parser.add_argument("workflow", type=Path)
     parser.add_argument(
+        "--buck",
+        type=Path,
+        default=ROOT_BUCK,
+        help="root BUCK file declaring which corpora own a required-CI job",
+    )
+    parser.add_argument(
         "--test-runner-source",
         type=Path,
         default=TEST_RUNNER_SOURCE,
         help="rue-test-runner source declaring the platform responsibility matrix",
     )
     args = parser.parse_args()
-    errors = validate(args.workflow, NATIVE_RUNNER_SCRIPT, args.test_runner_source)
+    errors = validate(
+        args.workflow, NATIVE_RUNNER_SCRIPT, args.test_runner_source, args.buck
+    )
     if errors:
         for error in errors:
             print(f"error: {error}")

--- a/test.sh
+++ b/test.sh
@@ -54,7 +54,6 @@ set -euo pipefail
 # inputs. Nothing here parses output to decide what really ran.
 
 cd "$(dirname "$0")"
-repo_root="$PWD"
 
 requested_test_tier="${RUE_TEST_TIER:-}"
 test_tier="${requested_test_tier:-standard}"
@@ -95,13 +94,6 @@ print_test_suite_result() {
     fi
 }
 trap print_test_suite_result EXIT
-
-REPOSITORY_QUALITY_GATES=(
-    //:tutorial-snippet-tool-tests
-    //:tutorial-snippet-tests
-    //:spec-traceability
-    //:adr-registry-validation
-)
 
 if [[ $# -eq 0 ]]; then
     # Fail closed before executing anything if a target is unowned, multiply
@@ -176,27 +168,22 @@ else
     echo "Running unit tests..."
     ./buck2 test //crates/...
 
-    # Get the path to the rue binary (this also builds it if needed).
-    # scripts/rue-bin resolves it to a stable absolute path.
-    RUE_BINARY="$(./scripts/rue-bin)"
-
+    # RUE-1163: each harness has a command_alias carrying the corpus's declared
+    # inputs, so a filtered run plumbs no environment by hand. The previous
+    # spelling set a smaller set than BUCK does — it never passed
+    # RUE_REAL_STD_PATH, so `real_std` spec and UI cases resolved the standard
+    # library through a cwd-relative fallback that only worked because this
+    # script cd's to the repository root. A filtered run now uses exactly the
+    # inputs //:spec-tests, //:ui-tests, and //:cli-tests use.
     echo "Running spec tests..."
-    RUE_BINARY="$RUE_BINARY" \
-    RUE_SPEC_CASES="crates/rue-spec/cases" \
-    ./buck2 run //crates/rue-spec:rue-spec -- --quiet "$@"
+    ./buck2 run //crates/rue-spec:spec -- --quiet "$@"
 
     echo "Running UI tests..."
-    RUE_BINARY="$RUE_BINARY" \
-    RUE_UI_CASES="crates/rue-ui-tests/cases" \
-    ./buck2 run //crates/rue-ui-tests:rue-ui-tests -- --quiet "$@"
+    ./buck2 run //crates/rue-ui-tests:ui -- --quiet "$@"
 
     echo "Running CLI integration tests..."
-    RUE_BINARY="$RUE_BINARY" \
-    RUE_CLI_CASES="crates/rue-cli-tests/cases" \
-    RUE_EXAMPLES_DIR="$repo_root/examples" \
-    RUE_STD_DIR="std" \
-    ./buck2 run //crates/rue-cli-tests:rue-cli-tests -- --quiet "$@"
+    ./buck2 run //crates/rue-cli-tests:cli -- --quiet "$@"
 
     echo "Running repository quality gates..."
-    ./buck2 test "${REPOSITORY_QUALITY_GATES[@]}"
+    ./buck2 test //:repository-quality-gates
 fi

--- a/test.sh
+++ b/test.sh
@@ -36,16 +36,22 @@ set -euo pipefail
 # trusting `$?`. (The tally text alone is not a verdict: a partial run can print
 # a green-looking count and still have failed a later gate.)
 #
-# CORPUS-OMISSION AUDIT (RUE-924). A green `buck2 test //...` summary is only
-# trustworthy if the compiler-consuming corpus harnesses (cli/spec/ui/oracle/
-# reproducibility/tutorial) actually EXECUTED. A suite that never ran cannot
-# fail, so the exit code alone cannot catch its disappearance — a served
-# test-result cache entry, an accidental target-pattern narrowing, or a
-# platform gate can all silently drop a suite, and one such omission once let a
-# Pass tally hide five real CLI-case failures that CI caught. The unfiltered
-# path therefore captures the run, streams it live, and asserts each required
-# corpus harness produced a Pass/Fail result line; a missing one is a HARD
-# failure even when buck2 exited 0.
+# CORPUS COMPLETENESS (RUE-924, reworked by RUE-1163). A green summary is only
+# trustworthy if the compiler-consuming corpus harnesses actually EXECUTED: a
+# suite that never ran cannot fail, and one such omission once let a Pass tally
+# hide five real CLI-case failures that CI caught. This script used to defend
+# that by tee'ing every invocation into a log and grepping for a result line per
+# entry in a hand-maintained required-corpus list.
+#
+# That defense is now structural instead. Heavy suites come from
+# `//test_tiers.bxl:heavy_suites`, which computes membership from the same
+# labels that define the tiers, so the list cannot go stale against BUCK. Each
+# one is then run as a NAMED target: a misspelled or deleted target is a Buck
+# error rather than a quietly missing log line, and a `//...` pattern can no
+# longer narrow underneath the run. And since RUE-1118/RUE-1163 every corpus is
+# a build action whose stamp its test asserts, so buck2 exiting 0 for a named
+# corpus means that corpus passed — in this run or in a cached one over the same
+# inputs. Nothing here parses output to decide what really ran.
 
 cd "$(dirname "$0")"
 repo_root="$PWD"
@@ -97,112 +103,52 @@ REPOSITORY_QUALITY_GATES=(
     //:adr-registry-validation
 )
 
-# The compiler-consuming corpus harnesses that an unfiltered run MUST actually
-# execute (RUE-924). Each compiles and/or runs real programs through the rue
-# binary, so a silent omission (cache, pattern narrowing, platform gate) is
-# exactly the failure that hides miscompilations behind a green tally. The
-# unfiltered path audits that every one of these produced a result line.
-REQUIRED_PREMERGE_CORPUS_HARNESSES=(
-    //:cli-tests
-    //:large-example-caldera-canary
-    //:large-example-meridian-canary
-    //:spec-tests
-    //:ui-tests
-    //:oracle-diff-generated-smoke
-    //:reproducible-programs
-    //:tutorial-snippet-tests
-    //:frontend-diff-test
-)
-
-REQUIRED_SLOW_CORPUS_HARNESSES=(
-    //:cli-tests-slow
-    # The RUE-205/RUE-204 codegen differential. Both corpora run every runnable
-    # case through the reference interpreter, so a silent omission here hides
-    # exactly the miscompilation class the audit exists for (RUE-1117).
-    //crates/rue-oracle-diff:oracle-diff-test
-    //crates/rue-oracle-diff:oracle-diff-spec-test
-)
-
 if [[ $# -eq 0 ]]; then
     # Fail closed before executing anything if a target is unowned, multiply
     # owned, or a named tier has no real members.
     ./buck2 bxl //test_tiers.bxl:validate
 
-    # Keep discovery broad so new crate and repository tests cannot disappear
-    # behind a hand-maintained list. Heavy opaque harnesses are labeled in BUCK:
-    # query that label from the live graph, exclude it from the broad pass, then
-    # run every returned target alone. A newly labeled target is automatically
-    # included without ever putting the whole heavy set in one test invocation.
-    # RUE-1116: the CI-only CLI shards are labeled rue_heavy_suite (so
-    # ci-heavy-suite accepts them and the broad pass excludes them) AND
-    # rue_cli_shard. A local full run must execute the monolithic //:cli-tests
-    # exactly once instead of re-running every 1/N slice, so subtract the
-    # rue_cli_shard set from heavy-suite discovery here.
-    cli_shard_targets="$(./buck2 uquery 'attrfilter(labels, rue_cli_shard, //...)')"
-    heavy_query='attrfilter(labels, rue_heavy_suite, //...)'
-    tier_label=""
-    if [[ "$test_tier" == standard ]]; then
-        heavy_query='attrfilter(labels, rue_heavy_suite, //...) except attrfilter(labels, rue_test_tier_stress, //...)'
-    elif [[ "$test_tier" != all ]]; then
-        tier_label="rue_test_tier_$test_tier"
-        heavy_query="attrfilter(labels, rue_heavy_suite, attrfilter(labels, $tier_label, //...))"
+    # RUE-1163: heavy-suite membership is computed once, by Buck. This used to
+    # be two `buck2 uquery` invocations whose results were filtered and
+    # cross-checked in bash, duplicating the tier vocabulary the BXL already
+    # owns. The selector subtracts the CLI shards (a local full run executes the
+    # monolithic //:cli-tests once rather than re-running every 1/N slice) and,
+    # on required CI, the corpora that have their own platform job.
+    heavy_selector_args=(--tier "$test_tier" --exclude_label rue_cli_shard)
+    if [[ "${CI:-}" == "true" ]]; then
+        heavy_selector_args+=(--exclude_label rue_ci_dedicated_lane)
     fi
-
+    # Not piped into the loop: a BXL failure (an unknown tier, a stale
+    # exclusion, an unowned target) must abort under `set -e` rather than
+    # produce an empty selection that silently runs no corpus at all.
+    heavy_selection="$(./buck2 bxl //test_tiers.bxl:heavy_suites -- "${heavy_selector_args[@]}")"
     HEAVY_SUITES=()
     while IFS= read -r suite; do
         [[ -n "$suite" ]] || continue
-        grep -Fxq "$suite" <<<"$cli_shard_targets" && continue
         HEAVY_SUITES+=("$suite")
-    done < <(./buck2 uquery "$heavy_query")
-    if [[ ${#HEAVY_SUITES[@]} -eq 0 && "$test_tier" != slow && "$test_tier" != stress ]]; then
-        echo "error: Buck query found no rue_heavy_suite targets" >&2
+    done <<<"$heavy_selection"
+    if [[ ${#HEAVY_SUITES[@]} -eq 0 && "$test_tier" != stress ]]; then
+        echo "error: Buck selected no heavy suites for tier $test_tier" >&2
         exit 1
     fi
 
-    # Required CI may move selected heavy suites to their own platform runner
-    # so expensive corpus harnesses overlap instead of serializing the merge
-    # queue. This is deliberately CI-only: an ordinary local `./test.sh` still
-    # owns and audits the complete corpus in one invocation. Every deferred
-    # target must be present in Buck's live heavy-suite query; a stale or
-    # misspelled shard therefore fails here instead of becoming a false green.
-    DEFERRED_HEAVY_SUITES=()
-    if [[ -n "${RUE_CI_DEFER_HEAVY_SUITES:-}" ]]; then
-        if [[ "${CI:-}" != "true" ]]; then
-            echo "error: RUE_CI_DEFER_HEAVY_SUITES is reserved for required CI" >&2
-            exit 1
-        fi
-        read -r -a DEFERRED_HEAVY_SUITES <<<"$RUE_CI_DEFER_HEAVY_SUITES"
-        for deferred in "${DEFERRED_HEAVY_SUITES[@]}"; do
-            found=0
-            for suite in "${HEAVY_SUITES[@]}"; do
-                [[ "${suite#root}" == "${deferred#root}" ]] && found=1
-            done
-            if [[ "$found" -ne 1 ]]; then
-                echo "error: deferred CI suite is not labeled rue_heavy_suite: $deferred" >&2
-                exit 1
-            fi
-        done
+    tier_label=""
+    if [[ "$test_tier" != standard && "$test_tier" != all ]]; then
+        tier_label="rue_test_tier_$test_tier"
     fi
 
-    suite_is_deferred() {
-        local candidate="$1" deferred
-        # Bash 3.2 treats an empty array expansion as an unbound variable under
-        # `set -u`. macOS runners normally provide a newer Bash, but keeping the
-        # no-deferral path portable also makes relocated/cache-free validation
-        # behave exactly like the canonical worktree.
-        [[ -z "${RUE_CI_DEFER_HEAVY_SUITES:-}" ]] && return 1
-        for deferred in "${DEFERRED_HEAVY_SUITES[@]}"; do
-            [[ "${candidate#root}" == "${deferred#root}" ]] && return 0
-        done
-        return 1
-    }
-
-    # Stream every invocation live AND capture it into one log, so we can audit
-    # afterward that no corpus harness was silently omitted (RUE-924).
-    # PIPESTATUS[0] is buck2's real exit code (tee always exits 0), preserving
-    # the RUE-579 "exit code is authoritative" contract; the worst status across
-    # the broad pass and every heavy suite is what this script reports.
-    run_log="$(mktemp)"
+    # The worst status across the broad pass and every heavy suite is what this
+    # script reports (RUE-579: the exit code is authoritative).
+    #
+    # RUE-1163 retired the RUE-924 log audit that used to live here. It tee'd
+    # every invocation into one file and grepped for a `<Status>: root<target>`
+    # line per hand-maintained required-corpus entry, because a `//...` pattern
+    # could silently narrow and a suite that never ran could not fail. Neither
+    # premise survives: every corpus is now named explicitly from Buck's own
+    # membership (an unknown target is a Buck error, not a missing log line),
+    # and every corpus is a build action whose stamp the test asserts, so buck2
+    # exiting 0 for a named target means that corpus passed. Shell no longer
+    # parses output to decide whether the suite really ran.
     overall_status=0
     set +e
     echo "Running $test_tier unit tests and lightweight repository checks..."
@@ -212,94 +158,16 @@ if [[ $# -eq 0 ]]; then
     elif [[ -n "$tier_label" ]]; then
         broad_test_args+=(--include "$tier_label")
     fi
-    if [[ -n "${RUE_CI_DEFER_DEDICATED_SUITES:-}" ]]; then
-        if [[ "${CI:-}" != "true" ]]; then
-            echo "error: RUE_CI_DEFER_DEDICATED_SUITES is reserved for required CI" >&2
-            exit 1
-        fi
-
-        # Dedicated targets remain pre-merge coverage, but their explicit CI
-        # jobs must not also execute inside every platform's broad pass. Require
-        # the workflow's declared set to match Buck's live scheduling metadata
-        # exactly before excluding the label, so a newly tagged target cannot
-        # disappear behind a stale environment variable.
-        dedicated_query='attrfilter(labels, rue_dedicated_suite, //...)'
-        if [[ "$test_tier" == standard ]]; then
-            dedicated_query='attrfilter(labels, rue_dedicated_suite, //...) except attrfilter(labels, rue_test_tier_stress, //...)'
-        elif [[ -n "$tier_label" ]]; then
-            dedicated_query="attrfilter(labels, rue_dedicated_suite, attrfilter(labels, $tier_label, //...))"
-        fi
-        dedicated_targets="$(./buck2 uquery "$dedicated_query")"
-        read -r -a deferred_dedicated <<<"$RUE_CI_DEFER_DEDICATED_SUITES"
-        for deferred in "${deferred_dedicated[@]}"; do
-            if ! grep -Fxq "root${deferred#root}" <<<"$dedicated_targets"; then
-                echo "error: deferred CI target is not labeled rue_dedicated_suite: $deferred" >&2
-                exit 1
-            fi
-        done
-        while IFS= read -r dedicated; do
-            [[ -n "$dedicated" ]] || continue
-            found=0
-            for deferred in "${deferred_dedicated[@]}"; do
-                [[ "${dedicated#root}" == "${deferred#root}" ]] && found=1
-            done
-            if [[ "$found" -ne 1 ]]; then
-                echo "error: dedicated Buck target has no explicit CI owner: $dedicated" >&2
-                exit 1
-            fi
-        done <<<"$dedicated_targets"
-        broad_test_args+=(--exclude rue_dedicated_suite)
-    fi
-    ./buck2 test "${broad_test_args[@]}" 2>&1 | tee "$run_log"
-    step_status=${PIPESTATUS[0]}
+    ./buck2 test "${broad_test_args[@]}"
+    step_status=$?
     [[ "$step_status" -ne 0 && "$overall_status" -eq 0 ]] && overall_status=$step_status
-    if [[ ${#HEAVY_SUITES[@]} -gt 0 ]]; then
-        for suite in "${HEAVY_SUITES[@]}"; do
-            if suite_is_deferred "$suite"; then
-                echo "Deferring heavy suite $suite to its required CI shard..."
-                continue
-            fi
-            echo "Running heavy suite $suite..."
-            # Normalize Buck's configured-cell spelling before handing execution
-            # to the single audited heavy-suite runner. It owns target-specific
-            # executor arguments as well as the per-target result check.
-            ./scripts/ci-heavy-suite "${suite#root}" 2>&1 | tee -a "$run_log"
-            step_status=${PIPESTATUS[0]}
-            [[ "$step_status" -ne 0 && "$overall_status" -eq 0 ]] && overall_status=$step_status
-        done
-    fi
-    set -e
-
-    # buck2 prints exactly one "<Status>: root<target> (<time>)" summary line
-    # per executed test (Pass/Fail/Skip/Timeout/...), including cache hits. No
-    # such line for a required harness means it never ran under this invocation
-    # — neither in the broad pass nor as a heavy suite.
-    missing_corpus=()
-    required_corpus=()
-    if [[ "$test_tier" == standard || "$test_tier" == all || "$test_tier" == premerge ]]; then
-        required_corpus+=("${REQUIRED_PREMERGE_CORPUS_HARNESSES[@]}")
-    fi
-    if [[ "$test_tier" == standard || "$test_tier" == all || "$test_tier" == slow ]]; then
-        required_corpus+=("${REQUIRED_SLOW_CORPUS_HARNESSES[@]}")
-    fi
-    for target in "${required_corpus[@]}"; do
-        if suite_is_deferred "$target"; then
-            continue
-        fi
-        if ! grep -qE "(Pass|Fail|Skip|Timeout|Fatal|Omit|Flaky): root${target} " "$run_log"; then
-            missing_corpus+=("$target")
-        fi
+    for suite in "${HEAVY_SUITES[@]}"; do
+        echo "Running heavy suite $suite..."
+        ./scripts/ci-heavy-suite "$suite"
+        step_status=$?
+        [[ "$step_status" -ne 0 && "$overall_status" -eq 0 ]] && overall_status=$step_status
     done
-    rm -f "${run_log:?}"
-
-    if [[ ${#missing_corpus[@]} -gt 0 ]]; then
-        echo "=== CORPUS OMITTED (RUE-924): ${missing_corpus[*]} ===" >&2
-        echo "test.sh: the corpus harness(es) above produced no Pass/Fail result in" >&2
-        echo "test.sh: this unfiltered run; refusing to report success on a partial" >&2
-        echo "test.sh: run. If a stale test-result cache is serving them, re-run with" >&2
-        echo "test.sh: a busted cache, e.g. './buck2 test //... --no-remote-cache'." >&2
-        exit 1
-    fi
+    set -e
 
     exit "$overall_status"
 else

--- a/test_tiers.bxl
+++ b/test_tiers.bxl
@@ -91,6 +91,83 @@ def _select(ctx, tiers):
 
     ctx.output.print("\n".join(sorted(selected)))
 
+_HEAVY_LABEL = "rue_heavy_suite"
+
+def _tier_labels(tier):
+    """The tier labels a selection name covers.
+
+    `standard` is the no-argument local default: everything except the opt-in
+    stress tier. `all` is the complete union.
+    """
+    if tier == "all":
+        return _TEST_TIER_LABELS
+    if tier == "standard":
+        return [label for label in _TEST_TIER_LABELS if label != "rue_test_tier_stress"]
+    label = "rue_test_tier_" + tier
+    if label not in _TEST_TIER_LABELS:
+        fail("unknown Rue test tier '{}'".format(tier))
+    return [label]
+
+def _heavy_suites(ctx):
+    """Every heavy corpus in the requested tier, as an ordered target list.
+
+    RUE-1163: this is the one place heavy-suite membership is computed. It used
+    to be duplicated in test.sh as a pair of `buck2 uquery` invocations whose
+    results were filtered, cross-checked, and audited in bash; the shell now
+    consumes this list and reports Buck's exit codes rather than re-deriving
+    what should have run and grepping a log to find out whether it did.
+
+    Args (via `--`):
+        tier: premerge | slow | stress | all | standard.
+        exclude_label: labels to subtract. `rue_cli_shard` is how a local full
+            run executes the monolithic //:cli-tests once instead of re-running
+            every 1/N slice.
+        exclude_target: specific targets a caller schedules elsewhere (required
+            CI gives the biggest corpora their own platform jobs). Every name
+            must be in the tier's heavy set, so a stale or misspelled exclusion
+            fails here instead of silently shrinking the corpus.
+    """
+    tiers = _tier_labels(ctx.cli_args.tier)
+    excluded_labels = ctx.cli_args.exclude_label or []
+
+    # Buck spells targets in this cell `root//:name`; every caller (CI matrices,
+    # scripts/ci-heavy-suite, this repository's docs) spells them `//:name`.
+    # Normalize here so the shell never has to strip a prefix to compare two
+    # spellings of the same target.
+    requested_exclusions = [
+        target[len("root"):] if target.startswith("root//") else target
+        for target in ctx.cli_args.exclude_target or []
+    ]
+
+    selected = []
+    for test in _owned_tests(ctx):
+        labels = test.get_attr("labels")
+        if _HEAVY_LABEL not in labels:
+            continue
+        if [label for label in excluded_labels if label in labels]:
+            continue
+        target_tiers = _target_tiers(test)
+        if len(target_tiers) == 1 and target_tiers[0] in tiers:
+            name = "{}".format(test.label)
+            selected.append(name[len("root"):] if name.startswith("root//") else name)
+
+    unknown = [
+        target
+        for target in requested_exclusions
+        if target not in selected
+    ]
+    if unknown:
+        fail(
+            "excluded target(s) are not heavy suites in tier {}: {}\nheavy suites are:\n{}".format(
+                ctx.cli_args.tier,
+                ", ".join(sorted(unknown)),
+                "\n".join(sorted(selected)),
+            ),
+        )
+
+    remaining = [target for target in selected if target not in requested_exclusions]
+    ctx.output.print("\n".join(sorted(remaining)))
+
 def _premerge(ctx):
     _select(ctx, ["rue_test_tier_premerge"])
 
@@ -126,4 +203,13 @@ stress = bxl_main(
 all = bxl_main(
     impl = _all,
     cli_args = {},
+)
+
+heavy_suites = bxl_main(
+    impl = _heavy_suites,
+    cli_args = {
+        "exclude_label": cli_args.option(cli_args.list(cli_args.string())),
+        "exclude_target": cli_args.option(cli_args.list(cli_args.string())),
+        "tier": cli_args.string(),
+    },
 )


### PR DESCRIPTION
Refs RUE-1163. Suite membership, corpus completeness, timeout profiles, and the filtered developer path move from `test.sh` into Buck. The serialization loop and the host-wide lock are deliberately left for a follow-up — see "What's left" below.

`test.sh` goes from **334 to 189 lines**; `scripts/ci-heavy-suite` from **95 to 75**, with no per-target branch remaining in either.

## Every corpus is a cacheable action

RUE-1118 converted five of thirteen corpus suites and stopped. Two of the rest were documented as blocked on their input contracts; the current sources no longer match that description — `scripts/test-reproducible-output.sh` guards all four of its inputs with `${VAR:?}` and reads nothing else from the checkout.

All eight remaining are converted. Measured on `reproducible-programs`: **1m11s to execute, 0.15s to replay**. Shell-script harnesses get an `sh_binary` wrapper, since `harness` is a dep rather than a source path.

Worth stating plainly: caching a suite whose subject *is* determinism means a hit replays a proof rather than re-running it. That is the bargain every corpus here already takes, and RUE-1159's repetition workflow runs cache-free for exactly that class.

## A latent timeout bug, found by wiring the two sources together

A corpus action gets no test-executor timeout, so `timeout_seconds` in BUCK is the only bound on a wedged harness. Nothing connected it to the deadline `cli-timeout-policy.py` derives from the measured weights, and they had already drifted:

```
//:cli-tests   BUCK bound 1800s   derived deadline 3600s   measured expected cost 2203s
```

A healthy run could be killed, on all three platforms. The tool gains a `--buck` mode checking every corpus bound against the derived deadline per platform, wired into `//:cli-timeout-policy-validation` with BUCK as a declared input, and `//:cli-tests` is raised to 3700s.

## Membership and completeness

`test.sh` discovered heavy suites with two `buck2 uquery` invocations, filtered and cross-checked them in bash, then proved completeness by tee'ing everything into a log and grepping for a `<Status>: root<target>` line per entry in a hand-maintained list. Shell decided what should run, and shell decided whether it had.

Membership moves to `//test_tiers.bxl:heavy_suites`, beside the tier vocabulary it already owned. It validates its exclusions — a stale or misspelled one fails there rather than silently shrinking the corpus — and returns targets. `test.sh` runs each as a **named** target and reports Buck's exit codes.

That makes the RUE-924 audit unnecessary rather than merely deleted. Its premise was that a `//...` pattern could narrow underneath a run and a suite that never ran could not fail. Neither survives: an unknown target is a Buck error, not a missing log line, and every corpus is now an action whose stamp its test asserts, so buck2 exiting 0 for a named corpus means that corpus passed. The same reasoning retires `ci-heavy-suite`'s label query and result grep.

## Two environment protocols removed

- `RUE_CI_DEFER_HEAVY_SUITES` named `//:cli-tests` and `//:spec-tests` in `ci.yml` and had `test.sh` re-derive and cross-check them. Those corpora now carry `rue_ci_dedicated_lane` in BUCK; `test.sh` subtracts the label when `CI=true`, and `validate-ci-gate.py` fails if a labeled corpus has no platform-corpus job, if none carries the label, or if the variable reappears.
- `RUE_CI_DEFER_DEDICATED_SUITES` had **no caller at all** — no workflow set it — so its ~38 lines of validation never ran. Deleted.

## The filtered developer path

`test.sh <pattern>` and `scripts/rue spec|cli|ui` each hand-wrote the corpus environment, and both had drifted: neither passed `RUE_REAL_STD_PATH`, so `real_std` spec and UI cases resolved the standard library through a cwd-relative fallback instead of the declared input. It worked only because both scripts `cd` to the repository root first — the undeclared-input hazard the BUCK header warns about, and the same bug RUE-1118 fixed for `//:ui-tests`.

Each harness gets a `command_alias` carrying its corpus's declared inputs:

```
./buck2 run //crates/rue-spec:spec -- 4.2
./buck2 run //crates/rue-ui-tests:ui -- <filter>
./buck2 run //crates/rue-cli-tests:cli -- <filter>
```

`RUE_CLI_CASE_TIER` is deliberately unset on the CLI alias, which the harness reads as `all`: a developer filtering by name wants every tier's cases, where `//:cli-tests` bounds itself to the premerge inventory.

`$(location ...)` expands to an absolute path in a `command_alias` — verified directly, then end to end through `cli.examples::hello` — so the RUE-537/RUE-550 property, a filtered examples case staying readable after the harness changes to a per-case directory, is Buck's guarantee rather than a `$repo_root/...` string built in shell.

The four repository quality gates move from a bash array into the `//:repository-quality-gates` test_suite.

## Contract tests

Every wrapper-contract test that asserted an orchestration internal now asserts the contract instead: the flags handed to the selector and the targets run afterwards, that each corpus is invoked bare, that the wrappers set no corpus environment at all, and gate membership read from BUCK rather than grepped out of `test.sh`.

## Testing

`RUE_TEST_TIER=premerge ./test.sh` passes against the rewritten script, running all six premerge heavy suites from Buck's selection. Also green: 107 wrapper checks, 31 build-sharing checks, `//:ci-gate-validation`, `//:ci-gate-validator-tool-tests`, `//:tier-ci-selector-validation`, `//:cli-timeout-policy-validation`, `//:tutorial-snippet-tool-tests`, `//:repository-quality-gates`, `./fmt.sh check`.

## What's left

Tracked for a follow-up on RUE-1163, so this PR's blast radius stays reviewable:

- the one-at-a-time heavy-suite loop, and the worst-status aggregation that exists only because there are N invocations;
- `scripts/with-full-suite-lock` (118 lines), the host-wide serialization the ticket wants gone.

Both are about scheduling rather than ownership, and the risk in dropping them is CI-runner concurrency, which is only really measurable by landing it.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cv3HLfUuxX2wTww3BJz5Qi)_