### PR TITLE
RUE-1254: add retained watch host

### DIFF
--- a/crates/rue-compiler/src/queries.rs
+++ b/crates/rue-compiler/src/queries.rs
@@ -1194,6 +1194,38 @@ pub(crate) fn compile_with_session(
     compile_rooted_with_session(session, snapshot, options, rooted)
 }
 
+pub(crate) fn compile_with_session_with_cancellation(
+    session: &mut CompilerSession,
+    snapshot: &SourceSnapshot,
+    options: &CompileOptions,
+    cancellation: rue_query::CancellationToken,
+) -> Result<CompileOutput, crate::session::PipelineRequestControl> {
+    let _span = info_span!("compile_pipeline").entered();
+    if cancellation.is_canceled() {
+        return Err(crate::session::PipelineRequestControl::Abort(
+            rue_query::QueryAbort::Canceled,
+        ));
+    }
+    let rooted = session.rooted_codegen_with_cancellation(
+        options,
+        rue_codegen::BackendArtifactRequest::default(),
+        cancellation.clone(),
+    )?;
+    if cancellation.is_canceled() {
+        return Err(crate::session::PipelineRequestControl::Abort(
+            rue_query::QueryAbort::Canceled,
+        ));
+    }
+    let output = compile_rooted_with_session(session, snapshot, options, rooted)
+        .map_err(crate::session::PipelineRequestControl::Compile)?;
+    if cancellation.is_canceled() {
+        return Err(crate::session::PipelineRequestControl::Abort(
+            rue_query::QueryAbort::Canceled,
+        ));
+    }
+    Ok(output)
+}
+
 /// Finish a canonical compilation from the exact objects-ready continuation
 /// issued by this session. Used by the retained host's unstable endpoint API;
 /// the ordinary one-shot adapter reaches the same helper through

--- a/crates/rue-compiler/src/session.rs
+++ b/crates/rue-compiler/src/session.rs
@@ -863,6 +863,31 @@ enum SemanticRequestControl {
     Parked(Box<crate::ParkedToolchainModules>),
 }
 
+#[derive(Debug)]
+pub(crate) enum PipelineRequestControl {
+    Compile(CompileErrors),
+    Abort(rue_query::QueryAbort),
+}
+
+impl From<CompileErrors> for PipelineRequestControl {
+    fn from(errors: CompileErrors) -> Self {
+        Self::Compile(errors)
+    }
+}
+
+impl From<CompileError> for PipelineRequestControl {
+    fn from(error: CompileError) -> Self {
+        Self::Compile(error.into())
+    }
+}
+
+fn pipeline_abort_errors(context: &str, abort: rue_query::QueryAbort) -> CompileErrors {
+    CompileError::without_span(ErrorKind::InternalError(format!(
+        "{context} query aborted: {abort:?}"
+    )))
+    .into()
+}
+
 /// The outcome of the rooted, park-aware semantic entry
 /// [`CompilerSession::semantic_or_toolchain_park`] (RUE-1112), consumed by the
 /// host source-loading driver through the unstable facade.
@@ -4662,7 +4687,8 @@ impl CompilerSession {
     fn rooted_warning_references(
         &mut self,
         graph: &RootedBodyGraph,
-    ) -> Result<BTreeSet<crate::StableDefinitionKey>, CompileErrors> {
+        cancellation: rue_query::CancellationToken,
+    ) -> Result<BTreeSet<crate::StableDefinitionKey>, PipelineRequestControl> {
         let functions = graph
             .declarations
             .iter()
@@ -4746,13 +4772,9 @@ impl CompilerSession {
                         instance: crate::FunctionInstanceKey::Definition(declaration.key.clone()),
                         configuration: graph.configuration.clone(),
                     },
-                    rue_query::CancellationToken::new(),
+                    cancellation.clone(),
                 )
-                .map_err(|abort| {
-                    CompileError::without_span(ErrorKind::InternalError(format!(
-                        "warning body-reference query aborted: {abort:?}"
-                    )))
-                })?;
+                .map_err(PipelineRequestControl::Abort)?;
             #[cfg(not(test))]
             let _ = execution;
             #[cfg(test)]
@@ -4782,16 +4804,32 @@ impl CompilerSession {
         &mut self,
         options: &CompileOptions,
     ) -> Result<RootedCfgOutput, CompileErrors> {
-        let graph = match self
-            .rooted_body_graph_with_cancellation(options, rue_query::CancellationToken::new())
-        {
+        match self.rooted_cfg_with_cancellation(options, rue_query::CancellationToken::new()) {
+            Ok(output) => Ok(output),
+            Err(PipelineRequestControl::Compile(errors)) => Err(errors),
+            Err(PipelineRequestControl::Abort(abort)) => {
+                Err(pipeline_abort_errors("rooted CFG", abort))
+            }
+        }
+    }
+
+    pub(crate) fn rooted_cfg_with_cancellation(
+        &mut self,
+        options: &CompileOptions,
+        cancellation: rue_query::CancellationToken,
+    ) -> Result<RootedCfgOutput, PipelineRequestControl> {
+        let graph = match self.rooted_body_graph_with_cancellation(options, cancellation.clone()) {
             Ok(graph) => graph,
-            Err(SemanticRequestControl::Compile(errors)) => return Err(errors),
+            Err(SemanticRequestControl::Compile(errors)) => {
+                return Err(PipelineRequestControl::Compile(errors));
+            }
             Err(SemanticRequestControl::Parked(park)) => {
-                return Err(unresolved_toolchain_park_errors(&park));
+                return Err(PipelineRequestControl::Compile(
+                    unresolved_toolchain_park_errors(&park),
+                ));
             }
             Err(SemanticRequestControl::Abort(abort)) => {
-                panic!("uncanceled rooted CFG request aborted: {abort:?}")
+                return Err(PipelineRequestControl::Abort(abort));
             }
         };
         let mut work = graph.work;
@@ -4823,7 +4861,7 @@ impl CompilerSession {
             })
             .collect::<BTreeMap<_, _>>();
         let mut cfg_inputs = Vec::with_capacity(identities.len());
-        let warning_references = self.rooted_warning_references(&graph)?;
+        let warning_references = self.rooted_warning_references(&graph, cancellation.clone())?;
         let mut warnings = rooted_unused_function_warnings(&graph, &warning_references);
         for closure_body in graph.closure.bodies.iter() {
             let rue_query::QueryOutcome::Success(bundle) = closure_body.bundle.outcome() else {
@@ -4839,13 +4877,9 @@ impl CompilerSession {
                 .body_source_locator_projection(
                     graph.revision,
                     closure_body.key.clone(),
-                    rue_query::CancellationToken::new(),
+                    cancellation.clone(),
                 )
-                .map_err(|abort| {
-                    CompileError::without_span(ErrorKind::InternalError(format!(
-                        "body source locator query aborted: {abort:?}"
-                    )))
-                })?;
+                .map_err(PipelineRequestControl::Abort)?;
             let rue_query::QueryOutcome::Success(locator) = locator.outcome() else {
                 unreachable!("BodySourceLocator publishes typed values")
             };
@@ -5029,7 +5063,7 @@ impl CompilerSession {
         let (cfg_batch_key, attempt) = self.queries.revisioned.optimized_cfg_batch(
             graph.revision,
             optimized_keys,
-            rue_query::CancellationToken::new(),
+            cancellation,
         );
         let batch_execution = attempt.execution();
         let executions = if batch_execution == rue_query::RequestExecution::Computed {
@@ -5059,11 +5093,9 @@ impl CompilerSession {
                 terminal,
             );
         }
-        let batch = attempt.into_result().map_err(|abort| {
-            CompileError::without_span(ErrorKind::InternalError(format!(
-                "optimized CFG batch query aborted: {abort:?}"
-            )))
-        })?;
+        let batch = attempt
+            .into_result()
+            .map_err(PipelineRequestControl::Abort)?;
         let rue_query::QueryOutcome::Success(batch) = batch.outcome() else {
             unreachable!("OptimizedCfgBatch publishes typed values")
         };
@@ -5099,8 +5131,8 @@ impl CompilerSession {
                     errors,
                     body_span: old_span,
                 } => {
-                    return Err(crate::cfg_query::import_errors(
-                        errors, *old_span, body_span,
+                    return Err(PipelineRequestControl::Compile(
+                        crate::cfg_query::import_errors(errors, *old_span, body_span),
                     ));
                 }
             };
@@ -5173,8 +5205,28 @@ impl CompilerSession {
         options: &CompileOptions,
         request: rue_codegen::BackendArtifactRequest,
     ) -> Result<RootedCodegenOutput, CompileErrors> {
-        let ready = self.rooted_codegen_ready(options, request)?;
-        self.rooted_objects_ready(ready)
+        match self.rooted_codegen_with_cancellation(
+            options,
+            request,
+            rue_query::CancellationToken::new(),
+        ) {
+            Ok(output) => Ok(output),
+            Err(PipelineRequestControl::Compile(errors)) => Err(errors),
+            Err(PipelineRequestControl::Abort(abort)) => {
+                Err(pipeline_abort_errors("rooted codegen", abort))
+            }
+        }
+    }
+
+    pub(crate) fn rooted_codegen_with_cancellation(
+        &mut self,
+        options: &CompileOptions,
+        request: rue_codegen::BackendArtifactRequest,
+        cancellation: rue_query::CancellationToken,
+    ) -> Result<RootedCodegenOutput, PipelineRequestControl> {
+        let ready =
+            self.rooted_codegen_ready_with_cancellation(options, request, cancellation.clone())?;
+        self.rooted_objects_ready_with_cancellation(ready, cancellation)
     }
 
     /// Collect the rooted reached set's canonical CodegenUnits while retaining
@@ -5184,6 +5236,25 @@ impl CompilerSession {
         options: &CompileOptions,
         request: rue_codegen::BackendArtifactRequest,
     ) -> Result<RootedCodegenReadyOutput, CompileErrors> {
+        match self.rooted_codegen_ready_with_cancellation(
+            options,
+            request,
+            rue_query::CancellationToken::new(),
+        ) {
+            Ok(output) => Ok(output),
+            Err(PipelineRequestControl::Compile(errors)) => Err(errors),
+            Err(PipelineRequestControl::Abort(abort)) => {
+                Err(pipeline_abort_errors("codegen-ready", abort))
+            }
+        }
+    }
+
+    pub(crate) fn rooted_codegen_ready_with_cancellation(
+        &mut self,
+        options: &CompileOptions,
+        request: rue_codegen::BackendArtifactRequest,
+        cancellation: rue_query::CancellationToken,
+    ) -> Result<RootedCodegenReadyOutput, PipelineRequestControl> {
         let RootedCfgOutput {
             graph,
             cfgs,
@@ -5191,7 +5262,7 @@ impl CompilerSession {
             work,
             backend_work: cfg_work,
             mut backend_root,
-        } = self.rooted_cfg(options)?;
+        } = self.rooted_cfg_with_cancellation(options, cancellation.clone())?;
 
         let codegen_keys = cfgs
             .iter()
@@ -5216,11 +5287,10 @@ impl CompilerSession {
         }
         let _codegen_collection_span =
             tracing::info_span!("codegen_collection", phase = "backend").entered();
-        let (codegen_batch_key, attempt) = self.queries.revisioned.codegen_unit_batch(
-            graph.revision,
-            codegen_keys,
-            rue_query::CancellationToken::new(),
-        );
+        let (codegen_batch_key, attempt) =
+            self.queries
+                .revisioned
+                .codegen_unit_batch(graph.revision, codegen_keys, cancellation);
         let batch_execution = attempt.execution();
         let child_attempts = if batch_execution == rue_query::RequestExecution::Computed {
             let attempts = attempt
@@ -5259,11 +5329,9 @@ impl CompilerSession {
                 terminal,
             );
         }
-        let batch = attempt.into_result().map_err(|abort| {
-            CompileError::without_span(ErrorKind::InternalError(format!(
-                "codegen batch query aborted: {abort:?}"
-            )))
-        })?;
+        let batch = attempt
+            .into_result()
+            .map_err(PipelineRequestControl::Abort)?;
         let rue_query::QueryOutcome::Success(batch) = batch.outcome() else {
             unreachable!("CodegenUnitBatch publishes typed terminals")
         };
@@ -5296,7 +5364,7 @@ impl CompilerSession {
                     }
                 }
                 crate::codegen_query::CodegenUnitValue::Failure(errors) => {
-                    return Err(errors.clone());
+                    return Err(PipelineRequestControl::Compile(errors.clone()));
                 }
             }
         }
@@ -5320,6 +5388,22 @@ impl CompilerSession {
         &mut self,
         ready: RootedCodegenReadyOutput,
     ) -> Result<RootedCodegenOutput, CompileErrors> {
+        match self
+            .rooted_objects_ready_with_cancellation(ready, rue_query::CancellationToken::new())
+        {
+            Ok(output) => Ok(output),
+            Err(PipelineRequestControl::Compile(errors)) => Err(errors),
+            Err(PipelineRequestControl::Abort(abort)) => {
+                Err(pipeline_abort_errors("objects-ready", abort))
+            }
+        }
+    }
+
+    pub(crate) fn rooted_objects_ready_with_cancellation(
+        &mut self,
+        ready: RootedCodegenReadyOutput,
+        cancellation: rue_query::CancellationToken,
+    ) -> Result<RootedCodegenOutput, PipelineRequestControl> {
         let RootedCodegenReadyOutput {
             graph,
             units,
@@ -5341,7 +5425,7 @@ impl CompilerSession {
         let (object_batch_key, object_attempt) = self.queries.revisioned.object_projection_batch(
             graph.revision,
             object_keys,
-            rue_query::CancellationToken::new(),
+            cancellation.clone(),
         );
         let object_batch_execution = object_attempt.execution();
         let object_child_attempts =
@@ -5371,11 +5455,9 @@ impl CompilerSession {
                     terminal,
                 );
         }
-        let object_batch = object_attempt.into_result().map_err(|abort| {
-            CompileError::without_span(ErrorKind::InternalError(format!(
-                "object projection batch query aborted: {abort:?}"
-            )))
-        })?;
+        let object_batch = object_attempt
+            .into_result()
+            .map_err(PipelineRequestControl::Abort)?;
         let rue_query::QueryOutcome::Success(object_batch) = object_batch.outcome() else {
             unreachable!("ObjectProjectionBatch publishes typed terminals")
         };
@@ -5403,7 +5485,7 @@ impl CompilerSession {
                     }
                 }
                 crate::object_query::ObjectProjectionValue::Failure(errors) => {
-                    return Err(errors.clone());
+                    return Err(PipelineRequestControl::Compile(errors.clone()));
                 }
             }
         }
@@ -5440,14 +5522,15 @@ impl CompilerSession {
                 }
             })
             .collect();
+        if cancellation.is_canceled() {
+            return Err(PipelineRequestControl::Abort(
+                rue_query::QueryAbort::Canceled,
+            ));
+        }
         self.queries
             .revisioned
             .publish_backend_root(graph.revision, backend_root, object_batch_key)
-            .map_err(|abort| {
-                CompileError::without_span(ErrorKind::InternalError(format!(
-                    "backend root publication aborted: {abort:?}"
-                )))
-            })?;
+            .map_err(PipelineRequestControl::Abort)?;
         Ok(RootedCodegenOutput {
             units,
             objects,

--- a/crates/rue-compiler/src/unstable.rs
+++ b/crates/rue-compiler/src/unstable.rs
@@ -510,6 +510,71 @@ pub fn executable_in_compile_scope(
     session.executable_in_compile_scope(options)
 }
 
+/// Cloneable cancellation authority for one retained-host compile cycle.
+///
+/// This deliberately hides query-runtime identities and keys. Canceling a
+/// request prevents its unpublished backend root and linked bytes from being
+/// selected for publication; already retained terminals remain reusable.
+#[derive(Clone, Default)]
+pub struct CompilationCancellation {
+    token: rue_query::CancellationToken,
+}
+
+impl CompilationCancellation {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn cancel(&self) {
+        self.token.cancel();
+    }
+
+    pub fn is_canceled(&self) -> bool {
+        self.token.is_canceled()
+    }
+}
+
+/// Host-facing outcome of a cancellable retained compilation.
+pub enum CancellableCompileOutcome {
+    Completed(Box<crate::CompileOutput>),
+    Errors(crate::CompileErrors),
+    Canceled,
+}
+
+/// Compile the current closed discovery revision with cooperative
+/// cancellation, inside a tracing span owned by the filesystem driver.
+pub fn cancellable_executable_in_compile_scope(
+    session: &mut crate::CompilerSession,
+    options: &crate::CompileOptions,
+    cancellation: CompilationCancellation,
+) -> CancellableCompileOutcome {
+    let snapshot = match session.committed_snapshot_for_executable() {
+        Ok(snapshot) => snapshot,
+        Err(errors) => return CancellableCompileOutcome::Errors(errors),
+    };
+    match crate::queries::compile_with_session_with_cancellation(
+        session,
+        &snapshot,
+        options,
+        cancellation.token,
+    ) {
+        Ok(output) => CancellableCompileOutcome::Completed(Box::new(output)),
+        Err(crate::session::PipelineRequestControl::Compile(errors)) => {
+            CancellableCompileOutcome::Errors(errors)
+        }
+        Err(crate::session::PipelineRequestControl::Abort(rue_query::QueryAbort::Canceled)) => {
+            CancellableCompileOutcome::Canceled
+        }
+        Err(crate::session::PipelineRequestControl::Abort(abort)) => {
+            CancellableCompileOutcome::Errors(crate::CompileErrors::from(
+                crate::CompileError::without_span(crate::ErrorKind::InternalError(format!(
+                    "cancellable compile query aborted: {abort:?}"
+                ))),
+            ))
+        }
+    }
+}
+
 /// Opaque continuation at ADR-0068's codegen-ready endpoint.
 ///
 /// It owns the unpublished backend-root protection acquired with the rooted

--- a/crates/rue/src/compile.rs
+++ b/crates/rue/src/compile.rs
@@ -1,4 +1,4 @@
-use rue_compiler::unstable::OneShotMetrics;
+use rue_compiler::unstable::{CancellableCompileOutcome, CompilationCancellation, OneShotMetrics};
 use rue_compiler::{CompileErrors, CompileOptions, CompileWarning};
 use rue_driver::FilesystemCompilerHost;
 
@@ -9,6 +9,19 @@ pub(crate) struct CompileRequest<'a> {
     pub(crate) host: &'a mut FilesystemCompilerHost,
     pub(crate) options: CompileOptions,
     pub(crate) destination: PublicationDestination,
+}
+
+pub(crate) struct CancellableCompileRequest<'a> {
+    pub(crate) host: &'a mut FilesystemCompilerHost,
+    pub(crate) options: CompileOptions,
+    pub(crate) destination: PublicationDestination,
+    pub(crate) cancellation: CompilationCancellation,
+}
+
+pub(crate) enum CompileCycleOutcome {
+    Linked(Box<LinkedExecutable>),
+    Errors(CompileErrors),
+    Canceled,
 }
 
 pub(crate) struct LinkedExecutable {
@@ -40,6 +53,27 @@ pub(crate) fn execute(request: CompileRequest<'_>) -> Result<LinkedExecutable, C
         linked_bytes: output.elf,
         destination: request.destination,
     })
+}
+
+pub(crate) fn execute_cancellable(request: CancellableCompileRequest<'_>) -> CompileCycleOutcome {
+    let output = request
+        .host
+        .cancellable_executable_in_compile_scope(&request.options, request.cancellation);
+    match output {
+        CancellableCompileOutcome::Completed(output) => {
+            let output = *output;
+            let metrics = output.unstable_metrics();
+            CompileCycleOutcome::Linked(Box::new(LinkedExecutable {
+                target: request.options.target,
+                warnings: output.warnings,
+                metrics,
+                linked_bytes: output.elf,
+                destination: request.destination,
+            }))
+        }
+        CancellableCompileOutcome::Errors(errors) => CompileCycleOutcome::Errors(errors),
+        CancellableCompileOutcome::Canceled => CompileCycleOutcome::Canceled,
+    }
 }
 
 impl LinkedExecutable {

--- a/crates/rue/src/host.rs
+++ b/crates/rue/src/host.rs
@@ -1,8 +1,9 @@
 use std::path::Path;
 
 use rue_compiler::unstable::{
-    CodegenReady, ObjectsReady, PresentationOutput, PresentationRequest, codegen_ready,
-    executable_in_compile_scope, objects_ready, runnable_ready,
+    CancellableCompileOutcome, CodegenReady, CompilationCancellation, ObjectsReady,
+    PresentationOutput, PresentationRequest, cancellable_executable_in_compile_scope,
+    codegen_ready, executable_in_compile_scope, objects_ready, runnable_ready,
 };
 use rue_compiler::{
     AcceptedReadManifest, CompileOptions, CompileOutput, ImportDiscoveryContext,
@@ -66,6 +67,12 @@ impl FilesystemCompilerHost {
         &self.state.read_manifest
     }
 
+    /// Exact accepted filesystem closure, plus the policy manifest that can
+    /// change which reads are allowed on the next observation.
+    pub fn watch_inputs(&self) -> Vec<(std::path::PathBuf, u64)> {
+        self.state.watch_inputs()
+    }
+
     pub fn root_path(&self) -> &Path {
         &self.state.resolution.root_path
     }
@@ -99,6 +106,14 @@ impl FilesystemCompilerHost {
         options: &CompileOptions,
     ) -> MultiErrorResult<CompileOutput> {
         executable_in_compile_scope(&mut self.state.session, options)
+    }
+
+    pub fn cancellable_executable_in_compile_scope(
+        &mut self,
+        options: &CompileOptions,
+        cancellation: CompilationCancellation,
+    ) -> CancellableCompileOutcome {
+        cancellable_executable_in_compile_scope(&mut self.state.session, options, cancellation)
     }
 
     /// Reach ADR-0068's codegen-ready endpoint without projecting objects.
@@ -315,5 +330,19 @@ mod tests {
 
         assert!(!errors.is_empty());
         assert!(errors.to_string().contains("missing_name"));
+    }
+
+    #[test]
+    fn canceled_compile_does_not_produce_linked_bytes() {
+        let dir = TestDir::new("canceled-compile");
+        dir.write("main.rue", "fn main() -> i32 { 0 }\n");
+        let mut host = dir.open();
+        let cancellation = CompilationCancellation::new();
+        cancellation.cancel();
+
+        assert!(matches!(
+            host.cancellable_executable_in_compile_scope(&CompileOptions::default(), cancellation,),
+            CancellableCompileOutcome::Canceled
+        ));
     }
 }

--- a/crates/rue/src/main.rs
+++ b/crates/rue/src/main.rs
@@ -14,6 +14,7 @@ mod emit;
 mod output;
 mod platform_signing;
 mod timing;
+mod watch;
 
 use emit::EmitStage;
 #[cfg(test)]
@@ -198,6 +199,7 @@ struct Options {
     error_format: ErrorFormat,
     time_passes: bool,
     benchmark_json: bool,
+    watch: bool,
     /// Number of parallel jobs (0 = auto-detect, use all cores).
     jobs: usize,
 }
@@ -263,6 +265,7 @@ Options:
                        Formats: {error_formats}
   --time-passes        Show timing for each compilation pass
   --benchmark-json     Output timing as JSON (for benchmarking)
+  --watch              Recompile when the accepted source closure changes
   --version            Show version information
   --help               Show this help message",
         targets = Target::all_names(),
@@ -365,6 +368,7 @@ fn parse_args_from(args: &[&str]) -> ParseResult {
     let mut error_format: Option<ErrorFormat> = None;
     let mut time_passes = false;
     let mut benchmark_json = false;
+    let mut watch = false;
     let mut jobs: Option<usize> = None;
     let mut source_manifest_path: Option<String> = None;
     let mut output_path: Option<String> = None;
@@ -514,6 +518,9 @@ fn parse_args_from(args: &[&str]) -> ParseResult {
             "--benchmark-json" => {
                 benchmark_json = true;
             }
+            "--watch" => {
+                watch = true;
+            }
             "--help" | "-h" => {
                 // Explicit help request: success, so write to stdout (RUE-518).
                 print_help();
@@ -652,6 +659,7 @@ fn parse_args_from(args: &[&str]) -> ParseResult {
         error_format: error_format.unwrap_or_default(),
         time_passes,
         benchmark_json,
+        watch,
         jobs: jobs.unwrap_or(0),
     }))
 }
@@ -664,6 +672,16 @@ fn parse_args() -> Option<Options> {
         ParseResult::Options(opts) => Some(*opts),
         ParseResult::Error => None,
         ParseResult::Exit => std::process::exit(0),
+    }
+}
+
+fn validate_watch_modes(options: &Options) -> Result<(), &'static str> {
+    if options.watch
+        && (!options.emit_stages.is_empty() || options.benchmark_json || options.time_passes)
+    {
+        Err("Error: --watch cannot be combined with --emit, --benchmark-json, or --time-passes")
+    } else {
+        Ok(())
     }
 }
 
@@ -1011,6 +1029,10 @@ fn main() {
         eprintln!("{message}");
         std::process::exit(1);
     }
+    if let Err(message) = validate_watch_modes(&options) {
+        eprintln!("{message}");
+        std::process::exit(1);
+    }
 
     // Initialize tracing based on CLI options
     // Returns timing data if --time-passes or --benchmark-json was specified
@@ -1085,6 +1107,16 @@ fn main() {
         if let Err(error) = compiler_host.acquire_reached_toolchain_modules(&compile_options) {
             report_source_load_error(error, options.error_format);
         }
+    }
+
+    if options.watch {
+        watch::run(watch::WatchRequest {
+            host: compiler_host,
+            compile_options,
+            source_path: options.source_path,
+            output_path: options.output_path,
+            error_format: options.error_format,
+        });
     }
 
     #[cfg(rue_benchmark_allocations)]
@@ -1374,6 +1406,56 @@ mod tests {
                 assert_eq!(pass.root_invocations, 0, "{}", pass.name);
             }
         }
+    }
+
+    #[test]
+    fn watch_cycle_preserves_last_good_output_across_error_and_fix() {
+        let dir = TestDir::new("watch-error-fix");
+        let main = dir.write("main.rue", "fn main() -> i32 { 1 }\n");
+        let destination = dir.path.join("program");
+        let mut host = FilesystemCompilerHost::open(HostOpenRequest {
+            root_source: main.to_str().unwrap(),
+            source_manifest_path: None,
+            std_root: None,
+        })
+        .unwrap();
+        let options = CompileOptions::default();
+
+        let compile_cycle = |host: &mut FilesystemCompilerHost| {
+            let publication = output::preflight_destination(
+                &destination,
+                host.source_snapshot().files().map(|source| source.path),
+            )
+            .unwrap();
+            compile::execute_cancellable(compile::CancellableCompileRequest {
+                host,
+                options: options.clone(),
+                destination: publication,
+                cancellation: rue_compiler::unstable::CompilationCancellation::new(),
+            })
+        };
+
+        let compile::CompileCycleOutcome::Linked(linked) = compile_cycle(&mut host) else {
+            panic!("initial watch cycle must compile")
+        };
+        (*linked).publish().result.unwrap();
+        let first = fs::read(&destination).unwrap();
+
+        fs::write(&main, "fn main() -> i32 { missing }\n").unwrap();
+        host.reobserve().unwrap();
+        assert!(matches!(
+            compile_cycle(&mut host),
+            compile::CompileCycleOutcome::Errors(_)
+        ));
+        assert_eq!(fs::read(&destination).unwrap(), first);
+
+        fs::write(&main, "fn main() -> i32 { 2 }\n").unwrap();
+        host.reobserve().unwrap();
+        let compile::CompileCycleOutcome::Linked(linked) = compile_cycle(&mut host) else {
+            panic!("fixed watch cycle must compile")
+        };
+        (*linked).publish().result.unwrap();
+        assert_ne!(fs::read(&destination).unwrap(), first);
     }
 
     impl Drop for TestDir {
@@ -2255,6 +2337,33 @@ mod tests {
         ]));
         assert!(opts.time_passes);
         assert!(opts.benchmark_json);
+    }
+
+    // ========== --watch tests ==========
+
+    #[test]
+    fn parse_watch() {
+        let opts = unwrap_options(parse_args_from(&["--watch", "source.rue"]));
+        assert!(opts.watch);
+        assert!(validate_watch_modes(&opts).is_ok());
+    }
+
+    #[test]
+    fn watch_rejects_presentation_and_benchmark_modes() {
+        for args in [
+            &["--watch", "--emit", "air", "source.rue"][..],
+            &["--watch", "--benchmark-json", "source.rue"][..],
+            &["--watch", "--time-passes", "source.rue"][..],
+        ] {
+            let opts = unwrap_options(parse_args_from(args));
+            assert!(validate_watch_modes(&opts).is_err(), "{args:?}");
+        }
+    }
+
+    #[test]
+    fn watch_is_disabled_by_default() {
+        let opts = unwrap_options(parse_args_from(&["source.rue"]));
+        assert!(!opts.watch);
     }
 
     // ========== --jobs tests ==========

--- a/crates/rue/src/source_loader.rs
+++ b/crates/rue/src/source_loader.rs
@@ -38,6 +38,7 @@ use rue_compiler::{
 #[derive(Debug)]
 pub(crate) struct SourceManifest {
     path: PathBuf,
+    content_hash: u64,
     allowed: std::collections::HashSet<PathBuf>,
     declared_paths: std::collections::HashSet<PathBuf>,
 }
@@ -107,6 +108,7 @@ impl SourceManifest {
 
         Ok(Self {
             path: manifest_path.to_path_buf(),
+            content_hash: watch_content_hash(content.as_bytes()),
             allowed,
             declared_paths,
         })
@@ -697,6 +699,41 @@ pub(crate) struct SourceResolutionInputs {
     pub(crate) context: ImportDiscoveryContext,
 }
 
+impl ImportDiscoveryResult {
+    pub(crate) fn watch_inputs(&self) -> Vec<(PathBuf, u64)> {
+        let mut paths = Vec::with_capacity(self.read_manifest.len() * 2 + 1);
+        for entry in self.read_manifest.iter() {
+            let source = self
+                .source_snapshot
+                .files()
+                .find(|source| {
+                    self.source_snapshot.module_id(source.file_id) == Some(entry.module())
+                })
+                .expect("an accepted read has source bytes in the committed snapshot");
+            let hash = watch_content_hash(source.source.as_bytes());
+            paths.push((PathBuf::from(entry.requested_path()), hash));
+            paths.push((PathBuf::from(entry.canonical_path()), hash));
+        }
+        if let Some(manifest) = &self.source_manifest {
+            paths.push((manifest.path.clone(), manifest.content_hash));
+        }
+        paths.sort_by(|left, right| left.0.cmp(&right.0));
+        paths.dedup_by(|left, right| left.0 == right.0);
+        paths
+    }
+}
+
+pub(crate) fn watch_content_hash(bytes: &[u8]) -> u64 {
+    // A fixed FNV-1a hash keeps the polling watcher deterministic and avoids
+    // retaining another copy of every source buffer in its monitor thread.
+    let mut hash = 0xcbf29ce484222325_u64;
+    for byte in bytes {
+        hash ^= u64::from(*byte);
+        hash = hash.wrapping_mul(0x100000001b3);
+    }
+    hash
+}
+
 /// The closed import-discovery revision produced by
 /// [`drive_import_discovery_to_close`].
 struct ClosedDiscovery {
@@ -1038,10 +1075,8 @@ pub(crate) fn discover_and_load_imports(
     })
 }
 
-// The command-line driver is intentionally one-shot today. Keep this host
-// entrypoint compiled in non-test builds so a long-lived caller can begin its
-// next request without reimplementing the filesystem soundness boundary.
-#[cfg_attr(not(test), allow(dead_code))]
+// Long-lived hosts begin each successor request by re-observing the exact
+// accepted-read closure through this filesystem soundness boundary.
 pub(crate) fn reload_from_filesystem(
     result: &mut ImportDiscoveryResult,
 ) -> Result<(), SourceLoadError> {

--- a/crates/rue/src/watch.rs
+++ b/crates/rue/src/watch.rs
@@ -1,0 +1,308 @@
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::thread;
+use std::time::{Duration, Instant};
+
+use rue_compiler::unstable::{CompilationCancellation, SourceInfo};
+use rue_compiler::{CompileOptions, LinkerMode};
+use rue_driver::{FilesystemCompilerHost, SourceLoadError};
+
+use crate::compile::{CancellableCompileRequest, CompileCycleOutcome, execute_cancellable};
+use crate::output;
+use crate::{DiagnosticOutput, ErrorFormat};
+
+const POLL_INTERVAL: Duration = Duration::from_millis(25);
+const QUIET_PERIOD: Duration = Duration::from_millis(75);
+const FAILED_REOBSERVE_RETRY: Duration = Duration::from_millis(250);
+
+pub(crate) struct WatchRequest {
+    pub(crate) host: FilesystemCompilerHost,
+    pub(crate) compile_options: CompileOptions,
+    pub(crate) source_path: String,
+    pub(crate) output_path: String,
+    pub(crate) error_format: ErrorFormat,
+}
+
+struct ChangeMonitor {
+    stop: Arc<AtomicBool>,
+    changed: Arc<AtomicBool>,
+    thread: thread::JoinHandle<()>,
+}
+
+impl ChangeMonitor {
+    fn start(inputs: Vec<(PathBuf, u64)>, cancellation: CompilationCancellation) -> Self {
+        let stop = Arc::new(AtomicBool::new(false));
+        let changed = Arc::new(AtomicBool::new(false));
+        let thread_stop = stop.clone();
+        let thread_changed = changed.clone();
+        let thread = thread::spawn(move || {
+            while !thread_stop.load(Ordering::Acquire) {
+                if inputs_changed(&inputs) {
+                    thread_changed.store(true, Ordering::Release);
+                    cancellation.cancel();
+                    return;
+                }
+                thread::sleep(POLL_INTERVAL);
+            }
+        });
+        Self {
+            stop,
+            changed,
+            thread,
+        }
+    }
+
+    fn changed(&self) -> bool {
+        self.changed.load(Ordering::Acquire)
+    }
+
+    fn finish(self) -> bool {
+        self.stop.store(true, Ordering::Release);
+        self.thread
+            .join()
+            .expect("watch change monitor thread panicked");
+        self.changed.load(Ordering::Acquire)
+    }
+}
+
+pub(crate) fn run(mut request: WatchRequest) -> ! {
+    let mut needs_reobserve = false;
+    println!("Watching {} for changes", request.source_path);
+
+    loop {
+        let cycle_started = Instant::now();
+        if needs_reobserve {
+            match request.host.reobserve() {
+                Ok(()) => {}
+                Err(error) => {
+                    print_source_load_error(error, request.error_format);
+                    eprintln!(
+                        "Watch cycle failed after {} ms; keeping the last successful executable",
+                        cycle_started.elapsed().as_millis()
+                    );
+                    thread::sleep(FAILED_REOBSERVE_RETRY);
+                    continue;
+                }
+            }
+            if let Err(error) = request
+                .host
+                .acquire_reached_toolchain_modules(&request.compile_options)
+            {
+                print_source_load_error(error, request.error_format);
+                eprintln!(
+                    "Watch cycle failed after {} ms; keeping the last successful executable",
+                    cycle_started.elapsed().as_millis()
+                );
+                thread::sleep(FAILED_REOBSERVE_RETRY);
+                continue;
+            }
+        }
+
+        let inputs = request.host.watch_inputs();
+        let source_snapshot = request.host.source_snapshot().clone();
+        let source_infos = source_snapshot
+            .files()
+            .map(|source| (source.file_id, SourceInfo::new(source.source, source.path)))
+            .collect();
+        let diagnostics = DiagnosticOutput::new(request.error_format, source_infos);
+
+        let destination = match output::preflight_destination(
+            Path::new(&request.output_path),
+            source_snapshot.files().map(|source| source.path),
+        ) {
+            Ok(destination) => destination,
+            Err(output::PublishError::WouldClobberSource) => {
+                eprintln!(
+                    "Error: output path '{}' is also an input source file; refusing to overwrite it",
+                    request.output_path
+                );
+                wait_for_change(&inputs);
+                debounce(&inputs);
+                needs_reobserve = true;
+                continue;
+            }
+            Err(error) => {
+                diagnostics.print_error(&error.into_compile_error());
+                wait_for_change(&inputs);
+                debounce(&inputs);
+                needs_reobserve = true;
+                continue;
+            }
+        };
+
+        let cancellation = CompilationCancellation::new();
+        let monitor = ChangeMonitor::start(inputs.clone(), cancellation.clone());
+        let outcome = execute_cancellable(CancellableCompileRequest {
+            host: &mut request.host,
+            options: request.compile_options.clone(),
+            destination,
+            cancellation,
+        });
+
+        let changed_before_publication = monitor.changed() || inputs_changed(&inputs);
+        if changed_before_publication {
+            eprintln!(
+                "Watch cycle canceled after {} ms; a newer source revision is available",
+                cycle_started.elapsed().as_millis()
+            );
+        } else {
+            match outcome {
+                CompileCycleOutcome::Linked(output) => {
+                    let publication = (*output).publish();
+                    diagnostics.print_warnings(&publication.warnings);
+                    match publication.result {
+                        Ok(_) => {
+                            println!(
+                                "Compiled {} -> {} in {} ms (target: {}, linker: {})",
+                                request.source_path,
+                                request.output_path,
+                                cycle_started.elapsed().as_millis(),
+                                request.compile_options.target,
+                                linker_name(&request.compile_options.linker),
+                            );
+                        }
+                        Err(output::PublishError::WouldClobberSource) => eprintln!(
+                            "Error: output path '{}' became an input source; keeping the last successful executable",
+                            request.output_path
+                        ),
+                        Err(error) => diagnostics.print_error(&error.into_compile_error()),
+                    }
+                }
+                CompileCycleOutcome::Canceled => {
+                    eprintln!(
+                        "Watch cycle canceled after {} ms",
+                        cycle_started.elapsed().as_millis()
+                    );
+                }
+                CompileCycleOutcome::Errors(errors) => {
+                    diagnostics.print_errors(&errors);
+                    eprintln!(
+                        "Watch cycle failed after {} ms; keeping the last successful executable",
+                        cycle_started.elapsed().as_millis()
+                    );
+                }
+            }
+        }
+
+        let changed = monitor.finish() || inputs_changed(&inputs);
+        if !changed {
+            wait_for_change(&inputs);
+        }
+        debounce(&inputs);
+        needs_reobserve = true;
+    }
+}
+
+fn linker_name(linker: &LinkerMode) -> &str {
+    match linker {
+        LinkerMode::Internal => "internal",
+        LinkerMode::System(command) => command,
+    }
+}
+
+fn print_source_load_error(error: SourceLoadError, error_format: ErrorFormat) {
+    match error {
+        SourceLoadError::Message(message) => eprintln!("{message}"),
+        SourceLoadError::Toolchain(error) => eprintln!("{error}"),
+        SourceLoadError::HermeticDenial(error) => eprintln!("{error}"),
+        SourceLoadError::Compiler { snapshot, errors } => {
+            let infos = snapshot
+                .as_ref()
+                .map(|snapshot| {
+                    snapshot
+                        .files()
+                        .map(|source| (source.file_id, SourceInfo::new(source.source, source.path)))
+                        .collect()
+                })
+                .unwrap_or_default();
+            DiagnosticOutput::new(error_format, infos).print_errors(&errors);
+        }
+    }
+}
+
+fn wait_for_change(inputs: &[(PathBuf, u64)]) {
+    while !inputs_changed(inputs) {
+        thread::sleep(POLL_INTERVAL);
+    }
+}
+
+fn debounce(inputs: &[(PathBuf, u64)]) {
+    let paths = inputs
+        .iter()
+        .map(|(path, _)| path.clone())
+        .collect::<Vec<_>>();
+    let mut previous = current_fingerprints(&paths);
+    let mut quiet_since = Instant::now();
+    while quiet_since.elapsed() < QUIET_PERIOD {
+        thread::sleep(POLL_INTERVAL);
+        let current = current_fingerprints(&paths);
+        if current != previous {
+            previous = current;
+            quiet_since = Instant::now();
+        }
+    }
+}
+
+fn inputs_changed(inputs: &[(PathBuf, u64)]) -> bool {
+    inputs
+        .iter()
+        .any(|(path, expected)| file_hash(path).as_ref() != Some(expected))
+}
+
+fn current_fingerprints(paths: &[PathBuf]) -> Vec<Option<u64>> {
+    paths.iter().map(|path| file_hash(path)).collect()
+}
+
+fn file_hash(path: &Path) -> Option<u64> {
+    fs::read(path).ok().map(|bytes| content_hash(&bytes))
+}
+
+fn content_hash(bytes: &[u8]) -> u64 {
+    let mut hash = 0xcbf29ce484222325_u64;
+    for byte in bytes {
+        hash ^= u64::from(*byte);
+        hash = hash.wrapping_mul(0x100000001b3);
+    }
+    hash
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn detects_content_changes_even_when_file_length_is_unchanged() {
+        let path = std::env::temp_dir().join(format!(
+            "rue-watch-fingerprint-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        fs::write(&path, b"alpha").unwrap();
+        let inputs = vec![(path.clone(), content_hash(b"alpha"))];
+        assert!(!inputs_changed(&inputs));
+        fs::write(&path, b"bravo").unwrap();
+        assert!(inputs_changed(&inputs));
+        fs::remove_file(path).unwrap();
+    }
+
+    #[test]
+    fn detects_deleted_inputs() {
+        let path = std::env::temp_dir().join(format!(
+            "rue-watch-deletion-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        fs::write(&path, b"source").unwrap();
+        let inputs = vec![(path.clone(), content_hash(b"source"))];
+        fs::remove_file(path).unwrap();
+        assert!(inputs_changed(&inputs));
+    }
+}

--- a/docs/designs/0068-incremental-edit-performance-measurement.md
+++ b/docs/designs/0068-incremental-edit-performance-measurement.md
@@ -318,9 +318,9 @@ projects. None may introduce a peer compilation path.
   RUE-1252
 - [x] **Phase 5: Scheduled report.** Publish lower-frequency JSON and Markdown
   workflow artifacts with no dashboard/headline integration. — RUE-1253
-- [ ] **Phase 6: Product host.** Add and measure `rue --watch` on the same seam,
+- [x] **Phase 6: Product host.** Add and measure `rue --watch` on the same seam,
   including cancellation, error/fix, import-set, and atomic-publication tests. —
-  follow-up issue
+  RUE-1254
 - [ ] **Phase 7: Linker gate.** Record the Lattice decision result on RUE-1096
   and either advance its ADR or explicitly defer it. — RUE-1096
 


### PR DESCRIPTION
Fixes RUE-1254.

Adds `rue --watch` on the canonical filesystem host and retained compiler session. Source edits cooperatively cancel in-flight query work; canceled and failed cycles preserve the last successful executable, while successful cycles use the existing atomic publication path.

The watcher tracks the exact accepted-read closure plus the source manifest, coalesces bursts, recovers from error/fix and import-set changes, and reports each cycle outcome and latency.

Validation:
- `scripts/rue premerge`
- manual valid edit → error → fix watch cycle