### PR TITLE
RUE-1257: identify the runtime archive without digesting it per compile

### DIFF
--- a/crates/rue-compiler/src/program_image_plan.rs
+++ b/crates/rue-compiler/src/program_image_plan.rs
@@ -9,7 +9,7 @@ use std::{
     collections::{BTreeMap, BTreeSet},
     sync::OnceLock,
 };
-use tracing::info;
+use tracing::{info, info_span};
 
 #[cfg(test)]
 use crate::FunctionWithCfg;
@@ -65,7 +65,7 @@ pub(crate) struct ProgramImagePlan {
     pub(crate) entry_point: &'static str,
     pub(crate) runtime_abi_version: u32,
     pub(crate) runtime_abi_symbol: &'static str,
-    pub(crate) runtime_archive_digest: ContentDigest,
+    pub(crate) runtime_archive: RuntimeArchiveIdentity,
     pub(crate) required_runtime_symbols: Vec<String>,
 }
 
@@ -150,7 +150,7 @@ impl ProgramImagePlan {
             || self.entry_point != previous.entry_point
             || self.runtime_abi_version != previous.runtime_abi_version
             || self.runtime_abi_symbol != previous.runtime_abi_symbol
-            || self.runtime_archive_digest != previous.runtime_archive_digest
+            || self.runtime_archive != previous.runtime_archive
             || self.required_runtime_symbols != previous.required_runtime_symbols;
         Ok(delta)
     }
@@ -173,6 +173,10 @@ impl ProgramImage {
         exports: Vec<RootedExportThunk>,
         options: &CompileOptions,
     ) -> MultiErrorResult<Self> {
+        // Aggregating link inputs is compiler-root work like any other pass. It
+        // stayed outside every phase span until RUE-1257, so ADR-0067's
+        // taxonomy could only report its cost as `unattributed`.
+        let _span = info_span!("program_image_plan", phase = "object_generation").entered();
         validate_rooted_program_image_inputs(&objects, &exports)?;
         let export_thunk_objects: Vec<Vec<u8>> = exports
             .iter()
@@ -260,6 +264,8 @@ impl ProgramImage {
     /// Object serialization happened in the registered query graph; this
     /// adapter only materializes the linker's existing owned byte-vector API.
     pub(crate) fn fresh_objects(&self, options: &CompileOptions) -> MultiErrorResult<Vec<Vec<u8>>> {
+        let _span =
+            info_span!("fresh_object_materialization", phase = "object_generation").entered();
         if self.plan.target != options.target {
             return Err(CompileErrors::from(CompileError::without_span(
                 ErrorKind::InvalidCompilerInput(
@@ -428,7 +434,7 @@ impl ProgramImagePlan {
             entry_point,
             runtime_abi_version: rue_runtime_abi::RUNTIME_ABI_VERSION,
             runtime_abi_symbol: rue_runtime_abi::RUNTIME_ABI_VERSION_SYMBOL,
-            runtime_archive_digest: runtime_archive_digest(options.target),
+            runtime_archive: RuntimeArchiveIdentity::for_target(options.target),
             required_runtime_symbols: required_runtime_symbols.into_iter().collect(),
         };
         validate_program_image_plan(&plan)?;
@@ -612,18 +618,53 @@ static X86_64_LINUX_RUNTIME_DIGEST: OnceLock<ContentDigest> = OnceLock::new();
 static AARCH64_LINUX_RUNTIME_DIGEST: OnceLock<ContentDigest> = OnceLock::new();
 static AARCH64_MACOS_RUNTIME_DIGEST: OnceLock<ContentDigest> = OnceLock::new();
 
-fn runtime_archive_digest(target: Target) -> ContentDigest {
-    let cache = match target {
-        Target::X86_64Linux => &X86_64_LINUX_RUNTIME_DIGEST,
-        Target::Aarch64Linux => &AARCH64_LINUX_RUNTIME_DIGEST,
-        Target::Aarch64Macos => &AARCH64_MACOS_RUNTIME_DIGEST,
-    };
-    *cache.get_or_init(|| {
-        bytes_digest(
-            b"rue.program-image.runtime-archive\0v1\0",
-            linking::runtime_for_target(target),
-        )
-    })
+/// Counts every request for archive content, cached or not, so a test can
+/// assert that an ordinary compilation never reaches for the archive bytes.
+#[cfg(test)]
+static RUNTIME_ARCHIVE_CONTENT_REQUESTS: std::sync::atomic::AtomicUsize =
+    std::sync::atomic::AtomicUsize::new(0);
+
+/// Which runtime archive a plan links against.
+///
+/// The archive is an `include_bytes!` constant of the compiler binary, so
+/// within one process the target names it exactly: two plans built by the same
+/// compiler link the same runtime whenever they agree on the target, and
+/// comparing them needs no bytes at all. [`Self::content_digest`] is the
+/// stronger identity a plan needs only once it outlives the process that built
+/// it, and is therefore materialized on demand.
+///
+/// The distinction is worth the type. Digesting several megabytes of archive
+/// costs multiples of an entire fresh compilation of a small program, so
+/// computing it during plan construction made every fresh link pay for a fact
+/// no fresh link reads (RUE-1257).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct RuntimeArchiveIdentity {
+    target: Target,
+}
+
+impl RuntimeArchiveIdentity {
+    pub(crate) fn for_target(target: Target) -> Self {
+        Self { target }
+    }
+
+    /// SHA-256 over the exact embedded archive bytes, memoized for the process
+    /// because those bytes cannot change within one.
+    #[allow(dead_code)] // the durable identity a later incremental linker persists
+    pub(crate) fn content_digest(self) -> ContentDigest {
+        #[cfg(test)]
+        RUNTIME_ARCHIVE_CONTENT_REQUESTS.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        let cache = match self.target {
+            Target::X86_64Linux => &X86_64_LINUX_RUNTIME_DIGEST,
+            Target::Aarch64Linux => &AARCH64_LINUX_RUNTIME_DIGEST,
+            Target::Aarch64Macos => &AARCH64_MACOS_RUNTIME_DIGEST,
+        };
+        *cache.get_or_init(|| {
+            bytes_digest(
+                b"rue.program-image.runtime-archive\0v1\0",
+                linking::runtime_for_target(self.target),
+            )
+        })
+    }
 }
 
 /// SHA-256 writer with a fixed domain and explicit length framing. This avoids
@@ -735,7 +776,7 @@ mod tests {
             entry_point: "_start",
             runtime_abi_version: 1,
             runtime_abi_symbol: "__rue_runtime_abi_v1",
-            runtime_archive_digest: [1; 32],
+            runtime_archive: RuntimeArchiveIdentity::for_target(Target::X86_64Linux),
             required_runtime_symbols: vec!["_start".to_owned()],
         }
     }
@@ -799,6 +840,51 @@ mod tests {
         assert_ne!(
             bytes_digest(b"test-domain", b"runtime"),
             bytes_digest(b"test-domain", b"Runtime")
+        );
+    }
+
+    /// The runtime archive is a build-time constant of the compiler binary, so
+    /// a plan identifies it by target and digests it only when something asks
+    /// for the durable identity. Digesting it during plan construction made a
+    /// fresh compilation of `fn main() -> i32 { return 0; }` several times
+    /// slower than the whole rest of the pipeline (RUE-1257).
+    ///
+    /// This is the only test that materializes the digest, so the counter it
+    /// reads is untouched by anything but production plan construction.
+    #[test]
+    fn a_fresh_program_image_never_digests_the_runtime_archive() {
+        use std::sync::atomic::Ordering;
+
+        let source = "fn callee() -> i32 { 7 } fn main() -> i32 { callee() }";
+        let snapshot = crate::SourceSnapshot::single("main.rue", source).unwrap();
+        let options = CompileOptions {
+            target: Target::X86_64Linux,
+            ..CompileOptions::default()
+        };
+        let mut session = crate::CompilerSession::new();
+        crate::publish_test_snapshot(&mut session, &snapshot).unwrap();
+        let rooted = session
+            .rooted_codegen(&options, rue_codegen::BackendArtifactRequest::default())
+            .unwrap();
+        let image = ProgramImage::from_rooted(rooted.objects, rooted.exports, &options).unwrap();
+        image.fresh_objects(&options).unwrap();
+        assert_eq!(
+            RUNTIME_ARCHIVE_CONTENT_REQUESTS.load(Ordering::Relaxed),
+            0,
+            "building and materializing a program image must not read the runtime archive"
+        );
+
+        // The durable identity is still exact when a caller does want it.
+        let identity = image.plan.runtime_archive;
+        assert_eq!(
+            identity,
+            RuntimeArchiveIdentity::for_target(Target::X86_64Linux)
+        );
+        assert_eq!(identity.content_digest(), identity.content_digest());
+        assert_ne!(
+            identity.content_digest(),
+            RuntimeArchiveIdentity::for_target(Target::Aarch64Linux).content_digest(),
+            "each target embeds its own archive"
         );
     }
 


### PR DESCRIPTION
Fixes RUE-1257.

## What regressed

`ProgramImagePlan::finish()` computed `runtime_archive_digest(options.target)` on every fresh compilation. That is a SHA-256 over the 4.2–4.5 MiB runtime staticlib the compiler embeds with `include_bytes!` per target.

Callgrind on the startup probe (`fn main() -> i32 { return 0; }`):

| | instructions |
| -- | -- |
| whole compilation | 268,678,381 |
| `runtime_archive_digest` | 229,190,786 (85%) |

Two things make it worse on the collection platforms than on a developer x86-64 box:

* The per-process `OnceLock` never helps the probe, which measures one fresh compilation per process.
* `sha2`'s accelerated backends are not uniformly available. x86-64 picks up SHA-NI through runtime detection, but the aarch64 backend is behind the crate's `asm` feature, which the vendored target does not enable — so both aarch64 platforms always run `sha256::soft::compress`. That matches aarch64 regressing 7.50x/7.59x against x86-64's 3.74x.

The digest is also a pure function of `target`, which the plan already carries: the archive is a build-time constant of the compiler binary and cannot change within a process. So every fresh link paid to recompute a constant, for a field whose only consumer is `delta_from` — still `#[allow(dead_code)]` pending the stateful linker.

## What changed

`RuntimeArchiveIdentity` identifies the archive by target and exposes the SHA-256 as `content_digest()`, materialized on demand and still memoized, domain-separated, and length-framed. The durable content identity remains available for the later incremental linker, which is the consumer that needs it; nothing on the compile path computes it. Plan equality and `link_context_changed` keep their meaning — two plans from one compiler link the same runtime exactly when they agree on the target.

Plan construction and object materialization also ran outside every instrumented phase, which is the issue's second complaint: ADR-0067 could only bill their cost to `unattributed`, leaving a ~240 ms band with no name. `program_image_plan` and `fresh_object_materialization` now enter spans under the already-published `object_generation` phase. Reusing an existing phase name makes this an attribution fix, not a timing-schema change, so no new suite revision is required.

## Measured

Startup probe, this repository's release configuration:

| | before | after |
| -- | -- | -- |
| instructions, soft-SHA path | 268.7 M | 39.5 M (6.8x fewer) |
| wall clock, x86-64 with SHA-NI (n=60, interleaved) | 16.44 ms | 13.27 ms (−19.3%) |
| `compiler_root_ns` | 22.35 ms | 11.98 ms |
| `unattributed_ns` | 7.16 ms (32%) | 0.44 ms (3.7%) |

The 6.8x instruction reduction on the soft-SHA path lines up with the 6.99x step the report measures on `aarch64-linux` at `b4f7356b`. The issue notes that commit is the first *measured* one rather than a bisected culprit; this is direct causal evidence, since the code removed here is the code that commit added, and it accounts for 85% of the probe.

## Testing

* Premerge tier: 79 targets pass, 0 fail, 0 timeout, 0 build failures.
* `scripts/rue quick` — 810 compiler unit tests across 31 targets, green.
* All 15 `program_image_plan` tests, including a new guard asserting that building and materializing a program image never reads the archive bytes, so the cost cannot return unnoticed.
* Clippy clean on `rue-compiler` and `rue-compiler-test`.
* Emitted binaries are byte-identical before and after on `x86-64-linux`, `aarch64-linux`, and `aarch64-macos`, and for a program with a C-ABI export.

## Not addressed

* The published series cannot be re-derived here — `rue-bench derive` needs a `performance-data-v1` root this environment does not have. Recovery should be confirmed from the next collection run.
* With the digest gone, `linking` is 73% of compiler root on the probe, nearly all of it `Link_archive_resolve` re-parsing the same archive every compile. The report shows that band flat across the step, so it is pre-existing rather than part of this regression, but it is the obvious next target.
* The `sha2` aarch64 `asm` backend being compiled out affects every other digest the compiler computes. Changing it is a vendoring change and out of scope here.
