### PR TITLE
RUE-1215: make CFG queries own semantic materialization

### DIFF
--- a/crates/rue-air/src/semantic_import.rs
+++ b/crates/rue-air/src/semantic_import.rs
@@ -1278,10 +1278,18 @@ where
     {
         nominals.sort_by(|left, right| left.key.cmp(&right.key));
         callables.sort_by(|left, right| left.key.cmp(&right.key));
-        if nominals
-            .iter()
-            .any(|nominal| matches!(nominal.key, NominalInstanceKey::Builtin { .. }))
-        {
+        if nominals.iter().any(|nominal| {
+            let NominalInstanceKey::Builtin { name, .. } = &nominal.key else {
+                return false;
+            };
+            name.as_ref() == "str"
+                || rue_builtins::get_builtin_enum(name).is_some()
+                || name
+                    .strip_prefix("Str(")
+                    .and_then(|name| name.strip_suffix(')'))
+                    .and_then(|capacity| capacity.parse::<u64>().ok())
+                    .is_some()
+        }) {
             return Err(SemanticImportFailure::BuiltinNominalShadow);
         }
         let mut modules = modules;
@@ -1321,7 +1329,21 @@ where
         );
         let mut local_identities = std::collections::BTreeSet::new();
         for nominal in &nominals {
-            if epoch.nominals.contains_key(&nominal.key) {
+            let builtin_key = match &nominal.key {
+                NominalInstanceKey::Builtin { kind, name } => Some((
+                    name.clone(),
+                    match kind {
+                        crate::AnonymousNominalKind::Struct => SemanticImportNominalKind::Struct,
+                        crate::AnonymousNominalKind::Enum => SemanticImportNominalKind::Enum,
+                    },
+                )),
+                _ => None,
+            };
+            if epoch.nominals.contains_key(&nominal.key)
+                || builtin_key
+                    .as_ref()
+                    .is_some_and(|key| epoch.builtins.contains_key(key))
+            {
                 return Err(SemanticImportFailure::DuplicateNominal);
             }
             if !local_identities.insert((
@@ -1343,7 +1365,7 @@ where
                             is_copy: false,
                             is_linear: false,
                             destructor: None,
-                            is_builtin: false,
+                            is_builtin: builtin_key.is_some(),
                             is_pub: nominal.is_public,
                             file_id,
                         },
@@ -1371,6 +1393,9 @@ where
                 }
             };
             epoch.nominals.insert(nominal.key.clone(), local);
+            if let Some(key) = builtin_key {
+                epoch.builtins.insert(key, local);
+            }
         }
 
         for nominal in &nominals {

--- a/crates/rue-cli-tests/cases/anon_struct_destructor.toml
+++ b/crates/rue-cli-tests/cases/anon_struct_destructor.toml
@@ -39,6 +39,35 @@ args = ["main.rue", "-o", "prog"]
 stdout = "100\n7\n"
 exit_code = 0
 
+# A receiver wider than the ordinary direct aggregate threshold proves that
+# anonymous destructors use the destructor-specific flattened cleanup ABI.
+[[case]]
+name = "multi_slot_receiver_uses_cleanup_abi"
+description = "A multi-slot anonymous-struct destructor receives every flattened field."
+files = [{ path = "main.rue", source = """
+fn Wide(comptime T: type) -> type {
+    struct {
+        first: T,
+        second: T,
+        third: T,
+        drop fn(self) {
+            @dbg(self.first);
+            @dbg(self.second);
+            @dbg(self.third);
+        }
+    }
+}
+
+fn main() -> i32 {
+    let W = Wide(i32);
+    let _value = W { first: 11, second: 22, third: 33 };
+    0
+}
+""" }]
+args = ["main.rue", "-o", "prog"]
+stdout = "11\n22\n33\n"
+exit_code = 0
+
 # RUE-578: this direct literal has no method call to pull the anonymous type's
 # destructor into the old eager body's one-time method sweep. The universal
 # demand-driven driver must discover the destructor registered while analyzing

--- a/crates/rue-compiler/src/api_inventory.rs
+++ b/crates/rue-compiler/src/api_inventory.rs
@@ -111,6 +111,44 @@ fn local_semantic_materialization_is_an_inert_exact_fact_boundary() {
     }
 }
 
+#[test]
+fn cfg_queries_own_local_semantic_materialization_and_terminal_domains() {
+    let cfg = include_str!("cfg_query.rs");
+    let database = include_str!("revisioned_query_database.rs");
+    for required in [
+        "CfgSemanticInput::Body",
+        "materialize_canonical_body(",
+        "materialize_semantic_body(",
+        "synthesize_canonical_drop_glue(",
+        "CfgDomainProjection::from_local_body(",
+        "pub(crate) type_pool: rue_air::FrozenTypeInternPool",
+        "pub(crate) interner: Arc<lasso::ThreadedRodeo>",
+        "pub(crate) local_atoms:",
+        "&record.type_pool",
+    ] {
+        assert!(
+            cfg.contains(required),
+            "CFG ownership boundary lost: {required}"
+        );
+    }
+    for forbidden in [
+        "struct CfgLiveInput",
+        "pub(crate) live:",
+        "key.live",
+        "same_optimized_memo_domain",
+        "optimized_memo_domain_hash",
+    ] {
+        assert!(
+            !cfg.contains(forbidden),
+            "CFG key regained request-local identity state: {forbidden}"
+        );
+    }
+    assert!(
+        !database.contains("live: Arc<crate::cfg_query::CfgLiveInput>"),
+        "the registered request facade must not require caller-owned CFG live input"
+    );
+}
+
 const RUE_868_RAW_FACADE_VOCABULARY: &[&str] = &[
     "Lexer",
     "Token",

--- a/crates/rue-compiler/src/canonical_semantic.rs
+++ b/crates/rue-compiler/src/canonical_semantic.rs
@@ -11,6 +11,7 @@ pub(crate) struct PreparedDurableBodyCandidate {
     pub owner: crate::StableDefinitionKey,
     pub body_span: rue_span::Span,
     pub body: rue_air::SemanticBody<crate::StableDefinitionKey, crate::ModuleId>,
+    pub canonical: Arc<crate::body_query::CanonicalBody>,
 }
 
 pub(crate) struct PreparedDurableSpecializedBodyCandidate {
@@ -19,12 +20,14 @@ pub(crate) struct PreparedDurableSpecializedBodyCandidate {
         rue_air::SemanticSpecializationIdentity<crate::StableDefinitionKey, crate::ModuleId>,
     pub body_span: rue_span::Span,
     pub body: rue_air::SemanticBody<crate::StableDefinitionKey, crate::ModuleId>,
+    pub canonical: Arc<crate::body_query::CanonicalBody>,
 }
 
 pub(crate) struct PreparedDurableAnonymousBodyCandidate {
     pub identity: crate::FunctionInstanceKey,
     pub body_span: rue_span::Span,
     pub body: rue_air::SemanticBody<crate::StableDefinitionKey, crate::ModuleId>,
+    pub canonical: Arc<crate::body_query::CanonicalBody>,
 }
 
 fn fold_body_import_work(durable: &mut crate::DurableBodyWork, body: BodyAnalysisWork) {
@@ -57,7 +60,6 @@ use crate::{
 #[cfg(test)]
 thread_local! {
     static INJECT_CFG_FAILURE: Cell<bool> = const { Cell::new(false) };
-    static INJECT_CFG_IMPORT_FAILURE: Cell<bool> = const { Cell::new(false) };
     static INJECT_DECLARATION_FAILURE: Cell<bool> = const { Cell::new(false) };
     static INJECT_AUTHORITATIVE_KEY_MISMATCH: Cell<bool> = const { Cell::new(false) };
 }
@@ -80,30 +82,6 @@ pub(crate) fn with_test_cfg_failure_injection<T>(run: impl FnOnce() -> T) -> T {
     });
     let _reset = Reset;
     run()
-}
-
-#[cfg(test)]
-pub(crate) fn with_test_cfg_import_failure_injection<T>(run: impl FnOnce() -> T) -> T {
-    struct Reset;
-    impl Drop for Reset {
-        fn drop(&mut self) {
-            INJECT_CFG_IMPORT_FAILURE.with(|enabled| enabled.set(false));
-        }
-    }
-
-    INJECT_CFG_IMPORT_FAILURE.with(|enabled| {
-        assert!(
-            !enabled.replace(true),
-            "CFG import failure injection is not nestable"
-        );
-    });
-    let _reset = Reset;
-    run()
-}
-
-#[cfg(test)]
-pub(crate) fn take_test_cfg_import_failure() -> bool {
-    INJECT_CFG_IMPORT_FAILURE.with(|enabled| enabled.replace(false))
 }
 
 #[cfg(test)]
@@ -1041,6 +1019,8 @@ pub(crate) fn analyze_prepared_canonical_program_reusing_declarations(
         body_candidates,
         specialized_body_candidates,
         anonymous_body_candidates,
+        durable,
+        anonymous_nominals,
         demanded_drop_glue,
         demanded_drop_glue_plans,
         body_work,
@@ -1341,6 +1321,8 @@ fn finish_canonical_analysis(
     durable_body_candidates: Vec<PreparedDurableBodyCandidate>,
     durable_specialized_body_candidates: Vec<PreparedDurableSpecializedBodyCandidate>,
     durable_anonymous_body_candidates: Vec<PreparedDurableAnonymousBodyCandidate>,
+    durable_declarations: &[DurableDeclarationSemantic],
+    durable_anonymous_nominals: &[crate::durable_semantics::DurableAnonymousNominal],
     demanded_drop_glue: Arc<[crate::TypeInstanceKey]>,
     demanded_drop_glue_plans: Arc<[(crate::TypeInstanceKey, crate::type_queries::DropGlueFacts)]>,
     durable_body_reuse_work: crate::DurableBodyWork,
@@ -1361,6 +1343,8 @@ fn finish_canonical_analysis(
         durable_body_candidates,
         durable_specialized_body_candidates,
         durable_anonymous_body_candidates,
+        durable_declarations,
+        durable_anonymous_nominals,
         demanded_drop_glue,
         demanded_drop_glue_plans,
         durable_body_reuse_work,
@@ -1395,6 +1379,8 @@ fn finish_canonical_analysis_with(
     durable_body_candidates: Vec<PreparedDurableBodyCandidate>,
     durable_specialized_body_candidates: Vec<PreparedDurableSpecializedBodyCandidate>,
     durable_anonymous_body_candidates: Vec<PreparedDurableAnonymousBodyCandidate>,
+    durable_declarations: &[DurableDeclarationSemantic],
+    durable_anonymous_nominals: &[crate::durable_semantics::DurableAnonymousNominal],
     demanded_drop_glue: Arc<[crate::TypeInstanceKey]>,
     demanded_drop_glue_plans: Arc<[(crate::TypeInstanceKey, crate::type_queries::DropGlueFacts)]>,
     mut durable_body_reuse_work: crate::DurableBodyWork,
@@ -1561,6 +1547,27 @@ fn finish_canonical_analysis_with(
         .zip(authoritative_keys.iter())
         .map(|(endpoint, key)| ((*key).clone(), endpoint.token))
         .collect::<std::collections::BTreeMap<_, _>>();
+    let queried_cfg_bodies = durable_body_candidates
+        .iter()
+        .map(|candidate| {
+            (
+                crate::FunctionInstanceKey::Definition(candidate.owner.clone()),
+                (candidate.body_span, candidate.canonical.clone()),
+            )
+        })
+        .chain(durable_specialized_body_candidates.iter().map(|candidate| {
+            (
+                candidate.instance.clone(),
+                (candidate.body_span, candidate.canonical.clone()),
+            )
+        }))
+        .chain(durable_anonymous_body_candidates.iter().map(|candidate| {
+            (
+                candidate.identity.clone(),
+                (candidate.body_span, candidate.canonical.clone()),
+            )
+        }))
+        .collect::<std::collections::BTreeMap<_, _>>();
     let mut queried_candidates = durable_body_candidates
         .into_iter()
         .filter_map(|candidate| {
@@ -1596,15 +1603,6 @@ fn finish_canonical_analysis_with(
                 body: candidate.body,
             }),
     );
-    let queried_cfg_bodies = queried_candidates
-        .iter()
-        .map(|candidate| {
-            (
-                candidate.identity.clone(),
-                (candidate.body_span, candidate.body.clone()),
-            )
-        })
-        .collect::<std::collections::BTreeMap<_, _>>();
     let composition = analyze_bodies(
         bound,
         queried_candidates,
@@ -1857,12 +1855,14 @@ fn finish_canonical_analysis_with(
             .and_then(|function_key| {
                 queried_cfg_bodies
                     .get(function_key)
-                    .map(|(body_span, body)| (*body_span, body.clone(), function_key.clone()))
+                    .map(|(body_span, canonical)| {
+                        (*body_span, canonical.clone(), function_key.clone())
+                    })
             });
-        if let Some((body_span, body, function_key)) = selected {
+        if let Some((body_span, canonical, function_key)) = selected {
             stable_cfg_inputs.push(crate::cfg_query::CfgBodyInput {
                 function: function_key,
-                body,
+                canonical,
                 body_span,
             });
         }
@@ -1882,6 +1882,8 @@ fn finish_canonical_analysis_with(
         options.opt_level,
         rir.semantic_symbols().shared_interner(),
         &stable_cfg_inputs,
+        durable_declarations,
+        durable_anonymous_nominals,
         stable_aggregate_types,
         &projected_callable_identities,
         cfg_queries,

--- a/crates/rue-compiler/src/cfg_query.rs
+++ b/crates/rue-compiler/src/cfg_query.rs
@@ -2,9 +2,8 @@
 //!
 //! The unoptimized family owns AIR-to-CFG lowering. The optimized family owns
 //! only the selected optimization pipeline and observes the exact unoptimized
-//! terminal. Both publish stable relocation domains; request-local AIR, type
-//! indexes, symbols, strings, and spans are construction inputs, never memo
-//! identity.
+//! terminal. Both publish stable relocation domains and own the body-local AIR,
+//! type pool, symbols, strings, and local atoms required by their CFG.
 
 use std::hash::{Hash, Hasher};
 use std::sync::Arc;
@@ -12,64 +11,78 @@ use std::sync::Arc;
 use rue_query::{QueryAbort, QueryContext, QueryFamily, QueryKey, QueryOutcome, QueryOutput};
 use rue_span::Span;
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone)]
 pub(crate) enum CfgSemanticInput {
-    Body(Arc<rue_air::SemanticBody<crate::StableDefinitionKey, crate::ModuleId>>),
+    Body {
+        input: Arc<CfgBodyInput>,
+        materialization: Arc<crate::local_semantic_materialization::LocalMaterializationFacts>,
+    },
     DropGlue {
         owner: crate::TypeInstanceKey,
         facts: Box<crate::type_queries::DropGlueFacts>,
+        materialization: Arc<crate::local_semantic_materialization::LocalMaterializationFacts>,
+        body_span: Span,
     },
 }
 
 #[derive(Debug, Clone)]
 pub(crate) struct CfgBodyInput {
     pub(crate) function: crate::FunctionInstanceKey,
-    pub(crate) body: rue_air::SemanticBody<crate::StableDefinitionKey, crate::ModuleId>,
+    pub(crate) canonical: Arc<crate::body_query::CanonicalBody>,
     pub(crate) body_span: Span,
 }
 
-#[derive(Debug)]
-pub(crate) struct CfgLiveInput {
-    pub(crate) function: Arc<rue_air::AnalyzedFunction>,
-    pub(crate) type_pool: rue_air::FrozenTypeInternPool,
-    pub(crate) interner: Arc<lasso::ThreadedRodeo>,
-    pub(crate) domains: crate::durable_cfg::CfgDomainProjection,
-    pub(crate) body_span: Span,
-    pub(crate) aggregate_types:
-        Arc<std::collections::HashMap<rue_air::Type, crate::TypeInstanceKey>>,
-    pub(crate) implicit_destructor_dependencies_complete: bool,
+impl PartialEq for CfgBodyInput {
+    fn eq(&self, other: &Self) -> bool {
+        self.function == other.function && self.canonical == other.canonical
+    }
 }
+
+impl Eq for CfgBodyInput {}
+
+impl PartialEq for CfgSemanticInput {
+    fn eq(&self, other: &Self) -> bool {
+        match (self, other) {
+            (
+                Self::Body {
+                    input: left_input,
+                    materialization: left_materialization,
+                },
+                Self::Body {
+                    input: right_input,
+                    materialization: right_materialization,
+                },
+            ) => left_input == right_input && left_materialization == right_materialization,
+            (
+                Self::DropGlue {
+                    owner: left_owner,
+                    facts: left_facts,
+                    materialization: left_materialization,
+                    ..
+                },
+                Self::DropGlue {
+                    owner: right_owner,
+                    facts: right_facts,
+                    materialization: right_materialization,
+                    ..
+                },
+            ) => {
+                left_owner == right_owner
+                    && left_facts == right_facts
+                    && left_materialization == right_materialization
+            }
+            _ => false,
+        }
+    }
+}
+
+impl Eq for CfgSemanticInput {}
 
 #[derive(Debug, Clone)]
 pub(crate) struct CfgQueryKey {
     pub(crate) function: crate::FunctionInstanceKey,
     pub(crate) configuration: crate::semantic_query_nucleus::SemanticQueryConfiguration,
     pub(crate) semantic_input: CfgSemanticInput,
-    pub(crate) layouts: Arc<
-        [(
-            crate::type_queries::TypeQueryKey,
-            crate::type_queries::LayoutValue,
-        )],
-    >,
-    pub(crate) type_facts: Arc<
-        [(
-            crate::type_queries::TypeQueryKey,
-            crate::type_queries::TypeFactsValue,
-        )],
-    >,
-    pub(crate) drop_glues: Arc<
-        [(
-            crate::type_queries::TypeQueryKey,
-            crate::type_queries::DropGlueValue,
-        )],
-    >,
-    pub(crate) call_abis: Arc<
-        [(
-            crate::type_queries::CallAbiQueryKey,
-            crate::type_queries::CallAbiValue,
-        )],
-    >,
-    pub(crate) live: Arc<CfgLiveInput>,
     memo_hash: u64,
 }
 
@@ -78,31 +91,6 @@ impl CfgQueryKey {
         function: crate::FunctionInstanceKey,
         configuration: crate::semantic_query_nucleus::SemanticQueryConfiguration,
         semantic_input: CfgSemanticInput,
-        layouts: Arc<
-            [(
-                crate::type_queries::TypeQueryKey,
-                crate::type_queries::LayoutValue,
-            )],
-        >,
-        type_facts: Arc<
-            [(
-                crate::type_queries::TypeQueryKey,
-                crate::type_queries::TypeFactsValue,
-            )],
-        >,
-        drop_glues: Arc<
-            [(
-                crate::type_queries::TypeQueryKey,
-                crate::type_queries::DropGlueValue,
-            )],
-        >,
-        call_abis: Arc<
-            [(
-                crate::type_queries::CallAbiQueryKey,
-                crate::type_queries::CallAbiValue,
-            )],
-        >,
-        live: Arc<CfgLiveInput>,
     ) -> Self {
         let mut hasher = std::collections::hash_map::DefaultHasher::new();
         function.hash(&mut hasher);
@@ -110,21 +98,27 @@ impl CfgQueryKey {
         // These stable values deliberately do not implement `Hash`. Compute
         // their complete Debug framing once at key construction instead of on
         // every memo-table probe; equality still resolves hash collisions.
-        format!("{semantic_input:?}").hash(&mut hasher);
-        format!("{layouts:?}").hash(&mut hasher);
-        format!("{type_facts:?}").hash(&mut hasher);
-        format!("{drop_glues:?}").hash(&mut hasher);
-        format!("{call_abis:?}").hash(&mut hasher);
+        match &semantic_input {
+            CfgSemanticInput::Body {
+                input,
+                materialization,
+            } => {
+                format!("{:?};{:?}", input.canonical, materialization).hash(&mut hasher);
+            }
+            CfgSemanticInput::DropGlue {
+                owner,
+                facts,
+                materialization,
+                ..
+            } => {
+                format!("{owner:?};{facts:?};{materialization:?}").hash(&mut hasher);
+            }
+        }
         let memo_hash = hasher.finish();
         Self {
             function,
             configuration,
             semantic_input,
-            layouts,
-            type_facts,
-            drop_glues,
-            call_abis,
-            live,
             memo_hash,
         }
     }
@@ -135,10 +129,6 @@ impl PartialEq for CfgQueryKey {
         self.function == other.function
             && self.configuration == other.configuration
             && self.semantic_input == other.semantic_input
-            && self.layouts == other.layouts
-            && self.type_facts == other.type_facts
-            && self.drop_glues == other.drop_glues
-            && self.call_abis == other.call_abis
     }
 }
 
@@ -163,38 +153,17 @@ impl QueryKey for CfgQueryKey {
 pub(crate) struct OptimizedCfgQueryKey {
     pub(crate) cfg: CfgQueryKey,
     pub(crate) opt_level: rue_cfg::OptLevel,
-    live_domain_hash: u64,
 }
 
 impl OptimizedCfgQueryKey {
     pub(crate) fn new(cfg: CfgQueryKey, opt_level: rue_cfg::OptLevel) -> Self {
-        let mut hasher = std::collections::hash_map::DefaultHasher::new();
-        // Complete domains are relocatable by the collector and therefore do
-        // not belong in optimized memo identity. An incomplete projection is
-        // deliberately epoch-local: distinguish that one token so a successor
-        // reruns the evaluator and takes its fail-closed rebuild path.
-        cfg.live
-            .domains
-            .optimized_memo_domain_hash()
-            .hash(&mut hasher);
-        let live_domain_hash = hasher.finish();
-        Self {
-            cfg,
-            opt_level,
-            live_domain_hash,
-        }
+        Self { cfg, opt_level }
     }
 }
 
 impl PartialEq for OptimizedCfgQueryKey {
     fn eq(&self, other: &Self) -> bool {
-        self.cfg == other.cfg
-            && self.opt_level == other.opt_level
-            && self
-                .cfg
-                .live
-                .domains
-                .same_optimized_memo_domain(&other.cfg.live.domains)
+        self.cfg == other.cfg && self.opt_level == other.opt_level
     }
 }
 
@@ -204,7 +173,6 @@ impl std::hash::Hash for OptimizedCfgQueryKey {
     fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
         self.cfg.hash(state);
         std::mem::discriminant(&self.opt_level).hash(state);
-        self.live_domain_hash.hash(state);
     }
 }
 
@@ -218,6 +186,12 @@ impl QueryKey for OptimizedCfgQueryKey {
 pub(crate) struct CfgRecord {
     pub(crate) cfg: rue_cfg::ValidatedCfg,
     pub(crate) domains: crate::durable_cfg::CfgDomainProjection,
+    pub(crate) type_pool: rue_air::FrozenTypeInternPool,
+    pub(crate) interner: Arc<lasso::ThreadedRodeo>,
+    pub(crate) strings: Arc<[String]>,
+    pub(crate) local_atoms:
+        Arc<[rue_air::LocalAtomRecord<crate::StableDefinitionKey, crate::ModuleId>]>,
+    pub(crate) materialization_warnings: Arc<[rue_error::CompileWarning]>,
     pub(crate) body_span: Span,
     pub(crate) warnings: Arc<[rue_error::CompileWarning]>,
     pub(crate) implicit_destructor_targets: Arc<[crate::TypeInstanceKey]>,
@@ -372,43 +346,8 @@ pub(crate) fn evaluate_cfg(
     >,
     key: &CfgQueryKey,
 ) -> Result<QueryOutput<CfgValue>, QueryAbort> {
-    for (dependency, expected) in key.layouts.iter() {
-        let terminal = context.query_registered(layouts, dependency.clone())?;
-        let QueryOutcome::Success(actual) = terminal.outcome() else {
-            unreachable!("Layout publishes typed values")
-        };
-        if actual != expected {
-            return Err(QueryAbort::Canceled);
-        }
-    }
-    for (dependency, expected) in key.type_facts.iter() {
-        let terminal = context.query_registered(type_facts, dependency.clone())?;
-        let QueryOutcome::Success(actual) = terminal.outcome() else {
-            unreachable!("TypeFacts publishes typed values")
-        };
-        if actual != expected {
-            return Err(QueryAbort::Canceled);
-        }
-    }
-    for (dependency, expected) in key.drop_glues.iter() {
-        let terminal = context.query_registered(drop_glues, dependency.clone())?;
-        let QueryOutcome::Success(actual) = terminal.outcome() else {
-            unreachable!("DropGlue publishes typed values")
-        };
-        if actual != expected {
-            return Err(QueryAbort::Canceled);
-        }
-    }
-    for (dependency, expected) in key.call_abis.iter() {
-        let terminal = context.query_registered(call_abis, dependency.clone())?;
-        let QueryOutcome::Success(actual) = terminal.outcome() else {
-            unreachable!("CallAbi publishes typed values")
-        };
-        if actual != expected {
-            return Err(QueryAbort::Canceled);
-        }
-    }
-    let value = build_cfg(context, key);
+    let value =
+        materialize_and_build_cfg(context, layouts, type_facts, drop_glues, call_abis, key)?;
     let kind = if matches!(value, CfgValue::Failure { .. }) {
         rue_query::QueryTerminalKind::Failure
     } else {
@@ -417,28 +356,266 @@ pub(crate) fn evaluate_cfg(
     Ok(QueryOutput::success(value).with_terminal_kind(kind))
 }
 
-fn build_cfg(context: &QueryContext, key: &CfgQueryKey) -> CfgValue {
+fn internal_failure(message: impl Into<String>, body_span: Span) -> CfgValue {
+    CfgValue::Failure {
+        errors: crate::CompileError::new(
+            rue_error::ErrorKind::InternalError(message.into()),
+            body_span,
+        )
+        .into(),
+        body_span,
+    }
+}
+
+fn canonical_body(
+    canonical: &crate::body_query::CanonicalBody,
+) -> &rue_air::SemanticBody<crate::StableDefinitionKey, crate::ModuleId> {
+    match canonical {
+        crate::body_query::CanonicalBody::Ordinary { body, .. }
+        | crate::body_query::CanonicalBody::Anonymous { body, .. }
+        | crate::body_query::CanonicalBody::Specialization { body, .. } => body,
+    }
+}
+
+fn collect_plan_types(
+    owner: &crate::TypeInstanceKey,
+    facts: &crate::type_queries::DropGlueFacts,
+) -> std::collections::BTreeSet<crate::TypeInstanceKey> {
+    let mut output = std::collections::BTreeSet::from([owner.clone()]);
+    output.extend(facts.nested.iter().cloned());
+    match &facts.plan {
+        crate::type_queries::DropGluePlan::Struct { fields } => {
+            output.extend(fields.iter().map(|field| field.ty.clone()));
+        }
+        crate::type_queries::DropGluePlan::Array { element, .. } => {
+            output.insert(element.clone());
+        }
+        crate::type_queries::DropGluePlan::Enum { variants } => {
+            output.extend(
+                variants
+                    .iter()
+                    .flat_map(|variant| variant.fields.iter())
+                    .map(|field| field.ty.clone()),
+            );
+        }
+        crate::type_queries::DropGluePlan::None => {}
+    }
+    output
+}
+
+fn materialize_and_build_cfg(
+    context: &QueryContext,
+    layouts: &QueryFamily<crate::type_queries::TypeQueryKey, crate::type_queries::LayoutValue>,
+    type_facts: &QueryFamily<
+        crate::type_queries::TypeQueryKey,
+        crate::type_queries::TypeFactsValue,
+    >,
+    drop_glues: &QueryFamily<crate::type_queries::TypeQueryKey, crate::type_queries::DropGlueValue>,
+    call_abis: &QueryFamily<
+        crate::type_queries::CallAbiQueryKey,
+        crate::type_queries::CallAbiValue,
+    >,
+    key: &CfgQueryKey,
+) -> Result<CfgValue, QueryAbort> {
+    let synthesized;
+    let (body, body_span, facts) = match &key.semantic_input {
+        CfgSemanticInput::Body {
+            input,
+            materialization,
+        } => (
+            canonical_body(&input.canonical),
+            input.body_span,
+            materialization.as_ref(),
+        ),
+        CfgSemanticInput::DropGlue {
+            owner,
+            facts,
+            materialization,
+            body_span,
+        } => {
+            let mut slots = std::collections::BTreeMap::new();
+            for ty in collect_plan_types(owner, facts) {
+                let dependency = crate::type_queries::TypeQueryKey {
+                    ty: ty.clone(),
+                    configuration: key.configuration.clone(),
+                };
+                let terminal = context.query_registered(layouts, dependency)?;
+                let QueryOutcome::Success(value) = terminal.outcome() else {
+                    unreachable!("Layout publishes typed values")
+                };
+                let crate::type_queries::LayoutValue::Available(layout) = value else {
+                    return Ok(internal_failure(
+                        format!("drop-glue layout unavailable for {ty:?}: {value:?}"),
+                        *body_span,
+                    ));
+                };
+                slots.insert(ty, layout.abi_slots);
+            }
+            synthesized =
+                match crate::drop_glue::synthesize_canonical_drop_glue(owner, facts, &slots) {
+                    Ok(body) => body,
+                    Err(error) => return Ok(internal_failure(error.as_ref(), *body_span)),
+                };
+            (&synthesized, *body_span, materialization.as_ref())
+        }
+    };
+    let mut builtin_facts = Vec::with_capacity(facts.builtin_nominals.len());
+    for request in facts.builtin_nominals.iter() {
+        let dependency = crate::type_queries::TypeQueryKey {
+            ty: request.query_ty.clone(),
+            configuration: key.configuration.clone(),
+        };
+        let terminal = context.query_registered(type_facts, dependency)?;
+        let QueryOutcome::Success(value) = terminal.outcome() else {
+            unreachable!("TypeFacts publishes typed values")
+        };
+        let crate::type_queries::TypeFactsValue::Available(value) = value else {
+            return Ok(internal_failure(
+                format!("builtin nominal facts unavailable for {request:?}: {value:?}"),
+                body_span,
+            ));
+        };
+        builtin_facts.push(
+            crate::local_semantic_materialization::LocalBuiltinNominalFact {
+                request: request.clone(),
+                facts: value.as_ref().clone(),
+            },
+        );
+    }
+    context.record_work(rue_query::WorkItem::new("cfg.materialize.attempts", 1));
+    let materialized = match &key.semantic_input {
+        CfgSemanticInput::Body { input, .. } => {
+            crate::local_semantic_materialization::materialize_canonical_body(
+                &input.canonical,
+                body_span,
+                &facts.declarations,
+                &facts.anonymous_nominals,
+                &facts.callables,
+                &facts.nominal_metadata,
+                &facts.modules,
+                &builtin_facts,
+            )
+        }
+        CfgSemanticInput::DropGlue { owner, .. } => {
+            crate::local_semantic_materialization::materialize_semantic_body(
+                crate::FunctionInstanceKey::DropGlue(Box::new(owner.clone())),
+                body,
+                body_span,
+                &facts.declarations,
+                &facts.anonymous_nominals,
+                &facts.callables,
+                &facts.nominal_metadata,
+                &facts.modules,
+                &builtin_facts,
+            )
+        }
+    };
+    let materialized = match materialized {
+        Ok(value) => value,
+        Err(error) => {
+            context.record_work(rue_query::WorkItem::new("cfg.materialize.failures", 1));
+            return Ok(internal_failure(
+                format!("canonical CFG materialization failed: {error:?}"),
+                body_span,
+            ));
+        }
+    };
+    context.record_work(rue_query::WorkItem::new("cfg.materialize.successes", 1));
+
+    let domains = match crate::durable_cfg::CfgDomainProjection::from_local_body(
+        &materialized,
+        body,
+        |ty| {
+            crate::durable_cfg::canonical_type_from_live(
+                ty,
+                &materialized.type_pool,
+                &materialized.aggregate_types,
+            )
+        },
+        |symbol| {
+            let name = materialized.interner.resolve(&symbol);
+            facts
+                .callables
+                .iter()
+                .find(|fact| fact.symbol.as_ref() == name)
+                .map(|fact| fact.identity.clone())
+        },
+    ) {
+        Ok(value) => value,
+        Err(error) => {
+            return Ok(internal_failure(
+                format!("canonical CFG domain projection failed: {error:?}"),
+                body_span,
+            ));
+        }
+    };
+
+    let mut layout_dependencies = std::collections::BTreeSet::new();
+    let mut drop_dependencies = std::collections::BTreeSet::new();
+    for ty in domains.stable_types() {
+        collect_type_dependencies(ty, &mut layout_dependencies);
+        collect_drop_type_dependency(ty, &mut drop_dependencies);
+    }
+    for ty in layout_dependencies {
+        context.query_registered(
+            layouts,
+            crate::type_queries::TypeQueryKey {
+                ty,
+                configuration: key.configuration.clone(),
+            },
+        )?;
+    }
+    for ty in drop_dependencies {
+        let dependency = crate::type_queries::TypeQueryKey {
+            ty,
+            configuration: key.configuration.clone(),
+        };
+        context.query_registered(type_facts, dependency.clone())?;
+        context.query_registered(drop_glues, dependency)?;
+    }
+    let mut callables = domains
+        .stable_callables()
+        .collect::<std::collections::BTreeSet<_>>();
+    callables.insert(key.function.clone());
+    for callable in callables {
+        context.query_registered(
+            call_abis,
+            crate::type_queries::CallAbiQueryKey {
+                callable,
+                configuration: key.configuration.clone(),
+            },
+        )?;
+    }
+    Ok(build_cfg(context, key, materialized, domains))
+}
+
+fn build_cfg(
+    context: &QueryContext,
+    key: &CfgQueryKey,
+    materialized: crate::local_semantic_materialization::LocalSemanticMaterialization,
+    domains: crate::durable_cfg::CfgDomainProjection,
+) -> CfgValue {
     context.record_work(rue_query::WorkItem::new("cfg.build.attempts", 1));
     context.record_work(rue_query::WorkItem::new(
         "cfg.air.instructions",
-        key.live.function.air.instructions().len() as u64,
+        materialized.air.instructions().len() as u64,
     ));
     let output = rue_cfg::CfgBuilder::build(
-        &key.live.function.air,
-        key.live.function.num_locals,
-        key.live.function.num_param_slots,
-        &key.live.function.name,
-        &key.live.type_pool,
-        key.live.function.param_modes.clone(),
-        &key.live.interner,
-        key.live.function.allow_unreachable_code,
-        key.live.function.callable_kind,
+        &materialized.air,
+        materialized.num_locals,
+        materialized.num_param_slots,
+        &materialized.name,
+        &materialized.type_pool,
+        materialized.param_modes.clone(),
+        &materialized.interner,
+        materialized.allow_unreachable_code,
+        materialized.callable_kind,
     );
     if !output.errors.is_empty() {
         context.record_work(rue_query::WorkItem::new("cfg.build.failures", 1));
         return CfgValue::Failure {
             errors: output.errors.into(),
-            body_span: key.live.body_span,
+            body_span: materialized.body_span,
         };
     }
     context.record_work(rue_query::WorkItem::new("cfg.build.successes", 1));
@@ -450,13 +627,13 @@ fn build_cfg(context: &QueryContext, key: &CfgQueryKey) -> CfgValue {
         .implicit_named_destructors
         .iter()
         .filter_map(|id| {
-            key.live
+            materialized
                 .aggregate_types
                 .get(&rue_air::Type::new_struct(*id))
                 .cloned()
         })
         .collect::<std::collections::BTreeSet<_>>();
-    if let CfgSemanticInput::DropGlue { owner, facts } = &key.semantic_input
+    if let CfgSemanticInput::DropGlue { owner, facts, .. } = &key.semantic_input
         && facts.destructor.is_some()
     {
         // A synthesized struct glue body does not explicitly drop its owner,
@@ -469,16 +646,19 @@ fn build_cfg(context: &QueryContext, key: &CfgQueryKey) -> CfgValue {
         cfg: output
             .cfg
             .expect("successful CFG construction publishes a validated CFG"),
-        domains: key.live.domains.clone(),
-        body_span: key.live.body_span,
+        domains,
+        type_pool: materialized.type_pool,
+        interner: materialized.interner,
+        strings: materialized.strings.into(),
+        local_atoms: materialized.local_atoms.into(),
+        materialization_warnings: materialized.warnings,
+        body_span: materialized.body_span,
         warnings: output.warnings.into(),
         implicit_destructor_targets: implicit_destructor_targets
             .into_iter()
             .collect::<Vec<_>>()
             .into(),
-        implicit_destructor_dependencies_complete: key
-            .live
-            .implicit_destructor_dependencies_complete
+        implicit_destructor_dependencies_complete: materialized.completeness.is_complete()
             && !output.anonymous_destructor_dependency_incomplete,
     }))
 }
@@ -497,56 +677,25 @@ pub(crate) fn evaluate_optimized_cfg(
         return Ok(QueryOutput::success(value.clone())
             .with_terminal_kind(rue_query::QueryTerminalKind::Failure));
     };
-    let (current, record) = if record.domains.same_live_domain(&key.cfg.live.domains) {
-        (record.cfg.clone(), record.clone())
-    } else {
-        context.record_work(rue_query::WorkItem::new("cfg.import.attempts", 1));
-        match crate::durable_cfg::CfgDomainProjection::import_cfg(
-            &record.domains,
-            &key.cfg.live.domains,
-            &record.cfg,
-            key.cfg.live.body_span,
-        )
-        .and_then(|editor| {
-            editor
-                .finish_after_optimization(&key.cfg.live.type_pool)
-                .map_err(|_| crate::durable_cfg::CfgDomainFailure::Shape)
-        }) {
-            Ok(current) => {
-                context.record_work(rue_query::WorkItem::new("cfg.import.successes", 1));
-                (current, record.clone())
-            }
-            Err(_) => {
-                // A relocation-domain miss must not turn a valid current body
-                // into an ICE. Rebuild from the exact current AIR and continue
-                // optimization; the regular Cfg family remains the canonical
-                // fast path, while this fail-closed path preserves correctness
-                // if a newly introduced CFG domain escaped projection.
-                context.record_work(rue_query::WorkItem::new("cfg.import.failures", 1));
-                context.record_work(rue_query::WorkItem::new("cfg.fallbacks", 1));
-                match build_cfg(context, &key.cfg) {
-                    CfgValue::Available(record) => (record.cfg.clone(), record.clone()),
-                    rebuilt @ CfgValue::Failure { .. } => {
-                        return Ok(QueryOutput::success(rebuilt)
-                            .with_terminal_kind(rue_query::QueryTerminalKind::Failure));
-                    }
-                }
-            }
-        }
-    };
+    let current = record.cfg.clone();
     context.record_work(rue_query::WorkItem::new("cfg.optimize.attempts", 1));
     context.record_work(rue_query::WorkItem::new(
         "cfg.optimize.nonzero-level",
         u64::from(key.opt_level != rue_cfg::OptLevel::O0),
     ));
-    match rue_cfg::opt::optimize(current, key.opt_level, &key.cfg.live.type_pool) {
+    match rue_cfg::opt::optimize(current, key.opt_level, &record.type_pool) {
         Ok(cfg) => {
             context.record_work(rue_query::WorkItem::new("cfg.optimize.successes", 1));
             Ok(QueryOutput::success(CfgValue::Available(Arc::new(
                 CfgRecord {
                     cfg,
-                    domains: key.cfg.live.domains.clone(),
-                    body_span: key.cfg.live.body_span,
+                    domains: record.domains.clone(),
+                    type_pool: record.type_pool.clone(),
+                    interner: record.interner.clone(),
+                    strings: record.strings.clone(),
+                    local_atoms: record.local_atoms.clone(),
+                    materialization_warnings: record.materialization_warnings.clone(),
+                    body_span: record.body_span,
                     warnings: record.warnings.clone(),
                     implicit_destructor_targets: record.implicit_destructor_targets.clone(),
                     implicit_destructor_dependencies_complete: record
@@ -562,7 +711,7 @@ pub(crate) fn evaluate_optimized_cfg(
                         "CFG optimization failed: {error}"
                     )),
                 )),
-                body_span: key.cfg.live.body_span,
+                body_span: record.body_span,
             })
             .with_terminal_kind(rue_query::QueryTerminalKind::Failure))
         }

--- a/crates/rue-compiler/src/drop_glue.rs
+++ b/crates/rue-compiler/src/drop_glue.rs
@@ -26,9 +26,219 @@ use rue_air::{
 };
 use rue_error::{CompileError, CompileResult, ErrorKind};
 use rue_span::Span;
+use std::sync::Arc;
 
 type IssuedTypeInstanceKey =
     rue_air::TypeInstanceKey<rue_air::SemanticDefinitionToken, rue_air::SemanticModuleToken>;
+
+pub(crate) fn semantic_type_from_instance(
+    ty: &crate::TypeInstanceKey,
+) -> rue_air::SemanticImportType<crate::StableDefinitionKey, crate::ModuleId> {
+    use crate::TypeInstanceKey as T;
+    use rue_air::SemanticImportType as S;
+    match ty {
+        T::I8 => S::I8,
+        T::I16 => S::I16,
+        T::I32 => S::I32,
+        T::I64 => S::I64,
+        T::U8 => S::U8,
+        T::U16 => S::U16,
+        T::U32 => S::U32,
+        T::U64 => S::U64,
+        T::Bool => S::Bool,
+        T::Unit => S::Unit,
+        T::Never => S::Never,
+        T::ComptimeType => S::ComptimeType,
+        T::BuiltinNominal { kind, name } => S::BuiltinNominal {
+            kind: match kind {
+                crate::AnonymousNominalKind::Struct => rue_air::SemanticImportNominalKind::Struct,
+                crate::AnonymousNominalKind::Enum => rue_air::SemanticImportNominalKind::Enum,
+            },
+            name: name.clone(),
+        },
+        T::Nominal(crate::NominalInstanceKey::Named(key)) => S::Nominal(key.clone()),
+        T::Nominal(crate::NominalInstanceKey::Anonymous(key)) => S::AnonymousNominal(key.clone()),
+        T::Nominal(crate::NominalInstanceKey::Builtin { kind, name }) => S::BuiltinNominal {
+            kind: match kind {
+                crate::AnonymousNominalKind::Struct => rue_air::SemanticImportNominalKind::Struct,
+                crate::AnonymousNominalKind::Enum => rue_air::SemanticImportNominalKind::Enum,
+            },
+            name: name.clone(),
+        },
+        T::Array { element, len } => S::Array {
+            element: Box::new(semantic_type_from_instance(element)),
+            len: *len,
+        },
+        T::Slice { element, name } => S::Slice {
+            element: Box::new(semantic_type_from_instance(element)),
+            name: name.clone(),
+        },
+        T::PtrConst(element) => S::PtrConst(Box::new(semantic_type_from_instance(element))),
+        T::PtrMut(element) => S::PtrMut(Box::new(semantic_type_from_instance(element))),
+        T::Module(module) => S::Module(module.clone()),
+        T::GenericParameter(index) => S::GenericParameter(*index),
+    }
+}
+
+/// Build the canonical AIR-shaped body for one exact drop-glue fact. Layout
+/// slots are supplied by registered Layout dependencies observed by the CFG
+/// evaluator, so this path never needs a caller-owned frozen pool.
+pub(crate) fn synthesize_canonical_drop_glue(
+    owner: &crate::TypeInstanceKey,
+    facts: &crate::type_queries::DropGlueFacts,
+    abi_slots: &std::collections::BTreeMap<crate::TypeInstanceKey, u32>,
+) -> Result<rue_air::SemanticBody<crate::StableDefinitionKey, crate::ModuleId>, Arc<str>> {
+    use rue_air::{SemanticBodyAnchor, SemanticBodyInst, SemanticBodyInstData};
+    type Body = rue_air::SemanticBody<crate::StableDefinitionKey, crate::ModuleId>;
+    type Ty = rue_air::SemanticImportType<crate::StableDefinitionKey, crate::ModuleId>;
+
+    let slots = |ty: &crate::TypeInstanceKey| {
+        abi_slots
+            .get(ty)
+            .copied()
+            .ok_or_else(|| Arc::<str>::from(format!("missing layout for drop-glue type {ty:?}")))
+    };
+    let anchor = SemanticBodyAnchor { start: 0, end: 0 };
+    let mut instructions = Vec::<SemanticBodyInst<_, _>>::new();
+    let mut add = |data, ty: Ty| {
+        let index = u32::try_from(instructions.len()).expect("drop-glue body fits u32");
+        instructions.push(SemanticBodyInst { data, ty, anchor });
+        index
+    };
+    let mut statements = Vec::new();
+    let num_param_slots = slots(owner)?;
+
+    match &facts.plan {
+        crate::type_queries::DropGluePlan::Struct { fields } => {
+            let mut current = 0;
+            for field in fields.iter() {
+                let width = slots(&field.ty)?;
+                if field.drop {
+                    let ty = semantic_type_from_instance(&field.ty);
+                    let param = add(SemanticBodyInstData::Param { index: current }, ty.clone());
+                    statements.push(add(SemanticBodyInstData::Drop { value: param }, ty));
+                }
+                current = current.saturating_add(width);
+            }
+        }
+        crate::type_queries::DropGluePlan::Array {
+            element,
+            len,
+            drop_element,
+        } => {
+            let width = slots(element)?;
+            if *drop_element {
+                for index in 0..*len {
+                    let ty = semantic_type_from_instance(element);
+                    let param = add(
+                        SemanticBodyInstData::Param {
+                            index: u32::try_from(index)
+                                .unwrap_or(u32::MAX)
+                                .saturating_mul(width),
+                        },
+                        ty.clone(),
+                    );
+                    statements.push(add(SemanticBodyInstData::Drop { value: param }, ty));
+                }
+            }
+        }
+        crate::type_queries::DropGluePlan::Enum { variants } => {
+            let disc_ty = if variants.is_empty() {
+                Ty::Never
+            } else if variants.len() <= 256 {
+                Ty::U8
+            } else if variants.len() <= 65_536 {
+                Ty::U16
+            } else if variants.len() <= 4_294_967_296usize {
+                Ty::U32
+            } else {
+                Ty::U64
+            };
+            let disc = add(
+                SemanticBodyInstData::Param {
+                    index: num_param_slots.saturating_sub(1),
+                },
+                disc_ty.clone(),
+            );
+            let unit = add(SemanticBodyInstData::UnitConst, Ty::Unit);
+            let mut arms = Vec::new();
+            for (variant_index, variant) in variants.iter().enumerate() {
+                if !variant.fields.iter().any(|field| field.drop) {
+                    continue;
+                }
+                let mut field_slot = 1u32;
+                let mut drops = Vec::new();
+                for field in variant.fields.iter() {
+                    let width = slots(&field.ty)?;
+                    if field.drop {
+                        let ty = semantic_type_from_instance(&field.ty);
+                        let param = add(
+                            SemanticBodyInstData::Param {
+                                index: num_param_slots
+                                    .saturating_sub(field_slot.saturating_add(width)),
+                            },
+                            ty.clone(),
+                        );
+                        drops.push(add(SemanticBodyInstData::Drop { value: param }, ty));
+                    }
+                    field_slot = field_slot.saturating_add(width);
+                }
+                let body = add(
+                    SemanticBodyInstData::Block {
+                        statements: drops.into(),
+                        value: unit,
+                    },
+                    Ty::Unit,
+                );
+                arms.push(rue_air::SemanticBodyMatchArm {
+                    pattern: rue_air::SemanticBodyPattern::Int(variant_index as i64),
+                    body,
+                });
+            }
+            arms.push(rue_air::SemanticBodyMatchArm {
+                pattern: rue_air::SemanticBodyPattern::Wildcard,
+                body: unit,
+            });
+            statements.push(add(
+                SemanticBodyInstData::Match {
+                    scrutinee: disc,
+                    arms: arms.into(),
+                },
+                Ty::Unit,
+            ));
+        }
+        crate::type_queries::DropGluePlan::None => {}
+    }
+    let unit = add(SemanticBodyInstData::UnitConst, Ty::Unit);
+    let value = if statements.is_empty() {
+        unit
+    } else {
+        add(
+            SemanticBodyInstData::Block {
+                statements: statements.into(),
+                value: unit,
+            },
+            Ty::Unit,
+        )
+    };
+    add(SemanticBodyInstData::Ret(Some(value)), Ty::Unit);
+    Ok(Body {
+        return_type: Ty::Unit,
+        instructions: instructions.into(),
+        places: Arc::new([]),
+        strings: Arc::new([]),
+        local_atoms: Arc::new([]),
+        param_drops: Arc::new([]),
+        borrow_slots: Arc::new([]),
+        num_locals: 0,
+        num_param_slots,
+        param_by_ref: vec![false; num_param_slots as usize].into(),
+        param_writable: vec![false; num_param_slots as usize].into(),
+        allow_unreachable_code: false,
+        warnings: Arc::new([]),
+        method_references: Arc::new([]),
+    })
+}
 
 fn plan_type_matches_live(
     planned: &IssuedTypeInstanceKey,
@@ -563,6 +773,52 @@ mod tests {
     use std::sync::Arc;
 
     use super::*;
+
+    #[test]
+    fn canonical_drop_glue_is_synthesized_from_exact_facts_and_layout_slots() {
+        let element = crate::TypeInstanceKey::BuiltinNominal {
+            kind: crate::AnonymousNominalKind::Struct,
+            name: Arc::from("Owned"),
+        };
+        let owner = crate::TypeInstanceKey::Array {
+            element: Box::new(element.clone()),
+            len: 3,
+        };
+        let facts = crate::type_queries::DropGlueFacts {
+            required: true,
+            synthesize: true,
+            destructor: None,
+            nested: Arc::from([element.clone()]),
+            plan: crate::type_queries::DropGluePlan::Array {
+                element: element.clone(),
+                len: 3,
+                drop_element: true,
+            },
+        };
+        let slots = std::collections::BTreeMap::from([(element, 2), (owner.clone(), 6)]);
+        let body = synthesize_canonical_drop_glue(&owner, &facts, &slots).unwrap();
+        assert_eq!(body.num_param_slots, 6);
+        assert_eq!(body.param_by_ref.as_ref(), &[false; 6]);
+        let params = body
+            .instructions
+            .iter()
+            .filter_map(|instruction| match instruction.data {
+                rue_air::SemanticBodyInstData::Param { index } => Some(index),
+                _ => None,
+            })
+            .collect::<Vec<_>>();
+        assert_eq!(params, [0, 2, 4]);
+        assert_eq!(
+            body.instructions
+                .iter()
+                .filter(|instruction| matches!(
+                    instruction.data,
+                    rue_air::SemanticBodyInstData::Drop { .. }
+                ))
+                .count(),
+            3
+        );
+    }
 
     fn test_type_identity(ty: Type, type_pool: &FrozenTypeInternPool) -> IssuedTypeInstanceKey {
         use rue_air::{AnonymousNominalKind as K, TypeInstanceKey as T, TypeKind};

--- a/crates/rue-compiler/src/durable_cfg.rs
+++ b/crates/rue-compiler/src/durable_cfg.rs
@@ -155,6 +155,43 @@ pub(crate) fn canonical_type_from_live(
     })
 }
 
+fn canonical_primitive(ty: Type) -> Option<CanonicalType> {
+    use rue_air::TypeKind as K;
+    Some(match ty.kind() {
+        K::I8 => CanonicalType::I8,
+        K::I16 => CanonicalType::I16,
+        K::I32 => CanonicalType::I32,
+        K::I64 => CanonicalType::I64,
+        K::U8 => CanonicalType::U8,
+        K::U16 => CanonicalType::U16,
+        K::U32 => CanonicalType::U32,
+        K::U64 => CanonicalType::U64,
+        K::Bool => CanonicalType::Bool,
+        K::Unit => CanonicalType::Unit,
+        K::Never => CanonicalType::Never,
+        K::ComptimeType => CanonicalType::ComptimeType,
+        _ => return None,
+    })
+}
+
+fn live_primitive(ty: &CanonicalType) -> Option<Type> {
+    Some(match ty {
+        CanonicalType::I8 => Type::I8,
+        CanonicalType::I16 => Type::I16,
+        CanonicalType::I32 => Type::I32,
+        CanonicalType::I64 => Type::I64,
+        CanonicalType::U8 => Type::U8,
+        CanonicalType::U16 => Type::U16,
+        CanonicalType::U32 => Type::U32,
+        CanonicalType::U64 => Type::U64,
+        CanonicalType::Bool => Type::BOOL,
+        CanonicalType::Unit => Type::UNIT,
+        CanonicalType::Never => Type::NEVER,
+        CanonicalType::ComptimeType => Type::COMPTIME_TYPE,
+        _ => return None,
+    })
+}
+
 fn deduplicate_type_mappings(
     mappings: Vec<(Type, CanonicalType)>,
 ) -> Result<Vec<(Type, CanonicalType)>, CfgDomainFailure> {
@@ -240,11 +277,6 @@ pub(crate) enum CfgDomainFailure {
 }
 
 impl CfgDomainProjection {
-    #[cfg(test)]
-    pub(crate) fn force_import_failure_for_test(&mut self) {
-        self.incomplete_epoch = Some(Arc::new(()));
-    }
-
     pub(crate) fn same_live_domain(&self, other: &Self) -> bool {
         let complete_or_same_epoch = match (&self.incomplete_epoch, &other.incomplete_epoch) {
             (None, None) => true,
@@ -258,20 +290,6 @@ impl CfgDomainProjection {
             && self.atoms == other.atoms
             && self.spans == other.spans
             && self.symbols == other.symbols
-    }
-
-    pub(crate) fn same_optimized_memo_domain(&self, other: &Self) -> bool {
-        match (&self.incomplete_epoch, &other.incomplete_epoch) {
-            (None, None) => true,
-            (Some(left), Some(right)) => Arc::ptr_eq(left, right),
-            _ => false,
-        }
-    }
-
-    pub(crate) fn optimized_memo_domain_hash(&self) -> usize {
-        self.incomplete_epoch
-            .as_ref()
-            .map_or(0, |epoch| Arc::as_ptr(epoch) as usize)
     }
 
     /// Build the relocation domain for one canonical analyzed function without
@@ -441,23 +459,76 @@ impl CfgDomainProjection {
         stable_type: impl Fn(Type) -> Result<CanonicalType, CfgDomainFailure>,
         stable_callable: impl Fn(lasso::Spur) -> Option<crate::FunctionInstanceKey>,
     ) -> Result<Self, CfgDomainFailure> {
-        if function.air.instructions().len() != body.instructions.len() {
+        Self::from_body_parts(
+            &function.air,
+            &function.identity,
+            &function.local_atoms,
+            stable_function,
+            body,
+            body_span,
+            strings,
+            type_pool,
+            interner,
+            stable_type,
+            stable_callable,
+        )
+    }
+
+    pub fn from_local_body(
+        materialization: &rue_air::SemanticLocalMaterialization<
+            crate::StableDefinitionKey,
+            crate::ModuleId,
+        >,
+        body: &rue_air::SemanticBody<crate::StableDefinitionKey, crate::ModuleId>,
+        stable_type: impl Fn(Type) -> Result<CanonicalType, CfgDomainFailure>,
+        stable_callable: impl Fn(lasso::Spur) -> Option<crate::FunctionInstanceKey>,
+    ) -> Result<Self, CfgDomainFailure> {
+        Self::from_body_parts(
+            &materialization.air,
+            &materialization.identity,
+            &materialization.local_atoms,
+            &materialization.identity,
+            body,
+            materialization.body_span,
+            &materialization.strings,
+            &materialization.type_pool,
+            &materialization.interner,
+            stable_type,
+            stable_callable,
+        )
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn from_body_parts<D: PartialEq, M: PartialEq>(
+        air: &rue_air::ValidatedAir,
+        current_identity: &rue_air::FunctionInstanceKey<D, M>,
+        local_atoms: &[rue_air::LocalAtomRecord<D, M>],
+        stable_function: &crate::FunctionInstanceKey,
+        body: &rue_air::SemanticBody<crate::StableDefinitionKey, crate::ModuleId>,
+        body_span: Span,
+        strings: &[String],
+        type_pool: &rue_air::FrozenTypeInternPool,
+        interner: &lasso::ThreadedRodeo,
+        stable_type: impl Fn(Type) -> Result<CanonicalType, CfgDomainFailure>,
+        stable_callable: impl Fn(lasso::Spur) -> Option<crate::FunctionInstanceKey>,
+    ) -> Result<Self, CfgDomainFailure> {
+        if air.instructions().len() != body.instructions.len() {
             return Err(CfgDomainFailure::Shape);
         }
         let mut types = vec![
-            (function.air.return_type(), body.return_type.clone()),
+            (air.return_type(), body.return_type.clone()),
+            (Type::I32, CanonicalType::I32),
             (Type::UNIT, CanonicalType::Unit),
         ];
         let mut stable_strings = Vec::new();
         let mut spans = Vec::new();
         let mut symbols = Vec::new();
-        if function.local_atoms.len() != body.local_atoms.len() {
+        if local_atoms.len() != body.local_atoms.len() {
             return Err(CfgDomainFailure::Shape);
         }
-        if function
-            .local_atoms
+        if local_atoms
             .iter()
-            .any(|atom| atom.identity.producer != function.identity)
+            .any(|atom| atom.identity.producer != *current_identity)
             || body
                 .local_atoms
                 .iter()
@@ -465,8 +536,7 @@ impl CfgDomainProjection {
         {
             return Err(CfgDomainFailure::Shape);
         }
-        let mut current_atoms = function
-            .local_atoms
+        let mut current_atoms = local_atoms
             .iter()
             .map(|atom| {
                 if strings.get(atom.dense_id as usize).map(String::as_str)
@@ -498,7 +568,7 @@ impl CfgDomainProjection {
         {
             return Err(CfgDomainFailure::Shape);
         }
-        for ((_, current), durable) in function.air.iter().zip(body.instructions.iter()) {
+        for ((_, current), durable) in air.iter().zip(body.instructions.iter()) {
             let current_kind = live_instruction_kind(&current.data);
             let durable_kind = durable.data.kind();
             if current_kind != durable_kind
@@ -588,7 +658,7 @@ impl CfgDomainProjection {
                     AirInstData::Match { arms, .. },
                     DurableAirInstData::Match { arms: stable, .. },
                 ) => {
-                    let current = function.air.get_match_arms(arms).collect::<Vec<_>>();
+                    let current = air.get_match_arms(arms).collect::<Vec<_>>();
                     if current.len() != stable.len() {
                         return Err(CfgDomainFailure::Shape);
                     }
@@ -610,9 +680,9 @@ impl CfgDomainProjection {
                 _ => return Err(CfgDomainFailure::Shape),
             }
         }
-        for (current, stable) in function.air.places().iter().zip(body.places.iter()) {
+        for (current, stable) in air.places().iter().zip(body.places.iter()) {
             types.push((current.base_type, stable.base_type.clone()));
-            let current_projections = function.air.get_place_projections(current);
+            let current_projections = air.get_place_projections(current);
             if current_projections.len() != stable.projections.len() {
                 return Err(CfgDomainFailure::Shape);
             }
@@ -632,14 +702,11 @@ impl CfgDomainProjection {
                 }
             }
         }
-        if function.air.param_drops().len() != body.param_drops.len() {
+        if air.param_drops().len() != body.param_drops.len() {
             return Err(CfgDomainFailure::Shape);
         }
-        for ((current_slot, current), (stable_slot, stable)) in function
-            .air
-            .param_drops()
-            .iter()
-            .zip(body.param_drops.iter())
+        for ((current_slot, current), (stable_slot, stable)) in
+            air.param_drops().iter().zip(body.param_drops.iter())
         {
             if current_slot != stable_slot {
                 return Err(CfgDomainFailure::Shape);
@@ -731,6 +798,9 @@ impl CfgDomainProjection {
     }
 
     fn stable_type(&self, value: Type) -> Result<CanonicalType, CfgDomainFailure> {
+        if let Some(stable) = canonical_primitive(value) {
+            return Ok(stable);
+        }
         self.types
             .iter()
             .find(|(current, _)| *current == value)
@@ -738,6 +808,9 @@ impl CfgDomainProjection {
             .ok_or(CfgDomainFailure::MissingLiveType(value))
     }
     fn current_type(&self, value: &CanonicalType) -> Result<Type, CfgDomainFailure> {
+        if let Some(current) = live_primitive(value) {
+            return Ok(current);
+        }
         self.types
             .iter()
             .find(|(_, stable)| stable == value)

--- a/crates/rue-compiler/src/local_semantic_materialization.rs
+++ b/crates/rue-compiler/src/local_semantic_materialization.rs
@@ -16,7 +16,6 @@ use crate::durable_semantics::{
 use crate::{FunctionInstanceKey, ModuleId, StableDefinitionKey, StableDefinitionKind};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-#[allow(dead_code)] // RUE-1215 installs this exact input at the CFG boundary.
 pub(crate) struct LocalCallableFact {
     pub(crate) identity: FunctionInstanceKey,
     pub(crate) symbol: Arc<str>,
@@ -26,13 +25,11 @@ pub(crate) struct LocalCallableFact {
 /// lookup/index fact. `None` is meaningful: every supplied named nominal has a
 /// record, so omission cannot silently strip compiler-recognized metadata.
 #[derive(Debug, Clone, PartialEq, Eq)]
-#[allow(dead_code)] // RUE-1215 installs this exact input at the CFG boundary.
 pub(crate) struct LocalNominalMetadataFact {
     identity: StableDefinitionKey,
     lang_item: Option<rue_air::LangItem>,
 }
 
-#[allow(dead_code)] // RUE-1215 supplies these facts from the CFG request.
 impl LocalNominalMetadataFact {
     pub(crate) fn new(identity: StableDefinitionKey, lang_item: Option<rue_air::LangItem>) -> Self {
         Self {
@@ -51,7 +48,35 @@ impl LocalNominalMetadataFact {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-#[allow(dead_code)] // RUE-1215 installs this exact failure at the CFG boundary.
+pub(crate) struct LocalMaterializationFacts {
+    pub(crate) declarations: Arc<[DurableDeclarationSemantic]>,
+    pub(crate) anonymous_nominals: Arc<[DurableAnonymousNominal]>,
+    pub(crate) callables: Arc<[LocalCallableFact]>,
+    pub(crate) nominal_metadata: Arc<[LocalNominalMetadataFact]>,
+    pub(crate) modules: Arc<[ModuleId]>,
+    pub(crate) builtin_nominals: Arc<[LocalBuiltinNominalRequest]>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub(crate) struct LocalBuiltinNominalRequest {
+    pub(crate) kind: crate::AnonymousNominalKind,
+    pub(crate) name: Arc<str>,
+    pub(crate) query_ty: crate::TypeInstanceKey,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct LocalBuiltinNominalFact {
+    pub(crate) request: LocalBuiltinNominalRequest,
+    pub(crate) facts: crate::type_queries::TypeFacts,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum LocalFactSelectionFailure {
+    MissingNamedNominal(StableDefinitionKey),
+    MissingAnonymousNominal(crate::AnonymousNominalKey),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) enum LocalMaterializationFailure {
     InvalidSpecializationIdentity,
     DuplicateNominalMetadata,
@@ -74,16 +99,44 @@ impl From<rue_air::SemanticBodyImportFailure> for LocalMaterializationFailure {
     }
 }
 
-#[allow(dead_code)] // RUE-1215 installs this exact result at the CFG boundary.
 pub(crate) type LocalSemanticMaterialization =
     rue_air::SemanticLocalMaterialization<StableDefinitionKey, ModuleId>;
+
+fn callable_kind_for_identity(identity: &FunctionInstanceKey) -> rue_air::AnalyzedCallableKind {
+    match identity {
+        FunctionInstanceKey::Definition(key) if key.kind() == StableDefinitionKind::Destructor => {
+            rue_air::AnalyzedCallableKind::Destructor
+        }
+        FunctionInstanceKey::Specialization { base, .. } => callable_kind_for_identity(base),
+        FunctionInstanceKey::AnonymousMember { member, .. }
+            if member.kind == crate::AnonymousMemberKind::Destructor =>
+        {
+            rue_air::AnalyzedCallableKind::Destructor
+        }
+        FunctionInstanceKey::DropGlue(_) => rue_air::AnalyzedCallableKind::DropGlue,
+        _ => rue_air::AnalyzedCallableKind::Ordinary,
+    }
+}
+
+fn fallback_callable_symbol(identity: &FunctionInstanceKey) -> Arc<str> {
+    if let Some(symbol) = crate::semantic_identity::anonymous_member_source_symbol(identity) {
+        return Arc::from(symbol);
+    }
+    let encoded = crate::StableSymbolEncoder::encode(&crate::StableSymbolId::Callable(
+        crate::StableCallableId::Function(identity.clone()),
+    ));
+    if callable_kind_for_identity(identity) == rue_air::AnalyzedCallableKind::Destructor {
+        Arc::from(format!("{encoded}.__drop"))
+    } else {
+        Arc::from(encoded)
+    }
+}
 
 /// Materialize one canonical body from exact query facts.
 ///
 /// The declaration and anonymous slices may contain only the facts required by
 /// this body. Missing transitive shapes/callables fail closed in `rue-air`;
 /// this adapter never widens the request by discovering a program universe.
-#[allow(dead_code)] // RUE-1215 installs this as the canonical CFG producer.
 pub(crate) fn materialize_canonical_body(
     canonical: &crate::body_query::CanonicalBody,
     body_span: rue_span::Span,
@@ -92,6 +145,7 @@ pub(crate) fn materialize_canonical_body(
     callable_facts: &[LocalCallableFact],
     nominal_metadata: &[LocalNominalMetadataFact],
     modules: &[ModuleId],
+    builtin_facts: &[LocalBuiltinNominalFact],
 ) -> Result<LocalSemanticMaterialization, LocalMaterializationFailure> {
     let (identity, body) = match canonical {
         crate::body_query::CanonicalBody::Ordinary { owner, body } => {
@@ -106,13 +160,32 @@ pub(crate) fn materialize_canonical_body(
             body,
         ),
     };
-    let callable_kind = match &identity {
-        FunctionInstanceKey::Definition(key) if key.kind() == StableDefinitionKind::Destructor => {
-            rue_air::AnalyzedCallableKind::Destructor
-        }
-        FunctionInstanceKey::DropGlue(_) => rue_air::AnalyzedCallableKind::DropGlue,
-        _ => rue_air::AnalyzedCallableKind::Ordinary,
-    };
+    materialize_semantic_body(
+        identity,
+        body,
+        body_span,
+        declarations,
+        anonymous_nominals,
+        callable_facts,
+        nominal_metadata,
+        modules,
+        builtin_facts,
+    )
+}
+
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn materialize_semantic_body(
+    identity: FunctionInstanceKey,
+    body: &rue_air::SemanticBody<StableDefinitionKey, ModuleId>,
+    body_span: rue_span::Span,
+    declarations: &[DurableDeclarationSemantic],
+    anonymous_nominals: &[DurableAnonymousNominal],
+    callable_facts: &[LocalCallableFact],
+    nominal_metadata: &[LocalNominalMetadataFact],
+    modules: &[ModuleId],
+    builtin_facts: &[LocalBuiltinNominalFact],
+) -> Result<LocalSemanticMaterialization, LocalMaterializationFailure> {
+    let callable_kind = callable_kind_for_identity(&identity);
 
     let mut destructors = std::collections::BTreeMap::new();
     for candidate in declarations {
@@ -240,6 +313,96 @@ pub(crate) fn materialize_canonical_body(
             shape,
         }
     }));
+    for fact in builtin_facts {
+        let identity_kind = fact.request.kind;
+        let name = fact.request.name.clone();
+        let (kind, shape) = match (&identity_kind, &fact.facts.shape, &fact.request.query_ty) {
+            (
+                crate::AnonymousNominalKind::Struct,
+                crate::type_queries::TypeShape::Struct { fields },
+                _,
+            ) => (
+                rue_air::SemanticImportNominalKind::Struct,
+                rue_air::SemanticLocalNominalShape::Struct {
+                    fields: fields
+                        .iter()
+                        .map(|(name, ty)| {
+                            (
+                                name.clone(),
+                                crate::drop_glue::semantic_type_from_instance(ty),
+                            )
+                        })
+                        .collect::<Vec<_>>()
+                        .into(),
+                    is_copy: fact.facts.is_copy,
+                    is_linear: fact.facts.carries_linear,
+                    destructor: fact.facts.destructor.clone(),
+                },
+            ),
+            (
+                crate::AnonymousNominalKind::Enum,
+                crate::type_queries::TypeShape::Enum { variants },
+                _,
+            ) => (
+                rue_air::SemanticImportNominalKind::Enum,
+                rue_air::SemanticLocalNominalShape::Enum {
+                    variants: variants
+                        .iter()
+                        .map(|(name, fields)| {
+                            (
+                                name.clone(),
+                                fields
+                                    .iter()
+                                    .map(crate::drop_glue::semantic_type_from_instance)
+                                    .collect::<Vec<_>>()
+                                    .into(),
+                            )
+                        })
+                        .collect::<Vec<_>>()
+                        .into(),
+                },
+            ),
+            (
+                crate::AnonymousNominalKind::Struct,
+                crate::type_queries::TypeShape::Slice,
+                crate::TypeInstanceKey::Slice { element, .. },
+            ) => (
+                rue_air::SemanticImportNominalKind::Struct,
+                rue_air::SemanticLocalNominalShape::Struct {
+                    fields: vec![
+                        (
+                            Arc::from("ptr"),
+                            rue_air::SemanticImportType::PtrConst(Box::new(
+                                crate::drop_glue::semantic_type_from_instance(element),
+                            )),
+                        ),
+                        (Arc::from("len"), rue_air::SemanticImportType::U64),
+                    ]
+                    .into(),
+                    is_copy: true,
+                    is_linear: false,
+                    destructor: None,
+                },
+            ),
+            _ => {
+                return Err(LocalMaterializationFailure::Import(
+                    rue_air::SemanticImportFailure::NominalKindMismatch,
+                ));
+            }
+        };
+        nominals.push(rue_air::SemanticLocalNominal {
+            key: rue_air::NominalInstanceKey::Builtin {
+                kind: identity_kind,
+                name: name.clone(),
+            },
+            module_path: Arc::from("<builtin>"),
+            name,
+            kind,
+            is_public: true,
+            lang_item: None,
+            shape,
+        });
+    }
     let callables = callable_facts
         .iter()
         .map(|fact| rue_air::SemanticLocalCallable {
@@ -249,6 +412,618 @@ pub(crate) fn materialize_canonical_body(
         .collect();
     let epoch = rue_air::SemanticImportEpoch::new_local(nominals, callables, modules.to_vec())?;
     Ok(epoch.materialize_local_body(identity, callable_kind, body, body_span)?)
+}
+
+/// Select the transitive nominal and callable closure needed to materialize one
+/// stable body. The returned value contains no whole-program collection: edits
+/// outside this closure cannot change CFG memo identity.
+pub(crate) fn select_materialization_facts(
+    identity: &FunctionInstanceKey,
+    body: &rue_air::SemanticBody<StableDefinitionKey, ModuleId>,
+    declarations: &[DurableDeclarationSemantic],
+    anonymous_nominals: &[DurableAnonymousNominal],
+    callable_symbols: &std::collections::BTreeMap<FunctionInstanceKey, Arc<str>>,
+) -> Result<LocalMaterializationFacts, LocalFactSelectionFailure> {
+    use rue_air::SemanticBodyInstDependency as Dependency;
+
+    struct Selection<'a> {
+        declarations:
+            std::collections::BTreeMap<StableDefinitionKey, &'a DurableDeclarationSemantic>,
+        destructors: std::collections::BTreeMap<
+            (ModuleId, StableDefinitionKind, Arc<str>),
+            &'a DurableDeclarationSemantic,
+        >,
+        anonymous:
+            std::collections::BTreeMap<crate::AnonymousNominalKey, &'a DurableAnonymousNominal>,
+        selected_declarations:
+            std::collections::BTreeMap<StableDefinitionKey, DurableDeclarationSemantic>,
+        selected_anonymous:
+            std::collections::BTreeMap<crate::AnonymousNominalKey, DurableAnonymousNominal>,
+        pending_nominals: Vec<crate::NominalInstanceKey>,
+        seen_nominals: std::collections::BTreeSet<crate::NominalInstanceKey>,
+        opaque_nominals: std::collections::BTreeSet<crate::NominalInstanceKey>,
+        callables: std::collections::BTreeSet<FunctionInstanceKey>,
+        modules: std::collections::BTreeSet<ModuleId>,
+        builtins: std::collections::BTreeSet<LocalBuiltinNominalRequest>,
+        slice_sources: std::collections::BTreeMap<Arc<str>, crate::TypeInstanceKey>,
+    }
+
+    impl Selection<'_> {
+        fn builtin(&mut self, kind: crate::AnonymousNominalKind, name: &Arc<str>) {
+            // The local semantic epoch owns the canonical fixed builtins and
+            // lazily materializes fixed-capacity strings. Supplying query
+            // facts for either would shadow that canonical registry. Only
+            // synthetic builtin-shaped values such as slice views need an
+            // exact fact request here.
+            if name.as_ref() == "str"
+                || rue_builtins::get_builtin_enum(name).is_some()
+                || name
+                    .strip_prefix("Str(")
+                    .and_then(|name| name.strip_suffix(')'))
+                    .and_then(|capacity| capacity.parse::<u64>().ok())
+                    .is_some()
+            {
+                return;
+            }
+            let query_ty = self.slice_sources.get(name).cloned().unwrap_or_else(|| {
+                crate::TypeInstanceKey::BuiltinNominal {
+                    kind,
+                    name: name.clone(),
+                }
+            });
+            self.builtins.insert(LocalBuiltinNominalRequest {
+                kind,
+                name: name.clone(),
+                query_ty,
+            });
+        }
+
+        fn semantic_type(&mut self, ty: &crate::durable_semantics::DurableType) {
+            use rue_air::SemanticImportType as T;
+            match ty {
+                T::Nominal(key) => self.nominal(&crate::NominalInstanceKey::Named(key.clone())),
+                T::AnonymousNominal(key) => {
+                    self.nominal(&crate::NominalInstanceKey::Anonymous(key.clone()))
+                }
+                T::BuiltinNominal { kind, name } => {
+                    self.builtin(
+                        match kind {
+                            rue_air::SemanticImportNominalKind::Struct => {
+                                crate::AnonymousNominalKind::Struct
+                            }
+                            rue_air::SemanticImportNominalKind::Enum => {
+                                crate::AnonymousNominalKind::Enum
+                            }
+                        },
+                        name,
+                    );
+                }
+                T::Array { element, .. } => self.semantic_type(element),
+                T::PtrConst(element) | T::PtrMut(element) | T::Slice { element, .. } => {
+                    self.opaque_semantic_type(element)
+                }
+                T::Module(module) => {
+                    self.modules.insert(module.clone());
+                }
+                _ => {}
+            }
+        }
+
+        fn opaque_semantic_type(&mut self, ty: &crate::durable_semantics::DurableType) {
+            use rue_air::SemanticImportType as T;
+            match ty {
+                T::Nominal(key) => {
+                    self.opaque_nominals
+                        .insert(crate::NominalInstanceKey::Named(key.clone()));
+                }
+                T::AnonymousNominal(key) => {
+                    self.opaque_nominals
+                        .insert(crate::NominalInstanceKey::Anonymous(key.clone()));
+                }
+                T::BuiltinNominal { kind, name } => {
+                    self.builtin(
+                        match kind {
+                            rue_air::SemanticImportNominalKind::Struct => {
+                                crate::AnonymousNominalKind::Struct
+                            }
+                            rue_air::SemanticImportNominalKind::Enum => {
+                                crate::AnonymousNominalKind::Enum
+                            }
+                        },
+                        name,
+                    );
+                }
+                T::Array { element, .. }
+                | T::PtrConst(element)
+                | T::PtrMut(element)
+                | T::Slice { element, .. } => self.opaque_semantic_type(element),
+                T::Module(module) => {
+                    self.modules.insert(module.clone());
+                }
+                _ => {}
+            }
+        }
+
+        fn nominal(&mut self, nominal: &crate::NominalInstanceKey) {
+            if self.seen_nominals.insert(nominal.clone()) {
+                self.pending_nominals.push(nominal.clone());
+            }
+        }
+
+        fn instance_type(&mut self, ty: &crate::TypeInstanceKey) {
+            use crate::TypeInstanceKey as T;
+            match ty {
+                T::BuiltinNominal { kind, name } => {
+                    self.builtin(*kind, name);
+                }
+                T::I8
+                | T::I16
+                | T::I32
+                | T::I64
+                | T::U8
+                | T::U16
+                | T::U32
+                | T::U64
+                | T::Bool
+                | T::Unit
+                | T::Never
+                | T::ComptimeType
+                | T::GenericParameter(_) => {}
+                T::Nominal(crate::NominalInstanceKey::Builtin { kind, name }) => {
+                    self.builtin(*kind, name);
+                }
+                T::Nominal(nominal) => self.nominal(nominal),
+                T::Array { element, .. } => self.instance_type(element),
+                T::Slice { element, .. } | T::PtrConst(element) | T::PtrMut(element) => {
+                    self.opaque_instance_type(element)
+                }
+                T::Module(module) => {
+                    self.modules.insert(module.clone());
+                }
+            }
+        }
+
+        fn opaque_instance_type(&mut self, ty: &crate::TypeInstanceKey) {
+            use crate::TypeInstanceKey as T;
+            match ty {
+                T::BuiltinNominal { kind, name }
+                | T::Nominal(crate::NominalInstanceKey::Builtin { kind, name }) => {
+                    self.builtin(*kind, name);
+                }
+                T::Nominal(nominal) => {
+                    self.opaque_nominals.insert(nominal.clone());
+                }
+                T::Array { element, .. }
+                | T::Slice { element, .. }
+                | T::PtrConst(element)
+                | T::PtrMut(element) => self.opaque_instance_type(element),
+                T::Module(module) => {
+                    self.modules.insert(module.clone());
+                }
+                _ => {}
+            }
+        }
+
+        fn arguments(&mut self, arguments: &crate::CanonicalArguments) {
+            for ty in arguments.types.iter() {
+                self.instance_type(ty);
+            }
+            for value in arguments.values.iter() {
+                match value {
+                    crate::CanonicalArgumentValue::Type(ty) => self.instance_type(ty),
+                    crate::CanonicalArgumentValue::Function(function) => self.callable(function),
+                    crate::CanonicalArgumentValue::Integer(_)
+                    | crate::CanonicalArgumentValue::Bool(_)
+                    | crate::CanonicalArgumentValue::Unit
+                    | crate::CanonicalArgumentValue::String(_) => {}
+                }
+            }
+        }
+
+        fn callable(&mut self, callable: &FunctionInstanceKey) {
+            if !self.callables.insert(callable.clone()) {
+                return;
+            }
+            match callable {
+                FunctionInstanceKey::Definition(definition) => {
+                    self.modules.insert(definition.module().clone());
+                }
+                FunctionInstanceKey::Specialization { base, arguments } => {
+                    if let FunctionInstanceKey::Definition(definition) = base.as_ref() {
+                        self.modules.insert(definition.module().clone());
+                    }
+                    self.arguments(arguments);
+                }
+                FunctionInstanceKey::AnonymousMember { owner, .. }
+                | FunctionInstanceKey::DropGlue(owner) => self.instance_type(owner),
+            }
+        }
+
+        fn finish_nominals(&mut self) -> Result<(), LocalFactSelectionFailure> {
+            while let Some(nominal) = self.pending_nominals.pop() {
+                match nominal {
+                    crate::NominalInstanceKey::Builtin { .. } => {}
+                    crate::NominalInstanceKey::Named(key) => {
+                        let declaration = self
+                            .declarations
+                            .get(&key)
+                            .copied()
+                            .cloned()
+                            .ok_or_else(|| {
+                                LocalFactSelectionFailure::MissingNamedNominal(key.clone())
+                            })?;
+                        self.modules.insert(key.module().clone());
+                        self.selected_declarations
+                            .insert(key.clone(), declaration.clone());
+                        match &declaration.payload {
+                            DurableDeclarationPayload::Struct { fields, .. } => {
+                                for (_, ty) in fields.iter() {
+                                    self.semantic_type(ty);
+                                }
+                                let owner = (
+                                    key.module().clone(),
+                                    key.kind(),
+                                    Arc::<str>::from(key.name()),
+                                );
+                                if let Some(destructor) =
+                                    self.destructors.get(&owner).copied().cloned()
+                                {
+                                    self.selected_declarations
+                                        .insert(destructor.key.clone(), destructor.clone());
+                                    self.callable(&FunctionInstanceKey::Definition(
+                                        destructor.key.clone(),
+                                    ));
+                                }
+                            }
+                            DurableDeclarationPayload::Enum { variants } => {
+                                for (_, fields) in variants.iter() {
+                                    for ty in fields.iter() {
+                                        self.semantic_type(ty);
+                                    }
+                                }
+                            }
+                            _ => {}
+                        }
+                    }
+                    crate::NominalInstanceKey::Anonymous(key) => {
+                        let nominal =
+                            self.anonymous.get(&key).copied().cloned().ok_or_else(|| {
+                                LocalFactSelectionFailure::MissingAnonymousNominal(key.clone())
+                            })?;
+                        self.selected_anonymous.insert(key.clone(), nominal.clone());
+                        for (_, ty) in nominal.type_captures.iter() {
+                            self.semantic_type(ty);
+                        }
+                        match &nominal.shape {
+                            DurableAnonymousNominalShape::Struct { fields, methods } => {
+                                for (_, ty) in fields.iter() {
+                                    self.semantic_type(ty);
+                                }
+                                for method in methods.iter() {
+                                    for (ty, _, _) in method.parameters.iter() {
+                                        if let crate::durable_semantics::DurableAnonymousMethodType::Concrete(ty) = ty {
+                                            self.semantic_type(ty);
+                                        }
+                                    }
+                                    if let crate::durable_semantics::DurableAnonymousMethodType::Concrete(ty) = &method.result {
+                                        self.semantic_type(ty);
+                                    }
+                                    if method.has_self && method.name.as_ref() == "__drop" {
+                                        self.callable(&FunctionInstanceKey::AnonymousMember {
+                                            owner: Box::new(crate::TypeInstanceKey::Nominal(
+                                                crate::NominalInstanceKey::Anonymous(key.clone()),
+                                            )),
+                                            member: crate::AnonymousMemberKey {
+                                                kind: crate::AnonymousMemberKind::Destructor,
+                                                name: Arc::from("__drop"),
+                                            },
+                                        });
+                                    }
+                                }
+                            }
+                            DurableAnonymousNominalShape::Enum { variants } => {
+                                for (_, fields) in variants.iter() {
+                                    for ty in fields.iter() {
+                                        self.semantic_type(ty);
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+            for nominal in std::mem::take(&mut self.opaque_nominals) {
+                if self.seen_nominals.contains(&nominal) {
+                    continue;
+                }
+                match nominal {
+                    crate::NominalInstanceKey::Builtin { .. } => {}
+                    crate::NominalInstanceKey::Named(key) => {
+                        let declaration =
+                            self.declarations.get(&key).copied().ok_or_else(|| {
+                                LocalFactSelectionFailure::MissingNamedNominal(key.clone())
+                            })?;
+                        let payload = match declaration.payload {
+                            DurableDeclarationPayload::Struct { .. } => {
+                                DurableDeclarationPayload::Struct {
+                                    fields: Arc::new([]),
+                                    is_copy: false,
+                                    is_linear: false,
+                                }
+                            }
+                            DurableDeclarationPayload::Enum { .. } => {
+                                DurableDeclarationPayload::Enum {
+                                    variants: Arc::new([]),
+                                }
+                            }
+                            _ => continue,
+                        };
+                        self.modules.insert(key.module().clone());
+                        self.selected_declarations.insert(
+                            key.clone(),
+                            DurableDeclarationSemantic {
+                                key,
+                                is_public: false,
+                                payload,
+                            },
+                        );
+                    }
+                    crate::NominalInstanceKey::Anonymous(key) => {
+                        let nominal = self.anonymous.get(&key).copied().ok_or_else(|| {
+                            LocalFactSelectionFailure::MissingAnonymousNominal(key.clone())
+                        })?;
+                        let shape = match nominal.shape {
+                            DurableAnonymousNominalShape::Struct { .. } => {
+                                DurableAnonymousNominalShape::Struct {
+                                    fields: Arc::new([]),
+                                    methods: Arc::new([]),
+                                }
+                            }
+                            DurableAnonymousNominalShape::Enum { .. } => {
+                                DurableAnonymousNominalShape::Enum {
+                                    variants: Arc::new([]),
+                                }
+                            }
+                        };
+                        self.selected_anonymous.insert(
+                            key,
+                            DurableAnonymousNominal {
+                                identity: nominal.identity.clone(),
+                                shape,
+                                type_captures: nominal.type_captures.clone(),
+                                value_captures: nominal.value_captures.clone(),
+                            },
+                        );
+                    }
+                }
+            }
+            Ok(())
+        }
+    }
+
+    fn collect_slice_sources(
+        ty: &crate::durable_semantics::DurableType,
+        output: &mut std::collections::BTreeMap<Arc<str>, crate::TypeInstanceKey>,
+    ) {
+        use rue_air::SemanticImportType as T;
+        match ty {
+            T::Slice { element, name } => {
+                if let Some(element) =
+                    crate::semantic_identity::type_instance_from_semantic(element)
+                {
+                    output.insert(
+                        name.clone(),
+                        crate::TypeInstanceKey::Slice {
+                            element: Box::new(element),
+                            name: name.clone(),
+                        },
+                    );
+                }
+                collect_slice_sources(element, output);
+            }
+            T::Array { element, .. } | T::PtrConst(element) | T::PtrMut(element) => {
+                collect_slice_sources(element, output)
+            }
+            _ => {}
+        }
+    }
+    let mut slice_sources = std::collections::BTreeMap::new();
+    for declaration in declarations {
+        match &declaration.payload {
+            DurableDeclarationPayload::Callable {
+                parameters, result, ..
+            } => {
+                for parameter in parameters.iter() {
+                    collect_slice_sources(&parameter.ty, &mut slice_sources);
+                }
+                collect_slice_sources(result, &mut slice_sources);
+            }
+            DurableDeclarationPayload::Struct { fields, .. } => {
+                for (_, ty) in fields.iter() {
+                    collect_slice_sources(ty, &mut slice_sources);
+                }
+            }
+            DurableDeclarationPayload::Enum { variants } => {
+                for (_, fields) in variants.iter() {
+                    for ty in fields.iter() {
+                        collect_slice_sources(ty, &mut slice_sources);
+                    }
+                }
+            }
+            DurableDeclarationPayload::Const { ty, .. } => {
+                collect_slice_sources(ty, &mut slice_sources);
+            }
+            _ => {}
+        }
+    }
+    let mut destructors = std::collections::BTreeMap::new();
+    let declaration_index = declarations
+        .iter()
+        .map(|declaration| (declaration.key.clone(), declaration))
+        .collect();
+    for declaration in declarations {
+        if matches!(declaration.payload, DurableDeclarationPayload::Destructor)
+            && let Some(owner) = declaration.key.owner()
+        {
+            destructors.insert(
+                (
+                    owner.module().clone(),
+                    owner.kind(),
+                    Arc::<str>::from(owner.name()),
+                ),
+                declaration,
+            );
+        }
+    }
+    let mut selection = Selection {
+        declarations: declaration_index,
+        destructors,
+        anonymous: anonymous_nominals
+            .iter()
+            .map(|nominal| (nominal.identity.clone(), nominal))
+            .collect(),
+        selected_declarations: std::collections::BTreeMap::new(),
+        selected_anonymous: std::collections::BTreeMap::new(),
+        pending_nominals: Vec::new(),
+        seen_nominals: std::collections::BTreeSet::new(),
+        opaque_nominals: std::collections::BTreeSet::new(),
+        callables: std::collections::BTreeSet::new(),
+        modules: std::collections::BTreeSet::new(),
+        builtins: std::collections::BTreeSet::new(),
+        slice_sources,
+    };
+    selection.callable(identity);
+    selection.semantic_type(&body.return_type);
+    for instruction in body.instructions.iter() {
+        selection.semantic_type(&instruction.ty);
+        if let rue_air::SemanticBodyInstData::CallSpecialized { identity, .. } = &instruction.data
+            && let Some(callable) =
+                crate::semantic_identity::function_instance_from_specialization(identity)
+        {
+            selection.callable(&callable);
+        }
+        instruction
+            .data
+            .visit_dependencies(&mut |dependency| match dependency {
+                Dependency::Definition(definition) => {
+                    selection.modules.insert(definition.module().clone());
+                }
+                Dependency::Nominal(nominal) => selection.nominal(nominal),
+                Dependency::Function(function) => selection.callable(function),
+                Dependency::Type(ty) => selection.semantic_type(ty),
+                Dependency::Instruction(_) | Dependency::Place(_) | Dependency::String(_) => {}
+            });
+    }
+    for place in body.places.iter() {
+        selection.semantic_type(&place.base_type);
+        for projection in place.projections.iter() {
+            match projection {
+                rue_air::SemanticBodyProjection::Field { struct_key, .. } => {
+                    selection.nominal(struct_key)
+                }
+                rue_air::SemanticBodyProjection::Index { array_type, .. } => {
+                    selection.semantic_type(array_type)
+                }
+            }
+        }
+    }
+    for (_, ty) in body.param_drops.iter() {
+        selection.semantic_type(ty);
+    }
+    for reference in body.method_references.iter() {
+        selection.nominal(&reference.receiver);
+    }
+    selection.finish_nominals()?;
+
+    let callables = selection
+        .callables
+        .into_iter()
+        .map(|identity| {
+            let symbol = callable_symbols
+                .get(&identity)
+                .cloned()
+                .unwrap_or_else(|| fallback_callable_symbol(&identity));
+            Ok(LocalCallableFact { identity, symbol })
+        })
+        .collect::<Result<Vec<_>, _>>()?;
+    let nominal_metadata = selection
+        .selected_declarations
+        .values()
+        .filter(|declaration| {
+            matches!(
+                declaration.payload,
+                DurableDeclarationPayload::Struct { .. } | DurableDeclarationPayload::Enum { .. }
+            )
+        })
+        .map(|declaration| {
+            let lang_item = (declaration.key.kind() == StableDefinitionKind::Struct
+                && declaration.key.module().is_trusted_standard_library())
+            .then(|| {
+                rue_air::LangItem::from_standard_library_nominal(
+                    declaration.key.module().as_str(),
+                    declaration.key.name(),
+                )
+            })
+            .flatten();
+            LocalNominalMetadataFact::new(declaration.key.clone(), lang_item)
+        })
+        .collect::<Vec<_>>();
+    Ok(LocalMaterializationFacts {
+        declarations: selection
+            .selected_declarations
+            .into_values()
+            .collect::<Vec<_>>()
+            .into(),
+        anonymous_nominals: selection
+            .selected_anonymous
+            .into_values()
+            .collect::<Vec<_>>()
+            .into(),
+        callables: callables.into(),
+        nominal_metadata: nominal_metadata.into(),
+        modules: selection.modules.into_iter().collect::<Vec<_>>().into(),
+        builtin_nominals: selection.builtins.into_iter().collect::<Vec<_>>().into(),
+    })
+}
+
+pub(crate) fn select_drop_glue_materialization_facts(
+    owner: &crate::TypeInstanceKey,
+    facts: &crate::type_queries::DropGlueFacts,
+    declarations: &[DurableDeclarationSemantic],
+    anonymous_nominals: &[DurableAnonymousNominal],
+    callable_symbols: &std::collections::BTreeMap<FunctionInstanceKey, Arc<str>>,
+) -> Result<LocalMaterializationFacts, LocalFactSelectionFailure> {
+    let identity = FunctionInstanceKey::DropGlue(Box::new(owner.clone()));
+    let mut roots = vec![(0, crate::drop_glue::semantic_type_from_instance(owner))];
+    roots.extend(facts.nested.iter().enumerate().map(|(index, ty)| {
+        (
+            u32::try_from(index + 1).expect("drop-glue fact count fits u32"),
+            crate::drop_glue::semantic_type_from_instance(ty),
+        )
+    }));
+    let body = rue_air::SemanticBody {
+        return_type: rue_air::SemanticImportType::Unit,
+        instructions: Arc::new([]),
+        places: Arc::new([]),
+        strings: Arc::new([]),
+        local_atoms: Arc::new([]),
+        param_drops: roots.into(),
+        borrow_slots: Arc::new([]),
+        num_locals: 0,
+        num_param_slots: 0,
+        param_by_ref: Arc::new([]),
+        param_writable: Arc::new([]),
+        allow_unreachable_code: false,
+        warnings: Arc::new([]),
+        method_references: Arc::new([]),
+    };
+    select_materialization_facts(
+        &identity,
+        &body,
+        declarations,
+        anonymous_nominals,
+        callable_symbols,
+    )
 }
 
 #[cfg(test)]
@@ -331,6 +1106,7 @@ mod tests {
                 }],
                 &[],
                 std::slice::from_ref(&module),
+                &[],
             )
             .err(),
             Some(LocalMaterializationFailure::MissingNominalMetadata)
@@ -349,6 +1125,7 @@ mod tests {
                 Some(rue_air::LangItem::StrBuf),
             )],
             std::slice::from_ref(&module),
+            &[],
         )
         .unwrap();
         let ty = output
@@ -419,9 +1196,103 @@ mod tests {
             }],
             &[LocalNominalMetadataFact::new(record, None)],
             &[module],
+            &[],
         )
         .err()
         .expect("duplicate destructor records must not select the first");
         assert_eq!(error, LocalMaterializationFailure::AmbiguousNamedDestructor);
+    }
+
+    #[test]
+    fn fallback_destructor_symbol_satisfies_the_source_naming_contract() {
+        let module = ModuleId::from_validated_canonical("main.rue");
+        let function = definition(
+            module.clone(),
+            StableDefinitionKind::Function,
+            "probe",
+            None,
+        );
+        let record = definition(module.clone(), StableDefinitionKind::Struct, "Record", None);
+        let destructor = definition(
+            module.clone(),
+            StableDefinitionKind::Destructor,
+            "Record",
+            Some((StableDefinitionKind::Struct, Arc::from("Record"))),
+        );
+        let declarations = vec![
+            DurableDeclarationSemantic {
+                key: record.clone(),
+                is_public: false,
+                payload: DurableDeclarationPayload::Struct {
+                    fields: Arc::new([]),
+                    is_copy: false,
+                    is_linear: false,
+                },
+            },
+            DurableDeclarationSemantic {
+                key: destructor.clone(),
+                is_public: false,
+                payload: DurableDeclarationPayload::Destructor,
+            },
+        ];
+        let mut selection_body = body();
+        selection_body.return_type = rue_air::SemanticImportType::Nominal(record);
+        let facts = select_materialization_facts(
+            &FunctionInstanceKey::Definition(function.clone()),
+            &selection_body,
+            &declarations,
+            &[],
+            &std::collections::BTreeMap::from([(
+                FunctionInstanceKey::Definition(function.clone()),
+                Arc::from("probe"),
+            )]),
+        )
+        .unwrap();
+
+        let destructor_symbol = facts
+            .callables
+            .iter()
+            .find(|fact| fact.identity == FunctionInstanceKey::Definition(destructor.clone()))
+            .expect("the selected nominal contributes its destructor callable")
+            .symbol
+            .as_ref();
+        assert!(destructor_symbol.ends_with(".__drop"));
+
+        materialize_canonical_body(
+            &crate::body_query::CanonicalBody::Ordinary {
+                owner: function,
+                body: body(),
+            },
+            rue_span::Span::with_file(rue_span::FileId::new(3), 100, 200),
+            &facts.declarations,
+            &facts.anonymous_nominals,
+            &facts.callables,
+            &facts.nominal_metadata,
+            &facts.modules,
+            &[],
+        )
+        .expect("fallback destructor symbols materialize without violating AIR invariants");
+    }
+
+    #[test]
+    fn anonymous_destructor_instances_keep_the_cleanup_callable_kind() {
+        let destructor = FunctionInstanceKey::AnonymousMember {
+            owner: Box::new(crate::TypeInstanceKey::I32),
+            member: crate::AnonymousMemberKey {
+                kind: crate::AnonymousMemberKind::Destructor,
+                name: Arc::from("__drop"),
+            },
+        };
+        assert_eq!(
+            callable_kind_for_identity(&destructor),
+            rue_air::AnalyzedCallableKind::Destructor
+        );
+        assert_eq!(
+            callable_kind_for_identity(&FunctionInstanceKey::Specialization {
+                base: Box::new(destructor),
+                arguments: crate::CanonicalArguments::default(),
+            }),
+            rue_air::AnalyzedCallableKind::Destructor
+        );
     }
 }

--- a/crates/rue-compiler/src/queries.rs
+++ b/crates/rue-compiler/src/queries.rs
@@ -194,6 +194,8 @@ pub(crate) fn collect_function_cfg_queries(
     opt_level: OptLevel,
     interner: std::sync::Arc<ThreadedRodeo>,
     stable_inputs: &[crate::cfg_query::CfgBodyInput],
+    durable_declarations: &[crate::durable_semantics::DurableDeclarationSemantic],
+    durable_anonymous_nominals: &[crate::durable_semantics::DurableAnonymousNominal],
     stable_aggregate_types: std::collections::HashMap<Type, crate::TypeInstanceKey>,
     projected_identities: &std::collections::BTreeMap<
         rue_air::FunctionInstanceKey<
@@ -238,6 +240,102 @@ pub(crate) fn collect_function_cfg_queries(
             .count(),
         ..Default::default()
     };
+    // AIR's active-aggregate index contains types named directly by reached
+    // bodies and demanded glue. CFG cleanup closes that domain transitively
+    // over aggregate fields, so join completed pool entries back to their
+    // durable nominal identities before projecting a current body.
+    let mut stable_aggregate_types = stable_aggregate_types;
+    let mut stable_types_by_symbol = std::collections::BTreeMap::new();
+    for nominal in durable_anonymous_nominals {
+        let symbol = crate::semantic_identity::anonymous_nominal_source_symbol(&nominal.identity);
+        let stable = crate::TypeInstanceKey::Nominal(crate::NominalInstanceKey::Anonymous(
+            nominal.identity.clone(),
+        ));
+        let candidate = (nominal.identity.kind, stable);
+        if let Some(previous) = stable_types_by_symbol.insert(symbol.clone(), candidate.clone())
+            && previous != candidate
+        {
+            return Err(CfgConstructionFailure {
+                errors: CompileError::without_span(ErrorKind::InternalError(format!(
+                    "aggregate symbol '{symbol}' has conflicting stable identities"
+                )))
+                .into(),
+                work,
+            });
+        }
+    }
+    for declaration in durable_declarations {
+        let kind = match &declaration.payload {
+            crate::durable_semantics::DurableDeclarationPayload::Struct { .. } => {
+                crate::AnonymousNominalKind::Struct
+            }
+            crate::durable_semantics::DurableDeclarationPayload::Enum { .. } => {
+                crate::AnonymousNominalKind::Enum
+            }
+            _ => continue,
+        };
+        let Some(symbol) = crate::semantic_identity::named_nominal_source_symbol(&declaration.key)
+        else {
+            unreachable!("struct and enum declarations have nominal source symbols")
+        };
+        let stable = crate::TypeInstanceKey::Nominal(crate::NominalInstanceKey::Named(
+            declaration.key.clone(),
+        ));
+        let candidate = (kind, stable);
+        if let Some(previous) = stable_types_by_symbol.insert(symbol.clone(), candidate.clone())
+            && previous != candidate
+        {
+            return Err(CfgConstructionFailure {
+                errors: CompileError::without_span(ErrorKind::InternalError(format!(
+                    "aggregate symbol '{symbol}' has conflicting stable identities"
+                )))
+                .into(),
+                work,
+            });
+        }
+    }
+    let live_nominal_types = type_pool
+        .all_struct_ids()
+        .map(|id| {
+            (
+                Type::new_struct(id),
+                type_pool.struct_symbol_name(id),
+                crate::AnonymousNominalKind::Struct,
+            )
+        })
+        .chain(type_pool.all_enum_ids().map(|id| {
+            (
+                Type::new_enum(id),
+                type_pool.enum_symbol_name(id),
+                crate::AnonymousNominalKind::Enum,
+            )
+        }))
+        .collect::<Vec<_>>();
+    for (live, symbol, live_kind) in live_nominal_types {
+        let Some((stable_kind, stable)) = stable_types_by_symbol.get(&symbol).cloned() else {
+            continue;
+        };
+        if stable_kind != live_kind {
+            return Err(CfgConstructionFailure {
+                errors: CompileError::without_span(ErrorKind::InternalError(format!(
+                    "aggregate symbol '{symbol}' has conflicting live and stable kinds"
+                )))
+                .into(),
+                work,
+            });
+        }
+        if let Some(previous) = stable_aggregate_types.insert(live, stable.clone())
+            && previous != stable
+        {
+            return Err(CfgConstructionFailure {
+                errors: CompileError::without_span(ErrorKind::InternalError(format!(
+                    "live aggregate {live:?} has conflicting stable identities"
+                )))
+                .into(),
+                work,
+            });
+        }
+    }
 
     // Combine user functions with drop glue, filtering out comptime-only functions.
     let mut all_functions: Vec<_> = functions
@@ -356,6 +454,42 @@ pub(crate) fn collect_function_cfg_queries(
             machine_name,
         ));
     }
+    // Cleanup closure discovery may encounter an anonymous destructor whose
+    // body was not otherwise reached. Its source symbol is still a stable
+    // function reference and must relocate through the owner identity rather
+    // than depending on membership in `all_functions`.
+    for (live, stable) in &stable_aggregate_types {
+        let TypeKind::Struct(id) = live.kind() else {
+            continue;
+        };
+        let Some(source_symbol) = type_pool.struct_def(id).destructor.as_ref() else {
+            continue;
+        };
+        let crate::TypeInstanceKey::Nominal(crate::NominalInstanceKey::Anonymous(owner)) = stable
+        else {
+            continue;
+        };
+        let identity = crate::FunctionInstanceKey::AnonymousMember {
+            owner: Box::new(crate::TypeInstanceKey::Nominal(
+                crate::NominalInstanceKey::Anonymous(owner.clone()),
+            )),
+            member: crate::AnonymousMemberKey {
+                kind: crate::AnonymousMemberKind::Destructor,
+                name: std::sync::Arc::from("__drop"),
+            },
+        };
+        if let Some(previous) = legacy_to_stable.insert(source_symbol.clone(), identity.clone())
+            && previous != identity
+        {
+            return Err(CfgConstructionFailure {
+                errors: CompileError::without_span(ErrorKind::InternalError(format!(
+                    "live anonymous destructor symbol '{source_symbol}' has conflicting identities"
+                )))
+                .into(),
+                work,
+            });
+        }
+    }
     // AIR and CFG remain source-semantic artifacts. Their live call names are
     // resolved through `legacy_to_machine` only at the codegen boundary; this
     // keeps presentation and durable CFG reuse independent of interner slots.
@@ -364,6 +498,15 @@ pub(crate) fn collect_function_cfg_queries(
     // linker layout. Machine symbols are the stable semantic
     // identity shared by user, specialized, destructor, and glue functions.
     all_functions.sort_by(|left, right| left.4.cmp(&right.4));
+    let callable_symbols = all_functions
+        .iter()
+        .map(|(function, identity, _, _, _)| {
+            (
+                identity.clone(),
+                std::sync::Arc::<str>::from(function.name.as_str()),
+            )
+        })
+        .collect::<std::collections::BTreeMap<_, _>>();
 
     let _span = info_span!("cfg_collection", phase = "cfg_query_collection").entered();
     let aggregate_types = std::sync::Arc::new(stable_aggregate_types);
@@ -396,9 +539,34 @@ pub(crate) fn collect_function_cfg_queries(
                     ));
                 };
                 let semantic_input = if let Some(input) = current_input {
-                    crate::cfg_query::CfgSemanticInput::Body(std::sync::Arc::new(
-                        input.body.clone(),
-                    ))
+                    let body = match input.canonical.as_ref() {
+                        crate::body_query::CanonicalBody::Ordinary { body, .. }
+                        | crate::body_query::CanonicalBody::Anonymous { body, .. }
+                        | crate::body_query::CanonicalBody::Specialization { body, .. } => body,
+                    };
+                    let materialization = crate::local_semantic_materialization::select_materialization_facts(
+                        &semantic_identity,
+                        body,
+                        durable_declarations,
+                        durable_anonymous_nominals,
+                        &callable_symbols,
+                    )
+                    .map_err(|error| {
+                        (
+                            CompileError::new(
+                                ErrorKind::InternalError(format!(
+                                    "CFG materialization fact selection failed: {error:?}"
+                                )),
+                                body_span,
+                            )
+                            .into(),
+                            canonical_semantic::CfgConstructionWork::default(),
+                        )
+                    })?;
+                    crate::cfg_query::CfgSemanticInput::Body {
+                        input: std::sync::Arc::new(input.clone()),
+                        materialization: std::sync::Arc::new(materialization),
+                    }
                 } else if let crate::FunctionInstanceKey::DropGlue(owner) = &semantic_identity {
                     let Some(facts) = stable_drop_glue_plans.get(owner.as_ref()) else {
                         return Err((
@@ -410,9 +578,30 @@ pub(crate) fn collect_function_cfg_queries(
                             canonical_semantic::CfgConstructionWork::default(),
                         ));
                     };
+                    let materialization = crate::local_semantic_materialization::select_drop_glue_materialization_facts(
+                        owner,
+                        facts,
+                        durable_declarations,
+                        durable_anonymous_nominals,
+                        &callable_symbols,
+                    )
+                    .map_err(|error| {
+                        (
+                            CompileError::new(
+                                ErrorKind::InternalError(format!(
+                                    "drop-glue materialization fact selection failed: {error:?}"
+                                )),
+                                body_span,
+                            )
+                            .into(),
+                            canonical_semantic::CfgConstructionWork::default(),
+                        )
+                    })?;
                     crate::cfg_query::CfgSemanticInput::DropGlue {
                         owner: owner.as_ref().clone(),
                         facts: Box::new(facts.clone()),
+                        materialization: std::sync::Arc::new(materialization),
+                        body_span,
                     }
                 } else {
                     return Err((
@@ -430,7 +619,11 @@ pub(crate) fn collect_function_cfg_queries(
                         crate::durable_cfg::CfgDomainProjection::from_body(
                             &func,
                             &input.function,
-                            &input.body,
+                            match input.canonical.as_ref() {
+                                crate::body_query::CanonicalBody::Ordinary { body, .. }
+                                | crate::body_query::CanonicalBody::Anonymous { body, .. }
+                                | crate::body_query::CanonicalBody::Specialization { body, .. } => body,
+                            },
                             body_span,
                             &strings,
                             &type_pool,
@@ -476,31 +669,12 @@ pub(crate) fn collect_function_cfg_queries(
                         ));
                     }
                 };
-                #[cfg(test)]
-                let mut domains = domains;
-                #[cfg(test)]
-                if crate::canonical_semantic::take_test_cfg_import_failure() {
-                    domains.force_import_failure_for_test();
-                }
-                let live = std::sync::Arc::new(crate::cfg_query::CfgLiveInput {
-                    function: func.clone(),
-                    type_pool: type_pool.clone(),
-                    interner: interner.clone(),
-                    domains: domains.clone(),
-                    body_span,
-                    aggregate_types: aggregate_types.clone(),
-                    implicit_destructor_dependencies_complete: !matches!(
-                        func.implicit_drop_source,
-                        Some(rue_air::ImplicitDropDependencySourceEvent::Anonymous)
-                    ),
-                });
                 let (optimized_cfg_key, attempt) = cfg_queries
                     .optimized_cfg(
                         revision,
                         semantic_identity.clone(),
                         configuration.clone(),
                         semantic_input,
-                        live,
                         opt_level,
                         cancellation.clone(),
                     )

--- a/crates/rue-compiler/src/revisioned_query_database.rs
+++ b/crates/rue-compiler/src/revisioned_query_database.rs
@@ -14135,7 +14135,6 @@ impl RevisionedQueryDatabase {
         function: crate::FunctionInstanceKey,
         configuration: crate::semantic_query_nucleus::SemanticQueryConfiguration,
         semantic_input: crate::cfg_query::CfgSemanticInput,
-        live: Arc<crate::cfg_query::CfgLiveInput>,
         opt_level: rue_cfg::OptLevel,
         cancellation: CancellationToken,
     ) -> Result<
@@ -14145,99 +14144,7 @@ impl RevisionedQueryDatabase {
         ),
         QueryAbort,
     > {
-        let mut layout_dependencies = BTreeSet::new();
-        let mut drop_dependencies = BTreeSet::new();
-        for ty in live.domains.stable_types() {
-            crate::cfg_query::collect_type_dependencies(ty, &mut layout_dependencies);
-            crate::cfg_query::collect_drop_type_dependency(ty, &mut drop_dependencies);
-        }
-        let layout_keys = layout_dependencies
-            .into_iter()
-            .map(|ty| crate::type_queries::TypeQueryKey {
-                ty,
-                configuration: configuration.clone(),
-            })
-            .collect::<Vec<_>>();
-        let mut layout_values = Vec::with_capacity(layout_keys.len());
-        for key in layout_keys {
-            let attempt = self.runtime.request_registered(
-                &self.layouts,
-                revision,
-                key.clone(),
-                cancellation.clone(),
-            );
-            let terminal = attempt.into_result()?;
-            let rue_query::QueryOutcome::Success(value) = terminal.outcome() else {
-                unreachable!("Layout publishes typed values")
-            };
-            layout_values.push((key, value.clone()));
-        }
-        let drop_keys = drop_dependencies
-            .into_iter()
-            .map(|ty| crate::type_queries::TypeQueryKey {
-                ty,
-                configuration: configuration.clone(),
-            })
-            .collect::<Vec<_>>();
-        let mut type_fact_values = Vec::with_capacity(drop_keys.len());
-        let mut drop_glue_values = Vec::with_capacity(drop_keys.len());
-        for key in drop_keys {
-            let attempt = self.runtime.request_registered(
-                &self.type_facts,
-                revision,
-                key.clone(),
-                cancellation.clone(),
-            );
-            let terminal = attempt.into_result()?;
-            let rue_query::QueryOutcome::Success(value) = terminal.outcome() else {
-                unreachable!("TypeFacts publishes typed values")
-            };
-            type_fact_values.push((key.clone(), value.clone()));
-            let attempt = self.runtime.request_registered(
-                &self.drop_glues,
-                revision,
-                key.clone(),
-                cancellation.clone(),
-            );
-            let terminal = attempt.into_result()?;
-            let rue_query::QueryOutcome::Success(value) = terminal.outcome() else {
-                unreachable!("DropGlue publishes typed values")
-            };
-            drop_glue_values.push((key, value.clone()));
-        }
-        let mut callables = live.domains.stable_callables().collect::<BTreeSet<_>>();
-        callables.insert(function.clone());
-        let call_abi_keys = callables
-            .into_iter()
-            .map(|callable| crate::type_queries::CallAbiQueryKey {
-                callable,
-                configuration: configuration.clone(),
-            })
-            .collect::<Vec<_>>();
-        let mut call_abi_values = Vec::with_capacity(call_abi_keys.len());
-        for key in call_abi_keys {
-            let attempt = self.runtime.request_registered(
-                &self.call_abis,
-                revision,
-                key.clone(),
-                cancellation.clone(),
-            );
-            let terminal = attempt.into_result()?;
-            let rue_query::QueryOutcome::Success(value) = terminal.outcome() else {
-                unreachable!("CallAbi publishes typed values")
-            };
-            call_abi_values.push((key, value.clone()));
-        }
-        let cfg = crate::cfg_query::CfgQueryKey::new(
-            function,
-            configuration,
-            semantic_input,
-            layout_values.into(),
-            type_fact_values.into(),
-            drop_glue_values.into(),
-            call_abi_values.into(),
-            live,
-        );
+        let cfg = crate::cfg_query::CfgQueryKey::new(function, configuration, semantic_input);
         let optimized = crate::cfg_query::OptimizedCfgQueryKey::new(cfg, opt_level);
         let attempt = self.runtime.request_registered(
             &self.optimized_cfgs,
@@ -18967,19 +18874,7 @@ fn provider_definition_symbol_component(key: &crate::StableDefinitionKey) -> Str
 /// Body closure aggregation calls this before any CFG/codegen consumer can
 /// materialize the collected nominal set.
 fn compiler_anonymous_identity_digest(identity: &crate::AnonymousNominalKey) -> u128 {
-    let identity = identity.with_canonical_producer();
-    let relocated: rue_air::AnonymousNominalKey<String, String> = identity
-        .as_ref()
-        .try_map_identities::<String, String, std::convert::Infallible>(
-            &|definition| Ok(provider_definition_symbol_component(definition)),
-            &|module| {
-                Ok(rue_air::stable_digest::stable_module_component(
-                    module.logical_path(),
-                ))
-            },
-        )
-        .expect("compiler anonymous identity relocation to stable content is infallible");
-    rue_air::stable_digest::stable_anonymous_identity_digest(&relocated)
+    crate::semantic_identity::anonymous_nominal_digest(identity)
 }
 
 fn register_body_closure_anonymous_digest(
@@ -32924,6 +32819,7 @@ fn main() -> i32 {
             std::slice::from_ref(&callable),
             &[],
             std::slice::from_ref(&module),
+            &[],
         )
         .expect("durable provider export materializes in a fresh local epoch");
 

--- a/crates/rue-compiler/src/semantic_identity.rs
+++ b/crates/rue-compiler/src/semantic_identity.rs
@@ -55,6 +55,87 @@ impl StableSymbolEncoder {
     }
 }
 
+pub(crate) fn anonymous_nominal_digest(identity: &AnonymousNominalKey) -> u128 {
+    let identity = identity.with_canonical_producer();
+    let relocated: rue_air::AnonymousNominalKey<String, String> = identity
+        .as_ref()
+        .try_map_identities::<String, String, std::convert::Infallible>(
+            &|definition| {
+                Ok(rue_air::stable_digest::stable_definition_component(
+                    definition.module().logical_path(),
+                    definition.name(),
+                    definition.owner().map(|owner| owner.name()),
+                    definition.kind() as u8,
+                ))
+            },
+            &|module| {
+                Ok(rue_air::stable_digest::stable_module_component(
+                    module.logical_path(),
+                ))
+            },
+        )
+        .expect("compiler anonymous identity relocation to stable content is infallible");
+    rue_air::stable_digest::stable_anonymous_identity_digest(&relocated)
+}
+
+/// Spell an anonymous nominal through the same stable-content digest used by
+/// both semantic engines. The digest is presentation only; the full key remains
+/// the identity used by queries and relocation.
+pub(crate) fn anonymous_nominal_source_symbol(identity: &AnonymousNominalKey) -> String {
+    let digest = anonymous_nominal_digest(identity);
+    let kind = match identity.kind {
+        AnonymousNominalKind::Struct => "struct",
+        AnonymousNominalKind::Enum => "enum",
+    };
+    format!("__anon_{kind}_{digest:032x}")
+}
+
+pub(crate) fn anonymous_member_source_symbol(identity: &FunctionInstanceKey) -> Option<String> {
+    let FunctionInstanceKey::AnonymousMember { owner, member } = identity else {
+        return None;
+    };
+    let TypeInstanceKey::Nominal(NominalInstanceKey::Anonymous(owner)) = owner.as_ref() else {
+        return None;
+    };
+    Some(format!(
+        "{}.{}",
+        anonymous_nominal_source_symbol(owner),
+        member.name
+    ))
+}
+
+/// Spell a named nominal through the same unconditional module qualification
+/// used by AIR's type pool. Canonical language-item and reserved builtin types
+/// retain their bare ABI names.
+pub(crate) fn named_nominal_source_symbol(identity: &StableDefinitionKey) -> Option<String> {
+    match identity.kind() {
+        crate::StableDefinitionKind::Struct => {
+            if identity.module().is_trusted_standard_library()
+                && rue_air::LangItem::from_standard_library_nominal(
+                    identity.module().logical_path(),
+                    identity.name(),
+                )
+                .is_some()
+            {
+                return Some(identity.name().to_owned());
+            }
+        }
+        crate::StableDefinitionKind::Enum => {
+            if rue_builtins::is_reserved_enum_name(identity.name()) {
+                return Some(identity.name().to_owned());
+            }
+        }
+        _ => return None,
+    }
+    Some(format!(
+        "{}${}",
+        identity.name(),
+        rue_air::mangle_symbol_component(&rue_air::normalize_module_path(
+            identity.module().logical_path()
+        ))
+    ))
+}
+
 pub(crate) fn type_instance_from_semantic(
     value: &rue_air::SemanticImportType<StableDefinitionKey, ModuleId>,
 ) -> Option<TypeInstanceKey> {
@@ -538,6 +619,38 @@ mod tests {
         assert_ne!(
             baseline,
             make(AnonymousNominalKind::Struct, 0, TypeInstanceKey::Bool)
+        );
+    }
+
+    #[test]
+    fn named_nominal_source_symbols_match_type_pool_qualification() {
+        let named = |module, kind, name| {
+            StableDefinitionKey::for_test(
+                module,
+                StableDefinitionNamespace::Type,
+                kind,
+                Arc::<str>::from(name),
+                None,
+            )
+        };
+        let record = named(
+            ModuleId::from_validated_canonical("pkg/main.rue"),
+            StableDefinitionKind::Struct,
+            "Record",
+        );
+        assert_eq!(
+            named_nominal_source_symbol(&record).as_deref(),
+            Some("Record$pkg_2fmain_2erue")
+        );
+
+        let strbuf = named(
+            ModuleId::from_trusted_validated_canonical("\0rue-std/strbuf.rue"),
+            StableDefinitionKind::Struct,
+            "StrBuf",
+        );
+        assert_eq!(
+            named_nominal_source_symbol(&strbuf).as_deref(),
+            Some("StrBuf")
         );
     }
 

--- a/crates/rue-compiler/src/session.rs
+++ b/crates/rue-compiler/src/session.rs
@@ -4707,6 +4707,7 @@ impl CompilerSession {
                             .map(|nominal| (nominal.identity.clone(), nominal)),
                     );
                 }
+                let canonical_body = body.clone();
                 match body.as_ref() {
                     crate::body_query::CanonicalBody::Ordinary { owner, body } => {
                         let Some(record) =
@@ -4742,6 +4743,7 @@ impl CompilerSession {
                                 owner: owner.clone(),
                                 body_span,
                                 body: body.clone(),
+                                canonical: canonical_body.clone().into(),
                             },
                         );
                     }
@@ -4810,6 +4812,7 @@ impl CompilerSession {
                                 identity: identity.clone(),
                                 body_span,
                                 body: body.clone(),
+                                canonical: canonical_body.clone().into(),
                             },
                         );
                     }
@@ -4836,6 +4839,7 @@ impl CompilerSession {
                                 identity: identity.clone(),
                                 body_span: record.declaration_span(),
                                 body: body.clone(),
+                                canonical: canonical_body.clone().into(),
                             },
                         );
                     }
@@ -7301,6 +7305,27 @@ mod tests {
     }
 
     #[test]
+    fn cfg_local_materialization_preserves_body_callable_names() {
+        let source = SourceSnapshot::single(
+            "main.rue",
+            "fn probe() -> u32 { @random_u32() }\nfn main() { probe(); }",
+        )
+        .unwrap();
+        let mut session = CompilerSession::new();
+        session.update(&source).into_result().unwrap();
+        let semantic = session
+            .canonical_semantic(&CompileOptions::default())
+            .unwrap();
+        let names = semantic
+            .functions()
+            .iter()
+            .map(|function| (function.analyzed.name.as_str(), function.cfg.fn_name()))
+            .collect::<std::collections::BTreeMap<_, _>>();
+        assert_eq!(names.get("probe"), Some(&"probe"));
+        assert_eq!(names.get("main"), Some(&"main"));
+    }
+
+    #[test]
     fn cfg_drop_facts_invalidate_same_layout_cleanup_changes() {
         let first = snapshot(
             &[(
@@ -7411,7 +7436,7 @@ mod tests {
     }
 
     #[test]
-    fn cfg_import_failure_rebuilds_current_body_with_exact_fallback_work() {
+    fn cfg_terminal_owned_domain_relocates_without_rebuild() {
         let first = snapshot(
             &[(1, "/p/main.rue", "main.rue", "fn main() -> i32 { 7 }")],
             1,
@@ -7434,21 +7459,19 @@ mod tests {
         session.canonical_semantic(&options).unwrap();
 
         session.update(&second).into_result().unwrap();
-        let warm = crate::canonical_semantic::with_test_cfg_import_failure_injection(|| {
-            session.canonical_semantic(&options).unwrap()
-        });
-        assert_eq!(warm.work().cfg.cfg_reuse_candidates, 1);
-        assert_eq!(warm.work().cfg.cfg_reuses, 0);
+        let warm = session.canonical_semantic(&options).unwrap();
+        assert_eq!(warm.work().cfg.cfg_reuse_candidates, 0);
+        assert_eq!(warm.work().cfg.cfg_reuses, 1);
         assert_eq!(warm.work().cfg.cfg_import_attempts, 1);
-        assert_eq!(warm.work().cfg.cfg_import_successes, 0);
-        assert_eq!(warm.work().cfg.cfg_import_failures, 1);
-        assert_eq!(warm.work().cfg.cfg_fallbacks, 1);
-        assert_eq!(warm.work().cfg.cfg_builds_attempted, 1);
-        assert_eq!(warm.work().cfg.cfg_builds_succeeded, 1);
+        assert_eq!(warm.work().cfg.cfg_import_successes, 1);
+        assert_eq!(warm.work().cfg.cfg_import_failures, 0);
+        assert_eq!(warm.work().cfg.cfg_fallbacks, 0);
+        assert_eq!(warm.work().cfg.cfg_builds_attempted, 0);
+        assert_eq!(warm.work().cfg.cfg_builds_succeeded, 0);
         assert_eq!(warm.work().cfg.cfg_builds_failed, 0);
-        assert_eq!(warm.work().cfg.optimization_attempts, 1);
-        assert_eq!(warm.work().cfg.optimization_completions, 1);
-        assert_eq!(warm.work().cfg.optimized_level_attempts, 1);
+        assert_eq!(warm.work().cfg.optimization_attempts, 0);
+        assert_eq!(warm.work().cfg.optimization_completions, 0);
+        assert_eq!(warm.work().cfg.optimized_level_attempts, 0);
 
         let mut fresh = CompilerSession::new();
         fresh.update(&second).into_result().unwrap();


### PR DESCRIPTION
## Summary

- move CFG construction onto query-owned canonical body materialization
- retain exact type, layout, drop-glue, callable, and ABI dependencies across durable relocation
- preserve incremental reuse while joining transitive named and anonymous aggregate identities fail-closed
- add architectural inventory and regression coverage for the new ownership boundary

## Validation

- `scripts/rue quick`
- `RUE_TEST_TIER=premerge ./test.sh` (78 passed; 0 failed; 0 timed out)
- `/opt/homebrew/bin/bash clippy.sh`
- focused raw-pointer, nested comptime type-constructor, and cross-module regressions

Fixes RUE-1215.

Refs RUE-1199.