### PR TITLE
File-qualify source-declared anon-lookalike types; exemption by registry membership

### DIFF
--- a/crates/rue-air/src/intern_pool.rs
+++ b/crates/rue-air/src/intern_pool.rs
@@ -557,11 +557,15 @@ struct TypeInternPoolInner {
     /// `__rue_*` and `_start` are reserved — so "was this generated?" is
     /// membership here, never a name prefix (RUE-1050). This is the authority
     /// for consumers below semantic analysis, which cannot see the sema-side
-    /// registry: CFG destructor discovery and drop glue.
+    /// registry: CFG destructor discovery, drop glue, and symbol spelling
+    /// (`struct_symbol_name` / `enum_symbol_name`).
     ///
-    /// Symbol spelling still tests the prefix. It cannot read this registry
-    /// until the provider boundary carries the same marks, because durable
-    /// export re-derives identities from the rendered symbol; see RUE-1193.
+    /// Every path that mints a generated anonymous nominal must mark it here:
+    /// the epoch-local `find_or_create_anon_struct` / `_enum` and the
+    /// producer-nominal `mint_anon_struct` / `mint_anon_enum` mirror at the
+    /// provider boundary. A pool that carries the type but not the mark spells
+    /// a generated anonymous type as if it were a user nominal and desyncs the
+    /// callable symbols joined across that boundary (RUE-1193).
     anonymous_structs: HashSet<StructId>,
     anonymous_enums: HashSet<EnumId>,
 
@@ -2008,16 +2012,21 @@ impl TypeInternPoolInner {
         // different files are distinct, so their symbols must never depend on
         // whether a collision happened to be observed. Builtins keep their bare
         // source names because they pair with runtime-provided definitions.
-        // Anonymous structs already carry a globally-unique synthetic name
-        // (`__anon_struct_<id>`) that distinguishes every producer, and their
-        // destructor/member symbols are spelled from that bare name; qualifying
-        // them would only desynchronize those spellings, so they are exempt.
+        // Generated anonymous structs already carry a globally-unique synthetic
+        // name (`__anon_struct_<digest>`) that distinguishes every producer, and
+        // their destructor/member symbols are spelled from that bare name;
+        // qualifying them would only desynchronize those spellings, so they are
+        // exempt. That exemption is REGISTRY MEMBERSHIP, never the generated-name
+        // prefix: `__anon_struct_N` is a legal source declaration (only `__rue_*`
+        // and `_start` are reserved, RUE-125), and a prefix test hands such a
+        // declaration the bare symbol of a generated type it collides with
+        // (RUE-1050, RUE-1193).
         // Language-item builtins (`str`, `StrBuf`, `Str(N)`) also keep their bare
         // names: they pair with runtime-provided definitions, and the lang-item
         // marker survives durable import even when `is_builtin` is not carried.
         if data.def.is_builtin
             || self.struct_lang_items.contains_key(&id)
-            || data.def.name.starts_with("__anon_struct_")
+            || self.is_anonymous_struct(id)
         {
             return data.def.name.to_string();
         }
@@ -2034,11 +2043,9 @@ impl TypeInternPoolInner {
             other => panic!("Expected enum at pool index {}, got {:?}", id.0, other),
         };
         // See `struct_symbol_name`: unconditional qualification, with the
-        // reserved built-in enums and the uniquely-named anonymous enums
-        // (`__anon_enum_<id> { … }`) keeping their bare names.
-        if rue_builtins::is_reserved_enum_name(&data.def.name)
-            || data.def.name.starts_with("__anon_enum_")
-        {
+        // reserved built-in enums and the registry-marked generated anonymous
+        // enums (`__anon_enum_<digest> { … }`) keeping their bare names.
+        if rue_builtins::is_reserved_enum_name(&data.def.name) || self.is_anonymous_enum(id) {
             return data.def.name.to_string();
         }
         format!(
@@ -5119,6 +5126,112 @@ mod tests {
         // is, so the pair stays distinct.
         assert_eq!(pool.struct_symbol_name(b1), "StrBufTest");
         assert_eq!(pool.struct_symbol_name(b2), "StrBufTest$3");
+    }
+
+    /// RUE-1193: the bare-symbol exemption is registry membership, not the
+    /// generated-name spelling. A source declaration may legally spell the exact
+    /// generated form -- including the full 32-hex-digit one -- and must still be
+    /// file-qualified, or it collides with the generated type it names.
+    #[test]
+    fn anonymity_exemption_is_membership_not_the_generated_name_spelling() {
+        let pool = TypeInternPool::new();
+        let interner = ThreadedRodeo::default();
+        let struct_def = |name: &str, file: u32| StructDef {
+            name: name.into(),
+            fields: vec![],
+            is_copy: false,
+            is_linear: false,
+            destructor: None,
+            is_builtin: false,
+            is_pub: true,
+            file_id: rue_span::FileId::new(file),
+        };
+        let digest_name = "__anon_struct_daa98b889bc477390889f83e53d5c4c3";
+
+        // Source declarations wearing the generated spelling.
+        let short_sym = interner.get_or_intern("__anon_struct_5");
+        let (short, _) = pool.register_struct(short_sym, struct_def("__anon_struct_5", 1));
+        let digest_sym = interner.get_or_intern(digest_name);
+        let (lookalike, _) = pool.register_struct(digest_sym, struct_def(digest_name, 1));
+
+        // The type the compiler actually generated, marked at creation.
+        let generated_sym = interner.get_or_intern("__anon_struct_deadbeef");
+        let (generated, _) =
+            pool.register_struct(generated_sym, struct_def("__anon_struct_deadbeef", 0));
+        pool.mark_anonymous_struct(generated);
+
+        assert_eq!(pool.struct_symbol_name(short), "__anon_struct_5$1");
+        assert_eq!(
+            pool.struct_symbol_name(lookalike),
+            format!("{digest_name}$1")
+        );
+        assert_eq!(pool.struct_symbol_name(generated), "__anon_struct_deadbeef");
+
+        // The enum half of the same rule.
+        let enum_def = |name: &str, file: u32| EnumDef {
+            name: name.into(),
+            variants: Arc::from(["A".into()]),
+            variant_payloads: vec![vec![]],
+            is_pub: true,
+            file_id: rue_span::FileId::new(file),
+        };
+        let source_enum_sym = interner.get_or_intern("__anon_enum_5");
+        let (source_enum, _) = pool.register_enum(source_enum_sym, enum_def("__anon_enum_5", 1));
+        let generated_enum_sym = interner.get_or_intern("__anon_enum_deadbeef { A }");
+        let (generated_enum, _) = pool.register_enum(
+            generated_enum_sym,
+            enum_def("__anon_enum_deadbeef { A }", 0),
+        );
+        pool.mark_anonymous_enum(generated_enum);
+
+        assert_eq!(pool.enum_symbol_name(source_enum), "__anon_enum_5$1");
+        assert_eq!(
+            pool.enum_symbol_name(generated_enum),
+            "__anon_enum_deadbeef { A }"
+        );
+    }
+
+    /// RUE-1193: symbol spelling reads the anonymity registry, so the registry
+    /// has to survive every representation the pool takes on downstream --
+    /// freezing for post-semantic phases and the per-body overlay derivation.
+    /// A mark that does not travel spells a generated anonymous type as if it
+    /// were a user nominal.
+    #[test]
+    fn anonymity_marks_survive_freezing_and_overlay_derivation() {
+        let pool = TypeInternPool::new();
+        let interner = ThreadedRodeo::default();
+        let name = "__anon_struct_deadbeef";
+        let symbol = interner.get_or_intern(name);
+        let (generated, _) = pool.register_struct(
+            symbol,
+            StructDef {
+                name: name.into(),
+                fields: vec![],
+                is_copy: true,
+                is_linear: false,
+                destructor: None,
+                is_builtin: false,
+                is_pub: false,
+                file_id: rue_span::FileId::new(0),
+            },
+        );
+        pool.mark_anonymous_struct(generated);
+
+        assert!(pool.is_anonymous_struct(generated));
+        assert_eq!(pool.struct_symbol_name(generated), name);
+
+        let cloned = pool.clone();
+        assert!(cloned.is_anonymous_struct(generated));
+        assert_eq!(cloned.struct_symbol_name(generated), name);
+
+        // The per-body overlay reads the mark through its shared base.
+        cloned.rebase_overlay_in_place();
+        assert!(cloned.is_anonymous_struct(generated));
+        assert_eq!(cloned.struct_symbol_name(generated), name);
+
+        let frozen = pool.freeze();
+        assert!(frozen.is_anonymous_struct(generated));
+        assert_eq!(frozen.struct_symbol_name(generated), name);
     }
 
     #[test]

--- a/crates/rue-air/src/sema/body_identity.rs
+++ b/crates/rue-air/src/sema/body_identity.rs
@@ -1887,6 +1887,12 @@ where
             },
         );
         let ty = Type::new_struct(id);
+        // Mirror the epoch's `find_or_create_anon_struct`: the pool-level
+        // anonymity registry is the authority for symbol spelling, CFG
+        // destructor discovery, and drop glue, and it has to survive the
+        // producer-nominal re-mint or those consumers see a generated
+        // anonymous type as an ordinary user nominal (RUE-1050, RUE-1193).
+        self.type_pool.mark_anonymous_struct(id);
         self.anon_nominals.insert(key.clone(), ty);
 
         let mut resolved = Vec::with_capacity(fields.len());
@@ -1971,6 +1977,8 @@ where
                 file_id: FileId::DEFAULT,
             },
         );
+        // See `mint_anon_struct` (RUE-1050, RUE-1193).
+        self.type_pool.mark_anonymous_enum(id);
         Ok(Type::new_enum(id))
     }
 
@@ -4314,6 +4322,57 @@ mod tests {
             def.variants.iter().map(Arc::as_ref).collect::<Vec<_>>(),
             ["Some", "None"]
         );
+    }
+
+    /// The producer-nominal mint records the pool-level anonymity mark, exactly
+    /// as the epoch's `find_or_create_anon_struct` / `_enum` do (RUE-1050).
+    ///
+    /// This is the drift guard for RUE-1193. The pool registry — not the
+    /// `__anon_struct_`/`__anon_enum_` spelling, which is a legal source name —
+    /// is what decides that symbol spelling keeps the bare synthetic name and
+    /// that CFG destructor discovery and drop glue treat the type as generated.
+    /// A mint that registers the type but forgets the mark republishes a
+    /// generated anonymous type as an ordinary user nominal: its callable
+    /// symbols become file-qualified here while the rooted image still spells
+    /// them bare, and the two sides stop joining.
+    #[test]
+    fn minted_anonymous_nominals_carry_the_pool_anonymity_mark() {
+        let struct_key = anon_key(AnonymousNominalKind::Struct, 0, 7);
+        let enum_key = anon_key(AnonymousNominalKind::Enum, 0, 8);
+        let struct_shape = DurableAnonymousShape::Struct {
+            fields: vec![(Arc::from("x"), DType::I32)],
+            struct_method_names: vec![Arc::from("get")],
+        };
+        let enum_shape = DurableAnonymousShape::Enum {
+            variants: vec![(Arc::from("A"), vec![])],
+        };
+        let mut pool = anon_pool(
+            [],
+            [
+                (struct_key.clone(), struct_shape),
+                (enum_key.clone(), enum_shape),
+            ],
+            [],
+        );
+
+        let struct_ty = pool.find_or_create_anon(&struct_key).unwrap();
+        let struct_id = struct_ty.as_struct().unwrap();
+        assert!(
+            pool.type_pool().is_anonymous_struct(struct_id),
+            "the mint must register the anonymity mark, not rely on the name",
+        );
+        // Membership is what keeps the symbol bare; the name is only evidence.
+        let struct_name = pool.type_pool().struct_def(struct_id).name.to_string();
+        assert_eq!(pool.type_pool().struct_symbol_name(struct_id), struct_name);
+
+        let enum_ty = pool.find_or_create_anon(&enum_key).unwrap();
+        let enum_id = enum_ty.as_enum().unwrap();
+        assert!(
+            pool.type_pool().is_anonymous_enum(enum_id),
+            "the enum mint must register the anonymity mark too",
+        );
+        let enum_name = pool.type_pool().enum_def(enum_id).name.to_string();
+        assert_eq!(pool.type_pool().enum_symbol_name(enum_id), enum_name);
     }
 
     /// Distinct producer keys forced onto one digest fail closed: the second is

--- a/crates/rue-cli-tests/cases/generated_name_lookalike_declarations.toml
+++ b/crates/rue-cli-tests/cases/generated_name_lookalike_declarations.toml
@@ -10,11 +10,20 @@
 # issue a named identity, both surfacing as an E9000 ICE rather than a working
 # program.
 #
-# Generated names are `__anon_struct_{32 hex digits}`, so these short names
+# Generated names are `__anon_struct_{32 hex digits}`, so the short names below
 # never collide with a real generated one by value -- classification is the
 # whole defect. Each case therefore declares the lookalike AND forces a genuine
 # generated anonymous type into the same program, so the two must be told apart
 # by identity rather than by spelling.
+#
+# RUE-1193 is the value-collision half. A source declaration may legally spell
+# the full 32-hex-digit form too, and symbol spelling still classified by prefix
+# long after semantic analysis stopped doing so: the source declaration was
+# handed the BARE symbol of the generated type whose digest it matched, so both
+# receivers' methods resolved to one callable and the program silently computed
+# the wrong answer. Symbol spelling now reads the same anonymity registry, which
+# in turn has to survive the producer-nominal re-mint at the provider boundary
+# (`body_identity::mint_anon_struct` / `mint_anon_enum`).
 
 [section]
 id = "cli.generated_name_lookalike_declarations"
@@ -99,3 +108,108 @@ fn main() -> i32 {
 args = ["main.rue", "-o", "prog"]
 stdout = "100\n9\n"
 exit_code = 2
+
+# RUE-1193 reproducer: a source declaration spelled with the FULL generated
+# form, matching the digest the compiler mints for this module's own anonymous
+# struct. Before the fix both `n.get()` and `a.get()` were spelled
+# `__anon_struct_daa9....get` -- the source declaration's qualified definition
+# was emitted and never called -- so the program returned 2 + 2 = 4 with no
+# diagnostic. The exit code is the whole assertion: 41 + 2 = 43.
+#
+# The digest is a function of this module's logical path (`main.rue`), the
+# producing function (`A`), and the literal's anchor. Renaming the file or
+# moving the `struct { ... }` literal changes it, at which point the two names
+# no longer collide and the case stops exercising RUE-1193 -- re-derive it with
+# `rue --emit air main.rue` if this case is ever edited.
+[[case]]
+name = "source_declaration_matching_a_generated_digest_keeps_its_own_method"
+description = "A source __anon_struct_<32 hex> whose name equals a live generated anonymous type's digest still resolves to its own method (RUE-1193)."
+files = [{ path = "main.rue", source = """
+struct __anon_struct_daa98b889bc477390889f83e53d5c4c3 { x: i32, fn get(self) -> i32 { 41 } }
+fn A() -> type { struct { x: i32, fn get(self) -> i32 { 2 } } }
+fn main() -> i32 {
+    let n = __anon_struct_daa98b889bc477390889f83e53d5c4c3 { x: 0 };
+    let T = A();
+    let a: T = T { x: 0 };
+    n.get() + a.get()
+}
+""" }]
+args = ["main.rue", "-o", "prog"]
+exit_code = 43
+
+# The cross-file half of RUE-1193: two files each declare the same lookalike
+# name. Producer-nominal identity makes them distinct types, so their callable
+# symbols must be file-qualified and each `get` must keep its own body.
+# 1 + 7 = 8.
+[[case]]
+name = "cross_file_lookalike_structs_keep_separate_methods"
+description = "The same source __anon_struct_N declared in two files stays two types with two methods (RUE-1193)."
+files = [
+    { path = "main.rue", source = """
+const helper = @import("helper.rue");
+
+struct __anon_struct_5 { x: i32, fn get(self) -> i32 { 1 } }
+
+fn main() -> i32 {
+    let n = __anon_struct_5 { x: 0 };
+    n.get() + helper.make()
+}
+""" },
+    { path = "helper.rue", source = """
+pub struct __anon_struct_5 {
+    x: i32,
+
+    fn get(self) -> i32 { 7 }
+}
+
+pub fn make() -> i32 {
+    let h = __anon_struct_5 { x: 0 };
+    h.get()
+}
+""" },
+]
+args = ["main.rue", "-o", "prog"]
+exit_code = 8
+
+# The ordinary-type control: a source lookalike alone in its module, with no
+# generated anonymous type anywhere in the program, behaves like any other named
+# struct -- fields, method, and a destructor that runs at scope end. 6 + 1 = 7.
+[[case]]
+name = "single_file_lookalike_is_an_ordinary_named_struct"
+description = "A source __anon_struct_N with no generated anonymous type in the program is an ordinary named struct (RUE-1193)."
+files = [{ path = "main.rue", source = """
+struct __anon_struct_5 {
+    x: i32,
+
+    fn get(self) -> i32 { self.x + 1 }
+}
+drop fn __anon_struct_5(self) { @dbg(self.x); }
+
+fn main() -> i32 {
+    let n = __anon_struct_5 { x: 6 };
+    n.get()
+}
+""" }]
+args = ["main.rue", "-o", "prog"]
+stdout = "6\n"
+exit_code = 7
+
+# The registry that symbol spelling now reads is also what CFG destructor
+# discovery (`rue-cfg` build) and drop-glue construction classify by, and those
+# run on the frozen pool -- past the producer-nominal re-mint that used to drop
+# the mark. A generated anonymous struct with its own `drop fn` exercises that
+# whole path end to end.
+[[case]]
+name = "generated_anonymous_struct_destructor_runs_through_the_anonymous_path"
+description = "A generated anonymous struct's own destructor runs, with the anonymity mark intact past the provider boundary (RUE-1050, RUE-1193)."
+files = [{ path = "main.rue", source = """
+fn A() -> type { struct { x: i32, drop fn (self) { @dbg(self.x); } } }
+fn main() -> i32 {
+    let T = A();
+    let a: T = T { x: 5 };
+    0
+}
+""" }]
+args = ["main.rue", "-o", "prog"]
+stdout = "5\n"
+exit_code = 0


### PR DESCRIPTION
The bare-symbol exemption for anonymous types in `TypeInternPool::struct_symbol_name`/`enum_symbol_name` tested the generated-name **prefix**, and `__anon_struct_N` is a legal source declaration (only `__rue_*`/`_start` are reserved, RUE-125).

Investigation found the issue's original cross-file E9000 repro was already closed incidentally by the rooted-image migration (RUE-1214/1217) — production symbol spelling qualifies every named nominal unconditionally. **But the prefix test was still a live silent miscompile**: a source struct spelled with a 32-hex digest matching a generated anonymous type in the same module stole its callable symbol — both call sites bound to the bare spelling, the program returned a wrong answer with no diagnostic (expected 43, got 4), and the correctly-qualified definition was emitted as dead code.

**The fix** (the issue's own "carry the anonymity mark across the provider boundary" alternative, viable now that RUE-1128 retired the callable-symbol reversal):
- `mint_anon_struct`/`mint_anon_enum` in `body_identity.rs` now mark the pool anonymity registry, mirroring `find_or_create_anon_*`. They previously dropped the mark — which was also silently leaving the RUE-1050 registry consumers (`rue-cfg/build.rs:2448`, `drop_glue.rs:479`) classifying every generated anonymous type as named on the rooted path.
- `struct_symbol_name`/`enum_symbol_name` test registry membership instead of the name prefix. A source declaration with a lookalike name is now an ordinary file-qualified type; a generated anonymous type keeps its bare spelling by membership.
- With the marks in place, the historical `E1403 MissingStableIdentity` regression that blocked the membership switch in the RUE-1050 era does not recur (all four `generated_name_lookalike_declarations` cases pass).

**Tests (7):** four CLI cases (digest collision asserting runtime exit 43; cross-file lookalike; single-file lookalike as ordinary type incl. `drop fn`; generated anon destructor through the provider boundary) and three unit tests (membership-not-spelling pool test; marks survive clone/overlay-rebase/freeze; mint-must-mark drift guard). Three of the seven fail on the prior code, verified by reverting only the production hunks.

Fixes RUE-1193.

Follow-ups filed rather than folded in: RUE-1236 (the surviving `anonymous_function_identities` spelling-agreement join + the inert `$`-split reversal), RUE-1237 (test-only-reachable declaration paths, which contain three of the remaining prefix-test sites; scratch file at repo root).

## Validation

Premerge 78/78. Full spec 2262 + traceability, rue-air 695, compiler 804 (warm-session/incremental coverage), CLI `generated_name` 8/8, `anon` 16, `struct` 195, `import` 57, quick, clippy, fmt. All five repro classes re-verified by execution at integration time (digest 43, cross-file 8, drop-glue variants, RUE-1050 single-file).

---
_Generated by [Claude Code](https://claude.ai/code/session_01DrKqpQgkHzDHGqpEMjxYdN)_