### PR TITLE
RUE-1173: document and pin the symbolized profiling build workflow

### DIFF
--- a/crates/rue-cli-tests/cases/profiling.toml
+++ b/crates/rue-cli-tests/cases/profiling.toml
@@ -1,0 +1,78 @@
+# Symbolized profiling builds (RUE-1173, docs/process/profiling.md).
+#
+# The supported workflow for producing an executable a native profiler can
+# attribute by function is an explicit system-linker build: `--linker cc`.
+# Rue's per-function objects each define their function's stable semantic
+# symbol (`__rue_sem_v1_...`, with the module path and source name hex-framed
+# inside it), and a system linker carries those symbols into the executable's
+# symbol table. The default internal linker deliberately emits a minimal
+# image with no section table and no symbols.
+#
+# These cases are the executable form of the profiling doc's two claims:
+# the documented workflow produces per-function symbols, and the default
+# build does not. If either linker path changes shape, update
+# docs/process/profiling.md together with the failing case.
+
+[section]
+id = "cli.profiling"
+name = "Symbolized profiling builds"
+description = "The `--linker cc` workflow keeps function symbols for native profilers; default internal-linker output is unsymbolized."
+
+# Runs natively on every CI host (x86-64 Linux, AArch64 Linux, AArch64 macOS):
+# no `--target`, so each host both links via its own `cc` driver and executes
+# the result. `686f745f6c6f6f70` is the hex framing of `hot_loop` inside the
+# stable semantic symbol, so the assertion proves a *user function* symbol
+# survived, not merely runtime symbols.
+[[case]]
+name = "system_linker_build_keeps_function_symbols"
+description = "A `--linker cc` build's symbol table names user functions (stable semantic symbols), the entry point, and runtime helpers."
+requires_system_linker = true
+files = [{ path = "main.rue", source = """
+fn hot_loop(n: i32) -> i32 {
+    let mut total = 0;
+    let mut i = 0;
+    while i < n {
+        total += i;
+        i += 1;
+    }
+    total
+}
+
+fn main() -> i32 {
+    if hot_loop(100) == 4950 { 0 } else { 1 }
+}
+""" }]
+args = ["main.rue", "--linker", "cc", "-o", "prog"]
+symbols_contain = [
+    "__rue_sem_v1_",
+    "686f745f6c6f6f70",
+    "main",
+    "__rue_exit",
+]
+exit_code = 0
+
+# The motivating fact for the workflow: the default internal-linker build is
+# deliberately minimal and carries no symbol table. If the internal linker
+# gains symbol emission, this case fails loudly — update the profiling doc's
+# limitations and this pin together.
+[[case]]
+name = "internal_linker_build_is_unsymbolized"
+description = "Default internal-linker output has no symbol table entries; profilers cannot attribute functions in it."
+files = [{ path = "main.rue", source = """
+fn hot_loop(n: i32) -> i32 {
+    let mut total = 0;
+    let mut i = 0;
+    while i < n {
+        total += i;
+        i += 1;
+    }
+    total
+}
+
+fn main() -> i32 {
+    if hot_loop(100) == 4950 { 0 } else { 1 }
+}
+""" }]
+args = ["main.rue", "-o", "prog"]
+no_symbol_table = true
+exit_code = 0

--- a/crates/rue-cli-tests/src/main.rs
+++ b/crates/rue-cli-tests/src/main.rs
@@ -91,6 +91,15 @@
 //!   across all levels, catching optimizer miscompiles (RUE-236). The runner
 //!   drives `-O`, so the case must not set its own `-O` in `args` and must not
 //!   be `compile_fail`/`compile_only`. Give it exact `stdout`/`exit_code`.
+//! - `requires_system_linker = true`: report the case as ignored when no `cc`
+//!   driver is on `PATH`. For cases exercising the `--linker cc` symbolized
+//!   profiling build (RUE-1173).
+//! - `symbols_contain`: substrings that must each match at least one defined
+//!   symbol name in the produced executable's symbol table (ELF `.symtab` /
+//!   Mach-O `LC_SYMTAB`), verifying the symbolized profiling build workflow
+//! - `no_symbol_table = true`: assert the produced executable carries no
+//!   symbol table entries, pinning that default internal-linker output is
+//!   unsymbolized (the documented motivation for the profiling workflow)
 //!
 //! # ICE detection
 //!
@@ -115,7 +124,7 @@ use std::fs::File;
 use std::io::{BufWriter, Write};
 use std::path::{Path, PathBuf};
 use std::process::{Command, Output};
-use std::sync::{Arc, Mutex};
+use std::sync::{Arc, Mutex, OnceLock};
 use std::time::{Duration, Instant};
 
 use libtest2_mimic::{Harness, RunContext, RunError, Trial};
@@ -1106,6 +1115,24 @@ struct Case {
     /// not merely against the other levels.
     #[serde(default)]
     differential_opt: bool,
+    /// Report the case as ignored when no system `cc` driver is on `PATH`.
+    /// For cases exercising the `--linker cc` symbolized profiling build
+    /// (RUE-1173): every supported CI host provides `cc`, but a minimal local
+    /// environment without a C toolchain should skip rather than fail.
+    #[serde(default)]
+    requires_system_linker: bool,
+    /// Substrings that must each match at least one defined symbol name in
+    /// the produced executable's symbol table (ELF `.symtab` / Mach-O
+    /// `LC_SYMTAB`). Verifies the symbolized profiling build keeps function
+    /// symbols (RUE-1173). Incompatible with `compile_fail`.
+    #[serde(default)]
+    symbols_contain: Vec<String>,
+    /// Assert the produced executable carries no symbol table entries. Pins
+    /// that default internal-linker output is unsymbolized — the documented
+    /// motivation for the `--linker cc` profiling workflow (RUE-1173).
+    /// Incompatible with `compile_fail` and `symbols_contain`.
+    #[serde(default)]
+    no_symbol_table: bool,
 }
 
 /// What running one case produced: the compiled program's exit code and
@@ -1502,6 +1529,230 @@ fn validate_executable(path: &Path, target: Target) -> TestResult {
     })
 }
 
+/// Upper bound on symbol-table entries the harness will read, mirroring the
+/// bounded-inspection posture of the structural validators above.
+const MAX_SYMBOLS: usize = 1_000_000;
+
+/// Read a NUL-terminated name out of a string table region.
+fn read_strtab_name(bytes: &[u8], strtab: std::ops::Range<usize>, index: usize) -> Option<String> {
+    let start = strtab.start.checked_add(index)?;
+    if start >= strtab.end {
+        return None;
+    }
+    let terminator = bytes[start..strtab.end]
+        .iter()
+        .position(|&byte| byte == 0)?;
+    Some(String::from_utf8_lossy(&bytes[start..start + terminator]).into_owned())
+}
+
+/// Collect every defined symbol name from an ELF executable's `.symtab`.
+/// An executable without section headers or without a symbol table yields an
+/// empty list — exactly the internal linker's default output shape.
+fn read_elf_symbol_names(bytes: &[u8]) -> Result<Vec<String>, String> {
+    if bytes.len() < 64 || bytes.get(..4) != Some(b"\x7fELF") {
+        return Err("output is not an ELF file".to_string());
+    }
+    let shoff = read_u64(bytes, 40, "ELF section-header offset")?;
+    let shentsize = read_u16(bytes, 58, "ELF section-header size")? as u64;
+    let shnum = read_u16(bytes, 60, "ELF section-header count")? as usize;
+    if shnum == 0 {
+        return Ok(Vec::new());
+    }
+    if shentsize < 64 || shnum > MAX_SECTIONS {
+        return Err(format!(
+            "ELF has invalid bounded section-header layout: size={shentsize}, count={shnum}"
+        ));
+    }
+    checked_region(
+        shoff,
+        shentsize * shnum as u64,
+        bytes.len(),
+        "ELF section headers",
+    )?;
+
+    let section_header = |index: usize| (shoff + index as u64 * shentsize) as usize;
+    let mut names = Vec::new();
+    for index in 0..shnum {
+        let header = section_header(index);
+        // SHT_SYMTAB
+        if read_u32(bytes, header + 4, "ELF section type")? != 2 {
+            continue;
+        }
+        let symtab_offset = read_u64(bytes, header + 24, "ELF symtab offset")?;
+        let symtab_size = read_u64(bytes, header + 32, "ELF symtab size")?;
+        let strtab_index = read_u32(bytes, header + 40, "ELF symtab link")? as usize;
+        let entry_size = read_u64(bytes, header + 56, "ELF symtab entry size")?;
+        if entry_size < 24
+            || symtab_size % entry_size != 0
+            || symtab_size / entry_size > MAX_SYMBOLS as u64
+        {
+            return Err("ELF symbol table is not bounded".to_string());
+        }
+        checked_region(symtab_offset, symtab_size, bytes.len(), "ELF symtab")?;
+        if strtab_index >= shnum {
+            return Err("ELF symtab links to an out-of-range string table".to_string());
+        }
+        let strtab_header = section_header(strtab_index);
+        let strtab_offset = read_u64(bytes, strtab_header + 24, "ELF strtab offset")?;
+        let strtab_size = read_u64(bytes, strtab_header + 32, "ELF strtab size")?;
+        checked_region(strtab_offset, strtab_size, bytes.len(), "ELF strtab")?;
+        let strtab = strtab_offset as usize..(strtab_offset + strtab_size) as usize;
+
+        for entry in 0..(symtab_size / entry_size) as usize {
+            let symbol = (symtab_offset + entry as u64 * entry_size) as usize;
+            let name_index = read_u32(bytes, symbol, "ELF symbol name")? as usize;
+            let section = read_u16(bytes, symbol + 6, "ELF symbol section")?;
+            // Skip SHN_UNDEF entries (imports and the null symbol): the
+            // assertions speak about symbols the executable defines.
+            if section == 0 {
+                continue;
+            }
+            if let Some(name) = read_strtab_name(bytes, strtab.clone(), name_index) {
+                if !name.is_empty() {
+                    names.push(name);
+                }
+            }
+        }
+    }
+    Ok(names)
+}
+
+/// Collect every defined symbol name from a Mach-O executable's `LC_SYMTAB`,
+/// excluding debug stabs and undefined entries.
+fn read_macho_symbol_names(bytes: &[u8]) -> Result<Vec<String>, String> {
+    if bytes.len() < 32 || bytes.get(..4) != Some(&[0xcf, 0xfa, 0xed, 0xfe]) {
+        return Err("output is not a little-endian 64-bit Mach-O file".to_string());
+    }
+    let command_count = read_u32(bytes, 16, "Mach-O load-command count")? as usize;
+    let command_bytes = read_u32(bytes, 20, "Mach-O load-command bytes")? as u64;
+    if command_count > MAX_LOAD_ENTRIES {
+        return Err(format!(
+            "Mach-O load-command count {command_count} is not bounded"
+        ));
+    }
+    checked_region(32, command_bytes, bytes.len(), "Mach-O load commands")?;
+    let command_end = 32usize + command_bytes as usize;
+
+    let mut names = Vec::new();
+    let mut command_offset = 32usize;
+    for index in 0..command_count {
+        let command = read_u32(bytes, command_offset, "Mach-O load command")?;
+        let command_size =
+            read_u32(bytes, command_offset + 4, "Mach-O load-command size")? as usize;
+        if command_size < 8 || command_offset + command_size > command_end {
+            return Err(format!("Mach-O load command {index} has an invalid size"));
+        }
+        // LC_SYMTAB
+        if command == 0x2 {
+            if command_size < 24 {
+                return Err("truncated Mach-O LC_SYMTAB".to_string());
+            }
+            let symtab_offset = read_u32(bytes, command_offset + 8, "Mach-O symtab offset")? as u64;
+            let symbol_count =
+                read_u32(bytes, command_offset + 12, "Mach-O symbol count")? as usize;
+            let strtab_offset =
+                read_u32(bytes, command_offset + 16, "Mach-O strtab offset")? as u64;
+            let strtab_size = read_u32(bytes, command_offset + 20, "Mach-O strtab size")? as u64;
+            if symbol_count > MAX_SYMBOLS {
+                return Err("Mach-O symbol table is not bounded".to_string());
+            }
+            checked_region(
+                symtab_offset,
+                symbol_count as u64 * 16,
+                bytes.len(),
+                "Mach-O symtab",
+            )?;
+            checked_region(strtab_offset, strtab_size, bytes.len(), "Mach-O strtab")?;
+            let strtab = strtab_offset as usize..(strtab_offset + strtab_size) as usize;
+
+            for entry in 0..symbol_count {
+                let symbol = (symtab_offset + entry as u64 * 16) as usize;
+                let name_index = read_u32(bytes, symbol, "Mach-O symbol name")? as usize;
+                let n_type = bytes[symbol + 4];
+                // Skip N_STAB debug entries and undefined (N_UNDF) entries.
+                if n_type & 0xe0 != 0 || n_type & 0x0e == 0 {
+                    continue;
+                }
+                if let Some(name) = read_strtab_name(bytes, strtab.clone(), name_index) {
+                    if !name.is_empty() {
+                        names.push(name);
+                    }
+                }
+            }
+        }
+        command_offset += command_size;
+    }
+    Ok(names)
+}
+
+/// Enforce a case's `symbols_contain` / `no_symbol_table` expectations against
+/// the produced executable (RUE-1173).
+fn check_symbol_expectations(path: &Path, target: Target, case: &Case) -> TestResult {
+    let bytes = std::fs::read(path).map_err(|error| {
+        TestFailure::assertion(format!(
+            "failed to read produced executable '{}': {error}",
+            path.display()
+        ))
+    })?;
+    if bytes.len() > MAX_EXECUTABLE_BYTES {
+        return Err(TestFailure::assertion(format!(
+            "produced executable is {} bytes, exceeding the {} byte inspection limit",
+            bytes.len(),
+            MAX_EXECUTABLE_BYTES
+        )));
+    }
+    let names = if target.is_elf() {
+        read_elf_symbol_names(&bytes)
+    } else {
+        read_macho_symbol_names(&bytes)
+    }
+    .map_err(|error| {
+        TestFailure::assertion(format!(
+            "failed to read {target} executable symbol table: {error}"
+        ))
+    })?;
+
+    if case.no_symbol_table {
+        if !names.is_empty() {
+            return Err(TestFailure::assertion(format!(
+                "expected no symbol table entries, but found {} (first: {}). If the \
+                 internal linker now emits symbols, update docs/process/profiling.md \
+                 and this case together.",
+                names.len(),
+                names[0]
+            )));
+        }
+        return Ok(());
+    }
+
+    for expected in &case.symbols_contain {
+        if !names.iter().any(|name| name.contains(expected)) {
+            let mut listing = names.clone();
+            listing.sort();
+            return Err(TestFailure::assertion(format!(
+                "no defined symbol contains `{expected}`\n--- defined symbols ({}) ---\n{}",
+                listing.len(),
+                listing.join("\n")
+            )));
+        }
+    }
+    Ok(())
+}
+
+/// Whether a system `cc` driver is available on `PATH`, probed once per
+/// process. Gates `requires_system_linker` cases (RUE-1173).
+fn system_linker_available() -> bool {
+    static AVAILABLE: OnceLock<bool> = OnceLock::new();
+    *AVAILABLE.get_or_init(|| {
+        Command::new("cc")
+            .arg("--version")
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
+            .status()
+            .is_ok_and(|status| status.success())
+    })
+}
+
 /// Expand `${REAL_STD}` in env values to the absolute path of the repo's std/.
 fn expand_env_value(value: &str, real_std: &Path) -> String {
     value.replace("${REAL_STD}", &real_std.to_string_lossy())
@@ -1808,6 +2059,16 @@ fn run_case(
         validate_executable(&program, target)?;
     }
 
+    // Symbol-table expectations (RUE-1173). The format is the case's declared
+    // executable target when present, otherwise the native host the compile
+    // defaulted to.
+    if !case.symbols_contain.is_empty() || case.no_symbol_table {
+        let symbol_target = executable_target.or_else(Target::host).ok_or_else(|| {
+            TestFailure::assertion("no target available for symbol-table inspection")
+        })?;
+        check_symbol_expectations(&program, symbol_target, case)?;
+    }
+
     if case.compile_only || (case.execute_if_native && executable_target != Target::host()) {
         return Ok(RunOutcome::default());
     }
@@ -1983,6 +2244,12 @@ fn run_case_wrapper(
         return ctx.ignore_for("marked as skip");
     }
 
+    // The `--linker cc` profiling workflow needs a system toolchain; a host
+    // without one skips rather than fails (RUE-1173).
+    if case.requires_system_linker && !system_linker_available() {
+        return ctx.ignore_for("no system `cc` linker driver on PATH");
+    }
+
     // Host-dependent cases: only run on the listed platforms.
     if !case.only_on.is_empty()
         && !case
@@ -2059,6 +2326,23 @@ fn invalid_executable_target(case: &Case) -> Option<&str> {
         .filter(|target| target.parse::<Target>().is_err())
 }
 
+/// Symbol-table expectations require a produced executable, so they cannot
+/// accompany `compile_fail`, and asserting an empty table contradicts
+/// asserting its contents (RUE-1173). Returns the load-time error, if any.
+fn invalid_symbol_expectations(case: &Case) -> Option<&'static str> {
+    let has_expectations = !case.symbols_contain.is_empty() || case.no_symbol_table;
+    if case.compile_fail && has_expectations {
+        return Some(
+            "`symbols_contain`/`no_symbol_table` inspect a produced executable \
+             and are incompatible with `compile_fail`",
+        );
+    }
+    if case.no_symbol_table && !case.symbols_contain.is_empty() {
+        return Some("`no_symbol_table` contradicts `symbols_contain`");
+    }
+    None
+}
+
 fn unknown_only_on_targets(case: &Case) -> Vec<&str> {
     case.only_on
         .iter()
@@ -2118,6 +2402,15 @@ fn load_cases(cases_dir: &Path) -> LoadedCorpus {
                             ),
                             path.display(),
                             case.name
+                        );
+                        std::process::exit(1);
+                    }
+                    if let Some(reason) = invalid_symbol_expectations(case) {
+                        eprintln!(
+                            "error: {}: case '{}': {}",
+                            path.display(),
+                            case.name,
+                            reason
                         );
                         std::process::exit(1);
                     }
@@ -3129,6 +3422,80 @@ mod tests {
         };
 
         assert!(compile_fail_has_exit_code(&case));
+    }
+
+    #[test]
+    fn symbol_expectations_reject_contradictory_configurations() {
+        // Symbol assertions need a produced executable.
+        let with_compile_fail = Case {
+            name: "symbols_vs_compile_fail".to_string(),
+            compile_fail: true,
+            symbols_contain: vec!["main".to_string()],
+            ..Default::default()
+        };
+        assert!(invalid_symbol_expectations(&with_compile_fail).is_some());
+
+        // Asserting emptiness and contents at once is contradictory.
+        let contradictory = Case {
+            name: "empty_vs_contents".to_string(),
+            no_symbol_table: true,
+            symbols_contain: vec!["main".to_string()],
+            ..Default::default()
+        };
+        assert!(invalid_symbol_expectations(&contradictory).is_some());
+
+        let symbolized = Case {
+            name: "symbolized".to_string(),
+            symbols_contain: vec!["main".to_string()],
+            ..Default::default()
+        };
+        assert!(invalid_symbol_expectations(&symbolized).is_none());
+
+        let unsymbolized = Case {
+            name: "unsymbolized".to_string(),
+            no_symbol_table: true,
+            ..Default::default()
+        };
+        assert!(invalid_symbol_expectations(&unsymbolized).is_none());
+    }
+
+    #[test]
+    fn elf_symbol_reader_finds_defined_symbols() {
+        // An ObjectBuilder object carries exactly one defined global symbol in
+        // an ELF `.symtab`; the reader must surface it and nothing spurious.
+        let object = rue_linker::ObjectBuilder::new(Target::X86_64Linux, "profiling_probe")
+            .code(vec![0; 4])
+            .build();
+        let names = read_elf_symbol_names(&object).expect("readable ELF symtab");
+        assert!(
+            names.iter().any(|name| name == "profiling_probe"),
+            "defined symbol missing from {names:?}"
+        );
+    }
+
+    #[test]
+    fn macho_symbol_reader_finds_defined_symbols() {
+        // Mach-O emission prepends exactly one `_` to the symbol name.
+        let object = rue_linker::ObjectBuilder::new(Target::Aarch64Macos, "profiling_probe")
+            .code(vec![0; 4])
+            .build();
+        let names = read_macho_symbol_names(&object).expect("readable Mach-O symtab");
+        assert!(
+            names.iter().any(|name| name == "_profiling_probe"),
+            "defined symbol missing from {names:?}"
+        );
+    }
+
+    #[test]
+    fn elf_symbol_reader_reports_empty_for_sectionless_executables() {
+        // The internal linker's default ELF output has no section table at
+        // all; the reader must report "no symbols" rather than an error.
+        let mut minimal = vec![0u8; 64];
+        minimal[..4].copy_from_slice(b"\x7fELF");
+        assert_eq!(
+            read_elf_symbol_names(&minimal).unwrap(),
+            Vec::<String>::new()
+        );
     }
 
     #[test]

--- a/crates/rue/src/main.rs
+++ b/crates/rue/src/main.rs
@@ -249,6 +249,8 @@ Options:
   --linker <linker>    Set linker to use (default: internal)
                        Use 'internal' for built-in linker, or a command
                        like 'clang', 'gcc', or 'ld' for system linker
+                       A system linker keeps function symbols for native
+                       profilers (see docs/process/profiling.md)
   -O<level>            Set optimization level (default: -O0)
                        Levels: {opt_levels}
   -j, --jobs <N>       Set number of parallel jobs (default: 0 = auto; max: {MAX_EXPLICIT_JOBS})

--- a/docs/designs/0067-compiler-performance-measurement.md
+++ b/docs/designs/0067-compiler-performance-measurement.md
@@ -349,6 +349,14 @@ commit, and commits-since-last-measurement when runs were skipped. Clicking
 pins the tooltip and links to the commit. Tooltip content is
 keyboard-reachable and exposed to assistive technology.
 
+Investigating a flagged movement happens outside the dashboard. Inclusive
+spans and `--time-passes` locate compiler phases; questions about the output
+binary itself — size composition, generated-code behavior — use the
+symbolized build workflow in `docs/process/profiling.md` (RUE-1173), because
+default internal-linker executables deliberately carry no symbol table.
+Measured series keep the epoch's pinned invocation; symbolized builds are
+investigation builds, never appended observations.
+
 ## Implementation Phases
 
 - [ ] **Phase 1: Measurement schema** - RUE-1184. Suite revisions, platform

--- a/docs/process/README.md
+++ b/docs/process/README.md
@@ -29,6 +29,7 @@ Each step has a corresponding document in this directory and a Claude Code comma
 | Review | [code-review.md](code-review.md) | `/code-review` | Check quality before committing |
 | Commit | [committing.md](committing.md) | `/commit` | Create well-formed commits |
 | - | [ci.md](ci.md) | - | Maintain required CI and its pinned tools |
+| - | [profiling.md](profiling.md) | - | Build symbolized executables for native profiling |
 | - | [compiler-facade.md](compiler-facade.md) | - | Review compiler API and tooling-view changes |
 | - | [tutorial.md](tutorial.md) | - | Maintain tutorial outline, style, and snippet checks |
 | - | [issue-tracking.md](issue-tracking.md) | Linear MCP tools | Track work with Linear |

--- a/docs/process/profiling.md
+++ b/docs/process/profiling.md
@@ -1,0 +1,91 @@
+# Profiling Rue executables: the symbolized build workflow
+
+The default Rue build links with the internal linker, which deliberately emits
+a minimal executable image: no section table, no symbol table, no debug or
+unwind sections. That is the right default for a fast, reproducible build, but
+a native profiler can only show raw addresses in it, and size-attribution
+tools have nothing to attribute.
+
+The supported workflow for a profilable executable is an explicit
+system-linker build (RUE-1173):
+
+```bash
+RUE="$(scripts/rue-bin)"
+"$RUE" prog.rue -O2 -o prog --linker cc
+```
+
+`--linker cc` intentionally selects the system-linker path. Rue emits one
+object per function, and each object defines that function's stable semantic
+symbol; a system linker carries those symbols into the executable's symbol
+table (ELF `.symtab` on Linux, Mach-O `LC_SYMTAB` on macOS), where profilers,
+debuggers, and size tools resolve them. `-O2` is not required for symbols but
+makes the measured code representative.
+
+This works on every supported platform with a C toolchain installed:
+x86-64 Linux and AArch64 Linux (`cc` from gcc or clang), and AArch64 macOS
+(`cc` from the Xcode command-line tools).
+
+## Verifying the symbols
+
+```bash
+nm prog | grep __rue_sem_v1_    # user functions
+nm prog | grep __rue_           # runtime helpers too
+```
+
+CI pins both halves of this contract: the `cli.profiling` cases
+(`crates/rue-cli-tests/cases/profiling.toml`, run with
+`scripts/rue cli profiling`) assert that a `--linker cc` build's symbol table
+names user functions, the entry point, and runtime helpers — and that the
+default internal-linker build stays unsymbolized. If either linker path
+changes shape, those cases and this document must move together.
+
+## Running a profiler
+
+Both backends maintain frame pointers (`rbp` / `x29`), so frame-pointer call
+graphs work. DWARF-based unwinding does not — there is no debug or unwind
+information to drive it.
+
+Linux:
+
+```bash
+perf record --call-graph fp ./prog
+perf report
+```
+
+macOS: use Instruments' Time Profiler or `samply record ./prog`; both resolve
+the same symbol table.
+
+## Reading the symbol names
+
+- **User functions** appear as stable semantic symbols:
+  `__rue_sem_v1_..._s<len>_<hex>...`. Each `s<len>_<hex>` frame is the
+  hex-encoded UTF-8 of a path or name component; `s8_686f745f6c6f6f70`
+  decodes to `hot_loop` (`echo 686f745f6c6f6f70 | xxd -r -p`). A
+  human-readable user-symbol mangling scheme is a separately tracked design
+  (RUE-178).
+- **`main`** is the Rue program's entry function.
+- **Runtime helpers** keep their readable ABI names (`__rue_alloc`,
+  `__rue_println`, ...). Runtime internals are Rust-mangled `_ZN...` names;
+  pipe through `rustfilt` if you need them readable.
+
+## Limitations
+
+- **Function-level attribution only.** No DWARF is emitted, so there are no
+  source lines, no variable info, and no source-annotated views in profilers
+  or debuggers.
+- **No unwind tables.** Rue objects carry no `.eh_frame`/compact-unwind data;
+  use frame-pointer call graphs (`--call-graph fp`), not DWARF unwinding.
+- **Mangled user names.** Function identity is precise but hex-framed until
+  RUE-178 lands.
+- **A C toolchain is required** on the build host, and the linked output
+  varies with that toolchain. Keep the internal linker for reproducibility
+  comparisons; use this workflow for investigation builds.
+
+## Use in performance investigation
+
+The compiler-performance system (ADR-0067) tracks output binary size and
+compile phases. When a question turns to the emitted executable itself —
+size composition, generated-code hot spots, where a workload's time goes at
+run time — build the workload with this workflow and profile or run `nm`/size
+tools over the symbolized output. Default benchmark builds keep the internal
+linker; symbolized builds are for investigation, not for the measured series.


### PR DESCRIPTION
Closes RUE-1173.

The default internal linker deliberately emits a minimal image — no section table, no symbol table — so native profilers, debuggers, and size-attribution tools see only raw addresses in default executables. Rather than expanding the internal linker, this makes the existing system-linker path the supported, documented, and CI-pinned profiling workflow.

## What's here

**Documentation** — `docs/process/profiling.md` documents the workflow:

```bash
RUE="$(scripts/rue-bin)"
"$RUE" prog.rue -O2 -o prog --linker cc
```

It explains why the system linker is selected on purpose (Rue's per-function objects each define their function's stable semantic symbol, which a system linker carries into ELF `.symtab` / Mach-O `LC_SYMTAB`), how to verify symbols with `nm`, how to read `__rue_sem_v1_*` names (hex-framed components; readable user mangling is designed separately, refs RUE-178), and how to profile with frame-pointer call graphs (both backends maintain frame pointers). Limitations are explicit: no DWARF source-level info, no unwind tables (so `--call-graph fp`, not DWARF unwinding), mangled user names, and a C-toolchain requirement.

ADR-0067's dashboard section now points performance investigation of output binaries at this workflow, `docs/process/README.md` indexes the new doc, and `--linker`'s help text mentions it.

**Smoke tests** — the CLI harness gains three case keys backed by bounded in-harness symbol-table readers for ELF and Mach-O executables:

- `symbols_contain`: substrings that must each match a defined symbol name in the produced executable;
- `no_symbol_table`: asserts the executable carries no symbol table entries;
- `requires_system_linker`: reports the case as ignored when no `cc` is on `PATH`.

New `cli.profiling` cases run natively on every CI host and pin both halves of the contract: a `--linker cc` build's symbol table names user functions (asserted via the hex framing of `hot_loop` inside the stable semantic symbol, so a user-function symbol specifically must survive), the entry point, and runtime helpers — and the default internal-linker build stays unsymbolized. Load-time validation rejects contradictory case configurations, and harness unit tests cover the readers and the validation.

## Verification

- `scripts/rue cli profiling` — both cases pass natively (x86-64 Linux).
- Harness unit tests (symbol readers against `ObjectBuilder` objects and a sectionless ELF, config validation) pass.
- `scripts/rue quick` green; clippy clean on touched targets; `scripts/rue fmt` applied.
- Verified end to end locally: a `--linker cc` build shows `main`, `__rue_sem_v1_…686f745f6c6f6f70…` (`hot_loop`), and runtime symbols in `nm`; the default build has no symbols and no section table.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NVZjp2cCUszoXNid92PJFb)_