### PR TITLE
RUE-1230: retain reached backend query cones

### DIFF
--- a/crates/rue-compiler/src/pipeline_tests.rs
+++ b/crates/rue-compiler/src/pipeline_tests.rs
@@ -18,6 +18,16 @@ mod tests {
         SourceSnapshot::new(metadata, vec![(file_id, Arc::new(source.to_owned()))]).unwrap()
     }
 
+    fn wide_reached_program(functions: usize, leaf_value: i32) -> SourceSnapshot {
+        assert!(functions > 0);
+        let mut source = format!("fn f0() -> i32 {{ {leaf_value} }} ");
+        for index in 1..functions {
+            source.push_str(&format!("fn f{index}() -> i32 {{ f{}() }} ", index - 1));
+        }
+        source.push_str(&format!("fn main() -> i32 {{ f{}() }}", functions - 1));
+        SourceSnapshot::single("<wide-backend-root>", source).unwrap()
+    }
+
     #[cfg(unix)]
     fn execute_compiled_output(output: &CompileOutput, label: &str) -> std::process::Output {
         use std::os::unix::fs::PermissionsExt;
@@ -246,6 +256,304 @@ mod tests {
         );
         assert!(execution.stdout.is_empty());
         assert!(execution.stderr.is_empty());
+    }
+
+    #[test]
+    fn published_backend_root_keeps_wide_no_edit_and_single_edit_builds_exactly_warm() {
+        const CHAIN_FUNCTIONS: usize = 33;
+        const REACHED_FUNCTIONS: usize = CHAIN_FUNCTIONS + 1;
+        let before = wide_reached_program(CHAIN_FUNCTIONS, 1);
+        let after = wide_reached_program(CHAIN_FUNCTIONS, 2);
+        let options = CompileOptions::default();
+        let mut session = CompilerSession::new();
+
+        session
+            .update_for_presentation(&before)
+            .into_result()
+            .unwrap();
+        crate::queries::compile_with_session(&mut session, &before, &options).unwrap();
+        let cold_root = session.backend_root_metrics();
+        assert_eq!(cold_root.functions, REACHED_FUNCTIONS, "{cold_root:?}");
+        assert_eq!(cold_root.cfg_terminals, REACHED_FUNCTIONS, "{cold_root:?}");
+        assert_eq!(
+            cold_root.optimized_cfg_terminals, REACHED_FUNCTIONS,
+            "{cold_root:?}"
+        );
+        assert_eq!(
+            cold_root.codegen_unit_terminals, REACHED_FUNCTIONS,
+            "{cold_root:?}"
+        );
+
+        let no_edit =
+            crate::queries::compile_with_session(&mut session, &before, &options).unwrap();
+        assert_eq!(session.rooted_cfg_executions().len(), REACHED_FUNCTIONS);
+        assert!(
+            session
+                .rooted_cfg_executions()
+                .iter()
+                .all(|(_, execution)| *execution == rue_query::RequestExecution::Reused),
+            "{:?}",
+            session.rooted_cfg_executions()
+        );
+        assert_eq!(session.codegen_executions().len(), REACHED_FUNCTIONS);
+        assert!(
+            session
+                .codegen_executions()
+                .iter()
+                .all(|(_, execution)| *execution == rue_query::RequestExecution::Reused),
+            "{:?}",
+            session.codegen_executions()
+        );
+
+        session
+            .update_for_presentation(&after)
+            .into_result()
+            .unwrap();
+        let warm = crate::queries::compile_with_session(&mut session, &after, &options).unwrap();
+        assert_eq!(
+            session
+                .rooted_cfg_executions()
+                .iter()
+                .filter(|(_, execution)| *execution == rue_query::RequestExecution::Computed)
+                .count(),
+            1,
+            "{:?}",
+            session.rooted_cfg_executions()
+        );
+        assert_eq!(
+            session
+                .codegen_executions()
+                .iter()
+                .filter(|(_, execution)| *execution == rue_query::RequestExecution::Computed)
+                .count(),
+            1,
+            "{:?}",
+            session.codegen_executions()
+        );
+        let edited_root = session.backend_root_metrics();
+        assert_eq!(edited_root.functions, REACHED_FUNCTIONS, "{edited_root:?}");
+
+        let mut fresh = CompilerSession::new();
+        fresh.update_for_presentation(&after).into_result().unwrap();
+        let expected = crate::queries::compile_with_session(&mut fresh, &after, &options).unwrap();
+        assert_eq!(warm.elf, expected.elf);
+        assert_eq!(warm.warnings, expected.warnings);
+        assert_ne!(no_edit.elf, warm.elf);
+    }
+
+    #[test]
+    fn published_backend_root_releases_unreachable_functions_after_successful_handoff() {
+        const CHAIN_FUNCTIONS: usize = 33;
+        const REACHED_FUNCTIONS: usize = CHAIN_FUNCTIONS + 1;
+        let before = wide_reached_program(CHAIN_FUNCTIONS, 1);
+        let after =
+            SourceSnapshot::single("<wide-backend-root>", "fn main() -> i32 { 7 }").unwrap();
+        let options = CompileOptions::default();
+        let mut session = CompilerSession::new();
+
+        session
+            .update_for_presentation(&before)
+            .into_result()
+            .unwrap();
+        crate::queries::compile_with_session(&mut session, &before, &options).unwrap();
+        let before_root = session.backend_root_metrics();
+        assert_eq!(before_root.functions, REACHED_FUNCTIONS, "{before_root:?}");
+
+        session
+            .update_for_presentation(&after)
+            .into_result()
+            .unwrap();
+        crate::queries::compile_with_session(&mut session, &after, &options).unwrap();
+        let after_root = session.backend_root_metrics();
+        assert_eq!(after_root.functions, 1, "{after_root:?}");
+        assert_eq!(after_root.cfg_terminals, 1, "{after_root:?}");
+        assert_eq!(after_root.optimized_cfg_terminals, 1, "{after_root:?}");
+        assert_eq!(after_root.codegen_unit_terminals, 1, "{after_root:?}");
+        assert_eq!(
+            after_root.deletions - before_root.deletions,
+            (REACHED_FUNCTIONS - 1) as u64,
+            "{before_root:?}\n{after_root:?}"
+        );
+
+        let evictions_before_pressure = session.query_evictions_for_test();
+        for value in 100..116 {
+            let pressure = SourceSnapshot::single(
+                "<wide-backend-root>",
+                format!("fn main() -> i32 {{ {value} }}"),
+            )
+            .unwrap();
+            session
+                .update_for_presentation(&pressure)
+                .into_result()
+                .unwrap();
+            crate::queries::compile_with_session(&mut session, &pressure, &options).unwrap();
+        }
+        assert!(
+            session.query_evictions_for_test() > evictions_before_pressure,
+            "the released chain must face real query-family eviction pressure"
+        );
+
+        session
+            .update_for_presentation(&before)
+            .into_result()
+            .unwrap();
+        crate::queries::compile_with_session(&mut session, &before, &options).unwrap();
+        assert_eq!(session.rooted_cfg_executions().len(), REACHED_FUNCTIONS);
+        assert!(
+            session
+                .rooted_cfg_executions()
+                .iter()
+                .all(|(_, execution)| *execution == rue_query::RequestExecution::Computed),
+            "released CFGs should recompute after re-entry: {:?}",
+            session.rooted_cfg_executions()
+        );
+        assert_eq!(session.codegen_executions().len(), REACHED_FUNCTIONS);
+        assert!(
+            session
+                .codegen_executions()
+                .iter()
+                .all(|(_, execution)| *execution == rue_query::RequestExecution::Computed),
+            "released codegen units should recompute after re-entry: {:?}",
+            session.codegen_executions()
+        );
+    }
+
+    #[test]
+    fn failed_and_canceled_backend_collections_preserve_the_last_good_root() {
+        let before =
+            SourceSnapshot::single("<backend-root-control>", "fn main() -> i32 { 0 }").unwrap();
+        let failing =
+            SourceSnapshot::single("<backend-root-control>", "fn main() -> i32 { 1 }").unwrap();
+        let options = CompileOptions::default();
+        let mut session = CompilerSession::new();
+        session
+            .update_for_presentation(&before)
+            .into_result()
+            .unwrap();
+        crate::queries::compile_with_session(&mut session, &before, &options).unwrap();
+        let last_good = session.backend_root_metrics();
+
+        session
+            .update_for_presentation(&failing)
+            .into_result()
+            .unwrap();
+        crate::codegen_query::with_test_codegen_failure_injection(|| {
+            assert!(
+                session
+                    .rooted_codegen(&options, rue_codegen::BackendArtifactRequest::default())
+                    .is_err()
+            );
+        });
+        assert_eq!(session.backend_root_metrics(), last_good);
+
+        let recovered =
+            SourceSnapshot::single("<backend-root-control>", "fn main() -> i32 { 2 }").unwrap();
+        session
+            .update_for_presentation(&recovered)
+            .into_result()
+            .unwrap();
+        let (owner, joiner) = session.exercise_codegen_schedule_for_test(&options, true);
+        assert_eq!(owner, rue_query::RequestExecution::Computed);
+        assert_eq!(joiner, rue_query::RequestExecution::Aborted);
+        assert_eq!(session.backend_root_metrics(), last_good);
+
+        crate::queries::compile_with_session(&mut session, &recovered, &options).unwrap();
+        let recovered_root = session.backend_root_metrics();
+        assert_eq!(recovered_root.functions, 1, "{recovered_root:?}");
+        assert_eq!(recovered_root.publications, last_good.publications + 1);
+    }
+
+    #[test]
+    fn published_backend_root_explicitly_retains_accessor_raw_cfg_dependencies() {
+        let snapshot = SourceSnapshot::single(
+            "<backend-root-accessor>",
+            "struct P { x: i64, fn value(borrow self) -> borrow i64 { yield self.x; } } \
+             fn helper() -> i64 { 1 } \
+             fn main() -> i32 { let p = P { x: 7 }; if p.value() + helper() == 8 { 0 } else { 1 } }",
+        )
+        .unwrap();
+        let mut options = CompileOptions::default();
+        options
+            .preview_features
+            .insert(rue_error::PreviewFeature::BorrowAccessors);
+        let mut session = CompilerSession::new();
+        session
+            .update_for_presentation(&snapshot)
+            .into_result()
+            .unwrap();
+        crate::queries::compile_with_session(&mut session, &snapshot, &options).unwrap();
+
+        let root = session.backend_root_metrics();
+        assert_eq!(
+            root.functions, 2,
+            "accessor has no standalone unit: {root:?}"
+        );
+        assert_eq!(root.optimized_cfg_terminals, 2, "{root:?}");
+        assert_eq!(root.codegen_unit_terminals, 2, "{root:?}");
+        assert_eq!(
+            root.cfg_terminals, 3,
+            "main's spliced accessor CFG must be retained explicitly: {root:?}"
+        );
+
+        let inspected = session.rooted_cfg(&options).unwrap();
+        let accessor_raw_cfg = inspected
+            .cfgs
+            .iter()
+            .find(|unit| {
+                matches!(
+                    &unit.function,
+                    FunctionInstanceKey::Definition(definition) if definition.name() == "main"
+                )
+            })
+            .and_then(|unit| unit.optimized_cfg_key.accessor_dependencies.first())
+            .cloned()
+            .expect("main's optimized CFG records the accessor raw-CFG dependency");
+        drop(inspected);
+        assert!(session.backend_cfg_key_is_retained(&accessor_raw_cfg));
+
+        let evictions_before_pressure = session.query_evictions_for_test();
+        for value in 100..116 {
+            let pressure = SourceSnapshot::single(
+                "<backend-root-accessor-pressure>",
+                format!("fn main() -> i32 {{ {value} }}"),
+            )
+            .unwrap();
+            session
+                .update_for_presentation(&pressure)
+                .into_result()
+                .unwrap();
+            drop(session.rooted_cfg(&options).unwrap());
+        }
+        assert!(
+            session.query_evictions_for_test() > evictions_before_pressure,
+            "the accessor dependency must face real raw-CFG eviction pressure"
+        );
+        assert!(
+            session.backend_cfg_key_is_retained(&accessor_raw_cfg),
+            "the published backend cone must keep the exact raw accessor CFG retained"
+        );
+
+        session
+            .update_for_presentation(&snapshot)
+            .into_result()
+            .unwrap();
+        crate::queries::compile_with_session(&mut session, &snapshot, &options).unwrap();
+        assert!(
+            session
+                .rooted_cfg_executions()
+                .iter()
+                .all(|(_, execution)| *execution == rue_query::RequestExecution::Reused),
+            "the accessor-dependent optimized CFGs should stay reusable: {:?}",
+            session.rooted_cfg_executions()
+        );
+        assert!(
+            session
+                .codegen_executions()
+                .iter()
+                .all(|(_, execution)| *execution == rue_query::RequestExecution::Reused),
+            "the accessor-dependent codegen units should stay reusable: {:?}",
+            session.codegen_executions()
+        );
     }
 
     /// Opt-in Phase 12 latency witness. This deliberately has no pass/fail

--- a/crates/rue-compiler/src/revisioned_query_database.rs
+++ b/crates/rue-compiler/src/revisioned_query_database.rs
@@ -7,7 +7,7 @@
 //! 12 registers each family directly with the runtime; native selection roots
 //! retain the current and last-good terminals.
 
-use std::collections::{BTreeMap, BTreeSet, HashMap, VecDeque};
+use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet, VecDeque};
 use std::ops::Deref;
 use std::rc::Rc;
 use std::sync::{Arc, Mutex};
@@ -400,6 +400,7 @@ pub(crate) struct RevisionedQueryDatabase {
         crate::codegen_query::CodegenUnitQueryKey,
         crate::codegen_query::CodegenUnitValue,
     >,
+    backend_root_publications: QueryFamily<BackendRootPublicationKey, bool>,
     /// One-shot rendezvous inside the registered CodegenUnit evaluator. Unit
     /// tests use it to force an exact-key owner to remain live while a second
     /// request joins or cancels. It changes scheduling only: both requests still
@@ -496,6 +497,14 @@ pub(crate) struct RevisionedQueryDatabase {
     body_closure_root: Arc<Mutex<PublishedBodyClosureRoot>>,
     #[allow(dead_code)]
     body_reachability_root: Arc<Mutex<PublishedBodyReachabilityRoot>>,
+    /// The exact backend terminal cone selected by the latest successful
+    /// rooted codegen collection. The candidate set is populated while each
+    /// request lease is still live, then installed before the predecessor is
+    /// released so programs wider than the family retention floor stay warm.
+    #[cfg_attr(not(test), allow(dead_code))]
+    backend_root: Arc<Mutex<PublishedBackendRoot>>,
+    backend_root_publication_gate: BackendRootPublicationGate,
+    next_backend_root_epoch: std::sync::atomic::AtomicU64,
     /// Session-scoped injection shared with structured body-query children.
     /// Keeping it on the database avoids both thread-local scheduler escapes
     /// and cross-test interference between independent compiler sessions.
@@ -977,7 +986,7 @@ struct PublishedBodyClosureLookupRollback {
 
 #[derive(Debug, Default)]
 struct PublishedBodyClosureRoot {
-    lease: rue_query::RetainedPinSet,
+    lease: Arc<rue_query::RetainedPinSet>,
     reached: BTreeSet<crate::FunctionInstanceKey>,
     additions: u64,
     deletions: u64,
@@ -985,13 +994,147 @@ struct PublishedBodyClosureRoot {
 
 #[derive(Debug, Default)]
 struct PublishedBodyReachabilityRoot {
+    lease: Arc<rue_query::RetainedPinSet>,
+}
+
+/// One in-flight rooted backend collection. Merely collecting or pinning a
+/// terminal cannot alter the session's published root: only
+/// [`RevisionedQueryDatabase::publish_backend_root`] installs this candidate.
+/// Dropping a failed, canceled, or speculative collection releases only its
+/// candidate pins and leaves the last successful root untouched.
+#[derive(Debug, Default)]
+pub(crate) struct BackendRootCandidate {
     lease: rue_query::RetainedPinSet,
+    functions: BTreeSet<crate::FunctionInstanceKey>,
+    cfg_keys: HashSet<crate::cfg_query::CfgQueryKey>,
+    optimized_cfg_terminals: usize,
+    codegen_unit_terminals: usize,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+struct BackendRootPublicationKey {
+    epoch: u64,
+    codegen_units: Arc<[crate::codegen_query::CodegenUnitQueryKey]>,
+    functions: Arc<[crate::FunctionInstanceKey]>,
+    cfg_terminals: usize,
+}
+
+#[derive(Debug, Default)]
+struct BackendRootPublicationGate(Mutex<()>);
+
+impl BackendRootPublicationGate {
+    fn enter(&self) -> std::sync::MutexGuard<'_, ()> {
+        self.0
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+    }
+}
+
+impl QueryKey for BackendRootPublicationKey {
+    fn stable_identity(&self) -> String {
+        format!(
+            "backend-root;epoch={};units={}",
+            self.epoch,
+            self.codegen_units.len()
+        )
+    }
+}
+
+#[derive(Debug, Default)]
+struct PublishedBackendRoot {
+    #[allow(dead_code)] // Owning the set is the retention root.
+    lease: Arc<rue_query::RetainedPinSet>,
+    functions: BTreeSet<crate::FunctionInstanceKey>,
+    #[allow(dead_code)]
+    cfg_terminals: usize,
+    #[allow(dead_code)]
+    optimized_cfg_terminals: usize,
+    #[allow(dead_code)]
+    codegen_unit_terminals: usize,
+    publications: u64,
+    additions: u64,
+    deletions: u64,
+}
+
+#[derive(Debug)]
+struct PublishedBackendRootHandoff {
+    root: Arc<Mutex<PublishedBackendRoot>>,
+    pending: Option<Arc<rue_query::RetainedPinSet>>,
+    functions: Option<BTreeSet<crate::FunctionInstanceKey>>,
+    cfg_terminals: usize,
+    optimized_cfg_terminals: usize,
+    codegen_unit_terminals: usize,
+    previous: Option<PublishedBackendRoot>,
+    installed: bool,
+}
+
+impl rue_query::QueryAttemptHandoff for PublishedBackendRootHandoff {
+    fn commit(&mut self) {
+        let pending = self
+            .pending
+            .take()
+            .expect("backend-root handoff commits at most once");
+        let functions = self
+            .functions
+            .take()
+            .expect("backend-root handoff retains exact membership");
+        let mut root = self
+            .root
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let additions = functions.difference(&root.functions).count() as u64;
+        let deletions = root.functions.difference(&functions).count() as u64;
+        let next = PublishedBackendRoot {
+            lease: pending,
+            functions,
+            cfg_terminals: self.cfg_terminals,
+            optimized_cfg_terminals: self.optimized_cfg_terminals,
+            codegen_unit_terminals: self.codegen_unit_terminals,
+            publications: root.publications.saturating_add(1),
+            additions: root.additions.saturating_add(additions),
+            deletions: root.deletions.saturating_add(deletions),
+        };
+        self.previous = Some(std::mem::replace(&mut *root, next));
+        self.installed = true;
+    }
+
+    fn abort(&mut self) {
+        if self.installed {
+            let mut root = self
+                .root
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
+            let previous = self
+                .previous
+                .take()
+                .expect("an installed backend root retains its predecessor");
+            let installed = std::mem::replace(&mut *root, previous);
+            self.pending = Some(installed.lease);
+            self.functions = Some(installed.functions);
+            self.installed = false;
+        } else {
+            drop(self.pending.take());
+            drop(self.functions.take());
+        }
+    }
+}
+
+#[cfg(test)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct PublishedBackendRootMetrics {
+    pub(crate) functions: usize,
+    pub(crate) cfg_terminals: usize,
+    pub(crate) optimized_cfg_terminals: usize,
+    pub(crate) codegen_unit_terminals: usize,
+    pub(crate) publications: u64,
+    pub(crate) additions: u64,
+    pub(crate) deletions: u64,
 }
 
 #[derive(Debug)]
 struct PublishedBodyReachabilityTerminalHandoff {
     root: Arc<Mutex<PublishedBodyReachabilityRoot>>,
-    pending: Option<rue_query::RetainedPinSet>,
+    pending: Option<Arc<rue_query::RetainedPinSet>>,
     previous: Option<PublishedBodyReachabilityRoot>,
     installed: bool,
 }
@@ -1035,7 +1178,7 @@ impl rue_query::QueryAttemptHandoff for PublishedBodyReachabilityTerminalHandoff
 #[derive(Debug)]
 struct PublishedBodyClosureTerminalHandoff {
     root: Arc<Mutex<PublishedBodyClosureRoot>>,
-    pending: Option<rue_query::RetainedPinSet>,
+    pending: Option<Arc<rue_query::RetainedPinSet>>,
     pending_reached: Option<BTreeSet<crate::FunctionInstanceKey>>,
     previous: Option<PublishedBodyClosureRoot>,
     installed: bool,
@@ -13963,6 +14106,58 @@ impl RevisionedQueryDatabase {
         let lookup_root_lease = Arc::new(Mutex::new(PublishedRootLookupLease::default()));
         let body_closure_root = Arc::new(Mutex::new(PublishedBodyClosureRoot::default()));
         let body_reachability_root = Arc::new(Mutex::new(PublishedBodyReachabilityRoot::default()));
+        let backend_root = Arc::new(Mutex::new(PublishedBackendRoot::default()));
+        let codegen_units_for_backend_publication = codegen_units.clone();
+        let backend_root_for_publication = backend_root.clone();
+        let backend_root_publications = runtime
+            .family_with_equality_and_evaluator(
+                "compiler.backend-root-publication",
+                1,
+                |left: &bool, right: &bool| left == right,
+                move |context, _, key: &BackendRootPublicationKey| {
+                    let _validated_registered = context.endorse_registered_validations();
+                    let fallback = backend_root_for_publication
+                        .lock()
+                        .unwrap_or_else(std::sync::PoisonError::into_inner)
+                        .lease
+                        .clone();
+                    let mut terminals = Vec::with_capacity(key.codegen_units.len());
+                    for codegen_key in key.codegen_units.iter() {
+                        let terminal = context.query_registered(
+                            &codegen_units_for_backend_publication,
+                            codegen_key.clone(),
+                        )?;
+                        let rue_query::QueryOutcome::Success(value) = terminal.outcome() else {
+                            unreachable!("CodegenUnit publishes typed terminals")
+                        };
+                        if matches!(value, crate::codegen_query::CodegenUnitValue::Failure(_)) {
+                            return Ok(QueryOutput::success(false)
+                                .with_terminal_kind(QueryTerminalKind::Failure));
+                        }
+                        terminals.push(terminal);
+                    }
+                    let pending = context
+                        .retain_observed_terminal_cones_from(
+                            &terminals,
+                            std::slice::from_ref(&fallback),
+                        )
+                        .expect(
+                            "registered backend-root validation observes every final CodegenUnit dependency cone",
+                        );
+                    context.register_attempt_handoff(PublishedBackendRootHandoff {
+                        root: backend_root_for_publication.clone(),
+                        pending: Some(Arc::new(pending)),
+                        functions: Some(key.functions.iter().cloned().collect()),
+                        cfg_terminals: key.cfg_terminals,
+                        optimized_cfg_terminals: key.codegen_units.len(),
+                        codegen_unit_terminals: key.codegen_units.len(),
+                        previous: None,
+                        installed: false,
+                    });
+                    Ok(QueryOutput::success(true))
+                },
+            )
+            .expect("the backend-root publication family has one canonical name");
         #[cfg(test)]
         let inject_body_transaction_failure = Arc::new(std::sync::atomic::AtomicBool::new(false));
         let transactions_for_analysis_bundle = body_transactions.clone();
@@ -14874,7 +15069,6 @@ impl RevisionedQueryDatabase {
             .expect("the BodyClosure family has one canonical name");
         let closures_for_publication = body_closures.clone();
         let reachability_for_publication = body_reachability.clone();
-        let bundles_for_closure_publication = body_analysis_bundles.clone();
         let names_for_closure_publication = lookup_names.clone();
         let imports_for_closure_publication = lookup_imports.clone();
         let lease_for_closure_publication = lookup_root_lease.clone();
@@ -14927,38 +15121,24 @@ impl RevisionedQueryDatabase {
                                     &bundle.transaction,
                                     crate::body_query::BodyTransaction::DeterministicFailure { .. }
                                 )
-                            });
+                        });
                         if closure.kind() == QueryTerminalKind::Success {
-                            let pending = match context.retain_observed_terminal_cone(&closure) {
-                                Ok(pending) => pending,
-                                Err(rue_query::RetainTerminalConeError::DependencyNotObserved(
-                                    _,
-                                )) => {
-                                    // When every reached body stays green, the
-                                    // reused closure carries its bundle
-                                    // terminals without observing them in this
-                                    // publication task. Re-observe those exact
-                                    // carried keys before transferring the
-                                    // closure's retention cone.
-                                    for body in output.bodies.iter() {
-                                        context.query_registered(
-                                            &bundles_for_closure_publication,
-                                            body.key.clone(),
-                                        )?;
-                                    }
-                                    context
-                                        .retain_observed_terminal_cone(&closure)
-                                        .expect(
-                                            "registered closure validation retains its exact dependency cone after observing carried body bundles",
-                                        )
-                                }
-                                Err(error) => panic!(
-                                    "registered closure validation retains its exact dependency cone: {error:?}"
-                                ),
-                            };
+                            let fallback = terminal_root_for_closure_publication
+                                .lock()
+                                .unwrap_or_else(std::sync::PoisonError::into_inner)
+                                .lease
+                                .clone();
+                            let pending = context
+                                .retain_observed_terminal_cone_from(
+                                    &closure,
+                                    std::slice::from_ref(&fallback),
+                                )
+                                .expect(
+                                    "registered closure validation retains its exact dependency cone",
+                                );
                             context.register_attempt_handoff(PublishedBodyClosureTerminalHandoff {
                                 root: terminal_root_for_closure_publication.clone(),
-                                pending: Some(pending),
+                                pending: Some(Arc::new(pending)),
                                 pending_reached: Some(output.reached.iter().cloned().collect()),
                                 previous: None,
                                 installed: false,
@@ -14969,7 +15149,7 @@ impl RevisionedQueryDatabase {
                             context.register_attempt_handoff(
                                 PublishedBodyReachabilityTerminalHandoff {
                                     root: terminal_root_for_reachability_publication.clone(),
-                                    pending: Some(rue_query::RetainedPinSet::new()),
+                                    pending: Some(Arc::new(rue_query::RetainedPinSet::new())),
                                     previous: None,
                                     installed: false,
                                 },
@@ -15041,13 +15221,21 @@ impl RevisionedQueryDatabase {
                             context.register_attempt_handoff(
                                 PublishedBodyReachabilityTerminalHandoff {
                                     root: terminal_root_for_reachability_publication.clone(),
-                                    pending: Some(
+                                    pending: Some(Arc::new({
+                                        let fallback = terminal_root_for_reachability_publication
+                                            .lock()
+                                            .unwrap_or_else(std::sync::PoisonError::into_inner)
+                                            .lease
+                                            .clone();
                                         context
-                                            .retain_observed_terminal_cone(&reachability)
+                                            .retain_observed_terminal_cone_from(
+                                                &reachability,
+                                                std::slice::from_ref(&fallback),
+                                            )
                                             .expect(
                                                 "registered reachability validation retains its exact dependency cone",
-                                            ),
-                                    ),
+                                            )
+                                    })),
                                     previous: None,
                                     installed: false,
                                 },
@@ -15144,6 +15332,7 @@ impl RevisionedQueryDatabase {
             cfgs,
             optimized_cfgs,
             codegen_units,
+            backend_root_publications,
             #[cfg(test)]
             codegen_evaluator_gate,
             lookup_names,
@@ -15175,6 +15364,9 @@ impl RevisionedQueryDatabase {
             lookup_root_lease,
             body_closure_root,
             body_reachability_root,
+            backend_root,
+            backend_root_publication_gate: BackendRootPublicationGate::default(),
+            next_backend_root_epoch: std::sync::atomic::AtomicU64::new(1),
             #[cfg(test)]
             inject_body_transaction_failure,
             #[cfg(test)]
@@ -15553,6 +15745,126 @@ impl RevisionedQueryDatabase {
             ),
             cancellation,
         ))
+    }
+
+    /// Start an unpublished backend-root handoff. Every terminal retained into
+    /// this candidate is acquired while its request attempt still owns the
+    /// result lease, closing the birth-to-publication eviction window.
+    pub(crate) fn begin_backend_root(&self) -> BackendRootCandidate {
+        BackendRootCandidate::default()
+    }
+
+    /// Retain one reached optimized-CFG terminal across sequential collection.
+    /// Raw CFG identities are recorded for exact-root metrics; the registered
+    /// publication request captures their full terminal cones.
+    pub(crate) fn retain_backend_optimized_cfg(
+        &self,
+        candidate: &mut BackendRootCandidate,
+        function: crate::FunctionInstanceKey,
+        key: &crate::cfg_query::OptimizedCfgQueryKey,
+        terminal: &Arc<rue_query::QueryTerminal<crate::cfg_query::CfgValue>>,
+    ) {
+        for cfg_key in std::iter::once(&key.cfg).chain(key.accessor_dependencies.iter()) {
+            candidate.cfg_keys.insert(cfg_key.clone());
+        }
+        let pin = self
+            .optimized_cfgs
+            .pin_terminal(terminal)
+            .expect("optimized-CFG result belongs to the registered family");
+        if candidate.lease.lease(pin) {
+            candidate.optimized_cfg_terminals += 1;
+        }
+        candidate.functions.insert(function);
+    }
+
+    /// Retain one reached CodegenUnit terminal. Its optimized-CFG input was
+    /// pinned explicitly during the preceding rooted CFG collection.
+    pub(crate) fn retain_backend_codegen_unit(
+        &self,
+        candidate: &mut BackendRootCandidate,
+        terminal: &Arc<rue_query::QueryTerminal<crate::codegen_query::CodegenUnitValue>>,
+    ) {
+        let pin = self
+            .codegen_units
+            .pin_terminal(terminal)
+            .expect("codegen result belongs to the registered family");
+        if candidate.lease.lease(pin) {
+            candidate.codegen_unit_terminals += 1;
+        }
+    }
+
+    /// Publish the full transitive query cone behind a successful backend
+    /// collection. Direct candidate pins bridge the host collection into this
+    /// registered request; its query context then observes and atomically hands
+    /// off every exact validation dependency, not just the three backend-family
+    /// terminals at the top of the graph.
+    pub(crate) fn publish_backend_root(
+        &self,
+        revision: Revision,
+        candidate: BackendRootCandidate,
+        codegen_units: Arc<[crate::codegen_query::CodegenUnitQueryKey]>,
+    ) -> Result<(), QueryAbort> {
+        // A root-publication request is transactional through its handoff
+        // callbacks. Serialize only these short, whole-program swaps so a
+        // canceled publication always rolls back the root it installed; all
+        // per-function CFG and codegen queries remain independently parallel.
+        let _publication = self.backend_root_publication_gate.enter();
+        let epoch = self
+            .next_backend_root_epoch
+            .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        let key = BackendRootPublicationKey {
+            epoch,
+            codegen_units,
+            functions: candidate.functions.iter().cloned().collect(),
+            cfg_terminals: candidate.cfg_keys.len(),
+        };
+        let attempt = self.runtime.request_registered(
+            &self.backend_root_publications,
+            revision,
+            key,
+            CancellationToken::new(),
+        );
+        let terminal = attempt.into_result()?;
+        let rue_query::QueryOutcome::Success(published) = terminal.outcome() else {
+            unreachable!("backend-root publication uses a typed terminal")
+        };
+        assert!(
+            *published,
+            "a host-validated successful CodegenUnit collection must publish successfully"
+        );
+        drop(candidate);
+        Ok(())
+    }
+
+    #[cfg(test)]
+    pub(crate) fn backend_root_metrics_for_test(&self) -> PublishedBackendRootMetrics {
+        let root = self
+            .backend_root
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let _retained_pins = root.lease.len();
+        PublishedBackendRootMetrics {
+            functions: root.functions.len(),
+            cfg_terminals: root.cfg_terminals,
+            optimized_cfg_terminals: root.optimized_cfg_terminals,
+            codegen_unit_terminals: root.codegen_unit_terminals,
+            publications: root.publications,
+            additions: root.additions,
+            deletions: root.deletions,
+        }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn backend_cfg_key_is_retained_for_test(
+        &self,
+        key: &crate::cfg_query::CfgQueryKey,
+    ) -> bool {
+        self.cfgs.contains_retained_key(key)
+    }
+
+    #[cfg(test)]
+    pub(crate) fn query_evictions_for_test(&self) -> u64 {
+        self.runtime.metrics().evictions
     }
 
     /// Publish an immutable, revisioned import authority for lower-layer
@@ -23190,6 +23502,66 @@ mod tests {
     use std::collections::{BTreeSet, HashMap};
 
     #[test]
+    fn backend_root_publication_gate_serializes_distinct_epochs() {
+        let gate = Arc::new(BackendRootPublicationGate::default());
+        let first_epoch = gate.enter();
+        let attempted = Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let entered = Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let second_gate = gate.clone();
+        let second_attempted = attempted.clone();
+        let second_entered = entered.clone();
+        let second_epoch = std::thread::spawn(move || {
+            second_attempted.store(true, std::sync::atomic::Ordering::Release);
+            let _publication = second_gate.enter();
+            second_entered.store(true, std::sync::atomic::Ordering::Release);
+        });
+        while !attempted.load(std::sync::atomic::Ordering::Acquire) {
+            std::thread::yield_now();
+        }
+        assert!(
+            !entered.load(std::sync::atomic::Ordering::Acquire),
+            "a distinct backend-root epoch cannot enter while its predecessor may roll back"
+        );
+        drop(first_epoch);
+        second_epoch.join().unwrap();
+        assert!(entered.load(std::sync::atomic::Ordering::Acquire));
+    }
+
+    #[test]
+    fn backend_root_publication_handoff_restores_last_good_root_on_rollback() {
+        let root = Arc::new(Mutex::new(PublishedBackendRoot {
+            publications: 7,
+            additions: 11,
+            deletions: 3,
+            ..PublishedBackendRoot::default()
+        }));
+        let mut handoff = PublishedBackendRootHandoff {
+            root: root.clone(),
+            pending: Some(Arc::new(rue_query::RetainedPinSet::new())),
+            functions: Some(BTreeSet::new()),
+            cfg_terminals: 2,
+            optimized_cfg_terminals: 1,
+            codegen_unit_terminals: 1,
+            previous: None,
+            installed: false,
+        };
+        rue_query::QueryAttemptHandoff::commit(&mut handoff);
+        assert_eq!(
+            root.lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner)
+                .publications,
+            8
+        );
+        rue_query::QueryAttemptHandoff::abort(&mut handoff);
+        let restored = root
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        assert_eq!(restored.publications, 7);
+        assert_eq!(restored.additions, 11);
+        assert_eq!(restored.deletions, 3);
+    }
+
+    #[test]
     fn foreign_signature_agreement_uses_resolved_identity_mode_and_comptime_not_names() {
         use crate::durable_semantics::{
             DurableParameterMode as Mode, DurableSemanticParameter as Parameter,
@@ -23295,14 +23667,14 @@ mod tests {
         }));
         let mut closure_handoff = PublishedBodyClosureTerminalHandoff {
             root: closure_root.clone(),
-            pending: Some(rue_query::RetainedPinSet::new()),
+            pending: Some(Arc::new(rue_query::RetainedPinSet::new())),
             pending_reached: Some(BTreeSet::new()),
             previous: None,
             installed: false,
         };
         let mut reachability_handoff = PublishedBodyReachabilityTerminalHandoff {
             root: reachability_root,
-            pending: Some(rue_query::RetainedPinSet::new()),
+            pending: Some(Arc::new(rue_query::RetainedPinSet::new())),
             previous: None,
             installed: false,
         };

--- a/crates/rue-compiler/src/session.rs
+++ b/crates/rue-compiler/src/session.rs
@@ -860,12 +860,13 @@ pub(crate) struct RootedCfgUnit {
     pub(crate) body_span: rue_span::Span,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub(crate) struct RootedCfgOutput {
     graph: RootedBodyGraph,
     pub(crate) cfgs: Vec<RootedCfgUnit>,
     pub(crate) warnings: Vec<CompileWarning>,
     pub(crate) work: crate::CanonicalSemanticWork,
+    backend_root: crate::revisioned_query_database::BackendRootCandidate,
 }
 
 pub(crate) struct RootedCodegenOutput {
@@ -4870,6 +4871,7 @@ impl CompilerSession {
         let accessor_dependencies = accessor_subgraph.dependencies;
         let accessor_functions = accessor_subgraph.accessors;
         let mut cfgs = Vec::with_capacity(cfg_inputs.len());
+        let mut backend_root = self.queries.revisioned.begin_backend_root();
         #[cfg(test)]
         self.rooted_cfg_executions.clear();
         let _cfg_collection_span =
@@ -4916,6 +4918,14 @@ impl CompilerSession {
                     work.cfg.cfg_reuses += 1;
                 }
                 rue_query::RequestExecution::Aborted => {}
+            }
+            if let Some(terminal) = attempt.terminal() {
+                self.queries.revisioned.retain_backend_optimized_cfg(
+                    &mut backend_root,
+                    function.clone(),
+                    &optimized_cfg_key,
+                    terminal,
+                );
             }
             let terminal = attempt.into_result().map_err(|abort| {
                 CompileError::without_span(ErrorKind::InternalError(format!(
@@ -5001,6 +5011,7 @@ impl CompilerSession {
             cfgs,
             warnings,
             work,
+            backend_root,
         })
     }
 
@@ -5014,9 +5025,11 @@ impl CompilerSession {
             cfgs,
             warnings,
             work,
+            mut backend_root,
         } = self.rooted_cfg(options)?;
 
         let mut units = Vec::with_capacity(cfgs.len());
+        let mut backend_root_keys = Vec::with_capacity(cfgs.len());
         #[cfg(test)]
         {
             self.codegen_executions.clear();
@@ -5049,6 +5062,11 @@ impl CompilerSession {
                 self.codegen_attempt_work
                     .push((cfg.function.clone(), attempt.work().to_vec()));
             }
+            if let Some(terminal) = attempt.terminal() {
+                self.queries
+                    .revisioned
+                    .retain_backend_codegen_unit(&mut backend_root, terminal);
+            }
             let terminal = attempt.into_result().map_err(|abort| {
                 CompileError::without_span(ErrorKind::InternalError(format!(
                     "codegen query aborted: {abort:?}"
@@ -5059,6 +5077,12 @@ impl CompilerSession {
             };
             match value {
                 crate::codegen_query::CodegenUnitValue::Available(unit) => {
+                    backend_root_keys.push(crate::codegen_query::CodegenUnitQueryKey::new(
+                        cfg.optimized_cfg_key.clone(),
+                        options.target,
+                        request,
+                        options.opt_level,
+                    ));
                     units.push(crate::codegen_query::CollectedCodegenUnit {
                         function: cfg.function.clone(),
                         unit: unit.clone(),
@@ -5107,6 +5131,14 @@ impl CompilerSession {
                 }
             })
             .collect();
+        self.queries
+            .revisioned
+            .publish_backend_root(graph.revision, backend_root, backend_root_keys.into())
+            .map_err(|abort| {
+                CompileError::without_span(ErrorKind::InternalError(format!(
+                    "backend root publication aborted: {abort:?}"
+                )))
+            })?;
         Ok(RootedCodegenOutput {
             units,
             cfgs,
@@ -5249,6 +5281,25 @@ impl CompilerSession {
     #[cfg(test)]
     pub(crate) fn codegen_collections(&self) -> usize {
         self.codegen_collections
+    }
+
+    #[cfg(test)]
+    pub(crate) fn backend_root_metrics(
+        &self,
+    ) -> crate::revisioned_query_database::PublishedBackendRootMetrics {
+        self.queries.revisioned.backend_root_metrics_for_test()
+    }
+
+    #[cfg(test)]
+    pub(crate) fn backend_cfg_key_is_retained(&self, key: &crate::cfg_query::CfgQueryKey) -> bool {
+        self.queries
+            .revisioned
+            .backend_cfg_key_is_retained_for_test(key)
+    }
+
+    #[cfg(test)]
+    pub(crate) fn query_evictions_for_test(&self) -> u64 {
+        self.queries.revisioned.query_evictions_for_test()
     }
 
     /// Analyze the current revision, surfacing an unsatisfied trusted-toolchain

--- a/crates/rue-query/src/lib.rs
+++ b/crates/rue-query/src/lib.rs
@@ -421,6 +421,69 @@ mod registered_batch_tests {
     }
 
     #[test]
+    fn exact_terminal_cones_walk_one_deduplicated_union() {
+        let runtime = QueryRuntime::new(1);
+        publish_empty(&runtime, [revision(1)]);
+        let leaf = runtime
+            .family_with_evaluator::<Slot, u64, _>("exact-cones-union-leaf", 0, |_, _, key| {
+                Ok(QueryOutput::success(key.0))
+            })
+            .unwrap();
+        let leaf_for_root = leaf.clone();
+        let root = runtime
+            .family_with_evaluator::<Key, u64, _>(
+                "exact-cones-union-root",
+                0,
+                move |context, _, _| {
+                    context.query_registered(&leaf_for_root, Slot(0))?;
+                    Ok(QueryOutput::success(1))
+                },
+            )
+            .unwrap();
+        let root_for_publication = root.clone();
+        let runtime_for_publication = runtime.clone();
+        let publication = runtime
+            .family_with_evaluator::<Key, u64, _>(
+                "exact-cones-union-publication",
+                0,
+                move |context, _, _| {
+                    let _proof = context.endorse_registered_validations();
+                    let first = context.query_registered(&root_for_publication, Key("first"))?;
+                    let second = context.query_registered(&root_for_publication, Key("second"))?;
+                    let before = runtime_for_publication.metrics().active_retained_pins;
+                    let retained = context
+                        .retain_observed_terminal_cones_from(&[first, second], &[])
+                        .unwrap();
+                    assert_eq!(retained.len(), 3, "the shared leaf is retained once");
+                    assert_eq!(
+                        runtime_for_publication.metrics().active_retained_pins,
+                        before + 3,
+                        "deduplication accounting matches the exact union"
+                    );
+                    drop(retained);
+                    assert_eq!(
+                        runtime_for_publication.metrics().active_retained_pins,
+                        before
+                    );
+                    Ok(QueryOutput::success(1))
+                },
+            )
+            .unwrap();
+
+        assert!(
+            runtime
+                .request_registered(
+                    &publication,
+                    revision(1),
+                    Key("publish"),
+                    CancellationToken::new(),
+                )
+                .terminal()
+                .is_some()
+        );
+    }
+
+    #[test]
     fn exact_terminal_cone_requires_proof_authority_and_an_observed_root() {
         let runtime = QueryRuntime::new(1);
         publish_empty(&runtime, [revision(1)]);
@@ -523,6 +586,276 @@ mod registered_batch_tests {
         assert!(
             runtime
                 .request_registered(&check, revision(1), Key("check"), CancellationToken::new(),)
+                .terminal()
+                .is_some()
+        );
+    }
+
+    #[test]
+    fn exact_terminal_cone_inherits_a_missing_grandchild_from_a_published_snapshot() {
+        let runtime = QueryRuntime::new(1);
+        publish_empty(&runtime, [revision(1), revision(2)]);
+        let leaf = runtime
+            .family_with_evaluator::<Slot, u64, _>("fallback-grandchild-leaf", 8, |_, _, key| {
+                Ok(QueryOutput::success(key.0))
+            })
+            .unwrap();
+        let leaf_for_middle = leaf.clone();
+        let middle = runtime
+            .family_with_evaluator::<Key, u64, _>(
+                "fallback-grandchild-middle",
+                8,
+                move |context, _, _| {
+                    context.query_registered(&leaf_for_middle, Slot(1))?;
+                    Ok(QueryOutput::success(2))
+                },
+            )
+            .unwrap();
+        let middle_for_root = middle.clone();
+        let root = runtime
+            .family_with_evaluator::<Key, u64, _>(
+                "fallback-grandchild-root",
+                8,
+                move |context, _, _| {
+                    context.query_registered(&middle_for_root, Key("middle"))?;
+                    Ok(QueryOutput::success(3))
+                },
+            )
+            .unwrap();
+
+        let old_root = runtime
+            .request_registered(&root, revision(1), Key("root"), CancellationToken::new())
+            .into_result()
+            .unwrap();
+        let old_middle = runtime
+            .request_registered(
+                &middle,
+                revision(1),
+                Key("middle"),
+                CancellationToken::new(),
+            )
+            .into_result()
+            .unwrap();
+        let old_leaf = runtime
+            .request_registered(&leaf, revision(1), Slot(1), CancellationToken::new())
+            .into_result()
+            .unwrap();
+        let mut fallback = RetainedPinSet::new();
+        fallback.lease(root.pin_terminal(&old_root).unwrap());
+        fallback.lease(middle.pin_terminal(&old_middle).unwrap());
+        fallback.lease(leaf.pin_terminal(&old_leaf).unwrap());
+        let fallback = Arc::new(fallback);
+
+        let root_for_check = root.clone();
+        let check = runtime
+            .family_with_evaluator::<Key, u64, _>(
+                "fallback-grandchild-check",
+                1,
+                move |context, _, _| {
+                    let _proof = context.endorse_registered_validations();
+                    let current = context.query_registered(&root_for_check, Key("root"))?;
+                    let middle_edge = current.dependencies()[0].clone();
+                    let leaf_edge = {
+                        let leases = lock(&context.task.leases);
+                        leases
+                            .held
+                            .iter()
+                            .find(|lease| {
+                                let identity = lease.identity();
+                                identity.0 == middle_edge.incarnation
+                                    && identity.1 == middle_edge.stamp
+                            })
+                            .unwrap()
+                            .dependencies()[0]
+                            .clone()
+                    };
+                    let removed = {
+                        let mut leases = lock(&context.task.leases);
+                        let index = leases
+                            .held
+                            .iter()
+                            .position(|lease| {
+                                let identity = lease.identity();
+                                identity.0 == leaf_edge.incarnation && identity.1 == leaf_edge.stamp
+                            })
+                            .unwrap();
+                        leases.held.remove(index)
+                    };
+                    context.task.core.metrics.task_leases_released(1);
+                    drop(removed);
+                    let retained = context
+                        .retain_observed_terminal_cone_from(
+                            &current,
+                            std::slice::from_ref(&fallback),
+                        )
+                        .unwrap();
+                    assert_eq!(retained.len(), 3);
+                    Ok(QueryOutput::success(1))
+                },
+            )
+            .unwrap();
+        assert!(
+            runtime
+                .request_registered(&check, revision(2), Key("check"), CancellationToken::new())
+                .terminal()
+                .is_some()
+        );
+    }
+
+    #[test]
+    fn exact_terminal_cone_prefers_current_same_stamp_dependencies_over_predecessor() {
+        let runtime = QueryRuntime::new(1);
+        let input = InputIdentity::new("source", "fallback-choice");
+        runtime
+            .publish_revision(revision(1), [(input.clone(), 1)])
+            .unwrap();
+        runtime
+            .publish_revision(revision(2), [(input.clone(), 2)])
+            .unwrap();
+        let leaf = runtime
+            .family_with_evaluator::<Slot, u64, _>("fallback-choice-leaf", 8, |_, _, key| {
+                Ok(QueryOutput::success(key.0))
+            })
+            .unwrap();
+        let leaf_for_choice = leaf.clone();
+        let input_for_choice = input.clone();
+        let choice = runtime
+            .family_with_evaluator::<Key, u64, _>(
+                "fallback-choice-root",
+                8,
+                move |context, _, _| {
+                    let selected = context.input(input_for_choice.clone())?;
+                    context.query_registered(&leaf_for_choice, Slot(selected))?;
+                    Ok(QueryOutput::success(7))
+                },
+            )
+            .unwrap();
+        let old_root = runtime
+            .request_registered(&choice, revision(1), Key("root"), CancellationToken::new())
+            .into_result()
+            .unwrap();
+        let old_leaf = runtime
+            .request_registered(&leaf, revision(1), Slot(1), CancellationToken::new())
+            .into_result()
+            .unwrap();
+        let mut fallback = RetainedPinSet::new();
+        fallback.lease(choice.pin_terminal(&old_root).unwrap());
+        fallback.lease(leaf.pin_terminal(&old_leaf).unwrap());
+        let fallback = Arc::new(fallback);
+
+        let choice_for_check = choice.clone();
+        let old_root_for_check = old_root.clone();
+        let check = runtime
+            .family_with_evaluator::<Key, u64, _>(
+                "fallback-choice-check",
+                1,
+                move |context, _, _| {
+                    let _proof = context.endorse_registered_validations();
+                    let current = context.query_registered(&choice_for_check, Key("root"))?;
+                    assert_eq!(
+                        current.node_incarnation(),
+                        old_root_for_check.node_incarnation()
+                    );
+                    assert_eq!(current.stamp(), old_root_for_check.stamp());
+                    assert_ne!(current.dependencies(), old_root_for_check.dependencies());
+                    let current_leaf = current.dependencies()[0].clone();
+                    let retained = context
+                        .retain_observed_terminal_cone_from(
+                            &current,
+                            std::slice::from_ref(&fallback),
+                        )
+                        .unwrap();
+                    assert_eq!(retained.len(), 2, "the old leaf is excluded");
+                    assert!(retained.held.iter().any(|lease| {
+                        let identity = lease.identity();
+                        identity.0 == current_leaf.incarnation && identity.1 == current_leaf.stamp
+                    }));
+                    assert!(
+                        retained
+                            .held
+                            .iter()
+                            .all(|lease| lease.identity().0 != old_leaf.node_incarnation()),
+                        "the fallback's old leaf identity must not replace the current leaf"
+                    );
+                    Ok(QueryOutput::success(1))
+                },
+            )
+            .unwrap();
+        assert!(
+            runtime
+                .request_registered(&check, revision(2), Key("check"), CancellationToken::new())
+                .terminal()
+                .is_some()
+        );
+    }
+
+    #[test]
+    fn exact_terminal_cone_rejects_fallback_roots_and_foreign_runtime_snapshots() {
+        let runtime = QueryRuntime::new(1);
+        publish_empty(&runtime, [revision(1)]);
+        let family = runtime
+            .family_with_evaluator::<Key, u64, _>("fallback-authority", 8, |_, _, _| {
+                Ok(QueryOutput::success(1))
+            })
+            .unwrap();
+        let terminal = runtime
+            .request_registered(&family, revision(1), Key("root"), CancellationToken::new())
+            .into_result()
+            .unwrap();
+        let mut inherited_only = RetainedPinSet::new();
+        inherited_only.lease(family.pin_terminal(&terminal).unwrap());
+        let inherited_only = Arc::new(inherited_only);
+
+        let foreign_runtime = QueryRuntime::new(1);
+        publish_empty(&foreign_runtime, [revision(1)]);
+        let foreign_family = foreign_runtime
+            .family_with_evaluator::<Key, u64, _>("fallback-foreign", 8, |_, _, _| {
+                Ok(QueryOutput::success(1))
+            })
+            .unwrap();
+        let foreign_terminal = foreign_runtime
+            .request_registered(
+                &foreign_family,
+                revision(1),
+                Key("root"),
+                CancellationToken::new(),
+            )
+            .into_result()
+            .unwrap();
+        let mut foreign = RetainedPinSet::new();
+        foreign.lease(foreign_family.pin_terminal(&foreign_terminal).unwrap());
+        let foreign = Arc::new(foreign);
+
+        let family_for_check = family.clone();
+        let terminal_for_check = terminal.clone();
+        let check = runtime
+            .family_with_evaluator::<Key, u64, _>(
+                "fallback-authority-check",
+                1,
+                move |context, _, _| {
+                    let _proof = context.endorse_registered_validations();
+                    assert!(matches!(
+                        context.retain_observed_terminal_cone_from(
+                            &terminal_for_check,
+                            std::slice::from_ref(&inherited_only),
+                        ),
+                        Err(RetainTerminalConeError::RootNotObserved)
+                    ));
+                    let current = context.query_registered(&family_for_check, Key("current"))?;
+                    assert!(matches!(
+                        context.retain_observed_terminal_cone_from(
+                            &current,
+                            std::slice::from_ref(&foreign),
+                        ),
+                        Err(RetainTerminalConeError::ForeignRuntime)
+                    ));
+                    Ok(QueryOutput::success(1))
+                },
+            )
+            .unwrap();
+        assert!(
+            runtime
+                .request_registered(&check, revision(1), Key("check"), CancellationToken::new())
                 .terminal()
                 .is_some()
         );
@@ -4763,6 +5096,8 @@ pub enum RetainTerminalConeError {
     NoRegisteredValidationScope,
     /// The proposed root was not observed by this task.
     RootNotObserved,
+    /// A fallback lease universe belongs to another query runtime.
+    ForeignRuntime,
     /// One immutable edge in the proposed root's transitive cone had no
     /// matching live task lease.
     DependencyNotObserved(Observation),
@@ -5274,12 +5609,7 @@ impl QueryContext {
     /// live, so a publication handoff can promote the exact dependency cone
     /// past request completion without an eviction window.
     pub fn retain_observed_terminals(&self) -> RetainedPinSet {
-        let leases = lock(&self.task.leases);
-        let mut retained = RetainedPinSet::new();
-        for lease in &leases.held {
-            retained.lease_erased(lease.duplicate());
-        }
-        retained
+        retain_task_observations(&self.task)
     }
 
     /// Duplicates only the observed terminals reachable from one exact root.
@@ -5296,42 +5626,103 @@ impl QueryContext {
     where
         V: Clone + Send + Sync + 'static,
     {
+        self.retain_observed_terminal_cones_from(std::slice::from_ref(root), &[])
+    }
+
+    /// Retain one exact current-task terminal cone, filling validation leaves
+    /// omitted by green reuse from prioritized published snapshots.
+    pub fn retain_observed_terminal_cone_from<V>(
+        &self,
+        root: &Arc<QueryTerminal<V>>,
+        fallbacks: &[Arc<RetainedPinSet>],
+    ) -> Result<RetainedPinSet, RetainTerminalConeError>
+    where
+        V: Clone + Send + Sync + 'static,
+    {
+        self.retain_observed_terminal_cones_from(std::slice::from_ref(root), fallbacks)
+    }
+
+    /// Retain the union of exact current-task terminal cones, filling
+    /// validation leaves omitted by green reuse from prioritized published
+    /// snapshots. Every root must be observed by this task; fallback snapshots
+    /// may satisfy only dependency edges. Current observations always override
+    /// fallbacks, and within one source an edge selects the greatest terminal
+    /// revision with the requested incarnation and stamp.
+    ///
+    /// The hash-indexed lease universe is built once and exact identities are
+    /// hash-deduplicated while the union is walked once. Promotion is therefore
+    /// expected O(N + E) in available leases and selected dependency edges,
+    /// rather than rescanning or tree-searching leases per edge and per root.
+    pub fn retain_observed_terminal_cones_from<V>(
+        &self,
+        roots: &[Arc<QueryTerminal<V>>],
+        fallbacks: &[Arc<RetainedPinSet>],
+    ) -> Result<RetainedPinSet, RetainTerminalConeError>
+    where
+        V: Clone + Send + Sync + 'static,
+    {
         if lock(&self.task.validation_endorsements).is_empty() {
             return Err(RetainTerminalConeError::NoRegisteredValidationScope);
         }
+        if fallbacks.iter().any(|fallback| {
+            fallback
+                .held
+                .iter()
+                .any(|lease| lease.runtime_identity() != self.task.core.identity)
+        }) {
+            return Err(RetainTerminalConeError::ForeignRuntime);
+        }
         let leases = lock(&self.task.leases);
-        let mut by_observation = BTreeMap::new();
-        let mut root_index = None;
-        for (index, lease) in leases.held.iter().enumerate() {
+        let mut current_exact = HashMap::with_capacity(leases.held.len());
+        let mut selected = HashMap::with_capacity(leases.held.len());
+        for lease in &leases.held {
             let identity = lease.identity();
-            by_observation
+            current_exact.insert(identity, lease.as_ref());
+            let selected_for_stamp = selected
                 .entry((identity.0, identity.1))
-                .and_modify(|current: &mut usize| {
-                    if leases.held[*current].identity().2 < identity.2 {
-                        *current = index;
-                    }
-                })
-                .or_insert(index);
-            if identity == (root.node_incarnation, root.stamp, root.revision) {
-                root_index = Some(index);
+                .or_insert(lease.as_ref());
+            if selected_for_stamp.identity().2 < identity.2 {
+                *selected_for_stamp = lease.as_ref();
             }
         }
+        for fallback in fallbacks {
+            let mut fallback_selected = HashMap::with_capacity(fallback.held.len());
+            for lease in &fallback.held {
+                let identity = lease.identity();
+                let selected_for_stamp = fallback_selected
+                    .entry((identity.0, identity.1))
+                    .or_insert(lease.as_ref());
+                if selected_for_stamp.identity().2 < identity.2 {
+                    *selected_for_stamp = lease.as_ref();
+                }
+            }
+            for (identity, lease) in fallback_selected {
+                selected.entry(identity).or_insert(lease);
+            }
+        }
+
+        let mut pending = Vec::with_capacity(roots.len());
+        for root in roots {
+            pending.push(
+                *current_exact
+                    .get(&(root.node_incarnation, root.stamp, root.revision))
+                    .ok_or(RetainTerminalConeError::RootNotObserved)?,
+            );
+        }
         let mut retained = RetainedPinSet::new();
-        let root_index = root_index.ok_or(RetainTerminalConeError::RootNotObserved)?;
-        let mut pending = vec![root_index];
-        let mut visited = BTreeSet::new();
-        while let Some(index) = pending.pop() {
-            let lease = &leases.held[index];
+        let mut visited = HashSet::with_capacity(selected.len());
+        while let Some(lease) = pending.pop() {
             if !visited.insert(lease.identity()) {
                 continue;
             }
             for dependency in lease.dependencies() {
-                let index = by_observation
-                    .get(&(dependency.incarnation, dependency.stamp))
-                    .ok_or_else(|| {
-                        RetainTerminalConeError::DependencyNotObserved(dependency.clone())
-                    })?;
-                pending.push(*index);
+                pending.push(
+                    *selected
+                        .get(&(dependency.incarnation, dependency.stamp))
+                        .ok_or_else(|| {
+                            RetainTerminalConeError::DependencyNotObserved(dependency.clone())
+                        })?,
+                );
             }
             retained.lease_erased(lease.duplicate());
         }
@@ -5341,6 +5732,15 @@ impl QueryContext {
     fn task_runtime(&self) -> Arc<RuntimeCore> {
         self.task.core.clone()
     }
+}
+
+fn retain_task_observations(task: &Task) -> RetainedPinSet {
+    let leases = lock(&task.leases);
+    let mut retained = RetainedPinSet::new();
+    for lease in &leases.held {
+        retained.lease_erased(lease.duplicate());
+    }
+    retained
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
@@ -5652,7 +6052,7 @@ pub struct RetainedPinSet {
     /// `(node incarnation, stamp, terminal revision)` of every terminal already
     /// leased here, mirroring [`TaskLeases::observed`] so a redundant re-lease is
     /// dropped rather than double-held.
-    observed: BTreeSet<(u64, u64, Revision)>,
+    observed: HashSet<(u64, u64, Revision)>,
     /// Live pins, type-erased across families. Dropping the set drops these
     /// through the batched two-phase release.
     held: Vec<Box<dyn ObservedLease>>,
@@ -5737,6 +6137,7 @@ impl Drop for RetainedPinSet {
 /// touches without a second retention structure.
 trait ObservedLease: Send + Sync {
     fn metrics(&self) -> &Metrics;
+    fn runtime_identity(&self) -> u64;
     fn identity(&self) -> (u64, u64, Revision);
 
     fn dependencies(&self) -> &[Observation];
@@ -5760,6 +6161,10 @@ where
 {
     fn metrics(&self) -> &Metrics {
         &self.family.core.metrics
+    }
+
+    fn runtime_identity(&self) -> u64 {
+        self.family.core.identity
     }
 
     fn identity(&self) -> (u64, u64, Revision) {


### PR DESCRIPTION
Fixes RUE-1230.

## Summary

- publish one exact retained backend root for all reached CodegenUnits and their transitive query dependencies
- carry the last-good cone across revisions while preferring current observations and rejecting foreign runtimes
- serialize only final root publication and rollback, leaving per-function CFG and codegen work parallel
- release functions that leave reachability and preserve raw accessor CFG dependencies under eviction pressure

## Validation

- `scripts/rue unit query exact_terminal_cone` (7 passed)
- focused backend retention, invalidation, cancellation, and publication-handoff tests
- `scripts/rue quick` (30 targets passed)
- canonical pre-merge tier: clippy clean; 78 targets passed, 0 failed
- compiler scaling matrix: 798 passed, 2 ignored