### PR TITLE
RUE-1033: complete incremental phase 12 acceptance

### DIFF
--- a/crates/rue-compiler/src/pipeline_tests.rs
+++ b/crates/rue-compiler/src/pipeline_tests.rs
@@ -248,6 +248,113 @@ mod tests {
         assert!(execution.stderr.is_empty());
     }
 
+    /// Opt-in Phase 12 latency witness. This deliberately has no pass/fail
+    /// timing threshold: it emits release-build samples and medians together
+    /// with the exact structural work that makes the samples comparable.
+    #[cfg(unix)]
+    #[test]
+    #[ignore]
+    fn rue_1033_warm_single_function_latency_witness() {
+        const SAMPLES: usize = 11;
+        let options = CompileOptions::default();
+        let snapshot = |value| {
+            SourceSnapshot::single(
+                "<rue-1033-latency>",
+                format!("fn callee() -> i32 {{ {value} }} fn main() -> i32 {{ callee() }}"),
+            )
+            .unwrap()
+        };
+        let baseline = snapshot(1);
+
+        let mut codegen_micros = Vec::with_capacity(SAMPLES);
+        let mut runnable_micros = Vec::with_capacity(SAMPLES);
+        for sample in 0..SAMPLES {
+            // Give every sample the same two-revision history. Reusing one
+            // session across the sample loop would make later samples observe
+            // older retained revisions and cease to measure an identical edit.
+            let mut session = CompilerSession::with_query_concurrency(4);
+            session
+                .update_for_presentation(&baseline)
+                .into_result()
+                .unwrap();
+            crate::queries::compile_with_session(&mut session, &baseline, &options).unwrap();
+            let edited = snapshot(sample as i32 + 2);
+            let edit_start = std::time::Instant::now();
+            session
+                .update_for_presentation(&edited)
+                .into_result()
+                .unwrap();
+            let rooted = session
+                .rooted_codegen(&options, rue_codegen::BackendArtifactRequest::default())
+                .unwrap();
+            let edit_to_codegen = edit_start.elapsed().as_micros();
+
+            let parse = session.work().last_parse.clone();
+            assert_eq!(parse.syntax.lexer_invocations, 1);
+            assert_eq!(parse.syntax.parser_invocations, 1);
+            assert_eq!(parse.modules_reparsed, 1);
+            assert_eq!(rooted.work.body_analysis.body_analyses_computed, 1);
+            assert_eq!(rooted.work.body_analysis.body_analyses_reused, 1);
+            assert_eq!(rooted.work.body_analysis.body_analyses_invalidated, 1);
+            assert_eq!(rooted.work.cfg.cfg_builds_attempted, 1);
+            assert_eq!(rooted.work.cfg.cfg_builds_succeeded, 1);
+            assert_eq!(
+                session
+                    .codegen_executions()
+                    .iter()
+                    .filter(|(_, execution)| {
+                        *execution == rue_query::RequestExecution::Computed
+                    })
+                    .count(),
+                1
+            );
+            assert_eq!(
+                session
+                    .codegen_executions()
+                    .iter()
+                    .filter(|(_, execution)| { *execution == rue_query::RequestExecution::Reused })
+                    .count(),
+                1
+            );
+
+            let image = crate::program_image_plan::ProgramImage::from_rooted(
+                rooted.units,
+                rooted.exports,
+                &options,
+            )
+            .unwrap();
+            let output = image.fresh_link(&options, &rooted.warnings).unwrap();
+            let edit_to_runnable = edit_start.elapsed().as_micros();
+            let execution = execute_compiled_output(&output, &format!("rue-1033-latency-{sample}"));
+            assert_eq!(execution.status.code(), Some(sample as i32 + 2));
+            assert!(execution.stdout.is_empty());
+            assert!(execution.stderr.is_empty());
+            codegen_micros.push(edit_to_codegen);
+            runnable_micros.push(edit_to_runnable);
+        }
+
+        let median = |samples: &mut Vec<u128>| {
+            samples.sort_unstable();
+            samples[samples.len() / 2]
+        };
+        let codegen_median = median(&mut codegen_micros);
+        let runnable_median = median(&mut runnable_micros);
+        eprintln!(
+            "RUE-1033 warm single-function latency: target={} workers=4 samples={} \
+             edit_to_codegen_unit_us={:?} median_edit_to_codegen_unit_us={} \
+             edit_to_runnable_fresh_link_us={:?} median_edit_to_runnable_fresh_link_us={} \
+             exact_work=lexer:1,parser:1,modules_reparsed:1,bodies_computed:1,bodies_reused:1,\
+             bodies_invalidated:1,cfgs_computed:1,codegen_units_computed:1,codegen_units_reused:1,\
+             fresh_links:1",
+            options.target,
+            SAMPLES,
+            codegen_micros,
+            codegen_median,
+            runnable_micros,
+            runnable_median,
+        );
+    }
+
     #[test]
     fn warm_unreachable_body_edit_reuses_every_rooted_downstream_terminal() {
         let before = SourceSnapshot::single(
@@ -598,6 +705,79 @@ mod tests {
             assert!(execution.stdout.is_empty());
             assert!(execution.stderr.is_empty());
         }
+    }
+
+    #[cfg(unix)]
+    fn assert_scheduled_codegen_matches_fresh_link(cancel_joiner: bool) {
+        let snapshot =
+            SourceSnapshot::single("<scheduled-codegen-executable>", "fn main() -> i32 { 42 }")
+                .unwrap();
+        let options = CompileOptions::default();
+        let mut scheduled = CompilerSession::with_query_concurrency(2);
+        scheduled
+            .update_for_presentation(&snapshot)
+            .into_result()
+            .unwrap();
+        let (owner, joiner) = scheduled.exercise_codegen_schedule_for_test(&options, cancel_joiner);
+        assert_eq!(owner, rue_query::RequestExecution::Computed);
+        assert_eq!(
+            joiner,
+            if cancel_joiner {
+                rue_query::RequestExecution::Aborted
+            } else {
+                rue_query::RequestExecution::Joined
+            }
+        );
+
+        // The ordinary compiler adapter must consume the terminal produced by
+        // that schedule, collect the image plan, and fresh-link it. No test
+        // helper constructs a CodegenUnit or executable directly.
+        let scheduled_output =
+            crate::queries::compile_with_session(&mut scheduled, &snapshot, &options).unwrap();
+        assert!(
+            scheduled
+                .codegen_executions()
+                .iter()
+                .all(|(_, execution)| *execution == rue_query::RequestExecution::Reused)
+        );
+
+        let mut fresh = CompilerSession::new();
+        fresh
+            .update_for_presentation(&snapshot)
+            .into_result()
+            .unwrap();
+        let fresh_output =
+            crate::queries::compile_with_session(&mut fresh, &snapshot, &options).unwrap();
+        assert_eq!(scheduled_output.elf, fresh_output.elf);
+        assert_eq!(scheduled_output.warnings, fresh_output.warnings);
+        let execution = execute_compiled_output(
+            &scheduled_output,
+            if cancel_joiner {
+                "canceled-codegen-schedule"
+            } else {
+                "joined-codegen-schedule"
+            },
+        );
+        assert_eq!(execution.status.code(), Some(42), "{execution:?}");
+        assert!(execution.stdout.is_empty());
+        assert!(execution.stderr.is_empty());
+    }
+
+    /// A joined CodegenUnit request must be observationally equivalent to a
+    /// fresh execution through final executable bytes.
+    #[cfg(unix)]
+    #[test]
+    fn joined_codegen_schedule_matches_fresh_linked_executable() {
+        assert_scheduled_codegen_matches_fresh_link(false);
+    }
+
+    /// Canceling one joined waiter must neither cancel nor corrupt the live
+    /// CodegenUnit owner; the owner's terminal must remain usable through the
+    /// ordinary fresh-link adapter and match a fresh compiler session.
+    #[cfg(unix)]
+    #[test]
+    fn canceled_codegen_waiter_schedule_matches_fresh_linked_executable() {
+        assert_scheduled_codegen_matches_fresh_link(true);
     }
 
     #[cfg(unix)]

--- a/crates/rue-compiler/src/revisioned_query_database.rs
+++ b/crates/rue-compiler/src/revisioned_query_database.rs
@@ -400,6 +400,12 @@ pub(crate) struct RevisionedQueryDatabase {
         crate::codegen_query::CodegenUnitQueryKey,
         crate::codegen_query::CodegenUnitValue,
     >,
+    /// One-shot rendezvous inside the registered CodegenUnit evaluator. Unit
+    /// tests use it to force an exact-key owner to remain live while a second
+    /// request joins or cancels. It changes scheduling only: both requests still
+    /// execute the production family and evaluator.
+    #[cfg(test)]
+    codegen_evaluator_gate: Arc<Mutex<Option<Arc<TestCodegenEvaluatorGate>>>>,
     lookup_names: QueryFamily<LookupNameKey, LookupNameValue>,
     /// Per-`(module, import-path)` binding-resolution family. Registered query
     /// machinery for the exact provider boundary. Production body import
@@ -514,6 +520,37 @@ pub(crate) struct RevisionedQueryDatabase {
         CompatibilityKey<super::session::ParseQueryKey>,
         super::session::ParseQueryRecord,
     >,
+}
+
+/// Two-phase rendezvous for deterministic compiler schedule tests. The first
+/// wait tells the test that the owner entered the canonical evaluator; the
+/// second releases that owner after the runtime has observed the intended
+/// join/cancellation lifecycle.
+#[cfg(test)]
+pub(crate) struct TestCodegenEvaluatorGate {
+    rendezvous: std::sync::Barrier,
+}
+
+#[cfg(test)]
+impl TestCodegenEvaluatorGate {
+    fn new() -> Self {
+        Self {
+            rendezvous: std::sync::Barrier::new(2),
+        }
+    }
+
+    fn evaluator_wait(&self) {
+        self.rendezvous.wait();
+        self.rendezvous.wait();
+    }
+
+    pub(crate) fn wait_until_entered(&self) {
+        self.rendezvous.wait();
+    }
+
+    pub(crate) fn release(&self) {
+        self.rendezvous.wait();
+    }
 }
 
 impl std::fmt::Debug for RevisionedQueryDatabase {
@@ -13895,12 +13932,24 @@ impl RevisionedQueryDatabase {
             )
             .expect("the OptimizedCfg family has one canonical name");
         let optimized_cfgs_for_codegen = optimized_cfgs.clone();
+        #[cfg(test)]
+        let codegen_evaluator_gate = Arc::new(Mutex::new(None::<Arc<TestCodegenEvaluatorGate>>));
+        #[cfg(test)]
+        let codegen_gate_for_evaluator = codegen_evaluator_gate.clone();
         let codegen_units = runtime
             .family_with_equality_and_evaluator(
                 "compiler.codegen-unit",
                 BODY_QUERY_MEMO_RETENTION,
                 crate::codegen_query::codegen_unit_value_equal,
                 move |context, _, key: &crate::codegen_query::CodegenUnitQueryKey| {
+                    #[cfg(test)]
+                    if let Some(gate) = codegen_gate_for_evaluator
+                        .lock()
+                        .unwrap_or_else(std::sync::PoisonError::into_inner)
+                        .take()
+                    {
+                        gate.evaluator_wait();
+                    }
                     crate::codegen_query::evaluate_codegen_unit(
                         context,
                         &optimized_cfgs_for_codegen,
@@ -15094,6 +15143,8 @@ impl RevisionedQueryDatabase {
             cfgs,
             optimized_cfgs,
             codegen_units,
+            #[cfg(test)]
+            codegen_evaluator_gate,
             lookup_names,
             lookup_imports,
             #[cfg(test)]
@@ -15138,6 +15189,23 @@ impl RevisionedQueryDatabase {
 }
 
 impl RevisionedQueryDatabase {
+    #[cfg(test)]
+    pub(crate) fn arm_codegen_evaluator_gate_for_test(&self) -> Arc<TestCodegenEvaluatorGate> {
+        let gate = Arc::new(TestCodegenEvaluatorGate::new());
+        let replaced = self
+            .codegen_evaluator_gate
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .replace(gate.clone());
+        assert!(replaced.is_none(), "only one CodegenUnit gate may be armed");
+        gate
+    }
+
+    #[cfg(test)]
+    pub(crate) fn runtime_metrics_for_test(&self) -> rue_query::RuntimeMetrics {
+        self.runtime.metrics()
+    }
+
     #[cfg(test)]
     pub(crate) fn inject_body_transaction_failure_for_test(
         &self,

--- a/crates/rue-compiler/src/scaling_harness.rs
+++ b/crates/rue-compiler/src/scaling_harness.rs
@@ -1100,7 +1100,6 @@ fn import_source(
     )
 }
 
-#[allow(dead_code)]
 fn rooted_demand_locality_source(
     leaf_value: i32,
     unrelated_value: i32,
@@ -1979,6 +1978,89 @@ fn correctness_oracle_import_edit_compares_imported_body_and_linked_bytes() {
         changed_body_origins(&before, &after).contains("main"),
         "changing an imported value must refresh its root consumer"
     );
+}
+
+/// Phase 12's rooted-host locality gate. Both revisions enter through the
+/// production import-input protocol, and both edits are driven all the way
+/// through rooted CFG/CodegenUnit collection and the fresh linker. This is not
+/// a driver-shaped compatibility harness: `CompilerSession` remains the sole
+/// owner of the canonical query graph.
+#[cfg(unix)]
+#[test]
+fn query_native_rooted_demand_warm_edit_locality_through_fresh_link() {
+    #[derive(Debug)]
+    struct Locality {
+        bodies_computed: usize,
+        bodies_reused: usize,
+        cfgs_computed: usize,
+        codegen_computed: usize,
+        codegen_reused: usize,
+    }
+
+    let options = CompileOptions::default();
+    let run_edit = |leaf_value, unrelated_value| {
+        let (baseline, baseline_context, baseline_reads) = rooted_demand_locality_source(1, 10, 1);
+        let (edited, edited_context, edited_reads) =
+            rooted_demand_locality_source(leaf_value, unrelated_value, 2);
+        let mut warm = CompilerSession::with_query_concurrency(4);
+        close_import_source(&mut warm, &baseline, baseline_context, baseline_reads);
+        crate::queries::compile_with_session(&mut warm, &baseline, &options)
+            .expect("rooted-demand baseline fresh-links");
+
+        close_import_source(&mut warm, &edited, edited_context, edited_reads);
+        let warm_output = crate::queries::compile_with_session(&mut warm, &edited, &options)
+            .expect("rooted-demand warm edit fresh-links");
+        let codegen_computed = warm
+            .codegen_executions()
+            .iter()
+            .filter(|(_, execution)| *execution == rue_query::RequestExecution::Computed)
+            .count();
+        let codegen_reused = warm
+            .codegen_executions()
+            .iter()
+            .filter(|(_, execution)| {
+                matches!(
+                    execution,
+                    rue_query::RequestExecution::Reused | rue_query::RequestExecution::Joined
+                )
+            })
+            .count();
+
+        let mut fresh = CompilerSession::new();
+        let (_, fresh_context, fresh_reads) =
+            rooted_demand_locality_source(leaf_value, unrelated_value, 2);
+        close_import_source(&mut fresh, &edited, fresh_context, fresh_reads);
+        let fresh_output = crate::queries::compile_with_session(&mut fresh, &edited, &options)
+            .expect("fresh rooted-demand edit fresh-links");
+        assert_eq!(warm_output.elf, fresh_output.elf);
+        assert_eq!(warm_output.warnings, fresh_output.warnings);
+
+        Locality {
+            bodies_computed: warm_output
+                .work
+                .semantic
+                .body_analysis
+                .body_analyses_computed,
+            bodies_reused: warm_output.work.semantic.body_analysis.body_analyses_reused,
+            cfgs_computed: warm_output.work.semantic.cfg.cfg_builds_attempted,
+            codegen_computed,
+            codegen_reused,
+        }
+    };
+
+    let reachable = run_edit(2, 10);
+    assert_eq!(reachable.bodies_computed, 1, "{reachable:?}");
+    assert_eq!(reachable.bodies_reused, 1, "{reachable:?}");
+    assert_eq!(reachable.cfgs_computed, 1, "{reachable:?}");
+    assert_eq!(reachable.codegen_computed, 1, "{reachable:?}");
+    assert_eq!(reachable.codegen_reused, 1, "{reachable:?}");
+
+    let unrelated = run_edit(1, 11);
+    assert_eq!(unrelated.bodies_computed, 0, "{unrelated:?}");
+    assert_eq!(unrelated.bodies_reused, 2, "{unrelated:?}");
+    assert_eq!(unrelated.cfgs_computed, 0, "{unrelated:?}");
+    assert_eq!(unrelated.codegen_computed, 0, "{unrelated:?}");
+    assert_eq!(unrelated.codegen_reused, 2, "{unrelated:?}");
 }
 
 #[test]

--- a/crates/rue-compiler/src/session.rs
+++ b/crates/rue-compiler/src/session.rs
@@ -1341,6 +1341,108 @@ impl CompilerSession {
             );
         session
     }
+
+    /// Force one exact production CodegenUnit request through an owner/joiner
+    /// schedule. The normal rooted CFG query supplies the key; the registered
+    /// CodegenUnit evaluator supplies the value. This controls only when the
+    /// owner may finish and never constructs a peer artifact path.
+    #[cfg(test)]
+    pub(crate) fn exercise_codegen_schedule_for_test(
+        &mut self,
+        options: &CompileOptions,
+        cancel_joiner: bool,
+    ) -> (rue_query::RequestExecution, rue_query::RequestExecution) {
+        let rooted = self
+            .rooted_cfg(options)
+            .expect("the schedule fixture reaches a valid CFG");
+        let [cfg] = rooted.cfgs.as_slice() else {
+            panic!("the schedule fixture must reach exactly one CodegenUnit");
+        };
+        let revision = rooted.graph.revision;
+        let key = cfg.optimized_cfg_key.clone();
+        let database = &self.queries.revisioned;
+        let gate = database.arm_codegen_evaluator_gate_for_test();
+        let baseline = database.runtime_metrics_for_test();
+        let joiner_cancellation = rue_query::CancellationToken::new();
+
+        let (owner_execution, joiner_execution) = std::thread::scope(|scope| {
+            let owner_key = key.clone();
+            let owner = scope.spawn(|| {
+                database
+                    .codegen_unit(
+                        revision,
+                        owner_key,
+                        options.target,
+                        rue_codegen::BackendArtifactRequest::default(),
+                        options.opt_level,
+                        rue_query::CancellationToken::new(),
+                    )
+                    .expect("the owner CodegenUnit request is registered")
+            });
+            gate.wait_until_entered();
+
+            let joiner_key = key.clone();
+            let joiner_token = joiner_cancellation.clone();
+            let joiner = scope.spawn(|| {
+                database
+                    .codegen_unit(
+                        revision,
+                        joiner_key,
+                        options.target,
+                        rue_codegen::BackendArtifactRequest::default(),
+                        options.opt_level,
+                        joiner_token,
+                    )
+                    .expect("the joining CodegenUnit request is registered")
+            });
+
+            let wait_for = |predicate: &dyn Fn(rue_query::RuntimeMetrics) -> bool| {
+                let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
+                while !predicate(database.runtime_metrics_for_test())
+                    && std::time::Instant::now() < deadline
+                {
+                    std::thread::yield_now();
+                }
+                predicate(database.runtime_metrics_for_test())
+            };
+            let joined = wait_for(&|metrics| metrics.joins > baseline.joins);
+            let canceled = if cancel_joiner && joined {
+                joiner_cancellation.cancel();
+                wait_for(&|metrics| metrics.cancellations > baseline.cancellations)
+            } else {
+                true
+            };
+
+            // Always release the owner before asserting the schedule so a
+            // failed observation cannot strand a scoped worker.
+            gate.release();
+            let owner = owner.join().expect("CodegenUnit owner did not panic");
+            let joiner = joiner.join().expect("CodegenUnit joiner did not panic");
+            assert!(
+                joined,
+                "the exact-key request did not join within 5 seconds"
+            );
+            assert!(
+                canceled,
+                "the joined waiter did not cancel within 5 seconds"
+            );
+            assert!(
+                owner.terminal().is_some(),
+                "the live owner must publish the canonical CodegenUnit"
+            );
+            if cancel_joiner {
+                assert!(matches!(
+                    joiner.abort(),
+                    Some(rue_query::QueryAbort::Canceled)
+                ));
+                assert!(joiner.terminal().is_none());
+            } else {
+                assert!(joiner.terminal().is_some());
+            }
+            (owner.execution(), joiner.execution())
+        });
+        (owner_execution, joiner_execution)
+    }
     /// Perturb one canonical observation for the in-tree differential oracle.
     #[doc(hidden)]
     pub(crate) fn inject_stale_query_for_oracle(

--- a/docs/designs/0063-parallel-demand-driven-incremental-compilation.md
+++ b/docs/designs/0063-parallel-demand-driven-incremental-compilation.md
@@ -1,12 +1,12 @@
 ---
 id: 0063
 title: "Parallel demand-driven incremental compilation"
-status: accepted
+status: implemented
 tags: [architecture, compiler, incremental, parallelism, codegen, linker, performance]
 feature-flag: null
 created: 2026-07-18
 accepted: 2026-07-18
-implemented:
+implemented: 2026-08-04
 spec-sections: []
 superseded-by:
 supersedes: [0045, 0050, 0053]
@@ -19,15 +19,18 @@ relates: ["ADR-0052", "ADR-0055", "ADR-0058", "ADR-0061", "RUE-328", "RUE-648", 
 
 ## Status
 
-Accepted by Steve on 2026-07-18 after adversarial review in PR #1824. This is
+Accepted by Steve on 2026-07-18 after adversarial review in PR #1824 and
+implemented through the Phase 12 fresh-link boundary on 2026-08-04. This is
 an internal compiler and tooling design with no language-semantics or preview-
 feature change. It authorizes the phased demand-driven compilation project
 through fresh linking; incremental linker implementation still requires the
 follow-up ADR described below.
 
-Implementation is tracked by the Linear project **Parallel demand-driven
+Implementation was tracked by the Linear project **Parallel demand-driven
 incremental compilation** under the RUE-648 epic. RUE-1021 through RUE-1033 are
-the dependency-ordered phase issues.
+the completed dependency-ordered phase issues. The retained-artifact policy and
+calibration are recorded by RUE-1210; the final structural and latency witnesses
+are recorded in the [RUE-1033 acceptance ledger](../notes/rue-1033-acceptance-ledger.md).
 
 This ADR supersedes ADR-0045's compiler-architecture rollout and
 its exclusion of cross-request and cross-invocation incremental state. It
@@ -817,7 +820,7 @@ Tracked in Linear under the RUE-648 epic. The dependency order is:
   fresh internal/system linker paths, and establish the delta/fingerprint
   contract for follow-up direct and incremental internal linking. — RUE-1032
   (blocked by RUE-1031)
-- [ ] **Phase 12: Compatibility and performance completion.** Generalize the
+- [x] **Phase 12: Compatibility and performance completion.** Generalize the
   cold-versus-reused oracle, add multi-worker determinism and cancellation
   schedules and source-position-shift cases, delete the selected-state
   compatibility shim and peer cache state, enforce memory budgets, and publish
@@ -970,17 +973,15 @@ the architectural scope expands.
 
 ## Open Questions
 
-- Which execution substrate best satisfies Rue's attempt/diagnostic/import and
-  current/last-good requirements after the Phase 0 comparison: an evolution of
-  the in-house database, Salsa, or another typed query runtime?
-- Which fixed warm-edit benchmark corpus and host normalization should define
-  the first latency budgets without turning one machine's number into a language
-  promise?
 - Is `LoweredMir` independently valuable enough to retain as a memo terminal, or
   should MIR presentation be a projection/debug recomputation from
   `OptimizedCfg` until measurements justify it?
 
-These questions affect implementation and measured policy, not the accepted
+The implementation uses Rue's in-house typed query runtime. Warm-edit evidence
+uses the fixed single-callee fixture and records raw host context and structural
+work rather than normalizing one machine into a portable latency promise; see
+the [RUE-1033 acceptance ledger](../notes/rue-1033-acceptance-ledger.md). The
+remaining MIR question affects future measured policy, not the implemented
 identity, revision, dependency, `CodegenUnit`, or linking-seam decisions.
 
 ## Future Work
@@ -1006,3 +1007,4 @@ identity, revision, dependency, `CodegenUnit`, or linking-seam decisions.
 - [ADR-0061: Supported compiler facade](0061-supported-compiler-facade.md)
 - [Body analysis and CFG incrementality audit](../notes/body-analysis-cfg-incrementality-audit.md)
 - [Compiler session architecture completion audit](../notes/canonical-query-completion-audit.md)
+- [RUE-1033 Phase 12 acceptance ledger](../notes/rue-1033-acceptance-ledger.md)

--- a/docs/designs/README.md
+++ b/docs/designs/README.md
@@ -225,7 +225,7 @@ The table is generated from ADR frontmatter. Run
 | [0060](0060-network-io-v1.md) | Network IO v1: blocking IPv4 TCP in pure Rue | Accepted | stdlib, io, networking, tcp, syscalls, error-handling, ownership |
 | [0061](0061-supported-compiler-facade.md) | Supported compiler facade and immutable artifact views | Accepted | architecture, compiler, tooling, api, incremental |
 | [0062](0062-place-returning-borrow-accessors.md) | Place-returning borrow accessors: projection reads of owned elements | Accepted | ownership, borrows, collections, accessors, stdlib, formal-semantics |
-| [0063](0063-parallel-demand-driven-incremental-compilation.md) | Parallel demand-driven incremental compilation | Accepted | architecture, compiler, incremental, parallelism, codegen, linker, performance |
+| [0063](0063-parallel-demand-driven-incremental-compilation.md) | Parallel demand-driven incremental compilation | Implemented | architecture, compiler, incremental, parallelism, codegen, linker, performance |
 | [0064](0064-c-ffi.md) | C FFI: a guaranteed target-C boundary for imports and exports | Accepted | ffi, abi, codegen, linker, types, semantics, unsafe, interop |
 | [0065](0065-floating-point.md) | Floating point: f32/f64, IEEE-754 semantics, and register classes | Accepted | types, semantics, codegen, numerics, abi |
 | [0066](0066-producer-nominal-anonymous-types-and-incremental-locality.md) | Producer-nominal anonymous types and incremental locality | Implemented | types, semantics, comptime, incremental, performance, parallelism |

--- a/docs/notes/rue-1033-acceptance-ledger.md
+++ b/docs/notes/rue-1033-acceptance-ledger.md
@@ -1,0 +1,81 @@
+# RUE-1033 Phase 12 acceptance ledger
+
+This note records the final structural and latency witnesses for ADR-0063's
+fresh-link implementation. The executable gates remain tests; this ledger fixes
+the measurement context so future runs can be compared without turning one
+host's timing into a compiler guarantee.
+
+## Warm single-function edit baseline
+
+Measured 2026-08-04 from the RUE-1033 working tree based on `cb9812cd`, using an
+optimized compiler test binary:
+
+```text
+./buck2 run --target-platforms //platforms:release \
+  //crates/rue-compiler:rue-compiler-test -- \
+  rue_1033_warm_single_function_latency_witness --ignored --nocapture
+```
+
+| Context | Value |
+| --- | --- |
+| Host | MacBook Pro `Mac17,2`; Apple M5; 10 logical CPUs |
+| OS | macOS 26.5.2 (25F84), Darwin 25.5.0 ARM64 |
+| Compiler target | `aarch64-macos` |
+| Query workers | 4 |
+| Sampling | 11 independent two-revision sessions; median is the sixth sorted sample |
+| Edit-to-CodegenUnit | 300 µs median; samples 272, 279, 292, 296, 298, 300, 303, 306, 306, 318, 359 µs |
+| Edit-to-runnable fresh link | 1,618 µs median; samples 1,573, 1,593, 1,598, 1,599, 1,610, 1,618, 1,622, 1,629, 1,677, 1,694, 1,741 µs |
+
+Each sample prepares the same cold baseline before the clock begins. The timed
+interval starts immediately before publishing the edited snapshot. The first
+endpoint is completion of rooted CodegenUnit collection; the second is
+completion of the deliberately fresh internal link. Source-string construction,
+executing the resulting program, and macOS test signing are outside the timed
+interval. Every linked result is executed after measurement.
+
+Every sample asserts this exact warm work:
+
+- one lexer invocation, one parser invocation, and one reparsed module;
+- one computed, one reused, and one invalidated body analysis;
+- one computed CFG;
+- one computed replacement CodegenUnit and one reused CodegenUnit; and
+- one intentionally fresh link.
+
+The ignored witness has no latency threshold. Structural assertions run every
+time it is invoked; release engineering may record new host-specific rows when
+tracking performance changes.
+
+## Executable schedule and locality gates
+
+The ordinary compiler unit suite also proves the Phase 12 schedules through
+final executable bytes:
+
+- `joined_codegen_schedule_matches_fresh_linked_executable` forces an exact-key
+  CodegenUnit join inside the registered production evaluator, then verifies
+  that the ordinary image/fresh-link adapter matches a fresh session.
+- `canceled_codegen_waiter_schedule_matches_fresh_linked_executable` cancels
+  only a joined waiter while its owner remains live, then verifies the owner's
+  terminal through the same fresh-link comparison.
+- `query_native_rooted_demand_warm_edit_locality_through_fresh_link` publishes
+  two revisions through the rooted import-input protocol. Editing the reached
+  imported function computes one body, CFG, and replacement CodegenUnit;
+  editing an unreachable imported function computes none. Both cases compare
+  fresh-linked executable bytes with a fresh session.
+
+The wider Phase 12 acceptance suite retains the remaining schedule and edit
+coverage. The differential oracle compares cold, reused, recovered-failure, and
+bounded-eviction histories with stepwise fresh sessions. Position-free trivia
+reuse is covered by the revisioned-query tests; reachability edge deletion by
+the body-closure and scaling-harness gates; and one-worker/many-worker linked
+executable parity by
+`one_and_many_query_workers_produce_identical_linked_executables`. The query
+runtime suite owns the underlying adversarial claim/join/cancellation and
+deterministic retention-budget schedules.
+
+## Remaining linker delta
+
+Phase 12 ends at a `ProgramImagePlan` consumed by a deterministic fresh internal
+link. Stateful incremental linking remains a separate design: placement and
+slack policy, stable-address growth, reverse-relocation patching, runtime
+archive changes, compaction/fallback, atomic publication, and target-specific
+signing all require the follow-up incremental-linker ADR described by ADR-0063.


### PR DESCRIPTION
## Summary

- close Phase 12 with executable-byte parity for joined and canceled CodegenUnit schedules through the ordinary compile/link adapter
- add a query-native rooted warm-edit locality test that records exact recomputation and verifies a fresh-link executable
- record the release-mode latency witness and acceptance evidence, and mark ADR-0063 implemented

## Performance and work evidence

On an Apple M5 with four query workers, 11 independent two-revision release-mode sessions measured a median of 300 us to produce the edited CodegenUnit and 1,618 us to produce a runnable executable. The reachable imported edit recomputes exactly one body, one CFG, and one CodegenUnit; an unrelated imported edit recomputes none of those downstream artifacts.

## Validation

- joined/canceled schedule executable-parity tests: 2/2
- rooted warm-edit locality test: 1/1
- release-mode latency witness: passed
- quick suite: 30/30
- clippy: 63/63
- premerge: 77/78 in the full run; the sole failure was the stale generated ADR index, which was regenerated and its isolated validation then passed (1/1)
- adversarial architectural review: no blockers

Fixes RUE-1033.
