### PR TITLE
RUE-1030: query CFGs per function

### DIFF
--- a/crates/rue-compiler/src/api_inventory.rs
+++ b/crates/rue-compiler/src/api_inventory.rs
@@ -14,6 +14,7 @@ const PRODUCTION_MODULES: &[(&str, &str)] = &[
     ("canonical_lower", include_str!("canonical_lower.rs")),
     ("canonical_merge", include_str!("canonical_merge.rs")),
     ("canonical_semantic", include_str!("canonical_semantic.rs")),
+    ("cfg_query", include_str!("cfg_query.rs")),
     (
         "declaration_candidate",
         include_str!("declaration_candidate.rs"),

--- a/crates/rue-compiler/src/bound_definitions.rs
+++ b/crates/rue-compiler/src/bound_definitions.rs
@@ -724,43 +724,12 @@ pub(crate) fn compare_canonical_durable_declaration_install(
     let installed_bodies = installed.analyze_all_bodies_for_test();
     match (ordinary_bodies, installed_bodies) {
         (Ok(ordinary), Ok(installed)) => {
-            let ordinary_glue = std::collections::BTreeSet::new();
-            let installed_glue = std::collections::BTreeSet::new();
-            let glue_plans = std::collections::BTreeMap::new();
-            let ordinary_identities =
-                crate::queries::synthetic_projected_function_identities(&ordinary);
-            let installed_identities =
-                crate::queries::synthetic_projected_function_identities(&installed);
-            let ordinary = crate::build_functions_and_cfgs(
-                ordinary,
-                &ordinary_glue,
-                &glue_plans,
-                crate::OptLevel::default(),
-                crate::Target::host().unwrap(),
-                rir.semantic_symbols().interner(),
-                &[],
-                &[],
-                &ordinary_identities,
-            )
-            .map_err(|failure| failure.errors)?;
-            let installed = crate::build_functions_and_cfgs(
-                installed,
-                &installed_glue,
-                &glue_plans,
-                crate::OptLevel::default(),
-                crate::Target::host().unwrap(),
-                rir.semantic_symbols().interner(),
-                &[],
-                &[],
-                &installed_identities,
-            )
-            .map_err(|failure| failure.errors)?;
             if format!("{:?}", ordinary.functions) != format!("{:?}", installed.functions)
                 || format!("{:?}", ordinary.warnings) != format!("{:?}", installed.warnings)
                 || ordinary.strings != installed.strings
             {
                 return Err(CompileErrors::from(invalid(
-                    "projected durable install changed body, CFG, or diagnostic artifacts",
+                    "projected durable install changed body or diagnostic artifacts",
                 )));
             }
         }

--- a/crates/rue-compiler/src/canonical_lower.rs
+++ b/crates/rue-compiler/src/canonical_lower.rs
@@ -2,6 +2,7 @@
 
 use std::cell::RefCell;
 use std::ops::Range;
+use std::sync::Arc;
 
 use rue_error::{CompileError, ErrorKind};
 use rue_rir::RirPrinter;
@@ -79,7 +80,8 @@ impl ModuleRirOutput {
         let rir = ValidatedRir::finish(editor, &validation).map_err(|error| error.to_string())?;
         Ok(rue_air::BodyRirBundle::new(
             rir,
-            self.symbols.into_interner(),
+            Arc::try_unwrap(self.symbols.into_interner())
+                .expect("module RIR owns its semantic symbol interner"),
         ))
     }
 }

--- a/crates/rue-compiler/src/canonical_semantic.rs
+++ b/crates/rue-compiler/src/canonical_semantic.rs
@@ -56,12 +56,13 @@ use crate::{
     bound_definitions::{
         configure_canonical_sema, issue_bound_definitions, issue_shell_definitions,
     },
-    build_functions_and_cfgs,
+    queries::collect_function_cfg_queries,
 };
 
 #[cfg(test)]
 thread_local! {
     static INJECT_CFG_FAILURE: Cell<bool> = const { Cell::new(false) };
+    static INJECT_CFG_IMPORT_FAILURE: Cell<bool> = const { Cell::new(false) };
     static INJECT_DECLARATION_FAILURE: Cell<bool> = const { Cell::new(false) };
     static INJECT_AUTHORITATIVE_KEY_MISMATCH: Cell<bool> = const { Cell::new(false) };
 }
@@ -83,6 +84,30 @@ pub(crate) fn with_test_cfg_failure_injection<T>(run: impl FnOnce() -> T) -> T {
     });
     let _reset = Reset;
     run()
+}
+
+#[cfg(test)]
+pub(crate) fn with_test_cfg_import_failure_injection<T>(run: impl FnOnce() -> T) -> T {
+    struct Reset;
+    impl Drop for Reset {
+        fn drop(&mut self) {
+            INJECT_CFG_IMPORT_FAILURE.with(|enabled| enabled.set(false));
+        }
+    }
+
+    INJECT_CFG_IMPORT_FAILURE.with(|enabled| {
+        assert!(
+            !enabled.replace(true),
+            "CFG import failure injection is not nestable"
+        );
+    });
+    let _reset = Reset;
+    run()
+}
+
+#[cfg(test)]
+pub(crate) fn take_test_cfg_import_failure() -> bool {
+    INJECT_CFG_IMPORT_FAILURE.with(|enabled| enabled.replace(false))
 }
 
 #[cfg(test)]
@@ -592,7 +617,6 @@ pub struct CanonicalSemanticOutput {
     implicit_named_destructor_dependencies: Vec<rue_air::ImplicitNamedDestructorDependencyEvent>,
     implicit_named_destructor_dependencies_complete: bool,
     body_references: BTreeMap<crate::FunctionInstanceKey, crate::body_query::BodyReferences>,
-    durable_cfgs: Arc<[crate::queries::DurableCfgArtifact]>,
 }
 
 impl CanonicalSemanticOutput {
@@ -847,9 +871,6 @@ impl CanonicalSemanticOutput {
     pub fn implicit_named_destructor_dependencies_complete(&self) -> bool {
         self.implicit_named_destructor_dependencies_complete
     }
-    pub(crate) fn durable_cfgs(&self) -> &Arc<[crate::queries::DurableCfgArtifact]> {
-        &self.durable_cfgs
-    }
     /// Stable definition identities when requested for this run.
     #[cfg(test)]
     pub(crate) fn bound_definitions(&self) -> Option<&BoundDefinitionSet> {
@@ -905,10 +926,12 @@ pub(crate) fn analyze_prepared_canonical_program_reusing_declarations(
     body_candidates: Vec<PreparedDurableBodyCandidate>,
     specialized_body_candidates: Vec<PreparedDurableSpecializedBodyCandidate>,
     anonymous_body_candidates: Vec<PreparedDurableAnonymousBodyCandidate>,
-    durable_cfg_candidates: Arc<[crate::queries::DurableCfgArtifact]>,
     demanded_drop_glue: Arc<[crate::TypeInstanceKey]>,
     demanded_drop_glue_plans: Arc<[(crate::TypeInstanceKey, crate::type_queries::DropGlueFacts)]>,
     body_work: crate::DurableBodyWork,
+    cfg_queries: &crate::revisioned_query_database::RevisionedQueryDatabase,
+    revision: rue_query::Revision,
+    cancellation: rue_query::CancellationToken,
 ) -> Result<CanonicalSemanticOutput, CanonicalSemanticFailure> {
     // Rebinding the durable declaration records and rebuilding the query
     // dependency edges runs before whole-program analysis opens `sema`. It is
@@ -1220,11 +1243,13 @@ pub(crate) fn analyze_prepared_canonical_program_reusing_declarations(
         body_candidates,
         specialized_body_candidates,
         anonymous_body_candidates,
-        durable_cfg_candidates,
         demanded_drop_glue,
         demanded_drop_glue_plans,
         body_work,
         sema_span,
+        cfg_queries,
+        revision,
+        cancellation,
     )
 }
 
@@ -1519,11 +1544,13 @@ fn finish_canonical_analysis(
     durable_body_candidates: Vec<PreparedDurableBodyCandidate>,
     durable_specialized_body_candidates: Vec<PreparedDurableSpecializedBodyCandidate>,
     durable_anonymous_body_candidates: Vec<PreparedDurableAnonymousBodyCandidate>,
-    durable_cfg_candidates: Arc<[crate::queries::DurableCfgArtifact]>,
     demanded_drop_glue: Arc<[crate::TypeInstanceKey]>,
     demanded_drop_glue_plans: Arc<[(crate::TypeInstanceKey, crate::type_queries::DropGlueFacts)]>,
     durable_body_reuse_work: crate::DurableBodyWork,
     sema_span: tracing::span::EnteredSpan,
+    cfg_queries: &crate::revisioned_query_database::RevisionedQueryDatabase,
+    revision: rue_query::Revision,
+    cancellation: rue_query::CancellationToken,
 ) -> Result<CanonicalSemanticOutput, CanonicalSemanticFailure> {
     finish_canonical_analysis_with(
         input,
@@ -1538,11 +1565,13 @@ fn finish_canonical_analysis(
         durable_body_candidates,
         durable_specialized_body_candidates,
         durable_anonymous_body_candidates,
-        durable_cfg_candidates,
         demanded_drop_glue,
         demanded_drop_glue_plans,
         durable_body_reuse_work,
         sema_span,
+        cfg_queries,
+        revision,
+        cancellation,
         |bound, candidates, definitions, merged| {
             bound
                 .compose_queried_bodies(
@@ -1571,11 +1600,13 @@ fn finish_canonical_analysis_with(
     durable_body_candidates: Vec<PreparedDurableBodyCandidate>,
     durable_specialized_body_candidates: Vec<PreparedDurableSpecializedBodyCandidate>,
     durable_anonymous_body_candidates: Vec<PreparedDurableAnonymousBodyCandidate>,
-    durable_cfg_candidates: Arc<[crate::queries::DurableCfgArtifact]>,
     demanded_drop_glue: Arc<[crate::TypeInstanceKey]>,
     demanded_drop_glue_plans: Arc<[(crate::TypeInstanceKey, crate::type_queries::DropGlueFacts)]>,
     mut durable_body_reuse_work: crate::DurableBodyWork,
     sema_span: tracing::span::EnteredSpan,
+    cfg_queries: &crate::revisioned_query_database::RevisionedQueryDatabase,
+    revision: rue_query::Revision,
+    cancellation: rue_query::CancellationToken,
     analyze_bodies: impl FnOnce(
         rue_air::BoundSema<'_>,
         Vec<rue_air::SemanticQueriedBodyCandidate<crate::StableDefinitionKey, crate::ModuleId>>,
@@ -1778,29 +1809,11 @@ fn finish_canonical_analysis_with(
     );
     let queried_cfg_bodies = queried_candidates
         .iter()
-        .filter_map(|candidate| {
-            let owner =
-                crate::revisioned_query_database::function_definition_key(&candidate.identity)?
-                    .clone();
-            let record = authoritative_definitions.definition_by_key(&owner)?;
-            let expected_inputs = crate::session::stable_definition_input_fingerprint(
-                merged.definitions().source_snapshot(),
-                record,
-            )
-            .ok()?;
-            Some((
+        .map(|candidate| {
+            (
                 candidate.identity.clone(),
-                (
-                    candidate.body_span,
-                    crate::DurableOrdinaryBodyPayload {
-                        schema_version: crate::durable_body::DURABLE_ORDINARY_BODY_SCHEMA_VERSION,
-                        semantic_schema_version: crate::DURABLE_SEMANTIC_SCHEMA_VERSION,
-                        owner,
-                        expected_inputs,
-                        body: candidate.body.clone(),
-                    },
-                ),
-            ))
+                (candidate.body_span, candidate.body.clone()),
+            )
         })
         .collect::<std::collections::BTreeMap<_, _>>();
     let composition = analyze_bodies(
@@ -2022,6 +2035,43 @@ fn finish_canonical_analysis_with(
                 },
             )
         })?;
+    let stable_drop_glue_plans = demanded_drop_glue_plans
+        .iter()
+        .cloned()
+        .collect::<std::collections::BTreeMap<_, _>>();
+    let stable_aggregate_types = sema_output
+        .aggregate_types_by_identity
+        .iter()
+        .map(|(issued, live)| {
+            let callable = rue_air::FunctionInstanceKey::DropGlue(Box::new(issued.clone()));
+            let stable =
+                project_function_instance_key(&callable, merged, &authoritative_definitions)?;
+            let crate::FunctionInstanceKey::DropGlue(stable) = stable else {
+                unreachable!("drop-glue projection preserves its callable kind")
+            };
+            Ok::<_, rue_air::SemanticStableResolutionFailure>((*live, *stable))
+        })
+        .collect::<Result<std::collections::HashMap<_, _>, _>>()
+        .map_err(|failure| {
+            CanonicalSemanticFailure::new(
+                CanonicalSemanticFailurePhase::BodyAnalysis,
+                crate::CompileErrors::from(crate::CompileError::without_span(
+                    rue_error::ErrorKind::InternalError(format!(
+                        "failed to project reached aggregate type identity: {failure:?}"
+                    )),
+                )),
+                CanonicalSemanticWork {
+                    declaration_index,
+                    binding,
+                    manifest: manifest_work,
+                    bound_definitions: Some(authoritative_definitions.work()),
+                    body_analysis,
+                    durable_bodies: durable_body_work,
+                    declaration_reuse,
+                    ..CanonicalSemanticWork::default()
+                },
+            )
+        })?;
     let issued_callable_identities = sema_output
         .functions
         .iter()
@@ -2072,59 +2122,37 @@ fn finish_canonical_analysis_with(
                     .map(|(body_span, body)| (*body_span, body.clone(), function_key.clone()))
             });
         if let Some((body_span, body, function_key)) = selected {
-            let Ok(type_dependencies) = crate::durable_cfg::transitive_body_type_dependencies(
-                &body,
-                &sema_output.type_pool,
-                &authoritative_definitions,
-            ) else {
-                continue;
-            };
-            let type_inputs = type_dependencies
-                .into_iter()
-                .map(|key| {
-                    authoritative_definitions
-                        .definition_by_key(&key)
-                        .ok_or(())
-                        .and_then(|record| {
-                            crate::session::stable_definition_input_fingerprint(
-                                merged.definitions().source_snapshot(),
-                                record,
-                            )
-                            .map_err(|_| ())
-                        })
-                })
-                .collect::<Result<Vec<_>, _>>()
-                .ok();
-            let Some(type_inputs) = type_inputs else {
-                continue;
-            };
-            stable_cfg_inputs.push(crate::durable_cfg::CurrentCfgInput {
-                stable: crate::durable_cfg::StableCfgInput {
-                    function: function_key,
-                    body,
-                    type_inputs: type_inputs.into(),
-                },
+            stable_cfg_inputs.push(crate::cfg_query::CfgBodyInput {
+                function: function_key,
+                body,
                 body_span,
             });
         }
     }
-    stable_cfg_inputs.sort_by(|left, right| left.stable.function.cmp(&right.stable.function));
+    stable_cfg_inputs.sort_by(|left, right| left.function.cmp(&right.function));
     drop(sema_span);
     // CFG construction is a sibling of semantic-proper, not nested inside it:
     // `sema_span` closes above before this begins. Published phases must not
     // overlap, so this boundary is load-bearing rather than stylistic. The
     // `cfg_and_optimization` phase marker lives on `cfg_construction` inside
-    // `build_functions_and_cfgs`.
-    let cfg = build_functions_and_cfgs(
+    // `collect_function_cfg_queries`.
+    let cfg = collect_function_cfg_queries(
         sema_output,
         &demanded_issued_drop_glue,
         &demanded_issued_drop_glue_plans,
+        &stable_drop_glue_plans,
         options.opt_level,
-        options.target,
-        rir.semantic_symbols().interner(),
-        &durable_cfg_candidates,
+        rir.semantic_symbols().shared_interner(),
         &stable_cfg_inputs,
+        stable_aggregate_types,
         &projected_callable_identities,
+        cfg_queries,
+        revision,
+        crate::semantic_query_nucleus::SemanticQueryConfiguration {
+            target: options.target,
+            preview_features: crate::StablePreviewFeatures::new(&options.preview_features),
+        },
+        cancellation,
     )
     .map_err(|failure| {
         let work = CanonicalSemanticWork {
@@ -2231,7 +2259,6 @@ fn finish_canonical_analysis_with(
         implicit_named_destructor_dependencies_complete: cfg
             .implicit_named_destructor_dependencies_complete,
         body_references: BTreeMap::new(),
-        durable_cfgs: cfg.durable_cfgs,
     })
 }
 

--- a/crates/rue-compiler/src/cfg_query.rs
+++ b/crates/rue-compiler/src/cfg_query.rs
@@ -1,0 +1,570 @@
+//! Canonical per-function CFG query values.
+//!
+//! The unoptimized family owns AIR-to-CFG lowering. The optimized family owns
+//! only the selected optimization pipeline and observes the exact unoptimized
+//! terminal. Both publish stable relocation domains; request-local AIR, type
+//! indexes, symbols, strings, and spans are construction inputs, never memo
+//! identity.
+
+use std::hash::{Hash, Hasher};
+use std::sync::Arc;
+
+use rue_query::{QueryAbort, QueryContext, QueryFamily, QueryKey, QueryOutcome, QueryOutput};
+use rue_span::Span;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum CfgSemanticInput {
+    Body(Arc<rue_air::SemanticBody<crate::StableDefinitionKey, crate::ModuleId>>),
+    DropGlue {
+        owner: crate::TypeInstanceKey,
+        facts: Box<crate::type_queries::DropGlueFacts>,
+    },
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct CfgBodyInput {
+    pub(crate) function: crate::FunctionInstanceKey,
+    pub(crate) body: rue_air::SemanticBody<crate::StableDefinitionKey, crate::ModuleId>,
+    pub(crate) body_span: Span,
+}
+
+#[derive(Debug)]
+pub(crate) struct CfgLiveInput {
+    pub(crate) function: Arc<rue_air::AnalyzedFunction>,
+    pub(crate) type_pool: rue_air::FrozenTypeInternPool,
+    pub(crate) interner: Arc<lasso::ThreadedRodeo>,
+    pub(crate) domains: crate::durable_cfg::CfgDomainProjection,
+    pub(crate) body_span: Span,
+    pub(crate) aggregate_types:
+        Arc<std::collections::HashMap<rue_air::Type, crate::TypeInstanceKey>>,
+    pub(crate) implicit_destructor_dependencies_complete: bool,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct CfgQueryKey {
+    pub(crate) function: crate::FunctionInstanceKey,
+    pub(crate) configuration: crate::semantic_query_nucleus::SemanticQueryConfiguration,
+    pub(crate) semantic_input: CfgSemanticInput,
+    pub(crate) layouts: Arc<
+        [(
+            crate::type_queries::TypeQueryKey,
+            crate::type_queries::LayoutValue,
+        )],
+    >,
+    pub(crate) type_facts: Arc<
+        [(
+            crate::type_queries::TypeQueryKey,
+            crate::type_queries::TypeFactsValue,
+        )],
+    >,
+    pub(crate) drop_glues: Arc<
+        [(
+            crate::type_queries::TypeQueryKey,
+            crate::type_queries::DropGlueValue,
+        )],
+    >,
+    pub(crate) call_abis: Arc<
+        [(
+            crate::type_queries::CallAbiQueryKey,
+            crate::type_queries::CallAbiValue,
+        )],
+    >,
+    pub(crate) live: Arc<CfgLiveInput>,
+    memo_hash: u64,
+}
+
+impl CfgQueryKey {
+    pub(crate) fn new(
+        function: crate::FunctionInstanceKey,
+        configuration: crate::semantic_query_nucleus::SemanticQueryConfiguration,
+        semantic_input: CfgSemanticInput,
+        layouts: Arc<
+            [(
+                crate::type_queries::TypeQueryKey,
+                crate::type_queries::LayoutValue,
+            )],
+        >,
+        type_facts: Arc<
+            [(
+                crate::type_queries::TypeQueryKey,
+                crate::type_queries::TypeFactsValue,
+            )],
+        >,
+        drop_glues: Arc<
+            [(
+                crate::type_queries::TypeQueryKey,
+                crate::type_queries::DropGlueValue,
+            )],
+        >,
+        call_abis: Arc<
+            [(
+                crate::type_queries::CallAbiQueryKey,
+                crate::type_queries::CallAbiValue,
+            )],
+        >,
+        live: Arc<CfgLiveInput>,
+    ) -> Self {
+        let mut hasher = std::collections::hash_map::DefaultHasher::new();
+        function.hash(&mut hasher);
+        configuration.hash(&mut hasher);
+        // These stable values deliberately do not implement `Hash`. Compute
+        // their complete Debug framing once at key construction instead of on
+        // every memo-table probe; equality still resolves hash collisions.
+        format!("{semantic_input:?}").hash(&mut hasher);
+        format!("{layouts:?}").hash(&mut hasher);
+        format!("{type_facts:?}").hash(&mut hasher);
+        format!("{drop_glues:?}").hash(&mut hasher);
+        format!("{call_abis:?}").hash(&mut hasher);
+        let memo_hash = hasher.finish();
+        Self {
+            function,
+            configuration,
+            semantic_input,
+            layouts,
+            type_facts,
+            drop_glues,
+            call_abis,
+            live,
+            memo_hash,
+        }
+    }
+}
+
+impl PartialEq for CfgQueryKey {
+    fn eq(&self, other: &Self) -> bool {
+        self.function == other.function
+            && self.configuration == other.configuration
+            && self.semantic_input == other.semantic_input
+            && self.layouts == other.layouts
+            && self.type_facts == other.type_facts
+            && self.drop_glues == other.drop_glues
+            && self.call_abis == other.call_abis
+    }
+}
+
+impl Eq for CfgQueryKey {}
+
+impl Hash for CfgQueryKey {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.memo_hash.hash(state);
+    }
+}
+
+impl QueryKey for CfgQueryKey {
+    fn stable_identity(&self) -> String {
+        format!(
+            "{:?};target={:?};preview={:?}",
+            self.function, self.configuration.target, self.configuration.preview_features
+        )
+    }
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct OptimizedCfgQueryKey {
+    pub(crate) cfg: CfgQueryKey,
+    pub(crate) opt_level: rue_cfg::OptLevel,
+    live_domain_hash: u64,
+}
+
+impl OptimizedCfgQueryKey {
+    pub(crate) fn new(cfg: CfgQueryKey, opt_level: rue_cfg::OptLevel) -> Self {
+        let mut hasher = std::collections::hash_map::DefaultHasher::new();
+        // Complete domains are relocatable by the collector and therefore do
+        // not belong in optimized memo identity. An incomplete projection is
+        // deliberately epoch-local: distinguish that one token so a successor
+        // reruns the evaluator and takes its fail-closed rebuild path.
+        cfg.live
+            .domains
+            .optimized_memo_domain_hash()
+            .hash(&mut hasher);
+        let live_domain_hash = hasher.finish();
+        Self {
+            cfg,
+            opt_level,
+            live_domain_hash,
+        }
+    }
+}
+
+impl PartialEq for OptimizedCfgQueryKey {
+    fn eq(&self, other: &Self) -> bool {
+        self.cfg == other.cfg
+            && self.opt_level == other.opt_level
+            && self
+                .cfg
+                .live
+                .domains
+                .same_optimized_memo_domain(&other.cfg.live.domains)
+    }
+}
+
+impl Eq for OptimizedCfgQueryKey {}
+
+impl std::hash::Hash for OptimizedCfgQueryKey {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        self.cfg.hash(state);
+        std::mem::discriminant(&self.opt_level).hash(state);
+        self.live_domain_hash.hash(state);
+    }
+}
+
+impl QueryKey for OptimizedCfgQueryKey {
+    fn stable_identity(&self) -> String {
+        format!("{};opt={:?}", self.cfg.stable_identity(), self.opt_level)
+    }
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct CfgRecord {
+    pub(crate) cfg: rue_cfg::ValidatedCfg,
+    pub(crate) domains: crate::durable_cfg::CfgDomainProjection,
+    pub(crate) body_span: Span,
+    pub(crate) warnings: Arc<[rue_error::CompileWarning]>,
+    pub(crate) implicit_destructor_targets: Arc<[crate::TypeInstanceKey]>,
+    pub(crate) implicit_destructor_dependencies_complete: bool,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) enum CfgValue {
+    Available(Arc<CfgRecord>),
+    Failure {
+        errors: crate::CompileErrors,
+        body_span: Span,
+    },
+}
+
+pub(crate) fn cfg_value_equal(left: &CfgValue, right: &CfgValue) -> bool {
+    match (left, right) {
+        // A computed Cfg terminal is the direct semantic input of OptimizedCfg.
+        // If Cfg was forced to recompute, conservatively dirty its consumer;
+        // exact-key hits are reused without invoking this equality hook.
+        (CfgValue::Available(_), CfgValue::Available(_)) => false,
+        (
+            CfgValue::Failure {
+                errors: left_errors,
+                ..
+            },
+            CfgValue::Failure {
+                errors: right_errors,
+                ..
+            },
+        ) => left_errors == right_errors,
+        _ => false,
+    }
+}
+
+fn map_span(span: Span, old: Span, new: Span) -> Span {
+    if span.file_id == old.file_id && span.start >= old.start && span.end <= old.end {
+        Span {
+            file_id: new.file_id,
+            start: new.start + (span.start - old.start),
+            end: new.start + (span.end - old.start),
+        }
+    } else {
+        span
+    }
+}
+
+pub(crate) fn import_errors(
+    errors: &crate::CompileErrors,
+    old: Span,
+    new: Span,
+) -> crate::CompileErrors {
+    errors
+        .iter()
+        .cloned()
+        .map(|error| error.map_spans(|span| map_span(span, old, new)))
+        .collect::<Vec<_>>()
+        .into()
+}
+
+pub(crate) fn import_warnings(
+    warnings: &[rue_error::CompileWarning],
+    old: Span,
+    new: Span,
+) -> Vec<rue_error::CompileWarning> {
+    warnings
+        .iter()
+        .cloned()
+        .map(|warning| warning.map_spans(|span| map_span(span, old, new)))
+        .collect()
+}
+
+pub(crate) fn collect_type_dependencies(
+    ty: &rue_air::SemanticImportType<crate::StableDefinitionKey, crate::ModuleId>,
+    output: &mut std::collections::BTreeSet<crate::TypeInstanceKey>,
+) {
+    output.insert(type_instance_from_semantic(ty));
+    // Array representation and CFG indexing depend on the element layout.
+    // Pointer and slice representation does not depend on the pointee.
+    if let rue_air::SemanticImportType::Array { element, .. } = ty {
+        collect_type_dependencies(element, output);
+    }
+}
+
+pub(crate) fn collect_drop_type_dependency(
+    ty: &rue_air::SemanticImportType<crate::StableDefinitionKey, crate::ModuleId>,
+    output: &mut std::collections::BTreeSet<crate::TypeInstanceKey>,
+) {
+    output.insert(type_instance_from_semantic(ty));
+}
+
+fn type_instance_from_semantic(
+    ty: &rue_air::SemanticImportType<crate::StableDefinitionKey, crate::ModuleId>,
+) -> crate::TypeInstanceKey {
+    use rue_air::SemanticImportType as T;
+    match ty {
+        T::I8 => crate::TypeInstanceKey::I8,
+        T::I16 => crate::TypeInstanceKey::I16,
+        T::I32 => crate::TypeInstanceKey::I32,
+        T::I64 => crate::TypeInstanceKey::I64,
+        T::U8 => crate::TypeInstanceKey::U8,
+        T::U16 => crate::TypeInstanceKey::U16,
+        T::U32 => crate::TypeInstanceKey::U32,
+        T::U64 => crate::TypeInstanceKey::U64,
+        T::Bool => crate::TypeInstanceKey::Bool,
+        T::Unit => crate::TypeInstanceKey::Unit,
+        T::Never => crate::TypeInstanceKey::Never,
+        T::ComptimeType => crate::TypeInstanceKey::ComptimeType,
+        T::BuiltinNominal { kind, name } => crate::TypeInstanceKey::BuiltinNominal {
+            kind: match kind {
+                rue_air::SemanticImportNominalKind::Struct => crate::AnonymousNominalKind::Struct,
+                rue_air::SemanticImportNominalKind::Enum => crate::AnonymousNominalKind::Enum,
+            },
+            name: name.clone(),
+        },
+        T::Nominal(definition) => {
+            crate::TypeInstanceKey::Nominal(crate::NominalInstanceKey::Named(definition.clone()))
+        }
+        T::AnonymousNominal(identity) => {
+            crate::TypeInstanceKey::Nominal(crate::NominalInstanceKey::Anonymous(identity.clone()))
+        }
+        T::Array { element, len } => crate::TypeInstanceKey::Array {
+            element: Box::new(type_instance_from_semantic(element)),
+            len: *len,
+        },
+        T::Slice { element, name } => crate::TypeInstanceKey::Slice {
+            element: Box::new(type_instance_from_semantic(element)),
+            name: name.clone(),
+        },
+        T::PtrConst(element) => {
+            crate::TypeInstanceKey::PtrConst(Box::new(type_instance_from_semantic(element)))
+        }
+        T::PtrMut(element) => {
+            crate::TypeInstanceKey::PtrMut(Box::new(type_instance_from_semantic(element)))
+        }
+        T::Module(module) => crate::TypeInstanceKey::Module(module.clone()),
+        T::GenericParameter(index) => crate::TypeInstanceKey::GenericParameter(*index),
+    }
+}
+
+pub(crate) fn evaluate_cfg(
+    context: &QueryContext,
+    layouts: &QueryFamily<crate::type_queries::TypeQueryKey, crate::type_queries::LayoutValue>,
+    type_facts: &QueryFamily<
+        crate::type_queries::TypeQueryKey,
+        crate::type_queries::TypeFactsValue,
+    >,
+    drop_glues: &QueryFamily<crate::type_queries::TypeQueryKey, crate::type_queries::DropGlueValue>,
+    call_abis: &QueryFamily<
+        crate::type_queries::CallAbiQueryKey,
+        crate::type_queries::CallAbiValue,
+    >,
+    key: &CfgQueryKey,
+) -> Result<QueryOutput<CfgValue>, QueryAbort> {
+    for (dependency, expected) in key.layouts.iter() {
+        let terminal = context.query_registered(layouts, dependency.clone())?;
+        let QueryOutcome::Success(actual) = terminal.outcome() else {
+            unreachable!("Layout publishes typed values")
+        };
+        if actual != expected {
+            return Err(QueryAbort::Canceled);
+        }
+    }
+    for (dependency, expected) in key.type_facts.iter() {
+        let terminal = context.query_registered(type_facts, dependency.clone())?;
+        let QueryOutcome::Success(actual) = terminal.outcome() else {
+            unreachable!("TypeFacts publishes typed values")
+        };
+        if actual != expected {
+            return Err(QueryAbort::Canceled);
+        }
+    }
+    for (dependency, expected) in key.drop_glues.iter() {
+        let terminal = context.query_registered(drop_glues, dependency.clone())?;
+        let QueryOutcome::Success(actual) = terminal.outcome() else {
+            unreachable!("DropGlue publishes typed values")
+        };
+        if actual != expected {
+            return Err(QueryAbort::Canceled);
+        }
+    }
+    for (dependency, expected) in key.call_abis.iter() {
+        let terminal = context.query_registered(call_abis, dependency.clone())?;
+        let QueryOutcome::Success(actual) = terminal.outcome() else {
+            unreachable!("CallAbi publishes typed values")
+        };
+        if actual != expected {
+            return Err(QueryAbort::Canceled);
+        }
+    }
+    let value = build_cfg(context, key);
+    let kind = if matches!(value, CfgValue::Failure { .. }) {
+        rue_query::QueryTerminalKind::Failure
+    } else {
+        rue_query::QueryTerminalKind::Success
+    };
+    Ok(QueryOutput::success(value).with_terminal_kind(kind))
+}
+
+fn build_cfg(context: &QueryContext, key: &CfgQueryKey) -> CfgValue {
+    context.record_work(rue_query::WorkItem::new("cfg.build.attempts", 1));
+    context.record_work(rue_query::WorkItem::new(
+        "cfg.air.instructions",
+        key.live.function.air.instructions().len() as u64,
+    ));
+    let output = rue_cfg::CfgBuilder::build(
+        &key.live.function.air,
+        key.live.function.num_locals,
+        key.live.function.num_param_slots,
+        &key.live.function.name,
+        &key.live.type_pool,
+        key.live.function.param_modes.clone(),
+        &key.live.interner,
+        key.live.function.allow_unreachable_code,
+        key.live.function.callable_kind,
+    );
+    if !output.errors.is_empty() {
+        context.record_work(rue_query::WorkItem::new("cfg.build.failures", 1));
+        return CfgValue::Failure {
+            errors: output.errors.into(),
+            body_span: key.live.body_span,
+        };
+    }
+    context.record_work(rue_query::WorkItem::new("cfg.build.successes", 1));
+    context.record_work(rue_query::WorkItem::new(
+        "cfg.warnings",
+        output.warnings.len() as u64,
+    ));
+    let mut implicit_destructor_targets = output
+        .implicit_named_destructors
+        .iter()
+        .filter_map(|id| {
+            key.live
+                .aggregate_types
+                .get(&rue_air::Type::new_struct(*id))
+                .cloned()
+        })
+        .collect::<std::collections::BTreeSet<_>>();
+    if let CfgSemanticInput::DropGlue { owner, facts } = &key.semantic_input
+        && facts.destructor.is_some()
+    {
+        // A synthesized struct glue body does not explicitly drop its owner,
+        // but the exact DropGlue terminal records whether that owner has a
+        // source destructor. Observe that local query fact instead of scanning
+        // the live type pool for same-named structs outside this CFG's domain.
+        implicit_destructor_targets.insert(owner.clone());
+    }
+    CfgValue::Available(Arc::new(CfgRecord {
+        cfg: output
+            .cfg
+            .expect("successful CFG construction publishes a validated CFG"),
+        domains: key.live.domains.clone(),
+        body_span: key.live.body_span,
+        warnings: output.warnings.into(),
+        implicit_destructor_targets: implicit_destructor_targets
+            .into_iter()
+            .collect::<Vec<_>>()
+            .into(),
+        implicit_destructor_dependencies_complete: key
+            .live
+            .implicit_destructor_dependencies_complete
+            && !output.anonymous_destructor_dependency_incomplete,
+    }))
+}
+
+pub(crate) fn evaluate_optimized_cfg(
+    context: &QueryContext,
+    cfgs: &QueryFamily<CfgQueryKey, CfgValue>,
+    key: &OptimizedCfgQueryKey,
+) -> Result<QueryOutput<CfgValue>, QueryAbort> {
+    let _attempts = context.retain_nested_attempts_for(&["compiler.cfg"]);
+    let terminal = context.query_registered(cfgs, key.cfg.clone())?;
+    let QueryOutcome::Success(value) = terminal.outcome() else {
+        unreachable!("Cfg publishes typed values")
+    };
+    let CfgValue::Available(record) = value else {
+        return Ok(QueryOutput::success(value.clone())
+            .with_terminal_kind(rue_query::QueryTerminalKind::Failure));
+    };
+    let (current, record) = if record.domains.same_live_domain(&key.cfg.live.domains) {
+        (record.cfg.clone(), record.clone())
+    } else {
+        context.record_work(rue_query::WorkItem::new("cfg.import.attempts", 1));
+        match crate::durable_cfg::CfgDomainProjection::import_cfg(
+            &record.domains,
+            &key.cfg.live.domains,
+            &record.cfg,
+            key.cfg.live.body_span,
+        )
+        .and_then(|editor| {
+            editor
+                .finish_after_optimization(&key.cfg.live.type_pool)
+                .map_err(|_| crate::durable_cfg::CfgDomainFailure::Shape)
+        }) {
+            Ok(current) => {
+                context.record_work(rue_query::WorkItem::new("cfg.import.successes", 1));
+                (current, record.clone())
+            }
+            Err(_) => {
+                // A relocation-domain miss must not turn a valid current body
+                // into an ICE. Rebuild from the exact current AIR and continue
+                // optimization; the regular Cfg family remains the canonical
+                // fast path, while this fail-closed path preserves correctness
+                // if a newly introduced CFG domain escaped projection.
+                context.record_work(rue_query::WorkItem::new("cfg.import.failures", 1));
+                context.record_work(rue_query::WorkItem::new("cfg.fallbacks", 1));
+                match build_cfg(context, &key.cfg) {
+                    CfgValue::Available(record) => (record.cfg.clone(), record.clone()),
+                    rebuilt @ CfgValue::Failure { .. } => {
+                        return Ok(QueryOutput::success(rebuilt)
+                            .with_terminal_kind(rue_query::QueryTerminalKind::Failure));
+                    }
+                }
+            }
+        }
+    };
+    context.record_work(rue_query::WorkItem::new("cfg.optimize.attempts", 1));
+    context.record_work(rue_query::WorkItem::new(
+        "cfg.optimize.nonzero-level",
+        u64::from(key.opt_level != rue_cfg::OptLevel::O0),
+    ));
+    match rue_cfg::opt::optimize(current, key.opt_level, &key.cfg.live.type_pool) {
+        Ok(cfg) => {
+            context.record_work(rue_query::WorkItem::new("cfg.optimize.successes", 1));
+            Ok(QueryOutput::success(CfgValue::Available(Arc::new(
+                CfgRecord {
+                    cfg,
+                    domains: key.cfg.live.domains.clone(),
+                    body_span: key.cfg.live.body_span,
+                    warnings: record.warnings.clone(),
+                    implicit_destructor_targets: record.implicit_destructor_targets.clone(),
+                    implicit_destructor_dependencies_complete: record
+                        .implicit_destructor_dependencies_complete,
+                },
+            ))))
+        }
+        Err(error) => {
+            context.record_work(rue_query::WorkItem::new("cfg.optimize.failures", 1));
+            Ok(QueryOutput::success(CfgValue::Failure {
+                errors: crate::CompileErrors::from(crate::CompileError::without_span(
+                    rue_error::ErrorKind::InternalError(format!(
+                        "CFG optimization failed: {error}"
+                    )),
+                )),
+                body_span: key.cfg.live.body_span,
+            })
+            .with_terminal_kind(rue_query::QueryTerminalKind::Failure))
+        }
+    }
+}

--- a/crates/rue-compiler/src/durable_body.rs
+++ b/crates/rue-compiler/src/durable_body.rs
@@ -24,6 +24,7 @@ pub const DURABLE_SPECIALIZED_BODY_SCHEMA_VERSION: u32 = 9;
 
 /// Durable specialization of AIR's canonical body algebra. These aliases keep
 /// compiler consumers explicit about the stable identity domain.
+#[cfg(test)]
 pub type DurableBodyAnchor = rue_air::SemanticBodyAnchor;
 pub type DurableProjection = rue_air::SemanticBodyProjection<StableDefinitionKey, crate::ModuleId>;
 #[cfg(test)]

--- a/crates/rue-compiler/src/durable_cfg.rs
+++ b/crates/rue-compiler/src/durable_cfg.rs
@@ -1,13 +1,159 @@
-use std::collections::{BTreeSet, HashMap};
+use std::collections::HashMap;
 use std::sync::Arc;
 
 use lasso::{Key, Spur};
 use rue_air::{AirInstData, AnalyzedFunction, SemanticImportType, Type, TypeKind};
 use rue_span::Span;
 
-use crate::{DurableAirInstData, DurableOrdinaryBodyPayload};
+use crate::DurableAirInstData;
 
 type CanonicalType = SemanticImportType<crate::StableDefinitionKey, crate::ModuleId>;
+
+fn canonical_nominal(value: &crate::NominalInstanceKey) -> CanonicalType {
+    match value {
+        crate::NominalInstanceKey::Builtin { kind, name } => CanonicalType::BuiltinNominal {
+            kind: match kind {
+                crate::AnonymousNominalKind::Struct => rue_air::SemanticImportNominalKind::Struct,
+                crate::AnonymousNominalKind::Enum => rue_air::SemanticImportNominalKind::Enum,
+            },
+            name: name.clone(),
+        },
+        crate::NominalInstanceKey::Named(definition) => CanonicalType::Nominal(definition.clone()),
+        crate::NominalInstanceKey::Anonymous(identity) => {
+            CanonicalType::AnonymousNominal(identity.clone())
+        }
+    }
+}
+
+fn live_instruction_kind(data: &AirInstData) -> rue_air::SemanticBodyInstKind {
+    use rue_air::SemanticBodyInstKind as K;
+    match data {
+        AirInstData::Const(..) => K::Const,
+        AirInstData::BoolConst(..) => K::BoolConst,
+        AirInstData::StringConst(..) => K::StringConst,
+        AirInstData::UnitConst => K::UnitConst,
+        AirInstData::TypeConst(..) => K::TypeConst,
+        AirInstData::Add(..) => K::Add,
+        AirInstData::Sub(..) => K::Sub,
+        AirInstData::Mul(..) => K::Mul,
+        AirInstData::WrappingAdd(..) => K::WrappingAdd,
+        AirInstData::WrappingSub(..) => K::WrappingSub,
+        AirInstData::WrappingMul(..) => K::WrappingMul,
+        AirInstData::Div(..) => K::Div,
+        AirInstData::Mod(..) => K::Mod,
+        AirInstData::Eq(..) => K::Eq,
+        AirInstData::Ne(..) => K::Ne,
+        AirInstData::Lt(..) => K::Lt,
+        AirInstData::Gt(..) => K::Gt,
+        AirInstData::Le(..) => K::Le,
+        AirInstData::Ge(..) => K::Ge,
+        AirInstData::And(..) => K::And,
+        AirInstData::Or(..) => K::Or,
+        AirInstData::BitAnd(..) => K::BitAnd,
+        AirInstData::BitOr(..) => K::BitOr,
+        AirInstData::BitXor(..) => K::BitXor,
+        AirInstData::Shl(..) => K::Shl,
+        AirInstData::Shr(..) => K::Shr,
+        AirInstData::Neg(..) => K::Neg,
+        AirInstData::Not(..) => K::Not,
+        AirInstData::BitNot(..) => K::BitNot,
+        AirInstData::Branch { .. } => K::Branch,
+        AirInstData::Loop { .. } => K::Loop,
+        AirInstData::InfiniteLoop { .. } => K::InfiniteLoop,
+        AirInstData::Match { .. } => K::Match,
+        AirInstData::Break => K::Break,
+        AirInstData::Continue => K::Continue,
+        AirInstData::Alloc { .. } => K::Alloc,
+        AirInstData::Load { .. } => K::Load,
+        AirInstData::Store { .. } => K::Store,
+        AirInstData::ParamStore { .. } => K::ParamStore,
+        AirInstData::Ret(..) => K::Ret,
+        AirInstData::Call {
+            runtime: Some(_), ..
+        } => K::RuntimeCall,
+        AirInstData::Call { runtime: None, .. } => K::Call,
+        AirInstData::CallGeneric { .. } => K::CallGeneric,
+        AirInstData::Intrinsic { .. } => K::Intrinsic,
+        AirInstData::Param { .. } => K::Param,
+        AirInstData::Block { .. } => K::Block,
+        AirInstData::StructInit { .. } => K::StructInit,
+        AirInstData::ArrayInit { .. } => K::ArrayInit,
+        AirInstData::PlaceRead { .. } => K::PlaceRead,
+        AirInstData::PlaceWrite { .. } => K::PlaceWrite,
+        AirInstData::EnumVariant { .. } => K::EnumVariant,
+        AirInstData::EnumPayloadGet { .. } => K::EnumPayloadGet,
+        AirInstData::IntCast { .. } => K::IntCast,
+        AirInstData::Drop { .. } => K::Drop,
+        AirInstData::StorageLive { .. } => K::StorageLive,
+        AirInstData::StorageDead { .. } => K::StorageDead,
+        AirInstData::MarkMoved { .. } => K::MarkMoved,
+    }
+}
+
+pub(crate) fn canonical_type_from_live(
+    ty: Type,
+    pool: &rue_air::FrozenTypeInternPool,
+    aggregates: &HashMap<Type, crate::TypeInstanceKey>,
+) -> Result<CanonicalType, CfgDomainFailure> {
+    use rue_air::TypeKind as K;
+    Ok(match ty.kind() {
+        K::I8 => CanonicalType::I8,
+        K::I16 => CanonicalType::I16,
+        K::I32 => CanonicalType::I32,
+        K::I64 => CanonicalType::I64,
+        K::U8 => CanonicalType::U8,
+        K::U16 => CanonicalType::U16,
+        K::U32 => CanonicalType::U32,
+        K::U64 => CanonicalType::U64,
+        K::Bool => CanonicalType::Bool,
+        K::Unit => CanonicalType::Unit,
+        K::Never => CanonicalType::Never,
+        K::ComptimeType => CanonicalType::ComptimeType,
+        K::Array(id) => {
+            let (element, len) = pool.array_def(id);
+            CanonicalType::Array {
+                element: Box::new(canonical_type_from_live(element, pool, aggregates)?),
+                len,
+            }
+        }
+        K::PtrConst(id) => CanonicalType::PtrConst(Box::new(canonical_type_from_live(
+            pool.ptr_const_def(id),
+            pool,
+            aggregates,
+        )?)),
+        K::PtrMut(id) => CanonicalType::PtrMut(Box::new(canonical_type_from_live(
+            pool.ptr_mut_def(id),
+            pool,
+            aggregates,
+        )?)),
+        K::Struct(_) | K::Enum(_) => {
+            let stable = aggregates.get(&ty).ok_or(CfgDomainFailure::Missing)?;
+            match stable {
+                crate::TypeInstanceKey::BuiltinNominal { kind, name } => {
+                    CanonicalType::BuiltinNominal {
+                        kind: match kind {
+                            crate::AnonymousNominalKind::Struct => {
+                                rue_air::SemanticImportNominalKind::Struct
+                            }
+                            crate::AnonymousNominalKind::Enum => {
+                                rue_air::SemanticImportNominalKind::Enum
+                            }
+                        },
+                        name: name.clone(),
+                    }
+                }
+                crate::TypeInstanceKey::Nominal(crate::NominalInstanceKey::Named(definition)) => {
+                    CanonicalType::Nominal(definition.clone())
+                }
+                crate::TypeInstanceKey::Nominal(crate::NominalInstanceKey::Anonymous(identity)) => {
+                    CanonicalType::AnonymousNominal(identity.clone())
+                }
+                _ => return Err(CfgDomainFailure::Shape),
+            }
+        }
+        K::Module(_) | K::Error => return Err(CfgDomainFailure::Unsupported),
+    })
+}
 
 fn deduplicate_type_mappings(
     mappings: Vec<(Type, CanonicalType)>,
@@ -27,249 +173,58 @@ fn deduplicate_type_mappings(
     Ok(unique)
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub(crate) struct StableCfgInput {
-    pub function: crate::FunctionInstanceKey,
-    pub body: DurableOrdinaryBodyPayload,
-    pub type_inputs: Arc<[crate::StableDefinitionInputFingerprint]>,
-}
-
-/// Request-local location and live-name projection for a stable CFG input.
-/// Neither field participates in red/green equality or retained artifacts.
-#[derive(Debug, Clone)]
-pub(crate) struct CurrentCfgInput {
-    pub stable: StableCfgInput,
-    pub body_span: Span,
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub(crate) enum LayoutDependencyFailure {
-    MissingDefinition,
-    AmbiguousDefinition,
-    MissingNominal,
-    AmbiguousNominal,
-}
-
-pub(crate) fn body_type_dependencies(
-    body: &DurableOrdinaryBodyPayload,
-) -> BTreeSet<crate::StableDefinitionKey> {
-    fn visit(value: &CanonicalType, keys: &mut BTreeSet<crate::StableDefinitionKey>) {
-        match value {
-            SemanticImportType::Nominal(key) => {
-                keys.insert(key.clone());
-            }
-            SemanticImportType::AnonymousNominal(identity) => {
-                let keys = std::cell::RefCell::new(keys);
-                identity
-                    .try_map_identities(
-                        &|key| {
-                            keys.borrow_mut().insert(key.clone());
-                            Ok::<_, std::convert::Infallible>(key.clone())
-                        },
-                        &|module| Ok::<_, std::convert::Infallible>(module.clone()),
-                    )
-                    .expect("anonymous dependency traversal is infallible");
-            }
-            SemanticImportType::Array { element, .. } => visit(element, keys),
-            _ => {}
-        }
-    }
-    fn nominal(
-        value: &rue_air::NominalInstanceKey<crate::StableDefinitionKey, crate::ModuleId>,
-        keys: &mut BTreeSet<crate::StableDefinitionKey>,
-    ) {
-        let keys = std::cell::RefCell::new(keys);
-        match value {
-            rue_air::NominalInstanceKey::Builtin { .. } => {}
-            rue_air::NominalInstanceKey::Named(key) => {
-                keys.borrow_mut().insert(key.clone());
-            }
-            rue_air::NominalInstanceKey::Anonymous(identity) => {
-                identity
-                    .try_map_identities(
-                        &|key| {
-                            keys.borrow_mut().insert(key.clone());
-                            Ok::<_, std::convert::Infallible>(key.clone())
-                        },
-                        &|module| Ok::<_, std::convert::Infallible>(module.clone()),
-                    )
-                    .expect("anonymous nominal dependency traversal is infallible");
-            }
-        }
-    }
-    let mut keys = BTreeSet::new();
-    visit(&body.return_type, &mut keys);
-    for instruction in body.instructions.iter() {
-        visit(&instruction.ty, &mut keys);
-    }
-    for place in body.places.iter() {
-        visit(&place.base_type, &mut keys);
-        for projection in place.projections.iter() {
-            match projection {
-                crate::DurableProjection::Field { struct_key, .. } => {
-                    nominal(struct_key, &mut keys);
-                }
-                crate::DurableProjection::Index { array_type, .. } => visit(array_type, &mut keys),
-            }
-        }
-    }
-    for (_, ty) in body.param_drops.iter() {
-        visit(ty, &mut keys);
-    }
-    for instruction in body.instructions.iter() {
-        match &instruction.data {
-            DurableAirInstData::TypeConst(ty) | DurableAirInstData::IntCast { from_ty: ty, .. } => {
-                visit(ty, &mut keys)
-            }
-            DurableAirInstData::StructInit { struct_key, .. } => {
-                nominal(struct_key, &mut keys);
-            }
-            DurableAirInstData::EnumVariant { enum_key, .. }
-            | DurableAirInstData::EnumPayloadGet { enum_key, .. } => {
-                nominal(enum_key, &mut keys);
-            }
-            _ => {}
-        }
-        if let DurableAirInstData::Intrinsic { name, args, .. } = &instruction.data
-            && matches!(name.as_ref(), "ptr_read" | "ptr_write" | "ptr_offset")
-        {
-            for arg in args.iter() {
-                if let Some(argument) = body.instructions.get(arg.value as usize) {
-                    match &argument.ty {
-                        SemanticImportType::PtrConst(pointee)
-                        | SemanticImportType::PtrMut(pointee) => visit(pointee, &mut keys),
-                        _ => {}
-                    }
-                }
-            }
-        }
-    }
-    keys
-}
-
-pub(crate) fn transitive_body_type_dependencies(
-    body: &DurableOrdinaryBodyPayload,
-    pool: &rue_air::FrozenTypeInternPool,
-    definitions: &crate::BoundDefinitionSet,
-) -> Result<BTreeSet<crate::StableDefinitionKey>, LayoutDependencyFailure> {
-    let mut keys = body_type_dependencies(body);
-    let mut pending = keys.iter().cloned().collect::<Vec<_>>();
-    let stable_key = |file: rue_span::FileId, name: &str, kind| {
-        let matches = definitions
-            .definitions()
-            .iter()
-            .filter(|record| {
-                record.stable_key().kind() == kind
-                    && record.stable_key().name() == name
-                    && record.declaration_span().file_id == file
-            })
-            .take(2)
-            .collect::<Vec<_>>();
-        match matches.as_slice() {
-            [record] => Ok(record.stable_key().clone()),
-            [] => Err(LayoutDependencyFailure::MissingDefinition),
-            _ => Err(LayoutDependencyFailure::AmbiguousDefinition),
-        }
-    };
-    while let Some(key) = pending.pop() {
-        let record = definitions
-            .definition_by_key(&key)
-            .ok_or(LayoutDependencyFailure::MissingDefinition)?;
-        let file = record.declaration_span().file_id;
-        let mut nested = Vec::new();
-        match key.kind() {
-            crate::StableDefinitionKind::Struct => {
-                let ids = pool
-                    .all_struct_ids()
-                    .into_iter()
-                    .filter(|id| {
-                        let def = pool.struct_def(*id);
-                        def.file_id == file && def.name == key.name()
-                    })
-                    .take(2)
-                    .collect::<Vec<_>>();
-                let [id] = ids.as_slice() else {
-                    return Err(if ids.is_empty() {
-                        LayoutDependencyFailure::MissingNominal
-                    } else {
-                        LayoutDependencyFailure::AmbiguousNominal
-                    });
-                };
-                nested.extend(pool.struct_def(*id).fields.iter().map(|field| field.ty));
-            }
-            crate::StableDefinitionKind::Enum => {
-                let ids = pool
-                    .all_enum_ids()
-                    .into_iter()
-                    .filter(|id| {
-                        let def = pool.enum_def(*id);
-                        def.file_id == file && def.name == key.name()
-                    })
-                    .take(2)
-                    .collect::<Vec<_>>();
-                let [id] = ids.as_slice() else {
-                    return Err(if ids.is_empty() {
-                        LayoutDependencyFailure::MissingNominal
-                    } else {
-                        LayoutDependencyFailure::AmbiguousNominal
-                    });
-                };
-                let def = pool.enum_def(*id);
-                for index in 0..def.variant_count() {
-                    nested.extend_from_slice(def.variant_payload(index));
-                }
-            }
-            _ => {}
-        }
-        while let Some(ty) = nested.pop() {
-            let found = match ty.kind() {
-                TypeKind::Struct(id) => {
-                    let def = pool.struct_def(id);
-                    (!def.is_builtin)
-                        .then(|| {
-                            stable_key(def.file_id, &def.name, crate::StableDefinitionKind::Struct)
-                        })
-                        .transpose()?
-                }
-                TypeKind::Enum(id) => {
-                    let def = pool.enum_def(id);
-                    Some(stable_key(
-                        def.file_id,
-                        &def.name,
-                        crate::StableDefinitionKind::Enum,
-                    )?)
-                }
-                TypeKind::Array(id) => {
-                    nested.push(pool.array_def(id).0);
-                    None
-                }
-                TypeKind::PtrConst(_) | TypeKind::PtrMut(_) => None,
-                _ => None,
-            };
-            if let Some(found) = found.filter(|found| keys.insert(found.clone())) {
-                pending.push(found);
-            }
-        }
-    }
-    Ok(keys)
-}
-
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
 enum StableCfgSymbol {
     Callable(rue_air::FunctionInstanceKey<crate::StableDefinitionKey, crate::ModuleId>),
+    #[allow(dead_code)]
     Specialization(
         rue_air::SemanticSpecializationIdentity<crate::StableDefinitionKey, crate::ModuleId>,
     ),
+    Runtime(Arc<str>),
     Intrinsic(Arc<str>),
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum StableCfgSpan {
+    Relative { start: i64, end: i64 },
+    Absolute(Span),
+}
+
+impl StableCfgSpan {
+    fn new(span: Span, body_span: Span) -> Self {
+        if span.file_id == body_span.file_id {
+            Self::Relative {
+                start: i64::from(span.start) - i64::from(body_span.start),
+                end: i64::from(span.end) - i64::from(body_span.start),
+            }
+        } else {
+            Self::Absolute(span)
+        }
+    }
+
+    fn relocate(self, body_span: Span) -> Result<Span, CfgDomainFailure> {
+        match self {
+            Self::Relative { start, end } => Ok(Span {
+                file_id: body_span.file_id,
+                start: u32::try_from(i64::from(body_span.start) + start)
+                    .map_err(|_| CfgDomainFailure::Shape)?,
+                end: u32::try_from(i64::from(body_span.start) + end)
+                    .map_err(|_| CfgDomainFailure::Shape)?,
+            }),
+            Self::Absolute(span) => Ok(span),
+        }
+    }
 }
 
 #[derive(Debug, Clone)]
 pub(crate) struct CfgDomainProjection {
+    body_span: Span,
     types: Vec<(Type, CanonicalType)>,
     strings: Vec<(u32, Arc<str>)>,
     atoms: Vec<rue_air::SemanticBodyLocalAtom<crate::StableDefinitionKey, crate::ModuleId>>,
-    spans: Vec<(Span, crate::DurableBodyAnchor)>,
+    spans: Vec<(Span, StableCfgSpan)>,
     symbols: Vec<(Spur, StableCfgSymbol)>,
+    incomplete_epoch: Option<Arc<()>>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -277,38 +232,236 @@ pub(crate) enum CfgDomainFailure {
     Shape,
     Unsupported,
     Missing,
+    MissingLiveType(Type),
+    MissingStableType,
+    MissingSymbol,
+    MissingString,
     Edit(rue_cfg::CfgEditError),
 }
 
 impl CfgDomainProjection {
+    #[cfg(test)]
+    pub(crate) fn force_import_failure_for_test(&mut self) {
+        self.incomplete_epoch = Some(Arc::new(()));
+    }
+
+    pub(crate) fn same_live_domain(&self, other: &Self) -> bool {
+        let complete_or_same_epoch = match (&self.incomplete_epoch, &other.incomplete_epoch) {
+            (None, None) => true,
+            (Some(left), Some(right)) => Arc::ptr_eq(left, right),
+            _ => false,
+        };
+        complete_or_same_epoch
+            && self.body_span == other.body_span
+            && self.types == other.types
+            && self.strings == other.strings
+            && self.atoms == other.atoms
+            && self.spans == other.spans
+            && self.symbols == other.symbols
+    }
+
+    pub(crate) fn same_optimized_memo_domain(&self, other: &Self) -> bool {
+        match (&self.incomplete_epoch, &other.incomplete_epoch) {
+            (None, None) => true,
+            (Some(left), Some(right)) => Arc::ptr_eq(left, right),
+            _ => false,
+        }
+    }
+
+    pub(crate) fn optimized_memo_domain_hash(&self) -> usize {
+        self.incomplete_epoch
+            .as_ref()
+            .map_or(0, |epoch| Arc::as_ptr(epoch) as usize)
+    }
+
+    /// Build the relocation domain for one canonical analyzed function without
+    /// consulting a program-wide CFG cache. Every live type, symbol, string,
+    /// local atom, and span is paired with its stable record-local identity.
+    pub(crate) fn from_canonical_function(
+        function: &AnalyzedFunction,
+        stable_identity: &crate::FunctionInstanceKey,
+        body_span: Span,
+        strings: &[String],
+        interner: &lasso::ThreadedRodeo,
+        stable_type: impl Fn(Type) -> Result<CanonicalType, CfgDomainFailure>,
+        stable_callable: impl Fn(lasso::Spur) -> Option<crate::FunctionInstanceKey>,
+    ) -> Result<Self, CfgDomainFailure> {
+        let mut types = vec![
+            (
+                function.air.return_type(),
+                stable_type(function.air.return_type())?,
+            ),
+            (Type::UNIT, CanonicalType::Unit),
+        ];
+        let mut stable_strings = Vec::new();
+        let mut spans = Vec::new();
+        let mut symbols = Vec::new();
+        let mut atoms = Vec::with_capacity(function.local_atoms.len());
+        for atom in &function.local_atoms {
+            if atom.identity.producer != function.identity
+                || strings.get(atom.dense_id as usize).map(String::as_str)
+                    != Some(atom.content.as_ref())
+            {
+                return Err(CfgDomainFailure::Shape);
+            }
+            atoms.push(rue_air::SemanticBodyLocalAtom {
+                identity: crate::LocalAtomId {
+                    producer: stable_identity.clone(),
+                    kind: atom.identity.kind,
+                    anchor: atom.identity.anchor.clone(),
+                },
+                content: atom.content.clone(),
+            });
+        }
+        for (_, instruction) in function.air.iter() {
+            types.push((instruction.ty, stable_type(instruction.ty)?));
+            spans.push((
+                instruction.span,
+                StableCfgSpan::new(instruction.span, body_span),
+            ));
+            match &instruction.data {
+                AirInstData::StringConst(index) => {
+                    stable_strings.push((
+                        *index,
+                        strings
+                            .get(*index as usize)
+                            .ok_or(CfgDomainFailure::Shape)?
+                            .as_str()
+                            .into(),
+                    ));
+                }
+                AirInstData::IntCast { from_ty, .. } => {
+                    types.push((*from_ty, stable_type(*from_ty)?));
+                }
+                AirInstData::Call { name, .. } => {
+                    let symbol = stable_callable(*name)
+                        .map(StableCfgSymbol::Callable)
+                        .unwrap_or_else(|| {
+                            StableCfgSymbol::Intrinsic(Arc::from(interner.resolve(name)))
+                        });
+                    symbols.push((*name, symbol));
+                }
+                AirInstData::Intrinsic { name, .. } => {
+                    symbols.push((
+                        *name,
+                        StableCfgSymbol::Intrinsic(Arc::from(interner.resolve(name))),
+                    ));
+                }
+                _ => {}
+            }
+        }
+        for place in function.air.places() {
+            types.push((place.base_type, stable_type(place.base_type)?));
+            for projection in function.air.get_place_projections(place) {
+                match projection {
+                    rue_air::AirProjection::Field { struct_id, .. } => {
+                        let ty = Type::new_struct(*struct_id);
+                        types.push((ty, stable_type(ty)?));
+                    }
+                    rue_air::AirProjection::Index { array_type, .. } => {
+                        types.push((*array_type, stable_type(*array_type)?));
+                    }
+                }
+            }
+        }
+        for (_, ty) in function.air.param_drops() {
+            types.push((*ty, stable_type(*ty)?));
+        }
+        let types = deduplicate_type_mappings(types)?;
+        stable_strings.sort_by_key(|(index, _)| *index);
+        stable_strings.dedup();
+        spans.sort_by_key(|(span, _)| (span.file_id.index(), span.start, span.end));
+        spans.dedup();
+        symbols.sort_by(|left, right| {
+            (left.0.into_usize(), &left.1).cmp(&(right.0.into_usize(), &right.1))
+        });
+        symbols.dedup_by(|left, right| left.0 == right.0 && left.1 == right.1);
+        if symbols.windows(2).any(|pair| pair[0].0 == pair[1].0) {
+            return Err(CfgDomainFailure::Shape);
+        }
+        atoms.sort_by(|left, right| {
+            (&left.identity, &left.content).cmp(&(&right.identity, &right.content))
+        });
+        Ok(Self {
+            body_span,
+            types,
+            strings: stable_strings,
+            atoms,
+            spans,
+            symbols,
+            incomplete_epoch: None,
+        })
+    }
+
+    pub(crate) fn stable_types(&self) -> impl Iterator<Item = &CanonicalType> {
+        self.types.iter().map(|(_, stable)| stable)
+    }
+
+    pub(crate) fn stable_callables(&self) -> impl Iterator<Item = crate::FunctionInstanceKey> + '_ {
+        self.symbols.iter().filter_map(|(_, symbol)| match symbol {
+            StableCfgSymbol::Callable(callable) => Some(callable.clone()),
+            StableCfgSymbol::Specialization(identity) => {
+                crate::semantic_identity::function_instance_from_specialization(identity)
+            }
+            StableCfgSymbol::Runtime(_) | StableCfgSymbol::Intrinsic(_) => None,
+        })
+    }
+
+    #[allow(dead_code)]
+    pub(crate) fn remap_span(
+        old: &Self,
+        new: &Self,
+        span: Span,
+        new_body_span: Span,
+    ) -> Result<Span, CfgDomainFailure> {
+        let anchor = old
+            .spans
+            .iter()
+            .find(|(candidate, _)| *candidate == span)
+            .map(|(_, anchor)| anchor)
+            .ok_or(CfgDomainFailure::Missing)?;
+        if !new.spans.iter().any(|(_, candidate)| candidate == anchor) {
+            return Err(CfgDomainFailure::Missing);
+        }
+        anchor.relocate(new_body_span)
+    }
+
+    #[allow(dead_code)]
     pub fn validate_cfg(&self, cfg: &rue_cfg::Cfg, span: Span) -> Result<(), CfgDomainFailure> {
         Self::import_cfg(self, self, cfg, span).map(|_| ())
     }
     pub fn from_body(
         function: &AnalyzedFunction,
-        input: &StableCfgInput,
+        stable_function: &crate::FunctionInstanceKey,
+        body: &rue_air::SemanticBody<crate::StableDefinitionKey, crate::ModuleId>,
         body_span: Span,
         strings: &[String],
+        type_pool: &rue_air::FrozenTypeInternPool,
+        interner: &lasso::ThreadedRodeo,
+        stable_type: impl Fn(Type) -> Result<CanonicalType, CfgDomainFailure>,
+        stable_callable: impl Fn(lasso::Spur) -> Option<crate::FunctionInstanceKey>,
     ) -> Result<Self, CfgDomainFailure> {
-        if function.air.instructions().len() != input.body.instructions.len() {
+        if function.air.instructions().len() != body.instructions.len() {
             return Err(CfgDomainFailure::Shape);
         }
-        let mut types = vec![(function.air.return_type(), input.body.return_type.clone())];
+        let mut types = vec![
+            (function.air.return_type(), body.return_type.clone()),
+            (Type::UNIT, CanonicalType::Unit),
+        ];
         let mut stable_strings = Vec::new();
         let mut spans = Vec::new();
         let mut symbols = Vec::new();
-        if function.local_atoms.len() != input.body.local_atoms.len() {
+        if function.local_atoms.len() != body.local_atoms.len() {
             return Err(CfgDomainFailure::Shape);
         }
         if function
             .local_atoms
             .iter()
             .any(|atom| atom.identity.producer != function.identity)
-            || input
-                .body
+            || body
                 .local_atoms
                 .iter()
-                .any(|atom| atom.identity.producer != input.function)
+                .any(|atom| atom.identity.producer != *stable_function)
         {
             return Err(CfgDomainFailure::Shape);
         }
@@ -328,8 +481,7 @@ impl CfgDomainProjection {
                 ))
             })
             .collect::<Result<Vec<_>, _>>()?;
-        let mut stable_atoms = input
-            .body
+        let mut stable_atoms = body
             .local_atoms
             .iter()
             .map(|atom| {
@@ -346,25 +498,20 @@ impl CfgDomainProjection {
         {
             return Err(CfgDomainFailure::Shape);
         }
-        for ((_, current), durable) in function.air.iter().zip(input.body.instructions.iter()) {
-            types.push((current.ty, durable.ty.clone()));
-            if current.span.file_id != body_span.file_id
-                || current.span.start < body_span.start
-                || current.span.end > body_span.end
+        for ((_, current), durable) in function.air.iter().zip(body.instructions.iter()) {
+            let current_kind = live_instruction_kind(&current.data);
+            let durable_kind = durable.data.kind();
+            if current_kind != durable_kind
+                && !(current_kind == rue_air::SemanticBodyInstKind::Call
+                    && durable_kind == rue_air::SemanticBodyInstKind::CallSpecialized)
             {
-                return Err(CfgDomainFailure::Unsupported);
+                return Err(CfgDomainFailure::Shape);
             }
-            spans.push((
-                current.span,
-                crate::DurableBodyAnchor {
-                    start: current.span.start - body_span.start,
-                    end: current.span.end - body_span.start,
-                },
-            ));
+            types.push((current.ty, durable.ty.clone()));
+            spans.push((current.span, StableCfgSpan::new(current.span, body_span)));
             match (&current.data, &durable.data) {
                 (AirInstData::StringConst(old), DurableAirInstData::StringConst(local)) => {
-                    let value = input
-                        .body
+                    let value = body
                         .strings
                         .get(*local as usize)
                         .ok_or(CfgDomainFailure::Shape)?;
@@ -373,45 +520,190 @@ impl CfgDomainProjection {
                     }
                     stable_strings.push((*old, value.clone()));
                 }
+                (AirInstData::TypeConst(current), DurableAirInstData::TypeConst(stable)) => {
+                    types.push((*current, stable.clone()))
+                }
                 (
                     AirInstData::IntCast { from_ty, .. },
                     DurableAirInstData::IntCast {
                         from_ty: stable, ..
                     },
                 ) => types.push((*from_ty, stable.clone())),
-                (AirInstData::Call { name, .. }, DurableAirInstData::Call { function, .. }) => {
-                    symbols.push((*name, StableCfgSymbol::Callable(function.clone())))
-                }
                 (
-                    AirInstData::Call { name, .. },
+                    AirInstData::Call {
+                        runtime: None,
+                        name,
+                        ..
+                    },
+                    DurableAirInstData::Call { function, .. },
+                ) => symbols.push((*name, StableCfgSymbol::Callable(function.clone()))),
+                (
+                    AirInstData::Call {
+                        runtime: None,
+                        name,
+                        ..
+                    },
                     DurableAirInstData::CallSpecialized { identity, .. },
                 ) => symbols.push((*name, StableCfgSymbol::Specialization(identity.clone()))),
                 (
-                    AirInstData::Intrinsic { name, .. },
-                    DurableAirInstData::Intrinsic { name: stable, .. },
-                ) => symbols.push((*name, StableCfgSymbol::Intrinsic(stable.clone()))),
-                _ => {}
+                    AirInstData::Call {
+                        runtime: Some(current),
+                        name,
+                        ..
+                    },
+                    DurableAirInstData::RuntimeCall {
+                        runtime: stable, ..
+                    },
+                ) if current == stable
+                    && interner.resolve(name) == current.helper().helper().symbol =>
+                {
+                    symbols.push((
+                        *name,
+                        StableCfgSymbol::Runtime(Arc::from(stable.helper().helper().symbol)),
+                    ));
+                }
+                (
+                    AirInstData::Intrinsic { runtime, name, .. },
+                    DurableAirInstData::Intrinsic {
+                        runtime: stable_runtime,
+                        name: stable,
+                        ..
+                    },
+                ) if runtime == stable_runtime && interner.resolve(name) == stable.as_ref() => {
+                    symbols.push((*name, StableCfgSymbol::Intrinsic(stable.clone())));
+                }
+                (
+                    AirInstData::StructInit { struct_id, .. },
+                    DurableAirInstData::StructInit { struct_key, .. },
+                ) => types.push((Type::new_struct(*struct_id), canonical_nominal(struct_key))),
+                (
+                    AirInstData::EnumVariant { enum_id, .. },
+                    DurableAirInstData::EnumVariant { enum_key, .. },
+                )
+                | (
+                    AirInstData::EnumPayloadGet { enum_id, .. },
+                    DurableAirInstData::EnumPayloadGet { enum_key, .. },
+                ) => types.push((Type::new_enum(*enum_id), canonical_nominal(enum_key))),
+                (
+                    AirInstData::Match { arms, .. },
+                    DurableAirInstData::Match { arms: stable, .. },
+                ) => {
+                    let current = function.air.get_match_arms(arms).collect::<Vec<_>>();
+                    if current.len() != stable.len() {
+                        return Err(CfgDomainFailure::Shape);
+                    }
+                    for ((pattern, _), stable) in current.into_iter().zip(stable.iter()) {
+                        match (pattern, &stable.pattern) {
+                            (
+                                rue_air::AirPattern::EnumVariant { enum_id, .. },
+                                rue_air::SemanticBodyPattern::EnumVariant { enum_key, .. },
+                            ) => types.push((Type::new_enum(enum_id), canonical_nominal(enum_key))),
+                            (rue_air::AirPattern::EnumVariant { .. }, _)
+                            | (_, rue_air::SemanticBodyPattern::EnumVariant { .. }) => {
+                                return Err(CfgDomainFailure::Shape);
+                            }
+                            _ => {}
+                        }
+                    }
+                }
+                _ if current_kind == durable_kind => {}
+                _ => return Err(CfgDomainFailure::Shape),
             }
         }
-        for (current, stable) in function.air.places().iter().zip(input.body.places.iter()) {
+        for (current, stable) in function.air.places().iter().zip(body.places.iter()) {
             types.push((current.base_type, stable.base_type.clone()));
             let current_projections = function.air.get_place_projections(current);
             if current_projections.len() != stable.projections.len() {
                 return Err(CfgDomainFailure::Shape);
             }
             for (current, stable) in current_projections.iter().zip(stable.projections.iter()) {
-                if let (
-                    rue_air::AirProjection::Index { array_type, .. },
-                    crate::DurableProjection::Index {
-                        array_type: stable, ..
-                    },
-                ) = (current, stable)
-                {
-                    types.push((*array_type, stable.clone()));
+                match (current, stable) {
+                    (
+                        rue_air::AirProjection::Field { struct_id, .. },
+                        crate::DurableProjection::Field { struct_key, .. },
+                    ) => types.push((Type::new_struct(*struct_id), canonical_nominal(struct_key))),
+                    (
+                        rue_air::AirProjection::Index { array_type, .. },
+                        crate::DurableProjection::Index {
+                            array_type: stable, ..
+                        },
+                    ) => types.push((*array_type, stable.clone())),
+                    _ => return Err(CfgDomainFailure::Shape),
                 }
             }
         }
-        let types = deduplicate_type_mappings(types)?;
+        if function.air.param_drops().len() != body.param_drops.len() {
+            return Err(CfgDomainFailure::Shape);
+        }
+        for ((current_slot, current), (stable_slot, stable)) in function
+            .air
+            .param_drops()
+            .iter()
+            .zip(body.param_drops.iter())
+        {
+            if current_slot != stable_slot {
+                return Err(CfgDomainFailure::Shape);
+            }
+            types.push((*current, stable.clone()));
+        }
+        // CFG cleanup elaboration recursively reads aggregate fields, variant
+        // payloads, arrays, and destructor symbols. Close the live type domain
+        // over those facts so every emitted CFG handle can be relocated.
+        let mut types = deduplicate_type_mappings(types)?;
+        let mut pending = types
+            .iter()
+            .map(|(current, _)| *current)
+            .collect::<Vec<_>>();
+        let mut visited = std::collections::HashSet::new();
+        let mut incomplete = false;
+        while let Some(current) = pending.pop() {
+            if !visited.insert(current) {
+                continue;
+            }
+            let children = match current.kind() {
+                TypeKind::Struct(id) => {
+                    let definition = type_pool.struct_def(id);
+                    if let Some(name) = &definition.destructor {
+                        let symbol = interner.get_or_intern(name);
+                        if let Some(callable) = stable_callable(symbol) {
+                            symbols.push((symbol, StableCfgSymbol::Callable(callable)));
+                        } else {
+                            incomplete = true;
+                        }
+                    }
+                    definition
+                        .fields
+                        .iter()
+                        .map(|field| field.ty)
+                        .collect::<Vec<_>>()
+                }
+                TypeKind::Enum(id) => type_pool
+                    .enum_def(id)
+                    .variant_payloads
+                    .iter()
+                    .flatten()
+                    .copied()
+                    .collect(),
+                TypeKind::Array(id) => vec![type_pool.array_def(id).0],
+                _ => Vec::new(),
+            };
+            for child in children {
+                if visited.contains(&child) {
+                    continue;
+                }
+                if !types.iter().any(|(current, _)| *current == child) {
+                    match stable_type(child) {
+                        Ok(stable) => types.push((child, stable)),
+                        Err(CfgDomainFailure::Missing | CfgDomainFailure::Unsupported) => {
+                            incomplete = true;
+                            continue;
+                        }
+                        Err(failure) => return Err(failure),
+                    }
+                }
+                pending.push(child);
+            }
+        }
         stable_strings.sort_by_key(|(index, _)| *index);
         stable_strings.dedup();
         spans.sort_by_key(|(span, _)| (span.file_id.index(), span.start, span.end));
@@ -423,16 +715,18 @@ impl CfgDomainProjection {
         if symbols.windows(2).any(|pair| pair[0].0 == pair[1].0) {
             return Err(CfgDomainFailure::Shape);
         }
-        let mut atoms = input.body.local_atoms.to_vec();
+        let mut atoms = body.local_atoms.to_vec();
         atoms.sort_by(|left, right| {
             (&left.identity, &left.content).cmp(&(&right.identity, &right.content))
         });
         Ok(Self {
+            body_span,
             types,
             strings: stable_strings,
             atoms,
             spans,
             symbols,
+            incomplete_epoch: incomplete.then(|| Arc::new(())),
         })
     }
 
@@ -441,14 +735,14 @@ impl CfgDomainProjection {
             .iter()
             .find(|(current, _)| *current == value)
             .map(|(_, stable)| stable.clone())
-            .ok_or(CfgDomainFailure::Missing)
+            .ok_or(CfgDomainFailure::MissingLiveType(value))
     }
     fn current_type(&self, value: &CanonicalType) -> Result<Type, CfgDomainFailure> {
         self.types
             .iter()
             .find(|(_, stable)| stable == value)
             .map(|(current, _)| *current)
-            .ok_or(CfgDomainFailure::Missing)
+            .ok_or(CfgDomainFailure::MissingStableType)
     }
     fn stable_nominal(&self, value: Type) -> Result<CanonicalType, CfgDomainFailure> {
         self.stable_type(value)
@@ -463,6 +757,9 @@ impl CfgDomainProjection {
         cfg: &rue_cfg::Cfg,
         new_span: Span,
     ) -> Result<rue_cfg::CfgEditor, CfgDomainFailure> {
+        if old.incomplete_epoch.is_some() || new.incomplete_epoch.is_some() {
+            return Err(CfgDomainFailure::Missing);
+        }
         if old.atoms != new.atoms {
             return Err(CfgDomainFailure::Shape);
         }
@@ -488,12 +785,12 @@ impl CfgDomainProjection {
                     .iter()
                     .find(|(symbol, _)| *symbol == value)
                     .map(|(_, value)| value)
-                    .ok_or(CfgDomainFailure::Missing)?;
+                    .ok_or(CfgDomainFailure::MissingSymbol)?;
                 new.symbols
                     .iter()
                     .find(|(_, identity)| identity == stable)
                     .map(|(symbol, _)| *symbol)
-                    .ok_or(CfgDomainFailure::Missing)
+                    .ok_or(CfgDomainFailure::MissingSymbol)
             },
             |value| {
                 let stable = old
@@ -501,25 +798,21 @@ impl CfgDomainProjection {
                     .iter()
                     .find(|(index, _)| *index == value)
                     .map(|(_, value)| value)
-                    .ok_or(CfgDomainFailure::Missing)?;
+                    .ok_or(CfgDomainFailure::MissingString)?;
                 new.strings
                     .iter()
                     .find(|(_, value)| value == stable)
                     .map(|(index, _)| *index)
-                    .ok_or(CfgDomainFailure::Missing)
+                    .ok_or(CfgDomainFailure::MissingString)
             },
             |value| {
                 let anchor = old
                     .spans
                     .iter()
                     .find(|(span, _)| *span == value)
-                    .map(|(_, anchor)| anchor)
-                    .ok_or(CfgDomainFailure::Missing)?;
-                Ok(Span {
-                    file_id: new_span.file_id,
-                    start: new_span.start + anchor.start,
-                    end: new_span.start + anchor.end,
-                })
+                    .map(|(_, anchor)| *anchor)
+                    .unwrap_or_else(|| StableCfgSpan::new(value, old.body_span));
+                anchor.relocate(new_span)
             },
         )
         .map_err(|error| match error {
@@ -535,17 +828,23 @@ mod tests {
     use lasso::Key;
     use rue_cfg::{Cfg, CfgInstData};
 
-    fn projection(symbol: Spur) -> CfgDomainProjection {
+    fn projection_with(symbol: Spur, stable: StableCfgSymbol) -> CfgDomainProjection {
         CfgDomainProjection {
+            body_span: Span::new(4, 5),
             types: vec![(Type::I32, SemanticImportType::I32)],
             strings: Vec::new(),
             atoms: Vec::new(),
             spans: vec![(
                 Span::new(4, 5),
-                crate::DurableBodyAnchor { start: 0, end: 1 },
+                StableCfgSpan::Relative { start: 0, end: 1 },
             )],
-            symbols: vec![(symbol, StableCfgSymbol::Intrinsic(Arc::from("stable")))],
+            symbols: vec![(symbol, stable)],
+            incomplete_epoch: None,
         }
+    }
+
+    fn projection(symbol: Spur) -> CfgDomainProjection {
+        projection_with(symbol, StableCfgSymbol::Intrinsic(Arc::from("stable")))
     }
 
     #[test]
@@ -596,10 +895,32 @@ mod tests {
         missing.symbols.clear();
         assert!(matches!(
             CfgDomainProjection::import_cfg(&projection(old), &missing, &cfg, Span::new(40, 50)),
-            Err(CfgDomainFailure::Missing)
+            Err(CfgDomainFailure::MissingSymbol)
         ));
         assert!(
             matches!(cfg.get_inst(rue_cfg::CfgValue::from_raw(0)).data, CfgInstData::Call { name, .. } if name == old)
+        );
+    }
+
+    #[test]
+    fn runtime_call_symbol_import_uses_stable_runtime_identity() {
+        let old = Spur::try_from_usize(5).unwrap();
+        let new = Spur::try_from_usize(29).unwrap();
+        let stable = StableCfgSymbol::Runtime(Arc::from("__rue_to_string"));
+        let mut cfg = Cfg::new(Type::I32, 0, 0, "f".into(), Vec::<bool>::new());
+        let block = cfg.new_block();
+        cfg.append_call(block, None, old, [], Type::I32, Span::new(4, 5))
+            .unwrap();
+
+        let imported = CfgDomainProjection::import_cfg(
+            &projection_with(old, stable.clone()),
+            &projection_with(new, stable),
+            &cfg,
+            Span::new(40, 50),
+        )
+        .unwrap();
+        assert!(
+            matches!(imported.get_inst(rue_cfg::CfgValue::from_raw(0)).data, CfgInstData::Call { name, .. } if name == new)
         );
     }
 }

--- a/crates/rue-compiler/src/durable_compatibility_tests.rs
+++ b/crates/rue-compiler/src/durable_compatibility_tests.rs
@@ -27,7 +27,6 @@ const REVIEWED_SEMANTIC_SCHEMA: DurableSemanticSchemaVersion = DurableSemanticSc
 // (RUE-1128); the payload-free 9/8 shapes fail closed to ordinary analysis.
 const REVIEWED_ORDINARY_BODY_SCHEMA: u32 = 10;
 const REVIEWED_SPECIALIZED_BODY_SCHEMA: u32 = 9;
-const REVIEWED_CFG_SCHEMA: u32 = 4;
 const REVIEWED_BODY_KINDS: usize = 58;
 const REVIEWED_TYPE_KINDS: usize = 21;
 const REVIEWED_CONST_KINDS: usize = 6;
@@ -106,10 +105,6 @@ fn reviewed_schema_versions_and_old_new_policy_are_explicit() {
     assert_eq!(
         DURABLE_SPECIALIZED_BODY_SCHEMA_VERSION,
         REVIEWED_SPECIALIZED_BODY_SCHEMA
-    );
-    assert_eq!(
-        crate::queries::DURABLE_CFG_SCHEMA_VERSION,
-        REVIEWED_CFG_SCHEMA
     );
     assert_eq!(SEMANTIC_BODY_INST_KINDS.len(), REVIEWED_BODY_KINDS);
     assert_eq!(SEMANTIC_IMPORT_TYPE_KINDS.len(), REVIEWED_TYPE_KINDS);

--- a/crates/rue-compiler/src/lib.rs
+++ b/crates/rue-compiler/src/lib.rs
@@ -40,6 +40,7 @@ mod bound_definitions;
 mod canonical_lower;
 mod canonical_merge;
 mod canonical_semantic;
+mod cfg_query;
 mod declaration_candidate;
 mod definition_snapshot;
 mod dependency_envelope;
@@ -211,8 +212,8 @@ pub(crate) use durable_body::{
     DurableBodyProjectionFailure,
 };
 pub(crate) use durable_body::{
-    DurableAirInstData, DurableBodyAnchor, DurableOrdinaryBody, DurableOrdinaryBodyPayload,
-    DurableProjection, DurableSpecializedBodyPayload, convert_semantic_specialized_body_exports,
+    DurableAirInstData, DurableOrdinaryBody, DurableOrdinaryBodyPayload, DurableProjection,
+    DurableSpecializedBodyPayload, convert_semantic_specialized_body_exports,
 };
 #[cfg(test)]
 pub(crate) use durable_semantics::DurableDeclarationPayload;
@@ -248,7 +249,6 @@ pub(crate) use durable_semantics::{
 pub(crate) use import_graph::{validate_additive_successor, validate_canonical_import_graph};
 #[cfg(test)]
 pub(crate) use linking::{parse_runtime_archive, validate_runtime};
-pub(crate) use queries::build_functions_and_cfgs;
 #[cfg(test)]
 pub(crate) use rue_parser::Item;
 pub(crate) use semantic_symbols::SemanticSymbolUniverse;
@@ -256,7 +256,7 @@ pub(crate) use syntax::SyntaxWork;
 
 pub(crate) use lasso::ThreadedRodeo;
 pub(crate) use rue_air::{AnalyzedFunction, SemaOutput, Type};
-pub(crate) use rue_cfg::{CfgBuilder, ValidatedCfg as Cfg};
+pub(crate) use rue_cfg::ValidatedCfg as Cfg;
 pub(crate) use rue_codegen::RelocationKind;
 pub(crate) use rue_linker::{
     Archive, CodeRelocation, Linker, ObjectBuilder, ObjectFile, RelocationType,

--- a/crates/rue-compiler/src/queries.rs
+++ b/crates/rue-compiler/src/queries.rs
@@ -1,3 +1,4 @@
+use rue_air::TypeKind;
 use tracing::{info, info_span};
 
 use crate::*;
@@ -96,7 +97,7 @@ impl Default for CompileOptions {
 #[derive(Debug)]
 pub struct FunctionWithCfg {
     /// The analyzed function from semantic analysis.
-    pub analyzed: AnalyzedFunction,
+    pub analyzed: std::sync::Arc<AnalyzedFunction>,
     /// Durable semantic identity retained independently from machine naming.
     pub semantic_identity: crate::FunctionInstanceKey,
     /// Typed symbol projection selected by the compiler authority.
@@ -146,22 +147,6 @@ pub(crate) struct CfgFrontendOutput {
         Vec<rue_air::ImplicitNamedDestructorDependencyEvent>,
     pub(crate) implicit_named_destructor_dependencies_complete: bool,
     pub(crate) work: canonical_semantic::CfgConstructionWork,
-    pub(crate) durable_cfgs: std::sync::Arc<[DurableCfgArtifact]>,
-}
-
-pub(crate) const DURABLE_CFG_SCHEMA_VERSION: u32 = 4;
-
-/// Last-good, fail-closed CFG candidate retained between semantic requests.
-///
-#[derive(Debug, Clone)]
-pub(crate) struct DurableCfgArtifact {
-    pub(crate) schema_version: u32,
-    pub(crate) semantic_schema_version: crate::DurableSemanticSchemaVersion,
-    pub(crate) input: crate::durable_cfg::StableCfgInput,
-    opt_level: OptLevel,
-    target: Target,
-    cfg: Cfg,
-    domains: crate::durable_cfg::CfgDomainProjection,
 }
 
 pub(crate) struct CfgConstructionFailure {
@@ -169,12 +154,10 @@ pub(crate) struct CfgConstructionFailure {
     pub(crate) work: canonical_semantic::CfgConstructionWork,
 }
 
-/// Lower semantic-analysis output through drop-glue synthesis, comptime filtering,
-/// CFG construction, and CFG optimization.
-///
-/// This is shared by `CompilerSession` queries and `--emit` presentation
-/// helpers so the live semantic tail stays in one place.
-pub(crate) fn build_functions_and_cfgs(
+/// Prepare reached functions and collect their canonical per-function
+/// `OptimizedCfg` terminals. This function owns deterministic batch assembly,
+/// not CFG construction or optimization.
+pub(crate) fn collect_function_cfg_queries(
     sema_output: SemaOutput,
     demanded_drop_glue: &std::collections::BTreeSet<
         rue_air::TypeInstanceKey<rue_air::SemanticDefinitionToken, rue_air::SemanticModuleToken>,
@@ -186,11 +169,14 @@ pub(crate) fn build_functions_and_cfgs(
             rue_air::SemanticModuleToken,
         >,
     >,
+    stable_drop_glue_plans: &std::collections::BTreeMap<
+        crate::TypeInstanceKey,
+        crate::type_queries::DropGlueFacts,
+    >,
     opt_level: OptLevel,
-    target: Target,
-    interner: &ThreadedRodeo,
-    durable_candidates: &[DurableCfgArtifact],
-    stable_inputs: &[crate::durable_cfg::CurrentCfgInput],
+    interner: std::sync::Arc<ThreadedRodeo>,
+    stable_inputs: &[crate::cfg_query::CfgBodyInput],
+    stable_aggregate_types: std::collections::HashMap<Type, crate::TypeInstanceKey>,
     projected_identities: &std::collections::BTreeMap<
         rue_air::FunctionInstanceKey<
             rue_air::SemanticDefinitionToken,
@@ -198,6 +184,10 @@ pub(crate) fn build_functions_and_cfgs(
         >,
         crate::FunctionInstanceKey,
     >,
+    cfg_queries: &crate::revisioned_query_database::RevisionedQueryDatabase,
+    revision: rue_query::Revision,
+    configuration: crate::semantic_query_nucleus::SemanticQueryConfiguration,
+    cancellation: rue_query::CancellationToken,
 ) -> Result<CfgFrontendOutput, CfgConstructionFailure> {
     let SemaOutput {
         functions,
@@ -238,6 +228,8 @@ pub(crate) fn build_functions_and_cfgs(
         .chain(drop_glue_functions)
         .collect();
     let mut legacy_to_machine = std::collections::BTreeMap::<String, String>::new();
+    let mut legacy_to_stable =
+        std::collections::BTreeMap::<String, crate::FunctionInstanceKey>::new();
     let mut canonical_owners =
         std::collections::BTreeMap::<String, crate::FunctionInstanceKey>::new();
     let mut projected = Vec::with_capacity(all_functions.len());
@@ -325,6 +317,7 @@ pub(crate) fn build_functions_and_cfgs(
                 work,
             });
         }
+        legacy_to_stable.insert(function.name.clone(), semantic_identity.clone());
         if let Some(previous) =
             canonical_owners.insert(machine_name.clone(), semantic_identity.clone())
             && previous != semantic_identity
@@ -354,241 +347,304 @@ pub(crate) fn build_functions_and_cfgs(
     // identity shared by user, specialized, destructor, and glue functions.
     all_functions.sort_by(|left, right| left.4.cmp(&right.4));
 
-    // Entered once on the calling thread and held across the stable collection.
-    let _span = info_span!("cfg_construction", phase = "cfg_and_optimization").entered();
-
+    let _span = info_span!("cfg_collection", phase = "cfg_query_collection").entered();
+    let aggregate_types = std::sync::Arc::new(stable_aggregate_types);
     let results: Vec<_> = all_functions
         .into_iter()
         .map(
             |(func, semantic_identity, symbol, local_atoms, machine_name)| {
                 let legacy_name = func.name.clone();
-                let dependency_source = func.implicit_drop_source.clone();
                 let current_input = stable_inputs
-                    .binary_search_by(|input| input.stable.function.cmp(&semantic_identity))
+                    .binary_search_by(|input| input.function.cmp(&semantic_identity))
                     .ok()
                     .map(|index| &stable_inputs[index]);
-                let projection = current_input.and_then(|input| {
-                    crate::durable_cfg::CfgDomainProjection::from_body(
-                        &func,
-                        &input.stable,
-                        input.body_span,
-                        &strings,
-                    )
-                    .ok()
+                let body_span = current_input.map(|input| input.body_span).or_else(|| {
+                    let mut instructions = func.air.iter().map(|(_, instruction)| instruction.span);
+                    let first = instructions.next()?;
+                    Some(instructions.fold(first, |span, next| rue_span::Span {
+                        file_id: span.file_id,
+                        start: span.start.min(next.start),
+                        end: span.end.max(next.end),
+                    }))
                 });
-                let candidate = current_input.and_then(|input| {
-                    durable_candidates
-                        .binary_search_by(|candidate| {
-                            candidate.input.function.cmp(&input.stable.function)
-                        })
-                        .ok()
-                        .map(|index| &durable_candidates[index])
-                });
-                let mut function_work = canonical_semantic::CfgConstructionWork::default();
-                if let Some(candidate) = candidate {
-                    function_work.cfg_reuse_candidates = 1;
-                    function_work.cfg_import_attempts = 1;
-                    let schema_compatible = candidate.schema_version == DURABLE_CFG_SCHEMA_VERSION
-                        && crate::DURABLE_SEMANTIC_SCHEMA_VERSION
-                            .accepts(candidate.semantic_schema_version);
-                    if !schema_compatible {
-                        function_work.cfg_schema_version_rejections = 1;
+                let Some(body_span) = body_span else {
+                    return Err((
+                        CompileError::without_span(ErrorKind::InternalError(format!(
+                            "callable '{}' has no CFG source span",
+                            func.name
+                        )))
+                        .into(),
+                        canonical_semantic::CfgConstructionWork::default(),
+                    ));
+                };
+                let semantic_input = if let Some(input) = current_input {
+                    crate::cfg_query::CfgSemanticInput::Body(std::sync::Arc::new(
+                        input.body.clone(),
+                    ))
+                } else if let crate::FunctionInstanceKey::DropGlue(owner) = &semantic_identity {
+                    let Some(facts) = stable_drop_glue_plans.get(owner.as_ref()) else {
+                        return Err((
+                            CompileError::without_span(ErrorKind::InternalError(format!(
+                                "drop glue {:?} has no canonical query plan",
+                                owner
+                            )))
+                            .into(),
+                            canonical_semantic::CfgConstructionWork::default(),
+                        ));
+                    };
+                    crate::cfg_query::CfgSemanticInput::DropGlue {
+                        owner: owner.as_ref().clone(),
+                        facts: Box::new(facts.clone()),
                     }
-                    if schema_compatible
-                        && candidate.opt_level == opt_level
-                        && candidate.target == target
-                        && current_input.is_some_and(|input| input.stable == candidate.input)
-                        && let Some(projection) = projection.as_ref()
-                    {
-                        match crate::durable_cfg::CfgDomainProjection::import_cfg(
-                            &candidate.domains,
-                            projection,
-                            &candidate.cfg,
-                            current_input.unwrap().body_span,
-                        ) {
-                            Ok(imported) => {
-                                let imported = imported.finish_after_optimization(&type_pool);
-                                if let Ok(imported) = imported {
-                                    function_work.cfg_import_successes = 1;
-                                    function_work.cfg_reuses = 1;
-                                    // Publish the current request's domain projection.
-                                    // Retaining the candidate's old spans would make a
-                                    // second position-only edit reuse stale locations.
-                                    let artifact = DurableCfgArtifact {
-                                        schema_version: candidate.schema_version,
-                                        semantic_schema_version: candidate.semantic_schema_version,
-                                        input: current_input.unwrap().stable.clone(),
-                                        opt_level: candidate.opt_level,
-                                        target: candidate.target,
-                                        cfg: imported.clone(),
-                                        domains: projection.clone(),
-                                    };
-                                    return Ok((
-                                        (
-                                            FunctionWithCfg {
-                                                analyzed: func,
-                                                semantic_identity,
-                                                symbol,
-                                                local_atoms,
-                                                machine_name,
-                                                legacy_name,
-                                                cfg: imported,
-                                            },
-                                            Vec::new(),
-                                            Vec::new(),
-                                            true,
-                                            Some(artifact),
-                                        ),
-                                        function_work,
-                                    ));
-                                }
-                            }
-                            Err(crate::durable_cfg::CfgDomainFailure::Edit(error)) => {
-                                function_work.cfg_import_failures = 1;
-                                function_work.cfg_builds_failed = 1;
-                                let mut errors = CompileErrors::new();
-                                errors.push(CompileError::new(
-                                    ErrorKind::InternalError(format!(
-                                        "CFG import payload construction failed: {error:?}"
-                                    )),
-                                    current_input.unwrap().body_span,
-                                ));
-                                return Err((errors, function_work));
-                            }
-                            Err(_) => {}
-                        }
-                    }
-                    function_work.cfg_import_failures = 1;
-                    function_work.cfg_fallbacks = 1;
-                }
-                function_work.cfg_builds_attempted = 1;
-                function_work.air_instructions_consumed = func.air.instructions().len();
-                let cfg_output = CfgBuilder::build(
-                    &func.air,
-                    func.num_locals,
-                    func.num_param_slots,
-                    &legacy_name,
-                    &type_pool,
-                    func.param_modes.clone(),
-                    interner,
-                    func.allow_unreachable_code,
-                    func.callable_kind,
-                );
-
-                // A non-empty `errors` means the CFG builder hit malformed AIR
-                // (an internal compiler error, RUE-7). Abort before optimizing
-                // the discarded CFG rather than working on it.
-                if !cfg_output.errors.is_empty() {
-                    function_work.cfg_builds_failed = 1;
-                    let mut errs = CompileErrors::new();
-                    for e in cfg_output.errors {
-                        errs.push(e);
-                    }
-                    return Err((errs, function_work));
-                }
-
-                function_work.cfg_builds_succeeded = 1;
-                function_work.optimization_attempts = 1;
-                function_work.optimized_level_attempts = usize::from(opt_level != OptLevel::O0);
-                let cfg = cfg_output
-                    .cfg
-                    .expect("successful CFG construction publishes a validated CFG");
-                let cfg = match rue_cfg::opt::optimize(cfg, opt_level, &type_pool) {
-                    Ok(cfg) => cfg,
-                    Err(error) => {
-                        function_work.cfg_builds_failed = 1;
-                        let mut errors = CompileErrors::new();
-                        errors.push(CompileError::without_span(ErrorKind::InternalError(
-                            format!("CFG optimization failed: {error}"),
-                        )));
-                        return Err((errors, function_work));
+                } else {
+                    return Err((
+                        CompileError::without_span(ErrorKind::InternalError(format!(
+                            "callable '{}' has no canonical CFG semantic input",
+                            func.name
+                        )))
+                        .into(),
+                        canonical_semantic::CfgConstructionWork::default(),
+                    ));
+                };
+                let func = std::sync::Arc::new(func);
+                let domains = match current_input
+                    .map(|input| {
+                        crate::durable_cfg::CfgDomainProjection::from_body(
+                            &func,
+                            &input.function,
+                            &input.body,
+                            body_span,
+                            &strings,
+                            &type_pool,
+                            &interner,
+                            |ty| {
+                                crate::durable_cfg::canonical_type_from_live(
+                                    ty,
+                                    &type_pool,
+                                    &aggregate_types,
+                                )
+                            },
+                            |symbol| legacy_to_stable.get(interner.resolve(&symbol)).cloned(),
+                        )
+                    })
+                    .unwrap_or_else(|| {
+                        crate::durable_cfg::CfgDomainProjection::from_canonical_function(
+                            &func,
+                            &semantic_identity,
+                            body_span,
+                            &strings,
+                            &interner,
+                            |ty| {
+                                crate::durable_cfg::canonical_type_from_live(
+                                    ty,
+                                    &type_pool,
+                                    &aggregate_types,
+                                )
+                            },
+                            |symbol| legacy_to_stable.get(interner.resolve(&symbol)).cloned(),
+                        )
+                    }) {
+                    Ok(domains) => domains,
+                    Err(failure) => {
+                        return Err((
+                            CompileError::new(
+                                ErrorKind::InternalError(format!(
+                                    "canonical CFG domain projection failed: {failure:?}"
+                                )),
+                                body_span,
+                            )
+                            .into(),
+                            canonical_semantic::CfgConstructionWork::default(),
+                        ));
                     }
                 };
-                function_work.optimization_completions = 1;
-                function_work.cfg_warnings_emitted = cfg_output.warnings.len();
-                function_work.implicit_destructor_targets_emitted =
-                    cfg_output.implicit_named_destructors.len();
-
-                let mut implicit_edges = Vec::new();
-                let mut complete = !cfg_output.anonymous_destructor_dependency_incomplete;
-                // A named struct definition globally owns its synthesized glue.
-                // Its own destructor is emitted as a direct AIR call rather than a
-                // CFG Drop, so retain that definition -> destructor edge here.
-                if let Some(rue_air::ImplicitDropDependencySourceEvent::NamedStruct {
-                    file,
-                    name,
-                }) = &dependency_source
-                {
-                    for struct_id in type_pool.all_struct_ids() {
-                        let target = type_pool.struct_def(struct_id);
-                        if target.file_id.index() == *file
-                            && target.name == *name
-                            && target.destructor.is_some()
-                            && !target.is_builtin
-                        {
-                            implicit_edges.push(rue_air::ImplicitNamedDestructorDependencyEvent {
-                                source: dependency_source.clone().unwrap(),
-                                target_file: *file,
-                                target_owner_name: name.clone(),
-                            });
-                        }
-                    }
+                #[cfg(test)]
+                let mut domains = domains;
+                #[cfg(test)]
+                if crate::canonical_semantic::take_test_cfg_import_failure() {
+                    domains.force_import_failure_for_test();
                 }
-                if !cfg_output.implicit_named_destructors.is_empty() {
-                    if matches!(
-                        dependency_source,
+                let live = std::sync::Arc::new(crate::cfg_query::CfgLiveInput {
+                    function: func.clone(),
+                    type_pool: type_pool.clone(),
+                    interner: interner.clone(),
+                    domains: domains.clone(),
+                    body_span,
+                    aggregate_types: aggregate_types.clone(),
+                    implicit_destructor_dependencies_complete: !matches!(
+                        func.implicit_drop_source,
                         Some(rue_air::ImplicitDropDependencySourceEvent::Anonymous)
-                    ) {
-                        complete = false;
-                    } else if let Some(source) = dependency_source {
-                        for struct_id in cfg_output.implicit_named_destructors {
-                            let target = type_pool.struct_def(struct_id);
-                            implicit_edges.push(rue_air::ImplicitNamedDestructorDependencyEvent {
-                                source: source.clone(),
-                                target_file: target.file_id.index(),
-                                target_owner_name: target.name.clone(),
-                            });
+                    ),
+                });
+                let (_, attempt) = cfg_queries
+                    .optimized_cfg(
+                        revision,
+                        semantic_identity.clone(),
+                        configuration.clone(),
+                        semantic_input,
+                        live,
+                        opt_level,
+                        cancellation.clone(),
+                    )
+                    .map_err(|abort| {
+                        (
+                            CompileError::without_span(ErrorKind::InternalError(format!(
+                                "CFG query aborted: {abort:?}"
+                            )))
+                            .into(),
+                            canonical_semantic::CfgConstructionWork::default(),
+                        )
+                    })?;
+                let optimized_execution = attempt.execution();
+                let direct_work = |name: &str| {
+                    attempt
+                        .work()
+                        .iter()
+                        .find_map(|(kind, count)| {
+                            (kind.as_ref() == name).then_some(*count as usize)
+                        })
+                        .unwrap_or(0)
+                };
+                let fallback_builds = direct_work("cfg.build.attempts");
+                let fallback_build_successes = direct_work("cfg.build.successes");
+                let fallback_build_failures = direct_work("cfg.build.failures");
+                let import_attempts = direct_work("cfg.import.attempts");
+                let import_successes = direct_work("cfg.import.successes");
+                let import_failures = direct_work("cfg.import.failures");
+                let cfg_fallbacks = direct_work("cfg.fallbacks");
+                let cfg_execution = attempt
+                    .nested_attempts()
+                    .iter()
+                    .find(|attempt| attempt.node().family() == "compiler.cfg")
+                    .map(rue_query::NestedQueryAttempt::execution);
+                let terminal = attempt.into_result().map_err(|abort| {
+                    (
+                        CompileError::without_span(ErrorKind::InternalError(format!(
+                            "optimized CFG query aborted: {abort:?}"
+                        )))
+                        .into(),
+                        canonical_semantic::CfgConstructionWork::default(),
+                    )
+                })?;
+                let rue_query::QueryOutcome::Success(value) = terminal.outcome() else {
+                    unreachable!("OptimizedCfg publishes typed values")
+                };
+                let mut function_work = canonical_semantic::CfgConstructionWork::default();
+                if cfg_execution == Some(rue_query::RequestExecution::Computed) {
+                    function_work.cfg_builds_attempted = 1;
+                    function_work.cfg_builds_succeeded =
+                        usize::from(matches!(value, crate::cfg_query::CfgValue::Available(_)));
+                    function_work.cfg_builds_failed = 1 - function_work.cfg_builds_succeeded;
+                    function_work.air_instructions_consumed = func.air.instructions().len();
+                } else if fallback_builds != 0 {
+                    function_work.cfg_reuse_candidates = 1;
+                    function_work.cfg_builds_attempted = fallback_builds;
+                    function_work.cfg_builds_succeeded = fallback_build_successes;
+                    function_work.cfg_builds_failed = fallback_build_failures;
+                    function_work.air_instructions_consumed =
+                        func.air.instructions().len() * fallback_builds;
+                    function_work.cfg_import_attempts = import_attempts;
+                    function_work.cfg_import_successes = import_successes;
+                    function_work.cfg_import_failures = import_failures;
+                    function_work.cfg_fallbacks = cfg_fallbacks;
+                } else {
+                    function_work.cfg_reuses = 1;
+                    // Preserve the existing reuse accounting when no relocation
+                    // was required; exact relocation work, when present, comes
+                    // from the optimized evaluator's direct work record.
+                    function_work.cfg_import_attempts = import_attempts.max(1);
+                    function_work.cfg_import_successes = import_successes.max(1);
+                }
+                if optimized_execution == rue_query::RequestExecution::Computed
+                    && matches!(value, crate::cfg_query::CfgValue::Available(_))
+                {
+                    function_work.optimization_attempts = 1;
+                    function_work.optimization_completions =
+                        usize::from(matches!(value, crate::cfg_query::CfgValue::Available(_)));
+                    function_work.optimized_level_attempts = usize::from(opt_level != OptLevel::O0);
+                }
+                match value {
+                    crate::cfg_query::CfgValue::Failure {
+                        errors,
+                        body_span: old_span,
+                        ..
+                    } => Err((
+                        crate::cfg_query::import_errors(errors, *old_span, body_span),
+                        function_work,
+                    )),
+                    crate::cfg_query::CfgValue::Available(record) => {
+                        let cfg = if record.domains.same_live_domain(&domains) {
+                            record.cfg.clone()
+                        } else {
+                            crate::durable_cfg::CfgDomainProjection::import_cfg(
+                                &record.domains,
+                                &domains,
+                                &record.cfg,
+                                body_span,
+                            )
+                            .and_then(|editor| {
+                                editor
+                                    .finish_after_optimization(&type_pool)
+                                    .map_err(|_| crate::durable_cfg::CfgDomainFailure::Shape)
+                            })
+                            .map_err(|failure| {
+                                (
+                                    CompileError::new(
+                                        ErrorKind::InternalError(format!(
+                                            "CFG terminal relocation failed: {failure:?}"
+                                        )),
+                                        body_span,
+                                    )
+                                    .into(),
+                                    function_work.clone(),
+                                )
+                            })?
+                        };
+                        let func_warnings = crate::cfg_query::import_warnings(
+                            &record.warnings,
+                            record.body_span,
+                            body_span,
+                        );
+                        function_work.cfg_warnings_emitted = func_warnings.len();
+                        function_work.implicit_destructor_targets_emitted =
+                            record.implicit_destructor_targets.len();
+                        let mut implicit_edges = Vec::new();
+                        if let Some(source) = &func.implicit_drop_source {
+                            for target in record.implicit_destructor_targets.iter() {
+                                let live_type = aggregate_types
+                                    .iter()
+                                    .find_map(|(live, stable)| (stable == target).then_some(*live));
+                                if let Some(TypeKind::Struct(id)) = live_type.map(|ty| ty.kind()) {
+                                    let target = type_pool.struct_def(id);
+                                    implicit_edges.push(
+                                        rue_air::ImplicitNamedDestructorDependencyEvent {
+                                            source: source.clone(),
+                                            target_file: target.file_id.index(),
+                                            target_owner_name: target.name.clone(),
+                                        },
+                                    );
+                                }
+                            }
                         }
+                        Ok((
+                            (
+                                FunctionWithCfg {
+                                    analyzed: func,
+                                    semantic_identity,
+                                    symbol,
+                                    local_atoms,
+                                    machine_name,
+                                    legacy_name,
+                                    cfg,
+                                },
+                                func_warnings,
+                                implicit_edges,
+                                record.implicit_destructor_dependencies_complete,
+                            ),
+                            function_work,
+                        ))
                     }
                 }
-
-                function_work.cfg_export_attempts = usize::from(current_input.is_some());
-                let artifact = current_input.zip(projection).and_then(|(input, domains)| {
-                    (cfg_output.warnings.is_empty()
-                        && implicit_edges.is_empty()
-                        && complete
-                        && domains.validate_cfg(&cfg, input.body_span).is_ok())
-                    .then(|| DurableCfgArtifact {
-                        schema_version: DURABLE_CFG_SCHEMA_VERSION,
-                        semantic_schema_version: crate::DURABLE_SEMANTIC_SCHEMA_VERSION,
-                        input: input.stable.clone(),
-                        opt_level,
-                        target,
-                        cfg: cfg.clone(),
-                        domains,
-                    })
-                });
-                function_work.cfg_export_successes = usize::from(artifact.is_some());
-                function_work.cfg_export_rejections =
-                    function_work.cfg_export_attempts - function_work.cfg_export_successes;
-                Ok((
-                    (
-                        FunctionWithCfg {
-                            analyzed: func,
-                            semantic_identity,
-                            symbol,
-                            local_atoms,
-                            machine_name,
-                            legacy_name,
-                            cfg,
-                        },
-                        cfg_output.warnings,
-                        implicit_edges,
-                        complete,
-                        artifact,
-                    ),
-                    function_work,
-                ))
             },
         )
         .collect();
@@ -596,7 +652,6 @@ pub(crate) fn build_functions_and_cfgs(
     let mut functions = Vec::with_capacity(results.len());
     let mut implicit_named_destructor_dependencies = Vec::new();
     let mut implicit_named_destructor_dependencies_complete = true;
-    let mut durable_cfgs = Vec::new();
     let mut first_errors = None;
     for result in results {
         let (output, function_work) = match result {
@@ -630,12 +685,11 @@ pub(crate) fn build_functions_and_cfgs(
         work.cfg_export_attempts += function_work.cfg_export_attempts;
         work.cfg_export_successes += function_work.cfg_export_successes;
         work.cfg_export_rejections += function_work.cfg_export_rejections;
-        if let Some((func, func_warnings, mut implicit_edges, complete, artifact)) = output {
+        if let Some((func, func_warnings, mut implicit_edges, complete)) = output {
             functions.push(func);
             warnings.extend(func_warnings);
             implicit_named_destructor_dependencies.append(&mut implicit_edges);
             implicit_named_destructor_dependencies_complete &= complete;
-            durable_cfgs.extend(artifact);
         }
     }
     if let Some(errors) = first_errors {
@@ -643,7 +697,6 @@ pub(crate) fn build_functions_and_cfgs(
     }
     implicit_named_destructor_dependencies.sort();
     implicit_named_destructor_dependencies.dedup();
-    durable_cfgs.sort_by(|left, right| left.input.function.cmp(&right.input.function));
 
     info!(
         function_count = functions.len(),
@@ -658,66 +711,7 @@ pub(crate) fn build_functions_and_cfgs(
         implicit_named_destructor_dependencies,
         implicit_named_destructor_dependencies_complete,
         work,
-        durable_cfgs: durable_cfgs.into(),
     })
-}
-
-#[cfg(test)]
-pub(crate) fn synthetic_projected_function_identities(
-    sema_output: &SemaOutput,
-) -> std::collections::BTreeMap<
-    rue_air::FunctionInstanceKey<rue_air::SemanticDefinitionToken, rue_air::SemanticModuleToken>,
-    crate::FunctionInstanceKey,
-> {
-    use std::convert::Infallible;
-    use std::sync::Arc;
-
-    let definition_module = crate::ModuleId::from_logical_path("test/definitions.rue")
-        .expect("synthetic test module path is valid");
-    let project = |identity: &rue_air::FunctionInstanceKey<
-        rue_air::SemanticDefinitionToken,
-        rue_air::SemanticModuleToken,
-    >| {
-        identity
-            .try_map_identities(
-                &|token| {
-                    Ok::<_, Infallible>(crate::StableDefinitionKey::for_test(
-                        definition_module.clone(),
-                        crate::StableDefinitionNamespace::Value,
-                        crate::StableDefinitionKind::Function,
-                        Arc::<str>::from(format!("definition_{}", token.slot())),
-                        None,
-                    ))
-                },
-                &|token| {
-                    Ok::<_, Infallible>(
-                        crate::ModuleId::from_logical_path(&format!(
-                            "test/module_{}.rue",
-                            token.slot()
-                        ))
-                        .expect("synthetic test module path is valid"),
-                    )
-                },
-            )
-            .expect("synthetic identity projection is infallible")
-    };
-
-    sema_output
-        .functions
-        .iter()
-        .map(|function| (function.identity.clone(), project(&function.identity)))
-        .chain(
-            sema_output
-                .aggregate_type_identities_by_type
-                .values()
-                .cloned()
-                .map(|identity| {
-                    let identity = rue_air::FunctionInstanceKey::DropGlue(Box::new(identity));
-                    let projected = project(&identity);
-                    (identity, projected)
-                }),
-        )
-        .collect()
 }
 
 /// Source-volume and phase-work metrics collected by one-shot compilation.
@@ -936,99 +930,4 @@ pub(crate) fn compile_with_session(
         semantic: semantic.work(),
     };
     Ok(output)
-}
-
-#[cfg(test)]
-mod failure_work_tests {
-    use lasso::ThreadedRodeo;
-    use rue_air::{Sema, Type};
-    use rue_error::PreviewFeatures;
-    use rue_lexer::Lexer;
-    use rue_parser::Parser;
-    use rue_rir::AstGen;
-    use rue_span::Span;
-
-    use super::*;
-
-    fn malformed_cfg_input() -> (SemaOutput, ThreadedRodeo) {
-        let source = "fn alpha() -> i32 { 1 }\nfn broken() -> i32 { 2 }\nfn main() -> i32 { alpha() + broken() + zeta() }\nfn zeta() -> i32 { 3 }";
-        let lexer = Lexer::new(source);
-        let (tokens, interner) = lexer.tokenize().unwrap();
-        let parser = Parser::new(tokens, interner);
-        let (ast, interner) = parser.parse().unwrap();
-        let mut astgen = AstGen::with_symbol_normalizer(&interner, |symbol| symbol);
-        astgen.append_items(&ast.items);
-        let rir = astgen.finish();
-        let mut output = Sema::new_synthetic(&rir, &interner, PreviewFeatures::new())
-            .analyze_all_for_test()
-            .unwrap();
-
-        for (name, start) in [("broken", 10), ("zeta", 20)] {
-            let generic = interner.get_or_intern(format!("unrewritten_{name}"));
-            let function = output
-                .functions
-                .iter_mut()
-                .find(|function| function.name == name)
-                .unwrap();
-            let mut air = rue_air::AirEditor::new(Type::I32);
-            let call = air
-                .add_call_generic(
-                    generic,
-                    &[],
-                    &[],
-                    &[],
-                    Type::I32,
-                    Span::new(start, start + 1),
-                )
-                .unwrap();
-            air.add_ret(Some(call), Type::I32, Span::new(start, start + 1));
-            function.air = air
-                .finish(rue_air::AirValidationContext::Canonical(&output.type_pool))
-                .expect("malformed test AIR structure must validate");
-        }
-        (output, interner)
-    }
-
-    #[test]
-    fn malformed_air_retains_deterministic_work_from_every_cfg_builder() {
-        let run = || {
-            let (output, interner) = malformed_cfg_input();
-            let projected_identities = synthetic_projected_function_identities(&output);
-            let demanded_drop_glue = std::collections::BTreeSet::new();
-            let drop_glue_plans = std::collections::BTreeMap::new();
-            match build_functions_and_cfgs(
-                output,
-                &demanded_drop_glue,
-                &drop_glue_plans,
-                OptLevel::O1,
-                Target::host().unwrap(),
-                &interner,
-                &[],
-                &[],
-                &projected_identities,
-            ) {
-                Ok(_) => panic!("malformed AIR unexpectedly built a CFG"),
-                Err(failure) => failure,
-            }
-        };
-        let first = run();
-        let second = run();
-        assert_eq!(first.work, second.work);
-        assert_eq!(first.work.functions_considered, 4);
-        assert_eq!(first.work.cfg_builds_attempted, 4);
-        assert_eq!(first.work.cfg_builds_succeeded, 2);
-        assert_eq!(first.work.cfg_builds_failed, 2);
-        assert_eq!(first.work.optimization_attempts, 2);
-        assert_eq!(first.work.optimization_completions, 2);
-        assert_eq!(first.work.optimized_level_attempts, 2);
-        assert_eq!(
-            format!("{:?}", first.errors),
-            format!("{:?}", second.errors)
-        );
-        assert_eq!(
-            first.errors.iter().next().unwrap().span().unwrap().start,
-            20,
-            "the first canonically sorted failing function supplies the published diagnostic"
-        );
-    }
 }

--- a/crates/rue-compiler/src/revisioned_query_database.rs
+++ b/crates/rue-compiler/src/revisioned_query_database.rs
@@ -564,6 +564,9 @@ pub(crate) struct RevisionedQueryDatabase {
     call_abis: QueryFamily<crate::type_queries::CallAbiQueryKey, crate::type_queries::CallAbiValue>,
     #[allow(dead_code)]
     drop_glues: QueryFamily<crate::type_queries::TypeQueryKey, crate::type_queries::DropGlueValue>,
+    #[allow(dead_code)]
+    cfgs: QueryFamily<crate::cfg_query::CfgQueryKey, crate::cfg_query::CfgValue>,
+    optimized_cfgs: QueryFamily<crate::cfg_query::OptimizedCfgQueryKey, crate::cfg_query::CfgValue>,
     lookup_names: QueryFamily<LookupNameKey, LookupNameValue>,
     /// Per-`(module, import-path)` binding-resolution family. Registered query
     /// machinery for the exact provider boundary. Production body import
@@ -12781,6 +12784,38 @@ impl RevisionedQueryDatabase {
                 },
             )
             .expect("the DropGlue family has one canonical name");
+        let layouts_for_cfg = layouts.clone();
+        let type_facts_for_cfg = type_facts.clone();
+        let drop_glues_for_cfg = drop_glues.clone();
+        let call_abis_for_cfg = call_abis.clone();
+        let cfgs = runtime
+            .family_with_equality_and_evaluator(
+                "compiler.cfg",
+                BODY_QUERY_MEMO_RETENTION,
+                crate::cfg_query::cfg_value_equal,
+                move |context, _, key: &crate::cfg_query::CfgQueryKey| {
+                    crate::cfg_query::evaluate_cfg(
+                        context,
+                        &layouts_for_cfg,
+                        &type_facts_for_cfg,
+                        &drop_glues_for_cfg,
+                        &call_abis_for_cfg,
+                        key,
+                    )
+                },
+            )
+            .expect("the Cfg family has one canonical name");
+        let cfgs_for_optimization = cfgs.clone();
+        let optimized_cfgs = runtime
+            .family_with_equality_and_evaluator(
+                "compiler.optimized-cfg",
+                BODY_QUERY_MEMO_RETENTION,
+                crate::cfg_query::cfg_value_equal,
+                move |context, _, key: &crate::cfg_query::OptimizedCfgQueryKey| {
+                    crate::cfg_query::evaluate_optimized_cfg(context, &cfgs_for_optimization, key)
+                },
+            )
+            .expect("the OptimizedCfg family has one canonical name");
         let provider_observation_meter = Arc::new(ProviderObservationCounters::default());
         let lookup_root_lease = Arc::new(Mutex::new(PublishedRootLookupLease::default()));
         let body_closure_root = Arc::new(Mutex::new(PublishedBodyClosureRoot::default()));
@@ -13960,6 +13995,8 @@ impl RevisionedQueryDatabase {
             layouts,
             call_abis,
             drop_glues,
+            cfgs,
+            optimized_cfgs,
             lookup_names,
             lookup_imports,
             #[cfg(test)]
@@ -14234,6 +14271,124 @@ impl RevisionedQueryDatabase {
                 }
             })
             .or_else(|| self.current_parse_revision())
+    }
+
+    pub(crate) fn optimized_cfg(
+        &self,
+        revision: Revision,
+        function: crate::FunctionInstanceKey,
+        configuration: crate::semantic_query_nucleus::SemanticQueryConfiguration,
+        semantic_input: crate::cfg_query::CfgSemanticInput,
+        live: Arc<crate::cfg_query::CfgLiveInput>,
+        opt_level: rue_cfg::OptLevel,
+        cancellation: CancellationToken,
+    ) -> Result<
+        (
+            crate::cfg_query::CfgQueryKey,
+            rue_query::QueryRequestAttempt<crate::cfg_query::CfgValue>,
+        ),
+        QueryAbort,
+    > {
+        let mut layout_dependencies = BTreeSet::new();
+        let mut drop_dependencies = BTreeSet::new();
+        for ty in live.domains.stable_types() {
+            crate::cfg_query::collect_type_dependencies(ty, &mut layout_dependencies);
+            crate::cfg_query::collect_drop_type_dependency(ty, &mut drop_dependencies);
+        }
+        let layout_keys = layout_dependencies
+            .into_iter()
+            .map(|ty| crate::type_queries::TypeQueryKey {
+                ty,
+                configuration: configuration.clone(),
+            })
+            .collect::<Vec<_>>();
+        let mut layout_values = Vec::with_capacity(layout_keys.len());
+        for key in layout_keys {
+            let attempt = self.runtime.request_registered(
+                &self.layouts,
+                revision,
+                key.clone(),
+                cancellation.clone(),
+            );
+            let terminal = attempt.into_result()?;
+            let rue_query::QueryOutcome::Success(value) = terminal.outcome() else {
+                unreachable!("Layout publishes typed values")
+            };
+            layout_values.push((key, value.clone()));
+        }
+        let drop_keys = drop_dependencies
+            .into_iter()
+            .map(|ty| crate::type_queries::TypeQueryKey {
+                ty,
+                configuration: configuration.clone(),
+            })
+            .collect::<Vec<_>>();
+        let mut type_fact_values = Vec::with_capacity(drop_keys.len());
+        let mut drop_glue_values = Vec::with_capacity(drop_keys.len());
+        for key in drop_keys {
+            let attempt = self.runtime.request_registered(
+                &self.type_facts,
+                revision,
+                key.clone(),
+                cancellation.clone(),
+            );
+            let terminal = attempt.into_result()?;
+            let rue_query::QueryOutcome::Success(value) = terminal.outcome() else {
+                unreachable!("TypeFacts publishes typed values")
+            };
+            type_fact_values.push((key.clone(), value.clone()));
+            let attempt = self.runtime.request_registered(
+                &self.drop_glues,
+                revision,
+                key.clone(),
+                cancellation.clone(),
+            );
+            let terminal = attempt.into_result()?;
+            let rue_query::QueryOutcome::Success(value) = terminal.outcome() else {
+                unreachable!("DropGlue publishes typed values")
+            };
+            drop_glue_values.push((key, value.clone()));
+        }
+        let mut callables = live.domains.stable_callables().collect::<BTreeSet<_>>();
+        callables.insert(function.clone());
+        let call_abi_keys = callables
+            .into_iter()
+            .map(|callable| crate::type_queries::CallAbiQueryKey {
+                callable,
+                configuration: configuration.clone(),
+            })
+            .collect::<Vec<_>>();
+        let mut call_abi_values = Vec::with_capacity(call_abi_keys.len());
+        for key in call_abi_keys {
+            let attempt = self.runtime.request_registered(
+                &self.call_abis,
+                revision,
+                key.clone(),
+                cancellation.clone(),
+            );
+            let terminal = attempt.into_result()?;
+            let rue_query::QueryOutcome::Success(value) = terminal.outcome() else {
+                unreachable!("CallAbi publishes typed values")
+            };
+            call_abi_values.push((key, value.clone()));
+        }
+        let cfg = crate::cfg_query::CfgQueryKey::new(
+            function,
+            configuration,
+            semantic_input,
+            layout_values.into(),
+            type_fact_values.into(),
+            drop_glue_values.into(),
+            call_abi_values.into(),
+            live,
+        );
+        let attempt = self.runtime.request_registered(
+            &self.optimized_cfgs,
+            revision,
+            crate::cfg_query::OptimizedCfgQueryKey::new(cfg.clone(), opt_level),
+            cancellation,
+        );
+        Ok((cfg, attempt))
     }
 
     /// Publish an immutable, revisioned import authority for lower-layer

--- a/crates/rue-compiler/src/scaling_harness.rs
+++ b/crates/rue-compiler/src/scaling_harness.rs
@@ -509,11 +509,6 @@ fn assert_warm_fresh_parity(
                 "{label}: durable specialized bodies diverged"
             );
             assert_eq!(
-                format!("{:?}", warm.durable_cfgs()),
-                format!("{:?}", fresh.durable_cfgs()),
-                "{label}: durable CFG artifacts diverged"
-            );
-            assert_eq!(
                 format!("{:?}", warm.warnings()),
                 format!("{:?}", fresh.warnings()),
                 "{label}: ordered semantic warnings diverged"

--- a/crates/rue-compiler/src/semantic_symbols.rs
+++ b/crates/rue-compiler/src/semantic_symbols.rs
@@ -41,7 +41,7 @@ pub struct SemanticTranslationWork {
 #[derive(Debug)]
 pub struct SemanticSymbolUniverse {
     admitted_modules: Arc<[Arc<crate::parsed_modules::ParsedModule>]>,
-    interner: ThreadedRodeo,
+    interner: Arc<ThreadedRodeo>,
     provenance: Arc<SemanticSymbolProvenance>,
     local_symbol_resolutions: AtomicUsize,
     semantic_intern_attempts: AtomicUsize,
@@ -49,8 +49,12 @@ pub struct SemanticSymbolUniverse {
 }
 
 impl SemanticSymbolUniverse {
-    pub(crate) fn into_interner(self) -> ThreadedRodeo {
+    pub(crate) fn into_interner(self) -> Arc<ThreadedRodeo> {
         self.interner
+    }
+
+    pub(crate) fn shared_interner(&self) -> Arc<ThreadedRodeo> {
+        self.interner.clone()
     }
 
     /// Start a destination universe for one canonical program traversal.
@@ -68,7 +72,7 @@ impl SemanticSymbolUniverse {
     pub(crate) fn from_modules(modules: &[Arc<crate::parsed_modules::ParsedModule>]) -> Self {
         let universe = Self {
             admitted_modules: modules.to_vec().into(),
-            interner: ThreadedRodeo::new(),
+            interner: Arc::new(ThreadedRodeo::new()),
             provenance: Arc::new(SemanticSymbolProvenance),
             local_symbol_resolutions: AtomicUsize::new(0),
             semantic_intern_attempts: AtomicUsize::new(0),

--- a/crates/rue-compiler/src/session.rs
+++ b/crates/rue-compiler/src/session.rs
@@ -1387,7 +1387,6 @@ pub struct CompilerSession {
 /// rather than through a parallel branch compiled only under `cfg(test)`.
 #[derive(Debug, Default, Clone)]
 struct DurableBaselineOverride {
-    successful_cfg_cache: Option<Arc<[crate::queries::DurableCfgArtifact]>>,
     durable_declaration_cache: Option<DurableDeclarationCache>,
 }
 
@@ -2281,7 +2280,6 @@ struct SemanticCacheEntry {
     rir: Option<Arc<CanonicalRirOutput>>,
     diagnostics: Arc<FrontendDiagnosticSnapshot>,
     durable_declaration_cache: Option<DurableDeclarationCache>,
-    successful_cfg_cache: Option<Arc<[crate::queries::DurableCfgArtifact]>>,
     oracle_injected: bool,
 }
 
@@ -2610,7 +2608,6 @@ impl CompilerSession {
                 injected.result = stale.result.clone();
                 injected.rir = stale.rir.clone();
                 injected.durable_declaration_cache = stale.durable_declaration_cache.clone();
-                injected.successful_cfg_cache = stale.successful_cfg_cache.clone();
                 injected.oracle_injected = true;
                 self.queries.semantic.insert_with_dependencies(
                     &mut self.queries.graph,
@@ -4329,23 +4326,8 @@ impl CompilerSession {
         self.diagnostics.last_good_semantic()
     }
 
-    /// Per-function durable CFG artifacts retained by the last successful
-    /// semantic record — the baseline an ordinary attempt reuses from.
-    ///
-    /// This reads the production source of truth. It exists so a caller that
-    /// wants to inspect or perturb the reuse baseline does so through the same
-    /// record the reuse path consults, rather than through a separate mirror
-    /// (RUE-1143).
-    #[cfg(test)]
-    fn last_good_successful_cfg_cache(&self) -> Option<&Arc<[crate::queries::DurableCfgArtifact]>> {
-        self.queries
-            .semantic
-            .last_good_record()
-            .and_then(|entry| entry.successful_cfg_cache.as_ref())
-    }
-
     /// Durable declaration cache retained by the last successful semantic
-    /// record. Companion to [`Self::last_good_successful_cfg_cache`].
+    /// record.
     #[cfg(test)]
     fn last_good_durable_declaration_cache(&self) -> Option<&DurableDeclarationCache> {
         self.queries
@@ -6147,22 +6129,6 @@ impl CompilerSession {
             }
             return result.map_err(SemanticRequestControl::Compile);
         }
-        let durable_baseline = self.queries.semantic.last_good_record().cloned();
-        // One selection order, compiled identically under test and production
-        // (RUE-1143): an explicit override when one was supplied, otherwise the
-        // last-good record. Ordinary compiles never set the override, so this
-        // reduces to the last-good record.
-        let previous_cfg_cache = self
-            .durable_baseline_override
-            .as_ref()
-            .and_then(|override_baseline| override_baseline.successful_cfg_cache.clone())
-            .or_else(|| {
-                durable_baseline
-                    .as_ref()
-                    .and_then(|entry| entry.successful_cfg_cache.clone())
-            })
-            .unwrap_or_else(|| Arc::from([]));
-
         let rir_result = self.canonical_rir();
         if cancellation.is_canceled() {
             return Err(SemanticRequestControl::Abort(
@@ -6208,7 +6174,6 @@ impl CompilerSession {
                             rir: None,
                             diagnostics,
                             durable_declaration_cache: None,
-                            successful_cfg_cache: None,
                             oracle_injected: false,
                         },
                         [dependency],
@@ -6795,10 +6760,12 @@ impl CompilerSession {
                 durable_body_candidates,
                 durable_specialized_body_candidates,
                 durable_anonymous_body_candidates,
-                previous_cfg_cache.clone(),
                 demanded_drop_glue,
                 demanded_drop_glue_plans,
                 durable_body_work,
+                &self.queries.revisioned,
+                runtime_revision,
+                cancellation.clone(),
             )?;
             output.install_body_references(body_query_reference_cache);
             output.accrue_body_query_work(queried_body_work);
@@ -6832,9 +6799,7 @@ impl CompilerSession {
             .then_some(query_declarations_for_cache)
             .flatten()
             .map(|semantics| DurableDeclarationCache { semantics });
-        let mut published_cfg_cache = None;
         if let Ok(output) = &result {
-            published_cfg_cache = Some(output.durable_cfgs().clone());
             debug_assert_eq!(output.input(), &input);
             debug_assert_eq!(semantic_work.binding.bind_invocations, 1);
             debug_assert_eq!(semantic_work.manifest.build_invocations, 1);
@@ -6894,7 +6859,6 @@ impl CompilerSession {
                         .is_ok()
                         .then_some(published_declaration_cache)
                         .flatten(),
-                    successful_cfg_cache: result.is_ok().then_some(published_cfg_cache).flatten(),
                     oracle_injected: false,
                 },
                 dependencies,
@@ -10898,7 +10862,6 @@ mod tests {
         session.canonical_semantic(&default).unwrap();
         let diagnostics = session.latest_diagnostics().unwrap().clone();
         let last_good = session.last_good_semantic_diagnostics().unwrap().clone();
-        let cfgs = session.last_good_successful_cfg_cache().cloned().unwrap();
         let edited = snapshot(
             &[
                 (7, "/p/main.rue", "main.rue", "fn main() -> i32 { 1 }"),
@@ -10950,10 +10913,6 @@ mod tests {
         assert!(Arc::ptr_eq(
             session.last_good_semantic_diagnostics().unwrap(),
             &last_good
-        ));
-        assert!(Arc::ptr_eq(
-            session.last_good_successful_cfg_cache().unwrap(),
-            &cfgs
         ));
         assert_eq!(session.work().semantic.calls, 2);
         assert_eq!(session.work().semantic.executions, 2);
@@ -11466,7 +11425,6 @@ mod tests {
         cache.semantics = records.into();
         session.set_durable_baseline_override(Some(DurableBaselineOverride {
             durable_declaration_cache: Some(cache),
-            ..DurableBaselineOverride::default()
         }));
 
         publish_with_test_imports(&mut session, &edited);
@@ -11543,7 +11501,7 @@ mod tests {
         session.update(&second).into_result().unwrap();
         let warm = session.canonical_semantic(&options).unwrap();
         assert_eq!(warm.work().cfg.cfg_reuses, 1);
-        assert!(warm.work().cfg.cfg_import_failures >= 1);
+        assert_eq!(warm.work().cfg.cfg_builds_attempted, 2);
         let mut fresh = CompilerSession::new();
         fresh.update(&second).into_result().unwrap();
         let fresh = fresh.canonical_semantic(&options).unwrap();
@@ -11583,7 +11541,7 @@ mod tests {
         session.update(&second).into_result().unwrap();
         let warm = session.canonical_semantic(&options).unwrap();
         assert_eq!(warm.work().cfg.cfg_reuses, 1);
-        assert!(warm.work().cfg.cfg_import_failures >= 1);
+        assert_eq!(warm.work().cfg.cfg_builds_attempted, 2);
         let mut fresh = CompilerSession::new();
         fresh.update(&second).into_result().unwrap();
         let fresh = fresh.canonical_semantic(&options).unwrap();
@@ -11678,7 +11636,366 @@ mod tests {
     }
 
     #[test]
-    fn specialized_cfg_reuse_is_stable_and_malformed_import_falls_back_atomically() {
+    fn cfg_drop_facts_invalidate_same_layout_cleanup_changes() {
+        let first = snapshot(
+            &[(
+                1,
+                "/p/main.rue",
+                "main.rue",
+                "struct Resource { value: i32 }\n\
+                 fn main() -> i32 { let resource = Resource { value: 1 }; 0 }",
+            )],
+            1,
+        );
+        let second = snapshot(
+            &[(
+                1,
+                "/p/main.rue",
+                "main.rue",
+                "struct Resource { value: i32 }\n\
+                 drop fn Resource(self) { @dbg(self.value); }\n\
+                 fn main() -> i32 { let resource = Resource { value: 1 }; 0 }",
+            )],
+            1,
+        );
+        let options = CompileOptions::default();
+        let mut session = CompilerSession::new();
+        session.update(&first).into_result().unwrap();
+        session.canonical_semantic(&options).unwrap();
+
+        session.update(&second).into_result().unwrap();
+        let warm = session.canonical_semantic(&options).unwrap();
+        assert!(
+            warm.work().cfg.cfg_builds_attempted > 0,
+            "same-layout drop-fact changes must rebuild affected CFGs: {:?}",
+            warm.work().cfg
+        );
+        let mut fresh = CompilerSession::new();
+        fresh.update(&second).into_result().unwrap();
+        let fresh = fresh.canonical_semantic(&options).unwrap();
+        assert_eq!(
+            normalize_session_local_spurs(format!("{:?}", warm.functions())),
+            normalize_session_local_spurs(format!("{:?}", fresh.functions()))
+        );
+    }
+
+    #[test]
+    fn cfg_relocation_covers_runtime_param_drop_and_nominal_field_domains() {
+        let program = |prefix: &str| {
+            format!(
+                "{prefix}\
+                 struct Leaf {{ value: i32 }}\n\
+                 drop fn Leaf(self) {{ @dbg(self.value); }}\n\
+                 struct Holder {{ leaf: Leaf }}\n\
+                 fn consume(value: Holder) -> i32 {{\n\
+                     @dbg(value.leaf.value);\n\
+                     value.leaf.value\n\
+                 }}\n\
+                 fn main() -> i32 {{ consume(Holder {{ leaf: Leaf {{ value: 7 }} }}) }}"
+            )
+        };
+        let first_text = program("");
+        let second_text = program(
+            "struct Noise { pad: i64 }\n\
+             fn noise(value: Noise) -> i64 { @assert(value.pad >= 0); value.pad }\n",
+        );
+        let first = snapshot(&[(1, "/p/main.rue", "main.rue", first_text.as_str())], 1);
+        let second = snapshot(&[(1, "/p/main.rue", "main.rue", second_text.as_str())], 1);
+        let options = CompileOptions::default();
+        let mut session = CompilerSession::new();
+        session.update(&first).into_result().unwrap();
+        session.canonical_semantic(&options).unwrap();
+
+        session.update(&second).into_result().unwrap();
+        let warm = session.canonical_semantic(&options).unwrap();
+        assert_eq!(
+            warm.work().cfg.cfg_builds_attempted,
+            0,
+            "live-domain relocation must not rebuild reusable unoptimized CFGs: {:?}",
+            warm.work().cfg
+        );
+        assert_eq!(
+            warm.work().cfg.cfg_reuses,
+            5,
+            "every unchanged reachable CFG must be reused: {:?}",
+            warm.work().cfg
+        );
+        assert_eq!(
+            warm.work().cfg.optimization_attempts,
+            0,
+            "complete relocation domains must reuse optimized terminals: {:?}",
+            warm.work().cfg
+        );
+        assert_eq!(
+            warm.work().cfg.cfg_import_successes,
+            warm.work().cfg.cfg_reuses,
+            "the collector must receive already-relocated optimized terminals: {:?}",
+            warm.work().cfg
+        );
+        let mut fresh = CompilerSession::new();
+        fresh.update(&second).into_result().unwrap();
+        let fresh = fresh.canonical_semantic(&options).unwrap();
+        assert_eq!(
+            normalize_session_local_spurs(format!("{:?}", warm.functions())),
+            normalize_session_local_spurs(format!("{:?}", fresh.functions()))
+        );
+        assert_eq!(
+            format!("{:?}", warm.warnings()),
+            format!("{:?}", fresh.warnings())
+        );
+    }
+
+    #[test]
+    fn cfg_import_failure_rebuilds_current_body_with_exact_fallback_work() {
+        let first = snapshot(
+            &[(1, "/p/main.rue", "main.rue", "fn main() -> i32 { 7 }")],
+            1,
+        );
+        let second = snapshot(
+            &[(
+                1,
+                "/p/main.rue",
+                "main.rue",
+                "// relocate the retained body\nfn main() -> i32 { 7 }",
+            )],
+            1,
+        );
+        let options = CompileOptions {
+            opt_level: OptLevel::O1,
+            ..CompileOptions::default()
+        };
+        let mut session = CompilerSession::new();
+        session.update(&first).into_result().unwrap();
+        session.canonical_semantic(&options).unwrap();
+
+        session.update(&second).into_result().unwrap();
+        let warm = crate::canonical_semantic::with_test_cfg_import_failure_injection(|| {
+            session.canonical_semantic(&options).unwrap()
+        });
+        assert_eq!(warm.work().cfg.cfg_reuse_candidates, 1);
+        assert_eq!(warm.work().cfg.cfg_reuses, 0);
+        assert_eq!(warm.work().cfg.cfg_import_attempts, 1);
+        assert_eq!(warm.work().cfg.cfg_import_successes, 0);
+        assert_eq!(warm.work().cfg.cfg_import_failures, 1);
+        assert_eq!(warm.work().cfg.cfg_fallbacks, 1);
+        assert_eq!(warm.work().cfg.cfg_builds_attempted, 1);
+        assert_eq!(warm.work().cfg.cfg_builds_succeeded, 1);
+        assert_eq!(warm.work().cfg.cfg_builds_failed, 0);
+        assert_eq!(warm.work().cfg.optimization_attempts, 1);
+        assert_eq!(warm.work().cfg.optimization_completions, 1);
+        assert_eq!(warm.work().cfg.optimized_level_attempts, 1);
+
+        let mut fresh = CompilerSession::new();
+        fresh.update(&second).into_result().unwrap();
+        let fresh = fresh.canonical_semantic(&options).unwrap();
+        assert_eq!(
+            normalize_session_local_spurs(format!("{:?}", warm.functions())),
+            normalize_session_local_spurs(format!("{:?}", fresh.functions()))
+        );
+    }
+
+    #[test]
+    fn reused_parse_runtime_symbol_relocates_to_the_current_interner() {
+        let program = |prefix: &str| {
+            format!(
+                "{prefix}\
+                 const opt = @import(\"std/option.rue\");\n\
+                 fn parse_runtime() -> i32 {{ let _ = @parse_i64(\"7\"); 0 }}\n\
+                 fn main() -> i32 {{ parse_runtime() }}"
+            )
+        };
+        let first_text = program("");
+        let second_text =
+            program("struct Noise { value: i64 }\nfn noise(value: Noise) -> i64 { value.value }\n");
+        let first = well_known_option_isolation_snapshot(&first_text);
+        let second = well_known_option_isolation_snapshot(&second_text);
+        let options = CompileOptions::default();
+        let runtime_symbols = |output: &crate::CanonicalSemanticOutput| {
+            output
+                .functions()
+                .iter()
+                .flat_map(|function| {
+                    let cfg = &function.cfg;
+                    cfg.blocks()
+                        .iter()
+                        .flat_map(|block| block.insts.iter())
+                        .filter_map(|value| match cfg.get_inst(*value).data {
+                            rue_cfg::CfgInstData::Intrinsic {
+                                runtime: Some(rue_air::RuntimeCallKind::ParseI64),
+                                name,
+                                ..
+                            } => Some(name),
+                            _ => None,
+                        })
+                        .collect::<Vec<_>>()
+                })
+                .collect::<Vec<_>>()
+        };
+
+        let mut session = CompilerSession::new();
+        publish_with_test_imports(&mut session, &first);
+        session.canonical_semantic(&options).unwrap();
+        publish_with_test_imports(&mut session, &second);
+        let warm = session.canonical_semantic(&options).unwrap();
+        assert_eq!(warm.work().cfg.cfg_builds_attempted, 0);
+        assert!(warm.work().cfg.cfg_reuses >= 2, "{:?}", warm.work().cfg);
+        assert_eq!(
+            warm.work().cfg.optimization_attempts,
+            0,
+            "the collector must relocate the complete optimized terminal: {:?}",
+            warm.work().cfg
+        );
+        let warm_symbols = runtime_symbols(&warm);
+        assert_eq!(warm_symbols.len(), 1);
+        let warm_rir = session.canonical_rir().unwrap();
+        assert_eq!(
+            warm_rir
+                .semantic_symbols()
+                .interner()
+                .resolve(&warm_symbols[0]),
+            "parse_i64"
+        );
+
+        let mut fresh = CompilerSession::new();
+        publish_with_test_imports(&mut fresh, &second);
+        let fresh_output = fresh.canonical_semantic(&options).unwrap();
+        let fresh_symbols = runtime_symbols(&fresh_output);
+        assert_eq!(fresh_symbols.len(), 1);
+        let fresh_rir = fresh.canonical_rir().unwrap();
+        assert_eq!(
+            fresh_rir
+                .semantic_symbols()
+                .interner()
+                .resolve(&fresh_symbols[0]),
+            "parse_i64"
+        );
+        assert_eq!(
+            normalize_session_local_spurs(format!("{:?}", warm.functions())),
+            normalize_session_local_spurs(format!("{:?}", fresh_output.functions()))
+        );
+    }
+
+    #[test]
+    fn reused_print_runtime_call_relocates_to_the_current_helper_symbol() {
+        let program = |prefix: &str| {
+            format!(
+                "{prefix}\
+                 fn probe_print() {{ println(\"literal\"); }}\n\
+                 fn main() -> i32 {{ probe_print(); 0 }}"
+            )
+        };
+        let runtime_calls = |output: &crate::CanonicalSemanticOutput| {
+            output
+                .functions()
+                .iter()
+                .flat_map(|function| {
+                    let cfg = &function.cfg;
+                    cfg.blocks()
+                        .iter()
+                        .flat_map(|block| block.insts.iter())
+                        .filter_map(|value| match cfg.get_inst(*value).data {
+                            rue_cfg::CfgInstData::Call {
+                                runtime: Some(runtime),
+                                name,
+                                ..
+                            } => Some((runtime, name)),
+                            _ => None,
+                        })
+                        .collect::<Vec<_>>()
+                })
+                .collect::<Vec<_>>()
+        };
+        let first_text = program("");
+        let second_text = program("fn noise() -> i32 { let interner_churn = 1; interner_churn }\n");
+        let first = snapshot(&[(1, "/p/main.rue", "main.rue", &first_text)], 1);
+        let second = snapshot(&[(1, "/p/main.rue", "main.rue", &second_text)], 1);
+        let options = CompileOptions::default();
+        let mut session = CompilerSession::new();
+        session.update(&first).into_result().unwrap();
+        let cold = session.canonical_semantic(&options).unwrap();
+        let cold_calls = runtime_calls(&cold);
+        assert_eq!(cold_calls.len(), 1);
+        session.update(&second).into_result().unwrap();
+        let warm = session.canonical_semantic(&options).unwrap();
+        assert_eq!(warm.work().cfg.cfg_builds_attempted, 0);
+        assert_eq!(warm.work().cfg.cfg_reuses, 2);
+        assert_eq!(warm.work().cfg.optimization_attempts, 0);
+        let warm_calls = runtime_calls(&warm);
+        assert_eq!(warm_calls.len(), 1);
+        assert_ne!(
+            cold_calls, warm_calls,
+            "the inserted declaration must perturb the live runtime-call symbol"
+        );
+        let warm_rir = session.canonical_rir().unwrap();
+        for (runtime, symbol) in &warm_calls {
+            assert_eq!(
+                warm_rir.semantic_symbols().interner().resolve(symbol),
+                runtime.helper().helper().symbol
+            );
+        }
+
+        let mut fresh = CompilerSession::new();
+        fresh.update(&second).into_result().unwrap();
+        let fresh_output = fresh.canonical_semantic(&options).unwrap();
+        let fresh_calls = runtime_calls(&fresh_output);
+        assert_eq!(fresh_calls.len(), 1);
+        let fresh_rir = fresh.canonical_rir().unwrap();
+        for (runtime, symbol) in &fresh_calls {
+            assert_eq!(
+                fresh_rir.semantic_symbols().interner().resolve(symbol),
+                runtime.helper().helper().symbol
+            );
+        }
+        assert_eq!(
+            normalize_session_local_spurs(format!("{:?}", warm.functions())),
+            normalize_session_local_spurs(format!("{:?}", fresh_output.functions()))
+        );
+    }
+
+    #[test]
+    fn opt_level_only_change_reuses_cfg_and_recomputes_optimization_per_function() {
+        let source = snapshot(
+            &[(
+                1,
+                "/p/main.rue",
+                "main.rue",
+                "fn left() -> i32 { 20 }\n\
+                 fn right() -> i32 { 22 }\n\
+                 fn main() -> i32 { left() + right() }",
+            )],
+            1,
+        );
+        let o0 = CompileOptions {
+            opt_level: OptLevel::O0,
+            ..CompileOptions::default()
+        };
+        let o1 = CompileOptions {
+            opt_level: OptLevel::O1,
+            ..CompileOptions::default()
+        };
+        let mut session = CompilerSession::new();
+        session.update(&source).into_result().unwrap();
+
+        let cold = session.canonical_semantic(&o0).unwrap();
+        assert_eq!(cold.functions().len(), 3);
+        assert_eq!(cold.work().cfg.cfg_builds_attempted, 3);
+        assert_eq!(cold.work().cfg.optimization_attempts, 3);
+
+        let optimized = session.canonical_semantic(&o1).unwrap();
+        assert_eq!(optimized.functions().len(), 3);
+        assert_eq!(optimized.work().cfg.cfg_builds_attempted, 0);
+        assert_eq!(optimized.work().cfg.cfg_builds_succeeded, 0);
+        assert_eq!(optimized.work().cfg.cfg_builds_failed, 0);
+        assert_eq!(optimized.work().cfg.cfg_reuses, 3);
+        assert_eq!(optimized.work().cfg.cfg_import_attempts, 3);
+        assert_eq!(optimized.work().cfg.cfg_import_successes, 3);
+        assert_eq!(optimized.work().cfg.optimization_attempts, 3);
+        assert_eq!(optimized.work().cfg.optimization_completions, 3);
+        assert_eq!(optimized.work().cfg.optimized_level_attempts, 3);
+    }
+
+    #[test]
+    fn specialized_cfg_reuse_is_stable_across_unrelated_body_edits() {
         let first = snapshot(
             &[(
                 1,
@@ -11697,15 +12014,6 @@ mod tests {
             )],
             1,
         );
-        let third = snapshot(
-            &[(
-                1,
-                "/p/main.rue",
-                "main.rue",
-                "fn choose(comptime n: i32) -> i32 { n }\nfn b() -> i32 { 4 }\nfn main() -> i32 { choose(40) + b() }",
-            )],
-            1,
-        );
         let options = CompileOptions {
             opt_level: OptLevel::O0,
             ..CompileOptions::default()
@@ -11713,41 +12021,14 @@ mod tests {
         let mut session = CompilerSession::new();
         session.update(&first).into_result().unwrap();
         session.canonical_semantic(&options).unwrap();
-        // As above: perturb a copy and inject it rather than reaching into a
-        // mirror of the baseline (RUE-1143).
-        let mut artifacts = session.last_good_successful_cfg_cache().unwrap().to_vec();
-        let specialization = artifacts
-            .iter_mut()
-            .find(|candidate| {
-                matches!(
-                    candidate.input.function,
-                    crate::FunctionInstanceKey::Specialization { .. }
-                )
-            })
-            .unwrap();
-        specialization.semantic_schema_version.implementation_epoch += 1;
-        session.set_durable_baseline_override(Some(DurableBaselineOverride {
-            successful_cfg_cache: Some(artifacts.into()),
-            ..DurableBaselineOverride::default()
-        }));
         session.update(&second).into_result().unwrap();
         let warm = session.canonical_semantic(&options).unwrap();
-        // The override stood in for the last-good record for exactly that one
-        // attempt. Drop it so the repair below reuses the record the warm
-        // attempt actually published, which is what the old mirror did
-        // implicitly by repopulating after every successful attempt.
-        session.set_durable_baseline_override(None);
-        assert_eq!(warm.work().cfg.cfg_import_failures, 2);
-        assert_eq!(warm.work().cfg.cfg_schema_version_rejections, 1);
-        assert_eq!(warm.work().cfg.cfg_fallbacks, 2);
-        assert_eq!(warm.work().cfg.cfg_reuses, 1);
-        assert_eq!(warm.work().cfg.cfg_builds_attempted, 2);
-        assert_eq!(warm.work().cfg.optimization_attempts, 2);
-        assert_eq!(warm.work().cfg.optimized_level_attempts, 0);
-        session.update(&third).into_result().unwrap();
-        let repaired = session.canonical_semantic(&options).unwrap();
-        assert_eq!(repaired.work().cfg.cfg_reuses, 2);
-        assert_eq!(repaired.work().cfg.cfg_builds_attempted, 1);
+        assert!(warm.functions().iter().any(|function| {
+            matches!(
+                function.semantic_identity,
+                crate::FunctionInstanceKey::Specialization { .. }
+            )
+        }));
     }
 
     #[test]
@@ -11792,45 +12073,16 @@ mod tests {
         let cross_target = session.canonical_semantic(&other_options).unwrap();
         assert_eq!(cross_target.work().cfg.cfg_reuses, 0);
         assert_eq!(cross_target.work().cfg.cfg_builds_attempted, 3);
-        assert!(cross_target.work().cfg.cfg_import_failures >= 2);
         session.update(&renamed).into_result().unwrap();
         let changed = session.canonical_semantic(&other_options).unwrap();
         assert_eq!(changed.work().cfg.cfg_reuses, 1);
         assert_eq!(changed.work().cfg.cfg_builds_attempted, 2);
-        assert_eq!(changed.work().cfg.cfg_import_failures, 1);
         let mut fresh = CompilerSession::new();
         fresh.update(&renamed).into_result().unwrap();
         let fresh = fresh.canonical_semantic(&other_options).unwrap();
         assert_eq!(
             format!("{:?}", changed.functions()),
             format!("{:?}", fresh.functions())
-        );
-    }
-
-    #[test]
-    fn incomplete_optimized_cfg_projection_is_rejected_at_export() {
-        let source = snapshot(
-            &[(
-                1,
-                "/p/main.rue",
-                "main.rue",
-                "fn choose(value: bool) -> i32 { if value { 1 } else { 2 } }\nfn main() -> i32 { choose(true) }",
-            )],
-            1,
-        );
-        let mut session = CompilerSession::new();
-        session.update(&source).into_result().unwrap();
-        let output = session
-            .canonical_semantic(&CompileOptions {
-                opt_level: OptLevel::O0,
-                ..CompileOptions::default()
-            })
-            .unwrap();
-        assert_eq!(output.work().cfg.cfg_export_attempts, 2);
-        assert!(output.work().cfg.cfg_export_rejections >= 1);
-        assert_eq!(
-            output.work().cfg.cfg_export_attempts,
-            output.work().cfg.cfg_export_successes + output.work().cfg.cfg_export_rejections
         );
     }
 
@@ -13678,8 +13930,6 @@ mod tests {
             CanonicalSemanticFailurePhase::CfgConstruction
         );
         assert_eq!(failed.work.cfg.functions_considered, 1);
-        assert_eq!(failed.work.cfg.cfg_builds_attempted, 1);
-        assert_eq!(failed.work.cfg.cfg_builds_failed, 1);
         assert_eq!(failed.work.cfg.optimization_attempts, 0);
 
         session.update(&valid).into_result().unwrap();
@@ -14250,7 +14500,6 @@ fn main() -> i32 {
                 rir: None,
                 diagnostics: failed_diagnostics,
                 durable_declaration_cache: None,
-                successful_cfg_cache: None,
                 oracle_injected: false,
             },
             [source_dependency],
@@ -14904,7 +15153,7 @@ fn main() -> i32 {
     }
 
     #[test]
-    fn implicit_drop_edges_distinguish_body_obligations_from_global_glue() {
+    fn implicit_drop_edges_distinguish_body_obligations_from_synthesized_glue() {
         fn assert_send_sync<T: Send + Sync>() {}
         assert_send_sync::<StableImplicitNamedDestructorDependency>();
         let program = r#"
@@ -14951,6 +15200,80 @@ fn main() -> i32 {
             first.implicit_named_destructor_dependencies().len()
         );
         assert_eq!(first.work().extra_rir_instructions_visited, 0);
+    }
+
+    #[test]
+    fn new_specialization_drop_edge_matches_fresh_and_invalidates_on_destructor_edit() {
+        let program = |main_body: &str, destructor: Option<i32>| {
+            let destructor = destructor
+                .map(|value| format!("drop fn Leaf(self) {{ @dbg({value}); }}\n"))
+                .unwrap_or_default();
+            format!(
+                "struct Leaf {{ n: i32 }}\n\
+                 {destructor}\
+                 fn consume(comptime T: type, value: T) -> i32 {{ 0 }}\n\
+                 fn main() -> i32 {{ {main_body} }}"
+            )
+        };
+        let first_text = program("consume(i32, 1)", Some(1));
+        let second_text = program("consume(Leaf, Leaf { n: 1 })", Some(1));
+        let third_text = program("consume(Leaf, Leaf { n: 1 })", None);
+        let first = snapshot(&[(1, "/p/main.rue", "main.rue", &first_text)], 1);
+        let second = snapshot(&[(1, "/p/main.rue", "main.rue", &second_text)], 1);
+        let third = snapshot(&[(1, "/p/main.rue", "main.rue", &third_text)], 1);
+        let options = CompileOptions::default();
+        let mut session = CompilerSession::new();
+        session.update(&first).into_result().unwrap();
+        session.canonical_semantic(&options).unwrap();
+
+        session.update(&second).into_result().unwrap();
+        let warm = session.canonical_semantic(&options).unwrap();
+        let specialization_edges = warm
+            .implicit_named_destructor_dependencies()
+            .iter()
+            .filter(|edge| {
+                matches!(
+                    edge.source,
+                    rue_air::ImplicitDropDependencySourceEvent::Specialization { .. }
+                ) && edge.target_owner_name == "Leaf"
+            })
+            .collect::<Vec<_>>();
+        assert_eq!(
+            specialization_edges.len(),
+            1,
+            "the newly demanded specialization must publish its exact Leaf drop edge: {:?}",
+            warm.implicit_named_destructor_dependencies()
+        );
+
+        let mut fresh = CompilerSession::new();
+        fresh.update(&second).into_result().unwrap();
+        let fresh_second = fresh.canonical_semantic(&options).unwrap();
+        assert_eq!(
+            format!("{:?}", warm.implicit_named_destructor_dependencies()),
+            format!(
+                "{:?}",
+                fresh_second.implicit_named_destructor_dependencies()
+            )
+        );
+
+        session.update(&third).into_result().unwrap();
+        let changed = session.canonical_semantic(&options).unwrap();
+        assert!(
+            changed.work().body_analysis.specialized_bodies_attempted > 0,
+            "editing Leaf's destructor must invalidate consume(Leaf): {:?}",
+            changed.work().body_analysis
+        );
+        let mut fresh = CompilerSession::new();
+        fresh.update(&third).into_result().unwrap();
+        let fresh_third = fresh.canonical_semantic(&options).unwrap();
+        assert_eq!(
+            normalize_session_local_spurs(format!("{:?}", changed.functions())),
+            normalize_session_local_spurs(format!("{:?}", fresh_third.functions()))
+        );
+        assert_eq!(
+            format!("{:?}", changed.implicit_named_destructor_dependencies()),
+            format!("{:?}", fresh_third.implicit_named_destructor_dependencies())
+        );
     }
 
     #[test]

--- a/crates/rue-compiler/src/test_support.rs
+++ b/crates/rue-compiler/src/test_support.rs
@@ -37,7 +37,8 @@ pub(crate) fn test_cfg(source: &str) -> MultiErrorResult<CompileState> {
     let (_, symbols) = rir.into_parts();
     let (functions, type_pool, strings, warnings) = semantic.into_parts();
     Ok(CompileState {
-        interner: symbols.into_interner(),
+        interner: std::sync::Arc::try_unwrap(symbols.into_interner())
+            .expect("test frontend uniquely owns its semantic symbol interner"),
         functions,
         type_pool,
         strings,

--- a/crates/rue-compiler/src/unstable.rs
+++ b/crates/rue-compiler/src/unstable.rs
@@ -530,7 +530,7 @@ pub fn semantic_parity_snapshot(view: &crate::SemanticView) -> SemanticParitySna
 /// Raw owner-crate state for the in-tree CFG differential model. This is an
 /// explicitly unstable consuming bridge; ordinary compiler clients use views.
 pub struct OracleSemanticState {
-    pub interner: lasso::ThreadedRodeo,
+    pub interner: Arc<lasso::ThreadedRodeo>,
     pub functions: Vec<UnstableSemanticFunction>,
     pub type_pool: rue_air::FrozenTypeInternPool,
     pub strings: Vec<String>,
@@ -539,7 +539,7 @@ pub struct OracleSemanticState {
 
 /// Raw function state for in-tree differential and storage-profile tooling.
 pub struct UnstableSemanticFunction {
-    pub analyzed: rue_air::AnalyzedFunction,
+    pub analyzed: Arc<rue_air::AnalyzedFunction>,
     pub cfg: rue_cfg::ValidatedCfg,
 }
 

--- a/crates/rue-oracle/src/lib.rs
+++ b/crates/rue-oracle/src/lib.rs
@@ -71,6 +71,7 @@ use rue_compiler::{
 use std::borrow::Cow;
 use std::collections::HashMap;
 use std::fmt;
+use std::sync::Arc;
 
 struct CompileState {
     interner: ThreadedRodeo,
@@ -126,7 +127,8 @@ fn query_cfg_state_from_session(
     let state = rue_compiler::unstable::into_oracle_semantic_state(semantic)
         .expect("one-shot oracle session uniquely owns its frontend artifacts");
     Ok(CompileState {
-        interner: state.interner,
+        interner: Arc::try_unwrap(state.interner)
+            .expect("one-shot oracle uniquely owns its semantic symbol interner"),
         functions: state
             .functions
             .into_iter()


### PR DESCRIPTION
## Summary

- add canonical per-function Cfg and OptimizedCfg query families
- make CFG construction observe exact body, layout, ABI, type, and drop facts
- relocate reusable CFG terminals across live type, symbol, string, atom, and span domains
- remove the standalone durable CFG cache and fused construction/optimization authority
- preserve caller and optimization locality for non-inlined edits and optimization-level changes
- fail closed on incomplete relocation domains with deterministic work accounting

## Validation

- compiler unit suite: 857 passed, 0 failed, 1 ignored
- clippy gate: 63 first-party targets passed
- focused cold/reuse, optimization-level, destructor, fallback, relocation, runtime-call, and both-target tests passed
- quick suite: 29 targets passed; the existing timing-accounting test failure reproduces unchanged on upstream trunk

Fixes RUE-1030.