### PR TITLE
Borrow-accessor hardening: recursion guard, declaration-flag ground truth, unconditional legality checks

### DIFF
--- a/crates/rue-air/src/sema/analysis/ownership.rs
+++ b/crates/rue-air/src/sema/analysis/ownership.rs
@@ -896,6 +896,13 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
     /// `ctx.expression_loans`); and the accessor body must be well-formed —
     /// guards may diverge, and the single trailing `yield` names a place
     /// rooted at the receiver.
+    ///
+    /// Expansion is acyclic (6.6:14, E0261): while an accessor's body is
+    /// being inlined it is recorded on `ctx.accessor_expansion_stack`, and a
+    /// call naming an accessor already on that stack is rejected — inlining a
+    /// cycle has no fixed point. The marker covers the body only; the
+    /// receiver and argument traces are caller syntax, so a finite chain like
+    /// `v.get_ref(i).get_ref(j)` is unaffected.
     #[allow(clippy::too_many_arguments)]
     fn expand_accessor_call(
         &mut self,
@@ -908,6 +915,17 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
         span: Span,
         ctx: &mut AnalysisContext,
     ) -> CompileResult<PlaceTrace> {
+        if ctx.accessor_expansion_stack.contains(&(struct_id, method)) {
+            return Err(CompileError::new(
+                ErrorKind::AccessorRecursion {
+                    method: self.body_interner().resolve(&method).to_string(),
+                },
+                span,
+            )
+            .with_note(
+                "an accessor call is expanded by inlining its body at the call site, so a cycle of accessor calls has no finite expansion",
+            ));
+        }
         let info = self
             .call_facts()
             .method_info(struct_id, method)
@@ -1040,7 +1058,11 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
         // Locate the body's guard statements and trailing yield. The shape
         // (single trailing `yield`) is the accessor's well-formedness rule;
         // it is re-checked here because a caller may analyze before the
-        // accessor's own standalone analysis runs.
+        // accessor's own standalone analysis runs. This accessor is on the
+        // in-progress stack for exactly the body's analysis, so a call it
+        // makes back into an enclosing accessor is E0261 rather than an
+        // unbounded re-expansion.
+        ctx.accessor_expansion_stack.push((struct_id, method));
         let expansion = (|| -> CompileResult<PlaceTrace> {
             // A single-statement body lowers to the instruction itself.
             let body_insts = match &self.body_rir_ref().get(body).data {
@@ -1122,6 +1144,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
         })();
 
         // Unwind the inline scope regardless of outcome.
+        ctx.accessor_expansion_stack.pop();
         match saved_alias {
             Some(alias) => {
                 ctx.place_aliases.insert(self_sym, alias);

--- a/crates/rue-air/src/sema/context.rs
+++ b/crates/rue-air/src/sema/context.rs
@@ -521,6 +521,12 @@ pub(crate) struct AnalysisContext<'a> {
     /// consult this after analyzing an operand to reject binding a borrowed
     /// place beyond its full expression, naming the offending accessor.
     pub accessor_call_insts: HashMap<InstRef, (Spur, Spur)>,
+    /// Accessors whose inline expansion is in progress, outermost first. An
+    /// accessor call compiles by inlining its body (ADR-0062), so a call that
+    /// names an accessor already on this stack has no finite expansion and is
+    /// E0261 — the acyclicity rule that makes required-inlineability
+    /// well-founded.
+    pub accessor_expansion_stack: Vec<(StructId, Spur)>,
     /// Active accessor-result loans for the current full expression
     /// (ADR-0062): each entry is the receiver root of an expanded accessor
     /// call, shared mode, together with the call span. The statement loop
@@ -748,6 +754,7 @@ impl<'a> AnalysisContext<'a> {
             infer_ctx: self.infer_ctx,
             accessor_trailing_yield: self.accessor_trailing_yield,
             accessor_call_insts: self.accessor_call_insts.clone(),
+            accessor_expansion_stack: self.accessor_expansion_stack.clone(),
             expression_loans: self.expression_loans.clone(),
             inline_resolved_types: self.inline_resolved_types.clone(),
             place_aliases: self.place_aliases.clone(),

--- a/crates/rue-air/src/sema/ordinary_engine.rs
+++ b/crates/rue-air/src/sema/ordinary_engine.rs
@@ -2130,6 +2130,7 @@ impl<'h, H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'h, H> {
             infer_ctx,
             accessor_trailing_yield: None,
             accessor_call_insts: HashMap::new(),
+            accessor_expansion_stack: Vec::new(),
             expression_loans: Vec::new(),
             inline_resolved_types: Vec::new(),
             place_aliases: HashMap::new(),

--- a/crates/rue-air/src/sema/tests.rs
+++ b/crates/rue-air/src/sema/tests.rs
@@ -3977,6 +3977,85 @@ fn main() -> i32 {
     }
 
     #[test]
+    fn accessor_cannot_yield_a_call_to_itself() {
+        // 6.6:14: the call is the inlined body, so a self-call in yield
+        // position has no finite expansion (E0261) rather than a compiler
+        // stack overflow (RUE-1211).
+        let source = "
+struct P {
+    x: i64,
+
+    fn xr(borrow self) -> borrow i64 {
+        yield self.xr();
+    }
+}
+fn main() -> i32 {
+    let p = P { x: 1 };
+    if p.xr() == 1 { 0 } else { 1 }
+}";
+        let errors = compile_with_accessors(source).expect_err("self-recursive accessor");
+        assert!(
+            errors
+                .iter()
+                .any(|error| matches!(&error.kind, ErrorKind::AccessorRecursion { .. }))
+        );
+    }
+
+    #[test]
+    fn accessor_cannot_call_itself_from_a_guard() {
+        // The cycle is rejected wherever the re-entrant call appears, not
+        // only in yield position (RUE-1211).
+        let source = "
+struct P {
+    x: i64,
+
+    fn xr(borrow self) -> borrow i64 {
+        let _ = self.xr();
+        yield self.x;
+    }
+}
+fn main() -> i32 {
+    let p = P { x: 1 };
+    if p.xr() == 1 { 0 } else { 1 }
+}";
+        let errors = compile_with_accessors(source).expect_err("self-recursive accessor guard");
+        assert!(
+            errors
+                .iter()
+                .any(|error| matches!(&error.kind, ErrorKind::AccessorRecursion { .. }))
+        );
+    }
+
+    #[test]
+    fn mutually_recursive_accessors_are_rejected() {
+        // A cycle through several accessors is the same non-terminating
+        // expansion as a direct self-call, and is rejected at the point the
+        // expansion re-enters an accessor already on the stack (6.6:14).
+        let source = "
+struct P {
+    x: i64,
+
+    fn a(borrow self) -> borrow i64 {
+        yield self.b();
+    }
+
+    fn b(borrow self) -> borrow i64 {
+        yield self.a();
+    }
+}
+fn main() -> i32 {
+    let p = P { x: 1 };
+    if p.a() == 1 { 0 } else { 1 }
+}";
+        let errors = compile_with_accessors(source).expect_err("mutually recursive accessors");
+        assert!(
+            errors
+                .iter()
+                .any(|error| matches!(&error.kind, ErrorKind::AccessorRecursion { .. }))
+        );
+    }
+
+    #[test]
     fn yield_outside_accessor_is_rejected() {
         let errors =
             compile_with_accessors("fn main() -> i32 { yield 1; }").expect_err("stray yield");

--- a/crates/rue-error/src/lib.rs
+++ b/crates/rue-error/src/lib.rs
@@ -129,7 +129,7 @@ impl ErrorCode {
     /// arguments and consumes either its status code or the unit value, so a
     /// different source signature would violate the entry ABI.
     pub const INVALID_MAIN_SIGNATURE: Self = Self(211);
-    // E0250-E0260 form the borrow-accessor block (ADR-0062, RUE-662). The
+    // E0250-E0261 form the borrow-accessor block (ADR-0062, RUE-662). The
     // ownership/borrow family's E04xx band is at its ceiling (E0499), so
     // accessor diagnostics live here in the semantic band instead.
     /// An accessor result (`v.get_ref(i)`) was returned from the enclosing
@@ -185,6 +185,12 @@ impl ErrorCode {
     /// arguments are by-value guard inputs (ADR-0062); by-ref accessor
     /// parameters are deferred with the coroutine form (RUE-1012).
     pub const ACCESSOR_PARAM_MODE_UNSUPPORTED: Self = Self(260);
+    /// An accessor call re-entered an accessor whose expansion is already in
+    /// progress: `fn xr(borrow self) -> borrow i64 { yield self.xr(); }`, or
+    /// the same cycle through several accessors. An accessor call compiles by
+    /// inlining its body at the call site (ADR-0062), so an accessor-call
+    /// cycle has no finite expansion.
+    pub const ACCESSOR_RECURSION: Self = Self(261);
 
     // ========================================================================
     // Struct/enum errors (E0400-E0499)
@@ -1543,6 +1549,11 @@ pub enum ErrorKind {
         "an accessor parameter must be by-value: `{mode}` accessor parameters are not supported"
     )]
     AccessorParamModeUnsupported { mode: String },
+    /// An accessor call re-entered an accessor already being expanded.
+    #[error(
+        "recursive accessor `{method}`: an accessor may not invoke itself, directly or through other accessors, in its own body"
+    )]
+    AccessorRecursion { method: String },
     /// Cannot move `self` out of a destructor body (RUE-139). The compiler
     /// drops a value by running its destructor and THEN dropping its fields;
     /// moving `self` to a new owner (a call argument, another binding, ...)
@@ -2008,6 +2019,7 @@ impl ErrorKind {
             ErrorKind::AccessorParamModeUnsupported { .. } => {
                 ErrorCode::ACCESSOR_PARAM_MODE_UNSUPPORTED
             }
+            ErrorKind::AccessorRecursion { .. } => ErrorCode::ACCESSOR_RECURSION,
             ErrorKind::InoutKeywordMissing => ErrorCode::INOUT_KEYWORD_MISSING,
             ErrorKind::BorrowKeywordMissing => ErrorCode::BORROW_KEYWORD_MISSING,
             ErrorKind::UnexpectedCallArgumentMode { .. } => {

--- a/crates/rue-spec/cases/items/borrow-accessors.toml
+++ b/crates/rue-spec/cases/items/borrow-accessors.toml
@@ -4,11 +4,12 @@
 # Coverage note (RUE-662 ruling, 2026-07-29): declaration- and body-level
 # rules are enforced today and carry `preview_should_pass = true`, as does the
 # guard-trap dynamics case (the guard observably traps whether or not the call
-# is inlined). The remaining call-site rules (6.6:8-6.6:11) are implemented in
-# the semantic engine but do not yet fire through the incremental driver, whose
-# per-body RIR pruning cannot see accessor callee bodies; they become
-# enforceable with the RUE-662 epoch-eligibility scaffold (after RUE-1033) and
-# are tracked as known-uncovered until their cases flip to
+# is inlined) and the expansion-acyclicity rejection (6.6:14, which fires as
+# soon as an expansion is entered). The remaining call-site rules (6.6:8-6.6:11)
+# are implemented in the semantic engine but do not yet fire through the
+# incremental driver, whose per-body RIR pruning cannot see accessor callee
+# bodies; they become enforceable with the RUE-662 epoch-eligibility scaffold
+# (after RUE-1033) and are tracked as known-uncovered until their cases flip to
 # `preview_should_pass = true`.
 
 [section]
@@ -164,6 +165,28 @@ fn main() -> i32 {
 """
 compile_fail = true
 error_contains = ["E0255", "place rooted at `self`"]
+
+[[case]]
+name = "accessor_may_not_call_itself"
+spec = ["6.6:14"]
+description = "A directly self-recursive accessor has no finite inline expansion (E0261)."
+preview = "borrow_accessors"
+preview_should_pass = true
+source = """
+struct P {
+    x: i64,
+
+    fn xr(borrow self) -> borrow i64 {
+        yield self.xr();
+    }
+}
+fn main() -> i32 {
+    let p = P { x: 1 };
+    if p.xr() == 1 { 0 } else { 1 }
+}
+"""
+compile_fail = true
+error_contains = ["E0261", "an accessor may not invoke itself"]
 
 # ---------------------------------------------------------------------------
 # Call-site semantics: implemented in the semantic engine (see the rue-air

--- a/docs/spec/src/06-items/06-borrow-accessors.md
+++ b/docs/spec/src/06-items/06-borrow-accessors.md
@@ -115,3 +115,11 @@ Accessors are required-inlineable by design: no calling convention for
 "returning a place" exists, which is the forward-compatibility contract that
 keeps the future coroutine-accessor generalization (RUE-1012) free to choose
 its own call shape.
+
+{{ rule(id="6.6:14", cat="legality-rule") }}
+
+Accessor expansion **MUST** be acyclic: an accessor body **MUST NOT** call an
+accessor whose expansion encloses it, whether directly (`fn xr(borrow self) ->
+borrow i64 { yield self.xr(); }`) or through a chain of other accessors
+(E0261). Because the call is the inlined body (6.6:12), a cycle has no finite
+expansion. The rejection names the recursive call.


### PR DESCRIPTION
Hardens the freshly landed RUE-662 phase 0–1 borrow-accessor groundwork against the highest-severity bug found by the 2026-08-03 autonomous hunt.

**Recursion guard (E0261).** A directly self-recursive accessor (`fn xr(borrow self) -> borrow i64 { yield self.xr(); }`) crashed the compiler with a native stack overflow (SIGABRT, no diagnostic) once a call site forced expansion. `expand_accessor_call` now records in-progress expansions on the analysis context and rejects a call naming an accessor already on the stack — inlining a cycle has no fixed point. The marker covers the body only, so finite caller-side chains like `v.get_ref(i).get_ref(j)` are unaffected. Adds spec rule 6.6:14 (expansion acyclicity), a required-pass spec case, and rue-air unit coverage for yield-position, guard-position, and mutual recursion.

Fixes RUE-1211.

Two sibling findings from the same hunt land in a follow-up PR: trusting the RIR `returns_borrow` flag over body re-derivation (refs RUE-1213) and unconditional accessor declaration/body legality checks (refs RUE-1212).

## Validation

`scripts/rue quick` (30/30), `scripts/rue spec 6.6`, `scripts/rue ui` (209/209), spec traceability gate, clippy, fmt — all green.