### PR TITLE
RUE-1253: publish scheduled incremental reports

### DIFF
--- a/.github/workflows/performance-incremental.yml
+++ b/.github/workflows/performance-incremental.yml
@@ -1,0 +1,69 @@
+# Lower-frequency retained-session edit report (ADR-0068 / RUE-1253).
+#
+# This suite is advisory performance evidence and intentionally does not append
+# to ADR-0067's raw history, dashboard, or headline index. Structural invalidity
+# produces no report. A warm/fresh divergence publishes its JSON and Markdown
+# evidence before the workflow preserves the runner's nonzero status.
+name: Incremental compiler performance
+
+on:
+  schedule:
+    - cron: "43 8 * * 4"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+# Two retained-session runs on one hosted machine would measure contention,
+# not Rue. Let an active weekly or manually dispatched run finish.
+concurrency:
+  group: compiler-incremental-performance
+  cancel-in-progress: false
+
+jobs:
+  measure:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 360
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install dotslash
+        uses: facebook/install-dotslash@v2
+
+      - name: Build the retained-session runner
+        run: ./buck2 build //crates/rue-bench:rue-bench
+
+      - name: Measure retained-session edits
+        id: measure
+        env:
+          RUE_BENCH_RUNNER_LABEL: github-hosted
+          RUE_BENCH_RUNNER_IMAGE: ubuntu-24.04
+        run: |
+          set -euo pipefail
+          mkdir -p incremental-report
+          set +e
+          ./buck2 run //crates/rue-bench:rue-bench -- incremental \
+            --manifest performance/incremental.toml \
+            --fixtures performance/incremental-fixtures.toml \
+            --commit "${{ github.sha }}" \
+            --repo-root . \
+            --std-root std \
+            --out incremental-report/report.json
+          status=$?
+          set -e
+          echo "status=$status" >> "$GITHUB_OUTPUT"
+
+      - name: Publish report artifact
+        if: steps.measure.outputs.status == '0' || steps.measure.outputs.status == '3'
+        uses: actions/upload-artifact@v6
+        with:
+          name: compiler-incremental-${{ github.sha }}
+          path: incremental-report/
+          retention-days: 90
+          if-no-files-found: error
+
+      - name: Preserve collection status
+        if: steps.measure.outputs.status != '0'
+        env:
+          MEASUREMENT_STATUS: ${{ steps.measure.outputs.status }}
+        run: exit "${MEASUREMENT_STATUS:-2}"

--- a/crates/rue-bench/src/incremental.rs
+++ b/crates/rue-bench/src/incremental.rs
@@ -17,7 +17,8 @@ use rue_perf_schema::{
     EditReportIdentity, EditReportRegime, EditRow, EditSample, EditScenario, ExpectedEditOutcome,
     FailureStage, OptimizationSetting, OracleComparison, OutcomeIdentity, OutcomeKind, PhaseWork,
     RetainedGauges, RetentionSequence, RetentionStep, RetentionStepOutcome, SourceShape,
-    StructuralWork, TransformationIdentity, WorkerMode, canonical_json, validate_edit_report,
+    StructuralWork, TransformationIdentity, WorkerMode, canonical_json, derive_edit_report,
+    render_edit_report_markdown, validate_edit_report,
 };
 use serde::Deserialize;
 use sha2::{Digest, Sha256};
@@ -531,8 +532,25 @@ pub(crate) fn write_validated_report(
     }
     let encoded = canonical_json(report)
         .map_err(|error| format!("could not serialize incremental report: {error}"))?;
+    let derived = derive_edit_report(manifest, report).map_err(|findings| {
+        let details = findings
+            .iter()
+            .map(|finding| format!("{}: {}", finding.path, finding.detail))
+            .collect::<Vec<_>>()
+            .join("; ");
+        format!("could not derive incremental report: {details}")
+    })?;
+    let markdown = render_edit_report_markdown(&derived);
     fs::write(path, encoded)
         .map_err(|error| format!("could not write {}: {error}", path.display()))?;
+    let markdown_path = path.with_extension("md");
+    fs::write(&markdown_path, markdown)
+        .map_err(|error| format!("could not write {}: {error}", markdown_path.display()))?;
+    eprintln!(
+        "rue-bench: wrote {} and {}",
+        path.display(),
+        markdown_path.display()
+    );
     Ok(if validation.divergences.is_empty() {
         ReportStatus::Valid
     } else {
@@ -1631,5 +1649,6 @@ mod tests {
         let output = tempfile::tempdir().unwrap().path().join("report.json");
         assert!(write_validated_report(&output, &manifest, &report).is_err());
         assert!(!output.exists());
+        assert!(!output.with_extension("md").exists());
     }
 }

--- a/crates/rue-bench/src/main.rs
+++ b/crates/rue-bench/src/main.rs
@@ -85,7 +85,8 @@ Subcommands:
 
   incremental --commit <sha> --out <path>
                        measure retained-session edits of Mosaic and Lattice,
-                       including the bounded 1,000-revision retention witness.
+                       including the bounded 1,000-revision retention witness;
+                       writes raw JSON and same-stem derived Markdown.
                        Defaults to performance/incremental.toml and
                        performance/incremental-fixtures.toml.
 

--- a/docs/designs/0068-incremental-edit-performance-measurement.md
+++ b/docs/designs/0068-incremental-edit-performance-measurement.md
@@ -316,8 +316,8 @@ projects. None may introduce a peer compilation path.
 - [x] **Phase 4: Maintained edit fixtures.** Add exact Mosaic and Lattice
   transformations, structural expectations, and warm/fresh oracle coverage. —
   RUE-1252
-- [ ] **Phase 5: Scheduled report.** Publish lower-frequency JSON and Markdown
-  workflow artifacts with no dashboard/headline integration. — follow-up issue
+- [x] **Phase 5: Scheduled report.** Publish lower-frequency JSON and Markdown
+  workflow artifacts with no dashboard/headline integration. — RUE-1253
 - [ ] **Phase 6: Product host.** Add and measure `rue --watch` on the same seam,
   including cancellation, error/fix, import-set, and atomic-publication tests. —
   follow-up issue


### PR DESCRIPTION
## Summary

- write deterministic same-stem Markdown beside each validated incremental JSON report
- add a weekly and manually dispatched Ubuntu reference-host workflow that uploads valid or divergent evidence while preserving divergence failure status
- mark ADR-0068 Phase 5 complete

## Validation

- scripts/rue fmt
- scripts/rue unit bench incremental
- scripts/rue unit perf-schema incremental
- scripts/rue quick
- scripts/rue premerge (78 passed; only the known RUE-1248 nested-worktree scanner false positive failed locally)
- workflow YAML parse

Fixes RUE-1253.