### PR TITLE
Preserve failing CI suite output as workflow artifacts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -268,6 +268,18 @@ jobs:
             --repo . \
             --ref origin/trunk
 
+      # The Actions job-log API serves a truncated tail, so a failing target
+      # whose output scrolled past the cap is undiagnosable after the fact
+      # (RUE-1268). ci-timed preserves each failed command's complete output;
+      # keep it as an artifact.
+      - name: Upload failing-suite output
+        if: failure()
+        uses: actions/upload-artifact@v6
+        with:
+          name: premerge-linux-x64-failure-logs
+          path: ${{ runner.temp }}/rue-ci-failed-logs
+          if-no-files-found: ignore
+
   # Native ARM64 lanes own only behavior that requires their host ABI, linker,
   # runtime, or backend. Target-independent unit/spec coverage remains on
   # Linux, avoiding three copies of the same broad suite.
@@ -342,6 +354,15 @@ jobs:
 
       - name: Run native filesystem and platform programs
         run: scripts/ci-timed "${{ matrix.name }} platform" -- scripts/rue cli cli.fs_file_io
+
+      # See the premerge lane's rationale (RUE-1268).
+      - name: Upload failing-suite output
+        if: failure()
+        uses: actions/upload-artifact@v6
+        with:
+          name: native-${{ matrix.name }}-failure-logs
+          path: ${{ runner.temp }}/rue-ci-failed-logs
+          if-no-files-found: ignore
 
   # RUE-617/RUE-1019: keep the byte-reproducibility proof independent of the
   # cache-enabled Linux test lane. Both reference and relocated candidate are
@@ -559,6 +580,15 @@ jobs:
           path: ${{ runner.temp }}/rue-cli-case-timings.jsonl
           if-no-files-found: ignore
           overwrite: true
+
+      # See the premerge lane's rationale (RUE-1268).
+      - name: Upload failing-suite output
+        if: failure()
+        uses: actions/upload-artifact@v6
+        with:
+          name: ${{ matrix.check_name }}-failure-logs
+          path: ${{ runner.temp }}/rue-ci-failed-logs
+          if-no-files-found: ignore
 
   # Focused release-mode coverage (RUE-1129). Correctness-critical compiler
   # invariants are enforced independently by validate-debug-assert-policy.py;

--- a/scripts/ci-timed
+++ b/scripts/ci-timed
@@ -17,6 +17,18 @@ cleanup() {
 }
 trap cleanup EXIT
 
+# On CI failure, preserve the complete command output where an upload step can
+# collect it. The Actions job-log API serves a truncated tail, so a failing
+# target whose output scrolled past the cap is otherwise undiagnosable after
+# the fact (RUE-1268). Local runs keep the delete-on-exit temp file only.
+preserve_failure_log() {
+    [[ -n "${GITHUB_ACTIONS:-}" && -n "${RUNNER_TEMP:-}" ]] || return 0
+    local dir="$RUNNER_TEMP/rue-ci-failed-logs" slug
+    slug="$(printf '%s' "$label" | tr -c 'A-Za-z0-9._-' '-')"
+    mkdir -p "$dir"
+    cp "$log" "$dir/${slug}.log"
+}
+
 started="$(date +%s)"
 "$@" 2>&1 | tee "$log"
 status=${PIPESTATUS[0]}
@@ -76,6 +88,7 @@ fi
 result="passed"
 if [[ "$status" -ne 0 ]]; then
     result="failed ($status)"
+    preserve_failure_log
 fi
 
 if [[ -n "${GITHUB_STEP_SUMMARY:-}" ]]; then


### PR DESCRIPTION
Refs RUE-1268 (the diagnosability sub-task; the query-graph investigation of the recurrence itself remains open).

## What

When the second differential-oracle queue ejection hit (#2137's first queue run), the failing target's output was unrecoverable after the fact: the Actions job-log API serves a capped tail (~673 KB) that started *after* the oracle target's output, and the run uploaded no failure artifact. The next occurrence of the intermittent would have been equally undiagnosable.

## How

- `scripts/ci-timed` already tees each wrapped command's complete output to a temp log (for the timing summary) and deleted it unconditionally. On failure under CI (`GITHUB_ACTIONS` + `RUNNER_TEMP` set), it now preserves the log as `$RUNNER_TEMP/rue-ci-failed-logs/<label-slug>.log` before exiting with the original status. Local runs keep the delete-on-exit behavior.
- The premerge, native-platform, and platform-corpus lanes get an `Upload failing-suite output` step (`if: failure()`, `if-no-files-found: ignore`) collecting that directory, following the existing reproducibility-diagnostics artifact pattern. Artifact names are unique per lane (`premerge-linux-x64-failure-logs`, `native-<matrix>-failure-logs`, `<check_name>-failure-logs`).

Both PR and merge-group runs go through the same jobs, so queue-only failures — where this class of intermittent exclusively lives — are covered.

## Testing

- `bash -n` on ci-timed; workflow YAML parses.
- Simulated locally with `GITHUB_ACTIONS`/`RUNNER_TEMP` set: a failing wrapped command (exit 3) preserves `linux-x64-premerge.log` with the full output and propagates the exit status; a passing command preserves nothing.
- actionlint runs as a required CI job on this PR itself.

---
_Generated by [Claude Code](https://claude.ai/code/session_01DrKqpQgkHzDHGqpEMjxYdN)_