### PR TITLE
Overnight cycle 1: ZST addresses, CFG compaction, unified allocator ABI, JSON diagnostics audit, spec reconciliation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -370,3 +370,8 @@ PR into `trunk`.
 - Rue uses `tracing` with wide events: one pass span, one structured completion
   event, key-value fields, and negligible cost without a subscriber. See
   `docs/process/logging.md`.
+- Program diagnostics are a separate, versioned surface from logging.
+  `--error-format json` publishes them as structured JSON on stderr; the schema
+  and its ICE/ordering guarantees are in `docs/process/diagnostics.md`. Changing
+  a JSON field there is a consumer-visible break — update the doc and the
+  `json_diagnostics` CLI cases in the same change.

--- a/cli-test-fixtures/cross_runtime_smoke.rue
+++ b/cli-test-fixtures/cross_runtime_smoke.rue
@@ -7,11 +7,16 @@ fn main() -> i32 {
     text.push_str(" matrix");
     println(text);
     checked {
-        let values: ptr mut i32 = @alloc(2);
+        // Typed allocation is source-computed over the byte allocator
+        // (ADR-0059 Phase 3, RUE-961), the same shape std/rawbuf.rue uses.
+        let bytes: u64 = 2 * @intCast(@size_of(i32));
+        let align: u64 = @intCast(@align_of(i32));
+        let block: ptr mut u8 = @alloc(bytes, align);
+        let values: ptr mut i32 = @int_to_ptr(@ptr_to_int(block));
         @ptr_write(values, 19);
         @ptr_write(@ptr_offset(values, 1), 23);
         let result = @ptr_read(values) + @ptr_read(@ptr_offset(values, 1));
-        @free(values, 2);
+        @free(block, bytes, align);
         result
     }
 }

--- a/crates/rue-air/src/inference/generate.rs
+++ b/crates/rue-air/src/inference/generate.rs
@@ -1892,25 +1892,11 @@ impl<'a> ConstraintGenerator<'a> {
                     }
                     let result_var = self.fresh_var();
                     InferType::Var(result_var)
-                } else if intrinsic_name == "alloc" {
-                    // @alloc(count: u64) -> ptr mut T. The element type T (and
-                    // thus the result pointer type) is inferred from context,
-                    // exactly like @int_to_ptr; sema validates it is `ptr mut T`.
-                    // Constrain `count` to u64 so a bare integer literal
-                    // (`@alloc(4)`) defaults to u64 rather than i64.
-                    for arg_ref in args.iter() {
-                        let info = self.generate(*arg_ref, ctx);
-                        self.add_constraint(Constraint::equal(
-                            info.ty,
-                            InferType::Concrete(Type::U64),
-                            info.span,
-                        ));
-                    }
-                    let result_var = self.fresh_var();
-                    InferType::Var(result_var)
-                } else if intrinsic_name == "alloc_bytes" {
-                    // @alloc_bytes(size: u64, align: u64) -> ptr mut u8. Both
-                    // operands are u64 (ADR-0059 Phase 2, RUE-960).
+                } else if intrinsic_name == "alloc" || intrinsic_name == "alloc_zeroed" {
+                    // @alloc(size: u64, align: u64) -> ptr mut u8 and its
+                    // zeroing twin (ADR-0059 Phase 3, RUE-961/RUE-968). Both
+                    // operands are physical byte counts, so both are u64 and
+                    // the result type is fixed rather than context-inferred.
                     for arg_ref in args.iter() {
                         let info = self.generate(*arg_ref, ctx);
                         self.add_constraint(Constraint::equal(
@@ -1922,33 +1908,11 @@ impl<'a> ConstraintGenerator<'a> {
                     InferType::Concrete(Type::new_ptr_mut(
                         self.type_pool.intern_ptr_mut_from_type(Type::U8),
                     ))
-                } else if intrinsic_name == "realloc" {
-                    // @realloc(ptr: ptr mut T, old_count: u64, new_count: u64)
-                    // -> ptr mut T. The result type is the same pointer type as
-                    // the first argument; unify a fresh var with arg0's type so
-                    // it flows in both directions. Counts are constrained to u64.
-                    let mut first_ty: Option<InferType> = None;
-                    for (i, arg_ref) in args.iter().enumerate() {
-                        let info = self.generate(*arg_ref, ctx);
-                        if i == 0 {
-                            first_ty = Some(info.ty);
-                        } else {
-                            self.add_constraint(Constraint::equal(
-                                info.ty,
-                                InferType::Concrete(Type::U64),
-                                info.span,
-                            ));
-                        }
-                    }
-                    let result_var = self.fresh_var();
-                    let result_ty = InferType::Var(result_var);
-                    if let Some(arg0_ty) = first_ty {
-                        self.add_constraint(Constraint::equal(result_ty.clone(), arg0_ty, span));
-                    }
-                    result_ty
-                } else if intrinsic_name == "realloc_bytes" {
-                    // @realloc_bytes(ptr mut u8, u64, u64, u64) -> ptr mut u8:
-                    // (p, old_size, align, new_size) (ADR-0059 Phase 2).
+                } else if intrinsic_name == "realloc" || intrinsic_name == "resize" {
+                    // @realloc(p, old_size, align, new_size) -> ptr mut u8 and
+                    // @resize(p, old_size, align, new_size) -> bool share one
+                    // operand shape: a `ptr mut u8` block plus three u64 byte
+                    // counts (ADR-0059 Phase 3, RUE-961/RUE-968).
                     let ptr_ty =
                         Type::new_ptr_mut(self.type_pool.intern_ptr_mut_from_type(Type::U8));
                     for (i, arg_ref) in args.iter().enumerate() {
@@ -1960,22 +1924,13 @@ impl<'a> ConstraintGenerator<'a> {
                             info.span,
                         ));
                     }
-                    InferType::Concrete(ptr_ty)
+                    InferType::Concrete(if intrinsic_name == "resize" {
+                        Type::BOOL
+                    } else {
+                        ptr_ty
+                    })
                 } else if intrinsic_name == "free" {
-                    // @free(ptr: ptr mut T, count: u64) -> (). Constrain the
-                    // `count` (second) argument to u64.
-                    for (i, arg_ref) in args.iter().enumerate() {
-                        let info = self.generate(*arg_ref, ctx);
-                        if i == 1 {
-                            self.add_constraint(Constraint::equal(
-                                info.ty,
-                                InferType::Concrete(Type::U64),
-                                info.span,
-                            ));
-                        }
-                    }
-                    InferType::Concrete(Type::UNIT)
-                } else if intrinsic_name == "free_bytes" {
+                    // @free(p: ptr mut u8, size: u64, align: u64) -> ().
                     let ptr_ty =
                         Type::new_ptr_mut(self.type_pool.intern_ptr_mut_from_type(Type::U8));
                     for (i, arg_ref) in args.iter().enumerate() {
@@ -2020,11 +1975,14 @@ impl<'a> ConstraintGenerator<'a> {
                         }
                     }
                     InferType::Concrete(Type::UNIT)
-                } else if intrinsic_name == "byte_copy" {
-                    // @byte_copy(dst: ptr mut u8, src: ptr const u8 | ptr mut u8,
-                    // size: u64) -> (). Constrain dst to `ptr mut u8` and size to
-                    // u64; the source pointer may be const or mut u8, so it is
-                    // left to sema's `require_u8_pointer` rather than pinned here.
+                } else if intrinsic_name == "byte_copy" || intrinsic_name == "byte_move" {
+                    // @byte_copy/@byte_move(dst: ptr mut u8,
+                    // src: ptr const u8 | ptr mut u8, size: u64) -> (). Constrain
+                    // dst to `ptr mut u8` and size to u64; the source pointer may
+                    // be const or mut u8, so it is left to sema's
+                    // `require_u8_pointer` rather than pinned here. The two
+                    // differ only in their overlap contract (RUE-964), which
+                    // inference does not see.
                     let ptr_ty =
                         Type::new_ptr_mut(self.type_pool.intern_ptr_mut_from_type(Type::U8));
                     for (i, arg_ref) in args.iter().enumerate() {

--- a/crates/rue-air/src/runtime_call.rs
+++ b/crates/rue-air/src/runtime_call.rs
@@ -21,21 +21,14 @@ pub enum RuntimeOperandOrigin {
         source: RuntimeAirType,
     },
     /// A `ptr const u8` / `ptr mut u8` argument passed straight through to a
-    /// `const u8*` runtime parameter (the `@byte_copy` source, ADR-0058).
+    /// `const u8*` runtime parameter (the `@byte_copy`/`@byte_move` source,
+    /// ADR-0059).
     BytePointerArgument(u8),
     TextPointer(u8),
     TextLength(u8),
     ProjectedTextPointer(u8),
     ProjectedTextLength(u8),
-    ResultPointeeAlign,
-    ScaledByResultPointeeSize(u8),
-    PointerPointeeAlign(u8),
-    ScaledByPointerPointeeSize {
-        pointer: u8,
-        count: u8,
-    },
     OptionDiscriminant(OptionVariant),
-    ByteAlignment,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
@@ -88,14 +81,7 @@ impl RuntimeOperandOrigin {
             Self::TextPointer(_) | Self::ProjectedTextPointer(_) | Self::BytePointerArgument(_) => {
                 parameter.ty == AbiType::Byte && parameter.mode == ParameterMode::ConstPointer
             }
-            Self::TextLength(_)
-            | Self::ProjectedTextLength(_)
-            | Self::ResultPointeeAlign
-            | Self::ScaledByResultPointeeSize(_)
-            | Self::PointerPointeeAlign(_)
-            | Self::ScaledByPointerPointeeSize { .. }
-            | Self::OptionDiscriminant(_)
-            | Self::ByteAlignment => {
+            Self::TextLength(_) | Self::ProjectedTextLength(_) | Self::OptionDiscriminant(_) => {
                 parameter.ty == AbiType::U64 && parameter.mode == ParameterMode::Value
             }
             Self::ValueArgument { ty, .. } => {
@@ -145,12 +131,11 @@ pub enum RuntimeCallKind {
     ParseU64,
     RandomU32,
     RandomU64,
-    AllocTyped,
-    FreeTyped,
-    ReallocTyped,
-    AllocBytes,
-    FreeBytes,
-    ReallocBytes,
+    Alloc,
+    AllocZeroed,
+    Free,
+    Realloc,
+    Resize,
     ArgCount,
     ArgPtr,
     ArgLen,
@@ -158,6 +143,7 @@ pub enum RuntimeCallKind {
     EnvPtr,
     EnvLen,
     ByteCopy,
+    ByteMove,
     ByteSet,
 }
 
@@ -212,43 +198,16 @@ const PARSE: &[RuntimeOperandOrigin] = &[
     RuntimeOperandOrigin::OptionDiscriminant(OptionVariant::Some),
     RuntimeOperandOrigin::OptionDiscriminant(OptionVariant::None),
 ];
-const ALLOC_TYPED: &[RuntimeOperandOrigin] = &[
-    RuntimeOperandOrigin::ScaledByResultPointeeSize(0),
-    RuntimeOperandOrigin::ResultPointeeAlign,
-];
-const FREE_TYPED: &[RuntimeOperandOrigin] = &[
-    RuntimeOperandOrigin::MutablePointerArgument {
-        index: 0,
-        source: RuntimeAirType::MutPointer,
-    },
-    RuntimeOperandOrigin::ScaledByPointerPointeeSize {
-        pointer: 0,
-        count: 1,
-    },
-    RuntimeOperandOrigin::PointerPointeeAlign(0),
-];
-const REALLOC_TYPED: &[RuntimeOperandOrigin] = &[
-    RuntimeOperandOrigin::MutablePointerArgument {
-        index: 0,
-        source: RuntimeAirType::MutPointer,
-    },
-    RuntimeOperandOrigin::ScaledByPointerPointeeSize {
-        pointer: 0,
-        count: 1,
-    },
-    RuntimeOperandOrigin::ScaledByPointerPointeeSize {
-        pointer: 0,
-        count: 2,
-    },
-    RuntimeOperandOrigin::PointerPointeeAlign(0),
-];
-const ALLOC_BYTES: &[RuntimeOperandOrigin] = &[
+// The unified allocation family is byte-shaped end to end (ADR-0059 Phase 3,
+// RUE-961): `@alloc(size, align)` and `@alloc_zeroed(size, align)` hand their
+// two `u64` operands straight to the runtime helper, so no operand is derived
+// from a pointee type. Typed allocation is source-computed sugar over
+// `@size_of`/`@align_of` and never reaches this table.
+const ALLOC: &[RuntimeOperandOrigin] = &[
     RuntimeOperandOrigin::ValueArgument {
         index: 0,
         ty: AbiType::U64,
     },
-    // Explicit alignment argument (ADR-0059 Phase 2, RUE-960): sourced from the
-    // intrinsic's `align` operand rather than a synthesized `ByteAlignment`.
     RuntimeOperandOrigin::ValueArgument {
         index: 1,
         ty: AbiType::U64,
@@ -261,7 +220,9 @@ const PROCESS_INDEX: &[RuntimeOperandOrigin] = &[RuntimeOperandOrigin::ValueArgu
     index: 0,
     ty: AbiType::U64,
 }];
-const FREE_BYTES: &[RuntimeOperandOrigin] = &[
+// `@free(p, size, align)` — the sizeless-allocator ABI hands the block's layout
+// back to the runtime (ADR-0059 Phase 3, RUE-961).
+const FREE: &[RuntimeOperandOrigin] = &[
     RuntimeOperandOrigin::MutablePointerArgument {
         index: 0,
         source: RuntimeAirType::MutBytePointer,
@@ -270,17 +231,19 @@ const FREE_BYTES: &[RuntimeOperandOrigin] = &[
         index: 1,
         ty: AbiType::U64,
     },
-    // Explicit alignment argument (ADR-0059 Phase 2, RUE-960).
     RuntimeOperandOrigin::ValueArgument {
         index: 2,
         ty: AbiType::U64,
     },
 ];
-// `@realloc_bytes(p, old_size, align, new_size)` maps onto the runtime helper
-// signature `__rue_realloc(ptr, old_size, new_size, align)`, so the alignment
-// operand (AIR argument 2) is passed last while `new_size` (AIR argument 3)
-// precedes it (ADR-0059 Phase 2, RUE-960).
-const REALLOC_BYTES: &[RuntimeOperandOrigin] = &[
+// `@realloc(p, old_size, align, new_size)` and `@resize(p, old_size, align,
+// new_size)` map onto the runtime helper signatures `__rue_realloc(ptr,
+// old_size, new_size, align)` and `__rue_resize(ptr, old_size, new_size,
+// align)`, so the alignment operand (AIR argument 2) is passed last while
+// `new_size` (AIR argument 3) precedes it. Keeping the intrinsic's `align`
+// ahead of `new_size` keeps `(p, old_size, align, ...)` identical across
+// `@free`, `@realloc`, and `@resize` at the call site.
+const RESIZE_LAYOUT: &[RuntimeOperandOrigin] = &[
     RuntimeOperandOrigin::MutablePointerArgument {
         index: 0,
         source: RuntimeAirType::MutBytePointer,
@@ -298,6 +261,8 @@ const REALLOC_BYTES: &[RuntimeOperandOrigin] = &[
         ty: AbiType::U64,
     },
 ];
+// `@byte_copy` and `@byte_move` share one operand plan and differ only in the
+// helper they select (memcpy vs memmove, RUE-937 / RUE-964).
 const BYTE_COPY: &[RuntimeOperandOrigin] = &[
     RuntimeOperandOrigin::MutablePointerArgument {
         index: 0,
@@ -349,12 +314,11 @@ impl RuntimeCallKind {
         Self::ParseU64,
         Self::RandomU32,
         Self::RandomU64,
-        Self::AllocTyped,
-        Self::FreeTyped,
-        Self::ReallocTyped,
-        Self::AllocBytes,
-        Self::FreeBytes,
-        Self::ReallocBytes,
+        Self::Alloc,
+        Self::AllocZeroed,
+        Self::Free,
+        Self::Realloc,
+        Self::Resize,
         Self::ArgCount,
         Self::ArgPtr,
         Self::ArgLen,
@@ -362,6 +326,7 @@ impl RuntimeCallKind {
         Self::EnvPtr,
         Self::EnvLen,
         Self::ByteCopy,
+        Self::ByteMove,
         Self::ByteSet,
     ];
 
@@ -391,9 +356,11 @@ impl RuntimeCallKind {
             Self::ParseU64 => RuntimeHelperId::ParseU64,
             Self::RandomU32 => RuntimeHelperId::RandomU32,
             Self::RandomU64 => RuntimeHelperId::RandomU64,
-            Self::AllocTyped | Self::AllocBytes => RuntimeHelperId::Alloc,
-            Self::FreeTyped | Self::FreeBytes => RuntimeHelperId::Free,
-            Self::ReallocTyped | Self::ReallocBytes => RuntimeHelperId::Realloc,
+            Self::Alloc => RuntimeHelperId::Alloc,
+            Self::AllocZeroed => RuntimeHelperId::AllocZeroed,
+            Self::Free => RuntimeHelperId::Free,
+            Self::Realloc => RuntimeHelperId::Realloc,
+            Self::Resize => RuntimeHelperId::Resize,
             Self::ArgCount => RuntimeHelperId::ArgCount,
             Self::ArgPtr => RuntimeHelperId::ArgPtr,
             Self::ArgLen => RuntimeHelperId::ArgLen,
@@ -401,6 +368,7 @@ impl RuntimeCallKind {
             Self::EnvPtr => RuntimeHelperId::EnvPtr,
             Self::EnvLen => RuntimeHelperId::EnvLen,
             Self::ByteCopy => RuntimeHelperId::ByteCopy,
+            Self::ByteMove => RuntimeHelperId::ByteMove,
             Self::ByteSet => RuntimeHelperId::ByteSet,
         }
     }
@@ -434,13 +402,10 @@ impl RuntimeCallKind {
             Self::ArgPtr | Self::ArgLen | Self::EnvPtr | Self::EnvLen => PROCESS_INDEX,
             Self::ReadLine => READ_LINE,
             Self::ParseI32 | Self::ParseI64 | Self::ParseU32 | Self::ParseU64 => PARSE,
-            Self::AllocTyped => ALLOC_TYPED,
-            Self::FreeTyped => FREE_TYPED,
-            Self::ReallocTyped => REALLOC_TYPED,
-            Self::AllocBytes => ALLOC_BYTES,
-            Self::FreeBytes => FREE_BYTES,
-            Self::ReallocBytes => REALLOC_BYTES,
-            Self::ByteCopy => BYTE_COPY,
+            Self::Alloc | Self::AllocZeroed => ALLOC,
+            Self::Free => FREE,
+            Self::Realloc | Self::Resize => RESIZE_LAYOUT,
+            Self::ByteCopy | Self::ByteMove => BYTE_COPY,
             Self::ByteSet => BYTE_SET,
         }
     }
@@ -515,11 +480,6 @@ impl RuntimeCallKind {
                             _ => return false,
                         },
                     }
-                } else if self.has_result_pointee_origin() {
-                    if helper_result != AbiResult::Scalar(AbiType::MutBytePointer) {
-                        return false;
-                    }
-                    RuntimeAirType::MutPointer
                 } else if helper_result == AbiResult::Scalar(AbiType::MutBytePointer) {
                     self.pointer_result_type()
                 } else {
@@ -545,16 +505,6 @@ impl RuntimeCallKind {
             }
         }
         shape
-    }
-
-    fn has_result_pointee_origin(self) -> bool {
-        self.operands().iter().any(|operand| {
-            matches!(
-                operand,
-                RuntimeOperandOrigin::ResultPointeeAlign
-                    | RuntimeOperandOrigin::ScaledByResultPointeeSize(_)
-            )
-        })
     }
 
     fn pointer_result_type(self) -> RuntimeAirType {
@@ -596,9 +546,7 @@ impl RuntimeCallKind {
         for operand in operands {
             let valid = match *operand {
                 RuntimeOperandOrigin::OutResult(_)
-                | RuntimeOperandOrigin::ResultPointeeAlign
-                | RuntimeOperandOrigin::OptionDiscriminant(_)
-                | RuntimeOperandOrigin::ByteAlignment => true,
+                | RuntimeOperandOrigin::OptionDiscriminant(_) => true,
                 RuntimeOperandOrigin::ValueArgument { index, ty } => {
                     require(index, Self::air_type_for_abi_value(ty))
                 }
@@ -628,16 +576,8 @@ impl RuntimeCallKind {
                 RuntimeOperandOrigin::ProjectedTextPointer(index) => {
                     require(index, RuntimeAirType::BytePointer)
                 }
-                RuntimeOperandOrigin::ProjectedTextLength(index)
-                | RuntimeOperandOrigin::ScaledByResultPointeeSize(index) => {
+                RuntimeOperandOrigin::ProjectedTextLength(index) => {
                     require(index, RuntimeAirType::U64)
-                }
-                RuntimeOperandOrigin::PointerPointeeAlign(pointer) => {
-                    require(pointer, RuntimeAirType::MutPointer)
-                }
-                RuntimeOperandOrigin::ScaledByPointerPointeeSize { pointer, count } => {
-                    require(pointer, RuntimeAirType::MutPointer)
-                        && require(count, RuntimeAirType::U64)
                 }
             };
             if !valid {
@@ -696,9 +636,10 @@ impl RuntimeCallKind {
                 actual,
                 T::BytePointer | T::ConstBytePointer | T::MutBytePointer
             ),
-            // A typed allocation specialized with `T = u8` has the same AIR
-            // pointer type as the byte-oriented helpers, while retaining the
-            // typed helper's pointee-scaled operand plan.
+            // No runtime helper takes a non-`u8` pointer since the allocation
+            // family became byte-shaped (ADR-0059 Phase 3), but the AIR
+            // classification still distinguishes the two, and a `ptr mut u8`
+            // satisfies a plan written for any mutable pointer.
             T::MutPointer => matches!(actual, T::MutPointer | T::MutBytePointer),
             _ => expected == actual,
         }
@@ -733,7 +674,7 @@ mod tests {
         assert!(RuntimeCallKind::ToString.validate_air_arguments(&[normal(RuntimeAirType::I64)]));
         assert!(!RuntimeCallKind::ToString.validate_air_arguments(&[normal(RuntimeAirType::U64)]));
         assert!(
-            !RuntimeCallKind::AllocBytes
+            !RuntimeCallKind::Alloc
                 .validate_air_arguments(&[normal(RuntimeAirType::SignedInteger)])
         );
         assert!(
@@ -780,42 +721,30 @@ mod tests {
     }
 
     #[test]
-    fn scaled_pointer_origins_validate_both_pointer_and_count_indices() {
+    fn layout_returning_plans_require_a_byte_pointer_and_u64_sizes() {
         let normal = |ty| RuntimeAirArgument {
             ty,
             mode: crate::AirArgMode::Normal,
         };
-        let scaled = [RuntimeOperandOrigin::ScaledByPointerPointeeSize {
-            pointer: 0,
-            count: 1,
-        }];
-        assert!(RuntimeCallKind::validate_air_arguments_for_plan(
-            &scaled,
-            RuntimeCallActivation::Always,
-            &[
-                normal(RuntimeAirType::MutPointer),
-                normal(RuntimeAirType::U64),
-            ],
-        ));
-        assert!(!RuntimeCallKind::validate_air_arguments_for_plan(
-            &scaled,
-            RuntimeCallActivation::Always,
-            &[
-                normal(RuntimeAirType::U64),
-                normal(RuntimeAirType::MutPointer),
-            ],
-        ));
-        assert!(!RuntimeCallKind::validate_air_arguments_for_plan(
-            &[RuntimeOperandOrigin::ScaledByPointerPointeeSize {
-                pointer: 0,
-                count: 2,
-            }],
-            RuntimeCallActivation::Always,
-            &[
-                normal(RuntimeAirType::MutPointer),
-                normal(RuntimeAirType::U64),
-            ],
-        ));
+        // `@realloc`/`@resize`: (ptr mut u8, old_size, align, new_size).
+        let layout = [
+            normal(RuntimeAirType::MutBytePointer),
+            normal(RuntimeAirType::U64),
+            normal(RuntimeAirType::U64),
+            normal(RuntimeAirType::U64),
+        ];
+        assert!(RuntimeCallKind::Realloc.validate_air_arguments(&layout));
+        assert!(RuntimeCallKind::Resize.validate_air_arguments(&layout));
+        // The pointer operand is not interchangeable with a size operand.
+        assert!(!RuntimeCallKind::Realloc.validate_air_arguments(&[
+            normal(RuntimeAirType::U64),
+            normal(RuntimeAirType::U64),
+            normal(RuntimeAirType::U64),
+            normal(RuntimeAirType::MutBytePointer),
+        ]));
+        // `@free`: (ptr mut u8, size, align) — one operand shorter.
+        assert!(!RuntimeCallKind::Free.validate_air_arguments(&layout));
+        assert!(RuntimeCallKind::Free.validate_air_arguments(&layout[..3]));
     }
 
     #[test]
@@ -850,9 +779,18 @@ mod tests {
             assert!(!kind.validate_air_result(wrong_width));
             assert!(!kind.validate_air_result(RuntimeAirType::OptionStrBuf));
         }
-        assert!(RuntimeCallKind::AllocTyped.validate_air_result(RuntimeAirType::MutPointer));
-        assert!(RuntimeCallKind::AllocTyped.validate_air_result(RuntimeAirType::MutBytePointer));
-        assert!(!RuntimeCallKind::AllocTyped.validate_air_result(RuntimeAirType::U64));
+        for kind in [RuntimeCallKind::Alloc, RuntimeCallKind::AllocZeroed] {
+            assert!(kind.validate_air_result(RuntimeAirType::MutBytePointer));
+            assert!(!kind.validate_air_result(RuntimeAirType::U64));
+        }
+        // `@resize` reports success as a `bool`, not as a pointer.
+        assert!(RuntimeCallKind::Resize.validate_air_result(RuntimeAirType::Bool));
+        assert!(!RuntimeCallKind::Resize.validate_air_result(RuntimeAirType::MutBytePointer));
+        assert!(RuntimeCallKind::Realloc.validate_air_result(RuntimeAirType::MutBytePointer));
+        assert!(!RuntimeCallKind::Realloc.validate_air_result(RuntimeAirType::Bool));
+        // The overlapping and non-overlapping bulk moves are both statements.
+        assert!(RuntimeCallKind::ByteMove.validate_air_result(RuntimeAirType::Unit));
+        assert!(!RuntimeCallKind::ByteMove.validate_air_result(RuntimeAirType::U64));
         assert!(RuntimeCallKind::Panic.validate_air_result(RuntimeAirType::Never));
         assert!(!RuntimeCallKind::Panic.validate_air_result(RuntimeAirType::Unit));
         assert!(RuntimeCallKind::AssertFailed.validate_air_result(RuntimeAirType::Unit));

--- a/crates/rue-air/src/sema/analysis/intrinsics.rs
+++ b/crates/rue-air/src/sema/analysis/intrinsics.rs
@@ -252,8 +252,9 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
         // them before the per-intrinsic dispatch so every one shares a single
         // diagnostic. `@syscall` has its own gating; the set here is
         // @raw/@raw_mut/@field_ptr/@ptr_read/@ptr_write/@ptr_offset/
-        // @ptr_to_int/@int_to_ptr plus the heap intrinsics
-        // @alloc/@free/@realloc (RUE-1, RUE-301).
+        // @ptr_to_int/@int_to_ptr plus the unified byte allocation family
+        // @alloc/@alloc_zeroed/@free/@realloc/@resize (RUE-1, RUE-301,
+        // ADR-0059 Phase 3).
         if ctx.checked_depth == 0
             && (name == known.ptr_read
                 || name == known.ptr_write
@@ -266,25 +267,24 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
                 || name == known.raw_mut
                 || name == known.field_ptr
                 || name == known.alloc
+                || name == known.alloc_zeroed
                 || name == known.free
                 || name == known.realloc
-                || name == known.alloc_bytes
-                || name == known.realloc_bytes
-                || name == known.free_bytes
+                || name == known.resize
                 || name == known.byte_read
                 || name == known.byte_write
                 || name == known.byte_copy
+                || name == known.byte_move
                 || name == known.byte_set
                 || name == known.arg_ptr
                 || name == known.env_ptr)
         {
             let intrinsic_name_str = self.body_interner().resolve(&name);
             let kind = if name == known.alloc
+                || name == known.alloc_zeroed
                 || name == known.free
                 || name == known.realloc
-                || name == known.alloc_bytes
-                || name == known.realloc_bytes
-                || name == known.free_bytes
+                || name == known.resize
             {
                 "heap"
             } else {
@@ -414,23 +414,19 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
             self.analyze_ptr_to_int_intrinsic(air, name, &args, span, ctx)
         } else if name == known.int_to_ptr {
             self.analyze_int_to_ptr_intrinsic(air, name, inst_ref, &args, span, ctx)
-        } else if name == known.alloc {
+        } else if name == known.alloc || name == known.alloc_zeroed {
             self.analyze_alloc_intrinsic(air, name, inst_ref, &args, span, ctx)
-        } else if name == known.free {
-            self.analyze_free_intrinsic(air, name, &args, span, ctx)
         } else if name == known.realloc {
             self.analyze_realloc_intrinsic(air, name, &args, span, ctx)
-        } else if name == known.alloc_bytes {
-            self.analyze_alloc_bytes_intrinsic(air, name, inst_ref, &args, span, ctx)
-        } else if name == known.realloc_bytes {
-            self.analyze_realloc_bytes_intrinsic(air, name, &args, span, ctx)
-        } else if name == known.free_bytes {
-            self.analyze_free_bytes_intrinsic(air, name, &args, span, ctx)
+        } else if name == known.resize {
+            self.analyze_resize_intrinsic(air, name, &args, span, ctx)
+        } else if name == known.free {
+            self.analyze_free_intrinsic(air, name, &args, span, ctx)
         } else if name == known.byte_read {
             self.analyze_byte_read_intrinsic(air, name, &args, span, ctx)
         } else if name == known.byte_write {
             self.analyze_byte_write_intrinsic(air, name, &args, span, ctx)
-        } else if name == known.byte_copy {
+        } else if name == known.byte_copy || name == known.byte_move {
             self.analyze_byte_copy_intrinsic(air, name, &args, span, ctx)
         } else if name == known.byte_set {
             self.analyze_byte_set_intrinsic(air, name, &args, span, ctx)

--- a/crates/rue-air/src/sema/analysis/pointers.rs
+++ b/crates/rue-air/src/sema/analysis/pointers.rs
@@ -369,12 +369,15 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
         Ok(AnalysisResult::new(air_ref, result_type))
     }
 
-    /// Analyze @alloc intrinsic: allocate an uninitialized heap block (RUE-1).
-    /// Signature: @alloc(count: u64) -> ptr mut T
-    /// The element type T (and thus the result pointer type `ptr mut T`) is
-    /// inferred from context, exactly like @int_to_ptr. The allocation is
-    /// `count * size_of(T)` bytes; the returned pointer is null on failure
-    /// (the caller is expected to check), so this is an unchecked operation.
+    /// Analyze `@alloc(size, align)` and `@alloc_zeroed(size, align)`, the
+    /// unified byte-and-alignment allocation entry points (ADR-0059 Phase 3,
+    /// RUE-961 / RUE-968).
+    ///
+    /// `size` is a physical byte count and `align` a power-of-two byte count;
+    /// the result is always `ptr mut u8`. Typed allocation is source-computed
+    /// sugar — `@alloc(count * @size_of(T), @align_of(T))` — so nothing here
+    /// consults a pointee type. `@alloc_zeroed` shares this shape and differs
+    /// only in the dynamic guarantee that the storage reads as zero bytes.
     pub(super) fn analyze_alloc_intrinsic(
         &mut self,
         air: &mut Air,
@@ -384,209 +387,11 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
         span: Span,
         ctx: &mut AnalysisContext,
     ) -> CompileResult<AnalysisResult> {
-        if args.len() != 1 {
-            return Err(CompileError::new(
-                ErrorKind::IntrinsicWrongArgCount {
-                    name: "alloc".to_string(),
-                    expected: 1,
-                    found: args.len(),
-                },
-                span,
-            ));
-        }
-
-        let count_result = self.analyze_inst(air, args[0].value, ctx)?;
-        let count_type = count_result.ty;
-        if count_type != Type::U64 && !count_type.is_error() && !count_type.is_never() {
-            return Err(CompileError::new(
-                ErrorKind::IntrinsicTypeMismatch(Box::new(IntrinsicTypeMismatchError {
-                    name: "alloc".to_string(),
-                    expected: "u64".to_string(),
-                    found: self.format_type_name(count_type),
-                })),
-                span,
-            ));
-        }
-
-        // The result type comes from HM inference (assignment/annotation
-        // context) and must be a mutable pointer `ptr mut T`. In a discarded or
-        // otherwise unconstrained position (`@alloc(4);`) the result variable
-        // has no context to fix its pointee and decays to `<error>`; report
-        // that cleanly rather than letting the `<error>`-typed value reach the
-        // end of analysis as a graceful ICE (RUE-153 backstop, found by the
-        // sema fuzzer). The `count` arg was analyzed above via `?`, so an
-        // `<error>` result here is specifically the unresolved-pointee case.
-        let result_type = Self::get_resolved_type(ctx, inst_ref, span, "@alloc intrinsic")?;
-        if result_type.is_error() {
-            return Err(CompileError::new(
-                ErrorKind::CannotInferPointeeType("alloc".to_string()),
-                span,
-            ));
-        }
-        if !result_type.is_ptr_mut() && !result_type.is_never() {
-            return Err(CompileError::new(
-                ErrorKind::IntrinsicTypeMismatch(Box::new(IntrinsicTypeMismatchError {
-                    name: "alloc".to_string(),
-                    expected: "ptr mut T".to_string(),
-                    found: self.format_type_name(result_type),
-                })),
-                span,
-            ));
-        }
-
-        let air_ref = air.add_intrinsic(
-            Some(crate::RuntimeCallKind::AllocTyped),
-            name,
-            &[count_result.air_ref],
-            result_type,
-            span,
-        )?;
-        Ok(AnalysisResult::new(air_ref, result_type))
-    }
-
-    /// Analyze @free intrinsic: free a block previously `@alloc`'d (RUE-1).
-    /// Signature: @free(ptr: ptr mut T, count: u64) -> ()
-    /// `count` must match the element count passed to `@alloc` so the runtime
-    /// can compute the block size.
-    pub(super) fn analyze_free_intrinsic(
-        &mut self,
-        air: &mut Air,
-        name: Spur,
-        args: &[RirCallArg],
-        span: Span,
-        ctx: &mut AnalysisContext,
-    ) -> CompileResult<AnalysisResult> {
+        let intrinsic = self.body_interner().resolve(&name).to_string();
         if args.len() != 2 {
             return Err(CompileError::new(
                 ErrorKind::IntrinsicWrongArgCount {
-                    name: "free".to_string(),
-                    expected: 2,
-                    found: args.len(),
-                },
-                span,
-            ));
-        }
-
-        let ptr_result = self.analyze_inst(air, args[0].value, ctx)?;
-        let ptr_type = ptr_result.ty;
-        if !ptr_type.is_ptr_mut() && !ptr_type.is_error() && !ptr_type.is_never() {
-            return Err(CompileError::new(
-                ErrorKind::IntrinsicTypeMismatch(Box::new(IntrinsicTypeMismatchError {
-                    name: "free".to_string(),
-                    expected: "ptr mut T".to_string(),
-                    found: self.format_type_name(ptr_type),
-                })),
-                span,
-            ));
-        }
-
-        let count_result = self.analyze_inst(air, args[1].value, ctx)?;
-        let count_type = count_result.ty;
-        if count_type != Type::U64 && !count_type.is_error() && !count_type.is_never() {
-            return Err(CompileError::new(
-                ErrorKind::IntrinsicTypeMismatch(Box::new(IntrinsicTypeMismatchError {
-                    name: "free".to_string(),
-                    expected: "u64".to_string(),
-                    found: self.format_type_name(count_type),
-                })),
-                span,
-            ));
-        }
-
-        let air_ref = air.add_intrinsic(
-            Some(crate::RuntimeCallKind::FreeTyped),
-            name,
-            &[ptr_result.air_ref, count_result.air_ref],
-            Type::UNIT,
-            span,
-        )?;
-        Ok(AnalysisResult::new(air_ref, Type::UNIT))
-    }
-
-    /// Analyze @realloc intrinsic: grow/shrink an `@alloc`'d block (RUE-1).
-    /// Signature: @realloc(ptr: ptr mut T, old_count: u64, new_count: u64) -> ptr mut T
-    /// The result pointer has the same type as `ptr`; contents up to
-    /// `min(old_count, new_count)` elements are preserved (runtime copies).
-    pub(super) fn analyze_realloc_intrinsic(
-        &mut self,
-        air: &mut Air,
-        name: Spur,
-        args: &[RirCallArg],
-        span: Span,
-        ctx: &mut AnalysisContext,
-    ) -> CompileResult<AnalysisResult> {
-        if args.len() != 3 {
-            return Err(CompileError::new(
-                ErrorKind::IntrinsicWrongArgCount {
-                    name: "realloc".to_string(),
-                    expected: 3,
-                    found: args.len(),
-                },
-                span,
-            ));
-        }
-
-        let ptr_result = self.analyze_inst(air, args[0].value, ctx)?;
-        let ptr_type = ptr_result.ty;
-        if !ptr_type.is_ptr_mut() && !ptr_type.is_error() && !ptr_type.is_never() {
-            return Err(CompileError::new(
-                ErrorKind::IntrinsicTypeMismatch(Box::new(IntrinsicTypeMismatchError {
-                    name: "realloc".to_string(),
-                    expected: "ptr mut T".to_string(),
-                    found: self.format_type_name(ptr_type),
-                })),
-                span,
-            ));
-        }
-
-        let old_result = self.analyze_inst(air, args[1].value, ctx)?;
-        let new_result = self.analyze_inst(air, args[2].value, ctx)?;
-        for count_result in [&old_result, &new_result] {
-            let count_type = count_result.ty;
-            if count_type != Type::U64 && !count_type.is_error() && !count_type.is_never() {
-                return Err(CompileError::new(
-                    ErrorKind::IntrinsicTypeMismatch(Box::new(IntrinsicTypeMismatchError {
-                        name: "realloc".to_string(),
-                        expected: "u64".to_string(),
-                        found: self.format_type_name(count_type),
-                    })),
-                    span,
-                ));
-            }
-        }
-
-        let air_ref = air.add_intrinsic(
-            Some(crate::RuntimeCallKind::ReallocTyped),
-            name,
-            &[ptr_result.air_ref, old_result.air_ref, new_result.air_ref],
-            ptr_type,
-            span,
-        )?;
-        Ok(AnalysisResult::new(air_ref, ptr_type))
-    }
-
-    /// Analyze the preview raw-byte intrinsic family (RUE-879). Unlike typed
-    /// pointer operations, byte counts and offsets here are physical bytes and
-    /// access operations transfer exactly one byte.
-    ///
-    /// The byte allocators carry an explicit `align: u64` byte count that must
-    /// be a power of two (ADR-0059 Phase 2, RUE-960). A comptime-constant
-    /// `align` that is zero or not a power of two is rejected here; a
-    /// non-constant `align` is a documented checked-gate contract left to the
-    /// runtime (spec 9.2:14j).
-    pub(super) fn analyze_alloc_bytes_intrinsic(
-        &mut self,
-        air: &mut Air,
-        name: Spur,
-        inst_ref: InstRef,
-        args: &[RirCallArg],
-        span: Span,
-        ctx: &mut AnalysisContext,
-    ) -> CompileResult<AnalysisResult> {
-        if args.len() != 2 {
-            return Err(CompileError::new(
-                ErrorKind::IntrinsicWrongArgCount {
-                    name: "alloc_bytes".to_string(),
+                    name: intrinsic,
                     expected: 2,
                     found: args.len(),
                 },
@@ -594,10 +399,10 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
             ));
         }
         let size = self.analyze_inst(air, args[0].value, ctx)?;
-        self.require_intrinsic_type("alloc_bytes", size.ty, Type::U64, span)?;
+        self.require_intrinsic_type(&intrinsic, size.ty, Type::U64, span)?;
         let align = self.analyze_inst(air, args[1].value, ctx)?;
-        self.require_intrinsic_type("alloc_bytes", align.ty, Type::U64, span)?;
-        self.require_power_of_two_align("alloc_bytes", args[1].value, span, ctx)?;
+        self.require_intrinsic_type(&intrinsic, align.ty, Type::U64, span)?;
+        self.require_power_of_two_align(&intrinsic, args[1].value, span, ctx)?;
         let result_ty = Type::new_ptr_mut(self.body_type_pool().intern_ptr_mut_from_type(Type::U8));
         if let Some(expected) = ctx.resolved_type_of(inst_ref)
             && !self.types_equivalent(expected, result_ty)
@@ -606,8 +411,13 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
         {
             return Err(self.type_mismatch_error(expected, result_ty, span));
         }
+        let zeroed = name == self.known_symbols().alloc_zeroed;
         let air_ref = air.add_intrinsic(
-            Some(crate::RuntimeCallKind::AllocBytes),
+            Some(if zeroed {
+                crate::RuntimeCallKind::AllocZeroed
+            } else {
+                crate::RuntimeCallKind::Alloc
+            }),
             name,
             &[size.air_ref, align.air_ref],
             result_ty,
@@ -616,7 +426,10 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
         Ok(AnalysisResult::new(air_ref, result_ty))
     }
 
-    pub(super) fn analyze_realloc_bytes_intrinsic(
+    /// Analyze `@realloc(p, old_size, align, new_size) -> ptr mut u8`
+    /// (ADR-0059 Phase 3, RUE-961). Every size is a physical byte count and
+    /// `align` must equal the alignment the block was allocated with.
+    pub(super) fn analyze_realloc_intrinsic(
         &mut self,
         air: &mut Air,
         name: Spur,
@@ -627,7 +440,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
         if args.len() != 4 {
             return Err(CompileError::new(
                 ErrorKind::IntrinsicWrongArgCount {
-                    name: "realloc_bytes".to_string(),
+                    name: "realloc".to_string(),
                     expected: 4,
                     found: args.len(),
                 },
@@ -635,16 +448,16 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
             ));
         }
         let ptr = self.analyze_inst(air, args[0].value, ctx)?;
-        self.require_mut_u8_pointer("realloc_bytes", ptr.ty, span)?;
+        self.require_mut_u8_pointer("realloc", ptr.ty, span)?;
         let old_size = self.analyze_inst(air, args[1].value, ctx)?;
         let align = self.analyze_inst(air, args[2].value, ctx)?;
         let new_size = self.analyze_inst(air, args[3].value, ctx)?;
-        self.require_intrinsic_type("realloc_bytes", old_size.ty, Type::U64, span)?;
-        self.require_intrinsic_type("realloc_bytes", align.ty, Type::U64, span)?;
-        self.require_intrinsic_type("realloc_bytes", new_size.ty, Type::U64, span)?;
-        self.require_power_of_two_align("realloc_bytes", args[2].value, span, ctx)?;
+        self.require_intrinsic_type("realloc", old_size.ty, Type::U64, span)?;
+        self.require_intrinsic_type("realloc", align.ty, Type::U64, span)?;
+        self.require_intrinsic_type("realloc", new_size.ty, Type::U64, span)?;
+        self.require_power_of_two_align("realloc", args[2].value, span, ctx)?;
         let air_ref = air.add_intrinsic(
-            Some(crate::RuntimeCallKind::ReallocBytes),
+            Some(crate::RuntimeCallKind::Realloc),
             name,
             &[
                 ptr.air_ref,
@@ -658,7 +471,59 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
         Ok(AnalysisResult::new(air_ref, ptr.ty))
     }
 
-    pub(super) fn analyze_free_bytes_intrinsic(
+    /// Analyze `@resize(p, old_size, align, new_size) -> bool` (RUE-968), the
+    /// in-place-only counterpart of `@realloc` modeled on Zig's
+    /// `Allocator.resize`. The block never moves: the call either relabels the
+    /// existing allocation as `new_size` bytes and evaluates to `true`, or
+    /// changes nothing and evaluates to `false`. Its operand shape is exactly
+    /// `@realloc`'s so a caller can fall back to `@realloc` without reordering
+    /// arguments.
+    pub(super) fn analyze_resize_intrinsic(
+        &mut self,
+        air: &mut Air,
+        name: Spur,
+        args: &[RirCallArg],
+        span: Span,
+        ctx: &mut AnalysisContext,
+    ) -> CompileResult<AnalysisResult> {
+        if args.len() != 4 {
+            return Err(CompileError::new(
+                ErrorKind::IntrinsicWrongArgCount {
+                    name: "resize".to_string(),
+                    expected: 4,
+                    found: args.len(),
+                },
+                span,
+            ));
+        }
+        let ptr = self.analyze_inst(air, args[0].value, ctx)?;
+        self.require_mut_u8_pointer("resize", ptr.ty, span)?;
+        let old_size = self.analyze_inst(air, args[1].value, ctx)?;
+        let align = self.analyze_inst(air, args[2].value, ctx)?;
+        let new_size = self.analyze_inst(air, args[3].value, ctx)?;
+        self.require_intrinsic_type("resize", old_size.ty, Type::U64, span)?;
+        self.require_intrinsic_type("resize", align.ty, Type::U64, span)?;
+        self.require_intrinsic_type("resize", new_size.ty, Type::U64, span)?;
+        self.require_power_of_two_align("resize", args[2].value, span, ctx)?;
+        let air_ref = air.add_intrinsic(
+            Some(crate::RuntimeCallKind::Resize),
+            name,
+            &[
+                ptr.air_ref,
+                old_size.air_ref,
+                align.air_ref,
+                new_size.air_ref,
+            ],
+            Type::BOOL,
+            span,
+        )?;
+        Ok(AnalysisResult::new(air_ref, Type::BOOL))
+    }
+
+    /// Analyze `@free(p, size, align)` (ADR-0059 Phase 3, RUE-961). The
+    /// sizeless-allocator ABI: the caller returns the block's `(size, align)`
+    /// so the runtime keeps no per-block header.
+    pub(super) fn analyze_free_intrinsic(
         &mut self,
         air: &mut Air,
         name: Spur,
@@ -669,7 +534,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
         if args.len() != 3 {
             return Err(CompileError::new(
                 ErrorKind::IntrinsicWrongArgCount {
-                    name: "free_bytes".to_string(),
+                    name: "free".to_string(),
                     expected: 3,
                     found: args.len(),
                 },
@@ -677,14 +542,14 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
             ));
         }
         let ptr = self.analyze_inst(air, args[0].value, ctx)?;
-        self.require_mut_u8_pointer("free_bytes", ptr.ty, span)?;
+        self.require_mut_u8_pointer("free", ptr.ty, span)?;
         let size = self.analyze_inst(air, args[1].value, ctx)?;
         let align = self.analyze_inst(air, args[2].value, ctx)?;
-        self.require_intrinsic_type("free_bytes", size.ty, Type::U64, span)?;
-        self.require_intrinsic_type("free_bytes", align.ty, Type::U64, span)?;
-        self.require_power_of_two_align("free_bytes", args[2].value, span, ctx)?;
+        self.require_intrinsic_type("free", size.ty, Type::U64, span)?;
+        self.require_intrinsic_type("free", align.ty, Type::U64, span)?;
+        self.require_power_of_two_align("free", args[2].value, span, ctx)?;
         let air_ref = air.add_intrinsic(
-            Some(crate::RuntimeCallKind::FreeBytes),
+            Some(crate::RuntimeCallKind::Free),
             name,
             &[ptr.air_ref, size.air_ref, align.air_ref],
             Type::UNIT,
@@ -693,11 +558,11 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
         Ok(AnalysisResult::new(air_ref, Type::UNIT))
     }
 
-    /// Reject a comptime-constant byte-allocator `align` argument that is zero
-    /// or not a power of two (ADR-0059 Phase 2, RUE-960). A non-constant
-    /// `align` evaluates to `None` here and is permitted: the power-of-two
-    /// contract for runtime values is documented checked-gate territory
-    /// (spec 9.2:14j), enforced by the allocator rather than the compiler.
+    /// Reject a comptime-constant allocator `align` argument that is zero or
+    /// not a power of two (ADR-0059, RUE-960/RUE-961). A non-constant `align`
+    /// evaluates to `None` here and is permitted: the power-of-two contract for
+    /// runtime values is documented checked-gate territory (spec 9.2:13),
+    /// enforced by the allocator rather than the compiler.
     fn require_power_of_two_align(
         &mut self,
         name: &str,
@@ -781,11 +646,15 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
         Ok(AnalysisResult::new(air_ref, Type::UNIT))
     }
 
-    /// Analyze `@byte_copy(dst: ptr mut u8, src: ptr const u8 | ptr mut u8,
-    /// size: u64) -> ()` (ADR-0058 Phase 1, RUE-937). A memcpy-shaped bulk copy
-    /// of `size` physical bytes; `dst` and `src` must not overlap (undefined
-    /// behavior otherwise) and `size == 0` is a no-op. Lowers to the shared
-    /// `__rue_byte_copy` runtime helper.
+    /// Analyze the bulk byte-move pair `@byte_copy(dst, src, size)` and
+    /// `@byte_move(dst, src, size)` (ADR-0059 Phase 1, RUE-937 / RUE-964).
+    /// Both take `dst: ptr mut u8`, `src: ptr const u8 | ptr mut u8`, and a
+    /// `size: u64` physical byte count, and both evaluate to `()` with
+    /// `size == 0` a no-op. They differ only in the overlap contract:
+    /// `@byte_copy` is memcpy-shaped and overlapping regions are undefined
+    /// behavior, while `@byte_move` is memmove-shaped and copies as if through
+    /// a temporary buffer. They lower to the `__rue_byte_copy` and
+    /// `__rue_byte_move` runtime helpers respectively.
     pub(super) fn analyze_byte_copy_intrinsic(
         &mut self,
         air: &mut Air,
@@ -794,10 +663,11 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
         span: Span,
         ctx: &mut AnalysisContext,
     ) -> CompileResult<AnalysisResult> {
+        let intrinsic = self.body_interner().resolve(&name).to_string();
         if args.len() != 3 {
             return Err(CompileError::new(
                 ErrorKind::IntrinsicWrongArgCount {
-                    name: "byte_copy".to_string(),
+                    name: intrinsic,
                     expected: 3,
                     found: args.len(),
                 },
@@ -805,13 +675,18 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
             ));
         }
         let dst = self.analyze_inst(air, args[0].value, ctx)?;
-        self.require_mut_u8_pointer("byte_copy", dst.ty, span)?;
+        self.require_mut_u8_pointer(&intrinsic, dst.ty, span)?;
         let src = self.analyze_inst(air, args[1].value, ctx)?;
-        self.require_u8_pointer("byte_copy", src.ty, span)?;
+        self.require_u8_pointer(&intrinsic, src.ty, span)?;
         let size = self.analyze_inst(air, args[2].value, ctx)?;
-        self.require_intrinsic_type("byte_copy", size.ty, Type::U64, span)?;
+        self.require_intrinsic_type(&intrinsic, size.ty, Type::U64, span)?;
+        let overlapping = name == self.known_symbols().byte_move;
         let air_ref = air.add_intrinsic(
-            Some(crate::RuntimeCallKind::ByteCopy),
+            Some(if overlapping {
+                crate::RuntimeCallKind::ByteMove
+            } else {
+                crate::RuntimeCallKind::ByteCopy
+            }),
             name,
             &[dst.air_ref, src.air_ref, size.air_ref],
             Type::UNIT,

--- a/crates/rue-air/src/sema/known_symbols.rs
+++ b/crates/rue-air/src/sema/known_symbols.rs
@@ -131,22 +131,35 @@ pub struct KnownSymbols {
     pub field_ptr: Spur,
     /// The `syscall` intrinsic symbol - direct OS syscall.
     pub syscall: Spur,
-    /// The `alloc` intrinsic symbol - allocate an uninitialized heap block
-    /// of `count` elements of the (context-inferred) element type (RUE-1).
+    /// The unified byte-and-alignment allocation family (ADR-0059 Phase 3,
+    /// RUE-961). Every operand is a physical byte count and every pointer is
+    /// `ptr mut u8`; typed allocation is source-computed sugar over
+    /// `@size_of`/`@align_of`.
+    ///
+    /// `alloc` is `@alloc(size, align) -> ptr mut u8`, `free` is
+    /// `@free(p, size, align)`, and `realloc` is
+    /// `@realloc(p, old_size, align, new_size) -> ptr mut u8`. The sizeless
+    /// allocator ABI means `@free`/`@realloc` hand the layout back rather than
+    /// making the runtime keep a per-block header.
     pub alloc: Spur,
     /// The `free` intrinsic symbol - free a block previously `@alloc`'d.
     pub free: Spur,
     /// The `realloc` intrinsic symbol - grow/shrink an `@alloc`'d block.
     pub realloc: Spur,
-    /// Raw physical-byte allocation and access intrinsics (RUE-879).
-    pub alloc_bytes: Spur,
-    pub realloc_bytes: Spur,
-    pub free_bytes: Spur,
+    /// The `alloc_zeroed` intrinsic symbol — `@alloc` whose storage is
+    /// guaranteed all-zero bytes (ADR-0059 Future Work, RUE-968).
+    pub alloc_zeroed: Spur,
+    /// The `resize` intrinsic symbol — `@resize(p, old_size, align, new_size)`,
+    /// the in-place-only grow/shrink that never moves the block and reports
+    /// success as a `bool` (Zig's `Allocator.resize`, RUE-968).
+    pub resize: Spur,
     pub byte_read: Spur,
     pub byte_write: Spur,
-    /// Bulk byte primitives `@byte_copy` (memcpy) and `@byte_set` (memset),
-    /// ADR-0058 Phase 1 (RUE-937).
+    /// Bulk byte primitives `@byte_copy` (memcpy), `@byte_move` (memmove), and
+    /// `@byte_set` (memset). ADR-0059 Phase 1 (RUE-937) plus the overlapping
+    /// sibling `@byte_move` (RUE-964).
     pub byte_copy: Spur,
+    pub byte_move: Spur,
     pub byte_set: Spur,
 
     // Target platform intrinsics
@@ -214,12 +227,12 @@ impl KnownSymbols {
             alloc: interner.get_or_intern_static("alloc"),
             free: interner.get_or_intern_static("free"),
             realloc: interner.get_or_intern_static("realloc"),
-            alloc_bytes: interner.get_or_intern_static("alloc_bytes"),
-            realloc_bytes: interner.get_or_intern_static("realloc_bytes"),
-            free_bytes: interner.get_or_intern_static("free_bytes"),
+            alloc_zeroed: interner.get_or_intern_static("alloc_zeroed"),
+            resize: interner.get_or_intern_static("resize"),
             byte_read: interner.get_or_intern_static("byte_read"),
             byte_write: interner.get_or_intern_static("byte_write"),
             byte_copy: interner.get_or_intern_static("byte_copy"),
+            byte_move: interner.get_or_intern_static("byte_move"),
             byte_set: interner.get_or_intern_static("byte_set"),
 
             // Target platform intrinsics
@@ -305,12 +318,12 @@ mod tests {
         assert_eq!(interner.resolve(&known.alloc), "alloc");
         assert_eq!(interner.resolve(&known.free), "free");
         assert_eq!(interner.resolve(&known.realloc), "realloc");
-        assert_eq!(interner.resolve(&known.alloc_bytes), "alloc_bytes");
-        assert_eq!(interner.resolve(&known.realloc_bytes), "realloc_bytes");
-        assert_eq!(interner.resolve(&known.free_bytes), "free_bytes");
+        assert_eq!(interner.resolve(&known.alloc_zeroed), "alloc_zeroed");
+        assert_eq!(interner.resolve(&known.resize), "resize");
         assert_eq!(interner.resolve(&known.byte_read), "byte_read");
         assert_eq!(interner.resolve(&known.byte_write), "byte_write");
         assert_eq!(interner.resolve(&known.byte_copy), "byte_copy");
+        assert_eq!(interner.resolve(&known.byte_move), "byte_move");
         assert_eq!(interner.resolve(&known.byte_set), "byte_set");
         assert_eq!(interner.resolve(&known.target_arch), "target_arch");
         assert_eq!(interner.resolve(&known.target_os), "target_os");

--- a/crates/rue-air/src/sema/typeck.rs
+++ b/crates/rue-air/src/sema/typeck.rs
@@ -18,12 +18,19 @@ use rue_span::{FileId, Span};
 use super::context::AnalysisContext;
 use super::{DeclarationPhase, Sema};
 
-/// Maximum size of a single object in bytes: `i32::MAX`, matching the
-/// codegen frame-offset (disp32) addressing range (spec C.4:3, RUE-561).
-/// Types larger than this are rejected with E0906 rather than wrapping the
-/// slot arithmetic, per the graceful-failure policy in spec C.1:2.
+/// Frame-displacement budget a single object's slots must address: `i32::MAX`
+/// bytes, matching the codegen frame-offset (disp32) addressing range (spec
+/// C.4:3, RUE-561). This is the derivation basis for [`MAX_TYPE_SLOTS`], not a
+/// limit that is checked on its own: nothing compares a byte total against it.
 pub(crate) const MAX_TYPE_SIZE_BYTES: u64 = i32::MAX as u64;
-/// [`MAX_TYPE_SIZE_BYTES`] expressed in 8-byte ABI slots.
+/// Maximum ABI slot count for a single object: [`MAX_TYPE_SIZE_BYTES`] divided
+/// by the 8-byte slot width, i.e. 268,435,455 slots. This — not a byte total —
+/// is the limit E0906 enforces and names, because a layout spends one slot per
+/// scalar, struct field, and array element whatever the element's own width
+/// (spec C.4:2, RUE-1272). A `[i8; N]` therefore stops at this many *elements*,
+/// well under `MAX_TYPE_SIZE_BYTES` bytes. Types past it are rejected with
+/// E0906 rather than wrapping the slot arithmetic, per the graceful-failure
+/// policy in spec C.1:2.
 pub(crate) const MAX_TYPE_SLOTS: u64 = MAX_TYPE_SIZE_BYTES / 8;
 use super::info::FunctionInfo;
 use crate::inference::InferType;
@@ -3373,18 +3380,18 @@ impl<'a, D: DeclarationPhase> Sema<'a, D> {
 
 impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
     /// Reject a type whose layout exceeds the implementation's maximum object
-    /// size (Appendix C practical limit, RUE-561), returning the slot count on
-    /// success. Call this wherever a value of `ty` is MATERIALIZED — a local
-    /// or temporary slot allocation, a by-value parameter, `@size_of` /
-    /// `@align_of` — so the saturating fallback in [`Self::abi_slot_count`]
-    /// is never observable.
+    /// size — [`MAX_TYPE_SLOTS`] ABI slots (Appendix C practical limit,
+    /// RUE-561) — returning the slot count on success. Call this wherever a
+    /// value of `ty` is MATERIALIZED — a local or temporary slot allocation, a
+    /// by-value parameter, `@size_of` / `@align_of` — so the saturating
+    /// fallback in [`Self::abi_slot_count`] is never observable.
     pub(crate) fn require_layout_slots(&self, ty: Type, span: Span) -> CompileResult<u32> {
         match self.checked_abi_slot_count(ty) {
             Some(slots) => Ok(slots as u32),
             None => Err(CompileError::new(
                 ErrorKind::TypeTooLarge {
                     type_name: ty.safe_name_with_pool(Some(self.body_type_pool())),
-                    max_bytes: MAX_TYPE_SIZE_BYTES,
+                    max_slots: MAX_TYPE_SLOTS,
                 },
                 span,
             )),

--- a/crates/rue-allocator/src/lib.rs
+++ b/crates/rue-allocator/src/lib.rs
@@ -204,6 +204,44 @@ impl<M: PageMapper> Allocator<M> {
         }
     }
 
+    /// Try to relabel a live allocation as `new_size` bytes without moving it.
+    ///
+    /// Returns `true` when the block already satisfies the new layout — the
+    /// same size class, or the same page-rounded mapping — in which case the
+    /// caller may treat the memory at `pointer` as `new_size` bytes and must
+    /// hand `new_size` back at deallocation. Returns `false` without touching
+    /// anything when the new layout needs different storage; the caller keeps
+    /// the old `(old_size, align)` layout and can fall back to
+    /// [`Allocator::reallocate`].
+    ///
+    /// This is the in-place-only half of `reallocate`: it never allocates,
+    /// never copies, and never frees, so a container that manages its own copy
+    /// can grow where it stands whenever the allocator has room.
+    ///
+    /// # Safety
+    ///
+    /// A non-null `pointer` must identify a live allocation returned by this
+    /// allocator for exactly `old_size` and `align`.
+    pub unsafe fn resize_in_place(
+        &self,
+        pointer: *mut u8,
+        old_size: u64,
+        new_size: u64,
+        align: u64,
+    ) -> bool {
+        // A null block owns no storage and a zero new size describes no
+        // allocation at all; neither can be satisfied in place.
+        if pointer.is_null() || new_size == 0 {
+            return false;
+        }
+        let (Some(old_kind), Some(new_kind)) =
+            (classify(old_size, align), classify(new_size, align))
+        else {
+            return false;
+        };
+        old_kind == new_kind
+    }
+
     /// Resize an allocation while preserving its initialized prefix.
     ///
     /// If the old and new layouts use the same size class or page-rounded
@@ -464,6 +502,43 @@ mod tests {
         let smaller = allocator.allocate(16, 1);
         assert!(!smaller.is_null());
         assert_ne!(smaller, larger);
+    }
+
+    #[test]
+    fn resize_in_place_accepts_the_same_class_and_refuses_a_different_one() {
+        let allocator = Allocator::<TestMapper>::new();
+        let pointer = allocator.allocate(65, 8);
+        assert!(!pointer.is_null());
+        // SAFETY: pointer is live for 65 bytes.
+        unsafe { pointer.write(99) };
+
+        // 65 and 120 share the 128-byte class, so the block is relabeled where
+        // it stands and its bytes are untouched.
+        // SAFETY: pointer is live with layout (65, 8).
+        assert!(unsafe { allocator.resize_in_place(pointer, 65, 120, 8) });
+        // SAFETY: the block is still live and readable.
+        assert_eq!(unsafe { pointer.read() }, 99);
+
+        // A direct mapping needs different storage, so the block cannot grow
+        // in place and the old layout stays in force.
+        // SAFETY: pointer is live with layout (120, 8).
+        assert!(!unsafe { allocator.resize_in_place(pointer, 120, 40_000, 8) });
+        // SAFETY: pointer is live with layout (120, 8).
+        unsafe { allocator.deallocate(pointer, 120, 8) };
+    }
+
+    #[test]
+    fn resize_in_place_refuses_a_null_block_and_a_zero_new_size() {
+        let allocator = Allocator::<TestMapper>::new();
+        // SAFETY: a null block is explicitly accepted and refused.
+        assert!(!unsafe { allocator.resize_in_place(ptr::null_mut(), 0, 16, 8) });
+
+        let pointer = allocator.allocate(64, 8);
+        assert!(!pointer.is_null());
+        // SAFETY: pointer is live with layout (64, 8).
+        assert!(!unsafe { allocator.resize_in_place(pointer, 64, 0, 8) });
+        // SAFETY: the refusal left the block live and unchanged.
+        unsafe { allocator.deallocate(pointer, 64, 8) };
     }
 
     #[test]

--- a/crates/rue-cfg/src/inst.rs
+++ b/crates/rue-cfg/src/inst.rs
@@ -2593,6 +2593,82 @@ impl Cfg {
         (0..self.blocks.len() as u32).map(BlockId)
     }
 
+    /// Drop every block `keep` rejects and renumber the survivors densely,
+    /// rewriting every block reference in the graph (RUE-769).
+    ///
+    /// `BlockId` is a dense index into `blocks`, so a block cannot be removed
+    /// without renumbering: `get_block` indexes the vector directly and each
+    /// block's own `id` must equal its position. This is the single place that
+    /// performs that renumbering, and it covers every block reference there is
+    /// — the entry id, each block's own id, `Goto`/`Branch` targets, and a
+    /// `Switch`'s default plus its case targets in the payload store. Block
+    /// *parameters* and instructions of dropped blocks are left in the value
+    /// arena as detached values, exactly as dead instruction elimination
+    /// leaves them.
+    ///
+    /// The entry block must survive; callers derive `keep` from reachability
+    /// from the entry, which always includes it. Returns `true` when at least
+    /// one block was dropped.
+    pub(crate) fn retain_blocks(&mut self, keep: impl Fn(BlockId) -> bool) -> bool {
+        let old_count = self.blocks.len();
+        let mut remap: Vec<Option<BlockId>> = Vec::with_capacity(old_count);
+        let mut kept = 0u32;
+        for index in 0..old_count as u32 {
+            if keep(BlockId(index)) {
+                remap.push(Some(BlockId(kept)));
+                kept += 1;
+            } else {
+                remap.push(None);
+            }
+        }
+        if kept as usize == old_count {
+            return false;
+        }
+        let entry = remap[self.entry.0 as usize]
+            .expect("block compaction must keep the entry block reachable");
+
+        let mut old_index = 0;
+        self.blocks.retain(|_| {
+            let survives = remap[old_index].is_some();
+            old_index += 1;
+            survives
+        });
+
+        // A surviving block's successors are reachable by construction, so
+        // every target below has a new identity. Renumber ids first, then
+        // targets, so the two passes read one consistent `remap`.
+        for (new_index, block) in self.blocks.iter_mut().enumerate() {
+            block.id = BlockId(new_index as u32);
+        }
+        let target_of = |old: BlockId| -> BlockId {
+            remap[old.0 as usize].expect("a reachable block cannot branch to a dropped block")
+        };
+        let mut switch_ranges = Vec::new();
+        for block in &mut self.blocks {
+            match &mut block.terminator {
+                Terminator::Goto { target, .. } => *target = target_of(*target),
+                Terminator::Branch {
+                    then_block,
+                    else_block,
+                    ..
+                } => {
+                    *then_block = target_of(*then_block);
+                    *else_block = target_of(*else_block);
+                }
+                Terminator::Switch { cases, default, .. } => {
+                    *default = target_of(*default);
+                    switch_ranges.push(cases.duplicate());
+                }
+                Terminator::Return { .. } | Terminator::Unreachable | Terminator::None => {}
+            }
+        }
+        for range in &switch_ranges {
+            payload::remap_switch_case_targets(&mut self.switch_cases, range, target_of);
+        }
+        self.entry = entry;
+        true
+    }
+
     /// Rewrite every value USE in the CFG through `map`, covering all the
     /// places a `CfgValue` can be referenced: instruction operands, the
     /// `extra` array (struct fields, array elements, intrinsic args, and

--- a/crates/rue-cfg/src/opt/dce.rs
+++ b/crates/rue-cfg/src/opt/dce.rs
@@ -10,7 +10,8 @@
 //! 2. Mark all values used by terminators as live
 //! 3. Transitively mark all values used by live instructions
 //! 4. Remove dead instructions from basic blocks
-//! 5. Remove unreachable blocks
+//! 5. Remove unreachable blocks, compacting the survivors into a dense block
+//!    numbering (see [`eliminate_unreachable_blocks`] for the invariant)
 //!
 //! ## What keeps an instruction live
 //!
@@ -328,24 +329,27 @@ fn eliminate_dead_instructions(cfg: &mut Cfg, live: &BitSet) {
 }
 
 /// Remove unreachable blocks (blocks with no predecessors except entry).
+///
+/// ## Compaction invariant (RUE-769)
+///
+/// Unreachable blocks are *deleted*, not emptied into `Unreachable`
+/// placeholders. `BlockId` is a dense index into the block vector, so deletion
+/// implies renumbering; [`Cfg::retain_blocks`] performs both together and
+/// rewrites every block reference in the graph, so the invariant this pass
+/// establishes is:
+///
+/// - after DCE, every block in the CFG is reachable from the entry;
+/// - block ids remain `0..block_count()`, each block's own `id` equal to its
+///   position, and the entry id is rewritten with the rest.
+///
+/// An `Unreachable` *terminator* that survives DCE therefore always belongs to
+/// a reachable block — one that ends in a diverging expression — and is never
+/// the husk of a pruned region. Nothing outside the CFG may hold a `BlockId`
+/// across this pass; DCE is the last pass in the pipeline, and every pass
+/// derives block ids from the graph it is handed.
 fn eliminate_unreachable_blocks(cfg: &mut Cfg) {
-    // First, compute which blocks are reachable from entry
     let reachable = compute_reachable_blocks(cfg);
-
-    // Collect the block IDs to process (to avoid borrowing issues)
-    let block_ids: Vec<BlockId> = cfg.block_ids().collect();
-
-    // For now, we don't actually remove blocks from the vector
-    // (that would require renumbering all BlockIds).
-    // Instead, we mark unreachable blocks with Unreachable terminator
-    // and empty their instruction lists.
-    for block_id in block_ids {
-        if block_id != cfg.entry && !reachable.contains(block_id.as_u32()) {
-            let block = cfg.get_block_mut(block_id);
-            block.insts.clear();
-            block.terminator = Terminator::Unreachable;
-        }
-    }
+    cfg.retain_blocks(|block_id| reachable.contains(block_id.as_u32()));
 }
 
 /// Compute the set of blocks reachable from the entry block.
@@ -560,17 +564,97 @@ mod tests {
         );
         cfg.set_terminator(unreachable_block, Terminator::Return { value: Some(c2) });
 
+        assert_eq!(cfg.block_count(), 2);
         run(&mut cfg);
 
-        // Unreachable block should have Unreachable terminator and no instructions
-        let block = cfg.get_block(unreachable_block);
-        assert!(
-            block.insts.is_empty(),
-            "Unreachable block should have no instructions"
+        // The unreachable block is removed outright, not left as an
+        // `Unreachable` husk, and the survivors stay densely numbered
+        // (RUE-769). `unreachable_block`'s id is deliberately not reused here:
+        // ids are only meaningful against the graph they were read from.
+        assert_eq!(cfg.block_count(), 1);
+        assert_eq!(cfg.entry, entry);
+        let block = cfg.get_block(cfg.entry);
+        assert_eq!(block.id, cfg.entry);
+        assert_eq!(block.insts, vec![c1]);
+        assert!(matches!(block.terminator, Terminator::Return { .. }));
+    }
+
+    /// Compaction rewrites every block reference, including the case targets a
+    /// `Switch` keeps in the payload store rather than in the terminator
+    /// (RUE-769). Unreachable blocks are interleaved with live ones so every
+    /// surviving target has to shift by a different amount — an identity
+    /// remap, or one applied to the terminator but not the payload, would
+    /// leave a target naming the wrong block.
+    #[test]
+    fn test_dce_compaction_renumbers_switch_and_goto_targets() {
+        let mut cfg = make_cfg();
+        let entry = cfg.entry;
+        let scrutinee = add_const(&mut cfg, 2, Type::I32);
+        let result = add_const(&mut cfg, 42, Type::I32);
+
+        // 0: entry   1: first case   2: DEAD   3: second case
+        // 4: default 5: DEAD
+        let first_case = cfg.new_block();
+        let dead_between = cfg.new_block();
+        let second_case = cfg.new_block();
+        let default = cfg.new_block();
+        let dead_last = cfg.new_block();
+
+        cfg.set_switch(
+            entry,
+            scrutinee,
+            [(1, first_case), (2, second_case)],
+            default,
         );
+        let no_args = cfg.push_goto_args(std::iter::empty()).unwrap();
+        cfg.set_terminator(
+            first_case,
+            Terminator::Goto {
+                target: default,
+                args: no_args,
+            },
+        );
+        for block in [second_case, default, dead_between, dead_last] {
+            cfg.set_terminator(
+                block,
+                Terminator::Return {
+                    value: Some(result),
+                },
+            );
+        }
+
+        assert_eq!(cfg.block_count(), 6);
+        run(&mut cfg);
+
+        // Four blocks survive, densely renumbered in their original order:
+        // entry -> 0, first_case -> 1, second_case -> 2, default -> 3.
+        assert_eq!(cfg.block_count(), 4);
+        for (index, block) in cfg.blocks().iter().enumerate() {
+            assert_eq!(block.id, BlockId(index as u32));
+        }
+        assert_eq!(cfg.entry, BlockId(0));
+
+        let terminator = &cfg.get_block(BlockId(0)).terminator;
+        assert_eq!(
+            cfg.get_switch_cases(terminator),
+            &[(1, BlockId(1)), (2, BlockId(2))]
+        );
+        let Terminator::Switch { default, .. } = terminator else {
+            panic!("entry must still switch");
+        };
+        assert_eq!(*default, BlockId(3));
+        assert!(matches!(
+            cfg.get_block(BlockId(1)).terminator,
+            Terminator::Goto {
+                target: BlockId(3),
+                ..
+            }
+        ));
         assert!(
-            matches!(block.terminator, Terminator::Unreachable),
-            "Unreachable block should have Unreachable terminator"
+            cfg.blocks()
+                .iter()
+                .all(|block| !matches!(block.terminator, Terminator::Unreachable)),
+            "DCE must leave no unreachable placeholder blocks behind"
         );
     }
 

--- a/crates/rue-cfg/src/opt/simplify.rs
+++ b/crates/rue-cfg/src/opt/simplify.rs
@@ -1133,9 +1133,10 @@ mod tests {
             ),
             "entry must return the else-arm value directly"
         );
-        // The dead then-arm is a husk.
-        let dead = cfg.get_block(then_block);
-        assert!(dead.insts.is_empty());
-        assert!(matches!(dead.terminator, Terminator::Unreachable));
+        // The dead then-arm is gone entirely: DCE compacts unreachable blocks
+        // away rather than leaving an `Unreachable` husk behind (RUE-769), so
+        // the collapsed diamond is a single densely numbered block.
+        assert_eq!(cfg.block_count(), 1);
+        assert_eq!(cfg.get_block(cfg.entry).id, cfg.entry);
     }
 }

--- a/crates/rue-cfg/src/payload.rs
+++ b/crates/rue-cfg/src/payload.rs
@@ -244,13 +244,26 @@ impl<S, E> Store<S, E> {
         })
     }
 
-    fn view<F>(&self, range: &Range<F>, family: &'static str) -> Result<&[E], PayloadError>
+    /// Resolve `range` to element indices, or `None` for the canonical empty
+    /// range. Shared by the shared and exclusive views so both agree on what a
+    /// well-formed range is.
+    fn bounds<F>(
+        &self,
+        range: &Range<F>,
+        family: &'static str,
+    ) -> Result<Option<(usize, usize)>, PayloadError>
     where
         F: Family<Store = S>,
     {
+        let malformed = || PayloadError {
+            family,
+            start: range.start,
+            extent: range.extent,
+            store_len: self.elements.len(),
+        };
         if range.extent == 0 {
             return if range.start == 0 {
-                Ok(&[])
+                Ok(None)
             } else {
                 Err(PayloadError {
                     family,
@@ -260,30 +273,37 @@ impl<S, E> Store<S, E> {
                 })
             };
         }
-        let start = usize::try_from(range.start).map_err(|_| PayloadError {
-            family,
-            start: range.start,
-            extent: range.extent,
-            store_len: self.elements.len(),
-        })?;
-        let extent = usize::try_from(range.extent).map_err(|_| PayloadError {
-            family,
-            start: range.start,
-            extent: range.extent,
-            store_len: self.elements.len(),
-        })?;
-        let end = start.checked_add(extent).ok_or(PayloadError {
-            family,
-            start: range.start,
-            extent: range.extent,
-            store_len: self.elements.len(),
-        })?;
-        self.elements.get(start..end).ok_or(PayloadError {
-            family,
-            start: range.start,
-            extent: range.extent,
-            store_len: self.elements.len(),
-        })
+        let start = usize::try_from(range.start).map_err(|_| malformed())?;
+        let extent = usize::try_from(range.extent).map_err(|_| malformed())?;
+        let end = start.checked_add(extent).ok_or_else(malformed)?;
+        if end > self.elements.len() {
+            return Err(malformed());
+        }
+        Ok(Some((start, end)))
+    }
+
+    fn view<F>(&self, range: &Range<F>, family: &'static str) -> Result<&[E], PayloadError>
+    where
+        F: Family<Store = S>,
+    {
+        match self.bounds(range, family)? {
+            None => Ok(&[]),
+            Some((start, end)) => Ok(&self.elements[start..end]),
+        }
+    }
+
+    fn view_mut<F>(
+        &mut self,
+        range: &Range<F>,
+        family: &'static str,
+    ) -> Result<&mut [E], PayloadError>
+    where
+        F: Family<Store = S>,
+    {
+        match self.bounds(range, family)? {
+            None => Ok(&mut []),
+            Some((start, end)) => Ok(&mut self.elements[start..end]),
+        }
     }
 }
 
@@ -409,6 +429,27 @@ accessors!(
     Projections,
     Projection
 );
+
+/// Rewrite the target of every switch case in `range` through `remap`.
+///
+/// A `Switch`'s case targets are the only block references that live in a
+/// payload store rather than in the terminator struct itself, so block
+/// compaction (RUE-769) needs to renumber them in place. This stays a narrow
+/// per-range operation instead of a mutable slice accessor so the store's
+/// elements are never handed out for general mutation, and so the case values
+/// themselves cannot be edited through it.
+pub(crate) fn remap_switch_case_targets(
+    store: &mut SwitchCases,
+    range: &CfgSwitchCases,
+    mut remap: impl FnMut(BlockId) -> BlockId,
+) {
+    let cases = store
+        .view_mut(&range.0, CfgSwitchCases::FAMILY)
+        .expect("validated CFG payload");
+    for (_, target) in cases {
+        *target = remap(*target);
+    }
+}
 
 /// Safe fuzzing hook for the owner-local checked CFG range decoders.
 #[doc(hidden)]

--- a/crates/rue-cli-tests/cases/aggregate_abi_matrix.toml
+++ b/crates/rue-cli-tests/cases/aggregate_abi_matrix.toml
@@ -89,11 +89,11 @@ files = [{ path = "main.rue", source = """
 struct S1 { a: i32 }
 fn main() -> i32 {
     checked {
-        let wp: ptr mut S1 = @alloc(1);
+        let wp: ptr mut S1 = @int_to_ptr(@ptr_to_int(@alloc(1 * @intCast(@size_of(S1)), @intCast(@align_of(S1)))));
         @ptr_write(wp, S1 { a: 55 });
         let v = @ptr_read(wp);
         @dbg(v.a);
-        @free(wp, 1);
+        @free(@int_to_ptr(@ptr_to_int(wp)), 1 * @intCast(@size_of(S1)), @intCast(@align_of(S1)));
     };
     0
 }
@@ -200,11 +200,11 @@ files = [{ path = "main.rue", source = """
 struct S2 { a: i32, b: i32 }
 fn main() -> i32 {
     checked {
-        let wp: ptr mut S2 = @alloc(1);
+        let wp: ptr mut S2 = @int_to_ptr(@ptr_to_int(@alloc(1 * @intCast(@size_of(S2)), @intCast(@align_of(S2)))));
         @ptr_write(wp, S2 { a: 7, b: 8 });
         let v = @ptr_read(wp);
         @dbg(v.a); @dbg(v.b);
-        @free(wp, 1);
+        @free(@int_to_ptr(@ptr_to_int(wp)), 1 * @intCast(@size_of(S2)), @intCast(@align_of(S2)));
     };
     0
 }
@@ -239,11 +239,11 @@ files = [{ path = "main.rue", source = """
 struct S3 { a: i32, b: i32, c: i32 }
 fn main() -> i32 {
     checked {
-        let wp: ptr mut S3 = @alloc(1);
+        let wp: ptr mut S3 = @int_to_ptr(@ptr_to_int(@alloc(1 * @intCast(@size_of(S3)), @intCast(@align_of(S3)))));
         @ptr_write(wp, S3 { a: 3, b: 6, c: 9 });
         let v = @ptr_read(wp);
         @dbg(v.a); @dbg(v.b); @dbg(v.c);
-        @free(wp, 1);
+        @free(@int_to_ptr(@ptr_to_int(wp)), 1 * @intCast(@size_of(S3)), @intCast(@align_of(S3)));
     };
     0
 }
@@ -295,11 +295,11 @@ files = [{ path = "main.rue", source = """
 struct S8 { a: i32, b: i32, c: i32, d: i32, e: i32, f: i32, g: i32, h: i32 }
 fn main() -> i32 {
     checked {
-        let wp: ptr mut S8 = @alloc(1);
+        let wp: ptr mut S8 = @int_to_ptr(@ptr_to_int(@alloc(1 * @intCast(@size_of(S8)), @intCast(@align_of(S8)))));
         @ptr_write(wp, S8 { a: 11, b: 22, c: 33, d: 44, e: 55, f: 66, g: 77, h: 88 });
         let v = @ptr_read(wp);
         @dbg(v.a); @dbg(v.e); @dbg(v.h);
-        @free(wp, 1);
+        @free(@int_to_ptr(@ptr_to_int(wp)), 1 * @intCast(@size_of(S8)), @intCast(@align_of(S8)));
     };
     0
 }
@@ -366,11 +366,11 @@ struct Inner { a: i32, b: i32 }
 struct Outer { p: Inner, q: i32 }
 fn main() -> i32 {
     checked {
-        let wp: ptr mut Outer = @alloc(1);
+        let wp: ptr mut Outer = @int_to_ptr(@ptr_to_int(@alloc(1 * @intCast(@size_of(Outer)), @intCast(@align_of(Outer)))));
         @ptr_write(wp, Outer { p: Inner { a: 1, b: 2 }, q: 3 });
         let v = @ptr_read(wp);
         @dbg(v.p.a); @dbg(v.p.b); @dbg(v.q);
-        @free(wp, 1);
+        @free(@int_to_ptr(@ptr_to_int(wp)), 1 * @intCast(@size_of(Outer)), @intCast(@align_of(Outer)));
     };
     0
 }
@@ -430,11 +430,11 @@ files = [{ path = "main.rue", source = """
 struct ArrBox { a: [i32; 4] }
 fn main() -> i32 {
     checked {
-        let wp: ptr mut ArrBox = @alloc(1);
+        let wp: ptr mut ArrBox = @int_to_ptr(@ptr_to_int(@alloc(1 * @intCast(@size_of(ArrBox)), @intCast(@align_of(ArrBox)))));
         @ptr_write(wp, ArrBox { a: [1, 2, 3, 4] });
         let v = @ptr_read(wp);
         @dbg(v.a[0]); @dbg(v.a[3]);
-        @free(wp, 1);
+        @free(@int_to_ptr(@ptr_to_int(wp)), 1 * @intCast(@size_of(ArrBox)), @intCast(@align_of(ArrBox)));
     };
     0
 }
@@ -481,11 +481,11 @@ struct P { x: i32, y: i32 }
 struct AosBox { a: [P; 2] }
 fn main() -> i32 {
     checked {
-        let wp: ptr mut AosBox = @alloc(1);
+        let wp: ptr mut AosBox = @int_to_ptr(@ptr_to_int(@alloc(1 * @intCast(@size_of(AosBox)), @intCast(@align_of(AosBox)))));
         @ptr_write(wp, AosBox { a: [P { x: 1, y: 2 }, P { x: 3, y: 4 }] });
         let v = @ptr_read(wp);
         @dbg(v.a[0].x); @dbg(v.a[1].y);
-        @free(wp, 1);
+        @free(@int_to_ptr(@ptr_to_int(wp)), 1 * @intCast(@size_of(AosBox)), @intCast(@align_of(AosBox)));
     };
     0
 }
@@ -617,11 +617,11 @@ enum E { V(i32, i32), Empty }
 fn sum(e: E) -> i32 { match e { E.V(x, y) => x + y, E.Empty => 0 } }
 fn main() -> i32 {
     checked {
-        let wp: ptr mut E = @alloc(1);
+        let wp: ptr mut E = @int_to_ptr(@ptr_to_int(@alloc(1 * @intCast(@size_of(E)), @intCast(@align_of(E)))));
         @ptr_write(wp, E.V(9, 8));
         let v = @ptr_read(wp);
         @dbg(sum(v));
-        @free(wp, 1);
+        @free(@int_to_ptr(@ptr_to_int(wp)), 1 * @intCast(@size_of(E)), @intCast(@align_of(E)));
     };
     0
 }

--- a/crates/rue-cli-tests/cases/aggregate_ascending_layout.toml
+++ b/crates/rue-cli-tests/cases/aggregate_ascending_layout.toml
@@ -34,9 +34,9 @@ files = [{ path = "main.rue", source = """
 struct Pair { a: i32, b: i32 }
 fn main() -> i32 {
     checked {
-        let guard: ptr mut Pair = @alloc(1);
+        let guard: ptr mut Pair = @int_to_ptr(@ptr_to_int(@alloc(1 * @intCast(@size_of(Pair)), @intCast(@align_of(Pair)))));
         @ptr_write(guard, Pair { a: 999, b: 999 });
-        let p: ptr mut Pair = @alloc(2);
+        let p: ptr mut Pair = @int_to_ptr(@ptr_to_int(@alloc(2 * @intCast(@size_of(Pair)), @intCast(@align_of(Pair)))));
         @ptr_write(p, Pair { a: 11, b: 22 });
         let q: ptr mut Pair = @ptr_offset(p, 1);
         @ptr_write(q, Pair { a: 33, b: 44 });
@@ -46,8 +46,8 @@ fn main() -> i32 {
         @dbg(v1.a); @dbg(v1.b);
         let g = @ptr_read(guard);
         @dbg(g.a); @dbg(g.b);
-        @free(p, 2);
-        @free(guard, 1);
+        @free(@int_to_ptr(@ptr_to_int(p)), 2 * @intCast(@size_of(Pair)), @intCast(@align_of(Pair)));
+        @free(@int_to_ptr(@ptr_to_int(guard)), 1 * @intCast(@size_of(Pair)), @intCast(@align_of(Pair)));
     };
     0
 }

--- a/crates/rue-cli-tests/cases/aggregate_layout.toml
+++ b/crates/rue-cli-tests/cases/aggregate_layout.toml
@@ -170,25 +170,25 @@ args = ["main.rue", "-o", "prog"]
 files = [{ path = "main.rue", source = """
 fn main() -> i32 {
     checked {
-        let pi: ptr mut i32 = @alloc(1);
+        let pi: ptr mut i32 = @int_to_ptr(@ptr_to_int(@alloc(1 * @intCast(@size_of(i32)), @intCast(@align_of(i32)))));
         @ptr_write(pi, 10);
         @dbg(@ptr_read(pi));
-        @free(pi, 1);
-        let ps: ptr mut i16 = @alloc(1);
+        @free(@int_to_ptr(@ptr_to_int(pi)), 1 * @intCast(@size_of(i32)), @intCast(@align_of(i32)));
+        let ps: ptr mut i16 = @int_to_ptr(@ptr_to_int(@alloc(1 * @intCast(@size_of(i16)), @intCast(@align_of(i16)))));
         let neg: i16 = -1;
         @ptr_write(ps, neg);
         @dbg(@ptr_read(ps));
-        @free(ps, 1);
-        let pu: ptr mut u16 = @alloc(1);
+        @free(@int_to_ptr(@ptr_to_int(ps)), 1 * @intCast(@size_of(i16)), @intCast(@align_of(i16)));
+        let pu: ptr mut u16 = @int_to_ptr(@ptr_to_int(@alloc(1 * @intCast(@size_of(u16)), @intCast(@align_of(u16)))));
         let big: u16 = 65535;
         @ptr_write(pu, big);
         @dbg(@ptr_read(pu));
-        @free(pu, 1);
-        let pb: ptr mut u8 = @alloc(1);
+        @free(@int_to_ptr(@ptr_to_int(pu)), 1 * @intCast(@size_of(u16)), @intCast(@align_of(u16)));
+        let pb: ptr mut u8 = @int_to_ptr(@ptr_to_int(@alloc(1 * @intCast(@size_of(u8)), @intCast(@align_of(u8)))));
         let by: u8 = 200;
         @ptr_write(pb, by);
         @dbg(@ptr_read(pb));
-        @free(pb, 1);
+        @free(@int_to_ptr(@ptr_to_int(pb)), 1 * @intCast(@size_of(u8)), @intCast(@align_of(u8)));
     };
     0
 }
@@ -206,7 +206,7 @@ args = ["main.rue", "-o", "prog"]
 files = [{ path = "main.rue", source = """
 fn main() -> i32 {
     checked {
-        let pa: ptr mut u8 = @alloc(4);
+        let pa: ptr mut u8 = @int_to_ptr(@ptr_to_int(@alloc(4 * @intCast(@size_of(u8)), @intCast(@align_of(u8)))));
         let v0: u8 = 10; let v1: u8 = 20; let v2: u8 = 30; let v3: u8 = 40;
         @ptr_write(@ptr_offset(pa, 0), v0);
         @ptr_write(@ptr_offset(pa, 1), v1);
@@ -214,21 +214,21 @@ fn main() -> i32 {
         @ptr_write(@ptr_offset(pa, 3), v3);
         @dbg(@ptr_read(@ptr_offset(pa, 0)));
         @dbg(@ptr_read(@ptr_offset(pa, 3)));
-        @free(pa, 4);
-        let ph: ptr mut i16 = @alloc(3);
+        @free(@int_to_ptr(@ptr_to_int(pa)), 4 * @intCast(@size_of(u8)), @intCast(@align_of(u8)));
+        let ph: ptr mut i16 = @int_to_ptr(@ptr_to_int(@alloc(3 * @intCast(@size_of(i16)), @intCast(@align_of(i16)))));
         let h0: i16 = -5; let h1: i16 = 6; let h2: i16 = -7;
         @ptr_write(@ptr_offset(ph, 0), h0);
         @ptr_write(@ptr_offset(ph, 1), h1);
         @ptr_write(@ptr_offset(ph, 2), h2);
         @dbg(@ptr_read(@ptr_offset(ph, 0)));
         @dbg(@ptr_read(@ptr_offset(ph, 2)));
-        @free(ph, 3);
-        let pw: ptr mut i32 = @alloc(3);
+        @free(@int_to_ptr(@ptr_to_int(ph)), 3 * @intCast(@size_of(i16)), @intCast(@align_of(i16)));
+        let pw: ptr mut i32 = @int_to_ptr(@ptr_to_int(@alloc(3 * @intCast(@size_of(i32)), @intCast(@align_of(i32)))));
         @ptr_write(@ptr_offset(pw, 0), 100);
         @ptr_write(@ptr_offset(pw, 1), 200);
         @ptr_write(@ptr_offset(pw, 2), 300);
         @dbg(@ptr_read(@ptr_offset(pw, 2)));
-        @free(pw, 3);
+        @free(@int_to_ptr(@ptr_to_int(pw)), 3 * @intCast(@size_of(i32)), @intCast(@align_of(i32)));
     };
     0
 }
@@ -281,10 +281,10 @@ files = [{ path = "main.rue", source = """
 struct Padded { a: u8, b: i32, c: u8 }
 fn main() -> i32 {
     let r = checked {
-        let p: ptr mut Padded = @alloc(1);
+        let p: ptr mut Padded = @int_to_ptr(@ptr_to_int(@alloc(1 * @intCast(@size_of(Padded)), @intCast(@align_of(Padded)))));
         @ptr_write(p, Padded { a: 7, b: 100000, c: 9 });
         let q = @ptr_read(p);
-        @free(p, 1);
+        @free(@int_to_ptr(@ptr_to_int(p)), 1 * @intCast(@size_of(Padded)), @intCast(@align_of(Padded)));
         q
     };
     let ra: i32 = @intCast(r.a);
@@ -312,10 +312,10 @@ files = [{ path = "main.rue", source = """
 struct HasArr { xs: [i32; 2] }
 fn main() -> i32 {
     let r = checked {
-        let p: ptr mut HasArr = @alloc(1);
+        let p: ptr mut HasArr = @int_to_ptr(@ptr_to_int(@alloc(1 * @intCast(@size_of(HasArr)), @intCast(@align_of(HasArr)))));
         @ptr_write(p, HasArr { xs: [10, 20] });
         let v = @ptr_read(p);
-        @free(p, 1);
+        @free(@int_to_ptr(@ptr_to_int(p)), 1 * @intCast(@size_of(HasArr)), @intCast(@align_of(HasArr)));
         v.xs[0] + v.xs[1]
     };
     @dbg(r);
@@ -381,14 +381,14 @@ files = [{ path = "main.rue", source = """
 enum Opt { Some(i32), None }
 fn main() -> i32 {
     checked {
-        let p: ptr mut Opt = @alloc(1);
+        let p: ptr mut Opt = @int_to_ptr(@ptr_to_int(@alloc(1 * @intCast(@size_of(Opt)), @intCast(@align_of(Opt)))));
         @ptr_write(p, Opt.Some(42));
         let some = @ptr_read(p);
         match some { Opt.Some(x) => @dbg(x), Opt.None => @dbg(-1), };
         @ptr_write(p, Opt.None);
         let none = @ptr_read(p);
         match none { Opt.Some(x) => @dbg(x), Opt.None => @dbg(-1), };
-        @free(p, 1);
+        @free(@int_to_ptr(@ptr_to_int(p)), 1 * @intCast(@size_of(Opt)), @intCast(@align_of(Opt)));
     };
     0
 }
@@ -409,7 +409,7 @@ files = [{ path = "main.rue", source = """
 enum Num { B(u8), W(i32), Big(i64) }
 fn main() -> i32 {
     checked {
-        let p: ptr mut Num = @alloc(1);
+        let p: ptr mut Num = @int_to_ptr(@ptr_to_int(@alloc(1 * @intCast(@size_of(Num)), @intCast(@align_of(Num)))));
         @ptr_write(p, Num.B(200));
         let a = @ptr_read(p);
         match a { Num.B(x) => @dbg(x), Num.W(y) => @dbg(y), Num.Big(z) => { let zi: i64 = z; @dbg(zi); }, };
@@ -419,7 +419,7 @@ fn main() -> i32 {
         @ptr_write(p, Num.Big(9000000000));
         let c = @ptr_read(p);
         match c { Num.B(x) => @dbg(x), Num.W(y) => @dbg(y), Num.Big(z) => { let zi: i64 = z; @dbg(zi); }, };
-        @free(p, 1);
+        @free(@int_to_ptr(@ptr_to_int(p)), 1 * @intCast(@size_of(Num)), @intCast(@align_of(Num)));
     };
     0
 }
@@ -439,14 +439,14 @@ files = [{ path = "main.rue", source = """
 enum Shape { Circle(i32), Rect(i32, i32), Empty }
 fn main() -> i32 {
     checked {
-        let p: ptr mut Shape = @alloc(1);
+        let p: ptr mut Shape = @int_to_ptr(@ptr_to_int(@alloc(1 * @intCast(@size_of(Shape)), @intCast(@align_of(Shape)))));
         @ptr_write(p, Shape.Rect(3, 4));
         let r = @ptr_read(p);
         match r { Shape.Circle(a) => @dbg(a), Shape.Rect(w, h) => @dbg(w + h), Shape.Empty => @dbg(0), };
         @ptr_write(p, Shape.Circle(9));
         let c = @ptr_read(p);
         match c { Shape.Circle(a) => @dbg(a), Shape.Rect(w, h) => @dbg(w + h), Shape.Empty => @dbg(0), };
-        @free(p, 1);
+        @free(@int_to_ptr(@ptr_to_int(p)), 1 * @intCast(@size_of(Shape)), @intCast(@align_of(Shape)));
     };
     0
 }
@@ -470,7 +470,7 @@ files = [{ path = "main.rue", source = """
 enum Wide { A(u8, i32), B }
 fn main() -> i32 {
     checked {
-        let ep: ptr mut Wide = @alloc(1);
+        let ep: ptr mut Wide = @int_to_ptr(@ptr_to_int(@alloc(1 * @intCast(@size_of(Wide)), @intCast(@align_of(Wide)))));
         let addr: u64 = @ptr_to_int(ep);
         let bp: ptr mut u8 = @int_to_ptr(addr);
         // Poison every byte so any un-zeroed padding would be observable.
@@ -508,7 +508,7 @@ fn main() -> i32 {
         if @byte_read(bp, 5) != 0 { return 13; }
         if @byte_read(bp, 6) != 0 { return 14; }
         if @byte_read(bp, 7) != 0 { return 15; }
-        @free(ep, 1);
+        @free(@int_to_ptr(@ptr_to_int(ep)), 1 * @intCast(@size_of(Wide)), @intCast(@align_of(Wide)));
     };
     0
 }
@@ -532,12 +532,12 @@ fn first(v: Bad) -> i64 {
 }
 fn main() -> i32 {
     let r = checked {
-        let p: ptr mut Bad = @alloc(1);
+        let p: ptr mut Bad = @int_to_ptr(@ptr_to_int(@alloc(1 * @intCast(@size_of(Bad)), @intCast(@align_of(Bad)))));
         @ptr_write(p, Bad.A(0 - 3));
         let a: Bad = @ptr_read(p);
         @ptr_write(p, Bad.B(40, 2));
         let b: Bad = @ptr_read(p);
-        @free(p, 1);
+        @free(@int_to_ptr(@ptr_to_int(p)), 1 * @intCast(@size_of(Bad)), @intCast(@align_of(Bad)));
         first(a) * 100 + first(b)
     };
     let t: i32 = @intCast(r);
@@ -560,12 +560,12 @@ struct Res { id: i32 }
 enum Holder { Full(Res), Nothing }
 fn main() -> i32 {
     let r = checked {
-        let p: ptr mut Holder = @alloc(1);
+        let p: ptr mut Holder = @int_to_ptr(@ptr_to_int(@alloc(1 * @intCast(@size_of(Holder)), @intCast(@align_of(Holder)))));
         @ptr_write(p, Holder.Full(Res { id: 7 }));
         let a = @ptr_read(p);
         @ptr_write(p, Holder.Nothing);
         let b = @ptr_read(p);
-        @free(p, 1);
+        @free(@int_to_ptr(@ptr_to_int(p)), 1 * @intCast(@size_of(Holder)), @intCast(@align_of(Holder)));
         let av: i32 = match a { Holder.Full(res) => res.id, Holder.Nothing => 0 - 1 };
         let bv: i32 = match b { Holder.Full(res) => res.id, Holder.Nothing => 0 - 1 };
         av * 10 + bv
@@ -897,7 +897,7 @@ pub fn ArrayBuf(comptime T: type) -> type {
             if self.len == self.cap {
                 let new_cap: u64 = if self.cap == 0 { 4 } else { self.cap * 2 };
                 checked {
-                    let grown = @realloc(self.buf, self.cap, new_cap);
+                    let grown = @int_to_ptr(@ptr_to_int(@realloc(@int_to_ptr(@ptr_to_int(self.buf)), self.cap * @intCast(@size_of(T)), @intCast(@align_of(T)), new_cap * @intCast(@size_of(T)))));
                     self.buf = grown;
                 };
                 self.cap = new_cap;
@@ -945,7 +945,7 @@ pub fn ArrayBuf(comptime T: type) -> type {
         }
         fn clear(inout self) { self.len = 0; }
         fn free(inout self) {
-            checked { @free(self.buf, self.cap); };
+            checked { @free(@int_to_ptr(@ptr_to_int(self.buf)), self.cap * @intCast(@size_of(T)), @intCast(@align_of(T))); };
             let zero: u64 = 0;
             self.buf = checked { @int_to_ptr(zero) };
             self.len = 0;
@@ -1014,7 +1014,7 @@ pub fn ArrayBuf(comptime T: type) -> type {
             if self.len == self.cap {
                 let new_cap: u64 = if self.cap == 0 { 4 } else { self.cap * 2 };
                 checked {
-                    let grown = @realloc(self.buf, self.cap, new_cap);
+                    let grown = @int_to_ptr(@ptr_to_int(@realloc(@int_to_ptr(@ptr_to_int(self.buf)), self.cap * @intCast(@size_of(T)), @intCast(@align_of(T)), new_cap * @intCast(@size_of(T)))));
                     self.buf = grown;
                 };
                 self.cap = new_cap;
@@ -1048,7 +1048,7 @@ pub fn ArrayBuf(comptime T: type) -> type {
             }
         }
         fn free(inout self) {
-            checked { @free(self.buf, self.cap); };
+            checked { @free(@int_to_ptr(@ptr_to_int(self.buf)), self.cap * @intCast(@size_of(T)), @intCast(@align_of(T))); };
             let zero: u64 = 0;
             self.buf = checked { @int_to_ptr(zero) };
             self.len = 0;
@@ -1101,12 +1101,12 @@ files = [{ path = "main.rue", source = """
 enum E { Big(i64, i64), Small(u8) }
 fn main() -> i32 {
     let hi = checked {
-        let p: ptr mut E = @alloc(1);
+        let p: ptr mut E = @int_to_ptr(@ptr_to_int(@alloc(1 * @intCast(@size_of(E)), @intCast(@align_of(E)))));
         @ptr_write(p, E.Big(0 - 1, 0 - 1));
         @ptr_write(p, E.Small(7));
         let bytes: ptr mut u8 = @int_to_ptr(@ptr_to_int(p));
         let b: u8 = @ptr_read(@ptr_offset(bytes, 16));
-        @free(p, 1);
+        @free(@int_to_ptr(@ptr_to_int(p)), 1 * @intCast(@size_of(E)), @intCast(@align_of(E)));
         let z: i32 = @intCast(b);
         z
     };
@@ -1285,13 +1285,13 @@ fn classify(r: R) -> i64 {
 }
 fn main() -> i32 {
     let out = checked {
-        let p: ptr mut R = @alloc(1);
+        let p: ptr mut R = @int_to_ptr(@ptr_to_int(@alloc(1 * @intCast(@size_of(R)), @intCast(@align_of(R)))));
         @ptr_write(p, R.Ok(Point { x: 11, y: 22, z: 33 }));
         @ptr_write(p, R.Err(0 - 5));
         let bytes: ptr mut u8 = @int_to_ptr(@ptr_to_int(p));
         let poison: u8 = @ptr_read(@ptr_offset(bytes, 16));
         let r: R = @ptr_read(p);
-        @free(p, 1);
+        @free(@int_to_ptr(@ptr_to_int(p)), 1 * @intCast(@size_of(R)), @intCast(@align_of(R)));
         let z: i32 = @intCast(classify(r)) + @intCast(poison);
         z
     };

--- a/crates/rue-cli-tests/cases/aggregate_layout_std_sweep.toml
+++ b/crates/rue-cli-tests/cases/aggregate_layout_std_sweep.toml
@@ -40,7 +40,7 @@ files = [{ path = "main.rue", source = """
 struct Rec { id: u8, val: i32, tag: u16 }
 fn main() -> i32 {
     let sum = checked {
-        let p: ptr mut Rec = @alloc(4);
+        let p: ptr mut Rec = @int_to_ptr(@ptr_to_int(@alloc(4 * @intCast(@size_of(Rec)), @intCast(@align_of(Rec)))));
         let mut i: u64 = 0;
         while i < 4 {
             let slot = @ptr_offset(p, i);
@@ -56,7 +56,7 @@ fn main() -> i32 {
             s = s + r.val + idc + tg;
             j = j + 1;
         }
-        @free(p, 4);
+        @free(@int_to_ptr(@ptr_to_int(p)), 4 * @intCast(@size_of(Rec)), @intCast(@align_of(Rec)));
         s
     };
     @dbg(sum);
@@ -79,10 +79,10 @@ struct Inner { a: u8, b: i32 }
 struct Outer { x: u16, inner: Inner, y: u8 }
 fn main() -> i32 {
     let r = checked {
-        let p: ptr mut Outer = @alloc(1);
+        let p: ptr mut Outer = @int_to_ptr(@ptr_to_int(@alloc(1 * @intCast(@size_of(Outer)), @intCast(@align_of(Outer)))));
         @ptr_write(p, Outer { x: 300, inner: Inner { a: 5, b: 9999 }, y: 42 });
         let o = @ptr_read(p);
-        @free(p, 1);
+        @free(@int_to_ptr(@ptr_to_int(p)), 1 * @intCast(@size_of(Outer)), @intCast(@align_of(Outer)));
         o
     };
     let x: i32 = @intCast(r.x);
@@ -108,13 +108,13 @@ args = ["main.rue", "-o", "prog"]
 files = [{ path = "main.rue", source = """
 fn main() -> i32 {
     let sum = checked {
-        let p: ptr mut u8 = @alloc(5);
+        let p: ptr mut u8 = @int_to_ptr(@ptr_to_int(@alloc(5 * @intCast(@size_of(u8)), @intCast(@align_of(u8)))));
         let mut i: u64 = 0;
         while i < 5 { let bv: u8 = @intCast(65 + i); @ptr_write(@ptr_offset(p, i), bv); i = i + 1; }
         let mut s: i32 = 0;
         let mut j: u64 = 0;
         while j < 5 { let b: i32 = @intCast(@ptr_read(@ptr_offset(p, j))); s = s + b; j = j + 1; }
-        @free(p, 5);
+        @free(@int_to_ptr(@ptr_to_int(p)), 5 * @intCast(@size_of(u8)), @intCast(@align_of(u8)));
         s
     };
     @dbg(sum);
@@ -166,7 +166,7 @@ pub fn ArrayBuf(comptime T: type) -> type {
         fn reserve(inout self) {
             if self.len == self.cap {
                 let nc: u64 = if self.cap == 0 { 4 } else { self.cap * 2 };
-                checked { let g = @realloc(self.buf, self.cap, nc); self.buf = g; };
+                checked { let g = @int_to_ptr(@ptr_to_int(@realloc(@int_to_ptr(@ptr_to_int(self.buf)), self.cap * @intCast(@size_of(T)), @intCast(@align_of(T)), nc * @intCast(@size_of(T))))); self.buf = g; };
                 self.cap = nc;
             }
         }
@@ -186,7 +186,7 @@ pub fn ArrayBuf(comptime T: type) -> type {
             }
         }
         fn free(inout self) {
-            checked { @free(self.buf, self.cap); };
+            checked { @free(@int_to_ptr(@ptr_to_int(self.buf)), self.cap * @intCast(@size_of(T)), @intCast(@align_of(T))); };
             let z: u64 = 0; self.buf = checked { @int_to_ptr(z) }; self.len = 0; self.cap = 0;
         }
     }
@@ -346,12 +346,12 @@ enum Ov { A(u16, u16), B(u32) }
 fn make(v: bool) -> Ov { if v { Ov.A(1, 2) } else { Ov.B(3) } }
 fn main() -> i32 {
     let r = checked {
-        let p: ptr mut Ov = @alloc(1);
+        let p: ptr mut Ov = @int_to_ptr(@ptr_to_int(@alloc(1 * @intCast(@size_of(Ov)), @intCast(@align_of(Ov)))));
         @ptr_write(p, make(true));
         let a: Ov = @ptr_read(p);
         @ptr_write(p, make(false));
         let b: Ov = @ptr_read(p);
-        @free(p, 1);
+        @free(@int_to_ptr(@ptr_to_int(p)), 1 * @intCast(@size_of(Ov)), @intCast(@align_of(Ov)));
         let av: i32 = match a { Ov.A(x, y) => @intCast(x) + @intCast(y), Ov.B(c) => @intCast(c) };
         let bv: i32 = match b { Ov.A(x, y) => @intCast(x) + @intCast(y), Ov.B(c) => @intCast(c) };
         av * 10 + bv
@@ -409,10 +409,10 @@ fn main() -> i32 {
     let s1 = classify(local_addr_ok());
     let s2 = classify(local_addr_err());
     let s3 = checked {
-        let p: ptr mut NetResult = @alloc(1);
+        let p: ptr mut NetResult = @int_to_ptr(@ptr_to_int(@alloc(1 * @intCast(@size_of(NetResult)), @intCast(@align_of(NetResult)))));
         @ptr_write(p, local_addr_ok());
         let back: NetResult = @ptr_read(p);
-        @free(p, 1);
+        @free(@int_to_ptr(@ptr_to_int(p)), 1 * @intCast(@size_of(NetResult)), @intCast(@align_of(NetResult)));
         classify(back)
     };
     let total: i32 = @intCast(s1 + s2 + s3);

--- a/crates/rue-cli-tests/cases/anon_struct_destructor.toml
+++ b/crates/rue-cli-tests/cases/anon_struct_destructor.toml
@@ -167,7 +167,7 @@ fn Buf(comptime T: type) -> type {
             let zero: u64 = 0;
             let mut s = Self { buf: checked { @int_to_ptr(zero) }, cap: 0 };
             checked {
-                let grown = @realloc(s.buf, s.cap, n);
+                let grown = @int_to_ptr(@ptr_to_int(@realloc(@int_to_ptr(@ptr_to_int(s.buf)), s.cap * @intCast(@size_of(T)), @intCast(@align_of(T)), n * @intCast(@size_of(T)))));
                 s.buf = grown;
             };
             s.cap = n;
@@ -180,7 +180,7 @@ fn Buf(comptime T: type) -> type {
         }
 
         drop fn(self) {
-            checked { @free(self.buf, self.cap); };
+            checked { @free(@int_to_ptr(@ptr_to_int(self.buf)), self.cap * @intCast(@size_of(T)), @intCast(@align_of(T))); };
             @dbg(999);
         }
     }

--- a/crates/rue-cli-tests/cases/arraybuf_library.toml
+++ b/crates/rue-cli-tests/cases/arraybuf_library.toml
@@ -86,7 +86,7 @@ pub fn ArrayBuf(comptime T: type) -> type {
             if self.len == self.cap {
                 let new_cap: u64 = if self.cap == 0 { 4 } else { self.cap * 2 };
                 checked {
-                    let grown = @realloc(self.buf, self.cap, new_cap);
+                    let grown = @int_to_ptr(@ptr_to_int(@realloc(@int_to_ptr(@ptr_to_int(self.buf)), self.cap * @intCast(@size_of(T)), @intCast(@align_of(T)), new_cap * @intCast(@size_of(T)))));
                     self.buf = grown;
                 };
                 self.cap = new_cap;
@@ -134,7 +134,7 @@ pub fn ArrayBuf(comptime T: type) -> type {
         }
         fn clear(inout self) { self.len = 0; }
         fn free(inout self) {
-            checked { @free(self.buf, self.cap); };
+            checked { @free(@int_to_ptr(@ptr_to_int(self.buf)), self.cap * @intCast(@size_of(T)), @intCast(@align_of(T))); };
             let zero: u64 = 0;
             self.buf = checked { @int_to_ptr(zero) };
             self.len = 0;
@@ -200,7 +200,7 @@ pub fn ArrayBuf(comptime T: type) -> type {
             if self.len == self.cap {
                 let new_cap: u64 = if self.cap == 0 { 4 } else { self.cap * 2 };
                 checked {
-                    let grown = @realloc(self.buf, self.cap, new_cap);
+                    let grown = @int_to_ptr(@ptr_to_int(@realloc(@int_to_ptr(@ptr_to_int(self.buf)), self.cap * @intCast(@size_of(T)), @intCast(@align_of(T)), new_cap * @intCast(@size_of(T)))));
                     self.buf = grown;
                 };
                 self.cap = new_cap;
@@ -234,7 +234,7 @@ pub fn ArrayBuf(comptime T: type) -> type {
             }
         }
         fn free(inout self) {
-            checked { @free(self.buf, self.cap); };
+            checked { @free(@int_to_ptr(@ptr_to_int(self.buf)), self.cap * @intCast(@size_of(T)), @intCast(@align_of(T))); };
             let zero: u64 = 0;
             self.buf = checked { @int_to_ptr(zero) };
             self.len = 0;
@@ -293,7 +293,7 @@ pub fn ArrayBuf(comptime T: type) -> type {
             if self.len == self.cap {
                 let new_cap: u64 = if self.cap == 0 { 4 } else { self.cap * 2 };
                 checked {
-                    let grown = @realloc(self.buf, self.cap, new_cap);
+                    let grown = @int_to_ptr(@ptr_to_int(@realloc(@int_to_ptr(@ptr_to_int(self.buf)), self.cap * @intCast(@size_of(T)), @intCast(@align_of(T)), new_cap * @intCast(@size_of(T)))));
                     self.buf = grown;
                 };
                 self.cap = new_cap;
@@ -312,7 +312,7 @@ pub fn ArrayBuf(comptime T: type) -> type {
         }
 
         drop fn(self) {
-            checked { @free(self.buf, self.cap); };
+            checked { @free(@int_to_ptr(@ptr_to_int(self.buf)), self.cap * @intCast(@size_of(T)), @intCast(@align_of(T))); };
         }
     }
 }
@@ -384,7 +384,7 @@ pub fn ArrayBuf(comptime T: type) -> type {
             if self.len == self.cap {
                 let new_cap: u64 = if self.cap == 0 { 4 } else { self.cap * 2 };
                 checked {
-                    let grown = @realloc(self.buf, self.cap, new_cap);
+                    let grown = @int_to_ptr(@ptr_to_int(@realloc(@int_to_ptr(@ptr_to_int(self.buf)), self.cap * @intCast(@size_of(T)), @intCast(@align_of(T)), new_cap * @intCast(@size_of(T)))));
                     self.buf = grown;
                 };
                 self.cap = new_cap;
@@ -407,7 +407,7 @@ pub fn ArrayBuf(comptime T: type) -> type {
             }
         }
         fn free(inout self) {
-            checked { @free(self.buf, self.cap); };
+            checked { @free(@int_to_ptr(@ptr_to_int(self.buf)), self.cap * @intCast(@size_of(T)), @intCast(@align_of(T))); };
             let zero: u64 = 0;
             self.buf = checked { @int_to_ptr(zero) };
             self.len = 0;
@@ -509,7 +509,7 @@ pub fn ArrayBuf(comptime T: type) -> type {
             if self.len == self.cap {
                 let new_cap: u64 = if self.cap == 0 { 4 } else { self.cap * 2 };
                 checked {
-                    let grown = @realloc(self.buf, self.cap, new_cap);
+                    let grown = @int_to_ptr(@ptr_to_int(@realloc(@int_to_ptr(@ptr_to_int(self.buf)), self.cap * @intCast(@size_of(T)), @intCast(@align_of(T)), new_cap * @intCast(@size_of(T)))));
                     self.buf = grown;
                 };
                 self.cap = new_cap;

--- a/crates/rue-cli-tests/cases/dce_block_compaction.toml
+++ b/crates/rue-cli-tests/cases/dce_block_compaction.toml
@@ -1,0 +1,136 @@
+# DCE compacts unreachable blocks away (RUE-769).
+#
+# `BlockId` is a dense index into the CFG's block vector, so removing a block
+# implies renumbering every survivor. Rather than pay that, DCE used to empty
+# each unreachable block and give it an `Unreachable` terminator, leaving husks
+# in the graph: every consumer (verification, dominators, display, codegen)
+# then had to walk and skip them, and an `Unreachable` terminator was ambiguous
+# between "this block diverges" and "this block is debris".
+#
+# DCE now runs a remapping compaction: unreachable blocks are dropped and the
+# survivors are renumbered densely, with the entry id, every Goto/Branch target,
+# and every Switch default and case target rewritten in one place
+# (`Cfg::retain_blocks`). These cases pin the observable half of that — the
+# emitted CFG carries no placeholder blocks, its block references still name
+# the right blocks, and control flow through folded branches, matches, and
+# loops is unchanged at every optimization level.
+
+[section]
+id = "cli.dce_block_compaction"
+name = "DCE block compaction"
+description = "Optimized CFGs retain no unreachable placeholder blocks, and every rewritten block reference still selects the right successor (RUE-769)."
+
+# --- The graph itself: no husks left behind ---------------------------------
+[[case]]
+name = "optimized_cfg_has_no_unreachable_placeholder_blocks"
+description = "A folded `if false` and a lowered match leave unreachable blocks behind; after compaction the emitted CFG contains no `unreachable` block at all."
+files = [{ path = "main.rue", source = """
+fn classify(n: i32) -> i32 {
+    let base = if false { 100 } else { 1 };
+    let bonus = match n {
+        0 => 10,
+        1 => 20,
+        _ => 30,
+    };
+    let mut total = base + bonus;
+    let mut i = 0;
+    while i < 3 {
+        total = total + 1;
+        i = i + 1;
+    }
+    total
+}
+fn main() -> i32 {
+    @dbg(classify(0));
+    0
+}
+""" }]
+args = ["--emit", "cfg", "-O1", "main.rue"]
+compile_only = true
+compile_stdout_contains = ["=== CFG ===", "cfg main"]
+# No block in this program diverges, so every `unreachable` in the dump would
+# be a pruned-block husk. Before compaction three of them survived here.
+compile_stdout_not_contains = ["unreachable"]
+
+# --- The references: every rewritten target still selects the right block ---
+[[case]]
+name = "compacted_switch_and_branch_targets_still_select_the_right_arm"
+description = "Renumbering runs across a switch whose arms sit after pruned blocks; each arm, the default, and the loop back-edge must still be reached."
+files = [{ path = "main.rue", source = """
+fn classify(n: i32) -> i32 {
+    let base = if false { 100 } else { 1 };
+    let bonus = match n {
+        0 => 10,
+        1 => 20,
+        _ => 30,
+    };
+    let mut total = base + bonus;
+    let mut i = 0;
+    while i < 3 {
+        total = total + 1;
+        i = i + 1;
+    }
+    total
+}
+fn main() -> i32 {
+    @dbg(classify(0));
+    @dbg(classify(1));
+    @dbg(classify(7));
+    0
+}
+""" }]
+stdout = "14\n24\n34\n"
+exit_code = 0
+differential_opt = true
+
+# --- A genuinely diverging block keeps its Unreachable terminator -----------
+[[case]]
+name = "diverging_block_keeps_its_unreachable_terminator"
+description = "Compaction removes unreachable BLOCKS, not `Unreachable` TERMINATORS: a reachable block that ends in a diverging call keeps one."
+files = [{ path = "main.rue", source = """
+fn bail(n: i32) -> i32 {
+    if n > 0 {
+        @panic("positive");
+    }
+    n
+}
+fn main() -> i32 {
+    @dbg(bail(-1));
+    0
+}
+""" }]
+args = ["--emit", "cfg", "-O1", "main.rue"]
+compile_only = true
+compile_stdout_contains = ["=== CFG ===", "unreachable"]
+
+# --- Nested and early-return control flow survives renumbering --------------
+[[case]]
+name = "nested_loops_and_early_returns_survive_renumbering"
+description = "A denser graph — nested loops, a break, an early return, and a constant-folded guard — still computes the same result at every level."
+files = [{ path = "main.rue", source = """
+fn total(limit: i32) -> i32 {
+    if false { return -1; }
+    let mut sum = 0;
+    let mut i = 0;
+    while i < limit {
+        let mut j = 0;
+        while j < 3 {
+            if j == 2 { break; }
+            sum = sum + j;
+            j = j + 1;
+        }
+        if sum > 100 { return sum; }
+        i = i + 1;
+    }
+    sum
+}
+fn main() -> i32 {
+    @dbg(total(0));
+    @dbg(total(4));
+    @dbg(total(200));
+    0
+}
+""" }]
+stdout = "0\n4\n101\n"
+exit_code = 0
+differential_opt = true

--- a/crates/rue-cli-tests/cases/diagnostic_json.toml
+++ b/crates/rue-cli-tests/cases/diagnostic_json.toml
@@ -4,6 +4,14 @@ name = "JSON diagnostic output"
 description = """
 Regression coverage for RUE-365: --error-format json routes compiler
 diagnostics through the JSON formatter instead of the human-rendered formatter.
+
+RUE-436 extends this from substring matching to schema validation. Cases marked
+`json_diagnostics` parse EVERY stderr line as a JSON array of diagnostic
+objects and reject any object whose key set, field types, or span invariants
+drift from `docs/process/diagnostics.md`; `json_diagnostic_order` then pins the
+exact emission ORDER, so a reordering (or a parallelism-dependent shuffle) is a
+failure and not a silent behavior change. Substring assertions cannot see any
+of that — they pass on malformed JSON as long as the bytes appear somewhere.
 """
 
 [[case]]
@@ -13,6 +21,8 @@ fn main() -> i32 { true }
 """ }]
 args = ["--error-format", "json", "main.rue", "-o", "prog"]
 compile_fail = true
+json_diagnostics = true
+json_diagnostic_order = ["error E0206 main.rue:1:20"]
 error_contains = [
   '"severity":"error"',
   '"code":"E0206"',
@@ -21,7 +31,11 @@ error_contains = [
   '"primary":true',
 ]
 compile_stderr_not_contains = [
-  "error[E0206]",
+  # The exact banner and snippet gutter the TEXT renderer would have produced
+  # for this same program (`error: [E0206]: ...` / ` --> main.rue:1:20`), so
+  # this asserts the human renderer is genuinely bypassed rather than merely
+  # that some other spelling is absent.
+  "error: [E0206]",
   "-->",
 ]
 
@@ -35,6 +49,11 @@ fn main() -> i32 {
 """ }]
 args = ["--error-format", "json", "main.rue", "-o", "prog"]
 compile_only = true
+json_diagnostics = true
+# A warning carries no code today; the digest renders the empty code as `-`.
+# When warnings gain codes this line must change, which is the point: the
+# schema doc and this pin move together.
+json_diagnostic_order = ["warning - main.rue:2:5"]
 compile_stderr_contains = [
   '"severity":"warning"',
   "\"message\":\"unused variable 'unused'\"",
@@ -46,4 +65,174 @@ compile_stderr_not_contains = [
   "warning[",
   "-->",
   "  |",
+]
+
+[[case]]
+name = "error_batch_order_follows_source_order"
+description = """
+RUE-436: four errors in one file must be published in a single JSON array in
+source order. The digest is exact, so a batch that reorders — or drops — a
+diagnostic fails even though every individual substring would still match.
+"""
+files = [{ path = "main.rue", source = """
+fn a() -> i32 { true }
+fn b() -> i32 { false }
+fn c() -> bool { 1 }
+fn main() -> i32 {
+    let x: i32 = a();
+    let y: i32 = b();
+    let z: bool = c();
+    let w: i32 = true;
+    0
+}
+""" }]
+args = ["--error-format", "json", "main.rue", "-o", "prog"]
+compile_fail = true
+json_diagnostics = true
+json_diagnostic_order = [
+  "error E0206 main.rue:1:17",
+  "error E0206 main.rue:2:17",
+  "error E0206 main.rue:3:18",
+  "error E0206 main.rue:8:5",
+]
+error_contains = ['"code":"E0206"']
+
+[[case]]
+name = "error_batch_order_is_job_count_independent"
+description = """
+RUE-436: the SAME program as `error_batch_order_follows_source_order`, compiled
+single-threaded. Identical pinned order proves diagnostic ordering does not
+depend on `-j`/`--jobs` — a machine consumer diffing two CI runs configured
+with different parallelism must not see a spurious change.
+"""
+files = [{ path = "main.rue", source = """
+fn a() -> i32 { true }
+fn b() -> i32 { false }
+fn c() -> bool { 1 }
+fn main() -> i32 {
+    let x: i32 = a();
+    let y: i32 = b();
+    let z: bool = c();
+    let w: i32 = true;
+    0
+}
+""" }]
+args = ["-j1", "--error-format", "json", "main.rue", "-o", "prog"]
+compile_fail = true
+json_diagnostics = true
+json_diagnostic_order = [
+  "error E0206 main.rue:1:17",
+  "error E0206 main.rue:2:17",
+  "error E0206 main.rue:3:18",
+  "error E0206 main.rue:8:5",
+]
+error_contains = ['"code":"E0206"']
+
+[[case]]
+name = "multi_file_errors_are_ordered_and_attributed"
+description = """
+RUE-436: errors from two files in one import graph land in one JSON array, each
+span attributed to the file it actually came from, in a fixed cross-file order.
+Guards both the ordering contract and the multi-file span attribution the
+JSON formatter shares with the text formatter (RUE-175).
+"""
+files = [
+  { path = "main.rue", source = """
+const helper = @import("helper");
+
+fn main() -> i32 {
+    let bad: i32 = true;
+    helper.from_helper()
+}
+""" },
+  { path = "helper.rue", source = """
+pub fn from_helper() -> i32 {
+    let wrong: bool = 1;
+    0
+}
+""" },
+]
+args = ["--error-format", "json", "main.rue", "-o", "prog"]
+compile_fail = true
+json_diagnostics = true
+json_diagnostic_order = [
+  "error E0206 helper.rue:2:5",
+  "error E0206 main.rue:4:5",
+]
+error_contains = ['"file":"helper.rue"', '"file":"main.rue"']
+
+[[case]]
+name = "secondary_span_carries_a_label_after_the_primary"
+description = """
+RUE-436: a diagnostic with a secondary span must place the primary span FIRST
+with a null label, and the secondary after it with its label text and
+`primary: false`. The schema check enforces the ordering invariant; the
+substring assertions pin the label text itself.
+"""
+files = [{ path = "main.rue", source = """
+struct Point { x: i32, y: i32 }
+
+fn take(p: Point) -> i32 { p.x }
+
+fn main() -> i32 {
+    let p = Point { x: 1, y: 2 };
+    let a = take(p);
+    let b = take(p);
+    a + b
+}
+""" }]
+args = ["--error-format", "json", "main.rue", "-o", "prog"]
+compile_fail = true
+json_diagnostics = true
+json_diagnostic_order = ["error E0205 main.rue:8:18"]
+error_contains = [
+  '"code":"E0205"',
+  '"label":"value moved here"',
+  '"primary":false',
+  '"helps":["to use `p` after the move, pass it by borrow instead: `borrow p`"]',
+]
+
+[[case]]
+name = "publication_error_is_a_single_element_array"
+description = """
+RUE-436: the single-error driver paths (output publication here, watch-cycle
+publication in --watch) used to emit a BARE JSON object while every batch path
+emitted an array, so a consumer had to switch on object-vs-array per line. They
+now emit a one-element array like everything else. The schema validator rejects
+a bare object outright, so this case fails if the framing regresses.
+
+The diagnostic also has no spans — a publication failure has no location in the
+user's program — which pins that `spans: []` is legal and digests as `-`.
+"""
+files = [{ path = "main.rue", source = """
+fn main() -> i32 { 0 }
+""" }]
+args = ["--error-format", "json", "main.rue", "-o", "missing_dir/prog"]
+compile_fail = true
+json_diagnostics = true
+json_diagnostic_order = ["error E1403 -"]
+error_contains = [
+  '"code":"E1403"',
+  '"spans":[]',
+  "output publication failed",
+]
+
+[[case]]
+name = "text_format_is_unchanged_by_default"
+description = """
+RUE-436 control case: without --error-format the human renderer still owns
+stderr, so nothing in the JSON work silently promoted JSON to the default.
+"""
+files = [{ path = "main.rue", source = """
+fn main() -> i32 { true }
+""" }]
+args = ["main.rue", "-o", "prog"]
+compile_fail = true
+error_contains = [
+  "error: [E0206]: type mismatch: expected i32, found bool",
+  " --> main.rue:1:20",
+]
+compile_stderr_not_contains = [
+  '"severity":"error"',
+  '"primary":true',
 ]

--- a/crates/rue-cli-tests/cases/heap_intrinsics.toml
+++ b/crates/rue-cli-tests/cases/heap_intrinsics.toml
@@ -1,7 +1,11 @@
-# @alloc / @free / @realloc heap intrinsics driven the way a user does — real
-# files, the real driver, real program exit codes and stdout (RUE-1).
+# The unified byte-and-alignment allocation family driven the way a user does —
+# real files, the real driver, real program exit codes and stdout (RUE-1,
+# ADR-0059 Phase 3 / RUE-961).
 #
-# These are the unchecked heap primitives a source-level ArrayBuf is built on. The
+# These are the unchecked heap primitives a source-level ArrayBuf is built on.
+# `@alloc`/`@realloc`/`@free` take physical byte sizes plus an alignment over
+# `ptr mut u8`, so a fixture that wants `count` values of `T` computes the byte
+# size itself and casts the block — the same thing `std/rawbuf.rue` does. The
 # runtime __rue_alloc/__rue_free/__rue_realloc are already used by StrBuf, so
 # these cases also confirm the archive symbols resolve when referenced only
 # from user code.
@@ -18,7 +22,7 @@ description = "Round-trips values through an @alloc'd i32 buffer and frees it."
 files = [{ path = "main.rue", source = """
 fn main() -> i32 {
     checked {
-        let p: ptr mut i32 = @alloc(3);
+        let p: ptr mut i32 = @int_to_ptr(@ptr_to_int(@alloc(3 * @intCast(@size_of(i32)), @intCast(@align_of(i32)))));
         @ptr_write(p, 10);
         @ptr_write(@ptr_offset(p, 1), 20);
         @ptr_write(@ptr_offset(p, 2), 30);
@@ -26,7 +30,7 @@ fn main() -> i32 {
         @dbg(@ptr_read(@ptr_offset(p, 1)));
         @dbg(@ptr_read(@ptr_offset(p, 2)));
         let sum = @ptr_read(p) + @ptr_read(@ptr_offset(p, 1)) + @ptr_read(@ptr_offset(p, 2));
-        @free(p, 3);
+        @free(@int_to_ptr(@ptr_to_int(p)), 3 * @intCast(@size_of(i32)), @intCast(@align_of(i32)));
         sum
     }
 }
@@ -41,13 +45,13 @@ description = "Growing an @alloc'd block with @realloc keeps the existing elemen
 files = [{ path = "main.rue", source = """
 fn main() -> i32 {
     checked {
-        let mut p: ptr mut i32 = @alloc(2);
+        let mut p: ptr mut i32 = @int_to_ptr(@ptr_to_int(@alloc(2 * @intCast(@size_of(i32)), @intCast(@align_of(i32)))));
         @ptr_write(p, 5);
         @ptr_write(@ptr_offset(p, 1), 7);
-        p = @realloc(p, 2, 16);
+        p = @int_to_ptr(@ptr_to_int(@realloc(@int_to_ptr(@ptr_to_int(p)), 2 * @intCast(@size_of(i32)), @intCast(@align_of(i32)), 16 * @intCast(@size_of(i32)))));
         @ptr_write(@ptr_offset(p, 8), 100);
         let sum: i32 = @ptr_read(p) + @ptr_read(@ptr_offset(p, 1)) + @ptr_read(@ptr_offset(p, 8));
-        @free(p, 16);
+        @free(@int_to_ptr(@ptr_to_int(p)), 16 * @intCast(@size_of(i32)), @intCast(@align_of(i32)));
         sum
     }
 }
@@ -60,21 +64,21 @@ description = "A failed @realloc returns null while the original u8 allocation a
 files = [{ path = "main.rue", source = """
 fn main() -> i32 {
     checked {
-        let p: ptr mut u8 = @alloc(4);
+        let p: ptr mut u8 = @int_to_ptr(@ptr_to_int(@alloc(4 * @intCast(@size_of(u8)), @intCast(@align_of(u8)))));
         @ptr_write(p, 10);
         @ptr_write(@ptr_offset(p, 1), 20);
         @ptr_write(@ptr_offset(p, 2), 30);
         @ptr_write(@ptr_offset(p, 3), 40);
-        let q: ptr mut u8 = @realloc(p, 4, 2305843009213693951);
+        let q: ptr mut u8 = @int_to_ptr(@ptr_to_int(@realloc(@int_to_ptr(@ptr_to_int(p)), 4 * @intCast(@size_of(u8)), @intCast(@align_of(u8)), 2305843009213693951 * @intCast(@size_of(u8)))));
         if @ptr_to_int(q) == 0 {
             let sum: i32 = @intCast(@ptr_read(p))
                 + @intCast(@ptr_read(@ptr_offset(p, 1)))
                 + @intCast(@ptr_read(@ptr_offset(p, 2)))
                 + @intCast(@ptr_read(@ptr_offset(p, 3)));
-            @free(p, 4);
+            @free(@int_to_ptr(@ptr_to_int(p)), 4 * @intCast(@size_of(u8)), @intCast(@align_of(u8)));
             sum
         } else {
-            @free(q, 2305843009213693951);
+            @free(@int_to_ptr(@ptr_to_int(q)), 2305843009213693951 * @intCast(@size_of(u8)), @intCast(@align_of(u8)));
             1
         }
     }
@@ -94,7 +98,7 @@ struct Buf {
     cap: u64,
     fn init() -> Self {
         checked {
-            let p: ptr mut i32 = @alloc(4);
+            let p: ptr mut i32 = @int_to_ptr(@ptr_to_int(@alloc(4 * @intCast(@size_of(i32)), @intCast(@align_of(i32)))));
             @ptr_write(p, 111);
             Self { data: p, cap: 4 }
         }
@@ -105,7 +109,7 @@ struct Buf {
 }
 
 drop fn Buf(self) {
-    checked { @free(self.data, self.cap); };
+    checked { @free(@int_to_ptr(@ptr_to_int(self.data)), self.cap * @intCast(@size_of(i32)), @intCast(@align_of(i32))); };
     @dbg(999);
 }
 
@@ -126,24 +130,25 @@ name = "alloc_outside_checked_rejected"
 description = "@alloc outside a checked block is rejected (E1300)."
 files = [{ path = "main.rue", source = """
 fn main() -> i32 {
-    let p: ptr mut i32 = @alloc(4);
+    let p: ptr mut u8 = @alloc(4, 1);
     0
 }
 """ }]
 compile_fail = true
 error_contains = ["heap intrinsic `@alloc`", "checked"]
 
-# The hidden `count * size_of(T)` performed by heap intrinsics is part of the
-# runtime allocation ABI. It must trap instead of wrapping to a smaller byte
-# count, which would under-allocate the buffer the source pointer describes
-# (RUE-345).
+# `count * size_of(T)` is now written in source (ADR-0059 Phase 3, RUE-961)
+# rather than hidden inside the intrinsic, so the overflow that RUE-345 pinned
+# is caught by the language's ordinary trapping multiply (§8.1). It must still
+# trap rather than wrap to a smaller byte count, which would under-allocate the
+# buffer the source pointer describes.
 [[case]]
 name = "alloc_count_size_overflow_traps"
-description = "@alloc traps when count * size_of(T) overflows u64."
+description = "The source-computed count * @size_of(T) traps on overflow instead of wrapping."
 files = [{ path = "main.rue", source = """
 fn main() -> i32 {
     checked {
-        let p: ptr mut i64 = @alloc(2305843009213693952);
+        let p: ptr mut i64 = @int_to_ptr(@ptr_to_int(@alloc(2305843009213693952 * @intCast(@size_of(i64)), @intCast(@align_of(i64)))));
         if @ptr_to_int(p) == 0 { 0 } else { 1 }
     }
 }
@@ -153,12 +158,12 @@ exit_code = 101
 
 [[case]]
 name = "realloc_count_size_overflow_traps"
-description = "@realloc traps when the new count * size_of(T) overflows u64."
+description = "The source-computed new count * @size_of(T) traps on overflow instead of wrapping."
 files = [{ path = "main.rue", source = """
 fn main() -> i32 {
     checked {
-        let p: ptr mut i64 = @alloc(1);
-        let q: ptr mut i64 = @realloc(p, 1, 2305843009213693952);
+        let p: ptr mut i64 = @int_to_ptr(@ptr_to_int(@alloc(1 * @intCast(@size_of(i64)), @intCast(@align_of(i64)))));
+        let q: ptr mut i64 = @int_to_ptr(@ptr_to_int(@realloc(@int_to_ptr(@ptr_to_int(p)), 1 * @intCast(@size_of(i64)), @intCast(@align_of(i64)), 2305843009213693952 * @intCast(@size_of(i64)))));
         if @ptr_to_int(q) == 0 { 0 } else { 1 }
     }
 }
@@ -176,7 +181,7 @@ description = "A near-usize::MAX @alloc returns null instead of an unbacked poin
 files = [{ path = "main.rue", source = """
 fn main() -> i32 {
     checked {
-        let p: ptr mut u8 = @alloc(2305843009213693951);
+        let p: ptr mut u8 = @int_to_ptr(@ptr_to_int(@alloc(2305843009213693951 * @intCast(@size_of(u8)), @intCast(@align_of(u8)))));
         let addr: u64 = @ptr_to_int(p);
         if addr == 0 { 0 } else { 1 }
     }

--- a/crates/rue-cli-tests/cases/ptr_read_write_aggregate.toml
+++ b/crates/rue-cli-tests/cases/ptr_read_write_aggregate.toml
@@ -30,12 +30,12 @@ files = [{ path = "main.rue", source = """
 struct P { x: i32, y: i32 }
 fn main() -> i32 {
     checked {
-        let p: ptr mut P = @alloc(1);
+        let p: ptr mut P = @int_to_ptr(@ptr_to_int(@alloc(1 * @intCast(@size_of(P)), @intCast(@align_of(P)))));
         @ptr_write(p, P { x: 1, y: 2 });
         let v = @ptr_read(p);
         @dbg(v.x);
         @dbg(v.y);
-        @free(p, 1);
+        @free(@int_to_ptr(@ptr_to_int(p)), 1 * @intCast(@size_of(P)), @intCast(@align_of(P)));
     };
     0
 }
@@ -49,12 +49,12 @@ files = [{ path = "main.rue", source = """
 struct P { x: i32, y: i32 }
 fn main() -> i32 {
     checked {
-        let p: ptr mut P = @alloc(1);
+        let p: ptr mut P = @int_to_ptr(@ptr_to_int(@alloc(1 * @intCast(@size_of(P)), @intCast(@align_of(P)))));
         @ptr_write(p, P { x: 7, y: 9 });
         let v = @ptr_read(p);
         @dbg(v.x);
         @dbg(v.y);
-        @free(p, 1);
+        @free(@int_to_ptr(@ptr_to_int(p)), 1 * @intCast(@size_of(P)), @intCast(@align_of(P)));
     };
     0
 }
@@ -69,7 +69,7 @@ struct Inner { a: i32, b: i32 }
 struct Outer { p: Inner, q: i32 }
 fn main() -> i32 {
     checked {
-        let wp: ptr mut Outer = @alloc(1);
+        let wp: ptr mut Outer = @int_to_ptr(@ptr_to_int(@alloc(1 * @intCast(@size_of(Outer)), @intCast(@align_of(Outer)))));
         @ptr_write(wp, Outer { p: Inner { a: 10, b: 20 }, q: 30 });
         let v = @ptr_read(wp);
         @dbg(v.p.a);
@@ -80,7 +80,7 @@ fn main() -> i32 {
         @dbg(v2.p.a);
         @dbg(v2.p.b);
         @dbg(v2.q);
-        @free(wp, 1);
+        @free(@int_to_ptr(@ptr_to_int(wp)), 1 * @intCast(@size_of(Outer)), @intCast(@align_of(Outer)));
     };
     0
 }

--- a/crates/rue-cli-tests/cases/raw_bytes_degate_readiness.toml
+++ b/crates/rue-cli-tests/cases/raw_bytes_degate_readiness.toml
@@ -8,7 +8,7 @@
 # through the same one-byte narrow scalar access a typed `ptr u8` takes, and the
 # byte allocators share the general allocator helper. These cases pin that the
 # fold-in is behavior-preserving: the byte family is byte-granular (a
-# `@byte_read` reads one physical byte, `@alloc_bytes(n, a)` reserves n physical
+# `@byte_read` reads one physical byte, `@alloc(n, a)` reserves n physical
 # bytes, offsets are never scaled by the slot size), so the result never moves.
 #
 # Note: the byte surface deliberately avoids `@ptr_offset` for byte addressing
@@ -21,8 +21,8 @@ id = "cli.raw_bytes_degate_readiness"
 name = "raw-byte surface behaves identically under the compact layout"
 description = "Byte-intrinsic programs compute the byte-granular result the byte surface guarantees, evidencing that the RUE-978 fold-in into the narrow typed path is behavior-preserving."
 
-# The whole byte family — @alloc_bytes/@byte_set/@byte_write/@realloc_bytes/
-# @byte_copy/@byte_read/@free_bytes — in one round-trip.
+# The whole byte family — @alloc/@byte_set/@byte_write/@realloc/
+# @byte_copy/@byte_read/@free — in one round-trip.
 [[case]]
 name = "byte_family_roundtrip_plain"
 description = "Full byte-family round-trip through the byte surface."
@@ -31,21 +31,21 @@ args = ["main.rue", "-o", "prog"]
 files = [{ path = "main.rue", source = """
 fn main() -> i32 {
     checked {
-        let p: ptr mut u8 = @alloc_bytes(6, 1);
+        let p: ptr mut u8 = @alloc(6, 1);
         @byte_set(p, 0, 6);
         @byte_write(p, 0, 10);
         @byte_write(p, 1, 20);
         @byte_write(p, 2, 30);
-        let q: ptr mut u8 = @realloc_bytes(p, 6, 1, 8);
+        let q: ptr mut u8 = @realloc(p, 6, 1, 8);
         @byte_write(q, 3, 40);
-        let dst: ptr mut u8 = @alloc_bytes(8, 1);
+        let dst: ptr mut u8 = @alloc(8, 1);
         @byte_copy(dst, q, 8);
         let sum: i32 = @intCast(@byte_read(dst, 0)) + @intCast(@byte_read(dst, 1))
             + @intCast(@byte_read(dst, 2)) + @intCast(@byte_read(dst, 3))
             + @intCast(@byte_read(dst, 4));
         @dbg(sum);
-        @free_bytes(q, 8, 1);
-        @free_bytes(dst, 8, 1);
+        @free(q, 8, 1);
+        @free(dst, 8, 1);
     };
     0
 }
@@ -63,13 +63,13 @@ args = ["main.rue", "-o", "prog"]
 files = [{ path = "main.rue", source = """
 fn main() -> i32 {
     checked {
-        let src: ptr mut u8 = @alloc_bytes(5, 1);
+        let src: ptr mut u8 = @alloc(5, 1);
         let mut i: u64 = 0;
         while i < 5 {
             @byte_write(src, i, @intCast(i + 1));
             i = i + 1;
         }
-        let dst: ptr mut u8 = @alloc_bytes(5, 1);
+        let dst: ptr mut u8 = @alloc(5, 1);
         @byte_set(dst, 0, 5);
         let sp: ptr mut u8 = @int_to_ptr(@ptr_to_int(src) + 1);
         let dp: ptr mut u8 = @int_to_ptr(@ptr_to_int(dst) + 2);
@@ -81,8 +81,8 @@ fn main() -> i32 {
             j = j + 1;
         }
         @dbg(sum);
-        @free_bytes(src, 5, 1);
-        @free_bytes(dst, 5, 1);
+        @free(src, 5, 1);
+        @free(dst, 5, 1);
     };
     0
 }

--- a/crates/rue-cli-tests/cases/std_strbuf.toml
+++ b/crates/rue-cli-tests/cases/std_strbuf.toml
@@ -327,7 +327,7 @@ const std = @import("std");
 const S = std.strbuf.StrBuf;
 
 fn owned(byte: u8) -> S {
-    let p: ptr mut u8 = checked { @alloc_bytes(4, 1) };
+    let p: ptr mut u8 = checked { @alloc(4, 1) };
     checked { @byte_write(p, 0, byte); };
     // White-box: assemble an owned header (cap = 4 exactly, below the 16 floor)
     // over the RawBuf core (RUE-1066).

--- a/crates/rue-cli-tests/cases/zero_sized_place_address.toml
+++ b/crates/rue-cli-tests/cases/zero_sized_place_address.toml
@@ -1,0 +1,183 @@
+# Addresses of zero-sized places (RUE-605).
+#
+# A zero-sized place occupies no storage, so the slot model has no cell that
+# names it. Codegen still anchored every projected address at
+# `base + (root_slot_count - 1) - static_slot_offset`, which two shapes push
+# below zero: an all-ZST root (zero slots) and a zero-sized field at the end of
+# a sized root (its offset equals the root's slot count). The subtraction
+# underflowed `u32` — an ICE in a debug compiler, a wild frame slot in a release
+# one. Reads already returned the canonical zero and zero-sized writes were
+# already skipped; only address formation (`@raw`/`@raw_mut` and inout/borrow
+# arguments) still entered the math.
+#
+# ADR-0052 ruling 3 settles the semantics: a ZST has size 0 and alignment 1, and
+# a well-aligned dangling pointer to one is valid and non-dereferenceable. So
+# address-taking stays accepted and every zero-sized place now forms one
+# canonical constant address — non-null, well-aligned, frame-independent, and
+# identical on both backends.
+#
+# These cases assert only what the ruling actually promises: the address exists,
+# is non-null, does not collide with a sized sibling's address, and disturbs
+# nothing around it. The specific constant is an implementation choice, not an
+# observable of the language, so it is pinned where it belongs — in
+# `place_lower`'s two-backend unit test and in the AArch64 `--emit asm` case
+# below — rather than as expected program output.
+
+[section]
+id = "cli.zero_sized_place_address"
+name = "Zero-sized place addresses"
+description = "@raw and inout/borrow arguments over zero-sized places form a canonical non-null address instead of underflowing the frame slot arithmetic (RUE-605)."
+
+# --- The issue's verbatim repro: an all-ZST root ----------------------------
+[[case]]
+name = "all_zst_root_projected_address"
+description = "RUE-605 repro: `@raw(empty.unit)` on a struct whose only field is `()`. The root spans zero slots, so `root_slot_count - 1` underflowed."
+files = [{ path = "main.rue", source = """
+struct Empty { unit: () }
+fn main() -> i32 {
+    let empty = Empty { unit: () };
+    let _pointer: ptr const () = checked { @raw(empty.unit) };
+    0
+}
+""" }]
+stdout = ""
+exit_code = 0
+differential_opt = true
+
+[[case]]
+name = "all_zst_root_address_is_non_null"
+description = "The address an all-ZST root yields is a real, non-null pointer value — the ruling's well-aligned dangling pointer, not a null placeholder."
+files = [{ path = "main.rue", source = """
+struct Empty { unit: () }
+fn main() -> i32 {
+    let empty = Empty { unit: () };
+    let pointer: ptr const () = checked { @raw(empty.unit) };
+    let address = checked { @ptr_to_int(pointer) };
+    if address == 0 { @dbg(0); } else { @dbg(1); }
+    0
+}
+""" }]
+stdout = "1\n"
+exit_code = 0
+differential_opt = true
+
+# --- The same underflow from the other direction: a trailing ZST field ------
+[[case]]
+name = "trailing_zero_sized_field_address_keeps_neighbour_intact"
+description = "A `()` field at the end of a sized struct sits at the root's past-the-end slot offset; forming its address must not disturb the sized field it follows."
+files = [{ path = "main.rue", source = """
+struct Tail { value: i64, unit: () }
+fn main() -> i32 {
+    let tail = Tail { value: 42, unit: () };
+    let _pointer: ptr const () = checked { @raw(tail.unit) };
+    @intCast(tail.value)
+}
+""" }]
+stdout = ""
+exit_code = 42
+differential_opt = true
+
+[[case]]
+name = "trailing_zero_sized_field_address_is_non_null_and_distinct"
+description = "The trailing `()` field's address is non-null and does not alias its sized sibling's address, and reading that sibling still gives its value."
+files = [{ path = "main.rue", source = """
+struct Tail { value: i64, unit: () }
+fn main() -> i32 {
+    let tail = Tail { value: 7, unit: () };
+    let zero_sized: ptr const () = checked { @raw(tail.unit) };
+    let sized: ptr const i64 = checked { @raw(tail.value) };
+    let zero_sized_address = checked { @ptr_to_int(zero_sized) };
+    let sized_address = checked { @ptr_to_int(sized) };
+    if zero_sized_address == 0 { @dbg(0); } else { @dbg(1); }
+    if zero_sized_address == sized_address { @dbg(0); } else { @dbg(1); }
+    @dbg(tail.value);
+    0
+}
+""" }]
+stdout = "1\n1\n7\n"
+exit_code = 0
+differential_opt = true
+
+# --- The by-reference argument entry point ----------------------------------
+[[case]]
+name = "inout_and_borrow_zero_sized_field_arguments"
+description = "inout/borrow of a projected zero-sized field forms its address through the checked entry point; the enclosing struct's sized field survives the call."
+files = [{ path = "main.rue", source = """
+struct Tail { value: i64, unit: () }
+fn touch(inout unit: ()) -> i32 { unit = (); 1 }
+fn look(borrow unit: ()) -> i32 { 2 }
+fn main() -> i32 {
+    let mut tail = Tail { value: 7, unit: () };
+    @dbg(touch(inout tail.unit));
+    @dbg(look(borrow tail.unit));
+    @dbg(tail.value);
+    0
+}
+""" }]
+stdout = "1\n2\n7\n"
+exit_code = 0
+differential_opt = true
+
+# --- An indexed zero-sized place keeps its language-level bounds check -------
+# The canonical address short-circuits the index arithmetic (a zero-sized
+# element cannot be moved past by an index), so the trap edge has to come from
+# the shared bounds check emitted before it. These two cases pin both sides.
+[[case]]
+name = "indexed_zero_sized_field_address_in_bounds"
+description = "An in-bounds `@raw(arr[i].unit)` reaches the zero-sized field through an index level and yields a non-null address; the element's sized field is untouched."
+files = [{ path = "main.rue", source = """
+struct Tail { value: i64, unit: () }
+fn main() -> i32 {
+    let arr: [Tail; 2] = [Tail { value: 7, unit: () }, Tail { value: 9, unit: () }];
+    let i: u64 = 1;
+    let element: ptr const () = checked { @raw(arr[i].unit) };
+    let address = checked { @ptr_to_int(element) };
+    if address == 0 { @dbg(0); } else { @dbg(1); }
+    @dbg(arr[i].value);
+    0
+}
+""" }]
+stdout = "1\n9\n"
+exit_code = 0
+differential_opt = true
+
+[[case]]
+name = "indexed_zero_sized_field_address_out_of_bounds_still_traps"
+description = "Skipping the index arithmetic must not skip the bounds check: an out-of-range index still traps before any address is formed."
+files = [{ path = "main.rue", source = """
+struct Tail { value: i64, unit: () }
+fn main() -> i32 {
+    let arr: [Tail; 2] = [Tail { value: 7, unit: () }, Tail { value: 9, unit: () }];
+    let i: u64 = 5;
+    let element: ptr const () = checked { @raw(arr[i].unit) };
+    @dbg(checked { @ptr_to_int(element) });
+    0
+}
+""" }]
+exit_code = 101
+runtime_error_contains = ["index out of bounds"]
+
+# --- AArch64 lowers the same shapes (CI runs this natively) -----------------
+[[case]]
+name = "aarch64_zero_sized_place_addresses_lower"
+description = "Both underflowing shapes and the by-ref argument path emit AArch64 assembly; before RUE-605 this aborted in the shared place lowering."
+files = [{ path = "main.rue", source = """
+struct Tail { value: i64, unit: () }
+struct Empty { unit: () }
+fn look(borrow unit: ()) -> i32 { 2 }
+fn main() -> i32 {
+    let tail = Tail { value: 7, unit: () };
+    let empty = Empty { unit: () };
+    let _tail_zst: ptr const () = checked { @raw(tail.unit) };
+    let _empty_zst: ptr const () = checked { @raw(empty.unit) };
+    look(borrow tail.unit)
+}
+""" }]
+args = ["--emit", "asm", "--target", "aarch64-linux", "main.rue"]
+compile_only = true
+compile_stdout_contains = ["=== Assembly (aarch64-linux) ===", "main:"]
+# Every address this program forms is zero-sized, so no frame address may be
+# formed at all. AArch64 spells one `sub <reg>, fp, #<n>` / `add <reg>, fp,
+# #<n>`; the bracketed `[fp, #...]` of an ordinary slot load or store does not
+# match this substring.
+compile_stdout_not_contains = [", fp, #"]

--- a/crates/rue-cli-tests/src/main.rs
+++ b/crates/rue-cli-tests/src/main.rs
@@ -1070,6 +1070,25 @@ struct Case {
     /// or leaked internal diagnostics (e.g. raw `DEBUG:` eprintln lines).
     #[serde(default)]
     compile_stderr_not_contains: Vec<String>,
+    /// Validate the compiler's stderr as the `--error-format json` surface
+    /// (RUE-436): EVERY non-empty stderr line must parse as a JSON array of
+    /// diagnostic objects, and every object must carry the full documented
+    /// schema (see `docs/process/diagnostics.md`). Substring assertions cannot
+    /// catch malformed JSON, a dropped field, or a renamed key — this can, and
+    /// it fails the case when they happen. Under `--error-format json` stderr
+    /// carries diagnostics only (the `Compiled ... -> ...` banner is stdout),
+    /// so the "every line" rule is exact rather than a filter.
+    #[serde(default)]
+    json_diagnostics: bool,
+    /// Exact, ordered digest of the diagnostics `json_diagnostics` parsed, as
+    /// `"<severity> <code> <file>:<line>:<column>"` per diagnostic, flattened
+    /// across every stderr line in emission order. An absent field renders as
+    /// `-`: warnings are uncoded (`"warning - main.rue:2:5"`) and a diagnostic
+    /// with no span has no locator (`"error E1403 -"`). This pins diagnostic
+    /// ORDER, not merely presence: a case that lists the same diagnostics in a
+    /// different order fails. Requires `json_diagnostics`.
+    #[serde(default)]
+    json_diagnostic_order: Vec<String>,
     /// Exact expected program stdout.
     #[serde(default)]
     stdout: Option<String>,
@@ -1995,6 +2014,23 @@ fn run_case(
         }
     }
 
+    // Structured `--error-format json` validation: parse every stderr line and
+    // check the documented schema, then pin the diagnostic ORDER (RUE-436).
+    if case.json_diagnostics {
+        let digests = validate_json_diagnostic_stream(&compile_stderr).map_err(|failure| {
+            TestFailure::assertion(format!(
+                "--error-format json schema violation: {failure}\n--- actual stderr ---\n{}",
+                compile_stderr
+            ))
+        })?;
+        if !case.json_diagnostic_order.is_empty() && digests != case.json_diagnostic_order {
+            return Err(TestFailure::assertion(format!(
+                "--error-format json diagnostic order mismatch:\n  expected: {:?}\n  actual:   {:?}\n--- actual stderr ---\n{}",
+                case.json_diagnostic_order, digests, compile_stderr
+            )));
+        }
+    }
+
     for expected in &case.compile_stdout_contains {
         if !compile_stdout.contains(expected) {
             return Err(TestFailure::assertion(format!(
@@ -2294,6 +2330,268 @@ fn run_case_wrapper(
     }
 }
 
+// ============================================================================
+// `--error-format json` schema validation (RUE-436)
+// ============================================================================
+
+/// Every key a JSON diagnostic object must carry, and nothing else. Declared
+/// as an exhaustive set so BOTH a dropped field and a silently added one fail
+/// the case: the flag's contract is a schema, not a set of substrings.
+const JSON_DIAGNOSTIC_KEYS: &[&str] = &[
+    "code",
+    "message",
+    "severity",
+    "spans",
+    "suggestions",
+    "notes",
+    "helps",
+];
+
+/// Every key a JSON span object must carry, and nothing else.
+const JSON_SPAN_KEYS: &[&str] = &["file", "start", "end", "line", "column", "label", "primary"];
+
+/// Every key a JSON suggestion object must carry, and nothing else.
+const JSON_SUGGESTION_KEYS: &[&str] = &[
+    "message",
+    "file",
+    "start",
+    "end",
+    "replacement",
+    "applicability",
+];
+
+/// Assert an object's key set is exactly `expected`.
+fn check_json_keys(
+    object: &serde_json::Map<String, serde_json::Value>,
+    expected: &[&str],
+    what: &str,
+) -> Result<(), String> {
+    let mut actual: Vec<&str> = object.keys().map(String::as_str).collect();
+    actual.sort_unstable();
+    let mut wanted: Vec<&str> = expected.to_vec();
+    wanted.sort_unstable();
+    if actual == wanted {
+        return Ok(());
+    }
+    Err(format!(
+        "{what} has keys {actual:?}, expected exactly {wanted:?}"
+    ))
+}
+
+/// Read a required string field.
+fn json_string<'v>(
+    object: &'v serde_json::Map<String, serde_json::Value>,
+    key: &str,
+    what: &str,
+) -> Result<&'v str, String> {
+    object
+        .get(key)
+        .and_then(serde_json::Value::as_str)
+        .ok_or_else(|| format!("{what}: `{key}` is not a string"))
+}
+
+/// Read a required non-negative integer field.
+fn json_u64(
+    object: &serde_json::Map<String, serde_json::Value>,
+    key: &str,
+    what: &str,
+) -> Result<u64, String> {
+    object
+        .get(key)
+        .and_then(serde_json::Value::as_u64)
+        .ok_or_else(|| format!("{what}: `{key}` is not a non-negative integer"))
+}
+
+/// Validate one span object and return its `file:line:column` locator.
+fn validate_json_span(span: &serde_json::Value, what: &str) -> Result<String, String> {
+    let span = span
+        .as_object()
+        .ok_or_else(|| format!("{what}: span is not an object"))?;
+    check_json_keys(span, JSON_SPAN_KEYS, what)?;
+
+    let file = json_string(span, "file", what)?;
+    if file.is_empty() {
+        return Err(format!("{what}: span `file` is empty"));
+    }
+    let start = json_u64(span, "start", what)?;
+    let end = json_u64(span, "end", what)?;
+    if start > end {
+        return Err(format!("{what}: span start {start} exceeds end {end}"));
+    }
+    let line = json_u64(span, "line", what)?;
+    let column = json_u64(span, "column", what)?;
+    if line < 1 || column < 1 {
+        return Err(format!(
+            "{what}: span line/column are 1-indexed, got {line}:{column}"
+        ));
+    }
+    match span.get("label") {
+        Some(serde_json::Value::Null) | Some(serde_json::Value::String(_)) => {}
+        other => {
+            return Err(format!(
+                "{what}: span `label` must be a string or null, got {other:?}"
+            ));
+        }
+    }
+    if !matches!(span.get("primary"), Some(serde_json::Value::Bool(_))) {
+        return Err(format!("{what}: span `primary` is not a boolean"));
+    }
+    Ok(format!("{file}:{line}:{column}"))
+}
+
+/// Validate one diagnostic object and return its ordering digest.
+fn validate_json_diagnostic(value: &serde_json::Value, what: &str) -> Result<String, String> {
+    let diagnostic = value
+        .as_object()
+        .ok_or_else(|| format!("{what}: diagnostic is not an object"))?;
+    check_json_keys(diagnostic, JSON_DIAGNOSTIC_KEYS, what)?;
+
+    let severity = json_string(diagnostic, "severity", what)?;
+    if severity != "error" && severity != "warning" {
+        return Err(format!(
+            "{what}: `severity` must be \"error\" or \"warning\", got {severity:?}"
+        ));
+    }
+
+    // Errors always carry an `E####` code; warnings are not yet coded and
+    // carry the empty string. Both halves are pinned so the day warnings gain
+    // codes, this test — and the documented schema — must be updated together.
+    let code = json_string(diagnostic, "code", what)?;
+    if severity == "error" {
+        let coded = code
+            .strip_prefix('E')
+            .is_some_and(|digits| digits.len() >= 4 && digits.chars().all(|c| c.is_ascii_digit()));
+        if !coded {
+            return Err(format!(
+                "{what}: error `code` must look like \"E0206\", got {code:?}"
+            ));
+        }
+    } else if !code.is_empty() {
+        return Err(format!(
+            "{what}: warning `code` must be empty until warnings are coded, got {code:?}"
+        ));
+    }
+
+    let message = json_string(diagnostic, "message", what)?;
+    if message.is_empty() {
+        return Err(format!("{what}: `message` is empty"));
+    }
+
+    let spans = diagnostic
+        .get("spans")
+        .and_then(serde_json::Value::as_array)
+        .ok_or_else(|| format!("{what}: `spans` is not an array"))?;
+    let mut primary_locator: Option<String> = None;
+    for (index, span) in spans.iter().enumerate() {
+        let locator = validate_json_span(span, &format!("{what} span[{index}]"))?;
+        let primary = span["primary"].as_bool().unwrap_or(false);
+        if !primary {
+            continue;
+        }
+        if primary_locator.is_some() {
+            return Err(format!("{what}: more than one span is marked primary"));
+        }
+        if index != 0 {
+            return Err(format!(
+                "{what}: the primary span must come first, found it at index {index}"
+            ));
+        }
+        primary_locator = Some(locator);
+    }
+    if !spans.is_empty() && primary_locator.is_none() {
+        return Err(format!(
+            "{what}: has {} span(s) but none is marked primary",
+            spans.len()
+        ));
+    }
+
+    let suggestions = diagnostic
+        .get("suggestions")
+        .and_then(serde_json::Value::as_array)
+        .ok_or_else(|| format!("{what}: `suggestions` is not an array"))?;
+    for (index, suggestion) in suggestions.iter().enumerate() {
+        let what = format!("{what} suggestion[{index}]");
+        let suggestion = suggestion
+            .as_object()
+            .ok_or_else(|| format!("{what}: suggestion is not an object"))?;
+        check_json_keys(suggestion, JSON_SUGGESTION_KEYS, &what)?;
+        json_string(suggestion, "message", &what)?;
+        json_string(suggestion, "file", &what)?;
+        json_string(suggestion, "replacement", &what)?;
+        json_string(suggestion, "applicability", &what)?;
+        let start = json_u64(suggestion, "start", &what)?;
+        let end = json_u64(suggestion, "end", &what)?;
+        if start > end {
+            return Err(format!(
+                "{what}: suggestion start {start} exceeds end {end}"
+            ));
+        }
+    }
+
+    for key in ["notes", "helps"] {
+        let entries = diagnostic
+            .get(key)
+            .and_then(serde_json::Value::as_array)
+            .ok_or_else(|| format!("{what}: `{key}` is not an array"))?;
+        if entries.iter().any(|entry| !entry.is_string()) {
+            return Err(format!("{what}: `{key}` must be an array of strings"));
+        }
+    }
+
+    // A warning's code is empty today, and a diagnostic can have no span at
+    // all; both render as `-` so a digest is always three space-separated
+    // fields rather than a string with a hole in it.
+    Ok(format!(
+        "{severity} {} {}",
+        if code.is_empty() { "-" } else { code },
+        primary_locator.as_deref().unwrap_or("-")
+    ))
+}
+
+/// Parse and schema-check the whole `--error-format json` stderr stream,
+/// returning one ordering digest per diagnostic in emission order.
+fn validate_json_diagnostic_stream(stderr: &str) -> Result<Vec<String>, String> {
+    let mut digests = Vec::new();
+    for (index, line) in stderr.lines().enumerate() {
+        if line.trim().is_empty() {
+            continue;
+        }
+        let value: serde_json::Value = serde_json::from_str(line)
+            .map_err(|e| format!("stderr line {}: not valid JSON: {e}", index + 1))?;
+        let batch = value.as_array().ok_or_else(|| {
+            format!(
+                "stderr line {}: expected a JSON array of diagnostics, got {}",
+                index + 1,
+                match value {
+                    serde_json::Value::Object(_) => "an object",
+                    _ => "a scalar",
+                }
+            )
+        })?;
+        if batch.is_empty() {
+            return Err(format!(
+                "stderr line {}: emitted an empty diagnostic array; \
+                 a batch with nothing to report must print nothing",
+                index + 1
+            ));
+        }
+        for (position, diagnostic) in batch.iter().enumerate() {
+            digests.push(validate_json_diagnostic(
+                diagnostic,
+                &format!("stderr line {} diagnostic[{position}]", index + 1),
+            )?);
+        }
+    }
+    Ok(digests)
+}
+
+/// `json_diagnostic_order` pins the output of the `json_diagnostics` parse, so
+/// declaring it without the parse asserts nothing. Returns true when the case
+/// declares an order without enabling validation — a load-time error.
+fn json_order_without_validation(case: &Case) -> bool {
+    !case.json_diagnostic_order.is_empty() && !case.json_diagnostics
+}
+
 /// A `differential_opt` case's cross-level check is only meaningful if each opt
 /// level is also pinned to a known-good result, so it must declare both an
 /// explicit `stdout` and `exit_code`. Returns true when the case is
@@ -2441,6 +2739,16 @@ fn load_cases(cases_dir: &Path) -> LoadedCorpus {
                             "error: {}: differential_opt case '{}' must declare both an explicit \
                              `stdout` and `exit_code` (each opt level is checked against them, so \
                              the cross-level compare can't pass a consistently-wrong program)",
+                            path.display(),
+                            case.name
+                        );
+                        std::process::exit(1);
+                    }
+                    if json_order_without_validation(case) {
+                        eprintln!(
+                            "error: {}: case '{}' declares `json_diagnostic_order` without \
+                             `json_diagnostics`, so the order is never parsed or compared. \
+                             Set `json_diagnostics = true`.",
                             path.display(),
                             case.name
                         );
@@ -3374,6 +3682,173 @@ mod tests {
         case.error_contains = vec![];
         case.compile_stderr_contains = vec!["bad.rue:".to_string()];
         assert!(!compile_fail_missing_assertion(&case));
+    }
+
+    // ===== `--error-format json` schema validation (RUE-436) =====
+    //
+    // The validator is the net under the JSON diagnostic contract, so it needs
+    // its own net: each test below is a mutation of one well-formed stream
+    // that MUST be rejected. A validator that silently accepts everything
+    // would make every `json_diagnostics` case vacuous.
+
+    /// One well-formed batch: an error with a primary and a labelled secondary
+    /// span, a suggestion, a note and a help — every optional part populated.
+    fn well_formed_json_batch() -> String {
+        r#"[{"code":"E0205","message":"use of moved value 'p'","severity":"error","spans":[{"file":"main.rue","start":158,"end":159,"line":8,"column":18,"label":null,"primary":true},{"file":"main.rue","start":137,"end":138,"line":7,"column":18,"label":"value moved here","primary":false}],"suggestions":[{"message":"borrow instead","file":"main.rue","start":158,"end":159,"replacement":"borrow p","applicability":"machine-applicable"}],"notes":["a note"],"helps":["a help"]}]"#.to_string()
+    }
+
+    #[test]
+    fn well_formed_json_diagnostics_validate() {
+        let digests = validate_json_diagnostic_stream(&well_formed_json_batch()).unwrap();
+        assert_eq!(digests, vec!["error E0205 main.rue:8:18".to_string()]);
+    }
+
+    #[test]
+    fn json_digests_flatten_multiple_lines_in_emission_order() {
+        let stream = format!(
+            "{}\n{}\n",
+            r#"[{"code":"","message":"unused variable 'u'","severity":"warning","spans":[{"file":"main.rue","start":23,"end":39,"line":2,"column":5,"label":null,"primary":true}],"suggestions":[],"notes":[],"helps":[]}]"#,
+            r#"[{"code":"E1403","message":"output publication failed","severity":"error","spans":[],"suggestions":[],"notes":[],"helps":[]}]"#
+        );
+        let digests = validate_json_diagnostic_stream(&stream).unwrap();
+        assert_eq!(
+            digests,
+            vec![
+                "warning - main.rue:2:5".to_string(),
+                "error E1403 -".to_string(),
+            ]
+        );
+    }
+
+    /// Each entry is (mutation applied to the well-formed batch, substring the
+    /// rejection message must contain).
+    #[test]
+    fn malformed_json_diagnostics_are_rejected() {
+        let cases: &[(String, &str)] = &[
+            // Not JSON at all — the failure substring assertions in the old
+            // test style could not see this.
+            (
+                "error: [E0206]: type mismatch".to_string(),
+                "not valid JSON",
+            ),
+            // A bare object instead of a batch array.
+            (
+                well_formed_json_batch()
+                    .trim_start_matches('[')
+                    .trim_end_matches(']')
+                    .to_string(),
+                "expected a JSON array",
+            ),
+            // An empty batch: printing `[]` instead of printing nothing.
+            ("[]".to_string(), "empty diagnostic array"),
+            // A dropped field.
+            (
+                well_formed_json_batch().replace(r#""notes":["a note"],"#, ""),
+                "expected exactly",
+            ),
+            // A renamed field.
+            (
+                well_formed_json_batch().replace(r#""message":"use"#, r#""text":"use"#),
+                "expected exactly",
+            ),
+            // An added field.
+            (
+                well_formed_json_batch()
+                    .replace(r#""helps":["a help"]"#, r#""helps":["a help"],"extra":1"#),
+                "expected exactly",
+            ),
+            // An uncoded error.
+            (
+                well_formed_json_batch().replace(r#""code":"E0205""#, r#""code":"""#),
+                "must look like",
+            ),
+            // A coded warning (warnings are uncoded until the day they aren't,
+            // and that day must update the schema doc).
+            (
+                well_formed_json_batch()
+                    .replace(r#""severity":"error""#, r#""severity":"warning""#),
+                "must be empty",
+            ),
+            // An unknown severity.
+            (
+                well_formed_json_batch().replace(r#""severity":"error""#, r#""severity":"note""#),
+                "must be \"error\" or \"warning\"",
+            ),
+            // A 0-indexed column.
+            (
+                well_formed_json_batch()
+                    .replace(r#""column":18,"label":null"#, r#""column":0,"label":null"#),
+                "1-indexed",
+            ),
+            // An inverted byte range.
+            (
+                well_formed_json_batch().replace(
+                    r#""start":158,"end":159,"line":8"#,
+                    r#""start":159,"end":158,"line":8"#,
+                ),
+                "exceeds end",
+            ),
+            // A demoted primary: the only span is secondary.
+            (
+                well_formed_json_batch().replace(
+                    r#""label":null,"primary":true"#,
+                    r#""label":null,"primary":false"#,
+                ),
+                "none is marked primary",
+            ),
+            // A primary span that is not first.
+            (
+                well_formed_json_batch()
+                    .replace(
+                        r#""label":null,"primary":true"#,
+                        r#""label":null,"primary":false"#,
+                    )
+                    .replace(
+                        r#""label":"value moved here","primary":false"#,
+                        r#""label":"value moved here","primary":true"#,
+                    ),
+                "must come first",
+            ),
+            // A wrongly typed note.
+            (
+                well_formed_json_batch().replace(r#""notes":["a note"]"#, r#""notes":[7]"#),
+                "array of strings",
+            ),
+            // A malformed suggestion.
+            (
+                well_formed_json_batch().replace(
+                    r#""applicability":"machine-applicable""#,
+                    r#""applicability":3"#,
+                ),
+                "`applicability` is not a string",
+            ),
+        ];
+
+        for (stream, expected) in cases {
+            let failure = validate_json_diagnostic_stream(stream)
+                .expect_err(&format!("this stream must be rejected: {stream}"));
+            assert!(
+                failure.contains(expected),
+                "rejection message {failure:?} does not mention {expected:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn json_diagnostic_order_requires_json_diagnostics() {
+        let mut case = Case {
+            name: "c".to_string(),
+            json_diagnostic_order: vec!["error E0206 main.rue:1:20".to_string()],
+            ..Default::default()
+        };
+        assert!(json_order_without_validation(&case));
+
+        case.json_diagnostics = true;
+        assert!(!json_order_without_validation(&case));
+
+        // Validation without a pinned order is fine: schema-only checking.
+        case.json_diagnostic_order = vec![];
+        assert!(!json_order_without_validation(&case));
     }
 
     #[test]

--- a/crates/rue-codegen/src/aarch64/cfg_lower.rs
+++ b/crates/rue-codegen/src/aarch64/cfg_lower.rs
@@ -2119,35 +2119,35 @@ impl<'a> CfgLower<'a> {
                 });
                 dst
             }
-            crate::value_plan::IntrinsicOperation::Alloc { element_size } => {
-                let _ = element_size;
+            // The unified allocation family and the bulk byte primitives are
+            // pure runtime calls: the shared plan already carries their
+            // operands in helper order (ADR-0059 Phase 3, RUE-961).
+            crate::value_plan::IntrinsicOperation::Alloc => {
                 self.lower_runtime_call(plan.runtime_call.expect("alloc runtime call plan"))
                     .primary
             }
-            crate::value_plan::IntrinsicOperation::Free { element_size } => {
-                let _ = element_size;
+            crate::value_plan::IntrinsicOperation::AllocZeroed => {
+                self.lower_runtime_call(plan.runtime_call.expect("alloc-zeroed runtime call plan"))
+                    .primary
+            }
+            crate::value_plan::IntrinsicOperation::Free => {
                 self.lower_runtime_call(plan.runtime_call.expect("free runtime call plan"))
                     .primary
             }
-            crate::value_plan::IntrinsicOperation::Realloc { element_size } => {
-                let _ = element_size;
+            crate::value_plan::IntrinsicOperation::Realloc => {
                 self.lower_runtime_call(plan.runtime_call.expect("realloc runtime call plan"))
                     .primary
             }
-            crate::value_plan::IntrinsicOperation::AllocBytes => {
-                self.lower_runtime_call(plan.runtime_call.expect("alloc-bytes runtime call plan"))
-                    .primary
-            }
-            crate::value_plan::IntrinsicOperation::FreeBytes => {
-                self.lower_runtime_call(plan.runtime_call.expect("free-bytes runtime call plan"))
-                    .primary
-            }
-            crate::value_plan::IntrinsicOperation::ReallocBytes => {
-                self.lower_runtime_call(plan.runtime_call.expect("realloc-bytes runtime call plan"))
+            crate::value_plan::IntrinsicOperation::Resize => {
+                self.lower_runtime_call(plan.runtime_call.expect("resize runtime call plan"))
                     .primary
             }
             crate::value_plan::IntrinsicOperation::ByteCopy => {
                 self.lower_runtime_call(plan.runtime_call.expect("byte-copy runtime call plan"))
+                    .primary
+            }
+            crate::value_plan::IntrinsicOperation::ByteMove => {
+                self.lower_runtime_call(plan.runtime_call.expect("byte-move runtime call plan"))
                     .primary
             }
             crate::value_plan::IntrinsicOperation::ByteSet => {
@@ -3978,8 +3978,8 @@ mod tests {
     /// narrow pseudos (`ldrsw`/`str w`) instead of the eight-byte `Ldr`/`Str`.
     #[test]
     fn aggregate_layout_allows_narrow_scalar_physical_access() {
-        let source = "fn main() -> i32 { checked { let p: ptr mut i32 = @alloc(1); \
-                      @ptr_write(p, 5); @dbg(@ptr_read(p)); @free(p, 1); }; 0 }";
+        let source = "fn main() -> i32 { checked { let p: ptr mut i32 = @int_to_ptr(@ptr_to_int(@alloc(@intCast(@size_of(i32)), @intCast(@align_of(i32))))); \
+                      @ptr_write(p, 5); @dbg(@ptr_read(p)); @free(@int_to_ptr(@ptr_to_int(p)), @intCast(@size_of(i32)), @intCast(@align_of(i32))); }; 0 }";
         let mir = try_lower_first_fn(source, PreviewFeatures::new())
             .expect("a narrow scalar through a typed pointer must lower under compact layout");
         assert!(
@@ -4007,10 +4007,10 @@ mod tests {
     #[test]
     fn aggregate_layout_allows_compact_enum_memory() {
         let source = "enum Opt { Some(i32), None } \
-                      fn main() -> i32 { checked { let p: ptr mut Opt = @alloc(1); \
+                      fn main() -> i32 { checked { let p: ptr mut Opt = @int_to_ptr(@ptr_to_int(@alloc(@intCast(@size_of(Opt)), @intCast(@align_of(Opt))))); \
                       @ptr_write(p, Opt.Some(42)); let e = @ptr_read(p); \
                       match e { Opt.Some(x) => @dbg(x), Opt.None => @dbg(0), }; \
-                      @free(p, 1); }; 0 }";
+                      @free(@int_to_ptr(@ptr_to_int(p)), @intCast(@size_of(Opt)), @intCast(@align_of(Opt))); }; 0 }";
         let mir = try_lower_first_fn(source, PreviewFeatures::new())
             .expect("a compact enum with a variant-independent image must lower");
         assert!(
@@ -4040,7 +4040,7 @@ mod tests {
         let source = "enum R { Ok(Point), Err(i64) } \
                       struct Point { x: i32, y: i32, z: i32 } \
                       fn store_it(p: ptr mut R) { checked { @ptr_write(p, R.Ok(Point { x: 1, y: 2, z: 3 })); }; } \
-                      fn main() -> i32 { checked { let p: ptr mut R = @alloc(1); store_it(p); @free(p, 1); }; 0 }";
+                      fn main() -> i32 { checked { let p: ptr mut R = @int_to_ptr(@ptr_to_int(@alloc(@intCast(@size_of(R)), @intCast(@align_of(R))))); store_it(p); @free(@int_to_ptr(@ptr_to_int(p)), @intCast(@size_of(R)), @intCast(@align_of(R))); }; 0 }";
         let mir = try_lower_named_fn(source, PreviewFeatures::new(), Some("store_it"))
             .expect("a heterogeneous enum @ptr_write must lower via tag dispatch");
         assert!(
@@ -4063,9 +4063,9 @@ mod tests {
     #[test]
     fn aggregate_layout_allows_compact_struct_memory() {
         let source = "struct Padded { a: u8, b: i32, c: u8 } \
-                      fn main() -> i32 { checked { let p: ptr mut Padded = @alloc(1); \
+                      fn main() -> i32 { checked { let p: ptr mut Padded = @int_to_ptr(@ptr_to_int(@alloc(@intCast(@size_of(Padded)), @intCast(@align_of(Padded))))); \
                       @ptr_write(p, Padded { a: 7, b: 1000, c: 9 }); let s = @ptr_read(p); \
-                      @dbg(s.b); @free(p, 1); }; 0 }";
+                      @dbg(s.b); @free(@int_to_ptr(@ptr_to_int(p)), @intCast(@size_of(Padded)), @intCast(@align_of(Padded))); }; 0 }";
         let mir = try_lower_first_fn(source, PreviewFeatures::new()).expect(
             "a whole compact struct through a typed pointer must lower under compact layout",
         );
@@ -4089,9 +4089,9 @@ mod tests {
     #[test]
     fn aggregate_layout_allows_array_bearing_struct_memory() {
         let source = "struct HasArr { tag: u8, xs: [i32; 2] } \
-                      fn main() -> i32 { let r = checked { let p: ptr mut HasArr = @alloc(1); \
+                      fn main() -> i32 { let r = checked { let p: ptr mut HasArr = @int_to_ptr(@ptr_to_int(@alloc(@intCast(@size_of(HasArr)), @intCast(@align_of(HasArr))))); \
                       @ptr_write(p, HasArr { tag: 5, xs: [10, 20] }); let v = @ptr_read(p); \
-                      @free(p, 1); v.xs[0] + v.xs[1] }; @dbg(r); 0 }";
+                      @free(@int_to_ptr(@ptr_to_int(p)), @intCast(@size_of(HasArr)), @intCast(@align_of(HasArr))); v.xs[0] + v.xs[1] }; @dbg(r); 0 }";
         let mir = try_lower_first_fn(source, PreviewFeatures::new())
             .expect("a struct with a compact array image must lower under compact layout");
         assert!(
@@ -4108,9 +4108,9 @@ mod tests {
     #[test]
     fn aggregate_layout_allows_variant_dependent_enum_image() {
         let source = "struct Point { x: i32, y: i32 } enum Opt { Some(Point), None } \
-                      fn main() -> i32 { let r = checked { let p: ptr mut Opt = @alloc(1); \
+                      fn main() -> i32 { let r = checked { let p: ptr mut Opt = @int_to_ptr(@ptr_to_int(@alloc(@intCast(@size_of(Opt)), @intCast(@align_of(Opt))))); \
                       @ptr_write(p, Opt.Some(Point { x: 40, y: 2 })); let v = @ptr_read(p); \
-                      @free(p, 1); match v { Opt.Some(pt) => pt.x + pt.y, Opt.None => 0 - 1 } }; \
+                      @free(@int_to_ptr(@ptr_to_int(p)), @intCast(@size_of(Opt)), @intCast(@align_of(Opt))); match v { Opt.Some(pt) => pt.x + pt.y, Opt.None => 0 - 1 } }; \
                       @dbg(r); 0 }";
         let mir = try_lower_first_fn(source, PreviewFeatures::new())
             .expect("an enum with a variant-independent struct-payload image must lower");
@@ -4129,8 +4129,8 @@ mod tests {
     #[test]
     fn aggregate_layout_marshals_struct_embedding_heterogeneous_enum() {
         let source = "enum Bad { A(i64), B(i32, i32) } struct HasBad { b: Bad } \
-                      fn main() -> i32 { checked { let p: ptr mut HasBad = @alloc(1); \
-                      @ptr_write(p, HasBad { b: Bad.A(5) }); @free(p, 1); }; 0 }";
+                      fn main() -> i32 { checked { let p: ptr mut HasBad = @int_to_ptr(@ptr_to_int(@alloc(@intCast(@size_of(HasBad)), @intCast(@align_of(HasBad))))); \
+                      @ptr_write(p, HasBad { b: Bad.A(5) }); @free(@int_to_ptr(@ptr_to_int(p)), @intCast(@size_of(HasBad)), @intCast(@align_of(HasBad))); }; 0 }";
         let mir = try_lower_first_fn(source, PreviewFeatures::new())
             .expect("a struct embedding a heterogeneous enum must lower via nested tag dispatch");
         assert!(
@@ -4216,8 +4216,8 @@ mod tests {
     fn aggregate_layout_marshals_variant_dependent_enum_memory() {
         let mir = try_lower_first_fn(
             "enum Bad { A(i64), B(i32, i32) } \
-             fn main() -> i32 { checked { let p: ptr mut Bad = @alloc(1); \
-             @ptr_write(p, Bad.A(5)); @free(p, 1); }; 0 }",
+             fn main() -> i32 { checked { let p: ptr mut Bad = @int_to_ptr(@ptr_to_int(@alloc(@intCast(@size_of(Bad)), @intCast(@align_of(Bad))))); \
+             @ptr_write(p, Bad.A(5)); @free(@int_to_ptr(@ptr_to_int(p)), @intCast(@size_of(Bad)), @intCast(@align_of(Bad))); }; 0 }",
             PreviewFeatures::new(),
         )
         .expect("a variant-dependent enum memory image must lower via tag dispatch");
@@ -4388,9 +4388,9 @@ mod tests {
     fn raw_bytes_runtime_helper_identity_and_slots_match_shared_plan() {
         let preview = PreviewFeatures::new();
         let mir = lower_function_to_mir_with_preview(
-            "fn main() -> i32 { checked { let p = @alloc_bytes(3, 1); \
-             @byte_write(p, 1, 255); let q = @realloc_bytes(p, 3, 1, 5); \
-             let b = @byte_read(q, 1); @free_bytes(q, 5, 1); \
+            "fn main() -> i32 { checked { let p = @alloc(3, 1); \
+             @byte_write(p, 1, 255); let q = @realloc(p, 3, 1, 5); \
+             let b = @byte_read(q, 1); @free(q, 5, 1); \
              @intCast(b) } }",
             "main",
             preview,
@@ -4427,9 +4427,9 @@ mod tests {
     #[test]
     fn aggregate_layout_folds_byte_access_into_narrow_typed_path() {
         let mir = lower_function_to_mir_with_preview(
-            "fn main() -> i32 { checked { let p = @alloc_bytes(2, 1); \
+            "fn main() -> i32 { checked { let p = @alloc(2, 1); \
              @byte_write(p, 0, 65); let b = @byte_read(p, 1); \
-             @free_bytes(p, 2, 1); @intCast(b) } }",
+             @free(p, 2, 1); @intCast(b) } }",
             "main",
             PreviewFeatures::new(),
         );

--- a/crates/rue-codegen/src/aarch64/cfg_lower.rs
+++ b/crates/rue-codegen/src/aarch64/cfg_lower.rs
@@ -3541,6 +3541,13 @@ impl crate::place_lower::PlaceLowerBackend for CfgLower<'_> {
         });
     }
 
+    fn emit_zero_sized_place_addr(&mut self, dst: VReg) {
+        self.mir.push(Aarch64Inst::MovImm {
+            dst: Operand::Virtual(dst),
+            imm: crate::place_lower::ZERO_SIZED_PLACE_ADDR,
+        });
+    }
+
     fn emit_load_ptr_base(&mut self, dst: VReg, ptr: VReg) {
         self.mir.push(Aarch64Inst::LdrIndexed {
             dst: Operand::Virtual(dst),

--- a/crates/rue-codegen/src/allocation.rs
+++ b/crates/rue-codegen/src/allocation.rs
@@ -24,7 +24,14 @@ pub enum ScalePurpose {
     IndexOffset,
     /// Scaling a raw pointer offset before adding it to a pointer.
     PointerOffset,
-    /// Scaling an allocation count for a runtime heap call.
+    /// Scaling an element count into a trapping byte product.
+    ///
+    /// No plan carries this purpose today: the allocation family became
+    /// byte-shaped in ADR-0059 Phase 3 (RUE-961), so `count * @size_of(T)` is
+    /// ordinary source arithmetic whose overflow the language already traps
+    /// (§8.1), not a codegen-private multiply. The purpose and both backends'
+    /// checked-multiply lowering are retained as the one place a trapping
+    /// scale is expressed, should another consumer need it.
     AllocationSize,
 }
 
@@ -100,21 +107,6 @@ pub fn pointer_element_width(type_pool: &FrozenTypeInternPool, ptr_ty: Type) -> 
     type_width(type_pool, pointee)
 }
 
-/// Canonical byte alignment a pointer's pointee requires, from the layout
-/// authority. Companion to [`pointer_element_width`]; typed allocation passes
-/// this as the runtime allocator's `align` operand so the allocation carries the
-/// pointee's canonical `(size, alignment)` contract (ADR-0052). The defensive
-/// fallback mirrors [`pointer_element_width`]'s one-slot scalar width.
-#[inline]
-pub fn pointer_element_align(type_pool: &FrozenTypeInternPool, ptr_ty: Type) -> u64 {
-    let pointee = match ptr_ty.kind() {
-        TypeKind::PtrMut(id) => type_pool.ptr_mut_def(id),
-        TypeKind::PtrConst(id) => type_pool.ptr_const_def(id),
-        _ => return SLOT_BYTES,
-    };
-    type_pool.layout(pointee).alignment
-}
-
 /// Select the shared constant scaling operation for a byte width.
 #[inline]
 pub const fn scale_kind(bytes: u64) -> ScaleKind {
@@ -155,17 +147,6 @@ pub fn pointer_offset_scale_plan(type_pool: &FrozenTypeInternPool, ptr_ty: Type)
         kind: scale_kind(pointer_element_width(type_pool, ptr_ty).bytes),
         purpose: ScalePurpose::PointerOffset,
         overflow: OverflowBehavior::Wrap,
-    }
-}
-
-/// Build the checked scaling plan used by `@alloc`, `@free`, and `@realloc`.
-#[inline]
-pub fn allocation_size_scale_plan(type_pool: &FrozenTypeInternPool, ptr_ty: Type) -> ScalePlan {
-    let width = pointer_element_width(type_pool, ptr_ty);
-    ScalePlan {
-        kind: scale_kind(width.bytes),
-        purpose: ScalePurpose::AllocationSize,
-        overflow: OverflowBehavior::Trap,
     }
 }
 

--- a/crates/rue-codegen/src/place_lower.rs
+++ b/crates/rue-codegen/src/place_lower.rs
@@ -21,6 +21,23 @@ use rue_air::Type;
 /// entry points below.
 pub type ResolvedPlace = crate::value_plan::PlacePlan;
 
+/// The canonical address of a zero-sized place (RUE-605).
+///
+/// A zero-sized place occupies no storage, so the slot model has no cell that
+/// names it: an all-ZST root spans zero slots, and a zero-sized field at the
+/// end of its root names the root's past-the-end address, which the descending
+/// slot numbering cannot express at all (it underflowed `u32`, panicking in
+/// debug and wrapping to a wild frame slot in release).
+///
+/// ADR-0052 ruling 3 settles the semantics: a zero-sized type has size 0 and
+/// alignment 1, and a well-aligned dangling pointer to one is a valid,
+/// non-dereferenceable address. Address-taking is therefore accepted and every
+/// zero-sized place forms this one constant instead of a frame address: it is
+/// non-null, well-aligned for alignment 1, frame-independent, and identical on
+/// both backends. Nothing can dereference it — zero-sized reads return the
+/// canonical zero value and zero-sized writes store no slots.
+pub(crate) const ZERO_SIZED_PLACE_ADDR: i64 = 1;
+
 /// Per-target instruction leaves used by shared place lowering.
 pub(crate) trait PlaceLowerBackend: SlotBackend {
     /// Get or lazily materialize a received by-reference parameter pointer.
@@ -45,6 +62,13 @@ pub(crate) trait PlaceLowerBackend: SlotBackend {
     /// historically used a 64-bit immediate here; retaining that exact MIR is
     /// part of making this extraction mechanically output-neutral.
     fn emit_zero_sized_place(&mut self, dst: VReg);
+
+    /// Materialize [`ZERO_SIZED_PLACE_ADDR`], the canonical address of a place
+    /// that occupies no storage.
+    ///
+    /// The constant itself is shared; only the immediate-materialization
+    /// instruction differs per target, so this leaf carries no policy.
+    fn emit_zero_sized_place_addr(&mut self, dst: VReg);
 
     /// Load from the address in `ptr` with no encoded displacement.
     ///
@@ -93,6 +117,55 @@ fn resolved_root_count<B: PlaceLowerBackend + ?Sized>(b: &B, place: &ResolvedPla
     b.ctx().type_slot_count(place.base_type)
 }
 
+/// Slot count of the sub-object the projection chain selects.
+///
+/// Every projection carries the type it projects *out of*, so the last link
+/// alone determines the selected type; an empty chain selects the root. Zero
+/// here means the place has no storage, which is what
+/// [`ZERO_SIZED_PLACE_ADDR`] answers for.
+fn resolved_projected_slot_count<B: PlaceLowerBackend + ?Sized>(
+    b: &B,
+    place: &ResolvedPlace,
+) -> u32 {
+    match place.projections.last() {
+        None => resolved_root_count(b, place),
+        Some(crate::value_plan::ProjectionPlan::Field {
+            struct_id,
+            field_index,
+        }) => {
+            let struct_def = b.ctx().type_pool.struct_def(*struct_id);
+            b.ctx()
+                .type_slot_count(struct_def.fields[*field_index as usize].ty)
+        }
+        Some(crate::value_plan::ProjectionPlan::Index { array_type, .. }) => {
+            b.ctx().array_element_slot_count(*array_type)
+        }
+    }
+}
+
+/// The frame slot holding the low (lowest-addressed) end of a projected place.
+///
+/// The root occupies slots `base_slot ..= base_slot + root_count - 1` and slot
+/// numbers descend in address, so the field at static slot offset `k` starts at
+/// `base_slot + root_count - 1 - k`. A place with at least one slot always has
+/// `k + slot_count <= root_count`, hence `k <= root_count - 1`, so the
+/// subtraction is in range. A zero-sized place is the only shape that can push
+/// `k` past the end, and every caller diverts those to
+/// [`ZERO_SIZED_PLACE_ADDR`] before reaching here (RUE-605) — so an underflow
+/// is a violated invariant, reported as an ICE rather than silently wrapping to
+/// a wild slot in release builds.
+fn projected_low_slot(base_slot: u32, root_count: u32, static_slot_offset: u32) -> u32 {
+    (base_slot + root_count)
+        .checked_sub(1 + static_slot_offset)
+        .unwrap_or_else(|| {
+            panic!(
+                "projected place at slot offset {static_slot_offset} of a \
+                 {root_count}-slot root has no storage slot; zero-sized places \
+                 must be diverted to the canonical zero-sized address"
+            )
+        })
+}
+
 fn resolved_access<B: PlaceLowerBackend + ?Sized>(
     b: &mut B,
     place: &ResolvedPlace,
@@ -103,7 +176,7 @@ fn resolved_access<B: PlaceLowerBackend + ?Sized>(
     match place.base {
         crate::value_plan::PlaceBasePlan::Local(slot) => frame_access(
             b,
-            slot + root_count.saturating_sub(1) - offsets.static_slot_offset,
+            projected_low_slot(slot, root_count, offsets.static_slot_offset),
             dynamic_offset,
         ),
         crate::value_plan::PlaceBasePlan::Param { slot, by_ref: true } => {
@@ -124,12 +197,14 @@ fn resolved_access<B: PlaceLowerBackend + ?Sized>(
         crate::value_plan::PlaceBasePlan::Param {
             slot,
             by_ref: false,
-        } => frame_access(
-            b,
-            b.ctx().param_frame_slot(slot) + root_count.saturating_sub(1)
-                - offsets.static_slot_offset,
-            dynamic_offset,
-        ),
+        } => {
+            let base_slot = b.ctx().param_frame_slot(slot);
+            frame_access(
+                b,
+                projected_low_slot(base_slot, root_count, offsets.static_slot_offset),
+                dynamic_offset,
+            )
+        }
     }
 }
 
@@ -241,13 +316,21 @@ fn lower_place_addr_plan_with_bounds<B: PlaceLowerBackend + ?Sized>(
     check_bounds: bool,
 ) {
     let offsets = resolved_offsets(b, place, check_bounds);
+    // `resolved_offsets` has already emitted the bounds checks, so a zero-sized
+    // indexed place keeps its language-level trap edge even though the address
+    // itself is a constant. The index math below is deliberately skipped: a
+    // zero-sized element has a zero stride, so no index can move the address.
+    if resolved_projected_slot_count(b, place) == 0 {
+        b.emit_zero_sized_place_addr(dst);
+        return;
+    }
     let root_count = resolved_root_count(b, place);
     let dynamic = compute_resolved_index_offset(b, &offsets.index_levels);
     match place.base {
         crate::value_plan::PlaceBasePlan::Local(slot) => {
             b.emit_frame_addr(
                 dst,
-                slot + root_count.saturating_sub(1) - offsets.static_slot_offset,
+                projected_low_slot(slot, root_count, offsets.static_slot_offset),
             );
             if let Some(dynamic) = dynamic {
                 b.emit_addr_add(dst, dynamic);
@@ -268,10 +351,10 @@ fn lower_place_addr_plan_with_bounds<B: PlaceLowerBackend + ?Sized>(
             slot,
             by_ref: false,
         } => {
+            let base_slot = b.ctx().param_frame_slot(slot);
             b.emit_frame_addr(
                 dst,
-                b.ctx().param_frame_slot(slot) + root_count.saturating_sub(1)
-                    - offsets.static_slot_offset,
+                projected_low_slot(base_slot, root_count, offsets.static_slot_offset),
             );
             if let Some(dynamic) = dynamic {
                 b.emit_addr_add(dst, dynamic);
@@ -332,7 +415,10 @@ mod tests {
     use rue_span::{FileId, Span};
     use rue_target::Target;
 
-    use crate::aarch64::{Aarch64Inst, CfgLower as Aarch64CfgLower};
+    use super::ZERO_SIZED_PLACE_ADDR;
+    use crate::aarch64::{
+        Aarch64Inst, CfgLower as Aarch64CfgLower, Operand as Aarch64Operand, Reg as Aarch64Reg,
+    };
     use crate::x86_64::{CfgLower as X86CfgLower, X86Inst};
 
     /// Exercise all three shared entry points with a field followed by two
@@ -702,6 +788,114 @@ mod tests {
         assert!(unit_write_arm.instructions().iter().any(|inst| {
             matches!(inst, Aarch64Inst::Bl { symbol_id, .. } if unit_write_arm.get_symbol(*symbol_id) == "__rue_bounds_check")
         }));
+    }
+
+    /// Forming the address of a place with no storage yields
+    /// [`ZERO_SIZED_PLACE_ADDR`] rather than frame slot arithmetic (RUE-605).
+    ///
+    /// Both address-forming entry points are exercised: `@raw` through
+    /// [`lower_place_addr_plan`], and a `borrow` argument through
+    /// [`lower_checked_place_addr_plan`]. Both root shapes are exercised too:
+    /// an all-ZST root, which spans zero slots, and a zero-sized field at the
+    /// end of a sized root, which names the root's past-the-end address. Before
+    /// the fix the latter underflowed the descending slot numbering — an ICE in
+    /// debug, a wild frame slot in release.
+    #[test]
+    fn zero_sized_place_addresses_are_canonical_on_both_backends() {
+        let source = r#"
+            struct Empty { unit: () }
+            struct Tail { value: i64, unit: () }
+            fn take_unit(borrow unit: ()) -> i32 { 0 }
+            fn main() -> i32 {
+                let empty = Empty { unit: () };
+                let _all_zst: ptr const () = checked { @raw(empty.unit) };
+                let tail = Tail { value: 7, unit: () };
+                let _tail_zst: ptr const () = checked { @raw(tail.unit) };
+                take_unit(borrow tail.unit)
+            }
+        "#;
+
+        let lexer = Lexer::new(source);
+        let (tokens, interner) = lexer.tokenize().expect("fixture should lex");
+        let parser = Parser::new(tokens, interner);
+        let (ast, mut interner) = parser.parse().expect("fixture should parse");
+        let mut astgen = AstGen::with_symbol_normalizer(&interner, |symbol| symbol);
+        astgen.append_items(&ast.items);
+        let rir = astgen.finish();
+        let output = Sema::new_synthetic(&rir, &mut interner, PreviewFeatures::new())
+            .analyze_all_for_test()
+            .expect("fixture should analyze");
+        let function = output
+            .functions
+            .iter()
+            .find(|function| function.name == "main")
+            .expect("fixture function should exist");
+        let cfg = CfgBuilder::build(
+            &function.air,
+            function.num_locals,
+            function.num_param_slots,
+            &function.name,
+            &output.type_pool,
+            function.param_modes.clone(),
+            &interner,
+            function.allow_unreachable_code,
+            function.callable_kind,
+        )
+        .cfg
+        .unwrap();
+
+        let x86 = X86CfgLower::new_unchecked(&cfg, &output.type_pool, &interner)
+            .lower()
+            .expect("x86 zero-sized address fixture should lower");
+        let arm = Aarch64CfgLower::new_unchecked(
+            &cfg,
+            &output.type_pool,
+            &interner,
+            Target::Aarch64Linux,
+        )
+        .lower()
+        .expect("AArch64 zero-sized address fixture should lower");
+
+        // Three zero-sized addresses, one canonical constant each, and no frame
+        // address formed for any of them: the only `lea`/`add fp` in the
+        // function would come from this lowering, since nothing else here takes
+        // an address.
+        assert_eq!(
+            x86.instructions()
+                .iter()
+                .filter(|inst| matches!(
+                    inst,
+                    X86Inst::MovRI64 { imm, .. } if *imm == ZERO_SIZED_PLACE_ADDR
+                ))
+                .count(),
+            3
+        );
+        assert!(
+            !x86.instructions()
+                .iter()
+                .any(|inst| matches!(inst, X86Inst::Lea { .. })),
+            "a zero-sized place must not form a frame address"
+        );
+        assert_eq!(
+            arm.instructions()
+                .iter()
+                .filter(|inst| matches!(
+                    inst,
+                    Aarch64Inst::MovImm { imm, .. } if *imm == ZERO_SIZED_PLACE_ADDR
+                ))
+                .count(),
+            3
+        );
+        assert!(
+            !arm.instructions().iter().any(|inst| matches!(
+                inst,
+                Aarch64Inst::AddImm {
+                    src: Aarch64Operand::Physical(Aarch64Reg::Fp),
+                    ..
+                }
+            )),
+            "a zero-sized place must not form a frame address"
+        );
     }
 
     /// Taking a raw pointer into an element of a frame-resident non-slot-identical

--- a/crates/rue-codegen/src/types.rs
+++ b/crates/rue-codegen/src/types.rs
@@ -895,7 +895,8 @@ fn pointee_or_self(type_pool: &FrozenTypeInternPool, ty: Type) -> Type {
 /// Purely compile-time layout queries (`@size_of`/`@align_of`/`@offset_of`) fold
 /// to constants before code generation. Slot-identical aggregates (all
 /// eight-byte leaves, e.g. `StrBuf`) marshal correctly, as does the
-/// byte-addressed raw-byte family (`@byte_read`/`@byte_write`/`@alloc_bytes`).
+/// byte-addressed raw-byte family (`@byte_read`/`@byte_write` over an
+/// `@alloc`'d block).
 ///
 /// Returning `None` never weakens correctness: every remaining physical access
 /// is either byte-for-byte identical to the slot model, a narrow scalar access

--- a/crates/rue-codegen/src/value_plan.rs
+++ b/crates/rue-codegen/src/value_plan.rs
@@ -282,25 +282,20 @@ pub enum IntrinsicOperation {
     PtrRead,
     PtrWrite,
     PtrOffset,
-    Alloc {
-        /// The pointee's canonical byte alignment (from the layout authority),
-        /// passed as the runtime allocator's `align` operand.
-        element_size: u64,
-    },
-    Free {
-        /// The pointee's canonical byte alignment (see [`Self::Alloc`]).
-        element_size: u64,
-    },
-    Realloc {
-        /// The pointee's canonical byte alignment (see [`Self::Alloc`]).
-        element_size: u64,
-    },
-    AllocBytes,
-    FreeBytes,
-    ReallocBytes,
+    /// The unified byte-and-alignment allocation family (ADR-0059 Phase 3,
+    /// RUE-961). Every operand — the block pointer, the byte sizes, and the
+    /// alignment — is a user-supplied value, so these carry no layout-derived
+    /// payload; typed allocation is source-computed `@size_of`/`@align_of`
+    /// arithmetic at the call site.
+    Alloc,
+    AllocZeroed,
+    Free,
+    Realloc,
+    Resize,
     ByteRead,
     ByteWrite,
     ByteCopy,
+    ByteMove,
     ByteSet,
     ArgCount,
     ArgPtr,
@@ -1658,30 +1653,19 @@ pub(crate) fn lower_value<A: ValueLowerAdapter>(
                     "ptr_read" | "ptr_read_unaligned" => IntrinsicOperation::PtrRead,
                     "ptr_write" | "ptr_write_unaligned" => IntrinsicOperation::PtrWrite,
                     "ptr_offset" => IntrinsicOperation::PtrOffset,
-                    "alloc" => IntrinsicOperation::Alloc {
-                        element_size: crate::allocation::pointer_element_align(
-                            ctx.type_pool,
-                            inst.ty,
-                        ),
-                    },
-                    "free" => IntrinsicOperation::Free {
-                        element_size: crate::allocation::pointer_element_align(
-                            ctx.type_pool,
-                            ctx.cfg.get_inst(args[0]).ty,
-                        ),
-                    },
-                    "realloc" => IntrinsicOperation::Realloc {
-                        element_size: crate::allocation::pointer_element_align(
-                            ctx.type_pool,
-                            ctx.cfg.get_inst(args[0]).ty,
-                        ),
-                    },
-                    "alloc_bytes" => IntrinsicOperation::AllocBytes,
-                    "free_bytes" => IntrinsicOperation::FreeBytes,
-                    "realloc_bytes" => IntrinsicOperation::ReallocBytes,
+                    // The unified allocation family carries physical byte
+                    // sizes and an explicit alignment in its own operands
+                    // (ADR-0059 Phase 3, RUE-961), so nothing here consults a
+                    // pointee layout: every operand passes straight through.
+                    "alloc" => IntrinsicOperation::Alloc,
+                    "alloc_zeroed" => IntrinsicOperation::AllocZeroed,
+                    "free" => IntrinsicOperation::Free,
+                    "realloc" => IntrinsicOperation::Realloc,
+                    "resize" => IntrinsicOperation::Resize,
                     "byte_read" => IntrinsicOperation::ByteRead,
                     "byte_write" => IntrinsicOperation::ByteWrite,
                     "byte_copy" => IntrinsicOperation::ByteCopy,
+                    "byte_move" => IntrinsicOperation::ByteMove,
                     "byte_set" => IntrinsicOperation::ByteSet,
                     "arg_count" => IntrinsicOperation::ArgCount,
                     "arg_ptr" => IntrinsicOperation::ArgPtr,
@@ -1701,19 +1685,10 @@ pub(crate) fn lower_value<A: ValueLowerAdapter>(
                             ctx.cfg.get_inst(args[0]).ty,
                         ))
                     }
-                    IntrinsicOperation::Alloc { .. } => Some(
-                        crate::allocation::allocation_size_scale_plan(ctx.type_pool, inst.ty),
-                    ),
-                    IntrinsicOperation::Free { .. } | IntrinsicOperation::Realloc { .. } => {
-                        Some(crate::allocation::allocation_size_scale_plan(
-                            ctx.type_pool,
-                            ctx.cfg.get_inst(args[0]).ty,
-                        ))
-                    }
                     _ => None,
                 };
                 let result_slots = ctx.type_slot_count(inst.ty);
-                let runtime_call = intrinsic_runtime_call(&operation, &values, scale, result_slots);
+                let runtime_call = intrinsic_runtime_call(&operation, &values, result_slots);
                 // A narrow-scalar `@ptr_read`/`@ptr_write` under the compact
                 // layout accesses 1/2/4 physical bytes with the pointee's
                 // extension (RUE-989). The read's pointee is its result type; the
@@ -1895,18 +1870,20 @@ pub(crate) fn lower_value<A: ValueLowerAdapter>(
 /// Realize an allocation-family runtime call's operand list from its manifest
 /// (`RuntimeCallKind::operands()`) — the single description the AIR validator in
 /// `rue_air::runtime_call` also consumes, so the two encodings of the alloc ABI
-/// the ADR-0052 audit found are reconciled to one authority (RUE-973). Each
-/// operand's semantic origin selects how it is materialized: a size scales its
-/// count by the pointee's canonical layout size (`scale`), an alignment takes
-/// the pointee's canonical alignment (`pointee_align`, from the layout
-/// authority), a pointer passes straight through, and a plain byte-family value
-/// operand passes its AIR argument. Ordering, arity, and ABI types come from the
-/// manifest and are re-checked by `RuntimeCallPlan::expect_manifest`.
+/// the ADR-0052 audit found stay reconciled to one authority (RUE-973).
+/// Ordering, arity, and ABI types come from the manifest and are re-checked by
+/// `RuntimeCallPlan::expect_manifest`.
+///
+/// Every operand of `@alloc`/`@alloc_zeroed`/`@free`/`@realloc`/`@resize` is a
+/// user-supplied value — a `ptr mut u8` block or a `u64` byte count — so this
+/// only reorders the intrinsic's arguments into the helper's parameter order
+/// (ADR-0059 Phase 3, RUE-961). Codegen computes no size and synthesizes no
+/// alignment: `count * @size_of(T)` and `@align_of(T)` are ordinary source
+/// arithmetic at the call site, which also means their overflow is the
+/// language's ordinary trapping multiply rather than a codegen-private check.
 fn realize_alloc_operands(
     kind: rue_air::RuntimeCallKind,
     args: &[IntrinsicArgPlan],
-    scale: Option<crate::allocation::ScalePlan>,
-    pointee_align: u64,
 ) -> Vec<crate::runtime_call_plan::RuntimeCallArg> {
     use crate::runtime_call_plan::RuntimeCallArg;
     use rue_air::RuntimeOperandOrigin;
@@ -1917,22 +1894,6 @@ fn realize_alloc_operands(
         .map(|origin| match *origin {
             RuntimeOperandOrigin::MutablePointerArgument { index, .. } => {
                 RuntimeCallArg::mut_pointer(args[index as usize].primary, AbiType::Byte)
-            }
-            RuntimeOperandOrigin::ScaledByResultPointeeSize(index) => RuntimeCallArg::scaled(
-                args[index as usize].primary,
-                scale.expect("typed allocation size scale"),
-                AbiType::U64,
-            ),
-            RuntimeOperandOrigin::ScaledByPointerPointeeSize { count, .. } => {
-                RuntimeCallArg::scaled(
-                    args[count as usize].primary,
-                    scale.expect("typed allocation size scale"),
-                    AbiType::U64,
-                )
-            }
-            RuntimeOperandOrigin::ResultPointeeAlign
-            | RuntimeOperandOrigin::PointerPointeeAlign(_) => {
-                RuntimeCallArg::immediate(pointee_align, AbiType::U64)
             }
             RuntimeOperandOrigin::ValueArgument { index, ty } => {
                 RuntimeCallArg::value(args[index as usize].primary, ty)
@@ -1945,7 +1906,6 @@ fn realize_alloc_operands(
 fn intrinsic_runtime_call(
     operation: &IntrinsicOperation,
     args: &[IntrinsicArgPlan],
-    scale: Option<crate::allocation::ScalePlan>,
     result_slots: u32,
 ) -> Option<crate::runtime_call_plan::RuntimeCallPlan> {
     use crate::runtime_call_plan::{RuntimeCallArg, RuntimeCallPlan};
@@ -2003,24 +1963,28 @@ fn intrinsic_runtime_call(
             RuntimeHelperId::EnvPtr,
             vec![RuntimeCallArg::value(args[0].primary, AbiType::U64)],
         ),
-        IntrinsicOperation::Alloc { element_size } => (
+        IntrinsicOperation::Alloc => (
             RuntimeHelperId::Alloc,
-            realize_alloc_operands(RuntimeCallKind::AllocTyped, args, scale, *element_size),
+            realize_alloc_operands(RuntimeCallKind::Alloc, args),
         ),
-        IntrinsicOperation::AllocBytes => (
-            RuntimeHelperId::Alloc,
-            realize_alloc_operands(RuntimeCallKind::AllocBytes, args, scale, 0),
+        IntrinsicOperation::AllocZeroed => (
+            RuntimeHelperId::AllocZeroed,
+            realize_alloc_operands(RuntimeCallKind::AllocZeroed, args),
         ),
-        IntrinsicOperation::Free { element_size } => (
+        IntrinsicOperation::Free => (
             RuntimeHelperId::Free,
-            realize_alloc_operands(RuntimeCallKind::FreeTyped, args, scale, *element_size),
-        ),
-        IntrinsicOperation::FreeBytes => (
-            RuntimeHelperId::Free,
-            realize_alloc_operands(RuntimeCallKind::FreeBytes, args, scale, 0),
+            realize_alloc_operands(RuntimeCallKind::Free, args),
         ),
         IntrinsicOperation::ByteCopy => (
             RuntimeHelperId::ByteCopy,
+            vec![
+                RuntimeCallArg::mut_pointer(args[0].primary, AbiType::Byte),
+                RuntimeCallArg::const_pointer(args[1].primary, AbiType::Byte),
+                RuntimeCallArg::value(args[2].primary, AbiType::U64),
+            ],
+        ),
+        IntrinsicOperation::ByteMove => (
+            RuntimeHelperId::ByteMove,
             vec![
                 RuntimeCallArg::mut_pointer(args[0].primary, AbiType::Byte),
                 RuntimeCallArg::const_pointer(args[1].primary, AbiType::Byte),
@@ -2035,13 +1999,13 @@ fn intrinsic_runtime_call(
                 RuntimeCallArg::value(args[2].primary, AbiType::U64),
             ],
         ),
-        IntrinsicOperation::Realloc { element_size } => (
+        IntrinsicOperation::Realloc => (
             RuntimeHelperId::Realloc,
-            realize_alloc_operands(RuntimeCallKind::ReallocTyped, args, scale, *element_size),
+            realize_alloc_operands(RuntimeCallKind::Realloc, args),
         ),
-        IntrinsicOperation::ReallocBytes => (
-            RuntimeHelperId::Realloc,
-            realize_alloc_operands(RuntimeCallKind::ReallocBytes, args, scale, 0),
+        IntrinsicOperation::Resize => (
+            RuntimeHelperId::Resize,
+            realize_alloc_operands(RuntimeCallKind::Resize, args),
         ),
         IntrinsicOperation::Debug => {
             let arg = args.first()?;
@@ -3288,18 +3252,13 @@ mod tests {
             some_discriminant: 1,
             none_discriminant: 0,
         };
-        let scale = crate::allocation::ScalePlan {
-            kind: crate::allocation::ScaleKind::Constant(8),
-            purpose: crate::allocation::ScalePurpose::AllocationSize,
-            overflow: crate::allocation::OverflowBehavior::Trap,
-        };
-        let call = |operation, args: &[IntrinsicArgPlan], scale, result_slots| {
-            super::intrinsic_runtime_call(&operation, args, scale, result_slots)
+        let call = |operation, args: &[IntrinsicArgPlan], result_slots| {
+            super::intrinsic_runtime_call(&operation, args, result_slots)
                 .expect("operation should have a runtime call")
         };
 
         assert_eq!(
-            call(option(OptionIntrinsic::ReadLine), &[], None, 4).helper(),
+            call(option(OptionIntrinsic::ReadLine), &[], 4).helper(),
             RuntimeHelperId::ReadLine
         );
         for (intrinsic, helper) in [
@@ -3308,28 +3267,22 @@ mod tests {
             (OptionIntrinsic::ParseU32, RuntimeHelperId::ParseU32),
             (OptionIntrinsic::ParseU64, RuntimeHelperId::ParseU64),
         ] {
-            let plan = call(
-                option(intrinsic),
-                std::slice::from_ref(&string_arg),
-                None,
-                2,
-            );
+            let plan = call(option(intrinsic), std::slice::from_ref(&string_arg), 2);
             assert_eq!(plan.helper(), helper);
             assert_eq!(plan.args().len(), 5);
         }
         assert_eq!(
-            call(IntrinsicOperation::RandomU32, &[], None, 1).helper(),
+            call(IntrinsicOperation::RandomU32, &[], 1).helper(),
             RuntimeHelperId::RandomU32
         );
         assert_eq!(
-            call(IntrinsicOperation::RandomU64, &[], None, 1).helper(),
+            call(IntrinsicOperation::RandomU64, &[], 1).helper(),
             RuntimeHelperId::RandomU64
         );
         assert_eq!(
             call(
-                IntrinsicOperation::Alloc { element_size: 8 },
-                std::slice::from_ref(&scalar_arg),
-                Some(scale),
+                IntrinsicOperation::Alloc,
+                &[scalar_arg.clone(), scalar_arg.clone()],
                 1,
             )
             .helper(),
@@ -3337,9 +3290,17 @@ mod tests {
         );
         assert_eq!(
             call(
-                IntrinsicOperation::Free { element_size: 8 },
+                IntrinsicOperation::AllocZeroed,
                 &[scalar_arg.clone(), scalar_arg.clone()],
-                Some(scale),
+                1,
+            )
+            .helper(),
+            RuntimeHelperId::AllocZeroed
+        );
+        assert_eq!(
+            call(
+                IntrinsicOperation::Free,
+                &[scalar_arg.clone(), scalar_arg.clone(), scalar_arg.clone()],
                 0,
             )
             .helper(),
@@ -3347,9 +3308,13 @@ mod tests {
         );
         assert_eq!(
             call(
-                IntrinsicOperation::Realloc { element_size: 8 },
-                &[scalar_arg.clone(), scalar_arg.clone(), scalar_arg.clone()],
-                Some(scale),
+                IntrinsicOperation::Realloc,
+                &[
+                    scalar_arg.clone(),
+                    scalar_arg.clone(),
+                    scalar_arg.clone(),
+                    scalar_arg.clone(),
+                ],
                 1,
             )
             .helper(),
@@ -3357,9 +3322,31 @@ mod tests {
         );
         assert_eq!(
             call(
+                IntrinsicOperation::Resize,
+                &[
+                    scalar_arg.clone(),
+                    scalar_arg.clone(),
+                    scalar_arg.clone(),
+                    scalar_arg.clone(),
+                ],
+                1,
+            )
+            .helper(),
+            RuntimeHelperId::Resize
+        );
+        assert_eq!(
+            call(
+                IntrinsicOperation::ByteMove,
+                &[scalar_arg.clone(), scalar_arg.clone(), scalar_arg.clone()],
+                0,
+            )
+            .helper(),
+            RuntimeHelperId::ByteMove
+        );
+        assert_eq!(
+            call(
                 IntrinsicOperation::Debug,
                 std::slice::from_ref(&scalar_arg),
-                None,
                 0,
             )
             .helper(),
@@ -3369,7 +3356,6 @@ mod tests {
             call(
                 IntrinsicOperation::Debug,
                 std::slice::from_ref(&string_arg),
-                None,
                 0,
             )
             .helper(),
@@ -3377,9 +3363,13 @@ mod tests {
         );
 
         let realloc = call(
-            IntrinsicOperation::Realloc { element_size: 8 },
-            &[scalar_arg.clone(), scalar_arg.clone(), scalar_arg],
-            Some(scale),
+            IntrinsicOperation::Realloc,
+            &[
+                scalar_arg.clone(),
+                scalar_arg.clone(),
+                scalar_arg.clone(),
+                scalar_arg,
+            ],
             1,
         );
         assert_eq!(

--- a/crates/rue-codegen/src/x86_64/cfg_lower.rs
+++ b/crates/rue-codegen/src/x86_64/cfg_lower.rs
@@ -2348,35 +2348,35 @@ impl<'a> CfgLower<'a> {
                 });
                 dst
             }
-            crate::value_plan::IntrinsicOperation::Alloc { element_size } => {
-                let _ = element_size;
+            // The unified allocation family and the bulk byte primitives are
+            // pure runtime calls: the shared plan already carries their
+            // operands in helper order (ADR-0059 Phase 3, RUE-961).
+            crate::value_plan::IntrinsicOperation::Alloc => {
                 self.lower_runtime_call(plan.runtime_call.expect("alloc runtime call plan"))
                     .primary
             }
-            crate::value_plan::IntrinsicOperation::Free { element_size } => {
-                let _ = element_size;
+            crate::value_plan::IntrinsicOperation::AllocZeroed => {
+                self.lower_runtime_call(plan.runtime_call.expect("alloc-zeroed runtime call plan"))
+                    .primary
+            }
+            crate::value_plan::IntrinsicOperation::Free => {
                 self.lower_runtime_call(plan.runtime_call.expect("free runtime call plan"))
                     .primary
             }
-            crate::value_plan::IntrinsicOperation::Realloc { element_size } => {
-                let _ = element_size;
+            crate::value_plan::IntrinsicOperation::Realloc => {
                 self.lower_runtime_call(plan.runtime_call.expect("realloc runtime call plan"))
                     .primary
             }
-            crate::value_plan::IntrinsicOperation::AllocBytes => {
-                self.lower_runtime_call(plan.runtime_call.expect("alloc-bytes runtime call plan"))
-                    .primary
-            }
-            crate::value_plan::IntrinsicOperation::FreeBytes => {
-                self.lower_runtime_call(plan.runtime_call.expect("free-bytes runtime call plan"))
-                    .primary
-            }
-            crate::value_plan::IntrinsicOperation::ReallocBytes => {
-                self.lower_runtime_call(plan.runtime_call.expect("realloc-bytes runtime call plan"))
+            crate::value_plan::IntrinsicOperation::Resize => {
+                self.lower_runtime_call(plan.runtime_call.expect("resize runtime call plan"))
                     .primary
             }
             crate::value_plan::IntrinsicOperation::ByteCopy => {
                 self.lower_runtime_call(plan.runtime_call.expect("byte-copy runtime call plan"))
+                    .primary
+            }
+            crate::value_plan::IntrinsicOperation::ByteMove => {
+                self.lower_runtime_call(plan.runtime_call.expect("byte-move runtime call plan"))
                     .primary
             }
             crate::value_plan::IntrinsicOperation::ByteSet => {
@@ -3644,8 +3644,8 @@ mod tests {
     /// access.
     #[test]
     fn aggregate_layout_allows_narrow_scalar_physical_access() {
-        let source = "fn main() -> i32 { checked { let p: ptr mut i32 = @alloc(1); \
-                      @ptr_write(p, 5); @dbg(@ptr_read(p)); @free(p, 1); }; 0 }";
+        let source = "fn main() -> i32 { checked { let p: ptr mut i32 = @int_to_ptr(@ptr_to_int(@alloc(@intCast(@size_of(i32)), @intCast(@align_of(i32))))); \
+                      @ptr_write(p, 5); @dbg(@ptr_read(p)); @free(@int_to_ptr(@ptr_to_int(p)), @intCast(@size_of(i32)), @intCast(@align_of(i32))); }; 0 }";
         let mir = try_lower_first_fn(source, PreviewFeatures::new())
             .expect("a narrow scalar through a typed pointer must lower under compact layout");
         assert!(
@@ -3673,10 +3673,10 @@ mod tests {
     #[test]
     fn aggregate_layout_allows_compact_enum_memory() {
         let source = "enum Opt { Some(i32), None } \
-                      fn main() -> i32 { checked { let p: ptr mut Opt = @alloc(1); \
+                      fn main() -> i32 { checked { let p: ptr mut Opt = @int_to_ptr(@ptr_to_int(@alloc(@intCast(@size_of(Opt)), @intCast(@align_of(Opt))))); \
                       @ptr_write(p, Opt.Some(42)); let e = @ptr_read(p); \
                       match e { Opt.Some(x) => @dbg(x), Opt.None => @dbg(0), }; \
-                      @free(p, 1); }; 0 }";
+                      @free(@int_to_ptr(@ptr_to_int(p)), @intCast(@size_of(Opt)), @intCast(@align_of(Opt))); }; 0 }";
         let mir = try_lower_first_fn(source, PreviewFeatures::new())
             .expect("a compact enum with a variant-independent image must lower");
         assert!(
@@ -3704,9 +3704,9 @@ mod tests {
     #[test]
     fn aggregate_layout_allows_compact_struct_memory() {
         let source = "struct Padded { a: u8, b: i32, c: u8 } \
-                      fn main() -> i32 { checked { let p: ptr mut Padded = @alloc(1); \
+                      fn main() -> i32 { checked { let p: ptr mut Padded = @int_to_ptr(@ptr_to_int(@alloc(@intCast(@size_of(Padded)), @intCast(@align_of(Padded))))); \
                       @ptr_write(p, Padded { a: 7, b: 1000, c: 9 }); let s = @ptr_read(p); \
-                      @dbg(s.b); @free(p, 1); }; 0 }";
+                      @dbg(s.b); @free(@int_to_ptr(@ptr_to_int(p)), @intCast(@size_of(Padded)), @intCast(@align_of(Padded))); }; 0 }";
         let mir = try_lower_first_fn(source, PreviewFeatures::new()).expect(
             "a whole compact struct through a typed pointer must lower under compact layout",
         );
@@ -3731,9 +3731,9 @@ mod tests {
     #[test]
     fn aggregate_layout_allows_array_bearing_struct_memory() {
         let source = "struct HasArr { tag: u8, xs: [i32; 2] } \
-                      fn main() -> i32 { let r = checked { let p: ptr mut HasArr = @alloc(1); \
+                      fn main() -> i32 { let r = checked { let p: ptr mut HasArr = @int_to_ptr(@ptr_to_int(@alloc(@intCast(@size_of(HasArr)), @intCast(@align_of(HasArr))))); \
                       @ptr_write(p, HasArr { tag: 5, xs: [10, 20] }); let v = @ptr_read(p); \
-                      @free(p, 1); v.xs[0] + v.xs[1] }; @dbg(r); 0 }";
+                      @free(@int_to_ptr(@ptr_to_int(p)), @intCast(@size_of(HasArr)), @intCast(@align_of(HasArr))); v.xs[0] + v.xs[1] }; @dbg(r); 0 }";
         let mir = try_lower_first_fn(source, PreviewFeatures::new())
             .expect("a struct with a compact array image must lower under compact layout");
         assert!(
@@ -3750,9 +3750,9 @@ mod tests {
     #[test]
     fn aggregate_layout_allows_variant_dependent_enum_image() {
         let source = "struct Point { x: i32, y: i32 } enum Opt { Some(Point), None } \
-                      fn main() -> i32 { let r = checked { let p: ptr mut Opt = @alloc(1); \
+                      fn main() -> i32 { let r = checked { let p: ptr mut Opt = @int_to_ptr(@ptr_to_int(@alloc(@intCast(@size_of(Opt)), @intCast(@align_of(Opt))))); \
                       @ptr_write(p, Opt.Some(Point { x: 40, y: 2 })); let v = @ptr_read(p); \
-                      @free(p, 1); match v { Opt.Some(pt) => pt.x + pt.y, Opt.None => 0 - 1 } }; \
+                      @free(@int_to_ptr(@ptr_to_int(p)), @intCast(@size_of(Opt)), @intCast(@align_of(Opt))); match v { Opt.Some(pt) => pt.x + pt.y, Opt.None => 0 - 1 } }; \
                       @dbg(r); 0 }";
         let mir = try_lower_first_fn(source, PreviewFeatures::new())
             .expect("an enum with a variant-independent struct-payload image must lower");
@@ -3771,8 +3771,8 @@ mod tests {
     #[test]
     fn aggregate_layout_marshals_struct_embedding_heterogeneous_enum() {
         let source = "enum Bad { A(i64), B(i32, i32) } struct HasBad { b: Bad } \
-                      fn main() -> i32 { checked { let p: ptr mut HasBad = @alloc(1); \
-                      @ptr_write(p, HasBad { b: Bad.A(5) }); @free(p, 1); }; 0 }";
+                      fn main() -> i32 { checked { let p: ptr mut HasBad = @int_to_ptr(@ptr_to_int(@alloc(@intCast(@size_of(HasBad)), @intCast(@align_of(HasBad))))); \
+                      @ptr_write(p, HasBad { b: Bad.A(5) }); @free(@int_to_ptr(@ptr_to_int(p)), @intCast(@size_of(HasBad)), @intCast(@align_of(HasBad))); }; 0 }";
         let mir = try_lower_first_fn(source, PreviewFeatures::new())
             .expect("a struct embedding a heterogeneous enum must lower via nested tag dispatch");
         assert!(
@@ -3810,7 +3810,7 @@ mod tests {
         let source = "enum R { Ok(Point), Err(i64) } \
                       struct Point { x: i32, y: i32, z: i32 } \
                       fn store_it(p: ptr mut R) { checked { @ptr_write(p, R.Ok(Point { x: 1, y: 2, z: 3 })); }; } \
-                      fn main() -> i32 { checked { let p: ptr mut R = @alloc(1); store_it(p); @free(p, 1); }; 0 }";
+                      fn main() -> i32 { checked { let p: ptr mut R = @int_to_ptr(@ptr_to_int(@alloc(@intCast(@size_of(R)), @intCast(@align_of(R))))); store_it(p); @free(@int_to_ptr(@ptr_to_int(p)), @intCast(@size_of(R)), @intCast(@align_of(R))); }; 0 }";
         let mir = try_lower_named_fn(source, PreviewFeatures::new(), Some("store_it"))
             .expect("a heterogeneous enum @ptr_write must lower via tag dispatch");
         assert!(
@@ -4054,8 +4054,8 @@ mod tests {
     fn aggregate_layout_marshals_variant_dependent_enum_memory() {
         let mir = try_lower_first_fn(
             "enum Bad { A(i64), B(i32, i32) } \
-             fn main() -> i32 { checked { let p: ptr mut Bad = @alloc(1); \
-             @ptr_write(p, Bad.A(5)); @free(p, 1); }; 0 }",
+             fn main() -> i32 { checked { let p: ptr mut Bad = @int_to_ptr(@ptr_to_int(@alloc(@intCast(@size_of(Bad)), @intCast(@align_of(Bad))))); \
+             @ptr_write(p, Bad.A(5)); @free(@int_to_ptr(@ptr_to_int(p)), @intCast(@size_of(Bad)), @intCast(@align_of(Bad))); }; 0 }",
             PreviewFeatures::new(),
         )
         .expect("a variant-dependent enum memory image must lower via tag dispatch");
@@ -4249,9 +4249,9 @@ mod tests {
     fn raw_bytes_runtime_helper_identity_and_slots_match_shared_plan() {
         let preview = PreviewFeatures::new();
         let mir = lower_to_mir_with_preview(
-            "fn main() -> i32 { checked { let p = @alloc_bytes(3, 1); \
-             @byte_write(p, 1, 255); let q = @realloc_bytes(p, 3, 1, 5); \
-             let b = @byte_read(q, 1); @free_bytes(q, 5, 1); \
+            "fn main() -> i32 { checked { let p = @alloc(3, 1); \
+             @byte_write(p, 1, 255); let q = @realloc(p, 3, 1, 5); \
+             let b = @byte_read(q, 1); @free(q, 5, 1); \
              @intCast(b) } }",
             preview,
         );
@@ -4286,9 +4286,9 @@ mod tests {
     /// of a `u8` pointee does.
     #[test]
     fn aggregate_layout_folds_byte_access_into_narrow_typed_path() {
-        let source = "fn main() -> i32 { checked { let p = @alloc_bytes(2, 1); \
+        let source = "fn main() -> i32 { checked { let p = @alloc(2, 1); \
              @byte_write(p, 0, 65); let b = @byte_read(p, 1); \
-             @free_bytes(p, 2, 1); @intCast(b) } }";
+             @free(p, 2, 1); @intCast(b) } }";
         let mir = lower_to_mir_with_preview(source, PreviewFeatures::new());
         assert!(
             mir.instructions()

--- a/crates/rue-codegen/src/x86_64/cfg_lower.rs
+++ b/crates/rue-codegen/src/x86_64/cfg_lower.rs
@@ -3293,6 +3293,13 @@ impl crate::place_lower::PlaceLowerBackend for CfgLower<'_> {
         });
     }
 
+    fn emit_zero_sized_place_addr(&mut self, dst: VReg) {
+        self.mir.push(X86Inst::MovRI64 {
+            dst: Operand::Virtual(dst),
+            imm: crate::place_lower::ZERO_SIZED_PLACE_ADDR,
+        });
+    }
+
     fn emit_load_ptr_base(&mut self, dst: VReg, ptr: VReg) {
         self.mir.push(X86Inst::MovRMIndexed {
             dst: Operand::Virtual(dst),

--- a/crates/rue-error/src/lib.rs
+++ b/crates/rue-error/src/lib.rs
@@ -413,7 +413,7 @@ impl ErrorCode {
     pub const CANNOT_INFER_POINTEE_TYPE: Self = Self(710);
     pub const CONTAINER_ELEMENT_NOT_TRIVIALLY_DROPPABLE: Self = Self(711);
     /// A comptime-constant `align` argument to a byte-allocation intrinsic
-    /// (`@alloc_bytes`/`@realloc_bytes`/`@free_bytes`, ADR-0059 Phase 2) was
+    /// (`@alloc`/`@alloc_zeroed`/`@free`/`@realloc`/`@resize`, ADR-0059) was
     /// zero or not a power of two. Alignment must be a power of two.
     pub const INTRINSIC_ALIGN_NOT_POWER_OF_TWO: Self = Self(712);
 

--- a/crates/rue-error/src/lib.rs
+++ b/crates/rue-error/src/lib.rs
@@ -1761,8 +1761,18 @@ pub enum ErrorKind {
     /// (Appendix C practical limit; RUE-561 — unchecked u32 slot arithmetic
     /// previously ICEd on 2 GiB arrays and silently truncated 32 GiB ones to
     /// zero-sized).
-    #[error("type '{type_name}' exceeds the maximum supported object size ({max_bytes} bytes)")]
-    TypeTooLarge { type_name: String, max_bytes: u64 },
+    ///
+    /// The limit that is actually enforced is a count of 8-byte ABI slots, not
+    /// a byte total: a layout spends one slot per scalar, per struct field, and
+    /// per array element, whatever the element's own width. The message names
+    /// the slot ceiling so it reports the limit the compiler checks, as spec
+    /// C.1:2 requires (RUE-1272).
+    #[error(
+        "type '{type_name}' exceeds the maximum supported object size \
+         ({max_slots} ABI slots; a layout spends one 8-byte slot per scalar, \
+         struct field, and array element)"
+    )]
+    TypeTooLarge { type_name: String, max_slots: u64 },
     /// A function's cumulative locals, parameter homes, sret cell, spills, or
     /// transient outgoing call area exceeds the backend displacement budget.
     #[error(

--- a/crates/rue-oracle-diff/src/model_gaps/cli.rs
+++ b/crates/rue-oracle-diff/src/model_gaps/cli.rs
@@ -103,7 +103,7 @@ const ENTRIES: &[Entry] = &[
     ),
     // std.fs File IO v0 (RUE-712, ADR-0057): pure-Rue fs over @syscall. The
     // oracle model cannot execute the raw-pointer/syscall substrate (StrBuf/
-    // ArrayBuf `@int_to_ptr` prologue, `@alloc_bytes`, `@syscall`), so every
+    // ArrayBuf `@int_to_ptr` prologue, `@alloc`, `@syscall`), so every
     // case is accepted debt, exactly like the arraybuf/strbuf CLI cases. The
     // two error-detection cases run `only_on` Linux (macOS carry-flag gap,
     // ADR-0057 §3a), so their gap registration is Linux-scoped to match.
@@ -251,10 +251,10 @@ const ENTRIES: &[Entry] = &[
         &[],
     ),
     // RUE-1014: the real-std json/priority-queue cases reach memory through the
-    // std allocators (`@alloc_bytes` in StrBuf, `@int_to_ptr` in ArrayBuf.new()),
+    // std allocators (`@alloc` in StrBuf, `@int_to_ptr` in ArrayBuf.new()),
     // outside the oracle model.
 
-    // RUE-978: the byte-surface behavior cases allocate through @alloc_bytes,
+    // RUE-978: the byte-surface behavior cases allocate through @alloc,
     // which the oracle model does not model.
     Entry::new(
         "cli.pointers",

--- a/crates/rue-oracle/src/lib.rs
+++ b/crates/rue-oracle/src/lib.rs
@@ -260,14 +260,14 @@ pub enum UnsupportedIntrinsicKind {
     RawMutableAddress,
     FieldPointer,
     Allocate,
+    AllocateZeroed,
     Free,
     Reallocate,
-    AllocateBytes,
-    FreeBytes,
-    ReallocateBytes,
+    Resize,
     ByteRead,
     ByteWrite,
     ByteCopy,
+    ByteMove,
     ByteSet,
 }
 
@@ -694,10 +694,25 @@ struct Allocation {
     /// projection): its single cell is the scalar, and a redirected `Load` of
     /// the owning slot must unwrap `root[0]` rather than return the aggregate.
     wrapped_scalar: bool,
-    /// `@free`/`@free_bytes` released this allocation. Pointer access checks the
-    /// flag so undefined use-after-free remains a typed oracle gap rather than
+    /// `@free` released this allocation. Pointer access checks the flag so
+    /// undefined use-after-free remains a typed oracle gap rather than
     /// receiving a deterministic value that native execution does not promise.
     freed: bool,
+    /// The block came from `@alloc`/`@alloc_zeroed`, which reserve raw physical
+    /// bytes and carry no element type (ADR-0059 Phase 3, RUE-961). Such a block
+    /// starts out as one-byte cells; the first typed pointer formed over an
+    /// **untouched** one reinterprets it as cells of that pointee. That is
+    /// exactly the shape `std/rawbuf.rue` gives a block when it turns
+    /// `cap * @size_of(T)` bytes into `cap` cells of `T`, and it lets the
+    /// interpreter keep modeling typed containers now that the compiler no
+    /// longer knows an allocation's element type. Reinterpreting clears the
+    /// flag.
+    untyped_bytes: bool,
+    /// Some cell of this allocation has been written. A touched block is never
+    /// reinterpreted, because its existing cells hold values a reinterpretation
+    /// would silently discard. Reads do not set this: an untouched block reads
+    /// as zero bytes whatever shape its cells are given.
+    touched: bool,
 }
 
 impl Value {
@@ -836,18 +851,16 @@ fn unsupported_intrinsic_kind(name: &str) -> UnsupportedKind {
         }
         "field_ptr" => UnsupportedKind::SemanticGap(Semantic::Intrinsic(Intrinsic::FieldPointer)),
         "alloc" => UnsupportedKind::SemanticGap(Semantic::Intrinsic(Intrinsic::Allocate)),
+        "alloc_zeroed" => {
+            UnsupportedKind::SemanticGap(Semantic::Intrinsic(Intrinsic::AllocateZeroed))
+        }
         "free" => UnsupportedKind::SemanticGap(Semantic::Intrinsic(Intrinsic::Free)),
         "realloc" => UnsupportedKind::SemanticGap(Semantic::Intrinsic(Intrinsic::Reallocate)),
-        "alloc_bytes" => {
-            UnsupportedKind::SemanticGap(Semantic::Intrinsic(Intrinsic::AllocateBytes))
-        }
-        "free_bytes" => UnsupportedKind::SemanticGap(Semantic::Intrinsic(Intrinsic::FreeBytes)),
-        "realloc_bytes" => {
-            UnsupportedKind::SemanticGap(Semantic::Intrinsic(Intrinsic::ReallocateBytes))
-        }
+        "resize" => UnsupportedKind::SemanticGap(Semantic::Intrinsic(Intrinsic::Resize)),
         "byte_read" => UnsupportedKind::SemanticGap(Semantic::Intrinsic(Intrinsic::ByteRead)),
         "byte_write" => UnsupportedKind::SemanticGap(Semantic::Intrinsic(Intrinsic::ByteWrite)),
         "byte_copy" => UnsupportedKind::SemanticGap(Semantic::Intrinsic(Intrinsic::ByteCopy)),
+        "byte_move" => UnsupportedKind::SemanticGap(Semantic::Intrinsic(Intrinsic::ByteMove)),
         "byte_set" => UnsupportedKind::SemanticGap(Semantic::Intrinsic(Intrinsic::ByteSet)),
         "read_line" => UnsupportedKind::ExternalDependency(External::StandardInput),
         "random_u32" => UnsupportedKind::ExternalDependency(External::RandomU32),
@@ -1430,11 +1443,11 @@ impl<'a> Interp<'a> {
             "ptr_write"
             | "ptr_write_unaligned"
             | "ptr_offset"
-            | "free"
             | "byte_read"
-            | "alloc_bytes" => args.len() == 2,
-            "realloc" | "byte_write" | "byte_copy" | "byte_set" | "free_bytes" => args.len() == 3,
-            "realloc_bytes" => args.len() == 4,
+            | "alloc"
+            | "alloc_zeroed" => args.len() == 2,
+            "byte_write" | "byte_copy" | "byte_move" | "byte_set" | "free" => args.len() == 3,
+            "realloc" | "resize" => args.len() == 4,
             "syscall" => (1..=7).contains(&args.len()),
             _ => args.len() == 1,
         };
@@ -1499,42 +1512,25 @@ impl<'a> Interp<'a> {
                         .pointer_pointee(result_ty)
                         .is_some_and(|(pointee, mutable)| mutable && pointee == ty(0))
             }
-            "alloc" => {
-                ty(0) == Type::U64
-                    && self
-                        .pointer_pointee(result_ty)
-                        .is_some_and(|(_, mutable)| mutable)
-            }
-            "free" => {
-                self.pointer_pointee(ty(0))
-                    .is_some_and(|(_, mutable)| mutable)
-                    && ty(1) == Type::U64
-                    && result_ty == Type::UNIT
-            }
-            "realloc" => {
-                self.pointer_pointee(ty(0))
-                    .is_some_and(|(_, mutable)| mutable)
-                    && ty(1) == Type::U64
-                    && ty(2) == Type::U64
-                    && result_ty == ty(0)
-            }
-            "alloc_bytes" => {
+            "alloc" | "alloc_zeroed" => {
                 ty(0) == Type::U64
                     && ty(1) == Type::U64
                     && self.pointer_pointee(result_ty) == Some((Type::U8, true))
             }
-            "free_bytes" => {
+            "free" => {
                 self.pointer_pointee(ty(0)) == Some((Type::U8, true))
                     && ty(1) == Type::U64
                     && ty(2) == Type::U64
                     && result_ty == Type::UNIT
             }
-            "realloc_bytes" => {
+            "realloc" | "resize" => {
+                // `(p, old_size, align, new_size)`; `@realloc` hands back the
+                // (possibly moved) block, `@resize` reports in-place success.
                 self.pointer_pointee(ty(0)) == Some((Type::U8, true))
                     && ty(1) == Type::U64
                     && ty(2) == Type::U64
                     && ty(3) == Type::U64
-                    && result_ty == ty(0)
+                    && result_ty == if name == "resize" { Type::BOOL } else { ty(0) }
             }
             "byte_read" => {
                 self.pointer_pointee(ty(0))
@@ -1548,7 +1544,7 @@ impl<'a> Interp<'a> {
                     && ty(2) == Type::U8
                     && result_ty == Type::UNIT
             }
-            "byte_copy" => {
+            "byte_copy" | "byte_move" => {
                 self.pointer_pointee(ty(0)) == Some((Type::U8, true))
                     && self
                         .pointer_pointee(ty(1))
@@ -3385,13 +3381,63 @@ impl<'a> Interp<'a> {
 
     /// Push a new allocation, returning its index.
     fn heap_alloc(&mut self, root: Value, elem_stride: u64, wrapped_scalar: bool) -> usize {
+        self.heap_alloc_with(root, elem_stride, wrapped_scalar, false)
+    }
+
+    /// Push a new allocation, optionally marking it as a raw byte block whose
+    /// element type is not yet known (see [`Allocation::untyped_bytes`]).
+    fn heap_alloc_with(
+        &mut self,
+        root: Value,
+        elem_stride: u64,
+        wrapped_scalar: bool,
+        untyped_bytes: bool,
+    ) -> usize {
         self.heap.push(Allocation {
             root,
             elem_stride: elem_stride.max(1),
             wrapped_scalar,
             freed: false,
+            untyped_bytes,
+            touched: false,
         });
         self.heap.len() - 1
+    }
+
+    /// Reinterpret an untouched raw byte block as cells of `pointee`.
+    ///
+    /// `std/rawbuf.rue` allocates `count * @size_of(T)` bytes and immediately
+    /// casts the result to `ptr mut T`; this is where that cast becomes the
+    /// interpreter's cell shape. Only an untouched block whose byte size is a
+    /// whole number of `pointee`s is reinterpreted — anything else keeps its
+    /// byte cells, so a genuinely byte-addressed block (`std/strbuf.rue`) is
+    /// never disturbed.
+    fn retype_untyped_bytes(&mut self, alloc: usize, pointee: Type) -> bool {
+        let stride = self.type_byte_size(pointee).max(1);
+        let Some(allocation) = self.heap.get(alloc) else {
+            return false;
+        };
+        if !allocation.untyped_bytes
+            || allocation.touched
+            || allocation.freed
+            || stride == allocation.elem_stride
+        {
+            return false;
+        }
+        let Value::Aggregate(cells) = &allocation.root else {
+            return false;
+        };
+        let bytes = cells.len() as u64;
+        if stride == 0 || bytes % stride != 0 {
+            return false;
+        }
+        let count = (bytes / stride) as usize;
+        let cells = (0..count).map(|_| self.zeroed_value(pointee)).collect();
+        let allocation = &mut self.heap[alloc];
+        allocation.root = Value::Aggregate(cells);
+        allocation.elem_stride = stride;
+        allocation.untyped_bytes = false;
+        true
     }
 
     /// Synthesize a stable non-null address for `target`, used by `@ptr_to_int`.
@@ -3477,6 +3523,9 @@ impl<'a> Interp<'a> {
         if alloc.freed {
             return Err(unsupported(gap, "pointer write after free"));
         }
+        // The block now carries meaningful values, which retires it from
+        // reinterpretation (see `Allocation::untyped_bytes`).
+        alloc.touched = true;
         let container = Self::nav_mut(&mut alloc.root, &target.path)
             .ok_or_else(|| unsupported(gap, "pointer path escapes allocation"))?;
         match container {
@@ -3588,19 +3637,18 @@ impl<'a> Interp<'a> {
                 };
                 Ok(Some(Value::Ptr(Some(target))))
             }
-            "alloc" => {
-                let count = self.eval(cfg, frame, args[0])?.as_int();
-                let (pointee, _) = self
-                    .pointer_pointee(result_ty)
-                    .expect("validated @alloc result is a pointer");
-                Ok(Some(self.do_alloc(count, pointee)?))
-            }
-            "alloc_bytes" => {
+            // `@alloc(size, align)` and `@alloc_zeroed(size, align)` both
+            // reserve `size` raw bytes. The interpreter's cells always read as
+            // zero, so the two differ only in what a program may rely on;
+            // modeling them identically never reports a false agreement,
+            // because reading uninitialized `@alloc` storage is undefined
+            // behavior a corpus program must not depend on.
+            "alloc" | "alloc_zeroed" => {
                 let size = self.eval(cfg, frame, args[0])?.as_int();
                 let _align = self.eval(cfg, frame, args[1])?.as_int();
-                Ok(Some(self.do_alloc_bytes(size)?))
+                Ok(Some(self.do_alloc(size)?))
             }
-            "free" | "free_bytes" => {
+            "free" => {
                 // Evaluate every operand before releasing the allocation.
                 let p = self.eval(cfg, frame, args[0])?;
                 for a in &args[1..] {
@@ -3618,29 +3666,31 @@ impl<'a> Interp<'a> {
             }
             "realloc" => {
                 let p = self.eval(cfg, frame, args[0])?;
-                let old_count = self.eval(cfg, frame, args[1])?.as_int();
-                let new_count = self.eval(cfg, frame, args[2])?.as_int();
-                let (pointee, _) = self
-                    .pointer_pointee(result_ty)
-                    .expect("validated @realloc result is a pointer");
-                let stride = self.type_byte_size(pointee);
-                Ok(Some(self.do_realloc(
-                    p, old_count, new_count, stride, pointee, false,
-                )?))
-            }
-            "realloc_bytes" => {
-                let p = self.eval(cfg, frame, args[0])?;
                 let old_size = self.eval(cfg, frame, args[1])?.as_int();
                 let _align = self.eval(cfg, frame, args[2])?.as_int();
                 let new_size = self.eval(cfg, frame, args[3])?.as_int();
-                Ok(Some(self.do_realloc(
-                    p,
-                    old_size,
-                    new_size,
-                    1,
-                    Type::U8,
-                    true,
-                )?))
+                Ok(Some(self.do_realloc(p, old_size, new_size)?))
+            }
+            // `@resize` is in-place-only and the interpreter's allocator has no
+            // size classes to grow into, so the honest model is "never resizes
+            // in place": it changes nothing and reports `false`, which the
+            // native allocator is also always free to do. A program whose
+            // result depends on a `true` here is depending on allocator
+            // internals the language does not promise.
+            "resize" => {
+                let p = self.eval(cfg, frame, args[0])?;
+                for a in &args[1..] {
+                    self.eval(cfg, frame, *a)?;
+                }
+                if let Value::Ptr(Some(target)) = p
+                    && self
+                        .heap
+                        .get(target.alloc)
+                        .is_some_and(|allocation| allocation.freed)
+                {
+                    return Err(unsupported(gap, "resize after free"));
+                }
+                Ok(Some(Value::Bool(false)))
             }
             "ptr_read" | "ptr_read_unaligned" => {
                 let p = self.eval(cfg, frame, args[0])?;
@@ -3683,9 +3733,33 @@ impl<'a> Interp<'a> {
                 let (pointee, _) = self
                     .pointer_pointee(result_ty)
                     .expect("validated @int_to_ptr result is a pointer");
+                // A `ptr mut u8` from `@alloc` becomes a typed pointer through
+                // this round trip; reinterpret the block's cells first so the
+                // decoded index is in the pointee's units (ADR-0059 Phase 3).
+                if let Some(target) = self.address_target(addr, pointee) {
+                    self.retype_untyped_bytes(target.alloc, pointee);
+                }
                 match self.address_target(addr, pointee) {
                     // A pointer-derived integer round-trips to its allocation.
-                    Some(target) => Ok(Some(Value::Ptr(Some(target)))),
+                    Some(target) => {
+                        // If the block's cells are still a different width than
+                        // the pointee, this pointer would read and write cells
+                        // of the wrong shape. A one-byte pointee is exempt: that
+                        // is the `ptr mut u8` base view `std/rawbuf.rue` forms to
+                        // pass a typed block back to `@realloc`/`@free`, which
+                        // never dereferences it. Anything wider is a genuine
+                        // reinterpretation the cell model cannot express, so it
+                        // stays a typed gap rather than a false agreement.
+                        let stride = self.type_byte_size(pointee).max(1);
+                        let cell_stride = self
+                            .heap
+                            .get(target.alloc)
+                            .map_or(stride, |allocation| allocation.elem_stride);
+                        if stride != cell_stride && stride > 1 {
+                            return Ok(None);
+                        }
+                        Ok(Some(Value::Ptr(Some(target))))
+                    }
                     // An arbitrary integer names no allocation: unmodelable,
                     // stays the typed `IntToPointer` model gap.
                     None => Ok(None),
@@ -3710,15 +3784,16 @@ impl<'a> Interp<'a> {
                 self.ptr_cell_write(&at, Value::Int(val & 0xFF), gap)?;
                 Ok(Some(Value::Unit))
             }
-            "byte_copy" => {
+            "byte_copy" | "byte_move" => {
                 let dst = self.eval(cfg, frame, args[0])?;
                 let src = self.eval(cfg, frame, args[1])?;
                 let count = self.eval(cfg, frame, args[2])?.as_int();
                 let dst = self.expect_ptr(dst, gap)?;
                 let src = self.expect_ptr(src, gap)?;
-                // Read all source bytes first so an overlapping copy is well
-                // defined (the runtime uses copy_nonoverlapping; corpus copies
-                // never overlap, but buffering keeps a same-allocation copy sane).
+                // Read all source bytes first. That is `@byte_move`'s defining
+                // semantics (memmove: copy as if through a temporary), and for
+                // `@byte_copy` it keeps a same-allocation copy sane even though
+                // overlap there is undefined behavior a corpus program avoids.
                 let mut buf = Vec::with_capacity(count.max(0) as usize);
                 for k in 0..count {
                     buf.push(self.byte_at(&src, k, gap)?);
@@ -3762,31 +3837,17 @@ impl<'a> Interp<'a> {
         }
     }
 
-    /// `@alloc(count)`: `count` zeroed cells of the pointee type, or null on
-    /// allocator failure (zero size or a byte size beyond [`MAX_ALLOC_BYTES`]).
-    fn do_alloc(&mut self, count: i128, pointee: Type) -> Step<Value> {
-        let stride = self.type_byte_size(pointee);
-        let Some(_bytes) = self.alloc_byte_size(count, stride)? else {
-            return Ok(Value::Ptr(None));
-        };
-        self.materialize_cells_guard(count)?;
-        let cells = (0..count).map(|_| self.zeroed_value(pointee)).collect();
-        let alloc = self.heap_alloc(Value::Aggregate(cells), stride, false);
-        Ok(Value::Ptr(Some(PtrTarget {
-            alloc,
-            path: Vec::new(),
-            index: 0,
-        })))
-    }
-
-    /// `@alloc_bytes(size, align)`: `size` zeroed byte cells, or null on failure.
-    fn do_alloc_bytes(&mut self, size: i128) -> Step<Value> {
+    /// `@alloc(size, align)`: `size` zeroed byte cells, or null on allocator
+    /// failure (zero size or a size beyond [`MAX_ALLOC_BYTES`]). The block is
+    /// marked untyped so the first typed pointer over it can reinterpret its
+    /// cells (see [`Allocation::untyped_bytes`]).
+    fn do_alloc(&mut self, size: i128) -> Step<Value> {
         let Some(_bytes) = self.alloc_byte_size(size, 1)? else {
             return Ok(Value::Ptr(None));
         };
         self.materialize_cells_guard(size)?;
         let cells = (0..size).map(|_| Value::Int(0)).collect();
-        let alloc = self.heap_alloc(Value::Aggregate(cells), 1, false);
+        let alloc = self.heap_alloc_with(Value::Aggregate(cells), 1, false, true);
         Ok(Value::Ptr(Some(PtrTarget {
             alloc,
             path: Vec::new(),
@@ -3800,25 +3861,11 @@ impl<'a> Interp<'a> {
     /// identity is deliberately unspecified. Returns null on `new == 0` or allocator failure, leaving the
     /// original allocation valid (spec 8.6:3), and traps on a `new * stride`
     /// overflow like the compiled size arithmetic (spec 8.6:1).
-    fn do_realloc(
-        &mut self,
-        p: Value,
-        old_count: i128,
-        new_count: i128,
-        stride: u64,
-        pointee: Type,
-        bytes: bool,
-    ) -> Step<Value> {
+    fn do_realloc(&mut self, p: Value, old_size: i128, new_size: i128) -> Step<Value> {
         let target = match p {
             Value::Ptr(Some(t)) => t,
-            // realloc(null, .., new) behaves like a fresh allocation.
-            Value::Ptr(None) => {
-                return if bytes {
-                    self.do_alloc_bytes(new_count)
-                } else {
-                    self.do_alloc(new_count, pointee)
-                };
-            }
+            // realloc(null, .., new_size) behaves like a fresh allocation.
+            Value::Ptr(None) => return self.do_alloc(new_size),
             _ => return Ok(Value::Ptr(None)),
         };
         if self
@@ -3826,22 +3873,21 @@ impl<'a> Interp<'a> {
             .get(target.alloc)
             .is_some_and(|allocation| allocation.freed)
         {
-            let name = if bytes { "realloc_bytes" } else { "realloc" };
             return Err(unsupported(
-                unsupported_intrinsic_kind(name),
+                unsupported_intrinsic_kind("realloc"),
                 "realloc after free",
             ));
         }
-        if new_count == 0 {
+        if new_size == 0 {
             if let Some(alloc) = self.heap.get_mut(target.alloc) {
                 alloc.freed = true;
             }
             return Ok(Value::Ptr(None));
         }
-        let Some(_new_bytes) = self.alloc_byte_size(new_count, stride)? else {
+        if self.alloc_byte_size(new_size, 1)?.is_none() {
             return Ok(Value::Ptr(None));
-        };
-        if new_count <= old_count {
+        }
+        if new_size <= old_size {
             // No move needed; the original block already holds the data.
             return Ok(Value::Ptr(Some(PtrTarget {
                 alloc: target.alloc,
@@ -3849,22 +3895,42 @@ impl<'a> Interp<'a> {
                 index: 0,
             })));
         }
+        // Sizes are physical bytes but the block's cells may already have been
+        // reinterpreted as a wider element type (see
+        // [`Allocation::untyped_bytes`]), so convert through its stride. A byte
+        // size that is not a whole number of cells cannot be modeled against
+        // this cell-shaped heap and stays a typed gap rather than a guess.
+        let (stride, untyped) = match self.heap.get(target.alloc) {
+            Some(allocation) => (allocation.elem_stride.max(1), allocation.untyped_bytes),
+            None => (1, true),
+        };
+        let stride_i128 = stride as i128;
+        if new_size % stride_i128 != 0 {
+            return Err(unsupported(
+                unsupported_intrinsic_kind("realloc"),
+                "realloc to a size that is not a whole number of elements",
+            ));
+        }
+        let new_count = new_size / stride_i128;
+        let old_count = old_size / stride_i128;
         self.materialize_cells_guard(new_count)?;
         let old_cells = match self.heap.get(target.alloc).map(|a| &a.root) {
             Some(Value::Aggregate(cells)) => cells.clone(),
             _ => Vec::new(),
         };
+        // Growth is uninitialized storage; the interpreter fills it with a
+        // zeroed value shaped like the cells already there so a later typed
+        // read finds a well-formed cell rather than a shape mismatch.
+        let fill = old_cells.first().map_or(Value::Int(0), zeroed_like);
         let mut cells: Vec<Value> = Vec::with_capacity(new_count as usize);
         for i in 0..new_count {
             if (i as usize) < old_cells.len() && i < old_count {
                 cells.push(old_cells[i as usize].clone());
-            } else if bytes {
-                cells.push(Value::Int(0));
             } else {
-                cells.push(self.zeroed_value(pointee));
+                cells.push(fill.clone());
             }
         }
-        let alloc = self.heap_alloc(Value::Aggregate(cells), stride, false);
+        let alloc = self.heap_alloc_with(Value::Aggregate(cells), stride, false, untyped);
         self.heap[target.alloc].freed = true;
         Ok(Value::Ptr(Some(PtrTarget {
             alloc,
@@ -3911,6 +3977,22 @@ impl<'a> Interp<'a> {
     }
 }
 
+/// A zeroed value with the same shape as `value`.
+///
+/// Reallocation growth is uninitialized storage, but the interpreter's cells
+/// are typed values, so a grown block's new cells must at least have the shape
+/// its existing cells do. Cloning the shape avoids having to rediscover the
+/// element type the compiler no longer records at the allocation site
+/// (ADR-0059 Phase 3, RUE-961).
+fn zeroed_like(value: &Value) -> Value {
+    match value {
+        Value::Aggregate(cells) => Value::Aggregate(cells.iter().map(zeroed_like).collect()),
+        Value::Bool(_) => Value::Bool(false),
+        Value::Ptr(_) => Value::Ptr(None),
+        _ => Value::Int(0),
+    }
+}
+
 /// Whether the interpreter now executes this pointer/heap intrinsic instead of
 /// reporting it as a model gap. Excludes the still-unmodeled text parses and the
 /// empty-slice `@int_to_ptr(0)` special case (kept as its own typed gap).
@@ -3927,14 +4009,14 @@ fn modeled_pointer_intrinsic(kind: UnsupportedIntrinsicKind) -> bool {
             | I::RawMutableAddress
             | I::FieldPointer
             | I::Allocate
+            | I::AllocateZeroed
             | I::Free
             | I::Reallocate
-            | I::AllocateBytes
-            | I::FreeBytes
-            | I::ReallocateBytes
+            | I::Resize
             | I::ByteRead
             | I::ByteWrite
             | I::ByteCopy
+            | I::ByteMove
             | I::ByteSet
     )
 }

--- a/crates/rue-oracle/src/tests.rs
+++ b/crates/rue-oracle/src/tests.rs
@@ -414,9 +414,9 @@ fn every_known_unsupported_intrinsic_has_a_closed_kind() {
         ("alloc", Intrinsic::Allocate),
         ("free", Intrinsic::Free),
         ("realloc", Intrinsic::Reallocate),
-        ("alloc_bytes", Intrinsic::AllocateBytes),
-        ("free_bytes", Intrinsic::FreeBytes),
-        ("realloc_bytes", Intrinsic::ReallocateBytes),
+        ("alloc_zeroed", Intrinsic::AllocateZeroed),
+        ("resize", Intrinsic::Resize),
+        ("byte_move", Intrinsic::ByteMove),
         ("byte_read", Intrinsic::ByteRead),
         ("byte_write", Intrinsic::ByteWrite),
         ("byte_copy", Intrinsic::ByteCopy),
@@ -491,7 +491,7 @@ fn every_known_missing_runtime_call_has_a_closed_kind() {
     for kind in [
         RuntimeCallKind::StrByteAt,
         RuntimeCallKind::DebugI64,
-        RuntimeCallKind::AllocBytes,
+        RuntimeCallKind::Alloc,
     ] {
         assert_eq!(unsupported_runtime_call_kind(kind), None, "{kind:?}");
     }
@@ -1148,14 +1148,17 @@ fn ptr_offset_strides_by_element() {
 fn alloc_read_after_free_is_unsupported() {
     let src = r#"fn main() -> i32 {
         checked {
-            let p: ptr mut i32 = @alloc(3);
+            let bytes: u64 = 3 * @intCast(@size_of(i32));
+            let align: u64 = @intCast(@align_of(i32));
+            let raw: ptr mut u8 = @alloc(bytes, align);
+            let p: ptr mut i32 = @int_to_ptr(@ptr_to_int(raw));
             @ptr_write(p, 10);
             @ptr_write(@ptr_offset(p, 1), 20);
             @ptr_write(@ptr_offset(p, 2), 30);
             @dbg(@ptr_read(p));
             @dbg(@ptr_read(@ptr_offset(p, 1)));
             @dbg(@ptr_read(@ptr_offset(p, 2)));
-            @free(p, 3);
+            @free(raw, bytes, align);
             @ptr_read(p) + @ptr_read(@ptr_offset(p, 1)) + @ptr_read(@ptr_offset(p, 2))
         }
     }"#;
@@ -1176,11 +1179,14 @@ fn alloc_read_write_aggregate() {
     struct AosBox { a: [P; 2] }
     fn main() -> i32 {
         checked {
-            let wp: ptr mut AosBox = @alloc(1);
+            let bytes: u64 = @intCast(@size_of(AosBox));
+            let align: u64 = @intCast(@align_of(AosBox));
+            let raw: ptr mut u8 = @alloc(bytes, align);
+            let wp: ptr mut AosBox = @int_to_ptr(@ptr_to_int(raw));
             @ptr_write(wp, AosBox { a: [P { x: 1, y: 2 }, P { x: 3, y: 4 }] });
             let v = @ptr_read(wp);
             @dbg(v.a[0].x); @dbg(v.a[1].y);
-            @free(wp, 1);
+            @free(raw, bytes, align);
         };
         0
     }"#;
@@ -1221,27 +1227,27 @@ fn field_ptr_on_param_struct() {
     assert_eq!(run(src).stdout, "44\n");
 }
 
-/// The full byte family round-trips through `@alloc_bytes`, `@byte_*`, and
-/// `@realloc_bytes` with contents preserved across a grow.
+/// The full byte family round-trips through `@alloc`, `@byte_*`, and
+/// `@realloc` with contents preserved across a grow.
 #[test]
 fn byte_family_roundtrip() {
     let src = r#"fn main() -> i32 {
         checked {
-            let p: ptr mut u8 = @alloc_bytes(6, 1);
+            let p: ptr mut u8 = @alloc(6, 1);
             @byte_set(p, 0, 6);
             @byte_write(p, 0, 10);
             @byte_write(p, 1, 20);
             @byte_write(p, 2, 30);
-            let q: ptr mut u8 = @realloc_bytes(p, 6, 1, 8);
+            let q: ptr mut u8 = @realloc(p, 6, 1, 8);
             @byte_write(q, 3, 40);
-            let dst: ptr mut u8 = @alloc_bytes(8, 1);
+            let dst: ptr mut u8 = @alloc(8, 1);
             @byte_copy(dst, q, 8);
             let sum: i32 = @intCast(@byte_read(dst, 0)) + @intCast(@byte_read(dst, 1))
                 + @intCast(@byte_read(dst, 2)) + @intCast(@byte_read(dst, 3))
                 + @intCast(@byte_read(dst, 4));
             @dbg(sum);
-            @free_bytes(q, 8, 1);
-            @free_bytes(dst, 8, 1);
+            @free(q, 8, 1);
+            @free(dst, 8, 1);
         };
         0
     }"#;
@@ -1254,13 +1260,13 @@ fn byte_family_roundtrip() {
 fn byte_address_arithmetic_roundtrip() {
     let src = r#"fn main() -> i32 {
         checked {
-            let src: ptr mut u8 = @alloc_bytes(5, 1);
+            let src: ptr mut u8 = @alloc(5, 1);
             let mut i: u64 = 0;
             while i < 5 {
                 @byte_write(src, i, @intCast(i + 1));
                 i = i + 1;
             }
-            let dst: ptr mut u8 = @alloc_bytes(5, 1);
+            let dst: ptr mut u8 = @alloc(5, 1);
             @byte_set(dst, 0, 5);
             let sp: ptr mut u8 = @int_to_ptr(@ptr_to_int(src) + 1);
             let dp: ptr mut u8 = @int_to_ptr(@ptr_to_int(dst) + 2);
@@ -1272,8 +1278,8 @@ fn byte_address_arithmetic_roundtrip() {
                 j = j + 1;
             }
             @dbg(sum);
-            @free_bytes(src, 5, 1);
-            @free_bytes(dst, 5, 1);
+            @free(src, 5, 1);
+            @free(dst, 5, 1);
         };
         0
     }"#;
@@ -1285,13 +1291,17 @@ fn byte_address_arithmetic_roundtrip() {
 fn realloc_grows_and_preserves() {
     let src = r#"fn main() -> i32 {
         checked {
-            let mut p: ptr mut i32 = @alloc(2);
+            let unit: u64 = @intCast(@size_of(i32));
+            let align: u64 = @intCast(@align_of(i32));
+            let mut raw: ptr mut u8 = @alloc(2 * unit, align);
+            let mut p: ptr mut i32 = @int_to_ptr(@ptr_to_int(raw));
             @ptr_write(p, 5);
             @ptr_write(@ptr_offset(p, 1), 7);
-            p = @realloc(p, 2, 16);
+            raw = @realloc(raw, 2 * unit, align, 16 * unit);
+            p = @int_to_ptr(@ptr_to_int(raw));
             @ptr_write(@ptr_offset(p, 8), 100);
             let sum: i32 = @ptr_read(p) + @ptr_read(@ptr_offset(p, 1)) + @ptr_read(@ptr_offset(p, 8));
-            @free(p, 16);
+            @free(raw, 16 * unit, align);
             sum
         }
     }"#;
@@ -1304,21 +1314,21 @@ fn realloc_grows_and_preserves() {
 fn realloc_failure_returns_null_and_preserves_original() {
     let src = r#"fn main() -> i32 {
         checked {
-            let p: ptr mut u8 = @alloc(4);
+            let p: ptr mut u8 = @alloc(4, 1);
             @ptr_write(p, 10);
             @ptr_write(@ptr_offset(p, 1), 20);
             @ptr_write(@ptr_offset(p, 2), 30);
             @ptr_write(@ptr_offset(p, 3), 40);
-            let q: ptr mut u8 = @realloc(p, 4, 2305843009213693951);
+            let q: ptr mut u8 = @realloc(p, 4, 1, 2305843009213693951);
             if @ptr_to_int(q) == 0 {
                 let sum: i32 = @intCast(@ptr_read(p))
                     + @intCast(@ptr_read(@ptr_offset(p, 1)))
                     + @intCast(@ptr_read(@ptr_offset(p, 2)))
                     + @intCast(@ptr_read(@ptr_offset(p, 3)));
-                @free(p, 4);
+                @free(p, 4, 1);
                 sum
             } else {
-                @free(q, 2305843009213693951);
+                @free(q, 2305843009213693951, 1);
                 1
             }
         }

--- a/crates/rue-oracle/src/tests/call_contracts.rs
+++ b/crates/rue-oracle/src/tests/call_contracts.rs
@@ -130,7 +130,7 @@ fn stable_text_runtime_calls_require_exact_metadata() {
     for runtime in [
         RuntimeCallKind::StrByteAt,
         RuntimeCallKind::DebugI64,
-        RuntimeCallKind::AllocBytes,
+        RuntimeCallKind::Alloc,
     ] {
         assert_eq!(
             interp.classify_unsupported_runtime_call(runtime, &[], &[], &[], Type::UNIT),

--- a/crates/rue-runtime-abi/src/lib.rs
+++ b/crates/rue-runtime-abi/src/lib.rs
@@ -356,6 +356,9 @@ const VOID: AbiResult = AbiResult::Void;
 const U32_RESULT: AbiResult = AbiResult::Scalar(AbiType::U32);
 const U64_RESULT: AbiResult = AbiResult::Scalar(AbiType::U64);
 const MUT_POINTER_RESULT: AbiResult = AbiResult::Scalar(AbiType::MutBytePointer);
+/// A `bool`-valued helper result: the C-ABI word carrying 0 or 1, the same
+/// representation `AbiType::BoolWordI64` gives a `bool` argument.
+const BOOL_WORD_RESULT: AbiResult = AbiResult::Scalar(AbiType::BoolWordI64);
 const TARGET_C: CallingConvention = CallingConvention::TargetC;
 const ALL_TARGETS: TargetSet = TargetSet::ALL;
 
@@ -500,6 +503,13 @@ macro_rules! for_each_runtime_helper {
             safety: ALLOC_LAYOUT,
             returns: RETURNS
         },
+        AllocZeroed => safe __rue_alloc_zeroed(size: u64, align: u64) -> *mut u8 {
+            symbol: "__rue_alloc_zeroed",
+            parameters: params![U64_VALUE, U64_VALUE],
+            result: MUT_POINTER_RESULT,
+            safety: ALLOC_LAYOUT,
+            returns: RETURNS
+        },
         Free => unsafe __rue_free(ptr: *mut u8, size: u64, align: u64) {
             symbol: "__rue_free",
             parameters: params![MUT_BYTE_POINTER, U64_VALUE, U64_VALUE],
@@ -516,6 +526,18 @@ macro_rules! for_each_runtime_helper {
             symbol: "__rue_realloc",
             parameters: params![MUT_BYTE_POINTER, U64_VALUE, U64_VALUE, U64_VALUE],
             result: MUT_POINTER_RESULT,
+            safety: VALID_ALLOC_LAYOUT,
+            returns: RETURNS
+        },
+        Resize => unsafe __rue_resize(
+            ptr: *mut u8,
+            old_size: u64,
+            new_size: u64,
+            align: u64,
+        ) -> i64 {
+            symbol: "__rue_resize",
+            parameters: params![MUT_BYTE_POINTER, U64_VALUE, U64_VALUE, U64_VALUE],
+            result: BOOL_WORD_RESULT,
             safety: VALID_ALLOC_LAYOUT,
             returns: RETURNS
         },
@@ -841,6 +863,16 @@ macro_rules! for_each_runtime_helper {
             result: VOID,
             // Copies `size` bytes from `src` into the non-overlapping region at
             // `dst`; both pointer/length ranges must describe accessible bytes.
+            safety: READABLE.union(WRITABLE),
+            returns: RETURNS
+        },
+        ByteMove => unsafe __rue_byte_move(dst: *mut u8, src: *const u8, size: u64) {
+            symbol: "__rue_byte_move",
+            parameters: params![MUT_BYTE_POINTER, BYTE_VIEW, U64_VALUE],
+            result: VOID,
+            // Copies `size` bytes from `src` into `dst` as if through a
+            // temporary buffer, so the two ranges may overlap; both must
+            // describe accessible bytes.
             safety: READABLE.union(WRITABLE),
             returns: RETURNS
         },
@@ -1296,7 +1328,7 @@ mod tests {
     #[test]
     fn manifest_is_const_valid_and_exhaustive() {
         assert_eq!(validate_manifest(), Ok(()));
-        assert_eq!(RuntimeHelperId::ALL.len(), 43);
+        assert_eq!(RuntimeHelperId::ALL.len(), 46);
         assert_eq!(RuntimeHelperId::ALL.len(), RUNTIME_HELPERS.len());
         for (index, id) in RuntimeHelperId::ALL.iter().copied().enumerate() {
             assert_eq!(id as usize, index);
@@ -1320,8 +1352,10 @@ mod tests {
         let expected = [
             "__rue_exit",
             "__rue_alloc",
+            "__rue_alloc_zeroed",
             "__rue_free",
             "__rue_realloc",
+            "__rue_resize",
             "__rue_div_by_zero",
             "__rue_overflow",
             "__rue_intcast_overflow",
@@ -1360,6 +1394,7 @@ mod tests {
             "__rue_env_ptr",
             "__rue_env_len",
             "__rue_byte_copy",
+            "__rue_byte_move",
             "__rue_byte_set",
         ];
         assert_eq!(
@@ -1372,7 +1407,7 @@ mod tests {
     #[test]
     fn every_helper_has_the_exact_accepted_signature_and_contract() {
         fn check(
-            visited: &mut [bool; 43],
+            visited: &mut [bool; 46],
             ids: &[RuntimeHelperId],
             parameters: &[AbiParameter],
             result: AbiResult,
@@ -1393,7 +1428,7 @@ mod tests {
             }
         }
 
-        let mut visited = [false; 43];
+        let mut visited = [false; 46];
         check(
             &mut visited,
             &[RuntimeHelperId::Exit],
@@ -1404,7 +1439,7 @@ mod tests {
         );
         check(
             &mut visited,
-            &[RuntimeHelperId::Alloc],
+            &[RuntimeHelperId::Alloc, RuntimeHelperId::AllocZeroed],
             &[U64_VALUE, U64_VALUE],
             MUT_POINTER_RESULT,
             ALLOC_LAYOUT,
@@ -1423,6 +1458,14 @@ mod tests {
             &[RuntimeHelperId::Realloc],
             &[MUT_BYTE_POINTER, U64_VALUE, U64_VALUE, U64_VALUE],
             MUT_POINTER_RESULT,
+            VALID_ALLOC_LAYOUT,
+            RETURNS,
+        );
+        check(
+            &mut visited,
+            &[RuntimeHelperId::Resize],
+            &[MUT_BYTE_POINTER, U64_VALUE, U64_VALUE, U64_VALUE],
+            BOOL_WORD_RESULT,
             VALID_ALLOC_LAYOUT,
             RETURNS,
         );
@@ -1599,7 +1642,7 @@ mod tests {
         );
         check(
             &mut visited,
-            &[RuntimeHelperId::ByteCopy],
+            &[RuntimeHelperId::ByteCopy, RuntimeHelperId::ByteMove],
             &[MUT_BYTE_POINTER, BYTE_VIEW, U64_VALUE],
             VOID,
             READABLE.union(WRITABLE),

--- a/crates/rue-runtime/src/heap.rs
+++ b/crates/rue-runtime/src/heap.rs
@@ -94,6 +94,35 @@ pub unsafe fn free(pointer: *mut u8, size: u64, align: u64) {
     unsafe { ALLOCATOR.deallocate(pointer, size, align) };
 }
 
+/// Allocate storage for the supplied layout with every byte set to zero.
+///
+/// Returns null on the same failures as [`alloc`]. The allocator has no cheaper
+/// zeroing path than writing the bytes today (its arenas are recycled), so this
+/// allocates and clears; the intrinsic exists so the guarantee is expressible
+/// and so a future zero-page mapping is a runtime-local change (RUE-968).
+pub fn alloc_zeroed(size: u64, align: u64) -> *mut u8 {
+    let pointer = ALLOCATOR.allocate(size, align);
+    if !pointer.is_null() {
+        // SAFETY: a successful allocation is writable for `size` bytes.
+        unsafe { crate::memory::memset(pointer, 0, size as usize) };
+    }
+    pointer
+}
+
+/// Try to relabel an allocation as `new_size` bytes without moving it.
+///
+/// Reports whether the block now describes `new_size` bytes at the same
+/// address. A `false` result changed nothing: the caller keeps `old_size`.
+///
+/// # Safety
+///
+/// A non-null `pointer` must identify a live allocation for `old_size` and
+/// `align`.
+pub unsafe fn resize(pointer: *mut u8, old_size: u64, new_size: u64, align: u64) -> bool {
+    // SAFETY: inherited from this function's caller contract.
+    unsafe { ALLOCATOR.resize_in_place(pointer, old_size, new_size, align) }
+}
+
 /// Resize an allocation, preserving `min(old_size, new_size)` bytes.
 ///
 /// Allocation failure returns null and leaves the old allocation live and
@@ -234,6 +263,41 @@ mod tests {
         );
         // SAFETY: failed realloc left pointer live.
         unsafe { free(pointer, 32, 8) };
+    }
+
+    #[test]
+    fn zeroed_allocation_reads_as_zero_and_reports_failure_as_null() {
+        let pointer = alloc_zeroed(96, 8);
+        assert!(!pointer.is_null());
+        // SAFETY: the allocation is live and readable for 96 bytes.
+        assert!(
+            unsafe { core::slice::from_raw_parts(pointer, 96) }
+                .iter()
+                .all(|byte| *byte == 0)
+        );
+        // SAFETY: pointer is live with this layout.
+        unsafe { free(pointer, 96, 8) };
+
+        assert!(alloc_zeroed(0, 8).is_null());
+        assert!(alloc_zeroed(16, 3).is_null());
+    }
+
+    #[test]
+    fn in_place_resize_keeps_the_pointer_or_changes_nothing() {
+        let pointer = alloc(65, 8);
+        assert!(!pointer.is_null());
+        // SAFETY: the allocation is live and writable for 65 bytes.
+        unsafe { pointer.write(7) };
+
+        // SAFETY: pointer is live with layout (65, 8).
+        assert!(unsafe { resize(pointer, 65, 120, 8) });
+        // SAFETY: an accepted in-place resize never moves or clears the block.
+        assert_eq!(unsafe { pointer.read() }, 7);
+
+        // SAFETY: pointer is live with layout (120, 8).
+        assert!(!unsafe { resize(pointer, 120, 200 * 1024, 8) });
+        // SAFETY: the refusal left the (120, 8) layout in force.
+        unsafe { free(pointer, 120, 8) };
     }
 
     #[test]

--- a/crates/rue-runtime/src/lib.rs
+++ b/crates/rue-runtime/src/lib.rs
@@ -158,8 +158,10 @@ pub mod string;
 macro_rules! call_runtime_helper_implementation {
     (__rue_exit($($argument:expr),*)) => { crate::entry::__rue_exit($($argument),*) };
     (__rue_alloc($($argument:expr),*)) => { crate::string::__rue_alloc($($argument),*) };
+    (__rue_alloc_zeroed($($argument:expr),*)) => { crate::string::__rue_alloc_zeroed($($argument),*) };
     (__rue_free($($argument:expr),*)) => { crate::string::__rue_free($($argument),*) };
     (__rue_realloc($($argument:expr),*)) => { crate::string::__rue_realloc($($argument),*) };
+    (__rue_resize($($argument:expr),*)) => { crate::string::__rue_resize($($argument),*) };
     (__rue_div_by_zero($($argument:expr),*)) => { crate::error::__rue_div_by_zero($($argument),*) };
     (__rue_overflow($($argument:expr),*)) => { crate::error::__rue_overflow($($argument),*) };
     (__rue_intcast_overflow($($argument:expr),*)) => { crate::error::__rue_intcast_overflow($($argument),*) };
@@ -198,6 +200,7 @@ macro_rules! call_runtime_helper_implementation {
     (__rue_env_ptr($($argument:expr),*)) => { crate::process::__rue_env_ptr($($argument),*) };
     (__rue_env_len($($argument:expr),*)) => { crate::process::__rue_env_len($($argument),*) };
     (__rue_byte_copy($($argument:expr),*)) => { crate::memory::__rue_byte_copy($($argument),*) };
+    (__rue_byte_move($($argument:expr),*)) => { crate::memory::__rue_byte_move($($argument),*) };
     (__rue_byte_set($($argument:expr),*)) => { crate::memory::__rue_byte_set($($argument),*) };
 }
 

--- a/crates/rue-runtime/src/memory.rs
+++ b/crates/rue-runtime/src/memory.rs
@@ -110,6 +110,21 @@ pub unsafe fn __rue_byte_set(dst: *mut u8, value: u64, size: u64) {
     unsafe { memset(dst, value as i32, size as usize) };
 }
 
+/// `@byte_move(dst, src, size)` runtime helper: copy `size` bytes from `src`
+/// into `dst` as if through a temporary buffer, so the two regions may overlap
+/// (RUE-964). This is the memmove-shaped sibling of [`__rue_byte_copy`].
+///
+/// # Safety
+///
+/// - When `size > 0`, `dst` must be valid for writes of `size` bytes and `src`
+///   valid for reads of `size` bytes. The regions may overlap.
+/// - Either pointer may be null when `size == 0` (a no-op).
+pub unsafe fn __rue_byte_move(dst: *mut u8, src: *const u8, size: u64) {
+    // SAFETY: the caller upholds `memmove`'s validity contract, which is
+    // `memcpy`'s minus the non-overlap requirement.
+    unsafe { memmove(dst, src, size as usize) };
+}
+
 /// Compare `n` bytes of memory at `s1` and `s2`.
 ///
 /// Returns 0 if equal, negative if s1 < s2, positive if s1 > s2.

--- a/crates/rue-runtime/src/string.rs
+++ b/crates/rue-runtime/src/string.rs
@@ -110,6 +110,31 @@ crate::define_runtime_implementation! {
 }
 
 crate::define_runtime_implementation! {
+    /// Allocate zero-initialized memory from the heap.
+    ///
+    /// Identical to `__rue_alloc` except that every byte of the returned block
+    /// reads as zero (RUE-968).
+    ///
+    /// # Arguments
+    ///
+    /// * `size` - Number of bytes to allocate
+    /// * `align` - Required alignment (must be a power of 2)
+    ///
+    /// # Returns
+    ///
+    /// A pointer to zeroed memory, or null on failure.
+    ///
+    /// # ABI
+    ///
+    /// ```text
+    /// extern "C" fn __rue_alloc_zeroed(size: u64, align: u64) -> *mut u8
+    /// ```
+    pub extern "C" fn __rue_alloc_zeroed(size: u64, align: u64) -> *mut u8 {
+        heap::alloc_zeroed(size, align)
+    }
+}
+
+crate::define_runtime_implementation! {
     /// Free memory previously allocated by `__rue_alloc`.
     ///
     /// # Arguments
@@ -168,6 +193,41 @@ crate::define_runtime_implementation! {
     pub unsafe extern "C" fn __rue_realloc(ptr: *mut u8, old_size: u64, new_size: u64, align: u64) -> *mut u8 {
         // SAFETY: inherited from the exported helper's caller contract.
         unsafe { heap::realloc(ptr, old_size, new_size, align) }
+    }
+}
+
+crate::define_runtime_implementation! {
+    /// Resize an allocation in place, without ever moving it.
+    ///
+    /// # Arguments
+    ///
+    /// * `ptr` - Pointer to the existing allocation
+    /// * `old_size` - Size the allocation currently carries
+    /// * `new_size` - Desired new size
+    /// * `align` - Alignment the allocation was made with
+    ///
+    /// # Returns
+    ///
+    /// `1` when the block now describes `new_size` bytes at the same address —
+    /// the caller must hand `new_size` back at deallocation — and `0` when the
+    /// request was refused, in which case nothing changed and `old_size` still
+    /// describes the block.
+    ///
+    /// # ABI
+    ///
+    /// ```text
+    /// extern "C" fn __rue_resize(ptr: *mut u8, old_size: u64, new_size: u64, align: u64) -> i64
+    /// ```
+    ///
+    /// The `i64` result is the C-ABI word carrying a Rue `bool`.
+    ///
+    /// # Safety
+    ///
+    /// A non-null `ptr` must be a pointer returned by this runtime allocator
+    /// that is live with exactly the supplied `old_size` and `align`.
+    pub unsafe extern "C" fn __rue_resize(ptr: *mut u8, old_size: u64, new_size: u64, align: u64) -> i64 {
+        // SAFETY: inherited from the exported helper's caller contract.
+        i64::from(unsafe { heap::resize(ptr, old_size, new_size, align) })
     }
 }
 

--- a/crates/rue-spec/cases/appendices/implementation-limits.toml
+++ b/crates/rue-spec/cases/appendices/implementation-limits.toml
@@ -331,19 +331,19 @@ exit_code = 2
 # Exceeding an implementation limit is a diagnosable compile-time failure, not
 # a wrapped index or a crash. The two limits whose boundary is reachable
 # without an impractical fixture are the object-size ceiling (E0906, a type
-# whose layout exceeds i32::MAX bytes) and the nesting depth (E0482, below).
-# The source-length ceiling (E1401) needs a >4 GiB input, so its boundary is
-# pinned by unit tests in rue-lexer and rue-compiler instead.
+# whose layout needs more than 268,435,455 ABI slots) and the nesting depth
+# (E0482, below). The source-length ceiling (E1401) needs a >4 GiB input, so its
+# boundary is pinned by unit tests in rue-lexer and rue-compiler instead.
 
 [[case]]
 name = "oversized_object_diagnosed"
 spec = ["C.1:2", "C.4:3"]
-description = "A type whose layout exceeds the published object-size ceiling is diagnosed, not silently truncated"
+description = "A type whose layout exceeds the published object-size ceiling is diagnosed, not silently truncated, and the diagnostic names the slot ceiling it actually checks (C.1:2)"
 source = """
 fn main() -> i32 { @size_of([i32; 4294967296]) }
 """
 compile_fail = true
-error_contains = ["[E0906]", "exceeds the maximum supported object size", "2147483647"]
+error_contains = ["[E0906]", "exceeds the maximum supported object size", "268435455", "ABI slots"]
 
 [[case]]
 name = "object_within_limit_compiles"
@@ -352,6 +352,38 @@ source = """
 fn main() -> i32 { if @size_of([i32; 1000]) == 4000 { 0 } else { 1 } }
 """
 exit_code = 0
+
+# The ceiling is a slot count, so it lands at the same element count whatever
+# the element width: one element under it compiles for a one-byte element type
+# (a 256 MiB object) and for an eight-byte one (a 2 GiB object) alike, and one
+# element over it is rejected even though the object is only 256 MiB (RUE-1272).
+[[case]]
+name = "narrow_element_array_at_slot_ceiling_compiles"
+spec = ["C.4:2", "C.4:3"]
+description = "An [i8; N] at exactly the slot ceiling is accepted; its byte size is far below the disp32 frame range"
+source = """
+fn main() -> i32 { if @size_of([i8; 268435455]) == 268435455 { 0 } else { 1 } }
+"""
+exit_code = 0
+
+[[case]]
+name = "wide_element_array_at_slot_ceiling_compiles"
+spec = ["C.4:2"]
+description = "An [i64; N] at the same N is also accepted, so a narrow element type buys no extra headroom"
+source = """
+fn main() -> i32 { if @size_of([i64; 268435455]) == 2147483640 { 0 } else { 1 } }
+"""
+exit_code = 0
+
+[[case]]
+name = "narrow_element_array_past_slot_ceiling_diagnosed"
+spec = ["C.1:2", "C.4:2"]
+description = "One element past the slot ceiling is rejected even though the layout is only about 256 MiB"
+source = """
+fn main() -> i32 { @size_of([i8; 268435456]) }
+"""
+compile_fail = true
+error_contains = ["[E0906]", "268435455", "ABI slots"]
 
 # =============================================================================
 # Syntactic Nesting Depth (C.6:3) -- RUE-42

--- a/crates/rue-spec/cases/expressions/intrinsics.toml
+++ b/crates/rue-spec/cases/expressions/intrinsics.toml
@@ -618,6 +618,49 @@ fn main() -> i32 {
 """
 exit_code = 4
 
+# RUE-969: `@offset_of` folds at compile time and so composes with ordinary
+# constant arithmetic and constant-folded control flow inside a function body,
+# not just as a bare initializer.
+[[case]]
+name = "offset_of_folds_inside_a_larger_constant_expression"
+spec = ["4.13:94"]
+source = """
+struct Point { x: i32, y: i32 }
+struct Pair { head: Point, tail: Point }
+fn main() -> i32 {
+    // A nested field's byte displacement is the sum of the two hops, computed
+    // entirely from folded @offset_of values.
+    let nested: u64 = @offset_of(Pair, tail) + @offset_of(Point, y);
+    if nested == 12 { @intCast(nested) } else { 0 }
+}
+"""
+exit_code = 12
+
+# RUE-969: `@offset_of` reports a field's displacement in the type's compact
+# memory image, and `@field_ptr` addresses that field's storage. For a
+# slot-identical struct — every field exactly one eight-byte slot — the frame's
+# slot-shaped storage and the compact image coincide, so the two agree exactly.
+# (They deliberately do not agree for a non-slot-identical struct held in a
+# frame: §3.6 stores such a value slot-shaped while @offset_of describes the
+# compact image.)
+[[case]]
+name = "offset_of_agrees_with_field_ptr_when_storage_is_slot_identical"
+spec = ["4.13:94", "9.2:18"]
+source = """
+struct Cell { first: i64, second: i64, third: i64 }
+fn main() -> i32 {
+    let mut c = Cell { first: 1, second: 2, third: 3 };
+    let agree: bool = checked {
+        let p0: u64 = @ptr_to_int(@field_ptr(c.first));
+        let p1: u64 = @ptr_to_int(@field_ptr(c.second));
+        let p2: u64 = @ptr_to_int(@field_ptr(c.third));
+        p1 - p0 == @offset_of(Cell, second) && p2 - p0 == @offset_of(Cell, third)
+    };
+    if agree { 0 } else { 1 }
+}
+"""
+exit_code = 0
+
 [[case]]
 name = "offset_of_non_struct_type_errors"
 spec = ["4.13:95"]

--- a/crates/rue-spec/cases/runtime/heap.toml
+++ b/crates/rue-spec/cases/runtime/heap.toml
@@ -1,17 +1,22 @@
 # Heap Allocation Intrinsic Tests
 #
-# Tests for @alloc / @free / @realloc — the raw, unchecked heap primitives
-# (RUE-1). Like the raw-pointer intrinsics they must appear inside a `checked`
-# block. These are the primitives a source-level `Vec` is built on.
+# Tests for the unified byte-and-alignment allocation family
+# @alloc / @alloc_zeroed / @free / @realloc / @resize (ADR-0059 Phase 3,
+# RUE-961, RUE-968). Every size is a physical byte count, every allocation
+# states its alignment, and every pointer is `ptr mut u8`. Like the raw-pointer
+# intrinsics they must appear inside a `checked` block. These are the primitives
+# a source-level `ArrayBuf` is built on, which is why several cases exercise the
+# typed-allocation idiom `@alloc(count * @size_of(T), @align_of(T))` followed by
+# a `@int_to_ptr(@ptr_to_int(..))` cast to `ptr mut T`.
 
 [section]
 id = "runtime.heap"
 spec_chapter = "9.2"
 name = "Heap Allocation Intrinsics"
-description = "Tests for @alloc, @free, and @realloc heap intrinsics"
+description = "Tests for the byte-oriented @alloc, @alloc_zeroed, @free, @realloc, and @resize intrinsics"
 
 # =============================================================================
-# @alloc allocates a typed block; write/read through the returned pointer.
+# @alloc reserves physical bytes; write/read through the returned pointer.
 # =============================================================================
 
 [[case]]
@@ -20,33 +25,73 @@ spec = ["9.2:9", "9.2:10"]
 source = """
 fn main() -> i32 {
     checked {
-        let p: ptr mut i32 = @alloc(4);
-        @ptr_write(p, 42);
-        @ptr_read(p)
+        let p: ptr mut u8 = @alloc(4, 1);
+        @byte_write(p, 0, 42);
+        @intCast(@byte_read(p, 0))
     }
 }
 """
 exit_code = 42
 
-# @alloc + @ptr_offset addresses successive elements (element i at offset i).
+# Typed allocation is source-computed sugar: the byte size and alignment come
+# from the element type's own layout, and the block is then viewed as `ptr mut T`.
 [[case]]
-name = "alloc_multiple_elements"
-spec = ["9.2:10"]
+name = "alloc_typed_block_is_source_computed"
+spec = ["9.2:9", "9.2:10", "9.2:14"]
 source = """
 fn main() -> i32 {
     checked {
-        let p: ptr mut i32 = @alloc(3);
+        let align: u64 = @intCast(@align_of(i32));
+        let bytes: u64 = 3 * @intCast(@size_of(i32));
+        let raw: ptr mut u8 = @alloc(bytes, align);
+        let p: ptr mut i32 = @int_to_ptr(@ptr_to_int(raw));
         @ptr_write(p, 10);
         @ptr_write(@ptr_offset(p, 1), 20);
         @ptr_write(@ptr_offset(p, 2), 30);
-        @ptr_read(p) + @ptr_read(@ptr_offset(p, 1)) + @ptr_read(@ptr_offset(p, 2))
+        let sum: i32 = @ptr_read(p) + @ptr_read(@ptr_offset(p, 1)) + @ptr_read(@ptr_offset(p, 2));
+        @free(raw, bytes, align);
+        sum
     }
 }
 """
 exit_code = 60
 
+# A zero-byte request names no storage and yields null.
+[[case]]
+name = "alloc_of_zero_bytes_is_null"
+spec = ["9.2:10"]
+source = """
+fn main() -> i32 {
+    checked {
+        let p: ptr mut u8 = @alloc(0, 8);
+        if @ptr_to_int(p) == 0 { 0 } else { 1 }
+    }
+}
+"""
+exit_code = 0
+
+# @alloc_zeroed guarantees every byte of the block reads as zero.
+[[case]]
+name = "alloc_zeroed_block_reads_as_zero"
+spec = ["9.2:10"]
+source = """
+fn main() -> i32 {
+    checked {
+        let p: ptr mut u8 = @alloc_zeroed(5, 1);
+        let sum: i32 = @intCast(@byte_read(p, 0))
+            + @intCast(@byte_read(p, 1))
+            + @intCast(@byte_read(p, 2))
+            + @intCast(@byte_read(p, 3))
+            + @intCast(@byte_read(p, 4));
+        @free(p, 5, 1);
+        sum
+    }
+}
+"""
+exit_code = 0
+
 # =============================================================================
-# @free releases an allocated block (value read out before freeing).
+# @free releases a block, returning the layout it was allocated with.
 # =============================================================================
 
 [[case]]
@@ -55,18 +100,34 @@ spec = ["9.2:11"]
 source = """
 fn main() -> i32 {
     checked {
-        let p: ptr mut i32 = @alloc(2);
-        @ptr_write(p, 7);
-        let v: i32 = @ptr_read(p);
-        @free(p, 2);
+        let p: ptr mut u8 = @alloc(2, 1);
+        @byte_write(p, 0, 7);
+        let v: i32 = @intCast(@byte_read(p, 0));
+        @free(p, 2, 1);
         v
     }
 }
 """
 exit_code = 7
 
+# Freeing a null pointer is permitted and has no effect.
+[[case]]
+name = "free_of_null_is_a_noop"
+spec = ["9.2:11"]
+source = """
+fn main() -> i32 {
+    checked {
+        let zero: u64 = 0;
+        let p: ptr mut u8 = @int_to_ptr(zero);
+        @free(p, 0, 1);
+        0
+    }
+}
+"""
+exit_code = 0
+
 # =============================================================================
-# @realloc grows a block and preserves the existing contents.
+# @realloc grows a block and preserves the existing bytes.
 # =============================================================================
 
 [[case]]
@@ -75,12 +136,12 @@ spec = ["9.2:12"]
 source = """
 fn main() -> i32 {
     checked {
-        let mut p: ptr mut i32 = @alloc(2);
-        @ptr_write(p, 5);
-        @ptr_write(@ptr_offset(p, 1), 7);
-        p = @realloc(p, 2, 8);
-        let sum: i32 = @ptr_read(p) + @ptr_read(@ptr_offset(p, 1));
-        @free(p, 8);
+        let mut p: ptr mut u8 = @alloc(2, 1);
+        @byte_write(p, 0, 5);
+        @byte_write(p, 1, 7);
+        p = @realloc(p, 2, 1, 8);
+        let sum: i32 = @intCast(@byte_read(p, 0)) + @intCast(@byte_read(p, 1));
+        @free(p, 8, 1);
         sum
     }
 }
@@ -95,21 +156,21 @@ spec = ["9.2:12", "8.6:3", "8.6:4"]
 source = """
 fn main() -> i32 {
     checked {
-        let p: ptr mut u8 = @alloc(4);
-        @ptr_write(p, 10);
-        @ptr_write(@ptr_offset(p, 1), 20);
-        @ptr_write(@ptr_offset(p, 2), 30);
-        @ptr_write(@ptr_offset(p, 3), 40);
-        let q: ptr mut u8 = @realloc(p, 4, 2305843009213693951);
+        let p: ptr mut u8 = @alloc(4, 1);
+        @byte_write(p, 0, 10);
+        @byte_write(p, 1, 20);
+        @byte_write(p, 2, 30);
+        @byte_write(p, 3, 40);
+        let q: ptr mut u8 = @realloc(p, 4, 1, 18446744073709551615);
         if @ptr_to_int(q) == 0 {
-            let sum: i32 = @intCast(@ptr_read(p))
-                + @intCast(@ptr_read(@ptr_offset(p, 1)))
-                + @intCast(@ptr_read(@ptr_offset(p, 2)))
-                + @intCast(@ptr_read(@ptr_offset(p, 3)));
-            @free(p, 4);
+            let sum: i32 = @intCast(@byte_read(p, 0))
+                + @intCast(@byte_read(p, 1))
+                + @intCast(@byte_read(p, 2))
+                + @intCast(@byte_read(p, 3));
+            @free(p, 4, 1);
             sum
         } else {
-            @free(q, 2305843009213693951);
+            @free(q, 18446744073709551615, 1);
             1
         }
     }
@@ -125,16 +186,75 @@ source = """
 fn main() -> i32 {
     checked {
         let zero: u64 = 0;
-        let start: ptr mut i32 = @int_to_ptr(zero);
-        let p: ptr mut i32 = @realloc(start, 0, 4);
-        @ptr_write(p, 99);
-        let v: i32 = @ptr_read(p);
-        @free(p, 4);
+        let start: ptr mut u8 = @int_to_ptr(zero);
+        let p: ptr mut u8 = @realloc(start, 0, 1, 4);
+        @byte_write(p, 0, 99);
+        let v: i32 = @intCast(@byte_read(p, 0));
+        @free(p, 4, 1);
         v
     }
 }
 """
 exit_code = 99
+
+# @realloc to zero bytes frees a non-null block and returns null.
+[[case]]
+name = "realloc_to_zero_frees_and_returns_null"
+spec = ["9.2:12"]
+source = """
+fn main() -> i32 {
+    checked {
+        let p: ptr mut u8 = @alloc(4, 1);
+        let q: ptr mut u8 = @realloc(p, 4, 1, 0);
+        if @ptr_to_int(q) == 0 { 0 } else { 1 }
+    }
+}
+"""
+exit_code = 0
+
+# =============================================================================
+# @resize is in-place only: the pointer never moves, and a refusal changes
+# nothing. The result is unspecified, so a case may only observe that the
+# block is intact and still described by whichever size the answer selects.
+# =============================================================================
+
+[[case]]
+name = "resize_never_moves_or_disturbs_the_block"
+spec = ["9.2:12a"]
+source = """
+fn main() -> i32 {
+    checked {
+        let p: ptr mut u8 = @alloc(65, 8);
+        @byte_write(p, 0, 21);
+        let size: u64 = if @resize(p, 65, 8, 120) { 120 } else { 65 };
+        let v: i32 = @intCast(@byte_read(p, 0));
+        @free(p, size, 8);
+        v
+    }
+}
+"""
+exit_code = 21
+
+# An in-place request the allocator cannot satisfy answers false and leaves the
+# old layout in force. Growing by many orders of magnitude cannot be satisfied
+# in place by any implementation that does not already own the address space
+# beyond the block.
+[[case]]
+name = "resize_refusal_leaves_the_old_layout_in_force"
+spec = ["9.2:12a"]
+source = """
+fn main() -> i32 {
+    checked {
+        let p: ptr mut u8 = @alloc(8, 8);
+        @byte_write(p, 0, 33);
+        let refused: bool = !@resize(p, 8, 8, 18446744073709551615);
+        let v: i32 = @intCast(@byte_read(p, 0));
+        @free(p, 8, 8);
+        if refused { v } else { 0 }
+    }
+}
+"""
+exit_code = 33
 
 # =============================================================================
 # Legality: heap intrinsics require a `checked` block.
@@ -146,7 +266,7 @@ error_contains = "[E1300]"
 spec = ["9.2:13"]
 source = """
 fn main() -> i32 {
-    let p: ptr mut i32 = @alloc(4);
+    let p: ptr mut u8 = @alloc(4, 1);
     0
 }
 """
@@ -159,9 +279,56 @@ spec = ["9.2:13"]
 source = """
 fn main() -> i32 {
     let zero: u64 = 0;
-    let p: ptr mut i32 = checked { @int_to_ptr(zero) };
-    @free(p, 4);
+    let p: ptr mut u8 = checked { @int_to_ptr(zero) };
+    @free(p, 4, 1);
     0
+}
+"""
+compile_fail = true
+
+[[case]]
+name = "resize_requires_checked"
+error_contains = "[E1300]"
+spec = ["9.2:13"]
+source = """
+fn main() -> i32 {
+    let zero: u64 = 0;
+    let p: ptr mut u8 = checked { @int_to_ptr(zero) };
+    let ok: bool = @resize(p, 4, 1, 8);
+    0
+}
+"""
+compile_fail = true
+
+# @resize evaluates to bool, not to a pointer.
+[[case]]
+name = "resize_result_is_bool"
+spec = ["9.2:13"]
+source = """
+fn main() -> i32 {
+    checked {
+        let p: ptr mut u8 = @alloc(16, 8);
+        let answered: bool = @resize(p, 16, 8, 16);
+        let size: u64 = if answered { 16 } else { 16 };
+        @free(p, size, 8);
+        if answered { 1 } else { 1 }
+    }
+}
+"""
+exit_code = 1
+
+# The allocation family takes u64 sizes; a mistyped operand is rejected.
+[[case]]
+name = "alloc_size_must_be_u64"
+error_contains = "expected u64, found i32"
+spec = ["9.2:13"]
+source = """
+fn main() -> i32 {
+    checked {
+        let n: i32 = 4;
+        let p: ptr mut u8 = @alloc(n, 1);
+        0
+    }
 }
 """
 compile_fail = true

--- a/crates/rue-spec/cases/runtime/raw-bytes.toml
+++ b/crates/rue-spec/cases/runtime/raw-bytes.toml
@@ -1,5 +1,9 @@
-# Raw physical-byte allocation and access intrinsics (RUE-879; the raw_bytes
-# preview gate was removed at stabilization, ADR-0059 Phase 6, RUE-937).
+# Raw physical-byte access and bulk-memory intrinsics (RUE-879; the raw_bytes
+# preview gate was removed at stabilization, ADR-0059 Phase 6, RUE-937). The
+# `_bytes` allocators folded into the unified `@alloc`/`@realloc`/`@free` family
+# in ADR-0059 Phase 3 (RUE-961), so allocation behavior is specified in §9.2's
+# heap section and covered by `runtime/heap.toml`; these cases allocate only to
+# get a byte block to access.
 
 [section]
 id = "runtime.raw_bytes"
@@ -9,18 +13,18 @@ description = "Packed physical-byte allocation and access"
 
 [[case]]
 name = "packed_offsets_read_write_exactly_one_byte"
-spec = ["9.2:14a", "9.2:14b", "9.2:14d"]
+spec = ["9.2:14a", "9.2:14d"]
 source = """
 fn main() -> i32 {
     checked {
-        let p: ptr mut u8 = @alloc_bytes(3, 1);
+        let p: ptr mut u8 = @alloc(3, 1);
         @byte_write(p, 0, 11);
         @byte_write(p, 1, 22);
         @byte_write(p, 2, 33);
         let result: i32 = @intCast(@byte_read(p, 0))
             + @intCast(@byte_read(p, 1))
             + @intCast(@byte_read(p, 2));
-        @free_bytes(p, 3, 1);
+        @free(p, 3, 1);
         result
     }
 }
@@ -33,7 +37,7 @@ spec = ["9.2:14d"]
 source = """
 fn main() -> i32 {
     checked {
-        let p = @alloc_bytes(3, 1);
+        let p = @alloc(3, 1);
         @byte_write(p, 0, 17);
         @byte_write(p, 1, 34);
         @byte_write(p, 2, 51);
@@ -41,7 +45,7 @@ fn main() -> i32 {
         let result: i32 = @intCast(@byte_read(p, 0))
             + @intCast(@byte_read(p, 1))
             + @intCast(@byte_read(p, 2));
-        @free_bytes(p, 3, 1);
+        @free(p, 3, 1);
         result
     }
 }
@@ -63,15 +67,15 @@ fn main() -> i32 {
 exit_code = 79
 
 [[case]]
-name = "alloc_bytes_result_type_is_inferred"
-spec = ["9.2:14b", "9.2:14f"]
+name = "alloc_result_type_is_inferred"
+spec = ["9.2:10", "9.2:14f"]
 source = """
 fn main() -> i32 {
     checked {
-        let p = @alloc_bytes(1, 1);
+        let p = @alloc(1, 1);
         @byte_write(p, 0, 71);
         let result: i32 = @intCast(@byte_read(p, 0));
-        @free_bytes(p, 1, 1);
+        @free(p, 1, 1);
         result
     }
 }
@@ -79,20 +83,20 @@ fn main() -> i32 {
 exit_code = 71
 
 [[case]]
-name = "realloc_bytes_preserves_packed_prefix"
-spec = ["9.2:14b", "9.2:14c", "9.2:14f"]
+name = "realloc_preserves_packed_prefix"
+spec = ["9.2:12", "9.2:14f"]
 source = """
 fn main() -> i32 {
     checked {
-        let p: ptr mut u8 = @alloc_bytes(2, 1);
+        let p: ptr mut u8 = @alloc(2, 1);
         @byte_write(p, 0, 40);
         @byte_write(p, 1, 2);
-        let q = @realloc_bytes(p, 2, 1, 4);
+        let q = @realloc(p, 2, 1, 4);
         @byte_write(q, 2, 3);
         let result: i32 = @intCast(@byte_read(q, 0))
             + @intCast(@byte_read(q, 1))
             + @intCast(@byte_read(q, 2));
-        @free_bytes(q, 4, 1);
+        @free(q, 4, 1);
         result
     }
 }
@@ -101,36 +105,36 @@ exit_code = 45
 
 [[case]]
 name = "raw_byte_allocation_failure_returns_null"
-spec = ["9.2:14b", "8.6:4"]
+spec = ["9.2:10", "8.6:4"]
 source = """
 fn main() -> i32 {
     checked {
-        let p: ptr mut u8 = @alloc_bytes(18446744073709551615, 1);
-        if @ptr_to_int(p) == 0 { 0 } else { @free_bytes(p, 18446744073709551615, 1); 1 }
+        let p: ptr mut u8 = @alloc(18446744073709551615, 1);
+        if @ptr_to_int(p) == 0 { 0 } else { @free(p, 18446744073709551615, 1); 1 }
     }
 }
 """
 exit_code = 0
 
 [[case]]
-name = "failed_realloc_bytes_preserves_original"
-spec = ["9.2:14c", "8.6:4"]
+name = "failed_realloc_preserves_original"
+spec = ["9.2:12", "8.6:4"]
 source = """
 fn main() -> i32 {
     checked {
-        let p = @alloc_bytes(3, 1);
+        let p = @alloc(3, 1);
         @byte_write(p, 0, 11);
         @byte_write(p, 1, 22);
         @byte_write(p, 2, 33);
-        let q = @realloc_bytes(p, 3, 1, 18446744073709551615);
+        let q = @realloc(p, 3, 1, 18446744073709551615);
         if @ptr_to_int(q) == 0 {
             let result: i32 = @intCast(@byte_read(p, 0))
                 + @intCast(@byte_read(p, 1))
                 + @intCast(@byte_read(p, 2));
-            @free_bytes(p, 3, 1);
+            @free(p, 3, 1);
             result
         } else {
-            @free_bytes(q, 18446744073709551615, 1);
+            @free(q, 18446744073709551615, 1);
             1
         }
     }
@@ -139,12 +143,12 @@ fn main() -> i32 {
 exit_code = 66
 
 [[case]]
-name = "alloc_bytes_zero_returns_null"
-spec = ["9.2:14b"]
+name = "alloc_zero_returns_null"
+spec = ["9.2:10"]
 source = """
 fn main() -> i32 {
     checked {
-        let p = @alloc_bytes(0, 1);
+        let p = @alloc(0, 1);
         if @ptr_to_int(p) == 0 { 0 } else { 1 }
     }
 }
@@ -152,13 +156,13 @@ fn main() -> i32 {
 exit_code = 0
 
 [[case]]
-name = "free_bytes_null_zero_is_permitted"
-spec = ["9.2:14b"]
+name = "free_null_zero_is_permitted"
+spec = ["9.2:10"]
 source = """
 fn main() -> i32 {
     checked {
-        let p = @alloc_bytes(0, 1);
-        @free_bytes(p, 0, 1);
+        let p = @alloc(0, 1);
+        @free(p, 0, 1);
         0
     }
 }
@@ -166,14 +170,14 @@ fn main() -> i32 {
 exit_code = 0
 
 [[case]]
-name = "realloc_bytes_zero_frees_and_returns_null"
-spec = ["9.2:14c"]
+name = "realloc_zero_frees_and_returns_null"
+spec = ["9.2:12"]
 source = """
 fn main() -> i32 {
     checked {
-        let p = @alloc_bytes(1, 1);
+        let p = @alloc(1, 1);
         @byte_write(p, 0, 42);
-        let q = @realloc_bytes(p, 1, 1, 0);
+        let q = @realloc(p, 1, 1, 0);
         if @ptr_to_int(q) == 0 { 0 } else { 1 }
     }
 }
@@ -185,7 +189,7 @@ name = "raw_bytes_require_checked"
 spec = ["9.2:14a", "9.2:14e"]
 source = """
 fn main() -> i32 {
-    let p: ptr mut u8 = @alloc_bytes(1, 1);
+    let p: ptr mut u8 = @alloc(1, 1);
     0
 }
 """
@@ -198,7 +202,7 @@ spec = ["9.2:14e"]
 source = """
 fn main() -> i32 {
     checked {
-        let p: ptr mut u8 = @alloc_bytes(1, 1);
+        let p: ptr mut u8 = @alloc(1, 1);
         let value: u64 = 1;
         @byte_write(p, 0, value);
     };
@@ -214,17 +218,17 @@ spec = ["9.2:14g", "9.2:14h"]
 source = """
 fn main() -> i32 {
     checked {
-        let src: ptr mut u8 = @alloc_bytes(3, 1);
+        let src: ptr mut u8 = @alloc(3, 1);
         @byte_write(src, 0, 10);
         @byte_write(src, 1, 20);
         @byte_write(src, 2, 30);
-        let dst: ptr mut u8 = @alloc_bytes(3, 1);
+        let dst: ptr mut u8 = @alloc(3, 1);
         @byte_copy(dst, src, 3);
         let result: i32 = @intCast(@byte_read(dst, 0))
             + @intCast(@byte_read(dst, 1))
             + @intCast(@byte_read(dst, 2));
-        @free_bytes(src, 3, 1);
-        @free_bytes(dst, 3, 1);
+        @free(src, 3, 1);
+        @free(dst, 3, 1);
         result
     }
 }
@@ -237,13 +241,13 @@ spec = ["9.2:14g", "9.2:14h"]
 source = """
 fn main() -> i32 {
     checked {
-        let p: ptr mut u8 = @alloc_bytes(4, 1);
+        let p: ptr mut u8 = @alloc(4, 1);
         @byte_set(p, 9, 4);
         let result: i32 = @intCast(@byte_read(p, 0))
             + @intCast(@byte_read(p, 1))
             + @intCast(@byte_read(p, 2))
             + @intCast(@byte_read(p, 3));
-        @free_bytes(p, 4, 1);
+        @free(p, 4, 1);
         result
     }
 }
@@ -256,15 +260,15 @@ spec = ["9.2:14g"]
 source = """
 fn main() -> i32 {
     checked {
-        let dst: ptr mut u8 = @alloc_bytes(2, 1);
+        let dst: ptr mut u8 = @alloc(2, 1);
         @byte_write(dst, 0, 55);
         @byte_write(dst, 1, 11);
-        let src: ptr mut u8 = @alloc_bytes(2, 1);
+        let src: ptr mut u8 = @alloc(2, 1);
         @byte_set(src, 99, 2);
         @byte_copy(dst, src, 0);
         let result: i32 = @intCast(@byte_read(dst, 0)) + @intCast(@byte_read(dst, 1));
-        @free_bytes(src, 2, 1);
-        @free_bytes(dst, 2, 1);
+        @free(src, 2, 1);
+        @free(dst, 2, 1);
         result
     }
 }
@@ -277,18 +281,18 @@ spec = ["9.2:14g"]
 source = """
 fn main() -> i32 {
     checked {
-        let src: ptr mut u8 = @alloc_bytes(4, 1);
+        let src: ptr mut u8 = @alloc(4, 1);
         @byte_write(src, 0, 1);
         @byte_write(src, 1, 2);
         @byte_write(src, 2, 3);
         @byte_write(src, 3, 4);
-        let dst: ptr mut u8 = @alloc_bytes(2, 1);
+        let dst: ptr mut u8 = @alloc(2, 1);
         @byte_set(dst, 0, 2);
         let src_mid: ptr mut u8 = @int_to_ptr(@ptr_to_int(src) + 1);
         @byte_copy(dst, src_mid, 2);
         let result: i32 = @intCast(@byte_read(dst, 0)) + @intCast(@byte_read(dst, 1));
-        @free_bytes(src, 4, 1);
-        @free_bytes(dst, 2, 1);
+        @free(src, 4, 1);
+        @free(dst, 2, 1);
         result
     }
 }
@@ -304,9 +308,9 @@ fn use_it(p: ptr mut u8) -> i32 {
     0
 }
 fn main() -> i32 {
-    let p: ptr mut u8 = checked { @alloc_bytes(1, 1) };
+    let p: ptr mut u8 = checked { @alloc(1, 1) };
     let r = use_it(p);
-    checked { @free_bytes(p, 1, 1); };
+    checked { @free(p, 1, 1); };
     r
 }
 """
@@ -319,7 +323,7 @@ spec = ["9.2:14h"]
 source = """
 fn main() -> i32 {
     checked {
-        let p: ptr mut u8 = @alloc_bytes(1, 1);
+        let p: ptr mut u8 = @alloc(1, 1);
         let value: u64 = 1;
         @byte_set(p, value, 1);
     };
@@ -346,13 +350,13 @@ compile_fail = true
 error_contains = "ptr mut u8"
 
 [[case]]
-name = "alloc_bytes_result_is_ptr_mut_u8"
-spec = ["9.2:14b", "9.2:14e"]
+name = "alloc_result_is_ptr_mut_u8"
+spec = ["9.2:10", "9.2:13"]
 source = """
 fn main() -> i32 {
     checked {
-        let p: ptr mut i32 = @alloc_bytes(1, 1);
-        @free_bytes(p, 1, 1);
+        let p: ptr mut i32 = @alloc(1, 1);
+        @free(p, 1, 1);
     };
     0
 }
@@ -361,20 +365,20 @@ compile_fail = true
 error_contains = "ptr mut u8"
 
 [[case]]
-name = "alloc_bytes_align_one_round_trip"
-spec = ["9.2:14b", "9.2:14c", "9.2:14j"]
+name = "alloc_align_one_round_trip"
+spec = ["9.2:10", "9.2:12", "9.2:13a"]
 source = """
 fn main() -> i32 {
     checked {
-        let p: ptr mut u8 = @alloc_bytes(4, 1);
+        let p: ptr mut u8 = @alloc(4, 1);
         @byte_write(p, 0, 20);
         @byte_write(p, 1, 22);
-        let q = @realloc_bytes(p, 4, 1, 8);
+        let q = @realloc(p, 4, 1, 8);
         @byte_write(q, 2, 3);
         let result: i32 = @intCast(@byte_read(q, 0))
             + @intCast(@byte_read(q, 1))
             + @intCast(@byte_read(q, 2));
-        @free_bytes(q, 8, 1);
+        @free(q, 8, 1);
         result
     }
 }
@@ -382,20 +386,20 @@ fn main() -> i32 {
 exit_code = 45
 
 [[case]]
-name = "alloc_bytes_align_eight_round_trip"
-spec = ["9.2:14b", "9.2:14c", "9.2:14j"]
+name = "alloc_align_eight_round_trip"
+spec = ["9.2:10", "9.2:12", "9.2:13a"]
 source = """
 fn main() -> i32 {
     checked {
-        let p: ptr mut u8 = @alloc_bytes(16, 8);
+        let p: ptr mut u8 = @alloc(16, 8);
         @byte_write(p, 0, 30);
         @byte_write(p, 7, 12);
-        let q = @realloc_bytes(p, 16, 8, 32);
+        let q = @realloc(p, 16, 8, 32);
         @byte_write(q, 8, 6);
         let result: i32 = @intCast(@byte_read(q, 0))
             + @intCast(@byte_read(q, 7))
             + @intCast(@byte_read(q, 8));
-        @free_bytes(q, 32, 8);
+        @free(q, 32, 8);
         result
     }
 }
@@ -403,13 +407,13 @@ fn main() -> i32 {
 exit_code = 48
 
 [[case]]
-name = "alloc_bytes_align_zero_rejected"
-spec = ["9.2:14j"]
+name = "alloc_align_zero_rejected"
+spec = ["9.2:13a"]
 source = """
 fn main() -> i32 {
     checked {
-        let p: ptr mut u8 = @alloc_bytes(1, 0);
-        @free_bytes(p, 1, 1);
+        let p: ptr mut u8 = @alloc(1, 0);
+        @free(p, 1, 1);
     };
     0
 }
@@ -418,14 +422,14 @@ compile_fail = true
 error_contains = "[E0712]"
 
 [[case]]
-name = "realloc_bytes_align_not_power_of_two_rejected"
-spec = ["9.2:14j"]
+name = "realloc_align_not_power_of_two_rejected"
+spec = ["9.2:13a"]
 source = """
 fn main() -> i32 {
     checked {
-        let p: ptr mut u8 = @alloc_bytes(2, 1);
-        let q = @realloc_bytes(p, 2, 3, 4);
-        @free_bytes(q, 4, 1);
+        let p: ptr mut u8 = @alloc(2, 1);
+        let q = @realloc(p, 2, 3, 4);
+        @free(q, 4, 1);
     };
     0
 }
@@ -434,13 +438,13 @@ compile_fail = true
 error_contains = "power of two"
 
 [[case]]
-name = "free_bytes_requires_align_argument"
+name = "free_requires_align_argument"
 spec = ["9.2:14e"]
 source = """
 fn main() -> i32 {
     checked {
-        let p: ptr mut u8 = @alloc_bytes(1, 1);
-        @free_bytes(p, 1);
+        let p: ptr mut u8 = @alloc(1, 1);
+        @free(p, 1);
     };
     0
 }
@@ -456,10 +460,13 @@ spec = ["9.2:14k", "9.2:14m"]
 source = """
 fn main() -> i32 {
     checked {
-        let p: ptr mut i32 = @alloc(1);
+        let bytes: u64 = @intCast(@size_of(i32));
+        let align: u64 = @intCast(@align_of(i32));
+        let raw: ptr mut u8 = @alloc(bytes, align);
+        let p: ptr mut i32 = @int_to_ptr(@ptr_to_int(raw));
         @ptr_write_unaligned(p, 1234);
         let v: i32 = @ptr_read_unaligned(p);
-        @free(p, 1);
+        @free(raw, bytes, align);
         @intCast(v % 200)
     }
 }
@@ -475,13 +482,188 @@ fn read(p: ptr mut i32) -> i32 {
 }
 fn main() -> i32 {
     checked {
-        let p: ptr mut i32 = @alloc(1);
+        let bytes: u64 = @intCast(@size_of(i32));
+        let align: u64 = @intCast(@align_of(i32));
+        let raw: ptr mut u8 = @alloc(bytes, align);
+        let p: ptr mut i32 = @int_to_ptr(@ptr_to_int(raw));
         @ptr_write(p, 0);
         let v: i32 = read(p);
-        @free(p, 1);
+        @free(raw, bytes, align);
     };
     0
 }
 """
 compile_fail = true
 error_contains = "[E1300]"
+
+# =============================================================================
+# @byte_move — the overlapping sibling of @byte_copy (RUE-964). memmove
+# semantics: the copy behaves as if every source byte were read into a
+# temporary region before any destination byte is written, so both overlap
+# directions are well defined. A naive forward byte loop gets the dst > src
+# case wrong and a naive backward loop gets the dst < src case wrong, so both
+# directions are pinned here with results that distinguish them.
+# =============================================================================
+
+[[case]]
+name = "byte_move_non_overlapping_matches_byte_copy"
+spec = ["9.2:14g", "9.2:14h"]
+source = """
+fn main() -> i32 {
+    checked {
+        let src: ptr mut u8 = @alloc(3, 1);
+        @byte_write(src, 0, 10);
+        @byte_write(src, 1, 20);
+        @byte_write(src, 2, 30);
+        let dst: ptr mut u8 = @alloc(3, 1);
+        @byte_move(dst, src, 3);
+        let result: i32 = @intCast(@byte_read(dst, 0))
+            + @intCast(@byte_read(dst, 1))
+            + @intCast(@byte_read(dst, 2));
+        @free(src, 3, 1);
+        @free(dst, 3, 1);
+        result
+    }
+}
+"""
+exit_code = 60
+
+# Forward overlap (dst > src): [1,2,3,0] shifted up one byte must yield
+# [1,1,2,3]. The four bytes are packed base-4 into one exit code (weights
+# 64/16/4/1) so the whole result fits the process exit status. Correct memmove
+# gives 64+16+8+3 = 91; a naive forward byte loop would smear the first byte to
+# [1,1,1,1] = 85.
+[[case]]
+name = "byte_move_forward_overlap_shifts_up"
+spec = ["9.2:14g"]
+source = """
+fn main() -> i32 {
+    checked {
+        let p: ptr mut u8 = @alloc(4, 1);
+        @byte_write(p, 0, 1);
+        @byte_write(p, 1, 2);
+        @byte_write(p, 2, 3);
+        @byte_write(p, 3, 0);
+        let dst: ptr mut u8 = @int_to_ptr(@ptr_to_int(p) + 1);
+        @byte_move(dst, p, 3);
+        let result: i32 = @intCast(@byte_read(p, 0)) * 64
+            + @intCast(@byte_read(p, 1)) * 16
+            + @intCast(@byte_read(p, 2)) * 4
+            + @intCast(@byte_read(p, 3));
+        @free(p, 4, 1);
+        result
+    }
+}
+"""
+exit_code = 91
+
+# Backward overlap (dst < src): [0,1,2,3] shifted down one byte must yield
+# [1,2,3,3], packed the same way. Correct memmove gives 64+32+12+3 = 111; a
+# naive backward byte loop would smear the last byte to [3,3,3,3] = 255.
+[[case]]
+name = "byte_move_backward_overlap_shifts_down"
+spec = ["9.2:14g"]
+source = """
+fn main() -> i32 {
+    checked {
+        let p: ptr mut u8 = @alloc(4, 1);
+        @byte_write(p, 0, 0);
+        @byte_write(p, 1, 1);
+        @byte_write(p, 2, 2);
+        @byte_write(p, 3, 3);
+        let src: ptr mut u8 = @int_to_ptr(@ptr_to_int(p) + 1);
+        @byte_move(p, src, 3);
+        let result: i32 = @intCast(@byte_read(p, 0)) * 64
+            + @intCast(@byte_read(p, 1)) * 16
+            + @intCast(@byte_read(p, 2)) * 4
+            + @intCast(@byte_read(p, 3));
+        @free(p, 4, 1);
+        result
+    }
+}
+"""
+exit_code = 111
+
+# A fully overlapping self-move is the identity.
+[[case]]
+name = "byte_move_onto_itself_is_the_identity"
+spec = ["9.2:14g"]
+source = """
+fn main() -> i32 {
+    checked {
+        let p: ptr mut u8 = @alloc(2, 1);
+        @byte_write(p, 0, 40);
+        @byte_write(p, 1, 5);
+        @byte_move(p, p, 2);
+        let result: i32 = @intCast(@byte_read(p, 0)) + @intCast(@byte_read(p, 1));
+        @free(p, 2, 1);
+        result
+    }
+}
+"""
+exit_code = 45
+
+# A zero-length move touches no memory, so it is well defined even between
+# overlapping (here identical) addresses.
+[[case]]
+name = "byte_move_of_zero_bytes_is_a_noop"
+spec = ["9.2:14g"]
+source = """
+fn main() -> i32 {
+    checked {
+        let p: ptr mut u8 = @alloc(1, 1);
+        @byte_write(p, 0, 77);
+        @byte_move(p, p, 0);
+        let result: i32 = @intCast(@byte_read(p, 0));
+        @free(p, 1, 1);
+        result
+    }
+}
+"""
+exit_code = 77
+
+[[case]]
+name = "byte_move_requires_checked"
+spec = ["9.2:14h"]
+source = """
+fn main() -> i32 {
+    let p: ptr mut u8 = checked { @alloc(2, 1) };
+    @byte_move(p, p, 1);
+    0
+}
+"""
+compile_fail = true
+error_contains = "[E1300]"
+
+[[case]]
+name = "byte_move_destination_must_be_ptr_mut_u8"
+spec = ["9.2:14h"]
+source = """
+fn main() -> i32 {
+    checked {
+        let p: ptr mut u8 = @alloc(1, 1);
+        let value: u8 = 0;
+        let src: ptr const u8 = @raw(value);
+        @byte_move(src, p, 1);
+    };
+    0
+}
+"""
+compile_fail = true
+error_contains = "ptr mut u8"
+
+[[case]]
+name = "byte_move_size_must_be_u64"
+spec = ["9.2:14h"]
+source = """
+fn main() -> i32 {
+    checked {
+        let p: ptr mut u8 = @alloc(2, 1);
+        let n: i32 = 1;
+        @byte_move(p, p, n);
+    };
+    0
+}
+"""
+compile_fail = true
+error_contains = "expected u64, found i32"

--- a/crates/rue-spec/cases/types/mutable-strings.toml
+++ b/crates/rue-spec/cases/types/mutable-strings.toml
@@ -412,10 +412,17 @@ exit_code = 0
 # Growth Strategy (3.10:24 - 3.10:25)
 # =============================================================================
 
+# The capacities are pinned, not merely compared, because 3.10:25 now documents
+# THIS implementation's choice and the pre-RUE-1274 text got it wrong. Growth
+# starts from max(current, 16) and doubles in a loop until the required capacity
+# is reached: the first append of 5 bytes lands on the 16-byte minimum rather
+# than on double of zero, and the second append (30 more bytes, 35 required)
+# runs 16 -> 32 -> 64, so one append MORE than doubles the capacity. A std
+# growth-policy change now fails here instead of silently invalidating 3.10:25.
 [[case]]
 name = "string_growth_on_append"
 spec = ["3.10:24", "3.10:25"]
-description = "StrBuf grows capacity when needed"
+description = "StrBuf grows to at least the required capacity; the concrete values pin the implementation-defined policy documented in 3.10:25"
 real_std = true
 source = """
 const std = @import("std");
@@ -424,13 +431,17 @@ fn main() -> i32 {
     let mut s = StrBuf.new();
     s.push_str("hello");
     let cap1 = s.capacity();
+    @dbg(cap1);
     // Append enough to exceed initial capacity
     s.push_str(" world hello world hello world");
     let cap2 = s.capacity();
-    if cap2 > cap1 { 0 } else { 1 }
+    @dbg(s.len());
+    @dbg(cap2);
+    if cap2 > cap1 && cap2 >= s.len() { 0 } else { 1 }
 }
 """
 exit_code = 0
+expected_stdout = "16\n35\n64\n"
 
 # =============================================================================
 # Clone (3.10:26 - 3.10:28)

--- a/crates/rue-spec/cases/types/strings.toml
+++ b/crates/rue-spec/cases/types/strings.toml
@@ -134,6 +134,29 @@ fn main() -> i32 {
 exit_code = 0
 expected_stdout = "foobar\n"
 
+# 3.7:41 — capacity is implementation-defined but OBSERVABLE: capacity() hands
+# back the chosen value, so a program CAN branch on it (and thereby stop being
+# portable). The pre-RUE-1274 text claimed a conforming program never observes
+# it, which this case would have contradicted.
+[[case]]
+name = "string_capacity_is_observable"
+spec = ["3.7:41"]
+description = "capacity() returns the implementation's chosen capacity: 0 for a literal, a nonzero value after a clone allocates."
+real_std = true
+source = """
+const std = @import("std");
+const StrBuf = std.strbuf.StrBuf;
+fn main() -> i32 {
+    let lit: StrBuf = "hello";
+    @dbg(lit.capacity());
+    let owned = lit.clone();
+    let zero: u64 = 0;
+    if owned.capacity() > zero { 0 } else { 1 }
+}
+"""
+exit_code = 0
+expected_stdout = "0\n"
+
 # =============================================================================
 # StrBuf Escape Sequences
 # =============================================================================
@@ -899,6 +922,39 @@ real_std = true
 source = """
 const std = @import("std");
 const StrBuf = std.strbuf.StrBuf;
+fn main() -> i32 {
+    @dbg(@to_string(42));
+    0
+}
+"""
+exit_code = 0
+expected_stdout = "42\n"
+
+# 3.7:22 — @to_string names StrBuf in its result type without rooting the
+# trusted module itself, so the file must import std lexically. The import need
+# not be used and StrBuf need not be bound to a name (RUE-1276); contrast
+# @read_line (4.13:35) and @parse_* (4.13:44), which do self-root.
+[[case]]
+name = "to_string_requires_lexical_std_import"
+spec = ["3.7:22"]
+description = "Without a lexical @import(\"std\"), @to_string is rejected with E0204 for the unknown type StrBuf."
+real_std = true
+source = """
+fn main() -> i32 {
+    @dbg(@to_string(42));
+    0
+}
+"""
+compile_fail = true
+error_contains = ["[E0204]", "StrBuf"]
+
+[[case]]
+name = "to_string_import_alone_suffices"
+spec = ["3.7:22"]
+description = "A bare std import is enough: @to_string works without binding the name StrBuf."
+real_std = true
+source = """
+const std = @import("std");
 fn main() -> i32 {
     @dbg(@to_string(42));
     0

--- a/crates/rue-ui-tests/cases/diagnostics/alloc_infer_pointee.toml
+++ b/crates/rue-ui-tests/cases/diagnostics/alloc_infer_pointee.toml
@@ -1,31 +1,19 @@
 [section]
 id = "diagnostics.alloc-infer-pointee"
-name = "@alloc / @int_to_ptr uninferrable pointee reports a clean error, not an ICE"
+name = "@int_to_ptr uninferrable pointee reports a clean error, not an ICE"
 description = """
-The pointer intrinsics `@alloc(count)` and `@int_to_ptr(addr)` return `ptr mut T`
-whose pointee `T` comes only from context. In a discarded or otherwise
-unconstrained position (`@alloc(4);`) the result variable has nothing to fix its
-pointee and decayed to `<error>`, which reached the end of semantic analysis as
-a graceful ICE (E9000, RUE-153 backstop) — found by the daily sema fuzzer
-(github #1419). It now reports a targeted E0710 naming the intrinsic and
-suggesting a `ptr mut T` annotation. An annotated allocation still compiles.
-"""
+`@int_to_ptr(addr)` returns `ptr mut T` whose pointee `T` comes only from
+context. In a discarded or otherwise unconstrained position the result variable
+has nothing to fix its pointee and decayed to `<error>`, which reached the end
+of semantic analysis as a graceful ICE (E9000, RUE-153 backstop) — found by the
+daily sema fuzzer (github #1419). It now reports a targeted E0710 naming the
+intrinsic and suggesting a `ptr mut T` annotation.
 
-[[case]]
-name = "bare_alloc_cannot_infer_pointee"
-description = "@alloc whose result is discarded cannot infer its pointee: clean E0710, not an ICE."
-source = """
-fn main() -> i32 {
-    checked { @alloc(4); };
-    0
-}
+`@alloc` was the other half of this pair until ADR-0059 Phase 3 (RUE-961) gave
+the allocation family a fixed `ptr mut u8` result, so it can no longer fail to
+infer a pointee; the cases below pin that its result type is now fixed rather
+than context-derived, which is what removes it from this diagnostic's scope.
 """
-compile_fail = true
-error_contains = [
-    "E0710",
-    "cannot infer the pointee type of '@alloc'",
-    "add a type annotation",
-]
 
 [[case]]
 name = "bare_int_to_ptr_cannot_infer_pointee"
@@ -43,14 +31,42 @@ error_contains = [
 ]
 
 [[case]]
-name = "annotated_alloc_still_compiles"
-description = "An @alloc bound to a `ptr mut T` annotation still infers its pointee and compiles."
+name = "bare_alloc_needs_no_pointee_context"
+description = "@alloc in a discarded position compiles: its result type is `ptr mut u8`, not context-inferred."
+source = """
+fn main() -> i32 {
+    checked { @alloc(4, 1); };
+    0
+}
+"""
+compile_fail = false
+exit_code = 0
+
+[[case]]
+name = "alloc_result_is_ptr_mut_u8_not_the_annotation"
+description = "A `ptr mut T` annotation no longer steers @alloc; a non-u8 pointee is a type error."
 source = """
 fn main() -> i32 {
     checked {
-        let p: ptr mut i32 = @alloc(4);
-        @ptr_write(p, 42);
+        let p: ptr mut i32 = @alloc(4, 4);
         @ptr_read(p)
+    }
+}
+"""
+compile_fail = true
+error_contains = ["ptr mut u8"]
+
+[[case]]
+name = "annotated_alloc_still_compiles"
+description = "An @alloc bound to a `ptr mut u8` annotation compiles and its block is usable."
+source = """
+fn main() -> i32 {
+    checked {
+        let p: ptr mut u8 = @alloc(4, 1);
+        @byte_write(p, 0, 42);
+        let v: i32 = @intCast(@byte_read(p, 0));
+        @free(p, 4, 1);
+        v
     }
 }
 """

--- a/crates/rue-ui-tests/cases/diagnostics/type_too_large.toml
+++ b/crates/rue-ui-tests/cases/diagnostics/type_too_large.toml
@@ -1,15 +1,26 @@
 [section]
 id = "diagnostics.type_too_large"
 name = "Oversized type layouts (E0906)"
-description = "Types exceeding the maximum object size (spec C.4:3, RUE-561) are rejected with E0906 instead of ICEing (debug multiply overflow) or silently truncating the slot count to zero, as spec C.1:2 requires."
+description = "Types exceeding the maximum object size (spec C.4:3, RUE-561) are rejected with E0906 instead of ICEing (debug multiply overflow) or silently truncating the slot count to zero, as spec C.1:2 requires. The enforced ceiling is 268,435,455 ABI slots — one slot per scalar, struct field, and array element — and the diagnostic names that slot ceiling rather than a byte total it does not check (RUE-1272)."
 
 [[case]]
-name = "size_of_2gib_array_rejected"
+name = "size_of_oversized_array_rejected"
 source = """
 fn main() -> i32 { @size_of([i32; 536870912]) }
 """
 compile_fail = true
-error_contains = ["[E0906]", "[i32; 536870912]", "2147483647"]
+error_contains = ["[E0906]", "[i32; 536870912]", "268435455", "ABI slots"]
+
+# The ceiling counts slots, not bytes: a one-byte element type reaches it at the
+# same element count as an eight-byte one, so this 256 MiB array is rejected
+# even though its byte size is a fraction of the disp32 frame range (RUE-1272).
+[[case]]
+name = "narrow_element_array_past_slot_ceiling_rejected"
+source = """
+fn main() -> i32 { @size_of([i8; 268435456]) }
+"""
+compile_fail = true
+error_contains = ["[E0906]", "[i8; 268435456]", "268435455", "ABI slots"]
 
 [[case]]
 name = "size_of_32gib_array_rejected_not_zero"

--- a/crates/rue/src/main.rs
+++ b/crates/rue/src/main.rs
@@ -1,5 +1,6 @@
 use std::env;
 use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicBool, Ordering};
 #[cfg(test)]
 use std::{fs, sync::Arc};
 
@@ -21,7 +22,9 @@ use emit::EmitStage;
 use emit::{EmitFrontendRoute, build_emit_frontend, emit_frontend_route, emit_requires_semantic};
 #[cfg(test)]
 use rue_compiler::unstable::update_for_presentation;
-use rue_compiler::unstable::{MultiFileFormatter, MultiFileJsonFormatter, SourceInfo};
+use rue_compiler::unstable::{
+    JsonDiagnostic, MultiFileFormatter, MultiFileJsonFormatter, SourceInfo,
+};
 use rue_driver::{FilesystemCompilerHost, HostOpenRequest, SourceLoadError};
 
 use rue_compiler::{
@@ -30,7 +33,7 @@ use rue_compiler::{
 };
 #[cfg(test)]
 use rue_compiler::{CompilerSession, SourceMetadata, SourceSnapshot};
-use rue_error::CompileError;
+use rue_error::{CompileError, ErrorCode};
 use rue_target::Target;
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 enum LogLevel {
@@ -263,6 +266,9 @@ Options:
                        Formats: {log_formats}
   --error-format <fmt> Set diagnostic format (default: text)
                        Formats: {error_formats}
+                       'json' writes one JSON array of diagnostic objects per
+                       stderr line, compiler panics (ICEs) included
+                       (schema: docs/process/diagnostics.md)
   --time-passes        Show timing for each compilation pass
   --benchmark-json     Output timing as JSON (for benchmarking)
   --watch              Recompile when the accepted source closure changes
@@ -278,6 +284,12 @@ Options:
     )
 }
 
+// CAUTION: `rue_test_runner::ice_message` treats the substring
+// "internal compiler error" anywhere on the compiler's stderr as proof the
+// compiler crashed, and usage text goes to stderr on an argument error. Never
+// spell that phrase out in this help text — an ordinary `rue --bogus-flag`
+// would then be reported as an ICE and fail every case that pins it.
+//
 /// Write usage to stderr, for the argument-error paths.
 fn print_usage() {
     eprintln!("{}", usage_text());
@@ -700,18 +712,39 @@ impl<'a> DiagnosticOutput<'a> {
         }
     }
 
-    fn print_error(&self, error: &CompileError) {
+    /// Render one error. Under `--error-format json` a lone error is still
+    /// wrapped in a one-element array: every JSON diagnostic line the CLI
+    /// writes is an array of diagnostic objects, so a consumer parses one
+    /// shape rather than switching on object-vs-array (RUE-436). The
+    /// single-error paths (output publication, watch-cycle publication) used
+    /// to emit a bare object here while every batch path emitted an array.
+    fn render_error(&self, error: &CompileError) -> String {
         match self.format {
-            ErrorFormat::Text => eprintln!("{}", self.text.format_error(error)),
-            ErrorFormat::Json => eprintln!("{}", self.json.format_error(error).to_json()),
+            ErrorFormat::Text => self.text.format_error(error).to_string(),
+            ErrorFormat::Json => format!("[{}]", self.json.format_error(error).to_json()),
         }
     }
 
-    fn print_errors(&self, errors: &CompileErrors) {
+    fn render_errors(&self, errors: &CompileErrors) -> String {
         match self.format {
-            ErrorFormat::Text => eprintln!("{}", self.text.format_errors(errors)),
-            ErrorFormat::Json => eprintln!("{}", self.json.format_errors(errors)),
+            ErrorFormat::Text => self.text.format_errors(errors),
+            ErrorFormat::Json => self.json.format_errors(errors),
         }
+    }
+
+    fn render_warnings(&self, warnings: &[CompileWarning]) -> String {
+        match self.format {
+            ErrorFormat::Text => self.text.format_warnings(warnings),
+            ErrorFormat::Json => self.json.format_warnings(warnings),
+        }
+    }
+
+    fn print_error(&self, error: &CompileError) {
+        eprintln!("{}", self.render_error(error));
+    }
+
+    fn print_errors(&self, errors: &CompileErrors) {
+        eprintln!("{}", self.render_errors(errors));
     }
 
     fn print_warnings(&self, warnings: &[CompileWarning]) {
@@ -719,10 +752,7 @@ impl<'a> DiagnosticOutput<'a> {
             return;
         }
 
-        match self.format {
-            ErrorFormat::Text => eprintln!("{}", self.text.format_warnings(warnings)),
-            ErrorFormat::Json => eprintln!("{}", self.json.format_warnings(warnings)),
-        }
+        eprintln!("{}", self.render_warnings(warnings));
     }
 }
 
@@ -991,6 +1021,91 @@ fn report_source_load_error(error: SourceLoadError, error_format: ErrorFormat) -
     std::process::exit(1);
 }
 
+/// Diagnostic format the ICE panic hook renders with.
+///
+/// The hook is installed before `--error-format` has been parsed (so a panic
+/// inside argument parsing is still an ICE report rather than a raw Rust
+/// backtrace), and a `&'static` panic hook cannot borrow the parsed options.
+/// The driver publishes the chosen format here exactly once, immediately after
+/// parsing; `false` — the initial value — means the `text` default.
+static ICE_FORMAT_IS_JSON: AtomicBool = AtomicBool::new(false);
+
+/// Publish the diagnostic format the ICE panic hook must render with.
+fn set_ice_error_format(format: ErrorFormat) {
+    ICE_FORMAT_IS_JSON.store(format == ErrorFormat::Json, Ordering::Relaxed);
+}
+
+/// The diagnostic format the ICE panic hook renders with. `Text` until the
+/// driver publishes a parsed `--error-format`.
+fn ice_error_format() -> ErrorFormat {
+    if ICE_FORMAT_IS_JSON.load(Ordering::Relaxed) {
+        ErrorFormat::Json
+    } else {
+        ErrorFormat::Text
+    }
+}
+
+/// Render a compiler panic as a structured diagnostic.
+///
+/// A thin adapter over [`ice_diagnostic`] and [`panic_payload_message`]: this
+/// crate is compiled with `panic = "abort"` (see `toolchains/rust/defs.bzl`),
+/// so no test can raise a catchable panic to obtain a real `PanicHookInfo`.
+/// Splitting the two testable halves out keeps everything but this three-line
+/// projection under unit test.
+fn ice_panic_diagnostic(info: &std::panic::PanicHookInfo<'_>) -> JsonDiagnostic {
+    ice_diagnostic(
+        &panic_payload_message(info.payload()),
+        info.location().map(|location| location.to_string()),
+    )
+}
+
+/// Build the structured diagnostic for a compiler panic.
+///
+/// The code is [`ErrorCode::INTERNAL_ERROR`] (`E9000`) — the same code a
+/// graceful `ice_error!` ICE carries — so a consumer filters both halves of
+/// the ICE surface on one code. The diagnostic has no spans: a panic has no
+/// source location in the *user's* program, and inventing one would be a lie.
+fn ice_diagnostic(payload: &str, panic_site: Option<String>) -> JsonDiagnostic {
+    let mut notes = vec![format!("rue version {VERSION}")];
+    if let Some(site) = panic_site {
+        notes.push(format!("panic at {site}"));
+    }
+    // `Backtrace::capture` is a no-op unless RUST_BACKTRACE is set, matching
+    // the text hook's behavior — the JSON report is not more verbose by
+    // default, it is only parseable.
+    let backtrace = std::backtrace::Backtrace::capture();
+    if backtrace.status() == std::backtrace::BacktraceStatus::Captured {
+        notes.push(format!("backtrace:\n{backtrace}"));
+    }
+
+    JsonDiagnostic {
+        code: ErrorCode::INTERNAL_ERROR.to_string(),
+        message: format!(
+            "internal compiler error: the compiler panicked; this is a bug in rue: {payload}"
+        ),
+        severity: "error",
+        spans: Vec::new(),
+        suggestions: Vec::new(),
+        notes,
+        helps: vec![
+            "please report this at https://github.com/rue-language/rue/issues".to_string(),
+            "re-run with RUST_BACKTRACE=1 for a backtrace".to_string(),
+        ],
+    }
+}
+
+/// Extract a panic's message payload. `panic!` produces either a `&'static str`
+/// (a literal) or a formatted `String`; anything else is an opaque payload.
+fn panic_payload_message(payload: &(dyn std::any::Any + Send)) -> String {
+    if let Some(message) = payload.downcast_ref::<&str>() {
+        (*message).to_string()
+    } else if let Some(message) = payload.downcast_ref::<String>() {
+        message.clone()
+    } else {
+        "panic with a non-string payload".to_string()
+    }
+}
+
 fn main() {
     // Rust's startup ignores SIGPIPE, so a write to a closed pipe
     // (`rue --emit tokens x.rue | head`) returns EPIPE and `println!` panics
@@ -1005,8 +1120,22 @@ fn main() {
     // Present compiler panics as internal compiler errors with a report
     // banner instead of a raw Rust backtrace pointer (RUE-130). The default
     // hook still runs first so RUST_BACKTRACE=1 output is preserved.
+    //
+    // Under `--error-format json` the same ICE is instead published as an
+    // ordinary structured diagnostic (RUE-436): a machine consumer that asked
+    // for JSON must be able to parse EVERY line the compiler writes to stderr,
+    // and the default hook's `thread 'main' panicked at ...` banner is not
+    // JSON. Nothing is lost — the panic payload, panic location, and (when
+    // `RUST_BACKTRACE` is set) the backtrace all move into the diagnostic's
+    // notes. Graceful ICEs (`ice_error!` -> `ErrorKind::InternalError`) are
+    // ordinary `CompileError`s and already travel the normal JSON path; this
+    // closes the panic half of the same surface.
     let default_panic_hook = std::panic::take_hook();
     std::panic::set_hook(Box::new(move |info| {
+        if ice_error_format() == ErrorFormat::Json {
+            eprintln!("[{}]", ice_panic_diagnostic(info).to_json());
+            return;
+        }
         default_panic_hook(info);
         eprintln!();
         eprintln!("error: internal compiler error: the compiler panicked; this is a bug in rue");
@@ -1019,6 +1148,11 @@ fn main() {
         Some(opts) => opts,
         None => std::process::exit(1),
     };
+
+    // The hook above is installed BEFORE argument parsing, so a panic inside
+    // the parser is still reported as an ICE. Publish the requested format now
+    // that it is known; until this point the hook uses the `text` default.
+    set_ice_error_format(options.error_format);
 
     // Reject incompatible output modes before any tracing, thread-pool, manifest,
     // or source I/O work. This is a pure options check, so surfacing it first
@@ -2133,6 +2267,176 @@ mod tests {
             "invalid",
             "source.rue"
         ])));
+    }
+
+    // ========== --error-format json surface tests (RUE-436) ==========
+
+    /// A diagnostic rendering fixture over one in-memory file.
+    fn json_output(source: &str) -> DiagnosticOutput<'_> {
+        DiagnosticOutput::new(
+            ErrorFormat::Json,
+            vec![(FileId::DEFAULT, SourceInfo::new(source, "main.rue"))],
+        )
+    }
+
+    /// Every JSON line the CLI writes is an ARRAY of diagnostics, including the
+    /// single-error driver paths (output publication, watch-cycle publication)
+    /// that used to emit a bare object. A consumer parses one shape.
+    #[test]
+    fn json_single_error_is_wrapped_in_an_array() {
+        let source = "fn main() -> i32 { 0 }\n";
+        let error = CompileError::without_span(rue_error::ErrorKind::InternalError(
+            "publication exploded".to_string(),
+        ));
+        let rendered = json_output(source).render_error(&error);
+
+        let batch: serde_json::Value = serde_json::from_str(&rendered).expect("valid JSON");
+        let batch = batch.as_array().expect("a JSON array, not a bare object");
+        assert_eq!(batch.len(), 1);
+        assert_eq!(batch[0]["severity"], "error");
+    }
+
+    /// A graceful ICE (`ice_error!` -> `ErrorKind::InternalError`) is an
+    /// ordinary `CompileError`, so it travels the SAME structured path as any
+    /// user-facing diagnostic and carries the E9000 internal-error code.
+    #[test]
+    fn json_graceful_ice_routes_through_the_structured_surface() {
+        let source = "fn main() -> i32 { 0 }\n";
+        let errors = CompileErrors::from(vec![CompileError::without_span(
+            rue_error::ErrorKind::InternalError("did not resolve type".to_string()),
+        )]);
+        let rendered = json_output(source).render_errors(&errors);
+
+        let batch: serde_json::Value = serde_json::from_str(&rendered).expect("valid JSON");
+        let batch = batch.as_array().expect("a JSON array");
+        assert_eq!(batch.len(), 1);
+        assert_eq!(batch[0]["code"], ErrorCode::INTERNAL_ERROR.to_string());
+        assert_eq!(batch[0]["severity"], "error");
+    }
+
+    /// The ICE panic hook renders text until the driver publishes a parsed
+    /// `--error-format`, so a panic *inside* argument parsing still gets the
+    /// human banner rather than JSON nobody asked for.
+    #[test]
+    fn ice_error_format_defaults_to_text() {
+        // The published format is process-global; assert the default only
+        // through a fresh read of the initial value's meaning.
+        assert_eq!(
+            if ICE_FORMAT_IS_JSON.load(Ordering::Relaxed) {
+                ErrorFormat::Json
+            } else {
+                ErrorFormat::Text
+            },
+            ice_error_format()
+        );
+        assert_eq!(ErrorFormat::default(), ErrorFormat::Text);
+    }
+
+    /// A compiler panic under `--error-format json` becomes an ordinary
+    /// structured diagnostic: E9000, no spans (a panic has no location in the
+    /// *user's* program), the panic payload in the message, and the panic site
+    /// and compiler version preserved in notes.
+    ///
+    /// This surface has no end-to-end test on either side of the fence, which
+    /// is why the rendering is pinned this precisely. A CLI case cannot host
+    /// it — `rue_test_runner::ice_message` fails ANY case whose compiler
+    /// panicked, by design, so a crash never satisfies a `compile_fail`. Nor
+    /// can a unit test raise a real panic and read the hook's output: the
+    /// crate is built with `panic = "abort"` (`toolchains/rust/defs.bzl`), so
+    /// `catch_unwind` cannot catch and the panicking process dies. The hook
+    /// itself is therefore a three-line projection onto this function.
+    #[test]
+    fn ice_panic_is_published_as_a_json_diagnostic() {
+        let rendered = ice_diagnostic(
+            "cfg edge 7 exploded",
+            Some("crates/rue-cfg/src/build.rs:118:9".to_string()),
+        )
+        .to_json();
+        let diagnostic: serde_json::Value = serde_json::from_str(&rendered).expect("valid JSON");
+
+        assert_eq!(diagnostic["severity"], "error");
+        assert_eq!(diagnostic["code"], ErrorCode::INTERNAL_ERROR.to_string());
+        assert_eq!(
+            diagnostic["spans"].as_array().expect("spans array").len(),
+            0
+        );
+        let message = diagnostic["message"].as_str().expect("message string");
+        assert!(
+            message.contains("internal compiler error"),
+            "the ICE marker the harness detector greps for is missing: {message}"
+        );
+        assert!(
+            message.contains("cfg edge 7 exploded"),
+            "the panic payload was dropped: {message}"
+        );
+
+        let notes: Vec<&str> = diagnostic["notes"]
+            .as_array()
+            .expect("notes array")
+            .iter()
+            .map(|note| note.as_str().expect("note string"))
+            .collect();
+        assert!(
+            notes.iter().any(|note| note.contains(VERSION)),
+            "the compiler version note was dropped: {notes:?}"
+        );
+        assert!(
+            notes
+                .iter()
+                .any(|note| *note == "panic at crates/rue-cfg/src/build.rs:118:9"),
+            "the panic site note was dropped: {notes:?}"
+        );
+
+        let helps: Vec<&str> = diagnostic["helps"]
+            .as_array()
+            .expect("helps array")
+            .iter()
+            .map(|help| help.as_str().expect("help string"))
+            .collect();
+        assert!(
+            helps.iter().any(|help| help.contains("issues")),
+            "the report-this-bug help was dropped: {helps:?}"
+        );
+    }
+
+    /// A panic with no recorded location (possible for a panic raised outside
+    /// Rust's `#[track_caller]` machinery) still renders a valid diagnostic —
+    /// it simply omits the site note rather than emitting a hole.
+    #[test]
+    fn ice_diagnostic_without_a_panic_site_is_still_valid() {
+        let rendered = ice_diagnostic("no location", None).to_json();
+        let diagnostic: serde_json::Value = serde_json::from_str(&rendered).expect("valid JSON");
+        let notes: Vec<&str> = diagnostic["notes"]
+            .as_array()
+            .expect("notes array")
+            .iter()
+            .map(|note| note.as_str().expect("note string"))
+            .collect();
+        assert!(
+            !notes.iter().any(|note| note.starts_with("panic at ")),
+            "an absent panic site must be omitted, not rendered empty: {notes:?}"
+        );
+    }
+
+    /// `panic!` hands the hook either a `&'static str` (a literal) or a
+    /// `String` (a formatted message); anything else is opaque. All three
+    /// produce a usable message rather than an empty one.
+    #[test]
+    fn panic_payloads_of_every_shape_produce_a_message() {
+        let literal: Box<dyn std::any::Any + Send> = Box::new("cfg edge exploded");
+        assert_eq!(panic_payload_message(literal.as_ref()), "cfg edge exploded");
+
+        let formatted: Box<dyn std::any::Any + Send> = Box::new("cfg edge 7 exploded".to_string());
+        assert_eq!(
+            panic_payload_message(formatted.as_ref()),
+            "cfg edge 7 exploded"
+        );
+
+        let opaque: Box<dyn std::any::Any + Send> = Box::new(42u32);
+        assert_eq!(
+            panic_payload_message(opaque.as_ref()),
+            "panic with a non-string payload"
+        );
     }
 
     // ========== --help and --version tests ==========

--- a/docs/designs/0059-byte-oriented-memory-intrinsics.md
+++ b/docs/designs/0059-byte-oriented-memory-intrinsics.md
@@ -374,10 +374,29 @@ Phases are ordered by the sequencing above. RUE-937 is the tracking issue.
   the `align` parameter to the byte allocator, giving the interim surface the
   `(size, align)` contract; update the runtime operand plan (already
   `(size, align)`-shaped) and `std` call sites.
-- [ ] **Phase 3: Byte-oriented allocation family (post-/co-RUE-971)** —
+- [x] **Phase 3: Byte-oriented allocation family (post-/co-RUE-971)** —
   RUE-961. Re-shape `@alloc`/`@realloc`/`@free` to byte + align; fold
   the `_bytes` allocators in; move `ArrayBuf` typed allocation to source-computed
-  `@size_of`/`@align_of` sugar.
+  `@size_of`/`@align_of` sugar. Landed with the hard removal ruled at
+  acceptance: `@alloc_bytes`/`@realloc_bytes`/`@free_bytes` no longer exist and
+  every `std/` consumer moved in the same change. Typed allocation now lives in
+  `std/rawbuf.rue`, the one place that turns `count` into
+  `count * @size_of(T)` and casts the `ptr mut u8` block to `ptr mut T`.
+  Two consequences worth recording: the allocation-size overflow trap moved out
+  of codegen into the language's ordinary trapping multiply, and the differential
+  oracle gained a lazy reinterpretation of an untouched byte block as cells of
+  the first pointee viewed over it, which is how it keeps modeling typed
+  containers now that no allocation carries an element type.
+- [x] **Phase 3a: In-place resize and zeroed allocation** — RUE-968. Added
+  `@resize(p, old_size, align, new_size) -> bool` (Zig's `Allocator.resize`:
+  in-place only, the pointer never moves, refusal is `false`) and
+  `@alloc_zeroed(size, align)`, both on the unified `(size, align)` ABI, with
+  the new `__rue_resize` / `__rue_alloc_zeroed` runtime helpers. Pulled forward
+  from Future Work ahead of the issue's wait-for-trigger note.
+- [x] **Phase 3b: Overlapping bulk move** — RUE-964. Added
+  `@byte_move(dst, src, size)`, the memmove-shaped sibling of `@byte_copy`
+  (which stays memcpy-shaped, overlap undefined), over the new
+  `__rue_byte_move` helper. Purely additive.
 - [ ] **Phase 4: Byte-correct typed access (post-RUE-971)** — RUE-962.
   Make `@ptr_read`/`@ptr_write`/`@ptr_offset` physical-layout-driven; add
   `@ptr_read_unaligned`/`@ptr_write_unaligned`; fold `@byte_read`/`@byte_write`
@@ -455,7 +474,8 @@ The proposal's open questions, settled by the 2026-07-17 ratification:
   them ungated through std via the trusted-std carve-out regardless.
 - **Overlapping copy: deferred.** `@byte_copy` (non-overlapping) only; no std
   consumer overlaps today, and a later `@byte_move` (memmove) is purely
-  additive.
+  additive. Superseded: `@byte_move` shipped in Phase 3b (RUE-964), exactly as
+  the additive change this ruling anticipated.
 - **Null primitive: keep the `@int_to_ptr(0)` idiom.** A dedicated `@null_ptr`
   acquires design questions (typed or untyped result?) better answered by the
   future provenance work.
@@ -480,10 +500,16 @@ Explicitly out of scope for this ADR, for later designs:
   question).
 - **Strict/exposed provenance split** on `@ptr_to_int`/`@int_to_ptr` as Rue's
   memory model formalizes.
-- **In-place-only resize** (`@resize` returning a success bool, Zig-style) for
-  containers that manage their own copy.
-- **`@offset_of`** once aggregate layout stabilizes under RUE-971.
-- **`@alloc_zeroed`** if the allocator can zero more cheaply than `@byte_set`.
+- ~~**In-place-only resize** (`@resize` returning a success bool, Zig-style) for
+  containers that manage their own copy.~~ Delivered in Phase 3a (RUE-968).
+- ~~**`@offset_of`** once aggregate layout stabilizes under RUE-971.~~ Already
+  present since RUE-301; verified against `@field_ptr` and in comptime constant
+  positions under RUE-969.
+- ~~**`@alloc_zeroed`** if the allocator can zero more cheaply than
+  `@byte_set`.~~ Delivered in Phase 3a (RUE-968). The current allocator recycles
+  arenas and so has no cheaper path than clearing the block, but the intrinsic
+  makes the guarantee expressible and confines a future zero-page mapping to the
+  runtime.
 - **Endianness** stays library-level forever (`to_le_bytes`/`from_le_bytes`-style
   conversions over the byte primitives); no byte-order intrinsic.
 

--- a/docs/formal/01-core-calculus.md
+++ b/docs/formal/01-core-calculus.md
@@ -1957,8 +1957,8 @@ citation:
 `StrBuf` is the `u8` refinement of the trio's growable rung plus the
 byte-string convention (ADR-0043; the RUE-386 two-types ruling), and like
 `ArrayBuf` it is **source-defined** (`std/strbuf.rue`) over the byte-oriented
-unchecked intrinsics (`@alloc_bytes`/`@realloc_bytes`/`@free_bytes`/
-`@byte_read`/`@byte_write`/`@byte_copy`, ADR-0058), so the same
+unchecked intrinsics (`@alloc`/`@realloc`/`@free`/
+`@byte_read`/`@byte_write`/`@byte_copy`, ADR-0059), so the same
 defining-equation device applies at its public boundary. Its value is
 `{ h ; len ; cap }_StrBuf` over `u8` cells, with one representation twist the
 source pins in its header comment: **`cap = 0` is the non-owning state.**

--- a/docs/process/README.md
+++ b/docs/process/README.md
@@ -29,6 +29,7 @@ Each step has a corresponding document in this directory and a Claude Code comma
 | Review | [code-review.md](code-review.md) | `/code-review` | Check quality before committing |
 | Commit | [committing.md](committing.md) | `/commit` | Create well-formed commits |
 | - | [ci.md](ci.md) | - | Maintain required CI and its pinned tools |
+| - | [diagnostics.md](diagnostics.md) | - | Consume `--error-format json` structured diagnostics |
 | - | [profiling.md](profiling.md) | - | Build symbolized executables for native profiling |
 | - | [compiler-scaling.md](compiler-scaling.md) | - | Measure maintained-program compiler scaling |
 | - | [compiler-facade.md](compiler-facade.md) | - | Review compiler API and tooling-view changes |

--- a/docs/process/diagnostics.md
+++ b/docs/process/diagnostics.md
@@ -1,0 +1,137 @@
+# Machine-Readable Diagnostics (`--error-format`)
+
+`rue --error-format <fmt>` selects how compiler diagnostics are presented.
+
+| Format | Meaning |
+|--------|---------|
+| `text` (default) | Human-readable diagnostics with source snippets, carets, and colour. |
+| `json` | Machine-readable structured diagnostics for editors, LSP bridges, and CI. |
+
+```bash
+rue --error-format json main.rue -o prog
+rue --error-format=json main.rue -o prog   # both spellings work
+```
+
+The flag is orthogonal to `--log-format` (see [logging.md](logging.md)):
+`--log-format` controls the *tracing* stream (`--log-level`, `--time-passes`),
+`--error-format` controls *program diagnostics*. Setting one does not change
+the other.
+
+## Stream and framing
+
+Under `--error-format json`:
+
+- **All diagnostics go to stderr.** Nothing else does. The success banner
+  (`Compiled main.rue -> prog (...)`) and every `--emit` artifact go to
+  **stdout**, so a consumer can treat the entire stderr stream as structured
+  output without filtering.
+- **Every non-empty stderr line is one JSON array of diagnostic objects.** The
+  compiler emits diagnostics in batches (the warnings of a successful compile;
+  the errors of a failed one), one batch per line. A batch with nothing to
+  report prints nothing rather than `[]`.
+- A batch is never a bare object. A single diagnostic — an output-publication
+  failure, a compiler panic — is still wrapped in a one-element array, so a
+  consumer parses one shape (RUE-436).
+- Exit status is unchanged by the flag: `0` on success, `1` on a rejected
+  program or a failed publication.
+
+```console
+$ rue --error-format json main.rue -o prog
+[{"code":"E0206","helps":[],"message":"type mismatch: expected i32, found bool","notes":[],"severity":"error","spans":[{"column":20,"end":23,"file":"main.rue","label":null,"line":1,"primary":true,"start":19}],"suggestions":[]}]
+```
+
+## Diagnostic schema
+
+Each element of a batch is an object with exactly these seven keys. Object keys
+are serialized in alphabetical order; consumers must not depend on key order.
+
+| Key | Type | Meaning |
+|-----|------|---------|
+| `severity` | `"error"` \| `"warning"` | Diagnostic class. |
+| `code` | string | Error code, e.g. `"E0206"`. **Warnings are not yet coded and carry `""`.** |
+| `message` | string | The primary, human-readable message. Never empty. |
+| `spans` | array of span objects | Source locations. May be empty (a diagnostic with no location in the user's program). |
+| `suggestions` | array of suggestion objects | Machine-applicable fixes. May be empty. |
+| `notes` | array of strings | Contextual footnotes. |
+| `helps` | array of strings | Actionable advice footnotes. |
+
+### Span object
+
+| Key | Type | Meaning |
+|-----|------|---------|
+| `file` | string | Source path as the compiler observed it. Never empty. |
+| `start` | integer | Start byte offset into that file, 0-indexed. |
+| `end` | integer | End byte offset, exclusive. Never less than `start`. |
+| `line` | integer | Line of `start`, **1-indexed**. |
+| `column` | integer | Column of `start`, **1-indexed**. |
+| `label` | string \| `null` | Label text for a secondary span; `null` on the primary. |
+| `primary` | boolean | Whether this is the diagnostic's primary span. |
+
+When `spans` is non-empty, exactly one span has `"primary": true` and it is
+**`spans[0]`**; every later entry is a secondary label span. A diagnostic that
+has no location at all reports `"spans": []`.
+
+### Suggestion object
+
+| Key | Type | Meaning |
+|-----|------|---------|
+| `message` | string | What the fix does. |
+| `file` | string | File the replacement applies to. |
+| `start` / `end` | integer | Byte range to replace. |
+| `replacement` | string | Text to substitute for that range. |
+| `applicability` | string | How safe the fix is to apply automatically. |
+
+## Internal compiler errors
+
+Both halves of the ICE surface are structured under `--error-format json`:
+
+- A **graceful ICE** (`ice_error!` → `ErrorKind::InternalError`) is an ordinary
+  `CompileError` and travels the normal diagnostic path, with code `E9000`.
+- A **compiler panic** is caught by the driver's panic hook and published as a
+  `E9000` diagnostic with `"spans": []` — a panic has no location in the user's
+  program, and inventing one would be a lie. The panic payload is appended to
+  `message`; the panic site, compiler version, and (when `RUST_BACKTRACE` is
+  set) the backtrace are carried in `notes`. The default Rust
+  `thread 'main' panicked at ...` banner is suppressed in this mode precisely
+  because it is not JSON.
+
+Either way the string `internal compiler error` appears in `message`, so the
+existing harness ICE detector (`rue_test_runner::ice_message`) still catches
+crashes hiding inside a JSON stream.
+
+## Ordering
+
+Diagnostic order is deterministic and independent of `-j`/`--jobs`: the
+compiler sorts its published diagnostics before handing them to a formatter,
+and the JSON formatter preserves that order exactly (it never re-sorts or
+groups by file, unlike the text formatter's per-file snippet rendering). Two
+runs of the same inputs produce byte-identical JSON.
+
+CLI cases pin this with `json_diagnostic_order`, which asserts the exact
+`"<severity> <code> <file>:<line>:<column>"` sequence across the whole stderr
+stream (an absent field renders as `-`) — see
+`crates/rue-cli-tests/cases/diagnostic_json.toml`.
+
+## Known gap
+
+Driver-level failures raised *before* a compilation snapshot exists — a missing
+root file, a broken toolchain, a hermetic-build denial — are still printed as
+plain text (`Error reading main.rue: No such file or directory`) even under
+`--error-format json`. They carry no error code today, so they have no schema
+to be rendered into. Consumers should treat a non-JSON stderr line as such a
+driver failure rather than a parse bug.
+
+## Testing the surface
+
+`crates/rue-cli-tests` validates the schema rather than substrings. A case with
+
+```toml
+json_diagnostics = true
+json_diagnostic_order = ["error E0206 main.rue:1:17"]
+```
+
+parses **every** stderr line, rejects any object whose key set is not exactly
+the documented one, checks span/suggestion field types and the 1-indexed
+line/column invariant, and then compares the full ordered digest. Malformed
+JSON, a dropped field, a renamed key, a demoted primary span, or a reordered
+batch each fail the case.

--- a/docs/spec/src/03-types/07-string-type.md
+++ b/docs/spec/src/03-types/07-string-type.md
@@ -66,10 +66,16 @@ moved-from binding.
 {{ rule(id="3.7:41", cat="informative") }}
 
 The capacity of a heap-allocated `StrBuf`, and the growth strategy that chooses
-it, are implementation-defined (1.3:6): a conforming program observes only the
-length and byte content of a `StrBuf`, never its exact capacity. The
-mutable-string extension ([Mutable Strings](@/03-types/10-mutable-strings.md),
-section 3.10) builds on this same three-word representation.
+it, are implementation-defined (1.3:6). Capacity is nonetheless *observable*:
+`capacity()` (§3.10:11) returns the exact allocated capacity, and the value it
+returns is the implementation-defined quantity itself, not a normalized one. A
+program that only reads the length and byte content of a `StrBuf` is portable
+across conforming implementations; one whose result depends on `capacity()` — or
+on how much a single append grows it — depends on an implementation-defined
+choice this implementation documents in §3.10:24 and may change in a later
+release. The mutable-string extension
+([Mutable Strings](@/03-types/10-mutable-strings.md), section 3.10) builds on
+this same three-word representation.
 
 {{ rule(id="3.7:42") }}
 
@@ -230,7 +236,16 @@ The intrinsic `@to_string(n)` takes an argument of any integer type (`i8`,
 `i16`, `i32`, `i64`, `u8`, `u16`, `u32`, or `u64`) and returns a new,
 heap-allocated `StrBuf` containing the base-10 decimal representation of `n`
 (see ADR-0035). The argument keeps its own type; a bare integer literal argument
-is inferred to be `i32` (the default integer type).
+is inferred to be `i32` (the default integer type). Using `@to_string` requires
+the enclosing file to import the standard library lexically
+(`const std = @import("std");`), because the intrinsic names `StrBuf` in its
+result type without rooting the trusted-module demand itself. In a file with no
+such import, a use of `@to_string` is rejected with E0204 (unknown type
+`StrBuf`) — the import must be present, but it need not be otherwise used, and
+the name `StrBuf` need not be brought into scope. This distinguishes
+`@to_string` from `@read_line` (§4.13:35) and the `@parse_*` intrinsics
+(§4.13:44), which do root the trusted module themselves and so have their
+`Option` result type even without a lexical `std` import.
 
 {{ rule(id="3.7:23", cat="dynamic-semantics") }}
 

--- a/docs/spec/src/03-types/09-destructors.md
+++ b/docs/spec/src/03-types/09-destructors.md
@@ -294,7 +294,10 @@ fn Buf(comptime T: type) -> type {
         buf: ptr mut T,
         cap: u64,
         drop fn(self) {
-            checked { @free(self.buf, self.cap); };
+            checked {
+                let block: ptr mut u8 = @int_to_ptr(@ptr_to_int(self.buf));
+                @free(block, self.cap * @intCast(@size_of(T)), @intCast(@align_of(T)));
+            };
         }
     }
 }

--- a/docs/spec/src/03-types/10-mutable-strings.md
+++ b/docs/spec/src/03-types/10-mutable-strings.md
@@ -8,7 +8,10 @@ template = "spec/page.html"
 
 This section describes the mutable string capabilities, building on the core `StrBuf` type from section 3.7.
 
-{{ preview_feature(feature="mutable_strings", adr="ADR-0014") }}
+These capabilities are not gated behind a preview feature: ADR-0014 was
+implemented on 2025-12-27, and everything specified here compiles with no
+`--preview` flag. As §3.7:2 states, the only thing a program needs in order to
+name `StrBuf` is an explicit import of the trusted standard-library module.
 
 ## StrBuf Representation
 
@@ -175,11 +178,27 @@ fn main() -> i32 {
 
 {{ rule(id="3.10:24", cat="dynamic-semantics") }}
 
-When appending would exceed the current capacity, a new buffer is allocated with double the current capacity (minimum 16 bytes). The existing content is copied and the old buffer is freed.
+When appending would exceed the current capacity, a new buffer is allocated
+whose capacity is at least the required capacity (the current length plus the
+appended bytes), the existing content is copied into it, and the old buffer is
+freed. The capacity actually chosen is implementation-defined (§3.7:41): the
+only guarantees are that it is sufficient for the append and that growth is
+amortized, so that a sequence of appends costs O(1) amortized time per appended
+byte. A program **MUST NOT** assume any particular resulting value from
+`capacity()`.
 
 {{ rule(id="3.10:25", cat="informative") }}
 
-The doubling growth strategy amortizes allocation cost over many appends, providing O(1) amortized time per append.
+This implementation chooses that capacity by starting from the larger of the
+current capacity and 16 bytes and doubling until it reaches the required
+capacity. Two consequences are worth naming, because the earlier "double the
+current capacity" wording implied otherwise. Growth from a literal or an empty
+buffer lands on 16 however few bytes were appended; and a single append can
+*more than* double the capacity, because the doubling is a loop rather than one
+step. Appending 5 bytes to an empty `StrBuf` gives capacity 16, and appending 30
+more (35 required) then runs 16 → 32 → 64, giving capacity 64 rather than 32.
+The loop is what provides the amortized bound of 3.10:24; it is not itself a
+requirement, and a later release may choose differently.
 
 ## Clone
 

--- a/docs/spec/src/04-expressions/13-intrinsics.md
+++ b/docs/spec/src/04-expressions/13-intrinsics.md
@@ -92,15 +92,15 @@ full semantics):
 | `@ptr_offset` | Pointer arithmetic | 2 expressions (`ptr T`, integer) | `ptr T` |
 | `@ptr_to_int` | Pointer to integer | 1 expression (pointer) | `u64` |
 | `@int_to_ptr` | Integer to pointer | 1 expression (`u64`) | inferred `ptr mut T` |
-| `@alloc` | Allocate a heap block | 1 expression (`u64` count) | inferred `ptr mut T` |
-| `@free` | Free a heap block | 2 expressions (`ptr mut T`, `u64` count) | `()` |
-| `@realloc` | Resize a heap block | 3 expressions (`ptr mut T`, `u64`, `u64`) | `ptr mut T` |
-| `@alloc_bytes` | Allocate physical bytes with alignment | 2 expressions (`u64` size, `u64` align) | `ptr mut u8` |
-| `@free_bytes` | Free physical bytes | 3 expressions (`ptr mut u8`, `u64` size, `u64` align) | `()` |
-| `@realloc_bytes` | Resize physical bytes with alignment | 4 expressions (`ptr mut u8`, `u64` old size, `u64` align, `u64` new size) | `ptr mut u8` |
+| `@alloc` | Allocate physical bytes with alignment (§9.2) | 2 expressions (`u64` size, `u64` align) | `ptr mut u8` |
+| `@alloc_zeroed` | Allocate zero-filled physical bytes (§9.2) | 2 expressions (`u64` size, `u64` align) | `ptr mut u8` |
+| `@free` | Free an allocated block (§9.2) | 3 expressions (`ptr mut u8`, `u64` size, `u64` align) | `()` |
+| `@realloc` | Resize an allocated block, possibly moving it (§9.2) | 4 expressions (`ptr mut u8`, `u64` old size, `u64` align, `u64` new size) | `ptr mut u8` |
+| `@resize` | Resize an allocated block in place only (§9.2) | 4 expressions (`ptr mut u8`, `u64` old size, `u64` align, `u64` new size) | `bool` |
 | `@byte_read` | Read one physical byte | 2 expressions (`ptr const u8`/`ptr mut u8`, `u64`) | `u8` |
 | `@byte_write` | Write one physical byte | 3 expressions (`ptr mut u8`, `u64`, `u8`) | `()` |
 | `@byte_copy` | Copy `size` non-overlapping bytes | 3 expressions (`ptr mut u8`, `ptr const u8`/`ptr mut u8`, `u64`) | `()` |
+| `@byte_move` | Copy `size` possibly overlapping bytes (§9.2) | 3 expressions (`ptr mut u8`, `ptr const u8`/`ptr mut u8`, `u64`) | `()` |
 | `@byte_set` | Fill `size` bytes with a byte | 3 expressions (`ptr mut u8`, `u8`, `u64`) | `()` |
 | `@arg_ptr` | Pointer to argument `i`'s bytes (null out of range) | 1 expression (`u64` index) | `ptr mut u8` |
 | `@env_ptr` | Pointer to environment entry `i`'s bytes (null out of range) | 1 expression (`u64` index) | `ptr mut u8` |

--- a/docs/spec/src/04-expressions/13-intrinsics.md
+++ b/docs/spec/src/04-expressions/13-intrinsics.md
@@ -58,7 +58,7 @@ Expression intrinsics (usable in any expression position):
 | `@wrapping_add` | Wrapping (modular) addition (§4.13:97) | 2 expressions (same integer type) | that integer type |
 | `@wrapping_sub` | Wrapping (modular) subtraction (§4.13:97) | 2 expressions (same integer type) | that integer type |
 | `@wrapping_mul` | Wrapping (modular) multiplication (§4.13:97) | 2 expressions (same integer type) | that integer type |
-| `@to_string` | Format an integer as its decimal `StrBuf` | 1 expression (any integer) | `StrBuf` |
+| `@to_string` | Format an integer as its decimal `StrBuf` (requires a lexical `@import("std")` in the file; §3.7:22) | 1 expression (any integer) | `StrBuf` |
 | `@drop` | Run a value's drop glue and consume it (RUE-187) | 1 expression (any type) | `()` |
 | `@read_line` | Read line from stdin | none | `Option(StrBuf)` |
 | `@parse_i32` | Parse text to i32 | 1 expression (any text rung) | `Option(i32)` |

--- a/docs/spec/src/08-runtime-behavior/06-allocation-failure.md
+++ b/docs/spec/src/08-runtime-behavior/06-allocation-failure.md
@@ -30,8 +30,8 @@ allocation-failure trap terminates the program.
 
 {{ rule(id="8.6:4", cat="normative") }}
 
-The raw `@alloc`, `@realloc`, `@alloc_bytes`, and `@realloc_bytes` intrinsics
-are not safe, infallible allocation APIs. Allocator failure returns null as
-specified by §9.2, and does not itself produce the safe allocation-failure
-trap; checked code using these raw intrinsics is responsible for handling a
-null result.
+The raw `@alloc`, `@alloc_zeroed`, and `@realloc` intrinsics are not safe,
+infallible allocation APIs. Allocator failure returns null as specified by
+§9.2, and does not itself produce the safe allocation-failure trap; checked
+code using these raw intrinsics is responsible for handling a null result.
+`@resize` likewise never traps: it reports refusal as `false`.

--- a/docs/spec/src/09-unchecked-code/02-intrinsics.md
+++ b/docs/spec/src/09-unchecked-code/02-intrinsics.md
@@ -49,7 +49,7 @@ fn main() -> i32 {
         // A syscall buffer must be a contiguous byte image; allocate it on the
         // heap (@alloc storage is the compact image) rather than an @raw of a
         // frame-resident byte array, whose storage is slot-shaped (§3.6, ADR-0040).
-        let msg: ptr mut u8 = @alloc(3); // "HI\n"
+        let msg: ptr mut u8 = @alloc(3, 1); // "HI\n"
         @ptr_write(msg, 72);
         @ptr_write(@ptr_offset(msg, 1), 73);
         @ptr_write(@ptr_offset(msg, 2), 10);
@@ -57,7 +57,7 @@ fn main() -> i32 {
         let msg_ptr: u64 = @ptr_to_int(msg);
         let msg_len: u64 = 3;
         let result = @syscall(write_num, fd, msg_ptr, msg_len);
-        @free(msg, 3);
+        @free(msg, 3, 1);
 
         // exit_group(code)
         @syscall(exit_num, code);
@@ -102,62 +102,98 @@ fn main() -> i32 {
 
 {{ rule(id="9.2:9", cat="normative") }}
 
-The `@alloc`, `@free`, and `@realloc` intrinsics provide raw, unchecked access
-to the heap. Like the raw-pointer intrinsics they may only appear inside a
-`checked` block (§9.1). They are the primitives on which safe, owned
-collections (for example a source-level `ArrayBuf`) are built: the unsafety is
-confined to the collection's internals behind a checked API.
+The `@alloc`, `@alloc_zeroed`, `@free`, `@realloc`, and `@resize` intrinsics
+provide raw, unchecked access to the heap. Like the raw-pointer intrinsics they
+may only appear inside a `checked` block (§9.1). They form **one byte-oriented
+allocation family**: every size is a count of physical bytes, every allocation
+states an explicit alignment, and every pointer is `ptr mut u8`. Allocating
+storage for values of a type `T` is ordinary source arithmetic over the
+reflection intrinsics — `@alloc(count * @size_of(T), @align_of(T))` — so the
+language has no separate element-counted allocator. They are the primitives on
+which safe, owned collections (for example a source-level `ArrayBuf`) are built:
+the unsafety is confined to the collection's internals behind a checked API.
 
 {{ rule(id="9.2:10", cat="dynamic-semantics") }}
 
-`@alloc(count)` allocates a heap block large enough to hold `count` elements of
-type `T` — that is, `count * size_of(T)` bytes of **uninitialized** storage —
-and returns a `ptr mut T` addressing the block. The element type `T` (and hence
-the result type `ptr mut T`) is inferred from the surrounding context, exactly
-as for `@int_to_ptr`. `count` must have type `u64`. On allocation failure the
-returned pointer is null; the caller is responsible for checking. The returned
-pointer is suitable for `@ptr_offset`/`@ptr_read`/`@ptr_write` over the
-`count` elements (element `i` at `@ptr_offset(p, i)`).
+`@alloc(size, align)` allocates `size` physical bytes of **uninitialized**
+storage aligned to `align` bytes and returns a `ptr mut u8` addressing the
+block. `@alloc_zeroed(size, align)` is identical except that every byte of the
+returned block reads as zero. On allocation failure both return null; the caller
+is responsible for checking. `@alloc(0, align)` and `@alloc_zeroed(0, align)`
+return null. The returned pointer is suitable for the byte intrinsics and, once
+converted to a `ptr mut T` addressing a correctly aligned offset, for
+`@ptr_offset`/`@ptr_read`/`@ptr_write` over the `T` values the block can hold.
 
 {{ rule(id="9.2:11", cat="dynamic-semantics") }}
 
-`@free(p, count)` releases a block previously returned by `@alloc`/`@realloc`,
-where `p` is a `ptr mut T` and `count` (a `u64`) is the element count that was
-allocated. Using `p` after it is freed is undefined behavior. Freeing a null
-pointer is permitted and has no effect.
+`@free(p, size, align)` releases a block previously returned by
+`@alloc`/`@alloc_zeroed`/`@realloc`. The `size` and `align` must equal those the
+block currently carries: the allocator keeps no per-block header, so the caller
+returns the layout. Using `p` after it is freed is undefined behavior. Freeing a
+null pointer is permitted and has no effect.
 
 {{ rule(id="9.2:12", cat="dynamic-semantics") }}
 
-`@realloc(p, old_count, new_count)` resizes the block addressed by `p` (a
-`ptr mut T`) from `old_count` to `new_count` elements and returns a `ptr mut T`
-to the resized block, which may differ from `p`. The first
-`min(old_count, new_count)` elements are preserved. If `p` is null it behaves
-like `@alloc(new_count)`. `old_count` and `new_count` must have type `u64`. The
-result type is the same pointer type as `p`. On allocation failure it returns
-null and leaves the original block allocated, with its contents unchanged; the
-caller remains responsible for freeing that original block.
+`@realloc(p, old_size, align, new_size)` resizes the block addressed by `p` from
+`old_size` to `new_size` physical bytes and returns a `ptr mut u8` to the
+resized block, which may differ from `p`. The first
+`min(old_size, new_size)` bytes are preserved and `align` must equal the
+alignment the block was allocated with. If `p` is null it behaves like
+`@alloc(new_size, align)`, including returning null when `new_size` is zero. If
+`new_size` is zero and `p` is non-null, the block is freed and null is returned.
+On allocation failure it returns null and leaves the original block allocated,
+with its contents unchanged; the caller remains responsible for freeing that
+original block.
+
+{{ rule(id="9.2:12a", cat="dynamic-semantics") }}
+
+`@resize(p, old_size, align, new_size)` is the in-place-only counterpart of
+`@realloc`: the block **never moves**. It evaluates to `true` when the block at
+`p` now describes `new_size` bytes at the same address — the caller must then
+pass `new_size` to a later `@free`/`@realloc`/`@resize` — and to `false` when
+the request was refused, in which case nothing changed and `old_size` still
+describes the block. Bytes below `min(old_size, new_size)` are preserved on
+success and no byte is written on refusal. Whether any particular request is
+satisfied in place is unspecified; a conforming implementation may always
+answer `false`, so a program's observable behavior must not depend on `true`.
+`@resize` never copies, never frees, and never allocates, so it cannot fail with
+a null result.
 
 {{ rule(id="9.2:13", cat="legality-rule") }}
 
-`@alloc`, `@free`, and `@realloc` may only be used inside a `checked` block. The
-element-count arguments (`count`, `old_count`, `new_count`) must be `u64`, and
-the pointer arguments of `@free`/`@realloc` must be a mutable pointer
-`ptr mut T`. The result type of `@alloc` must be resolvable to a `ptr mut T`
-from context.
+`@alloc`, `@alloc_zeroed`, `@free`, `@realloc`, and `@resize` may only be used
+inside a `checked` block. Every size and alignment operand (`size`, `align`,
+`old_size`, `new_size`) must be `u64`, and the pointer operand of
+`@free`/`@realloc`/`@resize` must be `ptr mut u8`. `@alloc` and `@alloc_zeroed`
+evaluate to `ptr mut u8`, `@realloc` to `ptr mut u8`, `@resize` to `bool`, and
+`@free` to `()`.
+
+{{ rule(id="9.2:13a", cat="legality-rule") }}
+
+The `align` argument of every intrinsic in this family is a byte count that must
+be a power of two. When `align` is a compile-time constant that is zero or not a
+power of two, the program is rejected at compile time. A non-constant `align` is
+not checked at compile time; supplying a value that is zero or not a power of
+two is then undefined behavior (§9.1, ADR-0028), like the other unchecked
+contracts of this family.
 
 {{ rule(id="9.2:14", cat="example") }}
 
 ```rue
 fn main() -> i32 {
     checked {
-        // Allocate room for 4 i32s, write three, read one back, then free.
-        let p: ptr mut i32 = @alloc(4);
+        // Room for 4 i32s, computed from the type's own layout.
+        let unit: u64 = @intCast(@size_of(i32));
+        let align: u64 = @intCast(@align_of(i32));
+        let raw: ptr mut u8 = @alloc(4 * unit, align);
+        let p: ptr mut i32 = @int_to_ptr(@ptr_to_int(raw));
         @ptr_write(p, 10);
         @ptr_write(@ptr_offset(p, 1), 20);
         @ptr_write(@ptr_offset(p, 2), 30);
-        let grown: ptr mut i32 = @realloc(p, 4, 8); // contents preserved
+        let grown_raw: ptr mut u8 = @realloc(raw, 4 * unit, align, 8 * unit);
+        let grown: ptr mut i32 = @int_to_ptr(@ptr_to_int(grown_raw));
         let v: i32 = @ptr_read(@ptr_offset(grown, 1)); // 20
-        @free(grown, 8);
+        @free(grown_raw, 8 * unit, align);
         v
     }
 }
@@ -167,36 +203,11 @@ fn main() -> i32 {
 
 {{ rule(id="9.2:14a", cat="normative") }}
 
-The `@alloc_bytes`, `@realloc_bytes`, `@free_bytes`, `@byte_read`,
-`@byte_write`, `@byte_copy`, `@byte_set`, `@ptr_read_unaligned`, and
-`@ptr_write_unaligned` intrinsics provide raw access to packed physical bytes
-and to potentially unaligned typed scalars. They may only appear inside a
-`checked` block. They do not change the element-scaled semantics of `@alloc`,
-`@realloc`, `@free`, `@ptr_offset`, `@ptr_read`, or `@ptr_write`.
-
-{{ rule(id="9.2:14b", cat="dynamic-semantics") }}
-
-`@alloc_bytes(size, align)` allocates `size` physical bytes of uninitialized
-storage aligned to `align` bytes and returns `ptr mut u8`. `@free_bytes(p, size,
-align)` releases a block returned by `@alloc_bytes` or `@realloc_bytes`; the
-`size` and `align` passed to `@free_bytes` must equal those used to allocate the
-block, and freeing a null pointer is permitted. All `size` and `align` arguments
-have type `u64`, and `align` must be a power of two (9.2:14j). Allocation failure
-returns null and does not trap. `@alloc_bytes(0, align)` returns null.
-`@free_bytes(null, 0, align)` is permitted and has no effect.
-
-{{ rule(id="9.2:14c", cat="dynamic-semantics") }}
-
-`@realloc_bytes(p, old_size, align, new_size)` resizes a raw-byte block. The
-first `min(old_size, new_size)` physical bytes are preserved. The `align` must
-equal the alignment used to allocate the block, and behaves as an allocation
-with that alignment; a null `p` behaves like `@alloc_bytes(new_size, align)`. On
-failure it returns null and leaves the original block allocated and unchanged.
-
-If `new_size` is zero, `@realloc_bytes(p, old_size, align, 0)` frees a non-null
-`p` and returns null. If `p` is null, reallocation behaves like
-`@alloc_bytes(new_size, align)`, including returning null when `new_size` is
-zero.
+The `@byte_read`, `@byte_write`, `@byte_copy`, `@byte_move`, `@byte_set`,
+`@ptr_read_unaligned`, and `@ptr_write_unaligned` intrinsics provide raw access
+to packed physical bytes and to potentially unaligned typed scalars. They may
+only appear inside a `checked` block. Every count and offset they take is a
+number of physical bytes; none is multiplied by a pointee width.
 
 {{ rule(id="9.2:14d", cat="dynamic-semantics") }}
 
@@ -208,23 +219,20 @@ Offsets are not multiplied by Rue's typed-pointer slot size.
 
 {{ rule(id="9.2:14e", cat="legality-rule") }}
 
-Every raw-byte intrinsic requires an enclosing
-`checked` block. Allocation and write pointers must be `ptr mut u8`; a byte
-read also accepts `ptr const u8`. Size, offset, and alignment operands are
-exactly `u64`, and a byte-write value is exactly `u8`. `@alloc_bytes` takes
-`(size, align)`, `@realloc_bytes` takes `(p, old_size, align, new_size)`, and
-`@free_bytes` takes `(p, size, align)`.
+Every raw-byte intrinsic requires an enclosing `checked` block. Write pointers
+must be `ptr mut u8`; a byte read also accepts `ptr const u8`. Size and offset
+operands are exactly `u64`, and a byte-write value is exactly `u8`.
 
 {{ rule(id="9.2:14f", cat="example") }}
 
 ```rue
 fn main() -> i32 {
     checked {
-        let p = @alloc_bytes(2, 1);
+        let p = @alloc(2, 1);
         @byte_write(p, 0, 65);
         @byte_write(p, 1, 66);
         let result: i32 = @intCast(@byte_read(p, 1));
-        @free_bytes(p, 2, 1);
+        @free(p, 2, 1);
         result // 66
     }
 }
@@ -235,49 +243,44 @@ fn main() -> i32 {
 `@byte_copy(dst, src, size)` copies exactly `size` physical bytes from the
 region beginning at `src` to the region beginning at `dst`, in the manner of a
 memcpy. The two regions must not overlap; a call in which `[dst, dst + size)`
-and `[src, src + size)` overlap is undefined behavior (§9.1, ADR-0028). `dst`
-must be `ptr mut u8`; `src` may be `ptr const u8` or `ptr mut u8`. `@byte_set(dst,
-byte, size)` writes the `u8` value `byte` to each of the `size` physical bytes
-beginning at `dst`, in the manner of a memset; `dst` must be `ptr mut u8`. In
-both intrinsics `size` has type `u64`, byte counts are not multiplied by Rue's
-typed-pointer slot size, and a `size` of zero performs no access and reads and
-writes no memory.
+and `[src, src + size)` overlap is undefined behavior (§9.1, ADR-0028).
+`@byte_move(dst, src, size)` copies the same bytes in the manner of a memmove:
+the two regions **may** overlap, and the result is as if the `size` source bytes
+were first read into a temporary region and then written to `dst`, so every
+source byte is observed before any destination byte overwrites it. In both, `dst`
+must be `ptr mut u8` and `src` may be `ptr const u8` or `ptr mut u8`.
+`@byte_set(dst, byte, size)` writes the `u8` value `byte` to each of the `size`
+physical bytes beginning at `dst`, in the manner of a memset; `dst` must be
+`ptr mut u8`. In all three intrinsics `size` has type `u64`, byte counts are not
+multiplied by a pointee width, and a `size` of zero performs no access and reads
+and writes no memory.
 
 {{ rule(id="9.2:14h", cat="legality-rule") }}
 
-`@byte_copy` and `@byte_set` each require an
-enclosing `checked` block. Their destination operand is exactly `ptr mut u8`;
-the `@byte_copy` source operand is `ptr const u8` or `ptr mut u8`. The
-`@byte_set` fill operand is exactly `u8`, and every `size` operand is exactly
-`u64`. Both intrinsics evaluate to `()`.
+`@byte_copy`, `@byte_move`, and `@byte_set` each require an enclosing `checked`
+block. Their destination operand is exactly `ptr mut u8`; the `@byte_copy` and
+`@byte_move` source operand is `ptr const u8` or `ptr mut u8`. The `@byte_set`
+fill operand is exactly `u8`, and every `size` operand is exactly `u64`. All
+three intrinsics evaluate to `()`.
 
 {{ rule(id="9.2:14i", cat="example") }}
 
 ```rue
 fn main() -> i32 {
     checked {
-        let src = @alloc_bytes(3, 1);
+        let src = @alloc(3, 1);
         @byte_set(src, 7, 3);
-        let dst = @alloc_bytes(3, 1);
+        let dst = @alloc(3, 1);
         @byte_copy(dst, src, 3);
         let result: i32 = @intCast(@byte_read(dst, 0))
             + @intCast(@byte_read(dst, 1))
             + @intCast(@byte_read(dst, 2));
-        @free_bytes(src, 3, 1);
-        @free_bytes(dst, 3, 1);
+        @free(src, 3, 1);
+        @free(dst, 3, 1);
         result // 21
     }
 }
 ```
-
-{{ rule(id="9.2:14j", cat="legality-rule") }}
-
-The `align` argument to `@alloc_bytes`, `@realloc_bytes`, and `@free_bytes` is a
-byte count that must be a power of two. When `align` is a compile-time constant
-that is zero or not a power of two, the program is rejected at compile time.
-A non-constant `align` is not checked at compile time; supplying a value that is
-zero or not a power of two is then undefined behavior (§9.1, ADR-0028), like the
-other unchecked contracts of this family.
 
 {{ rule(id="9.2:14k", cat="dynamic-semantics") }}
 
@@ -304,10 +307,13 @@ and a written value has type `T`.
 ```rue
 fn main() -> i32 {
     checked {
-        let p: ptr mut i32 = @alloc(1);
+        let bytes: u64 = @intCast(@size_of(i32));
+        let align: u64 = @intCast(@align_of(i32));
+        let raw: ptr mut u8 = @alloc(bytes, align);
+        let p: ptr mut i32 = @int_to_ptr(@ptr_to_int(raw));
         @ptr_write_unaligned(p, 1234);
         let v: i32 = @ptr_read_unaligned(p);
-        @free(p, 1);
+        @free(raw, bytes, align);
         v // 1234
     }
 }

--- a/docs/spec/src/appendices/B-undefined-behavior.md
+++ b/docs/spec/src/appendices/B-undefined-behavior.md
@@ -36,7 +36,7 @@ implementation:
 |----------|----------------------------------|
 | **Undefined** | None. A program that exhibits undefined behavior is invalid and the implementation may do anything. In Rue this arises **only within `unchecked` code** (see B.3). |
 | **Unspecified** | Choose from a permitted set of behaviors; no particular choice is required and none need be documented. Rue specifies most such choices (e.g. evaluation order §4.0, drop order §3.9), so this category has few instances today. |
-| **Implementation-defined** | Choose from a permitted set **and document** the choice. Examples: `StrBuf` growth/capacity (§3.7), struct and array layout (§3.6), the width of `usize`/`isize` (§3.1), and the limits of Appendix C. |
+| **Implementation-defined** | Choose from a permitted set **and document** the choice. Examples: `StrBuf` growth/capacity (§3.7:41, documented in §3.10:25 — and *observable*, since `capacity()` (§3.10:11) returns the chosen value, so a program that branches on it is not portable), struct and array layout (§3.6), the width of `usize`/`isize` (§3.1), and the limits of Appendix C. |
 | **Erroneous** | Well-defined behavior that is nonetheless a program error a conforming implementation is encouraged to diagnose. Rue currently has **no** erroneous behavior — conditions other languages leave erroneous (e.g. integer overflow) Rue instead *traps* as a defined panic (see B.2). |
 
 {{ rule(id="B.1:3", cat="informative") }}

--- a/docs/spec/src/appendices/B-undefined-behavior.md
+++ b/docs/spec/src/appendices/B-undefined-behavior.md
@@ -172,7 +172,7 @@ defines it.
 | Mutating storage through a `ptr mut T` while another live pointer aliases the same storage in a way the program's reasoning assumes cannot happen (aliasing violation). | ADR-0028 |
 | Accessing storage through a pointer that does not satisfy the pointee type's alignment requirement. | ADR-0028 |
 | Reading or writing with `@byte_read`/`@byte_write` when `address_of(p) + offset` is not a live byte within the referenced storage, including null, out-of-bounds, use-after-free, and overflowed-address access. | §9.2 (9.2:14d) |
-| Passing an incorrect size, a pointer from a different allocation family, or an already-freed pointer to `@free_bytes`/`@realloc_bytes`. | §9.2 (9.2:14b–14c) |
+| Passing an incorrect size or alignment, a pointer not returned by the allocation family, or an already-freed pointer to `@free`/`@realloc`/`@resize`. | §9.2 (9.2:11–13) |
 
 {{ rule(id="B.3:3", cat="informative") }}
 

--- a/docs/spec/src/appendices/C-implementation-limits.md
+++ b/docs/spec/src/appendices/C-implementation-limits.md
@@ -57,11 +57,13 @@ An array length is a compile-time value of type `u64`, so the language itself ad
 
 {{ rule(id="C.4:2") }}
 
-An array whose element count is legal for the type system may still be rejected: the binding constraint is the total layout size of the array type, not the element count on its own, and not available memory.
+An array whose element count is legal for the type system may still be rejected: the binding constraint is the number of ABI slots the array type's layout occupies (C.4:3), not available memory. A layout spends one 8-byte slot per scalar, per struct field, and per array element, *whatever the element's own width* — so for an array the slot count is exactly the element count times the element type's own slot count, and for an array of scalars it is exactly the element count. A narrow element type therefore buys no extra headroom: `[i8; N]` and `[i64; N]` reach the ceiling at the same `N`.
 
 {{ rule(id="C.4:3") }}
 
-The current implementation limits any single object (including an array type) to 2,147,483,647 bytes (`i32::MAX`), matching the code generator's frame-offset addressing range. A type whose layout exceeds this limit is rejected with a diagnostic (E0906) wherever a value of the type would be materialized — a variable, a parameter, or a `@size_of`/`@align_of` query.
+The current implementation limits any single object (including an array type) to 268,435,455 ABI slots. That ceiling is the code generator's frame-offset addressing range (`i32::MAX`, 2,147,483,647 bytes) divided by the 8-byte slot width, so a layout that fits it is always addressable by a signed 32-bit displacement. A type whose layout needs more slots is rejected with a diagnostic (E0906) wherever a value of the type would be materialized — a variable, a parameter, or a `@size_of`/`@align_of` query — and the diagnostic names the slot ceiling, as C.1:2 requires.
+
+Because the check counts slots rather than bytes, it binds well below 2,147,483,647 bytes for any element narrower than 8 bytes: `[i8; 268435455]` is accepted and reports `@size_of` of 268,435,455 (about 256 MiB), while `[i8; 268435456]` — one element more, and still only about 256 MiB — is rejected. Only an object built entirely from 8-byte scalars reaches the ceiling and the byte range together.
 
 The cumulative storage for one function is limited to 2,147,483,632 bytes: the
 largest 16-byte-aligned value within that same signed displacement range.
@@ -99,7 +101,7 @@ The compiler stores syntax, untyped IR, and typed IR in compact index-based form
 | Variants of one enum | 4,294,967,295 | 1 payload word per variant; the discriminant tag widens to at most `u32` | E1401, via the shared word store |
 | Elements of one array literal | 4,294,967,295 | 1 payload word per element | E1401, via the shared word store |
 | Distinct composite types (structs, enums, arrays, pointers, modules) | 16,777,216 | `Type` is a `u32`: an 8-bit kind tag plus a 24-bit type-pool index | E1401, at the semantic boundary |
-| Size of one object | 2,147,483,647 bytes | signed 32-bit frame displacement | E0906 |
+| ABI slots in one object's layout | 268,435,455 slots | signed 32-bit frame displacement divided by the 8-byte slot width; one slot per scalar, struct field, and array element (C.4:2) | E0906 |
 | Cumulative storage of one function | 2,147,483,632 bytes | signed 32-bit frame displacement, 16-byte aligned | E0907 |
 | Syntactic nesting depth | 256 | guarded recursion depth in the parser and RIR lowering | E0482 |
 

--- a/std/c.rue
+++ b/std/c.rue
@@ -140,7 +140,7 @@ pub const c_bool = bool;
 //
 // POINTER MUTABILITY. These are typed `ptr mut u8` (C `char*`), not
 // `ptr const u8` (C `const char*`), because Rue v0 provides no way to construct
-// or coerce to a `ptr const u8` value: `@alloc_bytes` and `@int_to_ptr` both
+// or coerce to a `ptr const u8` value: `@alloc` and `@int_to_ptr` both
 // yield `ptr mut u8`, and there is no `ptr mut → ptr const` coercion, so a
 // `ptr const u8` parameter is currently uncallable with a constructed pointer.
 // `char*` is the callable spelling of a C string boundary today; a `const
@@ -185,7 +185,7 @@ pub fn c_strlen(cstr: ptr mut u8) -> u64 {
 /// fail-fast, matching StrBuf's allocator convention.
 pub fn owned_c_string(borrow source: strbuf.StrBuf) -> ptr mut u8 {
     let len = source.len();
-    let buf: ptr mut u8 = checked { @alloc_bytes(len + 1, 1) };
+    let buf: ptr mut u8 = checked { @alloc(len + 1, 1) };
     if checked { @ptr_to_int(buf) } == 0 {
         @panic("out of memory");
     }
@@ -230,5 +230,5 @@ pub fn free_c_string(cstr: ptr mut u8) {
     while checked { @byte_read(cstr, len) } != 0 {
         len += 1;
     }
-    checked { @free_bytes(cstr, len + 1, 1); };
+    checked { @free(cstr, len + 1, 1); };
 }

--- a/std/fs.rue
+++ b/std/fs.rue
@@ -527,7 +527,7 @@ fn _normalize_macos(e: i64) -> FileError {
 
 fn _path_to_cbuf(borrow path: strbuf.StrBuf) -> ptr mut u8 {
     let n = path.len();
-    let buf: ptr mut u8 = checked { @alloc_bytes(n + 1, 1) };
+    let buf: ptr mut u8 = checked { @alloc(n + 1, 1) };
     if checked { @ptr_to_int(buf) } == 0 {
         @panic("out of memory");
     }
@@ -562,7 +562,7 @@ pub struct File {
         let addr: u64 = checked { @ptr_to_int(cbuf) };
         let free_len = path.len() + 1;
         let ret: i64 = checked { @syscall(_sys_openat(), _at_fdcwd(), addr, flags, mode) };
-        checked { @free_bytes(cbuf, free_len, 1); };
+        checked { @free(cbuf, free_len, 1); };
         if ret < 0 {
             R.Err(_normalize_errno(0 - ret))
         } else {
@@ -606,7 +606,7 @@ pub struct File {
             // A full buffer is a caller error, distinct from EOF (Ok(0)).
             return R.Err(FileError.InvalidInput);
         }
-        let tmp: ptr mut u8 = checked { @alloc_bytes(want, 1) };
+        let tmp: ptr mut u8 = checked { @alloc(want, 1) };
         if checked { @ptr_to_int(tmp) } == 0 {
             @panic("out of memory");
         }
@@ -614,7 +614,7 @@ pub struct File {
         let fd_u: u64 = @intCast(self.fd);
         let ret: i64 = checked { @syscall(_sys_read(), fd_u, addr, want) };
         if ret < 0 {
-            checked { @free_bytes(tmp, want, 1); };
+            checked { @free(tmp, want, 1); };
             return R.Err(_normalize_errno(0 - ret));
         }
         let n: u64 = @intCast(ret);
@@ -624,7 +624,7 @@ pub struct File {
             buf.push(b);
             i += 1;
         }
-        checked { @free_bytes(tmp, want, 1); };
+        checked { @free(tmp, want, 1); };
         R.Ok(n)
     }
 
@@ -638,7 +638,7 @@ pub struct File {
         if n == 0 {
             return R.Ok(0);
         }
-        let tmp: ptr mut u8 = checked { @alloc_bytes(n, 1) };
+        let tmp: ptr mut u8 = checked { @alloc(n, 1) };
         if checked { @ptr_to_int(tmp) } == 0 {
             @panic("out of memory");
         }
@@ -650,7 +650,7 @@ pub struct File {
         let addr: u64 = checked { @ptr_to_int(tmp) };
         let fd_u: u64 = @intCast(self.fd);
         let ret: i64 = checked { @syscall(_sys_write(), fd_u, addr, n) };
-        checked { @free_bytes(tmp, n, 1); };
+        checked { @free(tmp, n, 1); };
         if ret < 0 {
             R.Err(_normalize_errno(0 - ret))
         } else {
@@ -665,7 +665,7 @@ pub struct File {
         if n == 0 {
             return R.Ok(());
         }
-        let tmp: ptr mut u8 = checked { @alloc_bytes(n, 1) };
+        let tmp: ptr mut u8 = checked { @alloc(n, 1) };
         if checked { @ptr_to_int(tmp) } == 0 {
             @panic("out of memory");
         }
@@ -686,20 +686,20 @@ pub struct File {
                     _ => false,
                 };
                 if !retry {
-                    checked { @free_bytes(tmp, n, 1); };
+                    checked { @free(tmp, n, 1); };
                     return R.Err(e);
                 }
             } else {
                 let wrote: u64 = @intCast(ret);
                 if wrote == 0 {
                     // No progress on a non-error write; stop rather than spin.
-                    checked { @free_bytes(tmp, n, 1); };
+                    checked { @free(tmp, n, 1); };
                     return R.Err(FileError.Other(0));
                 }
                 off += wrote;
             }
         }
-        checked { @free_bytes(tmp, n, 1); };
+        checked { @free(tmp, n, 1); };
         R.Ok(())
     }
 
@@ -745,7 +745,7 @@ pub struct File {
     fn metadata(inout self) -> result.Result(Metadata, FileError) {
         let R = result.Result(Metadata, FileError);
         let sz = _stat_buf_size();
-        let buf: ptr mut u8 = checked { @alloc_bytes(sz, 8) };
+        let buf: ptr mut u8 = checked { @alloc(sz, 8) };
         if checked { @ptr_to_int(buf) } == 0 {
             @panic("out of memory");
         }
@@ -753,11 +753,11 @@ pub struct File {
         let fd_u: u64 = @intCast(self.fd);
         let ret: i64 = checked { @syscall(_sys_fstat(), fd_u, addr) };
         if ret < 0 {
-            checked { @free_bytes(buf, sz, 8); };
+            checked { @free(buf, sz, 8); };
             return R.Err(_normalize_errno(0 - ret));
         }
         let md = _decode_stat(buf);
-        checked { @free_bytes(buf, sz, 8); };
+        checked { @free(buf, sz, 8); };
         R.Ok(md)
     }
 
@@ -809,20 +809,20 @@ pub fn metadata(borrow path: strbuf.StrBuf) -> result.Result(Metadata, FileError
     let free_len = path.len() + 1;
 
     let sz = _stat_buf_size();
-    let sbuf: ptr mut u8 = checked { @alloc_bytes(sz, 8) };
+    let sbuf: ptr mut u8 = checked { @alloc(sz, 8) };
     if checked { @ptr_to_int(sbuf) } == 0 {
         @panic("out of memory");
     }
     let saddr: u64 = checked { @ptr_to_int(sbuf) };
     let no_flags: u64 = 0; // follow symlinks (AT_SYMLINK_NOFOLLOW unset)
     let ret: i64 = checked { @syscall(_sys_newfstatat(), _at_fdcwd(), paddr, saddr, no_flags) };
-    checked { @free_bytes(cbuf, free_len, 1); };
+    checked { @free(cbuf, free_len, 1); };
     if ret < 0 {
-        checked { @free_bytes(sbuf, sz, 8); };
+        checked { @free(sbuf, sz, 8); };
         return R.Err(_normalize_errno(0 - ret));
     }
     let md = _decode_stat(sbuf);
-    checked { @free_bytes(sbuf, sz, 8); };
+    checked { @free(sbuf, sz, 8); };
     R.Ok(md)
 }
 
@@ -837,8 +837,8 @@ pub fn rename(borrow from: strbuf.StrBuf, borrow to: strbuf.StrBuf) -> result.Re
     let taddr: u64 = checked { @ptr_to_int(tbuf) };
     let tlen = to.len() + 1;
     let ret: i64 = checked { @syscall(_sys_renameat(), _at_fdcwd(), faddr, _at_fdcwd(), taddr) };
-    checked { @free_bytes(fbuf, flen, 1); };
-    checked { @free_bytes(tbuf, tlen, 1); };
+    checked { @free(fbuf, flen, 1); };
+    checked { @free(tbuf, tlen, 1); };
     if ret < 0 {
         R.Err(_normalize_errno(0 - ret))
     } else {
@@ -855,7 +855,7 @@ pub fn remove(borrow path: strbuf.StrBuf) -> result.Result((), FileError) {
     let free_len = path.len() + 1;
     let no_flags: u64 = 0; // no AT_REMOVEDIR: unlink a file, not a directory
     let ret: i64 = checked { @syscall(_sys_unlinkat(), _at_fdcwd(), addr, no_flags) };
-    checked { @free_bytes(cbuf, free_len, 1); };
+    checked { @free(cbuf, free_len, 1); };
     if ret < 0 {
         R.Err(_normalize_errno(0 - ret))
     } else {
@@ -872,7 +872,7 @@ pub fn create_dir(borrow path: strbuf.StrBuf) -> result.Result((), FileError) {
     let addr: u64 = checked { @ptr_to_int(cbuf) };
     let free_len = path.len() + 1;
     let ret: i64 = checked { @syscall(_sys_mkdirat(), _at_fdcwd(), addr, _dir_mode()) };
-    checked { @free_bytes(cbuf, free_len, 1); };
+    checked { @free(cbuf, free_len, 1); };
     if ret < 0 {
         R.Err(_normalize_errno(0 - ret))
     } else {
@@ -888,7 +888,7 @@ pub fn remove_dir(borrow path: strbuf.StrBuf) -> result.Result((), FileError) {
     let addr: u64 = checked { @ptr_to_int(cbuf) };
     let free_len = path.len() + 1;
     let ret: i64 = checked { @syscall(_sys_unlinkat(), _at_fdcwd(), addr, _at_removedir()) };
-    checked { @free_bytes(cbuf, free_len, 1); };
+    checked { @free(cbuf, free_len, 1); };
     if ret < 0 {
         R.Err(_normalize_errno(0 - ret))
     } else {

--- a/std/net.rue
+++ b/std/net.rue
@@ -299,9 +299,9 @@ fn _normalize_net_errno(e: i64) -> NetworkError {
 // heap buffer. A `[u8; 16]` VALUE lives in 8-byte logical slots (ADR-0040),
 // so its storage is not the contiguous byte image the kernel needs; this is
 // the one copy from value space into byte space. Caller frees with
-// `@free_bytes(buf, sockaddr_in_len(), 1)`.
+// `@free(buf, sockaddr_in_len(), 1)`.
 fn _sockaddr_to_kernel_buf(b: [u8; 16]) -> ptr mut u8 {
-    let buf: ptr mut u8 = checked { @alloc_bytes(sockaddr_in_len(), 1) };
+    let buf: ptr mut u8 = checked { @alloc(sockaddr_in_len(), 1) };
     if checked { @ptr_to_int(buf) } == 0 {
         @panic("out of memory");
     }
@@ -360,7 +360,7 @@ pub struct TcpStream {
         let baddr: u64 = checked { @ptr_to_int(buf) };
         let fd_u: u64 = @intCast(fd);
         let ret: i64 = checked { @syscall(_sys_connect(), fd_u, baddr, sockaddr_in_len()) };
-        checked { @free_bytes(buf, sockaddr_in_len(), 1); };
+        checked { @free(buf, sockaddr_in_len(), 1); };
         if ret < 0 {
             _close_raw(fd);
             return R.Err(_normalize_net_errno(0 - ret));
@@ -378,7 +378,7 @@ pub struct TcpStream {
         if want == 0 {
             return R.Err(NetworkError.InvalidInput);
         }
-        let tmp: ptr mut u8 = checked { @alloc_bytes(want, 1) };
+        let tmp: ptr mut u8 = checked { @alloc(want, 1) };
         if checked { @ptr_to_int(tmp) } == 0 {
             @panic("out of memory");
         }
@@ -386,7 +386,7 @@ pub struct TcpStream {
         let fd_u: u64 = @intCast(self.fd);
         let ret: i64 = checked { @syscall(_sys_net_read(), fd_u, addr, want) };
         if ret < 0 {
-            checked { @free_bytes(tmp, want, 1); };
+            checked { @free(tmp, want, 1); };
             return R.Err(_normalize_net_errno(0 - ret));
         }
         let n: u64 = @intCast(ret);
@@ -396,7 +396,7 @@ pub struct TcpStream {
             buf.push(b);
             i += 1;
         }
-        checked { @free_bytes(tmp, want, 1); };
+        checked { @free(tmp, want, 1); };
         R.Ok(n)
     }
 
@@ -409,7 +409,7 @@ pub struct TcpStream {
         if n == 0 {
             return R.Ok(0);
         }
-        let tmp: ptr mut u8 = checked { @alloc_bytes(n, 1) };
+        let tmp: ptr mut u8 = checked { @alloc(n, 1) };
         if checked { @ptr_to_int(tmp) } == 0 {
             @panic("out of memory");
         }
@@ -421,7 +421,7 @@ pub struct TcpStream {
         let addr: u64 = checked { @ptr_to_int(tmp) };
         let fd_u: u64 = @intCast(self.fd);
         let ret: i64 = checked { @syscall(_sys_net_write(), fd_u, addr, n) };
-        checked { @free_bytes(tmp, n, 1); };
+        checked { @free(tmp, n, 1); };
         if ret < 0 {
             R.Err(_normalize_net_errno(0 - ret))
         } else {
@@ -436,7 +436,7 @@ pub struct TcpStream {
         if n == 0 {
             return R.Ok(());
         }
-        let tmp: ptr mut u8 = checked { @alloc_bytes(n, 1) };
+        let tmp: ptr mut u8 = checked { @alloc(n, 1) };
         if checked { @ptr_to_int(tmp) } == 0 {
             @panic("out of memory");
         }
@@ -457,20 +457,20 @@ pub struct TcpStream {
                     _ => false,
                 };
                 if !retry {
-                    checked { @free_bytes(tmp, n, 1); };
+                    checked { @free(tmp, n, 1); };
                     return R.Err(e);
                 }
             } else {
                 let wrote: u64 = @intCast(ret);
                 if wrote == 0 {
                     // No progress on a non-error write; stop rather than spin.
-                    checked { @free_bytes(tmp, n, 1); };
+                    checked { @free(tmp, n, 1); };
                     return R.Err(NetworkError.Other(0));
                 }
                 off += wrote;
             }
         }
-        checked { @free_bytes(tmp, n, 1); };
+        checked { @free(tmp, n, 1); };
         R.Ok(())
     }
 
@@ -543,7 +543,7 @@ pub struct TcpListener {
         let baddr: u64 = checked { @ptr_to_int(buf) };
         let fd_u: u64 = @intCast(fd);
         let bret: i64 = checked { @syscall(_sys_bind(), fd_u, baddr, sockaddr_in_len()) };
-        checked { @free_bytes(buf, sockaddr_in_len(), 1); };
+        checked { @free(buf, sockaddr_in_len(), 1); };
         if bret < 0 {
             _close_raw(fd);
             return R.Err(_normalize_net_errno(0 - bret));
@@ -562,13 +562,13 @@ pub struct TcpListener {
     // (ADR-0060 §3).
     fn local_addr(inout self) -> result.Result(SockAddr, NetworkError) {
         let R = result.Result(SockAddr, NetworkError);
-        let abuf: ptr mut u8 = checked { @alloc_bytes(sockaddr_in_len(), 1) };
+        let abuf: ptr mut u8 = checked { @alloc(sockaddr_in_len(), 1) };
         if checked { @ptr_to_int(abuf) } == 0 {
             @panic("out of memory");
         }
         // socklen_t in/out argument: starts at 16, kernel writes the actual
         // length back (little-endian u32 on both v1 targets).
-        let lbuf: ptr mut u8 = checked { @alloc_bytes(4, 1) };
+        let lbuf: ptr mut u8 = checked { @alloc(4, 1) };
         if checked { @ptr_to_int(lbuf) } == 0 {
             @panic("out of memory");
         }
@@ -581,18 +581,18 @@ pub struct TcpListener {
         let fd_u: u64 = @intCast(self.fd);
         let ret: i64 = checked { @syscall(_sys_getsockname(), fd_u, aaddr, laddr) };
         if ret < 0 {
-            checked { @free_bytes(abuf, sockaddr_in_len(), 1); };
-            checked { @free_bytes(lbuf, 4, 1); };
+            checked { @free(abuf, sockaddr_in_len(), 1); };
+            checked { @free(lbuf, 4, 1); };
             return R.Err(_normalize_net_errno(0 - ret));
         }
         let l0 = checked { @byte_read(lbuf, 0) };
         let l1 = checked { @byte_read(lbuf, 1) };
         let l2 = checked { @byte_read(lbuf, 2) };
         let l3 = checked { @byte_read(lbuf, 3) };
-        checked { @free_bytes(lbuf, 4, 1); };
+        checked { @free(lbuf, 4, 1); };
         let written_len = binary.u32_from_le_bytes([l0, l1, l2, l3]);
         if written_len != 16 {
-            checked { @free_bytes(abuf, sockaddr_in_len(), 1); };
+            checked { @free(abuf, sockaddr_in_len(), 1); };
             return R.Err(NetworkError.InvalidInput);
         }
         let b0 = checked { @byte_read(abuf, 0) };
@@ -603,7 +603,7 @@ pub struct TcpListener {
         let b5 = checked { @byte_read(abuf, 5) };
         let b6 = checked { @byte_read(abuf, 6) };
         let b7 = checked { @byte_read(abuf, 7) };
-        checked { @free_bytes(abuf, sockaddr_in_len(), 1); };
+        checked { @free(abuf, sockaddr_in_len(), 1); };
         let bytes: [u8; 16] = [b0, b1, b2, b3, b4, b5, b6, b7, 0, 0, 0, 0, 0, 0, 0, 0];
         let O = option.Option(SockAddr);
         match SockAddr.from_sockaddr_in(bytes) {

--- a/std/rawbuf.rue
+++ b/std/rawbuf.rue
@@ -7,6 +7,18 @@
 // confines every unchecked heap intrinsic (`@realloc`/`@ptr_read`/`@ptr_write`/
 // `@ptr_offset`/`@free`) behind a safe method API.
 //
+// TYPED ALLOCATION IS SOURCE-COMPUTED HERE. The allocator surface is byte- and
+// alignment-shaped (`@alloc(size, align)`, `@realloc(p, old_size, align,
+// new_size)`, `@free(p, size, align)`, all over `ptr mut u8`; ADR-0059 Phase 3,
+// RUE-961). This type is where element counts become byte counts: it computes
+// `cap * @size_of(T)` and `@align_of(T)` itself and casts the resulting
+// `ptr mut u8` to `ptr mut T` through `@int_to_ptr(@ptr_to_int(..))`, the same
+// division of labor as Rust's `RawVec` over `GlobalAlloc`. Because the byte
+// size is now ordinary source arithmetic, its overflow is the language's
+// ordinary trapping multiply rather than a compiler-internal check — but the
+// explicit `@panic("out of memory")` guard below still runs first, so an
+// oversized request is a diagnosable OOM rather than an overflow trap.
+//
 // Deliberately NOT a container: it has no `len`, runs no element drop glue, and
 // makes no growth-policy decision. Length, the amortized growth policy and its
 // floor, the trivially-droppable read gate (RUE-651), and ascending element
@@ -50,11 +62,16 @@ pub fn RawBuf(comptime T: type) -> type {
                 if new_cap > 18446744073709551615 / element_size {
                     @panic("out of memory");
                 }
+                let align: u64 = @intCast(@align_of(T));
                 checked {
-                    let grown = @realloc(self.buf, self.cap, new_cap);
-                    if @ptr_to_int(grown) == 0 {
+                    let old_bytes: u64 = self.cap * element_size;
+                    let new_bytes: u64 = new_cap * element_size;
+                    let block: ptr mut u8 = @int_to_ptr(@ptr_to_int(self.buf));
+                    let grown_block = @realloc(block, old_bytes, align, new_bytes);
+                    if @ptr_to_int(grown_block) == 0 {
                         @panic("out of memory");
                     }
+                    let grown: ptr mut T = @int_to_ptr(@ptr_to_int(grown_block));
                     self.buf = grown;
                 };
             }
@@ -82,14 +99,27 @@ pub fn RawBuf(comptime T: type) -> type {
         }
 
         // Release the allocation and reset to the empty state. Idempotent and
-        // safe on an empty buffer: `@free(null, 0)` is a no-op. Callers that have
-        // already moved/dropped the live cells use this for early release; the
-        // destructor calls the same path at scope exit.
+        // safe on an empty buffer: `@free(null, 0, align)` is a no-op. Callers
+        // that have already moved/dropped the live cells use this for early
+        // release; the destructor calls the same path at scope exit.
         fn free(inout self) {
-            checked { @free(self.buf, self.cap); };
+            self.release();
             let zero: u64 = 0;
             self.buf = checked { @int_to_ptr(zero) };
             self.cap = 0;
+        }
+
+        // Hand the block back to the allocator with exactly the `(size, align)`
+        // it was allocated with — the sizeless-allocator ABI's requirement.
+        // A zero-sized `T` never reached the allocator, so `cap * 0` is 0 and
+        // the pointer is null: the call is the documented no-op.
+        fn release(borrow self) {
+            let element_size: u64 = @intCast(@size_of(T));
+            let align: u64 = @intCast(@align_of(T));
+            checked {
+                let block: ptr mut u8 = @int_to_ptr(@ptr_to_int(self.buf));
+                @free(block, self.cap * element_size, align);
+            };
         }
 
         // Free the backing allocation when the buffer goes out of scope. The
@@ -98,7 +128,7 @@ pub fn RawBuf(comptime T: type) -> type {
         // has already run its elements' drop glue and this only reclaims storage.
         // After an explicit `free()` the pointer is null and this is a no-op.
         drop fn(self) {
-            checked { @free(self.buf, self.cap); };
+            self.release();
         }
     }
 }

--- a/std/strbuf.rue
+++ b/std/strbuf.rue
@@ -175,7 +175,7 @@ pub struct StrBuf {
 
         let new_cap = Self.growth_capacity(self.core.cap, required);
         if self.core.cap == 0 {
-            let replacement: ptr mut u8 = checked { @alloc_bytes(new_cap, 1) };
+            let replacement: ptr mut u8 = checked { @alloc(new_cap, 1) };
             if checked { @ptr_to_int(replacement) } == 0 {
                 @panic("out of memory");
             }


### PR DESCRIPTION
Four integrated work clusters from the overnight fix cycle, each developed by an isolated worker on base d55cc82 and re-verified by hand on trunk 1b4fac4d before commit.

## Codegen / CFG (c60e981f)
- Zero-sized places now form one canonical non-null alignment-1 address (ADR-0052 ruling 3) in `@raw` and inout/borrow argument formation. The filed all-ZST repro turned out not to ICE (a `saturating_sub` silently returned a neighboring local's frame address — worse); the sibling shape `struct S { a: i64, u: () }` did ICE. All four raw subtractions in `place_lower.rs` are now `checked_sub` + named ICE, and release builds can no longer wrap to a wild slot.
- `Cfg::retain_blocks` compacts unreachable blocks after DCE, renumbering entry/Goto/Branch/Switch targets. Verified: `-O1` CFG output retains zero unreachable husks.

## Unified allocation family + byte intrinsics (78d62631)
- ADR-0059 Phase 3: `@alloc(size, align)` / `@realloc(p, old, align, new)` / `@free(p, size, align)` over `ptr mut u8`; `_bytes` trio hard-removed (no alias window), std migrated in the same change. Typed allocation is source-computed sugar in `std/rawbuf.rue`.
- New: `@resize` (in-place only, returns `bool`), `@alloc_zeroed`, `@byte_move` (memmove; forward- and backward-overlap spec cases pin direction handling).
- `@offset_of` (RUE-969) verified already implemented; new spec cases pin body-position folding and `@field_ptr` agreement on slot-identical aggregates. Not closed — see the issue comment for the const-context limitation, which is general, not `@offset_of`-specific.
- Spec 9.2 rewritten for the unified family; 4.13 quick-reference and Appendix B updated to match.

## CLI JSON diagnostics audit (d5e308d1)
- Compiler panics now emit an E9000 JSON diagnostic under `--error-format=json` (graceful ICEs already did); `print_error` emits a one-element array instead of a bare object so consumers get one shape.
- Ordering determinism verified (refuted as a gap) and pinned with exact-order assertions; schema test now parses every stderr line instead of substring matching; `docs/process/diagnostics.md` added.
- Driver-level failures (missing root file, toolchain errors) still bypass JSON — filed as RUE-1323 (needs an error-code range decision).

## Spec reconciliation (e40c8b43)
- E0906 names the limit it actually enforces (268,435,455 ABI slots), and Appendix C.4/C.6 document the slot ceiling instead of the false 2 GiB byte claim.
- Chapter 3.10 loses the nonexistent `mutable_strings` preview banner; capacity documented as observable; growth demoted to implementation-defined amortized.
- `@to_string`'s lexical std-import precondition documented (3.7:22, 4.13).

## Verification
- Full CLI suite 1783/0, string/heap/intrinsic/limits spec slices green, oracle unit 103/0, `rue unit cfg` 251/0
- `scripts/rue premerge` (canonical required tier): **PASSED** on the final combined tree
- Known watch item: `large-example-caldera-slow` runs ~9m24 standalone against a 10m budget (passes; pre-existing, tracked as RUE-1077)

Fixes RUE-605
Fixes RUE-769
Fixes RUE-961
Fixes RUE-964
Fixes RUE-968
Fixes RUE-436
Fixes RUE-1272
Fixes RUE-1274
Fixes RUE-1276
Refs RUE-969

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GPYyXZHFGimCvkbzMtBG2U

---
_Generated by [Claude Code](https://claude.ai/code/session_01GPYyXZHFGimCvkbzMtBG2U)_