### PR TITLE
RUE-1255: bound retained-report runtime

### DIFF
--- a/.github/workflows/performance-incremental.yml
+++ b/.github/workflows/performance-incremental.yml
@@ -23,7 +23,9 @@ concurrency:
 jobs:
   measure:
     runs-on: ubuntu-24.04
-    timeout-minutes: 360
+    # A report that cannot finish within this bounded evidence window is itself
+    # too expensive to keep as a scheduled compiler-performance instrument.
+    timeout-minutes: 40
     steps:
       - uses: actions/checkout@v6
 

--- a/crates/rue-bench/src/incremental.rs
+++ b/crates/rue-bench/src/incremental.rs
@@ -7,9 +7,11 @@
 use std::collections::BTreeSet;
 use std::fs;
 use std::path::{Path, PathBuf};
-use std::time::Instant;
+use std::time::{Duration, Instant};
 
-use rue_compiler::unstable::{EndpointQueryWork, EndpointWork, MetricsSnapshot};
+use rue_compiler::unstable::{
+    EndpointQueryWork, EndpointWork, MetricsSnapshot, QueryRuntimeMetrics,
+};
 use rue_compiler::{CompileErrors, CompileOptions, CompileOutput, CompileWarning, OptLevel};
 use rue_driver::{FilesystemCompilerHost, HostOpenRequest, SourceLoadError};
 use rue_perf_schema::{
@@ -99,6 +101,7 @@ impl FixtureManifest {
         let manifest_ids: Vec<_> = manifest
             .workloads
             .iter()
+            .chain(std::iter::once(&manifest.retention_workload))
             .map(|workload| &workload.id)
             .collect();
         if declared_ids != manifest_ids {
@@ -120,6 +123,7 @@ impl FixtureManifest {
             let manifest_workload = manifest
                 .workloads
                 .iter()
+                .chain(std::iter::once(&manifest.retention_workload))
                 .find(|entry| entry.id == workload.id)
                 .expect("workload ids were compared above");
             if source != Path::new(&manifest_workload.source) {
@@ -277,11 +281,47 @@ pub(crate) struct SampleRequest<'a> {
     pub sample_index: u32,
     pub session_id: String,
     pub collection_order: u32,
+    pub fresh_oracle: Option<&'a OutcomeIdentity>,
 }
 
 pub(crate) struct SampleObservation {
     pub shape: SourceShape,
     pub sample: EditSample,
+    collection_timing: CollectionTiming,
+}
+
+#[derive(Debug, Clone, Copy, Default)]
+struct CollectionTiming {
+    setup_and_baseline: Duration,
+    warm: Duration,
+    fresh_oracle: Duration,
+    total: Duration,
+    query_runtime: QueryRuntimeMetrics,
+}
+
+impl CollectionTiming {
+    fn add(&mut self, other: Self) {
+        self.setup_and_baseline += other.setup_and_baseline;
+        self.warm += other.warm;
+        self.fresh_oracle += other.fresh_oracle;
+        self.total += other.total;
+        self.query_runtime.validation_memo_hits += other.query_runtime.validation_memo_hits;
+        self.query_runtime.validation_memo_misses += other.query_runtime.validation_memo_misses;
+        self.query_runtime.retention_enforcements += other.query_runtime.retention_enforcements;
+        self.query_runtime.retention_scan_entries += other.query_runtime.retention_scan_entries;
+    }
+
+    fn other(self) -> Duration {
+        self.total.saturating_sub(
+            self.setup_and_baseline
+                .saturating_add(self.warm)
+                .saturating_add(self.fresh_oracle),
+        )
+    }
+}
+
+fn elapsed_ms(duration: Duration) -> u128 {
+    duration.as_millis()
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -344,22 +384,51 @@ pub(crate) fn run() -> Result<ReportStatus, String> {
                     },
                     scenario: scenario.scenario,
                     worker_mode: worker.mode,
-                    samples: Vec::with_capacity(manifest.samples_per_row as usize),
+                    samples: Vec::with_capacity(manifest.samples_for(scenario.scenario) as usize),
                 });
             }
         }
     }
 
+    let collection_started = Instant::now();
+    let matrix_started = Instant::now();
+    let mut matrix_timing = CollectionTiming::default();
     let scenario_count = manifest.scenarios.len();
     for (workload_index, workload) in manifest.workloads.iter().enumerate() {
         let fixture = fixtures.workload(&workload.id);
         let fixture_root = options.repo_root.join(&fixture.fixture_root);
+        let oracle_started = Instant::now();
+        let fresh_oracles = manifest
+            .scenarios
+            .iter()
+            .map(|declaration| {
+                eprintln!(
+                    "rue-bench: preparing fresh oracle for {} {}",
+                    workload.id,
+                    declaration.scenario.wire_name()
+                );
+                fresh_fixture_identity(
+                    &fixture_root,
+                    &fixture.root_source,
+                    &fixture.overlays,
+                    options.std_root.as_deref(),
+                    &compile_options,
+                    Some(&fixture.edit(declaration.scenario)),
+                    declaration.expected_outcome,
+                )
+            })
+            .collect::<Result<Vec<_>, _>>()?;
+        matrix_timing.fresh_oracle += oracle_started.elapsed();
         for (worker_index, worker) in manifest.workers.iter().enumerate() {
-            for sample_index in 0..manifest.samples_per_row {
+            for sample_index in 0..manifest.timing_samples_per_row {
                 for collection_order in 0..scenario_count {
                     let scenario_index =
                         (collection_order + sample_index as usize) % scenario_count;
                     let declaration = &manifest.scenarios[scenario_index];
+                    let sample_count = manifest.samples_for(declaration.scenario);
+                    if sample_index >= sample_count {
+                        continue;
+                    }
                     let operation = fixture.edit(declaration.scenario);
                     eprintln!(
                         "rue-bench: incremental {} {} {} sample {}/{}",
@@ -367,7 +436,7 @@ pub(crate) fn run() -> Result<ReportStatus, String> {
                         declaration.scenario.wire_name(),
                         worker.mode.wire_name(),
                         sample_index + 1,
-                        manifest.samples_per_row
+                        sample_count
                     );
                     let observation = measure_sample(SampleRequest {
                         fixture_root: &fixture_root,
@@ -389,11 +458,44 @@ pub(crate) fn run() -> Result<ReportStatus, String> {
                             sample_index
                         ),
                         collection_order: collection_order as u32,
+                        fresh_oracle: Some(&fresh_oracles[scenario_index]),
                     })?;
                     validate_structural_expectation(
                         declaration.scenario,
                         &observation.sample.work,
                     )?;
+                    eprintln!(
+                        "rue-bench: incremental {} {} {} sample {}/{} completed in {} ms \
+                         (setup+baseline {} ms, warm {} ms, fresh-oracle {} ms, other {} ms; \
+                         validation hits {}, misses {}; retention passes {}, scan entries {})",
+                        workload.id,
+                        declaration.scenario.wire_name(),
+                        worker.mode.wire_name(),
+                        sample_index + 1,
+                        sample_count,
+                        elapsed_ms(observation.collection_timing.total),
+                        elapsed_ms(observation.collection_timing.setup_and_baseline),
+                        elapsed_ms(observation.collection_timing.warm),
+                        elapsed_ms(observation.collection_timing.fresh_oracle),
+                        elapsed_ms(observation.collection_timing.other()),
+                        observation
+                            .collection_timing
+                            .query_runtime
+                            .validation_memo_hits,
+                        observation
+                            .collection_timing
+                            .query_runtime
+                            .validation_memo_misses,
+                        observation
+                            .collection_timing
+                            .query_runtime
+                            .retention_enforcements,
+                        observation
+                            .collection_timing
+                            .query_runtime
+                            .retention_scan_entries,
+                    );
+                    matrix_timing.add(observation.collection_timing);
                     let row_index = ((workload_index * scenario_count + scenario_index)
                         * manifest.workers.len())
                         + worker_index;
@@ -416,7 +518,18 @@ pub(crate) fn run() -> Result<ReportStatus, String> {
         }
     }
 
+    eprintln!(
+        "rue-bench: incremental edit matrix completed in {} ms \
+         (sample totals: setup+baseline {} ms, warm {} ms, fresh-oracle {} ms, other {} ms)",
+        elapsed_ms(matrix_started.elapsed()),
+        elapsed_ms(matrix_timing.setup_and_baseline),
+        elapsed_ms(matrix_timing.warm),
+        elapsed_ms(matrix_timing.fresh_oracle),
+        elapsed_ms(matrix_timing.other()),
+    );
+
     eprintln!("rue-bench: incremental bounded-retention sequence");
+    let retention_started = Instant::now();
     let retention = collect_retention(
         &manifest,
         &fixtures,
@@ -424,6 +537,14 @@ pub(crate) fn run() -> Result<ReportStatus, String> {
         options.std_root.as_deref(),
         &compile_options,
     )?;
+    eprintln!(
+        "rue-bench: incremental bounded-retention sequence completed in {} ms",
+        elapsed_ms(retention_started.elapsed())
+    );
+    eprintln!(
+        "rue-bench: incremental collection completed in {} ms",
+        elapsed_ms(collection_started.elapsed())
+    );
     let report = EditReport {
         schema_version: EDIT_REPORT_SCHEMA_VERSION,
         identity: EditReportIdentity {
@@ -437,7 +558,8 @@ pub(crate) fn run() -> Result<ReportStatus, String> {
         regime: EditReportRegime {
             compiler_state: "retained_session".into(),
             os_page_cache: "uncontrolled".into(),
-            samples_per_row: manifest.samples_per_row,
+            timing_samples_per_row: manifest.timing_samples_per_row,
+            structural_samples_per_row: manifest.structural_samples_per_row,
             retention_revisions: manifest.retention_revisions,
             rotation: manifest.rotation,
             optimization: manifest.optimization,
@@ -559,6 +681,7 @@ pub(crate) fn write_validated_report(
 }
 
 pub(crate) fn measure_sample(request: SampleRequest<'_>) -> Result<SampleObservation, String> {
+    let total_started = Instant::now();
     let resolved_workers = resolve_workers(request.worker_mode);
     rue_compiler::configure_thread_pool(resolved_workers as usize);
 
@@ -581,7 +704,11 @@ pub(crate) fn measure_sample(request: SampleRequest<'_>) -> Result<SampleObserva
     let one_shot = baseline.unstable_metrics();
     let shape = SourceShape {
         files: one_shot.files as u64,
-        modules: one_shot.parsed.modules_considered as u64,
+        // The accepted filesystem closure has one source file per Rue module.
+        // `modules_considered` is a work counter and may be zero when retained
+        // query terminals satisfy the baseline without running the retired
+        // whole-program parse projection.
+        modules: one_shot.files as u64,
         bytes: one_shot.bytes as u64,
         lines: one_shot.lines as u64,
         tokens: one_shot.tokens as u64,
@@ -589,6 +716,7 @@ pub(crate) fn measure_sample(request: SampleRequest<'_>) -> Result<SampleObserva
     };
 
     apply_operation(isolated.path(), request.operation)?;
+    let setup_and_baseline = total_started.elapsed();
     let started = Instant::now();
     warm.reobserve().map_err(source_load_error)?;
     warm.acquire_reached_toolchain_modules(request.options)
@@ -645,6 +773,10 @@ pub(crate) fn measure_sample(request: SampleRequest<'_>) -> Result<SampleObserva
         ),
     };
     let endpoint_metrics = warm.unstable_metrics();
+    let query_runtime = query_runtime_delta(
+        baseline_metrics.query_runtime(),
+        endpoint_metrics.query_runtime(),
+    );
     let work = structural_work(
         &baseline_metrics,
         &endpoint_metrics,
@@ -653,15 +785,31 @@ pub(crate) fn measure_sample(request: SampleRequest<'_>) -> Result<SampleObserva
     );
     let retention = retained_gauges(endpoint_metrics);
     let warm_identity = outcome_identity(&outcome);
+    let warm = match &outcome {
+        EditOutcome::Success { endpoints, .. } => Duration::from_nanos(endpoints.runnable_ready_ns),
+        EditOutcome::ExpectedDiagnostics {
+            diagnostics_ready_ns,
+            ..
+        } => Duration::from_nanos(*diagnostics_ready_ns),
+        EditOutcome::UnexpectedFailure { .. } => started.elapsed(),
+    };
 
-    // The correctness oracle owns a new session over revision B and is wholly
-    // outside the measured interval.
-    let mut fresh = open_host(&root, manifest.as_deref(), request.std_root)?;
-    fresh
-        .acquire_reached_toolchain_modules(request.options)
-        .map_err(source_load_error)?;
-    let fresh_identity = fresh_identity(&mut fresh, request.options, request.expected_outcome);
+    // The correctness oracle is wholly outside the measured interval. The
+    // report runner precomputes one fresh identity per exact fixture state;
+    // focused callers may still request an inline independent oracle.
+    let oracle_started = Instant::now();
+    let fresh_identity = match request.fresh_oracle {
+        Some(identity) => identity.clone(),
+        None => {
+            let mut fresh = open_host(&root, manifest.as_deref(), request.std_root)?;
+            fresh
+                .acquire_reached_toolchain_modules(request.options)
+                .map_err(source_load_error)?;
+            fresh_identity(&mut fresh, request.options, request.expected_outcome)
+        }
+    };
     let oracle = compare_identities(warm_identity, fresh_identity);
+    let fresh_oracle = oracle_started.elapsed();
 
     Ok(SampleObservation {
         shape,
@@ -676,7 +824,34 @@ pub(crate) fn measure_sample(request: SampleRequest<'_>) -> Result<SampleObserva
             retention,
             oracle,
         },
+        collection_timing: CollectionTiming {
+            setup_and_baseline,
+            warm,
+            fresh_oracle,
+            total: total_started.elapsed(),
+            query_runtime,
+        },
     })
+}
+
+fn query_runtime_delta(
+    before: QueryRuntimeMetrics,
+    after: QueryRuntimeMetrics,
+) -> QueryRuntimeMetrics {
+    QueryRuntimeMetrics {
+        validation_memo_hits: after
+            .validation_memo_hits
+            .saturating_sub(before.validation_memo_hits),
+        validation_memo_misses: after
+            .validation_memo_misses
+            .saturating_sub(before.validation_memo_misses),
+        retention_enforcements: after
+            .retention_enforcements
+            .saturating_sub(before.retention_enforcements),
+        retention_scan_entries: after
+            .retention_scan_entries
+            .saturating_sub(before.retention_scan_entries),
+    }
 }
 
 fn validate_structural_expectation(
@@ -777,10 +952,7 @@ fn collect_retention(
     std_root: Option<&Path>,
     options: &CompileOptions,
 ) -> Result<RetentionSequence, String> {
-    let workload = manifest
-        .workloads
-        .first()
-        .expect("the validated manifest has a workload");
+    let workload = &manifest.retention_workload;
     let fixture = fixtures.workload(&workload.id);
     let fixture_root = repo_root.join(&fixture.fixture_root);
     let resolved_workers = resolve_workers(WorkerMode::Automatic);
@@ -851,6 +1023,7 @@ fn collect_retention(
         .map_err(source_load_error)?;
     run_success(&mut warm, options)
         .map_err(|errors| format!("retention baseline did not compile: {errors}"))?;
+    let initial_query_evictions = warm.unstable_metrics().retention().query_evictions as u64;
 
     let mut revisions = Vec::with_capacity(manifest.retention_revisions as usize);
     for revision_index in 0..manifest.retention_revisions {
@@ -900,11 +1073,32 @@ fn collect_retention(
             )),
             retention: retained_gauges(warm.unstable_metrics()),
         });
+        let completed = revision_index + 1;
+        if completed % 100 == 0 || completed == manifest.retention_revisions {
+            let gauges = &revisions
+                .last()
+                .expect("the completed retention revision was just recorded")
+                .retention;
+            eprintln!(
+                "rue-bench: incremental bounded-retention revision {completed}/{} \
+                 (current {} bytes, peak {} bytes, observations {}/{})",
+                manifest.retention_revisions,
+                gauges.current_bytes,
+                gauges.peak_bytes,
+                gauges
+                    .dependency_observations
+                    .saturating_add(gauges.input_observations),
+                gauges.observation_budget,
+            );
+        }
     }
+    let query_evictions = (warm.unstable_metrics().retention().query_evictions as u64)
+        .saturating_sub(initial_query_evictions);
     Ok(RetentionSequence {
         workload: workload.id.clone(),
         worker_mode: WorkerMode::Automatic,
         resolved_workers,
+        query_evictions,
         revisions,
     })
 }
@@ -919,7 +1113,7 @@ fn fresh_fixture_identity(
     expected: ExpectedEditOutcome,
 ) -> Result<OutcomeIdentity, String> {
     let isolated = tempfile::tempdir()
-        .map_err(|error| format!("could not create fresh retention oracle: {error}"))?;
+        .map_err(|error| format!("could not create fresh fixture oracle: {error}"))?;
     copy_tree(fixture_root, isolated.path())?;
     apply_overlays(isolated.path(), overlays)?;
     if let Some(operation) = operation {
@@ -1356,6 +1550,24 @@ mod tests {
         OptimizationSetting, RetentionSequence, RotationRule,
     };
 
+    #[test]
+    fn collection_timing_attributes_only_time_outside_declared_stages() {
+        let timing = CollectionTiming {
+            setup_and_baseline: Duration::from_millis(20),
+            warm: Duration::from_millis(5),
+            fresh_oracle: Duration::from_millis(10),
+            total: Duration::from_millis(40),
+            query_runtime: QueryRuntimeMetrics::default(),
+        };
+        assert_eq!(timing.other(), Duration::from_millis(5));
+
+        let overlapping_clocks = CollectionTiming {
+            total: Duration::from_millis(1),
+            ..timing
+        };
+        assert_eq!(overlapping_clocks.other(), Duration::ZERO);
+    }
+
     fn fixture(source: &str) -> tempfile::TempDir {
         let dir = tempfile::tempdir().unwrap();
         fs::write(dir.path().join("main.rue"), source).unwrap();
@@ -1394,6 +1606,7 @@ mod tests {
             sample_index: 0,
             session_id: "test-session".into(),
             collection_order: 0,
+            fresh_oracle: None,
         }
     }
 
@@ -1423,14 +1636,59 @@ mod tests {
             observation.sample.oracle,
             OracleComparison::Matched { .. }
         ));
-        assert_eq!(observation.shape.files, 1);
+        assert!(
+            observation.shape.files > 0
+                && observation.shape.modules > 0
+                && observation.shape.bytes > 0
+                && observation.shape.lines > 0
+                && observation.shape.tokens > 0
+                && observation.shape.functions > 0,
+            "compiler-derived source shape must be complete: {:?}",
+            observation.shape
+        );
+    }
+
+    #[test]
+    fn successful_edit_accepts_a_precomputed_fresh_oracle() {
+        let fixture = fixture("fn main() -> i32 { 1 }\n");
+        let operation = EditOperation::Replace {
+            id: "body".into(),
+            logical_file: "main.rue".into(),
+            before: "{ 1 }".into(),
+            after: "{ 2 }".into(),
+        };
+        let options = CompileOptions::default();
+        let fresh_oracle = fresh_fixture_identity(
+            fixture.path(),
+            Path::new("main.rue"),
+            &[],
+            None,
+            &options,
+            Some(&operation),
+            ExpectedEditOutcome::Success,
+        )
+        .unwrap();
+        let mut request = request(
+            fixture.path(),
+            &operation,
+            &options,
+            ExpectedEditOutcome::Success,
+        );
+        request.fresh_oracle = Some(&fresh_oracle);
+
+        let observation = measure_sample(request).unwrap();
+
+        assert!(matches!(
+            observation.sample.oracle,
+            OracleComparison::Matched { .. }
+        ));
     }
 
     #[test]
     fn maintained_fixture_manifest_covers_the_exact_versioned_matrix() {
         let (manifest, fixtures) = maintained_fixtures();
         assert_eq!(fixtures.fixture_revision, manifest.fixture_revision);
-        assert_eq!(fixtures.workloads.len(), 2);
+        assert_eq!(fixtures.workloads.len(), 3);
         assert!(
             fixtures
                 .workload("mosaic")
@@ -1444,6 +1702,13 @@ mod tests {
                 .edit(EditScenario::ImportSet)
                 .id()
                 .starts_with("lattice-")
+        );
+        assert!(
+            fixtures
+                .workload("retention")
+                .edit(EditScenario::ReachedBodyOnly)
+                .id()
+                .starts_with("retention-")
         );
     }
 
@@ -1490,6 +1755,7 @@ mod tests {
                         declaration.scenario.wire_name()
                     ),
                     collection_order: 0,
+                    fresh_oracle: None,
                 })
                 .unwrap_or_else(|error| {
                     panic!(
@@ -1498,6 +1764,34 @@ mod tests {
                         declaration.scenario.wire_name()
                     )
                 });
+                eprintln!(
+                    "rue-bench: maintained fixture {} {} completed in {} ms \
+                     (setup+baseline {} ms, warm {} ms, fresh-oracle {} ms, other {} ms; \
+                     validation hits {}, misses {}; retention passes {}, scan entries {})",
+                    workload.id,
+                    declaration.scenario.wire_name(),
+                    elapsed_ms(observation.collection_timing.total),
+                    elapsed_ms(observation.collection_timing.setup_and_baseline),
+                    elapsed_ms(observation.collection_timing.warm),
+                    elapsed_ms(observation.collection_timing.fresh_oracle),
+                    elapsed_ms(observation.collection_timing.other()),
+                    observation
+                        .collection_timing
+                        .query_runtime
+                        .validation_memo_hits,
+                    observation
+                        .collection_timing
+                        .query_runtime
+                        .validation_memo_misses,
+                    observation
+                        .collection_timing
+                        .query_runtime
+                        .retention_enforcements,
+                    observation
+                        .collection_timing
+                        .query_runtime
+                        .retention_scan_entries,
+                );
                 assert!(matches!(
                     observation.sample.oracle,
                     OracleComparison::Matched { .. }
@@ -1505,6 +1799,55 @@ mod tests {
                 validate_structural_expectation(declaration.scenario, &observation.sample.work)
                     .unwrap();
             }
+        }
+    }
+
+    #[test]
+    #[ignore = "the full 1000-revision retention witness belongs to the slow measurement lane"]
+    fn maintained_retention_sequence_reaches_every_declared_state() {
+        let (mut manifest, fixtures) = maintained_fixtures();
+        manifest.retention_revisions = std::env::var("RUE_INCREMENTAL_TEST_RETENTION_REVISIONS")
+            .ok()
+            .and_then(|value| value.parse().ok())
+            .unwrap_or(16);
+        let options = CompileOptions {
+            target: manifest
+                .target
+                .parse()
+                .expect("manifest target is supported"),
+            ..CompileOptions::default()
+        };
+        let started = Instant::now();
+        let retention = collect_retention(
+            &manifest,
+            &fixtures,
+            Path::new("."),
+            Some(Path::new("std")),
+            &options,
+        )
+        .unwrap();
+        eprintln!(
+            "rue-bench: maintained retention diagnostic completed {} revisions with {} query \
+             evictions in {} ms",
+            retention.revisions.len(),
+            retention.query_evictions,
+            elapsed_ms(started.elapsed()),
+        );
+        assert_eq!(
+            retention.revisions.len(),
+            manifest.retention_revisions as usize
+        );
+        assert!(
+            retention
+                .revisions
+                .iter()
+                .all(|revision| matches!(revision.oracle, Some(OracleComparison::Matched { .. })))
+        );
+        if manifest.retention_revisions >= 1_000 {
+            assert!(
+                retention.query_evictions > 0,
+                "the full retention witness must exercise query cleanup"
+            );
         }
     }
 
@@ -1632,7 +1975,8 @@ mod tests {
             regime: EditReportRegime {
                 compiler_state: "retained_session".into(),
                 os_page_cache: "uncontrolled".into(),
-                samples_per_row: manifest.samples_per_row,
+                timing_samples_per_row: manifest.timing_samples_per_row,
+                structural_samples_per_row: manifest.structural_samples_per_row,
                 retention_revisions: manifest.retention_revisions,
                 rotation: RotationRule::LeftBySample,
                 optimization: OptimizationSetting::Default,
@@ -1640,9 +1984,10 @@ mod tests {
             },
             rows: Vec::new(),
             retention: RetentionSequence {
-                workload: "mosaic".into(),
-                worker_mode: WorkerMode::One,
+                workload: manifest.retention_workload.id.clone(),
+                worker_mode: WorkerMode::Automatic,
                 resolved_workers: 1,
+                query_evictions: 0,
                 revisions: Vec::new(),
             },
         };

--- a/crates/rue-compiler/src/session.rs
+++ b/crates/rue-compiler/src/session.rs
@@ -126,6 +126,14 @@ pub struct FrontendRetentionMetrics {
     pub diagnostic_source_bytes: usize,
 }
 
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub(crate) struct FrontendRuntimeMetrics {
+    pub(crate) validation_memo_hits: u64,
+    pub(crate) validation_memo_misses: u64,
+    pub(crate) retention_enforcements: u64,
+    pub(crate) retention_scan_entries: u64,
+}
+
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct CompilerSessionWork {
     pub updates: usize,
@@ -157,6 +165,7 @@ pub struct CompilerSessionWork {
     pub declaration_reuse_fallbacks: usize,
     /// Current bounded-retention gauges for long-lived service integrations.
     pub retention: FrontendRetentionMetrics,
+    pub(crate) runtime: FrontendRuntimeMetrics,
 }
 
 trait SessionQueryMetricsFamily {
@@ -543,6 +552,10 @@ impl CompilerSessionMetrics {
 
     fn set_retention(&mut self, retention: FrontendRetentionMetrics) {
         self.aggregate.retention = retention;
+    }
+
+    fn set_runtime(&mut self, runtime: FrontendRuntimeMetrics) {
+        self.aggregate.runtime = runtime;
     }
 }
 
@@ -3277,6 +3290,12 @@ impl CompilerSession {
             diagnostic_entries: diagnostics.entries,
             diagnostic_source_attempts: diagnostics.source_attempts,
             diagnostic_source_bytes: diagnostics.source_bytes,
+        });
+        self.metrics.set_runtime(FrontendRuntimeMetrics {
+            validation_memo_hits: runtime.validation_memo_hits,
+            validation_memo_misses: runtime.validation_memo_misses,
+            retention_enforcements: runtime.retention_enforcements,
+            retention_scan_entries: runtime.retention_scan_entries,
         });
     }
 

--- a/crates/rue-compiler/src/unstable.rs
+++ b/crates/rue-compiler/src/unstable.rs
@@ -1615,6 +1615,19 @@ pub struct QueryMetrics {
     pub reuses: usize,
 }
 
+/// Query-runtime validation and retention work contained in [`MetricsSnapshot`].
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct QueryRuntimeMetrics {
+    /// Dependency validations satisfied by a revision-scoped memo.
+    pub validation_memo_hits: u64,
+    /// Dependency validations that inspected or re-demanded the node.
+    pub validation_memo_misses: u64,
+    /// Family-local retention passes run.
+    pub retention_enforcements: u64,
+    /// Retention-queue entries examined by those passes.
+    pub retention_scan_entries: u64,
+}
+
 impl From<crate::session::FrontendQueryWork> for QueryMetrics {
     fn from(work: crate::session::FrontendQueryWork) -> Self {
         Self {
@@ -1944,6 +1957,14 @@ impl MetricsSnapshot {
             diagnostic_entries: self.inner.retention.diagnostic_entries,
             diagnostic_source_attempts: self.inner.retention.diagnostic_source_attempts,
             diagnostic_source_bytes: self.inner.retention.diagnostic_source_bytes,
+        }
+    }
+    pub fn query_runtime(&self) -> QueryRuntimeMetrics {
+        QueryRuntimeMetrics {
+            validation_memo_hits: self.inner.runtime.validation_memo_hits,
+            validation_memo_misses: self.inner.runtime.validation_memo_misses,
+            retention_enforcements: self.inner.runtime.retention_enforcements,
+            retention_scan_entries: self.inner.runtime.retention_scan_entries,
         }
     }
     pub fn semantic_work_json(&self, from: usize) -> Value {

--- a/crates/rue-perf-schema/src/incremental.rs
+++ b/crates/rue-perf-schema/src/incremental.rs
@@ -14,7 +14,7 @@ use serde::{Deserialize, Serialize};
 use crate::{EnvironmentFingerprint, median, median_absolute_deviation};
 
 /// Version of the retained-session raw report wire format.
-pub const EDIT_REPORT_SCHEMA_VERSION: u32 = 1;
+pub const EDIT_REPORT_SCHEMA_VERSION: u32 = 2;
 
 /// One retained-session edit class from ADR-0068's initial matrix.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
@@ -66,7 +66,7 @@ impl EditScenario {
     }
 }
 
-/// The two worker modes every retained-session row must measure.
+/// Query-worker modes available to retained-session measurements.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum WorkerMode {
@@ -77,8 +77,11 @@ pub enum WorkerMode {
 }
 
 impl WorkerMode {
-    /// Canonical worker-mode order.
+    /// Canonical order of every supported worker mode.
     pub const ALL: [Self; 2] = [Self::One, Self::Automatic];
+
+    /// Worker modes retained by the scheduled reference-host report.
+    pub const SCHEDULED: [Self; 1] = [Self::Automatic];
 
     /// Stable display name.
     pub const fn wire_name(self) -> &'static str {
@@ -215,8 +218,10 @@ pub struct EditManifest {
     pub report_schema_version: u32,
     /// Revision of maintained-program edit fixtures.
     pub fixture_revision: u32,
-    /// Independent retained sessions per workload/scenario/worker row.
-    pub samples_per_row: u32,
+    /// Independent sessions for the latency/linker-decision scenario.
+    pub timing_samples_per_row: u32,
+    /// Independent sessions for deterministic structural-coverage scenarios.
+    pub structural_samples_per_row: u32,
     /// Revisions in the bounded long-edit sequence.
     pub retention_revisions: u32,
     /// Deterministic interleaving rule.
@@ -234,6 +239,8 @@ pub struct EditManifest {
     pub workers: Vec<WorkerDeclaration>,
     /// Maintained programs, in report order.
     pub workloads: Vec<EditWorkload>,
+    /// Compact multi-module workload used only by the long retention witness.
+    pub retention_workload: EditWorkload,
     /// Host allowed to decide the numerical linker gate.
     pub reference_host: ReferenceHost,
 }
@@ -266,7 +273,7 @@ impl EditManifest {
     /// Validate an already-deserialized manifest.
     pub fn validate(&self) -> Result<(), EditManifestError> {
         let fail = |detail: String| Err(EditManifestError { detail });
-        if self.schema_version != 1 {
+        if self.schema_version != 2 {
             return fail(format!(
                 "unsupported incremental manifest schema version {}",
                 self.schema_version
@@ -281,8 +288,13 @@ impl EditManifest {
         if self.fixture_revision == 0 {
             return fail("fixture revision must be nonzero".to_string());
         }
-        if self.samples_per_row < 5 {
-            return fail("retained-session rows require at least five samples".to_string());
+        if self.timing_samples_per_row < 5 {
+            return fail("retained-session timing rows require at least five samples".to_string());
+        }
+        if self.structural_samples_per_row != 1 {
+            return fail(
+                "deterministic structural-coverage rows require exactly one sample".to_string(),
+            );
         }
         if self.retention_revisions < 1_000 {
             return fail(
@@ -326,10 +338,10 @@ impl EditManifest {
         }
 
         let workers: Vec<_> = self.workers.iter().map(|entry| entry.mode).collect();
-        if workers != WorkerMode::ALL {
+        if workers != WorkerMode::SCHEDULED {
             return fail(format!(
                 "worker modes must be exactly {:?}, got {workers:?}",
-                WorkerMode::ALL
+                WorkerMode::SCHEDULED
             ));
         }
         for worker in &self.workers {
@@ -349,7 +361,11 @@ impl EditManifest {
             return fail("the incremental manifest declares no workloads".to_string());
         }
         let mut workload_ids = BTreeSet::new();
-        for workload in &self.workloads {
+        for workload in self
+            .workloads
+            .iter()
+            .chain(std::iter::once(&self.retention_workload))
+        {
             if workload.id.trim().is_empty() || !workload_ids.insert(&workload.id) {
                 return fail(format!(
                     "invalid or duplicate workload id {:?}",
@@ -398,6 +414,15 @@ impl EditManifest {
 
     fn workload(&self, id: &str) -> Option<&EditWorkload> {
         self.workloads.iter().find(|entry| entry.id == id)
+    }
+
+    /// Declared independent-session count for one scenario row.
+    pub fn samples_for(&self, scenario: EditScenario) -> u32 {
+        if scenario == EditScenario::ReachedBodyOnly {
+            self.timing_samples_per_row
+        } else {
+            self.structural_samples_per_row
+        }
     }
 }
 
@@ -770,8 +795,10 @@ pub struct EditReportRegime {
     pub compiler_state: String,
     /// Always `uncontrolled`.
     pub os_page_cache: String,
-    /// Manifest sampling count.
-    pub samples_per_row: u32,
+    /// Manifest sampling count for latency/linker-decision rows.
+    pub timing_samples_per_row: u32,
+    /// Manifest sampling count for deterministic structural rows.
+    pub structural_samples_per_row: u32,
     /// Manifest long-sequence revision count.
     pub retention_revisions: u32,
     /// Manifest rotation rule.
@@ -820,6 +847,8 @@ pub struct RetentionSequence {
     pub worker_mode: WorkerMode,
     /// Exact worker count used.
     pub resolved_workers: u32,
+    /// Lifetime query terminals evicted during this sequence.
+    pub query_evictions: u64,
     /// Ordered revision observations.
     pub revisions: Vec<RetentionStep>,
 }
@@ -1052,7 +1081,8 @@ pub fn validate_edit_report(manifest: &EditManifest, report: &EditReport) -> Edi
     let regime = &report.regime;
     if regime.compiler_state != "retained_session"
         || regime.os_page_cache != "uncontrolled"
-        || regime.samples_per_row != manifest.samples_per_row
+        || regime.timing_samples_per_row != manifest.timing_samples_per_row
+        || regime.structural_samples_per_row != manifest.structural_samples_per_row
         || regime.retention_revisions != manifest.retention_revisions
         || regime.rotation != manifest.rotation
         || regime.optimization != manifest.optimization
@@ -1130,7 +1160,7 @@ pub fn validate_edit_report(manifest: &EditManifest, report: &EditReport) -> Edi
                 "revision-A source shape changed within a workload",
             ));
         }
-        if row.samples.len() != manifest.samples_per_row as usize {
+        if row.samples.len() != manifest.samples_for(row.scenario) as usize {
             errors.push(finding(
                 &row_path,
                 "row has the wrong number of independent samples",
@@ -1300,10 +1330,10 @@ pub fn validate_edit_report(manifest: &EditManifest, report: &EditReport) -> Edi
     }
 
     let sequence = &report.retention;
-    if manifest.workload(&sequence.workload).is_none() {
+    if sequence.workload != manifest.retention_workload.id {
         errors.push(finding(
             "retention.workload",
-            "retention row names an unknown workload",
+            "retention row differs from the manifest's dedicated workload",
         ));
     }
     if sequence.worker_mode != WorkerMode::Automatic
@@ -1320,6 +1350,12 @@ pub fn validate_edit_report(manifest: &EditManifest, report: &EditReport) -> Edi
         errors.push(finding(
             "retention.revisions",
             "retention row has the wrong revision count",
+        ));
+    }
+    if sequence.query_evictions == 0 {
+        errors.push(finding(
+            "retention.query_evictions",
+            "long retention sequence did not exercise query eviction",
         ));
     }
     for (position, step) in sequence.revisions.iter().enumerate() {
@@ -1451,6 +1487,8 @@ pub struct EditRowSummary {
     pub scenario: EditScenario,
     /// Worker mode.
     pub worker_mode: WorkerMode,
+    /// Number of independent sessions summarized by this row.
+    pub sample_count: u32,
     /// Diagnostics-ready timing for the error row.
     pub diagnostics_ready_ns: Option<EndpointSummary>,
     /// Codegen-ready timing for successful rows.
@@ -1485,6 +1523,8 @@ pub struct EditSummary {
     pub divergences: Vec<ValidationFinding>,
     /// Number of long-sequence revisions.
     pub retention_revisions: u32,
+    /// Query terminals evicted during the long sequence.
+    pub retention_query_evictions: u64,
     /// Maximum current retained charge in the long sequence.
     pub retention_max_current_bytes: u64,
     /// Maximum peak retained charge in the long sequence.
@@ -1579,6 +1619,7 @@ pub fn derive_edit_report(
                     workload: row.workload.clone(),
                     scenario: row.scenario,
                     worker_mode: row.worker_mode,
+                    sample_count: row.samples.len() as u32,
                     diagnostics_ready_ns: (!diagnostics.is_empty())
                         .then(|| summarize(&diagnostics)),
                     codegen_ready_ns: (!codegen.is_empty()).then(|| summarize(&codegen)),
@@ -1616,7 +1657,7 @@ pub fn derive_edit_report(
         .map(|step| step.retention.current_bytes)
         .unwrap_or(0);
     Ok(EditSummary {
-        schema_version: 1,
+        schema_version: 2,
         fixture_revision: report.identity.fixture_revision,
         commit: report.identity.commit.clone(),
         target: report.identity.target.clone(),
@@ -1624,6 +1665,7 @@ pub fn derive_edit_report(
         rows,
         divergences: validation.divergences,
         retention_revisions: report.retention.revisions.len() as u32,
+        retention_query_evictions: report.retention.query_evictions,
         retention_max_current_bytes,
         retention_peak_bytes,
         retention_final_bytes,
@@ -1648,9 +1690,9 @@ pub fn render_edit_report_markdown(summary: &EditSummary) -> String {
         }
         out.push('\n');
     } else {
-        out.push_str("| workload | scenario | workers | diagnostics ns | codegen ns | objects ns | runnable ns | link ns | link bp | computed | reused |\n");
+        out.push_str("| workload | scenario | workers | n | diagnostics ns | codegen ns | objects ns | runnable ns | link ns | link bp | computed | reused |\n");
         out.push_str(
-            "| --- | --- | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |\n",
+            "| --- | --- | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |\n",
         );
         for row in &summary.rows {
             let value = |summary: &Option<EndpointSummary>| {
@@ -1675,10 +1717,11 @@ pub fn render_edit_report_markdown(summary: &EditSummary) -> String {
                 })
                 .unwrap_or_else(|| "—".to_string());
             out.push_str(&format!(
-                "| {} | {} | {} | {} | {} | {} | {} | {} | {} | {} ± {} | {} ± {} |\n",
+                "| {} | {} | {} | {} | {} | {} | {} | {} | {} | {} | {} ± {} | {} ± {} |\n",
                 row.workload,
                 row.scenario.wire_name(),
                 row.worker_mode.wire_name(),
+                row.sample_count,
                 value(&row.diagnostics_ready_ns),
                 value(&row.codegen_ready_ns),
                 value(&row.objects_ready_ns),
@@ -1694,8 +1737,9 @@ pub fn render_edit_report_markdown(summary: &EditSummary) -> String {
         out.push('\n');
     }
     out.push_str(&format!(
-        "Retention sequence: {} revisions; max current {} bytes; peak {} bytes; final {} bytes.\n",
+        "Retention sequence: {} revisions; {} query evictions; max current {} bytes; peak {} bytes; final {} bytes.\n",
         summary.retention_revisions,
+        summary.retention_query_evictions,
         summary.retention_max_current_bytes,
         summary.retention_peak_bytes,
         summary.retention_final_bytes,
@@ -1710,10 +1754,11 @@ mod tests {
     const CHECKED_IN_MANIFEST: &str = include_str!("incremental.toml");
 
     const MANIFEST: &str = r#"
-schema_version = 1
-report_schema_version = 1
+schema_version = 2
+report_schema_version = 2
 fixture_revision = 3
-samples_per_row = 5
+timing_samples_per_row = 5
+structural_samples_per_row = 1
 retention_revisions = 1000
 rotation = "left_by_sample"
 target = "x86-64-linux"
@@ -1754,9 +1799,6 @@ expected_outcome = "diagnostics"
 structural_claim = "only the diagnostic cone recomputes"
 
 [[workers]]
-mode = "one"
-compiler_arg = "-j1"
-[[workers]]
 mode = "automatic"
 compiler_arg = "-j0"
 
@@ -1768,6 +1810,11 @@ question = "medium maintained program"
 id = "lattice"
 source = "examples/lattice/main.rue"
 question = "largest maintained program"
+
+[retention_workload]
+id = "retention"
+source = "performance/fixtures/incremental-retention/main.rue"
+question = "compact multi-module long-edit retention witness"
 
 [reference_host]
 target = "x86-64-linux"
@@ -1908,7 +1955,7 @@ minimum_memory_bytes = 15000000000
                         },
                         scenario: scenario.scenario,
                         worker_mode: worker.mode,
-                        samples: (0..manifest.samples_per_row)
+                        samples: (0..manifest.samples_for(scenario.scenario))
                             .map(|index| {
                                 sample(
                                     scenario.scenario,
@@ -1937,7 +1984,8 @@ minimum_memory_bytes = 15000000000
             regime: EditReportRegime {
                 compiler_state: "retained_session".to_string(),
                 os_page_cache: "uncontrolled".to_string(),
-                samples_per_row: manifest.samples_per_row,
+                timing_samples_per_row: manifest.timing_samples_per_row,
+                structural_samples_per_row: manifest.structural_samples_per_row,
                 retention_revisions: manifest.retention_revisions,
                 rotation: manifest.rotation,
                 optimization: manifest.optimization,
@@ -1945,9 +1993,10 @@ minimum_memory_bytes = 15000000000
             },
             rows,
             retention: RetentionSequence {
-                workload: "mosaic".to_string(),
+                workload: manifest.retention_workload.id.clone(),
                 worker_mode: WorkerMode::Automatic,
                 resolved_workers: 4,
+                query_evictions: 12,
                 revisions: (0..manifest.retention_revisions)
                     .map(|index| RetentionStep {
                         revision_index: index,
@@ -1970,16 +2019,21 @@ minimum_memory_bytes = 15000000000
     fn parses_the_versioned_adr_0068_manifest() {
         let manifest = EditManifest::parse(CHECKED_IN_MANIFEST).unwrap();
         assert_eq!(manifest.scenarios.len(), 8);
-        assert_eq!(manifest.workers.len(), 2);
-        assert_eq!(manifest.samples_per_row, 5);
+        assert_eq!(manifest.workers.len(), 1);
+        assert_eq!(manifest.workers[0].mode, WorkerMode::Automatic);
+        assert_eq!(manifest.timing_samples_per_row, 5);
+        assert_eq!(manifest.structural_samples_per_row, 1);
+        assert_eq!(manifest.samples_for(EditScenario::ReachedBodyOnly), 5);
+        assert_eq!(manifest.samples_for(EditScenario::LayoutAbi), 1);
         assert_eq!(manifest.retention_revisions, 1_000);
+        assert_eq!(manifest.retention_workload.id, "retention");
     }
 
     #[test]
     fn manifest_rejects_unknown_fields_and_incomplete_matrixes() {
         let unknown = MANIFEST.replacen(
-            "schema_version = 1",
-            "schema_version = 1\nsurprise = true",
+            "schema_version = 2",
+            "schema_version = 2\nsurprise = true",
             1,
         );
         assert!(
@@ -2010,8 +2064,15 @@ minimum_memory_bytes = 15000000000
         let first = derive_edit_report(&manifest, &report).unwrap();
         let second = derive_edit_report(&manifest, &report).unwrap();
         assert_eq!(first, second);
-        assert_eq!(first.rows.len(), 32);
+        assert_eq!(first.rows.len(), 16);
+        assert_eq!(
+            first.rows.iter().map(|row| row.sample_count).sum::<u32>(),
+            24
+        );
+        assert_eq!(first.schema_version, 2);
         assert!(first.reference_host_eligible);
+        assert_eq!(first.retention_query_evictions, 12);
+        assert!(render_edit_report_markdown(&first).contains("12 query evictions"));
         assert_eq!(
             render_edit_report_markdown(&first),
             render_edit_report_markdown(&second)
@@ -2030,7 +2091,7 @@ minimum_memory_bytes = 15000000000
 
         let mut malformed = report(&manifest);
         let sample = &mut malformed.rows[0].samples[0];
-        sample.resolved_workers = 2;
+        sample.resolved_workers = 0;
         if let EditOutcome::Success { endpoints, .. } = &mut sample.outcome {
             endpoints.objects_ready_ns = endpoints.codegen_ready_ns - 1;
         }
@@ -2039,7 +2100,7 @@ minimum_memory_bytes = 15000000000
             validation
                 .errors
                 .iter()
-                .any(|error| error.detail.contains("one-worker"))
+                .any(|error| error.detail.contains("automatic-worker"))
         );
         assert!(
             validation
@@ -2064,6 +2125,16 @@ minimum_memory_bytes = 15000000000
                 .any(|error| error.detail.contains("detected parallelism"))
         );
 
+        let mut no_cleanup = report(&manifest);
+        no_cleanup.retention.query_evictions = 0;
+        let validation = validate_edit_report(&manifest, &no_cleanup);
+        assert!(
+            validation
+                .errors
+                .iter()
+                .any(|error| error.detail.contains("did not exercise query eviction"))
+        );
+
         let mut overflowed = report(&manifest);
         let work = &mut overflowed.rows[0].samples[0].work;
         work.source_observation.computed = u64::MAX;
@@ -2078,8 +2149,8 @@ minimum_memory_bytes = 15000000000
 
         let json = serde_json::to_string(&report(&manifest)).unwrap();
         let unknown = json.replacen(
-            "\"schema_version\":1",
-            "\"schema_version\":1,\"surprise\":true",
+            "\"schema_version\":2",
+            "\"schema_version\":2,\"surprise\":true",
             1,
         );
         assert!(

--- a/crates/rue-query/src/lib.rs
+++ b/crates/rue-query/src/lib.rs
@@ -19,6 +19,7 @@ static NEXT_RUNTIME_ID: AtomicU64 = AtomicU64::new(1);
 const VALIDATION_PROOF_REGISTERED: u8 = 0;
 const VALIDATION_PROOF_RETRYABLE: u8 = 1;
 const VALIDATION_PROOF_UNREGISTERED: u8 = 2;
+const VALIDATION_PUBLISH_SWEEP_QUANTUM: usize = 64;
 
 /// Initial runtime-wide soft budget for deterministic retained terminal charge.
 ///
@@ -4798,6 +4799,7 @@ where
                 match validation {
                     Ok((true, registered_only, _)) => {
                         if observe_result && !task.observe_handoff(handoffs) {
+                            task.defer_pin_release(pin);
                             self.detach_terminal_attempt(node, attempt_id);
                             continue;
                         }
@@ -4814,18 +4816,18 @@ where
                         }
                         if observe_result || endorse {
                             self.lease_observed_pin(&task, pin);
+                        } else {
+                            task.defer_pin_release(pin);
                         }
-                        // An unobserved validation reuse drops `pin` here,
-                        // releasing it, as a stale candidate does at the end of
-                        // its own iteration.
                         return TaskQueryResult::Terminal {
                             terminal,
                             execution: RequestExecution::Reused,
                             work: Vec::new(),
                         };
                     }
-                    Ok((false, _, _)) => {}
+                    Ok((false, _, _)) => task.defer_pin_release(pin),
                     Err(abort) => {
+                        task.defer_pin_release(pin);
                         return TaskQueryResult::Aborted {
                             abort,
                             dependencies: Vec::new(),
@@ -5366,9 +5368,15 @@ where
         if lease {
             self.enforce_retention_after_publish();
         } else {
-            // A validation-only publication has no birth lease. It can be
-            // evicted immediately, so preserve eager enforcement for it.
-            self.enforce_retention();
+            // A validation-only publication has no birth lease and can be
+            // evicted immediately. Sweep in bounded batches rather than once
+            // per publication: when a large protected prefix occupies the
+            // queue, evicting one new unpinned terminal per full scan is
+            // quadratic in the validation cone. The rooted task schedules one
+            // final strict pass, so the family is back at its configured bound
+            // when the request completes.
+            task.defer_family_enforcement(self.retention_enforcer());
+            self.enforce_retention_after_publish_with_margin(VALIDATION_PUBLISH_SWEEP_QUANTUM);
         }
         if aggregate_probe {
             self.core.enforce_runtime_retention_after_probe();
@@ -5377,6 +5385,10 @@ where
     }
 
     fn enforce_retention_after_publish(&self) {
+        self.enforce_retention_after_publish_with_margin(1);
+    }
+
+    fn enforce_retention_after_publish_with_margin(&self, sweep_margin: usize) {
         let retained = self.inner.retained_count.load(Ordering::Acquire);
         loop {
             let threshold = self.inner.next_publish_sweep.load(Ordering::Acquire);
@@ -5392,13 +5404,17 @@ where
                 .compare_exchange(threshold, usize::MAX, Ordering::AcqRel, Ordering::Acquire)
                 .is_ok()
             {
-                self.enforce_retention();
+                self.enforce_retention_with_margin(sweep_margin);
                 return;
             }
         }
     }
 
     fn enforce_retention(&self) {
+        self.enforce_retention_with_margin(1);
+    }
+
+    fn enforce_retention_with_margin(&self, sweep_margin: usize) {
         self.core
             .metrics
             .retention_enforcements
@@ -5419,11 +5435,22 @@ where
         let next_publish_sweep = if retained > self.inner.retention_limit {
             retained.saturating_mul(2).max(retained.saturating_add(1))
         } else {
-            self.inner.retention_limit.saturating_add(1)
+            self.inner.retention_limit.saturating_add(sweep_margin)
         };
         self.inner
             .next_publish_sweep
             .store(next_publish_sweep, Ordering::Release);
+    }
+
+    fn retention_enforcer(&self) -> FamilyEnforcer {
+        FamilyEnforcer {
+            family_id: Arc::as_ptr(&self.inner) as *const () as usize,
+            core: self.core.clone(),
+            enforce: Box::new({
+                let family = self.clone();
+                move || family.enforce_retention()
+            }),
+        }
     }
 
     /// Pins a retained terminal against eviction.
@@ -6600,6 +6627,10 @@ struct TaskLeases {
     /// each of which decrements its terminal's pin count and re-enforces the
     /// owning family's retention bound.
     held: Vec<Box<dyn ObservedLease>>,
+    /// Family/runtime retention passes deferred until this rooted request has
+    /// finished publishing and all of its task leases can be released in the
+    /// same one-per-family batch.
+    deferred: DeferredEnforcements,
 }
 
 impl fmt::Debug for TaskLeases {
@@ -6608,6 +6639,7 @@ impl fmt::Debug for TaskLeases {
             .debug_struct("TaskLeases")
             .field("observed", &self.observed.len())
             .field("held", &self.held.len())
+            .field("deferred_families", &self.deferred.enforcers.len())
             .finish()
     }
 }
@@ -6631,7 +6663,8 @@ impl Drop for TaskLeases {
     /// that family's decrements are visible. The result is O(pins) decrements
     /// plus O(distinct families) enforcement passes.
     fn drop(&mut self) {
-        batched_release(&mut self.held);
+        batched_release_into(&mut self.held, &mut self.deferred);
+        std::mem::take(&mut self.deferred).enforce();
     }
 }
 
@@ -6649,22 +6682,17 @@ fn batched_release(held: &mut Vec<Box<dyn ObservedLease>>) {
     if held.is_empty() {
         return;
     }
-    let mut enforcers: BTreeMap<usize, FamilyEnforcer> = BTreeMap::new();
-    let mut runtimes: BTreeMap<u64, Arc<RuntimeCore>> = BTreeMap::new();
+    let mut deferred = DeferredEnforcements::default();
+    batched_release_into(held, &mut deferred);
+    deferred.enforce();
+}
+
+fn batched_release_into(
+    held: &mut Vec<Box<dyn ObservedLease>>,
+    deferred: &mut DeferredEnforcements,
+) {
     for lease in held.drain(..) {
-        let Some(enforcer) = lease.release_deferred() else {
-            continue;
-        };
-        runtimes
-            .entry(enforcer.core.identity)
-            .or_insert_with(|| enforcer.core.clone());
-        enforcers.entry(enforcer.family_id).or_insert(enforcer);
-    }
-    for (_family_id, enforcer) in enforcers {
-        enforcer.enforce();
-    }
-    for (_runtime_id, runtime) in runtimes {
-        runtime.enforce_runtime_retention();
+        deferred.release(lease);
     }
 }
 
@@ -6841,19 +6869,7 @@ where
         // Suppress the `Drop` decrement/enforce so the boxed pin can free its
         // Arcs normally without double-releasing or scanning.
         self.deferred.store(true, Ordering::Relaxed);
-        // Stable per-family identity: the address of the shared `FamilyInner`,
-        // identical across every pin and clone of one family, distinct across
-        // families even when their types coincide. This is the dedup key that
-        // collapses N pins in a family to one enforcement.
-        let family_id = Arc::as_ptr(&self.family.inner) as *const () as usize;
-        (previous == 1).then(|| FamilyEnforcer {
-            family_id,
-            core: self.family.core.clone(),
-            enforce: Box::new({
-                let family = self.family.clone();
-                move || family.enforce_retention()
-            }),
-        })
+        (previous == 1).then(|| self.family.retention_enforcer())
     }
 }
 
@@ -6866,6 +6882,37 @@ struct FamilyEnforcer {
     family_id: usize,
     core: Arc<RuntimeCore>,
     enforce: Box<dyn FnOnce() + Send>,
+}
+
+#[derive(Default)]
+struct DeferredEnforcements {
+    enforcers: BTreeMap<usize, FamilyEnforcer>,
+    runtimes: BTreeMap<u64, Arc<RuntimeCore>>,
+}
+
+impl DeferredEnforcements {
+    fn insert(&mut self, enforcer: FamilyEnforcer) {
+        self.runtimes
+            .entry(enforcer.core.identity)
+            .or_insert_with(|| enforcer.core.clone());
+        self.enforcers.entry(enforcer.family_id).or_insert(enforcer);
+    }
+
+    fn release(&mut self, lease: Box<dyn ObservedLease>) {
+        let Some(enforcer) = lease.release_deferred() else {
+            return;
+        };
+        self.insert(enforcer);
+    }
+
+    fn enforce(self) {
+        for (_family_id, enforcer) in self.enforcers {
+            enforcer.enforce();
+        }
+        for (_runtime_id, runtime) in self.runtimes {
+            runtime.enforce_runtime_retention();
+        }
+    }
 }
 
 impl FamilyEnforcer {
@@ -7218,6 +7265,18 @@ impl Drop for AttemptHandoffLifecycle {
 }
 
 impl Task {
+    fn defer_pin_release<K, V>(&self, pin: TerminalPin<K, V>)
+    where
+        K: QueryKey,
+        V: Clone + Send + Sync + 'static,
+    {
+        lock(&self.leases).deferred.release(Box::new(pin));
+    }
+
+    fn defer_family_enforcement(&self, enforcer: FamilyEnforcer) {
+        lock(&self.leases).deferred.insert(enforcer);
+    }
+
     fn batch_child(self: &Arc<Self>, id: u64) -> Arc<Self> {
         let inherited_filter = lock(&self.nested_attempt_filters).last().cloned();
         let inherits_registered_validation = !lock(&self.validation_endorsements).is_empty();
@@ -14573,6 +14632,90 @@ mod tests {
         assert_eq!(
             deep, shallow,
             "one reuse costs the same whether the node retains 4 attempts or 32"
+        );
+    }
+
+    // A rooted request which invalidates many parent/child pairs used to run
+    // retention once for every stale discovery pin and every speculative child
+    // publication. The task boundary is the safe batching boundary: all pins
+    // release before one strict pass per family, and the runtime-wide pass runs
+    // only after those family passes have converged.
+    #[test]
+    fn validation_only_publication_sweeps_are_batched_per_rooted_request() {
+        const CHILDREN: u64 = 64;
+
+        let runtime = QueryRuntime::new(1);
+        let first = Revision::new(1, 1);
+        let second = Revision::new(2, 1);
+        let inputs = (0..CHILDREN)
+            .map(|slot| InputIdentity::new("source", format!("child-{slot}")))
+            .collect::<Vec<_>>();
+        runtime
+            .publish_revision(first, inputs.iter().cloned().map(|input| (input, 1)))
+            .unwrap();
+
+        let child = runtime
+            .family_with_evaluator::<Slot, u64, _>(
+                "batched-validation-publish-child",
+                4096,
+                move |context, _, key| {
+                    let input = InputIdentity::new("source", format!("child-{}", key.0));
+                    Ok(QueryOutput::success(context.input(input)?))
+                },
+            )
+            .unwrap();
+        let child_for_parent = child.clone();
+        let parent = runtime
+            .family_with_evaluator::<Slot, u64, _>(
+                "batched-validation-publish-parent",
+                4096,
+                move |context, _, key| {
+                    let child = context.query_registered(&child_for_parent, key.clone())?;
+                    let QueryOutcome::Success(value) = child.outcome() else {
+                        unreachable!("the child publishes typed values")
+                    };
+                    Ok(QueryOutput::success(*value))
+                },
+            )
+            .unwrap();
+        for slot in 0..CHILDREN {
+            runtime
+                .request_registered(&parent, first, Slot(slot), CancellationToken::new())
+                .into_result()
+                .unwrap();
+        }
+
+        runtime
+            .publish_revision(second, inputs.into_iter().map(|input| (input, 2)))
+            .unwrap();
+        let root = runtime
+            .family::<Key, u64>("batched-validation-publish-root", 4096)
+            .unwrap();
+        let before = runtime.metrics();
+        runtime
+            .query(
+                &root,
+                second,
+                Key("root"),
+                CancellationToken::new(),
+                |context| {
+                    for slot in 0..CHILDREN {
+                        let terminal = context.query_registered(&parent, Slot(slot))?;
+                        assert_eq!(terminal.outcome(), &QueryOutcome::Success(2));
+                    }
+                    Ok(QueryOutput::success(CHILDREN))
+                },
+            )
+            .unwrap();
+        let after = runtime.metrics();
+
+        assert_eq!(
+            after.retention_enforcements - before.retention_enforcements,
+            3
+        );
+        assert_eq!(
+            after.retention_scan_entries - before.retention_scan_entries,
+            0
         );
     }
 

--- a/docs/designs/0068-incremental-edit-performance-measurement.md
+++ b/docs/designs/0068-incremental-edit-performance-measurement.md
@@ -88,8 +88,9 @@ This ADR owns **retained-session edit performance**. One independent sample is:
 5. time canonical re-observation, successor publication, and compilation to the
    selected endpoint;
 6. collect structural work and retention gauges immediately at the endpoint;
-7. outside the timed interval, compile revision B in a fresh session and compare
-   diagnostics, warnings, and executable bytes when the scenario succeeds; and
+7. compare revision B with the exact fixture state's precomputed fresh-session
+   identity: diagnostics, warnings, and executable bytes when the scenario
+   succeeds; and
 8. discard the host and isolated fixture before the next independent sample.
 
 Operating-system page-cache and scheduler state are uncontrolled. Reports call
@@ -195,15 +196,27 @@ The initial report is lower-frequency and advisory. It publishes raw JSON plus a
 derived Markdown report as a workflow artifact; it does not append to
 ADR-0067's content-addressed history or dashboard.
 
-The initial suite declares two query-worker modes for every workload/scenario
-row: exactly one worker (`-j1`) and the production automatic setting (`-j0`).
-The raw observation records both the declared mode and the exact worker count
-to which automatic mode resolved. Neither lane may substitute for the other.
+The scheduled suite measures the production automatic worker setting (`-j0`)
+and records the exact worker count to which it resolved. Exactly-one-worker
+(`-j1`) runs remain useful focused diagnostics, but they are not part of the
+versioned reference-host report and cannot decide the linker gate.
 
-Each workload/scenario/worker row uses at least five independent sessions.
-Scenario order rotates deterministically between samples so one scenario does
-not always receive the same thermal position. The report retains every raw
-observation and shows median and median absolute deviation for each endpoint.
+Every workload/scenario row uses one independent session to prove its
+deterministic structural claim and warm/fresh equality. The reached body-only
+row uses five independent sessions because it is the latency and linker-
+decision row; the report derives its median and median absolute deviation from
+those five observations. Single-sample structural rows retain their raw timing
+as diagnostic context but are not statistical latency claims. Repeating their
+identical baseline setup five times adds collection cost without strengthening
+their deterministic counters or oracle result.
+
+Before collecting those sessions, the runner compiles each workload/scenario
+revision-B fixture state once in a fresh host and retains only its deterministic
+outcome identity. Every scheduled independent warm sample compares with that
+same exact oracle. Recompiling an identical deterministic oracle for every
+sample adds fresh-build cost without adding correctness evidence; oracle
+preparation remains outside all retained-session latency endpoints and is
+reported separately as collection overhead.
 
 Infrastructure invalidity and compiler divergence have opposite publication
 rules:
@@ -225,15 +238,20 @@ compiler correctness failure.
 ### 6. Long-edit retention row
 
 In addition to independent edit samples, the suite has one untimed or separately
-timed bounded-retention sequence on a representative multi-module fixture. It
-alternates a finite set of valid edits, errors, fixes, reachability additions,
-and deletions through at least 1,000 revisions. Before the sequence starts, the
-runner prepares one fresh oracle for every distinct fixture state; every warm
-success compares with the corresponding precomputed oracle without paying a
-fresh compile on each revision. The row asserts:
+timed bounded-retention sequence on a compact, dedicated multi-module fixture.
+Maintained-program scale belongs to the Mosaic and Lattice edit rows; repeating
+a medium maintained-program baseline 1,000 times does not strengthen the query-
+lifecycle claim. The compact sequence alternates the same finite set of valid
+edits, errors, fixes, reachability additions, and deletions through at least
+1,000 revisions. Before the sequence starts, the runner prepares one fresh
+oracle for every distinct fixture state; every warm success compares with the
+corresponding precomputed oracle without paying a fresh compile on each
+revision. The row asserts:
 
 - every successful warm result matches a fresh session;
 - canceled and failed revisions never publish a successful artifact;
+- the sequence causes at least one retained query-terminal eviction, proving
+  that it exercises cleanup rather than only remaining below every limit;
 - retained bytes and dependency observations respect the existing soft-budget
   and protected-overflow contract; and
 - after protection releases, retained gauges return within their configured
@@ -262,10 +280,21 @@ determinism, compaction, fallback, atomic publication, target runtime inputs,
 and signing. Failing the gate records a measured deferral and shifts effort to
 the dominant warm interval.
 
+Fixture revision 2 crossed the absolute reference-host gate in
+[run 31337749929](https://github.com/rue-language/rue/actions/runs/31337749929)
+at compiler commit `a9739f03381e3df2cf99a588c35600f7057db485`. The automatic-worker
+Lattice reached-body row used five independent samples and reported a median
+objects-ready-to-runnable interval of 204,341,060 ns (MAD 1,102,274 ns), or 109
+basis points (MAD 1) of the 18,788,578,912 ns median warm interval. It did not
+cross the combined 10-millisecond/20% rule, but it exceeded the independent
+20-millisecond rule by more than ten times. RUE-1096 therefore advances to
+linker ADR work; implementation remains unauthorized until that design is
+accepted.
+
 The versioned incremental manifest declares the reference-host identity and its
 required hardware, operating-system, target, and automatic-worker fingerprint.
 Only a matching host's automatic-worker Lattice row may decide the numerical
-gate; other hosts and the `-j1` lane remain valid diagnostic evidence.
+gate; other hosts and focused `-j1` runs remain valid diagnostic evidence.
 
 The numerical gate is a project-prioritization rule tied to that manifest's
 reference host and fixture revision, not a language guarantee or permanent user
@@ -321,8 +350,9 @@ projects. None may introduce a peer compilation path.
 - [x] **Phase 6: Product host.** Add and measure `rue --watch` on the same seam,
   including cancellation, error/fix, import-set, and atomic-publication tests. —
   RUE-1254
-- [ ] **Phase 7: Linker gate.** Record the Lattice decision result on RUE-1096
-  and either advance its ADR or explicitly defer it. — RUE-1096
+- [x] **Phase 7: Linker gate.** Fixture revision 2 measured a 204.34 ms median
+  Lattice fresh-link interval on the reference host, crossing the independent
+  20 ms gate and advancing RUE-1096 to ADR work. — RUE-1096
 
 ## Consequences
 
@@ -338,12 +368,14 @@ projects. None may introduce a peer compilation path.
 
 ### Negative
 
-- Independent retained-session samples repeatedly pay an untimed large-program
-  baseline, making the scheduled suite expensive.
+- Each retained-session sample pays an untimed large-program baseline. The
+  scheduled suite limits that repeated cost to the reached body-only latency
+  row while collecting structural rows once.
 - Exact source transformations create maintained fixture work whenever example
   programs change.
-- Five samples expose trends rather than laboratory-grade microbenchmark
-  certainty; very small endpoints still need focused local witnesses.
+- Five reached body-only samples expose trends rather than laboratory-grade
+  microbenchmark certainty; single-sample structural-row timings and very small
+  endpoints still need focused local witnesses.
 - Warm measurement adds a second report schema that must remain explicitly
   separate from the fresh-build system.
 

--- a/performance/fixtures/incremental-retention/incremental_fixture.rue
+++ b/performance/fixtures/incremental-retention/incremental_fixture.rue
@@ -1,0 +1,1 @@
+pub fn value() -> u64 { 601 }

--- a/performance/fixtures/incremental-retention/main.rue
+++ b/performance/fixtures/incremental-retention/main.rue
@@ -1,0 +1,33 @@
+const support = @import("support.rue");
+
+const incremental_import_value: u64 = 0;
+fn incremental_import_probe() -> u64 { incremental_import_value }
+
+fn incremental_unreachable() -> u64 { 101 }
+
+fn incremental_body() -> u64 { 201 }
+
+fn incremental_signature(value: u64) -> u64 { value + 1 }
+fn incremental_signature_probe() -> u64 { incremental_signature(301) }
+
+struct IncrementalLayout {
+    first: u64,
+}
+
+fn incremental_layout_probe() -> u64 {
+    let value = IncrementalLayout { first: 401 };
+    value.first
+}
+
+fn incremental_reachable_leaf() -> u64 { 501 }
+
+fn incremental_anchor() -> u64 {
+    incremental_import_probe()
+        + incremental_body()
+        + incremental_signature_probe()
+        + incremental_layout_probe()
+        + incremental_reachable_leaf()
+        + support.value()
+}
+
+fn main() -> i32 { @intCast(incremental_anchor()) }

--- a/performance/fixtures/incremental-retention/support.rue
+++ b/performance/fixtures/incremental-retention/support.rue
@@ -1,0 +1,1 @@
+pub fn value() -> u64 { 7 }

--- a/performance/incremental-fixtures.toml
+++ b/performance/incremental-fixtures.toml
@@ -5,7 +5,7 @@
 # maintained Mosaic and Lattice sources remain unchanged. Every replacement
 # fragment must occur exactly once.
 schema_version = 1
-fixture_revision = 1
+fixture_revision = 2
 
 [[workloads]]
 id = "mosaic"
@@ -265,6 +265,95 @@ after = "        + incremental_layout_probe()"
 scenario = "error_introduction"
 kind = "replace"
 id = "lattice-error-introduction-v1"
+logical_file = "main.rue"
+before = "fn incremental_body() -> u64 { 201 }"
+after = "fn incremental_body() -> u64 { incremental_missing_name }"
+
+[[workloads]]
+id = "retention"
+fixture_root = "performance/fixtures/incremental-retention"
+root_source = "main.rue"
+overlays = []
+
+[[workloads.edits]]
+scenario = "no_op_reobservation"
+kind = "reobserve"
+id = "retention-no-op-v1"
+
+[[workloads.edits]]
+scenario = "unreachable_body"
+kind = "replace"
+id = "retention-unreachable-body-v1"
+logical_file = "main.rue"
+before = "fn incremental_unreachable() -> u64 { 101 }"
+after = "fn incremental_unreachable() -> u64 { 102 }"
+
+[[workloads.edits]]
+scenario = "reached_body_only"
+kind = "replace"
+id = "retention-reached-body-v1"
+logical_file = "main.rue"
+before = "fn incremental_body() -> u64 { 201 }"
+after = "fn incremental_body() -> u64 { 202 }"
+
+[[workloads.edits]]
+scenario = "callable_signature"
+kind = "replace"
+id = "retention-callable-signature-v1"
+logical_file = "main.rue"
+before = '''fn incremental_signature(value: u64) -> u64 { value + 1 }
+fn incremental_signature_probe() -> u64 { incremental_signature(301) }'''
+after = '''fn incremental_signature(value: u64, extra: u64) -> u64 { value + extra }
+fn incremental_signature_probe() -> u64 { incremental_signature(301, 1) }'''
+
+[[workloads.edits]]
+scenario = "layout_abi"
+kind = "replace"
+id = "retention-layout-abi-v1"
+logical_file = "main.rue"
+before = '''struct IncrementalLayout {
+    first: u64,
+}
+
+fn incremental_layout_probe() -> u64 {
+    let value = IncrementalLayout { first: 401 };
+    value.first
+}'''
+after = '''struct IncrementalLayout {
+    first: u64,
+    second: u64,
+}
+
+fn incremental_layout_probe() -> u64 {
+    let value = IncrementalLayout { first: 401, second: 1 };
+    value.first + value.second
+}'''
+
+[[workloads.edits]]
+scenario = "import_set"
+kind = "replace"
+id = "retention-import-set-v1"
+logical_file = "main.rue"
+before = '''const incremental_import_value: u64 = 0;
+fn incremental_import_probe() -> u64 { incremental_import_value }'''
+after = '''const incremental_fixture = @import("incremental_fixture.rue");
+fn incremental_import_probe() -> u64 { incremental_fixture.value() }'''
+
+[[workloads.edits]]
+scenario = "reachability_deletion"
+kind = "replace"
+id = "retention-reachability-deletion-v1"
+logical_file = "main.rue"
+before = '''        + incremental_layout_probe()
+        + incremental_reachable_leaf()
+        + support.value()'''
+after = '''        + incremental_layout_probe()
+        + support.value()'''
+
+[[workloads.edits]]
+scenario = "error_introduction"
+kind = "replace"
+id = "retention-error-introduction-v1"
 logical_file = "main.rue"
 before = "fn incremental_body() -> u64 { 201 }"
 after = "fn incremental_body() -> u64 { incremental_missing_name }"

--- a/performance/incremental.toml
+++ b/performance/incremental.toml
@@ -4,10 +4,13 @@
 # fresh-process headline) and `scaling.toml` (fresh maintained-program scale).
 # Fixture edits are added under a new `fixture_revision`; raw report syntax
 # advances independently under `report_schema_version`.
-schema_version = 1
-report_schema_version = 1
-fixture_revision = 1
-samples_per_row = 5
+schema_version = 2
+report_schema_version = 2
+fixture_revision = 2
+# Two workloads each collect seven one-sample structural rows and one five-
+# sample latency row: 24 independent retained sessions in the scheduled matrix.
+timing_samples_per_row = 5
+structural_samples_per_row = 1
 retention_revisions = 1000
 rotation = "left_by_sample"
 target = "x86-64-linux"
@@ -55,10 +58,6 @@ expected_outcome = "diagnostics"
 structural_claim = "Only the exact diagnostic cone recomputes and no successful downstream artifact publishes."
 
 [[workers]]
-mode = "one"
-compiler_arg = "-j1"
-
-[[workers]]
 mode = "automatic"
 compiler_arg = "-j0"
 
@@ -71,6 +70,11 @@ question = "How does a retained edit behave in the medium maintained multi-modul
 id = "lattice"
 source = "examples/lattice/main.rue"
 question = "How does a retained edit behave in the largest maintained program and its fresh-link boundary?"
+
+[retention_workload]
+id = "retention"
+source = "performance/fixtures/incremental-retention/main.rue"
+question = "Does a compact multi-module host remain correct and bounded across a long edit sequence?"
 
 # GitHub documents the standard public Linux x64 runner as 4 CPUs and 16 GB.
 # The memory probe sees usable host memory rather than the marketing capacity,


### PR DESCRIPTION
Fixes RUE-1255. Refs RUE-1096.

## Summary

- batch query-retention enforcement at rooted-request teardown instead of scanning protected queues after every validation-only publication
- precompute one deterministic fresh-session oracle per exact revision-B fixture state and reuse it across independent warm samples
- keep five independent samples for the reached-body latency/linker-decision row, sample deterministic structural rows once, and keep focused `-j1` runs outside the scheduled reference report
- use a compact dedicated multi-module fixture for the 1,000-revision retention witness while retaining Mosaic and Lattice for edit-latency measurements
- require the retention witness to exercise real query eviction and report its eviction count
- report collection-stage timings, row sample counts, and query-runtime counters
- bound the scheduled workflow at 40 minutes
- amend ADR-0068 and advance the manifest/raw/derived schemas for the narrower contract

## Performance evidence

The original Lattice `reached_body_only` warm path fell from 271,977 ms to 10,408 ms after batching validation-only retention enforcement: a 26× speedup. Retention queue entries scanned fell from 3,285,225,902 to 29,945 (>100,000× reduction).

The final reference-host report passed in 29m19s and published valid [JSON and Markdown artifacts](https://github.com/rue-language/rue/actions/runs/31337749929). It is reference-host eligible and used five independent automatic-worker Lattice reached-body samples:

- median warm re-observation-to-runnable: 18,788,578,912 ns
- median objects-ready-to-runnable link interval: 204,341,060 ns (MAD 1,102,274 ns)
- median link share: 109 basis points / 1.09% (MAD 1 bp)
- all warm outcomes matched the precomputed fresh-session oracle

The link interval crosses ADR-0068's independent 20 ms gate by more than 10×, so Phase 7 advances RUE-1096 to linker ADR work. This authorizes design, not implementation.

The compact 1,000-revision retention witness completed with 47,843 query evictions and a final retained charge of 6,206,607 bytes.

## Validation

- `scripts/rue fmt`
- `scripts/rue unit query` (135 passed)
- `scripts/rue unit perf-schema` (104 passed)
- `scripts/rue unit bench` (73 passed, 2 slow diagnostics ignored)
- full 1,000-revision retention diagnostic (every oracle matched; 47,843 query evictions)
- `scripts/rue quick` (31 targets passed)
- GitHub CI on the code-bearing commit: all required checks passed, including premerge, reproducibility, ASan, Valgrind, Linux ARM64, and macOS ARM64
- final scheduled reference report: passed and artifact validated
