### PR TITLE
RUE-1318: index reusable specialization candidates

### DIFF
--- a/crates/rue-air/src/api_inventory.rs
+++ b/crates/rue-air/src/api_inventory.rs
@@ -14,6 +14,18 @@ fn peer_one_body_authority_cannot_return() {
 }
 
 #[test]
+fn reusable_specialization_candidates_have_one_indexed_first_wins_authority() {
+    let sema = include_str!("sema/mod.rs");
+    let installer = include_str!("sema/binding_manifest.rs");
+    let consumer = include_str!("specialize.rs");
+
+    assert!(sema.contains("reusable_specialized_bodies: HashMap<"));
+    assert!(installer.contains(".entry(identity.clone())\n                    .or_insert_with("));
+    assert!(consumer.contains("reusable_specialized_bodies.remove(&identity)"));
+    assert!(!consumer.contains(".position(|candidate| candidate.identity == identity)"));
+}
+
+#[test]
 fn retired_whole_program_body_driver_is_an_explicit_test_oracle_only() {
     let analysis = include_str!("sema/analysis.rs");
     let manifest = include_str!("sema/binding_manifest.rs");

--- a/crates/rue-air/src/sema/binding_manifest.rs
+++ b/crates/rue-air/src/sema/binding_manifest.rs
@@ -2203,15 +2203,16 @@ impl<'a> BoundSema<'a> {
                 .map(&map_definition)
                 .collect::<Result<Vec<_>, _>>();
             if let (Ok(identity), Ok(body), Ok(dependencies)) = (identity, body, dependencies) {
-                self.sema.reusable_specialized_bodies.push(
-                    crate::SemanticSpecializedBodyCandidate {
+                self.sema
+                    .reusable_specialized_bodies
+                    .entry(identity.clone())
+                    .or_insert_with(|| crate::SemanticSpecializedBodyCandidate {
                         identity,
                         body_span: candidate.body_span,
                         body,
                         dependencies: dependencies.into(),
                         dependency_boundary_complete: candidate.dependency_boundary_complete,
-                    },
-                );
+                    });
                 work.successes += 1;
             } else {
                 work.mapping_failures += 1;

--- a/crates/rue-air/src/sema/mod.rs
+++ b/crates/rue-air/src/sema/mod.rs
@@ -416,7 +416,11 @@ pub struct Sema<'a, D: DeclarationPhase = MutableDeclarations> {
         BodyOwnerToken,
         crate::SemanticBodyCandidate<crate::SemanticDefinitionToken, crate::SemanticModuleToken>,
     >,
-    pub(crate) reusable_specialized_bodies: Vec<
+    pub(crate) reusable_specialized_bodies: HashMap<
+        crate::SemanticSpecializationIdentity<
+            crate::SemanticDefinitionToken,
+            crate::SemanticModuleToken,
+        >,
         crate::SemanticSpecializedBodyCandidate<
             crate::SemanticDefinitionToken,
             crate::SemanticModuleToken,
@@ -1216,7 +1220,7 @@ impl<'a> Sema<'a, MutableDeclarations> {
             ordinary_body_exports: Vec::new(),
             specialized_body_exports: Vec::new(),
             reusable_ordinary_bodies: HashMap::new(),
-            reusable_specialized_bodies: Vec::new(),
+            reusable_specialized_bodies: HashMap::new(),
             stable_definition_tokens: Arc::default(),
             stable_definition_endpoints: Arc::default(),
             const_candidate_tokens: Arc::default(),

--- a/crates/rue-air/src/specialize.rs
+++ b/crates/rue-air/src/specialize.rs
@@ -185,11 +185,7 @@ impl Specializer {
         >,
     > {
         let identity = Self::stable_identity(key, sema).ok()?;
-        let index = sema
-            .reusable_specialized_bodies
-            .iter()
-            .position(|candidate| candidate.identity == identity)?;
-        Some(sema.reusable_specialized_bodies.remove(index))
+        sema.reusable_specialized_bodies.remove(&identity)
     }
 
     /// Analyze and rewrite every specialization reachable from newly appended


### PR DESCRIPTION
Fixes RUE-1318.

## Summary
- store retained specialization candidates by stable identity
- consume each candidate with direct map removal instead of a linear scan plus vector shift
- preserve first-installed behavior for duplicate identities

## Validation
- `scripts/rue unit air specialization`
- `scripts/rue unit air reusable_specialization_candidates_have_one_indexed_first_wins_authority`
- `scripts/rue unit compiler specialized_reuse_survives_relocation_file_ids_and_input_order`
- `scripts/rue unit compiler nested_specialized_bodies_reuse_and_close_over_changed_callees`