### PR TITLE
RUE-1256: measure std as product rather than pinning it

### DIFF
--- a/crates/rue-bench/src/derive.rs
+++ b/crates/rue-bench/src/derive.rs
@@ -81,6 +81,24 @@ pub struct EpochData {
     /// The epoch pins an environment *policy*, not a machine, so hosted runners
     /// change underneath it. Comparisons crossing one of these are advisory.
     pub environment_annotations: Vec<EnvironmentAnnotation>,
+    /// Standard-library changes within this epoch.
+    ///
+    /// Deliberately *not* advisory, unlike an environment annotation. `std` is
+    /// part of the product being measured, so a change here is a real movement
+    /// in what the series tracks — the same status as a compiler change, which
+    /// gets no annotation only because every point already is one.
+    pub stdlib_annotations: Vec<StdlibAnnotation>,
+}
+
+/// A point at which the standard library changed underneath a series.
+#[derive(Debug, Serialize)]
+pub struct StdlibAnnotation {
+    /// The first commit measured against the new standard library.
+    pub commit: String,
+    pub finished_at: String,
+    /// The resolved hashes either side of the change, for provenance.
+    pub previous: String,
+    pub current: String,
 }
 
 #[derive(Debug, Serialize)]
@@ -268,6 +286,8 @@ fn derive_epoch(
     let mut points: Vec<PointData> = Vec::new();
     let mut environment_annotations = Vec::new();
     let mut previous_environment: Option<(String, &rue_perf_schema::EnvironmentFingerprint)> = None;
+    let mut stdlib_annotations = Vec::new();
+    let mut previous_stdlib: Option<&str> = None;
 
     // History of each workload's summary, so the trailing window can be taken
     // over the *medians* of prior runs, matching the flagging rule's definition.
@@ -297,6 +317,22 @@ fn derive_epoch(
             });
         }
         previous_environment = Some((fingerprint.clone(), &run.identity.environment));
+
+        // Recorded, never a reason to exclude the run. This is the annotation
+        // that replaced the `stdlib_hash` pin: a std change moves the product,
+        // and the page should say where it moved rather than stop drawing.
+        let stdlib = run.identity.pins.stdlib_hash.as_str();
+        if let Some(previous) = previous_stdlib
+            && previous != stdlib
+        {
+            stdlib_annotations.push(StdlibAnnotation {
+                commit: run.identity.commit.clone(),
+                finished_at: run.identity.finished_at.clone(),
+                previous: previous.to_string(),
+                current: stdlib.to_string(),
+            });
+        }
+        previous_stdlib = Some(stdlib);
 
         let invalid: BTreeSet<(String, u32)> = outcome
             .invalid_samples
@@ -422,6 +458,7 @@ fn derive_epoch(
         baseline_commit: epoch.baseline.as_ref().map(|b| b.commit.clone()),
         points,
         environment_annotations,
+        stdlib_annotations,
     }
 }
 
@@ -566,7 +603,6 @@ suite_revision = 1
 target = "x86_64-unknown-linux-gnu"
 args = []
 toolchain_hash = "toolchain"
-stdlib_hash = "stdlib"
 
 [epoch.workload_source_hashes]
 startup = "startup-hash"
@@ -856,6 +892,51 @@ window = 3
         assert!(
             annotations[0].changed.iter().any(|c| c.contains("CPU")),
             "{annotations:?}"
+        );
+    }
+
+    #[test]
+    fn a_standard_library_change_annotates_the_series_without_breaking_it() {
+        // The regression this whole change exists to prevent: a std edit used
+        // to fail the `stdlib_hash` pin, so every later run was rejected and
+        // the published page silently stopped moving (RUE-1256).
+        let first = run_at("a", "2026-07-28T00:00:00Z", [100, 100, 100]);
+        let manifest = manifest_with_baseline(std::slice::from_ref(&first));
+        let mut second = run_at("b", "2026-07-28T01:00:00Z", [110, 110, 110]);
+        second.identity.pins.stdlib_hash = "a-new-standard-library".to_string();
+
+        let data = derive(&manifest, &[first, second]);
+
+        assert!(data.rejected.is_empty(), "{:?}", data.rejected);
+        let epoch = &data.platforms[0].epochs[0];
+        assert_eq!(epoch.points.len(), 2, "both points belong to one series");
+
+        assert_eq!(epoch.stdlib_annotations.len(), 1);
+        assert_eq!(epoch.stdlib_annotations[0].commit, "b".repeat(40));
+        assert_eq!(
+            epoch.stdlib_annotations[0].current,
+            "a-new-standard-library"
+        );
+
+        // The point across the change is still measured against the same
+        // baseline: std moving is movement in the product, not a discontinuity
+        // that resets what 1.0 means.
+        assert_eq!(epoch.points[1].workloads["startup"].ratio, Some(1.1));
+    }
+
+    #[test]
+    fn an_unchanged_standard_library_produces_no_annotation() {
+        let manifest = Manifest::parse(MANIFEST).unwrap();
+        let data = derive(
+            &manifest,
+            &[
+                run_at("a", "2026-07-28T00:00:00Z", [100, 100, 100]),
+                run_at("b", "2026-07-28T01:00:00Z", [100, 100, 100]),
+            ],
+        );
+        assert!(
+            data.platforms[0].epochs[0].stdlib_annotations.is_empty(),
+            "an annotation on every point would be noise, not a finding"
         );
     }
 

--- a/crates/rue-bench/src/derive.rs
+++ b/crates/rue-bench/src/derive.rs
@@ -318,9 +318,8 @@ fn derive_epoch(
         }
         previous_environment = Some((fingerprint.clone(), &run.identity.environment));
 
-        // Recorded, never a reason to exclude the run. This is the annotation
-        // that replaced the `stdlib_hash` pin: a std change moves the product,
-        // and the page should say where it moved rather than stop drawing.
+        // Recorded, never a reason to exclude the run: a std change moves the
+        // product, so the page says where it moved rather than stop drawing.
         let stdlib = run.identity.pins.stdlib_hash.as_str();
         if let Some(previous) = previous_stdlib
             && previous != stdlib
@@ -897,9 +896,9 @@ window = 3
 
     #[test]
     fn a_standard_library_change_annotates_the_series_without_breaking_it() {
-        // The regression this whole change exists to prevent: a std edit used
-        // to fail the `stdlib_hash` pin, so every later run was rejected and
-        // the published page silently stopped moving (RUE-1256).
+        // A std change must annotate the series, not truncate it: rejecting
+        // these runs would silently stop the published page at the last point
+        // measured before the edit.
         let first = run_at("a", "2026-07-28T00:00:00Z", [100, 100, 100]);
         let manifest = manifest_with_baseline(std::slice::from_ref(&first));
         let mut second = run_at("b", "2026-07-28T01:00:00Z", [110, 110, 110]);

--- a/crates/rue-bench/src/main.rs
+++ b/crates/rue-bench/src/main.rs
@@ -569,7 +569,6 @@ suite_revision = 1
 target = "x86_64-unknown-linux-gnu"
 args = ["-O2"]
 toolchain_hash = "toolchain"
-stdlib_hash = "stdlib"
 
 [epoch.workload_source_hashes]
 startup = "startup-hash"

--- a/crates/rue-bench/src/pins.rs
+++ b/crates/rue-bench/src/pins.rs
@@ -14,7 +14,7 @@
 //! run and gates nothing: `std` is part of the product being measured, so a
 //! change to it moves the series rather than invalidating it, and the dashboard
 //! annotates where that happened. [`workload_source_hash`] excludes std reads
-//! for the same reason (ADR-0067 "The product boundary", RUE-1256).
+//! for the same reason. See ADR-0067, "The product boundary".
 
 use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
@@ -150,9 +150,8 @@ struct AcceptedRead {
 /// Standard-library reads are excluded deliberately. `std` is part of the
 /// product being measured, not an input pinned against it, so a std edit must
 /// move the series the way a compiler change does. Folding std into this hash
-/// would invalidate every series whose workload reads it — including the
-/// std-compiling workload, on every std commit — which is the same failure as
-/// the removed `stdlib_hash` pin wearing a different name (RUE-1256).
+/// would invalidate every series whose workload reads it, and would invalidate
+/// a std-compiling workload on every std commit.
 pub fn workload_source_hash(
     compiler: &Path,
     source: &Path,
@@ -228,8 +227,7 @@ fn is_stdlib_read(canonical_path: &Path, std_root: Option<&Path>) -> bool {
 /// The report's paths are canonical, so the standard-library root must be too.
 /// A relative or symlinked `--std-root` would otherwise fail every comparison
 /// and silently fold the whole standard library back into the workload's
-/// identity — the exact failure this exclusion exists to prevent, and one that
-/// would look like nothing at all until a std edit froze the series.
+/// identity, which looks like nothing at all until the next std edit.
 fn resolve_for_comparison(path: &Path) -> PathBuf {
     std::fs::canonicalize(path).unwrap_or_else(|_| path.to_path_buf())
 }

--- a/crates/rue-bench/src/pins.rs
+++ b/crates/rue-bench/src/pins.rs
@@ -9,6 +9,12 @@
 //!
 //! Resolving must therefore never consult the epoch. A resolver that fell back
 //! to the declared value on error would defeat the check it exists to feed.
+//!
+//! Not everything resolved here is compared. [`stdlib_hash`] is recorded on the
+//! run and gates nothing: `std` is part of the product being measured, so a
+//! change to it moves the series rather than invalidating it, and the dashboard
+//! annotates where that happened. [`workload_source_hash`] excludes std reads
+//! for the same reason (ADR-0067 "The product boundary", RUE-1256).
 
 use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
@@ -128,7 +134,8 @@ struct AcceptedRead {
     canonical_path: PathBuf,
 }
 
-/// Hash a workload's full transitive source closure.
+/// Hash a workload's own transitive source closure, excluding the standard
+/// library.
 ///
 /// The closure comes from the compiler's own `--emit deps`, so it is the set
 /// the compiler would actually read rather than a guess at the import graph.
@@ -139,6 +146,13 @@ struct AcceptedRead {
 /// Files are keyed by module path, which is relative to the project root, so
 /// two checkouts of the same tree at different absolute paths resolve to the
 /// same hash.
+///
+/// Standard-library reads are excluded deliberately. `std` is part of the
+/// product being measured, not an input pinned against it, so a std edit must
+/// move the series the way a compiler change does. Folding std into this hash
+/// would invalidate every series whose workload reads it — including the
+/// std-compiling workload, on every std commit — which is the same failure as
+/// the removed `stdlib_hash` pin wearing a different name (RUE-1256).
 pub fn workload_source_hash(
     compiler: &Path,
     source: &Path,
@@ -174,17 +188,50 @@ pub fn workload_source_hash(
         });
     }
 
+    let std_root = std_root.map(resolve_for_comparison);
     let mut entries = BTreeMap::new();
+    let mut standard_library_reads = 0usize;
     for read in &report.accepted_reads {
+        if is_stdlib_read(&read.canonical_path, std_root.as_deref()) {
+            standard_library_reads += 1;
+            continue;
+        }
         entries.insert(read.module.clone(), hash_file(&read.canonical_path)?);
     }
     if entries.is_empty() {
         return Err(PinError {
             subject,
-            detail: "dependency discovery accepted no reads".to_string(),
+            detail: if standard_library_reads > 0 {
+                // Distinguished from "no reads at all": a workload whose whole
+                // closure is std has no identity of its own to pin, which is a
+                // corpus mistake rather than a discovery failure.
+                format!(
+                    "dependency discovery accepted {standard_library_reads} read(s), all within \
+                     the standard library, so the workload has no source identity of its own"
+                )
+            } else {
+                "dependency discovery accepted no reads".to_string()
+            },
         });
     }
     Ok(fold(&entries))
+}
+
+/// Whether a resolved read belongs to the standard library rather than to the
+/// workload itself.
+fn is_stdlib_read(canonical_path: &Path, std_root: Option<&Path>) -> bool {
+    std_root.is_some_and(|root| canonical_path.starts_with(root))
+}
+
+/// Resolve a path so it can be prefix-compared against the dependency report.
+///
+/// The report's paths are canonical, so the standard-library root must be too.
+/// A relative or symlinked `--std-root` would otherwise fail every comparison
+/// and silently fold the whole standard library back into the workload's
+/// identity — the exact failure this exclusion exists to prevent, and one that
+/// would look like nothing at all until a std edit froze the series.
+fn resolve_for_comparison(path: &Path) -> PathBuf {
+    std::fs::canonicalize(path).unwrap_or_else(|_| path.to_path_buf())
 }
 
 #[cfg(test)]
@@ -258,6 +305,64 @@ mod tests {
 
         std::fs::write(directory.path().join("nested/b.rue"), "fn b() { 1 }").unwrap();
         assert_ne!(first, stdlib_hash(directory.path()).unwrap());
+    }
+
+    #[test]
+    fn standard_library_reads_are_excluded_from_a_workloads_identity() {
+        let std_root = Path::new("/repo/std");
+        assert!(is_stdlib_read(
+            Path::new("/repo/std/math.rue"),
+            Some(std_root)
+        ));
+        assert!(is_stdlib_read(
+            Path::new("/repo/std/nested/deep.rue"),
+            Some(std_root)
+        ));
+        assert!(!is_stdlib_read(
+            Path::new("/repo/performance/workloads/startup/main.rue"),
+            Some(std_root)
+        ));
+    }
+
+    #[test]
+    fn a_sibling_directory_sharing_a_prefix_is_not_the_standard_library() {
+        // Component-wise, not textual: `/repo/stdlib-tests` merely starts with
+        // the same characters as `/repo/std`, and excluding it would silently
+        // drop real workload sources from the hash.
+        assert!(!is_stdlib_read(
+            Path::new("/repo/stdlib-tests/main.rue"),
+            Some(Path::new("/repo/std"))
+        ));
+    }
+
+    #[test]
+    fn without_a_standard_library_root_nothing_is_excluded() {
+        assert!(!is_stdlib_read(Path::new("/repo/std/math.rue"), None));
+    }
+
+    #[test]
+    fn the_standard_library_root_is_resolved_before_comparison() {
+        // The dependency report's paths are canonical. A relative std root that
+        // stayed relative would match nothing, folding std back into every
+        // workload's identity without any visible symptom until a std edit.
+        let directory = tempfile::tempdir().expect("temp dir");
+        let std_root = directory.path().join("std");
+        std::fs::create_dir(&std_root).unwrap();
+
+        let resolved = resolve_for_comparison(&std_root);
+        assert!(resolved.is_absolute());
+        assert!(is_stdlib_read(
+            &resolved.join("math.rue"),
+            Some(resolved.as_path())
+        ));
+    }
+
+    #[test]
+    fn a_path_that_cannot_be_resolved_is_kept_as_given() {
+        // Falling back rather than failing: an unresolvable std root is not
+        // this function's error to report.
+        let missing = Path::new("/definitely/not/here");
+        assert_eq!(resolve_for_comparison(missing), missing.to_path_buf());
     }
 
     #[test]

--- a/crates/rue-perf-schema/src/manifest.rs
+++ b/crates/rue-perf-schema/src/manifest.rs
@@ -164,11 +164,18 @@ pub struct PlatformEpoch {
     pub target: String,
     /// Every behavior-affecting compiler argument, in order.
     pub args: Vec<String>,
-    /// Content hash of the toolchain as built for this target.
+    /// Content hash of the Rust toolchain the compiler is built with.
+    ///
+    /// Build environment, not product: changing it changes generated code and
+    /// therefore measurements, while measuring nothing anyone ships. The Rue
+    /// compiler, `std`, and the first-party toolchain are the *subject* of
+    /// measurement and are deliberately not pinned here.
     pub toolchain_hash: String,
-    /// Content hash of the standard library.
-    pub stdlib_hash: String,
-    /// Content hash of each workload's full source closure, keyed by workload.
+    /// Content hash of each workload's own source closure, keyed by workload.
+    ///
+    /// The workload's own sources only. `std` is part of the product under
+    /// measurement, so std files a workload reads are excluded — otherwise a
+    /// std edit would invalidate every series that reads it.
     pub workload_source_hashes: BTreeMap<String, String>,
     /// The environment class this epoch requires.
     pub environment: EnvironmentPolicy,
@@ -495,7 +502,6 @@ suite_revision = 1
 target = "x86_64-unknown-linux-gnu"
 args = ["-O2"]
 toolchain_hash = "toolchain-aaa"
-stdlib_hash = "stdlib-bbb"
 
 [epoch.workload_source_hashes]
 startup = "startup-ccc"

--- a/crates/rue-perf-schema/src/run.rs
+++ b/crates/rue-perf-schema/src/run.rs
@@ -353,7 +353,13 @@ pub struct Invocation {
 pub struct ResolvedPins {
     /// Content hash of the toolchain as built for this target.
     pub toolchain_hash: String,
-    /// Content hash of the standard library.
+    /// Content hash of the standard library at the measured revision.
+    ///
+    /// Recorded, not pinned. `std` is part of the product under measurement, so
+    /// a change here moves the series rather than invalidating it; validation
+    /// does not compare this against the epoch, and the dashboard annotates the
+    /// point where it changed. It stays in the run object because the
+    /// observation is worth keeping even though nothing gates on it.
     pub stdlib_hash: String,
     /// Content hash of each workload's full source closure, keyed by workload.
     pub workload_source_hashes: BTreeMap<String, String>,

--- a/crates/rue-perf-schema/src/validate.rs
+++ b/crates/rue-perf-schema/src/validate.rs
@@ -1340,9 +1340,8 @@ window = 10
     #[test]
     fn a_std_change_does_not_prevent_a_run_from_entering_its_series() {
         // `std` is part of the product being measured, not an input pinned
-        // against it. A std edit must move the series exactly as a compiler
-        // change does — the alternative froze the published dashboard for ten
-        // days while collection stayed green (RUE-1256).
+        // against it: a std edit moves the series exactly as a compiler change
+        // does. Rejecting the run instead would stop the series entirely.
         let mut run = sample_run();
         run.identity.pins.stdlib_hash = "a-completely-different-standard-library".to_string();
         let outcome = validate_run(&manifest(), &run);

--- a/crates/rue-perf-schema/src/validate.rs
+++ b/crates/rue-perf-schema/src/validate.rs
@@ -512,7 +512,10 @@ fn check_pins(
         &epoch.toolchain_hash,
         &pins.toolchain_hash,
     );
-    compare("stdlib_hash", &epoch.stdlib_hash, &pins.stdlib_hash);
+    // `stdlib_hash` is deliberately not compared. `std` is part of the product
+    // under measurement, not an input to it, so a std change moves the series
+    // exactly as a compiler change does. The run still records the hash it
+    // resolved, and the dashboard annotates the point where it changed.
     compare("invocation/target", &epoch.target, &pins.invocation.target);
 
     if epoch.args != pins.invocation.args {
@@ -783,7 +786,6 @@ suite_revision = 1
 target = "x86_64-unknown-linux-gnu"
 args = ["-O2"]
 toolchain_hash = "toolchain-aaa"
-stdlib_hash = "stdlib-bbb"
 
 [epoch.workload_source_hashes]
 caldera = "caldera-ccc"
@@ -966,10 +968,6 @@ window = 10
                 Box::new(|run: &mut RunObject| {
                     run.identity.pins.toolchain_hash = "other".to_string()
                 }),
-            ),
-            (
-                "stdlib_hash",
-                Box::new(|run: &mut RunObject| run.identity.pins.stdlib_hash = "other".to_string()),
             ),
             (
                 "invocation/target",
@@ -1333,9 +1331,57 @@ window = 10
     fn every_problem_is_reported_rather_than_the_first() {
         let mut run = sample_run();
         run.identity.pins.toolchain_hash = "other".to_string();
-        run.identity.pins.stdlib_hash = "other".to_string();
+        run.identity.pins.invocation.target = "other".to_string();
         run.identity.environment.runner_image = "ubuntu-22.04".to_string();
         let outcome = validate_run(&manifest(), &run);
         assert_eq!(outcome.errors.len(), 3, "{:?}", outcome.errors);
+    }
+
+    #[test]
+    fn a_std_change_does_not_prevent_a_run_from_entering_its_series() {
+        // `std` is part of the product being measured, not an input pinned
+        // against it. A std edit must move the series exactly as a compiler
+        // change does — the alternative froze the published dashboard for ten
+        // days while collection stayed green (RUE-1256).
+        let mut run = sample_run();
+        run.identity.pins.stdlib_hash = "a-completely-different-standard-library".to_string();
+        let outcome = validate_run(&manifest(), &run);
+
+        assert!(
+            outcome.is_appendable(),
+            "a std change must not reject a run: {:?}",
+            outcome.errors
+        );
+        assert!(
+            !outcome.errors.iter().any(
+                |error| matches!(error, ValidationError::PinMismatch { field, .. }
+                    if field == "stdlib_hash")
+            ),
+            "{:?}",
+            outcome.errors
+        );
+    }
+
+    #[test]
+    fn a_workloads_own_source_change_still_rejects_the_run() {
+        // The counterpart to the test above. Relaxing the std pin must not
+        // relax the pin that gives a series its meaning: changing what a
+        // workload *is* still requires declaring the next revision.
+        let mut run = sample_run();
+        run.identity
+            .pins
+            .workload_source_hashes
+            .insert("startup".to_string(), "edited".to_string());
+        let outcome = validate_run(&manifest(), &run);
+
+        assert!(!outcome.is_appendable());
+        assert!(
+            outcome.errors.iter().any(
+                |error| matches!(error, ValidationError::PinMismatch { field, .. }
+                    if field == "workload_source_hashes/startup")
+            ),
+            "{:?}",
+            outcome.errors
+        );
     }
 }

--- a/docs/designs/0067-compiler-performance-measurement.md
+++ b/docs/designs/0067-compiler-performance-measurement.md
@@ -194,15 +194,11 @@ own sources, the target and invocation, the environment policy, and the Rust
 toolchain the compiler is built with. That last one is build environment rather
 than product — changing it changes generated code while shipping nothing.
 
-This boundary replaces an earlier rule under which an epoch pinned the standard
-library outright. That rule was exercised once, by a mechanical
-`i = i + 1` -> `i += 1` sweep across `std/` that changed no measured behaviour:
-output binaries were byte-identical on all three platforms, and every run for
-the next ten days was refused while collection, the data branch, and the site
-build all reported success. An input change should be visible, but a pin
-reports only that a hash moved. A workload that compiles `std` reports what the
-change cost, which is both a stronger signal and one that cannot stop the
-series.
+An epoch pinned the standard library outright until RUE-1256. Pinning makes a
+`std` edit refuse every subsequent run, which stops the series rather than
+describing it, and a pin reports only that a hash moved. Measuring `std` — a
+workload that compiles it — reports what a change cost, which is both the
+stronger signal and one that cannot halt collection.
 
 A change to what a workload *is* creates a new suite revision and therefore
 new epochs on every participating platform. Raising only the macOS sample
@@ -245,15 +241,13 @@ and never invalidate anything.
 **Versioning a workload rather than refusing its runs.** Refusal is the
 forcing function, not the resolution. When a workload genuinely must change,
 the answer is a new workload identity rather than an edit under the old name:
-suffix the identifier (`caldera`, then `caldera-2`, then `caldera-3`), declare
-it in the next suite revision, and add the new one before removing the old so
-coverage is continuous across the change. Both series render, the old one
-ending where the new one begins. This follows `rustc-perf`, which versions its
-benchmarks the same way and keeps a deliberately frozen set for long-horizon
-comparison; the cost is a bounded loss of continuity in exchange for measuring
-something that is still worth measuring. What must never happen is a workload
-silently changing meaning under a continuing headline, which is exactly what
-refusal prevents.
+suffix the identifier (`caldera`, then `caldera-2`), declare it in the next
+suite revision, and add the new one before removing the old so coverage stays
+continuous. Both series render, the old one ending where the new one begins.
+This follows `rustc-perf`, which versions its benchmarks the same way. The
+trade is a bounded loss of continuity for measuring something still worth
+measuring; what must never happen is a workload silently changing meaning
+under a continuing headline.
 
 ### 5. Sampling and noise
 

--- a/docs/designs/0067-compiler-performance-measurement.md
+++ b/docs/designs/0067-compiler-performance-measurement.md
@@ -170,14 +170,39 @@ A **platform epoch** pins, per platform:
 - the suite revision it implements;
 - the target and the complete compiler invocation (optimization level, linker
   mode, feature flags, and any behavior-affecting arguments);
-- the resolved transitive content hashes: each workload's full source
-  closure, the standard library, and the toolchain as built for this target;
+- the resolved transitive content hash of each workload's **own** source
+  closure, excluding the standard library (see "The product boundary" below);
+- the content hash of the Rust toolchain the compiler is built with;
 - the per-workload sampling and batching policy;
 - the environment policy: runner environment class and image label
   (e.g. `github-hosted`, `ubuntu-24.04`);
 - the headline baseline: the first **complete, valid** run at a declared
   trunk revision, whose per-workload medians define ratio 1.0. An attempted
   or partial run is never a baseline.
+
+**The product boundary.** The Rue language, `std`, and the first-party
+toolchain are a single product, and this suite measures that product. They are
+therefore the *subject* of measurement, never pinned inputs: a `std` change
+moves a series exactly as a change to compiler internals does. Each run records
+the standard library's resolved hash, validation does not compare it against
+the epoch, and the dashboard annotates the point where it changed. The
+annotation is deliberately not marked advisory — unlike an environment change,
+this is real movement in the thing being tracked.
+
+What remains pinned is everything that is *not* the product: each workload's
+own sources, the target and invocation, the environment policy, and the Rust
+toolchain the compiler is built with. That last one is build environment rather
+than product — changing it changes generated code while shipping nothing.
+
+This boundary replaces an earlier rule under which an epoch pinned the standard
+library outright. That rule was exercised once, by a mechanical
+`i = i + 1` -> `i += 1` sweep across `std/` that changed no measured behaviour:
+output binaries were byte-identical on all three platforms, and every run for
+the next ten days was refused while collection, the data branch, and the site
+build all reported success. An input change should be visible, but a pin
+reports only that a hash moved. A workload that compiles `std` reports what the
+change cost, which is both a stronger signal and one that cannot stop the
+series.
 
 A change to what a workload *is* creates a new suite revision and therefore
 new epochs on every participating platform. Raising only the macOS sample
@@ -213,7 +238,22 @@ baseline while the headline continues.
 The guarantee, stated precisely: observations that are invalid for a series'
 suite revision or platform configuration cannot enter it; environment
 variation within the epoch's policy remains possible, is recorded via
-fingerprints, and makes the affected comparisons advisory.
+fingerprints, and makes the affected comparisons advisory. Product changes —
+compiler, `std`, first-party toolchain — are what the series exists to show,
+and never invalidate anything.
+
+**Versioning a workload rather than refusing its runs.** Refusal is the
+forcing function, not the resolution. When a workload genuinely must change,
+the answer is a new workload identity rather than an edit under the old name:
+suffix the identifier (`caldera`, then `caldera-2`, then `caldera-3`), declare
+it in the next suite revision, and add the new one before removing the old so
+coverage is continuous across the change. Both series render, the old one
+ending where the new one begins. This follows `rustc-perf`, which versions its
+benchmarks the same way and keeps a deliberately frozen set for long-horizon
+comparison; the cost is a bounded loss of continuity in exchange for measuring
+something that is still worth measuring. What must never happen is a workload
+silently changing meaning under a continuing headline, which is exactly what
+refusal prevents.
 
 ### 5. Sampling and noise
 

--- a/performance/manifest.toml
+++ b/performance/manifest.toml
@@ -3,25 +3,27 @@
 # Two layers. A `[[suite]]` pins the platform-independent logical contract:
 # which workloads exist, what program each one is, the phase taxonomy, and the
 # runner protocol. A `[[epoch]]` pins everything that varies per platform:
-# target and invocation, resolved content hashes, sampling policy, environment
-# policy, and the headline baseline.
+# target and invocation, each workload's own source identity, sampling policy,
+# environment policy, and the headline baseline.
 #
 # Changing what a workload *is* requires a new suite revision, and therefore new
 # epochs on every participating platform. Changing only one platform's sampling
 # creates a new epoch there alone. Both are deliberate, reviewable events.
+#
+# What is deliberately NOT pinned here is the product being measured: the Rue
+# compiler, `std`, and the first-party toolchain. A std change moves the series
+# exactly as a compiler change does, is annotated on the dashboard, and never
+# invalidates an observation. Pinning `std` was tried and removed in RUE-1256:
+# an `i = i + 1` -> `i += 1` sweep across `std/` rejected every subsequent run
+# for ten days while collection, the data branch, and the site build all stayed
+# green. `toolchain_hash` remains pinned because it names the *Rust* toolchain
+# the compiler is built with — build environment, not product.
 #
 # STATUS: the `local` epoch below exists so the runner can be exercised during
 # development. Its sampling counts are placeholders, not calibrated values, and
 # it declares no baseline. The published epochs — with counts, batching factors,
 # and the flagging multiplier established by the Phase 4 noise calibration —
 # arrive with suite revision 1's declaration in RUE-1188.
-#
-# Its `stdlib_hash` goes stale whenever the standard library changes, and a
-# local run then reports a pin mismatch and exits 3. That is the mechanism
-# working, not a bug: an epoch pins what was measured, so changing an input
-# means declaring a new epoch. Refresh the value from the mismatch the runner
-# prints. Whether a suite whose workloads never read `std` should pin `std` at
-# all is an open question for RUE-1188.
 
 [[suite]]
 revision = 1
@@ -42,7 +44,6 @@ suite_revision = 1
 target = "x86_64-unknown-linux-gnu"
 args = []
 toolchain_hash = "30f50af0ac7111ffb25d5ef1a423642eaeb2e381931a57583e190a84634ee3fe"
-stdlib_hash = "6b6ecc2e8550c6efb353c8aec4a8db4e2341880549544fc4d26fc5d421aa212f"
 
 [epoch.workload_source_hashes]
 startup = "87869467f94e34b8df41900bda44546b610296077c14fab6defda8939fe22be7"
@@ -82,7 +83,6 @@ suite_revision = 1
 target = "x86_64-unknown-linux-gnu"
 args = []
 toolchain_hash = "calibration-epoch-pins-are-placeholders"
-stdlib_hash = "calibration-epoch-pins-are-placeholders"
 
 [epoch.workload_source_hashes]
 startup = "calibration-epoch-pins-are-placeholders"
@@ -108,7 +108,6 @@ suite_revision = 1
 target = "aarch64-unknown-linux-gnu"
 args = []
 toolchain_hash = "calibration-epoch-pins-are-placeholders"
-stdlib_hash = "calibration-epoch-pins-are-placeholders"
 
 [epoch.workload_source_hashes]
 startup = "calibration-epoch-pins-are-placeholders"
@@ -132,7 +131,6 @@ suite_revision = 1
 target = "aarch64-apple-darwin"
 args = []
 toolchain_hash = "calibration-epoch-pins-are-placeholders"
-stdlib_hash = "calibration-epoch-pins-are-placeholders"
 
 [epoch.workload_source_hashes]
 startup = "calibration-epoch-pins-are-placeholders"
@@ -199,7 +197,6 @@ suite_revision = 1
 target = "x86_64-unknown-linux-gnu"
 args = []
 toolchain_hash = "30f50af0ac7111ffb25d5ef1a423642eaeb2e381931a57583e190a84634ee3fe"
-stdlib_hash = "6b6ecc2e8550c6efb353c8aec4a8db4e2341880549544fc4d26fc5d421aa212f"
 
 [epoch.workload_source_hashes]
 startup = "87869467f94e34b8df41900bda44546b610296077c14fab6defda8939fe22be7"
@@ -230,7 +227,6 @@ suite_revision = 1
 target = "aarch64-unknown-linux-gnu"
 args = []
 toolchain_hash = "30f50af0ac7111ffb25d5ef1a423642eaeb2e381931a57583e190a84634ee3fe"
-stdlib_hash = "6b6ecc2e8550c6efb353c8aec4a8db4e2341880549544fc4d26fc5d421aa212f"
 
 [epoch.workload_source_hashes]
 startup = "87869467f94e34b8df41900bda44546b610296077c14fab6defda8939fe22be7"
@@ -259,7 +255,6 @@ suite_revision = 1
 target = "aarch64-apple-darwin"
 args = []
 toolchain_hash = "30f50af0ac7111ffb25d5ef1a423642eaeb2e381931a57583e190a84634ee3fe"
-stdlib_hash = "6b6ecc2e8550c6efb353c8aec4a8db4e2341880549544fc4d26fc5d421aa212f"
 
 [epoch.workload_source_hashes]
 startup = "87869467f94e34b8df41900bda44546b610296077c14fab6defda8939fe22be7"

--- a/performance/manifest.toml
+++ b/performance/manifest.toml
@@ -13,11 +13,9 @@
 # What is deliberately NOT pinned here is the product being measured: the Rue
 # compiler, `std`, and the first-party toolchain. A std change moves the series
 # exactly as a compiler change does, is annotated on the dashboard, and never
-# invalidates an observation. Pinning `std` was tried and removed in RUE-1256:
-# an `i = i + 1` -> `i += 1` sweep across `std/` rejected every subsequent run
-# for ten days while collection, the data branch, and the site build all stayed
-# green. `toolchain_hash` remains pinned because it names the *Rust* toolchain
-# the compiler is built with — build environment, not product.
+# invalidates an observation. `toolchain_hash` remains pinned because it names
+# the *Rust* toolchain the compiler is built with — build environment, not
+# product. See ADR-0067, "The product boundary".
 #
 # STATUS: the `local` epoch below exists so the runner can be exercised during
 # development. Its sampling counts are placeholders, not calibrated values, and

--- a/website/static/performance.js
+++ b/website/static/performance.js
@@ -427,6 +427,18 @@
             note.changed.join("; ") + ". Comparisons across this point are advisory.";
           list.appendChild(item);
         });
+        // Deliberately not marked advisory. The standard library is part of the
+        // product being measured, so a change here is real movement in what the
+        // series tracks — the note says where it happened, not that the
+        // comparison is untrustworthy.
+        (epoch.stdlib_annotations || []).forEach(function (note) {
+          any = true;
+          var item = document.createElement("li");
+          item.textContent = shortHash(note.commit) +
+            " — standard library changed. Measured, not excluded: std is part of " +
+            "the product, so its cost moves the series like any compiler change.";
+          list.appendChild(item);
+        });
       });
       if (!any) {
         var item = document.createElement("li");


### PR DESCRIPTION
The compiler-performance suite measures the Rue language, `std`, and the first-party toolchain as one product. A `std` change is therefore a change in what is being measured, exactly like a change to compiler internals, and must move the series rather than invalidate it.

Closes RUE-1256.

## The failure this fixes

Epoch 2 pinned `stdlib_hash`. Commit cea5edd — a mechanical `i = i + 1` -> `i += 1` sweep across `std/` — moved the resolved hash, so every run measured after 2026-07-29T03:58Z failed `check_pins` and was dropped at derivation. The published dashboard stopped moving while collection, the `performance-data-v1` branch, and the site build all stayed green; 225 of 305 collected runs never reached a chart.

The triggering edit was measurement-neutral: output binaries were byte-identical on all three platforms, and the timing deltas across it disagreed in sign.

## Changes

- **Validation no longer compares `stdlib_hash`.** Runs still record it, and the dashboard annotates the point where it changed — deliberately *not* marked advisory the way an environment change is, because this is real movement in the product rather than a reason to distrust a comparison.
- **`workload_source_hash` excludes standard-library reads.** This is the non-obvious half. The per-workload closure comes from `--emit deps` and folds in std files a workload reads, so removing the epoch pin alone would have relocated the invalidation rather than removed it — and would have invalidated a std-compiling workload on every std commit.
- **`toolchain_hash` stays pinned**, with a test asserting it. It names the *Rust* toolchain the compiler is built with: build environment, not product.
- **ADR-0067 §3 gains "The product boundary"**, and §4 records versioning a workload rather than refusing its runs as the response to a genuine workload change, following `rustc-perf`'s `-2`/`-3` convention.

## Scope note for review

The scope line "adopt series versioning for genuine workload changes, in place of refusal" is implemented as a documented convention in ADR-0067 §4, not as new machinery. Refusal on a workload's *own* source change is retained deliberately: it is the forcing function that makes versioning happen, and removing it would let a workload silently change meaning under a continuing headline. Versioning is what a maintainer does in response, exactly as in `rustc-perf`, where the rename is a curation act rather than an automated one.

## Verification

`rue-bench derive` against the real `performance-data-v1` branch, before and after:

| | points plotted | rejected |
| --- | --- | --- |
| before | 80 of 305 | 225 |
| after | 305 of 305 | 0 |

Per platform after the change: `aarch64-linux` 102, `x86_64-linux` 102, `aarch64-macos` 101, one standard-library annotation each, and epoch 2's declared baseline `31ff07f6` unchanged — so the ten days back-fill with no epoch change and no baseline reset.

Also run: 104 `rue-perf-schema` tests, 63 `rue-bench` tests, the clippy gate across all 65 first-party targets, `scripts/rue fmt`, and `scripts/validate-adrs.py`.

## Follow-ups, not in this PR

- A collection-staleness alarm: a newest run that does not enter its series must fail loudly, and the status line should carry the newest plotted point's date. Nothing here prevents a *future* silent freeze from a different cause.
- A workload that compiles the standard library, so std cost is measured rather than hashed.

Refs RUE-1188, RUE-1043.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MgbZ4wpBwZKj6GhsT52YAw)_