### PR TITLE
RUE-1297: index semantic parameter lookups

### DIFF
--- a/crates/rue-air/src/sema/aggregates.rs
+++ b/crates/rue-air/src/sema/aggregates.rs
@@ -851,7 +851,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
     /// Comptime type variables are intentionally not runtime bindings:
     /// `let O = Option(i32); O.Some(1)` names the type, not a runtime value.
     pub(crate) fn is_runtime_value_binding(&self, name: Spur, ctx: &AnalysisContext) -> bool {
-        ctx.locals.contains_key(&name) || ctx.params.iter().any(|param| param.name == name)
+        ctx.locals.contains_key(&name) || ctx.has_param(name)
     }
 
     /// Resolve the module a reference denotes, if any, without emitting AIR.

--- a/crates/rue-air/src/sema/analysis/builtin_ops.rs
+++ b/crates/rue-air/src/sema/analysis/builtin_ops.rs
@@ -481,7 +481,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
                 if let Some(local) = ctx.locals.get(name) {
                     return Some(local.ty);
                 }
-                ctx.params.iter().find(|p| p.name == *name).map(|p| p.ty)
+                ctx.param(*name).map(|param| param.ty)
             }
             // A `-> borrow T` accessor call is a place of its element type
             // (ADR-0062); any other method call is not a place.

--- a/crates/rue-air/src/sema/analysis/ownership.rs
+++ b/crates/rue-air/src/sema/analysis/ownership.rs
@@ -391,7 +391,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
             // body reads in place.
             return self.place_root_with_accessors(value, ctx).is_some();
         };
-        ctx.locals.contains_key(&root) || ctx.params.iter().any(|param| param.name == root)
+        ctx.locals.contains_key(&root) || ctx.has_param(root)
     }
 
     /// Whether a `borrow` operand qualifies for **static promotion**
@@ -479,7 +479,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
             // constant or a `comptime` parameter has a static image.
             InstData::VarRef { name, .. } => {
                 !ctx.locals.contains_key(name)
-                    && !ctx.params.iter().any(|param| param.name == *name)
+                    && !ctx.has_param(*name)
                     && (self.borrow_operand_is_static_string(operand, ctx)
                         || ctx.comptime_value_vars.contains_key(name)
                         || self
@@ -498,7 +498,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
             InstData::StringConst { .. } => true,
             InstData::VarRef { name, .. } => {
                 !ctx.locals.contains_key(name)
-                    && !ctx.params.iter().any(|param| param.name == *name)
+                    && !ctx.has_param(*name)
                     && self
                         .call_facts()
                         .value_const(self.body_rir_ref().get(operand).span.file_id, *name)
@@ -953,7 +953,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
                 }
 
                 // Otherwise it may be a parameter.
-                if let Some(param_info) = ctx.params.iter().find(|p| p.name == *name) {
+                if let Some(param_info) = ctx.param(*name) {
                     return Ok(Some(PlaceTrace {
                         base: AirPlaceBase::Param(param_info.abi_slot),
                         base_type: param_info.ty,
@@ -1739,7 +1739,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
         // reads (spec 5.1:10, RUE-278). A same-named local can only exist by
         // shadowing, so its presence means "resolve as local" (handled below).
         if !ctx.locals.contains_key(&name) {
-            if let Some(param_info) = ctx.params.iter().find(|p| p.name == name) {
+            if let Some(param_info) = ctx.param(name) {
                 let ty = param_info.ty;
                 let name_str = self.body_interner().resolve(&name);
 
@@ -2131,7 +2131,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
         // Without this guard, `let mut x = x; x = x + 1;` wrongly reports E0203
         // against the immutable parameter with a bogus "make it inout" hint.
         if !ctx.locals.contains_key(&name) {
-            if let Some(param_info) = ctx.params.iter().find(|p| p.name == name) {
+            if let Some(param_info) = ctx.param(name) {
                 // Inout params and `mut self` (a mutable by-value receiver
                 // binding) can be assigned to.
                 match param_info.mode {
@@ -2336,7 +2336,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
         if ctx.locals.contains_key(&root_var) {
             return Ok(());
         }
-        if let Some(param_info) = ctx.params.iter().find(|p| p.name == root_var) {
+        if let Some(param_info) = ctx.param(root_var) {
             match param_info.mode {
                 RirParamMode::Inout => {
                     return Err(move_out_of_inout_error(
@@ -4530,7 +4530,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
         if let Some(local) = ctx.locals.get(&root) {
             return local.is_mut;
         }
-        if let Some(param) = ctx.params.iter().find(|p| p.name == root) {
+        if let Some(param) = ctx.param(root) {
             return param.mode == RirParamMode::Inout || param.is_mut;
         }
         false

--- a/crates/rue-air/src/sema/analysis/type_inference.rs
+++ b/crates/rue-air/src/sema/analysis/type_inference.rs
@@ -605,7 +605,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
             // same-named local, which then wins for all later references
             // (spec 5.1:10, RUE-278); the local is resolved just below.
             if !ctx.locals.contains_key(name) {
-                if let Some(param_info) = ctx.params.iter().find(|p| p.name == *name) {
+                if let Some(param_info) = ctx.param(*name) {
                     let ty = param_info.ty;
 
                     // Check if this parameter has been fully moved

--- a/crates/rue-air/src/sema/comptime_eval.rs
+++ b/crates/rue-air/src/sema/comptime_eval.rs
@@ -54,7 +54,7 @@ use rue_error::{CompileError, CompileResult, ErrorKind};
 use rue_rir::{InstData, InstRef, RepeatCount};
 use rue_span::{FileId, Span};
 
-use super::context::{AnalysisContext, ConstValue, LocalVar, ParamInfo};
+use super::context::{AnalysisContext, ConstValue, LocalVar, ParamIndex, ParamInfo};
 use super::ordinary_engine::{OrdinaryBodyAnalysisHost, OrdinaryBodyEngine};
 
 pub(super) fn validate_comptime_value_for_type_impl(
@@ -150,7 +150,7 @@ pub(crate) struct ComptimeEnv<'a> {
     /// Runtime parameters in scope. They shadow same-named type values and
     /// constants just like locals; comptime parameters resolve through the
     /// substitution maps before this guard is consulted.
-    runtime_params: Option<&'a [ParamInfo]>,
+    runtime_params: Option<(&'a [ParamInfo], &'a ParamIndex)>,
     /// Runtime bindings known only by name during the pre-inference local
     /// type-alias walk. This lightweight lexical view prevents ordinary
     /// parameters and earlier `let` bindings from falling through to global
@@ -252,7 +252,7 @@ impl<'a> ComptimeEnv<'a> {
             value_subst: &ctx.comptime_value_vars,
             resolved_types: Some(ctx.resolved_types),
             runtime_locals: Some(&ctx.locals),
-            runtime_params: Some(ctx.params),
+            runtime_params: Some((ctx.params, ctx.param_index)),
             runtime_binding_names: None,
             locals: HashMap::new(),
             const_module_members: &EMPTY_MODULE_MEMBERS,
@@ -483,7 +483,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
         if let InstData::VarRef { name, .. } = &self.body_rir_ref().get(inst_ref).data {
             // A runtime local of the same name shadows the parameter.
             !ctx.locals.contains_key(name)
-                && ctx.params.iter().any(|p| p.name == *name && p.is_comptime)
+                && ctx.param(*name).is_some_and(|param| param.is_comptime)
         } else {
             false
         }
@@ -1228,8 +1228,8 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
                 // 5. Runtime parameters shadow file-level constants and type
                 //    names. A comptime parameter with a concrete value was
                 //    already handled by the substitution maps above.
-                if let Some(params) = env.runtime_params {
-                    if params.iter().any(|param| param.name == *name) {
+                if let Some((params, param_index)) = env.runtime_params {
+                    if param_index.get(params, *name).is_some() {
                         return Ok(None);
                     }
                 }
@@ -1585,8 +1585,8 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
         {
             return Ok(None);
         }
-        if let Some(params) = env.runtime_params
-            && params.iter().any(|param| param.name == root_name)
+        if let Some((params, param_index)) = env.runtime_params
+            && param_index.get(params, root_name).is_some()
         {
             return Ok(None);
         }
@@ -1665,9 +1665,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
         // A runtime local or parameter of the same name shadows the import, so
         // this is an ordinary field access on a value — the generic help is
         // correct there.
-        if ctx.locals.contains_key(&root_name)
-            || ctx.params.iter().any(|param| param.name == root_name)
-        {
+        if ctx.locals.contains_key(&root_name) || ctx.has_param(root_name) {
             return None;
         }
         // The root must name a module import of the current file for this to be

--- a/crates/rue-air/src/sema/context.rs
+++ b/crates/rue-air/src/sema/context.rs
@@ -424,6 +424,43 @@ pub(crate) struct ParamInfo {
     pub is_mut: bool,
 }
 
+/// Resolves parameter names without making tiny signatures pay for an index.
+///
+/// Most Rue functions have only a handful of parameters, where a flat scan is
+/// cheaper than allocating a map. Larger signatures are the case where the
+/// repeated semantic lookups become quadratic in parameter uses, so they get
+/// one body-scoped index shared by every analysis pass.
+#[derive(Debug)]
+pub(crate) struct ParamIndex {
+    by_name: Option<HashMap<Spur, usize>>,
+}
+
+impl ParamIndex {
+    const LINEAR_LOOKUP_LIMIT: usize = 8;
+
+    pub(crate) fn new(params: &[ParamInfo]) -> Self {
+        let by_name = (params.len() > Self::LINEAR_LOOKUP_LIMIT).then(|| {
+            let mut by_name = HashMap::with_capacity(params.len());
+            for (index, param) in params.iter().enumerate() {
+                let previous = by_name.insert(param.name, index);
+                assert!(
+                    previous.is_none(),
+                    "parameter names are unique before body analysis"
+                );
+            }
+            by_name
+        });
+        Self { by_name }
+    }
+
+    pub(crate) fn get<'a>(&self, params: &'a [ParamInfo], name: Spur) -> Option<&'a ParamInfo> {
+        match &self.by_name {
+            Some(by_name) => by_name.get(&name).map(|index| &params[*index]),
+            None => params.iter().find(|param| param.name == name),
+        }
+    }
+}
+
 /// How a call argument (or method receiver) loans its root variable for the
 /// duration of the call — the two by-ref modes tracked in
 /// [`AnalysisContext::call_loaned_roots`]. Carried in the loan frame so the
@@ -494,6 +531,8 @@ pub(crate) struct AnalysisContext<'a> {
     pub locals: HashMap<Spur, LocalVar>,
     /// Function parameters (immutable reference, shared across the function)
     pub params: &'a [ParamInfo],
+    /// Body-scoped parameter-name index shared by every semantic consumer.
+    pub param_index: &'a ParamIndex,
     /// Next available slot for local variables
     pub next_slot: u32,
     /// How many loops we're nested inside (for break/continue validation)
@@ -773,6 +812,16 @@ impl ScopedContext for AnalysisContext<'_> {
 }
 
 impl<'a> AnalysisContext<'a> {
+    /// Resolve one function parameter through the body's canonical lookup.
+    pub(crate) fn param(&self, name: Spur) -> Option<&'a ParamInfo> {
+        self.param_index.get(self.params, name)
+    }
+
+    /// Whether this body has a function parameter with `name`.
+    pub(crate) fn has_param(&self, name: Spur) -> bool {
+        self.param(name).is_some()
+    }
+
     /// Run one nested analysis with an explicit expected-type context, then
     /// restore the caller's context before returning its result.
     ///
@@ -838,6 +887,7 @@ impl<'a> AnalysisContext<'a> {
             current_file_id: self.current_file_id,
             locals: self.locals.clone(),
             params: self.params,
+            param_index: self.param_index,
             next_slot: self.next_slot,
             loop_depth: self.loop_depth,
             checked_depth: self.checked_depth,
@@ -1162,6 +1212,54 @@ impl ConstValue {
 mod tests {
     use super::*;
     use lasso::ThreadedRodeo;
+
+    fn test_param(name: Spur, abi_slot: u32) -> ParamInfo {
+        ParamInfo {
+            name,
+            abi_slot,
+            ty: Type::I32,
+            mode: RirParamMode::Normal,
+            is_comptime: false,
+            is_mut: false,
+        }
+    }
+
+    #[test]
+    fn small_parameter_signatures_use_flat_lookup() {
+        let interner = ThreadedRodeo::new();
+        let first = interner.get_or_intern("first");
+        let second = interner.get_or_intern("second");
+        let missing = interner.get_or_intern("missing");
+        let params = [test_param(first, 0), test_param(second, 1)];
+        let index = ParamIndex::new(&params);
+
+        assert!(index.by_name.is_none());
+        assert_eq!(
+            index.get(&params, second).map(|param| param.abi_slot),
+            Some(1)
+        );
+        assert!(index.get(&params, missing).is_none());
+    }
+
+    #[test]
+    fn large_parameter_signatures_use_indexed_lookup() {
+        let interner = ThreadedRodeo::new();
+        let params = (0..=ParamIndex::LINEAR_LOOKUP_LIMIT)
+            .map(|slot| {
+                let name = interner.get_or_intern(format!("param_{slot}"));
+                test_param(name, slot as u32)
+            })
+            .collect::<Vec<_>>();
+        let index = ParamIndex::new(&params);
+
+        assert!(index.by_name.is_some());
+        for param in &params {
+            assert_eq!(
+                index.get(&params, param.name).map(|found| found.abi_slot),
+                Some(param.abi_slot)
+            );
+        }
+    }
 
     // =========================================================================
     // VariableMoveState tests

--- a/crates/rue-air/src/sema/ordinary_engine.rs
+++ b/crates/rue-air/src/sema/ordinary_engine.rs
@@ -22,7 +22,7 @@ use super::anon_structs::{
     IssuedCanonicalArguments, IssuedFunctionInstanceKey, IssuedStableProducerId,
 };
 use super::call_resolution::CallResolutionFacts;
-use super::context::{AnalysisContext, ParamInfo};
+use super::context::{AnalysisContext, ParamIndex, ParamInfo};
 use super::fact_mode::BodyAnalysisHost;
 use super::info::{FunctionCallInfo, MethodCallInfo};
 use super::{
@@ -2062,6 +2062,7 @@ impl<'h, H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'h, H> {
                 .map(|p| (p.abi_slot, p.ty))
                 .collect(),
         );
+        let param_index = ParamIndex::new(&param_vec);
 
         // ======================================================================
         // Phase 1-2: Hindley-Milner Type Inference
@@ -2109,6 +2110,7 @@ impl<'h, H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'h, H> {
             current_file_id: self.body_rir_ref().get(body).span.file_id,
             locals: HashMap::new(),
             params: &param_vec,
+            param_index: &param_index,
             next_slot: 0,
             loop_depth: 0,
             checked_depth: 0,

--- a/crates/rue-air/src/sema/tests.rs
+++ b/crates/rue-air/src/sema/tests.rs
@@ -310,6 +310,17 @@ mod tests {
     }
 
     #[test]
+    fn large_signature_parameter_uses_resolve_through_body_analysis() {
+        compile_to_air(
+            "fn sum(a: i32, b: i32, c: i32, d: i32, e: i32, f: i32, g: i32, h: i32, i: i32) -> i32 {\n\
+                 a + b + c + d + e + f + g + h + i\n\
+             }\n\
+             fn main() -> i32 { sum(1, 2, 3, 4, 5, 6, 7, 8, 9) }",
+        )
+        .expect("indexed parameter lookup preserves ordinary body semantics");
+    }
+
+    #[test]
     fn reserved_looking_source_intrinsics_never_select_internal_operations() {
         for (name, args) in [
             ("__rue_iter_len", "0"),


### PR DESCRIPTION
Fixes RUE-1297.

## Summary

- add one canonical body-scoped parameter lookup
- keep flat scans for signatures of eight or fewer parameters
- index larger signatures once and reuse it across inference, ownership, comptime, aggregate, and builtin analysis
- preserve the ordered parameter vector for ABI and drop behavior

## Validation

- `scripts/rue unit air parameter_signatures`
- `scripts/rue unit air large_signature_parameter_uses`
- `scripts/rue quick`