### PR TITLE
RUE-1225: slim hermetic Rust toolchains

### DIFF
--- a/docs/process/build-cache.md
+++ b/docs/process/build-cache.md
@@ -140,10 +140,17 @@ they're recorded here so a future config change doesn't silently regress:
    knob are required — without them the client connects and downloads CAS
    inputs, but locally compiled Rust results never populate the action cache.
 4. **rustc under RE** (`toolchains/rust/defs.bzl`): rustc finds `librustc_driver.so`
-   via its native `$ORIGIN/../lib` RPATH, which only resolves if the whole toolchain
-   tree is materialized on the remote worker. The `compiler`/`rustdoc` RunInfo carry
-   the full distribution as a hidden input so RE uploads it co-located. This is the
-   relocatable, canonical fix — *not* an absolute-path `LD_LIBRARY_PATH` hack.
+   via its native `$ORIGIN/../lib` RPATH, which only resolves if the whole rustc
+   component tree is materialized on the remote worker. The `compiler`/`rustdoc`
+   RunInfo carry that component plus the separate standard-library component as
+   hidden inputs, so RE uploads the compiler co-located and preserves the merged
+   sysroot's relative links. This is the relocatable, canonical fix — *not* an
+   absolute-path `LD_LIBRARY_PATH` hack. Clippy and rustfmt are separate official
+   component archives; Rue does not materialize the monolithic distribution's
+   unused Cargo, rust-analyzer, LLVM tools, or documentation payloads. On macOS
+   ARM64 this reduces the unpacked host toolchain from about 1.67 GiB to 492 MiB
+   (71 percent), and the archives are execution dependencies so debug and
+   release target configurations share that payload.
 5. **Container** (`platforms/remote_cache.bzl`): pinned to `rbe-ubuntu22-04`
    (Python 3.10 — the prelude's rustc wrapper needs ≥3.9; the default image ships
    3.6), by immutable digest rather than by its moving tag. See

--- a/toolchains/BUCK
+++ b/toolchains/BUCK
@@ -4,8 +4,9 @@
 # - Rust toolchain: Downloaded prebuilt binaries (Rust 1.92.0)
 # - C++ toolchain: System (clang/gcc)
 #
-# The hermetic Rust toolchain downloads prebuilt binaries for each platform,
-# ensuring reproducible builds without depending on system-installed rustc.
+# The hermetic Rust toolchain downloads the pinned rustc, rust-std, Clippy, and
+# rustfmt components for each platform, ensuring reproducible builds without
+# depending on system-installed Rust or materializing unused distribution parts.
 #
 # Note: Building the Rue *compiler* is hermetic. However, *running* the Rue
 # compiler to produce executables has platform-specific requirements:

--- a/toolchains/rust/BUCK
+++ b/toolchains/rust/BUCK
@@ -1,9 +1,11 @@
 # Hermetic Rust toolchain configuration
 #
-# Downloads prebuilt Rust toolchains for reproducible builds.
-# The toolchain includes rustc, cargo, rust-lld, and the standard library.
+# Downloads only the prebuilt Rust components Rue uses: rustc/rustdoc and
+# rust-lld, the standard library, Clippy, and rustfmt. The monolithic Rust
+# archive also contains Cargo, rust-analyzer, LLVM tools, and large documentation
+# trees; materializing those unused payloads in every worktree is wasteful.
 
-load(":defs.bzl", "RUST_VERSION", "RUST_RELEASES", "RUST_STD_RELEASES", "hermetic_rust_toolchain", "rustfmt", "host_rustfmt")
+load(":defs.bzl", "RUST_VERSION", "RUST_STD_RELEASES", "hermetic_rust_toolchain", "rust_host_archives", "rustfmt", "host_rustfmt")
 load("@root//:test_defs.bzl", "rue_sh_test")
 
 export_file(
@@ -17,49 +19,14 @@ rue_sh_test(
     args = ["$(location :merge-sysroot)"],
 )
 
-# Download Rust for Linux x86_64
-http_archive(
-    name = "rust-linux-x86_64",
-    urls = [RUST_RELEASES["x86_64-unknown-linux-gnu"].url],
-    sha256 = RUST_RELEASES["x86_64-unknown-linux-gnu"].sha256,
-    strip_prefix = "rust-{}-x86_64-unknown-linux-gnu".format(RUST_VERSION),
-    type = "tar.xz",
-    visibility = [],
-)
+rust_host_archives("linux-x86_64", "x86_64-unknown-linux-gnu")
+rust_host_archives("linux-aarch64", "aarch64-unknown-linux-gnu")
+rust_host_archives("macos-aarch64", "aarch64-apple-darwin")
+rust_host_archives("macos-x86_64", "x86_64-apple-darwin")
 
-# Download Rust for Linux ARM64
-http_archive(
-    name = "rust-linux-aarch64",
-    urls = [RUST_RELEASES["aarch64-unknown-linux-gnu"].url],
-    sha256 = RUST_RELEASES["aarch64-unknown-linux-gnu"].sha256,
-    strip_prefix = "rust-{}-aarch64-unknown-linux-gnu".format(RUST_VERSION),
-    type = "tar.xz",
-    visibility = [],
-)
-
-# Download Rust for macOS ARM64 (Apple Silicon)
-http_archive(
-    name = "rust-macos-aarch64",
-    urls = [RUST_RELEASES["aarch64-apple-darwin"].url],
-    sha256 = RUST_RELEASES["aarch64-apple-darwin"].sha256,
-    strip_prefix = "rust-{}-aarch64-apple-darwin".format(RUST_VERSION),
-    type = "tar.xz",
-    visibility = [],
-)
-
-# Download Rust for macOS x86_64 (Intel)
-http_archive(
-    name = "rust-macos-x86_64",
-    urls = [RUST_RELEASES["x86_64-apple-darwin"].url],
-    sha256 = RUST_RELEASES["x86_64-apple-darwin"].sha256,
-    strip_prefix = "rust-{}-x86_64-apple-darwin".format(RUST_VERSION),
-    type = "tar.xz",
-    visibility = [],
-)
-
-# Target standard-library components used by the fixed-target Rue runtime
-# rules. Unlike the full distributions above, these are compiler-host agnostic:
-# whichever hermetic rustc runs consumes the same pinned target sysroot.
+# Standard-library components used by the host toolchains and fixed-target Rue
+# runtime rules. They are compiler-host agnostic: whichever hermetic rustc runs
+# consumes the same pinned target sysroot.
 http_archive(
     name = "rust-std-x86_64-unknown-linux-gnu",
     urls = [RUST_STD_RELEASES["x86_64-unknown-linux-gnu"].url],
@@ -83,6 +50,15 @@ http_archive(
     urls = [RUST_STD_RELEASES["aarch64-apple-darwin"].url],
     sha256 = RUST_STD_RELEASES["aarch64-apple-darwin"].sha256,
     strip_prefix = "rust-std-{}-aarch64-apple-darwin".format(RUST_VERSION),
+    type = "tar.xz",
+    visibility = ["PUBLIC"],
+)
+
+http_archive(
+    name = "rust-std-x86_64-apple-darwin",
+    urls = [RUST_STD_RELEASES["x86_64-apple-darwin"].url],
+    sha256 = RUST_STD_RELEASES["x86_64-apple-darwin"].sha256,
+    strip_prefix = "rust-std-{}-x86_64-apple-darwin".format(RUST_VERSION),
     type = "tar.xz",
     visibility = ["PUBLIC"],
 )
@@ -195,7 +171,9 @@ _CLIPPY_ALLOW = [
 # Hermetic toolchain for Linux x86_64
 hermetic_rust_toolchain(
     name = "hermetic-linux-x86_64",
-    distribution = ":rust-linux-x86_64",
+    rustc_distribution = ":rustc-linux-x86_64",
+    standard_library_distribution = ":rust-std-x86_64-unknown-linux-gnu",
+    clippy_distribution = ":clippy-linux-x86_64",
     merge_script = ":merge-sysroot",
     target_triple = "x86_64-unknown-linux-gnu",
     default_edition = "2024",
@@ -208,7 +186,9 @@ hermetic_rust_toolchain(
 # Hermetic toolchain for Linux ARM64
 hermetic_rust_toolchain(
     name = "hermetic-linux-aarch64",
-    distribution = ":rust-linux-aarch64",
+    rustc_distribution = ":rustc-linux-aarch64",
+    standard_library_distribution = ":rust-std-aarch64-unknown-linux-gnu",
+    clippy_distribution = ":clippy-linux-aarch64",
     merge_script = ":merge-sysroot",
     target_triple = "aarch64-unknown-linux-gnu",
     default_edition = "2024",
@@ -221,7 +201,9 @@ hermetic_rust_toolchain(
 # Hermetic toolchain for macOS ARM64
 hermetic_rust_toolchain(
     name = "hermetic-macos-aarch64",
-    distribution = ":rust-macos-aarch64",
+    rustc_distribution = ":rustc-macos-aarch64",
+    standard_library_distribution = ":rust-std-aarch64-apple-darwin",
+    clippy_distribution = ":clippy-macos-aarch64",
     merge_script = ":merge-sysroot",
     target_triple = "aarch64-apple-darwin",
     default_edition = "2024",
@@ -234,7 +216,9 @@ hermetic_rust_toolchain(
 # Hermetic toolchain for macOS x86_64
 hermetic_rust_toolchain(
     name = "hermetic-macos-x86_64",
-    distribution = ":rust-macos-x86_64",
+    rustc_distribution = ":rustc-macos-x86_64",
+    standard_library_distribution = ":rust-std-x86_64-apple-darwin",
+    clippy_distribution = ":clippy-macos-x86_64",
     merge_script = ":merge-sysroot",
     target_triple = "x86_64-apple-darwin",
     default_edition = "2024",
@@ -247,25 +231,29 @@ hermetic_rust_toolchain(
 # Rustfmt for each platform
 rustfmt(
     name = "rustfmt-linux-x86_64",
-    distribution = ":rust-linux-x86_64",
+    rustc_distribution = ":rustc-linux-x86_64",
+    rustfmt_distribution = ":rustfmt-dist-linux-x86_64",
     visibility = ["PUBLIC"],
 )
 
 rustfmt(
     name = "rustfmt-linux-aarch64",
-    distribution = ":rust-linux-aarch64",
+    rustc_distribution = ":rustc-linux-aarch64",
+    rustfmt_distribution = ":rustfmt-dist-linux-aarch64",
     visibility = ["PUBLIC"],
 )
 
 rustfmt(
     name = "rustfmt-macos-aarch64",
-    distribution = ":rust-macos-aarch64",
+    rustc_distribution = ":rustc-macos-aarch64",
+    rustfmt_distribution = ":rustfmt-dist-macos-aarch64",
     visibility = ["PUBLIC"],
 )
 
 rustfmt(
     name = "rustfmt-macos-x86_64",
-    distribution = ":rust-macos-x86_64",
+    rustc_distribution = ":rustc-macos-x86_64",
+    rustfmt_distribution = ":rustfmt-dist-macos-x86_64",
     visibility = ["PUBLIC"],
 )
 

--- a/toolchains/rust/defs.bzl
+++ b/toolchains/rust/defs.bzl
@@ -8,28 +8,42 @@ load("@prelude//rust:rust_toolchain.bzl", "PanicRuntime", "RustToolchainInfo")
 # Rust 1.92.0 release info
 RUST_VERSION = "1.92.0"
 
-# SHA256 hashes for each platform's Rust distribution
-# These are the official hashes from static.rust-lang.org
+# Official component archives and SHA256 hashes from Rust's 1.92.0 channel
+# manifest. Download only the compiler, Clippy, and rustfmt components: the
+# monolithic `rust` archive also carries Cargo, rust-analyzer, LLVM tools, and
+# two documentation trees that Rue never consumes.
 RUST_RELEASES = {
     "x86_64-unknown-linux-gnu": struct(
-        url = "https://static.rust-lang.org/dist/rust-1.92.0-x86_64-unknown-linux-gnu.tar.xz",
-        sha256 = "d2ccef59dd9f7439f2c694948069f789a044dc1addcc0803613232af8f88ee0c",
-        triple = "x86_64-unknown-linux-gnu",
+        rustc_url = "https://static.rust-lang.org/dist/rustc-1.92.0-x86_64-unknown-linux-gnu.tar.xz",
+        rustc_sha256 = "78b2dd9c6b1fcd2621fa81c611cf5e2d6950690775038b585c64f364422886e0",
+        clippy_url = "https://static.rust-lang.org/dist/clippy-1.92.0-x86_64-unknown-linux-gnu.tar.xz",
+        clippy_sha256 = "2c1bf6e7da8ec50feba03fe188fc9a744ba59e2c6ece7970c13e201d08defa9a",
+        rustfmt_url = "https://static.rust-lang.org/dist/rustfmt-1.92.0-x86_64-unknown-linux-gnu.tar.xz",
+        rustfmt_sha256 = "38951ee55f21e9170236fc98c8ba373ae4338d863087c6b0a5fa8c4e797d52c4",
     ),
     "aarch64-unknown-linux-gnu": struct(
-        url = "https://static.rust-lang.org/dist/rust-1.92.0-aarch64-unknown-linux-gnu.tar.xz",
-        sha256 = "3e383f8b4fca710d0600d0c1de97b78281672be2cda6575ecbe1c183a12e3822",
-        triple = "aarch64-unknown-linux-gnu",
+        rustc_url = "https://static.rust-lang.org/dist/rustc-1.92.0-aarch64-unknown-linux-gnu.tar.xz",
+        rustc_sha256 = "7c8706fad4c038b5eacab0092e15db54d2b365d5f3323ca046fe987f814e7826",
+        clippy_url = "https://static.rust-lang.org/dist/clippy-1.92.0-aarch64-unknown-linux-gnu.tar.xz",
+        clippy_sha256 = "333ab38c673b589468b8293b525e5704fb52515d9d516ee28d3d34dd5a63d3c3",
+        rustfmt_url = "https://static.rust-lang.org/dist/rustfmt-1.92.0-aarch64-unknown-linux-gnu.tar.xz",
+        rustfmt_sha256 = "1dce37aea2a7cb801f1756ffc531d7140428315a3d2c2f836272547eb7b9dacd",
     ),
     "aarch64-apple-darwin": struct(
-        url = "https://static.rust-lang.org/dist/rust-1.92.0-aarch64-apple-darwin.tar.xz",
-        sha256 = "22276ecf826b22e718f099d7bf7ddb8c88aa46230fdba74962ab3c5031472268",
-        triple = "aarch64-apple-darwin",
+        rustc_url = "https://static.rust-lang.org/dist/rustc-1.92.0-aarch64-apple-darwin.tar.xz",
+        rustc_sha256 = "15dee753c9217dff4cf45d734b29dc13ce6017d8a55fe34eed75022b39a63ff0",
+        clippy_url = "https://static.rust-lang.org/dist/clippy-1.92.0-aarch64-apple-darwin.tar.xz",
+        clippy_sha256 = "08c65b6cf8faae3861706f8c97acf2aa6b784ed9455354c3b13495a7cfe5cb84",
+        rustfmt_url = "https://static.rust-lang.org/dist/rustfmt-1.92.0-aarch64-apple-darwin.tar.xz",
+        rustfmt_sha256 = "5d8ea865a7999dc9141603be8a9352745bf8440da051eb1c43f0fcaaf6845441",
     ),
     "x86_64-apple-darwin": struct(
-        url = "https://static.rust-lang.org/dist/rust-1.92.0-x86_64-apple-darwin.tar.xz",
-        sha256 = "ef71fcdcd50efd3301144e701faf15124113a1b2efe9a111175d7d1e4f2d31d2",
-        triple = "x86_64-apple-darwin",
+        rustc_url = "https://static.rust-lang.org/dist/rustc-1.92.0-x86_64-apple-darwin.tar.xz",
+        rustc_sha256 = "0facbd5d2742c8e97c53d59c9b5b81db6088cfc285d9ecb99523a50d6765fc5c",
+        clippy_url = "https://static.rust-lang.org/dist/clippy-1.92.0-x86_64-apple-darwin.tar.xz",
+        clippy_sha256 = "39cce87aab3d8b71350edcb3f943fba7bc59581ce1e65e158ee01e64cf0f1cf5",
+        rustfmt_url = "https://static.rust-lang.org/dist/rustfmt-1.92.0-x86_64-apple-darwin.tar.xz",
+        rustfmt_sha256 = "e038bda323ed7f4d417efc5be44c4245d74b8394f9f8393b9d464d662c3a9499",
     ),
 }
 
@@ -49,10 +63,42 @@ RUST_STD_RELEASES = {
         url = "https://static.rust-lang.org/dist/rust-std-1.92.0-aarch64-apple-darwin.tar.xz",
         sha256 = "ea619984fcb8e24b05dbd568d599b8e10d904435ab458dfba6469e03e0fd69aa",
     ),
+    "x86_64-apple-darwin": struct(
+        url = "https://static.rust-lang.org/dist/rust-std-1.92.0-x86_64-apple-darwin.tar.xz",
+        sha256 = "6ce143bf9e83c71e200f4180e8774ab22c8c8c2351c88484b13ff13be82c8d57",
+    ),
 }
 
-# Paths within the extracted Rust distribution
-# After http_archive extracts and strips the prefix, we have:
+def rust_host_archives(name: str, triple: str):
+    """Declare the minimal official host components for one Rust platform."""
+    release = RUST_RELEASES[triple]
+    native.http_archive(
+        name = "rustc-{}".format(name),
+        urls = [release.rustc_url],
+        sha256 = release.rustc_sha256,
+        strip_prefix = "rustc-{}-{}".format(RUST_VERSION, triple),
+        type = "tar.xz",
+        visibility = [],
+    )
+    native.http_archive(
+        name = "clippy-{}".format(name),
+        urls = [release.clippy_url],
+        sha256 = release.clippy_sha256,
+        strip_prefix = "clippy-{}-{}".format(RUST_VERSION, triple),
+        type = "tar.xz",
+        visibility = [],
+    )
+    native.http_archive(
+        name = "rustfmt-dist-{}".format(name),
+        urls = [release.rustfmt_url],
+        sha256 = release.rustfmt_sha256,
+        strip_prefix = "rustfmt-{}-{}".format(RUST_VERSION, triple),
+        type = "tar.xz",
+        visibility = [],
+    )
+
+# Paths within the extracted Rust component archives. After http_archive strips
+# each outer prefix, we have:
 #   rustc/bin/rustc, rustc/bin/rustdoc
 #   rustc/lib/rustlib/{triple}/bin/rust-lld (linker tools)
 #   clippy-preview/bin/clippy-driver
@@ -65,24 +111,26 @@ RUST_STD_RELEASES = {
 def _hermetic_rust_toolchain_impl(ctx: AnalysisContext) -> list[Provider]:
     """Implementation of hermetic_rust_toolchain rule."""
 
-    dist = ctx.attrs.distribution[DefaultInfo].default_outputs[0]
+    rustc_dist = ctx.attrs.rustc_distribution[DefaultInfo].default_outputs[0]
+    std_dist = ctx.attrs.standard_library_distribution[DefaultInfo].default_outputs[0]
+    clippy_dist = ctx.attrs.clippy_distribution[DefaultInfo].default_outputs[0]
     triple = ctx.attrs.target_triple
 
     # Paths to binaries
-    rustc_bin = dist.project("rustc/bin/rustc")
-    rustdoc_bin = dist.project("rustc/bin/rustdoc")
-    clippy_bin = dist.project("clippy-preview/bin/clippy-driver")
+    rustc_bin = rustc_dist.project("rustc/bin/rustc")
+    rustdoc_bin = rustc_dist.project("rustc/bin/rustdoc")
+    clippy_bin = clippy_dist.project("clippy-preview/bin/clippy-driver")
 
-    # Create RunInfo for each tool. Include the full distribution as a hidden
-    # input so rustc/rustdoc's native $ORIGIN/../lib RPATH resolves under REMOTE
-    # execution too: RE materializes the toolchain tree on the remote worker, so
-    # rustc/bin/rustc must land co-located with rustc/lib/ (where librustc_driver
-    # lives). Locally the http_archive tree is already co-located, so this is a
-    # no-op there; on RE it's what makes rustc find its shared libs (RUE-316).
+    # Create RunInfo for each tool. Include the component trees as hidden inputs
+    # so rustc/rustdoc's native $ORIGIN/../lib RPATH resolves under REMOTE
+    # execution too: RE materializes the rustc component tree on the worker, so
+    # rustc/bin/rustc lands co-located with rustc/lib/ (where librustc_driver
+    # lives). The separate standard-library component is also hidden because the
+    # merged sysroot contains relative links into it (RUE-316/RUE-1225).
     # This is the relocatable, canonical approach ($ORIGIN RPATH), not an
     # absolute-path LD_LIBRARY_PATH hack.
-    compiler = RunInfo(args = cmd_args(rustc_bin, hidden = [dist]))
-    rustdoc = RunInfo(args = cmd_args(rustdoc_bin, hidden = [dist]))
+    compiler = RunInfo(args = cmd_args(rustc_bin, hidden = [rustc_dist, std_dist]))
+    rustdoc = RunInfo(args = cmd_args(rustdoc_bin, hidden = [rustc_dist, std_dist]))
 
     # clippy-driver dynamically loads librustc_driver from rustc/lib/, but
     # unlike rustc that dir isn't on the loader's search path, so a bare
@@ -96,7 +144,7 @@ def _hermetic_rust_toolchain_impl(ctx: AnalysisContext) -> list[Provider]:
     # `format` is applied per-argument — a multi-arg RunInfo would emit one
     # broken `<arg> "$@"` line per element. So we bake the paths into a
     # self-contained script and point RunInfo at just that file.
-    clippy_lib_dir = dist.project("rustc/lib")
+    clippy_lib_dir = rustc_dist.project("rustc/lib")
     clippy_wrapper, _ = ctx.actions.write(
         "clippy_driver_wrapper.sh",
         [
@@ -109,14 +157,14 @@ def _hermetic_rust_toolchain_impl(ctx: AnalysisContext) -> list[Provider]:
         is_executable = True,
         allow_args = True,
     )
-    clippy_driver = RunInfo(args = cmd_args(clippy_wrapper, hidden = [clippy_bin, clippy_lib_dir]))
+    clippy_driver = RunInfo(args = cmd_args(clippy_wrapper, hidden = [clippy_bin, clippy_lib_dir, std_dist]))
 
     # Build a merged sysroot by running the checked-in shell script. Keeping the
     # script as an explicit action input ensures content changes invalidate the
     # action cache along with the generated sysroot.
-    # The Rust distribution has components in separate directories that need merging:
-    #   rustc/                                      - compiler and core libs
-    #   rust-std-{triple}/lib/rustlib/{triple}/lib/ - stdlib rlibs
+    # The Rust components are separate archives that need merging:
+    #   rustc_dist/rustc/                                      - compiler and core libs
+    #   std_dist/rust-std-{triple}/lib/rustlib/{triple}/lib/   - stdlib rlibs
     #
     # We use a shell action to create symlinks properly merging these.
     sysroot = ctx.actions.declare_output("sysroot", dir = True)
@@ -126,7 +174,8 @@ def _hermetic_rust_toolchain_impl(ctx: AnalysisContext) -> list[Provider]:
         cmd_args(
             "/bin/bash",
             merge_script,
-            dist,
+            rustc_dist,
+            std_dist,
             sysroot.as_output(),
             triple,
         ),
@@ -161,8 +210,17 @@ def _hermetic_rust_toolchain_impl(ctx: AnalysisContext) -> list[Provider]:
 hermetic_rust_toolchain = rule(
     impl = _hermetic_rust_toolchain_impl,
     attrs = {
-        "distribution": attrs.dep(
-            doc = "The downloaded Rust distribution (from http_archive)",
+        # Toolchain payloads are consumed by build actions, so configure them
+        # for the execution platform. A target-configured dep would materialize
+        # the same archive again for every debug/release target configuration.
+        "rustc_distribution": attrs.exec_dep(
+            doc = "The downloaded rustc component (from http_archive)",
+        ),
+        "standard_library_distribution": attrs.exec_dep(
+            doc = "The downloaded rust-std component (from http_archive)",
+        ),
+        "clippy_distribution": attrs.exec_dep(
+            doc = "The downloaded Clippy component (from http_archive)",
         ),
         "merge_script": attrs.source(
             doc = "Portable script that assembles a relocatable Rust sysroot",
@@ -188,14 +246,15 @@ hermetic_rust_toolchain = rule(
 
 # Rule to expose rustfmt from the hermetic toolchain
 def _rustfmt_impl(ctx: AnalysisContext) -> list[Provider]:
-    """Exposes rustfmt binary from the Rust distribution.
+    """Exposes rustfmt from the separate rustc and rustfmt components.
 
     rustfmt needs librustc_driver.dylib to be at ../lib/ relative to the binary.
     We create a wrapper script that sets up the environment correctly.
     """
-    dist = ctx.attrs.distribution[DefaultInfo].default_outputs[0]
-    rustfmt_bin = dist.project("rustfmt-preview/bin/rustfmt")
-    lib_dir = dist.project("rustc/lib")
+    rustc_dist = ctx.attrs.rustc_distribution[DefaultInfo].default_outputs[0]
+    rustfmt_dist = ctx.attrs.rustfmt_distribution[DefaultInfo].default_outputs[0]
+    rustfmt_bin = rustfmt_dist.project("rustfmt-preview/bin/rustfmt")
+    lib_dir = rustc_dist.project("rustc/lib")
 
     # Create a wrapper script that sets the library path
     wrapper = ctx.actions.write(
@@ -219,8 +278,13 @@ def _rustfmt_impl(ctx: AnalysisContext) -> list[Provider]:
 rustfmt = rule(
     impl = _rustfmt_impl,
     attrs = {
-        "distribution": attrs.dep(
-            doc = "The downloaded Rust distribution (from http_archive)",
+        # rustfmt runs on the execution host; keep its component archives out
+        # of each target configuration for the same reason as the toolchain.
+        "rustc_distribution": attrs.exec_dep(
+            doc = "The downloaded rustc component (from http_archive)",
+        ),
+        "rustfmt_distribution": attrs.exec_dep(
+            doc = "The downloaded rustfmt component (from http_archive)",
         ),
     },
 )

--- a/toolchains/rust/merge_sysroot.sh
+++ b/toolchains/rust/merge_sysroot.sh
@@ -2,15 +2,17 @@
 
 set -euo pipefail
 
-dist=$1
-sysroot=$2
-triple=$3
+rustc_dist=$1
+std_dist=$2
+sysroot=$3
+triple=$4
 
 # Work with absolute paths while calculating each link, but only store the
 # relative path between the link's directory and its target. Unlike `ln -r` or
 # `realpath --relative-to`, this uses only shell path manipulation available in
 # the Bash shipped by macOS as well as Linux.
-dist=$(cd "$dist" && pwd)
+rustc_dist=$(cd "$rustc_dist" && pwd)
+std_dist=$(cd "$std_dist" && pwd)
 sysroot_parent=$(cd "$(dirname "$sysroot")" && pwd)
 sysroot="$sysroot_parent/$(basename "$sysroot")"
 
@@ -74,13 +76,13 @@ link_relative() {
 # Create the sysroot structure and merge the separately packaged compiler and
 # standard-library components into the layout rustc expects.
 mkdir -p "$sysroot"
-link_relative "$dist/rustc/bin" "$sysroot/bin"
-link_relative "$dist/rustc/libexec" "$sysroot/libexec"
+link_relative "$rustc_dist/rustc/bin" "$sysroot/bin"
+link_relative "$rustc_dist/rustc/libexec" "$sysroot/libexec"
 
 mkdir -p "$sysroot/lib/rustlib/$triple"
 
 # Link compiler libraries while reserving rustlib for the merged structure.
-for file in "$dist/rustc/lib/"*; do
+for file in "$rustc_dist/rustc/lib/"*; do
     name=$(basename "$file")
     if [ "$name" != "rustlib" ]; then
         link_relative "$file" "$sysroot/lib/$name"
@@ -88,11 +90,11 @@ for file in "$dist/rustc/lib/"*; do
 done
 
 link_relative \
-    "$dist/rustc/lib/rustlib/etc" \
+    "$rustc_dist/rustc/lib/rustlib/etc" \
     "$sysroot/lib/rustlib/etc"
 link_relative \
-    "$dist/rustc/lib/rustlib/$triple/bin" \
+    "$rustc_dist/rustc/lib/rustlib/$triple/bin" \
     "$sysroot/lib/rustlib/$triple/bin"
 link_relative \
-    "$dist/rust-std-$triple/lib/rustlib/$triple/lib" \
+    "$std_dist/rust-std-$triple/lib/rustlib/$triple/lib" \
     "$sysroot/lib/rustlib/$triple/lib"

--- a/toolchains/rust/merge_sysroot_test.sh
+++ b/toolchains/rust/merge_sysroot_test.sh
@@ -8,26 +8,27 @@ test_root=$(mktemp -d "${TMPDIR:-/tmp}/rue-merge-sysroot.XXXXXX")
 trap 'rm -rf "$test_root"' EXIT
 
 producer="$test_root/original/producer"
-dist="$producer/dist"
+rustc_dist="$producer/rustc-dist"
+std_dist="$producer/std-dist"
 sysroot="$producer/sysroot"
 
 mkdir -p \
-    "$dist/rustc/bin" \
-    "$dist/rustc/libexec" \
-    "$dist/rustc/lib/rustlib/etc" \
-    "$dist/rustc/lib/rustlib/$triple/bin" \
-    "$dist/rust-std-$triple/lib/rustlib/$triple/lib"
+    "$rustc_dist/rustc/bin" \
+    "$rustc_dist/rustc/libexec" \
+    "$rustc_dist/rustc/lib/rustlib/etc" \
+    "$rustc_dist/rustc/lib/rustlib/$triple/bin" \
+    "$std_dist/rust-std-$triple/lib/rustlib/$triple/lib"
 
-printf 'rustc\n' > "$dist/rustc/bin/rustc"
-printf 'rustdoc\n' > "$dist/rustc/bin/rustdoc"
-printf 'libexec\n' > "$dist/rustc/libexec/rust-analyzer-proc-macro-srv"
-printf 'compiler dylib\n' > "$dist/rustc/lib/librustc_driver.fake"
-printf 'debugger helpers\n' > "$dist/rustc/lib/rustlib/etc/gdb_load_rust_pretty_printers.py"
-printf 'linker\n' > "$dist/rustc/lib/rustlib/$triple/bin/rust-lld"
+printf 'rustc\n' > "$rustc_dist/rustc/bin/rustc"
+printf 'rustdoc\n' > "$rustc_dist/rustc/bin/rustdoc"
+printf 'libexec\n' > "$rustc_dist/rustc/libexec/rust-analyzer-proc-macro-srv"
+printf 'compiler dylib\n' > "$rustc_dist/rustc/lib/librustc_driver.fake"
+printf 'debugger helpers\n' > "$rustc_dist/rustc/lib/rustlib/etc/gdb_load_rust_pretty_printers.py"
+printf 'linker\n' > "$rustc_dist/rustc/lib/rustlib/$triple/bin/rust-lld"
 printf 'standard library\n' > \
-    "$dist/rust-std-$triple/lib/rustlib/$triple/lib/libstd.fake.rlib"
+    "$std_dist/rust-std-$triple/lib/rustlib/$triple/lib/libstd.fake.rlib"
 
-/bin/bash "$merge_script" "$dist" "$sysroot" "$triple"
+/bin/bash "$merge_script" "$rustc_dist" "$std_dist" "$sysroot" "$triple"
 
 assert_relative_link() {
     local path=$1


### PR DESCRIPTION
## Summary

- replace the monolithic Rust distribution with pinned official rustc, rust-std, Clippy, and rustfmt component archives
- configure those archives as execution dependencies so debug and release graphs share one payload
- preserve relocatable local and remote sysroots across the separated component trees
- document the measured macOS ARM64 reduction from about 1.67 GiB to 492 MiB (71 percent)

## Validation

- merge-sysroot focused test
- rustfmt invocation
- compiler build
- Clippy across all 65 first-party targets
- scripts/rue quick
- scripts/rue premerge (79 targets)

Fixes RUE-1225.