### PR TITLE
RUE-1201: keep position data out of semantic reuse

### DIFF
--- a/crates/rue-compiler/src/body_query.rs
+++ b/crates/rue-compiler/src/body_query.rs
@@ -21,6 +21,77 @@ pub(crate) struct BodyRelativeRange {
     pub(crate) end: u32,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum BodyDiagnosticOffset {
+    Declaration(u32),
+    Body(u32),
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum BodyDiagnosticCoordinate {
+    Relative {
+        start: BodyDiagnosticOffset,
+        end: BodyDiagnosticOffset,
+    },
+    Preserved {
+        file_id: rue_span::FileId,
+        start: u32,
+        end: u32,
+    },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct BodyDiagnosticBasis {
+    pub(crate) coordinates: Arc<[BodyDiagnosticCoordinate]>,
+}
+
+pub(crate) fn relative_body_diagnostics(
+    errors: crate::CompileErrors,
+    source: &BodySourceLocator,
+) -> (crate::CompileErrors, BodyDiagnosticBasis) {
+    let mut coordinates = Vec::new();
+    let errors = errors.map_spans(|span| {
+        let coordinate = if span.file_id == source.file_id
+            && span.start >= source.declaration_start
+            && span.end <= source.body_end
+        {
+            let offset = |position| {
+                if position >= source.body_start {
+                    BodyDiagnosticOffset::Body(position - source.body_start)
+                } else {
+                    BodyDiagnosticOffset::Declaration(position - source.declaration_start)
+                }
+            };
+            BodyDiagnosticCoordinate::Relative {
+                start: offset(span.start),
+                end: offset(span.end),
+            }
+        } else {
+            BodyDiagnosticCoordinate::Preserved {
+                file_id: span.file_id,
+                start: span.start,
+                end: span.end,
+            }
+        };
+        coordinates.push(coordinate);
+
+        // The typed coordinate stream owns every location. Erasing the payload
+        // prevents stale absolute positions from entering semantic equality and
+        // makes projection independent of any otherwise-valid FileId value.
+        let mut erased = span;
+        erased.file_id = rue_span::FileId::DEFAULT;
+        erased.start = 0;
+        erased.end = 0;
+        erased
+    });
+    (
+        errors,
+        BodyDiagnosticBasis {
+            coordinates: coordinates.into(),
+        },
+    )
+}
+
 pub(crate) fn body_source_locator_equal(
     left: &Option<BodySourceLocator>,
     right: &Option<BodySourceLocator>,
@@ -238,7 +309,7 @@ pub(crate) enum BodyTransaction {
     },
     DeterministicFailure {
         errors: crate::CompileErrors,
-        diagnostic_basis: Option<BodySourceLocator>,
+        diagnostic_basis: Option<BodyDiagnosticBasis>,
         references: BodyReferences,
         lookup_observations: BodyLookupObservations,
     },
@@ -247,29 +318,15 @@ pub(crate) enum BodyTransaction {
 
 #[derive(Debug, Clone)]
 pub(crate) struct BodyAnalysisBundle {
+    // This aggregate is semantic-only so its enclosing BodyClosure can stay
+    // green across relocation. Presentation consumers request the exact
+    // BodySourceLocator projection for their current revision.
     pub(crate) transaction: BodyTransaction,
     pub(crate) produced_anonymous: Option<ProducedAnonymous>,
-    pub(crate) source_locator: Option<BodySourceLocator>,
 }
 
 pub(crate) fn analysis_bundle_equal(left: &BodyAnalysisBundle, right: &BodyAnalysisBundle) -> bool {
-    let transaction_equal = match (&left.transaction, &right.transaction) {
-        (
-            BodyTransaction::DeterministicFailure {
-                errors: left_errors,
-                references: left_references,
-                ..
-            },
-            BodyTransaction::DeterministicFailure {
-                errors: right_errors,
-                references: right_references,
-                ..
-            },
-        ) => left_errors == right_errors && left_references == right_references,
-        (left, right) => transaction_equal(left, right),
-    };
-    transaction_equal
-        && left.source_locator == right.source_locator
+    transaction_equal(&left.transaction, &right.transaction)
         && match (&left.produced_anonymous, &right.produced_anonymous) {
             (Some(left), Some(right)) => produced_anonymous_equal(left, right),
             (None, None) => true,
@@ -508,15 +565,21 @@ pub(crate) fn transaction_equal(left: &BodyTransaction, right: &BodyTransaction)
         (
             BodyTransaction::DeterministicFailure {
                 errors: left_errors,
+                diagnostic_basis: left_basis,
                 references: left_references,
                 ..
             },
             BodyTransaction::DeterministicFailure {
                 errors: right_errors,
+                diagnostic_basis: right_basis,
                 references: right_references,
                 ..
             },
-        ) => left_errors == right_errors && left_references == right_references,
+        ) => {
+            left_errors == right_errors
+                && left_basis == right_basis
+                && left_references == right_references
+        }
         (
             BodyTransaction::Control(BodyTransactionControl::DeferredAnonymousProducers(left)),
             BodyTransaction::Control(BodyTransactionControl::DeferredAnonymousProducers(right)),

--- a/crates/rue-compiler/src/definition_snapshot.rs
+++ b/crates/rue-compiler/src/definition_snapshot.rs
@@ -178,7 +178,8 @@ pub struct DefinitionShardWork {
 #[derive(Debug, Clone)]
 pub struct DefinitionShard {
     key: ModuleId,
-    file_id: FileId,
+    // Reuse-critical facts only. Current file IDs and spans are projected from
+    // the successor ModuleIndex when DefinitionRecords are materialized.
     records: Arc<[DefinitionShardRecord]>,
 }
 
@@ -188,18 +189,14 @@ struct DefinitionShardRecord {
     kind: DefinitionKind,
     visibility: Option<Visibility>,
     name: Arc<str>,
-    name_span: Span,
-    declaration_span: Span,
 }
 
 impl DefinitionShard {
     fn matches_index(
         &self,
-        module: &crate::parsed_modules::ParsedModule,
         index: &crate::revisioned_query_database::ProjectedModuleIndex,
     ) -> bool {
-        self.file_id == module.file_id()
-            && self.records.len() == index.definitions.len()
+        self.records.len() == index.definitions.len()
             && self
                 .records
                 .iter()
@@ -209,8 +206,6 @@ impl DefinitionShard {
                         && record.kind == candidate.kind
                         && record.visibility == candidate.visibility
                         && record.name == candidate.name
-                        && record.name_span == candidate.name_span
-                        && record.declaration_span == candidate.declaration_span
                 })
     }
 }
@@ -302,8 +297,6 @@ impl DefinitionSnapshot {
                         kind: candidate.kind,
                         visibility: candidate.visibility,
                         name: candidate.name.clone(),
-                        name_span: candidate.name_span,
-                        declaration_span: candidate.declaration_span,
                     })
                     .collect::<Vec<_>>()
             };
@@ -315,7 +308,7 @@ impl DefinitionSnapshot {
                         .ok()
                         .map(|position| snapshot.shards[position].clone())
                 })
-                .filter(|shard| shard.matches_index(module, index));
+                .filter(|shard| shard.matches_index(index));
             let shard = if let Some(shard) = shard {
                 work.shards_reused += 1;
                 shard
@@ -323,12 +316,16 @@ impl DefinitionSnapshot {
                 work.shards_rebuilt += 1;
                 Arc::new(DefinitionShard {
                     key: module.module_id().clone(),
-                    file_id: module.file_id(),
                     records: candidate_records().into(),
                 })
             };
             let mut definitions = Vec::with_capacity(shard.records.len());
-            for (definition_index, candidate) in shard.records.iter().enumerate() {
+            for (definition_index, (candidate, current)) in shard
+                .records
+                .iter()
+                .zip(index.definitions.iter())
+                .enumerate()
+            {
                 let id = DefinitionId {
                     module_index,
                     definition_index,
@@ -348,8 +345,8 @@ impl DefinitionSnapshot {
                     kind: candidate.kind,
                     visibility: candidate.visibility,
                     file_id: module.file_id(),
-                    name_span: candidate.name_span,
-                    declaration_span: candidate.declaration_span,
+                    name_span: current.name_span,
+                    declaration_span: current.declaration_span,
                 });
             }
             modules.push(ModuleDefinition {

--- a/crates/rue-compiler/src/revisioned_query_database.rs
+++ b/crates/rue-compiler/src/revisioned_query_database.rs
@@ -225,6 +225,8 @@ pub(crate) struct RevisionedQueryDatabase {
     raw_declaration_bodies: QueryFamily<RawDeclarationBodyQueryKey, RawDeclarationBodyQueryValue>,
     #[allow(dead_code)]
     body_inputs: QueryFamily<crate::body_query::BodyQueryKey, crate::body_query::BodyInputValue>,
+    body_source_locators:
+        QueryFamily<crate::body_query::BodyQueryKey, Option<crate::body_query::BodySourceLocator>>,
     // The registered `body-toolchain-demands` node (RUE-1112). It projects one
     // reached body's exact raw declaration body to the sorted, deduplicated set
     // of trusted toolchain modules its fallible intrinsics demand plus the
@@ -1919,7 +1921,7 @@ fn module_input_view(
         .ok_or(QueryAbort::UnpublishedRevision(revision))
 }
 
-fn project_transaction_diagnostics(
+pub(crate) fn project_transaction_diagnostics(
     transaction: crate::body_query::BodyTransaction,
     current: Option<&crate::body_query::BodySourceLocator>,
 ) -> crate::body_query::BodyTransaction {
@@ -1931,43 +1933,75 @@ fn project_transaction_diagnostics(
             references,
             lookup_observations,
         } => {
-            let errors = match (diagnostic_basis.as_ref(), current) {
-                (Some(basis), Some(current)) => errors.map_spans(|span| {
-                    if span.file_id != basis.file_id
-                        || span.start < basis.declaration_start
-                        || span.end > basis.body_end
-                    {
-                        return span;
-                    }
-                    let project = |offset: u32| {
-                        if offset >= basis.body_start {
-                            current
-                                .body_start
-                                .saturating_add(offset - basis.body_start)
-                                .min(current.body_end)
-                        } else {
-                            current
-                                .declaration_start
-                                .saturating_add(offset - basis.declaration_start)
-                                .min(current.declaration_end)
+            let errors = if let Some(basis) = diagnostic_basis.as_ref() {
+                let mut coordinates = basis.coordinates.iter();
+                let errors = errors.map_spans(|mut span| {
+                    let coordinate = coordinates
+                        .next()
+                        .expect("body diagnostic coordinates match diagnostic spans");
+                    match coordinate {
+                        crate::body_query::BodyDiagnosticCoordinate::Relative { start, end } => {
+                            let Some(current) = current else {
+                                return span;
+                            };
+                            let project =
+                                |offset: &crate::body_query::BodyDiagnosticOffset| match offset {
+                                    crate::body_query::BodyDiagnosticOffset::Declaration(
+                                        offset,
+                                    ) => current
+                                        .declaration_start
+                                        .saturating_add(*offset)
+                                        .min(current.declaration_end),
+                                    crate::body_query::BodyDiagnosticOffset::Body(offset) => {
+                                        current
+                                            .body_start
+                                            .saturating_add(*offset)
+                                            .min(current.body_end)
+                                    }
+                                };
+                            span.file_id = current.file_id;
+                            span.start = project(start);
+                            span.end = project(end);
+                            span
                         }
-                    };
-                    rue_span::Span::with_file(
-                        current.file_id,
-                        project(span.start),
-                        project(span.end),
-                    )
-                }),
-                _ => errors,
+                        crate::body_query::BodyDiagnosticCoordinate::Preserved {
+                            file_id,
+                            start,
+                            end,
+                        } => {
+                            span.file_id = *file_id;
+                            span.start = *start;
+                            span.end = *end;
+                            span
+                        }
+                    }
+                });
+                errors
+            } else {
+                errors
             };
             BodyTransaction::DeterministicFailure {
                 errors,
-                diagnostic_basis: current.cloned().or(diagnostic_basis),
+                diagnostic_basis,
                 references,
                 lookup_observations,
             }
         }
         other => other,
+    }
+}
+
+fn body_failure_with_source(
+    error: crate::CompileError,
+    source: &crate::body_query::BodySourceLocator,
+) -> crate::body_query::BodyTransaction {
+    let (errors, diagnostic_basis) =
+        crate::body_query::relative_body_diagnostics(crate::CompileErrors::from(error), source);
+    crate::body_query::BodyTransaction::DeterministicFailure {
+        errors,
+        diagnostic_basis: Some(diagnostic_basis),
+        references: crate::body_query::BodyReferences(Arc::from([])),
+        lookup_observations: crate::body_query::BodyLookupObservations::default(),
     }
 }
 
@@ -12582,7 +12616,6 @@ impl RevisionedQueryDatabase {
         let transactions_for_analysis_bundle = body_transactions.clone();
         let produced_for_analysis_bundle = body_produced_anonymous.clone();
         let canonical_for_analysis_bundle = canonical_bodies.clone();
-        let locators_for_analysis_bundle = body_source_locators.clone();
         let body_analysis_bundles = runtime
             .family_with_equality_and_evaluator(
                 "compiler.body-analysis-bundle",
@@ -12595,14 +12628,7 @@ impl RevisionedQueryDatabase {
                     else {
                         unreachable!("BodyTransaction publishes typed values")
                     };
-                    let current =
-                        context.query_registered(&locators_for_analysis_bundle, key.clone())?;
-                    let current = match current.outcome() {
-                        rue_query::QueryOutcome::Success(Some(locator)) => Some(locator),
-                        _ => None,
-                    };
-                    let transaction = project_transaction_diagnostics(transaction.clone(), current);
-                    let produced_anonymous = match &transaction {
+                    let produced_anonymous = match transaction {
                         crate::body_query::BodyTransaction::Success { .. } => {
                             let produced = context
                                 .query_registered(&produced_for_analysis_bundle, key.clone())?;
@@ -12631,9 +12657,8 @@ impl RevisionedQueryDatabase {
                         QueryTerminalKind::Failure
                     };
                     Ok(QueryOutput::success(crate::body_query::BodyAnalysisBundle {
-                        transaction,
+                        transaction: transaction.clone(),
                         produced_anonymous,
-                        source_locator: current.cloned(),
                     })
                     .with_terminal_kind(terminal_kind))
                 },
@@ -13740,6 +13765,7 @@ impl RevisionedQueryDatabase {
             #[cfg(test)]
             raw_declaration_bodies: raw_declaration_bodies.clone(),
             body_inputs,
+            body_source_locators,
             body_toolchain_demands,
             body_transactions,
             canonical_bodies,
@@ -15033,12 +15059,7 @@ impl BodyTransactionEvaluator {
                             }
                         }
                     }
-                    Err(error) => crate::body_query::BodyTransaction::DeterministicFailure {
-                        diagnostic_basis: Some(input.source.clone()),
-                        errors: crate::CompileErrors::from(error),
-                        references: crate::body_query::BodyReferences(Arc::from([])),
-                        lookup_observations: crate::body_query::BodyLookupObservations::default(),
-                    },
+                    Err(error) => body_failure_with_source(error, &input.source),
                 }
             } else if let crate::FunctionInstanceKey::Specialization { base: _, arguments } =
                 &key.instance
@@ -15304,12 +15325,7 @@ impl BodyTransactionEvaluator {
                             },
                         }
                     }
-                    Err(error) => crate::body_query::BodyTransaction::DeterministicFailure {
-                        diagnostic_basis: Some(input.source.clone()),
-                        errors: crate::CompileErrors::from(error),
-                        references: crate::body_query::BodyReferences(Arc::from([])),
-                        lookup_observations: crate::body_query::BodyLookupObservations::default(),
-                    },
+                    Err(error) => body_failure_with_source(error, &input.source),
                 }
             } else if let crate::FunctionInstanceKey::AnonymousMember { owner, member } =
                 &key.instance
@@ -15370,7 +15386,6 @@ impl BodyTransactionEvaluator {
                     source_length: source_basis.source_length,
                 };
                 let producer_fragment_start = source_basis.body_start;
-                let diagnostic_basis = Some(source_basis.clone());
                 let lowering = match lower_anonymous_member_body_input(
                     member_input,
                     member,
@@ -15518,12 +15533,7 @@ impl BodyTransactionEvaluator {
                             },
                         }
                     }
-                    Err(error) => crate::body_query::BodyTransaction::DeterministicFailure {
-                        diagnostic_basis,
-                        errors: crate::CompileErrors::from(error),
-                        references: crate::body_query::BodyReferences(Arc::from([])),
-                        lookup_observations: crate::body_query::BodyLookupObservations::default(),
-                    },
+                    Err(error) => body_failure_with_source(error, source_basis),
                 }
             } else {
                 crate::body_query::BodyTransaction::DeterministicFailure {
@@ -15831,6 +15841,22 @@ impl RevisionedQueryDatabase {
     ) -> Result<Arc<rue_query::QueryTerminal<crate::body_query::CanonicalBody>>, QueryAbort> {
         self.runtime
             .request_registered(&self.canonical_bodies, revision, key, cancellation)
+            .into_result()
+    }
+
+    /// Request the current presentation locator for one body independently of
+    /// its retained semantic transaction and aggregate body closure.
+    pub(crate) fn body_source_locator_projection(
+        &self,
+        revision: Revision,
+        key: crate::body_query::BodyQueryKey,
+        cancellation: CancellationToken,
+    ) -> Result<
+        Arc<rue_query::QueryTerminal<Option<crate::body_query::BodySourceLocator>>>,
+        QueryAbort,
+    > {
+        self.runtime
+            .request_registered(&self.body_source_locators, revision, key, cancellation)
             .into_result()
     }
 
@@ -33557,6 +33583,149 @@ fn main() -> i32 {
                 "BodyInput evaluator boundary contains banned artifact `{banned}`"
             );
         }
+    }
+
+    #[test]
+    fn anonymous_member_body_anchors_are_producer_fragment_relative() {
+        let first_text = "// unrelated leading source\nfn Box() -> type {\n    struct { fn get(self) -> i32 { 7 } }\n}";
+        let shifted_text = "// another position-only line\n// unrelated leading source\nfn Box() -> type {\n    struct { fn get(self) -> i32 { 7 } }\n}";
+        let source = |text| source_snapshot(&[(1, "/main.rue", "main.rue", text)], 1);
+        let module = ModuleId::from_logical_path("main.rue").unwrap();
+        let producer = crate::FunctionInstanceKey::Specialization {
+            base: Box::new(free_function_instance(&module, "Box")),
+            arguments: crate::CanonicalArguments::default(),
+        };
+        let key = crate::body_query::BodyQueryKey {
+            instance: producer,
+            configuration: semantic_configuration(),
+        };
+        let member_syntax =
+            |terminal: &rue_query::QueryTerminal<crate::body_query::ProducedAnonymous>| {
+                let rue_query::QueryOutcome::Success(
+                    crate::body_query::ProducedAnonymous::Produced(produced),
+                ) = terminal.outcome()
+                else {
+                    panic!("anonymous producer did not publish its member syntax")
+                };
+                produced
+                    .0
+                    .iter()
+                    .find_map(|nominal| {
+                        let crate::durable_semantics::DurableAnonymousNominalShape::Struct {
+                            methods,
+                            ..
+                        } = &nominal.shape
+                        else {
+                            return None;
+                        };
+                        methods
+                            .iter()
+                            .find(|method| method.name.as_ref() == "get")?
+                            .body
+                            .clone()
+                    })
+                    .expect("producer publishes the anonymous get body")
+            };
+
+        let mut database = RevisionedQueryDatabase::default();
+        let first_source = source(first_text);
+        let first_revision = revision_for(&mut database, &first_source);
+        let first = database.runtime.request_registered(
+            &database.body_produced_anonymous,
+            first_revision,
+            key.clone(),
+            CancellationToken::new(),
+        );
+        let first_terminal = first.terminal().unwrap();
+        let first_syntax = member_syntax(first_terminal);
+        let producer_fragment_start = first_text.find("{\n    struct").unwrap();
+        let declaration_start = first_text.find("fn get").unwrap() - producer_fragment_start;
+        let body_start = first_text.find("{ 7 }").unwrap() - producer_fragment_start;
+        assert_eq!(
+            first_syntax.declaration_start,
+            u32::try_from(declaration_start).unwrap(),
+        );
+        assert_eq!(first_syntax.body_start, u32::try_from(body_start).unwrap());
+        assert_eq!(
+            first_syntax.body_end,
+            u32::try_from(body_start + "{ 7 }".len()).unwrap(),
+        );
+
+        let shifted_source = source(shifted_text);
+        let shifted_revision = revision_for(&mut database, &shifted_source);
+        let shifted = database.runtime.request_registered(
+            &database.body_produced_anonymous,
+            shifted_revision,
+            key,
+            CancellationToken::new(),
+        );
+        let shifted_terminal = shifted.terminal().unwrap();
+        assert_eq!(
+            shifted_terminal.stamp(),
+            first_terminal.stamp(),
+            "moving the producer in its module must not restamp its member syntax",
+        );
+        assert_eq!(member_syntax(shifted_terminal), first_syntax);
+    }
+
+    #[test]
+    fn body_diagnostic_projection_preserves_nonlocal_and_unknown_spans() {
+        let source = crate::body_query::BodySourceLocator {
+            file_id: FileId::new(7),
+            physical_path: Arc::from("/old/main.rue"),
+            source_length: 180,
+            declaration_start: 100,
+            declaration_end: 150,
+            body_start: 120,
+            body_end: 145,
+        };
+        let local = crate::Span::with_file(source.file_id, 125, 128);
+        let absolute = crate::Span::with_file(FileId::new(8), 4, 6);
+        let unknown = crate::Span::new(2, 3);
+        let empty_unknown = crate::Span::default();
+        let mut errors = crate::CompileErrors::new();
+        for span in [local, absolute, unknown, empty_unknown] {
+            errors.push(crate::CompileError::new(
+                crate::ErrorKind::InvalidInteger,
+                span,
+            ));
+        }
+        let (errors, diagnostic_basis) =
+            crate::body_query::relative_body_diagnostics(errors, &source);
+        let transaction = crate::body_query::BodyTransaction::DeterministicFailure {
+            errors,
+            diagnostic_basis: Some(diagnostic_basis),
+            references: crate::body_query::BodyReferences(Arc::from([])),
+            lookup_observations: crate::body_query::BodyLookupObservations::default(),
+        };
+
+        let current = crate::body_query::BodySourceLocator {
+            file_id: FileId::new(9),
+            physical_path: Arc::from("/current/main.rue"),
+            source_length: 280,
+            declaration_start: 200,
+            declaration_end: 250,
+            body_start: 220,
+            body_end: 245,
+        };
+        let crate::body_query::BodyTransaction::DeterministicFailure { errors, .. } =
+            project_transaction_diagnostics(transaction, Some(&current))
+        else {
+            panic!("diagnostic projection preserves the transaction variant")
+        };
+        let projected: Vec<_> = errors
+            .iter()
+            .map(|error| error.span().expect("test diagnostics have primary spans"))
+            .collect();
+        assert_eq!(
+            projected,
+            [
+                crate::Span::with_file(current.file_id, 225, 228),
+                absolute,
+                unknown,
+                empty_unknown,
+            ]
+        );
     }
 
     #[test]

--- a/crates/rue-compiler/src/session.rs
+++ b/crates/rue-compiler/src/session.rs
@@ -4570,6 +4570,45 @@ impl CompilerSession {
                 else {
                     unreachable!("BodyAnalysisBundle publishes typed values")
                 };
+                let needs_source_locator = match &analysis.transaction {
+                    crate::body_query::BodyTransaction::DeterministicFailure { .. } => true,
+                    crate::body_query::BodyTransaction::Success { body, .. } => matches!(
+                        body.as_ref(),
+                        crate::body_query::CanonicalBody::Anonymous { .. }
+                    ),
+                    crate::body_query::BodyTransaction::Control(_) => false,
+                };
+                let current_source_locator = if needs_source_locator {
+                    let locator = self
+                        .queries
+                        .revisioned
+                        .body_source_locator_projection(
+                            runtime_revision,
+                            key.clone(),
+                            cancellation.clone(),
+                        )
+                        .map_err(SemanticRequestControl::Abort)?;
+                    let rue_query::QueryOutcome::Success(locator) = locator.outcome() else {
+                        unreachable!("BodySourceLocator publishes typed values")
+                    };
+                    locator.clone()
+                } else {
+                    None
+                };
+                let projected_transaction;
+                let transaction = if matches!(
+                    &analysis.transaction,
+                    crate::body_query::BodyTransaction::DeterministicFailure { .. }
+                ) {
+                    projected_transaction =
+                        crate::revisioned_query_database::project_transaction_diagnostics(
+                            analysis.transaction.clone(),
+                            current_source_locator.as_ref(),
+                        );
+                    &projected_transaction
+                } else {
+                    &analysis.transaction
+                };
                 let computed = matches!(
                     closure_request.execution_for(key),
                     rue_query::RequestExecution::Computed
@@ -4580,7 +4619,6 @@ impl CompilerSession {
                 } else {
                     queried_body_work.body_analyses_reused += 1;
                 }
-                let transaction = &analysis.transaction;
                 if computed {
                     let specialized =
                         matches!(instance, crate::FunctionInstanceKey::Specialization { .. });
@@ -4743,7 +4781,7 @@ impl CompilerSession {
                             );
                             continue;
                         };
-                        let Some(source) = analysis.source_locator.as_ref() else {
+                        let Some(source) = current_source_locator.as_ref() else {
                             body_query_errors.insert(
                                 instance.clone(),
                                 crate::CompileErrors::from(
@@ -5581,6 +5619,66 @@ mod tests {
             unreachable!("BodyTransaction publishes typed values")
         };
         (terminal.stamp(), terminal.kind(), transaction.clone())
+    }
+
+    fn retained_body_closure_stamps(
+        session: &CompilerSession,
+        key: &crate::body_query::BodyQueryKey,
+    ) -> (u64, u64) {
+        let revision = session
+            .queries
+            .revisioned
+            .current_semantic_revision()
+            .unwrap();
+        let crate::FunctionInstanceKey::Definition(definition) = &key.instance else {
+            panic!("test closure root must be an ordinary definition")
+        };
+        let request = session
+            .queries
+            .revisioned
+            .body_closure(
+                revision,
+                crate::body_query::BodyClosureQueryKey {
+                    modules: Arc::from([definition.module().clone()]),
+                    roots: Arc::from([key.instance.clone()]),
+                    configuration: key.configuration.clone(),
+                },
+                rue_query::CancellationToken::new(),
+            )
+            .unwrap();
+        let rue_query::QueryOutcome::Success(output) = request.terminal.outcome() else {
+            unreachable!("BodyClosure publishes typed values")
+        };
+        let body = output
+            .bodies
+            .iter()
+            .find(|body| body.key == *key)
+            .expect("test closure contains its root body");
+        (request.terminal.stamp(), body.bundle.stamp())
+    }
+
+    fn retained_body_source_locator(
+        session: &CompilerSession,
+        key: &crate::body_query::BodyQueryKey,
+    ) -> (u64, crate::body_query::BodySourceLocator) {
+        let revision = session
+            .queries
+            .revisioned
+            .current_semantic_revision()
+            .unwrap();
+        let terminal = session
+            .queries
+            .revisioned
+            .body_source_locator_projection(
+                revision,
+                key.clone(),
+                rue_query::CancellationToken::new(),
+            )
+            .unwrap();
+        let rue_query::QueryOutcome::Success(Some(locator)) = terminal.outcome() else {
+            panic!("ordinary test body has a current source locator")
+        };
+        (terminal.stamp(), locator.clone())
     }
 
     fn retained_body_dependency_nodes(
@@ -8138,6 +8236,8 @@ mod tests {
         session.update(&first).into_result().unwrap();
         let first_errors = session.canonical_semantic(&options).unwrap_err();
         let (first_stamp, _, _) = retained_body_transaction(&session, &key);
+        let first_closure_stamps = retained_body_closure_stamps(&session, &key);
+        let (first_locator_stamp, _) = retained_body_source_locator(&session, &key);
         assert_eq!(
             first_errors
                 .first()
@@ -8150,9 +8250,19 @@ mod tests {
         session.update(&shifted).into_result().unwrap();
         let shifted_errors = session.canonical_semantic(&options).unwrap_err();
         let (shifted_stamp, _, _) = retained_body_transaction(&session, &key);
+        let shifted_closure_stamps = retained_body_closure_stamps(&session, &key);
+        let (shifted_locator_stamp, _) = retained_body_source_locator(&session, &key);
         assert_eq!(
             shifted_stamp, first_stamp,
             "a locator-only edit must reuse the semantic body transaction",
+        );
+        assert_eq!(
+            shifted_closure_stamps, first_closure_stamps,
+            "positioned diagnostic payload must not restamp the semantic body closure",
+        );
+        assert_ne!(
+            shifted_locator_stamp, first_locator_stamp,
+            "diagnostics obtain the shifted position from the independent locator projection",
         );
         let shifted_span = shifted_errors
             .first()
@@ -8163,6 +8273,69 @@ mod tests {
             u32::try_from(shifted_text.find("missing_name").unwrap()).unwrap(),
         );
         assert_eq!(shifted_span.file_id, crate::FileId::new(1));
+    }
+
+    #[test]
+    fn whitespace_above_definition_reuses_semantic_shards_and_body_closure() {
+        let first_text = "fn main() -> i32 { 0 }";
+        let shifted_text = "// position-only leading trivia\n\nfn main() -> i32 { 0 }";
+        let first = snapshot(&[(1, "/p/main.rue", "main.rue", first_text)], 1);
+        let shifted = snapshot(&[(1, "/p/main.rue", "main.rue", shifted_text)], 1);
+        let options = CompileOptions::default();
+        let mut session = CompilerSession::new();
+
+        session.update(&first).into_result().unwrap();
+        session.canonical_semantic(&options).unwrap();
+        let key = body_query_key(&mut session, &options, "main");
+        let first_body_stamps = retained_body_query_stamps(&session, &key);
+        let first_closure_stamps = retained_body_closure_stamps(&session, &key);
+        let (first_locator_stamp, first_locator) = retained_body_source_locator(&session, &key);
+
+        session.update(&shifted).into_result().unwrap();
+        let warm = session.canonical_semantic(&options).unwrap();
+        let shifted_body_stamps = retained_body_query_stamps(&session, &key);
+        let shifted_closure_stamps = retained_body_closure_stamps(&session, &key);
+        let (shifted_locator_stamp, shifted_locator) = retained_body_source_locator(&session, &key);
+
+        assert_eq!(
+            shifted_body_stamps, first_body_stamps,
+            "position-only edits keep the body transaction and its semantic projections green",
+        );
+        assert_eq!(
+            shifted_closure_stamps, first_closure_stamps,
+            "the aggregate body-analysis bundle and body closure stay green",
+        );
+        assert_ne!(
+            shifted_locator_stamp, first_locator_stamp,
+            "the independently stamped source-locator projection refreshes",
+        );
+        assert_eq!(first_locator.declaration_start, 0);
+        assert_eq!(
+            shifted_locator.declaration_start,
+            u32::try_from(shifted_text.find("fn main").unwrap()).unwrap(),
+        );
+        assert_eq!(
+            shifted_locator.body_start,
+            u32::try_from(shifted_text.find("{ 0 }").unwrap()).unwrap(),
+        );
+        assert_eq!(warm.work().body_analysis.body_analyses_computed, 0);
+        assert_eq!(warm.work().body_analysis.body_analyses_reused, 1);
+
+        let merge = session.unstable_metrics().merge_metrics();
+        assert_eq!(merge.definition_shards_indexed, 1);
+        assert_eq!(merge.definition_shards_reused, 1);
+        assert_eq!(merge.definition_shards_rebuilt, 0);
+        let merged = session.merge().unwrap();
+        let main = merged
+            .definitions()
+            .definitions()
+            .find(|definition| definition.name_key().name() == "main")
+            .unwrap();
+        assert_eq!(
+            main.declaration_span().start,
+            u32::try_from(shifted_text.find("fn main").unwrap()).unwrap(),
+            "reusing the position-free shard must still rebuild current navigation records",
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- keep definition reuse shards free of file IDs and spans, then project current positions when materializing definition records
- separate semantic body-analysis reuse from revision-specific source locators
- preserve deterministic diagnostics through typed relative or absolute coordinates, including anonymous-body anchors
- add relocation regressions covering successful reuse, retained failures, anonymous members, and mixed local/nonlocal/unknown spans

## Validation

- scripts/rue fmt
- focused RUE-1201 compiler tests
- scripts/rue quick
- premerge Clippy tier (63 targets)
- premerge test tier (78 targets; 0 failures, timeouts, or infrastructure failures)
- adversarial architectural review

Fixes RUE-1201.