### PR TITLE
Check accessor body interiors at declaration processing

### DIFF
--- a/crates/rue-air/src/sema/control_flow.rs
+++ b/crates/rue-air/src/sema/control_flow.rs
@@ -1352,8 +1352,12 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
         // A `?` early return is a non-diverging exit that bypasses an
         // accessor body's single trailing `yield` (ADR-0062 phase 1).
         if ctx.accessor_trailing_yield.is_some() {
-            return Err(CompileError::new(ErrorKind::AccessorBodyMissingYield, span)
-                .with_note("an accessor body cannot contain `?`; guards may only diverge or fall through to the trailing `yield`"));
+            return Err(CompileError::new(
+                ErrorKind::AccessorBodyOtherExit {
+                    found: "a `?`".to_string(),
+                },
+                span,
+            ));
         }
         let return_type = ctx.return_type;
 
@@ -1801,8 +1805,12 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
             return Err(CompileError::new(ErrorKind::YieldOutsideAccessor, span));
         };
         if trailing != inst_ref {
-            return Err(CompileError::new(ErrorKind::AccessorBodyMissingYield, span)
-                .with_note("this `yield` is not the single trailing exit of the accessor body"));
+            return Err(CompileError::new(
+                ErrorKind::AccessorBodyOtherExit {
+                    found: "a second `yield`".to_string(),
+                },
+                span,
+            ));
         }
 
         // The yielded place must be a projection chain rooted at the receiver
@@ -1920,8 +1928,12 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
         // (ADR-0062 phase 1); an early `return` would be a non-diverging exit
         // that bypasses it.
         if ctx.accessor_trailing_yield.is_some() {
-            return Err(CompileError::new(ErrorKind::AccessorBodyMissingYield, span)
-                .with_note("an accessor body cannot contain `return`; guards may only diverge or fall through to the trailing `yield`"));
+            return Err(CompileError::new(
+                ErrorKind::AccessorBodyOtherExit {
+                    found: "a `return`".to_string(),
+                },
+                span,
+            ));
         }
         let inner_air_ref = if let Some(inner) = inner {
             // Explicit return with value. A `str`-returning function

--- a/crates/rue-air/src/sema/declarations.rs
+++ b/crates/rue-air/src/sema/declarations.rs
@@ -1459,6 +1459,7 @@ impl<'a> Sema<'a, super::MutableDeclarations> {
         // function can never satisfy: it has no receiver to project from.
         check_accessor_declaration_shape(
             self.rir,
+            self.interner,
             declaration,
             Some(body),
             false,
@@ -1777,6 +1778,7 @@ impl<'a> Sema<'a, super::MutableDeclarations> {
                 // in the signature resolves.
                 check_accessor_declaration_shape(
                     self.rir,
+                    self.interner,
                     method_ref,
                     Some(*body),
                     true,
@@ -3195,15 +3197,20 @@ impl<'a> Sema<'a, super::MutableDeclarations> {
     }
 }
 
-/// The declaration-shape legality of a `-> borrow T` accessor (ADR-0062):
-/// the result position requires the `borrow_accessors` preview (6.6:3), the
-/// receiver is a shared `borrow self` (6.6:4), and every other parameter is a
-/// plain by-value guard input (6.6:5).
+/// The declaration legality of a `-> borrow T` accessor (ADR-0062): the result
+/// position requires the `borrow_accessors` preview (6.6:3), the receiver is a
+/// shared `borrow self` (6.6:4), every other parameter is a plain by-value
+/// guard input (6.6:5), the body's only exit is its trailing `yield` (6.6:6),
+/// and that `yield` hands out a receiver-rooted place (6.6:7).
 ///
 /// These are legality rules on the declaration, so a declared-but-uncalled
 /// accessor is exactly as ill-formed as a called one. Every producer runs this
-/// over every accessor declaration it admits, which is what keeps the rule
-/// independent of the driver's on-demand body analysis.
+/// over every accessor declaration it admits, which is what keeps the rules
+/// independent of the driver's on-demand body analysis. The body rules are
+/// syntactic over the RIR, so they belong here with the signature rules; the
+/// single part that is not — whether a method-call link in the yielded chain
+/// names an accessor — is documented on [`check_accessor_yield_root`] and
+/// stays with the demanded path.
 ///
 /// The declaring `FnDecl` is the only carrier of `returns_borrow`: the durable
 /// signature records the result type's source spelling, which never contains
@@ -3213,6 +3220,7 @@ impl<'a> Sema<'a, super::MutableDeclarations> {
 /// than a shape error about a form it cannot name yet.
 pub(super) fn check_accessor_declaration_shape(
     rir: &rue_rir::Rir,
+    interner: &lasso::ThreadedRodeo,
     declaration: InstRef,
     body: Option<InstRef>,
     has_named_owner: bool,
@@ -3293,9 +3301,135 @@ pub(super) fn check_accessor_declaration_shape(
         }
     }
     if let Some(body) = body {
-        accessor_trailing_yield(rir, body)?;
+        let trailing = accessor_trailing_yield(rir, body)?;
+        check_accessor_body_exits(rir, body, trailing)?;
+        check_accessor_yield_root(rir, interner, trailing)?;
     }
     Ok(())
+}
+
+/// Every instruction lexically contained in `body`, `body` itself included,
+/// in lowering (source) order.
+///
+/// The walk stops at a nested declaration — a nested `fn`, drop function,
+/// struct, or anonymous type owns its own body, and predeclaration reaches
+/// that declaration on its own entry — so a containment question answered
+/// here is answered about this body alone.
+fn body_instructions(rir: &rue_rir::Rir, body: InstRef) -> Vec<InstRef> {
+    let mut pending = vec![body];
+    let mut seen = HashSet::new();
+    let mut contained = Vec::new();
+    let mut children = Vec::new();
+    while let Some(current) = pending.pop() {
+        if !seen.insert(current) {
+            continue;
+        }
+        contained.push(current);
+        if current != body
+            && matches!(
+                rir.get(current).data,
+                InstData::FnDecl { .. }
+                    | InstData::DropFnDecl { .. }
+                    | InstData::StructDecl { .. }
+                    | InstData::EnumDecl { .. }
+                    | InstData::AnonStructType { .. }
+                    | InstData::AnonEnumType { .. }
+            )
+        {
+            continue;
+        }
+        children.clear();
+        rir.child_instructions(current, &mut children);
+        pending.extend(children.iter().copied());
+    }
+    // Instruction indices are assigned as astgen lowers, so ordering by index
+    // reports the first offending form in the source rather than an arbitrary
+    // one from the traversal.
+    contained.sort_unstable_by_key(|inst_ref| inst_ref.as_u32());
+    contained
+}
+
+/// The rest of 6.6:6: an accessor body's trailing `yield` is its *only* exit —
+/// no second `yield`, no `return`, no `?` (E0254).
+///
+/// "Contains" is the spec's own wording, and containment is decidable from the
+/// RIR, so this runs at the declaration for every accessor the program
+/// declares rather than only for a body some call site demands. The
+/// comptime-pruned branch of an `if` counts: 6.6:6 forbids the form appearing
+/// in the body, not merely on a path the specialization keeps.
+fn check_accessor_body_exits(
+    rir: &rue_rir::Rir,
+    body: InstRef,
+    trailing: InstRef,
+) -> CompileResult<()> {
+    for inst_ref in body_instructions(rir, body) {
+        let inst = rir.get(inst_ref);
+        let found = match &inst.data {
+            InstData::Yield(_) if inst_ref != trailing => "a second `yield`",
+            InstData::Ret(_) => "a `return`",
+            InstData::Try { .. } => "a `?`",
+            _ => continue,
+        };
+        return Err(CompileError::new(
+            ErrorKind::AccessorBodyOtherExit {
+                found: found.to_string(),
+            },
+            inst.span,
+        ));
+    }
+    Ok(())
+}
+
+/// 6.6:7 over the RIR: the trailing `yield`'s operand is a projection chain
+/// rooted at the receiver (E0255).
+///
+/// Everything this rule needs is syntactic except one link. A nested
+/// method-call link is legal only when the callee is *itself* an accessor,
+/// and which method a call names is a resolved-type question, so this walk
+/// accepts any method call and keeps descending to the chain's root. That
+/// leaves exactly one residual for a declaration nothing calls: a chain
+/// through a plain (non-accessor) method of the receiver, such as
+/// `yield self.plain();`, whose rejection stays with
+/// [`super::control_flow`]'s demanded-path check. Every other shape — a local,
+/// a non-receiver parameter, a computed value, a chain rooted at anything but
+/// `self` — is rejected here with no call site.
+fn check_accessor_yield_root(
+    rir: &rue_rir::Rir,
+    interner: &lasso::ThreadedRodeo,
+    trailing: InstRef,
+) -> CompileResult<()> {
+    let InstData::Yield(operand) = rir.get(trailing).data else {
+        return Ok(());
+    };
+    let self_sym = interner.get_or_intern("self");
+    let mut current = operand;
+    loop {
+        let inst = rir.get(current);
+        let span = inst.span;
+        match &inst.data {
+            InstData::VarRef { name, .. } => {
+                if *name == self_sym {
+                    return Ok(());
+                }
+                return Err(CompileError::new(
+                    ErrorKind::AccessorYieldNotReceiverRooted {
+                        found: format!("a place rooted at `{}`", interner.resolve(name)),
+                    },
+                    span,
+                ));
+            }
+            InstData::FieldGet { base, .. } | InstData::IndexGet { base, .. } => current = *base,
+            InstData::MethodCall { receiver, .. } => current = *receiver,
+            _ => {
+                return Err(CompileError::new(
+                    ErrorKind::AccessorYieldNotReceiverRooted {
+                        found: "a value expression".to_string(),
+                    },
+                    span,
+                ));
+            }
+        }
+    }
 }
 
 /// The single trailing `yield` that an accessor body must fall through to
@@ -3303,9 +3437,8 @@ pub(super) fn check_accessor_declaration_shape(
 ///
 /// Which instruction is the trailing exit is decidable from the RIR alone, so
 /// the declaration seam rejects a body with no trailing `yield` for every
-/// accessor in the program. Rejecting the *other* exits — a second `yield`, a
-/// `return`, a `?` — needs the per-instruction analysis, which the driver runs
-/// only for a body something demands.
+/// accessor in the program. [`check_accessor_body_exits`] then rejects the
+/// *other* exits from the same seam.
 pub(super) fn accessor_trailing_yield(rir: &rue_rir::Rir, body: InstRef) -> CompileResult<InstRef> {
     // A single-statement body lowers to the instruction itself; a
     // multi-statement body lowers to a block whose last instruction is the

--- a/crates/rue-air/src/sema/mod.rs
+++ b/crates/rue-air/src/sema/mod.rs
@@ -1456,13 +1456,20 @@ impl<'a> Sema<'a, MutableDeclarations> {
 
     /// Reject every declaration whose legality is decided by its own shape,
     /// before any signature type is resolved: ill-formed `-> borrow T`
-    /// accessors (6.6:3-6.6:5, ADR-0062) and `extern "C"` declarations of the
+    /// accessors (6.6:3-6.6:7, ADR-0062) and `extern "C"` declarations of the
     /// program entry symbol (9.3:6, RUE-1220).
     ///
     /// Predeclaration is the one point every producer reaches for every
     /// declaration the program contains, whether or not anything calls it.
     /// The driver analyzes bodies only on demand, so a rule that runs from a
     /// body would let an uncalled accessor escape the preview gate entirely.
+    ///
+    /// A `yield` in a body whose declaration is *not* an accessor (E0256, the
+    /// last sentence of 6.6:6) is deliberately not decided here: an ordinary
+    /// declaration's legality never depends on its own body, and reaching that
+    /// rule for an uncalled ordinary function means analyzing every body the
+    /// program declares. It stays with the demanded path in
+    /// [`super::control_flow`].
     fn check_declaration_shapes(
         &self,
         pending_payloads: &[binding_manifest::PendingDeclarationPayload],
@@ -1474,6 +1481,7 @@ impl<'a> Sema<'a, MutableDeclarations> {
             };
             declarations::check_accessor_declaration_shape(
                 self.rir,
+                self.interner,
                 pending.declaration,
                 body,
                 pending.shell.identity.owner.is_some(),

--- a/crates/rue-air/src/sema/provider_body_host.rs
+++ b/crates/rue-air/src/sema/provider_body_host.rs
@@ -2823,6 +2823,7 @@ where
     fn reject_free_function_accessor(&self, declaration: InstRef) -> CompileResult<()> {
         super::declarations::check_accessor_declaration_shape(
             self.rir.rir(),
+            &self.interner,
             declaration,
             None,
             false,

--- a/crates/rue-air/src/sema/tests.rs
+++ b/crates/rue-air/src/sema/tests.rs
@@ -4321,7 +4321,7 @@ struct P {{
     fn uncalled_accessor_body_requires_a_trailing_yield() {
         // 6.6:6 with no call site. Which instruction is the trailing exit is
         // decidable from the RIR, so this half of the rule holds without body
-        // analysis; rejecting the other exits still needs a demanded body.
+        // analysis.
         let source = format!(
             "
 struct P {{
@@ -4338,6 +4338,91 @@ struct P {{
                 .iter()
                 .any(|error| matches!(&error.kind, ErrorKind::AccessorBodyMissingYield))
         );
+    }
+
+    #[test]
+    fn uncalled_accessor_body_rejects_a_second_yield() {
+        // The rest of 6.6:6 with no call site: containment of a second exit
+        // is decidable from the RIR, so it is decided at the declaration.
+        let source = format!(
+            "
+struct P {{
+    x: i64,
+
+    fn xr(borrow self) -> borrow i64 {{
+        yield self.x;
+        yield self.x;
+    }}
+}}{UNCALLED_MAIN}"
+        );
+        let errors = compile_with_accessors(&source).expect_err("second yield");
+        assert!(errors.iter().any(|error| matches!(
+            &error.kind,
+            ErrorKind::AccessorBodyOtherExit { found } if found == "a second `yield`"
+        )));
+    }
+
+    #[test]
+    fn uncalled_accessor_body_rejects_return() {
+        // 6.6:6 forbids `return` appearing in the body, with no call site.
+        let source = format!(
+            "
+struct P {{
+    x: i64,
+
+    fn xr(borrow self, k: i64) -> borrow i64 {{
+        if k == 0 {{
+            return 1;
+        }}
+        yield self.x;
+    }}
+}}{UNCALLED_MAIN}"
+        );
+        let errors = compile_with_accessors(&source).expect_err("return in accessor");
+        assert!(errors.iter().any(|error| matches!(
+            &error.kind,
+            ErrorKind::AccessorBodyOtherExit { found } if found == "a `return`"
+        )));
+    }
+
+    #[test]
+    fn uncalled_accessor_yield_must_root_at_receiver() {
+        // 6.6:7 with no call site: the yielded chain's root is syntactic.
+        let source = format!(
+            "
+struct P {{
+    x: i64,
+
+    fn xr(borrow self, other: i64) -> borrow i64 {{
+        yield other;
+    }}
+}}{UNCALLED_MAIN}"
+        );
+        let errors = compile_with_accessors(&source).expect_err("yield of a non-receiver place");
+        assert!(errors.iter().any(|error| matches!(
+            &error.kind,
+            ErrorKind::AccessorYieldNotReceiverRooted { found } if found.contains("`other`")
+        )));
+    }
+
+    #[test]
+    fn uncalled_nested_accessor_yield_compiles() {
+        // Control for the one link 6.6:7 leaves to the demanded path: a
+        // method-call link is accepted at the declaration, so a legal nested
+        // accessor chain nothing calls still compiles.
+        let source = format!(
+            "
+struct P {{
+    x: i64,
+
+    @allow(unused_function)
+    fn inner(borrow self) -> borrow i64 {{ yield self.x; }}
+
+    @allow(unused_function)
+    fn outer(borrow self) -> borrow i64 {{ yield self.inner(); }}
+}}{UNCALLED_MAIN}"
+        );
+        compile_with_accessors(&source).expect("a legal uncalled accessor chain compiles");
     }
 
     #[test]

--- a/crates/rue-compiler/src/retained_charge.rs
+++ b/crates/rue-compiler/src/retained_charge.rs
@@ -1344,6 +1344,7 @@ impl RetainedCharge for rue_error::ErrorKind {
             | E::BorrowInoutConflict { variable: value }
             | E::MoveOutOfInout { variable: value }
             | E::AccessorYieldNotReceiverRooted { found: value }
+            | E::AccessorBodyOtherExit { found: value }
             | E::AccessorRequiresBorrowSelf { found: value }
             | E::AccessorResultMoved { ty: value }
             | E::AccessorLoanConflict {

--- a/crates/rue-compiler/src/revisioned_query_database.rs
+++ b/crates/rue-compiler/src/revisioned_query_database.rs
@@ -9853,7 +9853,7 @@ fn resolve_parsed_semantic_signature(
             is_extern,
             is_c_export,
             is_accessor,
-            accessor_body_has_trailing_yield,
+            accessor_body,
         } => {
             if *is_accessor {
                 if !provider
@@ -9914,8 +9914,29 @@ fn resolve_parsed_semantic_signature(
                         },
                     ));
                 }
-                if !*accessor_body_has_trailing_yield {
-                    return Err(diagnostic(rue_error::ErrorKind::AccessorBodyMissingYield));
+                // 6.6:6 and 6.6:7 over the accessor's own retained body. These
+                // are legality rules on the declaration, so they hold with no
+                // call site anywhere in the program (RUE-1212); see
+                // `AccessorBodyShape` for the single link they leave to the
+                // demanded path.
+                use crate::semantic_query_nucleus::AccessorBodyShape as Shape;
+                match accessor_body {
+                    Shape::WellFormed => {}
+                    Shape::MissingTrailingYield => {
+                        return Err(diagnostic(rue_error::ErrorKind::AccessorBodyMissingYield));
+                    }
+                    Shape::OtherExit { found } => {
+                        return Err(diagnostic(rue_error::ErrorKind::AccessorBodyOtherExit {
+                            found: found.to_string(),
+                        }));
+                    }
+                    Shape::YieldNotReceiverRooted { found } => {
+                        return Err(diagnostic(
+                            rue_error::ErrorKind::AccessorYieldNotReceiverRooted {
+                                found: found.to_string(),
+                            },
+                        ));
+                    }
                 }
             }
             let mut generic_index = 0_u32;

--- a/crates/rue-compiler/src/semantic_query_nucleus.rs
+++ b/crates/rue-compiler/src/semantic_query_nucleus.rs
@@ -29,6 +29,30 @@ pub(crate) struct ParsedSemanticParameter {
     pub(crate) ty: Arc<str>,
 }
 
+/// The accessor-body legality facts that are decidable from the declaration's
+/// own retained syntax (spec 6.6:6, 6.6:7).
+///
+/// An accessor is the one declaration whose body its signature query reads:
+/// 6.6:6 and 6.6:7 are legality rules on the declaration, so a
+/// declared-but-uncalled accessor is exactly as ill-formed as a called one,
+/// and the driver analyzes a body only when something demands it (RUE-1212).
+/// Everything here is syntactic; the one accessor-body question that is not —
+/// whether a method-call link in the yielded projection chain names an
+/// accessor — stays with the demanded path and is documented on
+/// [`accessor_body_shape`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum AccessorBodyShape {
+    /// The body's final statement is not a `yield` (E0254).
+    MissingTrailingYield,
+    /// A trailing `yield` exists, but another exit bypasses it (E0254).
+    OtherExit { found: Arc<str> },
+    /// The trailing `yield` hands out something that is not a place rooted at
+    /// the receiver (E0255).
+    YieldNotReceiverRooted { found: Arc<str> },
+    /// Well-formed as far as the declaration alone can decide.
+    WellFormed,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) enum ParsedSemanticSignature {
     Callable {
@@ -40,7 +64,11 @@ pub(crate) enum ParsedSemanticSignature {
         is_extern: bool,
         is_c_export: bool,
         is_accessor: bool,
-        accessor_body_has_trailing_yield: bool,
+        /// What the accessor body's own syntax decides about spec 6.6:6 and
+        /// 6.6:7. Meaningful only when `is_accessor`; an ordinary signature
+        /// retains no body and always reports
+        /// [`AccessorBodyShape::MissingTrailingYield`] for the empty stand-in.
+        accessor_body: AccessorBodyShape,
     },
     Struct {
         fields: Arc<[(Arc<str>, Arc<str>)]>,
@@ -132,6 +160,92 @@ fn parsed_parameters(
         .map(Into::into)
 }
 
+/// The `yield` an accessor body falls through to: the body itself, the
+/// block's final expression, or its final statement (spec 6.6:6).
+fn trailing_yield(body: &rue_parser::ast::Expr) -> Option<&rue_parser::ast::YieldExpr> {
+    use rue_parser::ast::{Expr, Statement};
+    match body {
+        Expr::Yield(exit) => Some(exit),
+        Expr::Block(block) => match (block.expr.as_ref(), block.statements.last()) {
+            (Expr::Yield(exit), _) | (_, Some(Statement::Expr(Expr::Yield(exit)))) => Some(exit),
+            _ => None,
+        },
+        _ => None,
+    }
+}
+
+/// Decide 6.6:6 and 6.6:7 from an accessor body's own syntax.
+///
+/// Both rules are containment and shape questions — "the final statement is a
+/// `yield`, no other `yield` may appear, ... the body **MUST NOT** contain
+/// `return` or `?`", and "the operand ... **MUST** be a place rooted at the
+/// receiver parameter" — so an accessor the program merely declares is
+/// judged exactly like one something calls (RUE-1212). Containment is read
+/// off the syntax, which is why a `return` in a branch a specialization would
+/// later prune still counts: 6.6:6 forbids the form appearing in the body.
+///
+/// One link of 6.6:7 is not syntactic. A projection chain may pass through a
+/// nested accessor call, and whether `self.f()` names an accessor or a plain
+/// method is a resolved-type question the declaration cannot answer. This
+/// walk therefore accepts any method-call link and keeps descending to the
+/// chain's root, leaving exactly one residual for a declaration nothing
+/// calls: `yield self.plain();`, where the chain is receiver-rooted but the
+/// link is not an accessor. `rue_air::sema::control_flow` rejects that on the
+/// demanded path, with the receiver's type in hand.
+fn accessor_body_shape(
+    body: &rue_parser::ast::Expr,
+    interner: &crate::ThreadedRodeo,
+) -> AccessorBodyShape {
+    use rue_parser::ast::Expr;
+    let Some(trailing) = trailing_yield(body) else {
+        return AccessorBodyShape::MissingTrailingYield;
+    };
+    let mut pending = vec![body];
+    while let Some(expr) = pending.pop() {
+        let found = match expr {
+            // Occurrences are distinguished by span: the reparsed signature
+            // source holds each `yield` exactly once.
+            Expr::Yield(exit) if exit.span != trailing.span => "a second `yield`",
+            Expr::Return(_) => "a `return`",
+            Expr::Try(_) => "a `?`",
+            _ => {
+                expr.child_exprs(&mut pending);
+                continue;
+            }
+        };
+        return AccessorBodyShape::OtherExit {
+            found: Arc::from(found),
+        };
+    }
+    let mut current = trailing.value.as_ref();
+    loop {
+        let found = match current {
+            Expr::SelfExpr(_) => return AccessorBodyShape::WellFormed,
+            Expr::Paren(paren) => {
+                current = &paren.inner;
+                continue;
+            }
+            Expr::Field(field) => {
+                current = &field.base;
+                continue;
+            }
+            Expr::Index(index) => {
+                current = &index.base;
+                continue;
+            }
+            Expr::MethodCall(call) => {
+                current = &call.receiver;
+                continue;
+            }
+            Expr::Ident(name) => format!("a place rooted at `{}`", interner.resolve(&name.name)),
+            _ => "a value expression".to_owned(),
+        };
+        return AccessorBodyShape::YieldNotReceiverRooted {
+            found: Arc::from(found),
+        };
+    }
+}
+
 /// Reparse one exact body-free syntax terminal into a value-only shape. This
 /// parser owns no name or type resolution policy; every type fragment is later
 /// routed through `rue_air::resolve_semantic_type_syntax`.
@@ -156,19 +270,7 @@ pub(crate) fn parse_semantic_signature(
         .first()
         .ok_or_else(|| Arc::from("semantic signature parsed no declaration"))?;
     let unit: Arc<str> = Arc::from("()");
-    let has_trailing_yield = |body: &rue_parser::ast::Expr| match body {
-        rue_parser::ast::Expr::Yield(_) => true,
-        rue_parser::ast::Expr::Block(block) => {
-            matches!(block.expr.as_ref(), rue_parser::ast::Expr::Yield(_))
-                || matches!(
-                    block.statements.last(),
-                    Some(rue_parser::ast::Statement::Expr(
-                        rue_parser::ast::Expr::Yield(_)
-                    ))
-                )
-        }
-        _ => false,
-    };
+    let body_shape = |body: &rue_parser::ast::Expr| accessor_body_shape(body, &interner);
     let callable = |parameters: &[rue_parser::ast::Param],
                     result: Option<&rue_parser::ast::TypeExpr>,
                     has_self,
@@ -177,7 +279,7 @@ pub(crate) fn parse_semantic_signature(
                     is_extern,
                     is_c_export,
                     is_accessor,
-                    accessor_body_has_trailing_yield|
+                    accessor_body|
      -> Result<ParsedSemanticSignature, Arc<str>> {
         Ok(ParsedSemanticSignature::Callable {
             parameters: parsed_parameters(&source, &interner, parameters)?,
@@ -191,7 +293,7 @@ pub(crate) fn parse_semantic_signature(
             is_extern,
             is_c_export,
             is_accessor,
-            accessor_body_has_trailing_yield,
+            accessor_body,
         })
     };
     match (key.category, item) {
@@ -204,7 +306,7 @@ pub(crate) fn parse_semantic_signature(
             false,
             function.export_abi.is_some(),
             function.borrow_return.is_some(),
-            has_trailing_yield(&function.body),
+            body_shape(&function.body),
         ),
         (Category::ExternFunction, rue_parser::ast::Item::Extern(block)) => {
             let function = block
@@ -220,7 +322,7 @@ pub(crate) fn parse_semantic_signature(
                 true,
                 false,
                 false,
-                false,
+                AccessorBodyShape::MissingTrailingYield,
             )
         }
         (Category::Method | Category::AssociatedFunction, rue_parser::ast::Item::Struct(owner)) => {
@@ -240,7 +342,7 @@ pub(crate) fn parse_semantic_signature(
                 false,
                 false,
                 method.borrow_return.is_some(),
-                has_trailing_yield(&method.body),
+                body_shape(&method.body),
             )
         }
         (Category::Struct, rue_parser::ast::Item::Struct(structure)) => {

--- a/crates/rue-error/src/lib.rs
+++ b/crates/rue-error/src/lib.rs
@@ -1560,6 +1560,15 @@ pub enum ErrorKind {
         "an accessor body must end in a single trailing `yield`: every non-diverging path must fall through to it, and no code may follow it"
     )]
     AccessorBodyMissingYield,
+    /// An accessor body contains an exit that bypasses its trailing `yield`:
+    /// a second `yield`, a `return`, or a `?` (ADR-0062 phase 1). Shares
+    /// E0254 with [`ErrorKind::AccessorBodyMissingYield`]; the two halves of
+    /// 6.6:6 differ only in which way the body fails to end in exactly one
+    /// `yield`.
+    #[error(
+        "an accessor body must end in a single trailing `yield`, but this body contains {found}: guards may only diverge or fall through to the trailing `yield`"
+    )]
+    AccessorBodyOtherExit { found: String },
     /// The operand of an accessor's `yield` is not a place rooted at the
     /// receiver parameter.
     #[error("an accessor must yield a place rooted at `self`, not {found}")]
@@ -2080,7 +2089,9 @@ impl ErrorKind {
             ErrorKind::AccessorResultStored { .. } => ErrorCode::ACCESSOR_RESULT_STORED,
             ErrorKind::AccessorResultBound { .. } => ErrorCode::ACCESSOR_RESULT_BOUND,
             ErrorKind::AccessorResultCaptured { .. } => ErrorCode::ACCESSOR_RESULT_CAPTURED,
-            ErrorKind::AccessorBodyMissingYield => ErrorCode::ACCESSOR_BODY_MISSING_YIELD,
+            ErrorKind::AccessorBodyMissingYield | ErrorKind::AccessorBodyOtherExit { .. } => {
+                ErrorCode::ACCESSOR_BODY_MISSING_YIELD
+            }
             ErrorKind::AccessorYieldNotReceiverRooted { .. } => {
                 ErrorCode::ACCESSOR_YIELD_NOT_RECEIVER_ROOTED
             }

--- a/crates/rue-parser/src/ast.rs
+++ b/crates/rue-parser/src/ast.rs
@@ -1359,6 +1359,103 @@ impl Expr {
             Expr::Error(span) => *span,
         }
     }
+
+    /// Append this expression's direct sub-expressions to `out`.
+    ///
+    /// The match is exhaustive with no catch-all arm, so a new [`Expr`]
+    /// variant does not compile until its sub-expressions are listed here.
+    /// That is what lets a consumer decide a containment question over a body
+    /// — "does this accessor body contain a `return`?" (spec 6.6:6) — from
+    /// syntax alone, with no chance of silently missing a form.
+    ///
+    /// Statements are traversed through the blocks that hold them. Types are
+    /// not expressions and are never reported, so an anonymous struct type
+    /// written inside a body keeps its own method bodies to itself.
+    pub fn child_exprs<'a>(&'a self, out: &mut Vec<&'a Expr>) {
+        fn block<'a>(block: &'a BlockExpr, out: &mut Vec<&'a Expr>) {
+            for statement in &block.statements {
+                match statement {
+                    Statement::Let(binding) => out.push(&binding.init),
+                    Statement::Assign(assignment) => {
+                        match &assignment.target {
+                            AssignTarget::Var(_) => {}
+                            AssignTarget::Field(field) => out.push(&field.base),
+                            AssignTarget::Index(index) => {
+                                out.extend([index.base.as_ref(), index.index.as_ref()])
+                            }
+                        }
+                        out.push(&assignment.value);
+                    }
+                    Statement::Expr(expr) => out.push(expr),
+                }
+            }
+            out.push(&block.expr);
+        }
+        fn args<'a>(args: &'a [CallArg], out: &mut Vec<&'a Expr>) {
+            out.extend(args.iter().map(|arg| &arg.expr));
+        }
+        match self {
+            Expr::Int(_)
+            | Expr::String(_)
+            | Expr::Bool(_)
+            | Expr::Unit(_)
+            | Expr::Ident(_)
+            | Expr::Continue(_)
+            | Expr::SelfExpr(_)
+            | Expr::TypeLit(_)
+            | Expr::Error(_) => {}
+            Expr::Binary(binary) => out.extend([binary.left.as_ref(), binary.right.as_ref()]),
+            Expr::Unary(unary) => out.push(&unary.operand),
+            Expr::Paren(paren) => out.push(&paren.inner),
+            Expr::Block(body) => block(body, out),
+            Expr::If(expr) => {
+                out.push(&expr.cond);
+                block(&expr.then_block, out);
+                if let Some(otherwise) = &expr.else_block {
+                    block(otherwise, out);
+                }
+            }
+            Expr::Match(expr) => {
+                out.push(&expr.scrutinee);
+                out.extend(expr.arms.iter().map(|arm| arm.body.as_ref()));
+            }
+            Expr::While(expr) => {
+                out.push(&expr.cond);
+                block(&expr.body, out);
+            }
+            Expr::Loop(expr) => block(&expr.body, out),
+            Expr::For(expr) => {
+                out.push(&expr.iterable);
+                block(&expr.body, out);
+            }
+            Expr::Call(call) => args(&call.args, out),
+            Expr::Break(expr) => out.extend(expr.value.as_deref()),
+            Expr::Return(expr) => out.extend(expr.value.as_deref()),
+            Expr::Yield(expr) => out.push(&expr.value),
+            Expr::StructLit(literal) => {
+                out.extend(literal.base.as_deref());
+                if let Some(ctor_args) = &literal.ctor_args {
+                    args(ctor_args, out);
+                }
+                out.extend(literal.fields.iter().map(|field| field.value.as_ref()));
+            }
+            Expr::Field(field) => out.push(&field.base),
+            Expr::MethodCall(call) => {
+                out.push(&call.receiver);
+                args(&call.args, out);
+            }
+            Expr::Try(expr) => out.push(&expr.operand),
+            Expr::IntrinsicCall(call) => out.extend(call.args.iter().filter_map(|arg| match arg {
+                IntrinsicArg::Expr(expr) => Some(expr),
+                IntrinsicArg::Type(_) => None,
+            })),
+            Expr::ArrayLit(literal) => out.extend(literal.elements.iter()),
+            Expr::Index(index) => out.extend([index.base.as_ref(), index.index.as_ref()]),
+            Expr::Path(path) => out.extend(path.base.as_deref()),
+            Expr::Comptime(expr) => out.push(&expr.expr),
+            Expr::Checked(expr) => out.push(&expr.expr),
+        }
+    }
 }
 
 fn rebind_span(span: &mut Span, file_id: FileId) {

--- a/crates/rue-rir/src/inst.rs
+++ b/crates/rue-rir/src/inst.rs
@@ -3032,6 +3032,131 @@ impl Rir {
         Ok(())
     }
 
+    /// Append every instruction `instruction` references — its operands, block
+    /// members, match-arm bodies, call arguments, and nested declaration
+    /// bodies — to `out`.
+    ///
+    /// The match is exhaustive with no catch-all arm, so a new [`InstData`]
+    /// variant does not compile until its operands are listed here. That is
+    /// what lets a consumer walk an instruction's whole subtree without
+    /// silently missing a syntactic form; the accessor-body legality rules
+    /// (spec 6.6:6, 6.6:7) decide containment questions this way, before any
+    /// type resolves.
+    ///
+    /// Declaration-forming variants report their nested bodies as children. A
+    /// consumer that must not cross a declaration boundary — a nested `fn` owns
+    /// its own body — stops on the declaration instruction itself rather than
+    /// filtering the children out here.
+    pub fn child_instructions(&self, instruction: InstRef, out: &mut Vec<InstRef>) {
+        match &self.get(instruction).data {
+            InstData::IntConst(_)
+            | InstData::BoolConst(_)
+            | InstData::UnitConst
+            | InstData::Continue
+            | InstData::StringConst { .. }
+            | InstData::VarRef { .. }
+            | InstData::TypeConst { .. }
+            | InstData::TypeIntrinsic { .. }
+            | InstData::OffsetOf { .. }
+            | InstData::EnumDecl { .. }
+            | InstData::AnonEnumType { .. } => {}
+            InstData::Add { lhs, rhs }
+            | InstData::Sub { lhs, rhs }
+            | InstData::Mul { lhs, rhs }
+            | InstData::Div { lhs, rhs }
+            | InstData::Mod { lhs, rhs }
+            | InstData::Eq { lhs, rhs }
+            | InstData::Ne { lhs, rhs }
+            | InstData::Lt { lhs, rhs }
+            | InstData::Gt { lhs, rhs }
+            | InstData::Le { lhs, rhs }
+            | InstData::Ge { lhs, rhs }
+            | InstData::And { lhs, rhs }
+            | InstData::Or { lhs, rhs }
+            | InstData::BitAnd { lhs, rhs }
+            | InstData::BitOr { lhs, rhs }
+            | InstData::BitXor { lhs, rhs }
+            | InstData::Shl { lhs, rhs }
+            | InstData::Shr { lhs, rhs } => out.extend([*lhs, *rhs]),
+            InstData::Neg { operand }
+            | InstData::Not { operand }
+            | InstData::BitNot { operand }
+            | InstData::Try { operand }
+            | InstData::Comptime { expr: operand }
+            | InstData::Checked { expr: operand }
+            | InstData::Yield(operand) => out.push(*operand),
+            InstData::Branch {
+                cond,
+                then_block,
+                else_block,
+            } => {
+                out.extend([*cond, *then_block]);
+                out.extend(else_block.iter().copied());
+            }
+            InstData::Loop { cond, body } => out.extend([*cond, *body]),
+            InstData::InfiniteLoop { body, .. } => out.push(*body),
+            InstData::Match { scrutinee, arms } => {
+                out.push(*scrutinee);
+                for (pattern, body) in self.match_arms(arms).iter() {
+                    out.push(body);
+                    if let RirPatternView::Path {
+                        module, ctor_head, ..
+                    } = pattern
+                    {
+                        out.extend(module);
+                        out.extend(ctor_head);
+                    }
+                }
+            }
+            InstData::Break { value } | InstData::Ret(value) => out.extend(value.iter().copied()),
+            InstData::FnDecl { body, .. } | InstData::DropFnDecl { body, .. } => out.push(*body),
+            InstData::ConstDecl { init, .. } | InstData::Alloc { init, .. } => out.push(*init),
+            InstData::Call { args, .. } => {
+                out.extend(self.call_args(args).values().map(|arg| arg.value))
+            }
+            InstData::MethodCall { receiver, args, .. } => {
+                out.push(*receiver);
+                out.extend(self.call_args(args).values().map(|arg| arg.value));
+            }
+            InstData::Intrinsic { args, .. } => out.extend(self.intrinsic_args(args).values()),
+            InstData::InternalIntrinsic { args, .. } => {
+                out.extend(self.internal_intrinsic_args(args).values())
+            }
+            InstData::Block { instructions } => out.extend(self.block_insts(instructions).values()),
+            InstData::Assign { value, .. } => out.push(*value),
+            InstData::StructDecl { methods, .. } => {
+                out.extend(self.struct_methods(methods).values())
+            }
+            InstData::AnonStructType { methods, .. } => {
+                out.extend(self.anon_struct_methods(methods).values())
+            }
+            InstData::StructInit {
+                module,
+                ctor_head,
+                fields,
+                ..
+            } => {
+                out.extend(module.iter().copied());
+                out.extend(ctor_head.iter().copied());
+                out.extend(self.field_inits(fields).values().map(|(_, value)| value));
+            }
+            InstData::FieldGet { base, .. } => out.push(*base),
+            InstData::FieldSet { base, value, .. } => out.extend([*base, *value]),
+            InstData::EnumVariant { module, .. } => out.extend(module.iter().copied()),
+            InstData::ArrayInit { elements } => out.extend(self.array_elements(elements).values()),
+            InstData::ArrayRepeat { value, .. } => out.push(*value),
+            InstData::IndexGet {
+                base,
+                index: subscript,
+            } => out.extend([*base, *subscript]),
+            InstData::IndexSet {
+                base,
+                index: subscript,
+                value,
+            } => out.extend([*base, *subscript, *value]),
+        }
+    }
+
     fn validate_directive_range(&self, range: &RirDirectivesRange) -> Result<(), RirPayloadError> {
         self.validate_variable_records(
             range,

--- a/crates/rue-spec/cases/items/borrow-accessors.toml
+++ b/crates/rue-spec/cases/items/borrow-accessors.toml
@@ -292,12 +292,18 @@ compile_fail = true
 error_contains = ["E0255", "place rooted at `self`"]
 
 # ---------------------------------------------------------------------------
-# Declared but never called (RUE-1212). 6.6:3-6.6:5 are legality rules on the
-# declaration, so they hold with no call site anywhere in the program; the
-# trailing-exit half of 6.6:6 is decidable from the declaration's body shape
-# and holds too. The remaining 6.6:6/6.6:7 body rules need the per-instruction
-# analysis, which the driver runs only for a body something demands, so they
-# are covered above with a call site.
+# Declared but never called (RUE-1212). 6.6:3-6.6:7 are legality rules on the
+# declaration, so they hold with no call site anywhere in the program: the
+# signature, the body's exits, and the yielded projection's root are all
+# decidable from the declaration's own syntax.
+#
+# Two parts of 6.6 remain demand-driven, both because they need resolved
+# types. A projection chain through a nested method call is legal only when
+# that method is itself an accessor, which the declaration cannot tell from a
+# plain method (covered with a call site by
+# `accessor_yield_through_plain_method_is_rejected`); and a `yield` in a body
+# that is not an accessor's is E0256 from the body analysis, since an ordinary
+# declaration retains no body to inspect.
 # ---------------------------------------------------------------------------
 
 [[case]]
@@ -397,6 +403,161 @@ fn main() -> i32 { 0 }
 """
 compile_fail = true
 error_contains = ["E0254", "single trailing `yield`"]
+
+[[case]]
+name = "uncalled_accessor_body_rejects_a_second_yield"
+spec = ["6.6:6"]
+description = "A second `yield` bypasses the trailing exit, with no call site (E0254)."
+preview = "borrow_accessors"
+preview_should_pass = true
+source = """
+struct P {
+    x: i64,
+
+    @allow(unused_function)
+    fn xr(borrow self) -> borrow i64 {
+        yield self.x;
+        yield self.x;
+    }
+}
+fn main() -> i32 { 0 }
+"""
+compile_fail = true
+error_contains = ["E0254", "single trailing `yield`", "a second `yield`"]
+
+[[case]]
+name = "uncalled_accessor_body_rejects_return"
+spec = ["6.6:6"]
+description = "An accessor body may not contain `return`, with no call site (E0254)."
+preview = "borrow_accessors"
+preview_should_pass = true
+source = """
+struct P {
+    x: i64,
+
+    @allow(unused_function)
+    fn xr(borrow self, k: i64) -> borrow i64 {
+        if k == 0 {
+            return 1;
+        }
+        yield self.x;
+    }
+}
+fn main() -> i32 { 0 }
+"""
+compile_fail = true
+error_contains = ["E0254", "single trailing `yield`", "a `return`"]
+
+[[case]]
+name = "uncalled_accessor_body_rejects_try"
+spec = ["6.6:6"]
+description = "An accessor body may not contain `?`, with no call site (E0254)."
+preview = "borrow_accessors"
+preview_should_pass = true
+source = """
+struct P {
+    x: i64,
+
+    @allow(unused_function)
+    fn xr(borrow self) -> borrow i64 {
+        let parsed = @parse_i64("1")?;
+        yield self.x;
+    }
+}
+fn main() -> i32 { 0 }
+"""
+compile_fail = true
+error_contains = ["E0254", "single trailing `yield`", "a `?`"]
+
+[[case]]
+name = "uncalled_accessor_yield_must_root_at_receiver"
+spec = ["6.6:7"]
+description = "Yielding a parameter other than the receiver is rejected with no call site (E0255)."
+preview = "borrow_accessors"
+preview_should_pass = true
+source = """
+struct P {
+    x: i64,
+
+    @allow(unused_function)
+    fn xr(borrow self, other: i64) -> borrow i64 {
+        yield other;
+    }
+}
+fn main() -> i32 { 0 }
+"""
+compile_fail = true
+error_contains = ["E0255", "place rooted at `self`", "`other`"]
+
+[[case]]
+name = "uncalled_accessor_yield_of_a_computed_value_is_rejected"
+spec = ["6.6:7"]
+description = "Yielding a computed value, not a place, is rejected with no call site (E0255)."
+preview = "borrow_accessors"
+preview_should_pass = true
+source = """
+struct P {
+    x: i64,
+
+    @allow(unused_function)
+    fn xr(borrow self) -> borrow i64 {
+        yield self.x + 1;
+    }
+}
+fn main() -> i32 { 0 }
+"""
+compile_fail = true
+error_contains = ["E0255", "place rooted at `self`", "a value expression"]
+
+[[case]]
+name = "uncalled_nested_accessor_yield_compiles"
+spec = ["6.6:7"]
+description = "Control: a nested accessor call is a legal projection link, so an uncalled accessor chain compiles."
+preview = "borrow_accessors"
+preview_should_pass = true
+source = """
+struct P {
+    x: i64,
+    cells: [i64; 4],
+
+    @allow(unused_function)
+    fn inner(borrow self) -> borrow i64 { yield self.x; }
+
+    @allow(unused_function)
+    fn outer(borrow self) -> borrow i64 { yield self.inner(); }
+
+    @allow(unused_function)
+    fn at(borrow self, i: u64) -> borrow i64 {
+        if i >= 4 {
+            @panic("index out of bounds");
+        }
+        yield self.cells[i];
+    }
+}
+fn main() -> i32 { 0 }
+"""
+exit_code = 0
+
+[[case]]
+name = "accessor_yield_through_plain_method_is_rejected"
+spec = ["6.6:7"]
+description = "A projection link through a non-accessor method is rejected (E0255); this link is the one part of 6.6:7 that needs the receiver's resolved type, so it is diagnosed from the call site."
+preview = "borrow_accessors"
+preview_should_pass = true
+source = """
+struct P {
+    x: i64,
+
+    fn plain(borrow self) -> i64 { self.x }
+    fn xr(borrow self) -> borrow i64 { yield self.plain(); }
+}
+fn main() -> i32 {
+    let p = P { x: 1 };
+    if p.xr() == 1 { 0 } else { 1 }
+}
+"""
+compile_fail = true
+error_contains = ["E0255", "not an accessor projection"]
 
 [[case]]
 name = "uncalled_legal_accessor_compiles"

--- a/crates/rue-ui-tests/cases/diagnostics/borrow-accessors.toml
+++ b/crates/rue-ui-tests/cases/diagnostics/borrow-accessors.toml
@@ -24,3 +24,44 @@ fn main() -> i32 {
 preview = "borrow_accessors"
 compile_fail = true
 error_contains = ["E0250", "cannot return an accessor result", "`xr`", "`p`"]
+
+[[case]]
+name = "uncalled_accessor_body_exit_names_the_offending_form"
+description = "The declaration-seam E0254 names which exit bypasses the trailing `yield`, since it has no body analysis to anchor a note to."
+source = """
+struct P {
+    x: i64,
+
+    @allow(unused_function)
+    fn xr(borrow self) -> borrow i64 {
+        yield self.x;
+        yield self.x;
+    }
+}
+fn main() -> i32 { 0 }
+"""
+preview = "borrow_accessors"
+compile_fail = true
+error_contains = [
+    "E0254",
+    "a second `yield`",
+    "guards may only diverge or fall through to the trailing `yield`",
+]
+
+[[case]]
+name = "uncalled_accessor_yield_root_names_the_offending_root"
+description = "The declaration-seam E0255 names the root the body actually yielded from."
+source = """
+struct P {
+    x: i64,
+
+    @allow(unused_function)
+    fn xr(borrow self, other: i64) -> borrow i64 {
+        yield other;
+    }
+}
+fn main() -> i32 { 0 }
+"""
+preview = "borrow_accessors"
+compile_fail = true
+error_contains = ["E0255", "place rooted at `self`", "`other`"]


### PR DESCRIPTION
Finishes what #2088 started, unblocked by RUE-1208's landing. The body-interior halves of the accessor legality rules — 6.6:6's "no exit other than the trailing yield" and 6.6:7's receiver-rooted operand — only ran when a call demanded the body, so an uncalled accessor with a second `yield`, a `return`, a `?`, or a non-receiver root compiled clean.

**Both producers now walk the body at declaration processing** — necessarily both, since instrumentation proved the driver never reaches the rue-air declaration checks for accessors: the driver walks the accessor-only reparsed body that `RawDeclarationSignatureSyntax` already retains (`AccessorBodyShape` replacing the boolean trailing-yield fact), and rue-air walks the RIR body inside the predeclaration shape check. Both walks rest on new **exhaustive child enumerators with no catch-all** (`Rir::child_instructions`, `Expr::child_exprs`), so a future syntax variant cannot open a silent hole. Containment is syntactic — a `return` in a comptime-pruned branch counts, matching 6.6:6's MUST NOT wording; no corpus program was affected. E0254 diagnostics now name the offending form ("this body contains a `return`").

**Honestly-documented residuals** (at both walk sites and in the spec-case comments): `yield self.plain();` — a chain whose method link is a plain method rather than an accessor — needs resolved types and stays demand-driven (still correctly rejected when called); E0256 for uncalled *non*-accessor bodies stays demand-driven because ordinary signatures deliberately remain body-agnostic, and reaching it means the global analyze-every-body change this PR deliberately avoids.

With this, **legality-rule traceability reaches 154/154 (100%)**. Uncalled coverage: 7 new spec cases, 4 rue-air units, 2 UI cases; non-regression verified explicitly for E0261 (still wins over the new checks), RUE-1213, and RUE-1208's splicing.

Fixes RUE-1212.

Follow-up being filed: 6.6:3–6.6:7 are now implemented twice (rue-air over RIR, driver over reparsed AST) and both #2088 and this change had to edit them in lockstep — the "duplicate discovery path" AGENTS.md warns about; consolidation plus the two documented residuals go in one issue.

## Validation

Premerge (78/78, run twice), full spec 2259 + traceability (legality 154/154), spec 6.6 36/36 (re-run post-commit), rue-air 687 + accessor filter 32, compiler 789 (incl. RUE-1208's splice tests), UI, CLI `borrow`/`accessor` filters, quick (re-run), clippy ×2, fmt.

---
_Generated by [Claude Code](https://claude.ai/code/session_01DrKqpQgkHzDHGqpEMjxYdN)_