### PR TITLE
Emit the frame whenever frame planning establishes one

### DIFF
--- a/crates/rue-codegen/src/aarch64/emit.rs
+++ b/crates/rue-codegen/src/aarch64/emit.rs
@@ -398,12 +398,18 @@ pub struct Emitter<'a> {
     has_frame_pointer: bool,
     /// Whether frame planning classified this function as a frameless leaf.
     /// Distinct from `has_frame_pointer`, which is also false for a synthetic
-    /// emitter built with no frame facts at all.
+    /// emitter that explicitly opted out of frame emission.
     frameless: bool,
     /// An FP-relative operand reached a function planned as frameless. That is
     /// an internal inconsistency, reported after emission rather than silently
     /// encoded against a frame pointer that was never established.
     frameless_frame_reference: bool,
+    /// Explicit opt-out of prologue/epilogue emission: the instruction stream
+    /// is emitted bare. Synthetic single-instruction encoding tests and the
+    /// emitter fuzz harnesses assert exact byte output and opt out here; the
+    /// production pipeline never does — it supplies a frame layout, and a
+    /// planned frame is always emitted (RUE-1195).
+    frame_opt_out: bool,
     /// Canonical checked layout supplied by the production pipeline.
     frame_layout: Option<crate::frame_layout::FrameLayout>,
     /// String constants (for StringConstPtr/StringConstLen)
@@ -454,12 +460,26 @@ impl<'a> Emitter<'a> {
             has_frame_pointer: false,
             frameless: false,
             frameless_frame_reference: false,
+            frame_opt_out: false,
             frame_layout: None,
             strings,
             inst_start: 0,
             emit_asm: false,
             param_homing: Vec::new(),
         }
+    }
+
+    /// Opt out of prologue/epilogue emission entirely and emit the instruction
+    /// stream bare.
+    ///
+    /// For synthetic single-instruction encoding tests and fuzz harnesses that
+    /// assert exact byte output. A function that makes a call must never opt
+    /// out: it needs the prologue's FP/LR save to preserve the link register
+    /// across `bl` (RUE-1195). The production pipeline always supplies a
+    /// checked frame layout instead.
+    pub fn without_frame(mut self) -> Self {
+        self.frame_opt_out = true;
+        self
     }
 
     /// Supply the per-source-parameter prologue homing plan (RUE-1005). Without
@@ -626,16 +646,20 @@ impl<'a> Emitter<'a> {
             }
         }
 
-        // A frame pointer exists to address frame slots; an eligible frameless
-        // leaf has none, so its prologue is at most the callee-saved pushes and
-        // it neither establishes X29 nor saves the FP/LR pair (RUE-1171).
-        self.frameless = self.frame().frame_pointer() == crate::frame_layout::FramePointer::Omitted;
-        self.has_frame_pointer = !self.frameless
-            && (self.num_locals > 0
-                || self.num_params > 0
-                || self.has_sret
-                || !self.callee_saved.is_empty());
-        self.has_frame = self.has_frame_pointer || !self.callee_saved.is_empty();
+        // Frame planning is authoritative: an eligible frameless leaf
+        // (`FramePointer::Omitted`) gets at most the callee-saved pushes and
+        // neither establishes X29 nor saves the FP/LR pair (RUE-1171); every
+        // other function gets the full prologue, even with zero frame slots
+        // and no callee-saved registers — a calling function still needs the
+        // FP/LR save so `bl` does not clobber its return address (RUE-1195).
+        // Synthetic encoding tests that want bare instruction bytes opt out
+        // explicitly via `without_frame`.
+        if !self.frame_opt_out {
+            self.frameless =
+                self.frame().frame_pointer() == crate::frame_layout::FramePointer::Omitted;
+            self.has_frame_pointer = !self.frameless;
+            self.has_frame = self.has_frame_pointer || !self.callee_saved.is_empty();
+        }
         if self.has_frame {
             self.emit_prologue();
         }
@@ -2583,7 +2607,11 @@ mod tests {
     fn emit_single(inst: Aarch64Inst) -> Vec<u8> {
         let mut mir = Aarch64Mir::new();
         mir.push(inst);
-        Emitter::new(&mir, 0, 0, 0, &[], &[]).emit().unwrap().0
+        Emitter::new(&mir, 0, 0, 0, &[], &[])
+            .without_frame()
+            .emit()
+            .unwrap()
+            .0
     }
 
     // --- Move instructions ---
@@ -3269,7 +3297,10 @@ mod tests {
             id: LabelId::new(0),
         });
 
-        let (code, _) = Emitter::new(&mir, 0, 0, 0, &[], &[]).emit().unwrap();
+        let (code, _) = Emitter::new(&mir, 0, 0, 0, &[], &[])
+            .without_frame()
+            .emit()
+            .unwrap();
 
         // b forward -> 0x14000002 (offset = 2 instructions = 8 bytes / 4)
         let inst = u32::from_le_bytes(code[0..4].try_into().unwrap());
@@ -3288,7 +3319,10 @@ mod tests {
             id: LabelId::new(0),
         });
 
-        let (code, _) = Emitter::new(&mir, 0, 0, 0, &[], &[]).emit().unwrap();
+        let (code, _) = Emitter::new(&mir, 0, 0, 0, &[], &[])
+            .without_frame()
+            .emit()
+            .unwrap();
 
         // b.eq -> 0x54000000 + condition (eq = 0)
         let inst = u32::from_le_bytes(code[0..4].try_into().unwrap());
@@ -3306,7 +3340,10 @@ mod tests {
             id: LabelId::new(0),
         });
 
-        let (code, _) = Emitter::new(&mir, 0, 0, 0, &[], &[]).emit().unwrap();
+        let (code, _) = Emitter::new(&mir, 0, 0, 0, &[], &[])
+            .without_frame()
+            .emit()
+            .unwrap();
 
         // cbz x0, label
         let inst = u32::from_le_bytes(code[0..4].try_into().unwrap());
@@ -3325,7 +3362,10 @@ mod tests {
             id: LabelId::new(0),
         });
 
-        let (code, _) = Emitter::new(&mir, 0, 0, 0, &[], &[]).emit().unwrap();
+        let (code, _) = Emitter::new(&mir, 0, 0, 0, &[], &[])
+            .without_frame()
+            .emit()
+            .unwrap();
 
         // cbnz x0, label
         let inst = u32::from_le_bytes(code[0..4].try_into().unwrap());
@@ -3340,7 +3380,10 @@ mod tests {
         let symbol_id = mir.intern_symbol("test_func");
         mir.push(Aarch64Inst::Bl { symbol_id });
 
-        let (code, relocs) = Emitter::new(&mir, 0, 0, 0, &[], &[]).emit().unwrap();
+        let (code, relocs) = Emitter::new(&mir, 0, 0, 0, &[], &[])
+            .without_frame()
+            .emit()
+            .unwrap();
 
         // bl -> 0x94000000
         let inst = u32::from_le_bytes(code[0..4].try_into().unwrap());
@@ -3355,6 +3398,63 @@ mod tests {
             "Should be Call26 relocation"
         );
         assert_eq!(relocs[0].addend, 0, "Addend should be 0");
+    }
+
+    #[test]
+    fn test_without_frame_emits_no_prologue() {
+        // The explicit opt-out — not zero slot counts — is what suppresses the
+        // frame for synthetic encoding tests (RUE-1195).
+        let mir = Aarch64Mir::new();
+        let (code, _) = Emitter::new(&mir, 0, 0, 0, &[], &[])
+            .without_frame()
+            .emit()
+            .unwrap();
+        assert!(code.is_empty());
+    }
+
+    #[test]
+    fn test_zero_slot_calling_function_gets_full_frame() {
+        // A function that makes a call needs the prologue even with no frame
+        // slots and no callee-saved registers: `bl` overwrites X30, so without
+        // the FP/LR save its `ret` would branch to the callee's return address
+        // (RUE-1195).
+        let mut mir = Aarch64Mir::new();
+        let symbol_id = mir.intern_symbol("callee");
+        mir.push(Aarch64Inst::Bl { symbol_id });
+        mir.push(Aarch64Inst::Ret);
+
+        let expected: Vec<u32> = vec![
+            0xA9BF7BFD, // stp x29, x30, [sp, #-16]!  (prologue: LR saved)
+            0x910003FD, // mov x29, sp
+            0x94000000, // bl callee
+            0xA8C17BFD, // ldp x29, x30, [sp], #16    (epilogue: LR restored)
+            0xD65F03C0, // ret
+        ];
+
+        let words = |code: &[u8]| -> Vec<u32> {
+            code.chunks_exact(4)
+                .map(|c| u32::from_le_bytes(c.try_into().unwrap()))
+                .collect()
+        };
+
+        // The pipeline path: frame planning classified the function as
+        // FramePointer::Established (zero slots, non-leaf).
+        let layout = crate::frame_layout::FrameLayout::try_new(
+            crate::frame_layout::SavedRegScheme::Aarch64,
+            0,
+            0,
+        )
+        .unwrap();
+        let (code, _) = Emitter::new(&mir, 0, 0, 0, &[], &[])
+            .with_frame_layout(layout)
+            .emit()
+            .unwrap();
+        assert_eq!(words(&code), expected);
+
+        // A synthetic emitter without an explicit opt-out gets the same frame:
+        // zero slot counts alone no longer suppress the prologue.
+        let (code, _) = Emitter::new(&mir, 0, 0, 0, &[], &[]).emit().unwrap();
+        assert_eq!(words(&code), expected);
     }
 
     // --- Stack operations ---
@@ -3437,7 +3537,10 @@ mod tests {
             dst: Operand::Physical(Reg::X0),
             imm: 42,
         });
-        let (code, _relocations) = Emitter::new(&mir, 0, 0, 0, &[], &[]).emit().unwrap();
+        let (code, _relocations) = Emitter::new(&mir, 0, 0, 0, &[], &[])
+            .without_frame()
+            .emit()
+            .unwrap();
         // Code should be generated
         assert!(!code.is_empty());
     }
@@ -3450,7 +3553,10 @@ mod tests {
             dst: Operand::Physical(Reg::X0),
             imm: 42,
         });
-        let emitted = Emitter::new(&mir, 0, 0, 0, &[], &[]).emit_all().unwrap();
+        let emitted = Emitter::new(&mir, 0, 0, 0, &[], &[])
+            .without_frame()
+            .emit_all()
+            .unwrap();
         // Instructions should be populated with asm text
         assert!(!emitted.instructions.is_empty());
         // Should contain the mov instruction

--- a/crates/rue-codegen/src/x86_64/emit.rs
+++ b/crates/rue-codegen/src/x86_64/emit.rs
@@ -268,12 +268,18 @@ pub struct Emitter<'a> {
     has_frame_pointer: bool,
     /// Whether frame planning classified this function as a frameless leaf.
     /// Distinct from `has_frame_pointer`, which is also false for a synthetic
-    /// emitter built with no frame facts at all.
+    /// emitter that explicitly opted out of frame emission.
     frameless: bool,
     /// An RBP-relative operand reached a function planned as frameless. That is
     /// an internal inconsistency, reported after emission rather than silently
     /// encoded against a frame pointer that was never established.
     frameless_frame_reference: bool,
+    /// Explicit opt-out of prologue/epilogue emission: the instruction stream
+    /// is emitted bare. Synthetic single-instruction encoding tests and the
+    /// emitter fuzz harnesses assert exact byte output and opt out here; the
+    /// production pipeline never does — it supplies a frame layout, and a
+    /// planned frame is always emitted (RUE-1195).
+    frame_opt_out: bool,
     /// Canonical checked layout supplied by the production pipeline.
     frame_layout: Option<crate::frame_layout::FrameLayout>,
     /// Byte offset where the current instruction started (for recording).
@@ -328,11 +334,24 @@ impl<'a> Emitter<'a> {
             has_frame_pointer: false,
             frameless: false,
             frameless_frame_reference: false,
+            frame_opt_out: false,
             frame_layout: None,
             inst_start: 0,
             emit_asm: false,
             param_homing: Vec::new(),
         }
+    }
+
+    /// Opt out of prologue/epilogue emission entirely and emit the instruction
+    /// stream bare.
+    ///
+    /// For synthetic single-instruction encoding tests and fuzz harnesses that
+    /// assert exact byte output. A function that makes a call must never opt
+    /// out: it needs the prologue's call-boundary stack alignment (RUE-1195).
+    /// The production pipeline always supplies a checked frame layout instead.
+    pub fn without_frame(mut self) -> Self {
+        self.frame_opt_out = true;
+        self
     }
 
     /// Supply the per-source-parameter prologue homing plan (RUE-1005). Without
@@ -485,16 +504,19 @@ impl<'a> Emitter<'a> {
             }
         }
 
-        // A frame pointer exists to address frame slots; an eligible frameless
-        // leaf has none, so its prologue is at most the callee-saved pushes and
-        // it never establishes RBP (RUE-1171).
-        self.frameless = self.frame().frame_pointer() == crate::frame_layout::FramePointer::Omitted;
-        self.has_frame_pointer = !self.frameless
-            && (self.num_locals > 0
-                || self.num_params > 0
-                || self.has_sret
-                || !self.callee_saved.is_empty());
-        self.has_frame = self.has_frame_pointer || !self.callee_saved.is_empty();
+        // Frame planning is authoritative: an eligible frameless leaf
+        // (`FramePointer::Omitted`) gets at most the callee-saved pushes and
+        // never establishes RBP (RUE-1171); every other function gets the full
+        // prologue, even with zero frame slots and no callee-saved registers —
+        // a calling function still needs `push rbp` to leave RSP 16-byte
+        // aligned at its call sites (RUE-1195). Synthetic encoding tests that
+        // want bare instruction bytes opt out explicitly via `without_frame`.
+        if !self.frame_opt_out {
+            self.frameless =
+                self.frame().frame_pointer() == crate::frame_layout::FramePointer::Omitted;
+            self.has_frame_pointer = !self.frameless;
+            self.has_frame = self.has_frame_pointer || !self.callee_saved.is_empty();
+        }
         if self.has_frame {
             self.emit_prologue();
         }
@@ -3002,7 +3024,11 @@ mod tests {
     fn emit_single(inst: X86Inst) -> Vec<u8> {
         let mut mir = X86Mir::new();
         mir.push(inst);
-        Emitter::new(&mir, 0, 0, 0, &[], &[]).emit().unwrap().0
+        Emitter::new(&mir, 0, 0, 0, &[], &[])
+            .without_frame()
+            .emit()
+            .unwrap()
+            .0
     }
 
     #[test]
@@ -3130,7 +3156,10 @@ mod tests {
         });
         mir.push(X86Inst::Syscall);
 
-        let (code, _) = Emitter::new(&mir, 0, 0, 0, &[], &[]).emit().unwrap();
+        let (code, _) = Emitter::new(&mir, 0, 0, 0, &[], &[])
+            .without_frame()
+            .emit()
+            .unwrap();
 
         // 41 BA 2A 00 00 00  mov r10d, 42
         // 4C 89 D7           mov rdi, r10
@@ -3155,7 +3184,10 @@ mod tests {
         let symbol_id = mir.intern_symbol("__rue_exit");
         mir.push(X86Inst::CallRel { symbol_id });
 
-        let (code, relocs) = Emitter::new(&mir, 0, 0, 0, &[], &[]).emit().unwrap();
+        let (code, relocs) = Emitter::new(&mir, 0, 0, 0, &[], &[])
+            .without_frame()
+            .emit()
+            .unwrap();
 
         // call rel32 -> E8 00 00 00 00
         assert_eq!(code, vec![0xE8, 0x00, 0x00, 0x00, 0x00]);
@@ -3470,11 +3502,54 @@ mod tests {
     }
 
     #[test]
-    fn test_no_prologue_no_locals() {
-        // With 0 locals, no prologue should be emitted
+    fn test_without_frame_emits_no_prologue() {
+        // The explicit opt-out — not zero slot counts — is what suppresses the
+        // frame for synthetic encoding tests (RUE-1195).
         let mir = X86Mir::new();
-        let (code, _) = Emitter::new(&mir, 0, 0, 0, &[], &[]).emit().unwrap();
+        let (code, _) = Emitter::new(&mir, 0, 0, 0, &[], &[])
+            .without_frame()
+            .emit()
+            .unwrap();
         assert!(code.is_empty());
+    }
+
+    #[test]
+    fn test_zero_slot_calling_function_gets_full_frame() {
+        // A function that makes a call needs the prologue even with no frame
+        // slots and no callee-saved registers: `push rbp` is what leaves RSP
+        // 16-byte aligned at the call site (RUE-1195).
+        let mut mir = X86Mir::new();
+        let symbol_id = mir.intern_symbol("callee");
+        mir.push(X86Inst::CallRel { symbol_id });
+        mir.push(X86Inst::Ret);
+
+        let expected = vec![
+            0x55, // push rbp            (prologue; RSP now 16-byte aligned)
+            0x48, 0x89, 0xE5, // mov rbp, rsp
+            0xE8, 0x00, 0x00, 0x00, 0x00, // call callee
+            0x48, 0x8D, 0x65, 0x00, // lea rsp, [rbp+0]  (epilogue)
+            0x5D, // pop rbp
+            0xC3, // ret
+        ];
+
+        // The pipeline path: frame planning classified the function as
+        // FramePointer::Established (zero slots, non-leaf).
+        let layout = crate::frame_layout::FrameLayout::try_new(
+            crate::frame_layout::SavedRegScheme::X86_64,
+            0,
+            0,
+        )
+        .unwrap();
+        let (code, _) = Emitter::new(&mir, 0, 0, 0, &[], &[])
+            .with_frame_layout(layout)
+            .emit()
+            .unwrap();
+        assert_eq!(code, expected);
+
+        // A synthetic emitter without an explicit opt-out gets the same frame:
+        // zero slot counts alone no longer suppress the prologue.
+        let (code, _) = Emitter::new(&mir, 0, 0, 0, &[], &[]).emit().unwrap();
+        assert_eq!(code, expected);
     }
 
     #[test]
@@ -4194,7 +4269,10 @@ mod tests {
             id: LabelId::new(0),
         });
 
-        let (code, _) = Emitter::new(&mir, 0, 0, 0, &[], &[]).emit().unwrap();
+        let (code, _) = Emitter::new(&mir, 0, 0, 0, &[], &[])
+            .without_frame()
+            .emit()
+            .unwrap();
 
         // jmp rel32 -> E9 xx xx xx xx (displacement = 5)
         assert_eq!(code[0], 0xE9);
@@ -4216,7 +4294,10 @@ mod tests {
             id: LabelId::new(0),
         });
 
-        let (code, _) = Emitter::new(&mir, 0, 0, 0, &[], &[]).emit().unwrap();
+        let (code, _) = Emitter::new(&mir, 0, 0, 0, &[], &[])
+            .without_frame()
+            .emit()
+            .unwrap();
 
         // jz rel32 -> 0F 84 xx xx xx xx (displacement = 5)
         assert_eq!(code[0], 0x0F);
@@ -4239,7 +4320,10 @@ mod tests {
             id: LabelId::new(0),
         });
 
-        let (code, _) = Emitter::new(&mir, 0, 0, 0, &[], &[]).emit().unwrap();
+        let (code, _) = Emitter::new(&mir, 0, 0, 0, &[], &[])
+            .without_frame()
+            .emit()
+            .unwrap();
 
         // jnz rel32 -> 0F 85 xx xx xx xx (displacement = 5)
         assert_eq!(code[0], 0x0F);
@@ -4256,7 +4340,10 @@ mod tests {
             id: LabelId::new(0),
         });
 
-        let (code, _) = Emitter::new(&mir, 0, 0, 0, &[], &[]).emit().unwrap();
+        let (code, _) = Emitter::new(&mir, 0, 0, 0, &[], &[])
+            .without_frame()
+            .emit()
+            .unwrap();
 
         // jo rel32 -> 0F 80 00 00 00 00
         assert_eq!(&code[0..6], &[0x0F, 0x80, 0x00, 0x00, 0x00, 0x00]);
@@ -4272,7 +4359,10 @@ mod tests {
             id: LabelId::new(0),
         });
 
-        let (code, _) = Emitter::new(&mir, 0, 0, 0, &[], &[]).emit().unwrap();
+        let (code, _) = Emitter::new(&mir, 0, 0, 0, &[], &[])
+            .without_frame()
+            .emit()
+            .unwrap();
 
         // jno rel32 -> 0F 81 00 00 00 00
         assert_eq!(&code[0..6], &[0x0F, 0x81, 0x00, 0x00, 0x00, 0x00]);
@@ -4288,7 +4378,10 @@ mod tests {
             id: LabelId::new(0),
         });
 
-        let (code, _) = Emitter::new(&mir, 0, 0, 0, &[], &[]).emit().unwrap();
+        let (code, _) = Emitter::new(&mir, 0, 0, 0, &[], &[])
+            .without_frame()
+            .emit()
+            .unwrap();
 
         // jb rel32 -> 0F 82 00 00 00 00
         assert_eq!(&code[0..6], &[0x0F, 0x82, 0x00, 0x00, 0x00, 0x00]);
@@ -4304,7 +4397,10 @@ mod tests {
             id: LabelId::new(0),
         });
 
-        let (code, _) = Emitter::new(&mir, 0, 0, 0, &[], &[]).emit().unwrap();
+        let (code, _) = Emitter::new(&mir, 0, 0, 0, &[], &[])
+            .without_frame()
+            .emit()
+            .unwrap();
 
         // jae rel32 -> 0F 83 00 00 00 00
         assert_eq!(&code[0..6], &[0x0F, 0x83, 0x00, 0x00, 0x00, 0x00]);
@@ -4320,7 +4416,10 @@ mod tests {
             id: LabelId::new(0),
         });
 
-        let (code, _) = Emitter::new(&mir, 0, 0, 0, &[], &[]).emit().unwrap();
+        let (code, _) = Emitter::new(&mir, 0, 0, 0, &[], &[])
+            .without_frame()
+            .emit()
+            .unwrap();
 
         // jbe rel32 -> 0F 86 00 00 00 00
         assert_eq!(&code[0..6], &[0x0F, 0x86, 0x00, 0x00, 0x00, 0x00]);
@@ -4360,7 +4459,10 @@ mod tests {
             string_id: 0,
         });
 
-        let (code, _) = Emitter::new(&mir, 0, 0, 0, &[], &strings).emit().unwrap();
+        let (code, _) = Emitter::new(&mir, 0, 0, 0, &[], &strings)
+            .without_frame()
+            .emit()
+            .unwrap();
 
         // mov rax, 5 -> 48 B8 05 00 00 00 00 00 00 00
         assert_eq!(
@@ -4428,7 +4530,10 @@ mod tests {
             dst: Operand::Physical(Reg::Rax),
             imm: 42,
         });
-        let (code, _relocations) = Emitter::new(&mir, 0, 0, 0, &[], &[]).emit().unwrap();
+        let (code, _relocations) = Emitter::new(&mir, 0, 0, 0, &[], &[])
+            .without_frame()
+            .emit()
+            .unwrap();
         // Code should be generated
         assert!(!code.is_empty());
     }
@@ -4441,7 +4546,10 @@ mod tests {
             dst: Operand::Physical(Reg::Rax),
             imm: 42,
         });
-        let emitted = Emitter::new(&mir, 0, 0, 0, &[], &[]).emit_all().unwrap();
+        let emitted = Emitter::new(&mir, 0, 0, 0, &[], &[])
+            .without_frame()
+            .emit_all()
+            .unwrap();
         // Instructions should be populated with asm text
         assert!(!emitted.instructions.is_empty());
         // Should contain the mov instruction
@@ -4804,7 +4912,10 @@ mod tests {
             id: LabelId::new(0),
         });
 
-        let (code, _) = Emitter::new(&mir, 0, 0, 0, &[], &[]).emit().unwrap();
+        let (code, _) = Emitter::new(&mir, 0, 0, 0, &[], &[])
+            .without_frame()
+            .emit()
+            .unwrap();
 
         // jge rel32 -> 0F 8D 00 00 00 00 (rel8 opcode 0x7D + 0x10 = 0x8D)
         assert_eq!(&code[0..6], &[0x0F, 0x8D, 0x00, 0x00, 0x00, 0x00]);
@@ -4820,7 +4931,10 @@ mod tests {
             id: LabelId::new(0),
         });
 
-        let (code, _) = Emitter::new(&mir, 0, 0, 0, &[], &[]).emit().unwrap();
+        let (code, _) = Emitter::new(&mir, 0, 0, 0, &[], &[])
+            .without_frame()
+            .emit()
+            .unwrap();
 
         // jle rel32 -> 0F 8E 00 00 00 00 (rel8 opcode 0x7E + 0x10 = 0x8E)
         assert_eq!(&code[0..6], &[0x0F, 0x8E, 0x00, 0x00, 0x00, 0x00]);

--- a/crates/rue-codegen/src/x86_64/verify.rs
+++ b/crates/rue-codegen/src/x86_64/verify.rs
@@ -29,7 +29,14 @@
 //! when the prologue hasn't been added yet. We verify that the body of the function
 //! maintains alignment assuming the prologue left RSP aligned.
 //!
-//! The prologue's alignment is correct by construction (see `emit_prologue` in emit.rs).
+//! The prologue's alignment is correct by construction (see `emit_prologue` in
+//! emit.rs), and the starting-depth assumption is guaranteed to apply wherever
+//! it matters: alignment is only checked at `call` instructions, any function
+//! containing a call is planned as `FramePointer::Established`
+//! (`codegen_pipeline::plan_frame_pointer`), and the emitter emits the
+//! prologue for every established frame — even one with zero slots and no
+//! callee-saved registers (RUE-1195). A function the emitter leaves without a
+//! prologue is a frameless leaf, which contains no call for this pass to check.
 
 use super::mir::{LabelId, Operand, Reg, X86Inst, X86Mir};
 use crate::stack_verify::{self, StackVerifyAdapter};

--- a/crates/rue-fuzz/src/codegen_generators.rs
+++ b/crates/rue-fuzz/src/codegen_generators.rs
@@ -620,7 +620,7 @@ mod tests {
             }
 
             // Emission must not panic (a graceful ICE Err is acceptable).
-            let emitter = Aarch64Emitter::new(&mir, 0, 0, 0, &[], &[]);
+            let emitter = Aarch64Emitter::new(&mir, 0, 0, 0, &[], &[]).without_frame();
             let _ = emitter.emit();
         }
     }

--- a/crates/rue-fuzz/src/targets.rs
+++ b/crates/rue-fuzz/src/targets.rs
@@ -338,7 +338,7 @@ impl FuzzTarget for EmitterTarget {
         }
 
         // Try to emit the instructions - should not panic
-        let emitter = X86Emitter::new(&mir, 0, 0, 0, &[], &[]);
+        let emitter = X86Emitter::new(&mir, 0, 0, 0, &[], &[]).without_frame();
         let _ = emitter.emit();
     }
 }
@@ -530,7 +530,7 @@ impl FuzzTarget for EmitterAarch64Target {
             mir.push(inst);
         }
 
-        let emitter = Aarch64Emitter::new(&mir, 0, 0, 0, &[], &[]);
+        let emitter = Aarch64Emitter::new(&mir, 0, 0, 0, &[], &[]).without_frame();
         let _ = emitter.emit();
     }
 }
@@ -688,7 +688,7 @@ impl FuzzTarget for EmitterSequenceTarget {
         mir.push(X86Inst::Ret);
 
         // Try to emit - should handle any valid label/jump combination
-        let emitter = X86Emitter::new(&mir, 0, 0, 0, &[], &[]);
+        let emitter = X86Emitter::new(&mir, 0, 0, 0, &[], &[]).without_frame();
         let _ = emitter.emit();
     }
 }
@@ -1050,7 +1050,7 @@ impl FuzzTarget for EmitterSequenceAarch64Target {
         }
         let build = aarch64_seq::build_sequence(input);
 
-        let emitter = Aarch64Emitter::new(&build.mir, 0, 0, 0, &[], &[]);
+        let emitter = Aarch64Emitter::new(&build.mir, 0, 0, 0, &[], &[]).without_frame();
         let (code, _relocations) = match emitter.emit() {
             Ok(result) => result,
             // A graceful ICE (e.g. an out-of-range displacement) is a normal
@@ -1061,7 +1061,7 @@ impl FuzzTarget for EmitterSequenceAarch64Target {
         aarch64_seq::validate(&build, &code);
 
         // The assembly-recording path must produce identical final bytes.
-        let recording = Aarch64Emitter::new(&build.mir, 0, 0, 0, &[], &[]);
+        let recording = Aarch64Emitter::new(&build.mir, 0, 0, 0, &[], &[]).without_frame();
         if let Ok(emitted) = recording.emit_all() {
             assert_eq!(
                 emitted.to_bytes(),
@@ -1342,10 +1342,12 @@ mod tests {
     /// produce identical bytes. Returns the emitted code.
     fn emit_and_validate(build: &SequenceBuild) -> Vec<u8> {
         let (code, _) = Aarch64Emitter::new(&build.mir, 0, 0, 0, &[], &[])
+            .without_frame()
             .emit()
             .expect("in-range sequence should emit");
         aarch64_seq::validate(build, &code);
         let recorded = Aarch64Emitter::new(&build.mir, 0, 0, 0, &[], &[])
+            .without_frame()
             .emit_all()
             .expect("in-range sequence should emit_all");
         assert_eq!(
@@ -1358,6 +1360,7 @@ mod tests {
 
     fn emit_is_err(build: &SequenceBuild) -> bool {
         Aarch64Emitter::new(&build.mir, 0, 0, 0, &[], &[])
+            .without_frame()
             .emit()
             .is_err()
     }
@@ -1616,14 +1619,14 @@ mod codegen_proptest_tests {
         fn emitter_never_panics_on_instruction(inst in codegen_generators::arb_x86_inst_physical()) {
             let mut mir = X86Mir::new();
             mir.push(inst);
-            let emitter = Emitter::new(&mir, 0, 0, 0, &[], &[]);
+            let emitter = Emitter::new(&mir, 0, 0, 0, &[], &[]).without_frame();
             let _ = emitter.emit();
         }
 
         /// The emitter should never panic on any valid MIR.
         #[test]
         fn emitter_never_panics_on_mir(mir in codegen_generators::arb_x86_mir(20, 3)) {
-            let emitter = Emitter::new(&mir, 0, 0, 0, &[], &[]);
+            let emitter = Emitter::new(&mir, 0, 0, 0, &[], &[]).without_frame();
             let _ = emitter.emit();
         }
 
@@ -1644,7 +1647,7 @@ mod codegen_proptest_tests {
             mir.push(X86Inst::MovRI32 { dst: op1, imm });
             mir.push(X86Inst::CmpRR { src1: op1, src2: op2 });
 
-            let emitter = Emitter::new(&mir, 0, 0, 0, &[], &[]);
+            let emitter = Emitter::new(&mir, 0, 0, 0, &[], &[]).without_frame();
             let _ = emitter.emit();
         }
 
@@ -1656,7 +1659,7 @@ mod codegen_proptest_tests {
 
             mir.push(X86Inst::MovRI64 { dst, imm: imm64 });
 
-            let emitter = Emitter::new(&mir, 0, 0, 0, &[], &[]);
+            let emitter = Emitter::new(&mir, 0, 0, 0, &[], &[]).without_frame();
             let _ = emitter.emit();
         }
 
@@ -1676,7 +1679,7 @@ mod codegen_proptest_tests {
             mir.push(X86Inst::Shr32RI { dst, imm: shift % 32 });
             mir.push(X86Inst::Sar32RI { dst, imm: shift % 32 });
 
-            let emitter = Emitter::new(&mir, 0, 0, 0, &[], &[]);
+            let emitter = Emitter::new(&mir, 0, 0, 0, &[], &[]).without_frame();
             let _ = emitter.emit();
         }
 
@@ -1685,14 +1688,14 @@ mod codegen_proptest_tests {
         fn emitter_aarch64_never_panics_on_instruction(inst in codegen_generators::arb_aarch64_inst_physical()) {
             let mut mir = Aarch64Mir::new();
             mir.push(inst);
-            let emitter = Aarch64Emitter::new(&mir, 0, 0, 0, &[], &[]);
+            let emitter = Aarch64Emitter::new(&mir, 0, 0, 0, &[], &[]).without_frame();
             let _ = emitter.emit();
         }
 
         /// The AArch64 emitter should never panic on generated physical MIR.
         #[test]
         fn emitter_aarch64_never_panics_on_mir(mir in codegen_generators::arb_aarch64_mir(20)) {
-            let emitter = Aarch64Emitter::new(&mir, 0, 0, 0, &[], &[]);
+            let emitter = Aarch64Emitter::new(&mir, 0, 0, 0, &[], &[]).without_frame();
             let _ = emitter.emit();
         }
 
@@ -1702,7 +1705,7 @@ mod codegen_proptest_tests {
         fn emitter_aarch64_sequence_never_panics_on_mir(
             mir in codegen_generators::arb_aarch64_branch_mir(20, 3)
         ) {
-            let emitter = Aarch64Emitter::new(&mir, 0, 0, 0, &[], &[]);
+            let emitter = Aarch64Emitter::new(&mir, 0, 0, 0, &[], &[]).without_frame();
             let _ = emitter.emit();
         }
 
@@ -1724,7 +1727,7 @@ mod codegen_proptest_tests {
             mir.push(Aarch64Inst::SubImm { dst: op1, src: op2, imm });
             mir.push(Aarch64Inst::CmpRR { src1: op1, src2: op2 });
 
-            let emitter = Aarch64Emitter::new(&mir, 0, 0, 0, &[], &[]);
+            let emitter = Aarch64Emitter::new(&mir, 0, 0, 0, &[], &[]).without_frame();
             let _ = emitter.emit();
         }
     }


### PR DESCRIPTION
Fixes RUE-1195.

Both emitters skipped the prologue and epilogue when a function had no frame slots and the allocator used no callee-saved registers, even when the function makes calls. On AArch64 that loses X30 across `bl`, so the function's own `ret` branches to the callee's return address; on x86-64 RSP is 8 (mod 16) at the call site, and `verify.rs` cannot catch it because its depth tracking assumes the prologue ran. The hole is latent today — the allocatable set is callee-saved-only (refs RUE-1146), so every calling function reachable from Rue source carries a callee-saved register that restored the frame — but the emission condition was wrong on its own terms.

## Changes

* Both `emit_internal`s now treat frame planning as authoritative: `FramePointer::Established` (which `codegen_pipeline::plan_frame_pointer` assigns to every calling function and every function with a frame slot) always emits the full prologue and epilogue. The `num_locals/num_params/has_sret/callee_saved` disjunction is gone. Frameless-leaf elision (refs RUE-1171) is unchanged, including the callee-saved-pushes-only frame.
* Synthetic single-instruction encoding tests and the emitter fuzz harnesses assert exact byte output with no frame; they now opt out explicitly via the new `Emitter::without_frame()` instead of depending on zero slot counts. The rue-fuzz sequence oracles (which decode branch targets at fixed byte offsets) opt out the same way.
* `x86_64/verify.rs` documents why its start-at-depth-0 assumption is now guaranteed: alignment is only checked at `call` instructions, any function containing a call is planned as `Established`, and an established frame is always emitted.

## Tests

* New per-backend emitter tests: a zero-slot, no-callee-saved calling function (`call`/`bl` + `ret`) asserts the exact full-frame byte sequence — `push rbp; mov rbp, rsp; … lea rsp, [rbp+0]; pop rbp; ret` on x86-64 and `stp x29, x30, [sp, #-16]!; mov x29, sp; … ldp x29, x30, [sp], #16; ret` on AArch64 — through both the pipeline frame-layout path and the synthetic fallback.
* New explicit `without_frame` tests replace the old `test_no_prologue_no_locals`, which encoded the buggy condition.
* Ran: rue-codegen units (625), rue-fuzz units (95), `scripts/rue quick`, the full CLI suite (1734 passed), and `scripts/rue fmt`. Native AArch64 execution is covered by Linux ARM64/macOS CI.

---
_Generated by [Claude Code](https://claude.ai/code/session_015zr92tDQqdZC9gTG3DSzgC)_