### PR TITLE
Join break- and continue-edge move states into the loop's exit and back-edge states

### DIFF
--- a/crates/rue-air/src/sema/context.rs
+++ b/crates/rue-air/src/sema/context.rs
@@ -262,6 +262,118 @@ impl PartialEq for VariableMoveState {
     }
 }
 
+/// Apply one scope's saved move-state frame to a move map, restoring each
+/// name declared in that scope to its pre-declaration state (or absence), in
+/// reverse declaration order — the RUE-522 restoration `pop_scope` performs
+/// on the live `moved_vars`, factored out so a loop can apply it to its
+/// break-site snapshots too (RUE-1293): a snapshot taken inside the loop's
+/// scope may carry loop-local names, and for a name that *shadows* an outer
+/// binding the snapshot's entry describes the dead inner binding, while the
+/// outer binding's state at the break is exactly the saved entry this
+/// restoration writes back.
+pub(crate) fn restore_scope_moves(
+    moves: &mut HashMap<Spur, VariableMoveState>,
+    frame: &[(Spur, Option<VariableMoveState>)],
+) {
+    for (symbol, old_moves) in frame.iter().rev() {
+        match old_moves {
+            Some(state) => {
+                moves.insert(*symbol, state.clone());
+            }
+            None => {
+                moves.remove(symbol);
+            }
+        }
+    }
+}
+
+/// The move states one enclosing loop's `break`s and `continue`s have
+/// established so far (RUE-1293).
+///
+/// Both are diverging edges, so the `if`/`match` joins correctly exclude
+/// their states from the fall-through — but each state still arrives
+/// somewhere: a `break`'s at the code AFTER the loop (the exit is the union
+/// of the break states; formal core §5.7, (Loop-Break)), and a `continue`'s
+/// at the next iteration's entry (the back edge is the union of the
+/// fall-through and continue states). Before this record collected them,
+/// both edges dropped their move states entirely, accepting use-after-move
+/// with an observable double-drop through either a post-loop use (break) or
+/// a next-iteration use (continue).
+#[derive(Debug, Clone, Default)]
+pub(crate) struct LoopEdgeStates {
+    /// A `break` targeting this loop exists: the loop is `()`-typed.
+    pub broke: bool,
+    /// One `moved_vars` snapshot per `break` targeting this loop.
+    pub break_snaps: Vec<(HashMap<Spur, VariableMoveState>, usize)>,
+    /// One `moved_vars` snapshot per `continue` targeting this loop.
+    pub continue_snaps: Vec<(HashMap<Spur, VariableMoveState>, usize)>,
+}
+
+/// Record one snapshot in a per-loop edge list, merging with an existing
+/// same-depth snapshot (union — moved on either edge ⇒ moved at the join).
+///
+/// Each snapshot is tagged with the scope depth (`moved_scope_stack.len()`)
+/// at which it was taken: it names whatever bindings were visible at the
+/// edge, so as each intervening scope pops, `pop_scope` replays that scope's
+/// RUE-522 restoration onto every snapshot taken inside it (and lowers its
+/// tag) — a shadowed outer binding resumes its own state, and scope locals
+/// drop out. By the time the loop pops its record, every snapshot describes
+/// the post-loop scope view. Eager same-depth merging keeps each list as
+/// small as the loop's live scope nesting.
+fn record_edge_snapshot(
+    snaps: &mut Vec<(HashMap<Spur, VariableMoveState>, usize)>,
+    moves: &HashMap<Spur, VariableMoveState>,
+    depth: usize,
+) {
+    if let Some((existing, existing_depth)) = snaps.last_mut()
+        && *existing_depth == depth
+    {
+        *existing = union_move_maps(existing, moves);
+        return;
+    }
+    snaps.push((moves.clone(), depth));
+}
+
+/// Union-merge a drained edge list, or `None` when the edge never fired.
+fn merged_edge_moves(
+    snaps: Vec<(HashMap<Spur, VariableMoveState>, usize)>,
+) -> Option<HashMap<Spur, VariableMoveState>> {
+    let mut snaps = snaps.into_iter();
+    let (mut merged, _) = snaps.next()?;
+    for (snap, _) in snaps {
+        merged = union_move_maps(&merged, &snap);
+    }
+    Some(merged)
+}
+
+impl LoopEdgeStates {
+    /// Record one break's snapshot.
+    pub fn record_break(&mut self, moves: &HashMap<Spur, VariableMoveState>, depth: usize) {
+        self.broke = true;
+        record_edge_snapshot(&mut self.break_snaps, moves, depth);
+    }
+
+    /// Record one continue's snapshot.
+    pub fn record_continue(&mut self, moves: &HashMap<Spur, VariableMoveState>, depth: usize) {
+        record_edge_snapshot(&mut self.continue_snaps, moves, depth);
+    }
+
+    /// The union-merge of every break snapshot — the loop's exit ownership
+    /// state — or `None` when the loop has no break; and of every continue
+    /// snapshot — the back edge's addition to the fall-through state.
+    pub fn merged_moves(
+        self,
+    ) -> (
+        Option<HashMap<Spur, VariableMoveState>>,
+        Option<HashMap<Spur, VariableMoveState>>,
+    ) {
+        (
+            merged_edge_moves(self.break_snaps),
+            merged_edge_moves(self.continue_snaps),
+        )
+    }
+}
+
 /// Union-merge two branch move-state maps (see [`VariableMoveState::merge_union`]).
 ///
 /// A variable with state in only one map is merged against the default
@@ -392,10 +504,14 @@ pub(crate) struct AnalysisContext<'a> {
     /// chapter 9). An `unchecked fn` body does NOT implicitly count as a
     /// checked context; the modifier only gates *callers* (see spec 9.1:1).
     pub checked_depth: u32,
-    /// One entry per enclosing loop (innermost last); set to `true` when a
-    /// `break` targeting that loop is analyzed. An infinite loop containing a
-    /// break has type `()`; without one it has type `!` (see spec 4.8).
-    pub loop_break_stack: Vec<bool>,
+    /// One entry per enclosing loop (innermost last), recording what that
+    /// loop's diverging edges establish: whether a `break` exists at all (an
+    /// infinite loop containing one has type `()`; without one it has type
+    /// `!` — spec 4.8), and the move-state snapshots at the break and
+    /// continue sites. The break states are the loop's exit ownership state,
+    /// and the continue states join the fall-through as the back-edge state
+    /// (RUE-1293; formal core §5.7, (Loop-Break)) — see [`LoopEdgeStates`].
+    pub loop_break_stack: Vec<LoopEdgeStates>,
     /// Local variables that have been read (for unused variable detection)
     pub used_locals: HashSet<Spur>,
     /// Return type of the current function (for explicit return validation)
@@ -618,14 +734,25 @@ impl ScopedContext for AnalysisContext<'_> {
                 }
             }
         }
+        let depth_before_pop = self.moved_scope_stack.len();
         if let Some(move_frame) = self.moved_scope_stack.pop() {
-            for (symbol, old_moves) in move_frame.into_iter().rev() {
-                match old_moves {
-                    Some(state) => {
-                        self.moved_vars.insert(symbol, state);
-                    }
-                    None => {
-                        self.moved_vars.remove(&symbol);
+            restore_scope_moves(&mut self.moved_vars, &move_frame);
+            // RUE-1293: a break-site snapshot taken while this scope was open
+            // names this scope's bindings; replay the same restoration on it
+            // so a shadowed outer binding resumes its own state and this
+            // scope's locals drop out. Every record on the stack encloses the
+            // popping scope (an inner loop's record is pushed and popped
+            // strictly within one enclosing scope), so only the depth tag
+            // decides applicability.
+            for record in &mut self.loop_break_stack {
+                for (snap, depth) in record
+                    .break_snaps
+                    .iter_mut()
+                    .chain(record.continue_snaps.iter_mut())
+                {
+                    if *depth >= depth_before_pop {
+                        restore_scope_moves(snap, &move_frame);
+                        *depth = depth_before_pop - 1;
                     }
                 }
             }

--- a/crates/rue-air/src/sema/control_flow.rs
+++ b/crates/rue-air/src/sema/control_flow.rs
@@ -375,8 +375,11 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
         // break-site snapshots still on the stack, so the record popped
         // afterwards describes the post-loop scope view.
         ctx.pop_scope();
-        let (break_moves, continue_moves) =
-            ctx.loop_break_stack.pop().unwrap_or_default().merged_moves();
+        let (break_moves, continue_moves) = ctx
+            .loop_break_stack
+            .pop()
+            .unwrap_or_default()
+            .merged_moves();
         // The back edge carries the fall-through state joined with the
         // continue-site states — a continue re-enters the loop exactly like
         // falling off the body's end — while a break path never re-enters.

--- a/crates/rue-air/src/sema/control_flow.rs
+++ b/crates/rue-air/src/sema/control_flow.rs
@@ -16,7 +16,9 @@ use rue_span::Span;
 use super::analysis::FirstClassStrSite;
 use super::anon_structs::TrustedTryProducer;
 use super::call_resolution::CallResolutionFacts;
-use super::context::{AnalysisContext, AnalysisResult, ConstValue, LocalVar};
+use super::context::{
+    AnalysisContext, AnalysisResult, ConstValue, LocalVar, LoopEdgeStates, union_move_maps,
+};
 use crate::declaration_validation::{
     AccessorExitForm, AccessorMethodLink, AccessorYieldRootForm, accessor_method_link_error,
     accessor_yield_root_error,
@@ -75,10 +77,16 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
                     return Err(CompileError::new(ErrorKind::BreakWithValue, inst.span));
                 }
 
-                // Record the break against the innermost enclosing loop, so
-                // the loop can be typed `()` instead of `!` (spec 4.8:17).
-                if let Some(broke) = ctx.loop_break_stack.last_mut() {
-                    *broke = true;
+                // Record the break against the innermost enclosing loop: it
+                // is now `()`-typed instead of `!` (spec 4.8:17), and the
+                // move state in force HERE is one of the loop's exit states —
+                // union-merged with the other breaks' states, it becomes the
+                // ownership state after the loop (RUE-1293; formal core §5.7,
+                // (Loop-Break): Σ_exit = join over the at-break states).
+                let break_depth = ctx.moved_scope_stack.len();
+                let break_moves = ctx.moved_vars.clone();
+                if let Some(record) = ctx.loop_break_stack.last_mut() {
+                    record.record_break(&break_moves, break_depth);
                 }
 
                 // Break has the never type - it diverges
@@ -94,6 +102,18 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
                 // Validate that we're inside a loop
                 if ctx.loop_depth == 0 {
                     return Err(CompileError::new(ErrorKind::ContinueOutsideLoop, inst.span));
+                }
+
+                // The move state in force HERE rides the back edge into the
+                // next iteration: record it so the loop's back-edge recheck
+                // is seeded with it — the branch joins exclude this diverging
+                // arm, so without the record a move on a continue path would
+                // vanish and the next iteration could re-use the value
+                // (RUE-1293, the continue-edge variant).
+                let continue_depth = ctx.moved_scope_stack.len();
+                let continue_moves = ctx.moved_vars.clone();
+                if let Some(record) = ctx.loop_break_stack.last_mut() {
+                    record.record_continue(&continue_moves, continue_depth);
                 }
 
                 // Continue has the never type - it diverges
@@ -348,11 +368,31 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
         // the flag itself is unused because a while loop is always `()`.
         ctx.push_scope();
         ctx.loop_depth += 1;
-        ctx.loop_break_stack.push(false);
+        ctx.loop_break_stack.push(LoopEdgeStates::default());
         let body_result = self.analyze_inst(air, body, ctx)?;
-        ctx.loop_break_stack.pop();
         ctx.loop_depth -= 1;
+        // pop_scope replays this scope's RUE-522 restoration onto the
+        // break-site snapshots still on the stack, so the record popped
+        // afterwards describes the post-loop scope view.
         ctx.pop_scope();
+        let (break_moves, continue_moves) =
+            ctx.loop_break_stack.pop().unwrap_or_default().merged_moves();
+        // The back edge carries the fall-through state joined with the
+        // continue-site states — a continue re-enters the loop exactly like
+        // falling off the body's end — while a break path never re-enters.
+        // Keep the joined state for the recheck below (RUE-1293).
+        let mut backedge_moves = ctx.moved_vars.clone();
+        if let Some(continue_moves) = &continue_moves {
+            backedge_moves = union_move_maps(&backedge_moves, continue_moves);
+        }
+        // A while loop's exits are the condition-false fall-through — whose
+        // state on iterations past the first is the back-edge state — AND its
+        // breaks; union in the at-break states so a move on a break path is
+        // marked after the loop too (RUE-1293).
+        ctx.moved_vars = match &break_moves {
+            Some(break_moves) => union_move_maps(&backedge_moves, break_moves),
+            None => backedge_moves.clone(),
+        };
 
         // A while loop discards its body's result value on every iteration;
         // discarding a value that carries a linear value would implicitly
@@ -364,15 +404,21 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
         // state. Any use of a value moved by a previous iteration then errors.
         // The scratch Air and context are discarded - this pass exists only
         // for the checks.
-        if !ctx.in_loop_move_recheck && ctx.moved_vars != moves_before_loop {
+        if !ctx.in_loop_move_recheck && backedge_moves != moves_before_loop {
             let checkpoint = air.checkpoint();
             let mut scratch_ctx = ctx.fork_for_loop_recheck();
+            // Seed the back-edge recheck with the back-edge state (the
+            // fall-through joined with the continue states), not the exit
+            // state: break-path moves never reach the back edge, and seeding
+            // them would reject a value legitimately moved only on a path
+            // that exits the loop (RUE-1293).
+            scratch_ctx.moved_vars = backedge_moves;
             let recovered_before = self.body_analysis_recovered_errors_mut().len();
             let result = (|| -> CompileResult<()> {
                 self.analyze_inst(air, cond, &mut scratch_ctx)?;
                 scratch_ctx.push_scope();
                 scratch_ctx.loop_depth += 1;
-                scratch_ctx.loop_break_stack.push(false);
+                scratch_ctx.loop_break_stack.push(LoopEdgeStates::default());
                 self.analyze_inst(air, body, &mut scratch_ctx)?;
                 scratch_ctx.loop_break_stack.pop();
                 scratch_ctx.loop_depth -= 1;
@@ -418,7 +464,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
 
         ctx.push_scope();
         ctx.loop_depth += 1;
-        ctx.loop_break_stack.push(false);
+        ctx.loop_break_stack.push(LoopEdgeStates::default());
         // A `for` over a named variable borrows it (shared) for the body's
         // duration (spec 4.8:26, RUE-233): record the borrow so a mutation of
         // the iterated collection inside the body is rejected (E0428).
@@ -429,9 +475,28 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
         if iter_borrow.is_some() {
             ctx.iter_borrows.pop();
         }
-        let has_break = ctx.loop_break_stack.pop().unwrap_or(false);
         ctx.loop_depth -= 1;
+        // pop_scope replays this scope's RUE-522 restoration onto the
+        // break-site snapshots still on the stack (see analyze_while_loop).
         ctx.pop_scope();
+        let edge_record = ctx.loop_break_stack.pop().unwrap_or_default();
+        let has_break = edge_record.broke;
+        let (break_moves, continue_moves) = edge_record.merged_moves();
+        // The back edge carries the fall-through state joined with the
+        // continue-site states; keep it for the recheck below (RUE-1293).
+        let mut backedge_moves = ctx.moved_vars.clone();
+        if let Some(continue_moves) = &continue_moves {
+            backedge_moves = union_move_maps(&backedge_moves, continue_moves);
+        }
+        // An infinite loop's only exits are its breaks, so the union of the
+        // at-break states IS the exit ownership state — the back-edge state
+        // re-enters the loop and never reaches the code after it (RUE-1293;
+        // formal core §5.7, (Loop-Break)). A breakless loop is `!`-typed and
+        // the code after it unreachable; its state is left as the
+        // fall-through, which nothing can observe.
+        if let Some(break_moves) = break_moves {
+            ctx.moved_vars = break_moves;
+        }
 
         // The loop discards its body's result value on every iteration;
         // discarding a value that carries a linear value would implicitly
@@ -441,13 +506,17 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
         // Loop back-edge move check (see analyze_while_loop for details).
         // Note: like Rust, this is conservative - a body that unconditionally
         // breaks after the move still errors.
-        if !ctx.in_loop_move_recheck && ctx.moved_vars != moves_before_loop {
+        if !ctx.in_loop_move_recheck && backedge_moves != moves_before_loop {
             let checkpoint = air.checkpoint();
             let mut scratch_ctx = ctx.fork_for_loop_recheck();
+            // Seed with the back-edge state (fall-through joined with the
+            // continue states), not the exit state: only the back edge's
+            // moves reach the next iteration (RUE-1293).
+            scratch_ctx.moved_vars = backedge_moves;
             let recovered_before = self.body_analysis_recovered_errors_mut().len();
             scratch_ctx.push_scope();
             scratch_ctx.loop_depth += 1;
-            scratch_ctx.loop_break_stack.push(false);
+            scratch_ctx.loop_break_stack.push(LoopEdgeStates::default());
             if let Some(var) = iter_borrow {
                 scratch_ctx.iter_borrows.push(var);
             }

--- a/crates/rue-air/src/sema/tests.rs
+++ b/crates/rue-air/src/sema/tests.rs
@@ -2616,6 +2616,59 @@ mod tests {
     }
 
     #[test]
+    fn break_path_move_is_moved_after_loop() {
+        // RUE-1293: a loop's exit ownership state is the union of the
+        // at-break states (formal core §5.7, (Loop-Break)), so a value moved
+        // on a break path is moved after the loop. Before the fix the exit
+        // state was the fall-through state — which never reaches the exit —
+        // and this use-after-move was accepted (observable double-drop).
+        let result = compile_to_air(
+            "struct NonCopy { x: i32 }
+             fn consume(n: NonCopy) -> i32 { n.x }
+             fn main() -> i32 {
+                 let n = NonCopy { x: 1 };
+                 let mut i = 0;
+                 loop {
+                     i = i + 1;
+                     if i > 0 { let v = consume(n); break; }
+                 }
+                 consume(n)
+             }",
+        );
+
+        assert!(result.is_err());
+        let errors = result.unwrap_err();
+        assert!(
+            errors
+                .iter()
+                .any(|error| matches!(&error.kind, ErrorKind::UseAfterMove { .. }))
+        );
+    }
+
+    #[test]
+    fn break_path_move_of_shadow_leaves_outer_owned() {
+        // The exit join is per-binding, not per-name (RUE-522 × RUE-1293):
+        // the break snapshot names the loop-local shadow, and pop_scope's
+        // restoration replayed onto it must resume the outer binding's own
+        // state, not poison it with the shadow's move.
+        compile_to_air(
+            "struct NonCopy { x: i32 }
+             fn consume(n: NonCopy) -> i32 { n.x }
+             fn main() -> i32 {
+                 let n = NonCopy { x: 1 };
+                 let mut i = 0;
+                 loop {
+                     i = i + 1;
+                     let n = NonCopy { x: 2 };
+                     if i > 0 { let v = consume(n); break; }
+                 }
+                 consume(n)
+             }",
+        )
+        .expect("outer binding is untouched by the shadow's break-path move");
+    }
+
+    #[test]
     fn test_partial_move_sibling_still_valid() {
         // After moving one field, sibling fields should still be usable
         // Note: Inner is non-copy, Outer is also non-copy (can't be @copy with non-copy field)

--- a/crates/rue-spec/cases/types/move-semantics.toml
+++ b/crates/rue-spec/cases/types/move-semantics.toml
@@ -2297,3 +2297,54 @@ fn main() -> i32 {
 """
 compile_fail = true
 error_contains = ["E0205", "use of moved value"]
+
+# The continue edge is the back edge: a move on a continue path is moved when
+# the next iteration begins, exactly like a move left unrestored at the body's
+# end (RUE-1293, the continue-edge variant).
+[[case]]
+name = "continue_path_move_is_moved_next_iteration"
+spec = ["3.8:5", "3.8:50"]
+description = "A value moved on a continue path is moved when the next iteration re-enters the body."
+source = """
+struct P { x: i64 }
+
+fn consume(p: P) -> i64 { p.x }
+
+fn main() -> i32 {
+    let p = P { x: 1 };
+    let mut i = 0;
+    loop {
+        i = i + 1;
+        if i == 1 { let v = consume(p); continue; }
+        if i == 2 { let w = consume(p); continue; }
+        break;
+    }
+    0
+}
+"""
+compile_fail = true
+error_contains = ["E0205", "use of moved value"]
+
+# Reinitializing before the continue restores the back-edge state (3.8:55).
+[[case]]
+name = "continue_path_move_reinitialized_is_legal"
+spec = ["3.8:50", "3.8:55"]
+description = "Moving and reinitializing before a continue keeps the back edge owned."
+source = """
+struct P { x: i64 }
+
+fn consume(p: P) -> i64 { p.x }
+
+fn main() -> i32 {
+    let mut p = P { x: 1 };
+    let mut i = 0;
+    loop {
+        i = i + 1;
+        if i == 1 { let v = consume(p); p = P { x: v + 1 }; continue; }
+        if i == 3 { break; }
+    }
+    let q = consume(p);
+    if q == 2 { 0 } else { 1 }
+}
+"""
+exit_code = 0

--- a/crates/rue-spec/cases/types/move-semantics.toml
+++ b/crates/rue-spec/cases/types/move-semantics.toml
@@ -2174,16 +2174,11 @@ error_contains = ["[E0493]", "overwrite a live linear value"]
 
 # A value moved on a `break` path must be MovedOut after the loop: the loop's
 # exit ownership state is the join of the break-site states (formal core §5.7,
-# (Loop-Break)), exactly as an `if` join. The compiler currently computes the
-# loop-exit state from the loop-entry state instead, accepting this
-# use-after-move — and, for a drop-glue type, running the destructor twice
-# (RUE-1293). Skipped until that lands; the equivalent if/else shape is
-# correctly rejected today.
+# (Loop-Break)), exactly as an `if` join (RUE-1293).
 [[case]]
 name = "break_path_move_is_moved_after_loop"
 spec = ["3.8:50", "3.8:51"]
 description = "A value moved on a break path is moved after the loop; post-loop use is E0205."
-skip = true
 source = """
 struct P { x: i64 }
 
@@ -2193,6 +2188,106 @@ fn main() -> i32 {
     let p = P { x: 1 };
     let mut i = 0;
     loop {
+        i = i + 1;
+        if i > 0 { let v = consume(p); break; }
+    }
+    let q = consume(p);
+    if q == 1 { 0 } else { 1 }
+}
+"""
+compile_fail = true
+error_contains = ["E0205", "use of moved value"]
+
+# The exit join is per-binding, not per-name (RUE-522 × RUE-1293): a loop-local
+# shadow consumed on the break path leaves the outer binding untouched.
+[[case]]
+name = "break_path_move_of_shadow_leaves_outer_owned"
+spec = ["3.8:50", "3.8:12"]
+description = "Consuming a loop-local shadow on a break path does not mark the outer binding moved."
+source = """
+struct P { x: i64 }
+
+fn consume(p: P) -> i64 { p.x }
+
+fn main() -> i32 {
+    let p = P { x: 1 };
+    let mut i = 0;
+    loop {
+        i = i + 1;
+        let p = P { x: 2 };
+        if i > 0 { let v = consume(p); break; }
+    }
+    let q = consume(p);
+    if q == 1 { 0 } else { 1 }
+}
+"""
+exit_code = 0
+
+# Reinitialization after the loop discharges the exit join's MovedOut exactly
+# as after an if join (3.8:55).
+[[case]]
+name = "break_path_move_reassigned_after_loop"
+spec = ["3.8:50", "3.8:55"]
+description = "A value moved on a break path may be reinitialized after the loop and used."
+source = """
+struct P { x: i64 }
+
+fn consume(p: P) -> i64 { p.x }
+
+fn main() -> i32 {
+    let mut p = P { x: 1 };
+    let mut i = 0;
+    loop {
+        i = i + 1;
+        if i > 0 { let v = consume(p); break; }
+    }
+    p = P { x: 5 };
+    let q = consume(p);
+    if q == 5 { 0 } else { 1 }
+}
+"""
+exit_code = 0
+
+# A move on one break path with no use after the loop stays legal: the join
+# marks the value conservatively and the per-path drop flag drops it on
+# exactly the exits that did not move it (3.8:73).
+[[case]]
+name = "break_path_move_without_later_use_is_legal"
+spec = ["3.8:73"]
+description = "Moving on one of several break paths is legal when the value is not used after the loop."
+source = """
+struct P { x: i64 }
+
+fn consume(p: P) -> i64 { p.x }
+
+fn main() -> i32 {
+    let p = P { x: 1 };
+    let mut i = 0;
+    loop {
+        i = i + 1;
+        if i > 2 { let v = consume(p); break; }
+        if i > 1 { break; }
+    }
+    0
+}
+"""
+exit_code = 0
+
+# The while form has the same exit join: its exits are the condition-false
+# fall-through and its breaks.
+[[case]]
+name = "while_break_path_move_is_moved_after_loop"
+spec = ["3.8:50", "3.8:51"]
+description = "A value moved on a while-loop break path is moved after the loop; post-loop use is E0205."
+source = """
+struct P { x: i64 }
+
+fn consume(p: P) -> i64 { p.x }
+
+fn main() -> i32 {
+    let p = P { x: 1 };
+    let mut i = 0;
+    while i < 10 {
         i = i + 1;
         if i > 0 { let v = consume(p); break; }
     }


### PR DESCRIPTION
Fixes RUE-1293 — the soundness hole found while writing the formal core's (Loop-Break) rule (#2164), plus a second variant of the same hole found during the fix.

## The defect

The `if`/`match` joins correctly exclude a diverging arm's move state from the fall-through — but each excluded state still arrives somewhere: a `break`'s at the code **after the loop**, a `continue`'s at the **next iteration's entry**. Neither was collected:

- The loop-exit state was the fall-through state, which (for an infinite `loop`) never actually reaches the exit — so a value moved on a break path was Owned after the loop. Verified: accepted use-after-move, and an observable **double-drop** with a destructor type (a buffer-owning type would double-free).
- The back-edge recheck was seeded with the fall-through state only — so a value moved behind a `continue` was Owned when the next iteration re-entered. Same verified double-drop through a second iteration's re-use.

Both survived because surface `while` puts its implicit exit at the condition with the back-edge-invariant state, and straight-line moves in a body do reach the fall-through state — only moves confined to explicitly diverging edges slipped through.

## The fix

Each enclosing loop's stack entry (`LoopEdgeStates`, formerly a lone `bool`) now records a `moved_vars` snapshot at every `break` and `continue` site, depth-tagged with the scope depth where it was taken. `pop_scope` replays each popping scope's RUE-522 restoration onto the snapshots taken inside it — so a snapshot naming a loop-local shadow resumes the **outer** binding's own state rather than poisoning it, and scope locals drop out. Same-depth snapshots merge eagerly, keeping the lists as small as the live scope nesting.

At the loop:
- the union of the break snapshots becomes the **exit ownership state** (formal core §5.7, (Loop-Break): `Σ_exit = join over the at-break states`); a breakless `!`-typed loop keeps its unobservable fall-through state;
- the union of the fall-through and continue snapshots seeds the **back-edge recheck**, and is the recheck's trigger condition;
- a `while` loop's exit additionally unions the back-edge state, since its condition-false exit rides it.

The exit state is installed from post-restoration snapshots, so break-path moves never leak into the back-edge seed (which would falsely reject values legitimately moved only on exiting paths) and vice versa.

## What stays legal (all verified, all pinned)

- move + reassign before the back edge or before a `continue` (reinitialization, 3.8:55)
- move on one of several break paths with no later use (per-path drop flags, 3.8:73)
- consuming a loop-local **shadow** on a break path — the outer binding stays Owned (RUE-522 × RUE-1293)
- reassign-after-loop discharging the exit join's MovedOut

## Testing

- The previously skip-marked `break_path_move_is_moved_after_loop` spec case un-skips; seven new cases pin the shadow, reinit, no-later-use, `while`-break, and both continue-edge shapes (3.8:5/50/51/55/73)
- Two sema unit tests cover the batch producer path, including the shadowing interaction
- Full spec corpus: 2283 passed, 0 failed; `buck2 test //crates/rue-air:` green; `./clippy.sh` green; full local tier green on the break half (103 passed, only the known-environmental caldera-slow timeout, which reproduces identically on trunk in this container)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DrKqpQgkHzDHGqpEMjxYdN

---
_Generated by [Claude Code](https://claude.ai/code/session_01DrKqpQgkHzDHGqpEMjxYdN)_