### PR TITLE
Derive free-function identity from the declaring module

### DIFF
--- a/crates/rue-air/src/sema/binding_manifest.rs
+++ b/crates/rue-air/src/sema/binding_manifest.rs
@@ -2369,6 +2369,27 @@ impl<'a> BoundSema<'a> {
         self.sema.function_info(name).copied()
     }
 
+    /// Map a source free-function name in one file to the internal symbol its
+    /// declaration was bound under.
+    ///
+    /// An ordinary function's internal symbol is module-qualified (RUE-1125),
+    /// so it is never the source spelling; a caller holding a source name needs
+    /// this binding before consulting [`Self::function_info`].
+    pub fn free_function_symbol(&self, file: FileId, source_name: Spur) -> Option<Spur> {
+        self.sema.resolve_function_name_local(source_name, file)
+    }
+
+    /// Map an internal function symbol back to the source name it was declared
+    /// under, leaving any other symbol unchanged.
+    ///
+    /// Parity checks against the durable provider path compare declarations,
+    /// and the provider assembles its facts in source-name handles while an
+    /// epoch names callables by internal symbol; this is the projection that
+    /// puts both in the same terms.
+    pub fn function_source_name(&self, symbol: Spur) -> Spur {
+        self.sema.source_function_name(symbol)
+    }
+
     /// Return the canonical resolved nominal [`Type`] for `(file, name)`.
     /// Provider-boundary parity checks compare it with the independently
     /// assembled `ProviderEndpointFacts` result.

--- a/crates/rue-air/src/sema/declaration_index.rs
+++ b/crates/rue-air/src/sema/declaration_index.rs
@@ -74,9 +74,6 @@ pub(super) struct RirDeclarationIndex {
     anonymous_methods: Vec<InstRef>,
     named_method_refs: HashSet<InstRef>,
     anonymous_method_refs: HashSet<InstRef>,
-    /// Deliberately preserves the historical internal-symbol rule: every
-    /// receiverless `FnDecl` counts, including associated functions.
-    non_receiver_name_multiplicity: HashMap<Spur, usize>,
     destructors: Vec<RirDestructorDeclaration>,
     shell_declarations: Vec<RirShellDeclaration>,
     work: RirDeclarationIndexWork,
@@ -146,7 +143,6 @@ impl RirDeclarationIndex {
         let mut named_method_owners = HashMap::new();
         let mut anonymous_method_refs = HashSet::new();
         let mut declaration_source_orders = HashMap::new();
-        let mut non_receiver_name_multiplicity = HashMap::<Spur, usize>::new();
         let mut destructors = Vec::new();
         let mut const_shell_declarations = Vec::new();
         let mut work = RirDeclarationIndexWork {
@@ -169,9 +165,6 @@ impl RirDeclarationIndex {
                         name: *name,
                         has_self: *has_self,
                     });
-                    if !*has_self {
-                        *non_receiver_name_multiplicity.entry(*name).or_default() += 1;
-                    }
                 }
                 InstData::StructDecl { name, methods, .. } => {
                     for method_ref in rir.struct_methods(methods) {
@@ -274,7 +267,6 @@ impl RirDeclarationIndex {
             anonymous_methods,
             named_method_refs,
             anonymous_method_refs,
-            non_receiver_name_multiplicity,
             destructors,
             shell_declarations,
             work,
@@ -291,14 +283,6 @@ impl RirDeclarationIndex {
         );
         debug_assert_eq!(self.work.destructors_indexed, self.destructors.len());
         self.work
-    }
-
-    #[inline]
-    pub(super) fn non_receiver_name_multiplicity(&self, name: Spur) -> usize {
-        self.non_receiver_name_multiplicity
-            .get(&name)
-            .copied()
-            .unwrap_or_default()
     }
 
     pub(super) fn first_free_function(
@@ -488,7 +472,6 @@ mod tests {
             .first_free_function(collide, Some(FileId::new(7)))
             .unwrap();
         assert!(!index.is_type_scoped_method(free_collide));
-        assert_eq!(index.non_receiver_name_multiplicity(collide), 3);
 
         let destructors = index.destructors();
         assert_eq!(destructors.len(), 1);
@@ -559,7 +542,6 @@ mod tests {
             index.first_free_function(same, Some(second)),
             second_candidates.first().copied()
         );
-        assert_eq!(index.non_receiver_name_multiplicity(same), 3);
         let bound_consts = bound_const_candidates(&rir, &index);
         assert_eq!(bound_consts.candidates(second, same).len(), 1);
 
@@ -655,9 +637,9 @@ mod tests {
         sema.set_symbol_paths(HashMap::from([(file_id, "pkg/main.rue".to_owned())]));
         let output = sema.analyze_all().unwrap();
 
-        // Receiverless associated functions historically participate in the
-        // free-function name multiplicity used for machine symbols. RUE-656
-        // indexes that rule instead of silently "correcting" the spelling.
+        // A free function's internal symbol is module-qualified from its own
+        // declaration (RUE-1125), and the index selects the free declaration
+        // rather than the same-named associated function that precedes it.
         let expected_name = "__rue_fn_pkg_2fmain_2erue__collide";
         let free = output
             .functions

--- a/crates/rue-air/src/sema/declarations.rs
+++ b/crates/rue-air/src/sema/declarations.rs
@@ -47,45 +47,71 @@ impl<'a, D: DeclarationPhase> Sema<'a, D> {
             .unwrap_or(internal_name)
     }
 
+    /// The internal symbol of an ordinary function, derived only from its own
+    /// declaration and module (RUE-1125).
+    ///
+    /// A function's identity is a property of where it is declared, never of
+    /// what else the program happens to contain: the spelling is decided from
+    /// `(module, source name)` alone, so adding or removing an unrelated
+    /// declaration anywhere else cannot restamp an existing function's
+    /// semantic identity, body artifact, or dependency edges. Two declarations
+    /// name themselves instead, and each is recognized from its own
+    /// declaration, never from what the rest of the program contains:
+    ///
+    /// - The ROOT module's `main` keeps the unmangled `main` symbol the runtime
+    ///   `_start`/`__main` glue calls (spec 6.1:38, RUE-920/RUE-921). When no
+    ///   root is designated (single-file callers that never call
+    ///   `set_root_file_id`) that lone file is the root, so its `main` keeps the
+    ///   bare name too. A `main` in any OTHER module is an ordinary namespaced
+    ///   function: it must never keep the bare `main` symbol, so it cannot
+    ///   collide with the root entry point and so a root that lacks `main` still
+    ///   fails with `NoMainFunction` instead of silently adopting an imported
+    ///   entry point.
+    ///
+    /// - An `extern "C"` foreign declaration (ADR-0064) declares an external C
+    ///   symbol rather than a Rue callable: it has no body, no artifact, and no
+    ///   Rue namespace of its own, and a call site lowers to that raw symbol for
+    ///   the linker to satisfy from an archive. Its internal symbol therefore is
+    ///   the C name it declares. The declaration is read from its own module, so
+    ///   this stays a property of the declaration.
+    ///
+    /// A `pub extern "C" fn` export is *not* an exception here. Its native body
+    /// is an ordinary module-qualified callable like any other; its unmangled C
+    /// symbol is specified separately and emitted as a distinct entry thunk
+    /// (ADR-0064 P4, `backend::generate_export_thunk_objects`).
     pub(super) fn internal_function_name(&self, source_name: Spur, file_id: FileId) -> Spur {
         let source = self.interner.resolve(&source_name);
-        // The program entry point is the ROOT module's `main`: it keeps the
-        // unmangled `main` symbol the runtime `_start`/`__main` glue calls
-        // (spec 6.1:38, RUE-920/RUE-921). When no root is designated (single-file
-        // callers that never call `set_root_file_id`) that lone file is the
-        // root, so its `main` keeps the bare name too.
         let file_is_root = self.root_file_id.is_none_or(|root| root == file_id);
         if source == "main" && file_is_root {
             return source_name;
         }
-        // A `main` in any OTHER module is an ordinary namespaced function
-        // (spec 6.1:38). It must never keep the bare `main` symbol — even as the
-        // only `main` in the program — so it cannot collide with the root's
-        // entry point and so a root that lacks `main` still fails with
-        // `NoMainFunction` instead of silently adopting an imported entry
-        // point. Force it down the mangling path regardless of multiplicity.
-        //
-        // Otherwise preserve the historical symbol rule exactly in this
-        // preparatory slice: receiverless associated functions count too.
-        // Correct free function classification is indexed separately for body
-        // lookup.
-        let non_root_main = source == "main";
-        if non_root_main
-            || self
-                .declaration_index
-                .non_receiver_name_multiplicity(source_name)
-                > 1
-        {
-            let module_component = self
-                .get_symbol_path(file_id)
-                .map(normalize_module_path)
-                .unwrap_or_else(|| format!("file{}", file_id.index()));
-            let module_component = mangle_symbol_component(&module_component);
-            self.interner
-                .get_or_intern(&format!("__rue_fn_{}__{}", module_component, source))
-        } else {
-            source_name
+        if self.declares_foreign_function(source_name, file_id) {
+            return source_name;
         }
+        let module_component = self
+            .get_symbol_path(file_id)
+            .map(normalize_module_path)
+            .unwrap_or_else(|| format!("file{}", file_id.index()));
+        let module_component = mangle_symbol_component(&module_component);
+        self.interner
+            .get_or_intern(&format!("__rue_fn_{}__{}", module_component, source))
+    }
+
+    /// Whether `file_id` declares `source_name` as an `extern "C"` foreign
+    /// function. This reads only that file's own declarations — the same
+    /// file-scoped free-function selection body binding performs.
+    fn declares_foreign_function(&self, source_name: Spur, file_id: FileId) -> bool {
+        self.declaration_index
+            .first_free_function(source_name, Some(file_id))
+            .is_some_and(|declaration| {
+                matches!(
+                    self.rir.get(declaration).data,
+                    InstData::FnDecl {
+                        is_extern: true,
+                        ..
+                    }
+                )
+            })
     }
 
     /// Resolve a source-level function name only in the given source file.

--- a/crates/rue-air/src/sema/metadata.rs
+++ b/crates/rue-air/src/sema/metadata.rs
@@ -44,6 +44,25 @@ impl SemaMetadata {
         .expect("synthetic sema fixture path must be non-empty")
     }
 
+    /// The internal symbol an ordinary free function declared in the root
+    /// module of a [`super::Sema::new_synthetic`] program is bound under.
+    ///
+    /// A synthetic program names its modules `synthetic/<file index>.rue`, and
+    /// an ordinary function's internal symbol is derived from its own module
+    /// and source name (RUE-1125); only the root module's `main` keeps the bare
+    /// source spelling. Tests that locate an analyzed function by source name
+    /// go through this so the naming rule has one statement.
+    pub fn synthetic_root_function_symbol(source_name: &str) -> String {
+        if source_name == "main" {
+            return source_name.to_owned();
+        }
+        let module = crate::path_norm::mangle_symbol_component(&normalize_module_path(&format!(
+            "synthetic/{}.rue",
+            FileId::DEFAULT.index()
+        )));
+        format!("__rue_fn_{module}__{source_name}")
+    }
+
     pub(super) fn synthetic_for_rir(rir: &Rir) -> Self {
         let mut ids: Vec<_> = rir.iter().map(|(_, inst)| inst.span.file_id).collect();
         ids.sort_by_key(|id| id.index());

--- a/crates/rue-air/src/sema/tests.rs
+++ b/crates/rue-air/src/sema/tests.rs
@@ -60,6 +60,12 @@ mod tests {
         compile_to_air_with_preview_features(source, PreviewFeatures::new())
     }
 
+    /// The internal symbol of an ordinary free function declared in a synthetic
+    /// single-module test program (RUE-1125).
+    fn internal_name(source_name: &str) -> String {
+        crate::SemaMetadata::synthetic_root_function_symbol(source_name)
+    }
+
     fn compile_to_air_with_preview_features(
         source: &str,
         preview_features: PreviewFeatures,
@@ -741,7 +747,7 @@ mod tests {
         let make_type = output
             .functions
             .iter()
-            .find(|function| function.name == "make")
+            .find(|function| function.name == internal_name("make"))
             .unwrap()
             .air
             .return_type();
@@ -1215,7 +1221,7 @@ mod tests {
             let function = output
                 .functions
                 .iter()
-                .find(|function| function.name == "probe")
+                .find(|function| function.name == internal_name("probe"))
                 .unwrap_or_else(|| panic!("missing analyzed function {name}"));
             let intrinsic_types: Vec<_> = function
                 .air
@@ -1870,7 +1876,7 @@ mod tests {
         let replace = output
             .functions
             .iter()
-            .find(|function| function.name == "replace")
+            .find(|function| function.name == internal_name("replace"))
             .unwrap();
         let stored_value = replace
             .air
@@ -1938,7 +1944,7 @@ mod tests {
         let replace = output
             .functions
             .iter()
-            .find(|function| function.name == "replace")
+            .find(|function| function.name == internal_name("replace"))
             .unwrap();
         let stored_value = replace
             .air
@@ -2183,7 +2189,7 @@ mod tests {
         let shadow = output
             .functions
             .iter()
-            .find(|function| function.name == "shadow")
+            .find(|function| function.name == internal_name("shadow"))
             .unwrap();
         assert_eq!(shadow.num_locals, 2);
         assert_eq!(shadow.air.return_type(), Type::BOOL);
@@ -2461,7 +2467,7 @@ mod tests {
             output
                 .functions
                 .iter()
-                .find(|function| function.name == "length")
+                .find(|function| function.name == internal_name("length"))
                 .unwrap()
                 .air
                 .return_type(),
@@ -2485,7 +2491,7 @@ mod tests {
             output
                 .functions
                 .iter()
-                .find(|function| function.name == "empty")
+                .find(|function| function.name == internal_name("empty"))
                 .unwrap()
                 .air
                 .return_type(),
@@ -2511,7 +2517,7 @@ mod tests {
             output
                 .functions
                 .iter()
-                .find(|function| function.name == "has_content")
+                .find(|function| function.name == internal_name("has_content"))
                 .unwrap()
                 .num_locals
                 >= 2
@@ -2616,7 +2622,7 @@ mod tests {
             output
                 .functions
                 .iter()
-                .find(|function| function.name == "value")
+                .find(|function| function.name == internal_name("value"))
                 .unwrap()
                 .air
                 .return_type(),
@@ -2636,7 +2642,7 @@ mod tests {
             output
                 .functions
                 .iter()
-                .find(|function| function.name == "value")
+                .find(|function| function.name == internal_name("value"))
                 .unwrap()
                 .air
                 .return_type(),
@@ -2660,7 +2666,7 @@ mod tests {
             output
                 .functions
                 .iter()
-                .find(|function| function.name == "value")
+                .find(|function| function.name == internal_name("value"))
                 .unwrap()
                 .air
                 .return_type(),
@@ -2960,7 +2966,7 @@ fn main() -> i32 {
             output
                 .functions
                 .iter()
-                .any(|function| function.name == "good_drop")
+                .any(|function| function.name == internal_name("good_drop"))
         );
         assert!(output.aggregate_type_identities_by_type.keys().any(|ty| {
             ty.as_struct().is_some_and(|id| {
@@ -3017,7 +3023,7 @@ fn main() -> i32 {
             output
                 .functions
                 .iter()
-                .any(|function| function.name == "bad_drop")
+                .any(|function| function.name == internal_name("bad_drop"))
         );
         assert!(output.aggregate_type_identities_by_type.keys().any(|ty| {
             ty.as_struct().is_some_and(|id| {
@@ -4330,5 +4336,171 @@ fn main() -> i32 {{
             )
         });
         assert!(has_panic, "the accessor guard's panic inlines into main");
+    }
+
+    // =========================================================================
+    // Callable identity (RUE-1125)
+    // =========================================================================
+    // An ordinary function's internal symbol is decided by its own module and
+    // source name, so no other declaration in the program can rename it. The
+    // exceptions are declaration-local too: the root module's `main` keeps the
+    // entry-point symbol, and an `extern "C"` declaration keeps the C symbol it
+    // names.
+
+    /// The internal symbols of `(source name, file)` in a program assembled
+    /// from `files`, each `(source, file id, module symbol path)`. The first
+    /// file is the root module.
+    fn internal_symbols(files: &[(&str, FileId, &str)], queries: &[(&str, FileId)]) -> Vec<String> {
+        let sources = files
+            .iter()
+            .map(|&(source, file_id, _)| (source, file_id))
+            .collect::<Vec<_>>();
+        let (rir, interner) = lower_files(&sources);
+        let mut sema = Sema::new_synthetic(&rir, &interner, PreviewFeatures::new());
+        sema.set_root_file_id(files[0].1);
+        sema.set_symbol_paths(
+            files
+                .iter()
+                .map(|&(_, file_id, path)| (file_id, path.to_owned()))
+                .collect::<HashMap<_, _>>(),
+        );
+        queries
+            .iter()
+            .map(|&(name, file_id)| {
+                let name = interner.get(name).expect("query name is interned");
+                interner
+                    .resolve(&sema.internal_function_name(name, file_id))
+                    .to_owned()
+            })
+            .collect()
+    }
+
+    const IDENTITY_ROOT: (&str, FileId, &str) =
+        ("fn main() -> i32 { 0 }", FileId::new(1), "pkg/main.rue");
+    const IDENTITY_HELPERS: (&str, FileId, &str) = (
+        "pub fn value() -> i32 { 1 }",
+        FileId::new(2),
+        "pkg/helpers.rue",
+    );
+
+    #[test]
+    fn free_function_identity_is_module_local_not_program_wide() {
+        let value = [("value", FileId::new(2))];
+        let alone = internal_symbols(&[IDENTITY_ROOT, IDENTITY_HELPERS], &value);
+        assert_eq!(alone, ["__rue_fn_pkg_2fhelpers_2erue__value"]);
+
+        // An unrelated same-named free function in another module is not an
+        // input to this declaration's identity.
+        let with_free_twin = internal_symbols(
+            &[
+                IDENTITY_ROOT,
+                IDENTITY_HELPERS,
+                (
+                    "pub fn value() -> i32 { 2 }",
+                    FileId::new(3),
+                    "pkg/other.rue",
+                ),
+            ],
+            &value,
+        );
+        assert_eq!(with_free_twin, alone);
+
+        // Neither is a same-named receiverless associated function, which was
+        // never a free-function lookup candidate to begin with.
+        let with_associated_twin = internal_symbols(
+            &[
+                IDENTITY_ROOT,
+                IDENTITY_HELPERS,
+                (
+                    "pub struct Owner { fn value() -> i32 { 3 } }",
+                    FileId::new(3),
+                    "pkg/other.rue",
+                ),
+            ],
+            &value,
+        );
+        assert_eq!(with_associated_twin, alone);
+
+        // A same-named associated function in the declaration's OWN module is
+        // equally irrelevant.
+        let with_local_associated_twin = internal_symbols(
+            &[
+                IDENTITY_ROOT,
+                (
+                    "pub struct Owner { fn value() -> i32 { 3 } }\n\
+                     pub fn value() -> i32 { 1 }",
+                    FileId::new(2),
+                    "pkg/helpers.rue",
+                ),
+            ],
+            &value,
+        );
+        assert_eq!(with_local_associated_twin, alone);
+    }
+
+    #[test]
+    fn same_named_free_functions_in_distinct_modules_are_distinct_symbols() {
+        let symbols = internal_symbols(
+            &[
+                IDENTITY_ROOT,
+                (
+                    "pub fn value() -> i32 { 1 }",
+                    FileId::new(2),
+                    "pkg/left.rue",
+                ),
+                (
+                    "pub fn value() -> i32 { 2 }",
+                    FileId::new(3),
+                    "pkg/right.rue",
+                ),
+            ],
+            &[("value", FileId::new(2)), ("value", FileId::new(3))],
+        );
+        assert_eq!(
+            symbols,
+            [
+                "__rue_fn_pkg_2fleft_2erue__value",
+                "__rue_fn_pkg_2fright_2erue__value"
+            ],
+            "each module owns its own callable (RUE-426)"
+        );
+    }
+
+    #[test]
+    fn only_the_root_module_main_keeps_the_entry_point_symbol() {
+        let symbols = internal_symbols(
+            &[
+                IDENTITY_ROOT,
+                (
+                    "pub fn main() -> i32 { 7 }",
+                    FileId::new(2),
+                    "pkg/helpers.rue",
+                ),
+            ],
+            &[("main", FileId::new(1)), ("main", FileId::new(2))],
+        );
+        assert_eq!(symbols, ["main", "__rue_fn_pkg_2fhelpers_2erue__main"]);
+    }
+
+    #[test]
+    fn a_foreign_declaration_keeps_the_c_symbol_it_names() {
+        // A foreign `extern "C"` declaration has no Rue body: it names an
+        // external symbol the linker resolves, so that name is its identity.
+        // An export is the opposite — an ordinary Rue body whose separately
+        // specified C name rides its entry thunk (ADR-0064 P4).
+        let symbols = internal_symbols(
+            &[(
+                "extern \"C\" { fn c_answer() -> i32; }\n\
+                 pub extern \"C\" fn rue_answer() -> i32 { 42 }\n\
+                 fn main() -> i32 { 0 }",
+                FileId::new(1),
+                "pkg/main.rue",
+            )],
+            &[("c_answer", FileId::new(1)), ("rue_answer", FileId::new(1))],
+        );
+        assert_eq!(
+            symbols,
+            ["c_answer", "__rue_fn_pkg_2fmain_2erue__rue_answer"]
+        );
     }
 }

--- a/crates/rue-air/src/sema/typeck.rs
+++ b/crates/rue-air/src/sema/typeck.rs
@@ -1925,7 +1925,13 @@ impl<'source, D: DeclarationPhase> TypeSyntaxHost for Sema<'source, D> {
                 self.declaration_type_observer = observer;
                 self.resolve_function_name_local(name, file)
             }
-            (TypeRootAuthority::GlobalSpeculative, None) => Some(name),
+            // A speculative root resolves against the default file, which is
+            // where its caller anchors the syntax. The function table is keyed
+            // by internal symbol, never by source spelling, so the binding must
+            // be reached through the file-local source namespace.
+            (TypeRootAuthority::GlobalSpeculative, None) => {
+                self.resolve_function_name_local(name, FileId::DEFAULT)
+            }
             (TypeRootAuthority::GlobalSpeculative, Some(_)) => return Ok(None),
         };
         let Some(key) = key else { return Ok(None) };

--- a/crates/rue-cfg/src/build.rs
+++ b/crates/rue-cfg/src/build.rs
@@ -3361,7 +3361,7 @@ impl<'a> CfgBuilder<'a> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use rue_air::{AirEditor, AirValidationContext, Sema};
+    use rue_air::{AirEditor, AirValidationContext, Sema, SemaMetadata};
     use rue_error::PreviewFeatures;
     use rue_lexer::Lexer;
     use rue_parser::Parser;
@@ -3382,10 +3382,11 @@ mod tests {
     /// Build the CFG for the analyzed function called `name` in `source`
     /// (robust to analysis order, unlike `build_cfg_for`).
     fn build_cfg_named(source: &str, name: &str) -> Cfg {
+        let symbol = SemaMetadata::synthetic_root_function_symbol(name);
         build_cfg_select(source, |functions| {
             functions
                 .iter()
-                .find(|f| f.name == name)
+                .find(|f| f.name == symbol)
                 .unwrap_or_else(|| panic!("no analyzed function named '{}'", name))
         })
     }
@@ -3473,10 +3474,18 @@ mod tests {
         sema.set_trusted_standard_library_files(HashSet::from([module_file]));
         let output = sema.analyze_all_for_test_with_stable_endpoints().unwrap();
 
+        // The fixture's module carries an explicit trusted-standard-library
+        // symbol path, so its ordinary functions qualify by that path.
+        let symbol = format!(
+            "__rue_fn_{}__{name}",
+            rue_air::mangle_symbol_component(&rue_air::normalize_module_path(
+                "\0rue-std/option.rue"
+            ))
+        );
         let func = output
             .functions
             .iter()
-            .find(|f| f.name == name)
+            .find(|f| f.name == symbol)
             .unwrap_or_else(|| panic!("no analyzed function named '{}'", name));
         CfgBuilder::build(
             &func.air,

--- a/crates/rue-cfg/src/inline.rs
+++ b/crates/rue-cfg/src/inline.rs
@@ -835,7 +835,7 @@ mod tests {
     use super::*;
     use crate::CfgBuilder;
     use lasso::ThreadedRodeo;
-    use rue_air::Sema;
+    use rue_air::{Sema, SemaMetadata};
     use rue_error::{PreviewFeature, PreviewFeatures};
     use rue_lexer::Lexer;
     use rue_parser::Parser;
@@ -905,17 +905,21 @@ mod tests {
     }
 
     impl Program {
+        /// CFGs are keyed by internal symbol, which an ordinary function
+        /// qualifies by its module (RUE-1125); fixtures name functions by
+        /// source, so every lookup projects the source name first.
         fn cfg(&self, name: &str) -> &ValidatedCfg {
             self.cfgs
-                .get(name)
+                .get(&SemaMetadata::synthetic_root_function_symbol(name))
                 .unwrap_or_else(|| panic!("no CFG for function '{name}'"))
         }
 
         fn find_call(&self, caller: &str, callee: &str) -> CfgValue {
             let cfg = self.cfg(caller);
+            let callee_symbol = SemaMetadata::synthetic_root_function_symbol(callee);
             attached_values(cfg)
                 .find(|&value| match &cfg.get_inst(value).data {
-                    CfgInstData::Call { name, .. } => self.interner.resolve(name) == callee,
+                    CfgInstData::Call { name, .. } => self.interner.resolve(name) == callee_symbol,
                     _ => false,
                 })
                 .unwrap_or_else(|| panic!("no call to '{callee}' in '{caller}'"))

--- a/crates/rue-codegen/src/aarch64/cfg_lower.rs
+++ b/crates/rue-codegen/src/aarch64/cfg_lower.rs
@@ -3708,7 +3708,7 @@ impl crate::aggregate_eq::AggregateEqPlanBackend for CfgLower<'_> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use rue_air::Sema;
+    use rue_air::{Sema, SemaMetadata};
     use rue_cfg::CfgBuilder;
     use rue_error::PreviewFeatures;
     use rue_lexer::Lexer;
@@ -3736,10 +3736,11 @@ mod tests {
         let sema = Sema::new_synthetic(&rir, &mut interner, preview);
         let output = sema.analyze_all_for_test().unwrap();
 
+        let symbol = SemaMetadata::synthetic_root_function_symbol(function_name);
         let func = output
             .functions
             .iter()
-            .find(|func| func.name == function_name)
+            .find(|func| func.name == symbol)
             .expect("requested test function should exist");
         let type_pool = &output.type_pool;
         let cfg_output = CfgBuilder::build(
@@ -3785,10 +3786,11 @@ mod tests {
         let output = Sema::new_synthetic(&rir, &mut interner, PreviewFeatures::new())
             .analyze_all_for_test()
             .unwrap();
+        let symbol = SemaMetadata::synthetic_root_function_symbol(name);
         let func = output
             .functions
             .iter()
-            .find(|f| f.name == name)
+            .find(|f| f.name == symbol)
             .unwrap_or_else(|| panic!("no function named `{name}`"));
         let type_pool = &output.type_pool;
         let cfg_output = CfgBuilder::build(
@@ -3893,11 +3895,14 @@ mod tests {
             .analyze_all_for_test()
             .unwrap();
         let func = match name {
-            Some(name) => output
-                .functions
-                .iter()
-                .find(|f| f.name == name)
-                .unwrap_or_else(|| panic!("no function named `{name}`")),
+            Some(name) => {
+                let symbol = SemaMetadata::synthetic_root_function_symbol(name);
+                output
+                    .functions
+                    .iter()
+                    .find(|f| f.name == symbol)
+                    .unwrap_or_else(|| panic!("no function named `{name}`"))
+            }
             None => &output.functions[0],
         };
         let type_pool = &output.type_pool;

--- a/crates/rue-codegen/src/place_lower.rs
+++ b/crates/rue-codegen/src/place_lower.rs
@@ -323,7 +323,7 @@ enum ProjectedAccess {
 #[cfg(test)]
 mod tests {
     use lasso::ThreadedRodeo;
-    use rue_air::{Sema, StructDef, StructField, Type, TypeInternPool};
+    use rue_air::{Sema, SemaMetadata, StructDef, StructField, Type, TypeInternPool};
     use rue_cfg::{Cfg, CfgBuilder, CfgInst, CfgInstData, PlaceBase, Projection};
     use rue_error::PreviewFeatures;
     use rue_lexer::Lexer;
@@ -376,10 +376,11 @@ mod tests {
             .analyze_all_for_test()
             .expect("fixture should analyze");
         let build_cfg = |name: &str| {
+            let symbol = SemaMetadata::synthetic_root_function_symbol(name);
             let function = output
                 .functions
                 .iter()
-                .find(|function| function.name == name)
+                .find(|function| function.name == symbol)
                 .expect("fixture function should exist");
             CfgBuilder::build(
                 &function.air,

--- a/crates/rue-codegen/src/stack_frame.rs
+++ b/crates/rue-codegen/src/stack_frame.rs
@@ -850,7 +850,7 @@ fn main() -> i32 {
         source: &str,
         name: &str,
     ) -> (rue_cfg::ValidatedCfg, FrozenTypeInternPool, ThreadedRodeo) {
-        use rue_air::Sema;
+        use rue_air::{Sema, SemaMetadata};
         use rue_error::PreviewFeatures;
         use rue_lexer::Lexer;
         use rue_parser::Parser;
@@ -864,10 +864,11 @@ fn main() -> i32 {
         let output = Sema::new_synthetic(&rir, &mut interner, PreviewFeatures::new())
             .analyze_all_for_test()
             .unwrap();
+        let symbol = SemaMetadata::synthetic_root_function_symbol(name);
         let func = output
             .functions
             .iter()
-            .find(|f| f.name == name)
+            .find(|f| f.name == symbol)
             .expect("requested test function should exist");
         let cfg = CfgBuilder::build(
             &func.air,

--- a/crates/rue-codegen/src/x86_64/cfg_lower.rs
+++ b/crates/rue-codegen/src/x86_64/cfg_lower.rs
@@ -3498,7 +3498,7 @@ impl crate::aggregate_eq::AggregateEqPlanBackend for CfgLower<'_> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use rue_air::Sema;
+    use rue_air::{Sema, SemaMetadata};
     use rue_cfg::CfgBuilder;
     use rue_error::PreviewFeatures;
     use rue_lexer::Lexer;
@@ -3566,11 +3566,14 @@ mod tests {
             .analyze_all_for_test()
             .unwrap();
         let func = match name {
-            Some(name) => output
-                .functions
-                .iter()
-                .find(|f| f.name == name)
-                .unwrap_or_else(|| panic!("no function named `{name}`")),
+            Some(name) => {
+                let symbol = SemaMetadata::synthetic_root_function_symbol(name);
+                output
+                    .functions
+                    .iter()
+                    .find(|f| f.name == symbol)
+                    .unwrap_or_else(|| panic!("no function named `{name}`"))
+            }
             None => &output.functions[0],
         };
         let type_pool = &output.type_pool;
@@ -3854,10 +3857,11 @@ mod tests {
         let output = Sema::new_synthetic(&rir, &mut interner, PreviewFeatures::new())
             .analyze_all_for_test()
             .unwrap();
+        let symbol = SemaMetadata::synthetic_root_function_symbol(name);
         let func = output
             .functions
             .iter()
-            .find(|f| f.name == name)
+            .find(|f| f.name == symbol)
             .unwrap_or_else(|| panic!("no function named `{name}`"));
         let type_pool = &output.type_pool;
         let cfg_output = CfgBuilder::build(
@@ -3964,7 +3968,8 @@ mod tests {
             let output = Sema::new_synthetic(&rir, &mut interner, preview)
                 .analyze_all_for_test()
                 .unwrap();
-            let func = output.functions.iter().find(|f| f.name == "take").unwrap();
+            let take = SemaMetadata::synthetic_root_function_symbol("take");
+            let func = output.functions.iter().find(|f| f.name == take).unwrap();
             let type_pool = &output.type_pool;
             let cfg = CfgBuilder::build(
                 &func.air,

--- a/crates/rue-compiler/src/artifact_views.rs
+++ b/crates/rue-compiler/src/artifact_views.rs
@@ -843,8 +843,18 @@ impl FunctionView {
         &self.owner.functions()[self.function]
     }
 
+    /// The declaration's source-level name.
+    ///
+    /// A callable's internal symbol is not a source name: an ordinary
+    /// definition qualifies it by module (RUE-1125) and glue and
+    /// specializations carry their own generated spellings. Presentation names
+    /// the declaration, so an ordinary definition reports its source name and
+    /// only a generated callable falls back to its internal symbol.
     pub fn name(&self) -> &str {
-        &self.function().analyzed.name
+        let function = self.function();
+        function
+            .definition_source_name()
+            .unwrap_or(&function.analyzed.name)
     }
 
     pub fn instruction_count(&self) -> usize {

--- a/crates/rue-compiler/src/backend.rs
+++ b/crates/rue-compiler/src/backend.rs
@@ -386,10 +386,10 @@ pub(crate) fn compile_backend_products(
 ///
 /// Each exported function was already code-generated as an ordinary native body
 /// under its mangled `machine_name`; this adds one extra object per export whose
-/// single global symbol is the unmangled C name (`legacy_name`, the source
-/// identifier) and whose body receives arguments per the target-C convention,
-/// re-extends narrow scalars, and forwards to the native body. The signature was
-/// gated to register-resident scalars/pointers in semantic analysis
+/// single global symbol is the unmangled C name (the export's source identifier)
+/// and whose body receives arguments per the target-C convention, re-extends
+/// narrow scalars, and forwards to the native body. The signature was gated to
+/// register-resident scalars/pointers in semantic analysis
 /// (`ExportSignatureUnsupported`), so the entry block's parameters are exactly
 /// the argument-register scalars the thunk marshals.
 pub(crate) fn generate_export_thunk_objects(
@@ -404,9 +404,12 @@ pub(crate) fn generate_export_thunk_objects(
         export_symbols.iter().map(String::as_str).collect();
     let mut objects = Vec::new();
     for function in functions {
-        if !export_set.contains(function.legacy_name.as_str()) {
+        let Some(exported_symbol) = function
+            .definition_source_name()
+            .filter(|name| export_set.contains(name))
+        else {
             continue;
-        }
+        };
         let cfg = &function.cfg;
         // A scalar parameter is materialized as a `Param { index }` instruction
         // carrying its type; parameter `index` arrives in the matching argument
@@ -432,7 +435,7 @@ pub(crate) fn generate_export_thunk_objects(
             &function.machine_name,
             &param_types,
         );
-        let mut obj_builder = ObjectBuilder::new(options.target, &function.legacy_name)
+        let mut obj_builder = ObjectBuilder::new(options.target, exported_symbol)
             .code(machine_code.code)
             .strings(machine_code.strings);
         for reloc in machine_code.relocations {

--- a/crates/rue-compiler/src/integration_tests.rs
+++ b/crates/rue-compiler/src/integration_tests.rs
@@ -1091,7 +1091,7 @@ drop fn StrBuf(self) { }
                 let cfg = &state
                     .functions
                     .iter()
-                    .find(|function| function.analyzed.name == "probe")
+                    .find(|function| function.definition_source_name() == Some("probe"))
                     .unwrap_or_else(|| panic!("missing CFG for {name}"))
                     .cfg;
                 let intrinsic_types: Vec<_> = cfg
@@ -1168,7 +1168,7 @@ drop fn StrBuf(self) { }
                 let cfg = &state
                     .functions
                     .iter()
-                    .find(|function| function.analyzed.name == "probe")
+                    .find(|function| function.definition_source_name() == Some("probe"))
                     .unwrap_or_else(|| panic!("missing CFG for {name}"))
                     .cfg;
                 let intrinsic_types: Vec<_> = cfg

--- a/crates/rue-compiler/src/program_image_plan.rs
+++ b/crates/rue-compiler/src/program_image_plan.rs
@@ -171,7 +171,11 @@ impl ProgramImage {
             .collect::<BTreeSet<_>>();
         let expected_thunks = functions
             .iter()
-            .filter(|function| export_set.contains(function.legacy_name.as_str()))
+            .filter(|function| {
+                function
+                    .definition_source_name()
+                    .is_some_and(|name| export_set.contains(name))
+            })
             .count();
         if export_thunk_objects.len() != expected_thunks {
             return Err(CompileErrors::from(CompileError::without_span(
@@ -265,13 +269,20 @@ impl ProgramImagePlan {
             .collect::<BTreeSet<_>>();
         let mut export_thunks = functions
             .iter()
-            .filter(|function| export_set.contains(function.legacy_name.as_str()))
-            .zip(export_thunk_objects)
-            .map(|(function, bytes)| ProgramImageExportThunk {
-                exported_symbol: function.legacy_name.clone(),
-                native_symbol: function.machine_name.clone(),
-                content_digest: bytes_digest(b"rue.program-image.export-thunk\0v1\0", bytes),
+            .filter_map(|function| {
+                function
+                    .definition_source_name()
+                    .filter(|name| export_set.contains(name))
+                    .map(|name| (function, name))
             })
+            .zip(export_thunk_objects)
+            .map(
+                |((function, exported_symbol), bytes)| ProgramImageExportThunk {
+                    exported_symbol: exported_symbol.to_owned(),
+                    native_symbol: function.machine_name.clone(),
+                    content_digest: bytes_digest(b"rue.program-image.export-thunk\0v1\0", bytes),
+                },
+            )
             .collect::<Vec<_>>();
         export_thunks.sort_by(|left, right| {
             left.exported_symbol
@@ -340,12 +351,13 @@ fn validate_program_image_inputs(
         return duplicate_plan_input("C-ABI export symbol", "duplicate export declaration");
     }
     let mut thunk_identities = BTreeSet::new();
-    for function in functions
+    for exported_symbol in functions
         .iter()
-        .filter(|function| export_set.contains(function.legacy_name.as_str()))
+        .filter_map(FunctionWithCfg::definition_source_name)
+        .filter(|name| export_set.contains(name))
     {
-        if !thunk_identities.insert(function.legacy_name.as_str()) {
-            return duplicate_plan_input("C-ABI export thunk identity", &function.legacy_name);
+        if !thunk_identities.insert(exported_symbol) {
+            return duplicate_plan_input("C-ABI export thunk identity", exported_symbol);
         }
     }
 
@@ -711,10 +723,62 @@ mod tests {
         assert!(error.to_string().contains("duplicate defined symbol"));
     }
 
+    /// A C export's linker-visible name is the identifier its declaration
+    /// spells, independently of the module-qualified internal symbol its native
+    /// body carries (ADR-0064 P4, RUE-1125).
+    #[test]
+    fn export_thunks_carry_the_declared_c_name_over_a_module_qualified_body() {
+        let source = "pub extern \"C\" fn rue_answer() -> i32 { 42 }\n\
+                      fn main() -> i32 { 0 }";
+        let snapshot = crate::SourceSnapshot::single("main.rue", source).unwrap();
+        let options = CompileOptions {
+            preview_features: crate::PreviewFeatures::from([crate::PreviewFeature::CFfi]),
+            ..CompileOptions::default()
+        };
+        let mut session = crate::CompilerSession::new();
+        crate::publish_test_snapshot(&mut session, &snapshot).unwrap();
+        let rir = session.canonical_rir().unwrap();
+        let semantic = session.canonical_semantic(&options).unwrap();
+        let exports = backend::collect_export_symbols(rir.rir(), rir.semantic_symbols().interner());
+        assert_eq!(exports, ["rue_answer"]);
+        let units = session
+            .codegen_units(
+                &semantic,
+                &options,
+                rue_codegen::BackendArtifactRequest::default(),
+            )
+            .unwrap();
+        let image = ProgramImage::new(units, semantic.functions(), &options, &exports).unwrap();
+
+        let exported = semantic
+            .functions()
+            .iter()
+            .find(|function| function.definition_source_name() == Some("rue_answer"))
+            .expect("the export is code-generated as an ordinary body");
+        assert_eq!(
+            exported.legacy_name, "__rue_fn_main_2erue__rue_answer",
+            "the export's native body is an ordinary module-qualified callable"
+        );
+        assert_eq!(
+            image.plan.export_thunks.len(),
+            1,
+            "{:?}",
+            image.plan.export_thunks
+        );
+        assert_eq!(image.plan.export_thunks[0].exported_symbol, "rue_answer");
+        assert_eq!(
+            image.plan.export_thunks[0].native_symbol,
+            exported.machine_name
+        );
+    }
+
     #[test]
     fn duplicate_export_thunk_identities_are_rejected() {
         let (units, mut functions, options) = session_inputs("fn main() -> i32 { 0 }");
-        let exported = functions[0].legacy_name.clone();
+        let exported = functions[0]
+            .definition_source_name()
+            .expect("main is an ordinary definition")
+            .to_owned();
         functions.push(functions[0].clone());
         let error = ProgramImage::new(units, &functions, &options, &[exported])
             .err()

--- a/crates/rue-compiler/src/queries.rs
+++ b/crates/rue-compiler/src/queries.rs
@@ -119,6 +119,23 @@ pub struct FunctionWithCfg {
     pub cfg: Cfg,
 }
 
+impl FunctionWithCfg {
+    /// The source-level name of this callable's declaration, when it is an
+    /// ordinary definition rather than a specialization or drop glue.
+    ///
+    /// Neither `machine_name` nor `legacy_name` spells a source name: an
+    /// ordinary callable's internal symbol is module-qualified (RUE-1125) and
+    /// its machine symbol is encoded from the semantic identity. Anything that
+    /// must speak in source terms — the C export boundary above all — reads the
+    /// name from the durable identity, which records module and source name.
+    pub(crate) fn definition_source_name(&self) -> Option<&str> {
+        match &self.semantic_identity {
+            crate::FunctionInstanceKey::Definition(definition) => Some(definition.name()),
+            _ => None,
+        }
+    }
+}
+
 impl std::fmt::Debug for FunctionWithCfg {
     fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         // The optimized query key contains request-local relocation domains;

--- a/crates/rue-compiler/src/revisioned_query_database.rs
+++ b/crates/rue-compiler/src/revisioned_query_database.rs
@@ -30019,8 +30019,11 @@ fn main() -> i32 {
         // its `Spur`s and the driver's line up.
         let interner = rir.semantic_symbols().interner();
         let make_sym = interner.get("make").expect("make interned");
+        let make_symbol = bound
+            .free_function_symbol(file, make_sym)
+            .expect("make is bound in its own module");
         let prod = bound
-            .function_info(make_sym)
+            .function_info(make_symbol)
             .expect("the epoch has make's FunctionInfo");
 
         let rir_ref = rir.rir();
@@ -31837,6 +31840,16 @@ fn main() -> i32 {
         )
         .expect("declarations bind");
         let interner = rir.semantic_symbols().interner();
+        // A function-valued constant names a declaration. The provider holds it
+        // as a source-name handle joined to a durable definition, while an epoch
+        // holds the internal symbol, which is module-qualified (RUE-1125), so
+        // the epoch side renders through the source-name projection to compare
+        // the same declaration rather than two symbol spaces.
+        let epoch_symbol = |symbol| {
+            interner
+                .resolve(&bound.function_source_name(symbol))
+                .to_owned()
+        };
         let epoch = value_keys
             .iter()
             .map(|(name, _)| {
@@ -31844,9 +31857,8 @@ fn main() -> i32 {
                 let info = bound
                     .epoch_const_info(file, symbol)
                     .unwrap_or_else(|| panic!("epoch resolves {name}"));
-                let rendered = bound.with_type_pool(|pool| {
-                    render_const_info(&info, pool, |symbol| interner.resolve(&symbol).to_owned())
-                });
+                let rendered =
+                    bound.with_type_pool(|pool| render_const_info(&info, pool, epoch_symbol));
                 (*name, rendered)
             })
             .collect::<Vec<_>>();
@@ -31854,11 +31866,8 @@ fn main() -> i32 {
         let epoch_module = bound
             .epoch_module_binding_info(file, dep_symbol)
             .expect("the LIVE epoch resolves the module binding");
-        let epoch_module = bound.with_type_pool(|pool| {
-            render_const_info(&epoch_module, pool, |symbol| {
-                interner.resolve(&symbol).to_owned()
-            })
-        });
+        let epoch_module =
+            bound.with_type_pool(|pool| render_const_info(&epoch_module, pool, epoch_symbol));
 
         // Pool side: the production durable declaration adapter plus the real
         // ProviderEndpointFacts registration primitive, which composes the

--- a/crates/rue-compiler/src/session.rs
+++ b/crates/rue-compiler/src/session.rs
@@ -5576,6 +5576,28 @@ mod tests {
         }
     }
 
+    /// The comptime arguments of a specialization of the definition named
+    /// `source_name`, or `None` for any other callable.
+    ///
+    /// A live callable name is never a source name: an ordinary definition's
+    /// internal symbol is module-qualified (RUE-1125) and a specialization
+    /// appends its argument mangling to that. Tests therefore select a
+    /// specialization through its durable identity.
+    fn specialization_arguments<'a>(
+        function: &'a FunctionWithCfg,
+        source_name: &str,
+    ) -> Option<&'a crate::CanonicalArguments> {
+        let crate::FunctionInstanceKey::Specialization { base, arguments } =
+            &function.semantic_identity
+        else {
+            return None;
+        };
+        let crate::FunctionInstanceKey::Definition(definition) = base.as_ref() else {
+            return None;
+        };
+        (definition.name() == source_name).then_some(arguments)
+    }
+
     fn retained_body_query_stamps(
         session: &CompilerSession,
         key: &crate::body_query::BodyQueryKey,
@@ -5768,8 +5790,8 @@ mod tests {
 
     use super::*;
     use crate::{
-        ModuleId, OptLevel, PreviewFeature, PreviewFeatures, SourceMetadata, SourceSnapshot,
-        StableDefinitionKey, StableDefinitionKind, Target,
+        FunctionWithCfg, ModuleId, OptLevel, PreviewFeature, PreviewFeatures, SourceMetadata,
+        SourceSnapshot, StableDefinitionKey, StableDefinitionKind, Target,
     };
 
     #[test]
@@ -7334,7 +7356,10 @@ mod tests {
             .iter()
             .map(|function| (function.analyzed.name.as_str(), function.cfg.fn_name()))
             .collect::<std::collections::BTreeMap<_, _>>();
-        assert_eq!(names.get("probe"), Some(&"probe"));
+        assert_eq!(
+            names.get("__rue_fn_main_2erue__probe"),
+            Some(&"__rue_fn_main_2erue__probe")
+        );
         assert_eq!(names.get("main"), Some(&"main"));
     }
 
@@ -8962,7 +8987,11 @@ fn main() -> i32 { 0 }
         let choose_true = cold
             .functions()
             .iter()
-            .find(|function| function.legacy_name == "choose.vtrue")
+            .find(|function| {
+                specialization_arguments(function, "choose").is_some_and(|arguments| {
+                    arguments.values.as_ref() == [crate::CanonicalArgumentValue::Bool(true)]
+                })
+            })
             .unwrap();
         let choose_true_key = crate::body_query::BodyQueryKey {
             instance: choose_true.semantic_identity.clone(),
@@ -9625,6 +9654,166 @@ fn main() -> i32 {
         );
     }
 
+    /// Warm-session locality of callable identity (RUE-1125).
+    ///
+    /// Inserting an unreachable, same-named free function into an unrelated
+    /// module must not touch an existing function at all. Identity is derived
+    /// from a declaration's own module and source name, so `helpers.value`
+    /// keeps its semantic identity, its body/declaration terminals, its
+    /// dependency set, its machine symbol, and its presentation name, and its
+    /// body is reused rather than recomputed.
+    #[test]
+    fn an_unrelated_same_named_declaration_does_not_disturb_a_warm_body() {
+        const ROOT: &str = "const helpers = @import(\"helpers.rue\");\n\
+             const spare = @import(\"spare.rue\");\n\
+             fn main() -> i32 { helpers.value() + spare.unrelated() }";
+        const HELPERS: &str = "pub fn value() -> i32 { 10 }";
+        const SPARE: &str = "pub fn unrelated() -> i32 { 20 }";
+        let program = |spare: &str| {
+            snapshot(
+                &[
+                    (1, "/p/main.rue", "main.rue", ROOT),
+                    (2, "/p/helpers.rue", "helpers.rue", HELPERS),
+                    (3, "/p/spare.rue", "spare.rue", spare),
+                ],
+                1,
+            )
+        };
+        let options = CompileOptions::default();
+
+        let mut session = CompilerSession::new();
+        publish_with_test_imports(&mut session, &program(SPARE));
+        let cold = session.canonical_semantic(&options).unwrap();
+        let value = body_query_key(&mut session, &options, "value");
+
+        // Everything RUE-1125 requires to be a function of `value`'s own
+        // declaration: its query terminals, its dependency set, its emitted
+        // symbols, and how it is presented.
+        let observed = |session: &CompilerSession,
+                        semantic: &Arc<crate::CanonicalSemanticOutput>| {
+            let function = semantic
+                .functions()
+                .iter()
+                .find(|function| function.definition_source_name() == Some("value"))
+                .expect("value is reached from main");
+            (
+                retained_body_query_stamps(session, &value),
+                retained_body_closure_stamps(session, &value),
+                retained_body_dependency_nodes(session, &value),
+                function.semantic_identity.clone(),
+                function.legacy_name.clone(),
+                function.machine_name.clone(),
+            )
+        };
+        let before = observed(&session, &cold);
+        assert_eq!(
+            before.4, "__rue_fn_helpers_2erue__value",
+            "an ordinary free function is module-qualified from the start"
+        );
+        let codegen = |session: &mut CompilerSession, semantic| {
+            session
+                .codegen_units(
+                    semantic,
+                    &options,
+                    rue_codegen::BackendArtifactRequest::default(),
+                )
+                .unwrap();
+            session
+                .codegen_executions()
+                .iter()
+                .find(|(identity, _)| *identity == before.3)
+                .map(|(_, execution)| *execution)
+                .expect("value publishes a codegen unit")
+        };
+        assert_eq!(
+            codegen(&mut session, &cold),
+            rue_query::RequestExecution::Computed
+        );
+
+        // Insert an unreachable free function with the same source name into a
+        // module `value` has no relationship with. Appending leaves every
+        // existing span in `spare.rue` untouched.
+        let edited = format!("{SPARE}\n@allow(unused_function)\npub fn value() -> i32 {{ 99 }}\n");
+        publish_with_test_imports(&mut session, &program(&edited));
+        let warm = session.canonical_semantic(&options).unwrap();
+        let after = observed(&session, &warm);
+
+        assert_eq!(
+            before.0, after.0,
+            "the body transaction, canonical body, reference, and produced-anonymous \
+             terminals must all keep their stamps"
+        );
+        assert_eq!(
+            before.1, after.1,
+            "the body closure and its bundle must keep their stamps"
+        );
+        assert_eq!(before.2, after.2, "the dependency set must be unchanged");
+        assert_eq!(
+            (&before.3, &before.4, &before.5),
+            (&after.3, &after.4, &after.5),
+            "semantic identity, internal symbol, and machine symbol must be unchanged"
+        );
+        assert_eq!(
+            warm.work().body_analysis.body_analyses_computed,
+            0,
+            "no body may be recomputed: {:?}",
+            warm.work().body_analysis
+        );
+        assert_eq!(
+            codegen(&mut session, &warm),
+            rue_query::RequestExecution::Reused,
+            "the machine-code terminal must be reused, not re-emitted"
+        );
+
+        // The declaration terminal and the presentation identity are equally
+        // unaffected, and the new declaration really is present and distinct.
+        let declarations = |session: &mut CompilerSession| {
+            session
+                .stable_definitions(&options)
+                .unwrap()
+                .definitions()
+                .iter()
+                .filter(|record| {
+                    record.stable_key().kind() == StableDefinitionKind::Function
+                        && record.stable_key().name() == "value"
+                })
+                .map(|record| record.stable_key().clone())
+                .collect::<Vec<_>>()
+        };
+        let bound = declarations(&mut session);
+        let helpers_value = match &before.3 {
+            crate::FunctionInstanceKey::Definition(key) => key.clone(),
+            other => panic!("value is an ordinary definition: {other:?}"),
+        };
+        assert!(
+            bound.contains(&helpers_value),
+            "helpers.value keeps its declaration identity: {bound:?}"
+        );
+        assert!(
+            bound
+                .iter()
+                .any(|key| key.module().logical_path() == "spare.rue"),
+            "the inserted declaration is really bound, as its own module's: {bound:?}"
+        );
+        assert_eq!(bound.len(), 2, "{bound:?}");
+        let presented = session
+            .semantic(&options)
+            .unwrap()
+            .function_views()
+            .map(|function| function.name().to_owned())
+            .collect::<Vec<_>>();
+        assert!(
+            presented.contains(&"value".to_owned()),
+            "presentation names the declaration, not its internal symbol: {presented:?}"
+        );
+
+        // Warm and fresh must agree on the whole artifact.
+        let mut fresh = CompilerSession::new();
+        publish_with_test_imports(&mut fresh, &program(&edited));
+        let expected = fresh.canonical_semantic(&options).unwrap();
+        assert_semantic_artifact_parity(&session, &warm, &expected);
+    }
+
     #[test]
     fn body_query_stamps_preserve_caller_and_reference_values_across_body_only_edits() {
         let options = CompileOptions::default();
@@ -9728,7 +9917,7 @@ fn main() -> i32 {
         let identity_for = |name: &str| {
             warm.functions()
                 .iter()
-                .find(|function| function.legacy_name == name)
+                .find(|function| function.definition_source_name() == Some(name))
                 .unwrap()
                 .semantic_identity
                 .clone()
@@ -9860,7 +10049,7 @@ fn main() -> i32 {
         let size = cold
             .functions()
             .iter()
-            .find(|function| function.legacy_name.starts_with("size."))
+            .find(|function| specialization_arguments(function, "size").is_some())
             .unwrap();
         let size = crate::body_query::BodyQueryKey {
             instance: size.semantic_identity.clone(),

--- a/crates/rue-compiler/src/unstable.rs
+++ b/crates/rue-compiler/src/unstable.rs
@@ -555,6 +555,11 @@ pub struct OracleSemanticState {
 /// Raw function state for in-tree differential and storage-profile tooling.
 pub struct UnstableSemanticFunction {
     pub analyzed: Arc<rue_air::AnalyzedFunction>,
+    /// The declaration's source name when this callable is an ordinary
+    /// definition. `analyzed.name` is the internal symbol, which an ordinary
+    /// definition qualifies by module (RUE-1125), so a consumer that speaks in
+    /// source terms reads this instead.
+    pub source_name: Option<String>,
     pub cfg: rue_cfg::ValidatedCfg,
 }
 
@@ -575,6 +580,7 @@ pub fn into_oracle_semantic_state(
         functions: functions
             .into_iter()
             .map(|function| UnstableSemanticFunction {
+                source_name: function.definition_source_name().map(str::to_owned),
                 analyzed: function.analyzed,
                 cfg: function.cfg,
             })
@@ -1098,7 +1104,7 @@ mod codegen_unit_tests {
         let consume_name = semantic
             .functions()
             .iter()
-            .find(|function| function.analyzed.name == "consume")
+            .find(|function| function.definition_source_name() == Some("consume"))
             .unwrap()
             .machine_name
             .clone();

--- a/crates/rue-oracle/src/lib.rs
+++ b/crates/rue-oracle/src/lib.rs
@@ -81,7 +81,21 @@ struct CompileState {
 }
 
 struct OracleFunction {
+    /// The declaration's source name, for ordinary definitions. A CFG's
+    /// `fn_name` is the internal symbol, which an ordinary definition
+    /// qualifies by module (RUE-1125); interpretation dispatches on that
+    /// symbol, so only in-tree probes that name a function the way its source
+    /// does need this.
+    #[cfg(test)]
+    source_name: Option<String>,
     cfg: rue_cfg::ValidatedCfg,
+}
+
+#[cfg(test)]
+impl OracleFunction {
+    fn is_source_named(&self, name: &str) -> bool {
+        self.source_name.as_deref() == Some(name)
+    }
 }
 
 fn query_cfg_state(source: &str) -> Result<CompileState, CompileErrors> {
@@ -132,7 +146,11 @@ fn query_cfg_state_from_session(
         functions: state
             .functions
             .into_iter()
-            .map(|function| OracleFunction { cfg: function.cfg })
+            .map(|function| OracleFunction {
+                #[cfg(test)]
+                source_name: function.source_name,
+                cfg: function.cfg,
+            })
             .collect(),
         type_pool: state.type_pool,
         strings: state.strings,
@@ -1783,6 +1801,9 @@ impl<'a> Interp<'a> {
         &self.state.interner
     }
 
+    /// Locate a callee by the internal symbol its call site names. This is the
+    /// interpreter's dispatch, so it must speak the CFG's own symbol space,
+    /// not source names.
     fn find_cfg(&self, name: &str) -> Option<&'a Cfg> {
         self.state
             .functions

--- a/crates/rue-oracle/src/tests.rs
+++ b/crates/rue-oracle/src/tests.rs
@@ -80,8 +80,8 @@ fn stable_str_equality_is_lowered_and_modeled_by_byte_content() {
         let cfg = state
             .functions
             .iter()
-            .map(|function| &function.cfg)
-            .find(|cfg| cfg.fn_name() == function)
+            .find(|candidate| candidate.is_source_named(function))
+            .map(|candidate| &candidate.cfg)
             .unwrap_or_else(|| panic!("missing {function} CFG"));
         let (lhs, rhs) = cfg
             .blocks()

--- a/crates/rue-oracle/src/tests/call_contracts.rs
+++ b/crates/rue-oracle/src/tests/call_contracts.rs
@@ -176,8 +176,8 @@ fn find_intrinsic_in_function<'a>(
     let cfg = state
         .functions
         .iter()
+        .find(|function| function.is_source_named(function_name))
         .map(|function| &function.cfg)
-        .find(|cfg| cfg.fn_name() == function_name)
         .unwrap_or_else(|| panic!("missing CFG for {function_name}"));
     let mut found = None;
     for value in cfg
@@ -385,8 +385,16 @@ fn user_call_layout_is_rejected_before_unmodeled_operands_run() {
         let main_index = state
             .functions
             .iter()
-            .position(|function| function.cfg.fn_name() == "main")
+            .position(|function| function.is_source_named("main"))
             .expect("main CFG");
+        // A call site names its callee by internal symbol, so the probe reads
+        // that symbol off the callee's own CFG rather than assuming a spelling.
+        let callee_symbol = state
+            .functions
+            .iter()
+            .find(|function| function.is_source_named(callee_name))
+            .map(|function| function.cfg.fn_name().to_owned())
+            .unwrap_or_else(|| panic!("missing CFG for {callee_name}"));
         let (random, call) = {
             let cfg = &state.functions[main_index].cfg;
             let mut random = None;
@@ -403,7 +411,7 @@ fn user_call_layout_is_rejected_before_unmodeled_operands_run() {
                         random = Some(value);
                     }
                     CfgInstData::Call { name, .. }
-                        if state.interner.resolve(name) == callee_name =>
+                        if state.interner.resolve(name) == callee_symbol =>
                     {
                         assert!(
                             call.replace(value).is_none(),
@@ -468,7 +476,7 @@ fn abort_intrinsic_static_contracts_precede_unmodeled_operands() {
         let main_index = state
             .functions
             .iter()
-            .position(|function| function.cfg.fn_name() == "main")
+            .position(|function| function.is_source_named("main"))
             .expect("main CFG");
         let (random, panic, panic_args, assertion, assert_args) = {
             let cfg = &state.functions[main_index].cfg;
@@ -740,7 +748,7 @@ fn pointer_intrinsic_gaps_require_exact_signature_and_synthesized_provenance() {
     let drift_user_index = drift_state
         .functions
         .iter()
-        .position(|function| function.cfg.fn_name() == "user_pointer")
+        .position(|function| function.is_source_named("user_pointer"))
         .expect("user_pointer CFG");
     let type_pool = &drift_state.type_pool;
     drift_state.functions[drift_user_index]
@@ -780,7 +788,7 @@ fn pointer_intrinsic_gaps_require_exact_signature_and_synthesized_provenance() {
     let extra_main = extra_use_state
         .functions
         .iter()
-        .position(|function| function.cfg.fn_name() == "main")
+        .position(|function| function.is_source_named("main"))
         .expect("main CFG");
     let outer_cast = extra_use_state.functions[extra_main]
         .cfg
@@ -835,7 +843,7 @@ fn pointer_intrinsic_gaps_require_exact_signature_and_synthesized_provenance() {
     let extra_init_main = extra_init_use_state
         .functions
         .iter()
-        .position(|function| function.cfg.fn_name() == "main")
+        .position(|function| function.is_source_named("main"))
         .expect("main CFG");
     let (slice_init, slice_ty, outer_cast) = {
         let cfg = &extra_init_use_state.functions[extra_init_main].cfg;
@@ -899,7 +907,7 @@ fn pointer_intrinsic_gaps_require_exact_signature_and_synthesized_provenance() {
     let wrong_consumer_main = wrong_consumer_state
         .functions
         .iter()
-        .position(|function| function.cfg.fn_name() == "main")
+        .position(|function| function.is_source_named("main"))
         .expect("main CFG");
     let (wrong_consumer_init, consumer, mut consumer_args) = {
         let cfg = &wrong_consumer_state.functions[wrong_consumer_main].cfg;
@@ -977,7 +985,7 @@ fn pointer_intrinsic_gaps_require_exact_signature_and_synthesized_provenance() {
     let wrong_init_main = wrong_init_state
         .functions
         .iter()
-        .position(|function| function.cfg.fn_name() == "main")
+        .position(|function| function.is_source_named("main"))
         .expect("main CFG");
     let slice_init = {
         let cfg = &wrong_init_state.functions[wrong_init_main].cfg;
@@ -1056,7 +1064,7 @@ fn validated_cfg_rejects_out_of_bounds_field_pointer_projection_metadata() {
     let main_index = state
         .functions
         .iter()
-        .position(|function| function.cfg.fn_name() == "main")
+        .position(|function| function.is_source_named("main"))
         .expect("main CFG");
     let (_, _, args, _) = find_intrinsic_in_function(&state, "main", "field_ptr");
     let field_read = args[0];

--- a/crates/rue-oracle/src/tests/place_contracts.rs
+++ b/crates/rue-oracle/src/tests/place_contracts.rs
@@ -21,8 +21,8 @@ fn flattened_parameter_padding_is_a_semantic_gap_but_oob_is_a_contract_failure()
     let cfg = state
         .functions
         .iter()
+        .find(|function| function.is_source_named("take"))
         .map(|function| &function.cfg)
-        .find(|cfg| cfg.fn_name() == "take")
         .expect("take CFG");
     assert_eq!(cfg.num_params(), 2, "Pair is flattened into two ABI slots");
     let frame = Frame {
@@ -98,8 +98,8 @@ fn matching_cfg_metadata_is_required_before_a_runtime_symptom_is_registrable() {
     let cfg = state
         .functions
         .iter()
+        .find(|function| function.is_source_named("read"))
         .map(|function| &function.cfg)
-        .find(|cfg| cfg.fn_name() == "read")
         .expect("read CFG");
     let mut field_read = None;
     for value in cfg
@@ -154,8 +154,8 @@ fn matching_cfg_metadata_is_required_before_a_runtime_symptom_is_registrable() {
     let ordinary_cfg = ordinary_state
         .functions
         .iter()
+        .find(|function| function.is_source_named("identity"))
         .map(|function| &function.cfg)
-        .find(|cfg| cfg.fn_name() == "identity")
         .expect("identity CFG");
     let ordinary_param = ordinary_cfg
         .blocks()
@@ -208,7 +208,7 @@ fn validated_cfg_requires_the_complete_ordinary_nominal_chain_to_be_well_typed()
         let read_index = state
             .functions
             .iter()
-            .position(|function| function.cfg.fn_name() == "read")
+            .position(|function| function.is_source_named("read"))
             .expect("read CFG");
         let (place_value, base) = {
             let cfg = &state.functions[read_index].cfg;
@@ -284,8 +284,8 @@ fn logical_inout_writability_is_distinct_from_the_by_reference_abi() {
         let cfg = state
             .functions
             .iter()
+            .find(|function| function.is_source_named(name))
             .map(|function| &function.cfg)
-            .find(|cfg| cfg.fn_name() == name)
             .unwrap_or_else(|| panic!("missing {name} CFG"));
         let value = cfg
             .blocks()
@@ -331,8 +331,8 @@ fn validated_cfg_rejects_invalid_owned_text_projection_metadata() {
     let view_cfg = view_state
         .functions
         .iter()
+        .find(|function| function.is_source_named("main"))
         .map(|function| &function.cfg)
-        .find(|cfg| cfg.fn_name() == "main")
         .expect("main CFG");
     let view_value = view_cfg
         .blocks()
@@ -387,7 +387,7 @@ fn validated_cfg_rejects_invalid_owned_text_projection_metadata() {
     let main_index = owned_state
         .functions
         .iter()
-        .position(|function| function.cfg.fn_name() == "main")
+        .position(|function| function.is_source_named("main"))
         .expect("main CFG");
     let (owned_ty, zero) = {
         let cfg = &owned_state.functions[main_index].cfg;
@@ -485,7 +485,7 @@ fn validated_cfg_rejects_malformed_place_writes_before_oracle_model_gaps() {
         let write_index = state
             .functions
             .iter()
-            .position(|function| function.cfg.fn_name() == "write")
+            .position(|function| function.is_source_named("write"))
             .expect("write CFG");
         let (write_value, base, base_type, rhs, projections) = {
             let cfg = &state.functions[write_index].cfg;
@@ -551,7 +551,7 @@ fn validated_cfg_rejects_out_of_bounds_place_read_bases() {
         let read_index = state
             .functions
             .iter()
-            .position(|function| function.cfg.fn_name() == "read")
+            .position(|function| function.is_source_named("read"))
             .expect("read CFG");
         let (read_value, base_type, projections) = {
             let cfg = &state.functions[read_index].cfg;
@@ -600,7 +600,7 @@ fn zero_sized_place_base_uses_the_canonical_boundary_slot() {
     let main_index = state
         .functions
         .iter()
-        .position(|function| function.cfg.fn_name() == "main")
+        .position(|function| function.is_source_named("main"))
         .expect("main CFG");
     let (read_value, base_type, projections) = {
         let cfg = &state.functions[main_index].cfg;
@@ -681,7 +681,7 @@ fn validated_cfg_requires_exact_type_and_writable_storage_for_whole_place_writes
         let write_index = state
             .functions
             .iter()
-            .position(|function| function.cfg.fn_name() == "write")
+            .position(|function| function.is_source_named("write"))
             .expect("write CFG");
         let (write_value, base, base_type, rhs) = {
             let cfg = &state.functions[write_index].cfg;
@@ -747,7 +747,7 @@ fn validated_cfg_allows_only_the_explicit_str_view_whole_place_read_coercion() {
     let probe_index = state
         .functions
         .iter()
-        .position(|function| function.cfg.fn_name() == "probe")
+        .position(|function| function.is_source_named("probe"))
         .expect("probe CFG");
     let other_fixed_type = state.functions[probe_index]
         .cfg

--- a/scripts/test-reproducible-output.sh
+++ b/scripts/test-reproducible-output.sh
@@ -157,12 +157,19 @@ assert_relocated_symbol_names() {
 
     assert_identical "relocated AIR symbol names" "$symbols_a" "$symbols_b"
 
+    # Every ordinary free function is module-qualified from its own declaration
+    # (RUE-1125), so the diamond's uniquely named `shared.rue` callables carry a
+    # module component too, and a specialization appends its argument mangling
+    # to that base. Each component is the module's logical path, never the
+    # relocated physical root — which is what this assertion exists to pin.
     local expected actual
     expected="$(printf '%s\n' \
         '__rue_fn_left_2fentry_2erue__compute' \
         '__rue_fn_left_2fshared_2erue__make' \
         '__rue_fn_right_2fentry_2erue__compute' \
-        '__rue_fn_right_2fshared_2erue__make')"
+        '__rue_fn_right_2fshared_2erue__make' \
+        '__rue_fn_shared_2erue__choose.i32' \
+        '__rue_fn_shared_2erue__perturb')"
     actual="$(< "$symbols_a")"
     if [ "$actual" != "$expected" ]; then
         printf 'FAIL: reproducibility fixture generated unexpected AIR symbols\n' >&2
@@ -195,9 +202,16 @@ assert_source_order_independent_ir() {
     assert_identical "source-order root-only AIR/CFG/lowering" "$ir_a" "$ir_b"
 
     # Make the comparison non-vacuous: each adapter must have resolved the
-    # symbols exercised by ordinary, generic, and intrinsic calls.
+    # symbols exercised by ordinary, generic, and intrinsic calls. A source
+    # call resolves to the callee's internal symbol, which an ordinary function
+    # qualifies by its own module (RUE-1125) and a specialization extends with
+    # its argument mangling; an intrinsic keeps its own name.
     local expected_symbol
-    for expected_symbol in '@rotate(' '@finish(' '@identity.i32(' '@assert('; do
+    for expected_symbol in \
+        '@__rue_fn_main_2erue__rotate(' \
+        '@__rue_fn_main_2erue__finish(' \
+        '@__rue_fn_main_2erue__identity.i32(' \
+        '@assert('; do
         if ! grep -Fq "$expected_symbol" "$ir_a"; then
             printf 'FAIL: stable IR omitted resolved symbol %s\n' "$expected_symbol" >&2
             return 1


### PR DESCRIPTION
An ordinary free function's internal symbol is now derived from `(module, source name)` alone — `__rue_fn_<module>__<name>`, always, from the start — never from observing a program-wide collision. Previously `internal_function_name` kept the bare source name while the program-wide receiverless-name count was 1, so adding an unrelated same-named declaration in another module silently restamped an existing function's internal symbol, body artifact, and dependency edges — an incremental-locality violation.

Two declarations name themselves, each recognized from its own declaration: the root module's `main` (spec 6.1:38, the `_start`/`__main` glue) and `extern "C"` foreign declarations (which name a raw C symbol and have no body or Rue namespace). A `pub extern "C"` export is deliberately not an exception — its body is an ordinary qualified callable and its C name is emitted as a separate entry thunk.

Also in the change, each found while auditing consumers:

- **Latent export-thunk loss fixed:** all four export-thunk sites matched `export_set.contains(legacy_name)`; two modules each declaring a same-named `pub extern "C"` export both mangled past the set, so a valid program linked with **no exported symbols**. Thunk selection is now keyed on the durable identity's source name.
- **`GlobalSpeculative` type-constructor lookup fixed:** it keyed the `functions` map by bare source name; now resolves through the file-local projection.
- `non_receiver_name_multiplicity` is deleted outright (field, accumulation, accessor, tests) — no production read of program-wide multiplicity remains.
- Presentation stays source-named: `FunctionView::name()`, diagnostics, and warnings all project through the source name; no `__rue_fn_` leaks into user-facing output (UI corpus unchanged, 209/209).

The headline test is a warm-session locality regression: append an unreachable same-named declaration in revision 2 and assert equal body/declaration/closure stamps, unchanged dependency nodes, zero body recomputation, codegen `Reused`, and warm/fresh artifact parity. Mutation-tested: restoring the old rule fails it three independent ways — including revealing that the old rule left warm artifacts internally inconsistent (`AnalyzedFunction.name` mangled while the reused CFG still carried the bare `fn_name`).

Fixes RUE-1125.

One follow-up worth its own issue (being filed): two modules declaring the same `extern "C" fn` now correctly share the raw C symbol, but a signature disagreement between them gets no diagnostic (previously an unresolved-relocation ICE).

## Validation

Full premerge tier green (`./clippy.sh` 63 targets + `RUE_TEST_TIER=premerge ./test.sh`: 78 pass, 0 fail, exit 0), plus `scripts/rue quick` (30/30), rue-air (655) / compiler (749) units, CLI `multi`/`c_ffi`/`modules`/`emit_pipeline`/`sibling_module_identity`, UI (209/209), full spec (2221), reproducible-programs, fmt. Two intentional expectation updates in `scripts/test-reproducible-output.sh` (newly qualified symbols now match the `__rue_fn_` filters), both explained in the diff.

---
_Generated by [Claude Code](https://claude.ai/code/session_01DrKqpQgkHzDHGqpEMjxYdN)_