### PR TITLE
RUE-1329: snapshot live query runtime counters

### DIFF
--- a/crates/rue-compiler/src/session.rs
+++ b/crates/rue-compiler/src/session.rs
@@ -3096,7 +3096,17 @@ impl CompilerSession {
     /// The snapshot cannot be installed back into this or another session and
     /// therefore grants no access to query ownership or invalidation state.
     pub fn unstable_metrics(&self) -> crate::unstable::MetricsSnapshot {
-        crate::unstable::MetricsSnapshot::new(self.metrics.work().clone())
+        let mut work = self.metrics.work().clone();
+        // Query tasks publish counters independently of the session's phase
+        // projections. Read the runtime at this observation boundary so a
+        // baseline-to-successor delta cannot inherit late predecessor work.
+        let runtime = self.queries.revisioned.runtime_retention_metrics();
+        work.runtime = FrontendRuntimeMetrics {
+            validation: runtime.validation,
+            retention_enforcements: runtime.retention_enforcements,
+            retention_scan_entries: runtime.retention_scan_entries,
+        };
+        crate::unstable::MetricsSnapshot::new(work)
     }
     #[cfg(test)]
     pub(crate) fn set_module_input_retention_for_test(&self, retention_limit: usize) {
@@ -7887,6 +7897,39 @@ mod tests {
         assert_eq!(warm.dependency_pins, cold.dependency_pins);
         assert!(warm.peak_retained_bytes >= warm.retained_bytes);
         assert!(warm.peak_dependency_pins >= warm.dependency_pins);
+    }
+
+    #[test]
+    fn unstable_metrics_observe_live_query_runtime_work() {
+        let source = base();
+        let options = CompileOptions::default();
+        let mut session = CompilerSession::new();
+        session.update(&source).into_result().unwrap();
+        session.canonical_semantic(&options).unwrap();
+        let merged = session.merge().unwrap();
+        let revision = session
+            .queries
+            .revisioned
+            .current_semantic_revision()
+            .unwrap();
+        let before = session.queries.revisioned.runtime_metrics_for_test();
+
+        session
+            .queries
+            .revisioned
+            .projected_declaration_shells(
+                revision,
+                merged.ast(),
+                rue_query::CancellationToken::new(),
+            )
+            .unwrap();
+
+        let live = session.queries.revisioned.runtime_metrics_for_test();
+        assert!(live.validation.traversals > before.validation.traversals);
+        let observed = session.unstable_metrics().query_runtime();
+        assert_eq!(observed.validation, live.validation.into());
+        assert_eq!(observed.retention_enforcements, live.retention_enforcements);
+        assert_eq!(observed.retention_scan_entries, live.retention_scan_entries);
     }
 
     #[test]

--- a/docs/designs/0068-incremental-edit-performance-measurement.md
+++ b/docs/designs/0068-incremental-edit-performance-measurement.md
@@ -192,6 +192,8 @@ session's retained-charge gauges or serve as an exact eviction assertion.
 High-frequency validation counters accumulate on each rooted request and merge
 once at task completion; the measurement contract does not permit a shared
 atomic or lock acquisition for every validation event.
+Baseline and successor observations snapshot those live runtime aggregates at
+the observation boundary rather than reusing a session phase's cached metrics.
 
 Unknown fields are rejected. Schema changes and fixture changes advance separate
 explicit revisions so a workload edit cannot silently reset its own history.


### PR DESCRIPTION
## Summary

- snapshot query-runtime validation and retention work live when `CompilerSession::unstable_metrics()` is observed
- prevent baseline-to-successor deltas from inheriting late work from a cached predecessor phase
- document the live observation boundary in ADR-0068
- add a focused regression test that performs runtime work without refreshing the session metrics cache

## Evidence

The maintained Lattice no-op run previously reported 3,646,577 validation walks and 3,552,584 re-demands. A temporary 1-in-64 family-labelled event profile observed 1,350,646 walks and 1,335,693 re-demands in the actual warm interval. With this change, the aggregate ledger reports exactly those live totals, including all 707 dirty traversals.

## Validation

- `scripts/rue fmt`
- `scripts/rue unit compiler unstable_metrics_observe_live_query_runtime_work`

Fixes RUE-1329.
Refs RUE-1328, RUE-1247.
