### PR TITLE
ADR-0063: status and consumer-list pass

### DIFF
--- a/docs/designs/0063-parallel-demand-driven-incremental-compilation.md
+++ b/docs/designs/0063-parallel-demand-driven-incremental-compilation.md
@@ -691,9 +691,13 @@ published artifact views. Exact public method shapes are handled under
 ADR-0061's facade rules.
 
 Batch compilation, `--emit` presentation, benchmarks, the oracle, a future LSP,
-and a future incremental linker request artifacts through the same graph.
-Presentation queries project canonical artifacts; they do not call free backend
-helpers or run a second lowering/regalloc/emission path.
+a future incremental linker, and future test selection/caching tooling request
+artifacts through the same graph. The test-selection consumer follows RUE-506's
+compiler-informed direction: reachability/`BodyReferences` and terminal
+fingerprints answer "which tests could this change affect" through the same
+queries every other consumer uses. Presentation queries project canonical
+artifacts; they do not call free backend helpers or run a second
+lowering/regalloc/emission path.
 
 The implementation may use an in-house engine, Salsa, or another substrate only
 if one database owns query state. A migration may not keep the current store as a
@@ -706,39 +710,39 @@ oracle.
 
 Tracked in Linear under the RUE-648 epic. The dependency order is:
 
-- [ ] **Phase 0: Runtime prototype and benchmark gate.** Prove exact-key
+- [x] **Phase 0: Runtime prototype and benchmark gate.** Prove exact-key
   claim-or-join, different-key parallel execution, red/green propagation,
   deterministic diagnostics, cancellation/revision isolation, exact cycle
   handling, bounded retention, and progress with one permit and adversarial
   claim/join/dependency schedules on representative query shapes. Compare an
   in-house evolution with a query-library prototype if substrate choice remains
   open. — RUE-1022
-- [ ] **Phase 1: Revisioned keyed database and compatibility shim.** Introduce
+- [x] **Phase 1: Revisioned keyed database and compatibility shim.** Introduce
   immutable revisions, per-key nodes, joined waiters, task-scoped dependency
   recording, and single-worker scheduling beneath a compatibility shim over the
   selected-state API. Do not require all query families to change call
   discipline in one diff. — RUE-1021 (blocked by RUE-1022)
-- [ ] **Phase 2: Source and import inputs.** Publish per-module source leaves,
+- [x] **Phase 2: Source and import inputs.** Publish per-module source leaves,
   fulfill rooted missing import observations in deduplicated frontier batches,
   prohibit speculative host demands, and preserve canonical read policy,
   precedence, provenance, and discovery-epoch reuse across successor attempts.
   — RUE-1023 (blocked by RUE-1021)
-- [ ] **Phase 3: Module syntax/RIR queries.** Parse and lower demanded modules,
+- [x] **Phase 3: Module syntax/RIR queries.** Parse and lower demanded modules,
   provide stable definition/name/import indexes, and keep whole-program views as
   thin projections. — RUE-1024 (blocked by RUE-1023)
-- [ ] **Phase 4: Complete stable semantic identity.** Cover named definitions,
+- [x] **Phase 4: Complete stable semantic identity.** Cover named definitions,
   specializations, anonymous nominals, methods/destructors,
   definition-relative structural anchors, and synthesized entities with
   schedule- and position-independent keys. — RUE-1025 (blocked by RUE-1024)
-- [ ] **Phase 5: Declaration and comptime queries.** Move shells, signatures,
+- [x] **Phase 5: Declaration and comptime queries.** Move shells, signatures,
   constants, type constructors, method lookup, and domain-specific cycle
   handling behind keyed canonical queries. — RUE-1026 (blocked by RUE-1025)
-- [ ] **Phase 6: Per-body semantics and projections.** Analyze one body per
+- [x] **Phase 6: Per-body semantics and projections.** Analyze one body per
   query, publish canonical bodies and independently stamped `BodyReferences`,
   including deterministic references from failed bodies, and remove the
   whole-program mutable Sema epoch as an authority. — RUE-1027 (blocked by
   RUE-1026)
-- [ ] **Phase 7: Reachability and parallel scheduling.** Implement
+- [x] **Phase 7: Reachability and parallel scheduling.** Implement
   database-owned reachability with per-identity memberships, correct edge
   deletion, and separate addition/deletion measurement gates; handle legal call
   SCCs; move existing Rayon CFG/backend parallelism onto the shared budget; and


### PR DESCRIPTION
Two bookkeeping edits to ADR-0063 (parallel demand-driven incremental compilation); no new decisions.

1. **Phase status.** Ticks the checkboxes for phases 0 through 7, whose tracking issues are all Done in Linear (ADR-0066's status section records the same milestone state). Phases 8 through 12 stay unchecked — phase 8 is In Progress and the rest are queued behind it. The checkbox list was the only status surface in the ADR that had not caught up.

2. **Section 15 consumer list.** The enumerated consumers of the one compiler graph gain future test selection and caching tooling, citing the compiler-informed test selection direction sketched in the agent-first test-runner design capture (refs RUE-506). That tooling is the natural consumer of reachability/`BodyReferences` and terminal fingerprints, so naming it alongside the LSP and incremental linker is a clarifying addition consistent with the accepted design — the section's rules do not change.

Validation: `./buck2 test //:adr-registry-validation` — Pass 1, Fail 0 on the edited registry.

---
_Generated by [Claude Code](https://claude.ai/code/session_01FC6GZYxBG2ciQRmPWN1xni)_