### PR TITLE
Index member lookups and share metadata strings

### DIFF
--- a/crates/rue-air-profile/src/main.rs
+++ b/crates/rue-air-profile/src/main.rs
@@ -480,7 +480,7 @@ fn profile_families() -> Value {
         symbols.get_or_intern("ProfileEnum"),
         EnumDef {
             name: "ProfileEnum".into(),
-            variants: vec!["Only".into()],
+            variants: std::sync::Arc::from(["Only".into()]),
             variant_payloads: vec![vec![Type::I32; 64]],
             is_pub: false,
             file_id: rue_span::FileId::DEFAULT,

--- a/crates/rue-air/src/drop_glue_names.rs
+++ b/crates/rue-air/src/drop_glue_names.rs
@@ -81,6 +81,8 @@ pub fn type_name(ty: Type, type_pool: &FrozenTypeInternPool) -> String {
 
 #[cfg(test)]
 mod tests {
+    use std::sync::Arc;
+
     use lasso::ThreadedRodeo;
 
     use super::*;
@@ -98,7 +100,7 @@ mod tests {
             .register_struct(
                 symbol,
                 StructDef {
-                    name: name.to_string(),
+                    name: name.into(),
                     fields,
                     is_copy: false,
                     is_linear: false,
@@ -122,8 +124,8 @@ mod tests {
             .register_enum(
                 symbol,
                 EnumDef {
-                    name: name.to_string(),
-                    variants: vec!["Only".to_string()],
+                    name: name.into(),
+                    variants: Arc::from(["Only".into()]),
                     variant_payloads: vec![vec![]],
                     is_pub: false,
                     file_id,

--- a/crates/rue-air/src/inference/generate.rs
+++ b/crates/rue-air/src/inference/generate.rs
@@ -619,7 +619,7 @@ impl<'a> ConstraintGenerator<'a> {
         if let InferType::Concrete(t) = ty
             && let Some(id) = t.as_struct()
         {
-            let name = &self.type_pool.struct_def(id).name;
+            let name: &str = &self.type_pool.struct_def(id).name;
             return name == "str"
                 || (name.starts_with("Str(") && name.ends_with(')'))
                 || (name.starts_with('[')
@@ -3387,7 +3387,7 @@ impl<'a> ConstraintGenerator<'a> {
     fn string_literal_default_is_str(&self) -> bool {
         self.string_literal_default
             .as_struct()
-            .is_some_and(|id| self.type_pool.struct_def(id).name == "str")
+            .is_some_and(|id| &*self.type_pool.struct_def(id).name == "str")
     }
 
     /// Generate constraints for a type-qualified call — an associated-function

--- a/crates/rue-air/src/inst.rs
+++ b/crates/rue-air/src/inst.rs
@@ -3816,6 +3816,8 @@ impl Air {
 
 #[cfg(test)]
 mod tests {
+    use std::sync::Arc;
+
     use super::*;
 
     #[test]
@@ -4195,7 +4197,7 @@ mod tests {
             interner.get_or_intern("Choice"),
             crate::EnumDef {
                 name: "Choice".into(),
-                variants: vec!["Only".into()],
+                variants: Arc::from(["Only".into()]),
                 variant_payloads: Vec::new(),
                 is_pub: false,
                 file_id: rue_span::FileId::DEFAULT,
@@ -4239,7 +4241,7 @@ mod tests {
             interner.get_or_intern("Choice"),
             crate::EnumDef {
                 name: "Choice".into(),
-                variants: vec!["Only".into()],
+                variants: Arc::from(["Only".into()]),
                 variant_payloads: Vec::new(),
                 is_pub: false,
                 file_id: rue_span::FileId::DEFAULT,

--- a/crates/rue-air/src/intern_pool.rs
+++ b/crates/rue-air/src/intern_pool.rs
@@ -27,6 +27,7 @@
 //! - Write lock for insertions (rare, during declaration gathering)
 
 use std::collections::{HashMap, HashSet};
+use std::ops::Deref;
 use std::sync::{Arc, PoisonError, RwLock};
 
 use lasso::Spur;
@@ -36,8 +37,8 @@ use crate::layout::{Layout, LayoutKind, PaddingRange};
 use crate::path_norm::{mangle_symbol_component, normalize_module_path};
 use crate::type_encoding;
 use crate::types::{
-    ArrayTypeId, EnumDef, EnumId, LangItem, PtrConstTypeId, PtrMutTypeId, StructDef, StructId,
-    Type, TypeKind,
+    ArrayTypeId, EnumDef, EnumId, LangItem, PtrConstTypeId, PtrMutTypeId, StructDef, StructField,
+    StructId, Type, TypeKind,
 };
 
 /// Type data stored in the intern pool.
@@ -221,6 +222,164 @@ impl ValidationMode {
     }
 }
 
+/// Declaration-order lookup for a nominal's member names.
+///
+/// A struct's fields and an enum's variants are fixed when the definition is
+/// installed, so the position of every member name is known once and never
+/// changes. Building it there replaces the per-lookup walk of `String`
+/// comparisons the bare definitions used with one hash and a binary search
+/// (RUE-1219).
+///
+/// The index stores `(name hash, declaration position)` sorted by hash rather
+/// than owning the names: one allocation per nominal instead of one per member,
+/// which matters because installation is the common case and lookup is the rare
+/// one for small nominals. A probe therefore *proposes* positions and the caller
+/// confirms each against the real member name, so a hash collision costs an
+/// extra comparison and never a wrong answer.
+///
+/// A duplicate name resolves to the *first* declaration position, matching the
+/// linear scan this replaces: duplicates are a declaration error reported
+/// elsewhere, and until then both resolve the way they always did.
+#[derive(Clone, Default)]
+struct MemberNameIndex {
+    /// `(hash, position)` sorted by hash, then by position so equal-hash runs
+    /// stay in declaration order.
+    entries: Box<[(u64, u32)]>,
+}
+
+impl MemberNameIndex {
+    /// FNV-1a. Chosen for being short enough to inline over the two-to-ten
+    /// byte member names that dominate, and fixed rather than randomly seeded
+    /// so a pool built twice from the same declarations probes identically.
+    fn hash(name: &str) -> u64 {
+        let mut hash = 0xcbf2_9ce4_8422_2325u64;
+        for byte in name.as_bytes() {
+            hash ^= u64::from(*byte);
+            hash = hash.wrapping_mul(0x0000_0100_0000_01b3);
+        }
+        hash
+    }
+
+    fn build<'a>(names: impl ExactSizeIterator<Item = &'a str>) -> Self {
+        let mut entries: Vec<(u64, u32)> = names
+            .enumerate()
+            .map(|(position, name)| (Self::hash(name), position as u32))
+            .collect();
+        entries.sort_unstable();
+        Self {
+            entries: entries.into_boxed_slice(),
+        }
+    }
+
+    /// The declaration positions whose member name hashes to `name`'s hash, in
+    /// declaration order. Callers confirm the name itself.
+    fn candidates(&self, name: &str) -> impl Iterator<Item = usize> + '_ {
+        let hash = Self::hash(name);
+        let start = self.entries.partition_point(|(entry, _)| *entry < hash);
+        self.entries[start..]
+            .iter()
+            .take_while(move |(entry, _)| *entry == hash)
+            .map(|(_, position)| *position as usize)
+    }
+}
+
+/// A struct definition as the pool stores it: the definition plus the field
+/// lookup built from it.
+///
+/// The index travels with the definition rather than living beside it in the
+/// pool entry, so a reader that already holds the shared definition resolves a
+/// field name without reacquiring the pool lock, and the frozen pool's
+/// borrow-returning reads get the same lookup (RUE-1219).
+///
+/// Only destructor assignment, destructor requalification, and the linearity
+/// marker mutate an installed definition, and none of them touch `fields`;
+/// [`StructDefEntry::metadata_mut`] is the narrow door they go through, so the
+/// index cannot drift from the fields it indexes.
+#[derive(Clone)]
+pub struct StructDefEntry {
+    def: StructDef,
+    field_index: MemberNameIndex,
+}
+
+impl StructDefEntry {
+    pub(crate) fn new(def: StructDef) -> Self {
+        let field_index =
+            MemberNameIndex::build(def.fields.iter().map(|field| field.name.as_str()));
+        Self { def, field_index }
+    }
+
+    /// Find a field by name and return its declaration index and definition.
+    pub fn find_field(&self, name: &str) -> Option<(usize, &StructField)> {
+        self.field_index
+            .candidates(name)
+            .map(|index| (index, &self.def.fields[index]))
+            .find(|(_, field)| field.name == name)
+    }
+
+    /// Mutable access to the declaration metadata of an installed definition.
+    ///
+    /// Callers may update drop and linearity metadata only. Replacing `fields`
+    /// would invalidate the field index built at installation.
+    fn metadata_mut(&mut self) -> &mut StructDef {
+        &mut self.def
+    }
+}
+
+impl Deref for StructDefEntry {
+    type Target = StructDef;
+
+    fn deref(&self) -> &StructDef {
+        &self.def
+    }
+}
+
+/// The lookup index is derived from `fields` and carries no information the
+/// definition does not already state, so it stays out of the rendering that
+/// durable-output comparisons hash and diff.
+impl std::fmt::Debug for StructDefEntry {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.def.fmt(f)
+    }
+}
+
+/// An enum definition as the pool stores it: the definition plus the variant
+/// lookup built from it. See [`StructDefEntry`].
+#[derive(Clone)]
+pub struct EnumDefEntry {
+    def: EnumDef,
+    variant_index: MemberNameIndex,
+}
+
+impl EnumDefEntry {
+    pub(crate) fn new(def: EnumDef) -> Self {
+        let variant_index =
+            MemberNameIndex::build(def.variants.iter().map(|variant| variant.as_ref()));
+        Self { def, variant_index }
+    }
+
+    /// Find a variant by name and return its declaration index.
+    pub fn find_variant(&self, name: &str) -> Option<usize> {
+        self.variant_index
+            .candidates(name)
+            .find(|&index| &*self.def.variants[index] == name)
+    }
+}
+
+impl Deref for EnumDefEntry {
+    type Target = EnumDef;
+
+    fn deref(&self) -> &EnumDef {
+        &self.def
+    }
+}
+
+/// See [`StructDefEntry`]'s `Debug`: the variant index is derived state.
+impl std::fmt::Debug for EnumDefEntry {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.def.fmt(f)
+    }
+}
+
 /// Data for a struct type in the intern pool.
 ///
 /// The pool entry for a nominal struct and its definition.
@@ -237,7 +396,7 @@ pub struct StructData {
     /// The name symbol (interned string).
     pub name: Spur,
     /// The canonical struct definition stored at this pool index.
-    pub def: Arc<StructDef>,
+    pub def: Arc<StructDefEntry>,
 }
 
 /// Data for an enum type in the intern pool.
@@ -249,19 +408,24 @@ pub struct EnumData {
     /// The name symbol (interned string).
     pub name: Spur,
     /// The canonical enum definition stored at this pool index.
-    pub def: Arc<EnumDef>,
+    pub def: Arc<EnumDefEntry>,
 }
 
 /// Declaration-only struct metadata available before field resolution.
 ///
 /// Fields are deliberately absent so declaration consumers cannot mistake a
 /// nominal shell for a complete definition.
+///
+/// The names are shared handles, not copies: the pool cannot lend a borrow
+/// across its `RwLock`, and most readers want only `file_id`, `is_pub`, or a
+/// drop fact, so a read is a pair of refcount bumps rather than two string
+/// allocations (RUE-1219).
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct StructDeclarationMetadata {
-    pub name: String,
+    pub name: Arc<str>,
     pub is_copy: bool,
     pub is_linear: bool,
-    pub destructor: Option<String>,
+    pub destructor: Option<Arc<str>>,
     pub is_builtin: bool,
     pub is_pub: bool,
     pub file_id: FileId,
@@ -270,11 +434,12 @@ pub(crate) struct StructDeclarationMetadata {
 /// Declaration-only enum metadata available before payload resolution.
 ///
 /// Variant names are declaration metadata; payloads are intentionally absent
-/// until the enum reaches the complete state.
+/// until the enum reaches the complete state. Names are shared for the same
+/// reason as [`StructDeclarationMetadata`].
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct EnumDeclarationMetadata {
-    pub name: String,
-    pub variants: Vec<String>,
+    pub name: Arc<str>,
+    pub variants: Arc<[Arc<str>]>,
     pub is_pub: bool,
     pub file_id: FileId,
 }
@@ -778,8 +943,8 @@ impl TypeInternPoolInner {
             .copied()
             .chain(std::iter::once(repeated))
             .filter_map(|index| match self.entry(index) {
-                TypeData::Struct(data) => Some(data.def.name.clone()),
-                TypeData::Enum(data) => Some(data.def.name.clone()),
+                TypeData::Struct(data) => Some(data.def.name.to_string()),
+                TypeData::Enum(data) => Some(data.def.name.to_string()),
                 TypeData::Array { .. }
                 | TypeData::PtrConst { .. }
                 | TypeData::PtrMut { .. }
@@ -916,7 +1081,7 @@ impl TypeInternPoolInner {
                 && value.carries_linear
                 && let TypeData::Struct(data) = self.entry_mut(index)
             {
-                Arc::make_mut(&mut data.def).is_linear = true;
+                Arc::make_mut(&mut data.def).metadata_mut().is_linear = true;
             }
         }
         for (index, value) in facts.into_iter().enumerate() {
@@ -1000,7 +1165,7 @@ impl TypeInternPoolInner {
         self.entry(index as usize)
     }
 
-    fn try_struct_def(&self, id: StructId) -> Option<&StructDef> {
+    fn try_struct_def(&self, id: StructId) -> Option<&StructDefEntry> {
         self.try_struct_def_arc(id).map(Arc::as_ref)
     }
 
@@ -1009,7 +1174,7 @@ impl TypeInternPoolInner {
     /// Callers that cannot hold a borrow — the mutable pool's accessors, which
     /// would otherwise leak `RwLock` scope — clone this handle instead of the
     /// definition it points at.
-    fn try_struct_def_arc(&self, id: StructId) -> Option<&Arc<StructDef>> {
+    fn try_struct_def_arc(&self, id: StructId) -> Option<&Arc<StructDefEntry>> {
         match self.try_entry(id.0 as usize)? {
             TypeData::Struct(data) => Some(&data.def),
             _ => None,
@@ -1051,7 +1216,7 @@ impl TypeInternPoolInner {
         }
     }
 
-    fn struct_def(&self, id: StructId) -> &StructDef {
+    fn struct_def(&self, id: StructId) -> &StructDefEntry {
         self.try_struct_def(id)
             .unwrap_or_else(|| panic!("Expected struct at pool index {}", id.0))
     }
@@ -1059,7 +1224,7 @@ impl TypeInternPoolInner {
     fn struct_def_mut(&mut self, id: StructId) -> &mut StructDef {
         let pool_index = id.pool_index() as usize;
         match self.try_entry_mut(pool_index) {
-            Some(TypeData::Struct(data)) => Arc::make_mut(&mut data.def),
+            Some(TypeData::Struct(data)) => Arc::make_mut(&mut data.def).metadata_mut(),
             other => panic!(
                 "Expected complete struct at pool index {}, got {:?}",
                 pool_index, other
@@ -1067,13 +1232,13 @@ impl TypeInternPoolInner {
         }
     }
 
-    fn try_enum_def(&self, id: EnumId) -> Option<&EnumDef> {
+    fn try_enum_def(&self, id: EnumId) -> Option<&EnumDefEntry> {
         self.try_enum_def_arc(id).map(Arc::as_ref)
     }
 
     /// The shared handle behind a completed enum definition. See
     /// [`TypeInternPoolInner::try_struct_def_arc`].
-    fn try_enum_def_arc(&self, id: EnumId) -> Option<&Arc<EnumDef>> {
+    fn try_enum_def_arc(&self, id: EnumId) -> Option<&Arc<EnumDefEntry>> {
         match self.try_entry(id.0 as usize)? {
             TypeData::Enum(data) => Some(&data.def),
             _ => None,
@@ -1104,7 +1269,7 @@ impl TypeInternPoolInner {
         }
     }
 
-    fn enum_def(&self, id: EnumId) -> &EnumDef {
+    fn enum_def(&self, id: EnumId) -> &EnumDefEntry {
         self.try_enum_def(id)
             .unwrap_or_else(|| panic!("Expected enum at pool index {}", id.0))
     }
@@ -1710,7 +1875,7 @@ impl TypeInternPoolInner {
             || self.struct_lang_items.contains_key(&id)
             || data.def.name.starts_with("__anon_struct_")
         {
-            return data.def.name.clone();
+            return data.def.name.to_string();
         }
         format!(
             "{}${}",
@@ -1730,7 +1895,7 @@ impl TypeInternPoolInner {
         if rue_builtins::is_reserved_enum_name(&data.def.name)
             || data.def.name.starts_with("__anon_enum_")
         {
-            return data.def.name.clone();
+            return data.def.name.to_string();
         }
         format!(
             "{}${}",
@@ -1743,11 +1908,11 @@ impl TypeInternPoolInner {
         match ty.try_kind() {
             Some(TypeKind::Struct(id)) => self
                 .struct_metadata(id)
-                .map(|metadata| metadata.name)
+                .map(|metadata| metadata.name.to_string())
                 .unwrap_or_else(|| format!("<struct#{}>", id.0)),
             Some(TypeKind::Enum(id)) => self
                 .enum_metadata(id)
-                .map(|metadata| metadata.name)
+                .map(|metadata| metadata.name.to_string())
                 .unwrap_or_else(|| format!("<enum#{}>", id.0)),
             Some(TypeKind::Array(id)) => self
                 .try_array_def(id)
@@ -1994,14 +2159,14 @@ impl TypeInternPool {
 
         let mut entry = TypeData::Struct(StructData {
             name,
-            def: Arc::new(def),
+            def: Arc::new(StructDefEntry::new(def)),
         });
         let facts = inner.incremental_facts(&entry);
         if facts.is_some_and(|facts| facts.carries_linear) {
             let TypeData::Struct(data) = &mut entry else {
                 unreachable!()
             };
-            Arc::make_mut(&mut data.def).is_linear = true;
+            Arc::make_mut(&mut data.def).metadata_mut().is_linear = true;
         }
         inner.push_entry(entry, facts);
         inner.struct_by_file_name.insert(key, ty);
@@ -2036,7 +2201,7 @@ impl TypeInternPool {
         inner.push_entry(
             TypeData::DeclaredStruct(StructData {
                 name,
-                def: Arc::new(shell),
+                def: Arc::new(StructDefEntry::new(shell)),
             }),
             None,
         );
@@ -2118,14 +2283,14 @@ impl TypeInternPool {
         let key = (def.file_id, name);
         let mut entry = TypeData::Struct(StructData {
             name,
-            def: Arc::new(def),
+            def: Arc::new(StructDefEntry::new(def)),
         });
         let facts = inner.incremental_facts(&entry);
         if facts.is_some_and(|facts| facts.carries_linear) {
             let TypeData::Struct(data) = &mut entry else {
                 unreachable!()
             };
-            Arc::make_mut(&mut data.def).is_linear = true;
+            Arc::make_mut(&mut data.def).metadata_mut().is_linear = true;
         }
         *inner.entry_mut(pool_index) = entry;
         inner.set_facts(pool_index, facts);
@@ -2150,13 +2315,13 @@ impl TypeInternPool {
                     "completed struct changed defining file"
                 );
                 assert_eq!(
-                    data.def.name.as_str(),
-                    def.name.as_str(),
+                    data.def.name.as_ref(),
+                    def.name.as_ref(),
                     "completed struct changed textual name"
                 );
                 *entry = TypeData::Struct(StructData {
                     name: data.name,
-                    def: Arc::new(def),
+                    def: Arc::new(StructDefEntry::new(def)),
                 });
             }
             other => panic!(
@@ -2205,7 +2370,7 @@ impl TypeInternPool {
 
         let entry = TypeData::Enum(EnumData {
             name,
-            def: Arc::new(def),
+            def: Arc::new(EnumDefEntry::new(def)),
         });
         let facts = inner.incremental_facts(&entry);
         inner.push_entry(entry, facts);
@@ -2241,7 +2406,7 @@ impl TypeInternPool {
         inner.push_entry(
             TypeData::DeclaredEnum(EnumData {
                 name,
-                def: Arc::new(shell),
+                def: Arc::new(EnumDefEntry::new(shell)),
             }),
             None,
         );
@@ -2263,13 +2428,13 @@ impl TypeInternPool {
                     "completed enum changed defining file"
                 );
                 assert_eq!(
-                    data.def.name.as_str(),
-                    def.name.as_str(),
+                    data.def.name.as_ref(),
+                    def.name.as_ref(),
                     "completed enum changed textual name"
                 );
                 *entry = TypeData::Enum(EnumData {
                     name: data.name,
-                    def: Arc::new(def),
+                    def: Arc::new(EnumDefEntry::new(def)),
                 });
             }
             other => panic!(
@@ -2455,7 +2620,7 @@ impl TypeInternPool {
     }
 
     /// Get the struct definition if this is a struct type.
-    pub fn get_struct_def(&self, ty: Type) -> Option<Arc<StructDef>> {
+    pub fn get_struct_def(&self, ty: Type) -> Option<Arc<StructDefEntry>> {
         match self.get(ty)? {
             TypeData::Struct(data) => Some(data.def),
             _ => None,
@@ -2463,7 +2628,7 @@ impl TypeInternPool {
     }
 
     /// Get the enum definition if this is an enum type.
-    pub fn get_enum_def(&self, ty: Type) -> Option<Arc<EnumDef>> {
+    pub fn get_enum_def(&self, ty: Type) -> Option<Arc<EnumDefEntry>> {
         match self.get(ty)? {
             TypeData::Enum(data) => Some(data.def),
             _ => None,
@@ -2497,7 +2662,7 @@ impl TypeInternPool {
     ///
     /// Panics if the StructId doesn't correspond to a struct in the pool.
     #[track_caller]
-    pub fn struct_def(&self, struct_id: StructId) -> Arc<StructDef> {
+    pub fn struct_def(&self, struct_id: StructId) -> Arc<StructDefEntry> {
         let inner = self.inner.read().unwrap_or_else(PoisonError::into_inner);
         match inner.try_struct_def_arc(struct_id) {
             Some(def) => Arc::clone(def),
@@ -2506,7 +2671,7 @@ impl TypeInternPool {
     }
 
     /// Get a struct definition without panicking on an invalid or wrong-kind ID.
-    pub fn try_struct_def(&self, struct_id: StructId) -> Option<Arc<StructDef>> {
+    pub fn try_struct_def(&self, struct_id: StructId) -> Option<Arc<StructDefEntry>> {
         let inner = self.inner.read().unwrap_or_else(PoisonError::into_inner);
         inner.try_struct_def_arc(struct_id).map(Arc::clone)
     }
@@ -2628,7 +2793,7 @@ impl TypeInternPool {
     ///
     /// Panics if the EnumId doesn't correspond to an enum in the pool.
     #[track_caller]
-    pub fn enum_def(&self, enum_id: EnumId) -> Arc<EnumDef> {
+    pub fn enum_def(&self, enum_id: EnumId) -> Arc<EnumDefEntry> {
         let inner = self.inner.read().unwrap_or_else(PoisonError::into_inner);
         match inner.try_enum_def_arc(enum_id) {
             Some(def) => Arc::clone(def),
@@ -2637,14 +2802,14 @@ impl TypeInternPool {
     }
 
     /// Get an enum definition without panicking on an invalid or wrong-kind ID.
-    pub fn try_enum_def(&self, enum_id: EnumId) -> Option<Arc<EnumDef>> {
+    pub fn try_enum_def(&self, enum_id: EnumId) -> Option<Arc<EnumDefEntry>> {
         let inner = self.inner.read().unwrap_or_else(PoisonError::into_inner);
         inner.try_enum_def_arc(enum_id).map(Arc::clone)
     }
 
     pub(crate) fn enum_variant_count(&self, enum_id: EnumId) -> Option<usize> {
         let inner = self.inner.read().unwrap_or_else(PoisonError::into_inner);
-        inner.try_enum_def(enum_id).map(EnumDef::variant_count)
+        inner.try_enum_def(enum_id).map(|def| def.variant_count())
     }
 
     pub(crate) fn enum_variant_payload_len(
@@ -2733,7 +2898,7 @@ impl TypeInternPool {
             def.destructor.is_none(),
             "struct destructor metadata can only be assigned once"
         );
-        def.destructor = Some(symbol);
+        def.destructor = Some(Arc::from(symbol));
         inner.invalidate_containment_metadata();
     }
 
@@ -2754,10 +2919,11 @@ impl TypeInternPool {
             .as_mut()
             .expect("destructor requalification requires assigned metadata");
         assert_ne!(
-            destructor, &symbol,
+            destructor.as_ref(),
+            symbol.as_str(),
             "destructor requalification requires a different symbol"
         );
-        *destructor = symbol;
+        *destructor = Arc::from(symbol);
     }
 
     /// Finalize the canonical by-value graph after declaration fields,
@@ -3154,20 +3320,20 @@ impl FrozenTypeInternPool {
     }
 
     /// Borrow a completed nominal struct definition without locking or cloning.
-    pub fn struct_def(&self, id: StructId) -> &StructDef {
+    pub fn struct_def(&self, id: StructId) -> &StructDefEntry {
         self.inner.struct_def(id)
     }
 
-    pub fn try_struct_def(&self, id: StructId) -> Option<&StructDef> {
+    pub fn try_struct_def(&self, id: StructId) -> Option<&StructDefEntry> {
         self.inner.try_struct_def(id)
     }
 
     /// Borrow a completed nominal enum definition without locking or cloning.
-    pub fn enum_def(&self, id: EnumId) -> &EnumDef {
+    pub fn enum_def(&self, id: EnumId) -> &EnumDefEntry {
         self.inner.enum_def(id)
     }
 
-    pub fn try_enum_def(&self, id: EnumId) -> Option<&EnumDef> {
+    pub fn try_enum_def(&self, id: EnumId) -> Option<&EnumDefEntry> {
         self.inner.try_enum_def(id)
     }
 
@@ -3455,7 +3621,7 @@ mod tests {
     fn enum_def(name: &str) -> EnumDef {
         EnumDef {
             name: name.into(),
-            variants: vec![],
+            variants: Arc::from([]),
             variant_payloads: vec![],
             is_pub: false,
             file_id: FileId::DEFAULT,
@@ -3485,7 +3651,7 @@ mod tests {
         assert!(pool.is_struct(interned));
         assert!(pool.get_struct_def(interned).is_none());
         assert!(pool.try_struct_def(id).is_none());
-        assert_eq!(pool.struct_declaration_metadata(id).unwrap().name, "Node");
+        assert_eq!(&*pool.struct_declaration_metadata(id).unwrap().name, "Node");
         assert_eq!(
             pool.validate_complete_type(interned),
             Err(TypeValidationError::IncompleteDefinition)
@@ -3722,7 +3888,7 @@ mod tests {
         let def = pool.struct_def(owner);
         assert!(def.is_linear);
         assert_eq!(def.destructor.as_deref(), Some("Owner$left.__drop"));
-        assert_eq!(def.name, "Owner");
+        assert_eq!(&*def.name, "Owner");
         assert_eq!(def.fields.len(), 1);
         assert_eq!(def.fields[0].ty, Type::I64);
     }
@@ -3750,7 +3916,7 @@ mod tests {
             let mut def = struct_def(&name, fields);
             if index + 1 == COUNT {
                 def.is_linear = true;
-                def.destructor = Some(format!("{name}.__drop"));
+                def.destructor = Some(format!("{name}.__drop").into());
             }
             pool.complete_struct_registration(id, declarations.get_or_intern(&name), def);
         }
@@ -3855,7 +4021,7 @@ mod tests {
             );
             if index == 0 {
                 def.is_linear = true;
-                def.destructor = Some(format!("{name}.__drop"));
+                def.destructor = Some(format!("{name}.__drop").into());
             }
             let (id, inserted) = pool.register_struct(declarations.get_or_intern(&name), def);
             assert!(inserted);
@@ -3898,7 +4064,7 @@ mod tests {
         let pointer = pool.try_intern_ptr_mut(Type::new_struct(resource)).unwrap();
         let choice = EnumDef {
             name: "Choice".into(),
-            variants: vec!["Some".into(), "None".into()],
+            variants: Arc::from(["Some".into(), "None".into()]),
             variant_payloads: vec![vec![one_array], vec![pointer]],
             is_pub: false,
             file_id: FileId::DEFAULT,
@@ -4001,7 +4167,7 @@ mod tests {
         let name = interner.get_or_intern("Point");
 
         let def = StructDef {
-            name: "Point".to_string(),
+            name: "Point".into(),
             fields: vec![],
             is_copy: false,
             is_linear: false,
@@ -4028,7 +4194,7 @@ mod tests {
         let pool = TypeInternPool::new();
         let interner = ThreadedRodeo::default();
         let make_def = |name: &str, file_id| StructDef {
-            name: name.to_string(),
+            name: name.into(),
             fields: vec![],
             is_copy: false,
             is_linear: false,
@@ -4055,7 +4221,7 @@ mod tests {
         let pool = TypeInternPool::new();
         let interner = ThreadedRodeo::default();
         let make_def = |name: &str, file_id| StructDef {
-            name: name.to_string(),
+            name: name.into(),
             fields: vec![],
             is_copy: false,
             is_linear: false,
@@ -4084,8 +4250,8 @@ mod tests {
         let name = interner.get_or_intern("Color");
 
         let def = EnumDef {
-            name: "Color".to_string(),
-            variants: vec!["Red".to_string(), "Green".to_string(), "Blue".to_string()],
+            name: "Color".into(),
+            variants: Arc::from(["Red".into(), "Green".into(), "Blue".into()]),
             variant_payloads: Vec::new(),
             is_pub: false,
             file_id: rue_span::FileId::DEFAULT,
@@ -4139,7 +4305,7 @@ mod tests {
         );
 
         let def = StructDef {
-            name: "Point".to_string(),
+            name: "Point".into(),
             fields: vec![],
             is_copy: false,
             is_linear: false,
@@ -4169,8 +4335,8 @@ mod tests {
         );
 
         let def = EnumDef {
-            name: "Status".to_string(),
-            variants: vec!["Active".to_string(), "Inactive".to_string()],
+            name: "Status".into(),
+            variants: Arc::from(["Active".into(), "Inactive".into()]),
             variant_payloads: Vec::new(),
             is_pub: false,
             file_id: rue_span::FileId::DEFAULT,
@@ -4206,7 +4372,7 @@ mod tests {
         // Register a struct
         let struct_name = interner.get_or_intern("Point");
         let struct_def = StructDef {
-            name: "Point".to_string(),
+            name: "Point".into(),
             fields: vec![],
             is_copy: false,
             is_linear: false,
@@ -4241,7 +4407,7 @@ mod tests {
 
         let struct_name = interner.get_or_intern("Point");
         let struct_def = StructDef {
-            name: "Point".to_string(),
+            name: "Point".into(),
             fields: vec![],
             is_copy: false,
             is_linear: false,
@@ -4255,8 +4421,8 @@ mod tests {
 
         let enum_name = interner.get_or_intern("Color");
         let enum_def = EnumDef {
-            name: "Color".to_string(),
-            variants: vec!["Red".to_string()],
+            name: "Color".into(),
+            variants: Arc::from(["Red".into()]),
             variant_payloads: Vec::new(),
             is_pub: false,
             file_id: rue_span::FileId::DEFAULT,
@@ -4292,7 +4458,7 @@ mod tests {
 
         let name = interner.get_or_intern("Point");
         let def = StructDef {
-            name: "Point".to_string(),
+            name: "Point".into(),
             fields: vec![],
             is_copy: true,
             is_linear: false,
@@ -4328,8 +4494,8 @@ mod tests {
 
         let name = interner.get_or_intern("Status");
         let def = EnumDef {
-            name: "Status".to_string(),
-            variants: vec!["A".to_string(), "B".to_string()],
+            name: "Status".into(),
+            variants: Arc::from(["A".into(), "B".into()]),
             variant_payloads: Vec::new(),
             is_pub: false,
             file_id: rue_span::FileId::DEFAULT,
@@ -4367,7 +4533,7 @@ mod tests {
         let interner = ThreadedRodeo::default();
         let name = interner.get_or_intern("X");
         let def = StructDef {
-            name: "X".to_string(),
+            name: "X".into(),
             fields: vec![],
             is_copy: false,
             is_linear: false,
@@ -4399,7 +4565,7 @@ mod tests {
         let e1 = interner.get_or_intern("E1");
 
         let def = StructDef {
-            name: "S1".to_string(),
+            name: "S1".into(),
             fields: vec![],
             is_copy: false,
             is_linear: false,
@@ -4412,7 +4578,7 @@ mod tests {
         pool.register_struct(
             s2,
             StructDef {
-                name: "S2".to_string(),
+                name: "S2".into(),
                 ..def
             },
         );
@@ -4420,8 +4586,8 @@ mod tests {
         pool.register_enum(
             e1,
             EnumDef {
-                name: "E1".to_string(),
-                variants: vec![],
+                name: "E1".into(),
+                variants: Arc::from([]),
                 variant_payloads: Vec::new(),
                 is_pub: false,
                 file_id: rue_span::FileId::DEFAULT,
@@ -4486,7 +4652,7 @@ mod tests {
                         let idx = thread_id * 10 + i;
                         let name = names[idx];
                         let def = StructDef {
-                            name: format!("Type{}", idx),
+                            name: format!("Type{}", idx).into(),
                             fields: vec![],
                             is_copy: false,
                             is_linear: false,
@@ -4566,7 +4732,7 @@ mod tests {
         let name = interner.get_or_intern(&name_str);
 
         let def = StructDef {
-            name: name_str.clone(),
+            name: name_str.as_str().into(),
             fields: vec![],
             is_copy: false,
             is_linear: false,
@@ -4588,7 +4754,7 @@ mod tests {
 
         // Can retrieve the struct definition
         let retrieved = pool.struct_def(struct_id);
-        assert_eq!(retrieved.name, name_str);
+        assert_eq!(retrieved.name.as_ref(), name_str);
     }
 
     /// RUE-571: a struct name registered by two files yields file-qualified
@@ -4598,7 +4764,7 @@ mod tests {
         let pool = TypeInternPool::new();
         let interner = ThreadedRodeo::default();
         let mk = |name: &str, file: u32, is_builtin: bool| StructDef {
-            name: name.to_string(),
+            name: name.into(),
             fields: vec![],
             is_copy: false,
             is_linear: false,
@@ -4642,7 +4808,7 @@ mod tests {
 
         let payload = interner.get_or_intern("Payload");
         let struct_def = |file_id| StructDef {
-            name: "Payload".to_string(),
+            name: "Payload".into(),
             fields: vec![],
             is_copy: false,
             is_linear: false,
@@ -4656,8 +4822,8 @@ mod tests {
 
         let choice = interner.get_or_intern("Choice");
         let enum_def = |file_id| EnumDef {
-            name: "Choice".to_string(),
-            variants: vec!["Value".to_string()],
+            name: "Choice".into(),
+            variants: Arc::from(["Value".into()]),
             variant_payloads: vec![vec![]],
             is_pub: true,
             file_id,
@@ -4704,7 +4870,7 @@ mod tests {
             let name_str = format!("__anon_struct_{}", i);
             let name = interner.get_or_intern(&name_str);
             let def = StructDef {
-                name: name_str,
+                name: name_str.into(),
                 fields: vec![],
                 is_copy: false,
                 is_linear: false,
@@ -4948,8 +5114,8 @@ mod tests {
         let pool = TypeInternPool::new();
         let interner = ThreadedRodeo::default();
         let def = EnumDef {
-            name: "Wide".to_string(),
-            variants: vec!["A".to_string(), "B".to_string()],
+            name: "Wide".into(),
+            variants: Arc::from(["A".into(), "B".into()]),
             variant_payloads: vec![vec![Type::U8, Type::I32], vec![]],
             is_pub: false,
             file_id: FileId::DEFAULT,
@@ -5020,8 +5186,8 @@ mod tests {
         let pool = TypeInternPool::new();
         let interner = ThreadedRodeo::default();
         let def = EnumDef {
-            name: "Shape".to_string(),
-            variants: vec!["Pair".to_string(), "One".to_string()],
+            name: "Shape".into(),
+            variants: Arc::from(["Pair".into(), "One".into()]),
             variant_payloads: vec![vec![Type::I32, Type::I64], vec![Type::I32]],
             is_pub: false,
             file_id: FileId::DEFAULT,

--- a/crates/rue-air/src/lib.rs
+++ b/crates/rue-air/src/lib.rs
@@ -61,8 +61,8 @@ pub use inst::{
     ValidatedAir,
 };
 pub use intern_pool::{
-    EnumData, FrozenTypeInternPool, StructData, TypeData, TypeInternPool, TypeInternPoolStats,
-    TypeValidationError,
+    EnumData, EnumDefEntry, FrozenTypeInternPool, StructData, StructDefEntry, TypeData,
+    TypeInternPool, TypeInternPoolStats, TypeValidationError,
 };
 pub use layout::{Layout, LayoutKind, PaddingRange, SLOT_BYTES};
 pub use module_registry::ModuleRegistry;

--- a/crates/rue-air/src/sema/aggregates.rs
+++ b/crates/rue-air/src/sema/aggregates.rs
@@ -451,7 +451,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
             if !field_index_map.contains_key(init_name.as_str()) {
                 return Err(CompileError::new(
                     ErrorKind::UnknownField {
-                        struct_name: struct_def.name.clone(),
+                        struct_name: struct_def.name.to_string(),
                         field_name: init_name.to_string(),
                     },
                     span,
@@ -461,7 +461,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
             if !seen_fields.insert(init_name.clone()) {
                 return Err(CompileError::new(
                     ErrorKind::DuplicateField {
-                        struct_name: struct_def.name.clone(),
+                        struct_name: struct_def.name.to_string(),
                         field_name: init_name.to_string(),
                     },
                     span,
@@ -479,7 +479,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
                 .collect();
             return Err(CompileError::new(
                 ErrorKind::MissingFields(Box::new(MissingFieldsError {
-                    struct_name: struct_def.name.clone(),
+                    struct_name: struct_def.name.to_string(),
                     missing_fields,
                 })),
                 span,
@@ -924,7 +924,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
             let variant_name = self.body_interner().resolve(&method);
             let variant_index = enum_def.find_variant(variant_name).ok_or_compile_error(
                 ErrorKind::UnknownVariant {
-                    enum_name: enum_def.name.clone(),
+                    enum_name: enum_def.name.to_string(),
                     variant_name: variant_name.to_string(),
                 },
                 span,
@@ -1025,7 +1025,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
         let variant_name = self.body_interner().resolve(&variant);
         let variant_index = enum_def.find_variant(variant_name).ok_or_compile_error(
             ErrorKind::UnknownVariant {
-                enum_name: enum_def.name.clone(),
+                enum_name: enum_def.name.to_string(),
                 variant_name: variant_name.to_string(),
             },
             span,
@@ -1078,7 +1078,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
         let variant_name = self.body_interner().resolve(&variant);
         let variant_index = enum_def.find_variant(variant_name).ok_or_compile_error(
             ErrorKind::UnknownVariant {
-                enum_name: enum_def.name.clone(),
+                enum_name: enum_def.name.to_string(),
                 variant_name: variant_name.to_string(),
             },
             span,
@@ -1370,7 +1370,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
                 let variant_name = self.body_interner().resolve(&*variant);
                 let variant_index = enum_def.find_variant(variant_name).ok_or_compile_error(
                     ErrorKind::UnknownVariant {
-                        enum_name: enum_def.name.clone(),
+                        enum_name: enum_def.name.to_string(),
                         variant_name: variant_name.to_string(),
                     },
                     inst.span,

--- a/crates/rue-air/src/sema/analysis.rs
+++ b/crates/rue-air/src/sema/analysis.rs
@@ -1462,7 +1462,7 @@ fn named_method_dependency_events(
                 rue_span::Span::default(),
             )
         })?;
-    let caller_owner_name = sema.type_pool.struct_def(caller_struct).name.clone();
+    let caller_owner_name = sema.type_pool.struct_def(caller_struct).name.to_string();
     let caller_method_name = sema.interner.resolve(&caller_method).to_string();
     let mut events = Vec::new();
     for callee in referenced_functions {
@@ -1499,7 +1499,7 @@ fn named_method_dependency_events(
         });
     }
     for (callee_struct, callee_method) in referenced_methods {
-        let owner_name = sema.type_pool.struct_def(*callee_struct).name.clone();
+        let owner_name = sema.type_pool.struct_def(*callee_struct).name.to_string();
         // Membership, not the generated-name prefix: `__anon_struct_N` is a
         // legal source declaration, and only `anonymous_struct_ids` knows which
         // structs the compiler generated (RUE-1050).
@@ -1550,7 +1550,7 @@ fn named_destructor_dependency_events(
     referenced_functions: &HashSet<Spur>,
     referenced_methods: &HashSet<(StructId, Spur)>,
 ) -> CompileResult<Vec<super::NamedDestructorDependencyEvent>> {
-    let caller_owner_name = sema.type_pool.struct_def(caller_struct).name.clone();
+    let caller_owner_name = sema.type_pool.struct_def(caller_struct).name.to_string();
     let mut events = Vec::new();
     for callee in referenced_functions {
         let info = sema.function_info(*callee).copied().ok_or_else(|| {
@@ -1580,7 +1580,7 @@ fn named_destructor_dependency_events(
         });
     }
     for (callee_struct, callee_method) in referenced_methods {
-        let owner_name = sema.type_pool.struct_def(*callee_struct).name.clone();
+        let owner_name = sema.type_pool.struct_def(*callee_struct).name.to_string();
         // Membership, not the generated-name prefix: `__anon_struct_N` is a
         // legal source declaration, and only `anonymous_struct_ids` knows which
         // structs the compiler generated (RUE-1050).
@@ -2235,7 +2235,7 @@ fn analyze_function_bodies_lazy(sema: &mut BodySema<'_>) -> MultiErrorResult<Sem
 
                 // Get the struct definition to find its name for impl block lookup
                 let struct_def = sema.type_pool.struct_def(struct_id);
-                let type_name_str = struct_def.name.clone();
+                let type_name_str = struct_def.name.to_string();
                 let method_name_str = sema.interner.resolve(&method_name).to_string();
 
                 // For anonymous structs, use the MethodInfo directly since there's no named StructDecl.
@@ -2814,7 +2814,7 @@ fn analyze_function_bodies_lazy(sema: &mut BodySema<'_>) -> MultiErrorResult<Sem
                     let struct_type = Type::new_struct(struct_id);
                     let full_name = sema.destructor_symbol(struct_id);
 
-                    let owner_name = sema.type_pool.struct_def(struct_id).name.clone();
+                    let owner_name = sema.type_pool.struct_def(struct_id).name.to_string();
                     let named_destructor_identity = match sema.stable_definition_token(
                         destructor.span.file_id.index(),
                         &owner_name,
@@ -2971,7 +2971,7 @@ fn analyze_function_bodies_lazy(sema: &mut BodySema<'_>) -> MultiErrorResult<Sem
                                 super::BodyOwnerKind::Destructor,
                             ),
                             file: destructor.span.file_id.index(),
-                            owner_name: sema.type_pool.struct_def(struct_id).name.clone(),
+                            owner_name: sema.type_pool.struct_def(struct_id).name.to_string(),
                         },
                     );
                     let analysis = sema.analyze_destructor_function(
@@ -3004,7 +3004,11 @@ fn analyze_function_bodies_lazy(sema: &mut BodySema<'_>) -> MultiErrorResult<Sem
                                         super::BodyOwnerKind::Destructor,
                                     ),
                                     file: destructor.span.file_id.index(),
-                                    owner_name: sema.type_pool.struct_def(struct_id).name.clone(),
+                                    owner_name: sema
+                                        .type_pool
+                                        .struct_def(struct_id)
+                                        .name
+                                        .to_string(),
                                 },
                             );
                             analyzed.ordinary_owner = Some(sema.body_owner_token(
@@ -3048,7 +3052,11 @@ fn analyze_function_bodies_lazy(sema: &mut BodySema<'_>) -> MultiErrorResult<Sem
                                         super::BodyOwnerKind::Destructor,
                                     ),
                                     file: destructor.span.file_id.index(),
-                                    owner_name: sema.type_pool.struct_def(struct_id).name.clone(),
+                                    owner_name: sema
+                                        .type_pool
+                                        .struct_def(struct_id)
+                                        .name
+                                        .to_string(),
                                 });
                             match named_destructor_dependency_events(
                                 sema,
@@ -3257,7 +3265,7 @@ pub(crate) fn non_exhaustive_match_error(
             .iter()
             .enumerate()
             .filter(|(i, _)| !variant_covered(*i as u32))
-            .map(|(_, v)| v.as_str())
+            .map(|(_, v)| v.as_ref())
             .collect();
         if missing.is_empty() {
             return err;

--- a/crates/rue-air/src/sema/analysis/calls.rs
+++ b/crates/rue-air/src/sema/analysis/calls.rs
@@ -999,7 +999,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
 
         // Look up the struct name by its ID (for error messages)
         let struct_def = self.body_type_pool().struct_def(struct_id);
-        let struct_name_str = struct_def.name.clone();
+        let struct_name_str = struct_def.name.to_string();
 
         // Look up the method using StructId directly
         let method_key = (struct_id, method);

--- a/crates/rue-air/src/sema/analysis/intrinsics.rs
+++ b/crates/rue-air/src/sema/analysis/intrinsics.rs
@@ -189,7 +189,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
             None => {
                 return Err(CompileError::new(
                     ErrorKind::UnknownField {
-                        struct_name: struct_def.name.clone(),
+                        struct_name: struct_def.name.to_string(),
                         field_name: field_name_str.to_string(),
                     },
                     span,

--- a/crates/rue-air/src/sema/analysis/ownership.rs
+++ b/crates/rue-air/src/sema/analysis/ownership.rs
@@ -2560,7 +2560,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
                         let err = CompileError::new(
                             ErrorKind::LinearFieldDroppedByDestructure(Box::new(
                                 rue_error::LinearFieldDroppedByDestructureError {
-                                    struct_name: def.name.clone(),
+                                    struct_name: def.name.to_string(),
                                     accessed,
                                     dropped: field.name.clone(),
                                 },
@@ -2620,7 +2620,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
                 .unwrap_or_default();
             let mut err = CompileError::new(
                 ErrorKind::MoveFieldOutOfDestructorType {
-                    struct_name: struct_def.name.clone(),
+                    struct_name: struct_def.name.to_string(),
                     field_name: field_name.clone(),
                 },
                 span,
@@ -2957,7 +2957,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
         let (field_index, struct_field) =
             struct_def.find_field(&field_name_str).ok_or_compile_error(
                 ErrorKind::UnknownField {
-                    struct_name: struct_def.name.clone(),
+                    struct_name: struct_def.name.to_string(),
                     field_name: field_name_str.clone(),
                 },
                 span,
@@ -3746,7 +3746,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
                     .body_type_pool()
                     .struct_def(slice_struct_id)
                     .name
-                    .clone(),
+                    .to_string(),
             },
             span,
         ))
@@ -3835,7 +3835,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
             let (field_index, struct_field) =
                 struct_def.find_field(&field_name_str).ok_or_compile_error(
                     ErrorKind::UnknownField {
-                        struct_name: struct_def.name.clone(),
+                        struct_name: struct_def.name.to_string(),
                         field_name: field_name_str.clone(),
                     },
                     span,

--- a/crates/rue-air/src/sema/analysis/type_inference.rs
+++ b/crates/rue-air/src/sema/analysis/type_inference.rs
@@ -758,7 +758,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
             let (field_index, struct_field) =
                 struct_def.find_field(&field_name_str).ok_or_compile_error(
                     ErrorKind::UnknownField {
-                        struct_name: struct_def.name.clone(),
+                        struct_name: struct_def.name.to_string(),
                         field_name: field_name_str.clone(),
                     },
                     field_span,

--- a/crates/rue-air/src/sema/anon_structs.rs
+++ b/crates/rue-air/src/sema/anon_structs.rs
@@ -218,7 +218,7 @@ impl<D: DeclarationPhase> Sema<'_, D> {
                     if def.is_builtin {
                         T::BuiltinNominal {
                             kind: K::Struct,
-                            name: std::sync::Arc::from(def.name.as_str()),
+                            name: def.name.clone(),
                         }
                     } else {
                         T::Nominal(N::Named(self.struct_identity(id)?))
@@ -232,11 +232,11 @@ impl<D: DeclarationPhase> Sema<'_, D> {
                     let def = self.type_pool.enum_metadata(id).ok_or(F::UnsupportedType)?;
                     if rue_builtins::BUILTIN_ENUMS
                         .iter()
-                        .any(|builtin| builtin.name == def.name)
+                        .any(|builtin| builtin.name == &*def.name)
                     {
                         T::BuiltinNominal {
                             kind: K::Enum,
-                            name: std::sync::Arc::from(def.name.as_str()),
+                            name: def.name.clone(),
                         }
                     } else {
                         T::Nominal(N::Named(self.enum_identity(id)?))

--- a/crates/rue-air/src/sema/binding_manifest.rs
+++ b/crates/rue-air/src/sema/binding_manifest.rs
@@ -1244,7 +1244,7 @@ impl<'a> DeclarationShells<'a> {
                     if metadata
                         .variants
                         .iter()
-                        .map(String::as_str)
+                        .map(Arc::as_ref)
                         .ne(variants.iter().map(|variant| variant.0.as_ref()))
                     {
                         return Err(DeclarationInstallFailure::NominalShapeMismatch);
@@ -3244,11 +3244,11 @@ impl<'a, D: super::DeclarationPhase> Sema<'a, D> {
                 {
                     Ok(SemanticExportType::Slice {
                         element: Box::new(self.export_type(element, stack)?),
-                        name: Arc::from(def.name.as_str()),
+                        name: def.name.clone(),
                     })
                 } else if def.is_builtin {
                     Ok(SemanticExportType::BuiltinNominal {
-                        name: Arc::from(def.name.as_str()),
+                        name: def.name.clone(),
                         kind: crate::SemanticImportNominalKind::Struct,
                     })
                 } else {
@@ -3258,7 +3258,7 @@ impl<'a, D: super::DeclarationPhase> Sema<'a, D> {
                     }
                     Ok(SemanticExportType::Nominal(SemanticNominalIdentity {
                         file_id: def.file_id,
-                        name: Arc::from(def.name.as_str()),
+                        name: def.name.clone(),
                         kind: StableDefinitionKind::Struct,
                     }))
                 }
@@ -3268,13 +3268,13 @@ impl<'a, D: super::DeclarationPhase> Sema<'a, D> {
                 let symbol = self.interner.get_or_intern(&def.name);
                 if self.builtin_enums.get(&symbol) == Some(&id) {
                     Ok(SemanticExportType::BuiltinNominal {
-                        name: Arc::from(def.name.as_str()),
+                        name: def.name.clone(),
                         kind: crate::SemanticImportNominalKind::Enum,
                     })
                 } else {
                     Ok(SemanticExportType::Nominal(SemanticNominalIdentity {
                         file_id: def.file_id,
-                        name: Arc::from(def.name.as_str()),
+                        name: def.name.clone(),
                         kind: StableDefinitionKind::Enum,
                     }))
                 }
@@ -3517,7 +3517,7 @@ impl<'a, D: super::DeclarationPhase> Sema<'a, D> {
                                 .iter()
                                 .map(|&t| self.export_type(t, &mut Vec::new()))
                                 .collect::<Result<Vec<_>, _>>()?;
-                            Ok((Arc::from(n.as_str()), Arc::from(payload)))
+                            Ok((n.clone(), Arc::from(payload)))
                         })
                         .collect::<Result<Vec<_>, _>>()?;
                     SemanticDeclarationPayload::Enum {

--- a/crates/rue-air/src/sema/body_identity.rs
+++ b/crates/rue-air/src/sema/body_identity.rs
@@ -837,8 +837,8 @@ where
             let (id, _) = type_pool.register_enum(
                 symbol,
                 EnumDef {
-                    name: builtin.name.to_owned(),
-                    variants: builtin.variants.iter().map(|v| (*v).to_owned()).collect(),
+                    name: Arc::from(builtin.name),
+                    variants: builtin.variants.iter().map(|v| Arc::from(*v)).collect(),
                     variant_payloads: Vec::new(),
                     is_pub: true,
                     file_id: FileId::DEFAULT,
@@ -858,7 +858,7 @@ where
         let (str_id, _) = type_pool.register_struct(
             str_symbol,
             StructDef {
-                name: "str".to_owned(),
+                name: Arc::from("str"),
                 fields: vec![
                     StructField {
                         name: "ptr".to_owned(),
@@ -992,7 +992,7 @@ where
     /// resolver), so the pool takes an already-reduced `u64` and never re-derives
     /// a non-literal capacity.
     pub(in crate::sema) fn get_or_create_str_fixed(&mut self, capacity: u64) -> Type {
-        let name = format!("Str({capacity})");
+        let name: Arc<str> = Arc::from(format!("Str({capacity})").as_str());
         let symbol = self.interner.get_or_intern(&name);
         let ptr_id = self.type_pool.intern_ptr_const_from_type(Type::U8);
         let (id, _) = self.type_pool.register_struct(
@@ -1106,7 +1106,7 @@ where
                 let (id, _) = self.type_pool.register_struct(
                     symbol,
                     StructDef {
-                        name: name.to_string(),
+                        name: Arc::from(name.as_ref()),
                         fields: vec![
                             StructField {
                                 name: "ptr".to_owned(),
@@ -1217,7 +1217,7 @@ where
             self.file_for_module(&module_path)
         };
         let symbol = self.interner.get_or_intern(name.as_ref());
-        let name = name.to_string();
+        let name = name.clone();
         match body {
             DurableNominalBody::Struct {
                 fields,
@@ -1280,8 +1280,8 @@ where
             DurableNominalBody::Enum { variants } => {
                 let variant_names = variants
                     .iter()
-                    .map(|(name, _)| name.to_string())
-                    .collect::<Vec<_>>();
+                    .map(|(name, _)| Arc::from(name.as_ref()))
+                    .collect::<Arc<[Arc<str>]>>();
                 let (id, _) = self.type_pool.declare_enum(
                     symbol,
                     EnumDef {
@@ -1360,7 +1360,7 @@ where
 
         let file_id = self.file_for_module(&module_path);
         let symbol = self.interner.get_or_intern(name.as_ref());
-        let name = name.to_string();
+        let name = name.clone();
 
         match body {
             DurableNominalBody::Struct {
@@ -1423,8 +1423,10 @@ where
                 Ok(Type::new_struct(id))
             }
             DurableNominalBody::Enum { variants } => {
-                let variant_names: Vec<String> =
-                    variants.iter().map(|(name, _)| name.to_string()).collect();
+                let variant_names: Arc<[Arc<str>]> = variants
+                    .iter()
+                    .map(|(name, _)| Arc::from(name.as_ref()))
+                    .collect();
                 let (id, _) = self.type_pool.declare_enum(
                     symbol,
                     EnumDef {
@@ -1860,12 +1862,12 @@ where
         fields: &[(Arc<str>, SemanticImportType<K, M>)],
         method_names: &[Arc<str>],
     ) -> Result<Type, IdentityMintError> {
-        let name = format!("__anon_struct_{digest:032x}");
+        let name: Arc<str> = Arc::from(format!("__anon_struct_{digest:032x}").as_str());
         let symbol = self.interner.get_or_intern(&name);
         let has_destructor = method_names
             .iter()
             .any(|method| method.as_ref() == ANON_DROP_METHOD);
-        let destructor = has_destructor.then(|| format!("{name}.__drop"));
+        let destructor = has_destructor.then(|| Arc::from(format!("{name}.__drop").as_str()));
 
         // Declare the shell before resolving fields so a field that points back
         // at this nominal resolves the recursive reference to the shell id — the
@@ -1924,8 +1926,10 @@ where
         digest: u128,
         variants: &[(Arc<str>, Vec<SemanticImportType<K, M>>)],
     ) -> Result<Type, IdentityMintError> {
-        let variant_names: Vec<String> =
-            variants.iter().map(|(name, _)| name.to_string()).collect();
+        let variant_names: Arc<[Arc<str>]> = variants
+            .iter()
+            .map(|(name, _)| Arc::from(name.as_ref()))
+            .collect();
         let mut variant_payloads = Vec::with_capacity(variants.len());
         for (_, payload) in variants {
             let mut resolved = Vec::with_capacity(payload.len());
@@ -1959,7 +1963,7 @@ where
         let (id, _) = self.type_pool.register_enum(
             symbol,
             EnumDef {
-                name,
+                name: Arc::from(name.as_str()),
                 variants: variant_names,
                 variant_payloads,
                 is_pub: false,
@@ -2941,7 +2945,7 @@ mod tests {
             let (id, _) = pool.register_struct(
                 widget,
                 StructDef {
-                    name: "Widget".to_owned(),
+                    name: "Widget".into(),
                     fields: Vec::new(),
                     is_copy: true,
                     is_linear: false,
@@ -2988,7 +2992,7 @@ mod tests {
             let (id, _) = pool.register_struct(
                 generated,
                 StructDef {
-                    name: "Generated".to_owned(),
+                    name: "Generated".into(),
                     fields: Vec::new(),
                     is_copy: true,
                     is_linear: false,
@@ -3022,7 +3026,7 @@ mod tests {
             let (id, _) = pool.declare_struct(
                 interner.get_or_intern("Pending"),
                 StructDef {
-                    name: "Pending".to_owned(),
+                    name: "Pending".into(),
                     fields: Vec::new(),
                     is_copy: true,
                     is_linear: false,
@@ -3506,8 +3510,8 @@ mod tests {
             TypeKind::Unit => "()".into(),
             TypeKind::Never => "!".into(),
             TypeKind::Error => "<error>".into(),
-            TypeKind::Struct(id) => pool.struct_def(id).name.clone(),
-            TypeKind::Enum(id) => pool.enum_def(id).name.clone(),
+            TypeKind::Struct(id) => pool.struct_def(id).name.to_string(),
+            TypeKind::Enum(id) => pool.enum_def(id).name.to_string(),
             TypeKind::Array(id) => {
                 let (element, len) = pool.array_def(id);
                 format!("[{}; {}]", render(pool, element), len)
@@ -3585,7 +3589,7 @@ mod tests {
         let (id, _) = pool.declare_struct(
             symbol,
             StructDef {
-                name: name.to_owned(),
+                name: name.into(),
                 fields: Vec::new(),
                 is_copy,
                 is_linear,
@@ -3601,7 +3605,7 @@ mod tests {
         pool.complete_declared_struct(
             id,
             StructDef {
-                name: name.to_owned(),
+                name: name.into(),
                 fields: fields
                     .into_iter()
                     .map(|(name, ty)| StructField {
@@ -3628,11 +3632,11 @@ mod tests {
         variants: Vec<(&str, Vec<Type>)>,
     ) -> EnumId {
         let symbol = interner.get_or_intern(name);
-        let variant_names: Vec<String> = variants.iter().map(|(n, _)| (*n).to_owned()).collect();
+        let variant_names: Arc<[Arc<str>]> = variants.iter().map(|(n, _)| Arc::from(*n)).collect();
         let (id, _) = pool.declare_enum(
             symbol,
             EnumDef {
-                name: name.to_owned(),
+                name: name.into(),
                 variants: variant_names.clone(),
                 variant_payloads: Vec::new(),
                 is_pub,
@@ -3642,7 +3646,7 @@ mod tests {
         pool.complete_declared_enum(
             id,
             EnumDef {
-                name: name.to_owned(),
+                name: name.into(),
                 variants: variant_names,
                 variant_payloads: variants.into_iter().map(|(_, p)| p).collect(),
                 is_pub,
@@ -4277,7 +4281,10 @@ mod tests {
         let ty = pool.find_or_create_anon(&key).unwrap();
         let def = pool.type_pool().struct_def(ty.as_struct().unwrap());
         assert!(!def.is_copy, "a type with a destructor cannot be copy");
-        assert_eq!(def.destructor, Some(format!("{}.__drop", def.name)));
+        assert_eq!(
+            def.destructor.as_deref(),
+            Some(format!("{}.__drop", def.name).as_str())
+        );
     }
 
     /// An anonymous enum mints the `__anon_enum_{digest} { A(i32), B }` name whose
@@ -4302,7 +4309,10 @@ mod tests {
             def.name
         );
         assert!(!def.is_pub);
-        assert_eq!(def.variants, vec!["Some".to_string(), "None".to_string()]);
+        assert_eq!(
+            def.variants.iter().map(Arc::as_ref).collect::<Vec<_>>(),
+            ["Some", "None"]
+        );
     }
 
     /// Distinct producer keys forced onto one digest fail closed: the second is
@@ -4766,7 +4776,7 @@ mod tests {
             );
             assert_eq!(pool.well_known_option_for_payload(inner_ty), Some(outer_ty));
             let inner_def = pool.type_pool().enum_def(inner_ty.as_enum().unwrap());
-            (inner_def.name.clone(), outer_def.name.clone())
+            (inner_def.name.to_string(), outer_def.name.to_string())
         };
         // OUTER first: its payload consult blocks on the not-yet-minted inner
         // enum in round one and succeeds in round two.
@@ -4788,7 +4798,7 @@ mod tests {
         let str8 = pool.get_or_create_str_fixed(8);
         let id = str8.as_struct().unwrap();
         let def = pool.type_pool().struct_def(id);
-        assert_eq!(def.name, "Str(8)");
+        assert_eq!(&*def.name, "Str(8)");
         assert!(def.is_copy);
         assert!(def.is_builtin);
         assert!(def.is_pub);
@@ -4801,7 +4811,7 @@ mod tests {
         let str16 = pool.get_or_create_str_fixed(16);
         assert_ne!(str16, str8);
         assert_eq!(
-            pool.type_pool().struct_def(str16.as_struct().unwrap()).name,
+            &*pool.type_pool().struct_def(str16.as_struct().unwrap()).name,
             "Str(16)"
         );
     }
@@ -4836,7 +4846,7 @@ mod tests {
             .unwrap();
         let id = slice.as_struct().unwrap();
         let def = pool.type_pool().struct_def(id);
-        assert_eq!(def.name, "__slice_i64");
+        assert_eq!(&*def.name, "__slice_i64");
         assert!(def.is_copy, "slice headers are copy");
         assert!(def.is_builtin, "slice structs register as builtin");
         assert_eq!(def.fields.len(), 2, "ptr + len: {:?}", def.fields);

--- a/crates/rue-air/src/sema/builtins.rs
+++ b/crates/rue-air/src/sema/builtins.rs
@@ -2,6 +2,8 @@
 //!
 //! This module handles injection of compiler-provided enums like Arch and Os.
 
+use std::sync::Arc;
+
 use rue_builtins::BUILTIN_ENUMS;
 
 use super::{DeclarationPhase, Sema};
@@ -18,15 +20,15 @@ impl<'a> Sema<'a, super::MutableDeclarations> {
     pub(crate) fn inject_builtin_types(&mut self) {
         // Inject built-in enum types (Arch, Os)
         for builtin_enum in BUILTIN_ENUMS {
-            let variants: Vec<String> = builtin_enum
+            let variants: Arc<[Arc<str>]> = builtin_enum
                 .variants
                 .iter()
-                .map(|v| v.to_string())
+                .map(|v| Arc::from(*v))
                 .collect();
 
             // Create the synthetic enum definition
             let enum_def = EnumDef {
-                name: builtin_enum.name.to_string(),
+                name: Arc::from(builtin_enum.name),
                 variants,
                 variant_payloads: Vec::new(),
                 is_pub: true,                      // Built-in enums are always public

--- a/crates/rue-air/src/sema/comptime_eval.rs
+++ b/crates/rue-air/src/sema/comptime_eval.rs
@@ -1285,7 +1285,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
                             self.record_body_named_dependency(
                                 super::NamedConstDependencyTargetEvent::NamedType {
                                     file: def.file_id.index(),
-                                    name: def.name,
+                                    name: def.name.to_string(),
                                     kind: super::DeclarationTypeDependencyTargetKind::Struct,
                                 },
                             );
@@ -1298,7 +1298,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
                             self.record_body_named_dependency(
                                 super::NamedConstDependencyTargetEvent::NamedType {
                                     file: def.file_id.index(),
-                                    name: def.name,
+                                    name: def.name.to_string(),
                                     kind: super::DeclarationTypeDependencyTargetKind::Enum,
                                 },
                             );

--- a/crates/rue-air/src/sema/control_flow.rs
+++ b/crates/rue-air/src/sema/control_flow.rs
@@ -1065,7 +1065,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
                             ErrorKind::TypeMismatch {
                                 expected: scrutinee_type
                                     .safe_name_with_pool(Some(self.body_type_pool())),
-                                found: enum_def.name.clone(),
+                                found: enum_def.name.to_string(),
                             },
                             pattern_span,
                         ));
@@ -1075,7 +1075,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
                     let variant_name = self.body_interner().resolve(&*variant);
                     let variant_index = enum_def.find_variant(variant_name).ok_or_compile_error(
                         ErrorKind::UnknownVariant {
-                            enum_name: enum_def.name.clone(),
+                            enum_name: enum_def.name.to_string(),
                             variant_name: variant_name.to_string(),
                         },
                         pattern_span,
@@ -1276,7 +1276,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
             return Err(super::analysis::non_exhaustive_match_error(
                 span,
                 scrutinee_type,
-                enum_def.as_deref(),
+                enum_def.as_deref().map(|entry| &**entry),
                 |i| covered_variants.contains_key(&i),
                 bool_true_covered,
                 bool_false_covered,
@@ -1689,7 +1689,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
         let variant_name = self.body_interner().resolve(&*variant).to_string();
         let variant_index = def.find_variant(&variant_name).ok_or_compile_error(
             ErrorKind::UnknownVariant {
-                enum_name: def.name.clone(),
+                enum_name: def.name.to_string(),
                 variant_name: variant_name.clone(),
             },
             pattern_span,

--- a/crates/rue-air/src/sema/declarations.rs
+++ b/crates/rue-air/src/sema/declarations.rs
@@ -10,6 +10,7 @@
 //! - Validating @copy structs
 
 use std::collections::{HashMap, HashSet};
+use std::sync::Arc;
 
 use lasso::Spur;
 use rue_error::{CompileError, CompileResult, ErrorKind};
@@ -341,13 +342,13 @@ impl<'a> Sema<'a, super::MutableDeclarations> {
                     }
 
                     // Convert variant symbols to strings
-                    let variant_names: Vec<String> = variants
+                    let variant_names: Arc<[Arc<str>]> = variants
                         .iter()
-                        .map(|v| self.interner.resolve(&*v).to_string())
+                        .map(|v| Arc::from(self.interner.resolve(&*v)))
                         .collect();
 
                     let enum_def = EnumDef {
-                        name: enum_name,
+                        name: Arc::from(enum_name.as_str()),
                         variants: variant_names,
                         // Payload types are resolved in phase 2
                         // (`resolve_enum_payloads`), once all type names are
@@ -392,7 +393,7 @@ impl<'a> Sema<'a, super::MutableDeclarations> {
 
                     // Create placeholder struct def (fields will be resolved in phase 2)
                     let struct_def = StructDef {
-                        name: struct_name,
+                        name: Arc::from(struct_name.as_str()),
                         fields: Vec::new(), // Filled in during resolve_declarations
                         is_copy,
                         is_linear: *is_linear,
@@ -576,7 +577,7 @@ impl<'a> Sema<'a, super::MutableDeclarations> {
             self.capture_declaration_type(
                 info.span.file_id,
                 self.interner.resolve(&method_name).to_string(),
-                Some(owner.name.clone()),
+                Some(owner.name.to_string()),
                 source_kind,
                 Edge::Owner,
                 Type::new_struct(struct_id),
@@ -587,7 +588,7 @@ impl<'a> Sema<'a, super::MutableDeclarations> {
                 self.capture_declaration_type(
                     info.span.file_id,
                     self.interner.resolve(&method_name).to_string(),
-                    Some(owner.name.clone()),
+                    Some(owner.name.to_string()),
                     source_kind,
                     Edge::Signature,
                     ty,
@@ -711,7 +712,7 @@ impl<'a> Sema<'a, super::MutableDeclarations> {
                     source_kind,
                     dependency_kind,
                     target_file: target_file.index(),
-                    target_name,
+                    target_name: target_name.to_string(),
                     target_kind,
                 });
             self.body_analysis_work.declaration_type_dependency_events += 1;

--- a/crates/rue-air/src/sema/ordinary_engine.rs
+++ b/crates/rue-air/src/sema/ordinary_engine.rs
@@ -9,6 +9,7 @@
 //! exact facts.
 
 use std::collections::{HashMap, HashSet};
+use std::sync::Arc;
 
 use lasso::{Spur, ThreadedRodeo};
 use rue_error::{CompileError, CompileResult, CompileWarning, ErrorKind};
@@ -717,7 +718,7 @@ impl<'h, H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'h, H> {
             .body_type_pool()
             .intern_ptr_const_from_type(Type::U8);
         let struct_def = StructDef {
-            name: "str".to_owned(),
+            name: Arc::from("str"),
             fields: vec![
                 StructField {
                     name: "ptr".to_owned(),
@@ -989,9 +990,9 @@ impl<'h, H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'h, H> {
             && fields
                 .iter()
                 .all(|field| field.ty.is_copy_in_pool(self.storage.body_type_pool()));
-        let destructor = has_destructor.then(|| format!("{name}.__drop"));
+        let destructor = has_destructor.then(|| Arc::from(format!("{name}.__drop").as_str()));
         let def = crate::types::StructDef {
-            name,
+            name: Arc::from(name.as_str()),
             fields: fields.to_vec(),
             is_copy,
             is_linear: false,
@@ -1057,8 +1058,8 @@ impl<'h, H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'h, H> {
         name.push_str(" }");
         let name_spur = self.storage.body_interner().get_or_intern(&name);
         let def = crate::types::EnumDef {
-            name,
-            variants: names.to_vec(),
+            name: Arc::from(name.as_str()),
+            variants: names.iter().map(|n| Arc::from(n.as_str())).collect(),
             variant_payloads: payloads.to_vec(),
             is_pub: false,
             file_id: FileId::new(0),
@@ -1363,7 +1364,7 @@ impl<'h, H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'h, H> {
             && def.name.ends_with(']')
             && crate::types::parse_array_type_syntax(&def.name).is_none();
         let is_str_fixed = def.name.starts_with("Str(") && def.name.ends_with(')');
-        if is_slice || def.name == "str" || is_str_fixed {
+        if is_slice || &*def.name == "str" || is_str_fixed {
             if let crate::types::TypeKind::PtrConst(ptr_id) = def.fields[0].ty.kind() {
                 return Some(self.body_type_pool().ptr_const_def(ptr_id));
             }

--- a/crates/rue-air/src/sema/provider_body_host.rs
+++ b/crates/rue-air/src/sema/provider_body_host.rs
@@ -333,9 +333,9 @@ where
                 let def = self.type_pool.struct_def(id);
                 if let Some(identity) = self.issued_anonymous_identity_for_type(ty) {
                     T::AnonymousNominal(identity)
-                } else if def.is_builtin || def.name == "str" {
+                } else if def.is_builtin || &*def.name == "str" {
                     T::BuiltinNominal {
-                        name: Arc::from(def.name.as_str()),
+                        name: def.name.clone(),
                         kind: crate::SemanticImportNominalKind::Struct,
                     }
                 } else {
@@ -349,10 +349,10 @@ where
                     T::AnonymousNominal(identity)
                 } else if rue_builtins::BUILTIN_ENUMS
                     .iter()
-                    .any(|builtin| builtin.name == def.name)
+                    .any(|builtin| builtin.name == &*def.name)
                 {
                     T::BuiltinNominal {
-                        name: Arc::from(def.name.as_str()),
+                        name: def.name.clone(),
                         kind: crate::SemanticImportNominalKind::Enum,
                     }
                 } else {
@@ -386,10 +386,10 @@ where
             return Ok(crate::NominalInstanceKey::Anonymous(identity));
         }
         let def = self.type_pool.struct_def(id);
-        if def.is_builtin || def.name == "str" {
+        if def.is_builtin || &*def.name == "str" {
             return Ok(crate::NominalInstanceKey::Builtin {
                 kind: crate::AnonymousNominalKind::Struct,
-                name: def.name.as_str().into(),
+                name: def.name.clone(),
             });
         }
         let (token, _) = self.ensure_named_nominal_identity(ty, &def.name)?;
@@ -406,11 +406,11 @@ where
         let def = self.type_pool.enum_def(id);
         if rue_builtins::BUILTIN_ENUMS
             .iter()
-            .any(|builtin| builtin.name == def.name)
+            .any(|builtin| builtin.name == &*def.name)
         {
             return Ok(crate::NominalInstanceKey::Builtin {
                 kind: crate::AnonymousNominalKind::Enum,
-                name: def.name.as_str().into(),
+                name: def.name.clone(),
             });
         }
         if let Some(identity) = self.issued_anonymous_identity_for_type(ty) {
@@ -1989,7 +1989,7 @@ where
                             .enumerate()
                             .map(|(index, name)| {
                                 Ok((
-                                    Arc::from(name.as_str()),
+                                    name.clone(),
                                     definition
                                         .variant_payload(index)
                                         .iter()

--- a/crates/rue-air/src/sema/semantic_body_export.rs
+++ b/crates/rue-air/src/sema/semantic_body_export.rs
@@ -714,7 +714,7 @@ impl<D: DeclarationPhase> Sema<'_, D> {
         self.stable_definition_token(
             info.span.file_id.index(),
             method,
-            Some(owner.name.as_str()),
+            Some(owner.name.as_ref()),
             if method == "__drop" {
                 StableDefinitionKind::Destructor
             } else if info.has_self {
@@ -770,11 +770,11 @@ impl BodySema<'_> {
         Ok(match self.canonical_anonymous_types.get(&ty) {
             Some(key) => crate::NominalInstanceKey::Anonymous(key.clone()),
             None if self.type_pool.struct_def(id).is_builtin
-                || self.type_pool.struct_def(id).name == "str" =>
+                || &*self.type_pool.struct_def(id).name == "str" =>
             {
                 crate::NominalInstanceKey::Builtin {
                     kind: crate::AnonymousNominalKind::Struct,
-                    name: Arc::from(self.type_pool.struct_def(id).name.as_str()),
+                    name: self.type_pool.struct_def(id).name.clone(),
                 }
             }
             None => crate::NominalInstanceKey::Named(self.struct_identity(id)?),
@@ -790,11 +790,11 @@ impl BodySema<'_> {
             Some(key) => crate::NominalInstanceKey::Anonymous(key.clone()),
             None if rue_builtins::BUILTIN_ENUMS
                 .iter()
-                .any(|builtin| builtin.name == self.type_pool.enum_def(id).name) =>
+                .any(|builtin| builtin.name == &*self.type_pool.enum_def(id).name) =>
             {
                 crate::NominalInstanceKey::Builtin {
                     kind: crate::AnonymousNominalKind::Enum,
-                    name: Arc::from(self.type_pool.enum_def(id).name.as_str()),
+                    name: self.type_pool.enum_def(id).name.clone(),
                 }
             }
             None => crate::NominalInstanceKey::Named(self.enum_identity(id)?),
@@ -819,7 +819,7 @@ impl<D: DeclarationPhase> Sema<'_, D> {
         }
         self.stable_definition_token(
             def.file_id.index(),
-            def.name.as_str(),
+            def.name.as_ref(),
             None,
             StableDefinitionKind::Struct,
         )
@@ -833,7 +833,7 @@ impl<D: DeclarationPhase> Sema<'_, D> {
         }
         self.stable_definition_token(
             def.file_id.index(),
-            def.name.as_str(),
+            def.name.as_ref(),
             None,
             StableDefinitionKind::Enum,
         )
@@ -914,11 +914,11 @@ impl BodySema<'_> {
                 {
                     SemanticImportType::Slice {
                         element: Box::new(self.export_body_type(element)?),
-                        name: Arc::from(def.name.as_str()),
+                        name: def.name.clone(),
                     }
-                } else if def.is_builtin || def.name == "str" {
+                } else if def.is_builtin || &*def.name == "str" {
                     SemanticImportType::BuiltinNominal {
-                        name: Arc::from(def.name.as_str()),
+                        name: def.name.clone(),
                         kind: crate::SemanticImportNominalKind::Struct,
                     }
                 } else {
@@ -931,10 +931,10 @@ impl BodySema<'_> {
                     SemanticImportType::AnonymousNominal(identity.clone())
                 } else if rue_builtins::BUILTIN_ENUMS
                     .iter()
-                    .any(|builtin| builtin.name == def.name)
+                    .any(|builtin| builtin.name == &*def.name)
                 {
                     SemanticImportType::BuiltinNominal {
-                        name: Arc::from(def.name.as_str()),
+                        name: def.name.clone(),
                         kind: crate::SemanticImportNominalKind::Enum,
                     }
                 } else {

--- a/crates/rue-air/src/sema/tests.rs
+++ b/crates/rue-air/src/sema/tests.rs
@@ -2446,7 +2446,7 @@ mod tests {
                 .type_pool
                 .all_struct_ids()
                 .map(|id| output.type_pool.struct_def(id))
-                .any(|s| s.name == "Point" && s.is_copy)
+                .any(|s| &*s.name == "Point" && s.is_copy)
         );
     }
 
@@ -2512,7 +2512,7 @@ mod tests {
                 .type_pool
                 .all_struct_ids()
                 .map(|id| output.type_pool.struct_def(id))
-                .any(|s| s.name == "StrBuf")
+                .any(|s| &*s.name == "StrBuf")
         );
     }
 
@@ -3318,7 +3318,7 @@ fn main() -> i32 {
             sema.type_pool
                 .all_struct_ids()
                 .iter()
-                .all(|id| sema.type_pool.struct_def(*id).name != "StrBuf")
+                .all(|id| &*sema.type_pool.struct_def(*id).name != "StrBuf")
         );
     }
 
@@ -3349,7 +3349,7 @@ fn main() -> i32 {
         // Check the pool definition
         let pool_def = sema.type_pool.get_struct_def(pool_point.unwrap()).unwrap();
 
-        assert_eq!(pool_def.name, "Point");
+        assert_eq!(&*pool_def.name, "Point");
         assert_eq!(pool_def.fields.len(), 2);
         assert_eq!(pool_def.fields[0].name, "x");
         assert_eq!(pool_def.fields[1].name, "y");
@@ -3382,11 +3382,11 @@ fn main() -> i32 {
         let enum_id = *registry_color.unwrap();
         let pool_def = sema.type_pool.enum_def(enum_id);
 
-        assert_eq!(pool_def.name, "Color");
+        assert_eq!(&*pool_def.name, "Color");
         assert_eq!(pool_def.variants.len(), 3);
-        assert_eq!(pool_def.variants[0], "Red");
-        assert_eq!(pool_def.variants[1], "Green");
-        assert_eq!(pool_def.variants[2], "Blue");
+        assert_eq!(&*pool_def.variants[0], "Red");
+        assert_eq!(&*pool_def.variants[1], "Green");
+        assert_eq!(&*pool_def.variants[2], "Blue");
     }
 
     #[test]

--- a/crates/rue-air/src/sema/typeck.rs
+++ b/crates/rue-air/src/sema/typeck.rs
@@ -9,6 +9,7 @@
 use super::ordinary_engine::{OrdinaryBodyAnalysisHost, OrdinaryBodyEngine};
 use std::collections::HashMap;
 use std::convert::Infallible;
+use std::sync::Arc;
 
 use lasso::Spur;
 use rue_error::{CompileError, CompileResult, ErrorKind, PreviewFeature};
@@ -2020,7 +2021,7 @@ impl<'source, D: DeclarationPhase> TypeSyntaxHost for Sema<'source, D> {
                 (!def.is_builtin && !self.anonymous_struct_ids.contains(&id))
                     .then_some((
                         def.file_id,
-                        def.name,
+                        def.name.to_string(),
                         super::DeclarationTypeDependencyTargetKind::Struct,
                     ))
                     .into_iter()
@@ -2033,7 +2034,7 @@ impl<'source, D: DeclarationPhase> TypeSyntaxHost for Sema<'source, D> {
                     .expect("resolved declaration type names a registered enum identity");
                 vec![(
                     def.file_id,
-                    def.name,
+                    def.name.to_string(),
                     super::DeclarationTypeDependencyTargetKind::Enum,
                 )]
             }
@@ -2233,18 +2234,18 @@ impl<'a, D: DeclarationPhase> Sema<'a, D> {
             TypeKind::Never => "!".to_string(),
             TypeKind::Error => "<error>".to_string(),
             // Nominal strings and generated string views are ordinary structs.
-            TypeKind::Struct(struct_id) => {
-                self.type_pool
-                    .struct_metadata(struct_id)
-                    .expect("struct type must have declaration metadata")
-                    .name
-            }
-            TypeKind::Enum(enum_id) => {
-                self.type_pool
-                    .enum_metadata(enum_id)
-                    .expect("enum type must have declaration metadata")
-                    .name
-            }
+            TypeKind::Struct(struct_id) => self
+                .type_pool
+                .struct_metadata(struct_id)
+                .expect("struct type must have declaration metadata")
+                .name
+                .to_string(),
+            TypeKind::Enum(enum_id) => self
+                .type_pool
+                .enum_metadata(enum_id)
+                .expect("enum type must have declaration metadata")
+                .name
+                .to_string(),
             TypeKind::Array(array_id) => {
                 let (element_type, length) = self.type_pool.array_def(array_id);
                 format!("[{}; {}]", self.format_type_name(element_type), length)
@@ -2373,7 +2374,7 @@ impl<'a, D: DeclarationPhase> Sema<'a, D> {
         let ptr_ty = Type::new_ptr_const(ptr_type_id);
 
         let struct_def = StructDef {
-            name: type_name.to_string(),
+            name: Arc::from(type_name),
             fields: vec![
                 StructField {
                     name: "ptr".to_string(),
@@ -2512,7 +2513,7 @@ impl<'a, D: DeclarationPhase> Sema<'a, D> {
         let ptr_ty = Type::new_ptr_const(ptr_type_id);
 
         let struct_def = StructDef {
-            name,
+            name: Arc::from(name.as_str()),
             fields: vec![
                 StructField {
                     name: "ptr".to_string(),
@@ -2544,7 +2545,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
     /// keeping `str` first-class (exempt from the slice second-class rule).
     pub(crate) fn is_str_struct(&self, ty: Type) -> bool {
         if let TypeKind::Struct(struct_id) = ty.kind() {
-            self.body_type_pool().struct_def(struct_id).name == "str"
+            &*self.body_type_pool().struct_def(struct_id).name == "str"
         } else {
             false
         }
@@ -2599,7 +2600,7 @@ impl<'a, D: DeclarationPhase> Sema<'a, D> {
             // + UTF-8 and shares the `{ptr, len}` shape, so `.len()` and byte
             // indexing route through the same slice/str path as `str`.
             let is_str_fixed = def.name.starts_with("Str(") && def.name.ends_with(')');
-            if is_slice || def.name == "str" || is_str_fixed {
+            if is_slice || &*def.name == "str" || is_str_fixed {
                 // Field 0 is `ptr const T`; recover T from its pointee.
                 if let TypeKind::PtrConst(ptr_id) = def.fields[0].ty.kind() {
                     return Some(self.type_pool.ptr_const_def(ptr_id));
@@ -2736,7 +2737,7 @@ impl<'a, D: DeclarationPhase> Sema<'a, D> {
                 if !def.is_builtin && !self.anonymous_struct_ids.contains(&id) {
                     self.record_resolved_declaration_type_target(
                         def.file_id,
-                        def.name,
+                        def.name.to_string(),
                         super::DeclarationTypeDependencyTargetKind::Struct,
                     );
                 }
@@ -2748,7 +2749,7 @@ impl<'a, D: DeclarationPhase> Sema<'a, D> {
                     .expect("resolved declaration type names a registered enum identity");
                 self.record_resolved_declaration_type_target(
                     def.file_id,
-                    def.name,
+                    def.name.to_string(),
                     super::DeclarationTypeDependencyTargetKind::Enum,
                 );
             }

--- a/crates/rue-air/src/semantic_import.rs
+++ b/crates/rue-air/src/semantic_import.rs
@@ -1112,8 +1112,8 @@ where
             let (id, _) = type_pool.register_enum(
                 symbol,
                 EnumDef {
-                    name: builtin.name.to_owned(),
-                    variants: builtin.variants.iter().map(|v| (*v).to_owned()).collect(),
+                    name: Arc::from(builtin.name),
+                    variants: builtin.variants.iter().map(|v| Arc::from(*v)).collect(),
                     variant_payloads: Vec::new(),
                     is_pub: true,
                     file_id: FileId::DEFAULT,
@@ -1178,8 +1178,8 @@ where
                 return Err(SemanticImportFailure::DuplicateNominalLocalIdentity);
             }
             let file_id = module_files[&nominal.module_path];
-            let name = nominal.name.to_string();
-            let symbol = interner.get_or_intern(&name);
+            let name = nominal.name.clone();
+            let symbol = interner.get_or_intern(name.as_ref());
             let value = match nominal.kind {
                 SemanticImportNominalKind::Struct => {
                     let (id, _) = type_pool.declare_struct(
@@ -1205,7 +1205,7 @@ where
                         symbol,
                         EnumDef {
                             name,
-                            variants: vec![],
+                            variants: Arc::from([]),
                             variant_payloads: vec![],
                             is_pub: nominal.is_public,
                             file_id,
@@ -1225,7 +1225,7 @@ where
         let (str_id, _) = type_pool.register_struct(
             str_symbol,
             StructDef {
-                name: "str".to_owned(),
+                name: Arc::from("str"),
                 fields: vec![
                     StructField {
                         name: "ptr".to_owned(),
@@ -1360,7 +1360,7 @@ where
                     let (id, _) = epoch.type_pool.declare_struct(
                         symbol,
                         StructDef {
-                            name: nominal.name.to_string(),
+                            name: nominal.name.clone(),
                             fields: Vec::new(),
                             is_copy: false,
                             is_linear: false,
@@ -1382,8 +1382,8 @@ where
                     let (id, _) = epoch.type_pool.declare_enum(
                         symbol,
                         EnumDef {
-                            name: nominal.name.to_string(),
-                            variants: Vec::new(),
+                            name: nominal.name.clone(),
+                            variants: Arc::from([]),
                             variant_payloads: Vec::new(),
                             is_pub: nominal.is_public,
                             file_id,
@@ -1582,7 +1582,7 @@ where
             let (id, _) = type_pool.register_struct(
                 symbol,
                 StructDef {
-                    name: name.to_string(),
+                    name: Arc::from(name.as_ref()),
                     fields: vec![
                         StructField {
                             name: "ptr".to_owned(),
@@ -1701,7 +1701,7 @@ where
                     let (id, _) = type_pool.register_struct(
                         symbol,
                         StructDef {
-                            name: name.to_string(),
+                            name: Arc::from(name.as_ref()),
                             fields: vec![
                                 StructField {
                                     name: "ptr".to_owned(),
@@ -1854,7 +1854,7 @@ where
                         element: Box::new(
                             self.export_type_local(self.type_pool.ptr_const_def(pointer))?,
                         ),
-                        name: Arc::from(def.name.as_str()),
+                        name: def.name.clone(),
                     }
                 } else if let Some(((name, kind), _)) = self
                     .builtins
@@ -1878,7 +1878,7 @@ where
                     // spelling is the durable classification; unrelated source
                     // structs never acquire that bit.
                     SemanticImportType::BuiltinNominal {
-                        name: Arc::from(def.name.as_str()),
+                        name: def.name.clone(),
                         kind: SemanticImportNominalKind::Struct,
                     }
                 } else {
@@ -2071,7 +2071,7 @@ where
                 id,
                 EnumDef {
                     name: metadata.name,
-                    variants: variants.iter().map(|(name, _)| name.to_string()).collect(),
+                    variants: variants.iter().map(|(name, _)| name.clone()).collect(),
                     variant_payloads,
                     is_pub: metadata.is_pub,
                     file_id: metadata.file_id,

--- a/crates/rue-air/src/type_properties.rs
+++ b/crates/rue-air/src/type_properties.rs
@@ -39,7 +39,7 @@ fn empty_struct(name: &str) -> StructDef {
 fn empty_enum(name: &str) -> EnumDef {
     EnumDef {
         name: name.into(),
-        variants: vec!["Only".into()],
+        variants: Arc::from(["Only".into()]),
         variant_payloads: vec![vec![]],
         is_pub: false,
         file_id: FileId::DEFAULT,

--- a/crates/rue-air/src/types.rs
+++ b/crates/rue-air/src/types.rs
@@ -6,6 +6,8 @@
 //! lifetimes. The system covers integer and boolean primitives, user structs
 //! and enums, references and raw pointers, and generic instantiations.
 
+use std::sync::Arc;
+
 use crate::type_encoding::{self, Composite, Decoded, Primitive};
 
 /// A unique identifier for a struct definition.
@@ -371,16 +373,20 @@ impl LangItem {
 /// Definition of a struct type.
 #[derive(Debug, Clone)]
 pub struct StructDef {
-    /// Struct name
-    pub name: String,
+    /// Struct name.
+    ///
+    /// Shared rather than owned: declaration metadata reads hand this name to
+    /// consumers by refcount instead of copying it out of the pool (RUE-1219).
+    pub name: Arc<str>,
     /// Fields in declaration order
     pub fields: Vec<StructField>,
     /// Whether this struct is marked with @copy (can be implicitly duplicated)
     pub is_copy: bool,
     /// Whether this struct is a linear type (must be consumed, cannot be dropped)
     pub is_linear: bool,
-    /// User-defined destructor function name, if any (e.g., "Data.__drop")
-    pub destructor: Option<String>,
+    /// User-defined destructor function name, if any (e.g., "Data.__drop").
+    /// Shared for the same reason as [`StructDef::name`].
+    pub destructor: Option<Arc<str>>,
     /// Whether this is a built-in type (e.g., String) injected by the compiler.
     ///
     /// Built-in types behave like regular structs but have runtime implementations
@@ -402,11 +408,6 @@ pub struct StructField {
 }
 
 impl StructDef {
-    /// Find a field by name and return its index and definition.
-    pub fn find_field(&self, name: &str) -> Option<(usize, &StructField)> {
-        self.fields.iter().enumerate().find(|(_, f)| f.name == name)
-    }
-
     /// Get the number of fields in this struct.
     pub fn field_count(&self) -> usize {
         self.fields.len()
@@ -416,10 +417,13 @@ impl StructDef {
 /// Definition of an enum type.
 #[derive(Debug, Clone)]
 pub struct EnumDef {
-    /// Enum name
-    pub name: String,
-    /// Variant names in declaration order
-    pub variants: Vec<String>,
+    /// Enum name. Shared for the same reason as [`StructDef::name`].
+    pub name: Arc<str>,
+    /// Variant names in declaration order.
+    ///
+    /// Shared as a whole so a declaration-metadata read copies neither the
+    /// sequence nor its names (RUE-1219).
+    pub variants: Arc<[Arc<str>]>,
     /// Payload field types for each variant, in declaration order (RUE-221,
     /// ADR-0038). Parallel to `variants`: `variant_payloads[i]` is the list of
     /// payload types carried by tuple variant `variants[i]`, or empty for a
@@ -437,11 +441,6 @@ impl EnumDef {
     /// Get the number of variants in this enum.
     pub fn variant_count(&self) -> usize {
         self.variants.len()
-    }
-
-    /// Find a variant by name and return its index.
-    pub fn find_variant(&self, name: &str) -> Option<usize> {
-        self.variants.iter().position(|v| v == name)
     }
 
     /// Get the payload field types carried by variant `index`.
@@ -1711,7 +1710,7 @@ mod tests {
     #[test]
     fn test_struct_def_find_field() {
         let def = StructDef {
-            name: "Point".to_string(),
+            name: "Point".into(),
             fields: vec![
                 StructField {
                     name: "x".to_string(),
@@ -1730,6 +1729,7 @@ mod tests {
             file_id: rue_span::FileId::DEFAULT,
         };
 
+        let def = crate::intern_pool::StructDefEntry::new(def);
         let (idx, field) = def.find_field("x").unwrap();
         assert_eq!(idx, 0);
         assert_eq!(field.name, "x");
@@ -1745,7 +1745,7 @@ mod tests {
     #[test]
     fn test_struct_def_field_count() {
         let empty = StructDef {
-            name: "Empty".to_string(),
+            name: "Empty".into(),
             fields: vec![],
             is_copy: false,
             is_linear: false,
@@ -1757,7 +1757,7 @@ mod tests {
         assert_eq!(empty.field_count(), 0);
 
         let with_fields = StructDef {
-            name: "Data".to_string(),
+            name: "Data".into(),
             fields: vec![
                 StructField {
                     name: "a".to_string(),
@@ -1787,8 +1787,8 @@ mod tests {
     #[test]
     fn test_enum_def_variant_count() {
         let empty = EnumDef {
-            name: "Empty".to_string(),
-            variants: vec![],
+            name: "Empty".into(),
+            variants: Arc::from([]),
             variant_payloads: Vec::new(),
             is_pub: false,
             file_id: rue_span::FileId::DEFAULT,
@@ -1796,8 +1796,8 @@ mod tests {
         assert_eq!(empty.variant_count(), 0);
 
         let color = EnumDef {
-            name: "Color".to_string(),
-            variants: vec!["Red".to_string(), "Green".to_string(), "Blue".to_string()],
+            name: "Color".into(),
+            variants: Arc::from(["Red".into(), "Green".into(), "Blue".into()]),
             variant_payloads: Vec::new(),
             is_pub: false,
             file_id: rue_span::FileId::DEFAULT,
@@ -1808,13 +1808,14 @@ mod tests {
     #[test]
     fn test_enum_def_find_variant() {
         let color = EnumDef {
-            name: "Color".to_string(),
-            variants: vec!["Red".to_string(), "Green".to_string(), "Blue".to_string()],
+            name: "Color".into(),
+            variants: Arc::from(["Red".into(), "Green".into(), "Blue".into()]),
             variant_payloads: Vec::new(),
             is_pub: false,
             file_id: rue_span::FileId::DEFAULT,
         };
 
+        let color = crate::intern_pool::EnumDefEntry::new(color);
         assert_eq!(color.find_variant("Red"), Some(0));
         assert_eq!(color.find_variant("Green"), Some(1));
         assert_eq!(color.find_variant("Blue"), Some(2));
@@ -1824,8 +1825,8 @@ mod tests {
     #[test]
     fn test_enum_def_discriminant_type_empty() {
         let empty = EnumDef {
-            name: "Empty".to_string(),
-            variants: vec![],
+            name: "Empty".into(),
+            variants: Arc::from([]),
             variant_payloads: Vec::new(),
             is_pub: false,
             file_id: rue_span::FileId::DEFAULT,
@@ -1837,8 +1838,8 @@ mod tests {
     fn test_enum_def_discriminant_type_small() {
         // 1-256 variants -> U8
         let small = EnumDef {
-            name: "Small".to_string(),
-            variants: vec!["A".to_string()],
+            name: "Small".into(),
+            variants: Arc::from(["A".into()]),
             variant_payloads: Vec::new(),
             is_pub: false,
             file_id: rue_span::FileId::DEFAULT,
@@ -1846,8 +1847,10 @@ mod tests {
         assert_eq!(small.discriminant_type(), Type::U8);
 
         let max_u8 = EnumDef {
-            name: "MaxU8".to_string(),
-            variants: (0..256).map(|i| format!("V{}", i)).collect(),
+            name: "MaxU8".into(),
+            variants: (0..256)
+                .map(|i| Arc::from(format!("V{}", i).as_str()))
+                .collect(),
             variant_payloads: Vec::new(),
             is_pub: false,
             file_id: rue_span::FileId::DEFAULT,
@@ -1859,8 +1862,10 @@ mod tests {
     fn test_enum_def_discriminant_type_medium() {
         // 257-65536 variants -> U16
         let medium = EnumDef {
-            name: "Medium".to_string(),
-            variants: (0..257).map(|i| format!("V{}", i)).collect(),
+            name: "Medium".into(),
+            variants: (0..257)
+                .map(|i| Arc::from(format!("V{}", i).as_str()))
+                .collect(),
             variant_payloads: Vec::new(),
             is_pub: false,
             file_id: rue_span::FileId::DEFAULT,

--- a/crates/rue-cfg/src/build.rs
+++ b/crates/rue-cfg/src/build.rs
@@ -394,7 +394,7 @@ impl<'a> CfgBuilder<'a> {
             return Some(R::UnsignedInteger);
         }
         if let TypeKind::Struct(struct_id) = ty.kind() {
-            let name = &self.type_pool.struct_def(struct_id).name;
+            let name: &str = &self.type_pool.struct_def(struct_id).name;
             if self.type_pool.is_strbuf(struct_id)
                 || name == "str"
                 || (name.starts_with("Str(") && name.ends_with(')'))
@@ -4150,7 +4150,7 @@ mod tests {
             let type_pool = TypeInternPool::new();
             let span = Span::new(0, 1);
             let struct_def = |name: &str, fields, destructor| StructDef {
-                name: name.to_string(),
+                name: name.into(),
                 fields,
                 is_copy: false,
                 is_linear: false,

--- a/crates/rue-cfg/src/inst.rs
+++ b/crates/rue-cfg/src/inst.rs
@@ -3042,6 +3042,8 @@ impl Cfg {
 
 #[cfg(test)]
 mod tests {
+    use std::sync::Arc;
+
     use super::*;
 
     #[test]
@@ -3252,7 +3254,7 @@ mod tests {
             interner.get_or_intern("Maybe"),
             EnumDef {
                 name: "Maybe".into(),
-                variants: vec!["None".into(), "Some".into()],
+                variants: Arc::from(["None".into(), "Some".into()]),
                 variant_payloads: vec![vec![], vec![Type::I32]],
                 is_pub: false,
                 file_id: FileId::DEFAULT,

--- a/crates/rue-cfg/src/opt/forward.rs
+++ b/crates/rue-cfg/src/opt/forward.rs
@@ -353,7 +353,7 @@ mod tests {
             .register_struct(
                 Spur::try_from_usize(0).unwrap(),
                 StructDef {
-                    name: "Test".to_string(),
+                    name: "Test".into(),
                     fields: vec![],
                     is_copy: false,
                     is_linear: false,

--- a/crates/rue-cfg/src/verify.rs
+++ b/crates/rue-cfg/src/verify.rs
@@ -923,7 +923,7 @@ impl<'a> Verifier<'a> {
             .and_then(|rest| rest.strip_suffix(')'))
             .is_some_and(|capacity| capacity.parse::<u64>().is_ok());
         is_fixed_str
-            && result_def.name == "str"
+            && &*result_def.name == "str"
             && source_def.fields.len() == result_def.fields.len()
             && source_def
                 .fields
@@ -1351,7 +1351,7 @@ mod tests {
         pool.register_struct(
             interner.get_or_intern(name),
             StructDef {
-                name: name.to_string(),
+                name: name.into(),
                 fields: field_types
                     .iter()
                     .enumerate()

--- a/crates/rue-codegen/src/cfg_lower.rs
+++ b/crates/rue-codegen/src/cfg_lower.rs
@@ -422,7 +422,7 @@ impl<'a> CfgLowerContext<'a> {
             TypeKind::Struct(struct_id) => {
                 let struct_def = self.type_pool.struct_def(struct_id);
                 self.is_strbuf(ty)
-                    || struct_def.name == "str"
+                    || &*struct_def.name == "str"
                     || (struct_def.name.starts_with("Str(") && struct_def.name.ends_with(')'))
             }
             _ => false,

--- a/crates/rue-codegen/src/param_storage.rs
+++ b/crates/rue-codegen/src/param_storage.rs
@@ -593,7 +593,7 @@ mod tests {
         let (struct_id, _) = type_pool.register_struct(
             interner.get_or_intern("PairLike"),
             rue_air::StructDef {
-                name: "PairLike".to_string(),
+                name: "PairLike".into(),
                 fields: vec![
                     rue_air::StructField {
                         name: "a".to_string(),

--- a/crates/rue-codegen/src/place_lower.rs
+++ b/crates/rue-codegen/src/place_lower.rs
@@ -484,7 +484,7 @@ mod tests {
         let (pair_id, _) = synthetic_types.register_struct(
             synthetic_interner.get_or_intern("IndexedPair"),
             StructDef {
-                name: "IndexedPair".to_string(),
+                name: "IndexedPair".into(),
                 fields: vec![
                     StructField {
                         name: "left".to_string(),

--- a/crates/rue-codegen/src/terminator_plan.rs
+++ b/crates/rue-codegen/src/terminator_plan.rs
@@ -654,7 +654,7 @@ mod tests {
         let (struct_id, _) = pool.register_struct(
             interner.get_or_intern(name),
             StructDef {
-                name: name.to_string(),
+                name: name.into(),
                 fields: struct_fields,
                 is_copy: true,
                 is_linear: false,

--- a/crates/rue-codegen/src/value_plan.rs
+++ b/crates/rue-codegen/src/value_plan.rs
@@ -2345,6 +2345,8 @@ pub fn assert_slot_policy(plan: ValuePlan, actual: usize) {
 
 #[cfg(test)]
 mod tests {
+    use std::sync::Arc;
+
     use super::{
         ComparisonPreparation, DebugValuePlan, IntegerExtension, IntegerWidth, IntrinsicArgPlan,
         IntrinsicOperation, MaterializationRequirement, MaterializedValue, OptionIntrinsic,
@@ -2413,7 +2415,7 @@ mod tests {
         let (str_id, _) = pool.register_struct(
             interner.get_or_intern("str"),
             StructDef {
-                name: "str".to_string(),
+                name: "str".into(),
                 fields: vec![
                     StructField {
                         name: "ptr".to_string(),
@@ -2435,7 +2437,7 @@ mod tests {
         let (struct_id, _) = pool.register_struct(
             interner.get_or_intern("CoverageStruct"),
             StructDef {
-                name: "CoverageStruct".to_string(),
+                name: "CoverageStruct".into(),
                 fields: vec![
                     StructField {
                         name: "left".to_string(),
@@ -2457,8 +2459,8 @@ mod tests {
         let (enum_id, _) = pool.register_enum(
             interner.get_or_intern("CoverageEnum"),
             EnumDef {
-                name: "CoverageEnum".to_string(),
-                variants: vec!["None".to_string(), "Some".to_string()],
+                name: "CoverageEnum".into(),
+                variants: Arc::from(["None".into(), "Some".into()]),
                 variant_payloads: vec![vec![], vec![Type::I32]],
                 is_pub: false,
                 file_id: FileId::DEFAULT,
@@ -2681,8 +2683,8 @@ mod tests {
         let (enum_id, _) = pool.register_enum(
             enum_name,
             EnumDef {
-                name: "ComparisonEnum".to_string(),
-                variants: vec!["First".to_string(), "Second".to_string()],
+                name: "ComparisonEnum".into(),
+                variants: Arc::from(["First".into(), "Second".into()]),
                 variant_payloads: vec![vec![], vec![]],
                 is_pub: false,
                 file_id: FileId::DEFAULT,
@@ -2923,7 +2925,7 @@ mod tests {
         let (struct_id, _) = strbuf_pool.register_struct(
             name,
             StructDef {
-                name: "StrBuf".to_string(),
+                name: "StrBuf".into(),
                 fields: vec![
                     StructField {
                         name: "ptr".to_string(),
@@ -3167,7 +3169,7 @@ mod tests {
         let (struct_id, _) = pool.register_struct(
             name,
             StructDef {
-                name: "DropAggregate".to_string(),
+                name: "DropAggregate".into(),
                 fields: vec![
                     StructField {
                         name: "first".to_string(),
@@ -3184,7 +3186,7 @@ mod tests {
                 ],
                 is_copy: false,
                 is_linear: false,
-                destructor: Some("DropAggregate::__drop".to_string()),
+                destructor: Some("DropAggregate::__drop".into()),
                 is_builtin: true,
                 is_pub: false,
                 file_id: FileId::DEFAULT,

--- a/crates/rue-compiler/src/drop_glue.rs
+++ b/crates/rue-compiler/src/drop_glue.rs
@@ -480,7 +480,7 @@ fn create_struct_drop_glue_function(
         } else {
             Some(rue_air::ImplicitDropDependencySourceEvent::NamedStruct {
                 file: struct_def.file_id.index(),
-                name: struct_def.name.clone(),
+                name: struct_def.name.to_string(),
             })
         },
         air: air
@@ -654,8 +654,8 @@ fn create_enum_drop_glue_function(
     }
     if planned_variants
         .iter()
-        .zip(&enum_def.variants)
-        .any(|(planned, live)| planned.name.as_ref() != live.as_str())
+        .zip(enum_def.variants.iter())
+        .any(|(planned, live)| planned.name.as_ref() != live.as_ref())
     {
         return Err(CompileError::without_span(ErrorKind::InternalError(
             "enum drop-glue plan disagrees with live variant order".into(),
@@ -745,7 +745,7 @@ fn create_enum_drop_glue_function(
         name: fn_name,
         implicit_drop_source: Some(rue_air::ImplicitDropDependencySourceEvent::NamedEnum {
             file: enum_def.file_id.index(),
-            name: enum_def.name.clone(),
+            name: enum_def.name.to_string(),
         }),
         air: air
             .finish(AirValidationContext::Canonical(type_pool))
@@ -928,11 +928,11 @@ mod tests {
             .register_struct(
                 symbol,
                 StructDef {
-                    name: name.to_string(),
+                    name: Arc::from(name),
                     fields,
                     is_copy: false,
                     is_linear: false,
-                    destructor: destructor.map(str::to_string),
+                    destructor: destructor.map(Arc::from),
                     is_builtin: false,
                     is_pub: false,
                     file_id: rue_span::FileId::DEFAULT,
@@ -948,12 +948,14 @@ mod tests {
         payloads: Vec<Vec<Type>>,
     ) -> EnumId {
         let symbol = interner.get_or_intern(name);
-        let variants = (0..payloads.len()).map(|i| format!("V{i}")).collect();
+        let variants = (0..payloads.len())
+            .map(|i| Arc::from(format!("V{i}").as_str()))
+            .collect();
         type_pool
             .register_enum(
                 symbol,
                 EnumDef {
-                    name: name.to_string(),
+                    name: Arc::from(name),
                     variants,
                     variant_payloads: payloads,
                     is_pub: false,
@@ -1199,7 +1201,7 @@ mod tests {
         let symbol = interner.get_or_intern("Choice");
         let make_enum = |file_id| EnumDef {
             name: "Choice".into(),
-            variants: vec!["Only".into()],
+            variants: Arc::from(["Only".into()]),
             variant_payloads: vec![vec![]],
             is_pub: false,
             file_id,

--- a/crates/rue-compiler/src/durable_cfg.rs
+++ b/crates/rue-compiler/src/durable_cfg.rs
@@ -619,7 +619,7 @@ impl CfgDomainProjection {
                                 crate::StableCallableId::Function(callable),
                             ));
                         if let Some(previous) =
-                            symbol_mappings.insert(source.clone(), machine.clone())
+                            symbol_mappings.insert(source.to_string(), machine.clone())
                             && previous != machine
                         {
                             return Err(CfgDomainFailure::Shape);

--- a/crates/rue-compiler/src/integration_tests.rs
+++ b/crates/rue-compiler/src/integration_tests.rs
@@ -617,7 +617,7 @@ mod integration_tests {
             let point = result
                 .type_pool
                 .all_struct_ids()
-                .find(|&id| result.type_pool.struct_def(id).name == "Point");
+                .find(|&id| &*result.type_pool.struct_def(id).name == "Point");
             assert!(point.is_some(), "Point struct should exist in pool");
         }
 

--- a/crates/rue-compiler/src/pipeline_tests.rs
+++ b/crates/rue-compiler/src/pipeline_tests.rs
@@ -884,7 +884,7 @@ mod tests {
         let named_strbufs = pool
             .all_struct_ids()
             .into_iter()
-            .filter(|id| pool.struct_def(*id).name == "StrBuf")
+            .filter(|id| &*pool.struct_def(*id).name == "StrBuf")
             .collect::<Vec<_>>();
         let canonical = named_strbufs
             .iter()
@@ -1038,7 +1038,7 @@ mod tests {
             .type_pool()
             .all_struct_ids()
             .into_iter()
-            .find(|id| semantic.type_pool().struct_def(*id).name == "StrBuf")
+            .find(|id| &*semantic.type_pool().struct_def(*id).name == "StrBuf")
             .unwrap();
         assert_eq!(semantic.type_pool().struct_lang_item(spoof), None);
         assert!(!semantic.type_pool().is_strbuf(spoof));
@@ -2123,12 +2123,12 @@ mod tests {
             let pool = semantic.type_pool();
             let mut names = std::collections::BTreeSet::new();
             for id in pool.all_struct_ids() {
-                if pool.struct_def(id).name == "Payload" {
+                if &*pool.struct_def(id).name == "Payload" {
                     names.insert(format!("struct:{}", pool.struct_symbol_name(id)));
                 }
             }
             for id in pool.all_enum_ids() {
-                if pool.enum_def(id).name == "Choice" {
+                if &*pool.enum_def(id).name == "Choice" {
                     names.insert(format!("enum:{}", pool.enum_symbol_name(id)));
                 }
             }
@@ -2246,13 +2246,13 @@ mod tests {
             .type_pool
             .all_struct_ids()
             .into_iter()
-            .find(|&id| state.type_pool.struct_def(id).name == "Inner")
+            .find(|&id| &*state.type_pool.struct_def(id).name == "Inner")
             .expect("Inner should be interned");
         let enum_id = state
             .type_pool
             .all_enum_ids()
             .into_iter()
-            .find(|&id| state.type_pool.enum_def(id).name == "E")
+            .find(|&id| &*state.type_pool.enum_def(id).name == "E")
             .expect("E should be interned");
         let array_id = state
             .type_pool

--- a/crates/rue-compiler/src/producer_nominal_acceptance_tests.rs
+++ b/crates/rue-compiler/src/producer_nominal_acceptance_tests.rs
@@ -160,8 +160,8 @@ fn bound_parse_i64_digest(semantic: &CanonicalSemanticOutput) -> String {
     );
     let def = semantic.type_pool().enum_def(parse[0].1);
     assert_eq!(
-        def.variants,
-        vec!["Some".to_string(), "None".to_string()],
+        def.variants.iter().map(Arc::as_ref).collect::<Vec<_>>(),
+        ["Some", "None"],
         "the ?-bound type must be Option-shaped",
     );
     assert_eq!(
@@ -169,7 +169,7 @@ fn bound_parse_i64_digest(semantic: &CanonicalSemanticOutput) -> String {
         &[rue_air::Type::I64],
         "the ?-bound Option must carry the i64 payload",
     );
-    def.name.clone()
+    def.name.to_string()
 }
 
 /// The producer digests of every `Some(i64)/None`-shaped anonymous enum in a
@@ -182,10 +182,10 @@ fn option_i64_pool_digests(semantic: &CanonicalSemanticOutput) -> BTreeSet<Strin
         .into_iter()
         .map(|id| pool.enum_def(id))
         .filter(|def| {
-            def.variants == vec!["Some".to_string(), "None".to_string()]
+            def.variants.iter().map(Arc::as_ref).eq(["Some", "None"])
                 && def.variant_payload(0) == [rue_air::Type::I64]
         })
-        .map(|def| def.name.clone())
+        .map(|def| def.name.to_string())
         .collect()
 }
 

--- a/crates/rue-compiler/src/queries.rs
+++ b/crates/rue-compiler/src/queries.rs
@@ -496,7 +496,7 @@ pub(crate) fn collect_function_cfg_queries(
                 name: std::sync::Arc::from("__drop"),
             },
         };
-        if let Some(previous) = legacy_to_stable.insert(source_symbol.clone(), identity.clone())
+        if let Some(previous) = legacy_to_stable.insert(source_symbol.to_string(), identity.clone())
             && previous != identity
         {
             return Err(CfgConstructionFailure {
@@ -830,7 +830,7 @@ pub(crate) fn collect_function_cfg_queries(
                                         rue_air::ImplicitNamedDestructorDependencyEvent {
                                             source: source.clone(),
                                             target_file: target.file_id.index(),
-                                            target_owner_name: target.name.clone(),
+                                            target_owner_name: target.name.to_string(),
                                         },
                                     );
                                 }

--- a/crates/rue-compiler/src/revisioned_query_database.rs
+++ b/crates/rue-compiler/src/revisioned_query_database.rs
@@ -22700,8 +22700,8 @@ pub(crate) mod test_support {
             TypeKind::Unit => "()".into(),
             TypeKind::Never => "!".into(),
             TypeKind::ComptimeType => "type".into(),
-            TypeKind::Struct(id) => pool.struct_def(id).name.clone(),
-            TypeKind::Enum(id) => pool.enum_def(id).name.clone(),
+            TypeKind::Struct(id) => pool.struct_def(id).name.to_string(),
+            TypeKind::Enum(id) => pool.enum_def(id).name.to_string(),
             TypeKind::Array(id) => {
                 let (element, len) = pool.array_def(id);
                 format!("[{}; {}]", endpoint_display(pool, element), len)
@@ -22746,7 +22746,7 @@ pub(crate) mod test_support {
             TypeKind::Struct(id) => {
                 let def = pool.struct_def(id);
                 EndpointNominalRender {
-                    display: def.name.clone(),
+                    display: def.name.to_string(),
                     is_copy: def.is_copy,
                     is_pub: def.is_pub,
                     symbol: pool.struct_symbol_name(id),
@@ -22760,14 +22760,14 @@ pub(crate) mod test_support {
             TypeKind::Enum(id) => {
                 let def = pool.enum_def(id);
                 EndpointNominalRender {
-                    display: def.name.clone(),
+                    display: def.name.to_string(),
                     is_copy: endpoint_is_copy(pool, ty),
                     is_pub: def.is_pub,
                     symbol: pool.enum_symbol_name(id),
                     members: def
                         .variants
                         .iter()
-                        .map(|variant| (variant.clone(), String::new()))
+                        .map(|variant| (variant.to_string(), String::new()))
                         .collect(),
                 }
             }
@@ -29354,7 +29354,7 @@ fn main() -> i32 {
                 interner.get_or_intern("Choice"),
                 EnumDef {
                     name: "Choice".into(),
-                    variants: vec!["Small".into(), "Wide".into()],
+                    variants: Arc::from(["Small".into(), "Wide".into()]),
                     variant_payloads: vec![
                         vec![Type::U8, Type::U64],
                         vec![Type::U32, Type::U16, Type::U64],
@@ -31308,8 +31308,8 @@ fn main() -> i32 {
             TypeKind::Bool => "bool".into(),
             TypeKind::Unit => "()".into(),
             TypeKind::Never => "!".into(),
-            TypeKind::Struct(id) => pool.struct_def(id).name.clone(),
-            TypeKind::Enum(id) => pool.enum_def(id).name.clone(),
+            TypeKind::Struct(id) => pool.struct_def(id).name.to_string(),
+            TypeKind::Enum(id) => pool.enum_def(id).name.to_string(),
             other => format!("{other:?}"),
         }
     }

--- a/crates/rue-oracle/src/lib.rs
+++ b/crates/rue-oracle/src/lib.rs
@@ -962,11 +962,11 @@ impl<'a> Interp<'a> {
 
     fn is_bare_str_type(&self, ty: Type) -> bool {
         ty.as_struct()
-            .is_some_and(|struct_id| self.state.type_pool.struct_def(struct_id).name == "str")
+            .is_some_and(|struct_id| &*self.state.type_pool.struct_def(struct_id).name == "str")
     }
 
     fn is_str_like_struct(&self, struct_id: rue_air::StructId) -> bool {
-        let name = &self.state.type_pool.struct_def(struct_id).name;
+        let name: &str = &self.state.type_pool.struct_def(struct_id).name;
         name == "str" || (name.starts_with("Str(") && name.ends_with(')'))
     }
 

--- a/crates/rue-oracle/src/tests.rs
+++ b/crates/rue-oracle/src/tests.rs
@@ -97,7 +97,7 @@ fn stable_str_equality_is_lowered_and_modeled_by_byte_content() {
             let TypeKind::Struct(struct_id) = cfg.get_inst(operand).ty.kind() else {
                 panic!("{function} operand is not the stable str nominal")
             };
-            assert_eq!(state.type_pool.struct_def(struct_id).name, "str");
+            assert_eq!(&*state.type_pool.struct_def(struct_id).name, "str");
         }
     }
     let outcome = run_state(state).expect("stable str equality must be modeled");

--- a/crates/rue-oracle/src/tests/place_contracts.rs
+++ b/crates/rue-oracle/src/tests/place_contracts.rs
@@ -201,7 +201,7 @@ fn validated_cfg_requires_the_complete_ordinary_nominal_chain_to_be_well_typed()
             .type_pool
             .all_struct_ids()
             .into_iter()
-            .find(|id| state.type_pool.struct_def(*id).name == "Header")
+            .find(|id| &*state.type_pool.struct_def(*id).name == "Header")
             .expect("ordinary Header nominal");
         let header_ty = Type::new_struct(header_struct);
         assert_eq!(state.type_pool.struct_def(header_struct).fields.len(), 3);
@@ -757,7 +757,7 @@ fn validated_cfg_allows_only_the_explicit_str_view_whole_place_read_coercion() {
         .map(|value| state.functions[probe_index].cfg.get_inst(value).ty)
         .find(|ty| {
             ty.as_struct()
-                .is_some_and(|struct_id| state.type_pool.struct_def(struct_id).name == "Str(3)")
+                .is_some_and(|struct_id| &*state.type_pool.struct_def(struct_id).name == "Str(3)")
         })
         .expect("Str(3) parameter type");
     let (read_value, read_type) = {


### PR DESCRIPTION
The two read costs RUE-1147's `Arc` conversion deliberately left behind:

**Member lookup is indexed.** `find_field`/`find_variant` were linear `String` scans per lookup. Each pooled definition now carries a `MemberNameIndex` — `(FNV-1a hash, position)` pairs sorted by hash, built once at install, probed with the caller confirming against the real name so a collision costs a comparison, never a wrong answer. Fixed seed, so identical pools probe identically. Interning member names to `Spur` was rejected because the pool's freeze contract explicitly keeps request-scoped interners out of type definitions; a `HashMap` index was **measured and rejected** (one allocation per member name pushed total allocations *up*). The bare-definition scan methods are deleted, making the indexed entries the single lookup path — the frozen pool included — and mutation flows through a private projection with no `DerefMut`, so the index cannot go stale (all five RUE-1147 mutation points re-verified).

**Metadata reads stop allocating.** `StructDeclarationMetadata`/`EnumDeclarationMetadata` allocated 2–3 `String`s per read across 28 sites — about half of which read no string at all. Name/destructor/variant strings are `Arc<str>` (variants `Arc<[Arc<str>]>`, since `enum_metadata` otherwise still allocated a `Vec` per read) end to end, turning the shell→complete handoff into a move. The ~6 consumers that genuinely need owned `String`s keep an explicit `.to_string()`. The definitions don't cross the durable boundary (that's `DurableNominal`, already `Arc<str>`), so no schema concern.

Measured (valgrind, full compiles): allocated bytes −0.31%/−0.35% on ruelex/jsonfmt; allocation counts roughly flat because the index adds one allocation per nominal against the metadata savings — decomposed honestly in the numbers, and much smaller than RUE-1147's win because these costs were an order of magnitude smaller to begin with. **Emitted binaries are sha256-identical across five example programs** against a baseline binary built from clean HEAD before the change.

One real bug fixed in passing: deriving `Debug` on the pool entry leaked `HashMap` iteration order into rendering that **14 warm-vs-fresh durable-output tests compare as strings** — they failed nondeterministically until `Debug` was hand-implemented to forward to the definition. Reviewers should know pool-entry `Debug` output is load-bearing for those comparisons.

Fixes RUE-1219.

## Validation

Premerge tier (78/78), quick (30/30, re-run post-rebase), rue-air 678 / cfg 237 / codegen 648 / compiler 775 (post-rebase), reproducible-programs, type-architecture validator, clippy, fmt.

---
_Generated by [Claude Code](https://claude.ai/code/session_01DrKqpQgkHzDHGqpEMjxYdN)_