### PR TITLE
RUE-1328: Add contention-free validation counters

### DIFF
--- a/crates/rue-bench/src/incremental.rs
+++ b/crates/rue-bench/src/incremental.rs
@@ -10,7 +10,7 @@ use std::path::{Path, PathBuf};
 use std::time::{Duration, Instant};
 
 use rue_compiler::unstable::{
-    EndpointQueryWork, EndpointWork, MetricsSnapshot, QueryRuntimeMetrics,
+    EndpointQueryWork, EndpointWork, MetricsSnapshot, QueryRuntimeMetrics, QueryValidationMetrics,
 };
 use rue_compiler::{CompileErrors, CompileOptions, CompileOutput, CompileWarning, OptLevel};
 use rue_driver::{FilesystemCompilerHost, HostOpenRequest, SourceLoadError};
@@ -19,8 +19,8 @@ use rue_perf_schema::{
     EditReportIdentity, EditReportRegime, EditRow, EditSample, EditScenario, ExpectedEditOutcome,
     FailureStage, OptimizationSetting, OracleComparison, OutcomeIdentity, OutcomeKind, PhaseWork,
     RetainedGauges, RetentionSequence, RetentionStep, RetentionStepOutcome, SourceShape,
-    StructuralWork, TransformationIdentity, WorkerMode, canonical_json, derive_edit_report,
-    render_edit_report_markdown, validate_edit_report,
+    StructuralWork, TransformationIdentity, ValidationWork as ReportValidationWork, WorkerMode,
+    canonical_json, derive_edit_report, render_edit_report_markdown, validate_edit_report,
 };
 use serde::Deserialize;
 use sha2::{Digest, Sha256};
@@ -305,10 +305,17 @@ impl CollectionTiming {
         self.warm += other.warm;
         self.fresh_oracle += other.fresh_oracle;
         self.total += other.total;
-        self.query_runtime.validation_memo_hits += other.query_runtime.validation_memo_hits;
-        self.query_runtime.validation_memo_misses += other.query_runtime.validation_memo_misses;
-        self.query_runtime.retention_enforcements += other.query_runtime.retention_enforcements;
-        self.query_runtime.retention_scan_entries += other.query_runtime.retention_scan_entries;
+        self.query_runtime
+            .validation
+            .saturating_add_assign(other.query_runtime.validation);
+        self.query_runtime.retention_enforcements = self
+            .query_runtime
+            .retention_enforcements
+            .saturating_add(other.query_runtime.retention_enforcements);
+        self.query_runtime.retention_scan_entries = self
+            .query_runtime
+            .retention_scan_entries
+            .saturating_add(other.query_runtime.retention_scan_entries);
     }
 
     fn other(self) -> Duration {
@@ -322,6 +329,32 @@ impl CollectionTiming {
 
 fn elapsed_ms(duration: Duration) -> u128 {
     duration.as_millis()
+}
+
+fn validation_summary(work: QueryValidationMetrics) -> String {
+    format!(
+        "walks {}/{}/{}/{} total/clean/dirty/abort, edges {}/{}, nodes {}/{}/{} hit/miss/cycle, registry {}/{}, demands {}/{}/{}/{}/{}, endorsements {}/{}, superseded {}, certificates {}",
+        work.traversals,
+        work.successful_traversals,
+        work.dirty_traversals,
+        work.aborted_traversals,
+        work.input_observations,
+        work.dependency_observations,
+        work.memo_hits,
+        work.memo_misses,
+        work.active_cycle_prunes,
+        work.registry_misses,
+        work.registry_probes,
+        work.demand_reuses,
+        work.demand_computes,
+        work.demand_joins,
+        work.demand_aborts,
+        work.demands,
+        work.endorsement_hits,
+        work.endorsement_probes,
+        work.superseded,
+        work.certificates_published,
+    )
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -467,7 +500,7 @@ pub(crate) fn run() -> Result<ReportStatus, String> {
                     eprintln!(
                         "rue-bench: incremental {} {} {} sample {}/{} completed in {} ms \
                          (setup+baseline {} ms, warm {} ms, fresh-oracle {} ms, other {} ms; \
-                         validation hits {}, misses {}; retention passes {}, scan entries {})",
+                         validation {}; retention passes {}, scan entries {})",
                         workload.id,
                         declaration.scenario.wire_name(),
                         worker.mode.wire_name(),
@@ -478,14 +511,7 @@ pub(crate) fn run() -> Result<ReportStatus, String> {
                         elapsed_ms(observation.collection_timing.warm),
                         elapsed_ms(observation.collection_timing.fresh_oracle),
                         elapsed_ms(observation.collection_timing.other()),
-                        observation
-                            .collection_timing
-                            .query_runtime
-                            .validation_memo_hits,
-                        observation
-                            .collection_timing
-                            .query_runtime
-                            .validation_memo_misses,
+                        validation_summary(observation.collection_timing.query_runtime.validation),
                         observation
                             .collection_timing
                             .query_runtime
@@ -777,6 +803,7 @@ pub(crate) fn measure_sample(request: SampleRequest<'_>) -> Result<SampleObserva
         baseline_metrics.query_runtime(),
         endpoint_metrics.query_runtime(),
     );
+    let validation = report_validation_work(query_runtime.validation);
     let work = structural_work(
         &baseline_metrics,
         &endpoint_metrics,
@@ -821,6 +848,7 @@ pub(crate) fn measure_sample(request: SampleRequest<'_>) -> Result<SampleObserva
             transformation: request.operation.identity(),
             outcome,
             work,
+            validation,
             retention,
             oracle,
         },
@@ -839,18 +867,39 @@ fn query_runtime_delta(
     after: QueryRuntimeMetrics,
 ) -> QueryRuntimeMetrics {
     QueryRuntimeMetrics {
-        validation_memo_hits: after
-            .validation_memo_hits
-            .saturating_sub(before.validation_memo_hits),
-        validation_memo_misses: after
-            .validation_memo_misses
-            .saturating_sub(before.validation_memo_misses),
+        validation: after.validation.saturating_sub(before.validation),
         retention_enforcements: after
             .retention_enforcements
             .saturating_sub(before.retention_enforcements),
         retention_scan_entries: after
             .retention_scan_entries
             .saturating_sub(before.retention_scan_entries),
+    }
+}
+
+fn report_validation_work(work: QueryValidationMetrics) -> ReportValidationWork {
+    ReportValidationWork {
+        traversals: work.traversals,
+        successful_traversals: work.successful_traversals,
+        dirty_traversals: work.dirty_traversals,
+        aborted_traversals: work.aborted_traversals,
+        input_observations: work.input_observations,
+        dependency_observations: work.dependency_observations,
+        registry_probes: work.registry_probes,
+        registry_misses: work.registry_misses,
+        node_visits: work.node_visits,
+        active_cycle_prunes: work.active_cycle_prunes,
+        memo_hits: work.memo_hits,
+        memo_misses: work.memo_misses,
+        endorsement_probes: work.endorsement_probes,
+        endorsement_hits: work.endorsement_hits,
+        demands: work.demands,
+        demand_reuses: work.demand_reuses,
+        demand_computes: work.demand_computes,
+        demand_joins: work.demand_joins,
+        demand_aborts: work.demand_aborts,
+        superseded: work.superseded,
+        certificates_published: work.certificates_published,
     }
 }
 
@@ -1767,7 +1816,7 @@ mod tests {
                 eprintln!(
                     "rue-bench: maintained fixture {} {} completed in {} ms \
                      (setup+baseline {} ms, warm {} ms, fresh-oracle {} ms, other {} ms; \
-                     validation hits {}, misses {}; retention passes {}, scan entries {})",
+                     validation {}; retention passes {}, scan entries {})",
                     workload.id,
                     declaration.scenario.wire_name(),
                     elapsed_ms(observation.collection_timing.total),
@@ -1775,14 +1824,7 @@ mod tests {
                     elapsed_ms(observation.collection_timing.warm),
                     elapsed_ms(observation.collection_timing.fresh_oracle),
                     elapsed_ms(observation.collection_timing.other()),
-                    observation
-                        .collection_timing
-                        .query_runtime
-                        .validation_memo_hits,
-                    observation
-                        .collection_timing
-                        .query_runtime
-                        .validation_memo_misses,
+                    validation_summary(observation.collection_timing.query_runtime.validation),
                     observation
                         .collection_timing
                         .query_runtime

--- a/crates/rue-compiler/src/session.rs
+++ b/crates/rue-compiler/src/session.rs
@@ -128,8 +128,7 @@ pub struct FrontendRetentionMetrics {
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
 pub(crate) struct FrontendRuntimeMetrics {
-    pub(crate) validation_memo_hits: u64,
-    pub(crate) validation_memo_misses: u64,
+    pub(crate) validation: rue_query::ValidationWork,
     pub(crate) retention_enforcements: u64,
     pub(crate) retention_scan_entries: u64,
 }
@@ -3292,8 +3291,7 @@ impl CompilerSession {
             diagnostic_source_bytes: diagnostics.source_bytes,
         });
         self.metrics.set_runtime(FrontendRuntimeMetrics {
-            validation_memo_hits: runtime.validation_memo_hits,
-            validation_memo_misses: runtime.validation_memo_misses,
+            validation: runtime.validation,
             retention_enforcements: runtime.retention_enforcements,
             retention_scan_entries: runtime.retention_scan_entries,
         });

--- a/crates/rue-compiler/src/unstable.rs
+++ b/crates/rue-compiler/src/unstable.rs
@@ -1613,13 +1613,103 @@ pub struct QueryMetrics {
     pub reuses: usize,
 }
 
+/// Deterministic retained-terminal validation work contained in [`MetricsSnapshot`].
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct QueryValidationMetrics {
+    pub traversals: u64,
+    pub successful_traversals: u64,
+    pub dirty_traversals: u64,
+    pub aborted_traversals: u64,
+    pub input_observations: u64,
+    pub dependency_observations: u64,
+    pub registry_probes: u64,
+    pub registry_misses: u64,
+    pub node_visits: u64,
+    pub active_cycle_prunes: u64,
+    pub memo_hits: u64,
+    pub memo_misses: u64,
+    pub endorsement_probes: u64,
+    pub endorsement_hits: u64,
+    pub demands: u64,
+    pub demand_reuses: u64,
+    pub demand_computes: u64,
+    pub demand_joins: u64,
+    pub demand_aborts: u64,
+    pub superseded: u64,
+    pub certificates_published: u64,
+}
+
+impl QueryValidationMetrics {
+    #[must_use]
+    pub fn saturating_sub(self, earlier: Self) -> Self {
+        Self::from(self.into_runtime().saturating_sub(earlier.into_runtime()))
+    }
+
+    pub fn saturating_add_assign(&mut self, other: Self) {
+        let mut aggregate = self.into_runtime();
+        aggregate.saturating_add_assign(other.into_runtime());
+        *self = Self::from(aggregate);
+    }
+
+    fn into_runtime(self) -> rue_query::ValidationWork {
+        rue_query::ValidationWork {
+            traversals: self.traversals,
+            successful_traversals: self.successful_traversals,
+            dirty_traversals: self.dirty_traversals,
+            aborted_traversals: self.aborted_traversals,
+            input_observations: self.input_observations,
+            dependency_observations: self.dependency_observations,
+            registry_probes: self.registry_probes,
+            registry_misses: self.registry_misses,
+            node_visits: self.node_visits,
+            active_cycle_prunes: self.active_cycle_prunes,
+            memo_hits: self.memo_hits,
+            memo_misses: self.memo_misses,
+            endorsement_probes: self.endorsement_probes,
+            endorsement_hits: self.endorsement_hits,
+            demands: self.demands,
+            demand_reuses: self.demand_reuses,
+            demand_computes: self.demand_computes,
+            demand_joins: self.demand_joins,
+            demand_aborts: self.demand_aborts,
+            superseded: self.superseded,
+            certificates_published: self.certificates_published,
+        }
+    }
+}
+
+impl From<rue_query::ValidationWork> for QueryValidationMetrics {
+    fn from(work: rue_query::ValidationWork) -> Self {
+        Self {
+            traversals: work.traversals,
+            successful_traversals: work.successful_traversals,
+            dirty_traversals: work.dirty_traversals,
+            aborted_traversals: work.aborted_traversals,
+            input_observations: work.input_observations,
+            dependency_observations: work.dependency_observations,
+            registry_probes: work.registry_probes,
+            registry_misses: work.registry_misses,
+            node_visits: work.node_visits,
+            active_cycle_prunes: work.active_cycle_prunes,
+            memo_hits: work.memo_hits,
+            memo_misses: work.memo_misses,
+            endorsement_probes: work.endorsement_probes,
+            endorsement_hits: work.endorsement_hits,
+            demands: work.demands,
+            demand_reuses: work.demand_reuses,
+            demand_computes: work.demand_computes,
+            demand_joins: work.demand_joins,
+            demand_aborts: work.demand_aborts,
+            superseded: work.superseded,
+            certificates_published: work.certificates_published,
+        }
+    }
+}
+
 /// Query-runtime validation and retention work contained in [`MetricsSnapshot`].
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
 pub struct QueryRuntimeMetrics {
-    /// Dependency validations satisfied by a revision-scoped memo.
-    pub validation_memo_hits: u64,
-    /// Dependency validations that inspected or re-demanded the node.
-    pub validation_memo_misses: u64,
+    pub validation: QueryValidationMetrics,
     /// Family-local retention passes run.
     pub retention_enforcements: u64,
     /// Retention-queue entries examined by those passes.
@@ -1959,8 +2049,7 @@ impl MetricsSnapshot {
     }
     pub fn query_runtime(&self) -> QueryRuntimeMetrics {
         QueryRuntimeMetrics {
-            validation_memo_hits: self.inner.runtime.validation_memo_hits,
-            validation_memo_misses: self.inner.runtime.validation_memo_misses,
+            validation: self.inner.runtime.validation.into(),
             retention_enforcements: self.inner.runtime.retention_enforcements,
             retention_scan_entries: self.inner.runtime.retention_scan_entries,
         }

--- a/crates/rue-perf-schema/src/incremental.rs
+++ b/crates/rue-perf-schema/src/incremental.rs
@@ -14,7 +14,7 @@ use serde::{Deserialize, Serialize};
 use crate::{EnvironmentFingerprint, median, median_absolute_deviation};
 
 /// Version of the retained-session raw report wire format.
-pub const EDIT_REPORT_SCHEMA_VERSION: u32 = 2;
+pub const EDIT_REPORT_SCHEMA_VERSION: u32 = 3;
 
 /// One retained-session edit class from ADR-0068's initial matrix.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
@@ -719,6 +719,54 @@ pub enum OracleComparison {
     },
 }
 
+/// Deterministic work performed while validating retained query results.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ValidationWork {
+    /// Retained-terminal validation traversals started.
+    pub traversals: u64,
+    /// Traversals which proved a retained terminal current.
+    pub successful_traversals: u64,
+    /// Traversals which proved a retained terminal dirty.
+    pub dirty_traversals: u64,
+    /// Traversals aborted by cancellation or an engine error.
+    pub aborted_traversals: u64,
+    /// Direct input observations inspected.
+    pub input_observations: u64,
+    /// Retained dependency observations inspected.
+    pub dependency_observations: u64,
+    /// Exact node-incarnation registry probes.
+    pub registry_probes: u64,
+    /// Registry probes with no live exact incarnation.
+    pub registry_misses: u64,
+    /// Erased-node validation visits.
+    pub node_visits: u64,
+    /// Recursive visits pruned at an active incarnation.
+    pub active_cycle_prunes: u64,
+    /// Node visits satisfied by a revision-scoped certificate.
+    pub memo_hits: u64,
+    /// Node visits which inspected or re-demanded the node.
+    pub memo_misses: u64,
+    /// Registered-cone endorsement lookups.
+    pub endorsement_probes: u64,
+    /// Endorsement lookups satisfied by the rooted request.
+    pub endorsement_hits: u64,
+    /// Family-owned validation demands issued.
+    pub demands: u64,
+    /// Validation demands answered by retained terminals.
+    pub demand_reuses: u64,
+    /// Validation demands which computed terminals.
+    pub demand_computes: u64,
+    /// Validation demands which joined in-flight terminals.
+    pub demand_joins: u64,
+    /// Validation demands which aborted without terminals.
+    pub demand_aborts: u64,
+    /// Demands whose observed incarnation had been replaced.
+    pub superseded: u64,
+    /// New exact revision/stamp validation certificates published.
+    pub certificates_published: u64,
+}
+
 impl OracleComparison {
     fn warm(&self) -> &OutcomeIdentity {
         match self {
@@ -745,6 +793,8 @@ pub struct EditSample {
     pub outcome: EditOutcome,
     /// Exact structural work by compiler phase.
     pub work: StructuralWork,
+    /// Exact retained-terminal validation work.
+    pub validation: ValidationWork,
     /// Retained memory and observation gauges at the endpoint.
     pub retention: RetainedGauges,
     /// Fresh-session correctness comparison performed outside timing.
@@ -1034,6 +1084,70 @@ fn validate_gauges(path: &str, gauges: &RetainedGauges, errors: &mut Vec<Validat
     }
 }
 
+fn validate_validation_work(
+    path: &str,
+    work: &ValidationWork,
+    errors: &mut Vec<ValidationFinding>,
+) {
+    let traversal_outcomes = work
+        .successful_traversals
+        .checked_add(work.dirty_traversals)
+        .and_then(|total| total.checked_add(work.aborted_traversals));
+    if traversal_outcomes != Some(work.traversals) {
+        errors.push(finding(
+            path,
+            "validation traversals do not equal clean, dirty, and aborted outcomes",
+        ));
+    }
+
+    let visit_outcomes = work
+        .active_cycle_prunes
+        .checked_add(work.memo_hits)
+        .and_then(|total| total.checked_add(work.memo_misses));
+    if visit_outcomes != Some(work.node_visits) {
+        errors.push(finding(
+            path,
+            "validation node visits do not equal cycle prunes, memo hits, and memo misses",
+        ));
+    }
+
+    let expected_registry_probes = work
+        .dependency_observations
+        .checked_add(work.successful_traversals);
+    if expected_registry_probes != Some(work.registry_probes) {
+        errors.push(finding(
+            path,
+            "registry probes do not equal dependency observations plus published traversal probes",
+        ));
+    }
+    if work.registry_misses > work.registry_probes {
+        errors.push(finding(path, "registry misses exceed registry probes"));
+    }
+    if work.endorsement_hits > work.endorsement_probes {
+        errors.push(finding(
+            path,
+            "validation endorsement hits exceed endorsement probes",
+        ));
+    }
+    let completed_demands = work
+        .demand_reuses
+        .checked_add(work.demand_computes)
+        .and_then(|total| total.checked_add(work.demand_joins))
+        .and_then(|total| total.checked_add(work.demand_aborts));
+    if completed_demands.is_none_or(|completed| completed > work.demands) {
+        errors.push(finding(
+            path,
+            "validation demand outcomes exceed issued demands",
+        ));
+    }
+    if work.certificates_published > work.successful_traversals {
+        errors.push(finding(
+            path,
+            "published validation certificates exceed successful traversals",
+        ));
+    }
+}
+
 /// Strictly validate a raw report against its manifest.
 pub fn validate_edit_report(manifest: &EditManifest, report: &EditReport) -> EditValidation {
     let mut errors = Vec::new();
@@ -1310,6 +1424,11 @@ pub fn validate_edit_report(manifest: &EditManifest, report: &EditReport) -> Edi
             validate_gauges(
                 &format!("{sample_path}.retention"),
                 &sample.retention,
+                &mut errors,
+            );
+            validate_validation_work(
+                &format!("{sample_path}.validation"),
+                &sample.validation,
                 &mut errors,
             );
             if sample.work.totals().is_none() {
@@ -1755,7 +1874,7 @@ mod tests {
 
     const MANIFEST: &str = r#"
 schema_version = 2
-report_schema_version = 2
+report_schema_version = 3
 fixture_revision = 3
 timing_samples_per_row = 5
 structural_samples_per_row = 1
@@ -1929,6 +2048,7 @@ minimum_memory_bytes = 15000000000
                 }
             },
             work: StructuralWork::default(),
+            validation: ValidationWork::default(),
             retention: gauges(sample_index),
             oracle: OracleComparison::Matched {
                 warm: identity.clone(),
@@ -2083,6 +2203,47 @@ minimum_memory_bytes = 15000000000
     }
 
     #[test]
+    fn validation_work_conservation_is_strictly_validated() {
+        let manifest = EditManifest::parse(MANIFEST).unwrap();
+        let mut measured = report(&manifest);
+        measured.rows[0].samples[0].validation = ValidationWork {
+            traversals: 3,
+            successful_traversals: 1,
+            dirty_traversals: 1,
+            aborted_traversals: 1,
+            input_observations: 4,
+            dependency_observations: 5,
+            registry_probes: 6,
+            registry_misses: 1,
+            node_visits: 4,
+            active_cycle_prunes: 1,
+            memo_hits: 1,
+            memo_misses: 2,
+            endorsement_probes: 2,
+            endorsement_hits: 1,
+            demands: 2,
+            demand_reuses: 1,
+            demand_computes: 1,
+            demand_joins: 0,
+            demand_aborts: 0,
+            superseded: 0,
+            certificates_published: 1,
+        };
+        assert!(
+            validate_edit_report(&manifest, &measured).is_success(),
+            "a self-consistent nonzero validation ledger is valid"
+        );
+
+        measured.rows[0].samples[0].validation.node_visits += 1;
+        let validation = validate_edit_report(&manifest, &measured);
+        assert!(validation.errors.iter().any(|error| {
+            error
+                .detail
+                .contains("node visits do not equal cycle prunes")
+        }));
+    }
+
+    #[test]
     fn missing_rows_bad_endpoints_workers_and_unknown_fields_fail_loudly() {
         let manifest = EditManifest::parse(MANIFEST).unwrap();
         let mut missing = report(&manifest);
@@ -2149,8 +2310,8 @@ minimum_memory_bytes = 15000000000
 
         let json = serde_json::to_string(&report(&manifest)).unwrap();
         let unknown = json.replacen(
-            "\"schema_version\":2",
-            "\"schema_version\":2,\"surprise\":true",
+            "\"schema_version\":3",
+            "\"schema_version\":3,\"surprise\":true",
             1,
         );
         assert!(

--- a/crates/rue-perf-schema/src/lib.rs
+++ b/crates/rue-perf-schema/src/lib.rs
@@ -49,7 +49,7 @@ pub use incremental::{
     OptimizationSetting, OracleComparison, OutcomeIdentity, OutcomeKind, PhaseWork, ReferenceHost,
     RetainedGauges, RetentionSequence, RetentionStep, RetentionStepOutcome, RotationRule,
     SourceShape, StructuralWork, StructuralWorkSummary, TransformationIdentity, ValidationFinding,
-    WorkerDeclaration, WorkerMode, derive_edit_report, render_edit_report_markdown,
+    ValidationWork, WorkerDeclaration, WorkerMode, derive_edit_report, render_edit_report_markdown,
     validate_edit_report,
 };
 pub use manifest::{

--- a/crates/rue-query/src/lib.rs
+++ b/crates/rue-query/src/lib.rs
@@ -605,7 +605,7 @@ mod registered_batch_tests {
             "a superseded incarnation cannot certify a dependent, whatever its stamp reads"
         );
         assert!(
-            runtime.metrics().superseded_validations >= 1,
+            runtime.metrics().validation.superseded >= 1,
             "the retired incarnation is reported rather than silently accepted"
         );
     }
@@ -2244,6 +2244,239 @@ impl CancellationToken {
     }
 }
 
+/// Deterministic work performed while validating retained query terminals.
+///
+/// These counters describe semantic operations rather than elapsed time. The
+/// hot path accumulates them on the rooted request's [`Task`]; the runtime
+/// merges one aggregate when that task completes. This keeps the counters
+/// continuously available without a shared atomic update per validation edge.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct ValidationWork {
+    /// Retained-terminal validation traversals started.
+    pub traversals: u64,
+    /// Traversals which proved their retained terminal current.
+    pub successful_traversals: u64,
+    /// Traversals which proved their retained terminal dirty.
+    pub dirty_traversals: u64,
+    /// Traversals aborted by cancellation or an engine error.
+    pub aborted_traversals: u64,
+    /// Direct source/input observations inspected.
+    pub input_observations: u64,
+    /// Retained dependency observations inspected.
+    pub dependency_observations: u64,
+    /// Exact node-incarnation registry probes made by validation.
+    pub registry_probes: u64,
+    /// Registry probes which found no live exact incarnation.
+    pub registry_misses: u64,
+    /// Erased node validation entry-point visits.
+    pub node_visits: u64,
+    /// Recursive visits pruned because the incarnation was already active.
+    pub active_cycle_prunes: u64,
+    /// Node visits satisfied by a revision-scoped validation certificate.
+    pub memo_hits: u64,
+    /// Node visits which had to inspect or re-demand the node.
+    pub memo_misses: u64,
+    /// Exact registered-cone endorsement lookups.
+    pub endorsement_probes: u64,
+    /// Endorsement lookups satisfied by this rooted request's retained cone.
+    pub endorsement_hits: u64,
+    /// Family-owned validation demands issued after a memo miss.
+    pub demands: u64,
+    /// Validation demands answered by a retained terminal.
+    pub demand_reuses: u64,
+    /// Validation demands which computed a terminal.
+    pub demand_computes: u64,
+    /// Validation demands which joined an in-flight terminal.
+    pub demand_joins: u64,
+    /// Validation demands which aborted without a terminal.
+    pub demand_aborts: u64,
+    /// Demands whose recorded incarnation had been retired or replaced.
+    pub superseded: u64,
+    /// New exact node/revision/stamp validation certificates published.
+    pub certificates_published: u64,
+}
+
+impl ValidationWork {
+    /// Returns the non-negative counter delta from an earlier snapshot.
+    #[must_use]
+    pub fn saturating_sub(self, earlier: Self) -> Self {
+        macro_rules! subtract_fields {
+            ($($field:ident),+ $(,)?) => {
+                Self {
+                    $($field: self.$field.saturating_sub(earlier.$field)),+
+                }
+            };
+        }
+        subtract_fields!(
+            traversals,
+            successful_traversals,
+            dirty_traversals,
+            aborted_traversals,
+            input_observations,
+            dependency_observations,
+            registry_probes,
+            registry_misses,
+            node_visits,
+            active_cycle_prunes,
+            memo_hits,
+            memo_misses,
+            endorsement_probes,
+            endorsement_hits,
+            demands,
+            demand_reuses,
+            demand_computes,
+            demand_joins,
+            demand_aborts,
+            superseded,
+            certificates_published,
+        )
+    }
+
+    /// Adds another request's counters into this aggregate.
+    pub fn saturating_add_assign(&mut self, other: Self) {
+        macro_rules! add_fields {
+            ($($field:ident),+ $(,)?) => {
+                $(self.$field = self.$field.saturating_add(other.$field);)+
+            };
+        }
+        add_fields!(
+            traversals,
+            successful_traversals,
+            dirty_traversals,
+            aborted_traversals,
+            input_observations,
+            dependency_observations,
+            registry_probes,
+            registry_misses,
+            node_visits,
+            active_cycle_prunes,
+            memo_hits,
+            memo_misses,
+            endorsement_probes,
+            endorsement_hits,
+            demands,
+            demand_reuses,
+            demand_computes,
+            demand_joins,
+            demand_aborts,
+            superseded,
+            certificates_published,
+        );
+    }
+}
+
+#[derive(Debug, Default)]
+struct AtomicValidationWork {
+    traversals: AtomicU64,
+    successful_traversals: AtomicU64,
+    dirty_traversals: AtomicU64,
+    aborted_traversals: AtomicU64,
+    input_observations: AtomicU64,
+    dependency_observations: AtomicU64,
+    registry_probes: AtomicU64,
+    registry_misses: AtomicU64,
+    node_visits: AtomicU64,
+    active_cycle_prunes: AtomicU64,
+    memo_hits: AtomicU64,
+    memo_misses: AtomicU64,
+    endorsement_probes: AtomicU64,
+    endorsement_hits: AtomicU64,
+    demands: AtomicU64,
+    demand_reuses: AtomicU64,
+    demand_computes: AtomicU64,
+    demand_joins: AtomicU64,
+    demand_aborts: AtomicU64,
+    superseded: AtomicU64,
+    certificates_published: AtomicU64,
+}
+
+impl AtomicValidationWork {
+    fn snapshot(&self) -> ValidationWork {
+        ValidationWork {
+            traversals: self.traversals.load(Ordering::Relaxed),
+            successful_traversals: self.successful_traversals.load(Ordering::Relaxed),
+            dirty_traversals: self.dirty_traversals.load(Ordering::Relaxed),
+            aborted_traversals: self.aborted_traversals.load(Ordering::Relaxed),
+            input_observations: self.input_observations.load(Ordering::Relaxed),
+            dependency_observations: self.dependency_observations.load(Ordering::Relaxed),
+            registry_probes: self.registry_probes.load(Ordering::Relaxed),
+            registry_misses: self.registry_misses.load(Ordering::Relaxed),
+            node_visits: self.node_visits.load(Ordering::Relaxed),
+            active_cycle_prunes: self.active_cycle_prunes.load(Ordering::Relaxed),
+            memo_hits: self.memo_hits.load(Ordering::Relaxed),
+            memo_misses: self.memo_misses.load(Ordering::Relaxed),
+            endorsement_probes: self.endorsement_probes.load(Ordering::Relaxed),
+            endorsement_hits: self.endorsement_hits.load(Ordering::Relaxed),
+            demands: self.demands.load(Ordering::Relaxed),
+            demand_reuses: self.demand_reuses.load(Ordering::Relaxed),
+            demand_computes: self.demand_computes.load(Ordering::Relaxed),
+            demand_joins: self.demand_joins.load(Ordering::Relaxed),
+            demand_aborts: self.demand_aborts.load(Ordering::Relaxed),
+            superseded: self.superseded.load(Ordering::Relaxed),
+            certificates_published: self.certificates_published.load(Ordering::Relaxed),
+        }
+    }
+
+    fn take(&self) -> ValidationWork {
+        ValidationWork {
+            traversals: self.traversals.swap(0, Ordering::Relaxed),
+            successful_traversals: self.successful_traversals.swap(0, Ordering::Relaxed),
+            dirty_traversals: self.dirty_traversals.swap(0, Ordering::Relaxed),
+            aborted_traversals: self.aborted_traversals.swap(0, Ordering::Relaxed),
+            input_observations: self.input_observations.swap(0, Ordering::Relaxed),
+            dependency_observations: self.dependency_observations.swap(0, Ordering::Relaxed),
+            registry_probes: self.registry_probes.swap(0, Ordering::Relaxed),
+            registry_misses: self.registry_misses.swap(0, Ordering::Relaxed),
+            node_visits: self.node_visits.swap(0, Ordering::Relaxed),
+            active_cycle_prunes: self.active_cycle_prunes.swap(0, Ordering::Relaxed),
+            memo_hits: self.memo_hits.swap(0, Ordering::Relaxed),
+            memo_misses: self.memo_misses.swap(0, Ordering::Relaxed),
+            endorsement_probes: self.endorsement_probes.swap(0, Ordering::Relaxed),
+            endorsement_hits: self.endorsement_hits.swap(0, Ordering::Relaxed),
+            demands: self.demands.swap(0, Ordering::Relaxed),
+            demand_reuses: self.demand_reuses.swap(0, Ordering::Relaxed),
+            demand_computes: self.demand_computes.swap(0, Ordering::Relaxed),
+            demand_joins: self.demand_joins.swap(0, Ordering::Relaxed),
+            demand_aborts: self.demand_aborts.swap(0, Ordering::Relaxed),
+            superseded: self.superseded.swap(0, Ordering::Relaxed),
+            certificates_published: self.certificates_published.swap(0, Ordering::Relaxed),
+        }
+    }
+
+    fn add(&self, work: ValidationWork) {
+        macro_rules! add_fields {
+            ($($field:ident),+ $(,)?) => {
+                $(if work.$field != 0 {
+                    self.$field.fetch_add(work.$field, Ordering::Relaxed);
+                })+
+            };
+        }
+        add_fields!(
+            traversals,
+            successful_traversals,
+            dirty_traversals,
+            aborted_traversals,
+            input_observations,
+            dependency_observations,
+            registry_probes,
+            registry_misses,
+            node_visits,
+            active_cycle_prunes,
+            memo_hits,
+            memo_misses,
+            endorsement_probes,
+            endorsement_hits,
+            demands,
+            demand_reuses,
+            demand_computes,
+            demand_joins,
+            demand_aborts,
+            superseded,
+            certificates_published,
+        );
+    }
+}
+
 /// Deterministic structural execution counters.
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
 pub struct RuntimeMetrics {
@@ -2254,13 +2487,8 @@ pub struct RuntimeMetrics {
     pub joins: u64,
     /// Compatible retained terminals reused.
     pub reuses: u64,
-    /// Dependency validations satisfied by a node's revision-scoped memo.
-    pub validation_memo_hits: u64,
-    /// Dependency validations which had to inspect or re-demand the node.
-    pub validation_memo_misses: u64,
-    /// Retained dependency observations whose node incarnation was retired from
-    /// its family's key memo, so the dependent recomputed instead of reusing.
-    pub superseded_validations: u64,
+    /// Retained-terminal validation work.
+    pub validation: ValidationWork,
     /// Query bodies which completed before publication checks.
     pub body_completions: u64,
     /// Recomputations whose observable stamp stayed red.
@@ -2375,9 +2603,7 @@ struct Metrics {
     claims: AtomicU64,
     joins: AtomicU64,
     reuses: AtomicU64,
-    validation_memo_hits: AtomicU64,
-    validation_memo_misses: AtomicU64,
-    superseded_validations: AtomicU64,
+    validation: AtomicValidationWork,
     body_completions: AtomicU64,
     red_publications: AtomicU64,
     green_publications: AtomicU64,
@@ -2419,9 +2645,7 @@ impl Metrics {
             claims: self.claims.load(Ordering::Relaxed),
             joins: self.joins.load(Ordering::Relaxed),
             reuses: self.reuses.load(Ordering::Relaxed),
-            validation_memo_hits: self.validation_memo_hits.load(Ordering::Relaxed),
-            validation_memo_misses: self.validation_memo_misses.load(Ordering::Relaxed),
-            superseded_validations: self.superseded_validations.load(Ordering::Relaxed),
+            validation: self.validation.snapshot(),
             body_completions: self.body_completions.load(Ordering::Relaxed),
             red_publications: self.red_publications.load(Ordering::Relaxed),
             green_publications: self.green_publications.load(Ordering::Relaxed),
@@ -3530,6 +3754,7 @@ impl QueryRuntime {
             nested_attempt_filters: Mutex::new(Vec::new()),
             validation_endorsements: Mutex::new(Vec::new()),
             validation_proofs: Mutex::new(Vec::new()),
+            validation_work: AtomicValidationWork::default(),
             leases: Mutex::new(TaskLeases::default()),
             observed_handoffs: Mutex::new(Vec::new()),
             checked_handoffs: Mutex::new(HashSet::new()),
@@ -3974,7 +4199,8 @@ trait ErasedNode: fmt::Debug + Send + Sync {
         active: &mut BTreeSet<u64>,
     ) -> Result<Option<u64>, QueryAbort>;
 
-    fn mark_validated(&self, revision: Revision, stamp: u64, registered_only: bool);
+    /// Records one exact validation certificate and reports whether it was new.
+    fn mark_validated(&self, revision: Revision, stamp: u64, registered_only: bool) -> bool;
 
     /// The typed node behind this erased handle, for the family-owned
     /// exact-terminal adoption path ([`QueryFamily::observe_adopted_terminal`])
@@ -3994,7 +4220,13 @@ where
         task: &Arc<Task>,
         active: &mut BTreeSet<u64>,
     ) -> Result<Option<u64>, QueryAbort> {
+        task.validation_work
+            .node_visits
+            .fetch_add(1, Ordering::Relaxed);
         if !active.insert(self.incarnation) {
+            task.validation_work
+                .active_cycle_prunes
+                .fetch_add(1, Ordering::Relaxed);
             return Ok(None);
         }
         {
@@ -4018,17 +4250,18 @@ where
                 if !registered_only {
                     task.taint_validation_proofs();
                 }
-                core.metrics
-                    .validation_memo_hits
+                task.validation_work
+                    .memo_hits
                     .fetch_add(1, Ordering::Relaxed);
                 active.remove(&self.incarnation);
                 return Ok(Some(stamp));
             }
         }
-        core.metrics
-            .validation_memo_misses
+        task.validation_work
+            .memo_misses
             .fetch_add(1, Ordering::Relaxed);
         if let Some(demand) = &self.demand {
+            task.validation_work.demands.fetch_add(1, Ordering::Relaxed);
             #[cfg(test)]
             core.interpose(InterposeSite::RetainedDependencyDemand);
             let request_id = task.next_nested_request();
@@ -4037,8 +4270,8 @@ where
                 // The key is still computable, but only as a fresh incarnation
                 // whose stamps are unrelated to the retained observation, so the
                 // dependent is dirty rather than provably green.
-                core.metrics
-                    .superseded_validations
+                task.validation_work
+                    .superseded
                     .fetch_add(1, Ordering::Relaxed);
                 active.remove(&self.incarnation);
                 return Ok(None);
@@ -4051,14 +4284,21 @@ where
                     execution,
                     ..
                 } => {
+                    match execution {
+                        RequestExecution::Reused => &task.validation_work.demand_reuses,
+                        RequestExecution::Computed => &task.validation_work.demand_computes,
+                        RequestExecution::Joined => &task.validation_work.demand_joins,
+                        RequestExecution::Aborted => &task.validation_work.demand_aborts,
+                    }
+                    .fetch_add(1, Ordering::Relaxed);
                     // Retention can retire this incarnation between the memo
                     // check above and the request itself. The answering
                     // incarnation is authoritative: a stamp published by any
                     // other node is a different counter and never witnesses this
                     // observation, however numerically equal it looks.
                     if terminal.node_incarnation != self.incarnation {
-                        core.metrics
-                            .superseded_validations
+                        task.validation_work
+                            .superseded
                             .fetch_add(1, Ordering::Relaxed);
                         return Ok(None);
                     }
@@ -4093,8 +4333,18 @@ where
                 TaskQueryResult::Aborted {
                     abort: QueryAbort::MissingInput(_),
                     ..
-                } => Ok(None),
-                TaskQueryResult::Aborted { abort, .. } => Err(abort),
+                } => {
+                    task.validation_work
+                        .demand_aborts
+                        .fetch_add(1, Ordering::Relaxed);
+                    Ok(None)
+                }
+                TaskQueryResult::Aborted { abort, .. } => {
+                    task.validation_work
+                        .demand_aborts
+                        .fetch_add(1, Ordering::Relaxed);
+                    Err(abort)
+                }
             };
         }
         // An externally supplied evaluator cannot participate in a reusable
@@ -4127,7 +4377,7 @@ where
         self
     }
 
-    fn mark_validated(&self, revision: Revision, stamp: u64, registered_only: bool) {
+    fn mark_validated(&self, revision: Revision, stamp: u64, registered_only: bool) -> bool {
         let mut state = lock(&self.state);
         if state.attempts.iter().any(|attempt| {
             matches!(
@@ -4135,8 +4385,13 @@ where
                 AttemptState::Terminal { terminal, .. } if terminal.stamp == stamp
             )
         }) {
+            if state.validated_at == Some((revision, stamp, registered_only)) {
+                return false;
+            }
             state.validated_at = Some((revision, stamp, registered_only));
+            return true;
         }
+        false
     }
 }
 
@@ -6434,6 +6689,9 @@ struct Task {
     /// Active recursive validation certificates. Encountering an unregistered
     /// node taints every enclosing traversal.
     validation_proofs: Mutex<Vec<Arc<AtomicU8>>>,
+    /// High-frequency validation work accumulated on this rooted request and
+    /// merged into the runtime once at task completion.
+    validation_work: AtomicValidationWork,
     /// Request-scoped retention leases. This task, which owns one rooted request
     /// and all of its nested observations (nested queries share the task), holds
     /// one pin per distinct terminal it has observed. The pins release together
@@ -7312,6 +7570,7 @@ impl Task {
                     .collect(),
             ),
             validation_proofs: Mutex::new(inherited_validation_proofs),
+            validation_work: AtomicValidationWork::default(),
             leases: Mutex::new(TaskLeases::default()),
             observed_handoffs: Mutex::new(Vec::new()),
             checked_handoffs: Mutex::new(HashSet::new()),
@@ -7323,6 +7582,8 @@ impl Task {
     }
 
     fn absorb_batch_child(&self, child: &Arc<Self>, transfer_handoffs: bool) {
+        self.validation_work.add(child.validation_work.take());
+
         let mut child_leases = lock(&child.leases);
         let mut parent_leases = lock(&self.leases);
         for lease in child_leases.held.drain(..) {
@@ -7419,16 +7680,25 @@ impl Task {
         let Some(scope) = scopes.first() else {
             return false;
         };
+        self.validation_work
+            .endorsement_probes
+            .fetch_add(1, Ordering::Relaxed);
         #[cfg(test)]
         self.validation_endorsement_index_probes
             .fetch_add(1, Ordering::Relaxed);
-        scope
+        let hit = scope
             .range(
                 (incarnation, stamp, Revision::new(0, 0))
                     ..=(incarnation, stamp, Revision::new(u64::MAX, u64::MAX)),
             )
             .next()
-            .is_some()
+            .is_some();
+        if hit {
+            self.validation_work
+                .endorsement_hits
+                .fetch_add(1, Ordering::Relaxed);
+        }
+        hit
     }
 
     fn validation_endorsed<V>(&self, terminal: &QueryTerminal<V>) -> bool {
@@ -7437,10 +7707,19 @@ impl Task {
         let Some(scope) = scopes.first() else {
             return false;
         };
+        self.validation_work
+            .endorsement_probes
+            .fetch_add(1, Ordering::Relaxed);
         #[cfg(test)]
         self.validation_endorsement_index_probes
             .fetch_add(1, Ordering::Relaxed);
-        scope.contains(&identity)
+        let hit = scope.contains(&identity);
+        if hit {
+            self.validation_work
+                .endorsement_hits
+                .fetch_add(1, Ordering::Relaxed);
+        }
+        hit
     }
 
     fn endorse_validation<V>(&self, terminal: &QueryTerminal<V>) {
@@ -7856,6 +8135,10 @@ impl Drop for Task {
         self.discard_observed_handoffs();
         self.core
             .metrics
+            .validation
+            .add(self.validation_work.take());
+        self.core
+            .metrics
             .task_leases_released(lock(&self.leases).held.len());
     }
 }
@@ -8104,12 +8387,30 @@ impl RuntimeCore {
         terminal: &QueryTerminal<V>,
         task: &Arc<Task>,
     ) -> Result<(bool, bool, bool), QueryAbort> {
+        task.validation_work
+            .traversals
+            .fetch_add(1, Ordering::Relaxed);
         let proof = task.begin_validation();
-        let valid = self.valid_for_revision_inner(terminal, task, &mut BTreeSet::new())?;
+        let valid = match self.valid_for_revision_inner(terminal, task, &mut BTreeSet::new()) {
+            Ok(valid) => valid,
+            Err(abort) => {
+                task.validation_work
+                    .aborted_traversals
+                    .fetch_add(1, Ordering::Relaxed);
+                return Err(abort);
+            }
+        };
         let registered_only = proof.registered_only();
         let retryable = proof.retryable();
         if valid {
-            self.mark_terminal_validated(terminal, task.revision, registered_only);
+            task.validation_work
+                .successful_traversals
+                .fetch_add(1, Ordering::Relaxed);
+            self.mark_terminal_validated(terminal, task.revision, registered_only, task);
+        } else {
+            task.validation_work
+                .dirty_traversals
+                .fetch_add(1, Ordering::Relaxed);
         }
         Ok((valid, registered_only, retryable))
     }
@@ -8119,9 +8420,21 @@ impl RuntimeCore {
         terminal: &QueryTerminal<V>,
         revision: Revision,
         registered_only: bool,
+        task: &Task,
     ) {
+        task.validation_work
+            .registry_probes
+            .fetch_add(1, Ordering::Relaxed);
         if let Some(node) = self.registered_node(terminal.node_incarnation) {
-            node.mark_validated(revision, terminal.stamp, registered_only);
+            if node.mark_validated(revision, terminal.stamp, registered_only) {
+                task.validation_work
+                    .certificates_published
+                    .fetch_add(1, Ordering::Relaxed);
+            }
+        } else {
+            task.validation_work
+                .registry_misses
+                .fetch_add(1, Ordering::Relaxed);
         }
     }
 
@@ -8145,6 +8458,9 @@ impl RuntimeCore {
         {
             return Ok(false);
         }
+        task.validation_work
+            .input_observations
+            .fetch_add(terminal.inputs.len() as u64, Ordering::Relaxed);
         let direct_inputs_valid = terminal.inputs.iter().all(|observed| {
             if observed.stamp == 0 {
                 !revisions.input_present(task.revision.id, &observed.input)
@@ -8161,6 +8477,12 @@ impl RuntimeCore {
             return Ok(false);
         }
         for observed in terminal.dependencies.iter() {
+            task.validation_work
+                .dependency_observations
+                .fetch_add(1, Ordering::Relaxed);
+            task.validation_work
+                .registry_probes
+                .fetch_add(1, Ordering::Relaxed);
             let node = self.registered_node(observed.incarnation);
             let stamp = match node {
                 Some(node) => match node.validated_stamp(self, task, active) {
@@ -8184,7 +8506,12 @@ impl RuntimeCore {
                     Err(QueryAbort::Cycle(_)) => return Ok(false),
                     Err(abort) => return Err(abort),
                 },
-                None => None,
+                None => {
+                    task.validation_work
+                        .registry_misses
+                        .fetch_add(1, Ordering::Relaxed);
+                    None
+                }
             };
             if stamp != Some(observed.stamp) {
                 return Ok(false);
@@ -8498,6 +8825,31 @@ mod tests {
         fn stable_identity(&self) -> String {
             self.0.to_owned()
         }
+    }
+
+    fn assert_validation_work_consistent(work: ValidationWork) {
+        assert_eq!(
+            work.traversals,
+            work.successful_traversals + work.dirty_traversals + work.aborted_traversals,
+            "every validation traversal has exactly one outcome"
+        );
+        assert_eq!(
+            work.node_visits,
+            work.active_cycle_prunes + work.memo_hits + work.memo_misses,
+            "every erased-node visit has exactly one outcome"
+        );
+        assert_eq!(
+            work.registry_probes,
+            work.dependency_observations + work.successful_traversals,
+            "validation probes once per dependency and successful root certificate"
+        );
+        assert!(work.registry_misses <= work.registry_probes);
+        assert!(work.endorsement_hits <= work.endorsement_probes);
+        assert!(
+            work.demand_reuses + work.demand_computes + work.demand_joins + work.demand_aborts
+                <= work.demands
+        );
+        assert!(work.certificates_published <= work.successful_traversals);
     }
 
     // A numeric key for tests that need an unbounded supply of distinct keys
@@ -10423,6 +10775,7 @@ mod tests {
             nested_attempt_filters: Mutex::new(Vec::new()),
             validation_endorsements: Mutex::new(Vec::new()),
             validation_proofs: Mutex::new(Vec::new()),
+            validation_work: AtomicValidationWork::default(),
             leases: Mutex::new(TaskLeases::default()),
             observed_handoffs: Mutex::new(Vec::new()),
             checked_handoffs: Mutex::new(HashSet::new()),
@@ -10475,6 +10828,7 @@ mod tests {
             nested_attempt_filters: Mutex::new(Vec::new()),
             validation_endorsements: Mutex::new(Vec::new()),
             validation_proofs: Mutex::new(Vec::new()),
+            validation_work: AtomicValidationWork::default(),
             leases: Mutex::new(TaskLeases::default()),
             observed_handoffs: Mutex::new(Vec::new()),
             checked_handoffs: Mutex::new(HashSet::new()),
@@ -10749,6 +11103,7 @@ mod tests {
             nested_attempt_filters: Mutex::new(Vec::new()),
             validation_endorsements: Mutex::new(Vec::new()),
             validation_proofs: Mutex::new(Vec::new()),
+            validation_work: AtomicValidationWork::default(),
             leases: Mutex::new(TaskLeases::default()),
             observed_handoffs: Mutex::new(Vec::new()),
             checked_handoffs: Mutex::new(HashSet::new()),
@@ -12188,13 +12543,11 @@ mod tests {
             runtime.request_registered(&root, second, Key("root"), CancellationToken::new());
         assert_eq!(reused.execution(), RequestExecution::Reused);
         let after = runtime.metrics();
+        let validation = after.validation.saturating_sub(before.validation);
+        assert_validation_work_consistent(validation);
+        assert_eq!(validation.memo_misses, 3);
         assert_eq!(
-            after.validation_memo_misses - before.validation_memo_misses,
-            3
-        );
-        assert_eq!(
-            after.validation_memo_hits - before.validation_memo_hits,
-            1,
+            validation.memo_hits, 1,
             "the second edge into the shared leaf uses its revision memo"
         );
         assert_eq!(

--- a/docs/designs/0068-incremental-edit-performance-measurement.md
+++ b/docs/designs/0068-incremental-edit-performance-measurement.md
@@ -176,6 +176,9 @@ Every raw observation records at least:
   runnable-ready durations, present only for their declared outcome;
 - exact computed, reused, joined, invalidated, canceled, and evicted work by
   available compiler phase;
+- exact retained-terminal validation traversals and outcomes, input/dependency
+  observations, registry and memo results, registered-cone endorsements,
+  re-demand outcomes, superseded incarnations, and published certificates;
 - current and peak retained artifact charge, dependency/input observations, and
   configured budgets;
 - diagnostics/warning identity and executable fingerprint;
@@ -186,6 +189,9 @@ Every raw observation records at least:
 The compiler's deterministic counters are authoritative for locality. Process
 RSS may be recorded as an advisory host observation, but it cannot replace the
 session's retained-charge gauges or serve as an exact eviction assertion.
+High-frequency validation counters accumulate on each rooted request and merge
+once at task completion; the measurement contract does not permit a shared
+atomic or lock acquisition for every validation event.
 
 Unknown fields are rejected. Schema changes and fixture changes advance separate
 explicit revisions so a workload edit cannot silently reset its own history.

--- a/performance/incremental.toml
+++ b/performance/incremental.toml
@@ -5,7 +5,7 @@
 # Fixture edits are added under a new `fixture_revision`; raw report syntax
 # advances independently under `report_schema_version`.
 schema_version = 2
-report_schema_version = 2
+report_schema_version = 3
 fixture_revision = 2
 # Two workloads each collect seven one-sample structural rows and one five-
 # sample latency row: 24 independent retained sessions in the scheduled matrix.


### PR DESCRIPTION
Fixes RUE-1328.

## What changed

- Add a 21-counter retained-terminal validation ledger covering traversal outcomes, observations, registry and memo work, endorsements, re-demands, superseded incarnations, and certificates.
- Accumulate hot events on each rooted request and merge once at task completion, including structured batch children.
- Expose the ledger through compiler metrics and the maintained incremental report.
- Advance the raw report schema to v3 and strictly validate counter conservation laws.
- Document the counter and aggregation contract in ADR-0068.

## Why

Validation dominates retained no-op work, but the old two-counter view could not distinguish graph traversal, lookup, re-demand, and proof costs. Shared per-event instrumentation previously showed material observer overhead; request-local aggregation keeps the broader ledger cheap enough to leave enabled.

## Validation

- `//crates/rue-query:rue-query-test`: 135 passed
- `//crates/rue-perf-schema:rue-perf-schema-test`: 105 passed
- `//crates/rue-bench:rue-bench-test`: 73 passed, 2 expected ignored
- Compiler and lint portions of `scripts/rue premerge` passed; the redundant long corpus tail is delegated to CI.
- Three maintained Lattice no-op samples produced identical ledgers and warm times of 11.315s, 10.566s, and 10.881s (median 10.881s), versus the prior 11.22s median. No measurable observer regression.