### PR TITLE
Borrow accessors: declared-flag ground truth and predeclaration-time legality checks

### DIFF
--- a/crates/rue-air/src/sema/binding_manifest.rs
+++ b/crates/rue-air/src/sema/binding_manifest.rs
@@ -1326,6 +1326,11 @@ impl<'a> DeclarationShells<'a> {
                         // of the current RIR, so it is read here rather than
                         // threaded through the durable declaration shell.
                         is_c_export,
+                        // The `-> borrow T` accessor marker (ADR-0062) is the
+                        // same kind of property: the durable signature records
+                        // the result type's source spelling, which never
+                        // contains the result-position `borrow` qualifier.
+                        returns_borrow,
                         ..
                     } = &self.sema.rir.get(pending.declaration).data
                     else {
@@ -1340,6 +1345,7 @@ impl<'a> DeclarationShells<'a> {
                         return Err(DeclarationInstallFailure::CallableShapeMismatch);
                     }
                     let is_c_export = *is_c_export;
+                    let returns_borrow = *returns_borrow;
                     let type_name = self.sema.interner.get_or_intern("type");
                     let rir_parameters = self.sema.rir.params(params);
                     if parameters
@@ -1388,10 +1394,6 @@ impl<'a> DeclarationShells<'a> {
                             .structs_by_file_name
                             .get(&(pending.shell.declaration_span.file_id, owner))
                             .ok_or(DeclarationInstallFailure::MissingNominal)?;
-                        // The shell carries no accessor flag; derive it from
-                        // the body's trailing `yield`, which coincides on
-                        // every accepted program.
-                        let returns_borrow = super::info::body_ends_in_yield(self.sema.rir, body);
                         self.sema.methods.insert(
                             (id, *name),
                             super::MethodInfo {

--- a/crates/rue-air/src/sema/declarations.rs
+++ b/crates/rue-air/src/sema/declarations.rs
@@ -1367,32 +1367,23 @@ impl<'a> Sema<'a, super::MutableDeclarations> {
             super::DeclarationTypeDependencyKind::Signature,
         ));
 
+        // A `-> borrow T` result is the accessor form (ADR-0062), which a free
+        // function can never satisfy: it has no receiver to project from.
+        check_accessor_declaration_shape(
+            self.rir,
+            declaration,
+            Some(body),
+            false,
+            &self.preview_features,
+        )?;
         let InstData::FnDecl {
             params: rir_params_range,
             directives: directives_range,
-            returns_borrow,
             ..
         } = &self.rir.get(declaration).data
         else {
             unreachable!()
         };
-        // A `-> borrow T` result is the accessor form (ADR-0062) and exists
-        // only on `borrow self` methods; a free or associated function cannot
-        // hand out a receiver projection. Gate first so an ungated program
-        // reports E1100 rather than the shape error.
-        if *returns_borrow {
-            self.require_preview(
-                PreviewFeature::BorrowAccessors,
-                "a `-> borrow` accessor",
-                span,
-            )?;
-            return Err(CompileError::new(
-                ErrorKind::AccessorRequiresBorrowSelf {
-                    found: "a free function".to_string(),
-                },
-                span,
-            ));
-        }
         let params = self.rir.params(rir_params_range);
         let directives = self.rir.directives(directives_range);
         let allow_unused_function = self.has_allow_directive(directives.iter(), "unused_function");
@@ -1695,74 +1686,16 @@ impl<'a> Sema<'a, super::MutableDeclarations> {
                 let param_modes: Vec<RirParamMode> = params.iter().map(|p| p.mode).collect();
                 let param_comptime: Vec<bool> = params.iter().map(|p| p.is_comptime).collect();
 
-                // Place-returning borrow accessors (ADR-0062, RUE-662):
-                // `-> borrow T` is gated behind the `borrow_accessors` preview
-                // and requires a shared `borrow self` receiver (phase 1;
-                // `inout self` accessors are RUE-1016). Accessor parameters
-                // are by-value guard inputs.
-                if *returns_borrow {
-                    self.require_preview(
-                        PreviewFeature::BorrowAccessors,
-                        "a `-> borrow` accessor",
-                        method_inst.span,
-                    )?;
-                    if !*has_self {
-                        return Err(CompileError::new(
-                            ErrorKind::AccessorRequiresBorrowSelf {
-                                found: "an associated function with no receiver".to_string(),
-                            },
-                            method_inst.span,
-                        ));
-                    }
-                    match self_mode {
-                        RirParamMode::Borrow => {}
-                        RirParamMode::Inout => {
-                            return Err(CompileError::new(
-                                ErrorKind::AccessorRequiresBorrowSelf {
-                                    found: "an `inout self` receiver".to_string(),
-                                },
-                                method_inst.span,
-                            )
-                            .with_note(
-                                "mutable accessors (`inout self` -> exclusive result) are a \
-                                 later phase (RUE-1016)",
-                            ));
-                        }
-                        RirParamMode::Normal => {
-                            return Err(CompileError::new(
-                                ErrorKind::AccessorRequiresBorrowSelf {
-                                    found: "a by-value `self` receiver".to_string(),
-                                },
-                                method_inst.span,
-                            ));
-                        }
-                    }
-                    for param in params.iter() {
-                        if param.mode != RirParamMode::Normal {
-                            return Err(CompileError::new(
-                                ErrorKind::AccessorParamModeUnsupported {
-                                    mode: format!(
-                                        "`{}`",
-                                        match param.mode {
-                                            RirParamMode::Inout => "inout",
-                                            RirParamMode::Borrow => "borrow",
-                                            RirParamMode::Normal => unreachable!(),
-                                        }
-                                    ),
-                                },
-                                param.span,
-                            ));
-                        }
-                        if param.is_comptime {
-                            return Err(CompileError::new(
-                                ErrorKind::AccessorParamModeUnsupported {
-                                    mode: "`comptime`".to_string(),
-                                },
-                                param.span,
-                            ));
-                        }
-                    }
-                }
+                // Place-returning borrow accessors (ADR-0062, RUE-662): the
+                // `-> borrow T` declaration shape is checked before any type
+                // in the signature resolves.
+                check_accessor_declaration_shape(
+                    self.rir,
+                    method_ref,
+                    Some(*body),
+                    true,
+                    &self.preview_features,
+                )?;
                 // `Self` in a method signature (parameter or return position)
                 // resolves to the enclosing struct's type, just like the
                 // receiver does. Named-struct inline methods reach this path;
@@ -3174,6 +3107,130 @@ impl<'a> Sema<'a, super::MutableDeclarations> {
             span,
         ))
     }
+}
+
+/// The declaration-shape legality of a `-> borrow T` accessor (ADR-0062):
+/// the result position requires the `borrow_accessors` preview (6.6:3), the
+/// receiver is a shared `borrow self` (6.6:4), and every other parameter is a
+/// plain by-value guard input (6.6:5).
+///
+/// These are legality rules on the declaration, so a declared-but-uncalled
+/// accessor is exactly as ill-formed as a called one. Every producer runs this
+/// over every accessor declaration it admits, which is what keeps the rule
+/// independent of the driver's on-demand body analysis.
+///
+/// The declaring `FnDecl` is the only carrier of `returns_borrow`: the durable
+/// signature records the result type's source spelling, which never contains
+/// the result-position `borrow` qualifier.
+///
+/// The preview gate runs first, so an ungated program reports E1100 rather
+/// than a shape error about a form it cannot name yet.
+pub(super) fn check_accessor_declaration_shape(
+    rir: &rue_rir::Rir,
+    declaration: InstRef,
+    body: Option<InstRef>,
+    has_named_owner: bool,
+    preview_features: &rue_error::PreviewFeatures,
+) -> CompileResult<()> {
+    let inst = rir.get(declaration);
+    let InstData::FnDecl {
+        params,
+        has_self,
+        self_mode,
+        returns_borrow: true,
+        ..
+    } = &inst.data
+    else {
+        return Ok(());
+    };
+    let span = inst.span;
+    super::require_preview_feature(
+        preview_features,
+        PreviewFeature::BorrowAccessors,
+        "a `-> borrow` accessor",
+        span,
+    )?;
+    // An accessor hands out a projection of its receiver, so the receiver is
+    // the first thing that has to exist and be a shared borrow. `inout self`
+    // accessors (exclusive results) are a later phase.
+    let receiver = if !has_named_owner {
+        Some(("a free function", false))
+    } else if !*has_self {
+        Some(("an associated function with no receiver", false))
+    } else {
+        match self_mode {
+            RirParamMode::Borrow => None,
+            RirParamMode::Inout => Some(("an `inout self` receiver", true)),
+            RirParamMode::Normal => Some(("a by-value `self` receiver", false)),
+        }
+    };
+    if let Some((found, is_later_phase)) = receiver {
+        let error = CompileError::new(
+            ErrorKind::AccessorRequiresBorrowSelf {
+                found: found.to_string(),
+            },
+            span,
+        );
+        return Err(if is_later_phase {
+            error.with_note(
+                "mutable accessors (`inout self` -> exclusive result) are a later phase (RUE-1016)",
+            )
+        } else {
+            error
+        });
+    }
+    // `self` is carried by `has_self`, so this list is exactly the guard
+    // inputs: by-value runtime values, evaluated once at the call site.
+    for param in rir.params(params).iter() {
+        if param.mode != RirParamMode::Normal {
+            return Err(CompileError::new(
+                ErrorKind::AccessorParamModeUnsupported {
+                    mode: format!(
+                        "`{}`",
+                        match param.mode {
+                            RirParamMode::Inout => "inout",
+                            RirParamMode::Borrow => "borrow",
+                            RirParamMode::Normal => unreachable!(),
+                        }
+                    ),
+                },
+                param.span,
+            ));
+        }
+        if param.is_comptime {
+            return Err(CompileError::new(
+                ErrorKind::AccessorParamModeUnsupported {
+                    mode: "`comptime`".to_string(),
+                },
+                param.span,
+            ));
+        }
+    }
+    if let Some(body) = body {
+        accessor_trailing_yield(rir, body)?;
+    }
+    Ok(())
+}
+
+/// The single trailing `yield` that an accessor body must fall through to
+/// (6.6:6, ADR-0062 phase 1), or E0254.
+///
+/// Which instruction is the trailing exit is decidable from the RIR alone, so
+/// the declaration seam rejects a body with no trailing `yield` for every
+/// accessor in the program. Rejecting the *other* exits — a second `yield`, a
+/// `return`, a `?` — needs the per-instruction analysis, which the driver runs
+/// only for a body something demands.
+pub(super) fn accessor_trailing_yield(rir: &rue_rir::Rir, body: InstRef) -> CompileResult<InstRef> {
+    // A single-statement body lowers to the instruction itself; a
+    // multi-statement body lowers to a block whose last instruction is the
+    // trailing exit.
+    let trailing = match &rir.get(body).data {
+        InstData::Block { instructions } => rir.block_insts(instructions).values().last(),
+        _ => Some(body),
+    };
+    trailing
+        .filter(|inst_ref| matches!(rir.get(*inst_ref).data, InstData::Yield(_)))
+        .ok_or_else(|| CompileError::new(ErrorKind::AccessorBodyMissingYield, rir.get(body).span))
 }
 
 /// A constant declaration projected from the canonical RIR declaration index.

--- a/crates/rue-air/src/sema/info.rs
+++ b/crates/rue-air/src/sema/info.rs
@@ -100,24 +100,6 @@ pub struct MethodInfo {
     pub returns_borrow: bool,
 }
 
-/// Whether a function body block ends in a `yield` — the derived marker of a
-/// `-> borrow T` accessor body (ADR-0062) for install paths that carry a body
-/// handle but not the declaring `FnDecl`. A non-accessor body ending in
-/// `yield` is ill-formed (E0256) and never completes compilation, so the
-/// derivation agrees with the declaration flag on every accepted program.
-pub(crate) fn body_ends_in_yield(rir: &rue_rir::Rir, body: rue_rir::InstRef) -> bool {
-    match &rir.get(body).data {
-        rue_rir::InstData::Block { instructions } => rir
-            .block_insts(instructions)
-            .values()
-            .last()
-            .is_some_and(|last| matches!(rir.get(last).data, rue_rir::InstData::Yield(_))),
-        // A single-statement body lowers to the instruction itself.
-        rue_rir::InstData::Yield(_) => true,
-        _ => false,
-    }
-}
-
 /// Signature-only callable metadata consumed at a call site. Imported
 /// callables deliberately have no producer-local RIR handles or spans.
 #[derive(Debug, Clone, Copy)]

--- a/crates/rue-air/src/sema/mod.rs
+++ b/crates/rue-air/src/sema/mod.rs
@@ -603,6 +603,34 @@ pub struct Sema<'a, D: DeclarationPhase = MutableDeclarations> {
         std::collections::BTreeSet<anon_structs::IssuedAnonymousNominalKey>,
 }
 
+/// Reject a use of an incomplete language feature that the request did not
+/// enable (`docs/designs/0005-preview-features.md`). Declaration rules run
+/// before a `Sema` phase is available, so the gate is a free function over the
+/// request's feature set.
+pub(crate) fn require_preview_feature(
+    preview_features: &rue_error::PreviewFeatures,
+    feature: rue_error::PreviewFeature,
+    what: &str,
+    span: Span,
+) -> rue_error::CompileResult<()> {
+    if preview_features.contains(&feature) {
+        Ok(())
+    } else {
+        Err(rue_error::CompileError::new(
+            rue_error::ErrorKind::PreviewFeatureRequired {
+                feature,
+                what: what.to_string(),
+            },
+            span,
+        )
+        .with_help(format!(
+            "use `--preview {}` to enable this feature ({})",
+            feature.name(),
+            feature.adr()
+        )))
+    }
+}
+
 impl<D: DeclarationPhase> std::ops::Deref for Sema<'_, D> {
     type Target = DeclarationNamespace;
 
@@ -915,22 +943,7 @@ impl<'a, D: DeclarationPhase> Sema<'a, D> {
         what: &str,
         span: Span,
     ) -> rue_error::CompileResult<()> {
-        if self.preview_features.contains(&feature) {
-            Ok(())
-        } else {
-            Err(rue_error::CompileError::new(
-                rue_error::ErrorKind::PreviewFeatureRequired {
-                    feature,
-                    what: what.to_string(),
-                },
-                span,
-            )
-            .with_help(format!(
-                "use `--preview {}` to enable this feature ({})",
-                feature.name(),
-                feature.adr()
-            )))
-        }
+        require_preview_feature(&self.preview_features, feature, what, span)
     }
 
     pub(crate) fn collect_free_function_signature_during_binding(
@@ -1431,12 +1444,41 @@ impl<'a> Sema<'a, MutableDeclarations> {
         binding_work.callable_value_shells_predeclared = pending_payloads.len();
         binding_work.indexed_declaration_records_visited =
             pending_payloads.len() + pending_nominals.len();
+        self.check_accessor_declaration_shapes(&pending_payloads)?;
         Ok(DeclarationShells {
             sema: self,
             binding_work,
             pending_payloads,
             pending_nominals,
         })
+    }
+
+    /// Reject every ill-formed `-> borrow T` accessor declaration in the
+    /// program (6.6:3-6.6:5, ADR-0062).
+    ///
+    /// Predeclaration is the one point every producer reaches for every
+    /// declaration the program contains, whether or not anything calls it.
+    /// The driver analyzes bodies only on demand, so a rule that runs from a
+    /// body would let an uncalled accessor escape the preview gate entirely.
+    fn check_accessor_declaration_shapes(
+        &self,
+        pending_payloads: &[binding_manifest::PendingDeclarationPayload],
+    ) -> MultiErrorResult<()> {
+        for pending in pending_payloads {
+            let body = match pending.source {
+                binding_manifest::DeclarationPayloadSource::Callable { body } => Some(body),
+                _ => None,
+            };
+            declarations::check_accessor_declaration_shape(
+                self.rir,
+                pending.declaration,
+                body,
+                pending.shell.identity.owner.is_some(),
+                &self.preview_features,
+            )
+            .map_err(CompileErrors::from)?;
+        }
+        Ok(())
     }
 
     /// Import query-owned, position-free declaration shells and attach them to
@@ -1462,6 +1504,7 @@ impl<'a> Sema<'a, MutableDeclarations> {
         binding_work.callable_value_shells_predeclared = pending_payloads.len();
         binding_work.indexed_declaration_records_visited =
             pending_payloads.len() + pending_nominals.len();
+        self.check_accessor_declaration_shapes(&pending_payloads)?;
         Ok(DeclarationShells {
             sema: self,
             binding_work,

--- a/crates/rue-air/src/sema/ordinary_engine.rs
+++ b/crates/rue-air/src/sema/ordinary_engine.rs
@@ -2146,9 +2146,17 @@ impl<'h, H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'h, H> {
             // Declaration shape (ADR-0062 phase 1), re-checked at the engine
             // so it holds on every host that analyzes the body: the receiver
             // is a shared `borrow self`, and value parameters are plain
-            // by-value guard inputs. The epoch declaration collector reports
-            // the same errors earlier when it runs.
+            // by-value guard inputs. Predeclaration reports the same errors
+            // over the whole program before any body is demanded.
             let body_span = self.body_rir_ref().get(body).span;
+            // The `-> borrow` result position alone demands the preview
+            // (6.6:3), so an ungated program reports E1100 rather than a shape
+            // error about a form it cannot name yet.
+            self.require_preview(
+                rue_error::PreviewFeature::BorrowAccessors,
+                "a `-> borrow` accessor",
+                body_span,
+            )?;
             let self_sym_check = self.storage.body_interner().get_or_intern("self");
             match params
                 .iter()
@@ -2212,30 +2220,10 @@ impl<'h, H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'h, H> {
                 }
             }
 
-            // A single-statement body lowers to the instruction itself; a
-            // multi-statement body lowers to a block whose last instruction
-            // is the trailing exit.
-            let trailing = match &self.body_rir_ref().get(body).data {
-                rue_rir::InstData::Block { instructions } => self
-                    .body_rir_ref()
-                    .block_insts(instructions)
-                    .values()
-                    .last(),
-                _ => Some(body),
-            };
-            let trailing_yield = trailing.filter(|inst_ref| {
-                matches!(
-                    self.body_rir_ref().get(*inst_ref).data,
-                    rue_rir::InstData::Yield(_)
-                )
-            });
-            let Some(trailing_yield) = trailing_yield else {
-                return Err(CompileError::new(
-                    ErrorKind::AccessorBodyMissingYield,
-                    self.body_rir_ref().get(body).span,
-                ));
-            };
-            ctx.accessor_trailing_yield = Some(trailing_yield);
+            ctx.accessor_trailing_yield = Some(super::declarations::accessor_trailing_yield(
+                self.body_rir_ref(),
+                body,
+            )?);
         }
 
         // ======================================================================

--- a/crates/rue-air/src/sema/provider_body_host.rs
+++ b/crates/rue-air/src/sema/provider_body_host.rs
@@ -2823,37 +2823,19 @@ where
     K: Clone + Eq + Hash + Ord,
     M: Clone + Eq + Hash + Ord,
 {
-    /// Reject a free function whose declared result is `-> borrow T`. The
-    /// accessor form (ADR-0062) hands out a projection of its receiver, so it
-    /// exists only on `borrow self` methods and a free function is the first
-    /// entry in the 6.6:4 rejection list. The result position alone also
-    /// demands the preview (6.6:3), so the gate runs first and an ungated
-    /// program reports E1100 rather than the shape error.
-    ///
-    /// The declaring `FnDecl` is the only carrier of this flag: the durable
-    /// signature records the result type's source spelling, which never
-    /// contains the result-position `borrow` qualifier.
+    /// Apply the 6.6:3-6.6:5 accessor declaration rules to a free function
+    /// whose body this host is about to analyze. Predeclaration already ran
+    /// them over every declaration in the program; repeating them at the body
+    /// entry keeps a host that analyzes a body it did not predeclare from
+    /// admitting `-> borrow T` on a receiverless callable.
     fn reject_free_function_accessor(&self, declaration: InstRef) -> CompileResult<()> {
-        let inst = self.rir.rir().get(declaration);
-        let InstData::FnDecl {
-            returns_borrow: true,
-            ..
-        } = &inst.data
-        else {
-            return Ok(());
-        };
-        let span = inst.span;
-        self.require_preview(
-            rue_error::PreviewFeature::BorrowAccessors,
-            "a `-> borrow` accessor",
-            span,
-        )?;
-        Err(CompileError::new(
-            rue_error::ErrorKind::AccessorRequiresBorrowSelf {
-                found: "a free function".to_string(),
-            },
-            span,
-        ))
+        super::declarations::check_accessor_declaration_shape(
+            self.rir.rir(),
+            declaration,
+            None,
+            false,
+            &self.preview,
+        )
     }
 
     fn resolve_array_length_in_file(

--- a/crates/rue-air/src/sema/provider_body_host.rs
+++ b/crates/rue-air/src/sema/provider_body_host.rs
@@ -2823,6 +2823,39 @@ where
     K: Clone + Eq + Hash + Ord,
     M: Clone + Eq + Hash + Ord,
 {
+    /// Reject a free function whose declared result is `-> borrow T`. The
+    /// accessor form (ADR-0062) hands out a projection of its receiver, so it
+    /// exists only on `borrow self` methods and a free function is the first
+    /// entry in the 6.6:4 rejection list. The result position alone also
+    /// demands the preview (6.6:3), so the gate runs first and an ungated
+    /// program reports E1100 rather than the shape error.
+    ///
+    /// The declaring `FnDecl` is the only carrier of this flag: the durable
+    /// signature records the result type's source spelling, which never
+    /// contains the result-position `borrow` qualifier.
+    fn reject_free_function_accessor(&self, declaration: InstRef) -> CompileResult<()> {
+        let inst = self.rir.rir().get(declaration);
+        let InstData::FnDecl {
+            returns_borrow: true,
+            ..
+        } = &inst.data
+        else {
+            return Ok(());
+        };
+        let span = inst.span;
+        self.require_preview(
+            rue_error::PreviewFeature::BorrowAccessors,
+            "a `-> borrow` accessor",
+            span,
+        )?;
+        Err(CompileError::new(
+            rue_error::ErrorKind::AccessorRequiresBorrowSelf {
+                found: "a free function".to_string(),
+            },
+            span,
+        ))
+    }
+
     fn resolve_array_length_in_file(
         &mut self,
         length: &ArrayLen,
@@ -4134,6 +4167,7 @@ where
                         name.to_owned(),
                     ))
                 })?;
+            host.reject_free_function_accessor(declaration)?;
             let (params, return_type, body) = match &host.rir.rir().get(declaration).data {
                 InstData::FnDecl {
                     params,
@@ -4943,6 +4977,11 @@ where
             "provider specialization host could not be constructed".into(),
         ))
     })?;
+    // A generic free function reaches analysis only through its
+    // specializations, so the 6.6:3/6.6:4 accessor gate runs here as well.
+    if let Some(declaration) = host.endpoint.first_free_function(name, owner_file) {
+        host.reject_free_function_accessor(declaration)?;
+    }
     let initial_anonymous_identities = host
         .canonical_anonymous_types
         .values()

--- a/crates/rue-air/src/sema/tests.rs
+++ b/crates/rue-air/src/sema/tests.rs
@@ -4101,6 +4101,54 @@ fn main() -> i32 { 0 }";
     }
 
     #[test]
+    fn free_function_accessor_without_yield_requires_preview() {
+        // 6.6:3 is disjunctive: the `-> borrow` result position alone demands
+        // the preview, whether or not the body contains a `yield` (RUE-1213).
+        let source = "
+fn make() -> borrow i64 {
+    5
+}
+fn main() -> i32 { 0 }";
+        let errors = compile_to_air(source).expect_err("the gate is off");
+        assert!(errors.iter().any(|error| matches!(
+            &error.kind,
+            ErrorKind::PreviewFeatureRequired { feature, .. }
+                if *feature == PreviewFeature::BorrowAccessors
+        )));
+    }
+
+    #[test]
+    fn free_function_accessor_without_yield_is_rejected() {
+        // The accessor identity is the declaration's `-> borrow` result, not a
+        // trailing `yield` in the body: a free function carrying the result
+        // qualifier is rejected under the preview too (6.6:4, RUE-1213).
+        let source = "
+fn make() -> borrow i64 {
+    5
+}
+fn main() -> i32 { 0 }";
+        let errors = compile_with_accessors(source).expect_err("free-fn accessor");
+        assert!(errors.iter().any(|error| matches!(
+            &error.kind,
+            ErrorKind::AccessorRequiresBorrowSelf { found } if found == "a free function"
+        )));
+    }
+
+    #[test]
+    fn plain_free_function_is_not_an_accessor() {
+        // Control: an ordinary `-> T` free function keeps compiling with the
+        // preview enabled; only the result-position `borrow` marks an accessor.
+        let source = "
+fn make() -> i64 {
+    5
+}
+fn main() -> i32 {
+    if make() == 5 { 0 } else { 1 }
+}";
+        compile_with_accessors(source).expect("an ordinary free function is unaffected");
+    }
+
+    #[test]
     fn accessor_params_must_be_by_value() {
         let source = "
 struct P {

--- a/crates/rue-air/src/sema/tests.rs
+++ b/crates/rue-air/src/sema/tests.rs
@@ -4167,6 +4167,142 @@ fn main() -> i32 { 0 }";
         );
     }
 
+    // ------------------------------------------------------------------
+    // Declared but never called (RUE-1212). 6.6:3-6.6:5 are legality rules
+    // on the declaration and hold with no call site anywhere, as does the
+    // trailing-exit half of 6.6:6, which the declaration's body shape
+    // decides. The rest of 6.6:6 and 6.6:7 need the per-instruction body
+    // analysis, which runs only for a demanded body; those are covered with
+    // a call site above.
+    // ------------------------------------------------------------------
+
+    const UNCALLED_MAIN: &str = "\nfn main() -> i32 { 0 }";
+
+    #[test]
+    fn uncalled_accessor_declaration_requires_preview() {
+        // 6.6:3 on a method: the accessor surface is gated even when the
+        // program never calls the accessor.
+        let source = format!(
+            "
+struct P {{
+    x: i64,
+
+    fn xr(borrow self) -> borrow i64 {{
+        yield self.x;
+    }}
+}}{UNCALLED_MAIN}"
+        );
+        let errors = compile_to_air(&source).expect_err("the gate is off");
+        assert!(errors.iter().any(|error| matches!(
+            &error.kind,
+            ErrorKind::PreviewFeatureRequired { feature, .. }
+                if *feature == PreviewFeature::BorrowAccessors
+        )));
+    }
+
+    #[test]
+    fn uncalled_accessor_receiver_mode_is_rejected() {
+        // 6.6:4 with no call site.
+        let source = format!(
+            "
+struct P {{
+    x: i64,
+
+    fn xr(inout self) -> borrow i64 {{
+        yield self.x;
+    }}
+}}{UNCALLED_MAIN}"
+        );
+        let errors = compile_with_accessors(&source).expect_err("inout self accessor");
+        assert!(errors.iter().any(|error| matches!(
+            &error.kind,
+            ErrorKind::AccessorRequiresBorrowSelf { found } if found == "an `inout self` receiver"
+        )));
+    }
+
+    #[test]
+    fn uncalled_associated_function_accessor_is_rejected() {
+        // 6.6:4: an associated function has no receiver to project from.
+        let source = format!(
+            "
+struct P {{
+    x: i64,
+
+    fn xr(k: i64) -> borrow i64 {{
+        yield k;
+    }}
+}}{UNCALLED_MAIN}"
+        );
+        let errors = compile_with_accessors(&source).expect_err("associated fn accessor");
+        assert!(errors.iter().any(|error| matches!(
+            &error.kind,
+            ErrorKind::AccessorRequiresBorrowSelf { found }
+                if found == "an associated function with no receiver"
+        )));
+    }
+
+    #[test]
+    fn uncalled_accessor_parameter_mode_is_rejected() {
+        // 6.6:5 with no call site.
+        let source = format!(
+            "
+struct P {{
+    x: i64,
+
+    fn xr(borrow self, borrow k: i64) -> borrow i64 {{
+        yield self.x;
+    }}
+}}{UNCALLED_MAIN}"
+        );
+        let errors = compile_with_accessors(&source).expect_err("borrow accessor param");
+        assert!(
+            errors
+                .iter()
+                .any(|error| matches!(&error.kind, ErrorKind::AccessorParamModeUnsupported { .. }))
+        );
+    }
+
+    #[test]
+    fn uncalled_accessor_body_requires_a_trailing_yield() {
+        // 6.6:6 with no call site. Which instruction is the trailing exit is
+        // decidable from the RIR, so this half of the rule holds without body
+        // analysis; rejecting the other exits still needs a demanded body.
+        let source = format!(
+            "
+struct P {{
+    x: i64,
+
+    fn xr(borrow self) -> borrow i64 {{
+        self.x
+    }}
+}}{UNCALLED_MAIN}"
+        );
+        let errors = compile_with_accessors(&source).expect_err("missing yield");
+        assert!(
+            errors
+                .iter()
+                .any(|error| matches!(&error.kind, ErrorKind::AccessorBodyMissingYield))
+        );
+    }
+
+    #[test]
+    fn uncalled_legal_accessor_declaration_compiles() {
+        // Control: a well-formed accessor nothing calls is legal, so the
+        // unconditional declaration rules must not reject it.
+        let source = format!(
+            "
+struct P {{
+    x: i64,
+
+    @allow(unused_function)
+    fn xr(borrow self) -> borrow i64 {{
+        yield self.x;
+    }}
+}}{UNCALLED_MAIN}"
+        );
+        compile_with_accessors(&source).expect("a legal uncalled accessor compiles");
+    }
+
     #[test]
     fn accessor_guards_execute_before_the_read() {
         // The inlined guards must be part of the caller's AIR: the bounds

--- a/crates/rue-spec/cases/items/borrow-accessors.toml
+++ b/crates/rue-spec/cases/items/borrow-accessors.toml
@@ -64,6 +64,21 @@ compile_fail = true
 error_contains = ["E1100", "borrow_accessors"]
 
 [[case]]
+name = "accessor_result_position_requires_preview_gate"
+spec = ["6.6:3"]
+description = "The `-> borrow` result position alone is E1100 without the preview, with no `yield` anywhere in the body."
+source = """
+fn make() -> borrow i64 {
+    5
+}
+fn main() -> i32 {
+    if make() == 5 { 0 } else { 1 }
+}
+"""
+compile_fail = true
+error_contains = ["E1100", "borrow_accessors"]
+
+[[case]]
 name = "accessor_requires_borrow_self"
 spec = ["6.6:4"]
 description = "An `inout self` accessor is rejected: phase 1 accessors are shared projections (E0257)."
@@ -84,6 +99,40 @@ fn main() -> i32 {
 """
 compile_fail = true
 error_contains = ["E0257", "requires a `borrow self` receiver"]
+
+[[case]]
+name = "free_function_accessor_is_rejected"
+spec = ["6.6:4"]
+description = "A `-> borrow` result on a free function is rejected (E0257); the accessor identity is the declared result, not a trailing `yield`."
+preview = "borrow_accessors"
+preview_should_pass = true
+source = """
+fn make() -> borrow i64 {
+    5
+}
+fn main() -> i32 {
+    if make() == 5 { 0 } else { 1 }
+}
+"""
+compile_fail = true
+error_contains = ["E0257", "this is a free function"]
+
+[[case]]
+name = "generic_free_function_accessor_is_rejected"
+spec = ["6.6:4"]
+description = "A generic free function, which is analyzed only through its specializations, is rejected on the same rule (E0257)."
+preview = "borrow_accessors"
+preview_should_pass = true
+source = """
+fn make(comptime T: type, v: T) -> borrow T {
+    v
+}
+fn main() -> i32 {
+    if make(i64, 5) == 5 { 0 } else { 1 }
+}
+"""
+compile_fail = true
+error_contains = ["E0257", "this is a free function"]
 
 [[case]]
 name = "accessor_params_are_by_value"

--- a/crates/rue-spec/cases/items/borrow-accessors.toml
+++ b/crates/rue-spec/cases/items/borrow-accessors.toml
@@ -215,6 +215,132 @@ fn main() -> i32 {
 compile_fail = true
 error_contains = ["E0255", "place rooted at `self`"]
 
+# ---------------------------------------------------------------------------
+# Declared but never called (RUE-1212). 6.6:3-6.6:5 are legality rules on the
+# declaration, so they hold with no call site anywhere in the program; the
+# trailing-exit half of 6.6:6 is decidable from the declaration's body shape
+# and holds too. The remaining 6.6:6/6.6:7 body rules need the per-instruction
+# analysis, which the driver runs only for a body something demands, so they
+# are covered above with a call site.
+# ---------------------------------------------------------------------------
+
+[[case]]
+name = "uncalled_accessor_requires_preview_gate"
+spec = ["6.6:3"]
+description = "An accessor nothing calls is still accessor surface: E1100 without the preview."
+source = """
+struct P {
+    x: i64,
+
+    @allow(unused_function)
+    fn xr(borrow self) -> borrow i64 {
+        yield self.x;
+    }
+}
+fn main() -> i32 { 0 }
+"""
+compile_fail = true
+error_contains = ["E1100", "borrow_accessors"]
+
+[[case]]
+name = "uncalled_accessor_requires_borrow_self"
+spec = ["6.6:4"]
+description = "The receiver rule holds on a declaration nothing calls (E0257)."
+preview = "borrow_accessors"
+preview_should_pass = true
+source = """
+struct P {
+    x: i64,
+
+    @allow(unused_function)
+    fn xr(inout self) -> borrow i64 {
+        yield self.x;
+    }
+}
+fn main() -> i32 { 0 }
+"""
+compile_fail = true
+error_contains = ["E0257", "requires a `borrow self` receiver"]
+
+[[case]]
+name = "uncalled_associated_function_accessor_is_rejected"
+spec = ["6.6:4"]
+description = "An associated function has no receiver to project from, called or not (E0257)."
+preview = "borrow_accessors"
+preview_should_pass = true
+source = """
+struct P {
+    x: i64,
+
+    @allow(unused_function)
+    fn xr(k: i64) -> borrow i64 {
+        yield k;
+    }
+}
+fn main() -> i32 { 0 }
+"""
+compile_fail = true
+error_contains = ["E0257", "an associated function with no receiver"]
+
+[[case]]
+name = "uncalled_accessor_params_are_by_value"
+spec = ["6.6:5"]
+description = "The parameter-mode rule holds on a declaration nothing calls (E0260)."
+preview = "borrow_accessors"
+preview_should_pass = true
+source = """
+struct P {
+    x: i64,
+
+    @allow(unused_function)
+    fn xr(borrow self, borrow k: i64) -> borrow i64 {
+        yield self.x;
+    }
+}
+fn main() -> i32 { 0 }
+"""
+compile_fail = true
+error_contains = ["E0260", "must be by-value"]
+
+[[case]]
+name = "uncalled_accessor_body_requires_trailing_yield"
+spec = ["6.6:6"]
+description = "An accessor body with no trailing `yield` is rejected with no call site (E0254)."
+preview = "borrow_accessors"
+preview_should_pass = true
+source = """
+struct P {
+    x: i64,
+
+    @allow(unused_function)
+    fn xr(borrow self) -> borrow i64 {
+        self.x
+    }
+}
+fn main() -> i32 { 0 }
+"""
+compile_fail = true
+error_contains = ["E0254", "single trailing `yield`"]
+
+[[case]]
+name = "uncalled_legal_accessor_compiles"
+spec = ["6.6:1", "6.6:2"]
+description = "Control: a well-formed accessor nothing calls compiles, so the unconditional declaration rules reject only ill-formed ones."
+preview = "borrow_accessors"
+preview_should_pass = true
+source = """
+struct P {
+    x: i64,
+
+    @allow(unused_function)
+    fn xr(borrow self) -> borrow i64 {
+        yield self.x;
+    }
+}
+fn main() -> i32 { 0 }
+"""
+exit_code = 0
+
 [[case]]
 name = "accessor_may_not_call_itself"
 spec = ["6.6:14"]


### PR DESCRIPTION
Second and third borrow-accessor hardening fixes from the 2026-08-03 autonomous hunt (first was #2087). Two commits.

## Accessor identity comes from the declaration, not the body

The durable declaration signature records the result type's source spelling, which never contains the result-position `borrow` qualifier, so the install path re-derived accessor identity from the body's trailing `yield` — with a comment asserting the two "coincide on every accepted program". They don't: a free function `fn make() -> borrow i64 { 5 }` (no `yield`) was reclassified as an ordinary function and compiled with zero diagnostics, the qualifier silently stripped — ADR-0062 syntax shipping entirely outside the preview gate and the 6.6:4 receiver rule.

The fix reads `returns_borrow` off the request-local RIR `FnDecl` (the established `is_c_export` recovery pattern), deletes the falsified `body_ends_in_yield` derivation outright, and gates free functions on the specialization path too — the only route generic free functions take, which had the same silent-acceptance hole. One deliberate diagnostic change: a *yield*-bodied free function now reports E0257 instead of E0256 under the preview — the old E0256 was itself a symptom of the stripped flag, and 6.6:4 orders the declaration-shape rejection first.

Fixes RUE-1213.

## Declaration legality checks run at predeclaration, not at call sites

Accessor legality rules — including the E1100 preview gate — only ran when on-demand analysis reached a body, so an uncalled illegal accessor (`inout self` receiver, borrow/comptime params, missing trailing yield) compiled clean, and accessor syntax escaped the preview entirely for any program that declares but never calls one. Ordinary declaration checks (e.g. E0491 duplicate params) have always been unconditional; 6.6:3–6.6:7 are the same category.

One canonical `check_accessor_declaration_shape` rule now runs over every predeclared callable shell on both producer entry points — replacing three divergent inline implementations — and E1100 gates ahead of every shape error on all three surfaces (method, associated fn, free fn), called or uncalled. The trailing-exit half of 6.6:6 is shared with the body engines and fires uncalled too.

**Residual, deliberately not in this PR:** the body-interior rules (6.6:6 multi-yield, 6.6:7 non-receiver-rooted yield) still require a demanded body — no host analyzes uncalled bodies at all today (verified: an uncalled `fn f() -> i64 { undefined_name }` also compiles clean). Reaching them means adding declared accessor bodies to the driver's demanded-body set, which is the query-nucleus body-input work owned by the incremental-recompile track. Toward RUE-1212; the issue stays open with the residual documented.

## Validation

Full spec suite (2221 passed) + traceability gate (known-uncovered set unchanged), `scripts/rue quick` (30/30), rue-air (651) / compiler (747) / rir units, UI (209/209), CLI `abi`/`driver`/`multi`/`borrow` filters, clippy (63 targets), fmt — all green. Unfiltered CLI's Caldera example excluded per docs/process/ci.md (slow tier).