### PR TITLE
Run the clippy gate in scripts/rue premerge and all

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -19,7 +19,7 @@ scripts/rue build                    # build the compiler
 scripts/rue exec program.rue         # compile and run a program
 scripts/rue quick                    # Rust unit tests
 scripts/rue test [pattern]           # full suite, optionally filtered
-scripts/rue premerge                 # required-CI test tier
+scripts/rue premerge                 # required-CI tier: clippy gate + tests
 scripts/rue slow                     # scheduled exhaustive tests
 scripts/rue stress                   # opt-in resource stress tests
 scripts/rue all                      # union of every test tier

--- a/scripts/rue
+++ b/scripts/rue
@@ -8,10 +8,10 @@
 #   scripts/rue exec prog.rue      Compile prog.rue to a temp file AND run it
 #   scripts/rue test [pattern]     Full suite (./test.sh), optional filter
 #   scripts/rue quick              Unit tests only (./quick-test.sh)
-#   scripts/rue premerge           Canonical required test tier
+#   scripts/rue premerge           Canonical required tier: clippy gate + tests
 #   scripts/rue slow               Canonical scheduled slow tier
 #   scripts/rue stress             Canonical opt-in stress tier
-#   scripts/rue all                Canonical union of every test tier
+#   scripts/rue all                Canonical union of every tier (incl. clippy)
 #   scripts/rue unit <crate> [args] One crate's Rust unit tests, case-filtered
 #                                  (crate name with or without the rue- prefix,
 #                                  or an explicit <crate>:<target>; forwards
@@ -95,6 +95,18 @@ case "$cmd" in
         if [[ $# -ne 0 ]]; then
             echo "usage: scripts/rue $cmd" >&2
             exit 2
+        fi
+        # Required CI gates on the workspace clippy pass (the `clippy` job runs
+        # ./clippy.sh) in addition to the premerge Buck tier, so the local
+        # premerge command must run both or a green run can still fail required
+        # CI on lint (RUE-1205). The gate lives here rather than in test.sh
+        # because CI's linux-premerge job invokes ./test.sh directly and has
+        # its own clippy job — test.sh running it too would double the work.
+        # Clippy goes first: it is much cheaper than the corpus suites, so lint
+        # findings surface before the long test run. slow and stress stay
+        # test-only; they are supersets of nothing outside their Buck labels.
+        if [[ "$cmd" == premerge || "$cmd" == all ]]; then
+            ./clippy.sh
         fi
         RUE_TEST_TIER="$cmd" ./test.sh
         ;;

--- a/scripts/test-wrapper-scripts.sh
+++ b/scripts/test-wrapper-scripts.sh
@@ -271,7 +271,10 @@ test_rue_cli_examples_survive_case_chdir() {
 }
 
 # Canonical tier commands are intentionally thin: scripts/rue names the
-# selection while test.sh owns execution and reads Buck's tier metadata.
+# selection while test.sh owns execution and reads Buck's tier metadata. The
+# required tier additionally fronts the clippy gate (RUE-1205): required CI
+# runs ./clippy.sh as its own job next to the premerge Buck tier, so premerge
+# (and the union tier, all) must run both for local green to predict CI green.
 test_rue_named_test_tiers_delegate_to_testsh() {
   local sb; sb="$(make_rue_sandbox)"
   cat >"$sb/test.sh" <<'EOF'
@@ -279,15 +282,42 @@ test_rue_named_test_tiers_delegate_to_testsh() {
 printf '%s\n' "${RUE_TEST_TIER:-unset}" >>"$TIER_LOG"
 EOF
   chmod +x "$sb/test.sh"
+  cat >"$sb/clippy.sh" <<'EOF'
+#!/usr/bin/env bash
+printf 'clippy\n' >>"$TIER_LOG"
+exit "${FAKE_CLIPPY_EXIT:-0}"
+EOF
+  chmod +x "$sb/clippy.sh"
 
   local tier rc
   for tier in premerge slow stress all; do
     rc=0
+    : >"$sb/tiers.log"
     (cd "$sb/work" && TIER_LOG="$sb/tiers.log" "$sb/scripts/rue" "$tier") \
       >/dev/null 2>&1 || rc=$?
     check "scripts/rue $tier: delegates the named tier to test.sh" \
       "$([ "$rc" -eq 0 ] && grep -Fxq "$tier" <<<"$(tail -1 "$sb/tiers.log")" && echo 0 || echo 1)"
+    case "$tier" in
+      premerge|all)
+        check "scripts/rue $tier: runs the clippy gate before the tier" \
+          "$([ "$(head -1 "$sb/tiers.log")" = clippy ] && echo 0 || echo 1)"
+        ;;
+      *)
+        check "scripts/rue $tier: does not run the clippy gate" \
+          "$(! grep -Fxq clippy "$sb/tiers.log" && echo 0 || echo 1)"
+        ;;
+    esac
   done
+
+  # A clippy failure must fail the command and stop before the test tier runs.
+  rc=0
+  : >"$sb/tiers.log"
+  (cd "$sb/work" && TIER_LOG="$sb/tiers.log" FAKE_CLIPPY_EXIT=13 \
+    "$sb/scripts/rue" premerge) >/dev/null 2>&1 || rc=$?
+  check "scripts/rue premerge: clippy failure is propagated" \
+    "$([ "$rc" -eq 13 ] && echo 0 || echo 1)"
+  check "scripts/rue premerge: clippy failure stops the tier run" \
+    "$(! grep -Fxq premerge "$sb/tiers.log" && echo 0 || echo 1)"
 
   rc=0
   (cd "$sb/work" && TIER_LOG="$sb/tiers.log" "$sb/scripts/rue" slow unexpected) \


### PR DESCRIPTION
Closes RUE-1205.

`scripts/rue premerge` advertises itself as the canonical required-CI tier, but it only ran `RUE_TEST_TIER=premerge ./test.sh`. Required CI additionally gates on the workspace clippy pass (`./clippy.sh`, the `clippy` job), so a branch could pass local premerge and still fail required CI on lint findings — which has repeatedly forced a second fix-up pass on otherwise-finished PRs.

- `scripts/rue premerge` and `scripts/rue all` (the advertised union of every tier) now run `./clippy.sh` before the Buck test tier, so lint findings surface before the long corpus run. `slow` and `stress` stay test-only.
- The gate stays out of `test.sh`: CI's `linux-premerge` job invokes `./test.sh` directly and already has its own required `clippy` job, so putting it there would run the gate twice per CI round.
- `scripts/test-wrapper-scripts.sh` now covers the tier/clippy contract: premerge and all run clippy first, slow and stress don't, a clippy failure propagates its exit code and stops the tier from running.

Refs RUE-1153 (the deeper Buck-native restructuring of the fmt/clippy gates; this is just the wrapper-level parity fix).

Validated locally: `scripts/test-wrapper-scripts.sh` (113/113 checks) and `scripts/validate-shell-pipefail-pipelines.py`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01FFxbfEWP33CPmpT9QmLKXv)_