### PR TITLE
[demo, do not merge] Evidence for #2160: a README-only change

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ fn fib(n: i32) -> i32 {
 }
 
 fn main() -> i32 {
-    @dbg(fib(10));
+    println("fib(10) = " + @to_string(fib(10)));
     0
 }
 ```


### PR DESCRIPTION
**Demonstration PR. Not for merge — close once #2160 has landed.**

Companion to #2161. Together they cover the two change classes that reach `linux-premerge` differently. See #2161 for why #2160 cannot exercise its own fix and why stacking on the fix branch keeps the determinator honest.

## The case this covers

A documentation-only change: the front-page example now prints its result with `println` instead of `@dbg`. `README.md` is explicitly *selectable* rather than force-full (`scripts/test-affected-targets.sh:90`), so this is the peripheral class ADR-0069 measured at 444s against 465s for a compiler change.

## What to look at

`premerge (linux-x64)` → **Impacted target list** and **Build all targets**.

Expected:

- the determinator finds nothing impacted, so narrowing **declines** — `narrowed` is false and the build step falls back to `./buck2 build //crates/...`, exactly as it did before RUE-1130
- the six gated lanes (`native` ×2, `release`, `valgrind`, `asan`, `compiler reproducibility`) deselect
- no corpus action is built in the premerge job

This is the path #2160 leaves untouched, and that is the point: the fix changes only what happens when narrowing *engages*. If this run looks like a normal pre-RUE-1130 run, the fallback is intact.

It also exercises the third branch of the fixed step indirectly — a closure naming only corpora would print `no impacted //crates/... targets; this step has nothing to build` rather than silently skipping. That case is covered by unit tests in #2160 (`narrow: build-scope on a corpus-only closure yields nothing to build`), since producing it on a real PR needs a diff that touches corpus data and nothing else.

## On the change itself

`println("fib(10) = " + @to_string(fib(10)))` is the idiom the worked examples use (`examples/first/stats.rue:61`), needs no import, and labels its output. `@to_string` accepts any integer width (`intrinsics.rs:1361`, RUE-314), so the `i32` return of `fib` is fine.

Worth noting for its own sake: **nothing in CI compiles this snippet.** The tutorial snippet checker globs `*.md` under its own root and never sees the repository README, so the first Rue code anyone reads is unverified. That is a real gap, unrelated to #2160 and not fixed here.

---
_Generated by [Claude Code](https://claude.ai/code/session_01KZWH1A1JWstAednntzGoaD)_