### PR TITLE
Reject conflicting foreign redeclarations across modules

### DIFF
--- a/crates/rue-air/src/sema/binding_manifest.rs
+++ b/crates/rue-air/src/sema/binding_manifest.rs
@@ -336,6 +336,12 @@ pub enum DeclarationInstallFailure {
     /// types; the carried message names both stable keys and the digest. Surfaces
     /// as a fail-closed E9000 internal error.
     AnonymousDigestCollision(Box<str>),
+    /// Two `extern "C"` foreign declarations name the same C symbol with
+    /// disagreeing signatures (RUE-1218, spec 9.3:5). Unlike every other
+    /// variant here this is a *source* error, not a broken installation
+    /// invariant, so it carries the finished diagnostic for the caller to
+    /// report verbatim instead of collapsing into an internal error.
+    ForeignSignatureConflict(Box<CompileError>),
 }
 
 impl From<crate::SemanticStableResolutionFailure> for DeclarationInstallFailure {
@@ -1425,30 +1431,39 @@ impl<'a> DeclarationShells<'a> {
                         let allow_unreachable_code = self
                             .sema
                             .has_allow_directive(directives.iter(), "unreachable_code");
+                        let info = super::FunctionInfo {
+                            params: range,
+                            return_type: return_type_value,
+                            return_type_sym: *return_type,
+                            body,
+                            declaration: pending.declaration,
+                            span: pending.shell.declaration_span,
+                            is_generic: pending.shell.is_generic,
+                            is_pub: pending.shell.is_public,
+                            is_unchecked: pending.shell.is_unchecked,
+                            is_extern: pending.shell.is_extern,
+                            is_c_export,
+                            allow_unused_function,
+                            allow_unused_variable,
+                            allow_unreachable_code,
+                            file_id: pending.shell.declaration_span.file_id,
+                        };
+                        // Foreign declarations from different modules share one
+                        // key here — the raw C symbol (RUE-1125). Disagreeing
+                        // signatures are rejected before one silently wins
+                        // (RUE-1218, spec 9.3:5). This is a real user
+                        // diagnostic, not an installation invariant, so it
+                        // travels in its own variant rather than as an ICE.
+                        self.sema
+                            .check_foreign_redeclaration(internal, &info)
+                            .map_err(|error| {
+                                DeclarationInstallFailure::ForeignSignatureConflict(Box::new(error))
+                            })?;
                         self.sema
                             .functions_by_file_name
                             .insert((pending.shell.declaration_span.file_id, *name), internal);
                         self.sema.function_source_names.insert(internal, *name);
-                        self.sema.functions.insert(
-                            internal,
-                            super::FunctionInfo {
-                                params: range,
-                                return_type: return_type_value,
-                                return_type_sym: *return_type,
-                                body,
-                                declaration: pending.declaration,
-                                span: pending.shell.declaration_span,
-                                is_generic: pending.shell.is_generic,
-                                is_pub: pending.shell.is_public,
-                                is_unchecked: pending.shell.is_unchecked,
-                                is_extern: pending.shell.is_extern,
-                                is_c_export,
-                                allow_unused_function,
-                                allow_unused_variable,
-                                allow_unreachable_code,
-                                file_id: pending.shell.declaration_span.file_id,
-                            },
-                        );
+                        self.sema.functions.insert(internal, info);
                     }
                 }
                 (

--- a/crates/rue-air/src/sema/declarations.rs
+++ b/crates/rue-air/src/sema/declarations.rs
@@ -114,6 +114,135 @@ impl<'a, D: DeclarationPhase> Sema<'a, D> {
             })
     }
 
+    /// Reject a second `extern "C"` foreign declaration of a C symbol whose
+    /// declared signature disagrees with the first (RUE-1218, spec 9.3:5).
+    ///
+    /// A foreign declaration describes an *external* function rather than
+    /// defining a Rue callable, so under the module-local identity rule
+    /// (RUE-1125) its internal symbol is the raw C name it declares. Two
+    /// modules declaring the same C function therefore both name that one
+    /// symbol — the right answer for the linker, one undefined symbol — but
+    /// they also both land on one key in [`Sema::functions`]. Without this
+    /// check the last-installed signature silently wins and every call through
+    /// the losing module type-checks against a signature its own module never
+    /// wrote.
+    ///
+    /// The check lives at signature *installation* rather than in the
+    /// predeclaration sweep because it compares resolved types: predeclaration
+    /// runs before any signature type is resolved, and comparing the source
+    /// spellings instead would both miss a real conflict (two modules writing
+    /// `Point` for different structs) and invent a false one (the same struct
+    /// spelled `Point` in one module and `c.Point` in another). Both producers
+    /// that install a free-function signature call this, so it fires for every
+    /// declaration the program contains without needing a call site.
+    ///
+    /// "Same signature" is C's redeclaration rule expressed in Rue's terms:
+    /// the same number of parameters, pairwise-equal resolved parameter types
+    /// and passing modes, and an equal resolved return type. Parameter *names*
+    /// are not part of the comparison — they are not part of the C symbol's
+    /// contract — and Rue's foreign-declaration surface (ADR-0064) has neither
+    /// default nor named parameters, so there is nothing else for "same" to
+    /// range over.
+    pub(super) fn check_foreign_redeclaration(
+        &self,
+        internal_name: Spur,
+        candidate: &FunctionInfo,
+    ) -> CompileResult<()> {
+        if !candidate.is_extern {
+            return Ok(());
+        }
+        let Some(previous) = self.functions.get(&internal_name) else {
+            return Ok(());
+        };
+        // The declaration walk and the on-demand signature materializer can
+        // both reach one declaration; re-installing the same declaration is not
+        // a redeclaration. A non-foreign occupant of this key is a different
+        // rule's business (only `main` in the root module can be one).
+        if previous.declaration == candidate.declaration || !previous.is_extern {
+            return Ok(());
+        }
+        if self.foreign_signatures_agree(previous, candidate) {
+            return Ok(());
+        }
+        // Report at the later declaration with a label on the earlier one,
+        // ordered by source position so the diagnostic does not depend on which
+        // producer installed which signature first.
+        let order = |info: &FunctionInfo| (info.span.file_id.index(), info.span.start);
+        let (first, second) = if order(previous) <= order(candidate) {
+            (previous, candidate)
+        } else {
+            (candidate, previous)
+        };
+        let declared = self.foreign_signature_display(second);
+        let previously_declared = self.foreign_signature_display(first);
+        // Comparison is on resolved types, so two declarations can disagree
+        // while rendering alike: a nominal type declared in each module is a
+        // distinct type even when both modules spell it the same. Say so
+        // rather than printing an apparently self-contradictory message.
+        let spelled_alike = declared == previously_declared;
+        let mut error = CompileError::new(
+            ErrorKind::ForeignSignatureConflict(Box::new(
+                rue_error::ForeignSignatureConflictError {
+                    symbol: self.interner.resolve(&internal_name).to_string(),
+                    declared,
+                    previously_declared,
+                },
+            )),
+            second.span,
+        )
+        .with_label("conflicting declaration of the same C symbol", second.span)
+        .with_label("first declared here", first.span)
+        .with_note(
+            "an `extern \"C\"` declaration names an external C symbol, so every module that \
+             declares it describes the same function; only one definition is linked in",
+        );
+        if spelled_alike {
+            error = error.with_note(
+                "the two signatures are spelled alike but resolve to different types: a struct \
+                 or enum declared in each module is a distinct type, even under the same name",
+            );
+        }
+        Err(error.with_help(
+            "make the declarations identical, or declare the symbol once and import that module",
+        ))
+    }
+
+    /// Whether two foreign declarations describe the same C function: equal
+    /// parameter count, pairwise-equal resolved parameter types and passing
+    /// modes, and an equal resolved return type. Slice equality carries the
+    /// parameter-count check. `comptime`-ness is compared with the modes
+    /// because it decides whether a parameter exists at the C boundary at all.
+    fn foreign_signatures_agree(&self, left: &FunctionInfo, right: &FunctionInfo) -> bool {
+        left.return_type == right.return_type
+            && self.param_arena.types(left.params) == self.param_arena.types(right.params)
+            && self.param_arena.modes(left.params) == self.param_arena.modes(right.params)
+            && self.param_arena.comptime(left.params) == self.param_arena.comptime(right.params)
+    }
+
+    /// Render a foreign declaration's signature for the conflict diagnostic.
+    fn foreign_signature_display(&self, info: &FunctionInfo) -> String {
+        let types = self.param_arena.types(info.params);
+        let modes = self.param_arena.modes(info.params);
+        let params = types
+            .iter()
+            .zip(modes)
+            .map(|(ty, mode)| match mode {
+                RirParamMode::Borrow => format!("borrow {}", self.format_type_name(*ty)),
+                RirParamMode::Inout => format!("inout {}", self.format_type_name(*ty)),
+                RirParamMode::Normal => self.format_type_name(*ty),
+            })
+            .collect::<Vec<_>>()
+            .join(", ");
+        if info.return_type == Type::UNIT {
+            format!("fn({params})")
+        } else {
+            format!(
+                "fn({params}) -> {}",
+                self.format_type_name(info.return_type)
+            )
+        }
+    }
+
     /// Resolve a source-level function name only in the given source file.
     ///
     /// This is the sole source-level lookup path for unqualified calls.
@@ -1619,30 +1748,31 @@ impl<'a> Sema<'a, super::MutableDeclarations> {
         );
 
         let internal_name = self.internal_function_name(name, span.file_id);
+        let info = FunctionInfo {
+            params: params_range,
+            return_type: ret_type,
+            return_type_sym,
+            body,
+            declaration,
+            span,
+            is_generic,
+            is_pub,
+            is_unchecked,
+            is_extern,
+            is_c_export,
+            allow_unused_function,
+            allow_unused_variable,
+            allow_unreachable_code,
+            file_id: span.file_id,
+        };
+        // Two modules may each declare the same C symbol; their signatures must
+        // agree before one of them takes this key (RUE-1218, spec 9.3:5).
+        self.check_foreign_redeclaration(internal_name, &info)?;
         self.functions_by_file_name
             .insert((span.file_id, name), internal_name);
         self.function_source_names.insert(internal_name, name);
 
-        self.functions.insert(
-            internal_name,
-            FunctionInfo {
-                params: params_range,
-                return_type: ret_type,
-                return_type_sym,
-                body,
-                declaration,
-                span,
-                is_generic,
-                is_pub,
-                is_unchecked,
-                is_extern,
-                is_c_export,
-                allow_unused_function,
-                allow_unused_variable,
-                allow_unreachable_code,
-                file_id: span.file_id,
-            },
-        );
+        self.functions.insert(internal_name, info);
         Ok(())
     }
 

--- a/crates/rue-air/src/sema/tests.rs
+++ b/crates/rue-air/src/sema/tests.rs
@@ -4551,4 +4551,188 @@ fn main() -> i32 {{
             ["c_answer", "__rue_fn_pkg_2fmain_2erue__rue_answer"]
         );
     }
+
+    // =========================================================================
+    // Foreign redeclaration (spec 9.3:5, RUE-1218)
+    // =========================================================================
+    // Because a foreign declaration's identity is the raw C symbol it names,
+    // two modules declaring the same C function land on one signature key.
+    // Identical redeclarations are legal (C's rule); disagreeing ones must be
+    // rejected instead of letting the last-installed signature silently win.
+
+    /// Bind the declarations of a multi-module program with the `c_ffi`
+    /// preview enabled. The first file is the root module.
+    fn bind_foreign_program(files: &[(&str, FileId, &str)]) -> MultiErrorResult<()> {
+        let sources = files
+            .iter()
+            .map(|&(source, file_id, _)| (source, file_id))
+            .collect::<Vec<_>>();
+        let (rir, interner) = lower_files(&sources);
+        let mut features = PreviewFeatures::new();
+        features.insert(PreviewFeature::CFfi);
+        let mut sema = Sema::new_synthetic(&rir, &interner, features);
+        sema.set_root_file_id(files[0].1);
+        sema.set_symbol_paths(
+            files
+                .iter()
+                .map(|&(_, file_id, path)| (file_id, path.to_owned()))
+                .collect::<HashMap<_, _>>(),
+        );
+        sema.bind_declarations().map(|_| ())
+    }
+
+    const FOREIGN_ROOT: (&str, FileId, &str) =
+        ("fn main() -> i32 { 0 }", FileId::new(1), "pkg/main.rue");
+
+    #[test]
+    fn conflicting_foreign_redeclarations_name_both_declaration_sites() {
+        let errors = bind_foreign_program(&[
+            FOREIGN_ROOT,
+            (
+                "extern \"C\" { fn shared(x: i64) -> i64; }",
+                FileId::new(2),
+                "pkg/left.rue",
+            ),
+            (
+                "extern \"C\" { fn shared() -> bool; }",
+                FileId::new(3),
+                "pkg/right.rue",
+            ),
+        ])
+        .expect_err("disagreeing declarations of one C symbol are rejected");
+        let error = errors
+            .iter()
+            .find(|error| matches!(error.kind, ErrorKind::ForeignSignatureConflict(_)))
+            .expect("the conflict is reported as E1107");
+        let ErrorKind::ForeignSignatureConflict(payload) = &error.kind else {
+            unreachable!("just matched")
+        };
+        assert_eq!(payload.symbol, "shared");
+        assert_eq!(payload.declared, "fn() -> bool");
+        assert_eq!(payload.previously_declared, "fn(i64) -> i64");
+        // The primary span is the later declaration; the earlier one is a
+        // secondary label, so both sites are named.
+        assert_eq!(error.span().map(|span| span.file_id), Some(FileId::new(3)));
+        assert!(
+            error
+                .diagnostic()
+                .labels
+                .iter()
+                .any(|label| label.span.file_id == FileId::new(2)),
+            "the earlier declaration is labelled: {:?}",
+            error.diagnostic().labels
+        );
+    }
+
+    #[test]
+    fn identical_foreign_redeclarations_are_legal() {
+        // Parameter names are not part of a C symbol's contract, so the two
+        // declarations agree.
+        bind_foreign_program(&[
+            FOREIGN_ROOT,
+            (
+                "extern \"C\" { fn shared(x: i64) -> i64; }",
+                FileId::new(2),
+                "pkg/left.rue",
+            ),
+            (
+                "extern \"C\" { fn shared(y: i64) -> i64; }",
+                FileId::new(3),
+                "pkg/right.rue",
+            ),
+        ])
+        .expect("an identical redeclaration is legal, as in C");
+    }
+
+    #[test]
+    fn a_lone_foreign_declaration_is_unaffected() {
+        bind_foreign_program(&[
+            FOREIGN_ROOT,
+            (
+                "extern \"C\" { fn shared(x: i64) -> i64; }",
+                FileId::new(2),
+                "pkg/left.rue",
+            ),
+        ])
+        .expect("one foreign declaration has nothing to conflict with");
+    }
+
+    #[test]
+    fn a_same_named_ordinary_function_is_not_a_foreign_redeclaration() {
+        // An ordinary function's identity is module-qualified (RUE-1125), so it
+        // never occupies the C symbol's key and the rule does not apply to it.
+        bind_foreign_program(&[
+            FOREIGN_ROOT,
+            (
+                "extern \"C\" { fn shared(x: i64) -> i64; }",
+                FileId::new(2),
+                "pkg/left.rue",
+            ),
+            (
+                "pub fn shared() -> bool { true }",
+                FileId::new(3),
+                "pkg/right.rue",
+            ),
+        ])
+        .expect("a module-local Rue function is a different declaration entirely");
+    }
+
+    #[test]
+    fn foreign_redeclarations_disagreeing_only_in_parameter_mode_are_rejected() {
+        let errors = bind_foreign_program(&[
+            FOREIGN_ROOT,
+            (
+                "extern \"C\" { fn shared(x: i64) -> i64; }",
+                FileId::new(2),
+                "pkg/left.rue",
+            ),
+            (
+                "extern \"C\" { fn shared(borrow x: i64) -> i64; }",
+                FileId::new(3),
+                "pkg/right.rue",
+            ),
+        ])
+        .expect_err("passing mode is part of the declared signature");
+        assert!(
+            errors
+                .iter()
+                .any(|error| matches!(error.kind, ErrorKind::ForeignSignatureConflict(_))),
+            "{errors:?}"
+        );
+    }
+
+    #[test]
+    fn same_spelled_foreign_signatures_over_distinct_nominals_are_rejected() {
+        // The comparison is on resolved types, not source text: each module's
+        // `Point` is its own nominal type even though both spell it the same.
+        let errors = bind_foreign_program(&[
+            FOREIGN_ROOT,
+            (
+                "@repr(c)\n\
+                 pub struct Point { x: i32, y: i32 }\n\
+                 extern \"C\" { fn takes(p: Point) -> i32; }",
+                FileId::new(2),
+                "pkg/left.rue",
+            ),
+            (
+                "@repr(c)\n\
+                 pub struct Point { x: i64 }\n\
+                 extern \"C\" { fn takes(p: Point) -> i32; }",
+                FileId::new(3),
+                "pkg/right.rue",
+            ),
+        ])
+        .expect_err("two distinct nominal types are two distinct signatures");
+        let error = errors
+            .iter()
+            .find(|error| matches!(error.kind, ErrorKind::ForeignSignatureConflict(_)))
+            .expect("the conflict is reported as E1107");
+        assert!(
+            error.diagnostic().notes.iter().any(|note| note
+                .0
+                .contains("spelled alike but resolve to different types")),
+            "the diagnostic explains why two identical spellings disagree: {:?}",
+            error.diagnostic().notes
+        );
+    }
 }

--- a/crates/rue-cli-tests/cases/c_ffi.toml
+++ b/crates/rue-cli-tests/cases/c_ffi.toml
@@ -811,3 +811,78 @@ fn main() -> i32 { 0 }
 args = ["main.rue", "-o", "prog"]
 compile_fail = true
 error_contains = ["c_ffi"]
+
+# --- Foreign redeclaration across modules (spec 9.3:5, RUE-1218) ------------
+# Under the module-local identity rule (RUE-1125) a foreign declaration's
+# internal symbol is the raw C name it declares, so two modules declaring one C
+# function correctly produce one undefined symbol for the linker. They also land
+# on one signature key: disagreeing declarations must be rejected rather than
+# letting the last-installed signature silently type-check the other module's
+# calls. The check runs at declaration time, so no call site is needed.
+
+[[case]]
+name = "extern_conflicting_redeclaration_rejected"
+description = "Two modules declaring one C symbol with disagreeing signatures is rejected, naming both declaration sites (E1107)."
+args = ["main.rue", "--preview", "c_ffi", "-o", "prog"]
+files = [
+  { path = "main.rue", source = """const a = @import("a.rue");
+const b = @import("b.rue");
+
+fn main() -> i32 {
+    a.call() + b.call()
+}""" },
+  { path = "a.rue", source = """extern "C" {
+    fn shared(x: i64) -> i64;
+}
+
+pub fn call() -> i32 {
+    @intCast(checked { shared(1) })
+}""" },
+  { path = "b.rue", source = """extern "C" {
+    fn shared(x: ptr const u8) -> i32;
+}
+
+pub fn call() -> i32 {
+    let byte: u8 = 0;
+    checked { shared(@raw(byte)) }
+}""" },
+]
+compile_fail = true
+error_contains = ["E1107", "shared", "conflicting signatures", "a.rue", "b.rue"]
+
+[[case]]
+name = "extern_conflicting_redeclaration_rejected_without_call_site"
+description = "The redeclaration check is a declaration rule: it fires with no call to the foreign symbol at all (E1107)."
+args = ["main.rue", "--preview", "c_ffi", "-o", "prog"]
+files = [
+  { path = "main.rue", source = """const a = @import("a.rue");
+const b = @import("b.rue");
+
+fn main() -> i32 { 0 }""" },
+  { path = "a.rue", source = """extern "C" {
+    fn shared(x: i64) -> i64;
+}""" },
+  { path = "b.rue", source = """extern "C" {
+    fn shared() -> bool;
+}""" },
+]
+compile_fail = true
+error_contains = ["E1107", "shared", "conflicting signatures"]
+
+[[case]]
+name = "extern_identical_redeclaration_accepted"
+description = "An identical redeclaration of one C symbol in two modules is legal, as in C; parameter names are not part of the signature."
+args = ["main.rue", "--preview", "c_ffi", "-o", "prog"]
+files = [
+  { path = "main.rue", source = """const a = @import("a.rue");
+const b = @import("b.rue");
+
+fn main() -> i32 { 0 }""" },
+  { path = "a.rue", source = """extern "C" {
+    fn shared(x: i64) -> i64;
+}""" },
+  { path = "b.rue", source = """extern "C" {
+    fn shared(y: i64) -> i64;
+}""" },
+]
+exit_code = 0

--- a/crates/rue-compiler/src/canonical_semantic.rs
+++ b/crates/rue-compiler/src/canonical_semantic.rs
@@ -793,12 +793,21 @@ pub(crate) fn analyze_prepared_canonical_program_reusing_declarations(
     let bound = shells
         .install_declaration_semantics_with_anonymous(&projected, &projected_anonymous)
         .map_err(|reason| {
-            CanonicalSemanticFailure::declaration(
-                crate::CompileErrors::from(crate::CompileError::without_span(
+            // A foreign-signature conflict is the one installation outcome that
+            // reports a source error rather than a broken invariant: two modules
+            // declared the same C symbol with disagreeing signatures (RUE-1218).
+            let errors = match reason {
+                rue_air::DeclarationInstallFailure::ForeignSignatureConflict(error) => {
+                    crate::CompileErrors::from(*error)
+                }
+                reason => crate::CompileErrors::from(crate::CompileError::without_span(
                     rue_error::ErrorKind::InternalError(format!(
                         "query declaration installation invariant failed: {reason:?}"
                     )),
                 )),
+            };
+            CanonicalSemanticFailure::declaration(
+                errors,
                 declaration_stage_work(
                     declaration_index,
                     DeclarationBindingWork::default(),

--- a/crates/rue-error/src/lib.rs
+++ b/crates/rue-error/src/lib.rs
@@ -451,6 +451,17 @@ impl ErrorCode {
     pub const REPR_C_STRUCT_INELIGIBLE: Self = Self(1104);
     pub const EXTERN_VARIADIC_UNSUPPORTED: Self = Self(1105);
     pub const EXPORT_SIGNATURE_UNSUPPORTED: Self = Self(1106);
+    /// The same C symbol is declared by two `extern "C"` foreign declarations
+    /// whose Rue signatures disagree (RUE-1218, spec 9.3:5). A foreign
+    /// declaration names an external C symbol rather than a Rue callable, so
+    /// every module that declares it is describing *one* function; disagreeing
+    /// descriptions cannot both be right, and the program links against a
+    /// single definition. Sits in the FFI band beside the other `extern "C"`
+    /// signature rules (E1101-E1103) because it is a foreign-declaration rule,
+    /// not a general duplicate-definition rule — an ordinary function's
+    /// identity is module-local (RUE-1125), so only foreign declarations can
+    /// collide across modules at all.
+    pub const FOREIGN_SIGNATURE_CONFLICT: Self = Self(1107);
 
     // ========================================================================
     // Comptime errors (E1200-E1299)
@@ -569,6 +580,22 @@ pub struct ReprCIneligibleError {
     pub failing_type: String,
     /// Human phrase naming the reject-list reason.
     pub reason: String,
+}
+
+/// Payload for `ErrorKind::ForeignSignatureConflict`.
+///
+/// Two `extern "C"` foreign declarations name the same C symbol with
+/// disagreeing Rue signatures (RUE-1218). Both rendered signatures are carried
+/// so the diagnostic states the disagreement rather than only pointing at the
+/// two declaration sites.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ForeignSignatureConflictError {
+    /// The C symbol both declarations name.
+    pub symbol: String,
+    /// The later declaration's signature, as rendered for the user.
+    pub declared: String,
+    /// The earlier declaration's signature, as rendered for the user.
+    pub previously_declared: String,
 }
 
 /// Payload for `ErrorKind::LinearFieldDroppedByDestructure`.
@@ -1819,6 +1846,23 @@ pub enum ErrorKind {
         reason: String,
     },
 
+    /// Two `extern "C"` foreign declarations name the same C symbol with
+    /// disagreeing Rue signatures (RUE-1218, spec 9.3:5). A foreign declaration
+    /// is a description of an *external* function, not a Rue definition, so its
+    /// internal symbol is the raw C name it declares (RUE-1125) — two modules
+    /// declaring the same symbol produce one undefined symbol for the linker.
+    /// Identical redeclarations are legal, matching C; disagreeing ones cannot
+    /// both describe the definition that will be linked in, and without this
+    /// rule the last-collected signature silently wins for every call site.
+    #[error(
+        "`extern \"C\"` symbol `{}` is declared with conflicting signatures: `{}` here, \
+         but `{}` earlier",
+        .0.symbol,
+        .0.declared,
+        .0.previously_declared
+    )]
+    ForeignSignatureConflict(Box<ForeignSignatureConflictError>),
+
     /// A `@repr(c)` struct failed the reject-don't-guess eligibility check
     /// (ADR-0064 Amendment 1): an empty struct, an enum/aggregate field without
     /// its own `@repr(c)` marker, or a linear / destructor-bearing field. The
@@ -2101,6 +2145,7 @@ impl ErrorKind {
             ErrorKind::ExternArrayByValue { .. } => ErrorCode::EXTERN_ARRAY_BY_VALUE,
             ErrorKind::ExternVariadicUnsupported => ErrorCode::EXTERN_VARIADIC_UNSUPPORTED,
             ErrorKind::ExportSignatureUnsupported { .. } => ErrorCode::EXPORT_SIGNATURE_UNSUPPORTED,
+            ErrorKind::ForeignSignatureConflict(_) => ErrorCode::FOREIGN_SIGNATURE_CONFLICT,
             ErrorKind::ReprCStructIneligible(_) => ErrorCode::REPR_C_STRUCT_INELIGIBLE,
             ErrorKind::SliceNotYetImplemented => ErrorCode::SLICE_NOT_YET_IMPLEMENTED,
             ErrorKind::SliceReturnNotAllowed => ErrorCode::SLICE_RETURN_NOT_ALLOWED,

--- a/crates/rue-spec/cases/runtime/foreign-boundary.toml
+++ b/crates/rue-spec/cases/runtime/foreign-boundary.toml
@@ -1,0 +1,68 @@
+# Foreign-boundary semantics (§ 9.3, ADR-0064, `c_ffi` preview).
+#
+# Most of § 9.3 is not coverable here: the abort-at-boundary proof needs a C
+# caller linked to a Rue export, and the reverse-direction and ownership rules
+# describe undefined / programmer-responsibility behavior (see
+# KNOWN_UNCOVERED_NORMATIVE). The redeclaration rule is an ordinary
+# compile-time rejection, so it is pinned directly.
+
+[section]
+id = "runtime.foreign_boundary"
+spec_chapter = "9.3"
+name = "Foreign-Boundary Semantics"
+description = "Rules governing the target-C foreign boundary: foreign redeclaration agreement."
+
+# =============================================================================
+# Foreign redeclaration (9.3:5, RUE-1218)
+# =============================================================================
+
+[[case]]
+name = "foreign_redeclaration_must_agree"
+spec = ["9.3:5"]
+preview = "c_ffi"
+preview_should_pass = true
+description = "Two modules declaring one C symbol with disagreeing signatures is rejected, naming both sites"
+source = """
+const a = @import("a.rue");
+const b = @import("b.rue");
+
+fn main() -> i32 { 0 }
+"""
+aux_files = { "a.rue" = """
+extern "C" {
+    fn shared(x: i64) -> i64;
+}
+""", "b.rue" = """
+extern "C" {
+    fn shared() -> bool;
+}
+""" }
+compile_fail = true
+error_contains = [
+    "E1107",
+    "conflicting signatures",
+    "shared",
+]
+
+[[case]]
+name = "foreign_redeclaration_that_agrees_is_accepted"
+spec = ["9.3:5"]
+preview = "c_ffi"
+preview_should_pass = true
+description = "An identical redeclaration of one C symbol is legal, as in C; parameter names are not part of the signature"
+source = """
+const a = @import("a.rue");
+const b = @import("b.rue");
+
+fn main() -> i32 { 0 }
+"""
+aux_files = { "a.rue" = """
+extern "C" {
+    fn shared(x: i64) -> i64;
+}
+""", "b.rue" = """
+extern "C" {
+    fn shared(y: i64) -> i64;
+}
+""" }
+exit_code = 0

--- a/docs/spec/src/09-unchecked-code/03-foreign-boundary.md
+++ b/docs/spec/src/09-unchecked-code/03-foreign-boundary.md
@@ -61,3 +61,19 @@ compiler enforces no lifetime, exclusivity, aliasing, or destructor guarantee on
 a pointer handed to or received from C; honoring the foreign side's ownership and
 lifetime contract is the programmer's responsibility, exactly as for the raw
 pointer and heap intrinsics of § 9.2.
+
+## Foreign redeclaration
+
+{{ rule(id="9.3:5", cat="normative") }}
+
+A foreign declaration describes an external C symbol rather than defining a Rue
+function, so the same symbol **MAY** be declared in more than one module of a
+program; all such declarations name one symbol, and one definition is linked in.
+Every declaration of one symbol **MUST** declare the same signature: the same
+number of parameters, pairwise-equal parameter types and passing modes, and the
+same return type. Parameter names are not part of the signature, and types are
+compared as resolved in each declaring module, so a nominal type declared
+separately in two modules is two distinct types even under one name. A program
+in which two foreign declarations of one symbol disagree is ill-formed and is
+rejected at compile time, naming both declaration sites; a redeclaration that
+agrees is accepted, as in C.


### PR DESCRIPTION
Under module-local function identity (RUE-1125, #2092), two modules declaring the same `extern "C"` symbol correctly share one raw C symbol — but they also share one `Sema::functions` key, and the last-collected signature silently won: calls through the losing module type-checked against the winner with no diagnostic. (Before RUE-1125 this shape was an unresolved-relocation ICE, so nothing regressed; the silent behavior just became reachable.)

The installation point on **both** producers — the source-resolution path and the production binding-manifest path — now compares resolved signatures: pairwise parameter types, modes, and comptime-ness plus the return type, parameter names excluded per the C contract. Disagreement is **E1107** naming both declaration sites (primary at the later one, ordered by source position so the diagnostic doesn't depend on producer order), with a dedicated note when two distinct module-local nominals render alike so the message never reads self-contradictory. Identical redeclarations stay legal, matching C's redeclaration rules. The production surface required one honest plumbing change: `DeclarationInstallFailure` gained a variant that carries a real source diagnostic instead of collapsing into an E9000 internal error.

Deliberately **not** in the RUE-1212 predeclaration sweep: predeclaration precedes type resolution, and source-spelling comparison is wrong in both directions (misses real conflicts over same-named module-local types, invents false ones over differently-spelled aliases). The installation point has resolved types and still reaches every declaration — the check fires with no call site, verified.

Spec: new rule 9.3:5 ("Foreign redeclaration") in the foreign-boundary chapter; its cases fire through the driver (verified before marking required-pass — traceability 793/800 with the pre-existing 9.3:2–4 known-uncovered set untouched).

Fixes RUE-1218.

Discovered while testing, filed separately: a non-root module declaring `extern "C" { fn main() -> i32 }` takes the bare `main` symbol, links against the root entry point, and recurses to a stack overflow at runtime — signatures agree, so this check can't catch it; it needs its own extern-vs-entry-point rule (refs RUE-1220).

## Validation

Premerge tier green (78/78), quick (30/30, re-run post-rebase), rue-air 678 (post-rebase), compiler 763, error-crate units, CLI `c_ffi` (41) and `multi` (39), spec 9.3 + traceability, clippy, fmt.

---
_Generated by [Claude Code](https://claude.ai/code/session_01DrKqpQgkHzDHGqpEMjxYdN)_