### PR TITLE
RUE-1233: preserve accessor phase diagnostics

### DIFF
--- a/crates/rue-air/src/api_inventory.rs
+++ b/crates/rue-air/src/api_inventory.rs
@@ -79,6 +79,15 @@ fn accessor_producers_do_not_spell_their_own_declaration_diagnostics() {
         !producers.contains("\"a `-> borrow` accessor\""),
         "an accessor producer regained its own 6.6:3 gate subject"
     );
+
+    // Signature legality is decided before either body-analysis host can run:
+    // declaration binding owns the whole-RIR path, and the durable signature
+    // query owns the provider path. The ordinary engine therefore must not
+    // become a third signature producer again (RUE-1233).
+    assert!(
+        !include_str!("sema/ordinary_engine.rs").contains("accessor_signature("),
+        "the ordinary body engine regained an accessor signature re-check"
+    );
 }
 
 #[test]

--- a/crates/rue-air/src/declaration_validation.rs
+++ b/crates/rue-air/src/declaration_validation.rs
@@ -109,16 +109,16 @@ pub fn duplicate_destructor(type_name: &str) -> ErrorKind {
 //
 // These rules are legality rules on the *declaration*, so a declared-but-
 // uncalled accessor is exactly as ill-formed as a called one, and every
-// producer that admits an accessor declaration runs them: RIR predeclaration
-// (`sema::declarations`), the body engine (`sema::ordinary_engine`), the
-// demanded body walk (`sema::control_flow`), and the driver's reparsed
-// signature query (`rue_compiler::semantic_query_nucleus`). The producers
-// necessarily differ in *what they walk* — RIR instructions, a resolved
-// parameter list, or a reparsed AST — so the forms below are named after the
-// spec's own vocabulary rather than any one IR, and every producer lowers its
-// nodes into them. The mapping from a form to its diagnostic, and the order in
-// which the rules apply, live here exactly once; without that, the two
-// declaration-time producers drift on wording the way they did before RUE-1232.
+// declaration producer runs them: RIR predeclaration (`sema::declarations`)
+// and the driver's reparsed signature query
+// (`rue_compiler::semantic_query_nucleus`). The demanded body walk
+// (`sema::control_flow`) additionally resolves whether a method-call link in a
+// yielded projection names another accessor. The producers necessarily differ
+// in *what they walk* — RIR instructions or a reparsed AST — so the forms below
+// are named after the spec's own vocabulary rather than either IR. The mapping
+// from a form to its diagnostic, and the order in which the rules apply, live
+// here exactly once; without that, the two declaration producers drift on
+// wording the way they did before RUE-1232.
 
 /// The preview feature the accessor form is gated behind (6.6:3).
 pub const ACCESSOR_PREVIEW_FEATURE: rue_error::PreviewFeature =
@@ -150,10 +150,6 @@ pub enum AccessorReceiverForm {
     FreeFunction,
     /// A declaration with an owning type but no receiver parameter.
     AssociatedFunction,
-    /// No receiver parameter, from a producer that sees only a resolved
-    /// parameter list and so cannot tell a free function from an associated
-    /// one.
-    MissingReceiver,
 }
 
 /// The mode of one non-receiver accessor parameter (6.6:5). Guard inputs are
@@ -243,8 +239,7 @@ pub enum AccessorBodyVerdict {
 
 /// A violation of the accessor signature rules, in the order the rules apply.
 pub enum AccessorSignatureViolation {
-    /// 6.6:4. `note` is the phase pointer for `inout self`; a producer whose
-    /// diagnostic transport carries no note may drop it.
+    /// 6.6:4. `note` is the phase pointer for `inout self`.
     Receiver {
         kind: ErrorKind,
         note: Option<&'static str>,
@@ -295,7 +290,6 @@ pub fn accessor_receiver_error(
         AccessorReceiverForm::AssociatedFunction => {
             ("an associated function with no receiver", None)
         }
-        AccessorReceiverForm::MissingReceiver => ("a function with no receiver", None),
     };
     Some((
         ErrorKind::AccessorRequiresBorrowSelf {

--- a/crates/rue-air/src/sema/ordinary_engine.rs
+++ b/crates/rue-air/src/sema/ordinary_engine.rs
@@ -30,7 +30,6 @@ use super::{
     DeclarationPhase, DeclarationTypeDependencyKind, DeclarationTypeDependencySourceKind,
     FunctionInfo, InferenceContext, KnownSymbols, MethodInfo, ParamSlotModes, StructId, Type,
 };
-use crate::declaration_validation::AccessorReceiverForm;
 use crate::inference::InferType;
 use crate::inst::Air;
 use crate::inst::{AirInst, AirInstData};
@@ -2150,56 +2149,11 @@ impl<'h, H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'h, H> {
         // per-instruction `yield`/`return`/`?` analysis against the trailing
         // reference recorded here.
         if is_accessor {
-            // Declaration shape (ADR-0062 phase 1), re-checked at the engine
-            // so it holds on every host that analyzes the body: the receiver
-            // is a shared `borrow self`, and value parameters are plain
-            // by-value guard inputs. Predeclaration reports the same errors
-            // over the whole program before any body is demanded.
-            let body_span = self.body_rir_ref().get(body).span;
-            // The `-> borrow` result position alone demands the preview
-            // (6.6:3), so an ungated program reports E1100 rather than a shape
-            // error about a form it cannot name yet.
-            self.require_preview(
-                crate::declaration_validation::ACCESSOR_PREVIEW_FEATURE,
-                crate::declaration_validation::ACCESSOR_PREVIEW_SUBJECT,
-                body_span,
-            )?;
-            // 6.6:4 and 6.6:5 again, over the resolved parameter list. Which
-            // forms are illegal and how each one reads are
-            // `crate::declaration_validation`'s, shared with every other
-            // accessor producer; this seam sees no owner, so a missing
-            // receiver reports the less specific form.
-            let self_sym_check = self.storage.body_interner().get_or_intern("self");
-            let receiver = match params
-                .iter()
-                .find(|(name, _, _, _)| *name == self_sym_check)
-            {
-                Some((_, _, RirParamMode::Borrow, _)) => AccessorReceiverForm::BorrowSelf,
-                Some((_, _, RirParamMode::Inout, _)) => AccessorReceiverForm::InoutSelf,
-                Some(_) => AccessorReceiverForm::ValueSelf,
-                None => AccessorReceiverForm::MissingReceiver,
-            };
-            if let Some(violation) = crate::declaration_validation::accessor_signature(
-                receiver,
-                params
-                    .iter()
-                    .filter(|(name, _, _, _)| *name != self_sym_check)
-                    .map(|(_, _, mode, is_comptime)| {
-                        super::declarations::accessor_parameter_form(*mode, *is_comptime)
-                    }),
-            ) {
-                use crate::declaration_validation::AccessorSignatureViolation as Violation;
-                let (kind, note) = match violation {
-                    Violation::Receiver { kind, note } => (kind, note),
-                    Violation::Parameter { kind, .. } => (kind, None),
-                };
-                let error = CompileError::new(kind, body_span);
-                return Err(match note {
-                    Some(note) => error.with_note(note),
-                    None => error,
-                });
-            }
-
+            // Signature legality is a declaration invariant. The whole-RIR
+            // host freezes checked declarations before body analysis, and the
+            // provider host obtains this method's facts through its successful
+            // durable signature query. Re-checking 6.6:3-6.6:5 here would add
+            // a third producer without admitting any new body-analysis path.
             ctx.accessor_trailing_yield = Some(super::declarations::accessor_trailing_yield(
                 self.body_rir_ref(),
                 body,

--- a/crates/rue-compiler/src/revisioned_query_database.rs
+++ b/crates/rue-compiler/src/revisioned_query_database.rs
@@ -6185,7 +6185,8 @@ pub(crate) fn semantic_nucleus_failure_is_internal_error(
         | F::DuplicateDeclaration { kind, .. }
         | F::DiagnosticAtProducerRange { kind, .. }
         | F::OwnershipGate { kind, .. }
-        | F::DiagnosticWithHelp { kind, .. } => kind,
+        | F::DiagnosticWithHelp { kind, .. }
+        | F::DiagnosticWithNote { kind, .. } => kind,
         F::Shell(_)
         | F::DuplicateDeclarations(_)
         | F::ForeignSignatureConflict(_)
@@ -10456,9 +10457,7 @@ fn resolve_parsed_semantic_signature(
                 // illegal, in which order, and how each diagnostic reads are
                 // `rue_air::declaration_validation`'s, shared with the RIR
                 // producers (RUE-1232); this seam owns only the lowering of
-                // the reparsed signature into that vocabulary. This
-                // transport carries no note, so the `inout self` phase
-                // pointer is dropped here.
+                // the reparsed signature into that vocabulary.
                 use rue_air::declaration_validation as rules;
                 use rue_air::declaration_validation::{
                     AccessorParameterForm, AccessorReceiverForm,
@@ -10508,12 +10507,19 @@ fn resolve_parsed_semantic_signature(
                     }),
                 ) {
                     use rue_air::declaration_validation::AccessorSignatureViolation as Violation;
-                    let kind = match violation {
-                        Violation::Receiver { kind, .. } | Violation::Parameter { kind, .. } => {
-                            kind
-                        }
-                    };
-                    return Err(diagnostic(kind));
+                    return Err(match violation {
+                        Violation::Receiver {
+                            kind,
+                            note: Some(note),
+                        } => ResolveSemanticSignatureError::failure(
+                            crate::semantic_query_nucleus::SemanticNucleusFailure::DiagnosticWithNote {
+                                kind,
+                                note: Arc::from(note),
+                            },
+                        ),
+                        Violation::Receiver { kind, note: None }
+                        | Violation::Parameter { kind, .. } => diagnostic(kind),
+                    });
                 }
                 // 6.6:6 and 6.6:7 over the accessor's own retained body. These
                 // are legality rules on the declaration, so they hold with no
@@ -25455,7 +25461,8 @@ fn main() -> i32 {
                 | F::DiagnosticAtParameter { kind, .. }
                 | F::DiagnosticAtDeclaration { kind, .. }
                 | F::OwnershipGate { kind, .. }
-                | F::DiagnosticWithHelp { kind, .. },
+                | F::DiagnosticWithHelp { kind, .. }
+                | F::DiagnosticWithNote { kind, .. },
             ) => Some(kind.to_string()),
             _ => None,
         }

--- a/crates/rue-compiler/src/semantic_query_nucleus.rs
+++ b/crates/rue-compiler/src/semantic_query_nucleus.rs
@@ -893,6 +893,10 @@ pub(crate) enum SemanticNucleusFailure {
         kind: rue_error::ErrorKind,
         help: Arc<str>,
     },
+    DiagnosticWithNote {
+        kind: rue_error::ErrorKind,
+        note: Arc<str>,
+    },
     SignatureReentry {
         signature: StableDefinitionKey,
         cycle: Arc<[Arc<str>]>,
@@ -1091,6 +1095,9 @@ impl RetainedCharge for SemanticNucleusFailure {
             Self::DiagnosticWithHelp { kind, help } => kind
                 .retained_charge()
                 .saturating_add(help.retained_charge()),
+            Self::DiagnosticWithNote { kind, note } => kind
+                .retained_charge()
+                .saturating_add(note.retained_charge()),
             Self::SignatureReentry { signature, cycle } => signature
                 .retained_charge()
                 .saturating_add(cycle.retained_charge()),

--- a/crates/rue-compiler/src/session.rs
+++ b/crates/rue-compiler/src/session.rs
@@ -6761,18 +6761,19 @@ fn semantic_nucleus_failure_diagnostics(
             .and_then(|module| module.definitions().declaration_locator(key))
             .map(|locator| locator.declaration_span)
     });
-    let (kind, help) = match failure {
-        F::Diagnostic(kind) => (kind.clone(), None),
-        F::DiagnosticAtParameter { kind, .. } => (kind.clone(), None),
-        F::DiagnosticAtDeclaration { kind, .. } => (kind.clone(), None),
-        F::DuplicateDeclaration { kind, .. } => (kind.clone(), None),
+    let (kind, help, note) = match failure {
+        F::Diagnostic(kind) => (kind.clone(), None, None),
+        F::DiagnosticAtParameter { kind, .. } => (kind.clone(), None, None),
+        F::DiagnosticAtDeclaration { kind, .. } => (kind.clone(), None, None),
+        F::DuplicateDeclaration { kind, .. } => (kind.clone(), None, None),
         F::DuplicateDeclarations(_) => unreachable!("duplicate batches return above"),
         F::ForeignSignatureConflict(_) => {
             unreachable!("foreign-signature conflicts return above")
         }
-        F::DiagnosticAtProducerRange { kind, .. } => (kind.clone(), None),
-        F::OwnershipGate { kind, .. } => (kind.clone(), None),
-        F::DiagnosticWithHelp { kind, help } => (kind.clone(), Some(help.clone())),
+        F::DiagnosticAtProducerRange { kind, .. } => (kind.clone(), None, None),
+        F::OwnershipGate { kind, .. } => (kind.clone(), None, None),
+        F::DiagnosticWithHelp { kind, help } => (kind.clone(), Some(help.clone()), None),
+        F::DiagnosticWithNote { kind, note } => (kind.clone(), None, Some(note.clone())),
         F::Cycle(nodes) => (
             ErrorKind::ConstInitializerCycle {
                 cycle: nodes
@@ -6781,6 +6782,7 @@ fn semantic_nucleus_failure_diagnostics(
                     .collect::<Vec<_>>()
                     .join(" -> "),
             },
+            None,
             None,
         ),
         F::SignatureReentry { cycle, .. } => (
@@ -6791,6 +6793,7 @@ fn semantic_nucleus_failure_diagnostics(
                     .collect::<Vec<_>>()
                     .join(" -> "),
             ),
+            None,
             None,
         ),
         F::Resolution(message) if message.starts_with("unknown array length") => (
@@ -6804,15 +6807,18 @@ fn semantic_nucleus_failure_diagnostics(
                     ),
             },
             None,
+            None,
         ),
         F::Resolution(message) => (
             ErrorKind::ComptimeEvaluationFailed {
                 reason: message.to_string(),
             },
             None,
+            None,
         ),
         F::Shell(message) | F::Syntax(message) => (
             ErrorKind::InternalError(format!("semantic query invariant failed: {message}")),
+            None,
             None,
         ),
     };
@@ -6820,8 +6826,12 @@ fn semantic_nucleus_failure_diagnostics(
         Some(span) => CompileError::new(kind, span),
         None => CompileError::without_span(kind),
     };
-    CompileErrors::from(match help {
+    let error = match help {
         Some(help) => error.with_help(help.to_string()),
+        None => error,
+    };
+    CompileErrors::from(match note {
+        Some(note) => error.with_note(note.to_string()),
         None => error,
     })
 }

--- a/crates/rue-spec/cases/items/borrow-accessors.toml
+++ b/crates/rue-spec/cases/items/borrow-accessors.toml
@@ -174,7 +174,7 @@ fn main() -> i32 {
 }
 """
 compile_fail = true
-error_contains = ["E0257", "requires a `borrow self` receiver"]
+error_contains = ["E0257", "requires a `borrow self` receiver", "mutable accessors"]
 
 [[case]]
 name = "free_function_accessor_is_rejected"
@@ -342,7 +342,7 @@ struct P {
 fn main() -> i32 { 0 }
 """
 compile_fail = true
-error_contains = ["E0257", "requires a `borrow self` receiver"]
+error_contains = ["E0257", "requires a `borrow self` receiver", "mutable accessors"]
 
 [[case]]
 name = "uncalled_associated_function_accessor_is_rejected"


### PR DESCRIPTION
## Summary
- remove the body-engine accessor signature re-check after auditing both analysis hosts
- carry semantic-nucleus diagnostic notes through production projection
- require the mutable-accessor phase pointer in called and uncalled E0257 specs

## Validation
- `scripts/rue spec accessor_requires_borrow_self`
- `scripts/rue unit air accessor_producers_do_not_spell_their_own_declaration_diagnostics`
- `scripts/rue quick`
- `/opt/homebrew/bin/bash clippy.sh`
- `RUE_TEST_TIER=premerge /opt/homebrew/bin/bash test.sh`

Fixes RUE-1233.