### PR TITLE
RUE-1214: Materialize complete local semantic epochs

### DIFF
--- a/crates/rue-air/src/api_inventory.rs
+++ b/crates/rue-air/src/api_inventory.rs
@@ -422,6 +422,63 @@ fn semantic_schema_scaffolding_stays_exhaustive_and_reviewable() {
 }
 
 #[test]
+fn local_semantic_materialization_owns_complete_cfg_inputs_without_a_peer_cache() {
+    let import = include_str!("semantic_import.rs");
+    let providers = include_str!("sema/provider_body_host.rs");
+
+    for owned in [
+        "pub air: crate::ValidatedAir",
+        "pub type_pool: crate::FrozenTypeInternPool",
+        "pub interner: Arc<ThreadedRodeo>",
+        "pub aggregate_types:",
+        "pub strings: Vec<String>",
+        "pub body_span: Span",
+        "pub completeness: SemanticLocalCompleteness",
+    ] {
+        assert!(
+            import.contains(owned),
+            "local semantic materialization lost owned CFG input: {owned}"
+        );
+    }
+    assert!(import.contains("pub fn new_local("));
+    assert!(import.contains("pub fn materialize_local_body("));
+    assert!(import.contains("local_completeness: Option<SemanticLocalCompleteness>"));
+    let materialize_signature = import
+        .split("pub fn materialize_local_body(")
+        .nth(1)
+        .and_then(|source| source.split(") -> Result").next())
+        .expect("local materialization signature");
+    assert!(
+        !materialize_signature.contains("completeness:"),
+        "a caller-provided completeness witness could be crossed between epochs"
+    );
+    assert!(import.contains("NominalInstanceKey::Anonymous"));
+    assert!(import.contains("SemanticImportFailure::BuiltinNominalShadow"));
+    assert!(import.contains("specialization_key(specialization)"));
+    for provider in ["ProviderSpecializedBody", "ProviderAnonymousBody"] {
+        let body = providers
+            .split(&format!("pub struct {provider}"))
+            .nth(1)
+            .and_then(|source| source.split("\n}").next())
+            .expect("provider result declaration");
+        assert!(body.contains("pub function: AnalyzedFunction"));
+        assert!(body.contains("pub type_pool: Rc<TypeInternPool>"));
+        assert!(body.contains("pub interner: Rc<ThreadedRodeo>"));
+    }
+    for forbidden in ["Mutex<", "RwLock<", "QueryFamily<", "cache:", "selected:"] {
+        let materialization = import
+            .split("pub struct SemanticLocalMaterialization")
+            .nth(1)
+            .and_then(|source| source.split("\n}").next())
+            .expect("local materialization declaration");
+        assert!(
+            !materialization.contains(forbidden),
+            "body-local materialization became peer state: {forbidden}"
+        );
+    }
+}
+
+#[test]
 fn semantic_definition_taxonomy_has_one_enum_declaration() {
     let canonical = include_str!("semantic_identity.rs");
     let bindings = include_str!("sema/binding_manifest.rs");

--- a/crates/rue-air/src/lib.rs
+++ b/crates/rue-air/src/lib.rs
@@ -133,7 +133,9 @@ pub use semantic_import::{
     SEMANTIC_IMPORT_CONST_KINDS, SEMANTIC_IMPORT_TYPE_KINDS, SemanticImportConstKind,
     SemanticImportConstValue, SemanticImportEpoch, SemanticImportFailure, SemanticImportNominal,
     SemanticImportNominalKind, SemanticImportType, SemanticImportTypeFold, SemanticImportTypeKind,
-    SemanticImportedConstValue, SemanticImportedType,
+    SemanticImportedConstValue, SemanticImportedType, SemanticLocalCallable,
+    SemanticLocalCompleteness, SemanticLocalMaterialization, SemanticLocalNominal,
+    SemanticLocalNominalShape,
 };
 pub use semantic_type_resolution::{
     SemanticComptimeCallExpectation, SemanticComptimeCallResult, SemanticModuleBinding,

--- a/crates/rue-air/src/sema/provider_body_host.rs
+++ b/crates/rue-air/src/sema/provider_body_host.rs
@@ -132,6 +132,14 @@ pub struct ProviderOrdinaryBody<K, M> {
 /// Canonical result of one provider-backed specialization transaction.
 pub struct ProviderSpecializedBody<K, M> {
     pub export: crate::SemanticSpecializedBodyExport,
+    /// Exact body-local AIR and its issuing domains. The compiler currently
+    /// publishes the durable export; the local materializer/CFG cutover can
+    /// consume these without reconstructing a reachable-program Sema epoch.
+    pub function: AnalyzedFunction,
+    pub warnings: Vec<rue_error::CompileWarning>,
+    pub strings: Vec<String>,
+    pub type_pool: Rc<TypeInternPool>,
+    pub interner: Rc<ThreadedRodeo>,
     pub produced_anonymous_nominals: Arc<[crate::SemanticProducedAnonymousNominal]>,
     pub referenced_definitions: Vec<K>,
     pub referenced_values: Vec<K>,
@@ -144,6 +152,13 @@ pub struct ProviderSpecializedBody<K, M> {
 /// Canonical result of one provider-backed anonymous member body.
 pub struct ProviderAnonymousBody<K, M> {
     pub export: crate::SemanticAnonymousBodyExport,
+    /// Exact body-local AIR and its issuing domains; retained for the canonical
+    /// local-materialization boundary rather than discarded after export.
+    pub function: AnalyzedFunction,
+    pub warnings: Vec<rue_error::CompileWarning>,
+    pub strings: Vec<String>,
+    pub type_pool: Rc<TypeInternPool>,
+    pub interner: Rc<ThreadedRodeo>,
     pub produced_anonymous_nominals: Arc<[crate::SemanticProducedAnonymousNominal]>,
     pub referenced_definitions: Vec<K>,
     pub referenced_values: Vec<K>,
@@ -4905,6 +4920,11 @@ where
     let module_tokens = host.module_tokens.into_inner().into_values().collect();
     Ok(ProviderAnonymousBody {
         export,
+        function,
+        warnings,
+        strings,
+        type_pool: host.type_pool,
+        interner: host.interner,
         produced_anonymous_nominals,
         referenced_definitions,
         referenced_values,
@@ -5094,6 +5114,11 @@ where
     let module_tokens = host.module_tokens.into_inner().into_values().collect();
     Ok(ProviderSpecializedBody {
         export,
+        function,
+        warnings: specialized.warnings,
+        strings: specialized.local_strings,
+        type_pool: host.type_pool,
+        interner: host.interner,
         produced_anonymous_nominals,
         referenced_definitions,
         referenced_values,

--- a/crates/rue-air/src/semantic_import.rs
+++ b/crates/rue-air/src/semantic_import.rs
@@ -17,7 +17,7 @@ use crate::{
     ConstValue, EnumDef, EnumId, FunctionInstanceKey, ModuleId, ModuleRegistry, NominalInstanceKey,
     SemanticBody, SemanticBodyImportFailure, SemanticBodyInstData, SemanticBodyPattern,
     SemanticBodyProjection, SemanticImportedBody, StructDef, StructField, StructId, Type,
-    TypeInternPool,
+    TypeInstanceKey, TypeInternPool,
 };
 use rue_span::Span;
 
@@ -373,6 +373,184 @@ pub enum SemanticImportFailure {
     NominalAlreadyComplete,
     ForeignLocalType,
     ForeignLocalValue,
+    DuplicateCallable,
+    DuplicateCallableLocalIdentity,
+    DuplicateModule,
+    BuiltinNominalShadow,
+    MissingBodyIdentity,
+    IncompleteMaterialization,
+}
+
+/// One exact nominal fact supplied to a body-local semantic epoch.
+///
+/// The key supplies named and producer-owned anonymous identities. Builtin
+/// identities are epoch-owned and must not appear in this input; fixed builtins
+/// and dynamic `Str(N)` instances resolve through the canonical builtin
+/// registry and issuing type pool. A local epoch may materialize supplied
+/// anonymous structs/enums, but never invent their identity or rediscover their
+/// shape from a whole-program semantic universe.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SemanticLocalNominal<K, M> {
+    pub key: NominalInstanceKey<K, M>,
+    pub module_path: Arc<str>,
+    pub name: Arc<str>,
+    pub kind: SemanticImportNominalKind,
+    pub is_public: bool,
+    pub lang_item: Option<crate::LangItem>,
+    pub shape: SemanticLocalNominalShape<K, M>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SemanticLocalNominalShape<K, M> {
+    Struct {
+        fields: Arc<[(Arc<str>, SemanticImportType<K, M>)]>,
+        is_copy: bool,
+        is_linear: bool,
+        destructor: Option<FunctionInstanceKey<K, M>>,
+    },
+    Enum {
+        variants: Arc<[(Arc<str>, Arc<[SemanticImportType<K, M>]>)]>,
+    },
+}
+
+/// One exact callable symbol fact supplied to a body-local semantic epoch.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SemanticLocalCallable<K, M> {
+    pub key: FunctionInstanceKey<K, M>,
+    pub symbol: Arc<str>,
+}
+
+fn nominal_import_type<K, M>(key: NominalInstanceKey<K, M>) -> SemanticImportType<K, M> {
+    match key {
+        NominalInstanceKey::Builtin { kind, name } => SemanticImportType::BuiltinNominal {
+            name,
+            kind: match kind {
+                crate::AnonymousNominalKind::Struct => SemanticImportNominalKind::Struct,
+                crate::AnonymousNominalKind::Enum => SemanticImportNominalKind::Enum,
+            },
+        },
+        NominalInstanceKey::Named(key) => SemanticImportType::Nominal(key),
+        NominalInstanceKey::Anonymous(key) => SemanticImportType::AnonymousNominal(key),
+    }
+}
+
+fn import_type_identity<K: Clone, M: Clone>(
+    ty: &SemanticImportType<K, M>,
+) -> TypeInstanceKey<K, M> {
+    use SemanticImportType as S;
+    match ty {
+        S::I8 => TypeInstanceKey::I8,
+        S::I16 => TypeInstanceKey::I16,
+        S::I32 => TypeInstanceKey::I32,
+        S::I64 => TypeInstanceKey::I64,
+        S::U8 => TypeInstanceKey::U8,
+        S::U16 => TypeInstanceKey::U16,
+        S::U32 => TypeInstanceKey::U32,
+        S::U64 => TypeInstanceKey::U64,
+        S::Bool => TypeInstanceKey::Bool,
+        S::Unit => TypeInstanceKey::Unit,
+        S::Never => TypeInstanceKey::Never,
+        S::ComptimeType => TypeInstanceKey::ComptimeType,
+        S::BuiltinNominal { name, kind } => TypeInstanceKey::BuiltinNominal {
+            name: name.clone(),
+            kind: match kind {
+                SemanticImportNominalKind::Struct => crate::AnonymousNominalKind::Struct,
+                SemanticImportNominalKind::Enum => crate::AnonymousNominalKind::Enum,
+            },
+        },
+        S::Nominal(key) => TypeInstanceKey::Nominal(NominalInstanceKey::Named(key.clone())),
+        S::AnonymousNominal(key) => {
+            TypeInstanceKey::Nominal(NominalInstanceKey::Anonymous(key.clone()))
+        }
+        S::Array { element, len } => TypeInstanceKey::Array {
+            element: Box::new(import_type_identity(element)),
+            len: *len,
+        },
+        S::PtrConst(inner) => TypeInstanceKey::PtrConst(Box::new(import_type_identity(inner))),
+        S::PtrMut(inner) => TypeInstanceKey::PtrMut(Box::new(import_type_identity(inner))),
+        S::Slice { element, name } => TypeInstanceKey::Slice {
+            element: Box::new(import_type_identity(element)),
+            name: name.clone(),
+        },
+        S::Module(module) => TypeInstanceKey::Module(module.clone()),
+        S::GenericParameter(index) => TypeInstanceKey::GenericParameter(*index),
+    }
+}
+
+fn specialization_key<K: Clone, M: Clone>(
+    identity: &crate::SemanticSpecializationIdentity<K, M>,
+) -> FunctionInstanceKey<K, M> {
+    let values = identity
+        .value_arguments
+        .iter()
+        .map(|value| match value {
+            SemanticImportConstValue::Integer(value) => {
+                crate::CanonicalArgumentValue::Integer(*value)
+            }
+            SemanticImportConstValue::Bool(value) => crate::CanonicalArgumentValue::Bool(*value),
+            SemanticImportConstValue::Type(value) => {
+                crate::CanonicalArgumentValue::Type(Box::new(import_type_identity(value)))
+            }
+            SemanticImportConstValue::Function(value) => crate::CanonicalArgumentValue::Function(
+                Box::new(FunctionInstanceKey::Definition(value.clone())),
+            ),
+            SemanticImportConstValue::Unit => crate::CanonicalArgumentValue::Unit,
+            SemanticImportConstValue::String(value) => {
+                crate::CanonicalArgumentValue::String(value.clone())
+            }
+        })
+        .collect::<Vec<_>>();
+    FunctionInstanceKey::Specialization {
+        base: Box::new(FunctionInstanceKey::Definition(identity.base.clone())),
+        arguments: crate::CanonicalArguments {
+            types: identity
+                .type_arguments
+                .iter()
+                .map(import_type_identity)
+                .collect::<Vec<_>>()
+                .into(),
+            values: values.into(),
+        },
+    }
+}
+
+/// Completeness witness retained with an owned local materialization.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct SemanticLocalCompleteness {
+    nominals_declared: usize,
+    nominals_completed: usize,
+    callables_registered: usize,
+    modules_registered: usize,
+}
+
+impl SemanticLocalCompleteness {
+    pub fn is_complete(self) -> bool {
+        self.nominals_declared == self.nominals_completed
+    }
+}
+
+/// An owned, body-local semantic artifact suitable for a future CFG query.
+///
+/// Compact AIR indexes never escape without the exact pool/interner which
+/// issued them.  Stable identities remain alongside the local aggregate map;
+/// the epoch is a computation helper, not a retained semantic authority.
+pub struct SemanticLocalMaterialization<K, M> {
+    pub identity: FunctionInstanceKey<K, M>,
+    pub name: String,
+    pub callable_kind: crate::AnalyzedCallableKind,
+    pub air: crate::ValidatedAir,
+    pub local_atoms: Vec<crate::LocalAtomRecord<K, M>>,
+    pub num_locals: u32,
+    pub num_param_slots: u32,
+    pub param_modes: crate::ParamSlotModes,
+    pub allow_unreachable_code: bool,
+    pub type_pool: crate::FrozenTypeInternPool,
+    pub interner: Arc<ThreadedRodeo>,
+    pub aggregate_types: std::collections::HashMap<crate::Type, TypeInstanceKey<K, M>>,
+    pub strings: Vec<String>,
+    pub warnings: Arc<[rue_error::CompileWarning]>,
+    pub body_span: Span,
+    pub completeness: SemanticLocalCompleteness,
 }
 
 /// An AIR type branded with the import epoch which issued it.
@@ -419,10 +597,11 @@ pub struct SemanticImportEpoch<K: Ord, M: Ord> {
     interner: ThreadedRodeo,
     type_pool: TypeInternPool,
     module_registry: ModuleRegistry,
-    nominals: BTreeMap<K, LocalNominal>,
-    functions: BTreeMap<K, Spur>,
+    nominals: BTreeMap<NominalInstanceKey<K, M>, LocalNominal>,
+    functions: BTreeMap<FunctionInstanceKey<K, M>, Spur>,
     modules: BTreeMap<M, ModuleId>,
     builtins: BTreeMap<(Arc<str>, SemanticImportNominalKind), LocalNominal>,
+    local_completeness: Option<SemanticLocalCompleteness>,
 }
 
 impl<K, M> SemanticImportEpoch<K, M>
@@ -469,47 +648,22 @@ where
                 self.import_type_local_with(ty, type_pool, None)
                     .map_err(Into::into)
             },
-            |key| match key {
-                NominalInstanceKey::Builtin { .. } => Err(SemanticBodyImportFailure::Semantic(
-                    SemanticImportFailure::MissingNominal,
-                )),
-                NominalInstanceKey::Named(key) => match self.nominals.get(key) {
-                    Some(LocalNominal::Struct(id)) => Ok(*id),
-                    Some(LocalNominal::Enum(_)) => Err(SemanticBodyImportFailure::WrongNominalKind),
-                    None => Err(SemanticBodyImportFailure::Semantic(
-                        SemanticImportFailure::MissingNominal,
-                    )),
-                },
-                NominalInstanceKey::Anonymous(_) => Err(SemanticBodyImportFailure::Semantic(
-                    SemanticImportFailure::MissingNominal,
-                )),
+            |key| match self.resolve_nominal_in_pool(type_pool, key)? {
+                LocalNominal::Struct(id) => Ok(id),
+                LocalNominal::Enum(_) => Err(SemanticBodyImportFailure::WrongNominalKind),
+            },
+            |key| match self.resolve_nominal_in_pool(type_pool, key)? {
+                LocalNominal::Enum(id) => Ok(id),
+                LocalNominal::Struct(_) => Err(SemanticBodyImportFailure::WrongNominalKind),
             },
             |key| match key {
-                NominalInstanceKey::Builtin { .. } => Err(SemanticBodyImportFailure::Semantic(
-                    SemanticImportFailure::MissingNominal,
-                )),
-                NominalInstanceKey::Named(key) => match self.nominals.get(key) {
-                    Some(LocalNominal::Enum(id)) => Ok(*id),
-                    Some(LocalNominal::Struct(_)) => {
-                        Err(SemanticBodyImportFailure::WrongNominalKind)
-                    }
-                    None => Err(SemanticBodyImportFailure::Semantic(
-                        SemanticImportFailure::MissingNominal,
+                FunctionInstanceKey::Definition(key) => self
+                    .functions
+                    .get(&FunctionInstanceKey::Definition(key.clone()))
+                    .copied()
+                    .ok_or(SemanticBodyImportFailure::Semantic(
+                        SemanticImportFailure::MissingFunction,
                     )),
-                },
-                NominalInstanceKey::Anonymous(_) => Err(SemanticBodyImportFailure::Semantic(
-                    SemanticImportFailure::MissingNominal,
-                )),
-            },
-            |key| match key {
-                FunctionInstanceKey::Definition(key) => {
-                    self.functions
-                        .get(key)
-                        .copied()
-                        .ok_or(SemanticBodyImportFailure::Semantic(
-                            SemanticImportFailure::MissingFunction,
-                        ))
-                }
                 _ => Err(SemanticBodyImportFailure::Semantic(
                     SemanticImportFailure::MissingFunction,
                 )),
@@ -989,7 +1143,10 @@ where
                 return Err(SemanticImportFailure::DuplicateFunctionLocalIdentity);
             }
             let symbol = interner.get_or_intern(name.as_ref());
-            if functions.insert(key, symbol).is_some() {
+            if functions
+                .insert(FunctionInstanceKey::Definition(key), symbol)
+                .is_some()
+            {
                 return Err(SemanticImportFailure::DuplicateFunction);
             }
         }
@@ -1010,7 +1167,7 @@ where
         let mut local = BTreeMap::new();
         let mut local_identities = std::collections::BTreeSet::new();
         for nominal in nominals {
-            if local.contains_key(&nominal.key) {
+            if local.contains_key(&NominalInstanceKey::Named(nominal.key.clone())) {
                 return Err(SemanticImportFailure::DuplicateNominal);
             }
             if !local_identities.insert((
@@ -1057,7 +1214,7 @@ where
                     LocalNominal::Enum(id)
                 }
             };
-            local.insert(nominal.key, value);
+            local.insert(NominalInstanceKey::Named(nominal.key), value);
         }
         // Ordinary sema registers source nominals before lazily creating the
         // stable core `str` identity. Preserve that order so a fresh epoch's
@@ -1100,6 +1257,265 @@ where
             functions,
             modules,
             builtins,
+            local_completeness: None,
+        })
+    }
+
+    /// Construct a body-local epoch from exact query-owned facts.
+    ///
+    /// All nominal shells are declared before any shape is completed, so
+    /// recursive aggregates are supported without widening the input to a
+    /// reachable-program universe. Duplicate identities and duplicate local
+    /// symbols fail before a body can be imported.
+    pub fn new_local(
+        mut nominals: Vec<SemanticLocalNominal<K, M>>,
+        mut callables: Vec<SemanticLocalCallable<K, M>>,
+        modules: Vec<M>,
+    ) -> Result<Self, SemanticImportFailure>
+    where
+        K: Eq,
+        M: Clone + Eq,
+    {
+        nominals.sort_by(|left, right| left.key.cmp(&right.key));
+        callables.sort_by(|left, right| left.key.cmp(&right.key));
+        if nominals
+            .iter()
+            .any(|nominal| matches!(nominal.key, NominalInstanceKey::Builtin { .. }))
+        {
+            return Err(SemanticImportFailure::BuiltinNominalShadow);
+        }
+        let mut modules = modules;
+        modules.sort();
+        if modules.windows(2).any(|pair| pair[0] == pair[1]) {
+            return Err(SemanticImportFailure::DuplicateModule);
+        }
+        let mut epoch = Self::new(Vec::new(), Vec::new(), modules)?;
+
+        let mut callable_symbols = std::collections::BTreeSet::new();
+        for callable in &callables {
+            if !callable_symbols.insert(callable.symbol.clone()) {
+                return Err(SemanticImportFailure::DuplicateCallableLocalIdentity);
+            }
+            let symbol = epoch.interner.get_or_intern(callable.symbol.as_ref());
+            if epoch
+                .functions
+                .insert(callable.key.clone(), symbol)
+                .is_some()
+            {
+                return Err(SemanticImportFailure::DuplicateCallable);
+            }
+        }
+
+        let mut module_files = BTreeMap::<Arc<str>, FileId>::new();
+        for nominal in &nominals {
+            let next = u32::try_from(module_files.len() + 1).expect("too many local modules");
+            module_files
+                .entry(nominal.module_path.clone())
+                .or_insert(FileId::new(next));
+        }
+        epoch.type_pool.set_symbol_paths(
+            module_files
+                .iter()
+                .map(|(path, file)| (*file, path.to_string()))
+                .collect(),
+        );
+        let mut local_identities = std::collections::BTreeSet::new();
+        for nominal in &nominals {
+            if epoch.nominals.contains_key(&nominal.key) {
+                return Err(SemanticImportFailure::DuplicateNominal);
+            }
+            if !local_identities.insert((
+                nominal.kind,
+                nominal.module_path.clone(),
+                nominal.name.clone(),
+            )) {
+                return Err(SemanticImportFailure::DuplicateNominalLocalIdentity);
+            }
+            let file_id = module_files[&nominal.module_path];
+            let symbol = epoch.interner.get_or_intern(nominal.name.as_ref());
+            let local = match nominal.kind {
+                SemanticImportNominalKind::Struct => {
+                    let (id, _) = epoch.type_pool.declare_struct(
+                        symbol,
+                        StructDef {
+                            name: nominal.name.to_string(),
+                            fields: Vec::new(),
+                            is_copy: false,
+                            is_linear: false,
+                            destructor: None,
+                            is_builtin: false,
+                            is_pub: nominal.is_public,
+                            file_id,
+                        },
+                    );
+                    if let Some(lang_item) = nominal.lang_item {
+                        epoch.type_pool.set_struct_lang_item(id, lang_item);
+                    }
+                    LocalNominal::Struct(id)
+                }
+                SemanticImportNominalKind::Enum => {
+                    if nominal.lang_item.is_some() {
+                        return Err(SemanticImportFailure::NominalKindMismatch);
+                    }
+                    let (id, _) = epoch.type_pool.declare_enum(
+                        symbol,
+                        EnumDef {
+                            name: nominal.name.to_string(),
+                            variants: Vec::new(),
+                            variant_payloads: Vec::new(),
+                            is_pub: nominal.is_public,
+                            file_id,
+                        },
+                    );
+                    LocalNominal::Enum(id)
+                }
+            };
+            epoch.nominals.insert(nominal.key.clone(), local);
+        }
+
+        for nominal in &nominals {
+            match &nominal.shape {
+                SemanticLocalNominalShape::Struct {
+                    fields,
+                    is_copy,
+                    is_linear,
+                    destructor,
+                } => {
+                    epoch.complete_nominal_struct(&nominal.key, fields, *is_copy, *is_linear)?;
+                    if let Some(destructor) = destructor {
+                        let symbol = epoch
+                            .functions
+                            .get(destructor)
+                            .copied()
+                            .ok_or(SemanticImportFailure::MissingFunction)?;
+                        let Some(LocalNominal::Struct(id)) = epoch.nominals.get(&nominal.key)
+                        else {
+                            return Err(SemanticImportFailure::NominalKindMismatch);
+                        };
+                        epoch
+                            .type_pool
+                            .set_struct_destructor(*id, epoch.interner.resolve(&symbol).to_owned());
+                    }
+                }
+                SemanticLocalNominalShape::Enum { variants } => {
+                    epoch.complete_nominal_enum(&nominal.key, variants)?
+                }
+            }
+        }
+        epoch.local_completeness = Some(SemanticLocalCompleteness {
+            nominals_declared: nominals.len(),
+            nominals_completed: nominals.len(),
+            callables_registered: callables.len(),
+            modules_registered: epoch.modules.len(),
+        });
+        Ok(epoch)
+    }
+
+    /// Consume this exact local epoch into an owned function artifact.
+    pub fn materialize_local_body(
+        self,
+        identity: FunctionInstanceKey<K, M>,
+        callable_kind: crate::AnalyzedCallableKind,
+        body: &SemanticBody<K, M>,
+        body_span: Span,
+    ) -> Result<SemanticLocalMaterialization<K, M>, SemanticBodyImportFailure>
+    where
+        K: Eq + Hash,
+        M: Clone + Eq + Hash,
+    {
+        let completeness = self
+            .local_completeness
+            .ok_or(SemanticBodyImportFailure::Semantic(
+                SemanticImportFailure::IncompleteMaterialization,
+            ))?;
+        if !completeness.is_complete()
+            || completeness.nominals_declared != self.nominals.len()
+            || completeness.callables_registered != self.functions.len()
+            || completeness.modules_registered != self.modules.len()
+        {
+            return Err(SemanticBodyImportFailure::Semantic(
+                SemanticImportFailure::IncompleteMaterialization,
+            ));
+        }
+        let name =
+            self.functions
+                .get(&identity)
+                .copied()
+                .ok_or(SemanticBodyImportFailure::Semantic(
+                    SemanticImportFailure::MissingBodyIdentity,
+                ))?;
+        let imported = Self::import_body_with(
+            body,
+            body_span,
+            &self.type_pool,
+            true,
+            |ty| self.import_type_local(ty).map_err(Into::into),
+            |key| match self.resolve_nominal_in_pool(&self.type_pool, key)? {
+                LocalNominal::Struct(id) => Ok(id),
+                LocalNominal::Enum(_) => Err(SemanticBodyImportFailure::WrongNominalKind),
+            },
+            |key| match self.resolve_nominal_in_pool(&self.type_pool, key)? {
+                LocalNominal::Enum(id) => Ok(id),
+                LocalNominal::Struct(_) => Err(SemanticBodyImportFailure::WrongNominalKind),
+            },
+            |key| {
+                self.functions
+                    .get(key)
+                    .copied()
+                    .ok_or(SemanticBodyImportFailure::Semantic(
+                        SemanticImportFailure::MissingFunction,
+                    ))
+            },
+            |specialization| {
+                let key = specialization_key(specialization);
+                let symbol = self.functions.get(&key).copied().ok_or(
+                    SemanticBodyImportFailure::Semantic(SemanticImportFailure::MissingFunction),
+                )?;
+                Ok((symbol, Vec::new(), Vec::new()))
+            },
+            |value| self.interner.get_or_intern(value),
+        )?;
+        let mut aggregate_types = std::collections::HashMap::new();
+        let type_snapshot = self.type_pool.clone().freeze();
+        for ty in type_snapshot.all_types() {
+            if matches!(
+                ty.kind(),
+                crate::TypeKind::Struct(_) | crate::TypeKind::Enum(_) | crate::TypeKind::Array(_)
+            ) {
+                let stable = self
+                    .export_type_local(ty)
+                    .map_err(SemanticBodyImportFailure::Semantic)?;
+                aggregate_types.insert(ty, import_type_identity(&stable));
+            }
+        }
+        let SemanticImportedBody {
+            air,
+            strings,
+            local_atoms,
+            num_locals,
+            num_param_slots,
+            param_modes,
+            allow_unreachable_code,
+            warnings,
+            method_references: _,
+        } = imported;
+        Ok(SemanticLocalMaterialization {
+            identity,
+            name: self.interner.resolve(&name).to_owned(),
+            callable_kind,
+            air,
+            local_atoms,
+            num_locals,
+            num_param_slots,
+            param_modes,
+            allow_unreachable_code,
+            type_pool: self.type_pool.freeze(),
+            interner: Arc::new(self.interner),
+            aggregate_types,
+            strings,
+            warnings,
+            body_span,
+            completeness,
         })
     }
 
@@ -1112,6 +1528,89 @@ where
                 epoch: self.epoch.clone(),
                 value,
             })
+    }
+
+    fn resolve_builtin_nominal_in_pool(
+        &self,
+        type_pool: &TypeInternPool,
+        name: &Arc<str>,
+        kind: SemanticImportNominalKind,
+    ) -> Result<LocalNominal, SemanticImportFailure> {
+        if name
+            .strip_prefix("Str(")
+            .and_then(|name| name.strip_suffix(')'))
+            .and_then(|capacity| capacity.parse::<u64>().ok())
+            .is_some()
+        {
+            if kind != SemanticImportNominalKind::Struct {
+                return Err(SemanticImportFailure::BuiltinNominalKindMismatch);
+            }
+            let symbol = self.interner.get_or_intern(name.as_ref());
+            if let Some(existing) = type_pool.get_struct_by_file_name(FileId::DEFAULT, symbol) {
+                return Ok(LocalNominal::Struct(
+                    existing
+                        .as_struct()
+                        .expect("fixed string lookup returns a struct"),
+                ));
+            }
+            let pointer = type_pool.intern_ptr_const_from_type(Type::U8);
+            let (id, _) = type_pool.register_struct(
+                symbol,
+                StructDef {
+                    name: name.to_string(),
+                    fields: vec![
+                        StructField {
+                            name: "ptr".to_owned(),
+                            ty: Type::new_ptr_const(pointer),
+                        },
+                        StructField {
+                            name: "len".to_owned(),
+                            ty: Type::U64,
+                        },
+                    ],
+                    is_copy: true,
+                    is_linear: false,
+                    destructor: None,
+                    is_builtin: true,
+                    is_pub: true,
+                    file_id: FileId::DEFAULT,
+                },
+            );
+            return Ok(LocalNominal::Struct(id));
+        }
+
+        self.builtins
+            .get(&(name.clone(), kind))
+            .copied()
+            .ok_or_else(|| {
+                if self.builtins.keys().any(|(known, _)| known == name) {
+                    SemanticImportFailure::BuiltinNominalKindMismatch
+                } else {
+                    SemanticImportFailure::UnknownBuiltinNominal
+                }
+            })
+    }
+
+    fn resolve_nominal_in_pool(
+        &self,
+        type_pool: &TypeInternPool,
+        key: &NominalInstanceKey<K, M>,
+    ) -> Result<LocalNominal, SemanticImportFailure> {
+        match key {
+            NominalInstanceKey::Builtin { kind, name } => self.resolve_builtin_nominal_in_pool(
+                type_pool,
+                name,
+                match kind {
+                    crate::AnonymousNominalKind::Struct => SemanticImportNominalKind::Struct,
+                    crate::AnonymousNominalKind::Enum => SemanticImportNominalKind::Enum,
+                },
+            ),
+            NominalInstanceKey::Named(_) | NominalInstanceKey::Anonymous(_) => self
+                .nominals
+                .get(key)
+                .copied()
+                .ok_or(SemanticImportFailure::MissingNominal),
+        }
     }
 
     fn import_type_local(
@@ -1143,68 +1642,25 @@ where
                 F::Never => Type::NEVER,
                 F::ComptimeType => Type::COMPTIME_TYPE,
                 F::BuiltinNominal { name, kind } => {
-                    if let Some(_capacity) = name
-                        .strip_prefix("Str(")
-                        .and_then(|name| name.strip_suffix(')'))
-                        .and_then(|capacity| capacity.parse::<u64>().ok())
-                    {
-                        if kind != SemanticImportNominalKind::Struct {
-                            return Err(SemanticImportFailure::BuiltinNominalKindMismatch);
-                        }
-                        let symbol = self.interner.get_or_intern(name.as_ref());
-                        let pointer = type_pool.intern_ptr_const_from_type(Type::U8);
-                        let (id, _) = type_pool.register_struct(
-                            symbol,
-                            StructDef {
-                                name: name.to_string(),
-                                fields: vec![
-                                    StructField {
-                                        name: "ptr".to_owned(),
-                                        ty: Type::new_ptr_const(pointer),
-                                    },
-                                    StructField {
-                                        name: "len".to_owned(),
-                                        ty: Type::U64,
-                                    },
-                                ],
-                                is_copy: true,
-                                is_linear: false,
-                                destructor: None,
-                                is_builtin: true,
-                                is_pub: true,
-                                file_id: FileId::DEFAULT,
-                            },
-                        );
-                        Type::new_struct(id)
-                    } else {
-                        let local = self
-                            .builtins
-                            .get(&(name.clone(), kind))
-                            .copied()
-                            .ok_or_else(|| {
-                                if self.builtins.keys().any(|(known, _)| known == name) {
-                                    SemanticImportFailure::BuiltinNominalKindMismatch
-                                } else {
-                                    SemanticImportFailure::UnknownBuiltinNominal
-                                }
-                            })?;
-                        match local {
-                            LocalNominal::Struct(id) => Type::new_struct(id),
-                            LocalNominal::Enum(id) => Type::new_enum(id),
-                        }
+                    match self.resolve_builtin_nominal_in_pool(type_pool, name, kind)? {
+                        LocalNominal::Struct(id) => Type::new_struct(id),
+                        LocalNominal::Enum(id) => Type::new_enum(id),
                     }
                 }
-                F::Nominal(key) => match self.nominals.get(key) {
+                F::Nominal(key) => match self.nominals.get(&NominalInstanceKey::Named(key.clone()))
+                {
                     Some(LocalNominal::Struct(id)) => Type::new_struct(*id),
                     Some(LocalNominal::Enum(id)) => Type::new_enum(*id),
                     None => return Err(SemanticImportFailure::MissingNominal),
                 },
-                // A generic fresh import epoch has no current-request
-                // authority capable of joining an anonymous nominal key to a
-                // live AIR type. Only BodySema's exact-key importer may do so.
-                F::AnonymousNominal(_) => {
-                    return Err(SemanticImportFailure::MissingNominal);
-                }
+                F::AnonymousNominal(key) => match self
+                    .nominals
+                    .get(&NominalInstanceKey::Anonymous(key.clone()))
+                {
+                    Some(LocalNominal::Struct(id)) => Type::new_struct(*id),
+                    Some(LocalNominal::Enum(id)) => Type::new_enum(*id),
+                    None => return Err(SemanticImportFailure::MissingNominal),
+                },
                 F::Array { element, len } => type_pool
                     .try_intern_array(element, len)
                     .map_err(|_| SemanticImportFailure::InvalidStructuralType)?,
@@ -1315,7 +1771,7 @@ where
             SemanticImportConstValue::Function(key) => ConstValue::Function(
                 *self
                     .functions
-                    .get(key)
+                    .get(&FunctionInstanceKey::Definition(key.clone()))
                     .ok_or(SemanticImportFailure::MissingFunction)?,
             ),
             SemanticImportConstValue::Unit => ConstValue::Unit,
@@ -1384,8 +1840,24 @@ where
                         name: name.clone(),
                         kind: *kind,
                     }
+                } else if def.is_builtin
+                    && def
+                        .name
+                        .strip_prefix("Str(")
+                        .and_then(|name| name.strip_suffix(')'))
+                        .and_then(|capacity| capacity.parse::<u64>().ok())
+                        .is_some()
+                {
+                    // `Str(N)` is registered lazily in the exact transaction
+                    // pool. Its compiler-builtin bit plus canonical capacity
+                    // spelling is the durable classification; unrelated source
+                    // structs never acquire that bit.
+                    SemanticImportType::BuiltinNominal {
+                        name: Arc::from(def.name.as_str()),
+                        kind: SemanticImportNominalKind::Struct,
+                    }
                 } else {
-                    SemanticImportType::Nominal(
+                    nominal_import_type(
                         self.nominals
                             .iter()
                             .find_map(|(key, local)| {
@@ -1406,7 +1878,7 @@ where
                         kind: *kind,
                     }
                 } else {
-                    SemanticImportType::Nominal(
+                    nominal_import_type(
                         self.nominals
                             .iter()
                             .find_map(|(key, local)| {
@@ -1453,7 +1925,12 @@ where
             ConstValue::Function(symbol) => SemanticImportConstValue::Function(
                 self.functions
                     .iter()
-                    .find_map(|(key, local)| (*local == symbol).then(|| key.clone()))
+                    .find_map(|(key, local)| match key {
+                        FunctionInstanceKey::Definition(key) if *local == symbol => {
+                            Some(key.clone())
+                        }
+                        _ => None,
+                    })
                     .ok_or(SemanticImportFailure::ForeignLocalValue)?,
             ),
             ConstValue::Unit => SemanticImportConstValue::Unit,
@@ -1466,6 +1943,21 @@ where
     pub fn complete_struct(
         &self,
         key: &K,
+        fields: &[(Arc<str>, SemanticImportType<K, M>)],
+        is_copy: bool,
+        is_linear: bool,
+    ) -> Result<(), SemanticImportFailure> {
+        self.complete_nominal_struct(
+            &NominalInstanceKey::Named(key.clone()),
+            fields,
+            is_copy,
+            is_linear,
+        )
+    }
+
+    fn complete_nominal_struct(
+        &self,
+        key: &NominalInstanceKey<K, M>,
         fields: &[(Arc<str>, SemanticImportType<K, M>)],
         is_copy: bool,
         is_linear: bool,
@@ -1515,6 +2007,14 @@ where
     pub fn complete_enum(
         &self,
         key: &K,
+        variants: &[(Arc<str>, Arc<[SemanticImportType<K, M>]>)],
+    ) -> Result<(), SemanticImportFailure> {
+        self.complete_nominal_enum(&NominalInstanceKey::Named(key.clone()), variants)
+    }
+
+    fn complete_nominal_enum(
+        &self,
+        key: &NominalInstanceKey<K, M>,
         variants: &[(Arc<str>, Arc<[SemanticImportType<K, M>]>)],
     ) -> Result<(), SemanticImportFailure> {
         let LocalNominal::Enum(id) = self
@@ -1838,7 +2338,7 @@ mod tests {
         )
         .unwrap();
         for epoch in [&first, &second] {
-            let left = epoch.nominals["left"];
+            let left = epoch.nominals[&NominalInstanceKey::Named("left")];
             let LocalNominal::Struct(left) = left else {
                 panic!("left must be a struct")
             };
@@ -1877,7 +2377,7 @@ mod tests {
                 projection(&second, second.import_type(&ty).unwrap().value)
             );
         }
-        let LocalNominal::Struct(left) = first.nominals["left"] else {
+        let LocalNominal::Struct(left) = first.nominals[&NominalInstanceKey::Named("left")] else {
             panic!("left must be a struct")
         };
         assert!(first.type_pool().try_struct_def(left).is_some());
@@ -1895,7 +2395,7 @@ mod tests {
             vec![],
         )
         .unwrap();
-        let LocalNominal::Enum(id) = epoch.nominals["choice"] else {
+        let LocalNominal::Enum(id) = epoch.nominals[&NominalInstanceKey::Named("choice")] else {
             panic!("choice must be an enum")
         };
         let ty = Type::new_enum(id);
@@ -1946,7 +2446,7 @@ mod tests {
         );
         assert_eq!(epoch.type_pool().stats(), before);
         assert_eq!(epoch.type_pool().get_array(Type::U8, 4), None);
-        let LocalNominal::Struct(id) = epoch.nominals["node"] else {
+        let LocalNominal::Struct(id) = epoch.nominals[&NominalInstanceKey::Named("node")] else {
             panic!("node must be a struct")
         };
         assert!(epoch.type_pool().try_struct_def(id).is_none());
@@ -1968,7 +2468,7 @@ mod tests {
         );
         assert_eq!(epoch.type_pool().stats(), before);
         assert_eq!(epoch.type_pool().get_array(Type::U16, 5), None);
-        let LocalNominal::Enum(id) = epoch.nominals["choice"] else {
+        let LocalNominal::Enum(id) = epoch.nominals[&NominalInstanceKey::Named("choice")] else {
             panic!("choice must be an enum")
         };
         assert!(epoch.type_pool().try_enum_def(id).is_none());
@@ -2230,6 +2730,624 @@ mod tests {
                 .as_u32(),
             2
         );
+    }
+
+    fn local_callable(
+        key: FunctionInstanceKey<&'static str, &'static str>,
+        symbol: &'static str,
+    ) -> SemanticLocalCallable<&'static str, &'static str> {
+        SemanticLocalCallable {
+            key,
+            symbol: Arc::from(symbol),
+        }
+    }
+
+    fn materialize_local(
+        identity: FunctionInstanceKey<&'static str, &'static str>,
+        callable_kind: crate::AnalyzedCallableKind,
+        input: &SemanticBody<&'static str, &'static str>,
+        nominals: Vec<SemanticLocalNominal<&'static str, &'static str>>,
+        callables: Vec<SemanticLocalCallable<&'static str, &'static str>>,
+    ) -> Result<SemanticLocalMaterialization<&'static str, &'static str>, SemanticBodyImportFailure>
+    {
+        let epoch = Epoch::new_local(nominals, callables, vec!["main"]).unwrap();
+        epoch.materialize_local_body(
+            identity,
+            callable_kind,
+            input,
+            Span::with_file(FileId::new(7), 100, 200),
+        )
+    }
+
+    #[test]
+    fn local_materialization_owns_ordinary_air_strings_and_domains() {
+        use crate::SemanticBodyInstData as D;
+        let identity = FunctionInstanceKey::Definition("main");
+        let mut input = body(vec![
+            D::Const(42),
+            D::Intrinsic {
+                runtime: None,
+                name: Arc::from("compiler-intrinsic"),
+                args: Arc::new([]),
+            },
+            D::Ret(Some(1)),
+        ]);
+        input.strings = vec![Arc::from("body-local")].into();
+        input.local_atoms = vec![crate::SemanticBodyLocalAtom {
+            identity: crate::LocalAtomId {
+                producer: identity.clone(),
+                kind: crate::LocalAtomKind::String,
+                anchor: rue_rir::RirStructuralAnchor::new(vec![
+                    rue_rir::RirStructuralPathSegment::Body,
+                    rue_rir::RirStructuralPathSegment::StringLiteral(0),
+                ]),
+            },
+            content: Arc::from("body-local"),
+        }]
+        .into();
+        input.num_locals = 3;
+        input.num_param_slots = 2;
+        input.param_by_ref = vec![true, false].into();
+        input.param_writable = vec![false, true].into();
+        input.allow_unreachable_code = true;
+        input.warnings = vec![crate::SemanticBodyWarning {
+            kind: rue_error::WarningKind::UnreachableCode,
+            anchor: crate::SemanticBodyAnchor { start: 3, end: 4 },
+            labels: Arc::new([]),
+            notes: Arc::new([]),
+            helps: Arc::new([]),
+            suggestions: Arc::new([]),
+        }]
+        .into();
+        let output = materialize_local(
+            identity.clone(),
+            crate::AnalyzedCallableKind::Ordinary,
+            &input,
+            vec![],
+            vec![local_callable(identity.clone(), "main")],
+        )
+        .unwrap();
+        assert_eq!(output.identity, identity);
+        assert_eq!(output.name, "main");
+        assert_eq!(output.strings, ["body-local"]);
+        assert_eq!(output.air.len(), 3);
+        assert_eq!(output.body_span.file_id, FileId::new(7));
+        assert!(output.completeness.is_complete());
+        assert_eq!(output.interner.get("main"), output.interner.get("main"));
+        assert!(output.interner.get("compiler-intrinsic").is_some());
+        assert_eq!(output.num_locals, 3);
+        assert_eq!(output.num_param_slots, 2);
+        assert_eq!(output.param_modes.by_ref(), [true, false]);
+        assert_eq!(output.param_modes.writable(), [false, true]);
+        assert!(output.allow_unreachable_code);
+        assert_eq!(output.warnings.len(), 1);
+        assert_eq!(output.local_atoms.len(), 1);
+        assert_eq!(output.local_atoms[0].identity.producer, identity);
+        assert_eq!(output.local_atoms[0].dense_id, 0);
+    }
+
+    #[test]
+    fn local_materialization_resolves_specializations_directly() {
+        use crate::SemanticBodyInstData as D;
+        let arguments = crate::CanonicalArguments {
+            types: vec![TypeInstanceKey::I32].into(),
+            values: vec![crate::CanonicalArgumentValue::Integer(7)].into(),
+        };
+        let owner = FunctionInstanceKey::Specialization {
+            base: Box::new(FunctionInstanceKey::Definition("generic")),
+            arguments: arguments.clone(),
+        };
+        let callee = FunctionInstanceKey::Specialization {
+            base: Box::new(FunctionInstanceKey::Definition("callee")),
+            arguments,
+        };
+        let input = body(vec![
+            D::Const(1),
+            D::CallSpecialized {
+                identity: crate::SemanticSpecializationIdentity {
+                    base: "callee",
+                    type_arguments: vec![SemanticImportType::I32].into(),
+                    value_arguments: vec![SemanticImportConstValue::Integer(7)].into(),
+                },
+                args: Arc::new([]),
+            },
+            D::Ret(Some(1)),
+        ]);
+        let output = materialize_local(
+            owner.clone(),
+            crate::AnalyzedCallableKind::Ordinary,
+            &input,
+            vec![],
+            vec![
+                local_callable(owner, "generic::<stable>"),
+                local_callable(callee, "callee::<stable>"),
+            ],
+        )
+        .unwrap();
+        assert!(matches!(
+            output.air.get(crate::AirRef::from_raw(1)).data,
+            crate::AirInstData::Call { .. }
+        ));
+    }
+
+    #[test]
+    fn local_materialization_round_trips_fixed_and_dynamic_builtin_nominals() {
+        use crate::SemanticBodyInstData as D;
+        let identity = FunctionInstanceKey::Definition("main");
+        let arch_key = NominalInstanceKey::Builtin {
+            kind: crate::AnonymousNominalKind::Enum,
+            name: Arc::from("Arch"),
+        };
+        let arch_ty = SemanticImportType::BuiltinNominal {
+            name: Arc::from("Arch"),
+            kind: SemanticImportNominalKind::Enum,
+        };
+        let mut fixed = body(vec![
+            D::EnumVariant {
+                enum_key: arch_key,
+                variant_index: 0,
+                payload: Arc::new([]),
+            },
+            D::Ret(Some(0)),
+        ]);
+        fixed.return_type = arch_ty.clone();
+        let mut instructions = fixed.instructions.to_vec();
+        instructions[0].ty = arch_ty.clone();
+        instructions[1].ty = arch_ty;
+        fixed.instructions = instructions.into();
+        let fixed = materialize_local(
+            identity.clone(),
+            crate::AnalyzedCallableKind::Ordinary,
+            &fixed,
+            vec![],
+            vec![local_callable(identity.clone(), "main")],
+        )
+        .unwrap();
+        assert!(fixed.aggregate_types.values().any(|identity| matches!(
+            identity,
+            TypeInstanceKey::BuiltinNominal { name, kind }
+                if name.as_ref() == "Arch" && *kind == crate::AnonymousNominalKind::Enum
+        )));
+
+        let fixed_string = SemanticImportType::BuiltinNominal {
+            name: Arc::from("Str(8)"),
+            kind: SemanticImportNominalKind::Struct,
+        };
+        let fixed_string_key = NominalInstanceKey::Builtin {
+            kind: crate::AnonymousNominalKind::Struct,
+            name: Arc::from("Str(8)"),
+        };
+        let mut dynamic = body(vec![D::PlaceRead { place: 0 }, D::Ret(Some(0))]);
+        dynamic.return_type = SemanticImportType::U64;
+        dynamic.num_locals = 1;
+        dynamic.instructions = vec![
+            crate::SemanticBodyInst {
+                data: D::PlaceRead { place: 0 },
+                ty: SemanticImportType::U64,
+                anchor: crate::SemanticBodyAnchor { start: 1, end: 2 },
+            },
+            crate::SemanticBodyInst {
+                data: D::Ret(Some(0)),
+                ty: SemanticImportType::U64,
+                anchor: crate::SemanticBodyAnchor { start: 2, end: 3 },
+            },
+        ]
+        .into();
+        dynamic.places = vec![crate::SemanticBodyPlace {
+            base: crate::AirPlaceBase::Local(0),
+            base_type: fixed_string,
+            projections: vec![crate::SemanticBodyProjection::Field {
+                struct_key: fixed_string_key,
+                field_index: 1,
+            }]
+            .into(),
+        }]
+        .into();
+        let dynamic = materialize_local(
+            identity.clone(),
+            crate::AnalyzedCallableKind::Ordinary,
+            &dynamic,
+            vec![],
+            vec![local_callable(identity, "main")],
+        )
+        .unwrap();
+        assert!(dynamic.aggregate_types.values().any(|identity| matches!(
+            identity,
+            TypeInstanceKey::BuiltinNominal { name, kind }
+                if name.as_ref() == "Str(8)" && *kind == crate::AnonymousNominalKind::Struct
+        )));
+    }
+
+    #[test]
+    fn local_epoch_rejects_fixed_builtin_nominal_facts() {
+        let error = Epoch::new_local(
+            vec![SemanticLocalNominal {
+                key: NominalInstanceKey::Builtin {
+                    kind: crate::AnonymousNominalKind::Enum,
+                    name: Arc::from("Arch"),
+                },
+                module_path: Arc::from("<builtin>"),
+                name: Arc::from("Arch"),
+                kind: SemanticImportNominalKind::Enum,
+                is_public: true,
+                lang_item: None,
+                shape: SemanticLocalNominalShape::Enum {
+                    variants: Arc::new([]),
+                },
+            }],
+            vec![],
+            vec![],
+        )
+        .err();
+        assert_eq!(error, Some(SemanticImportFailure::BuiltinNominalShadow));
+    }
+
+    #[test]
+    fn local_epoch_rejects_dynamic_string_builtin_nominal_facts() {
+        let error = Epoch::new_local(
+            vec![SemanticLocalNominal {
+                key: NominalInstanceKey::Builtin {
+                    kind: crate::AnonymousNominalKind::Struct,
+                    name: Arc::from("Str(8)"),
+                },
+                module_path: Arc::from("<builtin>"),
+                name: Arc::from("Str(8)"),
+                kind: SemanticImportNominalKind::Struct,
+                is_public: true,
+                lang_item: None,
+                shape: SemanticLocalNominalShape::Struct {
+                    fields: Arc::new([]),
+                    is_copy: true,
+                    is_linear: false,
+                    destructor: None,
+                },
+            }],
+            vec![],
+            vec![],
+        )
+        .err();
+        assert_eq!(error, Some(SemanticImportFailure::BuiltinNominalShadow));
+    }
+
+    fn anonymous_key() -> crate::AnonymousNominalKey<&'static str, &'static str> {
+        crate::AnonymousNominalKey {
+            kind: crate::AnonymousNominalKind::Struct,
+            producer: crate::StableProducerId::Definition("producer"),
+            anchor: rue_rir::RirStructuralAnchor::new(vec![
+                rue_rir::RirStructuralPathSegment::Body,
+                rue_rir::RirStructuralPathSegment::AnonymousType(0),
+            ]),
+            arguments: crate::CanonicalArguments::default(),
+        }
+    }
+
+    #[test]
+    fn local_materialization_joins_anonymous_nominal_and_member_identity() {
+        use crate::SemanticBodyInstData as D;
+        let anonymous = anonymous_key();
+        let owner_type = TypeInstanceKey::Nominal(NominalInstanceKey::Anonymous(anonymous.clone()));
+        let identity = FunctionInstanceKey::AnonymousMember {
+            owner: Box::new(owner_type.clone()),
+            member: crate::AnonymousMemberKey {
+                kind: crate::AnonymousMemberKind::Method,
+                name: Arc::from("value"),
+            },
+        };
+        let nominal = SemanticLocalNominal {
+            key: NominalInstanceKey::Anonymous(anonymous.clone()),
+            module_path: Arc::from("main"),
+            name: Arc::from("anonymous-record"),
+            kind: SemanticImportNominalKind::Struct,
+            is_public: false,
+            lang_item: None,
+            shape: SemanticLocalNominalShape::Struct {
+                fields: Arc::new([]),
+                is_copy: false,
+                is_linear: false,
+                destructor: None,
+            },
+        };
+        let mut input = body(vec![D::UnitConst, D::Ret(None)]);
+        input.return_type = SemanticImportType::Unit;
+        input.instructions = vec![
+            crate::SemanticBodyInst {
+                data: D::UnitConst,
+                ty: SemanticImportType::Unit,
+                anchor: crate::SemanticBodyAnchor { start: 1, end: 2 },
+            },
+            crate::SemanticBodyInst {
+                data: D::Ret(None),
+                ty: SemanticImportType::Unit,
+                anchor: crate::SemanticBodyAnchor { start: 2, end: 3 },
+            },
+        ]
+        .into();
+        let output = materialize_local(
+            identity.clone(),
+            crate::AnalyzedCallableKind::Ordinary,
+            &input,
+            vec![nominal],
+            vec![local_callable(identity, "anonymous-record.value")],
+        )
+        .unwrap();
+        assert!(output.aggregate_types.values().any(|ty| ty == &owner_type));
+    }
+
+    #[test]
+    fn local_materialization_preserves_named_destructor_kind() {
+        use crate::SemanticBodyInstData as D;
+        let identity = FunctionInstanceKey::Definition("record-drop");
+        let mut input = body(vec![D::UnitConst, D::Ret(None)]);
+        input.return_type = SemanticImportType::Unit;
+        input.instructions = vec![
+            crate::SemanticBodyInst {
+                data: D::UnitConst,
+                ty: SemanticImportType::Unit,
+                anchor: crate::SemanticBodyAnchor { start: 1, end: 2 },
+            },
+            crate::SemanticBodyInst {
+                data: D::Ret(None),
+                ty: SemanticImportType::Unit,
+                anchor: crate::SemanticBodyAnchor { start: 2, end: 3 },
+            },
+        ]
+        .into();
+        let output = materialize_local(
+            identity.clone(),
+            crate::AnalyzedCallableKind::Destructor,
+            &input,
+            vec![SemanticLocalNominal {
+                key: NominalInstanceKey::Named("record"),
+                module_path: Arc::from("main"),
+                name: Arc::from("Record"),
+                kind: SemanticImportNominalKind::Struct,
+                is_public: false,
+                lang_item: None,
+                shape: SemanticLocalNominalShape::Struct {
+                    fields: Arc::new([]),
+                    is_copy: false,
+                    is_linear: false,
+                    destructor: Some(identity.clone()),
+                },
+            }],
+            vec![local_callable(identity, "Record.__drop")],
+        )
+        .unwrap();
+        assert_eq!(
+            output.callable_kind,
+            crate::AnalyzedCallableKind::Destructor
+        );
+        let record = output
+            .aggregate_types
+            .iter()
+            .find_map(|(ty, stable)| {
+                (stable == &TypeInstanceKey::Nominal(NominalInstanceKey::Named("record")))
+                    .then_some(*ty)
+            })
+            .unwrap();
+        assert_eq!(
+            output
+                .type_pool
+                .struct_def(record.as_struct().unwrap())
+                .destructor
+                .as_deref(),
+            Some("Record.__drop")
+        );
+    }
+
+    #[test]
+    fn local_materialization_fails_closed_for_missing_exact_facts() {
+        use crate::SemanticBodyInstData as D;
+        let identity = FunctionInstanceKey::Definition("main");
+        let input = body(vec![D::Call {
+            function: FunctionInstanceKey::Definition("missing"),
+            args: Arc::new([]),
+        }]);
+        let error = materialize_local(
+            identity.clone(),
+            crate::AnalyzedCallableKind::Ordinary,
+            &input,
+            vec![],
+            vec![local_callable(identity, "main")],
+        )
+        .err()
+        .expect("missing callable fact must fail");
+        assert_eq!(
+            error.kind(),
+            crate::SemanticBodyImportFailureKind::Semantic(SemanticImportFailure::MissingFunction)
+        );
+    }
+
+    #[test]
+    fn local_materialization_rejects_ambiguous_and_incomplete_fact_sets() {
+        let identity = FunctionInstanceKey::Definition("main");
+        assert_eq!(
+            Epoch::new_local(
+                vec![],
+                vec![
+                    local_callable(identity.clone(), "main-a"),
+                    local_callable(identity.clone(), "main-b"),
+                ],
+                vec!["main"],
+            )
+            .err(),
+            Some(SemanticImportFailure::DuplicateCallable)
+        );
+        assert_eq!(
+            Epoch::new_local(
+                vec![],
+                vec![
+                    local_callable(identity.clone(), "main"),
+                    local_callable(FunctionInstanceKey::Definition("other"), "main"),
+                ],
+                vec!["main"],
+            )
+            .err(),
+            Some(SemanticImportFailure::DuplicateCallableLocalIdentity)
+        );
+        assert_eq!(
+            Epoch::new_local(
+                vec![],
+                vec![local_callable(identity.clone(), "main")],
+                vec!["main", "main"],
+            )
+            .err(),
+            Some(SemanticImportFailure::DuplicateModule)
+        );
+
+        let mut epoch = Epoch::new_local(
+            vec![],
+            vec![local_callable(identity.clone(), "main")],
+            vec!["main"],
+        )
+        .unwrap();
+        epoch
+            .local_completeness
+            .as_mut()
+            .expect("local epoch carries its own witness")
+            .nominals_declared += 1;
+        let error = epoch
+            .materialize_local_body(
+                identity,
+                crate::AnalyzedCallableKind::Ordinary,
+                &body(vec![crate::SemanticBodyInstData::Const(0)]),
+                Span::with_file(FileId::new(7), 100, 200),
+            )
+            .err()
+            .expect("incomplete witness must fail");
+        assert_eq!(
+            error.kind(),
+            crate::SemanticBodyImportFailureKind::Semantic(
+                SemanticImportFailure::IncompleteMaterialization
+            )
+        );
+
+        for corrupt in [
+            |witness: &mut SemanticLocalCompleteness| witness.callables_registered += 1,
+            |witness: &mut SemanticLocalCompleteness| witness.modules_registered += 1,
+        ] {
+            let mut epoch = Epoch::new_local(
+                vec![],
+                vec![local_callable(
+                    FunctionInstanceKey::Definition("main"),
+                    "main",
+                )],
+                vec!["main"],
+            )
+            .unwrap();
+            corrupt(
+                epoch
+                    .local_completeness
+                    .as_mut()
+                    .expect("local epoch carries its own witness"),
+            );
+            let error = epoch
+                .materialize_local_body(
+                    FunctionInstanceKey::Definition("main"),
+                    crate::AnalyzedCallableKind::Ordinary,
+                    &body(vec![crate::SemanticBodyInstData::Const(0)]),
+                    Span::with_file(FileId::new(7), 100, 200),
+                )
+                .err()
+                .expect("corrupt internal count must fail");
+            assert_eq!(
+                error.kind(),
+                crate::SemanticBodyImportFailureKind::Semantic(
+                    SemanticImportFailure::IncompleteMaterialization
+                )
+            );
+        }
+    }
+
+    #[test]
+    fn local_materialization_is_independent_of_exact_fact_input_order() {
+        use crate::SemanticBodyInstData as D;
+        let identity = FunctionInstanceKey::Definition("main");
+        let input = body(vec![D::Const(7), D::Ret(Some(0))]);
+        let facts = vec![
+            SemanticLocalNominal {
+                key: NominalInstanceKey::Named("z"),
+                module_path: Arc::from("main"),
+                name: Arc::from("Z"),
+                kind: SemanticImportNominalKind::Struct,
+                is_public: false,
+                lang_item: None,
+                shape: SemanticLocalNominalShape::Struct {
+                    fields: Arc::new([]),
+                    is_copy: false,
+                    is_linear: false,
+                    destructor: None,
+                },
+            },
+            SemanticLocalNominal {
+                key: NominalInstanceKey::Named("a"),
+                module_path: Arc::from("main"),
+                name: Arc::from("A"),
+                kind: SemanticImportNominalKind::Enum,
+                is_public: false,
+                lang_item: None,
+                shape: SemanticLocalNominalShape::Enum {
+                    variants: Arc::new([]),
+                },
+            },
+        ];
+        let forward = materialize_local(
+            identity.clone(),
+            crate::AnalyzedCallableKind::Ordinary,
+            &input,
+            facts.clone(),
+            vec![local_callable(identity.clone(), "main")],
+        )
+        .unwrap();
+        let reverse = materialize_local(
+            identity,
+            crate::AnalyzedCallableKind::Ordinary,
+            &input,
+            facts.into_iter().rev().collect(),
+            vec![local_callable(
+                FunctionInstanceKey::Definition("main"),
+                "main",
+            )],
+        )
+        .unwrap();
+        assert_eq!(format!("{:?}", forward.air), format!("{:?}", reverse.air));
+        assert_eq!(forward.aggregate_types, reverse.aggregate_types);
+        assert_eq!(
+            forward.type_pool.all_types().collect::<Vec<_>>(),
+            reverse.type_pool.all_types().collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn local_materialization_matches_the_exact_body_import_boundary() {
+        use crate::SemanticBodyInstData as D;
+        let input = body(vec![
+            D::Const(4),
+            D::Const(5),
+            D::Add(0, 1),
+            D::Ret(Some(2)),
+        ]);
+        let span = Span::with_file(FileId::new(7), 100, 200);
+        let imported = Epoch::new(vec![], vec![("main", Arc::from("main"))], vec!["main"])
+            .unwrap()
+            .import_body(&input, span)
+            .unwrap();
+        let local = materialize_local(
+            FunctionInstanceKey::Definition("main"),
+            crate::AnalyzedCallableKind::Ordinary,
+            &input,
+            vec![],
+            vec![local_callable(
+                FunctionInstanceKey::Definition("main"),
+                "main",
+            )],
+        )
+        .unwrap();
+        assert_eq!(format!("{:?}", local.air), format!("{:?}", imported.air));
+        assert_eq!(local.strings, imported.strings);
+        assert_eq!(local.local_atoms, imported.local_atoms);
+        assert_eq!(local.param_modes, imported.param_modes);
+        assert_eq!(local.warnings, imported.warnings);
     }
 
     #[test]

--- a/crates/rue-compiler/src/api_inventory.rs
+++ b/crates/rue-compiler/src/api_inventory.rs
@@ -40,6 +40,10 @@ const PRODUCTION_MODULES: &[(&str, &str)] = &[
     ("import_discovery", include_str!("import_discovery.rs")),
     ("import_graph", include_str!("import_graph.rs")),
     ("linking", include_str!("linking.rs")),
+    (
+        "local_semantic_materialization",
+        include_str!("local_semantic_materialization.rs"),
+    ),
     ("parsed_modules", include_str!("parsed_modules.rs")),
     ("program_image_plan", include_str!("program_image_plan.rs")),
     ("queries", include_str!("queries.rs")),
@@ -68,6 +72,44 @@ const PRODUCTION_MODULES: &[(&str, &str)] = &[
     ("unstable", include_str!("unstable.rs")),
     ("well_known_option", include_str!("well_known_option.rs")),
 ];
+
+#[test]
+fn local_semantic_materialization_is_an_inert_exact_fact_boundary() {
+    let local = include_str!("local_semantic_materialization.rs");
+
+    for required in [
+        "canonical: &crate::body_query::CanonicalBody",
+        "declarations: &[DurableDeclarationSemantic]",
+        "anonymous_nominals: &[DurableAnonymousNominal]",
+        "callable_facts: &[LocalCallableFact]",
+        "nominal_metadata: &[LocalNominalMetadataFact]",
+        "pub(crate) fn new(",
+        "pub(crate) fn identity(&self) -> &StableDefinitionKey",
+        "pub(crate) fn lang_item(&self) -> Option<rue_air::LangItem>",
+        "rue_air::SemanticImportEpoch::new_local(",
+        ".materialize_local_body(",
+        "FunctionInstanceKey::AnonymousMember",
+    ] {
+        assert!(
+            local.contains(required),
+            "local semantic boundary lost exact input or identity support: {required}"
+        );
+    }
+    for forbidden in [
+        "CanonicalSemanticOutput",
+        "CanonicalMergedProgram",
+        "SemaOutput",
+        "QueryFamily<",
+        "Mutex<",
+        "RwLock<",
+        "cache:",
+    ] {
+        assert!(
+            !local.contains(forbidden),
+            "local semantic boundary gained a peer authority or cache: {forbidden}"
+        );
+    }
+}
 
 const RUE_868_RAW_FACADE_VOCABULARY: &[&str] = &[
     "Lexer",

--- a/crates/rue-compiler/src/lib.rs
+++ b/crates/rue-compiler/src/lib.rs
@@ -54,6 +54,7 @@ mod durable_semantics;
 mod import_discovery;
 mod import_graph;
 mod linking;
+mod local_semantic_materialization;
 mod parsed_modules;
 mod program_image_plan;
 mod queries;

--- a/crates/rue-compiler/src/local_semantic_materialization.rs
+++ b/crates/rue-compiler/src/local_semantic_materialization.rs
@@ -1,0 +1,427 @@
+//! Canonical body to body-local AIR materialization.
+//!
+//! This adapter joins one query-owned body with exact declaration, anonymous
+//! nominal, nominal-metadata, callable-symbol, and module facts. It deliberately
+//! owns no state: the returned AIR carries its issuing pool/interner and the
+//! temporary import epoch is consumed by the request. Target and preview
+//! configuration are absent because relocation of already-analyzed AIR is
+//! configuration-neutral; they remain part of the downstream CFG query key.
+
+use std::sync::Arc;
+
+use crate::durable_semantics::{
+    DurableAnonymousNominal, DurableAnonymousNominalShape, DurableDeclarationPayload,
+    DurableDeclarationSemantic,
+};
+use crate::{FunctionInstanceKey, ModuleId, StableDefinitionKey, StableDefinitionKind};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[allow(dead_code)] // RUE-1215 installs this exact input at the CFG boundary.
+pub(crate) struct LocalCallableFact {
+    pub(crate) identity: FunctionInstanceKey,
+    pub(crate) symbol: Arc<str>,
+}
+
+/// Exact classification projected from the selected nominal's query-owned
+/// lookup/index fact. `None` is meaningful: every supplied named nominal has a
+/// record, so omission cannot silently strip compiler-recognized metadata.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[allow(dead_code)] // RUE-1215 installs this exact input at the CFG boundary.
+pub(crate) struct LocalNominalMetadataFact {
+    identity: StableDefinitionKey,
+    lang_item: Option<rue_air::LangItem>,
+}
+
+#[allow(dead_code)] // RUE-1215 supplies these facts from the CFG request.
+impl LocalNominalMetadataFact {
+    pub(crate) fn new(identity: StableDefinitionKey, lang_item: Option<rue_air::LangItem>) -> Self {
+        Self {
+            identity,
+            lang_item,
+        }
+    }
+
+    pub(crate) fn identity(&self) -> &StableDefinitionKey {
+        &self.identity
+    }
+
+    pub(crate) fn lang_item(&self) -> Option<rue_air::LangItem> {
+        self.lang_item
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[allow(dead_code)] // RUE-1215 installs this exact failure at the CFG boundary.
+pub(crate) enum LocalMaterializationFailure {
+    InvalidSpecializationIdentity,
+    DuplicateNominalMetadata,
+    MissingNominalMetadata,
+    ExtraNominalMetadata,
+    AmbiguousNamedDestructor,
+    Import(rue_air::SemanticImportFailure),
+    Body(rue_air::SemanticBodyImportFailure),
+}
+
+impl From<rue_air::SemanticImportFailure> for LocalMaterializationFailure {
+    fn from(value: rue_air::SemanticImportFailure) -> Self {
+        Self::Import(value)
+    }
+}
+
+impl From<rue_air::SemanticBodyImportFailure> for LocalMaterializationFailure {
+    fn from(value: rue_air::SemanticBodyImportFailure) -> Self {
+        Self::Body(value)
+    }
+}
+
+#[allow(dead_code)] // RUE-1215 installs this exact result at the CFG boundary.
+pub(crate) type LocalSemanticMaterialization =
+    rue_air::SemanticLocalMaterialization<StableDefinitionKey, ModuleId>;
+
+/// Materialize one canonical body from exact query facts.
+///
+/// The declaration and anonymous slices may contain only the facts required by
+/// this body. Missing transitive shapes/callables fail closed in `rue-air`;
+/// this adapter never widens the request by discovering a program universe.
+#[allow(dead_code)] // RUE-1215 installs this as the canonical CFG producer.
+pub(crate) fn materialize_canonical_body(
+    canonical: &crate::body_query::CanonicalBody,
+    body_span: rue_span::Span,
+    declarations: &[DurableDeclarationSemantic],
+    anonymous_nominals: &[DurableAnonymousNominal],
+    callable_facts: &[LocalCallableFact],
+    nominal_metadata: &[LocalNominalMetadataFact],
+    modules: &[ModuleId],
+) -> Result<LocalSemanticMaterialization, LocalMaterializationFailure> {
+    let (identity, body) = match canonical {
+        crate::body_query::CanonicalBody::Ordinary { owner, body } => {
+            (FunctionInstanceKey::Definition(owner.clone()), body)
+        }
+        crate::body_query::CanonicalBody::Anonymous { identity, body, .. } => {
+            (identity.clone(), body)
+        }
+        crate::body_query::CanonicalBody::Specialization { identity, body, .. } => (
+            crate::semantic_identity::function_instance_from_specialization(identity)
+                .ok_or(LocalMaterializationFailure::InvalidSpecializationIdentity)?,
+            body,
+        ),
+    };
+    let callable_kind = match &identity {
+        FunctionInstanceKey::Definition(key) if key.kind() == StableDefinitionKind::Destructor => {
+            rue_air::AnalyzedCallableKind::Destructor
+        }
+        FunctionInstanceKey::DropGlue(_) => rue_air::AnalyzedCallableKind::DropGlue,
+        _ => rue_air::AnalyzedCallableKind::Ordinary,
+    };
+
+    let mut destructors = std::collections::BTreeMap::new();
+    for candidate in declarations {
+        if !matches!(candidate.payload, DurableDeclarationPayload::Destructor) {
+            continue;
+        }
+        let Some(owner) = candidate.key.owner() else {
+            continue;
+        };
+        let owner = (
+            owner.module().clone(),
+            owner.kind(),
+            Arc::<str>::from(owner.name()),
+        );
+        if destructors
+            .insert(
+                owner,
+                FunctionInstanceKey::Definition(candidate.key.clone()),
+            )
+            .is_some()
+        {
+            return Err(LocalMaterializationFailure::AmbiguousNamedDestructor);
+        }
+    }
+    let destructor_for = |owner: &StableDefinitionKey| {
+        destructors
+            .get(&(
+                owner.module().clone(),
+                owner.kind(),
+                Arc::<str>::from(owner.name()),
+            ))
+            .cloned()
+    };
+    let mut metadata = std::collections::BTreeMap::new();
+    for fact in nominal_metadata {
+        if metadata
+            .insert(fact.identity().clone(), fact.lang_item())
+            .is_some()
+        {
+            return Err(LocalMaterializationFailure::DuplicateNominalMetadata);
+        }
+    }
+    let mut nominals = Vec::new();
+    for declaration in declarations {
+        let (kind, shape) = match &declaration.payload {
+            DurableDeclarationPayload::Struct {
+                fields,
+                is_copy,
+                is_linear,
+            } => (
+                rue_air::SemanticImportNominalKind::Struct,
+                rue_air::SemanticLocalNominalShape::Struct {
+                    fields: fields.clone(),
+                    is_copy: *is_copy,
+                    is_linear: *is_linear,
+                    destructor: destructor_for(&declaration.key),
+                },
+            ),
+            DurableDeclarationPayload::Enum { variants } => (
+                rue_air::SemanticImportNominalKind::Enum,
+                rue_air::SemanticLocalNominalShape::Enum {
+                    variants: variants.clone(),
+                },
+            ),
+            _ => continue,
+        };
+        let lang_item = metadata
+            .remove(&declaration.key)
+            .ok_or(LocalMaterializationFailure::MissingNominalMetadata)?;
+        nominals.push(rue_air::SemanticLocalNominal {
+            key: rue_air::NominalInstanceKey::Named(declaration.key.clone()),
+            module_path: Arc::from(declaration.key.module().as_str()),
+            name: Arc::from(declaration.key.name()),
+            kind,
+            is_public: declaration.is_public,
+            lang_item,
+            shape,
+        });
+    }
+    if !metadata.is_empty() {
+        return Err(LocalMaterializationFailure::ExtraNominalMetadata);
+    }
+    nominals.extend(anonymous_nominals.iter().map(|nominal| {
+        let (kind, shape) = match &nominal.shape {
+            DurableAnonymousNominalShape::Struct { fields, methods } => {
+                let destructor = methods
+                    .iter()
+                    .find(|method| method.has_self && method.name.as_ref() == "__drop")
+                    .map(|_| FunctionInstanceKey::AnonymousMember {
+                        owner: Box::new(crate::TypeInstanceKey::Nominal(
+                            crate::NominalInstanceKey::Anonymous(nominal.identity.clone()),
+                        )),
+                        member: crate::AnonymousMemberKey {
+                            kind: crate::AnonymousMemberKind::Destructor,
+                            name: Arc::from("__drop"),
+                        },
+                    });
+                (
+                    rue_air::SemanticImportNominalKind::Struct,
+                    rue_air::SemanticLocalNominalShape::Struct {
+                        fields: fields.clone(),
+                        // Anonymous structs have no `copy` or `linear`
+                        // declaration modifiers. Transitive ownership facts are
+                        // derived by the completed local type pool.
+                        is_copy: false,
+                        is_linear: false,
+                        destructor,
+                    },
+                )
+            }
+            DurableAnonymousNominalShape::Enum { variants } => (
+                rue_air::SemanticImportNominalKind::Enum,
+                rue_air::SemanticLocalNominalShape::Enum {
+                    variants: variants.clone(),
+                },
+            ),
+        };
+        rue_air::SemanticLocalNominal {
+            key: rue_air::NominalInstanceKey::Anonymous(nominal.identity.clone()),
+            module_path: Arc::from("<anonymous>"),
+            name: Arc::from(format!("anonymous-{:?}", nominal.identity)),
+            kind,
+            is_public: false,
+            lang_item: None,
+            shape,
+        }
+    }));
+    let callables = callable_facts
+        .iter()
+        .map(|fact| rue_air::SemanticLocalCallable {
+            key: fact.identity.clone(),
+            symbol: fact.symbol.clone(),
+        })
+        .collect();
+    let epoch = rue_air::SemanticImportEpoch::new_local(nominals, callables, modules.to_vec())?;
+    Ok(epoch.materialize_local_body(identity, callable_kind, body, body_span)?)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn body() -> rue_air::SemanticBody<StableDefinitionKey, ModuleId> {
+        use rue_air::{SemanticBody, SemanticBodyAnchor, SemanticBodyInst, SemanticBodyInstData};
+        SemanticBody {
+            return_type: rue_air::SemanticImportType::I32,
+            instructions: vec![
+                SemanticBodyInst {
+                    data: SemanticBodyInstData::Const(7),
+                    ty: rue_air::SemanticImportType::I32,
+                    anchor: SemanticBodyAnchor { start: 1, end: 2 },
+                },
+                SemanticBodyInst {
+                    data: SemanticBodyInstData::Ret(Some(0)),
+                    ty: rue_air::SemanticImportType::I32,
+                    anchor: SemanticBodyAnchor { start: 2, end: 3 },
+                },
+            ]
+            .into(),
+            places: Arc::new([]),
+            strings: Arc::new([]),
+            local_atoms: Arc::new([]),
+            param_drops: Arc::new([]),
+            borrow_slots: Arc::new([]),
+            num_locals: 0,
+            num_param_slots: 0,
+            param_by_ref: Arc::new([]),
+            param_writable: Arc::new([]),
+            allow_unreachable_code: false,
+            warnings: Arc::new([]),
+            method_references: Arc::new([]),
+        }
+    }
+
+    fn definition(
+        module: ModuleId,
+        kind: StableDefinitionKind,
+        name: &str,
+        owner: Option<(StableDefinitionKind, Arc<str>)>,
+    ) -> StableDefinitionKey {
+        StableDefinitionKey::for_test(module, kind.namespace(), kind, name, owner)
+    }
+
+    #[test]
+    fn exact_metadata_restores_strbuf_language_item() {
+        let module = ModuleId::from_trusted_validated_canonical("\0rue-std/strbuf.rue");
+        let function = definition(
+            module.clone(),
+            StableDefinitionKind::Function,
+            "probe",
+            None,
+        );
+        let strbuf = definition(module.clone(), StableDefinitionKind::Struct, "StrBuf", None);
+        let canonical = crate::body_query::CanonicalBody::Ordinary {
+            owner: function.clone(),
+            body: body(),
+        };
+        let declaration = DurableDeclarationSemantic {
+            key: strbuf.clone(),
+            is_public: true,
+            payload: DurableDeclarationPayload::Struct {
+                fields: Arc::new([]),
+                is_copy: false,
+                is_linear: false,
+            },
+        };
+        assert_eq!(
+            materialize_canonical_body(
+                &canonical,
+                rue_span::Span::with_file(rue_span::FileId::new(3), 100, 200),
+                std::slice::from_ref(&declaration),
+                &[],
+                &[LocalCallableFact {
+                    identity: FunctionInstanceKey::Definition(function.clone()),
+                    symbol: Arc::from("probe"),
+                }],
+                &[],
+                std::slice::from_ref(&module),
+            )
+            .err(),
+            Some(LocalMaterializationFailure::MissingNominalMetadata)
+        );
+        let output = materialize_canonical_body(
+            &canonical,
+            rue_span::Span::with_file(rue_span::FileId::new(3), 100, 200),
+            std::slice::from_ref(&declaration),
+            &[],
+            &[LocalCallableFact {
+                identity: FunctionInstanceKey::Definition(function),
+                symbol: Arc::from("probe"),
+            }],
+            &[LocalNominalMetadataFact::new(
+                strbuf.clone(),
+                Some(rue_air::LangItem::StrBuf),
+            )],
+            std::slice::from_ref(&module),
+        )
+        .unwrap();
+        let ty = output
+            .aggregate_types
+            .iter()
+            .find_map(|(ty, identity)| {
+                (identity
+                    == &crate::TypeInstanceKey::Nominal(crate::NominalInstanceKey::Named(
+                        strbuf.clone(),
+                    )))
+                    .then_some(*ty)
+            })
+            .expect("StrBuf stable identity is retained");
+        assert_eq!(
+            output.type_pool.struct_lang_item(ty.as_struct().unwrap()),
+            Some(rue_air::LangItem::StrBuf)
+        );
+    }
+
+    #[test]
+    fn duplicate_named_destructor_facts_are_ambiguous() {
+        let module = ModuleId::from_validated_canonical("main.rue");
+        let function = definition(
+            module.clone(),
+            StableDefinitionKind::Function,
+            "probe",
+            None,
+        );
+        let record = definition(module.clone(), StableDefinitionKind::Struct, "Record", None);
+        let destructor = definition(
+            module.clone(),
+            StableDefinitionKind::Destructor,
+            "Record",
+            Some((StableDefinitionKind::Struct, Arc::from("Record"))),
+        );
+        let declarations = vec![
+            DurableDeclarationSemantic {
+                key: record.clone(),
+                is_public: false,
+                payload: DurableDeclarationPayload::Struct {
+                    fields: Arc::new([]),
+                    is_copy: false,
+                    is_linear: false,
+                },
+            },
+            DurableDeclarationSemantic {
+                key: destructor.clone(),
+                is_public: false,
+                payload: DurableDeclarationPayload::Destructor,
+            },
+            DurableDeclarationSemantic {
+                key: destructor,
+                is_public: false,
+                payload: DurableDeclarationPayload::Destructor,
+            },
+        ];
+        let error = materialize_canonical_body(
+            &crate::body_query::CanonicalBody::Ordinary {
+                owner: function.clone(),
+                body: body(),
+            },
+            rue_span::Span::with_file(rue_span::FileId::new(3), 100, 200),
+            &declarations,
+            &[],
+            &[LocalCallableFact {
+                identity: FunctionInstanceKey::Definition(function),
+                symbol: Arc::from("probe"),
+            }],
+            &[LocalNominalMetadataFact::new(record, None)],
+            &[module],
+        )
+        .err()
+        .expect("duplicate destructor records must not select the first");
+        assert_eq!(error, LocalMaterializationFailure::AmbiguousNamedDestructor);
+    }
+}

--- a/crates/rue-compiler/src/revisioned_query_database.rs
+++ b/crates/rue-compiler/src/revisioned_query_database.rs
@@ -32741,6 +32741,217 @@ fn main() -> i32 {
     }
 
     #[test]
+    fn retained_provider_specialization_materializes_with_live_air_parity() {
+        let snapshot = source_snapshot(
+            &[(
+                1,
+                "/m.rue",
+                "m.rue",
+                "fn selected(comptime N: i32, value: i32) -> i32 { value + N }\n\
+                 fn main() -> i32 { selected(7, 5) }\n",
+            )],
+            1,
+        );
+        let module = ModuleId::from_logical_path("m.rue").unwrap();
+        let base_instance = free_function_instance(&module, "selected");
+        let crate::FunctionInstanceKey::Definition(base) = base_instance else {
+            unreachable!("free function helper returns a definition")
+        };
+        let arguments = crate::CanonicalArguments {
+            types: Arc::from([]),
+            values: Arc::from([crate::CanonicalArgumentValue::Integer(7)]),
+        };
+        let instance = crate::FunctionInstanceKey::Specialization {
+            base: Box::new(crate::FunctionInstanceKey::Definition(base.clone())),
+            arguments: arguments.clone(),
+        };
+        let configuration = semantic_configuration();
+        let key = crate::body_query::BodyQueryKey {
+            instance: instance.clone(),
+            configuration: configuration.clone(),
+        };
+        let mut database = RevisionedQueryDatabase::default();
+        let revision = revision_for(&mut database, &snapshot);
+        let input = database
+            .body_input(revision, key, CancellationToken::new())
+            .expect("specialized body input request completes");
+        let rue_query::QueryOutcome::Success(crate::body_query::BodyInputValue::Available(input)) =
+            input.outcome()
+        else {
+            panic!("specialized body input is available: {input:?}")
+        };
+        let input = input.clone();
+        let lowering = lower_owned_body_input(&input).expect("owned specialized body lowers");
+        assert!(lowering.is_valid());
+        let preview = configuration
+            .preview_features
+            .names()
+            .iter()
+            .filter_map(|name| name.parse().ok())
+            .collect();
+        let owner_source = rue_air::DurableBodySourceLocator {
+            file_id: input.source.file_id,
+            physical_path: input.source.physical_path.clone(),
+            source_length: input.source.source_length,
+        };
+        let probe_base = base.clone();
+        let probe_arguments = arguments.clone();
+        let probe_module = module.clone();
+        let target = configuration.target;
+        let outcome = database.probe_ready_body_facts(
+            revision,
+            configuration,
+            "retained-specialization-local-materialization",
+            move |provider| {
+                let source = CompilerBodyDurableSource::with_anonymous(
+                    provider,
+                    &[],
+                    Some((probe_module, owner_source)),
+                );
+                rue_air::analyze_provider_specialized_body(
+                    provider,
+                    source,
+                    &lowering.bundle,
+                    probe_base.clone(),
+                    probe_base.name(),
+                    &probe_arguments,
+                    target,
+                    preview,
+                    &rue_air::ProviderWellKnownOptionFacts {
+                        nominals: Vec::new(),
+                        option_by_payload: Vec::new(),
+                    },
+                )
+            },
+        );
+        let analyzed = outcome
+            .result
+            .expect("real provider specialization analysis succeeds");
+
+        // Capture the retained live semantic result before relocating its
+        // durable export. These fields are deliberately the provider result's
+        // issuing AIR, pool, interner, strings, and warnings — not a second
+        // materialization wrapper.
+        let live_name = analyzed.function.name.clone();
+        let live_air = format!("{:?}", analyzed.function.air);
+        let live_callable_kind = analyzed.function.callable_kind;
+        let live_num_locals = analyzed.function.num_locals;
+        let live_num_param_slots = analyzed.function.num_param_slots;
+        let live_param_modes = analyzed.function.param_modes.clone();
+        let live_allow_unreachable_code = analyzed.function.allow_unreachable_code;
+        let live_body_start = analyzed
+            .function
+            .air
+            .iter()
+            .map(|(_, instruction)| instruction.span.start)
+            .min()
+            .expect("specialized AIR is non-empty");
+        let live_body_end = analyzed
+            .function
+            .air
+            .iter()
+            .map(|(_, instruction)| instruction.span.end)
+            .max()
+            .expect("specialized AIR is non-empty");
+        let live_pool_len = analyzed.type_pool.len();
+        let live_source_symbol = analyzed
+            .interner
+            .get("value")
+            .expect("retained provider interner owns analyzed source symbols");
+        assert_eq!(analyzed.interner.resolve(&live_source_symbol), "value");
+        let live_strings = analyzed.strings.clone();
+        let live_warnings = format!("{:?}", analyzed.warnings);
+
+        let definition_tokens = analyzed
+            .definition_tokens
+            .into_iter()
+            .collect::<HashMap<_, _>>();
+        let module_tokens = analyzed
+            .module_tokens
+            .into_iter()
+            .collect::<HashMap<_, _>>();
+        let definition = |token: &rue_air::SemanticDefinitionToken| {
+            definition_tokens
+                .get(token)
+                .cloned()
+                .ok_or(rue_air::SemanticStableResolutionFailure::Missing)
+        };
+        let relocate_module = |token: &rue_air::SemanticModuleToken| {
+            module_tokens
+                .get(token)
+                .cloned()
+                .ok_or(rue_air::SemanticStableResolutionFailure::Missing)
+        };
+        let live_identity = analyzed
+            .function
+            .identity
+            .try_map_identities(&definition, &relocate_module)
+            .expect("retained function identity relocates");
+        let identity = analyzed
+            .export
+            .identity
+            .try_map_keys(&definition, &relocate_module)
+            .expect("specialization identity relocates");
+        let body = analyzed
+            .export
+            .body
+            .try_map_keys(&definition, &relocate_module)
+            .expect("specialized body relocates");
+        let dependencies = analyzed
+            .export
+            .dependencies
+            .iter()
+            .map(&definition)
+            .collect::<Result<Vec<_>, _>>()
+            .expect("specialization dependencies relocate");
+        let canonical = crate::body_query::CanonicalBody::Specialization {
+            identity,
+            body,
+            dependencies: dependencies.into(),
+            dependency_boundary_complete: analyzed.export.dependency_boundary_complete,
+        };
+        let body_span =
+            rue_span::Span::with_file(input.source.file_id, live_body_start, live_body_end);
+        let callable = crate::local_semantic_materialization::LocalCallableFact {
+            identity: instance,
+            symbol: Arc::from(live_name.as_str()),
+        };
+        let materialized = crate::local_semantic_materialization::materialize_canonical_body(
+            &canonical,
+            body_span,
+            &[],
+            &[],
+            std::slice::from_ref(&callable),
+            &[],
+            std::slice::from_ref(&module),
+        )
+        .expect("durable provider export materializes in a fresh local epoch");
+
+        assert_eq!(materialized.identity, live_identity);
+        assert_eq!(materialized.name, live_name);
+        assert_eq!(materialized.callable_kind, live_callable_kind);
+        assert_eq!(format!("{:?}", materialized.air), live_air);
+        assert_eq!(materialized.num_locals, live_num_locals);
+        assert_eq!(materialized.num_param_slots, live_num_param_slots);
+        assert_eq!(materialized.param_modes, live_param_modes);
+        assert_eq!(
+            materialized.allow_unreachable_code,
+            live_allow_unreachable_code
+        );
+        assert_eq!(materialized.type_pool.len(), live_pool_len);
+        let local_name_symbol = materialized
+            .interner
+            .get(&materialized.name)
+            .expect("local materialization interner owns the function symbol");
+        assert_eq!(
+            materialized.interner.resolve(&local_name_symbol),
+            materialized.name
+        );
+        assert_eq!(materialized.strings, live_strings);
+        assert_eq!(format!("{:?}", materialized.warnings), live_warnings);
+    }
+
+    #[test]
     fn provider_producer_facts_preserve_specialization_instance_terminal() {
         use rue_air::BodyFactProvider;
         let snapshot = source_snapshot(


### PR DESCRIPTION
## Summary

- add an owned, body-local semantic materialization result covering named, specialized, anonymous, nominal, callable, intrinsic, string, and destructor identities
- adapt canonical compiler body facts into exact local semantic inputs, including authoritative nominal metadata and builtin handling
- retain provider specialization state for parity checks while keeping the production CFG path unchanged
- fail closed on incomplete epochs, builtin shadowing, ambiguous destructors, and duplicate module facts

This establishes the semantic ownership boundary needed for CFG queries to stop depending on caller-owned whole-program live state.

## Validation

- `scripts/rue fmt`
- `scripts/rue quick` (including a clean rerun after rebasing onto current trunk)
- Clippy pre-merge tier: 63 targets passed
- pre-merge test tier: integration corpus passed 77 targets; one unrelated parser target failed under the loaded aggregate run and then passed all 47 tests immediately in isolation
- focused semantic-import, compiler materialization, API-inventory, provider-parity, and builtin-shadow tests
- adversarial architectural review with all findings resolved

Fixes RUE-1214.

Refs RUE-1199.
