### PR TITLE
Unknown-intrinsic diagnostics and declaration-time accessor acyclicity

### DIFF
--- a/crates/rue-air/src/declaration_validation.rs
+++ b/crates/rue-air/src/declaration_validation.rs
@@ -372,8 +372,7 @@ pub struct AccessorOwnerMethod {
 }
 
 /// The note every producer attaches to the 6.6:14 recursion diagnostic.
-pub const ACCESSOR_RECURSION_NOTE: &str =
-    "an accessor call is expanded by mandatory CFG splicing, so a cycle of accessor calls has no finite expansion";
+pub const ACCESSOR_RECURSION_NOTE: &str = "an accessor call is expanded by mandatory CFG splicing, so a cycle of accessor calls has no finite expansion";
 
 /// 6.6:14: the diagnostic for an accessor that participates in an expansion
 /// cycle.
@@ -400,11 +399,7 @@ pub fn accessor_self_call_cycle(start: &str, methods: &[AccessorOwnerMethod]) ->
     let Some(origin) = accessor(start) else {
         return false;
     };
-    let mut pending: Vec<&str> = origin
-        .self_call_targets
-        .iter()
-        .map(AsRef::as_ref)
-        .collect();
+    let mut pending: Vec<&str> = origin.self_call_targets.iter().map(AsRef::as_ref).collect();
     let mut seen: std::collections::BTreeSet<&str> = std::collections::BTreeSet::new();
     while let Some(name) = pending.pop() {
         let Some(method) = accessor(name) else {

--- a/crates/rue-air/src/declaration_validation.rs
+++ b/crates/rue-air/src/declaration_validation.rs
@@ -352,3 +352,70 @@ pub fn accessor_yield_root_error(root: &AccessorYieldRootForm) -> ErrorKind {
     };
     ErrorKind::AccessorYieldNotReceiverRooted { found }
 }
+
+/// One method of an accessor's owner, as the 6.6:14 declaration-seam cycle
+/// rule reads it (RUE-1282).
+///
+/// `self_call_targets` are the method names the method's own body calls on its
+/// `self` receiver — a *parsed* fact of that sibling declaration, position-free
+/// and normalized (sorted, deduplicated), so a body edit that does not change
+/// the set leaves the value equal. A call through any other receiver is not
+/// recorded: per the well-founded component order, a cycle of accessor
+/// expansions on one owner can otherwise only pass through a guard parameter
+/// of the owner's own type, and those exotic edges stay with the demanded-path
+/// checks (the analysis-time identity check and the CFG dependency graph).
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct AccessorOwnerMethod {
+    pub name: std::sync::Arc<str>,
+    pub is_accessor: bool,
+    pub self_call_targets: std::sync::Arc<[std::sync::Arc<str>]>,
+}
+
+/// The note every producer attaches to the 6.6:14 recursion diagnostic.
+pub const ACCESSOR_RECURSION_NOTE: &str =
+    "an accessor call is expanded by mandatory CFG splicing, so a cycle of accessor calls has no finite expansion";
+
+/// 6.6:14: the diagnostic for an accessor that participates in an expansion
+/// cycle.
+pub fn accessor_recursion_error(method: &str) -> ErrorKind {
+    ErrorKind::AccessorRecursion {
+        method: method.to_owned(),
+    }
+}
+
+/// 6.6:14 at the declaration seam: whether the accessor named `start` reaches
+/// itself over the owner's `self`-receiver accessor-call edges.
+///
+/// An edge exists from one accessor to another exactly when the first's body
+/// calls the second on `self` — `self.m()` where `m` is an accessor of the
+/// same owner resolves to exactly that accessor, so the edge is certain with
+/// no type resolved. Plain-method targets are not edges: an ordinary call is
+/// not spliced, so it cannot extend an expansion.
+pub fn accessor_self_call_cycle(start: &str, methods: &[AccessorOwnerMethod]) -> bool {
+    let accessor = |name: &str| {
+        methods
+            .iter()
+            .find(|method| method.is_accessor && method.name.as_ref() == name)
+    };
+    let Some(origin) = accessor(start) else {
+        return false;
+    };
+    let mut pending: Vec<&str> = origin
+        .self_call_targets
+        .iter()
+        .map(AsRef::as_ref)
+        .collect();
+    let mut seen: std::collections::BTreeSet<&str> = std::collections::BTreeSet::new();
+    while let Some(name) = pending.pop() {
+        let Some(method) = accessor(name) else {
+            continue;
+        };
+        if method.name.as_ref() == start {
+            return true;
+        }
+        if seen.insert(name) {
+            pending.extend(method.self_call_targets.iter().map(AsRef::as_ref));
+        }
+    }
+    false
+}

--- a/crates/rue-air/src/inference/generate.rs
+++ b/crates/rue-air/src/inference/generate.rs
@@ -2109,13 +2109,25 @@ impl<'a> ConstraintGenerator<'a> {
                         self.generate(*arg_ref, ctx);
                     }
                     InferType::Concrete(Type::new_module(crate::types::ModuleId::UNRESOLVED))
-                } else {
-                    // Generate constraints for arguments (they need to be processed)
+                } else if intrinsic_name == "dbg"
+                    || intrinsic_name == "drop"
+                    || intrinsic_name == "test_preview_gate"
+                {
+                    // The remaining known intrinsics all return unit.
                     for arg_ref in args.iter() {
                         self.generate(*arg_ref, ctx);
                     }
-                    // @dbg and other intrinsics return Unit
                     InferType::Concrete(Type::UNIT)
+                } else {
+                    // Unknown intrinsic: a fresh var, so sema can reject it with
+                    // E0700 naming the bogus intrinsic instead of inference
+                    // masking it with a type-mismatch against the context's
+                    // expected type — the same treatment @cast gets (RUE-319,
+                    // here RUE-1281).
+                    for arg_ref in args.iter() {
+                        self.generate(*arg_ref, ctx);
+                    }
+                    InferType::Var(self.fresh_var())
                 }
             }
 

--- a/crates/rue-air/src/sema/analysis/ownership.rs
+++ b/crates/rue-air/src/sema/analysis/ownership.rs
@@ -1170,9 +1170,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
                 },
                 span,
             )
-            .with_note(
-                "an accessor call is expanded by mandatory CFG splicing, so a cycle of accessor calls has no finite expansion",
-            ));
+            .with_note(crate::declaration_validation::ACCESSOR_RECURSION_NOTE));
         }
 
         // RUE-1208: semantic analysis establishes the accessor's place/loan

--- a/crates/rue-air/src/sema/declarations.rs
+++ b/crates/rue-air/src/sema/declarations.rs
@@ -3299,6 +3299,120 @@ pub(super) fn check_accessor_declaration_shape(
     Ok(())
 }
 
+/// 6.6:14 at the declaration seam (RUE-1282): reject an accessor cycle for
+/// every accessor the program declares, whether or not anything calls one.
+///
+/// A cycle has no finite expansion — a property of the declarations alone —
+/// so this runs beside the other accessor shape rules rather than waiting for
+/// a call site to demand a body. The edge set is the `self`-receiver accessor
+/// calls in each body: a call `self.m()` where `m` is an accessor of the same
+/// owner resolves to exactly that accessor, so the edge is certain without
+/// resolving a single type. A re-entrant call through any other receiver (a
+/// `borrow`-mode guard parameter of the owner's own type) is not decidable
+/// here and stays with the demanded-path checks: the analysis-time identity
+/// check for a direct cycle and the CFG dependency graph for a mutual one.
+pub(super) fn check_accessor_acyclicity(
+    rir: &rue_rir::Rir,
+    interner: &lasso::ThreadedRodeo,
+    pending: &[super::binding_manifest::PendingDeclarationPayload],
+) -> CompileResult<()> {
+    struct DeclaredAccessor {
+        name: Arc<str>,
+        body: InstRef,
+        span: Span,
+        source_order: u32,
+    }
+    // Group declared accessors by owning nominal. `module_path` joins the key
+    // so same-named owners from different modules never share a graph.
+    let mut groups: std::collections::BTreeMap<(Arc<str>, Arc<str>), Vec<DeclaredAccessor>> =
+        std::collections::BTreeMap::new();
+    for payload in pending {
+        let super::binding_manifest::DeclarationPayloadSource::Callable { body } = payload.source
+        else {
+            continue;
+        };
+        let Some(owner) = payload.shell.identity.owner.clone() else {
+            continue;
+        };
+        let InstData::FnDecl {
+            returns_borrow: true,
+            has_self: true,
+            ..
+        } = rir.get(payload.declaration).data
+        else {
+            continue;
+        };
+        groups
+            .entry((payload.shell.identity.module_path.clone(), owner))
+            .or_default()
+            .push(DeclaredAccessor {
+                name: payload.shell.identity.name.clone(),
+                body,
+                span: payload.shell.declaration_span,
+                source_order: payload.shell.source_order,
+            });
+    }
+
+    let Some(self_sym) = interner.get("self") else {
+        return Ok(());
+    };
+    for accessors in groups.values_mut() {
+        // Source order makes the reported accessor the first of the cycle's
+        // members the program declares.
+        accessors.sort_by_key(|accessor| accessor.source_order);
+        let methods: Vec<crate::declaration_validation::AccessorOwnerMethod> = accessors
+            .iter()
+            .map(|accessor| crate::declaration_validation::AccessorOwnerMethod {
+                name: accessor.name.clone(),
+                is_accessor: true,
+                self_call_targets: rir_self_call_targets(rir, interner, self_sym, accessor.body),
+            })
+            .collect();
+        for accessor in accessors.iter() {
+            if crate::declaration_validation::accessor_self_call_cycle(&accessor.name, &methods) {
+                return Err(CompileError::new(
+                    crate::declaration_validation::accessor_recursion_error(&accessor.name),
+                    accessor.span,
+                )
+                .with_note(crate::declaration_validation::ACCESSOR_RECURSION_NOTE));
+            }
+        }
+    }
+    Ok(())
+}
+
+/// The method names one accessor body calls on its own `self` receiver, in the
+/// normalized (sorted, deduplicated) form [`accessor_self_call_cycle`]'s edges
+/// use.
+///
+/// [`accessor_self_call_cycle`]: crate::declaration_validation::accessor_self_call_cycle
+fn rir_self_call_targets(
+    rir: &rue_rir::Rir,
+    interner: &lasso::ThreadedRodeo,
+    self_sym: Spur,
+    body: InstRef,
+) -> Arc<[Arc<str>]> {
+    let mut targets: Vec<Arc<str>> = body_instructions(rir, body)
+        .into_iter()
+        .filter_map(|inst_ref| {
+            let InstData::MethodCall {
+                receiver, method, ..
+            } = &rir.get(inst_ref).data
+            else {
+                return None;
+            };
+            let receiver_is_self = matches!(
+                &rir.get(*receiver).data,
+                InstData::VarRef { name, .. } if *name == self_sym
+            );
+            receiver_is_self.then(|| Arc::from(interner.resolve(method)))
+        })
+        .collect();
+    targets.sort();
+    targets.dedup();
+    Arc::from(targets)
+}
+
 /// The 6.6:5 form of one RIR parameter.
 pub(super) fn accessor_parameter_form(
     mode: RirParamMode,

--- a/crates/rue-air/src/sema/declarations.rs
+++ b/crates/rue-air/src/sema/declarations.rs
@@ -3362,11 +3362,18 @@ pub(super) fn check_accessor_acyclicity(
         accessors.sort_by_key(|accessor| accessor.source_order);
         let methods: Vec<crate::declaration_validation::AccessorOwnerMethod> = accessors
             .iter()
-            .map(|accessor| crate::declaration_validation::AccessorOwnerMethod {
-                name: accessor.name.clone(),
-                is_accessor: true,
-                self_call_targets: rir_self_call_targets(rir, interner, self_sym, accessor.body),
-            })
+            .map(
+                |accessor| crate::declaration_validation::AccessorOwnerMethod {
+                    name: accessor.name.clone(),
+                    is_accessor: true,
+                    self_call_targets: rir_self_call_targets(
+                        rir,
+                        interner,
+                        self_sym,
+                        accessor.body,
+                    ),
+                },
+            )
             .collect();
         for accessor in accessors.iter() {
             if crate::declaration_validation::accessor_self_call_cycle(&accessor.name, &methods) {

--- a/crates/rue-air/src/sema/mod.rs
+++ b/crates/rue-air/src/sema/mod.rs
@@ -1464,6 +1464,11 @@ impl<'a> Sema<'a, MutableDeclarations> {
             self.check_foreign_entry_point_declaration(pending.declaration)
                 .map_err(CompileErrors::from)?;
         }
+        // Accessor acyclicity (6.6:14, RUE-1282) is likewise a property of the
+        // declarations alone, but it needs every accessor of an owner in hand,
+        // so it runs after the per-declaration rules above.
+        declarations::check_accessor_acyclicity(self.rir, self.interner, pending_payloads)
+            .map_err(CompileErrors::from)?;
         Ok(())
     }
 

--- a/crates/rue-air/src/sema/tests.rs
+++ b/crates/rue-air/src/sema/tests.rs
@@ -4081,24 +4081,52 @@ fn main() -> i32 {
     }
 
     #[test]
-    fn mutually_recursive_accessors_retain_marked_calls_for_cfg_cycle_rejection() {
-        // Cross-body cycle rejection belongs to the canonical CFG dependency
-        // graph; semantic analysis must preserve both exact accessor calls.
+    fn uncalled_accessor_cycle_is_rejected_at_declaration() {
+        // 6.6:14 is a legality rule on the declarations alone (RUE-1282): a
+        // cycle over `self`-receiver accessor calls needs no call site.
         let source = "
 struct P {
     x: i64,
 
-    fn a(borrow self) -> borrow i64 {
-        yield self.b();
+    @allow(unused_function)
+    fn a(borrow self) -> borrow i64 { yield self.b(); }
+    @allow(unused_function)
+    fn b(borrow self) -> borrow i64 { yield self.a(); }
+}
+fn main() -> i32 { 0 }";
+        let errors = compile_with_accessors(source).expect_err("uncalled accessor cycle");
+        assert!(
+            errors
+                .iter()
+                .any(|error| matches!(&error.kind, ErrorKind::AccessorRecursion { .. }))
+        );
+    }
+
+    #[test]
+    fn mutually_recursive_accessors_retain_marked_calls_for_cfg_cycle_rejection() {
+        // Cross-body cycle rejection belongs to the canonical CFG dependency
+        // graph; semantic analysis must preserve both exact accessor calls.
+        // The `a -> b` link runs through a by-value guard's receiver rather
+        // than `self`: a cycle whose every edge is a `self`-receiver call is
+        // now rejected at the declaration seam (6.6:14, RUE-1282), and this
+        // test pins the demanded-path division of labor for the edges that
+        // seam cannot see.
+        let source = "
+struct P {
+    x: i64,
+
+    fn a(borrow self, other: P) -> borrow i64 {
+        let _ = other.b();
+        yield self.x;
     }
 
     fn b(borrow self) -> borrow i64 {
-        yield self.a();
+        yield self.a(P { x: 3 });
     }
 }
 fn main() -> i32 {
     let p = P { x: 1 };
-    if p.a() == 1 { 0 } else { 1 }
+    if p.a(P { x: 2 }) == 1 { 0 } else { 1 }
 }";
         let output = compile_with_accessors(source).expect("sema preserves the accessor cycle");
         let calls = output

--- a/crates/rue-compiler/src/declaration_candidate.rs
+++ b/crates/rue-compiler/src/declaration_candidate.rs
@@ -153,23 +153,27 @@ pub(crate) struct RawAccessorSignatureSyntax {
     /// trailing-yield check even when no caller demands body analysis, so this
     /// one signature query legitimately depends on its own body.
     pub(crate) body: Arc<str>,
-    /// Every method the accessor's owner declares, paired with whether it is
-    /// itself an accessor, sorted by name and with ambiguous duplicate names
+    /// Every method the accessor's owner declares — its name, whether it is
+    /// itself an accessor, and the method names its body calls on its own
+    /// `self` receiver — sorted by name and with ambiguous duplicate names
     /// dropped.
     ///
     /// 6.6:7 admits a method-call link in the yielded chain only when the
-    /// callee is an accessor. For a link whose receiver is the accessor's own
-    /// `self`, the callee is a method of this owner, and whether it is an
-    /// accessor is a *parsed* fact of a sibling declaration — no signature or
-    /// body of that sibling is demanded, so there is no query cycle between
-    /// mutually recursive accessors. Retaining the facts here is what records
-    /// the dependency: this terminal is materialized from the module's parse,
-    /// so editing a sibling method's `-> borrow` qualifier changes this value
-    /// and re-runs every consumer of this accessor's signature.
+    /// callee is an accessor, and 6.6:14 rejects a cycle of accessor
+    /// expansions (RUE-1282). For a link whose receiver is the accessor's own
+    /// `self`, the callee is a method of this owner, and both deciding facts —
+    /// the sibling's `-> borrow` qualifier and its own `self`-call targets —
+    /// are *parsed* facts of the sibling declaration: no signature or body of
+    /// that sibling is demanded, so there is no query cycle between mutually
+    /// recursive accessors. Retaining the facts here is what records the
+    /// dependency: this terminal is materialized from the module's parse, so
+    /// editing a sibling method's `-> borrow` qualifier or `self`-call set
+    /// changes this value and re-runs every consumer of this accessor's
+    /// signature.
     ///
     /// Empty for an accessor with no owning type, or whose owner declares no
     /// other methods.
-    pub(crate) owner_methods: Arc<[(Arc<str>, bool)]>,
+    pub(crate) owner_methods: Arc<[rue_air::declaration_validation::AccessorOwnerMethod]>,
 }
 
 /// Stable, position-free failure retained by the exact raw-signature family.

--- a/crates/rue-compiler/src/parsed_modules.rs
+++ b/crates/rue-compiler/src/parsed_modules.rs
@@ -421,13 +421,13 @@ impl ParsedDefinitionIndex {
         Some(syntax)
     }
 
-    /// Every method one owner declares in this module, paired with whether it
-    /// is itself a `-> borrow` accessor, in the normalized form the raw
-    /// signature terminal retains.
+    /// Every method one owner declares in this module — its name, whether it
+    /// is itself a `-> borrow` accessor, and its `self`-call targets — in the
+    /// normalized form the raw signature terminal retains.
     fn owner_method_accessor_facts(
         &self,
         owner: &crate::declaration_candidate::DeclarationCandidateOwner,
-    ) -> Arc<[(Arc<str>, bool)]> {
+    ) -> Arc<[rue_air::declaration_validation::AccessorOwnerMethod]> {
         use crate::declaration_candidate::DeclarationCandidateCategory as Category;
         crate::semantic_query_nucleus::owner_method_accessor_facts(
             self.declarations
@@ -436,7 +436,13 @@ impl ParsedDefinitionIndex {
                     candidate.fact.key.category == Category::Method
                         && candidate.fact.key.owner.as_ref() == Some(owner)
                 })
-                .map(|candidate| (candidate.fact.key.name.clone(), candidate.is_accessor)),
+                .map(
+                    |candidate| rue_air::declaration_validation::AccessorOwnerMethod {
+                        name: candidate.fact.key.name.clone(),
+                        is_accessor: candidate.is_accessor,
+                        self_call_targets: candidate.self_call_targets.clone(),
+                    },
+                ),
         )
     }
 
@@ -536,6 +542,11 @@ pub(crate) struct ParsedDeclarationCandidate {
     raw_signature_locator: Option<RawDeclarationSignatureLocator>,
     raw_body_span: Option<Span>,
     is_accessor: bool,
+    /// The method names this declaration's body calls on its own `self`
+    /// receiver, normalized. Non-empty only for methods; the accessor
+    /// signature terminal retains it as a sibling's 6.6:14 cycle edge
+    /// (RUE-1282).
+    self_call_targets: Arc<[Arc<str>]>,
     raw_import_range: Option<RawDeclarationImportRange>,
     /// Value-position anonymous type literals inside this declaration's constant
     /// initializer or body, with module-relative spans and their frontend
@@ -1540,6 +1551,7 @@ fn bind_payload(
                 ),
                 raw_body_span: candidate.raw_body_span.map(remap_span),
                 is_accessor: candidate.is_accessor,
+                self_call_targets: candidate.self_call_targets.clone(),
                 raw_import_range: candidate.raw_import_range,
                 anonymous_sites: candidate
                     .anonymous_sites
@@ -2006,12 +2018,37 @@ fn build_definition_index(
         Option<RawDeclarationSignatureLocator>,
         Option<Span>,
         bool,
+        Arc<[Arc<str>]>,
         Option<RawDeclarationImportRange>,
         Arc<[rue_rir::AnonymousTypeSite]>,
     )>::new();
     let resolve_name = |ident: rue_parser::Ident| -> CompileResult<Arc<str>> {
         let symbol = resolver.symbol(ident.name)?;
         Ok(Arc::from(resolver.resolve(&symbol)?))
+    };
+    // The method names one body calls on its own `self` receiver, normalized
+    // (sorted, deduplicated). Retained per method candidate so an accessor's
+    // signature terminal can carry its siblings' 6.6:14 cycle edges
+    // (RUE-1282) exactly as it carries their `-> borrow` qualifiers.
+    let self_call_targets = |body: &rue_parser::ast::Expr| -> CompileResult<Arc<[Arc<str>]>> {
+        use rue_parser::ast::Expr;
+        let mut walk = vec![body];
+        let mut targets: Vec<Arc<str>> = Vec::new();
+        while let Some(expr) = walk.pop() {
+            if let Expr::MethodCall(call) = expr {
+                let mut receiver = &*call.receiver;
+                while let Expr::Paren(paren) = receiver {
+                    receiver = &paren.inner;
+                }
+                if matches!(receiver, Expr::SelfExpr(_)) {
+                    targets.push(resolve_name(call.method)?);
+                }
+            }
+            expr.child_exprs(&mut walk);
+        }
+        targets.sort();
+        targets.dedup();
+        Ok(Arc::from(targets))
     };
     let parameters =
         |params: &[rue_parser::Param]| -> CompileResult<Arc<[DeclarationParameterHeader]>> {
@@ -2084,6 +2121,7 @@ fn build_definition_index(
                         is_unchecked,
                         is_extern,
                         is_accessor,
+                        method_self_call_targets: Arc<[Arc<str>]>,
                         declaration_span,
                         signature_spans: Vec<Span>,
                         raw_const_syntax_spans: Option<RawConstSyntaxSpans>,
@@ -2157,6 +2195,7 @@ fn build_definition_index(
                 raw_signature_locator,
                 raw_body_span,
                 is_accessor,
+                method_self_call_targets,
                 raw_import_range,
                 anonymous_sites,
             ));
@@ -2176,6 +2215,7 @@ fn build_definition_index(
                 function.is_unchecked,
                 false,
                 function.borrow_return.is_some(),
+                Arc::from([]),
                 function.span,
                 vec![signature_prefix(function.span, function.body.span())?],
                 None,
@@ -2203,6 +2243,7 @@ fn build_definition_index(
                     false,
                     false,
                     false,
+                    Arc::from([]),
                     structure.span,
                     signature_fragments_excluding_method_bodies(structure)?,
                     None,
@@ -2238,6 +2279,7 @@ fn build_definition_index(
                         false,
                         false,
                         method.borrow_return.is_some(),
+                        self_call_targets(&method.body)?,
                         method.span,
                         vec![signature_prefix(method.span, method.body.span())?],
                         None,
@@ -2265,6 +2307,7 @@ fn build_definition_index(
                 false,
                 false,
                 false,
+                Arc::from([]),
                 value.span,
                 vec![value.span],
                 None,
@@ -2297,6 +2340,7 @@ fn build_definition_index(
                     false,
                     false,
                     false,
+                    Arc::from([]),
                     value.span,
                     vec![signature_prefix(value.span, value.init.span())?],
                     Some(raw_const_syntax_spans),
@@ -2320,6 +2364,7 @@ fn build_definition_index(
                 false,
                 false,
                 false,
+                Arc::from([]),
                 value.span,
                 vec![signature_prefix(value.span, value.body.span())?],
                 None,
@@ -2347,6 +2392,7 @@ fn build_definition_index(
                         false,
                         true,
                         false,
+                        Arc::from([]),
                         function.span,
                         vec![function.span],
                         None,
@@ -2431,6 +2477,7 @@ fn build_definition_index(
                 raw_signature_locator,
                 raw_body_span,
                 is_accessor,
+                self_call_targets,
                 raw_import_range,
                 anonymous_sites,
             )| {
@@ -2452,6 +2499,7 @@ fn build_definition_index(
                     raw_signature_locator,
                     raw_body_span,
                     is_accessor,
+                    self_call_targets,
                     raw_import_range,
                     anonymous_sites,
                 })

--- a/crates/rue-compiler/src/retained_charge.rs
+++ b/crates/rue-compiler/src/retained_charge.rs
@@ -1025,6 +1025,15 @@ impl RetainedCharge for crate::declaration_candidate::RawAccessorSignatureSyntax
     }
 }
 
+impl RetainedCharge for rue_air::declaration_validation::AccessorOwnerMethod {
+    fn retained_charge(&self) -> u64 {
+        self.name
+            .retained_charge()
+            .saturating_add(self.is_accessor.retained_charge())
+            .saturating_add(self.self_call_targets.retained_charge())
+    }
+}
+
 impl RetainedCharge for crate::declaration_candidate::RawDeclarationBodySyntax {
     fn retained_charge(&self) -> u64 {
         self.body

--- a/crates/rue-compiler/src/revisioned_query_database.rs
+++ b/crates/rue-compiler/src/revisioned_query_database.rs
@@ -7805,19 +7805,17 @@ impl SemanticConstEvaluator<'_, '_> {
                 // 6.6:7's accessor-link and 6.6:14 cycle-edge facts for this
                 // anonymous owner's own methods, exactly as a named owner's
                 // members retain them.
-                let owner_methods = crate::semantic_query_nucleus::owner_method_accessor_facts(
-                    methods.iter().map(|method| {
-                        rue_air::declaration_validation::AccessorOwnerMethod {
+                let owner_methods =
+                    crate::semantic_query_nucleus::owner_method_accessor_facts(methods.iter().map(
+                        |method| rue_air::declaration_validation::AccessorOwnerMethod {
                             name: Arc::from(self.interner.resolve(&method.name.name)),
                             is_accessor: method.borrow_return.is_some(),
-                            self_call_targets:
-                                crate::semantic_query_nucleus::ast_self_call_targets(
-                                    &method.body,
-                                    self.interner,
-                                ),
-                        }
-                    }),
-                );
+                            self_call_targets: crate::semantic_query_nucleus::ast_self_call_targets(
+                                &method.body,
+                                self.interner,
+                            ),
+                        },
+                    ));
                 let methods = methods
                     .iter()
                     .map(|method| {

--- a/crates/rue-compiler/src/revisioned_query_database.rs
+++ b/crates/rue-compiler/src/revisioned_query_database.rs
@@ -7802,14 +7802,20 @@ impl SemanticConstEvaluator<'_, '_> {
                         crate::durable_semantics::DurableParameterMode::Inout
                     }
                 };
-                // 6.6:7's accessor-link fact for this anonymous owner's own
-                // methods, exactly as a named owner's members retain it.
+                // 6.6:7's accessor-link and 6.6:14 cycle-edge facts for this
+                // anonymous owner's own methods, exactly as a named owner's
+                // members retain them.
                 let owner_methods = crate::semantic_query_nucleus::owner_method_accessor_facts(
                     methods.iter().map(|method| {
-                        (
-                            Arc::from(self.interner.resolve(&method.name.name)),
-                            method.borrow_return.is_some(),
-                        )
+                        rue_air::declaration_validation::AccessorOwnerMethod {
+                            name: Arc::from(self.interner.resolve(&method.name.name)),
+                            is_accessor: method.borrow_return.is_some(),
+                            self_call_targets:
+                                crate::semantic_query_nucleus::ast_self_call_targets(
+                                    &method.body,
+                                    self.interner,
+                                ),
+                        }
                     }),
                 );
                 let methods = methods
@@ -10516,6 +10522,7 @@ fn resolve_parsed_semantic_signature(
             is_c_export,
             is_accessor,
             accessor_body,
+            accessor_cycle,
         } => {
             if *is_accessor {
                 // 6.6:3-6.6:7 over the reparsed declaration. Which forms are
@@ -10593,6 +10600,19 @@ fn resolve_parsed_semantic_signature(
                 // demanded path.
                 if let Some(kind) = rules::accessor_body_error(accessor_body) {
                     return Err(diagnostic(kind));
+                }
+                // 6.6:14 over the owner's retained `self`-call edges: an
+                // accessor cycle has no finite expansion, so it too is a
+                // legality rule on the declaration (RUE-1282). Exotic edges
+                // through a non-`self` receiver stay with the demanded-path
+                // checks.
+                if let Some(method) = accessor_cycle {
+                    return Err(ResolveSemanticSignatureError::failure(
+                        crate::semantic_query_nucleus::SemanticNucleusFailure::DiagnosticWithNote {
+                            kind: rules::accessor_recursion_error(method),
+                            note: Arc::from(rules::ACCESSOR_RECURSION_NOTE),
+                        },
+                    ));
                 }
             }
             let mut generic_index = 0_u32;

--- a/crates/rue-compiler/src/semantic_query_nucleus.rs
+++ b/crates/rue-compiler/src/semantic_query_nucleus.rs
@@ -372,7 +372,10 @@ pub(crate) fn parse_semantic_signature(
         .first()
         .ok_or_else(|| Arc::from("semantic signature parsed no declaration"))?;
     let unit: Arc<str> = Arc::from("()");
-    let owner_methods = syntax.accessor.as_ref().map_or::<&[rue_air::declaration_validation::AccessorOwnerMethod], _>(
+    let owner_methods = syntax
+        .accessor
+        .as_ref()
+        .map_or::<&[rue_air::declaration_validation::AccessorOwnerMethod], _>(
         &[],
         |accessor| &accessor.owner_methods,
     );
@@ -382,11 +385,9 @@ pub(crate) fn parse_semantic_signature(
     // declaration reaches itself through its siblings' `self`-receiver
     // accessor calls. Decided here so the accessor's own signature query
     // rejects the cycle with no call site anywhere in the program.
-    let accessor_cycle = rue_air::declaration_validation::accessor_self_call_cycle(
-        &key.name,
-        owner_methods,
-    )
-    .then(|| key.name.clone());
+    let accessor_cycle =
+        rue_air::declaration_validation::accessor_self_call_cycle(&key.name, owner_methods)
+            .then(|| key.name.clone());
     let callable = |parameters: &[rue_parser::ast::Param],
                     result: Option<&rue_parser::ast::TypeExpr>,
                     has_self,

--- a/crates/rue-compiler/src/semantic_query_nucleus.rs
+++ b/crates/rue-compiler/src/semantic_query_nucleus.rs
@@ -51,6 +51,11 @@ pub(crate) enum ParsedSemanticSignature {
         /// [`AccessorBodyVerdict::MissingTrailingYield`] for the empty
         /// stand-in.
         accessor_body: AccessorBodyVerdict,
+        /// `Some(name)` when this accessor participates in a 6.6:14 expansion
+        /// cycle over its owner's `self`-receiver accessor calls (RUE-1282),
+        /// decided from the retained owner-method facts. Always `None` for an
+        /// ordinary callable.
+        accessor_cycle: Option<Arc<str>>,
     },
     Struct {
         fields: Arc<[(Arc<str>, Arc<str>)]>,
@@ -165,7 +170,7 @@ fn trailing_yield(body: &rue_parser::ast::Expr) -> Option<&rue_parser::ast::Yiel
     }
 }
 
-/// Normalize one owner's `(method name, is accessor)` pairs into the form
+/// Normalize one owner's method facts into the form
 /// [`crate::declaration_candidate::RawAccessorSignatureSyntax`] retains:
 /// sorted by name, with every ambiguously duplicated name dropped.
 ///
@@ -173,19 +178,47 @@ fn trailing_yield(body: &rue_parser::ast::Expr) -> Option<&rue_parser::ast::Yiel
 /// wherever it cannot *prove* a callee is a plain method, so a name that two
 /// declarations claim is simply not decided here.
 pub(crate) fn owner_method_accessor_facts(
-    methods: impl IntoIterator<Item = (Arc<str>, bool)>,
-) -> Arc<[(Arc<str>, bool)]> {
-    let mut facts: Vec<(Arc<str>, bool)> = methods.into_iter().collect();
+    methods: impl IntoIterator<Item = rue_air::declaration_validation::AccessorOwnerMethod>,
+) -> Arc<[rue_air::declaration_validation::AccessorOwnerMethod]> {
+    let mut facts: Vec<rue_air::declaration_validation::AccessorOwnerMethod> =
+        methods.into_iter().collect();
     facts.sort();
     let mut duplicated: BTreeSet<Arc<str>> = BTreeSet::new();
     for window in facts.windows(2) {
-        if window[0].0 == window[1].0 {
-            duplicated.insert(window[0].0.clone());
+        if window[0].name == window[1].name {
+            duplicated.insert(window[0].name.clone());
         }
     }
-    facts.dedup_by(|left, right| left.0 == right.0);
-    facts.retain(|(name, _)| !duplicated.contains(name));
+    facts.dedup_by(|left, right| left.name == right.name);
+    facts.retain(|fact| !duplicated.contains(&fact.name));
     Arc::from(facts)
+}
+
+/// The method names one body calls on its own `self` receiver, normalized
+/// (sorted, deduplicated) — the 6.6:14 cycle-edge fact (RUE-1282), for a
+/// producer holding the parsed AST and its interner.
+pub(crate) fn ast_self_call_targets(
+    body: &rue_parser::ast::Expr,
+    interner: &crate::ThreadedRodeo,
+) -> Arc<[Arc<str>]> {
+    use rue_parser::ast::Expr;
+    let mut walk = vec![body];
+    let mut targets: Vec<Arc<str>> = Vec::new();
+    while let Some(expr) = walk.pop() {
+        if let Expr::MethodCall(call) = expr {
+            let mut receiver = &*call.receiver;
+            while let Expr::Paren(paren) = receiver {
+                receiver = &paren.inner;
+            }
+            if matches!(receiver, Expr::SelfExpr(_)) {
+                targets.push(Arc::from(interner.resolve(&call.method.name)));
+            }
+        }
+        expr.child_exprs(&mut walk);
+    }
+    targets.sort();
+    targets.dedup();
+    Arc::from(targets)
 }
 
 /// What one method-call link in a yielded projection chain is, as far as the
@@ -198,7 +231,7 @@ pub(crate) fn owner_method_accessor_facts(
 fn accessor_method_link(
     call: &rue_parser::ast::MethodCallExpr,
     interner: &crate::ThreadedRodeo,
-    owner_methods: &[(Arc<str>, bool)],
+    owner_methods: &[rue_air::declaration_validation::AccessorOwnerMethod],
 ) -> rue_air::declaration_validation::AccessorMethodLink {
     use rue_air::declaration_validation::AccessorMethodLink as Link;
     use rue_parser::ast::Expr;
@@ -212,10 +245,10 @@ fn accessor_method_link(
     let name = interner.resolve(&call.method.name);
     match owner_methods
         .iter()
-        .find(|(method, _)| method.as_ref() == name)
+        .find(|method| method.name.as_ref() == name)
     {
-        Some((_, true)) => Link::Accessor,
-        Some((_, false)) => Link::PlainMethod,
+        Some(method) if method.is_accessor => Link::Accessor,
+        Some(_) => Link::PlainMethod,
         // A name the owner does not declare is not this rule's error to
         // report; call resolution names it.
         None => Link::Unresolved,
@@ -249,7 +282,7 @@ fn accessor_method_link(
 fn accessor_body_shape(
     body: &rue_parser::ast::Expr,
     interner: &crate::ThreadedRodeo,
-    owner_methods: &[(Arc<str>, bool)],
+    owner_methods: &[rue_air::declaration_validation::AccessorOwnerMethod],
 ) -> AccessorBodyVerdict {
     use rue_parser::ast::Expr;
     let Some(trailing) = trailing_yield(body) else {
@@ -339,12 +372,21 @@ pub(crate) fn parse_semantic_signature(
         .first()
         .ok_or_else(|| Arc::from("semantic signature parsed no declaration"))?;
     let unit: Arc<str> = Arc::from("()");
-    let owner_methods = syntax
-        .accessor
-        .as_ref()
-        .map_or::<&[(Arc<str>, bool)], _>(&[], |accessor| &accessor.owner_methods);
+    let owner_methods = syntax.accessor.as_ref().map_or::<&[rue_air::declaration_validation::AccessorOwnerMethod], _>(
+        &[],
+        |accessor| &accessor.owner_methods,
+    );
     let body_shape =
         |body: &rue_parser::ast::Expr| accessor_body_shape(body, &interner, owner_methods);
+    // 6.6:14 over the retained owner-method facts (RUE-1282): whether this
+    // declaration reaches itself through its siblings' `self`-receiver
+    // accessor calls. Decided here so the accessor's own signature query
+    // rejects the cycle with no call site anywhere in the program.
+    let accessor_cycle = rue_air::declaration_validation::accessor_self_call_cycle(
+        &key.name,
+        owner_methods,
+    )
+    .then(|| key.name.clone());
     let callable = |parameters: &[rue_parser::ast::Param],
                     result: Option<&rue_parser::ast::TypeExpr>,
                     has_self,
@@ -368,6 +410,7 @@ pub(crate) fn parse_semantic_signature(
             is_c_export,
             is_accessor,
             accessor_body,
+            accessor_cycle: accessor_cycle.clone(),
         })
     };
     match (key.category, item) {

--- a/crates/rue-spec/cases/expressions/intrinsics.toml
+++ b/crates/rue-spec/cases/expressions/intrinsics.toml
@@ -42,6 +42,33 @@ fn main() -> i32 {
 compile_fail = true
 error_contains = "unknown intrinsic"
 
+# An unknown intrinsic is E0700 in every expression position. In a context with
+# an expected type (a function tail, an annotated let), inference used to
+# default the unknown call to `()` and mask the legality error behind an E0206
+# type mismatch pointing at the return type (RUE-1281).
+[[case]]
+name = "unknown_intrinsic_tail_position"
+spec = ["4.13:5"]
+error_contains = ["[E0700]", "unknown intrinsic"]
+source = """
+fn main() -> i32 {
+    @unknown(42)
+}
+"""
+compile_fail = true
+
+[[case]]
+name = "unknown_intrinsic_annotated_let"
+spec = ["4.13:5"]
+error_contains = ["[E0700]", "unknown intrinsic"]
+source = """
+fn main() -> i32 {
+    let x: i32 = @unknown(42);
+    x
+}
+"""
+compile_fail = true
+
 # =============================================================================
 # Reserved-but-unspecified intrinsics: @panic / @assert / @cast (4.13:5b, RUE-319)
 #

--- a/crates/rue-spec/cases/items/borrow-accessors.toml
+++ b/crates/rue-spec/cases/items/borrow-accessors.toml
@@ -77,6 +77,79 @@ fn main() -> i32 {
 compile_fail = true
 error_contains = ["E0261", "directly or through other accessors"]
 
+# 6.6:14 is a legality rule on the declarations alone (RUE-1282): a cycle
+# whose every link is a `self`-receiver accessor call is rejected with no call
+# site anywhere in the program, exactly like the other accessor shape rules.
+[[case]]
+name = "uncalled_direct_accessor_recursion_is_rejected"
+spec = ["6.6:14"]
+description = "A directly self-recursive accessor is E0261 at its declaration, with no call site."
+preview = "borrow_accessors"
+preview_should_pass = true
+source = """
+struct P {
+    x: i64,
+
+    @allow(unused_function)
+    fn xr(borrow self) -> borrow i64 {
+        yield self.xr();
+    }
+}
+fn main() -> i32 { 0 }
+"""
+compile_fail = true
+error_contains = ["E0261", "an accessor may not invoke itself"]
+
+[[case]]
+name = "uncalled_indirect_accessor_recursion_is_rejected"
+spec = ["6.6:14"]
+description = "A mutual accessor cycle over `self`-receiver calls is E0261 at the declarations, with no call site."
+preview = "borrow_accessors"
+preview_should_pass = true
+source = """
+struct P {
+    x: i64,
+
+    @allow(unused_function)
+    fn a(borrow self) -> borrow i64 { yield self.b(); }
+    @allow(unused_function)
+    fn b(borrow self) -> borrow i64 { yield self.a(); }
+}
+fn main() -> i32 { 0 }
+"""
+compile_fail = true
+error_contains = ["E0261", "directly or through other accessors"]
+
+# The declaration seam sees only `self`-receiver links; a cycle routed through
+# a by-value guard's receiver is the demanded path's to reject, once a call
+# site demands analysis and expansion.
+[[case]]
+name = "guard_receiver_accessor_cycle_is_rejected"
+spec = ["6.6:14"]
+description = "An accessor cycle whose re-entrant link runs through a by-value guard receiver is still E0261 when demanded."
+preview = "borrow_accessors"
+preview_should_pass = true
+source = """
+struct P {
+    x: i64,
+
+    fn a(borrow self, other: P) -> borrow i64 {
+        let _ = other.b();
+        yield self.x;
+    }
+
+    fn b(borrow self) -> borrow i64 {
+        yield self.a(P { x: 3 });
+    }
+}
+fn main() -> i32 {
+    let p = P { x: 1 };
+    if p.a(P { x: 2 }) == 1 { 0 } else { 1 }
+}
+"""
+compile_fail = true
+error_contains = ["E0261"]
+
 [[case]]
 name = "projected_receiver_accessor_executes_in_place"
 spec = ["6.6:8"]

--- a/docs/spec/src/06-items/06-borrow-accessors.md
+++ b/docs/spec/src/06-items/06-borrow-accessors.md
@@ -122,4 +122,10 @@ Accessor expansion **MUST** be acyclic: an accessor body **MUST NOT** call an
 accessor whose expansion encloses it, whether directly (`fn xr(borrow self) ->
 borrow i64 { yield self.xr(); }`) or through a chain of other accessors
 (E0261). Because the call is the inlined body (6.6:12), a cycle has no finite
-expansion. The rejection names the recursive call.
+expansion — a property of the declarations alone, so a cycle whose every link
+is a call on the accessor's own `self` receiver is rejected at the
+declaration, whether or not anything calls an accessor in it, like the other
+legality rules of this chapter. A re-entrant call reached through any other
+receiver (a by-value guard of the owner's own type) is rejected when a call
+site demands the body's analysis and expansion. The rejection names the
+recursive accessor either way.


### PR DESCRIPTION
Two small audit-verified compiler fixes from the 2026-08-09 spec audit.

## RUE-1281: surface E0700 for unknown intrinsics in every position

Fixes RUE-1281.

In statement position an unknown intrinsic correctly reported E0700, but in any expected-type context — a function tail, an annotated `let` — inference's intrinsic catch-all typed the unknown call as `()`, so unification failed with E0206 "type mismatch: expected i32, found ()" and pointed the programmer at their return type instead of the bogus name.

The fix mirrors the existing `@cast` treatment in the same dispatch chain (RUE-319): unknown names get a fresh inference variable so unification succeeds and sema's E0700 fires with the intrinsic's name and span. The known unit-returning intrinsics that legitimately reach the catch-all (`@dbg`, `@drop`, `@test_preview_gate`) keep their explicit unit typing. Two spec cases pin the tail-position and annotated-`let` diagnostics.

## RUE-1282: enforce accessor acyclicity (E0261) at the declaration

Fixes RUE-1282, taking the "enforce at declaration" resolution.

6.6:14 was the one accessor legality rule of six enforced only when a call site demanded the body — the verbatim spec example compiled cleanly uncalled. A cycle has no finite expansion, which is a property of the declarations alone, so it now decides at the declaration seam like its five siblings:

- `rue_air::declaration_validation` (the RUE-1232 shared vocabulary) gains the `AccessorOwnerMethod` fact — a method's name, accessor-ness, and the method names its body calls on its own `self` receiver — plus the cycle decision and the shared E0261 wording/note.
- The parsed-module candidate extractor retains each method's `self`-call targets (position-free, normalized), the accessor signature terminal carries them in `owner_methods`, and the signature query rejects a cycle with no call site anywhere in the program. Editing a sibling's `self`-call set invalidates the terminal exactly as editing its `-> borrow` qualifier already did; an edit that leaves the set unchanged keeps the value equal.
- Batch sema predeclaration runs the same decision over the RIR, so both producers reject the same programs with the same diagnostic.

Only a cycle whose every link is a `self`-receiver call is decidable at the declaration (the owner's type cannot appear as a component of itself, so that is the only shape expressible without a by-value guard of the owner's own type). The guard-receiver shape stays with the demanded-path checks — the analysis-time identity check and the CFG dependency graph — which still fire; a spec case now covers that path end-to-end alongside the new uncalled direct and uncalled indirect cases, and 6.6:14's prose states the split.

## Testing

- `scripts/rue spec intrinsics` (146 passed) and `scripts/rue spec borrow` (110 passed) with the new cases
- `buck2 test //crates/rue-air:` (696 tests) including a new uncalled-cycle predeclaration test and the reworked marked-calls preservation test
- `buck2 test //:spec-traceability //crates/rue-compiler:` green
- `./clippy.sh` green
- Hand-verified on the built compiler: uncalled direct/indirect cycles now E0261 at declaration with the note; legal nested accessors and projected receivers unaffected; guard-receiver cycle still rejected when demanded

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DrKqpQgkHzDHGqpEMjxYdN

---
_Generated by [Claude Code](https://claude.ai/code/session_01DrKqpQgkHzDHGqpEMjxYdN)_