### PR TITLE
RUE-1114 prep: classify anonymity by registry membership, not name spelling

### DIFF
--- a/crates/rue-air/src/sema/comptime_eval.rs
+++ b/crates/rue-air/src/sema/comptime_eval.rs
@@ -2150,17 +2150,14 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
         callee_types: &HashMap<Spur, Type>,
         callee_values: &HashMap<Spur, ConstValue>,
     ) {
+        // Membership in the pool's anonymous registry is the classifier, never
+        // the name spelling (RUE-1050): a name-prefix test here silently broke
+        // for enums when the spelling changed to `__anon_enum_…`, and a source
+        // declaration is allowed to spell itself `__anon_struct_…` (RUE-125
+        // reserves only `__rue_*`), so the prefix can also false-positive.
         let is_anon = match ty.kind() {
-            TypeKind::Struct(id) => self
-                .body_type_pool()
-                .struct_def(id)
-                .name
-                .starts_with("__anon_struct_"),
-            TypeKind::Enum(id) => self
-                .body_type_pool()
-                .enum_def(id)
-                .name
-                .starts_with("enum {"),
+            TypeKind::Struct(id) => self.body_type_pool().is_anonymous_struct(id),
+            TypeKind::Enum(id) => self.body_type_pool().is_anonymous_enum(id),
             _ => false,
         };
         if !is_anon || self.has_ctor_type_display(ty) {

--- a/crates/rue-compiler/src/drop_glue.rs
+++ b/crates/rue-compiler/src/drop_glue.rs
@@ -744,10 +744,18 @@ fn create_enum_drop_glue_function(
         callable_kind: rue_air::AnalyzedCallableKind::DropGlue,
         ordinary_owner: None,
         name: fn_name,
-        implicit_drop_source: Some(rue_air::ImplicitDropDependencySourceEvent::NamedEnum {
-            file: enum_def.file_id.index(),
-            name: enum_def.name.to_string(),
-        }),
+        // Membership, not the generated-name prefix (RUE-1050) — mirroring the
+        // struct glue above: an anonymous enum has no source declaration to
+        // depend on, so recording its placeholder `file: 0` and generated name
+        // would capture a dependency on a file that never declared it.
+        implicit_drop_source: if type_pool.is_anonymous_enum(enum_id) {
+            None
+        } else {
+            Some(rue_air::ImplicitDropDependencySourceEvent::NamedEnum {
+                file: enum_def.file_id.index(),
+                name: enum_def.name.to_string(),
+            })
+        },
         air: air
             .finish(AirValidationContext::Canonical(type_pool))
             .map_err(|error| {


### PR DESCRIPTION
Two hygiene fixes from the RUE-1114 name-propagation audit — both places where the generated-name *spelling* still carried meaning after RUE-1050 made the pool's anonymous registry the classifier. Any future collision-continuation scheme (RUE-1114) requires that no consumer infers anonymity from the name, so these are prerequisites; they are also independently correct.

## What changed

- **`record_ctor_type_display` (comptime_eval.rs)**: the "is this anonymous?" gate used name-prefix tests, and the enum arm still tested `starts_with("enum {")` — dead since the spelling became `__anon_enum_{digest}` (RUE-1089), so the epoch producer never recorded RUE-610 constructor displays for anonymous enums. A prefix test can also false-positive: `__anon_struct_...` is a legal source declaration name (RUE-125 reserves only `__rue_*`, and `generated_name_lookalike_declarations.toml` deliberately declares one). Both arms now ask the pool registry (`is_anonymous_struct` / `is_anonymous_enum`).
- **Enum drop-glue synthesizer (drop_glue.rs)**: recorded its `ImplicitDropDependencySourceEvent::NamedEnum` unconditionally, unlike its struct twin — an anonymous enum has no source declaration to depend on, so the event captured a dependency on placeholder `file: 0` plus the full generated name (variant listing included). Now guarded by `is_anonymous_enum`, mirroring the struct arm's RUE-1050 guard.

## Related findings filed separately

- **RUE-1295**: the durable materializer and the type pool disagree on anonymous-enum symbol spelling (bare digest vs digest + variant listing), so a live-to-stable aggregate join can never match for anon enums.
- **RUE-1296**: the production query driver never records RUE-610 displays on the body path at all (verified by instrumentation — `record_ctor_type_display` never fires there), so body-position diagnostics print raw digest names for ctor-produced anonymous types of both kinds; the const/declaration path renders friendly spellings via a different mechanism, which is why the UI corpus never caught it.
- The full continuation design analysis for RUE-1114 (why a rename pass is unsound, the render-time projection shape, and the suggested order RUE-1295 → RUE-1296 → prototype) is a comment on RUE-1114.

## Testing

- `//crates/rue-air:rue-air-test` and `//crates/rue-compiler:rue-compiler-test` green
- UI suite green (232), spec suite green (2283 passed / 15 ignored)
- Differential oracle + CLI suites running at push time; will confirm on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DrKqpQgkHzDHGqpEMjxYdN

---
_Generated by [Claude Code](https://claude.ai/code/session_01DrKqpQgkHzDHGqpEMjxYdN)_