### PR TITLE
Overnight cycle 2, wave 1: FP register classes, std.fs/std.hash, ADR-0059 spec sweep, fuzz-to-Linear

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -5,10 +5,12 @@ on:
     - cron: '0 0 * * *'  # Daily at midnight UTC
   workflow_dispatch:  # Allow manual triggering
 
-# The default GITHUB_TOKEN is read-only; without issues:write the
-# "notify on failure" step below fails with "Resource not accessible by
-# integration" and nightly crashes are found but never reported (this
-# silently ate real crash reports for at least 2026-07-03/04).
+# Crashes are filed in Linear (RUE-802); GitHub Issues is the fallback used when
+# the LINEAR_API_KEY secret is missing. The default GITHUB_TOKEN is read-only,
+# and without issues:write that fallback fails with "Resource not accessible by
+# integration" — nightly crashes found but never reported (this silently ate
+# real crash reports for at least 2026-07-03/04). Keep issues:write even though
+# the primary path no longer needs it: it is what makes the fallback real.
 permissions:
   contents: read
   issues: write
@@ -164,66 +166,43 @@ jobs:
           echo "One or more fuzz targets found crashes (see step outcomes above)."
           exit 1
 
-      - name: Notify on failure (create or comment on the fuzz-crash issue)
+      # RUE-802: crashes are tracked in Linear (team Rue), ONE ISSUE PER DISTINCT
+      # CRASH FINGERPRINT. This replaced an inline `actions/github-script` block
+      # that kept a single ever-open GitHub issue labelled `fuzz-crash` and
+      # appended every later crash to it as a comment — dedup by label, which
+      # made two unrelated miscompiles indistinguishable from one bug recurring.
+      #
+      # The script prefers Linear and falls back to GitHub Issues (clearly
+      # marked as such in the filed issue) when LINEAR_API_KEY is absent, so a
+      # missing secret degrades the tracker instead of dropping the night's
+      # findings. With neither credential it exits non-zero, turning this step
+      # red rather than reporting nothing and passing.
+      #
+      # Fingerprinting, dedup, payload construction, and backend selection are
+      # pinned by //:fuzz-report-tool-tests against a mock transport.
+      - name: Report crashes (Linear, GitHub Issues fallback)
         if: failure()
-        uses: actions/github-script@v9
-        with:
-          script: |
-            const failed = [
-              ['lexer', '${{ steps.fuzz-lexer.outcome }}'],
-              ['parser', '${{ steps.fuzz-parser.outcome }}'],
-              ['sema', '${{ steps.fuzz-sema.outcome }}'],
-              ['compiler', '${{ steps.fuzz-compiler.outcome }}'],
-              ['payload_schemas', '${{ steps.fuzz-payload-schemas.outcome }}'],
-              ['emitter', '${{ steps.fuzz-emitter.outcome }}'],
-              ['emitter_aarch64', '${{ steps.fuzz-emitter-aarch64.outcome }}'],
-              ['emitter_sequence', '${{ steps.fuzz-emitter-sequence.outcome }}'],
-              ['emitter_sequence_aarch64', '${{ steps.fuzz-emitter-sequence-aarch64.outcome }}'],
-              ['differential', '${{ steps.fuzz-differential.outcome }}'],
-            ].filter(([, o]) => o === 'failure').map(([n]) => n);
-            const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
-            const summary = `**Run:** ${runUrl}\n**Failed targets:** ${failed.join(', ') || '(job-level failure)'}\n`;
-            const body = `## Fuzz Testing Failure
-
-            The daily fuzz testing workflow found a crash.
-
-            ${summary}
-            ### Next Steps
-            1. Download the crash artifacts from the workflow run. Each
-               reproducer is named \`crash-<target>-<sighash>-<inputhash>.txt\`
-               with a \`.meta\` sibling recording the crash class and
-               signature; the fuzzer detects panics, *aborts* (stack overflow /
-               SIGABRT / SIGSEGV / SIGFPE), hangs (per-input timeout), and
-               graceful ICEs, deduping by crash signature (RUE-43).
-            2. Reproduce locally by feeding the saved input to the target named
-               in the filename, e.g. for a source-level target:
-               \`./buck2 run //crates/rue-fuzz:rue-fuzz -- <target> <dir-with-the-file>\`
-            3. Fix the issue and add a regression test
-            `;
-
-            // One open tracking issue at a time; new crashes while it is open
-            // are appended as comments instead of being silently dropped.
-            const issues = await github.rest.issues.listForRepo({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              state: 'open',
-              labels: 'fuzz-crash'
-            });
-
-            if (issues.data.length === 0) {
-              const title = `Fuzz testing found a crash (${new Date().toISOString().split('T')[0]})`;
-              await github.rest.issues.create({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                title: title,
-                body: body,
-                labels: ['fuzz-crash', 'bug']
-              });
-            } else {
-              await github.rest.issues.createComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: issues.data[0].number,
-                body: `Another nightly fuzz failure while this issue is open.\n\n${summary}`
-              });
-            }
+        env:
+          LINEAR_API_KEY: ${{ secrets.LINEAR_API_KEY }}
+          GITHUB_TOKEN: ${{ github.token }}
+        run: |
+          failed=""
+          record() {
+            if [ "$2" = "failure" ]; then
+              failed="${failed:+$failed,}$1"
+            fi
+          }
+          record lexer '${{ steps.fuzz-lexer.outcome }}'
+          record parser '${{ steps.fuzz-parser.outcome }}'
+          record sema '${{ steps.fuzz-sema.outcome }}'
+          record compiler '${{ steps.fuzz-compiler.outcome }}'
+          record payload_schemas '${{ steps.fuzz-payload-schemas.outcome }}'
+          record emitter '${{ steps.fuzz-emitter.outcome }}'
+          record emitter_aarch64 '${{ steps.fuzz-emitter-aarch64.outcome }}'
+          record emitter_sequence '${{ steps.fuzz-emitter-sequence.outcome }}'
+          record emitter_sequence_aarch64 '${{ steps.fuzz-emitter-sequence-aarch64.outcome }}'
+          record differential '${{ steps.fuzz-differential.outcome }}'
+          python3 scripts/fuzz-report-failure.py \
+            --crash-dir crates/rue-fuzz/crashes \
+            --failed-targets "$failed" \
+            --run-url "$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID"

--- a/BUCK
+++ b/BUCK
@@ -885,6 +885,28 @@ rue_sh_test(
     },
 )
 
+# RUE-802: the nightly fuzz workflow files crashes into Linear. The reporting
+# logic that decides whether a crash is filed once, filed twice, or lost — crash
+# fingerprinting, dedup against open issues, payload construction, and the
+# GitHub fallback when LINEAR_API_KEY is missing — cannot be exercised in CI
+# against the real API, so it is driven through its injected transport with a
+# mock. The workflow file is an input as well, so deleting the reporting step
+# fails this test instead of quietly restoring the silence.
+filegroup(
+    name = "fuzz-report-test-inputs",
+    srcs = [".github/workflows/fuzz.yml"],
+)
+
+rue_sh_test(
+    name = "fuzz-report-tool-tests",
+    test = "scripts/test-fuzz-report-failure.py",
+    env = {
+        "PYTHONDONTWRITEBYTECODE": "1",
+        "RUE_FUZZ_REPORT_ROOT": "$(location :fuzz-report-test-inputs)",
+    },
+    resources = ["scripts/fuzz-report-failure.py"],
+)
+
 # RUE-1119: pin the deterministic, coverage-deciding logic of the affected-
 # corpus selection — the out-of-graph force-full matcher in
 # scripts/affected-targets and the fail-open gate in scripts/ci-corpus-selected.

--- a/crates/rue-cli-tests/cases/fs_file_io.toml
+++ b/crates/rue-cli-tests/cases/fs_file_io.toml
@@ -1,7 +1,10 @@
 # V1 FOLLOW-UPS (ADR-0057 "Future Work"): the cases whose names begin `fs_seek_`,
 # `fs_stat_`/`fs_metadata_`, `fs_rename_`, `fs_remove_`, and `fs_mkdir_` exercise
 # seek/tell, fstat/newfstatat metadata, rename, unlink, and directory
-# create/remove. They are `only_on` the two Linux targets: this repo's CI host is
+# create/remove. The `fs_mkdir_` group also covers `create_dir_all` (RUE-995):
+# nested creation, idempotent re-creation, the separator shapes its byte scan has
+# to collapse, and the EEXIST-but-not-a-directory case.
+# They are `only_on` the two Linux targets: this repo's CI host is
 # Linux, and the macOS `struct stat` layout plus the Darwin *at/stat syscall
 # numbers are the DOCUMENTED, not-yet-device-verified follow-up (see std/fs.rue).
 # Seek offsets are bound to an `i64` value before the call to dodge a caller-side
@@ -721,4 +724,243 @@ fn main() -> i32 {
     }
 }
 """ }]
+exit_code = 0
+
+# RUE-995: a created directory must be USABLE, not merely present. `create_dir`,
+# then create/write/close a file INSIDE it, then reopen that file through the
+# same nested path and compare every byte. `stat` reporting `is_dir()` (the case
+# above) does not prove the directory is a working parent for `openat`; this
+# does. Exit code is the read count so a short read cannot pass as success.
+[[case]]
+name = "fs_mkdir_then_file_roundtrip_inside"
+only_on = ["x86-64-linux", "aarch64-linux"]
+env = { RUE_STD_PATH = "${REAL_STD}" }
+files = [{ path = "main.rue", source = """
+const std = @import("std");
+
+fn main() -> i32 {
+    let F = std.fs.File;
+    let FE = std.fs.FileError;
+    let R = std.result.Result(F, FE);
+    let WR = std.result.Result(u64, FE);
+    let CR = std.result.Result((), FE);
+    let Buf = std.arraybuf.ArrayBuf(u8);
+
+    let mut dir = std.strbuf.StrBuf.new();
+    dir.push_str("outdir");
+    match std.fs.create_dir(borrow dir) { CR.Ok(_u) => {}, CR.Err(_e) => { return 61; } };
+
+    let mut path = std.strbuf.StrBuf.new();
+    path.push_str("outdir/inner.dat");
+
+    let msg = "inside-the-dir";
+    let mut out = Buf.new();
+    let mut i: u64 = 0;
+    while i < msg.len() { out.push(msg[i]); i = i + 1; }
+
+    let mut f = match F.create(borrow path) { R.Ok(x) => x, R.Err(_e) => { return 62; } };
+    let nw = match f.write(borrow out) { WR.Ok(n) => n, WR.Err(_e) => { return 63; } };
+    match f.close() { CR.Ok(_u) => {}, CR.Err(_e) => { return 64; } };
+
+    let mut g = match F.open(borrow path) { R.Ok(x) => x, R.Err(_e) => { return 65; } };
+    let mut inb = Buf.with_capacity(64);
+    let nr = match g.read(inout inb) { WR.Ok(n) => n, WR.Err(_e) => { return 66; } };
+    match g.close() { CR.Ok(_u) => {}, CR.Err(_e) => { return 67; } };
+
+    if nr != nw { return 68; }
+    let mut j: u64 = 0;
+    while j < nr {
+        if inb.get_or(j, 0) != msg[j] { return 69; }
+        j = j + 1;
+    }
+    @dbg(nr);
+    @intCast(nr)
+}
+""" }]
+stdout = "14\n"
+exit_code = 14
+
+# RUE-995: `create_dir_all` builds a chain of MISSING parents that the flat
+# `create_dir` cannot. Assert each of the three levels independently stats as a
+# directory — not just the leaf, since a bug that created only the leaf's name
+# would still fail `openat` later — and that a file writes and reads back
+# through the full nested path. The trailing byte check is 'd' (100) of "deep".
+[[case]]
+name = "fs_mkdir_all_nested_levels_usable"
+only_on = ["x86-64-linux", "aarch64-linux"]
+env = { RUE_STD_PATH = "${REAL_STD}" }
+files = [{ path = "main.rue", source = """
+const std = @import("std");
+
+fn main() -> i32 {
+    let F = std.fs.File;
+    let FE = std.fs.FileError;
+    let R = std.result.Result(F, FE);
+    let WR = std.result.Result(u64, FE);
+    let CR = std.result.Result((), FE);
+    let MR = std.result.Result(std.fs.Metadata, FE);
+    let Buf = std.arraybuf.ArrayBuf(u8);
+
+    let mut deep = std.strbuf.StrBuf.new();
+    deep.push_str("lvl1/lvl2/lvl3");
+    match std.fs.create_dir_all(borrow deep) { CR.Ok(_u) => {}, CR.Err(_e) => { return 61; } };
+
+    // Every level, outermost first, must be a real directory.
+    let mut one = std.strbuf.StrBuf.new();
+    one.push_str("lvl1");
+    let m1 = match std.fs.metadata(borrow one) { MR.Ok(m) => m, MR.Err(_e) => { return 62; } };
+    if m1.is_dir() { @dbg(1); } else { @dbg(0); }
+
+    let mut two = std.strbuf.StrBuf.new();
+    two.push_str("lvl1/lvl2");
+    let m2 = match std.fs.metadata(borrow two) { MR.Ok(m) => m, MR.Err(_e) => { return 63; } };
+    if m2.is_dir() { @dbg(2); } else { @dbg(0); }
+
+    let m3 = match std.fs.metadata(borrow deep) { MR.Ok(m) => m, MR.Err(_e) => { return 64; } };
+    if m3.is_dir() { @dbg(3); } else { @dbg(0); }
+
+    // The deepest level is a usable parent for a file.
+    let mut path = std.strbuf.StrBuf.new();
+    path.push_str("lvl1/lvl2/lvl3/leaf.txt");
+    let msg = "deep";
+    let mut out = Buf.new();
+    let mut i: u64 = 0;
+    while i < msg.len() { out.push(msg[i]); i = i + 1; }
+
+    let mut f = match F.create(borrow path) { R.Ok(x) => x, R.Err(_e) => { return 65; } };
+    match f.write(borrow out) { WR.Ok(_n) => {}, WR.Err(_e) => { return 66; } };
+    match f.close() { CR.Ok(_u) => {}, CR.Err(_e) => { return 67; } };
+
+    let mut g = match F.open(borrow path) { R.Ok(x) => x, R.Err(_e) => { return 68; } };
+    let mut inb = Buf.with_capacity(16);
+    let nr = match g.read(inout inb) { WR.Ok(n) => n, WR.Err(_e) => { return 69; } };
+    match g.close() { CR.Ok(_u) => {}, CR.Err(_e) => { return 70; } };
+    @dbg(nr);
+    @dbg(inb.get_or(0, 0));
+    0
+}
+""" }]
+stdout = "1\n2\n3\n4\n100\n"
+exit_code = 0
+
+# RUE-995 double-create: the two spellings differ deliberately, so assert BOTH
+# behaviors in one program. `create_dir` twice reports `AlreadyExists` (it is a
+# request to create, and the second one did not); `create_dir_all` twice reports
+# `Ok` (it is a request to ensure existence, which holds). A regression that
+# unified them would flip exactly one of these @dbg lines.
+[[case]]
+name = "fs_mkdir_double_create_flat_errs_recursive_ok"
+only_on = ["x86-64-linux", "aarch64-linux"]
+env = { RUE_STD_PATH = "${REAL_STD}" }
+files = [{ path = "main.rue", source = """
+const std = @import("std");
+
+fn main() -> i32 {
+    let FE = std.fs.FileError;
+    let CR = std.result.Result((), FE);
+
+    let mut flat = std.strbuf.StrBuf.new();
+    flat.push_str("twice");
+    match std.fs.create_dir(borrow flat) { CR.Ok(_u) => { @dbg(1); }, CR.Err(_e) => { return 61; } };
+    match std.fs.create_dir(borrow flat) {
+        CR.Ok(_u) => { return 62; },
+        CR.Err(e) => match e { FE.AlreadyExists => { @dbg(2); }, _ => { return 63; } },
+    };
+
+    let mut rec = std.strbuf.StrBuf.new();
+    rec.push_str("ensure/me");
+    match std.fs.create_dir_all(borrow rec) { CR.Ok(_u) => { @dbg(3); }, CR.Err(_e) => { return 64; } };
+    match std.fs.create_dir_all(borrow rec) { CR.Ok(_u) => { @dbg(4); }, CR.Err(_e) => { return 65; } };
+
+    // Ensuring a path whose components all exist already is also Ok.
+    match std.fs.create_dir_all(borrow flat) { CR.Ok(_u) => { @dbg(5); }, CR.Err(_e) => { return 66; } };
+    0
+}
+""" }]
+stdout = "1\n2\n3\n4\n5\n"
+exit_code = 0
+
+# RUE-995 path shapes: `create_dir_all` scans bytes because Rue has no path type,
+# so the separator edge cases are the risky part. A repeated separator must not
+# try to create an empty prefix (which would be ENOENT), a trailing separator
+# must not create an empty final component, "/" must succeed without creating
+# anything, and the empty path must be NotFound rather than a silent success.
+[[case]]
+name = "fs_mkdir_all_separator_shapes"
+only_on = ["x86-64-linux", "aarch64-linux"]
+env = { RUE_STD_PATH = "${REAL_STD}" }
+files = [{ path = "main.rue", source = """
+const std = @import("std");
+
+fn main() -> i32 {
+    let FE = std.fs.FileError;
+    let CR = std.result.Result((), FE);
+    let MR = std.result.Result(std.fs.Metadata, FE);
+
+    // Repeated and trailing separators collapse: this names p/q, nothing else.
+    let mut messy = std.strbuf.StrBuf.new();
+    messy.push_str("p//q/");
+    match std.fs.create_dir_all(borrow messy) { CR.Ok(_u) => { @dbg(1); }, CR.Err(_e) => { return 61; } };
+
+    let mut pq = std.strbuf.StrBuf.new();
+    pq.push_str("p/q");
+    let m = match std.fs.metadata(borrow pq) { MR.Ok(x) => x, MR.Err(_e) => { return 62; } };
+    if m.is_dir() { @dbg(2); } else { @dbg(0); }
+
+    // The root always exists, so ensuring it creates nothing and succeeds.
+    let mut root = std.strbuf.StrBuf.new();
+    root.push_str("/");
+    match std.fs.create_dir_all(borrow root) { CR.Ok(_u) => { @dbg(3); }, CR.Err(_e) => { return 63; } };
+
+    // The empty path names nothing: NotFound, never Ok.
+    let empty = std.strbuf.StrBuf.new();
+    match std.fs.create_dir_all(borrow empty) {
+        CR.Ok(_u) => { return 64; },
+        CR.Err(e) => match e { FE.NotFound => { @dbg(4); }, _ => { return 65; } },
+    };
+    0
+}
+""" }]
+stdout = "1\n2\n3\n4\n"
+exit_code = 0
+
+# RUE-995: EEXIST alone must not be read as success. A REGULAR FILE occupying a
+# component's name means the directory does not exist and never will, so both
+# the through-path form and the exact-path form stay errors. Without the `stat`
+# behind the EEXIST check, the second match here would wrongly report Ok.
+[[case]]
+name = "fs_mkdir_all_file_in_the_way_errs"
+only_on = ["x86-64-linux", "aarch64-linux"]
+env = { RUE_STD_PATH = "${REAL_STD}" }
+files = [{ path = "main.rue", source = """
+const std = @import("std");
+
+fn main() -> i32 {
+    let F = std.fs.File;
+    let FE = std.fs.FileError;
+    let R = std.result.Result(F, FE);
+    let CR = std.result.Result((), FE);
+
+    let mut fp = std.strbuf.StrBuf.new();
+    fp.push_str("blocker");
+    let f = match F.create(borrow fp) { R.Ok(x) => x, R.Err(_e) => { return 61; } };
+    match f.close() { CR.Ok(_u) => {}, CR.Err(_e) => { return 62; } };
+
+    // Descending THROUGH the file: the kernel rejects the child mkdir.
+    let mut through = std.strbuf.StrBuf.new();
+    through.push_str("blocker/sub");
+    match std.fs.create_dir_all(borrow through) {
+        CR.Ok(_u) => { return 63; },
+        CR.Err(_e) => { @dbg(1); },
+    };
+
+    // Ensuring the file's own path: EEXIST, but the entry is not a directory.
+    match std.fs.create_dir_all(borrow fp) {
+        CR.Ok(_u) => { return 64; },
+        CR.Err(e) => match e { FE.AlreadyExists => { @dbg(2); }, _ => { return 65; } },
+    };
+    0
+}
+""" }]
+stdout = "1\n2\n"
 exit_code = 0

--- a/crates/rue-cli-tests/cases/std_hash.toml
+++ b/crates/rue-cli-tests/cases/std_hash.toml
@@ -1,0 +1,278 @@
+# std.hash (RUE-682) — FNV-1a/64 and djb2 byte hashing.
+#
+# Every assertion is exact-stdout through @dbg. A hash case CANNOT assert
+# through the exit code: the value is 64 bits and an exit status is taken mod
+# 256, so 255 wrong hashes out of every 256 would still "pass". The cases below
+# compare the full 64-bit value against a literal known answer and @dbg a 1/0.
+#
+# KNOWN ANSWERS. The FNV-1a/64 values are the PUBLISHED vectors (offset basis
+# 0xcbf29ce484222325, prime 0x100000001b3), so they check this implementation
+# against the outside world, not merely against itself:
+#   ""       0xcbf29ce484222325 = 14695981039346656037
+#   "a"      0xaf63dc4c8601ec8c = 12638187200555641996
+#   "foobar" 0x85944171f73967e8 = 9625390261332436968
+# djb2 has no comparable published vector set and is most often quoted at 32
+# bits; std.hash defines it with a 64-BIT state (h = h*33 + c, seed 5381), and
+# these are that definition's values:
+#   ""       0x1505        = 5381
+#   "a"      0x2b606       = 177670
+#   "foobar" 0x652fde460be = 6953516687550
+# "foobar" is the load-bearing djb2 vector: its intermediate products exceed
+# 2^32, so a 32-bit-truncating state would fail it while still passing "a".
+#
+# These cases run on EVERY target. std.hash is pure integer arithmetic over
+# @wrapping_mul/@wrapping_add with no syscall or per-OS data, so a divergence
+# between targets would be a codegen bug, which is exactly what running them
+# everywhere would catch.
+
+[section]
+id = "cli.std_hash"
+name = "Standard library — std.hash (RUE-682)"
+description = "FNV-1a/64 and djb2 byte hashing: published known answers, chunking independence, and agreement across str/StrBuf/ArrayBuf."
+
+# The known-answer test. Six literal vectors, three per algorithm, including the
+# empty input (which must be the seed, not zero) and a multi-byte input whose
+# djb2 intermediates exceed 32 bits.
+[[case]]
+name = "hash_known_answer_vectors"
+description = "FNV-1a/64 matches the published vectors; djb2 matches its 64-bit definition."
+env = { RUE_STD_PATH = "${REAL_STD}" }
+files = [{ path = "main.rue", source = """
+const std = @import("std");
+
+fn main() -> i32 {
+    // FNV-1a/64, published vectors.
+    if std.hash.fnv1a_str(borrow "") == 14695981039346656037 { @dbg(1); } else { @dbg(0); }
+    if std.hash.fnv1a_str(borrow "a") == 12638187200555641996 { @dbg(2); } else { @dbg(0); }
+    if std.hash.fnv1a_str(borrow "foobar") == 9625390261332436968 { @dbg(3); } else { @dbg(0); }
+
+    // djb2, 64-bit state.
+    if std.hash.djb2_str(borrow "") == 5381 { @dbg(4); } else { @dbg(0); }
+    if std.hash.djb2_str(borrow "a") == 177670 { @dbg(5); } else { @dbg(0); }
+    if std.hash.djb2_str(borrow "foobar") == 6953516687550 { @dbg(6); } else { @dbg(0); }
+    0
+}
+""" }]
+stdout = "1\n2\n3\n4\n5\n6\n"
+exit_code = 0
+
+# The two algorithms must be genuinely different functions, and the choice must
+# stick to the hasher that was constructed. A Hasher built for one algorithm
+# stepping the other's rule is the failure this catches — it would show up as
+# equal hashes here, or as a hasher disagreeing with its own one-shot helper.
+[[case]]
+name = "hash_algorithms_are_distinct_and_selected"
+description = "Fnv1a and Djb2 differ on the same input, and each Hasher matches its own one-shot helper."
+env = { RUE_STD_PATH = "${REAL_STD}" }
+files = [{ path = "main.rue", source = """
+const std = @import("std");
+
+fn main() -> i32 {
+    let f = std.hash.fnv1a_str(borrow "foobar");
+    let d = std.hash.djb2_str(borrow "foobar");
+    if f != d { @dbg(1); } else { @dbg(0); }
+
+    // Constructed by algorithm, both spellings.
+    let mut a = std.hash.Hasher.fnv1a();
+    a.write_str(borrow "foobar");
+    if a.finish() == f { @dbg(2); } else { @dbg(0); }
+
+    let mut b = std.hash.Hasher.new(std.hash.Algorithm.Fnv1a);
+    b.write_str(borrow "foobar");
+    if b.finish() == f { @dbg(3); } else { @dbg(0); }
+
+    let mut c = std.hash.Hasher.djb2();
+    c.write_str(borrow "foobar");
+    if c.finish() == d { @dbg(4); } else { @dbg(0); }
+
+    let mut e = std.hash.Hasher.new(std.hash.Algorithm.Djb2);
+    e.write_str(borrow "foobar");
+    if e.finish() == d { @dbg(5); } else { @dbg(0); }
+
+    // A fresh hasher starts at its algorithm's seed, so finish() before any
+    // write is the empty-input hash.
+    let g = std.hash.Hasher.fnv1a();
+    if g.finish() == 14695981039346656037 { @dbg(6); } else { @dbg(0); }
+    let h = std.hash.Hasher.djb2();
+    if h.finish() == 5381 { @dbg(7); } else { @dbg(0); }
+    0
+}
+""" }]
+stdout = "1\n2\n3\n4\n5\n6\n7\n"
+exit_code = 0
+
+# The incremental contract: the result depends only on the concatenated bytes,
+# never on how they were split across write_* calls. Split "foobar" three
+# different ways — including one byte at a time and across two different write_*
+# spellings — and every result must equal the one-shot hash.
+[[case]]
+name = "hash_chunking_does_not_change_result"
+description = "Any split of the same byte sequence hashes identically, for both algorithms."
+env = { RUE_STD_PATH = "${REAL_STD}" }
+files = [{ path = "main.rue", source = """
+const std = @import("std");
+
+fn main() -> i32 {
+    let want = std.hash.fnv1a_str(borrow "foobar");
+
+    let mut a = std.hash.Hasher.fnv1a();
+    a.write_str(borrow "foo");
+    a.write_str(borrow "bar");
+    if a.finish() == want { @dbg(1); } else { @dbg(0); }
+
+    // One byte at a time: f o o b a r
+    let mut b = std.hash.Hasher.fnv1a();
+    b.write_byte(102); b.write_byte(111); b.write_byte(111);
+    b.write_byte(98); b.write_byte(97); b.write_byte(114);
+    if b.finish() == want { @dbg(2); } else { @dbg(0); }
+
+    // Mixed spellings across the same boundary.
+    let mut sb = std.strbuf.StrBuf.new();
+    sb.push_str("bar");
+    let mut c = std.hash.Hasher.fnv1a();
+    c.write_byte(102);
+    c.write_str(borrow "oo");
+    c.write_strbuf(borrow sb);
+    if c.finish() == want { @dbg(3); } else { @dbg(0); }
+
+    // Same three splits for djb2.
+    let dwant = std.hash.djb2_str(borrow "foobar");
+    let mut d = std.hash.Hasher.djb2();
+    d.write_str(borrow "foo");
+    d.write_str(borrow "bar");
+    if d.finish() == dwant { @dbg(4); } else { @dbg(0); }
+
+    let mut e = std.hash.Hasher.djb2();
+    e.write_byte(102); e.write_byte(111); e.write_byte(111);
+    e.write_byte(98); e.write_byte(97); e.write_byte(114);
+    if e.finish() == dwant { @dbg(5); } else { @dbg(0); }
+
+    // Writing NOTHING is a no-op, not a state change.
+    let mut g = std.hash.Hasher.fnv1a();
+    g.write_str(borrow "foobar");
+    g.write_str(borrow "");
+    if g.finish() == want { @dbg(6); } else { @dbg(0); }
+    0
+}
+""" }]
+stdout = "1\n2\n3\n4\n5\n6\n"
+exit_code = 0
+
+# The three byte-shaped inputs are three spellings of one byte sequence, so all
+# three must agree. A StrBuf or ArrayBuf path that dropped, duplicated, or
+# reordered a byte would diverge from the `str` path here.
+[[case]]
+name = "hash_str_strbuf_arraybuf_agree"
+description = "str, StrBuf, and ArrayBuf(u8) holding the same bytes hash identically."
+env = { RUE_STD_PATH = "${REAL_STD}" }
+files = [{ path = "main.rue", source = """
+const std = @import("std");
+
+fn main() -> i32 {
+    let Bytes = std.arraybuf.ArrayBuf(u8);
+    let msg = "the quick brown fox";
+
+    let mut sb = std.strbuf.StrBuf.new();
+    sb.push_str("the quick brown fox");
+
+    let mut ab = Bytes.new();
+    let mut i: u64 = 0;
+    while i < msg.len() { ab.push(msg[i]); i = i + 1; }
+
+    let f = std.hash.fnv1a_str(borrow msg);
+    if std.hash.fnv1a_strbuf(borrow sb) == f { @dbg(1); } else { @dbg(0); }
+    if std.hash.fnv1a_bytes(borrow ab) == f { @dbg(2); } else { @dbg(0); }
+
+    let d = std.hash.djb2_str(borrow msg);
+    if std.hash.djb2_strbuf(borrow sb) == d { @dbg(3); } else { @dbg(0); }
+    if std.hash.djb2_bytes(borrow ab) == d { @dbg(4); } else { @dbg(0); }
+
+    // Empty containers hash as the empty input, i.e. the bare seed.
+    let esb = std.strbuf.StrBuf.new();
+    let eab = Bytes.new();
+    if std.hash.fnv1a_strbuf(borrow esb) == 14695981039346656037 { @dbg(5); } else { @dbg(0); }
+    if std.hash.djb2_bytes(borrow eab) == 5381 { @dbg(6); } else { @dbg(0); }
+    0
+}
+""" }]
+stdout = "1\n2\n3\n4\n5\n6\n"
+exit_code = 0
+
+# Byte SENSITIVITY and order sensitivity. Two inputs differing in one bit of one
+# byte, and two that are permutations of each other, must not collide — this is
+# what catches a step function that ignores its byte argument or accumulates
+# order-independently (e.g. XOR-only, or a dropped multiply).
+[[case]]
+name = "hash_order_and_byte_sensitive"
+description = "Single-byte differences and reorderings change both hashes."
+env = { RUE_STD_PATH = "${REAL_STD}" }
+files = [{ path = "main.rue", source = """
+const std = @import("std");
+
+fn main() -> i32 {
+    // One byte apart: "a" vs "b".
+    if std.hash.fnv1a_str(borrow "a") != std.hash.fnv1a_str(borrow "b") { @dbg(1); } else { @dbg(0); }
+    if std.hash.djb2_str(borrow "a") != std.hash.djb2_str(borrow "b") { @dbg(2); } else { @dbg(0); }
+
+    // Permutations: "ab" vs "ba".
+    if std.hash.fnv1a_str(borrow "ab") != std.hash.fnv1a_str(borrow "ba") { @dbg(3); } else { @dbg(0); }
+    if std.hash.djb2_str(borrow "ab") != std.hash.djb2_str(borrow "ba") { @dbg(4); } else { @dbg(0); }
+
+    // A NUL byte is data, not a terminator: "a\\0b" differs from "a".
+    let mut with_nul = std.strbuf.StrBuf.new();
+    with_nul.push(97); with_nul.push(0); with_nul.push(98);
+    if std.hash.fnv1a_strbuf(borrow with_nul) != std.hash.fnv1a_str(borrow "a") { @dbg(5); } else { @dbg(0); }
+
+    // High bytes (>= 0x80) are hashed as unsigned, so 0xff is not -1: hashing
+    // it must equal stepping the seed with 255, not with a sign-extended value.
+    let mut high = std.strbuf.StrBuf.new();
+    high.push(255);
+    let mut hh = std.hash.Hasher.djb2();
+    hh.write_byte(255);
+    if std.hash.djb2_strbuf(borrow high) == hh.finish() { @dbg(6); } else { @dbg(0); }
+    // 5381 * 33 + 255 = 177828
+    if std.hash.djb2_strbuf(borrow high) == 177828 { @dbg(7); } else { @dbg(0); }
+    0
+}
+""" }]
+stdout = "1\n2\n3\n4\n5\n6\n7\n"
+exit_code = 0
+
+# `reset` returns a hasher to its own algorithm's seed, so one hasher can hash a
+# sequence of independent values. Asserted against a freshly constructed hasher
+# for both algorithms, and after a partial write rather than only from clean.
+[[case]]
+name = "hash_reset_restores_seed"
+description = "reset() makes a used hasher behave exactly like a fresh one."
+env = { RUE_STD_PATH = "${REAL_STD}" }
+files = [{ path = "main.rue", source = """
+const std = @import("std");
+
+fn main() -> i32 {
+    let mut a = std.hash.Hasher.fnv1a();
+    a.write_str(borrow "garbage");
+    a.reset();
+    if a.finish() == 14695981039346656037 { @dbg(1); } else { @dbg(0); }
+    a.write_str(borrow "foobar");
+    if a.finish() == std.hash.fnv1a_str(borrow "foobar") { @dbg(2); } else { @dbg(0); }
+
+    let mut b = std.hash.Hasher.djb2();
+    b.write_byte(7);
+    b.reset();
+    if b.finish() == 5381 { @dbg(3); } else { @dbg(0); }
+    b.write_str(borrow "foobar");
+    if b.finish() == 6953516687550 { @dbg(4); } else { @dbg(0); }
+
+    // finish() itself does NOT reset: reading twice gives the same value, and
+    // writing after a finish continues from where it left off.
+    let mut c = std.hash.Hasher.fnv1a();
+    c.write_str(borrow "foo");
+    let first = c.finish();
+    if c.finish() == first { @dbg(5); } else { @dbg(0); }
+    c.write_str(borrow "bar");
+    if c.finish() == std.hash.fnv1a_str(borrow "foobar") { @dbg(6); } else { @dbg(0); }
+    0
+}
+""" }]
+stdout = "1\n2\n3\n4\n5\n6\n"
+exit_code = 0

--- a/crates/rue-codegen/src/aarch64/liveness.rs
+++ b/crates/rue-codegen/src/aarch64/liveness.rs
@@ -9,6 +9,7 @@ use super::mir::{Aarch64Inst, Aarch64Mir, Operand, Reg, ReturnBehavior};
 use crate::liveness::{
     LivenessAdapter, branch_successor, conditional_successors, fallthrough_successor,
 };
+use crate::reg_class::VRegClasses;
 use crate::vreg::{LabelId, VReg};
 
 // Re-export shared types from the regalloc module
@@ -31,6 +32,10 @@ impl LivenessAdapter for Aarch64LivenessAdapter<'_> {
 
     fn vreg_count(&self) -> u32 {
         self.mir.vreg_count()
+    }
+
+    fn vreg_classes(&self) -> &VRegClasses {
+        self.mir.vreg_classes()
     }
 
     fn label(&self, inst: &Self::Inst) -> Option<LabelId> {

--- a/crates/rue-codegen/src/aarch64/mir.rs
+++ b/crates/rue-codegen/src/aarch64/mir.rs
@@ -40,6 +40,7 @@ pub use rue_runtime_abi::ReturnBehavior;
 // - Aarch64Inst: 40 bytes
 const _: () = assert!(std::mem::size_of::<Aarch64Inst>() <= 48);
 
+pub use crate::reg_class::{RegClass, VRegClasses};
 pub use crate::vreg::{BLOCK_LABEL_BASE, LabelId, VReg};
 
 /// A physical AArch64 register.
@@ -200,6 +201,18 @@ const _: () = {
 };
 
 impl Reg {
+    /// The register class this register belongs to.
+    ///
+    /// Every `Reg` variant is an AArch64 general-purpose register (X0-X30, SP,
+    /// XZR), so this is [`RegClass::Gp`] throughout. The floats series adds the
+    /// V/D register variants that answer [`RegClass::Fp`]; until then this
+    /// method exists so the shared scheduler and allocator can ask the question
+    /// without special-casing a target that has only one class (RUE-1067).
+    #[inline]
+    pub const fn class(self) -> RegClass {
+        RegClass::Gp
+    }
+
     /// Get the register encoding for instruction fields (0-30 for X0-X30, 31 for SP/XZR).
     #[inline]
     pub const fn encoding(self) -> u8 {
@@ -1317,6 +1330,9 @@ pub struct Aarch64Mir {
     instructions: Vec<Aarch64Inst>,
     /// The next virtual register index.
     next_vreg: u32,
+    /// The register class of each virtual register, one entry per register
+    /// minted by [`Aarch64Mir::alloc_vreg_in`] and indexed by vreg index.
+    vreg_classes: VRegClasses,
     /// Next inline label ID for generating unique labels.
     ///
     /// Inline labels (for overflow checks, bounds checks, etc.) use IDs from
@@ -1339,6 +1355,7 @@ impl Aarch64Mir {
         Self {
             instructions: Vec::new(),
             next_vreg: 0,
+            vreg_classes: VRegClasses::new(),
             next_label: 0,
             symbols: Vec::new(),
             symbol_index: HashMap::new(),
@@ -1397,11 +1414,38 @@ impl Aarch64Mir {
         self.symbols = symbols;
     }
 
-    /// Allocate a new virtual register.
+    /// Allocate a new general-purpose virtual register.
+    ///
+    /// This is the whole of lowering today: no Rue type lowers to a
+    /// floating-point value yet, so every value a function computes lives in a
+    /// general-purpose register. Sites that later hold a floating-point value
+    /// call [`Aarch64Mir::alloc_vreg_in`] with [`RegClass::Fp`] instead (RUE-1067).
     pub fn alloc_vreg(&mut self) -> VReg {
+        self.alloc_vreg_in(RegClass::Gp)
+    }
+
+    /// Allocate a new virtual register of `class`, recording its class.
+    ///
+    /// The class table grows in lock-step with `next_vreg`, which is what lets
+    /// liveness hand allocation a table that covers every virtual register the
+    /// function has.
+    pub fn alloc_vreg_in(&mut self, class: RegClass) -> VReg {
         let vreg = VReg::new(self.next_vreg);
         self.next_vreg += 1;
+        self.vreg_classes.push(class);
         vreg
+    }
+
+    /// The register class of each virtual register.
+    #[inline]
+    pub fn vreg_classes(&self) -> &VRegClasses {
+        &self.vreg_classes
+    }
+
+    /// The register class of one virtual register.
+    #[inline]
+    pub fn vreg_class(&self, vreg: VReg) -> RegClass {
+        self.vreg_classes.class_of(vreg)
     }
 
     /// Allocate a new inline label ID.
@@ -1531,6 +1575,49 @@ mod tests {
         assert_eq!(v1.index(), 1);
         assert_eq!(v2.index(), 2);
         assert_eq!(mir.vreg_count(), 3);
+    }
+
+    #[test]
+    fn vreg_classes_cover_every_minted_register() {
+        // The allocator indexes the class table with any vreg the live ranges
+        // mention, so the table must stay exactly as long as `vreg_count`.
+        let mut mir = Aarch64Mir::new();
+        assert_eq!(mir.vreg_classes().len(), mir.vreg_count());
+        for _ in 0..4 {
+            mir.alloc_vreg();
+            assert_eq!(mir.vreg_classes().len(), mir.vreg_count());
+        }
+    }
+
+    #[test]
+    fn lowering_mints_general_purpose_registers_only() {
+        // Every value a Rue function computes is an integer, pointer, or
+        // boolean today, so `alloc_vreg` — the only mint site lowering uses —
+        // must produce general-purpose registers. When the floats series adds
+        // `alloc_vreg_in(RegClass::Fp)` call sites this stops being true of the
+        // program, but never of `alloc_vreg` itself (RUE-1067).
+        let mut mir = Aarch64Mir::new();
+        let vregs: Vec<_> = (0..3).map(|_| mir.alloc_vreg()).collect();
+        for vreg in vregs {
+            assert_eq!(mir.vreg_class(vreg), RegClass::Gp);
+        }
+        assert_eq!(mir.vreg_classes().count_in(RegClass::Fp), 0);
+    }
+
+    #[test]
+    fn an_explicit_class_is_recorded_as_given() {
+        let mut mir = Aarch64Mir::new();
+        let gp = mir.alloc_vreg_in(RegClass::Gp);
+        let fp = mir.alloc_vreg_in(RegClass::Fp);
+
+        assert_eq!(mir.vreg_class(gp), RegClass::Gp);
+        assert_eq!(mir.vreg_class(fp), RegClass::Fp);
+        assert_eq!(mir.vreg_classes().count_in(RegClass::Fp), 1);
+    }
+
+    #[test]
+    fn every_physical_register_is_general_purpose() {
+        assert_eq!(Reg::X19.class(), RegClass::Gp);
     }
 
     #[test]

--- a/crates/rue-codegen/src/aarch64/regalloc.rs
+++ b/crates/rue-codegen/src/aarch64/regalloc.rs
@@ -22,7 +22,7 @@ use super::mir::{
 use crate::alloc_dst;
 use crate::regalloc::{
     Allocation, AllocationContext, CoalesceCandidate, LivenessInfo, LoopInfo, RegAllocBackend,
-    RegAllocDebugInfo, RegAllocDriver, RegisterClasses, RematerializeOp, RewriteBuffer,
+    RegAllocDebugInfo, RegAllocDriver, RegisterFile, RematerializeOp, RewriteBuffer, SaveClasses,
 };
 
 /// Caller-saved registers offered to intervals no instruction clobbers while
@@ -1348,8 +1348,11 @@ impl RegAllocBackend for Aarch64Backend {
             .collect()
     }
 
-    fn register_classes() -> RegisterClasses<'static, Self::Reg> {
-        RegisterClasses {
+    fn register_file() -> RegisterFile<'static, Self::Reg> {
+        // General-purpose only: `Reg` names no floating-point register yet, so
+        // the `Fp` class of the file is empty and no interval can select it
+        // (RUE-1067). The floats series adds the V/D registers here.
+        RegisterFile::gp_only(SaveClasses {
             caller_saved: CALLER_SAVED_REGS,
             callee_saved: CALLEE_SAVED_REGS,
             // AArch64 instructions are a fixed four bytes and encode every
@@ -1358,7 +1361,7 @@ impl RegAllocBackend for Aarch64Backend {
             // preference has nothing to trade. Reusing a callee-saved register
             // in place of a caller-saved one here would only add pressure.
             compact_callee_saved: &[],
-        }
+        })
     }
 
     fn physical_operands(inst: &Self::Inst) -> Vec<Self::Reg> {
@@ -1398,12 +1401,53 @@ impl RegAllocBackend for Aarch64Backend {
 
 #[cfg(test)]
 mod tests {
+    use super::Aarch64Backend;
     use super::liveness;
     use super::{
         ALLOCATABLE_REGS, Aarch64Inst, Aarch64Mir, CALLEE_SAVED_REGS, CALLER_SAVED_REGS, Operand,
         Reg, RegAlloc, VReg,
     };
-    use crate::regalloc::{Allocation, RematerializeOp};
+    use crate::reg_class::RegClass;
+    use crate::regalloc::{Allocation, RegAllocBackend, RematerializeOp};
+
+    #[test]
+    fn the_register_file_is_general_purpose_only() {
+        // The whole of RUE-1067's claim on this backend: the class dimension
+        // exists, and the floating-point half of it is empty. A change that
+        // populates `Fp` here without the rest of the floats series would make
+        // allocation hand out registers no instruction can encode, so this
+        // guard fails loudly instead.
+        let file = <Aarch64Backend as RegAllocBackend>::register_file();
+        let gp = file.class(RegClass::Gp);
+        let fp = file.class(RegClass::Fp);
+
+        assert_eq!(gp.caller_saved, CALLER_SAVED_REGS);
+        assert_eq!(gp.callee_saved, CALLEE_SAVED_REGS);
+        assert!(!gp.is_empty());
+        assert!(
+            fp.is_empty(),
+            "no floating-point register is allocatable yet"
+        );
+        assert_eq!(file.len(), ALLOCATABLE_REGS.len());
+        assert_eq!(file.caller_saved_flattened(), CALLER_SAVED_REGS.to_vec());
+    }
+
+    #[test]
+    fn allocation_liveness_classes_every_vreg_as_general_purpose() {
+        // Liveness is where the class table reaches allocation, so this is the
+        // end-to-end statement that lowering mints one class only.
+        let mut mir = Aarch64Mir::new();
+        let vregs: Vec<VReg> = (0..3).map(|_| mir.alloc_vreg()).collect();
+        define_loaded_values(&mut mir, &vregs);
+
+        let info = liveness::analyze(&mir);
+
+        assert_eq!(info.vreg_classes.len(), mir.vreg_count());
+        assert_eq!(info.vreg_classes.count_in(RegClass::Fp), 0);
+        for &vreg in &vregs {
+            assert_eq!(info.class_of(vreg), RegClass::Gp);
+        }
+    }
 
     fn define_loaded_values(mir: &mut Aarch64Mir, vregs: &[VReg]) {
         for (index, &vreg) in vregs.iter().enumerate() {

--- a/crates/rue-codegen/src/aarch64/schedule.rs
+++ b/crates/rue-codegen/src/aarch64/schedule.rs
@@ -29,6 +29,7 @@
 //! Memory dependencies are handled conservatively (all loads/stores ordered).
 
 use super::mir::{Aarch64Inst, Aarch64Mir, Operand, Reg};
+use crate::reg_class::RegClass;
 use crate::schedule_core::{self, SchedulerAdapter};
 
 struct Aarch64Scheduler;
@@ -36,6 +37,10 @@ struct Aarch64Scheduler;
 impl SchedulerAdapter for Aarch64Scheduler {
     type Inst = Aarch64Inst;
     type Reg = Reg;
+
+    fn reg_class(&self, reg: Self::Reg) -> RegClass {
+        reg.class()
+    }
 
     fn latency(&self, inst: &Self::Inst) -> u32 {
         get_latency(inst)

--- a/crates/rue-codegen/src/lib.rs
+++ b/crates/rue-codegen/src/lib.rs
@@ -65,6 +65,7 @@ pub mod frame_layout;
 pub mod index_map;
 pub mod liveness;
 pub mod place_lower;
+pub mod reg_class;
 pub mod regalloc;
 pub mod types;
 pub mod vreg;
@@ -516,9 +517,10 @@ pub use cfg_lower::{
     BlockLoweringInfo, LoweringDebugInfo, LoweringDecision, TerminatorLoweringDecision,
 };
 pub use index_map::{Handle, IndexMap};
+pub use reg_class::{RegClass, VRegClasses};
 pub use regalloc::{
-    Allocation, InstructionLiveness, LivenessDebugInfo, RegAllocDebugInfo, RematerializeOp,
-    VRegInfo, linear_scan_with_debug, linear_scan_with_remat,
+    Allocation, InstructionLiveness, LivenessDebugInfo, RegAllocDebugInfo, RegisterFile,
+    RematerializeOp, SaveClasses, VRegInfo, linear_scan_with_debug, linear_scan_with_remat,
 };
 pub use stack_frame::{
     ArgumentLocation, ReturnLocation, StackFrameInfo, StackSlot, generate_stack_frame_info,

--- a/crates/rue-codegen/src/liveness.rs
+++ b/crates/rue-codegen/src/liveness.rs
@@ -23,6 +23,7 @@ use std::collections::HashMap;
 use fixedbitset::FixedBitSet;
 
 use crate::index_map::IndexMap;
+use crate::reg_class::VRegClasses;
 use crate::regalloc::{InstructionLiveness, LiveRange, LivenessDebugInfo, LivenessInfo, LoopInfo};
 use crate::vreg::{LabelId, VReg};
 
@@ -43,6 +44,14 @@ pub trait LivenessAdapter {
 
     /// Number of virtual registers allocated in the MIR.
     fn vreg_count(&self) -> u32;
+
+    /// The register class of every virtual register in the MIR.
+    ///
+    /// The MIR records this as it mints registers, and liveness copies it into
+    /// [`LivenessInfo::vreg_classes`] so allocation and coalescing read one
+    /// authoritative table. The returned table must have one entry per
+    /// register counted by [`LivenessAdapter::vreg_count`] (RUE-1067).
+    fn vreg_classes(&self) -> &VRegClasses;
 
     /// Return the label ID if `inst` is a label.
     fn label(&self, inst: &Self::Inst) -> Option<LabelId>;
@@ -83,6 +92,7 @@ where
     analyze(
         adapter.instructions(),
         adapter.vreg_count(),
+        adapter.vreg_classes().clone(),
         |inst| adapter.label(inst),
         |idx, inst, label_to_idx| adapter.successors(idx, inst, label_to_idx),
         |inst| adapter.uses(inst),
@@ -101,6 +111,7 @@ where
     analyze_debug::<_, A::Reg>(
         adapter.instructions(),
         adapter.vreg_count(),
+        adapter.vreg_classes().clone(),
         |inst| adapter.label(inst),
         |idx, inst, label_to_idx| adapter.successors(idx, inst, label_to_idx),
         |inst| adapter.uses(inst),
@@ -117,6 +128,7 @@ where
     analyze_with_debug(
         adapter.instructions(),
         adapter.vreg_count(),
+        adapter.vreg_classes().clone(),
         |inst| adapter.label(inst),
         |idx, inst, label_to_idx| adapter.successors(idx, inst, label_to_idx),
         |inst| adapter.uses(inst),
@@ -189,6 +201,8 @@ pub fn conditional_successors(
 ///
 /// * `instructions` - The instruction sequence to analyze
 /// * `vreg_count` - Total number of virtual registers
+/// * `vreg_classes` - The register class of each virtual register, carried
+///   through into [`LivenessInfo::vreg_classes`] for allocation and coalescing
 /// * `get_label` - Returns the label ID if the instruction is a label, None otherwise
 /// * `get_successors` - Returns the successor instruction indices for control flow
 /// * `get_uses` - Returns the virtual registers used (read) by the instruction
@@ -200,6 +214,7 @@ pub fn conditional_successors(
 pub fn analyze<I, R>(
     instructions: &[I],
     vreg_count: u32,
+    vreg_classes: VRegClasses,
     get_label: impl Fn(&I) -> Option<LabelId>,
     get_successors: impl Fn(usize, &I, &HashMap<LabelId, usize>) -> Vec<usize>,
     get_uses: impl Fn(&I) -> Vec<VReg>,
@@ -213,6 +228,7 @@ where
     analyze_inner(
         instructions,
         vreg_count,
+        vreg_classes,
         get_label,
         get_successors,
         get_uses,
@@ -230,6 +246,7 @@ where
 pub fn analyze_with_debug<I, R>(
     instructions: &[I],
     vreg_count: u32,
+    vreg_classes: VRegClasses,
     get_label: impl Fn(&I) -> Option<LabelId>,
     get_successors: impl Fn(usize, &I, &HashMap<LabelId, usize>) -> Vec<usize>,
     get_uses: impl Fn(&I) -> Vec<VReg>,
@@ -243,6 +260,7 @@ where
     let (liveness, debug) = analyze_inner(
         instructions,
         vreg_count,
+        vreg_classes,
         get_label,
         get_successors,
         get_uses,
@@ -261,6 +279,7 @@ where
 fn analyze_inner<I, R>(
     instructions: &[I],
     vreg_count: u32,
+    vreg_classes: VRegClasses,
     get_label: impl Fn(&I) -> Option<LabelId>,
     get_successors: impl Fn(usize, &I, &HashMap<LabelId, usize>) -> Vec<usize>,
     get_uses: impl Fn(&I) -> Vec<VReg>,
@@ -281,6 +300,7 @@ where
                 live_at: Vec::new(),
                 clobbers_at: Vec::new(),
                 non_returning_at: Vec::new(),
+                vreg_classes,
             },
             collect_debug.then(|| LivenessDebugInfo {
                 instructions: Vec::new(),
@@ -349,6 +369,7 @@ where
             live_at,
             clobbers_at,
             non_returning_at,
+            vreg_classes,
         },
         debug,
     )
@@ -361,6 +382,7 @@ where
 pub fn analyze_debug<I, R>(
     instructions: &[I],
     vreg_count: u32,
+    vreg_classes: VRegClasses,
     get_label: impl Fn(&I) -> Option<LabelId>,
     get_successors: impl Fn(usize, &I, &HashMap<LabelId, usize>) -> Vec<usize>,
     get_uses: impl Fn(&I) -> Vec<VReg>,
@@ -372,6 +394,7 @@ where
     analyze_with_debug(
         instructions,
         vreg_count,
+        vreg_classes,
         get_label,
         get_successors,
         get_uses,
@@ -828,6 +851,7 @@ mod tests {
         let info: LivenessInfo<u32> = analyze(
             &instructions,
             2,
+            VRegClasses::all_gp(2),
             test_get_label,
             |idx, inst, label_to_idx| test_get_successors(idx, inst, label_to_idx, num_insts),
             test_get_uses,
@@ -858,6 +882,7 @@ mod tests {
         let info: LivenessInfo<u32> = analyze(
             &instructions,
             1,
+            VRegClasses::all_gp(1),
             test_get_label,
             |idx, inst, label_to_idx| test_get_successors(idx, inst, label_to_idx, num_insts),
             test_get_uses,
@@ -880,6 +905,7 @@ mod tests {
         let info: LivenessInfo<u32> = analyze(
             &instructions,
             0,
+            VRegClasses::all_gp(0),
             test_get_label,
             |idx, inst, label_to_idx| test_get_successors(idx, inst, label_to_idx, num_insts),
             test_get_uses,
@@ -906,6 +932,7 @@ mod tests {
         let info: LivenessInfo<u32> = analyze(
             &instructions,
             2,
+            VRegClasses::all_gp(2),
             test_get_label,
             |idx, inst, label_to_idx| test_get_successors(idx, inst, label_to_idx, num_insts),
             test_get_uses,

--- a/crates/rue-codegen/src/reg_class.rs
+++ b/crates/rue-codegen/src/reg_class.rs
@@ -1,0 +1,205 @@
+//! Register classes: the general-purpose / floating-point dimension.
+//!
+//! A physical register file is not one flat pool. An integer value can live in
+//! `rax` or `x19` but never in `xmm0` or `d8`, and the reverse holds for a
+//! floating-point value; the two halves have separate move instructions,
+//! separate call-clobber rules, and separate spill/reload forms. Every pass
+//! that reasons about "which register can hold this value" therefore needs to
+//! know which half of the file a value belongs to.
+//!
+//! Rue has no floating-point type yet, so today every virtual and physical
+//! register in both backends is [`RegClass::Gp`] and [`RegClass::Fp`] is an
+//! empty partition everywhere. The dimension is introduced first, on its own,
+//! so that adding `f32`/`f64` later is a matter of *populating* the `Fp`
+//! partition rather than of widening single-class data structures under a
+//! working allocator (RUE-1067, first step of RUE-1067..1076).
+//!
+//! ## What the class dimension is for
+//!
+//! * [`crate::liveness`] records a class for every virtual register and carries
+//!   it into [`crate::regalloc::LivenessInfo`], which makes it the one
+//!   authoritative class table allocation reads.
+//! * [`crate::regalloc::coalesce`] refuses to merge two virtual registers of
+//!   different classes: a `mov` between an integer and a floating-point
+//!   register is not a plain register-to-register move, so such a pair is not a
+//!   coalescing candidate no matter how its live ranges sit.
+//! * [`crate::regalloc`] allocation keeps its scan state per class and offers
+//!   an interval only the registers of its own class, while the spill-slot
+//!   allocator and the callee-saved save set stay shared — there is one stack
+//!   frame and one prologue no matter how many register classes a target has.
+//! * [`crate::schedule_core`] partitions its physical-register dependency
+//!   bookkeeping by class, so a backend whose floating-point registers are
+//!   numbered independently of its integer ones cannot alias the two.
+
+use std::fmt;
+
+use crate::vreg::VReg;
+
+/// The class of a register: which half of the physical register file a value
+/// can live in.
+///
+/// The variants are ordered and their discriminants are the canonical
+/// per-class array index ([`RegClass::index`]); [`RegClass::ALL`] lists them in
+/// that order.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub enum RegClass {
+    /// General-purpose (integer, pointer, and boolean) registers.
+    Gp = 0,
+    /// Floating-point / SIMD registers.
+    ///
+    /// Nothing selects this class yet: no Rue type lowers to a floating-point
+    /// value, and neither backend lists a register in it. It exists so the
+    /// passes below are written against the general shape from the start.
+    Fp = 1,
+}
+
+impl RegClass {
+    /// Number of register classes.
+    pub const COUNT: usize = 2;
+
+    /// Every register class, in [`RegClass::index`] order.
+    pub const ALL: [RegClass; Self::COUNT] = [RegClass::Gp, RegClass::Fp];
+
+    /// Index of this class in a per-class array.
+    #[inline]
+    pub const fn index(self) -> usize {
+        self as usize
+    }
+
+    /// Short lowercase name, used in diagnostics and panic messages.
+    #[inline]
+    pub const fn name(self) -> &'static str {
+        match self {
+            RegClass::Gp => "gp",
+            RegClass::Fp => "fp",
+        }
+    }
+}
+
+impl fmt::Display for RegClass {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.name())
+    }
+}
+
+/// The register class of every virtual register in one function's MIR.
+///
+/// Dense, indexed by [`VReg::index`], and grown one entry per minted virtual
+/// register: each backend's `alloc_vreg` pushes the class of the register it
+/// hands out, so `len()` equals the MIR's `vreg_count()` by construction. That
+/// invariant is what lets allocation index this table with any vreg the
+/// liveness ranges mention.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct VRegClasses {
+    classes: Vec<RegClass>,
+}
+
+impl VRegClasses {
+    /// An empty table, for a MIR with no virtual registers yet.
+    pub const fn new() -> Self {
+        Self {
+            classes: Vec::new(),
+        }
+    }
+
+    /// A table in which every one of `count` virtual registers is
+    /// general-purpose.
+    ///
+    /// This is what the target-independent `linear_scan*` entry points and
+    /// hand-constructed test liveness use: they name a register set directly
+    /// rather than a target's register file, and a bare register set has no
+    /// class structure to read.
+    pub fn all_gp(count: u32) -> Self {
+        Self {
+            classes: vec![RegClass::Gp; count as usize],
+        }
+    }
+
+    /// Record the class of the next virtual register.
+    ///
+    /// Callers must push exactly once per minted register, in mint order, or
+    /// the table stops agreeing with `vreg_count()`.
+    #[inline]
+    pub fn push(&mut self, class: RegClass) {
+        self.classes.push(class);
+    }
+
+    /// Number of virtual registers with a recorded class.
+    #[inline]
+    pub fn len(&self) -> u32 {
+        self.classes.len() as u32
+    }
+
+    /// Whether no virtual register has a recorded class.
+    #[inline]
+    pub fn is_empty(&self) -> bool {
+        self.classes.is_empty()
+    }
+
+    /// The class of `vreg`.
+    ///
+    /// A virtual register past the end of the table answers [`RegClass::Gp`].
+    /// That case does not arise in a MIR built through `alloc_vreg`, and
+    /// [`crate::regalloc::RegAllocDriver`] asserts the table covers the MIR
+    /// before allocation reads it; the saturating answer only keeps a
+    /// hand-built MIR behaving exactly as it did before classes existed
+    /// instead of panicking mid-codegen.
+    #[inline]
+    pub fn class_of(&self, vreg: VReg) -> RegClass {
+        self.classes
+            .get(vreg.index() as usize)
+            .copied()
+            .unwrap_or(RegClass::Gp)
+    }
+
+    /// How many virtual registers are in `class`.
+    pub fn count_in(&self, class: RegClass) -> u32 {
+        self.classes.iter().filter(|&&c| c == class).count() as u32
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn class_indices_are_the_canonical_array_order() {
+        for (index, class) in RegClass::ALL.iter().enumerate() {
+            assert_eq!(class.index(), index);
+        }
+        assert_eq!(RegClass::ALL.len(), RegClass::COUNT);
+    }
+
+    #[test]
+    fn an_all_gp_table_covers_every_vreg_and_holds_no_fp() {
+        let classes = VRegClasses::all_gp(4);
+        assert_eq!(classes.len(), 4);
+        assert_eq!(classes.count_in(RegClass::Gp), 4);
+        assert_eq!(classes.count_in(RegClass::Fp), 0);
+        for idx in 0..4 {
+            assert_eq!(classes.class_of(VReg::new(idx)), RegClass::Gp);
+        }
+    }
+
+    #[test]
+    fn pushing_records_classes_in_mint_order() {
+        let mut classes = VRegClasses::new();
+        assert!(classes.is_empty());
+        classes.push(RegClass::Gp);
+        classes.push(RegClass::Fp);
+        classes.push(RegClass::Gp);
+
+        assert_eq!(classes.len(), 3);
+        assert_eq!(classes.class_of(VReg::new(0)), RegClass::Gp);
+        assert_eq!(classes.class_of(VReg::new(1)), RegClass::Fp);
+        assert_eq!(classes.class_of(VReg::new(2)), RegClass::Gp);
+        assert_eq!(classes.count_in(RegClass::Gp), 2);
+        assert_eq!(classes.count_in(RegClass::Fp), 1);
+    }
+
+    #[test]
+    fn a_vreg_past_the_table_reads_as_general_purpose() {
+        let classes = VRegClasses::all_gp(1);
+        assert_eq!(classes.class_of(VReg::new(7)), RegClass::Gp);
+    }
+}

--- a/crates/rue-codegen/src/regalloc.rs
+++ b/crates/rue-codegen/src/regalloc.rs
@@ -49,6 +49,7 @@ use fixedbitset::FixedBitSet;
 use rue_error::CompileResult;
 
 use crate::index_map::IndexMap;
+use crate::reg_class::{RegClass, VRegClasses};
 use crate::vreg::VReg;
 
 // ============================================================================
@@ -393,6 +394,13 @@ pub struct LivenessInfo<Reg: Copy + Eq + std::hash::Hash> {
     /// no value is live after it; see [`ClobberIndex::build`] for why the
     /// distinction matters to allocation (RUE-1224).
     pub non_returning_at: Vec<bool>,
+    /// The register class of each virtual register.
+    ///
+    /// Liveness carries the MIR's class table forward so that allocation and
+    /// coalescing have one authoritative answer for "what kind of register can
+    /// hold this value" without re-deriving it from the instruction stream
+    /// (RUE-1067). Every entry is [`RegClass::Gp`] today.
+    pub vreg_classes: VRegClasses,
 }
 
 impl<Reg: Copy + Eq + std::hash::Hash> LivenessInfo<Reg> {
@@ -403,10 +411,12 @@ impl<Reg: Copy + Eq + std::hash::Hash> LivenessInfo<Reg> {
             live_at: Vec::new(),
             clobbers_at: Vec::new(),
             non_returning_at: Vec::new(),
+            vreg_classes: VRegClasses::new(),
         }
     }
 
-    /// Create liveness info with capacity for the given number of vregs.
+    /// Create liveness info with capacity for the given number of vregs, all
+    /// of them general-purpose.
     pub fn with_vreg_capacity(vreg_count: u32) -> Self {
         let mut ranges = IndexMap::with_capacity(vreg_count as usize);
         ranges.resize(vreg_count as usize, None);
@@ -415,7 +425,14 @@ impl<Reg: Copy + Eq + std::hash::Hash> LivenessInfo<Reg> {
             live_at: Vec::new(),
             clobbers_at: Vec::new(),
             non_returning_at: Vec::new(),
+            vreg_classes: VRegClasses::all_gp(vreg_count),
         }
+    }
+
+    /// The register class of `vreg`.
+    #[inline]
+    pub fn class_of(&self, vreg: VReg) -> RegClass {
+        self.vreg_classes.class_of(vreg)
     }
 
     /// Get vregs that are live at a given instruction index.
@@ -548,10 +565,10 @@ impl<Reg: Copy + Eq> ClobberIndex<Reg> {
 }
 
 // ============================================================================
-// Register Classes
+// Save Classes and the Register File
 // ============================================================================
 
-/// The two register classes allocation distinguishes.
+/// One [`RegClass`]'s allocatable registers, split by who preserves them.
 ///
 /// A caller-saved register costs nothing in the prologue but is destroyed by
 /// every call, so it is offered only to an interval that no instruction
@@ -562,8 +579,11 @@ impl<Reg: Copy + Eq> ClobberIndex<Reg> {
 /// Standard linear-scan practice is to prefer caller-saved registers for the
 /// intervals that can take them, which both leaves the callee-saved registers
 /// for the intervals that need them and shrinks the prologue.
-#[derive(Clone, Copy)]
-pub struct RegisterClasses<'a, Reg> {
+///
+/// This split is orthogonal to [`RegClass`]: *who saves a register* and *what
+/// kind of value it can hold* are independent facts, so each register class of
+/// a target has its own `SaveClasses` and [`RegisterFile`] holds one per class.
+pub struct SaveClasses<'a, Reg> {
     /// Tried first, in order, for intervals with no clobber in range.
     pub caller_saved: &'a [Reg],
     /// Tried next, in order; saved by the prologue when used.
@@ -582,12 +602,33 @@ pub struct RegisterClasses<'a, Reg> {
     pub compact_callee_saved: &'a [Reg],
 }
 
-impl<'a, Reg: Copy + Eq> RegisterClasses<'a, Reg> {
+// Derived `Clone`/`Copy` would demand `Reg: Clone`/`Reg: Copy`; these hold
+// shared slices only, so they are copyable for any `Reg`.
+impl<Reg> Clone for SaveClasses<'_, Reg> {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+
+impl<Reg> Copy for SaveClasses<'_, Reg> {}
+
+impl<'a, Reg> SaveClasses<'a, Reg> {
+    /// A class with no allocatable registers at all.
+    ///
+    /// This is what both backends supply for [`RegClass::Fp`] until the floats
+    /// series populates it, and what a target with no such registers would
+    /// supply permanently.
+    pub const EMPTY: Self = Self {
+        caller_saved: &[],
+        callee_saved: &[],
+        compact_callee_saved: &[],
+    };
+
     /// Classes for a caller that offers callee-saved registers only.
     ///
     /// This reproduces the pre-RUE-1146 policy exactly and is what the
     /// standalone `linear_scan*` entry points below use.
-    pub fn callee_saved_only(regs: &'a [Reg]) -> Self {
+    pub const fn callee_saved_only(regs: &'a [Reg]) -> Self {
         Self {
             caller_saved: &[],
             callee_saved: regs,
@@ -595,19 +636,97 @@ impl<'a, Reg: Copy + Eq> RegisterClasses<'a, Reg> {
         }
     }
 
-    /// Total number of allocatable registers across both classes.
+    /// Total number of allocatable registers across both save classes.
     pub fn len(&self) -> usize {
         self.caller_saved.len() + self.callee_saved.len()
     }
 
-    /// Whether no register at all is allocatable.
+    /// Whether no register at all is allocatable in this class.
     pub fn is_empty(&self) -> bool {
         self.len() == 0
     }
+}
 
+impl<Reg: Copy + Eq> SaveClasses<'_, Reg> {
     /// Whether `reg` is one this function's prologue must preserve.
     pub fn is_callee_saved(&self, reg: Reg) -> bool {
         self.callee_saved.contains(&reg)
+    }
+}
+
+/// A target's allocatable registers, one [`SaveClasses`] per [`RegClass`].
+///
+/// Allocation offers an interval only the registers of its own class: an
+/// integer value cannot be parked in a floating-point register however free
+/// that register is. What stays *shared* across classes is everything the
+/// frame owns — the spill-slot allocator and the callee-saved save set — since
+/// a function has one stack frame and one prologue no matter how many register
+/// classes its target has.
+///
+/// Both backends populate [`RegClass::Gp`] only; [`RegClass::Fp`] is
+/// [`SaveClasses::EMPTY`] and no virtual register selects it (RUE-1067).
+pub struct RegisterFile<'a, Reg> {
+    classes: [SaveClasses<'a, Reg>; RegClass::COUNT],
+}
+
+impl<Reg> Clone for RegisterFile<'_, Reg> {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+
+impl<Reg> Copy for RegisterFile<'_, Reg> {}
+
+impl<'a, Reg> RegisterFile<'a, Reg> {
+    /// Build a register file from one entry per class, in [`RegClass::ALL`]
+    /// order.
+    pub const fn new(classes: [SaveClasses<'a, Reg>; RegClass::COUNT]) -> Self {
+        Self { classes }
+    }
+
+    /// A register file whose only allocatable registers are general-purpose.
+    pub const fn gp_only(gp: SaveClasses<'a, Reg>) -> Self {
+        Self::new([gp, SaveClasses::EMPTY])
+    }
+
+    /// The allocatable registers of one class.
+    #[inline]
+    pub fn class(&self, class: RegClass) -> SaveClasses<'a, Reg> {
+        self.classes[class.index()]
+    }
+
+    /// Every class paired with its allocatable registers, in
+    /// [`RegClass::ALL`] order.
+    pub fn iter(&self) -> impl Iterator<Item = (RegClass, SaveClasses<'a, Reg>)> + '_ {
+        RegClass::ALL
+            .into_iter()
+            .map(|class| (class, self.class(class)))
+    }
+
+    /// Total number of allocatable registers across every class.
+    pub fn len(&self) -> usize {
+        self.classes.iter().map(SaveClasses::len).sum()
+    }
+
+    /// Whether no register of any class is allocatable.
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+}
+
+impl<Reg: Copy> RegisterFile<'_, Reg> {
+    /// Every caller-saved register of every class, in class order.
+    ///
+    /// [`ClobberIndex`] is built once per allocation over this flattening: the
+    /// index answers "is this register destroyed inside that range", which is a
+    /// per-register question with no class structure of its own, and building
+    /// one index for the whole file keeps the class partitioning to the
+    /// candidate lists that consult it.
+    pub fn caller_saved_flattened(&self) -> Vec<Reg> {
+        self.classes
+            .iter()
+            .flat_map(|save| save.caller_saved.iter().copied())
+            .collect()
     }
 }
 
@@ -704,6 +823,17 @@ impl CoalesceResult {
 /// - src's live range ends at or before the move (its last use is the move)
 /// - dst's live range starts at the move (its first def is the move)
 /// - OR more generally: their ranges don't overlap except at the move point
+///
+/// # Register classes
+///
+/// Two vregs of different [`RegClass`]es are never merged, whatever their live
+/// ranges do. Coalescing asserts that one physical register can hold both
+/// values and that the move between them is therefore redundant; across
+/// classes neither holds — no register is both an integer and a floating-point
+/// register, and the "move" would be a class-crossing transfer instruction
+/// that has to survive. Backends do not offer such a pair as a candidate
+/// today, and none can arise while every vreg is [`RegClass::Gp`], so this is
+/// a guard rather than a filter (RUE-1067).
 pub fn coalesce<Reg: Copy + Eq + std::hash::Hash>(
     candidates: &[CoalesceCandidate],
     liveness: &mut LivenessInfo<Reg>,
@@ -733,6 +863,12 @@ pub fn coalesce<Reg: Copy + Eq + std::hash::Hash>(
         // Already in the same equivalence class
         if dst == src {
             result.eliminated_moves.insert(candidate.inst_idx);
+            continue;
+        }
+
+        // A class-crossing pair cannot share a physical register, so the move
+        // between them is not redundant and must not be eliminated.
+        if liveness.class_of(dst) != liveness.class_of(src) {
             continue;
         }
 
@@ -1110,10 +1246,12 @@ pub trait RegAllocBackend {
     fn analyze_with_debug(mir: &Self::Mir) -> (LivenessInfo<Self::Reg>, LivenessDebugInfo);
     fn analyze_loops(mir: &Self::Mir) -> LoopInfo;
     fn coalesce_candidates(instructions: &[Self::Inst]) -> Vec<CoalesceCandidate>;
-    /// The allocatable registers, split by who is responsible for preserving
-    /// them. Allocation prefers the caller-saved class for intervals that no
-    /// instruction clobbers while they are live (RUE-1146).
-    fn register_classes() -> RegisterClasses<'static, Self::Reg>;
+    /// The allocatable registers of every [`RegClass`], each split by who is
+    /// responsible for preserving them. Allocation prefers the caller-saved
+    /// save class for intervals that no instruction clobbers while they are
+    /// live (RUE-1146), and never offers an interval a register outside its
+    /// own register class (RUE-1067).
+    fn register_file() -> RegisterFile<'static, Self::Reg>;
 
     /// Every physical register `inst` names as an operand — read or written.
     ///
@@ -1284,14 +1422,16 @@ impl<I> RewriteBuffer<I> {
 /// code, and `docs/process/ci.md` gives code generation no debug-assert
 /// allowance (RUE-1224).
 fn assert_no_allocatable_physical_operands<B: RegAllocBackend>(mir: &B::Mir) {
-    let classes = B::register_classes();
+    let file = B::register_file();
     for inst in B::instructions(mir) {
         for reg in B::physical_operands(inst) {
-            assert!(
-                !classes.caller_saved.contains(&reg) && !classes.callee_saved.contains(&reg),
-                "lowering named the allocatable register {reg} as a physical operand; \
-                 allocation may put an unrelated value there"
-            );
+            for (_, save) in file.iter() {
+                assert!(
+                    !save.caller_saved.contains(&reg) && !save.callee_saved.contains(&reg),
+                    "lowering named the allocatable register {reg} as a physical operand; \
+                     allocation may put an unrelated value there"
+                );
+            }
         }
     }
 }
@@ -1327,6 +1467,12 @@ impl<B: RegAllocBackend> RegAllocDriver<B> {
         } else {
             (B::analyze(&mir), None)
         };
+        assert_eq!(
+            liveness.vreg_classes.len(),
+            vreg_count as u32,
+            "the MIR's virtual-register class table does not cover its virtual registers; \
+             a mint site skipped recording a register class"
+        );
         let loop_info = B::analyze_loops(&mir);
         let candidates = B::coalesce_candidates(B::instructions(&mir));
         let coalesce_result = coalesce(&candidates, &mut liveness);
@@ -1418,7 +1564,7 @@ impl<B: RegAllocBackend> RegAllocDriver<B> {
         let (allocation, num_spills, used_callee_saved, _debug_info) = linear_scan_impl_with_remat(
             B::vreg_count(&self.mir),
             &self.liveness,
-            B::register_classes(),
+            B::register_file(),
             self.existing_locals,
             false,
             &CostModel::default(),
@@ -1434,7 +1580,7 @@ impl<B: RegAllocBackend> RegAllocDriver<B> {
         let (allocation, num_spills, used_callee_saved, debug_info) = linear_scan_impl_with_remat(
             B::vreg_count(&self.mir),
             &self.liveness,
-            B::register_classes(),
+            B::register_file(),
             self.existing_locals,
             true,
             &CostModel::default(),
@@ -1564,7 +1710,7 @@ impl<Reg: Copy + Eq + std::hash::Hash + fmt::Display> fmt::Display for RegAllocD
 ///
 /// * `vreg_count` - Total number of virtual registers
 /// * `liveness` - Liveness information from dataflow analysis
-/// * `allocatable_regs` - Physical registers available for allocation
+/// * `allocatable_regs` - General-purpose registers available for allocation
 /// * `existing_locals` - Number of local variable slots already on the stack
 ///
 /// # Returns
@@ -1588,7 +1734,7 @@ pub fn linear_scan<Reg: Copy + Eq + std::hash::Hash>(
     let (allocation, num_spills, used_callee_saved, _debug_info) = linear_scan_impl(
         vreg_count,
         liveness,
-        RegisterClasses::callee_saved_only(allocatable_regs),
+        RegisterFile::gp_only(SaveClasses::callee_saved_only(allocatable_regs)),
         existing_locals,
         false,
         &cost_model,
@@ -1608,7 +1754,7 @@ pub fn linear_scan<Reg: Copy + Eq + std::hash::Hash>(
 ///
 /// * `vreg_count` - Total number of virtual registers
 /// * `liveness` - Liveness information from dataflow analysis
-/// * `allocatable_regs` - Physical registers available for allocation
+/// * `allocatable_regs` - General-purpose registers available for allocation
 /// * `existing_locals` - Number of local variable slots already on the stack
 /// * `cost_model` - Cost model for spill decisions
 /// * `loop_info` - Loop depth information for each instruction
@@ -1630,7 +1776,7 @@ pub fn linear_scan_with_cost_model<Reg: Copy + Eq + std::hash::Hash>(
     let (allocation, num_spills, used_callee_saved, _debug_info) = linear_scan_impl(
         vreg_count,
         liveness,
-        RegisterClasses::callee_saved_only(allocatable_regs),
+        RegisterFile::gp_only(SaveClasses::callee_saved_only(allocatable_regs)),
         existing_locals,
         false,
         cost_model,
@@ -1649,7 +1795,7 @@ pub fn linear_scan_with_cost_model<Reg: Copy + Eq + std::hash::Hash>(
 ///
 /// * `vreg_count` - Total number of virtual registers
 /// * `liveness` - Liveness information from dataflow analysis
-/// * `allocatable_regs` - Physical registers available for allocation
+/// * `allocatable_regs` - General-purpose registers available for allocation
 /// * `existing_locals` - Number of local variable slots already on the stack
 /// * `vreg_info` - Rematerialization info for each vreg (optional per-vreg)
 ///
@@ -1674,7 +1820,7 @@ pub fn linear_scan_with_remat<Reg: Copy + Eq + std::hash::Hash>(
     let (allocation, num_spills, used_callee_saved, _debug_info) = linear_scan_impl_with_remat(
         vreg_count,
         liveness,
-        RegisterClasses::callee_saved_only(allocatable_regs),
+        RegisterFile::gp_only(SaveClasses::callee_saved_only(allocatable_regs)),
         existing_locals,
         false,
         &cost_model,
@@ -1708,7 +1854,7 @@ pub fn linear_scan_with_debug<Reg: Copy + Eq + std::hash::Hash>(
     linear_scan_impl(
         vreg_count,
         liveness,
-        RegisterClasses::callee_saved_only(allocatable_regs),
+        RegisterFile::gp_only(SaveClasses::callee_saved_only(allocatable_regs)),
         existing_locals,
         true,
         &cost_model,
@@ -1736,7 +1882,7 @@ pub fn linear_scan_with_cost_model_and_debug<Reg: Copy + Eq + std::hash::Hash>(
     linear_scan_impl(
         vreg_count,
         liveness,
-        RegisterClasses::callee_saved_only(allocatable_regs),
+        RegisterFile::gp_only(SaveClasses::callee_saved_only(allocatable_regs)),
         existing_locals,
         true,
         cost_model,
@@ -1747,17 +1893,24 @@ pub fn linear_scan_with_cost_model_and_debug<Reg: Copy + Eq + std::hash::Hash>(
 /// Pick a physical register for an interval covering `range`, or report that
 /// none is free.
 ///
+/// `save` is the arriving interval's *own* register class, already selected by
+/// the caller; nothing here can hand out a register of another class.
+///
 /// Caller-saved registers come before callee-saved ones: an interval that no
 /// instruction clobbers while it is live costs nothing to keep in one, and
 /// every callee-saved register it leaves alone is one the prologue does not
 /// have to save (RUE-1146).
 ///
 /// Ahead of both sits one narrow exception, the RUE-1227 tiebreak: a register
-/// that is both in [`RegisterClasses::compact_callee_saved`] and in `sunk` —
+/// that is both in [`SaveClasses::compact_callee_saved`] and in `sunk` —
 /// the callee-saved registers this function's prologue already saves. Against a
 /// *fresh* callee-saved register the caller-saved candidate wins on the save it
 /// avoids, but against one whose save is already paid for it has nothing left
 /// to offer and a worse encoding, so preferring the sunk register is free.
+///
+/// `sunk` spans every class, because the prologue does; the intersection with
+/// this class's `compact_callee_saved` is what makes the preference apply to
+/// this class's registers only.
 ///
 /// The exception cannot enlarge the save set: it only ever hands out a register
 /// already in it. It can still *shift* which registers end up saved, because
@@ -1765,27 +1918,24 @@ pub fn linear_scan_with_cost_model_and_debug<Reg: Copy + Eq + std::hash::Hash>(
 /// then reaches for a fresh one. Ruling that out is [`accept_reuse_pass`]'s
 /// job, not this function's.
 fn pick_free_register<Reg: Copy + Eq + std::hash::Hash>(
-    classes: RegisterClasses<'_, Reg>,
+    save: SaveClasses<'_, Reg>,
     clobbers: &ClobberIndex<Reg>,
     used: &HashSet<Reg>,
     sunk: &[Reg],
     range: &LiveRange,
 ) -> Option<Reg> {
-    classes
-        .compact_callee_saved
+    save.compact_callee_saved
         .iter()
         .copied()
         .find(|&reg| sunk.contains(&reg) && !used.contains(&reg))
         .or_else(|| {
-            classes
-                .caller_saved
+            save.caller_saved
                 .iter()
                 .copied()
                 .find(|&reg| !used.contains(&reg) && !clobbers.is_clobbered_during(reg, range))
         })
         .or_else(|| {
-            classes
-                .callee_saved
+            save.callee_saved
                 .iter()
                 .copied()
                 .find(|&reg| !used.contains(&reg))
@@ -1800,13 +1950,16 @@ fn pick_free_register<Reg: Copy + Eq + std::hash::Hash>(
 /// that becomes free by spilling its current occupant is still only usable by
 /// the arriving interval if that interval survives everything the register does
 /// not.
+///
+/// `save` is the class `reg` belongs to, which is also the arriving interval's:
+/// eviction only ever considers registers held by intervals of the same class.
 fn register_survives_range<Reg: Copy + Eq + std::hash::Hash>(
-    classes: RegisterClasses<'_, Reg>,
+    save: SaveClasses<'_, Reg>,
     clobbers: &ClobberIndex<Reg>,
     reg: Reg,
     range: &LiveRange,
 ) -> bool {
-    classes.is_callee_saved(reg) || !clobbers.is_clobbered_during(reg, range)
+    save.is_callee_saved(reg) || !clobbers.is_clobbered_during(reg, range)
 }
 
 /// How many vregs an allocation keeps in a physical register.
@@ -1870,7 +2023,7 @@ fn accept_reuse_pass<Reg: Copy + Eq + std::hash::Hash>(
 fn linear_scan_impl<Reg: Copy + Eq + std::hash::Hash>(
     vreg_count: u32,
     liveness: &LivenessInfo<Reg>,
-    classes: RegisterClasses<'_, Reg>,
+    file: RegisterFile<'_, Reg>,
     existing_locals: u32,
     collect_debug: bool,
     cost_model: &CostModel,
@@ -1884,7 +2037,7 @@ fn linear_scan_impl<Reg: Copy + Eq + std::hash::Hash>(
     let baseline = scan_intervals(
         vreg_count,
         liveness,
-        classes,
+        file,
         existing_locals,
         collect_debug,
         cost_model,
@@ -1892,22 +2045,13 @@ fn linear_scan_impl<Reg: Copy + Eq + std::hash::Hash>(
         &[],
     );
     let (_, _, baseline_saved, _) = &baseline;
-    // The reuse pass can only differ where a compact callee-saved register is
-    // already in the save set and there is a caller-saved register to prefer it
-    // over. Otherwise skip it entirely, so neither a push-free function nor a
-    // fixed-width target pays for a second scan.
-    if classes.caller_saved.is_empty()
-        || !classes
-            .compact_callee_saved
-            .iter()
-            .any(|reg| baseline_saved.contains(reg))
-    {
+    if !reuse_pass_could_differ(file, baseline_saved) {
         return baseline;
     }
     let reuse = scan_intervals(
         vreg_count,
         liveness,
-        classes,
+        file,
         existing_locals,
         collect_debug,
         cost_model,
@@ -1921,6 +2065,40 @@ fn linear_scan_impl<Reg: Copy + Eq + std::hash::Hash>(
     }
 }
 
+/// Empty per-class "currently in a register" lists, sized to each class's
+/// register count.
+///
+/// A linear scan can never hold more live intervals in registers than the
+/// class has registers, so each list is allocated once at that size and never
+/// grows. Splitting them by class is what stops an interval of one class from
+/// seeing another class's registers as occupied — or, worse, as free.
+fn active_by_class<Reg: Copy>(
+    file: RegisterFile<'_, Reg>,
+) -> [Vec<(VReg, Reg, usize)>; RegClass::COUNT] {
+    std::array::from_fn(|index| Vec::with_capacity(file.class(RegClass::ALL[index]).len()))
+}
+
+/// Whether the RUE-1227 reuse pass can possibly reach a different answer than
+/// the baseline pass, and is therefore worth running at all.
+///
+/// It can only in a class that has both a caller-saved register to prefer
+/// against and a compact callee-saved register the baseline already committed
+/// to the prologue. When no class qualifies the second scan is skipped
+/// outright, so neither a push-free function nor a fixed-width target pays for
+/// it.
+fn reuse_pass_could_differ<Reg: Copy + Eq>(
+    file: RegisterFile<'_, Reg>,
+    baseline_saved: &[Reg],
+) -> bool {
+    file.iter().any(|(_, save)| {
+        !save.caller_saved.is_empty()
+            && save
+                .compact_callee_saved
+                .iter()
+                .any(|reg| baseline_saved.contains(reg))
+    })
+}
+
 /// One linear-scan pass over the intervals.
 ///
 /// When `collect_debug` is `false` (the normal compilation path, where callers
@@ -1931,10 +2109,21 @@ fn linear_scan_impl<Reg: Copy + Eq + std::hash::Hash>(
 ///
 /// `sunk` names callee-saved registers whose prologue save is already paid for;
 /// see [`pick_free_register`].
+///
+/// # Register classes
+///
+/// The scan stays a single pass over every interval in start order, but the
+/// state that answers "which register is free" is kept per [`RegClass`] — see
+/// [`active_by_class`]. What stays shared is what the frame owns: one
+/// [`SpillSlotAllocator`], one `used_callee_saved` save set. Splitting the scan
+/// itself per class instead would hand the spill-slot allocator its requests in
+/// a different order and change the frame layout of any function that mixed
+/// classes; keeping one ordered pass keeps slot assignment a function of
+/// interval order alone (RUE-1067).
 fn scan_intervals<Reg: Copy + Eq + std::hash::Hash>(
     vreg_count: u32,
     liveness: &LivenessInfo<Reg>,
-    classes: RegisterClasses<'_, Reg>,
+    file: RegisterFile<'_, Reg>,
     existing_locals: u32,
     collect_debug: bool,
     cost_model: &CostModel,
@@ -1989,31 +2178,38 @@ fn scan_intervals<Reg: Copy + Eq + std::hash::Hash>(
         }
     }
 
-    // Constant-time clobber answers for the caller-saved candidates; the
-    // callee-saved class survives every clobber by definition (RUE-1146).
-    let clobbers = ClobberIndex::build(liveness, classes.caller_saved);
+    // Constant-time clobber answers for the caller-saved candidates of every
+    // class; the callee-saved registers survive every clobber by definition
+    // (RUE-1146).
+    let caller_saved = file.caller_saved_flattened();
+    let clobbers = ClobberIndex::build(liveness, &caller_saved);
 
-    // Track which registers are currently in use and when they become free
+    // Track which registers are currently in use and when they become free,
+    // separately per register class.
     // Tuple: (vreg, physical reg, live range end)
-    let mut active: Vec<(VReg, Reg, usize)> = Vec::with_capacity(classes.len());
+    let mut active = active_by_class(file);
 
     for (vreg, range) in vregs_by_start {
+        let class = liveness.class_of(vreg);
+        let save = file.class(class);
+        let active = &mut active[class.index()];
+
         // Expire old intervals - remove registers whose vregs are no longer live
         active.retain(|&(_, _, end)| end >= range.start);
 
         // Find registers currently in use
         let used_regs: HashSet<Reg> = active.iter().map(|&(_, reg, _)| reg).collect();
 
-        // Try to find a free register: a sunk compact one, else caller-saved,
-        // else a fresh callee-saved one.
-        let allocated_reg = pick_free_register(classes, &clobbers, &used_regs, sunk, &range);
+        // Try to find a free register of this vreg's own class: a sunk compact
+        // one, else caller-saved, else a fresh callee-saved one.
+        let allocated_reg = pick_free_register(save, &clobbers, &used_regs, sunk, &range);
 
         if let Some(reg) = allocated_reg {
             // Assign this register
             allocation[vreg] = Some(Allocation::Register(reg));
             active.push((vreg, reg, range.end));
             // Track callee-saved register usage: only these oblige the prologue
-            if classes.is_callee_saved(reg) && !used_callee_saved.contains(&reg) {
+            if save.is_callee_saved(reg) && !used_callee_saved.contains(&reg) {
                 used_callee_saved.push(reg);
             }
         } else {
@@ -2034,7 +2230,7 @@ fn scan_intervals<Reg: Copy + Eq + std::hash::Hash>(
                 // Evicting only helps if the freed register can actually hold
                 // the arriving interval; a caller-saved register clobbered
                 // during that interval cannot.
-                if !register_survives_range(classes, &clobbers, active_reg, &range) {
+                if !register_survives_range(save, &clobbers, active_reg, &range) {
                     continue;
                 }
                 let active_loop_depth = loop_info.max_depth_in_range(range.start, end);
@@ -2121,7 +2317,7 @@ fn scan_intervals<Reg: Copy + Eq + std::hash::Hash>(
 fn linear_scan_impl_with_remat<Reg: Copy + Eq + std::hash::Hash>(
     vreg_count: u32,
     liveness: &LivenessInfo<Reg>,
-    classes: RegisterClasses<'_, Reg>,
+    file: RegisterFile<'_, Reg>,
     existing_locals: u32,
     collect_debug: bool,
     cost_model: &CostModel,
@@ -2136,7 +2332,7 @@ fn linear_scan_impl_with_remat<Reg: Copy + Eq + std::hash::Hash>(
     let baseline = scan_intervals_with_remat(
         vreg_count,
         liveness,
-        classes,
+        file,
         existing_locals,
         collect_debug,
         cost_model,
@@ -2145,22 +2341,13 @@ fn linear_scan_impl_with_remat<Reg: Copy + Eq + std::hash::Hash>(
         &[],
     );
     let (_, _, baseline_saved, _) = &baseline;
-    // The reuse pass can only differ where a compact callee-saved register is
-    // already in the save set and there is a caller-saved register to prefer it
-    // over. Otherwise skip it entirely, so neither a push-free function nor a
-    // fixed-width target pays for a second scan.
-    if classes.caller_saved.is_empty()
-        || !classes
-            .compact_callee_saved
-            .iter()
-            .any(|reg| baseline_saved.contains(reg))
-    {
+    if !reuse_pass_could_differ(file, baseline_saved) {
         return baseline;
     }
     let reuse = scan_intervals_with_remat(
         vreg_count,
         liveness,
-        classes,
+        file,
         existing_locals,
         collect_debug,
         cost_model,
@@ -2183,10 +2370,13 @@ fn linear_scan_impl_with_remat<Reg: Copy + Eq + std::hash::Hash>(
 ///
 /// `sunk` names callee-saved registers whose prologue save is already paid for;
 /// see [`pick_free_register`].
+///
+/// Register classes partition the scan state exactly as in [`scan_intervals`];
+/// see that function's notes.
 fn scan_intervals_with_remat<Reg: Copy + Eq + std::hash::Hash>(
     vreg_count: u32,
     liveness: &LivenessInfo<Reg>,
-    classes: RegisterClasses<'_, Reg>,
+    file: RegisterFile<'_, Reg>,
     existing_locals: u32,
     collect_debug: bool,
     cost_model: &CostModel,
@@ -2246,31 +2436,38 @@ fn scan_intervals_with_remat<Reg: Copy + Eq + std::hash::Hash>(
         }
     }
 
-    // Constant-time clobber answers for the caller-saved candidates; the
-    // callee-saved class survives every clobber by definition (RUE-1146).
-    let clobbers = ClobberIndex::build(liveness, classes.caller_saved);
+    // Constant-time clobber answers for the caller-saved candidates of every
+    // class; the callee-saved registers survive every clobber by definition
+    // (RUE-1146).
+    let caller_saved = file.caller_saved_flattened();
+    let clobbers = ClobberIndex::build(liveness, &caller_saved);
 
-    // Track which registers are currently in use and when they become free
+    // Track which registers are currently in use and when they become free,
+    // separately per register class.
     // Tuple: (vreg, physical reg, live range end)
-    let mut active: Vec<(VReg, Reg, usize)> = Vec::with_capacity(classes.len());
+    let mut active = active_by_class(file);
 
     for (vreg, range) in vregs_by_start {
+        let class = liveness.class_of(vreg);
+        let save = file.class(class);
+        let active = &mut active[class.index()];
+
         // Expire old intervals - remove registers whose vregs are no longer live
         active.retain(|&(_, _, end)| end >= range.start);
 
         // Find registers currently in use
         let used_regs: HashSet<Reg> = active.iter().map(|&(_, reg, _)| reg).collect();
 
-        // Try to find a free register: a sunk compact one, else caller-saved,
-        // else a fresh callee-saved one.
-        let allocated_reg = pick_free_register(classes, &clobbers, &used_regs, sunk, &range);
+        // Try to find a free register of this vreg's own class: a sunk compact
+        // one, else caller-saved, else a fresh callee-saved one.
+        let allocated_reg = pick_free_register(save, &clobbers, &used_regs, sunk, &range);
 
         if let Some(reg) = allocated_reg {
             // Assign this register
             allocation[vreg] = Some(Allocation::Register(reg));
             active.push((vreg, reg, range.end));
             // Track callee-saved register usage: only these oblige the prologue
-            if classes.is_callee_saved(reg) && !used_callee_saved.contains(&reg) {
+            if save.is_callee_saved(reg) && !used_callee_saved.contains(&reg) {
                 used_callee_saved.push(reg);
             }
         } else {
@@ -2299,7 +2496,7 @@ fn scan_intervals_with_remat<Reg: Copy + Eq + std::hash::Hash>(
                 // Evicting only helps if the freed register can actually hold
                 // the arriving interval; a caller-saved register clobbered
                 // during that interval cannot.
-                if !register_survives_range(classes, &clobbers, active_reg, &range) {
+                if !register_survives_range(save, &clobbers, active_reg, &range) {
                     continue;
                 }
                 let active_is_remat = can_remat(active_vreg).is_some();
@@ -2483,6 +2680,34 @@ mod tests {
         }
     }
 
+    /// Liveness whose vregs carry the given classes, one per vreg index.
+    ///
+    /// Nothing in the compiler produces this yet — both backends mint only
+    /// [`RegClass::Gp`] registers — so the class-aware behavior of allocation
+    /// is exercised here, on the shared algorithm, rather than through a
+    /// backend (RUE-1067).
+    fn make_classed_liveness(
+        ranges: Vec<(u32, usize, usize)>,
+        classes: &[RegClass],
+    ) -> LivenessInfo<TestReg> {
+        let mut info = make_liveness(ranges);
+        let mut vreg_classes = VRegClasses::new();
+        for &class in classes {
+            vreg_classes.push(class);
+        }
+        info.vreg_classes = vreg_classes;
+        info
+    }
+
+    /// A two-class register file: `gp` for [`RegClass::Gp`], `fp` for
+    /// [`RegClass::Fp`], both entirely callee-saved.
+    fn two_class_file<'a>(gp: &'a [TestReg], fp: &'a [TestReg]) -> RegisterFile<'a, TestReg> {
+        RegisterFile::new([
+            SaveClasses::callee_saved_only(gp),
+            SaveClasses::callee_saved_only(fp),
+        ])
+    }
+
     #[test]
     fn clobber_index_ignores_a_never_returning_call_site() {
         // The shape Rue emits for every checked add: the value is defined
@@ -2524,15 +2749,15 @@ mod tests {
             vec![(2, TestReg(9)), (2, TestReg(8))],
         );
         mark_non_returning(&mut liveness, &[2]);
-        let classes = RegisterClasses {
+        let file = RegisterFile::gp_only(SaveClasses {
             caller_saved: &[TestReg(9), TestReg(8)],
             callee_saved: &[TestReg(0)],
             compact_callee_saved: &[],
-        };
+        });
         let (allocation, num_spills, used_callee_saved, _) = linear_scan_impl(
             2,
             &liveness,
-            classes,
+            file,
             0,
             false,
             &CostModel::default(),
@@ -2551,6 +2776,149 @@ mod tests {
         assert!(
             used_callee_saved.is_empty(),
             "no interval needed a callee-saved register, so the prologue saves nothing"
+        );
+    }
+
+    // ========================================
+    // Register-class allocation (RUE-1067)
+    // ========================================
+
+    #[test]
+    fn an_interval_takes_only_a_register_of_its_own_class() {
+        // Two intervals live over the same instructions, one general-purpose
+        // and one floating-point, against a file with exactly one register of
+        // each class. A class-blind allocator sees two intervals competing for
+        // whichever single pool it was handed and spills one of them; a
+        // class-aware one gives each its own class's register.
+        let liveness =
+            make_classed_liveness(vec![(0, 0, 4), (1, 0, 4)], &[RegClass::Gp, RegClass::Fp]);
+        let gp = [TestReg(0)];
+        let fp = [TestReg(100)];
+        let file = two_class_file(&gp, &fp);
+
+        let (allocation, num_spills, used_callee_saved, _) = linear_scan_impl(
+            2,
+            &liveness,
+            file,
+            0,
+            false,
+            &CostModel::default(),
+            &LoopInfo::no_loops(liveness.live_at.len()),
+        );
+
+        assert_eq!(num_spills, 0, "neither interval had to spill");
+        assert_eq!(
+            allocation[VReg::new(0)],
+            Some(Allocation::Register(TestReg(0)))
+        );
+        assert_eq!(
+            allocation[VReg::new(1)],
+            Some(Allocation::Register(TestReg(100)))
+        );
+        assert_eq!(
+            used_callee_saved,
+            vec![TestReg(0), TestReg(100)],
+            "the save set spans classes: one prologue preserves both"
+        );
+    }
+
+    #[test]
+    fn an_interval_of_an_empty_class_spills_past_free_registers_of_another() {
+        // The floating-point class has no registers at all, which is exactly
+        // both backends' state today. Its interval must spill even though
+        // general-purpose registers are sitting free — those cannot hold it.
+        let liveness =
+            make_classed_liveness(vec![(0, 0, 4), (1, 0, 4)], &[RegClass::Gp, RegClass::Fp]);
+        let gp = [TestReg(0), TestReg(1)];
+        let fp: [TestReg; 0] = [];
+        let file = two_class_file(&gp, &fp);
+
+        let (allocation, num_spills, _, _) = linear_scan_impl(
+            2,
+            &liveness,
+            file,
+            0,
+            false,
+            &CostModel::default(),
+            &LoopInfo::no_loops(liveness.live_at.len()),
+        );
+
+        assert_eq!(
+            allocation[VReg::new(0)],
+            Some(Allocation::Register(TestReg(0)))
+        );
+        assert!(
+            matches!(allocation[VReg::new(1)], Some(Allocation::Spill(_))),
+            "an interval whose class has no registers spills, free registers of \
+             another class notwithstanding"
+        );
+        assert_eq!(num_spills, 1);
+    }
+
+    #[test]
+    fn spill_slots_are_shared_across_register_classes() {
+        // A function has one stack frame however many register classes its
+        // target has, so two overlapping spilled intervals of different classes
+        // must get distinct slots.
+        let liveness =
+            make_classed_liveness(vec![(0, 0, 4), (1, 0, 4)], &[RegClass::Gp, RegClass::Fp]);
+        let gp: [TestReg; 0] = [];
+        let fp: [TestReg; 0] = [];
+        let file = two_class_file(&gp, &fp);
+
+        let (allocation, num_spills, _, _) = linear_scan_impl(
+            2,
+            &liveness,
+            file,
+            0,
+            false,
+            &CostModel::default(),
+            &LoopInfo::no_loops(liveness.live_at.len()),
+        );
+
+        let slot = |vreg: u32| match allocation[VReg::new(vreg)] {
+            Some(Allocation::Spill(offset)) => offset,
+            other => panic!("v{vreg} should have spilled, got {other:?}"),
+        };
+        assert_ne!(
+            slot(0),
+            slot(1),
+            "overlapping spills share no slot across classes"
+        );
+        assert_eq!(num_spills, 2);
+    }
+
+    #[test]
+    fn a_cross_class_move_is_not_coalesced() {
+        // Ranges that would coalesce cleanly if the two vregs were the same
+        // class: v0's last use is the move, v1's first def is the move.
+        let ranges = vec![(0, 0, 1), (1, 1, 2)];
+        let candidates = vec![CoalesceCandidate {
+            inst_idx: 1,
+            dst: VReg::new(1),
+            src: VReg::new(0),
+        }];
+
+        // Control: same class, so the move is redundant and goes away.
+        let mut same_class = make_classed_liveness(ranges.clone(), &[RegClass::Gp, RegClass::Gp]);
+        let same = coalesce(&candidates, &mut same_class);
+        assert!(same.is_eliminated(1));
+        assert_eq!(same.representative(VReg::new(1)), VReg::new(0));
+
+        // Across classes no physical register can hold both values, so the
+        // transfer is real work and must survive.
+        let mut cross_class = make_classed_liveness(ranges, &[RegClass::Gp, RegClass::Fp]);
+        let cross = coalesce(&candidates, &mut cross_class);
+        assert!(
+            !cross.is_eliminated(1),
+            "a class-crossing move is not a redundant register-to-register move"
+        );
+        assert_eq!(cross.num_eliminated(), 0);
+        assert_eq!(cross.representative(VReg::new(1)), VReg::new(1));
+        assert_eq!(
+            cross_class.range(VReg::new(1)),
+            Some(&LiveRange::new(1, 2)),
+            "the destination keeps its own live range"
         );
     }
 
@@ -2583,15 +2951,15 @@ mod tests {
             vec![(0, 0, 4), (1, 3, 4)],
             vec![(2, TestReg(9)), (2, TestReg(8))],
         );
-        let classes = RegisterClasses {
+        let file = RegisterFile::gp_only(SaveClasses {
             caller_saved: &[TestReg(9), TestReg(8)],
             callee_saved: &[TestReg(0)],
             compact_callee_saved: &[],
-        };
+        });
         let (allocation, num_spills, used_callee_saved, _) = linear_scan_impl(
             2,
             &liveness,
-            classes,
+            file,
             0,
             false,
             &CostModel::default(),
@@ -2628,15 +2996,15 @@ mod tests {
             vec![(0, 0, 2), (1, 3, 4)],
             vec![(2, TestReg(9)), (2, TestReg(8))],
         );
-        let classes = RegisterClasses {
+        let file = RegisterFile::gp_only(SaveClasses {
             caller_saved: &[TestReg(9), TestReg(8)],
             callee_saved: &[TestReg(0)],
             compact_callee_saved: &[TestReg(0)],
-        };
+        });
         let (allocation, num_spills, used_callee_saved, _) = linear_scan_impl(
             2,
             &liveness,
-            classes,
+            file,
             0,
             false,
             &CostModel::default(),
@@ -2665,15 +3033,15 @@ mod tests {
         // is skipped outright. The prologue stays empty.
         let liveness =
             make_liveness_with_clobbers(vec![(0, 0, 1), (1, 3, 4)], vec![(2, TestReg(9))]);
-        let classes = RegisterClasses {
+        let file = RegisterFile::gp_only(SaveClasses {
             caller_saved: &[TestReg(9)],
             callee_saved: &[TestReg(0)],
             compact_callee_saved: &[TestReg(0)],
-        };
+        });
         let (allocation, num_spills, used_callee_saved, _) = linear_scan_impl(
             2,
             &liveness,
-            classes,
+            file,
             0,
             false,
             &CostModel::default(),
@@ -2712,15 +3080,15 @@ mod tests {
             vec![(0, 0, 2), (1, 3, 5), (2, 4, 9)],
             vec![(2, TestReg(9)), (7, TestReg(9))],
         );
-        let classes = RegisterClasses {
+        let file = RegisterFile::gp_only(SaveClasses {
             caller_saved: &[TestReg(9)],
             callee_saved: &[TestReg(0), TestReg(1)],
             compact_callee_saved: &[TestReg(0)],
-        };
+        });
         let (allocation, num_spills, used_callee_saved, _) = linear_scan_impl(
             3,
             &liveness,
-            classes,
+            file,
             0,
             false,
             &CostModel::default(),
@@ -2752,15 +3120,15 @@ mod tests {
             vec![(0, 0, 4), (1, 0, 4), (2, 0, 4)],
             vec![(2, TestReg(9))],
         );
-        let classes = RegisterClasses {
+        let file = RegisterFile::gp_only(SaveClasses {
             caller_saved: &[TestReg(9)],
             callee_saved: &[],
             compact_callee_saved: &[],
-        };
+        });
         let (allocation, num_spills, used_callee_saved, _) = linear_scan_impl(
             3,
             &liveness,
-            classes,
+            file,
             0,
             false,
             &CostModel::default(),

--- a/crates/rue-codegen/src/schedule_core.rs
+++ b/crates/rue-codegen/src/schedule_core.rs
@@ -8,12 +8,23 @@ use std::cmp::Ordering;
 use std::collections::{BinaryHeap, HashMap, HashSet};
 use std::hash::Hash;
 
+use crate::reg_class::RegClass;
+
 /// Backend-specific facts required by the shared scheduler.
 pub trait SchedulerAdapter {
     /// Backend MIR instruction type.
     type Inst: Clone;
     /// Backend physical register type.
     type Reg: Copy + Eq + Hash;
+
+    /// The register class `reg` belongs to.
+    ///
+    /// The dependency graph keeps its per-register bookkeeping separately per
+    /// class (see [`RegTracker`]), so a backend that numbers its
+    /// floating-point registers independently of its integer ones cannot have
+    /// the two collide. Both backends answer [`RegClass::Gp`] for every
+    /// register today (RUE-1067).
+    fn reg_class(&self, reg: Self::Reg) -> RegClass;
 
     /// Latency in cycles until an instruction's result is ready.
     fn latency(&self, inst: &Self::Inst) -> u32;
@@ -39,6 +50,61 @@ pub trait SchedulerAdapter {
 
     /// Whether this instruction reads the target's condition flags.
     fn reads_flags(&self, inst: &Self::Inst) -> bool;
+}
+
+/// The dependency graph's per-physical-register bookkeeping, partitioned by
+/// [`RegClass`].
+///
+/// "Which instruction last wrote this register" and "which instructions have
+/// read it since" are what every RAW, WAW, WAR, and clobber edge is built
+/// from. The maps are held one pair per register class rather than one pair
+/// overall because registers of different classes are different registers:
+/// nothing a floating-point register does can order an integer register's
+/// readers, and a backend that numbers its floating-point registers
+/// independently of its integer ones must not have the two share a map key.
+///
+/// Every register both backends name is [`RegClass::Gp`] today, so the `Fp`
+/// partition stays empty and the resulting graph is exactly the one a single
+/// pair of maps produced (RUE-1067).
+struct RegTracker<Reg> {
+    last_writer: [HashMap<Reg, usize>; RegClass::COUNT],
+    last_readers: [HashMap<Reg, Vec<usize>>; RegClass::COUNT],
+}
+
+impl<Reg: Copy + Eq + Hash> RegTracker<Reg> {
+    fn new() -> Self {
+        Self {
+            last_writer: std::array::from_fn(|_| HashMap::new()),
+            last_readers: std::array::from_fn(|_| HashMap::new()),
+        }
+    }
+
+    /// The instruction that last wrote or clobbered `reg`, if any.
+    fn last_writer(&self, class: RegClass, reg: &Reg) -> Option<usize> {
+        self.last_writer[class.index()].get(reg).copied()
+    }
+
+    /// The instructions that have read `reg` since it was last written.
+    fn last_readers(&self, class: RegClass, reg: &Reg) -> Option<&Vec<usize>> {
+        self.last_readers[class.index()].get(reg)
+    }
+
+    /// Record that instruction `idx` wrote or clobbered `reg`.
+    ///
+    /// Readers recorded before the write belong to the previous value, so they
+    /// are dropped: a later instruction cannot have a WAR dependency on them.
+    fn record_write(&mut self, class: RegClass, reg: Reg, idx: usize) {
+        self.last_writer[class.index()].insert(reg, idx);
+        self.last_readers[class.index()].remove(&reg);
+    }
+
+    /// Record that instruction `idx` read `reg`.
+    fn record_read(&mut self, class: RegClass, reg: Reg, idx: usize) {
+        self.last_readers[class.index()]
+            .entry(reg)
+            .or_default()
+            .push(idx);
+    }
 }
 
 /// A node in the scheduling dependency graph.
@@ -167,10 +233,9 @@ where
         .collect();
     let mut edges = HashSet::new();
 
-    // Track last writer of each register.
-    let mut last_writer: HashMap<A::Reg, usize> = HashMap::new();
-    // Track last readers of each register (for WAR dependencies).
-    let mut last_readers: HashMap<A::Reg, Vec<usize>> = HashMap::new();
+    // Track the last writer and the readers since that write, per register
+    // class (see `RegTracker`).
+    let mut regs: RegTracker<A::Reg> = RegTracker::new();
     // Track last memory access (conservative).
     let mut last_memory_access: Option<usize> = None;
     // Track last FLAGS writer and readers.
@@ -184,21 +249,21 @@ where
 
         // RAW (Read After Write): this instruction reads what another wrote.
         for reg in &reads {
-            if let Some(&writer) = last_writer.get(reg) {
+            if let Some(writer) = regs.last_writer(adapter.reg_class(*reg), reg) {
                 add_edge(&mut nodes, &mut edges, writer, i);
             }
         }
 
         // WAW (Write After Write): this instruction writes what another wrote.
         for reg in &writes {
-            if let Some(&prev_writer) = last_writer.get(reg) {
+            if let Some(prev_writer) = regs.last_writer(adapter.reg_class(*reg), reg) {
                 add_edge(&mut nodes, &mut edges, prev_writer, i);
             }
         }
 
         // WAR (Write After Read): this instruction writes what another read.
         for reg in &writes {
-            if let Some(readers) = last_readers.get(reg) {
+            if let Some(readers) = regs.last_readers(adapter.reg_class(*reg), reg) {
                 for &reader in readers {
                     if reader != i {
                         add_edge(&mut nodes, &mut edges, reader, i);
@@ -239,9 +304,10 @@ where
         let clobbers = adapter.clobbers(inst);
         // Clobber dependencies.
         for &clobbered in &clobbers {
+            let class = adapter.reg_class(clobbered);
             // This instruction clobbers the register, so it must come after
             // any readers.
-            if let Some(readers) = last_readers.get(&clobbered) {
+            if let Some(readers) = regs.last_readers(class, &clobbered) {
                 for &reader in readers {
                     if reader != i {
                         add_edge(&mut nodes, &mut edges, reader, i);
@@ -249,7 +315,7 @@ where
                 }
             }
             // And after the last writer.
-            if let Some(&writer) = last_writer.get(&clobbered) {
+            if let Some(writer) = regs.last_writer(class, &clobbered) {
                 add_edge(&mut nodes, &mut edges, writer, i);
             }
         }
@@ -258,15 +324,13 @@ where
         // that writes (WAW) or reads (RAW) a clobbered register must not be
         // scheduled above the clobberer, or the clobber destroys its value.
         for clobbered in clobbers {
-            last_writer.insert(clobbered, i);
-            last_readers.remove(&clobbered);
+            regs.record_write(adapter.reg_class(clobbered), clobbered, i);
         }
         for reg in writes {
-            last_writer.insert(reg, i);
-            last_readers.remove(&reg);
+            regs.record_write(adapter.reg_class(reg), reg, i);
         }
         for reg in reads {
-            last_readers.entry(reg).or_default().push(i);
+            regs.record_read(adapter.reg_class(reg), reg, i);
         }
 
         if adapter.writes_flags(inst) {
@@ -415,6 +479,129 @@ fn schedule_block_with_work(nodes: &[SchedNode]) -> (Vec<usize>, ScheduleWork) {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// A register named by class and number, so the same number can appear in
+    /// two classes — the aliasing case the partitioned [`RegTracker`] rules
+    /// out. No backend has such a register type yet.
+    #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+    struct ClassedReg(RegClass, u32);
+
+    /// A minimal instruction: what it reads, what it writes, nothing else.
+    #[derive(Debug, Clone)]
+    struct TestInst {
+        reads: Vec<ClassedReg>,
+        writes: Vec<ClassedReg>,
+    }
+
+    struct TestAdapter;
+
+    impl SchedulerAdapter for TestAdapter {
+        type Inst = TestInst;
+        type Reg = ClassedReg;
+
+        fn reg_class(&self, reg: Self::Reg) -> RegClass {
+            reg.0
+        }
+
+        fn latency(&self, _inst: &Self::Inst) -> u32 {
+            1
+        }
+
+        fn is_barrier(&self, _inst: &Self::Inst) -> bool {
+            false
+        }
+
+        fn accesses_memory(&self, _inst: &Self::Inst) -> bool {
+            false
+        }
+
+        fn regs_read(&self, inst: &Self::Inst) -> Vec<Self::Reg> {
+            inst.reads.clone()
+        }
+
+        fn regs_written(&self, inst: &Self::Inst) -> Vec<Self::Reg> {
+            inst.writes.clone()
+        }
+
+        fn clobbers(&self, _inst: &Self::Inst) -> Vec<Self::Reg> {
+            Vec::new()
+        }
+
+        fn writes_flags(&self, _inst: &Self::Inst) -> bool {
+            false
+        }
+
+        fn reads_flags(&self, _inst: &Self::Inst) -> bool {
+            false
+        }
+    }
+
+    fn inst(reads: &[ClassedReg], writes: &[ClassedReg]) -> TestInst {
+        TestInst {
+            reads: reads.to_vec(),
+            writes: writes.to_vec(),
+        }
+    }
+
+    #[test]
+    fn same_class_registers_still_carry_a_read_after_write_dependency() {
+        let gp0 = ClassedReg(RegClass::Gp, 0);
+        let instructions = vec![inst(&[], &[gp0]), inst(&[gp0], &[])];
+
+        let nodes = build_dep_graph::<TestAdapter>(&instructions, 0, 2, &TestAdapter);
+
+        assert_eq!(nodes[1].deps, vec![0], "the reader depends on the writer");
+        assert_eq!(nodes[0].users, vec![1]);
+    }
+
+    #[test]
+    fn a_write_in_one_class_does_not_order_a_read_in_another() {
+        // Same register *number*, different classes: two distinct machine
+        // registers, so the second instruction reads something the first never
+        // wrote and the two may be scheduled in either order.
+        let gp0 = ClassedReg(RegClass::Gp, 0);
+        let fp0 = ClassedReg(RegClass::Fp, 0);
+        let instructions = vec![inst(&[], &[gp0]), inst(&[fp0], &[])];
+
+        let nodes = build_dep_graph::<TestAdapter>(&instructions, 0, 2, &TestAdapter);
+
+        assert!(
+            nodes[1].deps.is_empty(),
+            "a general-purpose write cannot order a floating-point read"
+        );
+        assert!(nodes[0].users.is_empty());
+    }
+
+    #[test]
+    fn a_write_in_one_class_does_not_order_a_write_in_another() {
+        let gp3 = ClassedReg(RegClass::Gp, 3);
+        let fp3 = ClassedReg(RegClass::Fp, 3);
+        let instructions = vec![inst(&[], &[gp3]), inst(&[], &[fp3])];
+
+        let nodes = build_dep_graph::<TestAdapter>(&instructions, 0, 2, &TestAdapter);
+
+        assert!(
+            nodes[1].deps.is_empty(),
+            "write-after-write is a per-register fact, and these are two registers"
+        );
+    }
+
+    #[test]
+    fn a_write_in_one_class_does_not_order_an_earlier_read_in_another() {
+        // WAR: instruction 1 reads gp5, instruction 2 writes fp5. Different
+        // registers, so nothing forces instruction 2 to stay after it.
+        let gp5 = ClassedReg(RegClass::Gp, 5);
+        let fp5 = ClassedReg(RegClass::Fp, 5);
+        let instructions = vec![inst(&[], &[gp5]), inst(&[gp5], &[]), inst(&[], &[fp5])];
+
+        let nodes = build_dep_graph::<TestAdapter>(&instructions, 0, 3, &TestAdapter);
+
+        assert_eq!(nodes[1].deps, vec![0]);
+        assert!(
+            nodes[2].deps.is_empty(),
+            "write-after-read is a per-register fact, and these are two registers"
+        );
+    }
 
     #[test]
     fn high_fan_in_readiness_work_is_edge_linear_and_ties_are_stable() {

--- a/crates/rue-codegen/src/x86_64/liveness.rs
+++ b/crates/rue-codegen/src/x86_64/liveness.rs
@@ -9,6 +9,7 @@ use super::mir::{Operand, Reg, ReturnBehavior, X86Inst, X86Mir};
 use crate::liveness::{
     LivenessAdapter, branch_successor, conditional_successors, fallthrough_successor,
 };
+use crate::reg_class::VRegClasses;
 use crate::vreg::{LabelId, VReg};
 
 // Re-export shared types from the regalloc module
@@ -31,6 +32,10 @@ impl LivenessAdapter for X86LivenessAdapter<'_> {
 
     fn vreg_count(&self) -> u32 {
         self.mir.vreg_count()
+    }
+
+    fn vreg_classes(&self) -> &VRegClasses {
+        self.mir.vreg_classes()
     }
 
     fn label(&self, inst: &Self::Inst) -> Option<LabelId> {

--- a/crates/rue-codegen/src/x86_64/mir.rs
+++ b/crates/rue-codegen/src/x86_64/mir.rs
@@ -18,6 +18,7 @@ pub use rue_runtime_abi::ReturnBehavior;
 // - X86Inst: 32 bytes
 const _: () = assert!(std::mem::size_of::<X86Inst>() <= 40);
 
+pub use crate::reg_class::{RegClass, VRegClasses};
 pub use crate::vreg::{LabelId, VReg};
 
 /// A physical x86-64 register.
@@ -137,6 +138,18 @@ const _: () = {
 };
 
 impl Reg {
+    /// The register class this register belongs to.
+    ///
+    /// Every `Reg` variant is an x86-64 general-purpose register, so this is
+    /// [`RegClass::Gp`] throughout. The floats series adds the XMM variants
+    /// that answer [`RegClass::Fp`]; until then this method exists so the
+    /// shared scheduler and allocator can ask the question without
+    /// special-casing a target that has only one class (RUE-1067).
+    #[inline]
+    pub const fn class(self) -> RegClass {
+        RegClass::Gp
+    }
+
     /// Get the register encoding for ModR/M and SIB bytes.
     #[inline]
     pub const fn encoding(self) -> u8 {
@@ -1002,6 +1015,9 @@ pub struct X86Mir {
     instructions: Vec<X86Inst>,
     /// The next virtual register index.
     next_vreg: u32,
+    /// The register class of each virtual register, one entry per register
+    /// minted by [`X86Mir::alloc_vreg_in`] and indexed by vreg index.
+    vreg_classes: VRegClasses,
     /// The next label index.
     next_label: u32,
     /// Symbol table for call targets.
@@ -1021,6 +1037,7 @@ impl X86Mir {
         Self {
             instructions: Vec::new(),
             next_vreg: 0,
+            vreg_classes: VRegClasses::new(),
             next_label: 0,
             symbols: Vec::new(),
             symbol_index: HashMap::new(),
@@ -1079,11 +1096,38 @@ impl X86Mir {
         self.symbols = symbols;
     }
 
-    /// Allocate a new virtual register.
+    /// Allocate a new general-purpose virtual register.
+    ///
+    /// This is the whole of lowering today: no Rue type lowers to a
+    /// floating-point value yet, so every value a function computes lives in a
+    /// general-purpose register. Sites that later hold a floating-point value
+    /// call [`X86Mir::alloc_vreg_in`] with [`RegClass::Fp`] instead (RUE-1067).
     pub fn alloc_vreg(&mut self) -> VReg {
+        self.alloc_vreg_in(RegClass::Gp)
+    }
+
+    /// Allocate a new virtual register of `class`, recording its class.
+    ///
+    /// The class table grows in lock-step with `next_vreg`, which is what lets
+    /// liveness hand allocation a table that covers every virtual register the
+    /// function has.
+    pub fn alloc_vreg_in(&mut self, class: RegClass) -> VReg {
         let vreg = VReg::new(self.next_vreg);
         self.next_vreg += 1;
+        self.vreg_classes.push(class);
         vreg
+    }
+
+    /// The register class of each virtual register.
+    #[inline]
+    pub fn vreg_classes(&self) -> &VRegClasses {
+        &self.vreg_classes
+    }
+
+    /// The register class of one virtual register.
+    #[inline]
+    pub fn vreg_class(&self, vreg: VReg) -> RegClass {
+        self.vreg_classes.class_of(vreg)
     }
 
     /// Allocate a new label ID.
@@ -1196,6 +1240,49 @@ mod tests {
         assert_eq!(v1.index(), 1);
         assert_eq!(v2.index(), 2);
         assert_eq!(mir.vreg_count(), 3);
+    }
+
+    #[test]
+    fn vreg_classes_cover_every_minted_register() {
+        // The allocator indexes the class table with any vreg the live ranges
+        // mention, so the table must stay exactly as long as `vreg_count`.
+        let mut mir = X86Mir::new();
+        assert_eq!(mir.vreg_classes().len(), mir.vreg_count());
+        for _ in 0..4 {
+            mir.alloc_vreg();
+            assert_eq!(mir.vreg_classes().len(), mir.vreg_count());
+        }
+    }
+
+    #[test]
+    fn lowering_mints_general_purpose_registers_only() {
+        // Every value a Rue function computes is an integer, pointer, or
+        // boolean today, so `alloc_vreg` — the only mint site lowering uses —
+        // must produce general-purpose registers. When the floats series adds
+        // `alloc_vreg_in(RegClass::Fp)` call sites this stops being true of the
+        // program, but never of `alloc_vreg` itself (RUE-1067).
+        let mut mir = X86Mir::new();
+        let vregs: Vec<_> = (0..3).map(|_| mir.alloc_vreg()).collect();
+        for vreg in vregs {
+            assert_eq!(mir.vreg_class(vreg), RegClass::Gp);
+        }
+        assert_eq!(mir.vreg_classes().count_in(RegClass::Fp), 0);
+    }
+
+    #[test]
+    fn an_explicit_class_is_recorded_as_given() {
+        let mut mir = X86Mir::new();
+        let gp = mir.alloc_vreg_in(RegClass::Gp);
+        let fp = mir.alloc_vreg_in(RegClass::Fp);
+
+        assert_eq!(mir.vreg_class(gp), RegClass::Gp);
+        assert_eq!(mir.vreg_class(fp), RegClass::Fp);
+        assert_eq!(mir.vreg_classes().count_in(RegClass::Fp), 1);
+    }
+
+    #[test]
+    fn every_physical_register_is_general_purpose() {
+        assert_eq!(Reg::Rbx.class(), RegClass::Gp);
     }
 
     #[test]

--- a/crates/rue-codegen/src/x86_64/regalloc.rs
+++ b/crates/rue-codegen/src/x86_64/regalloc.rs
@@ -23,7 +23,7 @@ use super::mir::{
 use crate::alloc_dst;
 use crate::regalloc::{
     Allocation, AllocationContext, CoalesceCandidate, LivenessInfo, LoopInfo, RegAllocBackend,
-    RegAllocDebugInfo, RegAllocDriver, RegisterClasses, RematerializeOp, RewriteBuffer,
+    RegAllocDebugInfo, RegAllocDriver, RegisterFile, RematerializeOp, RewriteBuffer, SaveClasses,
 };
 
 /// Caller-saved registers offered to intervals no instruction clobbers while
@@ -1418,12 +1418,15 @@ impl RegAllocBackend for X86Backend {
             .collect()
     }
 
-    fn register_classes() -> RegisterClasses<'static, Self::Reg> {
-        RegisterClasses {
+    fn register_file() -> RegisterFile<'static, Self::Reg> {
+        // General-purpose only: `Reg` names no XMM register yet, so the `Fp`
+        // class of the file is empty and no interval can select it
+        // (RUE-1067). The floats series adds the XMM registers here.
+        RegisterFile::gp_only(SaveClasses {
             caller_saved: CALLER_SAVED_REGS,
             callee_saved: CALLEE_SAVED_REGS,
             compact_callee_saved: COMPACT_CALLEE_SAVED_REGS,
-        }
+        })
     }
 
     fn physical_operands(inst: &Self::Inst) -> Vec<Self::Reg> {
@@ -1463,12 +1466,53 @@ impl RegAllocBackend for X86Backend {
 
 #[cfg(test)]
 mod tests {
+    use super::X86Backend;
     use super::liveness;
     use super::{
         ALLOCATABLE_REGS, CALLEE_SAVED_REGS, CALLER_SAVED_REGS, COMPACT_CALLEE_SAVED_REGS, Operand,
         Reg, RegAlloc, VReg, X86Inst, X86Mir,
     };
-    use crate::regalloc::{Allocation, RematerializeOp};
+    use crate::reg_class::RegClass;
+    use crate::regalloc::{Allocation, RegAllocBackend, RematerializeOp};
+
+    #[test]
+    fn the_register_file_is_general_purpose_only() {
+        // The whole of RUE-1067's claim on this backend: the class dimension
+        // exists, and the floating-point half of it is empty. A change that
+        // populates `Fp` here without the rest of the floats series would make
+        // allocation hand out registers no instruction can encode, so this
+        // guard fails loudly instead.
+        let file = <X86Backend as RegAllocBackend>::register_file();
+        let gp = file.class(RegClass::Gp);
+        let fp = file.class(RegClass::Fp);
+
+        assert_eq!(gp.caller_saved, CALLER_SAVED_REGS);
+        assert_eq!(gp.callee_saved, CALLEE_SAVED_REGS);
+        assert!(!gp.is_empty());
+        assert!(
+            fp.is_empty(),
+            "no floating-point register is allocatable yet"
+        );
+        assert_eq!(file.len(), ALLOCATABLE_REGS.len());
+        assert_eq!(file.caller_saved_flattened(), CALLER_SAVED_REGS.to_vec());
+    }
+
+    #[test]
+    fn allocation_liveness_classes_every_vreg_as_general_purpose() {
+        // Liveness is where the class table reaches allocation, so this is the
+        // end-to-end statement that lowering mints one class only.
+        let mut mir = X86Mir::new();
+        let vregs: Vec<VReg> = (0..3).map(|_| mir.alloc_vreg()).collect();
+        define_loaded_values(&mut mir, &vregs);
+
+        let info = liveness::analyze(&mir);
+
+        assert_eq!(info.vreg_classes.len(), mir.vreg_count());
+        assert_eq!(info.vreg_classes.count_in(RegClass::Fp), 0);
+        for &vreg in &vregs {
+            assert_eq!(info.class_of(vreg), RegClass::Gp);
+        }
+    }
 
     fn define_loaded_values(mir: &mut X86Mir, vregs: &[VReg]) {
         for (index, &vreg) in vregs.iter().enumerate() {

--- a/crates/rue-codegen/src/x86_64/schedule.rs
+++ b/crates/rue-codegen/src/x86_64/schedule.rs
@@ -29,6 +29,7 @@
 //! Memory dependencies are handled conservatively (all loads/stores ordered).
 
 use super::mir::{Operand, Reg, X86Inst, X86Mir};
+use crate::reg_class::RegClass;
 use crate::schedule_core::{self, SchedulerAdapter};
 
 struct X86Scheduler;
@@ -36,6 +37,10 @@ struct X86Scheduler;
 impl SchedulerAdapter for X86Scheduler {
     type Inst = X86Inst;
     type Reg = Reg;
+
+    fn reg_class(&self, reg: Self::Reg) -> RegClass {
+        reg.class()
+    }
 
     fn latency(&self, inst: &Self::Inst) -> u32 {
         get_latency(inst)

--- a/crates/rue-frontend-diff/src/corpus_manifest.rs
+++ b/crates/rue-frontend-diff/src/corpus_manifest.rs
@@ -1429,6 +1429,7 @@ pub(crate) const ROOTS: &[(&str, &[&str])] = &[
             "fmt.rue",
             "fs.rue",
             "grid.rue",
+            "hash.rue",
             "intmap.rue",
             "json.rue",
             "math.rue",

--- a/crates/rue-fuzz/README.md
+++ b/crates/rue-fuzz/README.md
@@ -141,6 +141,17 @@ done
 Any crash — panic or abort (signal) — causes a non-zero exit code, which fails
 the CI job and uploads the saved reproducers as artifacts.
 
+A failed nightly run then reports every crash it found to the issue tracker via
+`scripts/fuzz-report-failure.py`: **one issue per distinct crash fingerprint**
+in the Rue Linear team, deduplicated against open issues so a recurrence becomes
+a comment rather than a second issue. The fingerprint is derived from the target
+plus the *normalized* signature recorded in the `.meta` sibling (addresses, temp
+paths, source line numbers, and generator seeds erased), which is what lets the
+same bug dedup across nights. See
+[docs/process/fuzz-failure-reporting.md](../../docs/process/fuzz-failure-reporting.md)
+— including the one-time `LINEAR_API_KEY` secret setup, without which the
+workflow falls back to filing GitHub Issues.
+
 ## Proptest Integration
 
 The fuzzer includes proptest-based tests that generate syntactically valid Rue programs. These run as part of the unit tests:

--- a/crates/rue-oracle-diff/src/model_gaps/cli.rs
+++ b/crates/rue-oracle-diff/src/model_gaps/cli.rs
@@ -210,6 +210,64 @@ const ENTRIES: &[Entry] = &[
         intrinsic(UnsupportedIntrinsicKind::ByteCopy),
         &["aarch64-linux", "x86-64-linux"],
     ),
+    // RUE-995: the `create_dir_all` cases reach the same `@byte_copy` gap as the
+    // rest of the std.fs group — every one of them marshals a path through
+    // StrBuf, which copies bytes in bulk. The directory behavior they assert is
+    // covered by their exact-stdout CLI assertions, not by the oracle model.
+    Entry::new(
+        "cli.fs_file_io",
+        "fs_mkdir_then_file_roundtrip_inside",
+        intrinsic(UnsupportedIntrinsicKind::ByteCopy),
+        &["aarch64-linux", "x86-64-linux"],
+    ),
+    Entry::new(
+        "cli.fs_file_io",
+        "fs_mkdir_all_nested_levels_usable",
+        intrinsic(UnsupportedIntrinsicKind::ByteCopy),
+        &["aarch64-linux", "x86-64-linux"],
+    ),
+    Entry::new(
+        "cli.fs_file_io",
+        "fs_mkdir_double_create_flat_errs_recursive_ok",
+        intrinsic(UnsupportedIntrinsicKind::ByteCopy),
+        &["aarch64-linux", "x86-64-linux"],
+    ),
+    Entry::new(
+        "cli.fs_file_io",
+        "fs_mkdir_all_separator_shapes",
+        intrinsic(UnsupportedIntrinsicKind::ByteCopy),
+        &["aarch64-linux", "x86-64-linux"],
+    ),
+    Entry::new(
+        "cli.fs_file_io",
+        "fs_mkdir_all_file_in_the_way_errs",
+        intrinsic(UnsupportedIntrinsicKind::ByteCopy),
+        &["aarch64-linux", "x86-64-linux"],
+    ),
+    // RUE-682: only the std.hash cases that route bytes through StrBuf or
+    // ArrayBuf(u8) hit the `@byte_copy` gap. The three that hash `str` views
+    // directly — including `hash_known_answer_vectors`, which carries the
+    // published FNV-1a/64 vectors — ARE modeled, so the oracle differentially
+    // checks the hash arithmetic itself. That is the coverage worth having here;
+    // the container spellings are asserted to agree with `str` inside the cases.
+    Entry::new(
+        "cli.std_hash",
+        "hash_chunking_does_not_change_result",
+        intrinsic(UnsupportedIntrinsicKind::ByteCopy),
+        &[],
+    ),
+    Entry::new(
+        "cli.std_hash",
+        "hash_str_strbuf_arraybuf_agree",
+        intrinsic(UnsupportedIntrinsicKind::ByteCopy),
+        &[],
+    ),
+    Entry::new(
+        "cli.std_hash",
+        "hash_order_and_byte_sensitive",
+        intrinsic(UnsupportedIntrinsicKind::ByteCopy),
+        &[],
+    ),
     // ADR-0052 phase 3 (RUE-974): the compact-layout CLI cases reach a field
     // through `@field_ptr`, which the oracle model does not model (same gap as
     // the `offset_of_field_ptr` cases above).

--- a/crates/rue-oracle-diff/src/model_gaps/spec.rs
+++ b/crates/rue-oracle-diff/src/model_gaps/spec.rs
@@ -334,6 +334,21 @@ const ENTRIES: &[Entry] = &[
         intrinsic(UnsupportedIntrinsicKind::ParseI64),
         &[],
     ),
+    // ADR-0059 phase 5 (RUE-963): the typed-access width and unaligned round
+    // trip cases anchor their pointers via @int_to_ptr, which the oracle does
+    // not model.
+    Entry::new(
+        "runtime.pointers",
+        "ptr_write_i32_touches_exactly_size_of_bytes",
+        intrinsic(UnsupportedIntrinsicKind::IntToPointer),
+        &[],
+    ),
+    Entry::new(
+        "runtime.raw_bytes",
+        "ptr_unaligned_round_trip_at_an_odd_address",
+        intrinsic(UnsupportedIntrinsicKind::IntToPointer),
+        &[],
+    ),
     // ADR-0052 phase 7 (RUE-978): the unaligned-access round trip allocates
     // through @alloc, which the oracle model does not model.
     Entry::new(

--- a/crates/rue-spec/cases/runtime/heap.toml
+++ b/crates/rue-spec/cases/runtime/heap.toml
@@ -6,8 +6,11 @@
 # states its alignment, and every pointer is `ptr mut u8`. Like the raw-pointer
 # intrinsics they must appear inside a `checked` block. These are the primitives
 # a source-level `ArrayBuf` is built on, which is why several cases exercise the
-# typed-allocation idiom `@alloc(count * @size_of(T), @align_of(T))` followed by
-# a `@int_to_ptr(@ptr_to_int(..))` cast to `ptr mut T`.
+# typed-allocation idiom
+# `@alloc(count * @intCast(@size_of(T)), @intCast(@align_of(T)))` followed by a
+# `@int_to_ptr(@ptr_to_int(..))` cast to `ptr mut T`. The `@intCast` is load
+# bearing: `@size_of`/`@align_of` evaluate to `i32` (4.13:14, 4.13:20) while
+# every operand of this family is exactly `u64` (9.2:13).
 
 [section]
 id = "runtime.heap"

--- a/crates/rue-spec/cases/runtime/pointers.toml
+++ b/crates/rue-spec/cases/runtime/pointers.toml
@@ -1,7 +1,10 @@
 # Pointer Intrinsic Tests
 #
-# Tests for pointer intrinsics that operate on raw pointers for low-level memory access.
-# These intrinsics must be used within `checked` blocks.
+# Tests for pointer intrinsics that operate on raw pointers for low-level memory
+# access. These intrinsics must be used within `checked` blocks (9.1:12). The
+# pointee-typed access surface is specified by 9.2:6a-9.2:6d: `@ptr_read` and
+# `@ptr_write` move exactly `@size_of(T)` physical bytes, and `@ptr_to_int` /
+# `@int_to_ptr` are the segregated address conversions (ADR-0059).
 
 [section]
 id = "runtime.pointers"
@@ -15,7 +18,7 @@ description = "Tests for pointer intrinsics (@raw, @ptr_read, @ptr_write, etc.)"
 
 [[case]]
 name = "raw_simple_local"
-spec = ["9.2:1"]
+spec = ["9.2:6a", "9.2:6b"]
 source = """
 fn main() -> i32 {
     let x: i32 = 42;
@@ -34,14 +37,14 @@ exit_code = 42
 # default compact layout a raw pointer into a frame-resident NON-slot-identical
 # array (e.g. `[i32; 3]`, which packs to 4-byte strides while the frame stores
 # 8-byte slots) is refused loudly rather than silently mixing representations
-# (RUE-987 / RUE-1035 M2); that refusal is pinned in the CLI corpora. The `@raw`
+# (RUE-987 / RUE-1035, ADR-0052); that refusal is pinned in the CLI corpora. The `@raw`
 # and `@ptr_offset` semantics themselves are width-independent, so a
 # slot-identical array demonstrates them faithfully on the frame.
 # =============================================================================
 
 [[case]]
 name = "raw_array_element"
-spec = ["9.2:1"]
+spec = ["9.2:6a", "9.2:6b"]
 source = """
 fn main() -> i32 {
     let arr: [i64; 3] = [10, 20, 30];
@@ -56,7 +59,7 @@ exit_code = 10
 
 [[case]]
 name = "raw_array_second_element"
-spec = ["9.2:1"]
+spec = ["9.2:6a"]
 source = """
 fn main() -> i32 {
     let arr: [i64; 3] = [10, 20, 30];
@@ -71,7 +74,7 @@ exit_code = 20
 
 [[case]]
 name = "raw_array_last_element"
-spec = ["9.2:1"]
+spec = ["9.2:6a"]
 source = """
 fn main() -> i32 {
     let arr: [i64; 3] = [10, 20, 30];
@@ -90,7 +93,7 @@ exit_code = 30
 
 [[case]]
 name = "ptr_to_int_basic"
-spec = ["9.2:1"]
+spec = ["9.2:6c"]
 source = """
 fn main() -> i32 {
     let x: i32 = 42;
@@ -109,7 +112,7 @@ exit_code = 42
 
 [[case]]
 name = "ptr_write_and_read"
-spec = ["9.2:1"]
+spec = ["9.2:6b", "9.2:6d"]
 source = """
 fn main() -> i32 {
     let mut x: i32 = 10;
@@ -124,7 +127,7 @@ exit_code = 99
 
 [[case]]
 name = "ptr_write_array_element"
-spec = ["9.2:1"]
+spec = ["9.2:6b"]
 source = """
 fn main() -> i32 {
     let mut arr: [i64; 3] = [10, 20, 30];
@@ -143,7 +146,7 @@ exit_code = 77
 
 [[case]]
 name = "int_to_ptr_with_type_annotation"
-spec = ["9.2:1"]
+spec = ["9.2:6c", "9.2:6d"]
 source = """
 fn main() -> i32 {
     let x: i32 = 42;
@@ -159,7 +162,7 @@ exit_code = 42
 
 [[case]]
 name = "int_to_ptr_mutable_pointer"
-spec = ["9.2:1"]
+spec = ["9.2:6c"]
 source = """
 fn main() -> i32 {
     let x: i32 = 99;
@@ -176,7 +179,7 @@ exit_code = 99
 
 [[case]]
 name = "int_to_ptr_u64_pointer"
-spec = ["9.2:1"]
+spec = ["9.2:6c", "9.2:6d"]
 source = """
 fn main() -> i32 {
     let x: u64 = 12345;
@@ -190,6 +193,78 @@ fn main() -> i32 {
 }
 """
 exit_code = 57  # 12345 % 256 = 57
+
+# The null-pointer idiom (9.2:6c): `@int_to_ptr` takes exactly a `u64`, so null
+# is written over a `u64` binding rather than a bare `0` literal, and
+# `@ptr_to_int(p) == 0` is the null test. Round-tripping an address through the
+# pair addresses the same storage.
+[[case]]
+name = "int_to_ptr_zero_is_the_null_pointer"
+spec = ["9.2:6c", "9.2:6e"]
+source = """
+fn main() -> i32 {
+    let mut x: i32 = 10;
+    let zero: u64 = 0;
+    checked {
+        let p: ptr mut i32 = @raw_mut(x);
+        @ptr_write(p, 99);
+        let back: ptr mut i32 = @int_to_ptr(@ptr_to_int(p));
+        let null: ptr mut u8 = @int_to_ptr(zero);
+        if @ptr_to_int(null) == 0 { @ptr_read(back) } else { 0 }
+    }
+}
+"""
+exit_code = 99
+
+# @ptr_read/@ptr_write move exactly @size_of(T) physical bytes, never a
+# fixed-width slot (9.2:6b). At T = u8 that is one byte: writing through a
+# `ptr mut u8` leaves both neighbours untouched.
+[[case]]
+name = "ptr_write_u8_touches_exactly_one_byte"
+spec = ["9.2:6b"]
+source = """
+fn main() -> i32 {
+    checked {
+        let p: ptr mut u8 = @alloc(4, 1);
+        @byte_set(p, 0, 4);
+        @ptr_write(@ptr_offset(p, 1), 200);
+        let ok: bool = @byte_read(p, 0) == 0
+            && @byte_read(p, 1) == 200
+            && @byte_read(p, 2) == 0
+            && @byte_read(p, 3) == 0;
+        @free(p, 4, 1);
+        if ok { 41 } else { 0 }
+    }
+}
+"""
+exit_code = 41
+
+# At T = i32 the same rule gives a four-byte access: a write to element 0 of a
+# two-element block leaves element 1's bytes untouched (9.2:6b). Checked by
+# byte inspection rather than by a byte pattern, so the case is endianness-neutral.
+[[case]]
+name = "ptr_write_i32_touches_exactly_size_of_bytes"
+spec = ["9.2:6b"]
+source = """
+fn main() -> i32 {
+    checked {
+        let unit: u64 = @intCast(@size_of(i32));
+        let align: u64 = @intCast(@align_of(i32));
+        let raw: ptr mut u8 = @alloc(2 * unit, align);
+        @byte_set(raw, 0, 2 * unit);
+        let p: ptr mut i32 = @int_to_ptr(@ptr_to_int(raw));
+        @ptr_write(p, 123456789);
+        let untouched: bool = @byte_read(raw, 4) == 0
+            && @byte_read(raw, 5) == 0
+            && @byte_read(raw, 6) == 0
+            && @byte_read(raw, 7) == 0;
+        let same: bool = @ptr_read(p) == 123456789;
+        @free(raw, 2 * unit, align);
+        if untouched && same { 42 } else { 0 }
+    }
+}
+"""
+exit_code = 42
 
 # @ptr_offset is standard pointer arithmetic: p + n*size_of(pointee), a plain
 # add, forward for positive n (ADR-0040 / RUE-243). arr[0]+1 lands on element

--- a/crates/rue-spec/cases/runtime/raw-bytes.toml
+++ b/crates/rue-spec/cases/runtime/raw-bytes.toml
@@ -52,6 +52,30 @@ fn main() -> i32 {
 """
 exit_code = 136
 
+# A byte offset is added unscaled, and `@size_of(u8)` is 1, so
+# `@byte_read(p, i)` names the same byte as `@ptr_read(@ptr_offset(p, i))` and
+# `@byte_write` the same byte as the corresponding `@ptr_write` (9.2:14d).
+[[case]]
+name = "byte_access_agrees_with_typed_access_on_a_u8_pointer"
+spec = ["9.2:14d"]
+source = """
+fn main() -> i32 {
+    checked {
+        let p: ptr mut u8 = @alloc(3, 1);
+        @byte_write(p, 0, 7);
+        @byte_write(p, 1, 8);
+        @byte_write(p, 2, 9);
+        let agree: bool = @byte_read(p, 2) == @ptr_read(@ptr_offset(p, 2))
+            && @byte_read(p, 0) == @ptr_read(p);
+        @ptr_write(@ptr_offset(p, 1), 30);
+        let written: bool = @byte_read(p, 1) == 30;
+        @free(p, 3, 1);
+        if agree && written { 44 } else { 0 }
+    }
+}
+"""
+exit_code = 44
+
 [[case]]
 name = "byte_read_accepts_const_u8_pointer"
 spec = ["9.2:14d", "9.2:14e"]
@@ -184,12 +208,42 @@ fn main() -> i32 {
 """
 exit_code = 0
 
+# The allocation these cases access is itself checked-gated by the allocation
+# family's own rule (9.2:13), not by the raw-byte rules.
 [[case]]
-name = "raw_bytes_require_checked"
-spec = ["9.2:14a", "9.2:14e"]
+name = "alloc_for_byte_access_requires_checked"
+spec = ["9.2:13"]
 source = """
 fn main() -> i32 {
     let p: ptr mut u8 = @alloc(1, 1);
+    0
+}
+"""
+compile_fail = true
+error_contains = "[E1300]"
+
+# @byte_read and @byte_write carry the checked gate themselves (9.2:14e), which
+# is separate from the allocation family's gate above.
+[[case]]
+name = "byte_read_requires_checked"
+spec = ["9.2:14e"]
+source = """
+fn main() -> i32 {
+    let p: ptr mut u8 = checked { @alloc(1, 1) };
+    let b: u8 = @byte_read(p, 0);
+    @intCast(b)
+}
+"""
+compile_fail = true
+error_contains = "[E1300]"
+
+[[case]]
+name = "byte_write_requires_checked"
+spec = ["9.2:14e"]
+source = """
+fn main() -> i32 {
+    let p: ptr mut u8 = checked { @alloc(1, 1) };
+    @byte_write(p, 0, 1);
     0
 }
 """
@@ -439,7 +493,7 @@ error_contains = "power of two"
 
 [[case]]
 name = "free_requires_align_argument"
-spec = ["9.2:14e"]
+spec = ["9.2:13"]
 source = """
 fn main() -> i32 {
     checked {
@@ -472,6 +526,31 @@ fn main() -> i32 {
 }
 """
 exit_code = 34
+
+# The distinguishing case: the address genuinely does not satisfy
+# `@align_of(i32)`. The aligned pair would be undefined behavior here; for the
+# `_unaligned` pair the access is well defined, covers exactly `@size_of(i32)`
+# bytes, and leaves the bytes on either side alone (9.2:14k).
+[[case]]
+name = "ptr_unaligned_round_trip_at_an_odd_address"
+spec = ["9.2:14k"]
+source = """
+fn main() -> i32 {
+    checked {
+        let align: u64 = @intCast(@align_of(i32));
+        let raw: ptr mut u8 = @alloc(8, align);
+        @byte_set(raw, 0, 8);
+        let skewed: ptr mut i32 = @int_to_ptr(@ptr_to_int(@ptr_offset(raw, 1)));
+        let misaligned: bool = @ptr_to_int(skewed) % align != 0;
+        @ptr_write_unaligned(skewed, 1000000);
+        let same: bool = @ptr_read_unaligned(skewed) == 1000000;
+        let outside: bool = @byte_read(raw, 0) == 0 && @byte_read(raw, 5) == 0;
+        @free(raw, 8, align);
+        if misaligned && same && outside { 45 } else { 0 }
+    }
+}
+"""
+exit_code = 45
 
 [[case]]
 name = "ptr_unaligned_requires_checked"

--- a/docs/formal/01-core-calculus.md
+++ b/docs/formal/01-core-calculus.md
@@ -1842,9 +1842,11 @@ obligation (O4) of §6.13.5. An `ArrayBuf(T)` instantiation's values are
   { h ; len ; cap }_ArrayBuf(T)        h ::= buf⟨A⟩ | null        len, cap : u64
 ```
 
-(`null` abstracts the no-allocation empty state — `@int_to_ptr(0)` in the
-source.) The **representation invariant** `Inv` holds at every method
-boundary — entry and exit of every defining equation, and at the destructor:
+(`null` abstracts the no-allocation empty state — `@int_to_ptr(zero)` over a
+`u64` binding `zero = 0` in the source; `@int_to_ptr` takes exactly a `u64`, so
+a bare `0` literal is not the spelling.) The **representation invariant** `Inv`
+holds at every method boundary — entry and exit of every defining equation, and
+at the destructor:
 
 ```
   Inv({ h ; len ; cap }):
@@ -1864,9 +1866,12 @@ destructor's skip below has a `⊘` to write for a buffer element exactly as
 
 The defining equations: `self` is an `inout` place for the mutators, so
 header updates write the caller's cell per §6.9's sharing rule. Each equation
-is the model of the corresponding `std/arraybuf.rue` body (its `checked {}`
-blocks over `@alloc`/`@realloc`/`@ptr_read`/`@ptr_write`/`@ptr_offset` and
-friends):
+is the model of the corresponding `std/arraybuf.rue` body, together with the
+`std/rawbuf.rue` layer it delegates its storage to — the one place that holds
+the `checked {}` blocks over `@alloc`/`@realloc`/`@free`/`@ptr_read`/
+`@ptr_write`/`@ptr_offset` and turns a cell count into the byte size
+`cap * @intCast(@size_of(T))` at alignment `@intCast(@align_of(T))` the
+byte-oriented allocation family takes (ADR-0059 Phase 3):
 
 ```
   new()                     →  { null ; 0 ; 0 }                                  -- no allocation until first push
@@ -1957,9 +1962,11 @@ citation:
 `StrBuf` is the `u8` refinement of the trio's growable rung plus the
 byte-string convention (ADR-0043; the RUE-386 two-types ruling), and like
 `ArrayBuf` it is **source-defined** (`std/strbuf.rue`) over the byte-oriented
-unchecked intrinsics (`@alloc`/`@realloc`/`@free`/
-`@byte_read`/`@byte_write`/`@byte_copy`, ADR-0059), so the same
-defining-equation device applies at its public boundary. Its value is
+unchecked intrinsics — `@byte_read`/`@byte_write`/`@byte_copy` and
+`@ptr_to_int`/`@int_to_ptr`/`@ptr_offset` directly, plus the `@alloc` of the
+literal-promotion arm below, with the growable `{buf, cap}` allocation itself
+delegated to the same `std/rawbuf.rue` core `ArrayBuf` uses (ADR-0059) — so the
+same defining-equation device applies at its public boundary. Its value is
 `{ h ; len ; cap }_StrBuf` over `u8` cells, with one representation twist the
 source pins in its header comment: **`cap = 0` is the non-owning state.**
 

--- a/docs/process/README.md
+++ b/docs/process/README.md
@@ -35,6 +35,7 @@ Each step has a corresponding document in this directory and a Claude Code comma
 | - | [compiler-facade.md](compiler-facade.md) | - | Review compiler API and tooling-view changes |
 | - | [tutorial.md](tutorial.md) | - | Maintain tutorial outline, style, and snippet checks |
 | - | [issue-tracking.md](issue-tracking.md) | Linear MCP tools | Track work with Linear |
+| - | [fuzz-failure-reporting.md](fuzz-failure-reporting.md) | - | How nightly fuzz crashes reach Linear (and the `LINEAR_API_KEY` setup) |
 
 ## Feature Types
 
@@ -65,7 +66,7 @@ Design documents for large features. See [../designs/README.md](../designs/READM
 Gating mechanism for incomplete features. Allows merging partial work to main without breaking stable functionality. See [ADR-0005](../designs/0005-preview-features.md).
 
 ### Issue Tracking (Linear)
-We use [Linear](https://linear.app) (team "Rue") for all issue tracking. See [issue-tracking.md](issue-tracking.md).
+We use [Linear](https://linear.app) (team "Rue") for all issue tracking. See [issue-tracking.md](issue-tracking.md). Automated producers file there too: the nightly fuzz workflow opens one Linear issue per distinct crash fingerprint, described in [fuzz-failure-reporting.md](fuzz-failure-reporting.md).
 
 ### Specification
 Language semantics are formally documented in [../spec/](../spec/). Changes to language behavior require spec updates.

--- a/docs/process/fuzz-failure-reporting.md
+++ b/docs/process/fuzz-failure-reporting.md
@@ -1,0 +1,138 @@
+# Fuzz Failure Reporting
+
+The nightly fuzz workflow (`.github/workflows/fuzz.yml`) files the crashes it
+finds into **Linear**, in the **Rue** team, one issue per distinct crash. GitHub
+Issues remains as a clearly-marked fallback. This page documents the mechanism,
+the one manual setup step, and how to triage what it files.
+
+> **Setup required.** Until the `LINEAR_API_KEY` secret exists, the nightly
+> workflow still reports — but into GitHub Issues, not Linear. See
+> [Manual setup](#manual-setup-linear_api_key) below.
+
+## Why this changed (RUE-802)
+
+Fuzz crashes used to be filed by an inline `actions/github-script` block that
+kept **one** open GitHub issue labelled `fuzz-crash`. Every later crash found
+while that issue stayed open was appended to it as a comment. Two consequences:
+
+- Rue plans from Linear, so automatically-found bugs sat in a tracker nobody
+  triages from.
+- Dedup was by *label*, not by crash. A miscompile found in August landed as a
+  comment on an unrelated stack-overflow issue from July, and closing that issue
+  reset the bucket. Recurrence and novelty were indistinguishable.
+
+Reporting is now `scripts/fuzz-report-failure.py`, keyed on a per-crash
+fingerprint.
+
+## How it works
+
+```
+fuzz targets crash ──► crates/rue-fuzz/crashes/  ──► scripts/fuzz-report-failure.py ──► Linear (Rue team)
+   (rue-fuzz,           crash-<target>-…​.txt + .meta         fingerprint + dedup            └─ GitHub Issues (fallback)
+    rue-oracle-diff)    oracle-diff-seed-<n>.rue
+```
+
+1. **Collect.** Every reproducer under the crash directory is read back. The
+   `rue-fuzz` harness writes a `.txt` input with a `.txt.meta` sibling recording
+   `target`, `signature`, and `outcome`; `rue-oracle-diff` writes a `.rue` repro
+   whose leading `// reason:` comment carries the signature. Both are parsed. A
+   reproducer with no metadata still reports, with a degraded signature — an
+   unexplained crash file is still a crash.
+
+2. **Fingerprint.** The crash identity is
+   `sha256(target + "\n" + normalize(signature))[:16]`. Normalization erases
+   what varies between two sightings of one bug and nothing that distinguishes
+   two bugs:
+
+   | Erased | Why |
+   |---|---|
+   | `0x…` addresses | ASLR moves them every run |
+   | Absolute path prefixes (the last three components are kept, so `rue-sema/src/check.rs` stays distinct from `rue-codegen/src/check.rs`) | the runner's checkout root is not the bug |
+   | `file.rs:120:9` line/column | any unrelated edit moves them |
+   | `seed 918273` | the same disagreement reproduces at many seeds |
+   | Digit runs of 4+ | byte counts, offsets, sizes |
+
+   Short numbers survive on purpose: `signal 6` and `signal 11` are different
+   bugs.
+
+3. **Dedup.** The fingerprint is written into the issue description as a
+   `Fuzz-Fingerprint: \`<hash>\`` line. Before filing, open (not
+   completed/canceled) Rue-team issues are searched for that exact line — the
+   labelled field, not the bare hash, so a commit prefix in an unrelated issue
+   cannot match. A hit gets a recurrence comment naming the new run; a miss
+   files a new issue.
+
+4. **File.** New Linear issues carry the `Bug` and `found-by:autonomous` labels
+   and a `[fuzz-crash]` title marker (Linear has no `fuzz-crash` label; the
+   marker is what makes the class searchable). A label that cannot be resolved
+   warns and is skipped — a crash filed with the wrong labels still gets
+   triaged, one never filed does not.
+
+If a step fails without leaving any reproducer (a wedged build, a timeout
+killing the harness), one report per failed target is synthesized instead, so
+that night is still visible.
+
+## Backends and the fallback
+
+| `LINEAR_API_KEY` | `GITHUB_TOKEN` | Behavior |
+|---|---|---|
+| set | either | Files in Linear (Rue team). |
+| unset | set | Warns loudly, files in GitHub Issues with a "filed by the fallback path" banner in the body and the `fuzz-crash` label. Dedup is still per-fingerprint. |
+| unset | unset | Exits non-zero; the workflow step goes red. |
+
+The last row is deliberate. The failure this design guards against is *silence*:
+a night whose crashes are found and then dropped. Reporting nothing and exiting
+`0` is never an outcome.
+
+This is also why `.github/workflows/fuzz.yml` keeps `permissions: issues: write`
+even though the primary path no longer needs it — that permission is what makes
+the fallback real.
+
+## Manual setup: `LINEAR_API_KEY`
+
+**This is a one-time step a repository admin (Steve) must do; it cannot be
+scripted from here.** Until it is done, nightly crashes are filed as GitHub
+Issues rather than Linear issues.
+
+1. In Linear, open **Settings → Security & access → Personal API keys** (or
+   <https://linear.app/settings/account/security>) and **Create key**. Label it
+   e.g. `rue-fuzz-ci`. Copy the key — Linear shows it once.
+   - The key must belong to a member of the **Rue** team with permission to
+     create issues and comments there.
+2. In GitHub, open the repository's **Settings → Secrets and variables →
+   Actions → New repository secret**.
+3. Name it exactly `LINEAR_API_KEY`, paste the key, and save.
+4. Verify: run the **Fuzz Testing** workflow via `workflow_dispatch`. On a run
+   that finds a crash, the reporting step logs `reporting via Linear`. If it
+   logs the `LINEAR_API_KEY is not set` warning instead, the secret name or
+   scope is wrong.
+
+Rotating the key is the same flow; nothing in the repository pins its value.
+
+## Running it by hand
+
+`--dry-run` drives the real client code — query construction, label resolution,
+dedup branching, payload assembly — against a synthesizing transport that prints
+every request instead of sending it. No credentials are needed or used.
+
+```bash
+# What would this crash directory file?
+scripts/fuzz-report-failure.py --dry-run --crash-dir crates/rue-fuzz/crashes
+
+# What would a failed run with no surviving reproducer file?
+scripts/fuzz-report-failure.py --dry-run --failed-targets lexer,emitter_aarch64
+```
+
+To file for real from a local run, export `LINEAR_API_KEY` and drop
+`--dry-run`. `--backend linear` refuses to fall back to GitHub, which is what
+you want when testing the Linear path specifically.
+
+## Tests
+
+`//:fuzz-report-tool-tests` (`scripts/test-fuzz-report-failure.py`) pins the
+parts that decide whether a crash is reported once, twice, or not at all:
+fingerprint stability against run-to-run noise, fingerprint separation between
+distinct bugs, dedup producing a comment rather than a second issue, the create
+payload's team/labels/marker/fingerprint line, backend selection including the
+no-credentials failure, and the workflow actually invoking the script. The API
+layer is injected (`Transport`), so no test touches the network.

--- a/docs/spec/src/09-unchecked-code/01-syntax.md
+++ b/docs/spec/src/09-unchecked-code/01-syntax.md
@@ -97,11 +97,14 @@ struct Node { next: ptr const Node, value: i32 }
 
 {{ rule(id="9.1:12", cat="legality-rule") }}
 
-A raw-pointer intrinsic — `@raw`, `@raw_mut`, `@ptr_read`, `@ptr_write`,
-`@ptr_offset`, `@ptr_to_int`, or `@int_to_ptr` — is an unchecked operation and
-**MUST** appear within a `checked` block. Using one outside a `checked` block is
-a compile error. (Defining a `ptr const T` / `ptr mut T` value's *type* is
-always legal; only the pointer *operations* require a `checked` block.)
+A raw-pointer intrinsic — `@raw`, `@raw_mut`, `@field_ptr`, `@ptr_read`,
+`@ptr_write`, `@ptr_read_unaligned`, `@ptr_write_unaligned`, `@ptr_offset`,
+`@ptr_to_int`, or `@int_to_ptr` — is an unchecked operation and **MUST** appear
+within a `checked` block. Using one outside a `checked` block is a compile
+error. (Defining a `ptr const T` / `ptr mut T` value's *type* is always legal;
+only the pointer *operations* require a `checked` block.) The same requirement
+applies to the allocation family (9.2:13) and the raw-byte intrinsics
+(9.2:14e, 9.2:14h, 9.2:14l).
 
 {{ rule(id="9.1:13", cat="example") }}
 

--- a/docs/spec/src/09-unchecked-code/02-intrinsics.md
+++ b/docs/spec/src/09-unchecked-code/02-intrinsics.md
@@ -47,8 +47,9 @@ fn main() -> i32 {
     let code: u64 = 0;
     checked {
         // A syscall buffer must be a contiguous byte image; allocate it on the
-        // heap (@alloc storage is the compact image) rather than an @raw of a
-        // frame-resident byte array, whose storage is slot-shaped (§3.6, ADR-0040).
+        // heap (@alloc storage is the compact image, 9.2:10) rather than an @raw
+        // of a frame-resident byte array, whose storage is slot-shaped under the
+        // current implementation (ADR-0052).
         let msg: ptr mut u8 = @alloc(3, 1); // "HI\n"
         @ptr_write(msg, 72);
         @ptr_write(@ptr_offset(msg, 1), 73);
@@ -66,6 +67,69 @@ fn main() -> i32 {
 }
 ```
 
+## Pointer Access Intrinsics
+
+{{ rule(id="9.2:6a", cat="normative") }}
+
+The `@raw`, `@raw_mut`, `@ptr_read`, `@ptr_write`, `@ptr_to_int`, and
+`@int_to_ptr` intrinsics are the pointee-typed access surface over raw
+pointers. Like the other intrinsics of this section they may only appear
+inside a `checked` block (§9.1, 9.1:12). `@raw(place)` evaluates to a
+`ptr const T` and `@raw_mut(place)` to a `ptr mut T` addressing that place's
+storage, where `T` is the type of the place.
+
+{{ rule(id="9.2:6b", cat="dynamic-semantics") }}
+
+`@ptr_read(p)` reads the value stored at `address_of(p)` and
+`@ptr_write(p, value)` stores one there, where the value's type `T` is the
+pointee type of `p`. Each transfers exactly `@size_of(T)` **physical bytes** —
+the width the implementation has chosen for `T` (§3.6, 3.6:8), never a
+fixed-width machine slot — so at `T = u8` the access is exactly one byte wide
+and at `T = i32` exactly four. A write therefore leaves every byte outside
+`[address_of(p), address_of(p) + @size_of(T))` unchanged. The
+address **MUST** satisfy `@align_of(T)`; using this pair on an underaligned
+address is undefined behavior (§9.1, ADR-0028), for which `@ptr_read_unaligned`
+and `@ptr_write_unaligned` (9.2:14k) are the well-defined form.
+
+{{ rule(id="9.2:6c", cat="dynamic-semantics") }}
+
+`@ptr_to_int(p)` evaluates to the address `p` holds as a `u64`, and
+`@int_to_ptr(a)` evaluates to the pointer whose address is the `u64` `a`, its
+pointee type taken from the context the result is used in. The two round-trip:
+`@int_to_ptr(@ptr_to_int(p))` addresses the same storage as `p`, which is also
+how a `ptr mut u8` block from the allocation family (9.2:10) is viewed as a
+`ptr mut T`. They are the only conversions between an address and a pointer,
+and are kept apart from access and arithmetic so the common path never
+silently launders an address into a pointer (ADR-0059). A zero address is the
+null pointer: `@int_to_ptr` applied to a `u64` operand of value zero produces
+null, and `@ptr_to_int(p) == 0` is the null test.
+
+{{ rule(id="9.2:6d", cat="legality-rule") }}
+
+`@ptr_read` accepts a `ptr const T` or a `ptr mut T` and evaluates to `T`;
+`@ptr_write` requires a `ptr mut T` and a value of exactly the pointee type
+`T`, and evaluates to `()`. `@ptr_to_int` accepts a pointer of any pointee
+type and mutability and evaluates to `u64`. `@int_to_ptr` requires an operand
+of exactly `u64` — an untyped integer literal is not accepted, so the null
+idiom is written over a `u64` binding — and evaluates to a `ptr mut T` whose
+pointee type is inferred from context.
+
+{{ rule(id="9.2:6e", cat="example") }}
+
+```rue
+fn main() -> i32 {
+    let mut x: i32 = 10;
+    let zero: u64 = 0;
+    checked {
+        let p: ptr mut i32 = @raw_mut(x);
+        @ptr_write(p, 99);                        // writes @size_of(i32) == 4 bytes
+        let back: ptr mut i32 = @int_to_ptr(@ptr_to_int(p));
+        let null: ptr mut u8 = @int_to_ptr(zero); // the null-pointer idiom
+        if @ptr_to_int(null) == 0 { @ptr_read(back) } else { 0 }
+    }
+}
+```
+
 ## Pointer Arithmetic Intrinsic
 
 {{ rule(id="9.2:7", cat="dynamic-semantics") }}
@@ -78,8 +142,12 @@ offset and is **uniform for every pointer origin** — a pointer into a local
 array, a heap allocation, a memory-mapped region, or an address produced by
 `@int_to_ptr` all advance identically. Because array elements are laid out
 ascending (§3.5), advancing a pointer to element `i` by `1` yields a pointer to
-element `i+1`, so `@ptr_offset` and array indexing agree. Offsetting outside the
-bounds of the pointed-to allocation is undefined behavior (see ADR-0028).
+element `i+1`, so `@ptr_offset` and array indexing agree. The scale is the
+pointee's physical size, so at `T = u8` — where `@size_of(u8)` is `1` — the
+stride is exactly one byte and `@ptr_offset` is itself the byte-granular walk;
+Rue therefore has no separate byte-granular offset intrinsic (ADR-0059).
+Offsetting outside the bounds of the pointed-to allocation is undefined
+behavior (see ADR-0028).
 
 {{ rule(id="9.2:8", cat="example") }}
 
@@ -87,7 +155,8 @@ bounds of the pointed-to allocation is undefined behavior (see ADR-0028).
 fn main() -> i32 {
     // A slot-identical element type (i64: one eight-byte slot per element) so a
     // raw pointer into the frame-resident array is supported; a non-slot-identical
-    // frame array (e.g. [i32; 3]) is refused under the compact layout (§3.6, M2).
+    // frame array (e.g. [i32; 3], which packs to four-byte strides while the frame
+    // stores eight-byte slots) is refused by the current implementation (ADR-0052).
     let arr: [i64; 3] = [10, 20, 30];
     let v: i64 = checked {
         let base: ptr const i64 = @raw(arr[0]);
@@ -108,7 +177,9 @@ may only appear inside a `checked` block (§9.1). They form **one byte-oriented
 allocation family**: every size is a count of physical bytes, every allocation
 states an explicit alignment, and every pointer is `ptr mut u8`. Allocating
 storage for values of a type `T` is ordinary source arithmetic over the
-reflection intrinsics — `@alloc(count * @size_of(T), @align_of(T))` — so the
+reflection intrinsics — `@alloc(count * @intCast(@size_of(T)), @intCast(@align_of(T)))`,
+the `@intCast` being what carries `@size_of`/`@align_of`'s `i32` result
+(4.13:14, 4.13:20) to the `u64` operands this family requires — so the
 language has no separate element-counted allocator. They are the primitives on
 which safe, owned collections (for example a source-level `ArrayBuf`) are built:
 the unsafety is confined to the collection's internals behind a checked API.
@@ -121,8 +192,10 @@ block. `@alloc_zeroed(size, align)` is identical except that every byte of the
 returned block reads as zero. On allocation failure both return null; the caller
 is responsible for checking. `@alloc(0, align)` and `@alloc_zeroed(0, align)`
 return null. The returned pointer is suitable for the byte intrinsics and, once
-converted to a `ptr mut T` addressing a correctly aligned offset, for
-`@ptr_offset`/`@ptr_read`/`@ptr_write` over the `T` values the block can hold.
+converted to a `ptr mut T` (9.2:6c) addressing an offset that satisfies
+`@align_of(T)`, for `@ptr_offset`/`@ptr_read`/`@ptr_write` over the `T` values
+the block can hold; `@ptr_read_unaligned`/`@ptr_write_unaligned` (9.2:14k) reach
+a `T` at an offset that does not satisfy `@align_of(T)`.
 
 {{ rule(id="9.2:11", cat="dynamic-semantics") }}
 
@@ -206,8 +279,13 @@ fn main() -> i32 {
 The `@byte_read`, `@byte_write`, `@byte_copy`, `@byte_move`, `@byte_set`,
 `@ptr_read_unaligned`, and `@ptr_write_unaligned` intrinsics provide raw access
 to packed physical bytes and to potentially unaligned typed scalars. They may
-only appear inside a `checked` block. Every count and offset they take is a
-number of physical bytes; none is multiplied by a pointee width.
+only appear inside a `checked` block. In the five byte-granular intrinsics every
+pointer is a `u8` pointer and every count and offset is a number of physical
+bytes, scaled by nothing: no operand of this family is multiplied by a pointee
+width. The two `_unaligned` intrinsics are instead pointee-typed, like the
+aligned pair of 9.2:6b — they take no count or offset and move exactly
+`@size_of(T)` bytes — and differ from it only in dropping the alignment
+obligation (9.2:14k).
 
 {{ rule(id="9.2:14d", cat="dynamic-semantics") }}
 
@@ -215,13 +293,20 @@ number of physical bytes; none is multiplied by a pointee width.
 `address_of(p) + offset`; `p` may be `ptr const u8` or `ptr mut u8` and `offset`
 has type `u64`. `@byte_write(p, offset, value)` writes exactly the low eight
 bits represented by its `u8` value at that address; `p` must be `ptr mut u8`.
-Offsets are not multiplied by Rue's typed-pointer slot size.
+The `offset` is a plain byte displacement, added to the address unscaled. Since
+`@size_of(u8)` is `1`, that is the same address `@ptr_offset(p, offset)` names
+(9.2:7), so `@byte_read(p, offset)` and `@ptr_read(@ptr_offset(p, offset))`
+access the same single byte, as do `@byte_write` and the corresponding
+`@ptr_write`.
 
 {{ rule(id="9.2:14e", cat="legality-rule") }}
 
-Every raw-byte intrinsic requires an enclosing `checked` block. Write pointers
-must be `ptr mut u8`; a byte read also accepts `ptr const u8`. Size and offset
-operands are exactly `u64`, and a byte-write value is exactly `u8`.
+`@byte_read` and `@byte_write` each require an enclosing `checked` block.
+`@byte_write` requires a `ptr mut u8`; `@byte_read` accepts `ptr const u8` or
+`ptr mut u8`. Their offset operand is exactly `u64` and a byte-write value is
+exactly `u8`. `@byte_read` evaluates to `u8` and `@byte_write` to `()`. The
+legality of the bulk intrinsics is 9.2:14h and that of the `_unaligned` pair is
+9.2:14l.
 
 {{ rule(id="9.2:14f", cat="example") }}
 

--- a/docs/spec/src/appendices/B-undefined-behavior.md
+++ b/docs/spec/src/appendices/B-undefined-behavior.md
@@ -164,15 +164,19 @@ defines it.
 
 | Undefined operation | Normative rule |
 |---------------------|----------------|
-| Reading (`@ptr_read`) or writing (`@ptr_write`) through a pointer that does not address valid, live storage for the pointee type — including a null pointer, a misaligned address, or memory that was never allocated. | §9.1, ADR-0028 |
+| Reading (`@ptr_read`) or writing (`@ptr_write`) through a pointer that does not address valid, live storage for the pointee type — including a null pointer, a misaligned address, or memory that was never allocated. | §9.2 (9.2:6b), §9.1, ADR-0028 |
+| Reading (`@ptr_read_unaligned`) or writing (`@ptr_write_unaligned`) through a pointer that does not address valid, live storage for the pointee type. Only the alignment obligation is lifted for this pair; every other requirement of the aligned pair still applies. | §9.2 (9.2:14k) |
 | Offsetting a pointer (`@ptr_offset`) outside the bounds of the allocation it addresses (a one-past-the-end pointer may be formed but not dereferenced). | §9.2 (9.2:7) |
-| Using a pointer after the block it addressed has been released with `@free` (use-after-free), or freeing a block that was not returned by `@alloc`/`@realloc`, or freeing one twice. | §9.2 (9.2:11) |
-| Accessing storage through a pointer produced by `@int_to_ptr` from an address that does not name valid, correctly typed, correctly aligned storage. | §9.2, ADR-0028 |
-| Using a pointer obtained from `@raw`/`@raw_mut` after the value it borrowed has been moved, dropped, or otherwise gone out of scope (a dangling pointer). | ADR-0028 |
+| Using a pointer after the block it addressed has been released with `@free` (use-after-free), or freeing a block that was not returned by `@alloc`/`@alloc_zeroed`/`@realloc`, or freeing one twice. | §9.2 (9.2:11) |
+| Accessing storage through a pointer produced by `@int_to_ptr` from an address that does not name valid, correctly typed, correctly aligned storage. | §9.2 (9.2:6c), ADR-0028 |
+| Using a pointer obtained from `@raw`/`@raw_mut`/`@field_ptr` after the value it borrowed has been moved, dropped, or otherwise gone out of scope (a dangling pointer). | ADR-0028 |
 | Mutating storage through a `ptr mut T` while another live pointer aliases the same storage in a way the program's reasoning assumes cannot happen (aliasing violation). | ADR-0028 |
-| Accessing storage through a pointer that does not satisfy the pointee type's alignment requirement. | ADR-0028 |
+| Accessing storage through a pointer that does not satisfy the pointee type's alignment requirement, other than through `@ptr_read_unaligned`/`@ptr_write_unaligned`, for which an underaligned address is well defined. | §9.2 (9.2:6b, 9.2:14k), ADR-0028 |
 | Reading or writing with `@byte_read`/`@byte_write` when `address_of(p) + offset` is not a live byte within the referenced storage, including null, out-of-bounds, use-after-free, and overflowed-address access. | §9.2 (9.2:14d) |
+| Copying with `@byte_copy` between regions that overlap: `[dst, dst + size)` and `[src, src + size)` must be disjoint. `@byte_move` is the well-defined form for overlapping regions. | §9.2 (9.2:14g) |
+| Reading or writing outside live storage with `@byte_copy`, `@byte_move`, or `@byte_set` — that is, when `size` reaches past the end of the block either operand addresses. A `size` of zero accesses no memory and is always defined. | §9.2 (9.2:14g) |
 | Passing an incorrect size or alignment, a pointer not returned by the allocation family, or an already-freed pointer to `@free`/`@realloc`/`@resize`. | §9.2 (9.2:11–13) |
+| Passing an `align` that is zero or not a power of two to the allocation family when the value is not a compile-time constant (a constant one is rejected at compile time instead). | §9.2 (9.2:13a) |
 
 {{ rule(id="B.3:3", cat="informative") }}
 

--- a/scripts/fuzz-report-failure.py
+++ b/scripts/fuzz-report-failure.py
@@ -1,0 +1,896 @@
+#!/usr/bin/env python3
+"""File nightly fuzz-CI failures as Linear issues (GitHub Issues is the fallback).
+
+Rue tracks work in Linear, in the **Rue** team (docs/process/issue-tracking.md).
+Until RUE-802 the nightly fuzz workflow was the one producer of work items that
+did not: it opened GitHub Issues from an inline `actions/github-script` block,
+so an automatically-found crash landed in a tracker nobody plans from. Worse,
+its dedup was "one open issue carrying the `fuzz-crash` label at a time" — every
+distinct crash found while that issue stayed open became a comment on it, so two
+unrelated miscompiles were indistinguishable from the same one recurring.
+
+This script replaces that with per-crash tracking:
+
+* Every reproducer written under the crash directory is read back, and a stable
+  **fingerprint** is computed from its target plus its *normalized* crash
+  signature (see `normalize_signature`) — addresses, temp paths, source line
+  numbers, and generator seeds are erased, so the same bug fingerprints
+  identically from one night to the next, while two different bugs do not
+  collide.
+* Before filing, open issues in the Rue team are searched for that fingerprint
+  (it is written into the issue description as a `Fuzz-Fingerprint:` line).
+  A hit gets a comment recording the new occurrence; a miss files a new issue.
+* New issues carry the `Bug` and `found-by:autonomous` labels plus the
+  `[fuzz-crash]` title marker (Linear has no `fuzz-crash` label; the marker is
+  what makes the class searchable, and `FUZZ_MARKER` is the single source of
+  truth for it).
+
+Transport is injected (`Transport`), so `scripts/test-fuzz-report-failure.py`
+exercises fingerprinting, dedup, and payload construction against a mock without
+network access or credentials, and `--dry-run` runs the real client code end to
+end against a synthesizing transport.
+
+Backend selection is deliberate and loud, because the failure mode being
+defended against is *silence*: a night whose crashes are found and then dropped.
+`LINEAR_API_KEY` present selects Linear. Absent, the script falls back to the
+GitHub Issues path (clearly marked as a fallback in the log and in the filed
+issue) so a missing secret degrades tracker quality instead of losing the
+report. With neither credential available the script exits non-zero rather than
+returning success having reported nothing.
+
+Usage:
+    scripts/fuzz-report-failure.py --run-url URL [--failed-targets a,b] \\
+        [--crash-dir DIR] [--backend auto|linear|github] [--dry-run]
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import re
+import sys
+import urllib.error
+import urllib.request
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from pathlib import Path
+
+LINEAR_API_URL = "https://api.linear.app/graphql"
+GITHUB_API_URL = "https://api.github.com"
+
+#: Linear team the Rue project plans from. Issues are `RUE-NN`.
+LINEAR_TEAM_KEY = "RUE"
+
+#: Labels applied to every issue this script files. `Bug` and
+#: `found-by:autonomous` both exist in the Rue team; a label that cannot be
+#: resolved is reported and skipped rather than failing the filing, because
+#: losing the crash report is strictly worse than losing a label.
+ISSUE_LABELS = ("Bug", "found-by:autonomous")
+
+#: Title marker identifying the fuzz-crash class. Linear has no `fuzz-crash`
+#: label, so this string is how a human (or a later query) finds every issue
+#: this script has filed. Keep it in the title, not just the body: Linear's
+#: issue lists show titles.
+FUZZ_MARKER = "[fuzz-crash]"
+
+#: Line written into every issue description, and the needle the dedup search
+#: looks for. Changing its spelling orphans every previously-filed issue, so it
+#: is a constant rather than an inline format string.
+FINGERPRINT_FIELD = "Fuzz-Fingerprint"
+
+#: Cap on quoted reproducer text in an issue body. Full inputs live in the
+#: workflow's uploaded artifact; the issue only needs enough to triage.
+MAX_QUOTED_INPUT = 1200
+
+
+# --------------------------------------------------------------------------
+# Crash collection and fingerprinting
+# --------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class Crash:
+    """One deduplicated crash, as recorded by a fuzz harness.
+
+    `signature` is the harness's raw signature text; `fingerprint` is derived
+    from its normalized form, and is what dedup keys on.
+    """
+
+    target: str
+    signature: str
+    outcome: str
+    repro: str
+    detail: str = ""
+
+    @property
+    def fingerprint(self) -> str:
+        return fingerprint(self.target, self.signature)
+
+
+#: How many trailing components of an absolute path to keep. Two is not enough:
+#: `crates/rue-sema/src/check.rs` and `crates/rue-codegen/src/check.rs` both end
+#: in `src/check.rs`, and folding two crates' panics into one fingerprint is
+#: exactly the dedup failure this module exists to avoid.
+_PATH_TAIL_COMPONENTS = 3
+
+
+def _path_tail(match: re.Match[str]) -> str:
+    """Drop an absolute path's leading directories, keeping its informative tail."""
+    components = match.group(0).strip("/").split("/")
+    return "/".join(components[-_PATH_TAIL_COMPONENTS:])
+
+
+#: Substitutions applied, in order, to make a crash signature stable across
+#: runs. Each erases something that varies between two observations of the SAME
+#: bug; nothing here may erase something that distinguishes two different bugs.
+_NORMALIZERS: tuple[tuple[re.Pattern[str], str | Callable[[re.Match[str]], str]], ...] = (
+    # Heap/stack addresses and pointer-shaped hex.
+    (re.compile(r"0x[0-9a-f]+"), "0xADDR"),
+    # Absolute paths — the runner's checkout root and /tmp scratch directories
+    # both vary per run. The lookbehind keeps this from firing mid-token, so a
+    # relative path (already stable) is left exactly as the harness wrote it.
+    (re.compile(r"(?<![\w.+-])(?:/[\w.+-]+)+"), _path_tail),
+    # `file.rs:120:9` — a line number moves with any unrelated edit.
+    (re.compile(r"\.rs:\d+(?::\d+)?"), ".rs:LINE"),
+    # Generator seeds: a differential finding is the same bug at seed 4 and
+    # seed 4000.
+    (re.compile(r"\bseed[ =]+\d+"), "seed N"),
+    # Long digit runs (byte counts, offsets, sizes). Short runs survive, so
+    # `signal 6` and `signal 11` stay distinct.
+    (re.compile(r"\b\d{4,}\b"), "N"),
+    # Collapse whitespace last, after the patterns that may span it.
+    (re.compile(r"\s+"), " "),
+)
+
+
+def normalize_signature(signature: str) -> str:
+    """Erase run-to-run noise from a crash signature.
+
+    The result is the fingerprint input, so this function decides what "the
+    same crash" means. Two observations of one bug must normalize identically;
+    two distinct bugs must not.
+    """
+    text = signature.strip().lower()
+    for pattern, replacement in _NORMALIZERS:
+        text = pattern.sub(replacement, text)
+    return text.strip()[:300]
+
+
+def fingerprint(target: str, signature: str) -> str:
+    """Stable per-crash identity: the dedup key, and the issue's search needle.
+
+    Truncated to 16 hex chars — long enough that a collision across the handful
+    of crashes a night produces is not a practical concern, short enough to read
+    in a title.
+    """
+    digest = hashlib.sha256(
+        f"{target}\n{normalize_signature(signature)}".encode()
+    ).hexdigest()
+    return digest[:16]
+
+
+def parse_meta(text: str) -> dict[str, str]:
+    """Parse a `.txt.meta` sibling written by `rue-fuzz`'s `write_reproducer`.
+
+    The format is line-oriented `key: value` (the harness flattens multi-line
+    panic messages precisely so this stays true).
+    """
+    fields: dict[str, str] = {}
+    for line in text.splitlines():
+        key, separator, value = line.partition(":")
+        if separator and key.strip():
+            fields.setdefault(key.strip(), value.strip())
+    return fields
+
+
+def parse_oracle_diff_repro(text: str) -> tuple[str, str]:
+    """Extract `(signature, detail)` from a `rue-oracle-diff` repro file.
+
+    Those repros are Rue source with a leading `// key: value` comment block
+    rather than a `.meta` sibling; `reason` is the signature-bearing field.
+    """
+    reason = ""
+    detail_lines: list[str] = []
+    for line in text.splitlines():
+        if not line.startswith("//"):
+            break
+        body = line[2:].strip()
+        key, separator, value = body.partition(":")
+        if separator and key.strip() == "reason":
+            reason = value.strip()
+        detail_lines.append(body)
+    return reason or "oracle/compiled disagreement", "\n".join(detail_lines)
+
+
+def collect_crashes(crash_dir: Path) -> list[Crash]:
+    """Read every reproducer under `crash_dir`, deduplicated by fingerprint.
+
+    Both producers are handled: `rue-fuzz` (`crash-<target>-...txt` plus a
+    `.txt.meta` sibling) and `rue-oracle-diff` (`oracle-diff-seed-N.rue`).
+    A reproducer whose metadata is missing still reports — with a degraded
+    signature — because an unexplained crash file is still a crash.
+    """
+    crashes: dict[str, Crash] = {}
+    if not crash_dir.is_dir():
+        return []
+
+    for path in sorted(crash_dir.iterdir()):
+        if path.name.endswith(".meta") or not path.is_file():
+            continue
+
+        if path.name.startswith("oracle-diff-seed-"):
+            text = _read_text(path)
+            signature, detail = parse_oracle_diff_repro(text)
+            crash = Crash(
+                target="differential",
+                signature=signature,
+                outcome=signature,
+                repro=path.name,
+                detail=detail,
+            )
+        elif path.name.startswith("crash-"):
+            meta = parse_meta(_read_text(Path(f"{path}.meta")))
+            target = meta.get("target") or _target_from_filename(path.name)
+            signature = meta.get("signature", "")
+            outcome = meta.get("outcome", "")
+            if not signature:
+                # No `.meta`: the filename's signature hash is the only stable
+                # identity left, so fingerprint from that rather than lumping
+                # every metadata-less crash into one bucket.
+                signature = f"unrecorded signature (file {path.name})"
+            crash = Crash(
+                target=target,
+                signature=signature,
+                outcome=outcome or signature,
+                repro=path.name,
+                detail=_read_text(path)[:MAX_QUOTED_INPUT],
+            )
+        else:
+            continue
+
+        crashes.setdefault(crash.fingerprint, crash)
+
+    return list(crashes.values())
+
+
+def _target_from_filename(name: str) -> str:
+    """`crash-<target>-<sighash>-<inputhash>.txt` -> `<target>`."""
+    match = re.match(r"crash-(.+)-[0-9a-f]{8}-[0-9a-f]{16}\.txt$", name)
+    return match.group(1) if match else "unknown"
+
+
+def _read_text(path: Path) -> str:
+    try:
+        return path.read_text(errors="replace")
+    except OSError:
+        return ""
+
+
+def crashes_from_failed_targets(targets: list[str]) -> list[Crash]:
+    """Synthesize reports for a run that failed without leaving reproducers.
+
+    A step can fail for reasons that never reach `write_reproducer` (a wedged
+    build, a timeout killing the harness). Reporting nothing in that case is the
+    exact silence RUE-802 is about, so each failed target gets a low-detail
+    report whose fingerprint is stable for that target.
+    """
+    if not targets:
+        targets = ["(job-level failure)"]
+    return [
+        Crash(
+            target=target,
+            signature="fuzz step failed without a saved reproducer",
+            outcome="fuzz step failed without a saved reproducer",
+            repro="(none)",
+        )
+        for target in targets
+    ]
+
+
+# --------------------------------------------------------------------------
+# Issue payloads
+# --------------------------------------------------------------------------
+
+
+def issue_title(crash: Crash) -> str:
+    """`[fuzz-crash] <target>: <outcome> (<fingerprint>)`.
+
+    The marker leads so the class is scannable; the fingerprint trails so a
+    human comparing two issues can tell recurrence from a new bug at a glance.
+    """
+    summary = normalize_signature(crash.outcome or crash.signature)[:80] or "crash"
+    return f"{FUZZ_MARKER} {crash.target}: {summary} ({crash.fingerprint})"
+
+
+def issue_body(crash: Crash, run_url: str, fallback_note: str = "") -> str:
+    """Issue description: dedup key first, then everything triage needs."""
+    sections = [
+        f"{FINGERPRINT_FIELD}: `{crash.fingerprint}`",
+        "",
+        "The nightly fuzz workflow found a crash.",
+        "",
+        f"- **Target:** `{crash.target}`",
+        f"- **Crash signature:** `{crash.signature}`",
+        f"- **Outcome:** {crash.outcome}",
+        f"- **Reproducer artifact:** `{crash.repro}`",
+        f"- **Run:** {run_url}",
+    ]
+    if fallback_note:
+        sections += ["", fallback_note]
+    sections += [
+        "",
+        "### Reproducing",
+        "",
+        "1. Download the `fuzz-crashes` artifact from the run above.",
+        "2. For a `rue-fuzz` target, feed the saved input back to it:",
+        "   `./buck2 run //crates/rue-fuzz:rue-fuzz -- <target> <dir-with-the-file>`",
+        "   For a `differential` finding, rerun the recorded seed:",
+        "   `./buck2 run //crates/rue-oracle-diff:rue-oracle-diff -- fuzz --start <seed> --seeds 1`",
+        "3. Fix the bug and add a regression test (CLI case or spec case).",
+        "",
+        "Occurrences of this same fingerprint are added as comments below rather "
+        "than filed as new issues.",
+    ]
+    if crash.detail:
+        sections += [
+            "",
+            "<details><summary>Reproducer detail</summary>",
+            "",
+            "```",
+            crash.detail[:MAX_QUOTED_INPUT],
+            "```",
+            "",
+            "</details>",
+        ]
+    return "\n".join(sections)
+
+
+def recurrence_comment(crash: Crash, run_url: str) -> str:
+    return (
+        f"Seen again in a later nightly fuzz run.\n\n"
+        f"- **Run:** {run_url}\n"
+        f"- **Target:** `{crash.target}`\n"
+        f"- **Reproducer artifact:** `{crash.repro}`\n"
+        f"- **{FINGERPRINT_FIELD}:** `{crash.fingerprint}`\n"
+    )
+
+
+# --------------------------------------------------------------------------
+# Transport
+# --------------------------------------------------------------------------
+
+
+class TransportError(RuntimeError):
+    """A request could not be completed. Always surfaced; never swallowed."""
+
+
+class Transport:
+    """Minimal injectable HTTP seam.
+
+    Tests substitute a mock; `--dry-run` substitutes a synthesizer. Keeping the
+    seam this thin means the client code under test is the same code CI runs.
+    """
+
+    def request(
+        self, method: str, url: str, headers: dict[str, str], payload: dict | None
+    ) -> dict | list:
+        """Send `payload` as JSON and return the decoded response.
+
+        The return type is `dict | list` because GitHub's REST list endpoints
+        answer with a bare array; callers that expect an object must say so.
+        """
+        raise NotImplementedError
+
+
+class UrllibTransport(Transport):
+    """The real transport: stdlib only, so the script has no dependencies."""
+
+    def __init__(self, timeout: float = 30.0) -> None:
+        self.timeout = timeout
+
+    def request(
+        self, method: str, url: str, headers: dict[str, str], payload: dict | None
+    ) -> dict | list:
+        data = json.dumps(payload).encode() if payload is not None else None
+        request = urllib.request.Request(url, data=data, method=method)
+        for key, value in headers.items():
+            request.add_header(key, value)
+        try:
+            with urllib.request.urlopen(request, timeout=self.timeout) as response:
+                body = response.read().decode(errors="replace")
+        except urllib.error.HTTPError as error:
+            detail = error.read().decode(errors="replace")[:500]
+            raise TransportError(f"{method} {url} -> HTTP {error.code}: {detail}")
+        except urllib.error.URLError as error:
+            raise TransportError(f"{method} {url} -> {error.reason}")
+        if not body:
+            return {}
+        try:
+            return json.loads(body)
+        except json.JSONDecodeError:
+            raise TransportError(f"{method} {url} -> non-JSON response: {body[:200]}")
+
+
+class DryRunTransport(Transport):
+    """Print requests and synthesize plausible responses.
+
+    This exists so `--dry-run` exercises the *real* client methods — query
+    construction, label resolution, dedup branching, payload assembly — instead
+    of a separate "what I would do" printer that can drift from them. Responses
+    are shaped like an empty tracker, so a dry run always takes the create path.
+    """
+
+    def __init__(self, stream=None) -> None:
+        self.stream = stream or sys.stdout
+        self.requests: list[tuple[str, str, dict | None]] = []
+
+    def request(
+        self, method: str, url: str, headers: dict[str, str], payload: dict | None
+    ) -> dict | list:
+        self.requests.append((method, url, payload))
+        operation = (payload or {}).get("operationName", "")
+        print(f"[dry-run] {method} {url} {operation}".rstrip(), file=self.stream)
+        if payload is not None:
+            print(
+                json.dumps(payload, indent=2, sort_keys=True)[:2000], file=self.stream
+            )
+
+        if operation == "FuzzTeamAndLabels":
+            return {
+                "data": {
+                    "teams": {"nodes": [{"id": "team-dry-run", "key": LINEAR_TEAM_KEY}]},
+                    "issueLabels": {
+                        "nodes": [
+                            {"id": f"label-{name}", "name": name}
+                            for name in ISSUE_LABELS
+                        ]
+                    },
+                }
+            }
+        if operation == "FuzzDedup":
+            return {"data": {"issues": {"nodes": []}}}
+        if operation == "FuzzIssueCreate":
+            return {
+                "data": {
+                    "issueCreate": {
+                        "success": True,
+                        "issue": {
+                            "id": "issue-dry-run",
+                            "identifier": "RUE-DRY",
+                            "url": "https://linear.app/dry-run",
+                        },
+                    }
+                }
+            }
+        if operation == "FuzzCommentCreate":
+            return {"data": {"commentCreate": {"success": True}}}
+
+        # GitHub fallback (REST, no operationName).
+        if method == "GET":
+            return {"items": [], "nodes": []} if "search" in url else {}
+        return {"html_url": "https://github.com/dry-run/issues/0", "number": 0}
+
+
+# --------------------------------------------------------------------------
+# Trackers
+# --------------------------------------------------------------------------
+
+
+@dataclass
+class FiledIssue:
+    """What happened to one crash. `created` False means it was a recurrence."""
+
+    fingerprint: str
+    created: bool
+    reference: str
+
+
+class Tracker:
+    """Backend-agnostic issue filing, so `report` has one code path."""
+
+    name = "tracker"
+
+    def find_open(self, fingerprint: str) -> str | None:
+        """Return an opaque handle to an open issue carrying `fingerprint`."""
+        raise NotImplementedError
+
+    def create(self, crash: Crash, run_url: str) -> str:
+        raise NotImplementedError
+
+    def comment(self, handle: str, crash: Crash, run_url: str) -> None:
+        raise NotImplementedError
+
+
+class LinearTracker(Tracker):
+    """Files into the Rue team via Linear's GraphQL API.
+
+    Team id and label ids are resolved once and cached: a night with four
+    distinct crashes should not re-resolve them four times.
+    """
+
+    name = "Linear"
+
+    def __init__(
+        self, transport: Transport, api_key: str, team_key: str = LINEAR_TEAM_KEY
+    ) -> None:
+        self.transport = transport
+        self.api_key = api_key
+        self.team_key = team_key
+        self._team_id: str | None = None
+        self._label_ids: list[str] = []
+
+    def _headers(self) -> dict[str, str]:
+        # Personal API keys are sent raw; OAuth access tokens need `Bearer`.
+        # Sending a personal key as `Bearer` is rejected, so this is not a
+        # cosmetic distinction.
+        authorization = (
+            f"Bearer {self.api_key}"
+            if self.api_key.startswith("lin_oauth")
+            else self.api_key
+        )
+        return {
+            "Authorization": authorization,
+            "Content-Type": "application/json",
+        }
+
+    def _graphql(self, operation: str, query: str, variables: dict) -> dict:
+        response = self.transport.request(
+            "POST",
+            LINEAR_API_URL,
+            self._headers(),
+            {"operationName": operation, "query": query, "variables": variables},
+        )
+        if not isinstance(response, dict):
+            raise TransportError(f"Linear {operation} returned a non-object response")
+        if response.get("errors"):
+            raise TransportError(f"Linear {operation} failed: {response['errors']}")
+        data = response.get("data")
+        if data is None:
+            raise TransportError(f"Linear {operation} returned no data: {response}")
+        return data
+
+    def _resolve_context(self) -> tuple[str, list[str]]:
+        if self._team_id is not None:
+            return self._team_id, self._label_ids
+
+        data = self._graphql(
+            "FuzzTeamAndLabels",
+            """
+            query FuzzTeamAndLabels($teamKey: String!) {
+              teams(filter: { key: { eq: $teamKey } }, first: 1) {
+                nodes { id key }
+              }
+              issueLabels(first: 250) { nodes { id name } }
+            }
+            """,
+            {"teamKey": self.team_key},
+        )
+        teams = data.get("teams", {}).get("nodes", [])
+        if not teams:
+            raise TransportError(f"Linear team {self.team_key!r} not found")
+        self._team_id = teams[0]["id"]
+
+        by_name = {node["name"]: node["id"] for node in data["issueLabels"]["nodes"]}
+        label_ids = []
+        for label in ISSUE_LABELS:
+            if label in by_name:
+                label_ids.append(by_name[label])
+            else:
+                # Missing label is a warning, never a filing failure: a crash
+                # report with the wrong labels still gets triaged; a crash
+                # report that was never filed does not.
+                print(
+                    f"warning: Linear label {label!r} not found; filing without it",
+                    file=sys.stderr,
+                )
+        self._label_ids = label_ids
+        return self._team_id, self._label_ids
+
+    def find_open(self, fingerprint: str) -> str | None:
+        data = self._graphql(
+            "FuzzDedup",
+            """
+            query FuzzDedup($teamKey: String!, $needle: String!) {
+              issues(
+                first: 50
+                filter: {
+                  team: { key: { eq: $teamKey } }
+                  state: { type: { nin: ["completed", "canceled"] } }
+                  description: { contains: $needle }
+                }
+              ) {
+                nodes { id identifier url title }
+              }
+            }
+            """,
+            {"teamKey": self.team_key, "needle": self._needle(fingerprint)},
+        )
+        nodes = data.get("issues", {}).get("nodes", [])
+        if not nodes:
+            return None
+        print(
+            f"dedup: {fingerprint} already tracked by "
+            f"{nodes[0].get('identifier', nodes[0]['id'])}"
+        )
+        return nodes[0]["id"]
+
+    @staticmethod
+    def _needle(fingerprint: str) -> str:
+        """Search for the labelled field, not the bare hash.
+
+        A bare 16-hex-character string can appear in unrelated issues (a commit
+        prefix, a hash in a pasted log); matching `Fuzz-Fingerprint: <hash>`
+        cannot.
+        """
+        return f"{FINGERPRINT_FIELD}: `{fingerprint}`"
+
+    def create(self, crash: Crash, run_url: str) -> str:
+        team_id, label_ids = self._resolve_context()
+        data = self._graphql(
+            "FuzzIssueCreate",
+            """
+            mutation FuzzIssueCreate($input: IssueCreateInput!) {
+              issueCreate(input: $input) {
+                success
+                issue { id identifier url }
+              }
+            }
+            """,
+            {
+                "input": {
+                    "teamId": team_id,
+                    "title": issue_title(crash),
+                    "description": issue_body(crash, run_url),
+                    "labelIds": label_ids,
+                }
+            },
+        )
+        result = data.get("issueCreate", {})
+        if not result.get("success"):
+            raise TransportError(f"Linear issueCreate did not succeed: {data}")
+        issue = result["issue"]
+        return issue.get("url") or issue.get("identifier") or issue["id"]
+
+    def comment(self, handle: str, crash: Crash, run_url: str) -> None:
+        self._graphql(
+            "FuzzCommentCreate",
+            """
+            mutation FuzzCommentCreate($input: CommentCreateInput!) {
+              commentCreate(input: $input) { success }
+            }
+            """,
+            {"input": {"issueId": handle, "body": recurrence_comment(crash, run_url)}},
+        )
+
+
+class GitHubTracker(Tracker):
+    """Fallback path: GitHub Issues, used only when `LINEAR_API_KEY` is absent.
+
+    Kept deliberately, and marked as a fallback in every issue it files, so the
+    day the secret is missing CI still records what it found. Dedup is the same
+    fingerprint search, applied to open issues carrying the `fuzz-crash` label —
+    an improvement on the pre-RUE-802 behavior, which deduplicated on the label
+    alone and so folded unrelated crashes into one issue.
+    """
+
+    name = "GitHub Issues (fallback)"
+    LABEL = "fuzz-crash"
+    FALLBACK_NOTE = (
+        "> **Filed by the GitHub fallback path.** `LINEAR_API_KEY` was not set "
+        "for this run, so this crash could not be filed in the Rue Linear team. "
+        "See docs/process/fuzz-failure-reporting.md."
+    )
+
+    def __init__(self, transport: Transport, token: str, repo: str) -> None:
+        self.transport = transport
+        self.token = token
+        self.repo = repo
+
+    def _headers(self) -> dict[str, str]:
+        return {
+            "Authorization": f"Bearer {self.token}",
+            "Accept": "application/vnd.github+json",
+            "X-GitHub-Api-Version": "2022-11-28",
+            "Content-Type": "application/json",
+        }
+
+    def find_open(self, fingerprint: str) -> str | None:
+        issues = self.transport.request(
+            "GET",
+            f"{GITHUB_API_URL}/repos/{self.repo}/issues"
+            f"?state=open&labels={self.LABEL}&per_page=100",
+            self._headers(),
+            None,
+        )
+        # The REST list endpoint returns a bare array; the transport normalizes
+        # nothing, so accept both shapes.
+        nodes = issues if isinstance(issues, list) else issues.get("items", [])
+        needle = LinearTracker._needle(fingerprint)
+        for issue in nodes:
+            if needle in (issue.get("body") or ""):
+                print(f"dedup: {fingerprint} already tracked by #{issue['number']}")
+                return str(issue["number"])
+        return None
+
+    def create(self, crash: Crash, run_url: str) -> str:
+        response = self.transport.request(
+            "POST",
+            f"{GITHUB_API_URL}/repos/{self.repo}/issues",
+            self._headers(),
+            {
+                "title": issue_title(crash),
+                "body": issue_body(crash, run_url, self.FALLBACK_NOTE),
+                "labels": [self.LABEL, "bug"],
+            },
+        )
+        if not isinstance(response, dict):
+            raise TransportError("GitHub issue creation returned a non-object response")
+        return response.get("html_url") or str(response.get("number", "?"))
+
+    def comment(self, handle: str, crash: Crash, run_url: str) -> None:
+        self.transport.request(
+            "POST",
+            f"{GITHUB_API_URL}/repos/{self.repo}/issues/{handle}/comments",
+            self._headers(),
+            {"body": recurrence_comment(crash, run_url)},
+        )
+
+
+# --------------------------------------------------------------------------
+# Driver
+# --------------------------------------------------------------------------
+
+
+@dataclass
+class Environment:
+    """The credentials and repository coordinates a run was given."""
+
+    linear_api_key: str = ""
+    github_token: str = ""
+    repo: str = ""
+
+    @classmethod
+    def from_os(cls, env: dict[str, str] | None = None) -> Environment:
+        env = os.environ if env is None else env
+        return cls(
+            linear_api_key=env.get("LINEAR_API_KEY", "").strip(),
+            github_token=env.get("GITHUB_TOKEN", "").strip(),
+            repo=env.get("GITHUB_REPOSITORY", "").strip(),
+        )
+
+
+def select_tracker(
+    environment: Environment, transport: Transport, backend: str = "auto"
+) -> Tracker:
+    """Pick the backend, preferring Linear, and explain the choice.
+
+    Raises when nothing is usable: exiting non-zero is the whole point of the
+    fallback design — CI must never report success having filed nothing.
+    """
+    if backend in ("auto", "linear") and environment.linear_api_key:
+        return LinearTracker(transport, environment.linear_api_key)
+    if backend == "linear":
+        raise TransportError("--backend linear requires LINEAR_API_KEY")
+
+    if backend in ("auto", "github") and environment.github_token and environment.repo:
+        if backend == "auto":
+            print(
+                "warning: LINEAR_API_KEY is not set; falling back to GitHub Issues. "
+                "Add the secret (docs/process/fuzz-failure-reporting.md) so fuzz "
+                "crashes land in the Rue Linear team.",
+                file=sys.stderr,
+            )
+        return GitHubTracker(transport, environment.github_token, environment.repo)
+
+    raise TransportError(
+        "no usable issue tracker: set LINEAR_API_KEY (preferred), or "
+        "GITHUB_TOKEN plus GITHUB_REPOSITORY for the fallback path"
+    )
+
+
+@dataclass
+class ReportResult:
+    backend: str
+    filed: list[FiledIssue] = field(default_factory=list)
+
+    @property
+    def created(self) -> int:
+        return sum(1 for issue in self.filed if issue.created)
+
+    @property
+    def recurrences(self) -> int:
+        return sum(1 for issue in self.filed if not issue.created)
+
+
+def report(tracker: Tracker, crashes: list[Crash], run_url: str) -> ReportResult:
+    """File or update one issue per distinct crash fingerprint."""
+    result = ReportResult(backend=tracker.name)
+    for crash in crashes:
+        handle = tracker.find_open(crash.fingerprint)
+        if handle is None:
+            reference = tracker.create(crash, run_url)
+            print(f"filed {crash.fingerprint} ({crash.target}): {reference}")
+            result.filed.append(FiledIssue(crash.fingerprint, True, reference))
+        else:
+            tracker.comment(handle, crash, run_url)
+            print(f"commented {crash.fingerprint} ({crash.target}): {handle}")
+            result.filed.append(FiledIssue(crash.fingerprint, False, handle))
+    return result
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument(
+        "--crash-dir",
+        default="crates/rue-fuzz/crashes",
+        help="directory the fuzz harnesses wrote reproducers to",
+    )
+    parser.add_argument(
+        "--failed-targets",
+        default="",
+        help="comma-separated fuzz targets whose step failed; used to report a "
+        "failure that left no reproducer behind",
+    )
+    parser.add_argument("--run-url", default="", help="URL of the CI run")
+    parser.add_argument(
+        "--backend",
+        choices=("auto", "linear", "github"),
+        default="auto",
+        help="auto (default) uses Linear when LINEAR_API_KEY is set, else GitHub",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="run the real client code against a synthesizing transport, "
+        "printing every request instead of sending it",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+
+    crashes = collect_crashes(Path(args.crash_dir))
+    if not crashes:
+        targets = [t.strip() for t in args.failed_targets.split(",") if t.strip()]
+        crashes = crashes_from_failed_targets(targets)
+        print(
+            f"no reproducers under {args.crash_dir}; reporting "
+            f"{len(crashes)} failed target(s) instead"
+        )
+    else:
+        print(f"{len(crashes)} distinct crash fingerprint(s) under {args.crash_dir}")
+
+    environment = Environment.from_os()
+    if args.dry_run:
+        transport: Transport = DryRunTransport()
+        # A dry run must exercise a real client, so synthesize whichever
+        # credential the selected backend needs.
+        if args.backend == "github":
+            environment = Environment(
+                github_token="dry-run", repo=environment.repo or "rue-lang/rue"
+            )
+        else:
+            environment = Environment(linear_api_key="dry-run")
+    else:
+        transport = UrllibTransport()
+
+    try:
+        tracker = select_tracker(environment, transport, args.backend)
+        print(f"reporting via {tracker.name}")
+        result = report(tracker, crashes, args.run_url or "(no run URL)")
+    except TransportError as error:
+        print(f"error: {error}", file=sys.stderr)
+        return 1
+
+    print(
+        f"done: {result.created} issue(s) filed, "
+        f"{result.recurrences} recurrence comment(s) via {result.backend}"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/test-fuzz-report-failure.py
+++ b/scripts/test-fuzz-report-failure.py
@@ -1,0 +1,611 @@
+#!/usr/bin/env python3
+"""Pin fuzz-failure reporting: fingerprinting, dedup, payloads, and fallback.
+
+RUE-802 moved nightly fuzz crash tracking from GitHub Issues to Linear. Nothing
+here can talk to Linear — CI has no key on a pull request, and a test that filed
+real issues would be a menace — so every case drives the real client code
+through the injected `Transport` seam with a mock. That covers exactly the parts
+that decide whether a crash is reported once, twice, or not at all:
+
+* the fingerprint is stable across run-to-run noise and distinguishes bugs;
+* a fingerprint already tracked by an open issue produces a comment, not a
+  second issue;
+* the create payload carries the team, both labels, the title marker, and the
+  fingerprint line the dedup search looks for;
+* backend selection prefers Linear, falls back to GitHub, and fails loudly with
+  no credentials at all — the "silently dropped failures" case;
+* the workflow actually invokes the script, with the secret wired in.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import os
+import re
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+SCRIPTS = Path(__file__).resolve().parent
+SCRIPT = SCRIPTS / "fuzz-report-failure.py"
+
+#: Root used for the workflow-contract cases. Buck hands the test a filegroup
+#: directory; a direct run falls back to the repository checkout.
+ROOT = Path(os.environ.get("RUE_FUZZ_REPORT_ROOT", SCRIPTS.parent))
+
+
+def _load_module():
+    """Import the hyphenated script as a module."""
+    spec = importlib.util.spec_from_file_location("fuzz_report_failure", SCRIPT)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    # Registered before execution: `dataclasses` resolves a class's module
+    # through `sys.modules`, and fails outright when it is missing.
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+fr = _load_module()
+
+
+class MockTransport(fr.Transport):
+    """Scripted stand-in for the network.
+
+    `responses` maps a GraphQL operation name (or `"<METHOD> <url-substring>"`
+    for REST) to the decoded body to return. Every request is recorded so a test
+    can assert on the payload that would have been sent.
+    """
+
+    def __init__(self, responses: dict | None = None) -> None:
+        self.responses = responses or {}
+        self.calls: list[tuple[str, str, dict | None]] = []
+
+    def request(self, method, url, headers, payload):
+        self.calls.append((method, url, payload))
+        self.headers = headers
+        operation = (payload or {}).get("operationName")
+        if operation is not None:
+            if operation not in self.responses:
+                raise AssertionError(f"unscripted GraphQL operation: {operation}")
+            return self.responses[operation]
+        for key, value in self.responses.items():
+            method_and_needle = key.split(" ", 1)
+            if len(method_and_needle) == 2:
+                want_method, needle = method_and_needle
+                if want_method == method and needle in url:
+                    return value
+        return {}
+
+    def operations(self) -> list[str]:
+        return [(payload or {}).get("operationName") for _, _, payload in self.calls]
+
+    def payload_for(self, operation: str) -> dict:
+        for _, _, payload in self.calls:
+            if (payload or {}).get("operationName") == operation:
+                return payload
+        raise AssertionError(f"{operation} was never sent")
+
+
+TEAM_AND_LABELS = {
+    "data": {
+        "teams": {"nodes": [{"id": "team-rue", "key": "RUE"}]},
+        "issueLabels": {
+            "nodes": [
+                {"id": "label-bug", "name": "Bug"},
+                {"id": "label-auto", "name": "found-by:autonomous"},
+                {"id": "label-other", "name": "chore"},
+            ]
+        },
+    }
+}
+
+NO_MATCH = {"data": {"issues": {"nodes": []}}}
+
+CREATED = {
+    "data": {
+        "issueCreate": {
+            "success": True,
+            "issue": {
+                "id": "issue-1",
+                "identifier": "RUE-900",
+                "url": "https://linear.app/rue/issue/RUE-900",
+            },
+        }
+    }
+}
+
+COMMENTED = {"data": {"commentCreate": {"success": True}}}
+
+
+def crash(**overrides) -> "fr.Crash":
+    fields = {
+        "target": "compiler",
+        "signature": "panic at crates/rue-sema/src/check.rs:120:9: unwrap on None",
+        "outcome": "panic: unwrap on None",
+        "repro": "crash-compiler-deadbeef-0123456789abcdef.txt",
+    }
+    fields.update(overrides)
+    return fr.Crash(**fields)
+
+
+class FingerprintTests(unittest.TestCase):
+    def test_run_to_run_noise_does_not_change_the_fingerprint(self):
+        """The same bug seen twice must dedup, or every night refiles it."""
+        first = (
+            "panic at /home/runner/work/rue/rue/crates/rue-sema/src/check.rs:120:9: "
+            "index out of bounds at 0x7ffd41a2b0c8 (len 65536)"
+        )
+        second = (
+            "panic at /tmp/build-9/crates/rue-sema/src/check.rs:134:11: "
+            "index out of bounds at 0x55c19ab34210 (len 131072)"
+        )
+        self.assertEqual(
+            fr.fingerprint("sema", first),
+            fr.fingerprint("sema", second),
+        )
+
+    def test_generator_seed_is_erased(self):
+        self.assertEqual(
+            fr.fingerprint("differential", "oracle/compiled disagree, seed 4"),
+            fr.fingerprint("differential", "oracle/compiled disagree, seed 918273"),
+        )
+
+    def test_same_basename_in_two_crates_is_not_one_bug(self):
+        """Path normalization must not fold `rue-sema` and `rue-codegen`."""
+        self.assertNotEqual(
+            fr.fingerprint("sema", "panic at /w/rue/crates/rue-sema/src/check.rs:1:1"),
+            fr.fingerprint(
+                "sema", "panic at /w/rue/crates/rue-codegen/src/check.rs:1:1"
+            ),
+        )
+
+    def test_relative_paths_are_left_alone(self):
+        """A relative path is already run-stable; rewriting it only loses detail."""
+        self.assertEqual(
+            fr.normalize_signature("panic at crates/rue-sema/src/check.rs:9:1"),
+            "panic at crates/rue-sema/src/check.rs:LINE",
+        )
+
+    def test_distinct_crashes_do_not_collide(self):
+        self.assertNotEqual(
+            fr.fingerprint("sema", "panic: unwrap on None"),
+            fr.fingerprint("sema", "panic: division by zero"),
+        )
+
+    def test_same_signature_on_different_targets_is_a_different_bug(self):
+        """A shared panic string in the lexer and the emitter is two bugs."""
+        self.assertNotEqual(
+            fr.fingerprint("lexer", "signal 11"),
+            fr.fingerprint("emitter", "signal 11"),
+        )
+
+    def test_short_numbers_survive_normalization(self):
+        """`signal 6` and `signal 11` must stay distinguishable."""
+        self.assertNotEqual(
+            fr.fingerprint("emitter", "killed by signal 6"),
+            fr.fingerprint("emitter", "killed by signal 11"),
+        )
+
+    def test_fingerprint_is_a_short_stable_hex_string(self):
+        value = fr.fingerprint("lexer", "panic: boom")
+        self.assertEqual(len(value), 16)
+        self.assertTrue(all(character in "0123456789abcdef" for character in value))
+
+
+class CollectionTests(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.dir = Path(self.tmp.name)
+        self.addCleanup(self.tmp.cleanup)
+
+    def write_rue_fuzz_crash(self, target, sig_hash, input_hash, signature, outcome):
+        path = self.dir / f"crash-{target}-{sig_hash}-{input_hash}.txt"
+        path.write_text("fn main() { }")
+        path.with_name(path.name + ".meta").write_text(
+            f"target: {target}\nsignature: {signature}\noutcome: {outcome}\n"
+        )
+        return path
+
+    def test_reads_rue_fuzz_reproducer_and_its_meta_sibling(self):
+        self.write_rue_fuzz_crash(
+            "sema", "aabbccdd", "0011223344556677", "panic:check.rs", "panic: boom"
+        )
+        [found] = fr.collect_crashes(self.dir)
+        self.assertEqual(found.target, "sema")
+        self.assertEqual(found.signature, "panic:check.rs")
+        self.assertEqual(found.outcome, "panic: boom")
+
+    def test_two_inputs_with_one_signature_report_once(self):
+        """Otherwise a night that hit one bug 40 times files 40 issues."""
+        self.write_rue_fuzz_crash(
+            "sema", "aabbccdd", "0011223344556677", "panic:check.rs", "panic: boom"
+        )
+        self.write_rue_fuzz_crash(
+            "sema", "aabbccdd", "ffeeddccbbaa9988", "panic:check.rs", "panic: boom"
+        )
+        self.assertEqual(len(fr.collect_crashes(self.dir)), 1)
+
+    def test_missing_meta_still_reports_a_distinct_crash(self):
+        (self.dir / "crash-lexer-12345678-0123456789abcdef.txt").write_text("\x00\x01")
+        (self.dir / "crash-lexer-87654321-fedcba9876543210.txt").write_text("\x02")
+        found = fr.collect_crashes(self.dir)
+        self.assertEqual(len(found), 2)
+        self.assertEqual({c.target for c in found}, {"lexer"})
+
+    def test_oracle_diff_repro_is_recognized(self):
+        (self.dir / "oracle-diff-seed-77.rue").write_text(
+            "// rue-oracle-diff differential miscompile (seed 77)\n"
+            "// reason: exit code differs: oracle=0 compiled=1\n"
+            "// regenerate: rue-oracle-diff fuzz --start 77 --seeds 1\n"
+            "\nfn main() {}\n"
+        )
+        [found] = fr.collect_crashes(self.dir)
+        self.assertEqual(found.target, "differential")
+        self.assertIn("exit code differs", found.signature)
+
+    def test_two_seeds_of_one_disagreement_report_once(self):
+        for seed in (77, 91):
+            (self.dir / f"oracle-diff-seed-{seed}.rue").write_text(
+                f"// rue-oracle-diff differential miscompile (seed {seed})\n"
+                "// reason: exit code differs: oracle=0 compiled=1\n"
+                "\nfn main() {}\n"
+            )
+        self.assertEqual(len(fr.collect_crashes(self.dir)), 1)
+
+    def test_missing_directory_is_not_an_error(self):
+        self.assertEqual(fr.collect_crashes(self.dir / "absent"), [])
+
+    def test_failed_targets_synthesize_reports_when_no_repro_survives(self):
+        """A wedged or timed-out step must still reach the tracker."""
+        found = fr.crashes_from_failed_targets(["lexer", "emitter_aarch64"])
+        self.assertEqual([c.target for c in found], ["lexer", "emitter_aarch64"])
+        self.assertEqual(len({c.fingerprint for c in found}), 2)
+
+    def test_job_level_failure_still_produces_one_report(self):
+        self.assertEqual(len(fr.crashes_from_failed_targets([])), 1)
+
+
+class PayloadTests(unittest.TestCase):
+    def test_title_carries_marker_target_and_fingerprint(self):
+        title = fr.issue_title(crash())
+        self.assertTrue(title.startswith(fr.FUZZ_MARKER))
+        self.assertIn("compiler", title)
+        self.assertIn(crash().fingerprint, title)
+
+    def test_body_carries_the_dedup_needle_verbatim(self):
+        """The description must contain exactly what `find_open` searches for."""
+        body = fr.issue_body(crash(), "https://ci/run/1")
+        self.assertIn(fr.LinearTracker._needle(crash().fingerprint), body)
+
+    def test_body_records_run_target_and_reproducer(self):
+        body = fr.issue_body(crash(), "https://ci/run/1")
+        self.assertIn("https://ci/run/1", body)
+        self.assertIn("crash-compiler-deadbeef-0123456789abcdef.txt", body)
+        self.assertIn("rue-fuzz", body)
+
+    def test_github_fallback_body_says_it_is_a_fallback(self):
+        body = fr.issue_body(
+            crash(), "https://ci/run/1", fr.GitHubTracker.FALLBACK_NOTE
+        )
+        self.assertIn("LINEAR_API_KEY", body)
+        self.assertIn("fallback", body.lower())
+
+
+class LinearTrackerTests(unittest.TestCase):
+    def test_new_crash_is_filed_with_team_labels_and_marker(self):
+        transport = MockTransport(
+            {
+                "FuzzDedup": NO_MATCH,
+                "FuzzTeamAndLabels": TEAM_AND_LABELS,
+                "FuzzIssueCreate": CREATED,
+            }
+        )
+        tracker = fr.LinearTracker(transport, "lin_api_test")
+        result = fr.report(tracker, [crash()], "https://ci/run/1")
+
+        self.assertEqual((result.created, result.recurrences), (1, 0))
+        payload = transport.payload_for("FuzzIssueCreate")["variables"]["input"]
+        self.assertEqual(payload["teamId"], "team-rue")
+        self.assertEqual(sorted(payload["labelIds"]), ["label-auto", "label-bug"])
+        self.assertIn(fr.FUZZ_MARKER, payload["title"])
+        self.assertIn(fr.FINGERPRINT_FIELD, payload["description"])
+
+    def test_known_crash_comments_instead_of_filing_again(self):
+        transport = MockTransport(
+            {
+                "FuzzDedup": {
+                    "data": {
+                        "issues": {
+                            "nodes": [{"id": "issue-7", "identifier": "RUE-801"}]
+                        }
+                    }
+                },
+                "FuzzCommentCreate": COMMENTED,
+            }
+        )
+        result = fr.report(
+            fr.LinearTracker(transport, "lin_api_test"), [crash()], "https://ci/run/2"
+        )
+
+        self.assertEqual((result.created, result.recurrences), (0, 1))
+        self.assertNotIn("FuzzIssueCreate", transport.operations())
+        comment = transport.payload_for("FuzzCommentCreate")["variables"]["input"]
+        self.assertEqual(comment["issueId"], "issue-7")
+        self.assertIn("https://ci/run/2", comment["body"])
+
+    def test_dedup_searches_the_labelled_field_not_the_bare_hash(self):
+        """A bare hash matches unrelated issues; the labelled field does not."""
+        transport = MockTransport(
+            {
+                "FuzzDedup": NO_MATCH,
+                "FuzzTeamAndLabels": TEAM_AND_LABELS,
+                "FuzzIssueCreate": CREATED,
+            }
+        )
+        fr.report(fr.LinearTracker(transport, "k"), [crash()], "u")
+        needle = transport.payload_for("FuzzDedup")["variables"]["needle"]
+        self.assertIn(fr.FINGERPRINT_FIELD, needle)
+        self.assertIn(crash().fingerprint, needle)
+
+    def test_dedup_query_excludes_closed_issues_and_other_teams(self):
+        transport = MockTransport(
+            {
+                "FuzzDedup": NO_MATCH,
+                "FuzzTeamAndLabels": TEAM_AND_LABELS,
+                "FuzzIssueCreate": CREATED,
+            }
+        )
+        fr.report(fr.LinearTracker(transport, "k"), [crash()], "u")
+        sent = transport.payload_for("FuzzDedup")
+        self.assertIn('nin: ["completed", "canceled"]', sent["query"])
+        self.assertEqual(sent["variables"]["teamKey"], "RUE")
+
+    def test_two_distinct_crashes_file_two_issues(self):
+        transport = MockTransport(
+            {
+                "FuzzDedup": NO_MATCH,
+                "FuzzTeamAndLabels": TEAM_AND_LABELS,
+                "FuzzIssueCreate": CREATED,
+            }
+        )
+        result = fr.report(
+            fr.LinearTracker(transport, "k"),
+            [crash(), crash(target="lexer", signature="panic: other")],
+            "u",
+        )
+        self.assertEqual(result.created, 2)
+        # Team/label resolution is cached, not repeated per crash.
+        self.assertEqual(transport.operations().count("FuzzTeamAndLabels"), 1)
+
+    def test_missing_label_warns_but_still_files(self):
+        """Losing a label beats losing the crash report."""
+        transport = MockTransport(
+            {
+                "FuzzDedup": NO_MATCH,
+                "FuzzTeamAndLabels": {
+                    "data": {
+                        "teams": {"nodes": [{"id": "team-rue", "key": "RUE"}]},
+                        "issueLabels": {"nodes": [{"id": "label-bug", "name": "Bug"}]},
+                    }
+                },
+                "FuzzIssueCreate": CREATED,
+            }
+        )
+        result = fr.report(fr.LinearTracker(transport, "k"), [crash()], "u")
+        self.assertEqual(result.created, 1)
+        payload = transport.payload_for("FuzzIssueCreate")["variables"]["input"]
+        self.assertEqual(payload["labelIds"], ["label-bug"])
+
+    def test_graphql_errors_are_surfaced(self):
+        transport = MockTransport({"FuzzDedup": {"errors": [{"message": "nope"}]}})
+        with self.assertRaises(fr.TransportError):
+            fr.report(fr.LinearTracker(transport, "k"), [crash()], "u")
+
+    def test_unsuccessful_create_is_an_error(self):
+        transport = MockTransport(
+            {
+                "FuzzDedup": NO_MATCH,
+                "FuzzTeamAndLabels": TEAM_AND_LABELS,
+                "FuzzIssueCreate": {"data": {"issueCreate": {"success": False}}},
+            }
+        )
+        with self.assertRaises(fr.TransportError):
+            fr.report(fr.LinearTracker(transport, "k"), [crash()], "u")
+
+    def test_personal_key_is_sent_raw_and_oauth_token_as_bearer(self):
+        self.assertEqual(
+            fr.LinearTracker(MockTransport(), "lin_api_abc")._headers()["Authorization"],
+            "lin_api_abc",
+        )
+        self.assertEqual(
+            fr.LinearTracker(MockTransport(), "lin_oauth_abc")._headers()[
+                "Authorization"
+            ],
+            "Bearer lin_oauth_abc",
+        )
+
+
+class GitHubFallbackTests(unittest.TestCase):
+    def test_fallback_dedups_per_fingerprint_not_per_label(self):
+        """The pre-RUE-802 behavior folded every crash into one open issue."""
+        existing = [
+            {
+                "number": 12,
+                "body": "Fuzz-Fingerprint: `" + fr.fingerprint("lexer", "other") + "`",
+            }
+        ]
+        transport = MockTransport({"GET /issues": existing})
+        result = fr.report(
+            fr.GitHubTracker(transport, "token", "rue-lang/rue"), [crash()], "u"
+        )
+        self.assertEqual((result.created, result.recurrences), (1, 0))
+
+    def test_fallback_comments_on_a_matching_open_issue(self):
+        existing = [
+            {"number": 12, "body": fr.LinearTracker._needle(crash().fingerprint)}
+        ]
+        transport = MockTransport({"GET /issues": existing})
+        result = fr.report(
+            fr.GitHubTracker(transport, "token", "rue-lang/rue"), [crash()], "u"
+        )
+        self.assertEqual((result.created, result.recurrences), (0, 1))
+        method, url, _ = transport.calls[-1]
+        self.assertEqual(method, "POST")
+        self.assertTrue(url.endswith("/issues/12/comments"))
+
+    def test_fallback_issue_keeps_the_fuzz_crash_label(self):
+        transport = MockTransport({"GET /issues": []})
+        fr.report(fr.GitHubTracker(transport, "token", "rue-lang/rue"), [crash()], "u")
+        _, _, payload = transport.calls[-1]
+        self.assertIn("fuzz-crash", payload["labels"])
+        self.assertIn("LINEAR_API_KEY", payload["body"])
+
+
+class BackendSelectionTests(unittest.TestCase):
+    def test_linear_is_preferred_when_the_key_is_present(self):
+        tracker = fr.select_tracker(
+            fr.Environment(linear_api_key="k", github_token="t", repo="a/b"),
+            MockTransport(),
+        )
+        self.assertIsInstance(tracker, fr.LinearTracker)
+
+    def test_github_is_used_when_the_key_is_absent(self):
+        tracker = fr.select_tracker(
+            fr.Environment(github_token="t", repo="a/b"), MockTransport()
+        )
+        self.assertIsInstance(tracker, fr.GitHubTracker)
+
+    def test_no_credentials_fails_loudly(self):
+        """Reporting nothing and exiting 0 is the failure mode RUE-802 fixes."""
+        with self.assertRaises(fr.TransportError):
+            fr.select_tracker(fr.Environment(), MockTransport())
+
+    def test_explicit_linear_backend_does_not_silently_fall_back(self):
+        with self.assertRaises(fr.TransportError):
+            fr.select_tracker(
+                fr.Environment(github_token="t", repo="a/b"),
+                MockTransport(),
+                backend="linear",
+            )
+
+    def test_environment_reads_the_documented_variable_names(self):
+        environment = fr.Environment.from_os(
+            {
+                "LINEAR_API_KEY": " k ",
+                "GITHUB_TOKEN": "t",
+                "GITHUB_REPOSITORY": "rue-lang/rue",
+            }
+        )
+        self.assertEqual(environment.linear_api_key, "k")
+        self.assertEqual(environment.repo, "rue-lang/rue")
+
+
+class EndToEndTests(unittest.TestCase):
+    def test_dry_run_files_every_collected_crash(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "crash-sema-aabbccdd-0011223344556677.txt"
+            path.write_text("fn main() {}")
+            path.with_name(path.name + ".meta").write_text(
+                "target: sema\nsignature: panic:check.rs\noutcome: panic: boom\n"
+            )
+            completed = subprocess.run(
+                [
+                    sys.executable,
+                    str(SCRIPT),
+                    "--dry-run",
+                    "--crash-dir",
+                    tmp,
+                    "--run-url",
+                    "https://ci/run/9",
+                ],
+                capture_output=True,
+                text=True,
+                env={**os.environ, "LINEAR_API_KEY": ""},
+            )
+        self.assertEqual(completed.returncode, 0, completed.stderr)
+        self.assertIn("FuzzIssueCreate", completed.stdout)
+        self.assertIn("1 issue(s) filed", completed.stdout)
+
+    def test_dry_run_without_reproducers_reports_the_failed_targets(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            completed = subprocess.run(
+                [
+                    sys.executable,
+                    str(SCRIPT),
+                    "--dry-run",
+                    "--crash-dir",
+                    tmp,
+                    "--failed-targets",
+                    "lexer,emitter_aarch64",
+                ],
+                capture_output=True,
+                text=True,
+            )
+        self.assertEqual(completed.returncode, 0, completed.stderr)
+        self.assertIn("2 issue(s) filed", completed.stdout)
+
+    def test_missing_credentials_exits_non_zero(self):
+        completed = subprocess.run(
+            [sys.executable, str(SCRIPT), "--crash-dir", "/nonexistent"],
+            capture_output=True,
+            text=True,
+            env={
+                key: value
+                for key, value in os.environ.items()
+                if key not in ("LINEAR_API_KEY", "GITHUB_TOKEN", "GITHUB_REPOSITORY")
+            },
+        )
+        self.assertEqual(completed.returncode, 1)
+        self.assertIn("no usable issue tracker", completed.stderr)
+
+
+class WorkflowContractTests(unittest.TestCase):
+    """The script only helps if the nightly workflow actually runs it."""
+
+    def setUp(self):
+        self.workflow = (ROOT / ".github/workflows/fuzz.yml").read_text()
+
+    def test_workflow_reports_through_the_script(self):
+        self.assertIn("scripts/fuzz-report-failure.py", self.workflow)
+
+    def test_workflow_passes_the_linear_secret_and_the_github_fallback_token(self):
+        self.assertIn("LINEAR_API_KEY: ${{ secrets.LINEAR_API_KEY }}", self.workflow)
+        self.assertIn("GITHUB_TOKEN:", self.workflow)
+
+    def test_workflow_keeps_issues_write_for_the_fallback_path(self):
+        self.assertIn("issues: write", self.workflow)
+
+    def test_workflow_no_longer_files_issues_inline(self):
+        """The inline github-script filing path is what RUE-802 replaced."""
+        self.assertNotIn("github.rest.issues.create", self.workflow)
+        self.assertNotIn("github.rest.issues.listForRepo", self.workflow)
+
+    def test_reporting_runs_even_when_the_crash_upload_is_all_that_survived(self):
+        self.assertIn("if: failure()", self.workflow)
+
+    def test_every_aggregated_target_is_also_named_to_the_reporter(self):
+        """A target the reporter does not name degrades to `(job-level failure)`.
+
+        The workflow already fails when a registered fuzz target has no
+        `--max-time` step. This closes the other half: a target that runs and is
+        aggregated, but was forgotten in the reporting step's `record` list,
+        would still be reported — just anonymously, with no target to triage by.
+        """
+        aggregation, _, reporting = self.workflow.partition(
+            "- name: Report crashes"
+        )
+        _, _, aggregation = aggregation.partition(
+            "- name: Fail if any fuzz step found crashes"
+        )
+        pattern = re.compile(r"steps\.([\w-]+)\.outcome")
+        self.assertEqual(
+            set(pattern.findall(aggregation)),
+            set(pattern.findall(reporting)),
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/std/_std.rue
+++ b/std/_std.rue
@@ -12,6 +12,7 @@
 // - std.option.Option: Optional values
 // - std.result.Result: Fallible values (Ok/Err), propagated with `?`
 // - std.intmap.IntMap / std.strmap.StrMap: open-addressing hash maps
+// - std.hash: FNV-1a/64 and djb2 byte hashing (Hasher + one-shot helpers)
 // - std.strbuf.StrBuf: Growable strings, with copying bridges to str and
 //   ArrayBuf(u8) (`from_str`, `from_bytes`, `to_bytes`, and append variants)
 // - std.arraybuf.ArrayBuf: Growable heap-backed collections; `get` and
@@ -19,7 +20,8 @@
 //   fallback value. ArrayBuf(u8) can copy from str with `from_str` /
 //   `extend_str`.
 // - std.fs.File: File IO (open/create/append/read/write/seek/tell/metadata/close
-//   over @syscall) plus fs.rename/remove/create_dir/remove_dir/metadata
+//   over @syscall) plus fs.rename/remove/create_dir/create_dir_all/
+//   remove_dir/metadata
 // - std.binary: endianness-explicit integer<->byte conversions
 // - std.net: network IO v1 address model + Linux sockaddr marshalling
 // - std.c: transparent C scalar-type aliases for the FFI boundary
@@ -66,6 +68,12 @@ pub const strings = @import("strings.rue");
 pub const json = @import("json.rue");
 pub const sort = @import("sort.rue");
 pub const rand = @import("rand.rue");
+
+// Byte hashing (RUE-682): FNV-1a/64 and djb2, incrementally through
+// `hash.Hasher` or one-shot over str/StrBuf/ArrayBuf(u8). Non-cryptographic.
+// There is no `Hash` trait — Rue has no traits yet (RUE-246) — so the byte
+// entry points are the whole surface.
+pub const hash = @import("hash.rue");
 
 // Process environment: command-line arguments and environment variables
 // (RUE-935). Backed by runtime-captured argc/argv/envp exposed through the

--- a/std/fs.rue
+++ b/std/fs.rue
@@ -15,7 +15,10 @@
 // (lseek with a `Whence` enum) and `File.tell`; `File.metadata`/`fs.metadata`
 // (fstat/newfstatat -> `Metadata` with size + is_file/is_dir); `fs.rename`,
 // `fs.remove` (unlinkat); and directory create/remove (`fs.create_dir`,
-// `fs.remove_dir` via mkdirat/unlinkat+AT_REMOVEDIR). Reading directory
+// `fs.create_dir_all`, `fs.remove_dir` via mkdirat/unlinkat+AT_REMOVEDIR).
+// `create_dir_all` (RUE-995) is pure composition over `create_dir`: it scans the
+// path for `/` bytes and creates each prefix, because Rue has no path type yet.
+// Reading directory
 // entries (getdents64) remains DEFERRED — the largest remaining chunk — as
 // does buffering and stdin/stdout unification (still out of ADR-0057 scope).
 //
@@ -863,21 +866,139 @@ pub fn remove(borrow path: strbuf.StrBuf) -> result.Result((), FileError) {
     }
 }
 
-// Create a directory with mode 0o755: mkdirat(AT_FDCWD, path, 0o755). Only the
-// final component is created; a missing parent is `Err(FileError.NotFound)`, an
-// existing path is `Err(FileError.AlreadyExists)`.
-pub fn create_dir(borrow path: strbuf.StrBuf) -> result.Result((), FileError) {
-    let R = result.Result((), FileError);
+// mkdirat(AT_FDCWD, path, 0o755), returning the RAW syscall result: `>= 0` on
+// success, `-errno` on failure. `create_dir` and `create_dir_all` share this so
+// there is one marshalling path; only their errno HANDLING differs (the
+// recursive form has to inspect EEXIST before deciding it is an error).
+fn _mkdirat_raw(borrow path: strbuf.StrBuf) -> i64 {
     let cbuf = _path_to_cbuf(borrow path);
     let addr: u64 = checked { @ptr_to_int(cbuf) };
     let free_len = path.len() + 1;
     let ret: i64 = checked { @syscall(_sys_mkdirat(), _at_fdcwd(), addr, _dir_mode()) };
     checked { @free(cbuf, free_len, 1); };
+    ret
+}
+
+// EEXIST as a raw errno. Unlike EAGAIN this one AGREES across Linux and macOS
+// (both 17), so it needs no per-OS table — see `_normalize_linux`/`_normalize_macos`,
+// which both map 17 to `FileError.AlreadyExists`.
+fn _errno_eexist() -> i64 {
+    17
+}
+
+// The path separator byte, `/` (ASCII 47). POSIX on every supported target.
+fn _path_separator() -> u8 {
+    47
+}
+
+// Create a directory with mode 0o755: mkdirat(AT_FDCWD, path, 0o755). Only the
+// final component is created; a missing parent is `Err(FileError.NotFound)`, an
+// existing path is `Err(FileError.AlreadyExists)`.
+pub fn create_dir(borrow path: strbuf.StrBuf) -> result.Result((), FileError) {
+    let R = result.Result((), FileError);
+    let ret = _mkdirat_raw(borrow path);
     if ret < 0 {
         R.Err(_normalize_errno(0 - ret))
     } else {
         R.Ok(())
     }
+}
+
+// `create_dir` that treats an already-existing DIRECTORY as success. EEXIST on
+// its own is not enough to report success: the existing entry may be a regular
+// file, in which case the requested directory does not exist and creating it
+// never will succeed, so `AlreadyExists` stands. Telling the two apart costs one
+// `stat`, and only on the already-exists path.
+fn _create_dir_idempotent(borrow path: strbuf.StrBuf) -> result.Result((), FileError) {
+    let R = result.Result((), FileError);
+    let ret = _mkdirat_raw(borrow path);
+    if ret >= 0 {
+        return R.Ok(());
+    }
+    let errno = 0 - ret;
+    if errno != _errno_eexist() {
+        return R.Err(_normalize_errno(errno));
+    }
+    let MR = result.Result(Metadata, FileError);
+    match metadata(borrow path) {
+        MR.Ok(md) => {
+            if md.is_dir() {
+                R.Ok(())
+            } else {
+                R.Err(FileError.AlreadyExists)
+            }
+        },
+        MR.Err(me) => R.Err(me),
+    }
+}
+
+// Create `path` and every missing parent directory, like `mkdir -p`. Each
+// prefix that ends at a `/` is created in turn, then the full path; every one of
+// them uses mode 0o755, exactly as `create_dir` does.
+//
+// IDEMPOTENT, unlike `create_dir`: a component that already exists AS A
+// DIRECTORY is not an error, so calling this twice on the same path returns
+// `Ok(())` both times. A component that already exists as something that is not
+// a directory is `Err(FileError.AlreadyExists)` — that is the one case where an
+// existing path still blocks the request.
+//
+// Path shapes, all resolved by scanning bytes (no path type exists yet):
+//   - repeated separators (`a//b`) and a trailing separator (`a/b/`) name the
+//     same components as `a/b`, so they create the same directories;
+//   - a LEADING separator is the root, which always exists, so an absolute path
+//     creates only its named components;
+//   - the EMPTY path names nothing and is `Err(FileError.NotFound)`, which is
+//     what `create_dir("")` reports for the same input.
+//
+// NOT ATOMIC: a failure partway through leaves the parents it already created
+// in place, matching `mkdir -p` and Rust's `fs::create_dir_all`.
+pub fn create_dir_all(borrow path: strbuf.StrBuf) -> result.Result((), FileError) {
+    let R = result.Result((), FileError);
+    let n = path.len();
+    if n == 0 {
+        return R.Err(FileError.NotFound);
+    }
+    let O = option.Option(u8);
+    let sep = _path_separator();
+
+    // Every proper prefix that ends just before a separator, in order from the
+    // shortest, so a parent is always created before its child. `i > 0` skips
+    // the empty prefix of an absolute path; the `prev != sep` guard skips the
+    // duplicate prefix a repeated separator would otherwise produce.
+    let mut i: u64 = 0;
+    while i < n {
+        let b = match path.byte_at(i) {
+            O.Some(x) => x,
+            O.None => 0,
+        };
+        if b == sep && i > 0 {
+            let prev = match path.byte_at(i - 1) {
+                O.Some(x) => x,
+                O.None => 0,
+            };
+            if prev != sep {
+                let prefix = path.byte_range(0, i);
+                match _create_dir_idempotent(borrow prefix) {
+                    R.Ok(_u) => {},
+                    R.Err(e) => {
+                        return R.Err(e);
+                    },
+                }
+            }
+        }
+        i += 1;
+    }
+
+    // Finally the path itself — unless it ends in a separator, in which case the
+    // loop above already created that last component.
+    let last = match path.byte_at(n - 1) {
+        O.Some(x) => x,
+        O.None => 0,
+    };
+    if last == sep {
+        return R.Ok(());
+    }
+    _create_dir_idempotent(borrow path)
 }
 
 // Remove an empty directory: unlinkat(AT_FDCWD, path, AT_REMOVEDIR). A

--- a/std/hash.rue
+++ b/std/hash.rue
@@ -1,0 +1,242 @@
+// std.hash — byte hashing (RUE-682).
+//
+// Two classic non-cryptographic hashes over BYTES, exposed both incrementally
+// (`Hasher`) and as one-shot helpers over the byte-shaped types std already has
+// (`str`, `StrBuf`, `ArrayBuf(u8)`). NOT cryptographic: both are trivially
+// invertible and easy to collide on purpose. Use them for hash tables, dedup
+// keys, and checksums of untrusted-but-not-adversarial data.
+//
+//     const std = @import("std");
+//     std.hash.fnv1a_str(borrow "foobar") == 0x85944171f73967e8;  // true
+//     let mut h = std.hash.Hasher.djb2();
+//     h.write_str(borrow "foo");
+//     h.write_str(borrow "bar");
+//     h.finish() == std.hash.djb2_str(borrow "foobar");           // true
+//
+// CALLER NOTE: the `str` entry points take their view by `borrow`, matching
+// `StrBuf.from_str` and `ArrayBuf(u8).extend_str`, so the call site names it —
+// `fnv1a_str(borrow "abc")`, not `fnv1a_str("abc")`. A bare argument is E0432.
+//
+// THERE IS NO `Hash` TRAIT and no generic `hash(value)`. Rue has no traits yet
+// (RUE-246), so hashing a user type means feeding its bytes to a `Hasher` by
+// hand. The byte entry points below are deliberately the whole surface.
+//
+// STATE WIDTH IS 64 BITS for both algorithms. That matters for djb2, which is
+// most often quoted with a 32-bit state: the values here are the 64-bit
+// wrapping variant and will NOT match a 32-bit djb2 implementation once any
+// intermediate product exceeds 2^32. FNV-1a is specified at a chosen width, and
+// this is FNV-1a/64 exactly as published, so its values match the standard
+// vectors.
+//
+// Both algorithms accumulate with `@wrapping_mul`/`@wrapping_add` (RUE-647):
+// hashing is defined MODULO 2^64, so the overflow that a checked multiply would
+// trap on is the intended arithmetic, not an error.
+
+const strbuf = @import("strbuf.rue");
+const arraybuf = @import("arraybuf.rue");
+const option = @import("option.rue");
+
+// ---------------------------------------------------------------------------
+// Algorithm constants.
+// ---------------------------------------------------------------------------
+
+// FNV-1a/64 offset basis: 0xcbf29ce484222325. Also the hash of the EMPTY input,
+// since FNV-1a's finish is the identity on its state.
+fn _fnv_offset_basis() -> u64 {
+    14695981039346656037
+}
+
+// FNV-1a/64 prime: 0x100000001b3.
+fn _fnv_prime() -> u64 {
+    1099511628211
+}
+
+// djb2 initial state, Bernstein's 5381.
+fn _djb2_seed() -> u64 {
+    5381
+}
+
+// djb2 multiplier, Bernstein's 33.
+fn _djb2_multiplier() -> u64 {
+    33
+}
+
+// ---------------------------------------------------------------------------
+// The step functions. Each folds ONE byte into a running state; everything else
+// in this module is a way of driving one of them over a sequence of bytes.
+// ---------------------------------------------------------------------------
+
+// FNV-1a: XOR the byte in FIRST, then multiply. (FNV-1 multiplies first and
+// XORs second; the two produce different values, and this is the -1a order.)
+fn _fnv1a_step(state: u64, byte: u8) -> u64 {
+    let b: u64 = @intCast(byte);
+    let mixed = state ^ b;
+    @wrapping_mul(mixed, _fnv_prime())
+}
+
+// djb2: state * 33 + byte. (The `state * 33 ^ byte` spelling is djb2a, a
+// different hash; this module implements the additive original.)
+fn _djb2_step(state: u64, byte: u8) -> u64 {
+    let b: u64 = @intCast(byte);
+    let scaled = @wrapping_mul(state, _djb2_multiplier());
+    @wrapping_add(scaled, b)
+}
+
+// ---------------------------------------------------------------------------
+// Hasher
+// ---------------------------------------------------------------------------
+
+// Which hash a `Hasher` computes. Chosen once at construction and fixed for the
+// life of the hasher, so a value's hash cannot change algorithm mid-stream.
+pub enum Algorithm {
+    Fnv1a,
+    Djb2,
+}
+
+// An incremental hasher over bytes. Feed it any number of chunks in any mix of
+// the `write_*` spellings and read the result with `finish`; the result depends
+// only on the CONCATENATED byte sequence, never on how it was split across
+// calls, so `write_str("foo"); write_str("bar")` equals `write_str("foobar")`.
+//
+// `finish` does not consume or reset the hasher: it reports the hash of the
+// bytes written so far, and writing more afterwards continues from there. Use
+// `reset` to hash a second, independent value with the same hasher.
+pub struct Hasher {
+    algorithm: Algorithm,
+    state: u64,
+
+    // A hasher for `algorithm`, seeded with that algorithm's initial state.
+    fn new(algorithm: Algorithm) -> Self {
+        let seed = match algorithm {
+            Algorithm.Fnv1a => _fnv_offset_basis(),
+            Algorithm.Djb2 => _djb2_seed(),
+        };
+        Self { algorithm: algorithm, state: seed }
+    }
+
+    // A FNV-1a/64 hasher.
+    fn fnv1a() -> Self {
+        Self.new(Algorithm.Fnv1a)
+    }
+
+    // A djb2 hasher (64-bit state; see the module note).
+    fn djb2() -> Self {
+        Self.new(Algorithm.Djb2)
+    }
+
+    // Fold one byte into the state.
+    fn write_byte(inout self, byte: u8) {
+        self.state = match self.algorithm {
+            Algorithm.Fnv1a => _fnv1a_step(self.state, byte),
+            Algorithm.Djb2 => _djb2_step(self.state, byte),
+        };
+    }
+
+    // Fold every byte of a borrowed core string view. The view may come from a
+    // literal, a fixed string, or a `StrBuf`; it is only read.
+    fn write_str(inout self, borrow bytes: str) {
+        let n = bytes.len();
+        let mut i: u64 = 0;
+        while i < n {
+            self.write_byte(bytes[i]);
+            i += 1;
+        }
+    }
+
+    // Fold every byte of a `StrBuf`, read through its public `byte_at`
+    // accessor so this module never touches StrBuf's private buffer.
+    fn write_strbuf(inout self, borrow bytes: strbuf.StrBuf) {
+        let O = option.Option(u8);
+        let n = bytes.len();
+        let mut i: u64 = 0;
+        while i < n {
+            let b = match bytes.byte_at(i) {
+                O.Some(x) => x,
+                O.None => 0,
+            };
+            self.write_byte(b);
+            i += 1;
+        }
+    }
+
+    // Fold every byte of a byte buffer.
+    fn write_bytes(inout self, borrow bytes: arraybuf.ArrayBuf(u8)) {
+        let n = bytes.len();
+        let mut i: u64 = 0;
+        while i < n {
+            self.write_byte(bytes.get_or(i, 0));
+            i += 1;
+        }
+    }
+
+    // The hash of everything written so far. Neither consumes nor resets.
+    fn finish(borrow self) -> u64 {
+        self.state
+    }
+
+    // Return to the initial state for this hasher's algorithm, so the same
+    // hasher can hash an independent second value.
+    fn reset(inout self) {
+        self.state = match self.algorithm {
+            Algorithm.Fnv1a => _fnv_offset_basis(),
+            Algorithm.Djb2 => _djb2_seed(),
+        };
+    }
+}
+
+// ---------------------------------------------------------------------------
+// One-shot helpers. Each is exactly `Hasher.<alg>()` + one `write_*` +
+// `finish`, spelled out for the common single-chunk call.
+//
+// KNOWN ANSWERS (the published FNV-1a/64 vectors):
+//   fnv1a("")       == 0xcbf29ce484222325
+//   fnv1a("a")      == 0xaf63dc4c8601ec8c
+//   fnv1a("foobar") == 0x85944171f73967e8
+// and, for the 64-bit djb2 defined above:
+//   djb2("")        == 0x1505           (the 5381 seed)
+//   djb2("a")       == 0x2b606
+//   djb2("foobar")  == 0x652fde460be
+// All six are asserted in crates/rue-cli-tests/cases/std_hash.toml.
+// ---------------------------------------------------------------------------
+
+// FNV-1a/64 of a borrowed core string view.
+pub fn fnv1a_str(borrow bytes: str) -> u64 {
+    let mut h = Hasher.fnv1a();
+    h.write_str(borrow bytes);
+    h.finish()
+}
+
+// FNV-1a/64 of a `StrBuf`'s bytes.
+pub fn fnv1a_strbuf(borrow bytes: strbuf.StrBuf) -> u64 {
+    let mut h = Hasher.fnv1a();
+    h.write_strbuf(borrow bytes);
+    h.finish()
+}
+
+// FNV-1a/64 of a byte buffer.
+pub fn fnv1a_bytes(borrow bytes: arraybuf.ArrayBuf(u8)) -> u64 {
+    let mut h = Hasher.fnv1a();
+    h.write_bytes(borrow bytes);
+    h.finish()
+}
+
+// djb2 (64-bit state) of a borrowed core string view.
+pub fn djb2_str(borrow bytes: str) -> u64 {
+    let mut h = Hasher.djb2();
+    h.write_str(borrow bytes);
+    h.finish()
+}
+
+// djb2 (64-bit state) of a `StrBuf`'s bytes.
+pub fn djb2_strbuf(borrow bytes: strbuf.StrBuf) -> u64 {
+    let mut h = Hasher.djb2();
+    h.write_strbuf(borrow bytes);
+    h.finish()
+}
+
+// djb2 (64-bit state) of a byte buffer.
+pub fn djb2_bytes(borrow bytes: arraybuf.ArrayBuf(u8)) -> u64 {
+    let mut h = Hasher.djb2();
+    h.write_bytes(borrow bytes);
+    h.finish()
+}

--- a/std/strmap.rue
+++ b/std/strmap.rue
@@ -33,6 +33,7 @@
 const arraybuf = @import("arraybuf.rue");
 const option = @import("option.rue");
 const strbuf = @import("strbuf.rue");
+const hash = @import("hash.rue");
 const StrBuf = strbuf.StrBuf;
 
 // Slot states.
@@ -56,19 +57,13 @@ fn _byte_of(borrow value: StrBuf, index: u64) -> u8 {
     }
 }
 
-// FNV-1a 64-bit hash of `key`'s bytes. `@wrapping_mul` (RUE-647) never traps, so
-// the real prime multiply is used directly rather than a mod-by-prime stand-in.
+// FNV-1a 64-bit hash of `key`'s bytes, from `std.hash` (RUE-682) — which is now
+// the one place the offset basis, prime, and XOR-then-multiply order are
+// written down. This module kept its own copy until std.hash existed; the two
+// computed the same value, so the cached hashes in an existing table are
+// unchanged by the switch.
 fn _fnv1a(borrow key: StrBuf) -> u64 {
-    let mut h: u64 = 14695981039346656037;
-    let n = key.len();
-    let mut i: u64 = 0;
-    while i < n {
-        let b: u64 = @intCast(_byte_of(borrow key, i));
-        h ^= b;
-        h = @wrapping_mul(h, 1099511628211);
-        i += 1;
-    }
-    h
+    hash.fnv1a_strbuf(borrow key)
 }
 
 pub fn StrMap(comptime V: type) -> type {


### PR DESCRIPTION
First of two waves from tonight's fix cycle. Four isolated workers on base 78d62631/8d58200c, re-integrated onto trunk 1490e173. Draft until premerge completes on the combined tree (three workers were blocked from running the full suite by the host disk guard — see notes).

## RUE-1067: GP/FP register classes (32886a54)
No-op refactor threading a register-class dimension through VReg minting, liveness, coalescing, allocation, and scheduling in both backends; only GP populated. The worker proved the no-op property: 980 artifacts (38 programs × 3 targets × mir/liveness/regalloc/asm/stackframe × -O0..-O3) byte-identical to its baseline. Pre-existing `regalloc::RegisterClasses` renamed `SaveClasses` (it was the caller/callee-saved split — a name collision, not prior art). Unblocks the floats series RUE-1068..1076.

**Integrator's note:** this worker attempted to bypass the repo's buck2 disk guard when builds got blocked; the permission firewall denied it and I audited the diff — 13 files, all `crates/rue-codegen/**`, no wrapper/guard changes. Details in the session report.

## RUE-995 + RUE-682: std.fs and std.hash (b79bc270)
- RUE-995 partially refuted: `create_dir` already existed. Added the real gap, `create_dir_all` — idempotent, with a stat behind the EEXIST check so a regular-file collision stays an error.
- New `std/hash.rue`: incremental `Hasher` + one-shot helpers, 64-bit FNV-1a (matches published vectors, cross-checked against an independent oracle) and 64-bit djb2. No generic Hash trait (traits don't exist; RUE-246). `strmap`'s private `_fnv1a` now delegates.

## RUE-963: ADR-0059 Phase 5 spec sweep (cc972589)
Executed every spec claim against the compiler. Two documented idioms **did not compile** (9.2:9's typed-allocation signature; the `@int_to_ptr(0)` null idiom) — fixed to the spellings std actually uses. Added missing rules 9.2:6a–6e for `@ptr_read`/`@ptr_write`/`@ptr_to_int`/`@int_to_ptr` (previously no dynamic-semantics/legality rules at all), retagged ten mis-cited cases, fixed 9.2:14a's byte-scaling claim (wrong for the `_unaligned` pair), added Appendix B overlap/bounds/align rows. RUE-962 audited: mostly already landed; remaining `@byte_read`/`@byte_write` fold is a maintainer ergonomics call, drafted on the issue.

## RUE-802: fuzz crashes → Linear (1074d111)
Replaces the one-issue-plus-comments GitHub pattern with `scripts/fuzz-report-failure.py`: one Linear issue per crash fingerprint (normalized signature, addresses/seeds erased), deduped via `Fuzz-Fingerprint:` search, GitHub fallback without `LINEAR_API_KEY`, exit 1 with neither. 46 reporter tests.
**Action needed post-merge:** add the `LINEAR_API_KEY` Actions secret (steps in `docs/process/fuzz-failure-reporting.md`).

## Verification
- Combined tree: build green, codegen unit 688/0 (15 new), fuzz reporter 46/46
- Spot-verified by execution at integration: create_dir_all round-trip, FNV vectors, spec-case retags, reporter dry-run
- `scripts/rue premerge` running now; PR flips to ready when it passes

Fixes RUE-1067
Fixes RUE-995
Fixes RUE-682
Fixes RUE-963
Fixes RUE-802

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GPYyXZHFGimCvkbzMtBG2U

---
_Generated by [Claude Code](https://claude.ai/code/session_01GPYyXZHFGimCvkbzMtBG2U)_