### PR TITLE
Allocate caller-saved registers for intervals that cross no call

### DIFF
--- a/crates/rue-codegen/src/aarch64/cfg_lower.rs
+++ b/crates/rue-codegen/src/aarch64/cfg_lower.rs
@@ -47,6 +47,28 @@ pub(super) const RET_REGS: [Reg; 8] = [
     Reg::X7,
 ];
 
+// Call sequences and the prologue name these registers physically, and liveness
+// models neither those physical definitions nor their uses. So they must be off
+// limits to the allocator, not merely unlikely to collide (RUE-1146).
+const _: () = {
+    let mut index = 0;
+    while index < ARG_REGS.len() {
+        assert!(
+            super::mir::is_reserved(ARG_REGS[index]),
+            "every ABI argument register must be reserved from allocation"
+        );
+        index += 1;
+    }
+    let mut index = 0;
+    while index < RET_REGS.len() {
+        assert!(
+            super::mir::is_reserved(RET_REGS[index]),
+            "every ABI result register must be reserved from allocation"
+        );
+        index += 1;
+    }
+};
+
 /// Round `value` up to a multiple of `alignment` (a power of two ≥ 1).
 const fn align_up_u32(value: u32, alignment: u32) -> u32 {
     value.div_ceil(alignment) * alignment

--- a/crates/rue-codegen/src/aarch64/emit.rs
+++ b/crates/rue-codegen/src/aarch64/emit.rs
@@ -81,8 +81,8 @@
 use rue_error::{CompileError, CompileResult, ErrorKind, ice_error};
 
 use super::mir::{
-    Aarch64Inst, Aarch64Mir, BLOCK_LABEL_BASE, Cond, LabelId, Reg, narrow_load_mnemonic,
-    narrow_store_mnemonic,
+    Aarch64Inst, Aarch64Mir, BLOCK_LABEL_BASE, Cond, LabelId, Reg, SCRATCH_ADDRESS,
+    narrow_load_mnemonic, narrow_store_mnemonic,
 };
 use crate::{EmittedCode, EmittedInst, EmittedRelocation};
 
@@ -1796,20 +1796,25 @@ impl<'a> Emitter<'a> {
             self.emit_u32(inst);
         } else {
             // Offset outside the unscaled range: materialize the address in
-            // X15 — the dedicated address scratch; X9-X12 carry spilled values
-            // and may be the very rd/rs of this access. Previously the offset
-            // was masked & 0x1FF, silently WRAPPING — locals deeper than 256
-            // bytes loaded from above the frame pointer. (RUE-129)
-            // Correctness guard (must run in release): if the base were X15 we
-            // would clobber it while materializing the address and load from the
-            // wrong location, so plain `assert!` not `debug_assert!` (RUE-45).
+            // the dedicated address scratch; the allocation scratch registers
+            // carry spilled values and may be the very rd/rs of this access,
+            // and an allocated value may be in any allocatable register.
+            // `mir::RESERVED_REGS` keeps SCRATCH_ADDRESS out of both.
+            // Previously the offset was masked & 0x1FF, silently WRAPPING —
+            // locals deeper than 256 bytes loaded from above the frame
+            // pointer. (RUE-129)
+            // Correctness guard (must run in release): if the base were the
+            // address scratch we would clobber it while materializing the
+            // address and load from the wrong location, so plain `assert!` not
+            // `debug_assert!` (RUE-45).
             assert!(
-                base != Reg::Sp && base != Reg::X15,
+                base != Reg::Sp && base != SCRATCH_ADDRESS,
                 "large-offset load needs a general base register"
             );
-            self.emit_mov_imm(Reg::X15, offset as i64);
-            self.emit_add_rr(Reg::X15, base, Reg::X15, false);
-            let inst = OPCODE_LDR_UOFF | (Reg::X15.encoding() as u32) << 5 | rd.encoding() as u32;
+            self.emit_mov_imm(SCRATCH_ADDRESS, offset as i64);
+            self.emit_add_rr(SCRATCH_ADDRESS, base, SCRATCH_ADDRESS, false);
+            let inst =
+                OPCODE_LDR_UOFF | (SCRATCH_ADDRESS.encoding() as u32) << 5 | rd.encoding() as u32;
             self.emit_u32(inst);
         }
     }
@@ -1832,22 +1837,22 @@ impl<'a> Emitter<'a> {
             self.emit_u32(inst);
         } else {
             // Offset outside the unscaled range: materialize the address in
-            // X15 — the dedicated address scratch; X9-X12 carry spilled values
-            // and may be the very rd/rs of this access. Previously the offset
-            // was masked & 0x1FF, silently WRAPPING — locals deeper than 256
-            // bytes stored ABOVE the frame pointer, corrupting the caller's
-            // stack. (RUE-129)
+            // the dedicated address scratch; see `emit_ldr` for why no other
+            // register will do. Previously the offset was masked & 0x1FF,
+            // silently WRAPPING — locals deeper than 256 bytes stored ABOVE
+            // the frame pointer, corrupting the caller's stack. (RUE-129)
             // Correctness guard (must run in release): if the base or source
-            // were X15 we would clobber it while materializing the address and
-            // store to/from the wrong location, so plain `assert!` not
-            // `debug_assert!` (RUE-45).
+            // were the address scratch we would clobber it while materializing
+            // the address and store to/from the wrong location, so plain
+            // `assert!` not `debug_assert!` (RUE-45).
             assert!(
-                base != Reg::Sp && base != Reg::X15 && rs != Reg::X15,
+                base != Reg::Sp && base != SCRATCH_ADDRESS && rs != SCRATCH_ADDRESS,
                 "large-offset store needs a general base register"
             );
-            self.emit_mov_imm(Reg::X15, offset as i64);
-            self.emit_add_rr(Reg::X15, base, Reg::X15, false);
-            let inst = OPCODE_STR_UOFF | (Reg::X15.encoding() as u32) << 5 | rs.encoding() as u32;
+            self.emit_mov_imm(SCRATCH_ADDRESS, offset as i64);
+            self.emit_add_rr(SCRATCH_ADDRESS, base, SCRATCH_ADDRESS, false);
+            let inst =
+                OPCODE_STR_UOFF | (SCRATCH_ADDRESS.encoding() as u32) << 5 | rs.encoding() as u32;
             self.emit_u32(inst);
         }
     }

--- a/crates/rue-codegen/src/aarch64/mir.rs
+++ b/crates/rue-codegen/src/aarch64/mir.rs
@@ -95,6 +95,108 @@ pub enum Reg {
     Xzr = 32,
 }
 
+// ============================================================================
+// Register roles
+// ============================================================================
+//
+// Several passes name physical registers directly — for ABI argument and
+// result positions, for the emitter's address materialization, and as
+// allocation rewrite scratch. Those uses must never overlap what the register
+// allocator hands out. Before RUE-1146 the separation held only because the
+// allocator drew from X19-X28 exclusively; `RESERVED_REGS` states the
+// constraint instead, and `aarch64::regalloc` proves at compile time that no
+// allocatable register is in it.
+
+/// Registers the allocator must never hand to a virtual register.
+///
+/// Each entry is reserved for one of four reasons:
+///
+/// * **ABI position.** `x0`-`x7` carry arguments and results, and `x8` is the
+///   indirect-result register AAPCS64 reserves (and the Linux syscall number
+///   register). CFG lowering writes and reads these as physical registers
+///   around every call and in the prologue; liveness models a call's
+///   *clobbers* but not those physical defs and uses, so the clobber test
+///   cannot make an ABI register safe.
+/// * **Rewrite scratch.** [`SCRATCH_VALUE`] and [`SCRATCH_SOURCE_A`] through
+///   [`SCRATCH_SOURCE_C`] hold reloaded spill values while an instruction is
+///   rewritten.
+/// * **Emitter scratch.** [`SCRATCH_ADDRESS`] materializes a load/store offset
+///   too large for the immediate field; the emitter asserts that neither the
+///   base nor the transferred register is that register.
+/// * **Platform role.** `x16`/`x17` are the linker's veneer scratch (IP0/IP1)
+///   and are also the macOS syscall number register, `x18` is the reserved
+///   platform register, and `x29`/`x30`/`sp`/`xzr` are the frame pointer, link
+///   register, stack pointer, and zero register.
+///
+/// `x13` and `x14` are the caller-saved registers with no role here, which is
+/// why they are the whole caller-saved allocatable class on this target.
+pub(crate) const RESERVED_REGS: &[Reg] = &[
+    Reg::X0,  // argument/result 0
+    Reg::X1,  // argument/result 1
+    Reg::X2,  // argument 2
+    Reg::X3,  // argument 3
+    Reg::X4,  // argument 4
+    Reg::X5,  // argument 5
+    Reg::X6,  // argument 6
+    Reg::X7,  // argument 7
+    Reg::X8,  // indirect result location; Linux syscall number
+    Reg::X9,  // SCRATCH_VALUE
+    Reg::X10, // SCRATCH_SOURCE_A
+    Reg::X11, // SCRATCH_SOURCE_B
+    Reg::X12, // SCRATCH_SOURCE_C
+    Reg::X15, // SCRATCH_ADDRESS
+    Reg::X16, // IP0 linker veneer scratch; macOS syscall number
+    Reg::X17, // IP1 linker veneer scratch
+    Reg::X18, // reserved platform register
+    Reg::Fp,  // frame pointer (x29)
+    Reg::Lr,  // link register (x30)
+    Reg::Sp,  // stack pointer
+    Reg::Xzr, // zero register
+];
+
+/// Scratch register for a rewritten instruction's value: the destination when
+/// it is spilled, and the sole source operand of a unary instruction.
+pub(crate) const SCRATCH_VALUE: Reg = Reg::X9;
+
+/// Scratch register for a rewritten instruction's first source operand.
+pub(crate) const SCRATCH_SOURCE_A: Reg = Reg::X10;
+
+/// Scratch register for a rewritten instruction's second source operand, kept
+/// distinct from [`SCRATCH_SOURCE_A`] so both can be reloaded at once.
+pub(crate) const SCRATCH_SOURCE_B: Reg = Reg::X11;
+
+/// Scratch register for a rewritten instruction's third source operand, needed
+/// by the four-operand multiply-accumulate forms.
+pub(crate) const SCRATCH_SOURCE_C: Reg = Reg::X12;
+
+/// The emitter's address scratch: an unscaled load or store offset that does
+/// not fit the immediate field is materialized here and added to the base.
+/// Distinct from every allocation scratch because emission happens after
+/// rewriting, with allocated values already live in registers.
+pub(crate) const SCRATCH_ADDRESS: Reg = Reg::X15;
+
+/// Whether the allocator is forbidden from handing out `reg`.
+pub(crate) const fn is_reserved(reg: Reg) -> bool {
+    let mut index = 0;
+    while index < RESERVED_REGS.len() {
+        if RESERVED_REGS[index] as u8 == reg as u8 {
+            return true;
+        }
+        index += 1;
+    }
+    false
+}
+
+// Every scratch register is reserved. Without this, moving a scratch role to a
+// different register would silently make it allocatable as well.
+const _: () = {
+    assert!(is_reserved(SCRATCH_VALUE));
+    assert!(is_reserved(SCRATCH_SOURCE_A));
+    assert!(is_reserved(SCRATCH_SOURCE_B));
+    assert!(is_reserved(SCRATCH_SOURCE_C));
+    assert!(is_reserved(SCRATCH_ADDRESS));
+};
+
 impl Reg {
     /// Get the register encoding for instruction fields (0-30 for X0-X30, 31 for SP/XZR).
     #[inline]
@@ -865,10 +967,27 @@ impl Aarch64Inst {
                 Reg::X17,
                 Reg::Lr,
             ],
-            // Syscall clobbers X0 (return value) and preserves most registers.
-            // On macOS, X16 contains syscall number; on Linux, X8 does.
-            // We conservatively clobber both to handle either target.
-            Aarch64Inst::Svc { .. } => &[Reg::X0, Reg::X8, Reg::X16],
+            // Syscall returns in X0. On macOS, X16 carries the syscall
+            // number; on Linux, X8 does — clobber both to cover either target.
+            // The caller-saved temporaries X9-X15 and X17 are listed too: the
+            // Linux arm64 syscall ABI preserves them, but Darwin's kernel
+            // boundary follows the ordinary procedure-call standard and is
+            // free to destroy them. That distinction only became observable
+            // when allocation started handing out X13/X14 (RUE-1146), so the
+            // set is stated conservatively rather than per-target.
+            Aarch64Inst::Svc { .. } => &[
+                Reg::X0,
+                Reg::X8,
+                Reg::X9,
+                Reg::X10,
+                Reg::X11,
+                Reg::X12,
+                Reg::X13,
+                Reg::X14,
+                Reg::X15,
+                Reg::X16,
+                Reg::X17,
+            ],
             // All other instructions don't clobber additional registers
             _ => &[],
         }

--- a/crates/rue-codegen/src/aarch64/regalloc.rs
+++ b/crates/rue-codegen/src/aarch64/regalloc.rs
@@ -13,30 +13,33 @@
 use rue_error::{CompileError, CompileResult, ErrorKind};
 
 use super::liveness;
+use super::mir;
 use super::mir::VReg;
-use super::mir::{Aarch64Inst, Aarch64Mir, Operand, Reg};
+use super::mir::{
+    Aarch64Inst, Aarch64Mir, Operand, Reg, SCRATCH_SOURCE_A, SCRATCH_SOURCE_B, SCRATCH_SOURCE_C,
+    SCRATCH_VALUE,
+};
 use crate::alloc_dst;
 use crate::regalloc::{
     Allocation, AllocationContext, CoalesceCandidate, LivenessInfo, LoopInfo, RegAllocBackend,
-    RegAllocDebugInfo, RegAllocDriver, RematerializeOp, RewriteBuffer,
+    RegAllocDebugInfo, RegAllocDriver, RegisterClasses, RematerializeOp, RewriteBuffer,
 };
 
-/// Available registers for allocation.
+/// Caller-saved registers offered to intervals no instruction clobbers while
+/// they are live — in particular, intervals that cross no call.
 ///
-/// We use callee-saved registers (X19-X28) for general allocation.
-/// This ensures values survive across function calls.
+/// AAPCS64 makes X9-X15 caller-saved temporaries. X9-X12 are this pass's own
+/// rewrite scratch and X15 is the emitter's address scratch, leaving X13 and
+/// X14. See [`mir::RESERVED_REGS`] for the per-register reasoning; the
+/// assertion below keeps the two in agreement.
+const CALLER_SAVED_REGS: &[Reg] = &[Reg::X13, Reg::X14];
+
+/// Callee-saved registers, the only home for a value that must survive a call.
 ///
-/// We avoid:
-/// - X0-X7: Argument/return registers
-/// - X8: Indirect result location
-/// - X9-X15: Caller-saved temporaries (X9-X12 are spill scratches; X15 is
-///   reserved as the emitter's large-offset address scratch — never allocate)
-/// - X16-X17: IP0, IP1 (linker scratch)
-/// - X18: Platform register (reserved on macOS)
-/// - X29 (FP): Frame pointer
-/// - X30 (LR): Link register
-/// - SP: Stack pointer
-const ALLOCATABLE_REGS: &[Reg] = &[
+/// Each one used obliges the prologue to save it and the epilogue to restore
+/// it, so allocation reaches for these only after the caller-saved class above
+/// is exhausted or ineligible.
+const CALLEE_SAVED_REGS: &[Reg] = &[
     Reg::X19,
     Reg::X20,
     Reg::X21,
@@ -48,6 +51,55 @@ const ALLOCATABLE_REGS: &[Reg] = &[
     Reg::X27,
     Reg::X28,
 ];
+
+/// Every allocatable register, in preference order: caller-saved first.
+///
+/// This is the flattening of [`CALLER_SAVED_REGS`] and [`CALLEE_SAVED_REGS`];
+/// [`register_classes`](Aarch64Backend::register_classes) is what allocation
+/// actually consults, and it keeps the two classes apart. When neither class
+/// has a register available, values are spilled to the stack.
+const ALLOCATABLE_REGS: &[Reg] = &[
+    Reg::X13,
+    Reg::X14,
+    Reg::X19,
+    Reg::X20,
+    Reg::X21,
+    Reg::X22,
+    Reg::X23,
+    Reg::X24,
+    Reg::X25,
+    Reg::X26,
+    Reg::X27,
+    Reg::X28,
+];
+
+// No allocatable register may carry a reserved role, and the flattened list
+// must stay the concatenation of the two classes.
+const _: () = {
+    let mut index = 0;
+    while index < ALLOCATABLE_REGS.len() {
+        assert!(
+            !mir::is_reserved(ALLOCATABLE_REGS[index]),
+            "an allocatable register must not also be reserved for an ABI \
+             position, rewrite scratch, or a platform role"
+        );
+        index += 1;
+    }
+    assert!(ALLOCATABLE_REGS.len() == CALLER_SAVED_REGS.len() + CALLEE_SAVED_REGS.len());
+    let mut index = 0;
+    while index < CALLER_SAVED_REGS.len() {
+        assert!(ALLOCATABLE_REGS[index] as u8 == CALLER_SAVED_REGS[index] as u8);
+        index += 1;
+    }
+    let mut index = 0;
+    while index < CALLEE_SAVED_REGS.len() {
+        assert!(
+            ALLOCATABLE_REGS[CALLER_SAVED_REGS.len() + index] as u8
+                == CALLEE_SAVED_REGS[index] as u8
+        );
+        index += 1;
+    }
+};
 
 /// Zero-sized adapter for target-specific analysis and instruction rewriting.
 struct Aarch64Backend;
@@ -112,13 +164,13 @@ impl RegAlloc {
     ) -> CompileResult<()> {
         match inst {
             Aarch64Inst::MovImm { dst, imm } => {
-                alloc_dst!(Self::get_allocation(context, dst), dst, Reg::X9 =>
+                alloc_dst!(Self::get_allocation(context, dst), dst, SCRATCH_VALUE =>
                     emit |dst_op| {
                         mir.push(Aarch64Inst::MovImm { dst: dst_op, imm });
                     },
                     store |offset| {
                         mir.push_after(Aarch64Inst::Str {
-                            src: Operand::Physical(Reg::X9),
+                            src: Operand::Physical(SCRATCH_VALUE),
                             base: Reg::Fp,
                             offset,
                         });
@@ -127,7 +179,7 @@ impl RegAlloc {
             }
 
             Aarch64Inst::MovRR { dst, src } => {
-                let src_op = Self::load_operand(context, mir, src, Reg::X9)?;
+                let src_op = Self::load_operand(context, mir, src, SCRATCH_VALUE)?;
                 let dst_alloc = Self::get_allocation(context, dst);
 
                 match dst_alloc {
@@ -138,14 +190,14 @@ impl RegAlloc {
                         });
                     }
                     Some(Allocation::Spill(offset)) => {
-                        if src_op != Operand::Physical(Reg::X9) {
+                        if src_op != Operand::Physical(SCRATCH_VALUE) {
                             mir.push(Aarch64Inst::MovRR {
-                                dst: Operand::Physical(Reg::X9),
+                                dst: Operand::Physical(SCRATCH_VALUE),
                                 src: src_op,
                             });
                         }
                         mir.push_after(Aarch64Inst::Str {
-                            src: Operand::Physical(Reg::X9),
+                            src: Operand::Physical(SCRATCH_VALUE),
                             base: Reg::Fp,
                             offset,
                         });
@@ -160,13 +212,13 @@ impl RegAlloc {
             }
 
             Aarch64Inst::Ldr { dst, base, offset } => {
-                alloc_dst!(Self::get_allocation(context, dst), dst, Reg::X9 =>
+                alloc_dst!(Self::get_allocation(context, dst), dst, SCRATCH_VALUE =>
                     emit |dst_op| {
                         mir.push(Aarch64Inst::Ldr { dst: dst_op, base, offset });
                     },
                     store |spill_offset| {
                         mir.push_after(Aarch64Inst::Str {
-                            src: Operand::Physical(Reg::X9),
+                            src: Operand::Physical(SCRATCH_VALUE),
                             base: Reg::Fp,
                             offset: spill_offset,
                         });
@@ -175,7 +227,7 @@ impl RegAlloc {
             }
 
             Aarch64Inst::Str { src, base, offset } => {
-                let src_op = Self::load_operand(context, mir, src, Reg::X9)?;
+                let src_op = Self::load_operand(context, mir, src, SCRATCH_VALUE)?;
                 mir.push(Aarch64Inst::Str {
                     src: src_op,
                     base,
@@ -373,10 +425,10 @@ impl RegAlloc {
             } => {
                 // Use X10, X11, X12 for sources to avoid conflict with X9 used for spilled dst.
                 // X9 is reserved for the destination when it's spilled.
-                let src1_op = Self::load_operand(context, mir, src1, Reg::X10)?;
-                let src2_op = Self::load_operand(context, mir, src2, Reg::X11)?;
-                let src3_op = Self::load_operand(context, mir, src3, Reg::X12)?;
-                alloc_dst!(Self::get_allocation(context, dst), dst, Reg::X9 =>
+                let src1_op = Self::load_operand(context, mir, src1, SCRATCH_SOURCE_A)?;
+                let src2_op = Self::load_operand(context, mir, src2, SCRATCH_SOURCE_B)?;
+                let src3_op = Self::load_operand(context, mir, src3, SCRATCH_SOURCE_C)?;
+                alloc_dst!(Self::get_allocation(context, dst), dst, SCRATCH_VALUE =>
                     emit |dst_op| {
                         mir.push(Aarch64Inst::Msub {
                             dst: dst_op,
@@ -387,7 +439,7 @@ impl RegAlloc {
                     },
                     store |offset| {
                         mir.push_after(Aarch64Inst::Str {
-                            src: Operand::Physical(Reg::X9),
+                            src: Operand::Physical(SCRATCH_VALUE),
                             base: Reg::Fp,
                             offset,
                         });
@@ -402,10 +454,10 @@ impl RegAlloc {
                 src3,
             } => {
                 // Use X10, X11, X12 for sources to avoid conflict with X9 used for spilled dst.
-                let src1_op = Self::load_operand(context, mir, src1, Reg::X10)?;
-                let src2_op = Self::load_operand(context, mir, src2, Reg::X11)?;
-                let src3_op = Self::load_operand(context, mir, src3, Reg::X12)?;
-                alloc_dst!(Self::get_allocation(context, dst), dst, Reg::X9 =>
+                let src1_op = Self::load_operand(context, mir, src1, SCRATCH_SOURCE_A)?;
+                let src2_op = Self::load_operand(context, mir, src2, SCRATCH_SOURCE_B)?;
+                let src3_op = Self::load_operand(context, mir, src3, SCRATCH_SOURCE_C)?;
+                alloc_dst!(Self::get_allocation(context, dst), dst, SCRATCH_VALUE =>
                     emit |dst_op| {
                         mir.push(Aarch64Inst::Msub64 {
                             dst: dst_op,
@@ -416,7 +468,7 @@ impl RegAlloc {
                     },
                     store |offset| {
                         mir.push_after(Aarch64Inst::Str {
-                            src: Operand::Physical(Reg::X9),
+                            src: Operand::Physical(SCRATCH_VALUE),
                             base: Reg::Fp,
                             offset,
                         });
@@ -476,14 +528,14 @@ impl RegAlloc {
             }
 
             Aarch64Inst::EorImm { dst, src, imm } => {
-                let src_op = Self::load_operand(context, mir, src, Reg::X10)?;
-                alloc_dst!(Self::get_allocation(context, dst), dst, Reg::X9 =>
+                let src_op = Self::load_operand(context, mir, src, SCRATCH_SOURCE_A)?;
+                alloc_dst!(Self::get_allocation(context, dst), dst, SCRATCH_VALUE =>
                     emit |dst_op| {
                         mir.push(Aarch64Inst::EorImm { dst: dst_op, src: src_op, imm });
                     },
                     store |offset| {
                         mir.push_after(Aarch64Inst::Str {
-                            src: Operand::Physical(Reg::X9),
+                            src: Operand::Physical(SCRATCH_VALUE),
                             base: Reg::Fp,
                             offset,
                         });
@@ -566,8 +618,8 @@ impl RegAlloc {
             }
 
             Aarch64Inst::CmpRR { src1, src2 } => {
-                let src1_op = Self::load_operand(context, mir, src1, Reg::X9)?;
-                let src2_op = Self::load_operand(context, mir, src2, Reg::X10)?;
+                let src1_op = Self::load_operand(context, mir, src1, SCRATCH_VALUE)?;
+                let src2_op = Self::load_operand(context, mir, src2, SCRATCH_SOURCE_A)?;
                 mir.push(Aarch64Inst::CmpRR {
                     src1: src1_op,
                     src2: src2_op,
@@ -575,8 +627,8 @@ impl RegAlloc {
             }
 
             Aarch64Inst::Cmp64RR { src1, src2 } => {
-                let src1_op = Self::load_operand(context, mir, src1, Reg::X9)?;
-                let src2_op = Self::load_operand(context, mir, src2, Reg::X10)?;
+                let src1_op = Self::load_operand(context, mir, src1, SCRATCH_VALUE)?;
+                let src2_op = Self::load_operand(context, mir, src2, SCRATCH_SOURCE_A)?;
                 mir.push(Aarch64Inst::Cmp64RR {
                     src1: src1_op,
                     src2: src2_op,
@@ -584,28 +636,28 @@ impl RegAlloc {
             }
 
             Aarch64Inst::CmpImm { src, imm } => {
-                let src_op = Self::load_operand(context, mir, src, Reg::X9)?;
+                let src_op = Self::load_operand(context, mir, src, SCRATCH_VALUE)?;
                 mir.push(Aarch64Inst::CmpImm { src: src_op, imm });
             }
 
             Aarch64Inst::Cbz { src, label } => {
-                let src_op = Self::load_operand(context, mir, src, Reg::X9)?;
+                let src_op = Self::load_operand(context, mir, src, SCRATCH_VALUE)?;
                 mir.push(Aarch64Inst::Cbz { src: src_op, label });
             }
 
             Aarch64Inst::Cbnz { src, label } => {
-                let src_op = Self::load_operand(context, mir, src, Reg::X9)?;
+                let src_op = Self::load_operand(context, mir, src, SCRATCH_VALUE)?;
                 mir.push(Aarch64Inst::Cbnz { src: src_op, label });
             }
 
             Aarch64Inst::Cset { dst, cond } => {
-                alloc_dst!(Self::get_allocation(context, dst), dst, Reg::X9 =>
+                alloc_dst!(Self::get_allocation(context, dst), dst, SCRATCH_VALUE =>
                     emit |dst_op| {
                         mir.push(Aarch64Inst::Cset { dst: dst_op, cond });
                     },
                     store |offset| {
                         mir.push_after(Aarch64Inst::Str {
-                            src: Operand::Physical(Reg::X9),
+                            src: Operand::Physical(SCRATCH_VALUE),
                             base: Reg::Fp,
                             offset,
                         });
@@ -614,8 +666,8 @@ impl RegAlloc {
             }
 
             Aarch64Inst::TstRR { src1, src2 } => {
-                let src1_op = Self::load_operand(context, mir, src1, Reg::X9)?;
-                let src2_op = Self::load_operand(context, mir, src2, Reg::X10)?;
+                let src1_op = Self::load_operand(context, mir, src1, SCRATCH_VALUE)?;
+                let src2_op = Self::load_operand(context, mir, src2, SCRATCH_SOURCE_A)?;
                 mir.push(Aarch64Inst::TstRR {
                     src1: src1_op,
                     src2: src2_op,
@@ -658,8 +710,8 @@ impl RegAlloc {
             }
 
             Aarch64Inst::StpPre { src1, src2, offset } => {
-                let src1_op = Self::load_operand(context, mir, src1, Reg::X9)?;
-                let src2_op = Self::load_operand(context, mir, src2, Reg::X10)?;
+                let src1_op = Self::load_operand(context, mir, src1, SCRATCH_VALUE)?;
+                let src2_op = Self::load_operand(context, mir, src2, SCRATCH_SOURCE_A)?;
                 mir.push(Aarch64Inst::StpPre {
                     src1: src1_op,
                     src2: src2_op,
@@ -671,7 +723,7 @@ impl RegAlloc {
                 // LDP only defines, doesn't read vregs
                 let dst1_phys = match Self::get_allocation(context, dst1) {
                     Some(Allocation::Register(reg)) => Operand::Physical(reg),
-                    Some(Allocation::Spill(_)) => Operand::Physical(Reg::X9),
+                    Some(Allocation::Spill(_)) => Operand::Physical(SCRATCH_VALUE),
                     Some(Allocation::Rematerialize(_)) => {
                         unreachable!("destination cannot be rematerializable")
                     }
@@ -679,7 +731,7 @@ impl RegAlloc {
                 };
                 let dst2_phys = match Self::get_allocation(context, dst2) {
                     Some(Allocation::Register(reg)) => Operand::Physical(reg),
-                    Some(Allocation::Spill(_)) => Operand::Physical(Reg::X10),
+                    Some(Allocation::Spill(_)) => Operand::Physical(SCRATCH_SOURCE_A),
                     Some(Allocation::Rematerialize(_)) => {
                         unreachable!("destination cannot be rematerializable")
                     }
@@ -693,14 +745,14 @@ impl RegAlloc {
                 // Handle spills
                 if let Some(Allocation::Spill(off)) = Self::get_allocation(context, dst1) {
                     mir.push_after(Aarch64Inst::Str {
-                        src: Operand::Physical(Reg::X9),
+                        src: Operand::Physical(SCRATCH_VALUE),
                         base: Reg::Fp,
                         offset: off,
                     });
                 }
                 if let Some(Allocation::Spill(off)) = Self::get_allocation(context, dst2) {
                     mir.push_after(Aarch64Inst::Str {
-                        src: Operand::Physical(Reg::X10),
+                        src: Operand::Physical(SCRATCH_SOURCE_A),
                         base: Reg::Fp,
                         offset: off,
                     });
@@ -710,10 +762,10 @@ impl RegAlloc {
             Aarch64Inst::LdrIndexed { dst, base } => {
                 // Load base vreg into scratch, then emit load with the result allocation
                 let base_op = Operand::Virtual(base);
-                let base_reg = Self::load_operand(context, mir, base_op, Reg::X9)?;
+                let base_reg = Self::load_operand(context, mir, base_op, SCRATCH_VALUE)?;
                 let base_phys = match base_reg {
                     Operand::Physical(r) => r,
-                    _ => Reg::X9,
+                    _ => SCRATCH_VALUE,
                 };
 
                 match Self::get_allocation(context, dst) {
@@ -726,12 +778,12 @@ impl RegAlloc {
                     }
                     Some(Allocation::Spill(offset)) => {
                         mir.push(Aarch64Inst::Ldr {
-                            dst: Operand::Physical(Reg::X10),
+                            dst: Operand::Physical(SCRATCH_SOURCE_A),
                             base: base_phys,
                             offset: 0,
                         });
                         mir.push_after(Aarch64Inst::Str {
-                            src: Operand::Physical(Reg::X10),
+                            src: Operand::Physical(SCRATCH_SOURCE_A),
                             base: Reg::Fp,
                             offset,
                         });
@@ -750,12 +802,12 @@ impl RegAlloc {
             }
 
             Aarch64Inst::StrIndexed { src, base } => {
-                let src_op = Self::load_operand(context, mir, src, Reg::X9)?;
+                let src_op = Self::load_operand(context, mir, src, SCRATCH_VALUE)?;
                 let base_vreg_op = Operand::Virtual(base);
-                let base_reg = Self::load_operand(context, mir, base_vreg_op, Reg::X10)?;
+                let base_reg = Self::load_operand(context, mir, base_vreg_op, SCRATCH_SOURCE_A)?;
                 let base_phys = match base_reg {
                     Operand::Physical(r) => r,
-                    _ => Reg::X10,
+                    _ => SCRATCH_SOURCE_A,
                 };
                 mir.push(Aarch64Inst::Str {
                     src: src_op,
@@ -771,7 +823,8 @@ impl RegAlloc {
                 width,
                 signed,
             } => {
-                let base_reg = Self::load_operand(context, mir, Operand::Virtual(base), Reg::X9)?;
+                let base_reg =
+                    Self::load_operand(context, mir, Operand::Virtual(base), SCRATCH_VALUE)?;
                 let base_phys = base_reg.as_physical();
                 match Self::get_allocation(context, dst) {
                     Some(Allocation::Register(reg)) => mir.push(Aarch64Inst::NarrowLoad {
@@ -783,14 +836,14 @@ impl RegAlloc {
                     }),
                     Some(Allocation::Spill(offset)) => {
                         mir.push(Aarch64Inst::NarrowLoad {
-                            dst: Operand::Physical(Reg::X10),
+                            dst: Operand::Physical(SCRATCH_SOURCE_A),
                             base: base_phys,
                             offset: addr_offset,
                             width,
                             signed,
                         });
                         mir.push_after(Aarch64Inst::Str {
-                            src: Operand::Physical(Reg::X10),
+                            src: Operand::Physical(SCRATCH_SOURCE_A),
                             base: Reg::Fp,
                             offset,
                         });
@@ -814,8 +867,9 @@ impl RegAlloc {
                 offset,
                 width,
             } => {
-                let src_op = Self::load_operand(context, mir, src, Reg::X9)?;
-                let base_reg = Self::load_operand(context, mir, Operand::Virtual(base), Reg::X10)?;
+                let src_op = Self::load_operand(context, mir, src, SCRATCH_VALUE)?;
+                let base_reg =
+                    Self::load_operand(context, mir, Operand::Virtual(base), SCRATCH_SOURCE_A)?;
                 mir.push(Aarch64Inst::NarrowStore {
                     src: src_op,
                     base: base_reg.as_physical(),
@@ -827,10 +881,10 @@ impl RegAlloc {
             Aarch64Inst::LdrIndexedOffset { dst, base, offset } => {
                 // Load base vreg into scratch, then emit load with offset
                 let base_op = Operand::Virtual(base);
-                let base_reg = Self::load_operand(context, mir, base_op, Reg::X9)?;
+                let base_reg = Self::load_operand(context, mir, base_op, SCRATCH_VALUE)?;
                 let base_phys = match base_reg {
                     Operand::Physical(r) => r,
-                    _ => Reg::X9,
+                    _ => SCRATCH_VALUE,
                 };
 
                 match Self::get_allocation(context, dst) {
@@ -843,12 +897,12 @@ impl RegAlloc {
                     }
                     Some(Allocation::Spill(spill_offset)) => {
                         mir.push(Aarch64Inst::Ldr {
-                            dst: Operand::Physical(Reg::X10),
+                            dst: Operand::Physical(SCRATCH_SOURCE_A),
                             base: base_phys,
                             offset,
                         });
                         mir.push_after(Aarch64Inst::Str {
-                            src: Operand::Physical(Reg::X10),
+                            src: Operand::Physical(SCRATCH_SOURCE_A),
                             base: Reg::Fp,
                             offset: spill_offset,
                         });
@@ -867,12 +921,12 @@ impl RegAlloc {
             }
 
             Aarch64Inst::StrIndexedOffset { src, base, offset } => {
-                let src_op = Self::load_operand(context, mir, src, Reg::X9)?;
+                let src_op = Self::load_operand(context, mir, src, SCRATCH_VALUE)?;
                 let base_vreg_op = Operand::Virtual(base);
-                let base_reg = Self::load_operand(context, mir, base_vreg_op, Reg::X10)?;
+                let base_reg = Self::load_operand(context, mir, base_vreg_op, SCRATCH_SOURCE_A)?;
                 let base_phys = match base_reg {
                     Operand::Physical(r) => r,
-                    _ => Reg::X10,
+                    _ => SCRATCH_SOURCE_A,
                 };
                 mir.push(Aarch64Inst::Str {
                     src: src_op,
@@ -882,14 +936,14 @@ impl RegAlloc {
             }
 
             Aarch64Inst::LslImm { dst, src, imm } => {
-                let src_op = Self::load_operand(context, mir, src, Reg::X10)?;
-                alloc_dst!(Self::get_allocation(context, dst), dst, Reg::X9 =>
+                let src_op = Self::load_operand(context, mir, src, SCRATCH_SOURCE_A)?;
+                alloc_dst!(Self::get_allocation(context, dst), dst, SCRATCH_VALUE =>
                     emit |dst_op| {
                         mir.push(Aarch64Inst::LslImm { dst: dst_op, src: src_op, imm });
                     },
                     store |offset| {
                         mir.push_after(Aarch64Inst::Str {
-                            src: Operand::Physical(Reg::X9),
+                            src: Operand::Physical(SCRATCH_VALUE),
                             base: Reg::Fp,
                             offset,
                         });
@@ -898,14 +952,14 @@ impl RegAlloc {
             }
 
             Aarch64Inst::Lsl32Imm { dst, src, imm } => {
-                let src_op = Self::load_operand(context, mir, src, Reg::X10)?;
-                alloc_dst!(Self::get_allocation(context, dst), dst, Reg::X9 =>
+                let src_op = Self::load_operand(context, mir, src, SCRATCH_SOURCE_A)?;
+                alloc_dst!(Self::get_allocation(context, dst), dst, SCRATCH_VALUE =>
                     emit |dst_op| {
                         mir.push(Aarch64Inst::Lsl32Imm { dst: dst_op, src: src_op, imm });
                     },
                     store |offset| {
                         mir.push_after(Aarch64Inst::Str {
-                            src: Operand::Physical(Reg::X9),
+                            src: Operand::Physical(SCRATCH_VALUE),
                             base: Reg::Fp,
                             offset,
                         });
@@ -914,14 +968,14 @@ impl RegAlloc {
             }
 
             Aarch64Inst::Lsr32Imm { dst, src, imm } => {
-                let src_op = Self::load_operand(context, mir, src, Reg::X10)?;
-                alloc_dst!(Self::get_allocation(context, dst), dst, Reg::X9 =>
+                let src_op = Self::load_operand(context, mir, src, SCRATCH_SOURCE_A)?;
+                alloc_dst!(Self::get_allocation(context, dst), dst, SCRATCH_VALUE =>
                     emit |dst_op| {
                         mir.push(Aarch64Inst::Lsr32Imm { dst: dst_op, src: src_op, imm });
                     },
                     store |offset| {
                         mir.push_after(Aarch64Inst::Str {
-                            src: Operand::Physical(Reg::X9),
+                            src: Operand::Physical(SCRATCH_VALUE),
                             base: Reg::Fp,
                             offset,
                         });
@@ -930,14 +984,14 @@ impl RegAlloc {
             }
 
             Aarch64Inst::Asr32Imm { dst, src, imm } => {
-                let src_op = Self::load_operand(context, mir, src, Reg::X10)?;
-                alloc_dst!(Self::get_allocation(context, dst), dst, Reg::X9 =>
+                let src_op = Self::load_operand(context, mir, src, SCRATCH_SOURCE_A)?;
+                alloc_dst!(Self::get_allocation(context, dst), dst, SCRATCH_VALUE =>
                     emit |dst_op| {
                         mir.push(Aarch64Inst::Asr32Imm { dst: dst_op, src: src_op, imm });
                     },
                     store |offset| {
                         mir.push_after(Aarch64Inst::Str {
-                            src: Operand::Physical(Reg::X9),
+                            src: Operand::Physical(SCRATCH_VALUE),
                             base: Reg::Fp,
                             offset,
                         });
@@ -946,13 +1000,13 @@ impl RegAlloc {
             }
 
             Aarch64Inst::StringConstPtr { dst, string_id } => {
-                alloc_dst!(Self::get_allocation(context, dst), dst, Reg::X9 =>
+                alloc_dst!(Self::get_allocation(context, dst), dst, SCRATCH_VALUE =>
                     emit |dst_op| {
                         mir.push(Aarch64Inst::StringConstPtr { dst: dst_op, string_id });
                     },
                     store |offset| {
                         mir.push_after(Aarch64Inst::Str {
-                            src: Operand::Physical(Reg::X9),
+                            src: Operand::Physical(SCRATCH_VALUE),
                             base: Reg::Fp,
                             offset,
                         });
@@ -961,13 +1015,13 @@ impl RegAlloc {
             }
 
             Aarch64Inst::StringConstLen { dst, string_id } => {
-                alloc_dst!(Self::get_allocation(context, dst), dst, Reg::X9 =>
+                alloc_dst!(Self::get_allocation(context, dst), dst, SCRATCH_VALUE =>
                     emit |dst_op| {
                         mir.push(Aarch64Inst::StringConstLen { dst: dst_op, string_id });
                     },
                     store |offset| {
                         mir.push_after(Aarch64Inst::Str {
-                            src: Operand::Physical(Reg::X9),
+                            src: Operand::Physical(SCRATCH_VALUE),
                             base: Reg::Fp,
                             offset,
                         });
@@ -976,13 +1030,13 @@ impl RegAlloc {
             }
 
             Aarch64Inst::StringConstCap { dst, string_id } => {
-                alloc_dst!(Self::get_allocation(context, dst), dst, Reg::X9 =>
+                alloc_dst!(Self::get_allocation(context, dst), dst, SCRATCH_VALUE =>
                     emit |dst_op| {
                         mir.push(Aarch64Inst::StringConstCap { dst: dst_op, string_id });
                     },
                     store |offset| {
                         mir.push_after(Aarch64Inst::Str {
-                            src: Operand::Physical(Reg::X9),
+                            src: Operand::Physical(SCRATCH_VALUE),
                             base: Reg::Fp,
                             offset,
                         });
@@ -1124,15 +1178,15 @@ impl RegAlloc {
     where
         F: FnOnce(Operand, Operand) -> Aarch64Inst,
     {
-        let src_op = Self::load_operand(context, mir, src, Reg::X10)?;
+        let src_op = Self::load_operand(context, mir, src, SCRATCH_SOURCE_A)?;
         match Self::get_allocation(context, dst) {
             Some(Allocation::Register(reg)) => {
                 mir.push(make_inst(Operand::Physical(reg), src_op));
             }
             Some(Allocation::Spill(offset)) => {
-                mir.push(make_inst(Operand::Physical(Reg::X9), src_op));
+                mir.push(make_inst(Operand::Physical(SCRATCH_VALUE), src_op));
                 mir.push_after(Aarch64Inst::Str {
-                    src: Operand::Physical(Reg::X9),
+                    src: Operand::Physical(SCRATCH_VALUE),
                     base: Reg::Fp,
                     offset,
                 });
@@ -1158,16 +1212,20 @@ impl RegAlloc {
     where
         F: FnOnce(Operand, Operand, Operand) -> Aarch64Inst,
     {
-        let src1_op = Self::load_operand(context, mir, src1, Reg::X10)?;
-        let src2_op = Self::load_operand(context, mir, src2, Reg::X11)?;
+        let src1_op = Self::load_operand(context, mir, src1, SCRATCH_SOURCE_A)?;
+        let src2_op = Self::load_operand(context, mir, src2, SCRATCH_SOURCE_B)?;
         match Self::get_allocation(context, dst) {
             Some(Allocation::Register(reg)) => {
                 mir.push(make_inst(Operand::Physical(reg), src1_op, src2_op));
             }
             Some(Allocation::Spill(offset)) => {
-                mir.push(make_inst(Operand::Physical(Reg::X9), src1_op, src2_op));
+                mir.push(make_inst(
+                    Operand::Physical(SCRATCH_VALUE),
+                    src1_op,
+                    src2_op,
+                ));
                 mir.push_after(Aarch64Inst::Str {
-                    src: Operand::Physical(Reg::X9),
+                    src: Operand::Physical(SCRATCH_VALUE),
                     base: Reg::Fp,
                     offset,
                 });
@@ -1193,15 +1251,15 @@ impl RegAlloc {
     where
         F: FnOnce(Operand, Operand, i32) -> Aarch64Inst,
     {
-        let src_op = Self::load_operand(context, mir, src, Reg::X10)?;
+        let src_op = Self::load_operand(context, mir, src, SCRATCH_SOURCE_A)?;
         match Self::get_allocation(context, dst) {
             Some(Allocation::Register(reg)) => {
                 mir.push(make_inst(Operand::Physical(reg), src_op, imm));
             }
             Some(Allocation::Spill(offset)) => {
-                mir.push(make_inst(Operand::Physical(Reg::X9), src_op, imm));
+                mir.push(make_inst(Operand::Physical(SCRATCH_VALUE), src_op, imm));
                 mir.push_after(Aarch64Inst::Str {
-                    src: Operand::Physical(Reg::X9),
+                    src: Operand::Physical(SCRATCH_VALUE),
                     base: Reg::Fp,
                     offset,
                 });
@@ -1288,8 +1346,11 @@ impl RegAllocBackend for Aarch64Backend {
             .collect()
     }
 
-    fn allocatable_regs() -> &'static [Self::Reg] {
-        ALLOCATABLE_REGS
+    fn register_classes() -> RegisterClasses<'static, Self::Reg> {
+        RegisterClasses {
+            caller_saved: CALLER_SAVED_REGS,
+            callee_saved: CALLEE_SAVED_REGS,
+        }
     }
 
     fn new_mir() -> Self::Mir {
@@ -1324,7 +1385,10 @@ impl RegAllocBackend for Aarch64Backend {
 #[cfg(test)]
 mod tests {
     use super::liveness;
-    use super::{ALLOCATABLE_REGS, Aarch64Inst, Aarch64Mir, Operand, Reg, RegAlloc, VReg};
+    use super::{
+        ALLOCATABLE_REGS, Aarch64Inst, Aarch64Mir, CALLEE_SAVED_REGS, CALLER_SAVED_REGS, Operand,
+        Reg, RegAlloc, VReg,
+    };
     use crate::regalloc::{Allocation, RematerializeOp};
 
     fn define_loaded_values(mir: &mut Aarch64Mir, vregs: &[VReg]) {
@@ -1349,9 +1413,11 @@ mod tests {
 
         let mir = RegAlloc::new(mir, 0).allocate().unwrap();
 
+        // v0 should be allocated to the first allocatable register, which is
+        // caller-saved: nothing clobbers it while v0 is live (RUE-1146).
         match &mir.instructions()[0] {
             Aarch64Inst::MovImm { dst, imm } => {
-                assert_eq!(dst, &Operand::Physical(Reg::X19));
+                assert_eq!(dst, &Operand::Physical(ALLOCATABLE_REGS[0]));
                 assert_eq!(*imm, 42);
             }
             _ => panic!("expected MovImm"),
@@ -1473,8 +1539,10 @@ mod tests {
         // Test that spilling works correctly when we run out of registers
         let mut mir = Aarch64Mir::new();
 
-        // Create more vregs than available registers (10 allocatable)
-        let vregs: Vec<VReg> = (0..15).map(|_| mir.alloc_vreg()).collect();
+        // Five more simultaneously-live values than there are registers
+        let vregs: Vec<VReg> = (0..ALLOCATABLE_REGS.len() + 5)
+            .map(|_| mir.alloc_vreg())
+            .collect();
 
         // Define all vregs
         define_loaded_values(&mut mir, &vregs);
@@ -1526,8 +1594,10 @@ mod tests {
         // Force a spill and verify load/store instructions are inserted
         let mut mir = Aarch64Mir::new();
 
-        // Create 11 vregs to force spilling (10 allocatable regs: X19-X28)
-        let vregs: Vec<VReg> = (0..11).map(|_| mir.alloc_vreg()).collect();
+        // One more simultaneously-live value than there are registers
+        let vregs: Vec<VReg> = (0..ALLOCATABLE_REGS.len() + 1)
+            .map(|_| mir.alloc_vreg())
+            .collect();
 
         define_loaded_values(&mut mir, &vregs);
 
@@ -1583,20 +1653,23 @@ mod tests {
     #[test]
     fn test_production_rematerializes_constants_and_strings_without_spills() {
         let mut mir = Aarch64Mir::new();
-        let vregs: Vec<VReg> = (0..12).map(|_| mir.alloc_vreg()).collect();
+        // Two more simultaneously-live values than there are registers, so the
+        // callee-saved-only baseline below has to spill exactly twice.
+        let count = ALLOCATABLE_REGS.len() + 2;
+        let vregs: Vec<VReg> = (0..count).map(|_| mir.alloc_vreg()).collect();
 
-        for (index, &vreg) in vregs[..10].iter().enumerate() {
+        for (index, &vreg) in vregs[..count - 2].iter().enumerate() {
             mir.push(Aarch64Inst::MovImm {
                 dst: Operand::Virtual(vreg),
                 imm: index as i64,
             });
         }
         mir.push(Aarch64Inst::StringConstPtr {
-            dst: Operand::Virtual(vregs[10]),
+            dst: Operand::Virtual(vregs[count - 2]),
             string_id: 7,
         });
         mir.push(Aarch64Inst::MovImm {
-            dst: Operand::Virtual(vregs[11]),
+            dst: Operand::Virtual(vregs[count - 1]),
             imm: 99,
         });
         for &vreg in &vregs {
@@ -1771,6 +1844,139 @@ mod tests {
     }
 
     #[test]
+    fn caller_saved_registers_absorb_pressure_before_spilling() {
+        // A call-free function with more simultaneously-live values than there
+        // are callee-saved registers still fits in registers, because the
+        // caller-saved class is available to it (RUE-1146).
+        let mut mir = Aarch64Mir::new();
+        let vregs: Vec<VReg> = (0..ALLOCATABLE_REGS.len())
+            .map(|_| mir.alloc_vreg())
+            .collect();
+
+        define_loaded_values(&mut mir, &vregs);
+        for &vreg in &vregs {
+            mir.push(Aarch64Inst::MovRR {
+                dst: Operand::Physical(Reg::X0),
+                src: Operand::Virtual(vreg),
+            });
+        }
+
+        assert!(
+            vregs.len() > CALLEE_SAVED_REGS.len(),
+            "the fixture must exceed what the callee-saved class alone can hold"
+        );
+
+        let (mir, num_spills, used_callee_saved) =
+            RegAlloc::new(mir, 0).allocate_with_spills().unwrap();
+
+        assert_eq!(num_spills, 0, "every value should fit in a register");
+        assert!(
+            !mir.instructions().iter().any(|inst| matches!(
+                inst,
+                Aarch64Inst::Str { base: Reg::Fp, .. } | Aarch64Inst::Ldr { base: Reg::Fp, .. }
+            )),
+            "no value should touch the frame"
+        );
+
+        let assigned: Vec<Reg> = mir
+            .instructions()
+            .iter()
+            .filter_map(|inst| match inst {
+                Aarch64Inst::Ldr {
+                    dst: Operand::Physical(reg),
+                    base: Reg::X1,
+                    ..
+                } => Some(*reg),
+                _ => None,
+            })
+            .collect();
+        for &reg in CALLER_SAVED_REGS {
+            assert!(
+                assigned.contains(&reg),
+                "the caller-saved class should be used before spilling, missing {reg}"
+            );
+        }
+        for &reg in &used_callee_saved {
+            assert!(
+                CALLEE_SAVED_REGS.contains(&reg),
+                "only callee-saved registers oblige the prologue, got {reg}"
+            );
+        }
+    }
+
+    #[test]
+    fn call_free_function_saves_no_callee_saved_registers() {
+        // With the caller-saved class available, a small call-free function
+        // needs nothing preserved across its own body, so frame planning sees
+        // an empty callee-saved set (RUE-1146, and the reason RUE-1195 had to
+        // land first).
+        let mut mir = Aarch64Mir::new();
+        let vregs: Vec<VReg> = (0..CALLER_SAVED_REGS.len())
+            .map(|_| mir.alloc_vreg())
+            .collect();
+
+        define_loaded_values(&mut mir, &vregs);
+        for &vreg in &vregs {
+            mir.push(Aarch64Inst::MovRR {
+                dst: Operand::Physical(Reg::X0),
+                src: Operand::Virtual(vreg),
+            });
+        }
+
+        let (_, num_spills, used_callee_saved) =
+            RegAlloc::new(mir, 0).allocate_with_spills().unwrap();
+
+        assert_eq!(num_spills, 0);
+        assert!(
+            used_callee_saved.is_empty(),
+            "a call-free function this small should save nothing, got {used_callee_saved:?}"
+        );
+    }
+
+    #[test]
+    fn cross_call_values_never_take_a_caller_saved_register() {
+        // Every value here is defined before a call and used after it, so none
+        // may live in a caller-saved register — the call destroys them all.
+        let mut mir = Aarch64Mir::new();
+        let symbol = mir.intern_symbol("callee");
+        let vregs: Vec<VReg> = (0..ALLOCATABLE_REGS.len())
+            .map(|_| mir.alloc_vreg())
+            .collect();
+
+        define_loaded_values(&mut mir, &vregs);
+        mir.push(Aarch64Inst::Bl { symbol_id: symbol });
+        for &vreg in &vregs {
+            mir.push(Aarch64Inst::MovRR {
+                dst: Operand::Physical(Reg::X0),
+                src: Operand::Virtual(vreg),
+            });
+        }
+
+        let (mir, num_spills, used_callee_saved) =
+            RegAlloc::new(mir, 0).allocate_with_spills().unwrap();
+
+        // The values that exceed the callee-saved class spill rather than
+        // borrowing a caller-saved register.
+        assert_eq!(num_spills as usize, CALLER_SAVED_REGS.len());
+        for &reg in &used_callee_saved {
+            assert!(CALLEE_SAVED_REGS.contains(&reg));
+        }
+        for inst in mir.instructions() {
+            if let Aarch64Inst::Ldr {
+                dst: Operand::Physical(reg),
+                base: Reg::X1,
+                ..
+            } = inst
+            {
+                assert!(
+                    !CALLER_SAVED_REGS.contains(reg),
+                    "a value live across a call must not be in caller-saved {reg}"
+                );
+            }
+        }
+    }
+
+    #[test]
     fn test_call_survival_and_symbol_reconstruction() {
         let mut mir = Aarch64Mir::new();
         let value = mir.alloc_vreg();
@@ -1818,7 +2024,9 @@ mod tests {
     #[test]
     fn test_loop_pressure_uses_loop_aware_spilling() {
         let mut mir = Aarch64Mir::new();
-        let vregs: Vec<VReg> = (0..11).map(|_| mir.alloc_vreg()).collect();
+        let vregs: Vec<VReg> = (0..ALLOCATABLE_REGS.len() + 1)
+            .map(|_| mir.alloc_vreg())
+            .collect();
         let loop_label = mir.alloc_label();
 
         define_loaded_values(&mut mir, &vregs);
@@ -1840,8 +2048,10 @@ mod tests {
         }
 
         let loop_info = liveness::analyze_loops(&mir);
+        // The loop body starts one instruction past the label, which the
+        // per-value loads above precede.
         assert!(
-            loop_info.depth(12) > 0,
+            loop_info.depth(vregs.len() + 1) > 0,
             "loop body should have nonzero depth"
         );
 
@@ -1894,8 +2104,10 @@ mod tests {
         // Force multiple spills and verify they get unique stack offsets
         let mut mir = Aarch64Mir::new();
 
-        // Create 15 vregs to force 5 spills (10 allocatable regs)
-        let vregs: Vec<VReg> = (0..15).map(|_| mir.alloc_vreg()).collect();
+        // Five more simultaneously-live values than there are registers
+        let vregs: Vec<VReg> = (0..ALLOCATABLE_REGS.len() + 5)
+            .map(|_| mir.alloc_vreg())
+            .collect();
 
         define_loaded_values(&mut mir, &vregs);
 
@@ -1945,8 +2157,10 @@ mod tests {
         // Test that spills are placed after existing local variables
         let mut mir = Aarch64Mir::new();
 
-        // 11 vregs forces 1 spill
-        let vregs: Vec<VReg> = (0..11).map(|_| mir.alloc_vreg()).collect();
+        // One more simultaneously-live value than there are registers
+        let vregs: Vec<VReg> = (0..ALLOCATABLE_REGS.len() + 1)
+            .map(|_| mir.alloc_vreg())
+            .collect();
 
         define_loaded_values(&mut mir, &vregs);
         for vreg in &vregs {
@@ -1988,8 +2202,10 @@ mod tests {
         // Test a function with many virtual registers causing a large stack frame
         let mut mir = Aarch64Mir::new();
 
-        // Create 25 vregs (10 registers + 15 spills)
-        let vregs: Vec<VReg> = (0..25).map(|_| mir.alloc_vreg()).collect();
+        // Fifteen more simultaneously-live values than there are registers
+        let vregs: Vec<VReg> = (0..ALLOCATABLE_REGS.len() + 15)
+            .map(|_| mir.alloc_vreg())
+            .collect();
 
         define_loaded_values(&mut mir, &vregs);
 
@@ -2030,8 +2246,10 @@ mod tests {
         // Test spilling with many existing local variables
         let mut mir = Aarch64Mir::new();
 
-        // 11 vregs forces 1 spill
-        let vregs: Vec<VReg> = (0..11).map(|_| mir.alloc_vreg()).collect();
+        // One more simultaneously-live value than there are registers
+        let vregs: Vec<VReg> = (0..ALLOCATABLE_REGS.len() + 1)
+            .map(|_| mir.alloc_vreg())
+            .collect();
 
         define_loaded_values(&mut mir, &vregs);
         for vreg in &vregs {
@@ -2067,16 +2285,17 @@ mod tests {
         // Test that ternary operations work correctly when operands are spilled
         let mut mir = Aarch64Mir::new();
 
-        // Create enough vregs to force spilling
-        let vregs: Vec<VReg> = (0..13).map(|_| mir.alloc_vreg()).collect();
+        // Three more simultaneously-live values than there are registers
+        let count = ALLOCATABLE_REGS.len() + 3;
+        let vregs: Vec<VReg> = (0..count).map(|_| mir.alloc_vreg()).collect();
 
         define_loaded_values(&mut mir, &vregs);
 
         // Add using potentially spilled operands
         mir.push(Aarch64Inst::AddRR {
             dst: Operand::Virtual(vregs[0]),
-            src1: Operand::Virtual(vregs[11]),
-            src2: Operand::Virtual(vregs[12]),
+            src1: Operand::Virtual(vregs[count - 2]),
+            src2: Operand::Virtual(vregs[count - 1]),
         });
 
         // Use all to keep them live
@@ -2102,12 +2321,15 @@ mod tests {
     #[test]
     fn test_spilled_binary_destination_has_ordered_rewrite() {
         let mut mir = Aarch64Mir::new();
-        let vregs: Vec<VReg> = (0..12).map(|_| mir.alloc_vreg()).collect();
+        // The first value is never used again, so `count` must exceed the
+        // register count by two for the rest to outnumber the registers.
+        let count = ALLOCATABLE_REGS.len() + 2;
+        let vregs: Vec<VReg> = (0..count).map(|_| mir.alloc_vreg()).collect();
 
         define_loaded_values(&mut mir, &vregs);
         mir.push(Aarch64Inst::AddRR {
-            dst: Operand::Virtual(vregs[11]),
-            src1: Operand::Virtual(vregs[10]),
+            dst: Operand::Virtual(vregs[count - 1]),
+            src1: Operand::Virtual(vregs[count - 2]),
             src2: Operand::Virtual(vregs[0]),
         });
         for &vreg in &vregs[1..] {

--- a/crates/rue-codegen/src/lib.rs
+++ b/crates/rue-codegen/src/lib.rs
@@ -708,6 +708,30 @@ mod tests {
         (cfg_output.cfg.unwrap(), type_pool, interner)
     }
 
+    /// Assert that a `--emit regalloc` projection exercises the widened
+    /// caller-saved class (RUE-1146) and never reports one of its registers as
+    /// callee-saved.
+    ///
+    /// The projection covers every function in the fixture, so this pins both
+    /// halves of the policy on the real pipeline: `caller_saved` names the
+    /// first caller-saved candidate on the target, which allocation offers
+    /// before any callee-saved register, and no such register may reach frame
+    /// planning's save list.
+    fn assert_widened_allocation(regalloc: &str, caller_saved: &str) {
+        assert!(
+            regalloc.contains(&format!("-> {caller_saved}")),
+            "fixture must allocate the caller-saved register {caller_saved}"
+        );
+        for section in regalloc.split("Callee-saved registers used:").skip(1) {
+            let reported = section.lines().nth(1).unwrap_or_default();
+            assert!(
+                !reported.contains(caller_saved),
+                "{caller_saved} is caller-saved and must not reach the prologue \
+                 save list, found: {reported}"
+            );
+        }
+    }
+
     fn assert_same_machine_code(normal: &MachineCode, with_asm: &MachineCode) {
         assert_eq!(normal.code, with_asm.code);
         assert_eq!(normal.strings, with_asm.strings);
@@ -818,6 +842,7 @@ mod tests {
             !x86_regalloc.contains("Spills:\n  none"),
             "fixture must exercise x86 spills"
         );
+        assert_widened_allocation(&x86_regalloc, "r11");
         let x86_asm = x86_product.artifacts.asm.expect("x86 assembly projection");
         assert!(!x86_asm.is_empty());
         assert!(x86_asm.contains("jno "), "fixture must retain rel32 fixups");
@@ -851,6 +876,7 @@ mod tests {
                 !arm_regalloc.contains("Spills:\n  none"),
                 "fixture must exercise AArch64 spills"
             );
+            assert_widened_allocation(&arm_regalloc, "x13");
             let arm_asm = arm_product
                 .artifacts
                 .asm

--- a/crates/rue-codegen/src/regalloc.rs
+++ b/crates/rue-codegen/src/regalloc.rs
@@ -432,21 +432,125 @@ impl<Reg: Copy + Eq + std::hash::Hash> LivenessInfo<Reg> {
     pub fn clobbers_at(&self, inst_idx: usize) -> &[Reg] {
         &self.clobbers_at[inst_idx]
     }
+}
 
-    /// Check if a physical register is clobbered while a vreg is live.
+// ============================================================================
+// Clobber Index
+// ============================================================================
+
+/// Constant-time "is this register clobbered anywhere in this live range?".
+///
+/// Allocation asks that question once per candidate caller-saved register per
+/// interval: a caller-saved register is only a legal home for an interval that
+/// survives no clobber of it, and a call clobbers every caller-saved register
+/// (see each backend's `Inst::clobbers`). Answering it by scanning
+/// [`LivenessInfo::clobbers_at`] across the range costs O(range) per question,
+/// which is quadratic on a function that keeps many values live over a long
+/// span — the shape that made allocation quadratic in RUE-302.
+///
+/// So this precomputes, for each tracked register, a prefix count of the
+/// instructions that clobber it. A range is clobber-free exactly when the
+/// counts at its two endpoints agree. Building the index is O(tracked ×
+/// instructions) once per function; each query is O(tracked) lookup plus two
+/// array reads.
+pub struct ClobberIndex<Reg> {
+    /// One entry per tracked register: the register, and prefix counts where
+    /// `counts[i]` is the number of instructions before `i` that clobber it.
+    /// The count slice has `instruction_count + 1` entries.
+    tracked: Vec<(Reg, Vec<u32>)>,
+}
+
+impl<Reg: Copy + Eq> ClobberIndex<Reg> {
+    /// Build an index over `liveness`'s clobber data for `tracked`.
     ///
-    /// Returns true if `reg` is clobbered by any instruction during the live range of `vreg`.
-    /// This is used to prevent allocating a vreg to a register that would be clobbered
-    /// before the vreg's last use.
-    pub fn is_clobbered_during(&self, vreg: VReg, reg: Reg) -> bool {
-        if let Some(range) = self.range(vreg) {
-            for idx in range.start..=range.end {
-                if idx < self.clobbers_at.len() && self.clobbers_at[idx].contains(&reg) {
-                    return true;
+    /// Only the tracked registers get an answer; see [`Self::is_clobbered_during`].
+    pub fn build(liveness: &LivenessInfo<Reg>, tracked: &[Reg]) -> Self
+    where
+        Reg: std::hash::Hash,
+    {
+        let num_insts = liveness.clobbers_at.len();
+        let tracked = tracked
+            .iter()
+            .map(|&reg| {
+                let mut counts = Vec::with_capacity(num_insts + 1);
+                let mut running = 0_u32;
+                counts.push(running);
+                for idx in 0..num_insts {
+                    if liveness.clobbers_at(idx).contains(&reg) {
+                        running += 1;
+                    }
+                    counts.push(running);
                 }
-            }
+                (reg, counts)
+            })
+            .collect();
+        Self { tracked }
+    }
+
+    /// Whether any instruction in `range` (endpoints included) clobbers `reg`.
+    ///
+    /// A register the index was not built for answers `true`: the index proves
+    /// the *absence* of clobbers only for the registers it tracks, and the safe
+    /// answer for anything else is that the register may be destroyed.
+    pub fn is_clobbered_during(&self, reg: Reg, range: &LiveRange) -> bool {
+        let Some((_, counts)) = self.tracked.iter().find(|(tracked, _)| *tracked == reg) else {
+            return true;
+        };
+        let last = counts.len() - 1;
+        let start = range.start.min(last);
+        let end = range.end.saturating_add(1).min(last);
+        counts[end] > counts[start]
+    }
+}
+
+// ============================================================================
+// Register Classes
+// ============================================================================
+
+/// The two register classes allocation distinguishes.
+///
+/// A caller-saved register costs nothing in the prologue but is destroyed by
+/// every call, so it is offered only to an interval that no instruction
+/// clobbers while it is live. A callee-saved register survives calls and is the
+/// only register home for an interval that spans one, at the price of a
+/// prologue save and epilogue restore.
+///
+/// Standard linear-scan practice is to prefer caller-saved registers for the
+/// intervals that can take them, which both leaves the callee-saved registers
+/// for the intervals that need them and shrinks the prologue.
+#[derive(Clone, Copy)]
+pub struct RegisterClasses<'a, Reg> {
+    /// Tried first, in order, for intervals with no clobber in range.
+    pub caller_saved: &'a [Reg],
+    /// Tried next, in order; saved by the prologue when used.
+    pub callee_saved: &'a [Reg],
+}
+
+impl<'a, Reg: Copy + Eq> RegisterClasses<'a, Reg> {
+    /// Classes for a caller that offers callee-saved registers only.
+    ///
+    /// This reproduces the pre-RUE-1146 policy exactly and is what the
+    /// standalone `linear_scan*` entry points below use.
+    pub fn callee_saved_only(regs: &'a [Reg]) -> Self {
+        Self {
+            caller_saved: &[],
+            callee_saved: regs,
         }
-        false
+    }
+
+    /// Total number of allocatable registers across both classes.
+    pub fn len(&self) -> usize {
+        self.caller_saved.len() + self.callee_saved.len()
+    }
+
+    /// Whether no register at all is allocatable.
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
+    /// Whether `reg` is one this function's prologue must preserve.
+    pub fn is_callee_saved(&self, reg: Reg) -> bool {
+        self.callee_saved.contains(&reg)
     }
 }
 
@@ -949,7 +1053,10 @@ pub trait RegAllocBackend {
     fn analyze_with_debug(mir: &Self::Mir) -> (LivenessInfo<Self::Reg>, LivenessDebugInfo);
     fn analyze_loops(mir: &Self::Mir) -> LoopInfo;
     fn coalesce_candidates(instructions: &[Self::Inst]) -> Vec<CoalesceCandidate>;
-    fn allocatable_regs() -> &'static [Self::Reg];
+    /// The allocatable registers, split by who is responsible for preserving
+    /// them. Allocation prefers the caller-saved class for intervals that no
+    /// instruction clobbers while they are live (RUE-1146).
+    fn register_classes() -> RegisterClasses<'static, Self::Reg>;
 
     fn new_mir() -> Self::Mir;
     fn take_symbols(mir: &mut Self::Mir) -> Vec<String>;
@@ -1214,7 +1321,7 @@ impl<B: RegAllocBackend> RegAllocDriver<B> {
         let (allocation, num_spills, used_callee_saved, _debug_info) = linear_scan_impl_with_remat(
             B::vreg_count(&self.mir),
             &self.liveness,
-            B::allocatable_regs(),
+            B::register_classes(),
             self.existing_locals,
             false,
             &CostModel::default(),
@@ -1230,7 +1337,7 @@ impl<B: RegAllocBackend> RegAllocDriver<B> {
         let (allocation, num_spills, used_callee_saved, debug_info) = linear_scan_impl_with_remat(
             B::vreg_count(&self.mir),
             &self.liveness,
-            B::allocatable_regs(),
+            B::register_classes(),
             self.existing_locals,
             true,
             &CostModel::default(),
@@ -1384,7 +1491,7 @@ pub fn linear_scan<Reg: Copy + Eq + std::hash::Hash>(
     let (allocation, num_spills, used_callee_saved, _debug_info) = linear_scan_impl(
         vreg_count,
         liveness,
-        allocatable_regs,
+        RegisterClasses::callee_saved_only(allocatable_regs),
         existing_locals,
         false,
         &cost_model,
@@ -1426,7 +1533,7 @@ pub fn linear_scan_with_cost_model<Reg: Copy + Eq + std::hash::Hash>(
     let (allocation, num_spills, used_callee_saved, _debug_info) = linear_scan_impl(
         vreg_count,
         liveness,
-        allocatable_regs,
+        RegisterClasses::callee_saved_only(allocatable_regs),
         existing_locals,
         false,
         cost_model,
@@ -1470,7 +1577,7 @@ pub fn linear_scan_with_remat<Reg: Copy + Eq + std::hash::Hash>(
     let (allocation, num_spills, used_callee_saved, _debug_info) = linear_scan_impl_with_remat(
         vreg_count,
         liveness,
-        allocatable_regs,
+        RegisterClasses::callee_saved_only(allocatable_regs),
         existing_locals,
         false,
         &cost_model,
@@ -1504,7 +1611,7 @@ pub fn linear_scan_with_debug<Reg: Copy + Eq + std::hash::Hash>(
     linear_scan_impl(
         vreg_count,
         liveness,
-        allocatable_regs,
+        RegisterClasses::callee_saved_only(allocatable_regs),
         existing_locals,
         true,
         &cost_model,
@@ -1532,12 +1639,56 @@ pub fn linear_scan_with_cost_model_and_debug<Reg: Copy + Eq + std::hash::Hash>(
     linear_scan_impl(
         vreg_count,
         liveness,
-        allocatable_regs,
+        RegisterClasses::callee_saved_only(allocatable_regs),
         existing_locals,
         true,
         cost_model,
         loop_info,
     )
+}
+
+/// Pick a physical register for an interval covering `range`, or report that
+/// none is free.
+///
+/// Caller-saved registers come first: an interval that no instruction clobbers
+/// while it is live costs nothing to keep in one, and every callee-saved
+/// register it leaves alone is one the prologue does not have to save
+/// (RUE-1146). Callee-saved registers follow, in their declared order.
+fn pick_free_register<Reg: Copy + Eq + std::hash::Hash>(
+    classes: RegisterClasses<'_, Reg>,
+    clobbers: &ClobberIndex<Reg>,
+    used: &HashSet<Reg>,
+    range: &LiveRange,
+) -> Option<Reg> {
+    classes
+        .caller_saved
+        .iter()
+        .copied()
+        .find(|&reg| !used.contains(&reg) && !clobbers.is_clobbered_during(reg, range))
+        .or_else(|| {
+            classes
+                .callee_saved
+                .iter()
+                .copied()
+                .find(|&reg| !used.contains(&reg))
+        })
+}
+
+/// Whether `reg` can hold one value for the whole of `range`.
+///
+/// A callee-saved register always can. A caller-saved register can only when no
+/// instruction in the range clobbers it. This is the same condition
+/// [`pick_free_register`] applies, restated for the eviction path: a register
+/// that becomes free by spilling its current occupant is still only usable by
+/// the arriving interval if that interval survives everything the register does
+/// not.
+fn register_survives_range<Reg: Copy + Eq + std::hash::Hash>(
+    classes: RegisterClasses<'_, Reg>,
+    clobbers: &ClobberIndex<Reg>,
+    reg: Reg,
+    range: &LiveRange,
+) -> bool {
+    classes.is_callee_saved(reg) || !clobbers.is_clobbered_during(reg, range)
 }
 
 /// Internal implementation of linear scan register allocation.
@@ -1551,7 +1702,7 @@ pub fn linear_scan_with_cost_model_and_debug<Reg: Copy + Eq + std::hash::Hash>(
 fn linear_scan_impl<Reg: Copy + Eq + std::hash::Hash>(
     vreg_count: u32,
     liveness: &LivenessInfo<Reg>,
-    allocatable_regs: &[Reg],
+    classes: RegisterClasses<'_, Reg>,
     existing_locals: u32,
     collect_debug: bool,
     cost_model: &CostModel,
@@ -1605,9 +1756,13 @@ fn linear_scan_impl<Reg: Copy + Eq + std::hash::Hash>(
         }
     }
 
+    // Constant-time clobber answers for the caller-saved candidates; the
+    // callee-saved class survives every clobber by definition (RUE-1146).
+    let clobbers = ClobberIndex::build(liveness, classes.caller_saved);
+
     // Track which registers are currently in use and when they become free
     // Tuple: (vreg, physical reg, live range end)
-    let mut active: Vec<(VReg, Reg, usize)> = Vec::with_capacity(allocatable_regs.len());
+    let mut active: Vec<(VReg, Reg, usize)> = Vec::with_capacity(classes.len());
 
     for (vreg, range) in vregs_by_start {
         // Expire old intervals - remove registers whose vregs are no longer live
@@ -1616,21 +1771,15 @@ fn linear_scan_impl<Reg: Copy + Eq + std::hash::Hash>(
         // Find registers currently in use
         let used_regs: HashSet<Reg> = active.iter().map(|&(_, reg, _)| reg).collect();
 
-        // Try to find a free register
-        let mut allocated_reg = None;
-        for &reg in allocatable_regs {
-            if !used_regs.contains(&reg) {
-                allocated_reg = Some(reg);
-                break;
-            }
-        }
+        // Try to find a free register, caller-saved class first
+        let allocated_reg = pick_free_register(classes, &clobbers, &used_regs, &range);
 
         if let Some(reg) = allocated_reg {
             // Assign this register
             allocation[vreg] = Some(Allocation::Register(reg));
             active.push((vreg, reg, range.end));
-            // Track callee-saved register usage
-            if !used_callee_saved.contains(&reg) {
+            // Track callee-saved register usage: only these oblige the prologue
+            if classes.is_callee_saved(reg) && !used_callee_saved.contains(&reg) {
                 used_callee_saved.push(reg);
             }
         } else {
@@ -1647,7 +1796,13 @@ fn linear_scan_impl<Reg: Copy + Eq + std::hash::Hash>(
             let mut best_spill_idx = None;
             let mut best_spill_priority = current_priority;
 
-            for (i, &(_active_vreg, _, end)) in active.iter().enumerate() {
+            for (i, &(_active_vreg, active_reg, end)) in active.iter().enumerate() {
+                // Evicting only helps if the freed register can actually hold
+                // the arriving interval; a caller-saved register clobbered
+                // during that interval cannot.
+                if !register_survives_range(classes, &clobbers, active_reg, &range) {
+                    continue;
+                }
                 let active_loop_depth = loop_info.max_depth_in_range(range.start, end);
                 let active_remaining = end.saturating_sub(range.start);
                 let active_priority =
@@ -1712,7 +1867,7 @@ fn linear_scan_impl<Reg: Copy + Eq + std::hash::Hash>(
 fn linear_scan_impl_with_remat<Reg: Copy + Eq + std::hash::Hash>(
     vreg_count: u32,
     liveness: &LivenessInfo<Reg>,
-    allocatable_regs: &[Reg],
+    classes: RegisterClasses<'_, Reg>,
     existing_locals: u32,
     collect_debug: bool,
     cost_model: &CostModel,
@@ -1771,9 +1926,13 @@ fn linear_scan_impl_with_remat<Reg: Copy + Eq + std::hash::Hash>(
         }
     }
 
+    // Constant-time clobber answers for the caller-saved candidates; the
+    // callee-saved class survives every clobber by definition (RUE-1146).
+    let clobbers = ClobberIndex::build(liveness, classes.caller_saved);
+
     // Track which registers are currently in use and when they become free
     // Tuple: (vreg, physical reg, live range end)
-    let mut active: Vec<(VReg, Reg, usize)> = Vec::with_capacity(allocatable_regs.len());
+    let mut active: Vec<(VReg, Reg, usize)> = Vec::with_capacity(classes.len());
 
     for (vreg, range) in vregs_by_start {
         // Expire old intervals - remove registers whose vregs are no longer live
@@ -1782,21 +1941,15 @@ fn linear_scan_impl_with_remat<Reg: Copy + Eq + std::hash::Hash>(
         // Find registers currently in use
         let used_regs: HashSet<Reg> = active.iter().map(|&(_, reg, _)| reg).collect();
 
-        // Try to find a free register
-        let mut allocated_reg = None;
-        for &reg in allocatable_regs {
-            if !used_regs.contains(&reg) {
-                allocated_reg = Some(reg);
-                break;
-            }
-        }
+        // Try to find a free register, caller-saved class first
+        let allocated_reg = pick_free_register(classes, &clobbers, &used_regs, &range);
 
         if let Some(reg) = allocated_reg {
             // Assign this register
             allocation[vreg] = Some(Allocation::Register(reg));
             active.push((vreg, reg, range.end));
-            // Track callee-saved register usage
-            if !used_callee_saved.contains(&reg) {
+            // Track callee-saved register usage: only these oblige the prologue
+            if classes.is_callee_saved(reg) && !used_callee_saved.contains(&reg) {
                 used_callee_saved.push(reg);
             }
         } else {
@@ -1821,7 +1974,13 @@ fn linear_scan_impl_with_remat<Reg: Copy + Eq + std::hash::Hash>(
             let mut best_spill_priority = current_priority;
             let mut best_is_remat = current_is_remat;
 
-            for (i, &(active_vreg, _, end)) in active.iter().enumerate() {
+            for (i, &(active_vreg, active_reg, end)) in active.iter().enumerate() {
+                // Evicting only helps if the freed register can actually hold
+                // the arriving interval; a caller-saved register clobbered
+                // during that interval cannot.
+                if !register_survives_range(classes, &clobbers, active_reg, &range) {
+                    continue;
+                }
                 let active_is_remat = can_remat(active_vreg).is_some();
                 let active_loop_depth = loop_info.max_depth_in_range(range.start, end);
                 let active_remaining = end.saturating_sub(range.start);
@@ -1983,6 +2142,110 @@ mod tests {
         info.live_at = vec![FixedBitSet::with_capacity(vreg_count); max_inst + 1];
         info.clobbers_at = vec![Vec::new(); max_inst + 1];
         info
+    }
+
+    fn make_liveness_with_clobbers(
+        ranges: Vec<(u32, usize, usize)>,
+        clobbers: Vec<(usize, TestReg)>,
+    ) -> LivenessInfo<TestReg> {
+        let mut info = make_liveness(ranges);
+        for (idx, reg) in clobbers {
+            info.clobbers_at[idx].push(reg);
+        }
+        info
+    }
+
+    #[test]
+    fn clobber_index_answers_only_for_tracked_registers() {
+        let liveness = make_liveness_with_clobbers(vec![(0, 0, 4)], vec![(2, TestReg(0))]);
+        let index = ClobberIndex::build(&liveness, &[TestReg(0)]);
+
+        assert!(index.is_clobbered_during(TestReg(0), &LiveRange::new(0, 4)));
+        assert!(index.is_clobbered_during(TestReg(0), &LiveRange::new(2, 2)));
+        assert!(!index.is_clobbered_during(TestReg(0), &LiveRange::new(0, 1)));
+        assert!(!index.is_clobbered_during(TestReg(0), &LiveRange::new(3, 4)));
+        // An untracked register cannot be proven clobber-free.
+        assert!(index.is_clobbered_during(TestReg(1), &LiveRange::new(0, 1)));
+    }
+
+    #[test]
+    fn clobber_index_tolerates_ranges_past_the_last_instruction() {
+        let liveness = make_liveness_with_clobbers(vec![(0, 0, 1)], vec![(1, TestReg(0))]);
+        let index = ClobberIndex::build(&liveness, &[TestReg(0)]);
+
+        assert!(index.is_clobbered_during(TestReg(0), &LiveRange::new(0, usize::MAX)));
+        assert!(!index.is_clobbered_during(TestReg(0), &LiveRange::new(0, 0)));
+    }
+
+    #[test]
+    fn caller_saved_is_preferred_and_call_crossing_intervals_avoid_it() {
+        // v0 spans the clobber at instruction 2, v1 does not.
+        let liveness = make_liveness_with_clobbers(
+            vec![(0, 0, 4), (1, 3, 4)],
+            vec![(2, TestReg(9)), (2, TestReg(8))],
+        );
+        let classes = RegisterClasses {
+            caller_saved: &[TestReg(9), TestReg(8)],
+            callee_saved: &[TestReg(0)],
+        };
+        let (allocation, num_spills, used_callee_saved, _) = linear_scan_impl(
+            2,
+            &liveness,
+            classes,
+            0,
+            false,
+            &CostModel::default(),
+            &LoopInfo::no_loops(liveness.live_at.len()),
+        );
+
+        assert_eq!(num_spills, 0);
+        assert_eq!(
+            allocation[VReg::new(0)],
+            Some(Allocation::Register(TestReg(0))),
+            "an interval spanning the clobber must take the callee-saved register"
+        );
+        assert_eq!(
+            allocation[VReg::new(1)],
+            Some(Allocation::Register(TestReg(9))),
+            "an interval clear of the clobber should take the first caller-saved register"
+        );
+        assert_eq!(
+            used_callee_saved,
+            vec![TestReg(0)],
+            "only callee-saved registers are reported to frame planning"
+        );
+    }
+
+    #[test]
+    fn eviction_never_hands_a_clobbered_caller_saved_register_to_a_spanning_interval() {
+        // Only a caller-saved register exists, and every interval spans the
+        // clobber, so nothing can hold a value: all three must spill.
+        let liveness = make_liveness_with_clobbers(
+            vec![(0, 0, 4), (1, 0, 4), (2, 0, 4)],
+            vec![(2, TestReg(9))],
+        );
+        let classes = RegisterClasses {
+            caller_saved: &[TestReg(9)],
+            callee_saved: &[],
+        };
+        let (allocation, num_spills, used_callee_saved, _) = linear_scan_impl(
+            3,
+            &liveness,
+            classes,
+            0,
+            false,
+            &CostModel::default(),
+            &LoopInfo::no_loops(liveness.live_at.len()),
+        );
+
+        assert_eq!(num_spills, 3);
+        assert!(used_callee_saved.is_empty());
+        for idx in 0..3 {
+            assert!(
+                matches!(allocation[VReg::new(idx)], Some(Allocation::Spill(_))),
+                "v{idx} spans the clobber and must not hold the caller-saved register"
+            );
+        }
     }
 
     #[test]

--- a/crates/rue-codegen/src/x86_64/cfg_lower.rs
+++ b/crates/rue-codegen/src/x86_64/cfg_lower.rs
@@ -51,6 +51,28 @@ pub(super) const ARG_REGS: [Reg; 6] = [Reg::Rdi, Reg::Rsi, Reg::Rdx, Reg::Rcx, R
 /// `crate::cfg_lower::type_uses_sret_return`. (RUE-106)
 pub(super) const RET_REGS: [Reg; 6] = [Reg::Rax, Reg::Rdx, Reg::Rcx, Reg::R8, Reg::R9, Reg::R10];
 
+// Call sequences and the prologue name these registers physically, and liveness
+// models neither those physical definitions nor their uses. So they must be off
+// limits to the allocator, not merely unlikely to collide (RUE-1146).
+const _: () = {
+    let mut index = 0;
+    while index < ARG_REGS.len() {
+        assert!(
+            super::mir::is_reserved(ARG_REGS[index]),
+            "every ABI argument register must be reserved from allocation"
+        );
+        index += 1;
+    }
+    let mut index = 0;
+    while index < RET_REGS.len() {
+        assert!(
+            super::mir::is_reserved(RET_REGS[index]),
+            "every ABI result register must be reserved from allocation"
+        );
+        index += 1;
+    }
+};
+
 /// Round `value` up to a multiple of `alignment` (a power of two ≥ 1).
 const fn align_up_u32(value: u32, alignment: u32) -> u32 {
     value.div_ceil(alignment) * alignment

--- a/crates/rue-codegen/src/x86_64/emit.rs
+++ b/crates/rue-codegen/src/x86_64/emit.rs
@@ -133,7 +133,7 @@
 
 use rue_error::{CompileResult, ice_error};
 
-use super::mir::{LabelId, Reg, X86Inst, X86Mir};
+use super::mir::{LabelId, Reg, SHIFT_COUNT, X86Inst, X86Mir};
 use crate::vreg::BLOCK_LABEL_BASE;
 use crate::{EmittedCode, EmittedInst, EmittedRelocation, format_offset};
 
@@ -1299,20 +1299,22 @@ impl<'a> Emitter<'a> {
                 let dst_reg = dst.as_physical();
                 let cnt = count.as_physical();
 
-                // If count isn't in RCX, move it.
-                if cnt != Reg::Rcx {
+                // If count isn't already in the fixed count register, move it.
+                if cnt != SHIFT_COUNT {
                     // NB: this clobbers rcx, which is exactly what we want.
                     self.begin_inst();
-                    self.emit_mov_rr(Reg::Rcx, cnt);
-                    end_inst!(self, "mov rcx, {}", cnt);
+                    self.emit_mov_rr(SHIFT_COUNT, cnt);
+                    end_inst!(self, "mov {}, {}", SHIFT_COUNT, cnt);
                 }
 
-                // If dst is RCX, that's a conflict (dst would be clobbered by the move above
-                // or would shift itself by itself).
+                // If dst is the count register, that's a conflict (dst would be
+                // clobbered by the move above or would shift itself by itself).
+                // `mir::RESERVED_REGS` makes that unreachable by keeping the
+                // count register out of allocation entirely (RUE-1146).
                 assert!(
-                    dst_reg != Reg::Rcx,
-                    "Shl dst allocated to RCX, but x86 requires count in CL; \
-         regalloc must avoid assigning dst=RCX for Shl"
+                    dst_reg != SHIFT_COUNT,
+                    "Shl dst allocated to the shift-count register, but x86 requires \
+         the count in CL; regalloc must never assign it"
                 );
 
                 self.begin_inst();

--- a/crates/rue-codegen/src/x86_64/mir.rs
+++ b/crates/rue-codegen/src/x86_64/mir.rs
@@ -40,6 +40,100 @@ pub enum Reg {
     R15 = 15,
 }
 
+// ============================================================================
+// Register roles
+// ============================================================================
+//
+// The register allocator hands out physical registers; several passes also
+// name physical registers directly, for fixed-register instruction operands,
+// for ABI argument and result positions, and as rewrite scratch. Those two
+// uses must never overlap. Before RUE-1146 the separation held only because
+// the allocator drew from callee-saved registers exclusively and every
+// directly-named register happened to be caller-saved — a coincidence
+// documented in comments. `RESERVED_REGS` states the constraint instead, and
+// `x86_64::regalloc` proves at compile time that no allocatable register is in
+// it.
+
+/// Registers the allocator must never hand to a virtual register.
+///
+/// Each entry is reserved for one of four reasons:
+///
+/// * **Machine role.** `rsp` is the stack pointer and `rbp` the frame pointer.
+/// * **Fixed instruction operand.** `idiv`/`div`/`mul` read and write the
+///   `rdx:rax` pair (see `X86Inst::clobbers`), `cdq`/`cqo` write `rdx`, and the
+///   variable-count shifts take their count in `cl`, i.e. `rcx`. The emitter
+///   asserts the shift destination is not `rcx` for exactly this reason.
+/// * **Register-allocation scratch.** [`SCRATCH_VALUE`], [`SCRATCH_SOURCE`],
+///   [`SCRATCH_ADDR_BASE`], and [`SCRATCH_ADDR_INDEX`] hold reloaded spill
+///   values and lowered address components while an instruction is rewritten.
+/// * **ABI position.** `cfg_lower::ARG_REGS` and `cfg_lower::RET_REGS` are
+///   written and read as physical registers around every call and in the
+///   prologue. Liveness models a call's *clobbers* but not those physical
+///   defs and uses, so an ABI register is not something the clobber test can
+///   make safe; it is excluded outright.
+///
+/// `r11` is the one caller-saved register with no role here, which is why it
+/// is the whole caller-saved allocatable class on this target.
+pub(crate) const RESERVED_REGS: &[Reg] = &[
+    Reg::Rsp, // stack pointer
+    Reg::Rbp, // frame pointer
+    Reg::Rax, // div/mul low half, RET_REGS[0], SCRATCH_VALUE
+    Reg::Rcx, // shift count (cl), ARG_REGS[3], RET_REGS[2], SCRATCH_ADDR_INDEX
+    Reg::Rdx, // div/mul high half, cdq/cqo, ARG_REGS[2], RET_REGS[1], SCRATCH_ADDR_BASE
+    Reg::Rsi, // ARG_REGS[1]
+    Reg::Rdi, // ARG_REGS[0]
+    Reg::R8,  // ARG_REGS[4], RET_REGS[3]
+    Reg::R9,  // ARG_REGS[5], RET_REGS[4]
+    Reg::R10, // RET_REGS[5], SCRATCH_SOURCE
+];
+
+/// Scratch register for a rewritten instruction's value: the destination when
+/// it is spilled, and the first source operand of most instructions.
+pub(crate) const SCRATCH_VALUE: Reg = Reg::Rax;
+
+/// Scratch register for a rewritten instruction's second source operand, kept
+/// distinct from [`SCRATCH_VALUE`] so a two-operand instruction can reload both
+/// operands at once.
+pub(crate) const SCRATCH_SOURCE: Reg = Reg::R10;
+
+/// Scratch register for a memory rewrite's second temporary: the lowered base
+/// of a SIB address, and the transferred value of a store or indexed access
+/// whose base pointer already occupies [`SCRATCH_VALUE`].
+pub(crate) const SCRATCH_ADDR_BASE: Reg = Reg::Rdx;
+
+/// Scratch register for a lowered SIB index, distinct from the two registers a
+/// SIB address rewrite already occupies. (`rsp` cannot encode as a SIB index,
+/// which is one more reason it is reserved.)
+pub(crate) const SCRATCH_ADDR_INDEX: Reg = Reg::Rcx;
+
+/// The register a variable-count shift takes its count in: `cl`, the low byte
+/// of `rcx`. This is a fixed machine operand, not a choice — the emitter
+/// asserts that a shift's destination is not this register, and the allocator
+/// therefore cannot hand it out.
+pub(crate) const SHIFT_COUNT: Reg = Reg::Rcx;
+
+/// Whether the allocator is forbidden from handing out `reg`.
+pub(crate) const fn is_reserved(reg: Reg) -> bool {
+    let mut index = 0;
+    while index < RESERVED_REGS.len() {
+        if RESERVED_REGS[index] as u8 == reg as u8 {
+            return true;
+        }
+        index += 1;
+    }
+    false
+}
+
+// Every scratch register is reserved. Without this, moving a scratch role to a
+// different register would silently make it allocatable as well.
+const _: () = {
+    assert!(is_reserved(SCRATCH_VALUE));
+    assert!(is_reserved(SCRATCH_SOURCE));
+    assert!(is_reserved(SCRATCH_ADDR_BASE));
+    assert!(is_reserved(SCRATCH_ADDR_INDEX));
+    assert!(is_reserved(SHIFT_COUNT));
+};
+
 impl Reg {
     /// Get the register encoding for ModR/M and SIB bytes.
     #[inline]

--- a/crates/rue-codegen/src/x86_64/regalloc.rs
+++ b/crates/rue-codegen/src/x86_64/regalloc.rs
@@ -14,34 +14,76 @@
 use rue_error::{CompileError, CompileResult, ErrorKind};
 
 use super::liveness;
+use super::mir;
 use super::mir::VReg;
-use super::mir::{Operand, Reg, X86Inst, X86Mir};
+use super::mir::{
+    Operand, Reg, SCRATCH_ADDR_BASE, SCRATCH_ADDR_INDEX, SCRATCH_SOURCE, SCRATCH_VALUE,
+    SHIFT_COUNT, X86Inst, X86Mir,
+};
 use crate::alloc_dst;
 use crate::regalloc::{
     Allocation, AllocationContext, CoalesceCandidate, LivenessInfo, LoopInfo, RegAllocBackend,
-    RegAllocDebugInfo, RegAllocDriver, RematerializeOp, RewriteBuffer,
+    RegAllocDebugInfo, RegAllocDriver, RegisterClasses, RematerializeOp, RewriteBuffer,
 };
 
-/// Available registers for allocation.
+/// Caller-saved registers offered to intervals no instruction clobbers while
+/// they are live — in particular, intervals that cross no call.
 ///
-/// We ONLY use callee-saved registers for general allocation. This ensures
-/// that values survive across function calls without needing explicit save/restore.
-/// Caller-saved registers (rax, rcx, rdx, rsi, rdi, r8-r11) are avoided because
-/// they get clobbered by function calls.
+/// `r11` is the only caller-saved register with no other role on this target:
+/// every other one is a fixed instruction operand, an ABI argument or result
+/// position, or rewrite scratch. See [`mir::RESERVED_REGS`] for the per-register
+/// reasoning; the assertion below keeps the two in agreement.
+const CALLER_SAVED_REGS: &[Reg] = &[Reg::R11];
+
+/// Callee-saved registers, the only home for a value that must survive a call.
 ///
-/// We also avoid:
-/// - rsp (stack pointer)
-/// - rbp (frame pointer)
-/// - rax, rdx (used implicitly by idiv, and rax for scratch)
+/// Each one used obliges the prologue to save it and the epilogue to restore
+/// it, so allocation reaches for these only after the caller-saved class above
+/// is exhausted or ineligible.
+const CALLEE_SAVED_REGS: &[Reg] = &[Reg::R12, Reg::R13, Reg::R14, Reg::R15, Reg::Rbx];
+
+/// Every allocatable register, in preference order: caller-saved first.
 ///
-/// When we run out of callee-saved registers, values are spilled to the stack.
+/// This is the flattening of [`CALLER_SAVED_REGS`] and [`CALLEE_SAVED_REGS`];
+/// [`register_classes`](X86Backend::register_classes) is what allocation
+/// actually consults, and it keeps the two classes apart. When neither class
+/// has a register available, values are spilled to the stack.
 const ALLOCATABLE_REGS: &[Reg] = &[
+    Reg::R11, // Caller-saved
     Reg::R12, // Callee-saved
     Reg::R13, // Callee-saved
     Reg::R14, // Callee-saved
     Reg::R15, // Callee-saved
     Reg::Rbx, // Callee-saved
 ];
+
+// No allocatable register may carry a reserved role, and the flattened list
+// must stay the concatenation of the two classes.
+const _: () = {
+    let mut index = 0;
+    while index < ALLOCATABLE_REGS.len() {
+        assert!(
+            !mir::is_reserved(ALLOCATABLE_REGS[index]),
+            "an allocatable register must not also be reserved for a fixed \
+             operand, an ABI position, or rewrite scratch"
+        );
+        index += 1;
+    }
+    assert!(ALLOCATABLE_REGS.len() == CALLER_SAVED_REGS.len() + CALLEE_SAVED_REGS.len());
+    let mut index = 0;
+    while index < CALLER_SAVED_REGS.len() {
+        assert!(ALLOCATABLE_REGS[index] as u8 == CALLER_SAVED_REGS[index] as u8);
+        index += 1;
+    }
+    let mut index = 0;
+    while index < CALLEE_SAVED_REGS.len() {
+        assert!(
+            ALLOCATABLE_REGS[CALLER_SAVED_REGS.len() + index] as u8
+                == CALLEE_SAVED_REGS[index] as u8
+        );
+        index += 1;
+    }
+};
 
 /// Zero-sized adapter for target-specific analysis and instruction rewriting.
 struct X86Backend;
@@ -106,7 +148,7 @@ impl RegAlloc {
     ) -> CompileResult<()> {
         match inst {
             X86Inst::MovRI32 { dst, imm } => {
-                alloc_dst!(Self::get_allocation(context, dst), dst, Reg::Rax =>
+                alloc_dst!(Self::get_allocation(context, dst), dst, SCRATCH_VALUE =>
                     emit |dst_op| {
                         mir.push(X86Inst::MovRI32 { dst: dst_op, imm });
                     },
@@ -114,14 +156,14 @@ impl RegAlloc {
                         mir.push_after(X86Inst::MovMR {
                             base: Reg::Rbp,
                             offset,
-                            src: Operand::Physical(Reg::Rax),
+                            src: Operand::Physical(SCRATCH_VALUE),
                         });
                     },
                 );
             }
 
             X86Inst::MovRI64 { dst, imm } => {
-                alloc_dst!(Self::get_allocation(context, dst), dst, Reg::Rax =>
+                alloc_dst!(Self::get_allocation(context, dst), dst, SCRATCH_VALUE =>
                     emit |dst_op| {
                         mir.push(X86Inst::MovRI64 { dst: dst_op, imm });
                     },
@@ -129,14 +171,14 @@ impl RegAlloc {
                         mir.push_after(X86Inst::MovMR {
                             base: Reg::Rbp,
                             offset,
-                            src: Operand::Physical(Reg::Rax),
+                            src: Operand::Physical(SCRATCH_VALUE),
                         });
                     },
                 );
             }
 
             X86Inst::MovRR { dst, src } => {
-                let src_op = Self::load_operand(context, mir, src, Reg::Rax)?;
+                let src_op = Self::load_operand(context, mir, src, SCRATCH_VALUE)?;
                 let dst_alloc = Self::get_allocation(context, dst);
 
                 match dst_alloc {
@@ -148,16 +190,16 @@ impl RegAlloc {
                     }
                     Some(Allocation::Spill(offset)) => {
                         // Move src to RAX (if not already), then store to stack
-                        if src_op != Operand::Physical(Reg::Rax) {
+                        if src_op != Operand::Physical(SCRATCH_VALUE) {
                             mir.push(X86Inst::MovRR {
-                                dst: Operand::Physical(Reg::Rax),
+                                dst: Operand::Physical(SCRATCH_VALUE),
                                 src: src_op,
                             });
                         }
                         mir.push_after(X86Inst::MovMR {
                             base: Reg::Rbp,
                             offset,
-                            src: Operand::Physical(Reg::Rax),
+                            src: Operand::Physical(SCRATCH_VALUE),
                         });
                     }
                     Some(Allocation::Rematerialize(_)) => {
@@ -170,7 +212,7 @@ impl RegAlloc {
             }
 
             X86Inst::MovRM { dst, base, offset } => {
-                alloc_dst!(Self::get_allocation(context, dst), dst, Reg::Rax =>
+                alloc_dst!(Self::get_allocation(context, dst), dst, SCRATCH_VALUE =>
                     emit |dst_op| {
                         mir.push(X86Inst::MovRM { dst: dst_op, base, offset });
                     },
@@ -178,14 +220,14 @@ impl RegAlloc {
                         mir.push_after(X86Inst::MovMR {
                             base: Reg::Rbp,
                             offset: spill_offset,
-                            src: Operand::Physical(Reg::Rax),
+                            src: Operand::Physical(SCRATCH_VALUE),
                         });
                     },
                 );
             }
 
             X86Inst::MovMR { base, offset, src } => {
-                let src_op = Self::load_operand(context, mir, src, Reg::Rax)?;
+                let src_op = Self::load_operand(context, mir, src, SCRATCH_VALUE)?;
                 mir.push(X86Inst::MovMR {
                     base,
                     offset,
@@ -194,7 +236,7 @@ impl RegAlloc {
             }
 
             X86Inst::Movzx8RM { dst, base, offset } => {
-                alloc_dst!(Self::get_allocation(context, dst), dst, Reg::Rax =>
+                alloc_dst!(Self::get_allocation(context, dst), dst, SCRATCH_VALUE =>
                     emit |dst_op| {
                         mir.push(X86Inst::Movzx8RM { dst: dst_op, base, offset });
                     },
@@ -202,14 +244,14 @@ impl RegAlloc {
                         mir.push_after(X86Inst::MovMR {
                             base: Reg::Rbp,
                             offset: spill_offset,
-                            src: Operand::Physical(Reg::Rax),
+                            src: Operand::Physical(SCRATCH_VALUE),
                         });
                     },
                 );
             }
 
             X86Inst::MovMR8 { base, offset, src } => {
-                let src_op = Self::load_operand(context, mir, src, Reg::Rdx)?;
+                let src_op = Self::load_operand(context, mir, src, SCRATCH_ADDR_BASE)?;
                 mir.push(X86Inst::MovMR8 {
                     base,
                     offset,
@@ -398,38 +440,38 @@ impl RegAlloc {
             }
 
             X86Inst::IdivR { src } => {
-                let src_op = Self::load_operand(context, mir, src, Reg::R10)?;
+                let src_op = Self::load_operand(context, mir, src, SCRATCH_SOURCE)?;
                 mir.push(X86Inst::IdivR { src: src_op });
             }
 
             X86Inst::DivR { src } => {
-                let src_op = Self::load_operand(context, mir, src, Reg::R10)?;
+                let src_op = Self::load_operand(context, mir, src, SCRATCH_SOURCE)?;
                 mir.push(X86Inst::DivR { src: src_op });
             }
 
             X86Inst::Idiv64R { src } => {
-                let src_op = Self::load_operand(context, mir, src, Reg::R10)?;
+                let src_op = Self::load_operand(context, mir, src, SCRATCH_SOURCE)?;
                 mir.push(X86Inst::Idiv64R { src: src_op });
             }
 
             X86Inst::Div64R { src } => {
-                let src_op = Self::load_operand(context, mir, src, Reg::R10)?;
+                let src_op = Self::load_operand(context, mir, src, SCRATCH_SOURCE)?;
                 mir.push(X86Inst::Div64R { src: src_op });
             }
 
             X86Inst::MulR { src } => {
-                let src_op = Self::load_operand(context, mir, src, Reg::R10)?;
+                let src_op = Self::load_operand(context, mir, src, SCRATCH_SOURCE)?;
                 mir.push(X86Inst::MulR { src: src_op });
             }
 
             X86Inst::Mul64R { src } => {
-                let src_op = Self::load_operand(context, mir, src, Reg::R10)?;
+                let src_op = Self::load_operand(context, mir, src, SCRATCH_SOURCE)?;
                 mir.push(X86Inst::Mul64R { src: src_op });
             }
 
             X86Inst::TestRR { src1, src2 } => {
-                let src1_op = Self::load_operand(context, mir, src1, Reg::Rax)?;
-                let src2_op = Self::load_operand(context, mir, src2, Reg::R10)?;
+                let src1_op = Self::load_operand(context, mir, src1, SCRATCH_VALUE)?;
+                let src2_op = Self::load_operand(context, mir, src2, SCRATCH_SOURCE)?;
                 mir.push(X86Inst::TestRR {
                     src1: src1_op,
                     src2: src2_op,
@@ -437,8 +479,8 @@ impl RegAlloc {
             }
 
             X86Inst::Test64RR { src1, src2 } => {
-                let src1_op = Self::load_operand(context, mir, src1, Reg::Rax)?;
-                let src2_op = Self::load_operand(context, mir, src2, Reg::R10)?;
+                let src1_op = Self::load_operand(context, mir, src1, SCRATCH_VALUE)?;
+                let src2_op = Self::load_operand(context, mir, src2, SCRATCH_SOURCE)?;
                 mir.push(X86Inst::Test64RR {
                     src1: src1_op,
                     src2: src2_op,
@@ -446,8 +488,8 @@ impl RegAlloc {
             }
 
             X86Inst::CmpRR { src1, src2 } => {
-                let src1_op = Self::load_operand(context, mir, src1, Reg::Rax)?;
-                let src2_op = Self::load_operand(context, mir, src2, Reg::R10)?;
+                let src1_op = Self::load_operand(context, mir, src1, SCRATCH_VALUE)?;
+                let src2_op = Self::load_operand(context, mir, src2, SCRATCH_SOURCE)?;
                 mir.push(X86Inst::CmpRR {
                     src1: src1_op,
                     src2: src2_op,
@@ -455,8 +497,8 @@ impl RegAlloc {
             }
 
             X86Inst::Cmp64RR { src1, src2 } => {
-                let src1_op = Self::load_operand(context, mir, src1, Reg::Rax)?;
-                let src2_op = Self::load_operand(context, mir, src2, Reg::R10)?;
+                let src1_op = Self::load_operand(context, mir, src1, SCRATCH_VALUE)?;
+                let src2_op = Self::load_operand(context, mir, src2, SCRATCH_SOURCE)?;
                 mir.push(X86Inst::Cmp64RR {
                     src1: src1_op,
                     src2: src2_op,
@@ -464,12 +506,12 @@ impl RegAlloc {
             }
 
             X86Inst::CmpRI { src, imm } => {
-                let src_op = Self::load_operand(context, mir, src, Reg::Rax)?;
+                let src_op = Self::load_operand(context, mir, src, SCRATCH_VALUE)?;
                 mir.push(X86Inst::CmpRI { src: src_op, imm });
             }
 
             X86Inst::Cmp64RI { src, imm } => {
-                let src_op = Self::load_operand(context, mir, src, Reg::Rax)?;
+                let src_op = Self::load_operand(context, mir, src, SCRATCH_VALUE)?;
                 mir.push(X86Inst::Cmp64RI { src: src_op, imm });
             }
 
@@ -514,8 +556,8 @@ impl RegAlloc {
             }
 
             X86Inst::Movzx { dst, src } => {
-                let src_op = Self::load_operand(context, mir, src, Reg::Rax)?;
-                alloc_dst!(Self::get_allocation(context, dst), dst, Reg::Rax =>
+                let src_op = Self::load_operand(context, mir, src, SCRATCH_VALUE)?;
+                alloc_dst!(Self::get_allocation(context, dst), dst, SCRATCH_VALUE =>
                     emit |dst_op| {
                         mir.push(X86Inst::Movzx { dst: dst_op, src: src_op });
                     },
@@ -523,15 +565,15 @@ impl RegAlloc {
                         mir.push_after(X86Inst::MovMR {
                             base: Reg::Rbp,
                             offset,
-                            src: Operand::Physical(Reg::Rax),
+                            src: Operand::Physical(SCRATCH_VALUE),
                         });
                     },
                 );
             }
 
             X86Inst::Movsx8To64 { dst, src } => {
-                let src_op = Self::load_operand(context, mir, src, Reg::Rax)?;
-                alloc_dst!(Self::get_allocation(context, dst), dst, Reg::Rax =>
+                let src_op = Self::load_operand(context, mir, src, SCRATCH_VALUE)?;
+                alloc_dst!(Self::get_allocation(context, dst), dst, SCRATCH_VALUE =>
                     emit |dst_op| {
                         mir.push(X86Inst::Movsx8To64 { dst: dst_op, src: src_op });
                     },
@@ -539,15 +581,15 @@ impl RegAlloc {
                         mir.push_after(X86Inst::MovMR {
                             base: Reg::Rbp,
                             offset,
-                            src: Operand::Physical(Reg::Rax),
+                            src: Operand::Physical(SCRATCH_VALUE),
                         });
                     },
                 );
             }
 
             X86Inst::Movsx16To64 { dst, src } => {
-                let src_op = Self::load_operand(context, mir, src, Reg::Rax)?;
-                alloc_dst!(Self::get_allocation(context, dst), dst, Reg::Rax =>
+                let src_op = Self::load_operand(context, mir, src, SCRATCH_VALUE)?;
+                alloc_dst!(Self::get_allocation(context, dst), dst, SCRATCH_VALUE =>
                     emit |dst_op| {
                         mir.push(X86Inst::Movsx16To64 { dst: dst_op, src: src_op });
                     },
@@ -555,15 +597,15 @@ impl RegAlloc {
                         mir.push_after(X86Inst::MovMR {
                             base: Reg::Rbp,
                             offset,
-                            src: Operand::Physical(Reg::Rax),
+                            src: Operand::Physical(SCRATCH_VALUE),
                         });
                     },
                 );
             }
 
             X86Inst::Movsx32To64 { dst, src } => {
-                let src_op = Self::load_operand(context, mir, src, Reg::Rax)?;
-                alloc_dst!(Self::get_allocation(context, dst), dst, Reg::Rax =>
+                let src_op = Self::load_operand(context, mir, src, SCRATCH_VALUE)?;
+                alloc_dst!(Self::get_allocation(context, dst), dst, SCRATCH_VALUE =>
                     emit |dst_op| {
                         mir.push(X86Inst::Movsx32To64 { dst: dst_op, src: src_op });
                     },
@@ -571,15 +613,15 @@ impl RegAlloc {
                         mir.push_after(X86Inst::MovMR {
                             base: Reg::Rbp,
                             offset,
-                            src: Operand::Physical(Reg::Rax),
+                            src: Operand::Physical(SCRATCH_VALUE),
                         });
                     },
                 );
             }
 
             X86Inst::Movzx8To64 { dst, src } => {
-                let src_op = Self::load_operand(context, mir, src, Reg::Rax)?;
-                alloc_dst!(Self::get_allocation(context, dst), dst, Reg::Rax =>
+                let src_op = Self::load_operand(context, mir, src, SCRATCH_VALUE)?;
+                alloc_dst!(Self::get_allocation(context, dst), dst, SCRATCH_VALUE =>
                     emit |dst_op| {
                         mir.push(X86Inst::Movzx8To64 { dst: dst_op, src: src_op });
                     },
@@ -587,15 +629,15 @@ impl RegAlloc {
                         mir.push_after(X86Inst::MovMR {
                             base: Reg::Rbp,
                             offset,
-                            src: Operand::Physical(Reg::Rax),
+                            src: Operand::Physical(SCRATCH_VALUE),
                         });
                     },
                 );
             }
 
             X86Inst::Movzx16To64 { dst, src } => {
-                let src_op = Self::load_operand(context, mir, src, Reg::Rax)?;
-                alloc_dst!(Self::get_allocation(context, dst), dst, Reg::Rax =>
+                let src_op = Self::load_operand(context, mir, src, SCRATCH_VALUE)?;
+                alloc_dst!(Self::get_allocation(context, dst), dst, SCRATCH_VALUE =>
                     emit |dst_op| {
                         mir.push(X86Inst::Movzx16To64 { dst: dst_op, src: src_op });
                     },
@@ -603,14 +645,14 @@ impl RegAlloc {
                         mir.push_after(X86Inst::MovMR {
                             base: Reg::Rbp,
                             offset,
-                            src: Operand::Physical(Reg::Rax),
+                            src: Operand::Physical(SCRATCH_VALUE),
                         });
                     },
                 );
             }
 
             X86Inst::Pop { dst } => {
-                alloc_dst!(Self::get_allocation(context, dst), dst, Reg::Rax =>
+                alloc_dst!(Self::get_allocation(context, dst), dst, SCRATCH_VALUE =>
                     emit |dst_op| {
                         mir.push(X86Inst::Pop { dst: dst_op });
                     },
@@ -618,19 +660,19 @@ impl RegAlloc {
                         mir.push_after(X86Inst::MovMR {
                             base: Reg::Rbp,
                             offset,
-                            src: Operand::Physical(Reg::Rax),
+                            src: Operand::Physical(SCRATCH_VALUE),
                         });
                     },
                 );
             }
 
             X86Inst::Push { src } => {
-                let src_op = Self::load_operand(context, mir, src, Reg::Rax)?;
+                let src_op = Self::load_operand(context, mir, src, SCRATCH_VALUE)?;
                 mir.push(X86Inst::Push { src: src_op });
             }
 
             X86Inst::Lea { dst, base, disp } => {
-                alloc_dst!(Self::get_allocation(context, dst), dst, Reg::Rax =>
+                alloc_dst!(Self::get_allocation(context, dst), dst, SCRATCH_VALUE =>
                     emit |dst_op| {
                         mir.push(X86Inst::Lea { dst: dst_op, base, disp });
                     },
@@ -638,18 +680,19 @@ impl RegAlloc {
                         mir.push_after(X86Inst::MovMR {
                             base: Reg::Rbp,
                             offset,
-                            src: Operand::Physical(Reg::Rax),
+                            src: Operand::Physical(SCRATCH_VALUE),
                         });
                     },
                 );
             }
 
             X86Inst::Shl { dst, count } => {
-                // SHL needs count in RCX
-                let count_op = Self::load_operand(context, mir, count, Reg::Rcx)?;
-                if count_op != Operand::Physical(Reg::Rcx) {
+                // A variable-count shift reads its count from `cl`, so the
+                // count lands in that fixed register rather than in scratch.
+                let count_op = Self::load_operand(context, mir, count, SHIFT_COUNT)?;
+                if count_op != Operand::Physical(SHIFT_COUNT) {
                     mir.push(X86Inst::MovRR {
-                        dst: Operand::Physical(Reg::Rcx),
+                        dst: Operand::Physical(SHIFT_COUNT),
                         src: count_op,
                     });
                 }
@@ -658,23 +701,23 @@ impl RegAlloc {
                     Some(Allocation::Register(reg)) => {
                         mir.push(X86Inst::Shl {
                             dst: Operand::Physical(reg),
-                            count: Operand::Physical(Reg::Rcx),
+                            count: Operand::Physical(SHIFT_COUNT),
                         });
                     }
                     Some(Allocation::Spill(offset)) => {
                         mir.push(X86Inst::MovRM {
-                            dst: Operand::Physical(Reg::Rax),
+                            dst: Operand::Physical(SCRATCH_VALUE),
                             base: Reg::Rbp,
                             offset,
                         });
                         mir.push(X86Inst::Shl {
-                            dst: Operand::Physical(Reg::Rax),
-                            count: Operand::Physical(Reg::Rcx),
+                            dst: Operand::Physical(SCRATCH_VALUE),
+                            count: Operand::Physical(SHIFT_COUNT),
                         });
                         mir.push_after(X86Inst::MovMR {
                             base: Reg::Rbp,
                             offset,
-                            src: Operand::Physical(Reg::Rax),
+                            src: Operand::Physical(SCRATCH_VALUE),
                         });
                     }
                     Some(Allocation::Rematerialize(_)) => {
@@ -683,7 +726,7 @@ impl RegAlloc {
                     None => {
                         mir.push(X86Inst::Shl {
                             dst,
-                            count: Operand::Physical(Reg::Rcx),
+                            count: Operand::Physical(SHIFT_COUNT),
                         });
                     }
                 }
@@ -695,10 +738,10 @@ impl RegAlloc {
                 // only sees concrete memory operations with physical bases.
                 // Load base vreg into scratch register
                 let base_op = Operand::Virtual(base);
-                let base_reg = Self::load_operand(context, mir, base_op, Reg::Rax)?;
+                let base_reg = Self::load_operand(context, mir, base_op, SCRATCH_VALUE)?;
                 let base_phys = match base_reg {
                     Operand::Physical(r) => r,
-                    _ => Reg::Rax,
+                    _ => SCRATCH_VALUE,
                 };
 
                 match Self::get_allocation(context, dst) {
@@ -711,14 +754,14 @@ impl RegAlloc {
                     }
                     Some(Allocation::Spill(spill_off)) => {
                         mir.push(X86Inst::MovRM {
-                            dst: Operand::Physical(Reg::Rdx),
+                            dst: Operand::Physical(SCRATCH_ADDR_BASE),
                             base: base_phys,
                             offset,
                         });
                         mir.push_after(X86Inst::MovMR {
                             base: Reg::Rbp,
                             offset: spill_off,
-                            src: Operand::Physical(Reg::Rdx),
+                            src: Operand::Physical(SCRATCH_ADDR_BASE),
                         });
                     }
                     Some(Allocation::Rematerialize(_)) => {
@@ -736,12 +779,12 @@ impl RegAlloc {
 
             X86Inst::MovMRIndexed { base, offset, src } => {
                 // Lifecycle boundary: see MovRMIndexed above.
-                let src_op = Self::load_operand(context, mir, src, Reg::Rdx)?;
+                let src_op = Self::load_operand(context, mir, src, SCRATCH_ADDR_BASE)?;
                 let base_op = Operand::Virtual(base);
-                let base_reg = Self::load_operand(context, mir, base_op, Reg::Rax)?;
+                let base_reg = Self::load_operand(context, mir, base_op, SCRATCH_VALUE)?;
                 let base_phys = match base_reg {
                     Operand::Physical(r) => r,
-                    _ => Reg::Rax,
+                    _ => SCRATCH_VALUE,
                 };
                 mir.push(X86Inst::MovMR {
                     base: base_phys,
@@ -757,7 +800,8 @@ impl RegAlloc {
                 width,
                 signed,
             } => {
-                let base_reg = Self::load_operand(context, mir, Operand::Virtual(base), Reg::Rax)?;
+                let base_reg =
+                    Self::load_operand(context, mir, Operand::Virtual(base), SCRATCH_VALUE)?;
                 let base_phys = base_reg.as_physical();
                 match Self::get_allocation(context, dst) {
                     Some(Allocation::Register(reg)) => mir.push(X86Inst::NarrowLoadRM {
@@ -769,7 +813,7 @@ impl RegAlloc {
                     }),
                     Some(Allocation::Spill(spill_off)) => {
                         mir.push(X86Inst::NarrowLoadRM {
-                            dst: Operand::Physical(Reg::Rdx),
+                            dst: Operand::Physical(SCRATCH_ADDR_BASE),
                             base: base_phys,
                             offset,
                             width,
@@ -778,7 +822,7 @@ impl RegAlloc {
                         mir.push_after(X86Inst::MovMR {
                             base: Reg::Rbp,
                             offset: spill_off,
-                            src: Operand::Physical(Reg::Rdx),
+                            src: Operand::Physical(SCRATCH_ADDR_BASE),
                         });
                     }
                     Some(Allocation::Rematerialize(_)) => {
@@ -800,8 +844,9 @@ impl RegAlloc {
                 offset,
                 width,
             } => {
-                let src_op = Self::load_operand(context, mir, src, Reg::Rdx)?;
-                let base_reg = Self::load_operand(context, mir, Operand::Virtual(base), Reg::Rax)?;
+                let src_op = Self::load_operand(context, mir, src, SCRATCH_ADDR_BASE)?;
+                let base_reg =
+                    Self::load_operand(context, mir, Operand::Virtual(base), SCRATCH_VALUE)?;
                 mir.push(X86Inst::NarrowStoreMR {
                     base: base_reg.as_physical(),
                     src: src_op,
@@ -817,11 +862,11 @@ impl RegAlloc {
                 scale,
                 disp,
             } => {
-                // Load base into a register (use Rdx as scratch to avoid conflicts)
-                let base_op = Self::load_operand(context, mir, base, Reg::Rdx)?;
-                // Load index into a register (use Rcx as scratch)
-                // Note: RSP cannot be used as index in SIB encoding
-                let index_op = Self::load_operand(context, mir, index, Reg::Rcx)?;
+                // The address components go to the dedicated address scratch
+                // registers, which `mir::RESERVED_REGS` keeps out of allocation
+                // so neither can collide with an allocated value (RUE-1146).
+                let base_op = Self::load_operand(context, mir, base, SCRATCH_ADDR_BASE)?;
+                let index_op = Self::load_operand(context, mir, index, SCRATCH_ADDR_INDEX)?;
 
                 match Self::get_allocation(context, dst) {
                     Some(Allocation::Register(reg)) => {
@@ -836,7 +881,7 @@ impl RegAlloc {
                     Some(Allocation::Spill(offset)) => {
                         // Load into scratch register then store
                         mir.push(X86Inst::MovRMSib {
-                            dst: Operand::Physical(Reg::Rax),
+                            dst: Operand::Physical(SCRATCH_VALUE),
                             base: base_op,
                             index: index_op,
                             scale,
@@ -845,7 +890,7 @@ impl RegAlloc {
                         mir.push_after(X86Inst::MovMR {
                             base: Reg::Rbp,
                             offset,
-                            src: Operand::Physical(Reg::Rax),
+                            src: Operand::Physical(SCRATCH_VALUE),
                         });
                     }
                     Some(Allocation::Rematerialize(_)) => {
@@ -870,12 +915,11 @@ impl RegAlloc {
                 disp,
                 src,
             } => {
-                // Load base into a register (use Rdx as scratch)
-                let base_op = Self::load_operand(context, mir, base, Reg::Rdx)?;
-                // Load index into a register (use Rcx as scratch)
-                let index_op = Self::load_operand(context, mir, index, Reg::Rcx)?;
+                // See MovRMSib: the address scratch registers are reserved.
+                let base_op = Self::load_operand(context, mir, base, SCRATCH_ADDR_BASE)?;
+                let index_op = Self::load_operand(context, mir, index, SCRATCH_ADDR_INDEX)?;
                 // Load src value
-                let src_op = Self::load_operand(context, mir, src, Reg::Rax)?;
+                let src_op = Self::load_operand(context, mir, src, SCRATCH_VALUE)?;
 
                 mir.push(X86Inst::MovMRSib {
                     base: base_op,
@@ -887,7 +931,7 @@ impl RegAlloc {
             }
 
             X86Inst::StringConstPtr { dst, string_id } => {
-                alloc_dst!(Self::get_allocation(context, dst), dst, Reg::Rax =>
+                alloc_dst!(Self::get_allocation(context, dst), dst, SCRATCH_VALUE =>
                     emit |dst_op| {
                         mir.push(X86Inst::StringConstPtr { dst: dst_op, string_id });
                     },
@@ -895,14 +939,14 @@ impl RegAlloc {
                         mir.push_after(X86Inst::MovMR {
                             base: Reg::Rbp,
                             offset,
-                            src: Operand::Physical(Reg::Rax),
+                            src: Operand::Physical(SCRATCH_VALUE),
                         });
                     },
                 );
             }
 
             X86Inst::StringConstLen { dst, string_id } => {
-                alloc_dst!(Self::get_allocation(context, dst), dst, Reg::Rax =>
+                alloc_dst!(Self::get_allocation(context, dst), dst, SCRATCH_VALUE =>
                     emit |dst_op| {
                         mir.push(X86Inst::StringConstLen { dst: dst_op, string_id });
                     },
@@ -910,14 +954,14 @@ impl RegAlloc {
                         mir.push_after(X86Inst::MovMR {
                             base: Reg::Rbp,
                             offset,
-                            src: Operand::Physical(Reg::Rax),
+                            src: Operand::Physical(SCRATCH_VALUE),
                         });
                     },
                 );
             }
 
             X86Inst::StringConstCap { dst, string_id } => {
-                alloc_dst!(Self::get_allocation(context, dst), dst, Reg::Rax =>
+                alloc_dst!(Self::get_allocation(context, dst), dst, SCRATCH_VALUE =>
                     emit |dst_op| {
                         mir.push(X86Inst::StringConstCap { dst: dst_op, string_id });
                     },
@@ -925,7 +969,7 @@ impl RegAlloc {
                         mir.push_after(X86Inst::MovMR {
                             base: Reg::Rbp,
                             offset,
-                            src: Operand::Physical(Reg::Rax),
+                            src: Operand::Physical(SCRATCH_VALUE),
                         });
                     },
                 );
@@ -1075,7 +1119,7 @@ impl RegAlloc {
         F: FnOnce(Operand, Operand) -> X86Inst,
     {
         // Load src first (use R10 as scratch to avoid clobbering RAX)
-        let src_op = Self::load_operand(context, mir, src, Reg::R10)?;
+        let src_op = Self::load_operand(context, mir, src, SCRATCH_SOURCE)?;
 
         match Self::get_allocation(context, dst) {
             Some(Allocation::Register(reg)) => {
@@ -1084,17 +1128,17 @@ impl RegAlloc {
             Some(Allocation::Spill(offset)) => {
                 // Load dst from stack to RAX
                 mir.push(X86Inst::MovRM {
-                    dst: Operand::Physical(Reg::Rax),
+                    dst: Operand::Physical(SCRATCH_VALUE),
                     base: Reg::Rbp,
                     offset,
                 });
                 // Perform operation
-                mir.push(make_inst(Operand::Physical(Reg::Rax), src_op));
+                mir.push(make_inst(Operand::Physical(SCRATCH_VALUE), src_op));
                 // Store result back to stack
                 mir.push_after(X86Inst::MovMR {
                     base: Reg::Rbp,
                     offset,
-                    src: Operand::Physical(Reg::Rax),
+                    src: Operand::Physical(SCRATCH_VALUE),
                 });
             }
             Some(Allocation::Rematerialize(_)) => {
@@ -1124,17 +1168,17 @@ impl RegAlloc {
             Some(Allocation::Spill(offset)) => {
                 // Load from stack
                 mir.push(X86Inst::MovRM {
-                    dst: Operand::Physical(Reg::Rax),
+                    dst: Operand::Physical(SCRATCH_VALUE),
                     base: Reg::Rbp,
                     offset,
                 });
                 // Perform operation
-                mir.push(make_inst(Operand::Physical(Reg::Rax)));
+                mir.push(make_inst(Operand::Physical(SCRATCH_VALUE)));
                 // Store back
                 mir.push_after(X86Inst::MovMR {
                     base: Reg::Rbp,
                     offset,
-                    src: Operand::Physical(Reg::Rax),
+                    src: Operand::Physical(SCRATCH_VALUE),
                 });
             }
             Some(Allocation::Rematerialize(_)) => {
@@ -1162,15 +1206,15 @@ impl RegAlloc {
             }
             Some(Allocation::Spill(offset)) => {
                 mir.push(X86Inst::MovRM {
-                    dst: Operand::Physical(Reg::Rax),
+                    dst: Operand::Physical(SCRATCH_VALUE),
                     base: Reg::Rbp,
                     offset,
                 });
-                mir.push(make_inst(Operand::Physical(Reg::Rax), imm));
+                mir.push(make_inst(Operand::Physical(SCRATCH_VALUE), imm));
                 mir.push_after(X86Inst::MovMR {
                     base: Reg::Rbp,
                     offset,
-                    src: Operand::Physical(Reg::Rax),
+                    src: Operand::Physical(SCRATCH_VALUE),
                 });
             }
             Some(Allocation::Rematerialize(_)) => {
@@ -1198,15 +1242,15 @@ impl RegAlloc {
             }
             Some(Allocation::Spill(offset)) => {
                 mir.push(X86Inst::MovRM {
-                    dst: Operand::Physical(Reg::Rax),
+                    dst: Operand::Physical(SCRATCH_VALUE),
                     base: Reg::Rbp,
                     offset,
                 });
-                mir.push(make_inst(Operand::Physical(Reg::Rax), imm));
+                mir.push(make_inst(Operand::Physical(SCRATCH_VALUE), imm));
                 mir.push_after(X86Inst::MovMR {
                     base: Reg::Rbp,
                     offset,
-                    src: Operand::Physical(Reg::Rax),
+                    src: Operand::Physical(SCRATCH_VALUE),
                 });
             }
             Some(Allocation::Rematerialize(_)) => {
@@ -1233,11 +1277,11 @@ impl RegAlloc {
             }
             Some(Allocation::Spill(offset)) => {
                 // setcc writes a byte, so we use RAX and store
-                mir.push(make_inst(Operand::Physical(Reg::Rax)));
+                mir.push(make_inst(Operand::Physical(SCRATCH_VALUE)));
                 mir.push_after(X86Inst::MovMR {
                     base: Reg::Rbp,
                     offset,
-                    src: Operand::Physical(Reg::Rax),
+                    src: Operand::Physical(SCRATCH_VALUE),
                 });
             }
             Some(Allocation::Rematerialize(_)) => {
@@ -1325,8 +1369,11 @@ impl RegAllocBackend for X86Backend {
             .collect()
     }
 
-    fn allocatable_regs() -> &'static [Self::Reg] {
-        ALLOCATABLE_REGS
+    fn register_classes() -> RegisterClasses<'static, Self::Reg> {
+        RegisterClasses {
+            caller_saved: CALLER_SAVED_REGS,
+            callee_saved: CALLEE_SAVED_REGS,
+        }
     }
 
     fn new_mir() -> Self::Mir {
@@ -1361,7 +1408,10 @@ impl RegAllocBackend for X86Backend {
 #[cfg(test)]
 mod tests {
     use super::liveness;
-    use super::{ALLOCATABLE_REGS, Operand, Reg, RegAlloc, VReg, X86Inst, X86Mir};
+    use super::{
+        ALLOCATABLE_REGS, CALLEE_SAVED_REGS, CALLER_SAVED_REGS, Operand, Reg, RegAlloc, VReg,
+        X86Inst, X86Mir,
+    };
     use crate::regalloc::{Allocation, RematerializeOp};
 
     fn define_loaded_values(mir: &mut X86Mir, vregs: &[VReg]) {
@@ -1386,10 +1436,11 @@ mod tests {
 
         let mir = RegAlloc::new(mir, 0).allocate().unwrap();
 
-        // v0 should be allocated to R12 (first allocatable)
+        // v0 should be allocated to the first allocatable register, which is
+        // caller-saved: nothing clobbers it while v0 is live (RUE-1146).
         match &mir.instructions()[0] {
             X86Inst::MovRI32 { dst, imm } => {
-                assert_eq!(dst, &Operand::Physical(Reg::R12));
+                assert_eq!(dst, &Operand::Physical(ALLOCATABLE_REGS[0]));
                 assert_eq!(*imm, 42);
             }
             _ => panic!("expected MovRI32"),
@@ -1437,12 +1488,12 @@ mod tests {
 
         let mir = RegAlloc::new(mir, 0).allocate().unwrap();
 
-        // Both can be allocated to R12 since they don't interfere
+        // Both can be allocated to the same register since they don't interfere
         match (&mir.instructions()[0], &mir.instructions()[1]) {
             (X86Inst::MovRI32 { dst: d0, .. }, X86Inst::MovRI32 { dst: d1, .. }) => {
-                // They should both get R12 since v0 is dead before v1 is defined
-                assert_eq!(d0, &Operand::Physical(Reg::R12));
-                assert_eq!(d1, &Operand::Physical(Reg::R12));
+                // v0 is dead before v1 is defined, so both get the first register
+                assert_eq!(d0, &Operand::Physical(ALLOCATABLE_REGS[0]));
+                assert_eq!(d1, &Operand::Physical(ALLOCATABLE_REGS[0]));
             }
             _ => panic!("expected two MovRI32"),
         }
@@ -1558,8 +1609,10 @@ mod tests {
         // Force a spill and verify load/store instructions are inserted
         let mut mir = X86Mir::new();
 
-        // Create 6 vregs to force spilling (only 5 allocatable regs: R12-R15, Rbx)
-        let vregs: Vec<VReg> = (0..6).map(|_| mir.alloc_vreg()).collect();
+        // One more simultaneously-live value than there are registers
+        let vregs: Vec<VReg> = (0..ALLOCATABLE_REGS.len() + 1)
+            .map(|_| mir.alloc_vreg())
+            .collect();
 
         define_loaded_values(&mut mir, &vregs);
 
@@ -1616,20 +1669,23 @@ mod tests {
     #[test]
     fn test_production_rematerializes_constants_and_strings_without_spills() {
         let mut mir = X86Mir::new();
-        let vregs: Vec<VReg> = (0..7).map(|_| mir.alloc_vreg()).collect();
+        // Two more simultaneously-live values than there are registers, so the
+        // callee-saved-only baseline below has to spill exactly twice.
+        let count = ALLOCATABLE_REGS.len() + 2;
+        let vregs: Vec<VReg> = (0..count).map(|_| mir.alloc_vreg()).collect();
 
-        for (index, &vreg) in vregs[..5].iter().enumerate() {
+        for (index, &vreg) in vregs[..count - 2].iter().enumerate() {
             mir.push(X86Inst::MovRI32 {
                 dst: Operand::Virtual(vreg),
                 imm: index as i32,
             });
         }
         mir.push(X86Inst::StringConstPtr {
-            dst: Operand::Virtual(vregs[5]),
+            dst: Operand::Virtual(vregs[count - 2]),
             string_id: 7,
         });
         mir.push(X86Inst::MovRI64 {
-            dst: Operand::Virtual(vregs[6]),
+            dst: Operand::Virtual(vregs[count - 1]),
             imm: 99,
         });
         for &vreg in &vregs {
@@ -1832,6 +1888,139 @@ mod tests {
     }
 
     #[test]
+    fn caller_saved_registers_absorb_pressure_before_spilling() {
+        // A call-free function with more simultaneously-live values than there
+        // are callee-saved registers still fits in registers, because the
+        // caller-saved class is available to it (RUE-1146).
+        let mut mir = X86Mir::new();
+        let vregs: Vec<VReg> = (0..ALLOCATABLE_REGS.len())
+            .map(|_| mir.alloc_vreg())
+            .collect();
+
+        define_loaded_values(&mut mir, &vregs);
+        for &vreg in &vregs {
+            mir.push(X86Inst::MovRR {
+                dst: Operand::Physical(Reg::Rdi),
+                src: Operand::Virtual(vreg),
+            });
+        }
+
+        assert!(
+            vregs.len() > CALLEE_SAVED_REGS.len(),
+            "the fixture must exceed what the callee-saved class alone can hold"
+        );
+
+        let (mir, num_spills, used_callee_saved) =
+            RegAlloc::new(mir, 0).allocate_with_spills().unwrap();
+
+        assert_eq!(num_spills, 0, "every value should fit in a register");
+        assert!(
+            !mir.instructions().iter().any(|inst| matches!(
+                inst,
+                X86Inst::MovMR { base: Reg::Rbp, .. } | X86Inst::MovRM { base: Reg::Rbp, .. }
+            )),
+            "no value should touch the frame"
+        );
+
+        let assigned: Vec<Reg> = mir
+            .instructions()
+            .iter()
+            .filter_map(|inst| match inst {
+                X86Inst::MovRM {
+                    dst: Operand::Physical(reg),
+                    base: Reg::Rsi,
+                    ..
+                } => Some(*reg),
+                _ => None,
+            })
+            .collect();
+        for &reg in CALLER_SAVED_REGS {
+            assert!(
+                assigned.contains(&reg),
+                "the caller-saved class should be used before spilling, missing {reg}"
+            );
+        }
+        for &reg in &used_callee_saved {
+            assert!(
+                CALLEE_SAVED_REGS.contains(&reg),
+                "only callee-saved registers oblige the prologue, got {reg}"
+            );
+        }
+    }
+
+    #[test]
+    fn call_free_function_saves_no_callee_saved_registers() {
+        // With the caller-saved class available, a small call-free function
+        // needs nothing preserved across its own body, so frame planning sees
+        // an empty callee-saved set (RUE-1146, and the reason RUE-1195 had to
+        // land first).
+        let mut mir = X86Mir::new();
+        let vregs: Vec<VReg> = (0..CALLER_SAVED_REGS.len())
+            .map(|_| mir.alloc_vreg())
+            .collect();
+
+        define_loaded_values(&mut mir, &vregs);
+        for &vreg in &vregs {
+            mir.push(X86Inst::MovRR {
+                dst: Operand::Physical(Reg::Rdi),
+                src: Operand::Virtual(vreg),
+            });
+        }
+
+        let (_, num_spills, used_callee_saved) =
+            RegAlloc::new(mir, 0).allocate_with_spills().unwrap();
+
+        assert_eq!(num_spills, 0);
+        assert!(
+            used_callee_saved.is_empty(),
+            "a call-free function this small should save nothing, got {used_callee_saved:?}"
+        );
+    }
+
+    #[test]
+    fn cross_call_values_never_take_a_caller_saved_register() {
+        // Every value here is defined before a call and used after it, so none
+        // may live in a caller-saved register — the call destroys them all.
+        let mut mir = X86Mir::new();
+        let symbol = mir.intern_symbol("callee");
+        let vregs: Vec<VReg> = (0..ALLOCATABLE_REGS.len())
+            .map(|_| mir.alloc_vreg())
+            .collect();
+
+        define_loaded_values(&mut mir, &vregs);
+        mir.push(X86Inst::CallRel { symbol_id: symbol });
+        for &vreg in &vregs {
+            mir.push(X86Inst::MovRR {
+                dst: Operand::Physical(Reg::Rdi),
+                src: Operand::Virtual(vreg),
+            });
+        }
+
+        let (mir, num_spills, used_callee_saved) =
+            RegAlloc::new(mir, 0).allocate_with_spills().unwrap();
+
+        // One more value than the callee-saved class holds, so exactly one
+        // spills rather than borrowing a caller-saved register.
+        assert_eq!(num_spills as usize, CALLER_SAVED_REGS.len());
+        for &reg in &used_callee_saved {
+            assert!(CALLEE_SAVED_REGS.contains(&reg));
+        }
+        for inst in mir.instructions() {
+            if let X86Inst::MovRM {
+                dst: Operand::Physical(reg),
+                base: Reg::Rsi,
+                ..
+            } = inst
+            {
+                assert!(
+                    !CALLER_SAVED_REGS.contains(reg),
+                    "a value live across a call must not be in caller-saved {reg}"
+                );
+            }
+        }
+    }
+
+    #[test]
     fn test_call_survival_and_symbol_reconstruction() {
         let mut mir = X86Mir::new();
         let value = mir.alloc_vreg();
@@ -1860,10 +2049,10 @@ mod tests {
             })
             .expect("value definition should be physical");
 
-        assert!(matches!(
-            value_reg,
-            Reg::Rbx | Reg::R12 | Reg::R13 | Reg::R14 | Reg::R15
-        ));
+        assert!(
+            CALLEE_SAVED_REGS.contains(&value_reg),
+            "a value live across a call must land in a callee-saved register, got {value_reg}"
+        );
         assert!(
             mir.instructions()
                 .iter()
@@ -1882,7 +2071,9 @@ mod tests {
     #[test]
     fn test_loop_pressure_uses_loop_aware_spilling() {
         let mut mir = X86Mir::new();
-        let vregs: Vec<VReg> = (0..6).map(|_| mir.alloc_vreg()).collect();
+        let vregs: Vec<VReg> = (0..ALLOCATABLE_REGS.len() + 1)
+            .map(|_| mir.alloc_vreg())
+            .collect();
         let loop_label = mir.alloc_label();
 
         define_loaded_values(&mut mir, &vregs);
@@ -1904,8 +2095,10 @@ mod tests {
         }
 
         let loop_info = liveness::analyze_loops(&mir);
+        // The loop body starts one instruction past the label, which the
+        // per-value loads above precede.
         assert!(
-            loop_info.depth(7) > 0,
+            loop_info.depth(vregs.len() + 1) > 0,
             "loop body should have nonzero depth"
         );
 
@@ -1958,8 +2151,10 @@ mod tests {
         // Force multiple spills and verify they get unique stack offsets
         let mut mir = X86Mir::new();
 
-        // Create 10 vregs to force 5 spills
-        let vregs: Vec<VReg> = (0..10).map(|_| mir.alloc_vreg()).collect();
+        // Five more simultaneously-live values than there are registers
+        let vregs: Vec<VReg> = (0..ALLOCATABLE_REGS.len() + 5)
+            .map(|_| mir.alloc_vreg())
+            .collect();
 
         define_loaded_values(&mut mir, &vregs);
 
@@ -2009,16 +2204,14 @@ mod tests {
         // Test that spills are placed after existing local variables
         let mut mir = X86Mir::new();
 
-        let v0 = mir.alloc_vreg();
-        let v1 = mir.alloc_vreg();
-        let v2 = mir.alloc_vreg();
-        let v3 = mir.alloc_vreg();
-        let v4 = mir.alloc_vreg();
-        let v5 = mir.alloc_vreg();
+        // One more simultaneously-live value than there are registers
+        let vregs: Vec<VReg> = (0..ALLOCATABLE_REGS.len() + 1)
+            .map(|_| mir.alloc_vreg())
+            .collect();
 
         // Define and use all vregs.
-        define_loaded_values(&mut mir, &[v0, v1, v2, v3, v4, v5]);
-        for vreg in [v0, v1, v2, v3, v4, v5] {
+        define_loaded_values(&mut mir, &vregs);
+        for &vreg in &vregs {
             mir.push(X86Inst::MovRR {
                 dst: Operand::Physical(Reg::Rdi),
                 src: Operand::Virtual(vreg),
@@ -2057,8 +2250,10 @@ mod tests {
         // Test a function with many virtual registers causing a large stack frame
         let mut mir = X86Mir::new();
 
-        // Create 20 vregs (5 registers + 15 spills)
-        let vregs: Vec<VReg> = (0..20).map(|_| mir.alloc_vreg()).collect();
+        // Fifteen more simultaneously-live values than there are registers
+        let vregs: Vec<VReg> = (0..ALLOCATABLE_REGS.len() + 15)
+            .map(|_| mir.alloc_vreg())
+            .collect();
 
         define_loaded_values(&mut mir, &vregs);
 
@@ -2099,8 +2294,10 @@ mod tests {
         // Test spilling with many existing local variables
         let mut mir = X86Mir::new();
 
-        // 6 vregs forces 1 spill
-        let vregs: Vec<VReg> = (0..6).map(|_| mir.alloc_vreg()).collect();
+        // One more simultaneously-live value than there are registers
+        let vregs: Vec<VReg> = (0..ALLOCATABLE_REGS.len() + 1)
+            .map(|_| mir.alloc_vreg())
+            .collect();
 
         define_loaded_values(&mut mir, &vregs);
         for vreg in &vregs {
@@ -2136,8 +2333,10 @@ mod tests {
         // Test that binary operations work correctly when operands are spilled
         let mut mir = X86Mir::new();
 
-        // Create enough vregs to force spilling
-        let vregs: Vec<VReg> = (0..8).map(|_| mir.alloc_vreg()).collect();
+        // Three more simultaneously-live values than there are registers
+        let vregs: Vec<VReg> = (0..ALLOCATABLE_REGS.len() + 3)
+            .map(|_| mir.alloc_vreg())
+            .collect();
 
         define_loaded_values(&mut mir, &vregs);
 
@@ -2170,12 +2369,15 @@ mod tests {
     #[test]
     fn test_spilled_binary_destination_has_ordered_rewrite() {
         let mut mir = X86Mir::new();
-        let vregs: Vec<VReg> = (0..7).map(|_| mir.alloc_vreg()).collect();
+        // The first value is never used again, so `count` must exceed the
+        // register count by two for the rest to outnumber the registers.
+        let count = ALLOCATABLE_REGS.len() + 2;
+        let vregs: Vec<VReg> = (0..count).map(|_| mir.alloc_vreg()).collect();
 
         define_loaded_values(&mut mir, &vregs);
         mir.push(X86Inst::AddRR {
-            dst: Operand::Virtual(vregs[6]),
-            src: Operand::Virtual(vregs[5]),
+            dst: Operand::Virtual(vregs[count - 1]),
+            src: Operand::Virtual(vregs[count - 2]),
         });
         for &vreg in &vregs[1..] {
             mir.push(X86Inst::MovRR {

--- a/crates/rue-spec/cases/golden/ir-dumps.toml
+++ b/crates/rue-spec/cases/golden/ir-dumps.toml
@@ -903,14 +903,14 @@ bb0:
 [[case]]
 name = "simple_return_stackframe"
 spec = ["2.1:1"]
+description = "The constant dies before the exit call, so it lives in a caller-saved register and the frame saves nothing (RUE-1146). The prologue is still emitted, because a calling function needs it to keep RSP 16-byte aligned at the call site (RUE-1195)."
 source = "fn main() -> i32 { 42 }"
 target = "x86-64-linux"
 expected_stackframe = """
-Frame size: 16 bytes
+Frame size: 0 bytes
 Alignment: 16 bytes
 
 Layout (rbp-relative):
-  [rbp  -8] : saved r12 (callee-saved)
 
 Return: rax (Type::I32)
 """

--- a/docs/notes/ffi-abi-conformance-audit.md
+++ b/docs/notes/ffi-abi-conformance-audit.md
@@ -92,13 +92,20 @@ be exposed as C entry points without a target-C lowering path.
 
 The x86-64 allocator uses `rbx` and `r12`-`r15` for values live across calls;
 generated prologues save and restore every used callee-saved register along with
-`rbp`. It does not use the 128-byte System V red zone. Rue emits no direction-
+`rbp`. It also allocates the caller-saved `r11` to values that survive no call,
+which conforms: a caller-saved register carries no obligation across a call
+boundary, and a value in one never crosses one. Every other caller-saved
+register is reserved for a fixed instruction operand, an ABI position, or
+rewrite scratch. The allocator does not use the 128-byte System V red zone. Rue emits no direction-
 flag-setting, x87, or MMX operations; a conforming clear direction flag remains
 clear on return.
 
 The AArch64 allocator uses `x19`-`x28` for values live across calls and preserves
-them along with frame pointer and link register. It avoids the platform register
-`x18` and veneer scratch registers `x16`/`x17`. Vector registers are currently
+them along with frame pointer and link register. It also allocates the
+caller-saved `x13` and `x14` to values that survive no call; the remaining
+caller-saved temporaries `x9`-`x12` and `x15` are rewrite and address scratch.
+It avoids the indirect-result register `x8`, the platform register `x18`, and
+veneer scratch registers `x16`/`x17`. Vector registers are currently
 unused. The stack pointer remains 16-byte aligned, and generated code does not
 access memory below `sp`. Condition flags are caller-clobbered.
 


### PR DESCRIPTION
Both backends allocated from callee-saved registers only, while liveness computed per-position call-clobber data that nothing consulted (`clobbers_at` / `is_clobbered_during` had zero call sites). This wires that data into interval assignment — standard linear-scan practice: caller-saved for intervals no call crosses, callee-saved otherwise.

**Policy.** A new `ClobberIndex` (prefix-count over the clobber events, O(1) per query — the naive range scan would reintroduce the RUE-302 quadratic shape) gates both the free-register choice and the eviction path: a register freed by spilling its occupant is handed to the arriving interval only if that interval survives everything the register does not. Caller-saved registers never reach the prologue save list, so call-free functions also shed their callee-saved saves. No live-range splitting — this is a policy widening, not an allocator rewrite.

**Register roles are now named and compile-time-gated.** Every role both backends enforced by comment — ABI argument/return sets, rewrite and address scratch, the x86-64 shift-count `cl` — is a named constant, with `const` assertions proving the allocatable, reserved, and ABI sets stay disjoint. Moving a scratch role onto an allocatable register now fails to compile. The exclusion table pins every register: x86-64 gains exactly **R11** (Rax/Rdx/Rcx carry div/shift/scratch roles, the rest are ABI), AArch64 gains **X13/X14** (X9–X12 rewrite scratch, X15 address scratch, X16–X18 platform). ABI argument/return registers are deliberately excluded: liveness models call clobbers but not the physical defs/uses of argument marshalling, so no clobber test can make them safe under the current model.

**RUE-1195 verified, not re-fixed**: the frame-emission fix this widening makes load-bearing already landed (`2408a63d`) — a zero-slot calling function with no callee-saved registers, previously unconstructible and now produced for `fn main() -> i32 { 42 }`, keeps its prologue and call-site alignment. Verified against that issue's acceptance criteria in this tree.

Also widened conservatively while touching the model: the AArch64 `Svc` clobber list understated the Darwin syscall boundary (only X0/X8/X16); it now covers X9–X15/X17 so the new allocatable registers aren't exposed on macOS (refs RUE-1195; a per-target narrowing is possible follow-up work).

Measured: executable segments shrink 0.59% across the 21-example corpus (spill traffic drops where pressure was high — `life` −592 bytes); cross-call allocation is byte-identical by policy and demonstrated in the emitted assembly.

Fixes RUE-1146.

## Validation

Premerge tier ×2 (78/78 both), full spec (2242), codegen units 648 / cfg 237, quick (re-run post-rebase), CLI `abi`/`borrow`/`multi`/`emit` + the caldera stress example, differential oracle + generated-oracle smoke, reproducible-programs, clippy, fmt. New coverage: `ClobberIndex` boundary tests, two `linear_scan_impl` policy tests, three per-backend pressure/cross-call tests, spill tests re-expressed against `ALLOCATABLE_REGS.len()`, and an `assert_widened_allocation` parity fixture. AArch64 validated by cross-compiled assembly inspection locally; native execution is CI's.

---
_Generated by [Claude Code](https://claude.ai/code/session_01DrKqpQgkHzDHGqpEMjxYdN)_