### PR TITLE
Spec sweep: audit-verified corrections across four issues

### DIFF
--- a/crates/rue-spec/cases/expressions/intrinsics.toml
+++ b/crates/rue-spec/cases/expressions/intrinsics.toml
@@ -2098,6 +2098,71 @@ fn main() -> i32 {
 exit_code = 20
 
 # =============================================================================
+# @target_data_model Intrinsic (4.13:112-117, RUE-1271)
+#
+# Every target the reference compiler currently supports is LP64, so these
+# cases run everywhere without `only_on`. If an ILP32 or LLP64 target is ever
+# added, the value-asserting cases below need `only_on` splits like the
+# @target_arch/@target_os cases above.
+# =============================================================================
+
+[[case]]
+name = "target_data_model_returns_enum"
+spec = ["4.13:112", "4.13:114", "4.13:115"]
+description = "@target_data_model() returns a DataModel enum value; the built-in enum has exactly the Ilp32, Llp64, and Lp64 variants (an exhaustive match names all three)."
+source = """
+fn main() -> i32 {
+    match @target_data_model() {
+        DataModel.Lp64 => 1,
+        DataModel.Llp64 => 2,
+        DataModel.Ilp32 => 3,
+    }
+}
+"""
+exit_code = 1
+
+[[case]]
+name = "target_data_model_no_args"
+spec = ["4.13:113"]
+source = """
+fn main() -> i32 {
+    // Verify @target_data_model takes no arguments
+    let dm = @target_data_model();
+    0
+}
+"""
+exit_code = 0
+
+[[case]]
+name = "target_data_model_wrong_arg_count"
+spec = ["4.13:4", "4.13:113"]
+source = """
+fn main() -> i32 {
+    let dm = @target_data_model(42);
+    0
+}
+"""
+compile_fail = true
+error_contains = "argument"
+
+[[case]]
+name = "target_data_model_compile_time_lp64"
+spec = ["4.13:112", "4.13:116"]
+description = "The data model is determined at compile time from the compilation target; every currently supported target (x86-64/AArch64 Linux and macOS) is LP64."
+source = """
+fn main() -> i32 {
+    // The value is determined at compile time
+    let dm = @target_data_model();
+    match dm {
+        DataModel.Lp64 => 10,
+        DataModel.Llp64 => 20,
+        DataModel.Ilp32 => 30,
+    }
+}
+"""
+exit_code = 10
+
+# =============================================================================
 # Wrapping arithmetic intrinsics: @wrapping_add / @wrapping_sub / @wrapping_mul
 # (4.13:91-96, RUE-647)
 #

--- a/docs/spec/src/02-lexical-structure/01-tokens.md
+++ b/docs/spec/src/02-lexical-structure/01-tokens.md
@@ -69,14 +69,15 @@ Base prefixes are lowercase. An uppercase base prefix (`0X`, `0O`, `0B`) is a co
 
 ```rue
 fn main() -> i32 {
-    0            // zero
-    42           // decimal integer
-    255          // maximum u8 value
-    1_000_000    // underscore separators
-    0xFF         // hexadecimal, value 255
-    0x_FF_       // underscores legal after the prefix and trailing
-    0o17         // octal, value 15
-    0b1010       // binary, value 10
+    @dbg(0);            // zero
+    @dbg(42);           // decimal integer
+    @dbg(255);          // maximum u8 value
+    @dbg(1_000_000);    // underscore separators
+    @dbg(0xFF);         // hexadecimal, value 255
+    @dbg(0x_FF_);       // underscores legal after the prefix and trailing
+    @dbg(0o17);         // octal, value 15
+    @dbg(0b1010);       // binary, value 10
+    0
 }
 ```
 

--- a/docs/spec/src/02-lexical-structure/03-whitespace.md
+++ b/docs/spec/src/02-lexical-structure/03-whitespace.md
@@ -27,9 +27,9 @@ Multiple whitespace characters between tokens are equivalent to a single space.
 ```rue
 // Minimal whitespace
 fn main()->i32{42}
+```
 
-// Generous whitespace
+```rue
+// Generous whitespace: an equivalent program
 fn   main()   ->   i32   {   42   }
-
-// Both programs are equivalent
 ```

--- a/docs/spec/src/03-types/08-move-semantics.md
+++ b/docs/spec/src/03-types/08-move-semantics.md
@@ -21,6 +21,8 @@ The following types are Copy types:
 - All integer types (`i8`, `i16`, `i32`, `i64`, `u8`, `u16`, `u32`, `u64`)
 - The boolean type (`bool`)
 - The unit type (`()`)
+- The first-class string types: `str` (3.7:44) and the fixed inline buffers
+  `Str(N)` (3.7:50)
 - Discriminant-only enum types (every variant is payload-free, C-like)
 - Array types `[T; N]` where `T` is a Copy type
 
@@ -97,7 +99,7 @@ struct Outer { inner: Inner }  // ERROR: field 'inner' has non-Copy type 'Inner'
 
 {{ rule(id="3.8:20", cat="normative") }}
 
-A `@copy` struct **MAY** contain fields of primitive Copy types (integers, booleans, unit), discriminant-only enum types, arrays of Copy types, or other `@copy` struct types. A field whose type is a payload-carrying enum is admissible only when that enum is itself Copy under the join of 6.3:19 — that is, only when every one of its payloads is Copy; a `@copy` struct field must itself be a Copy type (3.8:18), so a move-typed enum field is rejected.
+A `@copy` struct **MAY** contain fields of primitive Copy types (integers, booleans, unit), first-class string types (`str`, `Str(N)` — 3.7:44, 3.7:50), discriminant-only enum types, arrays of Copy types, or other `@copy` struct types. A field whose type is a payload-carrying enum is admissible only when that enum is itself Copy under the join of 6.3:19 — that is, only when every one of its payloads is Copy; a `@copy` struct field must itself be a Copy type (3.8:18), so a move-typed enum field is rejected.
 
 {{ rule(id="3.8:21", cat="example") }}
 
@@ -225,7 +227,7 @@ fn main() -> i32 {
 
 {{ rule(id="3.8:60", cat="legality-rule") }}
 
-It is a compile-time error for a field access that consumes a linear value (destructuring, 3.8:33) to implicitly drop a *different* field that carries a linear value. Every struct level along the access path is checked: at each level, all fields other than the accessed one are dropped by the destructure.
+It is a compile-time error for a field access that consumes a linear value (destructuring, 3.8:33) to implicitly drop a *different* field that carries a linear value. Every struct level along the access path is checked. The access is a partial move of exactly the accessed field (3.8:22): sibling fields remain in place, and the residue — every field other than the accessed one, at each level — is dropped by the ordinary scope-exit walk of the destructured value's binding (3.9:2). A linear sibling in that residue would therefore be implicitly dropped at scope exit, which is what this rule rejects at the access itself.
 
 {{ rule(id="3.8:61", cat="example") }}
 

--- a/docs/spec/src/03-types/10-mutable-strings.md
+++ b/docs/spec/src/03-types/10-mutable-strings.md
@@ -62,6 +62,9 @@ returns a string whose capacity is zero.
 {{ rule(id="3.10:9", cat="example") }}
 
 ```rue
+const std = @import("std");
+const StrBuf = std.strbuf.StrBuf;
+
 fn main() -> i32 {
     let empty = StrBuf.new();
     let prealloc = StrBuf.with_capacity(1024);
@@ -90,6 +93,9 @@ Query methods use `borrow self` to access the string without consuming it, leavi
 {{ rule(id="3.10:14", cat="example") }}
 
 ```rue
+const std = @import("std");
+const StrBuf = std.strbuf.StrBuf;
+
 fn main() -> i32 {
     let s = "hello";
     if s.len() == 5 && !s.is_empty() {
@@ -125,6 +131,9 @@ Mutation methods use `inout self` to modify the string in place. The variable mu
 {{ rule(id="3.10:20", cat="example") }}
 
 ```rue
+const std = @import("std");
+const StrBuf = std.strbuf.StrBuf;
+
 fn main() -> i32 {
     let mut s = StrBuf.new();
     s.push_str("hello");
@@ -151,6 +160,9 @@ Heap promotion is transparent to the user. There is no separate "owned" vs "borr
 {{ rule(id="3.10:23", cat="example") }}
 
 ```rue
+const std = @import("std");
+const StrBuf = std.strbuf.StrBuf;
+
 fn main() -> i32 {
     let mut s = "hello";     // literal: capacity = 0
     s.push_str("!");     // promotes to heap, then appends
@@ -182,6 +194,9 @@ Clone borrows `self` so the original string remains valid. Cloning always alloca
 {{ rule(id="3.10:28", cat="example") }}
 
 ```rue
+const std = @import("std");
+const StrBuf = std.strbuf.StrBuf;
+
 fn main() -> i32 {
     let a = "hello";
     let b = a.clone();  // deep copy
@@ -205,6 +220,9 @@ The destructor automatically distinguishes between string literals and heap-allo
 {{ rule(id="3.10:31", cat="example") }}
 
 ```rue
+const std = @import("std");
+const StrBuf = std.strbuf.StrBuf;
+
 fn main() -> i32 {
     let mut s = "hello";
     s.push_str("!");  // promotes to heap

--- a/docs/spec/src/04-expressions/01-literal-expressions.md
+++ b/docs/spec/src/04-expressions/01-literal-expressions.md
@@ -24,9 +24,10 @@ Integer literals default to type `i32` unless the context requires a different t
 
 ```rue
 fn main() -> i32 {
-    0       // zero
-    42      // positive integer
-    255     // maximum u8 value
+    @dbg(0);      // zero
+    @dbg(42);     // positive integer
+    @dbg(255);    // maximum u8 value
+    0
 }
 ```
 

--- a/docs/spec/src/04-expressions/02-arithmetic-operators.md
+++ b/docs/spec/src/04-expressions/02-arithmetic-operators.md
@@ -42,8 +42,9 @@ Parentheses can be used to override the default precedence of operators. A paren
 
 ```rue
 fn main() -> i32 {
-    1 + 2 * 3    // = 7 (not 9)
-    (1 + 2) * 3  // = 9 (parentheses override)
+    @dbg(1 + 2 * 3);      // = 7 (not 9)
+    @dbg((1 + 2) * 3);    // = 9 (parentheses override)
+    0
 }
 ```
 
@@ -57,8 +58,9 @@ All binary arithmetic operators are left-associative.
 
 ```rue
 fn main() -> i32 {
-    10 - 3 - 2   // = 5, parsed as (10 - 3) - 2
-    24 / 4 / 2   // = 3, parsed as (24 / 4) / 2
+    @dbg(10 - 3 - 2);    // = 5, parsed as (10 - 3) - 2
+    @dbg(24 / 4 / 2);    // = 3, parsed as (24 / 4) / 2
+    0
 }
 ```
 

--- a/docs/spec/src/04-expressions/13-intrinsics.md
+++ b/docs/spec/src/04-expressions/13-intrinsics.md
@@ -55,6 +55,9 @@ Expression intrinsics (usable in any expression position):
 | `@align_of` | Get type alignment in bytes | 1 type | `i32` |
 | `@offset_of` | Get a struct field's byte offset | 1 type, 1 field name | `u64` |
 | `@intCast` | Convert between integer types | 1 expression (integer) | inferred integer type |
+| `@wrapping_add` | Wrapping (modular) addition (§4.13:97) | 2 expressions (same integer type) | that integer type |
+| `@wrapping_sub` | Wrapping (modular) subtraction (§4.13:97) | 2 expressions (same integer type) | that integer type |
+| `@wrapping_mul` | Wrapping (modular) multiplication (§4.13:97) | 2 expressions (same integer type) | that integer type |
 | `@to_string` | Format an integer as its decimal `StrBuf` | 1 expression (any integer) | `StrBuf` |
 | `@drop` | Run a value's drop glue and consume it (RUE-187) | 1 expression (any type) | `()` |
 | `@read_line` | Read line from stdin | none | `Option(StrBuf)` |
@@ -70,6 +73,7 @@ Expression intrinsics (usable in any expression position):
 | `@env_len` | Byte length of environment entry `i` (0 out of range) | 1 expression (`u64` index) | `u64` |
 | `@target_arch` | Get target architecture | none | `Arch` |
 | `@target_os` | Get target OS | none | `Os` |
+| `@target_data_model` | Get target C data model | none | `DataModel` |
 | `@import` | Import module | 1 expression (string literal) | module type |
 
 Unchecked intrinsics (only valid inside a `checked` block; see §9.2 for their
@@ -83,6 +87,8 @@ full semantics):
 | `@field_ptr` | `mut` pointer to a struct field place | 1 field-access expression | `ptr mut F` |
 | `@ptr_read` | Read through a pointer | 1 expression (`ptr const T`/`ptr mut T`) | `T` |
 | `@ptr_write` | Write through a pointer | 2 expressions (`ptr mut T`, `T`) | `()` |
+| `@ptr_read_unaligned` | Read through a possibly unaligned pointer (§9.2) | 1 expression (`ptr const T`/`ptr mut T`) | `T` |
+| `@ptr_write_unaligned` | Write through a possibly unaligned pointer (§9.2) | 2 expressions (`ptr mut T`, `T`) | `()` |
 | `@ptr_offset` | Pointer arithmetic | 2 expressions (`ptr T`, integer) | `ptr T` |
 | `@ptr_to_int` | Pointer to integer | 1 expression (pointer) | `u64` |
 | `@int_to_ptr` | Integer to pointer | 1 expression (`u64`) | inferred `ptr mut T` |
@@ -500,8 +506,10 @@ The result is `None` (a recoverable parse failure, not a panic) if:
 {{ rule(id="4.13:50") }}
 
 ```rue
+const std = @import("std");
+
 fn main() -> i32 {
-    let Opt = @import("std/option.rue").Option(i32);
+    let Opt = std.option.Option(i32);
     match @parse_i32("42") {
         Opt.Some(n) => n,   // returns 42
         Opt.None => 0,
@@ -512,8 +520,10 @@ fn main() -> i32 {
 {{ rule(id="4.13:51") }}
 
 ```rue
+const std = @import("std");
+
 fn main() -> i32 {
-    let Opt = @import("std/option.rue").Option(i32);
+    let Opt = std.option.Option(i32);
     match @parse_i32("-17") {
         Opt.Some(n) => n,   // returns -17
         Opt.None => 0,
@@ -524,8 +534,10 @@ fn main() -> i32 {
 {{ rule(id="4.13:52") }}
 
 ```rue
+const std = @import("std");
+
 fn main() -> i32 {
-    let Opt = @import("std/option.rue").Option(i32);
+    let Opt = std.option.Option(i32);
     let s = "42";
     // StrBuf is borrowed, not consumed
     let parsed: Opt = @parse_i32(s);
@@ -541,8 +553,10 @@ fn main() -> i32 {
 
 ```rue
 // An invalid character is a recoverable failure: `None`, not a panic.
+const std = @import("std");
+
 fn main() -> i32 {
-    let Opt = @import("std/option.rue").Option(i32);
+    let Opt = std.option.Option(i32);
     match @parse_i32("12abc") {
         Opt.Some(n) => n,
         Opt.None => -1,   // taken: "12abc" is not an integer
@@ -554,8 +568,10 @@ fn main() -> i32 {
 
 ```rue
 // A negative value for an unsigned type is a recoverable failure: `None`.
+const std = @import("std");
+
 fn main() -> i32 {
-    let Opt = @import("std/option.rue").Option(u32);
+    let Opt = std.option.Option(u32);
     match @parse_u32("-17") {
         Opt.Some(n) => @intCast(n),
         Opt.None => 0,   // taken: "-17" is negative
@@ -600,9 +616,12 @@ fn main() -> i32 {
 Using `@random_u32` in a guessing game:
 
 ```rue
+const std = @import("std");
+const StrBuf = std.strbuf.StrBuf;
+
 fn main() -> i32 {
-    let OptStr = @import("std/option.rue").Option(StrBuf);
-    let OptU32 = @import("std/option.rue").Option(u32);
+    let OptStr = std.option.Option(StrBuf);
+    let OptU32 = std.option.Option(u32);
     let secret: u32 = (@random_u32() % 100) + 1;  // 1-100
     @dbg("Guess the number between 1 and 100!");
 
@@ -829,6 +848,49 @@ fn main() -> i32 {
                 Os.Macos => 66,
             }
         },
+    }
+}
+```
+
+## `@target_data_model`
+
+{{ rule(id="4.13:112", cat="normative") }}
+
+The `@target_data_model` intrinsic returns the compilation target's C data
+model — the width convention the target's C ABI assigns to `int`, `long`, and
+pointers, which selects the widths of the `std.c` transparent scalar aliases
+(ADR-0064 Amendment 1) — as a `DataModel` enum value.
+
+{{ rule(id="4.13:113", cat="normative") }}
+
+`@target_data_model` accepts no arguments.
+
+{{ rule(id="4.13:114", cat="normative") }}
+
+The return type of `@target_data_model` is `DataModel`.
+
+{{ rule(id="4.13:115", cat="normative") }}
+
+The `DataModel` enum is a built-in enum with the following variants:
+- `DataModel.Ilp32` - `int`, `long`, and pointers are 32-bit
+- `DataModel.Llp64` - `long long` and pointers are 64-bit; `long` remains 32-bit
+- `DataModel.Lp64` - `long` and pointers are 64-bit
+
+{{ rule(id="4.13:116", cat="normative") }}
+
+The value returned by `@target_data_model` is determined at compile time based
+on the compilation target. Every target the reference compiler currently
+supports (the x86-64 and AArch64 Linux/macOS targets reachable through
+`@target_arch`/`@target_os`) is `Lp64`.
+
+{{ rule(id="4.13:117") }}
+
+```rue
+fn main() -> i32 {
+    match @target_data_model() {
+        DataModel.Lp64 => 1,
+        DataModel.Llp64 => 2,
+        DataModel.Ilp32 => 3,
     }
 }
 ```

--- a/docs/spec/src/04-expressions/15-try-expressions.md
+++ b/docs/spec/src/04-expressions/15-try-expressions.md
@@ -94,7 +94,7 @@ fn halve_then_div(a: i64, b: i64) -> std.option.Option(i64) {
 fn main() -> i32 {
     let O = std.option.Option(i64);
     match halve_then_div(40, 4) {
-        O.Some(n) => n,      // 40 / 4 / 2 == 5
+        O.Some(n) => @intCast(n),   // 40 / 4 / 2 == 5
         O.None => 0 - 1,
     }
 }


### PR DESCRIPTION
Fixes RUE-1273. Fixes RUE-1275. Fixes RUE-1271. Fixes RUE-1280.

Harvest of the mechanical tier of the 2026-08-09 spec audit — every change verified against the built compiler before editing, and every touched example re-extracted and compiled after.

## RUE-1273 — every non-compiling example now compiles as printed

- The six intrinsics-chapter parse/random examples (4.13:50–54, :61) migrate from the retired `@import("std/option.rue")` form to the std facade the same chapter already uses; the guessing-game example additionally gains its missing `StrBuf` binding.
- The six chapter-3.10 examples gain the `const std = @import("std"); const StrBuf = std.strbuf.StrBuf;` preamble that 3.7:2 declares mandatory.
- 4.15:8 casts its i64 payload with `@intCast`, matching its sibling 4.15:10 (fixed program verified exiting 5 as its comment promises).
- The five statement-form blocks (2.1:5, 2.3:4, 4.1:4, 4.2:5, 4.2:13) become real programs — `@dbg` per line with a trailing `0`, and the duplicate-`main` whitespace block split into two fences.

## RUE-1275 — Copy enumerations gain the first-class string types

3.8:2 and 3.8:20 now list `str` and `Str(N)`, which 3.7:44/3.7:50 declare `@copy` and the compiler accepts (both re-verified: `str` double-use and `@copy struct { s: str }` compile; `Str(N)` double-use compiles).

## RUE-1271 — @target_data_model documented; inventory completed

- New `## @target_data_model` section (rules 4.13:112–117) following the Arch/Os pattern: no arguments, `DataModel` built-in enum (`Ilp32`/`Llp64`/`Lp64` with their C-width meanings), compile-time determination, and a verified example (returns Lp64 on x86-64-linux; the variant set was pinned via E0600 during the audit).
- The 4.13:5a inventory gains its five missing rows: `@wrapping_add`/`@wrapping_sub`/`@wrapping_mul` in the expression table and `@ptr_read_unaligned`/`@ptr_write_unaligned` in the unchecked table.

## RUE-1280 — 3.8:60 states the mechanism the core and compiler implement

The destructure rule now describes the partial move (3.8:22) plus scope-exit drop of the residue (3.9:2), keeping its legality conclusion (a linear sibling in the residue is still rejected at the access). The old "dropped by the destructure" timing was refuted by both the core (§4.2/§5.6) and a compiler drop trace.

## Testing

- Every rewritten/repaired example extracted from the final markdown and compiled against the built compiler (18 programs, all clean; the `@target_data_model` example also run).
- Spec traceability suite 21/21 (all cited rule IDs resolve; new IDs don't collide — previous max was 4.13:111).

---
_Generated by [Claude Code](https://claude.ai/code/session_01DrKqpQgkHzDHGqpEMjxYdN)_