### PR TITLE
[demo, do not merge] Evidence for #2160: a compiler-internals change

### DIFF
--- a/crates/rue-compiler/src/cfg_query.rs
+++ b/crates/rue-compiler/src/cfg_query.rs
@@ -197,6 +197,20 @@ enum AccessorDagFailure<K> {
     Cycle(K),
 }
 
+/// Edge counters that make the linearity of accessor materialization
+/// assertable rather than merely intended (RUE-1284).
+///
+/// Validation and closure construction each visit every edge at most once, and
+/// the two walks are counted separately because they fail differently: a
+/// regression in validation shows up as repeated whole-graph walks, one per
+/// intermediate accessor, while a regression in closure construction shows up
+/// per root. A single total would average the two and hide either.
+///
+/// Both fields are `#[cfg(test)]`, so the struct is zero-sized in a release
+/// compiler and the `*_edge` calls compile away entirely. Keeping the calls
+/// unconditional at the call sites — rather than wrapping each in `cfg!` — is
+/// what stops the instrumentation from drifting out of step with the walks it
+/// measures.
 #[derive(Debug, Default)]
 struct AccessorGraphWork {
     #[cfg(test)]


### PR DESCRIPTION
**Demonstration PR. Not for merge — close once #2160 has landed.**

#2160 cannot exercise its own fix: it touches `.github/workflows/` and `scripts/affected-targets`, both on the determinator's force-full list, so its CI runs the unnarrowed path. That is the same blind spot that let the regression ship in #2147. This PR and its sibling exist to run the narrowed path against the fix and show what it does.

Stacked on `claude/premerge-build-regression-xnh6g7`, so it carries the fix. Because `RUE_AFFECTED_BASE_SHA` is `github.event.pull_request.base.sha` (`ci.yml:642`), the determinator diffs against the fix branch head — the fix's own workflow and script edits are not in this PR's changed-file set and so do not force a full run.

## The case this covers

A change to compiler internals: a doc comment on the accessor-graph edge counters in `crates/rue-compiler/src/cfg_query.rs`. Content is deliberately minimal; what matters is the change *class*. A `crates/rue-compiler` edit is the 74.5% case in ADR-0069's sampled mix, and it is the class that regressed — its impacted closure reaches the root-level corpus targets.

## What to look at

`premerge (linux-x64)` → **Impacted target list** and **Build all targets**.

Expected with the fix:

- narrowing engages — `impacted targets for this lane: N`
- the build step reports `linux-x64 build (narrowed)` over **only `//crates/...` targets**
- no `Waiting on root//:cli-tests-action`, `root//:cli-tests-shard-N-action`, `root//:spec-tests-action`, `root//:release-smoke-action`, or `root//:reproducible-programs-action` in the build step
- the CLI/spec/oracle corpora run **once**, in their own `test (linux-x64-*)` lanes, in parallel

Reference points for premerge wall time:

| | premerge | build step |
| --- | --- | --- |
| before narrowing (run 31332413558) | 12.1m | — |
| with the regression (run 31343268292) | 41.5m | 40.0m |
| with the regression (run 31342141141) | 33.7m | 31.8m |
| this PR | ← the number in question | |

The result should land at or below the 12.1m baseline, since the narrowed build is a subset of `//crates/...` rather than a superset of it.

## Sibling

The peripheral case is in the companion demo PR: a README-only edit, which deselects rather than narrows.

---
_Generated by [Claude Code](https://claude.ai/code/session_01KZWH1A1JWstAednntzGoaD)_