### PR TITLE
Delete the retired merge, definition-snapshot, and RIR peer paths

### DIFF
--- a/crates/rue-compiler/src/bound_definitions.rs
+++ b/crates/rue-compiler/src/bound_definitions.rs
@@ -1190,8 +1190,7 @@ mod tests {
     use rue_span::FileId;
 
     use super::*;
-    use crate::parsed_modules::parse_source_snapshot_modules;
-    use crate::{SourceMetadata, SourceSnapshot, lower_canonical_rir, merge_parsed_modules};
+    use crate::{SourceMetadata, SourceSnapshot};
 
     fn snapshot(entries: &[(u32, &str, &str, &str)], root: u32) -> SourceSnapshot {
         let physical = entries
@@ -1214,11 +1213,10 @@ mod tests {
     }
 
     fn bind(snapshot: &SourceSnapshot) -> BoundDefinitionSet {
-        let parsed = parse_source_snapshot_modules(snapshot).unwrap();
-        let merged = merge_parsed_modules(&parsed).unwrap();
-        let rir = lower_canonical_rir(&merged).unwrap();
-        bind_canonical_definitions(&merged, &rir, PreviewFeatures::new(), Target::default())
-            .unwrap()
+        let stages = crate::test_support::test_frontend_stages(snapshot).unwrap();
+        let merged = &stages.merged;
+        let rir = &stages.rir;
+        bind_canonical_definitions(merged, rir, PreviewFeatures::new(), Target::default()).unwrap()
     }
 
     fn export(
@@ -1228,13 +1226,13 @@ mod tests {
         Arc<[crate::DurableDeclarationSemantic]>,
         rue_air::SemanticDeclarationExportWork,
     ) {
-        let parsed = parse_source_snapshot_modules(snapshot).unwrap();
-        let merged = merge_parsed_modules(&parsed).unwrap();
-        let rir = lower_canonical_rir(&merged).unwrap();
+        let stages = crate::test_support::test_frontend_stages(snapshot).unwrap();
+        let merged = &stages.merged;
+        let rir = &stages.rir;
         let imports = crate::import_graph::import_free_canonical_graph(merged.ast()).unwrap();
         bind_canonical_declaration_semantics(
-            &merged,
-            &rir,
+            merged,
+            rir,
             PreviewFeatures::new(),
             Target::default(),
             &imports,
@@ -1252,12 +1250,12 @@ mod tests {
     fn compare(
         snapshot: &SourceSnapshot,
     ) -> (crate::DurableSemanticProjectionWork, DeclarationBindingWork) {
-        let parsed = parse_source_snapshot_modules(snapshot).unwrap();
-        let merged = merge_parsed_modules(&parsed).unwrap();
-        let rir = lower_canonical_rir(&merged).unwrap();
+        let stages = crate::test_support::test_frontend_stages(snapshot).unwrap();
+        let merged = &stages.merged;
+        let rir = &stages.rir;
         compare_canonical_durable_declaration_install(
-            &merged,
-            &rir,
+            merged,
+            rir,
             PreviewFeatures::new(),
             Target::default(),
         )
@@ -1316,14 +1314,14 @@ mod tests {
         }
 
         let (_, old_durable, _) = export(&first);
-        let parsed = parse_source_snapshot_modules(&relocated).unwrap();
-        let merged = merge_parsed_modules(&parsed).unwrap();
-        let rir = lower_canonical_rir(&merged).unwrap();
+        let stages = crate::test_support::test_frontend_stages(&relocated).unwrap();
+        let merged = &stages.merged;
+        let rir = &stages.rir;
         let current_definitions = bind(&relocated);
         let imports = crate::import_graph::import_free_canonical_graph(merged.ast()).unwrap();
         let shells = crate::canonical_semantic::query_owned_declaration_shells_for_test(
-            &merged,
-            &rir,
+            merged,
+            rir,
             PreviewFeatures::new(),
             Target::default(),
             &imports,
@@ -1331,7 +1329,7 @@ mod tests {
         .unwrap();
         let shell_records = shells.declaration_shells().cloned().collect::<Vec<_>>();
         let (projected, work) = crate::project_durable_declaration_semantics(
-            &merged,
+            merged,
             &current_definitions,
             &shell_records,
             &old_durable,
@@ -1365,13 +1363,13 @@ mod tests {
             .collect::<Vec<_>>();
         let input = snapshot(&borrowed, 1);
         let (definitions, durable, _) = export(&input);
-        let parsed = parse_source_snapshot_modules(&input).unwrap();
-        let merged = merge_parsed_modules(&parsed).unwrap();
-        let rir = lower_canonical_rir(&merged).unwrap();
+        let stages = crate::test_support::test_frontend_stages(&input).unwrap();
+        let merged = &stages.merged;
+        let rir = &stages.rir;
         let imports = crate::import_graph::import_free_canonical_graph(merged.ast()).unwrap();
         let shells = crate::canonical_semantic::query_owned_declaration_shells_for_test(
-            &merged,
-            &rir,
+            merged,
+            rir,
             PreviewFeatures::new(),
             Target::default(),
             &imports,
@@ -1379,7 +1377,7 @@ mod tests {
         .unwrap();
         let shell_records = shells.declaration_shells().cloned().collect::<Vec<_>>();
         let (projected, projection) = crate::project_durable_declaration_semantics(
-            &merged,
+            merged,
             &definitions,
             &shell_records,
             &durable,
@@ -1398,13 +1396,13 @@ mod tests {
     fn duplicate_projection_input_fails_before_shells_are_consumed() {
         let input = snapshot(&[(1, "/main.rue", "main.rue", "fn main() -> i32 { 0 }")], 1);
         let (definitions, durable, _) = export(&input);
-        let parsed = parse_source_snapshot_modules(&input).unwrap();
-        let merged = merge_parsed_modules(&parsed).unwrap();
-        let rir = lower_canonical_rir(&merged).unwrap();
+        let stages = crate::test_support::test_frontend_stages(&input).unwrap();
+        let merged = &stages.merged;
+        let rir = &stages.rir;
         let imports = crate::import_graph::import_free_canonical_graph(merged.ast()).unwrap();
         let shells = crate::canonical_semantic::query_owned_declaration_shells_for_test(
-            &merged,
-            &rir,
+            merged,
+            rir,
             PreviewFeatures::new(),
             Target::default(),
             &imports,
@@ -1419,7 +1417,7 @@ mod tests {
 
         assert_eq!(
             crate::project_durable_declaration_semantics(
-                &merged,
+                merged,
                 &definitions,
                 &shell_records,
                 &duplicated,
@@ -1428,7 +1426,7 @@ mod tests {
             crate::DurableSemanticProjectionFailure::DuplicateDefinition
         );
         let (projected, _) = crate::project_durable_declaration_semantics(
-            &merged,
+            merged,
             &definitions,
             &shell_records,
             &durable,
@@ -1449,12 +1447,12 @@ mod tests {
             )],
             1,
         );
-        let parsed = parse_source_snapshot_modules(&input).unwrap();
-        let merged = merge_parsed_modules(&parsed).unwrap();
-        let rir = lower_canonical_rir(&merged).unwrap();
+        let stages = crate::test_support::test_frontend_stages(&input).unwrap();
+        let merged = &stages.merged;
+        let rir = &stages.rir;
         compare_canonical_durable_declaration_install(
-            &merged,
-            &rir,
+            merged,
+            rir,
             PreviewFeatures::new(),
             Target::default(),
         )
@@ -1462,8 +1460,8 @@ mod tests {
         // A fresh oracle epoch remains valid after the query-owned install.
         let imports = crate::import_graph::import_free_canonical_graph(merged.ast()).unwrap();
         crate::canonical_semantic::bind_query_owned_declarations_for_test(
-            &merged,
-            &rir,
+            merged,
+            rir,
             PreviewFeatures::new(),
             Target::default(),
             &imports,
@@ -1574,8 +1572,7 @@ mod tests {
             ],
             0,
         );
-        let parsed = parse_source_snapshot_modules(&source).unwrap();
-        let merged = merge_parsed_modules(&parsed).unwrap();
+        let merged = crate::test_support::test_merged_program(&source).unwrap();
         let rue_air::SemanticExportType::Module(logical_identity) =
             rue_air::SemanticExportType::Module(Arc::from("lib.rue"))
         else {
@@ -1676,8 +1673,12 @@ mod tests {
         assert_eq!(first.work(), second.work());
     }
 
+    /// `AmbiguousSyntaxOccurrence` is defensive: merge refuses a program with
+    /// duplicate names, so a definition snapshot never carries two records for
+    /// one name key. The reachable join outcomes are asserted here; the
+    /// duplicate program is asserted to be refused instead of joined.
     #[test]
-    fn snapshot_to_durable_join_reports_missing_ambiguous_and_duplicate_outcomes_by_type() {
+    fn snapshot_to_durable_join_reports_missing_and_duplicate_outcomes_by_type() {
         let input = snapshot(
             &[(
                 1,
@@ -1687,19 +1688,22 @@ mod tests {
             )],
             1,
         );
-        let parsed = parse_source_snapshot_modules(&input).unwrap();
-        let definitions = crate::DefinitionSnapshot::from_parsed_modules(&parsed).unwrap();
-        let repeated = crate::DefinitionNameKey::new(
+        assert!(crate::test_support::test_merged_program(&input).is_err());
+
+        let merged = crate::test_support::test_merged_program(&snapshot(
+            &[(1, "/main.rue", "main.rue", "fn once() {}")],
+            1,
+        ))
+        .unwrap();
+        let definitions = merged.definitions();
+        let once = crate::DefinitionNameKey::new(
             crate::ModuleId::from_logical_path("main.rue").unwrap(),
             DefinitionNamespace::ModuleItem,
-            "repeated",
+            "once",
         );
+        join_syntax_occurrence(definitions, &once, DefinitionKind::Function).unwrap();
         assert_eq!(
-            join_syntax_occurrence(&definitions, &repeated, DefinitionKind::Function).unwrap_err(),
-            DefinitionIdentityJoinFailure::AmbiguousSyntaxOccurrence
-        );
-        assert_eq!(
-            join_syntax_occurrence(&definitions, &repeated, DefinitionKind::Struct).unwrap_err(),
+            join_syntax_occurrence(definitions, &once, DefinitionKind::Struct).unwrap_err(),
             DefinitionIdentityJoinFailure::MissingSyntaxOccurrence
         );
 
@@ -1805,24 +1809,23 @@ mod tests {
             )],
             1,
         );
-        let parsed = parse_source_snapshot_modules(&collision).unwrap();
-        let merged = merge_parsed_modules(&parsed).unwrap();
-        let rir = lower_canonical_rir(&merged).unwrap();
+        let stages = crate::test_support::test_frontend_stages(&collision).unwrap();
+        let merged = &stages.merged;
+        let rir = &stages.rir;
         assert!(
-            bind_canonical_definitions(&merged, &rir, PreviewFeatures::new(), Target::default())
+            bind_canonical_definitions(merged, rir, PreviewFeatures::new(), Target::default())
                 .is_err()
         );
 
         let source = snapshot(&[(2, "/main.rue", "main.rue", "fn main() {}")], 2);
-        let first = parse_source_snapshot_modules(&source).unwrap();
-        let second = parse_source_snapshot_modules(&source).unwrap();
-        let first = merge_parsed_modules(&first).unwrap();
-        let second = merge_parsed_modules(&second).unwrap();
-        let foreign_rir = lower_canonical_rir(&second).unwrap();
+        let first = crate::test_support::test_frontend_stages(&source).unwrap();
+        let second = crate::test_support::test_frontend_stages(&source).unwrap();
+        let first = &first.merged;
+        let foreign_rir = &second.rir;
         assert!(
             bind_canonical_definitions(
-                &first,
-                &foreign_rir,
+                first,
+                foreign_rir,
                 PreviewFeatures::new(),
                 Target::default()
             )

--- a/crates/rue-compiler/src/canonical_lower.rs
+++ b/crates/rue-compiler/src/canonical_lower.rs
@@ -3,8 +3,6 @@
 use std::cell::RefCell;
 use std::ops::Range;
 
-#[cfg(test)]
-use rue_error::CompileResult;
 use rue_error::{CompileError, ErrorKind};
 use rue_rir::RirPrinter;
 use rue_rir::{AstGen, InstRef, Rir, RirEditor, RirValidationContext, ValidatedRir};
@@ -181,102 +179,6 @@ impl CanonicalRirOutput {
             extra,
         }
     }
-}
-
-/// Lower canonical module views in stable `ModuleId` order into one RIR.
-#[cfg(test)]
-pub fn lower_canonical_rir(merged: &CanonicalMergedProgram) -> CompileResult<CanonicalRirOutput> {
-    lower_canonical_rir_with_work(merged).map_err(|(error, _)| error)
-}
-
-#[cfg(test)]
-pub(crate) fn lower_canonical_rir_with_work(
-    merged: &CanonicalMergedProgram,
-) -> Result<CanonicalRirOutput, (CompileError, CanonicalRirWork)> {
-    let ast = merged.ast();
-    let symbols = SemanticSymbolUniverse::from_modules(ast.modules());
-    let mut module_ranges = Vec::with_capacity(ast.modules().len());
-    let mut work = CanonicalRirWork::default();
-    let mut editor = RirEditor::new();
-    for module in ast.modules() {
-        let lowered =
-            lower_module_rir_with_work(module.clone()).map_err(|(error, module_work)| {
-                work.accumulate(module_work);
-                (error, work)
-            })?;
-        work.accumulate(lowered.work());
-        let appended = editor
-            .append_remapped(&lowered.rir, |local| {
-                let text = lowered
-                    .symbols
-                    .interner()
-                    .try_resolve(&local)
-                    .expect("validated module RIR symbol belongs to its module universe");
-                symbols.interner().get_or_intern(text)
-            })
-            .map_err(|error| {
-                (
-                    CompileError::new(
-                        ErrorKind::InternalError(format!("RIR module projection failed: {error}")),
-                        rue_span::Span::new(0, 0),
-                    ),
-                    work,
-                )
-            })?;
-        module_ranges.push(CanonicalRirModuleRange {
-            file_id: module.file_id(),
-            instructions: appended.instructions,
-            extra: appended.extra,
-        });
-    }
-    let sources: Vec<CanonicalRirSource> = ast
-        .modules()
-        .iter()
-        .map(|module| {
-            u32::try_from(module.source_text().len())
-                .map(|length| CanonicalRirSource {
-                    file_id: module.file_id(),
-                    revision: module.revision().clone(),
-                    length,
-                })
-                .map_err(|_| {
-                    CompileError::new(
-                        ErrorKind::InternalError(
-                            "canonical source length exceeds RIR span capacity".to_string(),
-                        ),
-                        rue_span::Span::new(0, 0),
-                    )
-                })
-        })
-        .collect::<Result<_, _>>()
-        .map_err(|error| (error, work))?;
-    let source_lengths = sources
-        .iter()
-        .map(|source| (source.file_id, source.length))
-        .collect::<Vec<_>>();
-    let validation = RirValidationContext {
-        symbol_count: symbols.interner().len(),
-        source_lengths: &source_lengths,
-    };
-    let rir = ValidatedRir::finish(editor, &validation).map_err(|error| {
-        (
-            CompileError::new(
-                ErrorKind::InternalError(format!("RIR payload validation failed: {error}")),
-                rue_span::Span::new(0, 0),
-            ),
-            work,
-        )
-    })?;
-
-    work.semantic_strings_retained = symbols.interner().len();
-    Ok(CanonicalRirOutput {
-        source_revision: ast.source_revision().clone(),
-        rir,
-        symbols,
-        work,
-        module_ranges,
-        sources,
-    })
 }
 
 impl CanonicalRirWork {
@@ -520,7 +422,7 @@ mod tests {
 
     use super::*;
     use crate::parsed_modules::{ParsedProgram, parse_source_snapshot_modules};
-    use crate::{SourceMetadata, SourceSnapshot, merge_parsed_modules};
+    use crate::{SourceMetadata, SourceSnapshot};
 
     fn assert_send_sync<T: Send + Sync>() {}
 
@@ -574,10 +476,10 @@ mod tests {
             ],
             1,
         );
-        let parsed = parse_source_snapshot_modules(&source).unwrap();
-        let merged = merge_parsed_modules(&parsed).unwrap();
-        let output = lower_canonical_rir(&merged).unwrap();
-        let rendered = print(&output);
+        let stages = crate::test_support::test_frontend_stages(&source).unwrap();
+        let merged = &stages.merged;
+        let output = &stages.rir;
+        let rendered = print(output);
 
         assert!(rendered.contains("alpha"));
         assert!(rendered.contains("beta"));
@@ -604,8 +506,7 @@ mod tests {
     #[test]
     fn projection_failure_preserves_incoming_query_work() {
         let source = snapshot(&[(1, "/main.rue", "main.rue", "fn main() -> i32 { 0 }")], 1);
-        let parsed = parse_source_snapshot_modules(&source).unwrap();
-        let merged = merge_parsed_modules(&parsed).unwrap();
+        let merged = crate::test_support::test_merged_program(&source).unwrap();
         let query_work = CanonicalRirWork {
             modules_visited: 1,
             items_visited: 1,
@@ -616,8 +517,11 @@ mod tests {
         assert_eq!(failure_work, query_work);
     }
 
+    /// Lowering consumes whatever module order [`ParsedProgram`] publishes, and
+    /// that order is canonical regardless of assembly order — so a reversed
+    /// module vector cannot reach lowering as a different program.
     #[test]
-    fn reordered_arc_assembly_has_identical_rir_and_work() {
+    fn reordered_arc_assembly_publishes_one_canonical_module_order() {
         let source = snapshot(
             &[
                 (8, "/z.rue", "z.rue", "fn zed() {}"),
@@ -629,11 +533,16 @@ mod tests {
         let mut modules = first.modules().to_vec();
         modules.reverse();
         let second = ParsedProgram::new(first.root().clone(), modules).unwrap();
-        let first = lower_canonical_rir(&merge_parsed_modules(&first).unwrap()).unwrap();
-        let second = lower_canonical_rir(&merge_parsed_modules(&second).unwrap()).unwrap();
 
-        assert_eq!(print(&first), print(&second));
-        assert_eq!(first.work(), second.work());
+        assert!(
+            first
+                .modules()
+                .iter()
+                .zip(second.modules())
+                .all(|(left, right)| Arc::ptr_eq(left, right))
+        );
+        let rir = crate::test_support::test_canonical_rir(&source).unwrap();
+        assert_eq!(rir.source_revision(), second.source_revision());
     }
 
     #[test]
@@ -655,8 +564,7 @@ mod tests {
             ],
             8,
         );
-        let parsed = parse_source_snapshot_modules(&source).unwrap();
-        let canonical = lower_canonical_rir(&merge_parsed_modules(&parsed).unwrap()).unwrap();
+        let canonical = crate::test_support::test_canonical_rir(&source).unwrap();
         let semantic = print(&canonical);
         let presentation = print_in_snapshot_order(&canonical, &source);
         assert!(semantic.find("alpha").unwrap() < semantic.find("zed").unwrap());
@@ -680,10 +588,8 @@ mod tests {
             ],
             91,
         );
-        let lower = |source: &SourceSnapshot| {
-            let parsed = parse_source_snapshot_modules(source).unwrap();
-            lower_canonical_rir(&merge_parsed_modules(&parsed).unwrap()).unwrap()
-        };
+        let lower =
+            |source: &SourceSnapshot| crate::test_support::test_canonical_rir(source).unwrap();
         let first_rir = lower(&first);
         let relocated_rir = lower(&relocated);
 
@@ -754,8 +660,7 @@ mod tests {
             ],
             2,
         );
-        let parsed = parse_source_snapshot_modules(&source).unwrap();
-        let canonical = lower_canonical_rir(&merge_parsed_modules(&parsed).unwrap()).unwrap();
+        let canonical = crate::test_support::test_canonical_rir(&source).unwrap();
         let rendered = print(&canonical);
 
         assert!(canonical.work().symbol_fields_translated > 40);

--- a/crates/rue-compiler/src/canonical_merge.rs
+++ b/crates/rue-compiler/src/canonical_merge.rs
@@ -96,13 +96,6 @@ struct CandidateDef {
     physical_path: Arc<str>,
 }
 
-#[cfg(test)]
-pub(crate) fn merge_parsed_modules(
-    program: &ParsedProgram,
-) -> Result<CanonicalMergedProgram, CompileErrors> {
-    merge_parsed_modules_in_order(program, None)
-}
-
 pub(crate) fn merge_parsed_modules_reusing_indexes(
     program: &ParsedProgram,
     indexes: &[ProjectedModuleIndex],
@@ -156,70 +149,6 @@ pub(crate) fn merge_parsed_modules_reusing_indexes(
     Ok(assemble_merged_program(program, definitions, work))
 }
 
-#[cfg(test)]
-pub(crate) fn merge_parsed_modules_for_batch(
-    program: &ParsedProgram,
-    diagnostic_order: &[ModuleId],
-) -> Result<CanonicalMergedProgram, CompileErrors> {
-    merge_parsed_modules_in_order(program, Some(diagnostic_order))
-}
-
-#[cfg(test)]
-fn merge_parsed_modules_in_order(
-    program: &ParsedProgram,
-    diagnostic_order: Option<&[ModuleId]>,
-) -> Result<CanonicalMergedProgram, CompileErrors> {
-    let (work, ordered_modules) = merge_inputs(program, diagnostic_order);
-    let errors = canonical_duplicate_errors(&ordered_modules);
-    if !errors.is_empty() {
-        return Err(CompileErrors::from(errors));
-    }
-    let (definitions, shards) = DefinitionSnapshot::from_parsed_modules_reusing(program, None)
-        .map_err(CompileErrors::from)?;
-    let mut work = work;
-    work.definition_shards_indexed = shards.shards_indexed;
-    work.definition_shards_reused = shards.shards_reused;
-    work.definition_shards_rebuilt = shards.shards_rebuilt;
-    Ok(assemble_merged_program(program, definitions, work))
-}
-
-#[cfg(test)]
-fn merge_inputs<'a>(
-    program: &'a ParsedProgram,
-    diagnostic_order: Option<&[ModuleId]>,
-) -> (CanonicalMergeWork, Vec<&'a Arc<ParsedModule>>) {
-    let work = CanonicalMergeWork {
-        modules_visited: program.modules().len(),
-        items_visited: program
-            .modules()
-            .iter()
-            .map(|module| module.ast().items.len())
-            .sum(),
-        candidates_visited: program
-            .modules()
-            .iter()
-            .map(|module| module.definitions().candidates().len())
-            .sum(),
-        ..CanonicalMergeWork::default()
-    };
-    let ordered_modules = if let Some(order) = diagnostic_order {
-        order
-            .iter()
-            .map(|module_id| {
-                program
-                    .modules()
-                    .binary_search_by(|module| module.module_id().cmp(module_id))
-                    .ok()
-                    .map(|index| &program.modules()[index])
-                    .expect("batch diagnostic order contains every parsed module")
-            })
-            .collect::<Vec<_>>()
-    } else {
-        program.modules().iter().collect()
-    };
-    (work, ordered_modules)
-}
-
 fn assemble_merged_program(
     program: &ParsedProgram,
     definitions: DefinitionSnapshot,
@@ -230,35 +159,6 @@ fn assemble_merged_program(
         definitions,
         work,
     }
-}
-
-#[cfg(test)]
-fn canonical_duplicate_errors(modules: &[&Arc<ParsedModule>]) -> Vec<CompileError> {
-    let indexes = modules
-        .iter()
-        .map(|module| {
-            module
-                .definitions()
-                .candidates()
-                .iter()
-                .map(|candidate| ModuleIndexEntry {
-                    namespace: candidate.namespace(),
-                    kind: candidate.kind(),
-                    visibility: candidate.visibility(),
-                    name: Arc::from(candidate.name()),
-                    language_item: None,
-                    name_span: candidate.name_span(),
-                    declaration_span: candidate.declaration_span(),
-                })
-                .collect::<Vec<_>>()
-        })
-        .collect::<Vec<_>>();
-    duplicate_errors(
-        modules
-            .iter()
-            .zip(&indexes)
-            .map(|(module, index)| (module.physical_path(), index.as_slice())),
-    )
 }
 
 fn canonical_duplicate_errors_from_indexes(
@@ -434,8 +334,7 @@ mod tests {
             enum kind {} struct kind {} struct record {} struct record {} \
             enum choice {} enum choice {}";
         let snapshot = snapshot(&[(1, "main.rue", "main.rue", source)], 1);
-        let canonical = parse_source_snapshot_modules(&snapshot).unwrap();
-        let canonical_errors = merge_parsed_modules(&canonical).unwrap_err();
+        let canonical_errors = crate::test_support::test_merged_program(&snapshot).unwrap_err();
         assert_eq!(canonical_errors.len(), 5);
         let errors = canonical_errors.as_slice();
         assert!(matches!(
@@ -478,41 +377,47 @@ mod tests {
             ],
             1,
         );
+        assert!(crate::test_support::test_merged_program(&snapshot).is_ok());
+        // Storage order cannot vary the outcome: a reversed module vector
+        // reassembles into the same canonical sequence the merge consumes.
         let canonical = parse_source_snapshot_modules(&snapshot).unwrap();
-        assert!(merge_parsed_modules(&canonical).is_ok());
         let mut reversed = canonical.modules().to_vec();
         reversed.reverse();
         let reordered = ParsedProgram::new(canonical.root().clone(), reversed).unwrap();
-        assert!(merge_parsed_modules(&reordered).is_ok());
+        assert!(
+            canonical
+                .modules()
+                .iter()
+                .zip(reordered.modules())
+                .all(|(left, right)| Arc::ptr_eq(left, right))
+        );
     }
 
     #[test]
-    fn batch_merge_uses_explicit_presentation_order_without_reordering_program() {
+    fn batch_merge_uses_snapshot_presentation_order_without_reordering_program() {
         // Same-file duplicates remain per-file conflicts (spec 10.5:1). With one
-        // in each module, the explicit presentation order [b, a] fixes the
+        // in each module, the snapshot's own file order [b, a] fixes the
         // diagnostic sequence (b's conflict before a's) without reordering the
-        // stored program.
+        // stored program, which stays in canonical ModuleId order.
         let snapshot = snapshot(
             &[
-                (1, "a.rue", "a.rue", "fn dup() {} fn dup() {}"),
                 (2, "b.rue", "b.rue", "fn clash() {} fn clash() {}"),
+                (1, "a.rue", "a.rue", "fn dup() {} fn dup() {}"),
             ],
             1,
         );
-        let parsed = parse_source_snapshot_modules(&snapshot).unwrap();
-        let order = [
-            ModuleId::from_logical_path("b.rue").unwrap(),
-            ModuleId::from_logical_path("a.rue").unwrap(),
-        ];
-        let errors = merge_parsed_modules_for_batch(&parsed, &order)
-            .unwrap_err()
-            .into_iter()
-            .collect::<Vec<_>>();
+        let mut session = crate::CompilerSession::new();
+        session
+            .update_for_presentation(&snapshot)
+            .into_owner_result()
+            .unwrap();
+        let errors = session.merge().unwrap_err().into_iter().collect::<Vec<_>>();
 
         // Presentation order [b, a]: b.rue's conflict (file 2) is reported
         // before a.rue's (file 1).
         assert_eq!(errors[0].span().unwrap().file_id, FileId::new(2));
         assert_eq!(errors[1].span().unwrap().file_id, FileId::new(1));
+        let parsed = parse_source_snapshot_modules(&snapshot).unwrap();
         assert_eq!(
             parsed
                 .modules()
@@ -536,8 +441,17 @@ mod tests {
         let mut reversed = first.modules().to_vec();
         reversed.reverse();
         let second = ParsedProgram::new(first.root().clone(), reversed).unwrap();
-        let first_merged = merge_parsed_modules(&first).unwrap();
-        let second_merged = merge_parsed_modules(&second).unwrap();
+        // Both assemblies publish one canonical module sequence, so the merge
+        // sees a single program however the vector arrived.
+        let first_merged = crate::test_support::test_merged_program(&snapshot).unwrap();
+        let second_merged = crate::test_support::test_merged_program(&snapshot).unwrap();
+        assert!(
+            first
+                .modules()
+                .iter()
+                .zip(second.modules())
+                .all(|(left, right)| Arc::ptr_eq(left, right))
+        );
 
         assert_eq!(first_merged.work(), second_merged.work());
         assert_eq!(
@@ -548,13 +462,19 @@ mod tests {
             definitions(first_merged.definitions()),
             definitions(second_merged.definitions())
         );
-        assert!(
+        assert_eq!(
             first_merged
                 .ast()
                 .modules()
                 .iter()
-                .zip(second_merged.ast().modules())
-                .all(|(left, right)| Arc::ptr_eq(left, right))
+                .map(|module| module.revision())
+                .collect::<Vec<_>>(),
+            second_merged
+                .ast()
+                .modules()
+                .iter()
+                .map(|module| module.revision())
+                .collect::<Vec<_>>()
         );
         assert_eq!(first_merged.work().parser_invocations, 0);
         assert_eq!(first_merged.work().ast_payload_clones, 0);
@@ -578,7 +498,7 @@ mod tests {
             left.symbol().test_local_ordinal(),
             right.symbol().test_local_ordinal()
         );
-        let merged = merge_parsed_modules(&program).unwrap();
+        let merged = crate::test_support::test_merged_program(&snapshot).unwrap();
         assert_eq!(
             definitions(merged.definitions())
                 .iter()
@@ -588,41 +508,61 @@ mod tests {
         );
     }
 
+    /// Duplicate occurrences are retained where production holds them — each
+    /// module's own definition index, built by the parse query — and the
+    /// program that contains them is refused by merge rather than reaching a
+    /// definition snapshot.
     #[test]
-    fn definition_snapshot_retains_duplicate_occurrences_without_resolving_spurs() {
+    fn duplicate_occurrences_are_retained_per_module_and_refused_by_merge() {
         let snapshot = snapshot(
             &[(1, "main.rue", "main.rue", "fn same() {} fn same() {}")],
             1,
         );
         let program = parse_source_snapshot_modules(&snapshot).unwrap();
-        let definitions = DefinitionSnapshot::from_parsed_modules(&program).unwrap();
-        let key = crate::DefinitionNameKey::new(
-            program.root().clone(),
-            crate::DefinitionNamespace::ModuleItem,
-            "same",
+        let candidates = program.modules()[0]
+            .definitions()
+            .candidates_named(crate::DefinitionNamespace::ModuleItem, "same")
+            .collect::<Vec<_>>();
+        assert_eq!(candidates.len(), 2);
+        assert_ne!(candidates[0].occurrence(), candidates[1].occurrence());
+        assert_eq!(
+            candidates[0].symbol().test_local_ordinal(),
+            candidates[1].symbol().test_local_ordinal()
         );
-        let matches = definitions.definitions_named(&key).collect::<Vec<_>>();
-        assert_eq!(matches.len(), 2);
-        assert_ne!(matches[0].id(), matches[1].id());
+
+        assert!(crate::test_support::test_merged_program(&snapshot).is_err());
     }
 
     #[test]
     fn trusted_snapshot_canonicalizes_equal_bytes_without_rehashing() {
+        // Two files whose bytes are equal but whose buffers are distinct
+        // allocations, so canonicalization cannot be an allocation accident.
         let text = "fn same() {}";
-        let left_snapshot = snapshot(&[(1, "left.rue", "left.rue", text)], 1);
-        let right_snapshot = snapshot(&[(2, "right.rue", "right.rue", text)], 2);
-        let left = parse_source_snapshot_modules(&left_snapshot).unwrap();
-        let right = parse_source_snapshot_modules(&right_snapshot).unwrap();
-        assert!(!Arc::ptr_eq(
-            &left.modules()[0].shared_source_text(),
-            &right.modules()[0].shared_source_text()
-        ));
-        let program = ParsedProgram::new(
-            left.root().clone(),
-            vec![left.modules()[0].clone(), right.modules()[0].clone()],
+        let metadata = SourceMetadata::new(
+            FileId::new(1),
+            [
+                (FileId::new(1), String::from("left.rue")),
+                (FileId::new(2), String::from("right.rue")),
+            ]
+            .into_iter()
+            .collect(),
+            [
+                (FileId::new(1), String::from("left.rue")),
+                (FileId::new(2), String::from("right.rue")),
+            ]
+            .into_iter()
+            .collect(),
         )
         .unwrap();
-        let merged = merge_parsed_modules(&program).unwrap();
+        let left_text = Arc::new(text.to_owned());
+        let right_text = Arc::new(text.to_owned());
+        assert!(!Arc::ptr_eq(&left_text, &right_text));
+        let source = SourceSnapshot::new(
+            metadata,
+            vec![(FileId::new(1), left_text), (FileId::new(2), right_text)],
+        )
+        .unwrap();
+        let merged = crate::test_support::test_merged_program(&source).unwrap();
         let rebuilt = merged.definitions().source_snapshot();
         assert_eq!(rebuilt.source_store().len(), 1);
         assert!(Arc::ptr_eq(
@@ -635,10 +575,10 @@ mod tests {
     #[test]
     fn canonical_merged_ast_rejects_independently_reparsed_view() {
         let snapshot = snapshot(&[(1, "main.rue", "main.rue", "fn main() {}")], 1);
-        let admitted = parse_source_snapshot_modules(&snapshot).unwrap();
         let foreign = parse_source_snapshot_modules(&snapshot).unwrap();
-        let merged = merge_parsed_modules(&admitted).unwrap();
-        let admitted_view = admitted.ast_views().next().unwrap();
+        let merged = crate::test_support::test_merged_program(&snapshot).unwrap();
+        let admitted_view =
+            crate::parsed_modules::ParsedAstView::from_module(merged.ast().modules()[0].clone());
         let foreign_view = foreign.ast_views().next().unwrap();
         merged.ast().validate_view(&admitted_view).unwrap();
         assert_eq!(

--- a/crates/rue-compiler/src/canonical_semantic.rs
+++ b/crates/rue-compiler/src/canonical_semantic.rs
@@ -2235,10 +2235,9 @@ mod tests {
         BodyOwnerTokenWork, CanonicalSemanticOutput, CanonicalSemanticWork,
         analyze_canonical_program_for_test_support,
     };
-    use crate::parsed_modules::parse_source_snapshot_modules;
     use crate::{
         CanonicalRirOutput, CompileOptions, FunctionWithCfg, PreviewFeatures, SourceMetadata,
-        SourceSnapshot, Target, lower_canonical_rir, merge_parsed_modules,
+        SourceSnapshot, Target,
     };
 
     fn snapshot(entries: &[(u32, &str, &str, &str)], root: u32) -> SourceSnapshot {
@@ -2263,9 +2262,9 @@ mod tests {
 
     fn assert_token_preparation_preserves_source_errors(source: &str) {
         let source = snapshot(&[(1, "/main.rue", "main.rue", source)], 1);
-        let parsed = parse_source_snapshot_modules(&source).unwrap();
-        let merged = merge_parsed_modules(&parsed).unwrap();
-        let rir = lower_canonical_rir(&merged).unwrap();
+        let stages = crate::test_support::test_frontend_stages(&source).unwrap();
+        let merged = &stages.merged;
+        let rir = &stages.rir;
         let options = CompileOptions::default();
         let imports = crate::import_graph::import_free_canonical_graph(merged.ast()).unwrap();
 
@@ -2280,7 +2279,7 @@ mod tests {
             Ok(_) => panic!("test input must fail ordinary declaration binding"),
         };
         let canonical =
-            analyze_canonical_program_for_test_support(&merged, &rir, &options, &imports, false)
+            analyze_canonical_program_for_test_support(merged, rir, &options, &imports, false)
                 .unwrap_err();
         let messages = |errors: crate::CompileErrors| {
             errors.iter().map(ToString::to_string).collect::<Vec<_>>()
@@ -2305,13 +2304,13 @@ mod tests {
     )]
     fn canonical_sema_cannot_invoke_raw_declaration_discovery() {
         let source = snapshot(&[(1, "/main.rue", "main.rue", "fn main() {}")], 1);
-        let parsed = parse_source_snapshot_modules(&source).unwrap();
-        let merged = merge_parsed_modules(&parsed).unwrap();
-        let rir = lower_canonical_rir(&merged).unwrap();
+        let stages = crate::test_support::test_frontend_stages(&source).unwrap();
+        let merged = &stages.merged;
+        let rir = &stages.rir;
         let imports = crate::import_graph::import_free_canonical_graph(merged.ast()).unwrap();
         crate::bound_definitions::configure_canonical_sema(
-            &merged,
-            &rir,
+            merged,
+            rir,
             PreviewFeatures::new(),
             Target::default(),
             &imports,
@@ -2325,15 +2324,18 @@ mod tests {
         snapshot: &SourceSnapshot,
         options: &CompileOptions,
         ids: bool,
-    ) -> (CanonicalSemanticOutput, CanonicalRirOutput) {
-        let parsed = parse_source_snapshot_modules(snapshot).unwrap();
-        let merged = merge_parsed_modules(&parsed).unwrap();
-        let rir = lower_canonical_rir(&merged).unwrap();
+    ) -> (CanonicalSemanticOutput, std::sync::Arc<CanonicalRirOutput>) {
+        let stages = crate::test_support::test_frontend_stages(snapshot).unwrap();
         let imports = crate::test_support::test_import_graph(snapshot).unwrap();
-        let output =
-            analyze_canonical_program_for_test_support(&merged, &rir, options, &imports, ids)
-                .unwrap();
-        (output, rir)
+        let output = analyze_canonical_program_for_test_support(
+            &stages.merged,
+            &stages.rir,
+            options,
+            &imports,
+            ids,
+        )
+        .unwrap();
+        (output, stages.rir)
     }
 
     fn function_fingerprint(

--- a/crates/rue-compiler/src/definition_snapshot.rs
+++ b/crates/rue-compiler/src/definition_snapshot.rs
@@ -193,24 +193,6 @@ struct DefinitionShardRecord {
 }
 
 impl DefinitionShard {
-    #[cfg(test)]
-    fn matches(&self, module: &crate::parsed_modules::ParsedModule) -> bool {
-        self.file_id == module.file_id()
-            && self.records.len() == module.definitions().candidates().len()
-            && self
-                .records
-                .iter()
-                .zip(module.definitions().candidates())
-                .all(|(record, candidate)| {
-                    record.namespace == candidate.namespace()
-                        && record.kind == candidate.kind()
-                        && record.visibility == candidate.visibility()
-                        && record.name.as_ref() == candidate.name()
-                        && record.name_span == candidate.name_span()
-                        && record.declaration_span == candidate.declaration_span()
-                })
-    }
-
     fn matches_index(
         &self,
         module: &crate::parsed_modules::ParsedModule,
@@ -279,124 +261,6 @@ pub struct DefinitionSnapshot {
 }
 
 impl DefinitionSnapshot {
-    /// Build durable definition candidates from self-contained parsed modules.
-    ///
-    /// Names are already owned values in each module's definition index; this
-    /// path performs no interner lookup, AST traversal, or source-byte hashing.
-    #[cfg(test)]
-    pub fn from_parsed_modules(
-        program: &crate::parsed_modules::ParsedProgram,
-    ) -> CompileResult<Self> {
-        Self::from_parsed_modules_reusing(program, None).map(|(snapshot, _)| snapshot)
-    }
-
-    #[cfg(test)]
-    pub(crate) fn from_parsed_modules_reusing(
-        program: &crate::parsed_modules::ParsedProgram,
-        previous: Option<&Self>,
-    ) -> CompileResult<(Self, DefinitionShardWork)> {
-        let _span = info_span!(
-            "definition_snapshot_modules",
-            module_count = program.modules().len()
-        )
-        .entered();
-        let source_snapshot = SourceSnapshot::from_parsed_modules(program)?;
-        let mut modules = Vec::with_capacity(program.modules().len());
-        let mut work = DefinitionShardWork {
-            shards_indexed: previous.map_or(0, |snapshot| snapshot.shards.len()),
-            ..DefinitionShardWork::default()
-        };
-        let mut shards = Vec::with_capacity(program.modules().len());
-        let definition_count = program
-            .modules()
-            .iter()
-            .map(|module| module.definitions().candidates().len())
-            .sum();
-        let mut definitions_by_name =
-            HashMap::<DefinitionNameKey, Vec<DefinitionId>>::with_capacity(definition_count);
-
-        for (module_index, module) in program.modules().iter().enumerate() {
-            let candidate_records = || {
-                module
-                    .definitions()
-                    .candidates()
-                    .iter()
-                    .map(|candidate| DefinitionShardRecord {
-                        namespace: candidate.namespace(),
-                        kind: candidate.kind(),
-                        visibility: candidate.visibility(),
-                        name: Arc::from(candidate.name()),
-                        name_span: candidate.name_span(),
-                        declaration_span: candidate.declaration_span(),
-                    })
-                    .collect::<Vec<_>>()
-            };
-            let shard = previous
-                .and_then(|snapshot| {
-                    snapshot
-                        .shards
-                        .binary_search_by(|shard| shard.key.cmp(module.module_id()))
-                        .ok()
-                        .map(|index| snapshot.shards[index].clone())
-                })
-                .filter(|shard| shard.matches(module));
-            let shard = if let Some(shard) = shard {
-                work.shards_reused += 1;
-                shard
-            } else {
-                work.shards_rebuilt += 1;
-                Arc::new(DefinitionShard {
-                    key: module.module_id().clone(),
-                    file_id: module.file_id(),
-                    records: candidate_records().into(),
-                })
-            };
-            let mut definitions = Vec::with_capacity(shard.records.len());
-            for (definition_index, candidate) in shard.records.iter().enumerate() {
-                let id = DefinitionId {
-                    module_index,
-                    definition_index,
-                };
-                let name_key = DefinitionNameKey::new(
-                    module.module_id().clone(),
-                    candidate.namespace,
-                    &candidate.name,
-                );
-                definitions_by_name
-                    .entry(name_key.clone())
-                    .or_default()
-                    .push(id);
-                definitions.push(DefinitionRecord {
-                    id,
-                    name_key,
-                    kind: candidate.kind,
-                    visibility: candidate.visibility,
-                    file_id: module.file_id(),
-                    name_span: candidate.name_span,
-                    declaration_span: candidate.declaration_span,
-                });
-            }
-            modules.push(ModuleDefinition {
-                key: module.module_id().clone(),
-                file_id: module.file_id(),
-                definitions,
-            });
-            shards.push(shard);
-        }
-
-        Ok((
-            Self {
-                source_snapshot,
-                #[cfg(test)]
-                root_module: program.root().clone(),
-                modules,
-                definitions_by_name,
-                shards: shards.into(),
-            },
-            work,
-        ))
-    }
-
     pub(crate) fn from_module_indexes_reusing(
         program: &crate::parsed_modules::ParsedProgram,
         indexes: &[crate::revisioned_query_database::ProjectedModuleIndex],
@@ -713,7 +577,6 @@ fn invalid_input(message: impl Into<String>) -> CompileError {
 mod tests {
     use super::*;
     use crate::SourceMetadata;
-    use crate::parsed_modules::parse_source_snapshot_modules;
 
     fn source_snapshot(entries: &[(u32, &str, &str, &str)], root: u32) -> SourceSnapshot {
         let physical = entries
@@ -735,10 +598,14 @@ mod tests {
         .unwrap()
     }
 
+    /// The canonical definition snapshot for a fixture, taken from the merge
+    /// query production uses rather than a second assembly.
     fn build(entries: &[(u32, &str, &str, &str)], root: u32) -> DefinitionSnapshot {
         let source = source_snapshot(entries, root);
-        let parsed = parse_source_snapshot_modules(&source).unwrap();
-        DefinitionSnapshot::from_parsed_modules(&parsed).unwrap()
+        crate::test_support::test_merged_program(&source)
+            .unwrap()
+            .definitions()
+            .clone()
     }
 
     fn durable_projection(
@@ -863,8 +730,8 @@ mod tests {
             1,
         );
         let original = source.shared_source_text(FileId::new(1)).unwrap();
-        let parsed = parse_source_snapshot_modules(&source).unwrap();
-        let definitions = DefinitionSnapshot::from_parsed_modules(&parsed).unwrap();
+        let merged = crate::test_support::test_merged_program(&source).unwrap();
+        let definitions = merged.definitions();
         let retained = definitions
             .source_snapshot()
             .shared_source_text(FileId::new(1))
@@ -877,44 +744,6 @@ mod tests {
                 .module(&ModuleId::from_logical_path("empty.rue").unwrap())
                 .unwrap()
                 .is_empty()
-        );
-    }
-
-    #[test]
-    fn duplicate_and_cross_kind_candidates_keep_unique_occurrences() {
-        let snapshot = build(
-            &[(
-                1,
-                "/root.rue",
-                "root.rue",
-                "fn shared() {} fn shared() {} struct shared {} const shared: i32 = 1;",
-            )],
-            1,
-        );
-        let definitions = snapshot.definitions().collect::<Vec<_>>();
-
-        assert_eq!(definitions.len(), 4);
-        assert!(
-            definitions
-                .windows(2)
-                .all(|pair| { pair[0].name_key() == pair[1].name_key() })
-        );
-        assert!(
-            definitions
-                .windows(2)
-                .all(|pair| pair[0].id() != pair[1].id())
-        );
-        assert_eq!(
-            snapshot
-                .definitions_named(definitions[0].name_key())
-                .map(DefinitionRecord::kind)
-                .collect::<Vec<_>>(),
-            [
-                DefinitionKind::Function,
-                DefinitionKind::Function,
-                DefinitionKind::Struct,
-                DefinitionKind::Const,
-            ],
         );
     }
 

--- a/crates/rue-compiler/src/lib.rs
+++ b/crates/rue-compiler/src/lib.rs
@@ -240,10 +240,6 @@ pub(crate) use rue_span::Span;
 pub use rue_target::{Arch, Target};
 
 // Internal phase vocabulary. These are intentionally not part of the facade.
-#[cfg(test)]
-pub(crate) use canonical_lower::lower_canonical_rir;
-#[cfg(test)]
-pub(crate) use canonical_merge::merge_parsed_modules;
 pub(crate) use durable_body::{convert_semantic_body_exports, finalize_durable_ordinary_bodies};
 pub(crate) use durable_semantics::{
     import_durable_declaration_semantics, project_durable_declaration_semantics,

--- a/crates/rue-compiler/src/revisioned_query_database.rs
+++ b/crates/rue-compiler/src/revisioned_query_database.rs
@@ -19456,14 +19456,14 @@ pub(crate) mod test_support {
     pub(crate) fn production_declarations(
         snapshot: &SourceSnapshot,
     ) -> Arc<[crate::durable_semantics::DurableDeclarationSemantic]> {
-        let parsed = crate::parsed_modules::parse_source_snapshot_modules(snapshot).unwrap();
-        let merged = crate::merge_parsed_modules(&parsed).unwrap();
-        let rir = crate::lower_canonical_rir(&merged).unwrap();
+        let stages = crate::test_support::test_frontend_stages(snapshot).unwrap();
+        let merged = &stages.merged;
+        let rir = &stages.rir;
         let imports = crate::test_support::test_import_graph(snapshot).unwrap();
         let (_definitions, query_declarations, _work) =
             crate::bound_definitions::bind_canonical_declaration_semantics(
-                &merged,
-                &rir,
+                merged,
+                rir,
                 crate::PreviewFeatures::default(),
                 rue_target::Target::X86_64Linux,
                 &imports,
@@ -20800,9 +20800,9 @@ fn main() -> i32 {
     fn retired_declaration_exports(
         source: &SourceSnapshot,
     ) -> Vec<rue_air::SemanticDeclarationExport> {
-        let parsed = crate::parsed_modules::parse_source_snapshot_modules(source).unwrap();
-        let merged = crate::merge_parsed_modules(&parsed).unwrap();
-        let rir = crate::lower_canonical_rir(&merged).unwrap();
+        let stages = crate::test_support::test_frontend_stages(source).unwrap();
+        let _merged = &stages.merged;
+        let rir = &stages.rir;
         let bound = rue_air::Sema::new_synthetic(
             rir.rir(),
             rir.semantic_symbols().interner(),
@@ -20816,9 +20816,9 @@ fn main() -> i32 {
     }
 
     fn retired_declaration_failure(source: &SourceSnapshot) -> String {
-        let parsed = crate::parsed_modules::parse_source_snapshot_modules(source).unwrap();
-        let merged = crate::merge_parsed_modules(&parsed).unwrap();
-        let rir = crate::lower_canonical_rir(&merged).unwrap();
+        let stages = crate::test_support::test_frontend_stages(source).unwrap();
+        let _merged = &stages.merged;
+        let rir = &stages.rir;
         let errors = match rue_air::Sema::new_synthetic(
             rir.rir(),
             rir.semantic_symbols().interner(),
@@ -21271,9 +21271,9 @@ fn main() -> i32 {
             )],
             1,
         );
-        let parsed = crate::parsed_modules::parse_source_snapshot_modules(&source).unwrap();
-        let merged = crate::merge_parsed_modules(&parsed).unwrap();
-        let rir = crate::lower_canonical_rir(&merged).unwrap();
+        let stages = crate::test_support::test_frontend_stages(&source).unwrap();
+        let _merged = &stages.merged;
+        let rir = &stages.rir;
         let retired = rue_air::Sema::new_synthetic(
             rir.rir(),
             rir.semantic_symbols().interner(),
@@ -28079,13 +28079,13 @@ fn main() -> i32 {
 
         // Independently bind the same source through the declaration path. This
         // is the oracle side of the comparison, not the queried durable terminal.
-        let parsed = crate::parsed_modules::parse_source_snapshot_modules(&snapshot).unwrap();
-        let merged = crate::merge_parsed_modules(&parsed).unwrap();
-        let rir = crate::lower_canonical_rir(&merged).unwrap();
+        let stages = crate::test_support::test_frontend_stages(&snapshot).unwrap();
+        let merged = &stages.merged;
+        let rir = &stages.rir;
         let imports = crate::import_graph::import_free_canonical_graph(merged.ast()).unwrap();
         let bound = crate::canonical_semantic::bind_query_owned_declarations_for_test(
-            &merged,
-            &rir,
+            merged,
+            rir,
             crate::PreviewFeatures::default(),
             rue_target::Target::X86_64Linux,
             &imports,
@@ -28285,13 +28285,13 @@ fn main() -> i32 {
         .expect("trusted-strbuf snapshot is valid");
 
         // The live epoch, through the production declaration-bind path.
-        let parsed = crate::parsed_modules::parse_source_snapshot_modules(&snapshot).unwrap();
-        let merged = crate::merge_parsed_modules(&parsed).unwrap();
-        let rir = crate::lower_canonical_rir(&merged).unwrap();
+        let stages = crate::test_support::test_frontend_stages(&snapshot).unwrap();
+        let merged = &stages.merged;
+        let rir = &stages.rir;
         let imports = crate::import_graph::import_free_canonical_graph(merged.ast()).unwrap();
         let bound = crate::canonical_semantic::bind_query_owned_declarations_for_test(
-            &merged,
-            &rir,
+            merged,
+            rir,
             crate::PreviewFeatures::default(),
             rue_target::Target::X86_64Linux,
             &imports,
@@ -28476,13 +28476,13 @@ fn main() -> i32 {
 
         // The LIVE epoch, bound through the production declaration path — the
         // INDEPENDENT side the provider assembly is compared against.
-        let parsed = crate::parsed_modules::parse_source_snapshot_modules(&snapshot).unwrap();
-        let merged = crate::merge_parsed_modules(&parsed).unwrap();
-        let rir = crate::lower_canonical_rir(&merged).unwrap();
+        let stages = crate::test_support::test_frontend_stages(&snapshot).unwrap();
+        let merged = &stages.merged;
+        let rir = &stages.rir;
         let imports = crate::import_graph::import_free_canonical_graph(merged.ast()).unwrap();
         let bound = crate::canonical_semantic::bind_query_owned_declarations_for_test(
-            &merged,
-            &rir,
+            merged,
+            rir,
             crate::PreviewFeatures::default(),
             rue_target::Target::X86_64Linux,
             &imports,
@@ -28633,13 +28633,13 @@ fn main() -> i32 {
             .key
             .clone();
 
-        let parsed = crate::parsed_modules::parse_source_snapshot_modules(&snapshot).unwrap();
-        let merged = crate::merge_parsed_modules(&parsed).unwrap();
-        let rir = crate::lower_canonical_rir(&merged).unwrap();
+        let stages = crate::test_support::test_frontend_stages(&snapshot).unwrap();
+        let merged = &stages.merged;
+        let rir = &stages.rir;
         let imports = crate::import_graph::import_free_canonical_graph(merged.ast()).unwrap();
         let bound = crate::canonical_semantic::bind_query_owned_declarations_for_test(
-            &merged,
-            &rir,
+            merged,
+            rir,
             crate::PreviewFeatures::default(),
             rue_target::Target::X86_64Linux,
             &imports,
@@ -28713,13 +28713,13 @@ fn main() -> i32 {
         let decls = production_declarations(&snapshot);
         let box_key = durable_decl(&decls, Kind::Struct, "Box").key.clone();
 
-        let parsed = crate::parsed_modules::parse_source_snapshot_modules(&snapshot).unwrap();
-        let merged = crate::merge_parsed_modules(&parsed).unwrap();
-        let rir = crate::lower_canonical_rir(&merged).unwrap();
+        let stages = crate::test_support::test_frontend_stages(&snapshot).unwrap();
+        let merged = &stages.merged;
+        let rir = &stages.rir;
         let imports = crate::import_graph::import_free_canonical_graph(merged.ast()).unwrap();
         let bound = crate::canonical_semantic::bind_query_owned_declarations_for_test(
-            &merged,
-            &rir,
+            merged,
+            rir,
             crate::PreviewFeatures::default(),
             rue_target::Target::X86_64Linux,
             &imports,
@@ -28828,13 +28828,13 @@ fn main() -> i32 {
 
         // The LIVE epoch, bound through the production declaration path — the
         // INDEPENDENT side the provider assembly is compared against.
-        let parsed = crate::parsed_modules::parse_source_snapshot_modules(&snapshot).unwrap();
-        let merged = crate::merge_parsed_modules(&parsed).unwrap();
-        let rir = crate::lower_canonical_rir(&merged).unwrap();
+        let stages = crate::test_support::test_frontend_stages(&snapshot).unwrap();
+        let merged = &stages.merged;
+        let rir = &stages.rir;
         let imports = crate::import_graph::import_free_canonical_graph(merged.ast()).unwrap();
         let bound = crate::canonical_semantic::bind_query_owned_declarations_for_test(
-            &merged,
-            &rir,
+            merged,
+            rir,
             crate::PreviewFeatures::default(),
             rue_target::Target::X86_64Linux,
             &imports,
@@ -29268,8 +29268,8 @@ fn main() -> i32 {
 
         // Independently produce the durable declaration set + the durable
         // anonymous nominal (the pool's inputs) through the nucleus projection.
-        let parsed = crate::parsed_modules::parse_source_snapshot_modules(&snapshot).unwrap();
-        let merged = crate::merge_parsed_modules(&parsed).unwrap();
+        let stages = crate::test_support::test_frontend_stages(&snapshot).unwrap();
+        let merged = &stages.merged;
         let mut proj_db = RevisionedQueryDatabase::default();
         let proj_revision = revision_for(&mut proj_db, &snapshot);
         let projection = proj_db
@@ -29300,11 +29300,11 @@ fn main() -> i32 {
         // The LIVE epoch, bound through the production declaration path — the
         // INDEPENDENT comparison side. Its anonymous materialization is the epoch's
         // own `find_or_create_anon_struct`, populated during the same bind.
-        let rir = crate::lower_canonical_rir(&merged).unwrap();
+        let rir = &stages.rir;
         let imports = crate::import_graph::import_free_canonical_graph(merged.ast()).unwrap();
         let bound = crate::canonical_semantic::bind_query_owned_declarations_for_test(
-            &merged,
-            &rir,
+            merged,
+            rir,
             crate::PreviewFeatures::default(),
             rue_target::Target::X86_64Linux,
             &imports,
@@ -29408,8 +29408,8 @@ fn main() -> i32 {
 
         // Independently produce the durable declaration set + the durable
         // anonymous nominal (the pool's inputs) through the nucleus projection.
-        let parsed = crate::parsed_modules::parse_source_snapshot_modules(&snapshot).unwrap();
-        let merged = crate::merge_parsed_modules(&parsed).unwrap();
+        let stages = crate::test_support::test_frontend_stages(&snapshot).unwrap();
+        let merged = &stages.merged;
         let mut proj_db = RevisionedQueryDatabase::default();
         let proj_revision = revision_for(&mut proj_db, &snapshot);
         let projection = proj_db
@@ -29439,11 +29439,11 @@ fn main() -> i32 {
         // The LIVE epoch, bound through the production declaration path — the
         // INDEPENDENT comparison side. Its anonymous materialization is the
         // epoch's own `find_or_create_anon_enum`, populated during the same bind.
-        let rir = crate::lower_canonical_rir(&merged).unwrap();
+        let rir = &stages.rir;
         let imports = crate::import_graph::import_free_canonical_graph(merged.ast()).unwrap();
         let bound = crate::canonical_semantic::bind_query_owned_declarations_for_test(
-            &merged,
-            &rir,
+            merged,
+            rir,
             crate::PreviewFeatures::default(),
             rue_target::Target::X86_64Linux,
             &imports,
@@ -29594,9 +29594,9 @@ fn main() -> i32 {
         )
         .unwrap();
 
-        let parsed = crate::parsed_modules::parse_source_snapshot_modules(&snapshot).unwrap();
-        let merged = crate::merge_parsed_modules(&parsed).unwrap();
-        let rir = crate::lower_canonical_rir(&merged).unwrap();
+        let stages = crate::test_support::test_frontend_stages(&snapshot).unwrap();
+        let merged = &stages.merged;
+        let rir = &stages.rir;
 
         let configuration = semantic_configuration();
         let demands = [
@@ -29661,8 +29661,8 @@ fn main() -> i32 {
         let imports = crate::import_graph::import_free_canonical_graph(merged.ast()).unwrap();
         let (bound, definitions) =
             crate::canonical_semantic::bind_query_owned_declarations_with_definitions_for_test(
-                &merged,
-                &rir,
+                merged,
+                rir,
                 crate::PreviewFeatures::default(),
                 rue_target::Target::X86_64Linux,
                 &imports,
@@ -29670,7 +29670,7 @@ fn main() -> i32 {
             .expect("declarations bind");
         let (nominal_exports, pair_exports) =
             crate::durable_semantics::project_durable_option_registry(
-                &merged,
+                merged,
                 &definitions,
                 &resolution,
             )
@@ -29838,13 +29838,13 @@ fn main() -> i32 {
 
         // The LIVE epoch, bound through the production declaration path with the
         // slices preview enabled.
-        let parsed = crate::parsed_modules::parse_source_snapshot_modules(&snapshot).unwrap();
-        let merged = crate::merge_parsed_modules(&parsed).unwrap();
-        let rir = crate::lower_canonical_rir(&merged).unwrap();
+        let stages = crate::test_support::test_frontend_stages(&snapshot).unwrap();
+        let merged = &stages.merged;
+        let rir = &stages.rir;
         let imports = crate::import_graph::import_free_canonical_graph(merged.ast()).unwrap();
         let bound = crate::canonical_semantic::bind_query_owned_declarations_for_test(
-            &merged,
-            &rir,
+            merged,
+            rir,
             slices.clone(),
             rue_target::Target::X86_64Linux,
             &imports,
@@ -30115,13 +30115,13 @@ fn main() -> i32 {
 
         // LIVE epoch side: production parsing/lowering/import registration and
         // declaration binding, independent of the pool's durable adapter.
-        let parsed = crate::parsed_modules::parse_source_snapshot_modules(&snapshot).unwrap();
-        let merged = crate::merge_parsed_modules(&parsed).unwrap();
-        let rir = crate::lower_canonical_rir(&merged).unwrap();
+        let stages = crate::test_support::test_frontend_stages(&snapshot).unwrap();
+        let merged = &stages.merged;
+        let rir = &stages.rir;
         let imports = crate::test_support::test_import_graph(&snapshot).unwrap();
         let bound = crate::canonical_semantic::bind_query_owned_declarations_for_test(
-            &merged,
-            &rir,
+            merged,
+            rir,
             crate::PreviewFeatures::default(),
             rue_target::Target::X86_64Linux,
             &imports,
@@ -30323,13 +30323,13 @@ fn main() -> i32 {
         let point_key = durable_decl(&decls, Kind::Struct, "Point").key.clone();
         let color_key = durable_decl(&decls, Kind::Enum, "Color").key.clone();
 
-        let parsed = crate::parsed_modules::parse_source_snapshot_modules(&snapshot).unwrap();
-        let merged = crate::merge_parsed_modules(&parsed).unwrap();
-        let rir = crate::lower_canonical_rir(&merged).unwrap();
+        let stages = crate::test_support::test_frontend_stages(&snapshot).unwrap();
+        let merged = &stages.merged;
+        let rir = &stages.rir;
         let imports = crate::import_graph::import_free_canonical_graph(merged.ast()).unwrap();
         let bound = crate::canonical_semantic::bind_query_owned_declarations_for_test(
-            &merged,
-            &rir,
+            merged,
+            rir,
             crate::PreviewFeatures::default(),
             rue_target::Target::X86_64Linux,
             &imports,
@@ -30414,13 +30414,13 @@ fn main() -> i32 {
         let color_key = durable_decl(&decls, Kind::Enum, "Color").key.clone();
         let limit_key = durable_decl(&decls, Kind::ValueConst, "LIMIT").key.clone();
 
-        let parsed = crate::parsed_modules::parse_source_snapshot_modules(&snapshot).unwrap();
-        let merged = crate::merge_parsed_modules(&parsed).unwrap();
-        let rir = crate::lower_canonical_rir(&merged).unwrap();
+        let stages = crate::test_support::test_frontend_stages(&snapshot).unwrap();
+        let merged = &stages.merged;
+        let rir = &stages.rir;
         let imports = crate::import_graph::import_free_canonical_graph(merged.ast()).unwrap();
         let bound = crate::canonical_semantic::bind_query_owned_declarations_for_test(
-            &merged,
-            &rir,
+            merged,
+            rir,
             crate::PreviewFeatures::default(),
             rue_target::Target::X86_64Linux,
             &imports,
@@ -30627,13 +30627,13 @@ fn main() -> i32 {
         )
         .expect("two-file snapshot is valid");
 
-        let parsed = crate::parsed_modules::parse_source_snapshot_modules(&snapshot).unwrap();
-        let merged = crate::merge_parsed_modules(&parsed).unwrap();
-        let rir = crate::lower_canonical_rir(&merged).unwrap();
+        let stages = crate::test_support::test_frontend_stages(&snapshot).unwrap();
+        let merged = &stages.merged;
+        let rir = &stages.rir;
         let imports = crate::import_graph::import_free_canonical_graph(merged.ast()).unwrap();
         let bound = crate::canonical_semantic::bind_query_owned_declarations_for_test(
-            &merged,
-            &rir,
+            merged,
+            rir,
             crate::PreviewFeatures::default(),
             rue_target::Target::X86_64Linux,
             &imports,
@@ -32624,8 +32624,7 @@ fn main() -> i32 {
         revision: Revision,
         snapshot: &SourceSnapshot,
     ) -> Arc<[crate::durable_semantics::DurableAnonymousNominal]> {
-        let parsed = crate::parsed_modules::parse_source_snapshot_modules(snapshot).unwrap();
-        let merged = crate::merge_parsed_modules(&parsed).unwrap();
+        let merged = crate::test_support::test_merged_program(snapshot).unwrap();
         database
             .projected_declaration_semantics(
                 revision,

--- a/crates/rue-compiler/src/session.rs
+++ b/crates/rue-compiler/src/session.rs
@@ -14238,9 +14238,9 @@ fn main() -> i32 { 0 }
             "drop fn Missing(self) {} fn main() {}",
         ] {
             let source = snapshot(&[(1, "/main.rue", "main.rue", text)], 1);
-            let parsed = crate::parsed_modules::parse_source_snapshot_modules(&source).unwrap();
-            let merged = crate::merge_parsed_modules(&parsed).unwrap();
-            let rir = crate::lower_canonical_rir(&merged).unwrap();
+            let stages = crate::test_support::test_frontend_stages(&source).unwrap();
+            let _merged = &stages.merged;
+            let rir = &stages.rir;
             let retired = match rue_air::Sema::new_synthetic(
                 rir.rir(),
                 rir.semantic_symbols().interner(),

--- a/crates/rue-compiler/src/test_support.rs
+++ b/crates/rue-compiler/src/test_support.rs
@@ -62,6 +62,49 @@ pub(crate) fn test_codegen_state(state: &CompileState, target: Target) -> MultiE
     .map(drop)
 }
 
+/// The canonical merge and RIR artifacts for `snapshot`.
+///
+/// Lower-layer unit tests that need a merged program or a whole-program RIR
+/// take them from the session queries production uses, so a fixture never
+/// exercises an assembly production does not perform. Both come from one
+/// session because the RIR query consumes the merge terminal.
+///
+/// The fixture is published as declared, not through a discovery epoch: merge
+/// and lowering do not consume the import graph, and a fixture that names its
+/// own physical paths must keep them for identity-sensitive assertions.
+pub(crate) struct TestFrontendStages {
+    pub(crate) merged: std::sync::Arc<CanonicalMergedProgram>,
+    pub(crate) rir: std::sync::Arc<CanonicalRirOutput>,
+}
+
+pub(crate) fn test_frontend_stages(
+    snapshot: &SourceSnapshot,
+) -> MultiErrorResult<TestFrontendStages> {
+    let mut session = CompilerSession::new();
+    session.update(snapshot).into_owner_result()?;
+    let merged = session.merge()?;
+    let rir = session.canonical_rir()?;
+    Ok(TestFrontendStages { merged, rir })
+}
+
+/// The canonical merged program for `snapshot`.
+pub(crate) fn test_merged_program(
+    snapshot: &SourceSnapshot,
+) -> MultiErrorResult<std::sync::Arc<CanonicalMergedProgram>> {
+    let mut session = CompilerSession::new();
+    session.update(snapshot).into_owner_result()?;
+    session.merge()
+}
+
+/// The canonical whole-program RIR for `snapshot`.
+pub(crate) fn test_canonical_rir(
+    snapshot: &SourceSnapshot,
+) -> MultiErrorResult<std::sync::Arc<CanonicalRirOutput>> {
+    let mut session = CompilerSession::new();
+    session.update(snapshot).into_owner_result()?;
+    session.canonical_rir()
+}
+
 pub(crate) fn test_frontend_snapshot(
     snapshot: &SourceSnapshot,
     options: &CompileOptions,


### PR DESCRIPTION
Refs RUE-1140. Second of a series, after #2057 took the parse family. The binding and semantic peers follow in a third PR, which closes the issue.

Production merges and lowers through per-module revisioned queries, but a second whole-program assembly for each stage survived under `#[cfg(test)]`.

## What changed

Deleted:

- `canonical_merge::merge_parsed_modules`, `merge_parsed_modules_for_batch`, `merge_parsed_modules_in_order`, `merge_inputs`, `canonical_duplicate_errors` — production uses `merge_parsed_modules_reusing_indexes` and `canonical_duplicate_errors_from_indexes`
- `definition_snapshot::DefinitionSnapshot::from_parsed_modules{,_reusing}` and the `DefinitionShard::matches` predicate only they used — production uses `from_module_indexes_reusing`
- `canonical_lower::lower_canonical_rir{,_with_work}` — production lowers per module via `module_rirs`
- the `#[cfg(test)]` re-exports of the first and third from `lib.rs`

Fixtures take these artifacts from the session queries production uses, through three new `test_support` helpers: `test_frontend_stages` (merge + RIR from one session, since the RIR query consumes the merge terminal), `test_merged_program`, and `test_canonical_rir`.

## Publishing route

The new helpers publish the fixture **as declared** (`session.update`) rather than through a discovery epoch, which is what the deleted peers received.

Routing them through `publish_test_snapshot` instead republishes any import-bearing fixture under discovery-canonical identities, rewriting physical paths and reassigning FileIds. That breaks tests whose subject *is* those identities — `codegen_input_tracks_root_paths_and_options_but_not_linker` asserts that relocating `/old/main.rue` to `/new/main.rue` changes the codegen input descriptor, and discovery normalizes both to `main.rue`, making the descriptors equal.

Merge and RIR lowering never consume the import graph, and `merge()` only rejects an *open* discovery attempt, so declared publication is both sufficient and faithful. A unit test at this layer should not be able to fail for a reason belonging to the stage above it. Merge and lowering over a discovery-published snapshot stay covered by `test_frontend_snapshot` and `test_compile_snapshot`, whose consumers do have to agree with a compiled program.

## Ported coverage

Where the peers and the canonical queries disagreed, the assertions now state what production guarantees:

- **Storage order.** `ParsedProgram::new` sorts modules on construction, so a reversed module vector cannot reach merge or lowering as a different program. `reordered_arc_assembly_has_identical_rir_and_work` and the merge and cross-module-`main` equivalents now assert that one canonical module sequence, instead of feeding a hand-reordered program through a peer.
- **Duplicate names.** Merge refuses them, so `definition_snapshot_retains_duplicate_occurrences_without_resolving_spurs` becomes `duplicate_occurrences_are_retained_per_module_and_refused_by_merge`: the duplicate candidates are asserted where production holds them — each module's own definition index, built by the parse query — together with merge's refusal.
- **Presentation order.** `batch_merge_uses_explicit_presentation_order_…` took an arbitrary `[b, a]` order the retired batch entry point accepted; it is now `batch_merge_uses_snapshot_presentation_order_…`, driving the same claim through `update_for_presentation` with a snapshot whose file order is `[b, a]`. The stored program stays in canonical ModuleId order.
- **Foreign views.** `canonical_merged_ast_rejects_independently_reparsed_view` now takes its admitted view from the merged program's own modules, since an independent parse is by definition foreign.
- **Equal bytes.** `trusted_snapshot_canonicalizes_equal_bytes_without_rehashing` assembled a program from two different snapshots' modules; it now uses one snapshot with two files whose equal bytes live in distinct allocations, which is the reachable form of the same claim.

### Coverage deliberately dropped

`DefinitionSnapshot`'s tolerance of duplicate and cross-kind records is unreachable once merge rejects such a program, so `duplicate_and_cross_kind_candidates_keep_unique_occurrences` is deleted rather than fabricated: it is subsumed by merge's duplicate-diagnostic coverage plus the new per-module index assertion. Correspondingly `join_syntax_occurrence`'s `AmbiguousSyntaxOccurrence` branch is now uncovered defensive code — `snapshot_to_durable_join_reports_missing_and_duplicate_outcomes_by_type` keeps the reachable join outcomes and asserts merge's refusal of the duplicate program. Restoring that branch's coverage would need a `cfg(test)` accessor exposing the session's projected module indexes so a test could call the production `from_module_indexes_reusing` directly.

## Testing

- compiler unit suite — 844 passed, 0 failed
- `scripts/rue quick` — pass 30, fail 0
- `scripts/rue premerge` — suite passed, 0 failures


---
_Generated by [Claude Code](https://claude.ai/code/session_01L3h7KgZAN7mV1sLvkCgPds)_