### PR TITLE
Discover query reuse candidates one pin at a time

### DIFF
--- a/crates/rue-query/src/lib.rs
+++ b/crates/rue-query/src/lib.rs
@@ -2605,8 +2605,8 @@ enum InterposeSite {
     /// A joiner has transferred waiter protection into a pin and decremented the
     /// waiter count.
     JoinHandoff,
-    /// Reuse candidates have been discovered and pinned under the node lock,
-    /// before recursive validation releases the lock.
+    /// The first reuse candidate has been discovered and pinned under the node
+    /// lock, before recursive validation releases the lock.
     ReuseDiscovered,
     /// A node joiner observed a still-computing attempt and live cancellation
     /// token while holding the predicate lock, immediately before parking.
@@ -4514,36 +4514,57 @@ where
                 Compute { attempt: u64 },
             }
 
-            // Acquire a protective pin on every reuse candidate while it is still
-            // retained under the node lock, before releasing the lock to validate.
-            // A candidate discovered here therefore cannot be evicted in the
-            // window between discovery and either lease transfer (on a validated
-            // reuse) or release (on a stale candidate): its pin holds it retained
-            // through the recursive validation that follows.
-            let candidates = {
-                let state = lock(&node.state);
-                state
-                    .attempts
-                    .iter()
-                    .rev()
-                    .filter_map(|attempt| match &attempt.state {
-                        AttemptState::Terminal {
-                            terminal, handoffs, ..
-                        } => Some((
-                            attempt.id,
-                            handoffs.clone(),
-                            self.pin_terminal(terminal)
-                                .expect("a family pins its own retained terminal"),
-                        )),
-                        AttemptState::Computing { .. } => None,
-                    })
-                    .collect::<Vec<_>>()
-            };
+            // Acquire a protective pin on the reuse candidate about to be
+            // validated while it is still retained under the node lock, before
+            // releasing the lock to validate. A candidate discovered here
+            // therefore cannot be evicted in the window between discovery and
+            // either lease transfer (on a validated reuse) or release (on a
+            // stale candidate): its pin holds it retained through the recursive
+            // validation that follows.
+            //
+            // Discovery is one candidate at a time, newest first, because the
+            // walk below returns on the first validated candidate. Pinning the
+            // node's whole retained set up front instead costs one pin per
+            // attempt the node has ever accumulated and releases all but one
+            // immediately, and every surplus release runs a family and runtime
+            // retention enforcement pass. That makes a single request O(retained
+            // attempts) and a session which republishes the same keys across
+            // revisions quadratic in its revision count (RUE-1262).
+            //
+            // `cursor` is the id of the last candidate examined; attempt ids
+            // ascend with publication, so selecting the greatest terminal id
+            // below it walks the same newest-first order the snapshot did. A
+            // candidate evicted before the cursor reaches it was unprotected by
+            // definition, and missing it costs an ordinary recompute rather
+            // than a wrong answer.
+            let mut cursor = u64::MAX;
             #[cfg(test)]
-            if !candidates.is_empty() {
-                self.core.interpose(InterposeSite::ReuseDiscovered);
-            }
-            for (attempt_id, handoffs, pin) in candidates {
+            let mut discovered = false;
+            loop {
+                let candidate = {
+                    let state = lock(&node.state);
+                    state.attempts.iter().rev().find_map(|attempt| {
+                        match (attempt.id < cursor).then_some(&attempt.state) {
+                            Some(AttemptState::Terminal {
+                                terminal, handoffs, ..
+                            }) => Some((
+                                attempt.id,
+                                handoffs.clone(),
+                                self.pin_terminal(terminal)
+                                    .expect("a family pins its own retained terminal"),
+                            )),
+                            Some(AttemptState::Computing { .. }) | None => None,
+                        }
+                    })
+                };
+                let Some((attempt_id, handoffs, pin)) = candidate else {
+                    break;
+                };
+                cursor = attempt_id;
+                #[cfg(test)]
+                if !std::mem::replace(&mut discovered, true) {
+                    self.core.interpose(InterposeSite::ReuseDiscovered);
+                }
                 let terminal = pin.terminal().clone();
                 let endorsement_enabled =
                     self.inner.evaluator.is_some() && task.validation_endorsements_active();
@@ -4581,8 +4602,9 @@ where
                         if observe_result || endorse {
                             self.lease_observed_pin(&task, pin);
                         }
-                        // A stale candidate's pin (or an unobserved validation
-                        // reuse) drops with `pin`/`candidates`, releasing it.
+                        // An unobserved validation reuse drops `pin` here,
+                        // releasing it, as a stale candidate does at the end of
+                        // its own iteration.
                         return TaskQueryResult::Terminal {
                             terminal,
                             execution: RequestExecution::Reused,
@@ -14166,6 +14188,77 @@ mod tests {
             computes.load(Ordering::SeqCst),
             1,
             "the candidate was reused throughout, never detached and recomputed"
+        );
+    }
+
+    // 3b. Reuse discovery cost: the window pin above protects the candidate
+    //     being validated, and the walk returns on the first candidate that
+    //     validates. Taking that pin on every retained attempt instead makes one
+    //     request O(retained attempts) — and because each surplus release is the
+    //     last pin on its terminal, each one also runs a retention enforcement
+    //     pass. A session which republishes the same key across revisions then
+    //     pays quadratically in its revision count (RUE-1262). The enforcement
+    //     counter observes exactly that, so measuring one reuse at two retained
+    //     depths separates per-request cost from history size.
+    #[test]
+    fn reuse_discovery_cost_is_independent_of_retained_attempt_depth() {
+        fn enforcements_for_one_reuse(depth: u64) -> u64 {
+            let runtime = QueryRuntime::new(1);
+            let input = InputIdentity::new("source", "reuse-depth");
+            // A bound far above `depth`: the node is meant to legitimately keep
+            // every attempt, so nothing here is reclaimed before the reuse.
+            let family = runtime.family::<Key, u64>("reuse-depth", 4096).unwrap();
+            for stamp in 1..=depth {
+                let revision = Revision::new(stamp, 1);
+                runtime
+                    .publish_revision(revision, [(input.clone(), stamp)])
+                    .unwrap();
+                let observed = input.clone();
+                runtime
+                    .query(
+                        &family,
+                        revision,
+                        Key("same"),
+                        CancellationToken::new(),
+                        move |context| {
+                            context.input(observed)?;
+                            Ok(QueryOutput::success(stamp))
+                        },
+                    )
+                    .unwrap();
+            }
+
+            // A successor revision which changes nothing: the newest attempt is
+            // the first candidate examined, and it validates.
+            let reuse = Revision::new(depth + 1, 1);
+            runtime
+                .publish_revision(reuse, [(input.clone(), depth)])
+                .unwrap();
+            let before = runtime.metrics();
+            let observed = input.clone();
+            runtime
+                .query(
+                    &family,
+                    reuse,
+                    Key("same"),
+                    CancellationToken::new(),
+                    move |context| {
+                        context.input(observed)?;
+                        unreachable!("the newest retained attempt is still valid")
+                    },
+                )
+                .unwrap();
+            let after = runtime.metrics();
+            assert_eq!(after.reuses - before.reuses, 1);
+            assert_eq!(after.claims - before.claims, 0);
+            after.retention_enforcements - before.retention_enforcements
+        }
+
+        let shallow = enforcements_for_one_reuse(4);
+        let deep = enforcements_for_one_reuse(32);
+        assert_eq!(
+            deep, shallow,
+            "one reuse costs the same whether the node retains 4 attempts or 32"
         );
     }
 


### PR DESCRIPTION
This follows the "Lead, not a claim" section of RUE-1262, which asked whether
the quadratic curve in
`pipeline_tests::failed_wide_batches_release_their_unpublished_child_cones_under_pressure`
was test cost or a real scaling characteristic of the retention/eviction
machinery. It is the latter, and it is fixed here. Refs RUE-1262.

## What the curve was

Reuse-candidate discovery in `QueryFamily::query_task_impl` pinned *every*
retained terminal attempt on a node before validating any of them, while the
walk immediately below returns on the first candidate that validates. Every
surplus pin was therefore released within the same request, and because each
surplus pin was the last pin on its terminal, each release ran a family
retention enforcement pass plus a full cross-family runtime charge
aggregation — one mutex acquisition per live family.

That makes a single request O(retained attempts) instead of O(candidates
examined). A session which republishes the same keys across revisions
accumulates one attempt per revision per node, so its cost is quadratic in
its revision count.

Measured per compile in the pressure test, with the compiler's own work held
constant (~388,600 node requests per compile every time):

| compile | pins taken per compile | last-pin releases | seconds |
| -- | -- | -- | -- |
| 1 | 490,734 | 328 | 6.0 |
| 3 | 695,594 | 104,050 | 8.2 |
| 5 | 900,450 | 308,833 | 10.1 |
| 8 | 1,002,878 | 615,834 | 12.9 |

Pins per request grew by ~102,400 per compile while the workload did not.
This is the non-plateauing behaviour the issue flagged: retention is capped
at 256 attempts per session-side ledger, but the per-node attempt history the
discovery snapshot walks is not what that cap bounds.

## The change

Discover candidates one at a time, newest first, using a descending
attempt-id cursor. Attempt ids ascend with publication, so the cursor walks
the same order the snapshot did, and each pin is still acquired under the
node lock that discovered it — the discovery-to-validation window the pin
exists to close is unchanged. A candidate evicted before the cursor reaches
it was unprotected by definition, so missing it costs an ordinary recompute
rather than a wrong answer.

## Effect

`failed_wide_batches_release_their_unpublished_child_cones_under_pressure`:
**215.5s to 94.6s**, and per-compile time is now flat at ~5.8s instead of
climbing from 6.0s to 12.9s across eight compiles. The whole
`//crates/rue-compiler:rue-compiler-test` target goes from 3m45s+ to 2m01s.

Behaviour is unchanged: across the same 8-compile run, claims, reuses, joins,
body completions, evictions, retention scan entries, validation memo hits and
misses, and red/green publications are all identical before and after.

## Tests

New `reuse_discovery_cost_is_independent_of_retained_attempt_depth` measures
one reuse at two retained depths and asserts the enforcement-pass count does
not track depth. Verified against the previous code, where it fails with 32
passes at depth 32 versus 4 at depth 4 — exactly linear in history size.

Locally green: `//crates/rue-query/...` (132 tests),
`//crates/rue-compiler:rue-compiler-test` (813 tests), and `scripts/rue
premerge` (82 targets, 0 failures).

## Not addressed here

The ~5.8s that remains per compile is a large linear constant — roughly
101,200 query claims and 7.16M retention scan entries to compile a
33-function chain. That is what now sets the test's floor, and it is
independent of this fix and of the issue's scope A and B.
