### PR TITLE
RUE-1285: bound segmented source lookup costs

### DIFF
--- a/crates/rue-compiler/src/import_discovery.rs
+++ b/crates/rue-compiler/src/import_discovery.rs
@@ -837,7 +837,8 @@ impl ImportDiscoveryPlan {
     ) -> CompileResult<(Self, u64)> {
         // Construct groups ONLY for the newly appended modules' occurrences; the
         // predecessor plan's groups are carried by reference through
-        // `SharedSegments::extend`, never copied or re-sorted.
+        // `SharedSegments::extend`; untouched tiers remain shared and tail-tier
+        // compaction preserves canonical order.
         let mut delta = Vec::new();
         let mut constructed = 0u64;
         for module_id in new_modules {
@@ -1443,8 +1444,8 @@ pub struct DiscoverySourceAssembler {
     canonical_identities: BTreeMap<Arc<str>, PhysicalFileIdentity>,
     accepted_reads: BTreeMap<ModuleId, AcceptedReadManifestEntry>,
     /// The last produced snapshot; the next [`Self::snapshot`] extends it with
-    /// only the modules added since, sharing every predecessor segment
-    /// (RUE-1112). Predecessor `FileId`s stay stable across extensions.
+    /// only the modules added since, using bounded shared size tiers (RUE-1112).
+    /// Predecessor `FileId`s stay stable across extensions.
     cached_snapshot: Option<SourceSnapshot>,
     /// Modules added since `cached_snapshot` was produced, in insertion order.
     appended_since_snapshot: Vec<ModuleId>,
@@ -1456,7 +1457,7 @@ pub struct DiscoverySourceAssembler {
     snapshot_sources_appended: u64,
     /// The last produced provenance manifest; the next
     /// [`Self::accepted_read_manifest`] extends it with only the entries added
-    /// since, sharing every predecessor segment (RUE-1112). Invalidated when a
+    /// since, using bounded shared size tiers (RUE-1112). Invalidated when a
     /// retained entry is rewritten (a canonical-path improvement), which falls
     /// back to a counted full rebuild.
     cached_manifest: Option<AcceptedReadManifest>,
@@ -1485,18 +1486,16 @@ struct AssembledSource {
 }
 
 /// The accepted-read provenance manifest as a persistent segmented sequence
-/// (RUE-1112): `Arc`-shared predecessor segments plus an appended delta, sorted
-/// by module identity within and across segments. A strictly-additive successor
-/// shares every predecessor segment by reference, so extending the manifest
-/// never copies or re-validates a predecessor entry; the merged contiguous
-/// slice materializes lazily, off the acquisition path. Equality and hashing
-/// are logical over the merged sequence.
+/// (RUE-1112): bounded size-tiered segments plus an exact appended delta, sorted
+/// by module identity. Untouched tiers and the lazily materialized contiguous
+/// slice are shared by clones. Equality and hashing are logical over the merged
+/// sequence.
 #[derive(Clone)]
 pub struct AcceptedReadManifest {
     entries: crate::shared_segments::SharedSegments<AcceptedReadManifestEntry>,
     /// Lazily materialized merged slice for consumers that need `Arc<[T]>`
     /// (the compiler-owned staging boundary and retained artifacts).
-    merged: std::sync::OnceLock<Arc<[AcceptedReadManifestEntry]>>,
+    merged: Arc<std::sync::OnceLock<Arc<[AcceptedReadManifestEntry]>>>,
 }
 
 fn accepted_read_order(
@@ -1541,7 +1540,7 @@ impl AcceptedReadManifest {
                 entries.into(),
                 accepted_read_order,
             ),
-            merged: std::sync::OnceLock::new(),
+            merged: Arc::new(std::sync::OnceLock::new()),
         }
     }
 
@@ -1554,7 +1553,7 @@ impl AcceptedReadManifest {
         let _ = merged.set(entries.clone());
         Self {
             entries: crate::shared_segments::SharedSegments::flat(entries, accepted_read_order),
-            merged,
+            merged: Arc::new(merged),
         }
     }
 
@@ -1567,7 +1566,7 @@ impl AcceptedReadManifest {
     ) -> Self {
         Self {
             entries: crate::shared_segments::SharedSegments::extend(&base.entries, appended),
-            merged: std::sync::OnceLock::new(),
+            merged: Arc::new(std::sync::OnceLock::new()),
         }
     }
 
@@ -1878,9 +1877,9 @@ impl DiscoverySourceAssembler {
 
     pub fn snapshot(&mut self) -> CompileResult<SourceSnapshot> {
         // Extension route: once a lineage's first snapshot exists, each
-        // successor snapshot appends only the modules added since, sharing every
-        // predecessor segment by reference — no predecessor source is copied,
-        // re-hashed, or re-validated, and predecessor FileIds stay stable.
+        // successor snapshot appends only the modules added since. Untouched
+        // tiers remain shared; compaction copies metadata but never re-hashes or
+        // copies source bytes, and predecessor FileIds stay stable.
         if let Some(cached) = self.cached_snapshot.clone() {
             if self.appended_since_snapshot.is_empty() {
                 return Ok(cached);
@@ -1984,9 +1983,9 @@ impl DiscoverySourceAssembler {
     }
 
     /// The accepted-read provenance manifest. Once a lineage's first manifest
-    /// exists, each successor manifest appends only the entries added since,
-    /// sharing every predecessor segment by reference — no predecessor entry is
-    /// copied, re-validated, or re-compared (RUE-1112).
+    /// exists, each successor manifest appends only the entries added since.
+    /// Untouched tiers remain shared and equal-magnitude tails compact without
+    /// re-validating entries (RUE-1112).
     pub fn accepted_read_manifest(&mut self) -> AcceptedReadManifest {
         if let Some(cached) = self.cached_manifest.clone() {
             if self.appended_since_manifest.is_empty() {

--- a/crates/rue-compiler/src/import_graph.rs
+++ b/crates/rue-compiler/src/import_graph.rs
@@ -53,9 +53,9 @@ impl ImportDirective {
 }
 
 /// Canonically ordered import sites from one lowered source snapshot, held as
-/// `Arc`-shared sorted segments: a strictly-additive successor program shares
-/// every predecessor segment by reference and appends only its new modules'
-/// sites (RUE-1112). Equality, hashing, and debug rendering are logical over
+/// bounded `Arc`-shared sorted tiers. A strictly-additive successor retains its
+/// exact new-module delta while compacting equal-magnitude tail tiers. Equality,
+/// hashing, and debug rendering are logical over
 /// the merged order; the contiguous slice materializes lazily, at most once
 /// per value, off the successor staging path.
 #[derive(Clone)]
@@ -182,9 +182,9 @@ fn record_order(a: &CanonicalImportRecord, b: &CanonicalImportRecord) -> std::cm
 /// Canonical resolved topology, independent of import-site occurrences.
 ///
 /// The record sequence is a [`SharedSegments`], so a strictly-additive
-/// trusted-toolchain successor (RUE-1112) reuses the predecessor's record `Arc`
-/// by reference and stores only its sorted delta — no predecessor record is
-/// copied, re-sorted, or reallocated when the successor graph is built.
+/// trusted-toolchain successor (RUE-1112) keeps an exact sorted delta and shares
+/// untouched size tiers. Equal-magnitude tail tiers compact to bound lookup and
+/// merge work.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct CanonicalImportGraph {
     root: ModuleId,

--- a/crates/rue-compiler/src/parsed_modules.rs
+++ b/crates/rue-compiler/src/parsed_modules.rs
@@ -991,9 +991,9 @@ impl ParsedModulesWork {
 }
 
 /// Deterministically ordered collection of independently parsed modules. The
-/// module table is held as `Arc`-shared sorted segments: a strictly-additive
-/// successor shares every predecessor segment by reference and appends only its
-/// newly parsed modules (RUE-1112). The whole-program merged views — the
+/// module table is held as bounded `Arc`-shared sorted tiers: a strictly-additive
+/// successor retains an exact delta while compacting equal-magnitude tail tiers.
+/// The whole-program merged views — the
 /// contiguous module slice and the merged import directives — are projections
 /// that materialize lazily, never on the successor staging path.
 #[derive(Debug, Clone)]

--- a/crates/rue-compiler/src/revisioned_query_database.rs
+++ b/crates/rue-compiler/src/revisioned_query_database.rs
@@ -19629,34 +19629,15 @@ impl RevisionedQueryDatabase {
         }
         .ok_or_else(|| import_input_error("import input revision is no longer retained"))?;
 
-        // Source additions come from STRUCTURAL AUTHORITY: when the successor
-        // snapshot's module segments share every parent segment by `Arc`
-        // identity, the shared segments ARE the parent view by construction —
-        // no predecessor comparison — and the appended segments are the exact
-        // source delta. A host handing a rebuilt (non-shared) snapshot instead
-        // falls back to the explicit byte-identical two-pointer diff, whose
-        // element comparisons are counted so the acquisition profile proves the
-        // structural path ran. The observation delta is likewise never
-        // re-derived: the persistent ledger's recorded head IS this step's
-        // delta.
+        // Source additions come from STRUCTURAL AUTHORITY: direct lineage
+        // pointer identity proves the parent and retains the exact newest delta
+        // even when the storage tiers compact. A rebuilt snapshot falls back to
+        // the explicit byte-identical two-pointer diff.
         let successor_segments = snapshot.source_revision().module_segments();
         let parent_segments = parent_view.sources.module_segments();
-        let structural_sources = {
-            let parent_count = parent_segments.segments().len();
-            let shared_prefix = successor_segments.segments().len() >= parent_count
-                && successor_segments
-                    .segments()
-                    .iter()
-                    .zip(parent_segments.segments().iter())
-                    .all(|(a, b)| Arc::ptr_eq(a, b));
-            shared_prefix.then(|| {
-                successor_segments.segments()[parent_count..]
-                    .iter()
-                    .flat_map(|segment| segment.iter())
-                    .cloned()
-                    .collect::<Vec<_>>()
-            })
-        };
+        let structural_sources = successor_segments
+            .direct_delta_from(parent_segments)
+            .map(<[crate::ModuleRevision]>::to_vec);
         let new_sources = match structural_sources {
             Some(appended) => appended,
             None => {
@@ -19672,30 +19653,11 @@ impl RevisionedQueryDatabase {
                 )?
             }
         };
-        // Accepted-read provenance additions come from the SAME structural
-        // authority: a successor manifest sharing every parent segment by `Arc`
-        // identity IS the parent manifest plus its appended segments, so the
-        // appended segments are the exact provenance delta with no predecessor
-        // comparison. A rebuilt (non-shared) manifest falls back to the counted
-        // byte-identical two-pointer diff.
-        let structural_reads = {
-            let parent_segments = parent_view.accepted_reads.segments();
-            let successor_segments = accepted_reads.segments();
-            let parent_count = parent_segments.segments().len();
-            let shared_prefix = successor_segments.segments().len() >= parent_count
-                && successor_segments
-                    .segments()
-                    .iter()
-                    .zip(parent_segments.segments().iter())
-                    .all(|(a, b)| Arc::ptr_eq(a, b));
-            shared_prefix.then(|| {
-                successor_segments.segments()[parent_count..]
-                    .iter()
-                    .flat_map(|segment| segment.iter())
-                    .cloned()
-                    .collect::<Vec<_>>()
-            })
-        };
+        // Accepted-read provenance uses the same direct-lineage proof.
+        let structural_reads = accepted_reads
+            .segments()
+            .direct_delta_from(parent_view.accepted_reads.segments())
+            .map(<[crate::AcceptedReadManifestEntry]>::to_vec);
         let new_reads = match structural_reads {
             Some(appended) => appended,
             None => {

--- a/crates/rue-compiler/src/session.rs
+++ b/crates/rue-compiler/src/session.rs
@@ -2691,9 +2691,9 @@ impl CompilerSession {
         let (reduced, validation) = match &narrow {
             Some((set, predecessor)) => {
                 // The reduction produced only the delta records; build the
-                // successor graph by structurally sharing the predecessor's record
-                // segment (no predecessor record is copied or re-sorted) and
-                // validate only the delta against the carried predecessor result.
+                // successor graph from the exact delta. Untouched size tiers stay
+                // shared; any tail compaction preserves canonical order. Validate
+                // only the delta against the carried predecessor result.
                 let new_records = reduced.records().to_vec();
                 let merged = crate::CanonicalImportGraph::from_additive_successor(
                     program.root().clone(),
@@ -3577,9 +3577,9 @@ impl CompilerSession {
     /// the committed predecessor for the first stage and the prior successor
     /// stage after a frontier batch), its presentation order, and the appended
     /// (module, file) pairs. The retained artifact must PROVE it is the
-    /// successor snapshot's structural ancestor — every one of its source
-    /// segments carried by `Arc` identity, same root, and its exact
-    /// presentation order — so a parse record from any other snapshot (an
+    /// successor snapshot's direct structural ancestor — proven by lineage
+    /// pointer identity, same root, and its exact presentation order — so a
+    /// parse record from any other snapshot (an
     /// intervening source or presentation update) can never be extended; the
     /// capability is rejected instead. Everything here is O(appended); content
     /// identity is pinned by the published revision, never re-hashed or
@@ -3623,24 +3623,17 @@ impl CompilerSession {
         };
         let predecessor_order = predecessor_order.clone();
         let predecessor_revision = record.runtime_revision;
-        // STRUCTURAL ANCESTRY: the successor snapshot must carry every source
-        // segment of the retained artifact's snapshot by `Arc` identity, with
-        // the same root. An artifact retained by an intervening update over a
-        // different or reordered snapshot cannot share this lineage and is
-        // rejected here rather than silently extended.
+        // STRUCTURAL ANCESTRY: the successor source revision must name the
+        // retained revision as its direct lineage parent (or be the same
+        // revision for an empty source delta), with the same root. This remains
+        // a constant-time pointer proof when storage tiers compact.
         let predecessor_snapshot = record.snapshot.clone();
         {
-            let successor_segments = snapshot.source_revision().module_segments().segments();
-            let predecessor_segments = predecessor_snapshot
+            let structural_delta = snapshot
                 .source_revision()
                 .module_segments()
-                .segments();
-            let shared_prefix = successor_segments.len() >= predecessor_segments.len()
-                && successor_segments
-                    .iter()
-                    .zip(predecessor_segments.iter())
-                    .all(|(a, b)| Arc::ptr_eq(a, b));
-            if !shared_prefix
+                .direct_delta_from(predecessor_snapshot.source_revision().module_segments());
+            if structural_delta.is_none()
                 || snapshot.source_revision().root()
                     != predecessor_snapshot.source_revision().root()
             {

--- a/crates/rue-compiler/src/shared_segments.rs
+++ b/crates/rue-compiler/src/shared_segments.rs
@@ -1,14 +1,12 @@
 //! Structurally shared, additively extended sorted sequences (RUE-1112).
 //!
 //! A [`SharedSegments`] holds a canonical sorted sequence as an ordered list of
-//! `Arc`-shared, mutually-disjoint sorted segments. A strictly-additive successor
-//! appends exactly one new segment and shares every predecessor segment by `Arc`
-//! clone — no predecessor element is copied, sorted, or reallocated, and a chain
-//! of successors accumulates one segment per acquisition round (bounded by the
-//! driver's round bound) rather than flattening. The merged flat slice is
-//! materialized at most once, lazily, and only when a consumer needs a contiguous
-//! `&[T]`; the acquisition path reads the newest delta segment directly and never
-//! triggers it.
+//! `Arc`-shared, mutually-disjoint sorted segments. Successors use size-tiered
+//! compaction: untouched tiers stay shared, while adjacent tiers of the same
+//! magnitude merge. Segment depth is therefore bounded by the number of bits in
+//! `usize`, and each element participates in at most logarithmically many merges.
+//! The exact newest delta and direct-parent lineage remain available to the
+//! acquisition path even when its storage tier was compacted.
 //!
 //! Equality and hashing are over the LOGICAL merged sequence, computed by a
 //! streaming k-way merge with no allocation of the merged buffer, so a flat value
@@ -19,6 +17,45 @@ use std::cmp::Ordering;
 use std::hash::{Hash, Hasher};
 use std::sync::{Arc, OnceLock};
 
+/// A size-tiered sequence has at most one segment at each possible `usize`
+/// magnitude, plus the possible empty flat base.
+pub(crate) const MAX_SIZE_TIERED_SEGMENTS: usize = usize::BITS as usize + 1;
+
+fn size_tier(len: usize) -> u32 {
+    if len == 0 {
+        0
+    } else {
+        usize::BITS - len.leading_zeros() - 1
+    }
+}
+
+/// Append one immutable segment and merge tail tiers until their size tiers are
+/// strictly descending from oldest to newest. The merge callback preserves the
+/// sequence-specific logical order.
+pub(crate) fn push_size_tiered_segment<T: ?Sized>(
+    segments: &mut Vec<Arc<T>>,
+    mut appended: Arc<T>,
+    len: impl Fn(&T) -> usize,
+    mut merge: impl FnMut(&T, &T) -> Arc<T>,
+) {
+    while let Some(previous) = segments.last() {
+        if size_tier(len(previous)) > size_tier(len(&appended)) {
+            break;
+        }
+        let previous = segments.pop().expect("the tail segment exists");
+        appended = merge(&previous, &appended);
+    }
+    segments.push(appended);
+    assert!(segments.len() <= MAX_SIZE_TIERED_SEGMENTS);
+}
+
+#[derive(Debug)]
+struct SegmentLineage<T> {
+    parent: Option<Arc<SegmentLineage<T>>>,
+    delta: Arc<[T]>,
+    root_segment: Arc<[T]>,
+}
+
 /// A canonical sorted sequence represented as an ordered list of `Arc`-shared,
 /// mutually-disjoint sorted segments. `cmp` is the canonical total order every
 /// segment is sorted by; the segments partition the logical sequence, so their
@@ -26,7 +63,8 @@ use std::sync::{Arc, OnceLock};
 pub(crate) struct SharedSegments<T> {
     segments: Arc<[Arc<[T]>]>,
     cmp: fn(&T, &T) -> Ordering,
-    merged: OnceLock<Arc<[T]>>,
+    merged: Arc<OnceLock<Arc<[T]>>>,
+    lineage: Arc<SegmentLineage<T>>,
 }
 
 impl<T> SharedSegments<T> {
@@ -34,34 +72,46 @@ impl<T> SharedSegments<T> {
     /// `cmp`, deduplicated).
     pub(crate) fn flat(items: Arc<[T]>, cmp: fn(&T, &T) -> Ordering) -> Self {
         Self {
-            segments: Arc::from([items]),
+            segments: Arc::from([Arc::clone(&items)]),
             cmp,
-            merged: OnceLock::new(),
+            merged: Arc::new(OnceLock::new()),
+            lineage: Arc::new(SegmentLineage {
+                parent: None,
+                delta: Arc::from([]),
+                root_segment: items,
+            }),
         }
     }
 
-    /// The first (oldest) segment: the original base carried through every
-    /// successor by reference. Two successors of the same base return
-    /// `Arc`-pointer-equal first segments, proving the base was never copied.
+    /// The original flat segment retained as a stable lineage witness. It is not
+    /// necessarily one of the current compacted storage tiers.
     pub(crate) fn predecessor_segment(&self) -> &Arc<[T]> {
-        &self.segments[0]
+        &self.lineage.root_segment
     }
 
-    /// The newest delta segment (empty for a flat value). Iterating this avoids
-    /// materializing the merged sequence on the acquisition path.
+    /// The exact newest logical delta (empty for a flat value), independent of
+    /// whether its physical storage tier was compacted.
     pub(crate) fn delta_segment(&self) -> &[T] {
-        if self.segments.len() > 1 {
-            &self.segments[self.segments.len() - 1]
-        } else {
-            &[]
-        }
+        &self.lineage.delta
     }
 
-    /// Every `Arc`-shared segment, oldest first. Two successors of a common
-    /// ancestor share every ancestor segment by pointer; consumers use this to
-    /// witness structural inheritance without walking predecessor entries.
+    /// Every bounded storage tier, oldest first.
     pub(crate) fn segments(&self) -> &[Arc<[T]>] {
         &self.segments
+    }
+
+    /// Return the exact appended values when `ancestor` is this value or its
+    /// direct structural parent. Pointer identity makes this a constant-time
+    /// ancestry proof even when size-tiered compaction replaced storage tiers.
+    pub(crate) fn direct_delta_from(&self, ancestor: &Self) -> Option<&[T]> {
+        if Arc::ptr_eq(&self.lineage, &ancestor.lineage) {
+            return Some(&[]);
+        }
+        self.lineage
+            .parent
+            .as_ref()
+            .is_some_and(|parent| Arc::ptr_eq(parent, &ancestor.lineage))
+            .then_some(self.lineage.delta.as_ref())
     }
 
     pub(crate) fn len(&self) -> usize {
@@ -103,20 +153,31 @@ impl<T> SharedSegments<T> {
 }
 
 impl<T: Clone> SharedSegments<T> {
-    /// Build a strictly-additive successor that carries every segment of `base`
-    /// by `Arc` clone and appends `delta` as one new segment. `delta` must be
-    /// disjoint from `base` and is sorted here (only `delta`, never `base`). No
-    /// base segment is copied or re-sorted, and the base is NOT flattened, so a
-    /// chain of successors stays O(round) segments.
+    /// Build a strictly-additive successor. `delta` must be disjoint from `base`
+    /// and is sorted here. Untouched size tiers remain shared; tail tiers merge
+    /// only when necessary to preserve the bounded-depth invariant.
     pub(crate) fn extend(base: &SharedSegments<T>, mut delta: Vec<T>) -> Self {
         delta.sort_by(base.cmp);
         delta.dedup_by(|a, b| (base.cmp)(a, b) == Ordering::Equal);
+        let delta: Arc<[T]> = delta.into();
         let mut segments: Vec<Arc<[T]>> = base.segments.to_vec();
-        segments.push(delta.into());
+        if !delta.is_empty() {
+            push_size_tiered_segment(
+                &mut segments,
+                Arc::clone(&delta),
+                <[T]>::len,
+                |left, right| merge_sorted(left, right, base.cmp),
+            );
+        }
         Self {
             segments: segments.into(),
             cmp: base.cmp,
-            merged: OnceLock::new(),
+            merged: Arc::new(OnceLock::new()),
+            lineage: Arc::new(SegmentLineage {
+                parent: Some(Arc::clone(&base.lineage)),
+                delta,
+                root_segment: Arc::clone(&base.lineage.root_segment),
+            }),
         }
     }
 
@@ -132,6 +193,23 @@ impl<T: Clone> SharedSegments<T> {
         self.merged
             .get_or_init(|| self.iter().cloned().collect::<Vec<_>>().into())
     }
+}
+
+fn merge_sorted<T: Clone>(left: &[T], right: &[T], cmp: fn(&T, &T) -> Ordering) -> Arc<[T]> {
+    let mut merged = Vec::with_capacity(left.len() + right.len());
+    let (mut left_index, mut right_index) = (0, 0);
+    while left_index < left.len() && right_index < right.len() {
+        if cmp(&right[right_index], &left[left_index]) == Ordering::Less {
+            merged.push(right[right_index].clone());
+            right_index += 1;
+        } else {
+            merged.push(left[left_index].clone());
+            left_index += 1;
+        }
+    }
+    merged.extend_from_slice(&left[left_index..]);
+    merged.extend_from_slice(&right[right_index..]);
+    merged.into()
 }
 
 /// Streaming k-way merge over the segments (each sorted, mutually disjoint).
@@ -179,12 +257,11 @@ impl<'a, T> ExactSizeIterator for MergeIter<'a, T> {}
 
 impl<T: Clone> Clone for SharedSegments<T> {
     fn clone(&self) -> Self {
-        // Share all segments by `Arc` clone; the materialized cache is not carried
-        // so a clone holds no predecessor-sized buffer.
         Self {
             segments: Arc::clone(&self.segments),
             cmp: self.cmp,
-            merged: OnceLock::new(),
+            merged: Arc::clone(&self.merged),
+            lineage: Arc::clone(&self.lineage),
         }
     }
 }
@@ -225,15 +302,13 @@ impl<T: std::fmt::Debug> std::fmt::Debug for SharedSegments<T> {
 }
 
 /// An append-only ORDERED sequence (no sort relation) represented as `Arc`-shared
-/// concatenated segments. A strictly-additive successor appends exactly one new
-/// segment and shares every predecessor segment by `Arc` clone; the logical
-/// sequence is the segments in order, back to back. Equality, hashing, and debug
+/// size-tiered concatenated segments. Untouched tiers stay shared and compacted
+/// tail tiers preserve concatenation order. Equality, hashing, and debug
 /// rendering are over the logical concatenation, so representation is invisible
-/// to memoization. The contiguous slice materializes lazily, at most once per
-/// value, and never on a path that only iterates.
+/// to memoization. Clones share the lazily materialized contiguous slice.
 pub(crate) struct SharedList<T> {
     segments: Arc<[Arc<[T]>]>,
-    merged: OnceLock<Arc<[T]>>,
+    merged: Arc<OnceLock<Arc<[T]>>>,
 }
 
 impl<T> SharedList<T> {
@@ -241,7 +316,7 @@ impl<T> SharedList<T> {
     pub(crate) fn flat(items: Arc<[T]>) -> Self {
         Self {
             segments: Arc::from([items]),
-            merged: OnceLock::new(),
+            merged: Arc::new(OnceLock::new()),
         }
     }
 
@@ -291,15 +366,23 @@ impl<'a, T> Iterator for ListIter<'a, T> {
 impl<'a, T> ExactSizeIterator for ListIter<'a, T> {}
 
 impl<T: Clone> SharedList<T> {
-    /// Build a strictly-additive successor that carries every segment of `base`
-    /// by `Arc` clone and appends `delta` in order as one new segment. No base
-    /// segment is copied and the base is never flattened.
+    /// Build a strictly-additive successor, compacting equal-magnitude tail
+    /// tiers while preserving concatenation order.
     pub(crate) fn extend(base: &SharedList<T>, delta: Vec<T>) -> Self {
         let mut segments: Vec<Arc<[T]>> = base.segments.to_vec();
-        segments.push(delta.into());
+        let delta: Arc<[T]> = delta.into();
+        if !delta.is_empty() {
+            push_size_tiered_segment(&mut segments, delta, <[T]>::len, |left, right| {
+                left.iter()
+                    .chain(right.iter())
+                    .cloned()
+                    .collect::<Vec<_>>()
+                    .into()
+            });
+        }
         Self {
             segments: segments.into(),
-            merged: OnceLock::new(),
+            merged: Arc::new(OnceLock::new()),
         }
     }
 
@@ -320,11 +403,9 @@ impl<T: Clone> SharedList<T> {
 
 impl<T: Clone> Clone for SharedList<T> {
     fn clone(&self) -> Self {
-        // Share all segments by `Arc` clone; the materialized cache is not
-        // carried so a clone holds no predecessor-sized buffer.
         Self {
             segments: Arc::clone(&self.segments),
-            merged: OnceLock::new(),
+            merged: Arc::clone(&self.merged),
         }
     }
 }
@@ -399,20 +480,19 @@ mod tests {
     }
 
     #[test]
-    fn chained_successors_stay_multi_segment_and_share_every_ancestor() {
+    fn chained_successors_compact_tail_tiers_and_preserve_direct_lineage() {
         let base = SharedSegments::flat(Arc::from([10, 20, 30]), cmp);
         let first = SharedSegments::extend(&base, vec![15, 25]);
         let second = SharedSegments::extend(&first, vec![5, 35]);
 
-        // The second successor is three segments (no flattening of `first`).
-        assert_eq!(second.segments().len(), 3);
-        // Every ancestor segment is shared by pointer with `first`.
+        // The first extension merges equal-magnitude tiers. The next smaller
+        // delta stays separate and shares the untouched compacted tier.
+        assert_eq!(first.segments().len(), 1);
+        assert_eq!(second.segments().len(), 2);
         assert!(Arc::ptr_eq(&second.segments()[0], &first.segments()[0]));
-        assert!(Arc::ptr_eq(&second.segments()[1], &first.segments()[1]));
-        assert!(Arc::ptr_eq(
-            second.predecessor_segment(),
-            base.predecessor_segment()
-        ));
+        assert_eq!(second.direct_delta_from(&first), Some(&[5, 35][..]));
+        assert!(first.direct_delta_from(&base).is_some());
+        assert!(second.direct_delta_from(&base).is_none());
 
         // Logical content and equivalence with a flat value are preserved.
         assert_eq!(
@@ -436,20 +516,21 @@ mod tests {
     }
 
     #[test]
-    fn shared_list_extends_in_order_sharing_ancestors() {
+    fn shared_list_extends_in_order_with_size_tiered_compaction() {
         let base = SharedList::flat(Arc::from([30, 10, 20]));
         let first = SharedList::extend(&base, vec![5, 25]);
         let second = SharedList::extend(&first, vec![15]);
 
-        // Order is concatenation order, never sorted; ancestors are shared by
-        // pointer and never flattened.
+        // Order is concatenation order, never sorted. The equal-magnitude first
+        // extension compacts, then the smaller tail remains separate.
         assert_eq!(
             second.iter().copied().collect::<Vec<_>>(),
             vec![30, 10, 20, 5, 25, 15]
         );
         assert_eq!(second.len(), 6);
+        assert_eq!(first.segments.len(), 1);
+        assert_eq!(second.segments.len(), 2);
         assert!(Arc::ptr_eq(&second.segments[0], &first.segments[0]));
-        assert!(Arc::ptr_eq(&second.segments[1], &first.segments[1]));
 
         // Logical equality/hash match a flat value with identical content.
         let flat = SharedList::flat(Arc::from([30, 10, 20, 5, 25, 15]));
@@ -461,6 +542,25 @@ mod tests {
         let items: Arc<[i32]> = Arc::from([1, 2]);
         let single = SharedList::flat(Arc::clone(&items));
         assert!(std::ptr::eq(single.as_arc().as_ptr(), items.as_ptr()));
+    }
+
+    #[test]
+    fn one_item_rounds_keep_depth_logarithmic_and_share_materialization() {
+        let mut value = SharedSegments::flat(Arc::from([0]), cmp);
+        let mut max_depth = value.segments().len();
+        for item in 1..=4096 {
+            let successor = SharedSegments::extend(&value, vec![item]);
+            assert_eq!(successor.direct_delta_from(&value), Some(&[item][..]));
+            max_depth = max_depth.max(successor.segments().len());
+            assert!(successor.segments().len() <= MAX_SIZE_TIERED_SEGMENTS);
+            value = successor;
+        }
+
+        assert!(max_depth <= 13, "4097 entries need at most 13 size tiers");
+        assert_eq!(value.len(), 4097);
+        let clone = value.clone();
+        let materialized = value.as_slice().as_ptr();
+        assert_eq!(clone.as_slice().as_ptr(), materialized);
     }
 
     fn hash_of_list(value: &SharedList<i32>) -> u64 {

--- a/crates/rue-compiler/src/source_identity.rs
+++ b/crates/rue-compiler/src/source_identity.rs
@@ -117,10 +117,54 @@ impl From<&SourceId> for SourceBucketKey {
 /// remain distinct entries.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SourceStore {
-    /// `Arc`-shared bucket segments, oldest first; a strictly-additive
-    /// successor appends one segment and shares the rest (RUE-1112).
-    buckets: Vec<Arc<BTreeMap<SourceBucketKey, Arc<[SourceId]>>>>,
+    /// `Arc`-shared size-tiered bucket segments, oldest first.
+    buckets: Vec<Arc<SourceStoreSegment>>,
     len: usize,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+struct SourceStoreSegment {
+    buckets: BTreeMap<SourceBucketKey, Arc<[SourceId]>>,
+    len: usize,
+}
+
+impl SourceStoreSegment {
+    fn from_sources(sources: Vec<SourceId>) -> Self {
+        let len = sources.len();
+        let mut buckets = BTreeMap::<_, Vec<_>>::new();
+        for source in sources {
+            buckets
+                .entry(SourceBucketKey::from(&source))
+                .or_default()
+                .push(source);
+        }
+        Self {
+            buckets: buckets
+                .into_iter()
+                .map(|(key, bucket)| (key, bucket.into()))
+                .collect(),
+            len,
+        }
+    }
+
+    fn merge(left: &Self, right: &Self) -> Self {
+        let mut buckets = left.buckets.clone();
+        for (key, right_bucket) in &right.buckets {
+            let bucket = buckets.entry(*key).or_default();
+            let mut merged = bucket
+                .iter()
+                .chain(right_bucket.iter())
+                .cloned()
+                .collect::<Vec<_>>();
+            merged.sort();
+            merged.dedup();
+            *bucket = merged.into();
+        }
+        Self {
+            buckets,
+            len: left.len + right.len,
+        }
+    }
 }
 
 impl SourceStore {
@@ -145,28 +189,15 @@ impl SourceStore {
         sources.sort();
         sources.dedup();
         let len = sources.len();
-        let mut buckets = BTreeMap::<_, Vec<_>>::new();
-        for source in sources {
-            buckets
-                .entry(SourceBucketKey::from(&source))
-                .or_default()
-                .push(source);
-        }
         Self {
-            buckets: vec![Arc::new(
-                buckets
-                    .into_iter()
-                    .map(|(key, bucket)| (key, bucket.into()))
-                    .collect(),
-            )],
+            buckets: vec![Arc::new(SourceStoreSegment::from_sources(sources))],
             len,
         }
     }
 
-    /// Build a strictly-additive successor store that shares every bucket
-    /// segment of `base` by reference and appends one segment holding only the
-    /// genuinely new identities (RUE-1112). No base identity is copied or
-    /// re-bucketed.
+    /// Build a strictly-additive successor store holding only genuinely new
+    /// identities. Untouched bucket tiers remain shared; equal-magnitude tail
+    /// tiers are re-bucketed to keep lookup depth bounded.
     pub(crate) fn extend_with_ids(
         base: &SourceStore,
         appended: impl IntoIterator<Item = SourceId>,
@@ -181,20 +212,13 @@ impl SourceStore {
             return base.clone();
         }
         let len = base.len + appended.len();
-        let mut new_bucket = BTreeMap::<_, Vec<_>>::new();
-        for source in appended {
-            new_bucket
-                .entry(SourceBucketKey::from(&source))
-                .or_default()
-                .push(source);
-        }
         let mut buckets = base.buckets.clone();
-        buckets.push(Arc::new(
-            new_bucket
-                .into_iter()
-                .map(|(key, bucket)| (key, bucket.into()))
-                .collect(),
-        ));
+        crate::shared_segments::push_size_tiered_segment(
+            &mut buckets,
+            Arc::new(SourceStoreSegment::from_sources(appended)),
+            |segment| segment.len,
+            |left, right| Arc::new(SourceStoreSegment::merge(left, right)),
+        );
         Self { buckets, len }
     }
 
@@ -208,11 +232,16 @@ impl SourceStore {
         self.len == 0
     }
 
+    #[cfg(test)]
+    pub(crate) fn segment_depth(&self) -> usize {
+        self.buckets.len()
+    }
+
     /// Return this store's canonical exact identity for `source`.
     pub fn get(&self, source: &SourceId) -> Option<&SourceId> {
         let key = SourceBucketKey::from(source);
         self.buckets.iter().find_map(|segment| {
-            let bucket = segment.get(&key)?;
+            let bucket = segment.buckets.get(&key)?;
             bucket
                 .binary_search(source)
                 .ok()
@@ -230,7 +259,7 @@ impl SourceStore {
     pub fn iter(&self) -> impl Iterator<Item = &SourceId> + '_ {
         self.buckets
             .iter()
-            .flat_map(|segment| segment.values().flat_map(|bucket| bucket.iter()))
+            .flat_map(|segment| segment.buckets.values().flat_map(|bucket| bucket.iter()))
     }
 }
 
@@ -414,10 +443,9 @@ impl SourceRevision {
         })
     }
 
-    /// Build a strictly-additive successor mapping that shares `base`'s module
-    /// segments by reference and appends only `appended` (RUE-1112). Validates
-    /// the appended entries alone: they must be new module identities. No base
-    /// entry is copied, re-sorted, or re-validated.
+    /// Build a strictly-additive successor mapping from an exact appended delta.
+    /// Validates only the appended entries; untouched size tiers remain shared
+    /// and equal-magnitude tails compact in canonical order.
     pub(crate) fn extend_with_appended(
         base: &SourceRevision,
         appended: Vec<ModuleRevision>,

--- a/crates/rue-compiler/src/source_metadata.rs
+++ b/crates/rue-compiler/src/source_metadata.rs
@@ -19,19 +19,16 @@ use crate::SourceView;
 /// Immutable, validated identities for every source in a compilation.
 ///
 /// The descriptor is a persistent structure (RUE-1112): it holds one or more
-/// `Arc`-shared segments, each owning its path maps and ascending `FileId`
-/// index. A strictly-additive successor appends one validated segment and
-/// shares every predecessor segment by reference, so extending the descriptor
-/// never copies, re-normalizes, or re-validates a predecessor entry; the merged
-/// ascending id index is materialized lazily, off the extension path. Callers
-/// retain constant-time lookup while deterministic iterators never depend on
-/// `HashMap` iteration order.
+/// `Arc`-shared size tiers, each owning its path maps and ascending `FileId`
+/// index. Strictly-additive successors compact equal-magnitude tail tiers, so
+/// lookup depth is bounded while untouched tiers remain shared. The merged
+/// ascending id index is materialized lazily and shared by clones.
 #[derive(Debug)]
 pub struct SourceMetadata {
     root_file_id: FileId,
     segments: Vec<std::sync::Arc<MetadataSegment>>,
     len: usize,
-    merged_ids: std::sync::OnceLock<Vec<FileId>>,
+    merged_ids: std::sync::Arc<std::sync::OnceLock<std::sync::Arc<[FileId]>>>,
 }
 
 /// One validated, immutable slice of the descriptor. Segment ids are ascending
@@ -55,7 +52,7 @@ impl Clone for SourceMetadata {
             root_file_id: self.root_file_id,
             segments: self.segments.clone(),
             len: self.len,
-            merged_ids: std::sync::OnceLock::new(),
+            merged_ids: std::sync::Arc::clone(&self.merged_ids),
         }
     }
 }
@@ -132,7 +129,7 @@ impl SourceMetadata {
             root_file_id,
             segments: vec![std::sync::Arc::new(segment)],
             len,
-            merged_ids: std::sync::OnceLock::new(),
+            merged_ids: std::sync::Arc::new(std::sync::OnceLock::new()),
         })
     }
 
@@ -162,16 +159,16 @@ impl SourceMetadata {
             root_file_id,
             segments: vec![std::sync::Arc::new(segment)],
             len,
-            merged_ids: std::sync::OnceLock::new(),
+            merged_ids: std::sync::Arc::new(std::sync::OnceLock::new()),
         })
     }
 
-    /// Build a strictly-additive successor descriptor that shares every segment
-    /// of `self` by reference and appends one validated segment (RUE-1112).
+    /// Build a strictly-additive successor descriptor with bounded size-tiered
+    /// segments.
     ///
     /// Only the appended entries are normalized and validated — nonempty
     /// identities, normalized-collision checks within the appended set and
-    /// against the shared base's retained normalized identities, id
+    /// against the base's retained normalized identities, id
     /// disjointness, and the trusted-namespace invariant — exactly the
     /// invariants full construction enforces, applied incrementally. Appended
     /// ids must be strictly greater than every existing id so chained segments
@@ -207,12 +204,17 @@ impl SourceMetadata {
         )?;
         let len = self.len + segment.sorted_ids.len();
         let mut segments = self.segments.clone();
-        segments.push(std::sync::Arc::new(segment));
+        crate::shared_segments::push_size_tiered_segment(
+            &mut segments,
+            std::sync::Arc::new(segment),
+            |segment| segment.sorted_ids.len(),
+            |left, right| std::sync::Arc::new(MetadataSegment::merge(left, right)),
+        );
         Ok(Self {
             root_file_id: self.root_file_id,
             segments,
             len,
-            merged_ids: std::sync::OnceLock::new(),
+            merged_ids: std::sync::Arc::new(std::sync::OnceLock::new()),
         })
     }
 
@@ -222,25 +224,40 @@ impl SourceMetadata {
         if self.segments.len() == 1 {
             return &self.segments[0].sorted_ids;
         }
-        self.merged_ids.get_or_init(|| {
-            self.segments
-                .iter()
-                .flat_map(|segment| segment.sorted_ids.iter().copied())
-                .collect()
-        })
+        self.merged_ids
+            .get_or_init(|| {
+                self.segments
+                    .iter()
+                    .flat_map(|segment| segment.sorted_ids.iter().copied())
+                    .collect::<Vec<_>>()
+                    .into()
+            })
+            .as_ref()
     }
 
     fn segment_for(&self, file_id: FileId) -> Option<&MetadataSegment> {
-        self.segments
-            .iter()
-            .map(std::sync::Arc::as_ref)
-            .find(|segment| segment.physical_paths.contains_key(&file_id))
+        let position = self.segments.partition_point(|segment| {
+            segment
+                .sorted_ids
+                .last()
+                .is_some_and(|last| last.index() < file_id.index())
+        });
+        let segment = self.segments.get(position)?;
+        segment
+            .sorted_ids
+            .binary_search_by_key(&file_id.index(), |candidate| candidate.index())
+            .is_ok()
+            .then_some(segment)
     }
 
     pub(crate) fn is_trusted_standard_library_file(&self, file_id: FileId) -> bool {
-        self.segments
-            .iter()
-            .any(|segment| segment.trusted_standard_library_files.contains(&file_id))
+        self.segment_for(file_id)
+            .is_some_and(|segment| segment.trusted_standard_library_files.contains(&file_id))
+    }
+
+    #[cfg(test)]
+    pub(crate) fn segment_depth(&self) -> usize {
+        self.segments.len()
     }
 
     #[cfg(test)]
@@ -466,6 +483,39 @@ impl SourceMetadata {
 }
 
 impl MetadataSegment {
+    fn merge(left: &Self, right: &Self) -> Self {
+        assert!(
+            left.sorted_ids
+                .last()
+                .zip(right.sorted_ids.first())
+                .is_some_and(|(left, right)| left.index() < right.index()),
+            "metadata tiers retain ascending disjoint file-id ranges"
+        );
+        let mut sorted_ids = Vec::with_capacity(left.sorted_ids.len() + right.sorted_ids.len());
+        sorted_ids.extend_from_slice(&left.sorted_ids);
+        sorted_ids.extend_from_slice(&right.sorted_ids);
+
+        let mut physical_paths = left.physical_paths.clone();
+        physical_paths.extend(right.physical_paths.clone());
+        let mut logical_paths = left.logical_paths.clone();
+        logical_paths.extend(right.logical_paths.clone());
+        let mut trusted_standard_library_files = left.trusted_standard_library_files.clone();
+        trusted_standard_library_files.extend(right.trusted_standard_library_files.iter().copied());
+        let mut normalized_physical = left.normalized_physical.clone();
+        normalized_physical.extend(right.normalized_physical.iter().cloned());
+        let mut normalized_logical = left.normalized_logical.clone();
+        normalized_logical.extend(right.normalized_logical.iter().cloned());
+
+        Self {
+            sorted_ids,
+            physical_paths,
+            logical_paths,
+            trusted_standard_library_files,
+            normalized_physical,
+            normalized_logical,
+        }
+    }
+
     /// Validate one segment's complete path maps: exactly the invariants full
     /// construction has always enforced (key agreement, nonempty normalized
     /// identities, normalized-collision freedom, trusted-namespace membership),

--- a/crates/rue-compiler/src/source_snapshot.rs
+++ b/crates/rue-compiler/src/source_snapshot.rs
@@ -31,10 +31,9 @@ pub struct SourceSnapshot {
 #[derive(Debug)]
 struct SourceSnapshotData {
     metadata: SourceMetadata,
-    /// `Arc`-shared record segments, oldest first (RUE-1112): a strictly
-    /// additive successor appends one segment and shares the rest, so extending
-    /// a snapshot never copies, re-hashes, or re-validates a predecessor
-    /// record.
+    /// `Arc`-shared size-tiered record segments, oldest first. Untouched tiers
+    /// stay shared; compacted tail tiers copy only record metadata and retain
+    /// the same source-text and identity `Arc`s.
     segments: Vec<Arc<SnapshotSegment>>,
     /// Global start index of each segment, aligned with `segments`.
     segment_offsets: Vec<usize>,
@@ -48,20 +47,48 @@ struct SnapshotSegment {
     contents: Vec<SourceRecord>,
     /// Position within THIS segment for each of its file ids.
     index: HashMap<FileId, usize>,
+    min_file_index: u32,
+    max_file_index: u32,
 }
 
 impl SnapshotSegment {
     fn from_records(contents: Vec<SourceRecord>) -> Self {
+        let min_file_index = contents
+            .iter()
+            .map(|record| record.file_id.index())
+            .min()
+            .expect("snapshot segments are nonempty");
+        let max_file_index = contents
+            .iter()
+            .map(|record| record.file_id.index())
+            .max()
+            .expect("snapshot segments are nonempty");
         let index = contents
             .iter()
             .enumerate()
             .map(|(index, record)| (record.file_id, index))
             .collect();
-        Self { contents, index }
+        Self {
+            contents,
+            index,
+            min_file_index,
+            max_file_index,
+        }
+    }
+
+    fn merge(left: &Self, right: &Self) -> Self {
+        assert!(left.max_file_index < right.min_file_index);
+        Self::from_records(
+            left.contents
+                .iter()
+                .chain(right.contents.iter())
+                .cloned()
+                .collect(),
+        )
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 struct SourceRecord {
     file_id: FileId,
     module_id: ModuleId,
@@ -156,18 +183,13 @@ impl SourceSnapshot {
                 })
             })
             .collect::<CompileResult<_>>()?;
-        let index = contents
-            .iter()
-            .enumerate()
-            .map(|(index, record)| (record.file_id, index))
-            .collect();
         let revision = program.source_revision().clone();
 
         Ok(Self {
             data: Arc::new(SourceSnapshotData {
                 metadata,
                 len: contents.len(),
-                segments: vec![Arc::new(SnapshotSegment { contents, index })],
+                segments: vec![Arc::new(SnapshotSegment::from_records(contents))],
                 segment_offsets: vec![0],
                 revision,
                 source_store,
@@ -271,11 +293,6 @@ impl SourceSnapshot {
                 }
             })
             .collect();
-        let index = contents
-            .iter()
-            .enumerate()
-            .map(|(index, record)| (record.file_id, index))
-            .collect();
         let root_module = metadata.root_module_id();
         let revision = SourceRevision::new(
             root_module,
@@ -292,7 +309,7 @@ impl SourceSnapshot {
             data: Arc::new(SourceSnapshotData {
                 metadata,
                 len: contents.len(),
-                segments: vec![Arc::new(SnapshotSegment { contents, index })],
+                segments: vec![Arc::new(SnapshotSegment::from_records(contents))],
                 segment_offsets: vec![0],
                 revision,
                 source_store,
@@ -393,24 +410,26 @@ impl SourceSnapshot {
     }
 
     fn record(&self, file_id: FileId) -> Option<&SourceRecord> {
-        let record = self.data.segments.iter().find_map(|segment| {
-            segment
-                .index
-                .get(&file_id)
-                .map(|&position| &segment.contents[position])
-        })?;
+        let segment_position = self
+            .data
+            .segments
+            .partition_point(|segment| segment.max_file_index < file_id.index());
+        let segment = self.data.segments.get(segment_position)?;
+        if file_id.index() < segment.min_file_index {
+            return None;
+        }
+        let position = *segment.index.get(&file_id)?;
+        let record = &segment.contents[position];
         debug_assert_eq!(record.file_id, file_id);
         Some(record)
     }
 
     fn record_at(&self, index: usize) -> &SourceRecord {
-        // Few segments (one per acquisition step, compacted publication-side),
-        // so a linear offset walk stays cheap.
         let segment_position = self
             .data
             .segment_offsets
-            .iter()
-            .rposition(|&start| start <= index)
+            .partition_point(|&start| start <= index)
+            .checked_sub(1)
             .expect("segment offsets begin at zero");
         let segment = &self.data.segments[segment_position];
         &segment.contents[index - self.data.segment_offsets[segment_position]]
@@ -427,11 +446,9 @@ impl SourceSnapshot {
         SourceView::new(path, record.text.as_str(), file_id)
     }
 
-    /// Build a strictly-additive successor snapshot that shares every record
-    /// segment, metadata segment, store bucket segment, and module-revision
-    /// segment of `base` by reference, appending one validated segment holding
-    /// only `appended` (RUE-1112). Only the appended sources are hashed and
-    /// validated; no predecessor record is copied, re-hashed, or re-validated.
+    /// Build a strictly-additive successor snapshot using bounded size-tiered
+    /// indexes. Only appended sources are hashed and validated; occasional tier
+    /// merges copy record/path metadata but never source bytes or identities.
     /// Appended file ids are assigned after the base's, so predecessor ids stay
     /// stable across the extension.
     pub(crate) fn extend_with_appended(
@@ -505,11 +522,24 @@ impl SourceSnapshot {
                 })
                 .collect(),
         )?;
+        let appended_len = records.len();
         let mut segments = base.data.segments.clone();
-        let mut segment_offsets = base.data.segment_offsets.clone();
-        segment_offsets.push(base.data.len);
-        let len = base.data.len + records.len();
-        segments.push(Arc::new(SnapshotSegment::from_records(records)));
+        crate::shared_segments::push_size_tiered_segment(
+            &mut segments,
+            Arc::new(SnapshotSegment::from_records(records)),
+            |segment| segment.contents.len(),
+            |left, right| Arc::new(SnapshotSegment::merge(left, right)),
+        );
+        let mut next_offset = 0;
+        let segment_offsets = segments
+            .iter()
+            .map(|segment| {
+                let offset = next_offset;
+                next_offset += segment.contents.len();
+                offset
+            })
+            .collect();
+        let len = base.data.len + appended_len;
         Ok(SourceSnapshot {
             data: Arc::new(SourceSnapshotData {
                 metadata,
@@ -774,6 +804,63 @@ mod tests {
     fn source_snapshots_are_send_and_sync() {
         fn assert_send_sync<T: Send + Sync>() {}
         assert_send_sync::<SourceSnapshot>();
+    }
+
+    #[test]
+    fn one_import_per_round_keeps_all_source_indexes_logarithmic() {
+        const DEPTH: u32 = 1024;
+        let mut snapshot = SourceSnapshot::single(
+            "/project/main.rue",
+            "const next = @import(\"module_1\"); fn main() {}",
+        )
+        .unwrap();
+
+        for index in 1..=DEPTH {
+            let text = if index == DEPTH {
+                "pub fn leaf() -> i32 { 42 }".to_owned()
+            } else {
+                format!("const next = @import(\"module_{}\");", index + 1)
+            };
+            let file_id = FileId::new(index);
+            snapshot = SourceSnapshot::extend_with_appended(
+                &snapshot,
+                vec![AppendedSource {
+                    file_id,
+                    physical_path: format!("/project/module_{index}.rue"),
+                    logical_path: format!("module_{index}.rue"),
+                    trusted_standard_library: false,
+                    text: Arc::new(text.clone()),
+                }],
+            )
+            .unwrap();
+            assert_eq!(snapshot.source_text(file_id), Some(text.as_str()));
+        }
+
+        let depths = [
+            snapshot.data.segments.len(),
+            snapshot.data.metadata.segment_depth(),
+            snapshot.data.source_store.segment_depth(),
+            snapshot
+                .source_revision()
+                .module_segments()
+                .segments()
+                .len(),
+        ];
+        assert!(depths.into_iter().all(|depth| depth <= 12), "{depths:?}");
+        assert!(
+            depths
+                .into_iter()
+                .all(|depth| depth <= crate::shared_segments::MAX_SIZE_TIERED_SEGMENTS)
+        );
+        assert_eq!(snapshot.files().count(), DEPTH as usize + 1);
+        assert_eq!(
+            snapshot
+                .files()
+                .next_back()
+                .expect("the deepest module is present")
+                .file_id,
+            FileId::new(DEPTH)
+        );
     }
 
     #[test]

--- a/crates/rue-compiler/src/unstable.rs
+++ b/crates/rue-compiler/src/unstable.rs
@@ -322,12 +322,10 @@ pub fn frontend_query_invalidations(session: &crate::CompilerSession) -> u64 {
     session.frontend_query_invalidations()
 }
 
-/// Structural-sharing witnesses for the committed import discovery's three
-/// additively shared artifacts (RUE-1112): `[graph_records, plan_groups,
-/// resolution_modules]`, each `(predecessor_segment_address, delta_len)`. A
-/// trusted-toolchain successor shares each predecessor segment `Arc` by
-/// reference, so every address is identical to the predecessor close's — proving
-/// no predecessor entry was copied when the successor artifacts were built.
+/// Storage-tier witnesses for the committed import discovery's three additive
+/// artifacts (RUE-1112): `[graph_records, plan_groups, resolution_modules]`,
+/// each `(lineage_root_segment_address, exact_delta_len)`. The address is a
+/// stable ancestry witness even when size-tiered storage compacts.
 pub fn committed_successor_sharing(
     session: &crate::CompilerSession,
 ) -> Option<[(usize, usize); 3]> {

--- a/crates/rue/src/source_loader.rs
+++ b/crates/rue/src/source_loader.rs
@@ -3014,14 +3014,10 @@ mod tests {
         assert_eq!(project_read_count(&small.read_manifest), 1);
         assert_eq!(project_read_count(&big.read_manifest), 4);
 
-        // STRUCTURAL SHARING: the committed successor carries the predecessor
-        // close's segment `Arc` by reference for ALL THREE additive artifacts —
-        // canonical graph records, plan request groups, and the module-resolution
-        // table. Each artifact's shared predecessor-segment address is
-        // byte-identical to the predecessor close's flat address (so no predecessor
-        // entry was copied, re-sorted, or reallocated), and each delta size is
-        // non-vacuous and identical across the two sharply different predecessor
-        // topologies (allocation independent of predecessor size).
+        // STRUCTURAL LINEAGE: the committed successor retains the predecessor
+        // close's root segment `Arc` as a stable witness for all three additive
+        // artifacts, even if bounded size-tiered storage compacted. Each exact
+        // delta is non-vacuous and independent of predecessor topology.
         let artifacts = ["graph records", "plan groups", "resolution modules"];
         for acq in [&small_acq, &big_acq] {
             let before = acq
@@ -3036,7 +3032,7 @@ mod tests {
                 assert_eq!(before_delta, 0, "the initial close is flat for {name}");
                 assert_eq!(
                     before_ptr, after_ptr,
-                    "the successor must share the predecessor {name} Arc by reference (no copy)"
+                    "the successor must retain the predecessor {name} lineage witness"
                 );
                 assert!(after_delta > 0, "the successor delta must carry new {name}");
             }


### PR DESCRIPTION
Fixes RUE-1285.

## Summary
- compact persistent source indexes into bounded size tiers
- preserve exact direct-parent deltas and stable lineage witnesses through compaction
- use bounded/binary-search lookups and clone-shared lazy materializations
- add a 1,024-module one-import-per-round regression covering all source indexes

## Validation
- `scripts/rue quick`
- focused compiler source, metadata, store, import, and successor tests
- `scripts/rue premerge` (81 targets passed; only the unrelated `shell-pipefail-pipeline-tool-tests` failure tracked by RUE-1248 remains)
