### PR TITLE
Apply affected-target determination to every CI lane

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -236,10 +236,13 @@ jobs:
       # and building its test binaries is the cost this narrowing exists to
       # avoid — measured at 286-317s whenever a compiler crate changes.
       - name: Build all targets
+        env:
+          NARROW_COUNT: ${{ steps.narrow.outputs.count }}
+          NARROW_FILE: ${{ steps.narrow.outputs.file }}
         run: |
           set -euo pipefail
-          if [ "${{ steps.narrow.outputs.count }}" -gt 0 ]; then
-            mapfile -t targets <"${{ steps.narrow.outputs.file }}"
+          if [ "$NARROW_COUNT" -gt 0 ]; then
+            mapfile -t targets <"$NARROW_FILE"
             scripts/ci-timed "linux-x64 build (narrowed)" -- ./buck2 build "${targets[@]}"
           else
             scripts/ci-timed "linux-x64 build" -- ./buck2 build //crates/...
@@ -396,6 +399,10 @@ jobs:
       # expensive part and an unimpacted one has nothing to prove.
       - name: Run native backend, linker, runtime, ABI, allocator, and target tests
         if: steps.sel.outputs.run == 'true'
+        env:
+          NARROW_COUNT: ${{ steps.narrow.outputs.count }}
+          NARROW_FILE: ${{ steps.narrow.outputs.file }}
+          LANE_NAME: ${{ matrix.name }}
         run: |
           set -euo pipefail
           targets=(
@@ -408,14 +415,14 @@ jobs:
             //crates/rue-allocator:rue-allocator-test
             //crates/rue-target:rue-target-test
           )
-          if [ "${{ steps.narrow.outputs.count }}" -gt 0 ]; then
-            mapfile -t targets < <(scripts/affected-targets intersect "${{ steps.narrow.outputs.file }}" "${targets[@]}")
+          if [ "$NARROW_COUNT" -gt 0 ]; then
+            mapfile -t targets < <(scripts/affected-targets intersect "$NARROW_FILE" "${targets[@]}")
           fi
           if [ "${#targets[@]}" -eq 0 ]; then
             echo "native units: no impacted unit targets on this diff; the merge-queue run covers them."
             exit 0
           fi
-          scripts/ci-timed "${{ matrix.name }} native units" -- ./buck2 test "${targets[@]}"
+          scripts/ci-timed "$LANE_NAME native units" -- ./buck2 test "${targets[@]}"
 
       - name: Run every declaratively platform-scoped spec and CLI case
         if: steps.sel.outputs.run == 'true'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -281,17 +281,33 @@ jobs:
             name: macos-arm64
     runs-on: ${{ matrix.os }}
     name: native (${{ matrix.name }})
+    if: ${{ always() }}
+    needs: affected-targets
     steps:
       - uses: actions/checkout@v6
 
+      # RUE-1130: consult the determinator before any heavy setup. On a
+      # selective pull_request run where nothing this lane executes is affected,
+      # the heavy steps are skipped and the check still reports success, so no
+      # branch-protection change is required. Fail-open: unless the determinator
+      # explicitly says full=false and omits this lane, the lane runs.
+      - name: Lane selection
+        id: sel
+        env:
+          RUE_AFFECTED_FULL: ${{ needs.affected-targets.outputs.full }}
+          RUE_AFFECTED_LANES: ${{ needs.affected-targets.outputs.selected_lanes }}
+        run: scripts/ci-corpus-decision "native-${{ matrix.name }}"
+
       - name: Select Xcode 16.2
-        if: runner.os == 'macOS'
+        if: runner.os == 'macOS' && steps.sel.outputs.run == 'true'
         run: sudo xcode-select -s /Applications/Xcode_16.2.app
 
       - name: Install dotslash
+        if: steps.sel.outputs.run == 'true'
         uses: facebook/install-dotslash@v2  # pinned: the moving `latest` branch broke macOS runners (sha256sum flags) on 2026-06-18
 
       - name: Cache dotslash artifacts
+        if: steps.sel.outputs.run == 'true'
         uses: actions/cache@v5
         with:
           path: |
@@ -302,6 +318,7 @@ jobs:
             dotslash-${{ matrix.name }}-
 
       - name: Provision remote build cache
+        if: steps.sel.outputs.run == 'true'
         env:
           BUILDBUDDY_API_KEY: ${{ secrets.BUILDBUDDY_API_KEY }}
         run: |
@@ -313,9 +330,11 @@ jobs:
           scripts/provision-build-cache apply
 
       - name: Build native compiler and linker
+        if: steps.sel.outputs.run == 'true'
         run: scripts/ci-timed "${{ matrix.name }} native build" -- ./buck2 build //crates/rue:rue
 
       - name: Run native backend, linker, runtime, ABI, allocator, and target tests
+        if: steps.sel.outputs.run == 'true'
         run: >-
           scripts/ci-timed "${{ matrix.name }} native units" --
           ./buck2 test
@@ -329,18 +348,22 @@ jobs:
           //crates/rue-target:rue-target-test
 
       - name: Run every declaratively platform-scoped spec and CLI case
+        if: steps.sel.outputs.run == 'true'
         # The shared manifest selector registers all `only_on` cases for this
         # host, including cases added later, without repeating either complete
         # target-independent corpus.
         run: scripts/ci-timed "${{ matrix.name }} platform corpus" -- scripts/run-native-platform-corpus.sh
 
       - name: Run native ABI programs
+        if: steps.sel.outputs.run == 'true'
         run: scripts/ci-timed "${{ matrix.name }} ABI" -- scripts/rue cli abi
 
       - name: Run native linker programs
+        if: steps.sel.outputs.run == 'true'
         run: scripts/ci-timed "${{ matrix.name }} linker" -- scripts/rue cli cli.linker
 
       - name: Run native filesystem and platform programs
+        if: steps.sel.outputs.run == 'true'
         run: scripts/ci-timed "${{ matrix.name }} platform" -- scripts/rue cli cli.fs_file_io
 
   # RUE-617/RUE-1019: keep the byte-reproducibility proof independent of the
@@ -350,13 +373,29 @@ jobs:
   compiler-reproducibility:
     runs-on: ubuntu-latest
     name: compiler reproducibility (linux-x64)
+    if: ${{ always() }}
+    needs: affected-targets
     steps:
       - uses: actions/checkout@v6
 
+      # RUE-1130: consult the determinator before any heavy setup. On a
+      # selective pull_request run where nothing this lane executes is affected,
+      # the heavy steps are skipped and the check still reports success, so no
+      # branch-protection change is required. Fail-open: unless the determinator
+      # explicitly says full=false and omits this lane, the lane runs.
+      - name: Lane selection
+        id: sel
+        env:
+          RUE_AFFECTED_FULL: ${{ needs.affected-targets.outputs.full }}
+          RUE_AFFECTED_LANES: ${{ needs.affected-targets.outputs.selected_lanes }}
+        run: scripts/ci-corpus-decision "compiler-reproducibility"
+
       - name: Install dotslash
+        if: steps.sel.outputs.run == 'true'
         uses: facebook/install-dotslash@v2  # pinned: the moving `latest` branch broke macOS runners (sha256sum flags) on 2026-06-18
 
       - name: Cache dotslash artifacts
+        if: steps.sel.outputs.run == 'true'
         uses: actions/cache@v5
         with:
           path: ~/.cache/dotslash
@@ -365,6 +404,7 @@ jobs:
             dotslash-linux-x64-
 
       - name: Verify compiler build reproducibility
+        if: steps.sel.outputs.run == 'true'
         id: compiler_repro
         run: scripts/ci-timed "compiler reproducibility" -- ./scripts/check-reproducible-compiler.sh
 
@@ -570,15 +610,31 @@ jobs:
   release:
     runs-on: ubuntu-latest
     name: release (linux-x64)
+    if: ${{ always() }}
+    needs: affected-targets
     steps:
       - uses: actions/checkout@v6
 
+      # RUE-1130: consult the determinator before any heavy setup. On a
+      # selective pull_request run where nothing this lane executes is affected,
+      # the heavy steps are skipped and the check still reports success, so no
+      # branch-protection change is required. Fail-open: unless the determinator
+      # explicitly says full=false and omits this lane, the lane runs.
+      - name: Lane selection
+        id: sel
+        env:
+          RUE_AFFECTED_FULL: ${{ needs.affected-targets.outputs.full }}
+          RUE_AFFECTED_LANES: ${{ needs.affected-targets.outputs.selected_lanes }}
+        run: scripts/ci-corpus-decision "release"
+
       - name: Install dotslash
+        if: steps.sel.outputs.run == 'true'
         uses: facebook/install-dotslash@v2  # pinned: the moving `latest` branch broke macOS runners (sha256sum flags) on 2026-06-18
 
       # Same dotslash cache as the other jobs (buck2 binary only; see the `test`
       # job for why buck-out isn't worth caching).
       - name: Cache dotslash artifacts
+        if: steps.sel.outputs.run == 'true'
         uses: actions/cache@v5
         with:
           path: |
@@ -591,6 +647,7 @@ jobs:
       # BuildBuddy remote action cache (RUE-316/RUE-1006); see the clippy job
       # for the secret-availability contract.
       - name: Provision remote build cache
+        if: steps.sel.outputs.run == 'true'
         env:
           BUILDBUDDY_API_KEY: ${{ secrets.BUILDBUDDY_API_KEY }}
         run: |
@@ -605,12 +662,14 @@ jobs:
       # of inferring optimization from complete binary bytes. This performs no
       # compilation and also pins the release callers to the target platform.
       - name: Validate release configuration
+        if: steps.sel.outputs.run == 'true'
         run: scripts/ci-timed "release configuration" -- scripts/validate-release-configuration.py
 
       # Builds only the Rue driver and CLI harness under the release platform,
       # then runs the 24 representative differential-opt cases (96 produced
       # programs across -O0/-O1/-O2/-O3) through the release-built compiler.
       - name: Run focused release smoke
+        if: steps.sel.outputs.run == 'true'
         run: scripts/ci-timed "release smoke" -- ./buck2 test //:release-smoke --target-platforms //platforms:release
 
   # Generated-code memory safety under Valgrind. Required PR and merge-group
@@ -619,13 +678,29 @@ jobs:
   valgrind:
     runs-on: ubuntu-latest
     name: valgrind (linux-x64)
+    if: ${{ always() }}
+    needs: affected-targets
     steps:
       - uses: actions/checkout@v6
 
+      # RUE-1130: consult the determinator before any heavy setup. On a
+      # selective pull_request run where nothing this lane executes is affected,
+      # the heavy steps are skipped and the check still reports success, so no
+      # branch-protection change is required. Fail-open: unless the determinator
+      # explicitly says full=false and omits this lane, the lane runs.
+      - name: Lane selection
+        id: sel
+        env:
+          RUE_AFFECTED_FULL: ${{ needs.affected-targets.outputs.full }}
+          RUE_AFFECTED_LANES: ${{ needs.affected-targets.outputs.selected_lanes }}
+        run: scripts/ci-corpus-decision "valgrind"
+
       - name: Install dotslash
+        if: steps.sel.outputs.run == 'true'
         uses: facebook/install-dotslash@v2  # pinned: the moving `latest` branch broke macOS runners (sha256sum flags) on 2026-06-18
 
       - name: Cache dotslash artifacts
+        if: steps.sel.outputs.run == 'true'
         uses: actions/cache@v5
         with:
           path: ~/.cache/dotslash
@@ -634,6 +709,7 @@ jobs:
             dotslash-linux-x64-
 
       - name: Provision remote build cache
+        if: steps.sel.outputs.run == 'true'
         env:
           BUILDBUDDY_API_KEY: ${{ secrets.BUILDBUDDY_API_KEY }}
         run: |
@@ -645,14 +721,17 @@ jobs:
           scripts/provision-build-cache apply
 
       - name: Install valgrind
+        if: steps.sel.outputs.run == 'true'
         run: |
           sudo apt-get update
           sudo apt-get install -y valgrind
 
       - name: Build Rue compiler
+        if: steps.sel.outputs.run == 'true'
         run: ./buck2 build //crates/rue:rue
 
       - name: Run programs under Valgrind memcheck
+        if: steps.sel.outputs.run == 'true'
         env:
           RUE_SANITIZER_LARGE_PROGRAMS: ${{ github.event_name == 'workflow_dispatch' && inputs.large_program || 'none' }}
         run: scripts/run-sanitizer.sh
@@ -664,15 +743,31 @@ jobs:
     name: asan (linux-x64)
     env:
       NIGHTLY: nightly-2026-04-13
+    if: ${{ always() }}
+    needs: affected-targets
     steps:
       - uses: actions/checkout@v6
 
+      # RUE-1130: consult the determinator before any heavy setup. On a
+      # selective pull_request run where nothing this lane executes is affected,
+      # the heavy steps are skipped and the check still reports success, so no
+      # branch-protection change is required. Fail-open: unless the determinator
+      # explicitly says full=false and omits this lane, the lane runs.
+      - name: Lane selection
+        id: sel
+        env:
+          RUE_AFFECTED_FULL: ${{ needs.affected-targets.outputs.full }}
+          RUE_AFFECTED_LANES: ${{ needs.affected-targets.outputs.selected_lanes }}
+        run: scripts/ci-corpus-decision "asan"
+
       - name: Install pinned nightly Rust
+        if: steps.sel.outputs.run == 'true'
         run: >
           rustup toolchain install "$NIGHTLY" --profile minimal
           --component clippy,rust-src
 
       - name: Clippy the ASan harness
+        if: steps.sel.outputs.run == 'true'
         env:
           RUSTFLAGS: "-Zsanitizer=address"
         run: >
@@ -682,6 +777,7 @@ jobs:
           -- -D warnings
 
       - name: Exercise the arena allocator under AddressSanitizer
+        if: steps.sel.outputs.run == 'true'
         env:
           RUSTFLAGS: "-Zsanitizer=address"
           ASAN_OPTIONS: "detect_leaks=0"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -434,6 +434,12 @@ jobs:
     outputs:
       full: ${{ steps.decide.outputs.full }}
       selected: ${{ steps.decide.outputs.selected }}
+      # RUE-1130. A referenced-but-undeclared job output silently resolves to
+      # the empty string, which for a lane gate means "selected nothing" —
+      # every gated lane would deselect on a selective run. validate-ci-gate.py
+      # now fails closed on that, because the failure only appears on the
+      # peripheral PRs the gating exists for, and never on a CI-touching one.
+      selected_lanes: ${{ steps.decide.outputs.selected_lanes }}
     steps:
       - uses: actions/checkout@v6
         # BTD compares the graph at the merge-base and at the head, so the base

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -162,6 +162,8 @@ jobs:
   linux-premerge:
     runs-on: ubuntu-latest
     name: premerge (linux-x64)
+    if: ${{ always() }}
+    needs: affected-targets
     steps:
       - uses: actions/checkout@v6
         with:
@@ -205,10 +207,43 @@ jobs:
           scripts/provision-build-cache install
           scripts/provision-build-cache apply
 
+      # RUE-1130: materialize the determinator's impacted-target closure so the
+      # heavy steps below can run exactly it. `narrowed` is the determinator's
+      # own flag: it declines to narrow when nothing is impacted or when so much
+      # is that the `//...` pattern is the better expression of it, so an empty
+      # file here always means "run everything", never "run nothing".
+      - name: Impacted target list
+        id: narrow
+        env:
+          RUE_AFFECTED_NARROWED: ${{ needs.affected-targets.outputs.narrowed }}
+          RUE_AFFECTED_IMPACTED: ${{ needs.affected-targets.outputs.impacted }}
+        run: |
+          set -euo pipefail
+          file="${RUNNER_TEMP}/impacted-targets.txt"
+          : >"$file"
+          if [ "${RUE_AFFECTED_NARROWED:-}" = "true" ]; then
+            printf '%s\n' "$RUE_AFFECTED_IMPACTED" | sed '/^$/d' >"$file"
+          fi
+          count="$(wc -l <"$file" | tr -d ' ')"
+          echo "file=$file" >>"$GITHUB_OUTPUT"
+          echo "count=$count" >>"$GITHUB_OUTPUT"
+          echo "impacted targets for this lane: $count"
+
       # Uses hermetic Rust toolchain downloaded by Buck2
-      # First verify everything builds (catches issues tests might miss)
+      # First verify everything builds (catches issues tests might miss).
+      # RUE-1130: on a narrowed run this builds the impacted closure instead of
+      # every crate. An unimpacted crate cannot have been broken by this diff,
+      # and building its test binaries is the cost this narrowing exists to
+      # avoid — measured at 286-317s whenever a compiler crate changes.
       - name: Build all targets
-        run: scripts/ci-timed "linux-x64 build" -- ./buck2 build //crates/...
+        run: |
+          set -euo pipefail
+          if [ "${{ steps.narrow.outputs.count }}" -gt 0 ]; then
+            mapfile -t targets <"${{ steps.narrow.outputs.file }}"
+            scripts/ci-timed "linux-x64 build (narrowed)" -- ./buck2 build "${targets[@]}"
+          else
+            scripts/ci-timed "linux-x64 build" -- ./buck2 build //crates/...
+          fi
 
       - name: Run complete target-independent premerge suite
         # RUE-1163: the corpora with their own platform-corpus job carry the
@@ -217,6 +252,7 @@ jobs:
         # fails if the labeled set and the platform-corpus matrix disagree.
         env:
           RUE_TEST_TIER: premerge
+          RUE_TEST_TARGETS_FILE: ${{ steps.narrow.outputs.file }}
         run: scripts/ci-timed "linux-x64 premerge" -- ./test.sh
 
       - name: Run explicit cross-backend compilation and encoding coverage
@@ -298,6 +334,28 @@ jobs:
           RUE_AFFECTED_LANES: ${{ needs.affected-targets.outputs.selected_lanes }}
         run: scripts/ci-corpus-decision "native-${{ matrix.name }}"
 
+      # RUE-1130: materialize the determinator's impacted-target closure so the
+      # heavy steps below can run exactly it. `narrowed` is the determinator's
+      # own flag: it declines to narrow when nothing is impacted or when so much
+      # is that the `//...` pattern is the better expression of it, so an empty
+      # file here always means "run everything", never "run nothing".
+      - name: Impacted target list
+        id: narrow
+        env:
+          RUE_AFFECTED_NARROWED: ${{ needs.affected-targets.outputs.narrowed }}
+          RUE_AFFECTED_IMPACTED: ${{ needs.affected-targets.outputs.impacted }}
+        run: |
+          set -euo pipefail
+          file="${RUNNER_TEMP}/impacted-targets.txt"
+          : >"$file"
+          if [ "${RUE_AFFECTED_NARROWED:-}" = "true" ]; then
+            printf '%s\n' "$RUE_AFFECTED_IMPACTED" | sed '/^$/d' >"$file"
+          fi
+          count="$(wc -l <"$file" | tr -d ' ')"
+          echo "file=$file" >>"$GITHUB_OUTPUT"
+          echo "count=$count" >>"$GITHUB_OUTPUT"
+          echo "impacted targets for this lane: $count"
+
       - name: Select Xcode 16.2
         if: runner.os == 'macOS' && steps.sel.outputs.run == 'true'
         run: sudo xcode-select -s /Applications/Xcode_16.2.app
@@ -333,19 +391,31 @@ jobs:
         if: steps.sel.outputs.run == 'true'
         run: scripts/ci-timed "${{ matrix.name }} native build" -- ./buck2 build //crates/rue:rue
 
+      # RUE-1130: the same eight targets, narrowed to the impacted ones. These
+      # are unit tests, never the critical path, but their binaries are the
+      # expensive part and an unimpacted one has nothing to prove.
       - name: Run native backend, linker, runtime, ABI, allocator, and target tests
         if: steps.sel.outputs.run == 'true'
-        run: >-
-          scripts/ci-timed "${{ matrix.name }} native units" --
-          ./buck2 test
-          //crates/rue-compiler:rue-compiler-test
-          //crates/rue-codegen:rue-codegen-test
-          //crates/rue-linker:rue-linker-test
-          //crates/rue-runtime:rue-runtime-test
-          //crates/rue-runtime:runtime-archives-test
-          //crates/rue-runtime-abi:rue-runtime-abi-test
-          //crates/rue-allocator:rue-allocator-test
-          //crates/rue-target:rue-target-test
+        run: |
+          set -euo pipefail
+          targets=(
+            //crates/rue-compiler:rue-compiler-test
+            //crates/rue-codegen:rue-codegen-test
+            //crates/rue-linker:rue-linker-test
+            //crates/rue-runtime:rue-runtime-test
+            //crates/rue-runtime:runtime-archives-test
+            //crates/rue-runtime-abi:rue-runtime-abi-test
+            //crates/rue-allocator:rue-allocator-test
+            //crates/rue-target:rue-target-test
+          )
+          if [ "${{ steps.narrow.outputs.count }}" -gt 0 ]; then
+            mapfile -t targets < <(scripts/affected-targets intersect "${{ steps.narrow.outputs.file }}" "${targets[@]}")
+          fi
+          if [ "${#targets[@]}" -eq 0 ]; then
+            echo "native units: no impacted unit targets on this diff; the merge-queue run covers them."
+            exit 0
+          fi
+          scripts/ci-timed "${{ matrix.name }} native units" -- ./buck2 test "${targets[@]}"
 
       - name: Run every declaratively platform-scoped spec and CLI case
         if: steps.sel.outputs.run == 'true'
@@ -440,6 +510,12 @@ jobs:
       # now fails closed on that, because the failure only appears on the
       # peripheral PRs the gating exists for, and never on a CI-touching one.
       selected_lanes: ${{ steps.decide.outputs.selected_lanes }}
+      # The impacted-target closure, and the determinator's own flag for whether
+      # narrowing to it is worthwhile. Consumers key on `narrowed`; an absent or
+      # empty `impacted` therefore reads as "run everything", never "run
+      # nothing".
+      narrowed: ${{ steps.decide.outputs.narrowed }}
+      impacted: ${{ steps.decide.outputs.impacted }}
     steps:
       - uses: actions/checkout@v6
         # BTD compares the graph at the merge-base and at the head, so the base

--- a/docs/designs/0069-ci-work-scheduling.md
+++ b/docs/designs/0069-ci-work-scheduling.md
@@ -16,8 +16,8 @@ relates: ["RUE-1250", "RUE-1262", "RUE-1164", "RUE-1130", "RUE-1131", "RUE-1222"
 
 ## Status
 
-Accepted. Phase 2 (lane-wide determination, RUE-1130) is implemented in the
-same change that accepted this ADR; the remaining phases are unstarted.
+Accepted. Phase 2 (determination on every lane, RUE-1130) is implemented in
+the same change that accepted this ADR; the remaining phases are unstarted.
 
 ## Summary
 
@@ -236,8 +236,25 @@ emit the lane plan the matrix consumes
 authoritative full run. The existing fail-open contract and
 `scripts/test-affected-targets.sh` pinning are retained unchanged.
 
-This is the decision RUE-1130 asks for, and the answer is *keep and extend*, not
-*remove*. The measured saving on a peripheral run is ~80% of its wall time, and
+This is the decision RUE-1130 asks for, and the answer is *keep and extend to
+everything*, not *remove*.
+
+Gating decides **whether** a lane runs; narrowing decides **what** it runs. Both
+are the same determinator output applied at different granularity, and a lane
+takes whichever fits it. A lane with a fixed target list is gated, then narrowed
+to the impacted subset of that list. `linux-premerge` is never gated — skipping
+the broad-discovery lane on a representative subset is the RUE-924 failure mode
+— but it *is* narrowed, running `impacted ∩ tier` in place of `//... ∩ tier`.
+Membership still comes from the live graph, so a target added since any list was
+written is still discovered; it simply is not built or run when the diff cannot
+reach it.
+
+Narrowing matters even where a lane is not the critical path. Building a test
+binary is most of what a unit target costs, and the premerge lane spends
+286–317s building every crate whenever a compiler crate changes. An unimpacted
+crate cannot have been broken by the diff, so that build is waste — and waste
+that grows with the repository rather than with the change, which is the whole
+reason to fix it structurally now rather than when it hurts. The measured saving on a peripheral run is ~80% of its wall time, and
 none of it is currently reachable, because the determinator gates 7 of ~14 jobs
 and `premerge` — the critical path in 86% of runs — is not one of them. Extending
 the gate is a smaller change than the rest of this ADR and does not depend on it:
@@ -337,15 +354,15 @@ completely.
 
 - [ ] **Phase 1: Eliminate the duplicated critical path** — RUE-1262.
       56–59% of the critical path, no new machinery, needs one coverage ruling.
-- [x] **Phase 2: Extend determination to every gateable lane** — RUE-1130,
-      whose "make it discriminate or remove it" question this ADR answers with
-      "keep it and extend it." Six lanes now consult the determinator
+- [x] **Phase 2: Determination on every lane, by gating or by narrowing** —
+      RUE-1130, whose "make it discriminate or remove it" question this ADR
+      answers with "keep it and extend it to everything." Six lanes are gated
       (`native` ×2, `release`, `valgrind`, `asan`, `compiler-reproducibility`),
       freeing **905–1034s of runner time** on each of four measured peripheral
-      runs. It moves the critical path in only one of those four: `premerge`
-      still dominates the rest, which is the measured argument for doing Phase 1
-      next rather than more gating. `linux-premerge` stays ungated on purpose —
-      see "Decision §3". Reporting the saved share per run is still to do.
+      runs. `linux-premerge` and the native unit targets are narrowed to the
+      impacted closure instead, so an unimpacted test binary is neither built
+      nor run. Reporting the saved share per run is still to do, and is what
+      turns the change-mix question from an argument into a measurement.
 - [ ] **Phase 3: Duplication gate** — new. Cheap, and it is what stops the class
       from recurring; lands while the evidence is fresh.
 - [ ] **Phase 4: Platform scope as a target attribute** — new (RUE-1262 scope C).

--- a/docs/designs/0069-ci-work-scheduling.md
+++ b/docs/designs/0069-ci-work-scheduling.md
@@ -1,11 +1,11 @@
 ---
 id: 0069
 title: "CI work scheduling for a compiler monorepo"
-status: proposal
+status: accepted
 tags: [process, ci, testing, build, performance]
 feature-flag: null
 created: 2026-08-09
-accepted:
+accepted: 2026-08-09
 implemented:
 spec-sections: []
 superseded-by:
@@ -16,7 +16,8 @@ relates: ["RUE-1250", "RUE-1262", "RUE-1164", "RUE-1130", "RUE-1131", "RUE-1222"
 
 ## Status
 
-Proposal
+Accepted. Phase 2 (lane-wide determination, RUE-1130) is implemented in the
+same change that accepted this ADR; the remaining phases are unstarted.
 
 ## Summary
 
@@ -336,12 +337,15 @@ completely.
 
 - [ ] **Phase 1: Eliminate the duplicated critical path** — RUE-1262.
       56–59% of the critical path, no new machinery, needs one coverage ruling.
-- [ ] **Phase 2: Extend determination to every lane and report its regime** —
-      RUE-1130, whose "make it discriminate or remove it" question this ADR
-      answers with "keep it, extend it, and make it report what it saved."
-      Promoted ahead of the gates below by measurement: ~80% of a peripheral run
-      is currently unnecessary and none of it is reachable, and the change is
-      independent of the rest of this ADR.
+- [x] **Phase 2: Extend determination to every gateable lane** — RUE-1130,
+      whose "make it discriminate or remove it" question this ADR answers with
+      "keep it and extend it." Six lanes now consult the determinator
+      (`native` ×2, `release`, `valgrind`, `asan`, `compiler-reproducibility`),
+      freeing **905–1034s of runner time** on each of four measured peripheral
+      runs. It moves the critical path in only one of those four: `premerge`
+      still dominates the rest, which is the measured argument for doing Phase 1
+      next rather than more gating. `linux-premerge` stays ungated on purpose —
+      see "Decision §3". Reporting the saved share per run is still to do.
 - [ ] **Phase 3: Duplication gate** — new. Cheap, and it is what stops the class
       from recurring; lands while the evidence is fresh.
 - [ ] **Phase 4: Platform scope as a target attribute** — new (RUE-1262 scope C).

--- a/docs/designs/0069-ci-work-scheduling.md
+++ b/docs/designs/0069-ci-work-scheduling.md
@@ -346,6 +346,38 @@ is 3.90% — the guard cannot fail on real data. Observed skew reached **24.9%**
 Guards compare observed lane wall time against plan, and stale weights surface as
 skew. A guard that validates the model against itself is not a guard.
 
+## The standard this is held to
+
+CI is a platform, and the test of a platform is what it demands of the people
+using it. The standard is therefore not "CI is fast" but: **the repository can
+grow — new crates, new corpora, an LSP, a test runner, code mods, a much larger
+`std/` — without anyone editing CI to keep it correct or fast.** Every hand-
+maintained list is a future outage or a future slowdown with a delay fuse,
+because it is correct on the day it is written and nobody is reminded when it
+stops being.
+
+Rue is some way from that, and the honest way to close the distance is to
+enumerate what still needs a human. Anything on this ledger is either derived
+from the graph later, or gated so that drift fails closed rather than silently:
+
+| Hand-maintained today | What goes wrong when the repo grows | Status |
+| --- | --- | --- |
+| `CLI_TEST_SHARD_COUNT` + the `platform-corpus` matrix | count and matrix drift | gated (`//:cli-shard-coverage-validation`); derive in phase 6 |
+| `SELECTABLE_CORPUS` | a new corpus job is ungated, so it always runs | fails open (runs); not yet gated |
+| `SELECTABLE_LANES` / `lane_targets` | a lane's job runs a target selection cannot see | **gated** (`lane_target_drift`) |
+| the native lanes' eight-target list, in the job and in the contract | new platform-sensitive tests are not enrolled | partly gated; phase 4 removes the list |
+| `RUE_AFFECTED_NARROW_LIMIT` (600) | a threshold nobody revisits | unmeasured; should follow measurement |
+| the platform responsibility matrix | a responsibility silently moves | gated (`validate-ci-gate.py`) |
+| `shard-weights.json` refresh | weights go stale, shards skew | manual (RUE-1222); guard is vacuous (§6) |
+
+The pattern the ledger is meant to enforce: a list that must exist is paired
+with a gate that fails closed, and a list that need not exist is deleted in
+favour of a query against the live graph. Phases 1 and 4 delete rows; phases 3
+and 6 gate the rest. **A phase that adds a row without a gate has not met the
+standard**, which is the test this ADR's own implementation failed once already:
+RUE-1130 introduced `lane_targets` as a second copy of the native lane's target
+list before that row was gated.
+
 ## Implementation Phases
 
 Ordered by measured value, with the packer deliberately last: until the earlier

--- a/docs/designs/README.md
+++ b/docs/designs/README.md
@@ -231,5 +231,5 @@ The table is generated from ADR frontmatter. Run
 | [0066](0066-producer-nominal-anonymous-types-and-incremental-locality.md) | Producer-nominal anonymous types and incremental locality | Implemented | types, semantics, comptime, incremental, performance, parallelism |
 | [0067](0067-compiler-performance-measurement.md) | Compiler performance measurement, epochs, and dashboard | Proposal | tooling, ci, performance, website |
 | [0068](0068-incremental-edit-performance-measurement.md) | Incremental edit-scenario performance measurement | Accepted | tooling, compiler, incremental, performance |
-| [0069](0069-ci-work-scheduling.md) | CI work scheduling for a compiler monorepo | Proposal | process, ci, testing, build, performance |
+| [0069](0069-ci-work-scheduling.md) | CI work scheduling for a compiler monorepo | Accepted | process, ci, testing, build, performance |
 <!-- ADR-INDEX:END -->

--- a/docs/process/ci.md
+++ b/docs/process/ci.md
@@ -306,13 +306,31 @@ compiler change, because the lanes that dominate a run were not consulting the
 determinator. On four measured peripheral runs the extension frees 905–1034s of
 runner time each.
 
-It does **not** shorten the critical path on its own — `premerge (linux-x64)`
-still dominates in three of those four runs — because `linux-premerge` is
-deliberately ungated. It is the broad-discovery lane and the RUE-924 backstop:
-it runs whatever the tier selection contains, including targets added since any
-list was written, so gating it on a representative subset is the one place where
-under-selection could silently drop a suite nobody enumerated. Narrowing what it
-runs, rather than whether it runs, is ADR-0069 phase 4.
+`linux-premerge` is handled differently, because skipping it wholesale on a
+representative subset is exactly the RUE-924 failure mode. It is **narrowed**
+instead of gated: the determinator publishes the impacted closure as the
+`impacted` output, and the lane runs `impacted ∩ tier` in place of
+`//... ∩ tier`, for both its build step and `test.sh`. Membership still comes
+from the live graph, so a target added since any list was written is still
+discovered — it is simply not built or run when the diff cannot reach it. That
+is where the build cost goes: the lane spends 286–317s building every crate
+whenever a compiler crate changes, and an unimpacted crate's test binary has
+nothing to prove.
+
+Narrowing is declined, and the ordinary pattern used, whenever nothing is
+impacted or so much is that the pattern is the better expression of it
+(`RUE_AFFECTED_NARROW_LIMIT`, default 600 targets — a compiler change reaches
+most of the graph, so narrowing it saves nothing). Consumers key on the
+determinator's `narrowed` flag rather than on the list being non-empty, so an
+absent, empty, or oversized list always reads as "run everything". `test.sh`
+applies the same rule: an unset, unreadable, or empty `RUE_TEST_TARGETS_FILE`
+runs the full pattern, and only a readable non-empty list narrows.
+
+One consequence is worth stating plainly: an explicit target list that filters
+down to no tests is a legitimate outcome, and buck2 exits 0 reporting
+`NO TESTS RAN`. That is indistinguishable by exit status from a narrowing bug,
+so the selected count is echoed in the log and the job summary rather than left
+to be inferred from a silent green.
 
 The ASan harness is a standalone Cargo project outside the Buck graph, so BTD
 cannot see it; `crates/rue-runtime-asan/` therefore forces a full run rather

--- a/docs/process/ci.md
+++ b/docs/process/ci.md
@@ -290,10 +290,33 @@ reverse-dependency closure to the whole corpus exactly as before. The
 deterministic force-full and gate logic is pinned by
 `scripts/test-affected-targets.sh`.
 
-Selection is applied **within** each `platform-corpus` job, not by skipping the
-job: `scripts/ci-corpus-selected` decides at job start, and a deselected corpus
-skips the heavy steps (paying only the runner spin-up) while the check still
-reports success, so no branch-protection change is required. The
+Selection is applied **within** each gated job, not by skipping the job:
+`scripts/ci-corpus-selected` decides at job start, and a deselected unit skips
+the heavy steps (paying only the runner spin-up) while the check still reports
+success, so no branch-protection change is required.
+
+RUE-1130 extended that gate from the `platform-corpus` corpora to six further
+lanes — `native (linux-arm64)`, `native (macos-arm64)`, `release (linux-x64)`,
+`valgrind (linux-x64)`, `asan (linux-x64)`, and
+`compiler reproducibility (linux-x64)`. Each is named in `SELECTABLE_LANES` and
+maps to the Buck targets it actually executes (`lane_targets`); a lane runs when
+any of those targets is in BTD's impacted closure. Gating the corpora alone had
+saved nothing measurable: a documentation change cost 444s against 465s for a
+compiler change, because the lanes that dominate a run were not consulting the
+determinator. On four measured peripheral runs the extension frees 905–1034s of
+runner time each.
+
+It does **not** shorten the critical path on its own — `premerge (linux-x64)`
+still dominates in three of those four runs — because `linux-premerge` is
+deliberately ungated. It is the broad-discovery lane and the RUE-924 backstop:
+it runs whatever the tier selection contains, including targets added since any
+list was written, so gating it on a representative subset is the one place where
+under-selection could silently drop a suite nobody enumerated. Narrowing what it
+runs, rather than whether it runs, is ADR-0069 phase 4.
+
+The ASan harness is a standalone Cargo project outside the Buck graph, so BTD
+cannot see it; `crates/rue-runtime-asan/` therefore forces a full run rather
+than being represented by a proxy target. The
 `affected-targets` job writes a selection manifest to the job summary accounting
 for every corpus as `RUN` or `DESELECTED (intentional)`, and each deselected job
 logs its own intentional-deselection line — so a legitimate selective skip is

--- a/scripts/affected-targets
+++ b/scripts/affected-targets
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Affected-corpus selection for pull-request CI (RUE-1119).
+# Affected-target selection for pull-request CI (RUE-1119, extended by RUE-1130).
 #
 # On a pull_request run, only the heavy corpus suites a change actually affects
 # need to run; the merge queue (merge_group) remains the authoritative full
@@ -36,6 +36,8 @@
 #                      matrix. The matrix gate uses this as its one source of
 #                      truth, so an added matrix target fails open until it is
 #                      deliberately added here.
+#   is-selectable-lane Exit 0 only for a gated workflow lane (RUE-1130).
+#   lane-targets       Print the Buck targets a gated lane executes.
 #
 # Deliberately NOT `set -e`: a full run is the safe fallback, so failures are
 # handled explicitly and converted into "full", never into a hard error that
@@ -76,9 +78,75 @@ SELECTABLE_CORPUS=(
     //crates/rue-oracle-diff:oracle-diff-spec-test
 )
 
+# RUE-1130. The corpus jobs above were the only gated lanes, and measurement
+# showed that gating them alone saves nothing: a documentation change costs 444s
+# against 465s for a compiler change, because the lanes that dominate a run were
+# not consulting this determinator at all. These are the remaining gateable
+# lanes, each named for its workflow job and represented by the Buck targets it
+# actually executes. A lane runs when any of its targets is in BTD's impacted
+# closure — the same rule the corpus targets already use, applied to a job whose
+# work is a set of targets rather than one.
+#
+# `linux-premerge` is deliberately absent. It is the broad-discovery lane and
+# the RUE-924 backstop: it runs whatever the tier selection contains, including
+# targets added since this list was written, so gating it on a representative
+# subset would be the one place where under-selection could silently drop a
+# suite nobody remembered to enumerate. Narrowing what it runs (rather than
+# whether it runs) needs the uniform-unit work in ADR-0069 phase 4.
+SELECTABLE_LANES=(
+    native-linux-arm64
+    native-macos-arm64
+    release
+    valgrind
+    asan
+    compiler-reproducibility
+)
+
+# Representative targets per lane, mirroring what each job executes in ci.yml.
+# An unknown lane prints nothing, and the gate treats that as "run".
+lane_targets() {
+    case "$1" in
+        native-linux-arm64|native-macos-arm64)
+            # The eight native unit targets, plus the two manifest-driven
+            # corpora whose `only_on` cases these lanes register.
+            echo //crates/rue-compiler:rue-compiler-test \
+                 //crates/rue-codegen:rue-codegen-test \
+                 //crates/rue-linker:rue-linker-test \
+                 //crates/rue-runtime:rue-runtime-test \
+                 //crates/rue-runtime:runtime-archives-test \
+                 //crates/rue-runtime-abi:rue-runtime-abi-test \
+                 //crates/rue-allocator:rue-allocator-test \
+                 //crates/rue-target:rue-target-test \
+                 //:spec-tests \
+                 //:cli-tests ;;
+        release)
+            echo //:release-smoke ;;
+        valgrind)
+            # Builds the compiler and runs generated programs under memcheck.
+            echo //crates/rue:rue //:cli-tests ;;
+        asan)
+            # A standalone Cargo harness over the arena allocator. Its own
+            # sources are outside the Buck graph, so they force a full run via
+            # FORCE_FULL_REGEX rather than being represented here.
+            echo //crates/rue-runtime:rue-runtime //crates/rue-allocator:rue-allocator ;;
+        compiler-reproducibility)
+            echo //crates/rue:rue ;;
+        *)
+            return 1 ;;
+    esac
+}
+
+is_selectable_lane() {
+    local wanted="$1" lane
+    for lane in "${SELECTABLE_LANES[@]}"; do
+        [[ "$lane" == "$wanted" ]] && return 0
+    done
+    return 1
+}
+
 # Out-of-graph (and belt-and-suspenders in-graph) paths that force a full run.
 # Anchored, repo-root-relative, extended-regex alternation.
-FORCE_FULL_REGEX='(^|/)BUCK$|\.bzl$|^\.buckconfig|^\.buckroot$|^\.github/workflows/|^toolchains/|^platforms/|^constraints/|^third-party/|^prelude/|^rust-toolchain\.toml$|^buck2$|^buck2-bin$|^reindeer$|^btd$|^test\.sh$|^scripts/ci-|^scripts/affected-targets$|^scripts/provision-build-cache$|^scripts/with-full-suite-lock$|^scripts/rue$|^scripts/rue-bin$'
+FORCE_FULL_REGEX='^crates/rue-runtime-asan/|(^|/)BUCK$|\.bzl$|^\.buckconfig|^\.buckroot$|^\.github/workflows/|^toolchains/|^platforms/|^constraints/|^third-party/|^prelude/|^rust-toolchain\.toml$|^buck2$|^buck2-bin$|^reindeer$|^btd$|^test\.sh$|^scripts/ci-|^scripts/affected-targets$|^scripts/provision-build-cache$|^scripts/with-full-suite-lock$|^scripts/rue$|^scripts/rue-bin$'
 
 # buck2 targets invocation BTD's own `targets` wrapper uses (td_util buck::run
 # targets_arguments). Both dumps use the identical command so their unconfigured
@@ -138,7 +206,7 @@ emit_output() {
 # as either RUN or DESELECTED, so an intentional deselection is never confused
 # with a silent drop.
 emit_manifest() {
-    local mode="$1" reason="$2" selected="$3"
+    local mode="$1" reason="$2" selected="$3" lanes="${4:-}"
     [[ -n "${GITHUB_STEP_SUMMARY:-}" ]] || return 0
     {
         echo "### Affected-corpus selection (RUE-1119)"
@@ -158,6 +226,20 @@ emit_manifest() {
             echo "| ${target} | ${state} |"
         done
         echo
+        echo "| Gated lane (RUE-1130) | Selection |"
+        echo "| --- | --- |"
+        local lane
+        for lane in "${SELECTABLE_LANES[@]}"; do
+            if [[ "$mode" == "full" ]] || [[ " ${lanes} " == *" ${lane} "* ]]; then
+                state="RUN"
+            else
+                state="DESELECTED (intentional)"
+            fi
+            echo "| ${lane} | ${state} |"
+        done
+        echo
+        echo "linux-premerge always runs: it is the broad-discovery lane and the RUE-924 backstop."
+        echo
     } >>"$GITHUB_STEP_SUMMARY"
 }
 
@@ -166,17 +248,20 @@ decide_full() {
     echo "affected-targets: FULL run — ${reason}"
     emit_output full "true"
     emit_output selected ""
-    emit_manifest "full" "$reason" ""
+    emit_output selected_lanes ""
+    emit_manifest "full" "$reason" "" ""
     exit 0
 }
 
 decide_select() {
-    local selected="$1" reason="$2"
+    local selected="$1" reason="$2" lanes="${3:-}"
     echo "affected-targets: SELECTIVE run — ${reason}"
     echo "affected-targets: selected corpus targets: ${selected:-<none>}"
+    echo "affected-targets: selected lanes: ${lanes:-<none>}"
     emit_output full "false"
     emit_output selected "$selected"
-    emit_manifest "select" "$reason" "$selected"
+    emit_output selected_lanes "$lanes"
+    emit_manifest "select" "$reason" "$selected" "$lanes"
     exit 0
 }
 
@@ -285,7 +370,18 @@ cmd_decide() {
         fi
     done
 
-    decide_select "$selected" "btd affected-target closure over the PR diff"
+    # RUE-1130: a lane runs when any target it executes is impacted.
+    local lanes="" lane
+    for lane in "${SELECTABLE_LANES[@]}"; do
+        for target in $(lane_targets "$lane"); do
+            if grep -Fxq "$target" <<<"$impacted"; then
+                lanes+="${lanes:+ }$lane"
+                break
+            fi
+        done
+    done
+
+    decide_select "$selected" "btd affected-target closure over the PR diff" "$lanes"
 }
 
 main() {
@@ -304,8 +400,14 @@ main() {
         is-selectable)
             [[ $# -eq 2 ]] || { echo "usage: scripts/affected-targets is-selectable //:TARGET" >&2; exit 2; }
             is_selectable "$2" ;;
+        is-selectable-lane)
+            [[ $# -eq 2 ]] || { echo "usage: scripts/affected-targets is-selectable-lane LANE" >&2; exit 2; }
+            is_selectable_lane "$2" ;;
+        lane-targets)
+            [[ $# -eq 2 ]] || { echo "usage: scripts/affected-targets lane-targets LANE" >&2; exit 2; }
+            lane_targets "$2" ;;
         *)
-            echo "usage: scripts/affected-targets [decide|force-full-match|status-paths|is-selectable]" >&2
+            echo "usage: scripts/affected-targets [decide|force-full-match|status-paths|is-selectable|is-selectable-lane|lane-targets]" >&2
             exit 2 ;;
     esac
 }

--- a/scripts/affected-targets
+++ b/scripts/affected-targets
@@ -38,6 +38,7 @@
 #                      deliberately added here.
 #   is-selectable-lane Exit 0 only for a gated workflow lane (RUE-1130).
 #   lane-targets       Print the Buck targets a gated lane executes.
+#   intersect          Print a lane's targets that appear in an impacted list.
 #
 # Deliberately NOT `set -e`: a full run is the safe fallback, so failures are
 # handled explicitly and converted into "full", never into a hard error that
@@ -87,12 +88,13 @@ SELECTABLE_CORPUS=(
 # closure — the same rule the corpus targets already use, applied to a job whose
 # work is a set of targets rather than one.
 #
-# `linux-premerge` is deliberately absent. It is the broad-discovery lane and
-# the RUE-924 backstop: it runs whatever the tier selection contains, including
-# targets added since this list was written, so gating it on a representative
-# subset would be the one place where under-selection could silently drop a
-# suite nobody remembered to enumerate. Narrowing what it runs (rather than
-# whether it runs) needs the uniform-unit work in ADR-0069 phase 4.
+# `linux-premerge` is absent from this list for a different reason than the
+# others are present. It is the broad-discovery lane and the RUE-924 backstop,
+# so it must never be skipped wholesale on a representative subset. Instead it
+# is NARROWED: the determinator publishes the impacted closure, and the lane
+# runs `impacted ∩ tier` rather than `//... ∩ tier`. Membership still comes from
+# the live graph, so a target added since this file was written is still
+# discovered — it simply is not built or run when the diff cannot reach it.
 SELECTABLE_LANES=(
     native-linux-arm64
     native-macos-arm64
@@ -202,6 +204,36 @@ emit_output() {
     printf '%s=%s\n' "$1" "$2" >>"$GITHUB_OUTPUT"
 }
 
+# Emit a multi-line value using the heredoc form GitHub requires.
+emit_output_multiline() {
+    [[ -n "${GITHUB_OUTPUT:-}" ]] || return 0
+    local key="$1" file="$2" delim="RUE_EOF_$$"
+    {
+        printf '%s<<%s\n' "$key" "$delim"
+        [[ -n "$file" && -s "$file" ]] && cat "$file"
+        printf '%s\n' "$delim"
+    } >>"$GITHUB_OUTPUT"
+}
+
+# RUE-1130. Beyond this many impacted targets, narrowing a lane to an explicit
+# list saves nothing — a compiler change reaches most of the graph, so the list
+# is the graph — and the `//...` pattern is cheaper to express and to read.
+# Emitting nothing means "do not narrow", which every consumer treats as full.
+NARROW_LIMIT="${RUE_AFFECTED_NARROW_LIMIT:-600}"
+
+# Intersect a newline-separated impacted list (file) with the targets given as
+# arguments, preserving argument order. Used by lanes whose contents are a fixed
+# list in the workflow rather than a pattern.
+intersect_impacted() {
+    local file="$1"; shift
+    [[ -r "$file" ]] || return 0
+    local target
+    for target in "$@"; do
+        grep -Fxq "$target" "$file" && printf '%s\n' "$target"
+    done
+    return 0
+}
+
 # Write the RUE-924 selection manifest: every selectable corpus is accounted for
 # as either RUN or DESELECTED, so an intentional deselection is never confused
 # with a silent drop.
@@ -249,18 +281,36 @@ decide_full() {
     emit_output full "true"
     emit_output selected ""
     emit_output selected_lanes ""
+    emit_output_multiline impacted ""
+    emit_output narrowed "false"
     emit_manifest "full" "$reason" "" ""
     exit 0
 }
 
 decide_select() {
-    local selected="$1" reason="$2" lanes="${3:-}"
+    local selected="$1" reason="$2" lanes="${3:-}" impacted_file="${4:-}"
     echo "affected-targets: SELECTIVE run — ${reason}"
     echo "affected-targets: selected corpus targets: ${selected:-<none>}"
     echo "affected-targets: selected lanes: ${lanes:-<none>}"
     emit_output full "false"
     emit_output selected "$selected"
     emit_output selected_lanes "$lanes"
+    # Narrowing is an optimization layered on the selective decision, and it is
+    # declined independently: too many impacted targets, or none at all, both
+    # mean the lane keeps its ordinary pattern. `narrowed` is the single flag
+    # consumers check, so an absent or oversized list can never be mistaken for
+    # "narrow to nothing".
+    local impacted_count=0
+    [[ -n "$impacted_file" && -s "$impacted_file" ]] && impacted_count="$(grep -c . "$impacted_file" || echo 0)"
+    if [[ "$impacted_count" -gt 0 && "$impacted_count" -le "$NARROW_LIMIT" ]]; then
+        echo "affected-targets: narrowing lanes to ${impacted_count} impacted targets"
+        emit_output_multiline impacted "$impacted_file"
+        emit_output narrowed "true"
+    else
+        echo "affected-targets: not narrowing (${impacted_count} impacted targets; limit ${NARROW_LIMIT})"
+        emit_output_multiline impacted ""
+        emit_output narrowed "false"
+    fi
     emit_manifest "select" "$reason" "$selected" "$lanes"
     exit 0
 }
@@ -381,7 +431,10 @@ cmd_decide() {
         done
     done
 
-    decide_select "$selected" "btd affected-target closure over the PR diff" "$lanes"
+    local impacted_file="$work/impacted-targets.txt"
+    printf '%s\n' "$impacted" | grep . >"$impacted_file" || true
+
+    decide_select "$selected" "btd affected-target closure over the PR diff" "$lanes" "$impacted_file"
 }
 
 main() {
@@ -403,11 +456,14 @@ main() {
         is-selectable-lane)
             [[ $# -eq 2 ]] || { echo "usage: scripts/affected-targets is-selectable-lane LANE" >&2; exit 2; }
             is_selectable_lane "$2" ;;
+        intersect)
+            [[ $# -ge 2 ]] || { echo "usage: scripts/affected-targets intersect FILE //:TARGET..." >&2; exit 2; }
+            shift; intersect_impacted "$@" ;;
         lane-targets)
             [[ $# -eq 2 ]] || { echo "usage: scripts/affected-targets lane-targets LANE" >&2; exit 2; }
             lane_targets "$2" ;;
         *)
-            echo "usage: scripts/affected-targets [decide|force-full-match|status-paths|is-selectable|is-selectable-lane|lane-targets]" >&2
+            echo "usage: scripts/affected-targets [decide|force-full-match|status-paths|is-selectable|is-selectable-lane|lane-targets|intersect]" >&2
             exit 2 ;;
     esac
 }

--- a/scripts/ci-corpus-selected
+++ b/scripts/ci-corpus-selected
@@ -38,16 +38,30 @@ if [[ "$full" != "false" ]]; then
     exit 0
 fi
 
+# RUE-1130: the same gate now answers for a named workflow lane as well as a
+# corpus target. Lanes consult `selected_lanes`; corpus targets consult
+# `selected`. Both fail open on anything unrecognized.
+kind="corpus"
+if "${affected[@]}" is-selectable-lane "$target"; then
+    kind="lane"
+    selected="${RUE_AFFECTED_LANES:-}"
+fi
+
 # The target list belongs to affected-targets, not this gate. A matrix entry
 # that was added without becoming selectable must run, never be silently
 # deselected. Corrupt selection output is similarly an unexpected failure.
-if ! "${affected[@]}" is-selectable "$target"; then
+if [[ "$kind" == "corpus" ]] && ! "${affected[@]}" is-selectable "$target"; then
     echo "ci-corpus-selected: unknown corpus target '${target}'; running it" >&2
     exit 0
 fi
 
 for selected_target in $selected; do
-    if ! "${affected[@]}" is-selectable "$selected_target"; then
+    if [[ "$kind" == "lane" ]]; then
+        if ! "${affected[@]}" is-selectable-lane "$selected_target"; then
+            echo "ci-corpus-selected: invalid selected lane '${selected_target}'" >&2
+            exit 2
+        fi
+    elif ! "${affected[@]}" is-selectable "$selected_target"; then
         echo "ci-corpus-selected: invalid selected target '${selected_target}'" >&2
         exit 2
     fi
@@ -60,7 +74,7 @@ fi
 
 # Intentional deselection — record it so it is never mistaken for a silent
 # corpus drop (RUE-924).
-note="corpus ${target} intentionally deselected by the affected-targets determinator (RUE-1119); it is not affected by this PR's diff and runs in the merge-queue full suite."
+note="${kind} ${target} intentionally deselected by the affected-targets determinator (RUE-1119/RUE-1130); it is not affected by this PR's diff and runs in the merge-queue full suite."
 echo "$note"
 if [[ -n "${GITHUB_STEP_SUMMARY:-}" ]]; then
     printf '%s\n' "$note" >>"$GITHUB_STEP_SUMMARY"

--- a/scripts/test-affected-targets.sh
+++ b/scripts/test-affected-targets.sh
@@ -133,6 +133,68 @@ check_gate "unknown matrix target runs" 0 "false" "" "//:future-corpus"
 # malformed selected output must not look like an intentional deselection
 check_gate "unknown selected output is an error" 2 "false" "//:future-corpus" "//:spec-tests"
 
+# --- RUE-1130: named lanes use the same gate and the same safety model -------
+
+lane_gate() { # lane_gate <full> <selected-lanes> <lane>; echoes exit status
+  RUE_AFFECTED_FULL="$1" RUE_AFFECTED_LANES="$2" "${GATE[@]}" "$3" >/dev/null 2>&1
+  echo $?
+}
+
+check_lane() { # check_lane <desc> <expected-status> <full> <lanes> <lane>
+  local desc="$1" expected="$2" got
+  TESTS=$((TESTS + 1))
+  got="$(lane_gate "$3" "$4" "$5")"
+  if [ "$got" = "$expected" ]; then
+    pass "lane: $desc"
+  else
+    fail "lane: $desc (expected exit $expected, got $got)"
+  fi
+}
+
+# Every gated lane must be recognized; an unrecognized name would silently fall
+# through to the corpus path and be treated as an unknown target (fail-open),
+# which is safe but would make the lane permanently ungated.
+for lane in native-linux-arm64 native-macos-arm64 release valgrind asan compiler-reproducibility; do
+  TESTS=$((TESTS + 1))
+  if "${AFFECTED[@]}" is-selectable-lane "$lane"; then
+    pass "lane: $lane is selectable"
+  else
+    fail "lane: $lane is not selectable (would never be gated)"
+  fi
+done
+
+# Each lane must name at least one representative Buck target, or it could never
+# be selected and would be deselected on every selective run.
+for lane in native-linux-arm64 native-macos-arm64 release valgrind asan compiler-reproducibility; do
+  TESTS=$((TESTS + 1))
+  if [ -n "$("${AFFECTED[@]}" lane-targets "$lane")" ]; then
+    pass "lane: $lane declares representative targets"
+  else
+    fail "lane: $lane declares no targets (would always deselect)"
+  fi
+done
+
+check_lane "full=true runs lane" 0 "true" "" "valgrind"
+check_lane "selected lane runs" 0 "false" "valgrind asan" "valgrind"
+check_lane "unselected lane deselected" 1 "false" "asan" "valgrind"
+check_lane "empty lane selection deselects" 1 "false" "" "valgrind"
+check_lane "unset full runs lane (fail-open)" 0 "" "" "valgrind"
+check_lane "malformed lane selection is an error" 2 "false" "not-a-lane" "valgrind"
+# A lane name must not be satisfied by a corpus target list, and vice versa:
+# the two selections are read from different environment variables.
+check_lane "corpus selection does not select a lane" 1 "false" "" "release"
+TESTS=$((TESTS + 1))
+if [ "$(RUE_AFFECTED_FULL=false RUE_AFFECTED_TARGETS="//:spec-tests" RUE_AFFECTED_LANES="" "${GATE[@]}" "//:spec-tests" >/dev/null 2>&1; echo $?)" = "0" ]; then
+  pass "lane: corpus targets still gate on RUE_AFFECTED_TARGETS"
+else
+  fail "lane: corpus gating regressed"
+fi
+
+# The asan harness is outside the Buck graph, so BTD cannot see it; its sources
+# must force a full run rather than relying on a representative target.
+expect_full "crates/rue-runtime-asan/src/main.rs"
+expect_full "crates/rue-runtime-asan/Cargo.toml"
+
 # The workflow-facing adapter must reserve `run=false` for the gate's explicit
 # deselection status. A gate crash or missing executable runs the corpus.
 decision_root="$(mktemp -d)"

--- a/scripts/test-affected-targets.sh
+++ b/scripts/test-affected-targets.sh
@@ -18,6 +18,7 @@ fi
 # Buck resource materialization.
 AFFECTED=(bash "$SCRIPTS_DIR/affected-targets")
 GATE=(bash "$SCRIPTS_DIR/ci-corpus-selected")
+REPO_ROOT="$(cd "$SCRIPTS_DIR/.." && pwd)"
 DECISION=(bash "$SCRIPTS_DIR/ci-corpus-decision")
 PARSER=(python3 "$SCRIPTS_DIR/parse-btd-impacted.py")
 
@@ -194,6 +195,85 @@ fi
 # must force a full run rather than relying on a representative target.
 expect_full "crates/rue-runtime-asan/src/main.rs"
 expect_full "crates/rue-runtime-asan/Cargo.toml"
+
+# --- RUE-1130: narrowing a lane to the impacted closure ---------------------
+
+# `intersect` is what turns a lane's fixed target list into the impacted subset.
+# Order follows the lane's own list so the runner's output stays stable.
+narrow_root="$(mktemp -d)"
+printf '//crates/rue-codegen:rue-codegen-test\n//crates/rue-target:rue-target-test\n' >"$narrow_root/impacted"
+TESTS=$((TESTS + 1))
+if [ "$("${AFFECTED[@]}" intersect "$narrow_root/impacted" \
+        //crates/rue-compiler:rue-compiler-test \
+        //crates/rue-target:rue-target-test \
+        //crates/rue-codegen:rue-codegen-test | tr '\n' ' ')" \
+     = "//crates/rue-target:rue-target-test //crates/rue-codegen:rue-codegen-test " ]; then
+  pass "narrow: intersect keeps the lane's order and drops unimpacted targets"
+else
+  fail "narrow: intersect produced the wrong subset"
+fi
+
+# An empty impacted file must yield an empty intersection rather than the whole
+# list; the caller distinguishes the two by the determinator's `narrowed` flag,
+# never by this output.
+: >"$narrow_root/none"
+TESTS=$((TESTS + 1))
+if [ -z "$("${AFFECTED[@]}" intersect "$narrow_root/none" //crates/rue-target:rue-target-test)" ]; then
+  pass "narrow: empty impacted list intersects to nothing"
+else
+  fail "narrow: empty impacted list did not intersect to nothing"
+fi
+
+# A missing file must not abort the caller mid-pipeline.
+TESTS=$((TESTS + 1))
+if "${AFFECTED[@]}" intersect "$narrow_root/absent" //crates/rue-target:rue-target-test >/dev/null 2>&1; then
+  pass "narrow: missing impacted file exits cleanly"
+else
+  fail "narrow: missing impacted file did not exit cleanly"
+fi
+
+# test.sh must fall back to the full pattern for every input that is not a
+# readable, non-empty list, and must never turn a bad list into "run nothing".
+run_test_sh_args() { # run_test_sh_args [VAR=VALUE ...] -> prints the buck2 test args
+  local shim="$narrow_root/bin"
+  mkdir -p "$shim"
+  printf '#!/usr/bin/env bash\nshift\n[ "${1:-}" = test ] && { shift; printf "ARGS: %%s\\n" "$*"; exit 0; }\nexit 0\n' >"$shim/dotslash"
+  chmod +x "$shim/dotslash"
+  ( cd "$REPO_ROOT" && PATH="$shim:$PATH" CI=true RUE_TEST_TIER=premerge env "$@" ./test.sh 2>&1 ) | grep '^ARGS: ' || true
+}
+
+check_narrow() { # check_narrow <desc> <expect-substring> [VAR=VALUE ...]
+  local desc="$1" expect="$2"; shift 2
+  TESTS=$((TESTS + 1))
+  # Capture first: `grep -q` exits on its first match, and behind a pipe under
+  # `set -o pipefail` that kills the producer with EPIPE and fails the pipeline
+  # (RUE-1011/RUE-1155). `--` so an expectation starting with a flag is not
+  # parsed as one.
+  local actual
+  actual="$(run_test_sh_args "$@")"
+  if grep -Fq -- "$expect" <<<"$actual"; then
+    pass "narrow: $desc"
+  else
+    fail "narrow: $desc (expected args containing '$expect')"
+  fi
+}
+
+printf '//crates/rue-span:rue-span-test\n' >"$narrow_root/one"
+check_narrow "a readable list narrows the suite" \
+  "ARGS: //crates/rue-span:rue-span-test --always-exclude" \
+  "RUE_TEST_TARGETS_FILE=$narrow_root/one"
+check_narrow "an empty list runs the full pattern" \
+  "ARGS: //... toolchains//..." \
+  "RUE_TEST_TARGETS_FILE=$narrow_root/none"
+check_narrow "an unreadable list runs the full pattern" \
+  "ARGS: //... toolchains//..." \
+  "RUE_TEST_TARGETS_FILE=$narrow_root/absent"
+check_narrow "an unset list runs the full pattern" \
+  "ARGS: //... toolchains//..."
+# Narrowing must not weaken the tier or deferral filters it runs under.
+check_narrow "a narrowed suite keeps its tier and deferral filters" \
+  "--include rue_test_tier_premerge --exclude rue_ci_dedicated_lane" \
+  "RUE_TEST_TARGETS_FILE=$narrow_root/one"
 
 # The workflow-facing adapter must reserve `run=false` for the gate's explicit
 # deselection status. A gate crash or missing executable runs the corpus.

--- a/scripts/test-validate-ci-gate.py
+++ b/scripts/test-validate-ci-gate.py
@@ -157,5 +157,43 @@ class GateValidatorTests(unittest.TestCase):
         )
 
 
+    def test_undeclared_need_output_fails_closed(self):
+        # RUE-1130 regression. GitHub resolves an undeclared job output to the
+        # empty string instead of failing, so a lane gate reading it would see
+        # "nothing selected" and deselect every lane. That is invisible on any
+        # PR touching CI, because those force a full run — i.e. invisible on
+        # exactly the PRs that would be used to test the feature.
+        changed = SOURCE.read_text().replace(
+            "      selected_lanes: ${{ steps.decide.outputs.selected_lanes }}\n", "", 1
+        )
+        errors = "\n".join(self.validate_text(changed))
+        self.assertIn("needs.affected-targets.outputs.selected_lanes is referenced", errors)
+        self.assertIn("silently resolve to the empty string", errors)
+
+    def test_declared_need_outputs_pass(self):
+        self.assertEqual(self.validate_text(SOURCE.read_text()), [])
+
+    def test_need_output_from_unknown_job_fails(self):
+        self.assertIn(
+            "references unknown job",
+            "\n".join(
+                MODULE.undeclared_need_outputs(
+                    "${{ needs.ghost.outputs.thing }}", {"real": "    outputs:\n      thing: x\n"}
+                )
+            ),
+        )
+
+    def test_declared_outputs_parses_past_comments(self):
+        # The declaration this guard protects carries an explanatory comment;
+        # the parser must not stop at it and report the output as undeclared.
+        block = (
+            "    outputs:\n"
+            "      full: ${{ steps.decide.outputs.full }}\n"
+            "      # why this exists\n"
+            "      selected_lanes: ${{ steps.decide.outputs.selected_lanes }}\n"
+        )
+        self.assertEqual(MODULE.declared_outputs(block), {"full", "selected_lanes"})
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/scripts/test-validate-ci-gate.py
+++ b/scripts/test-validate-ci-gate.py
@@ -195,5 +195,32 @@ class GateValidatorTests(unittest.TestCase):
         self.assertEqual(MODULE.declared_outputs(block), {"full", "selected_lanes"})
 
 
+    def test_lane_target_drift_fails_closed(self):
+        # RUE-1130. A target the native job runs but the determinator does not
+        # list is invisible to selection: the lane can be deselected, or
+        # narrowed away, by a diff that actually reaches it.
+        changed = SOURCE.read_text().replace(
+            "            //crates/rue-target:rue-target-test\n          )",
+            "            //crates/rue-target:rue-target-test\n"
+            "            //crates/rue-query:rue-query-test\n          )",
+            1,
+        )
+        errors = "\n".join(self.validate_text(changed))
+        self.assertIn("//crates/rue-query:rue-query-test", errors)
+        self.assertIn("selection cannot see it", errors)
+
+    def test_lane_targets_and_job_agree_today(self):
+        self.assertEqual(MODULE.lane_target_drift(SOURCE.read_text()), [])
+
+    def test_unreadable_lane_script_fails_closed(self):
+        # The gate must not pass silently when it cannot read the lane list.
+        self.assertIn(
+            "produced nothing",
+            "\n".join(
+                MODULE.lane_target_drift(SOURCE.read_text(), script=Path("/nonexistent/affected-targets"))
+            ),
+        )
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/scripts/validate-ci-gate.py
+++ b/scripts/validate-ci-gate.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import argparse
 import importlib.util
 import re
+import subprocess
 from pathlib import Path
 
 RESULTS_SCRIPT = Path(__file__).with_name("ci-required-results.py")
@@ -135,6 +136,49 @@ def undeclared_need_outputs(workflow: str, jobs: dict[str, str]) -> list[str]:
                 "it would silently resolve to the empty string"
             )
     return sorted(problems)
+
+
+
+AFFECTED_TARGETS_SCRIPT = Path(__file__).with_name("affected-targets")
+
+
+def lane_targets(lane: str, script: Path = AFFECTED_TARGETS_SCRIPT) -> set[str]:
+    """The Buck targets the determinator believes a gated lane executes."""
+    result = subprocess.run(
+        ["bash", str(script), "lane-targets", lane],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        return set()
+    return set(result.stdout.split())
+
+
+def lane_target_drift(workflow: str, script: Path = AFFECTED_TARGETS_SCRIPT) -> list[str]:
+    """Targets a lane's job runs that its determinator entry does not represent.
+
+    RUE-1130 gates and narrows lanes against `lane_targets`, so a target the job
+    runs but the determinator does not know about is invisible to selection: the
+    lane can be deselected, or narrowed away, by a diff that actually reaches
+    it. That is the RUE-924 failure mode arriving through a stale list rather
+    than a missing job, and the two lists are far apart in the tree, so nothing
+    but a gate keeps them together.
+    """
+    jobs = job_blocks(workflow)
+    native = jobs.get("native-platforms", "")
+    ran = set(re.findall(r"^\s+(//[A-Za-z0-9_./-]+:[A-Za-z0-9_.-]+)$", native, re.MULTILINE))
+    if not ran:
+        return ["native-platforms declares no Buck targets; the lane gate cannot be checked"]
+    known = lane_targets("native-linux-arm64", script)
+    if not known:
+        return ["scripts/affected-targets lane-targets native-linux-arm64 produced nothing"]
+    missing = sorted(ran - known)
+    return [
+        f"native-platforms runs {target} but scripts/affected-targets does not list it "
+        "for native-linux-arm64, so selection cannot see it"
+        for target in missing
+    ]
 
 
 def validate(
@@ -329,6 +373,7 @@ def validate(
         errors.append("manual Valgrind large_program selection was not preserved")
 
     errors.extend(undeclared_need_outputs(workflow, jobs))
+    errors.extend(lane_target_drift(workflow))
 
     if "  pull_request:\n" not in workflow or "  merge_group:\n" not in workflow:
         errors.append("CI must run on both pull_request and merge_group")

--- a/scripts/validate-ci-gate.py
+++ b/scripts/validate-ci-gate.py
@@ -105,6 +105,38 @@ def list_needs(block: str) -> set[str]:
     return set(re.findall(rf"^      - ({ACTION_ID})$", match.group(1), re.MULTILINE))
 
 
+
+def declared_outputs(block: str) -> set[str]:
+    """Output names a job block declares under `outputs:`."""
+    match = re.search(r"^    outputs:\n((?:      \S.*\n|      #.*\n)+)", block, re.MULTILINE)
+    if not match:
+        return set()
+    return set(re.findall(r"^      ([A-Za-z_][A-Za-z0-9_-]*):", match.group(1), re.MULTILINE))
+
+
+def undeclared_need_outputs(workflow: str, jobs: dict[str, str]) -> list[str]:
+    """`needs.<job>.outputs.<name>` references with no matching declaration.
+
+    GitHub resolves an undeclared job output to the empty string rather than
+    failing, so a typo or a forgotten declaration becomes a silent behaviour
+    change in whatever consumes it. For the RUE-1130 lane gates that means
+    every lane deselecting on a selective run, which is invisible on any pull
+    request that touches CI (those force a full run) and therefore exactly the
+    kind of drop RUE-924 exists to prevent.
+    """
+    problems: list[str] = []
+    for job, name in set(re.findall(r"needs\.([A-Za-z0-9_-]+)\.outputs\.([A-Za-z0-9_-]+)", workflow)):
+        block = jobs.get(job)
+        if block is None:
+            problems.append(f"needs.{job}.outputs.{name} references unknown job {job!r}")
+        elif name not in declared_outputs(block):
+            problems.append(
+                f"needs.{job}.outputs.{name} is referenced but {job!r} does not declare it; "
+                "it would silently resolve to the empty string"
+            )
+    return sorted(problems)
+
+
 def validate(
     ci_path: Path,
     native_runner_path: Path = NATIVE_RUNNER_SCRIPT,
@@ -295,6 +327,8 @@ def validate(
             errors.append(f"{sanitizer} is no longer consolidated into CI")
     if "inputs.large_program" not in jobs.get("valgrind", ""):
         errors.append("manual Valgrind large_program selection was not preserved")
+
+    errors.extend(undeclared_need_outputs(workflow, jobs))
 
     if "  pull_request:\n" not in workflow or "  merge_group:\n" not in workflow:
         errors.append("CI must run on both pull_request and merge_group")

--- a/test.sh
+++ b/test.sh
@@ -107,7 +107,36 @@ if [[ $# -eq 0 ]]; then
     # The CLI shards are excluded because they are scheduling alternatives for
     # the monolithic //:cli-tests, not additional coverage: running both would
     # execute the same cases five times.
-    test_args=(//... toolchains//... --always-exclude --ignore-tests-attribute --exclude rue_cli_shard)
+    # RUE-1130. On a selective CI run the determinator supplies the impacted
+    # target closure, and this lane runs that instead of the `//...` pattern.
+    # The label filters below are unchanged and still applied, so the result is
+    # exactly `impacted ∩ tier ∩ not-deferred` — narrowing what runs without
+    # changing what membership means.
+    #
+    # FAIL-OPEN, in the same direction as the determinator: an unset variable,
+    # an unreadable file, or a file the determinator declined to narrow (empty)
+    # all fall back to the full pattern. Only a readable, non-empty list
+    # narrows, and merge_group never narrows because it never runs selectively.
+    #
+    # An explicit list that filters down to no tests is a legitimate outcome
+    # (impacted libraries with no premerge tests of their own) and buck2 exits 0
+    # reporting NO TESTS RAN. That is indistinguishable from a narrowing bug by
+    # exit status alone, so the selection is echoed and counted here rather than
+    # left to be inferred from a silent green.
+    local_targets=(//... toolchains//...)
+    narrow_file="${RUE_TEST_TARGETS_FILE:-}"
+    if [[ -n "$narrow_file" ]]; then
+        if [[ ! -r "$narrow_file" ]]; then
+            echo "test.sh: RUE_TEST_TARGETS_FILE='$narrow_file' is unreadable; running the full pattern" >&2
+        elif [[ ! -s "$narrow_file" ]]; then
+            echo "test.sh: no narrowed target list supplied; running the full pattern"
+        else
+            mapfile -t local_targets <"$narrow_file"
+            echo "test.sh: narrowed to ${#local_targets[@]} impacted target(s) by the affected-targets determinator"
+        fi
+    fi
+
+    test_args=("${local_targets[@]}" --always-exclude --ignore-tests-attribute --exclude rue_cli_shard)
     if [[ "$test_tier" == standard ]]; then
         test_args+=(--exclude rue_test_tier_stress)
     elif [[ "$test_tier" != all ]]; then


### PR DESCRIPTION
Implements RUE-1130 and marks ADR-0069 accepted. Follows #2145, which merged while this was in progress, so this is a new pull request rather than a push to that one.

> **Description rewritten at `cd4b8354`.** The original said `linux-premerge` was deliberately left alone. That was reversed during review of the direction: it is now narrowed rather than gated, which is the central change here and the thing most worth reviewing.

## The decision RUE-1130 asks for

**Keep and extend to everything, not remove.**

The issue observed zero deselections across 9 runs × 18 corpus jobs and asked whether the selector earns its complexity. A wider sample says the deselection count was the wrong statistic: across **55 runs classified by change class and 21 timed to step level**, a two-file documentation change costs **444s against 465s** for a compiler change — 4.5% less. It still builds the compiler and still runs 813 compiler unit tests on linux-x64, then the same 813 again on linux-arm64 and again on macOS.

The determinator was already computing the right answer. It was wired to 7 of ~14 jobs, and not to any job that dominates a run.

## Gating and narrowing

Two granularities of the same determinator output:

- **Gating** decides *whether* a lane runs. Six lanes now consult it: `native (linux-arm64)`, `native (macos-arm64)`, `release`, `valgrind`, `asan`, `compiler reproducibility`. Selection stays *within* the job, so the aggregate gate and branch protection are untouched and a deselected lane costs only runner spin-up.
- **Narrowing** decides *what* a lane runs. `linux-premerge` is never gated — skipping the broad-discovery lane on a representative subset is the RUE-924 failure mode — but it now builds the impacted closure instead of `//crates/...`, and `test.sh` runs `impacted ∩ tier` in place of `//... ∩ tier`. The native lanes intersect their eight unit targets the same way.

Membership still comes from the live graph, so a target added since any list was written is still discovered; it is simply not built or run when the diff cannot reach it. Building a test binary is most of what a unit target costs, and this lane spends 286–317s building every crate whenever a compiler crate changes.

Narrowing is **declined** when nothing is impacted, or when so much is that `//...` is the better expression (`RUE_AFFECTED_NARROW_LIMIT`, default 600). Consumers key on a `narrowed` flag rather than on the list being non-empty, so an absent, empty, or oversized list always reads as "run everything". `test.sh` applies the same rule: unset, unreadable, or empty `RUE_TEST_TARGETS_FILE` runs the full pattern.

One asymmetry is called out in the code rather than left implicit: an explicit list that filters to no tests is legitimate, and buck2 exits 0 reporting `NO TESTS RAN` — indistinguishable by exit status from a narrowing bug. The selected count is echoed rather than inferred from a silent green.

The ASan harness is a standalone Cargo project outside the Buck graph, so BTD cannot see it; `crates/rue-runtime-asan/` forces a full run rather than relying on a proxy target.

## Two gates that fail closed

Both were written because this PR tripped the failure they now prevent.

- **Undeclared job outputs.** `selected_lanes` was read in five places before being declared. GitHub resolves an undeclared output to the empty string rather than failing, so every gated lane would have deselected itself on a selective run — RUE-924 through a silent empty string. `validate-ci-gate.py` now requires every `needs.<job>.outputs.<name>` to be declared by that job. It then caught the same class again on `impacted`/`narrowed`.
- **Lane-target drift.** `lane_targets` is a second copy of the native lane's eight targets. A target the job runs but the determinator does not list is invisible to selection, so the lane can be deselected — or narrowed away — by a diff that reaches it. The two lists are now compared, failing closed, including when the lane list cannot be read at all.

## Measured effect

Gating, on the four peripheral runs in the sample:

| run | runner time freed | critical path |
| --- | --- | --- |
| 31199530662 | 1034s | 409s → 409s |
| 31231601304 | 905s | 463s → 463s |
| 31291960267 | 954s | 460s → 460s |
| 31293391236 | 969s | **395s → 278s** |

Gating alone is a **cost win, not a latency win** — the critical path moves in one of four, because `premerge` dominates the rest. That is what narrowing addresses, and why the two landed together rather than gating being called done.

Not measured: the narrowed path's effect on a real run. `test.sh` and `.github/workflows/` are both in the force-full list, so this PR — like any PR that touches CI — structurally cannot exercise narrowing in its own CI. All four fallback paths were verified locally against a real buck2, including a narrowed run that executed exactly the two targets it was given. **The first real narrowed run will be the next docs-only PR after this merges, and is worth watching.**

## Cost

Gated lanes now wait on `affected-targets` (11–25s) before starting. They are not the critical path in 18 of 21 timed runs, so this is paid out of slack — but it is a real regression for the three runs where a native lane *was* the critical path.

## ADR-0069

Marked `accepted`, phase 2 recorded as done. Adds the standard this work is held to — *the repository should grow without anyone editing CI to keep it correct or fast* — and a ledger of everything still hand-maintained, what each breaks as the repo grows, and whether it is gated or merely fails open. Two rows remain ungated: `SELECTABLE_CORPUS`, and the 600-target narrowing limit, which is a number picked rather than measured.

## Tests and validation

The selector suite goes from 53 to **83 checks**: lane recognition, representative-target presence, the fail-open matrix, corpus/lane state separation, out-of-graph ASan sources, the intersection helper's ordering and empty/missing inputs, and `test.sh`'s four fallback paths including that a narrowed suite keeps its tier and deferral filters. `test-validate-ci-gate.py` goes to 21 tests covering both new gates.

Green locally: the four Python validators, 83 selector checks, 21 gate-validator tests, 13 Buck contract gates, and **actionlint 1.7.12 with shellcheck** — now installed locally, so that check is no longer one that can only fail in CI.

Refs RUE-1130. Refs RUE-1250. Refs RUE-1262.