### PR TITLE
RUE-1216: make codegen queries own lowering inputs

### DIFF
--- a/crates/rue-compiler/src/api_inventory.rs
+++ b/crates/rue-compiler/src/api_inventory.rs
@@ -149,6 +149,51 @@ fn cfg_queries_own_local_semantic_materialization_and_terminal_domains() {
     );
 }
 
+#[test]
+fn codegen_queries_consume_only_registered_optimized_cfg_domains() {
+    let cfg = include_str!("cfg_query.rs");
+    let codegen = include_str!("codegen_query.rs");
+    let database = include_str!("revisioned_query_database.rs");
+    for required in [
+        "pub(crate) codegen: Arc<CfgCodegenDomain>",
+        "record.codegen.symbol_mappings",
+        "&record.cfg",
+        "&record.type_pool",
+        "&record.strings",
+        "&record.interner",
+        "key.optimized_cfg.clone()",
+        "pub(crate) function: crate::FunctionInstanceKey",
+    ] {
+        assert!(
+            cfg.contains(required) || codegen.contains(required),
+            "codegen ownership boundary lost: {required}"
+        );
+    }
+    for forbidden in [
+        "struct CodegenLiveInput",
+        "pub(crate) live:",
+        "key.live",
+        "pub(crate) function: crate::FunctionWithCfg",
+    ] {
+        assert!(
+            !codegen.contains(forbidden),
+            "codegen key regained caller-owned live state: {forbidden}"
+        );
+    }
+    assert!(
+        !database.contains("function: crate::FunctionWithCfg")
+            && !database.contains("type_pool: crate::FrozenTypeInternPool")
+            && !database.contains("symbol_mappings: Arc<BTreeMap<String, String>>"),
+        "the registered codegen request facade must not require semantic/global live inputs"
+    );
+    let session = include_str!("session.rs");
+    assert!(
+        session.contains("RUE-1217 owns replacing this")
+            && !session.contains("_foreign_symbols: &[String]"),
+        "collection must retain only the explicitly tracked RUE-1217 root adapter"
+    );
+}
+
 const RUE_868_RAW_FACADE_VOCABULARY: &[&str] = &[
     "Lexer",
     "Token",

--- a/crates/rue-compiler/src/backend.rs
+++ b/crates/rue-compiler/src/backend.rs
@@ -5,6 +5,7 @@
 /// Collect the raw C symbol names of every `extern "C"` foreign declaration in
 /// the lowered program (ADR-0064 C FFI). These are the undefined symbols a call
 /// site references and the linker resolves from a supplied static archive.
+#[cfg(test)]
 pub(crate) fn collect_foreign_symbols(rir: &rue_rir::Rir, interner: &ThreadedRodeo) -> Vec<String> {
     rir.iter()
         .filter_map(|(_, inst)| match &inst.data {
@@ -43,6 +44,7 @@ pub(crate) fn collect_export_symbols(rir: &rue_rir::Rir, interner: &ThreadedRode
 /// and the linker satisfies it from a static archive. The identity mapping also
 /// lets `validate_production_call_relocations` recognize the raw name as a
 /// declared foreign call rather than an unresolved glue symbol.
+#[cfg(test)]
 pub(crate) fn foreign_call_symbol_mappings(
     functions: &[FunctionWithCfg],
     foreign_symbols: &[String],

--- a/crates/rue-compiler/src/cfg_query.rs
+++ b/crates/rue-compiler/src/cfg_query.rs
@@ -11,6 +11,32 @@ use std::sync::Arc;
 use rue_query::{QueryAbort, QueryContext, QueryFamily, QueryKey, QueryOutcome, QueryOutput};
 use rue_span::Span;
 
+#[cfg(test)]
+use std::cell::Cell;
+
+#[cfg(test)]
+thread_local! {
+    static INJECT_CALL_ABI_FAILURE: Cell<bool> = const { Cell::new(false) };
+}
+
+#[cfg(test)]
+pub(crate) fn with_test_call_abi_failure_injection<T>(run: impl FnOnce() -> T) -> T {
+    struct Reset;
+    impl Drop for Reset {
+        fn drop(&mut self) {
+            INJECT_CALL_ABI_FAILURE.with(|enabled| enabled.set(false));
+        }
+    }
+    INJECT_CALL_ABI_FAILURE.with(|enabled| {
+        assert!(
+            !enabled.replace(true),
+            "call-ABI failure injection is not nestable"
+        );
+    });
+    let _reset = Reset;
+    run()
+}
+
 #[derive(Debug, Clone)]
 pub(crate) enum CfgSemanticInput {
     Body {
@@ -191,11 +217,23 @@ pub(crate) struct CfgRecord {
     pub(crate) strings: Arc<[String]>,
     pub(crate) local_atoms:
         Arc<[rue_air::LocalAtomRecord<crate::StableDefinitionKey, crate::ModuleId>]>,
+    /// Owned current-domain aliases available while lowering this CFG. The
+    /// domain includes cleanup aliases that optimization may leave unused; its
+    /// stable identities and ABI classifications are still exact CFG-query
+    /// dependencies, never a caller-owned program resolver.
+    pub(crate) codegen: Arc<CfgCodegenDomain>,
     pub(crate) materialization_warnings: Arc<[rue_error::CompileWarning]>,
     pub(crate) body_span: Span,
     pub(crate) warnings: Arc<[rue_error::CompileWarning]>,
     pub(crate) implicit_destructor_targets: Arc<[crate::TypeInstanceKey]>,
     pub(crate) implicit_destructor_dependencies_complete: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct CfgCodegenDomain {
+    pub(crate) defined_symbol: Arc<str>,
+    pub(crate) symbol_mappings: Arc<std::collections::BTreeMap<String, String>>,
+    pub(crate) foreign_symbols: Arc<std::collections::BTreeSet<String>>,
 }
 
 #[derive(Debug, Clone)]
@@ -573,28 +611,19 @@ fn materialize_and_build_cfg(
         context.query_registered(type_facts, dependency.clone())?;
         context.query_registered(drop_glues, dependency)?;
     }
-    let mut callables = domains
-        .stable_callables()
-        .collect::<std::collections::BTreeSet<_>>();
-    callables.insert(key.function.clone());
-    for callable in callables {
-        context.query_registered(
-            call_abis,
-            crate::type_queries::CallAbiQueryKey {
-                callable,
-                configuration: key.configuration.clone(),
-            },
-        )?;
-    }
-    Ok(build_cfg(context, key, materialized, domains))
+    build_cfg(context, call_abis, key, materialized, domains)
 }
 
 fn build_cfg(
     context: &QueryContext,
+    call_abis: &QueryFamily<
+        crate::type_queries::CallAbiQueryKey,
+        crate::type_queries::CallAbiValue,
+    >,
     key: &CfgQueryKey,
     materialized: crate::local_semantic_materialization::LocalSemanticMaterialization,
     domains: crate::durable_cfg::CfgDomainProjection,
-) -> CfgValue {
+) -> Result<CfgValue, QueryAbort> {
     context.record_work(rue_query::WorkItem::new("cfg.build.attempts", 1));
     context.record_work(rue_query::WorkItem::new(
         "cfg.air.instructions",
@@ -613,16 +642,85 @@ fn build_cfg(
     );
     if !output.errors.is_empty() {
         context.record_work(rue_query::WorkItem::new("cfg.build.failures", 1));
-        return CfgValue::Failure {
+        return Ok(CfgValue::Failure {
             errors: output.errors.into(),
             body_span: materialized.body_span,
-        };
+        });
     }
     context.record_work(rue_query::WorkItem::new("cfg.build.successes", 1));
     context.record_work(rue_query::WorkItem::new(
         "cfg.warnings",
         output.warnings.len() as u64,
     ));
+    let cfg = output
+        .cfg
+        .as_ref()
+        .expect("successful CFG construction publishes a validated CFG");
+    let callables = match domains.runtime_callables(cfg) {
+        Ok(value) => value,
+        Err(error) => {
+            return Ok(internal_failure(
+                format!("canonical runtime-call projection failed: {error:?}"),
+                materialized.body_span,
+            ));
+        }
+    };
+    let mut call_abi_facts = std::collections::BTreeMap::new();
+    for callable in callables {
+        let terminal = context.query_registered(
+            call_abis,
+            crate::type_queries::CallAbiQueryKey {
+                callable: callable.clone(),
+                configuration: key.configuration.clone(),
+            },
+        )?;
+        let QueryOutcome::Success(value) = terminal.outcome() else {
+            unreachable!("CallAbi publishes typed values")
+        };
+        #[cfg(test)]
+        let injected;
+        #[cfg(test)]
+        let value = if INJECT_CALL_ABI_FAILURE.with(Cell::get) {
+            injected = crate::type_queries::CallAbiValue::Failure(
+                crate::type_queries::TypeQueryFailure::Unavailable(Arc::from(
+                    "injected call ABI failure",
+                )),
+            );
+            &injected
+        } else {
+            value
+        };
+        match value {
+            crate::type_queries::CallAbiValue::Available(facts) => {
+                call_abi_facts.insert(callable, facts.clone());
+            }
+            crate::type_queries::CallAbiValue::Failure(failure) => {
+                let detail = match failure {
+                    crate::type_queries::TypeQueryFailure::Unavailable(detail)
+                    | crate::type_queries::TypeQueryFailure::Invalid(detail) => detail,
+                };
+                return Ok(internal_failure(
+                    format!("call ABI unavailable for {callable:?}: {detail}"),
+                    materialized.body_span,
+                ));
+            }
+        }
+    }
+    let codegen = match domains.codegen_domain(
+        &key.function,
+        &materialized.name,
+        &materialized.type_pool,
+        &materialized.interner,
+        &call_abi_facts,
+    ) {
+        Ok(value) => value,
+        Err(error) => {
+            return Ok(internal_failure(
+                format!("canonical codegen domain projection failed: {error:?}"),
+                materialized.body_span,
+            ));
+        }
+    };
     let mut implicit_destructor_targets = output
         .implicit_named_destructors
         .iter()
@@ -642,7 +740,7 @@ fn build_cfg(
         // the live type pool for same-named structs outside this CFG's domain.
         implicit_destructor_targets.insert(owner.clone());
     }
-    CfgValue::Available(Arc::new(CfgRecord {
+    Ok(CfgValue::Available(Arc::new(CfgRecord {
         cfg: output
             .cfg
             .expect("successful CFG construction publishes a validated CFG"),
@@ -651,6 +749,7 @@ fn build_cfg(
         interner: materialized.interner,
         strings: materialized.strings.into(),
         local_atoms: materialized.local_atoms.into(),
+        codegen: Arc::new(codegen),
         materialization_warnings: materialized.warnings,
         body_span: materialized.body_span,
         warnings: output.warnings.into(),
@@ -660,7 +759,7 @@ fn build_cfg(
             .into(),
         implicit_destructor_dependencies_complete: materialized.completeness.is_complete()
             && !output.anonymous_destructor_dependency_incomplete,
-    }))
+    })))
 }
 
 pub(crate) fn evaluate_optimized_cfg(
@@ -694,6 +793,7 @@ pub(crate) fn evaluate_optimized_cfg(
                     interner: record.interner.clone(),
                     strings: record.strings.clone(),
                     local_atoms: record.local_atoms.clone(),
+                    codegen: record.codegen.clone(),
                     materialization_warnings: record.materialization_warnings.clone(),
                     body_span: record.body_span,
                     warnings: record.warnings.clone(),

--- a/crates/rue-compiler/src/codegen_query.rs
+++ b/crates/rue-compiler/src/codegen_query.rs
@@ -7,7 +7,7 @@
 //! callers keep their units unless a real ABI or emitted reference changes.
 
 use std::{
-    collections::{BTreeMap, BTreeSet},
+    collections::BTreeSet,
     hash::{Hash, Hasher},
     sync::Arc,
 };
@@ -42,17 +42,6 @@ pub(crate) fn with_test_codegen_failure_injection<T>(run: impl FnOnce() -> T) ->
 }
 
 #[derive(Debug, Clone)]
-pub(crate) struct CodegenLiveInput {
-    pub(crate) function: Arc<crate::FunctionWithCfg>,
-    pub(crate) type_pool: crate::FrozenTypeInternPool,
-    pub(crate) strings: Arc<[String]>,
-    pub(crate) interner: Arc<lasso::ThreadedRodeo>,
-    pub(crate) symbol_mappings: Arc<BTreeMap<String, String>>,
-    pub(crate) foreign_symbols: Arc<BTreeSet<String>>,
-    pub(crate) optimized_cfg_key: crate::cfg_query::OptimizedCfgQueryKey,
-}
-
-#[derive(Debug, Clone)]
 pub(crate) struct CodegenUnitQueryKey {
     pub(crate) function: crate::FunctionInstanceKey,
     pub(crate) target: rue_target::Target,
@@ -67,44 +56,21 @@ pub(crate) struct CodegenUnitQueryKey {
     /// equality because the evaluator retains those projections, but remains
     /// absent from logical identity and the link-content fingerprint.
     pub(crate) request: rue_codegen::BackendArtifactRequest,
-    /// The machine names that this unit can actually reference, including raw
-    /// foreign names. It intentionally omits unrelated program callables.
-    pub(crate) references: Arc<[(String, String)]>,
-    /// Exact content discriminator for revision revalidation. It is excluded
-    /// from `stable_identity`, but not memo equality: successor bodies/layouts
-    /// must select a fresh codegen terminal.
+    /// The registered optimized-CFG dependency owns every current-domain value
+    /// used by lowering. It is excluded from `stable_identity`, but remains in
+    /// memo equality so a different function body/configuration cannot alias.
     pub(crate) optimized_cfg: crate::cfg_query::OptimizedCfgQueryKey,
-    pub(crate) live: Arc<CodegenLiveInput>,
     memo_hash: u64,
 }
 
 impl CodegenUnitQueryKey {
     pub(crate) fn new(
-        live: Arc<CodegenLiveInput>,
+        optimized_cfg: crate::cfg_query::OptimizedCfgQueryKey,
         target: rue_target::Target,
         request: rue_codegen::BackendArtifactRequest,
         optimization: rue_cfg::OptLevel,
     ) -> Self {
-        let function = live.function.semantic_identity.clone();
-        // Codegen receives the complete resolver for its current-domain call
-        // names, but only names mentioned by this CFG belong in equality.
-        let mut references = BTreeSet::new();
-        for block in live.function.cfg.blocks() {
-            for value in &block.insts {
-                if let rue_cfg::CfgInstData::Call { name, .. } =
-                    &live.function.cfg.get_inst(*value).data
-                {
-                    let legacy = live.interner.resolve(name).to_owned();
-                    let resolved = live
-                        .symbol_mappings
-                        .get(&legacy)
-                        .cloned()
-                        .unwrap_or(legacy.clone());
-                    references.insert((legacy, resolved));
-                }
-            }
-        }
-        let references: Arc<[(String, String)]> = references.into_iter().collect::<Vec<_>>().into();
+        let function = optimized_cfg.cfg.function.clone();
         let mut hasher = std::collections::hash_map::DefaultHasher::new();
         function.hash(&mut hasher);
         target.hash(&mut hasher);
@@ -118,8 +84,7 @@ impl CodegenUnitQueryKey {
         request.liveness.hash(&mut hasher);
         request.regalloc.hash(&mut hasher);
         request.asm.hash(&mut hasher);
-        references.hash(&mut hasher);
-        live.optimized_cfg_key.hash(&mut hasher);
+        optimized_cfg.hash(&mut hasher);
         let memo_hash = hasher.finish();
         Self {
             function,
@@ -130,9 +95,7 @@ impl CodegenUnitQueryKey {
             backend_epoch: BACKEND_EPOCH,
             abi_layout_epoch: ABI_LAYOUT_EPOCH,
             request,
-            references,
-            optimized_cfg: live.optimized_cfg_key.clone(),
-            live,
+            optimized_cfg,
             memo_hash,
         }
     }
@@ -148,7 +111,6 @@ impl PartialEq for CodegenUnitQueryKey {
             && self.backend_epoch == other.backend_epoch
             && self.abi_layout_epoch == other.abi_layout_epoch
             && self.request == other.request
-            && self.references == other.references
             && self.optimized_cfg == other.optimized_cfg
     }
 }
@@ -188,13 +150,13 @@ pub(crate) struct CodegenUnit {
     pub(crate) presentation: Arc<str>,
 }
 
-/// A reached canonical terminal together with the function record that owns
-/// its stable identity.  The record is intentionally kept beside the terminal
-/// until the image adapter projects it to an object: it avoids making object
-/// generation rediscover or re-run codegen work.
+/// A reached canonical terminal paired only with its stable function identity.
+/// RUE-1217 owns replacing the semantic root enumerator that assembles this
+/// list; neither the terminal nor this collection record retains live frontend
+/// state.
 #[derive(Clone)]
 pub(crate) struct CollectedCodegenUnit {
-    pub(crate) function: crate::FunctionWithCfg,
+    pub(crate) function: crate::FunctionInstanceKey,
     pub(crate) unit: Arc<CodegenUnit>,
 }
 
@@ -335,15 +297,34 @@ pub(crate) fn evaluate_codegen_unit(
 ) -> Result<QueryOutput<CodegenUnitValue>, QueryAbort> {
     context.check_canceled()?;
     context.record_work(rue_query::WorkItem::new("codegen.unit.attempts", 1));
-    let optimized = context.query_registered(optimized_cfgs, key.live.optimized_cfg_key.clone())?;
+    let _nested = context.retain_nested_attempts_for(&["compiler.optimized-cfg"]);
+    let optimized = context.query_registered(optimized_cfgs, key.optimized_cfg.clone())?;
+    context.record_work(rue_query::WorkItem::new(
+        "codegen.dependencies.optimized-cfg",
+        1,
+    ));
     let QueryOutcome::Success(optimized) = optimized.outcome() else {
         unreachable!("OptimizedCfg publishes typed values");
     };
     if let crate::cfg_query::CfgValue::Failure { errors, .. } = optimized {
         return Ok(codegen_failure(errors.clone()));
     }
-    let function = &key.live.function;
-    let stable_atoms = function
+    let crate::cfg_query::CfgValue::Available(record) = optimized else {
+        unreachable!("failure handled above")
+    };
+    context.record_work(rue_query::WorkItem::new(
+        "codegen.domain.symbol-aliases",
+        record.codegen.symbol_mappings.len() as u64,
+    ));
+    context.record_work(rue_query::WorkItem::new(
+        "codegen.domain.foreign-aliases",
+        record.codegen.foreign_symbols.len() as u64,
+    ));
+    context.record_work(rue_query::WorkItem::new(
+        "codegen.dependencies.local-atoms",
+        record.local_atoms.len() as u64,
+    ));
+    let stable_atoms = record
         .local_atoms
         .iter()
         .map(|atom| {
@@ -352,7 +333,7 @@ pub(crate) fn evaluate_codegen_unit(
             ))
         })
         .collect::<Vec<_>>();
-    let atoms = function
+    let atoms = record
         .local_atoms
         .iter()
         .zip(&stable_atoms)
@@ -363,27 +344,25 @@ pub(crate) fn evaluate_codegen_unit(
         })
         .collect::<Vec<_>>();
     let symbols = rue_codegen::MachineSymbolResolver::new_with_foreign(
-        &key.live.symbol_mappings,
-        &key.live.foreign_symbols,
+        &record.codegen.symbol_mappings,
+        &record.codegen.foreign_symbols,
     );
+    context.record_work(rue_query::WorkItem::new("codegen.lowering.local", 1));
     let generated = match key.target.arch() {
         rue_target::Arch::X86_64 => rue_codegen::x86_64::generate_product_with_symbols_and_atoms(
-            // The nested terminal establishes exact invalidation. The CFG
-            // collector already relocated this function into the current
-            // request domain, so codegen must use that current-domain view.
-            &function.cfg,
-            &key.live.type_pool,
-            &key.live.strings,
-            &key.live.interner,
+            &record.cfg,
+            &record.type_pool,
+            &record.strings,
+            &record.interner,
             symbols,
             &atoms,
             key.request,
         ),
         rue_target::Arch::Aarch64 => rue_codegen::aarch64::generate_product_with_symbols_and_atoms(
-            &function.cfg,
-            &key.live.type_pool,
-            &key.live.strings,
-            &key.live.interner,
+            &record.cfg,
+            &record.type_pool,
+            &record.strings,
+            &record.interner,
             key.target,
             symbols,
             &atoms,
@@ -395,7 +374,7 @@ pub(crate) fn evaluate_codegen_unit(
         Err(error) => return Ok(codegen_failure(error.into())),
     };
     if let Some(lowering) = &mut product.artifacts.lowering {
-        lowering.fn_name.clone_from(&function.machine_name);
+        lowering.fn_name = record.codegen.defined_symbol.to_string();
     }
     #[cfg(test)]
     if INJECT_CODEGEN_FAILURE.with(Cell::get) {
@@ -414,14 +393,14 @@ pub(crate) fn evaluate_codegen_unit(
     }
     if let Err(error) = crate::backend::validate_production_call_relocations(
         &product.machine_code.relocations,
-        &key.live.symbol_mappings,
+        &record.codegen.symbol_mappings,
     ) {
         return Ok(codegen_failure(error.into()));
     }
     context.check_canceled()?;
     context.record_work(rue_query::WorkItem::new("codegen.unit.successes", 1));
     let product = crate::backend::FunctionBackendProduct {
-        machine_name: function.machine_name.clone(),
+        machine_name: record.codegen.defined_symbol.to_string(),
         machine_code: product.machine_code,
         artifacts: product.artifacts,
     };

--- a/crates/rue-compiler/src/durable_cfg.rs
+++ b/crates/rue-compiler/src/durable_cfg.rs
@@ -192,6 +192,61 @@ fn live_primitive(ty: &CanonicalType) -> Option<Type> {
     })
 }
 
+fn foreign_callable_symbol(callable: &crate::FunctionInstanceKey) -> Option<String> {
+    match callable {
+        crate::FunctionInstanceKey::Definition(definition) => Some(definition.name().to_owned()),
+        crate::FunctionInstanceKey::Specialization { base, .. } => foreign_callable_symbol(base),
+        crate::FunctionInstanceKey::AnonymousMember { .. }
+        | crate::FunctionInstanceKey::DropGlue(_) => None,
+    }
+}
+
+fn canonical_type_instance(ty: &CanonicalType) -> Option<crate::TypeInstanceKey> {
+    Some(match ty {
+        CanonicalType::I8 => crate::TypeInstanceKey::I8,
+        CanonicalType::I16 => crate::TypeInstanceKey::I16,
+        CanonicalType::I32 => crate::TypeInstanceKey::I32,
+        CanonicalType::I64 => crate::TypeInstanceKey::I64,
+        CanonicalType::U8 => crate::TypeInstanceKey::U8,
+        CanonicalType::U16 => crate::TypeInstanceKey::U16,
+        CanonicalType::U32 => crate::TypeInstanceKey::U32,
+        CanonicalType::U64 => crate::TypeInstanceKey::U64,
+        CanonicalType::Bool => crate::TypeInstanceKey::Bool,
+        CanonicalType::Unit => crate::TypeInstanceKey::Unit,
+        CanonicalType::Never => crate::TypeInstanceKey::Never,
+        CanonicalType::ComptimeType => crate::TypeInstanceKey::ComptimeType,
+        CanonicalType::BuiltinNominal { kind, name } => crate::TypeInstanceKey::BuiltinNominal {
+            kind: match kind {
+                rue_air::SemanticImportNominalKind::Struct => crate::AnonymousNominalKind::Struct,
+                rue_air::SemanticImportNominalKind::Enum => crate::AnonymousNominalKind::Enum,
+            },
+            name: name.clone(),
+        },
+        CanonicalType::Nominal(definition) => {
+            crate::TypeInstanceKey::Nominal(crate::NominalInstanceKey::Named(definition.clone()))
+        }
+        CanonicalType::AnonymousNominal(identity) => {
+            crate::TypeInstanceKey::Nominal(crate::NominalInstanceKey::Anonymous(identity.clone()))
+        }
+        CanonicalType::Array { element, len } => crate::TypeInstanceKey::Array {
+            element: Box::new(canonical_type_instance(element)?),
+            len: *len,
+        },
+        CanonicalType::PtrConst(element) => {
+            crate::TypeInstanceKey::PtrConst(Box::new(canonical_type_instance(element)?))
+        }
+        CanonicalType::PtrMut(element) => {
+            crate::TypeInstanceKey::PtrMut(Box::new(canonical_type_instance(element)?))
+        }
+        CanonicalType::Slice { element, name } => crate::TypeInstanceKey::Slice {
+            element: Box::new(canonical_type_instance(element)?),
+            name: name.clone(),
+        },
+        CanonicalType::Module(module) => crate::TypeInstanceKey::Module(module.clone()),
+        CanonicalType::GenericParameter(index) => crate::TypeInstanceKey::GenericParameter(*index),
+    })
+}
+
 fn deduplicate_type_mappings(
     mappings: Vec<(Type, CanonicalType)>,
 ) -> Result<Vec<(Type, CanonicalType)>, CfgDomainFailure> {
@@ -415,13 +470,191 @@ impl CfgDomainProjection {
         self.types.iter().map(|(_, stable)| stable)
     }
 
-    pub(crate) fn stable_callables(&self) -> impl Iterator<Item = crate::FunctionInstanceKey> + '_ {
-        self.symbols.iter().filter_map(|(_, symbol)| match symbol {
-            StableCfgSymbol::Callable(callable) => Some(callable.clone()),
-            StableCfgSymbol::Specialization(identity) => {
-                crate::semantic_identity::function_instance_from_specialization(identity)
+    /// Return the stable callable identities of the source-language calls that
+    /// actually survived AIR lowering into this CFG. The durable symbol domain
+    /// is deliberately broader: it also closes over compile-time constructors
+    /// and cleanup aliases that may never become runtime call instructions.
+    pub(crate) fn runtime_callables(
+        &self,
+        cfg: &rue_cfg::Cfg,
+    ) -> Result<std::collections::BTreeSet<crate::FunctionInstanceKey>, CfgDomainFailure> {
+        let mut callables = std::collections::BTreeSet::new();
+        for block in cfg.blocks() {
+            for value in &block.insts {
+                let rue_cfg::CfgInstData::Call {
+                    runtime: None,
+                    name,
+                    ..
+                } = &cfg.get_inst(*value).data
+                else {
+                    continue;
+                };
+                let stable = self
+                    .symbols
+                    .iter()
+                    .find_map(|(live, stable)| (live == name).then_some(stable))
+                    .ok_or(CfgDomainFailure::MissingSymbol)?;
+                let callable = match stable {
+                    StableCfgSymbol::Callable(callable) => callable.clone(),
+                    StableCfgSymbol::Specialization(identity) => {
+                        crate::semantic_identity::function_instance_from_specialization(identity)
+                            .ok_or(CfgDomainFailure::Shape)?
+                    }
+                    StableCfgSymbol::Runtime(_) | StableCfgSymbol::Intrinsic(_) => {
+                        return Err(CfgDomainFailure::Shape);
+                    }
+                };
+                callables.insert(callable);
             }
-            StableCfgSymbol::Runtime(_) | StableCfgSymbol::Intrinsic(_) => None,
+        }
+        Ok(callables)
+    }
+
+    /// Project the exact machine-symbol domain consumed by code generation.
+    ///
+    /// The live names remain paired with the CFG/interner that issued them,
+    /// while callable identities and ABI facts determine their durable machine
+    /// names. This keeps codegen independent of a whole-program resolver and
+    /// makes foreign classification an exact per-CFG dependency.
+    pub(crate) fn codegen_domain(
+        &self,
+        function: &crate::FunctionInstanceKey,
+        source_name: &str,
+        type_pool: &rue_air::FrozenTypeInternPool,
+        interner: &lasso::ThreadedRodeo,
+        call_abis: &std::collections::BTreeMap<
+            crate::FunctionInstanceKey,
+            crate::type_queries::CallAbiFacts,
+        >,
+    ) -> Result<crate::cfg_query::CfgCodegenDomain, CfgDomainFailure> {
+        let defined_symbol: Arc<str> = if source_name == "main" {
+            Arc::from("main")
+        } else {
+            Arc::from(crate::StableSymbolEncoder::encode(
+                &crate::StableSymbolId::Callable(crate::StableCallableId::Function(
+                    function.clone(),
+                )),
+            ))
+        };
+        let mut symbol_mappings = std::collections::BTreeMap::new();
+        let mut foreign_symbols = std::collections::BTreeSet::new();
+        for (live, stable) in &self.symbols {
+            let source = interner.resolve(live).to_owned();
+            let (machine, foreign) = match stable {
+                StableCfgSymbol::Callable(callable) => {
+                    let foreign = call_abis.get(callable).is_some_and(|facts| {
+                        matches!(
+                            facts.convention,
+                            crate::type_queries::CallAbiConvention::TargetC(_)
+                        )
+                    });
+                    let machine = if foreign {
+                        foreign_callable_symbol(callable).ok_or(CfgDomainFailure::Shape)?
+                    } else if source == "main" {
+                        source.clone()
+                    } else {
+                        crate::StableSymbolEncoder::encode(&crate::StableSymbolId::Callable(
+                            crate::StableCallableId::Function(callable.clone()),
+                        ))
+                    };
+                    (machine, foreign)
+                }
+                StableCfgSymbol::Specialization(identity) => {
+                    let callable =
+                        crate::semantic_identity::function_instance_from_specialization(identity)
+                            .ok_or(CfgDomainFailure::Shape)?;
+                    let foreign = call_abis.get(&callable).is_some_and(|facts| {
+                        matches!(
+                            facts.convention,
+                            crate::type_queries::CallAbiConvention::TargetC(_)
+                        )
+                    });
+                    let machine = if foreign {
+                        foreign_callable_symbol(&callable).ok_or(CfgDomainFailure::Shape)?
+                    } else if source == "main" {
+                        source.clone()
+                    } else {
+                        crate::StableSymbolEncoder::encode(&crate::StableSymbolId::Callable(
+                            crate::StableCallableId::Function(callable),
+                        ))
+                    };
+                    (machine, foreign)
+                }
+                StableCfgSymbol::Runtime(symbol) | StableCfgSymbol::Intrinsic(symbol) => {
+                    (symbol.to_string(), false)
+                }
+            };
+            if foreign {
+                foreign_symbols.insert(machine.clone());
+            }
+            if let Some(previous) = symbol_mappings.insert(source, machine.clone())
+                && previous != machine
+            {
+                return Err(CfgDomainFailure::Shape);
+            }
+        }
+        // Cleanup elaboration may synthesize destructor and drop-glue calls
+        // from aggregate metadata after AIR symbol collection. Project those
+        // exact aliases from the same local type pool and stable type domain.
+        for (current, stable) in &self.types {
+            let Some(owner) = canonical_type_instance(stable) else {
+                continue;
+            };
+            let drop_glue_source = match current.kind() {
+                TypeKind::Struct(id) => {
+                    if let (Some(source), CanonicalType::AnonymousNominal(identity)) =
+                        (&type_pool.struct_def(id).destructor, stable)
+                    {
+                        let callable = crate::FunctionInstanceKey::AnonymousMember {
+                            owner: Box::new(crate::TypeInstanceKey::Nominal(
+                                crate::NominalInstanceKey::Anonymous(identity.clone()),
+                            )),
+                            member: crate::AnonymousMemberKey {
+                                kind: crate::AnonymousMemberKind::Destructor,
+                                name: Arc::from("__drop"),
+                            },
+                        };
+                        let machine =
+                            crate::StableSymbolEncoder::encode(&crate::StableSymbolId::Callable(
+                                crate::StableCallableId::Function(callable),
+                            ));
+                        if let Some(previous) =
+                            symbol_mappings.insert(source.clone(), machine.clone())
+                            && previous != machine
+                        {
+                            return Err(CfgDomainFailure::Shape);
+                        }
+                    }
+                    Some(rue_air::drop_glue_names::struct_drop_glue_name(
+                        id, type_pool,
+                    ))
+                }
+                TypeKind::Enum(id) => {
+                    Some(rue_air::drop_glue_names::enum_drop_glue_name(id, type_pool))
+                }
+                TypeKind::Array(id) => Some(rue_air::drop_glue_names::array_drop_glue_name(
+                    id, type_pool,
+                )),
+                _ => None,
+            };
+            let Some(drop_glue_source) = drop_glue_source else {
+                continue;
+            };
+            let machine = crate::StableSymbolEncoder::encode(&crate::StableSymbolId::Callable(
+                crate::StableCallableId::Function(crate::FunctionInstanceKey::DropGlue(Box::new(
+                    owner,
+                ))),
+            ));
+            if let Some(previous) = symbol_mappings.insert(drop_glue_source, machine.clone())
+                && previous != machine
+            {
+                return Err(CfgDomainFailure::Shape);
+            }
+        }
+        Ok(crate::cfg_query::CfgCodegenDomain {
+            defined_symbol,
+            symbol_mappings: Arc::new(symbol_mappings),
+            foreign_symbols: Arc::new(foreign_symbols),
         })
     }
 
@@ -734,6 +967,25 @@ impl CfgDomainProjection {
                         let symbol = interner.get_or_intern(name);
                         if let Some(callable) = stable_callable(symbol) {
                             symbols.push((symbol, StableCfgSymbol::Callable(callable)));
+                        } else if let Some(CanonicalType::AnonymousNominal(owner)) =
+                            types.iter().find_map(|(candidate, stable)| {
+                                (*candidate == current).then_some(stable)
+                            })
+                        {
+                            symbols.push((
+                                symbol,
+                                StableCfgSymbol::Callable(
+                                    crate::FunctionInstanceKey::AnonymousMember {
+                                        owner: Box::new(crate::TypeInstanceKey::Nominal(
+                                            crate::NominalInstanceKey::Anonymous(owner.clone()),
+                                        )),
+                                        member: crate::AnonymousMemberKey {
+                                            kind: crate::AnonymousMemberKind::Destructor,
+                                            name: Arc::from("__drop"),
+                                        },
+                                    },
+                                ),
+                            ));
                         } else {
                             incomplete = true;
                         }

--- a/crates/rue-compiler/src/program_image_plan.rs
+++ b/crates/rue-compiler/src/program_image_plan.rs
@@ -251,8 +251,8 @@ impl ProgramImagePlan {
         let mut plan_units = units
             .iter()
             .map(|collected| ProgramImageUnit {
-                function: collected.function.semantic_identity.clone(),
-                identity: function_identity(&collected.function),
+                function: collected.function.clone(),
+                identity: stable_function_identity(&collected.function),
                 defined_symbol: collected.unit.defined_symbol.to_string(),
                 content_digest: unit_digest(&collected.unit),
             })
@@ -323,7 +323,7 @@ fn validate_program_image_inputs(
     let mut unit_identities = BTreeSet::new();
     let mut defined_symbols = BTreeSet::new();
     for collected in units {
-        let identity = function_identity(&collected.function);
+        let identity = stable_function_identity(&collected.function);
         if !unit_identities.insert(identity.clone()) {
             return duplicate_plan_input("codegen unit identity", &identity);
         }
@@ -369,7 +369,7 @@ fn validate_program_image_inputs(
         }
     }
     for collected in units {
-        let identity = function_identity(&collected.function);
+        let identity = stable_function_identity(&collected.function);
         let Some(expected_symbol) = functions_by_identity.get(&identity) else {
             return Err(CompileErrors::from(CompileError::without_span(
                 ErrorKind::InternalError(format!(
@@ -377,9 +377,7 @@ fn validate_program_image_inputs(
                 )),
             )));
         };
-        if collected.function.machine_name != *expected_symbol
-            || collected.unit.defined_symbol.as_ref() != *expected_symbol
-        {
+        if collected.unit.defined_symbol.as_ref() != *expected_symbol {
             return Err(CompileErrors::from(CompileError::without_span(
                 ErrorKind::InternalError(format!(
                     "program image codegen unit `{identity}` does not match its semantic function symbol"
@@ -391,8 +389,12 @@ fn validate_program_image_inputs(
 }
 
 fn function_identity(function: &FunctionWithCfg) -> String {
+    stable_function_identity(&function.semantic_identity)
+}
+
+fn stable_function_identity(function: &crate::FunctionInstanceKey) -> String {
     crate::StableSymbolEncoder::encode(&crate::StableSymbolId::Callable(
-        crate::StableCallableId::Function(function.semantic_identity.clone()),
+        crate::StableCallableId::Function(function.clone()),
     ))
 }
 
@@ -546,13 +548,10 @@ mod tests {
         crate::publish_test_snapshot(&mut session, &snapshot).unwrap();
         let rir = session.canonical_rir().unwrap();
         let semantic = session.canonical_semantic(&options).unwrap();
-        let foreign =
-            backend::collect_foreign_symbols(rir.rir(), rir.semantic_symbols().interner());
         let exports = backend::collect_export_symbols(rir.rir(), rir.semantic_symbols().interner());
         let units = session
             .codegen_units(
                 &semantic,
-                &foreign,
                 &options,
                 rue_codegen::BackendArtifactRequest::default(),
             )
@@ -579,13 +578,10 @@ mod tests {
         crate::publish_test_snapshot(&mut session, &snapshot).unwrap();
         let rir = session.canonical_rir().unwrap();
         let semantic = session.canonical_semantic(&options).unwrap();
-        let foreign =
-            backend::collect_foreign_symbols(rir.rir(), rir.semantic_symbols().interner());
         let exports = backend::collect_export_symbols(rir.rir(), rir.semantic_symbols().interner());
         let products = session
             .codegen_products(
                 &semantic,
-                &foreign,
                 &options,
                 rue_codegen::BackendArtifactRequest::default(),
             )
@@ -679,14 +675,10 @@ mod tests {
         };
         let mut session = crate::CompilerSession::new();
         crate::publish_test_snapshot(&mut session, &snapshot).unwrap();
-        let rir = session.canonical_rir().unwrap();
         let semantic = session.canonical_semantic(&options).unwrap();
-        let foreign =
-            backend::collect_foreign_symbols(rir.rir(), rir.semantic_symbols().interner());
         let units = session
             .codegen_units(
                 &semantic,
-                &foreign,
                 &options,
                 rue_codegen::BackendArtifactRequest::default(),
             )
@@ -710,7 +702,7 @@ mod tests {
 
         let mut duplicate_symbol = units;
         let mut second = duplicate_symbol[0].clone();
-        second.function.semantic_identity =
+        second.function =
             crate::FunctionInstanceKey::DropGlue(Box::new(crate::TypeInstanceKey::I64));
         duplicate_symbol.push(second);
         let error = ProgramImage::new(duplicate_symbol, &functions, &options, &[])
@@ -792,14 +784,11 @@ mod tests {
         crate::publish_test_snapshot(&mut session, &snapshot).unwrap();
         let rir = session.canonical_rir().unwrap();
         let semantic = session.canonical_semantic(&options).unwrap();
-        let foreign =
-            backend::collect_foreign_symbols(rir.rir(), rir.semantic_symbols().interner());
         let exports = backend::collect_export_symbols(rir.rir(), rir.semantic_symbols().interner());
         let first = ProgramImage::new(
             session
                 .codegen_units(
                     &semantic,
-                    &foreign,
                     &options,
                     rue_codegen::BackendArtifactRequest::default(),
                 )
@@ -814,14 +803,11 @@ mod tests {
 
         let rir = session.canonical_rir().unwrap();
         let semantic = session.canonical_semantic(&options).unwrap();
-        let foreign =
-            backend::collect_foreign_symbols(rir.rir(), rir.semantic_symbols().interner());
         let exports = backend::collect_export_symbols(rir.rir(), rir.semantic_symbols().interner());
         let second = ProgramImage::new(
             session
                 .codegen_units(
                     &semantic,
-                    &foreign,
                     &options,
                     rue_codegen::BackendArtifactRequest::default(),
                 )
@@ -868,8 +854,6 @@ mod tests {
         crate::publish_test_snapshot(&mut old_session, &snapshot).unwrap();
         let old_rir = old_session.canonical_rir().unwrap();
         let old_semantic = old_session.canonical_semantic(&options).unwrap();
-        let old_foreign =
-            backend::collect_foreign_symbols(old_rir.rir(), old_rir.semantic_symbols().interner());
         let old_exports =
             backend::collect_export_symbols(old_rir.rir(), old_rir.semantic_symbols().interner());
         let old = backend::compile_backend_products(
@@ -877,7 +861,6 @@ mod tests {
             old_session
                 .codegen_products(
                     &old_semantic,
-                    &old_foreign,
                     &options,
                     rue_codegen::BackendArtifactRequest::default(),
                 )
@@ -892,10 +875,6 @@ mod tests {
         crate::publish_test_snapshot(&mut fresh_session, &snapshot).unwrap();
         let fresh_rir = fresh_session.canonical_rir().unwrap();
         let fresh_semantic = fresh_session.canonical_semantic(&options).unwrap();
-        let foreign = backend::collect_foreign_symbols(
-            fresh_rir.rir(),
-            fresh_rir.semantic_symbols().interner(),
-        );
         let exports = backend::collect_export_symbols(
             fresh_rir.rir(),
             fresh_rir.semantic_symbols().interner(),
@@ -904,7 +883,6 @@ mod tests {
             fresh_session
                 .codegen_units(
                     &fresh_semantic,
-                    &foreign,
                     &options,
                     rue_codegen::BackendArtifactRequest::default(),
                 )

--- a/crates/rue-compiler/src/queries.rs
+++ b/crates/rue-compiler/src/queries.rs
@@ -1035,13 +1035,10 @@ pub(crate) fn pre_link_object_bytes_with_session(
     let semantic = session.canonical_semantic(options)?;
     drop(_rir_span);
     let rir = semantic.rir_owner();
-    let foreign_symbols =
-        crate::backend::collect_foreign_symbols(rir.rir(), rir.semantic_symbols().interner());
     let export_symbols =
         crate::backend::collect_export_symbols(rir.rir(), rir.semantic_symbols().interner());
     let units = session.codegen_units(
         &semantic,
-        &foreign_symbols,
         options,
         rue_codegen::BackendArtifactRequest::default(),
     )?;
@@ -1086,13 +1083,10 @@ pub(crate) fn compile_with_session(
     drop(_rir_span);
     let rir = semantic.rir_owner();
     let session_work = session.work().clone();
-    let foreign_symbols =
-        crate::backend::collect_foreign_symbols(rir.rir(), rir.semantic_symbols().interner());
     let export_symbols =
         crate::backend::collect_export_symbols(rir.rir(), rir.semantic_symbols().interner());
     let units = session.codegen_units(
         &semantic,
-        &foreign_symbols,
         options,
         rue_codegen::BackendArtifactRequest::default(),
     )?;

--- a/crates/rue-compiler/src/revisioned_query_database.rs
+++ b/crates/rue-compiler/src/revisioned_query_database.rs
@@ -14155,38 +14155,27 @@ impl RevisionedQueryDatabase {
         Ok((optimized, attempt))
     }
 
-    /// Request one canonical backend terminal. Batch assembly supplies the
-    /// current resolver, but the query key records only the callable names its
-    /// CFG actually uses; unrelated functions cannot invalidate this unit.
-    #[allow(clippy::too_many_arguments)]
+    /// Request one canonical backend terminal from its registered optimized
+    /// CFG. The nested terminal owns every current-domain lowering input, so
+    /// this API requires no semantic output, type pool, or live function.
     pub(crate) fn codegen_unit(
         &self,
         revision: Revision,
-        function: crate::FunctionWithCfg,
-        type_pool: crate::FrozenTypeInternPool,
-        strings: Arc<[String]>,
-        interner: Arc<lasso::ThreadedRodeo>,
-        symbol_mappings: Arc<BTreeMap<String, String>>,
-        foreign_symbols: Arc<BTreeSet<String>>,
         optimized_cfg_key: crate::cfg_query::OptimizedCfgQueryKey,
         target: rue_target::Target,
         request: rue_codegen::BackendArtifactRequest,
         optimization: rue_cfg::OptLevel,
         cancellation: CancellationToken,
     ) -> Result<QueryRequestAttempt<crate::codegen_query::CodegenUnitValue>, QueryAbort> {
-        let live = Arc::new(crate::codegen_query::CodegenLiveInput {
-            function: Arc::new(function),
-            type_pool,
-            strings,
-            interner,
-            symbol_mappings,
-            foreign_symbols,
-            optimized_cfg_key,
-        });
         Ok(self.runtime.request_registered(
             &self.codegen_units,
             revision,
-            crate::codegen_query::CodegenUnitQueryKey::new(live, target, request, optimization),
+            crate::codegen_query::CodegenUnitQueryKey::new(
+                optimized_cfg_key,
+                target,
+                request,
+                optimization,
+            ),
             cancellation,
         ))
     }

--- a/crates/rue-compiler/src/session.rs
+++ b/crates/rue-compiler/src/session.rs
@@ -740,6 +740,10 @@ pub struct CompilerSession {
     queries: FrontendQueryDatabase,
     #[cfg(test)]
     codegen_executions: Vec<(crate::FunctionInstanceKey, rue_query::RequestExecution)>,
+    #[cfg(test)]
+    codegen_attempt_work: Vec<(crate::FunctionInstanceKey, Vec<(std::sync::Arc<str>, u64)>)>,
+    #[cfg(test)]
+    codegen_collections: usize,
     /// One-shot cancellation injections, each consumed with `mem::take` at a
     /// fixed point inside an attempt.
     ///
@@ -4038,12 +4042,11 @@ impl CompilerSession {
     pub(crate) fn codegen_products(
         &mut self,
         semantic: &crate::CanonicalSemanticOutput,
-        foreign_symbols: &[String],
         options: &crate::CompileOptions,
         request: rue_codegen::BackendArtifactRequest,
     ) -> Result<Vec<crate::backend::FunctionBackendProduct>, crate::CompileErrors> {
         Ok(self
-            .codegen_units(semantic, foreign_symbols, options, request)?
+            .codegen_units(semantic, options, request)?
             .into_iter()
             .map(|collected| collected.unit.backend_product())
             .collect())
@@ -4053,11 +4056,11 @@ impl CompilerSession {
     /// collapsing them into the historical backend-product representation.
     /// Object and link consumers aggregate this exact result in a
     /// `ProgramImagePlan`; presentation consumers may still use the thin
-    /// `codegen_products` projection above.
+    /// `codegen_products` projection above. RUE-1217 owns replacing this
+    /// remaining semantic root enumeration with query-native image roots.
     pub(crate) fn codegen_units(
         &mut self,
         semantic: &crate::CanonicalSemanticOutput,
-        foreign_symbols: &[String],
         options: &crate::CompileOptions,
         request: rue_codegen::BackendArtifactRequest,
     ) -> Result<Vec<crate::codegen_query::CollectedCodegenUnit>, crate::CompileErrors> {
@@ -4072,29 +4075,19 @@ impl CompilerSession {
                     ),
                 ))
             })?;
-        let mappings = Arc::new(crate::backend::foreign_call_symbol_mappings(
-            semantic.functions(),
-            foreign_symbols,
-        ));
-        let foreign: Arc<std::collections::BTreeSet<String>> =
-            Arc::new(foreign_symbols.iter().cloned().collect());
-        let strings: Arc<[String]> = semantic.strings().to_vec().into();
-        let interner = semantic.rir_owner().semantic_symbols().shared_interner();
         let mut units = Vec::with_capacity(semantic.functions().len());
         #[cfg(test)]
-        self.codegen_executions.clear();
+        {
+            self.codegen_executions.clear();
+            self.codegen_attempt_work.clear();
+            self.codegen_collections = 0;
+        }
         for function in semantic.functions() {
             let attempt = self
                 .queries
                 .revisioned
                 .codegen_unit(
                     revision,
-                    function.clone(),
-                    semantic.type_pool().clone(),
-                    strings.clone(),
-                    interner.clone(),
-                    mappings.clone(),
-                    foreign.clone(),
                     function.optimized_cfg_key.clone(),
                     options.target,
                     request,
@@ -4109,8 +4102,12 @@ impl CompilerSession {
                     ))
                 })?;
             #[cfg(test)]
-            self.codegen_executions
-                .push((function.semantic_identity.clone(), attempt.execution()));
+            {
+                self.codegen_executions
+                    .push((function.semantic_identity.clone(), attempt.execution()));
+                self.codegen_attempt_work
+                    .push((function.semantic_identity.clone(), attempt.work().to_vec()));
+            }
             let terminal = attempt.into_result().map_err(|abort| {
                 crate::CompileErrors::from(crate::CompileError::without_span(
                     crate::ErrorKind::InternalError(format!("codegen query aborted: {abort:?}")),
@@ -4122,9 +4119,13 @@ impl CompilerSession {
             match unit {
                 crate::codegen_query::CodegenUnitValue::Available(unit) => {
                     units.push(crate::codegen_query::CollectedCodegenUnit {
-                        function: function.clone(),
+                        function: function.semantic_identity.clone(),
                         unit: unit.clone(),
                     });
+                    #[cfg(test)]
+                    {
+                        self.codegen_collections += 1;
+                    }
                 }
                 crate::codegen_query::CodegenUnitValue::Failure(errors) => {
                     return Err(errors.clone());
@@ -4139,6 +4140,18 @@ impl CompilerSession {
         &self,
     ) -> &[(crate::FunctionInstanceKey, rue_query::RequestExecution)] {
         &self.codegen_executions
+    }
+
+    #[cfg(test)]
+    pub(crate) fn codegen_attempt_work(
+        &self,
+    ) -> &[(crate::FunctionInstanceKey, Vec<(std::sync::Arc<str>, u64)>)] {
+        &self.codegen_attempt_work
+    }
+
+    #[cfg(test)]
+    pub(crate) fn codegen_collections(&self) -> usize {
+        self.codegen_collections
     }
 
     /// Analyze the current revision, surfacing an unsatisfied trusted-toolchain
@@ -9646,6 +9659,177 @@ fn main() -> i32 {
         assert_ne!(first_helper.1, second_helper.1);
         assert_eq!(first_helper.2, second_helper.2);
         assert_eq!(first_helper.3, second_helper.3);
+    }
+
+    #[test]
+    fn codegen_units_observe_exact_owned_dependencies_and_reuse_unchanged_callers() {
+        let options = CompileOptions::default();
+        let first = SourceSnapshot::single(
+            "main.rue",
+            "fn helper() -> i32 { 1 } fn main() -> i32 { if false { helper() } else { 0 } }",
+        )
+        .unwrap();
+        let second = SourceSnapshot::single(
+            "main.rue",
+            "fn helper() -> i32 { 2 } fn main() -> i32 { if false { helper() } else { 0 } }",
+        )
+        .unwrap();
+        let mut session = CompilerSession::new();
+        let compile_units = |session: &mut CompilerSession| {
+            let semantic = session.canonical_semantic(&options).unwrap();
+            session
+                .codegen_units(
+                    &semantic,
+                    &options,
+                    rue_codegen::BackendArtifactRequest::default(),
+                )
+                .unwrap();
+            semantic
+        };
+
+        session.update(&first).into_result().unwrap();
+        let cold = compile_units(&mut session);
+        assert_eq!(session.codegen_collections(), cold.functions().len());
+        assert!(
+            session
+                .codegen_executions()
+                .iter()
+                .all(|(_, execution)| { *execution == rue_query::RequestExecution::Computed })
+        );
+        for (_, work) in session.codegen_attempt_work() {
+            let amount = |label: &str| {
+                work.iter()
+                    .find_map(|(candidate, amount)| {
+                        (candidate.as_ref() == label).then_some(*amount)
+                    })
+                    .unwrap_or(0)
+            };
+            assert_eq!(amount("codegen.dependencies.optimized-cfg"), 1);
+            assert_eq!(amount("codegen.lowering.local"), 1);
+            assert_eq!(amount("codegen.unit.successes"), 1);
+        }
+        let cold_main = cold
+            .functions()
+            .iter()
+            .find(|function| function.legacy_name == "main")
+            .unwrap();
+        let cold_main_work = session
+            .codegen_attempt_work()
+            .iter()
+            .find(|(identity, _)| identity == &cold_main.semantic_identity)
+            .unwrap();
+        assert!(cold_main_work.1.iter().any(|(label, amount)| {
+            label.as_ref() == "codegen.domain.symbol-aliases" && *amount > 0
+        }));
+
+        session.update(&second).into_result().unwrap();
+        let warm = compile_units(&mut session);
+        assert_eq!(session.codegen_collections(), warm.functions().len());
+        let identity_for = |name: &str| {
+            warm.functions()
+                .iter()
+                .find(|function| function.legacy_name == name)
+                .unwrap()
+                .semantic_identity
+                .clone()
+        };
+        let execution_for = |identity: &crate::FunctionInstanceKey| {
+            session
+                .codegen_executions()
+                .iter()
+                .find_map(|(candidate, execution)| (candidate == identity).then_some(*execution))
+                .unwrap()
+        };
+        assert_eq!(
+            execution_for(&identity_for("main")),
+            rue_query::RequestExecution::Reused,
+            "an optimized-away alias does not make a callee implementation an exact caller dependency"
+        );
+        assert_eq!(
+            execution_for(&identity_for("helper")),
+            rue_query::RequestExecution::Computed
+        );
+        let main_work = session
+            .codegen_attempt_work()
+            .iter()
+            .find(|(identity, _)| identity == &identity_for("main"))
+            .unwrap();
+        assert!(
+            main_work.1.is_empty(),
+            "reused codegen terminals perform no local lowering or dependency collection"
+        );
+    }
+
+    #[test]
+    fn cfg_fails_closed_when_an_exact_call_abi_dependency_fails() {
+        let source = SourceSnapshot::single(
+            "main.rue",
+            "fn helper(value: i32) -> i32 { value } fn main() -> i32 { helper(42) }",
+        )
+        .unwrap();
+        let mut session = CompilerSession::new();
+        session.update(&source).into_result().unwrap();
+        let errors = crate::cfg_query::with_test_call_abi_failure_injection(|| {
+            session
+                .canonical_semantic(&CompileOptions::default())
+                .unwrap_err()
+        });
+        let rendered = errors.to_string();
+        assert!(rendered.contains("call ABI unavailable"), "{rendered}");
+        assert!(rendered.contains("injected call ABI failure"), "{rendered}");
+    }
+
+    #[test]
+    fn owned_codegen_domains_preserve_legacy_backend_bytes_on_both_architectures() {
+        let source = SourceSnapshot::single(
+            "main.rue",
+            "fn add(left: i32, right: i32) -> i32 { left + right }\n\
+             fn main() -> i32 { let message = \"owned\"; @dbg(message); add(20, 22) }",
+        )
+        .unwrap();
+        for target in [Target::X86_64Linux, Target::Aarch64Linux] {
+            let options = CompileOptions {
+                target,
+                ..CompileOptions::default()
+            };
+            let mut session = CompilerSession::new();
+            session.update(&source).into_result().unwrap();
+            let semantic = session.canonical_semantic(&options).unwrap();
+            let foreign = crate::backend::collect_foreign_symbols(
+                semantic.rir_owner().rir(),
+                semantic.rir_owner().semantic_symbols().interner(),
+            );
+            let owned = session
+                .codegen_units(
+                    &semantic,
+                    &options,
+                    rue_codegen::BackendArtifactRequest::default(),
+                )
+                .unwrap()
+                .into_iter()
+                .map(|unit| unit.unit.backend_product())
+                .collect::<Vec<_>>();
+            let legacy = crate::backend::generate_backend_products(
+                semantic.functions(),
+                semantic.type_pool(),
+                semantic.strings(),
+                semantic.rir_owner().semantic_symbols().interner(),
+                &options,
+                &foreign,
+                rue_codegen::BackendArtifactRequest::default(),
+            )
+            .unwrap();
+            assert_eq!(owned.len(), legacy.len());
+            for (owned, legacy) in owned.iter().zip(&legacy) {
+                assert_eq!(owned.machine_name, legacy.machine_name);
+                assert_eq!(owned.machine_code.code, legacy.machine_code.code);
+                assert_eq!(owned.machine_code.strings, legacy.machine_code.strings);
+                assert_eq!(
+                    format!("{:?}", owned.machine_code.relocations),
+                    format!("{:?}", legacy.machine_code.relocations)
+                );
+            }
+        }
     }
 
     #[test]

--- a/crates/rue-compiler/src/unstable.rs
+++ b/crates/rue-compiler/src/unstable.rs
@@ -711,14 +711,8 @@ impl crate::CompilerSession {
                     _ => None,
                 };
                 if let Some(backend_request) = backend_request {
-                    let foreign_symbols =
-                        crate::backend::collect_foreign_symbols(rir.rir(), interner);
-                    let products = self.codegen_products(
-                        &semantic,
-                        &foreign_symbols,
-                        request.options,
-                        backend_request,
-                    )?;
+                    let products =
+                        self.codegen_products(&semantic, request.options, backend_request)?;
                     for product in products {
                         match stage {
                             PresentationStage::Lowering => {
@@ -863,7 +857,6 @@ mod codegen_unit_tests {
         first_emit
             .codegen_products(
                 &semantic,
-                &[],
                 &options,
                 rue_codegen::BackendArtifactRequest::default(),
             )
@@ -883,7 +876,6 @@ mod codegen_unit_tests {
         first_link
             .codegen_products(
                 &semantic,
-                &[],
                 &options,
                 rue_codegen::BackendArtifactRequest::default(),
             )
@@ -913,7 +905,6 @@ mod codegen_unit_tests {
             session
                 .codegen_products(
                     &semantic,
-                    &[],
                     &options,
                     rue_codegen::BackendArtifactRequest::default(),
                 )
@@ -950,7 +941,6 @@ mod codegen_unit_tests {
         let before = session
             .codegen_products(
                 &semantic,
-                &[],
                 &options,
                 rue_codegen::BackendArtifactRequest::default(),
             )
@@ -972,7 +962,6 @@ mod codegen_unit_tests {
         let after = session
             .codegen_products(
                 &semantic,
-                &[],
                 &options,
                 rue_codegen::BackendArtifactRequest::default(),
             )
@@ -1014,7 +1003,6 @@ mod codegen_unit_tests {
             let first = session
                 .codegen_products(
                     &semantic,
-                    &[],
                     &options,
                     rue_codegen::BackendArtifactRequest::default(),
                 )
@@ -1022,7 +1010,6 @@ mod codegen_unit_tests {
             let second = session
                 .codegen_products(
                     &semantic,
-                    &[],
                     &options,
                     rue_codegen::BackendArtifactRequest::default(),
                 )
@@ -1077,7 +1064,6 @@ mod codegen_unit_tests {
             let products = session
                 .codegen_products(
                     &semantic,
-                    &[],
                     &options,
                     rue_codegen::BackendArtifactRequest {
                         asm: true,
@@ -1119,7 +1105,6 @@ mod codegen_unit_tests {
         let before = session
             .codegen_products(
                 &semantic,
-                &[],
                 &options,
                 rue_codegen::BackendArtifactRequest::default(),
             )
@@ -1139,7 +1124,6 @@ mod codegen_unit_tests {
         let after = session
             .codegen_products(
                 &semantic,
-                &[],
                 &options,
                 rue_codegen::BackendArtifactRequest::default(),
             )


### PR DESCRIPTION
## Summary

- make each codegen-unit query obtain its optimized CFG and lowering domain through registered query dependencies
- move symbol relocation, foreign-call classification, type/string/interner data, and cleanup aliases into the CFG-owned terminal
- keep collected codegen units limited to stable function identity plus emitted unit
- derive call-ABI dependencies from actual CFG runtime calls and fail closed on unavailable ABI facts
- add architecture, reuse, constructor, foreign-call, and API-boundary regressions

## Validation

- `RUE_TEST_TIER=premerge ./test.sh` (78 targets passed)
- `scripts/rue quick` (761 passed, 1 ignored)
- `scripts/rue cli c_ffi` (38/38)
- focused zero-argument constructor and injected call-ABI failure regressions
- `scripts/rue fmt`
- `git diff --check`

Fixes RUE-1216.

Refs RUE-1199.