### PR TITLE
RUE-1320: index deferred generic signature lookup

### DIFF
--- a/crates/rue-air/src/api_inventory.rs
+++ b/crates/rue-air/src/api_inventory.rs
@@ -48,6 +48,16 @@ fn declaration_type_dependency_admission_is_deterministic_and_subquadratic() {
 }
 
 #[test]
+fn deferred_generic_signature_lookup_has_one_first_wins_index() {
+    let manifest = include_str!("sema/binding_manifest.rs");
+
+    assert!(manifest.contains("let mut generic_name_indices = HashMap::new()"));
+    assert!(manifest.contains(".entry(param.name)\n                .or_insert(index as u32)"));
+    assert!(manifest.contains(".and_then(|name| generic_name_indices.get(&name))"));
+    assert!(!manifest.contains(".position(|name| self.interner.resolve(name) == syntax)"));
+}
+
+#[test]
 fn retired_whole_program_body_driver_is_an_explicit_test_oracle_only() {
     let analysis = include_str!("sema/analysis.rs");
     let manifest = include_str!("sema/binding_manifest.rs");

--- a/crates/rue-air/src/sema/binding_manifest.rs
+++ b/crates/rue-air/src/sema/binding_manifest.rs
@@ -3329,16 +3329,27 @@ impl<'a, D: super::DeclarationPhase> Sema<'a, D> {
     ) -> Result<(Arc<[SemanticExportParameter]>, SemanticExportType), SemanticExportFailure> {
         let rir_params = self.rir.params(rir_params);
         let type_name = self.interner.get("type");
-        let generic_names = rir_params
+        // Deferred signature syntax can mention the same generic parameter in
+        // many nested positions. Index the filtered parameter ordinals once so
+        // each syntax leaf does one interner lookup and one map lookup instead
+        // of rescanning and resolving every preceding generic name. `entry`
+        // preserves the old `position` behavior if malformed input somehow
+        // presents duplicate names: the first filtered ordinal wins.
+        let mut generic_name_indices = HashMap::new();
+        for (index, param) in rir_params
             .iter()
             .filter(|param| param.is_comptime && Some(param.ty) == type_name)
-            .map(|param| param.name)
-            .collect::<Vec<_>>();
+            .enumerate()
+        {
+            generic_name_indices
+                .entry(param.name)
+                .or_insert(index as u32);
+        }
         let convert = |ty: Type, symbol: Spur| {
             if ty == Type::COMPTIME_TYPE {
                 let syntax = self.interner.resolve(&symbol);
                 if syntax != "type" {
-                    return self.export_deferred_signature_type(syntax, &generic_names);
+                    return self.export_deferred_signature_type(syntax, &generic_name_indices);
                 }
             }
             self.export_type(ty, &mut Vec::new())
@@ -3372,25 +3383,29 @@ impl<'a, D: super::DeclarationPhase> Sema<'a, D> {
     fn export_deferred_signature_type(
         &self,
         syntax: &str,
-        generic_names: &[Spur],
+        generic_name_indices: &HashMap<Spur, u32>,
     ) -> Result<SemanticExportType, SemanticExportFailure> {
-        if let Some(index) = generic_names
-            .iter()
-            .position(|name| self.interner.resolve(name) == syntax)
+        if let Some(index) = self
+            .interner
+            .get(syntax)
+            .and_then(|name| generic_name_indices.get(&name))
         {
-            return Ok(SemanticExportType::GenericParameter(index as u32));
+            return Ok(SemanticExportType::GenericParameter(*index));
         }
         if let Some((element, len)) = parse_array_type_syntax(syntax) {
             let ArrayLen::Literal(len) = len else {
                 return Err(SemanticExportFailure::UnsupportedGenericSignature);
             };
             return Ok(SemanticExportType::Array {
-                element: Box::new(self.export_deferred_signature_type(&element, generic_names)?),
+                element: Box::new(
+                    self.export_deferred_signature_type(&element, generic_name_indices)?,
+                ),
                 len,
             });
         }
         if let Some((pointee, mutability)) = parse_pointer_type_syntax(syntax) {
-            let pointee = Box::new(self.export_deferred_signature_type(&pointee, generic_names)?);
+            let pointee =
+                Box::new(self.export_deferred_signature_type(&pointee, generic_name_indices)?);
             return Ok(match mutability {
                 PtrMutability::Const => SemanticExportType::PtrConst(pointee),
                 PtrMutability::Mut => SemanticExportType::PtrMut(pointee),


### PR DESCRIPTION
Fixes RUE-1320.

## Summary
- index comptime type-parameter ordinals once per callable signature
- resolve each deferred syntax leaf once and use direct map lookup
- preserve first-wins ordinals and recursive array/pointer signature export

## Validation
- `scripts/rue unit air deferred_generic_signature_lookup_has_one_first_wins_index`
- `scripts/rue unit air declaration_export_is_resolved_owned_lazy_and_rir_free`