### PR TITLE
RUE-1210: enforce runtime retention budgets

### DIFF
--- a/crates/rue-compiler/src/api_inventory.rs
+++ b/crates/rue-compiler/src/api_inventory.rs
@@ -811,7 +811,12 @@ fn unsupported_api_layout(source: &str, root: bool) -> Option<String> {
             && let Some(path) = macro_invocation_path(trimmed)
         {
             let name = path.rsplit("::").next().unwrap_or(path);
-            if root || !matches!(name, "thread_local" | "session_query_metrics_family") {
+            if root
+                || !matches!(
+                    name,
+                    "thread_local" | "session_query_metrics_family" | "query_value_charge"
+                )
+            {
                 return Some(trimmed.to_owned());
             }
         }
@@ -1277,6 +1282,7 @@ fn facade_stays_small_and_session_centered() {
             "integration_tests",
             "pipeline_tests",
             "producer_nominal_acceptance_tests",
+            "retained_charge",
             "scaling_harness",
             "supported_api_inventory",
             "test_support",

--- a/crates/rue-compiler/src/body_query.rs
+++ b/crates/rue-compiler/src/body_query.rs
@@ -4,6 +4,8 @@ use std::sync::Arc;
 
 use rue_query::QueryKey;
 
+use crate::retained_charge::RetainedCharge;
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct BodySourceLocator {
     pub(crate) file_id: rue_span::FileId,
@@ -480,6 +482,262 @@ pub(crate) fn body_closure_output_equal(
         && left.scheduling_errors == right.scheduling_errors
         && left.fatal == right.fatal
         && left.parked_toolchain == right.parked_toolchain
+}
+
+impl RetainedCharge for BodySourceLocator {
+    fn retained_charge(&self) -> u64 {
+        self.physical_path.retained_charge()
+    }
+}
+
+impl RetainedCharge for BodyDiagnosticCoordinate {
+    fn retained_charge(&self) -> u64 {
+        0
+    }
+}
+
+impl RetainedCharge for BodyDiagnosticBasis {
+    fn retained_charge(&self) -> u64 {
+        self.coordinates.retained_charge()
+    }
+}
+
+impl RetainedCharge for OwnedBodyInput {
+    fn retained_charge(&self) -> u64 {
+        self.owner
+            .retained_charge()
+            .saturating_add(self.source.retained_charge())
+            .saturating_add(self.signature.retained_charge())
+            .saturating_add(self.body.retained_charge())
+    }
+}
+
+impl RetainedCharge for BodyInputIncomplete {
+    fn retained_charge(&self) -> u64 {
+        match self {
+            Self::MissingPrerequisite(detail) => detail.retained_charge(),
+            Self::UnsupportedInstance | Self::UnsupportedKind(_) | Self::Generic | Self::Extern => {
+                0
+            }
+        }
+    }
+}
+
+impl RetainedCharge for BodyInputValue {
+    fn retained_charge(&self) -> u64 {
+        match self {
+            Self::Available(input) => input.retained_charge(),
+            Self::Incomplete(incomplete) => incomplete.retained_charge(),
+        }
+    }
+}
+
+impl RetainedCharge for BodyQueryKey {
+    fn retained_charge(&self) -> u64 {
+        self.instance.retained_charge()
+    }
+}
+
+impl RetainedCharge for CanonicalBody {
+    fn retained_charge(&self) -> u64 {
+        match self {
+            Self::Ordinary { owner, body } => owner
+                .retained_charge()
+                .saturating_add(body.retained_charge()),
+            Self::Anonymous { identity, body, .. } => identity
+                .retained_charge()
+                .saturating_add(body.retained_charge()),
+            Self::Specialization {
+                identity,
+                body,
+                dependencies,
+                ..
+            } => identity
+                .retained_charge()
+                .saturating_add(body.retained_charge())
+                .saturating_add(dependencies.retained_charge()),
+        }
+    }
+}
+
+impl RetainedCharge for BodyReference {
+    fn retained_charge(&self) -> u64 {
+        match self {
+            Self::Callable(value) => value.retained_charge(),
+            Self::Definition(value) => value.retained_charge(),
+            Self::Type(value) | Self::DropGlue(value) => value.retained_charge(),
+        }
+    }
+}
+
+impl RetainedCharge for WellKnownOptionResolution {
+    fn retained_charge(&self) -> u64 {
+        self.option_by_payload
+            .retained_charge()
+            .saturating_add(self.anonymous_nominals.retained_charge())
+    }
+}
+
+impl RetainedCharge for BodyReferences {
+    fn retained_charge(&self) -> u64 {
+        self.0.retained_charge()
+    }
+}
+
+impl RetainedCharge for BodyLookupObservations {
+    fn retained_charge(&self) -> u64 {
+        self.terminals.retained_charge()
+    }
+}
+
+impl RetainedCharge for BodyTransactionControl {
+    fn retained_charge(&self) -> u64 {
+        match self {
+            Self::DeferredAnonymousProducers(values) => values.retained_charge(),
+            Self::ProducerFailed(failure) => failure.retained_charge(),
+            Self::WellKnownOptionResolution(failure) => failure.retained_charge(),
+        }
+    }
+}
+
+impl RetainedCharge for WellKnownOptionResolutionFailure {
+    fn retained_charge(&self) -> u64 {
+        match self {
+            Self::Incomplete {
+                prerequisite,
+                detail,
+                ..
+            } => prerequisite
+                .retained_charge()
+                .saturating_add(detail.retained_charge()),
+            Self::Semantic { failure, .. } => failure.retained_charge(),
+            Self::WrongProjection { detail, .. } => detail.retained_charge(),
+        }
+    }
+}
+
+impl RetainedCharge for BodyProducedAnonymousNominals {
+    fn retained_charge(&self) -> u64 {
+        self.0.retained_charge()
+    }
+}
+
+impl RetainedCharge for BodyConsultedAnonymousNominals {
+    fn retained_charge(&self) -> u64 {
+        self.0.retained_charge()
+    }
+}
+
+impl RetainedCharge for ProducedAnonymous {
+    fn retained_charge(&self) -> u64 {
+        match self {
+            Self::Produced(value) => value.retained_charge(),
+            Self::ProducerFailed(failure) => failure.retained_charge(),
+        }
+    }
+}
+
+impl RetainedCharge for BodyTransaction {
+    fn retained_charge(&self) -> u64 {
+        match self {
+            Self::Success {
+                body,
+                references,
+                produced_anonymous_nominals,
+                consulted_anonymous_nominals,
+                lookup_observations,
+            } => body
+                .retained_charge()
+                .saturating_add(references.retained_charge())
+                .saturating_add(produced_anonymous_nominals.retained_charge())
+                .saturating_add(consulted_anonymous_nominals.retained_charge())
+                .saturating_add(lookup_observations.retained_charge()),
+            Self::DeterministicFailure {
+                errors,
+                diagnostic_basis,
+                references,
+                lookup_observations,
+            } => errors
+                .retained_charge()
+                .saturating_add(diagnostic_basis.retained_charge())
+                .saturating_add(references.retained_charge())
+                .saturating_add(lookup_observations.retained_charge()),
+            Self::Control(control) => control.retained_charge(),
+        }
+    }
+}
+
+impl RetainedCharge for BodyAnalysisBundle {
+    fn retained_charge(&self) -> u64 {
+        self.transaction
+            .retained_charge()
+            .saturating_add(self.produced_anonymous.retained_charge())
+    }
+}
+
+impl RetainedCharge for BodyClosureBody {
+    fn retained_charge(&self) -> u64 {
+        self.key
+            .retained_charge()
+            .saturating_add(self.bundle.retained_charge())
+    }
+}
+
+impl RetainedCharge for BodyClosureFatal {
+    fn retained_charge(&self) -> u64 {
+        match self {
+            Self::DeclarationFailed {
+                declaration,
+                failure,
+            } => declaration
+                .retained_charge()
+                .saturating_add(failure.retained_charge()),
+            Self::BodyAvailability { instance, detail } => instance
+                .retained_charge()
+                .saturating_add(detail.retained_charge()),
+            Self::TypeQuery {
+                ty: Some(instance),
+                detail,
+            } => instance
+                .retained_charge()
+                .saturating_add(detail.retained_charge()),
+            Self::TypeQuery { ty: None, detail } => detail.retained_charge(),
+            Self::ProducerFailed { instance, failure } => instance
+                .retained_charge()
+                .saturating_add(failure.retained_charge()),
+            Self::WellKnownOptionResolution { instance, failure } => instance
+                .retained_charge()
+                .saturating_add(failure.retained_charge()),
+            Self::AnonymousDigestCollision { first, second, .. } => first
+                .retained_charge()
+                .saturating_add(second.retained_charge()),
+        }
+    }
+}
+
+impl RetainedCharge for BodyReachabilityOutput {
+    fn retained_charge(&self) -> u64 {
+        self.reached
+            .retained_charge()
+            .saturating_add(self.demanded_drop_glue.retained_charge())
+            .saturating_add(self.demanded_drop_glue_plans.retained_charge())
+            .saturating_add(self.scheduling_errors.retained_charge())
+            .saturating_add(self.fatal.retained_charge())
+            .saturating_add(self.parked_toolchain.retained_charge())
+    }
+}
+
+impl RetainedCharge for BodyClosureOutput {
+    fn retained_charge(&self) -> u64 {
+        self.reached
+            .retained_charge()
+            .saturating_add(self.demanded_drop_glue.retained_charge())
+            .saturating_add(self.demanded_drop_glue_plans.retained_charge())
+            .saturating_add(self.bodies.retained_charge())
+            .saturating_add(self.scheduling_errors.retained_charge())
+            .saturating_add(self.fatal.retained_charge())
+            .saturating_add(self.parked_toolchain.retained_charge())
+    }
 }
 
 impl BodyTransaction {

--- a/crates/rue-compiler/src/canonical_lower.rs
+++ b/crates/rue-compiler/src/canonical_lower.rs
@@ -9,6 +9,7 @@ use rue_rir::RirPrinter;
 use rue_rir::{AstGen, InstRef, Rir, RirEditor, RirValidationContext, ValidatedRir};
 use rue_span::FileId;
 
+use crate::retained_charge::RetainedCharge;
 use crate::{CanonicalMergedProgram, SemanticSymbolUniverse, SourceRevision};
 
 /// Structural work performed by canonical RIR lowering.
@@ -83,6 +84,24 @@ impl ModuleRirOutput {
             Arc::try_unwrap(self.symbols.into_interner())
                 .expect("module RIR owns its semantic symbol interner"),
         ))
+    }
+}
+
+impl RetainedCharge for ModuleRirOutput {
+    fn retained_charge(&self) -> u64 {
+        let instructions = self
+            .rir
+            .len()
+            .saturating_mul(std::mem::size_of::<rue_rir::Inst>()) as u64;
+        let payload = self
+            .rir
+            .extra_len()
+            .saturating_mul(std::mem::size_of::<u32>()) as u64;
+        self.revision
+            .retained_charge()
+            .saturating_add(instructions)
+            .saturating_add(payload)
+            .saturating_add(self.symbols.retained_charge())
     }
 }
 

--- a/crates/rue-compiler/src/cfg_query.rs
+++ b/crates/rue-compiler/src/cfg_query.rs
@@ -11,6 +11,8 @@ use std::sync::Arc;
 use rue_query::{QueryAbort, QueryContext, QueryFamily, QueryKey, QueryOutcome, QueryOutput};
 use rue_span::Span;
 
+use crate::retained_charge::RetainedCharge;
+
 #[cfg(test)]
 use std::cell::Cell;
 
@@ -247,6 +249,158 @@ pub(crate) enum CfgValue {
         errors: crate::CompileErrors,
         body_span: Span,
     },
+}
+
+impl RetainedCharge for lasso::ThreadedRodeo {
+    fn retained_charge(&self) -> u64 {
+        let entries = (self.len() * std::mem::size_of::<lasso::Spur>()) as u64;
+        self.strings().fold(entries, |charge, value| {
+            charge.saturating_add(value.len() as u64)
+        })
+    }
+}
+
+impl RetainedCharge for rue_air::ValidatedAir {
+    fn retained_charge(&self) -> u64 {
+        let payload = self.payload_store_stats();
+        std::mem::size_of_val(self.instructions()) as u64
+            + payload.word_store_logical_bytes as u64
+            + payload.projection_store_logical_bytes as u64
+            + payload.place_store_logical_bytes as u64
+            + std::mem::size_of_val(self.param_drops()) as u64
+    }
+}
+
+impl RetainedCharge for rue_cfg::ValidatedCfg {
+    fn retained_charge(&self) -> u64 {
+        let payload = self.payload_storage_stats();
+        let blocks = std::mem::size_of_val(self.blocks()) as u64;
+        let blocks = self.blocks().iter().fold(blocks, |charge, block| {
+            charge
+                .saturating_add(
+                    (block.params.len() * std::mem::size_of::<(rue_cfg::CfgValue, rue_air::Type)>())
+                        as u64,
+                )
+                .saturating_add(
+                    (block.insts.len() * std::mem::size_of::<rue_cfg::CfgValue>()) as u64,
+                )
+        });
+        blocks
+            .saturating_add((self.value_count() * std::mem::size_of::<rue_cfg::CfgInst>()) as u64)
+            .saturating_add(payload.value_store_logical_bytes as u64)
+            .saturating_add(payload.call_store_logical_bytes as u64)
+            .saturating_add(payload.switch_store_logical_bytes as u64)
+            .saturating_add(payload.projection_store_logical_bytes as u64)
+            .saturating_add(self.fn_name().len() as u64)
+            .saturating_add((self.param_modes().len() * 2 * std::mem::size_of::<bool>()) as u64)
+            .saturating_add(std::mem::size_of_val(self.source_param_abi()) as u64)
+    }
+}
+
+impl RetainedCharge for rue_air::FrozenTypeInternPool {
+    fn retained_charge(&self) -> u64 {
+        let mut charge = (self.len() * std::mem::size_of::<rue_air::Type>()) as u64;
+        for ty in self.all_types() {
+            if let Some(id) = ty.as_struct() {
+                let definition = self.struct_def(id);
+                charge = charge
+                    .saturating_add(definition.name.len() as u64)
+                    .saturating_add(
+                        (definition.fields.len() * std::mem::size_of::<rue_air::StructField>())
+                            as u64,
+                    )
+                    .saturating_add(definition.destructor.retained_charge());
+                charge = definition.fields.iter().fold(charge, |charge, field| {
+                    charge.saturating_add(field.name.len() as u64)
+                });
+            } else if let Some(id) = ty.as_enum() {
+                let definition = self.enum_def(id);
+                charge = charge
+                    .saturating_add(definition.name.len() as u64)
+                    .saturating_add(definition.variants.retained_charge())
+                    .saturating_add(
+                        (definition.variant_payloads.len()
+                            * std::mem::size_of::<Vec<rue_air::Type>>())
+                            as u64,
+                    );
+                charge = definition
+                    .variant_payloads
+                    .iter()
+                    .fold(charge, |charge, payload| {
+                        charge.saturating_add(
+                            (payload.len() * std::mem::size_of::<rue_air::Type>()) as u64,
+                        )
+                    });
+            }
+        }
+        charge
+    }
+}
+
+impl RetainedCharge for CfgBodyInput {
+    fn retained_charge(&self) -> u64 {
+        self.function
+            .retained_charge()
+            .saturating_add(self.canonical.retained_charge())
+    }
+}
+
+impl RetainedCharge for CfgSemanticInput {
+    fn retained_charge(&self) -> u64 {
+        match self {
+            Self::Body {
+                input,
+                materialization,
+            } => input
+                .retained_charge()
+                .saturating_add(materialization.retained_charge()),
+            Self::DropGlue {
+                owner,
+                facts,
+                materialization,
+                ..
+            } => owner
+                .retained_charge()
+                .saturating_add(facts.retained_charge())
+                .saturating_add(materialization.retained_charge()),
+        }
+    }
+}
+
+impl RetainedCharge for CfgCodegenDomain {
+    fn retained_charge(&self) -> u64 {
+        self.defined_symbol
+            .retained_charge()
+            .saturating_add(self.symbol_mappings.retained_charge())
+            .saturating_add(self.foreign_symbols.retained_charge())
+    }
+}
+
+impl RetainedCharge for CfgRecord {
+    fn retained_charge(&self) -> u64 {
+        self.air
+            .retained_charge()
+            .saturating_add(self.source_name.retained_charge())
+            .saturating_add(self.cfg.retained_charge())
+            .saturating_add(self.domains.retained_charge())
+            .saturating_add(self.type_pool.retained_charge())
+            .saturating_add(self.interner.retained_charge())
+            .saturating_add(self.strings.retained_charge())
+            .saturating_add(self.local_atoms.retained_charge())
+            .saturating_add(self.codegen.retained_charge())
+            .saturating_add(self.materialization_warnings.retained_charge())
+            .saturating_add(self.warnings.retained_charge())
+            .saturating_add(self.implicit_destructor_targets.retained_charge())
+    }
+}
+
+impl RetainedCharge for CfgValue {
+    fn retained_charge(&self) -> u64 {
+        match self {
+            Self::Available(record) => record.retained_charge(),
+            Self::Failure { errors, .. } => errors.retained_charge(),
+        }
+    }
 }
 
 pub(crate) fn cfg_value_equal(left: &CfgValue, right: &CfgValue) -> bool {

--- a/crates/rue-compiler/src/codegen_query.rs
+++ b/crates/rue-compiler/src/codegen_query.rs
@@ -14,6 +14,8 @@ use std::{
 
 use rue_query::{QueryAbort, QueryContext, QueryFamily, QueryKey, QueryOutcome, QueryOutput};
 
+use crate::retained_charge::RetainedCharge;
+
 #[cfg(test)]
 use std::cell::Cell;
 
@@ -210,6 +212,113 @@ pub(crate) struct NormalizedRelocation {
     pub(crate) symbol: Arc<str>,
     pub(crate) kind: rue_codegen::RelocationKind,
     pub(crate) addend: i64,
+}
+
+impl RetainedCharge for rue_codegen::LoweringDecision {
+    fn retained_charge(&self) -> u64 {
+        self.cfg_inst_desc
+            .retained_charge()
+            .saturating_add(self.cfg_type.retained_charge())
+            .saturating_add(self.mir_insts.retained_charge())
+            .saturating_add(self.rationale.retained_charge())
+    }
+}
+
+impl RetainedCharge for rue_codegen::terminator_plan::TerminatorTrace {
+    fn retained_charge(&self) -> u64 {
+        let edge_work = self.edge_work.iter().fold(
+            (self.edge_work.len() * std::mem::size_of::<Vec<(u32, u32)>>()) as u64,
+            |charge, edge| {
+                charge.saturating_add((edge.len() * std::mem::size_of::<(u32, u32)>()) as u64)
+            },
+        );
+        ((self.successors.len() * std::mem::size_of::<rue_cfg::BlockId>()) as u64)
+            .saturating_add((self.fallthrough.len() * std::mem::size_of::<bool>()) as u64)
+            .saturating_add((self.edge_move_counts.len() * std::mem::size_of::<usize>()) as u64)
+            .saturating_add(edge_work)
+            .saturating_add(
+                (self.switch_cases.len() * std::mem::size_of::<(i64, rue_cfg::BlockId)>()) as u64,
+            )
+    }
+}
+
+impl RetainedCharge for rue_codegen::TerminatorLoweringDecision {
+    fn retained_charge(&self) -> u64 {
+        self.terminator_desc
+            .retained_charge()
+            .saturating_add(self.mir_insts.retained_charge())
+            .saturating_add(self.rationale.retained_charge())
+            .saturating_add(self.policy_trace.retained_charge())
+    }
+}
+
+impl RetainedCharge for rue_codegen::BlockLoweringInfo {
+    fn retained_charge(&self) -> u64 {
+        self.instructions
+            .retained_charge()
+            .saturating_add(self.terminator.retained_charge())
+    }
+}
+
+impl RetainedCharge for rue_codegen::LoweringDebugInfo {
+    fn retained_charge(&self) -> u64 {
+        self.fn_name
+            .retained_charge()
+            .saturating_add(self.target_arch.retained_charge())
+            .saturating_add(self.blocks.retained_charge())
+    }
+}
+
+impl RetainedCharge for rue_codegen::BackendArtifacts {
+    fn retained_charge(&self) -> u64 {
+        self.lowering
+            .retained_charge()
+            .saturating_add(self.mir.retained_charge())
+            .saturating_add(self.liveness.retained_charge())
+            .saturating_add(self.regalloc.retained_charge())
+            .saturating_add(self.asm.retained_charge())
+    }
+}
+
+impl RetainedCharge for SectionContents {
+    fn retained_charge(&self) -> u64 {
+        self.bytes.retained_charge()
+    }
+}
+
+impl RetainedCharge for CodegenSection {
+    fn retained_charge(&self) -> u64 {
+        self.contents
+            .retained_charge()
+            .saturating_add(self.atoms.retained_charge())
+    }
+}
+
+impl RetainedCharge for NormalizedRelocation {
+    fn retained_charge(&self) -> u64 {
+        self.symbol.retained_charge()
+    }
+}
+
+impl RetainedCharge for CodegenUnit {
+    fn retained_charge(&self) -> u64 {
+        self.defined_symbol
+            .retained_charge()
+            .saturating_add(self.referenced_symbols.retained_charge())
+            .saturating_add(self.relocations.retained_charge())
+            .saturating_add(self.sections.retained_charge())
+            .saturating_add(self.artifacts.retained_charge())
+            .saturating_add(self.presentation.retained_charge())
+    }
+}
+
+impl RetainedCharge for CodegenUnitValue {
+    fn retained_charge(&self) -> u64 {
+        match self {
+            Self::Available(unit) => unit.retained_charge(),
+            Self::Failure(errors) => errors.retained_charge(),
+        }
+    }
 }
 
 const BACKEND_EPOCH: u32 = 1;

--- a/crates/rue-compiler/src/durable_cfg.rs
+++ b/crates/rue-compiler/src/durable_cfg.rs
@@ -6,6 +6,7 @@ use rue_air::{AirInstData, AnalyzedFunction, SemanticImportType, Type, TypeKind}
 use rue_span::Span;
 
 use crate::DurableAirInstData;
+use crate::retained_charge::RetainedCharge;
 
 type CanonicalType = SemanticImportType<crate::StableDefinitionKey, crate::ModuleId>;
 
@@ -276,6 +277,16 @@ enum StableCfgSymbol {
     Intrinsic(Arc<str>),
 }
 
+impl RetainedCharge for StableCfgSymbol {
+    fn retained_charge(&self) -> u64 {
+        match self {
+            Self::Callable(value) => value.retained_charge(),
+            Self::Specialization(value) => value.retained_charge(),
+            Self::Runtime(value) | Self::Intrinsic(value) => value.retained_charge(),
+        }
+    }
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum StableCfgSpan {
     Relative { start: i64, end: i64 },
@@ -317,6 +328,27 @@ pub(crate) struct CfgDomainProjection {
     spans: Vec<(Span, StableCfgSpan)>,
     symbols: Vec<(Spur, StableCfgSymbol)>,
     incomplete_epoch: Option<Arc<()>>,
+}
+
+impl RetainedCharge for CfgDomainProjection {
+    fn retained_charge(&self) -> u64 {
+        let types = (self.types.len() * std::mem::size_of::<(Type, CanonicalType)>()) as u64;
+        let types = self.types.iter().fold(types, |charge, (_, ty)| {
+            charge.saturating_add(ty.retained_charge())
+        });
+        let symbols = (self.symbols.len() * std::mem::size_of::<(Spur, StableCfgSymbol)>()) as u64;
+        let symbols = self.symbols.iter().fold(symbols, |charge, (_, symbol)| {
+            charge.saturating_add(symbol.retained_charge())
+        });
+        types
+            .saturating_add(self.strings.retained_charge())
+            .saturating_add(self.atoms.retained_charge())
+            .saturating_add(
+                (self.spans.len() * std::mem::size_of::<(Span, StableCfgSpan)>()) as u64,
+            )
+            .saturating_add(symbols)
+            .saturating_add(self.incomplete_epoch.retained_charge())
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/crates/rue-compiler/src/durable_semantics.rs
+++ b/crates/rue-compiler/src/durable_semantics.rs
@@ -15,6 +15,7 @@ use rue_air::{
 use rue_air::{SemanticExportFailure, SemanticImportNominalKind};
 use rue_span::FileId;
 
+use crate::retained_charge::RetainedCharge;
 use crate::{
     BoundDefinitionSet, CanonicalMergedProgram, ModuleId, StableDefinitionKey, StableDefinitionKind,
 };
@@ -141,6 +142,95 @@ pub struct DurableDeclarationSemantic {
     pub key: StableDefinitionKey,
     pub is_public: bool,
     pub payload: DurableDeclarationPayload,
+}
+
+impl RetainedCharge for DurableAnonymousNominal {
+    fn retained_charge(&self) -> u64 {
+        self.identity
+            .retained_charge()
+            .saturating_add(self.shape.retained_charge())
+            .saturating_add(self.type_captures.retained_charge())
+            .saturating_add(self.value_captures.retained_charge())
+    }
+}
+
+impl RetainedCharge for DurableAnonymousNominalShape {
+    fn retained_charge(&self) -> u64 {
+        match self {
+            Self::Struct { fields, methods } => fields
+                .retained_charge()
+                .saturating_add(methods.retained_charge()),
+            Self::Enum { variants } => variants.retained_charge(),
+        }
+    }
+}
+
+impl RetainedCharge for DurableAnonymousMethodSignature {
+    fn retained_charge(&self) -> u64 {
+        self.name
+            .retained_charge()
+            .saturating_add(self.parameters.retained_charge())
+            .saturating_add(self.result.retained_charge())
+            .saturating_add(self.body.retained_charge())
+    }
+}
+
+impl RetainedCharge for DurableAnonymousMemberBodySyntax {
+    fn retained_charge(&self) -> u64 {
+        self.signature
+            .retained_charge()
+            .saturating_add(self.body.retained_charge())
+    }
+}
+
+impl RetainedCharge for DurableAnonymousMethodType {
+    fn retained_charge(&self) -> u64 {
+        match self {
+            Self::SelfType => 0,
+            Self::Concrete(ty) => ty.retained_charge(),
+        }
+    }
+}
+
+impl RetainedCharge for DurableParameterMode {
+    fn retained_charge(&self) -> u64 {
+        0
+    }
+}
+
+impl RetainedCharge for DurableSemanticParameter {
+    fn retained_charge(&self) -> u64 {
+        self.name
+            .retained_charge()
+            .saturating_add(self.ty.retained_charge())
+    }
+}
+
+impl RetainedCharge for DurableDeclarationPayload {
+    fn retained_charge(&self) -> u64 {
+        match self {
+            Self::Callable {
+                parameters, result, ..
+            } => parameters
+                .retained_charge()
+                .saturating_add(result.retained_charge()),
+            Self::Struct { fields, .. } => fields.retained_charge(),
+            Self::Enum { variants } => variants.retained_charge(),
+            Self::Const { ty, value } => {
+                ty.retained_charge().saturating_add(value.retained_charge())
+            }
+            Self::ModuleBinding { target } => target.retained_charge(),
+            Self::Destructor => 0,
+        }
+    }
+}
+
+impl RetainedCharge for DurableDeclarationSemantic {
+    fn retained_charge(&self) -> u64 {
+        self.key
+            .retained_charge()
+            .saturating_add(self.payload.retained_charge())
+    }
 }
 
 /// Work performed by the stable-key/current-revision projection adapter.

--- a/crates/rue-compiler/src/lib.rs
+++ b/crates/rue-compiler/src/lib.rs
@@ -58,6 +58,7 @@ mod local_semantic_materialization;
 mod parsed_modules;
 mod program_image_plan;
 mod queries;
+mod retained_charge;
 mod revisioned_query_database;
 mod semantic_identity;
 mod semantic_query_nucleus;

--- a/crates/rue-compiler/src/local_semantic_materialization.rs
+++ b/crates/rue-compiler/src/local_semantic_materialization.rs
@@ -13,6 +13,7 @@ use crate::durable_semantics::{
     DurableAnonymousNominal, DurableAnonymousNominalShape, DurableDeclarationPayload,
     DurableDeclarationSemantic,
 };
+use crate::retained_charge::RetainedCharge;
 use crate::{FunctionInstanceKey, ModuleId, StableDefinitionKey, StableDefinitionKind};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -68,6 +69,40 @@ pub(crate) struct LocalBuiltinNominalRequest {
 pub(crate) struct LocalBuiltinNominalFact {
     pub(crate) request: LocalBuiltinNominalRequest,
     pub(crate) facts: crate::type_queries::TypeFacts,
+}
+
+impl RetainedCharge for LocalCallableFact {
+    fn retained_charge(&self) -> u64 {
+        self.identity
+            .retained_charge()
+            .saturating_add(self.symbol.retained_charge())
+    }
+}
+
+impl RetainedCharge for LocalNominalMetadataFact {
+    fn retained_charge(&self) -> u64 {
+        self.identity.retained_charge()
+    }
+}
+
+impl RetainedCharge for LocalBuiltinNominalRequest {
+    fn retained_charge(&self) -> u64 {
+        self.name
+            .retained_charge()
+            .saturating_add(self.query_ty.retained_charge())
+    }
+}
+
+impl RetainedCharge for LocalMaterializationFacts {
+    fn retained_charge(&self) -> u64 {
+        self.declarations
+            .retained_charge()
+            .saturating_add(self.anonymous_nominals.retained_charge())
+            .saturating_add(self.callables.retained_charge())
+            .saturating_add(self.nominal_metadata.retained_charge())
+            .saturating_add(self.modules.retained_charge())
+            .saturating_add(self.builtin_nominals.retained_charge())
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/crates/rue-compiler/src/parsed_modules.rs
+++ b/crates/rue-compiler/src/parsed_modules.rs
@@ -20,6 +20,7 @@ use rue_span::{FileId, Span};
 use sha2::{Digest, Sha256};
 
 use crate::definition_snapshot::{definition_parts, validate_span};
+use crate::retained_charge::RetainedCharge;
 use crate::{
     DefinitionKind, DefinitionNamespace, ImportDirective, ImportDirectives, ModuleId,
     ModuleRevision, SourceId, SourceRevision, SourceSnapshot, SyntaxWork,
@@ -189,6 +190,83 @@ pub struct ParsedDefinitionIndex {
 impl ParsedDefinitionIndex {
     pub fn candidates(&self) -> &[ParsedDefinitionCandidate] {
         &self.candidates
+    }
+
+    /// Deterministic charge for every owned allocation reachable from this
+    /// cloned index. Shared allocations are deliberately charged along each
+    /// retained path, matching the runtime retention policy.
+    pub(crate) fn retained_allocation_charge(&self) -> u64 {
+        let candidates =
+            (self.candidates.len() * std::mem::size_of::<ParsedDefinitionCandidate>()) as u64;
+        let candidates = self
+            .candidates
+            .iter()
+            .fold(candidates, |charge, candidate| {
+                let candidate_charge = candidate.name.retained_charge();
+                #[cfg(test)]
+                let candidate_charge =
+                    candidate_charge.saturating_add(std::mem::size_of::<SymbolProvenance>() as u64);
+                charge.saturating_add(candidate_charge)
+            });
+        let declarations =
+            (self.declarations.len() * std::mem::size_of::<ParsedDeclarationCandidate>()) as u64;
+        let declarations = self
+            .declarations
+            .iter()
+            .fold(declarations, |charge, declaration| {
+                let anonymous_sites = (declaration.anonymous_sites.len()
+                    * std::mem::size_of::<rue_rir::AnonymousTypeSite>())
+                    as u64;
+                charge
+                    .saturating_add(declaration.fact.retained_charge())
+                    .saturating_add(
+                        declaration
+                            .anonymous_sites
+                            .iter()
+                            .fold(anonymous_sites, |charge, site| {
+                                charge.saturating_add(site.anchor.retained_charge())
+                            }),
+                    )
+            });
+        let declaration_by_key = self.declaration_by_key.iter().fold(
+            (self.declaration_by_key.len()
+                * std::mem::size_of::<(DeclarationCandidateKey, usize)>()) as u64,
+            |charge, (key, _)| charge.saturating_add(key.retained_charge()),
+        );
+        let declaration_capabilities = (self.declaration_capabilities.len()
+            * std::mem::size_of::<DeclarationOccurrenceCapability>())
+            as u64;
+        let declaration_capabilities = self
+            .declaration_capabilities
+            .iter()
+            .fold(declaration_capabilities, |charge, capability| {
+                charge.saturating_add(capability.retained_charge())
+            });
+        let charge = candidates
+            .saturating_add(declarations)
+            .saturating_add(declaration_by_key)
+            .saturating_add(declaration_capabilities);
+        #[cfg(test)]
+        let charge = {
+            let atomics = 4_u64.saturating_mul(std::mem::size_of::<AtomicUsize>() as u64);
+            let by_name = self.by_name.iter().fold(
+                (self.by_name.len()
+                    * std::mem::size_of::<(
+                        (DefinitionNamespace, Arc<str>),
+                        Arc<[ParsedDefinitionOccurrence]>,
+                    )>()) as u64,
+                |charge, ((_, name), occurrences)| {
+                    charge
+                        .saturating_add(name.retained_charge())
+                        .saturating_add(
+                            (occurrences.len() * std::mem::size_of::<ParsedDefinitionOccurrence>())
+                                as u64,
+                        )
+                },
+            );
+            charge.saturating_add(atomics).saturating_add(by_name)
+        };
+        charge
     }
 
     pub(crate) fn declaration_capabilities(&self) -> &[DeclarationOccurrenceCapability] {
@@ -495,6 +573,10 @@ pub enum InvalidImportShape {
 }
 
 impl ParsedInvalidImport {
+    pub(crate) fn retained_allocation_charge(&self) -> u64 {
+        self.importer.retained_charge()
+    }
+
     pub fn span(&self) -> Span {
         self.span
     }
@@ -592,6 +674,63 @@ impl ParsedItemView {
 }
 
 impl ParsedModule {
+    /// Charge the complete retained graph, including the immutable parser
+    /// payload and the snapshot-local aliases derived from it. Aliased Arcs are
+    /// charged once per reachable field rather than deduplicated by address.
+    pub(crate) fn retained_allocation_charge(&self) -> u64 {
+        let ast_charge = |ast: &Arc<Ast>| ast.retained_charge();
+        let tokens_charge = |tokens: &[rue_lexer::Token]| std::mem::size_of_val(tokens) as u64;
+        let imports_charge = |imports: &[ImportDirective]| {
+            imports
+                .iter()
+                .fold(std::mem::size_of_val(imports) as u64, |charge, import| {
+                    charge.saturating_add(import.retained_charge())
+                })
+        };
+
+        let payload = (std::mem::size_of::<ParsedSyntaxPayload>() as u64)
+            .saturating_add(self.payload.source.retained_charge())
+            .saturating_add(self.payload.source_text.retained_charge())
+            .saturating_add(tokens_charge(&self.payload.tokens))
+            .saturating_add(ast_charge(&self.payload.ast.ast))
+            .saturating_add(std::mem::size_of::<SymbolProvenance>() as u64)
+            .saturating_add(self.payload.ast.source.retained_charge())
+            .saturating_add(std::mem::size_of::<RodeoResolver<Spur>>() as u64)
+            .saturating_add(
+                (self.payload.resolver.resolver.len() * std::mem::size_of::<Spur>()) as u64,
+            )
+            .saturating_add(
+                self.payload
+                    .resolver
+                    .resolver
+                    .iter()
+                    .fold(0_u64, |charge, (_, value)| {
+                        charge.saturating_add(value.len() as u64)
+                    }),
+            )
+            .saturating_add(std::mem::size_of::<SymbolProvenance>() as u64)
+            .saturating_add(self.payload.definitions.retained_allocation_charge())
+            .saturating_add(imports_charge(&self.payload.import_sites))
+            .saturating_add(
+                (self.payload.invalid_import_sites.len()
+                    * std::mem::size_of::<ParsedInvalidImportSite>()) as u64,
+            );
+        let invalid_imports = self.invalid_imports.iter().fold(
+            (self.invalid_imports.len() * std::mem::size_of::<ParsedInvalidImport>()) as u64,
+            |charge, invalid| charge.saturating_add(invalid.retained_allocation_charge()),
+        );
+
+        self.revision
+            .retained_charge()
+            .saturating_add(self.physical_path.retained_charge())
+            .saturating_add(payload)
+            .saturating_add(tokens_charge(&self.tokens))
+            .saturating_add(ast_charge(&self.ast))
+            .saturating_add(self.definitions.retained_allocation_charge())
+            .saturating_add(imports_charge(&self.imports))
+            .saturating_add(invalid_imports)
+    }
+
     pub(crate) fn evaluate_raw_const_syntax(
         &self,
         key: &DeclarationCandidateKey,

--- a/crates/rue-compiler/src/retained_charge.rs
+++ b/crates/rue-compiler/src/retained_charge.rs
@@ -1,0 +1,1703 @@
+//! Allocator-independent retained-artifact accounting.
+//!
+//! Inline storage is counted by its owning terminal or container exactly once.
+//! These implementations count only recursively reachable owned allocations by
+//! logical length. Shared `Arc`/`Rc` allocations are charged in full on every
+//! path that reaches them; no allocation-identity registry or allocator capacity
+//! enters the policy.
+
+use std::borrow::Cow;
+use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet, VecDeque};
+use std::rc::Rc;
+use std::sync::Arc;
+
+use rue_parser::ast;
+
+pub(crate) trait RetainedCharge {
+    fn retained_charge(&self) -> u64;
+}
+
+fn owned_slice_charge<T>(values: &[T], nested: impl Fn(&T) -> u64) -> u64 {
+    values
+        .iter()
+        .fold((std::mem::size_of_val(values)) as u64, |charge, value| {
+            charge.saturating_add(nested(value))
+        })
+}
+
+fn boxed_charge<T>(value: &Box<T>, nested: impl Fn(&T) -> u64) -> u64 {
+    (std::mem::size_of::<T>() as u64).saturating_add(nested(value))
+}
+
+fn directives_charge(directives: &ast::Directives) -> u64 {
+    let inline_or_heap = if directives.spilled() {
+        std::mem::size_of_val(directives.as_slice()) as u64
+    } else {
+        0
+    };
+    directives.iter().fold(inline_or_heap, |charge, directive| {
+        charge.saturating_add(owned_slice_charge(&directive.args, |_| 0))
+    })
+}
+
+fn type_charge(ty: &ast::TypeExpr) -> u64 {
+    use ast::TypeExpr;
+    match ty {
+        TypeExpr::Named(_) | TypeExpr::Unit(_) | TypeExpr::Never(_) => 0,
+        TypeExpr::Qualified { segments, .. } => owned_slice_charge(segments, |_| 0),
+        TypeExpr::Array {
+            element, length, ..
+        } => boxed_charge(element, type_charge).saturating_add(array_length_charge(length)),
+        TypeExpr::Slice { element, .. }
+        | TypeExpr::PointerConst {
+            pointee: element, ..
+        }
+        | TypeExpr::PointerMut {
+            pointee: element, ..
+        } => boxed_charge(element, type_charge),
+        TypeExpr::AnonymousStruct {
+            fields, methods, ..
+        } => owned_slice_charge(fields, |field| type_charge(&field.ty))
+            .saturating_add(owned_slice_charge(methods, method_charge)),
+        TypeExpr::AnonymousEnum { variants, .. } => {
+            owned_slice_charge(variants, enum_variant_charge)
+        }
+        TypeExpr::TypeCall { args, .. } => owned_slice_charge(args, type_charge),
+        TypeExpr::QualifiedTypeCall { segments, args, .. } => owned_slice_charge(segments, |_| 0)
+            .saturating_add(owned_slice_charge(args, type_charge)),
+        TypeExpr::StrFixed { .. } | TypeExpr::IntArg { .. } => 0,
+    }
+}
+
+fn array_length_charge(length: &ast::ArrayLength) -> u64 {
+    match length {
+        ast::ArrayLength::Call { args, .. } => owned_slice_charge(args, array_length_charge),
+        ast::ArrayLength::Literal(_) | ast::ArrayLength::Named(_) => 0,
+    }
+}
+
+fn param_charge(param: &ast::Param) -> u64 {
+    type_charge(&param.ty)
+}
+
+fn enum_variant_charge(variant: &ast::EnumVariant) -> u64 {
+    owned_slice_charge(&variant.payload, type_charge)
+}
+
+fn method_charge(method: &ast::Method) -> u64 {
+    directives_charge(&method.directives)
+        .saturating_add(owned_slice_charge(&method.params, param_charge))
+        .saturating_add(method.return_type.as_ref().map_or(0, type_charge))
+        .saturating_add(expr_charge(&method.body))
+}
+
+fn call_arg_charge(arg: &ast::CallArg) -> u64 {
+    expr_charge(&arg.expr)
+}
+
+fn block_charge(block: &ast::BlockExpr) -> u64 {
+    owned_slice_charge(&block.statements, statement_charge)
+        .saturating_add(boxed_charge(&block.expr, expr_charge))
+}
+
+fn pattern_charge(pattern: &ast::Pattern) -> u64 {
+    match pattern {
+        ast::Pattern::Path(path) => path
+            .base
+            .as_ref()
+            .map_or(0, |base| boxed_charge(base, expr_charge))
+            .saturating_add(
+                path.ctor_args
+                    .as_ref()
+                    .map_or(0, |args| owned_slice_charge(args, call_arg_charge)),
+            )
+            .saturating_add(owned_slice_charge(&path.bindings, |_| 0)),
+        ast::Pattern::Wildcard(_)
+        | ast::Pattern::Int(_)
+        | ast::Pattern::NegInt(_)
+        | ast::Pattern::Bool(_) => 0,
+    }
+}
+
+fn statement_charge(statement: &ast::Statement) -> u64 {
+    match statement {
+        ast::Statement::Let(statement) => directives_charge(&statement.directives)
+            .saturating_add(statement.ty.as_ref().map_or(0, type_charge))
+            .saturating_add(boxed_charge(&statement.init, expr_charge)),
+        ast::Statement::Assign(statement) => {
+            let target = match &statement.target {
+                ast::AssignTarget::Var(_) => 0,
+                ast::AssignTarget::Field(field) => boxed_charge(&field.base, expr_charge),
+                ast::AssignTarget::Index(index) => boxed_charge(&index.base, expr_charge)
+                    .saturating_add(boxed_charge(&index.index, expr_charge)),
+            };
+            target.saturating_add(boxed_charge(&statement.value, expr_charge))
+        }
+        ast::Statement::Expr(expr) => expr_charge(expr),
+    }
+}
+
+fn expr_charge(expr: &ast::Expr) -> u64 {
+    use ast::Expr;
+    match expr {
+        Expr::Int(_)
+        | Expr::String(_)
+        | Expr::Bool(_)
+        | Expr::Unit(_)
+        | Expr::Ident(_)
+        | Expr::Continue(_)
+        | Expr::SelfExpr(_)
+        | Expr::Error(_) => 0,
+        Expr::Binary(binary) => boxed_charge(&binary.left, expr_charge)
+            .saturating_add(boxed_charge(&binary.right, expr_charge)),
+        Expr::Unary(unary) => boxed_charge(&unary.operand, expr_charge),
+        Expr::Paren(paren) => boxed_charge(&paren.inner, expr_charge),
+        Expr::Block(block) => block_charge(block),
+        Expr::If(value) => boxed_charge(&value.cond, expr_charge)
+            .saturating_add(block_charge(&value.then_block))
+            .saturating_add(value.else_block.as_ref().map_or(0, block_charge)),
+        Expr::Match(value) => boxed_charge(&value.scrutinee, expr_charge).saturating_add(
+            owned_slice_charge(&value.arms, |arm| {
+                pattern_charge(&arm.pattern).saturating_add(boxed_charge(&arm.body, expr_charge))
+            }),
+        ),
+        Expr::While(value) => {
+            boxed_charge(&value.cond, expr_charge).saturating_add(block_charge(&value.body))
+        }
+        Expr::Loop(value) => block_charge(&value.body),
+        Expr::For(value) => {
+            boxed_charge(&value.iterable, expr_charge).saturating_add(block_charge(&value.body))
+        }
+        Expr::Call(value) => owned_slice_charge(&value.args, call_arg_charge),
+        Expr::Break(value) => value
+            .value
+            .as_ref()
+            .map_or(0, |value| boxed_charge(value, expr_charge)),
+        Expr::Return(value) => value
+            .value
+            .as_ref()
+            .map_or(0, |value| boxed_charge(value, expr_charge)),
+        Expr::Yield(value) => boxed_charge(&value.value, expr_charge),
+        Expr::StructLit(value) => value
+            .base
+            .as_ref()
+            .map_or(0, |base| boxed_charge(base, expr_charge))
+            .saturating_add(
+                value
+                    .ctor_args
+                    .as_ref()
+                    .map_or(0, |args| owned_slice_charge(args, call_arg_charge)),
+            )
+            .saturating_add(owned_slice_charge(&value.fields, |field| {
+                boxed_charge(&field.value, expr_charge)
+            })),
+        Expr::Field(value) => boxed_charge(&value.base, expr_charge),
+        Expr::MethodCall(value) => boxed_charge(&value.receiver, expr_charge)
+            .saturating_add(owned_slice_charge(&value.args, call_arg_charge)),
+        Expr::Try(value) => boxed_charge(&value.operand, expr_charge),
+        Expr::IntrinsicCall(value) => owned_slice_charge(&value.args, |arg| match arg {
+            ast::IntrinsicArg::Expr(expr) => expr_charge(expr),
+            ast::IntrinsicArg::Type(ty) => type_charge(ty),
+        }),
+        Expr::ArrayLit(value) => owned_slice_charge(&value.elements, expr_charge)
+            .saturating_add(value.repeat.as_ref().map_or(0, array_length_charge)),
+        Expr::Index(value) => boxed_charge(&value.base, expr_charge)
+            .saturating_add(boxed_charge(&value.index, expr_charge)),
+        Expr::Path(value) => value
+            .base
+            .as_ref()
+            .map_or(0, |base| boxed_charge(base, expr_charge)),
+        Expr::Comptime(value) => boxed_charge(&value.expr, expr_charge),
+        Expr::Checked(value) => boxed_charge(&value.expr, expr_charge),
+        Expr::TypeLit(value) => type_charge(&value.type_expr),
+    }
+}
+
+fn item_charge(item: &ast::Item) -> u64 {
+    match item {
+        ast::Item::Function(function) => directives_charge(&function.directives)
+            .saturating_add(owned_slice_charge(&function.params, param_charge))
+            .saturating_add(function.return_type.as_ref().map_or(0, type_charge))
+            .saturating_add(expr_charge(&function.body))
+            .saturating_add(function.export_abi.retained_charge()),
+        ast::Item::Struct(value) => directives_charge(&value.directives)
+            .saturating_add(owned_slice_charge(&value.fields, |field| {
+                type_charge(&field.ty)
+            }))
+            .saturating_add(owned_slice_charge(&value.methods, method_charge)),
+        ast::Item::Enum(value) => owned_slice_charge(&value.variants, enum_variant_charge),
+        ast::Item::DropFn(value) => expr_charge(&value.body),
+        ast::Item::Extern(value) => value
+            .abi
+            .retained_charge()
+            .saturating_add(owned_slice_charge(&value.fns, |function| {
+                owned_slice_charge(&function.params, param_charge)
+                    .saturating_add(function.return_type.as_ref().map_or(0, type_charge))
+            })),
+        ast::Item::Const(value) => directives_charge(&value.directives)
+            .saturating_add(value.ty.as_ref().map_or(0, type_charge))
+            .saturating_add(boxed_charge(&value.init, expr_charge)),
+        ast::Item::Error(_) => 0,
+    }
+}
+
+impl RetainedCharge for ast::Ast {
+    fn retained_charge(&self) -> u64 {
+        owned_slice_charge(&self.items, item_charge)
+    }
+}
+
+macro_rules! zero_charge {
+    ($($ty:ty),* $(,)?) => {
+        $(impl RetainedCharge for $ty {
+            fn retained_charge(&self) -> u64 { 0 }
+        })*
+    };
+}
+
+zero_charge!(
+    (),
+    bool,
+    char,
+    u8,
+    u16,
+    u32,
+    u64,
+    u128,
+    usize,
+    i8,
+    i16,
+    i32,
+    i64,
+    i128,
+    isize,
+    f32,
+    f64
+);
+
+zero_charge!(
+    rue_span::FileId,
+    rue_span::Span,
+    rue_query::Revision,
+    rue_cfg::BlockId
+);
+
+impl<'a> RetainedCharge for Cow<'a, str> {
+    fn retained_charge(&self) -> u64 {
+        match self {
+            Cow::Owned(value) => value.retained_charge(),
+            Cow::Borrowed(_) => 0,
+        }
+    }
+}
+
+impl RetainedCharge for str {
+    fn retained_charge(&self) -> u64 {
+        0
+    }
+}
+
+impl RetainedCharge for String {
+    fn retained_charge(&self) -> u64 {
+        self.len() as u64
+    }
+}
+
+impl<T: RetainedCharge + ?Sized> RetainedCharge for Arc<T> {
+    fn retained_charge(&self) -> u64 {
+        (std::mem::size_of_val(self.as_ref()) as u64)
+            .saturating_add(self.as_ref().retained_charge())
+    }
+}
+
+impl<T: RetainedCharge + ?Sized> RetainedCharge for Rc<T> {
+    fn retained_charge(&self) -> u64 {
+        (std::mem::size_of_val(self.as_ref()) as u64)
+            .saturating_add(self.as_ref().retained_charge())
+    }
+}
+
+impl<T: RetainedCharge + ?Sized> RetainedCharge for Box<T> {
+    fn retained_charge(&self) -> u64 {
+        (std::mem::size_of_val(self.as_ref()) as u64)
+            .saturating_add(self.as_ref().retained_charge())
+    }
+}
+
+impl<T: RetainedCharge> RetainedCharge for [T] {
+    fn retained_charge(&self) -> u64 {
+        self.iter().fold(0_u64, |charge, value| {
+            charge.saturating_add(value.retained_charge())
+        })
+    }
+}
+
+impl<T: RetainedCharge> RetainedCharge for Vec<T> {
+    fn retained_charge(&self) -> u64 {
+        (self.len().saturating_mul(std::mem::size_of::<T>()) as u64)
+            .saturating_add(self.as_slice().retained_charge())
+    }
+}
+
+impl<T: RetainedCharge> RetainedCharge for VecDeque<T> {
+    fn retained_charge(&self) -> u64 {
+        (self.len().saturating_mul(std::mem::size_of::<T>()) as u64).saturating_add(
+            self.iter().fold(0_u64, |charge, value| {
+                charge.saturating_add(value.retained_charge())
+            }),
+        )
+    }
+}
+
+impl<T: RetainedCharge> RetainedCharge for Option<T> {
+    fn retained_charge(&self) -> u64 {
+        self.as_ref().map_or(0, RetainedCharge::retained_charge)
+    }
+}
+
+impl<T: RetainedCharge, E: RetainedCharge> RetainedCharge for Result<T, E> {
+    fn retained_charge(&self) -> u64 {
+        match self {
+            Ok(value) => value.retained_charge(),
+            Err(error) => error.retained_charge(),
+        }
+    }
+}
+
+impl<K: RetainedCharge, V: RetainedCharge> RetainedCharge for BTreeMap<K, V> {
+    fn retained_charge(&self) -> u64 {
+        let entries = self.len().saturating_mul(std::mem::size_of::<(K, V)>()) as u64;
+        self.iter().fold(entries, |charge, (key, value)| {
+            charge
+                .saturating_add(key.retained_charge())
+                .saturating_add(value.retained_charge())
+        })
+    }
+}
+
+impl<T: RetainedCharge> RetainedCharge for BTreeSet<T> {
+    fn retained_charge(&self) -> u64 {
+        let entries = self.len().saturating_mul(std::mem::size_of::<T>()) as u64;
+        self.iter().fold(entries, |charge, value| {
+            charge.saturating_add(value.retained_charge())
+        })
+    }
+}
+
+impl<K: RetainedCharge, V: RetainedCharge> RetainedCharge for HashMap<K, V> {
+    fn retained_charge(&self) -> u64 {
+        let entries = self.len().saturating_mul(std::mem::size_of::<(K, V)>()) as u64;
+        self.iter().fold(entries, |charge, (key, value)| {
+            charge
+                .saturating_add(key.retained_charge())
+                .saturating_add(value.retained_charge())
+        })
+    }
+}
+
+impl<T: RetainedCharge> RetainedCharge for HashSet<T> {
+    fn retained_charge(&self) -> u64 {
+        let entries = self.len().saturating_mul(std::mem::size_of::<T>()) as u64;
+        self.iter().fold(entries, |charge, value| {
+            charge.saturating_add(value.retained_charge())
+        })
+    }
+}
+
+impl<T: RetainedCharge> RetainedCharge for crate::shared_segments::SharedSegments<T> {
+    fn retained_charge(&self) -> u64 {
+        let inline = self.len().saturating_mul(std::mem::size_of::<T>()) as u64;
+        self.iter().fold(inline, |charge, value| {
+            charge.saturating_add(value.retained_charge())
+        })
+    }
+}
+
+impl<T: RetainedCharge> RetainedCharge for crate::shared_segments::SharedList<T> {
+    fn retained_charge(&self) -> u64 {
+        let inline = self.len().saturating_mul(std::mem::size_of::<T>()) as u64;
+        self.iter().fold(inline, |charge, value| {
+            charge.saturating_add(value.retained_charge())
+        })
+    }
+}
+
+impl<A: RetainedCharge, B: RetainedCharge> RetainedCharge for (A, B) {
+    fn retained_charge(&self) -> u64 {
+        self.0
+            .retained_charge()
+            .saturating_add(self.1.retained_charge())
+    }
+}
+
+impl<A: RetainedCharge, B: RetainedCharge, C: RetainedCharge> RetainedCharge for (A, B, C) {
+    fn retained_charge(&self) -> u64 {
+        self.0
+            .retained_charge()
+            .saturating_add(self.1.retained_charge())
+            .saturating_add(self.2.retained_charge())
+    }
+}
+
+impl RetainedCharge for rue_query::InputIdentity {
+    fn retained_charge(&self) -> u64 {
+        (self.family().len() + self.key().len()) as u64
+    }
+}
+
+impl RetainedCharge for rue_query::InputObservation {
+    fn retained_charge(&self) -> u64 {
+        self.input.retained_charge()
+    }
+}
+
+impl RetainedCharge for rue_query::NodeIdentity {
+    fn retained_charge(&self) -> u64 {
+        (self.family().len() + self.key().len()) as u64
+    }
+}
+
+impl RetainedCharge for rue_query::Observation {
+    fn retained_charge(&self) -> u64 {
+        self.node.retained_charge()
+    }
+}
+
+impl RetainedCharge for rue_query::QueryFailure {
+    fn retained_charge(&self) -> u64 {
+        self.code
+            .retained_charge()
+            .saturating_add(self.payload.retained_charge())
+    }
+}
+
+impl RetainedCharge for rue_query::PresentationPosition {
+    fn retained_charge(&self) -> u64 {
+        self.source.retained_charge()
+    }
+}
+
+impl RetainedCharge for rue_query::QueryDiagnostic {
+    fn retained_charge(&self) -> u64 {
+        self.identity
+            .retained_charge()
+            .saturating_add(self.payload.retained_charge())
+            .saturating_add(self.presentation.retained_charge())
+    }
+}
+
+impl<V: RetainedCharge> RetainedCharge for rue_query::QueryOutcome<V> {
+    fn retained_charge(&self) -> u64 {
+        match self {
+            Self::Success(value) => value.retained_charge(),
+            Self::Failure(failure) => failure.retained_charge(),
+        }
+    }
+}
+
+impl<V: RetainedCharge> RetainedCharge for rue_query::QueryTerminal<V> {
+    fn retained_charge(&self) -> u64 {
+        // Publication already computed the terminal's complete deterministic
+        // charge. Reuse that summary when another artifact retains this
+        // terminal instead of recursively walking its value and observations.
+        // The blanket `Arc<T>` implementation adds the pointee's inline size,
+        // which is already in the summary, so exclude it here.
+        self.retained_charge()
+            .saturating_sub(std::mem::size_of::<Self>() as u64)
+    }
+}
+
+impl RetainedCharge for rue_rir::RirStructuralAnchor {
+    fn retained_charge(&self) -> u64 {
+        std::mem::size_of_val(self.segments()) as u64
+    }
+}
+
+impl RetainedCharge for rue_air::AnonymousMemberKey {
+    fn retained_charge(&self) -> u64 {
+        self.name.retained_charge()
+    }
+}
+
+impl<D: RetainedCharge, M: RetainedCharge> RetainedCharge
+    for rue_air::CanonicalArgumentValue<D, M>
+{
+    fn retained_charge(&self) -> u64 {
+        match self {
+            Self::Type(value) => value.retained_charge(),
+            Self::Function(value) => value.retained_charge(),
+            Self::String(value) => value.retained_charge(),
+            Self::Integer(_) | Self::Bool(_) | Self::Unit => 0,
+        }
+    }
+}
+
+impl<D: RetainedCharge, M: RetainedCharge> RetainedCharge for rue_air::CanonicalArguments<D, M> {
+    fn retained_charge(&self) -> u64 {
+        self.types
+            .retained_charge()
+            .saturating_add(self.values.retained_charge())
+    }
+}
+
+impl<D: RetainedCharge, M: RetainedCharge> RetainedCharge for rue_air::StableProducerId<D, M> {
+    fn retained_charge(&self) -> u64 {
+        match self {
+            Self::Definition(value) => value.retained_charge(),
+            Self::Function(value) => value.retained_charge(),
+        }
+    }
+}
+
+impl<D: RetainedCharge, M: RetainedCharge> RetainedCharge for rue_air::AnonymousNominalKey<D, M> {
+    fn retained_charge(&self) -> u64 {
+        self.producer
+            .retained_charge()
+            .saturating_add(self.anchor.retained_charge())
+            .saturating_add(self.arguments.retained_charge())
+    }
+}
+
+impl<D: RetainedCharge, M: RetainedCharge> RetainedCharge for rue_air::NominalInstanceKey<D, M> {
+    fn retained_charge(&self) -> u64 {
+        match self {
+            Self::Builtin { name, .. } => name.retained_charge(),
+            Self::Named(value) => value.retained_charge(),
+            Self::Anonymous(value) => value.retained_charge(),
+        }
+    }
+}
+
+impl<D: RetainedCharge, M: RetainedCharge> RetainedCharge for rue_air::TypeInstanceKey<D, M> {
+    fn retained_charge(&self) -> u64 {
+        match self {
+            Self::BuiltinNominal { name, .. } => name.retained_charge(),
+            Self::Nominal(value) => value.retained_charge(),
+            Self::Array { element, .. } | Self::PtrConst(element) | Self::PtrMut(element) => {
+                element.retained_charge()
+            }
+            Self::Slice { element, name } => element
+                .retained_charge()
+                .saturating_add(name.retained_charge()),
+            Self::Module(value) => value.retained_charge(),
+            Self::I8
+            | Self::I16
+            | Self::I32
+            | Self::I64
+            | Self::U8
+            | Self::U16
+            | Self::U32
+            | Self::U64
+            | Self::Bool
+            | Self::Unit
+            | Self::Never
+            | Self::ComptimeType
+            | Self::GenericParameter(_) => 0,
+        }
+    }
+}
+
+impl<D: RetainedCharge, M: RetainedCharge> RetainedCharge for rue_air::FunctionInstanceKey<D, M> {
+    fn retained_charge(&self) -> u64 {
+        match self {
+            Self::Definition(value) => value.retained_charge(),
+            Self::Specialization { base, arguments } => base
+                .retained_charge()
+                .saturating_add(arguments.retained_charge()),
+            Self::AnonymousMember { owner, member } => owner
+                .retained_charge()
+                .saturating_add(member.retained_charge()),
+            Self::DropGlue(value) => value.retained_charge(),
+        }
+    }
+}
+
+impl<K: RetainedCharge, M: RetainedCharge> RetainedCharge for rue_air::SemanticImportType<K, M> {
+    fn retained_charge(&self) -> u64 {
+        match self {
+            Self::BuiltinNominal { name, .. } => name.retained_charge(),
+            Self::Nominal(value) => value.retained_charge(),
+            Self::AnonymousNominal(value) => value.retained_charge(),
+            Self::Array { element, .. } | Self::PtrConst(element) | Self::PtrMut(element) => {
+                element.retained_charge()
+            }
+            Self::Slice { element, name } => element
+                .retained_charge()
+                .saturating_add(name.retained_charge()),
+            Self::Module(value) => value.retained_charge(),
+            Self::I8
+            | Self::I16
+            | Self::I32
+            | Self::I64
+            | Self::U8
+            | Self::U16
+            | Self::U32
+            | Self::U64
+            | Self::Bool
+            | Self::Unit
+            | Self::Never
+            | Self::ComptimeType
+            | Self::GenericParameter(_) => 0,
+        }
+    }
+}
+
+impl<K: RetainedCharge, M: RetainedCharge> RetainedCharge
+    for rue_air::SemanticImportConstValue<K, M>
+{
+    fn retained_charge(&self) -> u64 {
+        match self {
+            Self::Type(value) => value.retained_charge(),
+            Self::Function(value) => value.retained_charge(),
+            Self::String(value) => value.retained_charge(),
+            Self::Integer(_) | Self::Bool(_) | Self::Unit => 0,
+        }
+    }
+}
+
+impl<K: RetainedCharge, M: RetainedCharge> RetainedCharge
+    for rue_air::SemanticSpecializationIdentity<K, M>
+{
+    fn retained_charge(&self) -> u64 {
+        self.base
+            .retained_charge()
+            .saturating_add(self.type_arguments.retained_charge())
+            .saturating_add(self.value_arguments.retained_charge())
+    }
+}
+
+impl<D: RetainedCharge, M: RetainedCharge> RetainedCharge for rue_air::LocalAtomId<D, M> {
+    fn retained_charge(&self) -> u64 {
+        self.producer
+            .retained_charge()
+            .saturating_add(self.anchor.retained_charge())
+    }
+}
+
+impl<D: RetainedCharge, M: RetainedCharge> RetainedCharge for rue_air::LocalAtomRecord<D, M> {
+    fn retained_charge(&self) -> u64 {
+        self.identity
+            .retained_charge()
+            .saturating_add(self.content.retained_charge())
+    }
+}
+
+impl<D: RetainedCharge, M: RetainedCharge> RetainedCharge for rue_air::SemanticBodyLocalAtom<D, M> {
+    fn retained_charge(&self) -> u64 {
+        self.identity
+            .retained_charge()
+            .saturating_add(self.content.retained_charge())
+    }
+}
+
+impl RetainedCharge for rue_air::PaddingRange {
+    fn retained_charge(&self) -> u64 {
+        0
+    }
+}
+
+impl RetainedCharge for rue_air::DurableBodySourceLocator {
+    fn retained_charge(&self) -> u64 {
+        self.physical_path.retained_charge()
+    }
+}
+
+impl<K: RetainedCharge, M: RetainedCharge> RetainedCharge for rue_air::SemanticBodyPattern<K, M> {
+    fn retained_charge(&self) -> u64 {
+        match self {
+            Self::EnumVariant { enum_key, .. } => enum_key.retained_charge(),
+            Self::Wildcard | Self::Int(_) | Self::Bool(_) => 0,
+        }
+    }
+}
+
+impl<K: RetainedCharge, M: RetainedCharge> RetainedCharge for rue_air::SemanticBodyMatchArm<K, M> {
+    fn retained_charge(&self) -> u64 {
+        self.pattern.retained_charge()
+    }
+}
+
+impl RetainedCharge for rue_air::SemanticBodyCallArg {
+    fn retained_charge(&self) -> u64 {
+        0
+    }
+}
+
+impl<K: RetainedCharge, M: RetainedCharge> RetainedCharge
+    for rue_air::SemanticBodyProjection<K, M>
+{
+    fn retained_charge(&self) -> u64 {
+        match self {
+            Self::Field { struct_key, .. } => struct_key.retained_charge(),
+            Self::Index { array_type, .. } => array_type.retained_charge(),
+        }
+    }
+}
+
+impl<K: RetainedCharge, M: RetainedCharge> RetainedCharge for rue_air::SemanticBodyPlace<K, M> {
+    fn retained_charge(&self) -> u64 {
+        self.base_type
+            .retained_charge()
+            .saturating_add(self.projections.retained_charge())
+    }
+}
+
+impl<K: RetainedCharge, M: RetainedCharge> RetainedCharge for rue_air::SemanticBodyInst<K, M> {
+    fn retained_charge(&self) -> u64 {
+        self.data
+            .retained_charge()
+            .saturating_add(self.ty.retained_charge())
+    }
+}
+
+impl<K: RetainedCharge, M: RetainedCharge> RetainedCharge for rue_air::SemanticBodyInstData<K, M> {
+    fn retained_charge(&self) -> u64 {
+        match self {
+            Self::TypeConst(ty) => ty.retained_charge(),
+            Self::Match { arms, .. } => arms.retained_charge(),
+            Self::Call { function, args } => function
+                .retained_charge()
+                .saturating_add(args.retained_charge()),
+            Self::RuntimeCall { args, .. } => args.retained_charge(),
+            Self::CallSpecialized { identity, args } => identity
+                .retained_charge()
+                .saturating_add(args.retained_charge()),
+            Self::Intrinsic { name, args, .. } => name
+                .retained_charge()
+                .saturating_add(args.retained_charge()),
+            Self::Block { statements, .. } => statements.retained_charge(),
+            Self::StructInit {
+                struct_key,
+                fields,
+                source_order,
+            } => struct_key
+                .retained_charge()
+                .saturating_add(fields.retained_charge())
+                .saturating_add(source_order.retained_charge()),
+            Self::ArrayInit { elements } => elements.retained_charge(),
+            Self::EnumVariant {
+                enum_key, payload, ..
+            } => enum_key
+                .retained_charge()
+                .saturating_add(payload.retained_charge()),
+            Self::EnumPayloadGet { enum_key, .. } => enum_key.retained_charge(),
+            Self::IntCast { from_ty, .. } => from_ty.retained_charge(),
+            Self::Const(_)
+            | Self::BoolConst(_)
+            | Self::StringConst(_)
+            | Self::UnitConst
+            | Self::Add(_, _)
+            | Self::Sub(_, _)
+            | Self::Mul(_, _)
+            | Self::WrappingAdd(_, _)
+            | Self::WrappingSub(_, _)
+            | Self::WrappingMul(_, _)
+            | Self::Div(_, _)
+            | Self::Mod(_, _)
+            | Self::Eq(_, _)
+            | Self::Ne(_, _)
+            | Self::Lt(_, _)
+            | Self::Gt(_, _)
+            | Self::Le(_, _)
+            | Self::Ge(_, _)
+            | Self::And(_, _)
+            | Self::Or(_, _)
+            | Self::BitAnd(_, _)
+            | Self::BitOr(_, _)
+            | Self::BitXor(_, _)
+            | Self::Shl(_, _)
+            | Self::Shr(_, _)
+            | Self::Neg(_)
+            | Self::Not(_)
+            | Self::BitNot(_)
+            | Self::Branch { .. }
+            | Self::Loop { .. }
+            | Self::InfiniteLoop { .. }
+            | Self::Break
+            | Self::Continue
+            | Self::Alloc { .. }
+            | Self::Load { .. }
+            | Self::Store { .. }
+            | Self::ParamStore { .. }
+            | Self::Ret(_)
+            | Self::CallGeneric
+            | Self::Param { .. }
+            | Self::PlaceRead { .. }
+            | Self::PlaceWrite { .. }
+            | Self::Drop { .. }
+            | Self::StorageLive { .. }
+            | Self::StorageDead { .. }
+            | Self::MarkMoved { .. } => 0,
+        }
+    }
+}
+
+impl RetainedCharge for rue_air::SemanticBodyWarningLabel {
+    fn retained_charge(&self) -> u64 {
+        self.message.retained_charge()
+    }
+}
+
+impl RetainedCharge for rue_air::SemanticBodyWarningSuggestion {
+    fn retained_charge(&self) -> u64 {
+        self.message
+            .retained_charge()
+            .saturating_add(self.replacement.retained_charge())
+    }
+}
+
+impl RetainedCharge for rue_air::SemanticBodyWarning {
+    fn retained_charge(&self) -> u64 {
+        self.kind
+            .retained_charge()
+            .saturating_add(self.labels.retained_charge())
+            .saturating_add(self.notes.retained_charge())
+            .saturating_add(self.helps.retained_charge())
+            .saturating_add(self.suggestions.retained_charge())
+    }
+}
+
+impl<K: RetainedCharge, M: RetainedCharge> RetainedCharge
+    for rue_air::SemanticBodyMethodReference<K, M>
+{
+    fn retained_charge(&self) -> u64 {
+        self.receiver
+            .retained_charge()
+            .saturating_add(self.method.retained_charge())
+    }
+}
+
+impl<K: RetainedCharge, M: RetainedCharge> RetainedCharge for rue_air::SemanticBody<K, M> {
+    fn retained_charge(&self) -> u64 {
+        self.return_type
+            .retained_charge()
+            .saturating_add(self.instructions.retained_charge())
+            .saturating_add(self.places.retained_charge())
+            .saturating_add(self.strings.retained_charge())
+            .saturating_add(self.local_atoms.retained_charge())
+            .saturating_add(self.param_drops.retained_charge())
+            .saturating_add(self.borrow_slots.retained_charge())
+            .saturating_add(self.param_by_ref.retained_charge())
+            .saturating_add(self.param_writable.retained_charge())
+            .saturating_add(self.warnings.retained_charge())
+            .saturating_add(self.method_references.retained_charge())
+    }
+}
+
+impl RetainedCharge for crate::ModuleId {
+    fn retained_charge(&self) -> u64 {
+        self.as_str().len() as u64
+    }
+}
+
+impl RetainedCharge for crate::SourceId {
+    fn retained_charge(&self) -> u64 {
+        ((std::mem::size_of::<crate::SourceIdVersion>() + std::mem::size_of::<[u8; 32]>()) as u64)
+            .saturating_add(self.shared_text().retained_charge())
+    }
+}
+
+impl RetainedCharge for crate::ModuleRevision {
+    fn retained_charge(&self) -> u64 {
+        self.module
+            .retained_charge()
+            .saturating_add(self.source.retained_charge())
+    }
+}
+
+impl RetainedCharge for crate::SourceRevision {
+    fn retained_charge(&self) -> u64 {
+        self.root()
+            .retained_charge()
+            .saturating_add(self.module_segments().retained_charge())
+    }
+}
+
+impl RetainedCharge for crate::bound_definitions::StableNamedTypeKey {
+    fn retained_charge(&self) -> u64 {
+        self.module()
+            .retained_charge()
+            .saturating_add(self.name().len() as u64)
+    }
+}
+
+impl RetainedCharge for crate::StableDefinitionKey {
+    fn retained_charge(&self) -> u64 {
+        self.module()
+            .retained_charge()
+            .saturating_add(self.name().len() as u64)
+            .saturating_add(self.owner().map_or(0, RetainedCharge::retained_charge))
+    }
+}
+
+impl RetainedCharge for crate::declaration_candidate::DeclarationCandidateOwner {
+    fn retained_charge(&self) -> u64 {
+        self.name.retained_charge()
+    }
+}
+
+impl RetainedCharge for crate::declaration_candidate::DeclarationCandidateKey {
+    fn retained_charge(&self) -> u64 {
+        self.module
+            .retained_charge()
+            .saturating_add(self.name.retained_charge())
+            .saturating_add(self.owner.retained_charge())
+    }
+}
+
+impl RetainedCharge for crate::declaration_candidate::DeclarationOccurrenceCapability {
+    fn retained_charge(&self) -> u64 {
+        self.key().retained_charge()
+    }
+}
+
+impl RetainedCharge for crate::declaration_candidate::DeclarationOccurrenceFailure {
+    fn retained_charge(&self) -> u64 {
+        match self {
+            Self::ParseRejected { module } => module.retained_charge(),
+        }
+    }
+}
+
+impl RetainedCharge for crate::declaration_candidate::DeclarationShellFailure {
+    fn retained_charge(&self) -> u64 {
+        match self {
+            Self::OccurrencesUnavailable(value) => value.retained_charge(),
+            Self::Absent(key) | Self::Ambiguous(key) | Self::ParserCapabilityMismatch(key) => {
+                key.retained_charge()
+            }
+        }
+    }
+}
+
+impl RetainedCharge for crate::declaration_candidate::RawAnonymousSite {
+    fn retained_charge(&self) -> u64 {
+        0
+    }
+}
+
+impl RetainedCharge for crate::declaration_candidate::RawConstSyntax {
+    fn retained_charge(&self) -> u64 {
+        self.declared_type
+            .retained_charge()
+            .saturating_add(self.initializer.retained_charge())
+            .saturating_add(self.anonymous_sites.retained_charge())
+    }
+}
+
+macro_rules! candidate_failure_charge {
+    ($ty:ty) => {
+        impl RetainedCharge for $ty {
+            fn retained_charge(&self) -> u64 {
+                match self {
+                    Self::OccurrencesUnavailable(value) => value.retained_charge(),
+                    Self::Absent(key)
+                    | Self::Ambiguous(key)
+                    | Self::CategoryMismatch(key)
+                    | Self::ParserCapabilityMismatch(key) => key.retained_charge(),
+                }
+            }
+        }
+    };
+}
+
+candidate_failure_charge!(crate::declaration_candidate::RawConstSyntaxFailure);
+candidate_failure_charge!(crate::declaration_candidate::RawDeclarationSignatureFailure);
+candidate_failure_charge!(crate::declaration_candidate::RawDeclarationBodyFailure);
+
+impl RetainedCharge for crate::declaration_candidate::RawDeclarationSignatureSyntax {
+    fn retained_charge(&self) -> u64 {
+        self.declaration_fragments
+            .retained_charge()
+            .saturating_add(self.extern_abi.retained_charge())
+            .saturating_add(self.accessor_body.retained_charge())
+    }
+}
+
+impl RetainedCharge for crate::declaration_candidate::RawDeclarationBodySyntax {
+    fn retained_charge(&self) -> u64 {
+        self.body
+            .retained_charge()
+            .saturating_add(self.anonymous_sites.retained_charge())
+    }
+}
+
+impl RetainedCharge for crate::declaration_candidate::DeclarationImportSiteKey {
+    fn retained_charge(&self) -> u64 {
+        self.declaration
+            .retained_charge()
+            .saturating_add(self.specifier.retained_charge())
+    }
+}
+
+impl RetainedCharge for crate::declaration_candidate::DeclarationImportFailure {
+    fn retained_charge(&self) -> u64 {
+        match self {
+            Self::OccurrencesUnavailable(value) => value.retained_charge(),
+            Self::AbsentDeclaration(key)
+            | Self::AmbiguousDeclaration(key)
+            | Self::CategoryMismatch(key)
+            | Self::ParserCapabilityMismatch(key)
+            | Self::ResolutionUnavailable(key)
+            | Self::SiteOutOfRange { key, .. } => key.retained_charge(),
+            Self::SpecifierMismatch { key, actual } => key
+                .retained_charge()
+                .saturating_add(actual.retained_charge()),
+        }
+    }
+}
+
+impl RetainedCharge for crate::declaration_candidate::DeclarationParameterHeader {
+    fn retained_charge(&self) -> u64 {
+        self.name.retained_charge()
+    }
+}
+
+impl RetainedCharge for crate::declaration_candidate::DeclarationShellFact {
+    fn retained_charge(&self) -> u64 {
+        self.key
+            .retained_charge()
+            .saturating_add(self.parameters.retained_charge())
+    }
+}
+
+impl RetainedCharge for crate::ImportDiscoveryContext {
+    fn retained_charge(&self) -> u64 {
+        (self.project_root().len()
+            + self.std_root().map_or(0, str::len)
+            + self.read_policy_revision().len()) as u64
+    }
+}
+
+impl RetainedCharge for crate::ImportOccurrenceKey {
+    fn retained_charge(&self) -> u64 {
+        self.importer()
+            .retained_charge()
+            .saturating_add(self.specifier().len() as u64)
+    }
+}
+
+impl RetainedCharge for crate::ImportDiscoveryRequest {
+    fn retained_charge(&self) -> u64 {
+        self.context()
+            .retained_charge()
+            .saturating_add(self.occurrence().retained_charge())
+            .saturating_add(self.exact_specifier().len() as u64)
+            .saturating_add(self.normalized_specifier().len() as u64)
+            .saturating_add(self.importer_anchor().len() as u64)
+            .saturating_add(self.root_anchor().len() as u64)
+            .saturating_add(self.requested_path().len() as u64)
+    }
+}
+
+impl RetainedCharge for crate::CanonicalImportResolution {
+    fn retained_charge(&self) -> u64 {
+        match self {
+            Self::Resolved(module) => module.retained_charge(),
+            Self::Ambiguous {
+                file_module,
+                directory_module,
+            } => file_module
+                .retained_charge()
+                .saturating_add(directory_module.retained_charge()),
+            Self::Missing => 0,
+        }
+    }
+}
+
+impl RetainedCharge for crate::ImportDirective {
+    fn retained_charge(&self) -> u64 {
+        self.importer()
+            .retained_charge()
+            .saturating_add(self.specifier().len() as u64)
+    }
+}
+
+impl RetainedCharge for crate::SourceMetadata {
+    fn retained_charge(&self) -> u64 {
+        self.file_ids().fold(0_u64, |charge, file_id| {
+            // The descriptor owns two logical path maps and their normalized
+            // identity sets. Charge each retained string occurrence in full.
+            let physical = self.physical_path(file_id).map_or(0, str::len) as u64;
+            let logical = self.logical_path(file_id).map_or(0, str::len) as u64;
+            charge
+                .saturating_add((2 * std::mem::size_of::<(rue_span::FileId, String)>()) as u64)
+                .saturating_add(physical.saturating_mul(2))
+                .saturating_add(logical.saturating_mul(2))
+        })
+    }
+}
+
+impl RetainedCharge for crate::SourceSnapshot {
+    fn retained_charge(&self) -> u64 {
+        let records = self.metadata().file_ids().fold(0_u64, |charge, file_id| {
+            charge
+                .saturating_add(std::mem::size_of::<(
+                    rue_span::FileId,
+                    crate::ModuleId,
+                    crate::SourceId,
+                    Arc<String>,
+                )>() as u64)
+                .saturating_add(
+                    self.module_id(file_id)
+                        .map_or(0, RetainedCharge::retained_charge),
+                )
+                .saturating_add(
+                    self.shared_source_text(file_id)
+                        .map_or(0, |text| text.retained_charge()),
+                )
+        });
+        (std::mem::size_of::<crate::SourceMetadata>() as u64)
+            .saturating_add(self.metadata().retained_charge())
+            .saturating_add(self.source_revision().retained_charge())
+            .saturating_add(records)
+    }
+}
+
+impl RetainedCharge for crate::parsed_modules::ParsedModule {
+    fn retained_charge(&self) -> u64 {
+        self.retained_allocation_charge()
+    }
+}
+
+impl RetainedCharge for crate::parsed_modules::ParsedProgram {
+    fn retained_charge(&self) -> u64 {
+        let modules = self.modules_iter().fold(
+            (self.modules_len() * std::mem::size_of::<Arc<crate::parsed_modules::ParsedModule>>())
+                as u64,
+            |charge, module| charge.saturating_add(module.retained_charge()),
+        );
+        self.source_revision()
+            .retained_charge()
+            .saturating_add(modules)
+            .saturating_add(
+                (self.import_directives().len() * std::mem::size_of::<crate::ImportDirective>())
+                    as u64,
+            )
+            .saturating_add(
+                self.import_directives()
+                    .iter()
+                    .fold(0_u64, |charge, value| {
+                        charge.saturating_add(value.retained_charge())
+                    }),
+            )
+            .saturating_add(std::mem::size_of_val(self.invalid_imports()) as u64)
+            .saturating_add(
+                self.invalid_imports()
+                    .iter()
+                    .fold(0_u64, |charge, invalid| {
+                        charge.saturating_add(invalid.retained_allocation_charge())
+                    }),
+            )
+    }
+}
+
+impl RetainedCharge for crate::SemanticSymbolUniverse {
+    fn retained_charge(&self) -> u64 {
+        let modules = self.admitted_modules().iter().fold(
+            std::mem::size_of_val(self.admitted_modules()) as u64,
+            |charge, module| charge.saturating_add(module.retained_charge()),
+        );
+        let interner = (std::mem::size_of::<lasso::ThreadedRodeo>() as u64)
+            .saturating_add((self.interner().len() * std::mem::size_of::<lasso::Spur>()) as u64)
+            .saturating_add(self.interner().iter().fold(0_u64, |charge, (_, value)| {
+                charge.saturating_add(value.len() as u64)
+            }));
+        modules.saturating_add(interner)
+    }
+}
+
+impl RetainedCharge for crate::ParseInvalidationSummary {
+    fn retained_charge(&self) -> u64 {
+        self.exact_reused
+            .retained_charge()
+            .saturating_add(self.payload_rebound.retained_charge())
+            .saturating_add(self.reparsed.retained_charge())
+            .saturating_add(self.added.retained_charge())
+            .saturating_add(self.removed.retained_charge())
+    }
+}
+
+impl RetainedCharge for crate::diagnostic_attempt_store::DiagnosticAttemptProvenance {
+    fn retained_charge(&self) -> u64 {
+        match self {
+            Self::Canonical => 0,
+            Self::Presentation(modules) => modules.retained_charge(),
+        }
+    }
+}
+
+impl RetainedCharge for crate::TrustedToolchainModuleDemand {
+    fn retained_charge(&self) -> u64 {
+        self.logical_path().len() as u64
+    }
+}
+
+impl RetainedCharge for crate::ParkedToolchainModules {
+    fn retained_charge(&self) -> u64 {
+        let demands = std::mem::size_of_val(self.demands()) as u64;
+        let requesters = std::mem::size_of_val(self.requesters()) as u64;
+        demands
+            .saturating_add(self.demands().retained_charge())
+            .saturating_add(requesters)
+            .saturating_add(self.requesters().retained_charge())
+    }
+}
+
+impl RetainedCharge for rue_error::Label {
+    fn retained_charge(&self) -> u64 {
+        self.message.retained_charge()
+    }
+}
+
+impl RetainedCharge for rue_error::Note {
+    fn retained_charge(&self) -> u64 {
+        self.0.retained_charge()
+    }
+}
+
+impl RetainedCharge for rue_error::Help {
+    fn retained_charge(&self) -> u64 {
+        self.0.retained_charge()
+    }
+}
+
+impl RetainedCharge for rue_error::Suggestion {
+    fn retained_charge(&self) -> u64 {
+        self.message
+            .retained_charge()
+            .saturating_add(self.replacement.retained_charge())
+    }
+}
+
+impl RetainedCharge for rue_error::WarningKind {
+    fn retained_charge(&self) -> u64 {
+        match self {
+            Self::UnusedVariable(value)
+            | Self::UnusedFunction(value)
+            | Self::UnreachablePattern(value) => value.retained_charge(),
+            Self::UnreachableCode | Self::SentinelLookup => 0,
+        }
+    }
+}
+
+impl RetainedCharge for rue_error::ErrorKind {
+    fn retained_charge(&self) -> u64 {
+        use rue_error::ErrorKind as E;
+        match self {
+            E::MalformedByteLiteral(value)
+            | E::ParseError(value)
+            | E::UndefinedVariable(value)
+            | E::UndefinedFunction(value)
+            | E::AssignToImmutable(value)
+            | E::UnknownType(value)
+            | E::UseAfterMove(value)
+            | E::LinearValueNotConsumed(value)
+            | E::LinearValueNotConsumedOnAllPaths(value)
+            | E::LinearStructCopy(value)
+            | E::UnknownEnumType(value)
+            | E::InvalidMatchType(value)
+            | E::UnknownIntrinsic(value)
+            | E::CannotInferCastTarget(value)
+            | E::CannotInferPointeeType(value)
+            | E::CannotNegate(value)
+            | E::LinkError(value)
+            | E::UnsupportedTarget(value)
+            | E::InvalidCompilerInput(value)
+            | E::CompilerResourceLimit(value)
+            | E::CompilerResourceExhaustion(value)
+            | E::OutputPublication(value)
+            | E::UnsatisfiedTrustedToolchainInput(value)
+            | E::CompilerProducerInvariant(value)
+            | E::InternalError(value)
+            | E::InternalCodegenError(value) => value.retained_charge(),
+
+            E::InvalidArrayLength { reason: value }
+            | E::DuplicatePatternBinding { name: value }
+            | E::ReservedTypeName { type_name: value }
+            | E::ReservedFunctionName {
+                function_name: value,
+            }
+            | E::DuplicateTypeDefinition { type_name: value }
+            | E::DuplicateFunctionDefinition {
+                function_name: value,
+            }
+            | E::LinearValueDiscarded { type_name: value }
+            | E::LinearValueOverwritten { type_name: value }
+            | E::LinearValueOverwrittenThroughInout { type_name: value }
+            | E::DuplicateParameter { name: value }
+            | E::DuplicateDestructor { type_name: value }
+            | E::DestructorUnknownType { type_name: value }
+            | E::ConstExprNotSupported { expr_kind: value }
+            | E::ConstInitializerCycle { cycle: value }
+            | E::ConstMissingTypeAnnotation { name: value }
+            | E::FieldAccessOnNonStruct { found: value }
+            | E::StrViewNotFirstClass { site: value }
+            | E::ContainerElementIsLinear { ty: value }
+            | E::ContainerElementNotTriviallyDroppable { ty: value }
+            | E::InoutExclusiveAccess { variable: value }
+            | E::MutateBorrowedValue { variable: value }
+            | E::MoveOutOfBorrow { variable: value }
+            | E::BorrowInoutConflict { variable: value }
+            | E::MoveOutOfInout { variable: value }
+            | E::AccessorYieldNotReceiverRooted { found: value }
+            | E::AccessorRequiresBorrowSelf { found: value }
+            | E::AccessorResultMoved { ty: value }
+            | E::AccessorLoanConflict {
+                variable: value, ..
+            }
+            | E::AccessorParamModeUnsupported { mode: value }
+            | E::AccessorRecursion { method: value }
+            | E::MoveSelfOutOfDestructor { type_name: value }
+            | E::CopyStructWithDestructor { type_name: value }
+            | E::QuestionOutsideOptionFn { return_type: value }
+            | E::QuestionOnNonOption { found: value }
+            | E::QuestionOutsideResultFn { return_type: value }
+            | E::IntrinsicWrongArgCount { name: value, .. }
+            | E::IntrinsicAlignNotPowerOfTwo { name: value, .. }
+            | E::LiteralOutOfRange { ty: value, .. }
+            | E::IndexOnNonArray { found: value }
+            | E::MoveOutOfIndex {
+                element_type: value,
+            }
+            | E::ArrayRepeatNonCopy {
+                element_type: value,
+            }
+            | E::TypeTooLarge {
+                type_name: value, ..
+            }
+            | E::AssignToPartiallyMovedArray { array: value }
+            | E::PreviewFeatureRequired { what: value, .. }
+            | E::ExternSignatureTypeUnsupported { ty: value }
+            | E::ExternAggregateNotReprC { ty: value }
+            | E::ExternArrayByValue { ty: value }
+            | E::ComptimeEvaluationFailed { reason: value }
+            | E::ComptimeArgNotConst { param_name: value }
+            | E::UncheckedOpRequiresChecked { what: value } => value.retained_charge(),
+
+            E::TypeMismatch {
+                expected: left,
+                found: right,
+            }
+            | E::UnknownField {
+                struct_name: left,
+                field_name: right,
+            }
+            | E::DuplicateField {
+                struct_name: left,
+                field_name: right,
+            }
+            | E::DuplicateMethod {
+                type_name: left,
+                method_name: right,
+            }
+            | E::UndefinedMethod {
+                type_name: left,
+                method_name: right,
+            }
+            | E::UndefinedAssocFn {
+                type_name: left,
+                function_name: right,
+            }
+            | E::MethodCallOnNonStruct {
+                found: left,
+                method_name: right,
+            }
+            | E::MethodCalledAsAssocFn {
+                type_name: left,
+                method_name: right,
+            }
+            | E::AssocFnCalledAsMethod {
+                type_name: left,
+                function_name: right,
+            }
+            | E::DuplicateConstant {
+                name: left,
+                kind: right,
+            }
+            | E::RecursiveTypeInfiniteSize {
+                name: left,
+                cycle: right,
+            }
+            | E::DuplicateVariant {
+                enum_name: left,
+                variant_name: right,
+            }
+            | E::UnknownVariant {
+                enum_name: left,
+                variant_name: right,
+            }
+            | E::BufferNotFirstClassStr {
+                found: left,
+                site: right,
+            }
+            | E::MoveWhileCallLoaned {
+                variable: left,
+                loan_mode: right,
+            }
+            | E::AccessorResultReturned {
+                method: left,
+                root: right,
+            }
+            | E::AccessorResultStored {
+                method: left,
+                root: right,
+            }
+            | E::AccessorResultBound {
+                method: left,
+                root: right,
+            }
+            | E::AccessorResultCaptured {
+                method: left,
+                root: right,
+            }
+            | E::MoveFieldOutOfDestructorType {
+                struct_name: left,
+                field_name: right,
+            }
+            | E::QuestionErrTypeMismatch {
+                operand_err: left,
+                fn_err: right,
+            }
+            | E::PrivateMemberAccess {
+                item_kind: left,
+                name: right,
+            }
+            | E::UnknownModuleMember {
+                module_name: left,
+                member_name: right,
+            }
+            | E::ExportSignatureUnsupported {
+                name: left,
+                reason: right,
+            } => left
+                .retained_charge()
+                .saturating_add(right.retained_charge()),
+
+            E::UnexpectedToken { expected, found } => expected
+                .retained_charge()
+                .saturating_add(found.retained_charge()),
+            E::ModuleNotFound { path, candidates } => path
+                .retained_charge()
+                .saturating_add(candidates.retained_charge()),
+            E::MissingFields(value) => (std::mem::size_of_val(value.as_ref()) as u64)
+                .saturating_add(value.struct_name.retained_charge())
+                .saturating_add(value.missing_fields.retained_charge()),
+            E::CopyStructNonCopyField(value) => (std::mem::size_of_val(value.as_ref()) as u64)
+                .saturating_add(value.struct_name.retained_charge())
+                .saturating_add(value.field_name.retained_charge())
+                .saturating_add(value.field_type.retained_charge()),
+            E::LinearFieldDroppedByDestructure(value) => (std::mem::size_of_val(value.as_ref())
+                as u64)
+                .saturating_add(value.struct_name.retained_charge())
+                .saturating_add(value.accessed.retained_charge())
+                .saturating_add(value.dropped.retained_charge()),
+            E::IntrinsicTypeMismatch(value) => (std::mem::size_of_val(value.as_ref()) as u64)
+                .saturating_add(value.name.retained_charge())
+                .saturating_add(value.expected.retained_charge())
+                .saturating_add(value.found.retained_charge()),
+            E::AmbiguousModule(value) => (std::mem::size_of_val(value.as_ref()) as u64)
+                .saturating_add(value.path.retained_charge())
+                .saturating_add(value.file_module.retained_charge())
+                .saturating_add(value.dir_module.retained_charge()),
+            E::PrivateUnqualifiedAccess(value) => (std::mem::size_of_val(value.as_ref()) as u64)
+                .saturating_add(value.item_kind.retained_charge())
+                .saturating_add(value.name.retained_charge())
+                .saturating_add(value.defining_file.retained_charge()),
+            E::ForeignSignatureConflict(value) => (std::mem::size_of_val(value.as_ref()) as u64)
+                .saturating_add(value.symbol.retained_charge())
+                .saturating_add(value.declared.retained_charge())
+                .saturating_add(value.previously_declared.retained_charge()),
+            E::ReprCStructIneligible(value) => (std::mem::size_of_val(value.as_ref()) as u64)
+                .saturating_add(value.struct_name.retained_charge())
+                .saturating_add(value.field_path.retained_charge())
+                .saturating_add(value.failing_type.retained_charge())
+                .saturating_add(value.reason.retained_charge()),
+            E::UnexpectedCharacter(_)
+            | E::InvalidStringEscape(_)
+            | E::UppercaseBasePrefix(_)
+            | E::EmptyBasedLiteral { .. }
+            | E::InvalidDigitForBase { .. }
+            | E::LexerDiagnosticsOmitted { .. }
+            | E::ParserDiagnosticsOmitted { .. }
+            | E::NestingLimitExceeded { .. }
+            | E::InvalidMainSignature { .. }
+            | E::WrongArgumentCount { .. }
+            | E::StrFixedCapacityExceeded { .. }
+            | E::UnexpectedCallArgumentMode { .. }
+            | E::ArrayLengthMismatch { .. }
+            | E::IndexOutOfBounds { .. }
+            | E::FunctionFrameTooLarge { .. }
+            | E::InvalidInteger
+            | E::UnterminatedString
+            | E::NoMainFunction
+            | E::EmptyStruct
+            | E::InvalidAssignmentTarget
+            | E::RawRequiresPlace
+            | E::FieldPtrRequiresField
+            | E::InoutStrRequiresLocalBuffer
+            | E::StrViewReassignment
+            | E::InoutNonLvalue
+            | E::BorrowNonLvalue
+            | E::InoutKeywordMissing
+            | E::BorrowKeywordMissing
+            | E::AccessorBodyMissingYield
+            | E::YieldOutsideAccessor
+            | E::BreakOutsideLoop
+            | E::ContinueOutsideLoop
+            | E::BreakWithValue
+            | E::NonExhaustiveMatch
+            | E::EmptyMatch
+            | E::ImportRequiresStringLiteral
+            | E::StdLibNotFound
+            | E::ChainedComparison
+            | E::TypeAnnotationRequired
+            | E::ExternVariadicUnsupported
+            | E::ForeignEntryPointDeclaration
+            | E::SliceNotYetImplemented
+            | E::SliceReturnNotAllowed
+            | E::SliceInAggregateField
+            | E::SliceEscapesScope => 0,
+        }
+    }
+}
+
+impl<K: RetainedCharge> RetainedCharge for rue_error::DiagnosticWrapper<K> {
+    fn retained_charge(&self) -> u64 {
+        let diagnostic = self.diagnostic();
+        self.kind
+            .retained_charge()
+            .saturating_add(diagnostic.labels.retained_charge())
+            .saturating_add(diagnostic.notes.retained_charge())
+            .saturating_add(diagnostic.helps.retained_charge())
+            .saturating_add(diagnostic.suggestions.retained_charge())
+    }
+}
+
+impl RetainedCharge for rue_error::CompileErrors {
+    fn retained_charge(&self) -> u64 {
+        ((self.len() * std::mem::size_of::<rue_error::CompileError>()) as u64).saturating_add(
+            self.iter().fold(0_u64, |charge, value| {
+                charge.saturating_add(value.retained_charge())
+            }),
+        )
+    }
+}
+
+impl RetainedCharge for crate::FrontendDiagnosticSnapshot {
+    fn retained_charge(&self) -> u64 {
+        self.source
+            .retained_charge()
+            .saturating_add(self.provenance.retained_charge())
+            .saturating_add(self.errors.retained_charge())
+            .saturating_add(self.warnings.retained_charge())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::RetainedCharge;
+    use std::sync::Arc;
+
+    use crate::parsed_modules::parse_source_snapshot_modules;
+
+    #[test]
+    fn vector_charge_depends_on_logical_length_not_capacity() {
+        let compact = vec![String::from("alpha"), String::from("beta")];
+        let mut reserved = Vec::with_capacity(4096);
+        reserved.extend(compact.iter().cloned());
+
+        assert_eq!(compact.retained_charge(), reserved.retained_charge());
+        assert_eq!(
+            compact.retained_charge(),
+            (2 * std::mem::size_of::<String>() + "alpha".len() + "beta".len()) as u64
+        );
+    }
+
+    #[test]
+    fn nested_owned_strings_are_charged_recursively() {
+        let values = vec![vec![String::from("one"), String::from("three")]];
+        let expected = std::mem::size_of::<Vec<String>>()
+            + 2 * std::mem::size_of::<String>()
+            + "one".len()
+            + "three".len();
+        assert_eq!(values.retained_charge(), expected as u64);
+    }
+
+    #[test]
+    fn every_shared_arc_path_is_charged_in_full() {
+        let shared = Arc::new(String::from("shared payload"));
+        let one_path = shared.retained_charge();
+        let two_paths = (shared.clone(), shared).retained_charge();
+
+        assert_eq!(two_paths, one_path.saturating_mul(2));
+        assert_eq!(
+            one_path,
+            (std::mem::size_of::<String>() + "shared payload".len()) as u64
+        );
+    }
+
+    #[test]
+    fn parsed_module_charge_includes_recursive_ast_index_and_invalid_import_paths() {
+        let snapshot = crate::SourceSnapshot::single(
+            "/project/main.rue",
+            "struct Pair { left: i32, right: i32, fn sum(borrow self) -> i32 { self.left + self.right } } fn main() { @import(1); }",
+        )
+        .unwrap();
+        let parsed = parse_source_snapshot_modules(&snapshot).unwrap();
+        let module = &parsed.modules()[0];
+
+        let ast = module.ast().retained_charge();
+        assert!(
+            ast > (module.ast().items.len() * std::mem::size_of::<rue_parser::ast::Item>()) as u64,
+            "nested method/body allocations must exceed the root item vector"
+        );
+        let definitions = module.definitions().retained_allocation_charge();
+        assert!(
+            definitions > 0,
+            "definition-index owned collections are charged"
+        );
+        let invalid = module.invalid_imports()[0].retained_allocation_charge();
+        assert!(
+            invalid > 0,
+            "the invalid import's owned module path is charged"
+        );
+
+        let direct_paths = (std::mem::size_of::<rue_parser::ast::Ast>() as u64)
+            .saturating_add(ast)
+            .saturating_add(definitions)
+            .saturating_add(std::mem::size_of_val(module.invalid_imports()) as u64)
+            .saturating_add(invalid);
+        assert!(module.retained_charge() >= direct_paths);
+    }
+
+    #[test]
+    fn semantic_universe_charges_every_admitted_parsed_module_path() {
+        let snapshot = crate::SourceSnapshot::single(
+            "/project/main.rue",
+            "fn helper(value: i32) -> i32 { value + 1 } fn main() -> i32 { helper(1) }",
+        )
+        .unwrap();
+        let parsed = parse_source_snapshot_modules(&snapshot).unwrap();
+        let universe = crate::SemanticSymbolUniverse::new(&parsed);
+        let admitted = parsed.modules().iter().fold(
+            std::mem::size_of_val(parsed.modules()) as u64,
+            |charge, module| charge.saturating_add(module.retained_charge()),
+        );
+
+        let logical_interner = (std::mem::size_of::<lasso::ThreadedRodeo>() as u64)
+            .saturating_add((universe.interner().len() * std::mem::size_of::<lasso::Spur>()) as u64)
+            .saturating_add(
+                universe
+                    .interner()
+                    .iter()
+                    .fold(0_u64, |charge, (_, value)| {
+                        charge.saturating_add(value.len() as u64)
+                    }),
+            );
+        assert_eq!(
+            universe.retained_charge(),
+            admitted.saturating_add(logical_interner)
+        );
+    }
+}

--- a/crates/rue-compiler/src/revisioned_query_database.rs
+++ b/crates/rue-compiler/src/revisioned_query_database.rs
@@ -8,6 +8,7 @@
 //! retain the current and last-good terminals.
 
 use std::collections::{BTreeMap, BTreeSet, HashMap, VecDeque};
+use std::ops::Deref;
 use std::rc::Rc;
 use std::sync::{Arc, Mutex};
 
@@ -50,11 +51,113 @@ use crate::{
 use crate::canonical_lower::{ModuleRirOutput, lower_module_rir_with_work};
 use crate::parsed_modules::{ParsedModule, ParsedModulesWork, ParsedProgram};
 
+use crate::retained_charge::RetainedCharge;
 use crate::session::{AttemptId, QueryStructuralWork};
 use crate::typed_query_store::{
     AbortedQueryReason, AttemptExecution as CompilerAttemptExecution, AttemptOutcomeKind,
     AttemptView, RuntimeObservation,
 };
+
+/// Compiler-family registration wrapper. Every compiler success value is
+/// charged by a deterministic structural traversal of its owned representation;
+/// `QueryRuntime` itself keeps the zero-cost inline-only default for generic
+/// users that do not register an estimator.
+struct CompilerQueryRuntime(QueryRuntime);
+
+impl Deref for CompilerQueryRuntime {
+    type Target = QueryRuntime;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl CompilerQueryRuntime {
+    fn family_with_equality_and_evaluator<K, V, E>(
+        &self,
+        stable_name: impl Into<Arc<str>>,
+        retention_limit: usize,
+        value_equal: fn(&V, &V) -> bool,
+        evaluator: E,
+    ) -> Result<QueryFamily<K, V>, rue_query::FamilyError>
+    where
+        K: QueryKey,
+        V: Clone + RetainedCharge + Send + Sync + 'static,
+        E: Fn(&QueryContext, &QueryFamily<K, V>, &K) -> Result<QueryOutput<V>, QueryAbort>
+            + Send
+            + Sync
+            + 'static,
+    {
+        self.0
+            .family_with_equality_and_evaluator_and_retained_charge(
+                stable_name,
+                retention_limit,
+                value_equal,
+                RetainedCharge::retained_charge,
+                evaluator,
+            )
+    }
+
+    fn family_with_evaluator<K, V, E>(
+        &self,
+        stable_name: impl Into<Arc<str>>,
+        retention_limit: usize,
+        evaluator: E,
+    ) -> Result<QueryFamily<K, V>, rue_query::FamilyError>
+    where
+        K: QueryKey,
+        V: Clone + Eq + RetainedCharge + Send + Sync + 'static,
+        E: Fn(&QueryContext, &QueryFamily<K, V>, &K) -> Result<QueryOutput<V>, QueryAbort>
+            + Send
+            + Sync
+            + 'static,
+    {
+        self.family_with_equality_and_evaluator(
+            stable_name,
+            retention_limit,
+            PartialEq::eq,
+            evaluator,
+        )
+    }
+
+    #[cfg(test)]
+    fn family_with_equality<K, V>(
+        &self,
+        stable_name: impl Into<Arc<str>>,
+        retention_limit: usize,
+        value_equal: fn(&V, &V) -> bool,
+    ) -> Result<QueryFamily<K, V>, rue_query::FamilyError>
+    where
+        K: QueryKey,
+        V: Clone + RetainedCharge + Send + Sync + 'static,
+    {
+        self.0.family_with_equality_and_retained_charge(
+            stable_name,
+            retention_limit,
+            value_equal,
+            RetainedCharge::retained_charge,
+        )
+    }
+
+    fn content_addressed_family_with_equality<K, V>(
+        &self,
+        stable_name: impl Into<Arc<str>>,
+        retention_limit: usize,
+        value_equal: fn(&V, &V) -> bool,
+    ) -> Result<QueryFamily<K, V>, rue_query::FamilyError>
+    where
+        K: QueryKey,
+        V: Clone + RetainedCharge + Send + Sync + 'static,
+    {
+        self.0
+            .content_addressed_family_with_equality_and_retained_charge(
+                stable_name,
+                retention_limit,
+                value_equal,
+                RetainedCharge::retained_charge,
+            )
+    }
+}
 use crate::typed_query_store::{TerminalKind, TypedQueryFamily};
 
 const IMPORT_INPUT_REVISION_RETENTION: usize = 64;
@@ -505,6 +608,21 @@ impl LookupObservationKey {
             Self::Import(key) => {
                 format!("compiler.lookup-import\u{1}{}", key.stable_identity()).into()
             }
+        }
+    }
+}
+
+impl RetainedCharge for LookupObservationKey {
+    fn retained_charge(&self) -> u64 {
+        match self {
+            Self::Name(key) => key
+                .module
+                .retained_charge()
+                .saturating_add(key.name.retained_charge()),
+            Self::Import(key) => key
+                .module
+                .retained_charge()
+                .saturating_add(key.specifier.retained_charge()),
         }
     }
 }
@@ -1679,6 +1797,230 @@ impl LookupImportValue {
             normalized_specifier: Arc::from(requested),
             target: None,
         }))
+    }
+}
+
+impl RetainedCharge for ParseModuleValue {
+    fn retained_charge(&self) -> u64 {
+        self.result.retained_charge()
+    }
+}
+
+impl RetainedCharge for ModuleIndexEntry {
+    fn retained_charge(&self) -> u64 {
+        self.name.retained_charge()
+    }
+}
+
+impl RetainedCharge for ModuleIndex {
+    fn retained_charge(&self) -> u64 {
+        self.revision
+            .retained_charge()
+            .saturating_add(self.definitions.retained_charge())
+            .saturating_add(self.imports.retained_charge())
+    }
+}
+
+impl RetainedCharge for ModuleIndexValue {
+    fn retained_charge(&self) -> u64 {
+        self.0.retained_charge()
+    }
+}
+
+impl RetainedCharge for DeclarationOccurrenceIndex {
+    fn retained_charge(&self) -> u64 {
+        self.capabilities.retained_charge()
+    }
+}
+
+impl RetainedCharge for DeclarationOccurrenceIndexValue {
+    fn retained_charge(&self) -> u64 {
+        match self {
+            Self::Available(value) => value.retained_charge(),
+            Self::Failure(value) => value.retained_charge(),
+        }
+    }
+}
+
+impl RetainedCharge for DeclarationOrderValue {
+    fn retained_charge(&self) -> u64 {
+        match self {
+            Self::Available(value) => value.retained_charge(),
+            Self::Failure(value) => value.retained_charge(),
+        }
+    }
+}
+
+impl RetainedCharge for DeclarationShellQueryValue {
+    fn retained_charge(&self) -> u64 {
+        match self {
+            Self::Available(value) => value.retained_charge(),
+            Self::Failure(value) => value.retained_charge(),
+        }
+    }
+}
+
+impl RetainedCharge for StableDeclarationClassificationQueryValue {
+    fn retained_charge(&self) -> u64 {
+        match self {
+            Self::Selected(value) => value.retained_charge(),
+            Self::Invalid(value) => value.retained_charge(),
+            Self::Absent => 0,
+        }
+    }
+}
+
+impl RetainedCharge for StableDeclarationClassificationFailure {
+    fn retained_charge(&self) -> u64 {
+        match self {
+            Self::MalformedStableKey(value) => value.retained_charge(),
+            Self::OccurrencesUnavailable(value) => value.retained_charge(),
+            Self::Ambiguous(value)
+            | Self::ParserCapabilityMismatch(value)
+            | Self::DuplicateMultiplicity { key: value, .. } => value.retained_charge(),
+            Self::MultipleAvailable { first, second } => first
+                .retained_charge()
+                .saturating_add(second.retained_charge()),
+        }
+    }
+}
+
+macro_rules! query_value_charge {
+    ($ty:ty) => {
+        impl RetainedCharge for $ty {
+            fn retained_charge(&self) -> u64 {
+                match self {
+                    Self::Available(value) => value.retained_charge(),
+                    Self::Failure(value) => value.retained_charge(),
+                }
+            }
+        }
+    };
+}
+
+query_value_charge!(RawConstSyntaxQueryValue);
+query_value_charge!(RawDeclarationSignatureQueryValue);
+query_value_charge!(RawDeclarationBodyQueryValue);
+query_value_charge!(WarningBodySyntaxValue);
+query_value_charge!(WarningBodyReferencesValue);
+
+impl RetainedCharge for WarningStaticCallHead {
+    fn retained_charge(&self) -> u64 {
+        self.module
+            .retained_charge()
+            .saturating_add(self.components.retained_charge())
+    }
+}
+
+impl RetainedCharge for WarningSyntaxCallHead {
+    fn retained_charge(&self) -> u64 {
+        self.import
+            .retained_charge()
+            .saturating_add(self.components.retained_charge())
+    }
+}
+
+impl RetainedCharge for WarningBodyReferencesFailure {
+    fn retained_charge(&self) -> u64 {
+        match self {
+            Self::ClassificationAbsent(value) => value.retained_charge(),
+            Self::ClassificationInvalid(value) => value.retained_charge(),
+            Self::Shell(value) => value.retained_charge(),
+            Self::ParseRejected(value) => value.retained_charge(),
+            Self::ParserCapabilityMismatch(value) => value.retained_charge(),
+            Self::Import(value) => value.retained_charge(),
+            Self::ImportResolution { key, resolution } => key
+                .retained_charge()
+                .saturating_add(resolution.retained_charge()),
+        }
+    }
+}
+
+impl RetainedCharge for SemanticNucleusProjection {
+    fn retained_charge(&self) -> u64 {
+        self.declarations
+            .retained_charge()
+            .saturating_add(self.anonymous_nominals.retained_charge())
+            .saturating_add(self.dependencies.retained_charge())
+            .saturating_add(self.c_export_roots.retained_charge())
+    }
+}
+
+impl RetainedCharge for SemanticNucleusProjectionValue {
+    fn retained_charge(&self) -> u64 {
+        match self {
+            Self::Available(value) => value.retained_charge(),
+            Self::Failure {
+                declaration,
+                failure,
+            } => declaration
+                .retained_charge()
+                .saturating_add(failure.retained_charge()),
+        }
+    }
+}
+
+impl RetainedCharge for ModuleRirValue {
+    fn retained_charge(&self) -> u64 {
+        self.result.retained_charge()
+    }
+}
+
+impl RetainedCharge for ResolveImportValue {
+    fn retained_charge(&self) -> u64 {
+        self.groups
+            .retained_charge()
+            .saturating_add(self.requests.retained_charge())
+            .saturating_add(self.resolution.retained_charge())
+    }
+}
+
+impl RetainedCharge for DeclarationImportQueryValue {
+    fn retained_charge(&self) -> u64 {
+        match self {
+            Self::Available(value) => value.retained_charge(),
+            Self::Failure(value) => value.retained_charge(),
+        }
+    }
+}
+
+impl RetainedCharge for LookupNameFact {
+    fn retained_charge(&self) -> u64 {
+        self.name.retained_charge()
+    }
+}
+
+impl RetainedCharge for LookupNameFailure {
+    fn retained_charge(&self) -> u64 {
+        match self {
+            Self::ModuleIndexUnavailable(value) => value.retained_charge(),
+        }
+    }
+}
+
+impl RetainedCharge for LookupNameValue {
+    fn retained_charge(&self) -> u64 {
+        self.0.retained_charge()
+    }
+}
+
+impl RetainedCharge for ResolvedImportBinding {
+    fn retained_charge(&self) -> u64 {
+        self.normalized_specifier
+            .retained_charge()
+            .saturating_add(self.target.retained_charge())
+    }
+}
+
+impl RetainedCharge for ImportBindingFailure {
+    fn retained_charge(&self) -> u64 {
+        0
+    }
+}
+
+impl RetainedCharge for LookupImportValue {
+    fn retained_charge(&self) -> u64 {
+        self.0.retained_charge()
     }
 }
 
@@ -9943,7 +10285,7 @@ impl RevisionedQueryDatabase {
         declaration_memo_retention: usize,
         query_concurrency: usize,
     ) -> Self {
-        let runtime = QueryRuntime::new(query_concurrency);
+        let runtime = CompilerQueryRuntime(QueryRuntime::new(query_concurrency));
         let module_store = Arc::new(Mutex::new(ModuleInputStore::default()));
         #[cfg(test)]
         let test_import_store = Arc::new(Mutex::new(TestImportInputStore {
@@ -18801,29 +19143,8 @@ impl RevisionedQueryDatabase {
         origins.into_iter()
     }
 
-    pub(crate) fn parse_retained_aborted_len(&self) -> usize {
-        // Abort history belongs to the diagnostic/metrics attempt index.
-        0
-    }
-
-    pub(crate) fn parse_retention(&self) -> crate::typed_query_store::QueryStoreRetention {
-        let retention = self.parse.retention();
-        let protected = match (
-            self.parse_selection.current(),
-            self.parse_selection.last_good(),
-        ) {
-            (Some(current), Some(last_good)) if Arc::ptr_eq(current, last_good) => 1,
-            (Some(_), Some(_)) => 2,
-            (Some(_), None) | (None, Some(_)) => 1,
-            (None, None) => 0,
-        };
-        crate::typed_query_store::QueryStoreRetention {
-            retained: retention.terminals,
-            protected,
-            pinned: 0,
-            tombstones: 0,
-            evictions: self.runtime.metrics().evictions as usize,
-        }
+    pub(crate) fn runtime_retention_metrics(&self) -> rue_query::RuntimeMetrics {
+        self.runtime.metrics()
     }
 }
 
@@ -18909,6 +19230,13 @@ impl QueryKey for ProviderProbeKey {
 #[cfg(test)]
 #[derive(Debug, Clone, PartialEq, Eq)]
 struct ProviderProbeValue;
+
+#[cfg(test)]
+impl RetainedCharge for ProviderProbeValue {
+    fn retained_charge(&self) -> u64 {
+        0
+    }
+}
 
 /// Convert a rue-air provider namespace to the compiler's presemantic
 /// namespace, and back, so a body names a namespace without depending on the

--- a/crates/rue-compiler/src/semantic_query_nucleus.rs
+++ b/crates/rue-compiler/src/semantic_query_nucleus.rs
@@ -7,6 +7,8 @@
 use std::collections::{BTreeMap, BTreeSet};
 use std::sync::Arc;
 
+use crate::retained_charge::RetainedCharge;
+
 use crate::declaration_candidate::{
     DeclarationCandidateCategory as Category, DeclarationCandidateKey, DeclarationShellFact,
 };
@@ -835,6 +837,204 @@ pub(crate) enum ConstResolutionProjection {
 pub(crate) struct DeclarationSemanticValue {
     pub(crate) identity: DeclarationIdentityProjection,
     pub(crate) payload: DurableDeclarationPayload,
+}
+
+impl RetainedCharge for DeferredOwnershipApplication {
+    fn retained_charge(&self) -> u64 {
+        self.declaration.retained_charge()
+    }
+}
+
+impl RetainedCharge for DeferredOwnershipGateSource {
+    fn retained_charge(&self) -> u64 {
+        self.declaration.retained_charge()
+    }
+}
+
+impl RetainedCharge for DeferredOwnershipGate {
+    fn retained_charge(&self) -> u64 {
+        self.ty
+            .retained_charge()
+            .saturating_add(self.source.retained_charge())
+            .saturating_add(self.application.retained_charge())
+    }
+}
+
+impl RetainedCharge for DuplicateDeclarationFailure {
+    fn retained_charge(&self) -> u64 {
+        self.kind
+            .retained_charge()
+            .saturating_add(self.first.retained_charge())
+            .saturating_add(self.duplicate.retained_charge())
+    }
+}
+
+impl RetainedCharge for ForeignSignatureSite {
+    fn retained_charge(&self) -> u64 {
+        self.declaration
+            .retained_charge()
+            .saturating_add(self.signature.retained_charge())
+    }
+}
+
+impl RetainedCharge for ForeignSignatureConflictFailure {
+    fn retained_charge(&self) -> u64 {
+        self.symbol
+            .retained_charge()
+            .saturating_add(self.left.retained_charge())
+            .saturating_add(self.right.retained_charge())
+    }
+}
+
+impl RetainedCharge for SemanticNucleusFailure {
+    fn retained_charge(&self) -> u64 {
+        match self {
+            Self::Shell(detail) | Self::Syntax(detail) | Self::Resolution(detail) => {
+                detail.retained_charge()
+            }
+            Self::Diagnostic(kind)
+            | Self::DiagnosticAtParameter { kind, .. }
+            | Self::DiagnosticAtProducerRange { kind, .. } => kind.retained_charge(),
+            Self::DiagnosticAtDeclaration { kind, declaration } => kind
+                .retained_charge()
+                .saturating_add(declaration.retained_charge()),
+            Self::DuplicateDeclaration {
+                kind,
+                first,
+                duplicate,
+            } => kind
+                .retained_charge()
+                .saturating_add(first.retained_charge())
+                .saturating_add(duplicate.retained_charge()),
+            Self::DuplicateDeclarations(failures) => failures.retained_charge(),
+            Self::ForeignSignatureConflict(failure) => failure.retained_charge(),
+            Self::OwnershipGate { kind, gate } => kind
+                .retained_charge()
+                .saturating_add(gate.retained_charge()),
+            Self::DiagnosticWithHelp { kind, help } => kind
+                .retained_charge()
+                .saturating_add(help.retained_charge()),
+            Self::SignatureReentry { signature, cycle } => signature
+                .retained_charge()
+                .saturating_add(cycle.retained_charge()),
+            Self::Cycle(cycle) => cycle.retained_charge(),
+        }
+    }
+}
+
+impl RetainedCharge for SemanticDeclarationDependencyTarget {
+    fn retained_charge(&self) -> u64 {
+        match self {
+            Self::NamedType(key) | Self::TypeCallHead(key) | Self::NamedValue(key) => {
+                key.retained_charge()
+            }
+            Self::BuiltinTypeCallHead(_) => 0,
+        }
+    }
+}
+
+impl RetainedCharge for SemanticDeclarationDependency {
+    fn retained_charge(&self) -> u64 {
+        self.source
+            .retained_charge()
+            .saturating_add(self.target.retained_charge())
+    }
+}
+
+impl RetainedCharge for DeclarationIdentityProjection {
+    fn retained_charge(&self) -> u64 {
+        self.key.retained_charge()
+    }
+}
+
+impl RetainedCharge for DeclarationSignatureProjection {
+    fn retained_charge(&self) -> u64 {
+        match self {
+            Self::Callable {
+                parameters, result, ..
+            } => parameters
+                .retained_charge()
+                .saturating_add(result.retained_charge()),
+            Self::Struct { fields, .. } => fields.retained_charge(),
+            Self::Enum { variants } => variants.retained_charge(),
+            Self::Destructor => 0,
+        }
+    }
+}
+
+impl RetainedCharge for ResolvedDeclarationSignature {
+    fn retained_charge(&self) -> u64 {
+        self.signature
+            .retained_charge()
+            .saturating_add(self.anonymous_nominals.retained_charge())
+            .saturating_add(self.dependencies.retained_charge())
+            .saturating_add(self.deferred_ownership.retained_charge())
+    }
+}
+
+impl RetainedCharge for ComptimeCallResultProjection {
+    fn retained_charge(&self) -> u64 {
+        match self {
+            Self::Type(ty) => ty.retained_charge(),
+            Self::Value(value) => value.retained_charge(),
+        }
+    }
+}
+
+impl RetainedCharge for ComptimeCallProjection {
+    fn retained_charge(&self) -> u64 {
+        self.result
+            .retained_charge()
+            .saturating_add(self.anonymous_nominals.retained_charge())
+            .saturating_add(self.dependencies.retained_charge())
+            .saturating_add(self.deferred_ownership.retained_charge())
+    }
+}
+
+impl RetainedCharge for ConstResolutionProjection {
+    fn retained_charge(&self) -> u64 {
+        match self {
+            Self::Value {
+                key,
+                ty,
+                value,
+                anonymous_nominals,
+                dependencies,
+                deferred_ownership,
+            } => key
+                .retained_charge()
+                .saturating_add(ty.retained_charge())
+                .saturating_add(value.retained_charge())
+                .saturating_add(anonymous_nominals.retained_charge())
+                .saturating_add(dependencies.retained_charge())
+                .saturating_add(deferred_ownership.retained_charge()),
+            Self::ModuleBinding { key, target } => key
+                .retained_charge()
+                .saturating_add(target.retained_charge()),
+        }
+    }
+}
+
+impl RetainedCharge for SemanticNucleusValue {
+    fn retained_charge(&self) -> u64 {
+        match self {
+            Self::Identity(value) => value.retained_charge(),
+            Self::Signature(value) => value.retained_charge(),
+            Self::NominalWellFormedness | Self::DeferredOwnership => 0,
+            Self::ConstResolution(value) => value.retained_charge(),
+            Self::ComptimeCall(value) => value.retained_charge(),
+            Self::AnonymousNominal(value) => value.retained_charge(),
+            Self::Failure(failure) => failure.retained_charge(),
+        }
+    }
+}
+
+impl RetainedCharge for DeclarationSemanticValue {
+    fn retained_charge(&self) -> u64 {
+        self.identity
+            .retained_charge()
+            .saturating_add(self.payload.retained_charge())
+    }
 }
 
 impl DeclarationSemanticValue {

--- a/crates/rue-compiler/src/semantic_symbols.rs
+++ b/crates/rue-compiler/src/semantic_symbols.rs
@@ -170,6 +170,10 @@ impl SemanticSymbolUniverse {
         &self.interner
     }
 
+    pub(crate) fn admitted_modules(&self) -> &[Arc<crate::parsed_modules::ParsedModule>] {
+        &self.admitted_modules
+    }
+
     pub(crate) fn admits_exact_modules(
         &self,
         modules: &[Arc<crate::parsed_modules::ParsedModule>],

--- a/crates/rue-compiler/src/session.rs
+++ b/crates/rue-compiler/src/session.rs
@@ -27,6 +27,7 @@ use crate::diagnostic_attempt_store::{
     DiagnosticAttemptProvenance, DiagnosticAttemptStore, FrontendDiagnosticIdentity,
     FrontendDiagnosticSnapshot, ImportDiagnosticInputDescriptor,
 };
+use crate::retained_charge::RetainedCharge;
 use crate::typed_query_store::{
     AbortedQueryReason, AttemptExecution as QueryAttemptExecution, AttemptOutcomeKind, AttemptView,
     QUERY_TERMINAL_RETENTION_LIMIT, TerminalKind, TypedQueryFamily,
@@ -49,31 +50,38 @@ pub struct FrontendQueryWork {
 pub struct FrontendRetentionMetrics {
     /// Retained terminal artifacts across all typed query families.
     pub retained_query_records: usize,
-    /// Constant-size selected and last-good terminal protection.
-    pub protected_query_records: usize,
-    /// Retained terminals currently referenced by reverse dependency edges.
+    /// Current and peak deterministic terminal/artifact charge.
+    pub retained_bytes: usize,
+    pub peak_retained_bytes: usize,
+    /// Runtime-wide soft artifact-charge budget.
+    pub retained_byte_budget: usize,
+    /// Retained dependency and input observations. Validation is pull-based;
+    /// this is not a reverse-edge count.
     pub dependency_pins: usize,
-    /// Bounded validation stamps whose artifacts have been evicted.
-    pub validation_tombstones: usize,
-    /// Disappeared graph nodes pinned by retained reverse dependency edges
-    /// after their family tombstones have left bounded store retention.
-    pub graph_retained_disappeared_nodes: usize,
+    pub peak_dependency_pins: usize,
+    pub dependency_pin_budget: usize,
+    pub aggregate_retention_probes: usize,
+    pub retained_byte_probe_quantum: usize,
+    pub dependency_pin_probe_quantum: usize,
+    pub retained_byte_probe_overshoot_bound: usize,
+    pub dependency_pin_probe_overshoot_bound: usize,
+    /// Protection gauges already maintained by their owning scopes.
+    pub active_task_leases: usize,
+    pub peak_task_leases: usize,
+    pub active_retained_pins: usize,
+    pub peak_retained_pins: usize,
+    pub retained_revisions: usize,
+    /// Protected soft-budget overflow and pressure evidence.
+    pub retained_byte_pressure_events: usize,
+    pub dependency_pin_pressure_events: usize,
+    pub retained_byte_overflow_events: usize,
+    pub dependency_pin_overflow_events: usize,
+    pub peak_retained_byte_overage: usize,
+    pub peak_dependency_pin_overage: usize,
     /// Lifetime artifact evictions across all typed query families.
     pub query_evictions: usize,
-    /// Bounded canceled, duplicate, and cyclic query-attempt history.
-    pub aborted_query_attempts: usize,
-    /// Retained direct import-diagnostic query terminals.
-    pub import_query_entries: usize,
-    /// Lifetime direct import-diagnostic query evictions.
-    pub import_query_evictions: usize,
-    /// Retained semantic query terminals.
-    pub semantic_query_entries: usize,
-    /// Lifetime semantic query evictions.
-    pub semantic_query_evictions: usize,
-    /// Retained stable-definition query terminals.
-    pub definition_query_entries: usize,
-    /// Lifetime stable-definition query evictions.
-    pub definition_query_evictions: usize,
+    pub retained_byte_evictions: usize,
+    pub dependency_pin_evictions: usize,
     /// Diagnostic attempts indexed by the bounded diagnostic store.
     ///
     /// Producer caches may also retain the same origin `Arc`; those bounded or
@@ -1110,6 +1118,43 @@ pub(crate) struct ParseQueryRecord {
     diagnostics: Arc<FrontendDiagnosticSnapshot>,
     work: ParsedModulesWork,
     invalidation: ParseInvalidationSummary,
+}
+
+impl RetainedCharge for ExactSourceInput {
+    fn retained_charge(&self) -> u64 {
+        self.revision
+            .retained_charge()
+            .saturating_add(self.metadata.retained_charge())
+    }
+}
+
+impl RetainedCharge for OrdinaryParseKey {
+    fn retained_charge(&self) -> u64 {
+        self.source
+            .retained_charge()
+            .saturating_add(self.file_order.retained_charge())
+            .saturating_add(self.presentation.retained_charge())
+    }
+}
+
+impl RetainedCharge for ParseQueryKey {
+    fn retained_charge(&self) -> u64 {
+        match self {
+            Self::Ordinary(key) => key.retained_charge(),
+            Self::Successor { segment, .. } => segment.retained_charge(),
+        }
+    }
+}
+
+impl RetainedCharge for ParseQueryRecord {
+    fn retained_charge(&self) -> u64 {
+        self.key
+            .retained_charge()
+            .saturating_add(self.snapshot.retained_charge())
+            .saturating_add(self.result.retained_charge())
+            .saturating_add(self.diagnostics.retained_charge())
+            .saturating_add(self.invalidation.retained_charge())
+    }
 }
 
 impl ParseQueryRecord {
@@ -2935,27 +2980,41 @@ impl CompilerSession {
 
     fn refresh_retention_metrics(&mut self) {
         let diagnostics = self.diagnostics.retention_metrics();
-
-        let stores = [self.queries.revisioned.parse_retention()];
+        let runtime = self.queries.revisioned.runtime_retention_metrics();
 
         let mut pinned_attempts = BTreeSet::new();
         pinned_attempts.extend(self.queries.revisioned.parse_origin_attempt_ids());
         self.metrics.set_pinned_origins(pinned_attempts);
 
         self.metrics.set_retention(FrontendRetentionMetrics {
-            retained_query_records: stores.iter().map(|store| store.retained).sum(),
-            protected_query_records: stores.iter().map(|store| store.protected).sum(),
-            dependency_pins: stores.iter().map(|store| store.pinned).sum(),
-            validation_tombstones: stores.iter().map(|store| store.tombstones).sum(),
-            graph_retained_disappeared_nodes: 0,
-            query_evictions: stores.iter().map(|store| store.evictions).sum(),
-            aborted_query_attempts: self.queries.revisioned.parse_retained_aborted_len(),
-            import_query_entries: 0,
-            import_query_evictions: 0,
-            semantic_query_entries: 0,
-            semantic_query_evictions: 0,
-            definition_query_entries: 0,
-            definition_query_evictions: 0,
+            retained_query_records: runtime.retained_terminals as usize,
+            retained_bytes: runtime.retained_bytes as usize,
+            peak_retained_bytes: runtime.peak_retained_bytes as usize,
+            retained_byte_budget: runtime.retained_byte_budget as usize,
+            dependency_pins: runtime.retained_dependency_pins as usize,
+            peak_dependency_pins: runtime.peak_retained_dependency_pins as usize,
+            dependency_pin_budget: runtime.dependency_pin_budget as usize,
+            aggregate_retention_probes: runtime.aggregate_retention_probes as usize,
+            retained_byte_probe_quantum: runtime.retained_byte_probe_quantum as usize,
+            dependency_pin_probe_quantum: runtime.dependency_pin_probe_quantum as usize,
+            retained_byte_probe_overshoot_bound: runtime.retained_byte_probe_overshoot_bound
+                as usize,
+            dependency_pin_probe_overshoot_bound: runtime.dependency_pin_probe_overshoot_bound
+                as usize,
+            active_task_leases: runtime.active_task_leases as usize,
+            peak_task_leases: runtime.peak_task_leases as usize,
+            active_retained_pins: runtime.active_retained_pins as usize,
+            peak_retained_pins: runtime.peak_retained_pins as usize,
+            retained_revisions: runtime.retained_revisions as usize,
+            retained_byte_pressure_events: runtime.retained_byte_pressure_events as usize,
+            dependency_pin_pressure_events: runtime.dependency_pin_pressure_events as usize,
+            retained_byte_overflow_events: runtime.retained_byte_overflow_events as usize,
+            dependency_pin_overflow_events: runtime.dependency_pin_overflow_events as usize,
+            peak_retained_byte_overage: runtime.peak_retained_byte_overage as usize,
+            peak_dependency_pin_overage: runtime.peak_dependency_pin_overage as usize,
+            query_evictions: runtime.evictions as usize,
+            retained_byte_evictions: runtime.retained_byte_evictions as usize,
+            dependency_pin_evictions: runtime.dependency_pin_evictions as usize,
             diagnostic_entries: diagnostics.entries,
             diagnostic_source_attempts: diagnostics.source_attempts,
             diagnostic_source_bytes: diagnostics.source_bytes,
@@ -7134,6 +7193,30 @@ mod tests {
     }
 
     #[test]
+    fn warm_compiler_queries_report_bounded_runtime_retention() {
+        let source = base();
+        let options = CompileOptions::default();
+        let mut session = CompilerSession::new();
+        session.update(&source).into_result().unwrap();
+        session.canonical_semantic(&options).unwrap();
+
+        let cold = session.unstable_metrics().retention();
+        assert!(cold.retained_query_records > 0);
+        assert!(cold.retained_bytes > 0);
+        assert!(cold.dependency_pins > 0);
+        assert!(cold.retained_bytes <= cold.retained_byte_budget);
+        assert!(cold.dependency_pins <= cold.dependency_pin_budget);
+
+        session.canonical_semantic(&options).unwrap();
+        let warm = session.unstable_metrics().retention();
+        assert_eq!(warm.retained_query_records, cold.retained_query_records);
+        assert_eq!(warm.retained_bytes, cold.retained_bytes);
+        assert_eq!(warm.dependency_pins, cold.dependency_pins);
+        assert!(warm.peak_retained_bytes >= warm.retained_bytes);
+        assert!(warm.peak_dependency_pins >= warm.dependency_pins);
+    }
+
+    #[test]
     fn absent_trusted_option_parks_the_rooted_attempt_with_exact_demand_and_anchor() {
         // RUE-1112: a freestanding program whose reached `main` body uses a
         // fallible intrinsic while NO trusted std module is present. The
@@ -9951,8 +10034,6 @@ fn main() -> i32 { 0 }
         assert!(Arc::ptr_eq(&reused, &origin));
         assert_eq!(session.work().import_diagnostics.executions, 1);
         assert_eq!(session.work().import_diagnostics.reuses, 1);
-        assert_eq!(session.work().retention.import_query_entries, 0);
-        assert_eq!(session.work().retention.import_query_evictions, 0);
         assert_eq!(session.work().diagnostic_publications, publications);
         assert!(Arc::ptr_eq(
             session

--- a/crates/rue-compiler/src/toolchain_module_demand.rs
+++ b/crates/rue-compiler/src/toolchain_module_demand.rs
@@ -38,6 +38,7 @@ use std::sync::Arc;
 
 use rue_error::CompileResult;
 
+use crate::retained_charge::RetainedCharge;
 use crate::well_known_option::FalliblePayload;
 use crate::{ModuleId, StableDefinitionKey};
 
@@ -174,6 +175,17 @@ impl BodyToolchainDemand {
     /// present whenever any module is demanded.
     pub(crate) fn requester(&self) -> Option<&StableDefinitionKey> {
         self.requester.as_ref()
+    }
+}
+
+impl RetainedCharge for BodyToolchainDemand {
+    fn retained_charge(&self) -> u64 {
+        self.modules
+            .retained_charge()
+            .saturating_add(
+                (self.payload_kinds.len() * std::mem::size_of::<FalliblePayload>()) as u64,
+            )
+            .saturating_add(self.requester.retained_charge())
     }
 }
 

--- a/crates/rue-compiler/src/type_queries.rs
+++ b/crates/rue-compiler/src/type_queries.rs
@@ -8,6 +8,8 @@ use std::sync::Arc;
 
 use rue_query::QueryKey;
 
+use crate::retained_charge::RetainedCharge;
+
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub(crate) struct TypeQueryKey {
     pub(crate) ty: crate::TypeInstanceKey,
@@ -316,6 +318,154 @@ impl<D, M> DropGlueFacts<D, M> {
 pub(crate) enum DropGlueValue {
     Available(Box<DropGlueFacts>),
     Failure(TypeQueryFailure),
+}
+
+impl RetainedCharge for TypeShape {
+    fn retained_charge(&self) -> u64 {
+        match self {
+            Self::Array { element, .. } => element.retained_charge(),
+            Self::Struct { fields } => fields.retained_charge(),
+            Self::Enum { variants } => variants.retained_charge(),
+            Self::Scalar | Self::Pointer | Self::Slice | Self::Opaque => 0,
+        }
+    }
+}
+
+impl RetainedCharge for TypeShapeValue {
+    fn retained_charge(&self) -> u64 {
+        match self {
+            Self::Available(shape) => shape.retained_charge(),
+            Self::Failure(failure) => failure.retained_charge(),
+        }
+    }
+}
+
+impl RetainedCharge for TypeFacts {
+    fn retained_charge(&self) -> u64 {
+        self.destructor
+            .retained_charge()
+            .saturating_add(self.shape.retained_charge())
+    }
+}
+
+impl RetainedCharge for TypeQueryFailure {
+    fn retained_charge(&self) -> u64 {
+        match self {
+            Self::Unavailable(detail) | Self::Invalid(detail) => detail.retained_charge(),
+        }
+    }
+}
+
+impl RetainedCharge for TypeFactsValue {
+    fn retained_charge(&self) -> u64 {
+        match self {
+            Self::Available(facts) => facts.retained_charge(),
+            Self::Failure(failure) => failure.retained_charge(),
+        }
+    }
+}
+
+impl RetainedCharge for CanonicalLayout {
+    fn retained_charge(&self) -> u64 {
+        self.kind.retained_charge()
+    }
+}
+
+impl RetainedCharge for CanonicalLayoutKind {
+    fn retained_charge(&self) -> u64 {
+        match self {
+            Self::Array { element, .. } => element.retained_charge(),
+            Self::Struct {
+                field_offsets,
+                padding_ranges,
+            } => field_offsets
+                .retained_charge()
+                .saturating_add(padding_ranges.retained_charge()),
+            Self::Enum { variants, .. } => variants.retained_charge(),
+            Self::Scalar | Self::Pointer | Self::Slice => 0,
+        }
+    }
+}
+
+impl RetainedCharge for LayoutValue {
+    fn retained_charge(&self) -> u64 {
+        match self {
+            Self::Available(layout) => layout.retained_charge(),
+            Self::Failure(failure) => failure.retained_charge(),
+        }
+    }
+}
+
+impl RetainedCharge for CallAbiArgument {
+    fn retained_charge(&self) -> u64 {
+        0
+    }
+}
+
+impl RetainedCharge for CallAbiFacts {
+    fn retained_charge(&self) -> u64 {
+        self.arguments.retained_charge()
+    }
+}
+
+impl RetainedCharge for CallAbiValue {
+    fn retained_charge(&self) -> u64 {
+        match self {
+            Self::Available(facts) => facts.retained_charge(),
+            Self::Failure(failure) => failure.retained_charge(),
+        }
+    }
+}
+
+impl<D: RetainedCharge, M: RetainedCharge> RetainedCharge for DropGlueFacts<D, M> {
+    fn retained_charge(&self) -> u64 {
+        self.destructor
+            .retained_charge()
+            .saturating_add(self.nested.retained_charge())
+            .saturating_add(self.plan.retained_charge())
+    }
+}
+
+impl<D: RetainedCharge, M: RetainedCharge> RetainedCharge for DropGluePlan<D, M> {
+    fn retained_charge(&self) -> u64 {
+        match self {
+            Self::None => 0,
+            Self::Struct { fields } => fields.retained_charge(),
+            Self::Array { element, .. } => element.retained_charge(),
+            Self::Enum { variants } => variants.retained_charge(),
+        }
+    }
+}
+
+impl<D: RetainedCharge, M: RetainedCharge> RetainedCharge for DropGlueField<D, M> {
+    fn retained_charge(&self) -> u64 {
+        self.name
+            .retained_charge()
+            .saturating_add(self.ty.retained_charge())
+    }
+}
+
+impl<D: RetainedCharge, M: RetainedCharge> RetainedCharge for DropGlueVariant<D, M> {
+    fn retained_charge(&self) -> u64 {
+        self.name
+            .retained_charge()
+            .saturating_add(self.fields.retained_charge())
+    }
+}
+
+impl<D: RetainedCharge, M: RetainedCharge> RetainedCharge for DropGlueVariantField<D, M> {
+    fn retained_charge(&self) -> u64 {
+        self.ty.retained_charge()
+    }
+}
+
+impl RetainedCharge for DropGlueValue {
+    fn retained_charge(&self) -> u64 {
+        match self {
+            Self::Available(facts) => facts.retained_charge(),
+            Self::Failure(failure) => failure.retained_charge(),
+        }
+    }
 }
 
 pub(crate) fn type_instance(ty: &crate::durable_semantics::DurableType) -> crate::TypeInstanceKey {

--- a/crates/rue-compiler/src/typed_query_store.rs
+++ b/crates/rue-compiler/src/typed_query_store.rs
@@ -62,15 +62,6 @@ pub(crate) enum RuntimeObservation {
     Input(rue_query::InputObservation),
 }
 
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
-pub(crate) struct QueryStoreRetention {
-    pub(crate) retained: usize,
-    pub(crate) protected: usize,
-    pub(crate) pinned: usize,
-    pub(crate) tombstones: usize,
-    pub(crate) evictions: usize,
-}
-
 /// Immutable lifecycle view used by metrics and the diagnostic attempt index.
 pub(crate) trait AttemptView: std::fmt::Debug + Send + Sync {
     fn id(&self) -> AttemptId;

--- a/crates/rue-compiler/src/unstable.rs
+++ b/crates/rue-compiler/src/unstable.rs
@@ -1238,6 +1238,32 @@ impl From<crate::session::FrontendQueryWork> for QueryMetrics {
 /// Retention gauges contained in [`MetricsSnapshot`].
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
 pub struct RetentionMetrics {
+    pub retained_query_records: usize,
+    pub retained_bytes: usize,
+    pub peak_retained_bytes: usize,
+    pub retained_byte_budget: usize,
+    pub dependency_pins: usize,
+    pub peak_dependency_pins: usize,
+    pub dependency_pin_budget: usize,
+    pub aggregate_retention_probes: usize,
+    pub retained_byte_probe_quantum: usize,
+    pub dependency_pin_probe_quantum: usize,
+    pub retained_byte_probe_overshoot_bound: usize,
+    pub dependency_pin_probe_overshoot_bound: usize,
+    pub active_task_leases: usize,
+    pub peak_task_leases: usize,
+    pub active_retained_pins: usize,
+    pub peak_retained_pins: usize,
+    pub retained_revisions: usize,
+    pub retained_byte_pressure_events: usize,
+    pub dependency_pin_pressure_events: usize,
+    pub retained_byte_overflow_events: usize,
+    pub dependency_pin_overflow_events: usize,
+    pub peak_retained_byte_overage: usize,
+    pub peak_dependency_pin_overage: usize,
+    pub query_evictions: usize,
+    pub retained_byte_evictions: usize,
+    pub dependency_pin_evictions: usize,
     pub diagnostic_entries: usize,
     pub diagnostic_source_attempts: usize,
     pub diagnostic_source_bytes: usize,
@@ -1465,6 +1491,38 @@ impl MetricsSnapshot {
     }
     pub fn retention(&self) -> RetentionMetrics {
         RetentionMetrics {
+            retained_query_records: self.inner.retention.retained_query_records,
+            retained_bytes: self.inner.retention.retained_bytes,
+            peak_retained_bytes: self.inner.retention.peak_retained_bytes,
+            retained_byte_budget: self.inner.retention.retained_byte_budget,
+            dependency_pins: self.inner.retention.dependency_pins,
+            peak_dependency_pins: self.inner.retention.peak_dependency_pins,
+            dependency_pin_budget: self.inner.retention.dependency_pin_budget,
+            aggregate_retention_probes: self.inner.retention.aggregate_retention_probes,
+            retained_byte_probe_quantum: self.inner.retention.retained_byte_probe_quantum,
+            dependency_pin_probe_quantum: self.inner.retention.dependency_pin_probe_quantum,
+            retained_byte_probe_overshoot_bound: self
+                .inner
+                .retention
+                .retained_byte_probe_overshoot_bound,
+            dependency_pin_probe_overshoot_bound: self
+                .inner
+                .retention
+                .dependency_pin_probe_overshoot_bound,
+            active_task_leases: self.inner.retention.active_task_leases,
+            peak_task_leases: self.inner.retention.peak_task_leases,
+            active_retained_pins: self.inner.retention.active_retained_pins,
+            peak_retained_pins: self.inner.retention.peak_retained_pins,
+            retained_revisions: self.inner.retention.retained_revisions,
+            retained_byte_pressure_events: self.inner.retention.retained_byte_pressure_events,
+            dependency_pin_pressure_events: self.inner.retention.dependency_pin_pressure_events,
+            retained_byte_overflow_events: self.inner.retention.retained_byte_overflow_events,
+            dependency_pin_overflow_events: self.inner.retention.dependency_pin_overflow_events,
+            peak_retained_byte_overage: self.inner.retention.peak_retained_byte_overage,
+            peak_dependency_pin_overage: self.inner.retention.peak_dependency_pin_overage,
+            query_evictions: self.inner.retention.query_evictions,
+            retained_byte_evictions: self.inner.retention.retained_byte_evictions,
+            dependency_pin_evictions: self.inner.retention.dependency_pin_evictions,
             diagnostic_entries: self.inner.retention.diagnostic_entries,
             diagnostic_source_attempts: self.inner.retention.diagnostic_source_attempts,
             diagnostic_source_bytes: self.inner.retention.diagnostic_source_bytes,

--- a/crates/rue-query/src/lib.rs
+++ b/crates/rue-query/src/lib.rs
@@ -15,6 +15,35 @@ use std::sync::{Arc, Condvar, Mutex, MutexGuard, Weak};
 
 static NEXT_RUNTIME_ID: AtomicU64 = AtomicU64::new(1);
 
+/// Initial runtime-wide soft budget for deterministic retained terminal charge.
+///
+/// This is an accounting budget rather than an allocator/RSS promise. Protected
+/// terminals may exceed it; the runtime records that pressure and reclaims the
+/// excess as soon as protection releases.
+pub const DEFAULT_RETAINED_BYTE_BUDGET: u64 = 8 * 1024 * 1024 * 1024;
+
+/// Initial runtime-wide soft budget for retained dependency and input
+/// observations.
+pub const DEFAULT_DEPENDENCY_PIN_BUDGET: u64 = 4_000_000;
+
+/// Runtime-wide soft retention budgets.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct RetentionBudgets {
+    /// Deterministic terminal/artifact charge in bytes.
+    pub retained_bytes: u64,
+    /// Retained dependency plus input observation edges.
+    pub dependency_pins: u64,
+}
+
+impl Default for RetentionBudgets {
+    fn default() -> Self {
+        Self {
+            retained_bytes: DEFAULT_RETAINED_BYTE_BUDGET,
+            dependency_pins: DEFAULT_DEPENDENCY_PIN_BUDGET,
+        }
+    }
+}
+
 /// Registered evaluators historically ran on the requesting compiler thread,
 /// whose platform stack is materially larger than Rust's default spawned-thread
 /// stack. Keep structured batch children at that established floor so moving a
@@ -1023,6 +1052,7 @@ pub struct QueryOutput<V> {
     kind: QueryTerminalKind,
     diagnostics: Vec<QueryDiagnostic>,
     work: Vec<WorkItem>,
+    retained_value_charge: Option<u64>,
 }
 
 impl<V> QueryOutput<V> {
@@ -1033,6 +1063,7 @@ impl<V> QueryOutput<V> {
             kind: QueryTerminalKind::Success,
             diagnostics: Vec::new(),
             work: Vec::new(),
+            retained_value_charge: None,
         }
     }
 
@@ -1043,6 +1074,7 @@ impl<V> QueryOutput<V> {
             kind: QueryTerminalKind::Failure,
             diagnostics: Vec::new(),
             work: Vec::new(),
+            retained_value_charge: None,
         }
     }
 
@@ -1055,6 +1087,20 @@ impl<V> QueryOutput<V> {
     /// Attaches structural work. Publication reduces it by stable identity.
     pub fn with_work(mut self, work: Vec<WorkItem>) -> Self {
         self.work = work;
+        self
+    }
+
+    /// Adds this success value's deterministic reachable heap charge.
+    ///
+    /// The terminal envelope already includes the inline `V` storage, so this
+    /// charge is only for heap-owned allocations reachable through the value.
+    /// The runtime adds the terminal envelope, diagnostics,
+    /// structural work, dependencies, and inputs automatically. Shared
+    /// allocations may be charged in full by every terminal which reaches them.
+    /// Failure values ignore this override because their canonical strings are
+    /// charged directly.
+    pub fn with_retained_value_charge(mut self, bytes: u64) -> Self {
+        self.retained_value_charge = Some(bytes);
         self
     }
 
@@ -1118,6 +1164,8 @@ pub struct QueryTerminal<V> {
     work: Arc<[(Arc<str>, u64)]>,
     dependencies: Arc<[Observation]>,
     inputs: Arc<[InputObservation]>,
+    retained_charge: u64,
+    dependency_pin_charge: u64,
     pins: AtomicUsize,
 }
 
@@ -1176,6 +1224,16 @@ impl<V> QueryTerminal<V> {
     /// Exact input leaves read directly by the computing body.
     pub fn inputs(&self) -> &[InputObservation] {
         &self.inputs
+    }
+
+    /// Deterministic runtime-wide retained artifact charge.
+    pub const fn retained_charge(&self) -> u64 {
+        self.retained_charge
+    }
+
+    /// Retained dependency and input observation edges charged to this terminal.
+    pub const fn dependency_pin_charge(&self) -> u64 {
+        self.dependency_pin_charge
     }
 }
 
@@ -1501,6 +1559,45 @@ pub struct RuntimeMetrics {
     pub evictions: u64,
     /// Current retained terminal attempts.
     pub retained_terminals: u64,
+    /// Current deterministic charge for retained terminal artifacts.
+    pub retained_bytes: u64,
+    /// Peak deterministic charge for retained terminal artifacts.
+    pub peak_retained_bytes: u64,
+    /// Current retained dependency and input observation edges.
+    pub retained_dependency_pins: u64,
+    /// Peak retained dependency and input observation edges.
+    pub peak_retained_dependency_pins: u64,
+    /// Configured runtime-wide soft artifact-charge budget.
+    pub retained_byte_budget: u64,
+    /// Configured runtime-wide soft dependency-observation budget.
+    pub dependency_pin_budget: u64,
+    /// Cross-family charge aggregations triggered by family-local watermarks.
+    pub aggregate_retention_probes: u64,
+    /// Deterministic family-local byte/pin quanta between aggregate probes.
+    pub retained_byte_probe_quantum: u64,
+    pub dependency_pin_probe_quantum: u64,
+    /// Worst-case soft-budget detection overshoot from all currently live
+    /// families publishing just below their next probe watermark.
+    pub retained_byte_probe_overshoot_bound: u64,
+    pub dependency_pin_probe_overshoot_bound: u64,
+    /// Enforcement passes which began above the byte budget.
+    pub retained_byte_pressure_events: u64,
+    /// Enforcement passes which began above the dependency-pin budget.
+    pub dependency_pin_pressure_events: u64,
+    /// Byte-pressure passes unable to reach budget because all candidates were
+    /// protected.
+    pub retained_byte_overflow_events: u64,
+    /// Dependency-pressure passes unable to reach budget because all candidates
+    /// were protected.
+    pub dependency_pin_overflow_events: u64,
+    /// Largest protected byte overage observed after an enforcement pass.
+    pub peak_retained_byte_overage: u64,
+    /// Largest protected dependency-pin overage observed after enforcement.
+    pub peak_dependency_pin_overage: u64,
+    /// Terminals evicted while byte pressure was active.
+    pub retained_byte_evictions: u64,
+    /// Terminals evicted while dependency-pin pressure was active.
+    pub dependency_pin_evictions: u64,
     /// Retention passes forced to grow past the configured terminal bound
     /// because every eviction candidate was a protected root (waiter, pin,
     /// request-scoped observation lease, or retained revision). This is the
@@ -1568,6 +1665,17 @@ struct Metrics {
     cycles: AtomicU64,
     evictions: AtomicU64,
     retained_terminals: AtomicU64,
+    peak_retained_bytes: AtomicU64,
+    peak_retained_dependency_pins: AtomicU64,
+    retained_byte_pressure_events: AtomicU64,
+    dependency_pin_pressure_events: AtomicU64,
+    aggregate_retention_probes: AtomicU64,
+    retained_byte_overflow_events: AtomicU64,
+    dependency_pin_overflow_events: AtomicU64,
+    peak_retained_byte_overage: AtomicU64,
+    peak_dependency_pin_overage: AtomicU64,
+    retained_byte_evictions: AtomicU64,
+    dependency_pin_evictions: AtomicU64,
     retention_growth: AtomicU64,
     retention_enforcements: AtomicU64,
     retention_scan_entries: AtomicU64,
@@ -1581,7 +1689,11 @@ struct Metrics {
 }
 
 impl Metrics {
-    fn snapshot(&self) -> RuntimeMetrics {
+    fn snapshot(
+        &self,
+        budgets: RetentionBudgets,
+        retention: RuntimeRetentionSnapshot,
+    ) -> RuntimeMetrics {
         RuntimeMetrics {
             claims: self.claims.load(Ordering::Relaxed),
             joins: self.joins.load(Ordering::Relaxed),
@@ -1595,6 +1707,47 @@ impl Metrics {
             cycles: self.cycles.load(Ordering::Relaxed),
             evictions: self.evictions.load(Ordering::Relaxed),
             retained_terminals: self.retained_terminals.load(Ordering::Relaxed),
+            retained_bytes: retention.retained_bytes,
+            peak_retained_bytes: self.peak_retained_bytes.load(Ordering::Relaxed),
+            retained_dependency_pins: retention.dependency_pins,
+            peak_retained_dependency_pins: self
+                .peak_retained_dependency_pins
+                .load(Ordering::Relaxed),
+            retained_byte_budget: budgets.retained_bytes,
+            dependency_pin_budget: budgets.dependency_pins,
+            aggregate_retention_probes: self.aggregate_retention_probes.load(Ordering::Relaxed),
+            retained_byte_probe_quantum: retention_probe_quantum(
+                budgets.retained_bytes,
+                1024 * 1024,
+                32 * 1024 * 1024,
+            ),
+            dependency_pin_probe_quantum: retention_probe_quantum(
+                budgets.dependency_pins,
+                4096,
+                65_536,
+            ),
+            retained_byte_probe_overshoot_bound: retention.live_families.saturating_mul(
+                retention_probe_quantum(budgets.retained_bytes, 1024 * 1024, 32 * 1024 * 1024),
+            ),
+            dependency_pin_probe_overshoot_bound: retention.live_families.saturating_mul(
+                retention_probe_quantum(budgets.dependency_pins, 4096, 65_536),
+            ),
+            retained_byte_pressure_events: self
+                .retained_byte_pressure_events
+                .load(Ordering::Relaxed),
+            dependency_pin_pressure_events: self
+                .dependency_pin_pressure_events
+                .load(Ordering::Relaxed),
+            retained_byte_overflow_events: self
+                .retained_byte_overflow_events
+                .load(Ordering::Relaxed),
+            dependency_pin_overflow_events: self
+                .dependency_pin_overflow_events
+                .load(Ordering::Relaxed),
+            peak_retained_byte_overage: self.peak_retained_byte_overage.load(Ordering::Relaxed),
+            peak_dependency_pin_overage: self.peak_dependency_pin_overage.load(Ordering::Relaxed),
+            retained_byte_evictions: self.retained_byte_evictions.load(Ordering::Relaxed),
+            dependency_pin_evictions: self.dependency_pin_evictions.load(Ordering::Relaxed),
             retention_growth: self.retention_growth.load(Ordering::Relaxed),
             retention_enforcements: self.retention_enforcements.load(Ordering::Relaxed),
             retention_scan_entries: self.retention_scan_entries.load(Ordering::Relaxed),
@@ -1653,6 +1806,19 @@ struct RuntimeCore {
     family_names: Mutex<BTreeSet<Arc<str>>>,
     revisions: Mutex<RevisionStore>,
     nodes: Mutex<NodeRegistry>,
+    retention_families: Mutex<BTreeMap<u64, Weak<dyn RetentionFamily>>>,
+    retention_budgets: RetentionBudgets,
+    /// Aggregate thresholds are consulted only after a family-local probe, not
+    /// by every publication.
+    next_retained_byte_sweep: AtomicU64,
+    next_dependency_pin_sweep: AtomicU64,
+    /// Stable family token at which the next pressure pass begins. Only the
+    /// single claimed sweep owner mutates this cursor, so the runtime can carry
+    /// round-robin fairness across separate pressure events without putting a
+    /// lock on ordinary publication.
+    retention_sweep_cursor: AtomicU64,
+    retention_sweep_claimed: AtomicBool,
+    retention_sweep_pending: AtomicBool,
     /// Spawned structured-batch workers currently alive across every root and
     /// nesting depth. The caller always executes one child inline; this global
     /// counter caps additional OS threads at `permits.maximum - 1`.
@@ -1690,6 +1856,55 @@ struct RegisteredNode {
     node: Weak<dyn ErasedNode>,
     #[cfg(test)]
     entry_visits: Arc<AtomicUsize>,
+}
+
+/// One family-local FIFO exposed to the runtime only while aggregate retention
+/// is under pressure. Ordinary publication never consults this registry.
+trait RetentionFamily: fmt::Debug + Send + Sync {
+    /// Evicts the oldest currently unprotected terminal in this family. Stale
+    /// FIFO entries are discarded as they are encountered.
+    fn evict_one(&self) -> bool;
+
+    /// Exact family-local byte/pin gauges without walking terminal nodes.
+    fn charge_snapshot(&self) -> FamilyChargeSnapshot;
+}
+
+struct RetentionFamilyDriver {
+    name: Arc<str>,
+    evict_one: Box<dyn Fn() -> bool + Send + Sync>,
+    charge_snapshot: Box<dyn Fn() -> FamilyChargeSnapshot + Send + Sync>,
+}
+
+impl fmt::Debug for RetentionFamilyDriver {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("RetentionFamilyDriver")
+            .field("name", &self.name)
+            .finish_non_exhaustive()
+    }
+}
+
+impl RetentionFamily for RetentionFamilyDriver {
+    fn evict_one(&self) -> bool {
+        (self.evict_one)()
+    }
+
+    fn charge_snapshot(&self) -> FamilyChargeSnapshot {
+        (self.charge_snapshot)()
+    }
+}
+
+#[derive(Debug, Default, Clone, Copy)]
+struct FamilyChargeSnapshot {
+    retained_bytes: u64,
+    dependency_pins: u64,
+}
+
+#[derive(Debug, Default, Clone, Copy)]
+struct RuntimeRetentionSnapshot {
+    retained_bytes: u64,
+    dependency_pins: u64,
+    live_families: u64,
 }
 
 impl RegisteredNode {
@@ -1779,6 +1994,9 @@ enum InterposeSite {
     /// A lifecycle waiter observed neither completion nor cancellation while
     /// holding the predicate lock, immediately before atomically parking.
     HandoffCommitPark,
+    /// Aggregate retention has finished a pass and is about to hand sweep
+    /// ownership to any publisher which arrived concurrently.
+    RetentionSweepRelease,
 }
 
 const REVISION_RETENTION_LIMIT: usize = 64;
@@ -1892,6 +2110,18 @@ struct TestEvents {
 impl QueryRuntime {
     /// Creates a runtime with one shared structured concurrency budget.
     pub fn new(max_concurrency: usize) -> Self {
+        Self::with_retention_budgets(max_concurrency, RetentionBudgets::default())
+    }
+
+    /// Creates a runtime with explicit runtime-wide soft retention budgets.
+    ///
+    /// This constructor is primarily useful for deterministic policy tests and
+    /// benchmark calibration. A zero budget is valid: newly published work is
+    /// reclaimed immediately when it has no live protection.
+    pub fn with_retention_budgets(
+        max_concurrency: usize,
+        retention_budgets: RetentionBudgets,
+    ) -> Self {
         assert!(max_concurrency > 0, "query concurrency must be nonzero");
         Self {
             core: Arc::new(RuntimeCore {
@@ -1904,6 +2134,17 @@ impl QueryRuntime {
                     retired_through: 0,
                 }),
                 nodes: Mutex::new(NodeRegistry::default()),
+                retention_families: Mutex::new(BTreeMap::new()),
+                retention_budgets,
+                next_retained_byte_sweep: AtomicU64::new(
+                    retention_budgets.retained_bytes.saturating_add(1),
+                ),
+                next_dependency_pin_sweep: AtomicU64::new(
+                    retention_budgets.dependency_pins.saturating_add(1),
+                ),
+                retention_sweep_cursor: AtomicU64::new(1),
+                retention_sweep_claimed: AtomicBool::new(false),
+                retention_sweep_pending: AtomicBool::new(false),
                 batch_workers: AtomicUsize::new(0),
                 next_task: AtomicU64::new(1),
                 next_family: AtomicU64::new(1),
@@ -1918,6 +2159,12 @@ impl QueryRuntime {
     }
 
     /// Creates a typed family with deterministic FIFO terminal retention.
+    ///
+    /// This convenience form assigns no heap-owned success-value charge. A
+    /// caller retaining heap-backed values should use the corresponding
+    /// `*_and_retained_charge` constructor or set an exact charge on each
+    /// [`QueryOutput`]. The terminal envelope, diagnostics, work, and
+    /// observations are always charged by the runtime.
     pub fn family<K, V>(
         &self,
         stable_name: impl Into<Arc<str>>,
@@ -1934,7 +2181,8 @@ impl QueryRuntime {
     ///
     /// Compiler families use this when their retained success values do not
     /// implement blanket `Eq`, or when only a canonical projection participates
-    /// in red/green publication.
+    /// in red/green publication. This convenience form assigns no heap-owned
+    /// success-value charge; see [`Self::family_with_equality_and_retained_charge`].
     pub fn family_with_equality<K, V>(
         &self,
         stable_name: impl Into<Arc<str>>,
@@ -1945,7 +2193,29 @@ impl QueryRuntime {
         K: QueryKey,
         V: Clone + Send + Sync + 'static,
     {
-        self.family_with_optional_evaluator(stable_name, retention_limit, value_equal, None)
+        self.family_with_optional_evaluator(stable_name, retention_limit, value_equal, |_| 0, None)
+    }
+
+    /// Creates an unregistered family with an estimator for heap-owned success
+    /// value data.
+    pub fn family_with_equality_and_retained_charge<K, V>(
+        &self,
+        stable_name: impl Into<Arc<str>>,
+        retention_limit: usize,
+        value_equal: fn(&V, &V) -> bool,
+        retained_value_charge: fn(&V) -> u64,
+    ) -> Result<QueryFamily<K, V>, FamilyError>
+    where
+        K: QueryKey,
+        V: Clone + Send + Sync + 'static,
+    {
+        self.family_with_optional_evaluator(
+            stable_name,
+            retention_limit,
+            value_equal,
+            retained_value_charge,
+            None,
+        )
     }
 
     /// Creates a typed family with a canonical family-owned evaluator.
@@ -1995,6 +2265,35 @@ impl QueryRuntime {
             stable_name,
             retention_limit,
             value_equal,
+            |_| 0,
+            Some(Arc::new(evaluator)),
+        )
+    }
+
+    /// Creates a registered family with an allocator-independent estimator for
+    /// heap-owned success-value data. The estimator excludes inline `V` storage,
+    /// which is already part of the terminal envelope.
+    pub fn family_with_equality_and_evaluator_and_retained_charge<K, V, E>(
+        &self,
+        stable_name: impl Into<Arc<str>>,
+        retention_limit: usize,
+        value_equal: fn(&V, &V) -> bool,
+        retained_value_charge: fn(&V) -> u64,
+        evaluator: E,
+    ) -> Result<QueryFamily<K, V>, FamilyError>
+    where
+        K: QueryKey,
+        V: Clone + Send + Sync + 'static,
+        E: Fn(&QueryContext, &QueryFamily<K, V>, &K) -> Result<QueryOutput<V>, QueryAbort>
+            + Send
+            + Sync
+            + 'static,
+    {
+        self.family_with_optional_evaluator(
+            stable_name,
+            retention_limit,
+            value_equal,
+            retained_value_charge,
             Some(Arc::new(evaluator)),
         )
     }
@@ -2004,13 +2303,21 @@ impl QueryRuntime {
         stable_name: impl Into<Arc<str>>,
         retention_limit: usize,
         value_equal: fn(&V, &V) -> bool,
+        retained_value_charge: fn(&V) -> u64,
         evaluator: Option<Arc<FamilyEvaluator<K, V>>>,
     ) -> Result<QueryFamily<K, V>, FamilyError>
     where
         K: QueryKey,
         V: Clone + Send + Sync + 'static,
     {
-        self.family_inner(stable_name, retention_limit, value_equal, evaluator, false)
+        self.family_inner(
+            stable_name,
+            retention_limit,
+            value_equal,
+            retained_value_charge,
+            evaluator,
+            false,
+        )
     }
 
     /// Creates a typed family REGISTERED CONTENT-ADDRESSED: the family asserts
@@ -2029,7 +2336,30 @@ impl QueryRuntime {
         K: QueryKey,
         V: Clone + Send + Sync + 'static,
     {
-        self.family_inner(stable_name, retention_limit, value_equal, None, true)
+        self.family_inner(stable_name, retention_limit, value_equal, |_| 0, None, true)
+    }
+
+    /// Creates a content-addressed family with an estimator for heap-owned
+    /// success-value data.
+    pub fn content_addressed_family_with_equality_and_retained_charge<K, V>(
+        &self,
+        stable_name: impl Into<Arc<str>>,
+        retention_limit: usize,
+        value_equal: fn(&V, &V) -> bool,
+        retained_value_charge: fn(&V) -> u64,
+    ) -> Result<QueryFamily<K, V>, FamilyError>
+    where
+        K: QueryKey,
+        V: Clone + Send + Sync + 'static,
+    {
+        self.family_inner(
+            stable_name,
+            retention_limit,
+            value_equal,
+            retained_value_charge,
+            None,
+            true,
+        )
     }
 
     fn family_inner<K, V>(
@@ -2037,6 +2367,7 @@ impl QueryRuntime {
         stable_name: impl Into<Arc<str>>,
         retention_limit: usize,
         value_equal: fn(&V, &V) -> bool,
+        retained_value_charge: fn(&V) -> u64,
         evaluator: Option<Arc<FamilyEvaluator<K, V>>>,
         content_addressed: bool,
     ) -> Result<QueryFamily<K, V>, FamilyError>
@@ -2051,25 +2382,54 @@ impl QueryRuntime {
         if !lock(&self.core.family_names).insert(name.clone()) {
             return Err(FamilyError::DuplicateName(name));
         }
+        let family_number = self.core.next_family.fetch_add(1, Ordering::Relaxed);
+        let inner = Arc::new(FamilyInner {
+            core: Arc::downgrade(&self.core),
+            name: name.clone(),
+            token: FamilyToken {
+                runtime: self.core.identity,
+                family: family_number,
+            },
+            content_addressed,
+            retention_limit,
+            value_equal,
+            retained_value_charge,
+            evaluator,
+            nodes: Mutex::new(HashMap::new()),
+            retention: Mutex::new(FamilyRetentionQueue::new(self.core.retention_budgets)),
+            retained_count: AtomicUsize::new(0),
+            next_publish_sweep: AtomicUsize::new(retention_limit.saturating_add(1)),
+            retained_nodes: AtomicUsize::new(0),
+            retained_revisions: Mutex::new(BTreeMap::new()),
+        });
+        let weak_core = Arc::downgrade(&self.core);
+        let weak_inner = Arc::downgrade(&inner);
+        let charge_inner = Arc::downgrade(&inner);
+        let retention_driver: Arc<dyn RetentionFamily> = Arc::new(RetentionFamilyDriver {
+            name,
+            evict_one: Box::new(move || {
+                let Some(core) = weak_core.upgrade() else {
+                    return false;
+                };
+                let Some(inner) = weak_inner.upgrade() else {
+                    return false;
+                };
+                evict_one_from_family(&core, &inner)
+            }),
+            charge_snapshot: Box::new(move || {
+                charge_inner
+                    .upgrade()
+                    .map_or_else(FamilyChargeSnapshot::default, |inner| {
+                        family_charge_snapshot(&inner)
+                    })
+            }),
+        });
+        lock(&self.core.retention_families)
+            .insert(family_number, Arc::downgrade(&retention_driver));
         Ok(QueryFamily {
             core: self.core.clone(),
-            inner: Arc::new(FamilyInner {
-                name,
-                token: FamilyToken {
-                    runtime: self.core.identity,
-                    family: self.core.next_family.fetch_add(1, Ordering::Relaxed),
-                },
-                content_addressed,
-                retention_limit,
-                value_equal,
-                evaluator,
-                nodes: Mutex::new(HashMap::new()),
-                retention: Mutex::new(VecDeque::new()),
-                retained_count: AtomicUsize::new(0),
-                next_publish_sweep: AtomicUsize::new(retention_limit.saturating_add(1)),
-                retained_nodes: AtomicUsize::new(0),
-                retained_revisions: Mutex::new(BTreeMap::new()),
-            }),
+            inner,
+            retention_driver,
         })
     }
 
@@ -2517,7 +2877,12 @@ impl QueryRuntime {
 
     /// Returns a point-in-time structural metrics snapshot.
     pub fn metrics(&self) -> RuntimeMetrics {
-        let mut metrics = self.core.metrics.snapshot();
+        let retention = self.core.retention_snapshot();
+        self.core.record_retention_peaks(retention);
+        let mut metrics = self
+            .core
+            .metrics
+            .snapshot(self.core.retention_budgets, retention);
         metrics.retained_revisions = lock(&self.core.revisions).entries.len() as u64;
         metrics
     }
@@ -2580,12 +2945,14 @@ pub enum FamilyError {
 pub struct QueryFamily<K: QueryKey, V: Clone + Send + Sync + 'static> {
     core: Arc<RuntimeCore>,
     inner: Arc<FamilyInner<K, V>>,
+    retention_driver: Arc<dyn RetentionFamily>,
 }
 
 /// Non-owning handle for evaluator graphs with cross-family back edges.
 pub struct WeakQueryFamily<K: QueryKey, V: Clone + Send + Sync + 'static> {
     core: Weak<RuntimeCore>,
     inner: Weak<FamilyInner<K, V>>,
+    retention_driver: Weak<dyn RetentionFamily>,
 }
 
 impl<K, V> Clone for WeakQueryFamily<K, V>
@@ -2597,6 +2964,7 @@ where
         Self {
             core: self.core.clone(),
             inner: self.inner.clone(),
+            retention_driver: self.retention_driver.clone(),
         }
     }
 }
@@ -2611,6 +2979,7 @@ where
         Some(QueryFamily {
             core: self.core.upgrade()?,
             inner: self.inner.upgrade()?,
+            retention_driver: self.retention_driver.upgrade()?,
         })
     }
 }
@@ -2638,11 +3007,13 @@ where
         Self {
             core: self.core.clone(),
             inner: self.inner.clone(),
+            retention_driver: self.retention_driver.clone(),
         }
     }
 }
 
 struct FamilyInner<K: QueryKey, V: Clone + Send + Sync + 'static> {
+    core: Weak<RuntimeCore>,
     name: Arc<str>,
     token: FamilyToken,
     /// Registration policy: the family asserts every record is a pure function
@@ -2653,6 +3024,7 @@ struct FamilyInner<K: QueryKey, V: Clone + Send + Sync + 'static> {
     content_addressed: bool,
     retention_limit: usize,
     value_equal: fn(&V, &V) -> bool,
+    retained_value_charge: fn(&V) -> u64,
     evaluator: Option<Arc<FamilyEvaluator<K, V>>>,
     // Hashed typed-key memo index. Exact `K` equality is authoritative: the map
     // is keyed by the typed key itself, so hash collisions resolve through `Eq`
@@ -2661,7 +3033,7 @@ struct FamilyInner<K: QueryKey, V: Clone + Send + Sync + 'static> {
     // unordered: eviction order lives in `retention` below (the memo index never
     // encoded eviction order), so no companion order structure is required.
     nodes: Mutex<HashMap<K, Arc<Node<K, V>>>>,
-    retention: Mutex<VecDeque<RetentionEntry<K, V>>>,
+    retention: Mutex<FamilyRetentionQueue<K, V>>,
     retained_count: AtomicUsize,
     /// Retained-count watermark for the next publish-side sweep. A pass that
     /// finds only protected entries doubles this watermark, so growing a live
@@ -2685,6 +3057,31 @@ where
             .field("retention_limit", &self.retention_limit)
             .field("has_evaluator", &self.evaluator.is_some())
             .finish_non_exhaustive()
+    }
+}
+
+impl<K, V> Drop for FamilyInner<K, V>
+where
+    K: QueryKey,
+    V: Clone + Send + Sync + 'static,
+{
+    fn drop(&mut self) {
+        let Some(core) = self.core.upgrade() else {
+            return;
+        };
+        let mut terminals = 0_u64;
+        for node in lock(&self.nodes).values() {
+            for attempt in &lock(&node.state).attempts {
+                if let AttemptState::Terminal { .. } = &attempt.state {
+                    terminals += 1;
+                }
+            }
+        }
+        if terminals > 0 {
+            core.metrics
+                .retained_terminals
+                .fetch_sub(terminals, Ordering::Relaxed);
+        }
     }
 }
 
@@ -2950,6 +3347,174 @@ struct RetentionEntry<K, V> {
     attempt: u64,
 }
 
+struct FamilyRetentionQueue<K, V> {
+    entries: VecDeque<RetentionEntry<K, V>>,
+    retained_bytes: u64,
+    dependency_pins: u64,
+    next_byte_probe: u64,
+    next_pin_probe: u64,
+    byte_probe_quantum: u64,
+    pin_probe_quantum: u64,
+}
+
+impl<K, V> FamilyRetentionQueue<K, V> {
+    fn new(budgets: RetentionBudgets) -> Self {
+        let byte_probe_quantum =
+            retention_probe_quantum(budgets.retained_bytes, 1024 * 1024, 32 * 1024 * 1024);
+        let pin_probe_quantum = retention_probe_quantum(budgets.dependency_pins, 4096, 65_536);
+        Self {
+            entries: VecDeque::new(),
+            retained_bytes: 0,
+            dependency_pins: 0,
+            next_byte_probe: byte_probe_quantum,
+            next_pin_probe: pin_probe_quantum,
+            byte_probe_quantum,
+            pin_probe_quantum,
+        }
+    }
+
+    fn publish(
+        &mut self,
+        entry: RetentionEntry<K, V>,
+        retained_bytes: u64,
+        dependency_pins: u64,
+    ) -> bool {
+        self.entries.push_back(entry);
+        self.retained_bytes = self.retained_bytes.saturating_add(retained_bytes);
+        self.dependency_pins = self.dependency_pins.saturating_add(dependency_pins);
+        let probe = self.retained_bytes >= self.next_byte_probe
+            || self.dependency_pins >= self.next_pin_probe;
+        if probe {
+            self.next_byte_probe = next_probe(self.retained_bytes, self.byte_probe_quantum);
+            self.next_pin_probe = next_probe(self.dependency_pins, self.pin_probe_quantum);
+        }
+        probe
+    }
+
+    fn remove_charge(&mut self, retained_bytes: u64, dependency_pins: u64) {
+        self.retained_bytes = self
+            .retained_bytes
+            .checked_sub(retained_bytes)
+            .expect("retained byte charge releases exactly once");
+        self.dependency_pins = self
+            .dependency_pins
+            .checked_sub(dependency_pins)
+            .expect("retained dependency-pin charge releases exactly once");
+        // A sweep can reclaim most of a family's charge after its publication
+        // watermark advanced. Rebase both probes to the new live charge so a
+        // subsequent regrowth cannot hide below the stale high watermark.
+        self.next_byte_probe = next_probe(self.retained_bytes, self.byte_probe_quantum);
+        self.next_pin_probe = next_probe(self.dependency_pins, self.pin_probe_quantum);
+    }
+}
+
+fn retention_probe_quantum(budget: u64, normal_minimum: u64, normal_maximum: u64) -> u64 {
+    if budget < normal_minimum {
+        // Tiny deterministic policy tests need correspondingly exact probes.
+        return (budget / 64).max(1);
+    }
+    (budget / 128).clamp(normal_minimum, normal_maximum)
+}
+
+fn next_probe(current: u64, quantum: u64) -> u64 {
+    current
+        .checked_div(quantum)
+        .unwrap_or(u64::MAX)
+        .saturating_add(1)
+        .saturating_mul(quantum)
+}
+
+fn evict_one_from_family<K, V>(core: &Arc<RuntimeCore>, family: &Arc<FamilyInner<K, V>>) -> bool
+where
+    K: QueryKey,
+    V: Clone + Send + Sync + 'static,
+{
+    let mut retention = lock(&family.retention);
+    let mut remaining = retention.entries.len();
+    while remaining > 0 {
+        remaining -= 1;
+        let entry = retention
+            .entries
+            .pop_front()
+            .expect("retention scan is nonempty");
+        core.metrics
+            .retention_scan_entries
+            .fetch_add(1, Ordering::Relaxed);
+        let Some(node) = entry.node.upgrade() else {
+            continue;
+        };
+        let mut state = lock(&node.state);
+        let Some(index) = state
+            .attempts
+            .iter()
+            .position(|item| item.id == entry.attempt)
+        else {
+            continue;
+        };
+        let protected = match &state.attempts[index].state {
+            AttemptState::Computing { .. } => true,
+            AttemptState::Terminal {
+                terminal, waiters, ..
+            } => {
+                *waiters > 0
+                    || terminal.pins.load(Ordering::Acquire) > 0
+                    || lock(&family.retained_revisions).contains_key(&terminal.revision)
+            }
+        };
+        if protected {
+            drop(state);
+            retention.entries.push_back(entry);
+            continue;
+        }
+        let removed = state
+            .attempts
+            .remove(index)
+            .expect("retention selected an existing attempt");
+        let (terminal, handoffs) = match removed.state {
+            AttemptState::Terminal {
+                terminal, handoffs, ..
+            } => (terminal, handoffs),
+            AttemptState::Computing { .. } => unreachable!(),
+        };
+        let empty = state.attempts.is_empty();
+        drop(state);
+        core.metrics.evictions.fetch_add(1, Ordering::Relaxed);
+        core.metrics
+            .retained_terminals
+            .fetch_sub(1, Ordering::Relaxed);
+        family.retained_count.fetch_sub(1, Ordering::Relaxed);
+        retention.remove_charge(terminal.retained_charge, terminal.dependency_pin_charge);
+        if empty && node.users.load(Ordering::Acquire) == 0 {
+            let mut nodes = lock(&family.nodes);
+            if node.users.load(Ordering::Acquire) == 0
+                && lock(&node.state).attempts.is_empty()
+                && nodes
+                    .get(&node.key)
+                    .is_some_and(|candidate| Arc::ptr_eq(candidate, &node))
+            {
+                nodes.remove(&node.key);
+                family.retained_nodes.fetch_sub(1, Ordering::Relaxed);
+            }
+        }
+        drop(retention);
+        handoffs.abort();
+        return true;
+    }
+    false
+}
+
+fn family_charge_snapshot<K, V>(family: &FamilyInner<K, V>) -> FamilyChargeSnapshot
+where
+    K: QueryKey,
+    V: Clone + Send + Sync + 'static,
+{
+    let retention = lock(&family.retention);
+    FamilyChargeSnapshot {
+        retained_bytes: retention.retained_bytes,
+        dependency_pins: retention.dependency_pins,
+    }
+}
+
 enum TaskQueryResult<V> {
     Terminal {
         terminal: Arc<QueryTerminal<V>>,
@@ -3017,6 +3582,7 @@ where
         WeakQueryFamily {
             core: Arc::downgrade(&self.core),
             inner: Arc::downgrade(&self.inner),
+            retention_driver: Arc::downgrade(&self.retention_driver),
         }
     }
 
@@ -3087,6 +3653,7 @@ where
             let demand = self.inner.evaluator.as_ref().map(|_| {
                 let core = self.core.clone();
                 let family = Arc::downgrade(&self.inner);
+                let retention_driver = self.retention_driver.clone();
                 let key = key.clone();
                 Arc::new(move |task: Arc<Task>, origin_request: u64| {
                     let Some(inner) = family.upgrade() else {
@@ -3100,6 +3667,7 @@ where
                     QueryFamily {
                         core: core.clone(),
                         inner,
+                        retention_driver: retention_driver.clone(),
                     }
                     .query_task_registered_for_validation(
                         task,
@@ -3524,7 +4092,12 @@ where
     ) -> Result<Option<(u64, Arc<AttemptHandoffLifecycle>, TerminalPin<K, V>)>, QueryAbort> {
         let mut state = lock(&node.state);
         if task.cancellation.is_canceled() {
-            decrement_waiter(&mut state, attempt_id);
+            let enforce = decrement_waiter(&mut state, attempt_id);
+            drop(state);
+            if enforce {
+                self.enforce_retention();
+                self.core.enforce_runtime_retention();
+            }
             self.core
                 .metrics
                 .cancellations
@@ -3553,7 +4126,6 @@ where
                 drop(state);
                 #[cfg(test)]
                 self.core.interpose(InterposeSite::JoinHandoff);
-                self.enforce_retention();
                 return Ok(Some((attempt_id, handoffs, pin)));
             }
             AttemptState::Computing {
@@ -3575,10 +4147,12 @@ where
                 .fetch_add(1, Ordering::Relaxed);
         }
         drop(state);
+        let mut enforce_after_cancellation = false;
         let result = loop {
             let mut state = lock(&node.state);
             if task.cancellation.is_canceled() {
-                decrement_waiter(&mut state, attempt_id);
+                enforce_after_cancellation = decrement_waiter(&mut state, attempt_id);
+                drop(state);
                 break Err(QueryAbort::Canceled);
             }
             let Some(attempt) = state.attempts.iter_mut().find(|item| item.id == attempt_id) else {
@@ -3622,6 +4196,10 @@ where
         if donated {
             task.acquire_permit(&self.core);
         }
+        if enforce_after_cancellation {
+            self.enforce_retention();
+            self.core.enforce_runtime_retention();
+        }
         if matches!(result, Err(QueryAbort::Canceled)) {
             self.core
                 .metrics
@@ -3632,7 +4210,6 @@ where
         if matches!(result, Ok(Some(_))) {
             self.core.interpose(InterposeSite::JoinHandoff);
         }
-        self.enforce_retention();
         result
     }
 
@@ -3654,17 +4231,24 @@ where
             if !matches!(state.attempts[index].state, AttemptState::Terminal { .. }) {
                 return;
             }
-            state.attempts.remove(index);
-            true
+            let removed = state
+                .attempts
+                .remove(index)
+                .expect("terminal attempt exists");
+            match removed.state {
+                AttemptState::Terminal { terminal, .. } => Some(terminal),
+                AttemptState::Computing { .. } => unreachable!(),
+            }
         };
-        if removed {
+        if let Some(terminal) = removed {
             self.core
                 .metrics
                 .retained_terminals
                 .fetch_sub(1, Ordering::Relaxed);
             self.inner.retained_count.fetch_sub(1, Ordering::Relaxed);
+            lock(&self.inner.retention)
+                .remove_charge(terminal.retained_charge, terminal.dependency_pin_charge);
             node.wait.notify_all();
-            self.enforce_retention();
         }
     }
 
@@ -3681,8 +4265,30 @@ where
         lease: bool,
         handoffs: Arc<AttemptHandoffLifecycle>,
     ) -> Arc<QueryTerminal<V>> {
-        let diagnostics = canonical_diagnostics(output.diagnostics);
-        let work = canonical_work(output.work);
+        let QueryOutput {
+            outcome,
+            kind,
+            diagnostics,
+            work,
+            retained_value_charge,
+        } = output;
+        let diagnostics = canonical_diagnostics(diagnostics);
+        let work = canonical_work(work);
+        let retained_value_charge = match &outcome {
+            QueryOutcome::Success(value) => Some(
+                retained_value_charge.unwrap_or_else(|| (self.inner.retained_value_charge)(value)),
+            ),
+            QueryOutcome::Failure(_) => None,
+        };
+        let (retained_charge, dependency_pin_charge) = retained_terminal_charge(
+            &outcome,
+            retained_value_charge,
+            &node.identity,
+            &diagnostics,
+            &work,
+            &dependencies,
+            &inputs,
+        );
         let mut state = lock(&node.state);
         let previous = state
             .attempts
@@ -3693,8 +4299,8 @@ where
                 AttemptState::Computing { .. } => None,
             });
         let red = previous.as_ref().is_some_and(|terminal| {
-            terminal.kind == output.kind
-                && outcomes_equal(self.inner.value_equal, &terminal.outcome, &output.outcome)
+            terminal.kind == kind
+                && outcomes_equal(self.inner.value_equal, &terminal.outcome, &outcome)
                 && semantic_diagnostics_equal(&terminal.diagnostics, &diagnostics)
         });
         let stamp = if red {
@@ -3711,12 +4317,14 @@ where
             revision,
             stamp,
             origin_request,
-            outcome: output.outcome,
-            kind: output.kind,
+            outcome,
+            kind,
             diagnostics: diagnostics.into(),
             work: work.into(),
             dependencies: dependencies.into(),
             inputs: inputs.into(),
+            retained_charge,
+            dependency_pin_charge,
             pins: AtomicUsize::new(0),
         });
         let attempt = state
@@ -3770,10 +4378,14 @@ where
             .retained_terminals
             .fetch_add(1, Ordering::Relaxed);
         self.inner.retained_count.fetch_add(1, Ordering::Relaxed);
-        lock(&self.inner.retention).push_back(RetentionEntry {
-            node: Arc::downgrade(node),
-            attempt: attempt_id,
-        });
+        let aggregate_probe = lock(&self.inner.retention).publish(
+            RetentionEntry {
+                node: Arc::downgrade(node),
+                attempt: attempt_id,
+            },
+            retained_charge,
+            dependency_pin_charge,
+        );
         // The terminal is now exposed and enqueued — reachable to any concurrent
         // enforcer. With `lease_pin` already held (acquired under the node lock
         // above) it is protected before it becomes evictable, so an enforcer that
@@ -3793,6 +4405,9 @@ where
             // A validation-only publication has no birth lease. It can be
             // evicted immediately, so preserve eager enforcement for it.
             self.enforce_retention();
+        }
+        if aggregate_probe {
+            self.core.enforce_runtime_retention_after_probe();
         }
         terminal
     }
@@ -3824,78 +4439,9 @@ where
             .metrics
             .retention_enforcements
             .fetch_add(1, Ordering::Relaxed);
-        let mut retention = lock(&self.inner.retention);
-        let mut evicted_handoffs = Vec::new();
-        let mut remaining = retention.len();
         while self.inner.retained_count.load(Ordering::Relaxed) > self.inner.retention_limit
-            && remaining > 0
-        {
-            // Loop invariant: the pass ends only when the family is at or below
-            // its bound, or when every remaining candidate was protected and had
-            // to be kept — the latter is recorded as growth pressure below.
-            remaining -= 1;
-            let entry = retention.pop_front().expect("retention scan is nonempty");
-            self.core
-                .metrics
-                .retention_scan_entries
-                .fetch_add(1, Ordering::Relaxed);
-            let Some(node) = entry.node.upgrade() else {
-                continue;
-            };
-            let mut state = lock(&node.state);
-            let Some(index) = state
-                .attempts
-                .iter()
-                .position(|item| item.id == entry.attempt)
-            else {
-                continue;
-            };
-            let protected = match &state.attempts[index].state {
-                AttemptState::Computing { .. } => true,
-                AttemptState::Terminal {
-                    terminal, waiters, ..
-                } => {
-                    *waiters > 0
-                        || terminal.pins.load(Ordering::Acquire) > 0
-                        || lock(&self.inner.retained_revisions).contains_key(&terminal.revision)
-                }
-            };
-            if protected {
-                drop(state);
-                retention.push_back(entry);
-                continue;
-            }
-            let removed = state
-                .attempts
-                .remove(index)
-                .expect("retention selected an existing attempt");
-            if let AttemptState::Terminal { handoffs, .. } = removed.state {
-                evicted_handoffs.push(handoffs);
-            }
-            let empty = state.attempts.is_empty();
-            drop(state);
-            self.core.metrics.evictions.fetch_add(1, Ordering::Relaxed);
-            self.core
-                .metrics
-                .retained_terminals
-                .fetch_sub(1, Ordering::Relaxed);
-            self.inner.retained_count.fetch_sub(1, Ordering::Relaxed);
-            if empty && node.users.load(Ordering::Acquire) == 0 {
-                // Reverse-locate the node by its owned typed key (O(1)); the
-                // `ptr_eq` guard ensures a newer incarnation reinserted under
-                // the same key is never evicted in its place.
-                let mut nodes = lock(&self.inner.nodes);
-                if node.users.load(Ordering::Acquire) == 0
-                    && lock(&node.state).attempts.is_empty()
-                    && nodes
-                        .get(&node.key)
-                        .is_some_and(|candidate| Arc::ptr_eq(candidate, &node))
-                {
-                    nodes.remove(&node.key);
-                    self.inner.retained_nodes.fetch_sub(1, Ordering::Relaxed);
-                }
-            }
-        }
+            && evict_one_from_family(&self.core, &self.inner)
+        {}
         // The pass could not reach the configured bound: every remaining
         // candidate was a protected root the live closure still needs. Grow and
         // record the pressure event rather than evict a required terminal.
@@ -3914,10 +4460,6 @@ where
         self.inner
             .next_publish_sweep
             .store(next_publish_sweep, Ordering::Release);
-        drop(retention);
-        for handoffs in evicted_handoffs {
-            handoffs.abort();
-        }
     }
 
     /// Pins a retained terminal against eviction.
@@ -4079,6 +4621,8 @@ where
                 work: held.work.clone(),
                 dependencies: Arc::from([]),
                 inputs: Arc::from([]),
+                retained_charge: held.retained_charge,
+                dependency_pin_charge: 0,
                 pins: AtomicUsize::new(0),
             });
             let id = state.next_attempt;
@@ -4111,11 +4655,18 @@ where
             .retained_terminals
             .fetch_add(1, Ordering::Relaxed);
         self.inner.retained_count.fetch_add(1, Ordering::Relaxed);
-        lock(&self.inner.retention).push_back(RetentionEntry {
-            node: Arc::downgrade(node),
-            attempt: attempt_id,
-        });
+        let aggregate_probe = lock(&self.inner.retention).publish(
+            RetentionEntry {
+                node: Arc::downgrade(node),
+                attempt: attempt_id,
+            },
+            held.retained_charge,
+            0,
+        );
         self.enforce_retention_after_publish();
+        if aggregate_probe {
+            self.core.enforce_runtime_retention_after_probe();
+        }
         Ok(endorsed_pin)
     }
 
@@ -4272,6 +4823,7 @@ where
             // duplicate/root-overlap release cannot enable retention progress,
             // so scanning the full family here would be pure quadratic work.
             self.family.enforce_retention();
+            self.family.core.enforce_runtime_retention();
         }
     }
 }
@@ -4294,11 +4846,15 @@ where
             .get_mut(&self.revision)
             .expect("revision pin owns a retained root");
         *count -= 1;
-        if *count == 0 {
+        let released = *count == 0;
+        if released {
             revisions.remove(&self.revision);
         }
         drop(revisions);
-        self.family.enforce_retention();
+        if released {
+            self.family.enforce_retention();
+            self.family.core.enforce_runtime_retention();
+        }
         // The revision-view lease drops after terminal retention bookkeeping.
         let _ = &self.view;
     }
@@ -5017,9 +5573,10 @@ impl Drop for TaskLeases {
     /// Instead, release in two phases. First decrement every held pin
     /// (`release_deferred`), which never enforces: a decrement is a pure
     /// narrowing of protection, so ordering among released pins is free and no
-    /// still-leased terminal is left unprotected. Each release yields a
-    /// [`FamilyEnforcer`] keyed by its owning family's stable identity, kept
-    /// deduplicated so heterogeneous families collapse to one enforcer apiece.
+    /// still-leased terminal is left unprotected. A release which removes a
+    /// terminal's last pin yields a [`FamilyEnforcer`] keyed by its owning
+    /// family's stable identity; overlapping pins need no scan. Enforcers are
+    /// deduplicated so heterogeneous families collapse to one apiece.
     /// Second, run each distinct family's enforcement exactly once — after all of
     /// that family's decrements are visible. The result is O(pins) decrements
     /// plus O(distinct families) enforcement passes.
@@ -5031,9 +5588,9 @@ impl Drop for TaskLeases {
 /// Two-phase batched release of a heterogeneous pin set. First decrement every
 /// held pin (`release_deferred`), which never enforces — a decrement is a pure
 /// narrowing of protection, so ordering among released pins is free and no
-/// still-leased terminal is left unprotected. Each release yields a
-/// [`FamilyEnforcer`] keyed by its owning family's stable identity, kept
-/// deduplicated so heterogeneous families collapse to one enforcer apiece.
+/// still-leased terminal is left unprotected. Only releases which remove a
+/// terminal's last pin yield a [`FamilyEnforcer`]; they are keyed by stable
+/// family identity and deduplicated to one enforcer per family.
 /// Second, run each distinct family's enforcement exactly once — after all of
 /// that family's decrements are visible. The result is O(pins) decrements plus
 /// O(distinct families) enforcement passes. Shared by task-scoped
@@ -5043,12 +5600,21 @@ fn batched_release(held: &mut Vec<Box<dyn ObservedLease>>) {
         return;
     }
     let mut enforcers: BTreeMap<usize, FamilyEnforcer> = BTreeMap::new();
+    let mut runtimes: BTreeMap<u64, Arc<RuntimeCore>> = BTreeMap::new();
     for lease in held.drain(..) {
-        let enforcer = lease.release_deferred();
+        let Some(enforcer) = lease.release_deferred() else {
+            continue;
+        };
+        runtimes
+            .entry(enforcer.core.identity)
+            .or_insert_with(|| enforcer.core.clone());
         enforcers.entry(enforcer.family_id).or_insert(enforcer);
     }
     for (_family_id, enforcer) in enforcers {
         enforcer.enforce();
+    }
+    for (_runtime_id, runtime) in runtimes {
+        runtime.enforce_runtime_retention();
     }
 }
 
@@ -5171,12 +5737,13 @@ trait ObservedLease: Send + Sync {
     fn duplicate(&self) -> Box<dyn ObservedLease>;
 
     /// Decrement-only release for batched teardown. Consumes the lease and
-    /// decrements its terminal's pin count immediately, but defers the owning
-    /// family's `enforce_retention` into the returned [`FamilyEnforcer`] rather
-    /// than running it inline. Callers dropping many pins at once decrement all
-    /// of them first, then run one enforcement pass per distinct family — keeping
-    /// release linear instead of quadratic.
-    fn release_deferred(self: Box<Self>) -> FamilyEnforcer;
+    /// decrements its terminal's pin count immediately. When that was the last
+    /// pin, it defers the owning family's `enforce_retention` into the returned
+    /// [`FamilyEnforcer`] rather than running it inline; an overlapping pin
+    /// returns `None`. Callers dropping many pins at once decrement all of them
+    /// first, then run one pass per affected family and one aggregate pass per
+    /// runtime, keeping release linear instead of quadratic.
+    fn release_deferred(self: Box<Self>) -> Option<FamilyEnforcer>;
 }
 
 impl<K, V> ObservedLease for TerminalPin<K, V>
@@ -5208,10 +5775,14 @@ where
         )
     }
 
-    fn release_deferred(self: Box<Self>) -> FamilyEnforcer {
+    fn release_deferred(self: Box<Self>) -> Option<FamilyEnforcer> {
         // Narrow protection now: this pin no longer holds the terminal. This is
         // the same decrement `Drop` would perform, minus the enforcement pass.
-        self.terminal.pins.fetch_sub(1, Ordering::AcqRel);
+        let previous = self.terminal.pins.fetch_sub(1, Ordering::AcqRel);
+        assert!(
+            previous > 0,
+            "a deferred terminal pin releases exactly once"
+        );
         // Suppress the `Drop` decrement/enforce so the boxed pin can free its
         // Arcs normally without double-releasing or scanning.
         self.deferred.store(true, Ordering::Relaxed);
@@ -5220,13 +5791,14 @@ where
         // families even when their types coincide. This is the dedup key that
         // collapses N pins in a family to one enforcement.
         let family_id = Arc::as_ptr(&self.family.inner) as *const () as usize;
-        FamilyEnforcer {
+        (previous == 1).then(|| FamilyEnforcer {
             family_id,
+            core: self.family.core.clone(),
             enforce: Box::new({
                 let family = self.family.clone();
                 move || family.enforce_retention()
             }),
-        }
+        })
     }
 }
 
@@ -5237,6 +5809,7 @@ where
 /// family has been decrement-released.
 struct FamilyEnforcer {
     family_id: usize,
+    core: Arc<RuntimeCore>,
     enforce: Box<dyn FnOnce() + Send>,
 }
 
@@ -6150,6 +6723,222 @@ impl Drop for Task {
 }
 
 impl RuntimeCore {
+    fn live_retention_families(&self) -> Vec<(u64, Arc<dyn RetentionFamily>)> {
+        let mut registered = lock(&self.retention_families);
+        let mut live = Vec::with_capacity(registered.len());
+        registered.retain(|token, family| {
+            if let Some(family) = family.upgrade() {
+                live.push((*token, family));
+                true
+            } else {
+                false
+            }
+        });
+        live
+    }
+
+    fn retention_charge_snapshot_from(
+        families: &[(u64, Arc<dyn RetentionFamily>)],
+    ) -> RuntimeRetentionSnapshot {
+        let mut snapshot = families.iter().fold(
+            RuntimeRetentionSnapshot::default(),
+            |mut total, (_, family)| {
+                let family = family.charge_snapshot();
+                total.retained_bytes = total.retained_bytes.saturating_add(family.retained_bytes);
+                total.dependency_pins =
+                    total.dependency_pins.saturating_add(family.dependency_pins);
+                total
+            },
+        );
+        snapshot.live_families = u64::try_from(families.len()).unwrap_or(u64::MAX);
+        snapshot
+    }
+
+    fn retention_snapshot(&self) -> RuntimeRetentionSnapshot {
+        Self::retention_charge_snapshot_from(&self.live_retention_families())
+    }
+
+    fn record_retention_peaks(&self, snapshot: RuntimeRetentionSnapshot) {
+        self.metrics
+            .peak_retained_bytes
+            .fetch_max(snapshot.retained_bytes, Ordering::Relaxed);
+        self.metrics
+            .peak_retained_dependency_pins
+            .fetch_max(snapshot.dependency_pins, Ordering::Relaxed);
+    }
+
+    fn runtime_retention_over_budget(&self, snapshot: RuntimeRetentionSnapshot) -> (bool, bool) {
+        (
+            snapshot.retained_bytes > self.retention_budgets.retained_bytes,
+            snapshot.dependency_pins > self.retention_budgets.dependency_pins,
+        )
+    }
+
+    /// A family-local deterministic charge quantum crossed. This cold probe
+    /// performs the cross-family sum and touches aggregate peak/pressure state;
+    /// ordinary publications remain confined to their existing family lock.
+    fn enforce_runtime_retention_after_probe(&self) {
+        self.metrics
+            .aggregate_retention_probes
+            .fetch_add(1, Ordering::Relaxed);
+        let snapshot = Self::retention_charge_snapshot_from(&self.live_retention_families());
+        self.record_retention_peaks(snapshot);
+        if snapshot.retained_bytes < self.next_retained_byte_sweep.load(Ordering::Acquire)
+            && snapshot.dependency_pins < self.next_dependency_pin_sweep.load(Ordering::Acquire)
+        {
+            return;
+        }
+        self.enforce_runtime_retention();
+    }
+
+    fn enforce_runtime_retention(&self) {
+        let snapshot = Self::retention_charge_snapshot_from(&self.live_retention_families());
+        self.record_retention_peaks(snapshot);
+        let (bytes_over, pins_over) = self.runtime_retention_over_budget(snapshot);
+        if !bytes_over && !pins_over {
+            return;
+        }
+        self.retention_sweep_pending.store(true, Ordering::Release);
+        if self
+            .retention_sweep_claimed
+            .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
+            .is_err()
+        {
+            return;
+        }
+        loop {
+            self.retention_sweep_pending.store(false, Ordering::Release);
+            self.run_runtime_retention_sweep();
+            #[cfg(test)]
+            self.interpose(InterposeSite::RetentionSweepRelease);
+            if self.retention_sweep_pending.swap(false, Ordering::AcqRel) {
+                continue;
+            }
+            self.retention_sweep_claimed.store(false, Ordering::Release);
+            // Close the handoff race: a publisher which observed the old claim
+            // sets `pending` before returning. If it arrived between our final
+            // pending check and release, reclaim ownership and run its pass.
+            if !self.retention_sweep_pending.swap(false, Ordering::AcqRel) {
+                return;
+            }
+            if self
+                .retention_sweep_claimed
+                .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
+                .is_err()
+            {
+                return;
+            }
+        }
+    }
+
+    fn run_runtime_retention_sweep(&self) {
+        let families = self.live_retention_families();
+        let initial = Self::retention_charge_snapshot_from(&families);
+        self.record_retention_peaks(initial);
+        let (byte_pressure, pin_pressure) = self.runtime_retention_over_budget(initial);
+        if !byte_pressure && !pin_pressure {
+            return;
+        }
+        if byte_pressure {
+            self.metrics
+                .retained_byte_pressure_events
+                .fetch_add(1, Ordering::Relaxed);
+        }
+        if pin_pressure {
+            self.metrics
+                .dependency_pin_pressure_events
+                .fetch_add(1, Ordering::Relaxed);
+        }
+
+        // Family registration is cold. Snapshot and prune its weak entries only
+        // under actual pressure, then perform all eviction without the registry
+        // lock. BTreeMap order is the stable family-token order.
+        let mut start = families.partition_point(|(token, _)| {
+            *token < self.retention_sweep_cursor.load(Ordering::Relaxed)
+        });
+        if start == families.len() {
+            start = 0;
+        }
+        loop {
+            let snapshot = Self::retention_charge_snapshot_from(&families);
+            let (bytes_over, pins_over) = self.runtime_retention_over_budget(snapshot);
+            if !bytes_over && !pins_over {
+                break;
+            }
+            let mut progress = false;
+            for offset in 0..families.len() {
+                let snapshot = Self::retention_charge_snapshot_from(&families);
+                let (bytes_over, pins_over) = self.runtime_retention_over_budget(snapshot);
+                if !bytes_over && !pins_over {
+                    break;
+                }
+                let index = (start + offset) % families.len();
+                let (token, family) = &families[index];
+                if family.evict_one() {
+                    progress = true;
+                    let next = families
+                        .get((index + 1) % families.len())
+                        .map_or(token.saturating_add(1), |(token, _)| *token);
+                    self.retention_sweep_cursor.store(next, Ordering::Relaxed);
+                    if bytes_over {
+                        self.metrics
+                            .retained_byte_evictions
+                            .fetch_add(1, Ordering::Relaxed);
+                    }
+                    if pins_over {
+                        self.metrics
+                            .dependency_pin_evictions
+                            .fetch_add(1, Ordering::Relaxed);
+                    }
+                }
+            }
+            if !progress {
+                break;
+            }
+            start = (start + 1) % families.len();
+        }
+
+        let retained = Self::retention_charge_snapshot_from(&families);
+        let retained_bytes = retained.retained_bytes;
+        let retained_pins = retained.dependency_pins;
+        let byte_overage = retained_bytes.saturating_sub(self.retention_budgets.retained_bytes);
+        let pin_overage = retained_pins.saturating_sub(self.retention_budgets.dependency_pins);
+        if byte_overage > 0 {
+            self.metrics
+                .retained_byte_overflow_events
+                .fetch_add(1, Ordering::Relaxed);
+            self.metrics
+                .peak_retained_byte_overage
+                .fetch_max(byte_overage, Ordering::Relaxed);
+        }
+        if pin_overage > 0 {
+            self.metrics
+                .dependency_pin_overflow_events
+                .fetch_add(1, Ordering::Relaxed);
+            self.metrics
+                .peak_dependency_pin_overage
+                .fetch_max(pin_overage, Ordering::Relaxed);
+        }
+        let next_bytes = if byte_overage > 0 {
+            retained_bytes
+                .saturating_mul(2)
+                .max(retained_bytes.saturating_add(1))
+        } else {
+            self.retention_budgets.retained_bytes.saturating_add(1)
+        };
+        let next_pins = if pin_overage > 0 {
+            retained_pins
+                .saturating_mul(2)
+                .max(retained_pins.saturating_add(1))
+        } else {
+            self.retention_budgets.dependency_pins.saturating_add(1)
+        };
+        self.next_retained_byte_sweep
+            .store(next_bytes, Ordering::Release);
+        self.next_dependency_pin_sweep
+            .store(next_pins, Ordering::Release);
+    }
+
     fn revision_input(&self, revision: Revision, input: &InputIdentity) -> Option<u64> {
         let revisions = lock(&self.revisions);
         if revisions
@@ -6389,14 +7178,76 @@ impl PermitBudget {
     }
 }
 
-fn decrement_waiter<V>(state: &mut NodeState<V>, attempt_id: u64) {
+/// Drop one waiter and report whether an already-terminal attempt just lost its
+/// final waiter. Callers use the result only after releasing the node-state
+/// lock, because retention enforcement may revisit this node.
+fn decrement_waiter<V>(state: &mut NodeState<V>, attempt_id: u64) -> bool {
     if let Some(attempt) = state.attempts.iter_mut().find(|item| item.id == attempt_id) {
         match &mut attempt.state {
-            AttemptState::Computing { waiters, .. } | AttemptState::Terminal { waiters, .. } => {
-                *waiters -= 1
+            AttemptState::Computing { waiters, .. } => {
+                assert!(*waiters > 0, "a computing waiter releases exactly once");
+                *waiters -= 1;
+            }
+            AttemptState::Terminal { waiters, .. } => {
+                assert!(*waiters > 0, "a terminal waiter releases exactly once");
+                *waiters -= 1;
+                return *waiters == 0;
             }
         }
     }
+    false
+}
+
+fn retained_terminal_charge<V>(
+    outcome: &QueryOutcome<V>,
+    retained_value_charge: Option<u64>,
+    node: &NodeIdentity,
+    diagnostics: &[QueryDiagnostic],
+    work: &[(Arc<str>, u64)],
+    dependencies: &[Observation],
+    inputs: &[InputObservation],
+) -> (u64, u64) {
+    let mut bytes = std::mem::size_of::<QueryTerminal<V>>() as u64;
+    bytes = bytes
+        .saturating_add(node.family.len() as u64)
+        .saturating_add(node.key.len() as u64);
+    bytes = bytes.saturating_add(match outcome {
+        QueryOutcome::Success(_) => retained_value_charge.unwrap_or(0),
+        QueryOutcome::Failure(failure) => {
+            (failure.code.len() as u64).saturating_add(failure.payload.len() as u64)
+        }
+    });
+    for diagnostic in diagnostics {
+        bytes = bytes
+            .saturating_add(std::mem::size_of::<QueryDiagnostic>() as u64)
+            .saturating_add(diagnostic.identity.len() as u64)
+            .saturating_add(diagnostic.payload.len() as u64);
+        if let Some(position) = &diagnostic.presentation {
+            bytes = bytes
+                .saturating_add(std::mem::size_of::<PresentationPosition>() as u64)
+                .saturating_add(position.source.len() as u64);
+        }
+    }
+    for (identity, _) in work {
+        bytes = bytes
+            .saturating_add(std::mem::size_of::<(Arc<str>, u64)>() as u64)
+            .saturating_add(identity.len() as u64);
+    }
+    for dependency in dependencies {
+        bytes = bytes
+            .saturating_add(std::mem::size_of::<Observation>() as u64)
+            .saturating_add(dependency.node.family.len() as u64)
+            .saturating_add(dependency.node.key.len() as u64);
+    }
+    for input in inputs {
+        bytes = bytes
+            .saturating_add(std::mem::size_of::<InputObservation>() as u64)
+            .saturating_add(input.input.family.len() as u64)
+            .saturating_add(input.input.key.len() as u64);
+    }
+    let dependency_pins =
+        u64::try_from(dependencies.len().saturating_add(inputs.len())).unwrap_or(u64::MAX);
+    (bytes, dependency_pins)
 }
 
 fn canonical_diagnostics(mut diagnostics: Vec<QueryDiagnostic>) -> Vec<QueryDiagnostic> {
@@ -9450,6 +10301,93 @@ mod tests {
         let joined = joiner.join().unwrap().unwrap();
         assert!(Arc::ptr_eq(&owner, &joined));
         assert_eq!(joined.outcome(), &QueryOutcome::Success(11));
+        assert_eq!(family.retention().terminals, 0);
+        assert_eq!(family.retention().memo_nodes, 0);
+    }
+
+    #[test]
+    fn canceled_last_waiter_reclaims_terminal_with_zero_retention() {
+        let runtime = QueryRuntime::with_retention_budgets(
+            2,
+            RetentionBudgets {
+                retained_bytes: 0,
+                dependency_pins: 0,
+            },
+        );
+        publish_empty(&runtime, [revision(1)]);
+        let family = runtime
+            .family::<Key, u64>("zero-retention-cancel", 0)
+            .unwrap();
+        let (started_tx, started_rx) = mpsc::channel();
+        let (finish_tx, finish_rx) = mpsc::channel();
+        let owner = thread::spawn({
+            let runtime = runtime.clone();
+            let family = family.clone();
+            move || {
+                runtime.query(
+                    &family,
+                    revision(1),
+                    Key("shared"),
+                    CancellationToken::new(),
+                    |_| {
+                        started_tx.send(()).unwrap();
+                        finish_rx.recv().unwrap();
+                        Ok(QueryOutput::success(11))
+                    },
+                )
+            }
+        });
+        started_rx.recv().unwrap();
+
+        let (parked_tx, parked_rx) = mpsc::channel();
+        let release_park = Arc::new(Barrier::new(2));
+        let blocked_once = Arc::new(AtomicBool::new(false));
+        runtime.set_interpose(Arc::new({
+            let release_park = release_park.clone();
+            let blocked_once = blocked_once.clone();
+            move |site| {
+                if site == InterposeSite::NodeJoinPark && !blocked_once.swap(true, Ordering::SeqCst)
+                {
+                    parked_tx.send(()).unwrap();
+                    release_park.wait();
+                }
+            }
+        }));
+        let cancellation = CancellationToken::new();
+        let waiter = thread::spawn({
+            let runtime = runtime.clone();
+            let family = family.clone();
+            let cancellation = cancellation.clone();
+            move || {
+                runtime.query(&family, revision(1), Key("shared"), cancellation, |_| {
+                    panic!("waiter cannot become owner while shared work is live")
+                })
+            }
+        });
+        parked_rx.recv().unwrap();
+
+        // Publish while the only waiter is parked. The terminal remains above
+        // the zero budget solely because that waiter still protects it.
+        finish_tx.send(()).unwrap();
+        while runtime.metrics().green_publications != 1 {
+            thread::yield_now();
+        }
+        assert!(runtime.metrics().retained_bytes > 0);
+
+        let canceler = thread::spawn({
+            let cancellation = cancellation.clone();
+            move || cancellation.cancel()
+        });
+        while !cancellation.is_canceled() {
+            thread::yield_now();
+        }
+        release_park.wait();
+        canceler.join().unwrap();
+        owner.join().unwrap().unwrap();
+        assert_eq!(waiter.join().unwrap().unwrap_err(), QueryAbort::Canceled);
+        runtime.clear_interpose();
+        assert_eq!(runtime.metrics().retained_bytes, 0);
+        assert_eq!(runtime.metrics().retained_dependency_pins, 0);
         assert_eq!(family.retention().terminals, 0);
         assert_eq!(family.retention().memo_nodes, 0);
     }
@@ -12509,6 +13447,54 @@ mod tests {
         drop(sentinel_pin);
     }
 
+    #[test]
+    fn batched_release_runs_one_aggregate_pass_after_all_families() {
+        let runtime = QueryRuntime::with_retention_budgets(
+            1,
+            RetentionBudgets {
+                retained_bytes: 0,
+                dependency_pins: u64::MAX,
+            },
+        );
+        publish_empty(&runtime, [revision(1)]);
+        let first = runtime.family::<Slot, u64>("batch-global-a", 8).unwrap();
+        let second = runtime.family::<Slot, u64>("batch-global-b", 8).unwrap();
+        let first_attempt = runtime.request(
+            &first,
+            revision(1),
+            Slot(0),
+            CancellationToken::new(),
+            |_| Ok(QueryOutput::success(0)),
+        );
+        let first_pin = first
+            .pin_terminal(first_attempt.terminal().unwrap())
+            .unwrap();
+        drop(first_attempt);
+        let second_attempt = runtime.request(
+            &second,
+            revision(1),
+            Slot(0),
+            CancellationToken::new(),
+            |_| Ok(QueryOutput::success(0)),
+        );
+        let second_pin = second
+            .pin_terminal(second_attempt.terminal().unwrap())
+            .unwrap();
+        drop(second_attempt);
+
+        let before = runtime.metrics().retained_byte_pressure_events;
+        let mut held: Vec<Box<dyn ObservedLease>> = vec![Box::new(first_pin), Box::new(second_pin)];
+        batched_release(&mut held);
+
+        let after = runtime.metrics();
+        assert_eq!(
+            after.retained_byte_pressure_events - before,
+            1,
+            "heterogeneous batched teardown runs one runtime-wide pressure pass"
+        );
+        assert_eq!(after.retained_bytes, 0);
+    }
+
     // A session-held `RetainedPinSet` keeps a completed request's observed
     // terminal retained past its task, deduplicates a re-lease of the same
     // terminal, and hands off atomically to a successor set: pressure applied
@@ -13133,5 +14119,504 @@ mod tests {
             )
             .unwrap();
         assert!(Arc::ptr_eq(&reused, &dependent));
+    }
+
+    fn budget_unit_charge(family: &'static str, key: &'static str, value_charge: u64) -> u64 {
+        let output = QueryOutput::success(0_u64).with_retained_value_charge(value_charge);
+        retained_terminal_charge(
+            &output.outcome,
+            output.retained_value_charge,
+            &NodeIdentity {
+                family: family.into(),
+                key: key.into(),
+            },
+            &[],
+            &[],
+            &[],
+            &[],
+        )
+        .0
+    }
+
+    #[test]
+    fn family_estimator_charges_success_without_an_output_override() {
+        let runtime = QueryRuntime::new(1);
+        let family = runtime
+            .family_with_equality_and_retained_charge::<Key, u64>(
+                "charged-family",
+                8,
+                PartialEq::eq,
+                |_| 1234,
+            )
+            .unwrap();
+        publish_empty(&runtime, [revision(1)]);
+        let terminal = runtime
+            .query(
+                &family,
+                revision(1),
+                Key("value"),
+                CancellationToken::new(),
+                |_| Ok(QueryOutput::success(7)),
+            )
+            .unwrap();
+        assert!(terminal.retained_charge() >= 1234);
+        assert_eq!(runtime.metrics().retained_bytes, terminal.retained_charge());
+    }
+
+    #[test]
+    fn family_watermarks_bound_cross_family_probe_count() {
+        let runtime = QueryRuntime::with_retention_budgets(
+            1,
+            RetentionBudgets {
+                retained_bytes: 1024 * 1024 * 1024,
+                dependency_pins: u64::MAX,
+            },
+        );
+        let family = runtime
+            .family_with_equality_and_retained_charge::<Key, u64>(
+                "probe-quantum",
+                512,
+                PartialEq::eq,
+                |_| 64 * 1024,
+            )
+            .unwrap();
+        publish_empty(&runtime, [revision(1)]);
+        for index in 0..256 {
+            let key = Box::leak(format!("probe-{index}").into_boxed_str());
+            runtime
+                .query(
+                    &family,
+                    revision(1),
+                    Key(key),
+                    CancellationToken::new(),
+                    |_| Ok(QueryOutput::success(index)),
+                )
+                .unwrap();
+        }
+        let metrics = runtime.metrics();
+        assert!(metrics.aggregate_retention_probes > 0);
+        assert!(
+            metrics.aggregate_retention_probes <= 3,
+            "a family probes by charge quantum, not per publication: {metrics:?}"
+        );
+    }
+
+    #[test]
+    fn byte_probe_rebases_after_reclaim_and_enforces_on_regrowth() {
+        let budgets = RetentionBudgets {
+            retained_bytes: 1024,
+            dependency_pins: u64::MAX,
+        };
+        let mut retention = FamilyRetentionQueue::<Key, u64>::new(budgets);
+        let quantum = retention.byte_probe_quantum;
+        assert!(quantum > 1);
+
+        assert!(retention.publish(
+            RetentionEntry {
+                node: Weak::new(),
+                attempt: 1,
+            },
+            quantum * 8,
+            0,
+        ));
+        retention.remove_charge(quantum * 7, 0);
+        assert!(retention.next_byte_probe - retention.retained_bytes <= quantum);
+
+        assert!(!retention.publish(
+            RetentionEntry {
+                node: Weak::new(),
+                attempt: 2,
+            },
+            quantum - 1,
+            0,
+        ));
+        assert!(retention.publish(
+            RetentionEntry {
+                node: Weak::new(),
+                attempt: 3,
+            },
+            1,
+            0,
+        ));
+    }
+
+    #[test]
+    fn dependency_pin_probe_rebases_after_reclaim_and_enforces_on_regrowth() {
+        let budgets = RetentionBudgets {
+            retained_bytes: u64::MAX,
+            dependency_pins: 1024,
+        };
+        let mut retention = FamilyRetentionQueue::<Key, u64>::new(budgets);
+        let quantum = retention.pin_probe_quantum;
+        assert!(quantum > 1);
+
+        assert!(retention.publish(
+            RetentionEntry {
+                node: Weak::new(),
+                attempt: 1,
+            },
+            0,
+            quantum * 8,
+        ));
+        retention.remove_charge(0, quantum * 7);
+        assert!(retention.next_pin_probe - retention.dependency_pins <= quantum);
+
+        assert!(!retention.publish(
+            RetentionEntry {
+                node: Weak::new(),
+                attempt: 2,
+            },
+            0,
+            quantum - 1,
+        ));
+        assert!(retention.publish(
+            RetentionEntry {
+                node: Weak::new(),
+                attempt: 3,
+            },
+            0,
+            1,
+        ));
+    }
+
+    #[test]
+    fn byte_pressure_evicts_in_stable_family_round_robin_order() {
+        let unit = budget_unit_charge("budget-a", "0", 100);
+        let runtime = QueryRuntime::with_retention_budgets(
+            1,
+            RetentionBudgets {
+                retained_bytes: unit * 2,
+                dependency_pins: u64::MAX,
+            },
+        );
+        let first = runtime
+            .family_with_equality_and_retained_charge::<Key, u64>(
+                "budget-a",
+                8,
+                PartialEq::eq,
+                |_| 100,
+            )
+            .unwrap();
+        let second = runtime
+            .family_with_equality_and_retained_charge::<Key, u64>(
+                "budget-b",
+                8,
+                PartialEq::eq,
+                |_| 100,
+            )
+            .unwrap();
+        publish_empty(&runtime, [revision(1)]);
+        let caller_held = runtime
+            .query(
+                &first,
+                revision(1),
+                Key("0"),
+                CancellationToken::new(),
+                |_| Ok(QueryOutput::success(0)),
+            )
+            .unwrap();
+        for (key, value) in [("0", 1), ("1", 2)] {
+            runtime
+                .query(
+                    &second,
+                    revision(1),
+                    Key(key),
+                    CancellationToken::new(),
+                    |_| Ok(QueryOutput::success(value)),
+                )
+                .unwrap();
+        }
+        assert_eq!(caller_held.outcome(), &QueryOutcome::Success(0));
+        assert_eq!(first.retention().terminals, 0);
+        assert_eq!(second.retention().terminals, 2);
+        runtime
+            .query(
+                &first,
+                revision(1),
+                Key("1"),
+                CancellationToken::new(),
+                |_| Ok(QueryOutput::success(3)),
+            )
+            .unwrap();
+        // A later pressure event resumes after the family evicted above rather
+        // than always restarting at the lowest family token.
+        assert_eq!(first.retention().terminals, 1);
+        assert_eq!(second.retention().terminals, 1);
+        let metrics = runtime.metrics();
+        assert_eq!(metrics.retained_bytes, unit * 2);
+        assert_eq!(metrics.retained_byte_evictions, 2);
+    }
+
+    #[test]
+    fn protected_byte_overflow_reclaims_when_request_bridge_releases() {
+        let unit = budget_unit_charge("protected", "0", 100);
+        let runtime = QueryRuntime::with_retention_budgets(
+            1,
+            RetentionBudgets {
+                retained_bytes: unit,
+                dependency_pins: u64::MAX,
+            },
+        );
+        let family = runtime
+            .family_with_equality_and_retained_charge::<Key, u64>(
+                "protected",
+                8,
+                PartialEq::eq,
+                |_| 100,
+            )
+            .unwrap();
+        publish_empty(&runtime, [revision(1)]);
+        let first = runtime.request(
+            &family,
+            revision(1),
+            Key("0"),
+            CancellationToken::new(),
+            |_| Ok(QueryOutput::success(0)),
+        );
+        let second = runtime.request(
+            &family,
+            revision(1),
+            Key("1"),
+            CancellationToken::new(),
+            |_| Ok(QueryOutput::success(1)),
+        );
+        assert!(runtime.metrics().retained_byte_overflow_events > 0);
+        assert_eq!(runtime.metrics().retained_bytes, unit * 2);
+        drop(second);
+        assert_eq!(runtime.metrics().retained_bytes, unit);
+        assert_eq!(family.retention().terminals, 1);
+        drop(first);
+    }
+
+    #[test]
+    fn protected_overflow_does_not_repeat_aggregate_scans_below_watermark() {
+        let unit = budget_unit_charge("watermark", "0", 100);
+        let runtime = QueryRuntime::with_retention_budgets(
+            1,
+            RetentionBudgets {
+                retained_bytes: unit,
+                dependency_pins: u64::MAX,
+            },
+        );
+        let family = runtime
+            .family_with_equality_and_retained_charge::<Key, u64>(
+                "watermark",
+                0,
+                PartialEq::eq,
+                |_| 100,
+            )
+            .unwrap();
+        publish_empty(&runtime, [revision(1)]);
+        let first = runtime.request(
+            &family,
+            revision(1),
+            Key("0"),
+            CancellationToken::new(),
+            |_| Ok(QueryOutput::success(0)),
+        );
+        let second = runtime.request(
+            &family,
+            revision(1),
+            Key("1"),
+            CancellationToken::new(),
+            |_| Ok(QueryOutput::success(1)),
+        );
+        let before = runtime.metrics();
+        let third = runtime.request(
+            &family,
+            revision(1),
+            Key("2"),
+            CancellationToken::new(),
+            |_| Ok(QueryOutput::success(2)),
+        );
+        let after = runtime.metrics();
+
+        assert_eq!(
+            after.retained_byte_pressure_events, before.retained_byte_pressure_events,
+            "family-limit enforcement must not bypass the aggregate watermark"
+        );
+        assert_eq!(
+            after.retention_scan_entries - before.retention_scan_entries,
+            0,
+            "both family and aggregate geometric watermarks suppress a protected rescan"
+        );
+        drop((third, second, first));
+    }
+
+    #[test]
+    fn aggregate_pressure_respects_selection_and_revision_roots() {
+        let make_runtime = || {
+            QueryRuntime::with_retention_budgets(
+                1,
+                RetentionBudgets {
+                    retained_bytes: 0,
+                    dependency_pins: u64::MAX,
+                },
+            )
+        };
+
+        let runtime = make_runtime();
+        let family = runtime.family::<Key, u64>("selection-root", 8).unwrap();
+        publish_empty(&runtime, [revision(1)]);
+        let attempt = runtime.request(
+            &family,
+            revision(1),
+            Key("value"),
+            CancellationToken::new(),
+            |_| Ok(QueryOutput::success(1)),
+        );
+        let mut selection = family.selection();
+        selection.publish(attempt.terminal().unwrap()).unwrap();
+        attempt.release_result_lease();
+        drop(attempt);
+        assert!(runtime.metrics().retained_bytes > 0);
+        drop(selection);
+        assert_eq!(runtime.metrics().retained_bytes, 0);
+
+        let runtime = make_runtime();
+        let family = runtime.family::<Key, u64>("revision-root", 8).unwrap();
+        publish_empty(&runtime, [revision(1)]);
+        let attempt = runtime.request(
+            &family,
+            revision(1),
+            Key("value"),
+            CancellationToken::new(),
+            |_| Ok(QueryOutput::success(1)),
+        );
+        let revision_root = family.retain_revision(revision(1));
+        attempt.release_result_lease();
+        drop(attempt);
+        assert!(runtime.metrics().retained_bytes > 0);
+        drop(revision_root);
+        assert_eq!(runtime.metrics().retained_bytes, 0);
+    }
+
+    #[test]
+    fn dependency_observation_budget_reclaims_pull_validation_edges() {
+        let runtime = QueryRuntime::with_retention_budgets(
+            1,
+            RetentionBudgets {
+                retained_bytes: u64::MAX,
+                dependency_pins: 0,
+            },
+        );
+        let leaf = runtime.family::<Key, u64>("pin-leaf", 8).unwrap();
+        let root = runtime.family::<Key, u64>("pin-root", 8).unwrap();
+        publish_empty(&runtime, [revision(1)]);
+        runtime
+            .query(
+                &leaf,
+                revision(1),
+                Key("leaf"),
+                CancellationToken::new(),
+                |_| Ok(QueryOutput::success(1)),
+            )
+            .unwrap();
+        let rooted = runtime
+            .query(
+                &root,
+                revision(1),
+                Key("root"),
+                CancellationToken::new(),
+                |context| {
+                    context.query(&leaf, Key("leaf"), |_| {
+                        panic!("the retained leaf is reused")
+                    })?;
+                    Ok(QueryOutput::success(2))
+                },
+            )
+            .unwrap();
+        assert_eq!(rooted.dependencies().len(), 1);
+        let metrics = runtime.metrics();
+        assert_eq!(metrics.retained_dependency_pins, 0);
+        assert!(metrics.dependency_pin_overflow_events > 0);
+        assert!(metrics.dependency_pin_evictions > 0);
+    }
+
+    #[test]
+    fn concurrent_publisher_hands_pending_pressure_to_sweep_owner() {
+        let runtime = QueryRuntime::with_retention_budgets(
+            2,
+            RetentionBudgets {
+                retained_bytes: 0,
+                dependency_pins: u64::MAX,
+            },
+        );
+        let family = runtime.family::<Key, u64>("sweep-handoff", 8).unwrap();
+        publish_empty(&runtime, [revision(1)]);
+        let entered = Arc::new(Barrier::new(2));
+        let release = Arc::new(Barrier::new(2));
+        let blocked_once = Arc::new(AtomicBool::new(false));
+        runtime.set_interpose(Arc::new({
+            let entered = entered.clone();
+            let release = release.clone();
+            move |site| {
+                if site == InterposeSite::RetentionSweepRelease
+                    && !blocked_once.swap(true, Ordering::SeqCst)
+                {
+                    entered.wait();
+                    release.wait();
+                }
+            }
+        }));
+        let first = thread::spawn({
+            let runtime = runtime.clone();
+            let family = family.clone();
+            move || {
+                runtime
+                    .query(
+                        &family,
+                        revision(1),
+                        Key("a"),
+                        CancellationToken::new(),
+                        |_| Ok(QueryOutput::success(1)),
+                    )
+                    .unwrap()
+            }
+        });
+        entered.wait();
+        let second = thread::spawn({
+            let runtime = runtime.clone();
+            let family = family.clone();
+            move || {
+                runtime
+                    .query(
+                        &family,
+                        revision(1),
+                        Key("b"),
+                        CancellationToken::new(),
+                        |_| Ok(QueryOutput::success(2)),
+                    )
+                    .unwrap()
+            }
+        });
+        let held_second = second.join().unwrap();
+        release.wait();
+        let held_first = first.join().unwrap();
+        assert_eq!(held_first.outcome(), &QueryOutcome::Success(1));
+        assert_eq!(held_second.outcome(), &QueryOutcome::Success(2));
+        assert_eq!(runtime.metrics().retained_bytes, 0);
+        assert_eq!(family.retention().terminals, 0);
+    }
+
+    #[test]
+    fn dropping_last_family_releases_charge_while_terminal_arc_lives() {
+        let runtime = QueryRuntime::new(1);
+        publish_empty(&runtime, [revision(1)]);
+        let terminal = {
+            let family = runtime.family::<Key, u64>("family-drop", 8).unwrap();
+            runtime
+                .query(
+                    &family,
+                    revision(1),
+                    Key("value"),
+                    CancellationToken::new(),
+                    |_| Ok(QueryOutput::success(7)),
+                )
+                .unwrap()
+        };
+        assert_eq!(runtime.metrics().retained_bytes, 0);
+        assert_eq!(runtime.metrics().retained_terminals, 0);
+        assert_eq!(terminal.outcome(), &QueryOutcome::Success(7));
     }
 }

--- a/docs/designs/0063-parallel-demand-driven-incremental-compilation.md
+++ b/docs/designs/0063-parallel-demand-driven-incremental-compilation.md
@@ -667,10 +667,63 @@ entities. Wall time alone is not evidence of incremental correctness.
 
 ### 14. Retention, persistence, and long-lived service use
 
-The memo database is memory-budgeted. Retention policy accounts for artifact
-bytes, dependency/reverse-dependency pins, active waiters, current roots,
-last-good roots, and persistent-cache eligibility. It is not a fixed count of
-terminals shared by an entire query family.
+The memo database has runtime-wide soft budgets of 8 GiB of deterministic
+retained terminal/artifact charge and 4,000,000 retained dependency/input
+observations. These production values are policy defaults, not an RSS promise or
+language guarantee. A caller may select smaller budgets for deterministic policy
+tests.
+
+The release-build calibration on macOS ARM64, after charging full parsed AST,
+definition-index, invalid-import, and admitted-module paths, was:
+
+| Workload | Retained charge | Dependency/input observations | Aggregate probes | Compiler root | Peak RSS |
+| --- | ---: | ---: | ---: | ---: | ---: |
+| Meridian | 1,352,198,599 bytes | 503,083 | 31 | 7.09 s | 2,060,189,696 bytes |
+| Caldera | 4,796,396,175 bytes | 1,234,799 | 102 | 20.84 s | 4,286,857,216 bytes |
+
+The 8 GiB byte default leaves about 79% headroom above Caldera's protected live
+closure. The 4,000,000-observation default likewise exceeds Caldera by more than
+three times. Both workloads retained their prior output hashes during this
+accounting-only recalibration. Recalibration must use an optimized compiler
+binary; debug compiler timings are not comparable.
+
+Artifact charge is allocator-independent. The runtime counts each terminal
+envelope, diagnostic, structural-work record, dependency, and input
+automatically. Compiler families additionally register structural estimators for
+heap-owned success values: logical container lengths and recursively owned
+string/slice data are charged, never allocator capacity or pointer identity. A
+shared allocation is conservatively charged in full for every terminal which can
+reach it; there is deliberately no global allocation-identity registry. A nested
+query terminal reuses the complete immutable charge summary computed when that
+terminal was published, so transitive accounting does not recursively revisit
+its value and observation graph.
+
+The current runtime validates dependencies by pulling exact retained
+observations. It stores no reverse-dependency index. The dependency-pin budget
+therefore charges each retained dependency and input observation edge once; it
+does not imply an unimplemented reverse-edge graph. Rooted-request leases,
+session-retained pin sets, and retained revisions remain separate protection
+gauges. Exact all-terminal-pin or waiter audits require an explicit expensive
+debug traversal; ordinary compiler metrics do not add shared hot-path counters
+to reconstruct them.
+
+Ordinary publication appends to its family-local FIFO and updates byte/pin totals
+under that existing family lock. It mutates no runtime-wide charge or protection
+counter. Each family probes aggregate pressure only after crossing a deterministic
+local quantum: for normal budgets, `budget / 128`, clamped to 1–32 MiB for bytes
+and 4,096–65,536 observations; tiny test budgets use `max(1, budget / 64)`. The
+reported worst-case detection overshoot is `live families × quantum`. Once a
+probe observes pressure, one claimant snapshots the weak family registry in
+stable family-token order and evicts in deterministic round-robin order; each
+family still chooses its oldest unprotected terminal. Existing per-family
+terminal limits remain a secondary fairness/safety guard, not the memory policy.
+
+The budgets are soft because accounting estimates must never change compilation
+correctness. Waiters, terminal/task/session pins, current and last-good
+selections, retained revisions, and atomic handoff windows remain protected even
+when they exceed a budget. The runtime records pressure, protected overflow and
+peak overage, then reclaims the excess when protection releases. There is no
+hard cap and no budget-induced compilation failure in this first policy.
 
 The first implementation may retain only in-process typed values. Logical keys,
 canonical artifact envelopes, schema epochs, content fingerprints, and
@@ -771,12 +824,10 @@ Tracked in Linear under the RUE-648 epic. The dependency order is:
   warm edit-to-codegen and edit-to-runnable baselines. — RUE-1033 (blocked by
   RUE-1032)
 
-  The selected-state compatibility layer and peer cache state are deleted, but
-  this phase remains open until the maintainers choose the initial retained-byte
-  and dependency-lease budgets for the representative-project gate. Existing
-  per-family terminal counts safely evict unprotected terminals and report
-  protected-root pressure, but they are not a cross-family byte policy and must
-  not be presented as one. RUE-1210 tracks that decision and enforcement work.
+  The selected-state compatibility layer and peer cache state are deleted.
+  Runtime-wide retained-artifact and dependency-observation budgets supersede
+  the earlier per-family-count-only policy; the family limits remain secondary
+  guards. RUE-1210 records the initial policy and calibration evidence.
 
 Each family migrates through the compatibility shim one at a time and must pass
 the cold-versus-reused differential oracle before the next family moves. Each
@@ -922,8 +973,6 @@ the architectural scope expands.
 - Which execution substrate best satisfies Rue's attempt/diagnostic/import and
   current/last-good requirements after the Phase 0 comparison: an evolution of
   the in-house database, Salsa, or another typed query runtime?
-- Which initial memory budget and eviction policy should gate the representative
-  project benchmark?
 - Which fixed warm-edit benchmark corpus and host normalization should define
   the first latency budgets without turning one machine's number into a language
   promise?


### PR DESCRIPTION
## Summary

- enforce runtime-wide deterministic soft budgets for retained artifact charge and dependency/input observations
- evict in stable family round-robin order with family-local FIFO selection while preserving waiters, pins, current/last-good roots, and retained revisions
- add allocator-independent structural accounting for every compiler query value family without hot global per-pin/per-waiter instrumentation
- expose pressure, overflow, eviction, probe, and overshoot metrics
- calibrate the initial 8 GiB / 4,000,000-observation defaults against release Meridian and Caldera builds and record the policy in ADR-0063

## Representative calibration

| Workload | Retained charge | Observations | Probes | Compiler root | Peak RSS |
| --- | ---: | ---: | ---: | ---: | ---: |
| Meridian | 1,352,198,599 B | 503,083 | 31 | 7.0878 s | 2,060,189,696 B |
| Caldera | 4,796,396,175 B | 1,234,799 | 102 | 20.8369 s | 4,286,857,216 B |

Both output hashes remained unchanged. Neither workload recorded pressure, overflow, or retention eviction.

## Validation

- `scripts/rue quick` — 30/30 targets
- `/opt/homebrew/bin/bash clippy.sh` — 63/63 targets
- premerge tier — 78/78 targets
- query runtime — 119/119
- retained-charge structural tests — 5/5
- warm compiler retention — 1/1

Fixes RUE-1210.
