### PR TITLE
RUE-1231: retain per-unit object projections

### DIFF
--- a/crates/rue-compiler/src/api_inventory.rs
+++ b/crates/rue-compiler/src/api_inventory.rs
@@ -16,6 +16,7 @@ const PRODUCTION_MODULES: &[(&str, &str)] = &[
     ("canonical_semantic", include_str!("canonical_semantic.rs")),
     ("cfg_query", include_str!("cfg_query.rs")),
     ("codegen_query", include_str!("codegen_query.rs")),
+    ("object_query", include_str!("object_query.rs")),
     (
         "declaration_candidate",
         include_str!("declaration_candidate.rs"),

--- a/crates/rue-compiler/src/lib.rs
+++ b/crates/rue-compiler/src/lib.rs
@@ -55,6 +55,7 @@ mod import_discovery;
 mod import_graph;
 mod linking;
 mod local_semantic_materialization;
+mod object_query;
 mod parsed_modules;
 mod program_image_plan;
 mod queries;

--- a/crates/rue-compiler/src/object_query.rs
+++ b/crates/rue-compiler/src/object_query.rs
@@ -1,0 +1,222 @@
+//! Retained target-object projections of canonical codegen terminals.
+//!
+//! Object serialization is a typed query downstream of one exact
+//! `CodegenUnit` key. The fresh linker remains deliberately stateless: it
+//! consumes these stable bytes on every link, while unchanged units reuse the
+//! retained projection owned by the compiler query graph.
+
+use std::{hash::Hash, sync::Arc};
+
+use rue_query::{
+    QueryAbort, QueryContext, QueryFamily, QueryKey, QueryOutcome, QueryOutput, QueryTerminalKind,
+};
+
+use crate::retained_charge::RetainedCharge;
+
+/// Object-container format selected unambiguously by the target.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub(crate) enum ObjectFormat {
+    Elf,
+    MachO,
+}
+
+impl ObjectFormat {
+    pub(crate) fn for_target(target: rue_target::Target) -> Self {
+        if target.is_macho() {
+            Self::MachO
+        } else {
+            Self::Elf
+        }
+    }
+}
+
+/// Exact identity of one target-object projection.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub(crate) struct ObjectProjectionQueryKey {
+    /// The dependency key names the exact canonical CodegenUnit terminal. Its
+    /// backend and ABI-layout epochs remain part of this query's identity.
+    pub(crate) codegen: crate::codegen_query::CodegenUnitQueryKey,
+    pub(crate) target: rue_target::Target,
+    pub(crate) object_format: ObjectFormat,
+    pub(crate) abi_layout_epoch: u32,
+    pub(crate) object_writer_epoch: u32,
+}
+
+impl ObjectProjectionQueryKey {
+    pub(crate) fn new(codegen: crate::codegen_query::CodegenUnitQueryKey) -> Self {
+        let target = codegen.target;
+        Self {
+            abi_layout_epoch: codegen.abi_layout_epoch,
+            codegen,
+            target,
+            object_format: ObjectFormat::for_target(target),
+            object_writer_epoch: OBJECT_WRITER_EPOCH,
+        }
+    }
+}
+
+impl QueryKey for ObjectProjectionQueryKey {
+    fn stable_identity(&self) -> String {
+        format!(
+            "object-projection;{};target={:?};format={:?};abi-layout={};writer={}",
+            self.codegen.stable_identity(),
+            self.target,
+            self.object_format,
+            self.abi_layout_epoch,
+            self.object_writer_epoch,
+        )
+    }
+}
+
+/// Retained object-container bytes for one codegen unit.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct ObjectProjection {
+    pub(crate) bytes: Arc<[u8]>,
+}
+
+impl RetainedCharge for ObjectProjection {
+    fn retained_charge(&self) -> u64 {
+        self.bytes.retained_charge()
+    }
+}
+
+/// Typed object projection terminal. Serialization failures remain ordinary
+/// compiler diagnostics in the canonical query graph.
+#[derive(Debug, Clone)]
+pub(crate) enum ObjectProjectionValue {
+    Available(Arc<ObjectProjection>),
+    Failure(crate::CompileErrors),
+}
+
+impl RetainedCharge for ObjectProjectionValue {
+    fn retained_charge(&self) -> u64 {
+        match self {
+            Self::Available(object) => object.retained_charge(),
+            Self::Failure(errors) => errors.retained_charge(),
+        }
+    }
+}
+
+pub(crate) fn object_projection_value_equal(
+    left: &ObjectProjectionValue,
+    right: &ObjectProjectionValue,
+) -> bool {
+    match (left, right) {
+        (ObjectProjectionValue::Available(left), ObjectProjectionValue::Available(right)) => {
+            left == right
+        }
+        (ObjectProjectionValue::Failure(left), ObjectProjectionValue::Failure(right)) => {
+            left == right
+        }
+        _ => false,
+    }
+}
+
+/// Stable production collection retaining both the codegen metadata needed by
+/// `ProgramImagePlan` and its already-serialized object bytes.
+#[derive(Clone)]
+pub(crate) struct CollectedObjectProjection {
+    pub(crate) function: crate::FunctionInstanceKey,
+    pub(crate) unit: Arc<crate::codegen_query::CodegenUnit>,
+    pub(crate) object: Arc<ObjectProjection>,
+}
+
+pub(crate) fn evaluate_object_projection(
+    context: &QueryContext,
+    codegen_units: &QueryFamily<
+        crate::codegen_query::CodegenUnitQueryKey,
+        crate::codegen_query::CodegenUnitValue,
+    >,
+    key: &ObjectProjectionQueryKey,
+) -> Result<QueryOutput<ObjectProjectionValue>, QueryAbort> {
+    context.check_canceled()?;
+    let codegen = context.query_registered(codegen_units, key.codegen.clone())?;
+    let QueryOutcome::Success(codegen) = codegen.outcome() else {
+        unreachable!("CodegenUnit publishes typed values")
+    };
+    let crate::codegen_query::CodegenUnitValue::Available(unit) = codegen else {
+        let crate::codegen_query::CodegenUnitValue::Failure(errors) = codegen else {
+            unreachable!()
+        };
+        return Ok(object_failure(errors.clone()));
+    };
+    context.record_work(rue_query::WorkItem::new("object.projection.attempts", 1));
+    let value = match crate::backend::project_backend_object(unit.backend_product(), key.target) {
+        Ok(bytes) => ObjectProjectionValue::Available(Arc::new(ObjectProjection {
+            bytes: bytes.into(),
+        })),
+        Err(error) => return Ok(object_failure(error.into())),
+    };
+    Ok(QueryOutput::success(value))
+}
+
+fn object_failure(errors: crate::CompileErrors) -> QueryOutput<ObjectProjectionValue> {
+    QueryOutput::success(ObjectProjectionValue::Failure(errors))
+        .with_terminal_kind(QueryTerminalKind::Failure)
+}
+
+// Bump whenever object-container serialization changes independently of
+// CodegenUnit's backend/ABI-layout epochs.
+const OBJECT_WRITER_EPOCH: u32 = 1;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[derive(Clone, PartialEq, Eq, Hash)]
+    struct FailureKey;
+
+    impl QueryKey for FailureKey {
+        fn stable_identity(&self) -> String {
+            "object-failure".to_owned()
+        }
+    }
+
+    #[test]
+    fn retained_charge_accounts_object_bytes() {
+        let object = ObjectProjection {
+            bytes: Arc::from([1_u8, 2, 3, 4]),
+        };
+        assert_eq!(object.retained_charge(), 4);
+        assert_eq!(
+            ObjectProjectionValue::Available(Arc::new(object)).retained_charge(),
+            std::mem::size_of::<ObjectProjection>() as u64 + 4
+        );
+    }
+
+    #[test]
+    fn typed_object_failure_is_a_failure_terminal() {
+        let runtime = rue_query::QueryRuntime::new(1);
+        let revision = rue_query::Revision::new(1, 1);
+        runtime.publish_revision(revision, []).unwrap();
+        let family = runtime
+            .family_with_equality_and_evaluator(
+                "test.object-projection-failure",
+                1,
+                object_projection_value_equal,
+                |_, _, _| {
+                    Ok(object_failure(
+                        crate::CompileError::without_span(crate::ErrorKind::InternalCodegenError(
+                            "object failure".to_owned(),
+                        ))
+                        .into(),
+                    ))
+                },
+            )
+            .unwrap();
+        let terminal = runtime
+            .request_registered(
+                &family,
+                revision,
+                FailureKey,
+                rue_query::CancellationToken::new(),
+            )
+            .into_result()
+            .unwrap();
+        assert_eq!(terminal.kind(), QueryTerminalKind::Failure);
+        assert!(matches!(
+            terminal.outcome(),
+            QueryOutcome::Success(ObjectProjectionValue::Failure(_))
+        ));
+    }
+}

--- a/crates/rue-compiler/src/pipeline_tests.rs
+++ b/crates/rue-compiler/src/pipeline_tests.rs
@@ -683,7 +683,7 @@ mod tests {
             );
 
             let image = crate::program_image_plan::ProgramImage::from_rooted(
-                rooted.units,
+                rooted.objects,
                 rooted.exports,
                 &options,
             )
@@ -1181,7 +1181,7 @@ mod tests {
                 .map(|warning| (warning.to_string(), format!("{:?}", warning.diagnostic())))
                 .collect::<Vec<_>>();
             let image = crate::program_image_plan::ProgramImage::from_rooted(
-                rooted.units,
+                rooted.objects,
                 rooted.exports,
                 &options,
             )
@@ -1279,6 +1279,180 @@ mod tests {
             many_cold[SAMPLES / 2],
             many_broad,
             many_broad[SAMPLES / 2],
+        );
+    }
+
+    #[test]
+    fn retained_object_projection_is_local_bounded_and_released_with_the_backend_root() {
+        const FUNCTIONS: usize = 32;
+        let options = CompileOptions::default();
+        let snapshot = |edited: Option<usize>, count: usize| {
+            let mut source = String::new();
+            for index in 0..count {
+                let value = if edited == Some(index) { 99 } else { index };
+                source.push_str(&format!("fn f{index}() -> i32 {{ {value} }} "));
+            }
+            source.push_str("fn main() -> i32 { ");
+            for index in 0..count {
+                if index != 0 {
+                    source.push_str(" + ");
+                }
+                source.push_str(&format!("f{index}()"));
+            }
+            source.push_str(" }");
+            SourceSnapshot::single("<retained-object-projection>", source).unwrap()
+        };
+        let computed = |session: &CompilerSession| {
+            session
+                .object_projection_executions()
+                .iter()
+                .filter(|(_, execution)| *execution == rue_query::RequestExecution::Computed)
+                .count()
+        };
+
+        let initial = snapshot(None, FUNCTIONS);
+        let mut session = CompilerSession::with_query_concurrency(4);
+        session
+            .update_for_presentation(&initial)
+            .into_result()
+            .unwrap();
+        let cold = session
+            .rooted_codegen(&options, rue_codegen::BackendArtifactRequest::default())
+            .unwrap();
+        let removed_object_key = cold
+            .cfgs
+            .iter()
+            .find(|cfg| format!("{:?}", cfg.function).contains("f17"))
+            .map(|cfg| {
+                crate::object_query::ObjectProjectionQueryKey::new(
+                    crate::codegen_query::CodegenUnitQueryKey::new(
+                        cfg.optimized_cfg_key.clone(),
+                        options.target,
+                        rue_codegen::BackendArtifactRequest::default(),
+                        options.opt_level,
+                    ),
+                )
+            })
+            .unwrap();
+        assert!(session.object_projection_key_is_retained(&removed_object_key));
+        assert_eq!(computed(&session), FUNCTIONS + 1);
+        assert_eq!(session.object_projection_collections(), FUNCTIONS + 1);
+        let canonical_objects = cold
+            .units
+            .iter()
+            .map(|unit| {
+                crate::backend::project_backend_object(unit.unit.backend_product(), options.target)
+                    .unwrap()
+            })
+            .collect::<Vec<_>>();
+        let cold_image = crate::program_image_plan::ProgramImage::from_rooted(
+            cold.objects,
+            cold.exports,
+            &options,
+        )
+        .unwrap();
+        assert_eq!(
+            cold_image.fresh_objects(&options).unwrap(),
+            canonical_objects
+        );
+
+        let warm = session
+            .rooted_codegen(&options, rue_codegen::BackendArtifactRequest::default())
+            .unwrap();
+        assert_eq!(computed(&session), 0, "a no-edit build reprojects no units");
+        let warm_plan = crate::program_image_plan::ProgramImage::from_rooted(
+            warm.objects,
+            warm.exports,
+            &options,
+        )
+        .unwrap()
+        .plan;
+
+        let edited = snapshot(Some(17), FUNCTIONS);
+        session
+            .update_for_presentation(&edited)
+            .into_result()
+            .unwrap();
+        let changed = session
+            .rooted_codegen(&options, rue_codegen::BackendArtifactRequest::default())
+            .unwrap();
+        assert_eq!(computed(&session), 1, "only f17 has new object content");
+        let changed_plan = crate::program_image_plan::ProgramImage::from_rooted(
+            changed.objects,
+            changed.exports,
+            &options,
+        )
+        .unwrap()
+        .plan;
+        let delta = changed_plan.delta_from(&warm_plan).unwrap();
+        assert!(delta.added.is_empty(), "{delta:?}");
+        assert_eq!(delta.changed.len(), 1, "{delta:?}");
+        assert!(delta.removed.is_empty(), "{delta:?}");
+        assert!(
+            format!("{:?}", delta.changed[0].function).contains("f17"),
+            "{delta:?}"
+        );
+
+        let reduced = snapshot(None, 1);
+        session
+            .update_for_presentation(&reduced)
+            .into_result()
+            .unwrap();
+        session
+            .rooted_codegen(&options, rue_codegen::BackendArtifactRequest::default())
+            .unwrap();
+        let root = session.backend_root_metrics();
+        assert_eq!(root.functions, 2, "{root:?}");
+        assert_eq!(root.object_projection_terminals, 2, "{root:?}");
+        assert_eq!(root.deletions, FUNCTIONS as u64 - 1, "{root:?}");
+        let retention = session.unstable_metrics().retention();
+        assert!(retention.retained_bytes > 0);
+        assert!(
+            retention.retained_bytes <= retention.retained_byte_budget,
+            "{retention:?}"
+        );
+
+        let mut pressure_source = String::new();
+        for index in 0..70 {
+            pressure_source.push_str(&format!("fn g{index}() -> i32 {{ {index} }} "));
+        }
+        pressure_source.push_str("fn main() -> i32 { ");
+        for index in 0..70 {
+            if index != 0 {
+                pressure_source.push_str(" + ");
+            }
+            pressure_source.push_str(&format!("g{index}()"));
+        }
+        pressure_source.push_str(" }");
+        let pressure =
+            SourceSnapshot::single("<retained-object-projection>", pressure_source).unwrap();
+        session
+            .update_for_presentation(&pressure)
+            .into_result()
+            .unwrap();
+        session
+            .rooted_codegen(&options, rue_codegen::BackendArtifactRequest::default())
+            .unwrap();
+        assert!(
+            !session.object_projection_key_is_retained(&removed_object_key),
+            "an object absent from the published root is evictable under pressure"
+        );
+
+        session
+            .update_for_presentation(&initial)
+            .into_result()
+            .unwrap();
+        session
+            .rooted_codegen(&options, rue_codegen::BackendArtifactRequest::default())
+            .unwrap();
+        assert!(
+            session
+                .object_projection_executions()
+                .iter()
+                .any(|(function, execution)| {
+                    format!("{function:?}").contains("f17")
+                        && *execution == rue_query::RequestExecution::Computed
+                })
         );
     }
 

--- a/crates/rue-compiler/src/program_image_plan.rs
+++ b/crates/rue-compiler/src/program_image_plan.rs
@@ -16,10 +16,12 @@ use crate::FunctionWithCfg;
 
 use crate::{
     CompileError, CompileErrors, CompileOptions, CompileOutput, CompileWarning, ErrorKind,
-    LinkerMode, MultiErrorResult, Target, backend,
-    codegen_query::{CodegenSection, CollectedCodegenUnit, NormalizedRelocation, SectionKind},
-    linking,
+    LinkerMode, MultiErrorResult, Target, backend, linking,
+    object_query::CollectedObjectProjection,
 };
+
+#[cfg(test)]
+use crate::codegen_query::CollectedCodegenUnit;
 
 /// Stable, link-relevant identity for one reached codegen terminal.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -69,11 +71,7 @@ pub(crate) struct ProgramImagePlan {
 
 /// Stable local representation avoids making the linker implementation type
 /// part of the plan's API surface.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub(crate) enum ProgramObjectFormat {
-    Elf,
-    MachO,
-}
+pub(crate) use crate::object_query::ObjectFormat as ProgramObjectFormat;
 
 /// Collision-resistant, deterministic content identity. Every digest below is
 /// SHA-256 over a domain-separated, length-framed byte encoding.
@@ -163,7 +161,7 @@ impl ProgramImagePlan {
 /// lowering, allocation, or emission.
 pub(crate) struct ProgramImage {
     pub(crate) plan: ProgramImagePlan,
-    units: Vec<CollectedCodegenUnit>,
+    objects: Vec<CollectedObjectProjection>,
     export_thunk_objects: Vec<Vec<u8>>,
 }
 
@@ -171,11 +169,11 @@ impl ProgramImage {
     /// Construct the production image directly from rooted codegen terminals
     /// and their exact C-export projections.
     pub(crate) fn from_rooted(
-        units: Vec<CollectedCodegenUnit>,
+        objects: Vec<CollectedObjectProjection>,
         exports: Vec<RootedExportThunk>,
         options: &CompileOptions,
     ) -> MultiErrorResult<Self> {
-        validate_rooted_program_image_inputs(&units, &exports)?;
+        validate_rooted_program_image_inputs(&objects, &exports)?;
         let export_thunk_objects: Vec<Vec<u8>> = exports
             .iter()
             .map(|export| {
@@ -187,11 +185,15 @@ impl ProgramImage {
                 )
             })
             .collect();
-        let plan =
-            ProgramImagePlan::from_rooted_inputs(&units, &exports, options, &export_thunk_objects)?;
+        let plan = ProgramImagePlan::from_rooted_inputs(
+            &objects,
+            &exports,
+            options,
+            &export_thunk_objects,
+        )?;
         Ok(Self {
             plan,
-            units,
+            objects,
             export_thunk_objects,
         })
     }
@@ -226,8 +228,22 @@ impl ProgramImage {
                 ),
             )));
         }
+        let objects = units
+            .into_iter()
+            .map(|collected| {
+                backend::project_backend_object(collected.unit.backend_product(), options.target)
+                    .map(|bytes| CollectedObjectProjection {
+                        function: collected.function,
+                        unit: collected.unit,
+                        object: std::sync::Arc::new(crate::object_query::ObjectProjection {
+                            bytes: bytes.into(),
+                        }),
+                    })
+            })
+            .collect::<Result<Vec<_>, _>>()
+            .map_err(CompileErrors::from)?;
         let plan = ProgramImagePlan::from_inputs(
-            &units,
+            &objects,
             functions,
             export_symbols,
             options,
@@ -235,13 +251,14 @@ impl ProgramImage {
         )?;
         Ok(Self {
             plan,
-            units,
+            objects,
             export_thunk_objects,
         })
     }
 
-    /// Project the existing terminal bytes to ordinary object files. This is
-    /// the only production object-generation path after aggregation.
+    /// Collect the already-projected per-unit bytes for the fresh linker.
+    /// Object serialization happened in the registered query graph; this
+    /// adapter only materializes the linker's existing owned byte-vector API.
     pub(crate) fn fresh_objects(&self, options: &CompileOptions) -> MultiErrorResult<Vec<Vec<u8>>> {
         if self.plan.target != options.target {
             return Err(CompileErrors::from(CompileError::without_span(
@@ -251,15 +268,12 @@ impl ProgramImage {
             )));
         }
         let mut objects = self
-            .units
+            .objects
             .iter()
-            .map(|collected| {
-                backend::project_backend_object(collected.unit.backend_product(), options.target)
-            })
-            .collect::<Result<Vec<_>, _>>()
-            .map_err(CompileErrors::from)?;
+            .map(|collected| collected.object.bytes.to_vec())
+            .collect::<Vec<_>>();
         info!(
-            function_count = self.units.len(),
+            function_count = self.objects.len(),
             object_bytes = objects.iter().map(Vec::len).sum::<usize>(),
             "codegen complete"
         );
@@ -288,7 +302,7 @@ impl ProgramImage {
 
 impl ProgramImagePlan {
     fn from_rooted_inputs(
-        units: &[CollectedCodegenUnit],
+        units: &[CollectedObjectProjection],
         exports: &[RootedExportThunk],
         options: &CompileOptions,
         export_thunk_objects: &[Vec<u8>],
@@ -299,7 +313,7 @@ impl ProgramImagePlan {
                 function: collected.function.clone(),
                 identity: stable_function_identity(&collected.function),
                 defined_symbol: collected.unit.defined_symbol.to_string(),
-                content_digest: unit_digest(&collected.unit),
+                content_digest: object_digest(&collected.object.bytes),
             })
             .collect::<Vec<_>>();
         plan_units.sort_by(|left, right| left.identity.cmp(&right.identity));
@@ -318,12 +332,17 @@ impl ProgramImagePlan {
                 .cmp(&right.exported_symbol)
                 .then_with(|| left.native_symbol.cmp(&right.native_symbol))
         });
-        Self::finish(plan_units, export_thunks, units, options)
+        Self::finish(
+            plan_units,
+            export_thunks,
+            units.iter().map(|unit| unit.unit.as_ref()),
+            options,
+        )
     }
 
     #[cfg(test)]
     fn from_inputs(
-        units: &[CollectedCodegenUnit],
+        units: &[CollectedObjectProjection],
         functions: &[FunctionWithCfg],
         export_symbols: &[String],
         options: &CompileOptions,
@@ -335,7 +354,7 @@ impl ProgramImagePlan {
                 function: collected.function.clone(),
                 identity: stable_function_identity(&collected.function),
                 defined_symbol: collected.unit.defined_symbol.to_string(),
-                content_digest: unit_digest(&collected.unit),
+                content_digest: object_digest(&collected.object.bytes),
             })
             .collect::<Vec<_>>();
         plan_units.sort_by(|left, right| left.identity.cmp(&right.identity));
@@ -367,13 +386,18 @@ impl ProgramImagePlan {
                 .then_with(|| left.native_symbol.cmp(&right.native_symbol))
         });
 
-        Self::finish(plan_units, export_thunks, units, options)
+        Self::finish(
+            plan_units,
+            export_thunks,
+            units.iter().map(|unit| unit.unit.as_ref()),
+            options,
+        )
     }
 
-    fn finish(
+    fn finish<'a>(
         plan_units: Vec<ProgramImageUnit>,
         export_thunks: Vec<ProgramImageExportThunk>,
-        units: &[CollectedCodegenUnit],
+        units: impl IntoIterator<Item = &'a crate::codegen_query::CodegenUnit>,
         options: &CompileOptions,
     ) -> MultiErrorResult<Self> {
         let entry_point = if options.target.is_macho() {
@@ -385,7 +409,7 @@ impl ProgramImagePlan {
         required_runtime_symbols.insert(entry_point.to_owned());
         required_runtime_symbols.insert(rue_runtime_abi::RUNTIME_ABI_VERSION_SYMBOL.to_owned());
         for unit in units {
-            for symbol in unit.unit.referenced_symbols.iter() {
+            for symbol in unit.referenced_symbols.iter() {
                 if rue_runtime_abi::classify_export(symbol).is_some() {
                     required_runtime_symbols.insert(symbol.to_string());
                 }
@@ -488,7 +512,7 @@ fn validate_program_image_inputs(
 }
 
 fn validate_rooted_program_image_inputs(
-    units: &[CollectedCodegenUnit],
+    units: &[CollectedObjectProjection],
     exports: &[RootedExportThunk],
 ) -> MultiErrorResult<()> {
     let mut units_by_identity = BTreeMap::new();
@@ -574,22 +598,8 @@ fn validate_program_image_plan(plan: &ProgramImagePlan) -> MultiErrorResult<()> 
     Ok(())
 }
 
-fn unit_digest(unit: &crate::codegen_query::CodegenUnit) -> ContentDigest {
-    let mut digest = StableDigest::new(b"rue.program-image.unit\0v1\0");
-    digest.bytes(unit.defined_symbol.as_bytes());
-    digest.usize(unit.referenced_symbols.len());
-    for symbol in unit.referenced_symbols.iter() {
-        digest.bytes(symbol.as_bytes());
-    }
-    digest.usize(unit.relocations.len());
-    for relocation in unit.relocations.iter() {
-        digest.relocation(relocation);
-    }
-    digest.usize(unit.sections.len());
-    for section in unit.sections.iter() {
-        digest.section(section);
-    }
-    digest.finish()
+fn object_digest(bytes: &[u8]) -> ContentDigest {
+    bytes_digest(b"rue.program-image.object\0v1\0", bytes)
 }
 
 fn bytes_digest(domain: &[u8], bytes: &[u8]) -> ContentDigest {
@@ -628,10 +638,6 @@ impl StableDigest {
         Self(digest)
     }
 
-    fn byte(&mut self, byte: u8) {
-        self.0.update([byte]);
-    }
-
     fn bytes(&mut self, bytes: &[u8]) {
         self.u64(bytes.len() as u64);
         self.0.update(bytes);
@@ -639,40 +645,6 @@ impl StableDigest {
 
     fn u64(&mut self, value: u64) {
         self.0.update(value.to_le_bytes());
-    }
-
-    fn usize(&mut self, value: usize) {
-        self.u64(value as u64);
-    }
-
-    fn relocation(&mut self, relocation: &NormalizedRelocation) {
-        self.u64(relocation.offset);
-        self.bytes(relocation.symbol.as_bytes());
-        self.byte(match relocation.kind {
-            rue_codegen::RelocationKind::X86Pc32 => 0,
-            rue_codegen::RelocationKind::X86Plt32 => 1,
-            rue_codegen::RelocationKind::Aarch64AdrpPage21 => 2,
-            rue_codegen::RelocationKind::Aarch64AddLo12 => 3,
-            rue_codegen::RelocationKind::Aarch64Call26 => 4,
-        });
-        self.u64(relocation.addend as u64);
-    }
-
-    fn section(&mut self, section: &CodegenSection) {
-        self.byte(match section.kind {
-            SectionKind::Text => 0,
-            SectionKind::Rodata => 1,
-            SectionKind::Data => 2,
-            SectionKind::Bss => 3,
-        });
-        self.bytes(&section.contents.bytes);
-        self.u64(u64::from(section.contents.alignment));
-        self.byte(u8::from(section.contents.executable));
-        self.byte(u8::from(section.contents.writable));
-        self.usize(section.atoms.len());
-        for atom in section.atoms.iter() {
-            self.bytes(atom);
-        }
     }
 
     fn finish(self) -> ContentDigest {
@@ -776,6 +748,25 @@ mod tests {
         assert_eq!(delta.added, vec![unit("added", 1)]);
         assert_eq!(delta.changed, vec![unit("changed", 2)]);
         assert_eq!(delta.removed, vec![unit("removed", 1)]);
+
+        let reordered = plan(vec![unit("changed", 2), unit("added", 1), unit("a", 1)]);
+        assert_eq!(
+            reordered.delta_from(&after).unwrap(),
+            ProgramImagePlanDelta::default(),
+            "input enumeration order is not a program-image change"
+        );
+    }
+
+    #[test]
+    fn delta_tracks_serialized_object_bytes_not_only_codegen_metadata() {
+        let mut before = unit("same", 1);
+        before.content_digest = object_digest(b"first object encoding");
+        let mut after = before.clone();
+        after.content_digest = object_digest(b"second object encoding");
+        let delta = plan(vec![after.clone()])
+            .delta_from(&plan(vec![before]))
+            .unwrap();
+        assert_eq!(delta.changed, vec![after]);
     }
 
     #[test]
@@ -1032,13 +1023,28 @@ mod tests {
     #[test]
     fn fresh_adapter_matches_the_prior_object_projection_on_every_target() {
         let source = "fn callee() -> i32 { 7 } fn main() -> i32 { callee() }";
+        let snapshot = crate::SourceSnapshot::single("main.rue", source).unwrap();
         for target in [
             Target::X86_64Linux,
             Target::Aarch64Linux,
             Target::Aarch64Macos,
         ] {
-            let (_, objects, _) = image_for(source, target, 1);
-            assert_eq!(objects, old_objects_for(source, target), "{target:?}");
+            let options = CompileOptions {
+                target,
+                ..CompileOptions::default()
+            };
+            let mut session = crate::CompilerSession::new();
+            crate::publish_test_snapshot(&mut session, &snapshot).unwrap();
+            let rooted = session
+                .rooted_codegen(&options, rue_codegen::BackendArtifactRequest::default())
+                .unwrap();
+            let image =
+                ProgramImage::from_rooted(rooted.objects, rooted.exports, &options).unwrap();
+            assert_eq!(
+                image.fresh_objects(&options).unwrap(),
+                old_objects_for(source, target),
+                "{target:?}"
+            );
         }
     }
 
@@ -1075,28 +1081,11 @@ mod tests {
 
         let mut fresh_session = crate::CompilerSession::new();
         crate::publish_test_snapshot(&mut fresh_session, &snapshot).unwrap();
-        let fresh_rir = fresh_session.canonical_rir().unwrap();
-        let fresh_semantic = fresh_session.canonical_semantic(&options).unwrap();
-        let exports = backend::collect_export_symbols(
-            fresh_rir.rir(),
-            fresh_rir.semantic_symbols().interner(),
-        );
-        let image = ProgramImage::new(
-            fresh_session
-                .codegen_units(
-                    &fresh_semantic,
-                    &options,
-                    rue_codegen::BackendArtifactRequest::default(),
-                )
-                .unwrap(),
-            fresh_semantic.functions(),
-            &options,
-            &exports,
-        )
-        .unwrap();
-        let fresh = image
-            .fresh_link(&options, fresh_semantic.warnings())
+        let rooted = fresh_session
+            .rooted_codegen(&options, rue_codegen::BackendArtifactRequest::default())
             .unwrap();
+        let image = ProgramImage::from_rooted(rooted.objects, rooted.exports, &options).unwrap();
+        let fresh = image.fresh_link(&options, &rooted.warnings).unwrap();
         assert_eq!(fresh.elf, old.elf);
         assert_eq!(fresh.warnings, old.warnings);
     }

--- a/crates/rue-compiler/src/queries.rs
+++ b/crates/rue-compiler/src/queries.rs
@@ -1167,7 +1167,7 @@ pub(crate) fn pre_link_object_bytes_with_session(
     let _span = info_span!("compile_pipeline_pre_link").entered();
     let rooted = session.rooted_codegen(options, rue_codegen::BackendArtifactRequest::default())?;
     let image = crate::program_image_plan::ProgramImage::from_rooted(
-        rooted.units,
+        rooted.objects,
         rooted.exports,
         options,
     )?;
@@ -1204,7 +1204,7 @@ pub(crate) fn compile_with_session(
     let rooted = session.rooted_codegen(options, rue_codegen::BackendArtifactRequest::default())?;
     let session_work = session.work().clone();
     let image = crate::program_image_plan::ProgramImage::from_rooted(
-        rooted.units,
+        rooted.objects,
         rooted.exports,
         options,
     )?;

--- a/crates/rue-compiler/src/revisioned_query_database.rs
+++ b/crates/rue-compiler/src/revisioned_query_database.rs
@@ -1113,6 +1113,30 @@ struct PublishedBodyReachabilityRoot {
     lease: Arc<rue_query::RetainedPinSet>,
 }
 
+fn backend_retention_fallbacks(
+    backend: &Arc<Mutex<PublishedBackendRoot>>,
+    body_closure: &Arc<Mutex<PublishedBodyClosureRoot>>,
+    body_reachability: &Arc<Mutex<PublishedBodyReachabilityRoot>>,
+) -> [Arc<rue_query::RetainedPinSet>; 3] {
+    [
+        backend
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .lease
+            .clone(),
+        body_closure
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .lease
+            .clone(),
+        body_reachability
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .lease
+            .clone(),
+    ]
+}
+
 /// One in-flight rooted backend collection. Merely collecting or pinning a
 /// terminal cannot alter the session's published root: only
 /// [`RevisionedQueryDatabase::publish_backend_root`] installs this candidate.
@@ -14581,8 +14605,15 @@ impl RevisionedQueryDatabase {
             )
             .expect("the OptimizedCfg family has one canonical name");
         let backend_root = Arc::new(Mutex::new(PublishedBackendRoot::default()));
+        // Backend terminals extend the already-published semantic/body graph.
+        // Keep those independent roots available as retention fallbacks while
+        // each backend batch promotes its exact transitive cone.
+        let body_closure_root = Arc::new(Mutex::new(PublishedBodyClosureRoot::default()));
+        let body_reachability_root = Arc::new(Mutex::new(PublishedBodyReachabilityRoot::default()));
         let optimized_cfgs_for_batch = optimized_cfgs.clone();
         let backend_root_for_optimized_cfg_batch = backend_root.clone();
+        let body_closure_root_for_optimized_cfg_batch = body_closure_root.clone();
+        let body_reachability_root_for_optimized_cfg_batch = body_reachability_root.clone();
         let optimized_cfg_batches = runtime
             .family_with_equality_and_evaluator(
                 "compiler.optimized-cfg-batch",
@@ -14596,12 +14627,12 @@ impl RevisionedQueryDatabase {
                             .all(|(left, right)| crate::cfg_query::cfg_value_equal(left, right))
                 },
                 move |context, _, key: &OptimizedCfgBatchKey| {
+                    let fallbacks = backend_retention_fallbacks(
+                        &backend_root_for_optimized_cfg_batch,
+                        &body_closure_root_for_optimized_cfg_batch,
+                        &body_reachability_root_for_optimized_cfg_batch,
+                    );
                     let _validated_registered = context.endorse_registered_validations();
-                    let fallback = backend_root_for_optimized_cfg_batch
-                        .lock()
-                        .unwrap_or_else(std::sync::PoisonError::into_inner)
-                        .lease
-                        .clone();
                     let _attempts = context.retain_nested_attempts_for(&["compiler.optimized-cfg"]);
                     let terminals = context.query_registered_batch(
                         &optimized_cfgs_for_batch,
@@ -14617,10 +14648,7 @@ impl RevisionedQueryDatabase {
                     };
                     let retained_children = Arc::new(
                         context
-                            .retain_observed_terminal_cones_from(
-                                &terminals,
-                                std::slice::from_ref(&fallback),
-                            )
+                            .retain_observed_terminal_cones_from(&terminals, &fallbacks)
                             .expect(
                                 "the registered optimized-CFG batch observes every selected child cone",
                             ),
@@ -14686,6 +14714,8 @@ impl RevisionedQueryDatabase {
             .expect("the CodegenUnit family has one canonical name");
         let codegen_units_for_batch = codegen_units.clone();
         let backend_root_for_codegen_batch = backend_root.clone();
+        let body_closure_root_for_codegen_batch = body_closure_root.clone();
+        let body_reachability_root_for_codegen_batch = body_reachability_root.clone();
         let codegen_unit_batches = runtime
             .family_with_equality_and_evaluator(
                 "compiler.codegen-unit-batch",
@@ -14701,12 +14731,12 @@ impl RevisionedQueryDatabase {
                             })
                 },
                 move |context, _, key: &CodegenUnitBatchKey| {
+                    let fallbacks = backend_retention_fallbacks(
+                        &backend_root_for_codegen_batch,
+                        &body_closure_root_for_codegen_batch,
+                        &body_reachability_root_for_codegen_batch,
+                    );
                     let _validated_registered = context.endorse_registered_validations();
-                    let fallback = backend_root_for_codegen_batch
-                        .lock()
-                        .unwrap_or_else(std::sync::PoisonError::into_inner)
-                        .lease
-                        .clone();
                     let _attempts = context.retain_nested_attempts_for(&["compiler.codegen-unit"]);
                     let terminals = context.query_registered_batch(
                         &codegen_units_for_batch,
@@ -14722,10 +14752,7 @@ impl RevisionedQueryDatabase {
                     };
                     let retained_children = Arc::new(
                         context
-                            .retain_observed_terminal_cones_from(
-                                &terminals,
-                                std::slice::from_ref(&fallback),
-                            )
+                            .retain_observed_terminal_cones_from(&terminals, &fallbacks)
                             .expect(
                                 "the registered CodegenUnit batch observes every selected child cone",
                             ),
@@ -14765,6 +14792,8 @@ impl RevisionedQueryDatabase {
             .expect("the ObjectProjection family has one canonical name");
         let object_projections_for_batch = object_projections.clone();
         let backend_root_for_object_projection_batch = backend_root.clone();
+        let body_closure_root_for_object_projection_batch = body_closure_root.clone();
+        let body_reachability_root_for_object_projection_batch = body_reachability_root.clone();
         let object_projection_batches = runtime
             .family_with_equality_and_evaluator(
                 "compiler.object-projection-batch",
@@ -14778,12 +14807,12 @@ impl RevisionedQueryDatabase {
                         )
                 },
                 move |context, _, key: &ObjectProjectionBatchKey| {
+                    let fallbacks = backend_retention_fallbacks(
+                        &backend_root_for_object_projection_batch,
+                        &body_closure_root_for_object_projection_batch,
+                        &body_reachability_root_for_object_projection_batch,
+                    );
                     let _validated_registered = context.endorse_registered_validations();
-                    let fallback = backend_root_for_object_projection_batch
-                        .lock()
-                        .unwrap_or_else(std::sync::PoisonError::into_inner)
-                        .lease
-                        .clone();
                     let _attempts =
                         context.retain_nested_attempts_for(&["compiler.object-projection"]);
                     let terminals = context.query_registered_batch(
@@ -14800,10 +14829,7 @@ impl RevisionedQueryDatabase {
                     };
                     let retained_children = Arc::new(
                         context
-                            .retain_observed_terminal_cones_from(
-                                &terminals,
-                                std::slice::from_ref(&fallback),
-                            )
+                            .retain_observed_terminal_cones_from(&terminals, &fallbacks)
                             .expect(
                                 "the registered ObjectProjection batch observes every selected child cone",
                             ),
@@ -14828,10 +14854,10 @@ impl RevisionedQueryDatabase {
             .expect("the ObjectProjectionBatch family has one canonical name");
         let provider_observation_meter = Arc::new(ProviderObservationCounters::default());
         let lookup_root_lease = Arc::new(Mutex::new(PublishedRootLookupLease::default()));
-        let body_closure_root = Arc::new(Mutex::new(PublishedBodyClosureRoot::default()));
-        let body_reachability_root = Arc::new(Mutex::new(PublishedBodyReachabilityRoot::default()));
         let object_projections_for_backend_publication = object_projections.clone();
         let backend_root_for_publication = backend_root.clone();
+        let body_closure_root_for_backend_publication = body_closure_root.clone();
+        let body_reachability_root_for_backend_publication = body_reachability_root.clone();
         let backend_root_publications = runtime
             .family_with_equality_and_evaluator(
                 "compiler.backend-root-publication",
@@ -14839,11 +14865,11 @@ impl RevisionedQueryDatabase {
                 |left: &bool, right: &bool| left == right,
                 move |context, _, key: &BackendRootPublicationKey| {
                     let _validated_registered = context.endorse_registered_validations();
-                    let fallback = backend_root_for_publication
-                        .lock()
-                        .unwrap_or_else(std::sync::PoisonError::into_inner)
-                        .lease
-                        .clone();
+                    let fallbacks = backend_retention_fallbacks(
+                        &backend_root_for_publication,
+                        &body_closure_root_for_backend_publication,
+                        &body_reachability_root_for_backend_publication,
+                    );
                     let terminals = context.query_registered_batch(
                         &object_projections_for_backend_publication,
                         key.objects.keys.iter().cloned(),
@@ -14860,10 +14886,7 @@ impl RevisionedQueryDatabase {
                             .with_terminal_kind(QueryTerminalKind::Failure));
                     }
                     let pending = context
-                        .retain_observed_terminal_cones_from(
-                            &terminals,
-                            std::slice::from_ref(&fallback),
-                        )
+                        .retain_observed_terminal_cones_from(&terminals, &fallbacks)
                         .expect(
                             "registered backend-root validation observes every final ObjectProjection dependency cone",
                         );

--- a/crates/rue-compiler/src/revisioned_query_database.rs
+++ b/crates/rue-compiler/src/revisioned_query_database.rs
@@ -14580,7 +14580,9 @@ impl RevisionedQueryDatabase {
                 },
             )
             .expect("the OptimizedCfg family has one canonical name");
+        let backend_root = Arc::new(Mutex::new(PublishedBackendRoot::default()));
         let optimized_cfgs_for_batch = optimized_cfgs.clone();
+        let backend_root_for_optimized_cfg_batch = backend_root.clone();
         let optimized_cfg_batches = runtime
             .family_with_equality_and_evaluator(
                 "compiler.optimized-cfg-batch",
@@ -14595,6 +14597,11 @@ impl RevisionedQueryDatabase {
                 },
                 move |context, _, key: &OptimizedCfgBatchKey| {
                     let _validated_registered = context.endorse_registered_validations();
+                    let fallback = backend_root_for_optimized_cfg_batch
+                        .lock()
+                        .unwrap_or_else(std::sync::PoisonError::into_inner)
+                        .lease
+                        .clone();
                     let _attempts = context.retain_nested_attempts_for(&["compiler.optimized-cfg"]);
                     let terminals = context.query_registered_batch(
                         &optimized_cfgs_for_batch,
@@ -14610,7 +14617,10 @@ impl RevisionedQueryDatabase {
                     };
                     let retained_children = Arc::new(
                         context
-                            .retain_observed_terminal_cones_from(&terminals, &[])
+                            .retain_observed_terminal_cones_from(
+                                &terminals,
+                                std::slice::from_ref(&fallback),
+                            )
                             .expect(
                                 "the registered optimized-CFG batch observes every selected child cone",
                             ),
@@ -14675,6 +14685,7 @@ impl RevisionedQueryDatabase {
             )
             .expect("the CodegenUnit family has one canonical name");
         let codegen_units_for_batch = codegen_units.clone();
+        let backend_root_for_codegen_batch = backend_root.clone();
         let codegen_unit_batches = runtime
             .family_with_equality_and_evaluator(
                 "compiler.codegen-unit-batch",
@@ -14691,6 +14702,11 @@ impl RevisionedQueryDatabase {
                 },
                 move |context, _, key: &CodegenUnitBatchKey| {
                     let _validated_registered = context.endorse_registered_validations();
+                    let fallback = backend_root_for_codegen_batch
+                        .lock()
+                        .unwrap_or_else(std::sync::PoisonError::into_inner)
+                        .lease
+                        .clone();
                     let _attempts = context.retain_nested_attempts_for(&["compiler.codegen-unit"]);
                     let terminals = context.query_registered_batch(
                         &codegen_units_for_batch,
@@ -14706,7 +14722,10 @@ impl RevisionedQueryDatabase {
                     };
                     let retained_children = Arc::new(
                         context
-                            .retain_observed_terminal_cones_from(&terminals, &[])
+                            .retain_observed_terminal_cones_from(
+                                &terminals,
+                                std::slice::from_ref(&fallback),
+                            )
                             .expect(
                                 "the registered CodegenUnit batch observes every selected child cone",
                             ),
@@ -14745,6 +14764,7 @@ impl RevisionedQueryDatabase {
             )
             .expect("the ObjectProjection family has one canonical name");
         let object_projections_for_batch = object_projections.clone();
+        let backend_root_for_object_projection_batch = backend_root.clone();
         let object_projection_batches = runtime
             .family_with_equality_and_evaluator(
                 "compiler.object-projection-batch",
@@ -14759,6 +14779,11 @@ impl RevisionedQueryDatabase {
                 },
                 move |context, _, key: &ObjectProjectionBatchKey| {
                     let _validated_registered = context.endorse_registered_validations();
+                    let fallback = backend_root_for_object_projection_batch
+                        .lock()
+                        .unwrap_or_else(std::sync::PoisonError::into_inner)
+                        .lease
+                        .clone();
                     let _attempts =
                         context.retain_nested_attempts_for(&["compiler.object-projection"]);
                     let terminals = context.query_registered_batch(
@@ -14775,7 +14800,10 @@ impl RevisionedQueryDatabase {
                     };
                     let retained_children = Arc::new(
                         context
-                            .retain_observed_terminal_cones_from(&terminals, &[])
+                            .retain_observed_terminal_cones_from(
+                                &terminals,
+                                std::slice::from_ref(&fallback),
+                            )
                             .expect(
                                 "the registered ObjectProjection batch observes every selected child cone",
                             ),
@@ -14802,7 +14830,6 @@ impl RevisionedQueryDatabase {
         let lookup_root_lease = Arc::new(Mutex::new(PublishedRootLookupLease::default()));
         let body_closure_root = Arc::new(Mutex::new(PublishedBodyClosureRoot::default()));
         let body_reachability_root = Arc::new(Mutex::new(PublishedBodyReachabilityRoot::default()));
-        let backend_root = Arc::new(Mutex::new(PublishedBackendRoot::default()));
         let object_projections_for_backend_publication = object_projections.clone();
         let backend_root_for_publication = backend_root.clone();
         let backend_root_publications = runtime

--- a/crates/rue-compiler/src/revisioned_query_database.rs
+++ b/crates/rue-compiler/src/revisioned_query_database.rs
@@ -404,6 +404,12 @@ pub(crate) struct RevisionedQueryDatabase {
         crate::codegen_query::CodegenUnitValue,
     >,
     codegen_unit_batches: QueryFamily<CodegenUnitBatchKey, CodegenUnitBatchOutput>,
+    #[allow(dead_code)] // The registered batch evaluator owns production reads.
+    object_projections: QueryFamily<
+        crate::object_query::ObjectProjectionQueryKey,
+        crate::object_query::ObjectProjectionValue,
+    >,
+    object_projection_batches: QueryFamily<ObjectProjectionBatchKey, ObjectProjectionBatchOutput>,
     backend_root_publications: QueryFamily<BackendRootPublicationKey, bool>,
     /// One-shot rendezvous inside the registered CodegenUnit evaluator. Unit
     /// tests use it to force an exact-key owner to remain live while a second
@@ -1119,6 +1125,7 @@ pub(crate) struct BackendRootCandidate {
     cfg_keys: HashSet<crate::cfg_query::CfgQueryKey>,
     optimized_cfg_terminals: usize,
     codegen_unit_terminals: usize,
+    object_projection_terminals: usize,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -1182,9 +1189,39 @@ impl RetainedCharge for CodegenUnitBatchOutput {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub(crate) struct ObjectProjectionBatchKey {
+    pub(crate) keys: Arc<[crate::object_query::ObjectProjectionQueryKey]>,
+}
+
+impl QueryKey for ObjectProjectionBatchKey {
+    fn stable_identity(&self) -> String {
+        let mut identity = format!("object-projection-batch;units={}", self.keys.len());
+        for key in self.keys.iter() {
+            identity.push('\u{1e}');
+            identity.push_str(&key.stable_identity());
+        }
+        identity
+    }
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct ObjectProjectionBatchOutput {
+    pub(crate) values: Arc<[crate::object_query::ObjectProjectionValue]>,
+    /// Exact object children and their CodegenUnit dependency cones are pinned
+    /// from evaluation through backend-root publication.
+    _retained_children: Arc<rue_query::RetainedPinSet>,
+}
+
+impl RetainedCharge for ObjectProjectionBatchOutput {
+    fn retained_charge(&self) -> u64 {
+        self.values.retained_charge()
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 struct BackendRootPublicationKey {
     epoch: u64,
-    codegen_units: CodegenUnitBatchKey,
+    objects: ObjectProjectionBatchKey,
     functions: Arc<[crate::FunctionInstanceKey]>,
     cfg_terminals: usize,
 }
@@ -1205,7 +1242,7 @@ impl QueryKey for BackendRootPublicationKey {
         format!(
             "backend-root;epoch={};units={}",
             self.epoch,
-            self.codegen_units.keys.len()
+            self.objects.keys.len()
         )
     }
 }
@@ -1221,6 +1258,8 @@ struct PublishedBackendRoot {
     optimized_cfg_terminals: usize,
     #[allow(dead_code)]
     codegen_unit_terminals: usize,
+    #[allow(dead_code)]
+    object_projection_terminals: usize,
     publications: u64,
     additions: u64,
     deletions: u64,
@@ -1234,6 +1273,7 @@ struct PublishedBackendRootHandoff {
     cfg_terminals: usize,
     optimized_cfg_terminals: usize,
     codegen_unit_terminals: usize,
+    object_projection_terminals: usize,
     previous: Option<PublishedBackendRoot>,
     installed: bool,
 }
@@ -1260,6 +1300,7 @@ impl rue_query::QueryAttemptHandoff for PublishedBackendRootHandoff {
             cfg_terminals: self.cfg_terminals,
             optimized_cfg_terminals: self.optimized_cfg_terminals,
             codegen_unit_terminals: self.codegen_unit_terminals,
+            object_projection_terminals: self.object_projection_terminals,
             publications: root.publications.saturating_add(1),
             additions: root.additions.saturating_add(additions),
             deletions: root.deletions.saturating_add(deletions),
@@ -1296,6 +1337,7 @@ pub(crate) struct PublishedBackendRootMetrics {
     pub(crate) cfg_terminals: usize,
     pub(crate) optimized_cfg_terminals: usize,
     pub(crate) codegen_unit_terminals: usize,
+    pub(crate) object_projection_terminals: usize,
     pub(crate) publications: u64,
     pub(crate) additions: u64,
     pub(crate) deletions: u64,
@@ -14687,12 +14729,81 @@ impl RevisionedQueryDatabase {
                 },
             )
             .expect("the CodegenUnitBatch family has one canonical name");
+        let codegen_units_for_object_projection = codegen_units.clone();
+        let object_projections = runtime
+            .family_with_equality_and_evaluator(
+                "compiler.object-projection",
+                BODY_QUERY_MEMO_RETENTION,
+                crate::object_query::object_projection_value_equal,
+                move |context, _, key: &crate::object_query::ObjectProjectionQueryKey| {
+                    crate::object_query::evaluate_object_projection(
+                        context,
+                        &codegen_units_for_object_projection,
+                        key,
+                    )
+                },
+            )
+            .expect("the ObjectProjection family has one canonical name");
+        let object_projections_for_batch = object_projections.clone();
+        let object_projection_batches = runtime
+            .family_with_equality_and_evaluator(
+                "compiler.object-projection-batch",
+                0,
+                |left: &ObjectProjectionBatchOutput, right: &ObjectProjectionBatchOutput| {
+                    left.values.len() == right.values.len()
+                        && left.values.iter().zip(right.values.iter()).all(
+                            |(left, right)| {
+                                crate::object_query::object_projection_value_equal(left, right)
+                            },
+                        )
+                },
+                move |context, _, key: &ObjectProjectionBatchKey| {
+                    let _validated_registered = context.endorse_registered_validations();
+                    let _attempts =
+                        context.retain_nested_attempts_for(&["compiler.object-projection"]);
+                    let terminals = context.query_registered_batch(
+                        &object_projections_for_batch,
+                        key.keys.iter().cloned(),
+                    )?;
+                    let kind = if terminals
+                        .iter()
+                        .all(|terminal| terminal.kind() == QueryTerminalKind::Success)
+                    {
+                        QueryTerminalKind::Success
+                    } else {
+                        QueryTerminalKind::Failure
+                    };
+                    let retained_children = Arc::new(
+                        context
+                            .retain_observed_terminal_cones_from(&terminals, &[])
+                            .expect(
+                                "the registered ObjectProjection batch observes every selected child cone",
+                            ),
+                    );
+                    let values = terminals
+                        .iter()
+                        .map(|terminal| {
+                            let rue_query::QueryOutcome::Success(value) = terminal.outcome() else {
+                                unreachable!("ObjectProjection publishes typed values")
+                            };
+                            value.clone()
+                        })
+                        .collect::<Vec<_>>()
+                        .into();
+                    Ok(QueryOutput::success(ObjectProjectionBatchOutput {
+                        values,
+                        _retained_children: retained_children,
+                    })
+                    .with_terminal_kind(kind))
+                },
+            )
+            .expect("the ObjectProjectionBatch family has one canonical name");
         let provider_observation_meter = Arc::new(ProviderObservationCounters::default());
         let lookup_root_lease = Arc::new(Mutex::new(PublishedRootLookupLease::default()));
         let body_closure_root = Arc::new(Mutex::new(PublishedBodyClosureRoot::default()));
         let body_reachability_root = Arc::new(Mutex::new(PublishedBodyReachabilityRoot::default()));
         let backend_root = Arc::new(Mutex::new(PublishedBackendRoot::default()));
-        let codegen_units_for_backend_publication = codegen_units.clone();
+        let object_projections_for_backend_publication = object_projections.clone();
         let backend_root_for_publication = backend_root.clone();
         let backend_root_publications = runtime
             .family_with_equality_and_evaluator(
@@ -14707,14 +14818,14 @@ impl RevisionedQueryDatabase {
                         .lease
                         .clone();
                     let terminals = context.query_registered_batch(
-                        &codegen_units_for_backend_publication,
-                        key.codegen_units.keys.iter().cloned(),
+                        &object_projections_for_backend_publication,
+                        key.objects.keys.iter().cloned(),
                     )?;
                     if terminals.iter().any(|terminal| {
                         matches!(
                             terminal.outcome(),
                             rue_query::QueryOutcome::Success(
-                                crate::codegen_query::CodegenUnitValue::Failure(_)
+                                crate::object_query::ObjectProjectionValue::Failure(_)
                             )
                         )
                     }) {
@@ -14727,15 +14838,16 @@ impl RevisionedQueryDatabase {
                             std::slice::from_ref(&fallback),
                         )
                         .expect(
-                            "registered backend-root validation observes every final CodegenUnit dependency cone",
+                            "registered backend-root validation observes every final ObjectProjection dependency cone",
                         );
                     context.register_attempt_handoff(PublishedBackendRootHandoff {
                         root: backend_root_for_publication.clone(),
                         pending: Some(Arc::new(pending)),
                         functions: Some(key.functions.iter().cloned().collect()),
                         cfg_terminals: key.cfg_terminals,
-                        optimized_cfg_terminals: key.codegen_units.keys.len(),
-                        codegen_unit_terminals: key.codegen_units.keys.len(),
+                        optimized_cfg_terminals: key.objects.keys.len(),
+                        codegen_unit_terminals: key.objects.keys.len(),
+                        object_projection_terminals: key.objects.keys.len(),
                         previous: None,
                         installed: false,
                     });
@@ -15919,6 +16031,8 @@ impl RevisionedQueryDatabase {
             optimized_cfg_batches,
             codegen_units,
             codegen_unit_batches,
+            object_projections,
+            object_projection_batches,
             backend_root_publications,
             #[cfg(test)]
             codegen_evaluator_gate,
@@ -16402,6 +16516,27 @@ impl RevisionedQueryDatabase {
         (key, attempt)
     }
 
+    /// Request one stable-ordered production root of retained per-unit object
+    /// projections through the runtime's registered structured scheduler.
+    pub(crate) fn object_projection_batch(
+        &self,
+        revision: Revision,
+        keys: Arc<[crate::object_query::ObjectProjectionQueryKey]>,
+        cancellation: CancellationToken,
+    ) -> (
+        ObjectProjectionBatchKey,
+        QueryRequestAttempt<ObjectProjectionBatchOutput>,
+    ) {
+        let key = ObjectProjectionBatchKey { keys };
+        let attempt = self.runtime.request_registered(
+            &self.object_projection_batches,
+            revision,
+            key.clone(),
+            cancellation,
+        );
+        (key, attempt)
+    }
+
     /// Start an unpublished backend-root handoff. Every terminal retained into
     /// this candidate is acquired while its request attempt still owns the
     /// result lease, closing the birth-to-publication eviction window.
@@ -16453,6 +16588,22 @@ impl RevisionedQueryDatabase {
         candidate.codegen_unit_terminals = key.keys.len();
     }
 
+    /// Retain the registered object batch from result birth until publication
+    /// installs the exact object-to-codegen dependency cones.
+    pub(crate) fn retain_backend_object_projection_batch(
+        &self,
+        candidate: &mut BackendRootCandidate,
+        key: &ObjectProjectionBatchKey,
+        terminal: &Arc<rue_query::QueryTerminal<ObjectProjectionBatchOutput>>,
+    ) {
+        let pin = self
+            .object_projection_batches
+            .pin_terminal(terminal)
+            .expect("object projection batch result belongs to the registered family");
+        candidate.lease.lease(pin);
+        candidate.object_projection_terminals = key.keys.len();
+    }
+
     /// Publish the full transitive query cone behind a successful backend
     /// collection. Direct candidate pins bridge the host collection into this
     /// registered request; its query context then observes and atomically hands
@@ -16462,7 +16613,7 @@ impl RevisionedQueryDatabase {
         &self,
         revision: Revision,
         candidate: BackendRootCandidate,
-        codegen_units: CodegenUnitBatchKey,
+        objects: ObjectProjectionBatchKey,
     ) -> Result<(), QueryAbort> {
         // A root-publication request is transactional through its handoff
         // callbacks. Serialize only these short, whole-program swaps so a
@@ -16474,7 +16625,7 @@ impl RevisionedQueryDatabase {
             .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
         let key = BackendRootPublicationKey {
             epoch,
-            codegen_units,
+            objects,
             functions: candidate.functions.iter().cloned().collect(),
             cfg_terminals: candidate.cfg_keys.len(),
         };
@@ -16508,6 +16659,7 @@ impl RevisionedQueryDatabase {
             cfg_terminals: root.cfg_terminals,
             optimized_cfg_terminals: root.optimized_cfg_terminals,
             codegen_unit_terminals: root.codegen_unit_terminals,
+            object_projection_terminals: root.object_projection_terminals,
             publications: root.publications,
             additions: root.additions,
             deletions: root.deletions,
@@ -16520,6 +16672,14 @@ impl RevisionedQueryDatabase {
         key: &crate::cfg_query::CfgQueryKey,
     ) -> bool {
         self.cfgs.contains_retained_key(key)
+    }
+
+    #[cfg(test)]
+    pub(crate) fn object_projection_key_is_retained_for_test(
+        &self,
+        key: &crate::object_query::ObjectProjectionQueryKey,
+    ) -> bool {
+        self.object_projections.contains_retained_key(key)
     }
 
     #[cfg(test)]
@@ -24268,6 +24428,7 @@ mod tests {
             cfg_terminals: 2,
             optimized_cfg_terminals: 1,
             codegen_unit_terminals: 1,
+            object_projection_terminals: 1,
             previous: None,
             installed: false,
         };

--- a/crates/rue-compiler/src/session.rs
+++ b/crates/rue-compiler/src/session.rs
@@ -766,6 +766,10 @@ pub struct CompilerSession {
     codegen_attempt_work: Vec<(crate::FunctionInstanceKey, Vec<(std::sync::Arc<str>, u64)>)>,
     #[cfg(test)]
     codegen_collections: usize,
+    #[cfg(test)]
+    object_projection_executions: Vec<(crate::FunctionInstanceKey, rue_query::RequestExecution)>,
+    #[cfg(test)]
+    object_projection_collections: usize,
     /// One-shot cancellation injections, each consumed with `mem::take` at a
     /// fixed point inside an attempt.
     ///
@@ -881,6 +885,7 @@ pub(crate) struct RootedCfgOutput {
 
 pub(crate) struct RootedCodegenOutput {
     pub(crate) units: Vec<crate::codegen_query::CollectedCodegenUnit>,
+    pub(crate) objects: Vec<crate::object_query::CollectedObjectProjection>,
     #[allow(dead_code)]
     pub(crate) cfgs: Vec<RootedCfgUnit>,
     pub(crate) exports: Vec<crate::program_image_plan::RootedExportThunk>,
@@ -5139,6 +5144,8 @@ impl CompilerSession {
             self.codegen_executions.clear();
             self.codegen_attempt_work.clear();
             self.codegen_collections = 0;
+            self.object_projection_executions.clear();
+            self.object_projection_collections = 0;
         }
         let _codegen_collection_span =
             tracing::info_span!("codegen_collection", phase = "backend").entered();
@@ -5217,6 +5224,85 @@ impl CompilerSession {
             }
         }
         drop(_codegen_collection_span);
+        let object_keys = codegen_batch_key
+            .keys
+            .iter()
+            .cloned()
+            .map(crate::object_query::ObjectProjectionQueryKey::new)
+            .collect::<Vec<_>>()
+            .into();
+        let (object_batch_key, object_attempt) = self.queries.revisioned.object_projection_batch(
+            graph.revision,
+            object_keys,
+            rue_query::CancellationToken::new(),
+        );
+        #[cfg(test)]
+        let object_batch_execution = object_attempt.execution();
+        #[cfg(test)]
+        let object_child_attempts =
+            if object_batch_execution == rue_query::RequestExecution::Computed {
+                let attempts = object_attempt
+                    .nested_attempts()
+                    .iter()
+                    .filter(|attempt| attempt.node().family() == "compiler.object-projection")
+                    .map(|attempt| attempt.execution())
+                    .collect::<Vec<_>>();
+                assert_eq!(
+                    attempts.len(),
+                    cfgs.len(),
+                    "an evaluated ObjectProjection batch records one direct child per key"
+                );
+                Some(attempts)
+            } else {
+                None
+            };
+        if let Some(terminal) = object_attempt.terminal() {
+            self.queries
+                .revisioned
+                .retain_backend_object_projection_batch(
+                    &mut backend_root,
+                    &object_batch_key,
+                    terminal,
+                );
+        }
+        let object_batch = object_attempt.into_result().map_err(|abort| {
+            CompileError::without_span(ErrorKind::InternalError(format!(
+                "object projection batch query aborted: {abort:?}"
+            )))
+        })?;
+        let rue_query::QueryOutcome::Success(object_batch) = object_batch.outcome() else {
+            unreachable!("ObjectProjectionBatch publishes typed terminals")
+        };
+        assert_eq!(object_batch.values.len(), units.len());
+        let mut objects = Vec::with_capacity(units.len());
+        for (index, (collected, value)) in units.iter().zip(object_batch.values.iter()).enumerate()
+        {
+            #[cfg(not(test))]
+            let _ = index;
+            #[cfg(test)]
+            self.object_projection_executions.push((
+                collected.function.clone(),
+                object_child_attempts
+                    .as_ref()
+                    .map_or(object_batch_execution, |attempts| attempts[index]),
+            ));
+            match value {
+                crate::object_query::ObjectProjectionValue::Available(object) => {
+                    objects.push(crate::object_query::CollectedObjectProjection {
+                        function: collected.function.clone(),
+                        unit: collected.unit.clone(),
+                        object: object.clone(),
+                    });
+                    #[cfg(test)]
+                    {
+                        self.object_projection_collections += 1;
+                    }
+                }
+                crate::object_query::ObjectProjectionValue::Failure(errors) => {
+                    return Err(errors.clone());
+                }
+            }
+        }
         let export_roots = graph
             .c_export_roots
             .iter()
@@ -5252,7 +5338,7 @@ impl CompilerSession {
             .collect();
         self.queries
             .revisioned
-            .publish_backend_root(graph.revision, backend_root, codegen_batch_key)
+            .publish_backend_root(graph.revision, backend_root, object_batch_key)
             .map_err(|abort| {
                 CompileError::without_span(ErrorKind::InternalError(format!(
                     "backend root publication aborted: {abort:?}"
@@ -5260,6 +5346,7 @@ impl CompilerSession {
             })?;
         Ok(RootedCodegenOutput {
             units,
+            objects,
             cfgs,
             exports,
             warnings,
@@ -5403,6 +5490,18 @@ impl CompilerSession {
     }
 
     #[cfg(test)]
+    pub(crate) fn object_projection_executions(
+        &self,
+    ) -> &[(crate::FunctionInstanceKey, rue_query::RequestExecution)] {
+        &self.object_projection_executions
+    }
+
+    #[cfg(test)]
+    pub(crate) fn object_projection_collections(&self) -> usize {
+        self.object_projection_collections
+    }
+
+    #[cfg(test)]
     pub(crate) fn backend_root_metrics(
         &self,
     ) -> crate::revisioned_query_database::PublishedBackendRootMetrics {
@@ -5414,6 +5513,16 @@ impl CompilerSession {
         self.queries
             .revisioned
             .backend_cfg_key_is_retained_for_test(key)
+    }
+
+    #[cfg(test)]
+    pub(crate) fn object_projection_key_is_retained(
+        &self,
+        key: &crate::object_query::ObjectProjectionQueryKey,
+    ) -> bool {
+        self.queries
+            .revisioned
+            .object_projection_key_is_retained_for_test(key)
     }
 
     #[cfg(test)]


### PR DESCRIPTION
Fixes RUE-1231.

## Summary
- model target-aware per-CodegenUnit object serialization as a retained typed query artifact
- feed ProgramImage and the unchanged fresh-link paths from retained object bytes
- retain and meter the exact object-to-codegen-to-CFG dependency cones under the existing runtime budget and published backend root
- derive plan digests and deltas from exact serialized object bytes

## Validation
- 33-unit cold, no-edit, one-edit, removal, retention-pressure, eviction, and recomputation tests
- exact object-byte parity for x86-64 Linux, AArch64 Linux, and AArch64 macOS
- host executable byte-for-byte parity with the prior fresh projection path
- scripts/rue quick
- scripts/rue premerge
- scripts/rue fmt