### PR TITLE
RUE-1200: Gate rooted-demand warm-edit locality

### DIFF
--- a/crates/rue-compiler/src/revisioned_query_database.rs
+++ b/crates/rue-compiler/src/revisioned_query_database.rs
@@ -487,6 +487,7 @@ pub(crate) struct RevisionedQueryDatabase {
     #[cfg(test)]
     test_import_store: Arc<Mutex<TestImportInputStore>>,
     parse_modules: QueryFamily<ModuleQueryKey, ParseModuleValue>,
+    module_source_bases: QueryFamily<ModuleQueryKey, Option<rue_air::DurableBodySourceLocator>>,
     module_indexes: QueryFamily<ModuleQueryKey, ModuleIndexValue>,
     declaration_occurrence_indexes: QueryFamily<ModuleQueryKey, DeclarationOccurrenceIndexValue>,
     declaration_shells: QueryFamily<DeclarationShellQueryKey, DeclarationShellQueryValue>,
@@ -8025,6 +8026,48 @@ impl RevisionedQueryDatabase {
                 },
             )
             .expect("the ParseModule family has one canonical name");
+        let parse_for_module_source_bases = parse_modules.clone();
+        // Body-host module registration needs only stable file identity and
+        // path. Keep that dependency independent of the exact parsed module so
+        // an imported body's text edit does not invalidate every caller merely
+        // to rediscover the same module identity. Exact body locators remain
+        // responsible for current lengths and spans.
+        let module_source_bases = runtime
+            .family_with_equality_and_evaluator(
+                "compiler.module-source-basis",
+                BODY_QUERY_MEMO_RETENTION,
+                |left: &Option<rue_air::DurableBodySourceLocator>,
+                 right: &Option<rue_air::DurableBodySourceLocator>| {
+                    match (left, right) {
+                        (Some(left), Some(right)) => {
+                            left.file_id == right.file_id
+                                && left.physical_path == right.physical_path
+                        }
+                        (None, None) => true,
+                        _ => false,
+                    }
+                },
+                move |context, _, key: &ModuleQueryKey| {
+                    let parsed =
+                        context.query_registered(&parse_for_module_source_bases, key.clone())?;
+                    let rue_query::QueryOutcome::Success(ParseModuleValue {
+                        result: Ok(parsed),
+                        ..
+                    }) = parsed.outcome()
+                    else {
+                        return Ok(QueryOutput::success(None));
+                    };
+                    Ok(QueryOutput::success(Some(
+                        rue_air::DurableBodySourceLocator {
+                            file_id: parsed.file_id(),
+                            physical_path: Arc::from(parsed.physical_path()),
+                            source_length: u32::try_from(parsed.source_text().len())
+                                .map_err(|_| QueryAbort::Canceled)?,
+                        },
+                    )))
+                },
+            )
+            .expect("the ModuleSourceBasis family has one canonical name");
         // Test-only per-evaluator probes recording which modules and lookup keys
         // are (re)built. They make the ADR-0066 §4 fan-out bound observable:
         // building one module's index consults no other module, and editing a
@@ -11981,6 +12024,7 @@ impl RevisionedQueryDatabase {
             .expect("the BodyClosure family has one canonical name");
         let closures_for_publication = body_closures.clone();
         let reachability_for_publication = body_reachability.clone();
+        let bundles_for_closure_publication = body_analysis_bundles.clone();
         let names_for_closure_publication = lookup_names.clone();
         let imports_for_closure_publication = lookup_imports.clone();
         let lease_for_closure_publication = lookup_root_lease.clone();
@@ -12035,15 +12079,36 @@ impl RevisionedQueryDatabase {
                                 )
                             });
                         if closure.kind() == QueryTerminalKind::Success {
-                            context.register_attempt_handoff(PublishedBodyClosureTerminalHandoff {
-                                root: terminal_root_for_closure_publication.clone(),
-                                pending: Some(
+                            let pending = match context.retain_observed_terminal_cone(&closure) {
+                                Ok(pending) => pending,
+                                Err(rue_query::RetainTerminalConeError::DependencyNotObserved(
+                                    _,
+                                )) => {
+                                    // When every reached body stays green, the
+                                    // reused closure carries its bundle
+                                    // terminals without observing them in this
+                                    // publication task. Re-observe those exact
+                                    // carried keys before transferring the
+                                    // closure's retention cone.
+                                    for body in output.bodies.iter() {
+                                        context.query_registered(
+                                            &bundles_for_closure_publication,
+                                            body.key.clone(),
+                                        )?;
+                                    }
                                     context
                                         .retain_observed_terminal_cone(&closure)
                                         .expect(
-                                            "registered closure validation retains its exact dependency cone",
-                                        ),
+                                            "registered closure validation retains its exact dependency cone after observing carried body bundles",
+                                        )
+                                }
+                                Err(error) => panic!(
+                                    "registered closure validation retains its exact dependency cone: {error:?}"
                                 ),
+                            };
+                            context.register_attempt_handoff(PublishedBodyClosureTerminalHandoff {
+                                root: terminal_root_for_closure_publication.clone(),
+                                pending: Some(pending),
                                 pending_reached: Some(output.reached.iter().cloned().collect()),
                                 previous: None,
                                 installed: false,
@@ -12149,6 +12214,7 @@ impl RevisionedQueryDatabase {
             body_transaction_evaluator
                 .set(BodyTransactionEvaluator {
                     parse_modules: parse_modules.clone(),
+                    module_source_bases: module_source_bases.clone(),
                     raw_declaration_signatures: raw_declaration_signatures.clone(),
                     raw_declaration_bodies: raw_declaration_bodies.clone(),
                     body_inputs: body_inputs.clone(),
@@ -12180,6 +12246,7 @@ impl RevisionedQueryDatabase {
             #[cfg(test)]
             test_import_store,
             parse_modules,
+            module_source_bases,
             module_indexes,
             declaration_occurrence_indexes,
             declaration_shells,
@@ -12626,6 +12693,7 @@ impl RevisionedQueryDatabase {
 
 struct BodyTransactionEvaluator {
     parse_modules: QueryFamily<ModuleQueryKey, ParseModuleValue>,
+    module_source_bases: QueryFamily<ModuleQueryKey, Option<rue_air::DurableBodySourceLocator>>,
     raw_declaration_signatures:
         QueryFamily<RawDeclarationSignatureQueryKey, RawDeclarationSignatureQueryValue>,
     raw_declaration_bodies: QueryFamily<RawDeclarationBodyQueryKey, RawDeclarationBodyQueryValue>,
@@ -12680,6 +12748,7 @@ impl BodyTransactionEvaluator {
         CompilerBodyProviderQueries {
             context,
             parse_modules: self.parse_modules.clone(),
+            module_source_bases: self.module_source_bases.clone(),
             raw_declaration_signatures: self.raw_declaration_signatures.clone(),
             lookup_names: self.lookup_names.clone(),
             lookup_imports: self.lookup_imports.clone(),
@@ -15977,6 +16046,7 @@ fn provider_status_should_replace(
 pub(crate) struct CompilerBodyProviderQueries<'a> {
     context: &'a rue_query::QueryContext,
     parse_modules: QueryFamily<ModuleQueryKey, ParseModuleValue>,
+    module_source_bases: QueryFamily<ModuleQueryKey, Option<rue_air::DurableBodySourceLocator>>,
     raw_declaration_signatures:
         QueryFamily<RawDeclarationSignatureQueryKey, RawDeclarationSignatureQueryValue>,
     lookup_names: QueryFamily<LookupNameKey, LookupNameValue>,
@@ -17441,28 +17511,20 @@ impl<'a> CompilerBodyFactProvider<'a> {
     }
 
     fn source_locator(&self, module: &ModuleId) -> Option<rue_air::DurableBodySourceLocator> {
-        let terminal = match self
-            .queries
-            .context
-            .query_registered(&self.queries.parse_modules, ModuleQueryKey(module.clone()))
-        {
+        let terminal = match self.queries.context.query_registered(
+            &self.queries.module_source_bases,
+            ModuleQueryKey(module.clone()),
+        ) {
             Ok(terminal) => terminal,
             Err(abort) => {
                 self.observe_abort(abort);
                 return None;
             }
         };
-        let rue_query::QueryOutcome::Success(ParseModuleValue {
-            result: Ok(parsed), ..
-        }) = terminal.outcome()
-        else {
+        let rue_query::QueryOutcome::Success(Some(locator)) = terminal.outcome() else {
             return None;
         };
-        Some(rue_air::DurableBodySourceLocator {
-            file_id: parsed.file_id(),
-            physical_path: Arc::from(parsed.physical_path()),
-            source_length: u32::try_from(parsed.source_text().len()).ok()?,
-        })
+        Some(locator.clone())
     }
 
     fn producer_relative_span(
@@ -19266,6 +19328,7 @@ impl RevisionedQueryDatabase {
         CompilerBodyProviderQueries {
             context,
             parse_modules: self.parse_modules.clone(),
+            module_source_bases: self.module_source_bases.clone(),
             raw_declaration_signatures: self.raw_declaration_signatures.clone(),
             lookup_names: self.lookup_names.clone(),
             lookup_imports: self.lookup_imports.clone(),

--- a/crates/rue-compiler/src/scaling_harness.rs
+++ b/crates/rue-compiler/src/scaling_harness.rs
@@ -1115,6 +1115,49 @@ fn import_source(
     )
 }
 
+fn rooted_demand_locality_source(
+    leaf_value: i32,
+    unrelated_value: i32,
+    observation: u64,
+) -> (SourceSnapshot, ImportDiscoveryContext, AcceptedReadManifest) {
+    // The observation regime remains fixed across revisions. Only the imported
+    // source leaf changes, matching a long-lived host whose read policy is
+    // stable while it services successive import-input requests.
+    let context = ImportDiscoveryContext::new(1, "/p", None, "scaling-import").unwrap();
+    let root = Arc::new(
+        "const a = @import(\"a.rue\");\n\
+         fn main() -> i32 { a.value() }\n"
+            .to_owned(),
+    );
+    let imported = Arc::new(format!(
+        "pub fn value() -> i32 {{ {leaf_value} }}\n\
+         fn unrelated() -> i32 {{ {unrelated_value} }}\n"
+    ));
+    let mut assembler = DiscoverySourceAssembler::new(
+        context.clone(),
+        "/p/main.rue",
+        "/p/main.rue",
+        PhysicalFileIdentity::new(1200, 1),
+        FileMetadataFingerprint::new(root.len() as u64, 1, 1),
+        root,
+    )
+    .unwrap();
+    assembler
+        .add_explicit(
+            "/p/a.rue",
+            "/p/a.rue",
+            PhysicalFileIdentity::new(1200, 2),
+            FileMetadataFingerprint::new(imported.len() as u64, observation, observation),
+            imported,
+        )
+        .unwrap();
+    (
+        assembler.snapshot().unwrap(),
+        context,
+        assembler.accepted_read_manifest(),
+    )
+}
+
 fn close_import_source(
     session: &mut CompilerSession,
     source: &SourceSnapshot,
@@ -1950,6 +1993,80 @@ fn correctness_oracle_import_edit_compares_imported_body_and_linked_bytes() {
         changed_body_origins(&before, &after).contains("main"),
         "changing an imported value must refresh its root consumer"
     );
+}
+
+#[test]
+fn rooted_demand_in_process_host_pins_warm_edit_locality() {
+    let options = CompileOptions::default();
+    let run_edit = |leaf_value, unrelated_value| {
+        let (baseline, baseline_context, baseline_reads) = rooted_demand_locality_source(1, 10, 1);
+        let (edited, edited_context, edited_reads) =
+            rooted_demand_locality_source(leaf_value, unrelated_value, 2);
+        let mut session = CompilerSession::new();
+        // Stay entirely on the rooted import-input protocol. Mixing this with
+        // the ordinary update-token namespace is tracked separately by RUE-1202.
+        close_import_source(&mut session, &baseline, baseline_context, baseline_reads);
+        session
+            .semantic(&options)
+            .expect("rooted-demand baseline compiles");
+        session
+            .unstable_dependency_baseline(&options, None)
+            .expect("rooted-demand baseline dependency manifest is available");
+        close_import_source(&mut session, &edited, edited_context, edited_reads);
+        let semantic_record_start = session.unstable_metrics().semantic_record_count();
+        session
+            .semantic(&options)
+            .expect("rooted-demand warm edit compiles");
+        let work = session
+            .unstable_metrics()
+            .semantic_work_json(semantic_record_start);
+        let count = |path: &[&str]| {
+            path.iter()
+                .fold(&work, |value, key| &value[*key])
+                .as_u64()
+                .unwrap() as usize
+        };
+        [
+            count(&["body_analyses_computed"]),
+            count(&["body_analyses_reused"]),
+            count(&["declaration_reuse", "durable_records_compared"]),
+            count(&["declaration_reuse", "durable_records_reused"]),
+        ]
+    };
+    let reachable = run_edit(2, 10);
+    let unrelated = run_edit(1, 11);
+    let mut report = Report::new(
+        "rooted-demand warm locality: in-process import-input host \
+         (synthetic accepted reads; no filesystem re-observation)",
+    );
+    for (label, measured, computed, reused) in [
+        ("reachable imported leaf body edit", reachable, 1, 1),
+        ("unrelated imported body edit", unrelated, 0, 2),
+    ] {
+        assert_eq!(
+            measured[0], computed,
+            "{label}: rooted-demand warm computed-body count changed"
+        );
+        assert_eq!(
+            measured[1], reused,
+            "{label}: rooted-demand warm reused-body count changed"
+        );
+        assert_eq!(
+            measured[2], 4,
+            "{label}: rooted-demand declaration-context record count changed"
+        );
+        assert_eq!(
+            measured[3], 4,
+            "{label}: every unchanged declaration-context record must be reusable"
+        );
+        report.push(Row::Met {
+            label: format!(
+                "{label}: computed={} reused={} declaration-context records={}/{} reused",
+                measured[0], measured[1], measured[3], measured[2],
+            ),
+        });
+    }
+    report.emit();
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- add rooted-demand warm-edit scaling rows for reachable and unrelated imported-body edits
- pin exact body compute/reuse and declaration-context reuse counters
- keep module registration on a stable source basis and retain all-green closure bundle cones
- name the in-process synthetic-read host shape explicitly; filesystem re-observation remains excluded until its prerequisite lands

## Testing

- `scripts/rue fmt`
- `scripts/rue unit compiler rooted_demand_in_process_host_pins_warm_edit_locality`
- `scripts/rue quick`
- adversarial review: no findings

The local serialized premerge tier was queued behind another active Rue full-suite run; required CI is the final authority.

Fixes RUE-1200.