### PR TITLE
RUE-1302: avoid successful field lookup allocations

### DIFF
--- a/crates/rue-air/src/sema/analysis/ownership.rs
+++ b/crates/rue-air/src/sema/analysis/ownership.rs
@@ -2782,16 +2782,16 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
         };
 
         let struct_def = self.body_type_pool().struct_def(struct_id);
-        let field_name_str = self.body_interner().resolve(&field).to_string();
-
-        let (field_index, struct_field) =
-            struct_def.find_field(&field_name_str).ok_or_compile_error(
+        let field_name = self.body_interner().resolve(&field);
+        let Some((field_index, struct_field)) = struct_def.find_field(field_name) else {
+            return Err(CompileError::new(
                 ErrorKind::UnknownField {
                     struct_name: struct_def.name.to_string(),
-                    field_name: field_name_str.clone(),
+                    field_name: field_name.to_string(),
                 },
                 span,
-            )?;
+            ));
+        };
 
         let field_type = struct_field.ty;
 
@@ -3663,16 +3663,16 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
             };
 
             let struct_def = self.body_type_pool().struct_def(struct_id);
-            let field_name_str = self.body_interner().resolve(&field).to_string();
-
-            let (field_index, struct_field) =
-                struct_def.find_field(&field_name_str).ok_or_compile_error(
+            let field_name = self.body_interner().resolve(&field);
+            let Some((field_index, struct_field)) = struct_def.find_field(field_name) else {
+                return Err(CompileError::new(
                     ErrorKind::UnknownField {
                         struct_name: struct_def.name.to_string(),
-                        field_name: field_name_str.clone(),
+                        field_name: field_name.to_string(),
                     },
                     span,
-                )?;
+                ));
+            };
 
             let field_type = struct_field.ty;
 

--- a/crates/rue-air/src/sema/analysis/type_inference.rs
+++ b/crates/rue-air/src/sema/analysis/type_inference.rs
@@ -753,16 +753,16 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
             };
 
             let struct_def = self.body_type_pool().struct_def(struct_id);
-            let field_name_str = self.body_interner().resolve(&field).to_string();
-
-            let (field_index, struct_field) =
-                struct_def.find_field(&field_name_str).ok_or_compile_error(
+            let field_name = self.body_interner().resolve(&field);
+            let Some((field_index, struct_field)) = struct_def.find_field(field_name) else {
+                return Err(CompileError::new(
                     ErrorKind::UnknownField {
                         struct_name: struct_def.name.to_string(),
-                        field_name: field_name_str.clone(),
+                        field_name: field_name.to_string(),
                     },
                     field_span,
-                )?;
+                ));
+            };
 
             let field_type = struct_field.ty;
 

--- a/crates/rue-air/src/sema/consistency_tests.rs
+++ b/crates/rue-air/src/sema/consistency_tests.rs
@@ -1355,6 +1355,34 @@ mod tests {
     }
 
     #[test]
+    fn successful_field_lookup_keeps_the_interned_name_borrowed() {
+        for (file, source) in [
+            ("analysis/type_inference.rs", TYPE_INFERENCE_SOURCE),
+            ("analysis/ownership.rs", OWNERSHIP_SOURCE),
+        ] {
+            assert!(
+                !source.contains("resolve(&field).to_string()"),
+                "{file} eagerly allocates an owned field name before lookup"
+            );
+        }
+
+        assert_eq!(
+            TYPE_INFERENCE_SOURCE
+                .matches("field_name: field_name.to_string()")
+                .count(),
+            1,
+            "type inference must allocate the field name only for its unknown-field diagnostic"
+        );
+        assert_eq!(
+            OWNERSHIP_SOURCE
+                .matches("field_name: field_name.to_string()")
+                .count(),
+            2,
+            "ownership analysis must allocate field names only for its unknown-field diagnostics"
+        );
+    }
+
+    #[test]
     fn aggregate_analysis_has_one_cohesive_owner() {
         for method in [
             "analyze_struct_ops",


### PR DESCRIPTION
Fixes RUE-1302.

## Summary
- keep interned field names borrowed on successful lookup
- allocate owned field and struct names only for unknown-field diagnostics
- add a structural regression covering all three production paths

## Validation
- scripts/rue unit air successful_field_lookup_keeps_the_interned_name_borrowed
- scripts/rue quick