### PR TITLE
One canonical home for the accessor declaration rules

### DIFF
--- a/crates/rue-air/src/api_inventory.rs
+++ b/crates/rue-air/src/api_inventory.rs
@@ -48,6 +48,40 @@ fn retired_whole_program_body_driver_is_an_explicit_test_oracle_only() {
 }
 
 #[test]
+fn accessor_producers_do_not_spell_their_own_declaration_diagnostics() {
+    // RUE-1232: the 6.6:3-6.6:7 accessor rules have one source of truth in
+    // `declaration_validation`. Each producer lowers its own representation
+    // into that vocabulary and reports what it hands back; none of them may
+    // construct an accessor declaration diagnostic itself, which is how the
+    // RIR walks and the driver's reparsed-AST walk stay unable to drift on
+    // wording.
+    let producers = [
+        include_str!("sema/declarations.rs"),
+        include_str!("sema/ordinary_engine.rs"),
+        include_str!("sema/control_flow.rs"),
+    ]
+    .concat();
+
+    for kind in [
+        ["ErrorKind::Accessor", "RequiresBorrowSelf"].concat(),
+        ["ErrorKind::Accessor", "ParamModeUnsupported"].concat(),
+        ["ErrorKind::Accessor", "BodyMissingYield"].concat(),
+        ["ErrorKind::Accessor", "BodyOtherExit"].concat(),
+        ["ErrorKind::Accessor", "YieldNotReceiverRooted"].concat(),
+    ] {
+        assert!(
+            !producers.contains(&kind),
+            "an accessor producer regained its own copy of a declaration rule: {kind}"
+        );
+    }
+    // The preview subject is a rule too: 6.6:3 names the same form everywhere.
+    assert!(
+        !producers.contains("\"a `-> borrow` accessor\""),
+        "an accessor producer regained its own 6.6:3 gate subject"
+    );
+}
+
+#[test]
 fn canonical_import_consumers_do_not_grow_resolution_policy() {
     let consumers = [
         include_str!("canonical_imports.rs"),

--- a/crates/rue-air/src/declaration_validation.rs
+++ b/crates/rue-air/src/declaration_validation.rs
@@ -102,3 +102,259 @@ pub fn duplicate_destructor(type_name: &str) -> ErrorKind {
         type_name: type_name.to_owned(),
     }
 }
+
+// ---------------------------------------------------------------------------
+// `-> borrow` accessor declaration legality (spec 6.6:3-6.6:7, ADR-0062).
+// ---------------------------------------------------------------------------
+//
+// These rules are legality rules on the *declaration*, so a declared-but-
+// uncalled accessor is exactly as ill-formed as a called one, and every
+// producer that admits an accessor declaration runs them: RIR predeclaration
+// (`sema::declarations`), the body engine (`sema::ordinary_engine`), the
+// demanded body walk (`sema::control_flow`), and the driver's reparsed
+// signature query (`rue_compiler::semantic_query_nucleus`). The producers
+// necessarily differ in *what they walk* — RIR instructions, a resolved
+// parameter list, or a reparsed AST — so the forms below are named after the
+// spec's own vocabulary rather than any one IR, and every producer lowers its
+// nodes into them. The mapping from a form to its diagnostic, and the order in
+// which the rules apply, live here exactly once; without that, the two
+// declaration-time producers drift on wording the way they did before RUE-1232.
+
+/// The preview feature the accessor form is gated behind (6.6:3).
+pub const ACCESSOR_PREVIEW_FEATURE: rue_error::PreviewFeature =
+    rue_error::PreviewFeature::BorrowAccessors;
+
+/// The subject every producer names in the 6.6:3 gate diagnostic. The result
+/// position alone demands the preview, so this is reported before any shape
+/// rule about a form the program cannot yet name.
+pub const ACCESSOR_PREVIEW_SUBJECT: &str = "a `-> borrow` accessor";
+
+/// The note that points an `inout self` accessor at the phase that will admit
+/// it (6.6:4).
+pub const ACCESSOR_INOUT_SELF_NOTE: &str =
+    "mutable accessors (`inout self` -> exclusive result) are a later phase (RUE-1016)";
+
+/// What a producer found in the receiver position of a `-> borrow`
+/// declaration (6.6:4). Only [`AccessorReceiverForm::BorrowSelf`] is legal in
+/// ADR-0062 phase 1: an accessor hands out a shared projection of its
+/// receiver, so the receiver has to exist and be a shared borrow.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AccessorReceiverForm {
+    /// `borrow self`.
+    BorrowSelf,
+    /// `inout self`.
+    InoutSelf,
+    /// A by-value `self`.
+    ValueSelf,
+    /// A declaration with no owning type at all.
+    FreeFunction,
+    /// A declaration with an owning type but no receiver parameter.
+    AssociatedFunction,
+    /// No receiver parameter, from a producer that sees only a resolved
+    /// parameter list and so cannot tell a free function from an associated
+    /// one.
+    MissingReceiver,
+}
+
+/// The mode of one non-receiver accessor parameter (6.6:5). Guard inputs are
+/// plain by-value runtime values evaluated once at the call site.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AccessorParameterForm {
+    ByValue,
+    Borrow,
+    Inout,
+    Comptime,
+}
+
+/// A body element that exits an accessor body without falling through to its
+/// trailing `yield` (6.6:6).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AccessorExitForm {
+    SecondYield,
+    Return,
+    Try,
+}
+
+/// What the trailing `yield`'s projection chain bottoms out at, when that is
+/// *not* the receiver (6.6:7).
+///
+/// A chain descends through field, index, and accessor-call links; the
+/// receiver parameter `self` is the only legal root, so a producer names one
+/// of these forms exactly when the chain is illegal.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum AccessorYieldRootForm {
+    /// Some other named binding: a local, a guard parameter, a global.
+    Named(std::sync::Arc<str>),
+    /// A computed value rather than a place.
+    Value,
+    /// A method-call link the producer *proved* is not an accessor. A producer
+    /// that cannot decide the callee stays permissive and never reports this;
+    /// see [`accessor_method_link_error`].
+    PlainMethod,
+}
+
+/// What a producer knows about one method-call link in a yielded projection
+/// chain (6.6:7).
+///
+/// A link is a legal projection only when the callee is itself an accessor,
+/// which is a resolved-callee question rather than a syntactic one. Producers
+/// differ in how much of it they can answer: the demanded body walk has the
+/// receiver's type, the driver's signature query can decide a link whose
+/// receiver is the accessor's own `self` from the owner's other declarations,
+/// and RIR predeclaration cannot decide any. A producer that cannot decide
+/// reports [`AccessorMethodLink::Unresolved`] and the rule stays permissive —
+/// it never guesses a rejection.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AccessorMethodLink {
+    /// The callee is an accessor: a legal link, keep descending.
+    Accessor,
+    /// The callee is proven to be a plain method.
+    PlainMethod,
+    /// The producer cannot name the callee.
+    Unresolved,
+}
+
+/// 6.6:7 for one method-call link: rejected only when the callee is *proven*
+/// to be a plain method.
+pub fn accessor_method_link_error(link: AccessorMethodLink) -> Option<ErrorKind> {
+    matches!(link, AccessorMethodLink::PlainMethod)
+        .then(|| accessor_yield_root_error(&AccessorYieldRootForm::PlainMethod))
+}
+
+/// The 6.6:6/6.6:7 verdict for one accessor body, decided by a producer's own
+/// walk over its own representation of that body.
+///
+/// This is the producer-neutral currency of the body rules: the driver retains
+/// it in the declaration's durable signature and reports it later, while the
+/// RIR producers pair it with the span of the offending form and report it
+/// immediately.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum AccessorBodyVerdict {
+    /// Well-formed as far as the deciding producer can tell.
+    WellFormed,
+    /// The body's final statement is not a `yield`.
+    MissingTrailingYield,
+    /// A trailing `yield` exists, but another exit bypasses it.
+    OtherExit(AccessorExitForm),
+    /// The trailing `yield` hands out something other than a receiver-rooted
+    /// place.
+    YieldNotReceiverRooted(AccessorYieldRootForm),
+}
+
+/// A violation of the accessor signature rules, in the order the rules apply.
+pub enum AccessorSignatureViolation {
+    /// 6.6:4. `note` is the phase pointer for `inout self`; a producer whose
+    /// diagnostic transport carries no note may drop it.
+    Receiver {
+        kind: ErrorKind,
+        note: Option<&'static str>,
+    },
+    /// 6.6:5. `ordinal` indexes the non-receiver parameter list the caller
+    /// passed, so a producer holding parameter positions can anchor there.
+    Parameter { kind: ErrorKind, ordinal: usize },
+}
+
+/// 6.6:3: the accessor form requires its preview gate. `enabled` is the
+/// caller's answer for [`ACCESSOR_PREVIEW_FEATURE`], since producers carry
+/// their preview set in different shapes.
+pub fn accessor_preview_gate(enabled: bool) -> Option<ErrorKind> {
+    (!enabled).then(|| ErrorKind::PreviewFeatureRequired {
+        feature: ACCESSOR_PREVIEW_FEATURE,
+        what: ACCESSOR_PREVIEW_SUBJECT.to_owned(),
+    })
+}
+
+/// 6.6:4 then 6.6:5 over one accessor declaration's signature. `parameters`
+/// are the non-receiver parameters in declaration order.
+pub fn accessor_signature(
+    receiver: AccessorReceiverForm,
+    parameters: impl IntoIterator<Item = AccessorParameterForm>,
+) -> Option<AccessorSignatureViolation> {
+    if let Some((kind, note)) = accessor_receiver_error(receiver) {
+        return Some(AccessorSignatureViolation::Receiver { kind, note });
+    }
+    for (ordinal, parameter) in parameters.into_iter().enumerate() {
+        if let Some(kind) = accessor_parameter_error(parameter) {
+            return Some(AccessorSignatureViolation::Parameter { kind, ordinal });
+        }
+    }
+    None
+}
+
+/// 6.6:4 alone, for a producer that anchors the receiver diagnostic itself.
+pub fn accessor_receiver_error(
+    receiver: AccessorReceiverForm,
+) -> Option<(ErrorKind, Option<&'static str>)> {
+    let (found, note) = match receiver {
+        AccessorReceiverForm::BorrowSelf => return None,
+        AccessorReceiverForm::InoutSelf => {
+            ("an `inout self` receiver", Some(ACCESSOR_INOUT_SELF_NOTE))
+        }
+        AccessorReceiverForm::ValueSelf => ("a by-value `self` receiver", None),
+        AccessorReceiverForm::FreeFunction => ("a free function", None),
+        AccessorReceiverForm::AssociatedFunction => {
+            ("an associated function with no receiver", None)
+        }
+        AccessorReceiverForm::MissingReceiver => ("a function with no receiver", None),
+    };
+    Some((
+        ErrorKind::AccessorRequiresBorrowSelf {
+            found: found.to_owned(),
+        },
+        note,
+    ))
+}
+
+/// 6.6:5 alone, for one non-receiver parameter. `comptime` is reported ahead
+/// of the passing mode: a comptime guard input is rejected for being absent at
+/// run time, whatever mode it was spelled with.
+pub fn accessor_parameter_error(parameter: AccessorParameterForm) -> Option<ErrorKind> {
+    let mode = match parameter {
+        AccessorParameterForm::ByValue => return None,
+        AccessorParameterForm::Comptime => "`comptime`",
+        AccessorParameterForm::Borrow => "`borrow`",
+        AccessorParameterForm::Inout => "`inout`",
+    };
+    Some(ErrorKind::AccessorParamModeUnsupported {
+        mode: mode.to_owned(),
+    })
+}
+
+/// The diagnostic for a body verdict, or `None` when the body is well-formed.
+pub fn accessor_body_error(verdict: &AccessorBodyVerdict) -> Option<ErrorKind> {
+    match verdict {
+        AccessorBodyVerdict::WellFormed => None,
+        AccessorBodyVerdict::MissingTrailingYield => Some(accessor_missing_yield_error()),
+        AccessorBodyVerdict::OtherExit(exit) => Some(accessor_exit_error(*exit)),
+        AccessorBodyVerdict::YieldNotReceiverRooted(root) => Some(accessor_yield_root_error(root)),
+    }
+}
+
+/// The first half of 6.6:6: the body does not end in a trailing `yield`.
+pub fn accessor_missing_yield_error() -> ErrorKind {
+    ErrorKind::AccessorBodyMissingYield
+}
+
+/// The rest of 6.6:6: an exit that bypasses the trailing `yield`.
+pub fn accessor_exit_error(exit: AccessorExitForm) -> ErrorKind {
+    let found = match exit {
+        AccessorExitForm::SecondYield => "a second `yield`",
+        AccessorExitForm::Return => "a `return`",
+        AccessorExitForm::Try => "a `?`",
+    };
+    ErrorKind::AccessorBodyOtherExit {
+        found: found.to_owned(),
+    }
+}
+
+/// 6.6:7: the illegal root a producer's chain walk bottomed out at.
+pub fn accessor_yield_root_error(root: &AccessorYieldRootForm) -> ErrorKind {
+    let found = match root {
+        AccessorYieldRootForm::Named(name) => format!("a place rooted at `{name}`"),
+        AccessorYieldRootForm::Value => "a value expression".to_owned(),
+        AccessorYieldRootForm::PlainMethod => {
+            "a method-call result that is not an accessor projection".to_owned()
+        }
+    };
+    ErrorKind::AccessorYieldNotReceiverRooted { found }
+}

--- a/crates/rue-air/src/sema/control_flow.rs
+++ b/crates/rue-air/src/sema/control_flow.rs
@@ -6,6 +6,7 @@
 
 use super::ordinary_engine::{OrdinaryBodyAnalysisHost, OrdinaryBodyEngine};
 use std::collections::HashMap;
+use std::sync::Arc;
 
 use lasso::Spur;
 use rue_error::{CompileError, CompileResult, CompileWarning, ErrorKind, OptionExt, WarningKind};
@@ -16,6 +17,10 @@ use super::analysis::FirstClassStrSite;
 use super::anon_structs::TrustedTryProducer;
 use super::call_resolution::CallResolutionFacts;
 use super::context::{AnalysisContext, AnalysisResult, ConstValue, LocalVar};
+use crate::declaration_validation::{
+    AccessorExitForm, AccessorMethodLink, AccessorYieldRootForm, accessor_method_link_error,
+    accessor_yield_root_error,
+};
 use crate::inst::{Air, AirInst, AirInstData, AirPattern, AirRef};
 use crate::scope::ScopedContext;
 use crate::types::{Type, TypeKind};
@@ -1353,9 +1358,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
         // accessor body's single trailing `yield` (ADR-0062 phase 1).
         if ctx.accessor_trailing_yield.is_some() {
             return Err(CompileError::new(
-                ErrorKind::AccessorBodyOtherExit {
-                    found: "a `?`".to_string(),
-                },
+                crate::declaration_validation::accessor_exit_error(AccessorExitForm::Try),
                 span,
             ));
         }
@@ -1806,9 +1809,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
         };
         if trailing != inst_ref {
             return Err(CompileError::new(
-                ErrorKind::AccessorBodyOtherExit {
-                    found: "a second `yield`".to_string(),
-                },
+                crate::declaration_validation::accessor_exit_error(AccessorExitForm::SecondYield),
                 span,
             ));
         }
@@ -1825,9 +1826,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
         // return ABI exists (RUE-1208).
         let trace = self.try_trace_place(operand, air, ctx)?.ok_or_else(|| {
             CompileError::new(
-                ErrorKind::AccessorYieldNotReceiverRooted {
-                    found: "a value expression".to_string(),
-                },
+                accessor_yield_root_error(&AccessorYieldRootForm::Value),
                 span,
             )
         })?;
@@ -1877,39 +1876,37 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
                     if *name == self_sym {
                         return Ok(());
                     }
-                    let found =
-                        format!("a place rooted at `{}`", self.body_interner().resolve(name));
-                    return Err(CompileError::new(
-                        ErrorKind::AccessorYieldNotReceiverRooted { found },
-                        span,
-                    ));
+                    let root =
+                        AccessorYieldRootForm::Named(Arc::from(self.body_interner().resolve(name)));
+                    return Err(CompileError::new(accessor_yield_root_error(&root), span));
                 }
                 InstData::FieldGet { base, .. } => current = *base,
                 InstData::IndexGet { base, .. } => current = *base,
                 InstData::MethodCall {
                     receiver, method, ..
                 } => {
+                    // The demanded path holds the receiver's resolved type, so
+                    // it decides every link: an unresolvable callee here is a
+                    // plain method as far as 6.6:7 is concerned, since a
+                    // legal link has to name an accessor.
                     let is_accessor = ctx
                         .resolved_type_of(*receiver)
                         .and_then(|ty| ty.as_struct())
                         .and_then(|struct_id| self.call_facts().method_info(struct_id, *method))
                         .is_some_and(|info| info.returns_borrow);
-                    if !is_accessor {
-                        return Err(CompileError::new(
-                            ErrorKind::AccessorYieldNotReceiverRooted {
-                                found: "a method-call result that is not an accessor projection"
-                                    .to_string(),
-                            },
-                            span,
-                        ));
+                    let link = if is_accessor {
+                        AccessorMethodLink::Accessor
+                    } else {
+                        AccessorMethodLink::PlainMethod
+                    };
+                    if let Some(kind) = accessor_method_link_error(link) {
+                        return Err(CompileError::new(kind, span));
                     }
                     current = *receiver;
                 }
                 _ => {
                     return Err(CompileError::new(
-                        ErrorKind::AccessorYieldNotReceiverRooted {
-                            found: "a value expression".to_string(),
-                        },
+                        accessor_yield_root_error(&AccessorYieldRootForm::Value),
                         span,
                     ));
                 }
@@ -1929,9 +1926,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
         // that bypasses it.
         if ctx.accessor_trailing_yield.is_some() {
             return Err(CompileError::new(
-                ErrorKind::AccessorBodyOtherExit {
-                    found: "a `return`".to_string(),
-                },
+                crate::declaration_validation::accessor_exit_error(AccessorExitForm::Return),
                 span,
             ));
         }

--- a/crates/rue-air/src/sema/declarations.rs
+++ b/crates/rue-air/src/sema/declarations.rs
@@ -21,6 +21,10 @@ use rue_span::{FileId, Span};
 
 use super::{ConstInfo, ConstValue, DeclarationPhase, InferenceContext, Sema};
 use super::{FunctionInfo, MethodInfo};
+use crate::declaration_validation::{
+    AccessorBodyVerdict, AccessorExitForm, AccessorParameterForm, AccessorReceiverForm,
+    AccessorYieldRootForm,
+};
 use crate::path_norm::{mangle_symbol_component, normalize_module_path};
 use crate::types::StructField;
 use crate::types::{EnumDef, EnumId, StructDef, StructId, Type, TypeKind};
@@ -3204,13 +3208,15 @@ impl<'a> Sema<'a, super::MutableDeclarations> {
 /// and that `yield` hands out a receiver-rooted place (6.6:7).
 ///
 /// These are legality rules on the declaration, so a declared-but-uncalled
-/// accessor is exactly as ill-formed as a called one. Every producer runs this
+/// accessor is exactly as ill-formed as a called one. Every producer runs them
 /// over every accessor declaration it admits, which is what keeps the rules
-/// independent of the driver's on-demand body analysis. The body rules are
-/// syntactic over the RIR, so they belong here with the signature rules; the
-/// single part that is not — whether a method-call link in the yielded chain
-/// names an accessor — is documented on [`check_accessor_yield_root`] and
-/// stays with the demanded path.
+/// independent of the driver's on-demand body analysis. What this function
+/// owns is the *RIR walk*; which forms are illegal and how each one reads is
+/// [`crate::declaration_validation`]'s, shared with the driver's reparsed-AST
+/// producer. The body rules are syntactic over the RIR, so they belong here
+/// with the signature rules; the single part that is not — whether a
+/// method-call link in the yielded chain names an accessor — is documented on
+/// [`accessor_yield_root`] and stays with the demanded path.
 ///
 /// The declaring `FnDecl` is the only carrier of `returns_borrow`: the durable
 /// signature records the result type's source spelling, which never contains
@@ -3240,72 +3246,103 @@ pub(super) fn check_accessor_declaration_shape(
     let span = inst.span;
     super::require_preview_feature(
         preview_features,
-        PreviewFeature::BorrowAccessors,
-        "a `-> borrow` accessor",
+        crate::declaration_validation::ACCESSOR_PREVIEW_FEATURE,
+        crate::declaration_validation::ACCESSOR_PREVIEW_SUBJECT,
         span,
     )?;
     // An accessor hands out a projection of its receiver, so the receiver is
-    // the first thing that has to exist and be a shared borrow. `inout self`
-    // accessors (exclusive results) are a later phase.
+    // the first thing that has to exist and be a shared borrow. `self` is
+    // carried by `has_self`, so the parameter list is exactly the guard
+    // inputs.
     let receiver = if !has_named_owner {
-        Some(("a free function", false))
+        AccessorReceiverForm::FreeFunction
     } else if !*has_self {
-        Some(("an associated function with no receiver", false))
+        AccessorReceiverForm::AssociatedFunction
     } else {
         match self_mode {
-            RirParamMode::Borrow => None,
-            RirParamMode::Inout => Some(("an `inout self` receiver", true)),
-            RirParamMode::Normal => Some(("a by-value `self` receiver", false)),
+            RirParamMode::Borrow => AccessorReceiverForm::BorrowSelf,
+            RirParamMode::Inout => AccessorReceiverForm::InoutSelf,
+            RirParamMode::Normal => AccessorReceiverForm::ValueSelf,
         }
     };
-    if let Some((found, is_later_phase)) = receiver {
-        let error = CompileError::new(
-            ErrorKind::AccessorRequiresBorrowSelf {
-                found: found.to_string(),
-            },
-            span,
-        );
-        return Err(if is_later_phase {
-            error.with_note(
-                "mutable accessors (`inout self` -> exclusive result) are a later phase (RUE-1016)",
-            )
-        } else {
-            error
+    let params = rir.params(params);
+    if let Some(violation) = crate::declaration_validation::accessor_signature(
+        receiver,
+        params
+            .iter()
+            .map(|param| accessor_parameter_form(param.mode, param.is_comptime)),
+    ) {
+        use crate::declaration_validation::AccessorSignatureViolation as Violation;
+        return Err(match violation {
+            Violation::Receiver { kind, note } => {
+                let error = CompileError::new(kind, span);
+                match note {
+                    Some(note) => error.with_note(note),
+                    None => error,
+                }
+            }
+            Violation::Parameter { kind, ordinal } => {
+                let span = params
+                    .iter()
+                    .nth(ordinal)
+                    .map_or(span, |parameter| parameter.span);
+                CompileError::new(kind, span)
+            }
         });
     }
-    // `self` is carried by `has_self`, so this list is exactly the guard
-    // inputs: by-value runtime values, evaluated once at the call site.
-    for param in rir.params(params).iter() {
-        if param.mode != RirParamMode::Normal {
-            return Err(CompileError::new(
-                ErrorKind::AccessorParamModeUnsupported {
-                    mode: format!(
-                        "`{}`",
-                        match param.mode {
-                            RirParamMode::Inout => "inout",
-                            RirParamMode::Borrow => "borrow",
-                            RirParamMode::Normal => unreachable!(),
-                        }
-                    ),
-                },
-                param.span,
-            ));
-        }
-        if param.is_comptime {
-            return Err(CompileError::new(
-                ErrorKind::AccessorParamModeUnsupported {
-                    mode: "`comptime`".to_string(),
-                },
-                param.span,
-            ));
-        }
-    }
     if let Some(body) = body {
-        let trailing = accessor_trailing_yield(rir, body)?;
-        check_accessor_body_exits(rir, body, trailing)?;
-        check_accessor_yield_root(rir, interner, trailing)?;
+        let (verdict, span) = accessor_body_verdict(rir, interner, body);
+        if let Some(kind) = crate::declaration_validation::accessor_body_error(&verdict) {
+            return Err(CompileError::new(kind, span));
+        }
     }
     Ok(())
+}
+
+/// The 6.6:5 form of one RIR parameter.
+pub(super) fn accessor_parameter_form(
+    mode: RirParamMode,
+    is_comptime: bool,
+) -> AccessorParameterForm {
+    if is_comptime {
+        return AccessorParameterForm::Comptime;
+    }
+    match mode {
+        RirParamMode::Normal => AccessorParameterForm::ByValue,
+        RirParamMode::Borrow => AccessorParameterForm::Borrow,
+        RirParamMode::Inout => AccessorParameterForm::Inout,
+    }
+}
+
+/// Decide 6.6:6 and 6.6:7 for one accessor body over the RIR, with the span of
+/// the offending form.
+///
+/// The rules apply in the spec's own order — a body with no trailing `yield`
+/// is reported as that, not as whatever its last expression yields — and each
+/// verdict is turned into a diagnostic by
+/// [`crate::declaration_validation::accessor_body_error`], so this producer
+/// and the driver's reparsed-AST producer cannot disagree on wording.
+fn accessor_body_verdict(
+    rir: &rue_rir::Rir,
+    interner: &lasso::ThreadedRodeo,
+    body: InstRef,
+) -> (AccessorBodyVerdict, Span) {
+    let Some(trailing) = trailing_yield(rir, body) else {
+        return (
+            AccessorBodyVerdict::MissingTrailingYield,
+            rir.get(body).span,
+        );
+    };
+    if let Some((exit, span)) = accessor_body_exit(rir, body, trailing) {
+        return (AccessorBodyVerdict::OtherExit(exit), span);
+    }
+    let InstData::Yield(operand) = rir.get(trailing).data else {
+        unreachable!("the trailing exit is a `yield` by construction")
+    };
+    match accessor_yield_root(rir, interner, operand) {
+        Some((root, span)) => (AccessorBodyVerdict::YieldNotReceiverRooted(root), span),
+        None => (AccessorBodyVerdict::WellFormed, rir.get(body).span),
+    }
 }
 
 /// Every instruction lexically contained in `body`, `body` itself included,
@@ -3357,50 +3394,43 @@ fn body_instructions(rir: &rue_rir::Rir, body: InstRef) -> Vec<InstRef> {
 /// declares rather than only for a body some call site demands. The
 /// comptime-pruned branch of an `if` counts: 6.6:6 forbids the form appearing
 /// in the body, not merely on a path the specialization keeps.
-fn check_accessor_body_exits(
+fn accessor_body_exit(
     rir: &rue_rir::Rir,
     body: InstRef,
     trailing: InstRef,
-) -> CompileResult<()> {
+) -> Option<(AccessorExitForm, Span)> {
     for inst_ref in body_instructions(rir, body) {
         let inst = rir.get(inst_ref);
-        let found = match &inst.data {
-            InstData::Yield(_) if inst_ref != trailing => "a second `yield`",
-            InstData::Ret(_) => "a `return`",
-            InstData::Try { .. } => "a `?`",
+        let exit = match &inst.data {
+            InstData::Yield(_) if inst_ref != trailing => AccessorExitForm::SecondYield,
+            InstData::Ret(_) => AccessorExitForm::Return,
+            InstData::Try { .. } => AccessorExitForm::Try,
             _ => continue,
         };
-        return Err(CompileError::new(
-            ErrorKind::AccessorBodyOtherExit {
-                found: found.to_string(),
-            },
-            inst.span,
-        ));
+        return Some((exit, inst.span));
     }
-    Ok(())
+    None
 }
 
-/// 6.6:7 over the RIR: the trailing `yield`'s operand is a projection chain
-/// rooted at the receiver (E0255).
+/// 6.6:7 over the RIR: what the trailing `yield`'s operand chain is rooted at,
+/// and the span of the form that decided it (E0255).
 ///
 /// Everything this rule needs is syntactic except one link. A nested
 /// method-call link is legal only when the callee is *itself* an accessor,
 /// and which method a call names is a resolved-type question, so this walk
-/// accepts any method call and keeps descending to the chain's root. That
-/// leaves exactly one residual for a declaration nothing calls: a chain
-/// through a plain (non-accessor) method of the receiver, such as
-/// `yield self.plain();`, whose rejection stays with
+/// accepts any method call and keeps descending to the chain's root — it never
+/// reports [`AccessorYieldRootForm::PlainMethod`], which only a producer with
+/// the callee in hand may claim. That leaves exactly one residual for a
+/// declaration nothing calls: a chain through a plain (non-accessor) method of
+/// the receiver, such as `yield self.plain();`, whose rejection stays with
 /// [`super::control_flow`]'s demanded-path check. Every other shape — a local,
 /// a non-receiver parameter, a computed value, a chain rooted at anything but
-/// `self` — is rejected here with no call site.
-fn check_accessor_yield_root(
+/// `self` — is decided here with no call site.
+fn accessor_yield_root(
     rir: &rue_rir::Rir,
     interner: &lasso::ThreadedRodeo,
-    trailing: InstRef,
-) -> CompileResult<()> {
-    let InstData::Yield(operand) = rir.get(trailing).data else {
-        return Ok(());
-    };
+    operand: InstRef,
+) -> Option<(AccessorYieldRootForm, Span)> {
     let self_sym = interner.get_or_intern("self");
     let mut current = operand;
     loop {
@@ -3409,37 +3439,26 @@ fn check_accessor_yield_root(
         match &inst.data {
             InstData::VarRef { name, .. } => {
                 if *name == self_sym {
-                    return Ok(());
+                    return None;
                 }
-                return Err(CompileError::new(
-                    ErrorKind::AccessorYieldNotReceiverRooted {
-                        found: format!("a place rooted at `{}`", interner.resolve(name)),
-                    },
-                    span,
-                ));
+                let root = AccessorYieldRootForm::Named(Arc::from(interner.resolve(name)));
+                return Some((root, span));
             }
             InstData::FieldGet { base, .. } | InstData::IndexGet { base, .. } => current = *base,
             InstData::MethodCall { receiver, .. } => current = *receiver,
-            _ => {
-                return Err(CompileError::new(
-                    ErrorKind::AccessorYieldNotReceiverRooted {
-                        found: "a value expression".to_string(),
-                    },
-                    span,
-                ));
-            }
+            _ => return Some((AccessorYieldRootForm::Value, span)),
         }
     }
 }
 
-/// The single trailing `yield` that an accessor body must fall through to
-/// (6.6:6, ADR-0062 phase 1), or E0254.
+/// The single trailing `yield` that an accessor body falls through to
+/// (6.6:6, ADR-0062 phase 1), if it has one.
 ///
 /// Which instruction is the trailing exit is decidable from the RIR alone, so
-/// the declaration seam rejects a body with no trailing `yield` for every
-/// accessor in the program. [`check_accessor_body_exits`] then rejects the
-/// *other* exits from the same seam.
-pub(super) fn accessor_trailing_yield(rir: &rue_rir::Rir, body: InstRef) -> CompileResult<InstRef> {
+/// the declaration seam decides a body with no trailing `yield` for every
+/// accessor in the program. [`accessor_body_exit`] then finds the *other*
+/// exits from the same seam.
+fn trailing_yield(rir: &rue_rir::Rir, body: InstRef) -> Option<InstRef> {
     // A single-statement body lowers to the instruction itself; a
     // multi-statement body lowers to a block whose last instruction is the
     // trailing exit.
@@ -3447,9 +3466,18 @@ pub(super) fn accessor_trailing_yield(rir: &rue_rir::Rir, body: InstRef) -> Comp
         InstData::Block { instructions } => rir.block_insts(instructions).values().last(),
         _ => Some(body),
     };
-    trailing
-        .filter(|inst_ref| matches!(rir.get(*inst_ref).data, InstData::Yield(_)))
-        .ok_or_else(|| CompileError::new(ErrorKind::AccessorBodyMissingYield, rir.get(body).span))
+    trailing.filter(|inst_ref| matches!(rir.get(*inst_ref).data, InstData::Yield(_)))
+}
+
+/// [`trailing_yield`] as the body engine demands it: the trailing exit it
+/// records for the body it is about to analyze, or E0254.
+pub(super) fn accessor_trailing_yield(rir: &rue_rir::Rir, body: InstRef) -> CompileResult<InstRef> {
+    trailing_yield(rir, body).ok_or_else(|| {
+        CompileError::new(
+            crate::declaration_validation::accessor_missing_yield_error(),
+            rir.get(body).span,
+        )
+    })
 }
 
 /// A constant declaration projected from the canonical RIR declaration index.

--- a/crates/rue-air/src/sema/ordinary_engine.rs
+++ b/crates/rue-air/src/sema/ordinary_engine.rs
@@ -30,6 +30,7 @@ use super::{
     DeclarationPhase, DeclarationTypeDependencyKind, DeclarationTypeDependencySourceKind,
     FunctionInfo, InferenceContext, KnownSymbols, MethodInfo, ParamSlotModes, StructId, Type,
 };
+use crate::declaration_validation::AccessorReceiverForm;
 use crate::inference::InferType;
 use crate::inst::Air;
 use crate::inst::{AirInst, AirInstData};
@@ -2159,71 +2160,44 @@ impl<'h, H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'h, H> {
             // (6.6:3), so an ungated program reports E1100 rather than a shape
             // error about a form it cannot name yet.
             self.require_preview(
-                rue_error::PreviewFeature::BorrowAccessors,
-                "a `-> borrow` accessor",
+                crate::declaration_validation::ACCESSOR_PREVIEW_FEATURE,
+                crate::declaration_validation::ACCESSOR_PREVIEW_SUBJECT,
                 body_span,
             )?;
+            // 6.6:4 and 6.6:5 again, over the resolved parameter list. Which
+            // forms are illegal and how each one reads are
+            // `crate::declaration_validation`'s, shared with every other
+            // accessor producer; this seam sees no owner, so a missing
+            // receiver reports the less specific form.
             let self_sym_check = self.storage.body_interner().get_or_intern("self");
-            match params
+            let receiver = match params
                 .iter()
                 .find(|(name, _, _, _)| *name == self_sym_check)
             {
-                Some((_, _, RirParamMode::Borrow, _)) => {}
-                Some((_, _, RirParamMode::Inout, _)) => {
-                    return Err(CompileError::new(
-                        ErrorKind::AccessorRequiresBorrowSelf {
-                            found: "an `inout self` receiver".to_string(),
-                        },
-                        body_span,
-                    )
-                    .with_note(
-                        "mutable accessors (`inout self` -> exclusive result) are a later phase (RUE-1016)",
-                    ));
-                }
-                Some(_) => {
-                    return Err(CompileError::new(
-                        ErrorKind::AccessorRequiresBorrowSelf {
-                            found: "a by-value `self` receiver".to_string(),
-                        },
-                        body_span,
-                    ));
-                }
-                None => {
-                    return Err(CompileError::new(
-                        ErrorKind::AccessorRequiresBorrowSelf {
-                            found: "a function with no receiver".to_string(),
-                        },
-                        body_span,
-                    ));
-                }
-            }
-            for (name, _, mode, is_comptime) in params.iter() {
-                if *name == self_sym_check {
-                    continue;
-                }
-                if *is_comptime {
-                    return Err(CompileError::new(
-                        ErrorKind::AccessorParamModeUnsupported {
-                            mode: "`comptime`".to_string(),
-                        },
-                        body_span,
-                    ));
-                }
-                if *mode != RirParamMode::Normal {
-                    return Err(CompileError::new(
-                        ErrorKind::AccessorParamModeUnsupported {
-                            mode: format!(
-                                "`{}`",
-                                match mode {
-                                    RirParamMode::Inout => "inout",
-                                    RirParamMode::Borrow => "borrow",
-                                    RirParamMode::Normal => unreachable!(),
-                                }
-                            ),
-                        },
-                        body_span,
-                    ));
-                }
+                Some((_, _, RirParamMode::Borrow, _)) => AccessorReceiverForm::BorrowSelf,
+                Some((_, _, RirParamMode::Inout, _)) => AccessorReceiverForm::InoutSelf,
+                Some(_) => AccessorReceiverForm::ValueSelf,
+                None => AccessorReceiverForm::MissingReceiver,
+            };
+            if let Some(violation) = crate::declaration_validation::accessor_signature(
+                receiver,
+                params
+                    .iter()
+                    .filter(|(name, _, _, _)| *name != self_sym_check)
+                    .map(|(_, _, mode, is_comptime)| {
+                        super::declarations::accessor_parameter_form(*mode, *is_comptime)
+                    }),
+            ) {
+                use crate::declaration_validation::AccessorSignatureViolation as Violation;
+                let (kind, note) = match violation {
+                    Violation::Receiver { kind, note } => (kind, note),
+                    Violation::Parameter { kind, .. } => (kind, None),
+                };
+                let error = CompileError::new(kind, body_span);
+                return Err(match note {
+                    Some(note) => error.with_note(note),
+                    None => error,
+                });
             }
 
             ctx.accessor_trailing_yield = Some(super::declarations::accessor_trailing_yield(

--- a/crates/rue-compiler/src/api_inventory.rs
+++ b/crates/rue-compiler/src/api_inventory.rs
@@ -112,6 +112,48 @@ fn local_semantic_materialization_is_an_inert_exact_fact_boundary() {
 }
 
 #[test]
+fn the_driver_reads_accessor_declaration_rules_from_the_shared_rule_module() {
+    // RUE-1232: this producer walks its own reparsed AST, but the 6.6:3-6.6:7
+    // rules it applies — which forms are illegal, in which order, and how each
+    // diagnostic reads — are `rue_air::declaration_validation`'s, shared with
+    // the RIR producers. Spelling one here is how the two declaration-time
+    // producers drifted before.
+    let driver = [
+        include_str!("revisioned_query_database.rs"),
+        include_str!("semantic_query_nucleus.rs"),
+    ]
+    .concat();
+    for kind in [
+        ["ErrorKind::Accessor", "RequiresBorrowSelf"].concat(),
+        ["ErrorKind::Accessor", "ParamModeUnsupported"].concat(),
+        ["ErrorKind::Accessor", "BodyMissingYield"].concat(),
+        ["ErrorKind::Accessor", "BodyOtherExit"].concat(),
+        ["ErrorKind::Accessor", "YieldNotReceiverRooted"].concat(),
+    ] {
+        assert!(
+            !driver.contains(&kind),
+            "the driver regained its own copy of an accessor declaration rule: {kind}"
+        );
+    }
+    assert!(
+        !driver.contains("\"a `-> borrow` accessor\""),
+        "the driver regained its own 6.6:3 gate subject"
+    );
+    for required in [
+        "use rue_air::declaration_validation as rules;",
+        "rules::accessor_preview_gate(",
+        "rules::accessor_signature(",
+        "rules::accessor_body_error(",
+        "accessor_method_link_error(",
+    ] {
+        assert!(
+            driver.contains(required),
+            "the driver stopped reading an accessor rule from the shared module: {required}"
+        );
+    }
+}
+
+#[test]
 fn cfg_queries_own_local_semantic_materialization_and_terminal_domains() {
     let cfg = include_str!("cfg_query.rs");
     let database = include_str!("revisioned_query_database.rs");

--- a/crates/rue-compiler/src/declaration_candidate.rs
+++ b/crates/rue-compiler/src/declaration_candidate.rs
@@ -139,11 +139,37 @@ pub(crate) enum RawConstSyntaxFailure {
 pub(crate) struct RawDeclarationSignatureSyntax {
     pub(crate) declaration_fragments: Arc<[Arc<str>]>,
     pub(crate) extern_abi: Option<Arc<str>>,
-    /// The exact body is attached only for a `-> borrow` accessor. Its
-    /// declaration-shape rules include a trailing-yield check even when no
-    /// caller demands body analysis, so that one signature query legitimately
-    /// depends on its own body while ordinary signatures remain body-agnostic.
-    pub(crate) accessor_body: Option<Arc<str>>,
+    /// Present only for a `-> borrow` accessor: the extra syntax its
+    /// declaration rules read (spec 6.6:6, 6.6:7). `None` keeps every ordinary
+    /// signature body-agnostic.
+    pub(crate) accessor: Option<Arc<RawAccessorSignatureSyntax>>,
+}
+
+/// The syntax an accessor declaration's own legality rules read beyond its
+/// signature (spec 6.6:6, 6.6:7).
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub(crate) struct RawAccessorSignatureSyntax {
+    /// The accessor's exact body. Its declaration-shape rules include a
+    /// trailing-yield check even when no caller demands body analysis, so this
+    /// one signature query legitimately depends on its own body.
+    pub(crate) body: Arc<str>,
+    /// Every method the accessor's owner declares, paired with whether it is
+    /// itself an accessor, sorted by name and with ambiguous duplicate names
+    /// dropped.
+    ///
+    /// 6.6:7 admits a method-call link in the yielded chain only when the
+    /// callee is an accessor. For a link whose receiver is the accessor's own
+    /// `self`, the callee is a method of this owner, and whether it is an
+    /// accessor is a *parsed* fact of a sibling declaration — no signature or
+    /// body of that sibling is demanded, so there is no query cycle between
+    /// mutually recursive accessors. Retaining the facts here is what records
+    /// the dependency: this terminal is materialized from the module's parse,
+    /// so editing a sibling method's `-> borrow` qualifier changes this value
+    /// and re-runs every consumer of this accessor's signature.
+    ///
+    /// Empty for an accessor with no owning type, or whose owner declares no
+    /// other methods.
+    pub(crate) owner_methods: Arc<[(Arc<str>, bool)]>,
 }
 
 /// Stable, position-free failure retained by the exact raw-signature family.

--- a/crates/rue-compiler/src/parsed_modules.rs
+++ b/crates/rue-compiler/src/parsed_modules.rs
@@ -391,20 +391,53 @@ impl ParsedDefinitionIndex {
                 (vec![fragment(declaration)?].into(), Some(fragment(abi)?))
             }
         };
-        let accessor_body = if candidate.is_accessor {
-            Some(fragment(candidate.raw_body_span?)?)
+        // 6.6:7 lets an accessor yield through a nested *accessor* call. For a
+        // link whose receiver is this accessor's own `self`, the callee is one
+        // of the owner's methods, so the deciding fact is the sibling
+        // declaration's parsed `-> borrow` qualifier — retained here, where
+        // the terminal is already materialized from this module's parse, so an
+        // edit to a sibling invalidates this accessor's signature.
+        let accessor = if candidate.is_accessor {
+            Some(Arc::new(
+                crate::declaration_candidate::RawAccessorSignatureSyntax {
+                    body: fragment(candidate.raw_body_span?)?,
+                    owner_methods: key.owner.as_ref().map_or_else(
+                        || Arc::from(Vec::new()),
+                        |owner| self.owner_method_accessor_facts(owner),
+                    ),
+                },
+            ))
         } else {
             None
         };
         let syntax = RawDeclarationSignatureSyntax {
             declaration_fragments,
             extern_abi,
-            accessor_body,
+            accessor,
         };
         #[cfg(test)]
         self.raw_declaration_signature_terminal_materializations
             .fetch_add(1, Ordering::Relaxed);
         Some(syntax)
+    }
+
+    /// Every method one owner declares in this module, paired with whether it
+    /// is itself a `-> borrow` accessor, in the normalized form the raw
+    /// signature terminal retains.
+    fn owner_method_accessor_facts(
+        &self,
+        owner: &crate::declaration_candidate::DeclarationCandidateOwner,
+    ) -> Arc<[(Arc<str>, bool)]> {
+        use crate::declaration_candidate::DeclarationCandidateCategory as Category;
+        crate::semantic_query_nucleus::owner_method_accessor_facts(
+            self.declarations
+                .iter()
+                .filter(|candidate| {
+                    candidate.fact.key.category == Category::Method
+                        && candidate.fact.key.owner.as_ref() == Some(owner)
+                })
+                .map(|candidate| (candidate.fact.key.name.clone(), candidate.is_accessor)),
+        )
     }
 
     #[cfg(test)]

--- a/crates/rue-compiler/src/retained_charge.rs
+++ b/crates/rue-compiler/src/retained_charge.rs
@@ -1013,7 +1013,15 @@ impl RetainedCharge for crate::declaration_candidate::RawDeclarationSignatureSyn
         self.declaration_fragments
             .retained_charge()
             .saturating_add(self.extern_abi.retained_charge())
-            .saturating_add(self.accessor_body.retained_charge())
+            .saturating_add(self.accessor.retained_charge())
+    }
+}
+
+impl RetainedCharge for crate::declaration_candidate::RawAccessorSignatureSyntax {
+    fn retained_charge(&self) -> u64 {
+        self.body
+            .retained_charge()
+            .saturating_add(self.owner_methods.retained_charge())
     }
 }
 

--- a/crates/rue-compiler/src/revisioned_query_database.rs
+++ b/crates/rue-compiler/src/revisioned_query_database.rs
@@ -7295,6 +7295,16 @@ impl SemanticConstEvaluator<'_, '_> {
                         crate::durable_semantics::DurableParameterMode::Inout
                     }
                 };
+                // 6.6:7's accessor-link fact for this anonymous owner's own
+                // methods, exactly as a named owner's members retain it.
+                let owner_methods = crate::semantic_query_nucleus::owner_method_accessor_facts(
+                    methods.iter().map(|method| {
+                        (
+                            Arc::from(self.interner.resolve(&method.name.name)),
+                            method.borrow_return.is_some(),
+                        )
+                    }),
+                );
                 let methods = methods
                     .iter()
                     .map(|method| {
@@ -7436,10 +7446,12 @@ impl SemanticConstEvaluator<'_, '_> {
                                         crate::declaration_candidate::RawDeclarationSignatureSyntax {
                                             declaration_fragments: Arc::from([Arc::from(signature)]),
                                             extern_abi: None,
-                                            accessor_body: method
-                                                .borrow_return
-                                                .is_some()
-                                                .then(|| Arc::from(body)),
+                                            accessor: method.borrow_return.is_some().then(|| {
+                                                Arc::new(crate::declaration_candidate::RawAccessorSignatureSyntax {
+                                                    body: Arc::from(body),
+                                                    owner_methods: owner_methods.clone(),
+                                                })
+                                            }),
                                         },
                                     body:
                                         crate::declaration_candidate::RawDeclarationBodySyntax {
@@ -9999,87 +10011,76 @@ fn resolve_parsed_semantic_signature(
             accessor_body,
         } => {
             if *is_accessor {
-                if !provider
-                    .configuration
-                    .preview_features
-                    .contains(rue_error::PreviewFeature::BorrowAccessors)
-                {
-                    return Err(diagnostic(rue_error::ErrorKind::PreviewFeatureRequired {
-                        feature: rue_error::PreviewFeature::BorrowAccessors,
-                        what: "a `-> borrow` accessor".to_owned(),
-                    }));
+                // 6.6:3-6.6:7 over the reparsed declaration. Which forms are
+                // illegal, in which order, and how each diagnostic reads are
+                // `rue_air::declaration_validation`'s, shared with the RIR
+                // producers (RUE-1232); this seam owns only the lowering of
+                // the reparsed signature into that vocabulary. This
+                // transport carries no note, so the `inout self` phase
+                // pointer is dropped here.
+                use rue_air::declaration_validation as rules;
+                use rue_air::declaration_validation::{
+                    AccessorParameterForm, AccessorReceiverForm,
+                };
+                if let Some(kind) = rules::accessor_preview_gate(
+                    provider
+                        .configuration
+                        .preview_features
+                        .contains(rules::ACCESSOR_PREVIEW_FEATURE),
+                ) {
+                    return Err(diagnostic(kind));
                 }
                 let receiver = if provider.dependency_source.owner().is_none() {
-                    Some("a free function")
+                    AccessorReceiverForm::FreeFunction
                 } else if !*has_self {
-                    Some("an associated function with no receiver")
+                    AccessorReceiverForm::AssociatedFunction
                 } else {
                     match self_mode {
-                        crate::declaration_candidate::DeclarationParameterMode::Borrow => None,
+                        crate::declaration_candidate::DeclarationParameterMode::Borrow => {
+                            AccessorReceiverForm::BorrowSelf
+                        }
                         crate::declaration_candidate::DeclarationParameterMode::Inout => {
-                            Some("an `inout self` receiver")
+                            AccessorReceiverForm::InoutSelf
                         }
                         crate::declaration_candidate::DeclarationParameterMode::Value => {
-                            Some("a by-value `self` receiver")
+                            AccessorReceiverForm::ValueSelf
                         }
                     }
                 };
-                if let Some(found) = receiver {
-                    return Err(diagnostic(
-                        rue_error::ErrorKind::AccessorRequiresBorrowSelf {
-                            found: found.to_owned(),
-                        },
-                    ));
-                }
-                if let Some(parameter) = parameters.iter().find(|parameter| {
-                    parameter.is_comptime
-                        || parameter.mode
-                            != crate::declaration_candidate::DeclarationParameterMode::Value
-                }) {
-                    let mode = if parameter.is_comptime {
-                        "`comptime`"
-                    } else {
+                if let Some(violation) = rules::accessor_signature(
+                    receiver,
+                    parameters.iter().map(|parameter| {
+                        if parameter.is_comptime {
+                            return AccessorParameterForm::Comptime;
+                        }
                         match parameter.mode {
+                            crate::declaration_candidate::DeclarationParameterMode::Value => {
+                                AccessorParameterForm::ByValue
+                            }
                             crate::declaration_candidate::DeclarationParameterMode::Borrow => {
-                                "`borrow`"
+                                AccessorParameterForm::Borrow
                             }
                             crate::declaration_candidate::DeclarationParameterMode::Inout => {
-                                "`inout`"
-                            }
-                            crate::declaration_candidate::DeclarationParameterMode::Value => {
-                                unreachable!()
+                                AccessorParameterForm::Inout
                             }
                         }
+                    }),
+                ) {
+                    use rue_air::declaration_validation::AccessorSignatureViolation as Violation;
+                    let kind = match violation {
+                        Violation::Receiver { kind, .. } | Violation::Parameter { kind, .. } => {
+                            kind
+                        }
                     };
-                    return Err(diagnostic(
-                        rue_error::ErrorKind::AccessorParamModeUnsupported {
-                            mode: mode.to_owned(),
-                        },
-                    ));
+                    return Err(diagnostic(kind));
                 }
                 // 6.6:6 and 6.6:7 over the accessor's own retained body. These
                 // are legality rules on the declaration, so they hold with no
                 // call site anywhere in the program (RUE-1212); see
-                // `AccessorBodyShape` for the single link they leave to the
+                // `AccessorBodyVerdict` for the single link they leave to the
                 // demanded path.
-                use crate::semantic_query_nucleus::AccessorBodyShape as Shape;
-                match accessor_body {
-                    Shape::WellFormed => {}
-                    Shape::MissingTrailingYield => {
-                        return Err(diagnostic(rue_error::ErrorKind::AccessorBodyMissingYield));
-                    }
-                    Shape::OtherExit { found } => {
-                        return Err(diagnostic(rue_error::ErrorKind::AccessorBodyOtherExit {
-                            found: found.to_string(),
-                        }));
-                    }
-                    Shape::YieldNotReceiverRooted { found } => {
-                        return Err(diagnostic(
-                            rue_error::ErrorKind::AccessorYieldNotReceiverRooted {
-                                found: found.to_string(),
-                            },
-                        ));
-                    }
+                if let Some(kind) = rules::accessor_body_error(accessor_body) {
+                    return Err(diagnostic(kind));
                 }
             }
             let mut generic_index = 0_u32;

--- a/crates/rue-compiler/src/semantic_query_nucleus.rs
+++ b/crates/rue-compiler/src/semantic_query_nucleus.rs
@@ -7,6 +7,10 @@
 use std::collections::{BTreeMap, BTreeSet};
 use std::sync::Arc;
 
+use rue_air::declaration_validation::{
+    AccessorBodyVerdict, AccessorExitForm, AccessorYieldRootForm,
+};
+
 use crate::retained_charge::RetainedCharge;
 
 use crate::declaration_candidate::{
@@ -29,30 +33,6 @@ pub(crate) struct ParsedSemanticParameter {
     pub(crate) ty: Arc<str>,
 }
 
-/// The accessor-body legality facts that are decidable from the declaration's
-/// own retained syntax (spec 6.6:6, 6.6:7).
-///
-/// An accessor is the one declaration whose body its signature query reads:
-/// 6.6:6 and 6.6:7 are legality rules on the declaration, so a
-/// declared-but-uncalled accessor is exactly as ill-formed as a called one,
-/// and the driver analyzes a body only when something demands it (RUE-1212).
-/// Everything here is syntactic; the one accessor-body question that is not —
-/// whether a method-call link in the yielded projection chain names an
-/// accessor — stays with the demanded path and is documented on
-/// [`accessor_body_shape`].
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub(crate) enum AccessorBodyShape {
-    /// The body's final statement is not a `yield` (E0254).
-    MissingTrailingYield,
-    /// A trailing `yield` exists, but another exit bypasses it (E0254).
-    OtherExit { found: Arc<str> },
-    /// The trailing `yield` hands out something that is not a place rooted at
-    /// the receiver (E0255).
-    YieldNotReceiverRooted { found: Arc<str> },
-    /// Well-formed as far as the declaration alone can decide.
-    WellFormed,
-}
-
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) enum ParsedSemanticSignature {
     Callable {
@@ -65,10 +45,12 @@ pub(crate) enum ParsedSemanticSignature {
         is_c_export: bool,
         is_accessor: bool,
         /// What the accessor body's own syntax decides about spec 6.6:6 and
-        /// 6.6:7. Meaningful only when `is_accessor`; an ordinary signature
-        /// retains no body and always reports
-        /// [`AccessorBodyShape::MissingTrailingYield`] for the empty stand-in.
-        accessor_body: AccessorBodyShape,
+        /// 6.6:7, in the producer-neutral vocabulary every accessor producer
+        /// shares (RUE-1232). Meaningful only when `is_accessor`; an ordinary
+        /// signature retains no body and always reports
+        /// [`AccessorBodyVerdict::MissingTrailingYield`] for the empty
+        /// stand-in.
+        accessor_body: AccessorBodyVerdict,
     },
     Struct {
         fields: Arc<[(Arc<str>, Arc<str>)]>,
@@ -80,6 +62,17 @@ pub(crate) enum ParsedSemanticSignature {
         variants: Arc<[(Arc<str>, Arc<[Arc<str>]>)]>,
     },
     Destructor,
+}
+
+/// The body an accessor's signature reparse carries, or the empty stand-in
+/// every ordinary signature reconstructs with.
+fn accessor_body_source(
+    syntax: &crate::declaration_candidate::RawDeclarationSignatureSyntax,
+) -> &str {
+    syntax
+        .accessor
+        .as_ref()
+        .map_or("{}", |accessor| accessor.body.as_ref())
 }
 
 fn signature_source(
@@ -97,11 +90,9 @@ fn signature_source(
         // brace reconstructs valid field-only syntax; inserting a bare block
         // here would itself be parsed as a malformed field.
         Category::Struct => fragments.concat(),
-        Category::Function | Category::Destructor => format!(
-            "{} {}",
-            fragments.concat(),
-            syntax.accessor_body.as_deref().unwrap_or("{}")
-        ),
+        Category::Function | Category::Destructor => {
+            format!("{} {}", fragments.concat(), accessor_body_source(syntax))
+        }
         Category::Method | Category::AssociatedFunction => format!(
             "struct {} {{ {} {} }}",
             key.owner
@@ -109,7 +100,7 @@ fn signature_source(
                 .map(|owner| owner.name.as_ref())
                 .unwrap_or("__missing_owner"),
             fragments.concat(),
-            syntax.accessor_body.as_deref().unwrap_or("{}"),
+            accessor_body_source(syntax),
         ),
         Category::ExternFunction => format!(
             "extern {} {{ {} }}",
@@ -174,6 +165,63 @@ fn trailing_yield(body: &rue_parser::ast::Expr) -> Option<&rue_parser::ast::Yiel
     }
 }
 
+/// Normalize one owner's `(method name, is accessor)` pairs into the form
+/// [`crate::declaration_candidate::RawAccessorSignatureSyntax`] retains:
+/// sorted by name, with every ambiguously duplicated name dropped.
+///
+/// A duplicate method is its own diagnostic, and 6.6:7 stays permissive
+/// wherever it cannot *prove* a callee is a plain method, so a name that two
+/// declarations claim is simply not decided here.
+pub(crate) fn owner_method_accessor_facts(
+    methods: impl IntoIterator<Item = (Arc<str>, bool)>,
+) -> Arc<[(Arc<str>, bool)]> {
+    let mut facts: Vec<(Arc<str>, bool)> = methods.into_iter().collect();
+    facts.sort();
+    let mut duplicated: BTreeSet<Arc<str>> = BTreeSet::new();
+    for window in facts.windows(2) {
+        if window[0].0 == window[1].0 {
+            duplicated.insert(window[0].0.clone());
+        }
+    }
+    facts.dedup_by(|left, right| left.0 == right.0);
+    facts.retain(|(name, _)| !duplicated.contains(name));
+    Arc::from(facts)
+}
+
+/// What one method-call link in a yielded projection chain is, as far as the
+/// declaration's own parsed neighborhood can prove (spec 6.6:7).
+///
+/// Only a link applied directly to the receiver is decidable here: `self.m()`
+/// calls a method of this accessor's owner, so `owner_methods` names it. A
+/// receiver that is anything else — a chained call, a field, an index — has a
+/// type this query does not resolve, and a callee this query must not guess.
+fn accessor_method_link(
+    call: &rue_parser::ast::MethodCallExpr,
+    interner: &crate::ThreadedRodeo,
+    owner_methods: &[(Arc<str>, bool)],
+) -> rue_air::declaration_validation::AccessorMethodLink {
+    use rue_air::declaration_validation::AccessorMethodLink as Link;
+    use rue_parser::ast::Expr;
+    let mut receiver = &*call.receiver;
+    while let Expr::Paren(paren) = receiver {
+        receiver = &paren.inner;
+    }
+    if !matches!(receiver, Expr::SelfExpr(_)) {
+        return Link::Unresolved;
+    }
+    let name = interner.resolve(&call.method.name);
+    match owner_methods
+        .iter()
+        .find(|(method, _)| method.as_ref() == name)
+    {
+        Some((_, true)) => Link::Accessor,
+        Some((_, false)) => Link::PlainMethod,
+        // A name the owner does not declare is not this rule's error to
+        // report; call resolution names it.
+        None => Link::Unresolved,
+    }
+}
+
 /// Decide 6.6:6 and 6.6:7 from an accessor body's own syntax.
 ///
 /// Both rules are containment and shape questions — "the final statement is a
@@ -184,43 +232,58 @@ fn trailing_yield(body: &rue_parser::ast::Expr) -> Option<&rue_parser::ast::Yiel
 /// off the syntax, which is why a `return` in a branch a specialization would
 /// later prune still counts: 6.6:6 forbids the form appearing in the body.
 ///
+/// This function owns the *AST walk* only. Which forms are illegal, and how
+/// each one reads, are `rue_air::declaration_validation`'s, shared with the
+/// RIR producers (RUE-1232) — the walks differ because the representations do,
+/// but the rules cannot.
+///
 /// One link of 6.6:7 is not syntactic. A projection chain may pass through a
-/// nested accessor call, and whether `self.f()` names an accessor or a plain
-/// method is a resolved-type question the declaration cannot answer. This
-/// walk therefore accepts any method-call link and keeps descending to the
-/// chain's root, leaving exactly one residual for a declaration nothing
-/// calls: `yield self.plain();`, where the chain is receiver-rooted but the
-/// link is not an accessor. `rue_air::sema::control_flow` rejects that on the
-/// demanded path, with the receiver's type in hand.
+/// nested accessor call, and whether the callee is an accessor or a plain
+/// method is a resolved-callee question. `owner_methods` closes the part of it
+/// that is a *parsed* fact: a link whose receiver is the accessor's own `self`
+/// calls a method of the owner, and whether that method is an accessor is on
+/// the owner's other declarations (RUE-1232). Every other link — `self.a().b()`,
+/// `self.field.m()` — targets a type this query cannot name, so the walk stays
+/// permissive and leaves the rejection to the demanded path, which has the
+/// receiver's type in hand.
 fn accessor_body_shape(
     body: &rue_parser::ast::Expr,
     interner: &crate::ThreadedRodeo,
-) -> AccessorBodyShape {
+    owner_methods: &[(Arc<str>, bool)],
+) -> AccessorBodyVerdict {
     use rue_parser::ast::Expr;
     let Some(trailing) = trailing_yield(body) else {
-        return AccessorBodyShape::MissingTrailingYield;
+        return AccessorBodyVerdict::MissingTrailingYield;
     };
+    // The walk order is a stack, so an offending exit is kept only when it
+    // starts earlier in the body than any already found: both producers name
+    // the *first* illegal form in the source.
     let mut pending = vec![body];
+    let mut first_exit: Option<(AccessorExitForm, u32)> = None;
     while let Some(expr) = pending.pop() {
-        let found = match expr {
+        let exit = match expr {
             // Occurrences are distinguished by span: the reparsed signature
             // source holds each `yield` exactly once.
-            Expr::Yield(exit) if exit.span != trailing.span => "a second `yield`",
-            Expr::Return(_) => "a `return`",
-            Expr::Try(_) => "a `?`",
+            Expr::Yield(exit) if exit.span != trailing.span => AccessorExitForm::SecondYield,
+            Expr::Return(_) => AccessorExitForm::Return,
+            Expr::Try(_) => AccessorExitForm::Try,
             _ => {
                 expr.child_exprs(&mut pending);
                 continue;
             }
         };
-        return AccessorBodyShape::OtherExit {
-            found: Arc::from(found),
-        };
+        let start = expr.span().start;
+        if first_exit.is_none_or(|(_, earliest)| start < earliest) {
+            first_exit = Some((exit, start));
+        }
+    }
+    if let Some((exit, _)) = first_exit {
+        return AccessorBodyVerdict::OtherExit(exit);
     }
     let mut current = trailing.value.as_ref();
     loop {
-        let found = match current {
-            Expr::SelfExpr(_) => return AccessorBodyShape::WellFormed,
+        let root = match current {
+            Expr::SelfExpr(_) => return AccessorBodyVerdict::WellFormed,
             Expr::Paren(paren) => {
                 current = &paren.inner;
                 continue;
@@ -234,15 +297,21 @@ fn accessor_body_shape(
                 continue;
             }
             Expr::MethodCall(call) => {
+                let link = accessor_method_link(call, interner, owner_methods);
+                if rue_air::declaration_validation::accessor_method_link_error(link).is_some() {
+                    return AccessorBodyVerdict::YieldNotReceiverRooted(
+                        AccessorYieldRootForm::PlainMethod,
+                    );
+                }
                 current = &call.receiver;
                 continue;
             }
-            Expr::Ident(name) => format!("a place rooted at `{}`", interner.resolve(&name.name)),
-            _ => "a value expression".to_owned(),
+            Expr::Ident(name) => {
+                AccessorYieldRootForm::Named(Arc::from(interner.resolve(&name.name)))
+            }
+            _ => AccessorYieldRootForm::Value,
         };
-        return AccessorBodyShape::YieldNotReceiverRooted {
-            found: Arc::from(found),
-        };
+        return AccessorBodyVerdict::YieldNotReceiverRooted(root);
     }
 }
 
@@ -270,7 +339,12 @@ pub(crate) fn parse_semantic_signature(
         .first()
         .ok_or_else(|| Arc::from("semantic signature parsed no declaration"))?;
     let unit: Arc<str> = Arc::from("()");
-    let body_shape = |body: &rue_parser::ast::Expr| accessor_body_shape(body, &interner);
+    let owner_methods = syntax
+        .accessor
+        .as_ref()
+        .map_or::<&[(Arc<str>, bool)], _>(&[], |accessor| &accessor.owner_methods);
+    let body_shape =
+        |body: &rue_parser::ast::Expr| accessor_body_shape(body, &interner, owner_methods);
     let callable = |parameters: &[rue_parser::ast::Param],
                     result: Option<&rue_parser::ast::TypeExpr>,
                     has_self,
@@ -322,7 +396,7 @@ pub(crate) fn parse_semantic_signature(
                 true,
                 false,
                 false,
-                AccessorBodyShape::MissingTrailingYield,
+                AccessorBodyVerdict::MissingTrailingYield,
             )
         }
         (Category::Method | Category::AssociatedFunction, rue_parser::ast::Item::Struct(owner)) => {

--- a/crates/rue-compiler/src/unstable.rs
+++ b/crates/rue-compiler/src/unstable.rs
@@ -1054,6 +1054,56 @@ mod codegen_unit_tests {
     }
 
     #[test]
+    fn accessor_yield_link_verdict_follows_a_sibling_method_s_borrow_qualifier() {
+        // 6.6:7 admits `yield self.link()` only when `link` is itself an
+        // accessor. The declaration-time producer decides that from the
+        // owner's other *parsed* declarations, so editing `link`'s result
+        // qualifier has to invalidate the verdict recorded for `xr` — in both
+        // directions (RUE-1232).
+        let source = |link: &str| {
+            crate::SourceSnapshot::single(
+                "main.rue",
+                format!(
+                    "struct P {{ x: i64, fn link(borrow self) -> {link} fn xr(borrow self) -> borrow i64 {{ yield self.link(); }} }} fn main() -> i32 {{ let p = P {{ x: 0 }}; @intCast(p.xr()) }}"
+                ),
+            )
+            .unwrap()
+        };
+        let plain = "i64 { self.x }";
+        let accessor = "borrow i64 { yield self.x; }";
+        let mut options = crate::CompileOptions::default();
+        options
+            .preview_features
+            .insert(rue_error::PreviewFeature::BorrowAccessors);
+
+        let mut session = crate::CompilerSession::new();
+        session.update(&source(plain)).into_result().unwrap();
+        let errors = session.canonical_semantic(&options).unwrap_err();
+        assert!(
+            errors.iter().any(|error| matches!(
+                &error.kind,
+                rue_error::ErrorKind::AccessorYieldNotReceiverRooted { .. }
+            )),
+            "{errors:?}"
+        );
+
+        session.update(&source(accessor)).into_result().unwrap();
+        session
+            .canonical_semantic(&options)
+            .expect("an accessor link is a legal projection");
+
+        session.update(&source(plain)).into_result().unwrap();
+        let errors = session.canonical_semantic(&options).unwrap_err();
+        assert!(
+            errors.iter().any(|error| matches!(
+                &error.kind,
+                rue_error::ErrorKind::AccessorYieldNotReceiverRooted { .. }
+            )),
+            "{errors:?}"
+        );
+    }
+
+    #[test]
     fn accessor_edit_recomputes_caller_without_publishing_accessor_abi() {
         let source = |value| {
             crate::SourceSnapshot::single(

--- a/crates/rue-spec/cases/items/borrow-accessors.toml
+++ b/crates/rue-spec/cases/items/borrow-accessors.toml
@@ -541,7 +541,28 @@ exit_code = 0
 [[case]]
 name = "accessor_yield_through_plain_method_is_rejected"
 spec = ["6.6:7"]
-description = "A projection link through a non-accessor method is rejected (E0255); this link is the one part of 6.6:7 that needs the receiver's resolved type, so it is diagnosed from the call site."
+description = "A projection link through a non-accessor method of the receiver is rejected (E0255) with nothing calling the accessor: whether a `self.m()` link names an accessor is a parsed fact of the owner's other declarations."
+preview = "borrow_accessors"
+preview_should_pass = true
+source = """
+struct P {
+    x: i64,
+
+    @allow(unused_function)
+    fn plain(borrow self) -> i64 { self.x }
+
+    @allow(unused_function)
+    fn xr(borrow self) -> borrow i64 { yield self.plain(); }
+}
+fn main() -> i32 { 0 }
+"""
+compile_fail = true
+error_contains = ["E0255", "not an accessor projection"]
+
+[[case]]
+name = "called_accessor_yield_through_plain_method_is_rejected"
+spec = ["6.6:7"]
+description = "The same link is rejected from the call site, where the demanded body walk decides every link from the receiver's resolved type."
 preview = "borrow_accessors"
 preview_should_pass = true
 source = """
@@ -558,6 +579,31 @@ fn main() -> i32 {
 """
 compile_fail = true
 error_contains = ["E0255", "not an accessor projection"]
+
+[[case]]
+name = "accessor_yield_through_a_chained_type_s_accessor_compiles"
+spec = ["6.6:7"]
+description = "A link whose receiver is not the accessor's own `self` names a method of another type, which the declaration cannot resolve; it stays permissive there and the demanded path decides it."
+preview = "borrow_accessors"
+preview_should_pass = true
+source = """
+struct Inner {
+    v: i64,
+
+    fn get(borrow self) -> borrow i64 { yield self.v; }
+}
+struct P {
+    inner: Inner,
+
+    fn a(borrow self) -> borrow Inner { yield self.inner; }
+    fn chained(borrow self) -> borrow i64 { yield self.a().get(); }
+}
+fn main() -> i32 {
+    let p = P { inner: Inner { v: 0 } };
+    @intCast(p.chained())
+}
+"""
+exit_code = 0
 
 [[case]]
 name = "uncalled_legal_accessor_compiles"


### PR DESCRIPTION
Consolidation follow-up to #2112, worked in an isolated worktree during the Actions outage and integrated onto fresh trunk. **Draft until integration-time verification completes** (cold rebuild in progress — the sandbox's build cache was sacrificed to an earlier disk-pressure cleanup); will be marked ready + auto-merged once the full suite is re-verified on this exact base.

The 6.6:3–6.6:7 accessor legality rules turned out to exist in **four** places, not the two #2112 documented: the rue-air predeclaration walk, the driver's reparsed-AST walk, a third receiver/parameter copy in `ordinary_engine.rs` (with a divergent `found:` string — a live drift instance), and a second copy of the exit/rooting strings in `control_flow.rs`. All four now defer to `rue_air::declaration_validation` — the module that already exists for exactly this hazard — which owns every diagnostic string, the rule ordering, and a spec-form vocabulary (`AccessorReceiverForm`, `AccessorExitForm`, `AccessorYieldRootForm`, …) named after 6.6 rather than any producer's IR. Producers only lower their own nodes into the vocabulary; two new inventory tests pin that no producer spells an accessor diagnostic of its own. One behavior alignment: the driver's exit scan now reports the *first* offending form in source order, matching rue-air.

**Also closes the uncalled `yield self.plain();` residual for the provable case**: when the yield chain's method link is spelled directly on `self`, the callee is provably a method of the accessor's owner, and its accessor-ness is a *parsed* fact of a sibling declaration — carried next to the retained accessor body (`RawAccessorSignatureSyntax { body, owner_methods }`), so the signature query re-runs when a sibling gains or loses `-> borrow` (pinned in both directions by a new incremental test). Links through fields, chained calls, or unresolved names stay permissive and demand-driven — pinned by a new spec case for the chained-type side. E0256 body retention deliberately untouched.

Spec 6.6: 36 → 38 cases (`accessor_yield_through_plain_method_is_rejected` flipped to uncalled; called variant and chained-type-permissive case added).

Fixes RUE-1232.

## Validation

In-worktree (base = #2112's commit): quick, unit air 692, unit compiler 791, spec 6.6 38/38, full spec 2262, traceability, UI, CLI borrow, clippy, fmt, **premerge 78/78**. Integration re-verification on fresh trunk (now including RUE-1230): running, results to follow before this leaves draft.

---
_Generated by [Claude Code](https://claude.ai/code/session_01DrKqpQgkHzDHGqpEMjxYdN)_