### PR TITLE
RUE-1225: add host-wide Buck disk lifecycle

### DIFF
--- a/.buckconfig
+++ b/.buckconfig
@@ -23,6 +23,15 @@ execution_platforms = prelude//platforms:default
 
 [buck2]
 materializations = deferred
+sqlite_materializer_state = true
+defer_write_actions = true
+clean_stale_enabled = true
+# Keep one week of locally used outputs. Buck performs the cleanup after a
+# daemon has been up for twelve hours and then once a day; the materializer
+# coordinates the deletion with active builds.
+clean_stale_artifact_ttl_hours = 168
+clean_stale_period_hours = 24
+clean_stale_start_offset_hours = 12
 
 [project]
 # Keep buck2 from parsing/watching non-source trees inside the project root:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -83,7 +83,9 @@ scripts/rue spec 4.2                 # filtered specification tests
 scripts/rue cli abi                  # filtered CLI integration tests
 scripts/rue test [pattern]           # broad/full suite
 scripts/rue fmt                      # format changed Rust files
-scripts/rue gc                       # reclaim stale Buck2 artifacts
+scripts/rue storage status           # inventory Buck disk use across worktrees
+scripts/rue storage plan             # dry-run host-wide stale cleanup
+scripts/rue storage clean            # reclaim stale Buck2 artifacts host-wide
 scripts/rue cache install            # securely install the shared cache config
 scripts/rue cache apply --all        # provision current Git/Codex worktrees
 ```

--- a/BUCK
+++ b/BUCK
@@ -901,14 +901,14 @@ rue_test_suite(
     tests = ["//crates/rue-rir:rue-rir[doc]"],
 )
 
-# The destructive maintenance scripts under test (jj-tidy, worktree-gc). Their
-# fail-closed contract is pinned by scripts/test-cleanup-scripts.sh (RUE-567),
-# which runs copies of them against fake gh/git/df on PATH — no real repo,
-# remote, or disk touched.
+# Maintenance scripts with deletion behavior. Their fail-closed contract is
+# pinned by scripts/test-cleanup-scripts.sh (RUE-567, RUE-1225), which runs
+# copies against fake tools — no real repo, remote, or Buck output is touched.
 filegroup(
     name = "cleanup-script-inputs",
     srcs = [
         "scripts/jj-tidy",
+        "scripts/rue-storage",
         "scripts/worktree-gc",
     ],
 )
@@ -940,6 +940,7 @@ filegroup(
         "scripts/check-cache-probe",
         "scripts/rue",
         "scripts/rue-bin",
+        "scripts/rue-storage",
         "scripts/provision-build-cache",
         "scripts/run-large-example.sh",
         "scripts/run-sanitizer.sh",

--- a/docs/development.md
+++ b/docs/development.md
@@ -26,7 +26,9 @@ scripts/rue all                      # union of every test tier
 scripts/rue spec 4.2                 # filtered specification cases
 scripts/rue cli abi                  # filtered CLI integration cases
 scripts/rue fmt                      # format first-party Rust
-scripts/rue gc                       # remove stale Buck artifacts
+scripts/rue storage status           # inventory Buck usage across worktrees
+scripts/rue storage plan             # dry-run host-wide stale cleanup
+scripts/rue storage clean            # remove stale Buck artifacts host-wide
 ```
 
 For direct compiler invocations, resolve the binary through `scripts/rue-bin`:

--- a/docs/process/build-cache.md
+++ b/docs/process/build-cache.md
@@ -34,7 +34,10 @@ scripts/rue cache apply --all   # primary checkout + current Git/Codex worktrees
 `apply` places only an ignored `.buckconfig.local` symlink in each checkout, so
 the credential is neither copied between worktrees nor stored in Git. It refuses
 to replace an existing local config and refuses a central config readable by
-another account. Commands never print the key.
+another account. Commands never print the key. A secure config installed before
+the Rust upload gate existed is upgraded atomically in place, preserving its
+credential; an explicit `default_allow_cache_upload = false` remains an error
+instead of being silently overridden.
 
 Once installed, direct `./buck2`, `scripts/rue ...`, and `test.sh` runs
 automatically link a new worktree on first use. If the central config is absent,
@@ -42,6 +45,34 @@ Rue simply uses its ordinary local Buck configuration. If it is malformed or
 insecure, Rue warns and continues without provisioning it. Existing local paths,
 including broken or unrelated symlinks, are left untouched. This keeps cache
 setup opt-in and prevents a credential problem from making local builds unusable.
+
+## Host-wide disk lifecycle
+
+Every worktree has its own `buck-out`; a large primary checkout and many smaller
+worktrees therefore share one host budget even though Buck daemons cannot share
+their local materializer state. Rue configures Buck's deferred materializer to
+persist that state, defer write actions, and continuously remove outputs that
+have not been used for one week. Cleanup starts twelve hours after daemon startup
+and repeats daily. Buck coordinates those deletions with active builds; Rue does
+not infer that a worktree is disposable from its age or directory name.
+
+Use the host-wide storage command from any current Rue checkout:
+
+```bash
+scripts/rue storage status            # sizes, source state, and cache state
+scripts/rue storage plan [AGE]        # Buck dry-run in every registered worktree
+scripts/rue storage clean [AGE]       # coordinated stale cleanup; default 1w
+scripts/rue storage reset /exact/root # full Buck reset of an explicit target
+```
+
+The inventory comes from `git worktree list` and fails closed: if the registered
+set cannot be read, no cleanup runs. `clean` removes only stale or untracked Buck
+outputs. `reset` is the migration escape hatch for an older worktree whose
+artifacts predate persisted materializer state; it validates every named path as
+a registered Rue worktree before it resets any of them. Neither command removes
+source files or worktrees. `scripts/rue gc` remains a compatibility alias for
+the host-wide one-week stale cleanup, and the older `scripts/worktree-gc` entry
+point now performs the same safe cleanup without deleting directories.
 
 The default setup is for the shared **action cache**. Normal commands stay on
 `--prefer-local`; add `--prefer-remote` explicitly when remote execution is the

--- a/scripts/provision-build-cache
+++ b/scripts/provision-build-cache
@@ -14,11 +14,12 @@ usage: scripts/provision-build-cache install
 install reads BUILDBUDDY_API_KEY, or prompts without echo on a terminal, and
 writes the central config with mode 0600. apply links .buckconfig.local in the
 current checkout (or named roots) to that config. --all also discovers Git and
-Codex worktrees. No credential is printed.
+Codex worktrees. A private config from before the Rust upload gate was added is
+upgraded in place without replacing or printing its credential.
 EOF
 }
 
-validate_config() {
+validate_private_config() {
     if [[ ! -f "$central_config" ]] || [[ ! -r "$central_config" ]]; then
         echo "error: BuildBuddy config is unavailable; run scripts/provision-build-cache install" >&2
         return 1
@@ -40,8 +41,57 @@ validate_config() {
         echo "error: BuildBuddy config does not contain a configured API key" >&2
         return 1
     fi
+}
+
+migrate_config() {
+    validate_private_config || return 1
+    if grep -Eq '^[[:space:]]*default_allow_cache_upload[[:space:]]*=' "$central_config"; then
+        if ! grep -Eq '^[[:space:]]*default_allow_cache_upload[[:space:]]*=[[:space:]]*true([[:space:]]|$)' "$central_config"; then
+            echo "error: BuildBuddy config explicitly disables Rust action uploads" >&2
+            return 1
+        fi
+        return 0
+    fi
+
+    # This is the one recognized legacy shape: a secure, user-owned config
+    # with a configured credential but no upload gate. Preserve every existing
+    # byte (especially the credential) and atomically add only the public knob.
+    umask 077
+    local tmp="${central_config}.tmp.$$"
+    if ! awk '
+        BEGIN { in_buck2 = 0; saw_buck2 = 0; inserted = 0 }
+        /^\[buck2\][[:space:]]*$/ { in_buck2 = 1; saw_buck2 = 1; print; next }
+        /^\[/ && in_buck2 && !inserted {
+            print "default_allow_cache_upload = true"
+            inserted = 1
+            in_buck2 = 0
+        }
+        { print }
+        END {
+            if (saw_buck2 && !inserted) print "default_allow_cache_upload = true"
+            if (!saw_buck2) {
+                print ""
+                print "[buck2]"
+                print "default_allow_cache_upload = true"
+            }
+        }
+    ' "$central_config" >"$tmp"; then
+        rm -f "$tmp"
+        echo "error: could not prepare BuildBuddy config migration" >&2
+        return 1
+    fi
+    if ! chmod 600 "$tmp" || ! mv "$tmp" "$central_config"; then
+        rm -f "$tmp"
+        echo "error: could not install BuildBuddy config migration" >&2
+        return 1
+    fi
+    echo "Upgraded private BuildBuddy config with the Rust upload gate"
+}
+
+validate_config() {
+    migrate_config || return 1
     if ! grep -Eq '^[[:space:]]*default_allow_cache_upload[[:space:]]*=[[:space:]]*true([[:space:]]|$)' "$central_config"; then
-        echo "error: BuildBuddy config does not enable Rust action uploads; rerun scripts/provision-build-cache install" >&2
+        echo "error: BuildBuddy config does not enable Rust action uploads" >&2
         return 1
     fi
 }

--- a/scripts/rue
+++ b/scripts/rue
@@ -21,7 +21,8 @@
 #   scripts/rue ui [pattern]       UI/diagnostics tests, optional filter
 #   scripts/rue frontend-manifest  Refresh the audited frontend corpus manifest
 #   scripts/rue fmt                Format the code (./fmt.sh)
-#   scripts/rue gc                 Reclaim disk: drop buck-out artifacts unused for 1+ week
+#   scripts/rue storage [args...]  Inspect or reclaim Buck outputs across worktrees
+#   scripts/rue gc [age]           Compatibility alias for host-wide stale cleanup
 #   scripts/rue cache [args...]    Provision the shared BuildBuddy action cache
 #   scripts/rue path               Print the absolute binary path (build if needed)
 #
@@ -196,9 +197,10 @@ case "$cmd" in
         ./fmt.sh "$@"
         ;;
     gc)
-        # buck-out grows without bound; drop artifacts not used in the last
-        # week. An optional argument overrides the window: scripts/rue gc 1d
-        ./buck2 clean --stale "${1:-1w}"
+        scripts/rue-storage clean "${1:-1w}"
+        ;;
+    storage)
+        scripts/rue-storage "$@"
         ;;
     cache)
         scripts/provision-build-cache "$@"

--- a/scripts/rue-storage
+++ b/scripts/rue-storage
@@ -1,0 +1,165 @@
+#!/usr/bin/env bash
+# Inspect and reclaim Rue's rebuildable Buck outputs across this Git worktree
+# family. This script never removes a worktree or source file.
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd -P)"
+
+usage() {
+    cat <<'EOF'
+usage: scripts/rue-storage status
+       scripts/rue-storage plan [STALE_AGE]
+       scripts/rue-storage clean [STALE_AGE]
+       scripts/rue-storage reset RUE_ROOT [RUE_ROOT ...]
+
+status inventories every registered Rue worktree and its buck-out size. plan
+asks Buck what stale or untracked output it would remove. clean performs that
+coordinated stale cleanup (default age: 1w). reset fully removes Buck outputs
+only from the exact registered roots named by the caller. Source worktrees are
+never removed.
+EOF
+}
+
+collect_roots() {
+    local inventory
+    if ! inventory="$(git -C "$repo_root" worktree list --porcelain 2>/dev/null)"; then
+        echo "error: cannot inventory registered worktrees; refusing cleanup (fail-closed)" >&2
+        return 1
+    fi
+    awk '/^worktree / { sub(/^worktree /, ""); print }' <<<"$inventory"
+}
+
+is_rue_root() {
+    [[ -f "$1/.buckconfig" && -x "$1/buck2" ]]
+}
+
+size_kib() {
+    if [[ -d "$1/buck-out" ]]; then
+        du -sk "$1/buck-out" 2>/dev/null | awk '{print $1}'
+    else
+        printf '0\n'
+    fi
+}
+
+human_kib() {
+    awk -v kib="$1" 'BEGIN {
+        if (kib >= 1048576) printf "%.1f GiB", kib / 1048576;
+        else if (kib >= 1024) printf "%.1f MiB", kib / 1024;
+        else printf "%d KiB", kib;
+    }'
+}
+
+source_state() {
+    local out
+    if ! out="$(git -C "$1" status --porcelain 2>/dev/null)"; then
+        printf 'unknown'
+    elif [[ -n "$out" ]]; then
+        printf 'dirty'
+    else
+        printf 'clean'
+    fi
+}
+
+cache_state() {
+    local destination="$1/.buckconfig.local"
+    if [[ -L "$destination" && -e "$destination" ]]; then
+        printf 'shared'
+    elif [[ -e "$destination" || -L "$destination" ]]; then
+        printf 'custom'
+    else
+        printf 'off'
+    fi
+}
+
+registered_roots() {
+    local root roots
+    roots="$(collect_roots)" || return 1
+    while IFS= read -r root; do
+        [[ -n "$root" ]] || continue
+        if is_rue_root "$root"; then
+            printf '%s\n' "$root"
+        else
+            echo "warning: registered worktree is not a usable Rue checkout: $root" >&2
+        fi
+    done <<<"$roots"
+}
+
+status_all() {
+    local root kib roots total=0 count=0
+    roots="$(registered_roots)" || return 1
+    printf 'BUCK-OUT\tSOURCE\tCACHE\tWORKTREE\n'
+    while IFS= read -r root; do
+        kib="$(size_kib "$root")"
+        total=$((total + kib))
+        count=$((count + 1))
+        printf '%s\t%s\t%s\t%s\n' "$(human_kib "$kib")" "$(source_state "$root")" "$(cache_state "$root")" "$root"
+    done <<<"$roots"
+    printf 'Total: %s in %d registered Rue worktree(s)\n' "$(human_kib "$total")" "$count"
+    df -Pk "$repo_root" | awk 'NR == 2 { printf "Host filesystem: %s used, %.1f GiB available\n", $5, $4 / 1048576 }'
+}
+
+stale_all() {
+    local mode="$1" age="$2" root roots failed=0
+    roots="$(registered_roots)" || return 1
+    while IFS= read -r root; do
+        printf '\n%s: %s\n' "$mode" "$root"
+        if [[ "$mode" == plan ]]; then
+            (cd "$root" && ./buck2 clean --stale "$age" --dry-run) || failed=1
+        else
+            (cd "$root" && ./buck2 clean --stale "$age") || failed=1
+        fi
+    done <<<"$roots"
+    return "$failed"
+}
+
+canonical_registered_root() {
+    local requested="$1" canonical root roots
+    if ! canonical="$(cd "$requested" 2>/dev/null && pwd -P)"; then
+        echo "error: reset target is not a directory: $requested" >&2
+        return 1
+    fi
+    roots="$(registered_roots)" || return 1
+    while IFS= read -r root; do
+        [[ "$(cd "$root" && pwd -P)" == "$canonical" ]] && { printf '%s\n' "$root"; return 0; }
+    done <<<"$roots"
+    echo "error: reset target is not a registered Rue worktree: $requested" >&2
+    return 1
+}
+
+reset_roots() {
+    local requested root
+    # Resolve every target before cleaning any of them, so a typo cannot cause
+    # a partially applied reset.
+    local roots=()
+    for requested in "$@"; do
+        roots+=("$(canonical_registered_root "$requested")") || return 1
+    done
+    for root in "${roots[@]}"; do
+        printf 'reset: %s\n' "$root"
+        (cd "$root" && ./buck2 clean)
+    done
+}
+
+command="${1:-status}"
+shift || true
+case "$command" in
+    status)
+        [[ $# -eq 0 ]] || { usage >&2; exit 2; }
+        status_all
+        ;;
+    plan|clean)
+        [[ $# -le 1 ]] || { usage >&2; exit 2; }
+        stale_all "$command" "${1:-1w}"
+        ;;
+    reset)
+        [[ $# -gt 0 ]] || { usage >&2; exit 2; }
+        reset_roots "$@"
+        ;;
+    -h|--help|help)
+        usage
+        ;;
+    *)
+        usage >&2
+        exit 2
+        ;;
+esac

--- a/scripts/test-build-sharing.sh
+++ b/scripts/test-build-sharing.sh
@@ -41,10 +41,14 @@ http_headers = x-buildbuddy-api-key:$key
 EOF
     chmod 600 "$config"
     rc=0
-    HOME="$sb/home" XDG_CONFIG_HOME="$sb/config" \
-        "$SRC_ROOT/scripts/provision-build-cache" status "$sb/primary" >/dev/null 2>&1 || rc=$?
-    check "cache: pre-upload-gate configs require migration" \
-        "$([ "$rc" -ne 0 ] && echo 0 || echo 1)"
+    out="$(HOME="$sb/home" XDG_CONFIG_HOME="$sb/config" \
+        "$SRC_ROOT/scripts/provision-build-cache" apply "$sb/primary" "$sb/worktree" 2>&1)" || rc=$?
+    check "cache: private pre-upload-gate config migrates automatically" \
+        "$([ "$rc" -eq 0 ] && grep -Eq '^default_allow_cache_upload = true$' "$config" && echo 0 || echo 1)"
+    check "cache: migration preserves the credential without printing it" \
+        "$(grep -Fq "x-buildbuddy-api-key:$key" "$config" && [[ "$out" != *"$key"* ]] && echo 0 || echo 1)"
+    mode="$(stat -c '%a' "$config" 2>/dev/null || stat -f '%Lp' "$config")"
+    check "cache: migrated config remains private" "$([ $((8#$mode & 077)) -eq 0 ] && echo 0 || echo 1)"
 
     rc=0
     out="$(HOME="$sb/home" XDG_CONFIG_HOME="$sb/config" BUILDBUDDY_API_KEY="$key" \
@@ -85,6 +89,16 @@ EOF
     HOME="$sb/home" XDG_CONFIG_HOME="$sb/config" \
         "$SRC_ROOT/scripts/provision-build-cache" apply "$sb/primary" >/dev/null 2>&1 || rc=$?
     check "cache: insecure central permissions fail closed" "$([ "$rc" -ne 0 ] && echo 0 || echo 1)"
+
+    chmod 600 "$config"
+    sed 's/default_allow_cache_upload = true/default_allow_cache_upload = false/' "$config" >"$config.disabled"
+    mv "$config.disabled" "$config"
+    chmod 600 "$config"
+    rc=0
+    HOME="$sb/home" XDG_CONFIG_HOME="$sb/config" \
+        "$SRC_ROOT/scripts/provision-build-cache" apply "$sb/primary" >/dev/null 2>&1 || rc=$?
+    check "cache: an explicit upload opt-out is never rewritten" \
+        "$([ "$rc" -ne 0 ] && grep -Eq '^default_allow_cache_upload = false$' "$config" && echo 0 || echo 1)"
     rm -rf "$sb"
 }
 

--- a/scripts/test-cleanup-scripts.sh
+++ b/scripts/test-cleanup-scripts.sh
@@ -1,18 +1,12 @@
 #!/usr/bin/env bash
-# test-cleanup-scripts.sh — fail-closed regression tests for the destructive
-# maintenance scripts jj-tidy and worktree-gc (RUE-567).
+# test-cleanup-scripts.sh — fail-closed regression tests for maintenance
+# scripts jj-tidy and rue-storage (RUE-567, RUE-1225).
 #
-# Both scripts perform irreversible operations (remote branch deletion,
-# `rm -rf`) driven by Git/GitHub inventory. The bug these tests pin: treating a
-# FAILED or incomplete inventory query as proof that a resource is stale, so a
-# `gh`/`git` failure — or a branch merely absent from one user's open-PR list —
-# caused live resources to be destroyed.
+# jj-tidy performs remote branch deletion. rue-storage only deletes rebuildable
+# Buck outputs, but it still refuses to infer targets from a failed inventory.
 #
-# Each test runs a COPY of the real script in a throwaway sandbox with fake
-# `gh`/`git`/`jj`/`df`/`buck2` on PATH, so no real repo, remote, or disk is
-# touched. The fakes log every invocation; we assert that destructive commands
-# (`git push --delete`, `rm -rf`) are or are not issued as the fail-closed
-# contract requires.
+# Each test runs a copy of the real script in a throwaway sandbox with fake
+# tools, so no real repo, remote, or Buck output is touched.
 set -uo pipefail
 
 # Directory holding the scripts under test. Under buck2 sh_test this is the
@@ -175,87 +169,80 @@ EOF
 }
 
 # ===========================================================================
-# worktree-gc — worktree removal must be fail-closed
+# rue-storage — Buck cleanup must be host-wide and fail-closed
 # ===========================================================================
 
-# Common fakes: df reports high usage (past threshold) so step 2 runs; buck2 and
-# jj no-op. Real `rm`/`git` behavior is per-test.
-setup_gc_common() {
-  local sb="$1"
-  fake "$sb" df 'echo "Use% "; echo "99%"'
-  fake "$sb" buck2 'true'
-  mkdir -p "$sb/.claude/worktrees/live-1" "$sb/.claude/worktrees/live-2"
+setup_storage_root() {
+  local root="$1"
+  mkdir -p "$root/buck-out"
+  : >"$root/.buckconfig"
+  cat >"$root/buck2" <<'EOF'
+#!/usr/bin/env bash
+printf '%s:%s\n' "$PWD" "$*" >>"$CALLS"
+EOF
+  chmod +x "$root/buck2"
 }
 
-# Test 3: `git worktree list` FAILS (exit 128) -> no worktree dir removed.
-test_gc_git_failure_preserves_worktrees() {
-  local sb; sb="$(make_sandbox worktree-gc)"
-  setup_gc_common "$sb"
+test_storage_git_failure_is_fail_closed() {
+  local sb rc=0; sb="$(make_sandbox rue-storage)"
+  : >"$sb/.buckconfig"
+  printf '#!/bin/sh\nexit 0\n' >"$sb/buck2"; chmod +x "$sb/buck2"
   cat >"$sb/fakebin/git" <<'EOF'
 #!/usr/bin/env bash
 printf 'git ' >>"$CALLS"; printf '%s\n' "$*" >>"$CALLS"
-case "$1 $2" in
-  "worktree prune") exit 0 ;;
-  "worktree list") exit 128 ;;   # jj workspace w/o local .git
-esac
-exit 0
+exit 128
 EOF
   chmod +x "$sb/fakebin/git"
-
-  run_script "$sb" worktree-gc
-  if [ -d "$sb/.claude/worktrees/live-1" ] && [ -d "$sb/.claude/worktrees/live-2" ]; then
-    check "worktree-gc: git-list failure preserves ALL worktrees" 0
-  else
-    check "worktree-gc: git-list failure preserves ALL worktrees" 1
-  fi
-  grep -q 'fail-closed' "$sb/out.log" || fail "worktree-gc: expected fail-closed notice on git failure"
+  run_script "$sb" rue-storage clean || rc=$?
+  check "storage: failed inventory refuses cleanup" "$([ "$rc" -ne 0 ] && echo 0 || echo 1)"
+  check "storage: failed inventory invokes no Buck cleaner" "$(! grep -q ':clean ' "$sb/calls.log" && echo 0 || echo 1)"
+  grep -q 'fail-closed' "$sb/out.log" || fail "storage: expected fail-closed notice on git failure"
   rm -rf "$sb"
 }
 
-# Test 4 (positive control): git succeeds and lists live-1 as active; live-2 is
-# absent -> only the genuinely-orphaned live-2 is removed.
-test_gc_removes_only_orphans_when_git_ok() {
-  local sb; sb="$(make_sandbox worktree-gc)"
-  setup_gc_common "$sb"
-  # Emit live-1's absolute path as an active worktree; omit live-2.
+test_storage_plans_every_registered_root() {
+  local sb; sb="$(make_sandbox rue-storage)"
+  setup_storage_root "$sb/root-1"
+  setup_storage_root "$sb/root-2"
   cat >"$sb/fakebin/git" <<EOF
 #!/usr/bin/env bash
 printf 'git ' >>"\$CALLS"; printf '%s\n' "\$*" >>"\$CALLS"
-case "\$1 \$2" in
-  "worktree prune") exit 0 ;;
-  "worktree list") printf 'worktree %s/.claude/worktrees/live-1\n' "$sb"; exit 0 ;;
-esac
-exit 0
+if [[ "\$*" == *"worktree list --porcelain"* ]]; then
+  printf 'worktree %s/root-1\n\nworktree %s/root-2\n' "$sb" "$sb"
+  exit 0
+fi
+exit 1
 EOF
   chmod +x "$sb/fakebin/git"
-
-  run_script "$sb" worktree-gc
-  if [ -d "$sb/.claude/worktrees/live-1" ]; then
-    check "worktree-gc: active worktree kept when git succeeds" 0
-  else
-    check "worktree-gc: active worktree kept when git succeeds" 1
-  fi
-  if [ -d "$sb/.claude/worktrees/live-2" ]; then
-    check "worktree-gc: genuinely-orphaned worktree removed" 1
-  else
-    check "worktree-gc: genuinely-orphaned worktree removed" 0
-  fi
+  run_script "$sb" rue-storage plan 2d
+  check "storage: dry-run covers every registered Rue worktree" \
+    "$([ "$(grep -c ':clean --stale 2d --dry-run' "$sb/calls.log")" -eq 2 ] && echo 0 || echo 1)"
+  check "storage: dry-run never performs a full reset" \
+    "$(! grep -Eq ':clean$' "$sb/calls.log" && echo 0 || echo 1)"
   rm -rf "$sb"
 }
 
-# Test 5: disk below threshold -> step 2 never runs, nothing removed.
-test_gc_below_threshold_is_noop() {
-  local sb; sb="$(make_sandbox worktree-gc)"
-  fake "$sb" df 'echo "Use% "; echo "10%"'
-  fake "$sb" buck2 'true'
-  fake "$sb" git 'true'
-  mkdir -p "$sb/.claude/worktrees/live-1"
-  run_script "$sb" worktree-gc
-  if [ -d "$sb/.claude/worktrees/live-1" ]; then
-    check "worktree-gc: below threshold removes nothing" 0
-  else
-    check "worktree-gc: below threshold removes nothing" 1
-  fi
+test_storage_reset_validates_all_targets_first() {
+  local sb rc=0; sb="$(make_sandbox rue-storage)"
+  setup_storage_root "$sb/root-1"
+  cat >"$sb/fakebin/git" <<EOF
+#!/usr/bin/env bash
+if [[ "\$*" == *"worktree list --porcelain"* ]]; then
+  printf 'worktree %s/root-1\n' "$sb"
+  exit 0
+fi
+exit 1
+EOF
+  chmod +x "$sb/fakebin/git"
+  run_script "$sb" rue-storage reset "$sb/root-1" "$sb/not-registered" || rc=$?
+  check "storage: reset rejects an unregistered target" "$([ "$rc" -ne 0 ] && echo 0 || echo 1)"
+  check "storage: reset validates every target before deleting output" \
+    "$(! grep -Eq ':clean$' "$sb/calls.log" 2>/dev/null && echo 0 || echo 1)"
+
+  : >"$sb/calls.log"
+  run_script "$sb" rue-storage reset "$sb/root-1"
+  check "storage: exact registered target can be reset" \
+    "$(grep -Eq ':clean$' "$sb/calls.log" && echo 0 || echo 1)"
   rm -rf "$sb"
 }
 
@@ -263,9 +250,9 @@ test_gc_below_threshold_is_noop() {
 
 test_jjtidy_gh_failure_deletes_nothing
 test_jjtidy_only_deletes_proven_merged
-test_gc_git_failure_preserves_worktrees
-test_gc_removes_only_orphans_when_git_ok
-test_gc_below_threshold_is_noop
+test_storage_git_failure_is_fail_closed
+test_storage_plans_every_registered_root
+test_storage_reset_validates_all_targets_first
 
 echo "--------------------------------------------------"
 if [ "$FAILURES" -eq 0 ]; then

--- a/scripts/worktree-gc
+++ b/scripts/worktree-gc
@@ -1,62 +1,10 @@
 #!/usr/bin/env bash
-# worktree-gc — reclaim disk from workflow worktrees, SAFELY.
-#
-# Replaces the old blanket `rm -rf .claude/worktrees`, which raced running
-# workers (they reported "worktree deleted mid-run"). This only acts when disk
-# is actually low, and only removes worktrees git no longer lists as live — so
-# in-flight workers are never touched. Removal is FAIL CLOSED (RUE-567): if the
-# `git worktree list` inventory command fails (e.g. a jj workspace with no local
-# .git, where it exits 128), nothing is removed — a failed query is never read
-# as "zero active worktrees".
-#
-# Usage: scripts/worktree-gc [THRESHOLD_PERCENT]   (default 85)
-set -uo pipefail
-cd "$(dirname "$0")/.."
-THRESHOLD=${1:-85}
-
-used=$(df --output=pcent . 2>/dev/null | tail -1 | tr -dc '0-9')
-used=${used:-0}
-if [ "$used" -lt "$THRESHOLD" ]; then
-  echo "worktree-gc: disk ${used}% < ${THRESHOLD}% — nothing to do"
-  exit 0
+# Compatibility entry point. Worktree deletion is deliberately no longer a
+# disk-management side effect; only Buck's rebuildable outputs are reclaimed.
+set -euo pipefail
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+if [[ $# -gt 0 ]]; then
+    echo "warning: the legacy disk-percentage argument is ignored" >&2
 fi
-echo "worktree-gc: disk ${used}% >= ${THRESHOLD}% — reclaiming"
-
-# 1. Prune admin entries for worktrees whose directory is already gone.
-git worktree prune 2>/dev/null || true
-
-# 2. Remove ORPHANED worktree dirs — present on disk but no longer in git's live
-#    list (i.e. a finished worker's leftover, holding a stale buck-out). Anything
-#    git still lists is live and left alone. This is where the disk actually is.
-#
-#    FAIL CLOSED (RUE-567): a FAILED `git worktree list` is not the same as an
-#    empty one. In a linked jj workspace with no local `.git`, `git worktree
-#    list` exits 128; if that failure were read as "zero active worktrees",
-#    every live worker's dir would be classified orphaned and rm -rf'd. So gate
-#    on the command's real exit status — proceed only when it SUCCEEDS, and skip
-#    removal entirely otherwise.
-if [ -d .claude/worktrees ]; then
-  if wt_porcelain="$(git worktree list --porcelain 2>/dev/null)"; then
-    active="$(printf '%s\n' "$wt_porcelain" | awk '/^worktree /{print $2}')"
-    for d in .claude/worktrees/*/; do
-      [ -d "$d" ] || continue
-      d="${d%/}"
-      abs="$(cd "$d" 2>/dev/null && pwd)" || continue
-      # Herestring, not a pipe: under `pipefail` a matching `grep -q` kills the
-      # producer with EPIPE and the pipeline reports failure. This test is
-      # negated and guards an `rm -rf`, so that inversion would delete a live
-      # worktree precisely because it IS active (RUE-1155).
-      if ! grep -qxF "$abs" <<<"$active"; then
-        rm -rf "${d:?}" && echo "  removed orphaned worktree ${d##*/}"
-      fi
-    done
-  else
-    echo "worktree-gc: 'git worktree list' failed — skipping worktree removal (fail-closed)"
-  fi
-fi
-
-# 3. Stale main-repo buck artifacts (safe; rebuilds on demand).
-./buck2 clean --stale 1h >/dev/null 2>&1 || true
-
-now=$(df --output=pcent . 2>/dev/null | tail -1 | tr -dc '0-9')
-echo "worktree-gc: done — disk now ${now:-?}%"
+echo "worktree-gc: worktree removal retired; cleaning stale Buck outputs host-wide"
+exec "$repo_root/scripts/rue-storage" clean 1w


### PR DESCRIPTION
## Summary

- add a host-wide storage command that inventories every registered Rue worktree and delegates stale cleanup to Buck
- provide a fail-closed, exact-root reset escape hatch without deleting source trees
- enable persisted deferred-materializer state and automatic one-week stale cleanup
- migrate secure legacy shared-cache configs without exposing credentials
- retire automatic worktree deletion from the legacy cleanup entry point

## Validation

- `scripts/rue quick`
- `./buck2 test //:cleanup-script-tests //:build-sharing-tests //:wrapper-script-tests`
- `scripts/rue fmt`
- canonical premerge run: 77 targets passed; one spec action hit eight 10-second process timeouts while another workspace ran the full suite
- each timed-out spec case passed alone in 0.25–0.34 seconds

Contributes to RUE-1225.

Remaining issue scope: an adaptive host low-disk trigger/aggregate bound and toolchain-payload slimming.