### PR TITLE
RUE-1038: track maintained-program compiler scaling

### DIFF
--- a/.github/workflows/performance-scaling.yml
+++ b/.github/workflows/performance-scaling.yml
@@ -1,0 +1,56 @@
+# Lower-frequency maintained-program scale curve (RUE-1038).
+#
+# Unlike the fast ADR-0067 collection workflow, this does not run on every
+# trunk push and does not publish into the startup headline. Three independent
+# fresh compiler processes per workload provide a median and MAD without
+# inheriting startup's platform-specific high sample counts.
+name: Compiler scaling
+
+on:
+  schedule:
+    - cron: "17 8 * * 1"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+# Two scale runs on one hosted machine would measure contention, not Rue.
+concurrency:
+  group: compiler-scaling
+  cancel-in-progress: false
+
+jobs:
+  measure:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install dotslash
+        uses: facebook/install-dotslash@v2
+
+      - name: Build the compiler and measurement runner
+        run: ./buck2 build //crates/rue:rue //crates/rue-bench:rue-bench
+
+      - name: Measure maintained programs
+        env:
+          RUE_BENCH_RUNNER_LABEL: github-hosted
+          RUE_BENCH_RUNNER_IMAGE: ubuntu-24.04
+        run: |
+          set -euo pipefail
+          mkdir -p scaling-report
+          RUE="$(scripts/rue-bin)"
+          BENCH="$(./buck2 build //crates/rue-bench:rue-bench --show-simple-output 2>/dev/null | tail -1)"
+          "$BENCH" scaling \
+            --manifest performance/scaling.toml \
+            --compiler "$RUE" \
+            --commit "${{ github.sha }}" \
+            --repo-root . \
+            --out scaling-report/report.json
+
+      - name: Publish report artifact
+        uses: actions/upload-artifact@v6
+        with:
+          name: compiler-scaling-${{ github.sha }}
+          path: scaling-report/
+          retention-days: 90

--- a/crates/rue-bench/src/main.rs
+++ b/crates/rue-bench/src/main.rs
@@ -17,6 +17,7 @@ mod derive;
 mod environment;
 mod measure;
 mod pins;
+mod scaling;
 
 use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
@@ -77,6 +78,10 @@ Subcommands:
                        batching factors, and the flagging rule. Produces
                        artifacts only; nothing here enters a series.
 
+  scaling --manifest <path> --compiler <path> --commit <sha> --out <path>
+                       measure maintained programs with independent fresh
+                       compiler processes; also writes a Markdown report.
+
 Optional:
   --repo-root <path>   root for resolving workload sources (default: .)
   --std-root <path>    standard-library root (default: <repo-root>/std)
@@ -98,6 +103,15 @@ fn main() -> ExitCode {
     }
     if std::env::args().nth(1).as_deref() == Some("calibrate") {
         return match run_calibration() {
+            Ok(()) => ExitCode::from(exit::OK),
+            Err(message) => {
+                eprintln!("rue-bench: {message}");
+                ExitCode::from(exit::USAGE)
+            }
+        };
+    }
+    if std::env::args().nth(1).as_deref() == Some("scaling") {
+        return match scaling::run() {
             Ok(()) => ExitCode::from(exit::OK),
             Err(message) => {
                 eprintln!("rue-bench: {message}");
@@ -485,7 +499,7 @@ fn report(run: &RunObject, outcome: &ValidationOutcome, output: &Path) {
 /// One spelling, because two identical measurements formatting the same instant
 /// differently would produce two content addresses. Computed from the Unix
 /// epoch rather than pulling in a date library for two fields.
-fn utc_timestamp() -> String {
+pub(crate) fn utc_timestamp() -> String {
     let seconds = SystemTime::now()
         .duration_since(UNIX_EPOCH)
         .map(|elapsed| elapsed.as_secs())

--- a/crates/rue-bench/src/measure.rs
+++ b/crates/rue-bench/src/measure.rs
@@ -16,7 +16,7 @@ use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
 use std::time::Instant;
 
-use rue_perf_schema::{FailureRecord, PhaseAccounting, Sample};
+use rue_perf_schema::{FailureRecord, PhaseAccounting, Sample, WorkloadShape};
 
 /// Everything needed to measure one sample.
 pub struct SampleRequest<'a> {
@@ -52,11 +52,48 @@ pub enum SampleOutcome {
     Failed(Box<FailureRecord>),
 }
 
-/// The compiler's `--benchmark-json` output, of which only the additive
-/// partition matters here.
+/// The compiler's `--benchmark-json` output.
 #[derive(serde::Deserialize)]
 struct BenchmarkJson {
     phase_accounting: PhaseAccounting,
+    metadata: BenchmarkMetadata,
+    source_metrics: SourceMetrics,
+    emitted_output: EmittedOutput,
+}
+
+#[derive(serde::Deserialize)]
+struct BenchmarkMetadata {
+    target: String,
+}
+
+#[derive(serde::Deserialize)]
+struct SourceMetrics {
+    files: u64,
+    modules: u64,
+    bytes: u64,
+    lines: u64,
+    tokens: u64,
+    functions: u64,
+}
+
+#[derive(serde::Deserialize)]
+struct EmittedOutput {
+    size_bytes: u64,
+}
+
+struct CompletedCompile {
+    accounting: PhaseAccounting,
+    peak_memory_bytes: u64,
+    output_binary_bytes: u64,
+    shape: WorkloadShape,
+    target: String,
+}
+
+/// The raw result of one fresh compiler process for the scaling report.
+pub struct FreshCompile {
+    pub sample: Sample,
+    pub shape: WorkloadShape,
+    pub target: String,
 }
 
 /// Measure one sample.
@@ -71,11 +108,11 @@ pub fn measure_sample(request: &SampleRequest<'_>) -> SampleOutcome {
     let started = Instant::now();
     for _ in 0..request.batch_size {
         match run_once(request) {
-            Ok((accounting, peak)) => {
-                peak_memory_bytes = peak_memory_bytes.max(peak);
+            Ok(completed) => {
+                peak_memory_bytes = peak_memory_bytes.max(completed.peak_memory_bytes);
                 total = Some(match total {
-                    None => accounting,
-                    Some(running) => add_accounting(running, &accounting),
+                    None => completed.accounting,
+                    Some(running) => add_accounting(running, &completed.accounting),
                 });
             }
             Err(detail) => {
@@ -111,6 +148,31 @@ pub fn measure_sample(request: &SampleRequest<'_>) -> SampleOutcome {
     }))
 }
 
+/// Measure exactly one fresh compiler process and retain its fixture shape.
+///
+/// Unlike [`measure_sample`], this has no batching path: heavyweight programs
+/// need independent samples and uncertainty, not the startup probe's timer
+/// amplification policy.
+pub fn measure_fresh_compile(request: &SampleRequest<'_>) -> Result<FreshCompile, String> {
+    if request.batch_size != 1 {
+        return Err("a scaling sample must launch exactly one compiler process".to_string());
+    }
+    let started = Instant::now();
+    let completed = run_once(request)?;
+    let process_elapsed_ns = u64::try_from(started.elapsed().as_nanos()).unwrap_or(u64::MAX);
+    Ok(FreshCompile {
+        sample: Sample {
+            batch_size: 1,
+            process_elapsed_ns,
+            peak_memory_bytes: completed.peak_memory_bytes,
+            output_binary_bytes: completed.output_binary_bytes,
+            phases: completed.accounting,
+        },
+        shape: completed.shape,
+        target: completed.target,
+    })
+}
+
 /// Add two phase partitions band by band.
 ///
 /// Saturating throughout: a corrupt addend must not panic the runner. Any
@@ -133,7 +195,7 @@ fn add_accounting(mut running: PhaseAccounting, next: &PhaseAccounting) -> Phase
 
 /// Run the compiler once, returning its partition and externally measured peak
 /// resident memory.
-fn run_once(request: &SampleRequest<'_>) -> Result<(PhaseAccounting, u64), String> {
+fn run_once(request: &SampleRequest<'_>) -> Result<CompletedCompile, String> {
     let mut command = Command::new(request.compiler);
     command
         .arg(request.source)
@@ -180,7 +242,20 @@ fn run_once(request: &SampleRequest<'_>) -> Result<(PhaseAccounting, u64), Strin
         format!("no benchmark JSON on stdout ({error}); stderr tail:\n{tail}")
     })?;
 
-    Ok((parsed.phase_accounting, peak))
+    Ok(CompletedCompile {
+        accounting: parsed.phase_accounting,
+        peak_memory_bytes: peak,
+        output_binary_bytes: parsed.emitted_output.size_bytes,
+        shape: WorkloadShape {
+            files: parsed.source_metrics.files,
+            modules: parsed.source_metrics.modules,
+            bytes: parsed.source_metrics.bytes,
+            lines: parsed.source_metrics.lines,
+            tokens: parsed.source_metrics.tokens,
+            functions: parsed.source_metrics.functions,
+        },
+        target: parsed.metadata.target,
+    })
 }
 
 /// Reap one child and report *its* peak resident memory, in bytes.

--- a/crates/rue-bench/src/scaling.rs
+++ b/crates/rue-bench/src/scaling.rs
@@ -1,0 +1,404 @@
+//! Lower-frequency scale-curve collection for maintained Rue programs.
+//!
+//! This is intentionally a peer *reporting mode* of the ADR-0067 runner, not a
+//! second compilation path. It launches the same compiler binary, consumes the
+//! same `--benchmark-json` phase partition, and uses the same raw sample type.
+
+use std::path::{Path, PathBuf};
+
+use rue_perf_schema::{
+    Band, SCALING_REPORT_SCHEMA_VERSION, ScalingIdentity, ScalingManifest, ScalingObservation,
+    ScalingRegime, ScalingReport, Summary, WorkloadShape, canonical_json, content_address,
+};
+
+use crate::measure::{SampleRequest, measure_fresh_compile};
+
+struct Options {
+    manifest: PathBuf,
+    compiler: PathBuf,
+    commit: String,
+    repo_root: PathBuf,
+    std_root: Option<PathBuf>,
+    output: PathBuf,
+    workdir: Option<PathBuf>,
+}
+
+pub fn run() -> Result<(), String> {
+    let options = parse_args()?;
+    let text = std::fs::read_to_string(&options.manifest)
+        .map_err(|error| format!("could not read {}: {error}", options.manifest.display()))?;
+    let manifest = ScalingManifest::parse(&text)?;
+
+    let holder;
+    let workdir = match &options.workdir {
+        Some(directory) => {
+            std::fs::create_dir_all(directory)
+                .map_err(|error| format!("could not create {}: {error}", directory.display()))?;
+            directory.as_path()
+        }
+        None => {
+            holder = tempfile::tempdir()
+                .map_err(|error| format!("could not create a work directory: {error}"))?;
+            holder.path()
+        }
+    };
+
+    let started_at = crate::utc_timestamp();
+    let mut target: Option<String> = None;
+    let mut observations = Vec::with_capacity(manifest.workloads.len());
+    for workload in &manifest.workloads {
+        let source = options.repo_root.join(&workload.source);
+        if !source.is_file() {
+            return Err(format!(
+                "scaling workload {:?} does not exist at {}",
+                workload.id,
+                source.display()
+            ));
+        }
+        let output = workdir.join(format!("{}-out", workload.id));
+        let mut shape: Option<WorkloadShape> = None;
+        let mut samples = Vec::with_capacity(manifest.samples as usize);
+        for sample_index in 0..manifest.samples {
+            eprintln!(
+                "rue-bench: scaling {} sample {}/{}",
+                workload.id,
+                sample_index + 1,
+                manifest.samples
+            );
+            let request = SampleRequest {
+                compiler: &options.compiler,
+                source: &source,
+                args: &manifest.args,
+                output: output.clone(),
+                std_root: options.std_root.as_deref(),
+                batch_size: 1,
+                workload: &workload.id,
+                sample_index,
+            };
+            let measured = measure_fresh_compile(&request).map_err(|detail| {
+                format!(
+                    "scaling workload {:?} sample {} failed: {detail}",
+                    workload.id, sample_index
+                )
+            })?;
+            if !measured.sample.phases.holds() {
+                return Err(format!(
+                    "scaling workload {:?} sample {} violated phase accounting: root={} attributed={}",
+                    workload.id,
+                    sample_index,
+                    measured.sample.phases.compiler_root_ns,
+                    measured.sample.phases.attributed_ns()
+                ));
+            }
+            match &shape {
+                None => shape = Some(measured.shape.clone()),
+                Some(expected) if expected != &measured.shape => {
+                    return Err(format!(
+                        "scaling workload {:?} changed shape between samples: {expected:?} then {:?}",
+                        workload.id, measured.shape
+                    ));
+                }
+                Some(_) => {}
+            }
+            match &target {
+                None => target = Some(measured.target.clone()),
+                Some(expected) if expected != &measured.target => {
+                    return Err(format!(
+                        "compiler target changed between samples: {expected:?} then {:?}",
+                        measured.target
+                    ));
+                }
+                Some(_) => {}
+            }
+            samples.push(measured.sample);
+        }
+        observations.push(ScalingObservation {
+            workload: workload.id.clone(),
+            source: workload.source.clone(),
+            question: workload.question.clone(),
+            shape: shape.expect("the manifest requires at least two samples"),
+            samples,
+        });
+    }
+
+    let report = ScalingReport {
+        schema_version: SCALING_REPORT_SCHEMA_VERSION,
+        identity: ScalingIdentity {
+            manifest_revision: manifest.revision,
+            commit: options.commit,
+            started_at,
+            finished_at: crate::utc_timestamp(),
+            target: target.unwrap_or_else(|| "unknown".to_string()),
+            environment: crate::environment::fingerprint(),
+        },
+        regime: ScalingRegime {
+            compiler_state: "fresh_process_compile".to_string(),
+            os_page_cache: "uncontrolled".to_string(),
+            program_runtime_executed: false,
+            samples_per_workload: manifest.samples,
+            compiler_args: manifest.args,
+        },
+        workloads: observations,
+    };
+    write_report(&options.output, &report)?;
+    Ok(())
+}
+
+fn parse_args() -> Result<Options, String> {
+    let mut manifest = None;
+    let mut compiler = None;
+    let mut commit = None;
+    let mut output = None;
+    let mut repo_root = None;
+    let mut std_root = None;
+    let mut workdir = None;
+    let mut args = std::env::args().skip(2);
+    while let Some(flag) = args.next() {
+        let mut value = || {
+            args.next()
+                .ok_or_else(|| format!("{flag} requires a value"))
+        };
+        match flag.as_str() {
+            "--manifest" => manifest = Some(PathBuf::from(value()?)),
+            "--compiler" => compiler = Some(PathBuf::from(value()?)),
+            "--commit" => commit = Some(value()?),
+            "--out" => output = Some(PathBuf::from(value()?)),
+            "--repo-root" => repo_root = Some(PathBuf::from(value()?)),
+            "--std-root" => std_root = Some(PathBuf::from(value()?)),
+            "--workdir" => workdir = Some(PathBuf::from(value()?)),
+            other => return Err(format!("unrecognized scaling argument {other:?}")),
+        }
+    }
+    let commit = commit.ok_or("scaling requires --commit <revision>")?;
+    if commit.is_empty() {
+        return Err("--commit must not be empty".to_string());
+    }
+    let repo_root = repo_root.unwrap_or_else(|| PathBuf::from("."));
+    let std_root = std_root.or_else(|| {
+        let candidate = repo_root.join("std");
+        candidate.is_dir().then_some(candidate)
+    });
+    Ok(Options {
+        manifest: manifest.ok_or("scaling requires --manifest <path>")?,
+        compiler: compiler.ok_or("scaling requires --compiler <path>")?,
+        commit,
+        output: output.ok_or("scaling requires --out <path>")?,
+        repo_root,
+        std_root,
+        workdir,
+    })
+}
+
+fn write_report(path: &Path, report: &ScalingReport) -> Result<(), String> {
+    if let Some(parent) = path.parent().filter(|path| !path.as_os_str().is_empty()) {
+        std::fs::create_dir_all(parent)
+            .map_err(|error| format!("could not create {}: {error}", parent.display()))?;
+    }
+    let raw = canonical_json(report)
+        .map_err(|error| format!("could not serialize the scaling report: {error}"))?;
+    std::fs::write(path, raw)
+        .map_err(|error| format!("could not write {}: {error}", path.display()))?;
+    let markdown_path = path.with_extension("md");
+    std::fs::write(&markdown_path, render(report))
+        .map_err(|error| format!("could not write {}: {error}", markdown_path.display()))?;
+    let address = content_address(report).unwrap_or_else(|_| "unaddressable".to_string());
+    eprintln!(
+        "rue-bench: wrote {} and {} ({address})",
+        path.display(),
+        markdown_path.display()
+    );
+    Ok(())
+}
+
+fn render(report: &ScalingReport) -> String {
+    let mut out = String::new();
+    out.push_str("# Rue compiler scaling report\n\n");
+    out.push_str(&format!(
+        "- Commit: `{}`\n- Fixture revision: {}\n- Target: `{}`\n- Machine: {} ({} cores, {} bytes memory)\n- Runner: `{}` / `{}` ({})\n- Regime: {} sequential fresh compiler processes per workload; OS page-cache state is uncontrolled.\n- Runtime separation: compiled programs were not executed.\n\n",
+        report.identity.commit,
+        report.identity.manifest_revision,
+        report.identity.target,
+        report.identity.environment.cpu_model,
+        report.identity.environment.core_count,
+        report.identity.environment.memory_bytes,
+        report.identity.environment.runner_label,
+        report.identity.environment.runner_image,
+        report.identity.environment.runner_image_version,
+        report.regime.samples_per_workload,
+    ));
+    out.push_str("Times and memory are median ± median absolute deviation (MAD). A changed shape id marks comparisons with earlier artifacts as advisory.\n\n");
+    out.push_str("| workload | shape id | files/modules | functions | bytes/lines/tokens | process ms | compiler ms | peak MiB | output KiB |\n");
+    out.push_str("| --- | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |\n");
+    for observation in &report.workloads {
+        let process = summarize(
+            observation
+                .samples
+                .iter()
+                .map(|sample| sample.process_elapsed_ns),
+        );
+        let compiler = summarize(
+            observation
+                .samples
+                .iter()
+                .map(|sample| sample.phases.compiler_root_ns),
+        );
+        let memory = summarize(
+            observation
+                .samples
+                .iter()
+                .map(|sample| sample.peak_memory_bytes),
+        );
+        let output = summarize(
+            observation
+                .samples
+                .iter()
+                .map(|sample| sample.output_binary_bytes),
+        );
+        let shape_id = content_address(&(&observation.source, &observation.shape))
+            .map(|hash| hash[..12].to_string())
+            .unwrap_or_else(|_| "unknown".to_string());
+        out.push_str(&format!(
+            "| {} | `{}` | {}/{} | {} | {}/{}/{} | {:.2} ± {:.2} | {:.2} ± {:.2} | {:.1} ± {:.1} | {:.1} ± {:.1} |\n",
+            observation.workload,
+            shape_id,
+            observation.shape.files,
+            observation.shape.modules,
+            observation.shape.functions,
+            observation.shape.bytes,
+            observation.shape.lines,
+            observation.shape.tokens,
+            process.median as f64 / 1_000_000.0,
+            process.mad as f64 / 1_000_000.0,
+            compiler.median as f64 / 1_000_000.0,
+            compiler.mad as f64 / 1_000_000.0,
+            memory.median as f64 / (1024.0 * 1024.0),
+            memory.mad as f64 / (1024.0 * 1024.0),
+            output.median as f64 / 1024.0,
+            output.mad as f64 / 1024.0,
+        ));
+    }
+
+    out.push_str("\n## Additive compiler-root phase medians\n\n");
+    out.push_str("All values are milliseconds. Bands are mutually exclusive and sum to compiler-root time per raw sample.\n\n");
+    out.push_str("| workload | source/parse | program | semantic | CFG/opt | backend | object | linking | mixed | unattributed |\n");
+    out.push_str("| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |\n");
+    for observation in &report.workloads {
+        out.push_str(&format!("| {}", observation.workload));
+        for band in Band::all() {
+            let summary = summarize(
+                observation
+                    .samples
+                    .iter()
+                    .map(|sample| sample.phases.band_ns(band)),
+            );
+            out.push_str(&format!(" | {:.2}", summary.median as f64 / 1_000_000.0));
+        }
+        out.push_str(" |\n");
+    }
+
+    out.push_str("\n## Fixture intent\n\n");
+    for observation in &report.workloads {
+        out.push_str(&format!(
+            "- `{}` (`{}`): {}\n",
+            observation.workload, observation.source, observation.question
+        ));
+    }
+    out
+}
+
+fn summarize(values: impl Iterator<Item = u64>) -> Summary {
+    let values: Vec<u64> = values.collect();
+    Summary::of(&values).expect("a scaling observation always has samples")
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeMap;
+
+    use rue_perf_schema::{EnvironmentFingerprint, Phase, PhaseAccounting, Sample};
+
+    use super::*;
+
+    fn report() -> ScalingReport {
+        let phase_ns = Phase::ALL.into_iter().map(|phase| (phase, 10)).collect();
+        let sample = Sample {
+            batch_size: 1,
+            process_elapsed_ns: 100,
+            peak_memory_bytes: 1024,
+            output_binary_bytes: 512,
+            phases: PhaseAccounting {
+                phase_ns,
+                mixed_parallel_ns: 10,
+                unattributed_ns: 20,
+                compiler_root_ns: 100,
+            },
+        };
+        ScalingReport {
+            schema_version: SCALING_REPORT_SCHEMA_VERSION,
+            identity: ScalingIdentity {
+                manifest_revision: 1,
+                commit: "abc".to_string(),
+                started_at: "2026-01-01T00:00:00Z".to_string(),
+                finished_at: "2026-01-01T00:00:01Z".to_string(),
+                target: "test-target".to_string(),
+                environment: EnvironmentFingerprint {
+                    runner_label: "local".to_string(),
+                    runner_image: "local".to_string(),
+                    runner_image_version: "unknown".to_string(),
+                    cpu_model: "test cpu".to_string(),
+                    core_count: 4,
+                    memory_bytes: 4096,
+                    kernel_version: "test".to_string(),
+                    os_version: "test".to_string(),
+                    architecture: "test".to_string(),
+                },
+            },
+            regime: ScalingRegime {
+                compiler_state: "fresh_process_compile".to_string(),
+                os_page_cache: "uncontrolled".to_string(),
+                program_runtime_executed: false,
+                samples_per_workload: 2,
+                compiler_args: Vec::new(),
+            },
+            workloads: vec![ScalingObservation {
+                workload: "probe".to_string(),
+                source: "probe.rue".to_string(),
+                question: "test".to_string(),
+                shape: WorkloadShape {
+                    files: 1,
+                    modules: 1,
+                    bytes: 10,
+                    lines: 1,
+                    tokens: 5,
+                    functions: 1,
+                },
+                samples: vec![sample.clone(), sample],
+            }],
+        }
+    }
+
+    #[test]
+    fn markdown_states_the_regime_and_runtime_separation() {
+        let rendered = render(&report());
+        assert!(rendered.contains("OS page-cache state is uncontrolled"));
+        assert!(rendered.contains("compiled programs were not executed"));
+        assert!(rendered.contains("median absolute deviation"));
+        assert!(rendered.contains("shape id"));
+    }
+
+    #[test]
+    fn raw_report_round_trips_without_unknown_derived_fields() {
+        let report = report();
+        let encoded = canonical_json(&report).unwrap();
+        let decoded: ScalingReport = serde_json::from_str(&encoded).unwrap();
+        assert_eq!(decoded, report);
+    }
+
+    #[test]
+    fn phase_fixture_is_additive() {
+        let report = report();
+        assert!(report.workloads[0].samples[0].phases.holds());
+        let phase_map: BTreeMap<_, _> = report.workloads[0].samples[0].phases.phase_ns.clone();
+        assert_eq!(phase_map.len(), Phase::ALL.len());
+    }
+}

--- a/crates/rue-cli-tests/cases/benchmark_json.toml
+++ b/crates/rue-cli-tests/cases/benchmark_json.toml
@@ -15,7 +15,7 @@ args = ["--benchmark-json", "main.rue", "-o", "prog"]
 env = { RUST_LOG = "error" }
 exit_code = 42
 compile_stdout_contains = [
-  '"schema_version":3',
+  '"schema_version":4',
   '"timing_model":"inclusive_spans"',
   # The additive partition, which is the only model that may be stacked. Its
   # bands are integer nanoseconds summing exactly to compiler_root_ns.
@@ -36,7 +36,9 @@ compile_stdout_contains = [
   '"name":"codegen_unit"',
   '"source_metrics":',
   '"files":1',
+  '"modules":1',
   '"bytes":24',
   '"lines":1',
   '"tokens":',
+  '"functions":1',
 ]

--- a/crates/rue-compiler/src/unstable.rs
+++ b/crates/rue-compiler/src/unstable.rs
@@ -1525,6 +1525,7 @@ pub struct SemanticManifestMetrics {
 }
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
 pub struct SemanticCfgMetrics {
+    pub functions_considered: usize,
     pub cfg_builds_attempted: usize,
     pub cfg_builds_succeeded: usize,
     pub cfg_builds_failed: usize,
@@ -1566,6 +1567,7 @@ impl SemanticMetrics {
                 analyses_invalidated: work.body_analysis.body_analyses_invalidated,
             },
             cfg: SemanticCfgMetrics {
+                functions_considered: work.cfg.functions_considered,
                 cfg_builds_attempted: work.cfg.cfg_builds_attempted,
                 cfg_builds_succeeded: work.cfg.cfg_builds_succeeded,
                 cfg_builds_failed: work.cfg.cfg_builds_failed,

--- a/crates/rue-perf-schema/src/lib.rs
+++ b/crates/rue-perf-schema/src/lib.rs
@@ -34,6 +34,7 @@
 mod canonical;
 mod manifest;
 mod run;
+mod scaling;
 mod series;
 mod stats;
 mod validate;
@@ -46,6 +47,10 @@ pub use manifest::{
 pub use run::{
     Band, EnvironmentFingerprint, FailureRecord, Invocation, Phase, PhaseAccounting, ResolvedPins,
     RunIdentity, RunObject, Sample, WorkloadObservation,
+};
+pub use scaling::{
+    SCALING_REPORT_SCHEMA_VERSION, ScalingIdentity, ScalingManifest, ScalingObservation,
+    ScalingRegime, ScalingReport, ScalingWorkload, WorkloadShape,
 };
 pub use series::{Metric, SeriesId};
 pub use stats::{

--- a/crates/rue-perf-schema/src/scaling.rs
+++ b/crates/rue-perf-schema/src/scaling.rs
@@ -1,0 +1,210 @@
+//! Lower-frequency compiler scaling reports for maintained Rue programs.
+//!
+//! These records deliberately do not enter the ADR-0067 headline series. The
+//! startup suite answers a high-frequency regression question; this report
+//! answers how one fresh compiler process scales as maintained programs grow.
+//! Both use the same raw [`crate::Sample`] and additive phase accounting.
+
+use std::collections::BTreeSet;
+
+use serde::{Deserialize, Serialize};
+
+use crate::{EnvironmentFingerprint, Sample};
+
+/// Version of the scaling-report wire format.
+pub const SCALING_REPORT_SCHEMA_VERSION: u32 = 1;
+
+/// The lower-frequency scaling suite declaration.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ScalingManifest {
+    /// Version of this manifest syntax.
+    pub schema_version: u32,
+    /// Fixture revision. Increment when membership or intent changes.
+    pub revision: u32,
+    /// Independent fresh-process samples per workload.
+    pub samples: u32,
+    /// Behaviour-affecting arguments passed to every compiler process.
+    #[serde(default)]
+    pub args: Vec<String>,
+    /// Maintained programs, in report order.
+    pub workloads: Vec<ScalingWorkload>,
+}
+
+impl ScalingManifest {
+    /// Parse and validate one scaling manifest.
+    pub fn parse(text: &str) -> Result<Self, String> {
+        let manifest: ScalingManifest =
+            toml::from_str(text).map_err(|error| format!("invalid scaling manifest: {error}"))?;
+        if manifest.schema_version != 1 {
+            return Err(format!(
+                "unsupported scaling manifest schema version {}",
+                manifest.schema_version
+            ));
+        }
+        if manifest.samples < 2 {
+            return Err("scaling measurements require at least two samples".to_string());
+        }
+        if manifest.workloads.is_empty() {
+            return Err("the scaling manifest declares no workloads".to_string());
+        }
+        let mut ids = BTreeSet::new();
+        for workload in &manifest.workloads {
+            if workload.id.is_empty() {
+                return Err("a scaling workload has an empty id".to_string());
+            }
+            if !ids.insert(&workload.id) {
+                return Err(format!("duplicate scaling workload id {:?}", workload.id));
+            }
+            if workload.source.is_empty() || workload.source.starts_with('/') {
+                return Err(format!(
+                    "scaling workload {:?} must use a repository-relative source",
+                    workload.id
+                ));
+            }
+        }
+        Ok(manifest)
+    }
+}
+
+/// One maintained program in the scaling suite.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ScalingWorkload {
+    /// Stable short name.
+    pub id: String,
+    /// Root source, relative to the repository.
+    pub source: String,
+    /// The scaling question this program represents.
+    pub question: String,
+}
+
+/// One immutable, raw scaling report.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ScalingReport {
+    /// Version of this report syntax.
+    pub schema_version: u32,
+    /// Identity and environment of the measurement.
+    pub identity: ScalingIdentity,
+    /// Structural measurement regime.
+    pub regime: ScalingRegime,
+    /// Raw measurements, in manifest order.
+    pub workloads: Vec<ScalingObservation>,
+}
+
+/// Identity of a scaling report.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ScalingIdentity {
+    /// Scaling-manifest fixture revision.
+    pub manifest_revision: u32,
+    /// Compiler source revision under measurement.
+    pub commit: String,
+    /// UTC start timestamp.
+    pub started_at: String,
+    /// UTC completion timestamp.
+    pub finished_at: String,
+    /// Target reported by the compiler.
+    pub target: String,
+    /// Machine and runner fingerprint.
+    pub environment: EnvironmentFingerprint,
+}
+
+/// What every sample in a scaling report means.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ScalingRegime {
+    /// Always `fresh_process_compile`: every sample launches a compiler.
+    pub compiler_state: String,
+    /// Always `uncontrolled`: page-cache state is observed, not reset.
+    pub os_page_cache: String,
+    /// Always false. Heavyweight example runtime is a separate measurement.
+    pub program_runtime_executed: bool,
+    /// Sequential independent samples per workload.
+    pub samples_per_workload: u32,
+    /// Behaviour-affecting arguments passed to every compiler process.
+    pub compiler_args: Vec<String>,
+}
+
+/// Raw measurements for one maintained program.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ScalingObservation {
+    /// Stable workload id.
+    pub workload: String,
+    /// Root source recorded for human inspection.
+    pub source: String,
+    /// Why this fixture participates in the scale curve.
+    pub question: String,
+    /// Compiler-produced fixture shape. A change makes cross-report comparison
+    /// advisory even when the manifest revision was not yet advanced.
+    pub shape: WorkloadShape,
+    /// Independent raw fresh-process measurements.
+    pub samples: Vec<Sample>,
+}
+
+/// Compiler-produced dimensions of one fixture.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct WorkloadShape {
+    /// Physical source files in the resolved program.
+    pub files: u64,
+    /// Modules consumed by parsing.
+    pub modules: u64,
+    /// Source bytes.
+    pub bytes: u64,
+    /// Source lines.
+    pub lines: u64,
+    /// Lexer tokens consumed by parsing.
+    pub tokens: u64,
+    /// Source and synthesized functions considered for CFG construction.
+    pub functions: u64,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const VALID: &str = r#"
+schema_version = 1
+revision = 2
+samples = 3
+
+[[workloads]]
+id = "ruelex"
+source = "examples/ruelex/main.rue"
+question = "small maintained compiler frontend"
+"#;
+
+    #[test]
+    fn parses_a_versioned_scaling_manifest() {
+        let manifest = ScalingManifest::parse(VALID).unwrap();
+        assert_eq!(manifest.revision, 2);
+        assert_eq!(manifest.samples, 3);
+        assert_eq!(manifest.workloads[0].id, "ruelex");
+    }
+
+    #[test]
+    fn rejects_single_sample_reports_because_they_have_no_uncertainty() {
+        let error =
+            ScalingManifest::parse(&VALID.replace("samples = 3", "samples = 1")).unwrap_err();
+        assert!(error.contains("at least two samples"), "{error}");
+    }
+
+    #[test]
+    fn rejects_duplicate_fixture_ids() {
+        let duplicate = format!(
+            "{VALID}\n{}",
+            &VALID[VALID.find("[[workloads]]").unwrap()..]
+        );
+        let error = ScalingManifest::parse(&duplicate).unwrap_err();
+        assert!(error.contains("duplicate scaling workload"), "{error}");
+    }
+
+    #[test]
+    fn rejects_unknown_fields_instead_of_guessing() {
+        let error = ScalingManifest::parse(&format!("{VALID}\nsurprise = true\n")).unwrap_err();
+        assert!(error.contains("unknown field"), "{error}");
+    }
+}

--- a/crates/rue/src/main.rs
+++ b/crates/rue/src/main.rs
@@ -1242,9 +1242,15 @@ fn main() {
                     let source_stats = output.unstable_metrics();
                     timing::SourceMetrics {
                         files: source_stats.files,
+                        // Every accepted source file is one module in the
+                        // canonical import graph. Query-work counters do not
+                        // include the root module, so `files` is the exact
+                        // one-shot module count rather than a work estimate.
+                        modules: source_stats.files,
                         bytes: source_stats.bytes,
                         lines: source_stats.lines,
                         tokens: source_stats.tokens,
+                        functions: source_stats.semantic.cfg.functions_considered,
                     }
                 }),
                 options

--- a/crates/rue/src/timing.rs
+++ b/crates/rue/src/timing.rs
@@ -295,7 +295,7 @@ pub struct BenchmarkTiming {
     pub driver_phases: Vec<DriverPhaseTiming>,
     /// Total compilation time in milliseconds.
     pub total_ms: f64,
-    /// Source code metrics (lines, bytes, tokens).
+    /// Source and program-shape metrics for throughput calculations.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub source_metrics: Option<SourceMetrics>,
     /// Peak memory usage in bytes (if available).
@@ -303,17 +303,21 @@ pub struct BenchmarkTiming {
     pub peak_memory_bytes: Option<u64>,
 }
 
-/// Source code metrics for throughput calculations.
+/// Source and program-shape metrics for throughput calculations.
 #[derive(Debug, Clone, Serialize)]
 pub struct SourceMetrics {
     /// Number of source files compiled.
     pub files: usize,
+    /// Number of modules consumed by parsing.
+    pub modules: usize,
     /// Total bytes across source files.
     pub bytes: usize,
     /// Total lines across source files.
     pub lines: usize,
     /// Total tokens produced by the lexer invocations consumed by parsing.
     pub tokens: usize,
+    /// Number of source and synthesized functions considered for CFG construction.
+    pub functions: usize,
 }
 
 /// Metadata about a benchmark run for historical analysis.
@@ -630,7 +634,7 @@ impl TimingData {
     /// # Arguments
     /// * `target` - The target platform string (e.g., "x86_64-linux")
     /// * `version` - The compiler version string
-    /// * `source_metrics` - Optional source code metrics (bytes, lines, tokens)
+    /// * `source_metrics` - Optional source and program-shape metrics
     /// * `peak_memory_bytes` - Optional peak memory usage in bytes
     pub fn to_benchmark_timing_with_metrics(
         &self,
@@ -693,7 +697,7 @@ impl TimingData {
         };
 
         BenchmarkTiming {
-            schema_version: 3,
+            schema_version: 4,
             timing_model: "inclusive_spans",
             phase_accounting,
             metadata,
@@ -710,7 +714,7 @@ impl TimingData {
     /// # Arguments
     /// * `target` - The target platform string
     /// * `version` - The compiler version string
-    /// * `source_metrics` - Source code metrics (bytes, lines, tokens)
+    /// * `source_metrics` - Source and program-shape metrics
     /// * `peak_memory_bytes` - Optional peak memory usage
     pub fn to_json_with_metrics(
         &self,
@@ -2042,7 +2046,7 @@ mod tests {
         data.record("lexer", Duration::from_millis(100));
 
         let json = data.to_json_with_metrics("x86_64-linux", "0.1.0", None, None);
-        assert!(json.contains("\"schema_version\":3"));
+        assert!(json.contains("\"schema_version\":4"));
         assert!(json.contains("\"timing_model\":\"inclusive_spans\""));
         assert!(json.contains("\"passes\""));
         assert!(json.contains("\"name\""));
@@ -2629,7 +2633,7 @@ mod phase_accounting_tests {
         });
 
         let timing = data.to_benchmark_timing_with_metrics("probe-target", "probe", None, None);
-        assert_eq!(timing.schema_version, 3);
+        assert_eq!(timing.schema_version, 4);
         assert_eq!(timing.timing_model, "inclusive_spans");
         assert_invariant(&timing.phase_accounting);
 

--- a/docs/process/README.md
+++ b/docs/process/README.md
@@ -30,6 +30,7 @@ Each step has a corresponding document in this directory and a Claude Code comma
 | Commit | [committing.md](committing.md) | `/commit` | Create well-formed commits |
 | - | [ci.md](ci.md) | - | Maintain required CI and its pinned tools |
 | - | [profiling.md](profiling.md) | - | Build symbolized executables for native profiling |
+| - | [compiler-scaling.md](compiler-scaling.md) | - | Measure maintained-program compiler scaling |
 | - | [compiler-facade.md](compiler-facade.md) | - | Review compiler API and tooling-view changes |
 | - | [tutorial.md](tutorial.md) | - | Maintain tutorial outline, style, and snippet checks |
 | - | [issue-tracking.md](issue-tracking.md) | Linear MCP tools | Track work with Linear |

--- a/docs/process/compiler-scaling.md
+++ b/docs/process/compiler-scaling.md
@@ -1,0 +1,67 @@
+# Compiler scaling reports
+
+The weekly compiler-scaling workflow measures how the compiler behaves as
+maintained Rue programs grow from Ruelex through Mosaic and Harbor to Lattice.
+It complements the fast compiler-performance headline; it does not contribute
+to that index.
+
+## Measurement regime
+
+Each sample launches the canonical compiler binary in a new process and asks
+it for `--benchmark-json`. There is no retained compiler session or persistent
+query cache. Filesystem and operating-system page-cache state are not reset, so
+the reports call this a **fresh-process compile**, not a cold compile.
+
+The runner executes three samples sequentially for each workload. JSON keeps
+every raw observation in integer nanoseconds. The Markdown view reports the
+median and median absolute deviation (MAD), along with the machine and hosted
+runner fingerprint. It records:
+
+- files, modules, source bytes, lines, lexer tokens, and functions considered;
+- externally observed fresh-process wall time and peak resident memory;
+- the compiler's additive, mutually exclusive phase accounting;
+- output binary size.
+
+The compiled examples are never executed. Runtime tests and heavyweight
+example scenarios remain in their existing suites, so a slow example runtime
+cannot be mistaken for a compiler regression.
+
+## Running locally
+
+Build the compiler and the existing ADR-0067 runner, then run its scaling mode:
+
+```bash
+./buck2 build //crates/rue:rue //crates/rue-bench:rue-bench
+RUE="$(scripts/rue-bin)"
+BENCH="$(./buck2 build //crates/rue-bench:rue-bench --show-simple-output 2>/dev/null | tail -1)"
+"$BENCH" scaling \
+  --manifest performance/scaling.toml \
+  --compiler "$RUE" \
+  --commit <40-character-revision> \
+  --repo-root . \
+  --out /tmp/rue-scaling.json
+```
+
+This writes `/tmp/rue-scaling.json` and `/tmp/rue-scaling.md`. Supplying a
+`--workdir` keeps the generated executables for inspection; without it the
+runner uses a temporary directory.
+
+## Comparing history
+
+The scheduled workflow stores both report forms as a 90-day workflow artifact.
+Compare reports only within the same target and manifest revision, and treat a
+runner fingerprint change as advisory because GitHub-hosted hardware is not a
+controlled machine.
+
+Every workload row includes a shape id derived from its root path and the
+compiler-produced file/module/function and source-size counts. A changed shape
+id marks the timing comparison as advisory even if someone forgot to advance
+the fixture revision. Deliberate changes to workload membership or intent must
+increment `revision` in `performance/scaling.toml`; the old workflow artifact
+remains the boundary record. Raw JSON is the authority, while the Markdown
+table is a derived view that can be regenerated from those samples.
+
+The suite is intentionally lower frequency. Do not add these workloads to
+`performance/manifest.toml` or give them the startup probe's calibrated
+sampling policy: doing so would make every trunk collection expensive and
+silently change the headline's meaning.

--- a/performance/scaling.toml
+++ b/performance/scaling.toml
@@ -1,0 +1,31 @@
+# Lower-frequency compiler scale curve (RUE-1038).
+#
+# This is intentionally separate from `manifest.toml`: these maintained
+# programs take seconds rather than milliseconds, so they must not inherit the
+# startup probe's calibrated sample counts or enter the fast headline index.
+# Every sample launches the canonical compiler binary in a fresh process. The
+# compiled program is never run.
+schema_version = 1
+revision = 1
+samples = 3
+args = []
+
+[[workloads]]
+id = "ruelex"
+source = "examples/ruelex/main.rue"
+question = "How does the compiler handle a small maintained compiler frontend?"
+
+[[workloads]]
+id = "mosaic"
+source = "examples/mosaic/main.rue"
+question = "How does compilation scale to a medium multi-module application?"
+
+[[workloads]]
+id = "harbor"
+source = "examples/harbor/main.rue"
+question = "How does compilation scale with a broad domain model and many analysis passes?"
+
+[[workloads]]
+id = "lattice"
+source = "examples/lattice/main.rue"
+question = "How does compilation scale to the largest maintained maturity rung in the scheduled curve?"


### PR DESCRIPTION
## Summary

- add a versioned maintained-program scaling manifest covering ruelex, mosaic, harbor, and lattice
- add a `rue-bench scaling` runner that records three fresh-process samples and reports median/MAD
- capture exact program shape, compiler/process timings, phase timings, peak RSS, and output size in versioned JSON plus Markdown
- schedule the scaling run weekly on Ubuntu and retain its artifacts for 90 days
- extend compiler benchmark JSON with module and function counts

This gives Rue a reproducible scaling history across real maintained programs without conflating compiler performance with program runtime.

Fixes RUE-1038.

## Validation

- `scripts/rue fmt`
- `scripts/rue quick` (generated-oracle timeout under load passed immediately in isolation)
- `scripts/rue cli benchmark_json`
- focused `rue-perf-schema`, `rue-bench`, compiler CLI, and full scaling smoke suites
- clippy gate: 63 first-party targets
- canonical premerge tier: all compiler, CLI, spec, UI, differential, oracle, reproducibility, traceability, release-smoke, and scaling-matrix targets passed; the checkout-local shell-pipeline scanner failure caused by unrelated nested `.claude/worktrees` files passed in a clean workspace