### PR TITLE
RUE-1252: add maintained incremental edit fixtures

### DIFF
--- a/crates/rue-bench/BUCK
+++ b/crates/rue-bench/BUCK
@@ -14,5 +14,6 @@ rue_binary(
         "//third-party:serde_json",
         "//third-party:sha2",
         "//third-party:tempfile",
+        "//third-party:toml",
     ],
 )

--- a/crates/rue-bench/src/incremental.rs
+++ b/crates/rue-bench/src/incremental.rs
@@ -4,20 +4,209 @@
 //! isolation, exact mutation, endpoint timing, structural projection, and the
 //! fresh-session oracle so later suites cannot accidentally redefine a sample.
 
+use std::collections::BTreeSet;
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::time::Instant;
 
 use rue_compiler::unstable::{EndpointQueryWork, EndpointWork, MetricsSnapshot};
-use rue_compiler::{CompileErrors, CompileOptions, CompileOutput, CompileWarning};
+use rue_compiler::{CompileErrors, CompileOptions, CompileOutput, CompileWarning, OptLevel};
 use rue_driver::{FilesystemCompilerHost, HostOpenRequest, SourceLoadError};
 use rue_perf_schema::{
-    EditEndpoints, EditManifest, EditOutcome, EditReport, EditSample, ExpectedEditOutcome,
-    FailureStage, OracleComparison, OutcomeIdentity, OutcomeKind, PhaseWork, RetainedGauges,
-    SourceShape, StructuralWork, TransformationIdentity, WorkerMode, canonical_json,
-    validate_edit_report,
+    EDIT_REPORT_SCHEMA_VERSION, EditEndpoints, EditManifest, EditOutcome, EditReport,
+    EditReportIdentity, EditReportRegime, EditRow, EditSample, EditScenario, ExpectedEditOutcome,
+    FailureStage, OptimizationSetting, OracleComparison, OutcomeIdentity, OutcomeKind, PhaseWork,
+    RetainedGauges, RetentionSequence, RetentionStep, RetentionStepOutcome, SourceShape,
+    StructuralWork, TransformationIdentity, WorkerMode, canonical_json, validate_edit_report,
 };
+use serde::Deserialize;
 use sha2::{Digest, Sha256};
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct FixtureManifest {
+    schema_version: u32,
+    fixture_revision: u32,
+    workloads: Vec<FixtureWorkload>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct FixtureWorkload {
+    id: String,
+    fixture_root: PathBuf,
+    root_source: PathBuf,
+    overlays: Vec<OverlayOperation>,
+    edits: Vec<DeclaredEdit>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case", deny_unknown_fields)]
+pub(crate) enum OverlayOperation {
+    Replace {
+        logical_file: PathBuf,
+        before: String,
+        after: String,
+    },
+    Create {
+        logical_file: PathBuf,
+        content: String,
+    },
+}
+
+#[derive(Debug, Clone, Deserialize)]
+struct DeclaredEdit {
+    scenario: EditScenario,
+    #[serde(flatten)]
+    operation: DeclaredOperation,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case", deny_unknown_fields)]
+enum DeclaredOperation {
+    Reobserve {
+        id: String,
+    },
+    Replace {
+        id: String,
+        logical_file: PathBuf,
+        before: String,
+        after: String,
+    },
+}
+
+impl FixtureManifest {
+    pub(crate) fn parse(text: &str) -> Result<Self, String> {
+        toml::from_str(text)
+            .map_err(|error| format!("invalid incremental fixture manifest: {error}"))
+    }
+
+    pub(crate) fn validate(&self, manifest: &EditManifest, repo_root: &Path) -> Result<(), String> {
+        if self.schema_version != 1 {
+            return Err(format!(
+                "unsupported incremental fixture schema version {}",
+                self.schema_version
+            ));
+        }
+        if self.fixture_revision != manifest.fixture_revision {
+            return Err(format!(
+                "fixture revision {} differs from manifest revision {}",
+                self.fixture_revision, manifest.fixture_revision
+            ));
+        }
+        let declared_ids: Vec<_> = self.workloads.iter().map(|workload| &workload.id).collect();
+        let manifest_ids: Vec<_> = manifest
+            .workloads
+            .iter()
+            .map(|workload| &workload.id)
+            .collect();
+        if declared_ids != manifest_ids {
+            return Err("fixture workloads differ from the incremental manifest".into());
+        }
+
+        let mut edit_ids = BTreeSet::new();
+        for workload in &self.workloads {
+            validate_relative_path(&workload.fixture_root)?;
+            validate_relative_path(&workload.root_source)?;
+            let fixture_root = repo_root.join(&workload.fixture_root);
+            if !fixture_root.join(&workload.root_source).is_file() {
+                return Err(format!(
+                    "fixture root source does not exist: {}",
+                    fixture_root.join(&workload.root_source).display()
+                ));
+            }
+            let source = workload.fixture_root.join(&workload.root_source);
+            let manifest_workload = manifest
+                .workloads
+                .iter()
+                .find(|entry| entry.id == workload.id)
+                .expect("workload ids were compared above");
+            if source != Path::new(&manifest_workload.source) {
+                return Err(format!(
+                    "fixture {:?} root does not match the incremental manifest source",
+                    workload.id
+                ));
+            }
+            let scenarios: Vec<_> = workload.edits.iter().map(|edit| edit.scenario).collect();
+            if scenarios != EditScenario::ALL {
+                return Err(format!(
+                    "fixture {:?} must declare the exact scenario matrix",
+                    workload.id
+                ));
+            }
+            for edit in &workload.edits {
+                let operation = edit.operation();
+                if !edit_ids.insert(operation.id().to_string()) {
+                    return Err(format!(
+                        "duplicate incremental edit id {:?}",
+                        operation.id()
+                    ));
+                }
+                if matches!(operation, EditOperation::Reobserve { .. })
+                    != (edit.scenario == EditScenario::NoOpReobservation)
+                {
+                    return Err(format!(
+                        "fixture {:?} uses the wrong operation kind for {}",
+                        workload.id,
+                        edit.scenario.wire_name()
+                    ));
+                }
+            }
+
+            // Validate overlays and every A/B edit against an actual isolated
+            // copy. Reversing each edit also proves the declared operation can
+            // restore the exact revision-A fixture.
+            let isolated = tempfile::tempdir()
+                .map_err(|error| format!("could not create fixture validation copy: {error}"))?;
+            copy_tree(&fixture_root, isolated.path())?;
+            apply_overlays(isolated.path(), &workload.overlays)?;
+            for edit in &workload.edits {
+                let operation = edit.operation();
+                apply_operation(isolated.path(), &operation)?;
+                if let Some(reverse) = operation.reverse() {
+                    apply_operation(isolated.path(), &reverse)?;
+                }
+            }
+        }
+        Ok(())
+    }
+
+    pub(crate) fn workload(&self, id: &str) -> &FixtureWorkload {
+        self.workloads
+            .iter()
+            .find(|workload| workload.id == id)
+            .expect("validated fixture manifest covers every workload")
+    }
+}
+
+impl FixtureWorkload {
+    fn edit(&self, scenario: EditScenario) -> EditOperation {
+        self.edits
+            .iter()
+            .find(|edit| edit.scenario == scenario)
+            .expect("validated fixture covers every scenario")
+            .operation()
+    }
+}
+
+impl DeclaredEdit {
+    fn operation(&self) -> EditOperation {
+        match &self.operation {
+            DeclaredOperation::Reobserve { id } => EditOperation::Reobserve { id: id.clone() },
+            DeclaredOperation::Replace {
+                id,
+                logical_file,
+                before,
+                after,
+            } => EditOperation::Replace {
+                id: id.clone(),
+                logical_file: logical_file.clone(),
+                before: before.clone(),
+                after: after.clone(),
+            },
+        }
+    }
+}
 
 #[derive(Debug, Clone)]
 pub(crate) enum EditOperation {
@@ -33,6 +222,12 @@ pub(crate) enum EditOperation {
 }
 
 impl EditOperation {
+    fn id(&self) -> &str {
+        match self {
+            Self::Reobserve { id } | Self::Replace { id, .. } => id,
+        }
+    }
+
     pub(crate) fn identity(&self) -> TransformationIdentity {
         match self {
             Self::Reobserve { id } => TransformationIdentity::Reobserve { id: id.clone() },
@@ -49,11 +244,29 @@ impl EditOperation {
             },
         }
     }
+
+    fn reverse(&self) -> Option<Self> {
+        match self {
+            Self::Reobserve { .. } => None,
+            Self::Replace {
+                id,
+                logical_file,
+                before,
+                after,
+            } => Some(Self::Replace {
+                id: format!("{id}-reverse"),
+                logical_file: logical_file.clone(),
+                before: after.clone(),
+                after: before.clone(),
+            }),
+        }
+    }
 }
 
 pub(crate) struct SampleRequest<'a> {
     pub fixture_root: &'a Path,
     pub root_source: &'a Path,
+    pub baseline_overlays: &'a [OverlayOperation],
     pub source_manifest: Option<&'a Path>,
     pub std_root: Option<&'a Path>,
     pub options: &'a CompileOptions,
@@ -74,6 +287,216 @@ pub(crate) struct SampleObservation {
 pub(crate) enum ReportStatus {
     Valid,
     Diverged,
+}
+
+struct IncrementalOptions {
+    manifest: PathBuf,
+    fixtures: PathBuf,
+    commit: String,
+    repo_root: PathBuf,
+    std_root: Option<PathBuf>,
+    output: PathBuf,
+}
+
+pub(crate) fn run() -> Result<ReportStatus, String> {
+    let options = parse_args()?;
+    let manifest_text = fs::read_to_string(&options.manifest)
+        .map_err(|error| format!("could not read {}: {error}", options.manifest.display()))?;
+    let manifest = EditManifest::parse(&manifest_text).map_err(|error| error.to_string())?;
+    let fixture_text = fs::read_to_string(&options.fixtures)
+        .map_err(|error| format!("could not read {}: {error}", options.fixtures.display()))?;
+    let fixtures = FixtureManifest::parse(&fixture_text)?;
+    fixtures.validate(&manifest, &options.repo_root)?;
+    if !manifest.compiler_args.is_empty() {
+        return Err("incremental compiler_args are not supported by this runner version".into());
+    }
+
+    let compile_options = CompileOptions {
+        target: manifest
+            .target
+            .parse()
+            .map_err(|error| format!("unsupported incremental target: {error}"))?,
+        opt_level: match manifest.optimization {
+            OptimizationSetting::Default | OptimizationSetting::O0 => OptLevel::O0,
+            OptimizationSetting::O1 => OptLevel::O1,
+            OptimizationSetting::O2 => OptLevel::O2,
+            OptimizationSetting::O3 => OptLevel::O3,
+        },
+        ..CompileOptions::default()
+    };
+    let started_at = crate::utc_timestamp();
+
+    let mut rows = Vec::new();
+    for workload in &manifest.workloads {
+        for scenario in &manifest.scenarios {
+            for worker in &manifest.workers {
+                rows.push(EditRow {
+                    workload: workload.id.clone(),
+                    source: workload.source.clone(),
+                    shape: SourceShape {
+                        files: 0,
+                        modules: 0,
+                        bytes: 0,
+                        lines: 0,
+                        tokens: 0,
+                        functions: 0,
+                    },
+                    scenario: scenario.scenario,
+                    worker_mode: worker.mode,
+                    samples: Vec::with_capacity(manifest.samples_per_row as usize),
+                });
+            }
+        }
+    }
+
+    let scenario_count = manifest.scenarios.len();
+    for (workload_index, workload) in manifest.workloads.iter().enumerate() {
+        let fixture = fixtures.workload(&workload.id);
+        let fixture_root = options.repo_root.join(&fixture.fixture_root);
+        for (worker_index, worker) in manifest.workers.iter().enumerate() {
+            for sample_index in 0..manifest.samples_per_row {
+                for collection_order in 0..scenario_count {
+                    let scenario_index =
+                        (collection_order + sample_index as usize) % scenario_count;
+                    let declaration = &manifest.scenarios[scenario_index];
+                    let operation = fixture.edit(declaration.scenario);
+                    eprintln!(
+                        "rue-bench: incremental {} {} {} sample {}/{}",
+                        workload.id,
+                        declaration.scenario.wire_name(),
+                        worker.mode.wire_name(),
+                        sample_index + 1,
+                        manifest.samples_per_row
+                    );
+                    let observation = measure_sample(SampleRequest {
+                        fixture_root: &fixture_root,
+                        root_source: &fixture.root_source,
+                        baseline_overlays: &fixture.overlays,
+                        source_manifest: None,
+                        std_root: options.std_root.as_deref(),
+                        options: &compile_options,
+                        worker_mode: worker.mode,
+                        expected_outcome: declaration.expected_outcome,
+                        operation: &operation,
+                        sample_index,
+                        session_id: format!(
+                            "{}-{}-{}-{}-{}",
+                            options.commit,
+                            workload.id,
+                            declaration.scenario.wire_name(),
+                            worker.mode.wire_name(),
+                            sample_index
+                        ),
+                        collection_order: collection_order as u32,
+                    })?;
+                    validate_structural_expectation(
+                        declaration.scenario,
+                        &observation.sample.work,
+                    )?;
+                    let row_index = ((workload_index * scenario_count + scenario_index)
+                        * manifest.workers.len())
+                        + worker_index;
+                    let row = &mut rows[row_index];
+                    match row.samples.first() {
+                        None => row.shape = observation.shape,
+                        Some(_) if row.shape != observation.shape => {
+                            return Err(format!(
+                                "revision-A source shape changed for {} {} {}",
+                                workload.id,
+                                declaration.scenario.wire_name(),
+                                worker.mode.wire_name()
+                            ));
+                        }
+                        Some(_) => {}
+                    }
+                    row.samples.push(observation.sample);
+                }
+            }
+        }
+    }
+
+    eprintln!("rue-bench: incremental bounded-retention sequence");
+    let retention = collect_retention(
+        &manifest,
+        &fixtures,
+        &options.repo_root,
+        options.std_root.as_deref(),
+        &compile_options,
+    )?;
+    let report = EditReport {
+        schema_version: EDIT_REPORT_SCHEMA_VERSION,
+        identity: EditReportIdentity {
+            fixture_revision: manifest.fixture_revision,
+            commit: options.commit,
+            started_at,
+            finished_at: crate::utc_timestamp(),
+            target: manifest.target.clone(),
+            environment: crate::environment::fingerprint(),
+        },
+        regime: EditReportRegime {
+            compiler_state: "retained_session".into(),
+            os_page_cache: "uncontrolled".into(),
+            samples_per_row: manifest.samples_per_row,
+            retention_revisions: manifest.retention_revisions,
+            rotation: manifest.rotation,
+            optimization: manifest.optimization,
+            compiler_args: manifest.compiler_args.clone(),
+        },
+        rows,
+        retention,
+    };
+    if let Some(parent) = options
+        .output
+        .parent()
+        .filter(|path| !path.as_os_str().is_empty())
+    {
+        fs::create_dir_all(parent)
+            .map_err(|error| format!("could not create {}: {error}", parent.display()))?;
+    }
+    write_validated_report(&options.output, &manifest, &report)
+}
+
+fn parse_args() -> Result<IncrementalOptions, String> {
+    let mut manifest = None;
+    let mut fixtures = None;
+    let mut commit = None;
+    let mut repo_root = None;
+    let mut std_root = None;
+    let mut output = None;
+    let mut args = std::env::args().skip(2);
+    while let Some(flag) = args.next() {
+        let mut value = || {
+            args.next()
+                .ok_or_else(|| format!("{flag} requires a value"))
+        };
+        match flag.as_str() {
+            "--manifest" => manifest = Some(PathBuf::from(value()?)),
+            "--fixtures" => fixtures = Some(PathBuf::from(value()?)),
+            "--commit" => commit = Some(value()?),
+            "--repo-root" => repo_root = Some(PathBuf::from(value()?)),
+            "--std-root" => std_root = Some(PathBuf::from(value()?)),
+            "--out" => output = Some(PathBuf::from(value()?)),
+            other => return Err(format!("unrecognized incremental argument {other:?}")),
+        }
+    }
+    let commit = commit.ok_or("incremental requires --commit <revision>")?;
+    if commit.len() != 40 || !commit.bytes().all(|byte| byte.is_ascii_hexdigit()) {
+        return Err("incremental commit must be a 40-character hexadecimal hash".into());
+    }
+    let repo_root = repo_root.unwrap_or_else(|| PathBuf::from("."));
+    let std_root = std_root.or_else(|| {
+        let candidate = repo_root.join("std");
+        candidate.is_dir().then_some(candidate)
+    });
+    Ok(IncrementalOptions {
+        manifest: manifest.unwrap_or_else(|| repo_root.join("performance/incremental.toml")),
+        fixtures: fixtures
+            .unwrap_or_else(|| repo_root.join("performance/incremental-fixtures.toml")),
+        commit,
+        repo_root,
+        std_root,
+        output: output.ok_or("incremental requires --out <path>")?,
+    })
 }
 
 impl ReportStatus {
@@ -124,6 +547,7 @@ pub(crate) fn measure_sample(request: SampleRequest<'_>) -> Result<SampleObserva
     let isolated = tempfile::tempdir()
         .map_err(|error| format!("could not create isolated fixture: {error}"))?;
     copy_tree(request.fixture_root, isolated.path())?;
+    apply_overlays(isolated.path(), request.baseline_overlays)?;
     let root = isolated_path(isolated.path(), request.root_source)?;
     let manifest = request
         .source_manifest
@@ -235,6 +659,259 @@ pub(crate) fn measure_sample(request: SampleRequest<'_>) -> Result<SampleObserva
             oracle,
         },
     })
+}
+
+fn validate_structural_expectation(
+    scenario: EditScenario,
+    work: &StructuralWork,
+) -> Result<(), String> {
+    let fail = |detail: &str| {
+        Err(format!(
+            "{} structural expectation failed: {detail}; observed {work:?}",
+            scenario.wire_name()
+        ))
+    };
+    match scenario {
+        EditScenario::NoOpReobservation => {
+            if work.import_discovery.computed != 0
+                || work.parsing.computed != 0
+                || work.program.computed != 0
+                || work.semantic.computed != 0
+                || work.program.invalidated != 0
+                || work.cfg.computed != 0
+                || work.codegen.computed != 0
+                || work.object_projection.computed != 0
+            {
+                return fail("a compiler artifact recomputed");
+            }
+        }
+        EditScenario::UnreachableBody => {
+            if work.semantic.computed != 0
+                || work.cfg.computed != 0
+                || work.codegen.computed != 0
+                || work.object_projection.computed != 0
+            {
+                return fail("an unreachable edit recomputed a reached terminal");
+            }
+        }
+        EditScenario::ReachedBodyOnly => {
+            if work.cfg.computed != 1
+                || work.codegen.computed != 1
+                || work.object_projection.computed != 1
+            {
+                return fail("the edited body cone did not reach every backend endpoint");
+            }
+        }
+        EditScenario::CallableSignature => {
+            if work.cfg.computed != 2
+                || work.codegen.computed != 2
+                || work.object_projection.computed != 2
+            {
+                return fail("the changed callable and its direct consumer did not recompute");
+            }
+        }
+        EditScenario::LayoutAbi => {
+            if work.cfg.computed == 0
+                || work.codegen.computed == 0
+                || work.object_projection.computed == 0
+            {
+                return fail("layout and ABI consumers did not recompute");
+            }
+        }
+        EditScenario::ImportSet => {
+            if work.source_observation.computed == 0
+                || work.program.invalidated == 0
+                || work.codegen.computed == 0
+                || work.object_projection.computed == 0
+            {
+                return fail("the changed import cone did not reach its consumers");
+            }
+        }
+        EditScenario::ReachabilityDeletion => {
+            if work.cfg.computed != 1
+                || work.codegen.computed != 1
+                || work.object_projection.computed != 1
+                || work.codegen.reused == 0
+                || work.object_projection.reused == 0
+            {
+                return fail("unaffected rooted backend units were not reused");
+            }
+        }
+        EditScenario::ErrorIntroduction => {
+            if work.source_observation.computed == 0
+                || work.program.invalidated == 0
+                || work.cfg.computed != 0
+                || work.codegen.computed != 0
+                || work.object_projection.computed != 0
+                || work.linking.computed != 0
+            {
+                return fail("diagnostic work escaped into a successful downstream endpoint");
+            }
+        }
+    }
+    Ok(())
+}
+
+fn collect_retention(
+    manifest: &EditManifest,
+    fixtures: &FixtureManifest,
+    repo_root: &Path,
+    std_root: Option<&Path>,
+    options: &CompileOptions,
+) -> Result<RetentionSequence, String> {
+    let workload = manifest
+        .workloads
+        .first()
+        .expect("the validated manifest has a workload");
+    let fixture = fixtures.workload(&workload.id);
+    let fixture_root = repo_root.join(&fixture.fixture_root);
+    let resolved_workers = resolve_workers(WorkerMode::Automatic);
+    rue_compiler::configure_thread_pool(resolved_workers as usize);
+
+    let body = fixture.edit(EditScenario::ReachedBodyOnly);
+    let error = fixture.edit(EditScenario::ErrorIntroduction);
+    let reachability = fixture.edit(EditScenario::ReachabilityDeletion);
+    let imports = fixture.edit(EditScenario::ImportSet);
+    let transitions = vec![
+        body.clone(),
+        body.reverse().expect("body edit is reversible"),
+        error.clone(),
+        error.reverse().expect("error edit is reversible"),
+        reachability.clone(),
+        reachability
+            .reverse()
+            .expect("reachability edit is reversible"),
+        imports.clone(),
+        imports.reverse().expect("import edit is reversible"),
+    ];
+    let states = [
+        ("reached-body-b", Some(&body), ExpectedEditOutcome::Success),
+        ("baseline", None, ExpectedEditOutcome::Success),
+        ("error-b", Some(&error), ExpectedEditOutcome::Diagnostics),
+        ("baseline", None, ExpectedEditOutcome::Success),
+        (
+            "reachability-deleted",
+            Some(&reachability),
+            ExpectedEditOutcome::Success,
+        ),
+        ("baseline", None, ExpectedEditOutcome::Success),
+        ("import-added", Some(&imports), ExpectedEditOutcome::Success),
+        ("baseline", None, ExpectedEditOutcome::Success),
+    ];
+    let baseline_identity = fresh_fixture_identity(
+        &fixture_root,
+        &fixture.root_source,
+        &fixture.overlays,
+        std_root,
+        options,
+        None,
+        ExpectedEditOutcome::Success,
+    )?;
+    let mut fresh_states = Vec::with_capacity(states.len());
+    for (_, operation, expected) in &states {
+        fresh_states.push(match operation {
+            Some(operation) => fresh_fixture_identity(
+                &fixture_root,
+                &fixture.root_source,
+                &fixture.overlays,
+                std_root,
+                options,
+                Some(operation),
+                *expected,
+            )?,
+            None => baseline_identity.clone(),
+        });
+    }
+
+    let isolated = tempfile::tempdir()
+        .map_err(|error| format!("could not create retention fixture: {error}"))?;
+    copy_tree(&fixture_root, isolated.path())?;
+    apply_overlays(isolated.path(), &fixture.overlays)?;
+    let root = isolated_path(isolated.path(), &fixture.root_source)?;
+    let mut warm = open_host(&root, None, std_root)?;
+    warm.acquire_reached_toolchain_modules(options)
+        .map_err(source_load_error)?;
+    run_success(&mut warm, options)
+        .map_err(|errors| format!("retention baseline did not compile: {errors}"))?;
+
+    let mut revisions = Vec::with_capacity(manifest.retention_revisions as usize);
+    for revision_index in 0..manifest.retention_revisions {
+        let state_index = revision_index as usize % transitions.len();
+        apply_operation(isolated.path(), &transitions[state_index])?;
+        warm.reobserve().map_err(source_load_error)?;
+        warm.acquire_reached_toolchain_modules(options)
+            .map_err(source_load_error)?;
+        let expected = states[state_index].2;
+        let identity = match run_success(&mut warm, options) {
+            Ok(output) if expected == ExpectedEditOutcome::Success => output_identity(&output),
+            Ok(output) => OutcomeIdentity {
+                kind: OutcomeKind::UnexpectedFailure,
+                diagnostics: sha256(&[]),
+                warnings: warnings_identity(&output.warnings),
+                executable: Some(sha256(&output.elf)),
+            },
+            Err(errors) if expected == ExpectedEditOutcome::Diagnostics => OutcomeIdentity {
+                kind: OutcomeKind::Diagnostics,
+                diagnostics: errors_identity(&errors),
+                warnings: sha256(&[]),
+                executable: None,
+            },
+            Err(errors) => OutcomeIdentity {
+                kind: OutcomeKind::UnexpectedFailure,
+                diagnostics: errors_identity(&errors),
+                warnings: sha256(&[]),
+                executable: None,
+            },
+        };
+        let outcome = if expected == ExpectedEditOutcome::Diagnostics {
+            RetentionStepOutcome::Diagnostics {
+                identity: identity.clone(),
+            }
+        } else {
+            RetentionStepOutcome::Success {
+                identity: identity.clone(),
+            }
+        };
+        revisions.push(RetentionStep {
+            revision_index,
+            state_id: states[state_index].0.into(),
+            outcome,
+            oracle: Some(compare_identities(
+                identity,
+                fresh_states[state_index].clone(),
+            )),
+            retention: retained_gauges(warm.unstable_metrics()),
+        });
+    }
+    Ok(RetentionSequence {
+        workload: workload.id.clone(),
+        worker_mode: WorkerMode::Automatic,
+        resolved_workers,
+        revisions,
+    })
+}
+
+fn fresh_fixture_identity(
+    fixture_root: &Path,
+    root_source: &Path,
+    overlays: &[OverlayOperation],
+    std_root: Option<&Path>,
+    options: &CompileOptions,
+    operation: Option<&EditOperation>,
+    expected: ExpectedEditOutcome,
+) -> Result<OutcomeIdentity, String> {
+    let isolated = tempfile::tempdir()
+        .map_err(|error| format!("could not create fresh retention oracle: {error}"))?;
+    copy_tree(fixture_root, isolated.path())?;
+    apply_overlays(isolated.path(), overlays)?;
+    if let Some(operation) = operation {
+        apply_operation(isolated.path(), operation)?;
+    }
+    let root = isolated_path(isolated.path(), root_source)?;
+    let mut host = open_host(&root, None, std_root)?;
+    host.acquire_reached_toolchain_modules(options)
+        .map_err(source_load_error)?;
+    Ok(fresh_identity(&mut host, options, expected))
 }
 
 fn open_host(
@@ -507,17 +1184,65 @@ fn apply_operation(root: &Path, operation: &EditOperation) -> Result<(), String>
     fs::write(&path, edited).map_err(|error| format!("could not write {}: {error}", path.display()))
 }
 
-fn isolated_path(root: &Path, relative: &Path) -> Result<PathBuf, String> {
-    if relative.is_absolute()
-        || relative
+fn apply_overlays(root: &Path, overlays: &[OverlayOperation]) -> Result<(), String> {
+    for overlay in overlays {
+        match overlay {
+            OverlayOperation::Replace {
+                logical_file,
+                before,
+                after,
+            } => apply_operation(
+                root,
+                &EditOperation::Replace {
+                    id: "baseline-overlay".into(),
+                    logical_file: logical_file.clone(),
+                    before: before.clone(),
+                    after: after.clone(),
+                },
+            )?,
+            OverlayOperation::Create {
+                logical_file,
+                content,
+            } => {
+                let path = isolated_path(root, logical_file)?;
+                if path.exists() {
+                    return Err(format!(
+                        "baseline overlay refuses to overwrite {}",
+                        logical_file.display()
+                    ));
+                }
+                let parent = path.parent().expect("an isolated path has a parent");
+                if !parent.is_dir() {
+                    return Err(format!(
+                        "baseline overlay parent does not exist for {}",
+                        logical_file.display()
+                    ));
+                }
+                fs::write(&path, content)
+                    .map_err(|error| format!("could not create {}: {error}", path.display()))?;
+            }
+        }
+    }
+    Ok(())
+}
+
+fn validate_relative_path(path: &Path) -> Result<(), String> {
+    if path.as_os_str().is_empty()
+        || path.is_absolute()
+        || path
             .components()
             .any(|part| matches!(part, std::path::Component::ParentDir))
     {
         return Err(format!(
             "fixture path must be relative and contained: {}",
-            relative.display()
+            path.display()
         ));
     }
+    Ok(())
+}
+
+fn isolated_path(root: &Path, relative: &Path) -> Result<PathBuf, String> {
+    validate_relative_path(relative)?;
     Ok(root.join(relative))
 }
 
@@ -619,6 +1344,19 @@ mod tests {
         dir
     }
 
+    fn maintained_fixtures() -> (EditManifest, FixtureManifest) {
+        let manifest_text = fs::read_to_string("performance/incremental.toml")
+            .expect("checked-in incremental manifest is readable");
+        let manifest = EditManifest::parse(&manifest_text).expect("checked-in manifest is valid");
+        let fixture_text = fs::read_to_string("performance/incremental-fixtures.toml")
+            .expect("checked-in fixture manifest is readable");
+        let fixtures = FixtureManifest::parse(&fixture_text).expect("fixture manifest parses");
+        fixtures
+            .validate(&manifest, Path::new("."))
+            .expect("maintained fixture operations are exact and reversible");
+        (manifest, fixtures)
+    }
+
     fn request<'a>(
         fixture: &'a Path,
         operation: &'a EditOperation,
@@ -628,6 +1366,7 @@ mod tests {
         SampleRequest {
             fixture_root: fixture,
             root_source: Path::new("main.rue"),
+            baseline_overlays: &[],
             source_manifest: None,
             std_root: None,
             options,
@@ -667,6 +1406,99 @@ mod tests {
             OracleComparison::Matched { .. }
         ));
         assert_eq!(observation.shape.files, 1);
+    }
+
+    #[test]
+    fn maintained_fixture_manifest_covers_the_exact_versioned_matrix() {
+        let (manifest, fixtures) = maintained_fixtures();
+        assert_eq!(fixtures.fixture_revision, manifest.fixture_revision);
+        assert_eq!(fixtures.workloads.len(), 2);
+        assert!(
+            fixtures
+                .workload("mosaic")
+                .edit(EditScenario::LayoutAbi)
+                .id()
+                .starts_with("mosaic-")
+        );
+        assert!(
+            fixtures
+                .workload("lattice")
+                .edit(EditScenario::ImportSet)
+                .id()
+                .starts_with("lattice-")
+        );
+    }
+
+    #[test]
+    #[ignore = "full maintained-program warm/fresh verification belongs to the slow measurement lane"]
+    fn maintained_transformations_reach_their_declared_outcomes() {
+        let (manifest, fixtures) = maintained_fixtures();
+        let workload_selector =
+            std::env::var("RUE_INCREMENTAL_TEST_WORKLOAD").unwrap_or_else(|_| "all".into());
+        let scenario_selector =
+            std::env::var("RUE_INCREMENTAL_TEST_SCENARIO").unwrap_or_else(|_| "all".into());
+        let options = CompileOptions {
+            target: manifest
+                .target
+                .parse()
+                .expect("manifest target is supported"),
+            ..CompileOptions::default()
+        };
+        for workload in manifest
+            .workloads
+            .iter()
+            .filter(|workload| workload_selector == "all" || workload.id == workload_selector)
+        {
+            let fixture = fixtures.workload(&workload.id);
+            let fixture_root = Path::new(".").join(&fixture.fixture_root);
+            for declaration in manifest.scenarios.iter().filter(|declaration| {
+                scenario_selector == "all" || declaration.scenario.wire_name() == scenario_selector
+            }) {
+                let operation = fixture.edit(declaration.scenario);
+                let observation = measure_sample(SampleRequest {
+                    fixture_root: &fixture_root,
+                    root_source: &fixture.root_source,
+                    baseline_overlays: &fixture.overlays,
+                    source_manifest: None,
+                    std_root: Some(Path::new("std")),
+                    options: &options,
+                    worker_mode: WorkerMode::One,
+                    expected_outcome: declaration.expected_outcome,
+                    operation: &operation,
+                    sample_index: 0,
+                    session_id: format!(
+                        "test-{}-{}",
+                        workload.id,
+                        declaration.scenario.wire_name()
+                    ),
+                    collection_order: 0,
+                })
+                .unwrap_or_else(|error| {
+                    panic!(
+                        "{} {} failed: {error}",
+                        workload.id,
+                        declaration.scenario.wire_name()
+                    )
+                });
+                assert!(matches!(
+                    observation.sample.oracle,
+                    OracleComparison::Matched { .. }
+                ));
+                validate_structural_expectation(declaration.scenario, &observation.sample.work)
+                    .unwrap();
+            }
+        }
+    }
+
+    #[test]
+    fn fixture_manifest_rejects_unknown_edit_fields() {
+        let text = fs::read_to_string("performance/incremental-fixtures.toml").unwrap();
+        let malformed = text.replacen(
+            "id = \"mosaic-no-op-v1\"",
+            "id = \"mosaic-no-op-v1\"\nunknown_fixture_field = true",
+            1,
+        );
+        assert!(FixtureManifest::parse(&malformed).is_err());
     }
 
     #[test]

--- a/crates/rue-bench/src/main.rs
+++ b/crates/rue-bench/src/main.rs
@@ -15,9 +15,6 @@
 mod calibrate;
 mod derive;
 mod environment;
-// Phase 3 supplies the canonical engine; Phase 4's maintained fixture matrix
-// wires it to the binary entry point.
-#[allow(dead_code)]
 mod incremental;
 mod measure;
 mod pins;
@@ -86,6 +83,12 @@ Subcommands:
                        measure maintained programs with independent fresh
                        compiler processes; also writes a Markdown report.
 
+  incremental --commit <sha> --out <path>
+                       measure retained-session edits of Mosaic and Lattice,
+                       including the bounded 1,000-revision retention witness.
+                       Defaults to performance/incremental.toml and
+                       performance/incremental-fixtures.toml.
+
 Optional:
   --repo-root <path>   root for resolving workload sources (default: .)
   --std-root <path>    standard-library root (default: <repo-root>/std)
@@ -117,6 +120,15 @@ fn main() -> ExitCode {
     if std::env::args().nth(1).as_deref() == Some("scaling") {
         return match scaling::run() {
             Ok(()) => ExitCode::from(exit::OK),
+            Err(message) => {
+                eprintln!("rue-bench: {message}");
+                ExitCode::from(exit::USAGE)
+            }
+        };
+    }
+    if std::env::args().nth(1).as_deref() == Some("incremental") {
+        return match incremental::run() {
+            Ok(status) => ExitCode::from(status.exit_code()),
             Err(message) => {
                 eprintln!("rue-bench: {message}");
                 ExitCode::from(exit::USAGE)

--- a/docs/designs/0068-incremental-edit-performance-measurement.md
+++ b/docs/designs/0068-incremental-edit-performance-measurement.md
@@ -152,6 +152,9 @@ it may not change the compiler, generate a scaled program, or bypass ordinary
 filesystem discovery. This keeps the workloads recognizably maintained Mosaic
 and Lattice while making every edit class explicit and reversible.
 
+The checked-in operations live in `performance/incremental-fixtures.toml` and
+must carry the same fixture revision as `performance/incremental.toml`.
+
 The initial maintained-program suite is **Mosaic and Lattice**. Mosaic supplies a
 faster multi-module development rung; Lattice is the largest maintained scaling
 rung and the decision workload for linker investment. Ruelex and Harbor may be
@@ -310,9 +313,9 @@ projects. None may introduce a peer compilation path.
   diagnostics and three successful-compilation endpoints and serialize
   validated raw observations without duplicating source loading or compiler
   orchestration. — RUE-1251
-- [ ] **Phase 4: Maintained edit fixtures.** Add exact Mosaic and Lattice
+- [x] **Phase 4: Maintained edit fixtures.** Add exact Mosaic and Lattice
   transformations, structural expectations, and warm/fresh oracle coverage. —
-  follow-up issue
+  RUE-1252
 - [ ] **Phase 5: Scheduled report.** Publish lower-frequency JSON and Markdown
   workflow artifacts with no dashboard/headline integration. — follow-up issue
 - [ ] **Phase 6: Product host.** Add and measure `rue --watch` on the same seam,

--- a/performance/BUCK
+++ b/performance/BUCK
@@ -3,3 +3,9 @@ export_file(
     src = "incremental.toml",
     visibility = ["//crates/rue-perf-schema:"],
 )
+
+export_file(
+    name = "incremental-fixtures.toml",
+    src = "incremental-fixtures.toml",
+    visibility = ["//crates/rue-bench:"],
+)

--- a/performance/incremental-fixtures.toml
+++ b/performance/incremental-fixtures.toml
@@ -1,0 +1,270 @@
+# Exact maintained-program transformations for ADR-0068.
+#
+# Baseline overlays are applied to an isolated copy before revision A. They add
+# only the small source probes needed to express the scenario matrix; the
+# maintained Mosaic and Lattice sources remain unchanged. Every replacement
+# fragment must occur exactly once.
+schema_version = 1
+fixture_revision = 1
+
+[[workloads]]
+id = "mosaic"
+fixture_root = "examples/mosaic"
+root_source = "main.rue"
+
+[[workloads.overlays]]
+kind = "replace"
+logical_file = "main.rue"
+before = "const OptStr = std.option.Option(StrBuf);"
+after = '''const OptStr = std.option.Option(StrBuf);
+
+const incremental_import_value: u64 = 0;
+fn incremental_import_probe() -> u64 { incremental_import_value }
+
+fn incremental_unreachable() -> u64 { 101 }
+
+fn incremental_body() -> u64 { 201 }
+
+fn incremental_signature(value: u64) -> u64 { value + 1 }
+fn incremental_signature_probe() -> u64 { incremental_signature(301) }
+
+struct IncrementalLayout {
+    first: u64,
+}
+fn incremental_layout_probe() -> u64 {
+    let value = IncrementalLayout { first: 401 };
+    value.first
+}
+
+fn incremental_reachable_leaf() -> u64 { 501 }
+
+fn incremental_anchor() -> u64 {
+    incremental_import_probe()
+        + incremental_body()
+        + incremental_signature_probe()
+        + incremental_layout_probe()
+        + incremental_reachable_leaf()
+}'''
+
+[[workloads.overlays]]
+kind = "replace"
+logical_file = "main.rue"
+before = "fn main() -> i32 {"
+after = '''fn main() -> i32 {
+    let incremental_fixture_witness = incremental_anchor();
+    if incremental_fixture_witness == 0 { return 1; }'''
+
+[[workloads.overlays]]
+kind = "create"
+logical_file = "incremental_fixture.rue"
+content = "pub fn value() -> u64 { 601 }\n"
+
+[[workloads.edits]]
+scenario = "no_op_reobservation"
+kind = "reobserve"
+id = "mosaic-no-op-v1"
+
+[[workloads.edits]]
+scenario = "unreachable_body"
+kind = "replace"
+id = "mosaic-unreachable-body-v1"
+logical_file = "main.rue"
+before = "fn incremental_unreachable() -> u64 { 101 }"
+after = "fn incremental_unreachable() -> u64 { 102 }"
+
+[[workloads.edits]]
+scenario = "reached_body_only"
+kind = "replace"
+id = "mosaic-reached-body-v1"
+logical_file = "main.rue"
+before = "fn incremental_body() -> u64 { 201 }"
+after = "fn incremental_body() -> u64 { 202 }"
+
+[[workloads.edits]]
+scenario = "callable_signature"
+kind = "replace"
+id = "mosaic-callable-signature-v1"
+logical_file = "main.rue"
+before = '''fn incremental_signature(value: u64) -> u64 { value + 1 }
+fn incremental_signature_probe() -> u64 { incremental_signature(301) }'''
+after = '''fn incremental_signature(value: u64, extra: u64) -> u64 { value + extra }
+fn incremental_signature_probe() -> u64 { incremental_signature(301, 1) }'''
+
+[[workloads.edits]]
+scenario = "layout_abi"
+kind = "replace"
+id = "mosaic-layout-abi-v1"
+logical_file = "main.rue"
+before = '''struct IncrementalLayout {
+    first: u64,
+}
+fn incremental_layout_probe() -> u64 {
+    let value = IncrementalLayout { first: 401 };
+    value.first
+}'''
+after = '''struct IncrementalLayout {
+    first: u64,
+    second: u64,
+}
+fn incremental_layout_probe() -> u64 {
+    let value = IncrementalLayout { first: 401, second: 1 };
+    value.first + value.second
+}'''
+
+[[workloads.edits]]
+scenario = "import_set"
+kind = "replace"
+id = "mosaic-import-set-v1"
+logical_file = "main.rue"
+before = '''const incremental_import_value: u64 = 0;
+fn incremental_import_probe() -> u64 { incremental_import_value }'''
+after = '''const incremental_fixture = @import("incremental_fixture.rue");
+fn incremental_import_probe() -> u64 { incremental_fixture.value() }'''
+
+[[workloads.edits]]
+scenario = "reachability_deletion"
+kind = "replace"
+id = "mosaic-reachability-deletion-v1"
+logical_file = "main.rue"
+before = '''        + incremental_layout_probe()
+        + incremental_reachable_leaf()'''
+after = "        + incremental_layout_probe()"
+
+[[workloads.edits]]
+scenario = "error_introduction"
+kind = "replace"
+id = "mosaic-error-introduction-v1"
+logical_file = "main.rue"
+before = "fn incremental_body() -> u64 { 201 }"
+after = "fn incremental_body() -> u64 { incremental_missing_name }"
+
+[[workloads]]
+id = "lattice"
+fixture_root = "examples/lattice"
+root_source = "main.rue"
+
+[[workloads.overlays]]
+kind = "replace"
+logical_file = "main.rue"
+before = "const ReadRes = std.result.Result(u64, std.fs.FileError);"
+after = '''const ReadRes = std.result.Result(u64, std.fs.FileError);
+
+const incremental_import_value: u64 = 0;
+fn incremental_import_probe() -> u64 { incremental_import_value }
+
+fn incremental_unreachable() -> u64 { 101 }
+
+fn incremental_body() -> u64 { 201 }
+
+fn incremental_signature(value: u64) -> u64 { value + 1 }
+fn incremental_signature_probe() -> u64 { incremental_signature(301) }
+
+struct IncrementalLayout {
+    first: u64,
+}
+fn incremental_layout_probe() -> u64 {
+    let value = IncrementalLayout { first: 401 };
+    value.first
+}
+
+fn incremental_reachable_leaf() -> u64 { 501 }
+
+fn incremental_anchor() -> u64 {
+    incremental_import_probe()
+        + incremental_body()
+        + incremental_signature_probe()
+        + incremental_layout_probe()
+        + incremental_reachable_leaf()
+}'''
+
+[[workloads.overlays]]
+kind = "replace"
+logical_file = "main.rue"
+before = "fn main() -> i32 {"
+after = '''fn main() -> i32 {
+    let incremental_fixture_witness = incremental_anchor();
+    if incremental_fixture_witness == 0 { return 1; }'''
+
+[[workloads.overlays]]
+kind = "create"
+logical_file = "incremental_fixture.rue"
+content = "pub fn value() -> u64 { 601 }\n"
+
+[[workloads.edits]]
+scenario = "no_op_reobservation"
+kind = "reobserve"
+id = "lattice-no-op-v1"
+
+[[workloads.edits]]
+scenario = "unreachable_body"
+kind = "replace"
+id = "lattice-unreachable-body-v1"
+logical_file = "main.rue"
+before = "fn incremental_unreachable() -> u64 { 101 }"
+after = "fn incremental_unreachable() -> u64 { 102 }"
+
+[[workloads.edits]]
+scenario = "reached_body_only"
+kind = "replace"
+id = "lattice-reached-body-v1"
+logical_file = "main.rue"
+before = "fn incremental_body() -> u64 { 201 }"
+after = "fn incremental_body() -> u64 { 202 }"
+
+[[workloads.edits]]
+scenario = "callable_signature"
+kind = "replace"
+id = "lattice-callable-signature-v1"
+logical_file = "main.rue"
+before = '''fn incremental_signature(value: u64) -> u64 { value + 1 }
+fn incremental_signature_probe() -> u64 { incremental_signature(301) }'''
+after = '''fn incremental_signature(value: u64, extra: u64) -> u64 { value + extra }
+fn incremental_signature_probe() -> u64 { incremental_signature(301, 1) }'''
+
+[[workloads.edits]]
+scenario = "layout_abi"
+kind = "replace"
+id = "lattice-layout-abi-v1"
+logical_file = "main.rue"
+before = '''struct IncrementalLayout {
+    first: u64,
+}
+fn incremental_layout_probe() -> u64 {
+    let value = IncrementalLayout { first: 401 };
+    value.first
+}'''
+after = '''struct IncrementalLayout {
+    first: u64,
+    second: u64,
+}
+fn incremental_layout_probe() -> u64 {
+    let value = IncrementalLayout { first: 401, second: 1 };
+    value.first + value.second
+}'''
+
+[[workloads.edits]]
+scenario = "import_set"
+kind = "replace"
+id = "lattice-import-set-v1"
+logical_file = "main.rue"
+before = '''const incremental_import_value: u64 = 0;
+fn incremental_import_probe() -> u64 { incremental_import_value }'''
+after = '''const incremental_fixture = @import("incremental_fixture.rue");
+fn incremental_import_probe() -> u64 { incremental_fixture.value() }'''
+
+[[workloads.edits]]
+scenario = "reachability_deletion"
+kind = "replace"
+id = "lattice-reachability-deletion-v1"
+logical_file = "main.rue"
+before = '''        + incremental_layout_probe()
+        + incremental_reachable_leaf()'''
+after = "        + incremental_layout_probe()"
+
+[[workloads.edits]]
+scenario = "error_introduction"
+kind = "replace"
+id = "lattice-error-introduction-v1"
+logical_file = "main.rue"
+before = "fn incremental_body() -> u64 { 201 }"
+after = "fn incremental_body() -> u64 { incremental_missing_name }"


### PR DESCRIPTION
## Summary

- add a versioned, exact, reversible Mosaic and Lattice edit-fixture manifest covering all eight ADR-0068 scenarios
- wire the retained-session runner across both worker modes, left-rotated sampling, structural work assertions, warm/fresh identity oracles, and the 1,000-revision retention witness
- reject invalid fixture operations before sampling, preserve divergence evidence with a distinct exit status, and mark ADR-0068 Phase 4 complete

## Validation

- `scripts/rue fmt`
- `scripts/rue unit bench incremental`
- `scripts/rue quick`
- `scripts/rue premerge` (78/79 targets passed; the sole local failure is the nested-worktree shell scanner tracked by RUE-1248 and is unrelated to this change)

Fixes RUE-1252.
Refs RUE-1248.