### PR TITLE
Stop compiling rue-compiler twice for three scaling rows

### DIFF
--- a/crates/rue-compiler/BUCK
+++ b/crates/rue-compiler/BUCK
@@ -51,40 +51,35 @@ _DEPS = [
     "//third-party:tracing",
 ]
 
-# The default library and `rue-compiler-test` target declare `scaling_matrix` as
-# a known cfg name (so the RUE-1086 scaling harness's matrix-only tests do not
-# trip `unexpected_cfgs` under `-Dwarnings`) but never SET it, so the heavy
-# 100/1k structural matrix is excluded from the fast unit suite.
 rue_crate(
     name = "rue-compiler",
     mapped_srcs = _RUNTIME_MAPPED_SRCS,
     deps = _DEPS,
     rustc_flags = [
-        "--check-cfg=cfg(scaling_matrix)",
         "--check-cfg=cfg(test)",
     ],
 )
 
-# Dedicated heavy-matrix test targets (Finding 6, RUE-1086). Compiling with
-# `--cfg=scaling_matrix` turns on the `#[cfg(scaling_matrix)]` structural
-# scaling tests that the default unit target excludes.
-_SCALING_MATRIX_SRCS = glob(["src/**/*.rs"])
-_SCALING_MATRIX_RUSTC_FLAGS = [
-    "--cfg=scaling_matrix",
-    "--check-cfg=cfg(scaling_matrix)",
-    "--check-cfg=cfg(test)",
-]
+# Heavy-matrix scaling targets (Finding 6, RUE-1086). Both wrap the ordinary
+# `rue-compiler-test` binary and select the `#[ignore]`d `scaling_matrix_*`
+# rows out of it by name.
+#
+# RUE-1262: this used to be a second `rust_test` compiling the whole crate
+# under `--cfg=scaling_matrix`. That made it a strict superset of
+# `rue-compiler-test` — 816 tests against 813 — so the premerge lane ran the
+# shared 813 twice to gain three, and paid a third full compile of the crate
+# to do it. Wrapping one binary is the pattern the stress tier already used,
+# and it keeps the matrix rows selectable without a distinct configuration.
 
-# The bounded 100/1k matrix is a required premerge canary. It remains a
-# separate target so `scaling_matrix` coverage is isolated from the default
-# unit target while still running in the Linux premerge graph.
-rue_rust_test(
+# The bounded 100/1k matrix is a required premerge canary.
+rue_sh_test(
     name = "scaling-matrix-test",
+    args = [
+        "--ignored",
+        "scaling_matrix",
+    ],
     labels = ["rue_dedicated_suite"],
-    srcs = _SCALING_MATRIX_SRCS,
-    mapped_srcs = _RUNTIME_MAPPED_SRCS,
-    deps = _DEPS,
-    rustc_flags = _SCALING_MATRIX_RUSTC_FLAGS,
+    test = ":rue-compiler-test",
 )
 
 # The opt-in 10k-per-axis ladder is intentionally absent from premerge. This
@@ -93,12 +88,16 @@ rue_rust_test(
 rue_sh_test(
     name = "scaling-matrix-stress-test",
     tier = "stress",
-    args = ["scaling_matrix", "--nocapture"],
+    args = [
+        "--ignored",
+        "scaling_matrix",
+        "--nocapture",
+    ],
     env = {
         "RUE_SCALING_LARGE": "1",
     },
     labels = ["rue_dedicated_suite"],
-    test = ":scaling-matrix-test",
+    test = ":rue-compiler-test",
 )
 
 # Compiles against rue-compiler as an external crate so curated reexports and

--- a/crates/rue-compiler/src/scaling_harness.rs
+++ b/crates/rue-compiler/src/scaling_harness.rs
@@ -600,15 +600,13 @@ fn assert_warm_fresh_parity(
 // ---------------------------------------------------------------------------
 
 /// The larger 10k-per-axis corpus runs only when `RUE_SCALING_LARGE=1`. The
-/// dedicated matrix target runs the bounded 100/1k subset; the huge sizes stay
-/// behind this explicit flag.
-#[cfg(scaling_matrix)]
+/// premerge canary runs the bounded 100/1k subset; the huge sizes stay behind
+/// this explicit flag, which `scaling-matrix-stress-test` sets.
 fn large_sizes_enabled() -> bool {
     std::env::var_os("RUE_SCALING_LARGE").is_some_and(|v| v == "1")
 }
 
-/// The reached-body / declaration size ladder for the matrix target.
-#[cfg(scaling_matrix)]
+/// The reached-body / declaration size ladder for the matrix rows.
 fn matrix_size_ladder() -> Vec<usize> {
     if large_sizes_enabled() {
         vec![100, 1_000, 10_000]
@@ -903,23 +901,37 @@ fn identity_per_body_lookup_invariant_to_unrelated_declarations() {
 }
 
 // ---------------------------------------------------------------------------
-// Heavy structural matrix (dedicated `scaling-matrix-test` target only)
+// Heavy structural matrix (`scaling-matrix-test` premerge canary)
 // ---------------------------------------------------------------------------
+//
+// These rows are minutes of work at 100/1k, so they stay out of the default
+// `rue-compiler-test` run. They are excluded with libtest's own mechanism —
+// `#[ignore]`, selected back by `--ignored` — rather than by compiling the
+// whole crate a second time under `--cfg=scaling_matrix`. That second compile
+// made `scaling-matrix-test` a strict superset of `rue-compiler-test`: 816
+// tests against 813, re-running the shared 813 in the same lane to gain three
+// (RUE-1262).
+//
+// Selection is by name: `//crates/rue-compiler:scaling-matrix-test` and its
+// stress sibling wrap this binary and pass `--ignored scaling_matrix`. The
+// `scaling_matrix_` prefix is therefore load-bearing — an ignored test named
+// into that prefix joins the premerge canary, and one named out of it is not
+// run by any target.
 
-#[cfg(scaling_matrix)]
 #[test]
+#[ignore = "heavy 100/1k structural matrix; run by the scaling-matrix-test target"]
 fn scaling_matrix_fixed_bodies_growing_declarations() {
     run_fixed_bodies_growing_declarations(100, &matrix_size_ladder());
 }
 
-#[cfg(scaling_matrix)]
 #[test]
+#[ignore = "heavy 100/1k structural matrix; run by the scaling-matrix-test target"]
 fn scaling_matrix_fixed_declarations_growing_bodies() {
     run_fixed_declarations_growing_bodies(100, &matrix_size_ladder());
 }
 
-#[cfg(scaling_matrix)]
 #[test]
+#[ignore = "heavy 100/1k structural matrix; run by the scaling-matrix-test target"]
 fn scaling_matrix_identity_invariant() {
     run_identity_invariant(50, &[50, 200, 400]);
 }

--- a/docs/notes/rue-1083-closure-evidence.md
+++ b/docs/notes/rue-1083-closure-evidence.md
@@ -180,10 +180,10 @@ single raw ledger; it must not duplicate or silently revise the raw results.
 Run and record the exact structural commands:
 
 ```sh
-./buck2 build //crates/rue-compiler:scaling-matrix-test
-./buck2 run //crates/rue-compiler:scaling-matrix-test -- \
+./buck2 build //crates/rue-compiler:rue-compiler-test
+./buck2 run //crates/rue-compiler:rue-compiler-test -- --ignored \
   scaling_matrix_fixed_bodies_growing_declarations --nocapture
-RUE_SCALING_LARGE=1 ./buck2 run //crates/rue-compiler:scaling-matrix-test -- \
+RUE_SCALING_LARGE=1 ./buck2 run //crates/rue-compiler:rue-compiler-test -- --ignored \
   scaling_matrix_fixed_bodies_growing_declarations --nocapture
 ```
 

--- a/docs/process/ci.md
+++ b/docs/process/ci.md
@@ -166,6 +166,17 @@ canary target in the Linux premerge graph;
 10k-per-axis ladder and belongs to `stress`. Caldera and Meridian likewise
 keep their 4x configurations in dedicated stress targets.
 
+Both scaling-matrix targets wrap the ordinary
+`//crates/rue-compiler:rue-compiler-test` binary and select its `#[ignore]`d
+`scaling_matrix_*` rows with `--ignored scaling_matrix`. They do not compile
+the crate again. Excluding heavy rows with `#[ignore]` rather than a
+target-specific `--cfg` is what keeps a dedicated target from silently
+becoming a superset of the unit target it was meant to be separate from — the
+defect RUE-1262 found, where the premerge lane ran 813 shared tests twice to
+gain three. A test named `scaling_matrix_*` and marked `#[ignore]` is in the
+premerge canary; anything else marked `#[ignore]` is opt-in only and no target
+runs it.
+
 Execution tier and discovery are separate concerns. A required pre-merge test
 may also carry `rue_heavy_suite` or `rue_dedicated_suite` so wrappers can
 select it explicitly without misrepresenting it as scheduled-only coverage.


### PR DESCRIPTION
## What

`//crates/rue-compiler:scaling-matrix-test` compiled the whole crate a second time under `--cfg=scaling_matrix` to enable three `#[cfg(scaling_matrix)]` structural scaling rows. That made it a strict superset of `rue-compiler-test` — 816 tests against 813, all 813 shared — so the Linux premerge lane ran those 813 twice to gain three, and paid a third full compile of the crate to do it.

The three rows are now `#[ignore]`d in the one test binary and selected back with `--ignored scaling_matrix`. Both `scaling-matrix-test` (the premerge canary) and `scaling-matrix-stress-test` wrap `:rue-compiler-test` — the pattern the stress tier already used for the 10k ladder.

`#[ignore]` is libtest's own mechanism for keeping an expensive test out of the default run, and it needs no distinct build configuration. That is the point: a dedicated target selecting *by name out of one binary* cannot silently become a superset of the unit target it was meant to be separate from, which is how the duplication arose in the first place.

## Why not a `tests/` integration target

The other option considered was moving the matrix rows into their own `tests/` target, dropping the cfg pattern entirely. It does not survive contact with the harness: `Measure::cold` calls `CompilerSession::canonical_semantic` (`session.rs:4403`), which is `pub(crate)`, and reads `CanonicalSemanticWork` and its `body_analysis` / `declaration_reuse` / `cfg` / `binding` / `declaration_index` sub-records, all `pub(crate)` (`lib.rs:159-196`). An integration target is an external crate and can reach none of it.

Exposing them means widening `unstable`, against an explicit gate — `api_inventory.rs:1759`, `unstable_views_do_not_alias_query_engine_records`, whose message is *"unstable may reexport only reviewed presentation, source-assembly, and Phase-2 demand helpers."* Query-engine work records are what that gate exists to keep out. The `-fuzz-support` sibling-target pattern is not an escape either: it works by compiling the crate a second time under a feature cfg, which is the cost being removed here.

The matrix rows also do not own their logic — `run_fixed_bodies_growing_declarations` and friends are shared with the always-on smoke tests at 20/40, so "move the three tests" is really "move the harness," which would pull the smoke rows out of `rue-compiler-test` and therefore out of the native lanes' pinned coverage.

## Verification

Run locally against the live graph (pinned buck2, cold build):

- `buck2 bxl //test_tiers.bxl:validate` — passes, tier counts unchanged at 88 premerge / 5 slow / 3 stress.
- `buck2 build //crates/rue-compiler:rue-compiler-test` — succeeds, so the crate is clean under `-Dwarnings` with the cfg and both `--check-cfg=cfg(scaling_matrix)` flags removed.
- `--list` reports 816 tests, 6 of them ignored. `--list --ignored scaling_matrix` selects exactly the three matrix rows; the crate's three pre-existing `#[ignore]`d latency witnesses are left alone by the filter.
- `buck2 test //crates/rue-compiler:scaling-matrix-test` — `✓ Pass`, "3 passed; 0 failed; 813 filtered out; finished in 7.89s", confirming the `sh_test` wrapper plumbs args through the test executor.
- `buck2 test //crates/rue-compiler:rue-compiler-test` — passes; the binary's own summary is "810 passed; 0 failed; 6 ignored". The executed set is byte-for-byte the same 810 tests as before this change: the crate already had three ignored latency witnesses, and the three matrix rows join them rather than joining the run.

The stress target's 10k ladder was not executed locally; its wiring differs from the verified canary only by `RUE_SCALING_LARGE=1` and `--nocapture`, both carried over unchanged from the previous target.

## Scope

This is scope A only. It removes ~217s of duplicated execution and one of three full compiles of the crate from the premerge lane, but **it does not move the lane's critical path** — the eviction-pressure test still sets the floor, and that ruling is scope B. Lane wall time should be re-measured on CI after B, not after this.

Selection is by name, so the `scaling_matrix_` prefix is now load-bearing: an `#[ignore]`d test named into that prefix joins the premerge canary, one named out of it runs nowhere. That rule is recorded next to the tests and in `docs/process/ci.md`. It is the kind of convention the RUE-1265 duplication gate should eventually enforce mechanically rather than by comment.

`docs/designs/0069-ci-work-scheduling.md` and the `docs/notes/rue-1250-*` measurement notes still describe this duplication in the present tense. They are dated findings and were left as written; happy to mark the ADR bullet resolved if you would rather it track current state.

Refs RUE-1262.
