### PR TITLE
RUE-1330: count same-task exact terminal observations

### DIFF
--- a/crates/rue-bench/src/incremental.rs
+++ b/crates/rue-bench/src/incremental.rs
@@ -333,7 +333,7 @@ fn elapsed_ms(duration: Duration) -> u128 {
 
 fn validation_summary(work: QueryValidationMetrics) -> String {
     format!(
-        "walks {}/{}/{}/{} total/clean/dirty/abort, edges {}/{}, nodes {}/{}/{} hit/miss/cycle, registry {}/{}, demands {}/{}/{}/{}/{}, endorsements {}/{}, superseded {}, certificates {}",
+        "walks {}/{}/{}/{} total/clean/dirty/abort, edges {}/{}, nodes {}/{}/{} hit/miss/cycle, registry {}/{}, demands {}/{}/{}/{}/{}, endorsements {}/{}, query terminal leases {}/{} attempts/duplicates, superseded {}, certificates {}",
         work.traversals,
         work.successful_traversals,
         work.dirty_traversals,
@@ -352,6 +352,8 @@ fn validation_summary(work: QueryValidationMetrics) -> String {
         work.demands,
         work.endorsement_hits,
         work.endorsement_probes,
+        work.terminal_lease_observations,
+        work.duplicate_terminal_lease_observations,
         work.superseded,
         work.certificates_published,
     )
@@ -893,6 +895,8 @@ fn report_validation_work(work: QueryValidationMetrics) -> ReportValidationWork 
         memo_misses: work.memo_misses,
         endorsement_probes: work.endorsement_probes,
         endorsement_hits: work.endorsement_hits,
+        terminal_lease_observations: work.terminal_lease_observations,
+        duplicate_terminal_lease_observations: work.duplicate_terminal_lease_observations,
         demands: work.demands,
         demand_reuses: work.demand_reuses,
         demand_computes: work.demand_computes,

--- a/crates/rue-compiler/src/unstable.rs
+++ b/crates/rue-compiler/src/unstable.rs
@@ -1630,6 +1630,8 @@ pub struct QueryValidationMetrics {
     pub memo_misses: u64,
     pub endorsement_probes: u64,
     pub endorsement_hits: u64,
+    pub terminal_lease_observations: u64,
+    pub duplicate_terminal_lease_observations: u64,
     pub demands: u64,
     pub demand_reuses: u64,
     pub demand_computes: u64,
@@ -1667,6 +1669,8 @@ impl QueryValidationMetrics {
             memo_misses: self.memo_misses,
             endorsement_probes: self.endorsement_probes,
             endorsement_hits: self.endorsement_hits,
+            terminal_lease_observations: self.terminal_lease_observations,
+            duplicate_terminal_lease_observations: self.duplicate_terminal_lease_observations,
             demands: self.demands,
             demand_reuses: self.demand_reuses,
             demand_computes: self.demand_computes,
@@ -1695,6 +1699,8 @@ impl From<rue_query::ValidationWork> for QueryValidationMetrics {
             memo_misses: work.memo_misses,
             endorsement_probes: work.endorsement_probes,
             endorsement_hits: work.endorsement_hits,
+            terminal_lease_observations: work.terminal_lease_observations,
+            duplicate_terminal_lease_observations: work.duplicate_terminal_lease_observations,
             demands: work.demands,
             demand_reuses: work.demand_reuses,
             demand_computes: work.demand_computes,
@@ -1703,6 +1709,31 @@ impl From<rue_query::ValidationWork> for QueryValidationMetrics {
             superseded: work.superseded,
             certificates_published: work.certificates_published,
         }
+    }
+}
+
+#[cfg(test)]
+mod query_validation_metrics_tests {
+    use super::QueryValidationMetrics;
+
+    #[test]
+    fn exact_terminal_observations_survive_projection_and_deltas() {
+        let before = rue_query::ValidationWork {
+            terminal_lease_observations: 7,
+            duplicate_terminal_lease_observations: 2,
+            ..Default::default()
+        };
+        let after = rue_query::ValidationWork {
+            terminal_lease_observations: 11,
+            duplicate_terminal_lease_observations: 5,
+            ..Default::default()
+        };
+
+        assert_eq!(QueryValidationMetrics::from(after).into_runtime(), after);
+        let delta = QueryValidationMetrics::from(after)
+            .saturating_sub(QueryValidationMetrics::from(before));
+        assert_eq!(delta.terminal_lease_observations, 4);
+        assert_eq!(delta.duplicate_terminal_lease_observations, 3);
     }
 }
 

--- a/crates/rue-perf-schema/src/incremental.rs
+++ b/crates/rue-perf-schema/src/incremental.rs
@@ -14,7 +14,7 @@ use serde::{Deserialize, Serialize};
 use crate::{EnvironmentFingerprint, median, median_absolute_deviation};
 
 /// Version of the retained-session raw report wire format.
-pub const EDIT_REPORT_SCHEMA_VERSION: u32 = 3;
+pub const EDIT_REPORT_SCHEMA_VERSION: u32 = 4;
 
 /// One retained-session edit class from ADR-0068's initial matrix.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
@@ -751,6 +751,10 @@ pub struct ValidationWork {
     pub endorsement_probes: u64,
     /// Endorsement lookups satisfied by the rooted request.
     pub endorsement_hits: u64,
+    /// Exact query-result terminal lease observations attempted by requests.
+    pub terminal_lease_observations: u64,
+    /// Query-result terminal observations already leased by the same task.
+    pub duplicate_terminal_lease_observations: u64,
     /// Family-owned validation demands issued.
     pub demands: u64,
     /// Validation demands answered by retained terminals.
@@ -1127,6 +1131,12 @@ fn validate_validation_work(
         errors.push(finding(
             path,
             "validation endorsement hits exceed endorsement probes",
+        ));
+    }
+    if work.duplicate_terminal_lease_observations > work.terminal_lease_observations {
+        errors.push(finding(
+            path,
+            "duplicate exact-terminal observations exceed lease observations",
         ));
     }
     let completed_demands = work
@@ -1874,7 +1884,7 @@ mod tests {
 
     const MANIFEST: &str = r#"
 schema_version = 2
-report_schema_version = 3
+report_schema_version = 4
 fixture_revision = 3
 timing_samples_per_row = 5
 structural_samples_per_row = 1
@@ -2221,6 +2231,8 @@ minimum_memory_bytes = 15000000000
             memo_misses: 2,
             endorsement_probes: 2,
             endorsement_hits: 1,
+            terminal_lease_observations: 3,
+            duplicate_terminal_lease_observations: 1,
             demands: 2,
             demand_reuses: 1,
             demand_computes: 1,
@@ -2240,6 +2252,17 @@ minimum_memory_bytes = 15000000000
             error
                 .detail
                 .contains("node visits do not equal cycle prunes")
+        }));
+
+        measured.rows[0].samples[0].validation.node_visits -= 1;
+        measured.rows[0].samples[0]
+            .validation
+            .duplicate_terminal_lease_observations = 4;
+        let validation = validate_edit_report(&manifest, &measured);
+        assert!(validation.errors.iter().any(|error| {
+            error
+                .detail
+                .contains("duplicate exact-terminal observations exceed")
         }));
     }
 
@@ -2310,8 +2333,8 @@ minimum_memory_bytes = 15000000000
 
         let json = serde_json::to_string(&report(&manifest)).unwrap();
         let unknown = json.replacen(
-            "\"schema_version\":3",
-            "\"schema_version\":3,\"surprise\":true",
+            "\"schema_version\":4",
+            "\"schema_version\":4,\"surprise\":true",
             1,
         );
         assert!(

--- a/crates/rue-query/src/lib.rs
+++ b/crates/rue-query/src/lib.rs
@@ -244,6 +244,48 @@ mod registered_batch_tests {
         }
     }
 
+    #[test]
+    fn registered_batch_aggregates_exact_terminal_reobservations_from_children() {
+        let runtime = QueryRuntime::new(2);
+        publish_empty(&runtime, [revision(1)]);
+        let leaf = runtime
+            .family_with_evaluator::<Key, u64, _>("lease-metrics-leaf", 8, |_, _, _| {
+                Ok(QueryOutput::success(1))
+            })
+            .unwrap();
+        let leaf_for_branch = leaf.clone();
+        let branch = runtime
+            .family_with_evaluator::<Slot, u64, _>(
+                "lease-metrics-branch",
+                8,
+                move |context, _, key| {
+                    context.query_registered(&leaf_for_branch, Key("shared"))?;
+                    context.query_registered(&leaf_for_branch, Key("shared"))?;
+                    Ok(QueryOutput::success(key.0))
+                },
+            )
+            .unwrap();
+        let branch_for_root = branch.clone();
+        let root = runtime
+            .family_with_evaluator::<Key, u64, _>("lease-metrics-root", 8, move |context, _, _| {
+                context.query_registered_batch(&branch_for_root, [Slot(0), Slot(1)])?;
+                Ok(QueryOutput::success(0))
+            })
+            .unwrap();
+
+        let before = runtime.metrics().validation;
+        let attempt =
+            runtime.request_registered(&root, revision(1), Key("root"), CancellationToken::new());
+        assert_eq!(attempt.execution(), RequestExecution::Computed);
+        let work = runtime.metrics().validation.saturating_sub(before);
+
+        assert_eq!(work.terminal_lease_observations, 7);
+        assert_eq!(
+            work.duplicate_terminal_lease_observations, 2,
+            "each structured child must contribute its repeated shared-leaf observation"
+        );
+    }
+
     #[derive(Debug, PartialEq, Eq)]
     struct SharedValidationSnapshot {
         execution: RequestExecution,
@@ -2280,6 +2322,10 @@ pub struct ValidationWork {
     pub endorsement_probes: u64,
     /// Endorsement lookups satisfied by this rooted request's retained cone.
     pub endorsement_hits: u64,
+    /// Exact query-result terminal lease observations attempted by requests.
+    pub terminal_lease_observations: u64,
+    /// Query-result terminal observations already leased by the same task.
+    pub duplicate_terminal_lease_observations: u64,
     /// Family-owned validation demands issued after a memo miss.
     pub demands: u64,
     /// Validation demands answered by a retained terminal.
@@ -2322,6 +2368,8 @@ impl ValidationWork {
             memo_misses,
             endorsement_probes,
             endorsement_hits,
+            terminal_lease_observations,
+            duplicate_terminal_lease_observations,
             demands,
             demand_reuses,
             demand_computes,
@@ -2354,6 +2402,8 @@ impl ValidationWork {
             memo_misses,
             endorsement_probes,
             endorsement_hits,
+            terminal_lease_observations,
+            duplicate_terminal_lease_observations,
             demands,
             demand_reuses,
             demand_computes,
@@ -2381,6 +2431,8 @@ struct AtomicValidationWork {
     memo_misses: AtomicU64,
     endorsement_probes: AtomicU64,
     endorsement_hits: AtomicU64,
+    terminal_lease_observations: AtomicU64,
+    duplicate_terminal_lease_observations: AtomicU64,
     demands: AtomicU64,
     demand_reuses: AtomicU64,
     demand_computes: AtomicU64,
@@ -2407,6 +2459,10 @@ impl AtomicValidationWork {
             memo_misses: self.memo_misses.load(Ordering::Relaxed),
             endorsement_probes: self.endorsement_probes.load(Ordering::Relaxed),
             endorsement_hits: self.endorsement_hits.load(Ordering::Relaxed),
+            terminal_lease_observations: self.terminal_lease_observations.load(Ordering::Relaxed),
+            duplicate_terminal_lease_observations: self
+                .duplicate_terminal_lease_observations
+                .load(Ordering::Relaxed),
             demands: self.demands.load(Ordering::Relaxed),
             demand_reuses: self.demand_reuses.load(Ordering::Relaxed),
             demand_computes: self.demand_computes.load(Ordering::Relaxed),
@@ -2433,6 +2489,12 @@ impl AtomicValidationWork {
             memo_misses: self.memo_misses.swap(0, Ordering::Relaxed),
             endorsement_probes: self.endorsement_probes.swap(0, Ordering::Relaxed),
             endorsement_hits: self.endorsement_hits.swap(0, Ordering::Relaxed),
+            terminal_lease_observations: self
+                .terminal_lease_observations
+                .swap(0, Ordering::Relaxed),
+            duplicate_terminal_lease_observations: self
+                .duplicate_terminal_lease_observations
+                .swap(0, Ordering::Relaxed),
             demands: self.demands.swap(0, Ordering::Relaxed),
             demand_reuses: self.demand_reuses.swap(0, Ordering::Relaxed),
             demand_computes: self.demand_computes.swap(0, Ordering::Relaxed),
@@ -2466,6 +2528,8 @@ impl AtomicValidationWork {
             memo_misses,
             endorsement_probes,
             endorsement_hits,
+            terminal_lease_observations,
+            duplicate_terminal_lease_observations,
             demands,
             demand_reuses,
             demand_computes,
@@ -5802,8 +5866,8 @@ where
         // endorsement pin was acquired under the node lock, so there is no
         // instant in which it is both exposed and evictable.
         context.task.observe(terminal);
-        self.lease_observed_pin(&context.task, pin);
-        self.lease_observed_pin(&context.task, endorsed_pin);
+        self.lease_adopted_pin(&context.task, pin);
+        self.lease_adopted_pin(&context.task, endorsed_pin);
         Ok(())
     }
 
@@ -5936,16 +6000,39 @@ where
     /// terminals computed purely to validate a dependency (`observe_result ==
     /// false`) are speculative and their pins are dropped by the caller.
     fn lease_observed_pin(&self, task: &Arc<Task>, pin: TerminalPin<K, V>) {
+        task.validation_work
+            .terminal_lease_observations
+            .fetch_add(1, Ordering::Relaxed);
+        if !self.insert_task_lease(task, pin) {
+            task.validation_work
+                .duplicate_terminal_lease_observations
+                .fetch_add(1, Ordering::Relaxed);
+        }
+    }
+
+    /// Transfers exact terminals already held by the adoption capability.
+    /// Adoption never resolves a family key or visits its memo index, so it is
+    /// deliberately outside the repeated-query opportunity measured by
+    /// [`ValidationWork::terminal_lease_observations`].
+    fn lease_adopted_pin(&self, task: &Arc<Task>, pin: TerminalPin<K, V>) {
+        self.insert_task_lease(task, pin);
+    }
+
+    /// Inserts one exact terminal into the existing task lease set and reports
+    /// whether this task had not already leased it.
+    fn insert_task_lease(&self, task: &Arc<Task>, pin: TerminalPin<K, V>) -> bool {
         let mut leases = lock(&task.leases);
         let identity = (
             pin.terminal.node_incarnation,
             pin.terminal.stamp,
             pin.terminal.revision,
         );
-        if leases.observed.insert(identity) {
+        let inserted = leases.observed.insert(identity);
+        if inserted {
             leases.held.push(Box::new(pin));
             task.core.metrics.task_lease_acquired();
         }
+        inserted
     }
 
     /// Pins terminals computed under this exact retained revision.
@@ -8845,11 +8932,44 @@ mod tests {
         );
         assert!(work.registry_misses <= work.registry_probes);
         assert!(work.endorsement_hits <= work.endorsement_probes);
+        assert!(work.duplicate_terminal_lease_observations <= work.terminal_lease_observations);
         assert!(
             work.demand_reuses + work.demand_computes + work.demand_joins + work.demand_aborts
                 <= work.demands
         );
         assert!(work.certificates_published <= work.successful_traversals);
+    }
+
+    #[test]
+    fn exact_terminal_lease_observations_distinguish_first_and_duplicate() {
+        let runtime = QueryRuntime::new(1);
+        publish_empty(&runtime, [revision(1)]);
+        let leaf = runtime.family::<Key, u64>("lease-metrics-leaf", 8).unwrap();
+        let root = runtime.family::<Key, u64>("lease-metrics-root", 8).unwrap();
+        let leaf_for_root = leaf.clone();
+        let before = runtime.metrics().validation;
+
+        let attempt = runtime.request(
+            &root,
+            revision(1),
+            Key("root"),
+            CancellationToken::new(),
+            move |context| {
+                context.query(&leaf_for_root, Key("shared"), |_| {
+                    Ok(QueryOutput::success(1))
+                })?;
+                context.query(&leaf_for_root, Key("shared"), |_| {
+                    panic!("the second exact request must reuse the retained terminal")
+                })?;
+                Ok(QueryOutput::success(0))
+            },
+        );
+        assert_eq!(attempt.execution(), RequestExecution::Computed);
+        let work = runtime.metrics().validation.saturating_sub(before);
+
+        assert_eq!(work.terminal_lease_observations, 3);
+        assert_eq!(work.duplicate_terminal_lease_observations, 1);
+        assert_validation_work_consistent(work);
     }
 
     // A numeric key for tests that need an unbounded supply of distinct keys
@@ -15674,6 +15794,7 @@ mod tests {
             })
             .unwrap();
 
+        let before_adoption = runtime.metrics().validation;
         let dependent = runtime
             .query(
                 &dependents,
@@ -15692,6 +15813,12 @@ mod tests {
                 },
             )
             .unwrap();
+        let adoption_work = runtime.metrics().validation.saturating_sub(before_adoption);
+        assert_eq!(
+            adoption_work.terminal_lease_observations, 1,
+            "the dependent query is metered, but exact-capability adoption does not visit a query memo"
+        );
+        assert_eq!(adoption_work.duplicate_terminal_lease_observations, 0);
         // The recorded observation is the held terminal's exact identity.
         assert_eq!(dependent.dependencies().len(), 1);
         let observation = &dependent.dependencies()[0];

--- a/docs/designs/0068-incremental-edit-performance-measurement.md
+++ b/docs/designs/0068-incremental-edit-performance-measurement.md
@@ -178,6 +178,7 @@ Every raw observation records at least:
   available compiler phase;
 - exact retained-terminal validation traversals and outcomes, input/dependency
   observations, registry and memo results, registered-cone endorsements,
+  exact query-result terminal lease observations and same-task duplicates,
   re-demand outcomes, superseded incarnations, and published certificates;
 - current and peak retained artifact charge, dependency/input observations, and
   configured budgets;

--- a/performance/incremental.toml
+++ b/performance/incremental.toml
@@ -5,7 +5,7 @@
 # Fixture edits are added under a new `fixture_revision`; raw report syntax
 # advances independently under `report_schema_version`.
 schema_version = 2
-report_schema_version = 3
+report_schema_version = 4
 fixture_revision = 2
 # Two workloads each collect seven one-sample structural rows and one five-
 # sample latency row: 24 independent retained sessions in the scheduled matrix.


### PR DESCRIPTION
Fixes RUE-1330. Refs RUE-1247, RUE-1328, RUE-1329.

## Summary
- count exact query-terminal lease observations and same-task duplicates using the existing task lease-set insertion result
- aggregate structured child work without adding a lookup table, key formatting, or hot-path lock
- exclude exact-capability adoption because it already bypasses key resolution and the memo index
- project the counters through compiler metrics and ADR-0068 report schema v4 with strict validation

## Maintained Lattice evidence
- no-op: 1,358,813 observations; 19,416 duplicates (1.43%)
- reached-body: 1,430,798 observations; 72,397 duplicates (5.06%)

This keeps RUE-1247 in Backlog: the opportunity is real but does not explain the dominant first-observation validation traffic.

## Validation
- formatting
- focused query-runtime first/duplicate, structured-child aggregation, and adoption-exclusion tests
- focused compiler projection/delta test
- focused performance-schema conservation and strict-validation tests
- maintained Lattice no-op and reached-body measurements