### PR TITLE
RUE-1319: index declaration type dependency admission

### DIFF
--- a/crates/rue-air/src/api_inventory.rs
+++ b/crates/rue-air/src/api_inventory.rs
@@ -26,6 +26,28 @@ fn reusable_specialization_candidates_have_one_indexed_first_wins_authority() {
 }
 
 #[test]
+fn declaration_type_dependency_admission_is_deterministic_and_subquadratic() {
+    let sema = include_str!("sema/mod.rs");
+    let typeck = include_str!("sema/typeck.rs");
+    let declarations = include_str!("sema/declarations.rs");
+    let installer = include_str!("sema/binding_manifest.rs");
+    let output = include_str!("sema/analysis.rs");
+
+    assert!(
+        sema.contains("declaration_type_dependency_index: HashSet<DeclarationTypeDependencyEvent>")
+    );
+    assert!(typeck.contains("declaration_type_dependency_index.insert(event.clone())"));
+    assert!(!typeck.contains("declaration_type_dependencies.contains(&event)"));
+    assert!(declarations.contains("declaration_type_dependency_index.insert(event.clone())"));
+    assert!(
+        installer
+            .contains(".declaration_type_dependency_index\n                .insert(event.clone())")
+    );
+    assert!(output.contains("sema.declaration_type_dependencies.sort()"));
+    assert!(output.contains("baseline_declaration_type_dependency_index"));
+}
+
+#[test]
 fn retired_whole_program_body_driver_is_an_explicit_test_oracle_only() {
     let analysis = include_str!("sema/analysis.rs");
     let manifest = include_str!("sema/binding_manifest.rs");

--- a/crates/rue-air/src/sema/analysis.rs
+++ b/crates/rue-air/src/sema/analysis.rs
@@ -1628,6 +1628,7 @@ fn analyze_function_bodies_lazy(sema: &mut BodySema<'_>) -> MultiErrorResult<Sem
     let baseline_specialized_body_exports = sema.specialized_body_exports.clone();
     let baseline_body_named_dependencies = sema.body_named_dependencies.clone();
     let baseline_declaration_type_dependencies = sema.declaration_type_dependencies.clone();
+    let baseline_declaration_type_dependency_index = sema.declaration_type_dependency_index.clone();
     let baseline_declaration_type_call_head_dependencies =
         sema.declaration_type_call_head_dependencies.clone();
     let baseline_declaration_builtin_type_call_head_dependencies =
@@ -1646,6 +1647,7 @@ fn analyze_function_bodies_lazy(sema: &mut BodySema<'_>) -> MultiErrorResult<Sem
         sema.specialized_body_exports = baseline_specialized_body_exports.clone();
         sema.body_named_dependencies = baseline_body_named_dependencies.clone();
         sema.declaration_type_dependencies = baseline_declaration_type_dependencies.clone();
+        sema.declaration_type_dependency_index = baseline_declaration_type_dependency_index.clone();
         sema.declaration_type_call_head_dependencies =
             baseline_declaration_type_call_head_dependencies.clone();
         sema.declaration_builtin_type_call_head_dependencies =

--- a/crates/rue-air/src/sema/binding_manifest.rs
+++ b/crates/rue-air/src/sema/binding_manifest.rs
@@ -2117,9 +2117,15 @@ impl<'a> BoundSema<'a> {
         builtin_type_call_heads: &[crate::DeclarationBuiltinTypeCallHeadDependencyEvent],
         named_const_dependencies: &[crate::NamedConstDependencyEvent],
     ) -> Self {
-        self.sema
-            .declaration_type_dependencies
-            .extend_from_slice(type_dependencies);
+        for event in type_dependencies {
+            if self
+                .sema
+                .declaration_type_dependency_index
+                .insert(event.clone())
+            {
+                self.sema.declaration_type_dependencies.push(event.clone());
+            }
+        }
         self.sema
             .declaration_type_call_head_dependencies
             .extend_from_slice(type_call_heads);

--- a/crates/rue-air/src/sema/declarations.rs
+++ b/crates/rue-air/src/sema/declarations.rs
@@ -704,21 +704,23 @@ impl<'a> Sema<'a, super::MutableDeclarations> {
             _ => None,
         };
         if let Some((target_file, target_name, target_kind)) = target {
-            self.declaration_type_dependencies
-                .push(super::DeclarationTypeDependencyEvent {
-                    source_token: self
-                        .body_dependency_observer
-                        .as_ref()
-                        .and_then(super::AnalyzedBodyOwnerEvent::token),
-                    source_file: source_file.index(),
-                    source_name,
-                    source_owner_name,
-                    source_kind,
-                    dependency_kind,
-                    target_file: target_file.index(),
-                    target_name: target_name.to_string(),
-                    target_kind,
-                });
+            let event = super::DeclarationTypeDependencyEvent {
+                source_token: self
+                    .body_dependency_observer
+                    .as_ref()
+                    .and_then(super::AnalyzedBodyOwnerEvent::token),
+                source_file: source_file.index(),
+                source_name,
+                source_owner_name,
+                source_kind,
+                dependency_kind,
+                target_file: target_file.index(),
+                target_name: target_name.to_string(),
+                target_kind,
+            };
+            if self.declaration_type_dependency_index.insert(event.clone()) {
+                self.declaration_type_dependencies.push(event);
+            }
             self.body_analysis_work.declaration_type_dependency_events += 1;
         }
     }

--- a/crates/rue-air/src/sema/mod.rs
+++ b/crates/rue-air/src/sema/mod.rs
@@ -466,7 +466,13 @@ pub struct Sema<'a, D: DeclarationPhase = MutableDeclarations> {
         AnalyzedBodyOwnerEvent,
         crate::FunctionInstanceKey<crate::SemanticDefinitionToken, crate::SemanticModuleToken>,
     )>,
+    /// Insertion-ordered dependency log. Specialization export consumes the
+    /// suffix appended by one analysis, while final output sorts it.
     pub(crate) declaration_type_dependencies: Vec<DeclarationTypeDependencyEvent>,
+    /// Exact membership authority for the log above. Keep both in sync at the
+    /// three admission boundaries; the index avoids a growing-vector scan
+    /// without sacrificing suffix-based specialization capture.
+    pub(crate) declaration_type_dependency_index: HashSet<DeclarationTypeDependencyEvent>,
     pub(crate) declaration_type_call_head_dependencies: Vec<DeclarationTypeCallHeadDependencyEvent>,
     pub(crate) declaration_builtin_type_call_head_dependencies:
         Vec<DeclarationBuiltinTypeCallHeadDependencyEvent>,
@@ -684,6 +690,7 @@ impl<'a, D: DeclarationPhase> Sema<'a, D> {
             body_callable_dependencies,
             body_specialization_dependencies,
             declaration_type_dependencies,
+            declaration_type_dependency_index,
             declaration_type_call_head_dependencies,
             declaration_builtin_type_call_head_dependencies,
             named_const_dependencies,
@@ -761,6 +768,7 @@ impl<'a, D: DeclarationPhase> Sema<'a, D> {
             body_callable_dependencies,
             body_specialization_dependencies,
             declaration_type_dependencies,
+            declaration_type_dependency_index,
             declaration_type_call_head_dependencies,
             declaration_builtin_type_call_head_dependencies,
             named_const_dependencies,
@@ -1238,6 +1246,7 @@ impl<'a> Sema<'a, MutableDeclarations> {
             body_callable_dependencies: Vec::new(),
             body_specialization_dependencies: Vec::new(),
             declaration_type_dependencies: Vec::new(),
+            declaration_type_dependency_index: HashSet::new(),
             declaration_type_call_head_dependencies: Vec::new(),
             declaration_builtin_type_call_head_dependencies: Vec::new(),
             named_const_dependencies: Vec::new(),

--- a/crates/rue-air/src/sema/typeck.rs
+++ b/crates/rue-air/src/sema/typeck.rs
@@ -2791,11 +2791,10 @@ impl<'a, D: DeclarationPhase> Sema<'a, D> {
             target_name,
             target_kind,
         };
-        if self.declaration_type_dependencies.contains(&event) {
-            return;
+        if self.declaration_type_dependency_index.insert(event.clone()) {
+            self.declaration_type_dependencies.push(event);
+            self.body_analysis_work.declaration_type_dependency_events += 1;
         }
-        self.declaration_type_dependencies.push(event);
-        self.body_analysis_work.declaration_type_dependency_events += 1;
     }
 
     /// Resolve a type-annotation symbol to a `Type`, consulting the analysis


### PR DESCRIPTION
Fixes RUE-1319.

## Summary
- add one exact membership index beside the insertion-ordered declaration-type dependency log
- route declaration, query-install, and body type-check admission through the index
- preserve specialization suffix capture, retry restoration, deterministic output, and work-counter semantics

## Validation
- `scripts/rue unit air declaration_type_dependency_admission_is_deterministic_and_subquadratic`
- `scripts/rue unit air shared_type_syntax_observes_each_nominal_dependency_once_at_every_depth`
- `scripts/rue unit air selected_alias_observes_the_alias_and_its_nominal_result_once_each`
- `scripts/rue unit air substituted_signature_wrappers_emit_one_stable_edge_per_body`