### PR TITLE
Reject foreign declarations of the program entry point

### DIFF
--- a/crates/rue-air/src/sema/declarations.rs
+++ b/crates/rue-air/src/sema/declarations.rs
@@ -114,6 +114,67 @@ impl<'a, D: DeclarationPhase> Sema<'a, D> {
             })
     }
 
+    /// Reject an `extern "C"` foreign declaration of `main`, the program entry
+    /// symbol (RUE-1220, spec 9.3:6).
+    ///
+    /// A foreign declaration names the C symbol it declares (RUE-1125), so
+    /// `extern "C" { fn main(); }` takes the bare `main` symbol the runtime
+    /// start glue calls (spec 6.1:38). There is no external function for it to
+    /// describe: in a non-root module the declaration silently binds the
+    /// program's own entry point, so a call through it recurses into `main`,
+    /// and in the root module it collides with the entry point's definition.
+    /// The rule is the import-side mirror of E1106's rejection of a
+    /// `pub extern "C" fn` export named `main`, and applies in every module and
+    /// for every signature — agreement with the entry point is not a defence,
+    /// which is why RUE-1218's signature check cannot express it.
+    ///
+    /// This lives in the predeclaration sweep rather than at signature
+    /// installation (where the query layer's foreign-redeclaration conflict
+    /// check runs) because
+    /// it reads only the declaration's own name and `extern` marker: no type is
+    /// resolved, so the earlier seam is available, and it is the one point both
+    /// producers pass for every declaration the program contains (installation
+    /// is reachable only from an already-swept `DeclarationShells`). Rejecting
+    /// here means the colliding `main` key is never handed out at all.
+    pub(super) fn check_foreign_entry_point_declaration(
+        &self,
+        declaration: InstRef,
+    ) -> CompileResult<()> {
+        let inst = self.rir.get(declaration);
+        let InstData::FnDecl {
+            name,
+            is_extern: true,
+            ..
+        } = &inst.data
+        else {
+            return Ok(());
+        };
+        if self.interner.resolve(name) != "main" {
+            return Ok(());
+        }
+        // Without `c_ffi` the declaration is rejected as E1100 by the gate that
+        // owns every `extern "C"` form; reporting a rule about a form the
+        // program cannot name yet would bury it. Same layering as the accessor
+        // sweep, and the same order the driver already produces.
+        if !self.preview_features.contains(&PreviewFeature::CFfi) {
+            return Ok(());
+        }
+        // One declaration is the whole error, so the declaration's own span
+        // carries it: no second site to label, unlike the redeclaration rule.
+        Err(
+            CompileError::new(ErrorKind::ForeignEntryPointDeclaration, inst.span)
+                .with_note(
+                    "a foreign declaration names the C symbol it declares, so this one resolves \
+                     to the program's entry point rather than to anything external; the entry \
+                     symbol belongs to the runtime start glue (`_start`/`__main`)",
+                )
+                .with_help(
+                    "give the foreign function a different C name, or call the Rue function \
+                     directly instead of declaring it foreign",
+                ),
+        )
+    }
+
     /// Resolve a source-level function name only in the given source file.
     ///
     /// This is the sole source-level lookup path for unqualified calls.

--- a/crates/rue-air/src/sema/mod.rs
+++ b/crates/rue-air/src/sema/mod.rs
@@ -1445,7 +1445,7 @@ impl<'a> Sema<'a, MutableDeclarations> {
         binding_work.callable_value_shells_predeclared = pending_payloads.len();
         binding_work.indexed_declaration_records_visited =
             pending_payloads.len() + pending_nominals.len();
-        self.check_accessor_declaration_shapes(&pending_payloads)?;
+        self.check_declaration_shapes(&pending_payloads)?;
         Ok(DeclarationShells {
             sema: self,
             binding_work,
@@ -1454,14 +1454,16 @@ impl<'a> Sema<'a, MutableDeclarations> {
         })
     }
 
-    /// Reject every ill-formed `-> borrow T` accessor declaration in the
-    /// program (6.6:3-6.6:5, ADR-0062).
+    /// Reject every declaration whose legality is decided by its own shape,
+    /// before any signature type is resolved: ill-formed `-> borrow T`
+    /// accessors (6.6:3-6.6:5, ADR-0062) and `extern "C"` declarations of the
+    /// program entry symbol (9.3:6, RUE-1220).
     ///
     /// Predeclaration is the one point every producer reaches for every
     /// declaration the program contains, whether or not anything calls it.
     /// The driver analyzes bodies only on demand, so a rule that runs from a
     /// body would let an uncalled accessor escape the preview gate entirely.
-    fn check_accessor_declaration_shapes(
+    fn check_declaration_shapes(
         &self,
         pending_payloads: &[binding_manifest::PendingDeclarationPayload],
     ) -> MultiErrorResult<()> {
@@ -1478,6 +1480,8 @@ impl<'a> Sema<'a, MutableDeclarations> {
                 &self.preview_features,
             )
             .map_err(CompileErrors::from)?;
+            self.check_foreign_entry_point_declaration(pending.declaration)
+                .map_err(CompileErrors::from)?;
         }
         Ok(())
     }
@@ -1505,7 +1509,7 @@ impl<'a> Sema<'a, MutableDeclarations> {
         binding_work.callable_value_shells_predeclared = pending_payloads.len();
         binding_work.indexed_declaration_records_visited =
             pending_payloads.len() + pending_nominals.len();
-        self.check_accessor_declaration_shapes(&pending_payloads)?;
+        self.check_declaration_shapes(&pending_payloads)?;
         Ok(DeclarationShells {
             sema: self,
             binding_work,

--- a/crates/rue-air/src/sema/tests.rs
+++ b/crates/rue-air/src/sema/tests.rs
@@ -4551,4 +4551,158 @@ fn main() -> i32 {{
             ["c_answer", "__rue_fn_pkg_2fmain_2erue__rue_answer"]
         );
     }
+
+    // =========================================================================
+    // Foreign declarations of the entry point: shared binding helper
+    // =========================================================================
+
+    /// Bind the declarations of a multi-module program with the `c_ffi`
+    /// preview enabled. The first file is the root module.
+    fn bind_foreign_program(files: &[(&str, FileId, &str)]) -> MultiErrorResult<()> {
+        let sources = files
+            .iter()
+            .map(|&(source, file_id, _)| (source, file_id))
+            .collect::<Vec<_>>();
+        let (rir, interner) = lower_files(&sources);
+        let mut features = PreviewFeatures::new();
+        features.insert(PreviewFeature::CFfi);
+        let mut sema = Sema::new_synthetic(&rir, &interner, features);
+        sema.set_root_file_id(files[0].1);
+        sema.set_symbol_paths(
+            files
+                .iter()
+                .map(|&(_, file_id, path)| (file_id, path.to_owned()))
+                .collect::<HashMap<_, _>>(),
+        );
+        sema.bind_declarations().map(|_| ())
+    }
+
+    const FOREIGN_ROOT: (&str, FileId, &str) =
+        ("fn main() -> i32 { 0 }", FileId::new(1), "pkg/main.rue");
+
+    // =========================================================================
+    // Foreign declaration of the entry point (spec 9.3:6, RUE-1220)
+    // =========================================================================
+    // `main` is the program's own entry symbol, reserved for the runtime start
+    // glue (6.1:38). A foreign declaration names the C symbol it declares
+    // (RUE-1125), so an `extern "C"` declaration of `main` would bind that
+    // entry point rather than anything external. Rejected in every module and
+    // for every signature — signature agreement is not a defence, which is why
+    // the RUE-1218 conflict rule cannot reach it.
+
+    fn expect_foreign_entry_point_error(errors: &CompileErrors) -> &rue_error::CompileError {
+        errors
+            .iter()
+            .find(|error| matches!(error.kind, ErrorKind::ForeignEntryPointDeclaration))
+            .unwrap_or_else(|| panic!("the declaration is rejected as E1108: {errors:?}"))
+    }
+
+    #[test]
+    fn a_foreign_declaration_of_main_in_another_module_is_rejected() {
+        // The RUE-1220 repro: without this rule the declaration takes the bare
+        // `main` symbol and a call through it recurses into the program's own
+        // entry point (verified stack overflow at runtime).
+        let errors = bind_foreign_program(&[
+            FOREIGN_ROOT,
+            (
+                "extern \"C\" { fn main() -> i32; }",
+                FileId::new(2),
+                "pkg/left.rue",
+            ),
+        ])
+        .expect_err("a foreign declaration may not name the program entry point");
+        let error = expect_foreign_entry_point_error(&errors);
+        assert_eq!(error.span().map(|span| span.file_id), Some(FileId::new(2)));
+        assert_eq!(
+            error.kind.code(),
+            rue_error::ErrorCode::FOREIGN_ENTRY_POINT_DECLARATION
+        );
+    }
+
+    #[test]
+    fn a_foreign_declaration_of_main_in_the_root_module_is_rejected() {
+        // The root module is where `main` legitimately lives, so this is the
+        // case a "collides with another declaration" rule would miss when the
+        // root has no `main` of its own: the symbol is reserved regardless.
+        let errors = bind_foreign_program(&[(
+            "extern \"C\" { fn main() -> i32; }\n\
+             fn other() -> i32 { 0 }",
+            FileId::new(1),
+            "pkg/main.rue",
+        )])
+        .expect_err("the entry symbol is reserved in the root module too");
+        let error = expect_foreign_entry_point_error(&errors);
+        assert_eq!(error.span().map(|span| span.file_id), Some(FileId::new(1)));
+    }
+
+    #[test]
+    fn a_foreign_declaration_of_main_matching_the_entry_signature_is_still_rejected() {
+        // `fn main() -> i32` is exactly the root entry point's signature, so no
+        // signature-agreement rule can reject it; the name alone is the fault.
+        bind_foreign_program(&[
+            ("fn main() -> i32 { 0 }", FileId::new(1), "pkg/main.rue"),
+            (
+                "extern \"C\" { fn main() -> i32; }",
+                FileId::new(2),
+                "pkg/left.rue",
+            ),
+        ])
+        .expect_err("agreement with the entry point's signature is not a defence");
+    }
+
+    #[test]
+    fn an_ungated_foreign_declaration_of_main_reports_the_preview_gate() {
+        // The gate that owns every `extern "C"` form reports first: a program
+        // without `c_ffi` cannot name the form this rule is about.
+        let (rir, interner) =
+            lower_files(&[("extern \"C\" { fn main() -> i32; }", FileId::new(1))]);
+        let mut sema = Sema::new_synthetic(&rir, &interner, PreviewFeatures::new());
+        sema.set_root_file_id(FileId::new(1));
+        let errors = sema
+            .bind_declarations()
+            .map(|_| ())
+            .expect_err("an ungated `extern \"C\"` declaration is rejected");
+        assert!(
+            errors
+                .iter()
+                .all(|error| !matches!(error.kind, ErrorKind::ForeignEntryPointDeclaration))
+                && errors
+                    .iter()
+                    .any(|error| matches!(error.kind, ErrorKind::PreviewFeatureRequired { .. })),
+            "{errors:?}"
+        );
+    }
+
+    #[test]
+    fn a_foreign_declaration_of_another_symbol_is_unaffected() {
+        bind_foreign_program(&[
+            FOREIGN_ROOT,
+            (
+                "extern \"C\" { fn mainly(x: i64) -> i64; }",
+                FileId::new(2),
+                "pkg/left.rue",
+            ),
+        ])
+        .expect("the rule names the entry symbol exactly, not anything resembling it");
+    }
+
+    #[test]
+    fn an_ordinary_main_in_another_module_stays_legal_and_mangled() {
+        // A non-extern `main` outside the root is an ordinary namespaced
+        // function (6.1:38, RUE-1125): it never takes the entry symbol, so it
+        // has nothing to collide with and this rule does not apply to it.
+        bind_foreign_program(&[
+            FOREIGN_ROOT,
+            ("pub fn main() -> i32 { 7 }", FileId::new(2), "pkg/left.rue"),
+        ])
+        .expect("an ordinary non-root `main` is an ordinary function");
+        let symbols = internal_symbols(
+            &[
+                IDENTITY_ROOT,
+                ("pub fn main() -> i32 { 7 }", FileId::new(2), "pkg/left.rue"),
+            ],
+            &[("main", FileId::new(1)), ("main", FileId::new(2))],
+        );
+        assert_eq!(symbols, ["main", "__rue_fn_pkg_2fleft_2erue__main"]);
+    }
 }

--- a/crates/rue-cli-tests/cases/c_ffi.toml
+++ b/crates/rue-cli-tests/cases/c_ffi.toml
@@ -905,3 +905,79 @@ fn main() -> i32 { 0 }""" },
 }""" },
 ]
 exit_code = 0
+
+# --- Foreign declaration of the entry point (spec 9.3:6, RUE-1220) ----------
+# `main` is the program's own entry symbol, reserved for the runtime start glue
+# (spec 6.1:38). Because a foreign declaration names the C symbol it declares
+# (RUE-1125), `extern "C" { fn main(); }` in a non-root module used to take the
+# bare `main` symbol: the program compiled and linked, and a call through the
+# declaration recursed into the program's own `main` (stack overflow, exit 101).
+# The signature agrees with the entry point's, so the RUE-1218 conflict rule
+# cannot reach it — the name alone is the fault, in every module.
+
+[[case]]
+name = "extern_declaration_of_main_rejected"
+description = "The RUE-1220 repro: a non-root module declaring `extern \"C\" fn main` is rejected instead of binding the program's own entry point (E1108)."
+args = ["main.rue", "--preview", "c_ffi", "-o", "prog"]
+files = [
+  { path = "main.rue", source = """const a = @import("a.rue");
+
+fn main() -> i32 {
+    a.run()
+}""" },
+  { path = "a.rue", source = """extern "C" {
+    fn main() -> i32;
+}
+
+pub fn run() -> i32 {
+    checked { main() }
+}""" },
+]
+compile_fail = true
+error_contains = ["E1108", "main", "entry point", "a.rue"]
+
+[[case]]
+name = "extern_declaration_of_main_in_root_module_rejected"
+description = "The entry symbol is reserved in the root module too, with no other declaration to collide with (E1108). A root that also defines `main` is caught earlier still, by the duplicate-definition rule."
+args = ["main.rue", "--preview", "c_ffi", "-o", "prog"]
+files = [
+  { path = "main.rue", source = """extern "C" {
+    fn main() -> i32;
+}
+
+fn other() -> i32 { 0 }""" },
+]
+compile_fail = true
+error_contains = ["E1108", "entry point"]
+
+[[case]]
+name = "extern_declaration_of_another_symbol_still_accepted"
+description = "The rule names the entry symbol exactly: a foreign declaration under any other C name is unaffected."
+args = ["main.rue", "--preview", "c_ffi", "-o", "prog"]
+files = [
+  { path = "main.rue", source = """const a = @import("a.rue");
+
+fn main() -> i32 {
+    a.run()
+}""" },
+  { path = "a.rue", source = """extern "C" {
+    fn mainly(x: i64) -> i64;
+}
+
+pub fn run() -> i32 { 0 }""" },
+]
+exit_code = 0
+
+[[case]]
+name = "ordinary_main_in_another_module_still_compiles_and_runs"
+description = "An ordinary (non-`extern`) `main` outside the root stays a namespaced function (RUE-1125): it is mangled, called normally, and does not become the entry point."
+args = ["main.rue", "-o", "prog"]
+files = [
+  { path = "main.rue", source = """const a = @import("a.rue");
+
+fn main() -> i32 {
+    a.main()
+}""" },
+  { path = "a.rue", source = """pub fn main() -> i32 { 7 }""" },
+]
+exit_code = 7

--- a/crates/rue-compiler/src/revisioned_query_database.rs
+++ b/crates/rue-compiler/src/revisioned_query_database.rs
@@ -17335,6 +17335,22 @@ impl RevisionedQueryDatabase {
                         ..
                     } = &signature.signature
                     {
+                        // A foreign declaration names the C symbol it declares,
+                        // so `extern "C" fn main` binds the program's own entry
+                        // point rather than anything external (spec 9.3:6).
+                        // Checked before the redeclaration comparison: signature
+                        // agreement with the entry point is not a defence.
+                        if declaration.name.as_ref() == "main" {
+                            return Err(SemanticNucleusBatchFailure::Stable {
+                                declaration: None,
+                                failure: Box::new(
+                                    crate::semantic_query_nucleus::SemanticNucleusFailure::DiagnosticAtDeclaration {
+                                        kind: rue_error::ErrorKind::ForeignEntryPointDeclaration,
+                                        declaration: declaration.clone(),
+                                    },
+                                ),
+                            });
+                        }
                         if let Some((previous, previous_parameters, previous_result)) =
                             foreign_declarations.get(&declaration.name)
                             && !foreign_signatures_agree(

--- a/crates/rue-error/src/lib.rs
+++ b/crates/rue-error/src/lib.rs
@@ -463,6 +463,15 @@ impl ErrorCode {
     /// identity is module-local (RUE-1125), so only foreign declarations can
     /// collide across modules at all.
     pub const FOREIGN_SIGNATURE_CONFLICT: Self = Self(1107);
+    /// An `extern "C"` foreign declaration names `main`, the program entry
+    /// point (RUE-1220, spec 9.3:6). A foreign declaration names the C symbol
+    /// it declares (RUE-1125), so this one takes the bare `main` symbol the
+    /// runtime start glue calls (spec 6.1:38) — in the root module it collides
+    /// with the entry point's own definition, and in any other module a call
+    /// through it recurses into the program's own `main`. Sits in the FFI band
+    /// beside the other `extern "C"` rules, and is the import-side mirror of
+    /// E1106's rejection of a `pub extern "C" fn` export named `main`.
+    pub const FOREIGN_ENTRY_POINT_DECLARATION: Self = Self(1108);
 
     // ========================================================================
     // Comptime errors (E1200-E1299)
@@ -1864,6 +1873,20 @@ pub enum ErrorKind {
     )]
     ForeignSignatureConflict(Box<ForeignSignatureConflictError>),
 
+    /// An `extern "C"` foreign declaration names `main` (RUE-1220, spec
+    /// 9.3:6). The declared C symbol is the program's own entry point, which
+    /// belongs to the runtime start glue (`_start`/`__main`, spec 6.1:38), so
+    /// there is no external `main` for such a declaration to describe: in a
+    /// non-root module it silently binds the program's own entry point and a
+    /// call through it recurses, and in the root module it collides with the
+    /// entry point's definition. Rejected in every module and for every
+    /// signature, mirroring E1106's rejection of an export named `main`.
+    #[error(
+        "`extern \"C\"` declaration of `main` names the program entry point, which is not an \
+         external function (ADR-0064)"
+    )]
+    ForeignEntryPointDeclaration,
+
     /// A `@repr(c)` struct failed the reject-don't-guess eligibility check
     /// (ADR-0064 Amendment 1): an empty struct, an enum/aggregate field without
     /// its own `@repr(c)` marker, or a linear / destructor-bearing field. The
@@ -2149,6 +2172,7 @@ impl ErrorKind {
             ErrorKind::ExternVariadicUnsupported => ErrorCode::EXTERN_VARIADIC_UNSUPPORTED,
             ErrorKind::ExportSignatureUnsupported { .. } => ErrorCode::EXPORT_SIGNATURE_UNSUPPORTED,
             ErrorKind::ForeignSignatureConflict(_) => ErrorCode::FOREIGN_SIGNATURE_CONFLICT,
+            ErrorKind::ForeignEntryPointDeclaration => ErrorCode::FOREIGN_ENTRY_POINT_DECLARATION,
             ErrorKind::ReprCStructIneligible(_) => ErrorCode::REPR_C_STRUCT_INELIGIBLE,
             ErrorKind::SliceNotYetImplemented => ErrorCode::SLICE_NOT_YET_IMPLEMENTED,
             ErrorKind::SliceReturnNotAllowed => ErrorCode::SLICE_RETURN_NOT_ALLOWED,

--- a/crates/rue-spec/cases/runtime/foreign-boundary.toml
+++ b/crates/rue-spec/cases/runtime/foreign-boundary.toml
@@ -10,7 +10,7 @@
 id = "runtime.foreign_boundary"
 spec_chapter = "9.3"
 name = "Foreign-Boundary Semantics"
-description = "Rules governing the target-C foreign boundary: foreign redeclaration agreement."
+description = "Rules governing the target-C foreign boundary: foreign redeclaration agreement and the reserved entry-point symbol."
 
 # =============================================================================
 # Foreign redeclaration (9.3:5, RUE-1218)
@@ -64,5 +64,91 @@ extern "C" {
 extern "C" {
     fn shared(y: i64) -> i64;
 }
+""" }
+exit_code = 0
+
+# =============================================================================
+# The program entry point is not a foreign function (9.3:6, RUE-1220)
+# =============================================================================
+
+[[case]]
+name = "foreign_declaration_of_main_in_another_module_rejected"
+spec = ["9.3:6"]
+preview = "c_ffi"
+preview_should_pass = true
+description = "A non-root module declaring `extern \"C\" fn main` is rejected: it would bind the program's own entry point"
+source = """
+const a = @import("a.rue");
+
+fn main() -> i32 { a.run() }
+"""
+aux_files = { "a.rue" = """
+extern "C" {
+    fn main() -> i32;
+}
+
+pub fn run() -> i32 {
+    checked { main() }
+}
+""" }
+compile_fail = true
+error_contains = [
+    "E1108",
+    "main",
+    "entry point",
+]
+
+[[case]]
+name = "foreign_declaration_of_main_in_the_root_module_rejected"
+spec = ["9.3:6"]
+preview = "c_ffi"
+preview_should_pass = true
+description = "The rule holds in the root module too: the entry symbol is reserved even with no `main` definition to collide with"
+source = """
+extern "C" {
+    fn main() -> i32;
+}
+
+fn other() -> i32 { 0 }
+"""
+compile_fail = true
+error_contains = [
+    "E1108",
+    "entry point",
+]
+
+[[case]]
+name = "c_export_named_main_rejected"
+spec = ["9.3:6"]
+preview = "c_ffi"
+preview_should_pass = true
+description = "The export direction of the same rule: a `pub extern \"C\" fn` named `main` is rejected (E1106)"
+source = """
+pub extern "C" fn main() -> i32 { 0 }
+"""
+compile_fail = true
+error_contains = [
+    "E1106",
+    "main",
+    "entry point",
+]
+
+[[case]]
+name = "foreign_declaration_of_another_symbol_is_unaffected"
+spec = ["9.3:6"]
+preview = "c_ffi"
+preview_should_pass = true
+description = "The rule is about the entry symbol alone: a foreign declaration under any other C name is legal"
+source = """
+const a = @import("a.rue");
+
+fn main() -> i32 { a.run() }
+"""
+aux_files = { "a.rue" = """
+extern "C" {
+    fn rue_absent_symbol() -> i32;
+}
+
+pub fn run() -> i32 { 0 }
 """ }
 exit_code = 0

--- a/docs/spec/src/09-unchecked-code/03-foreign-boundary.md
+++ b/docs/spec/src/09-unchecked-code/03-foreign-boundary.md
@@ -77,3 +77,18 @@ separately in two modules is two distinct types even under one name. A program
 in which two foreign declarations of one symbol disagree is ill-formed and is
 rejected at compile time, naming both declaration sites; a redeclaration that
 agrees is accepted, as in C.
+
+## The program entry point is not a foreign function
+
+{{ rule(id="9.3:6", cat="legality-rule") }}
+
+A foreign declaration **MUST NOT** name `main`, and a `pub extern "C" fn` export
+**MUST NOT** be named `main`. The `main` symbol is the program's own entry point,
+reserved for the runtime start glue that invokes the root module's `main`
+(§ 6.1:38); no external definition of it can be linked in. Because a foreign
+declaration names the C symbol it declares, `extern "C" { fn main(...); }` would
+otherwise bind the program's own entry point — in the root module colliding with
+its definition, and in any other module resolving a call through the declaration
+back into `main` itself. The rule applies in every module and for every declared
+signature, including one that agrees with the entry point's; a program containing
+such a declaration or export is ill-formed and is rejected at compile time.


### PR DESCRIPTION
A foreign declaration names the C symbol it declares (RUE-1125), so `extern "C" { fn main() -> i32; }` binds the program's own entry point rather than anything external: the program compiled, linked, and a call through the declaration recursed into `main` — verified stack overflow, exit 101 at runtime. RUE-1218's E1107 signature-conflict rule can't catch it because the signatures agree.

**E1108** rejects the shape in every module, for every signature — the import-side mirror of E1106's export-named-`main` rejection. The check lives in two places, matching where each pipeline actually routes foreign declarations after RUE-1217:

- **Sema predeclaration sweep** (`check_foreign_entry_point_declaration`, called from the renamed `check_declaration_shapes`): the rule reads only the declaring `FnDecl`'s name and extern-ness, so it fires before `internal_function_name` ever hands out the colliding `main` key, on every declaration, called or not. E1100 still gates first when `c_ffi` is off.
- **Query nucleus** (beside the relocated E1107 comparison in the extern-signature batch arm): RUE-1217 routed the driver's foreign declarations through the nucleus rather than the sema sweep, so the guard runs there too, ahead of the redeclaration comparison — signature agreement is not a defence.

This PR also carries the rebase reconciliation with RUE-1217, which moved the E1107 check and its unit tests from `rue-air` sema to the query layer mid-flight: the sema-side trio stays deleted (not resurrected), the shared binding-helper test scaffolding is retained for the new E1108 tests, and the driver-path behavior was re-verified end-to-end after the move (the original two-module repro now reports E1108 with no binary emitted; without `--preview c_ffi` it stays E1100).

Spec: rule **9.3:6** covers both directions of the entry-point boundary — the import side is new, and the export side's existing E1106 enforcement retroactively gains normative text. Four spec cases verified to fire through the driver. One interaction pinned rather than changed: extern `main` alongside a root `main` definition still reports E0436 (duplicate definition) from canonical merge first, which predates this work; the E1108-firing root shape (extern `main` with no definition) is the one no collision rule can catch.

Fixes RUE-1220.

## Validation

quick (30/30), rue-air 678, compiler 775, CLI `c_ffi` 46/46 and `multi`, spec 9.3 (6/6) and full suite (2242), traceability green (9.3:6 covered), clippy, fmt — all re-run after the RUE-1217 rebase reconciliation. Premerge ran twice pre-rebase: 78/78 and 77/78+1, the single failure being a 17ms-over-budget compile timeout on the loaded sandbox that passes in 17.5s isolated (the AGENTS.md timeout-only class).

---
_Generated by [Claude Code](https://claude.ai/code/session_01DrKqpQgkHzDHGqpEMjxYdN)_