### PR TITLE
Narrow linux-premerge within its own build scope, not to the raw closure

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -235,17 +235,32 @@ jobs:
       # every crate. An unimpacted crate cannot have been broken by this diff,
       # and building its test binaries is the cost this narrowing exists to
       # avoid — measured at 286-317s whenever a compiler crate changes.
+      #
+      # The narrowed list is filtered back to this step's own `//crates/...`
+      # scope by `build-scope`. Handing `buck2 build` the determinator's raw
+      # closure also built the root-level `cached_corpus_suite` actions, and
+      # building one of those RUNS its corpus — so this step re-ran the CLI,
+      # spec, and oracle corpora that the platform-corpus lanes already own,
+      # serially, and premerge went from ~12m to 32-42m. See build_scope().
       - name: Build all targets
         env:
           NARROW_COUNT: ${{ steps.narrow.outputs.count }}
           NARROW_FILE: ${{ steps.narrow.outputs.file }}
         run: |
           set -euo pipefail
-          if [ "$NARROW_COUNT" -gt 0 ]; then
-            mapfile -t targets <"$NARROW_FILE"
+          if [ "$NARROW_COUNT" -le 0 ]; then
+            scripts/ci-timed "linux-x64 build" -- ./buck2 build //crates/...
+          elif ! scope="$(scripts/affected-targets build-scope "$NARROW_FILE")"; then
+            # Fail open: an unreadable list costs wall time, never coverage.
+            echo "narrowed build scope unavailable; building the full crate pattern" >&2
+            scripts/ci-timed "linux-x64 build" -- ./buck2 build //crates/...
+          elif [ -n "$scope" ]; then
+            mapfile -t targets <<<"$scope"
             scripts/ci-timed "linux-x64 build (narrowed)" -- ./buck2 build "${targets[@]}"
           else
-            scripts/ci-timed "linux-x64 build" -- ./buck2 build //crates/...
+            # Legitimate: a diff can impact corpus data without impacting any
+            # crate. Say so rather than leaving a silent no-op to be inferred.
+            echo "no impacted //crates/... targets; this step has nothing to build"
           fi
 
       - name: Run complete target-independent premerge suite

--- a/scripts/affected-targets
+++ b/scripts/affected-targets
@@ -39,6 +39,8 @@
 #   is-selectable-lane Exit 0 only for a gated workflow lane (RUE-1130).
 #   lane-targets       Print the Buck targets a gated lane executes.
 #   intersect          Print a lane's targets that appear in an impacted list.
+#   build-scope        Print the impacted targets a `//crates/...` lane may
+#                      build. Narrowing must stay inside the lane's own scope.
 #
 # Deliberately NOT `set -e`: a full run is the safe fallback, so failures are
 # handled explicitly and converted into "full", never into a hard error that
@@ -231,6 +233,33 @@ intersect_impacted() {
     for target in "$@"; do
         grep -Fxq "$target" "$file" && printf '%s\n' "$target"
     done
+    return 0
+}
+
+# The impacted subset a *pattern* lane may build, for lanes whose pre-narrowing
+# scope was `//crates/...` rather than a fixed list.
+#
+# RUE-1130 handed the raw impacted closure to `buck2 build` in linux-premerge.
+# That closure spans the whole graph, and the root-level targets in it are
+# `cached_corpus_suite` actions — building one RUNS the corpus (see corpus.bzl).
+# `--exclude rue_ci_dedicated_lane` cannot hold that back, because the label is
+# on the sh_test while `buck2 build` reaches the `-action` genrule, which
+# corpus.bzl documents as carrying no labels at all. So narrowing WIDENED the
+# step: it re-ran the CLI, spec, and oracle corpora inside the single job whose
+# dedicated lanes exist to keep them out, taking premerge from ~12m to 32-42m.
+#
+# Restoring the crate scope is what keeps narrowing a subset of what the lane
+# built before. A lane that builds a pattern must narrow within that pattern,
+# never to whatever the determinator happens to name.
+build_scope() {
+    local file="$1"
+    if [[ ! -r "$file" ]]; then
+        echo "affected-targets: impacted list '$file' is unreadable" >&2
+        return 1
+    fi
+    # Labels arrive normalized by parse-btd-impacted.py ("root//" stripped), so
+    # this prefix is exact rather than a heuristic over spellings.
+    grep '^//crates/' "$file" || true
     return 0
 }
 
@@ -459,11 +488,14 @@ main() {
         intersect)
             [[ $# -ge 2 ]] || { echo "usage: scripts/affected-targets intersect FILE //:TARGET..." >&2; exit 2; }
             shift; intersect_impacted "$@" ;;
+        build-scope)
+            [[ $# -eq 2 ]] || { echo "usage: scripts/affected-targets build-scope FILE" >&2; exit 2; }
+            build_scope "$2" ;;
         lane-targets)
             [[ $# -eq 2 ]] || { echo "usage: scripts/affected-targets lane-targets LANE" >&2; exit 2; }
             lane_targets "$2" ;;
         *)
-            echo "usage: scripts/affected-targets [decide|force-full-match|status-paths|is-selectable|is-selectable-lane|lane-targets|intersect]" >&2
+            echo "usage: scripts/affected-targets [decide|force-full-match|status-paths|is-selectable|is-selectable-lane|lane-targets|intersect|build-scope]" >&2
             exit 2 ;;
     esac
 }

--- a/scripts/test-affected-targets.sh
+++ b/scripts/test-affected-targets.sh
@@ -232,6 +232,56 @@ else
   fail "narrow: missing impacted file did not exit cleanly"
 fi
 
+# `build-scope` is what keeps a pattern lane's narrowing a SUBSET of what the
+# lane built before: exactly `//crates/...`, the scope linux-premerge built
+# before RUE-1130 narrowed it. The root-level entries here are
+# `cached_corpus_suite` actions that `//crates/...` never matched, and letting
+# one through re-runs a whole corpus inside linux-premerge — `buck2 build` runs
+# the action, and `rue_ci_dedicated_lane` is a `buck2 test` label filter that
+# cannot reach it.
+#
+# `//crates/rue-oracle-diff:oracle-diff-test-action` is deliberately KEPT: it is
+# a corpus action, but a crate-scoped one that `//crates/...` always matched, so
+# dropping it here would make this a behavior change rather than a restoration.
+# Taking corpus actions out of this lane wholesale needs the labels to live on
+# the action (RUE-1163's contract), which is tracked separately.
+printf '%s\n' \
+  //crates/rue-compiler:rue-compiler \
+  //:cli-tests \
+  //:cli-tests-action \
+  //crates/rue-codegen:rue-codegen-test \
+  //:spec-tests-action \
+  //:cli-tests-shard-2-action \
+  //crates/rue-oracle-diff:oracle-diff-test-action \
+  >"$narrow_root/mixed"
+TESTS=$((TESTS + 1))
+if [ "$("${AFFECTED[@]}" build-scope "$narrow_root/mixed" | tr '\n' ' ')" \
+     = "//crates/rue-compiler:rue-compiler //crates/rue-codegen:rue-codegen-test //crates/rue-oracle-diff:oracle-diff-test-action " ]; then
+  pass "narrow: build-scope keeps the crate scope and drops root-level corpus actions"
+else
+  fail "narrow: build-scope did not restore the //crates/... scope"
+fi
+
+# An impacted closure naming only corpora is legitimate — corpus data can change
+# without reaching a crate — and must read as "nothing to build", never as the
+# whole pattern. The workflow prints that case rather than silently skipping.
+printf '%s\n' //:cli-tests-action //:spec-tests-action >"$narrow_root/corpora-only"
+TESTS=$((TESTS + 1))
+if [ -z "$("${AFFECTED[@]}" build-scope "$narrow_root/corpora-only")" ]; then
+  pass "narrow: build-scope on a corpus-only closure yields nothing to build"
+else
+  fail "narrow: build-scope invented crate targets from a corpus-only closure"
+fi
+
+# An unreadable list must fail loudly so the caller can fall open to the full
+# pattern; silently yielding nothing would turn it into "build nothing".
+TESTS=$((TESTS + 1))
+if "${AFFECTED[@]}" build-scope "$narrow_root/absent" >/dev/null 2>&1; then
+  fail "narrow: build-scope accepted a missing impacted file"
+else
+  pass "narrow: build-scope rejects a missing impacted file"
+fi
+
 # test.sh must fall back to the full pattern for every input that is not a
 # readable, non-empty list, and must never turn a bad list into "run nothing".
 run_test_sh_args() { # run_test_sh_args [VAR=VALUE ...] -> prints the buck2 test args


### PR DESCRIPTION
`linux-premerge` regressed from ~12m to 32–42m when RUE-1130 pointed its build step at the determinator's impacted closure. Restores the lane's own `//crates/...` scope while keeping the narrowing.

## What happened

RUE-1130 changed the step from a pattern to the raw closure:

```diff
-run: scripts/ci-timed "linux-x64 build" -- ./buck2 build //crates/...
+if [ "$NARROW_COUNT" -gt 0 ]; then
+  mapfile -t targets <"$NARROW_FILE"
+  ./buck2 build "${targets[@]}"
```

The closure spans the whole graph. `//crates/...` never matched the root-level corpus targets — `test.sh:154` says so explicitly ("the suite sh_tests are at the repo root, so this scope keeps them out") — so narrowing **widened** this step.

That matters because those root-level targets are `cached_corpus_suite` actions, and **building one runs its corpus**. `corpus.bzl` splits each suite into a genrule that runs the harness plus a thin `sh_test` that checks the stamp.

`--exclude rue_ci_dedicated_lane` cannot hold them back. `cached_corpus_suite` passes `labels` to the `sh_test` and nothing to `_corpus_action`, which `corpus.bzl` documents as deliberate ("The action carries none: it is not a test"). The exclusion is a `buck2 test` label filter; `buck2 build` reaches the unlabelled action.

So `linux-premerge` re-ran the CLI, spec, release-smoke, and reproducible-programs corpora itself, serially, in the one job whose platform-corpus lanes exist to keep them out — while those lanes ran the same work in parallel and finished in under five minutes. `//:cli-tests-action` and all four `//:cli-tests-shard-N-action` ran in the same job, so the CLI corpus ran twice over.

## Measured

| run | premerge | build step | suite step |
| --- | --- | --- | --- |
| 31332413558 (before) | 12.1m | — | — |
| 31342141141 | 33.7m | 31.8m | 0.9m |
| 31343268292 | 41.5m | 40.0m | 1.1m |

Every other job in 31343268292 finished in ≤4.6m. The suite step is ~1m because the build step had already done its work.

Runs stayed fast only when narrowing *declined* — which is every PR touching `test.sh` or `.github/workflows/`, both on the force-full list. #2147 called this out: *"this PR — like any PR that touches CI — structurally cannot exercise narrowing in its own CI."* The narrowed path had never run in CI before it merged, and the effect is inverted: CI-touching PRs are fast, compiler PRs pay 40 minutes.

## The fix

A new `affected-targets build-scope` filters the closure back to the lane's own pattern. Labels arrive normalized by `parse-btd-impacted.py`, so the `//crates/` prefix is exact rather than a heuristic.

The rule it encodes: **a lane that builds a pattern narrows within that pattern**, never to whatever the determinator happens to name. Behaviour by path:

| input | result |
| --- | --- |
| closure with crate targets | build that subset |
| closure naming only corpora | nothing to build, reported explicitly |
| unreadable list | fail open to `//crates/...` |
| not narrowed | `//crates/...`, unchanged |

`//crates/rue-oracle-diff:oracle-diff-test-action` stays in scope: it is a corpus action, but a crate-scoped one that `//crates/...` always matched, so dropping it would make this a behaviour change rather than a restoration. Taking corpus actions out of this lane wholesale needs the labels to reach the action — see below.

The native lanes are unaffected: they already intersect against an explicit eight-target allowlist rather than consuming the raw list.

## Tests

`scripts/test-affected-targets.sh` goes from 83 to 86 checks, covering the crate-scope filter, the corpus-only closure, and the unreadable-list rejection. Green locally: 86 selector checks, 21 gate-validator tests, `validate-ci-gate.py`, `validate-shell-pipefail-pipelines.py`, `validate-adrs.py`, `validate-cli-shard-coverage.py`. All four workflow paths were exercised against a stubbed `buck2` using the impacted list from run 31343268292.

No actionlint or shellcheck available in this environment, so those checks run for the first time in CI here.

## Follow-up for RUE-1265

Phase 3's duplication gate would not have caught this, and is worth widening before it is built. It collects **test identities** via `--list` on test binaries, and enumerates lanes with `attrfilter(labels, 'rue_test_tier_premerge', ...)` minus the `rue_cli_shard` / `rue_ci_dedicated_lane` sets. A `cached_corpus_suite` action has no test binary to list and no labels to filter on, so this duplication is invisible to both halves of that design — the gate would have reported the premerge lane clean while it ran the CLI corpus twice.

The durable fix is for the deferral to be a property of the graph rather than a `buck2 test` flag, so that any execution path observes it.

Refs RUE-1130. Refs RUE-1265.

---
_Generated by [Claude Code](https://claude.ai/code/session_01KZWH1A1JWstAednntzGoaD)_