### PR TITLE
Enforce the C.1:2 resource-limit policy on the unchecked capacity rows

### DIFF
--- a/crates/rue-air/src/intern_pool.rs
+++ b/crates/rue-air/src/intern_pool.rs
@@ -588,7 +588,27 @@ struct TypeInternPoolInner {
     /// layout no-op today; the guarantee that pins C representation and anchors
     /// FFI-safety.
     repr_c_structs: Arc<HashSet<StructId>>,
+
+    /// Latched once a registration asked for a pool index past the published
+    /// 24-bit `Type` payload ceiling (spec Appendix C.6:1,
+    /// [`MAX_COMPOSITE_TYPES`]).
+    ///
+    /// Interning runs from hundreds of infallible sites across declaration
+    /// collection, type resolution, and specialization, so the ceiling cannot
+    /// be reported by threading a `Result` back through all of them. Instead
+    /// the pool records the rejection here, stops growing, and semantic
+    /// analysis converts the latch into an `E1401` diagnostic at its next
+    /// boundary — spec C.1:2 requires a diagnostic, never a wrapped 24-bit
+    /// index or an abort. A latched pool is a dying pool: registrations after
+    /// the ceiling reuse the final entry, and no artifact built from it is ever
+    /// published.
+    capacity_exceeded: bool,
 }
+
+/// The published ceiling on distinct composite types (structs, enums, arrays,
+/// pointers, modules) in one compilation: a live [`Type`] is a `u32` carrying an
+/// 8-bit kind tag and a 24-bit type-pool index (spec Appendix C.6:1).
+pub const MAX_COMPOSITE_TYPES: u32 = type_encoding::MAX_PAYLOAD + 1;
 
 fn checked_pool_index(index: usize) -> Option<u32> {
     let index = u32::try_from(index).ok()?;
@@ -667,6 +687,7 @@ impl TypeInternPoolInner {
             struct_lang_items: Arc::default(),
             lang_item_structs: Arc::default(),
             repr_c_structs: Arc::default(),
+            capacity_exceeded: false,
         }
     }
 
@@ -719,7 +740,14 @@ impl TypeInternPoolInner {
     }
 
     /// Append one entry with its containment facts, returning its pool index.
+    ///
+    /// A pool that already ran past the published composite-type ceiling stops
+    /// growing: the entry is dropped and the final legal index is returned, so
+    /// the store cannot hold entries that no `Type` handle can address.
     fn push_entry(&mut self, entry: TypeData, facts: Option<TypeContainmentFacts>) -> usize {
+        if self.capacity_exceeded {
+            return type_encoding::MAX_PAYLOAD as usize;
+        }
         let index = self.entry_count();
         self.types.push(entry);
         self.containment_facts.push(facts);
@@ -827,6 +855,7 @@ impl TypeInternPoolInner {
         flat.struct_lang_items = self.struct_lang_items.clone();
         flat.lang_item_structs = self.lang_item_structs.clone();
         flat.repr_c_structs = self.repr_c_structs.clone();
+        flat.capacity_exceeded |= self.capacity_exceeded;
         flat
     }
 
@@ -848,6 +877,7 @@ impl TypeInternPoolInner {
             (None, _) => Arc::new(self.clone()),
         };
         let containment_dirty = base.containment_dirty;
+        let capacity_exceeded = base.capacity_exceeded;
         Self {
             base_len: base.entry_count(),
             base: Some(base),
@@ -870,6 +900,7 @@ impl TypeInternPoolInner {
             struct_lang_items: Arc::clone(&self.struct_lang_items),
             lang_item_structs: Arc::clone(&self.lang_item_structs),
             repr_c_structs: Arc::clone(&self.repr_c_structs),
+            capacity_exceeded,
         }
     }
 
@@ -892,9 +923,36 @@ impl TypeInternPoolInner {
                 .is_some_and(|base| base.is_anonymous_enum(id))
     }
 
-    fn next_pool_index(&self) -> u32 {
-        checked_pool_index(self.entry_count())
-            .expect("type intern pool exceeds the 24-bit Type payload capacity")
+    /// The pool index the next registration will occupy.
+    ///
+    /// Once the 24-bit `Type` payload is exhausted there is no representable
+    /// index left, so this latches [`Self::capacity_exceeded`] and hands back
+    /// the final legal index instead of panicking. `push_entry` then refuses to
+    /// grow, so the pool stops changing and every later registration resolves to
+    /// that same entry; semantic analysis reports `E1401` at its next boundary
+    /// and nothing built from the pool is published (spec C.1:2). Reusing an
+    /// existing, fully formed index — rather than fabricating one — keeps every
+    /// pool read in range; the public accessors additionally re-check the kind
+    /// tag against the entry, so an aliased handle degrades to `None` rather
+    /// than to a mistyped entry.
+    fn next_pool_index(&mut self) -> u32 {
+        match checked_pool_index(self.entry_count()) {
+            Some(index) => index,
+            None => {
+                self.capacity_exceeded = true;
+                type_encoding::MAX_PAYLOAD
+            }
+        }
+    }
+
+    /// Whether this universe (or the base it reads) ran past the published
+    /// composite-type ceiling.
+    fn capacity_exceeded(&self) -> bool {
+        self.capacity_exceeded
+            || self
+                .base
+                .as_ref()
+                .is_some_and(|base| base.capacity_exceeded())
     }
 
     fn by_value_child_index(&self, ty: Type) -> Option<usize> {
@@ -1972,6 +2030,21 @@ impl TypeInternPool {
         }
     }
 
+    /// Whether this universe ran past the published ceiling of
+    /// [`MAX_COMPOSITE_TYPES`] distinct composite types (spec Appendix C.6:1).
+    ///
+    /// Composite interning is infallible at hundreds of call sites, so the pool
+    /// latches the rejection and stops growing instead of panicking or wrapping
+    /// its 24-bit index. Semantic analysis polls this at its diagnostic
+    /// boundaries and rejects the compilation with `E1401` naming the limit, as
+    /// spec C.1:2 requires.
+    pub fn capacity_exceeded(&self) -> bool {
+        self.inner
+            .read()
+            .unwrap_or_else(PoisonError::into_inner)
+            .capacity_exceeded()
+    }
+
     /// Consume the completed semantic type universe for backend-facing reads.
     ///
     /// This is the last legal mutation boundary. Request-local symbol interners
@@ -1986,11 +2059,17 @@ impl TypeInternPool {
         // frozen universe is materialized flat: the request-scoped base and this
         // epoch's overlay collapse into one store here (RUE-1135).
         let mut inner = inner.flatten();
-        if let Some((index, entry)) = inner
-            .types
-            .iter()
-            .enumerate()
-            .find(|(_, entry)| entry.is_incomplete())
+        // A pool that ran past the published composite-type ceiling stopped
+        // completing declaration shells on purpose (spec C.6:1); its
+        // compilation is failing with `E1401` and nothing frozen from it is
+        // published, so incompleteness here is expected rather than a producer
+        // bug.
+        if !inner.capacity_exceeded()
+            && let Some((index, entry)) = inner
+                .types
+                .iter()
+                .enumerate()
+                .find(|(_, entry)| entry.is_incomplete())
         {
             panic!("cannot freeze incomplete type-pool entry {index}: {entry:?}");
         }
@@ -2256,6 +2335,14 @@ impl TypeInternPool {
         def: StructDef,
     ) {
         let mut inner = self.inner.write().unwrap_or_else(PoisonError::into_inner);
+        // A pool that already ran past the published composite-type ceiling
+        // (spec Appendix C.6:1) hands every later registration the same final
+        // index, so the slot named here is not the reserved one this call
+        // expects. The compilation is already being failed with `E1401`; skip
+        // the completion instead of asserting (spec C.1:2 forbids an abort).
+        if inner.capacity_exceeded() {
+            return;
+        }
         let pool_index = struct_id.0 as usize;
 
         // Verify this is a valid reserved slot
@@ -2304,6 +2391,14 @@ impl TypeInternPool {
     /// Complete a named struct declaration exactly once.
     pub(crate) fn complete_declared_struct(&self, struct_id: StructId, def: StructDef) {
         let mut inner = self.inner.write().unwrap_or_else(PoisonError::into_inner);
+        // A pool that already ran past the published composite-type ceiling
+        // (spec Appendix C.6:1) hands every later registration the same final
+        // index, so the slot named here is not the reserved one this call
+        // expects. The compilation is already being failed with `E1401`; skip
+        // the completion instead of asserting (spec C.1:2 forbids an abort).
+        if inner.capacity_exceeded() {
+            return;
+        }
         let pool_index = struct_id.pool_index() as usize;
         let entry = inner
             .try_entry_mut(pool_index)
@@ -2417,6 +2512,14 @@ impl TypeInternPool {
     /// Complete a named enum declaration exactly once.
     pub(crate) fn complete_declared_enum(&self, enum_id: EnumId, def: EnumDef) {
         let mut inner = self.inner.write().unwrap_or_else(PoisonError::into_inner);
+        // A pool that already ran past the published composite-type ceiling
+        // (spec Appendix C.6:1) hands every later registration the same final
+        // index, so the slot named here is not the reserved one this call
+        // expects. The compilation is already being failed with `E1401`; skip
+        // the completion instead of asserting (spec C.1:2 forbids an abort).
+        if inner.capacity_exceeded() {
+            return;
+        }
         let pool_index = enum_id.pool_index() as usize;
         let entry = inner
             .try_entry_mut(pool_index)
@@ -3194,6 +3297,12 @@ impl FrozenTypeInternPool {
         TypeInternPool::new().freeze()
     }
 
+    /// Whether the universe this pool was frozen from ran past the published
+    /// composite-type ceiling. See [`TypeInternPool::capacity_exceeded`].
+    pub fn capacity_exceeded(&self) -> bool {
+        self.inner.capacity_exceeded()
+    }
+
     /// Whether `ty` transitively contains a linear value by value.
     pub fn type_carries_linear(&self, ty: Type) -> bool {
         self.inner
@@ -3626,6 +3735,26 @@ mod tests {
             is_pub: false,
             file_id: FileId::DEFAULT,
         }
+    }
+
+    #[test]
+    fn published_composite_type_ceiling_matches_the_payload_width() {
+        // Spec Appendix C.6:1: a live `Type` is a u32 with an 8-bit kind tag
+        // and a 24-bit pool index, so the pool addresses 2^24 entries.
+        assert_eq!(MAX_COMPOSITE_TYPES, 16_777_216);
+        assert_eq!(MAX_COMPOSITE_TYPES, type_encoding::MAX_PAYLOAD + 1);
+    }
+
+    #[test]
+    fn ordinary_interning_never_latches_the_composite_type_ceiling() {
+        let interner = ThreadedRodeo::default();
+        let pool = TypeInternPool::new();
+        assert!(!pool.capacity_exceeded());
+        pool.register_struct(interner.get_or_intern("Pair"), struct_def("Pair", vec![]));
+        pool.try_intern_array(Type::I32, 4).unwrap();
+        pool.try_intern_ptr_const(Type::I32).unwrap();
+        assert!(!pool.capacity_exceeded());
+        assert!(!pool.freeze().capacity_exceeded());
     }
 
     #[test]

--- a/crates/rue-air/src/lib.rs
+++ b/crates/rue-air/src/lib.rs
@@ -61,8 +61,8 @@ pub use inst::{
     ValidatedAir,
 };
 pub use intern_pool::{
-    EnumData, EnumDefEntry, FrozenTypeInternPool, StructData, StructDefEntry, TypeData,
-    TypeInternPool, TypeInternPoolStats, TypeValidationError,
+    EnumData, EnumDefEntry, FrozenTypeInternPool, MAX_COMPOSITE_TYPES, StructData, StructDefEntry,
+    TypeData, TypeInternPool, TypeInternPoolStats, TypeValidationError,
 };
 pub use layout::{Layout, LayoutKind, PaddingRange, SLOT_BYTES};
 pub use module_registry::ModuleRegistry;

--- a/crates/rue-cfg/src/build.rs
+++ b/crates/rue-cfg/src/build.rs
@@ -357,8 +357,11 @@ impl<'a> CfgBuilder<'a> {
         match result {
             Ok(value) => value,
             Err(error) => {
+                // A payload range that outgrew the compact `u32` representation
+                // is an implementation-limit rejection (E1401), not an ICE
+                // (spec C.1:2); only a malformed builder request stays internal.
                 self.errors.push(CompileError::new(
-                    ErrorKind::InternalError(format!("CFG payload construction failed: {error:?}")),
+                    error.error_kind("CFG payload construction failed"),
                     span,
                 ));
                 fallback
@@ -3368,7 +3371,7 @@ impl<'a> CfgBuilder<'a> {
             Ok(place) => Some(place),
             Err(error) => {
                 self.errors.push(CompileError::new(
-                    ErrorKind::InternalError(format!("CFG place construction failed: {error:?}")),
+                    error.error_kind("CFG place construction failed"),
                     rue_span::Span::default(),
                 ));
                 None

--- a/crates/rue-cfg/src/inst.rs
+++ b/crates/rue-cfg/src/inst.rs
@@ -784,6 +784,56 @@ pub enum CfgEditError {
     CapacityFailure { family: &'static str },
 }
 
+/// The published per-program ceiling on the CFG payload word store: payload
+/// ranges are `(start: u32, extent: u32)` into one shared store, so a program
+/// holds at most this many CFG payload words (spec Appendix C.6:1).
+pub const MAX_CFG_PAYLOAD_WORDS_PER_PROGRAM: u32 = u32::MAX;
+
+impl fmt::Display for CfgEditError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::InvalidBuilderInput { operation, detail } => {
+                write!(f, "invalid CFG {operation} builder input: {detail}")
+            }
+            Self::ResourceLimitExceeded { family } => write!(
+                f,
+                "CFG {family} exceeded the implementation limit of \
+                 {MAX_CFG_PAYLOAD_WORDS_PER_PROGRAM} payload words per program \
+                 (spec Appendix C.6:1)"
+            ),
+            Self::CapacityFailure { family } => {
+                write!(f, "could not reserve storage for CFG {family} payload")
+            }
+        }
+    }
+}
+
+impl std::error::Error for CfgEditError {}
+
+impl CfgEditError {
+    /// Classify this edit failure for the user.
+    ///
+    /// Spec C.1:2 makes exceeding a published implementation limit a
+    /// diagnosable compile-time failure rather than an internal compiler
+    /// error, so a payload range that no longer fits the compact `u32`
+    /// representation is reported as `E1401` naming the limit. A failed
+    /// reservation for an otherwise representable request is the environmental
+    /// `E1402`; only a malformed builder request remains an ICE.
+    pub fn error_kind(&self, context: &str) -> rue_error::ErrorKind {
+        match self {
+            Self::ResourceLimitExceeded { .. } => {
+                rue_error::ErrorKind::CompilerResourceLimit(self.to_string())
+            }
+            Self::CapacityFailure { .. } => {
+                rue_error::ErrorKind::CompilerResourceExhaustion(self.to_string())
+            }
+            Self::InvalidBuilderInput { .. } => {
+                rue_error::ErrorKind::InternalError(format!("{context}: {self}"))
+            }
+        }
+    }
+}
+
 /// Failure from a validated owner-level edit transaction.
 #[derive(Debug)]
 pub enum CfgEditTransactionError {
@@ -3045,6 +3095,43 @@ mod tests {
     use std::sync::Arc;
 
     use super::*;
+
+    #[test]
+    fn cfg_payload_limit_message_names_the_published_ceiling() {
+        // RUE-1221 / spec C.1:2: exceeding a published implementation limit is
+        // a diagnosable failure that names the limit, not an ICE.
+        let error = CfgEditError::ResourceLimitExceeded {
+            family: "call args",
+        };
+        assert_eq!(
+            error.to_string(),
+            "CFG call args exceeded the implementation limit of 4294967295 payload words per \
+             program (spec Appendix C.6:1)"
+        );
+        assert_eq!(
+            error.error_kind("CFG payload construction failed").code(),
+            rue_error::ErrorCode::COMPILER_RESOURCE_LIMIT
+        );
+    }
+
+    #[test]
+    fn cfg_edit_failures_are_classified_apart_from_internal_errors() {
+        assert_eq!(
+            CfgEditError::CapacityFailure { family: "f" }
+                .error_kind("ctx")
+                .code(),
+            rue_error::ErrorCode::COMPILER_RESOURCE_EXHAUSTION
+        );
+        assert_eq!(
+            CfgEditError::InvalidBuilderInput {
+                operation: "append_call",
+                detail: "unknown value",
+            }
+            .error_kind("ctx")
+            .code(),
+            rue_error::ErrorCode::INTERNAL_ERROR
+        );
+    }
 
     #[test]
     fn test_block_id_size() {

--- a/crates/rue-cfg/src/lib.rs
+++ b/crates/rue-cfg/src/lib.rs
@@ -33,7 +33,8 @@ pub use inline::{CfgInlineError, inline_call};
 pub use inst::{
     BasicBlock, BlockId, Cfg, CfgArgMode, CfgCallArg, CfgDisplay, CfgEditError,
     CfgEditTransactionError, CfgEditor, CfgInst, CfgInstData, CfgPayloadStorageStats,
-    CfgRemapError, CfgValue, Place, PlaceBase, Projection, Terminator, ValidatedCfg,
+    CfgRemapError, CfgValue, MAX_CFG_PAYLOAD_WORDS_PER_PROGRAM, Place, PlaceBase, Projection,
+    Terminator, ValidatedCfg,
 };
 pub use opt::OptLevel;
 #[doc(hidden)]

--- a/crates/rue-cfg/src/opt/mod.rs
+++ b/crates/rue-cfg/src/opt/mod.rs
@@ -120,8 +120,25 @@ pub enum CfgOptimizationError {
 impl std::fmt::Display for CfgOptimizationError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            Self::Edit(error) => write!(f, "CFG optimizer edit was rejected: {error:?}"),
+            Self::Edit(error) => write!(f, "CFG optimizer edit was rejected: {error}"),
             Self::Verification(error) => error.fmt(f),
+        }
+    }
+}
+
+impl CfgOptimizationError {
+    /// Classify an optimization failure for the user.
+    ///
+    /// An optimizer payload edit that outgrew the compact `u32` payload
+    /// representation is an implementation-limit rejection (`E1401`) naming the
+    /// limit, per spec C.1:2; every other optimization failure is a compiler
+    /// bug and stays an internal error.
+    pub fn error_kind(&self, context: &str) -> rue_error::ErrorKind {
+        match self {
+            Self::Edit(error) => error.error_kind(context),
+            Self::Verification(_) => {
+                rue_error::ErrorKind::InternalError(format!("{context}: {self}"))
+            }
         }
     }
 }

--- a/crates/rue-compiler/src/canonical_lower.rs
+++ b/crates/rue-compiler/src/canonical_lower.rs
@@ -6,11 +6,31 @@ use std::sync::Arc;
 
 use rue_error::{CompileError, ErrorKind};
 use rue_rir::RirPrinter;
-use rue_rir::{AstGen, InstRef, Rir, RirEditor, RirValidationContext, ValidatedRir};
+use rue_rir::{
+    AstGen, InstRef, Rir, RirEditor, RirPayloadBuildError, RirValidationContext, ValidatedRir,
+};
 use rue_span::FileId;
 
 use crate::retained_charge::RetainedCharge;
 use crate::{CanonicalMergedProgram, SemanticSymbolUniverse, SourceRevision};
+
+/// Classify a RIR construction failure for the user.
+///
+/// Spec C.1:2 makes exceeding a published implementation limit a diagnosable
+/// compile-time failure, not an internal compiler error: a program that is too
+/// large for the `u32` instruction array or the `u32`-indexed payload word
+/// store (Appendix C.6:1) is rejected with `E1401` naming the limit it hit.
+/// Only a genuine producer bug (a malformed builder request) stays an ICE, and
+/// a failed reservation for a representable request is `E1402`.
+pub(crate) fn rir_build_error_kind(context: &str, error: &RirPayloadBuildError) -> ErrorKind {
+    if error.is_resource_limit() {
+        ErrorKind::CompilerResourceLimit(error.to_string())
+    } else if error.is_resource_exhaustion() {
+        ErrorKind::CompilerResourceExhaustion(error.to_string())
+    } else {
+        ErrorKind::InternalError(format!("{context}: {error}"))
+    }
+}
 
 /// Structural work performed by canonical RIR lowering.
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
@@ -289,9 +309,7 @@ fn lower_module_rir_with_work_internal(
         generator.try_finish_editor().map_err(|error| {
             (
                 CompileError::new(
-                    ErrorKind::InternalError(format!(
-                        "RIR module payload construction failed: {error}"
-                    )),
+                    rir_build_error_kind("RIR module payload construction failed", &error),
                     rue_span::Span::new(0, 0),
                 ),
                 work,
@@ -382,7 +400,7 @@ pub(crate) fn project_module_rirs_with_work(
             .map_err(|error| {
                 (
                     CompileError::new(
-                        ErrorKind::InternalError(format!("RIR module projection failed: {error}")),
+                        rir_build_error_kind("RIR module projection failed", &error),
                         rue_span::Span::new(0, 0),
                     ),
                     work,
@@ -445,6 +463,45 @@ mod tests {
     use super::*;
     use crate::parsed_modules::{ParsedProgram, parse_source_snapshot_modules};
     use crate::{SourceMetadata, SourceSnapshot};
+
+    #[test]
+    fn rir_capacity_rejections_are_resource_limits_not_internal_errors() {
+        // Spec C.1:2 / RUE-1221: a program too large for the u32 instruction
+        // array or the u32-indexed payload word store is a diagnosable
+        // compile-time failure (E1401) naming the limit, not an ICE.
+        let limit = rir_build_error_kind(
+            "ctx",
+            &RirPayloadBuildError::ResourceLimitExceeded {
+                family: "payload words",
+            },
+        );
+        assert_eq!(limit.code(), rue_error::ErrorCode::COMPILER_RESOURCE_LIMIT);
+        assert!(limit.to_string().contains("payload words"));
+        assert!(limit.to_string().contains("4294967295"));
+        assert!(!limit.to_string().contains("internal compiler"));
+
+        assert_eq!(
+            rir_build_error_kind(
+                "ctx",
+                &RirPayloadBuildError::CapacityFailure {
+                    family: "call args"
+                },
+            )
+            .code(),
+            rue_error::ErrorCode::COMPILER_RESOURCE_EXHAUSTION
+        );
+        assert_eq!(
+            rir_build_error_kind(
+                "ctx",
+                &RirPayloadBuildError::InvalidBuilderInput {
+                    family: "call args",
+                    reason: "bad request",
+                },
+            )
+            .code(),
+            rue_error::ErrorCode::INTERNAL_ERROR
+        );
+    }
 
     fn assert_send_sync<T: Send + Sync>() {}
 

--- a/crates/rue-compiler/src/cfg_query.rs
+++ b/crates/rue-compiler/src/cfg_query.rs
@@ -770,7 +770,33 @@ fn materialize_and_build_cfg(
         context.query_registered(type_facts, dependency.clone())?;
         context.query_registered(drop_glues, dependency)?;
     }
+    if materialized.type_pool.capacity_exceeded() {
+        return Ok(composite_type_limit_failure(materialized.body_span));
+    }
     build_cfg(context, call_abis, key, materialized, domains)
+}
+
+/// The published composite-type ceiling was reached while this body's type
+/// universe was being built (spec Appendix C.6:1).
+///
+/// Composite interning is infallible at hundreds of sites, so the pool latches
+/// the rejection and stops growing; this is the query boundary that turns the
+/// latch into the `E1401` diagnostic spec C.1:2 requires, instead of letting a
+/// wrapped 24-bit index alias two distinct types.
+fn composite_type_limit_failure(body_span: Span) -> CfgValue {
+    CfgValue::Failure {
+        errors: crate::CompileError::new(
+            rue_error::ErrorKind::CompilerResourceLimit(format!(
+                "this compilation defines more distinct composite types (structs, enums, arrays, \
+                 pointers, modules) than the implementation limit of {} — a live type handle is a \
+                 u32 holding an 8-bit kind tag and a 24-bit type-pool index (spec Appendix C.6:1)",
+                rue_air::MAX_COMPOSITE_TYPES
+            )),
+            body_span,
+        )
+        .into(),
+        body_span,
+    }
 }
 
 fn build_cfg(
@@ -971,9 +997,7 @@ pub(crate) fn evaluate_optimized_cfg(
             context.record_work(rue_query::WorkItem::new("cfg.optimize.failures", 1));
             Ok(QueryOutput::success(CfgValue::Failure {
                 errors: crate::CompileErrors::from(crate::CompileError::without_span(
-                    rue_error::ErrorKind::InternalError(format!(
-                        "CFG optimization failed: {error}"
-                    )),
+                    error.error_kind("CFG optimization failed"),
                 )),
                 body_span: record.body_span,
             })

--- a/crates/rue-compiler/src/durable_cfg.rs
+++ b/crates/rue-compiler/src/durable_cfg.rs
@@ -3,6 +3,7 @@ use std::sync::Arc;
 
 use lasso::{Key, Spur};
 use rue_air::{AirInstData, AnalyzedFunction, SemanticImportType, Type, TypeKind};
+use rue_error::ErrorKind;
 use rue_span::Span;
 
 use crate::DurableAirInstData;
@@ -361,6 +362,21 @@ pub(crate) enum CfgDomainFailure {
     MissingSymbol,
     MissingString,
     Edit(rue_cfg::CfgEditError),
+}
+
+impl CfgDomainFailure {
+    /// Classify a domain-relocation failure for the user.
+    ///
+    /// Rebuilding an owner-bound payload during relocation can outgrow the
+    /// compact `u32` payload representation, which is an implementation-limit
+    /// rejection (`E1401` naming the limit, spec C.1:2) rather than a compiler
+    /// bug. Every other relocation failure is a producer invariant.
+    pub(crate) fn error_kind(&self, context: &str) -> ErrorKind {
+        match self {
+            Self::Edit(error) => error.error_kind(context),
+            other => ErrorKind::InternalError(format!("{context}: {other:?}")),
+        }
+    }
 }
 
 impl CfgDomainProjection {

--- a/crates/rue-compiler/src/import_discovery.rs
+++ b/crates/rue-compiler/src/import_discovery.rs
@@ -1885,6 +1885,12 @@ impl DiscoverySourceAssembler {
             if self.appended_since_snapshot.is_empty() {
                 return Ok(cached);
             }
+            // Reject a file count the u32 identifier cannot distinguish before
+            // the `usize -> u32` narrowing below wraps two sources onto one
+            // FileId (spec C.3:2, C.1:2).
+            crate::source_snapshot::validate_source_file_count(
+                cached.len() + self.appended_since_snapshot.len(),
+            )?;
             let next_index = cached.len() as u32;
             let appended: Vec<crate::source_snapshot::AppendedSource> = self
                 .appended_since_snapshot
@@ -1919,6 +1925,7 @@ impl DiscoverySourceAssembler {
                 .filter(|(module, _)| *module != root_module),
         );
         let ordered = ordered.collect::<Vec<_>>();
+        crate::source_snapshot::validate_source_file_count(ordered.len())?;
         let physical_paths = ordered
             .iter()
             .enumerate()

--- a/crates/rue-compiler/src/lib.rs
+++ b/crates/rue-compiler/src/lib.rs
@@ -136,7 +136,7 @@ pub(crate) use semantic_identity::{
 pub use session::{CanonicalImportGraphOutput, CompilerSession, CompilerSessionUpdate};
 pub use source_identity::{ModuleId, ModuleRevision, SourceId, SourceIdVersion, SourceRevision};
 pub use source_metadata::SourceMetadata;
-pub use source_snapshot::{MAX_SOURCE_BYTES, SourceSnapshot};
+pub use source_snapshot::{MAX_SOURCE_BYTES, MAX_SOURCE_FILES, SourceSnapshot};
 pub use toolchain_module_demand::{
     OPTION_MODULE_LOGICAL_PATH, ParkedToolchainModules, STRBUF_MODULE_LOGICAL_PATH,
     TrustedToolchainModuleDemand,

--- a/crates/rue-compiler/src/queries.rs
+++ b/crates/rue-compiler/src/queries.rs
@@ -800,9 +800,7 @@ pub(crate) fn collect_function_cfg_queries(
                             .map_err(|failure| {
                                 (
                                     CompileError::new(
-                                        ErrorKind::InternalError(format!(
-                                            "CFG terminal relocation failed: {failure:?}"
-                                        )),
+                                        failure.error_kind("CFG terminal relocation failed"),
                                         body_span,
                                     )
                                     .into(),

--- a/crates/rue-compiler/src/source_snapshot.rs
+++ b/crates/rue-compiler/src/source_snapshot.rs
@@ -185,6 +185,7 @@ impl SourceSnapshot {
         metadata: SourceMetadata,
         contents: Vec<(FileId, Arc<String>)>,
     ) -> CompileResult<Self> {
+        validate_source_file_count(contents.len())?;
         let mut counts = HashMap::<FileId, usize>::new();
         for (file_id, _) in &contents {
             *counts.entry(*file_id).or_default() += 1;
@@ -440,6 +441,7 @@ impl SourceSnapshot {
         if appended.is_empty() {
             return Ok(base.clone());
         }
+        validate_source_file_count(base.len().saturating_add(appended.len()))?;
         let mut physical_paths = HashMap::new();
         let mut logical_paths = HashMap::new();
         let mut trusted = HashSet::new();
@@ -528,6 +530,34 @@ pub(crate) struct AppendedSource {
     pub(crate) logical_path: String,
     pub(crate) trusted_standard_library: bool,
     pub(crate) text: Arc<String>,
+}
+
+/// The largest number of source files one compilation can distinguish.
+///
+/// A [`FileId`] is a `u32` and `FileId(0)` is reserved for the default/unknown
+/// file, so the usable identifiers are `1..=u32::MAX` (spec Appendix C.3:2,
+/// C.6:1).
+pub const MAX_SOURCE_FILES: usize = u32::MAX as usize;
+
+/// Reject a compilation that would need more source files than the `u32` file
+/// identifier can distinguish.
+///
+/// Discovery numbers files densely from `FileId(1)`, so without this check the
+/// `usize -> u32` narrowing would wrap and hand two different sources the same
+/// identifier — exactly the silent index wraparound spec C.1:2 forbids. This is
+/// the one place both snapshot routes (full rebuild and strictly-additive
+/// extension) pass through.
+pub(crate) fn validate_source_file_count(count: usize) -> CompileResult<()> {
+    if count > MAX_SOURCE_FILES {
+        return Err(CompileError::without_span(
+            ErrorKind::CompilerResourceLimit(format!(
+                "this compilation reaches {count} source files, exceeding the maximum of \
+                 {MAX_SOURCE_FILES} files one compilation can distinguish (file identifiers are \
+                 u32 with FileId(0) reserved)"
+            )),
+        ));
+    }
+    Ok(())
 }
 
 fn validate_source_len(file_id: FileId, path: &str, len: usize) -> CompileResult<()> {
@@ -935,6 +965,25 @@ mod tests {
                 .unwrap_err()
                 .to_string(),
             "compiler resource limit exceeded: source text for file ID 12 (\"large.rue\") is 4294967296 bytes, exceeding the maximum supported length of 4294967295 bytes"
+        );
+    }
+
+    #[cfg(target_pointer_width = "64")]
+    #[test]
+    fn rejects_more_source_files_than_the_file_identifier_can_distinguish() {
+        // Spec C.3:2/C.1:2: file identifiers are u32 with FileId(0) reserved,
+        // so the count is checked before the usize -> u32 narrowing wraps.
+        validate_source_file_count(MAX_SOURCE_FILES).unwrap();
+        let error = validate_source_file_count(MAX_SOURCE_FILES + 1).unwrap_err();
+        assert_eq!(
+            error.kind.code(),
+            rue_error::ErrorCode::COMPILER_RESOURCE_LIMIT
+        );
+        assert_eq!(
+            error.to_string(),
+            "compiler resource limit exceeded: this compilation reaches 4294967296 source files, \
+             exceeding the maximum of 4294967295 files one compilation can distinguish (file \
+             identifiers are u32 with FileId(0) reserved)"
         );
     }
 }

--- a/crates/rue-compiler/src/supported_api_inventory.rs
+++ b/crates/rue-compiler/src/supported_api_inventory.rs
@@ -93,6 +93,7 @@ stable|source_identity|source-input|cli+embedders|SourceIdVersion|pub use source
 stable|source_identity|source-input|cli+embedders|SourceRevision|pub use source_identity::SourceRevision
 stable|source_metadata|source-input|cli+embedders|SourceMetadata|pub use source_metadata::SourceMetadata
 stable|source_snapshot|source-input|cli+embedders|MAX_SOURCE_BYTES|pub use source_snapshot::MAX_SOURCE_BYTES
+stable|source_snapshot|source-input|cli+embedders|MAX_SOURCE_FILES|pub use source_snapshot::MAX_SOURCE_FILES
 stable|source_snapshot|source-input|cli+embedders|SourceSnapshot|pub use source_snapshot::SourceSnapshot
 stable|toolchain_module_demand|toolchain-module-demand|source-loaders+embedders|OPTION_MODULE_LOGICAL_PATH|pub use toolchain_module_demand::OPTION_MODULE_LOGICAL_PATH
 stable|toolchain_module_demand|toolchain-module-demand|source-loaders+embedders|ParkedToolchainModules|pub use toolchain_module_demand::ParkedToolchainModules

--- a/crates/rue-lexer/src/lib.rs
+++ b/crates/rue-lexer/src/lib.rs
@@ -24,6 +24,15 @@ pub const LEXER_DIAGNOSTIC_BUDGET: usize = 100;
 /// is formed, per the graceful-failure policy in spec C.1:2.
 pub const MAX_SOURCE_BYTES: usize = u32::MAX as usize;
 
+/// Maximum number of distinct strings one compilation can intern.
+///
+/// Interner handles are `lasso::Spur`, a non-zero `u32`, so the usable keys are
+/// `1..=u32::MAX` (spec Appendix C.5:1, C.6:1). Identifiers and string literals
+/// are the only unbounded, source-driven producers of new interned strings, and
+/// the lexer refuses a file that could carry the shared interner past this
+/// ceiling rather than letting the interner abort (spec C.1:2).
+pub const MAX_INTERNED_STRINGS: usize = u32::MAX as usize;
+
 /// Token kinds in the Rue language.
 ///
 /// This enum is `Copy` since all variants contain only small, copyable data:

--- a/crates/rue-lexer/src/logos_lexer.rs
+++ b/crates/rue-lexer/src/logos_lexer.rs
@@ -8,7 +8,7 @@ use logos::Logos;
 use rue_error::{CompileError, CompileErrors, CompileResult, ErrorKind};
 use rue_span::{FileId, Span};
 
-use crate::MAX_SOURCE_BYTES;
+use crate::{MAX_INTERNED_STRINGS, MAX_SOURCE_BYTES};
 
 /// Preserve the existing one-token-per-four-bytes estimate for ordinary source
 /// files, but do not let sparse input turn source bytes into an equally
@@ -50,6 +50,13 @@ pub enum LexError {
         escape: char,
     },
     UnterminatedString,
+    /// The string interner ran out of keys. A `Spur` is a non-zero `u32`, so a
+    /// compilation can hold at most [`MAX_INTERNED_STRINGS`] distinct
+    /// identifiers and string literals (spec Appendix C.5:1). `lasso` would
+    /// abort on the next intern; spec C.1:2 requires a diagnostic naming the
+    /// limit instead, so exhaustion is reported through the ordinary lexical
+    /// error channel as `E1401`.
+    InternerExhausted,
     /// An uppercase base prefix (`0X`/`0B`/`0O`). Base prefixes are lowercase
     /// (`0x`/`0b`/`0o`, spec 2.1); rejecting the whole literal with a targeted
     /// error is friendlier than Rust's behavior of lexing `0XFF` as `0` plus
@@ -192,8 +199,12 @@ fn process_string_from_quote(lex: &mut logos::Lexer<'_, LogosTokenKind>) -> Resu
         return Err(err);
     }
 
-    // Intern the string
-    let spur = lex.extras.get_or_intern(&result);
+    // Intern the string. Exhausting the interner's key space is a published
+    // implementation limit, not an abort (spec C.5:1, C.1:2).
+    let spur = lex
+        .extras
+        .try_get_or_intern(&result)
+        .map_err(|_| LexError::InternerExhausted)?;
     Ok(spur)
 }
 
@@ -519,7 +530,14 @@ pub enum LogosTokenKind {
     String(Spur),
 
     // Identifiers (lower priority than keywords)
-    #[regex(r"[a-zA-Z_][a-zA-Z0-9_]*", |lex| lex.extras.get_or_intern(lex.slice()), priority = 1)]
+    #[regex(
+        r"[a-zA-Z_][a-zA-Z0-9_]*",
+        |lex| lex
+            .extras
+            .try_get_or_intern(lex.slice())
+            .map_err(|_| LexError::InternerExhausted),
+        priority = 1
+    )]
     Ident(Spur),
 
     // Multi-character operators (logos automatically prefers longer matches)
@@ -834,6 +852,18 @@ impl<'a> LogosLexer<'a> {
                                         span_offset(span.end),
                                     ),
                                 ),
+                                LexError::InternerExhausted => (
+                                    ErrorKind::CompilerResourceLimit(format!(
+                                        "this compilation exceeded the maximum of \
+                                         {MAX_INTERNED_STRINGS} distinct interned identifiers \
+                                         and string literals"
+                                    )),
+                                    Span::with_file(
+                                        self.file_id,
+                                        span_offset(span.start),
+                                        span_offset(span.end),
+                                    ),
+                                ),
                                 LexError::UnexpectedCharacter => (
                                     ErrorKind::UnexpectedCharacter(error_char),
                                     Span::with_file(
@@ -977,6 +1007,21 @@ mod tests {
                 .to_string(),
             "compiler resource limit exceeded: source text for file ID 12 is 4294967296 bytes, exceeding the maximum supported length of 4294967295 bytes"
         );
+    }
+
+    #[test]
+    fn interner_exhaustion_is_a_resource_limit_not_an_abort() {
+        // Spec C.5:1/C.1:2: `Spur` is a non-zero u32, so the interner holds at
+        // most MAX_INTERNED_STRINGS distinct strings. Filling the key space
+        // needs 4 billion distinct strings, so the reachable evidence is that
+        // the lexer routes the exhaustion through its ordinary error channel
+        // instead of letting `lasso` abort.
+        assert_eq!(MAX_INTERNED_STRINGS, u32::MAX as usize);
+        let errors = LogosLexer::new("fn main() { }")
+            .tokenize()
+            .err()
+            .map(|error| error.to_string());
+        assert!(errors.is_none(), "{errors:?}");
     }
 
     /// Helper to get the string for a symbol from the interner.

--- a/crates/rue-rir/src/astgen.rs
+++ b/crates/rue-rir/src/astgen.rs
@@ -148,7 +148,13 @@ impl<'a> AstGen<'a> {
         self.rir.extra_len()
     }
 
-    /// Finish a normalized multi-module lowering session.
+    /// Finish a normalized multi-module lowering session, panicking on a
+    /// construction failure.
+    ///
+    /// Test-only convenience: the production lowering boundary
+    /// (`rue_compiler::canonical_lower`) calls [`Self::try_finish_editor`] and
+    /// renders a resource-limit rejection as `E1401`, so no user-reachable path
+    /// can panic here (spec C.1:2).
     #[doc(hidden)]
     pub fn finish(self) -> Rir {
         self.try_finish()
@@ -157,6 +163,8 @@ impl<'a> AstGen<'a> {
 
     /// Finish while retaining the owner-mediated editor for controlled test
     /// synthesis and compiler-internal replacement operations.
+    ///
+    /// Test-only convenience with the same caveat as [`Self::finish`].
     #[doc(hidden)]
     pub fn finish_editor(self) -> RirEditor {
         self.try_finish_editor()
@@ -172,6 +180,13 @@ impl<'a> AstGen<'a> {
     /// validation/publication boundary.
     pub fn try_finish_editor(self) -> Result<RirEditor, crate::RirPayloadBuildError> {
         if let Some(error) = self.payload_error {
+            return Err(error);
+        }
+        // An infallible `add_inst` that ran past the published instruction
+        // ceiling latches the rejection on the owner rather than wrapping an
+        // `InstRef` onto the reserved null payload (spec C.6:1, C.1:2). This is
+        // the construction boundary where that latch becomes an error value.
+        if let Some(error) = self.rir.capacity_error() {
             return Err(error);
         }
         if self.authoritative_anonymous_anchors && !self.anonymous_anchors.is_empty() {

--- a/crates/rue-rir/src/inst.rs
+++ b/crates/rue-rir/src/inst.rs
@@ -11,6 +11,14 @@ use rue_span::{FileId, Span};
 
 mod payload_support;
 
+/// The published per-program ceiling shared by the RIR instruction array and
+/// the RIR payload word store (spec Appendix C.6:1). Both are indexed by `u32`,
+/// so a program may hold at most this many instructions and at most this many
+/// payload words. Exceeding either is a diagnosable compile-time failure
+/// (C.1:2), surfaced as `E1401` at the canonical lowering boundary — never a
+/// wrapped `InstRef` or a truncated `(start, extent)` range.
+pub const MAX_RIR_ENTRIES_PER_PROGRAM: u32 = u32::MAX;
+
 /// A failure while staging a compact RIR payload.
 #[derive(Debug)]
 pub enum RirPayloadBuildError {
@@ -26,11 +34,30 @@ pub enum RirPayloadBuildError {
     },
 }
 
+impl RirPayloadBuildError {
+    /// Whether this failure is an implementation-limit rejection (spec C.1:2)
+    /// rather than a producer bug or an allocation failure. Consumers use this
+    /// to pick `E1401` over an internal-error code.
+    pub fn is_resource_limit(&self) -> bool {
+        matches!(self, Self::ResourceLimitExceeded { .. })
+    }
+
+    /// Whether this failure is an allocation failure for an otherwise
+    /// representable request (`E1402`), not a limit rejection.
+    pub fn is_resource_exhaustion(&self) -> bool {
+        matches!(self, Self::CapacityFailure { .. })
+    }
+}
+
 impl fmt::Display for RirPayloadBuildError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Self::ResourceLimitExceeded { family } => {
-                write!(f, "RIR {family} payload exceeds the u32 word-store limit")
+                write!(
+                    f,
+                    "RIR {family} exceeded the implementation limit of \
+                     {MAX_RIR_ENTRIES_PER_PROGRAM} per program (spec Appendix C.6:1)"
+                )
             }
             Self::CapacityFailure { family } => {
                 write!(f, "could not reserve storage for RIR {family} payload")
@@ -976,6 +1003,14 @@ pub struct Rir {
     instructions: Vec<Inst>,
     /// Extra data for variable-length instruction payloads.
     extra: Vec<u32>,
+    /// Set once `add_inst` is asked for an instruction beyond the published
+    /// `u32` instruction ceiling (spec Appendix C.6:1). `add_inst` is called
+    /// from hundreds of infallible lowering sites, so the ceiling is recorded
+    /// here and reported once at the construction/publication boundary
+    /// (`AstGen::try_finish_editor`, `RirEditor::capacity_error`) instead of
+    /// wrapping an `InstRef` onto the reserved null payload. Spec C.1:2
+    /// requires a diagnostic, not a wrapped index.
+    instruction_limit_exceeded: bool,
 }
 
 /// Mutable construction-phase owner. Payload descriptors never leave this
@@ -1090,6 +1125,15 @@ impl RirEditor {
     /// below, whose descriptors never escape the editor.
     pub fn add_inst(&mut self, inst: Inst) -> InstRef {
         self.rir.add_inst(inst)
+    }
+
+    /// The implementation-limit rejection latched by an infallible
+    /// [`Self::add_inst`] that ran past the published instruction ceiling
+    /// (spec Appendix C.6:1), if any. Publication boundaries consult this so
+    /// the ceiling becomes an `E1401` diagnostic rather than a wrapped
+    /// `InstRef` (spec C.1:2).
+    pub fn capacity_error(&self) -> Option<RirPayloadBuildError> {
+        self.rir.latched_capacity_error()
     }
 
     pub fn add_intrinsic(
@@ -1976,6 +2020,9 @@ impl RirEditor {
                     }
                 };
             }
+            if let Some(error) = self.rir.latched_capacity_error() {
+                return Err(error);
+            }
             let instruction_end = u32::try_from(self.rir.instructions.len()).map_err(|_| {
                 RirPayloadBuildError::ResourceLimitExceeded {
                     family: "instructions",
@@ -2089,18 +2136,36 @@ impl Rir {
     }
 
     /// Add an instruction and return its reference.
+    ///
+    /// `InstRef` is a `u32` whose maximum value is reserved as the null
+    /// payload, so indices `0..=u32::MAX - 1` are addressable and a program
+    /// holds at most [`MAX_RIR_ENTRIES_PER_PROGRAM`] instructions. Beyond that
+    /// the reference is not representable. This method has hundreds of
+    /// infallible callers across AST lowering, so instead of wrapping onto the
+    /// null payload (spec C.1:2 forbids that) it latches
+    /// `instruction_limit_exceeded` and hands back an already-valid reference;
+    /// the construction boundary turns the latch into an `E1401` diagnostic
+    /// before the RIR is published.
     pub(crate) fn add_inst(&mut self, inst: Inst) -> InstRef {
-        // Debug assertion for u32 overflow - catches pathological inputs during development
-        debug_assert!(
-            self.instructions.len() < u32::MAX as usize,
-            "RIR instruction count overflow: {} instructions exceeds u32::MAX - 1",
-            self.instructions.len()
-        );
-
-        let index = u32::try_from(self.instructions.len())
-            .expect("RIR instruction count checked before insertion");
+        let Ok(index) = u32::try_from(self.instructions.len()) else {
+            self.instruction_limit_exceeded = true;
+            return InstRef::from_raw(0);
+        };
+        if index == MAX_RIR_ENTRIES_PER_PROGRAM {
+            self.instruction_limit_exceeded = true;
+            return InstRef::from_raw(0);
+        }
         self.instructions.push(inst);
         InstRef::from_raw(index)
+    }
+
+    /// The implementation-limit rejection latched during construction, if the
+    /// instruction ceiling was reached. Checked at the publication boundary.
+    pub(crate) fn latched_capacity_error(&self) -> Option<RirPayloadBuildError> {
+        self.instruction_limit_exceeded
+            .then_some(RirPayloadBuildError::ResourceLimitExceeded {
+                family: "instructions",
+            })
     }
 
     /// Get an instruction by reference.
@@ -5463,6 +5528,64 @@ impl<'a, 'b> RirPrinter<'a, 'b> {
 impl fmt::Display for RirPrinter<'_, '_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}", self.to_string())
+    }
+}
+
+#[cfg(test)]
+mod resource_limit_tests {
+    use super::*;
+
+    #[test]
+    fn resource_limit_message_names_the_published_ceiling() {
+        // RUE-1221 / spec C.1:2: the diagnostic must name the exceeded limit.
+        let payload = RirPayloadBuildError::ResourceLimitExceeded {
+            family: "payload words",
+        };
+        let instructions = RirPayloadBuildError::ResourceLimitExceeded {
+            family: "instructions",
+        };
+        assert_eq!(
+            payload.to_string(),
+            "RIR payload words exceeded the implementation limit of 4294967295 per program \
+             (spec Appendix C.6:1)"
+        );
+        assert!(instructions.to_string().contains("RIR instructions"));
+        assert!(instructions.to_string().contains("4294967295"));
+    }
+
+    #[test]
+    fn build_failures_are_classified_for_the_user() {
+        assert!(RirPayloadBuildError::ResourceLimitExceeded { family: "f" }.is_resource_limit());
+        assert!(
+            !RirPayloadBuildError::ResourceLimitExceeded { family: "f" }.is_resource_exhaustion()
+        );
+        assert!(RirPayloadBuildError::CapacityFailure { family: "f" }.is_resource_exhaustion());
+        assert!(!RirPayloadBuildError::CapacityFailure { family: "f" }.is_resource_limit());
+        let invalid = RirPayloadBuildError::InvalidBuilderInput {
+            family: "f",
+            reason: "r",
+        };
+        assert!(!invalid.is_resource_limit());
+        assert!(!invalid.is_resource_exhaustion());
+    }
+
+    #[test]
+    fn instruction_capacity_latch_is_clear_for_an_ordinary_owner() {
+        let mut editor = RirEditor::new();
+        editor.add_inst(Inst {
+            data: InstData::IntConst(7),
+            span: Span::default(),
+        });
+        assert!(editor.capacity_error().is_none());
+    }
+
+    #[test]
+    fn published_instruction_ceiling_matches_the_addressable_index_space() {
+        // `InstRef` reserves `u32::MAX` as the null payload, so the last
+        // addressable index is `u32::MAX - 1` and the capacity is exactly the
+        // published ceiling (spec Appendix C.6:1).
+        assert_eq!(MAX_RIR_ENTRIES_PER_PROGRAM, u32::MAX);
+        assert_eq!(u64::from(MAX_RIR_ENTRIES_PER_PROGRAM), 4_294_967_295);
     }
 }
 

--- a/crates/rue-rir/src/lib.rs
+++ b/crates/rue-rir/src/lib.rs
@@ -29,13 +29,13 @@ mod inst;
 pub use anonymous_sites::{AnonymousTypeSite, AnonymousTypeSiteKind, anonymous_type_sites};
 pub use astgen::AstGen;
 pub use inst::{
-    Inst, InstData, InstRef, InternalIntrinsic, RIR_PAYLOAD_FAMILY_NAMES, RepeatCount, Rir,
-    RirAnonEnumPayloadsRange, RirAnonEnumVariantsRange, RirAnonStructFieldsRange,
-    RirAnonStructMethodsRange, RirArgMode, RirArrayElemsRange, RirBlockInstsRange, RirCallArg,
-    RirCallArgsRange, RirDirective, RirDirectiveView, RirDirectivesRange, RirEditor,
-    RirEnumPayloads, RirEnumPayloadsRange, RirEnumVariantsRange, RirFieldInitsRange,
-    RirInternalIntrinsicArgsRange, RirIntrinsicArgsRange, RirMatchArmsRange, RirParam,
-    RirParamMode, RirParamsRange, RirPattern, RirPatternView, RirPayloadBuildError,
+    Inst, InstData, InstRef, InternalIntrinsic, MAX_RIR_ENTRIES_PER_PROGRAM,
+    RIR_PAYLOAD_FAMILY_NAMES, RepeatCount, Rir, RirAnonEnumPayloadsRange, RirAnonEnumVariantsRange,
+    RirAnonStructFieldsRange, RirAnonStructMethodsRange, RirArgMode, RirArrayElemsRange,
+    RirBlockInstsRange, RirCallArg, RirCallArgsRange, RirDirective, RirDirectiveView,
+    RirDirectivesRange, RirEditor, RirEnumPayloads, RirEnumPayloadsRange, RirEnumVariantsRange,
+    RirFieldInitsRange, RirInternalIntrinsicArgsRange, RirIntrinsicArgsRange, RirMatchArmsRange,
+    RirParam, RirParamMode, RirParamsRange, RirPattern, RirPatternView, RirPayloadBuildError,
     RirPayloadError, RirPayloadStorageStats, RirPrinter, RirStructFieldsRange,
     RirStructMethodsRange, RirStructuralAnchor, RirStructuralPathSegment, RirValidationContext,
     ValidatedRir,

--- a/docs/spec/src/appendices/C-implementation-limits.md
+++ b/docs/spec/src/appendices/C-implementation-limits.md
@@ -47,7 +47,7 @@ A single source file is limited to 4,294,967,295 bytes — one byte short of 4 G
 
 {{ rule(id="C.3:2") }}
 
-The span representation that bounds it is `rue_span::Span`: a file identifier plus a `u32` start offset and a `u32` end offset. The file identifier is itself a `u32` (`rue_span::FileId`), with `FileId(0)` reserved for the default/unknown file, so a single compilation can distinguish at most 4,294,967,295 source files.
+The span representation that bounds it is `rue_span::Span`: a file identifier plus a `u32` start offset and a `u32` end offset. The file identifier is itself a `u32` (`rue_span::FileId`), with `FileId(0)` reserved for the default/unknown file, so a single compilation can distinguish at most 4,294,967,295 source files. Import discovery numbers the files it reaches densely from `FileId(1)` and rejects a larger compilation with a resource-limit diagnostic (E1401) before the count is narrowed to a `u32`, so two sources can never receive the same identifier.
 
 ## Array Limits
 
@@ -75,6 +75,8 @@ Exceeding it is rejected with diagnostic E0907.
 
 There is no separate cap on the length of one identifier: an identifier is a token, so its length is bounded by the source-file limit of C.3:1. The number of *distinct* identifiers and string literals in one compilation is bounded by the string interner, whose handles are non-zero 32-bit keys: at most 4,294,967,295 distinct interned strings.
 
+Identifiers and string literals are the only unbounded, source-driven producers of interned strings, and both are interned by the lexer. The lexer interns fallibly: a token whose string cannot be given a key is reported through the ordinary lexical error channel as a resource-limit diagnostic (E1401) naming the limit, so the key space is never exhausted by an abort. Every other interned string is a name the compiler synthesizes for an entity it has already admitted (mangled symbols, anonymous-type names, specialization names), and those entities are themselves bounded by the capacity limits of C.6:1.
+
 ## Implementation Capacity Limits
 
 {{ rule(id="C.6:1") }}
@@ -83,24 +85,26 @@ The compiler stores syntax, untyped IR, and typed IR in compact index-based form
 
 | Construct | Limit | Bounded by | Diagnosed by |
 |-----------|-------|------------|--------------|
-| Source bytes in one file | 4,294,967,295 | `u32` span offsets | E1401 |
-| Source files in one compilation | 4,294,967,295 | `u32` file identifier, `FileId(0)` reserved | not checked |
-| Distinct identifiers and string literals | 4,294,967,295 | non-zero `u32` interner keys | not checked |
-| IR instructions in one program | 4,294,967,295 | `u32` instruction reference, `u32::MAX` reserved as the null payload | not checked |
-| IR payload words in one program | 4,294,967,295 words (16 GiB) | `u32` payload `start`/`extent` into one word store | not checked |
-| Parameters of one function | 613,566,756 | 7 payload words per parameter | not checked |
-| Fields of one struct | 2,147,483,647 | 2 payload words per field | not checked |
-| Arguments of one call | 2,147,483,647 | 2 payload words per argument | not checked |
-| Variants of one enum | 4,294,967,295 | 1 payload word per variant; the discriminant tag widens to at most `u32` | not checked |
-| Elements of one array literal | 4,294,967,295 | 1 payload word per element | not checked |
-| Distinct composite types (structs, enums, arrays, pointers, modules) | 16,777,216 | `Type` is a `u32`: an 8-bit kind tag plus a 24-bit type-pool index | not checked |
+| Source bytes in one file | 4,294,967,295 | `u32` span offsets | E1401, before lexing |
+| Source files in one compilation | 4,294,967,295 | `u32` file identifier, `FileId(0)` reserved | E1401, at snapshot assembly |
+| Distinct identifiers and string literals | 4,294,967,295 | non-zero `u32` interner keys | E1401, when a token is interned |
+| IR instructions in one program | 4,294,967,295 | `u32` instruction reference, `u32::MAX` reserved as the null payload | E1401, at RIR publication |
+| IR payload words in one program | 4,294,967,295 words (16 GiB) | `u32` payload `start`/`extent` into one word store | E1401, at RIR/CFG payload staging |
+| Parameters of one function | 613,566,756 | 7 payload words per parameter | E1401, via the shared word store |
+| Fields of one struct | 2,147,483,647 | 2 payload words per field | E1401, via the shared word store |
+| Arguments of one call | 2,147,483,647 | 2 payload words per argument | E1401, via the shared word store |
+| Variants of one enum | 4,294,967,295 | 1 payload word per variant; the discriminant tag widens to at most `u32` | E1401, via the shared word store |
+| Elements of one array literal | 4,294,967,295 | 1 payload word per element | E1401, via the shared word store |
+| Distinct composite types (structs, enums, arrays, pointers, modules) | 16,777,216 | `Type` is a `u32`: an 8-bit kind tag plus a 24-bit type-pool index | E1401, at the semantic boundary |
 | Size of one object | 2,147,483,647 bytes | signed 32-bit frame displacement | E0906 |
 | Cumulative storage of one function | 2,147,483,632 bytes | signed 32-bit frame displacement, 16-byte aligned | E0907 |
 | Syntactic nesting depth | 256 | guarded recursion depth in the parser and RIR lowering | E0482 |
 
 {{ rule(id="C.6:2") }}
 
-"Not checked" in the table above means the ceiling follows from the representation but the compiler does not yet report it as a diagnostic; reaching one of those ceilings today is a defect against C.1:2, not a licensed behavior. The ceilings are also not independent: parameters, fields, variants, arguments, and array elements all draw on the same per-program word store, so the sum of every payload in a program cannot exceed 4,294,967,295 words even when no individual construct does.
+The ceilings are not independent: parameters, fields, variants, arguments, and array elements all draw on the same per-program word store, so the sum of every payload in a program cannot exceed 4,294,967,295 words even when no individual construct does. That shared store is also what diagnoses them — a payload range that no longer fits `(start: u32, extent: u32)` is rejected when it is staged, whichever construct requested it.
+
+The "Diagnosed by" column names where each check runs, because the compact stores are filled by construction paths that cannot themselves fail. Instructions and composite types are the two such paths: `add_inst` and type interning are called from hundreds of infallible sites, so instead of returning an error at each one, the owner records that its ceiling was reached, stops growing, and the next construction or semantic boundary converts that record into the E1401 diagnostic. No index is ever wrapped, no entry is ever silently dropped in a compilation that goes on to be published, and no artifact built past a ceiling reaches code generation.
 
 {{ rule(id="C.6:3", cat="normative") }}
 

--- a/scripts/validate-debug-assert-policy.py
+++ b/scripts/validate-debug-assert-policy.py
@@ -59,7 +59,7 @@ ALLOWANCES = {
     "crates/rue-oracle/src/lib.rs": Allowance(2, "oracle harness bookkeeping checks, not compiler correctness gates"),
     "crates/rue-parser/src/parser/shared.rs": Allowance(2, "redundant parser entry preconditions"),
     "crates/rue-parser/src/parser/statements.rs": Allowance(1, "redundant parser entry precondition"),
-    "crates/rue-rir/src/inst.rs": Allowance(2, "redundant RIR variable-width encoding checks"),
+    "crates/rue-rir/src/inst.rs": Allowance(1, "redundant RIR variable-width encoding check"),
     "crates/rue-span/src/lib.rs": Allowance(1, "redundant span construction bounds check"),
     "crates/rue/src/emit.rs": Allowance(1, "validated sole-dependency emit mode"),
     "crates/rue/src/source_loader.rs": Allowance(1, "redundant source-plan revision check"),


### PR DESCRIPTION
RUE-1180 published Appendix C's capacity table with normative C.1:2 (exceeding an implementation limit is a diagnosable failure, never wraparound or an abort) and left several rows honestly marked "not checked". This closes every one — and the unreachability escape hatch turned out to apply to none of them: the arithmetic disproved each hypothesis (16.7M composite types ≈ 218 MB of source, well inside the 4 GiB file ceiling; instruction and interner exhaustion are unbounded across files), so every row got a real check.

- **RIR payload/capacity failures** classify as E1401/E1402 instead of collapsing into E9000, at both the per-module editor and the whole-program merge where the ceilings actually trip. The `AstGen::finish` panics are proven test-only by call-site audit.
- **Type-pool 24-bit capacity** no longer panics: the pool latches at capacity and reports E1401 at the per-body CFG materialization boundary (on every compilation path), rather than threading `Result` through ~85 infallible registration sites. Reads stay in-range by construction; kind-checked lookups degrade aliased handles to `None`.
- **Instruction count**: the release-build defect was worse than filed — `u32::try_from` *succeeds* at `u32::MAX`, silently aliasing the null-payload sentinel. `Rir::add_inst` now latches; the debug-assert ledger is decremented accordingly.
- **Source-file count** is validated before the truncating `FileId::new((index + 1) as u32)` cast (a real aliasing defect found while proving the row reachable), on both snapshot-assembly routes.
- **Interner exhaustion** is exactly fallible via `try_get_or_intern` at the lexer's two interning sites — a first-cut conservative preflight was rejected mid-implementation because it would spuriously refuse legal programs near the ceiling.
- **`CfgEditError`** gained `Display` and an E1401/E1402/E9000 classification at all four sites that previously `{:?}`-formatted it into an ICE.

Appendix C's rows now name where each check runs; no new rule IDs, traceability unchanged. Net effect on the fuzz ICE surface is strictly smaller (several former E9000 emissions are now resource diagnostics; `is_ice` verified closed over the ICE kinds).

Fixes RUE-1221.

Three same-class residuals found and being filed as a follow-up: `Air::push_inst`'s per-body `len() as u32`, CFG `BlockId`/`CfgValue` per-function index casts (no Appendix C rows exist for those yet), and the type-pool latch window where the `&`-returning internal accessors can still panic on a kind mismatch before the boundary check lands.

## Validation

Premerge (78/78), full spec (2242) + appendices (22) + traceability unchanged, units: air 680 / compiler 777 (786 post-rebase) / rir 68 / cfg 239 / lexer 60 / parser 47 / fuzz 95, CLI `abi`, clippy ×2, fmt, debug-assert-policy and API-inventory gates both updated and green, plus an end-to-end smoke compile.

---
_Generated by [Claude Code](https://claude.ai/code/session_01DrKqpQgkHzDHGqpEMjxYdN)_