### PR TITLE
RUE-1251: add retained-session benchmark runner

### DIFF
--- a/crates/rue-bench/BUCK
+++ b/crates/rue-bench/BUCK
@@ -6,7 +6,9 @@ load("//crates:defs.bzl", "rue_binary")
 rue_binary(
     name = "rue-bench",
     deps = [
+        "//crates/rue-compiler:rue-compiler",
         "//crates/rue-perf-schema:rue-perf-schema",
+        "//crates/rue:rue-driver",
         "//third-party:libc",
         "//third-party:serde",
         "//third-party:serde_json",

--- a/crates/rue-bench/src/incremental.rs
+++ b/crates/rue-bench/src/incremental.rs
@@ -1,0 +1,803 @@
+//! Canonical retained-session measurement engine for ADR-0068.
+//!
+//! Maintained fixture declarations live outside this module. The engine owns
+//! isolation, exact mutation, endpoint timing, structural projection, and the
+//! fresh-session oracle so later suites cannot accidentally redefine a sample.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::time::Instant;
+
+use rue_compiler::unstable::{EndpointQueryWork, EndpointWork, MetricsSnapshot};
+use rue_compiler::{CompileErrors, CompileOptions, CompileOutput, CompileWarning};
+use rue_driver::{FilesystemCompilerHost, HostOpenRequest, SourceLoadError};
+use rue_perf_schema::{
+    EditEndpoints, EditManifest, EditOutcome, EditReport, EditSample, ExpectedEditOutcome,
+    FailureStage, OracleComparison, OutcomeIdentity, OutcomeKind, PhaseWork, RetainedGauges,
+    SourceShape, StructuralWork, TransformationIdentity, WorkerMode, canonical_json,
+    validate_edit_report,
+};
+use sha2::{Digest, Sha256};
+
+#[derive(Debug, Clone)]
+pub(crate) enum EditOperation {
+    Reobserve {
+        id: String,
+    },
+    Replace {
+        id: String,
+        logical_file: PathBuf,
+        before: String,
+        after: String,
+    },
+}
+
+impl EditOperation {
+    pub(crate) fn identity(&self) -> TransformationIdentity {
+        match self {
+            Self::Reobserve { id } => TransformationIdentity::Reobserve { id: id.clone() },
+            Self::Replace {
+                id,
+                logical_file,
+                before,
+                after,
+            } => TransformationIdentity::Replace {
+                id: id.clone(),
+                logical_file: logical_file.to_string_lossy().into_owned(),
+                before_sha256: sha256(before.as_bytes()),
+                after_sha256: sha256(after.as_bytes()),
+            },
+        }
+    }
+}
+
+pub(crate) struct SampleRequest<'a> {
+    pub fixture_root: &'a Path,
+    pub root_source: &'a Path,
+    pub source_manifest: Option<&'a Path>,
+    pub std_root: Option<&'a Path>,
+    pub options: &'a CompileOptions,
+    pub worker_mode: WorkerMode,
+    pub expected_outcome: ExpectedEditOutcome,
+    pub operation: &'a EditOperation,
+    pub sample_index: u32,
+    pub session_id: String,
+    pub collection_order: u32,
+}
+
+pub(crate) struct SampleObservation {
+    pub shape: SourceShape,
+    pub sample: EditSample,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ReportStatus {
+    Valid,
+    Diverged,
+}
+
+impl ReportStatus {
+    /// Divergence is publishable evidence but must still fail the collection
+    /// step, distinct from malformed input that produces no report.
+    pub(crate) const fn exit_code(self) -> u8 {
+        match self {
+            Self::Valid => 0,
+            Self::Diverged => 3,
+        }
+    }
+}
+
+/// Structural invalidity produces no latency artifact. A compiler divergence
+/// is serialized as explicit failing evidence for the workflow to publish.
+pub(crate) fn write_validated_report(
+    path: &Path,
+    manifest: &EditManifest,
+    report: &EditReport,
+) -> Result<ReportStatus, String> {
+    let validation = validate_edit_report(manifest, report);
+    if !validation.errors.is_empty() {
+        let details = validation
+            .errors
+            .iter()
+            .map(|finding| format!("{}: {}", finding.path, finding.detail))
+            .collect::<Vec<_>>()
+            .join("; ");
+        return Err(format!(
+            "incremental report is structurally invalid: {details}"
+        ));
+    }
+    let encoded = canonical_json(report)
+        .map_err(|error| format!("could not serialize incremental report: {error}"))?;
+    fs::write(path, encoded)
+        .map_err(|error| format!("could not write {}: {error}", path.display()))?;
+    Ok(if validation.divergences.is_empty() {
+        ReportStatus::Valid
+    } else {
+        ReportStatus::Diverged
+    })
+}
+
+pub(crate) fn measure_sample(request: SampleRequest<'_>) -> Result<SampleObservation, String> {
+    let resolved_workers = resolve_workers(request.worker_mode);
+    rue_compiler::configure_thread_pool(resolved_workers as usize);
+
+    let isolated = tempfile::tempdir()
+        .map_err(|error| format!("could not create isolated fixture: {error}"))?;
+    copy_tree(request.fixture_root, isolated.path())?;
+    let root = isolated_path(isolated.path(), request.root_source)?;
+    let manifest = request
+        .source_manifest
+        .map(|path| isolated_path(isolated.path(), path))
+        .transpose()?;
+
+    let mut warm = open_host(&root, manifest.as_deref(), request.std_root)?;
+    warm.acquire_reached_toolchain_modules(request.options)
+        .map_err(source_load_error)?;
+    let baseline = run_success(&mut warm, request.options)
+        .map_err(|errors| format!("revision A did not reach runnable-ready: {errors}"))?;
+    let baseline_metrics = warm.unstable_metrics();
+    let one_shot = baseline.unstable_metrics();
+    let shape = SourceShape {
+        files: one_shot.files as u64,
+        modules: one_shot.parsed.modules_considered as u64,
+        bytes: one_shot.bytes as u64,
+        lines: one_shot.lines as u64,
+        tokens: one_shot.tokens as u64,
+        functions: one_shot.semantic.cfg.functions_considered as u64,
+    };
+
+    apply_operation(isolated.path(), request.operation)?;
+    let started = Instant::now();
+    warm.reobserve().map_err(source_load_error)?;
+    warm.acquire_reached_toolchain_modules(request.options)
+        .map_err(source_load_error)?;
+
+    let (outcome, endpoint_work) = match warm.codegen_ready(request.options) {
+        Ok(codegen) => {
+            let codegen_ready_ns = elapsed_ns(started);
+            if request.expected_outcome == ExpectedEditOutcome::Diagnostics {
+                return Err(
+                    "diagnostics scenario unexpectedly reached the codegen-ready endpoint".into(),
+                );
+            }
+            let codegen_work = codegen.unstable_work();
+            match warm.objects_ready(codegen) {
+                Ok(objects) => {
+                    let objects_ready_ns = elapsed_ns(started);
+                    let work = objects.unstable_work();
+                    match warm.runnable_ready(objects) {
+                        Ok(output) => {
+                            let runnable_ready_ns = elapsed_ns(started);
+                            (
+                                success_outcome(
+                                    output,
+                                    EditEndpoints {
+                                        codegen_ready_ns,
+                                        objects_ready_ns,
+                                        runnable_ready_ns,
+                                    },
+                                ),
+                                work,
+                            )
+                        }
+                        Err(errors) => (unexpected_failure(FailureStage::Linking, &errors), work),
+                    }
+                }
+                Err(errors) => (
+                    unexpected_failure(FailureStage::Objects, &errors),
+                    codegen_work,
+                ),
+            }
+        }
+        Err(errors) if request.expected_outcome == ExpectedEditOutcome::Diagnostics => (
+            EditOutcome::ExpectedDiagnostics {
+                diagnostics_ready_ns: elapsed_ns(started),
+                diagnostics: errors_identity(&errors),
+                warnings: sha256(&[]),
+            },
+            EndpointWork::default(),
+        ),
+        Err(errors) => (
+            unexpected_failure(FailureStage::Codegen, &errors),
+            EndpointWork::default(),
+        ),
+    };
+    let endpoint_metrics = warm.unstable_metrics();
+    let work = structural_work(
+        &baseline_metrics,
+        &endpoint_metrics,
+        endpoint_work,
+        &outcome,
+    );
+    let retention = retained_gauges(endpoint_metrics);
+    let warm_identity = outcome_identity(&outcome);
+
+    // The correctness oracle owns a new session over revision B and is wholly
+    // outside the measured interval.
+    let mut fresh = open_host(&root, manifest.as_deref(), request.std_root)?;
+    fresh
+        .acquire_reached_toolchain_modules(request.options)
+        .map_err(source_load_error)?;
+    let fresh_identity = fresh_identity(&mut fresh, request.options, request.expected_outcome);
+    let oracle = compare_identities(warm_identity, fresh_identity);
+
+    Ok(SampleObservation {
+        shape,
+        sample: EditSample {
+            sample_index: request.sample_index,
+            session_id: request.session_id,
+            collection_order: request.collection_order,
+            resolved_workers,
+            transformation: request.operation.identity(),
+            outcome,
+            work,
+            retention,
+            oracle,
+        },
+    })
+}
+
+fn open_host(
+    root: &Path,
+    manifest: Option<&Path>,
+    std_root: Option<&Path>,
+) -> Result<FilesystemCompilerHost, String> {
+    FilesystemCompilerHost::open(HostOpenRequest {
+        root_source: root
+            .to_str()
+            .ok_or_else(|| format!("fixture root is not UTF-8: {}", root.display()))?,
+        source_manifest_path: manifest.and_then(Path::to_str),
+        std_root,
+    })
+    .map_err(source_load_error)
+}
+
+fn run_success(
+    host: &mut FilesystemCompilerHost,
+    options: &CompileOptions,
+) -> Result<CompileOutput, CompileErrors> {
+    let codegen = host.codegen_ready(options)?;
+    let objects = host.objects_ready(codegen)?;
+    host.runnable_ready(objects)
+}
+
+fn fresh_identity(
+    host: &mut FilesystemCompilerHost,
+    options: &CompileOptions,
+    expected: ExpectedEditOutcome,
+) -> OutcomeIdentity {
+    match run_success(host, options) {
+        Ok(output) if expected == ExpectedEditOutcome::Success => output_identity(&output),
+        Ok(output) => OutcomeIdentity {
+            kind: OutcomeKind::UnexpectedFailure,
+            diagnostics: sha256(&[]),
+            warnings: warnings_identity(&output.warnings),
+            executable: Some(sha256(&output.elf)),
+        },
+        Err(errors) if expected == ExpectedEditOutcome::Diagnostics => OutcomeIdentity {
+            kind: OutcomeKind::Diagnostics,
+            diagnostics: errors_identity(&errors),
+            warnings: sha256(&[]),
+            executable: None,
+        },
+        Err(errors) => OutcomeIdentity {
+            kind: OutcomeKind::UnexpectedFailure,
+            diagnostics: errors_identity(&errors),
+            warnings: sha256(&[]),
+            executable: None,
+        },
+    }
+}
+
+fn success_outcome(output: CompileOutput, endpoints: EditEndpoints) -> EditOutcome {
+    EditOutcome::Success {
+        endpoints,
+        diagnostics: sha256(&[]),
+        warnings: warnings_identity(&output.warnings),
+        executable: sha256(&output.elf),
+    }
+}
+
+fn unexpected_failure(stage: FailureStage, errors: &CompileErrors) -> EditOutcome {
+    EditOutcome::UnexpectedFailure {
+        stage,
+        diagnostics: errors_identity(errors),
+        warnings: sha256(&[]),
+    }
+}
+
+fn output_identity(output: &CompileOutput) -> OutcomeIdentity {
+    OutcomeIdentity {
+        kind: OutcomeKind::Success,
+        diagnostics: sha256(&[]),
+        warnings: warnings_identity(&output.warnings),
+        executable: Some(sha256(&output.elf)),
+    }
+}
+
+fn outcome_identity(outcome: &EditOutcome) -> OutcomeIdentity {
+    match outcome {
+        EditOutcome::Success {
+            diagnostics,
+            warnings,
+            executable,
+            ..
+        } => OutcomeIdentity {
+            kind: OutcomeKind::Success,
+            diagnostics: diagnostics.clone(),
+            warnings: warnings.clone(),
+            executable: Some(executable.clone()),
+        },
+        EditOutcome::ExpectedDiagnostics {
+            diagnostics,
+            warnings,
+            ..
+        } => OutcomeIdentity {
+            kind: OutcomeKind::Diagnostics,
+            diagnostics: diagnostics.clone(),
+            warnings: warnings.clone(),
+            executable: None,
+        },
+        EditOutcome::UnexpectedFailure {
+            diagnostics,
+            warnings,
+            ..
+        } => OutcomeIdentity {
+            kind: OutcomeKind::UnexpectedFailure,
+            diagnostics: diagnostics.clone(),
+            warnings: warnings.clone(),
+            executable: None,
+        },
+    }
+}
+
+fn compare_identities(warm: OutcomeIdentity, fresh: OutcomeIdentity) -> OracleComparison {
+    if warm == fresh {
+        OracleComparison::Matched { warm, fresh }
+    } else {
+        let first_difference = if warm.kind != fresh.kind {
+            format!(
+                "outcome kind differs: warm {:?}, fresh {:?}",
+                warm.kind, fresh.kind
+            )
+        } else if warm.diagnostics != fresh.diagnostics {
+            "diagnostic identity differs".to_string()
+        } else if warm.warnings != fresh.warnings {
+            "warning identity differs".to_string()
+        } else {
+            "executable identity differs".to_string()
+        };
+        OracleComparison::Diverged {
+            warm,
+            fresh,
+            first_difference,
+        }
+    }
+}
+
+fn structural_work(
+    before: &MetricsSnapshot,
+    after: &MetricsSnapshot,
+    endpoint: EndpointWork,
+    outcome: &EditOutcome,
+) -> StructuralWork {
+    let parse = after.parse_metrics();
+    let merge = query_delta(before.merge(), after.merge());
+    let rir = query_delta(before.rir(), after.rir());
+    let semantic = query_delta(before.semantic(), after.semantic());
+    let imports = query_delta(before.imports(), after.imports());
+    let mut program = merge;
+    add_work(&mut program, &rir);
+    program.invalidated = delta(
+        before.downstream_invalidations(),
+        after.downstream_invalidations(),
+    );
+    program.evicted = delta(
+        before.retention().query_evictions,
+        after.retention().query_evictions,
+    );
+    StructuralWork {
+        source_observation: PhaseWork {
+            computed: delta(before.updates(), after.updates()),
+            ..Default::default()
+        },
+        import_discovery: imports,
+        parsing: PhaseWork {
+            computed: parse.modules_reparsed as u64,
+            reused: parse.modules_reused as u64,
+            invalidated: parse.modules_rebound as u64,
+            ..Default::default()
+        },
+        program,
+        semantic: PhaseWork {
+            invalidated: delta(
+                before.semantic_entries_invalidated(),
+                after.semantic_entries_invalidated(),
+            ),
+            ..semantic
+        },
+        cfg: endpoint_phase(endpoint.cfg),
+        codegen: endpoint_phase(endpoint.codegen),
+        object_projection: endpoint_phase(endpoint.object_projection),
+        linking: PhaseWork {
+            computed: u64::from(matches!(outcome, EditOutcome::Success { .. })),
+            ..Default::default()
+        },
+    }
+}
+
+fn query_delta(
+    before: rue_compiler::unstable::QueryMetrics,
+    after: rue_compiler::unstable::QueryMetrics,
+) -> PhaseWork {
+    PhaseWork {
+        computed: delta(before.executions, after.executions),
+        reused: delta(before.reuses, after.reuses),
+        ..Default::default()
+    }
+}
+
+fn endpoint_phase(work: EndpointQueryWork) -> PhaseWork {
+    PhaseWork {
+        computed: work.computed as u64,
+        reused: work.reused as u64,
+        joined: work.joined as u64,
+        canceled: work.canceled as u64,
+        ..Default::default()
+    }
+}
+
+fn add_work(target: &mut PhaseWork, other: &PhaseWork) {
+    target.computed += other.computed;
+    target.reused += other.reused;
+    target.joined += other.joined;
+    target.invalidated += other.invalidated;
+    target.canceled += other.canceled;
+    target.evicted += other.evicted;
+}
+
+fn retained_gauges(metrics: MetricsSnapshot) -> RetainedGauges {
+    let retention = metrics.retention();
+    let input_observations = retention.retained_module_input_views
+        + retention.retained_module_source_stamps
+        + retention.retained_import_input_views
+        + retention.retained_import_context_stamps
+        + retention.retained_import_topology_stamps
+        + retention.retained_import_provenance_stamps
+        + retention.retained_import_observation_stamps;
+    let observations = retention.dependency_pins.saturating_add(input_observations);
+    RetainedGauges {
+        current_bytes: retention.retained_bytes as u64,
+        peak_bytes: retention.peak_retained_bytes.max(retention.retained_bytes) as u64,
+        soft_budget_bytes: retention.retained_byte_budget as u64,
+        protected_overflow_bytes: retention
+            .retained_bytes
+            .saturating_sub(retention.retained_byte_budget)
+            as u64,
+        dependency_observations: retention.dependency_pins as u64,
+        input_observations: input_observations as u64,
+        observation_budget: retention.dependency_pin_budget as u64,
+        protected_overflow_observations: observations
+            .saturating_sub(retention.dependency_pin_budget)
+            as u64,
+    }
+}
+
+fn apply_operation(root: &Path, operation: &EditOperation) -> Result<(), String> {
+    let EditOperation::Replace {
+        logical_file,
+        before,
+        after,
+        ..
+    } = operation
+    else {
+        return Ok(());
+    };
+    let path = isolated_path(root, logical_file)?;
+    let source = fs::read_to_string(&path)
+        .map_err(|error| format!("could not read {}: {error}", path.display()))?;
+    let matches = source.match_indices(before).count();
+    if matches != 1 {
+        return Err(format!(
+            "edit fragment occurs {matches} times in {}; expected exactly once",
+            logical_file.display()
+        ));
+    }
+    let edited = source.replacen(before, after, 1);
+    fs::write(&path, edited).map_err(|error| format!("could not write {}: {error}", path.display()))
+}
+
+fn isolated_path(root: &Path, relative: &Path) -> Result<PathBuf, String> {
+    if relative.is_absolute()
+        || relative
+            .components()
+            .any(|part| matches!(part, std::path::Component::ParentDir))
+    {
+        return Err(format!(
+            "fixture path must be relative and contained: {}",
+            relative.display()
+        ));
+    }
+    Ok(root.join(relative))
+}
+
+fn copy_tree(source: &Path, destination: &Path) -> Result<(), String> {
+    for entry in fs::read_dir(source)
+        .map_err(|error| format!("could not read fixture {}: {error}", source.display()))?
+    {
+        let entry = entry.map_err(|error| format!("could not read fixture entry: {error}"))?;
+        let kind = entry
+            .file_type()
+            .map_err(|error| format!("could not inspect {}: {error}", entry.path().display()))?;
+        let target = destination.join(entry.file_name());
+        if kind.is_dir() {
+            fs::create_dir_all(&target)
+                .map_err(|error| format!("could not create {}: {error}", target.display()))?;
+            copy_tree(&entry.path(), &target)?;
+        } else if kind.is_file() {
+            fs::copy(entry.path(), &target)
+                .map_err(|error| format!("could not copy {}: {error}", target.display()))?;
+        } else {
+            return Err(format!(
+                "fixture contains unsupported non-file entry {}",
+                entry.path().display()
+            ));
+        }
+    }
+    Ok(())
+}
+
+fn resolve_workers(mode: WorkerMode) -> u32 {
+    match mode {
+        WorkerMode::One => 1,
+        WorkerMode::Automatic => std::thread::available_parallelism()
+            .map(std::num::NonZeroUsize::get)
+            .unwrap_or(1) as u32,
+    }
+}
+
+fn elapsed_ns(started: Instant) -> u64 {
+    let elapsed = started.elapsed().as_nanos();
+    elapsed.min(u128::from(u64::MAX)).max(1) as u64
+}
+
+fn delta(before: usize, after: usize) -> u64 {
+    after.saturating_sub(before) as u64
+}
+
+fn sha256(bytes: &[u8]) -> String {
+    format!("{:x}", Sha256::digest(bytes))
+}
+
+fn warnings_identity(warnings: &[CompileWarning]) -> String {
+    let mut rendered = String::new();
+    for warning in warnings {
+        rendered.push_str(&format!(
+            "{:?}|{}|{:?}\n",
+            warning.span(),
+            warning,
+            warning.diagnostic()
+        ));
+    }
+    sha256(rendered.as_bytes())
+}
+
+fn errors_identity(errors: &CompileErrors) -> String {
+    let mut rendered = String::new();
+    for error in errors.iter() {
+        rendered.push_str(&format!(
+            "{:?}|{}|{:?}|{:?}\n",
+            error.span(),
+            error,
+            error.kind,
+            error.diagnostic()
+        ));
+    }
+    sha256(rendered.as_bytes())
+}
+
+fn source_load_error(error: SourceLoadError) -> String {
+    match error {
+        SourceLoadError::Message(message) => message,
+        SourceLoadError::Compiler { errors, .. } => errors.to_string(),
+        SourceLoadError::Toolchain(error) => format!("{error:?}"),
+        SourceLoadError::HermeticDenial(error) => format!("{error:?}"),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rue_perf_schema::{
+        EDIT_REPORT_SCHEMA_VERSION, EditReportIdentity, EditReportRegime, EnvironmentFingerprint,
+        OptimizationSetting, RetentionSequence, RotationRule,
+    };
+
+    fn fixture(source: &str) -> tempfile::TempDir {
+        let dir = tempfile::tempdir().unwrap();
+        fs::write(dir.path().join("main.rue"), source).unwrap();
+        dir
+    }
+
+    fn request<'a>(
+        fixture: &'a Path,
+        operation: &'a EditOperation,
+        options: &'a CompileOptions,
+        expected_outcome: ExpectedEditOutcome,
+    ) -> SampleRequest<'a> {
+        SampleRequest {
+            fixture_root: fixture,
+            root_source: Path::new("main.rue"),
+            source_manifest: None,
+            std_root: None,
+            options,
+            worker_mode: WorkerMode::One,
+            expected_outcome,
+            operation,
+            sample_index: 0,
+            session_id: "test-session".into(),
+            collection_order: 0,
+        }
+    }
+
+    #[test]
+    fn successful_edit_records_cumulative_endpoints_and_fresh_oracle() {
+        let fixture = fixture("fn main() -> i32 { 1 }\n");
+        let operation = EditOperation::Replace {
+            id: "body".into(),
+            logical_file: "main.rue".into(),
+            before: "{ 1 }".into(),
+            after: "{ 2 }".into(),
+        };
+        let options = CompileOptions::default();
+        let observation = measure_sample(request(
+            fixture.path(),
+            &operation,
+            &options,
+            ExpectedEditOutcome::Success,
+        ))
+        .unwrap();
+        let EditOutcome::Success { endpoints, .. } = observation.sample.outcome else {
+            panic!("expected successful outcome")
+        };
+        assert!(endpoints.codegen_ready_ns <= endpoints.objects_ready_ns);
+        assert!(endpoints.objects_ready_ns <= endpoints.runnable_ready_ns);
+        assert!(matches!(
+            observation.sample.oracle,
+            OracleComparison::Matched { .. }
+        ));
+        assert_eq!(observation.shape.files, 1);
+    }
+
+    #[test]
+    fn diagnostics_edit_records_only_the_diagnostics_endpoint() {
+        let fixture = fixture("fn main() -> i32 { 1 }\n");
+        let operation = EditOperation::Replace {
+            id: "error".into(),
+            logical_file: "main.rue".into(),
+            before: "{ 1 }".into(),
+            after: "{ missing }".into(),
+        };
+        let options = CompileOptions::default();
+        let observation = measure_sample(request(
+            fixture.path(),
+            &operation,
+            &options,
+            ExpectedEditOutcome::Diagnostics,
+        ))
+        .unwrap();
+        assert!(matches!(
+            observation.sample.outcome,
+            EditOutcome::ExpectedDiagnostics { .. }
+        ));
+        assert!(matches!(
+            observation.sample.oracle,
+            OracleComparison::Matched { .. }
+        ));
+    }
+
+    #[test]
+    fn malformed_or_nonunique_edit_produces_no_sample() {
+        let fixture = fixture("fn main() -> i32 { 1 + 1 }\n");
+        let operation = EditOperation::Replace {
+            id: "ambiguous".into(),
+            logical_file: "main.rue".into(),
+            before: "1".into(),
+            after: "2".into(),
+        };
+        let options = CompileOptions::default();
+        let error = measure_sample(request(
+            fixture.path(),
+            &operation,
+            &options,
+            ExpectedEditOutcome::Success,
+        ))
+        .err()
+        .unwrap();
+        assert!(error.contains("occurs 2 times"));
+    }
+
+    #[test]
+    fn no_op_reobservation_reuses_backend_work() {
+        let fixture = fixture("fn main() -> i32 { 1 }\n");
+        let operation = EditOperation::Reobserve { id: "noop".into() };
+        let options = CompileOptions::default();
+        let observation = measure_sample(request(
+            fixture.path(),
+            &operation,
+            &options,
+            ExpectedEditOutcome::Success,
+        ))
+        .unwrap();
+        assert_eq!(observation.sample.work.codegen.computed, 0);
+        assert!(observation.sample.work.codegen.reused > 0);
+        assert_eq!(observation.sample.work.object_projection.computed, 0);
+        assert!(observation.sample.work.object_projection.reused > 0);
+    }
+
+    #[test]
+    fn divergence_is_publishable_but_maps_to_a_nonzero_status() {
+        let warm = OutcomeIdentity {
+            kind: OutcomeKind::Success,
+            diagnostics: sha256(&[]),
+            warnings: sha256(&[]),
+            executable: Some(sha256(b"warm")),
+        };
+        let fresh = OutcomeIdentity {
+            executable: Some(sha256(b"fresh")),
+            ..warm.clone()
+        };
+        assert!(matches!(
+            compare_identities(warm, fresh),
+            OracleComparison::Diverged { .. }
+        ));
+        assert_ne!(ReportStatus::Diverged.exit_code(), 0);
+    }
+
+    #[test]
+    fn structurally_invalid_report_is_not_serialized() {
+        let manifest_text = fs::read_to_string("performance/incremental.toml")
+            .expect("checked-in incremental manifest is readable");
+        let manifest = EditManifest::parse(&manifest_text).expect("checked-in manifest is valid");
+        let report = EditReport {
+            schema_version: EDIT_REPORT_SCHEMA_VERSION,
+            identity: EditReportIdentity {
+                fixture_revision: manifest.fixture_revision,
+                commit: "c".repeat(40),
+                started_at: "2026-08-07T00:00:00Z".into(),
+                finished_at: "2026-08-07T01:00:00Z".into(),
+                target: manifest.target.clone(),
+                environment: EnvironmentFingerprint {
+                    runner_label: "local".into(),
+                    runner_image: "local".into(),
+                    runner_image_version: "local".into(),
+                    cpu_model: "local".into(),
+                    core_count: 1,
+                    memory_bytes: 1,
+                    kernel_version: "local".into(),
+                    os_version: "local".into(),
+                    architecture: "aarch64".into(),
+                },
+            },
+            regime: EditReportRegime {
+                compiler_state: "retained_session".into(),
+                os_page_cache: "uncontrolled".into(),
+                samples_per_row: manifest.samples_per_row,
+                retention_revisions: manifest.retention_revisions,
+                rotation: RotationRule::LeftBySample,
+                optimization: OptimizationSetting::Default,
+                compiler_args: Vec::new(),
+            },
+            rows: Vec::new(),
+            retention: RetentionSequence {
+                workload: "mosaic".into(),
+                worker_mode: WorkerMode::One,
+                resolved_workers: 1,
+                revisions: Vec::new(),
+            },
+        };
+        let output = tempfile::tempdir().unwrap().path().join("report.json");
+        assert!(write_validated_report(&output, &manifest, &report).is_err());
+        assert!(!output.exists());
+    }
+}

--- a/crates/rue-bench/src/main.rs
+++ b/crates/rue-bench/src/main.rs
@@ -15,6 +15,10 @@
 mod calibrate;
 mod derive;
 mod environment;
+// Phase 3 supplies the canonical engine; Phase 4's maintained fixture matrix
+// wires it to the binary entry point.
+#[allow(dead_code)]
+mod incremental;
 mod measure;
 mod pins;
 mod scaling;

--- a/crates/rue-compiler/src/session.rs
+++ b/crates/rue-compiler/src/session.rs
@@ -40,6 +40,28 @@ pub struct FrontendQueryWork {
     pub reuses: usize,
 }
 
+/// Aggregate lifecycle work for one collection of per-function backend
+/// queries. The aggregate deliberately omits query keys and artifacts so an
+/// external metrics consumer cannot become a second query-graph owner.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub(crate) struct BackendQueryWork {
+    pub(crate) computed: usize,
+    pub(crate) reused: usize,
+    pub(crate) joined: usize,
+    pub(crate) canceled: usize,
+}
+
+impl BackendQueryWork {
+    fn observe(&mut self, execution: rue_query::RequestExecution) {
+        match execution {
+            rue_query::RequestExecution::Computed => self.computed += 1,
+            rue_query::RequestExecution::Reused => self.reused += 1,
+            rue_query::RequestExecution::Joined => self.joined += 1,
+            rue_query::RequestExecution::Aborted => self.canceled += 1,
+        }
+    }
+}
+
 /// Session-owned indexed historical artifacts retained after the latest query.
 ///
 /// These are gauges, not cumulative work counters. Caller-owned
@@ -880,6 +902,7 @@ pub(crate) struct RootedCfgOutput {
     pub(crate) cfgs: Vec<RootedCfgUnit>,
     pub(crate) warnings: Vec<CompileWarning>,
     pub(crate) work: crate::CanonicalSemanticWork,
+    backend_work: BackendQueryWork,
     backend_root: crate::revisioned_query_database::BackendRootCandidate,
 }
 
@@ -891,6 +914,9 @@ pub(crate) struct RootedCodegenOutput {
     pub(crate) exports: Vec<crate::program_image_plan::RootedExportThunk>,
     pub(crate) warnings: Vec<CompileWarning>,
     pub(crate) work: crate::CanonicalSemanticWork,
+    pub(crate) cfg_work: BackendQueryWork,
+    pub(crate) codegen_work: BackendQueryWork,
+    pub(crate) object_projection_work: BackendQueryWork,
 }
 
 /// Opaque in-crate continuation between the canonical codegen-ready and
@@ -903,6 +929,8 @@ pub(crate) struct RootedCodegenReadyOutput {
     cfgs: Vec<RootedCfgUnit>,
     warnings: Vec<CompileWarning>,
     work: crate::CanonicalSemanticWork,
+    pub(crate) cfg_work: BackendQueryWork,
+    pub(crate) codegen_work: BackendQueryWork,
     backend_root: crate::revisioned_query_database::BackendRootCandidate,
     codegen_batch_key: crate::revisioned_query_database::CodegenUnitBatchKey,
 }
@@ -5020,6 +5048,10 @@ impl CompilerSession {
         } else {
             vec![batch_execution; cfg_requests.len()]
         };
+        let mut backend_work = BackendQueryWork::default();
+        for execution in &executions {
+            backend_work.observe(*execution);
+        }
         if let Some(terminal) = attempt.terminal() {
             self.queries.revisioned.retain_backend_optimized_cfg_batch(
                 &mut backend_root,
@@ -5131,6 +5163,7 @@ impl CompilerSession {
             cfgs,
             warnings,
             work,
+            backend_work,
             backend_root,
         })
     }
@@ -5156,6 +5189,7 @@ impl CompilerSession {
             cfgs,
             warnings,
             work,
+            backend_work: cfg_work,
             mut backend_root,
         } = self.rooted_cfg(options)?;
 
@@ -5187,15 +5221,13 @@ impl CompilerSession {
             codegen_keys,
             rue_query::CancellationToken::new(),
         );
-        #[cfg(test)]
         let batch_execution = attempt.execution();
-        #[cfg(test)]
         let child_attempts = if batch_execution == rue_query::RequestExecution::Computed {
             let attempts = attempt
                 .nested_attempts()
                 .iter()
                 .filter(|attempt| attempt.node().family() == "compiler.codegen-unit")
-                .map(|attempt| (attempt.execution(), attempt.work().to_vec()))
+                .map(rue_query::NestedQueryAttempt::execution)
                 .collect::<Vec<_>>();
             assert_eq!(
                 attempts.len(),
@@ -5206,6 +5238,20 @@ impl CompilerSession {
         } else {
             None
         };
+        #[cfg(test)]
+        let child_attempt_work = if batch_execution == rue_query::RequestExecution::Computed {
+            Some(
+                attempt
+                    .nested_attempts()
+                    .iter()
+                    .filter(|attempt| attempt.node().family() == "compiler.codegen-unit")
+                    .map(|attempt| attempt.work().to_vec())
+                    .collect::<Vec<_>>(),
+            )
+        } else {
+            None
+        };
+        let mut codegen_work = BackendQueryWork::default();
         if let Some(terminal) = attempt.terminal() {
             self.queries.revisioned.retain_backend_codegen_batch(
                 &mut backend_root,
@@ -5223,21 +5269,19 @@ impl CompilerSession {
         };
         assert_eq!(batch.values.len(), cfgs.len());
         for (index, (cfg, value)) in cfgs.iter().zip(batch.values.iter()).enumerate() {
-            #[cfg(not(test))]
-            let _ = index;
-            #[cfg(test)]
             let execution = child_attempts
                 .as_ref()
-                .map_or(batch_execution, |attempts| attempts[index].0);
+                .map_or(batch_execution, |attempts| attempts[index]);
+            codegen_work.observe(execution);
             #[cfg(test)]
             {
                 self.codegen_executions
                     .push((cfg.function.clone(), execution));
                 self.codegen_attempt_work.push((
                     cfg.function.clone(),
-                    child_attempts
+                    child_attempt_work
                         .as_ref()
-                        .map_or_else(Vec::new, |attempts| attempts[index].1.clone()),
+                        .map_or_else(Vec::new, |attempts| attempts[index].clone()),
                 ));
             }
             match value {
@@ -5263,6 +5307,8 @@ impl CompilerSession {
             cfgs,
             warnings,
             work,
+            cfg_work,
+            codegen_work,
             backend_root,
             codegen_batch_key,
         })
@@ -5280,6 +5326,8 @@ impl CompilerSession {
             cfgs,
             warnings,
             work,
+            cfg_work,
+            codegen_work,
             mut backend_root,
             codegen_batch_key,
         } = ready;
@@ -5295,9 +5343,7 @@ impl CompilerSession {
             object_keys,
             rue_query::CancellationToken::new(),
         );
-        #[cfg(test)]
         let object_batch_execution = object_attempt.execution();
-        #[cfg(test)]
         let object_child_attempts =
             if object_batch_execution == rue_query::RequestExecution::Computed {
                 let attempts = object_attempt
@@ -5315,6 +5361,7 @@ impl CompilerSession {
             } else {
                 None
             };
+        let mut object_projection_work = BackendQueryWork::default();
         if let Some(terminal) = object_attempt.terminal() {
             self.queries
                 .revisioned
@@ -5336,15 +5383,13 @@ impl CompilerSession {
         let mut objects = Vec::with_capacity(units.len());
         for (index, (collected, value)) in units.iter().zip(object_batch.values.iter()).enumerate()
         {
-            #[cfg(not(test))]
-            let _ = index;
+            let execution = object_child_attempts
+                .as_ref()
+                .map_or(object_batch_execution, |attempts| attempts[index]);
+            object_projection_work.observe(execution);
             #[cfg(test)]
-            self.object_projection_executions.push((
-                collected.function.clone(),
-                object_child_attempts
-                    .as_ref()
-                    .map_or(object_batch_execution, |attempts| attempts[index]),
-            ));
+            self.object_projection_executions
+                .push((collected.function.clone(), execution));
             match value {
                 crate::object_query::ObjectProjectionValue::Available(object) => {
                     objects.push(crate::object_query::CollectedObjectProjection {
@@ -5410,6 +5455,9 @@ impl CompilerSession {
             exports,
             warnings,
             work,
+            cfg_work,
+            codegen_work,
+            object_projection_work,
         })
     }
 

--- a/crates/rue-compiler/src/unstable.rs
+++ b/crates/rue-compiler/src/unstable.rs
@@ -532,6 +532,57 @@ pub struct ObjectsReady {
     generation: usize,
 }
 
+/// Aggregate lifecycle work for one canonical per-function query collection.
+///
+/// This is owned measurement data only. It contains no query keys, artifacts,
+/// or handles that can be installed back into a compiler session.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct EndpointQueryWork {
+    pub computed: usize,
+    pub reused: usize,
+    pub joined: usize,
+    pub canceled: usize,
+}
+
+impl From<crate::session::BackendQueryWork> for EndpointQueryWork {
+    fn from(work: crate::session::BackendQueryWork) -> Self {
+        Self {
+            computed: work.computed,
+            reused: work.reused,
+            joined: work.joined,
+            canceled: work.canceled,
+        }
+    }
+}
+
+/// Structural work available at the retained compilation endpoints.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct EndpointWork {
+    pub cfg: EndpointQueryWork,
+    pub codegen: EndpointQueryWork,
+    pub object_projection: EndpointQueryWork,
+}
+
+impl CodegenReady {
+    pub fn unstable_work(&self) -> EndpointWork {
+        EndpointWork {
+            cfg: self.rooted.cfg_work.into(),
+            codegen: self.rooted.codegen_work.into(),
+            object_projection: EndpointQueryWork::default(),
+        }
+    }
+}
+
+impl ObjectsReady {
+    pub fn unstable_work(&self) -> EndpointWork {
+        EndpointWork {
+            cfg: self.rooted.cfg_work.into(),
+            codegen: self.rooted.codegen_work.into(),
+            object_projection: self.rooted.object_projection_work.into(),
+        }
+    }
+}
+
 fn validate_endpoint_capability(
     session: &crate::CompilerSession,
     owner: &std::sync::Arc<()>,
@@ -1710,6 +1761,12 @@ impl MetricsSnapshot {
     }
     pub fn updates(&self) -> usize {
         self.inner.updates
+    }
+    pub fn imports(&self) -> QueryMetrics {
+        self.inner.imports.into()
+    }
+    pub fn import_diagnostics(&self) -> QueryMetrics {
+        self.inner.import_diagnostics.into()
     }
     pub fn merge(&self) -> QueryMetrics {
         self.inner.merge.into()

--- a/crates/rue-query/src/lib.rs
+++ b/crates/rue-query/src/lib.rs
@@ -8334,11 +8334,15 @@ mod tests {
              number of times (shard selection plus one in-shard lookup), \
              independent of the retained population"
         );
+        let present_probe_hashes = CONTAINS_HASH_CALLS.load(Ordering::Relaxed);
         assert!(!family.contains_retained_key(&CountingKey(64)));
-        assert_eq!(
-            CONTAINS_HASH_CALLS.load(Ordering::Relaxed),
-            4,
-            "a missing exact retained-key probe performs the same bounded lookup"
+        let missing_probe_hashes = CONTAINS_HASH_CALLS
+            .load(Ordering::Relaxed)
+            .saturating_sub(present_probe_hashes);
+        assert!(
+            (1..=2).contains(&missing_probe_hashes),
+            "a missing exact retained-key probe hashes only for shard selection \
+             and, when the selected shard exists, one in-shard lookup"
         );
 
         let predicate_visits = AtomicUsize::new(0);

--- a/crates/rue/src/host.rs
+++ b/crates/rue/src/host.rs
@@ -74,6 +74,12 @@ impl FilesystemCompilerHost {
         &self.state.resolution.context
     }
 
+    /// Return owned unstable instrumentation without exposing the retained
+    /// session or any query artifacts.
+    pub fn unstable_metrics(&self) -> rue_compiler::unstable::MetricsSnapshot {
+        self.state.session.unstable_metrics()
+    }
+
     /// Query RIR through the retained session for the CLI presentation path.
     pub fn rir(&mut self) -> MultiErrorResult<std::sync::Arc<RirView>> {
         self.state.session.rir()

--- a/docs/designs/0068-incremental-edit-performance-measurement.md
+++ b/docs/designs/0068-incremental-edit-performance-measurement.md
@@ -306,10 +306,10 @@ projects. None may introduce a peer compilation path.
   filesystem-backed reload/session seam into the shared driver library, add the
   narrow unstable codegen-ready projection, and keep the CLI on that same
   owner. — RUE-1246
-- [ ] **Phase 3: Retained-session runner.** Drive the shared host through the
+- [x] **Phase 3: Retained-session runner.** Drive the shared host through the
   diagnostics and three successful-compilation endpoints and serialize
   validated raw observations without duplicating source loading or compiler
-  orchestration. — follow-up issue
+  orchestration. — RUE-1251
 - [ ] **Phase 4: Maintained edit fixtures.** Add exact Mosaic and Lattice
   transformations, structural expectations, and warm/fresh oracle coverage. —
   follow-up issue


### PR DESCRIPTION
Fixes RUE-1251.

Adds the canonical retained-session measurement engine for ADR-0068, including isolated exact edits, cumulative compiler endpoints, structural work and retention projection, and a fresh-session correctness oracle. Exposes owned unstable endpoint-work metrics without allowing benchmark code to co-own the compiler query graph.

Also corrects a platform-sensitive `rue-query` complexity test exposed by Linux CI: missing exact-key probes may hash once when their shard is absent or twice when an in-shard lookup is needed; both remain bounded independently of retained population.

Validation:
- scripts/rue fmt
- //crates/rue-compiler:rue-compiler-test
- //crates/rue:rue-driver-test
- //crates/rue-bench:rue-bench-test
- //crates/rue-bench:rue-bench
- scripts/rue unit query
- scripts/rue quick
- scripts/rue premerge (all relevant tests passed; the repository scanner alone reports unrelated nested .claude worktrees)

Refs RUE-1248.