### PR TITLE
RUE-1029: query type layout ABI and drop glue on demand

### DIFF
--- a/crates/rue-air/src/sema/analysis.rs
+++ b/crates/rue-air/src/sema/analysis.rs
@@ -90,25 +90,10 @@ fn compose_queried_bodies_inner(
     let mut functions = Vec::with_capacity(candidates.len());
     let mut warnings = Vec::new();
     let mut seen_warnings = HashSet::new();
-    // Declaration-time aggregates remain part of the eager semantic universe.
-    // Snapshot them before importing bodies; body-produced aggregates become
-    // active only when committed AIR owns them.
-    let declaration_aggregate_roots = sema
-        .type_pool
-        .all_struct_ids()
-        .into_iter()
-        .filter(|id| !sema.anonymous_struct_ids.contains(id))
-        .map(Type::new_struct)
-        .chain(
-            sema.type_pool
-                .all_enum_ids()
-                .into_iter()
-                .filter(|id| !sema.anonymous_enum_ids.contains(id))
-                .map(Type::new_enum),
-        )
-        .collect::<Vec<_>>();
+    // Query-native composition materializes aggregate identities only from the
+    // exact reached AIR below. Merely declaring a type must not root layout,
+    // ownership, destructor diagnostics, or drop glue.
     let mut active_types = HashSet::new();
-    extend_owned_aggregate_types(sema, declaration_aggregate_roots, &mut active_types);
     let mut composed_identities = std::collections::BTreeSet::new();
     let mut errors = CompileErrors::new();
     for candidate in candidates {
@@ -1227,6 +1212,10 @@ fn finalize_function_body_analysis(
                 })
         })
         .collect::<CompileResult<HashMap<_, _>>>()?;
+    let aggregate_types_by_identity = aggregate_type_identities_by_type
+        .iter()
+        .map(|(ty, identity)| (identity.clone(), *ty))
+        .collect();
 
     let output = SemaOutput {
         functions,
@@ -1239,6 +1228,7 @@ fn finalize_function_body_analysis(
             .map(|(ty, identity)| (*ty, identity.clone()))
             .collect(),
         aggregate_type_identities_by_type,
+        aggregate_types_by_identity,
         body_analysis_work: sema.body_analysis_work,
         ordinary_body_exports: std::mem::take(&mut sema.ordinary_body_exports),
         specialized_body_exports: std::mem::take(&mut sema.specialized_body_exports),
@@ -3534,6 +3524,7 @@ mod error_invariant_tests {
             warnings: Vec::new(),
             anonymous_nominal_identities_by_type: HashMap::new(),
             aggregate_type_identities_by_type: HashMap::new(),
+            aggregate_types_by_identity: HashMap::new(),
             type_pool: TypeInternPool::new().freeze(),
             body_analysis_work: crate::BodyAnalysisWork::default(),
             ordinary_body_exports: Vec::new(),

--- a/crates/rue-air/src/sema/output.rs
+++ b/crates/rue-air/src/sema/output.rs
@@ -462,6 +462,13 @@ pub struct SemaOutput {
         Type,
         crate::TypeInstanceKey<crate::SemanticDefinitionToken, crate::SemanticModuleToken>,
     >,
+    /// Exact reverse index for demand-driven consumers.  Looking up one
+    /// reached glue owner must not scan either the complete type pool or the
+    /// complete active aggregate map.
+    pub aggregate_types_by_identity: HashMap<
+        crate::TypeInstanceKey<crate::SemanticDefinitionToken, crate::SemanticModuleToken>,
+        Type,
+    >,
     /// Exact structural work performed while dispatching reachable bodies.
     pub body_analysis_work: BodyAnalysisWork,
     /// Pre-specialization durable candidates for supported ordinary bodies.

--- a/crates/rue-compiler/src/api_inventory.rs
+++ b/crates/rue-compiler/src/api_inventory.rs
@@ -61,6 +61,7 @@ const PRODUCTION_MODULES: &[(&str, &str)] = &[
         "toolchain_module_demand",
         include_str!("toolchain_module_demand.rs"),
     ),
+    ("type_queries", include_str!("type_queries.rs")),
     ("typed_query_store", include_str!("typed_query_store.rs")),
     ("unstable", include_str!("unstable.rs")),
     ("well_known_option", include_str!("well_known_option.rs")),

--- a/crates/rue-compiler/src/body_query.rs
+++ b/crates/rue-compiler/src/body_query.rs
@@ -121,6 +121,9 @@ pub(crate) enum BodyReference {
     Definition(crate::StableDefinitionKey),
     #[allow(dead_code)]
     Type(crate::TypeInstanceKey),
+    /// Exact type whose value is destroyed by this body.  This is distinct
+    /// from an ordinary type mention: only this edge can root drop glue.
+    DropGlue(crate::TypeInstanceKey),
 }
 
 /// The per-body resolution of the well-known `Option` demands: the resolved
@@ -330,6 +333,9 @@ pub(crate) struct BodyClosureBody {
 #[derive(Debug, Clone)]
 pub(crate) struct BodyReachabilityOutput {
     pub(crate) reached: Arc<[crate::FunctionInstanceKey]>,
+    pub(crate) demanded_drop_glue: Arc<[crate::TypeInstanceKey]>,
+    pub(crate) demanded_drop_glue_plans:
+        Arc<[(crate::TypeInstanceKey, crate::type_queries::DropGlueFacts)]>,
     pub(crate) scheduling_errors: Arc<[(crate::FunctionInstanceKey, crate::CompileErrors)]>,
     pub(crate) fatal: Option<BodyClosureFatal>,
     pub(crate) parked_toolchain: Option<crate::ParkedToolchainModules>,
@@ -340,6 +346,8 @@ pub(crate) fn body_reachability_output_equal(
     right: &BodyReachabilityOutput,
 ) -> bool {
     left.reached == right.reached
+        && left.demanded_drop_glue == right.demanded_drop_glue
+        && left.demanded_drop_glue_plans == right.demanded_drop_glue_plans
         && left.scheduling_errors == right.scheduling_errors
         && left.fatal == right.fatal
         && left.parked_toolchain == right.parked_toolchain
@@ -363,6 +371,10 @@ pub(crate) enum BodyClosureFatal {
         instance: crate::FunctionInstanceKey,
         failure: crate::revisioned_query_database::WellKnownOptionResolutionFailure,
     },
+    TypeQuery {
+        ty: Option<crate::TypeInstanceKey>,
+        detail: Arc<str>,
+    },
     AnonymousDigestCollision {
         digest: u128,
         first: crate::AnonymousNominalKey,
@@ -373,6 +385,9 @@ pub(crate) enum BodyClosureFatal {
 #[derive(Debug, Clone)]
 pub(crate) struct BodyClosureOutput {
     pub(crate) reached: Arc<[crate::FunctionInstanceKey]>,
+    pub(crate) demanded_drop_glue: Arc<[crate::TypeInstanceKey]>,
+    pub(crate) demanded_drop_glue_plans:
+        Arc<[(crate::TypeInstanceKey, crate::type_queries::DropGlueFacts)]>,
     pub(crate) bodies: Arc<[BodyClosureBody]>,
     pub(crate) scheduling_errors: Arc<[(crate::FunctionInstanceKey, crate::CompileErrors)]>,
     pub(crate) fatal: Option<BodyClosureFatal>,
@@ -384,6 +399,8 @@ pub(crate) fn body_closure_output_equal(
     right: &BodyClosureOutput,
 ) -> bool {
     left.reached == right.reached
+        && left.demanded_drop_glue == right.demanded_drop_glue
+        && left.demanded_drop_glue_plans == right.demanded_drop_glue_plans
         && left.bodies.len() == right.bodies.len()
         && left
             .bodies

--- a/crates/rue-compiler/src/bound_definitions.rs
+++ b/crates/rue-compiler/src/bound_definitions.rs
@@ -724,12 +724,17 @@ pub(crate) fn compare_canonical_durable_declaration_install(
     let installed_bodies = installed.analyze_all_bodies_for_test();
     match (ordinary_bodies, installed_bodies) {
         (Ok(ordinary), Ok(installed)) => {
+            let ordinary_glue = std::collections::BTreeSet::new();
+            let installed_glue = std::collections::BTreeSet::new();
+            let glue_plans = std::collections::BTreeMap::new();
             let ordinary_identities =
                 crate::queries::synthetic_projected_function_identities(&ordinary);
             let installed_identities =
                 crate::queries::synthetic_projected_function_identities(&installed);
             let ordinary = crate::build_functions_and_cfgs(
                 ordinary,
+                &ordinary_glue,
+                &glue_plans,
                 crate::OptLevel::default(),
                 crate::Target::host().unwrap(),
                 rir.semantic_symbols().interner(),
@@ -740,6 +745,8 @@ pub(crate) fn compare_canonical_durable_declaration_install(
             .map_err(|failure| failure.errors)?;
             let installed = crate::build_functions_and_cfgs(
                 installed,
+                &installed_glue,
+                &glue_plans,
                 crate::OptLevel::default(),
                 crate::Target::host().unwrap(),
                 rir.semantic_symbols().interner(),

--- a/crates/rue-compiler/src/canonical_semantic.rs
+++ b/crates/rue-compiler/src/canonical_semantic.rs
@@ -888,63 +888,6 @@ impl CanonicalSemanticOutput {
     }
 }
 
-/// Bind declarations once, optionally issue stable IDs, then consume the same
-/// transient bound Sema for body analysis and CFG construction.
-#[cfg(test)]
-pub(crate) fn analyze_canonical_program_for_test_support(
-    merged: &CanonicalMergedProgram,
-    rir: &CanonicalRirOutput,
-    options: &CompileOptions,
-    imports: &CanonicalImportGraph,
-    request_stable_ids: bool,
-) -> MultiErrorResult<CanonicalSemanticOutput> {
-    let input = CodegenInputDescriptor {
-        semantic: SemanticInputDescriptor::new(
-            merged.definitions().source_snapshot(),
-            options.target,
-            &options.preview_features,
-        ),
-        opt_level: options.opt_level.into(),
-    };
-    let query_shells =
-        crate::revisioned_query_database::projected_declaration_shells_for_test(merged)?;
-    let prepared = prepare_query_declaration_shells(merged, rir, options, imports, &query_shells)
-        .map_err(|failure| failure.errors)?;
-    let CanonicalPreparedDeclarations {
-        shells,
-        shell_records: _,
-        definitions,
-        declaration_index,
-    } = prepared;
-    let bound = shells.resolve_declarations_for_test()?;
-    finish_canonical_analysis_with(
-        input,
-        merged,
-        rir,
-        options,
-        request_stable_ids,
-        declaration_index,
-        bound,
-        definitions,
-        CanonicalDeclarationReuseWork::default(),
-        Vec::new(),
-        Vec::new(),
-        Vec::new(),
-        Arc::from([]),
-        crate::DurableBodyWork::default(),
-        info_span!("sema", phase = "semantic_analysis").entered(),
-        |bound, _candidates, _definitions, _merged| {
-            bound
-                .analyze_all_bodies_for_test()
-                .map_err(|errors| CanonicalBodyCompositionFailure {
-                    errors,
-                    work: BodyAnalysisWork::default(),
-                })
-        },
-    )
-    .map_err(|failure| failure.errors)
-}
-
 /// Analyze bodies in a fresh semantic epoch whose declaration payloads come
 /// from the canonical keyed semantic nucleus. Projection and installation are
 /// invariant checks, not a compatibility choice: a failure is terminal and
@@ -963,6 +906,8 @@ pub(crate) fn analyze_prepared_canonical_program_reusing_declarations(
     specialized_body_candidates: Vec<PreparedDurableSpecializedBodyCandidate>,
     anonymous_body_candidates: Vec<PreparedDurableAnonymousBodyCandidate>,
     durable_cfg_candidates: Arc<[crate::queries::DurableCfgArtifact]>,
+    demanded_drop_glue: Arc<[crate::TypeInstanceKey]>,
+    demanded_drop_glue_plans: Arc<[(crate::TypeInstanceKey, crate::type_queries::DropGlueFacts)]>,
     body_work: crate::DurableBodyWork,
 ) -> Result<CanonicalSemanticOutput, CanonicalSemanticFailure> {
     // Rebinding the durable declaration records and rebuilding the query
@@ -1276,6 +1221,8 @@ pub(crate) fn analyze_prepared_canonical_program_reusing_declarations(
         specialized_body_candidates,
         anonymous_body_candidates,
         durable_cfg_candidates,
+        demanded_drop_glue,
+        demanded_drop_glue_plans,
         body_work,
         sema_span,
     )
@@ -1573,6 +1520,8 @@ fn finish_canonical_analysis(
     durable_specialized_body_candidates: Vec<PreparedDurableSpecializedBodyCandidate>,
     durable_anonymous_body_candidates: Vec<PreparedDurableAnonymousBodyCandidate>,
     durable_cfg_candidates: Arc<[crate::queries::DurableCfgArtifact]>,
+    demanded_drop_glue: Arc<[crate::TypeInstanceKey]>,
+    demanded_drop_glue_plans: Arc<[(crate::TypeInstanceKey, crate::type_queries::DropGlueFacts)]>,
     durable_body_reuse_work: crate::DurableBodyWork,
     sema_span: tracing::span::EnteredSpan,
 ) -> Result<CanonicalSemanticOutput, CanonicalSemanticFailure> {
@@ -1590,6 +1539,8 @@ fn finish_canonical_analysis(
         durable_specialized_body_candidates,
         durable_anonymous_body_candidates,
         durable_cfg_candidates,
+        demanded_drop_glue,
+        demanded_drop_glue_plans,
         durable_body_reuse_work,
         sema_span,
         |bound, candidates, definitions, merged| {
@@ -1621,6 +1572,8 @@ fn finish_canonical_analysis_with(
     durable_specialized_body_candidates: Vec<PreparedDurableSpecializedBodyCandidate>,
     durable_anonymous_body_candidates: Vec<PreparedDurableAnonymousBodyCandidate>,
     durable_cfg_candidates: Arc<[crate::queries::DurableCfgArtifact]>,
+    demanded_drop_glue: Arc<[crate::TypeInstanceKey]>,
+    demanded_drop_glue_plans: Arc<[(crate::TypeInstanceKey, crate::type_queries::DropGlueFacts)]>,
     mut durable_body_reuse_work: crate::DurableBodyWork,
     sema_span: tracing::span::EnteredSpan,
     analyze_bodies: impl FnOnce(
@@ -1984,14 +1937,98 @@ fn finish_canonical_analysis_with(
     let named_const_dependencies = sema_output.named_const_dependencies.clone();
     let named_value_const_dependencies_complete =
         sema_output.named_value_const_dependencies_complete;
+    let issue_type = |stable: &crate::TypeInstanceKey| {
+        stable.try_map_identities(
+            &|definition| authoritative_definitions.semantic_token_for_key(definition),
+            &|module| authoritative_definitions.module_token_for(merged, module),
+        )
+    };
+    let demanded_issued_drop_glue = demanded_drop_glue
+        .iter()
+        .map(|stable| {
+            issue_type(stable).map_err(|failure| {
+                CanonicalSemanticFailure::new(
+                    CanonicalSemanticFailurePhase::BodyAnalysis,
+                    crate::CompileErrors::from(crate::CompileError::without_span(
+                        rue_error::ErrorKind::InternalError(format!(
+                            "failed to issue demanded drop-glue owner {stable:?}: {failure:?}"
+                        )),
+                    )),
+                    CanonicalSemanticWork {
+                        declaration_index,
+                        binding,
+                        manifest: manifest_work,
+                        bound_definitions: Some(authoritative_definitions.work()),
+                        body_analysis,
+                        durable_bodies: durable_body_work,
+                        declaration_reuse,
+                        ..CanonicalSemanticWork::default()
+                    },
+                )
+            })
+        })
+        .collect::<Result<std::collections::BTreeSet<_>, _>>()?;
+    for issued in &demanded_issued_drop_glue {
+        if !sema_output.aggregate_types_by_identity.contains_key(issued) {
+            return Err(CanonicalSemanticFailure::new(
+                CanonicalSemanticFailurePhase::BodyAnalysis,
+                crate::CompileErrors::from(crate::CompileError::without_span(
+                    rue_error::ErrorKind::InternalError(
+                        "demanded drop-glue owner was not materialized by reached AIR".into(),
+                    ),
+                )),
+                CanonicalSemanticWork {
+                    declaration_index,
+                    binding,
+                    manifest: manifest_work,
+                    bound_definitions: Some(authoritative_definitions.work()),
+                    body_analysis,
+                    durable_bodies: durable_body_work,
+                    declaration_reuse,
+                    ..CanonicalSemanticWork::default()
+                },
+            ));
+        }
+    }
+    let demanded_issued_drop_glue_plans = demanded_drop_glue_plans
+        .iter()
+        .map(|(stable, plan)| {
+            issue_type(stable).and_then(|issued| {
+                plan.try_map_identities(
+                    &|definition| authoritative_definitions.semantic_token_for_key(definition),
+                    &|module| authoritative_definitions.module_token_for(merged, module),
+                )
+                .map(|plan| (issued, plan))
+            })
+        })
+        .collect::<Result<std::collections::BTreeMap<_, _>, _>>()
+        .map_err(|failure| {
+            CanonicalSemanticFailure::new(
+                CanonicalSemanticFailurePhase::BodyAnalysis,
+                crate::CompileErrors::from(crate::CompileError::without_span(
+                    rue_error::ErrorKind::InternalError(format!(
+                        "failed to issue demanded drop-glue plan owner: {failure:?}"
+                    )),
+                )),
+                CanonicalSemanticWork {
+                    declaration_index,
+                    binding,
+                    manifest: manifest_work,
+                    bound_definitions: Some(authoritative_definitions.work()),
+                    body_analysis,
+                    durable_bodies: durable_body_work,
+                    declaration_reuse,
+                    ..CanonicalSemanticWork::default()
+                },
+            )
+        })?;
     let issued_callable_identities = sema_output
         .functions
         .iter()
         .map(|function| function.identity.clone())
         .chain(
-            sema_output
-                .aggregate_type_identities_by_type
-                .values()
+            demanded_issued_drop_glue
+                .iter()
                 .cloned()
                 .map(|ty| rue_air::FunctionInstanceKey::DropGlue(Box::new(ty))),
         )
@@ -2080,6 +2117,8 @@ fn finish_canonical_analysis_with(
     // `build_functions_and_cfgs`.
     let cfg = build_functions_and_cfgs(
         sema_output,
+        &demanded_issued_drop_glue,
+        &demanded_issued_drop_glue_plans,
         options.opt_level,
         options.target,
         rir.semantic_symbols().interner(),
@@ -2231,13 +2270,10 @@ mod tests {
 
     use rue_span::FileId;
 
-    use super::{
-        BodyOwnerTokenWork, CanonicalSemanticOutput, CanonicalSemanticWork,
-        analyze_canonical_program_for_test_support,
-    };
+    use super::{BodyOwnerTokenWork, CanonicalSemanticOutput, CanonicalSemanticWork};
     use crate::{
-        CanonicalRirOutput, CompileOptions, FunctionWithCfg, PreviewFeatures, SourceMetadata,
-        SourceSnapshot, Target,
+        CanonicalRirOutput, CompileOptions, CompilerSession, FunctionWithCfg, PreviewFeatures,
+        SourceMetadata, SourceSnapshot, Target,
     };
 
     fn snapshot(entries: &[(u32, &str, &str, &str)], root: u32) -> SourceSnapshot {
@@ -2263,11 +2299,8 @@ mod tests {
     fn assert_token_preparation_preserves_source_errors(source: &str) {
         let source = snapshot(&[(1, "/main.rue", "main.rue", source)], 1);
         let stages = crate::test_support::test_frontend_stages(&source).unwrap();
-        let merged = &stages.merged;
         let rir = &stages.rir;
         let options = CompileOptions::default();
-        let imports = crate::import_graph::import_free_canonical_graph(merged.ast()).unwrap();
-
         let ordinary = match rue_air::Sema::new_synthetic(
             rir.rir(),
             rir.semantic_symbols().interner(),
@@ -2278,9 +2311,9 @@ mod tests {
             Err(errors) => errors,
             Ok(_) => panic!("test input must fail ordinary declaration binding"),
         };
-        let canonical =
-            analyze_canonical_program_for_test_support(merged, rir, &options, &imports, false)
-                .unwrap_err();
+        let mut session = CompilerSession::new();
+        session.update(&source).into_result().unwrap();
+        let canonical = session.canonical_semantic(&options).unwrap_err();
         let messages = |errors: crate::CompileErrors| {
             errors.iter().map(ToString::to_string).collect::<Vec<_>>()
         };
@@ -2325,45 +2358,19 @@ mod tests {
     fn canonical(
         snapshot: &SourceSnapshot,
         options: &CompileOptions,
-    ) -> (
-        std::sync::Arc<CanonicalSemanticOutput>,
-        std::sync::Arc<CanonicalRirOutput>,
-    ) {
-        let mut session = crate::CompilerSession::new();
-        crate::test_support::publish_test_snapshot(&mut session, snapshot).unwrap();
-        let rir = session.canonical_rir().unwrap();
-        let semantic = session.canonical_semantic(options).unwrap();
-        (semantic, rir)
-    }
-
-    /// Analyze a fixture through the whole-program body path rather than the
-    /// session's queried composition.
-    ///
-    /// Two kinds of test still need this. Stable declaration IDs are requested
-    /// by no production caller — the session asserts `!stable_ids_requested` —
-    /// so `ids` is reachable only here. And body-record assertions
-    /// (specialization origins, body-analysis counters) are empty through the
-    /// session because `compose_queried_bodies` never records them while the
-    /// shared finalizer still reports them complete; that is RUE-1204. Moving
-    /// those tests onto the session would assert the empty result and encode
-    /// the defect as expected behavior, so they stay here until RUE-1204 is
-    /// resolved.
-    fn whole_program_canonical(
-        snapshot: &SourceSnapshot,
-        options: &CompileOptions,
-        ids: bool,
-    ) -> (CanonicalSemanticOutput, std::sync::Arc<CanonicalRirOutput>) {
-        let stages = crate::test_support::test_frontend_stages(snapshot).unwrap();
-        let imports = crate::test_support::test_import_graph(snapshot).unwrap();
-        let output = analyze_canonical_program_for_test_support(
-            &stages.merged,
-            &stages.rir,
-            options,
-            &imports,
-            ids,
-        )
-        .unwrap();
-        (output, stages.rir)
+    ) -> (Arc<CanonicalSemanticOutput>, Arc<CanonicalRirOutput>) {
+        let mut session = CompilerSession::new();
+        if crate::test_support::fixture_has_imports(snapshot).unwrap() {
+            crate::test_support::TestDiscoveryHost::new(snapshot)
+                .unwrap()
+                .drive(&mut session)
+                .unwrap();
+        } else {
+            session.update(snapshot).into_result().unwrap();
+        }
+        let output = session.canonical_semantic(options).unwrap();
+        let rir = session.selected_semantic_rir_owner().unwrap();
+        (output, rir)
     }
 
     fn function_fingerprint(
@@ -2382,8 +2389,52 @@ mod tests {
             .collect()
     }
 
+    fn function_base_definition(
+        identity: &crate::FunctionInstanceKey,
+    ) -> Option<&crate::StableDefinitionKey> {
+        match identity {
+            crate::FunctionInstanceKey::Definition(definition) => Some(definition),
+            crate::FunctionInstanceKey::Specialization { base, .. } => {
+                function_base_definition(base)
+            }
+            crate::FunctionInstanceKey::AnonymousMember { .. }
+            | crate::FunctionInstanceKey::DropGlue(_) => None,
+        }
+    }
+
+    fn specialized_functions<'a>(
+        output: &'a CanonicalSemanticOutput,
+        base_name: &'a str,
+    ) -> impl Iterator<
+        Item = (
+            &'a crate::StableDefinitionKey,
+            &'a crate::CanonicalArguments,
+        ),
+    > {
+        output.functions().iter().filter_map(move |function| {
+            let crate::FunctionInstanceKey::Specialization { base, arguments } =
+                &function.semantic_identity
+            else {
+                return None;
+            };
+            let definition = function_base_definition(base)?;
+            (definition.name() == base_name).then_some((definition, arguments))
+        })
+    }
+
+    fn integer_arguments(arguments: &crate::CanonicalArguments) -> Vec<i128> {
+        arguments
+            .values
+            .iter()
+            .map(|value| match value {
+                crate::CanonicalArgumentValue::Integer(value) => *value,
+                value => panic!("expected integer specialization argument, got {value:?}"),
+            })
+            .collect()
+    }
+
     #[test]
-    fn specialization_origins_preserve_exact_generic_base_and_arguments() {
+    fn specialization_identities_preserve_exact_generic_base_and_arguments() {
         let source = snapshot(
             &[(
                 1,
@@ -2397,34 +2448,32 @@ mod tests {
             )],
             1,
         );
-        let (output, _) = whole_program_canonical(&source, &CompileOptions::default(), false);
-        let origins = output.specialized_free_function_origins();
-        let wraps = origins
-            .iter()
-            .filter(|origin| origin.base_name == "wrap")
-            .collect::<Vec<_>>();
-        let ids = origins
-            .iter()
-            .filter(|origin| origin.base_name == "id")
-            .collect::<Vec<_>>();
+        let (output, _) = canonical(&source, &CompileOptions::default());
+        let wraps = specialized_functions(&output, "wrap").collect::<Vec<_>>();
+        let ids = specialized_functions(&output, "id").collect::<Vec<_>>();
         assert_eq!(wraps.len(), 1, "identical specialization deduplicates");
         assert_eq!(ids.len(), 2, "direct and later-fixpoint specializations");
-        assert!(ids.iter().all(|origin| origin.base_file == 1));
-        assert_ne!(ids[0].value_arguments, ids[1].value_arguments);
-        assert!(
-            origins
-                .iter()
-                .all(|origin| origin.specialized_name != origin.base_name)
+        assert_eq!(integer_arguments(wraps[0].1), [1]);
+        assert_eq!(
+            ids.iter()
+                .map(|(_, arguments)| integer_arguments(arguments))
+                .collect::<std::collections::BTreeSet<_>>(),
+            std::collections::BTreeSet::from([vec![1], vec![2]])
         );
+        assert!(wraps.iter().chain(ids.iter()).all(|(definition, _)| {
+            definition.module().as_str() == "main.rue"
+                && definition.kind() == crate::StableDefinitionKind::Function
+        }));
         assert!(
             output
                 .functions()
                 .iter()
-                .all(|function| function.analyzed.name != "id" && function.analyzed.name != "wrap")
-        );
-        assert_eq!(
-            output.work().body_analysis.specialized_origin_records,
-            origins.len()
+                .filter_map(|function| match &function.semantic_identity {
+                    crate::FunctionInstanceKey::Definition(definition) => Some(definition),
+                    _ => None,
+                })
+                .all(|definition| !matches!(definition.name(), "id" | "wrap")),
+            "generic definitions are not runtime bodies"
         );
     }
 
@@ -2442,22 +2491,21 @@ mod tests {
             )],
             1,
         );
-        let (output, _) = whole_program_canonical(&source, &CompileOptions::default(), false);
-        let origins = output
-            .specialized_free_function_origins()
-            .iter()
-            .filter(|origin| origin.base_name == "fib")
-            .collect::<Vec<_>>();
-        assert_eq!(origins.len(), 6, "fib(0) through fib(5), each exactly once");
-        assert!(origins.iter().all(|origin| origin.base_file == 1));
+        let (output, _) = canonical(&source, &CompileOptions::default());
         assert_eq!(
-            output.work().body_analysis.specialized_origin_records,
-            origins.len()
+            specialized_functions(&output, "fib")
+                .map(|(definition, arguments)| {
+                    assert_eq!(definition.module().as_str(), "main.rue");
+                    integer_arguments(arguments)
+                })
+                .collect::<std::collections::BTreeSet<_>>(),
+            (0..=5).map(|value| vec![value]).collect(),
+            "fib(0) through fib(5) must each have one production identity"
         );
     }
 
     #[test]
-    fn sibling_same_name_specializations_retain_distinct_base_files() {
+    fn sibling_same_name_specializations_retain_distinct_base_modules() {
         let source = snapshot(
             &[
                 (
@@ -2483,19 +2531,22 @@ mod tests {
             ],
             9,
         );
-        let (output, _) = whole_program_canonical(&source, &CompileOptions::default(), false);
-        let origins = output
-            .specialized_free_function_origins()
-            .iter()
-            .filter(|origin| origin.base_name == "id")
-            .collect::<Vec<_>>();
-        assert_eq!(origins.len(), 2);
+        let (output, _) = canonical(&source, &CompileOptions::default());
+        let instances = specialized_functions(&output, "id").collect::<Vec<_>>();
+        assert_eq!(instances.len(), 2);
         assert_eq!(
-            origins
+            instances
                 .iter()
-                .map(|origin| origin.base_file)
+                .map(|(definition, _)| definition.module().as_str())
                 .collect::<std::collections::BTreeSet<_>>(),
-            std::collections::BTreeSet::from([3, 7])
+            std::collections::BTreeSet::from(["left.rue", "right.rue"])
+        );
+        assert_eq!(
+            instances
+                .iter()
+                .map(|(_, arguments)| integer_arguments(arguments))
+                .collect::<std::collections::BTreeSet<_>>(),
+            std::collections::BTreeSet::from([vec![1], vec![2]])
         );
     }
 
@@ -2551,38 +2602,6 @@ mod tests {
         assert!(canonical.bound_definitions().is_none());
     }
 
-    #[test]
-    fn requesting_ids_materializes_manifest_without_rebinding() {
-        let source = snapshot(
-            &[(
-                1,
-                "/main.rue",
-                "main.rue",
-                "struct Value { n: i32 } fn main() -> i32 { 42 }",
-            )],
-            1,
-        );
-        let options = CompileOptions::default();
-        let (ordinary, ordinary_rir) = whole_program_canonical(&source, &options, false);
-        let (with_ids, with_ids_rir) = whole_program_canonical(&source, &options, true);
-        assert_eq!(ordinary.work().binding.bind_invocations, 1);
-        assert_eq!(with_ids.work().binding.bind_invocations, 1);
-        assert_eq!(ordinary.work().manifest.build_invocations, 1);
-        assert_eq!(with_ids.work().manifest.build_invocations, 1);
-        assert!(ordinary.bound_definitions().is_none());
-        assert!(with_ids.bound_definitions().is_some());
-        assert_eq!(
-            function_fingerprint(
-                ordinary.functions(),
-                ordinary_rir.semantic_symbols().interner()
-            ),
-            function_fingerprint(
-                with_ids.functions(),
-                with_ids_rir.semantic_symbols().interner()
-            )
-        );
-    }
-
     fn irrelevant_declarations(count: usize) -> CanonicalSemanticWork {
         let mut source = String::from("fn main() -> i32 { 42 }");
         for index in 0..count {
@@ -2612,7 +2631,9 @@ mod tests {
         assert!(many.binding.indexed_free_functions > one.binding.indexed_free_functions);
     }
 
-    fn named_method_capture_with_irrelevant_declarations(count: usize) -> CanonicalSemanticWork {
+    fn named_method_capture_with_irrelevant_declarations(
+        count: usize,
+    ) -> (Arc<CanonicalSemanticOutput>, Arc<CanonicalRirOutput>) {
         let mut source = String::from(
             "fn helper() -> i32 { 1 } struct Value { fn run(borrow self) -> i32 { helper() } } fn main() -> i32 { let value = Value {}; value.run() }",
         );
@@ -2620,21 +2641,42 @@ mod tests {
             source.push_str(&format!(" fn irrelevant{index}() -> i32 {{ {index} }}"));
         }
         let snapshot = snapshot(&[(1, "/main.rue", "main.rue", &source)], 1);
-        whole_program_canonical(&snapshot, &CompileOptions::default(), false)
-            .0
-            .work()
+        canonical(&snapshot, &CompileOptions::default())
     }
 
     #[test]
-    fn named_method_capture_work_is_constant_with_128_irrelevant_declarations() {
-        let one = named_method_capture_with_irrelevant_declarations(1);
-        let many = named_method_capture_with_irrelevant_declarations(128);
-        assert_eq!(one.body_analysis.named_method_dependency_events, 1);
-        assert_eq!(many.body_analysis.named_method_dependency_events, 1);
-        assert_eq!(one.body_analysis.named_method_record_lookups, 1);
-        assert_eq!(many.body_analysis.named_method_record_lookups, 1);
-        assert_eq!(one.body_analysis.reachable_declaration_rir_visits, 0);
-        assert_eq!(many.body_analysis.reachable_declaration_rir_visits, 0);
+    fn named_method_capture_is_unchanged_by_irrelevant_declarations() {
+        let (one, one_rir) = named_method_capture_with_irrelevant_declarations(1);
+        let (many, many_rir) = named_method_capture_with_irrelevant_declarations(128);
+        assert_eq!(
+            function_fingerprint(one.functions(), one_rir.semantic_symbols().interner()),
+            function_fingerprint(many.functions(), many_rir.semantic_symbols().interner())
+        );
+
+        for output in [&one, &many] {
+            let method = output
+                .functions()
+                .iter()
+                .find(|function| {
+                    matches!(
+                        &function.semantic_identity,
+                        crate::FunctionInstanceKey::Definition(definition)
+                            if definition.kind() == crate::StableDefinitionKind::Method
+                                && definition.name() == "run"
+                                && definition.owner().is_some_and(|owner| owner.name() == "Value")
+                    )
+                })
+                .expect("reachable named method must be a production body");
+            let references = output
+                .body_references(&method.semantic_identity)
+                .expect("production body must retain its exact references");
+            assert!(references.0.iter().any(|reference| matches!(
+                reference,
+                crate::body_query::BodyReference::Callable(
+                    crate::FunctionInstanceKey::Definition(definition)
+                ) if definition.name() == "helper"
+            )));
+        }
     }
 
     #[test]
@@ -2648,23 +2690,94 @@ mod tests {
             )],
             1,
         );
-        let (output, _) = whole_program_canonical(&source, &CompileOptions::default(), false);
+        let (output, _) = canonical(&source, &CompileOptions::default());
         assert_eq!(
             output
                 .functions()
                 .iter()
-                // The named struct's method symbol is file-qualified
-                // (`Value$<file>.choose`) under ADR-0066.
-                .filter(|function| {
-                    function.analyzed.name.starts_with("Value$")
-                        && function.analyzed.name.ends_with(".choose")
-                })
+                .filter(|function| matches!(
+                    &function.semantic_identity,
+                    crate::FunctionInstanceKey::Definition(definition)
+                        if definition.kind() == crate::StableDefinitionKind::Method
+                            && definition.name() == "choose"
+                            && definition.owner().is_some_and(|owner| owner.name() == "Value")
+                ))
                 .count(),
-            1
+            1,
+            "{:#?}",
+            output
+                .functions()
+                .iter()
+                .map(|function| &function.semantic_identity)
+                .collect::<Vec<_>>()
         );
-        assert!(output.specialized_free_function_origins().is_empty());
-        assert_eq!(output.named_method_dependencies().len(), 1);
-        assert!(output.generic_named_method_dependencies_complete());
+        assert!(
+            output.functions().iter().all(|function| !matches!(
+                &function.semantic_identity,
+                crate::FunctionInstanceKey::Specialization { base, .. }
+                    if function_base_definition(base).is_some_and(|definition| {
+                        definition.kind() == crate::StableDefinitionKind::Method
+                            && definition.name() == "choose"
+                    })
+            )),
+            "comptime named-method arguments do not create runtime bodies"
+        );
+        let method = output
+            .functions()
+            .iter()
+            .find(|function| {
+                function_base_definition(&function.semantic_identity).is_some_and(|definition| {
+                    definition.kind() == crate::StableDefinitionKind::Method
+                        && definition.name() == "choose"
+                })
+            })
+            .unwrap();
+        let method_references = output.body_references(&method.semantic_identity).unwrap();
+        assert!(
+            method_references.0.iter().any(|reference| matches!(
+                reference,
+                crate::body_query::BodyReference::Callable(identity)
+                    if function_base_definition(identity)
+                        .is_some_and(|definition| definition.name() == "helper")
+            )),
+            "the retained named-method body must close over its transitive helper"
+        );
+        assert!(
+            output.functions().iter().any(|function| {
+                matches!(
+                    &function.semantic_identity,
+                    crate::FunctionInstanceKey::Definition(definition)
+                        if definition.kind() == crate::StableDefinitionKind::Function
+                            && definition.name() == "helper"
+                )
+            }),
+            "the transitive helper must be composed into production output"
+        );
+        let main = output
+            .functions()
+            .iter()
+            .find(|function| {
+                function_base_definition(&function.semantic_identity)
+                    .is_some_and(|definition| definition.name() == "main")
+            })
+            .unwrap();
+        let references = output.body_references(&main.semantic_identity).unwrap();
+        assert_eq!(
+            references
+                .0
+                .iter()
+                .filter(|reference| matches!(
+                    reference,
+                    crate::body_query::BodyReference::Callable(identity)
+                        if function_base_definition(identity).is_some_and(|definition| {
+                            definition.kind() == crate::StableDefinitionKind::Method
+                                && definition.name() == "choose"
+                        })
+                ))
+                .count(),
+            1,
+            "both calls share the named method's one exact body reference"
+        );
     }
 
     #[test]

--- a/crates/rue-compiler/src/drop_glue.rs
+++ b/crates/rue-compiler/src/drop_glue.rs
@@ -27,94 +27,119 @@ use rue_air::{
 use rue_error::{CompileError, CompileResult, ErrorKind};
 use rue_span::Span;
 
-/// Check if a type needs drop.
-fn type_needs_drop(ty: Type, type_pool: &FrozenTypeInternPool) -> bool {
-    type_pool.type_needs_drop(ty)
+type IssuedTypeInstanceKey =
+    rue_air::TypeInstanceKey<rue_air::SemanticDefinitionToken, rue_air::SemanticModuleToken>;
+
+fn plan_type_matches_live(
+    planned: &IssuedTypeInstanceKey,
+    live: Type,
+    type_pool: &FrozenTypeInternPool,
+    types_by_identity: &std::collections::HashMap<IssuedTypeInstanceKey, Type>,
+) -> bool {
+    use rue_air::TypeInstanceKey as P;
+    match planned {
+        P::I8 => live == Type::I8,
+        P::I16 => live == Type::I16,
+        P::I32 => live == Type::I32,
+        P::I64 => live == Type::I64,
+        P::U8 => live == Type::U8,
+        P::U16 => live == Type::U16,
+        P::U32 => live == Type::U32,
+        P::U64 => live == Type::U64,
+        P::Bool => live == Type::BOOL,
+        P::Unit => live == Type::UNIT,
+        P::Never => live == Type::NEVER,
+        P::ComptimeType => live == Type::COMPTIME_TYPE,
+        P::PtrConst(pointee) => live.as_ptr_const().is_some_and(|id| {
+            plan_type_matches_live(
+                pointee,
+                type_pool.ptr_const_def(id),
+                type_pool,
+                types_by_identity,
+            )
+        }),
+        P::PtrMut(pointee) => live.as_ptr_mut().is_some_and(|id| {
+            plan_type_matches_live(
+                pointee,
+                type_pool.ptr_mut_def(id),
+                type_pool,
+                types_by_identity,
+            )
+        }),
+        P::Array { .. } | P::Slice { .. } | P::BuiltinNominal { .. } | P::Nominal(_) => {
+            types_by_identity.get(planned).is_some_and(|ty| *ty == live)
+        }
+        P::Module(_) | P::GenericParameter(_) => false,
+    }
 }
 
-/// Synthesize drop glue functions for all structs and arrays that need them.
+/// Synthesize glue for the exact reached owner set.
 ///
-/// Returns a list of synthesized functions that should be added to the compilation.
-pub fn synthesize_drop_glue(
+/// `types_by_identity` is the semantic epoch's direct reverse index.  This
+/// path performs one keyed probe per demanded owner and never enumerates a
+/// struct/array/enum pool.
+pub fn synthesize_demanded_drop_glue(
     type_pool: &FrozenTypeInternPool,
-    type_identities: &std::collections::HashMap<
-        Type,
+    types_by_identity: &std::collections::HashMap<
         rue_air::TypeInstanceKey<rue_air::SemanticDefinitionToken, rue_air::SemanticModuleToken>,
+        Type,
+    >,
+    demanded: impl IntoIterator<Item = IssuedTypeInstanceKey>,
+    plans: &std::collections::BTreeMap<
+        IssuedTypeInstanceKey,
+        crate::type_queries::DropGlueFacts<
+            rue_air::SemanticDefinitionToken,
+            rue_air::SemanticModuleToken,
+        >,
     >,
 ) -> CompileResult<Vec<AnalyzedFunction>> {
     let mut drop_glue_functions = Vec::new();
-
-    // Create drop glue for structs
-    for struct_id in type_pool.all_struct_ids() {
-        let struct_def = type_pool.struct_def(struct_id);
-        let struct_ty = Type::new_struct(struct_id);
-        // Body analysis may retain inert request-local pool slots from an
-        // abandoned anonymous representative attempt. Only the active
-        // semantic identity map is authoritative for terminal glue emission.
-        if !type_identities.contains_key(&struct_ty) {
-            continue;
-        }
-        // Skip structs that don't need drop
-        if !type_needs_drop(struct_ty, type_pool) {
-            continue;
-        }
-
-        // Skip builtins that have runtime-provided destructors (e.g., String)
-        // to avoid duplicate symbol errors. User-defined destructors still need
-        // synthesized drop glue.
-        if struct_def.is_builtin && struct_def.destructor.is_some() {
-            continue;
-        }
-
-        // Create drop glue function for struct
-        let identity = type_identities.get(&struct_ty).cloned().ok_or_else(|| {
+    for identity in demanded {
+        let plan = plans.get(&identity).ok_or_else(|| {
             CompileError::without_span(ErrorKind::InternalError(
-                "missing canonical struct identity for drop glue".into(),
+                "demanded drop-glue owner has no authoritative query plan".into(),
             ))
         })?;
-        let func = create_struct_drop_glue_function(struct_def, struct_id, type_pool, identity)?;
-        drop_glue_functions.push(func);
-    }
-
-    // Create drop glue for arrays
-    for array_id in type_pool.all_array_ids() {
-        let array_ty = Type::new_array(array_id);
-        if !type_identities.contains_key(&array_ty) {
-            continue;
-        }
-        // Skip arrays that don't need drop
-        if !type_needs_drop(array_ty, type_pool) {
-            continue;
-        }
-
-        // Create drop glue function for array
-        let identity = type_identities.get(&array_ty).cloned().ok_or_else(|| {
+        let ty = types_by_identity.get(&identity).copied().ok_or_else(|| {
             CompileError::without_span(ErrorKind::InternalError(
-                "missing canonical array identity for drop glue".into(),
+                "demanded drop-glue owner has no live type materialization".into(),
             ))
         })?;
-        let func = create_array_drop_glue_function(array_id, type_pool, identity)?;
-        drop_glue_functions.push(func);
-    }
-
-    // Create drop glue for payload-carrying enums (RUE-221). The glue switches
-    // on the discriminant and drops the active variant's payload.
-    for enum_id in type_pool.all_enum_ids() {
-        let enum_ty = Type::new_enum(enum_id);
-        if !type_identities.contains_key(&enum_ty) {
+        if !plan.required || !plan.synthesize {
             continue;
         }
-        if !type_needs_drop(enum_ty, type_pool) {
-            continue;
+        match ty.kind() {
+            TypeKind::Struct(struct_id) => {
+                let struct_def = type_pool.struct_def(struct_id);
+                drop_glue_functions.push(create_struct_drop_glue_function(
+                    struct_def,
+                    struct_id,
+                    type_pool,
+                    types_by_identity,
+                    identity,
+                    plan,
+                )?);
+            }
+            TypeKind::Array(array_id) => {
+                drop_glue_functions.push(create_array_drop_glue_function(
+                    array_id,
+                    type_pool,
+                    types_by_identity,
+                    identity,
+                    plan,
+                )?);
+            }
+            TypeKind::Enum(enum_id) => {
+                drop_glue_functions.push(create_enum_drop_glue_function(
+                    enum_id,
+                    type_pool,
+                    types_by_identity,
+                    identity,
+                    plan,
+                )?);
+            }
+            _ => {}
         }
-
-        let identity = type_identities.get(&enum_ty).cloned().ok_or_else(|| {
-            CompileError::without_span(ErrorKind::InternalError(
-                "missing canonical enum identity for drop glue".into(),
-            ))
-        })?;
-        let func = create_enum_drop_glue_function(enum_id, type_pool, identity)?;
-        drop_glue_functions.push(func);
     }
 
     Ok(drop_glue_functions)
@@ -125,7 +150,9 @@ fn create_struct_drop_glue_function(
     struct_def: &StructDef,
     struct_id: rue_air::StructId,
     type_pool: &FrozenTypeInternPool,
-    identity: rue_air::TypeInstanceKey<
+    types_by_identity: &std::collections::HashMap<IssuedTypeInstanceKey, Type>,
+    identity: IssuedTypeInstanceKey,
+    facts: &crate::type_queries::DropGlueFacts<
         rue_air::SemanticDefinitionToken,
         rue_air::SemanticModuleToken,
     >,
@@ -148,10 +175,36 @@ fn create_struct_drop_glue_function(
     // We need to reconstruct the field values from the flattened parameters.
     let mut current_param_slot = 0u32;
 
-    for field in &struct_def.fields {
+    let crate::type_queries::DropGluePlan::Struct {
+        fields: planned_fields,
+    } = &facts.plan
+    else {
+        return Err(CompileError::without_span(ErrorKind::InternalError(
+            "struct drop-glue owner received a non-struct query plan".into(),
+        )));
+    };
+    if planned_fields.len() != struct_def.fields.len() {
+        return Err(CompileError::without_span(ErrorKind::InternalError(
+            "struct drop-glue plan disagrees with live field count".into(),
+        )));
+    }
+    if planned_fields
+        .iter()
+        .zip(&struct_def.fields)
+        .any(|(planned, live)| {
+            planned.name.as_ref() != live.name
+                || !plan_type_matches_live(&planned.ty, live.ty, type_pool, types_by_identity)
+        })
+    {
+        return Err(CompileError::without_span(ErrorKind::InternalError(
+            "struct drop-glue plan disagrees with live field order or type".into(),
+        )));
+    }
+    for (field_index, field) in struct_def.fields.iter().enumerate() {
         let field_slot_count = type_pool.abi_slot_count(field.ty);
 
-        if type_needs_drop(field.ty, type_pool) {
+        let should_drop = planned_fields[field_index].drop;
+        if should_drop {
             // Emit Drop for this field.
             // Type::Struct handles both user-defined structs and builtin String.
             match field.ty.kind() {
@@ -240,7 +293,9 @@ fn create_struct_drop_glue_function(
 fn create_array_drop_glue_function(
     array_id: rue_air::ArrayTypeId,
     type_pool: &FrozenTypeInternPool,
-    identity: rue_air::TypeInstanceKey<
+    types_by_identity: &std::collections::HashMap<IssuedTypeInstanceKey, Type>,
+    identity: IssuedTypeInstanceKey,
+    facts: &crate::type_queries::DropGlueFacts<
         rue_air::SemanticDefinitionToken,
         rue_air::SemanticModuleToken,
     >,
@@ -250,6 +305,23 @@ fn create_array_drop_glue_function(
 
     // Get array element type and length
     let (element_type, length) = type_pool.array_def(array_id);
+    let crate::type_queries::DropGluePlan::Array {
+        element,
+        len,
+        drop_element: planned_drop_element,
+    } = &facts.plan
+    else {
+        return Err(CompileError::without_span(ErrorKind::InternalError(
+            "array drop-glue owner received a non-array query plan".into(),
+        )));
+    };
+    if *len != length
+        || !plan_type_matches_live(element, element_type, type_pool, types_by_identity)
+    {
+        return Err(CompileError::without_span(ErrorKind::InternalError(
+            "array drop-glue plan disagrees with live length or element type".into(),
+        )));
+    }
 
     // Create AIR for the drop glue function
     let mut air = AirEditor::new(Type::UNIT);
@@ -276,6 +348,9 @@ fn create_array_drop_glue_function(
         let current_param_slot = phys_chunk as u32 * element_slot_count;
 
         // Emit Drop for this element
+        if !*planned_drop_element {
+            continue;
+        }
         match element_type.kind() {
             TypeKind::Struct(struct_id) => {
                 let param_ref =
@@ -346,12 +421,36 @@ fn create_array_drop_glue_function(
 fn create_enum_drop_glue_function(
     enum_id: EnumId,
     type_pool: &FrozenTypeInternPool,
-    identity: rue_air::TypeInstanceKey<
+    types_by_identity: &std::collections::HashMap<IssuedTypeInstanceKey, Type>,
+    identity: IssuedTypeInstanceKey,
+    facts: &crate::type_queries::DropGlueFacts<
         rue_air::SemanticDefinitionToken,
         rue_air::SemanticModuleToken,
     >,
 ) -> CompileResult<AnalyzedFunction> {
     let enum_def = type_pool.enum_def(enum_id);
+    let crate::type_queries::DropGluePlan::Enum {
+        variants: planned_variants,
+    } = &facts.plan
+    else {
+        return Err(CompileError::without_span(ErrorKind::InternalError(
+            "enum drop-glue owner received a non-enum query plan".into(),
+        )));
+    };
+    if planned_variants.len() != enum_def.variant_count() {
+        return Err(CompileError::without_span(ErrorKind::InternalError(
+            "enum drop-glue plan disagrees with live variant count".into(),
+        )));
+    }
+    if planned_variants
+        .iter()
+        .zip(&enum_def.variants)
+        .any(|(planned, live)| planned.name.as_ref() != live.as_str())
+    {
+        return Err(CompileError::without_span(ErrorKind::InternalError(
+            "enum drop-glue plan disagrees with live variant order".into(),
+        )));
+    }
     let fn_name = enum_drop_glue_name(enum_id, type_pool);
     let span = Span::new(0, 0); // Synthetic span
 
@@ -375,15 +474,29 @@ fn create_enum_drop_glue_function(
 
     for variant_index in 0..enum_def.variant_count() {
         let payload = enum_def.variant_payload(variant_index);
-        if !payload.iter().any(|&ty| type_needs_drop(ty, type_pool)) {
+        let planned_fields = planned_variants[variant_index].fields.as_ref();
+        if planned_fields.len() != payload.len() {
+            return Err(CompileError::without_span(ErrorKind::InternalError(
+                "enum drop-glue plan disagrees with live payload field count".into(),
+            )));
+        }
+        if planned_fields.iter().zip(payload).any(|(planned, &live)| {
+            !plan_type_matches_live(&planned.ty, live, type_pool, types_by_identity)
+        }) {
+            return Err(CompileError::without_span(ErrorKind::InternalError(
+                "enum drop-glue plan disagrees with live payload field type".into(),
+            )));
+        }
+        if !planned_fields.iter().any(|field| field.drop) {
             continue;
         }
 
         let mut drop_stmts: Vec<AirRef> = Vec::new();
         let mut field_slot = 1u32; // slot 0 is the discriminant
-        for &field_ty in payload {
+        for (field_index, &field_ty) in payload.iter().enumerate() {
             let field_slots = type_pool.abi_slot_count(field_ty);
-            if type_needs_drop(field_ty, type_pool) {
+            let should_drop = planned_fields[field_index].drop;
+            if should_drop {
                 // The logical half-open range [field_slot, field_slot +
                 // field_slots) becomes the reversed ABI range beginning here.
                 // Reading an aggregate Param reverses that range once more,
@@ -447,8 +560,105 @@ pub use rue_air::drop_glue_names::{array_drop_glue_name, enum_drop_glue_name};
 mod tests {
     use lasso::ThreadedRodeo;
     use rue_air::{AirInstData, EnumDef, StructField, TypeInternPool};
+    use std::sync::Arc;
 
     use super::*;
+
+    fn test_type_identity(ty: Type, type_pool: &FrozenTypeInternPool) -> IssuedTypeInstanceKey {
+        use rue_air::{AnonymousNominalKind as K, TypeInstanceKey as T, TypeKind};
+        match ty.kind() {
+            TypeKind::I8 => T::I8,
+            TypeKind::I16 => T::I16,
+            TypeKind::I32 => T::I32,
+            TypeKind::I64 => T::I64,
+            TypeKind::U8 => T::U8,
+            TypeKind::U16 => T::U16,
+            TypeKind::U32 => T::U32,
+            TypeKind::U64 => T::U64,
+            TypeKind::Bool => T::Bool,
+            TypeKind::Unit => T::Unit,
+            TypeKind::Never => T::Never,
+            TypeKind::ComptimeType => T::ComptimeType,
+            TypeKind::Struct(id) => T::BuiltinNominal {
+                kind: K::Struct,
+                name: type_pool.struct_def(id).name.clone().into(),
+            },
+            TypeKind::Enum(id) => T::BuiltinNominal {
+                kind: K::Enum,
+                name: type_pool.enum_def(id).name.clone().into(),
+            },
+            TypeKind::Array(id) => {
+                let (element, len) = type_pool.array_def(id);
+                T::Array {
+                    element: Box::new(test_type_identity(element, type_pool)),
+                    len,
+                }
+            }
+            TypeKind::PtrConst(id) => T::PtrConst(Box::new(test_type_identity(
+                type_pool.ptr_const_def(id),
+                type_pool,
+            ))),
+            TypeKind::PtrMut(id) => T::PtrMut(Box::new(test_type_identity(
+                type_pool.ptr_mut_def(id),
+                type_pool,
+            ))),
+            TypeKind::Module(_) | TypeKind::Error => {
+                panic!("test drop-glue plans contain only materializable runtime types")
+            }
+        }
+    }
+
+    fn insert_test_type(
+        ty: Type,
+        type_pool: &FrozenTypeInternPool,
+        output: &mut std::collections::HashMap<IssuedTypeInstanceKey, Type>,
+    ) {
+        match ty.kind() {
+            TypeKind::Struct(id) => {
+                output.insert(test_type_identity(ty, type_pool), ty);
+                for field in &type_pool.struct_def(id).fields {
+                    insert_test_type(field.ty, type_pool, output);
+                }
+            }
+            TypeKind::Enum(id) => {
+                output.insert(test_type_identity(ty, type_pool), ty);
+                for payload in &type_pool.enum_def(id).variant_payloads {
+                    for &field in payload {
+                        insert_test_type(field, type_pool, output);
+                    }
+                }
+            }
+            TypeKind::Array(id) => {
+                output.insert(test_type_identity(ty, type_pool), ty);
+                insert_test_type(type_pool.array_def(id).0, type_pool, output);
+            }
+            TypeKind::PtrConst(id) => {
+                insert_test_type(type_pool.ptr_const_def(id), type_pool, output);
+            }
+            TypeKind::PtrMut(id) => {
+                insert_test_type(type_pool.ptr_mut_def(id), type_pool, output);
+            }
+            _ => {}
+        }
+    }
+
+    fn test_facts(
+        plan: crate::type_queries::DropGluePlan<
+            rue_air::SemanticDefinitionToken,
+            rue_air::SemanticModuleToken,
+        >,
+    ) -> crate::type_queries::DropGlueFacts<
+        rue_air::SemanticDefinitionToken,
+        rue_air::SemanticModuleToken,
+    > {
+        crate::type_queries::DropGlueFacts {
+            required: true,
+            synthesize: true,
+            destructor: None,
+            nested: Arc::from([]),
+            plan,
+        }
+    }
 
     fn register_struct(
         type_pool: &TypeInternPool,
@@ -643,21 +853,46 @@ mod tests {
         );
         let outer_ty = Type::new_struct(outer_id);
         let type_pool = type_pool.freeze();
+        let mut types_by_identity = std::collections::HashMap::new();
+        insert_test_type(outer_ty, &type_pool, &mut types_by_identity);
+        let outer_facts = test_facts(crate::type_queries::DropGluePlan::Struct {
+            fields: type_pool
+                .struct_def(outer_id)
+                .fields
+                .iter()
+                .enumerate()
+                .map(|(index, field)| crate::type_queries::DropGlueField {
+                    name: field.name.clone().into(),
+                    ty: test_type_identity(field.ty, &type_pool),
+                    drop: index >= 16,
+                })
+                .collect::<Vec<_>>()
+                .into(),
+        });
         let outer = create_struct_drop_glue_function(
             type_pool.struct_def(outer_id),
             outer_id,
             &type_pool,
-            rue_air::TypeInstanceKey::I32,
+            &types_by_identity,
+            test_type_identity(outer_ty, &type_pool),
+            &outer_facts,
         )
         .unwrap();
         assert_eq!(outer.num_param_slots, type_pool.abi_slot_count(outer_ty));
         assert_eq!(outer.num_param_slots, 27);
         assert_eq!(param_indices(&outer), [19, 20, 22, 24]);
 
+        let array_facts = test_facts(crate::type_queries::DropGluePlan::Array {
+            element: test_type_identity(drop_ty, &type_pool),
+            len: 2,
+            drop_element: true,
+        });
         let array = create_array_drop_glue_function(
             drop_array_id,
             &type_pool,
-            rue_air::TypeInstanceKey::I32,
+            &types_by_identity,
+            test_type_identity(drop_array_ty, &type_pool),
+            &array_facts,
         )
         .unwrap();
         assert_eq!(
@@ -666,9 +901,34 @@ mod tests {
         );
         assert_eq!(param_indices(&array), [0, 1]);
 
-        let enum_glue =
-            create_enum_drop_glue_function(drop_enum_id, &type_pool, rue_air::TypeInstanceKey::I32)
-                .unwrap();
+        let enum_facts = test_facts(crate::type_queries::DropGluePlan::Enum {
+            variants: type_pool
+                .enum_def(drop_enum_id)
+                .variants
+                .iter()
+                .zip(&type_pool.enum_def(drop_enum_id).variant_payloads)
+                .map(|(name, payload)| crate::type_queries::DropGlueVariant {
+                    name: name.clone().into(),
+                    fields: payload
+                        .iter()
+                        .map(|&field| crate::type_queries::DropGlueVariantField {
+                            ty: test_type_identity(field, &type_pool),
+                            drop: field == drop_ty,
+                        })
+                        .collect::<Vec<_>>()
+                        .into(),
+                })
+                .collect::<Vec<_>>()
+                .into(),
+        });
+        let enum_glue = create_enum_drop_glue_function(
+            drop_enum_id,
+            &type_pool,
+            &types_by_identity,
+            test_type_identity(drop_enum_ty, &type_pool),
+            &enum_facts,
+        )
+        .unwrap();
         assert_eq!(
             enum_glue.num_param_slots,
             type_pool.abi_slot_count(drop_enum_ty)

--- a/crates/rue-compiler/src/lib.rs
+++ b/crates/rue-compiler/src/lib.rs
@@ -66,6 +66,7 @@ mod source_metadata;
 mod source_snapshot;
 mod syntax;
 mod toolchain_module_demand;
+mod type_queries;
 mod typed_query_store;
 pub mod unstable;
 mod well_known_option;

--- a/crates/rue-compiler/src/pipeline_tests.rs
+++ b/crates/rue-compiler/src/pipeline_tests.rs
@@ -1829,8 +1829,6 @@ mod tests {
             "fn:Payload$right_2fshared_2erue.__drop",
             "fn:__rue_drop_Payload$left_2fshared_2erue",
             "fn:__rue_drop_Payload$right_2fshared_2erue",
-            "fn:__rue_drop_Choice$left_2fshared_2erue",
-            "fn:__rue_drop_Choice$right_2fshared_2erue",
         ]
         .into_iter()
         .map(str::to_string)

--- a/crates/rue-compiler/src/queries.rs
+++ b/crates/rue-compiler/src/queries.rs
@@ -176,6 +176,16 @@ pub(crate) struct CfgConstructionFailure {
 /// helpers so the live semantic tail stays in one place.
 pub(crate) fn build_functions_and_cfgs(
     sema_output: SemaOutput,
+    demanded_drop_glue: &std::collections::BTreeSet<
+        rue_air::TypeInstanceKey<rue_air::SemanticDefinitionToken, rue_air::SemanticModuleToken>,
+    >,
+    demanded_drop_glue_plans: &std::collections::BTreeMap<
+        rue_air::TypeInstanceKey<rue_air::SemanticDefinitionToken, rue_air::SemanticModuleToken>,
+        crate::type_queries::DropGlueFacts<
+            rue_air::SemanticDefinitionToken,
+            rue_air::SemanticModuleToken,
+        >,
+    >,
     opt_level: OptLevel,
     target: Target,
     interner: &ThreadedRodeo,
@@ -194,19 +204,23 @@ pub(crate) fn build_functions_and_cfgs(
         strings,
         mut warnings,
         type_pool,
-        aggregate_type_identities_by_type,
+        aggregate_type_identities_by_type: _,
+        aggregate_types_by_identity,
         body_analysis_work: _,
         ..
     } = sema_output;
 
     // Synthesize drop glue functions.
-    let drop_glue_functions =
-        drop_glue::synthesize_drop_glue(&type_pool, &aggregate_type_identities_by_type).map_err(
-            |error| CfgConstructionFailure {
-                errors: error.into(),
-                work: canonical_semantic::CfgConstructionWork::default(),
-            },
-        )?;
+    let drop_glue_functions = drop_glue::synthesize_demanded_drop_glue(
+        &type_pool,
+        &aggregate_types_by_identity,
+        demanded_drop_glue.iter().cloned(),
+        demanded_drop_glue_plans,
+    )
+    .map_err(|error| CfgConstructionFailure {
+        errors: error.into(),
+        work: canonical_semantic::CfgConstructionWork::default(),
+    })?;
     let mut work = canonical_semantic::CfgConstructionWork {
         drop_glue_functions_synthesized: drop_glue_functions.len(),
         functions_considered: functions.len() + drop_glue_functions.len(),
@@ -980,8 +994,12 @@ mod failure_work_tests {
         let run = || {
             let (output, interner) = malformed_cfg_input();
             let projected_identities = synthetic_projected_function_identities(&output);
+            let demanded_drop_glue = std::collections::BTreeSet::new();
+            let drop_glue_plans = std::collections::BTreeMap::new();
             match build_functions_and_cfgs(
                 output,
+                &demanded_drop_glue,
+                &drop_glue_plans,
                 OptLevel::O1,
                 Target::host().unwrap(),
                 &interner,

--- a/crates/rue-compiler/src/revisioned_query_database.rs
+++ b/crates/rue-compiler/src/revisioned_query_database.rs
@@ -553,6 +553,17 @@ pub(crate) struct RevisionedQueryDatabase {
     >,
     declaration_semantics_projection:
         QueryFamily<SemanticNucleusProjectionKey, SemanticNucleusProjectionValue>,
+    #[allow(dead_code)]
+    type_shapes:
+        QueryFamily<crate::type_queries::TypeQueryKey, crate::type_queries::TypeShapeValue>,
+    #[allow(dead_code)]
+    type_facts: QueryFamily<crate::type_queries::TypeQueryKey, crate::type_queries::TypeFactsValue>,
+    #[allow(dead_code)]
+    layouts: QueryFamily<crate::type_queries::TypeQueryKey, crate::type_queries::LayoutValue>,
+    #[allow(dead_code)]
+    call_abis: QueryFamily<crate::type_queries::CallAbiQueryKey, crate::type_queries::CallAbiValue>,
+    #[allow(dead_code)]
+    drop_glues: QueryFamily<crate::type_queries::TypeQueryKey, crate::type_queries::DropGlueValue>,
     lookup_names: QueryFamily<LookupNameKey, LookupNameValue>,
     /// Per-`(module, import-path)` binding-resolution family. Registered query
     /// machinery for the exact provider boundary. Production body import
@@ -2669,7 +2680,11 @@ fn closure_callable_has_body(
             parameters, result, ..
         } => {
             !matches!(result, crate::durable_semantics::DurableType::ComptimeType)
-                && parameters.iter().all(|parameter| !parameter.is_comptime)
+                // Only comptime *type* parameters require a specialized
+                // callable identity. Comptime value parameters are retained
+                // runtime inputs, so the definition body is an ordinary
+                // closure node and must remain reachable.
+                && parameters.iter().all(durable_parameter_is_runtime)
         }
         Payload::Destructor => true,
         Payload::Struct { .. }
@@ -2677,236 +2692,6 @@ fn closure_callable_has_body(
         | Payload::Const { .. }
         | Payload::ModuleBinding { .. } => false,
     }))
-}
-
-fn enqueue_closure_destructors(
-    ty: &crate::TypeInstanceKey,
-    declarations: &BTreeMap<crate::StableDefinitionKey, crate::DurableDeclarationSemantic>,
-    declaration_anonymous: &[crate::durable_semantics::DurableAnonymousNominal],
-    produced_anonymous: &BTreeMap<
-        crate::AnonymousNominalKey,
-        crate::durable_semantics::DurableAnonymousNominal,
-    >,
-    pending: &mut BTreeSet<crate::FunctionInstanceKey>,
-) {
-    fn named(
-        owner: &crate::StableDefinitionKey,
-        declarations: &BTreeMap<crate::StableDefinitionKey, crate::DurableDeclarationSemantic>,
-        declaration_anonymous: &[crate::durable_semantics::DurableAnonymousNominal],
-        produced_anonymous: &BTreeMap<
-            crate::AnonymousNominalKey,
-            crate::durable_semantics::DurableAnonymousNominal,
-        >,
-        pending: &mut BTreeSet<crate::FunctionInstanceKey>,
-        visited: &mut BTreeSet<crate::TypeInstanceKey>,
-    ) {
-        let identity =
-            crate::TypeInstanceKey::Nominal(crate::NominalInstanceKey::Named(owner.clone()));
-        if !visited.insert(identity) {
-            return;
-        }
-        for candidate in declarations.keys() {
-            let Some(candidate_owner) = candidate.owner() else {
-                continue;
-            };
-            if candidate.kind() == crate::StableDefinitionKind::Destructor
-                && candidate_owner.module() == owner.module()
-                && candidate_owner.kind() == owner.kind()
-                && candidate_owner.name() == owner.name()
-            {
-                pending.insert(crate::FunctionInstanceKey::Definition(candidate.clone()));
-            }
-        }
-        let Some(declaration) = declarations.get(owner) else {
-            return;
-        };
-        use crate::durable_semantics::DurableDeclarationPayload as Payload;
-        match &declaration.payload {
-            Payload::Struct { fields, .. } => {
-                for (_, field) in fields.iter() {
-                    durable(
-                        field,
-                        declarations,
-                        declaration_anonymous,
-                        produced_anonymous,
-                        pending,
-                        visited,
-                    );
-                }
-            }
-            Payload::Enum { variants } => {
-                for (_, fields) in variants.iter() {
-                    for field in fields.iter() {
-                        durable(
-                            field,
-                            declarations,
-                            declaration_anonymous,
-                            produced_anonymous,
-                            pending,
-                            visited,
-                        );
-                    }
-                }
-            }
-            _ => {}
-        }
-    }
-
-    fn anonymous(
-        owner: &crate::AnonymousNominalKey,
-        declarations: &BTreeMap<crate::StableDefinitionKey, crate::DurableDeclarationSemantic>,
-        declaration_anonymous: &[crate::durable_semantics::DurableAnonymousNominal],
-        produced_anonymous: &BTreeMap<
-            crate::AnonymousNominalKey,
-            crate::durable_semantics::DurableAnonymousNominal,
-        >,
-        pending: &mut BTreeSet<crate::FunctionInstanceKey>,
-        visited: &mut BTreeSet<crate::TypeInstanceKey>,
-    ) {
-        let identity =
-            crate::TypeInstanceKey::Nominal(crate::NominalInstanceKey::Anonymous(owner.clone()));
-        if !visited.insert(identity.clone()) {
-            return;
-        }
-        let Some(nominal) = produced_anonymous.get(owner).or_else(|| {
-            declaration_anonymous
-                .iter()
-                .find(|nominal| nominal.identity == *owner)
-        }) else {
-            return;
-        };
-        match &nominal.shape {
-            crate::durable_semantics::DurableAnonymousNominalShape::Struct { fields, methods } => {
-                if methods
-                    .iter()
-                    .any(|method| method.has_self && method.name.as_ref() == "__drop")
-                {
-                    pending.insert(crate::FunctionInstanceKey::AnonymousMember {
-                        owner: Box::new(identity),
-                        member: crate::AnonymousMemberKey {
-                            kind: crate::AnonymousMemberKind::Destructor,
-                            name: Arc::from("__drop"),
-                        },
-                    });
-                }
-                for (_, field) in fields.iter() {
-                    durable(
-                        field,
-                        declarations,
-                        declaration_anonymous,
-                        produced_anonymous,
-                        pending,
-                        visited,
-                    );
-                }
-            }
-            crate::durable_semantics::DurableAnonymousNominalShape::Enum { variants } => {
-                for (_, fields) in variants.iter() {
-                    for field in fields.iter() {
-                        durable(
-                            field,
-                            declarations,
-                            declaration_anonymous,
-                            produced_anonymous,
-                            pending,
-                            visited,
-                        );
-                    }
-                }
-            }
-        }
-    }
-
-    fn durable(
-        ty: &crate::durable_semantics::DurableType,
-        declarations: &BTreeMap<crate::StableDefinitionKey, crate::DurableDeclarationSemantic>,
-        declaration_anonymous: &[crate::durable_semantics::DurableAnonymousNominal],
-        produced_anonymous: &BTreeMap<
-            crate::AnonymousNominalKey,
-            crate::durable_semantics::DurableAnonymousNominal,
-        >,
-        pending: &mut BTreeSet<crate::FunctionInstanceKey>,
-        visited: &mut BTreeSet<crate::TypeInstanceKey>,
-    ) {
-        match ty {
-            crate::durable_semantics::DurableType::Nominal(owner) => named(
-                owner,
-                declarations,
-                declaration_anonymous,
-                produced_anonymous,
-                pending,
-                visited,
-            ),
-            crate::durable_semantics::DurableType::AnonymousNominal(owner) => anonymous(
-                owner,
-                declarations,
-                declaration_anonymous,
-                produced_anonymous,
-                pending,
-                visited,
-            ),
-            crate::durable_semantics::DurableType::Array { element, .. } => durable(
-                element,
-                declarations,
-                declaration_anonymous,
-                produced_anonymous,
-                pending,
-                visited,
-            ),
-            _ => {}
-        }
-    }
-
-    fn instance(
-        ty: &crate::TypeInstanceKey,
-        declarations: &BTreeMap<crate::StableDefinitionKey, crate::DurableDeclarationSemantic>,
-        declaration_anonymous: &[crate::durable_semantics::DurableAnonymousNominal],
-        produced_anonymous: &BTreeMap<
-            crate::AnonymousNominalKey,
-            crate::durable_semantics::DurableAnonymousNominal,
-        >,
-        pending: &mut BTreeSet<crate::FunctionInstanceKey>,
-        visited: &mut BTreeSet<crate::TypeInstanceKey>,
-    ) {
-        match ty {
-            crate::TypeInstanceKey::Nominal(crate::NominalInstanceKey::Named(owner)) => named(
-                owner,
-                declarations,
-                declaration_anonymous,
-                produced_anonymous,
-                pending,
-                visited,
-            ),
-            crate::TypeInstanceKey::Nominal(crate::NominalInstanceKey::Anonymous(owner)) => {
-                anonymous(
-                    owner,
-                    declarations,
-                    declaration_anonymous,
-                    produced_anonymous,
-                    pending,
-                    visited,
-                );
-            }
-            crate::TypeInstanceKey::Array { element, .. } => instance(
-                element,
-                declarations,
-                declaration_anonymous,
-                produced_anonymous,
-                pending,
-                visited,
-            ),
-            _ => {}
-        }
-    }
-
-    instance(
-        ty,
-        declarations,
-        declaration_anonymous,
-        produced_anonymous,
-        pending,
-        &mut BTreeSet::new(),
-    );
 }
 
 /// The request-local result of lowering one owned body input. This type is
@@ -3316,6 +3101,1632 @@ fn anonymous_nominal_query_key(
     })
 }
 
+fn query_anonymous_nominal(
+    context: &rue_query::QueryContext,
+    semantic_nucleus: &SemanticNucleusFamily,
+    body_produced_anonymous: &QueryFamily<
+        crate::body_query::BodyQueryKey,
+        crate::body_query::ProducedAnonymous,
+    >,
+    identity: &crate::AnonymousNominalKey,
+    configuration: &crate::semantic_query_nucleus::SemanticQueryConfiguration,
+) -> Result<
+    Result<
+        crate::durable_semantics::DurableAnonymousNominal,
+        crate::type_queries::TypeQueryFailure,
+    >,
+    QueryAbort,
+> {
+    let unavailable = |detail| {
+        Err(crate::type_queries::TypeQueryFailure::Unavailable(
+            Arc::from(detail),
+        ))
+    };
+    if let Some(query) = anonymous_nominal_query_key(identity, configuration) {
+        let terminal = context.query_registered(
+            semantic_nucleus,
+            crate::semantic_query_nucleus::SemanticNucleusKey::AnonymousNominal(query),
+        )?;
+        let rue_query::QueryOutcome::Success(value) = terminal.outcome() else {
+            unreachable!("SemanticNucleus publishes typed values")
+        };
+        return Ok(match value {
+            crate::semantic_query_nucleus::SemanticNucleusValue::AnonymousNominal(nominal) => {
+                Ok(nominal.clone())
+            }
+            _ => unavailable("anonymous type facts are unavailable"),
+        });
+    }
+    let crate::StableProducerId::Function(producer) = &identity.producer else {
+        return Ok(unavailable("anonymous type has no stable producer"));
+    };
+    let produced = context.query_registered(
+        body_produced_anonymous,
+        crate::body_query::BodyQueryKey {
+            instance: producer.as_ref().clone(),
+            configuration: configuration.clone(),
+        },
+    )?;
+    let rue_query::QueryOutcome::Success(produced) = produced.outcome() else {
+        unreachable!("BodyProducedAnonymous publishes typed values")
+    };
+    let crate::body_query::ProducedAnonymous::Produced(produced) = produced else {
+        return Ok(unavailable("anonymous type producer failed"));
+    };
+    Ok(produced
+        .0
+        .iter()
+        .find(|nominal| nominal.identity == *identity)
+        .cloned()
+        .ok_or_else(|| {
+            crate::type_queries::TypeQueryFailure::Unavailable(Arc::from(
+                "anonymous type is absent from its producer",
+            ))
+        }))
+}
+
+fn type_shape_from_terminal(
+    terminal: &rue_query::QueryTerminal<crate::type_queries::TypeShapeValue>,
+) -> Result<&crate::type_queries::TypeShape, crate::type_queries::TypeQueryFailure> {
+    let rue_query::QueryOutcome::Success(value) = terminal.outcome() else {
+        unreachable!("TypeShape publishes typed values")
+    };
+    match value {
+        crate::type_queries::TypeShapeValue::Available(shape) => Ok(shape),
+        crate::type_queries::TypeShapeValue::Failure(failure) => Err(failure.clone()),
+    }
+}
+
+fn evaluate_type_shape(
+    context: &rue_query::QueryContext,
+    semantic_nucleus: &SemanticNucleusFamily,
+    body_produced_anonymous: &QueryFamily<
+        crate::body_query::BodyQueryKey,
+        crate::body_query::ProducedAnonymous,
+    >,
+    key: &crate::type_queries::TypeQueryKey,
+) -> Result<QueryOutput<crate::type_queries::TypeShapeValue>, QueryAbort> {
+    use crate::type_queries::{TypeQueryFailure, TypeShape, TypeShapeValue};
+    use crate::{NominalInstanceKey as N, TypeInstanceKey as T};
+    let value = match &key.ty {
+        T::I8
+        | T::I16
+        | T::I32
+        | T::I64
+        | T::U8
+        | T::U16
+        | T::U32
+        | T::U64
+        | T::Bool
+        | T::Unit
+        | T::Never => TypeShapeValue::Available(TypeShape::Scalar),
+        T::PtrConst(_) | T::PtrMut(_) => TypeShapeValue::Available(TypeShape::Pointer),
+        T::Slice { .. } => TypeShapeValue::Available(TypeShape::Slice),
+        T::Array { element, len } => TypeShapeValue::Available(TypeShape::Array {
+            element: element.as_ref().clone(),
+            len: *len,
+        }),
+        T::ComptimeType | T::Module(_) | T::GenericParameter(_) => {
+            TypeShapeValue::Available(TypeShape::Opaque)
+        }
+        T::BuiltinNominal { kind, name } | T::Nominal(N::Builtin { kind, name })
+            if *kind == rue_air::AnonymousNominalKind::Struct
+                && (name.as_ref() == "str"
+                    || (name.starts_with("Str(") && name.ends_with(')'))) =>
+        {
+            TypeShapeValue::Available(TypeShape::Struct {
+                fields: Arc::from([
+                    (Arc::from("ptr"), T::PtrConst(Box::new(T::U8))),
+                    (Arc::from("len"), T::U64),
+                ]),
+            })
+        }
+        T::BuiltinNominal { kind, name } | T::Nominal(N::Builtin { kind, name })
+            if *kind == rue_air::AnonymousNominalKind::Enum =>
+        {
+            TypeShapeValue::Available(match rue_builtins::get_builtin_enum(name) {
+                Some(definition) => TypeShape::Enum {
+                    variants: definition
+                        .variants
+                        .iter()
+                        .map(|variant| (Arc::from(*variant), Arc::from([])))
+                        .collect::<Vec<_>>()
+                        .into(),
+                },
+                None => TypeShape::Opaque,
+            })
+        }
+        T::BuiltinNominal { .. } | T::Nominal(N::Builtin { .. }) => {
+            TypeShapeValue::Available(TypeShape::Opaque)
+        }
+        T::Nominal(N::Named(definition)) => {
+            let Some(candidate) = declaration_candidate_for_stable_key(definition) else {
+                return Ok(QueryOutput::success(TypeShapeValue::Failure(
+                    TypeQueryFailure::Unavailable(Arc::from(
+                        "named type has no declaration candidate",
+                    )),
+                ))
+                .with_terminal_kind(QueryTerminalKind::Failure));
+            };
+            let signature = context.query_registered(
+                semantic_nucleus,
+                crate::semantic_query_nucleus::SemanticNucleusKey::Signature(
+                    crate::semantic_query_nucleus::DeclarationSemanticQueryKey {
+                        declaration: candidate,
+                        configuration: key.configuration.clone(),
+                    },
+                ),
+            )?;
+            let rue_query::QueryOutcome::Success(signature) = signature.outcome() else {
+                unreachable!("SemanticNucleus publishes typed values")
+            };
+            use crate::semantic_query_nucleus::DeclarationSignatureProjection as S;
+            match signature {
+                crate::semantic_query_nucleus::SemanticNucleusValue::Signature(signature) => {
+                    match &signature.signature {
+                        S::Struct { fields, .. } => TypeShapeValue::Available(TypeShape::Struct {
+                            fields: fields
+                                .iter()
+                                .map(|(name, ty)| {
+                                    (name.clone(), crate::type_queries::type_instance(ty))
+                                })
+                                .collect::<Vec<_>>()
+                                .into(),
+                        }),
+                        S::Enum { variants } => TypeShapeValue::Available(TypeShape::Enum {
+                            variants: variants
+                                .iter()
+                                .map(|(name, fields)| {
+                                    (
+                                        name.clone(),
+                                        fields
+                                            .iter()
+                                            .map(crate::type_queries::type_instance)
+                                            .collect::<Vec<_>>()
+                                            .into(),
+                                    )
+                                })
+                                .collect::<Vec<_>>()
+                                .into(),
+                        }),
+                        _ => TypeShapeValue::Failure(TypeQueryFailure::Invalid(Arc::from(
+                            "named type resolved to a non-type signature",
+                        ))),
+                    }
+                }
+                _ => TypeShapeValue::Failure(TypeQueryFailure::Unavailable(Arc::from(
+                    "type signature is unavailable",
+                ))),
+            }
+        }
+        T::Nominal(N::Anonymous(identity)) => {
+            let nominal = match query_anonymous_nominal(
+                context,
+                semantic_nucleus,
+                body_produced_anonymous,
+                identity,
+                &key.configuration,
+            )? {
+                Ok(nominal) => nominal,
+                Err(failure) => {
+                    return Ok(QueryOutput::success(TypeShapeValue::Failure(failure))
+                        .with_terminal_kind(QueryTerminalKind::Failure));
+                }
+            };
+            use crate::durable_semantics::DurableAnonymousNominalShape as S;
+            TypeShapeValue::Available(match &nominal.shape {
+                S::Struct { fields, .. } => TypeShape::Struct {
+                    fields: fields
+                        .iter()
+                        .map(|(name, ty)| (name.clone(), crate::type_queries::type_instance(ty)))
+                        .collect::<Vec<_>>()
+                        .into(),
+                },
+                S::Enum { variants } => TypeShape::Enum {
+                    variants: variants
+                        .iter()
+                        .map(|(name, fields)| {
+                            (
+                                name.clone(),
+                                fields
+                                    .iter()
+                                    .map(crate::type_queries::type_instance)
+                                    .collect::<Vec<_>>()
+                                    .into(),
+                            )
+                        })
+                        .collect::<Vec<_>>()
+                        .into(),
+                },
+            })
+        }
+    };
+    let kind = if matches!(value, TypeShapeValue::Failure(_)) {
+        QueryTerminalKind::Failure
+    } else {
+        QueryTerminalKind::Success
+    };
+    Ok(QueryOutput::success(value).with_terminal_kind(kind))
+}
+
+fn type_query_failure(detail: impl Into<Arc<str>>) -> crate::type_queries::TypeFactsValue {
+    crate::type_queries::TypeFactsValue::Failure(
+        crate::type_queries::TypeQueryFailure::Unavailable(detail.into()),
+    )
+}
+
+fn type_facts_from_terminal(
+    terminal: &rue_query::QueryTerminal<crate::type_queries::TypeFactsValue>,
+) -> Result<&crate::type_queries::TypeFacts, crate::type_queries::TypeQueryFailure> {
+    let rue_query::QueryOutcome::Success(value) = terminal.outcome() else {
+        unreachable!("TypeFacts publishes typed values")
+    };
+    match value {
+        crate::type_queries::TypeFactsValue::Available(facts) => Ok(facts.as_ref()),
+        crate::type_queries::TypeFactsValue::Failure(failure) => Err(failure.clone()),
+    }
+}
+
+fn evaluate_type_facts(
+    context: &rue_query::QueryContext,
+    family: &QueryFamily<crate::type_queries::TypeQueryKey, crate::type_queries::TypeFactsValue>,
+    type_shapes: &QueryFamily<
+        crate::type_queries::TypeQueryKey,
+        crate::type_queries::TypeShapeValue,
+    >,
+    semantic_nucleus: &SemanticNucleusFamily,
+    lookup_names: &QueryFamily<LookupNameKey, LookupNameValue>,
+    body_produced_anonymous: &QueryFamily<
+        crate::body_query::BodyQueryKey,
+        crate::body_query::ProducedAnonymous,
+    >,
+    key: &crate::type_queries::TypeQueryKey,
+) -> Result<QueryOutput<crate::type_queries::TypeFactsValue>, QueryAbort> {
+    use crate::type_queries::{TypeFacts, TypeFactsValue, TypeShape};
+    use crate::{NominalInstanceKey as N, TypeInstanceKey as T};
+
+    let shape_terminal = context.query_registered(type_shapes, key.clone())?;
+    let canonical_shape = match type_shape_from_terminal(&shape_terminal) {
+        Ok(shape) => shape.clone(),
+        Err(failure) => {
+            return Ok(QueryOutput::success(TypeFactsValue::Failure(failure))
+                .with_terminal_kind(QueryTerminalKind::Failure));
+        }
+    };
+    let direct = |is_copy| {
+        TypeFactsValue::Available(Box::new(TypeFacts {
+            is_copy,
+            carries_linear: false,
+            needs_drop: false,
+            destructor: None,
+            shape: canonical_shape.clone(),
+        }))
+    };
+    let mut value = match &key.ty {
+        T::I8
+        | T::I16
+        | T::I32
+        | T::I64
+        | T::U8
+        | T::U16
+        | T::U32
+        | T::U64
+        | T::Bool
+        | T::Unit
+        | T::Never => direct(true),
+        T::PtrConst(_) | T::PtrMut(_) => direct(true),
+        T::Slice { .. } => direct(true),
+        T::ComptimeType | T::Module(_) | T::GenericParameter(_) => direct(true),
+        T::BuiltinNominal { kind, name } | T::Nominal(N::Builtin { kind, name })
+            if *kind == rue_air::AnonymousNominalKind::Struct
+                && (name.as_ref() == "str"
+                    || (name.starts_with("Str(") && name.ends_with(')'))) =>
+        {
+            direct(true)
+        }
+        T::BuiltinNominal { kind, name } | T::Nominal(N::Builtin { kind, name })
+            if *kind == rue_air::AnonymousNominalKind::Enum =>
+        {
+            direct(rue_builtins::get_builtin_enum(name).is_some())
+        }
+        T::BuiltinNominal { .. } | T::Nominal(N::Builtin { .. }) => direct(false),
+        T::Array { element, len } => {
+            if *len == 0 {
+                return Ok(QueryOutput::success(TypeFactsValue::Available(Box::new(
+                    TypeFacts {
+                        is_copy: true,
+                        carries_linear: false,
+                        needs_drop: false,
+                        destructor: None,
+                        shape: canonical_shape.clone(),
+                    },
+                ))));
+            }
+            let child = context.query_registered(
+                family,
+                crate::type_queries::TypeQueryKey {
+                    ty: element.as_ref().clone(),
+                    configuration: key.configuration.clone(),
+                },
+            )?;
+            match type_facts_from_terminal(&child) {
+                Ok(child) => TypeFactsValue::Available(Box::new(TypeFacts {
+                    is_copy: child.is_copy,
+                    carries_linear: child.carries_linear,
+                    needs_drop: child.needs_drop,
+                    destructor: None,
+                    shape: canonical_shape.clone(),
+                })),
+                Err(failure) => TypeFactsValue::Failure(failure),
+            }
+        }
+        T::Nominal(N::Named(definition)) => {
+            let Some(candidate) = declaration_candidate_for_stable_key(definition) else {
+                return Ok(QueryOutput::success(type_query_failure(
+                    "named type has no declaration candidate",
+                ))
+                .with_terminal_kind(QueryTerminalKind::Failure));
+            };
+            let signature = context.query_registered(
+                semantic_nucleus,
+                crate::semantic_query_nucleus::SemanticNucleusKey::Signature(
+                    crate::semantic_query_nucleus::DeclarationSemanticQueryKey {
+                        declaration: candidate,
+                        configuration: key.configuration.clone(),
+                    },
+                ),
+            )?;
+            let rue_query::QueryOutcome::Success(signature) = signature.outcome() else {
+                unreachable!("SemanticNucleus publishes typed values")
+            };
+            let (is_copy, is_linear) = match signature {
+                crate::semantic_query_nucleus::SemanticNucleusValue::Signature(signature) => {
+                    use crate::semantic_query_nucleus::DeclarationSignatureProjection as S;
+                    match &signature.signature {
+                        S::Struct {
+                            is_copy, is_linear, ..
+                        } => (*is_copy, *is_linear),
+                        S::Enum { .. } => (false, false),
+                        _ => {
+                            return Ok(QueryOutput::success(type_query_failure(
+                                "named type resolved to a non-type signature",
+                            ))
+                            .with_terminal_kind(QueryTerminalKind::Failure));
+                        }
+                    }
+                }
+                crate::semantic_query_nucleus::SemanticNucleusValue::Failure(failure) => {
+                    return Ok(QueryOutput::success(type_query_failure(format!(
+                        "type signature failed: {failure:?}"
+                    )))
+                    .with_terminal_kind(QueryTerminalKind::Failure));
+                }
+                _ => {
+                    return Ok(QueryOutput::success(type_query_failure(
+                        "type signature returned the wrong projection",
+                    ))
+                    .with_terminal_kind(QueryTerminalKind::Failure));
+                }
+            };
+            let shape = canonical_shape.clone();
+            let children = match &shape {
+                TypeShape::Struct { fields } => {
+                    fields.iter().map(|(_, ty)| ty.clone()).collect::<Vec<_>>()
+                }
+                TypeShape::Enum { variants } => variants
+                    .iter()
+                    .flat_map(|(_, fields)| fields.iter().cloned())
+                    .collect::<Vec<_>>(),
+                _ => Vec::new(),
+            };
+            let child_keys = children
+                .iter()
+                .cloned()
+                .map(|ty| crate::type_queries::TypeQueryKey {
+                    ty,
+                    configuration: key.configuration.clone(),
+                })
+                .collect::<Vec<_>>();
+            let child_terminals = context.query_registered_batch(family, child_keys)?;
+            let mut carries_linear = is_linear;
+            let mut needs_drop = false;
+            for child in &child_terminals {
+                match type_facts_from_terminal(child) {
+                    Ok(child) => {
+                        carries_linear |= child.carries_linear;
+                        needs_drop |= child.needs_drop;
+                    }
+                    Err(failure) => {
+                        return Ok(QueryOutput::success(TypeFactsValue::Failure(failure))
+                            .with_terminal_kind(QueryTerminalKind::Failure));
+                    }
+                }
+            }
+            let destructor_lookup = context.query_registered(
+                lookup_names,
+                LookupNameKey {
+                    module: definition.module().clone(),
+                    namespace: DefinitionNamespace::Destructor,
+                    name: Arc::from(definition.name()),
+                },
+            )?;
+            let destructor = match destructor_lookup.outcome() {
+                rue_query::QueryOutcome::Success(LookupNameValue(Ok(facts))) => {
+                    facts.first().map(|_| {
+                        crate::FunctionInstanceKey::Definition(
+                            crate::StableDefinitionKey::from_stable_parts(
+                                definition.module().clone(),
+                                crate::StableDefinitionNamespace::Destructor,
+                                crate::StableDefinitionKind::Destructor,
+                                definition.name(),
+                                Some((definition.kind(), Arc::<str>::from(definition.name()))),
+                            ),
+                        )
+                    })
+                }
+                _ => None,
+            };
+            needs_drop |= destructor.is_some();
+            TypeFactsValue::Available(Box::new(TypeFacts {
+                is_copy,
+                carries_linear,
+                needs_drop,
+                destructor,
+                shape,
+            }))
+        }
+        T::Nominal(N::Anonymous(identity)) => {
+            let nominal = match query_anonymous_nominal(
+                context,
+                semantic_nucleus,
+                body_produced_anonymous,
+                identity,
+                &key.configuration,
+            )? {
+                Ok(nominal) => nominal,
+                Err(failure) => {
+                    return Ok(QueryOutput::success(TypeFactsValue::Failure(failure))
+                        .with_terminal_kind(QueryTerminalKind::Failure));
+                }
+            };
+            use crate::durable_semantics::DurableAnonymousNominalShape as S;
+            let destructor = match &nominal.shape {
+                S::Struct { methods, .. } => methods
+                    .iter()
+                    .find(|method| method.has_self && method.name.as_ref() == "__drop")
+                    .map(|_| crate::FunctionInstanceKey::AnonymousMember {
+                        owner: Box::new(key.ty.clone()),
+                        member: crate::AnonymousMemberKey {
+                            kind: crate::AnonymousMemberKind::Destructor,
+                            name: Arc::from("__drop"),
+                        },
+                    }),
+                S::Enum { .. } => None,
+            };
+            let shape = canonical_shape.clone();
+            let children = match &shape {
+                TypeShape::Struct { fields } => {
+                    fields.iter().map(|(_, ty)| ty.clone()).collect::<Vec<_>>()
+                }
+                TypeShape::Enum { variants } => variants
+                    .iter()
+                    .flat_map(|(_, fields)| fields.iter().cloned())
+                    .collect(),
+                _ => Vec::new(),
+            };
+            let child_terminals = context.query_registered_batch(
+                family,
+                children
+                    .iter()
+                    .cloned()
+                    .map(|ty| crate::type_queries::TypeQueryKey {
+                        ty,
+                        configuration: key.configuration.clone(),
+                    }),
+            )?;
+            let mut carries_linear = false;
+            let mut needs_drop = destructor.is_some();
+            for child in &child_terminals {
+                match type_facts_from_terminal(child) {
+                    Ok(child) => {
+                        carries_linear |= child.carries_linear;
+                        needs_drop |= child.needs_drop;
+                    }
+                    Err(failure) => {
+                        return Ok(QueryOutput::success(TypeFactsValue::Failure(failure))
+                            .with_terminal_kind(QueryTerminalKind::Failure));
+                    }
+                }
+            }
+            TypeFactsValue::Available(Box::new(TypeFacts {
+                is_copy: false,
+                carries_linear,
+                needs_drop,
+                destructor,
+                shape,
+            }))
+        }
+    };
+    if let TypeFactsValue::Available(facts) = &mut value {
+        facts.shape = canonical_shape;
+    }
+    let kind = if matches!(value, TypeFactsValue::Failure(_)) {
+        QueryTerminalKind::Failure
+    } else {
+        QueryTerminalKind::Success
+    };
+    Ok(QueryOutput::success(value).with_terminal_kind(kind))
+}
+
+fn scalar_layout(ty: &crate::TypeInstanceKey) -> crate::type_queries::CanonicalLayout {
+    use crate::TypeInstanceKey as T;
+    let size = match ty {
+        T::I8 | T::U8 | T::Bool => 1,
+        T::I16 | T::U16 => 2,
+        T::I32 | T::U32 => 4,
+        T::I64 | T::U64 => 8,
+        T::Unit | T::Never => 0,
+        _ => 8,
+    };
+    crate::type_queries::CanonicalLayout {
+        size,
+        alignment: size.max(1),
+        stride: size,
+        abi_slots: u32::from(size != 0),
+        slot_identical: matches!(ty, T::I64 | T::U64 | T::Unit | T::Never),
+        kind: crate::type_queries::CanonicalLayoutKind::Scalar,
+    }
+}
+
+fn layout_from_terminal(
+    terminal: &rue_query::QueryTerminal<crate::type_queries::LayoutValue>,
+) -> Result<&crate::type_queries::CanonicalLayout, crate::type_queries::TypeQueryFailure> {
+    let rue_query::QueryOutcome::Success(value) = terminal.outcome() else {
+        unreachable!("Layout publishes typed values")
+    };
+    match value {
+        crate::type_queries::LayoutValue::Available(layout) => Ok(layout),
+        crate::type_queries::LayoutValue::Failure(failure) => Err(failure.clone()),
+    }
+}
+
+fn evaluate_layout(
+    context: &rue_query::QueryContext,
+    family: &QueryFamily<crate::type_queries::TypeQueryKey, crate::type_queries::LayoutValue>,
+    type_shapes: &QueryFamily<
+        crate::type_queries::TypeQueryKey,
+        crate::type_queries::TypeShapeValue,
+    >,
+    key: &crate::type_queries::TypeQueryKey,
+) -> Result<QueryOutput<crate::type_queries::LayoutValue>, QueryAbort> {
+    use crate::TypeInstanceKey as T;
+    use crate::type_queries::{CanonicalLayout, CanonicalLayoutKind, LayoutValue, TypeShape};
+    if matches!(key.ty, T::PtrConst(_) | T::PtrMut(_)) {
+        return Ok(QueryOutput::success(LayoutValue::Available(
+            CanonicalLayout {
+                size: 8,
+                alignment: 8,
+                stride: 8,
+                abi_slots: 1,
+                slot_identical: true,
+                kind: CanonicalLayoutKind::Pointer,
+            },
+        )));
+    }
+    if matches!(key.ty, T::Slice { .. }) {
+        // A generated slice is the canonical `{ data: ptr const T, len: u64 }`
+        // fat pointer. Its pointee remains deliberately unobserved.
+        return Ok(QueryOutput::success(LayoutValue::Available(
+            CanonicalLayout {
+                size: 16,
+                alignment: 8,
+                stride: 16,
+                abi_slots: 2,
+                slot_identical: true,
+                kind: CanonicalLayoutKind::Slice,
+            },
+        )));
+    }
+    if matches!(
+        key.ty,
+        T::I8
+            | T::I16
+            | T::I32
+            | T::I64
+            | T::U8
+            | T::U16
+            | T::U32
+            | T::U64
+            | T::Bool
+            | T::Unit
+            | T::Never
+    ) {
+        return Ok(QueryOutput::success(LayoutValue::Available(scalar_layout(
+            &key.ty,
+        ))));
+    }
+    let shape_terminal = context.query_registered(type_shapes, key.clone())?;
+    let shape = match type_shape_from_terminal(&shape_terminal) {
+        Ok(shape) => shape,
+        Err(failure) => {
+            return Ok(QueryOutput::success(LayoutValue::Failure(failure))
+                .with_terminal_kind(QueryTerminalKind::Failure));
+        }
+    };
+    let value = match shape {
+        TypeShape::Array { element, len } => {
+            if *len == 0 {
+                return Ok(QueryOutput::success(LayoutValue::Available(
+                    CanonicalLayout {
+                        size: 0,
+                        alignment: 1,
+                        stride: 0,
+                        abi_slots: 0,
+                        slot_identical: true,
+                        kind: CanonicalLayoutKind::Array {
+                            element: None,
+                            count: 0,
+                        },
+                    },
+                )));
+            }
+            let element = context.query_registered(
+                family,
+                crate::type_queries::TypeQueryKey {
+                    ty: element.clone(),
+                    configuration: key.configuration.clone(),
+                },
+            )?;
+            match layout_from_terminal(&element) {
+                Ok(element) => {
+                    let size = element.stride.saturating_mul(*len);
+                    LayoutValue::Available(CanonicalLayout {
+                        size,
+                        alignment: element.alignment,
+                        stride: size,
+                        abi_slots: u32::try_from(u64::from(element.abi_slots).saturating_mul(*len))
+                            .unwrap_or(u32::MAX),
+                        slot_identical: element.slot_identical,
+                        kind: CanonicalLayoutKind::Array {
+                            element: Some(Box::new(element.clone())),
+                            count: *len,
+                        },
+                    })
+                }
+                Err(failure) => LayoutValue::Failure(failure),
+            }
+        }
+        TypeShape::Struct { fields } => {
+            let terminals = context.query_registered_batch(
+                family,
+                fields
+                    .iter()
+                    .map(|(_, ty)| crate::type_queries::TypeQueryKey {
+                        ty: ty.clone(),
+                        configuration: key.configuration.clone(),
+                    }),
+            )?;
+            let mut offset = 0u64;
+            let mut alignment = 1u64;
+            let mut slots = 0u32;
+            let mut slot_identical = true;
+            let mut offsets = Vec::with_capacity(terminals.len());
+            let mut padding_ranges = Vec::new();
+            for terminal in &terminals {
+                let layout = match layout_from_terminal(terminal) {
+                    Ok(layout) => layout,
+                    Err(failure) => {
+                        return Ok(QueryOutput::success(LayoutValue::Failure(failure))
+                            .with_terminal_kind(QueryTerminalKind::Failure));
+                    }
+                };
+                let placed = crate::type_queries::align_to(offset, layout.alignment);
+                if placed > offset {
+                    padding_ranges.push(rue_air::PaddingRange {
+                        start: offset,
+                        end: placed,
+                    });
+                }
+                offsets.push(placed);
+                offset = placed.saturating_add(layout.size);
+                alignment = alignment.max(layout.alignment);
+                slots = slots.saturating_add(layout.abi_slots);
+                slot_identical &= layout.slot_identical;
+            }
+            let size = crate::type_queries::align_to(offset, alignment);
+            if size > offset {
+                padding_ranges.push(rue_air::PaddingRange {
+                    start: offset,
+                    end: size,
+                });
+            }
+            LayoutValue::Available(CanonicalLayout {
+                size,
+                alignment,
+                stride: size,
+                abi_slots: slots,
+                slot_identical,
+                kind: CanonicalLayoutKind::Struct {
+                    field_offsets: offsets.into(),
+                    padding_ranges: padding_ranges.into(),
+                },
+            })
+        }
+        TypeShape::Enum { variants } => {
+            let keys = variants
+                .iter()
+                .flat_map(|(_, fields)| fields.iter())
+                .cloned()
+                .map(|ty| crate::type_queries::TypeQueryKey {
+                    ty,
+                    configuration: key.configuration.clone(),
+                })
+                .collect::<Vec<_>>();
+            let terminals = context.query_registered_batch(family, keys)?;
+            let tag_size = match variants.len() {
+                0..=256 => 1,
+                257..=65536 => 2,
+                _ => 4,
+            };
+            let mut cursor = 0usize;
+            let mut payload_size = 0u64;
+            let mut payload_alignment = 1u64;
+            let mut max_slots = 0u32;
+            let mut projected = Vec::with_capacity(variants.len());
+            for (_, fields) in variants.iter() {
+                let mut offset = 0u64;
+                let mut variant_slots = 0u32;
+                let mut offsets = Vec::with_capacity(fields.len());
+                for _ in fields.iter() {
+                    let layout = match layout_from_terminal(&terminals[cursor]) {
+                        Ok(layout) => layout,
+                        Err(failure) => {
+                            return Ok(QueryOutput::success(LayoutValue::Failure(failure))
+                                .with_terminal_kind(QueryTerminalKind::Failure));
+                        }
+                    };
+                    cursor += 1;
+                    offset = crate::type_queries::align_to(offset, layout.alignment);
+                    offsets.push(offset);
+                    offset = offset.saturating_add(layout.size);
+                    payload_alignment = payload_alignment.max(layout.alignment);
+                    variant_slots = variant_slots.saturating_add(layout.abi_slots);
+                }
+                payload_size = payload_size.max(offset);
+                max_slots = max_slots.max(variant_slots);
+                projected.push(offsets.into());
+            }
+            let alignment = payload_alignment.max(tag_size);
+            let payload_offset = crate::type_queries::align_to(tag_size, payload_alignment);
+            let size = crate::type_queries::align_to(
+                payload_offset.saturating_add(payload_size),
+                alignment,
+            );
+            LayoutValue::Available(CanonicalLayout {
+                size,
+                alignment,
+                stride: size,
+                abi_slots: 1u32.saturating_add(max_slots),
+                // Compact enums always carry a narrow tag rather than the
+                // eight-byte discriminant slot used by value decomposition.
+                slot_identical: false,
+                kind: CanonicalLayoutKind::Enum {
+                    tag_size,
+                    payload_offset,
+                    variants: projected
+                        .into_iter()
+                        .map(|offsets: Arc<[u64]>| {
+                            offsets
+                                .iter()
+                                .map(|offset| payload_offset.saturating_add(*offset))
+                                .collect::<Vec<_>>()
+                                .into()
+                        })
+                        .collect::<Vec<_>>()
+                        .into(),
+                },
+            })
+        }
+        TypeShape::Scalar => LayoutValue::Available(scalar_layout(&key.ty)),
+        TypeShape::Pointer => unreachable!("pointer layouts return before TypeShape"),
+        TypeShape::Slice => unreachable!("slice layouts return before TypeShape"),
+        TypeShape::Opaque => LayoutValue::Failure(crate::type_queries::TypeQueryFailure::Invalid(
+            Arc::from("type is not materializable"),
+        )),
+    };
+    let kind = if matches!(value, LayoutValue::Failure(_)) {
+        QueryTerminalKind::Failure
+    } else {
+        QueryTerminalKind::Success
+    };
+    Ok(QueryOutput::success(value).with_terminal_kind(kind))
+}
+
+#[derive(Debug)]
+struct StableCallableSignature {
+    parameters: Vec<(
+        crate::durable_semantics::DurableParameterMode,
+        crate::TypeInstanceKey,
+    )>,
+    result: crate::TypeInstanceKey,
+    target_c: bool,
+}
+
+fn named_callable_owner_type(
+    definition: &crate::StableDefinitionKey,
+) -> Option<crate::TypeInstanceKey> {
+    let owner = definition.owner()?;
+    Some(crate::TypeInstanceKey::Nominal(
+        crate::NominalInstanceKey::Named(crate::StableDefinitionKey::from_stable_parts(
+            owner.module().clone(),
+            crate::StableDefinitionNamespace::Type,
+            owner.kind(),
+            owner.name(),
+            None,
+        )),
+    ))
+}
+
+fn anonymous_method_type(
+    ty: &crate::durable_semantics::DurableAnonymousMethodType,
+    owner: &crate::TypeInstanceKey,
+) -> crate::TypeInstanceKey {
+    match ty {
+        crate::durable_semantics::DurableAnonymousMethodType::SelfType => owner.clone(),
+        crate::durable_semantics::DurableAnonymousMethodType::Concrete(ty) => {
+            crate::type_queries::type_instance(ty)
+        }
+    }
+}
+
+fn durable_parameter_is_runtime(
+    parameter: &crate::durable_semantics::DurableSemanticParameter,
+) -> bool {
+    !parameter.is_comptime || parameter.ty != crate::durable_semantics::DurableType::ComptimeType
+}
+
+fn anonymous_parameter_is_runtime(
+    ty: &crate::durable_semantics::DurableAnonymousMethodType,
+    is_comptime: bool,
+) -> bool {
+    !is_comptime
+        || !matches!(
+            ty,
+            crate::durable_semantics::DurableAnonymousMethodType::Concrete(
+                crate::durable_semantics::DurableType::ComptimeType
+            )
+        )
+}
+
+fn exact_specialized_callable_types(
+    context: &rue_query::QueryContext,
+    semantic_nucleus: &SemanticNucleusFamily,
+    declaration_shells: &QueryFamily<DeclarationShellQueryKey, DeclarationShellQueryValue>,
+    raw_declaration_signatures: &QueryFamily<
+        RawDeclarationSignatureQueryKey,
+        RawDeclarationSignatureQueryValue,
+    >,
+    lookup_names: &QueryFamily<LookupNameKey, LookupNameValue>,
+    declaration: &crate::declaration_candidate::DeclarationCandidateKey,
+    definition: &crate::StableDefinitionKey,
+    signature_parameters: &[crate::durable_semantics::DurableSemanticParameter],
+    arguments: &crate::CanonicalArguments,
+    configuration: &crate::semantic_query_nucleus::SemanticQueryConfiguration,
+) -> Result<
+    Result<
+        (
+            Vec<crate::durable_semantics::DurableType>,
+            crate::durable_semantics::DurableType,
+        ),
+        crate::type_queries::TypeQueryFailure,
+    >,
+    QueryAbort,
+> {
+    use crate::type_queries::TypeQueryFailure;
+
+    let shell = context.query_registered(
+        declaration_shells,
+        DeclarationShellQueryKey(declaration.clone()),
+    )?;
+    let rue_query::QueryOutcome::Success(shell) = shell.outcome() else {
+        unreachable!("DeclarationShell publishes typed values")
+    };
+    let DeclarationShellQueryValue::Available(shell) = shell else {
+        return Ok(Err(TypeQueryFailure::Unavailable(Arc::from(format!(
+            "specialized callable shell is unavailable: {shell:?}"
+        )))));
+    };
+    if shell.parameters.len() != signature_parameters.len() {
+        return Ok(Err(TypeQueryFailure::Invalid(Arc::from(
+            "specialized callable shell disagrees with its semantic signature",
+        ))));
+    }
+
+    let mut type_arguments = arguments.types.iter();
+    let mut value_arguments = arguments.values.iter();
+    let mut substitutions = BTreeMap::new();
+    let mut value_substitutions = BTreeMap::new();
+    for (header, parameter) in shell.parameters.iter().zip(signature_parameters) {
+        if !header.is_comptime {
+            continue;
+        }
+        if parameter.ty == crate::durable_semantics::DurableType::ComptimeType {
+            let Some(argument) = type_arguments
+                .next()
+                .and_then(durable_type_from_instance_key)
+            else {
+                return Ok(Err(TypeQueryFailure::Invalid(Arc::from(
+                    "specialized callable has an invalid comptime type argument stream",
+                ))));
+            };
+            substitutions.insert(header.name.clone(), argument);
+        } else {
+            let Some(argument) = value_arguments.next().and_then(durable_value_from_argument)
+            else {
+                return Ok(Err(TypeQueryFailure::Invalid(Arc::from(
+                    "specialized callable has an invalid comptime value argument stream",
+                ))));
+            };
+            value_substitutions.insert(header.name.clone(), argument);
+        }
+    }
+    if type_arguments.next().is_some() || value_arguments.next().is_some() {
+        return Ok(Err(TypeQueryFailure::Invalid(Arc::from(
+            "specialized callable has excess comptime arguments",
+        ))));
+    }
+
+    let raw = context.query_registered(
+        raw_declaration_signatures,
+        RawDeclarationSignatureQueryKey(declaration.clone()),
+    )?;
+    let rue_query::QueryOutcome::Success(raw) = raw.outcome() else {
+        unreachable!("RawDeclarationSignature publishes typed values")
+    };
+    let RawDeclarationSignatureQueryValue::Available(raw) = raw else {
+        return Ok(Err(TypeQueryFailure::Unavailable(Arc::from(format!(
+            "specialized callable syntax is unavailable: {raw:?}"
+        )))));
+    };
+    let parsed = match crate::semantic_query_nucleus::parse_semantic_signature(declaration, raw) {
+        Ok(parsed) => parsed,
+        Err(failure) => return Ok(Err(TypeQueryFailure::Invalid(failure))),
+    };
+    let crate::semantic_query_nucleus::ParsedSemanticSignature::Callable {
+        parameters, result, ..
+    } = parsed
+    else {
+        return Ok(Err(TypeQueryFailure::Invalid(Arc::from(
+            "specialized definition is not callable",
+        ))));
+    };
+    if parameters.len() != signature_parameters.len() {
+        return Ok(Err(TypeQueryFailure::Invalid(Arc::from(
+            "specialized callable syntax disagrees with its semantic signature",
+        ))));
+    }
+
+    let mut provider = SemanticNucleusTypeProvider {
+        context,
+        family: semantic_nucleus,
+        shells: declaration_shells,
+        names: lookup_names,
+        configuration: configuration.clone(),
+        substitutions,
+        value_substitutions,
+        deferred_value_parameters: BTreeMap::new(),
+        anonymous_nominals: BTreeMap::new(),
+        dependency_source: definition.clone(),
+        dependency_kind: rue_air::DeclarationTypeDependencyKind::Signature,
+        dependencies: BTreeSet::new(),
+        deferred_ownership: BTreeSet::new(),
+    };
+    let mut resolve = |syntax: &str| {
+        rue_air::resolve_semantic_type_syntax(&mut provider, &declaration.module, syntax)
+            .map_err(semantic_type_query_failure)
+    };
+    let mut runtime_parameters = Vec::new();
+    for (parameter, _semantic) in parameters
+        .iter()
+        .zip(signature_parameters)
+        .filter(|(_, semantic)| durable_parameter_is_runtime(semantic))
+    {
+        match resolve(&parameter.ty) {
+            Ok(ty) => runtime_parameters.push(ty),
+            Err(ResolveSemanticSignatureError::Abort(abort)) => return Err(abort),
+            Err(ResolveSemanticSignatureError::Failure(failure)) => {
+                return Ok(Err(TypeQueryFailure::Invalid(Arc::from(format!(
+                    "specialized callable parameter type failed to resolve: {failure:?}"
+                )))));
+            }
+        }
+    }
+    let result = match resolve(&result) {
+        Ok(result) => result,
+        Err(ResolveSemanticSignatureError::Abort(abort)) => return Err(abort),
+        Err(ResolveSemanticSignatureError::Failure(failure)) => {
+            return Ok(Err(TypeQueryFailure::Invalid(Arc::from(format!(
+                "specialized callable result type failed to resolve: {failure:?}"
+            )))));
+        }
+    };
+    Ok(Ok((runtime_parameters, result)))
+}
+
+fn query_callable_signature(
+    context: &rue_query::QueryContext,
+    semantic_nucleus: &SemanticNucleusFamily,
+    declaration_shells: &QueryFamily<DeclarationShellQueryKey, DeclarationShellQueryValue>,
+    raw_declaration_signatures: &QueryFamily<
+        RawDeclarationSignatureQueryKey,
+        RawDeclarationSignatureQueryValue,
+    >,
+    lookup_names: &QueryFamily<LookupNameKey, LookupNameValue>,
+    body_produced_anonymous: &QueryFamily<
+        crate::body_query::BodyQueryKey,
+        crate::body_query::ProducedAnonymous,
+    >,
+    key: &crate::type_queries::CallAbiQueryKey,
+) -> Result<Result<StableCallableSignature, crate::type_queries::TypeQueryFailure>, QueryAbort> {
+    use crate::durable_semantics::DurableParameterMode;
+    use crate::type_queries::TypeQueryFailure;
+    match &key.callable {
+        crate::FunctionInstanceKey::DropGlue(owner) => Ok(Ok(StableCallableSignature {
+            parameters: vec![(DurableParameterMode::Value, owner.as_ref().clone())],
+            result: crate::TypeInstanceKey::Unit,
+            target_c: false,
+        })),
+        crate::FunctionInstanceKey::Definition(definition)
+            if definition.kind() == crate::StableDefinitionKind::Destructor =>
+        {
+            let Some(owner) = named_callable_owner_type(definition) else {
+                return Ok(Err(TypeQueryFailure::Invalid(Arc::from(
+                    "named destructor has no nominal owner",
+                ))));
+            };
+            Ok(Ok(StableCallableSignature {
+                parameters: vec![(DurableParameterMode::Value, owner)],
+                result: crate::TypeInstanceKey::Unit,
+                target_c: false,
+            }))
+        }
+        crate::FunctionInstanceKey::AnonymousMember { owner, member } => {
+            let crate::TypeInstanceKey::Nominal(crate::NominalInstanceKey::Anonymous(identity)) =
+                owner.as_ref()
+            else {
+                return Ok(Err(TypeQueryFailure::Invalid(Arc::from(
+                    "anonymous member owner is not an anonymous nominal",
+                ))));
+            };
+            let nominal = match query_anonymous_nominal(
+                context,
+                semantic_nucleus,
+                body_produced_anonymous,
+                identity,
+                &key.configuration,
+            )? {
+                Ok(nominal) => nominal,
+                Err(failure) => return Ok(Err(failure)),
+            };
+            let crate::durable_semantics::DurableAnonymousNominalShape::Struct { methods, .. } =
+                &nominal.shape
+            else {
+                return Ok(Err(TypeQueryFailure::Invalid(Arc::from(
+                    "anonymous enum has no callable members",
+                ))));
+            };
+            let signature = methods.iter().find(|signature| {
+                signature.name == member.name
+                    && match member.kind {
+                        crate::AnonymousMemberKind::Destructor => {
+                            signature.has_self && signature.name.as_ref() == "__drop"
+                        }
+                        crate::AnonymousMemberKind::Method => signature.has_self,
+                        crate::AnonymousMemberKind::AssociatedFunction => !signature.has_self,
+                    }
+            });
+            let Some(signature) = signature else {
+                return Ok(Err(TypeQueryFailure::Unavailable(Arc::from(
+                    "anonymous member signature is unavailable",
+                ))));
+            };
+            let mut parameters = Vec::new();
+            if signature.has_self {
+                parameters.push((signature.self_mode, owner.as_ref().clone()));
+            }
+            parameters.extend(
+                signature
+                    .parameters
+                    .iter()
+                    .filter(|(ty, _, comptime)| anonymous_parameter_is_runtime(ty, *comptime))
+                    .map(|(ty, mode, _)| (*mode, anonymous_method_type(ty, owner))),
+            );
+            Ok(Ok(StableCallableSignature {
+                parameters,
+                result: anonymous_method_type(&signature.result, owner),
+                target_c: false,
+            }))
+        }
+        callable => {
+            let Some(definition) = function_definition_key(callable) else {
+                return Ok(Err(TypeQueryFailure::Invalid(Arc::from(
+                    "callable identity has no signature contract",
+                ))));
+            };
+            let Some(candidates) = stable_syntax_candidate_set(definition) else {
+                return Ok(Err(TypeQueryFailure::Unavailable(Arc::from(
+                    "callable has no declaration candidate",
+                ))));
+            };
+            let candidates = candidates.into_iter().flatten().collect::<Vec<_>>();
+            let terminals = context.query_registered_batch(
+                semantic_nucleus,
+                candidates.iter().cloned().map(|declaration| {
+                    crate::semantic_query_nucleus::SemanticNucleusKey::Signature(
+                        crate::semantic_query_nucleus::DeclarationSemanticQueryKey {
+                            declaration,
+                            configuration: key.configuration.clone(),
+                        },
+                    )
+                }),
+            )?;
+            let mut observed_failures = Vec::new();
+            let mut signatures =
+                terminals
+                    .iter()
+                    .zip(&candidates)
+                    .filter_map(|(terminal, declaration)| {
+                        let rue_query::QueryOutcome::Success(value) = terminal.outcome() else {
+                            unreachable!("SemanticNucleus publishes typed values")
+                        };
+                        match value {
+                            crate::semantic_query_nucleus::SemanticNucleusValue::Signature(
+                                signature,
+                            ) => Some((signature, declaration)),
+                            other => {
+                                observed_failures.push(format!("{other:?}"));
+                                None
+                            }
+                        }
+                    });
+            let Some((signature, declaration)) = signatures.next() else {
+                return Ok(Err(TypeQueryFailure::Unavailable(Arc::from(format!(
+                    "callable signature is unavailable: {}",
+                    observed_failures.join("; ")
+                )))));
+            };
+            if signatures.next().is_some() {
+                return Ok(Err(TypeQueryFailure::Invalid(Arc::from(
+                    "callable signature is ambiguous",
+                ))));
+            }
+            let crate::semantic_query_nucleus::DeclarationSignatureProjection::Callable {
+                parameters,
+                result,
+                has_self,
+                self_mode,
+                is_extern,
+                is_c_export: _,
+                ..
+            } = &signature.signature
+            else {
+                return Ok(Err(TypeQueryFailure::Invalid(Arc::from(
+                    "definition is not callable",
+                ))));
+            };
+            let mut runtime_parameters = Vec::new();
+            if *has_self {
+                let Some(owner) = named_callable_owner_type(definition) else {
+                    return Ok(Err(TypeQueryFailure::Invalid(Arc::from(
+                        "receiver-taking callable has no nominal owner",
+                    ))));
+                };
+                runtime_parameters.push((*self_mode, owner));
+            }
+            let (runtime_types, result) = match callable {
+                crate::FunctionInstanceKey::Specialization { arguments, .. } => {
+                    match exact_specialized_callable_types(
+                        context,
+                        semantic_nucleus,
+                        declaration_shells,
+                        raw_declaration_signatures,
+                        lookup_names,
+                        declaration,
+                        definition,
+                        parameters,
+                        arguments,
+                        &key.configuration,
+                    )? {
+                        Ok(signature) => signature,
+                        Err(failure) => return Ok(Err(failure)),
+                    }
+                }
+                _ => (
+                    parameters
+                        .iter()
+                        .filter(|parameter| durable_parameter_is_runtime(parameter))
+                        .map(|parameter| parameter.ty.clone())
+                        .collect(),
+                    result.clone(),
+                ),
+            };
+            runtime_parameters.extend(
+                parameters
+                    .iter()
+                    .filter(|parameter| durable_parameter_is_runtime(parameter))
+                    .zip(runtime_types)
+                    .map(|(parameter, ty)| {
+                        (parameter.mode, crate::type_queries::type_instance(&ty))
+                    }),
+            );
+            Ok(Ok(StableCallableSignature {
+                parameters: runtime_parameters,
+                result: crate::type_queries::type_instance(&result),
+                // A C export's source body uses Rue's native ABI. The separate
+                // entry thunk is the Target-C boundary.
+                target_c: *is_extern,
+            }))
+        }
+    }
+}
+
+fn stable_type_is_aggregate(ty: &crate::TypeInstanceKey) -> bool {
+    use crate::{NominalInstanceKey as N, TypeInstanceKey as T};
+    match ty {
+        T::Array { .. } | T::Slice { .. } => true,
+        T::BuiltinNominal { .. } | T::Nominal(N::Builtin { .. }) => true,
+        T::Nominal(N::Named(definition)) => matches!(
+            definition.kind(),
+            crate::StableDefinitionKind::Struct | crate::StableDefinitionKind::Enum
+        ),
+        T::Nominal(N::Anonymous(_)) => true,
+        _ => false,
+    }
+}
+
+fn stable_type_is_strbuf(ty: &crate::TypeInstanceKey) -> bool {
+    matches!(
+        ty,
+        crate::TypeInstanceKey::Nominal(crate::NominalInstanceKey::Named(definition))
+            if definition.module().is_trusted_standard_library()
+                && definition.kind() == crate::StableDefinitionKind::Struct
+                && definition.name() == "StrBuf"
+    )
+}
+
+fn c_scalar_extension(ty: &crate::TypeInstanceKey) -> rue_air::ScalarAbiExtension {
+    use crate::TypeInstanceKey as T;
+    match ty {
+        T::I8 => rue_air::ScalarAbiExtension::Signed { from_bits: 8 },
+        T::I16 => rue_air::ScalarAbiExtension::Signed { from_bits: 16 },
+        T::I32 => rue_air::ScalarAbiExtension::Signed { from_bits: 32 },
+        T::U8 | T::Bool => rue_air::ScalarAbiExtension::Unsigned { from_bits: 8 },
+        T::U16 => rue_air::ScalarAbiExtension::Unsigned { from_bits: 16 },
+        T::U32 => rue_air::ScalarAbiExtension::Unsigned { from_bits: 32 },
+        _ => rue_air::ScalarAbiExtension::None,
+    }
+}
+
+fn evaluate_call_abi(
+    context: &rue_query::QueryContext,
+    semantic_nucleus: &SemanticNucleusFamily,
+    declaration_shells: &QueryFamily<DeclarationShellQueryKey, DeclarationShellQueryValue>,
+    raw_declaration_signatures: &QueryFamily<
+        RawDeclarationSignatureQueryKey,
+        RawDeclarationSignatureQueryValue,
+    >,
+    lookup_names: &QueryFamily<LookupNameKey, LookupNameValue>,
+    body_produced_anonymous: &QueryFamily<
+        crate::body_query::BodyQueryKey,
+        crate::body_query::ProducedAnonymous,
+    >,
+    layouts: &QueryFamily<crate::type_queries::TypeQueryKey, crate::type_queries::LayoutValue>,
+    key: &crate::type_queries::CallAbiQueryKey,
+) -> Result<QueryOutput<crate::type_queries::CallAbiValue>, QueryAbort> {
+    use crate::durable_semantics::DurableParameterMode;
+    use crate::type_queries::{
+        CallAbiArgument, CallAbiArgumentClass as A, CallAbiConvention, CallAbiFacts,
+        CallAbiReturnClass as R, CallAbiValue,
+    };
+    let signature = match query_callable_signature(
+        context,
+        semantic_nucleus,
+        declaration_shells,
+        raw_declaration_signatures,
+        lookup_names,
+        body_produced_anonymous,
+        key,
+    )? {
+        Ok(signature) => signature,
+        Err(failure) => {
+            return Ok(QueryOutput::success(CallAbiValue::Failure(failure))
+                .with_terminal_kind(QueryTerminalKind::Failure));
+        }
+    };
+    let target_c_flavor = match key.configuration.target {
+        crate::Target::X86_64Linux => rue_air::TargetCAbiFlavor::SysVAmd64,
+        crate::Target::Aarch64Linux | crate::Target::Aarch64Macos => {
+            rue_air::TargetCAbiFlavor::Aapcs64
+        }
+    };
+    let convention = if signature.target_c {
+        CallAbiConvention::TargetC(target_c_flavor)
+    } else {
+        CallAbiConvention::Native
+    };
+    let mut arguments = Vec::with_capacity(signature.parameters.len());
+    for (mode, ty) in &signature.parameters {
+        if !matches!(mode, DurableParameterMode::Value) {
+            arguments.push(CallAbiArgument {
+                mode: *mode,
+                value_slots: 1,
+                class: A::Reference,
+            });
+            continue;
+        }
+        let layout = context.query_registered(
+            layouts,
+            crate::type_queries::TypeQueryKey {
+                ty: ty.clone(),
+                configuration: key.configuration.clone(),
+            },
+        )?;
+        let layout = match layout_from_terminal(&layout) {
+            Ok(layout) => layout,
+            Err(failure) => {
+                return Ok(QueryOutput::success(CallAbiValue::Failure(failure))
+                    .with_terminal_kind(QueryTerminalKind::Failure));
+            }
+        };
+        let aggregate = stable_type_is_aggregate(ty);
+        let class = match convention {
+            CallAbiConvention::Native => {
+                if layout.abi_slots == 0 {
+                    A::Omitted
+                } else if aggregate && layout.abi_slots > 1 && !layout.slot_identical {
+                    A::NativeIndirect
+                } else {
+                    A::NativeDirect {
+                        slots: layout.abi_slots,
+                    }
+                }
+            }
+            CallAbiConvention::TargetC(flavor) => {
+                if layout.size == 0 {
+                    A::Omitted
+                } else if !aggregate {
+                    A::CScalar {
+                        extension: c_scalar_extension(ty),
+                    }
+                } else if layout.size <= 16 {
+                    A::CIntegerRegisters {
+                        eightbytes: u32::try_from((layout.size + 7) / 8).unwrap_or(u32::MAX),
+                    }
+                } else {
+                    let size = u32::try_from(layout.size).unwrap_or(u32::MAX);
+                    let alignment = u32::try_from(layout.alignment).unwrap_or(u32::MAX);
+                    match flavor {
+                        rue_air::TargetCAbiFlavor::SysVAmd64 => {
+                            A::CByValueStack { size, alignment }
+                        }
+                        rue_air::TargetCAbiFlavor::Aapcs64 => {
+                            A::CByReferenceCopy { size, alignment }
+                        }
+                    }
+                }
+            }
+        };
+        arguments.push(CallAbiArgument {
+            mode: *mode,
+            value_slots: layout.abi_slots,
+            class,
+        });
+    }
+    let return_layout = context.query_registered(
+        layouts,
+        crate::type_queries::TypeQueryKey {
+            ty: signature.result.clone(),
+            configuration: key.configuration.clone(),
+        },
+    )?;
+    let return_layout = match layout_from_terminal(&return_layout) {
+        Ok(layout) => layout,
+        Err(failure) => {
+            return Ok(QueryOutput::success(CallAbiValue::Failure(failure))
+                .with_terminal_kind(QueryTerminalKind::Failure));
+        }
+    };
+    let aggregate = stable_type_is_aggregate(&signature.result);
+    let return_class = if return_layout.abi_slots == 0 {
+        R::ZeroSized
+    } else {
+        match convention {
+            CallAbiConvention::Native => {
+                let budget = match key.configuration.target {
+                    crate::Target::X86_64Linux => 6,
+                    crate::Target::Aarch64Linux | crate::Target::Aarch64Macos => 8,
+                };
+                if stable_type_is_strbuf(&signature.result)
+                    || (aggregate && return_layout.abi_slots > budget)
+                    || (aggregate && return_layout.abi_slots > 1 && !return_layout.slot_identical)
+                {
+                    R::NativeIndirect {
+                        slots: return_layout.abi_slots,
+                    }
+                } else if aggregate {
+                    R::NativeRegisters {
+                        slots: return_layout.abi_slots,
+                    }
+                } else {
+                    R::Scalar {
+                        extension: rue_air::ScalarAbiExtension::None,
+                    }
+                }
+            }
+            CallAbiConvention::TargetC(_) => {
+                if !aggregate {
+                    R::Scalar {
+                        extension: c_scalar_extension(&signature.result),
+                    }
+                } else if return_layout.size <= 16 {
+                    R::CIntegerRegisters {
+                        eightbytes: u32::try_from((return_layout.size + 7) / 8).unwrap_or(u32::MAX),
+                    }
+                } else {
+                    R::CIndirect {
+                        size: u32::try_from(return_layout.size).unwrap_or(u32::MAX),
+                        alignment: u32::try_from(return_layout.alignment).unwrap_or(u32::MAX),
+                    }
+                }
+            }
+        }
+    };
+    Ok(QueryOutput::success(CallAbiValue::Available(
+        CallAbiFacts {
+            convention,
+            return_class,
+            arguments: arguments.into(),
+        },
+    )))
+}
+
+fn evaluate_drop_glue(
+    context: &rue_query::QueryContext,
+    type_shapes: &QueryFamily<
+        crate::type_queries::TypeQueryKey,
+        crate::type_queries::TypeShapeValue,
+    >,
+    type_facts: &QueryFamily<
+        crate::type_queries::TypeQueryKey,
+        crate::type_queries::TypeFactsValue,
+    >,
+    key: &crate::type_queries::TypeQueryKey,
+) -> Result<QueryOutput<crate::type_queries::DropGlueValue>, QueryAbort> {
+    use crate::type_queries::{
+        DropGlueFacts, DropGlueField, DropGluePlan, DropGlueValue, DropGlueVariant,
+        DropGlueVariantField, TypeShape,
+    };
+    let terminal = context.query_registered(type_facts, key.clone())?;
+    let facts = match type_facts_from_terminal(&terminal) {
+        Ok(facts) => facts,
+        Err(failure) => {
+            return Ok(QueryOutput::success(DropGlueValue::Failure(failure))
+                .with_terminal_kind(QueryTerminalKind::Failure));
+        }
+    };
+    let shape_terminal = context.query_registered(type_shapes, key.clone())?;
+    let shape = match type_shape_from_terminal(&shape_terminal) {
+        Ok(shape) => shape,
+        Err(failure) => {
+            return Ok(QueryOutput::success(DropGlueValue::Failure(failure))
+                .with_terminal_kind(QueryTerminalKind::Failure));
+        }
+    };
+    let children = match shape {
+        TypeShape::Array { element, len } if *len != 0 => vec![element.clone()],
+        TypeShape::Array { .. } => Vec::new(),
+        TypeShape::Struct { fields } => fields.iter().map(|(_, ty)| ty.clone()).collect(),
+        TypeShape::Enum { variants } => variants
+            .iter()
+            .flat_map(|(_, fields)| fields.iter().cloned())
+            .collect(),
+        TypeShape::Scalar | TypeShape::Pointer | TypeShape::Slice | TypeShape::Opaque => Vec::new(),
+    };
+    let terminals = context.query_registered_batch(
+        type_facts,
+        children
+            .iter()
+            .cloned()
+            .map(|ty| crate::type_queries::TypeQueryKey {
+                ty,
+                configuration: key.configuration.clone(),
+            }),
+    )?;
+    let mut nested = Vec::new();
+    let mut decisions = Vec::new();
+    for (ty, terminal) in children.into_iter().zip(terminals) {
+        match type_facts_from_terminal(&terminal) {
+            Ok(child) => {
+                if child.needs_drop {
+                    nested.push(ty.clone());
+                }
+                decisions.push((ty, child.needs_drop));
+            }
+            Err(failure) => {
+                return Ok(QueryOutput::success(DropGlueValue::Failure(failure))
+                    .with_terminal_kind(QueryTerminalKind::Failure));
+            }
+        }
+    }
+    nested.sort();
+    nested.dedup();
+    let mut decisions = decisions.into_iter();
+    let plan = match shape {
+        TypeShape::Struct { fields } => DropGluePlan::Struct {
+            fields: fields
+                .iter()
+                .map(|(name, ty)| {
+                    let (_observed, drop) = decisions
+                        .next()
+                        .expect("one ownership decision per struct field");
+                    DropGlueField {
+                        name: name.clone(),
+                        ty: ty.clone(),
+                        drop,
+                    }
+                })
+                .collect::<Vec<_>>()
+                .into(),
+        },
+        TypeShape::Array { element, len } => DropGluePlan::Array {
+            element: element.clone(),
+            len: *len,
+            drop_element: if *len == 0 {
+                false
+            } else {
+                decisions
+                    .next()
+                    .expect("one ownership decision for a non-empty array")
+                    .1
+            },
+        },
+        TypeShape::Enum { variants } => DropGluePlan::Enum {
+            variants: variants
+                .iter()
+                .map(|(name, fields)| DropGlueVariant {
+                    name: name.clone(),
+                    fields: fields
+                        .iter()
+                        .map(|ty| {
+                            let (_observed, drop) = decisions
+                                .next()
+                                .expect("one ownership decision per enum field");
+                            DropGlueVariantField {
+                                ty: ty.clone(),
+                                drop,
+                            }
+                        })
+                        .collect::<Vec<_>>()
+                        .into(),
+                })
+                .collect::<Vec<_>>()
+                .into(),
+        },
+        TypeShape::Scalar | TypeShape::Pointer | TypeShape::Slice | TypeShape::Opaque => {
+            DropGluePlan::None
+        }
+    };
+    Ok(QueryOutput::success(DropGlueValue::Available(Box::new(
+        DropGlueFacts {
+            required: facts.needs_drop,
+            synthesize: facts.needs_drop,
+            destructor: facts.destructor.clone(),
+            nested: nested.into(),
+            plan,
+        },
+    ))))
+}
+
 #[derive(Debug)]
 #[allow(dead_code)]
 pub(crate) enum BodyTransactionRequestFailure {
@@ -3712,9 +5123,38 @@ fn collect_published_body_references(
     references: &mut BTreeSet<crate::body_query::BodyReference>,
 ) {
     use rue_air::SemanticBodyInstDependency as D;
+    let collect_drop_obligation =
+        |value: rue_air::SemanticBodyRef,
+         references: &mut BTreeSet<crate::body_query::BodyReference>| {
+            if let Some(value) = body.instructions.get(value as usize) {
+                references.insert(crate::body_query::BodyReference::DropGlue(
+                    body_type_instance(&value.ty),
+                ));
+            }
+        };
     collect_body_type_reference(&body.return_type, references);
     for instruction in body.instructions.iter() {
         collect_body_type_reference(&instruction.ty, references);
+        use rue_air::SemanticBodyInstData as I;
+        match &instruction.data {
+            // These are precisely the ownership sites from which CFG cleanup
+            // elaboration can emit an implicit destroy: a live local, an
+            // overwritten local/parameter/place, or a discarded statement
+            // result. Publishing their value types here keeps DropGlue rooted
+            // in the reached body that owns the obligation without duplicating
+            // CFG's path-sensitive drop elaboration.
+            I::Alloc { init: value, .. }
+            | I::Store { value, .. }
+            | I::ParamStore { value, .. }
+            | I::PlaceWrite { value, .. }
+            | I::Drop { value } => collect_drop_obligation(*value, references),
+            I::Block { statements, .. } => {
+                for &statement in statements.iter() {
+                    collect_drop_obligation(statement, references);
+                }
+            }
+            _ => {}
+        }
         instruction
             .data
             .visit_dependencies(&mut |dependency| match dependency {
@@ -3752,6 +5192,9 @@ fn collect_published_body_references(
     }
     for (_, ty) in body.param_drops.iter() {
         collect_body_type_reference(ty, references);
+        references.insert(crate::body_query::BodyReference::DropGlue(
+            body_type_instance(ty),
+        ));
     }
 }
 
@@ -9526,16 +10969,6 @@ impl RevisionedQueryDatabase {
                             Incomplete::MissingPrerequisite(Arc::from("declaration shell")),
                         )));
                     };
-                    if shell.is_generic
-                        && matches!(
-                            key.instance,
-                            crate::FunctionInstanceKey::Definition(_)
-                        )
-                    {
-                        return Ok(QueryOutput::success(BodyInputValue::Incomplete(
-                            Incomplete::Generic,
-                        )));
-                    }
                     if shell.is_extern
                         || candidate.category
                             == crate::declaration_candidate::DeclarationCandidateCategory::ExternFunction
@@ -9568,6 +11001,39 @@ impl RevisionedQueryDatabase {
                             )),
                         )));
                     };
+                    if shell.is_generic
+                        && matches!(
+                            key.instance,
+                            crate::FunctionInstanceKey::Definition(_)
+                        )
+                    {
+                        use crate::declaration_candidate::DeclarationCandidateCategory as Category;
+                        use crate::semantic_query_nucleus::ParsedSemanticSignature;
+
+                        // Free functions with any comptime parameter are
+                        // materialized only through specialization identities.
+                        // Named members are different: their comptime value
+                        // parameters stay in the one runtime body and ABI.
+                        // Only a comptime type parameter makes that definition
+                        // unavailable without a specialized identity.
+                        let named_runtime_value_body = matches!(
+                            candidate.category,
+                            Category::Method | Category::AssociatedFunction
+                        ) && matches!(
+                            crate::semantic_query_nucleus::parse_semantic_signature(
+                                &candidate, signature
+                            ),
+                            Ok(ParsedSemanticSignature::Callable { parameters, .. })
+                                if parameters.iter().all(|parameter| {
+                                    !parameter.is_comptime || parameter.ty.trim() != "type"
+                                })
+                        );
+                        if !named_runtime_value_body {
+                            return Ok(QueryOutput::success(BodyInputValue::Incomplete(
+                                Incomplete::Generic,
+                            )));
+                        }
+                    }
                     let body = match context.query_registered(
                         &bodies_for_body_inputs,
                         RawDeclarationBodyQueryKey(candidate.clone()),
@@ -9760,21 +11226,36 @@ impl RevisionedQueryDatabase {
                             .query_registered(&transactions_for_produced_anonymous, key.clone())
                         {
                             Ok(transaction) => {
-                                let rue_query::QueryOutcome::Success(
-                                    crate::body_query::BodyTransaction::Success {
-                                        produced_anonymous_nominals,
-                                        ..
-                                    },
-                                ) = transaction.outcome()
+                                let rue_query::QueryOutcome::Success(transaction) =
+                                    transaction.outcome()
                                 else {
-                                    return Err(QueryAbort::Canceled);
+                                    unreachable!("BodyTransaction publishes typed values")
                                 };
-                                if produced_anonymous_nominals.0.is_empty() {
+                                if let crate::body_query::BodyTransaction::Success {
+                                    produced_anonymous_nominals,
+                                    ..
+                                } = transaction
+                                    && produced_anonymous_nominals.0.is_empty()
+                                {
                                     return Ok(QueryOutput::success(
                                         crate::body_query::ProducedAnonymous::Produced(
                                             produced_anonymous_nominals.clone(),
                                         ),
                                     ));
+                                }
+                                // A deterministic producer diagnostic is a
+                                // stable semantic fact, not cancellation. Let
+                                // the comptime projection below recover its
+                                // typed `ProducerFailed` value so anonymous
+                                // type consumers cannot abort the rooted
+                                // request while collecting that diagnostic.
+                                // Control outcomes remain unavailable until
+                                // their exact prerequisite is scheduled.
+                                if matches!(
+                                    transaction,
+                                    crate::body_query::BodyTransaction::Control(_)
+                                ) {
+                                    return Err(QueryAbort::Canceled);
                                 }
                             }
                             Err(QueryAbort::Canceled) => {}
@@ -11172,6 +12653,126 @@ impl RevisionedQueryDatabase {
                 },
             )
             .expect("the DeclarationSemanticsProjection family has one canonical name");
+        let semantic_nucleus_for_type_shape = semantic_nucleus.clone();
+        let produced_anonymous_for_type_shape = body_produced_anonymous.clone();
+        let type_shapes = runtime
+            .family_with_equality_and_evaluator(
+                "compiler.type-shape",
+                BODY_QUERY_MEMO_RETENTION,
+                |left: &crate::type_queries::TypeShapeValue,
+                 right: &crate::type_queries::TypeShapeValue| left == right,
+                move |context, _, key: &crate::type_queries::TypeQueryKey| {
+                    evaluate_type_shape(
+                        context,
+                        &semantic_nucleus_for_type_shape,
+                        &produced_anonymous_for_type_shape,
+                        key,
+                    )
+                },
+            )
+            .expect("the TypeShape family has one canonical name");
+        let type_facts_family = Arc::new(std::sync::OnceLock::<
+            QueryFamily<crate::type_queries::TypeQueryKey, crate::type_queries::TypeFactsValue>,
+        >::new());
+        let type_facts_family_for_evaluator = type_facts_family.clone();
+        let semantic_nucleus_for_type_facts = semantic_nucleus.clone();
+        let lookup_names_for_type_facts = lookup_names.clone();
+        let produced_anonymous_for_type_facts = body_produced_anonymous.clone();
+        let type_shapes_for_type_facts = type_shapes.clone();
+        let type_facts = runtime
+            .family_with_equality_and_evaluator(
+                "compiler.type-facts",
+                BODY_QUERY_MEMO_RETENTION,
+                |left: &crate::type_queries::TypeFactsValue,
+                 right: &crate::type_queries::TypeFactsValue| left == right,
+                move |context, _, key: &crate::type_queries::TypeQueryKey| {
+                    evaluate_type_facts(
+                        context,
+                        type_facts_family_for_evaluator
+                            .get()
+                            .expect("TypeFacts family is installed before requests"),
+                        &type_shapes_for_type_facts,
+                        &semantic_nucleus_for_type_facts,
+                        &lookup_names_for_type_facts,
+                        &produced_anonymous_for_type_facts,
+                        key,
+                    )
+                },
+            )
+            .expect("the TypeFacts family has one canonical name");
+        type_facts_family
+            .set(type_facts.clone())
+            .expect("TypeFacts family is installed once");
+        let layout_family = Arc::new(std::sync::OnceLock::<
+            QueryFamily<crate::type_queries::TypeQueryKey, crate::type_queries::LayoutValue>,
+        >::new());
+        let layout_family_for_evaluator = layout_family.clone();
+        let type_shapes_for_layout = type_shapes.clone();
+        let layouts = runtime
+            .family_with_equality_and_evaluator(
+                "compiler.layout",
+                BODY_QUERY_MEMO_RETENTION,
+                |left: &crate::type_queries::LayoutValue,
+                 right: &crate::type_queries::LayoutValue| left == right,
+                move |context, _, key: &crate::type_queries::TypeQueryKey| {
+                    evaluate_layout(
+                        context,
+                        layout_family_for_evaluator
+                            .get()
+                            .expect("Layout family is installed before requests"),
+                        &type_shapes_for_layout,
+                        key,
+                    )
+                },
+            )
+            .expect("the Layout family has one canonical name");
+        layout_family
+            .set(layouts.clone())
+            .expect("Layout family is installed once");
+        let semantic_nucleus_for_call_abi = semantic_nucleus.clone();
+        let declaration_shells_for_call_abi = declaration_shells.clone();
+        let raw_signatures_for_call_abi = raw_declaration_signatures.clone();
+        let lookup_names_for_call_abi = lookup_names.clone();
+        let produced_anonymous_for_call_abi = body_produced_anonymous.clone();
+        let layouts_for_call_abi = layouts.clone();
+        let call_abis = runtime
+            .family_with_equality_and_evaluator(
+                "compiler.call-abi",
+                BODY_QUERY_MEMO_RETENTION,
+                |left: &crate::type_queries::CallAbiValue,
+                 right: &crate::type_queries::CallAbiValue| left == right,
+                move |context, _, key: &crate::type_queries::CallAbiQueryKey| {
+                    evaluate_call_abi(
+                        context,
+                        &semantic_nucleus_for_call_abi,
+                        &declaration_shells_for_call_abi,
+                        &raw_signatures_for_call_abi,
+                        &lookup_names_for_call_abi,
+                        &produced_anonymous_for_call_abi,
+                        &layouts_for_call_abi,
+                        key,
+                    )
+                },
+            )
+            .expect("the CallAbi family has one canonical name");
+        let type_shapes_for_drop_glue = type_shapes.clone();
+        let type_facts_for_drop_glue = type_facts.clone();
+        let drop_glues = runtime
+            .family_with_equality_and_evaluator(
+                "compiler.drop-glue",
+                BODY_QUERY_MEMO_RETENTION,
+                |left: &crate::type_queries::DropGlueValue,
+                 right: &crate::type_queries::DropGlueValue| left == right,
+                move |context, _, key: &crate::type_queries::TypeQueryKey| {
+                    evaluate_drop_glue(
+                        context,
+                        &type_shapes_for_drop_glue,
+                        &type_facts_for_drop_glue,
+                        key,
+                    )
+                },
+            )
+            .expect("the DropGlue family has one canonical name");
         let provider_observation_meter = Arc::new(ProviderObservationCounters::default());
         let lookup_root_lease = Arc::new(Mutex::new(PublishedRootLookupLease::default()));
         let body_closure_root = Arc::new(Mutex::new(PublishedBodyClosureRoot::default()));
@@ -11262,6 +12863,9 @@ impl RevisionedQueryDatabase {
         let produced_for_body_reachability = body_produced_anonymous.clone();
         let inputs_for_body_closure = body_inputs.clone();
         let declarations_for_body_closure = declaration_semantics_projection.clone();
+        let type_facts_for_body_reachability = type_facts.clone();
+        let call_abis_for_body_reachability = call_abis.clone();
+        let drop_glues_for_body_reachability = drop_glues.clone();
         let body_reachability = runtime
             .family_with_equality_and_evaluator(
                 "compiler.body-reachability",
@@ -11292,6 +12896,8 @@ impl RevisionedQueryDatabase {
                             return Ok(QueryOutput::success(
                                 crate::body_query::BodyReachabilityOutput {
                                     reached: Arc::from([]),
+                                    demanded_drop_glue: Arc::from([]),
+                                    demanded_drop_glue_plans: Arc::from([]),
                                     scheduling_errors: Arc::from([]),
                                     fatal: Some(
                                         crate::body_query::BodyClosureFatal::DeclarationFailed {
@@ -11329,6 +12935,10 @@ impl RevisionedQueryDatabase {
                         .map(|root| (root, 0usize))
                         .collect::<BTreeMap<_, _>>();
                     let mut reached_body_keys = Vec::new();
+                    let mut demanded_drop_glue = BTreeSet::new();
+                    let mut demanded_drop_glue_plans = BTreeMap::new();
+                    let mut pending_drop_glue = BTreeSet::new();
+                    let mut visited_drop_glue = BTreeSet::new();
                     let mut scheduling_errors = BTreeMap::new();
                     let mut fatal = None;
                     let mut parked_toolchain = None;
@@ -11734,34 +13344,27 @@ impl RevisionedQueryDatabase {
                                     .cloned()
                                     .map(|nominal| (nominal.identity.clone(), nominal)),
                             );
-                            for nominal in produced.0.iter() {
-                                if let crate::durable_semantics::DurableAnonymousNominalShape::Struct {
-                                    methods,
-                                    ..
-                                } = &nominal.shape
-                                    && methods.iter().any(|method| {
-                                        method.has_self && method.name.as_ref() == "__drop"
-                                    })
-                                {
-                                    pending.insert(
-                                        crate::FunctionInstanceKey::AnonymousMember {
-                                            owner: Box::new(crate::TypeInstanceKey::Nominal(
-                                                crate::NominalInstanceKey::Anonymous(
-                                                    nominal.identity.clone(),
-                                                ),
-                                            )),
-                                            member: crate::AnonymousMemberKey {
-                                                kind: crate::AnonymousMemberKind::Destructor,
-                                                name: Arc::from("__drop"),
-                                            },
-                                        },
-                                    );
-                                }
-                            }
                         }
                         for reference in references.0.iter() {
                             match reference {
                                 crate::body_query::BodyReference::Callable(callable) => {
+                                    let abi = context.query_registered(
+                                        &call_abis_for_body_reachability,
+                                        crate::type_queries::CallAbiQueryKey {
+                                            callable: callable.clone(),
+                                            configuration: key.configuration.clone(),
+                                        },
+                                    )?;
+                                    let rue_query::QueryOutcome::Success(abi) = abi.outcome()
+                                    else {
+                                        unreachable!("CallAbi publishes typed values")
+                                    };
+                                    // A typed unavailable ABI result is an
+                                    // honest query terminal. The legacy CFG
+                                    // consumer still owns materialization until
+                                    // RUE-1030 switches it to these facts, so it
+                                    // must not become a new source diagnostic.
+                                    let _ = abi;
                                     match closure_callable_has_body(
                                         context,
                                         &inputs_for_body_closure,
@@ -11796,15 +13399,78 @@ impl RevisionedQueryDatabase {
                                     }
                                 }
                                 crate::body_query::BodyReference::Type(ty) => {
-                                    enqueue_closure_destructors(
-                                        ty,
-                                        &declaration_payloads,
-                                        &projection.anonymous_nominals,
-                                        &produced_anonymous,
-                                        &mut pending,
-                                    );
+                                    let facts = context.query_registered(
+                                        &type_facts_for_body_reachability,
+                                        crate::type_queries::TypeQueryKey {
+                                            ty: ty.clone(),
+                                            configuration: key.configuration.clone(),
+                                        },
+                                    )?;
+                                    let rue_query::QueryOutcome::Success(facts) = facts.outcome()
+                                    else {
+                                        unreachable!("TypeFacts publishes typed values")
+                                    };
+                                    // TypeFacts publishes typed incomplete
+                                    // outcomes for non-materializable semantic
+                                    // types. Until RUE-1030 makes downstream
+                                    // consumers query-native, observing that
+                                    // terminal must preserve existing behavior.
+                                    let _ = facts;
+                                }
+                                crate::body_query::BodyReference::DropGlue(ty) => {
+                                    pending_drop_glue.insert(ty.clone());
                                 }
                                 crate::body_query::BodyReference::Definition(_) => {}
+                            }
+                        }
+                        while fatal.is_none() && !pending_drop_glue.is_empty() {
+                            let frontier = std::mem::take(&mut pending_drop_glue)
+                                .into_iter()
+                                .filter(|ty| !visited_drop_glue.contains(ty))
+                                .collect::<Vec<_>>();
+                            if frontier.is_empty() {
+                                break;
+                            }
+                            let terminals = context.query_registered_batch(
+                                &drop_glues_for_body_reachability,
+                                frontier.iter().cloned().map(|ty| {
+                                    crate::type_queries::TypeQueryKey {
+                                        ty,
+                                        configuration: key.configuration.clone(),
+                                    }
+                                }),
+                            )?;
+                            for (ty, terminal) in frontier.into_iter().zip(terminals) {
+                                visited_drop_glue.insert(ty.clone());
+                                let rue_query::QueryOutcome::Success(value) = terminal.outcome()
+                                else {
+                                    unreachable!("DropGlue publishes typed values")
+                                };
+                                match value {
+                                    crate::type_queries::DropGlueValue::Available(glue) => {
+                                        if !glue.required {
+                                            continue;
+                                        }
+                                        demanded_drop_glue_plans
+                                            .insert(ty.clone(), glue.as_ref().clone());
+                                        demanded_drop_glue.insert(ty);
+                                        pending_drop_glue.extend(glue.nested.iter().cloned());
+                                        if let Some(destructor) = &glue.destructor {
+                                            pending.insert(destructor.clone());
+                                        }
+                                    }
+                                    crate::type_queries::DropGlueValue::Failure(failure) => {
+                                        fatal = Some(
+                                            crate::body_query::BodyClosureFatal::TypeQuery {
+                                                ty: Some(ty),
+                                                detail: Arc::from(format!(
+                                                    "drop glue: {failure:?}"
+                                                )),
+                                            },
+                                        );
+                                        break;
+                                    }
+                                }
                             }
                         }
                     }
@@ -11821,6 +13487,11 @@ impl RevisionedQueryDatabase {
                         || parked_toolchain.is_some();
                     let output = crate::body_query::BodyReachabilityOutput {
                         reached: reached.into(),
+                        demanded_drop_glue: demanded_drop_glue.into_iter().collect::<Vec<_>>().into(),
+                        demanded_drop_glue_plans: demanded_drop_glue_plans
+                            .into_iter()
+                            .collect::<Vec<_>>()
+                            .into(),
                         scheduling_errors: scheduling_errors.into(),
                         fatal,
                         parked_toolchain,
@@ -12004,6 +13675,8 @@ impl RevisionedQueryDatabase {
                     }
                     let output = crate::body_query::BodyClosureOutput {
                         reached: reachability.reached.clone(),
+                        demanded_drop_glue: reachability.demanded_drop_glue.clone(),
+                        demanded_drop_glue_plans: reachability.demanded_drop_glue_plans.clone(),
                         bodies: bodies.into(),
                         scheduling_errors: reachability.scheduling_errors.clone(),
                         fatal,
@@ -12274,6 +13947,11 @@ impl RevisionedQueryDatabase {
             declaration_imports,
             semantic_nucleus,
             declaration_semantics_projection,
+            type_shapes,
+            type_facts,
+            layouts,
+            call_abis,
+            drop_glues,
             lookup_names,
             lookup_imports,
             #[cfg(test)]
@@ -26436,6 +28114,634 @@ fn main() -> i32 {
         )
     }
 
+    fn named_type_instance(
+        module: &ModuleId,
+        name: &str,
+        kind: crate::StableDefinitionKind,
+    ) -> crate::TypeInstanceKey {
+        crate::TypeInstanceKey::Nominal(crate::NominalInstanceKey::Named(
+            crate::StableDefinitionKey::from_stable_parts(
+                module.clone(),
+                crate::StableDefinitionNamespace::Type,
+                kind,
+                name,
+                None,
+            ),
+        ))
+    }
+
+    fn request_layout(
+        database: &RevisionedQueryDatabase,
+        revision: Revision,
+        ty: crate::TypeInstanceKey,
+    ) -> QueryRequestAttempt<crate::type_queries::LayoutValue> {
+        request_layout_for_target(database, revision, ty, crate::Target::X86_64Linux)
+    }
+
+    fn request_layout_for_target(
+        database: &RevisionedQueryDatabase,
+        revision: Revision,
+        ty: crate::TypeInstanceKey,
+        target: crate::Target,
+    ) -> QueryRequestAttempt<crate::type_queries::LayoutValue> {
+        database.runtime.request_registered(
+            &database.layouts,
+            revision,
+            crate::type_queries::TypeQueryKey {
+                ty,
+                configuration: crate::semantic_query_nucleus::SemanticQueryConfiguration {
+                    target,
+                    preview_features: crate::StablePreviewFeatures::new(
+                        &crate::PreviewFeatures::default(),
+                    ),
+                },
+            },
+            CancellationToken::new(),
+        )
+    }
+
+    fn assert_layout_parity(
+        canonical: &crate::type_queries::CanonicalLayout,
+        live: &rue_air::Layout,
+    ) {
+        use crate::type_queries::CanonicalLayoutKind as C;
+        use rue_air::LayoutKind as L;
+        assert_eq!(
+            (canonical.size, canonical.alignment, canonical.stride),
+            (live.size, live.alignment, live.stride)
+        );
+        match (&canonical.kind, &live.kind) {
+            (
+                C::Array {
+                    element: Some(canonical_element),
+                    count: canonical_count,
+                },
+                L::Array {
+                    element: live_element,
+                    count: live_count,
+                },
+            ) => {
+                assert_eq!(canonical_count, live_count);
+                assert_layout_parity(canonical_element, live_element);
+            }
+            (
+                C::Struct {
+                    field_offsets,
+                    padding_ranges,
+                },
+                L::Struct {
+                    field_offsets: live_offsets,
+                    padding_ranges: live_padding,
+                },
+            ) => {
+                assert_eq!(field_offsets.as_ref(), live_offsets);
+                assert_eq!(padding_ranges.as_ref(), live_padding);
+            }
+            (
+                C::Enum {
+                    tag_size,
+                    payload_offset,
+                    variants,
+                },
+                L::Enum {
+                    tag,
+                    payload_offset: live_payload_offset,
+                    variants: live_variants,
+                },
+            ) => {
+                assert_eq!(*tag_size, tag.size);
+                assert_eq!(payload_offset, live_payload_offset);
+                assert_eq!(
+                    variants
+                        .iter()
+                        .map(|variant| variant.to_vec())
+                        .collect::<Vec<_>>(),
+                    *live_variants
+                );
+            }
+            (C::Scalar, L::Scalar) => {}
+            (canonical, live) => panic!("layout kind mismatch: {canonical:?} != {live:?}"),
+        }
+    }
+
+    #[test]
+    fn canonical_layout_matches_frozen_pool_for_padding_nested_arrays_and_enums() {
+        use lasso::ThreadedRodeo;
+        use rue_air::{EnumDef, StructDef, StructField, Type, TypeInternPool};
+
+        let source = source_snapshot(
+            &[(
+                1,
+                "/main.rue",
+                "main.rue",
+                "struct Padded { first: u8, aligned: u64, tail: u16 }\n\
+                 enum Choice { Small(u8, u64), Wide(u32, u16, u64) }",
+            )],
+            1,
+        );
+        let module = ModuleId::from_logical_path("main.rue").unwrap();
+        let padded_key =
+            named_type_instance(&module, "Padded", crate::StableDefinitionKind::Struct);
+        let choice_key = named_type_instance(&module, "Choice", crate::StableDefinitionKind::Enum);
+        let inner_array_key = crate::TypeInstanceKey::Array {
+            element: Box::new(padded_key.clone()),
+            len: 2,
+        };
+        let outer_array_key = crate::TypeInstanceKey::Array {
+            element: Box::new(inner_array_key),
+            len: 3,
+        };
+
+        let pool = TypeInternPool::new();
+        let interner = ThreadedRodeo::new();
+        let padded_id = pool
+            .register_struct(
+                interner.get_or_intern("Padded"),
+                StructDef {
+                    name: "Padded".into(),
+                    fields: vec![
+                        StructField {
+                            name: "first".into(),
+                            ty: Type::U8,
+                        },
+                        StructField {
+                            name: "aligned".into(),
+                            ty: Type::U64,
+                        },
+                        StructField {
+                            name: "tail".into(),
+                            ty: Type::U16,
+                        },
+                    ],
+                    is_copy: false,
+                    is_linear: false,
+                    destructor: None,
+                    is_builtin: false,
+                    is_pub: false,
+                    file_id: rue_span::FileId::DEFAULT,
+                },
+            )
+            .0;
+        let padded_ty = Type::new_struct(padded_id);
+        let inner_array = pool.intern_array_from_type(padded_ty, 2);
+        let outer_array = pool.intern_array_from_type(Type::new_array(inner_array), 3);
+        let choice_id = pool
+            .register_enum(
+                interner.get_or_intern("Choice"),
+                EnumDef {
+                    name: "Choice".into(),
+                    variants: vec!["Small".into(), "Wide".into()],
+                    variant_payloads: vec![
+                        vec![Type::U8, Type::U64],
+                        vec![Type::U32, Type::U16, Type::U64],
+                    ],
+                    is_pub: false,
+                    file_id: rue_span::FileId::DEFAULT,
+                },
+            )
+            .0;
+        let pool = pool.freeze();
+
+        let mut database = RevisionedQueryDatabase::default();
+        let revision = revision_for(&mut database, &source);
+        for target in [crate::Target::X86_64Linux, crate::Target::Aarch64Linux] {
+            for (stable, live) in [
+                (padded_key.clone(), padded_ty),
+                (outer_array_key.clone(), Type::new_array(outer_array)),
+                (choice_key.clone(), Type::new_enum(choice_id)),
+            ] {
+                let attempt = request_layout_for_target(&database, revision, stable, target);
+                let terminal = attempt.terminal().unwrap();
+                let rue_query::QueryOutcome::Success(crate::type_queries::LayoutValue::Available(
+                    canonical,
+                )) = terminal.outcome()
+                else {
+                    panic!("layout query failed: {terminal:?}");
+                };
+                assert_layout_parity(canonical, &pool.layout(live));
+            }
+        }
+    }
+
+    #[test]
+    fn layout_observes_only_structural_by_value_dependencies() {
+        let module = ModuleId::from_logical_path("main.rue").unwrap();
+        let source = |text| source_snapshot(&[(1, "/main.rue", "main.rue", text)], 1);
+        let first = source("struct Foo { value: i64 }");
+        let destructor_only = source("struct Foo { value: i64 }\ndrop fn Foo(self) {}");
+        let linearity_only = source("linear struct Foo { value: i64 }\ndrop fn Foo(self) {}");
+        let shape_edit =
+            source("linear struct Foo { value: i64, extra: i64 }\ndrop fn Foo(self) {}");
+        let foo = named_type_instance(&module, "Foo", crate::StableDefinitionKind::Struct);
+        let pointer = crate::TypeInstanceKey::PtrConst(Box::new(foo.clone()));
+        let slice = crate::TypeInstanceKey::Slice {
+            element: Box::new(foo.clone()),
+            name: Arc::from("FooSlice"),
+        };
+        let zero_array = crate::TypeInstanceKey::Array {
+            element: Box::new(foo.clone()),
+            len: 0,
+        };
+        let mut database = RevisionedQueryDatabase::default();
+
+        let first_revision = revision_for(&mut database, &first);
+        let cold = request_layout(&database, first_revision, foo.clone());
+        let cold_stamp = cold.terminal().unwrap().stamp();
+        assert_eq!(cold.execution(), RequestExecution::Computed);
+        for ty in [pointer.clone(), slice.clone(), zero_array.clone()] {
+            assert_eq!(
+                request_layout(&database, first_revision, ty).execution(),
+                RequestExecution::Computed
+            );
+        }
+
+        let destructor_revision = revision_for(&mut database, &destructor_only);
+        let destructor = request_layout(&database, destructor_revision, foo.clone());
+        assert_eq!(destructor.execution(), RequestExecution::Reused);
+        assert_eq!(destructor.terminal().unwrap().stamp(), cold_stamp);
+
+        let linear_revision = revision_for(&mut database, &linearity_only);
+        let linear = request_layout(&database, linear_revision, foo.clone());
+        assert_eq!(linear.execution(), RequestExecution::Reused);
+        assert_eq!(linear.terminal().unwrap().stamp(), cold_stamp);
+
+        let shape_revision = revision_for(&mut database, &shape_edit);
+        let shape = request_layout(&database, shape_revision, foo);
+        assert_eq!(shape.execution(), RequestExecution::Computed);
+        assert_ne!(shape.terminal().unwrap().stamp(), cold_stamp);
+        for ty in [pointer, slice, zero_array] {
+            assert_eq!(
+                request_layout(&database, shape_revision, ty).execution(),
+                RequestExecution::Reused,
+                "non-by-value containment must not observe the element edit"
+            );
+        }
+    }
+
+    fn request_call_abi(
+        database: &RevisionedQueryDatabase,
+        revision: Revision,
+        callable: crate::FunctionInstanceKey,
+        target: crate::Target,
+    ) -> crate::type_queries::CallAbiFacts {
+        let attempt = database.runtime.request_registered(
+            &database.call_abis,
+            revision,
+            crate::type_queries::CallAbiQueryKey {
+                callable,
+                configuration: crate::semantic_query_nucleus::SemanticQueryConfiguration {
+                    target,
+                    preview_features: crate::StablePreviewFeatures::new(
+                        &crate::PreviewFeatures::from([rue_error::PreviewFeature::CFfi]),
+                    ),
+                },
+            },
+            CancellationToken::new(),
+        );
+        let terminal = attempt.terminal().unwrap();
+        let rue_query::QueryOutcome::Success(crate::type_queries::CallAbiValue::Available(facts)) =
+            terminal.outcome()
+        else {
+            panic!("call ABI query failed: {terminal:?}");
+        };
+        facts.clone()
+    }
+
+    #[test]
+    fn call_abi_classifies_native_target_c_named_destructor_and_drop_glue_on_both_targets() {
+        use crate::type_queries::{
+            CallAbiArgumentClass as A, CallAbiConvention as C, CallAbiReturnClass as R,
+        };
+        let source = source_snapshot(
+            &[(
+                1,
+                "/main.rue",
+                "main.rue",
+                "fn native(value: [u64; 7]) -> [u64; 7] { value }\n\
+                 extern \"C\" { fn foreign(value: u32) -> u32; }\n\
+                 pub extern \"C\" fn exported(value: u32) -> u32 { value }\n\
+                 struct Owner { value: i64 }\n\
+                 drop fn Owner(self) {}",
+            )],
+            1,
+        );
+        let module = ModuleId::from_logical_path("main.rue").unwrap();
+        let mut database = RevisionedQueryDatabase::default();
+        let revision = revision_for(&mut database, &source);
+        let native = free_function_instance(&module, "native");
+        let foreign = free_function_instance(&module, "foreign");
+        let exported = free_function_instance(&module, "exported");
+        let owner = named_type_instance(&module, "Owner", crate::StableDefinitionKind::Struct);
+        let destructor =
+            crate::FunctionInstanceKey::Definition(crate::StableDefinitionKey::from_stable_parts(
+                module,
+                crate::StableDefinitionNamespace::Destructor,
+                crate::StableDefinitionKind::Destructor,
+                "Owner",
+                Some((crate::StableDefinitionKind::Struct, Arc::from("Owner"))),
+            ));
+        for target in [crate::Target::X86_64Linux, crate::Target::Aarch64Linux] {
+            let native = request_call_abi(&database, revision, native.clone(), target);
+            assert_eq!(native.convention, C::Native);
+            assert_eq!(
+                native.return_class,
+                if target == crate::Target::X86_64Linux {
+                    R::NativeIndirect { slots: 7 }
+                } else {
+                    R::NativeRegisters { slots: 7 }
+                }
+            );
+
+            let foreign = request_call_abi(&database, revision, foreign.clone(), target);
+            assert_eq!(
+                foreign.convention,
+                C::TargetC(if target == crate::Target::X86_64Linux {
+                    rue_air::TargetCAbiFlavor::SysVAmd64
+                } else {
+                    rue_air::TargetCAbiFlavor::Aapcs64
+                })
+            );
+            assert_eq!(
+                foreign.return_class,
+                R::Scalar {
+                    extension: rue_air::ScalarAbiExtension::Unsigned { from_bits: 32 }
+                }
+            );
+            assert!(matches!(
+                foreign.arguments[0].class,
+                A::CScalar {
+                    extension: rue_air::ScalarAbiExtension::Unsigned { from_bits: 32 }
+                }
+            ));
+
+            let exported = request_call_abi(&database, revision, exported.clone(), target);
+            assert_eq!(exported.convention, C::Native);
+            assert_eq!(
+                exported.return_class,
+                R::Scalar {
+                    extension: rue_air::ScalarAbiExtension::None
+                }
+            );
+
+            let destructor = request_call_abi(&database, revision, destructor.clone(), target);
+            assert_eq!(destructor.convention, C::Native);
+            assert_eq!(destructor.arguments.len(), 1);
+            assert!(matches!(
+                destructor.arguments[0].class,
+                A::NativeDirect { slots: 1 }
+            ));
+
+            let glue = request_call_abi(
+                &database,
+                revision,
+                crate::FunctionInstanceKey::DropGlue(Box::new(owner.clone())),
+                target,
+            );
+            assert_eq!(glue.convention, C::Native);
+            assert_eq!(glue.return_class, R::ZeroSized);
+            assert!(matches!(
+                glue.arguments[0].class,
+                A::NativeDirect { slots: 1 }
+            ));
+        }
+    }
+
+    #[test]
+    fn call_abi_resolves_value_specialized_array_layout_on_both_targets() {
+        use crate::type_queries::{
+            CallAbiArgumentClass as A, CallAbiConvention as C, CallAbiReturnClass as R,
+        };
+        let source = source_snapshot(
+            &[(
+                1,
+                "/main.rue",
+                "main.rue",
+                "fn named(comptime N: i32, value: u64) -> u64 { value + N }\n\
+                 fn sized(comptime N: i32, value: [u64; N]) -> [u64; N] { value }",
+            )],
+            1,
+        );
+        let module = ModuleId::from_logical_path("main.rue").unwrap();
+        let named = free_function_instance(&module, "named");
+        let callable = crate::FunctionInstanceKey::Specialization {
+            base: Box::new(free_function_instance(&module, "sized")),
+            arguments: crate::CanonicalArguments {
+                types: Arc::from([]),
+                values: Arc::from([crate::CanonicalArgumentValue::Integer(7)]),
+            },
+        };
+        let mut database = RevisionedQueryDatabase::default();
+        let revision = revision_for(&mut database, &source);
+        for target in [crate::Target::X86_64Linux, crate::Target::Aarch64Linux] {
+            let named = request_call_abi(&database, revision, named.clone(), target);
+            assert_eq!(named.convention, C::Native);
+            assert_eq!(
+                named.return_class,
+                R::Scalar {
+                    extension: rue_air::ScalarAbiExtension::None
+                }
+            );
+            assert_eq!(named.arguments.len(), 2);
+            assert!(
+                named
+                    .arguments
+                    .iter()
+                    .all(|argument| matches!(argument.class, A::NativeDirect { slots: 1 }))
+            );
+
+            let facts = request_call_abi(&database, revision, callable.clone(), target);
+            assert_eq!(facts.convention, C::Native);
+            assert_eq!(
+                facts.return_class,
+                if target == crate::Target::X86_64Linux {
+                    R::NativeIndirect { slots: 7 }
+                } else {
+                    R::NativeRegisters { slots: 7 }
+                }
+            );
+            assert_eq!(facts.arguments.len(), 2);
+            assert!(matches!(
+                facts.arguments[0].class,
+                A::NativeDirect { slots: 1 }
+            ));
+            assert_eq!(facts.arguments[0].value_slots, 1);
+            assert!(matches!(
+                facts.arguments[1].class,
+                A::NativeDirect { slots: 7 }
+            ));
+            assert_eq!(facts.arguments[1].value_slots, 7);
+        }
+    }
+
+    #[test]
+    fn call_abi_derives_anonymous_destructor_signature_from_its_exact_producer() {
+        use crate::type_queries::{
+            CallAbiArgumentClass as A, CallAbiConvention as C, CallAbiReturnClass as R,
+        };
+        let source = source_snapshot(
+            &[(
+                1,
+                "/main.rue",
+                "main.rue",
+                "fn Box() -> type { struct { value: i64, drop fn(self) {} } }",
+            )],
+            1,
+        );
+        let module = ModuleId::from_logical_path("main.rue").unwrap();
+        let producer = crate::FunctionInstanceKey::Specialization {
+            base: Box::new(free_function_instance(&module, "Box")),
+            arguments: crate::CanonicalArguments::default(),
+        };
+        let configuration = semantic_configuration();
+        let mut database = RevisionedQueryDatabase::default();
+        let revision = revision_for(&mut database, &source);
+        let produced = database.runtime.request_registered(
+            &database.body_produced_anonymous,
+            revision,
+            crate::body_query::BodyQueryKey {
+                instance: producer,
+                configuration,
+            },
+            CancellationToken::new(),
+        );
+        let terminal = produced.terminal().unwrap();
+        let rue_query::QueryOutcome::Success(crate::body_query::ProducedAnonymous::Produced(
+            produced,
+        )) = terminal.outcome()
+        else {
+            panic!("anonymous producer failed: {terminal:?}");
+        };
+        let owner = crate::TypeInstanceKey::Nominal(crate::NominalInstanceKey::Anonymous(
+            produced.0[0].identity.clone(),
+        ));
+        let callable = crate::FunctionInstanceKey::AnonymousMember {
+            owner: Box::new(owner),
+            member: crate::AnonymousMemberKey {
+                kind: crate::AnonymousMemberKind::Destructor,
+                name: Arc::from("__drop"),
+            },
+        };
+        for target in [crate::Target::X86_64Linux, crate::Target::Aarch64Linux] {
+            let facts = request_call_abi(&database, revision, callable.clone(), target);
+            assert_eq!(facts.convention, C::Native);
+            assert_eq!(facts.return_class, R::ZeroSized);
+            assert_eq!(facts.arguments.len(), 1);
+            assert!(matches!(
+                facts.arguments[0].class,
+                A::NativeDirect { slots: 1 }
+            ));
+        }
+    }
+
+    #[test]
+    fn anonymous_producer_preserves_a_deterministic_body_diagnostic_as_a_typed_failure() {
+        let source = source_snapshot(
+            &[(
+                1,
+                "/main.rue",
+                "main.rue",
+                "fn Bad() -> type {\n\
+                     struct {\n\
+                         x: i32,\n\
+                         fn get(self) -> i32 { self.x }\n\
+                         fn get(self) -> i32 { 0 }\n\
+                     }\n\
+                 }\n\
+                 fn main() -> i32 {\n\
+                     let B = Bad();\n\
+                     0\n\
+                 }",
+            )],
+            1,
+        );
+        let module = ModuleId::from_logical_path("main.rue").unwrap();
+        let mut database = RevisionedQueryDatabase::default();
+        let revision = revision_for(&mut database, &source);
+
+        let request = database
+            .body_closure(
+                revision,
+                crate::body_query::BodyClosureQueryKey {
+                    modules: Arc::from([module.clone()]),
+                    roots: Arc::from([free_function_instance(&module, "main")]),
+                    configuration: semantic_configuration(),
+                },
+                CancellationToken::new(),
+            )
+            .expect("a deterministic producer diagnostic is not query cancellation");
+        let rue_query::QueryOutcome::Success(output) = request.terminal.outcome() else {
+            unreachable!("BodyClosure publishes typed values")
+        };
+        assert!(output.bodies.iter().any(|body| matches!(
+            body.bundle.outcome(),
+            rue_query::QueryOutcome::Success(crate::body_query::BodyAnalysisBundle {
+                transaction: crate::body_query::BodyTransaction::DeterministicFailure { .. },
+                ..
+            })
+        )));
+    }
+
+    fn request_drop_glue(
+        database: &RevisionedQueryDatabase,
+        revision: Revision,
+        ty: crate::TypeInstanceKey,
+    ) -> QueryRequestAttempt<crate::type_queries::DropGlueValue> {
+        database.runtime.request_registered(
+            &database.drop_glues,
+            revision,
+            crate::type_queries::TypeQueryKey {
+                ty,
+                configuration: semantic_configuration(),
+            },
+            CancellationToken::new(),
+        )
+    }
+
+    #[test]
+    fn drop_glue_plan_is_cold_reusable_and_changes_with_order_not_only_nested_set() {
+        let module = ModuleId::from_logical_path("main.rue").unwrap();
+        let source = |text| source_snapshot(&[(1, "/main.rue", "main.rue", text)], 1);
+        let first = source(
+            "struct Child { value: i64 }\n\
+             drop fn Child(self) {}\n\
+             struct Outer { first: Child, spacer: i64, second: Child }",
+        );
+        let reordered = source(
+            "struct Child { value: i64 }\n\
+             drop fn Child(self) {}\n\
+             struct Outer { spacer: i64, first: Child, second: Child }",
+        );
+        let outer = named_type_instance(&module, "Outer", crate::StableDefinitionKind::Struct);
+        let mut database = RevisionedQueryDatabase::default();
+        let first_revision = revision_for(&mut database, &first);
+        let cold = request_drop_glue(&database, first_revision, outer.clone());
+        assert_eq!(cold.execution(), RequestExecution::Computed);
+        let cold_stamp = cold.terminal().unwrap().stamp();
+        let reused = request_drop_glue(&database, first_revision, outer.clone());
+        assert_eq!(reused.execution(), RequestExecution::Reused);
+        assert_eq!(reused.terminal().unwrap().stamp(), cold_stamp);
+
+        let reordered_revision = revision_for(&mut database, &reordered);
+        let changed = request_drop_glue(&database, reordered_revision, outer);
+        assert_eq!(changed.execution(), RequestExecution::Computed);
+        assert_ne!(changed.terminal().unwrap().stamp(), cold_stamp);
+        let rue_query::QueryOutcome::Success(crate::type_queries::DropGlueValue::Available(facts)) =
+            changed.terminal().unwrap().outcome()
+        else {
+            panic!("drop-glue plan did not publish");
+        };
+        let crate::type_queries::DropGluePlan::Struct { fields } = &facts.plan else {
+            panic!("outer must have a struct plan");
+        };
+        assert_eq!(
+            fields
+                .iter()
+                .map(|field| (field.name.as_ref(), field.drop))
+                .collect::<Vec<_>>(),
+            [("spacer", false), ("first", true), ("second", true)]
+        );
+    }
+
     fn request_lookup_name(
         database: &RevisionedQueryDatabase,
         revision: Revision,
@@ -32202,6 +34508,9 @@ fn main() -> i32 {
                  fn b() -> i32 { 2 }\n\
                  fn c() -> i32 { 3 }\n\
                  fn d() -> i32 { 4 }\n\
+                 struct Dead { value: i64 }\n\
+                 drop fn Dead(self) { missing_named(); }\n\
+                 fn DeadAnonymous() -> type { struct { value: i64, drop fn(self) { missing_anonymous(); } } }\n\
                  fn main() -> i32 { a() + b() + c() + d() }\n",
             )],
             1,
@@ -32226,10 +34535,22 @@ fn main() -> i32 {
             let rue_query::QueryOutcome::Success(output) = request.terminal.outcome() else {
                 unreachable!("BodyClosure publishes typed values")
             };
+            assert_eq!(
+                output.reached.len(),
+                5,
+                "invalid unreachable destructors must not become roots"
+            );
+            assert!(
+                output.demanded_drop_glue_plans.is_empty(),
+                "unowned unreachable types must demand no glue"
+            );
+            assert!(output.scheduling_errors.is_empty());
+            assert!(output.fatal.is_none());
             (
                 output.reached.to_vec(),
                 output.scheduling_errors.clone(),
                 output.fatal.clone(),
+                output.demanded_drop_glue_plans.clone(),
                 work,
             )
         };

--- a/crates/rue-compiler/src/session.rs
+++ b/crates/rue-compiler/src/session.rs
@@ -1428,255 +1428,6 @@ fn stable_producer_definition_root(
     }
 }
 
-fn enqueue_owned_destructor_closure(
-    ty: &crate::TypeInstanceKey,
-    definitions: &crate::BoundDefinitionSet,
-    declarations: &[crate::durable_semantics::DurableDeclarationSemantic],
-    produced_anonymous: &BTreeMap<
-        crate::AnonymousNominalKey,
-        crate::durable_semantics::DurableAnonymousNominal,
-    >,
-    declaration_anonymous: &[crate::durable_semantics::DurableAnonymousNominal],
-    pending: &mut std::collections::BTreeSet<crate::FunctionInstanceKey>,
-) {
-    fn named(
-        owner: &crate::StableDefinitionKey,
-        definitions: &crate::BoundDefinitionSet,
-        declarations: &[crate::durable_semantics::DurableDeclarationSemantic],
-        produced_anonymous: &BTreeMap<
-            crate::AnonymousNominalKey,
-            crate::durable_semantics::DurableAnonymousNominal,
-        >,
-        declaration_anonymous: &[crate::durable_semantics::DurableAnonymousNominal],
-        pending: &mut std::collections::BTreeSet<crate::FunctionInstanceKey>,
-        visited: &mut std::collections::BTreeSet<crate::TypeInstanceKey>,
-    ) {
-        let identity =
-            crate::TypeInstanceKey::Nominal(crate::NominalInstanceKey::Named(owner.clone()));
-        if !visited.insert(identity) {
-            return;
-        }
-        for record in definitions.definitions() {
-            let candidate = record.stable_key();
-            let Some(candidate_owner) = candidate.owner() else {
-                continue;
-            };
-            if candidate.kind() == crate::StableDefinitionKind::Destructor
-                && candidate_owner.module() == owner.module()
-                && candidate_owner.kind() == owner.kind()
-                && candidate_owner.name() == owner.name()
-            {
-                pending.insert(crate::FunctionInstanceKey::Definition(candidate.clone()));
-            }
-        }
-        let Some(declaration) = declarations
-            .iter()
-            .find(|declaration| declaration.key == *owner)
-        else {
-            return;
-        };
-        match &declaration.payload {
-            crate::durable_semantics::DurableDeclarationPayload::Struct { fields, .. } => {
-                for (_, field) in fields.iter() {
-                    durable(
-                        field,
-                        definitions,
-                        declarations,
-                        produced_anonymous,
-                        declaration_anonymous,
-                        pending,
-                        visited,
-                    );
-                }
-            }
-            crate::durable_semantics::DurableDeclarationPayload::Enum { variants } => {
-                for (_, fields) in variants.iter() {
-                    for field in fields.iter() {
-                        durable(
-                            field,
-                            definitions,
-                            declarations,
-                            produced_anonymous,
-                            declaration_anonymous,
-                            pending,
-                            visited,
-                        );
-                    }
-                }
-            }
-            _ => {}
-        }
-    }
-
-    fn anonymous(
-        owner: &crate::AnonymousNominalKey,
-        definitions: &crate::BoundDefinitionSet,
-        declarations: &[crate::durable_semantics::DurableDeclarationSemantic],
-        produced_anonymous: &BTreeMap<
-            crate::AnonymousNominalKey,
-            crate::durable_semantics::DurableAnonymousNominal,
-        >,
-        declaration_anonymous: &[crate::durable_semantics::DurableAnonymousNominal],
-        pending: &mut std::collections::BTreeSet<crate::FunctionInstanceKey>,
-        visited: &mut std::collections::BTreeSet<crate::TypeInstanceKey>,
-    ) {
-        let identity =
-            crate::TypeInstanceKey::Nominal(crate::NominalInstanceKey::Anonymous(owner.clone()));
-        if !visited.insert(identity.clone()) {
-            return;
-        }
-        let Some(nominal) = produced_anonymous.get(owner).or_else(|| {
-            declaration_anonymous
-                .iter()
-                .find(|nominal| nominal.identity == *owner)
-        }) else {
-            return;
-        };
-        match &nominal.shape {
-            crate::durable_semantics::DurableAnonymousNominalShape::Struct { fields, methods } => {
-                if methods
-                    .iter()
-                    .any(|method| method.has_self && method.name.as_ref() == "__drop")
-                {
-                    pending.insert(crate::FunctionInstanceKey::AnonymousMember {
-                        owner: Box::new(identity),
-                        member: crate::AnonymousMemberKey {
-                            kind: crate::AnonymousMemberKind::Destructor,
-                            name: Arc::from("__drop"),
-                        },
-                    });
-                }
-                for (_, field) in fields.iter() {
-                    durable(
-                        field,
-                        definitions,
-                        declarations,
-                        produced_anonymous,
-                        declaration_anonymous,
-                        pending,
-                        visited,
-                    );
-                }
-            }
-            crate::durable_semantics::DurableAnonymousNominalShape::Enum { variants } => {
-                for (_, fields) in variants.iter() {
-                    for field in fields.iter() {
-                        durable(
-                            field,
-                            definitions,
-                            declarations,
-                            produced_anonymous,
-                            declaration_anonymous,
-                            pending,
-                            visited,
-                        );
-                    }
-                }
-            }
-        }
-    }
-
-    fn durable(
-        ty: &crate::durable_semantics::DurableType,
-        definitions: &crate::BoundDefinitionSet,
-        declarations: &[crate::durable_semantics::DurableDeclarationSemantic],
-        produced_anonymous: &BTreeMap<
-            crate::AnonymousNominalKey,
-            crate::durable_semantics::DurableAnonymousNominal,
-        >,
-        declaration_anonymous: &[crate::durable_semantics::DurableAnonymousNominal],
-        pending: &mut std::collections::BTreeSet<crate::FunctionInstanceKey>,
-        visited: &mut std::collections::BTreeSet<crate::TypeInstanceKey>,
-    ) {
-        match ty {
-            crate::durable_semantics::DurableType::Nominal(owner) => named(
-                owner,
-                definitions,
-                declarations,
-                produced_anonymous,
-                declaration_anonymous,
-                pending,
-                visited,
-            ),
-            crate::durable_semantics::DurableType::AnonymousNominal(owner) => anonymous(
-                owner,
-                definitions,
-                declarations,
-                produced_anonymous,
-                declaration_anonymous,
-                pending,
-                visited,
-            ),
-            crate::durable_semantics::DurableType::Array { element, .. } => durable(
-                element,
-                definitions,
-                declarations,
-                produced_anonymous,
-                declaration_anonymous,
-                pending,
-                visited,
-            ),
-            _ => {}
-        }
-    }
-
-    fn instance(
-        ty: &crate::TypeInstanceKey,
-        definitions: &crate::BoundDefinitionSet,
-        declarations: &[crate::durable_semantics::DurableDeclarationSemantic],
-        produced_anonymous: &BTreeMap<
-            crate::AnonymousNominalKey,
-            crate::durable_semantics::DurableAnonymousNominal,
-        >,
-        declaration_anonymous: &[crate::durable_semantics::DurableAnonymousNominal],
-        pending: &mut std::collections::BTreeSet<crate::FunctionInstanceKey>,
-        visited: &mut std::collections::BTreeSet<crate::TypeInstanceKey>,
-    ) {
-        match ty {
-            crate::TypeInstanceKey::Nominal(crate::NominalInstanceKey::Named(owner)) => named(
-                owner,
-                definitions,
-                declarations,
-                produced_anonymous,
-                declaration_anonymous,
-                pending,
-                visited,
-            ),
-            crate::TypeInstanceKey::Nominal(crate::NominalInstanceKey::Anonymous(owner)) => {
-                anonymous(
-                    owner,
-                    definitions,
-                    declarations,
-                    produced_anonymous,
-                    declaration_anonymous,
-                    pending,
-                    visited,
-                );
-            }
-            crate::TypeInstanceKey::Array { element, .. } => instance(
-                element,
-                definitions,
-                declarations,
-                produced_anonymous,
-                declaration_anonymous,
-                pending,
-                visited,
-            ),
-            _ => {}
-        }
-    }
-
-    instance(
-        ty,
-        definitions,
-        declarations,
-        produced_anonymous,
-        declaration_anonymous,
-        pending,
-        &mut std::collections::BTreeSet::new(),
-    );
-}
-
 #[derive(Debug)]
 enum SemanticRequestControl {
     Compile(CompileErrors),
@@ -6625,6 +6376,10 @@ impl CompilerSession {
         let mut body_consulted_anonymous = BTreeMap::new();
         let mut body_query_errors = BTreeMap::new();
         let mut body_query_reference_cache = BTreeMap::new();
+        let mut demanded_drop_glue: Arc<[crate::TypeInstanceKey]> = Arc::from([]);
+        let mut demanded_drop_glue_plans: Arc<
+            [(crate::TypeInstanceKey, crate::type_queries::DropGlueFacts)],
+        > = Arc::from([]);
         // RUE-1027 production boundary: derive the reached callable frontier
         // serially from the references owned by each body transaction. Ordinary
         // call recursion is worklist state, never a query dependency cycle.
@@ -6638,10 +6393,9 @@ impl CompilerSession {
             let mut pending = std::collections::BTreeSet::new();
             for record in prepared_definitions.definitions().definitions() {
                 let stable = record.stable_key();
-                if (stable.kind() == crate::StableDefinitionKind::Function
+                if stable.kind() == crate::StableDefinitionKind::Function
                     && stable.name() == "main"
-                    && stable.module() == merged.ast().root())
-                    || stable.kind() == crate::StableDefinitionKind::Destructor
+                    && stable.module() == merged.ast().root()
                 {
                     pending.insert(crate::FunctionInstanceKey::Definition(stable.clone()));
                 }
@@ -6652,27 +6406,6 @@ impl CompilerSession {
                     .cloned()
                     .map(crate::FunctionInstanceKey::Definition),
             );
-            let no_body_produced_anonymous = BTreeMap::new();
-            for record in prepared_definitions.definitions().definitions() {
-                let stable = record.stable_key();
-                if matches!(
-                    stable.kind(),
-                    crate::StableDefinitionKind::Struct | crate::StableDefinitionKind::Enum
-                ) {
-                    enqueue_owned_destructor_closure(
-                        &crate::TypeInstanceKey::Nominal(crate::NominalInstanceKey::Named(
-                            stable.clone(),
-                        )),
-                        prepared_definitions.definitions(),
-                        query_declarations
-                            .as_deref()
-                            .expect("body traversal follows a successful declaration projection"),
-                        &no_body_produced_anonymous,
-                        &query_anonymous_nominals,
-                        &mut pending,
-                    );
-                }
-            }
             let roots = pending;
             let closure_request = match self.queries.revisioned.body_closure(
                 runtime_revision,
@@ -6697,6 +6430,8 @@ impl CompilerSession {
             else {
                 unreachable!("BodyClosure publishes typed values")
             };
+            demanded_drop_glue = closure_output.demanded_drop_glue.clone();
+            demanded_drop_glue_plans = closure_output.demanded_drop_glue_plans.clone();
             if let Some(park) = &closure_output.parked_toolchain {
                 return Err(SemanticRequestControl::Parked(Box::new(park.clone())));
             }
@@ -6732,6 +6467,14 @@ impl CompilerSession {
                     } => (
                         Some(instance.clone()),
                         well_known_option_resolution_diagnostics(merged.ast(), failure),
+                    ),
+                    crate::body_query::BodyClosureFatal::TypeQuery { ty, detail } => (
+                        roots.iter().next().cloned(),
+                        crate::CompileErrors::from(crate::CompileError::without_span(
+                            rue_error::ErrorKind::InternalError(format!(
+                                "canonical type query failed for {ty:?}: {detail}"
+                            )),
+                        )),
                     ),
                     crate::body_query::BodyClosureFatal::AnonymousDigestCollision {
                         digest,
@@ -7053,6 +6796,8 @@ impl CompilerSession {
                 durable_specialized_body_candidates,
                 durable_anonymous_body_candidates,
                 previous_cfg_cache.clone(),
+                demanded_drop_glue,
+                demanded_drop_glue_plans,
                 durable_body_work,
             )?;
             output.install_body_references(body_query_reference_cache);
@@ -17924,7 +17669,8 @@ fn main() -> i32 {
                         producers.insert(definition.name().to_owned());
                     }
                 }
-                crate::body_query::BodyReference::Type(ty) => {
+                crate::body_query::BodyReference::Type(ty)
+                | crate::body_query::BodyReference::DropGlue(ty) => {
                     let owner = crate::FunctionInstanceKey::DropGlue(Box::new(ty.clone()));
                     producers.extend(
                         crate::revisioned_query_database::collect_instance_anonymous_nominals(
@@ -18087,7 +17833,8 @@ fn main() -> i32 {
                             crate::FunctionInstanceKey::Definition(owner) if owner == definition
                         )
                     }
-                    crate::body_query::BodyReference::Type(_) => false,
+                    crate::body_query::BodyReference::Type(_)
+                    | crate::body_query::BodyReference::DropGlue(_) => false,
                 })
         );
     }

--- a/crates/rue-compiler/src/type_queries.rs
+++ b/crates/rue-compiler/src/type_queries.rs
@@ -1,0 +1,370 @@
+//! Canonical demand-driven type, layout, call-ABI, and drop-glue query values.
+//!
+//! These records deliberately use stable semantic identities.  Live `Type`
+//! handles and pool indexes are materialization details and never cross this
+//! boundary.
+
+use std::sync::Arc;
+
+use rue_query::QueryKey;
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub(crate) struct TypeQueryKey {
+    pub(crate) ty: crate::TypeInstanceKey,
+    pub(crate) configuration: crate::semantic_query_nucleus::SemanticQueryConfiguration,
+}
+
+impl QueryKey for TypeQueryKey {
+    fn stable_identity(&self) -> String {
+        format!(
+            "{:?};target={:?};preview={:?}",
+            self.ty, self.configuration.target, self.configuration.preview_features
+        )
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum TypeShape {
+    Scalar,
+    Pointer,
+    Slice,
+    Array {
+        element: crate::TypeInstanceKey,
+        len: u64,
+    },
+    Struct {
+        fields: Arc<[(Arc<str>, crate::TypeInstanceKey)]>,
+    },
+    Enum {
+        variants: Arc<[(Arc<str>, Arc<[crate::TypeInstanceKey]>)]>,
+    },
+    Opaque,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum TypeShapeValue {
+    Available(TypeShape),
+    Failure(TypeQueryFailure),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct TypeFacts {
+    pub(crate) is_copy: bool,
+    pub(crate) carries_linear: bool,
+    pub(crate) needs_drop: bool,
+    pub(crate) destructor: Option<crate::FunctionInstanceKey>,
+    /// Repeated for ownership consumers that need to enumerate children. The
+    /// canonical structural stamp is [`TypeShapeValue`]; layout never observes
+    /// this aggregate ownership value.
+    pub(crate) shape: TypeShape,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum TypeQueryFailure {
+    Unavailable(Arc<str>),
+    Invalid(Arc<str>),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum TypeFactsValue {
+    Available(Box<TypeFacts>),
+    Failure(TypeQueryFailure),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct CanonicalLayout {
+    pub(crate) size: u64,
+    pub(crate) alignment: u64,
+    pub(crate) stride: u64,
+    pub(crate) abi_slots: u32,
+    /// Whether the compact memory image is byte-for-byte identical to the
+    /// flattened eight-byte slot representation used by the native call ABI.
+    pub(crate) slot_identical: bool,
+    pub(crate) kind: CanonicalLayoutKind,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum CanonicalLayoutKind {
+    Scalar,
+    Pointer,
+    Slice,
+    Array {
+        element: Option<Box<CanonicalLayout>>,
+        count: u64,
+    },
+    Struct {
+        field_offsets: Arc<[u64]>,
+        padding_ranges: Arc<[rue_air::PaddingRange]>,
+    },
+    Enum {
+        tag_size: u64,
+        payload_offset: u64,
+        variants: Arc<[Arc<[u64]>]>,
+    },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum LayoutValue {
+    Available(CanonicalLayout),
+    Failure(TypeQueryFailure),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub(crate) struct CallAbiQueryKey {
+    pub(crate) callable: crate::FunctionInstanceKey,
+    pub(crate) configuration: crate::semantic_query_nucleus::SemanticQueryConfiguration,
+}
+
+impl QueryKey for CallAbiQueryKey {
+    fn stable_identity(&self) -> String {
+        format!(
+            "{:?};target={:?};preview={:?}",
+            self.callable, self.configuration.target, self.configuration.preview_features
+        )
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct CallAbiFacts {
+    pub(crate) convention: CallAbiConvention,
+    pub(crate) return_class: CallAbiReturnClass,
+    pub(crate) arguments: Arc<[CallAbiArgument]>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum CallAbiConvention {
+    Native,
+    TargetC(rue_air::TargetCAbiFlavor),
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum CallAbiReturnClass {
+    ZeroSized,
+    Scalar {
+        extension: rue_air::ScalarAbiExtension,
+    },
+    NativeRegisters {
+        slots: u32,
+    },
+    NativeIndirect {
+        slots: u32,
+    },
+    CIntegerRegisters {
+        eightbytes: u32,
+    },
+    CIndirect {
+        size: u32,
+        alignment: u32,
+    },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct CallAbiArgument {
+    pub(crate) mode: crate::durable_semantics::DurableParameterMode,
+    pub(crate) value_slots: u32,
+    pub(crate) class: CallAbiArgumentClass,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum CallAbiArgumentClass {
+    Omitted,
+    NativeDirect {
+        slots: u32,
+    },
+    NativeIndirect,
+    CScalar {
+        extension: rue_air::ScalarAbiExtension,
+    },
+    CIntegerRegisters {
+        eightbytes: u32,
+    },
+    CByValueStack {
+        size: u32,
+        alignment: u32,
+    },
+    CByReferenceCopy {
+        size: u32,
+        alignment: u32,
+    },
+    Reference,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum CallAbiValue {
+    Available(CallAbiFacts),
+    Failure(TypeQueryFailure),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct DropGlueFacts<D = crate::StableDefinitionKey, M = crate::ModuleId> {
+    pub(crate) required: bool,
+    pub(crate) synthesize: bool,
+    pub(crate) destructor: Option<rue_air::FunctionInstanceKey<D, M>>,
+    pub(crate) nested: Arc<[rue_air::TypeInstanceKey<D, M>]>,
+    pub(crate) plan: DropGluePlan<D, M>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum DropGluePlan<D = crate::StableDefinitionKey, M = crate::ModuleId> {
+    None,
+    Struct {
+        fields: Arc<[DropGlueField<D, M>]>,
+    },
+    Array {
+        element: rue_air::TypeInstanceKey<D, M>,
+        len: u64,
+        drop_element: bool,
+    },
+    Enum {
+        variants: Arc<[DropGlueVariant<D, M>]>,
+    },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct DropGlueField<D = crate::StableDefinitionKey, M = crate::ModuleId> {
+    pub(crate) name: Arc<str>,
+    pub(crate) ty: rue_air::TypeInstanceKey<D, M>,
+    pub(crate) drop: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct DropGlueVariant<D = crate::StableDefinitionKey, M = crate::ModuleId> {
+    pub(crate) name: Arc<str>,
+    pub(crate) fields: Arc<[DropGlueVariantField<D, M>]>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct DropGlueVariantField<D = crate::StableDefinitionKey, M = crate::ModuleId> {
+    pub(crate) ty: rue_air::TypeInstanceKey<D, M>,
+    pub(crate) drop: bool,
+}
+
+impl<D, M> DropGlueFacts<D, M> {
+    pub(crate) fn try_map_identities<D2, M2, E>(
+        &self,
+        definition: &impl Fn(&D) -> Result<D2, E>,
+        module: &impl Fn(&M) -> Result<M2, E>,
+    ) -> Result<DropGlueFacts<D2, M2>, E> {
+        let map_type =
+            |ty: &rue_air::TypeInstanceKey<D, M>| ty.try_map_identities(definition, module);
+        Ok(DropGlueFacts {
+            required: self.required,
+            synthesize: self.synthesize,
+            destructor: self
+                .destructor
+                .as_ref()
+                .map(|value| value.try_map_identities(definition, module))
+                .transpose()?,
+            nested: self
+                .nested
+                .iter()
+                .map(&map_type)
+                .collect::<Result<Vec<_>, _>>()?
+                .into(),
+            plan: match &self.plan {
+                DropGluePlan::None => DropGluePlan::None,
+                DropGluePlan::Struct { fields } => DropGluePlan::Struct {
+                    fields: fields
+                        .iter()
+                        .map(|field| {
+                            Ok(DropGlueField {
+                                name: field.name.clone(),
+                                ty: map_type(&field.ty)?,
+                                drop: field.drop,
+                            })
+                        })
+                        .collect::<Result<Vec<_>, E>>()?
+                        .into(),
+                },
+                DropGluePlan::Array {
+                    element,
+                    len,
+                    drop_element,
+                } => DropGluePlan::Array {
+                    element: map_type(element)?,
+                    len: *len,
+                    drop_element: *drop_element,
+                },
+                DropGluePlan::Enum { variants } => DropGluePlan::Enum {
+                    variants: variants
+                        .iter()
+                        .map(|variant| {
+                            Ok(DropGlueVariant {
+                                name: variant.name.clone(),
+                                fields: variant
+                                    .fields
+                                    .iter()
+                                    .map(|field| {
+                                        Ok(DropGlueVariantField {
+                                            ty: map_type(&field.ty)?,
+                                            drop: field.drop,
+                                        })
+                                    })
+                                    .collect::<Result<Vec<_>, E>>()?
+                                    .into(),
+                            })
+                        })
+                        .collect::<Result<Vec<_>, E>>()?
+                        .into(),
+                },
+            },
+        })
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum DropGlueValue {
+    Available(Box<DropGlueFacts>),
+    Failure(TypeQueryFailure),
+}
+
+pub(crate) fn type_instance(ty: &crate::durable_semantics::DurableType) -> crate::TypeInstanceKey {
+    use crate::durable_semantics::DurableType as T;
+    match ty {
+        T::I8 => crate::TypeInstanceKey::I8,
+        T::I16 => crate::TypeInstanceKey::I16,
+        T::I32 => crate::TypeInstanceKey::I32,
+        T::I64 => crate::TypeInstanceKey::I64,
+        T::U8 => crate::TypeInstanceKey::U8,
+        T::U16 => crate::TypeInstanceKey::U16,
+        T::U32 => crate::TypeInstanceKey::U32,
+        T::U64 => crate::TypeInstanceKey::U64,
+        T::Bool => crate::TypeInstanceKey::Bool,
+        T::Unit => crate::TypeInstanceKey::Unit,
+        T::Never => crate::TypeInstanceKey::Never,
+        T::ComptimeType => crate::TypeInstanceKey::ComptimeType,
+        T::BuiltinNominal { kind, name } => crate::TypeInstanceKey::BuiltinNominal {
+            kind: match kind {
+                rue_air::SemanticImportNominalKind::Struct => rue_air::AnonymousNominalKind::Struct,
+                rue_air::SemanticImportNominalKind::Enum => rue_air::AnonymousNominalKind::Enum,
+            },
+            name: name.clone(),
+        },
+        T::Nominal(definition) => {
+            crate::TypeInstanceKey::Nominal(crate::NominalInstanceKey::Named(definition.clone()))
+        }
+        T::AnonymousNominal(identity) => {
+            crate::TypeInstanceKey::Nominal(crate::NominalInstanceKey::Anonymous(identity.clone()))
+        }
+        T::Array { element, len } => crate::TypeInstanceKey::Array {
+            element: Box::new(type_instance(element)),
+            len: *len,
+        },
+        T::Slice { element, name } => crate::TypeInstanceKey::Slice {
+            element: Box::new(type_instance(element)),
+            name: name.clone(),
+        },
+        T::PtrConst(element) => crate::TypeInstanceKey::PtrConst(Box::new(type_instance(element))),
+        T::PtrMut(element) => crate::TypeInstanceKey::PtrMut(Box::new(type_instance(element))),
+        T::Module(module) => crate::TypeInstanceKey::Module(module.clone()),
+        T::GenericParameter(index) => crate::TypeInstanceKey::GenericParameter(*index),
+    }
+}
+
+pub(crate) fn align_to(value: u64, alignment: u64) -> u64 {
+    if alignment <= 1 {
+        value
+    } else {
+        value.saturating_add(alignment - 1) / alignment * alignment
+    }
+}

--- a/crates/rue-compiler/tests/differential_oracle.rs
+++ b/crates/rue-compiler/tests/differential_oracle.rs
@@ -587,6 +587,41 @@ fn corpus() -> Vec<Step> {
             ),
         ),
         step(
+            "query-native-drop-glue",
+            snapshot(
+                &[(
+                    7,
+                    "/p/main.rue",
+                    "main.rue",
+                    r#"
+                    struct D { value: i32 }
+                    drop fn D(self) {}
+                    struct Inner { item: D, items: [D; 2] }
+                    enum E { Full(Inner, D), Empty }
+                    fn Box() -> type {
+                        struct { item: D, drop fn(self) {} }
+                    }
+                    fn main() -> i32 {
+                        let values = [
+                            E.Full(
+                                Inner {
+                                    item: D { value: 1 },
+                                    items: [D { value: 2 }, D { value: 3 }],
+                                },
+                                D { value: 4 },
+                            ),
+                            E.Empty,
+                        ];
+                        let B = Box();
+                        let anonymous = B { item: D { value: 5 } };
+                        0
+                    }
+                    "#,
+                )],
+                7,
+            ),
+        ),
+        step(
             "incomplete-manifest",
             snapshot(
                 &[(
@@ -616,6 +651,21 @@ fn bounded_corpus_matches_stepwise_fresh_sessions() {
         observe(&mut fresh, incomplete)
             .manifest
             .contains("complete=false")
+    );
+
+    let glue = corpus
+        .iter()
+        .find(|step| step.name == "query-native-drop-glue")
+        .unwrap();
+    let glue_observation = observe(&mut CompilerSession::new(), glue);
+    assert!(glue_observation.semantic.contains("__rue_drop_D"));
+    assert!(glue_observation.semantic.contains("__rue_drop_Inner"));
+    assert!(glue_observation.semantic.contains("__rue_drop_E"));
+    assert!(glue_observation.semantic.contains("__rue_drop_array_"));
+    assert!(
+        glue_observation.semantic.matches("__rue_drop_").count() >= 5,
+        "named, anonymous, array, and enum plans must all reach glue synthesis: {}",
+        glue_observation.semantic
     );
 }
 

--- a/reproducibility/fixture/semantic-order/root.rue
+++ b/reproducibility/fixture/semantic-order/root.rue
@@ -1,8 +1,8 @@
 // The root module owns the program entry point (spec 6.1:38, RUE-920) and
 // discovers both sibling modules through imports. The siblings still exchange
 // FileId-adjacent identities through manifest-order and parallelism
-// perturbation in the gate, and their same-named types keep colliding in the
-// path-qualified glue namespace.
+// perturbation in the gate, while the reached left type pins path-qualified
+// glue identity independently of the unreachable sibling declarations.
 const left = @import("left/types.rue");
 const right = @import("right/types.rue");
 

--- a/scripts/test-reproducible-output.sh
+++ b/scripts/test-reproducible-output.sh
@@ -253,13 +253,7 @@ assert_semantic_order_symbols() {
     for expected_name in \
         'Payload$left_2ftypes_2erue.__drop' \
         'Payload$left_2ftypes_2erue.score' \
-        'Payload$right_2ftypes_2erue.__drop' \
-        '__rue_drop_Payload$left_2ftypes_2erue' \
-        '__rue_drop_Payload$right_2ftypes_2erue' \
-        '__rue_drop_Choice$left_2ftypes_2erue' \
-        '__rue_drop_Choice$right_2ftypes_2erue' \
-        '__rue_drop_Clash$left_2ftypes_2erue' \
-        '__rue_drop_Clash$right_2ftypes_2erue'; do
+        '__rue_drop_Payload$left_2ftypes_2erue'; do
         if ! grep -Fq "function ${expected_name}:" "$output"; then
             printf 'FAIL: semantic-order output omitted stable symbol %s\n' \
                 "$expected_name" >&2


### PR DESCRIPTION
## Summary

- add canonical demand-driven type facts, layout, call ABI, and drop-glue queries keyed by stable type identity and explicit target inputs
- derive drop glue only from reached destruction obligations, recursively scheduling exact nested glue and destructor dependencies
- remove declaration-wide aggregate and destructor rooting so unreachable types do not receive semantic or code-generation work
- preserve typed deterministic producer failures while keeping cancellation as control flow
- cover exact layout/ABI parity, cold/reused/parallel query behavior, anonymous and named destruction, reachability, and production-session emission

## Behavior

Unreachable destructors and their glue symbols are no longer emitted. The reproducibility oracle now asserts only the reached left-module destructor/glue identity. Diagnostics from reached deterministic body failures are preserved; cancellation does not leak as a diagnostic or panic.

## Performance

Exploratory alternating release-build measurements found no demonstrated regression:

- startup wall time was flat; peak RSS increased by about 0.6 MiB
- Meridian's drift-controlled paired median was flat
- Caldera's five-pair median was flat, but host variance was too high for a stronger claim
- the Caldera output was 16 KiB smaller because unreachable glue is absent

## Validation

- formatting
- clippy across all 63 first-party Rust targets
- focused type-facts, layout, ABI, drop-glue, reachability, incremental-reuse, and producer-failure tests
- compiler suite: 851 passed, 1 ignored
- isolated CLI crate: 203 passed
- premerge tier: 78 targets passed, including CLI, UI, spec, frontend differential, generated oracle, reproducibility, and release smoke

Fixes RUE-1029.
