### PR TITLE
RUE-1258: fail CI when the performance series stalls

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -164,6 +164,12 @@ jobs:
     name: premerge (linux-x64)
     steps:
       - uses: actions/checkout@v6
+        with:
+          # The performance-staleness gate counts trunk commits merged since the
+          # newest plotted measurement, so it needs the measured commit in local
+          # history. The default depth-1 checkout has none of them, and a gate
+          # that cannot see the history fails rather than passing. (RUE-1258)
+          fetch-depth: 0
 
       - name: Install dotslash
         uses: facebook/install-dotslash@v2  # pinned: the moving `latest` branch broke macOS runners (sha256sum flags) on 2026-06-18
@@ -218,6 +224,49 @@ jobs:
         # Keep this named step visible even though the broad suite also reaches
         # the target, so platform responsibility cannot become implicit.
         run: scripts/ci-timed "cross-backend codegen" -- ./buck2 test //crates/rue-codegen:rue-codegen-test
+
+      # RUE-1258. Both performance gates live here because this job already has
+      # a built compiler and runner; a dedicated job would pay for a second
+      # compiler build to answer two cheap questions.
+      #
+      # Neither gate has a bypass. The remedy for either is declaring the next
+      # epoch, which is a small manifest change, and a genuine emergency is
+      # served by bypassing branch protection rather than by an escape hatch
+      # kept here for the purpose — an escape hatch would be a cheaper path
+      # than the emergency it exists for.
+      - name: Check the performance pins still match the tree
+        # Would this change stop runs entering their series? Decidable from this
+        # tree alone: every remaining pin is a content hash of a file in it.
+        run: |
+          set -euo pipefail
+          RUE="$(scripts/rue-bin)"
+          BENCH="$(./buck2 build //crates/rue-bench:rue-bench --show-simple-output 2>/dev/null | tail -1)"
+          "$BENCH" check-pins \
+            --manifest performance/manifest.toml \
+            --repo-root . \
+            --compiler "$RUE"
+
+      - name: Check the performance series is still advancing
+        # Is the series *already* stalled? A repository-wide condition, so this
+        # fails every pull request rather than only the one that caused it: a
+        # stalled series hides regressions instead of reporting them.
+        run: |
+          set -euo pipefail
+          BENCH="$(./buck2 build //crates/rue-bench:rue-bench --show-simple-output 2>/dev/null | tail -1)"
+          git fetch --no-tags origin trunk
+          git fetch --no-tags origin performance-data-v1
+          DATA="$(mktemp -d)"
+          git --work-tree="$DATA" checkout origin/performance-data-v1 -- .
+          git reset --quiet
+          DERIVED="$(mktemp)"
+          "$BENCH" derive \
+            --manifest performance/manifest.toml \
+            --data-root "$DATA" \
+            --out "$DERIVED"
+          scripts/validate-performance-stall.py \
+            --data "$DERIVED" \
+            --repo . \
+            --ref origin/trunk
 
   # Native ARM64 lanes own only behavior that requires their host ABI, linker,
   # runtime, or backend. Target-independent unit/spec coverage remains on

--- a/.github/workflows/performance-collect.yml
+++ b/.github/workflows/performance-collect.yml
@@ -13,6 +13,11 @@
 # summaries are rebuilt from these records at site build time and never written
 # here. Anything derived that landed on the branch would eventually disagree
 # with the records it came from, and the stored copy would be believed.
+#
+# A series that stops advancing is a failure. A run that cannot enter its
+# series fails this workflow rather than warning, because the only thing worse
+# than a broken measurement is a broken measurement that reports success
+# (RUE-1258).
 name: Performance collection
 
 on:
@@ -76,14 +81,18 @@ jobs:
           RUE="$(scripts/rue-bin)"
           BENCH="$(./buck2 build //crates/rue-bench:rue-bench --show-simple-output 2>/dev/null | tail -1)"
 
-          # Exit 3 is "written but not appendable". That is a real finding —
-          # usually a pin that no longer resolves — and the evidence is worth
-          # keeping, so the artifact still uploads and the publish job decides.
+          # Exit 3 is "written but not appendable". The evidence is worth
+          # keeping either way, so the status is recorded here and judged after
+          # the artifact has uploaded.
+          #
+          # No --epoch: the manifest marks its own collection epoch. A number
+          # here would have to be edited alongside the manifest whenever the
+          # next epoch is declared, and the two would eventually disagree about
+          # what is being collected.
           set +e
           "$BENCH" \
             --manifest performance/manifest.toml \
             --platform "${{ matrix.platform }}" \
-            --epoch 2 \
             --compiler "$RUE" \
             --commit "${{ github.sha }}" \
             --repo-root . \
@@ -95,17 +104,37 @@ jobs:
             echo "::error::the runner could not produce a run object"
             exit 1
           fi
-          if [ "$status" -eq 3 ]; then
-            echo "::warning::run is not appendable; it will not be published"
-          fi
           echo "status=$status" > "collected/${{ matrix.platform }}.status"
 
       - name: Upload the run object
+        # Always, so a run that cannot enter its series is still kept as
+        # evidence when the next step fails the job.
+        if: always()
         uses: actions/upload-artifact@v6
         with:
           name: run-${{ matrix.platform }}
           path: collected/
           retention-days: 30
+
+      # RUE-1258. A run that cannot enter its series is the series stopping,
+      # which is the failure this workflow exists to surface rather than a
+      # warning to scroll past. Ten days of a frozen dashboard, hiding a 7x
+      # compile-time regression, went unnoticed behind the warning this
+      # replaces.
+      #
+      # Checked after the upload so the raw record still reaches the publish
+      # job: storing the observation is right even when publishing a point from
+      # it is not.
+      - name: Fail if the run cannot enter its series
+        run: |
+          set -euo pipefail
+          status="$(cut -d= -f2 "collected/${{ matrix.platform }}.status")"
+          if [ "$status" -eq 3 ]; then
+            echo "::error::the run measured at this commit cannot enter its series;" \
+                 "the published series stops advancing here. Declare the next epoch in" \
+                 "performance/manifest.toml, marking it \`collection = true\`."
+            exit 1
+          fi
 
   publish:
     needs: measure

--- a/BUCK
+++ b/BUCK
@@ -711,6 +711,21 @@ rue_sh_test(
     ],
 )
 
+# RUE-1258: the staleness rule, exercised without a repository or a data
+# branch. This gate fails every pull request while the series is stalled and
+# has no bypass, so what "stalled" means — and that an empty dashboard is not
+# stalled — is load-bearing rather than incidental.
+rue_sh_test(
+    name = "performance-stall-validator-tool-tests",
+    test = "scripts/test-validate-performance-stall.py",
+    resources = [
+        "scripts/validate-performance-stall.py",
+    ],
+    env = {
+        "PYTHONDONTWRITEBYTECODE": "1",
+    },
+)
+
 rue_sh_test(
     name = "ci-gate-validator-tool-tests",
     test = "scripts/test-validate-ci-gate.py",

--- a/crates/rue-bench/src/check_pins.rs
+++ b/crates/rue-bench/src/check_pins.rs
@@ -1,0 +1,308 @@
+//! The pre-merge answer to "would this change stall the performance series?".
+//!
+//! Every pin that can still refuse a run is a content hash of a file in the
+//! tree, so the question is decidable from a checkout alone — no measurement,
+//! no data branch, no runner. That is what lets it run on a pull request and
+//! fail the author who introduced the drift, rather than being discovered days
+//! later by whoever notices the chart stopped moving.
+//!
+//! Resolution goes through `pins`, the same module the collector uses. A second
+//! implementation would eventually disagree with the first, and the gate would
+//! then be certifying something other than what collection enforces.
+
+use std::collections::BTreeMap;
+use std::path::PathBuf;
+
+use rue_perf_schema::{Manifest, PlatformEpoch};
+
+use crate::pins;
+
+/// One pinned component whose declared value no longer matches the tree.
+#[derive(Debug, PartialEq, Eq)]
+pub struct PinDrift {
+    pub platform: String,
+    pub epoch: u32,
+    /// The pin's name, matching `ValidationError::PinMismatch`'s spelling.
+    pub field: String,
+    pub declared: String,
+    pub resolved: String,
+    /// What a maintainer would look at to understand the change.
+    pub source: String,
+}
+
+/// Compare one epoch's declared pins against values resolved from the tree.
+///
+/// Pure, so the comparison is testable without a compiler or a checkout. Only
+/// the resolvable pins appear here: `target` and `args` are declarations with
+/// nothing in the tree to disagree with, so they cannot drift.
+pub fn compare(
+    epoch: &PlatformEpoch,
+    resolved_toolchain: &str,
+    resolved_workloads: &BTreeMap<String, String>,
+) -> Vec<PinDrift> {
+    let mut drifts = Vec::new();
+    if epoch.toolchain_hash != resolved_toolchain {
+        drifts.push(PinDrift {
+            platform: epoch.platform.clone(),
+            epoch: epoch.id,
+            field: "toolchain_hash".to_string(),
+            declared: epoch.toolchain_hash.clone(),
+            resolved: resolved_toolchain.to_string(),
+            source: "rust-toolchain.toml".to_string(),
+        });
+    }
+    for (workload, declared) in &epoch.workload_source_hashes {
+        // A workload the resolver could not read is reported as drift rather
+        // than skipped: "we could not tell" must never pass a gate whose whole
+        // job is to answer whether the series will keep running.
+        let resolved = resolved_workloads
+            .get(workload)
+            .map(String::as_str)
+            .unwrap_or("<unresolved>");
+        if resolved != declared {
+            drifts.push(PinDrift {
+                platform: epoch.platform.clone(),
+                epoch: epoch.id,
+                field: format!("workload_source_hashes/{workload}"),
+                declared: declared.clone(),
+                resolved: resolved.to_string(),
+                source: format!("the {workload} workload's own sources"),
+            });
+        }
+    }
+    drifts
+}
+
+/// Render the drift report a failing gate prints.
+///
+/// The message is the remedy. With no bypass available, an author who cannot
+/// tell what to do next is blocked, so this states which epoch to declare and
+/// the values to declare it with rather than only that a hash moved.
+pub fn render(drifts: &[PinDrift]) -> String {
+    let mut out = String::new();
+    let count = drifts.len();
+    let plural = if count == 1 { "pin has" } else { "pins have" };
+    out.push_str(&format!("{count} {plural} drifted from the tree:\n\n"));
+    for drift in drifts {
+        out.push_str(&format!(
+            "  {} epoch {} — {}\n    declared  {}\n    resolved  {}\n    from      {}\n\n",
+            drift.platform, drift.epoch, drift.field, drift.declared, drift.resolved, drift.source
+        ));
+    }
+    for line in [
+        "Collection would refuse every run measured after this change, and the published",
+        "dashboard would stop moving without anything going red.",
+        "",
+        "Two ways forward:",
+        "",
+        "  1. Declare the next epoch for each platform above in performance/manifest.toml,",
+        "     carrying the resolved values shown here. Mark the new epoch `collection = true`",
+        "     and drop that marking from the old one. A new epoch needs no baseline to begin",
+        "     accepting runs; its baseline is declared later, once one has been measured.",
+        "",
+        "  2. Or revert the change to the pinned input.",
+    ] {
+        out.push_str(line);
+        out.push('\n');
+    }
+    out
+}
+
+/// Resolve the tree's pins and compare them against every collection epoch.
+pub fn run() -> Result<(), String> {
+    let mut manifest_path = None;
+    let mut repo_root = None;
+    let mut compiler = None;
+    let mut std_root = None;
+    let mut args = std::env::args().skip(2);
+    while let Some(flag) = args.next() {
+        let mut value = || {
+            args.next()
+                .ok_or_else(|| format!("{flag} requires a value"))
+        };
+        match flag.as_str() {
+            "--manifest" => manifest_path = Some(PathBuf::from(value()?)),
+            "--repo-root" => repo_root = Some(PathBuf::from(value()?)),
+            "--compiler" => compiler = Some(PathBuf::from(value()?)),
+            "--std-root" => std_root = Some(PathBuf::from(value()?)),
+            other => return Err(format!("unrecognized argument {other:?}")),
+        }
+    }
+    let manifest_path = manifest_path.ok_or("check-pins requires --manifest <path>")?;
+    let compiler = compiler.ok_or("check-pins requires --compiler <path>")?;
+    let repo_root = repo_root.unwrap_or_else(|| PathBuf::from("."));
+    let std_root = std_root.or_else(|| {
+        let candidate = repo_root.join("std");
+        candidate.is_dir().then_some(candidate)
+    });
+
+    let text = std::fs::read_to_string(&manifest_path)
+        .map_err(|error| format!("could not read {}: {error}", manifest_path.display()))?;
+    let manifest = Manifest::parse(&text).map_err(|error| error.to_string())?;
+
+    let resolved_toolchain = pins::toolchain_hash(&repo_root).map_err(|error| error.to_string())?;
+
+    let epochs: Vec<&PlatformEpoch> = manifest.collection_epochs().collect();
+    if epochs.is_empty() {
+        // Not a pass. A manifest with nothing marked for collection means the
+        // gate is inspecting nothing, which looks identical to success.
+        return Err(format!(
+            "{} marks no epoch `collection = true`, so there is nothing to check",
+            manifest_path.display()
+        ));
+    }
+
+    let mut resolved_workloads: BTreeMap<String, String> = BTreeMap::new();
+    let mut drifts = Vec::new();
+    for epoch in &epochs {
+        let suite = manifest
+            .suite(epoch.suite_revision)
+            .ok_or_else(|| format!("suite revision {} is not declared", epoch.suite_revision))?;
+        for workload in &suite.workloads {
+            if resolved_workloads.contains_key(&workload.id) {
+                continue;
+            }
+            // Resolution does not depend on the epoch, so one pass over the
+            // suite's workloads serves every platform.
+            let source = repo_root.join(&workload.source);
+            match pins::workload_source_hash(&compiler, &source, std_root.as_deref()) {
+                Ok(hash) => {
+                    resolved_workloads.insert(workload.id.clone(), hash);
+                }
+                Err(error) => {
+                    return Err(format!(
+                        "could not resolve the {} workload's sources: {error}",
+                        workload.id
+                    ));
+                }
+            }
+        }
+        drifts.extend(compare(epoch, &resolved_toolchain, &resolved_workloads));
+    }
+
+    if drifts.is_empty() {
+        eprintln!(
+            "rue-bench: {} collection epoch(s) still match the tree",
+            epochs.len()
+        );
+        return Ok(());
+    }
+    Err(render(&drifts))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const MANIFEST: &str = r#"
+[[suite]]
+revision = 1
+timing_schema_version = 1
+protocol_version = 1
+
+[[suite.workloads]]
+id = "startup"
+source = "performance/workloads/startup/main.rue"
+question = "What does a minimal fresh compilation cost end to end?"
+
+[[epoch]]
+id = 1
+platform = "probe"
+suite_revision = 1
+target = "x86_64-unknown-linux-gnu"
+args = []
+toolchain_hash = "toolchain"
+
+[epoch.workload_source_hashes]
+startup = "startup-hash"
+
+[epoch.environment]
+runner_label = "github-hosted"
+runner_image = "ubuntu-24.04"
+
+[epoch.sampling.startup]
+samples = 3
+batch_size = 1
+
+[epoch.flagging]
+k = 2.0
+window = 3
+"#;
+
+    fn epoch(collection: bool) -> PlatformEpoch {
+        let text = if collection {
+            MANIFEST.replace("id = 1\nplatform", "id = 1\ncollection = true\nplatform")
+        } else {
+            MANIFEST.to_string()
+        };
+        Manifest::parse(&text)
+            .expect("fixture manifest")
+            .epochs()
+            .next()
+            .expect("one epoch")
+            .clone()
+    }
+
+    fn resolved(hash: &str) -> BTreeMap<String, String> {
+        BTreeMap::from([("startup".to_string(), hash.to_string())])
+    }
+
+    #[test]
+    fn a_tree_matching_its_epoch_reports_no_drift() {
+        let drifts = compare(&epoch(false), "toolchain", &resolved("startup-hash"));
+        assert!(drifts.is_empty(), "{drifts:?}");
+    }
+
+    #[test]
+    fn a_changed_rust_toolchain_is_drift() {
+        let drifts = compare(&epoch(false), "upgraded", &resolved("startup-hash"));
+        assert_eq!(drifts.len(), 1);
+        assert_eq!(drifts[0].field, "toolchain_hash");
+        assert_eq!(drifts[0].declared, "toolchain");
+        assert_eq!(drifts[0].resolved, "upgraded");
+    }
+
+    #[test]
+    fn an_edited_workload_source_is_drift() {
+        let drifts = compare(&epoch(false), "toolchain", &resolved("edited"));
+        assert_eq!(drifts.len(), 1);
+        assert_eq!(drifts[0].field, "workload_source_hashes/startup");
+    }
+
+    #[test]
+    fn a_workload_that_could_not_be_resolved_is_drift_rather_than_a_pass() {
+        // "We could not tell" must not pass a gate that exists to answer
+        // whether the series will keep running.
+        let drifts = compare(&epoch(false), "toolchain", &BTreeMap::new());
+        assert_eq!(drifts.len(), 1);
+        assert_eq!(drifts[0].resolved, "<unresolved>");
+    }
+
+    #[test]
+    fn every_drift_is_reported_rather_than_the_first() {
+        let drifts = compare(&epoch(false), "upgraded", &resolved("edited"));
+        assert_eq!(drifts.len(), 2, "{drifts:?}");
+    }
+
+    #[test]
+    fn the_report_names_the_remedy_and_both_values() {
+        // With no bypass available, an author who cannot tell what to do next
+        // is blocked. The message has to carry the fix.
+        let report = render(&compare(
+            &epoch(false),
+            "upgraded",
+            &resolved("startup-hash"),
+        ));
+        assert!(report.contains("toolchain_hash"), "{report}");
+        assert!(report.contains("upgraded"), "{report}");
+        assert!(report.contains("performance/manifest.toml"), "{report}");
+        assert!(report.contains("collection = true"), "{report}");
+        assert!(report.contains("needs no baseline"), "{report}");
+    }
+
+    #[test]
+    fn collection_marking_is_read_from_the_manifest() {
+        assert!(!epoch(false).collection);
+        assert!(epoch(true).collection);
+    }
+}

--- a/crates/rue-bench/src/main.rs
+++ b/crates/rue-bench/src/main.rs
@@ -13,6 +13,7 @@
 //! wrong.
 
 mod calibrate;
+mod check_pins;
 mod derive;
 mod environment;
 mod incremental;
@@ -49,7 +50,7 @@ mod exit {
 struct Options {
     manifest: PathBuf,
     platform: String,
-    epoch: u32,
+    epoch: Option<u32>,
     compiler: PathBuf,
     commit: String,
     repo_root: PathBuf,
@@ -65,6 +66,7 @@ Required:
   --manifest <path>    performance manifest declaring suites and epochs
   --platform <name>    platform whose epoch to run, e.g. x86_64-linux
   --epoch <n>          epoch identifier within that platform
+                       (default: the manifest's collection epoch)
   --compiler <path>    compiler binary under measurement
   --commit <sha>       40-character compiler revision being measured
   --out <path>         where to write the run object
@@ -73,6 +75,11 @@ Subcommands:
   derive --manifest <path> --data-root <dir> --out <path>
                        rebuild the dashboard's view from raw records. Reads the
                        performance-data-v1 checkout; writes derived JSON.
+
+  check-pins --manifest <path> --compiler <path> [--repo-root <path>]
+                       answer whether this tree still matches every collection
+                       epoch. Exits 3 on drift, which is the change stalling
+                       the series; nothing is measured.
 
   calibrate --runs <dir> [--report <path>]
                        analyse repeated runs and recommend sampling counts,
@@ -124,6 +131,15 @@ fn main() -> ExitCode {
             Err(message) => {
                 eprintln!("rue-bench: {message}");
                 ExitCode::from(exit::USAGE)
+            }
+        };
+    }
+    if std::env::args().nth(1).as_deref() == Some("check-pins") {
+        return match check_pins::run() {
+            Ok(()) => ExitCode::from(exit::OK),
+            Err(message) => {
+                eprintln!("rue-bench check-pins: {message}");
+                ExitCode::from(exit::NOT_APPENDABLE)
             }
         };
     }
@@ -299,7 +315,7 @@ fn parse_args() -> Result<Options, String> {
     Ok(Options {
         manifest: manifest.ok_or("--manifest is required")?,
         platform: platform.ok_or("--platform is required")?,
-        epoch: epoch.ok_or("--epoch is required")?,
+        epoch,
         compiler: compiler.ok_or("--compiler is required")?,
         commit: commit.ok_or("--commit is required")?,
         output: output.ok_or("--out is required")?,
@@ -314,14 +330,28 @@ fn run(options: &Options) -> Result<u8, String> {
         .map_err(|error| format!("could not read {}: {error}", options.manifest.display()))?;
     let manifest = Manifest::parse(&text).map_err(|error| error.to_string())?;
 
-    let epoch = manifest
-        .epoch(&options.platform, options.epoch)
-        .ok_or_else(|| {
+    // Without `--epoch`, the manifest's collection epoch for this platform is
+    // measured. Scheduled collection relies on that: a workflow naming an epoch
+    // number would have to be edited alongside the manifest whenever the next
+    // epoch is declared, and the two would eventually disagree about which
+    // epoch is being collected.
+    let epoch = match options.epoch {
+        Some(id) => manifest.epoch(&options.platform, id).ok_or_else(|| {
             format!(
-                "the manifest declares no epoch {} for platform {}",
-                options.epoch, options.platform
+                "the manifest declares no epoch {id} for platform {}",
+                options.platform
             )
-        })?;
+        })?,
+        None => manifest
+            .collection_epoch(&options.platform)
+            .ok_or_else(|| {
+                format!(
+                    "the manifest marks no collection epoch for platform {}; \
+                     pass --epoch to measure a specific one",
+                    options.platform
+                )
+            })?,
+    };
     let suite = manifest
         .suite(epoch.suite_revision)
         .ok_or_else(|| format!("suite revision {} is not declared", epoch.suite_revision))?;

--- a/crates/rue-perf-schema/src/manifest.rs
+++ b/crates/rue-perf-schema/src/manifest.rs
@@ -189,6 +189,17 @@ pub struct PlatformEpoch {
     /// can express them as an index.
     #[serde(default)]
     pub baseline: Option<Baseline>,
+    /// Whether scheduled collection measures this epoch.
+    ///
+    /// The manifest is the single place this is declared, so the collector, the
+    /// CI gate, and a maintainer resolving a stall all read the same answer. A
+    /// workflow that restated it would eventually disagree, and declaring the
+    /// next epoch would mean editing two files under time pressure.
+    ///
+    /// False for the `local` epoch and for calibration epochs, whose pins are
+    /// deliberate placeholders — checking those would fail permanently.
+    #[serde(default)]
+    pub collection: bool,
 }
 
 /// Why a manifest could not be loaded.
@@ -264,6 +275,19 @@ pub enum ManifestError {
         /// The workload whose policy is empty.
         workload: String,
     },
+    /// A platform declares more than one collection epoch.
+    ///
+    /// Collection measures one epoch per platform. Two would make "the epoch
+    /// being collected" ambiguous for the collector and the CI gate alike, and
+    /// they could resolve it differently.
+    DuplicateCollectionEpoch {
+        /// The platform carrying the ambiguity.
+        platform: String,
+        /// The epoch already marked for collection.
+        first: u32,
+        /// The epoch that also claims it.
+        second: u32,
+    },
 }
 
 impl std::fmt::Display for ManifestError {
@@ -311,6 +335,15 @@ impl std::fmt::Display for ManifestError {
                 f,
                 "epoch {epoch} on {platform} samples workload {workload:?} zero times or in \
                  zero-sized batches"
+            ),
+            ManifestError::DuplicateCollectionEpoch {
+                platform,
+                first,
+                second,
+            } => write!(
+                f,
+                "platform {platform} marks epochs {first} and {second} for collection; \
+                 exactly one epoch per platform may be collected"
             ),
         }
     }
@@ -381,7 +414,21 @@ impl Manifest {
 
     fn check_epochs(&self) -> Result<(), ManifestError> {
         let mut seen: Vec<(&str, u32)> = Vec::new();
+        let mut collected: Vec<(&str, u32)> = Vec::new();
         for epoch in &self.epochs {
+            if epoch.collection {
+                if let Some((_, first)) = collected
+                    .iter()
+                    .find(|(platform, _)| *platform == epoch.platform)
+                {
+                    return Err(ManifestError::DuplicateCollectionEpoch {
+                        platform: epoch.platform.clone(),
+                        first: *first,
+                        second: epoch.id,
+                    });
+                }
+                collected.push((epoch.platform.as_str(), epoch.id));
+            }
             let key = (epoch.platform.as_str(), epoch.id);
             if seen.contains(&key) {
                 return Err(ManifestError::DuplicateEpoch {
@@ -441,6 +488,18 @@ impl Manifest {
     /// Every declared epoch, in declaration order.
     pub fn epochs(&self) -> impl Iterator<Item = &PlatformEpoch> {
         self.epochs.iter()
+    }
+
+    /// Every epoch scheduled collection measures, in declaration order.
+    pub fn collection_epochs(&self) -> impl Iterator<Item = &PlatformEpoch> {
+        self.epochs.iter().filter(|epoch| epoch.collection)
+    }
+
+    /// The epoch scheduled collection measures on this platform, if any.
+    pub fn collection_epoch(&self, platform: &str) -> Option<&PlatformEpoch> {
+        self.epochs
+            .iter()
+            .find(|epoch| epoch.collection && epoch.platform == platform)
     }
 }
 

--- a/docs/designs/0067-compiler-performance-measurement.md
+++ b/docs/designs/0067-compiler-performance-measurement.md
@@ -178,7 +178,23 @@ A **platform epoch** pins, per platform:
   (e.g. `github-hosted`, `ubuntu-24.04`);
 - the headline baseline: the first **complete, valid** run at a declared
   trunk revision, whose per-workload medians define ratio 1.0. An attempted
-  or partial run is never a baseline.
+  or partial run is never a baseline;
+- whether scheduled collection measures this epoch. The manifest is the only
+  place this is declared, so the collector, the CI gate, and a maintainer
+  resolving a stall cannot disagree about which epoch is being collected.
+
+**A series may not stall silently.** Refusing an observation protects
+comparability, but a refusal that nobody sees stops the series while every job
+reports success — measurement that has quietly ceased is worse than no
+measurement, because it is still believed. Two gates enforce this. A change
+that moves a pinned input fails its own pull request, decided from that tree
+alone. A series that has stopped advancing — more than five merged trunk
+commits with no new plotted point on some platform — fails *every* pull
+request until it is resolved, because a stall is a repository-wide condition
+rather than a property of whichever change caused it. Neither has a bypass:
+the remedy is declaring the next epoch, which needs no baseline and so is a
+small manifest change, and a genuine emergency is served by bypassing branch
+protection rather than by an escape hatch maintained for the purpose.
 
 **The product boundary.** The Rue language, `std`, and the first-party
 toolchain are a single product, and this suite measures that product. They are

--- a/performance/manifest.toml
+++ b/performance/manifest.toml
@@ -190,6 +190,7 @@ window = 5
 
 [[epoch]]
 id = 2
+collection = true
 platform = "x86_64-linux"
 suite_revision = 1
 target = "x86_64-unknown-linux-gnu"
@@ -220,6 +221,7 @@ run = "4ae3eb4cf1e47277c30ae6c3002b6c84c651e35634424e874e2cca8219b25973"
 
 [[epoch]]
 id = 2
+collection = true
 platform = "aarch64-linux"
 suite_revision = 1
 target = "aarch64-unknown-linux-gnu"
@@ -248,6 +250,7 @@ run = "b0bbb8dd1bbf4b617da6c9c642218ce8435e1f250fea060e5baf307555e8b9ad"
 
 [[epoch]]
 id = 2
+collection = true
 platform = "aarch64-macos"
 suite_revision = 1
 target = "aarch64-apple-darwin"

--- a/scripts/test-validate-performance-stall.py
+++ b/scripts/test-validate-performance-stall.py
@@ -1,0 +1,136 @@
+#!/usr/bin/env python3
+"""Tests for the performance-staleness gate (RUE-1258)."""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+SPEC = importlib.util.spec_from_file_location(
+    "validate_performance_stall",
+    Path(__file__).resolve().parent / "validate-performance-stall.py",
+)
+stall = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(stall)
+
+
+def data(*points: tuple[str, str, str]) -> dict:
+    """Build derived data from (platform, commit, finished_at) triples."""
+    platforms: dict[str, list] = {}
+    for platform, commit, finished_at in points:
+        platforms.setdefault(platform, []).append(
+            {"commit": commit, "finished_at": finished_at}
+        )
+    return {
+        "platforms": [
+            {"platform": name, "epochs": [{"epoch": 2, "points": pts}]}
+            for name, pts in platforms.items()
+        ]
+    }
+
+
+def fixed(count: int):
+    return lambda _commit: count
+
+
+def test_a_current_series_is_not_stalled() -> None:
+    subject = data(("x86_64-linux", "a" * 40, "2026-08-08T00:00:00Z"))
+    assert stall.stalled(subject, fixed(0)) == []
+    assert stall.stalled(subject, fixed(5)) == [], "the threshold itself still passes"
+
+
+def test_a_series_past_the_threshold_is_stalled() -> None:
+    subject = data(("x86_64-linux", "a" * 40, "2026-08-08T00:00:00Z"))
+    behind = stall.stalled(subject, fixed(6))
+    assert len(behind) == 1
+    assert behind[0][0] == "x86_64-linux"
+    assert behind[0][2] == 6
+
+
+def test_one_stalled_platform_is_enough() -> None:
+    # A platform dropping out is a stall even while the others report, because
+    # the series that lost its points is the one hiding a regression.
+    subject = data(
+        ("x86_64-linux", "a" * 40, "2026-08-08T00:00:00Z"),
+        ("aarch64-macos", "b" * 40, "2026-07-29T00:00:00Z"),
+    )
+    counts = {"a" * 40: 0, "b" * 40: 40}
+    behind = stall.stalled(subject, lambda commit: counts[commit])
+    assert [entry[0] for entry in behind] == ["aarch64-macos"]
+
+
+def test_an_empty_dashboard_is_not_a_stall() -> None:
+    # The honest first state of a suite that has not collected yet. Failing
+    # here would block the repository the day collection is introduced.
+    assert stall.newest_plotted({"platforms": []}) == []
+    assert stall.stalled({"platforms": []}, fixed(1000)) == []
+
+
+def test_the_newest_point_wins_regardless_of_ordering() -> None:
+    subject = {
+        "platforms": [
+            {
+                "platform": "x86_64-linux",
+                "epochs": [
+                    {
+                        "epoch": 2,
+                        "points": [
+                            {"commit": "b" * 40, "finished_at": "2026-08-08T05:00:00Z"},
+                            {"commit": "a" * 40, "finished_at": "2026-08-08T01:00:00Z"},
+                        ],
+                    }
+                ],
+            }
+        ]
+    }
+    assert stall.newest_plotted(subject)[0][1] == "b" * 40
+
+
+def test_the_newest_point_spans_epochs() -> None:
+    # A freshly declared epoch carries the newest points while the previous
+    # epoch still holds most of them.
+    subject = {
+        "platforms": [
+            {
+                "platform": "x86_64-linux",
+                "epochs": [
+                    {
+                        "epoch": 2,
+                        "points": [
+                            {"commit": "a" * 40, "finished_at": "2026-08-01T00:00:00Z"}
+                        ],
+                    },
+                    {
+                        "epoch": 3,
+                        "points": [
+                            {"commit": "c" * 40, "finished_at": "2026-08-08T00:00:00Z"}
+                        ],
+                    },
+                ],
+            }
+        ]
+    }
+    assert stall.newest_plotted(subject)[0][1] == "c" * 40
+
+
+def test_the_report_says_it_is_not_the_authors_fault_and_how_to_fix_it() -> None:
+    # There is no bypass, so a pull request author blocked by an unrelated
+    # stall must be able to act without reading the issue.
+    text = stall.report([("x86_64-linux", "a" * 40, 9)], 5)
+    assert "not caused by" in text
+    assert "performance/manifest.toml" in text
+    assert "collection = true" in text
+    assert "needs no baseline" in text
+
+
+def main() -> int:
+    tests = [value for name, value in sorted(globals().items()) if name.startswith("test_")]
+    for test in tests:
+        test()
+    print(f"performance-stall gate valid: {len(tests)} checks")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/validate-ci-gate.py
+++ b/scripts/validate-ci-gate.py
@@ -172,6 +172,15 @@ def validate(
         "./test.sh",
         "Run explicit cross-backend compilation and encoding coverage",
         "//crates/rue-codegen:rue-codegen-test",
+        # RUE-1258: both performance gates. Losing either restores the silence
+        # that let the published series freeze for ten days while every job
+        # stayed green, so their presence is part of the CI contract rather
+        # than a step someone may quietly drop.
+        "check-pins",
+        "scripts/validate-performance-stall.py",
+        # The staleness gate counts trunk commits back to the newest measured
+        # one, which a depth-1 checkout cannot reach.
+        "fetch-depth: 0",
     ):
         if required not in linux:
             errors.append(f"linux-premerge responsibility missing {required!r}")

--- a/scripts/validate-performance-stall.py
+++ b/scripts/validate-performance-stall.py
@@ -1,0 +1,178 @@
+#!/usr/bin/env python3
+"""Fail when the published performance series has stopped advancing (RUE-1258).
+
+A stall is a repository-wide condition, not a property of whichever change
+caused it, so this runs on every pull request rather than only on changes that
+touch performance. There is deliberately no bypass: the remedy is to declare the
+next epoch, which is a small manifest change, and a genuine emergency is served
+by bypassing branch protection rather than by machinery kept here for the
+purpose.
+
+"Stalled" is measured in merged trunk commits rather than wall-clock, because
+commit count degrades gracefully across quiet weekends while a clock does not.
+Collection legitimately lags trunk by minutes, and a single failed collection
+should not block the repository, so the threshold tolerates both.
+
+The series state comes from `rue-bench derive`, never from a status file stored
+alongside the raw records: ADR-0067 keeps everything derived out of the data
+branch, and a stored staleness flag is exactly the kind of value that would
+drift from the records it came from and be believed anyway.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+# Five merged trunk commits with no new plotted point, per platform (RUE-1258).
+# Low enough to catch a real stall within hours at the current merge rate; high
+# enough that one failed collection, or collection simply lagging a merge, never
+# blocks a pull request.
+DEFAULT_MAX_COMMITS = 5
+
+
+class HistoryUnavailable(Exception):
+    """A measured commit is not present in the checkout's history."""
+
+
+def newest_plotted(data: dict) -> list[tuple[str, str, str]]:
+    """Return (platform, commit, finished_at) for each platform's newest point.
+
+    Points are ordered by measurement time within an epoch, and epochs are
+    ordered by identifier, so the newest point is the last point of the last
+    epoch that has any.
+    """
+    newest = []
+    for platform in data.get("platforms", []):
+        latest = None
+        for epoch in platform.get("epochs", []):
+            for point in epoch.get("points", []):
+                if latest is None or point["finished_at"] > latest["finished_at"]:
+                    latest = point
+        if latest is not None:
+            newest.append((platform["platform"], latest["commit"], latest["finished_at"]))
+    return newest
+
+
+def stalled(
+    data: dict,
+    commits_since,
+    max_commits: int = DEFAULT_MAX_COMMITS,
+) -> list[tuple[str, str, int]]:
+    """Return (platform, commit, commits_behind) for every stalled platform.
+
+    `commits_since` maps a commit to the number of trunk commits merged after
+    it. Injected rather than called directly so the rule is testable without a
+    repository.
+    """
+    behind = []
+    for platform, commit, _ in newest_plotted(data):
+        count = commits_since(commit)
+        if count > max_commits:
+            behind.append((platform, commit, count))
+    return behind
+
+
+def git_commits_since(repo: Path, ref: str):
+    """Count trunk commits merged after a given commit."""
+
+    def count(commit: str) -> int:
+        result = subprocess.run(
+            ["git", "-C", str(repo), "rev-list", "--count", f"{commit}..{ref}"],
+            capture_output=True,
+            text=True,
+        )
+        if result.returncode != 0:
+            # Almost always a shallow checkout that does not contain the
+            # measured commit. Distinguished from "not stalled" on purpose: a
+            # gate that cannot see the history must say so rather than pass.
+            raise HistoryUnavailable(
+                f"could not count commits between {commit[:12]} and {ref}: "
+                f"{result.stderr.strip()}"
+            )
+        return int(result.stdout.strip())
+
+    return count
+
+
+def report(behind: list[tuple[str, str, int]], max_commits: int) -> str:
+    lines = [
+        "The published performance series has stopped advancing.",
+        "",
+    ]
+    for platform, commit, count in behind:
+        lines.append(
+            f"  {platform}: newest plotted point is {commit[:12]}, "
+            f"{count} trunk commits behind (threshold {max_commits})"
+        )
+    lines += [
+        "",
+        "This is a repository-wide condition and almost certainly not caused by",
+        "this pull request. Every pull request fails while it lasts, because a",
+        "stalled series hides regressions rather than reporting them.",
+        "",
+        "To resolve it:",
+        "",
+        "  1. Find why runs stopped entering their series. The dashboard's",
+        "     'Collection health' disclosure lists rejected runs and the reason.",
+        "  2. If a pinned input changed, declare the next epoch in",
+        "     performance/manifest.toml and mark it `collection = true`. A new",
+        "     epoch needs no baseline to begin accepting runs.",
+        "  3. If collection itself is broken, fix the collector; the runs are",
+        "     kept on performance-data-v1 either way and will back-fill.",
+    ]
+    return "\n".join(lines)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--data",
+        type=Path,
+        required=True,
+        help="derived performance data, as written by `rue-bench derive`",
+    )
+    parser.add_argument("--repo", type=Path, default=Path("."))
+    parser.add_argument(
+        "--ref",
+        default="origin/trunk",
+        help="the branch a stall is measured against (default: origin/trunk)",
+    )
+    parser.add_argument("--max-commits", type=int, default=DEFAULT_MAX_COMMITS)
+    args = parser.parse_args()
+
+    data = json.loads(args.data.read_text())
+
+    plotted = newest_plotted(data)
+    if not plotted:
+        # An empty dashboard is the honest first state of a suite that has not
+        # collected yet, not a stall. Failing here would block the repository
+        # on the day collection is introduced.
+        print("no plotted points yet; nothing to stall")
+        return 0
+
+    try:
+        behind = stalled(data, git_commits_since(args.repo, args.ref), args.max_commits)
+    except HistoryUnavailable as error:
+        print(f"error: {error}", file=sys.stderr)
+        print(
+            "The measured commit must be present in the checkout. Fetch with "
+            "enough depth to reach it.",
+            file=sys.stderr,
+        )
+        return 2
+
+    if behind:
+        print(report(behind, args.max_commits), file=sys.stderr)
+        return 1
+
+    for platform, commit, finished_at in plotted:
+        print(f"{platform}: current at {commit[:12]} ({finished_at})")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/website/static/performance.js
+++ b/website/static/performance.js
@@ -147,16 +147,35 @@
         return latest.point.workloads[name].flagged === true;
       });
       parts.push(flagged.length ? "Flagged: " + flagged.join(", ") + "." : "Nothing flagged.");
+      // When the newest point is stated, a page that stopped advancing reads as
+      // stopped. Without it a ten-day-old chart is indistinguishable from a
+      // current one, which is exactly how a frozen series went unnoticed.
+      parts.push("Newest measurement: " + latest.point.finished_at + ".");
       status.textContent = parts.join(" ");
 
-      if (latest.point.complete) {
-        health.hidden = true;
-      } else {
+      // Two different unhealthy states, and the second used to be invisible: a
+      // rejected run never reaches a chart, so a series can stop advancing
+      // while every point already drawn stays perfectly healthy.
+      var notices = [];
+      if (!latest.point.complete) {
+        notices.push(
+          "the latest run was incomplete. Did not complete validly: " +
+            latest.point.missing.join(", ") +
+            ". No headline point is published from a partial run."
+        );
+      }
+      if (data.rejected && data.rejected.length) {
+        notices.push(
+          data.rejected.length +
+            " collected run(s) could not enter a series and are not drawn here, so this " +
+            "chart may be behind the compiler. See Collection health below."
+        );
+      }
+      if (notices.length) {
         health.hidden = false;
-        health.textContent =
-          "Collection health: the latest run was incomplete. Did not complete validly: " +
-          latest.point.missing.join(", ") +
-          ". No headline point is published from a partial run.";
+        health.textContent = "Collection health: " + notices.join(" ");
+      } else {
+        health.hidden = true;
       }
     }
 


### PR DESCRIPTION
Refusing an observation protects comparability, but a refusal nobody sees stops the series while every job reports success. Measurement that has quietly ceased is worse than no measurement, because it is still believed — the last stall ran ten days and hid RUE-1257, a 3.7x–7.6x compile-time regression that the flagging rule had detected correctly on 50 of 102 points.

Closes RUE-1258.

## Two gates

Both live in `linux-premerge`, which already has a built compiler and runner; a dedicated job would pay for a second compiler build to answer two cheap questions.

**"Would this change stall the series?"** — `rue-bench check-pins`, decided from the pull request's tree alone. Every pin that can still refuse a run after RUE-1256 is a content hash of a file in that tree, so no measurement and no data branch are needed. Resolution goes through `pins`, the same module the collector uses, so the gate and collection cannot drift apart on what a pin means.

**"Is the series already stalled?"** — `scripts/validate-performance-stall.py`, defined as more than five merged trunk commits with no new plotted point on some platform. This fails *every* pull request, not only one that touches performance, because a stall is a repository-wide condition rather than a property of whichever change caused it. Series state is derived from the raw records rather than read from a stored flag, since ADR-0067 keeps everything derived off the data branch and a stored staleness flag is exactly the kind of value that drifts from its records and gets believed anyway.

## No escape hatch

Deliberate, and the reasoning is recorded on the issue and in ADR-0067. The remedy for either gate is declaring the next epoch, which needs no baseline (`PlatformEpoch.baseline` is `Option`, documented as "an epoch may exist and collect observations before it can express them as an index") and is therefore a small manifest change. Both failure messages print that remedy rather than only reporting that a hash moved.

A genuine emergency is served by bypassing branch protection, which is already maintainer-only, visible on the pull request, and uncomfortable enough not to become routine. A bypass label would have been a *cheaper* path than the emergency it existed for.

## Supporting changes

- **An epoch declares whether collection measures it** (`collection = true`). The collector drops its hardcoded `--epoch 2` and follows the manifest, so declaring the next epoch under time pressure is one file rather than two that can disagree. Parsing rejects two collection epochs on one platform.
- **A run that cannot enter its series fails the collection workflow** instead of warning — after its artifact uploads, so the evidence survives and the raw record still reaches the data branch. The old `::warning::` also claimed the run "will not be published" when it was published and then dropped at derivation.
- **The dashboard states its newest measurement's date**, and reports rejected runs in the health line rather than only behind a collapsed disclosure. A frozen page was previously indistinguishable from a current one.
- The CI contract (`validate-ci-gate.py`) now proves both gates and the `fetch-depth: 0` they need remain in `linux-premerge`, so they cannot be quietly dropped.

## Verification

Both gates were exercised against real data, in both directions.

`check-pins` on the current tree, and with `rust-toolchain.toml` edited:

```
rue-bench: 3 collection epoch(s) still match the tree            exit 0

rue-bench check-pins: 3 pins have drifted from the tree:
  x86_64-linux epoch 2 — toolchain_hash
    declared  30f50af0ac71...
    resolved  1b35b7bda8fd...
    from      rust-toolchain.toml                                exit 3
```

The staleness gate against the live `performance-data-v1`, then against the same data rewound to the point the series was actually frozen at:

```
aarch64-linux: current at 80c1944c388d (2026-08-08T00:13:26Z)    exit 0

The published performance series has stopped advancing.
  aarch64-linux: newest plotted point is 5859c3b82d15,
                 95 trunk commits behind (threshold 5)           exit 1
```

That second case is the real July stall replayed through the gate.

Also run: 104 `rue-perf-schema` tests, 70 `rue-bench` tests (7 new for `check-pins`), 7 new staleness-rule tests, the CI-gate validator and its 14 tool tests, the clippy gate across all 65 first-party targets, `scripts/rue fmt`, `scripts/validate-adrs.py`, and `scripts/validate-shell-pipefail-pipelines.py`.

## For review

The threshold of five commits is a judgement call — low enough to catch a real stall within hours at the current merge rate, high enough that one failed collection or collection merely lagging a merge never blocks the repository. It is a one-line change in `scripts/validate-performance-stall.py` if it proves wrong in either direction.

The design accepts that it has no graceful degradation: if a stall happens and the remedy is somehow not the small change argued above, the fallback is an admin merging pull requests by hand. That is the accepted cost of making a stall impossible to absorb.

Refs RUE-1256, RUE-1257.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MgbZ4wpBwZKj6GhsT52YAw)_