### PR TITLE
ADR-0069: CI work scheduling for a compiler monorepo

### DIFF
--- a/docs/designs/0069-ci-work-scheduling.md
+++ b/docs/designs/0069-ci-work-scheduling.md
@@ -1,0 +1,352 @@
+---
+id: 0069
+title: "CI work scheduling for a compiler monorepo"
+status: proposal
+tags: [process, ci, testing, build, performance]
+feature-flag: null
+created: 2026-08-09
+accepted:
+implemented:
+spec-sections: []
+superseded-by:
+relates: ["RUE-1250", "RUE-1262", "RUE-1164", "RUE-1130", "RUE-1131", "RUE-1222", "RUE-1116", "RUE-1118", "RUE-1119", "RUE-1157", "RUE-1163"]
+---
+
+# ADR-0069: CI work scheduling for a compiler monorepo
+
+## Status
+
+Proposal
+
+## Summary
+
+Rue's CI has three good mechanisms for not doing work — a change determinator
+(RUE-1119), cacheable corpus actions (RUE-1118), and corpus sharding
+(RUE-1116/RUE-1158) — each applied to a different hand-picked subset of the work
+and composed in the wrong order. Measuring nine runs shows the consequence: the
+critical path is a single test function executed four times, and no topology
+change can move it.
+
+This ADR adopts a uniform model. Every unit of CI work is a Buck target carrying
+its own tier and platform scope; no workflow file names a target; every lane is a
+generated selection over the live graph. It also names the property that makes a
+compiler monorepo different from the systems these mechanisms were designed for:
+**the compiler is a universal dependency, so change-based selection and
+input-keyed caching share a blind spot covering the dominant change class.**
+Eliminating duplicated work — which helps in *every* regime — therefore ranks
+above both, and scheduling ranks above neither.
+
+## Context
+
+### What was measured
+
+Nine `CI` runs (2026-08-07/08, four `pull_request`, five `merge_group`), plus
+`buck2` run directly against the live graph. Full evidence is in
+`docs/notes/rue-1250-shard-topology-analysis.md`,
+`rue-1250-premerge-critical-path.md`, and `rue-1250-ci-architecture.md`.
+
+The finding that motivates this ADR is concentration, not imbalance:
+
+- `premerge (linux-x64)` was the longest job in **9 of 9** runs, 279–576s ahead
+  of the slowest CLI shard.
+- That lane runs 80 targets. Two are **81.4%** of it — and
+  `//crates/rue-compiler:scaling-matrix-test` turns out to be a strict superset
+  of `//crates/rue-compiler:rue-compiler-test`: 816 tests versus 813, all 813
+  shared. The lane runs those 813 twice to gain three.
+- Both native lanes are one step, and that step is **99.1%**
+  `rue-compiler-test`, contradicting `docs/process/ci.md:46` ("Linux ARM64 and
+  macOS ARM64 deliberately do not repeat the broad unit suite") while
+  `scripts/validate-ci-gate.py:204` pins the repetition in place.
+- Inside that target, **one test function is 181.7s** against a 5.7s runner-up.
+  It is compiled into two targets and runs on three platforms: **four executions
+  per CI run**, together 56–59% of the critical path (RUE-1262).
+
+Sharding cannot address this. Partitioning those 813 tests four ways gives
+3.4s / 6.8s / 7.2s / **227.0s**, and cost-balancing cannot do better when one
+item weighs 181.7s against ~44s of everything else. LPT's makespan is bounded
+below by the largest indivisible item, and the lane's measured parallel wall
+(268s) is already within 19% of that bound.
+
+### The property that makes this repository different
+
+The determinator and the action cache both key on change. In a compiler
+monorepo, that has a low ceiling, because the compiler is an input to nearly
+every downstream action. A change to any compiler crate changes the compiler
+binary's digest, which invalidates every Rue-program compile action, hence every
+corpus.
+
+This is measured from both directions. RUE-1130 records **zero deselections
+across 9 runs × 18 corpus jobs** — every job logged `SELECTIVE` and then selected
+everything, "because compiler-core changes legitimately reach the whole
+reverse-dependency closure." Independently, classifying the nine runs sampled
+here by their premerge build step:
+
+| regime | runs | compiler build | corpus |
+| --- | --- | --- | --- |
+| warm | 5 of 9 | ≤22s | cached |
+| corpus-cold | 1 of 9 | 19s | 900–1100s |
+| compiler-cold | 3 of 9 | 286–317s | 900–1100s |
+
+Determination and caching make the *warm* regime nearly free, which is real and
+worth keeping. Neither helps the compiler-cold regime at all, and that regime is
+a third of runs and most of the interesting ones.
+
+Two consequences follow, and they are the reason this ADR exists rather than a
+narrower one:
+
+1. **Sharding is load-bearing and is not made obsolete by caching.** RUE-1250
+   asked whether caching had retired the CLI shards. It has not: in the four runs
+   where the corpus executed, a single unsharded corpus projects to 900–1100s,
+   against an unshardable native ARM64 lane at 341–407s. Four shards stay under
+   that floor in 4 of 4 runs; two breach it in 4 of 4. **Keep four.**
+2. **Not doing duplicated work outranks both other mechanisms**, because it is
+   the only one that pays in every regime.
+
+### Why the current composition is inverted
+
+| mechanism | eliminates | applied to | not applied to |
+| --- | --- | --- | --- |
+| determinator (RUE-1119) | work the diff cannot affect | `platform-corpus`, `pull_request` only | premerge, both native lanes, valgrind, asan, release, reproducibility |
+| corpus action cache (RUE-1118) | work already done for this tree | 11 corpora | 75 of 80 premerge targets, every native target |
+| sharding (RUE-1116/1158) | wall time of work that must run | 1 corpus, fixed at 4 | everything else |
+
+Sharding is permanent and outermost, caching covers a middle slice, and
+determination is innermost and narrowest — the reverse of their cost order.
+
+The structural cause is that "unit of work" is not one thing. There are three:
+Buck actions (all mechanisms apply), Buck test targets (only determination
+applies, since OSS buck2 as configured has no test-result cache), and
+**hand-written target lists inside YAML steps** (nothing applies). Every defect
+found lives in the last two categories. The native lanes' eight-target shell
+invocation is the clearest case: invisible to the determinator, uncacheable,
+unshardable — and where a 181.7s test hid on two platforms for weeks.
+
+## Decision
+
+### 1. One unit of work, and no workflow file names a target
+
+Every piece of pre-merge work is a Buck target carrying its execution tier
+(RUE-1157) *and* its platform scope as attributes. Lanes are generated
+selections over the live graph. `.github/workflows/*.yml` contains no target
+label.
+
+The repository already proves this works for corpus cases: `only_on` plus
+`RUE_PLATFORM_CASE_SELECTION=native` makes platform-scoped cases self-enrolling,
+and `docs/process/ci.md` correctly cites that as the reason new cases need no
+workflow edit. This decision extends the same idea to unit targets, so the native
+lanes become a label selection rather than a list `validate-ci-gate.py` must pin.
+
+It also fixes a granularity error the measurement exposed: **platform scope is
+declared per target but is a property of individual tests.** `rue-compiler-test`
+contains ~27 host-conditional sites and 813 tests; the native lanes want the
+former and pay for the latter. Host-conditional compiler tests move into their
+own target, following the precedent already set in the same crate by
+`rue-compiler-public-api-test`, `rue-compiler-differential-oracle-test`, and
+`rue-compiler-payload-schema-test`.
+
+### 2. Nothing executes twice
+
+No unit of work executes more than once per platform per run without a declared
+reason.
+
+This is stated first among the behavioural rules because it is the only lever
+that pays in every regime. Three violations exist today and **no current gate can
+see any of them**, because every gate compares *target lists* while these are
+overlaps in *test contents*:
+
+- `scaling-matrix-test` re-runs 813 of `rue-compiler-test`'s tests, in the same
+  lane, to add three;
+- `rue-compiler-test` runs on linux-x64, linux-arm64, and macOS, against a
+  documented contract that says the native lanes do not repeat the broad unit
+  suite;
+- `release-smoke` runs in the premerge lane under the debug platform and again in
+  the `release` job under the release platform — defensible, but undecided.
+
+A repository gate collects each lane's test identities (`--list` on the test
+binaries — cheap, exact, and how the superset above was found) and fails on any
+test scheduled twice without an explicit allowance. That gate is what converts
+"we fixed this instance" into "this class cannot recur."
+
+### 3. Determinate every lane, and say which regime the run is in
+
+Extend `affected-targets` from gating one job to planning every lane, and have it
+emit the lane plan the matrix consumes
+(`strategy.matrix: ${{ fromJSON(...) }}`). `merge_group` keeps forcing the
+authoritative full run. The existing fail-open contract and
+`scripts/test-affected-targets.sh` pinning are retained unchanged.
+
+The coverage gate then becomes stronger *and* simpler than
+`validate-cli-shard-coverage.py`: **the union of planned lanes equals the tier
+selection from the live Buck graph**, failing closed on any target that is in the
+graph and in no lane. That subsumes the hand-written-matrix drift problem instead
+of policing it.
+
+Crucially, the planner **names the regime and the binding constraint on every
+run**. RUE-1130 had to discover the zero-deselection result empirically, and
+RUE-1250 asked about CLI shards while premerge was the actual critical path —
+both because nothing in CI reports what it is bound by. A determinator that
+reports "compiler-cold: selection saved nothing, the critical path is X" is worth
+more than one that silently selects everything.
+
+### 4. Cache with real input keys, not success stamps
+
+RUE-1118's `cached_corpus_suite` proved the mechanism and cut merge-group runs
+from ~12.5 to ~5 minutes. It is not the destination. RUE-1164 already states the
+constraint this ADR adopts: **do not use an aggregate success-stamp action as the
+destination — every source, import, compiler flag, target architecture, runtime
+input, and expected output must contribute to the action key.** The stamp is
+evidence, not design authority.
+
+Two things make extending caching safe rather than hopeful:
+
+- **Remote execution is the undeclared-input detector.** RUE-1222's item 3 warns
+  that an undeclared action input becomes a silent false pass rather than an
+  untracked re-run. RE materializes only declared inputs, so an undeclared read
+  fails with file-not-found instead. RUE-320 landed on 2026-07-18 ("full remote
+  execution now default-capable"); `AGENTS.md:182` and the `./buck2` wrapper
+  still describe it as open and should be reconciled with
+  `docs/process/build-cache.md`, which already describes it as supported.
+- **Check buck2's native path before hand-rolling more.** buck2 carries
+  `supports_test_execution_caching` on `ExternalRunnerTestInfo` and
+  `disable_test_execution_caching` in the executor protocol. Rue configures
+  `noop_test_toolchain` and `noop_remote_test_execution_toolchain`, so nothing
+  honors them — `corpus.bzl`'s "OSS buck2 ships no test-result cache" is true *as
+  configured*, not in general.
+
+### 5. Pack to a measured floor, and alarm on indivisible items
+
+The packer's objective is **minimize runners subject to the slowest lane staying
+under the floor** — bin-packing under a capacity constraint, not makespan across
+fixed bins. Only that objective can ever conclude "use fewer." The floor is
+measured (the slowest lane that cannot be split), never chosen.
+
+The load-bearing part is not the algorithm. **When the largest indivisible item
+exceeds the floor, the planner fails loudly, names the item, and refuses to
+express the problem as a lane count.** A packer reasoning about totals would have
+requested eight runners for the pre-fix premerge lane — where one item was
+225.6s — and reported success having changed nothing.
+
+Its three remedies are all ones this repository already has:
+
+| symptom | remedy | precedent |
+| --- | --- | --- |
+| one item dominates a lane | split it | CLI intra-target shards (RUE-1116) |
+| the item re-executes every run | cache it | cacheable actions (RUE-1118, RUE-1164) |
+| the item is heavier than pre-merge warrants | re-tier it | scaling matrix 100/1k vs 10k; large-example canary vs slow |
+
+Choosing among them is a human call. Noticing is not.
+
+The shard count follows from the same rule and, applied today, confirms the
+existing constant rather than contradicting it: `ceil(total ÷ floor)` gives 3,
+but measured shard skew is 8–25% and 366s × 1.25 breaches the 407s floor, so with
+a skew allowance it lands on **4**. The count stays; what changes is that the
+reason is written down and recomputed.
+
+### 6. Balance guards measure outcomes
+
+`CliShardPlan::validate_skew` rejects an estimated slowest shard >25% above the
+mean. LPT over the checked-in weights produces **0.00%** estimated skew at every
+count from 1 to 12, and the LPT bound proves the worst possible estimate at N=4
+is 3.90% — the guard cannot fail on real data. Observed skew reached **24.9%**.
+
+Guards compare observed lane wall time against plan, and stale weights surface as
+skew. A guard that validates the model against itself is not a guard.
+
+## Implementation Phases
+
+Ordered by measured value, with the packer deliberately last: until the earlier
+phases land it would be optimizing a distribution that is about to change
+completely.
+
+- [ ] **Phase 1: Eliminate the duplicated critical path** — RUE-1262.
+      56–59% of the critical path, no new machinery, needs one coverage ruling.
+- [ ] **Phase 2: Duplication gate** — new. Cheap, and it is what stops the class
+      from recurring; lands while the evidence is fresh.
+- [ ] **Phase 3: Platform scope as a target attribute** — new (RUE-1262 scope C).
+      Removes the `validate-ci-gate.py:204` pin and the per-test/per-target
+      granularity error.
+- [ ] **Phase 4: Determinator plans every lane and reports its regime** —
+      RUE-1130, whose "make it discriminate or remove it" question this ADR
+      answers with "keep it, extend it, and make it report what it saved."
+- [ ] **Phase 5: Real input-keyed compile actions** — RUE-1164, milestone
+      "Buck-native test actions"; RUE-1222 for the timing-refresh and
+      undeclared-input follow-ups.
+- [ ] **Phase 6: Floor-aware packer with the indivisible-item alarm** — new.
+      Subsumes `validate-cli-shard-coverage.py`.
+
+Adjacent, not sequenced: RUE-1131 (avoid compiler builds in stubbed jobs) is the
+same fixed-cost problem this ADR names in the compiler-cold regime.
+
+## Consequences
+
+### Positive
+
+- Measured 56–59% critical-path reduction from Phase 1 alone: `pull_request`
+  median 820s → 361s, `merge_group` 456s → 185s, with the whole-sample range
+  narrowing from 341–873s to 170–393s. The merge queue becomes predictable, not
+  merely faster.
+- The binding constraint stops being one defect and becomes distributed —
+  `valgrind` in 4 of 9 runs, the cold compiler build in 3, reproducibility in 1,
+  one CLI shard in 1. The next improvement becomes a real trade rather than a bug.
+- New work inherits all three mechanisms by construction. A new toolchain aspect
+  becomes a tier-labelled target and is determinated, cached, and packed without
+  a workflow edit — the scaling property RUE-1250 asked for.
+- Two hand-maintained gates disappear: the shard-count/matrix agreement check and
+  the pinned native target list, each replaced by a graph-derived assertion.
+
+### Negative
+
+- A generated matrix is harder to read than YAML. Mitigation: the plan is written
+  to the job summary, as `affected-targets` already does for corpus selection.
+- The planner becomes a new failure mode on the critical path. It must be
+  fail-open by construction, as `scripts/affected-targets` already is, and pinned
+  by its own tests.
+- The duplication gate costs a `--list` invocation per test binary per run.
+  Bounded and small, but it is new required work.
+- "Regime" is a new concept for contributors to learn. It earns its place only if
+  CI reports it plainly.
+- Phase 5 widens the class of false passes an undeclared input can cause, from
+  corpora to unit tests. This is why RE-based hermeticity validation gates it
+  rather than following it.
+
+## Open Questions
+
+- Does buck2's native `supports_test_execution_caching` work under a real remote
+  test-execution toolchain? If so it obsoletes most of Phase 5's per-target
+  conversion work, and should be established before that phase starts.
+- `compiler reproducibility` measured 164–183s in every regime — it is cache-free
+  by design (RUE-617/RUE-1019) and becomes a binding constraint once Phase 1
+  lands. Is its cost reducible without weakening the proof?
+- The compiler build is 286–317s whenever a compiler crate changes, and every
+  lane pays it. Build-once-and-fan-out serializes it ahead of the lanes and
+  measures worse; is there a third option (RUE-1131 is adjacent)?
+- Should `release-smoke`'s debug/release double execution be kept? It is
+  defensible coverage that nobody appears to have decided.
+
+## Future Work
+
+- **Finer-grained compiler invalidation.** The blind spot in "Context" exists
+  because CI keys on the compiler *binary*. Rue's own query engine (ADR-0063)
+  maintains fine-grained fingerprints internally while CI invalidates at
+  whole-binary granularity externally. Exposing query-level fingerprints to the
+  build system would make invalidation proportional to the change rather than
+  total. This is speculative and out of scope here, but it is the only idea in
+  sight that would raise the determinator's ceiling in the regime that matters.
+- Reliability. This ADR's evidence is nine runs over two days and computes no
+  flake rate; `correctness-repetitions.yml` is the right source, and shard
+  reliability remains unquantified.
+- Per-target measurement on real ARM64 and macOS runners. The native-lane
+  conclusions here scale CI step timings by locally measured target ratios; the
+  99.1% concentration is inferred from target composition, not measured on those
+  hosts.
+
+## References
+
+- `docs/notes/rue-1250-shard-topology-analysis.md` — shard decision and run sample
+- `docs/notes/rue-1250-premerge-critical-path.md` — premerge lane profile
+- `docs/notes/rue-1250-ci-architecture.md` — native lane profile and design detail
+- `docs/process/ci.md`, `docs/process/build-cache.md` — current contracts
+- ADR-0015 (test suite optimization), ADR-0063 (parallel demand-driven
+  incremental compilation), ADR-0067 (compiler performance measurement)
+- RUE-1250, RUE-1262, RUE-1164, RUE-1130, RUE-1131, RUE-1222; RUE-1116, RUE-1118,
+  RUE-1119, RUE-1157, RUE-1163 for the mechanisms this ADR unifies

--- a/docs/designs/0069-ci-work-scheduling.md
+++ b/docs/designs/0069-ci-work-scheduling.md
@@ -23,32 +23,44 @@ Proposal
 Rue's CI has three good mechanisms for not doing work — a change determinator
 (RUE-1119), cacheable corpus actions (RUE-1118), and corpus sharding
 (RUE-1116/RUE-1158) — each applied to a different hand-picked subset of the work
-and composed in the wrong order. Measuring nine runs shows the consequence: the
-critical path is a single test function executed four times, and no topology
-change can move it.
+and composed in the wrong order. Measuring 120 runs — 55 classified by what they
+changed, 21 timed to job and step level — shows the consequence: the critical
+path is a single test function executed four times, and no topology change can
+move it.
 
 This ADR adopts a uniform model. Every unit of CI work is a Buck target carrying
 its own tier and platform scope; no workflow file names a target; every lane is a
-generated selection over the live graph. It also names the property that makes a
-compiler monorepo different from the systems these mechanisms were designed for:
-**the compiler is a universal dependency, so change-based selection and
-input-keyed caching share a blind spot covering the dominant change class.**
-Eliminating duplicated work — which helps in *every* regime — therefore ranks
-above both, and scheduling ranks above neither.
+generated selection over the live graph.
+
+It rests on two measurements that pull in opposite directions and are both true.
+A compiler monorepo has a property the mechanisms were not designed for — **the
+compiler is a universal dependency, so today three quarters of changes invalidate
+everything downstream**, and neither selection nor input-keyed caching can help
+them. Eliminating duplicated work therefore ranks above both, because it is the
+only lever that pays in every regime. But the converse measurement is sharper:
+**a two-file documentation change costs 444s against 465s for a compiler change —
+a 4.5% difference — while roughly 80% of that run is provably unnecessary.**
+Determination is not near its ceiling; it is not connected to the critical path
+at all. Both facts must survive into the design, because the change mix that
+makes the first one true today is deliberately being changed.
 
 ## Context
 
 ### What was measured
 
-Nine `CI` runs (2026-08-07/08, four `pull_request`, five `merge_group`), plus
-`buck2` run directly against the live graph. Full evidence is in
+120 `CI` runs were collected (2026-08-06 to 2026-08-09). Of those, **55 were
+classified by change class**, by resolving each run to its commit through the
+merge-queue branch name and reading the changed-file list from local git; **21
+have full job- and step-level timings**. `buck2` was also run directly against
+the live graph for per-target measurement. Full evidence is in
 `docs/notes/rue-1250-shard-topology-analysis.md`,
 `rue-1250-premerge-critical-path.md`, and `rue-1250-ci-architecture.md`.
 
 The finding that motivates this ADR is concentration, not imbalance:
 
-- `premerge (linux-x64)` was the longest job in **9 of 9** runs, 279–576s ahead
-  of the slowest CLI shard.
+- `premerge (linux-x64)` was the longest job in **18 of 21** timed runs (86%);
+  `native (linux-arm64)` took over in the other three, all of them cheap runs.
+  In the nine originally sampled it was 279–576s ahead of the slowest CLI shard.
 - That lane runs 80 targets. Two are **81.4%** of it — and
   `//crates/rue-compiler:scaling-matrix-test` turns out to be a strict superset
   of `//crates/rue-compiler:rue-compiler-test`: 816 tests versus 813, all 813
@@ -67,29 +79,75 @@ item weighs 181.7s against ~44s of everything else. LPT's makespan is bounded
 below by the largest indivisible item, and the lane's measured parallel wall
 (268s) is already within 19% of that bound.
 
-### The property that makes this repository different
+### The change mix, and why it is the wrong thing to design against
 
 The determinator and the action cache both key on change. In a compiler
-monorepo, that has a low ceiling, because the compiler is an input to nearly
-every downstream action. A change to any compiler crate changes the compiler
+monorepo that looks like a poor bet, because the compiler is an input to nearly
+every downstream action: a change to any compiler crate changes the compiler
 binary's digest, which invalidates every Rue-program compile action, hence every
-corpus.
+corpus. Classifying 55 runs by what they touched:
 
-This is measured from both directions. RUE-1130 records **zero deselections
-across 9 runs × 18 corpus jobs** — every job logged `SELECTIVE` and then selected
-everything, "because compiler-core changes legitimately reach the whole
-reverse-dependency closure." Independently, classifying the nine runs sampled
-here by their premerge build step:
+| area touched | runs | share |
+| --- | --- | --- |
+| compiler internals | 41 | 74.5% |
+| docs / website | 29 | 52.7% |
+| CI / build inputs | 18 | 32.7% |
+| test cases | 15 | 27.3% |
+| tooling crates | 12 | 21.8% |
+| performance manifests | 8 | 14.5% |
+| **`std/`** | **0** | **0%** |
+
+Collapsing that to what a determinator can act on: **74.5% touch compiler
+internals** and cannot be narrowed; **18.2%** touch a graph-global CI or build
+input and correctly force a full run; **7.3%** are peripheral and addressable
+today. RUE-1130 records the corresponding symptom — zero deselections across
+9 runs × 18 corpus jobs.
+
+**It would be a mistake to read that as the mechanism's ceiling.** Two facts say
+otherwise.
+
+First, determination is not failing on the runs it *can* address; it is not
+reaching them. Comparing timed runs by class:
+
+| change class | runs | median wall |
+| --- | --- | --- |
+| touches compiler internals | 9 | 465s |
+| peripheral (docs, tooling, performance) | 4 | **444s** |
+
+A two-file documentation change costs 4.5% less than a compiler change. It still
+builds the compiler, still runs 813 compiler unit tests on linux-x64, and still
+runs those same 813 again on linux-arm64 and again on macOS. The correct run for
+that change is the doc-consuming targets — `tutorial-snippet-tests` (11.8s),
+`adr-registry-validation` (0.7s), `spec-traceability` — plus the lint and
+aggregate gates: on the order of 80s including runner overhead, against 444s
+actually paid. **Roughly 80% of a peripheral run is provably unnecessary, and the
+determinator computes the right answer already; it is simply wired to 7 of ~14
+jobs, and not to the one on the critical path in 86% of runs.**
+
+Second, the 74.5% figure describes the repository's *current* shape, not a
+property of the design. Rue is at a compiler-building stage, and the planned work
+is explicitly elsewhere: an LSP, a test runner, code mods, and a substantial
+standard-library expansion — components that carry their own tests and mostly do
+not touch compiler internals. The `std/` row above is the tell: **zero of 55
+sampled changes touched `std/` at all.** That entire class of work, along with
+the other three components, is ahead of this measurement rather than behind it.
+A design that treated 7.3% as the ceiling would be tuned for a repository shape
+that is deliberately being replaced.
+
+So the honest statement is narrower than "determination has a low ceiling in a
+compiler monorepo." It is: *determination's addressable share is a function of
+the change mix; the mix is currently compiler-heavy; the mechanism is
+nevertheless leaving its entire current share on the table, and the share is
+designed to grow.* Keep it, wire it to everything, and make it report what it
+saved so the question is answered by data next time rather than by argument.
+
+Classifying the same runs by cache state gives the complementary picture:
 
 | regime | runs | compiler build | corpus |
 | --- | --- | --- | --- |
 | warm | 5 of 9 | ≤22s | cached |
 | corpus-cold | 1 of 9 | 19s | 900–1100s |
 | compiler-cold | 3 of 9 | 286–317s | 900–1100s |
-
-Determination and caching make the *warm* regime nearly free, which is real and
-worth keeping. Neither helps the compiler-cold regime at all, and that regime is
-a third of runs and most of the interesting ones.
 
 Two consequences follow, and they are the reason this ADR exists rather than a
 narrower one:
@@ -100,7 +158,9 @@ narrower one:
    against an unshardable native ARM64 lane at 341–407s. Four shards stay under
    that floor in 4 of 4 runs; two breach it in 4 of 4. **Keep four.**
 2. **Not doing duplicated work outranks both other mechanisms**, because it is
-   the only one that pays in every regime.
+   the only one that pays in every regime — while determination pays hugely in a
+   regime that is currently small and growing, and caching pays in a regime that
+   is currently large and shrinking as the compiler stabilizes.
 
 ### Why the current composition is inverted
 
@@ -174,6 +234,22 @@ emit the lane plan the matrix consumes
 (`strategy.matrix: ${{ fromJSON(...) }}`). `merge_group` keeps forcing the
 authoritative full run. The existing fail-open contract and
 `scripts/test-affected-targets.sh` pinning are retained unchanged.
+
+This is the decision RUE-1130 asks for, and the answer is *keep and extend*, not
+*remove*. The measured saving on a peripheral run is ~80% of its wall time, and
+none of it is currently reachable, because the determinator gates 7 of ~14 jobs
+and `premerge` — the critical path in 86% of runs — is not one of them. Extending
+the gate is a smaller change than the rest of this ADR and does not depend on it:
+the existing `steps.sel.outputs.run` pattern already used by `platform-corpus`
+generalizes to the other lanes directly, and BTD already computes the closure
+these lanes would consult. Docs and specification sources are ordinary in-graph
+inputs (`tutorial-snippet-tests`, `adr-registry-validation`, `spec-traceability`
+declare them), so a documentation change narrows to exactly those targets without
+any new force-full rule.
+
+The same applies to the native lanes. A documentation change currently runs 813
+compiler unit tests on linux-arm64 and again on macOS; nothing about that change
+can reach them.
 
 The coverage gate then becomes stronger *and* simpler than
 `validate-cli-shard-coverage.py`: **the union of planned lanes equals the tier
@@ -260,14 +336,18 @@ completely.
 
 - [ ] **Phase 1: Eliminate the duplicated critical path** — RUE-1262.
       56–59% of the critical path, no new machinery, needs one coverage ruling.
-- [ ] **Phase 2: Duplication gate** — new. Cheap, and it is what stops the class
-      from recurring; lands while the evidence is fresh.
-- [ ] **Phase 3: Platform scope as a target attribute** — new (RUE-1262 scope C).
-      Removes the `validate-ci-gate.py:204` pin and the per-test/per-target
-      granularity error.
-- [ ] **Phase 4: Determinator plans every lane and reports its regime** —
+- [ ] **Phase 2: Extend determination to every lane and report its regime** —
       RUE-1130, whose "make it discriminate or remove it" question this ADR
       answers with "keep it, extend it, and make it report what it saved."
+      Promoted ahead of the gates below by measurement: ~80% of a peripheral run
+      is currently unnecessary and none of it is reachable, and the change is
+      independent of the rest of this ADR.
+- [ ] **Phase 3: Duplication gate** — new. Cheap, and it is what stops the class
+      from recurring; lands while the evidence is fresh.
+- [ ] **Phase 4: Platform scope as a target attribute** — new (RUE-1262 scope C).
+      Removes the `validate-ci-gate.py:204` pin and the per-test/per-target
+      granularity error. Phase 2 already stops peripheral changes from reaching
+      the native lanes; this makes compiler changes stop over-selecting them too.
 - [ ] **Phase 5: Real input-keyed compile actions** — RUE-1164, milestone
       "Buck-native test actions"; RUE-1222 for the timing-refresh and
       undeclared-input follow-ups.
@@ -285,6 +365,10 @@ same fixed-cost problem this ADR names in the compiler-cold regime.
   median 820s → 361s, `merge_group` 456s → 185s, with the whole-sample range
   narrowing from 341–873s to 170–393s. The merge queue becomes predictable, not
   merely faster.
+- Phase 2 takes a peripheral change from a measured 444s to roughly 80s, and its
+  share of runs grows with every component added outside the compiler. The two
+  phases are complementary rather than competing: Phase 1 shrinks the work every
+  change must do, Phase 2 stops changes doing work they cannot affect.
 - The binding constraint stops being one defect and becomes distributed —
   `valgrind` in 4 of 9 runs, the cold compiler build in 3, reproducibility in 1,
   one CLI shard in 1. The next improvement becomes a real trade rather than a bug.
@@ -332,9 +416,14 @@ same fixed-cost problem this ADR names in the compiler-cold regime.
   build system would make invalidation proportional to the change rather than
   total. This is speculative and out of scope here, but it is the only idea in
   sight that would raise the determinator's ceiling in the regime that matters.
-- Reliability. This ADR's evidence is nine runs over two days and computes no
-  flake rate; `correctness-repetitions.yml` is the right source, and shard
-  reliability remains unquantified.
+- Reliability. This ADR classifies 55 runs and times 21, but computes no flake
+  rate; `correctness-repetitions.yml` is the right source, and shard reliability
+  remains unquantified.
+- The change-mix measurement is four days of one repository at one stage. It is
+  the right input for Phase 2's priority and the wrong input for a permanent
+  constant, which is the general argument this ADR makes about derived rather
+  than pinned numbers. The determinator should report its own saved share so the
+  mix is observed continuously rather than sampled once.
 - Per-target measurement on real ARM64 and macOS runners. The native-lane
   conclusions here scale CI step timings by locally measured target ratios; the
   99.1% concentration is inferred from target composition, not measured on those

--- a/docs/designs/README.md
+++ b/docs/designs/README.md
@@ -231,4 +231,5 @@ The table is generated from ADR frontmatter. Run
 | [0066](0066-producer-nominal-anonymous-types-and-incremental-locality.md) | Producer-nominal anonymous types and incremental locality | Implemented | types, semantics, comptime, incremental, performance, parallelism |
 | [0067](0067-compiler-performance-measurement.md) | Compiler performance measurement, epochs, and dashboard | Proposal | tooling, ci, performance, website |
 | [0068](0068-incremental-edit-performance-measurement.md) | Incremental edit-scenario performance measurement | Accepted | tooling, compiler, incremental, performance |
+| [0069](0069-ci-work-scheduling.md) | CI work scheduling for a compiler monorepo | Proposal | process, ci, testing, build, performance |
 <!-- ADR-INDEX:END -->

--- a/docs/notes/rue-1250-ci-architecture.md
+++ b/docs/notes/rue-1250-ci-architecture.md
@@ -1,0 +1,249 @@
+# A uniform CI architecture for Rue
+
+Design conclusion of the RUE-1250 investigation. The two measurement notes
+(`rue-1250-shard-topology-analysis.md`, `rue-1250-premerge-critical-path.md`)
+establish what CI currently spends its time on; this one says what to build.
+
+Rue already has all three mechanisms an ideal CI system needs, and each is good.
+The defect is that each is applied to a different hand-picked subset of the work,
+and the subsets do not overlap where it matters.
+
+## The native lanes, profiled
+
+Completing the picture. Both native lanes are one step, and that step is one
+target:
+
+| lane | median | dominant step | share |
+| --- | --- | --- | --- |
+| `native (linux-arm64)` | 351s (341–407) | "Run native backend, linker, runtime, ABI, allocator, and target tests" | **87.2%** |
+| `native (macos-arm64)` | 230s (184–385) | the same step | **76.5%** |
+
+That step runs eight targets. Measured locally, seven of them total **2.1s** and
+`//crates/rue-compiler:rue-compiler-test` is **225.6s — 99.1% of the step**. And
+that target is 94% one test function
+(`failed_wide_batches_release_their_unpublished_child_cones_under_pressure`,
+181.7s, RUE-1262).
+
+So the same test function runs **four times per CI run**: twice in the premerge
+lane (`rue-compiler-test` and its duplicate `scaling-matrix-test`), once on
+linux-arm64, once on macOS. It is the dominant cost in all three lanes.
+
+The "ARM64 floor" that an earlier draft of the topology note treated as an
+immovable platform constraint is not a platform constraint. It is the same
+defect, seen from a third angle.
+
+### This contradicts the documented contract
+
+`docs/process/ci.md:46` states:
+
+> Linux ARM64 and macOS ARM64 deliberately do not repeat the broad unit suite or
+> the specification corpus.
+
+They do. `rue-compiler-test` is 813 tests — the broad compiler unit suite — and
+`scripts/validate-ci-gate.py:204` pins it into the native lanes' required list.
+The gate that exists to prevent coverage drift is what enforces the repetition.
+
+What the native lanes actually want is the host-conditional coverage: roughly 27
+`#[cfg(unix)]` / `#[cfg(target_os = "macos")]` / `#[cfg(target_arch = ...)]`
+sites in the crate. They get all 813 tests, including a query-eviction pressure
+test with no platform dependence whatsoever.
+
+That is the general shape of the bug: **platform requirements are declared
+per-target, but they are a property of individual tests.** A whole test binary is
+too coarse a unit to express "this needs a real Mach-O linker."
+
+## What the end state looks like
+
+Fixing the pressure test once, at the source, fixes it in all four places.
+Modelled against the nine sampled runs using each run's own step durations:
+
+| | today | after |
+| --- | --- | --- |
+| pull_request (median critical path) | 820s | **361s** (−56%) |
+| merge_group (median critical path) | 456s | **185s** (−59%) |
+| `native (linux-arm64)` | 341–407s | **56–103s** |
+| `native (macos-arm64)` | 184–385s | **41–130s** |
+| whole-sample range | 341–873s | 170–393s |
+
+The binding constraint stops being a single defect and becomes genuinely
+distributed: `valgrind` (4 of 9 runs, ~170–185s), the cold compiler build inside
+premerge (3 of 9, ~354–393s), `compiler reproducibility` (1), and one CLI shard
+(1). That is what a healthy system looks like — no one thing to fix, and the next
+improvement is a real trade rather than a bug.
+
+## The diagnosis
+
+| mechanism | eliminates | applied to | not applied to |
+| --- | --- | --- | --- |
+| determinator (BTD, RUE-1119) | work the diff cannot affect | the `platform-corpus` job, `pull_request` only | premerge, both native lanes, valgrind, asan, release, reproducibility |
+| caching (`cached_corpus_suite`, RUE-1118) | work already done for this tree | 11 corpora | 75 of the 80 premerge targets, every native target |
+| sharding (RUE-1116/1158) | wall time of work that must run | 1 corpus, fixed at 4 | everything else |
+
+Each mechanism is sound. The composition is inverted. Sharding is permanent and
+outermost; caching covers a middle slice; determination is innermost and
+narrowest. It should be the exact reverse, because each stage is strictly cheaper
+than the next and shrinks the next one's input:
+
+```
+determinate  ->  don't schedule what the diff cannot affect      (free)
+     cache   ->  don't execute what this tree already executed   (near-free)
+     shard   ->  spread only what genuinely must execute         (costs runners)
+```
+
+### The structural root cause
+
+There are three different kinds of "unit of work" in this CI system:
+
+1. **Buck actions** — cacheable, determinable, remotely executable.
+2. **Buck test targets** — visible to the determinator, but not cacheable as
+   configured, so they re-execute every run.
+3. **CI steps** — hand-written target lists in YAML, opaque to all three
+   mechanisms.
+
+Every defect this investigation found lives in category 3 or 2:
+
+- the native lanes' eight-target shell invocation (3) — the determinator cannot
+  see it, caching does not apply, sharding is impossible. A 181.7s test hid there
+  on two platforms;
+- the 75 uncached premerge targets (2) — 440–463s of cache-immune work per run;
+- `scaling-matrix-test` duplicating 813 of `rue-compiler-test`'s tests (2) —
+  invisible because nothing compares test *contents*, only target lists.
+
+## The architecture
+
+### 1. One kind of unit, and CI never names one
+
+Every piece of premerge work is a Buck target carrying its tier and its platform
+requirement as attributes. **No workflow file contains a target label.** Every
+lane is a generated selection over the live graph.
+
+The repository already does this well for corpus cases — `only_on` plus
+`RUE_PLATFORM_CASE_SELECTION=native` makes platform-scoped cases self-enrolling,
+and `docs/process/ci.md` correctly calls that out as the reason new cases do not
+need a workflow edit. Extend exactly that idea to unit targets, and the native
+lanes become `attrfilter(labels, 'rue_platform_native', …)` instead of a list
+that `validate-ci-gate.py` has to pin.
+
+This also fixes the granularity mismatch. If platform need is per-test, the unit
+must be per-test: split the host-conditional compiler tests into their own target
+(the repository's own precedent — `rue-compiler-public-api-test`,
+`rue-compiler-differential-oracle-test`, and `rue-compiler-payload-schema-test`
+are already separate targets in the same crate), and let the native lanes select
+that instead of the whole crate suite.
+
+### 2. Determinate everything, not just the corpora
+
+`affected-targets` already produces a fail-open decision, is already pinned by
+`scripts/test-affected-targets.sh`, and already publishes JSON the matrix
+consumes. Today only `platform-corpus` consults it; every other lane runs
+unconditionally.
+
+Extend it to every lane, and let it emit the lane plan rather than a
+selection flag — `strategy.matrix: ${{ fromJSON(needs.affected-targets.outputs.lanes) }}`.
+The coverage gate then becomes stronger *and* simpler than
+`validate-cli-shard-coverage.py`: **the union of planned lanes equals the tier
+selection from the live Buck graph**, fail-closed on any target in the graph and
+in no lane. `merge_group` keeps forcing the full authoritative run.
+
+### 3. Make test results cacheable, uniformly
+
+`rust_test` provides `RunInfo` (verified with `buck2 audit providers`), so
+`cached_corpus_suite`'s existing `_corpus_action` rule accepts a unit-test target
+as its `harness` with no new machinery. The input contract is *tighter* than any
+corpus already converted: the test binary's digest covers the entire Rust source
+closure, because Buck built it.
+
+Two things make this safe rather than hopeful:
+
+- **Remote execution is the undeclared-input detector.** RUE-1222's item 3 worries
+  that an undeclared action input becomes a silent false pass. RE materializes
+  only declared inputs, so an undeclared read fails with file-not-found instead.
+  RUE-320 is Done (2026-07-18, "full remote execution now default-capable"), and
+  the stale instructions in `AGENTS.md:182` and the `./buck2` wrapper should be
+  reconciled with `docs/process/build-cache.md`, which already describes it as
+  supported.
+- **Check the native path first.** buck2 carries
+  `supports_test_execution_caching` on `ExternalRunnerTestInfo` and
+  `disable_test_execution_caching` in the executor protocol. Rue configures
+  `noop_test_toolchain` and `noop_remote_test_execution_toolchain`, so nothing
+  honors them — `corpus.bzl`'s "OSS buck2 ships no test-result cache" is true *as
+  configured*, not in general. If a real remote test-execution toolchain makes
+  the native path work, it is one attribute instead of 75 conversions.
+
+### 4. Shard last, to a measured floor, with an alarm
+
+The objective is **minimize runners subject to the slowest lane staying under the
+floor** — bin-packing under a capacity constraint, not makespan across fixed
+bins. Only that objective can conclude "use fewer." The floor is measured (the
+slowest lane that cannot be split), never chosen.
+
+The load-bearing part is not the algorithm. **When the largest indivisible item
+exceeds the floor, the planner must fail loudly, name the item, and refuse to
+express the problem as a lane count.** A packer reasoning about totals would have
+requested eight runners for the pre-fix premerge lane, where one item was 225.6s,
+and reported success having changed nothing.
+
+Its three remedies are all ones this repository already has:
+
+| symptom | remedy | precedent |
+| --- | --- | --- |
+| one item dominates a lane | split it | CLI intra-target shards (RUE-1116) |
+| the item re-executes every run | cache it | `cached_corpus_suite` (RUE-1118) |
+| the item is heavier than pre-merge warrants | re-tier it | scaling matrix 100/1k vs 10k; large-example canary vs slow |
+
+Choosing among them is a human call. Noticing is not — and that alarm would have
+surfaced RUE-1262 on the day it landed, in three lanes at once.
+
+### 5. The invariant nobody currently checks: nothing executes twice
+
+This is the finding that generalizes furthest. Three duplications, none
+detectable by any existing gate:
+
+- `scaling-matrix-test` re-runs 813 of `rue-compiler-test`'s tests, in the same
+  lane, to add three;
+- `rue-compiler-test`'s 813 tests run on linux-x64, linux-arm64, and macOS, while
+  the documented contract says the native lanes do not repeat the broad unit
+  suite;
+- `release-smoke` runs in the premerge lane under the debug platform and again in
+  the `release` job under the release platform — arguably intentional, but nobody
+  decided it.
+
+Every CI gate here compares **target lists**. None compares **test contents**, so
+a target that is a strict superset of another is invisible. The fix is a gate
+that collects each lane's test identities (`--list` on the test binaries, which
+is how the `scaling-matrix-test` superset was found — cheap and exact) and fails
+when a test executes more than once per platform per run without a declared
+reason.
+
+That gate is what converts "we fixed this instance" into "this class cannot
+recur," which is the difference between a faster CI system and a robust one.
+
+## Ordering
+
+1. **RUE-1262** — the pressure test and the `scaling-matrix-test` duplicate. It
+   is 56–59% of the critical path, its scope is three lanes rather than one, and
+   it needs no new machinery.
+2. **The duplication gate** (§5). Cheap, and it is what stops the class from
+   recurring. Doing it second means it lands while the evidence is fresh.
+3. **Native-lane selection by attribute** (§1). Deletes the pinned target list
+   and fixes the per-test/per-target granularity mismatch.
+4. **Determinate every lane and generate the matrix** (§2). Largest workflow
+   change; safest once §1 has removed the hand-written lists it would otherwise
+   have to reproduce.
+5. **Uniform test caching** (§3), after establishing whether buck2's native path
+   works.
+6. **Floor-aware packing with the indivisible-item alarm** (§4). Last, because
+   until 1–5 land the packer would be optimizing a distribution that is about to
+   change completely.
+
+## Limits
+
+- The end-state model scales measured CI step durations by locally measured
+  target ratios. It assumes the native lanes' 99.1% concentration holds on ARM64
+  and macOS as it does on x86-64; that is an inference from target composition,
+  not a measurement on those hosts.
+- The native lanes were profiled from step timings, not per-target. The step runs
+  eight targets and the local composition is unambiguous, but a per-target
+  measurement on real ARM64/macOS runners would confirm it directly.
+- Nine runs over two days. Reliability and flake rate remain unmeasured; the
+  weekly `correctness-repetitions.yml` workflow is the right source.

--- a/docs/notes/rue-1250-premerge-critical-path.md
+++ b/docs/notes/rue-1250-premerge-critical-path.md
@@ -1,0 +1,243 @@
+# RUE-1250: the premerge critical path is one test function
+
+Follow-up to `rue-1250-shard-topology-analysis.md`, which established that
+`premerge (linux-x64)` — not the CLI shards — is the required-CI critical path
+in 9 of 9 sampled runs, and left the lane's internal composition unmeasured.
+
+This note measures it. The conclusion is that **no shard topology can improve
+the premerge lane**, because a single test function is 81% of it, and that
+function is compiled into two different targets that both run pre-merge.
+
+## Method
+
+`buck2` was run directly against the repository. The lane's membership is the
+live Buck graph, not an inference:
+
+```bash
+buck2 uquery "attrfilter(labels, 'rue_test_tier_premerge', set(//... toolchains//...))"
+# minus attrfilter(labels, 'rue_cli_shard', …) and 'rue_ci_dedicated_lane'
+```
+
+That is **80 targets**: 35 Rust unit tests and 45 root `sh_test` gates. Only
+five are `cached_corpus_suite` action-backed suites; the other 75 re-execute on
+every run, because OSS buck2 has no test-result cache (the premise of RUE-1118).
+
+Each of the 80 was then timed individually with a warm build, and the whole lane
+was timed as the single invocation CI actually issues.
+
+**The measurement host has 4 cores — the same as `ubuntu-latest`** — so these
+figures are directly comparable to CI rather than scaled. The host is faster
+per-core (cold compiler build 78s here versus 286s on CI), so treat absolute
+seconds as a lower bound and the *shares* as the result.
+
+| measurement | value |
+| --- | --- |
+| serial sum of all 80 targets | 551.7s |
+| lane as one parallel invocation (as CI runs it) | 268.0s |
+| CI's warm premerge step, for reference | 440–463s |
+
+## Finding 1: two targets are 81.4% of the lane
+
+| target | seconds | share |
+| --- | --- | --- |
+| `//crates/rue-compiler:rue-compiler-test` | 225.6 | 40.9% |
+| `//crates/rue-compiler:scaling-matrix-test` | 223.5 | 40.5% |
+| `//crates/rue-oracle-diff:rue-oracle-diff-test` | 17.5 | 3.2% |
+| `//:repository-quality-gates` | 12.2 | 2.2% |
+| `//:tutorial-snippet-tests` | 11.8 | 2.1% |
+| *all 45 root `sh_test` gates combined* | 56.9 | 10.3% |
+
+The 45 validation and tool-test gates that dominate the lane's *target count*
+are 10% of its cost. The 35 Rust unit tests are 89.7%, and two of them are
+nearly all of that.
+
+## Finding 2: the two big targets are the same test binary
+
+`scaling-matrix-test` compiles the same sources as `rue-compiler-test` with
+`--cfg=scaling_matrix`, which enables three `#[cfg(scaling_matrix)]` tests.
+Listing both binaries:
+
+```
+rue-compiler-test:    813 tests
+scaling-matrix-test:  816 tests
+shared:               813
+only in scaling-matrix-test:
+  scaling_harness::scaling_matrix_fixed_bodies_growing_declarations
+  scaling_harness::scaling_matrix_fixed_declarations_growing_bodies
+  scaling_harness::scaling_matrix_identity_invariant
+```
+
+A strict superset. The premerge lane runs those 813 tests **twice** — 223.5s the
+second time — to gain three tests.
+
+The intent was already right: the BUCK comment says the target "remains a
+separate target so `scaling_matrix` coverage is isolated from the default unit
+target," and the isolation *is* achieved, by the cfg. What is missing is a
+filter on execution. The stress sibling already has one —
+`scaling-matrix-stress-test` passes `args = ["scaling_matrix", "--nocapture"]` —
+and the premerge target passes nothing.
+
+Filtering it to the three tests it uniquely owns, measured:
+
+```
+223.5s  ->  6.2s     (3 passed; 813 filtered out)
+```
+
+Note that `rust_test` does not accept an `args` attribute — `buck2` rejects it
+outright — so this is a small structural choice, not a one-line edit. See
+"Options" below.
+
+## Finding 3: one test function is 81% of the remaining target
+
+Timing `rue-compiler-test` by module isolates it to `pipeline_tests` (226.0s of
+the target's 225.6s), and timing that module's 74 tests individually isolates it
+further:
+
+| test | seconds |
+| --- | --- |
+| `pipeline_tests::tests::failed_wide_batches_release_their_unpublished_child_cones_under_pressure` | **181.7** |
+| `published_backend_root_keeps_wide_no_edit_and_single_edit_builds_exactly_warm` | 5.7 |
+| `retained_object_projection_is_local_bounded_and_released_with_the_backend_root` | 5.5 |
+| *remaining 71 tests* | 7.6 |
+
+The runner-up is 32× smaller. Skipping this one test takes the whole binary from
+225.6s to **12.7s** for the other 809 tests.
+
+The test is not accidentally slow. It compiles `wide_reached_program(33, N)`
+eighteen times under codegen-failure injection, deliberately, to drive real
+query-family eviction pressure:
+
+```rust
+fail(&mut session, &failed_source);
+let evictions_before_pressure = session.query_evictions_for_test();
+for value in 101..117 {
+    fail(&mut session, &wide_reached_program(CHAIN_FUNCTIONS, value));
+}
+assert!(
+    session.query_evictions_for_test() > evictions_before_pressure,
+    "failed child cones must face real query-family eviction pressure"
+);
+```
+
+It is genuine coverage doing genuine work. It is also compiled into both
+binaries above, so the premerge lane pays it **twice**: roughly 363s of the
+lane's 551.7s serial cost, or 66%, is this one function.
+
+## Finding 4: sharding cannot move this
+
+Partitioning the 813 tests four ways by name hash and running each partition:
+
+| partition | tests | seconds |
+| --- | --- | --- |
+| 0 | 202 | 3.4 |
+| 1 | 184 | 6.8 |
+| 2 | 225 | 7.2 |
+| 3 | 202 | **227.0** |
+
+Count-balanced sharding does nothing. Cost-balanced sharding — the RUE-1158
+approach — cannot do better either: one item weighs 181.7s and the entire rest
+of the binary weighs ~44s, so every assignment puts that item alone on the
+critical path.
+
+This generalizes to the whole lane. LPT's makespan is bounded below by the
+largest indivisible item, so with a 225.6s target the lane cannot go below
+225.6s on any number of runners. The measured parallel wall is already 268s —
+within 19% of that floor. **Target-level fan-out has at most 16% left to give,
+and it costs a runner per lane to collect it.**
+
+## Options, in order of effect
+
+| scenario | serial lane cost | largest item | 4-core LPT bound |
+| --- | --- | --- | --- |
+| today | 551.7s | 225.6s | 225.6s (measured wall 268s) |
+| A — de-duplicate `scaling-matrix-test` only | 334.4s | 225.6s | **225.6s** |
+| B — A, plus the pressure test leaves premerge | 121.5s | 17.5s | **30.4s** |
+
+Read the middle row carefully: **de-duplication alone does not move the critical
+path.** It frees 217s of CPU and a shard's worth of runner cost, but the surviving
+copy of the pressure test still sets the floor. Only dealing with that one test
+changes the lane's wall time — and then the lane becomes genuinely flat, with a
+new largest item of 17.5s and no target above 20s.
+
+### A. De-duplicate the scaling-matrix target
+
+Because `rust_test` takes no `args`, either:
+
+1. wrap it the way the stress tier already does — keep the `rust_test` as the
+   binary and add an `rue_sh_test(test = ":scaling-matrix-test", args =
+   ["scaling_matrix"])` as the premerge canary, moving the binary target itself
+   out of the premerge tier so `//...` does not run all 816; or
+2. move the three `scaling_harness` matrix tests into their own `tests/`
+   integration target, so the binary contains only them and the cfg trick is no
+   longer needed.
+
+Option 2 is cleaner and removes a cfg-gated-superset pattern that is easy to
+regress into. Option 1 is smaller and matches existing precedent. Either is a
+maintainer call about where RUE-1086's coverage lives; both are behavior-neutral
+for what actually gets tested, since all 813 shared tests already run in
+`rue-compiler-test` in the same lane.
+
+### B. Give the pressure test the treatment this repository already uses twice
+
+A 181.7s eviction-pressure test in the pre-merge unit suite is the same shape as
+two problems this repository has already solved:
+
+- the scaling matrix keeps a bounded 100/1k premerge canary and puts the real
+  10k ladder in `stress`;
+- the large examples keep reduced `-canary` roots in premerge and the real
+  programs in `slow`.
+
+The same split applies: keep a bounded premerge canary that proves eviction
+happens at all (a smaller `CHAIN_FUNCTIONS`, or 3–4 pressure iterations instead
+of 16), and move the full 18-compile ladder to `slow`, where the oracle
+differentials already live and where a regression surfaces on the same day.
+
+This is a coverage decision, not a cleanup, and it belongs to whoever owns
+RUE-1083/RUE-1086. What the measurement establishes is only its price: this one
+test is currently two-thirds of the pre-merge unit suite's cost, and the merge
+queue serializes on it.
+
+## What this means for RUE-1250
+
+The sharding question is answered in the negative for premerge. Do not add lanes
+to it. After A and B the lane is ~30s of well-distributed work and the case for
+any premerge fan-out disappears entirely.
+
+The separate conclusions of the first note stand unchanged: the CLI corpus still
+needs *some* parallelism for cold runs, the shard count should be derived rather
+than written down, and the balance guard should measure outcomes rather than the
+model. But the ordering changes — these two fixes are worth more than every
+topology change in that note combined, and they cost no extra runners.
+
+## Adjacent findings
+
+- **RUE-320 is Done** (2026-07-18, "full remote execution now default-capable"),
+  but `AGENTS.md:182` still instructs agents not to use `--prefer-remote` "while
+  RUE-320 remains open", and the `./buck2` wrapper's comment still cites it as
+  open when forcing `--prefer-local`. `docs/process/build-cache.md` already
+  describes remote execution as supported. The two stale references should be
+  reconciled with the third.
+- **Buck has a native test-caching contract that this repository does not use.**
+  `ExternalRunnerTestInfo` carries `supports_test_execution_caching`, and the
+  executor protocol carries `disable_test_execution_caching`. Rue configures
+  `noop_test_toolchain` and `noop_remote_test_execution_toolchain`, so nothing
+  honors them — `corpus.bzl`'s "OSS buck2 ships no test-result cache" is true
+  *as configured*. Before generalizing RUE-1118's stamp pattern to the other 75
+  targets, it is worth establishing whether a real remote test-execution
+  toolchain makes the native path work; that would be one attribute instead of
+  75 conversions.
+- `rust_test` provides `RunInfo` (confirmed with `buck2 audit providers`), so if
+  the stamp pattern is generalized after all, `cached_corpus_suite`'s existing
+  `_corpus_action` rule accepts a unit-test target as its `harness` with no new
+  machinery, and with a tighter input contract than any corpus — the test
+  binary's digest already covers the whole Rust source closure.
+
+## Limits
+
+- Single host, single sample per target; no repetitions, so small targets carry
+  ordinary noise. The two findings that matter are 20–30× above that floor.
+- Per-target figures were measured serially, each target having all four cores.
+  The parallel wall (268s) was measured separately and is the number to compare
+  against CI.
+- Scenario B's 12.7s figure comes from `--skip` on the existing binary, not from
+  an actual re-tiering, which would also change what the binary compiles.

--- a/docs/notes/rue-1250-premerge-critical-path.md
+++ b/docs/notes/rue-1250-premerge-critical-path.md
@@ -203,11 +203,19 @@ The sharding question is answered in the negative for premerge. Do not add lanes
 to it. After A and B the lane is ~30s of well-distributed work and the case for
 any premerge fan-out disappears entirely.
 
-The separate conclusions of the first note stand unchanged: the CLI corpus still
-needs *some* parallelism for cold runs, the shard count should be derived rather
-than written down, and the balance guard should measure outcomes rather than the
-model. But the ordering changes — these two fixes are worth more than every
-topology change in that note combined, and they cost no extra runners.
+It also settles the CLI shard count, by removing the reason to move it. An
+earlier draft of the first note proposed reducing CLI shards 4 → 2 and spending
+the recovered runners on premerge halves. Both halves of that trade are wrong:
+premerge's parallel wall is already within 19% of its indivisible floor, so the
+runners would buy ~16%; and once premerge stops masking it, the floor that
+governs the CLI corpus is the native ARM64 lane at 341–407s, which two shards
+(450–550s) breach in 4 of 4 cold runs. The first note now records **keep four**.
+
+Its other conclusions stand: the balance guard should measure outcomes rather
+than the model, the weights should not drift undetected, and the count should be
+derived rather than replicated by hand. But the ordering changes — the two fixes
+above are worth more than every topology change in that note combined, and they
+cost no extra runners.
 
 ## Adjacent findings
 

--- a/docs/notes/rue-1250-premerge-critical-path.md
+++ b/docs/notes/rue-1250-premerge-critical-path.md
@@ -1,5 +1,8 @@
 # RUE-1250: the premerge critical path is one test function
 
+Tracked as **RUE-1262**, split out of RUE-1250 because it is not a topology
+change. This note is that issue's evidence.
+
 Follow-up to `rue-1250-shard-topology-analysis.md`, which established that
 `premerge (linux-x64)` — not the CLI shards — is the required-CI critical path
 in 9 of 9 sampled runs, and left the lane's internal composition unmeasured.

--- a/docs/notes/rue-1250-shard-topology-analysis.md
+++ b/docs/notes/rue-1250-shard-topology-analysis.md
@@ -22,6 +22,12 @@ actually moves required-CI latency, and it costs no extra runners.
 
 ## Method and sample
 
+> Superseded in breadth by ADR-0069, which collects 120 runs, classifies 55 by
+> change class, and times 21. Nothing measured here changed under the wider
+> sample — `premerge` remained the critical path in 18 of 21 timed runs — but the
+> determination conclusions belong to the ADR, which has the change-mix data this
+> note lacks.
+
 Nine `CI` runs from 2026-08-07/08 (four `pull_request`, five `merge_group`),
 read from the Actions jobs API: per-job `created_at` / `started_at` /
 `completed_at` and per-step durations. Shard-balance arithmetic is computed

--- a/docs/notes/rue-1250-shard-topology-analysis.md
+++ b/docs/notes/rue-1250-shard-topology-analysis.md
@@ -1,0 +1,279 @@
+# RUE-1250: CLI shard topology reassessment
+
+Measured reassessment of the four-way CLI corpus sharding introduced by
+RUE-1116 and cost-balanced by RUE-1158, against current cache and
+affected-target behavior.
+
+**Decision: reduce and generalize.** Keep parallel corpus execution — cold runs
+still need it — but stop expressing it as a hand-maintained shard count on one
+harness. The current topology spends its fan-out on the one corpus that caching
+already made cheap, while the actual critical path runs unsharded on a single
+runner.
+
+## Method and sample
+
+Nine `CI` runs from 2026-08-07/08 (four `pull_request`, five `merge_group`),
+read from the Actions jobs API: per-job `created_at` / `started_at` /
+`completed_at` and per-step durations. Shard-balance arithmetic is computed
+directly from the checked-in `crates/rue-cli-tests/shard-weights.json` against
+the LPT assignment in `crates/rue-cli-tests/src/sharding.rs`.
+
+Runs separate cleanly into two populations by whether the corpus actions hit the
+cache: five *warm* runs (CLI corpus step 4–5s) and four *executing* runs (corpus
+step 169–266s).
+
+Limits of this sample, stated up front:
+
+- Raw run logs are not retrievable from this environment (the artifact host is
+  blocked by network policy), so the **internal** composition of the premerge
+  lane is derived structurally — from `test.sh`, `corpus.bzl`, the tier labels,
+  and the Buck rule inventory — not measured per target. Every number attributed
+  to a *job* or *step* below is measured; no number attributed to a target
+  inside the premerge lane is.
+- All sampled pull requests are same-repository branches, so they carried
+  `BUILDBUDDY_API_KEY`. Genuinely cold fork PRs are not represented.
+- Observed queue delay was 2–85s (median 3s). Queue pressure is not currently a
+  constraint and is not a factor in the recommendation.
+
+## Findings
+
+### F1. The fan-out is aimed at a job that has never been the critical path
+
+`premerge (linux-x64)` was the longest job in **9 of 9** runs. The gap between
+it and the slowest CLI shard was 279–576s (median 444s).
+
+| run | event | wall | premerge | slowest shard | slack |
+| --- | --- | --- | --- | --- | --- |
+| 31228627966 | PR (warm) | 478 | 467 | 18 | 449 |
+| 31231601304 | MG (warm) | 478 | 463 | 19 | 444 |
+| 31229045120 | MG (warm) | 462 | 450 | 20 | 430 |
+| 31222559451 | MG (warm) | 483 | 456 | 21 | 435 |
+| 31226836874 | MG (warm) | 350 | 312 | 22 | 290 |
+| 31237682485 | MG (miss) | 571 | 548 | 269 | 279 |
+| 31230794223 | PR (miss) | 820 | 802 | 281 | 521 |
+| 31219956012 | PR (miss) | 848 | 839 | 290 | 549 |
+| 31220565989 | PR (miss) | 895 | 873 | 297 | 576 |
+
+Splitting the CLI corpus four ways has not shortened a required-CI run in this
+sample. It cannot: the shards finish while premerge still has 5–10 minutes left.
+
+### F2. The linux-x64 lane family is 2.6–6.7× off a perfect pack of its own runners
+
+Required CI always spends exactly **eight** linux-x64 job slots on this work:
+`premerge`, four CLI shards, `spec`, `oracle-diff`, `oracle-diff-spec`. Compare
+the observed critical path against a perfect pack of the same eight runners:
+
+| run | event | total lane-seconds | perfect pack | observed max | ratio |
+| --- | --- | --- | --- | --- | --- |
+| 31228627966 | PR (warm) | 560 | 70 | 467 | **6.67×** |
+| 31231601304 | MG (warm) | 577 | 72 | 463 | **6.42×** |
+| 31222559451 | MG (warm) | 577 | 72 | 456 | **6.32×** |
+| 31229045120 | MG (warm) | 572 | 72 | 450 | **6.29×** |
+| 31226836874 | MG (warm) | 426 | 53 | 312 | **5.86×** |
+| 31230794223 | PR (miss) | 2058 | 257 | 802 | **3.12×** |
+| 31219956012 | PR (miss) | 2300 | 288 | 839 | **2.92×** |
+| 31220565989 | PR (miss) | 2487 | 311 | 873 | **2.81×** |
+| 31237682485 | MG (miss) | 1668 | 208 | 548 | **2.63×** |
+
+The runners are already provisioned. The work is already parallel-safe. The
+packing is what is wrong — a single lane holds 27% (miss) to 82% (warm) of all
+the work assigned to eight machines.
+
+### F3. Event type does not predict cache warmth, so event-conditional topology would be wrong
+
+The issue asks whether PR and merge-group topology should differ. The sample
+says no: run 31228627966 is a **warm pull request** (65s of total shard time)
+and 31237682485 is a **cold merge group** (989s). Warmth tracks what the diff
+invalidated, not which event fired.
+
+Conditioning on the event would deselect fan-out on exactly the cold PR runs
+that need it and retain it on warm merge groups that do not. The existing
+`affected-targets` determinator already conditions on the right thing.
+
+### F4. The 25% skew budget is provably unreachable, while real skew reaches 24.9%
+
+`CliShardPlan::validate_skew` rejects an estimated slowest shard more than 25%
+above the mean. Run against the checked-in weights, the estimate is *perfect* at
+every shard count:
+
+```
+ N    max_ms    mean_ms   estimated skew
+ 2   1101488   1101485        0.00%
+ 4    550749    550742        0.00%
+ 8    275375    275371        0.00%
+```
+
+This is structural, not luck. LPT guarantees `max ≤ mean + (1 − 1/N)·w_max`.
+With `w_max` = 28.6s (`cli.examples_lattice::lattice_runs_cross_oracle_selftest`)
+and N = 4, the worst *possible* estimated skew is 3.90%. Breaching 25% would
+require a single case costing ≥ 183.6s — 6.4× the current slowest case. The
+guard cannot fail on real data; it only fires in its own unit test's contrived
+four-case fixture.
+
+Meanwhile the **observed** skew across executing runs was 8.1%, 8.8%, 18.4%, and
+**24.9%** — right at the budget the estimate claims is 0.00%.
+
+The cause is a units mismatch. `estimated_load_ms` sums *serial* per-case cost,
+but a shard's wall time is the makespan of those cases under the harness's own
+internal parallelism (effective ≈ 2.2× on a 4-vCPU runner: 550.7s of planned
+serial load completes in ~247s). Balancing serial sums does not balance parallel
+makespans, and the guard validates the model rather than the outcome.
+
+### F5. Weights drift with no detector
+
+The case corpus declares 1722 case tables across 208 files; the weights file
+carries 1714 entries, and 13 case files have no section in it at all. Unmeasured
+cases silently take `default_ms` (1059). Refresh is a manual human procedure
+(download per-platform JSONL artifacts, run `generate-cli-shard-weights.py`).
+Because F4's guard is vacuous, nothing detects staleness — the estimate stays at
+0.00% skew whatever the weights say.
+
+### F6. The shard count is a constant replicated across 23 files
+
+`CLI_TEST_SHARD_COUNT = 4` in `BUCK` is mirrored by four hand-written matrix
+entries in `ci.yml` (five fields each), by `correctness-repetitions.yml`, and by
+`docs/process/ci.md`. `scripts/validate-cli-shard-coverage.py` (118 lines) plus
+`scripts/test-cli-shard-coverage.py` exist for the sole purpose of asserting
+that two hand-written lists agree. Changing 4 → 2 or 4 → 6 is a multi-file edit
+across BUCK, two workflows, a validator, that validator's tests, and docs.
+
+That gate is real coverage insurance given a hand-written matrix — but the
+hand-written matrix is the thing worth removing, and the gate goes with it.
+
+### F7. Only one corpus can ever be sharded, and the rest serialize on one runner
+
+Sharding is a property of the CLI harness (`RUE_CLI_TEST_SHARD`, `CliShardPlan`,
+`shard-weights.json`, the `rue_cli_shard` label), not of the CI scheduler. The
+repository defines eleven `cached_corpus_suite` corpora. Two have dedicated
+lanes (`spec-tests`, `cli-tests` via its shards) and two more run as their own
+jobs (`oracle-diff-test`, `oracle-diff-spec-test`).
+
+The remaining premerge-tier corpora — `ui-tests`, `reproducible-programs`
+(timeout 1800), `frontend-diff-test` (900), `oracle-diff-generated-smoke` (600),
+`release-smoke` — have no lane. Every one declares `weight_percentage = 100` in
+`corpus.bzl`, meaning each demands the whole machine, so buck2 correctly runs
+them **one at a time inside the single premerge job**, alongside roughly 130
+unit and `sh_test` targets that OSS buck2 re-executes on every run because it
+has no test-result cache.
+
+This is why warm premerge is still 450–467s while every cached corpus costs 4s:
+that lane's cost is cache-immune test execution plus serialized corpora, and it
+is the one lane with no fan-out mechanism available to it.
+
+It is also the scaling answer the issue asks for. Each new independent aspect of
+the toolchain adds another `weight_percentage = 100` corpus to that serial
+queue, extending the critical path by its full wall time, with no way to
+parallelize it short of building a second bespoke shard system next to the CLI
+one.
+
+## Decision
+
+**Reduce** the CLI shard count and **generalize** the mechanism. Do not remove
+sharding: on the four executing runs, a single unsharded CLI corpus projects to
+900–1100s (measured shard sums), which would exceed premerge on the merge-group
+miss run (548s) and become the new critical path. Parallel corpus execution is
+load-bearing; the CLI-specific, hand-maintained expression of it is not.
+
+Note that "how many CLI shards" has no fixed answer, which is itself the
+argument. Two lanes (≈495s) sit under today's 548s merge-group critical path by
+54s. Fix F7 and premerge drops to roughly 300s — at which point two CLI lanes
+are the critical path and three are correct. A constant cannot track that; a
+derivation can.
+
+## Proposed topology
+
+### 1. Move sharding from the harness to the corpus rule
+
+Lift `CliShardPlan` out of `crates/rue-cli-tests` into `rue-test-runner`, beside
+the `ShardSelector` it already uses, and add `shardable = True` to
+`cached_corpus_suite`. Any corpus then declares its own slices with one
+attribute and a per-corpus weights file, reusing the existing `case_timings`
+output for measurement. `spec-tests`, `ui-tests`, `frontend-diff-test`, and the
+oracle differentials become shardable without new machinery.
+
+### 2. Generate the matrix instead of writing it
+
+`affected-targets` already runs before `platform-corpus` and already publishes
+JSON that the corpus jobs consume. Extend it to emit the lane plan, and have
+`platform-corpus` take `strategy.matrix: ${{ fromJSON(needs.affected-targets.outputs.lanes) }}`.
+
+The plan comes from `scripts/plan-ci-lanes.py`: read the live premerge test
+graph from `//test_tiers.bxl`, read measured per-target wall times from a
+checked-in timings file, LPT-pack into lanes, emit the matrix.
+
+This deletes the hand-written matrix, and with it the drift that
+`validate-cli-shard-coverage.py` exists to catch. Its replacement is a stronger
+and simpler assertion: **the union of planned lanes equals the premerge
+selection from the Buck graph**, fail-closed on any target that appears in the
+graph and in no lane. Unknown or newly added targets fail toward running, as
+`scripts/affected-targets` already does.
+
+### 3. Derive the lane count from measurement and a platform floor
+
+    K = clamp(ceil(total_measured_lane_seconds / lane_budget), 1, K_max)
+
+with `lane_budget` set to the cross-platform floor — the native lanes CI cannot
+go below. In this sample `native (linux-arm64)` ran 341–389s and
+`native (macos-arm64)` 184–322s, so a budget near 390s is the honest stopping
+point: driving linux lanes below the ARM64 lane buys nothing. K then grows on
+its own as corpora are added and shrinks when caching improves.
+
+### 4. Balance on observed wall time; guard on observed skew
+
+Feed the packer measured **lane wall times**, not summed serial case costs
+(F4's units bug). Replace `validate_skew` with a post-run check that compares
+observed lane durations against the plan and reports skew in the job summary,
+failing the weights-refresh path — not the contributor's PR — when observed
+skew exceeds budget. Keep LPT; validate it against reality rather than against
+itself.
+
+### 5. Condition on selection, not on event
+
+Keep one topology for `pull_request` and `merge_group` (F3). The determinator
+already deselects unaffected corpora, and a deselected lane already costs only
+spin-up.
+
+### 6. Concrete first move, runner-neutral
+
+Reduce CLI shards 4 → 2 and give the two recovered slots to premerge halves.
+Same eight linux-x64 runners, materially better packing, and it exercises the
+generalized rule on the lane that actually needs it.
+
+## Expected effect, with the Amdahl caveat
+
+The F2 ratios are an **upper bound**, not a forecast. Three floors apply:
+
+- per-job overhead of 13–25s (setup, checkout, dotslash, post) per lane;
+- the largest indivisible test target, which this sample cannot measure;
+- the compiler build, which every premerge lane pays and which does not shard.
+
+That last one dominates cold runs. On run 31230794223 the premerge job was 286s
+of build plus 505s of tests; a four-way split of the *tests* gives
+286 + 126 ≈ 412s, not 200s. On warm runs the build is 6s and the split is nearly
+linear. Fork PRs without the remote cache pay the full build in every lane
+concurrently — parallel, not serial, but real.
+
+Realistic critical path after the first move (F2 sample, premerge halved and CLI
+at two lanes):
+
+| scenario | today | projected |
+| --- | --- | --- |
+| warm merge group | 450–463s | ~240–260s |
+| miss merge group | 548s | ~350–400s |
+| cold pull request | 802–873s | ~550–600s |
+
+Runner cost is unchanged by construction. For reference, CLI shards are
+currently 19.2% of runner-seconds and 10.8% of billed job-minutes across the
+sample; on warm runs four shard jobs bill four minutes to verify ~20s of cached
+stamps.
+
+## What this note does not establish
+
+- The per-target breakdown inside the premerge lane. The split in step 6 is
+  justified by the lane's total and by the structural argument in F7, but the
+  actual cut points need one instrumented run (`buck2 test` with per-target
+  timings, or the existing `ci-timed` job summaries read from a real run).
+- Behavior of genuinely cold fork PRs, which carry no BuildBuddy key.
+- Whether the largest indivisible premerge target sets a floor above the
+  projections above. This is the main risk to step 6 and should be measured
+  before K is tuned.

--- a/docs/notes/rue-1250-shard-topology-analysis.md
+++ b/docs/notes/rue-1250-shard-topology-analysis.md
@@ -4,11 +4,18 @@ Measured reassessment of the four-way CLI corpus sharding introduced by
 RUE-1116 and cost-balanced by RUE-1158, against current cache and
 affected-target behavior.
 
-**Decision: reduce and generalize.** Keep parallel corpus execution — cold runs
-still need it — but stop expressing it as a hand-maintained shard count on one
-harness. The current topology spends its fan-out on the one corpus that caching
-already made cheap, while the actual critical path runs unsharded on a single
-runner.
+**Decision: keep four shards; fix the mechanism around them.** Four is the
+correct count — see "Decision" below, which supersedes an earlier draft of this
+note that recommended reducing to two. That draft measured the shards' slack
+against `premerge`, which is 279–576s ahead of them; but premerge's lead is a
+defect (`rue-1250-premerge-critical-path.md`), and the floor that actually
+governs the CLI corpus is the unshardable native ARM64 lane at 341–407s. At two
+shards the corpus exceeds that floor in 4 of 4 cold runs.
+
+What does need to change is the mechanism: a balance guard that cannot fire, a
+weights file that drifts undetected, and a count replicated by hand across 23
+files — so the right answer has to be re-derived from scratch every time the
+system moves, as this issue did.
 
 ## Method and sample
 
@@ -168,17 +175,37 @@ one.
 
 ## Decision
 
-**Reduce** the CLI shard count and **generalize** the mechanism. Do not remove
-sharding: on the four executing runs, a single unsharded CLI corpus projects to
-900–1100s (measured shard sums), which would exceed premerge on the merge-group
-miss run (548s) and become the new critical path. Parallel corpus execution is
-load-bearing; the CLI-specific, hand-maintained expression of it is not.
+**Keep four.** Reject *reduce*, *remove*, and *conditionalize*.
 
-Note that "how many CLI shards" has no fixed answer, which is itself the
-argument. Two lanes (≈495s) sit under today's 548s merge-group critical path by
-54s. Fix F7 and premerge drops to roughly 300s — at which point two CLI lanes
-are the critical path and three are correct. A constant cannot track that; a
-derivation can.
+The count must be judged against the slowest thing CI cannot shard away, not
+against whatever happens to be slowest today. That is the native ARM64 lane: it
+runs on every event, it is one runner by construction, and it measured 341–407s
+(median 351s) across all nine runs. Against that floor, on the four runs where
+the CLI corpus actually executed:
+
+| shards | corpus wall | exceeds the ARM64 floor |
+| --- | --- | --- |
+| 4 (today) | 269–297s | **0 of 4** |
+| 2 | 450–550s | **4 of 4** |
+| 1 | 900–1100s | 4 of 4 |
+
+Reducing to two would make the CLI corpus the critical path on every cold run
+the moment premerge is fixed. Removing sharding does so immediately.
+
+A derivation confirms the count rather than contradicting it.
+`ceil(total ÷ floor)` gives 3 on all four runs (327–366s per shard), but the
+measured shard skew is 8–25% (F4), and 366s × 1.25 = 458s breaches the 407s
+floor. With a skew allowance, the derivation lands on **4** — which is where the
+constant already is. Nobody had written down why, which is how this issue came
+to ask the question from scratch.
+
+Do not differ topology by event (F3): warmth tracks what the diff invalidated,
+not which event fired, so an event-conditional rule would drop fan-out on
+exactly the cold pull requests that need it.
+
+What remains wrong is the mechanism, not the number. The three defects below
+(F4, F5, F6) are worth fixing on their own terms, and none of them changes the
+count.
 
 ## Proposed topology
 
@@ -233,47 +260,69 @@ Keep one topology for `pull_request` and `merge_group` (F3). The determinator
 already deselects unaffected corpora, and a deselected lane already costs only
 spin-up.
 
-### 6. Concrete first move, runner-neutral
+### 6. Record the derivation next to the constant
 
-Reduce CLI shards 4 → 2 and give the two recovered slots to premerge halves.
-Same eight linux-x64 runners, materially better packing, and it exercises the
-generalized rule on the lane that actually needs it.
+`CLI_TEST_SHARD_COUNT = 4` should carry the reason it is 4 — the ARM64 floor and
+the skew allowance above — so the next reassessment starts from the rule instead
+of rediscovering it. Until step 3 computes the count, the comment is the
+mechanism.
 
-## Expected effect, with the Amdahl caveat
+## What not to do, and why
 
-The F2 ratios are an **upper bound**, not a forecast. Three floors apply:
+The obvious-looking move is to spend CLI shard slack on the premerge lane: same
+eight runners, better packing. Do not. The slack is not real — it exists only
+because premerge is 279–576s ahead, and that lead is a defect rather than a
+budget (`rue-1250-premerge-critical-path.md`). Two measurements close that door:
 
-- per-job overhead of 13–25s (setup, checkout, dotslash, post) per lane;
-- the largest indivisible test target, which this sample cannot measure;
-- the compiler build, which every premerge lane pays and which does not shard.
+- **Premerge does not want more lanes.** Its parallel wall is 268s against a
+  225.6s largest-indivisible-target floor, so target-level fan-out has at most
+  16% to give. Two source-level fixes take the same lane to a ~30s bound with no
+  extra runners at all.
+- **The CLI corpus cannot give lanes up.** At two shards it breaches the ARM64
+  floor in 4 of 4 cold runs.
 
-That last one dominates cold runs. On run 31230794223 the premerge job was 286s
-of build plus 505s of tests; a four-way split of the *tests* gives
-286 + 126 ≈ 412s, not 200s. On warm runs the build is 6s and the split is nearly
-linear. Fork PRs without the remote cache pay the full build in every lane
-concurrently — parallel, not serial, but real.
+Both halves of the trade fail independently. The runner budget is already in the
+right shape; what is mispriced is the work inside one lane.
 
-Realistic critical path after the first move (F2 sample, premerge halved and CLI
-at two lanes):
+The Amdahl caveat that applied to the old proposal is worth keeping for whoever
+revisits lane counts later: per-job overhead is 13–25s per lane, and the
+compiler build does not shard — on run 31230794223 premerge was 286s of build
+plus 505s of tests, so a four-way split of the *tests* would have given
+286 + 126 ≈ 412s, not 200s. Fork PRs without the remote cache pay that build in
+every lane concurrently.
 
-| scenario | today | projected |
+## Expected effect
+
+Keeping the count means required-CI latency is unchanged by this decision. The
+critical path moves when the premerge defects are fixed, and then it lands on the
+native ARM64 lane:
+
+| scenario | today | after the premerge fixes |
 | --- | --- | --- |
-| warm merge group | 450–463s | ~240–260s |
-| miss merge group | 548s | ~350–400s |
-| cold pull request | 802–873s | ~550–600s |
+| warm merge group | 450–463s (premerge) | ~351s (native ARM64) |
+| cold merge group | 548s (premerge) | ~349s (native ARM64) |
+| cold pull request | 802–873s (premerge) | ~390–407s (native ARM64) |
 
-Runner cost is unchanged by construction. For reference, CLI shards are
-currently 19.2% of runner-seconds and 10.8% of billed job-minutes across the
-sample; on warm runs four shard jobs bill four minutes to verify ~20s of cached
-stamps.
+At that point every linux-x64 lane, CLI shards included, sits below the floor,
+and the next honest CI question is about the native lanes rather than about
+sharding.
+
+For cost reference: CLI shards are 19.2% of runner-seconds and 10.8% of billed
+job-minutes across the sample. On warm runs four shard jobs bill four minutes to
+verify ~20s of cached stamps — the price of the cold-run insurance the table in
+"Decision" prices, and cheap against a wrong answer there.
 
 ## What this note does not establish
 
-- The per-target breakdown inside the premerge lane. The split in step 6 is
-  justified by the lane's total and by the structural argument in F7, but the
-  actual cut points need one instrumented run (`buck2 test` with per-target
-  timings, or the existing `ci-timed` job summaries read from a real run).
-- Behavior of genuinely cold fork PRs, which carry no BuildBuddy key.
-- Whether the largest indivisible premerge target sets a floor above the
-  projections above. This is the main risk to step 6 and should be measured
-  before K is tuned.
+- **Reliability.** The acceptance criteria ask for it and this note does not
+  supply it. One `merge_group` run in the sample failed (31225370145); it was
+  not investigated, and no flake rate was computed for the shards. The weekly
+  `correctness-repetitions.yml` workflow already owns that signal and is the
+  right place to read it from, not a nine-run sample.
+- Behavior of genuinely cold fork PRs, which carry no BuildBuddy key — every
+  sampled pull request was a same-repository branch.
+- Whether the ARM64 floor is itself reducible. It is treated here as fixed
+  because it is one runner by construction, but nothing in this note measures
+  what it spends its 341–407s on. If it were reduced, the shard-count derivation
+  would need re-running against the new floor — which is the argument for
+  computing the count rather than pinning it.

--- a/docs/notes/rue-1250-shard-topology-analysis.md
+++ b/docs/notes/rue-1250-shard-topology-analysis.md
@@ -315,6 +315,96 @@ job-minutes across the sample. On warm runs four shard jobs bill four minutes to
 verify ~20s of cached stamps — the price of the cold-run insurance the table in
 "Decision" prices, and cheap against a wrong answer there.
 
+## End state, and what the packer's objective should be
+
+Modelling all three changes together — derived shard count, `scaling-matrix-test`
+de-duplicated, and the pressure test reduced to its measured floor — against the
+nine sampled runs, using each run's *own* build-step and suite-step durations:
+
+| event | critical path today | after | driver after |
+| --- | --- | --- | --- |
+| pull_request (median) | 820s | **388s** | native (linux-arm64) |
+| merge_group (median) | 456s | **342s** | native (linux-arm64) |
+| whole-sample range | 341–873s | **341–407s** | native in **9 of 9** |
+
+Two things matter more than the headline reduction. First, **no linux-x64 lane is
+the bottleneck in any run any more** — including the cold-build pull requests,
+where premerge lands at 354–393s, just under the ARM64 lane. Second, the spread
+collapses from 2.6× to 1.19×, so the merge queue becomes predictable rather than
+merely faster.
+
+That changes what a packer should optimize. Once every linux lane sits under a
+floor set elsewhere, **minimizing makespan is the wrong objective** — work
+already finishes before the floor, so the remaining gain is zero. The right
+objective is to *minimize runners subject to the slowest lane staying under the
+floor*: bin-packing under a capacity constraint, not makespan across fixed bins.
+The two produce different answers, and only the second can conclude "use fewer".
+
+### Three regimes, measured
+
+Solving `build + work/K + overhead ≤ floor` per run, with the ARM64 lane as the
+floor and each run's measured build cost:
+
+| regime | runs | poolable linux-x64 work | lanes needed | lanes today |
+| --- | --- | --- | --- | --- |
+| build warm, corpus warm | 5 of 9 | 42–66s | **1** | 8 |
+| build warm, corpus cold | 1 of 9 | 1073s | **4** | 8 |
+| build cold | 3 of 9 | 1208–1570s | 14–21 (unreachable) | 8 |
+
+Read the third row as a boundary rather than a target. A cold build costs
+286–317s of a 387–407s floor, leaving 75–88s of per-lane budget, so each
+additional runner buys almost nothing and no lane count reaches the floor. **When
+the per-lane fixed cost approaches the floor, the answer is to attack the fixed
+cost, not to add lanes** — a packer that only knows how to add runners would ask
+for 21 of them here and still miss.
+
+Note also what "build cold" correlates with: all three were compiler-crate
+changes, which invalidate most of the graph. That is the common case for this
+repository's work, not an anomaly.
+
+(The lane-count model assumes every lane pays the premerge build in full, which
+overstates the fixed cost for corpus-only lanes. Treat the regimes as directional
+and the ordering as the result.)
+
+### The property that makes it robust
+
+Cost concentration, not imbalance, is what defeats a packer — and it is invisible
+to one that reasons only about totals. A packer given the pre-fix premerge lane
+would have happily requested eight runners for a workload where one item was
+225.6s, and reported success while changing nothing.
+
+So the load-bearing requirement is an alarm, not an algorithm: **when the largest
+indivisible item exceeds the floor, the planner must fail loudly, name the item,
+and refuse to express the problem as a lane count.** Its remedies are the three
+this repository already has — split the item (the CLI corpus's intra-target
+sharding), cache it (RUE-1118's action-stamp pattern), or re-tier it (the canary
+plus `slow`/`stress` split). Choosing among them is a human call; noticing is
+not, and that alarm is what would have surfaced RUE-1262 the day it landed.
+
+Two smaller properties follow from the same idea. The planner should **name its
+binding constraint on every run** — the reason this issue had to ask about CLI
+shards at all is that nothing in CI said what the critical path was. And the
+balance guard should **compare observed lane walls to plan**, since stale weights
+surface as skew and skew is the signal to refresh.
+
+The pieces already exist: `affected-targets` runs first and emits JSON the matrix
+consumes, `ci-timed` records per-command wall time and cache-hit rates, and
+`cache-probe.yml` tracks cache health on a schedule. What is missing is the
+arithmetic between them.
+
+### What this promotes to next
+
+Finishing this work does not end the question, it moves it. Two constraints
+inherit the critical path, and neither is in RUE-1250's scope:
+
+- **The native ARM64 lane, 341–407s, in 9 of 9 runs.** It is one runner by
+  construction and this note never measured what it spends that time on.
+- **The compiler build, 286–317s whenever a compiler crate changes.** It does not
+  shard, so it caps what any linux topology can achieve.
+
+Both are worth measuring the way the premerge lane was measured, before anyone
+proposes a topology for them.
+
 ## What this note does not establish
 
 - **Reliability.** The acceptance criteria ask for it and this note does not

--- a/docs/notes/rue-1250-shard-topology-analysis.md
+++ b/docs/notes/rue-1250-shard-topology-analysis.md
@@ -17,6 +17,9 @@ weights file that drifts undetected, and a count replicated by hand across 23
 files — so the right answer has to be re-derived from scratch every time the
 system moves, as this issue did.
 
+The premerge defect is tracked separately as **RUE-1262**; it is the change that
+actually moves required-CI latency, and it costs no extra runners.
+
 ## Method and sample
 
 Nine `CI` runs from 2026-08-07/08 (four `pull_request`, five `merge_group`),


### PR DESCRIPTION
Answers the sharding reassessment (refs RUE-1250) with a measured decision, and raises it into an ADR because the measurements say the interesting question is not the one that was asked.

Docs only. No workflow, BUCK, or source changes.

## The decision RUE-1250 asked for

**Keep four CLI shards.** Reject reduce, remove, and conditionalize-by-event.

The count has to be judged against the slowest thing CI cannot shard away, which is the native ARM64 lane — one runner by construction, 341–407s on every run. On the four sampled runs where the corpus actually executed:

| shards | corpus wall | breaches the ARM64 floor |
| --- | --- | --- |
| 4 (today) | 269–297s | 0 of 4 |
| 2 | 450–550s | 4 of 4 |
| 1 | 900–1100s | 4 of 4 |

A derivation confirms the constant rather than contradicting it: `ceil(total ÷ floor)` gives 3, but measured shard skew is 8–25% and 366s × 1.25 breaches the 407s floor, so with a skew allowance it lands on 4. Nobody had written that reasoning down, which is how the question came to be re-asked from scratch.

An earlier draft in this branch recommended reducing to two. That draft measured the shards' slack against `premerge`, which is 279–576s ahead of them — and that lead turned out to be a defect rather than a budget. The notes record the correction rather than hiding it.

## Why this became an ADR

Profiling the lanes the shards were being compared against found the actual critical path, and it is not a topology problem:

- `premerge (linux-x64)` was the longest job in **9 of 9** runs. It runs 80 targets; two are **81.4%** of it.
- `//crates/rue-compiler:scaling-matrix-test` is a strict superset of `rue-compiler-test` — 816 tests versus 813, all 813 shared. The lane runs those 813 twice to gain three.
- Both native lanes are one step, and that step is **99.1%** `rue-compiler-test` — against `docs/process/ci.md:46`, which states the native lanes deliberately do not repeat the broad unit suite, while `scripts/validate-ci-gate.py:204` pins the repetition in place.
- Inside that target, **one test function is 181.7s** against a 5.7s runner-up. It is compiled into two targets and runs on three platforms: four executions per run, together 56–59% of the critical path.

Sharding cannot touch this. Partitioning those 813 tests four ways gives 3.4s / 6.8s / 7.2s / **227.0s**, and cost-balancing cannot do better when one item weighs 181.7s against ~44s of everything else. Tracked as RUE-1262.

## What the ADR proposes

Rue has three good mechanisms — the determinator (RUE-1119), cacheable corpus actions (RUE-1118), and sharding (RUE-1116/RUE-1158) — each applied to a different hand-picked subset and composed in the reverse of their cost order. ADR-0069 adopts a uniform model: every unit of CI work is a Buck target carrying its own tier and platform scope, no workflow file names a target, and every lane is a generated selection over the live graph.

It also names the property that makes this repository different from the systems those mechanisms were designed for. **The compiler is a universal dependency, so change-based selection and input-keyed caching share a blind spot covering the dominant change class.** That is measured from both directions: RUE-1130 records zero deselections across 9 runs × 18 corpus jobs, and a third of the runs sampled here rebuild the compiler from cold. Two consequences follow — sharding is load-bearing rather than obsolete, and eliminating duplicated work outranks both other mechanisms because it is the only lever that pays in every regime.

## How it fits the CI Improvements project

The six phases map onto issues that already exist, and the ADR follows their stated constraints rather than re-litigating them:

| phase | issue |
| --- | --- |
| 1. Eliminate the duplicated critical path | RUE-1262 |
| 2. Duplication gate | new |
| 3. Platform scope as a target attribute | new (RUE-1262 scope C) |
| 4. Determinator plans every lane and reports its regime | RUE-1130 |
| 5. Real input-keyed compile actions | RUE-1164 (milestone "Buck-native test actions"), RUE-1222 |
| 6. Floor-aware packer with an indivisible-item alarm | new |

Notably, phase 5 follows RUE-1164's explicit constraint — *do not use an aggregate success-stamp action as the destination* — rather than generalizing RUE-1118's stamp, which that issue already designates as evidence rather than design authority. RUE-1131 is adjacent: it is the same fixed-cost problem the ADR names in the compiler-cold regime.

## Projected effect

Phase 1 alone, modelled against the nine runs using each run's own step durations: `pull_request` median critical path 820s → 361s, `merge_group` 456s → 185s, whole-sample range 341–873s → 170–393s. Afterwards the binding constraint is distributed across `valgrind`, the cold compiler build, reproducibility, and one CLI shard rather than concentrated in one function.

## What this does not establish

- **Reliability**, which RUE-1250 lists in its acceptance criteria. Nine runs over two days compute no flake rate; `correctness-repetitions.yml` is the right source. RUE-1250 is referenced rather than closed for this reason.
- Per-target measurement on real ARM64 and macOS runners. Those lanes were profiled by step; the 99.1% concentration is inferred from target composition measured on x86-64.
- Behaviour of genuinely cold fork PRs, which carry no BuildBuddy key.

## Validation

`//:adr-registry-validation`, `//:repository-quality-gates`, and `//:tutorial-snippet-tests` pass (4/4). ADR index regenerated with `scripts/validate-adrs.py --write`; registry valid at 70 records.

Refs RUE-1250. Refs RUE-1262. Related to RUE-1164, RUE-1130, RUE-1131, RUE-1222.


---
_Generated by [Claude Code](https://claude.ai/code/session_01AjuvbCasMPCxH9y1hA1Qbr)_