### PR TITLE
Fix the flaky rayon phase-accounting test: propagate the dispatcher so worker flush markers publish

### DIFF
--- a/crates/rue/src/timing.rs
+++ b/crates/rue/src/timing.rs
@@ -2132,6 +2132,7 @@ mod tests {
 /// entered or exited.
 #[cfg(test)]
 mod phase_accounting_tests {
+    use std::sync::Barrier;
     use std::thread;
     use std::time::Duration;
 
@@ -2515,29 +2516,98 @@ mod phase_accounting_tests {
         // Real threads and independent local buffers. The final partition is of
         // wall time globally, so overlapping workers in one phase still yield
         // that phase.
-        let accounting = collect(|| {
+        //
+        // Each worker publishes through the same bounded `timing_flush`
+        // completion marker a registered query worker emits — and, exactly as
+        // the query runtime does for its batch workers, installs the
+        // propagated dispatcher first so the marker reaches THIS subscriber.
+        // An earlier draft skipped the propagation: `with_default` is
+        // thread-scoped, so the worker's marker dispatched to the thread's
+        // (unset) global default and publication silently fell back to TLS
+        // teardown — which `thread::scope` does not order before its join, so
+        // the reader raced the workers' destructors and sometimes saw every
+        // phase band empty (RUE-1283).
+        let data = TimingData::new();
+        let subscriber = tracing_subscriber::registry().with(TimingLayer::new(data.clone()));
+        let dispatch = tracing::Dispatch::new(subscriber);
+        tracing::dispatcher::with_default(&dispatch, || {
             let _root = tracing::info_span!("compile").entered();
             let span = tracing::info_span!("codegen", phase = "backend");
             thread::scope(|scope| {
                 for _ in 0..4 {
                     let worker_span = span.clone();
+                    let worker_dispatch = dispatch.clone();
                     scope.spawn(move || {
-                        {
-                            let _entered = worker_span.entered();
-                            thread::sleep(TICK);
-                        }
-                        tracing::trace!(timing_flush = true, "test worker complete");
+                        tracing::dispatcher::with_default(&worker_dispatch, || {
+                            {
+                                let _entered = worker_span.entered();
+                                thread::sleep(TICK);
+                            }
+                            tracing::trace!(timing_flush = true, "test worker complete");
+                        });
                     });
                 }
             });
         });
+        let accounting = data.phase_accounting();
 
+        assert_eq!(
+            data.flush_threads().len(),
+            4,
+            "every worker's completion marker must reach this layer and flush"
+        );
         assert_invariant(&accounting);
         assert!(phase_ns(&accounting, Phase::Backend) > 0, "{accounting:?}");
         assert_eq!(
             accounting.mixed_parallel_ns, 0,
             "four workers in one phase is not mixed: {accounting:?}"
         );
+    }
+
+    #[test]
+    fn worker_flush_marker_publishes_phase_events_before_thread_teardown() {
+        // The deterministic form of the RUE-1283 race: the `timing_flush`
+        // marker must merge the worker's local buffer synchronously, so the
+        // phase bands are complete the moment the worker has emitted it —
+        // thread teardown is only a fallback, and `thread::scope` gives it no
+        // ordering against the scope's join. The barriers hold the worker
+        // alive past its flush, so a read that sees the phase can only have
+        // been served by the marker, never by teardown.
+        let data = TimingData::new();
+        let subscriber = tracing_subscriber::registry().with(TimingLayer::new(data.clone()));
+        let dispatch = tracing::Dispatch::new(subscriber);
+        let flushed = Barrier::new(2);
+        let release = Barrier::new(2);
+        tracing::dispatcher::with_default(&dispatch, || {
+            let _root = tracing::info_span!("compile").entered();
+            let span = tracing::info_span!("codegen", phase = "backend");
+            thread::scope(|scope| {
+                let worker_span = span.clone();
+                let worker_dispatch = dispatch.clone();
+                let (flushed, release) = (&flushed, &release);
+                scope.spawn(move || {
+                    tracing::dispatcher::with_default(&worker_dispatch, || {
+                        {
+                            let _entered = worker_span.entered();
+                            thread::sleep(TICK);
+                        }
+                        tracing::trace!(timing_flush = true, "worker flushed");
+                    });
+                    flushed.wait();
+                    // Stay alive until the reader is done: TLS teardown must
+                    // not be able to publish on this test's behalf.
+                    release.wait();
+                });
+                flushed.wait();
+                let accounting = data.phase_accounting();
+                assert!(
+                    phase_ns(&accounting, Phase::Backend) > 0,
+                    "the flush marker alone must have published the worker's \
+                     phase interval: {accounting:?}"
+                );
+                release.wait();
+            });
+        });
     }
 
     #[test]


### PR DESCRIPTION
Fixes RUE-1283.

## Diagnosis

`phases_entered_on_rayon_workers_are_accounted_across_threads` raced its reader against worker thread teardown, through two interacting defects in the test (production is sound):

1. **The flush marker went nowhere.** `collect` installs the timing subscriber with `tracing::subscriber::with_default` — which is *thread-scoped*. The workers' `tracing::trace!(timing_flush = true)` completion markers dispatched to each worker thread's default subscriber (the unset global default), never reaching this layer. The span enter/exits still arrived (a `Span` dispatches through its captured subscriber), so the phase events accumulated in the workers' thread-local buffers — but nothing published them at completion.
2. **The fallback is unordered.** Publication then fell to `LocalTiming`'s thread-local `Drop` — but `thread::scope` signals scope completion when a worker's *closure* returns, before its TLS destructors run. Under CI load the main thread could reach `phase_accounting()` before any worker's destructor merged its buffer: every phase band empty, the whole root unattributed — exactly the recorded failure.

**Production does not share the defect**: the query runtime captures the dispatcher at batch registration (`get_default(Clone::clone)`) and runs worker bodies — including their `timing_flush` markers — under `dispatcher::with_default`, so a registered worker's flush is a synchronous in-closure publication. The sibling thread-spawning tests in this file already call `flush_local()` explicitly ("instead of depending on platform TLS teardown timing"); this test was the one relying on a marker that couldn't land.

## Fix

The test now installs the propagated dispatcher in each worker exactly as the runtime does for its batch workers, making the existing marker line do its job synchronously, and asserts all four markers reached the layer (`flush_threads()`).

## Deterministic regression

`worker_flush_marker_publishes_phase_events_before_thread_teardown`: a barrier-held worker that has emitted its flush marker but is kept alive (so TLS teardown cannot publish on its behalf) must already have its phase interval visible to a concurrent reader. No sleeps-as-synchronization, no scheduler dependence: with the dispatcher propagation removed it fails **every** run, reproducing the exact CI failure signature (`phase_ns` all zero, `unattributed_ns == compiler_root_ns`).

## Testing

- `buck2 test //crates/rue:` green
- 40 sequential + 40 eight-way-parallel runs of the full phase-accounting module: 0 failures
- Pre-fix verification: with the worker dispatcher install stripped, the new regression fails 40/40 with the recorded failure shape
- `./fmt.sh check` and `./clippy.sh` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DrKqpQgkHzDHGqpEMjxYdN

---
_Generated by [Claude Code](https://claude.ai/code/session_01DrKqpQgkHzDHGqpEMjxYdN)_