### PR TITLE
RUE-1246: factor retained compiler host

### DIFF
--- a/crates/rue-compiler/src/pipeline_tests.rs
+++ b/crates/rue-compiler/src/pipeline_tests.rs
@@ -1283,6 +1283,82 @@ mod tests {
     }
 
     #[test]
+    fn retained_endpoint_capabilities_stop_and_continue_at_canonical_boundaries() {
+        let snapshot = SourceSnapshot::single(
+            "<retained-endpoints>",
+            "fn helper() -> i32 { 41 } fn main() -> i32 { helper() + 1 }",
+        )
+        .unwrap();
+        let options = CompileOptions::default();
+        let mut session = CompilerSession::new();
+        crate::test_support::TestDiscoveryHost::new(&snapshot)
+            .unwrap()
+            .drive(&mut session)
+            .unwrap();
+
+        let codegen = crate::unstable::codegen_ready(&mut session, &options).unwrap();
+        assert_eq!(session.codegen_collections(), 2);
+        assert!(
+            session.object_projection_executions().is_empty(),
+            "codegen-ready must not begin object projection"
+        );
+        assert_eq!(session.object_projection_collections(), 0);
+
+        let objects = crate::unstable::objects_ready(&mut session, codegen).unwrap();
+        assert_eq!(session.object_projection_collections(), 2);
+        let retained = crate::unstable::runnable_ready(&mut session, objects).unwrap();
+
+        let mut fresh = CompilerSession::new();
+        crate::test_support::TestDiscoveryHost::new(&snapshot)
+            .unwrap()
+            .drive(&mut fresh)
+            .unwrap();
+        let oracle = fresh.executable(&options).unwrap();
+        assert_eq!(retained.elf, oracle.elf);
+        assert_eq!(retained.warnings, oracle.warnings);
+    }
+
+    #[test]
+    fn retained_endpoint_capabilities_reject_another_session_or_revision() {
+        let snapshot =
+            SourceSnapshot::single("<retained-endpoint-owner>", "fn main() -> i32 { 42 }").unwrap();
+        let options = CompileOptions::default();
+
+        let mut first = CompilerSession::new();
+        crate::test_support::TestDiscoveryHost::new(&snapshot)
+            .unwrap()
+            .drive(&mut first)
+            .unwrap();
+        let wrong_owner = crate::unstable::codegen_ready(&mut first, &options).unwrap();
+
+        let mut second = CompilerSession::new();
+        crate::test_support::TestDiscoveryHost::new(&snapshot)
+            .unwrap()
+            .drive(&mut second)
+            .unwrap();
+        let wrong_owner_error = match crate::unstable::objects_ready(&mut second, wrong_owner) {
+            Err(errors) => errors,
+            Ok(_) => panic!("another session accepted a foreign endpoint capability"),
+        };
+        assert!(
+            wrong_owner_error
+                .to_string()
+                .contains("another compiler session")
+        );
+
+        let stale = crate::unstable::codegen_ready(&mut first, &options).unwrap();
+        crate::test_support::TestDiscoveryHost::new(&snapshot)
+            .unwrap()
+            .drive(&mut first)
+            .unwrap();
+        let stale_error = match crate::unstable::objects_ready(&mut first, stale) {
+            Err(errors) => errors,
+            Ok(_) => panic!("a newer revision accepted a stale endpoint capability"),
+        };
+        assert!(stale_error.to_string().contains("stale"));
+    }
+
+    #[test]
     fn retained_object_projection_is_local_bounded_and_released_with_the_backend_root() {
         const FUNCTIONS: usize = 32;
         let options = CompileOptions::default();

--- a/crates/rue-compiler/src/queries.rs
+++ b/crates/rue-compiler/src/queries.rs
@@ -1138,7 +1138,7 @@ impl CompilerSession {
         compile_with_session(self, &snapshot, options)
     }
 
-    fn committed_snapshot_for_executable(&self) -> MultiErrorResult<SourceSnapshot> {
+    pub(crate) fn committed_snapshot_for_executable(&self) -> MultiErrorResult<SourceSnapshot> {
         let snapshot = self
             .committed_import_discovery_artifact()
             .ok_or_else(|| {
@@ -1189,6 +1189,21 @@ pub(crate) fn compile_with_session(
     snapshot: &SourceSnapshot,
     options: &CompileOptions,
 ) -> MultiErrorResult<CompileOutput> {
+    let _span = info_span!("compile_pipeline").entered();
+    let rooted = session.rooted_codegen(options, rue_codegen::BackendArtifactRequest::default())?;
+    compile_rooted_with_session(session, snapshot, options, rooted)
+}
+
+/// Finish a canonical compilation from the exact objects-ready continuation
+/// issued by this session. Used by the retained host's unstable endpoint API;
+/// the ordinary one-shot adapter reaches the same helper through
+/// [`compile_with_session`].
+pub(crate) fn compile_rooted_with_session(
+    session: &mut CompilerSession,
+    snapshot: &SourceSnapshot,
+    options: &CompileOptions,
+    rooted: crate::session::RootedCodegenOutput,
+) -> MultiErrorResult<CompileOutput> {
     let source_tokens = session
         .published_owner()
         .filter(|program| program.belongs_to_exact_snapshot(snapshot))
@@ -1199,9 +1214,6 @@ pub(crate) fn compile_with_session(
             )))
         })?;
     let total_source_bytes: usize = snapshot.files().map(|source| source.source.len()).sum();
-    let _span = info_span!("compile_pipeline").entered();
-
-    let rooted = session.rooted_codegen(options, rue_codegen::BackendArtifactRequest::default())?;
     let session_work = session.work().clone();
     let image = crate::program_image_plan::ProgramImage::from_rooted(
         rooted.objects,

--- a/crates/rue-compiler/src/session.rs
+++ b/crates/rue-compiler/src/session.rs
@@ -893,6 +893,20 @@ pub(crate) struct RootedCodegenOutput {
     pub(crate) work: crate::CanonicalSemanticWork,
 }
 
+/// Opaque in-crate continuation between the canonical codegen-ready and
+/// objects-ready endpoints. The unpublished backend-root candidate keeps the
+/// exact CFG and CodegenUnit cones protected until object projection can
+/// atomically publish their successor root.
+pub(crate) struct RootedCodegenReadyOutput {
+    graph: RootedBodyGraph,
+    units: Vec<crate::codegen_query::CollectedCodegenUnit>,
+    cfgs: Vec<RootedCfgUnit>,
+    warnings: Vec<CompileWarning>,
+    work: crate::CanonicalSemanticWork,
+    backend_root: crate::revisioned_query_database::BackendRootCandidate,
+    codegen_batch_key: crate::revisioned_query_database::CodegenUnitBatchKey,
+}
+
 #[derive(Debug, Clone)]
 struct RootedBodyGraph {
     revision: rue_query::Revision,
@@ -2993,6 +3007,14 @@ impl CompilerSession {
     }
     pub(crate) fn work(&self) -> &CompilerSessionWork {
         self.metrics.work()
+    }
+
+    pub(crate) fn endpoint_capability_owner(&self) -> Arc<()> {
+        self.identity.clone()
+    }
+
+    pub(crate) fn endpoint_capability_generation(&self) -> usize {
+        self.metrics.work().updates
     }
     /// Return an owned snapshot of explicitly unstable compiler metrics.
     ///
@@ -5118,6 +5140,17 @@ impl CompilerSession {
         options: &CompileOptions,
         request: rue_codegen::BackendArtifactRequest,
     ) -> Result<RootedCodegenOutput, CompileErrors> {
+        let ready = self.rooted_codegen_ready(options, request)?;
+        self.rooted_objects_ready(ready)
+    }
+
+    /// Collect the rooted reached set's canonical CodegenUnits while retaining
+    /// the exact unpublished backend-root candidate for object projection.
+    pub(crate) fn rooted_codegen_ready(
+        &mut self,
+        options: &CompileOptions,
+        request: rue_codegen::BackendArtifactRequest,
+    ) -> Result<RootedCodegenReadyOutput, CompileErrors> {
         let RootedCfgOutput {
             graph,
             cfgs,
@@ -5224,6 +5257,32 @@ impl CompilerSession {
             }
         }
         drop(_codegen_collection_span);
+        Ok(RootedCodegenReadyOutput {
+            graph,
+            units,
+            cfgs,
+            warnings,
+            work,
+            backend_root,
+            codegen_batch_key,
+        })
+    }
+
+    /// Continue one compiler-issued codegen-ready capability through retained
+    /// per-unit object projection and atomically publish the backend root.
+    pub(crate) fn rooted_objects_ready(
+        &mut self,
+        ready: RootedCodegenReadyOutput,
+    ) -> Result<RootedCodegenOutput, CompileErrors> {
+        let RootedCodegenReadyOutput {
+            graph,
+            units,
+            cfgs,
+            warnings,
+            work,
+            mut backend_root,
+            codegen_batch_key,
+        } = ready;
         let object_keys = codegen_batch_key
             .keys
             .iter()

--- a/crates/rue-compiler/src/unstable.rs
+++ b/crates/rue-compiler/src/unstable.rs
@@ -510,6 +510,99 @@ pub fn executable_in_compile_scope(
     session.executable_in_compile_scope(options)
 }
 
+/// Opaque continuation at ADR-0068's codegen-ready endpoint.
+///
+/// It owns the unpublished backend-root protection acquired with the rooted
+/// CodegenUnit collection. Callers can only advance it through
+/// [`objects_ready`]; compiler query keys and mutable IR stay private.
+pub struct CodegenReady {
+    rooted: crate::session::RootedCodegenReadyOutput,
+    snapshot: crate::SourceSnapshot,
+    options: crate::CompileOptions,
+    owner: std::sync::Arc<()>,
+    generation: usize,
+}
+
+/// Opaque continuation at ADR-0068's objects-ready endpoint.
+pub struct ObjectsReady {
+    rooted: crate::session::RootedCodegenOutput,
+    snapshot: crate::SourceSnapshot,
+    options: crate::CompileOptions,
+    owner: std::sync::Arc<()>,
+    generation: usize,
+}
+
+fn validate_endpoint_capability(
+    session: &crate::CompilerSession,
+    owner: &std::sync::Arc<()>,
+    generation: usize,
+) -> crate::MultiErrorResult<()> {
+    if !std::sync::Arc::ptr_eq(owner, &session.endpoint_capability_owner()) {
+        return Err(crate::CompileErrors::from(
+            crate::CompileError::without_span(crate::ErrorKind::InvalidCompilerInput(
+                "retained endpoint capability belongs to another compiler session".into(),
+            )),
+        ));
+    }
+    if generation != session.endpoint_capability_generation() {
+        return Err(crate::CompileErrors::from(
+            crate::CompileError::without_span(crate::ErrorKind::InvalidCompilerInput(
+                "retained endpoint capability is stale after a newer source revision".into(),
+            )),
+        ));
+    }
+    Ok(())
+}
+
+/// Drive a closed retained session through rooted CodegenUnit collection only.
+/// Object projection and linking do not run before this function returns.
+pub fn codegen_ready(
+    session: &mut crate::CompilerSession,
+    options: &crate::CompileOptions,
+) -> crate::MultiErrorResult<CodegenReady> {
+    let snapshot = session.committed_snapshot_for_executable()?;
+    let rooted =
+        session.rooted_codegen_ready(options, rue_codegen::BackendArtifactRequest::default())?;
+    Ok(CodegenReady {
+        rooted,
+        snapshot,
+        options: options.clone(),
+        owner: session.endpoint_capability_owner(),
+        generation: session.endpoint_capability_generation(),
+    })
+}
+
+/// Consume a compiler-issued codegen-ready continuation and collect its exact
+/// retained object projections.
+pub fn objects_ready(
+    session: &mut crate::CompilerSession,
+    ready: CodegenReady,
+) -> crate::MultiErrorResult<ObjectsReady> {
+    validate_endpoint_capability(session, &ready.owner, ready.generation)?;
+    let rooted = session.rooted_objects_ready(ready.rooted)?;
+    Ok(ObjectsReady {
+        rooted,
+        snapshot: ready.snapshot,
+        options: ready.options,
+        owner: ready.owner,
+        generation: ready.generation,
+    })
+}
+
+/// Consume an objects-ready continuation and perform the canonical fresh link.
+pub fn runnable_ready(
+    session: &mut crate::CompilerSession,
+    ready: ObjectsReady,
+) -> crate::MultiErrorResult<crate::CompileOutput> {
+    validate_endpoint_capability(session, &ready.owner, ready.generation)?;
+    crate::queries::compile_rooted_with_session(
+        session,
+        &ready.snapshot,
+        &ready.options,
+        ready.rooted,
+    )
+}
+
 /// Drive this session through the pre-link boundary (RIR → semantic → CFG →
 /// codegen → object generation) without linking, returning the total generated
 /// object-byte count. Used by the RUE-1086 scaling-bench runner to time a

--- a/crates/rue/BUCK
+++ b/crates/rue/BUCK
@@ -1,4 +1,4 @@
-load("//crates:defs.bzl", "rue_binary")
+load("//crates:defs.bzl", "rue_binary", "rue_crate")
 
 _DEPS = [
     "//crates/rue-compiler:rue-compiler",
@@ -22,9 +22,24 @@ export_file(
     visibility = ["PUBLIC"],
 )
 
+# Reusable filesystem/project host shared by the one-shot CLI, retained edit
+# measurements, and later long-lived product modes.
+rue_crate(
+    name = "rue-driver",
+    crate_root = "src/lib.rs",
+    deps = _DEPS,
+    rustc_flags = [
+        "--check-cfg=cfg(rue_benchmark_allocations)",
+        "--check-cfg=cfg(test)",
+    ],
+)
+
 rue_binary(
     name = "rue",
-    deps = _DEPS,
+    crate_root = "src/main.rs",
+    deps = _DEPS + [
+        ":rue-driver",
+    ],
     test_deps = [
         "//crates/rue-query:rue-query",
     ],
@@ -38,7 +53,10 @@ rue_binary(
 # isolated from the production compiler target.
 rue_binary(
     name = "rue-benchmark",
-    deps = _DEPS,
+    crate_root = "src/main.rs",
+    deps = _DEPS + [
+        ":rue-driver",
+    ],
     rustc_flags = [
         "--cfg=rue_benchmark_allocations",
         "--check-cfg=cfg(rue_benchmark_allocations)",

--- a/crates/rue/src/compile.rs
+++ b/crates/rue/src/compile.rs
@@ -1,11 +1,12 @@
-use rue_compiler::unstable::{OneShotMetrics, executable_in_compile_scope};
-use rue_compiler::{CompileErrors, CompileOptions, CompileWarning, CompilerSession};
+use rue_compiler::unstable::OneShotMetrics;
+use rue_compiler::{CompileErrors, CompileOptions, CompileWarning};
+use rue_driver::FilesystemCompilerHost;
 
 use crate::output::{PublicationDestination, PublishRequest, publish_executable};
 
 /// Typed ownership boundary for the compile/link/publish operation.
 pub(crate) struct CompileRequest<'a> {
-    pub(crate) session: &'a mut CompilerSession,
+    pub(crate) host: &'a mut FilesystemCompilerHost,
     pub(crate) options: CompileOptions,
     pub(crate) destination: PublicationDestination,
 }
@@ -30,7 +31,7 @@ pub(crate) struct PublicationAttempt {
 
 /// Execute the canonical compiler session through linking.
 pub(crate) fn execute(request: CompileRequest<'_>) -> Result<LinkedExecutable, CompileErrors> {
-    let output = executable_in_compile_scope(request.session, &request.options)?;
+    let output = request.host.executable_in_compile_scope(&request.options)?;
     let metrics = output.unstable_metrics();
     Ok(LinkedExecutable {
         target: request.options.target,

--- a/crates/rue/src/emit.rs
+++ b/crates/rue/src/emit.rs
@@ -6,11 +6,11 @@ use rue_compiler::unstable::update_for_presentation;
 use rue_compiler::unstable::{LowerMetrics, ParseMetrics, SemanticMetrics, semantic_metrics};
 use rue_compiler::unstable::{PresentationRequest, PresentationStage};
 #[cfg(test)]
-use rue_compiler::{CompileErrors, RirView};
+use rue_compiler::{CompileErrors, CompilerSession, RirView, SourceSnapshot};
 use rue_compiler::{
-    CompileOptions, CompilerSession, DependencyEnvelope, DependencyEnvelopeStatus,
-    ImportDiscoveryStatus, ImportDiscoveryView, SourceSnapshot,
+    CompileOptions, DependencyEnvelope, DependencyEnvelopeStatus, ImportDiscoveryStatus,
 };
+use rue_driver::FilesystemCompilerHost;
 #[cfg(test)]
 use rue_error::{CompileError, ErrorKind};
 #[cfg(test)]
@@ -225,23 +225,22 @@ pub(crate) fn validate_output_modes(
 /// For early stages (tokens, ast), each file is processed and labeled individually.
 /// For later stages (rir, air, cfg, etc.), the merged program is used.
 pub(crate) struct EmitRequest<'a, 'diagnostics> {
-    pub(crate) source_snapshot: &'a SourceSnapshot,
-    pub(crate) session: &'a mut CompilerSession,
+    pub(crate) host: &'a mut FilesystemCompilerHost,
     pub(crate) stages: &'a [EmitStage],
-    pub(crate) discovery_revision: &'a ImportDiscoveryView,
     pub(crate) compile_options: CompileOptions,
     pub(crate) diagnostics: &'a DiagnosticOutput<'diagnostics>,
 }
 
 pub(crate) fn execute(request: EmitRequest<'_, '_>) -> Result<(), ()> {
     let EmitRequest {
-        source_snapshot,
-        session,
+        host,
         stages,
-        discovery_revision,
         compile_options,
         diagnostics,
     } = request;
+
+    let source_snapshot = host.source_snapshot().clone();
+    let discovery_revision = host.discovery_revision().clone();
 
     if stages.contains(&EmitStage::Deps) {
         // `validate_output_modes` already rejected `--emit deps` mixed with any
@@ -251,7 +250,7 @@ pub(crate) fn execute(request: EmitRequest<'_, '_>) -> Result<(), ()> {
             1,
             "validate_output_modes must reject --emit deps combined with other stages"
         );
-        let dependency_envelope = DependencyEnvelope::from_closed_revision(discovery_revision)
+        let dependency_envelope = DependencyEnvelope::from_closed_revision(&discovery_revision)
             .expect("closed valid or resolution-incomplete discovery has dependency topology");
         let incomplete = dependency_envelope.status == DependencyEnvelopeStatus::Incomplete;
         match serde_json::to_string_pretty(&dependency_envelope) {
@@ -284,7 +283,7 @@ pub(crate) fn execute(request: EmitRequest<'_, '_>) -> Result<(), ()> {
             // a reached fallible intrinsic. Semantic-only diagnostics (e.g. an
             // undefined variable) belong to a normal build or a later `--emit`
             // stage, not to the untyped-IR presentation.
-            if let Err(errors) = session.rir() {
+            if let Err(errors) = host.rir() {
                 diagnostics.print_errors(&errors);
                 return Err(());
             }
@@ -320,7 +319,7 @@ pub(crate) fn execute(request: EmitRequest<'_, '_>) -> Result<(), ()> {
                     EmitStage::Ast => println!("=== AST ({}) ===", source.path),
                     _ => unreachable!(),
                 }
-                let output = match session.unstable_present(PresentationRequest {
+                let output = match host.present(PresentationRequest {
                     stage: unstable_stage,
                     options: &compile_options,
                     file_order: &[source.file_id],
@@ -336,7 +335,7 @@ pub(crate) fn execute(request: EmitRequest<'_, '_>) -> Result<(), ()> {
             }
             continue;
         }
-        let output = match session.unstable_present(PresentationRequest {
+        let output = match host.present(PresentationRequest {
             stage: unstable_stage,
             options: &compile_options,
             file_order: &file_order,

--- a/crates/rue/src/host.rs
+++ b/crates/rue/src/host.rs
@@ -1,0 +1,313 @@
+use std::path::Path;
+
+use rue_compiler::unstable::{
+    CodegenReady, ObjectsReady, PresentationOutput, PresentationRequest, codegen_ready,
+    executable_in_compile_scope, objects_ready, runnable_ready,
+};
+use rue_compiler::{
+    AcceptedReadManifest, CompileOptions, CompileOutput, ImportDiscoveryContext,
+    ImportDiscoveryStatus, ImportDiscoveryView, MultiErrorResult, RirView, SourceSnapshot,
+};
+
+use crate::source_loader::{
+    ImportDiscoveryResult, SourceLoadError, SourceLoadRequest, acquire_reached_toolchain_modules,
+    load, reload_from_filesystem,
+};
+
+/// Immutable filesystem configuration captured when a retained host opens.
+pub struct HostOpenRequest<'a> {
+    pub root_source: &'a str,
+    pub source_manifest_path: Option<&'a str>,
+    pub std_root: Option<&'a Path>,
+}
+
+/// One canonical filesystem observer and retained compiler session.
+pub struct FilesystemCompilerHost {
+    state: ImportDiscoveryResult,
+}
+
+impl FilesystemCompilerHost {
+    /// Open a root source and drive parser-owned import discovery to closure.
+    pub fn open(request: HostOpenRequest<'_>) -> Result<Self, SourceLoadError> {
+        load(SourceLoadRequest {
+            root_source: request.root_source,
+            source_manifest_path: request.source_manifest_path,
+            std_root: request.std_root,
+        })
+        .map(|state| Self { state })
+    }
+
+    /// Re-observe the exact accepted-read closure and publish its successor.
+    pub fn reobserve(&mut self) -> Result<(), SourceLoadError> {
+        reload_from_filesystem(&mut self.state)
+    }
+
+    /// Satisfy compiler-issued reached-body toolchain demands for this revision.
+    pub fn acquire_reached_toolchain_modules(
+        &mut self,
+        options: &CompileOptions,
+    ) -> Result<(), SourceLoadError> {
+        acquire_reached_toolchain_modules(&mut self.state, options)
+    }
+
+    pub fn source_snapshot(&self) -> &SourceSnapshot {
+        &self.state.source_snapshot
+    }
+
+    pub fn discovery_revision(&self) -> &ImportDiscoveryView {
+        &self.state.revision
+    }
+
+    pub fn discovery_status(&self) -> ImportDiscoveryStatus {
+        self.state.revision.status()
+    }
+
+    pub fn accepted_reads(&self) -> &AcceptedReadManifest {
+        &self.state.read_manifest
+    }
+
+    pub fn root_path(&self) -> &Path {
+        &self.state.resolution.root_path
+    }
+
+    pub fn discovery_context(&self) -> &ImportDiscoveryContext {
+        &self.state.resolution.context
+    }
+
+    /// Query RIR through the retained session for the CLI presentation path.
+    pub fn rir(&mut self) -> MultiErrorResult<std::sync::Arc<RirView>> {
+        self.state.session.rir()
+    }
+
+    /// Produce one unstable presentation without exposing the session owner.
+    pub fn present(
+        &mut self,
+        request: PresentationRequest<'_>,
+    ) -> MultiErrorResult<PresentationOutput> {
+        self.state.session.unstable_present(request)
+    }
+
+    /// Preserve the command-line compiler's existing one-shot timed adapter.
+    pub fn executable_in_compile_scope(
+        &mut self,
+        options: &CompileOptions,
+    ) -> MultiErrorResult<CompileOutput> {
+        executable_in_compile_scope(&mut self.state.session, options)
+    }
+
+    /// Reach ADR-0068's codegen-ready endpoint without projecting objects.
+    pub fn codegen_ready(&mut self, options: &CompileOptions) -> MultiErrorResult<CodegenReady> {
+        codegen_ready(&mut self.state.session, options)
+    }
+
+    /// Continue a compiler-issued codegen-ready capability to objects-ready.
+    pub fn objects_ready(&mut self, ready: CodegenReady) -> MultiErrorResult<ObjectsReady> {
+        objects_ready(&mut self.state.session, ready)
+    }
+
+    /// Continue a compiler-issued objects-ready capability through fresh link.
+    pub fn runnable_ready(&mut self, ready: ObjectsReady) -> MultiErrorResult<CompileOutput> {
+        runnable_ready(&mut self.state.session, ready)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fs;
+    use std::path::PathBuf;
+
+    use super::*;
+
+    struct TestDir {
+        path: PathBuf,
+    }
+
+    impl TestDir {
+        fn new(name: &str) -> Self {
+            let unique = std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos();
+            let path = std::env::temp_dir().join(format!(
+                "rue-retained-host-{name}-{}-{unique}",
+                std::process::id()
+            ));
+            fs::create_dir_all(&path).unwrap();
+            Self { path }
+        }
+
+        fn write(&self, relative: &str, source: &str) -> PathBuf {
+            let path = self.path.join(relative);
+            if let Some(parent) = path.parent() {
+                fs::create_dir_all(parent).unwrap();
+            }
+            fs::write(&path, source).unwrap();
+            path
+        }
+
+        fn open(&self) -> FilesystemCompilerHost {
+            let root = self.path.join("main.rue");
+            FilesystemCompilerHost::open(HostOpenRequest {
+                root_source: root.to_str().unwrap(),
+                source_manifest_path: None,
+                std_root: None,
+            })
+            .unwrap()
+        }
+    }
+
+    impl Drop for TestDir {
+        fn drop(&mut self) {
+            let _ = fs::remove_dir_all(&self.path);
+        }
+    }
+
+    fn run_to_runnable(host: &mut FilesystemCompilerHost) -> CompileOutput {
+        let options = CompileOptions::default();
+        let codegen = host.codegen_ready(&options).unwrap();
+        let objects = host.objects_ready(codegen).unwrap();
+        host.runnable_ready(objects).unwrap()
+    }
+
+    #[test]
+    fn no_op_reobservation_reuses_the_retained_frontend() {
+        let dir = TestDir::new("noop");
+        dir.write(
+            "main.rue",
+            "const helper = @import(\"helper.rue\");\nfn main() -> i32 { helper.value() }\n",
+        );
+        dir.write("helper.rue", "pub fn value() -> i32 { 7 }\n");
+        let mut host = dir.open();
+
+        let first = run_to_runnable(&mut host);
+        let before = host.state.session.unstable_metrics();
+        host.reobserve().unwrap();
+        let second = run_to_runnable(&mut host);
+        let after = host.state.session.unstable_metrics();
+
+        assert_eq!(first.elf, second.elf);
+        assert!(after.updates() > before.updates());
+        assert_eq!(after.rir().executions, before.rir().executions);
+    }
+
+    #[test]
+    fn body_edit_matches_a_fresh_host_at_every_endpoint() {
+        let dir = TestDir::new("body-edit");
+        dir.write(
+            "main.rue",
+            "const helper = @import(\"helper.rue\");\nfn main() -> i32 { helper.value() }\n",
+        );
+        dir.write("helper.rue", "pub fn value() -> i32 { 1 }\n");
+        let mut retained = dir.open();
+        let before = run_to_runnable(&mut retained);
+
+        dir.write("helper.rue", "pub fn value() -> i32 { 2 }\n");
+        retained.reobserve().unwrap();
+        let after = run_to_runnable(&mut retained);
+        let mut fresh = dir.open();
+        let expected = run_to_runnable(&mut fresh);
+
+        assert_ne!(before.elf, after.elf);
+        assert_eq!(after.elf, expected.elf);
+        assert_eq!(after.warnings, expected.warnings);
+    }
+
+    #[test]
+    fn import_set_change_is_discovered_by_the_retained_host() {
+        let dir = TestDir::new("import-set");
+        dir.write(
+            "main.rue",
+            "const selected = @import(\"left.rue\");\nfn main() -> i32 { selected.value() }\n",
+        );
+        dir.write("left.rue", "pub fn value() -> i32 { 1 }\n");
+        dir.write("right.rue", "pub fn value() -> i32 { 2 }\n");
+        let mut retained = dir.open();
+        let before = run_to_runnable(&mut retained);
+
+        dir.write(
+            "main.rue",
+            "const selected = @import(\"right.rue\");\nfn main() -> i32 { selected.value() }\n",
+        );
+        retained.reobserve().unwrap();
+        let after = run_to_runnable(&mut retained);
+        let mut fresh = dir.open();
+        let expected = run_to_runnable(&mut fresh);
+
+        assert_ne!(before.elf, after.elf);
+        assert_eq!(retained.source_snapshot().len(), 2);
+        assert_eq!(after.elf, expected.elf);
+    }
+
+    #[test]
+    fn manifest_policy_is_reloaded_before_reobservation() {
+        let dir = TestDir::new("manifest-policy");
+        let main = dir.write(
+            "main.rue",
+            "const helper = @import(\"helper.rue\");\nfn main() -> i32 { helper.value() }\n",
+        );
+        dir.write("helper.rue", "pub fn value() -> i32 { 1 }\n");
+        let manifest = dir.write("sources.manifest", "main.rue\nhelper.rue\n");
+        let mut host = FilesystemCompilerHost::open(HostOpenRequest {
+            root_source: main.to_str().unwrap(),
+            source_manifest_path: Some(manifest.to_str().unwrap()),
+            std_root: None,
+        })
+        .unwrap();
+
+        fs::write(&manifest, "main.rue\n").unwrap();
+        match host.reobserve() {
+            Err(SourceLoadError::Compiler { errors, .. }) => {
+                let rendered = errors.to_string();
+                assert!(rendered.contains("source manifest"), "{rendered}");
+                assert!(rendered.contains("helper.rue"), "{rendered}");
+            }
+            other => panic!("expected a typed compiler policy error, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn reached_toolchain_demand_is_acquired_through_the_host() {
+        let project = TestDir::new("toolchain-project");
+        let stdlib = TestDir::new("toolchain-std");
+        let main = project.write(
+            "main.rue",
+            "fn main() -> i32 { let _ = @parse_i64(\"1\"); 0 }",
+        );
+        stdlib.write(
+            "option.rue",
+            "pub fn Option(comptime T: type) -> type { enum { Some(T), None } }",
+        );
+        let std_root = fs::canonicalize(&stdlib.path).unwrap();
+        let mut host = FilesystemCompilerHost::open(HostOpenRequest {
+            root_source: main.to_str().unwrap(),
+            source_manifest_path: None,
+            std_root: Some(&std_root),
+        })
+        .unwrap();
+
+        host.acquire_reached_toolchain_modules(&CompileOptions::default())
+            .unwrap();
+
+        assert_eq!(host.source_snapshot().len(), 2);
+        assert!(
+            host.accepted_reads()
+                .iter()
+                .any(|read| read.requested_path().ends_with("option.rue"))
+        );
+    }
+
+    #[test]
+    fn compiler_diagnostics_flow_through_the_host_endpoint() {
+        let dir = TestDir::new("diagnostics");
+        dir.write("main.rue", "fn main() -> i32 { missing_name }\n");
+        let mut host = dir.open();
+
+        let errors = match host.codegen_ready(&CompileOptions::default()) {
+            Err(errors) => errors,
+            Ok(_) => panic!("an undefined name must fail before codegen-ready"),
+        };
+
+        assert!(!errors.is_empty());
+        assert!(errors.to_string().contains("missing_name"));
+    }
+}

--- a/crates/rue/src/lib.rs
+++ b/crates/rue/src/lib.rs
@@ -1,0 +1,12 @@
+//! Canonical filesystem-backed host for the Rue compiler.
+//!
+//! The command-line compiler, retained-session benchmarks, and long-lived
+//! product hosts share this owner. Filesystem observation remains outside the
+//! compiler query graph while one retained `CompilerSession` owns every
+//! compiler artifact across revisions.
+
+mod host;
+mod source_loader;
+
+pub use host::{FilesystemCompilerHost, HostOpenRequest};
+pub use source_loader::{HermeticDenialError, SourceLoadError, ToolchainIntegrityError};

--- a/crates/rue/src/main.rs
+++ b/crates/rue/src/main.rs
@@ -13,7 +13,6 @@ mod compile;
 mod emit;
 mod output;
 mod platform_signing;
-mod source_loader;
 mod timing;
 
 use emit::EmitStage;
@@ -22,12 +21,7 @@ use emit::{EmitFrontendRoute, build_emit_frontend, emit_frontend_route, emit_req
 #[cfg(test)]
 use rue_compiler::unstable::update_for_presentation;
 use rue_compiler::unstable::{MultiFileFormatter, MultiFileJsonFormatter, SourceInfo};
-use source_loader::{SourceLoadError, SourceLoadRequest};
-#[cfg(test)]
-use source_loader::{
-    SourceManifest, derive_symbol_paths_with_std_root, discover_and_load_imports,
-    parse_source_manifest_entry,
-};
+use rue_driver::{FilesystemCompilerHost, HostOpenRequest, SourceLoadError};
 
 use rue_compiler::{
     CompileErrors, CompileOptions, CompileWarning, FileId, ImportDiscoveryStatus, LinkerMode,
@@ -1049,9 +1043,9 @@ fn main() {
     if options.benchmark_json {
         allocation::begin();
     }
-    let mut import_discovery = {
+    let mut compiler_host = {
         let _compile = compile_span.enter();
-        match source_loader::load(SourceLoadRequest {
+        match FilesystemCompilerHost::open(HostOpenRequest {
             root_source: &options.source_path,
             source_manifest_path: options.source_manifest_path.as_deref(),
             std_root: captured_std_root.as_deref(),
@@ -1088,10 +1082,7 @@ fn main() {
     // emit and compile, matching the acquire-before-everything ordering.
     if options.emit_stages.is_empty() || emit::emit_requires_semantic(&options.emit_stages) {
         let _compile = compile_span.enter();
-        if let Err(error) = source_loader::acquire_reached_toolchain_modules(
-            &mut import_discovery,
-            &compile_options,
-        ) {
+        if let Err(error) = compiler_host.acquire_reached_toolchain_modules(&compile_options) {
             report_source_load_error(error, options.error_format);
         }
     }
@@ -1100,13 +1091,13 @@ fn main() {
     if options.benchmark_json {
         allocation::pause();
     }
-    let source_snapshot = import_discovery.source_snapshot.clone();
+    let source_snapshot = compiler_host.source_snapshot().clone();
     tracing::debug!(
-        root = %import_discovery.resolution.root_path.display(),
-        project_root = import_discovery.resolution.context.project_root(),
-        std_root = import_discovery.resolution.context.std_root(),
-        read_policy_revision = import_discovery.resolution.context.read_policy_revision(),
-        accepted_reads = import_discovery.read_manifest.len(),
+        root = %compiler_host.root_path().display(),
+        project_root = compiler_host.discovery_context().project_root(),
+        std_root = compiler_host.discovery_context().std_root(),
+        read_policy_revision = compiler_host.discovery_context().read_policy_revision(),
+        accepted_reads = compiler_host.accepted_reads().len(),
         "source loading complete"
     );
 
@@ -1126,10 +1117,8 @@ fn main() {
         {
             let _compile = compile_span.enter();
             if let Err(()) = emit::execute(emit::EmitRequest {
-                source_snapshot: &source_snapshot,
-                session: &mut import_discovery.session,
+                host: &mut compiler_host,
                 stages: &options.emit_stages,
-                discovery_revision: &import_discovery.revision,
                 compile_options: compile_options.clone(),
                 diagnostics: &diagnostics,
             }) {
@@ -1148,8 +1137,8 @@ fn main() {
         return;
     }
 
-    if import_discovery.revision.status() != ImportDiscoveryStatus::ClosedValid {
-        diagnostics.print_errors(import_discovery.revision.diagnostics());
+    if compiler_host.discovery_status() != ImportDiscoveryStatus::ClosedValid {
+        diagnostics.print_errors(compiler_host.discovery_revision().diagnostics());
         std::process::exit(1);
     }
 
@@ -1182,7 +1171,7 @@ fn main() {
     let compile_result = {
         let _compile = compile_span.enter();
         compile::execute(compile::CompileRequest {
-            session: &mut import_discovery.session,
+            host: &mut compiler_host,
             options: compile_options,
             destination: publication_destination,
         })
@@ -1328,24 +1317,26 @@ mod tests {
 
         tracing::subscriber::with_default(subscriber, || {
             let compile_span = tracing::info_span!("compile", target = "test");
-            let mut discovery = {
+            let mut host = {
                 let _compile = compile_span.enter();
-                discover_and_load_imports(&root_source, None, None).unwrap()
+                FilesystemCompilerHost::open(HostOpenRequest {
+                    root_source: &root_source,
+                    source_manifest_path: None,
+                    std_root: None,
+                })
+                .unwrap()
             };
-            assert_eq!(discovery.source_snapshot.len(), 2);
-            assert_eq!(discovery.read_manifest.len(), 2);
-            assert_eq!(discovery.resolution.root_path, main);
+            assert_eq!(host.source_snapshot().len(), 2);
+            assert_eq!(host.accepted_reads().len(), 2);
+            assert_eq!(host.root_path(), main);
             assert_eq!(
-                discovery.resolution.context.project_root(),
+                host.discovery_context().project_root(),
                 dir.path.to_string_lossy().as_ref()
             );
             {
                 let _compile = compile_span.enter();
-                rue_compiler::unstable::executable_in_compile_scope(
-                    &mut discovery.session,
-                    &CompileOptions::default(),
-                )
-                .unwrap();
+                host.executable_in_compile_scope(&CompileOptions::default())
+                    .unwrap();
             }
             drop(compile_span);
         });
@@ -1356,7 +1347,8 @@ mod tests {
         // whole chain: the parse must still reach `compile`, and each link
         // names the phase that owns that share of discovery time.
         for expected in [
-            ("compile", "import_discovery_round"),
+            ("compile", "source_loading"),
+            ("source_loading", "import_discovery_round"),
             ("import_discovery_round", "import_plan"),
             ("import_plan", "import_stage"),
             ("import_stage", "import_parse_staging"),
@@ -1384,107 +1376,6 @@ mod tests {
         }
     }
 
-    #[test]
-    fn symbol_paths_are_root_relative_across_relocated_source_trees() {
-        fn sources_at(root: &Path) -> Vec<(String, String)> {
-            vec![
-                (
-                    root.join("project/main.rue").display().to_string(),
-                    String::new(),
-                ),
-                (
-                    root.join("project/./left/nested/../entry.rue")
-                        .display()
-                        .to_string(),
-                    String::new(),
-                ),
-                (root.join("dep.rue").display().to_string(), String::new()),
-                (
-                    root.join("project/right/shared.rue").display().to_string(),
-                    String::new(),
-                ),
-            ]
-        }
-
-        let base = std::env::temp_dir().join("rue-symbol-path-tests");
-        let short = sources_at(&base.join("a"));
-        let relocated = sources_at(&base.join("a-deliberately-much-longer-relocated-source-root"));
-        let expected = vec![
-            "main.rue",
-            "left/entry.rue",
-            "../dep.rue",
-            "right/shared.rue",
-        ];
-
-        assert_eq!(
-            derive_symbol_paths_with_std_root(&short, None).unwrap(),
-            expected
-        );
-        assert_eq!(
-            derive_symbol_paths_with_std_root(&relocated, None).unwrap(),
-            expected
-        );
-    }
-
-    #[test]
-    fn symbol_paths_give_external_std_a_stable_namespace() {
-        fn sources_at(project: &Path, std_root: &Path) -> Vec<(String, String)> {
-            vec![
-                (
-                    project.join("main.rue").display().to_string(),
-                    String::new(),
-                ),
-                (
-                    std_root.join("_std.rue").display().to_string(),
-                    String::new(),
-                ),
-                (
-                    std_root.join("math/float.rue").display().to_string(),
-                    String::new(),
-                ),
-                (
-                    project
-                        .join("@rue-std/math/float.rue")
-                        .display()
-                        .to_string(),
-                    String::new(),
-                ),
-            ]
-        }
-
-        let base = std::env::temp_dir().join("rue-symbol-std-tests");
-        let std_a = base.join("toolchain-a/std");
-        let std_b = base.join("a-different-toolchain-location/std");
-        let first = sources_at(&base.join("build-a/project"), &std_a);
-        let second = sources_at(&base.join("different-depth/build-b/project"), &std_b);
-        let expected = vec![
-            "main.rue",
-            "\0rue-std/_std.rue",
-            "\0rue-std/math/float.rue",
-            "@rue-std/math/float.rue",
-        ];
-
-        assert_eq!(
-            derive_symbol_paths_with_std_root(&first, Some(&std_a)).unwrap(),
-            expected
-        );
-        assert_eq!(
-            derive_symbol_paths_with_std_root(&second, Some(&std_b)).unwrap(),
-            expected
-        );
-    }
-
-    #[cfg(windows)]
-    #[test]
-    fn symbol_paths_reject_unnamed_cross_volume_sources() {
-        let sources = vec![
-            (r"C:\project\main.rue".to_string(), String::new()),
-            (r"D:\dependency\helper.rue".to_string(), String::new()),
-        ];
-        let error = derive_symbol_paths_with_std_root(&sources, None).unwrap_err();
-        assert!(error.contains("another filesystem volume"));
-    }
-
     impl Drop for TestDir {
         fn drop(&mut self) {
             let _ = fs::remove_dir_all(&self.path);
@@ -1508,42 +1399,6 @@ mod tests {
     /// Helper to check if result is an exit.
     fn is_exit(result: &ParseResult) -> bool {
         matches!(result, ParseResult::Exit)
-    }
-
-    #[test]
-    fn source_manifest_entry_parses_comments_and_escaped_hashes() {
-        assert_eq!(
-            parse_source_manifest_entry("main.rue # comment"),
-            "main.rue"
-        );
-        assert_eq!(
-            parse_source_manifest_entry("dir/has\\#hash.rue # comment"),
-            "dir/has#hash.rue"
-        );
-        assert_eq!(
-            parse_source_manifest_entry("dir/has\\\\#comment.rue"),
-            "dir/has\\\\"
-        );
-        assert_eq!(
-            parse_source_manifest_entry("dir/trailing-backslash\\"),
-            "dir/trailing-backslash\\"
-        );
-    }
-
-    #[test]
-    fn source_manifest_load_allows_escaped_hash_in_path() {
-        let dir = TestDir::new("source-manifest-escaped-hash");
-        let main = dir.write("main.rue", "fn main() -> i32 { 0 }\n");
-        let hashed = dir.write("has#hash.rue", "pub fn answer() -> i32 { 42 }\n");
-        let manifest = dir.write(
-            "sources.manifest",
-            "main.rue # normal comment\nhas\\#hash.rue # comment after escaped path\n",
-        );
-
-        let manifest = SourceManifest::load(manifest.to_str().unwrap()).unwrap();
-
-        assert!(manifest.allows_canonical(&fs::canonicalize(main).unwrap()));
-        assert!(manifest.allows_canonical(&fs::canonicalize(hashed).unwrap()));
     }
 
     // ========== Basic parsing tests ==========
@@ -1889,43 +1744,6 @@ mod tests {
         ));
     }
 
-    #[test]
-    fn unreadable_import_candidate_is_an_error_not_absence() {
-        // RUE-529: an import candidate that EXISTS but cannot be read
-        // (invalid UTF-8 here) must be a hard error, not treated as absent —
-        // absence misreported the import as E0704 "cannot find module" and
-        // silently erased one arm of a file-vs-directory ambiguity. (Unit
-        // test rather than a CLI case: TOML case sources cannot express
-        // invalid-UTF-8 file content.)
-        let dir =
-            std::env::temp_dir().join(format!("rue-unreadable-import-test-{}", std::process::id()));
-        fs::create_dir_all(&dir).unwrap();
-        let main_path = dir.join("main.rue");
-        fs::write(
-            &main_path,
-            "const h = @import(\"helper.rue\");\nfn main() -> i32 { 0 }\n",
-        )
-        .unwrap();
-        fs::write(dir.join("helper.rue"), [0xFFu8]).unwrap();
-
-        let root_source = main_path.to_string_lossy().into_owned();
-        let result = discover_and_load_imports(&root_source, None, None);
-        assert!(
-            result.is_err(),
-            "unreadable existing candidate must error, not resolve or vanish"
-        );
-
-        // Control: once the candidate is valid text, discovery loads it.
-        fs::write(dir.join("helper.rue"), "pub fn h() -> i32 {{ 1 }}\n").unwrap();
-        let result = discover_and_load_imports(&root_source, None, None).unwrap();
-        assert_eq!(
-            result.source_snapshot.len(),
-            2,
-            "helper must be discovered and loaded"
-        );
-
-        let _ = fs::remove_dir_all(&dir);
-    }
     #[test]
     fn parse_emit_ast() {
         let opts = unwrap_options(parse_args_from(&["--emit", "ast", "source.rue"]));

--- a/crates/rue/src/source_loader.rs
+++ b/crates/rue/src/source_loader.rs
@@ -618,7 +618,7 @@ pub(crate) struct SourceLoadRequest<'a> {
 }
 
 #[derive(Debug)]
-pub(crate) enum SourceLoadError {
+pub enum SourceLoadError {
     Message(String),
     Compiler {
         snapshot: Option<SourceSnapshot>,
@@ -1094,20 +1094,10 @@ pub(crate) fn reload_from_filesystem(
         root.source().clone(),
     )
     .map_err(|error| SourceLoadError::Message(format!("Error: {error}")))?;
-    for source in reobserved.values() {
-        if source.requested_path() != root.requested_path() {
-            assembler
-                .add_explicit(
-                    source.requested_path(),
-                    source.canonical_path(),
-                    source.metadata_identity(),
-                    source.metadata_fingerprint(),
-                    source.source().clone(),
-                )
-                .map_err(|error| SourceLoadError::Message(format!("Error: {error}")))?;
-        }
-    }
-
+    // Seed only the root. Reobserved predecessor reads are an observation cache
+    // for requests the new rooted frontier actually issues; making every old
+    // read explicit would keep modules that are no longer reachable after an
+    // import-set edit and grow the retained snapshot monotonically.
     let close = drive_import_discovery_to_close(
         &mut assembler,
         &mut result.session,
@@ -1400,7 +1390,7 @@ fn reclassify_reclose_failure(
 /// module; programs that never demand it never observe it. It is folded into
 /// [`SourceLoadError::Toolchain`] and kept distinct from a hermetic policy denial.
 #[derive(Debug)]
-pub(crate) enum ToolchainIntegrityError {
+pub enum ToolchainIntegrityError {
     /// A trusted toolchain module was demanded but no standard-library root is
     /// configured, so the host cannot resolve it at all.
     StdRootUnavailable { logical_path: String },
@@ -1476,7 +1466,7 @@ impl std::fmt::Display for ToolchainIntegrityError {
 /// / broken-installation framing. A manifest denial is enforced before any
 /// filesystem probe, so a denied path is never even stat-ed.
 #[derive(Debug)]
-pub(crate) struct HermeticDenialError {
+pub struct HermeticDenialError {
     pub(crate) logical_path: String,
     pub(crate) path: PathBuf,
     pub(crate) reason: String,
@@ -1791,6 +1781,160 @@ mod tests {
             fs::write(&path, source).unwrap();
             path
         }
+    }
+
+    #[test]
+    fn symbol_paths_are_root_relative_across_relocated_source_trees() {
+        fn sources_at(root: &Path) -> Vec<(String, String)> {
+            vec![
+                (
+                    root.join("project/main.rue").display().to_string(),
+                    String::new(),
+                ),
+                (
+                    root.join("project/./left/nested/../entry.rue")
+                        .display()
+                        .to_string(),
+                    String::new(),
+                ),
+                (root.join("dep.rue").display().to_string(), String::new()),
+                (
+                    root.join("project/right/shared.rue").display().to_string(),
+                    String::new(),
+                ),
+            ]
+        }
+
+        let base = std::env::temp_dir().join("rue-symbol-path-tests");
+        let short = sources_at(&base.join("a"));
+        let relocated = sources_at(&base.join("a-deliberately-much-longer-relocated-source-root"));
+        let expected = vec![
+            "main.rue",
+            "left/entry.rue",
+            "../dep.rue",
+            "right/shared.rue",
+        ];
+
+        assert_eq!(
+            derive_symbol_paths_with_std_root(&short, None).unwrap(),
+            expected
+        );
+        assert_eq!(
+            derive_symbol_paths_with_std_root(&relocated, None).unwrap(),
+            expected
+        );
+    }
+
+    #[test]
+    fn symbol_paths_give_external_std_a_stable_namespace() {
+        fn sources_at(project: &Path, std_root: &Path) -> Vec<(String, String)> {
+            vec![
+                (
+                    project.join("main.rue").display().to_string(),
+                    String::new(),
+                ),
+                (
+                    std_root.join("_std.rue").display().to_string(),
+                    String::new(),
+                ),
+                (
+                    std_root.join("math/float.rue").display().to_string(),
+                    String::new(),
+                ),
+                (
+                    project
+                        .join("@rue-std/math/float.rue")
+                        .display()
+                        .to_string(),
+                    String::new(),
+                ),
+            ]
+        }
+
+        let base = std::env::temp_dir().join("rue-symbol-std-tests");
+        let std_a = base.join("toolchain-a/std");
+        let std_b = base.join("a-different-toolchain-location/std");
+        let first = sources_at(&base.join("build-a/project"), &std_a);
+        let second = sources_at(&base.join("different-depth/build-b/project"), &std_b);
+        let expected = vec![
+            "main.rue",
+            "\0rue-std/_std.rue",
+            "\0rue-std/math/float.rue",
+            "@rue-std/math/float.rue",
+        ];
+
+        assert_eq!(
+            derive_symbol_paths_with_std_root(&first, Some(&std_a)).unwrap(),
+            expected
+        );
+        assert_eq!(
+            derive_symbol_paths_with_std_root(&second, Some(&std_b)).unwrap(),
+            expected
+        );
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn symbol_paths_reject_unnamed_cross_volume_sources() {
+        let sources = vec![
+            (r"C:\project\main.rue".to_string(), String::new()),
+            (r"D:\dependency\helper.rue".to_string(), String::new()),
+        ];
+        let error = derive_symbol_paths_with_std_root(&sources, None).unwrap_err();
+        assert!(error.contains("another filesystem volume"));
+    }
+
+    #[test]
+    fn source_manifest_entry_parses_comments_and_escaped_hashes() {
+        assert_eq!(
+            parse_source_manifest_entry("main.rue # comment"),
+            "main.rue"
+        );
+        assert_eq!(
+            parse_source_manifest_entry("dir/has\\#hash.rue # comment"),
+            "dir/has#hash.rue"
+        );
+        assert_eq!(
+            parse_source_manifest_entry("dir/has\\\\#comment.rue"),
+            "dir/has\\\\"
+        );
+        assert_eq!(
+            parse_source_manifest_entry("dir/trailing-backslash\\"),
+            "dir/trailing-backslash\\"
+        );
+    }
+
+    #[test]
+    fn source_manifest_load_allows_escaped_hash_in_path() {
+        let dir = TestDir::new("source-manifest-escaped-hash");
+        let main = dir.write("main.rue", "fn main() -> i32 { 0 }\n");
+        let hashed = dir.write("has#hash.rue", "pub fn answer() -> i32 { 42 }\n");
+        let manifest = dir.write(
+            "sources.manifest",
+            "main.rue # normal comment\nhas\\#hash.rue # comment after escaped path\n",
+        );
+
+        let manifest = SourceManifest::load(manifest.to_str().unwrap()).unwrap();
+
+        assert!(manifest.allows_canonical(&fs::canonicalize(main).unwrap()));
+        assert!(manifest.allows_canonical(&fs::canonicalize(hashed).unwrap()));
+    }
+
+    #[test]
+    fn unreadable_import_candidate_is_an_error_not_absence() {
+        let dir = TestDir::new("unreadable-import");
+        let main_path = dir.write(
+            "main.rue",
+            "const h = @import(\"helper.rue\");\nfn main() -> i32 { 0 }\n",
+        );
+        fs::write(dir.path.join("helper.rue"), [0xFFu8]).unwrap();
+
+        let root_source = main_path.to_string_lossy().into_owned();
+        assert!(discover_and_load_imports(&root_source, None, None).is_err());
+
+        fs::write(dir.path.join("helper.rue"), "pub fn h() -> i32 { 1 }\n").unwrap();
+        let result = discover_and_load_imports(&root_source, None, None).unwrap();
+        assert_eq!(result.source_snapshot.len(), 2);
     }
 
     #[test]

--- a/docs/designs/0068-incremental-edit-performance-measurement.md
+++ b/docs/designs/0068-incremental-edit-performance-measurement.md
@@ -302,10 +302,10 @@ projects. None may introduce a peer compilation path.
 - [x] **Phase 1: Contract and schema.** Add the versioned incremental manifest,
   raw report types, strict validation, and deterministic report derivation. —
   RUE-1245
-- [ ] **Phase 2: Canonical retained-session host.** Factor the existing
+- [x] **Phase 2: Canonical retained-session host.** Factor the existing
   filesystem-backed reload/session seam into the shared driver library, add the
   narrow unstable codegen-ready projection, and keep the CLI on that same
-  owner. — follow-up issue
+  owner. — RUE-1246
 - [ ] **Phase 3: Retained-session runner.** Drive the shared host through the
   diagnostics and three successful-compilation endpoints and serialize
   validated raw observations without duplicating source loading or compiler


### PR DESCRIPTION
Fixes RUE-1246.

## Summary

- factor the filesystem/compiler boundary into a reusable `FilesystemCompilerHost` that retains one canonical `CompilerSession` across re-observation
- add capability-checked codegen-ready, objects-ready, and runnable-ready endpoints so measurement can stop at exact production boundaries
- make the CLI consume the shared host and correct reload closure handling so removed imports are retired rather than accumulated
- cover no-op, body edit, import-set edit, manifest reload, toolchain demand, compiler diagnostics, endpoint progression, and stale/foreign capability rejection

## Validation

- `./buck2 build //crates/rue:rue //crates/rue:rue-benchmark //crates/rue:rue-driver`
- `scripts/rue unit compiler retained_endpoint_capabilities`
- `./buck2 test //crates/rue:rue-driver-test` (37/37)
- `./buck2 test //crates/rue:rue-test` (182/182)
- `scripts/rue quick`
- `scripts/rue premerge`: all compiler, driver, CLI, spec, UI, reproducibility, oracle, release, and scaling targets passed; the unrelated repository shell scan reported files beneath an external `.claude/worktrees` checkout
