### PR TITLE
Guard Rue builds against host disk pressure

### DIFF
--- a/.buckconfig
+++ b/.buckconfig
@@ -32,6 +32,12 @@ clean_stale_enabled = true
 clean_stale_artifact_ttl_hours = 168
 clean_stale_period_hours = 24
 clean_stale_start_offset_hours = 12
+# When the host falls to 20% free space, promote the oldest non-active outputs
+# until Buck projects that the threshold has been restored. Outputs accessed in
+# the last twelve hours remain protected even under pressure.
+clean_stale_low_disk_threshold = 20
+clean_stale_low_disk_adaptive_enabled = true
+clean_stale_low_disk_adaptive_min_ttl_hours = 12
 
 [project]
 # Keep buck2 from parsing/watching non-source trees inside the project root:

--- a/BUCK
+++ b/BUCK
@@ -983,6 +983,7 @@ filegroup(
         "scripts/ci-heavy-suite",
         "scripts/cli-timeout-policy.py",
         "scripts/provision-build-cache",
+        "scripts/rue-storage",
         "test.sh",
     ],
 )

--- a/buck2
+++ b/buck2
@@ -31,6 +31,15 @@ for arg in "${args[@]}"; do
     esac
 done
 
+# Starting another disk-heavy command while the host is near ENOSPC is unsafe.
+# The guard is normally just one portable `df` read. At 10% free or lower it
+# asks Buck to reclaim eligible outputs from every registered Rue worktree,
+# preserving materializer state and active artifacts. `clean` itself is not an
+# execution command, so the host-wide guard cannot recurse through this wrapper.
+if [[ "$execution_command" -eq 1 ]] && [[ -x "$repo_root/scripts/rue-storage" ]]; then
+    (cd "$repo_root" && scripts/rue-storage guard)
+fi
+
 if [[ "$uses_remote_cache" -eq 1 ]] && [[ "$execution_command" -eq 1 ]] && [[ "$explicit_preference" -eq 0 ]]; then
     original_args=("${args[@]}")
     args=()

--- a/docs/development.md
+++ b/docs/development.md
@@ -29,6 +29,7 @@ scripts/rue fmt                      # format first-party Rust
 scripts/rue storage status           # inventory Buck usage across worktrees
 scripts/rue storage plan             # dry-run host-wide stale cleanup
 scripts/rue storage clean            # remove stale Buck artifacts host-wide
+scripts/rue storage guard            # run the emergency low-disk preflight now
 ```
 
 For direct compiler invocations, resolve the binary through `scripts/rue-bin`:

--- a/docs/process/build-cache.md
+++ b/docs/process/build-cache.md
@@ -56,18 +56,38 @@ have not been used for one week. Cleanup starts twelve hours after daemon startu
 and repeats daily. Buck coordinates those deletions with active builds; Rue does
 not infer that a worktree is disposable from its age or directory name.
 
+The background cleaner also watches the host filesystem. At 20% free space or
+lower it adaptively promotes the oldest non-active outputs until Buck projects
+that 20% will be free again. Outputs accessed in the last twelve hours remain
+protected even under pressure. This threshold is host-wide—the worktrees have
+separate materializer databases, but they consume the same filesystem budget.
+
 Use the host-wide storage command from any current Rue checkout:
 
 ```bash
 scripts/rue storage status            # sizes, source state, and cache state
 scripts/rue storage plan [AGE]        # Buck dry-run in every registered worktree
-scripts/rue storage clean [AGE]       # coordinated stale cleanup; default 1w
+scripts/rue storage clean [AGE]       # stale + adaptive cleanup; default 1w
+scripts/rue storage guard             # run the build preflight explicitly
 scripts/rue storage reset /exact/root # full Buck reset of an explicit target
 ```
 
+Every `./buck2 build`, `test`, `run`, or `install` invocation runs the same
+portable free-space preflight. Above 10% free it is only a `df` read. At 10% or
+lower it synchronously requests adaptive cleanup from every registered Rue
+worktree before allowing more disk-heavy work. If inventory or cleanup fails,
+the command stops with recovery guidance instead of proceeding toward ENOSPC.
+If tracked cleanup cannot escape the emergency threshold, the guard may fully
+reset the largest legacy `buck-out` trees whose checked-out revisions predate
+deferred materializer state. It uses the coordinator checkout's pinned Buck and
+refuses to reset a root with an active command. Dirty source state is unrelated
+and remains untouched. Between 10% and 20%, Buck's ordinary background policy
+restores headroom without putting every build behind a host-wide scan.
+
 The inventory comes from `git worktree list` and fails closed: if the registered
-set cannot be read, no cleanup runs. `clean` removes only stale or untracked Buck
-outputs. `reset` is the migration escape hatch for an older worktree whose
+set cannot be read, no cleanup runs. `clean` removes stale or untracked Buck
+outputs and may promote older tracked, non-active outputs when the host is below
+the 20% target. `reset` is the migration escape hatch for an older worktree whose
 artifacts predate persisted materializer state; it validates every named path as
 a registered Rue worktree before it resets any of them. Neither command removes
 source files or worktrees. `scripts/rue gc` remains a compatibility alias for

--- a/scripts/rue-storage
+++ b/scripts/rue-storage
@@ -10,15 +10,23 @@ usage() {
 usage: scripts/rue-storage status
        scripts/rue-storage plan [STALE_AGE]
        scripts/rue-storage clean [STALE_AGE]
+       scripts/rue-storage guard
        scripts/rue-storage reset RUE_ROOT [RUE_ROOT ...]
 
 status inventories every registered Rue worktree and its buck-out size. plan
 asks Buck what stale or untracked output it would remove. clean performs that
-coordinated stale cleanup (default age: 1w). reset fully removes Buck outputs
-only from the exact registered roots named by the caller. Source worktrees are
-never removed.
+coordinated stale cleanup (default age: 1w) and, below 20% host free space,
+adaptively removes the oldest eligible output while preserving a 12-hour
+minimum TTL. guard is the build preflight: at 10% free space or lower it runs
+that cleanup across every worktree before allowing more disk-heavy work. reset
+fully removes Buck outputs only from the exact registered roots named by the
+caller. Source worktrees are never removed.
 EOF
 }
+
+adaptive_target_percent=20
+adaptive_min_ttl=12h
+emergency_trigger_percent=10
 
 collect_roots() {
     local inventory
@@ -96,20 +104,122 @@ status_all() {
     done <<<"$roots"
     printf 'Total: %s in %d registered Rue worktree(s)\n' "$(human_kib "$total")" "$count"
     df -Pk "$repo_root" | awk 'NR == 2 { printf "Host filesystem: %s used, %.1f GiB available\n", $5, $4 / 1048576 }'
+    printf 'Policy: adaptive cleanup targets %d%% free (minimum TTL %s); emergency guard starts at %d%%\n' \
+        "$adaptive_target_percent" "$adaptive_min_ttl" "$emergency_trigger_percent"
 }
 
 stale_all() {
     local mode="$1" age="$2" root roots failed=0
+    local args=(
+        clean --stale "$age"
+        --adaptive-low-disk-threshold "$adaptive_target_percent"
+        --adaptive-min-ttl "$adaptive_min_ttl"
+    )
+    [[ "$mode" == plan ]] && args+=(--dry-run)
     roots="$(registered_roots)" || return 1
     while IFS= read -r root; do
         printf '\n%s: %s\n' "$mode" "$root"
-        if [[ "$mode" == plan ]]; then
-            (cd "$root" && ./buck2 clean --stale "$age" --dry-run) || failed=1
-        else
-            (cd "$root" && ./buck2 clean --stale "$age") || failed=1
-        fi
+        # Use the coordinator checkout's pinned Buck. A registered worktree may
+        # be on an older revision whose wrapper predates adaptive cleanup, but
+        # clean still operates on the project selected by this subshell's cwd.
+        (cd "$root" && "$repo_root/buck2" "${args[@]}") || failed=1
     done <<<"$roots"
     return "$failed"
+}
+
+free_basis_points() {
+    local basis_points
+    if ! basis_points="$(df -Pk "$repo_root" 2>/dev/null | awk '
+        NR == 2 && $2 > 0 { printf "%d\n", ($4 * 10000) / $2; found = 1 }
+        END { if (!found) exit 1 }
+    ')"; then
+        echo "error: cannot determine host free space; refusing disk-pressure preflight" >&2
+        return 1
+    fi
+    printf '%s\n' "$basis_points"
+}
+
+format_basis_points() {
+    local basis_points="$1"
+    printf '%d.%02d' "$((basis_points / 100))" "$((basis_points % 100))"
+}
+
+tracking_state() {
+    local root="$1" config
+    if ! config="$(cd "$root" && "$repo_root/buck2" audit config \
+        buck2.defer_write_actions --output-format json 2>/dev/null)"; then
+        echo "error: cannot inspect Buck materializer policy for $root" >&2
+        return 1
+    fi
+    if grep -q '"buck2.defer_write_actions":"true"' <<<"$config"; then
+        printf 'tracked\n'
+    else
+        printf 'legacy\n'
+    fi
+}
+
+reset_legacy_under_pressure() {
+    local roots root state kib entries="" now failed=0
+    roots="$(registered_roots)" || return 1
+    while IFS= read -r root; do
+        state="$(tracking_state "$root")" || return 1
+        if [[ "$state" == legacy ]]; then
+            kib="$(size_kib "$root")"
+            (( kib > 0 )) && entries+="${kib}"$'\t'"${root}"$'\n'
+        fi
+    done <<<"$roots"
+
+    while IFS=$'\t' read -r kib root; do
+        [[ -n "$root" ]] || continue
+        echo "warning: resetting legacy Buck state ($(human_kib "$kib")) in inactive worktree: $root" >&2
+        # A legacy checkout cannot participate in tracked stale cleanup. A full
+        # Buck reset is the only materializer-consistent migration. The
+        # not-idle guard refuses to interrupt an active command.
+        if ! (cd "$root" && "$repo_root/buck2" clean --exit-when notidle); then
+            echo "warning: could not reset legacy Buck state in $root (it may be active)" >&2
+            failed=1
+            continue
+        fi
+        now="$(free_basis_points)" || return 1
+        if (( now > emergency_trigger_percent * 100 )); then
+            return 0
+        fi
+    done <<<"$(printf '%s' "$entries" | sort -rn)"
+
+    (( failed == 0 )) || return 1
+    return 1
+}
+
+guard_low_disk() {
+    local before_basis_points after_basis_points before after
+    before_basis_points="$(free_basis_points)" || return 1
+    if (( before_basis_points > emergency_trigger_percent * 100 )); then
+        return 0
+    fi
+    before="$(format_basis_points "$before_basis_points")"
+
+    echo "warning: host filesystem has ${before}% free; running Rue's host-wide adaptive cleanup before building" >&2
+    if ! stale_all clean 1w; then
+        echo "error: host-wide cleanup failed under disk pressure; build stopped before risking ENOSPC" >&2
+        return 1
+    fi
+
+    after_basis_points="$(free_basis_points)" || return 1
+    after="$(format_basis_points "$after_basis_points")"
+    if (( after_basis_points <= emergency_trigger_percent * 100 )); then
+        echo "warning: host filesystem still has only ${after}% free; trying largest legacy Buck roots while preserving active work" >&2
+        if ! reset_legacy_under_pressure; then
+            echo "error: host filesystem remains critically low after safe cleanup; inspect 'scripts/rue storage status' before building" >&2
+            return 1
+        fi
+        after_basis_points="$(free_basis_points)" || return 1
+        after="$(format_basis_points "$after_basis_points")"
+    fi
+    if (( after_basis_points < adaptive_target_percent * 100 )); then
+        echo "warning: cleanup raised host free space to ${after}%, below the ${adaptive_target_percent}% target but above the emergency threshold" >&2
+    else
+        echo "Host free space after Rue cleanup: ${after}%" >&2
+    fi
 }
 
 canonical_registered_root() {
@@ -136,7 +246,7 @@ reset_roots() {
     done
     for root in "${roots[@]}"; do
         printf 'reset: %s\n' "$root"
-        (cd "$root" && ./buck2 clean)
+        (cd "$root" && "$repo_root/buck2" clean)
     done
 }
 
@@ -150,6 +260,10 @@ case "$command" in
     plan|clean)
         [[ $# -le 1 ]] || { usage >&2; exit 2; }
         stale_all "$command" "${1:-1w}"
+        ;;
+    guard)
+        [[ $# -eq 0 ]] || { usage >&2; exit 2; }
+        guard_low_disk
         ;;
     reset)
         [[ $# -gt 0 ]] || { usage >&2; exit 2; }

--- a/scripts/test-build-sharing.sh
+++ b/scripts/test-build-sharing.sh
@@ -103,12 +103,17 @@ EOF
 }
 
 test_buck_wrapper_prefers_local_cache_misses() {
-    local sb
+    local sb guard_calls rc
     sb="$(mktemp -d)"
-    mkdir -p "$sb/fakebin"
+    mkdir -p "$sb/fakebin" "$sb/scripts"
     cp "$SRC_ROOT/buck2" "$sb/buck2"
     cp "$SRC_ROOT/buck2-bin" "$sb/buck2-bin"
     chmod +x "$sb/buck2"
+    cat >"$sb/scripts/rue-storage" <<'EOF'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >>"$STORAGE_ARGS"
+EOF
+    chmod +x "$sb/scripts/rue-storage"
     cat >"$sb/.buckconfig.local" <<'EOF'
 [build]
 execution_platforms = root//platforms:remote_cache
@@ -119,20 +124,38 @@ printf '%s\n' "$@" >"$DOTSLASH_ARGS"
 EOF
     chmod +x "$sb/fakebin/dotslash"
 
-    DOTSLASH_ARGS="$sb/build.args" PATH="$sb/fakebin:$PATH" "$sb/buck2" build //:probe
+    STORAGE_ARGS="$sb/storage.args" DOTSLASH_ARGS="$sb/build.args" PATH="$sb/fakebin:$PATH" "$sb/buck2" build //:probe
     check "buck wrapper: cache misses prefer local execution" \
         "$(grep -Fxq -- '--prefer-local' "$sb/build.args" && echo 0 || echo 1)"
 
-    DOTSLASH_ARGS="$sb/remote.args" PATH="$sb/fakebin:$PATH" "$sb/buck2" build --prefer-remote //:probe
+    STORAGE_ARGS="$sb/storage.args" DOTSLASH_ARGS="$sb/remote.args" PATH="$sb/fakebin:$PATH" "$sb/buck2" build --prefer-remote //:probe
     check "buck wrapper: explicit execution preference is preserved" \
         "$(! grep -Fxq -- '--prefer-local' "$sb/remote.args" && grep -Fxq -- '--prefer-remote' "$sb/remote.args" && echo 0 || echo 1)"
 
-    DOTSLASH_ARGS="$sb/run.args" PATH="$sb/fakebin:$PATH" "$sb/buck2" run //:probe -- program-arg
+    STORAGE_ARGS="$sb/storage.args" DOTSLASH_ARGS="$sb/run.args" PATH="$sb/fakebin:$PATH" "$sb/buck2" run //:probe -- program-arg
     local local_line separator_line
     local_line="$(grep -nFx -- '--prefer-local' "$sb/run.args" | cut -d: -f1)"
     separator_line="$(grep -nFx -- '--' "$sb/run.args" | cut -d: -f1)"
     check "buck wrapper: preference stays before executable arguments" \
         "$([ "$local_line" -lt "$separator_line" ] && echo 0 || echo 1)"
+    guard_calls="$(grep -c '^guard$' "$sb/storage.args")"
+    check "buck wrapper: every execution command runs the disk-pressure guard" \
+        "$([ "$guard_calls" -eq 3 ] && echo 0 || echo 1)"
+
+    STORAGE_ARGS="$sb/storage.args" DOTSLASH_ARGS="$sb/clean.args" PATH="$sb/fakebin:$PATH" "$sb/buck2" clean
+    check "buck wrapper: cleanup commands do not recurse through the guard" \
+        "$([ "$(grep -c '^guard$' "$sb/storage.args")" -eq "$guard_calls" ] && echo 0 || echo 1)"
+
+    cat >"$sb/scripts/rue-storage" <<'EOF'
+#!/usr/bin/env bash
+exit 1
+EOF
+    chmod +x "$sb/scripts/rue-storage"
+    rc=0
+    STORAGE_ARGS="$sb/storage.args" DOTSLASH_ARGS="$sb/blocked.args" PATH="$sb/fakebin:$PATH" \
+        "$sb/buck2" test //:probe || rc=$?
+    check "buck wrapper: a failed pressure guard blocks disk-heavy work" \
+        "$([ "$rc" -ne 0 ] && [ ! -e "$sb/blocked.args" ] && echo 0 || echo 1)"
     rm -rf "$sb"
 }
 

--- a/scripts/test-cleanup-scripts.sh
+++ b/scripts/test-cleanup-scripts.sh
@@ -45,6 +45,13 @@ make_sandbox() {
   mkdir -p "$sb/scripts" "$sb/fakebin"
   cp "$SCRIPTS_DIR/$name" "$sb/scripts/$name"
   chmod +x "$sb/scripts/$name"
+  if [[ "$name" == rue-storage ]]; then
+    cat >"$sb/buck2" <<'EOF'
+#!/usr/bin/env bash
+printf '%s:%s\n' "$PWD" "$*" >>"$CALLS"
+EOF
+    chmod +x "$sb/buck2"
+  fi
   printf '%s\n' "$sb"
 }
 
@@ -178,7 +185,8 @@ setup_storage_root() {
   : >"$root/.buckconfig"
   cat >"$root/buck2" <<'EOF'
 #!/usr/bin/env bash
-printf '%s:%s\n' "$PWD" "$*" >>"$CALLS"
+printf 'unexpected worktree-local Buck invocation\n' >>"$CALLS"
+exit 99
 EOF
   chmod +x "$root/buck2"
 }
@@ -216,9 +224,97 @@ EOF
   chmod +x "$sb/fakebin/git"
   run_script "$sb" rue-storage plan 2d
   check "storage: dry-run covers every registered Rue worktree" \
-    "$([ "$(grep -c ':clean --stale 2d --dry-run' "$sb/calls.log")" -eq 2 ] && echo 0 || echo 1)"
+    "$([ "$(grep -c ':clean --stale 2d' "$sb/calls.log")" -eq 2 ] && echo 0 || echo 1)"
+  check "storage: plan never applies its cleanup" \
+    "$([ "$(grep -c -- '--dry-run' "$sb/calls.log")" -eq 2 ] && echo 0 || echo 1)"
+  check "storage: dry-run includes the adaptive host-free target" \
+    "$([ "$(grep -c -- '--adaptive-low-disk-threshold 20' "$sb/calls.log")" -eq 2 ] && echo 0 || echo 1)"
+  check "storage: dry-run protects the minimum TTL" \
+    "$([ "$(grep -c -- '--adaptive-min-ttl 12h' "$sb/calls.log")" -eq 2 ] && echo 0 || echo 1)"
   check "storage: dry-run never performs a full reset" \
     "$(! grep -Eq ':clean$' "$sb/calls.log" && echo 0 || echo 1)"
+  rm -rf "$sb"
+}
+
+test_storage_guard_is_host_wide_only_under_pressure() {
+  local sb rc=0; sb="$(make_sandbox rue-storage)"
+  setup_storage_root "$sb/root-1"
+  setup_storage_root "$sb/root-2"
+  cat >"$sb/fakebin/git" <<EOF
+#!/usr/bin/env bash
+if [[ "\$*" == *"worktree list --porcelain"* ]]; then
+  printf 'worktree %s/root-1\n\nworktree %s/root-2\n' "$sb" "$sb"
+  exit 0
+fi
+exit 1
+EOF
+  chmod +x "$sb/fakebin/git"
+
+  # First probe is below the 10% emergency threshold; the post-clean probe is
+  # above the 20% target.
+  cat >"$sb/fakebin/df" <<EOF
+#!/usr/bin/env bash
+count=0
+[[ -f "$sb/df-count" ]] && count=\$(cat "$sb/df-count")
+printf '%d\n' \$((count + 1)) >"$sb/df-count"
+printf 'Filesystem 1024-blocks Used Available Capacity Mounted on\n'
+if [[ \$count -eq 0 ]]; then
+  printf 'disk 100000 95000 5000 95%% /\n'
+else
+  printf 'disk 100000 75000 25000 75%% /\n'
+fi
+EOF
+  chmod +x "$sb/fakebin/df"
+  run_script "$sb" rue-storage guard || rc=$?
+  check "storage: pressure guard succeeds after recovering headroom" "$([ "$rc" -eq 0 ] && echo 0 || echo 1)"
+  check "storage: pressure guard cleans every registered worktree" \
+    "$([ "$(grep -c ':clean --stale 1w' "$sb/calls.log")" -eq 2 ] && echo 0 || echo 1)"
+  check "storage: pressure guard uses adaptive materializer cleanup" \
+    "$([ "$(grep -c -- '--adaptive-low-disk-threshold 20 --adaptive-min-ttl 12h' "$sb/calls.log")" -eq 2 ] && echo 0 || echo 1)"
+
+  : >"$sb/calls.log"
+  cat >"$sb/fakebin/df" <<'EOF'
+#!/usr/bin/env bash
+printf 'Filesystem 1024-blocks Used Available Capacity Mounted on\n'
+printf 'disk 100000 89500 10500 89.5%% /\n'
+EOF
+  chmod +x "$sb/fakebin/df"
+  rc=0
+  run_script "$sb" rue-storage guard || rc=$?
+  check "storage: healthy guard succeeds without cleanup" "$([ "$rc" -eq 0 ] && echo 0 || echo 1)"
+  check "storage: healthy guard starts no Buck cleanup" \
+    "$(! grep -q ':clean ' "$sb/calls.log" 2>/dev/null && echo 0 || echo 1)"
+  rm -rf "$sb"
+}
+
+test_storage_guard_blocks_when_pressure_remains_critical() {
+  local sb rc=0; sb="$(make_sandbox rue-storage)"
+  setup_storage_root "$sb/root-1"
+  printf 'legacy output\n' >"$sb/root-1/buck-out/legacy"
+  cat >"$sb/fakebin/git" <<EOF
+#!/usr/bin/env bash
+if [[ "\$*" == *"worktree list --porcelain"* ]]; then
+  printf 'worktree %s/root-1\n' "$sb"
+  exit 0
+fi
+exit 1
+EOF
+  chmod +x "$sb/fakebin/git"
+  cat >"$sb/fakebin/df" <<'EOF'
+#!/usr/bin/env bash
+printf 'Filesystem 1024-blocks Used Available Capacity Mounted on\n'
+printf 'disk 100000 95000 5000 95%% /\n'
+EOF
+  chmod +x "$sb/fakebin/df"
+  run_script "$sb" rue-storage guard || rc=$?
+  check "storage: guard refuses a build when cleanup cannot escape critical pressure" \
+    "$([ "$rc" -ne 0 ] && echo 0 || echo 1)"
+  check "storage: critical guard tries a materializer-consistent legacy reset" \
+    "$(grep -q ':clean --exit-when notidle' "$sb/calls.log" && echo 0 || echo 1)"
+  check "storage: coordinator never trusts a worktree-local Buck wrapper" \
+    "$(! grep -q 'unexpected worktree-local' "$sb/calls.log" && echo 0 || echo 1)"
+  grep -q 'stopped before risking ENOSPC\|still has only' "$sb/out.log" || \
+    fail "storage: expected actionable ENOSPC prevention notice"
   rm -rf "$sb"
 }
 
@@ -252,6 +348,8 @@ test_jjtidy_gh_failure_deletes_nothing
 test_jjtidy_only_deletes_proven_merged
 test_storage_git_failure_is_fail_closed
 test_storage_plans_every_registered_root
+test_storage_guard_is_host_wide_only_under_pressure
+test_storage_guard_blocks_when_pressure_remains_critical
 test_storage_reset_validates_all_targets_first
 
 echo "--------------------------------------------------"


### PR DESCRIPTION
## Summary

- configure Buck's native adaptive cleaner to target 20% host free space while protecting the last 12 hours of output
- run a cheap preflight before Buck build, test, run, and install commands; at 10% free or lower, reclaim eligible output across every registered Rue worktree before proceeding
- use the coordinator checkout's pinned Buck for host policy and safely reset only inactive legacy Buck state when tracked cleanup cannot escape critical pressure
- document the thresholds, failure behavior, and operator commands

## Why

Per-worktree stale cleanup bounded normal retention, but it did not stop a new disk-heavy command when aggregate host space was already near ENOSPC. Older registered worktrees can also predate deferred materializer tracking and otherwise evade stale cleanup.

The guard keeps all deletion inside Buck's materializer-aware paths. Active artifacts and source changes are preserved; an inventory or cleanup failure under critical pressure stops the new build instead of risking filesystem exhaustion.

## Validation

- `bash scripts/test-cleanup-scripts.sh` (21 checks)
- `bash scripts/test-build-sharing.sh` (29 checks)
- `./buck2 test //:cleanup-script-tests //:build-sharing-tests //:wrapper-script-tests` (167 assertions)
- `scripts/rue quick`
- `scripts/rue premerge`
- real adaptive `clean --dry-run` with the pinned Buck binary

Contributes to RUE-1225.
