### PR TITLE
RUE-1321: index observed type dependency admission

### DIFF
--- a/crates/rue-air/src/api_inventory.rs
+++ b/crates/rue-air/src/api_inventory.rs
@@ -58,6 +58,19 @@ fn deferred_generic_signature_lookup_has_one_first_wins_index() {
 }
 
 #[test]
+fn type_syntax_dependency_admission_indexes_only_the_large_case() {
+    let typeck = include_str!("sema/typeck.rs");
+
+    assert!(
+        typeck.contains("observed_type_dependency_index: Option<HashSet<ObservedTypeDependency>>")
+    );
+    assert!(typeck.contains("const LINEAR_ADMISSION_LIMIT: usize = 8"));
+    assert!(typeck.contains("if index.insert(dependency.clone())"));
+    assert!(typeck.contains("index.clear()"));
+    assert!(typeck.contains(".len() == LINEAR_ADMISSION_LIMIT"));
+}
+
+#[test]
 fn retired_whole_program_body_driver_is_an_explicit_test_oracle_only() {
     let analysis = include_str!("sema/analysis.rs");
     let manifest = include_str!("sema/binding_manifest.rs");

--- a/crates/rue-air/src/sema/tests.rs
+++ b/crates/rue-air/src/sema/tests.rs
@@ -3587,6 +3587,46 @@ fn main() -> i32 {
     }
 
     #[test]
+    fn large_type_syntax_dependency_batch_preserves_order_and_uniqueness() {
+        let output = compile_to_air(
+            "struct S0 { value: i32 }
+             struct S1 { value: i32 }
+             struct S2 { value: i32 }
+             struct S3 { value: i32 }
+             struct S4 { value: i32 }
+             struct S5 { value: i32 }
+             struct S6 { value: i32 }
+             struct S7 { value: i32 }
+             struct S8 { value: i32 }
+             fn Bundle(
+                 comptime T0: type, comptime T1: type, comptime T2: type,
+                 comptime T3: type, comptime T4: type, comptime T5: type,
+                 comptime T6: type, comptime T7: type, comptime T8: type,
+             ) -> type {
+                 struct {
+                     f0: T0, f1: T1, f2: T2, f3: T3, f4: T4,
+                     f5: T5, f6: T6, f7: T7, f8: T8,
+                 }
+             }
+             fn main() -> i32 {
+                 @intCast(@size_of(Bundle(S0, S1, S2, S3, S4, S5, S6, S7, S8)))
+             }",
+        )
+        .unwrap();
+        let dependencies = output
+            .declaration_type_dependencies
+            .iter()
+            .filter(|event| event.source_name == "main")
+            .map(|event| event.target_name.as_str())
+            .collect::<Vec<_>>();
+
+        assert_eq!(
+            dependencies,
+            ["S0", "S1", "S2", "S3", "S4", "S5", "S6", "S7", "S8"]
+        );
+    }
+
+    #[test]
     fn selected_alias_observes_the_alias_and_its_nominal_result_once_each() {
         let output = compile_to_air(
             "struct Leaf { value: i32 }

--- a/crates/rue-air/src/sema/typeck.rs
+++ b/crates/rue-air/src/sema/typeck.rs
@@ -7,7 +7,7 @@
 //! - Type conversions between AIR types and inference types
 
 use super::ordinary_engine::{OrdinaryBodyAnalysisHost, OrdinaryBodyEngine};
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::convert::Infallible;
 use std::sync::Arc;
 
@@ -174,6 +174,8 @@ pub(super) enum TypeSyntaxNamedKind {
     Alias,
 }
 
+type ObservedTypeDependency = (FileId, String, super::DeclarationTypeDependencyTargetKind);
+
 pub(super) struct TypeSyntaxProvider<'host, 'c, H: TypeSyntaxHost> {
     host: &'host mut H,
     span: Span,
@@ -181,7 +183,10 @@ pub(super) struct TypeSyntaxProvider<'host, 'c, H: TypeSyntaxHost> {
     resolution_context: SemaTypeResolutionContext,
     type_substitutions: Option<&'c HashMap<Spur, Type>>,
     value_substitutions: Option<&'c HashMap<Spur, ConstValue>>,
-    observed_type_dependencies: Vec<(FileId, String, super::DeclarationTypeDependencyTargetKind)>,
+    // Preserve observation order for the host while using a lazy membership
+    // index once a resolution grows beyond the allocation-free small case.
+    observed_type_dependencies: Vec<ObservedTypeDependency>,
+    observed_type_dependency_index: Option<HashSet<ObservedTypeDependency>>,
 }
 
 /// The lexical root a type-syntax resolution walks from.
@@ -583,6 +588,7 @@ impl<'s, 'c, H: TypeSyntaxHost> TypeSyntaxProvider<'s, 'c, H> {
             type_substitutions,
             value_substitutions,
             observed_type_dependencies: Vec::new(),
+            observed_type_dependency_index: None,
         }
     }
 
@@ -741,6 +747,9 @@ impl<'s, 'c, H: TypeSyntaxHost> TypeSyntaxProvider<'s, 'c, H> {
     }
 
     pub(super) fn flush_observed_type_dependencies(&mut self) {
+        if let Some(index) = &mut self.observed_type_dependency_index {
+            index.clear();
+        }
         for (file, name, kind) in std::mem::take(&mut self.observed_type_dependencies) {
             self.host.type_syntax_flush_dependency(file, name, kind);
         }
@@ -752,9 +761,21 @@ impl<'s, 'c, H: TypeSyntaxHost> TypeSyntaxProvider<'s, 'c, H> {
         name: String,
         kind: super::DeclarationTypeDependencyTargetKind,
     ) {
+        const LINEAR_ADMISSION_LIMIT: usize = 8;
+
         let dependency = (file, name, kind);
+        if let Some(index) = &mut self.observed_type_dependency_index {
+            if index.insert(dependency.clone()) {
+                self.observed_type_dependencies.push(dependency);
+            }
+            return;
+        }
         if !self.observed_type_dependencies.contains(&dependency) {
             self.observed_type_dependencies.push(dependency);
+            if self.observed_type_dependencies.len() == LINEAR_ADMISSION_LIMIT {
+                self.observed_type_dependency_index =
+                    Some(self.observed_type_dependencies.iter().cloned().collect());
+            }
         }
     }
 


### PR DESCRIPTION
Fixes RUE-1321.

## Summary
- keep insertion-ordered per-resolution type dependencies for unchanged host behavior
- lazily add a membership index after the seven-entry allocation-free small case
- clear the index with each flush while retaining capacity for providers that already demonstrated large batches
- cover the indexed path with a nine-dependency generic type-syntax case

## Validation
- `scripts/rue unit air type_syntax_dependency_admission_indexes_only_the_large_case`
- `scripts/rue unit air shared_type_syntax_observes_each_nominal_dependency_once_at_every_depth`
- `scripts/rue unit air selected_alias_observes_the_alias_and_its_nominal_result_once_each`
- `scripts/rue unit air large_type_syntax_dependency_batch_preserves_order_and_uniqueness`