### PR TITLE
Elaborate borrow operands: promoted statics and hidden temporaries

### DIFF
--- a/crates/rue-air/src/sema/analysis.rs
+++ b/crates/rue-air/src/sema/analysis.rs
@@ -3417,8 +3417,9 @@ pub(crate) fn const_use_anchor_of(
 ///
 /// This is the shared implementation behind [`Sema::check_exclusive_access`].
 /// It enforces three rules:
-/// 1. Inout/borrow arguments must be lvalues (a variable, or a field/index
-///    projection chain rooted at one — RUE-143)
+/// 1. Inout arguments must be lvalues (a variable, or a field/index
+///    projection chain rooted at one — RUE-143). A `borrow` argument may
+///    instead be elaborated into a place by argument analysis (RUE-953).
 /// 2. Same ROOT variable cannot be passed to multiple inout parameters
 ///    (prevents aliasing; conservatively, even disjoint fields conflict)
 /// 3. Same root variable cannot be passed to both inout and borrow (law of
@@ -3459,12 +3460,10 @@ where
                 rir.get(arg.value).span,
             ));
         }
-        if arg.is_borrow() && maybe_var_symbol.is_none() {
-            return Err(CompileError::new(
-                ErrorKind::BorrowNonLvalue,
-                rir.get(arg.value).span,
-            ));
-        }
+        // A `borrow` operand that denotes no place is not an error: argument
+        // analysis elaborates it into a promoted static or a hidden temporary
+        // (spec 6.1:39, RUE-953). It has no root variable, so it takes part in
+        // no exclusivity conflict — nothing else can name that storage.
 
         if let Some(var_symbol) = maybe_var_symbol {
             if arg.is_inout() {
@@ -3538,7 +3537,7 @@ mod functions;
 mod instructions;
 mod intrinsics;
 mod ownership;
-pub(crate) use ownership::{AccessorEscapeSite, FirstClassStrSite};
+pub(crate) use ownership::{AccessorEscapeSite, CallOperands, FirstClassStrSite};
 mod pointers;
 mod type_inference;
 

--- a/crates/rue-air/src/sema/analysis/calls.rs
+++ b/crates/rue-air/src/sema/analysis/calls.rs
@@ -109,9 +109,9 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
         param_modes: &[RirParamMode],
         validate_semantic_types: bool,
         ctx: &mut AnalysisContext,
-    ) -> CompileResult<Vec<AirCallArg>> {
+    ) -> CompileResult<CallOperands> {
         let args = self.body_rir_ref().call_args(args_range).to_vec();
-        let air_args = self.analyze_call_args_coerced(
+        let operands = self.analyze_call_args_coerced(
             air,
             args.iter().copied(),
             param_types,
@@ -119,7 +119,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
             ctx,
         )?;
         if validate_semantic_types {
-            for ((arg, air_arg), expected) in args.iter().zip(&air_args).zip(param_types) {
+            for ((arg, air_arg), expected) in args.iter().zip(&operands.args).zip(param_types) {
                 let found = air.get(air_arg.value).ty;
                 if !self.types_compatible(found, *expected) {
                     return Err(self.type_mismatch_error(
@@ -130,19 +130,27 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
                 }
             }
         }
-        Ok(air_args)
+        Ok(operands)
     }
 
     /// Emit an ordinary resolved call and package its declared result.
+    ///
+    /// `temp_scope` carries the storage annotations of any borrow-operand
+    /// temporary this call materialized (RUE-953). Wrapping the *call* in that
+    /// block is what puts the temporaries' scope exit — and therefore their
+    /// drop — after the callee has read through the loan.
     fn emit_call_result(
-        &self,
+        &mut self,
         air: &mut Air,
         name: Spur,
         args: &[AirCallArg],
+        temp_scope: Vec<AirRef>,
         return_type: Type,
         span: Span,
     ) -> CompileResult<AnalysisResult> {
         let air_ref = air.add_call(None, name, args, return_type, span)?;
+        let air_ref =
+            self.wrap_value_with_temp_scope(air, air_ref, return_type, span, temp_scope)?;
         Ok(AnalysisResult::new(air_ref, return_type))
     }
 
@@ -546,8 +554,10 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
 
         // Analyze all arguments. Slice parameters (ADR-0043, RUE-322) coerce a
         // `borrow arr` argument into a by-value fat pointer here.
-        let air_args =
-            self.analyze_call_operands(air, args_range, &param_types, &param_modes, false, ctx)?;
+        let CallOperands {
+            args: air_args,
+            temp_scope,
+        } = self.analyze_call_operands(air, args_range, &param_types, &param_modes, false, ctx)?;
 
         // Handle generic function calls differently
         if is_generic {
@@ -732,7 +742,11 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
                 if let Some(ConstValue::Type(ty)) =
                     self.reduce_type_ctor_body(name, &type_subst, &value_subst, span)?
                 {
-                    // Success! Return a TypeConst instruction instead of a runtime call
+                    // Success! Return a TypeConst instruction instead of a
+                    // runtime call. This arm is reached only when every
+                    // parameter is `comptime`, and a `comptime` parameter takes
+                    // an unmarked argument (4.10:3), so `temp_scope` is
+                    // necessarily empty here — there is no call left to wrap.
                     let air_ref = air.add_inst(AirInst {
                         data: AirInstData::TypeConst(ty),
                         ty: Type::COMPTIME_TYPE,
@@ -752,11 +766,13 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
                 return_type,
                 span,
             )?;
+            let air_ref =
+                self.wrap_value_with_temp_scope(air, air_ref, return_type, span, temp_scope)?;
             Ok(AnalysisResult::new(air_ref, return_type))
         } else {
             // Regular non-generic call
             let return_type = base_return_type;
-            self.emit_call_result(air, name, &air_args, return_type, span)
+            self.emit_call_result(air, name, &air_args, temp_scope, return_type, span)
         }
     }
 
@@ -1191,7 +1207,12 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
         if receiver_frame_pushed {
             ctx.call_loaned_roots.pop();
         }
-        air_args.extend(args_result?);
+        let args_result = args_result?;
+        air_args.extend(args_result.args);
+        // The receiver's materialized owner is entered first: it is created
+        // before any explicit operand, so its scope must be the outer one.
+        let mut temp_scope = receiver_temp_scope;
+        temp_scope.extend(args_result.temp_scope);
 
         // Generate the method call symbol: `Type.method`, file-qualified when
         // the type name spans files (RUE-571) — must match the definition
@@ -1199,15 +1220,9 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
         let call_name = self.method_symbol(struct_id, &method_name_str, true);
         let call_name_sym = self.body_interner().get_or_intern(&call_name);
 
-        let call = self.emit_call_result(air, call_name_sym, &air_args, return_type, span)?;
-        let air_ref = self.wrap_value_with_temp_scope(
-            air,
-            call.air_ref,
-            return_type,
-            span,
-            receiver_temp_scope,
-        )?;
-        Ok(AnalysisResult::new(air_ref, return_type))
+        let call =
+            self.emit_call_result(air, call_name_sym, &air_args, temp_scope, return_type, span)?;
+        Ok(AnalysisResult::new(call.air_ref, return_type))
     }
 
     /// Analyze a module member call: `module.function(args)` becomes a direct function call.
@@ -1336,10 +1351,19 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
         // materialize their by-value fat-pointer views exactly like direct
         // calls do (RUE-559) — std functions taking `borrow s: str` are called
         // this way.
-        let air_args =
-            self.analyze_call_operands(air, args_range, &param_types, &param_modes, true, ctx)?;
+        let CallOperands {
+            args: air_args,
+            temp_scope,
+        } = self.analyze_call_operands(air, args_range, &param_types, &param_modes, true, ctx)?;
 
-        self.emit_call_result(air, function_key, &air_args, fn_info.return_type, span)
+        self.emit_call_result(
+            air,
+            function_key,
+            &air_args,
+            temp_scope,
+            fn_info.return_type,
+            span,
+        )
     }
 
     /// Analyze a type-qualified associated-function call.
@@ -1486,7 +1510,10 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
         // path as free and module-member calls. In particular, `borrow str`
         // and `[T]` parameters are physical by-value views even though their
         // source modes remain Borrow (RUE-634).
-        let air_args = self.analyze_call_operands(
+        let CallOperands {
+            args: air_args,
+            temp_scope,
+        } = self.analyze_call_operands(
             air,
             args_range,
             &method_param_types,
@@ -1503,6 +1530,6 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
         let call_name = self.method_symbol(struct_id, &function_name_str, false);
         let call_name_sym = self.body_interner().get_or_intern(&call_name);
 
-        self.emit_call_result(air, call_name_sym, &air_args, return_type, span)
+        self.emit_call_result(air, call_name_sym, &air_args, temp_scope, return_type, span)
     }
 }

--- a/crates/rue-air/src/sema/analysis/ownership.rs
+++ b/crates/rue-air/src/sema/analysis/ownership.rs
@@ -51,6 +51,53 @@ pub(crate) enum AccessorEscapeSite {
     Capture,
 }
 
+/// The mechanism that gave a `borrow` operand which is not an existing place
+/// something to loan (spec 6.1:39–6.1:41, RUE-953).
+///
+/// The two paths are deliberately distinct and separately criterioned; the
+/// choice between them is made once, in
+/// [`OrdinaryBodyEngine::elaborate_borrow_operand`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum BorrowOperandElaboration {
+    /// **Static promotion.** The operand is comptime-evaluable and infallible,
+    /// so the loan names the value's immortal static image: no destructor runs
+    /// and no cleanup is scheduled for it (formal core §6.13.2's `H0` story).
+    Promoted,
+    /// **Compiler-materialized temporary.** The operand is evaluated exactly
+    /// once into a fresh hidden binding scoped to the call — the exact extent
+    /// of the loan it backs — whose value is dropped exactly once on every
+    /// path that leaves that scope (formal core §5.6's scope-exit drop).
+    Temporary,
+}
+
+/// The AIR pieces of an elaborated `borrow` operand, kept separate so each
+/// lands in the position its obligation requires.
+pub(crate) struct ElaboratedBorrowOperand {
+    /// Addressable read of the hidden binding — the operand's replacement.
+    pub(crate) load: AirRef,
+    /// Initializer of the hidden binding. Stays at the operand's argument
+    /// position, so the operand is evaluated in source order (spec 4.10:7).
+    pub(crate) alloc: AirRef,
+    /// Storage annotation. Hoisted into a block wrapping the *call*, which is
+    /// the scope whose exit drops the binding — after the callee has read
+    /// through the loan, on every path that leaves the call.
+    pub(crate) storage_live: AirRef,
+}
+
+/// Analyzed call operands plus the storage annotations that must wrap the
+/// emitted call.
+///
+/// A borrow-operand temporary's `StorageLive` is hoisted here so the call
+/// emitter can wrap the *call* in the block whose exit drops it — after the
+/// callee has read through the loan. Its `Alloc` stays at the operand's
+/// argument position, so operands are still evaluated left to right
+/// (spec 4.10:7).
+pub(crate) struct CallOperands {
+    pub(crate) args: Vec<AirCallArg>,
+    /// `StorageLive` instructions to prefix onto the call, in operand order.
+    pub(crate) temp_scope: Vec<AirRef>,
+}
+
 // Place Building
 // ============================================================================
 
@@ -328,6 +375,207 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
         });
         let value = Self::finish_traced_value(air, &mut trace, value, ty, span)?;
         Ok(Some(AnalysisResult::new(value, ty)))
+    }
+
+    /// Whether a by-reference operand names an existing place: a local, a
+    /// parameter, or a field/index projection chain rooted at one.
+    ///
+    /// A name that resolves to no binding — a named constant, or a value
+    /// `const` re-export — is *not* a place: it has no caller-visible storage
+    /// to point at, which is why it used to be an E0427 (RUE-760) and is now a
+    /// borrow-operand elaboration candidate instead (RUE-953).
+    fn borrow_operand_names_place(&self, value: InstRef, ctx: &AnalysisContext) -> bool {
+        let Some(root) = root_variable_of(self.body_rir_ref(), value) else {
+            // A `-> borrow T` accessor chain (ADR-0062) is a place too: it
+            // re-roots at its receiver's binding, which the inlined accessor
+            // body reads in place.
+            return self.place_root_with_accessors(value, ctx).is_some();
+        };
+        ctx.locals.contains_key(&root) || ctx.params.iter().any(|param| param.name == root)
+    }
+
+    /// Whether a `borrow` operand qualifies for **static promotion**
+    /// (spec 6.1:40, RUE-953).
+    ///
+    /// The criterion is two conjuncts, both required:
+    ///
+    /// 1. the operand is drawn from the enumerated *infallible* form set
+    ///    below — literals, a named value constant, a `comptime` parameter,
+    ///    and the arithmetic, bitwise, comparison, and logical operators over
+    ///    them; and
+    /// 2. it actually folds to a value under the body's comptime environment
+    ///    (a string literal or string constant is its own folded image; the
+    ///    comptime engine deliberately holds no string values).
+    ///
+    /// The form set is *value-independent* so the criterion can be checked by
+    /// inspection. `/` and `%` are excluded outright even for a nonzero
+    /// literal divisor: their trap conditions (divisor zero, `MIN / -1`) are
+    /// value-dependent, and a value-dependent promotion rule is exactly the
+    /// mistake Rust had to walk back (RFC 1414 → RFC 3027). Anything outside
+    /// the set — a call, an index, a field read, a cast, an intrinsic — takes
+    /// the temporary path instead, which is observationally identical apart
+    /// from where the value lives.
+    ///
+    /// Conjunct 2 also rules out a *fallible* fold: an operand whose constant
+    /// evaluation overflows or is otherwise diagnosed yields no value here, so
+    /// it takes the temporary path and its error is reported by the ordinary
+    /// runtime analysis of that temporary.
+    fn borrow_operand_is_promotable(&mut self, operand: InstRef, ctx: &AnalysisContext) -> bool {
+        if !self.borrow_operand_has_infallible_form(operand, ctx) {
+            return false;
+        }
+        // A string literal (or a `const` bound to one) is `.rodata`-backed and
+        // never evaluated: it is already the static image the loan names, and
+        // the comptime engine intentionally carries no string values
+        // (RUE-957), so asking it to fold would reject the very case the
+        // ruling is about.
+        if self.borrow_operand_is_static_string(operand, ctx) {
+            return true;
+        }
+        self.try_evaluate_const_in_fn(operand, ctx)
+            .is_some_and(|value| {
+                matches!(
+                    value,
+                    ConstValue::Integer(_) | ConstValue::Bool(_) | ConstValue::Unit
+                )
+            })
+    }
+
+    /// Conjunct 1 of the promotion criterion: the operand's syntax is drawn
+    /// from the enumerated infallible form set.
+    fn borrow_operand_has_infallible_form(&self, operand: InstRef, ctx: &AnalysisContext) -> bool {
+        match &self.body_rir_ref().get(operand).data {
+            InstData::IntConst(_)
+            | InstData::BoolConst(_)
+            | InstData::UnitConst
+            | InstData::StringConst { .. } => true,
+            InstData::Neg { operand }
+            | InstData::Not { operand }
+            | InstData::BitNot { operand } => {
+                self.borrow_operand_has_infallible_form(*operand, ctx)
+            }
+            InstData::Add { lhs, rhs }
+            | InstData::Sub { lhs, rhs }
+            | InstData::Mul { lhs, rhs }
+            | InstData::Eq { lhs, rhs }
+            | InstData::Ne { lhs, rhs }
+            | InstData::Lt { lhs, rhs }
+            | InstData::Gt { lhs, rhs }
+            | InstData::Le { lhs, rhs }
+            | InstData::Ge { lhs, rhs }
+            | InstData::And { lhs, rhs }
+            | InstData::Or { lhs, rhs }
+            | InstData::BitAnd { lhs, rhs }
+            | InstData::BitOr { lhs, rhs }
+            | InstData::BitXor { lhs, rhs }
+            | InstData::Shl { lhs, rhs }
+            | InstData::Shr { lhs, rhs } => {
+                self.borrow_operand_has_infallible_form(*lhs, ctx)
+                    && self.borrow_operand_has_infallible_form(*rhs, ctx)
+            }
+            // A name is in the set only when it is compile-time known and is
+            // NOT a runtime binding: a `let` or an ordinary parameter is a
+            // place and never reaches elaboration, while a named value
+            // constant or a `comptime` parameter has a static image.
+            InstData::VarRef { name, .. } => {
+                !ctx.locals.contains_key(name)
+                    && !ctx.params.iter().any(|param| param.name == *name)
+                    && (self.borrow_operand_is_static_string(operand, ctx)
+                        || ctx.comptime_value_vars.contains_key(name)
+                        || self
+                            .call_facts()
+                            .value_const(self.body_rir_ref().get(operand).span.file_id, *name)
+                            .is_some())
+            }
+            _ => false,
+        }
+    }
+
+    /// Whether the operand is a `.rodata`-backed string image: an inline
+    /// string literal, or a name bound to a string `const` (RUE-957).
+    fn borrow_operand_is_static_string(&self, operand: InstRef, ctx: &AnalysisContext) -> bool {
+        match &self.body_rir_ref().get(operand).data {
+            InstData::StringConst { .. } => true,
+            InstData::VarRef { name, .. } => {
+                !ctx.locals.contains_key(name)
+                    && !ctx.params.iter().any(|param| param.name == *name)
+                    && self
+                        .call_facts()
+                        .value_const(self.body_rir_ref().get(operand).span.file_id, *name)
+                        .is_some_and(|info| matches!(info.value, ConstValue::String(_)))
+            }
+            _ => false,
+        }
+    }
+
+    /// Elaborate a `borrow` operand that denotes no existing place into one
+    /// that does (spec 6.1:39–6.1:41, RUE-953).
+    ///
+    /// Returns the hidden binding's three AIR pieces separately, because each
+    /// belongs in a different position. The split is what makes both
+    /// obligations hold at once:
+    ///
+    /// - the `Alloc` stays here, at the operand's argument position, so the
+    ///   operand is evaluated in source order (spec 4.10:7);
+    /// - the `StorageLive` opens its drop scope around the *call*, so a
+    ///   temporary is dropped after the callee has read through the loan, by
+    ///   the ordinary scope-exit machinery — which already covers early exits
+    ///   (`return`, `break`, `?`) and path-dependent moves through its drop
+    ///   flags. No new drop path is introduced.
+    ///
+    /// A promoted operand's slot is registered as non-owning, so drop
+    /// elaboration schedules nothing for it at all.
+    fn elaborate_borrow_operand(
+        &mut self,
+        air: &mut Air,
+        operand: InstRef,
+        value: AirRef,
+        ty: Type,
+        span: Span,
+        ctx: &mut AnalysisContext,
+    ) -> CompileResult<ElaboratedBorrowOperand> {
+        // The hidden binding is never named, so nothing can consume it: its
+        // value reaches the end of the statement owned and is dropped. That is
+        // precisely the condition the linear leak check forbids, so a linear
+        // operand is reported through the language's existing
+        // discarded-linear-value diagnostic — with the help text that already
+        // names the fix ("bind the value with `let` and consume it").
+        self.reject_discarded_linear_value(ty, operand)?;
+        let kind = if self.borrow_operand_is_promotable(operand, ctx) {
+            BorrowOperandElaboration::Promoted
+        } else {
+            BorrowOperandElaboration::Temporary
+        };
+        let slots = self.require_layout_slots(ty, span)?;
+        let slot = self.reserve_frame_slots(&mut ctx.next_slot, slots, span)?;
+        if kind == BorrowOperandElaboration::Promoted {
+            // The promoted image is immortal and owns nothing — a literal's
+            // bytes live in `.rodata`, and a `StrBuf` promoted at a `borrow
+            // StrBuf` position is the non-owning `cap == 0` header over them.
+            // Registering the slot as non-owning is what makes "no drop glue"
+            // structural rather than incidental.
+            air.add_borrow_slot(slot);
+        }
+        let live = air.add_inst(AirInst {
+            data: AirInstData::StorageLive { slot },
+            ty,
+            span,
+        });
+        let alloc = air.add_inst(AirInst {
+            data: AirInstData::Alloc { slot, init: value },
+            ty: Type::UNIT,
+            span,
+        });
+        let load = air.add_inst(AirInst {
+            data: AirInstData::Load { slot },
+            ty,
+            span,
+        });
+        Ok(ElaboratedBorrowOperand {
+            load,
+            alloc,
+            storage_live: live,
+        })
     }
 
     /// Give a compiler-synthesized borrow argument an addressable home.
@@ -932,9 +1180,10 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
             .expect("accessor expansion follows a successful method lookup");
         let method_name_str = self.body_interner().resolve(&method).to_string();
 
-        // The receiver of an accessor call must be a place, exactly as a
-        // `borrow` argument must (E0427); it is read through a shared borrow,
-        // never moved.
+        // The receiver of an accessor call must be a place (E0427): the
+        // accessor's body is inlined against the receiver's storage, so there
+        // is nothing for borrow-operand elaboration (RUE-953) to loan. It is
+        // read through a shared borrow, never moved.
         let receiver_span = self.body_rir_ref().get(receiver).span;
         let receiver_trace = {
             let prev_byref_root = ctx.byref_arg_root.take();
@@ -982,8 +1231,12 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
         let param_modes = param_data.modes().to_vec();
         let param_names = param_data.names().to_vec();
         self.validate_call_contract_for_accessor(args_range, &param_types, &param_modes, span)?;
-        let air_args =
-            self.analyze_call_operands(air, args_range, &param_types, &param_modes, false, ctx)?;
+        // Every accessor parameter is by-value, so no operand here can produce
+        // a borrow-operand temporary (RUE-953); the guard statements below are
+        // the accessor's own storage.
+        let air_args = self
+            .analyze_call_operands(air, args_range, &param_types, &param_modes, false, ctx)?
+            .args;
 
         // Run inference for the accessor body so the caller's analysis can
         // walk instructions the caller's own inference never visited. The
@@ -4763,6 +5016,11 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
     /// through the existing by-value aggregate ABI (the parameter is by-value —
     /// see [`crate::sema::Sema`] parameter setup). All other arguments retain
     /// the ordinary by-value/by-reference analysis in this same chokepoint.
+    ///
+    /// A `borrow` operand that denotes no existing place is elaborated here
+    /// into one that does (RUE-953); see
+    /// [`Self::elaborate_borrow_operand`] for the two mechanisms and for why
+    /// the returned [`CallOperands::temp_scope`] must wrap the emitted call.
     pub(crate) fn analyze_call_args_coerced<A>(
         &mut self,
         air: &mut Air,
@@ -4770,7 +5028,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
         param_types: &[Type],
         param_modes: &[RirParamMode],
         ctx: &mut AnalysisContext,
-    ) -> CompileResult<Vec<AirCallArg>>
+    ) -> CompileResult<CallOperands>
     where
         A: ExactSizeIterator<Item = rue_rir::RirCallArg> + Clone,
     {
@@ -4835,11 +5093,12 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
         param_types: &[Type],
         param_modes: &[RirParamMode],
         ctx: &mut AnalysisContext,
-    ) -> CompileResult<Vec<AirCallArg>>
+    ) -> CompileResult<CallOperands>
     where
         A: ExactSizeIterator<Item = rue_rir::RirCallArg>,
     {
         let mut air_args = Vec::with_capacity(args.len());
+        let mut temp_scope: Vec<AirRef> = Vec::new();
         for (i, arg) in args.enumerate() {
             // A `str` parameter (ADR-0043 Phase 3, RUE-324) is a first-class
             // 2-word value, not a `borrow`-materialized fat pointer. A string
@@ -4867,11 +5126,14 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
                 // re-borrowed view (ADR-0043 two-types model). The source is
                 // borrowed (never moved) and a `StrBuf` source's 3-word header
                 // is narrowed to the 2-word `{ptr, len}` view here (RUE-559).
-                // The argument is always a place: `check_exclusive_access`
-                // rejected non-lvalue `borrow` arguments (E0427) before
-                // argument analysis began.
+                // An operand that names no place is elaborated first (RUE-953):
+                // a promoted string literal already *is* the static-backed
+                // view, and any other value is viewed through the temporary
+                // that owns it for the call.
                 if arg.is_borrow() && self.is_str_struct(str_ty) {
-                    let value = self.coerce_borrow_str_place_to_view(air, &arg, str_ty, ctx)?;
+                    let (value, storage_live) =
+                        self.coerce_borrow_str_operand_to_view(air, &arg, str_ty, ctx)?;
+                    temp_scope.extend(storage_live);
                     air_args.push(AirCallArg {
                         value,
                         // The 2-word view is passed BY VALUE (multi-slot
@@ -4939,7 +5201,17 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
                 continue;
             }
 
-            let byref_root = if arg.is_inout() || arg.is_borrow() {
+            // A `borrow` operand that denotes no existing place — a literal, a
+            // named constant, a call result, an arithmetic expression — is
+            // elaborated into one (RUE-953). The decision is taken here,
+            // before analysis, so the operand is analyzed as an ordinary value
+            // under the parameter's expected type instead of being traced as a
+            // place. `inout` is unchanged: an exclusive loan still requires
+            // caller-visible storage.
+            let elaborates_borrow =
+                arg.is_borrow() && !self.borrow_operand_names_place(arg.value, ctx);
+
+            let byref_root = if !elaborates_borrow && (arg.is_inout() || arg.is_borrow()) {
                 // A `borrow` argument may be an accessor-call place chain
                 // (ADR-0062): it borrows the accessor receiver's root.
                 let root = match root_variable_of(self.body_rir_ref(), arg.value) {
@@ -4976,9 +5248,43 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
                 None
             };
             let prev_byref_root = std::mem::replace(&mut ctx.byref_arg_root, byref_root);
+            // An elaborated operand is materialized at the parameter's type, so
+            // a string literal at a `borrow StrBuf` position becomes the
+            // literal-backed `cap == 0` header and an enum-typed fallible
+            // intrinsic names its registry result — the same contextual
+            // materialization a `let` with that annotation performs.
+            let prev_expected = if elaborates_borrow
+                && (param_ty.is_enum() || self.is_str_like(param_ty) || self.is_strbuf(param_ty))
+            {
+                Some(ctx.expected_type.replace(param_ty))
+            } else {
+                None
+            };
             let arg_result = self.analyze_inst(air, arg.value, ctx);
+            if let Some(previous) = prev_expected {
+                ctx.expected_type = previous;
+            }
             ctx.byref_arg_root = prev_byref_root;
             let arg_result = arg_result?;
+            if elaborates_borrow {
+                let span = self.body_rir_ref().get(arg.value).span;
+                let elaborated = self.elaborate_borrow_operand(
+                    air,
+                    arg.value,
+                    arg_result.air_ref,
+                    arg_result.ty,
+                    span,
+                    ctx,
+                )?;
+                temp_scope.push(elaborated.storage_live);
+                let value =
+                    air.add_block(&[elaborated.alloc], elaborated.load, arg_result.ty, span)?;
+                air_args.push(AirCallArg {
+                    value,
+                    mode: AirArgMode::Borrow,
+                });
+                continue;
+            }
             if arg.is_inout() || arg.is_borrow() {
                 // An inlined accessor argument arrives as a guards block whose
                 // tail is the place read (ADR-0062); peel it for the address
@@ -5039,7 +5345,10 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
                 mode: Self::convert_arg_mode(arg.mode),
             });
         }
-        Ok(air_args)
+        Ok(CallOperands {
+            args: air_args,
+            temp_scope,
+        })
     }
 
     /// Build a by-value slice `{ptr, len}` value from a `borrow arr` argument
@@ -5171,16 +5480,23 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
     ///   value through the 2-slot by-value parameter ABI was the RUE-559
     ///   miscompile: the callee read `cap` as the length and dereferenced the
     ///   length as the data pointer (segfault on indexing).
-    fn coerce_borrow_str_place_to_view(
+    ///
+    /// An operand that names no place is elaborated first (RUE-953) and the
+    /// returned `StorageLive`, when there is one, must wrap the call so a
+    /// temporary outlives the view built from it.
+    fn coerce_borrow_str_operand_to_view(
         &mut self,
         air: &mut Air,
         arg: &RirCallArg,
         str_ty: Type,
         ctx: &mut AnalysisContext,
-    ) -> CompileResult<AirRef> {
+    ) -> CompileResult<(AirRef, Option<AirRef>)> {
         use crate::inst::{AirInstData, AirProjection};
 
         let span = self.body_rir_ref().get(arg.value).span;
+        if !self.borrow_operand_names_place(arg.value, ctx) {
+            return self.elaborate_borrow_str_operand(air, arg, str_ty, ctx);
+        }
         let root = require_byref_place_arg(self.body_rir_ref(), arg)?;
         let prev_byref_root = ctx.byref_arg_root.replace(root);
         let trace = self.try_trace_place(arg.value, air, ctx);
@@ -5194,11 +5510,14 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
         if self.is_str_like(src_ty) {
             let projs: Vec<AirProjection> = trace.projections.iter().map(|p| p.proj).collect();
             let place_ref = air.make_place(trace.base, trace.base_type, projs)?;
-            return Ok(air.add_inst(AirInst {
-                data: AirInstData::PlaceRead { place: place_ref },
-                ty: str_ty,
-                span,
-            }));
+            return Ok((
+                air.add_inst(AirInst {
+                    data: AirInstData::PlaceRead { place: place_ref },
+                    ty: str_ty,
+                    span,
+                }),
+                None,
+            ));
         }
 
         // `StrBuf` source: narrow the buffer header to the `{ptr, len}` view.
@@ -5216,9 +5535,69 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
                 span,
             });
             let (view, prefix) = self.strbuf_text_view(air, strbuf_read, src_ty, span, ctx)?;
-            return self.wrap_value_with_temp_scope(air, view, str_ty, span, prefix);
+            return Ok((
+                self.wrap_value_with_temp_scope(air, view, str_ty, span, prefix)?,
+                None,
+            ));
         }
 
         Err(self.type_mismatch_error(str_ty, src_ty, span))
+    }
+
+    /// Build the `borrow s: str` view for an operand that names no place
+    /// (RUE-953).
+    ///
+    /// A promoted string operand needs no storage at all: at a `str`
+    /// parameter the loan *is* the two-word static-backed view, so the literal
+    /// materializes directly under the expected type and is passed by value —
+    /// the purest form of the promotion the ruling describes (formal core
+    /// §6.13.2: `"hello" : str` is `view⟨A_lit | 0, len⟩` over an allocation in
+    /// `H0`).
+    ///
+    /// Any other operand is evaluated once into a hidden binding that owns it
+    /// for the call; the view is then read out of that binding exactly as it
+    /// would be from a source place, and the binding's `StorageLive` travels
+    /// to the call wrapper so its drop runs after the callee returns.
+    fn elaborate_borrow_str_operand(
+        &mut self,
+        air: &mut Air,
+        arg: &RirCallArg,
+        str_ty: Type,
+        ctx: &mut AnalysisContext,
+    ) -> CompileResult<(AirRef, Option<AirRef>)> {
+        let span = self.body_rir_ref().get(arg.value).span;
+
+        let prev_expected = ctx.expected_type.replace(str_ty);
+        let operand = self.analyze_inst(air, arg.value, ctx);
+        ctx.expected_type = prev_expected;
+        let operand = operand?;
+
+        // A `str`/`Str(N)` operand already *is* the two-word view: a promoted
+        // literal materialized under the expected type, or a view another call
+        // produced. There is nothing to own and nothing to drop, so no storage
+        // is introduced at all.
+        if self.is_str_like(operand.ty) {
+            return Ok((operand.air_ref, None));
+        }
+
+        // A `StrBuf` operand owns a buffer. The hidden binding owns it for the
+        // call, and the view is read out of that binding through the trusted
+        // accessors — the same narrowing a source place gets (RUE-1066).
+        if self.is_strbuf(operand.ty) {
+            let elaborated = self.elaborate_borrow_operand(
+                air,
+                arg.value,
+                operand.air_ref,
+                operand.ty,
+                span,
+                ctx,
+            )?;
+            let (view, mut prefix) =
+                self.strbuf_text_view(air, elaborated.load, operand.ty, span, ctx)?;
+            prefix.insert(0, elaborated.alloc);
+            let view = self.wrap_value_with_temp_scope(air, view, str_ty, span, prefix)?;
+            return Ok((view, Some(elaborated.storage_live)));
+        }
+        Err(self.type_mismatch_error(str_ty, operand.ty, span))
     }
 }

--- a/crates/rue-air/src/sema/tests.rs
+++ b/crates/rue-air/src/sema/tests.rs
@@ -417,43 +417,109 @@ mod tests {
     }
 
     #[test]
-    fn byref_arguments_reject_non_places_during_air_analysis() {
+    fn inout_arguments_reject_non_places_during_air_analysis() {
         let cases = [
-            (
-                "const VALUE: i32 = 1; fn take(inout x: i32) {} fn main() -> i32 { take(inout VALUE); 0 }",
-                true,
-            ),
-            (
-                "const VALUE: i32 = 1; fn take(borrow x: i32) {} fn main() -> i32 { take(borrow VALUE); 0 }",
-                false,
-            ),
-            (
-                "fn take(inout x: i32) {} fn main() -> i32 { take(inout 1); 0 }",
-                true,
-            ),
-            (
-                "fn take(borrow x: i32) {} fn main() -> i32 { take(borrow (1 + 2)); 0 }",
-                false,
-            ),
-            (
-                "fn value() -> i32 { 1 } fn take(borrow x: i32) {} fn main() -> i32 { take(borrow value()); 0 }",
-                false,
-            ),
+            "const VALUE: i32 = 1; fn take(inout x: i32) {} fn main() -> i32 { take(inout VALUE); 0 }",
+            "fn take(inout x: i32) {} fn main() -> i32 { take(inout 1); 0 }",
+            "fn value() -> i32 { 1 } fn take(inout x: i32) {} fn main() -> i32 { take(inout value()); 0 }",
         ];
 
-        for (source, is_inout) in cases {
+        for source in cases {
             let errors = compile_to_air(source).expect_err("non-place must fail in sema");
             assert!(
-                errors.iter().any(|error| {
-                    if is_inout {
-                        matches!(error.kind, ErrorKind::InoutNonLvalue)
-                    } else {
-                        matches!(error.kind, ErrorKind::BorrowNonLvalue)
-                    }
-                }),
+                errors
+                    .iter()
+                    .any(|error| matches!(error.kind, ErrorKind::InoutNonLvalue)),
                 "source: {source}\nerrors: {errors:#?}"
             );
         }
+    }
+
+    /// Every borrow-operand slot introduced by `main`, paired with whether it
+    /// is registered as non-owning (the AIR signature of static promotion).
+    fn borrow_operand_slots(output: &SemaOutput) -> Vec<(u32, bool)> {
+        output
+            .functions
+            .iter()
+            .flat_map(|function| {
+                function.air.iter().filter_map(|(_, inst)| match inst.data {
+                    AirInstData::StorageLive { slot } => {
+                        Some((slot, function.air.is_borrow_slot(slot)))
+                    }
+                    _ => None,
+                })
+            })
+            .collect()
+    }
+
+    #[test]
+    fn borrow_operands_that_name_no_place_are_elaborated() {
+        // Every shape the old E0427 rejected now compiles (RUE-953).
+        for source in [
+            "const VALUE: i32 = 1; fn take(borrow x: i32) {} fn main() -> i32 { take(borrow VALUE); 0 }",
+            "fn take(borrow x: i32) {} fn main() -> i32 { take(borrow (1 + 2)); 0 }",
+            "fn value() -> i32 { 1 } fn take(borrow x: i32) {} fn main() -> i32 { take(borrow value()); 0 }",
+            "fn take(borrow x: i32) {} fn main() -> i32 { take(borrow 5); 0 }",
+        ] {
+            compile_to_air(source).unwrap_or_else(|errors| {
+                panic!("source: {source}\nerrors: {errors:#?}");
+            });
+        }
+    }
+
+    #[test]
+    fn promoted_borrow_operands_schedule_no_cleanup() {
+        // A comptime-evaluable, infallible operand loans a static image: its
+        // hidden binding owns nothing, so its slot is non-owning and drop
+        // elaboration schedules nothing for it.
+        let promoted = compile_to_air(
+            "const VALUE: i32 = 1;
+             fn take(borrow x: i32) {}
+             fn main() -> i32 { take(borrow 5); take(borrow (1 + 2)); take(borrow VALUE); 0 }",
+        )
+        .expect("promotable operands compile");
+        let slots = borrow_operand_slots(&promoted);
+        assert_eq!(slots.len(), 3, "one hidden binding per operand: {slots:?}");
+        assert!(
+            slots.iter().all(|(_, non_owning)| *non_owning),
+            "every promoted operand's slot is non-owning: {slots:?}"
+        );
+    }
+
+    #[test]
+    fn runtime_borrow_operands_materialize_an_owning_temporary() {
+        // A runtime operand — and a form outside the promotion set, even with
+        // constant arguments — takes the temporary path, whose binding owns
+        // its value and is dropped by the ordinary scope-exit machinery.
+        for source in [
+            "fn value() -> i32 { 1 } fn take(borrow x: i32) {} fn main() -> i32 { take(borrow value()); 0 }",
+            "fn take(borrow x: i32) {} fn main() -> i32 { take(borrow (6 / 2)); 0 }",
+        ] {
+            let output = compile_to_air(source).expect("runtime operands compile");
+            let slots = borrow_operand_slots(&output);
+            assert_eq!(slots.len(), 1, "source: {source}, slots: {slots:?}");
+            assert!(
+                !slots[0].1,
+                "source: {source}: a temporary's slot owns its value"
+            );
+        }
+    }
+
+    #[test]
+    fn linear_borrow_operand_temporaries_are_rejected() {
+        let errors = compile_to_air(
+            "linear struct Token { id: i32 }
+             fn make() -> Token { Token { id: 1 } }
+             fn peek(borrow t: Token) -> i32 { 5 }
+             fn main() -> i32 { peek(borrow make()) }",
+        )
+        .expect_err("nothing can consume a hidden binding, so a linear one leaks");
+        assert!(
+            errors
+                .iter()
+                .any(|error| matches!(error.kind, ErrorKind::LinearValueDiscarded { .. })),
+            "errors: {errors:#?}"
+        );
     }
 
     #[test]

--- a/crates/rue-cfg/src/build.rs
+++ b/crates/rue-cfg/src/build.rs
@@ -1373,11 +1373,30 @@ impl<'a> CfgBuilder<'a> {
                 // Collect statements into a Vec for iteration (needed for checking remaining)
                 let statements: Vec<AirRef> = self.air.get_block_statements(statements).collect();
 
-                // Check if this is a "wrapper block" that only contains StorageLive statements.
-                // These are synthetic blocks created to pair StorageLive with Alloc, and they
-                // should NOT create a new scope for drop elaboration.
+                // A binding's storage wrapper — `Block { [StorageLive s], Alloc s }`,
+                // emitted by `let` lowering to pair a slot's storage annotation with
+                // its initializer — must NOT open a drop scope: the binding belongs
+                // to the enclosing block, which is where its drop is scheduled.
+                //
+                // The shape is matched exactly: every statement is a `StorageLive`
+                // AND the block's value is the `Alloc` that initializes one of those
+                // slots. A block whose statements are `StorageLive`s but whose value
+                // is an ordinary expression is a real drop scope. That is what a
+                // borrow-operand temporary is (RUE-953): its `StorageLive` is hoisted
+                // to a wrapper around the call so the temporary's drop lands *after*
+                // the call, while its `Alloc` stays at the operand's argument
+                // position so evaluation order is unchanged.
+                let value_alloc_slot = match self.air.get(*value).data {
+                    AirInstData::Alloc { slot, .. } => Some(slot),
+                    _ => None,
+                };
                 let is_storage_live_wrapper = statements.iter().all(|stmt| {
                     matches!(self.air.get(*stmt).data, AirInstData::StorageLive { .. })
+                }) && statements.iter().any(|stmt| {
+                    matches!(
+                        self.air.get(*stmt).data,
+                        AirInstData::StorageLive { slot } if Some(slot) == value_alloc_slot
+                    )
                 });
 
                 // Only push a scope if this is a real syntactic block (not a StorageLive wrapper)

--- a/crates/rue-cli-tests/cases/byref_params.toml
+++ b/crates/rue-cli-tests/cases/byref_params.toml
@@ -169,16 +169,33 @@ compile_fail = true
 error_contains = ["E0428", "cannot mutate borrowed value"]
 
 [[case]]
-name = "byref_arg_non_lvalue_still_rejected"
-description = "A call result still cannot be passed by reference: there is no caller-visible place to point at (E0427)."
+name = "inout_arg_non_lvalue_still_rejected"
+description = "A call result still cannot be passed by EXCLUSIVE reference: an inout loan writes through the argument's own storage, which a value has none of (E0425). The shared form is elaborated instead (RUE-953, see below)."
 files = [{ path = "main.rue", source = """
 struct D { x: i32 }
 fn mk() -> D { D { x: 1 } }
-fn peek(borrow v: D) -> i32 { v.x }
-fn main() -> i32 { peek(borrow mk()) }
+fn bump(inout v: D) { v.x = v.x + 1; }
+fn main() -> i32 { bump(inout mk()); 0 }
 """ }]
 compile_fail = true
-error_contains = ["E0427", "borrow argument must be a variable"]
+error_contains = ["E0425", "inout argument must be an lvalue"]
+
+[[case]]
+name = "borrow_arg_call_result_is_a_temporary"
+description = "A `borrow` call-result argument is materialized in a hidden binding that owns it for the call and is dropped exactly once when the call returns (RUE-953, spec 6.1:41)."
+files = [{ path = "main.rue", source = """
+struct D { x: i32 }
+drop fn D(self) { @dbg(self.x); }
+fn mk(x: i32) -> D { D { x: x } }
+fn peek(borrow v: D) -> i32 { v.x }
+fn main() -> i32 {
+    let seen = peek(borrow mk(41));
+    @dbg(100);
+    seen + 1
+}
+""" }]
+exit_code = 42
+stdout = "41\n100\n"
 
 [[case]]
 name = "inout_projections_same_root_rejected"

--- a/crates/rue-cli-tests/cases/ice_regressions.toml
+++ b/crates/rue-cli-tests/cases/ice_regressions.toml
@@ -356,8 +356,8 @@ compile_fail = true
 error_contains = ["E0481", "invalid array length", "'A' is not a compile-time constant"]
 
 [[case]]
-name = "borrow_const_not_lvalue_rue52"
-description = "RUE-52: `borrow CONST` reached codegen as an immediate `Const` and hit panic!(\"by-ref argument must be a place\") in byref_args -> SIGABRT. Now a clean E0427."
+name = "borrow_const_is_promoted_rue52"
+description = "RUE-52: `borrow CONST` reached codegen as an immediate `Const` and hit panic!(\"by-ref argument must be a place\") in byref_args -> SIGABRT. It is now promoted to a static loan in sema (RUE-953), so codegen still never sees a non-place by-ref argument."
 files = [{ path = "main.rue", source = """
 const C: i32 = 5;
 fn take(borrow v: i32) -> i32 { v }
@@ -365,8 +365,7 @@ fn main() -> i32 {
     take(borrow C)
 }
 """ }]
-compile_fail = true
-error_contains = ["E0427", "borrow argument must be"]
+exit_code = 5
 
 [[case]]
 name = "inout_const_not_lvalue_rue52"

--- a/crates/rue-error/src/lib.rs
+++ b/crates/rue-error/src/lib.rs
@@ -1460,7 +1460,11 @@ pub enum ErrorKind {
     /// Same variable passed to multiple inout parameters in a single call
     #[error("cannot pass same variable '{variable}' to multiple inout parameters")]
     InoutExclusiveAccess { variable: String },
-    /// Borrow argument is not an lvalue (variable, field, or array element)
+    /// A shared by-reference position that requires an existing place and has
+    /// no elaboration (RUE-953): a method's `borrow self` receiver, an
+    /// accessor's receiver, and the array source of a slice coercion. An
+    /// explicit `borrow` *argument* that names no place is elaborated into a
+    /// promoted static or a hidden temporary instead of reaching this.
     #[error("borrow argument must be a variable, field, or array element")]
     BorrowNonLvalue,
     /// Cannot mutate a borrowed value

--- a/crates/rue-spec/cases/items/functions.toml
+++ b/crates/rue-spec/cases/items/functions.toml
@@ -1347,3 +1347,185 @@ struct S {
 fn main() -> i32 { let s = S { v: 30 }; s.m(4, 8) }
 """
 exit_code = 42
+
+# =============================================================================
+# Borrow operands: static promotion and compiler-materialized temporaries
+# (6.1:39 - 6.1:41)
+# =============================================================================
+
+[[case]]
+name = "borrow_operand_literal_is_accepted"
+spec = ["6.1:39", "6.1:40"]
+description = "A `borrow` argument need not denote a place: a literal operand is promoted to a static loan"
+source = """
+fn take(borrow x: i32) -> i32 { x }
+fn main() -> i32 { take(borrow 42) }
+"""
+exit_code = 42
+
+[[case]]
+name = "borrow_operand_named_constant_is_promoted"
+spec = ["6.1:40"]
+description = "A named value constant has no caller-visible storage, so borrowing it is a promoted static loan"
+source = """
+const LIMIT: i32 = 42;
+fn take(borrow x: i32) -> i32 { x }
+fn main() -> i32 { take(borrow LIMIT) }
+"""
+exit_code = 42
+
+[[case]]
+name = "borrow_operand_const_expression_is_promoted"
+spec = ["6.1:40"]
+description = "Arithmetic over literals is in the promotion form set and folds infallibly"
+source = """
+fn take(borrow x: i32) -> i32 { x }
+fn main() -> i32 { take(borrow (6 * 7 - 0)) }
+"""
+exit_code = 42
+
+[[case]]
+name = "borrow_operand_inout_still_requires_a_place"
+spec = ["6.1:39"]
+description = "Elaboration does not extend to `inout`: an exclusive loan still needs the argument's own storage"
+source = """
+fn take(inout x: i32) { x = x + 1; }
+fn main() -> i32 { take(inout 1); 0 }
+"""
+compile_fail = true
+error_contains = ["E0425", "inout argument must be an lvalue"]
+
+[[case]]
+name = "borrow_operand_call_result_is_a_temporary"
+spec = ["6.1:41"]
+description = "A runtime operand is evaluated once into a hidden binding whose storage backs the loan"
+source = """
+fn value() -> i32 { 42 }
+fn take(borrow x: i32) -> i32 { x }
+fn main() -> i32 { take(borrow value()) }
+"""
+exit_code = 42
+
+[[case]]
+name = "borrow_operand_temporary_is_evaluated_exactly_once"
+spec = ["6.1:41"]
+description = "The operand runs once, not once per read of the parameter inside the callee"
+source = """
+fn source() -> i32 { @dbg(1); 21 }
+fn take(borrow x: i32) -> i32 { x + x }
+fn main() -> i32 { take(borrow source()) }
+"""
+exit_code = 42
+expected_stdout = "1\n"
+
+[[case]]
+name = "borrow_operand_temporary_drops_once_after_the_call"
+spec = ["6.1:41"]
+description = "A droppable temporary's destructor runs exactly once, after the call it backs returns"
+source = """
+struct Log { id: i32 }
+drop fn Log(self) { @dbg(self.id); }
+fn make(id: i32) -> Log { Log { id: id } }
+fn level(borrow entry: Log) -> i32 { entry.id }
+fn main() -> i32 {
+    let value = level(borrow make(7));
+    @dbg(100);
+    value
+}
+"""
+exit_code = 7
+expected_stdout = "7\n100\n"
+
+[[case]]
+name = "borrow_operand_temporary_drops_once_per_evaluation"
+spec = ["6.1:41"]
+description = "A temporary created in a loop is dropped on each iteration, not accumulated"
+source = """
+struct Log { id: i32 }
+drop fn Log(self) { @dbg(self.id); }
+fn make(id: i32) -> Log { Log { id: id } }
+fn level(borrow entry: Log) -> i32 { entry.id }
+fn main() -> i32 {
+    let mut i: i32 = 0;
+    let mut total: i32 = 0;
+    while i < 3 {
+        total = total + level(borrow make(i));
+        i = i + 1;
+    }
+    total
+}
+"""
+exit_code = 3
+expected_stdout = "0\n1\n2\n"
+
+[[case]]
+name = "borrow_operand_temporary_drops_on_an_early_exit_path"
+spec = ["6.1:41"]
+description = "A `return` taken by a later argument of the same call still drops the already-initialized temporary exactly once"
+source = """
+struct Log { id: i32 }
+drop fn Log(self) { @dbg(self.id); }
+fn make(id: i32) -> Log { Log { id: id } }
+fn both(borrow entry: Log, extra: i32) -> i32 { entry.id + extra }
+fn pick(early: bool) -> i32 { if early { 5 } else { 1 } }
+fn run(early: bool) -> i32 {
+    if early { return both(borrow make(7), pick(true)); }
+    both(borrow make(9), pick(false))
+}
+fn main() -> i32 {
+    let first = run(true);
+    let second = run(false);
+    first + second
+}
+"""
+exit_code = 22
+expected_stdout = "7\n9\n"
+
+[[case]]
+name = "borrow_operand_temporaries_nest"
+spec = ["6.1:41"]
+description = "A borrow operand may itself contain a borrow operand; the inner temporary's scope nests inside the outer one"
+source = """
+fn inner() -> i32 { @dbg(1); 20 }
+fn middle(borrow x: i32) -> i32 { @dbg(2); x + 1 }
+fn outer(borrow y: i32) -> i32 { @dbg(3); y * 2 }
+fn main() -> i32 { outer(borrow middle(borrow inner())) }
+"""
+exit_code = 42
+expected_stdout = "1\n2\n3\n"
+
+[[case]]
+name = "borrow_operand_preserves_left_to_right_evaluation"
+spec = ["6.1:41", "4.10:7"]
+description = "Elaborating a later argument does not hoist its evaluation ahead of an earlier argument"
+source = """
+fn first() -> i32 { @dbg(1); 20 }
+fn second() -> i32 { @dbg(2); 22 }
+fn take(a: i32, borrow b: i32) -> i32 { a + b }
+fn main() -> i32 { take(first(), borrow second()) }
+"""
+exit_code = 42
+expected_stdout = "1\n2\n"
+
+[[case]]
+name = "borrow_operand_linear_temporary_is_rejected"
+spec = ["6.1:41"]
+description = "Nothing can name the hidden binding, so a linear operand would be dropped unconsumed"
+source = """
+linear struct Token { id: i32 }
+fn make() -> Token { Token { id: 1 } }
+fn peek(borrow t: Token) -> i32 { 5 }
+fn main() -> i32 { peek(borrow make()) }
+"""
+compile_fail = true
+error_contains = ["E0478", "carries a linear value and must be consumed"]
+
+[[case]]
+name = "borrow_operand_promoted_string_at_str_parameter"
+spec = ["6.1:40"]
+description = "A string literal promoted at a `borrow str` parameter is the static-backed two-word view"
+source = """
+fn width(borrow s: str) -> i32 { @intCast(s.len()) }
+fn main() -> i32 { width(borrow "hello") }
+"""
+exit_code = 5

--- a/crates/rue-ui-tests/cases/diagnostics/borrow-operands.toml
+++ b/crates/rue-ui-tests/cases/diagnostics/borrow-operands.toml
@@ -1,0 +1,208 @@
+[section]
+id = "diagnostics.borrow-operands"
+name = "Borrow-operand elaboration"
+description = "A `borrow` argument that denotes no place is elaborated into a promoted static or a compiler-materialized temporary (spec 6.1:39-6.1:41, RUE-953). These cases pin what is accepted, what the temporary's cleanup looks like from the program's point of view, and which shapes still fail."
+
+[[case]]
+name = "promoted_literal_is_accepted"
+description = "A literal operand no longer needs a bind-then-borrow workaround (6.1:40)."
+source = """
+fn take(borrow value: i32) -> i32 { value }
+
+fn main() -> i32 {
+    take(borrow 42)
+}
+"""
+exit_code = 42
+no_warnings = true
+
+[[case]]
+name = "promoted_string_literal_at_borrow_str"
+description = "A string literal promoted at a `borrow str` parameter is the static-backed two-word view; no storage is materialized for it (6.1:40)."
+source = """
+fn width(borrow text: str) -> i32 { @intCast(text.len()) }
+
+fn main() -> i32 {
+    width(borrow "hello")
+}
+"""
+exit_code = 5
+no_warnings = true
+
+[[case]]
+name = "runtime_temporary_is_accepted"
+description = "A call result is evaluated once into a hidden binding whose storage backs the loan (6.1:41)."
+source = """
+fn source() -> i32 { @dbg(1); 21 }
+
+fn take(borrow value: i32) -> i32 { value + value }
+
+fn main() -> i32 {
+    take(borrow source())
+}
+"""
+exit_code = 42
+expected_stdout = "1\n"
+
+[[case]]
+name = "droppable_temporary_drops_exactly_once"
+description = "The destructor of a temporary runs once, after the call it backs returns and before the rest of the statement (6.1:41)."
+source = """
+struct Log { id: i32 }
+drop fn Log(self) { @dbg(self.id); }
+
+fn make(id: i32) -> Log { Log { id: id } }
+fn level(borrow entry: Log) -> i32 { entry.id }
+
+fn main() -> i32 {
+    let value = level(borrow make(7));
+    @dbg(100);
+    value
+}
+"""
+exit_code = 7
+expected_stdout = "7\n100\n"
+
+[[case]]
+name = "droppable_temporaries_drop_in_reverse_order"
+description = "Two temporaries in one call are dropped LIFO by the ordinary scope-exit machinery (3.9:4, 6.1:41)."
+source = """
+struct Log { id: i32 }
+drop fn Log(self) { @dbg(self.id); }
+
+fn make(id: i32) -> Log { Log { id: id } }
+fn pair(borrow first: Log, borrow second: Log) -> i32 { first.id + second.id }
+
+fn main() -> i32 {
+    pair(borrow make(1), borrow make(2))
+}
+"""
+exit_code = 3
+expected_stdout = "2\n1\n"
+
+[[case]]
+name = "temporary_drops_on_an_early_return_path"
+description = "A `return` in a later argument of the same call still drops the already-initialized temporary exactly once (6.1:41)."
+source = """
+struct Log { id: i32 }
+drop fn Log(self) { @dbg(self.id); }
+
+fn make(id: i32) -> Log { Log { id: id } }
+fn both(borrow entry: Log, extra: i32) -> i32 { entry.id + extra }
+
+fn run() -> i32 {
+    both(borrow make(7), { return 55; })
+}
+
+fn main() -> i32 {
+    run()
+}
+"""
+exit_code = 55
+expected_stdout = "7\n"
+
+[[case]]
+name = "temporary_drops_on_a_break_path"
+description = "A temporary created in a loop is dropped on each evaluation, including the iteration that breaks (6.1:41)."
+source = """
+struct Log { id: i32 }
+drop fn Log(self) { @dbg(self.id); }
+
+fn make(id: i32) -> Log { Log { id: id } }
+fn level(borrow entry: Log) -> i32 { entry.id }
+
+fn main() -> i32 {
+    let mut i = 0;
+    while i < 5 {
+        if level(borrow make(i)) == 2 { break; }
+        i = i + 1;
+    }
+    i
+}
+"""
+exit_code = 2
+expected_stdout = "0\n1\n2\n"
+
+[[case]]
+name = "nested_borrow_operands_evaluate_inside_out"
+description = "A borrow operand may itself contain one; the inner temporary's scope nests inside the outer one (6.1:41)."
+source = """
+fn inner() -> i32 { @dbg(1); 20 }
+fn middle(borrow x: i32) -> i32 { @dbg(2); x + 1 }
+fn outer(borrow y: i32) -> i32 { @dbg(3); y * 2 }
+
+fn main() -> i32 {
+    outer(borrow middle(borrow inner()))
+}
+"""
+exit_code = 42
+expected_stdout = "1\n2\n3\n"
+
+[[case]]
+name = "elaboration_preserves_left_to_right_argument_order"
+description = "The elaborated operand is still evaluated in its own argument position (4.10:7, 6.1:41)."
+source = """
+fn first() -> i32 { @dbg(1); 20 }
+fn second() -> i32 { @dbg(2); 22 }
+
+fn take(plain: i32, borrow loaned: i32) -> i32 { plain + loaned }
+
+fn main() -> i32 {
+    take(first(), borrow second())
+}
+"""
+exit_code = 42
+expected_stdout = "1\n2\n"
+
+[[case]]
+name = "linear_temporary_is_rejected"
+description = "Nothing can name the hidden binding, so a linear operand would reach the end of its scope unconsumed (6.1:41, 3.8:64)."
+source = """
+linear struct Token { id: i32 }
+
+fn make() -> Token { Token { id: 1 } }
+fn peek(borrow token: Token) -> i32 { 5 }
+
+fn main() -> i32 {
+    peek(borrow make())
+}
+"""
+compile_fail = true
+error_contains = [
+    "[E0478]",
+    "carries a linear value and must be consumed",
+    "bind the value with `let` and consume it, or pass it to a consumer",
+]
+
+[[case]]
+name = "elaboration_does_not_extend_to_inout"
+description = "An exclusive loan writes through the argument's own storage, so `inout` still requires an lvalue (6.1:17, 6.1:39)."
+source = """
+fn bump(inout value: i32) { value = value + 1; }
+
+fn main() -> i32 {
+    bump(inout 1);
+    0
+}
+"""
+compile_fail = true
+error_contains = [
+    "[E0425]",
+    "inout argument must be an lvalue",
+]
+
+[[case]]
+name = "borrow_keyword_is_still_required"
+description = "Elaboration relaxes what a `borrow` argument may be, not whether the keyword is written (6.1:23, E0432)."
+source = """
+fn take(borrow value: i32) {}
+
+fn main() {
+    take(7);
+}
+"""
+compile_fail = true
+error_contains = [
+    "[E0432]",
+    "borrow",
+]

--- a/crates/rue-ui-tests/cases/diagnostics/call-argument-modes.toml
+++ b/crates/rue-ui-tests/cases/diagnostics/call-argument-modes.toml
@@ -40,15 +40,32 @@ error_contains = [
 ]
 
 [[case]]
-name = "named_const_is_not_a_borrow_place"
-description = "Borrowing a named constant reports the ordinary non-lvalue diagnostic before CFG construction (RUE-760)."
+name = "named_const_borrow_is_promoted"
+description = "A named constant has no caller-visible storage, so a `borrow` of it is promoted to a static loan rather than rejected as a non-lvalue (RUE-953 supersedes the RUE-760 borrow case; `inout` above is unchanged)."
 source = """
 const VALUE: i32 = 42;
 
-fn take(borrow value: i32) {}
+fn take(borrow value: i32) -> i32 { value }
 
-fn main() {
-    take(borrow VALUE);
+fn main() -> i32 {
+    take(borrow VALUE)
+}
+"""
+exit_code = 42
+
+[[case]]
+name = "borrow_self_receiver_still_requires_a_place"
+description = "E0427 survives borrow-operand elaboration: the implicit autoref of a `borrow self` receiver is not a `borrow` operand, so a computed receiver still has nothing to loan (RUE-953)."
+source = """
+struct Pair {
+    value: i32,
+    fn read(borrow self) -> i32 { self.value }
+}
+
+fn make() -> Pair { Pair { value: 1 } }
+
+fn main() -> i32 {
+    make().read()
 }
 """
 compile_fail = true

--- a/docs/formal/01-core-calculus.md
+++ b/docs/formal/01-core-calculus.md
@@ -478,6 +478,37 @@ returned, stored, or outlive the call — this is what lets Rue omit lifetimes.
 first-class-reference feature is adopted (a live ADR question, deferred), this
 section is where it lands.
 
+**Borrow of a value (elaboration, RUE-953).** The rule above is stated over
+`borrow p` with `p` a place, and that is the whole of the core: surface syntax
+also admits `borrow e` for an arbitrary `e`, and it is *elaborated away* before
+these rules apply. Elaboration is a source-to-source function on the argument,
+choosing between two forms:
+
+```
+  borrow e   with   e comptime-evaluable and infallible
+      ⇝  borrow ℓ_e        where ℓ_e is e's immortal static allocation in H0 (§6.13.2)
+
+  borrow e   otherwise
+      ⇝  let x_fresh = e in  borrow x_fresh    -- x_fresh unnameable, scoped to the call
+```
+
+Neither form is a new rule. The promoted form loans an `H0` allocation, which
+by §6.13.2 is minted before `main` and never retired: `Σ(ℓ_e) = Owned` holds
+everywhere, no scope contains it, and §5.6 therefore schedules nothing for it —
+that is the precise content of "no drop glue". The temporary form is an
+ordinary `let` whose binding scope is the call, so §5.6 governs it unchanged:
+if `class(T)` is droppable the drop is scheduled at the call's exit, and if
+`residual-linear(Σ, x_fresh, T)` the program is **ill-formed** — which is the
+right answer, since `x_fresh` is unnameable and so can never be consumed. The
+must-consume rejection of `f(borrow make_token())` is thus a consequence of
+§5.6, not an added premise.
+
+The elaboration is a function of the *argument's syntax alone*: it commits to
+the promoted form only on a value-independent, enumerated set of infallible
+forms (literals, constants, and the total operators over them — notably not `/`
+or `%`, whose traps are value-dependent). A value-dependent promotion rule is
+unsound to weaken later, which is the history Rust's RFC 1414 → RFC 3027 records.
+
 An **equality compare** `e1 ≟ e2` reads each place operand through the same
 kind of shared loan, scoped to the compare rather than a call: it requires
 `Σ(p) = Owned`, takes a `(root(p), shared)` loan for the compare's duration,

--- a/docs/spec/src/04-expressions/10-call-expressions.md
+++ b/docs/spec/src/04-expressions/10-call-expressions.md
@@ -25,7 +25,7 @@ call_arg  = [ "inout" | "borrow" ] expression ;
 
 {{ rule(id="4.10:10", cat="informative") }}
 
-An `inout` or `borrow` argument must denote a place; that requirement is a post-parse legality rule of the parameter-mode system (6.1:17), not a grammar restriction (see the grammar notes in appendix A).
+An `inout` argument must denote a place; that requirement is a post-parse legality rule of the parameter-mode system (6.1:17), not a grammar restriction (see the grammar notes in appendix A). A `borrow` argument that denotes no place is elaborated into one instead of being rejected (6.1:39).
 
 {{ rule(id="4.10:3", cat="legality-rule") }}
 

--- a/docs/spec/src/06-items/01-functions.md
+++ b/docs/spec/src/06-items/01-functions.md
@@ -228,6 +228,86 @@ fn main() -> i32 {
 }
 ```
 
+## Borrow Operands
+
+{{ rule(id="6.1:39", cat="legality-rule") }}
+
+An argument to a `borrow` parameter **MAY** be any expression of the parameter's
+type. When the argument does not denote a place — a variable, or a field or
+element projection chain rooted at one — it is a *borrow operand*, and the
+implementation elaborates it into a place by exactly one of two mechanisms:
+**static promotion** (6.1:40) when the operand meets the promotion criterion,
+and a **compiler-materialized temporary** (6.1:41) otherwise. Elaboration
+introduces no binding that source code can name, so the storage it produces is
+reachable from no other expression and takes part in none of the exclusivity
+rules 6.1:20, 6.1:30, and 6.1:36. This rule does **not** extend to `inout`: an
+exclusive loan writes through the argument's own storage, so an `inout`
+argument **MUST** still be an lvalue (6.1:17). Nor does it extend to a method
+receiver, whose passing mode is chosen by autoref (6.4:25) rather than written
+as a `borrow` operand.
+
+{{ rule(id="6.1:40", cat="legality-rule") }}
+
+A borrow operand is **promoted** when it is compile-time evaluable and
+infallible. It is promoted exactly when both of the following hold:
+
+- it is built only from a literal (integer, boolean, unit, or string), a named
+  value constant (6.5), a `comptime` parameter, and the unary operators `-`,
+  `!`, `~` and the binary operators `+`, `-`, `*`, `&`, `|`, `^`, `<<`, `>>`,
+  `&&`, `||`, `==`, `!=`, `<`, `<=`, `>`, `>=` applied to promoted operands;
+  and
+- it is a string, or it evaluates to a value at compile time.
+
+Division (`/`) and remainder (`%`) are excluded from the first condition even
+when the divisor is a nonzero literal, because their trap conditions depend on
+operand values rather than on the shape of the expression. An operand outside
+the set, and an operand whose compile-time evaluation is diagnosed (for example
+one that overflows its type), is not promoted and is elaborated under 6.1:41
+instead.
+
+A promoted operand loans the value's static image, which exists for the whole
+program's execution: no destructor runs for it, and no cleanup is scheduled at
+any point. A string literal promoted at a `borrow str` parameter is the
+static-backed two-word view of 3.7:44; promoted at a `borrow StrBuf` parameter
+it is the zero-capacity, literal-backed representation of 3.10:2, which owns no
+allocation.
+
+{{ rule(id="6.1:41", cat="dynamic-semantics") }}
+
+A borrow operand that is not promoted is evaluated **exactly once**, in
+argument order (4.10:7), and its value is placed in a fresh hidden binding
+created for the call; the loan names that binding's storage, so the value is
+live for the whole call. The binding's scope is that call — the exact extent
+of the loan it backs, since loans are second-class and cannot outlive the call
+(6.1:26) — so the binding goes out of scope as soon as the call returns, and
+its value is dropped there under the ordinary rules of 3.9. It is dropped
+exactly once on every path that reaches it, including a path that leaves the
+enclosing statement early through `return`, `break`, `continue`, or `?` after
+the binding was initialized, and it is not dropped on a path that leaves before
+the operand was evaluated at all.
+
+Because no expression can name the hidden binding, nothing can consume it. An
+operand whose type carries a linear value (3.8:57) is therefore rejected, on
+the same ground as a discarded expression value (3.8:64).
+
+{{ rule(id="6.1:42", cat="example") }}
+
+```rue
+struct Log { id: i32 }
+drop fn Log(self) { @dbg(self.id); }
+
+fn make(id: i32) -> Log { Log { id: id } }
+fn level(borrow entry: Log) -> i32 { entry.id }
+
+fn threshold(borrow limit: i32) -> i32 { limit }
+
+fn main() -> i32 {
+    let promoted = threshold(borrow 40);  // static: no temporary, no drop
+    let temporary = level(borrow make(2));  // hidden binding, dropped after the call
+    promoted + temporary  // 42
+}
+```
+
 ## Parameter Immutability
 
 {{ rule(id="6.1:32", cat="legality-rule") }}

--- a/docs/spec/src/appendices/A-grammar.md
+++ b/docs/spec/src/appendices/A-grammar.md
@@ -139,8 +139,9 @@ suffix         = "." IDENT                                     (* field access /
 
 (* Call arguments: any argument may carry an `inout`/`borrow` mode. The
    argument itself is parsed as an arbitrary expression; the requirement that
-   an inout/borrow argument denote a place (a variable, optionally with field/
-   index projections) is a legality rule (6.1:17), not a syntactic one. *)
+   an inout argument denote a place (a variable, optionally with field/
+   index projections) is a legality rule (6.1:17), not a syntactic one. A
+   `borrow` argument that denotes no place is elaborated into one (6.1:39). *)
 call_args      = call_arg { "," call_arg } [ "," ] ;
 call_arg       = [ "inout" | "borrow" ] expression ;
 
@@ -238,11 +239,13 @@ Notes:
   that is the entire argument) parses as a type; anything else — including
   `!expr`, which is logical not — parses as an expression.
 - **`inout`/`borrow` call arguments** are parsed as ordinary expressions; the
-  rule that such an argument must denote a place — a variable optionally
+  rule that an `inout` argument must denote a place — a variable optionally
   followed by field and index projections (e.g. `inout s.arr[i]`) — is a
   legality rule enforced during semantic analysis (6.1:17), not a syntactic
-  restriction. A non-place argument such as `inout a + 1` parses but is
-  rejected with an lvalue error (E0425).
+  restriction. A non-place `inout` argument such as `inout a + 1` parses but is
+  rejected with an lvalue error (E0425). A `borrow` argument has no such
+  restriction: one that denotes no place is elaborated into a promoted static
+  or a compiler-materialized temporary (6.1:39).
 - **Type-function application in type position** (`named_type` followed by
   arguments): a name or
   module-qualified path applied to arguments, e.g. `Pair(i32)`,

--- a/examples/harbor/dot_report.rue
+++ b/examples/harbor/dot_report.rue
@@ -11,12 +11,9 @@ fn quoted_id(inout out: StrBuf, borrow scenario: model.Scenario, id: u64) {
 }
 
 fn kind_shape(borrow scenario: model.Scenario, kind: u64) -> str {
-    let port: StrBuf = "port";
-    let hub: StrBuf = "hub";
-    let factory: StrBuf = "factory";
-    if scenario.strings.equals(kind, borrow port) { "box" }
-    else if scenario.strings.equals(kind, borrow hub) { "diamond" }
-    else if scenario.strings.equals(kind, borrow factory) { "component" }
+    if scenario.strings.equals(kind, borrow "port") { "box" }
+    else if scenario.strings.equals(kind, borrow "hub") { "diamond" }
+    else if scenario.strings.equals(kind, borrow "factory") { "component" }
     else { "ellipse" }
 }
 

--- a/examples/harbor/model.rue
+++ b/examples/harbor/model.rue
@@ -201,13 +201,9 @@ pub fn code_name(code: u64) -> StrBuf {
 }
 
 pub fn location_kind(borrow scenario: Scenario, id: u64) -> u64 {
-    let port: StrBuf = "port";
-    let hub: StrBuf = "hub";
-    let factory: StrBuf = "factory";
-    let market: StrBuf = "market";
-    if scenario.strings.equals(id, borrow port) { LOCATION_PORT() }
-    else if scenario.strings.equals(id, borrow hub) { LOCATION_HUB() }
-    else if scenario.strings.equals(id, borrow factory) { LOCATION_FACTORY() }
-    else if scenario.strings.equals(id, borrow market) { LOCATION_MARKET() }
+    if scenario.strings.equals(id, borrow "port") { LOCATION_PORT() }
+    else if scenario.strings.equals(id, borrow "hub") { LOCATION_HUB() }
+    else if scenario.strings.equals(id, borrow "factory") { LOCATION_FACTORY() }
+    else if scenario.strings.equals(id, borrow "market") { LOCATION_MARKET() }
     else { 0 }
 }

--- a/examples/rill/main.rue
+++ b/examples/rill/main.rue
@@ -142,32 +142,21 @@ fn main() -> i32 {
     let mut arg_index: u64 = 1;
     match std.env.arg(1) {
         OptStr.Some(first) => {
-            let dump_flag: StrBuf = "--dump";
-            if StrBuf.equals_borrowed(borrow first, borrow dump_flag) {
+            if StrBuf.equals_borrowed(borrow first, borrow "--dump") {
                 dump = true;
                 arg_index = 2;
-            } else {
-                let stats_flag: StrBuf = "--stats";
-                let stress_flag: StrBuf = "--stress";
-                if StrBuf.equals_borrowed(borrow first, borrow stats_flag) {
-                    show_stats = true;
-                    arg_index = 2;
-                } else if StrBuf.equals_borrowed(borrow first, borrow stress_flag) {
-                    stress_mode = true;
-                    arg_index = 2;
-                } else {
-                    let ast_flag: StrBuf = "--ast";
-                    if StrBuf.equals_borrowed(borrow first, borrow ast_flag) {
-                        dump_ast = true;
-                        arg_index = 2;
-                    } else {
-                        let help_flag: StrBuf = "--help";
-                        if StrBuf.equals_borrowed(borrow first, borrow help_flag) {
-                            help_mode = true;
-                            arg_index = 2;
-                        }
-                    }
-                }
+            } else if StrBuf.equals_borrowed(borrow first, borrow "--stats") {
+                show_stats = true;
+                arg_index = 2;
+            } else if StrBuf.equals_borrowed(borrow first, borrow "--stress") {
+                stress_mode = true;
+                arg_index = 2;
+            } else if StrBuf.equals_borrowed(borrow first, borrow "--ast") {
+                dump_ast = true;
+                arg_index = 2;
+            } else if StrBuf.equals_borrowed(borrow first, borrow "--help") {
+                help_mode = true;
+                arg_index = 2;
             }
         },
         OptStr.None => {},

--- a/examples/rill/vm.rue
+++ b/examples/rill/vm.rue
@@ -332,8 +332,7 @@ struct VM {
 
 pub fn run(program: bytecode.Program) -> RunResult {
     let mut vm = VM.new(program);
-    let main_name: StrBuf = "main";
-    let main_symbol = vm.program.pool.find(borrow main_name);
+    let main_symbol = vm.program.pool.find(borrow "main");
     let value = vm.start(main_symbol);
     RunResult { ok: !vm.failed, value: value, output: vm.output, error: vm.error }
 }


### PR DESCRIPTION
Implements the 2026-07-18 RUE-953 ruling: a `borrow` argument no longer has to name an existing place, ending the bind-then-borrow ceremony (7 dogfood hits). Two mechanisms, per the ruling:

**Static promotion** for comptime-evaluable, *infallible* operands. `borrow "x"` loans the literal's immortal static image — the RUE-685 `cap == 0` literal-backed `StrBuf` header at `borrow StrBuf` parameters, the two-word static view at `borrow str` (no storage at all). Integer/bool folds loan an undropped hidden slot. The criterion is conservative and syntax-explicit from day one: `/` and `%` are excluded outright since their trap conditions are value-dependent (the RFC 1414 → RFC 3027 lesson).

**Compiler-materialized temporaries** for runtime operands (`borrow f()`). The hidden slot's `Alloc` stays at the operand position — argument order is unchanged, verified observable — while its `StorageLive` hoists around the call, so the *existing* drop machinery (scopes, drop flags, early-exit paths) cleans the value exactly once on every path, immediately after the call. No parallel drop path; CFG and both backends see ordinary bindings. The one always-on change is tightening the CFG storage-wrapper predicate to the exact `let` shape.

**⚠️ Two deliberate deviations from the recorded ruling — flagged for review:**

1. **Temporaries are call-scoped, not statement-scoped.** The ruling said "drops at the end of the enclosing statement", but statement scoping is unsound in a `while` condition or a short-circuit right operand (re-`Alloc` without dropping the previous occupant, or a drop on a path that never initialized). The call is the exact extent of the loan the temporary backs — second-class borrows cannot outlive it — so call scope is tighter, safe, and observable only as an *earlier* destructor. Spec 6.1:41 states this precisely.
2. **The linear-leak rejection is not the scope-exit check.** The ruling assumed linear temporaries would "fall out ill-formed via the existing scope-exit leak check"; that check iterates named locals and never sees hidden bindings (verified empirically). Linear operands are instead routed through the existing discarded-linear-value diagnostic (E0478) — same code, same help text, same semantic ground.

Spec: new "Borrow Operands" section 6.1:39–6.1:42 plus corrections to 4.10:10 and the grammar appendix; formal core §5.4 elaboration note. Coverage: 12 spec cases, 12 new UI cases (drop-once, LIFO, early-return/break paths, nesting, evaluation order, linear rejection), CLI cases against the real binary. E0432 untouched; E0427 remains reachable on three verified residual paths (computed `borrow self` receivers, accessor receivers, slice-source arrays) and is now documented as such.

Dogfood: de-ceremonized 4 example sites (rill flag dispatch −11 lines, rill VM main lookup, harbor kind literals ×2); all example golden tests pass unchanged.

Fixes RUE-953.

## Validation

Premerge tier green (78/78, 0 build failures), full spec (2221 + traceability at 99.1%, 6.1:39–41 covered), rue-air 671/671, compiler 763/763 (re-run after rebase onto current trunk), UI incl. the new corpus, CLI `byref_params`/`ice_regressions`/all de-ceremonized examples, clippy ×2, fmt. Unfiltered-CLI caldera/meridian excluded per docs/process/ci.md (slow tier; their canaries inside premerge passed).

---
_Generated by [Claude Code](https://claude.ai/code/session_01DrKqpQgkHzDHGqpEMjxYdN)_