### PR TITLE
RUE-1228: batch backend query roots

### DIFF
--- a/crates/rue-compiler/src/cfg_query.rs
+++ b/crates/rue-compiler/src/cfg_query.rs
@@ -797,12 +797,20 @@ fn materialize_and_build_cfg(
             body_span,
         } => {
             let mut slots = std::collections::BTreeMap::new();
-            for ty in collect_plan_types(owner, facts) {
-                let dependency = crate::type_queries::TypeQueryKey {
-                    ty: ty.clone(),
-                    configuration: key.configuration.clone(),
-                };
-                let terminal = context.query_registered(layouts, dependency)?;
+            let plan_types = collect_plan_types(owner, facts)
+                .into_iter()
+                .collect::<Vec<_>>();
+            let terminals = context.query_registered_batch(
+                layouts,
+                plan_types
+                    .iter()
+                    .cloned()
+                    .map(|ty| crate::type_queries::TypeQueryKey {
+                        ty,
+                        configuration: key.configuration.clone(),
+                    }),
+            )?;
+            for (ty, terminal) in plan_types.into_iter().zip(terminals) {
                 let QueryOutcome::Success(value) = terminal.outcome() else {
                     unreachable!("Layout publishes typed values")
                 };
@@ -823,12 +831,17 @@ fn materialize_and_build_cfg(
         }
     };
     let mut builtin_facts = Vec::with_capacity(facts.builtin_nominals.len());
-    for request in facts.builtin_nominals.iter() {
-        let dependency = crate::type_queries::TypeQueryKey {
-            ty: request.query_ty.clone(),
-            configuration: key.configuration.clone(),
-        };
-        let terminal = context.query_registered(type_facts, dependency)?;
+    let builtin_terminals = context.query_registered_batch(
+        type_facts,
+        facts
+            .builtin_nominals
+            .iter()
+            .map(|request| crate::type_queries::TypeQueryKey {
+                ty: request.query_ty.clone(),
+                configuration: key.configuration.clone(),
+            }),
+    )?;
+    for (request, terminal) in facts.builtin_nominals.iter().zip(builtin_terminals) {
         let QueryOutcome::Success(value) = terminal.outcome() else {
             unreachable!("TypeFacts publishes typed values")
         };
@@ -932,23 +945,24 @@ fn materialize_and_build_cfg(
         collect_type_dependencies(ty, &mut layout_dependencies);
         collect_drop_type_dependency(ty, &mut drop_dependencies);
     }
-    for ty in layout_dependencies {
-        context.query_registered(
-            layouts,
-            crate::type_queries::TypeQueryKey {
+    context.query_registered_batch(
+        layouts,
+        layout_dependencies
+            .into_iter()
+            .map(|ty| crate::type_queries::TypeQueryKey {
                 ty,
                 configuration: key.configuration.clone(),
-            },
-        )?;
-    }
-    for ty in drop_dependencies {
-        let dependency = crate::type_queries::TypeQueryKey {
+            }),
+    )?;
+    let drop_dependencies = drop_dependencies
+        .into_iter()
+        .map(|ty| crate::type_queries::TypeQueryKey {
             ty,
             configuration: key.configuration.clone(),
-        };
-        context.query_registered(type_facts, dependency.clone())?;
-        context.query_registered(drop_glues, dependency)?;
-    }
+        })
+        .collect::<Vec<_>>();
+    context.query_registered_batch(type_facts, drop_dependencies.iter().cloned())?;
+    context.query_registered_batch(drop_glues, drop_dependencies)?;
     build_cfg(context, call_abis, key, materialized, domains)
 }
 
@@ -1021,15 +1035,17 @@ fn build_cfg(
             ));
         }
     };
-    let mut call_abi_facts = std::collections::BTreeMap::new();
-    for callable in callables {
-        let terminal = context.query_registered(
-            call_abis,
-            crate::type_queries::CallAbiQueryKey {
+    let call_abi_terminals = context.query_registered_batch(
+        call_abis,
+        callables
+            .iter()
+            .map(|callable| crate::type_queries::CallAbiQueryKey {
                 callable: callable.clone(),
                 configuration: key.configuration.clone(),
-            },
-        )?;
+            }),
+    )?;
+    let mut call_abi_facts = std::collections::BTreeMap::new();
+    for (callable, terminal) in callables.into_iter().zip(call_abi_terminals) {
         let QueryOutcome::Success(value) = terminal.outcome() else {
             unreachable!("CallAbi publishes typed values")
         };
@@ -1151,9 +1167,10 @@ pub(crate) fn evaluate_optimized_cfg(
         .collect::<std::collections::BTreeSet<_>>();
     let mut implicit_destructor_dependencies_complete =
         record.implicit_destructor_dependencies_complete;
+    let accessor_terminals =
+        context.query_registered_batch(cfgs, key.accessor_dependencies.iter().cloned())?;
     let mut accessor_cfgs = std::collections::BTreeMap::new();
-    for dependency in key.accessor_dependencies.iter() {
-        let terminal = context.query_registered(cfgs, dependency.clone())?;
+    for (dependency, terminal) in key.accessor_dependencies.iter().zip(accessor_terminals) {
         let QueryOutcome::Success(value) = terminal.outcome() else {
             unreachable!("Cfg publishes typed values")
         };

--- a/crates/rue-compiler/src/codegen_query.rs
+++ b/crates/rue-compiler/src/codegen_query.rs
@@ -62,6 +62,11 @@ pub(crate) struct CodegenUnitQueryKey {
     /// used by lowering. It is excluded from `stable_identity`, but remains in
     /// memo equality so a different function body/configuration cannot alias.
     pub(crate) optimized_cfg: crate::cfg_query::OptimizedCfgQueryKey,
+    /// Request-local transport for the deterministic test failure injection.
+    /// Registered batch children run on worker threads, so thread-local test
+    /// state is captured into the exact key at the host boundary.
+    #[cfg(test)]
+    inject_failure: bool,
     memo_hash: u64,
 }
 
@@ -87,6 +92,10 @@ impl CodegenUnitQueryKey {
         request.regalloc.hash(&mut hasher);
         request.asm.hash(&mut hasher);
         optimized_cfg.hash(&mut hasher);
+        #[cfg(test)]
+        let inject_failure = INJECT_CODEGEN_FAILURE.with(Cell::get);
+        #[cfg(test)]
+        inject_failure.hash(&mut hasher);
         let memo_hash = hasher.finish();
         Self {
             function,
@@ -98,6 +107,8 @@ impl CodegenUnitQueryKey {
             abi_layout_epoch: ABI_LAYOUT_EPOCH,
             request,
             optimized_cfg,
+            #[cfg(test)]
+            inject_failure,
             memo_hash,
         }
     }
@@ -114,6 +125,16 @@ impl PartialEq for CodegenUnitQueryKey {
             && self.abi_layout_epoch == other.abi_layout_epoch
             && self.request == other.request
             && self.optimized_cfg == other.optimized_cfg
+            && {
+                #[cfg(test)]
+                {
+                    self.inject_failure == other.inject_failure
+                }
+                #[cfg(not(test))]
+                {
+                    true
+                }
+            }
     }
 }
 impl Eq for CodegenUnitQueryKey {}
@@ -487,7 +508,7 @@ pub(crate) fn evaluate_codegen_unit(
         lowering.fn_name = record.codegen.defined_symbol.to_string();
     }
     #[cfg(test)]
-    if INJECT_CODEGEN_FAILURE.with(Cell::get) {
+    if key.inject_failure {
         product
             .machine_code
             .relocations

--- a/crates/rue-compiler/src/pipeline_tests.rs
+++ b/crates/rue-compiler/src/pipeline_tests.rs
@@ -425,7 +425,7 @@ mod tests {
         let failing =
             SourceSnapshot::single("<backend-root-control>", "fn main() -> i32 { 1 }").unwrap();
         let options = CompileOptions::default();
-        let mut session = CompilerSession::new();
+        let mut session = CompilerSession::with_query_concurrency(4);
         session
             .update_for_presentation(&before)
             .into_result()
@@ -461,6 +461,63 @@ mod tests {
         let recovered_root = session.backend_root_metrics();
         assert_eq!(recovered_root.functions, 1, "{recovered_root:?}");
         assert_eq!(recovered_root.publications, last_good.publications + 1);
+    }
+
+    #[test]
+    fn failed_wide_batches_release_their_unpublished_child_cones_under_pressure() {
+        const CHAIN_FUNCTIONS: usize = 33;
+        let options = CompileOptions::default();
+        let last_good_source =
+            SourceSnapshot::single("<backend-root-failure-pressure>", "fn main() -> i32 { 0 }")
+                .unwrap();
+        let failed_source = wide_reached_program(CHAIN_FUNCTIONS, 100);
+        let mut session = CompilerSession::with_query_concurrency(4);
+
+        session
+            .update_for_presentation(&last_good_source)
+            .into_result()
+            .unwrap();
+        crate::queries::compile_with_session(&mut session, &last_good_source, &options).unwrap();
+        let last_good = session.backend_root_metrics();
+
+        let fail = |session: &mut CompilerSession, source: &SourceSnapshot| {
+            session
+                .update_for_presentation(source)
+                .into_result()
+                .unwrap();
+            crate::codegen_query::with_test_codegen_failure_injection(|| {
+                assert!(
+                    session
+                        .rooted_codegen(&options, rue_codegen::BackendArtifactRequest::default())
+                        .is_err()
+                );
+            });
+            assert_eq!(session.backend_root_metrics(), last_good);
+        };
+
+        fail(&mut session, &failed_source);
+        let evictions_before_pressure = session.query_evictions_for_test();
+        for value in 101..117 {
+            fail(&mut session, &wide_reached_program(CHAIN_FUNCTIONS, value));
+        }
+        assert!(
+            session.query_evictions_for_test() > evictions_before_pressure,
+            "failed child cones must face real query-family eviction pressure"
+        );
+
+        fail(&mut session, &failed_source);
+        assert_eq!(
+            session.codegen_executions().len(),
+            1,
+            "host projection stops at the first deterministic CodegenUnit failure"
+        );
+        let (identity, execution) = &session.codegen_executions()[0];
+        assert!(
+            matches!(identity, FunctionInstanceKey::Definition(definition) if definition.name() == "f0")
+                && *execution == rue_query::RequestExecution::Computed,
+            "the changed failed leaf must recompute after its batch cone is released: {:?}",
+            session.codegen_executions()
+        );
     }
 
     #[test]
@@ -1013,6 +1070,216 @@ mod tests {
             assert!(execution.stdout.is_empty());
             assert!(execution.stderr.is_empty());
         }
+    }
+
+    /// A registered CodegenUnit root donates the caller permit and dispatches
+    /// independent children through the runtime's one structured worker budget.
+    /// The gate makes overlap (or its absence) deterministic rather than timing
+    /// dependent.
+    #[test]
+    fn codegen_root_batch_overlaps_with_many_workers_and_is_serial_with_one() {
+        let snapshot = SourceSnapshot::single(
+            "<backend-batch-overlap>",
+            "fn a() -> i32 { 1 } fn b() -> i32 { 2 } fn main() -> i32 { a() + b() }",
+        )
+        .unwrap();
+        let options = CompileOptions::default();
+        let run = |workers, gated_children, rendezvous| {
+            let mut session = CompilerSession::with_query_concurrency(workers);
+            session
+                .update_for_presentation(&snapshot)
+                .into_result()
+                .unwrap();
+            session.exercise_codegen_batch_overlap_for_test(&options, gated_children, rendezvous)
+        };
+
+        assert_eq!(run(1, 2, false), (1, 2));
+        assert_eq!(run(4, 2, true), (2, 2));
+    }
+
+    /// The batch memo bound is intentionally smaller than this root. Retaining
+    /// only the batch terminal without its exact child leases would evict and
+    /// recompute early CodegenUnits during final backend-root publication.
+    #[test]
+    fn codegen_root_batch_retains_more_than_the_child_memo_bound_until_publication() {
+        let snapshot = SourceSnapshot::single(
+            "<backend-batch-retention>",
+            "fn f00() -> i32 { 0 } fn f01() -> i32 { 1 } fn f02() -> i32 { 2 } \
+             fn f03() -> i32 { 3 } fn f04() -> i32 { 4 } fn f05() -> i32 { 5 } \
+             fn f06() -> i32 { 6 } fn f07() -> i32 { 7 } fn f08() -> i32 { 8 } \
+             fn f09() -> i32 { 9 } fn f10() -> i32 { 10 } fn f11() -> i32 { 11 } \
+             fn f12() -> i32 { 12 } fn f13() -> i32 { 13 } fn f14() -> i32 { 14 } \
+             fn f15() -> i32 { 15 } \
+             fn main() -> i32 { f00() + f01() + f02() + f03() + f04() + f05() + \
+                 f06() + f07() + f08() + f09() + f10() + f11() + f12() + f13() + \
+                 f14() + f15() }",
+        )
+        .unwrap();
+        let mut session = CompilerSession::with_query_concurrency(4);
+        session
+            .update_for_presentation(&snapshot)
+            .into_result()
+            .unwrap();
+
+        let (peak, evaluations) = session.exercise_codegen_batch_overlap_for_test(
+            &CompileOptions::default(),
+            usize::MAX,
+            false,
+        );
+
+        assert!(peak > 0);
+        assert_eq!(
+            evaluations, 17,
+            "publication must not recompute CodegenUnits"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn backend_batches_preserve_all_one_and_many_worker_projections() {
+        let snapshot = SourceSnapshot::single(
+            "<backend-batch-determinism>",
+            "fn a() -> i32 { 1 } fn b() -> i32 { 2 } fn c() -> i32 { 3 } \
+             fn main() -> i32 { let unused = 9; a() + b() + c() }",
+        )
+        .unwrap();
+        let options = CompileOptions::default();
+        let run = |workers| {
+            let mut session = CompilerSession::with_query_concurrency(workers);
+            session
+                .update_for_presentation(&snapshot)
+                .into_result()
+                .unwrap();
+            let rooted = session
+                .rooted_codegen(
+                    &options,
+                    rue_codegen::BackendArtifactRequest {
+                        asm: true,
+                        ..Default::default()
+                    },
+                )
+                .unwrap();
+            let cfgs = rooted
+                .cfgs
+                .iter()
+                .map(|cfg| {
+                    (
+                        format!("{:?}", cfg.function),
+                        format!("{:?}", cfg.record.cfg),
+                        cfg.record.codegen.defined_symbol.to_string(),
+                    )
+                })
+                .collect::<Vec<_>>();
+            let codegen_units = rooted
+                .units
+                .iter()
+                .map(|unit| (format!("{:?}", unit.function), format!("{:?}", unit.unit)))
+                .collect::<Vec<_>>();
+            let diagnostics = rooted
+                .warnings
+                .iter()
+                .map(|warning| (warning.to_string(), format!("{:?}", warning.diagnostic())))
+                .collect::<Vec<_>>();
+            let image = crate::program_image_plan::ProgramImage::from_rooted(
+                rooted.units,
+                rooted.exports,
+                &options,
+            )
+            .unwrap();
+            let plan = image.plan.clone();
+            let objects = image.fresh_objects(&options).unwrap();
+            let executable = image.fresh_link(&options, &rooted.warnings).unwrap().elf;
+            (cfgs, codegen_units, diagnostics, plan, objects, executable)
+        };
+
+        assert_eq!(run(1), run(4));
+    }
+
+    /// Opt-in cold and broad-invalidation backend wall-time witness. It has no
+    /// timing threshold: samples include exact child counts so noisy hosts do
+    /// not turn a performance observation into a correctness gate.
+    #[test]
+    #[ignore]
+    fn rue_1228_backend_batch_latency_witness() {
+        const FUNCTIONS: usize = 64;
+        const SAMPLES: usize = 7;
+        let options = CompileOptions::default();
+        let snapshot = |salt: usize| {
+            let mut source = String::new();
+            for index in 0..FUNCTIONS {
+                source.push_str(&format!("fn f{index}() -> i32 {{ {} }} ", index + salt));
+            }
+            source.push_str("fn main() -> i32 { ");
+            for index in 0..FUNCTIONS {
+                if index != 0 {
+                    source.push_str(" + ");
+                }
+                source.push_str(&format!("f{index}()"));
+            }
+            source.push_str(" }");
+            SourceSnapshot::single("<rue-1228-backend-latency>", source).unwrap()
+        };
+
+        let measure = |workers| {
+            let mut cold = Vec::with_capacity(SAMPLES);
+            let mut broad = Vec::with_capacity(SAMPLES);
+            for sample in 0..SAMPLES {
+                let before = snapshot(sample * 2);
+                let after = snapshot(sample * 2 + 1);
+                let mut session = CompilerSession::with_query_concurrency(workers);
+                session
+                    .update_for_presentation(&before)
+                    .into_result()
+                    .unwrap();
+                let start = std::time::Instant::now();
+                session
+                    .rooted_codegen(&options, rue_codegen::BackendArtifactRequest::default())
+                    .unwrap();
+                cold.push(start.elapsed().as_micros());
+
+                session
+                    .update_for_presentation(&after)
+                    .into_result()
+                    .unwrap();
+                let start = std::time::Instant::now();
+                session
+                    .rooted_codegen(&options, rue_codegen::BackendArtifactRequest::default())
+                    .unwrap();
+                broad.push(start.elapsed().as_micros());
+                assert_eq!(
+                    session
+                        .codegen_executions()
+                        .iter()
+                        .filter(|(_, execution)| {
+                            *execution == rue_query::RequestExecution::Computed
+                        })
+                        .count(),
+                    FUNCTIONS,
+                    "every independently edited callee CodegenUnit recomputes"
+                );
+            }
+            cold.sort_unstable();
+            broad.sort_unstable();
+            (cold, broad)
+        };
+
+        let (one_cold, one_broad) = measure(1);
+        let (many_cold, many_broad) = measure(4);
+        eprintln!(
+            "RUE-1228 backend batch latency: functions={} samples={} \
+             workers=1 cold_us={:?} cold_median_us={} broad_us={:?} broad_median_us={} \
+             workers=4 cold_us={:?} cold_median_us={} broad_us={:?} broad_median_us={}",
+            FUNCTIONS,
+            SAMPLES,
+            one_cold,
+            one_cold[SAMPLES / 2],
+            one_broad,
+            one_broad[SAMPLES / 2],
+            many_cold,
+            many_cold[SAMPLES / 2],
+            many_broad,
+            many_broad[SAMPLES / 2],
+        );
     }
 
     #[cfg(unix)]

--- a/crates/rue-compiler/src/revisioned_query_database.rs
+++ b/crates/rue-compiler/src/revisioned_query_database.rs
@@ -397,10 +397,13 @@ pub(crate) struct RevisionedQueryDatabase {
     #[allow(dead_code)]
     cfgs: QueryFamily<crate::cfg_query::CfgQueryKey, crate::cfg_query::CfgValue>,
     optimized_cfgs: QueryFamily<crate::cfg_query::OptimizedCfgQueryKey, crate::cfg_query::CfgValue>,
+    optimized_cfg_batches: QueryFamily<OptimizedCfgBatchKey, OptimizedCfgBatchOutput>,
+    #[cfg_attr(not(test), allow(dead_code))]
     codegen_units: QueryFamily<
         crate::codegen_query::CodegenUnitQueryKey,
         crate::codegen_query::CodegenUnitValue,
     >,
+    codegen_unit_batches: QueryFamily<CodegenUnitBatchKey, CodegenUnitBatchOutput>,
     backend_root_publications: QueryFamily<BackendRootPublicationKey, bool>,
     /// One-shot rendezvous inside the registered CodegenUnit evaluator. Unit
     /// tests use it to force an exact-key owner to remain live while a second
@@ -408,6 +411,11 @@ pub(crate) struct RevisionedQueryDatabase {
     /// execute the production family and evaluator.
     #[cfg(test)]
     codegen_evaluator_gate: Arc<Mutex<Option<Arc<TestCodegenEvaluatorGate>>>>,
+    /// Multi-child rendezvous proving that the production CodegenUnit root
+    /// enters independent evaluators concurrently only when the shared query
+    /// budget has more than one worker.
+    #[cfg(test)]
+    codegen_batch_evaluator_gate: Arc<Mutex<Option<Arc<TestBackendBatchEvaluatorGate>>>>,
     lookup_names: QueryFamily<LookupNameKey, LookupNameValue>,
     /// Per-`(module, import-path)` binding-resolution family. Registered query
     /// machinery for the exact provider boundary. Production body import
@@ -560,6 +568,107 @@ impl TestCodegenEvaluatorGate {
 
     pub(crate) fn release(&self) {
         self.rendezvous.wait();
+    }
+}
+
+#[cfg(test)]
+pub(crate) struct TestBackendBatchEvaluatorGate {
+    remaining: std::sync::atomic::AtomicUsize,
+    entered: std::sync::atomic::AtomicUsize,
+    active: std::sync::atomic::AtomicUsize,
+    peak: std::sync::atomic::AtomicUsize,
+    rendezvous: Option<TestBackendBatchRendezvous>,
+}
+
+#[cfg(test)]
+struct TestBackendBatchRendezvous {
+    expected: usize,
+    released: Mutex<bool>,
+    changed: std::sync::Condvar,
+}
+
+#[cfg(test)]
+impl TestBackendBatchEvaluatorGate {
+    fn new(gated_children: usize, rendezvous: bool) -> Self {
+        assert!(gated_children > 0);
+        Self {
+            remaining: std::sync::atomic::AtomicUsize::new(gated_children),
+            entered: std::sync::atomic::AtomicUsize::new(0),
+            active: std::sync::atomic::AtomicUsize::new(0),
+            peak: std::sync::atomic::AtomicUsize::new(0),
+            rendezvous: rendezvous.then(|| TestBackendBatchRendezvous {
+                expected: gated_children,
+                released: Mutex::new(false),
+                changed: std::sync::Condvar::new(),
+            }),
+        }
+    }
+
+    fn evaluator_wait(&self) {
+        use std::sync::atomic::Ordering;
+        if self
+            .remaining
+            .fetch_update(Ordering::AcqRel, Ordering::Acquire, |remaining| {
+                remaining.checked_sub(1)
+            })
+            .is_err()
+        {
+            return;
+        }
+        self.entered.fetch_add(1, Ordering::AcqRel);
+        let active = self.active.fetch_add(1, Ordering::AcqRel) + 1;
+        self.peak.fetch_max(active, Ordering::AcqRel);
+        if let Some(rendezvous) = &self.rendezvous {
+            rendezvous.changed.notify_all();
+            let mut released = rendezvous
+                .released
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
+            while !*released {
+                released = rendezvous
+                    .changed
+                    .wait(released)
+                    .unwrap_or_else(std::sync::PoisonError::into_inner);
+            }
+        }
+        self.active.fetch_sub(1, Ordering::AcqRel);
+    }
+
+    pub(crate) fn wait_until_all_entered_and_release(&self) -> bool {
+        let rendezvous = self
+            .rendezvous
+            .as_ref()
+            .expect("only a rendezvous gate can wait for concurrent entry");
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
+        let mut released = rendezvous
+            .released
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        while self.entered() < rendezvous.expected {
+            let Some(remaining) = deadline.checked_duration_since(std::time::Instant::now()) else {
+                break;
+            };
+            let (next, timeout) = rendezvous
+                .changed
+                .wait_timeout(released, remaining)
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
+            released = next;
+            if timeout.timed_out() {
+                break;
+            }
+        }
+        let all_entered = self.entered() == rendezvous.expected;
+        *released = true;
+        rendezvous.changed.notify_all();
+        all_entered
+    }
+
+    pub(crate) fn peak(&self) -> usize {
+        self.peak.load(std::sync::atomic::Ordering::Acquire)
+    }
+
+    pub(crate) fn entered(&self) -> usize {
+        self.entered.load(std::sync::atomic::Ordering::Acquire)
     }
 }
 
@@ -1013,9 +1122,69 @@ pub(crate) struct BackendRootCandidate {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub(crate) struct OptimizedCfgBatchKey {
+    pub(crate) keys: Arc<[crate::cfg_query::OptimizedCfgQueryKey]>,
+}
+
+impl QueryKey for OptimizedCfgBatchKey {
+    fn stable_identity(&self) -> String {
+        let mut identity = format!("optimized-cfg-batch;units={}", self.keys.len());
+        for key in self.keys.iter() {
+            identity.push('\u{1e}');
+            identity.push_str(&key.stable_identity());
+        }
+        identity
+    }
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct OptimizedCfgBatchOutput {
+    pub(crate) values: Arc<[crate::cfg_query::CfgValue]>,
+    /// Exact child leases acquired while the rooted batch evaluator still owns
+    /// every request lease. The memoized root encapsulates these pins so
+    /// retaining it also retains the scheduled children through publication.
+    _retained_children: Arc<rue_query::RetainedPinSet>,
+}
+
+impl RetainedCharge for OptimizedCfgBatchOutput {
+    fn retained_charge(&self) -> u64 {
+        self.values.retained_charge()
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub(crate) struct CodegenUnitBatchKey {
+    pub(crate) keys: Arc<[crate::codegen_query::CodegenUnitQueryKey]>,
+}
+
+impl QueryKey for CodegenUnitBatchKey {
+    fn stable_identity(&self) -> String {
+        let mut identity = format!("codegen-unit-batch;units={}", self.keys.len());
+        for key in self.keys.iter() {
+            identity.push('\u{1e}');
+            identity.push_str(&key.stable_identity());
+        }
+        identity
+    }
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct CodegenUnitBatchOutput {
+    pub(crate) values: Arc<[crate::codegen_query::CodegenUnitValue]>,
+    /// See `OptimizedCfgBatchOutput::_retained_children`.
+    _retained_children: Arc<rue_query::RetainedPinSet>,
+}
+
+impl RetainedCharge for CodegenUnitBatchOutput {
+    fn retained_charge(&self) -> u64 {
+        self.values.retained_charge()
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 struct BackendRootPublicationKey {
     epoch: u64,
-    codegen_units: Arc<[crate::codegen_query::CodegenUnitQueryKey]>,
+    codegen_units: CodegenUnitBatchKey,
     functions: Arc<[crate::FunctionInstanceKey]>,
     cfg_terminals: usize,
 }
@@ -1036,7 +1205,7 @@ impl QueryKey for BackendRootPublicationKey {
         format!(
             "backend-root;epoch={};units={}",
             self.epoch,
-            self.codegen_units.len()
+            self.codegen_units.keys.len()
         )
     }
 }
@@ -14369,11 +14538,69 @@ impl RevisionedQueryDatabase {
                 },
             )
             .expect("the OptimizedCfg family has one canonical name");
+        let optimized_cfgs_for_batch = optimized_cfgs.clone();
+        let optimized_cfg_batches = runtime
+            .family_with_equality_and_evaluator(
+                "compiler.optimized-cfg-batch",
+                0,
+                |left: &OptimizedCfgBatchOutput, right: &OptimizedCfgBatchOutput| {
+                    left.values.len() == right.values.len()
+                        && left
+                            .values
+                            .iter()
+                            .zip(right.values.iter())
+                            .all(|(left, right)| crate::cfg_query::cfg_value_equal(left, right))
+                },
+                move |context, _, key: &OptimizedCfgBatchKey| {
+                    let _validated_registered = context.endorse_registered_validations();
+                    let _attempts = context.retain_nested_attempts_for(&["compiler.optimized-cfg"]);
+                    let terminals = context.query_registered_batch(
+                        &optimized_cfgs_for_batch,
+                        key.keys.iter().cloned(),
+                    )?;
+                    let kind = if terminals
+                        .iter()
+                        .all(|terminal| terminal.kind() == QueryTerminalKind::Success)
+                    {
+                        QueryTerminalKind::Success
+                    } else {
+                        QueryTerminalKind::Failure
+                    };
+                    let retained_children = Arc::new(
+                        context
+                            .retain_observed_terminal_cones_from(&terminals, &[])
+                            .expect(
+                                "the registered optimized-CFG batch observes every selected child cone",
+                            ),
+                    );
+                    let values = terminals
+                        .iter()
+                        .map(|terminal| {
+                            let rue_query::QueryOutcome::Success(value) = terminal.outcome() else {
+                                unreachable!("OptimizedCfg publishes typed values")
+                            };
+                            value.clone()
+                        })
+                        .collect::<Vec<_>>()
+                        .into();
+                    Ok(QueryOutput::success(OptimizedCfgBatchOutput {
+                        values,
+                        _retained_children: retained_children,
+                    })
+                    .with_terminal_kind(kind))
+                },
+            )
+            .expect("the OptimizedCfgBatch family has one canonical name");
         let optimized_cfgs_for_codegen = optimized_cfgs.clone();
         #[cfg(test)]
         let codegen_evaluator_gate = Arc::new(Mutex::new(None::<Arc<TestCodegenEvaluatorGate>>));
         #[cfg(test)]
         let codegen_gate_for_evaluator = codegen_evaluator_gate.clone();
+        #[cfg(test)]
+        let codegen_batch_evaluator_gate =
+            Arc::new(Mutex::new(None::<Arc<TestBackendBatchEvaluatorGate>>));
+        #[cfg(test)]
+        let codegen_batch_gate_for_evaluator = codegen_batch_evaluator_gate.clone();
         let codegen_units = runtime
             .family_with_equality_and_evaluator(
                 "compiler.codegen-unit",
@@ -14388,6 +14615,15 @@ impl RevisionedQueryDatabase {
                     {
                         gate.evaluator_wait();
                     }
+                    #[cfg(test)]
+                    let batch_gate = codegen_batch_gate_for_evaluator
+                        .lock()
+                        .unwrap_or_else(std::sync::PoisonError::into_inner)
+                        .clone();
+                    #[cfg(test)]
+                    if let Some(gate) = batch_gate {
+                        gate.evaluator_wait();
+                    }
                     crate::codegen_query::evaluate_codegen_unit(
                         context,
                         &optimized_cfgs_for_codegen,
@@ -14396,6 +14632,61 @@ impl RevisionedQueryDatabase {
                 },
             )
             .expect("the CodegenUnit family has one canonical name");
+        let codegen_units_for_batch = codegen_units.clone();
+        let codegen_unit_batches = runtime
+            .family_with_equality_and_evaluator(
+                "compiler.codegen-unit-batch",
+                0,
+                |left: &CodegenUnitBatchOutput, right: &CodegenUnitBatchOutput| {
+                    left.values.len() == right.values.len()
+                        && left
+                            .values
+                            .iter()
+                            .zip(right.values.iter())
+                            .all(|(left, right)| {
+                                crate::codegen_query::codegen_unit_value_equal(left, right)
+                            })
+                },
+                move |context, _, key: &CodegenUnitBatchKey| {
+                    let _validated_registered = context.endorse_registered_validations();
+                    let _attempts = context.retain_nested_attempts_for(&["compiler.codegen-unit"]);
+                    let terminals = context.query_registered_batch(
+                        &codegen_units_for_batch,
+                        key.keys.iter().cloned(),
+                    )?;
+                    let kind = if terminals
+                        .iter()
+                        .all(|terminal| terminal.kind() == QueryTerminalKind::Success)
+                    {
+                        QueryTerminalKind::Success
+                    } else {
+                        QueryTerminalKind::Failure
+                    };
+                    let retained_children = Arc::new(
+                        context
+                            .retain_observed_terminal_cones_from(&terminals, &[])
+                            .expect(
+                                "the registered CodegenUnit batch observes every selected child cone",
+                            ),
+                    );
+                    let values = terminals
+                        .iter()
+                        .map(|terminal| {
+                            let rue_query::QueryOutcome::Success(value) = terminal.outcome() else {
+                                unreachable!("CodegenUnit publishes typed values")
+                            };
+                            value.clone()
+                        })
+                        .collect::<Vec<_>>()
+                        .into();
+                    Ok(QueryOutput::success(CodegenUnitBatchOutput {
+                        values,
+                        _retained_children: retained_children,
+                    })
+                    .with_terminal_kind(kind))
+                },
+            )
+            .expect("the CodegenUnitBatch family has one canonical name");
         let provider_observation_meter = Arc::new(ProviderObservationCounters::default());
         let lookup_root_lease = Arc::new(Mutex::new(PublishedRootLookupLease::default()));
         let body_closure_root = Arc::new(Mutex::new(PublishedBodyClosureRoot::default()));
@@ -14415,20 +14706,20 @@ impl RevisionedQueryDatabase {
                         .unwrap_or_else(std::sync::PoisonError::into_inner)
                         .lease
                         .clone();
-                    let mut terminals = Vec::with_capacity(key.codegen_units.len());
-                    for codegen_key in key.codegen_units.iter() {
-                        let terminal = context.query_registered(
-                            &codegen_units_for_backend_publication,
-                            codegen_key.clone(),
-                        )?;
-                        let rue_query::QueryOutcome::Success(value) = terminal.outcome() else {
-                            unreachable!("CodegenUnit publishes typed terminals")
-                        };
-                        if matches!(value, crate::codegen_query::CodegenUnitValue::Failure(_)) {
-                            return Ok(QueryOutput::success(false)
-                                .with_terminal_kind(QueryTerminalKind::Failure));
-                        }
-                        terminals.push(terminal);
+                    let terminals = context.query_registered_batch(
+                        &codegen_units_for_backend_publication,
+                        key.codegen_units.keys.iter().cloned(),
+                    )?;
+                    if terminals.iter().any(|terminal| {
+                        matches!(
+                            terminal.outcome(),
+                            rue_query::QueryOutcome::Success(
+                                crate::codegen_query::CodegenUnitValue::Failure(_)
+                            )
+                        )
+                    }) {
+                        return Ok(QueryOutput::success(false)
+                            .with_terminal_kind(QueryTerminalKind::Failure));
                     }
                     let pending = context
                         .retain_observed_terminal_cones_from(
@@ -14443,8 +14734,8 @@ impl RevisionedQueryDatabase {
                         pending: Some(Arc::new(pending)),
                         functions: Some(key.functions.iter().cloned().collect()),
                         cfg_terminals: key.cfg_terminals,
-                        optimized_cfg_terminals: key.codegen_units.len(),
-                        codegen_unit_terminals: key.codegen_units.len(),
+                        optimized_cfg_terminals: key.codegen_units.keys.len(),
+                        codegen_unit_terminals: key.codegen_units.keys.len(),
                         previous: None,
                         installed: false,
                     });
@@ -15625,10 +15916,14 @@ impl RevisionedQueryDatabase {
             drop_glues,
             cfgs,
             optimized_cfgs,
+            optimized_cfg_batches,
             codegen_units,
+            codegen_unit_batches,
             backend_root_publications,
             #[cfg(test)]
             codegen_evaluator_gate,
+            #[cfg(test)]
+            codegen_batch_evaluator_gate,
             lookup_names,
             lookup_imports,
             #[cfg(test)]
@@ -15685,6 +15980,28 @@ impl RevisionedQueryDatabase {
             .unwrap_or_else(std::sync::PoisonError::into_inner)
             .replace(gate.clone());
         assert!(replaced.is_none(), "only one CodegenUnit gate may be armed");
+        gate
+    }
+
+    #[cfg(test)]
+    pub(crate) fn arm_codegen_batch_evaluator_gate_for_test(
+        &self,
+        gated_children: usize,
+        rendezvous: bool,
+    ) -> Arc<TestBackendBatchEvaluatorGate> {
+        let gate = Arc::new(TestBackendBatchEvaluatorGate::new(
+            gated_children,
+            rendezvous,
+        ));
+        let replaced = self
+            .codegen_batch_evaluator_gate
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .replace(gate.clone());
+        assert!(
+            replaced.is_none(),
+            "only one CodegenUnit batch gate may be armed"
+        );
         gate
     }
 
@@ -16016,9 +16333,32 @@ impl RevisionedQueryDatabase {
         Ok((optimized, attempt))
     }
 
+    /// Request one stable-ordered production root of optimized CFGs. The
+    /// registered evaluator owns structured scheduling; the host only builds
+    /// exact keys and projects returned typed values in the same order.
+    pub(crate) fn optimized_cfg_batch(
+        &self,
+        revision: Revision,
+        keys: Arc<[crate::cfg_query::OptimizedCfgQueryKey]>,
+        cancellation: CancellationToken,
+    ) -> (
+        OptimizedCfgBatchKey,
+        QueryRequestAttempt<OptimizedCfgBatchOutput>,
+    ) {
+        let key = OptimizedCfgBatchKey { keys };
+        let attempt = self.runtime.request_registered(
+            &self.optimized_cfg_batches,
+            revision,
+            key.clone(),
+            cancellation,
+        );
+        (key, attempt)
+    }
+
     /// Request one canonical backend terminal from its registered optimized
     /// CFG. The nested terminal owns every current-domain lowering input, so
     /// this API requires no semantic output, type pool, or live function.
+    #[cfg(test)]
     pub(crate) fn codegen_unit(
         &self,
         revision: Revision,
@@ -16041,6 +16381,27 @@ impl RevisionedQueryDatabase {
         ))
     }
 
+    /// Request one stable-ordered production root of CodegenUnits through the
+    /// runtime's registered structured scheduler.
+    pub(crate) fn codegen_unit_batch(
+        &self,
+        revision: Revision,
+        keys: Arc<[crate::codegen_query::CodegenUnitQueryKey]>,
+        cancellation: CancellationToken,
+    ) -> (
+        CodegenUnitBatchKey,
+        QueryRequestAttempt<CodegenUnitBatchOutput>,
+    ) {
+        let key = CodegenUnitBatchKey { keys };
+        let attempt = self.runtime.request_registered(
+            &self.codegen_unit_batches,
+            revision,
+            key.clone(),
+            cancellation,
+        );
+        (key, attempt)
+    }
+
     /// Start an unpublished backend-root handoff. Every terminal retained into
     /// this candidate is acquired while its request attempt still owns the
     /// result lease, closing the birth-to-publication eviction window.
@@ -16048,43 +16409,48 @@ impl RevisionedQueryDatabase {
         BackendRootCandidate::default()
     }
 
-    /// Retain one reached optimized-CFG terminal across sequential collection.
-    /// Raw CFG identities are recorded for exact-root metrics; the registered
-    /// publication request captures their full terminal cones.
-    pub(crate) fn retain_backend_optimized_cfg(
+    /// Retain the registered optimized-CFG batch while its request lease is
+    /// live. The batch value encapsulates pins acquired for every observed
+    /// child while the evaluator's leases were live, so this one root pin
+    /// protects the exact child cones until codegen acquires successor pins.
+    pub(crate) fn retain_backend_optimized_cfg_batch(
         &self,
         candidate: &mut BackendRootCandidate,
-        function: crate::FunctionInstanceKey,
-        key: &crate::cfg_query::OptimizedCfgQueryKey,
-        terminal: &Arc<rue_query::QueryTerminal<crate::cfg_query::CfgValue>>,
+        key: &OptimizedCfgBatchKey,
+        terminal: &Arc<rue_query::QueryTerminal<OptimizedCfgBatchOutput>>,
     ) {
-        for cfg_key in std::iter::once(&key.cfg).chain(key.accessor_dependencies.iter()) {
-            candidate.cfg_keys.insert(cfg_key.clone());
-        }
         let pin = self
-            .optimized_cfgs
+            .optimized_cfg_batches
             .pin_terminal(terminal)
-            .expect("optimized-CFG result belongs to the registered family");
-        if candidate.lease.lease(pin) {
-            candidate.optimized_cfg_terminals += 1;
+            .expect("optimized-CFG batch result belongs to the registered family");
+        candidate.lease.lease(pin);
+        for optimized in key.keys.iter() {
+            for cfg_key in
+                std::iter::once(&optimized.cfg).chain(optimized.accessor_dependencies.iter())
+            {
+                candidate.cfg_keys.insert(cfg_key.clone());
+            }
+            candidate.functions.insert(optimized.cfg.function.clone());
         }
-        candidate.functions.insert(function);
+        candidate.optimized_cfg_terminals = key.keys.len();
     }
 
-    /// Retain one reached CodegenUnit terminal. Its optimized-CFG input was
-    /// pinned explicitly during the preceding rooted CFG collection.
-    pub(crate) fn retain_backend_codegen_unit(
+    /// Retain the registered CodegenUnit batch from result birth until the
+    /// backend publication handoff installs its exact transitive cone. Its
+    /// encapsulated child pins prevent bounded child memo retention from
+    /// recomputing wide roots during that handoff.
+    pub(crate) fn retain_backend_codegen_batch(
         &self,
         candidate: &mut BackendRootCandidate,
-        terminal: &Arc<rue_query::QueryTerminal<crate::codegen_query::CodegenUnitValue>>,
+        key: &CodegenUnitBatchKey,
+        terminal: &Arc<rue_query::QueryTerminal<CodegenUnitBatchOutput>>,
     ) {
         let pin = self
-            .codegen_units
+            .codegen_unit_batches
             .pin_terminal(terminal)
-            .expect("codegen result belongs to the registered family");
-        if candidate.lease.lease(pin) {
-            candidate.codegen_unit_terminals += 1;
-        }
+            .expect("codegen batch result belongs to the registered family");
+        candidate.lease.lease(pin);
+        candidate.codegen_unit_terminals = key.keys.len();
     }
 
     /// Publish the full transitive query cone behind a successful backend
@@ -16096,7 +16462,7 @@ impl RevisionedQueryDatabase {
         &self,
         revision: Revision,
         candidate: BackendRootCandidate,
-        codegen_units: Arc<[crate::codegen_query::CodegenUnitQueryKey]>,
+        codegen_units: CodegenUnitBatchKey,
     ) -> Result<(), QueryAbort> {
         // A root-publication request is transactional through its handoff
         // callbacks. Serialize only these short, whole-program swaps so a

--- a/crates/rue-compiler/src/session.rs
+++ b/crates/rue-compiler/src/session.rs
@@ -1454,6 +1454,41 @@ impl CompilerSession {
         });
         (owner_execution, joiner_execution)
     }
+
+    /// Gate the first `gated_children` production CodegenUnit evaluators in one
+    /// rooted batch and return their peak simultaneous occupancy.
+    #[cfg(test)]
+    pub(crate) fn exercise_codegen_batch_overlap_for_test(
+        &mut self,
+        options: &CompileOptions,
+        gated_children: usize,
+        rendezvous: bool,
+    ) -> (usize, usize) {
+        let gate = self
+            .queries
+            .revisioned
+            .arm_codegen_batch_evaluator_gate_for_test(gated_children, rendezvous);
+        if rendezvous {
+            std::thread::scope(|scope| {
+                let compilation = scope.spawn(|| {
+                    self.rooted_codegen(options, rue_codegen::BackendArtifactRequest::default())
+                });
+                let all_entered = gate.wait_until_all_entered_and_release();
+                compilation
+                    .join()
+                    .expect("CodegenUnit batch compilation did not panic")
+                    .expect("CodegenUnit batch fixture compiles successfully");
+                assert!(
+                    all_entered,
+                    "CodegenUnit evaluators did not reach the requested concurrent occupancy"
+                );
+            });
+        } else {
+            self.rooted_codegen(options, rue_codegen::BackendArtifactRequest::default())
+                .expect("CodegenUnit batch fixture compiles successfully");
+        }
+        (gate.peak(), gate.entered())
+    }
     /// Perturb one canonical observation for the in-tree differential oracle.
     #[doc(hidden)]
     pub(crate) fn inject_stale_query_for_oracle(
@@ -4901,41 +4936,84 @@ impl CompilerSession {
         let accessor_roots = accessor_subgraph.roots;
         let accessor_dependencies = accessor_subgraph.dependencies;
         let accessor_functions = accessor_subgraph.accessors;
-        let mut cfgs = Vec::with_capacity(cfg_inputs.len());
-        let mut backend_root = self.queries.revisioned.begin_backend_root();
-        #[cfg(test)]
-        self.rooted_cfg_executions.clear();
-        let _cfg_collection_span =
-            tracing::info_span!("optimized_cfg_collection", phase = "cfg_and_optimization")
-                .entered();
-        for (function, semantic_input, body_span) in cfg_inputs {
-            if accessor_functions.contains(&function) {
-                continue;
-            }
-            let (optimized_cfg_key, attempt) = self
-                .queries
-                .revisioned
-                .optimized_cfg(
-                    graph.revision,
+        let cfg_requests = cfg_inputs
+            .into_iter()
+            .filter(|(function, _, _)| !accessor_functions.contains(function))
+            .map(|(function, semantic_input, body_span)| {
+                let cfg = crate::cfg_query::CfgQueryKey::new(
                     function.clone(),
                     graph.configuration.clone(),
                     accessor_roots
                         .get(&function)
                         .map(|key| key.semantic_input.clone())
                         .unwrap_or(semantic_input),
+                );
+                let optimized_cfg_key = crate::cfg_query::OptimizedCfgQueryKey::new(
+                    cfg,
                     options.opt_level,
                     accessor_dependencies
                         .get(&function)
                         .cloned()
                         .unwrap_or_else(|| Arc::new([])),
-                    rue_query::CancellationToken::new(),
-                )
-                .map_err(|abort| {
-                    CompileError::without_span(ErrorKind::InternalError(format!(
-                        "optimized CFG query aborted: {abort:?}"
-                    )))
-                })?;
-            let execution = attempt.execution();
+                );
+                (function, optimized_cfg_key, body_span)
+            })
+            .collect::<Vec<_>>();
+        let optimized_keys = cfg_requests
+            .iter()
+            .map(|(_, key, _)| key.clone())
+            .collect::<Vec<_>>()
+            .into();
+        let mut cfgs = Vec::with_capacity(cfg_requests.len());
+        let mut backend_root = self.queries.revisioned.begin_backend_root();
+        #[cfg(test)]
+        self.rooted_cfg_executions.clear();
+        let _cfg_collection_span =
+            tracing::info_span!("optimized_cfg_collection", phase = "cfg_and_optimization")
+                .entered();
+        let (cfg_batch_key, attempt) = self.queries.revisioned.optimized_cfg_batch(
+            graph.revision,
+            optimized_keys,
+            rue_query::CancellationToken::new(),
+        );
+        let batch_execution = attempt.execution();
+        let executions = if batch_execution == rue_query::RequestExecution::Computed {
+            let executions = attempt
+                .nested_attempts()
+                .iter()
+                .filter(|attempt| attempt.node().family() == "compiler.optimized-cfg")
+                .map(rue_query::NestedQueryAttempt::execution)
+                .collect::<Vec<_>>();
+            assert_eq!(
+                executions.len(),
+                cfg_requests.len(),
+                "an evaluated optimized-CFG batch records one direct child per key"
+            );
+            executions
+        } else {
+            vec![batch_execution; cfg_requests.len()]
+        };
+        if let Some(terminal) = attempt.terminal() {
+            self.queries.revisioned.retain_backend_optimized_cfg_batch(
+                &mut backend_root,
+                &cfg_batch_key,
+                terminal,
+            );
+        }
+        let batch = attempt.into_result().map_err(|abort| {
+            CompileError::without_span(ErrorKind::InternalError(format!(
+                "optimized CFG batch query aborted: {abort:?}"
+            )))
+        })?;
+        let rue_query::QueryOutcome::Success(batch) = batch.outcome() else {
+            unreachable!("OptimizedCfgBatch publishes typed values")
+        };
+        assert_eq!(batch.values.len(), cfg_requests.len());
+        for (((function, optimized_cfg_key, body_span), value), execution) in cfg_requests
+            .into_iter()
+            .zip(batch.values.iter())
+            .zip(executions)
+        {
             #[cfg(test)]
             self.rooted_cfg_executions
                 .push((function.clone(), execution));
@@ -4950,22 +5028,6 @@ impl CompilerSession {
                 }
                 rue_query::RequestExecution::Aborted => {}
             }
-            if let Some(terminal) = attempt.terminal() {
-                self.queries.revisioned.retain_backend_optimized_cfg(
-                    &mut backend_root,
-                    function.clone(),
-                    &optimized_cfg_key,
-                    terminal,
-                );
-            }
-            let terminal = attempt.into_result().map_err(|abort| {
-                CompileError::without_span(ErrorKind::InternalError(format!(
-                    "optimized CFG query aborted: {abort:?}"
-                )))
-            })?;
-            let rue_query::QueryOutcome::Success(value) = terminal.outcome() else {
-                unreachable!("OptimizedCfg publishes typed values")
-            };
             let record = match value {
                 crate::cfg_query::CfgValue::Available(record) => {
                     if execution == rue_query::RequestExecution::Computed {
@@ -5059,8 +5121,19 @@ impl CompilerSession {
             mut backend_root,
         } = self.rooted_cfg(options)?;
 
+        let codegen_keys = cfgs
+            .iter()
+            .map(|cfg| {
+                crate::codegen_query::CodegenUnitQueryKey::new(
+                    cfg.optimized_cfg_key.clone(),
+                    options.target,
+                    request,
+                    options.opt_level,
+                )
+            })
+            .collect::<Vec<_>>()
+            .into();
         let mut units = Vec::with_capacity(cfgs.len());
-        let mut backend_root_keys = Vec::with_capacity(cfgs.len());
         #[cfg(test)]
         {
             self.codegen_executions.clear();
@@ -5069,51 +5142,66 @@ impl CompilerSession {
         }
         let _codegen_collection_span =
             tracing::info_span!("codegen_collection", phase = "backend").entered();
-        for cfg in &cfgs {
-            let attempt = self
-                .queries
-                .revisioned
-                .codegen_unit(
-                    graph.revision,
-                    cfg.optimized_cfg_key.clone(),
-                    options.target,
-                    request,
-                    options.opt_level,
-                    rue_query::CancellationToken::new(),
-                )
-                .map_err(|abort| {
-                    CompileError::without_span(ErrorKind::InternalError(format!(
-                        "codegen query aborted: {abort:?}"
-                    )))
-                })?;
+        let (codegen_batch_key, attempt) = self.queries.revisioned.codegen_unit_batch(
+            graph.revision,
+            codegen_keys,
+            rue_query::CancellationToken::new(),
+        );
+        #[cfg(test)]
+        let batch_execution = attempt.execution();
+        #[cfg(test)]
+        let child_attempts = if batch_execution == rue_query::RequestExecution::Computed {
+            let attempts = attempt
+                .nested_attempts()
+                .iter()
+                .filter(|attempt| attempt.node().family() == "compiler.codegen-unit")
+                .map(|attempt| (attempt.execution(), attempt.work().to_vec()))
+                .collect::<Vec<_>>();
+            assert_eq!(
+                attempts.len(),
+                cfgs.len(),
+                "an evaluated CodegenUnit batch records one direct child per key"
+            );
+            Some(attempts)
+        } else {
+            None
+        };
+        if let Some(terminal) = attempt.terminal() {
+            self.queries.revisioned.retain_backend_codegen_batch(
+                &mut backend_root,
+                &codegen_batch_key,
+                terminal,
+            );
+        }
+        let batch = attempt.into_result().map_err(|abort| {
+            CompileError::without_span(ErrorKind::InternalError(format!(
+                "codegen batch query aborted: {abort:?}"
+            )))
+        })?;
+        let rue_query::QueryOutcome::Success(batch) = batch.outcome() else {
+            unreachable!("CodegenUnitBatch publishes typed terminals")
+        };
+        assert_eq!(batch.values.len(), cfgs.len());
+        for (index, (cfg, value)) in cfgs.iter().zip(batch.values.iter()).enumerate() {
+            #[cfg(not(test))]
+            let _ = index;
+            #[cfg(test)]
+            let execution = child_attempts
+                .as_ref()
+                .map_or(batch_execution, |attempts| attempts[index].0);
             #[cfg(test)]
             {
                 self.codegen_executions
-                    .push((cfg.function.clone(), attempt.execution()));
-                self.codegen_attempt_work
-                    .push((cfg.function.clone(), attempt.work().to_vec()));
+                    .push((cfg.function.clone(), execution));
+                self.codegen_attempt_work.push((
+                    cfg.function.clone(),
+                    child_attempts
+                        .as_ref()
+                        .map_or_else(Vec::new, |attempts| attempts[index].1.clone()),
+                ));
             }
-            if let Some(terminal) = attempt.terminal() {
-                self.queries
-                    .revisioned
-                    .retain_backend_codegen_unit(&mut backend_root, terminal);
-            }
-            let terminal = attempt.into_result().map_err(|abort| {
-                CompileError::without_span(ErrorKind::InternalError(format!(
-                    "codegen query aborted: {abort:?}"
-                )))
-            })?;
-            let rue_query::QueryOutcome::Success(value) = terminal.outcome() else {
-                unreachable!("CodegenUnit publishes typed terminals")
-            };
             match value {
                 crate::codegen_query::CodegenUnitValue::Available(unit) => {
-                    backend_root_keys.push(crate::codegen_query::CodegenUnitQueryKey::new(
-                        cfg.optimized_cfg_key.clone(),
-                        options.target,
-                        request,
-                        options.opt_level,
-                    ));
                     units.push(crate::codegen_query::CollectedCodegenUnit {
                         function: cfg.function.clone(),
                         unit: unit.clone(),
@@ -5164,7 +5252,7 @@ impl CompilerSession {
             .collect();
         self.queries
             .revisioned
-            .publish_backend_root(graph.revision, backend_root, backend_root_keys.into())
+            .publish_backend_root(graph.revision, backend_root, codegen_batch_key)
             .map_err(|abort| {
                 CompileError::without_span(ErrorKind::InternalError(format!(
                     "backend root publication aborted: {abort:?}"


### PR DESCRIPTION
Fixes RUE-1228.

## Summary
- schedule OptimizedCfg and CodegenUnit roots as registered deterministic query batches
- batch independent layout, type-fact, drop-glue, call-ABI, and accessor prerequisites
- preserve stable projections and birth-to-publication retention under failure, cancellation, and retention pressure

## Performance
64-function local latency witness, seven-sample medians:
- cold: 75,573 us with one worker, 62,863 us with four workers (16.8% faster)
- broad invalidation: 66,645 us with one worker, 50,744 us with four workers (23.9% faster)

## Validation
- focused overlap, retention, failure, cancellation, and one-vs-many projection tests
- scripts/rue quick
- scripts/rue premerge
- scripts/rue fmt
- production compiler build