### PR TITLE
RUE-1336: classify validation memo miss causes

### DIFF
--- a/crates/rue-bench/src/incremental.rs
+++ b/crates/rue-bench/src/incremental.rs
@@ -333,7 +333,7 @@ fn elapsed_ms(duration: Duration) -> u128 {
 
 fn validation_summary(work: QueryValidationMetrics) -> String {
     format!(
-        "walks {}/{}/{}/{} total/clean/dirty/abort, edges {}/{}, nodes {}/{}/{} hit/miss/cycle, registry {}/{}, demands {}/{}/{}/{}/{}, endorsements {}/{}, query terminal leases {}/{} attempts/duplicates, superseded {}, certificates {}",
+        "walks {}/{}/{}/{} total/clean/dirty/abort, edges {}/{}, nodes {}/{}/{} hit/miss/cycle (misses {}/{} certificate/proof-reacquisition), registry {}/{}, demands {}/{}/{}/{}/{}, endorsements {}/{}, query terminal leases {}/{} attempts/duplicates, superseded {}, certificates {}",
         work.traversals,
         work.successful_traversals,
         work.dirty_traversals,
@@ -343,6 +343,8 @@ fn validation_summary(work: QueryValidationMetrics) -> String {
         work.memo_hits,
         work.memo_misses,
         work.active_cycle_prunes,
+        work.certificate_misses,
+        work.proof_reacquisition_misses,
         work.registry_misses,
         work.registry_probes,
         work.demand_reuses,
@@ -893,6 +895,8 @@ fn report_validation_work(work: QueryValidationMetrics) -> ReportValidationWork 
         active_cycle_prunes: work.active_cycle_prunes,
         memo_hits: work.memo_hits,
         memo_misses: work.memo_misses,
+        certificate_misses: work.certificate_misses,
+        proof_reacquisition_misses: work.proof_reacquisition_misses,
         endorsement_probes: work.endorsement_probes,
         endorsement_hits: work.endorsement_hits,
         terminal_lease_observations: work.terminal_lease_observations,

--- a/crates/rue-compiler/src/unstable.rs
+++ b/crates/rue-compiler/src/unstable.rs
@@ -1628,6 +1628,8 @@ pub struct QueryValidationMetrics {
     pub active_cycle_prunes: u64,
     pub memo_hits: u64,
     pub memo_misses: u64,
+    pub certificate_misses: u64,
+    pub proof_reacquisition_misses: u64,
     pub endorsement_probes: u64,
     pub endorsement_hits: u64,
     pub terminal_lease_observations: u64,
@@ -1667,6 +1669,8 @@ impl QueryValidationMetrics {
             active_cycle_prunes: self.active_cycle_prunes,
             memo_hits: self.memo_hits,
             memo_misses: self.memo_misses,
+            certificate_misses: self.certificate_misses,
+            proof_reacquisition_misses: self.proof_reacquisition_misses,
             endorsement_probes: self.endorsement_probes,
             endorsement_hits: self.endorsement_hits,
             terminal_lease_observations: self.terminal_lease_observations,
@@ -1697,6 +1701,8 @@ impl From<rue_query::ValidationWork> for QueryValidationMetrics {
             active_cycle_prunes: work.active_cycle_prunes,
             memo_hits: work.memo_hits,
             memo_misses: work.memo_misses,
+            certificate_misses: work.certificate_misses,
+            proof_reacquisition_misses: work.proof_reacquisition_misses,
             endorsement_probes: work.endorsement_probes,
             endorsement_hits: work.endorsement_hits,
             terminal_lease_observations: work.terminal_lease_observations,
@@ -1717,13 +1723,19 @@ mod query_validation_metrics_tests {
     use super::QueryValidationMetrics;
 
     #[test]
-    fn exact_terminal_observations_survive_projection_and_deltas() {
+    fn validation_work_classification_survives_projection_and_deltas() {
         let before = rue_query::ValidationWork {
+            memo_misses: 3,
+            certificate_misses: 2,
+            proof_reacquisition_misses: 1,
             terminal_lease_observations: 7,
             duplicate_terminal_lease_observations: 2,
             ..Default::default()
         };
         let after = rue_query::ValidationWork {
+            memo_misses: 8,
+            certificate_misses: 5,
+            proof_reacquisition_misses: 3,
             terminal_lease_observations: 11,
             duplicate_terminal_lease_observations: 5,
             ..Default::default()
@@ -1732,6 +1744,9 @@ mod query_validation_metrics_tests {
         assert_eq!(QueryValidationMetrics::from(after).into_runtime(), after);
         let delta = QueryValidationMetrics::from(after)
             .saturating_sub(QueryValidationMetrics::from(before));
+        assert_eq!(delta.memo_misses, 5);
+        assert_eq!(delta.certificate_misses, 3);
+        assert_eq!(delta.proof_reacquisition_misses, 2);
         assert_eq!(delta.terminal_lease_observations, 4);
         assert_eq!(delta.duplicate_terminal_lease_observations, 3);
     }

--- a/crates/rue-perf-schema/src/incremental.rs
+++ b/crates/rue-perf-schema/src/incremental.rs
@@ -14,7 +14,7 @@ use serde::{Deserialize, Serialize};
 use crate::{EnvironmentFingerprint, median, median_absolute_deviation};
 
 /// Version of the retained-session raw report wire format.
-pub const EDIT_REPORT_SCHEMA_VERSION: u32 = 4;
+pub const EDIT_REPORT_SCHEMA_VERSION: u32 = 5;
 
 /// One retained-session edit class from ADR-0068's initial matrix.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
@@ -747,6 +747,10 @@ pub struct ValidationWork {
     pub memo_hits: u64,
     /// Node visits which inspected or re-demanded the node.
     pub memo_misses: u64,
+    /// Memo misses with no usable exact certificate and live matching terminal.
+    pub certificate_misses: u64,
+    /// Memo misses caused only by a registered proof scope lacking the exact lease.
+    pub proof_reacquisition_misses: u64,
     /// Registered-cone endorsement lookups.
     pub endorsement_probes: u64,
     /// Endorsement lookups satisfied by the rooted request.
@@ -1112,6 +1116,15 @@ fn validate_validation_work(
         errors.push(finding(
             path,
             "validation node visits do not equal cycle prunes, memo hits, and memo misses",
+        ));
+    }
+    let memo_miss_outcomes = work
+        .certificate_misses
+        .checked_add(work.proof_reacquisition_misses);
+    if memo_miss_outcomes != Some(work.memo_misses) {
+        errors.push(finding(
+            path,
+            "validation memo misses do not equal certificate and proof-reacquisition misses",
         ));
     }
 
@@ -1884,7 +1897,7 @@ mod tests {
 
     const MANIFEST: &str = r#"
 schema_version = 2
-report_schema_version = 4
+report_schema_version = 5
 fixture_revision = 3
 timing_samples_per_row = 5
 structural_samples_per_row = 1
@@ -2229,6 +2242,8 @@ minimum_memory_bytes = 15000000000
             active_cycle_prunes: 1,
             memo_hits: 1,
             memo_misses: 2,
+            certificate_misses: 1,
+            proof_reacquisition_misses: 1,
             endorsement_probes: 2,
             endorsement_hits: 1,
             terminal_lease_observations: 3,
@@ -2255,6 +2270,15 @@ minimum_memory_bytes = 15000000000
         }));
 
         measured.rows[0].samples[0].validation.node_visits -= 1;
+        measured.rows[0].samples[0].validation.certificate_misses += 1;
+        let validation = validate_edit_report(&manifest, &measured);
+        assert!(validation.errors.iter().any(|error| {
+            error
+                .detail
+                .contains("memo misses do not equal certificate")
+        }));
+
+        measured.rows[0].samples[0].validation.certificate_misses -= 1;
         measured.rows[0].samples[0]
             .validation
             .duplicate_terminal_lease_observations = 4;
@@ -2333,8 +2357,8 @@ minimum_memory_bytes = 15000000000
 
         let json = serde_json::to_string(&report(&manifest)).unwrap();
         let unknown = json.replacen(
-            "\"schema_version\":4",
-            "\"schema_version\":4,\"surprise\":true",
+            "\"schema_version\":5",
+            "\"schema_version\":5,\"surprise\":true",
             1,
         );
         assert!(

--- a/crates/rue-query/src/lib.rs
+++ b/crates/rue-query/src/lib.rs
@@ -2318,6 +2318,10 @@ pub struct ValidationWork {
     pub memo_hits: u64,
     /// Node visits which had to inspect or re-demand the node.
     pub memo_misses: u64,
+    /// Memo misses with no usable exact certificate and live matching terminal.
+    pub certificate_misses: u64,
+    /// Memo misses caused only by a registered proof scope lacking the exact lease.
+    pub proof_reacquisition_misses: u64,
     /// Exact registered-cone endorsement lookups.
     pub endorsement_probes: u64,
     /// Endorsement lookups satisfied by this rooted request's retained cone.
@@ -2366,6 +2370,8 @@ impl ValidationWork {
             active_cycle_prunes,
             memo_hits,
             memo_misses,
+            certificate_misses,
+            proof_reacquisition_misses,
             endorsement_probes,
             endorsement_hits,
             terminal_lease_observations,
@@ -2400,6 +2406,8 @@ impl ValidationWork {
             active_cycle_prunes,
             memo_hits,
             memo_misses,
+            certificate_misses,
+            proof_reacquisition_misses,
             endorsement_probes,
             endorsement_hits,
             terminal_lease_observations,
@@ -2429,6 +2437,8 @@ struct AtomicValidationWork {
     active_cycle_prunes: AtomicU64,
     memo_hits: AtomicU64,
     memo_misses: AtomicU64,
+    certificate_misses: AtomicU64,
+    proof_reacquisition_misses: AtomicU64,
     endorsement_probes: AtomicU64,
     endorsement_hits: AtomicU64,
     terminal_lease_observations: AtomicU64,
@@ -2457,6 +2467,8 @@ impl AtomicValidationWork {
             active_cycle_prunes: self.active_cycle_prunes.load(Ordering::Relaxed),
             memo_hits: self.memo_hits.load(Ordering::Relaxed),
             memo_misses: self.memo_misses.load(Ordering::Relaxed),
+            certificate_misses: self.certificate_misses.load(Ordering::Relaxed),
+            proof_reacquisition_misses: self.proof_reacquisition_misses.load(Ordering::Relaxed),
             endorsement_probes: self.endorsement_probes.load(Ordering::Relaxed),
             endorsement_hits: self.endorsement_hits.load(Ordering::Relaxed),
             terminal_lease_observations: self.terminal_lease_observations.load(Ordering::Relaxed),
@@ -2487,6 +2499,8 @@ impl AtomicValidationWork {
             active_cycle_prunes: self.active_cycle_prunes.swap(0, Ordering::Relaxed),
             memo_hits: self.memo_hits.swap(0, Ordering::Relaxed),
             memo_misses: self.memo_misses.swap(0, Ordering::Relaxed),
+            certificate_misses: self.certificate_misses.swap(0, Ordering::Relaxed),
+            proof_reacquisition_misses: self.proof_reacquisition_misses.swap(0, Ordering::Relaxed),
             endorsement_probes: self.endorsement_probes.swap(0, Ordering::Relaxed),
             endorsement_hits: self.endorsement_hits.swap(0, Ordering::Relaxed),
             terminal_lease_observations: self
@@ -2526,6 +2540,8 @@ impl AtomicValidationWork {
             active_cycle_prunes,
             memo_hits,
             memo_misses,
+            certificate_misses,
+            proof_reacquisition_misses,
             endorsement_probes,
             endorsement_hits,
             terminal_lease_observations,
@@ -4293,6 +4309,7 @@ where
                 .fetch_add(1, Ordering::Relaxed);
             return Ok(None);
         }
+        let mut proof_reacquisition_miss = false;
         {
             let state = lock(&self.state);
             if let Some((revision, stamp, registered_only)) = state.validated_at
@@ -4304,26 +4321,38 @@ where
                             if terminal.stamp == stamp
                     )
                 })
+            {
                 // A registered-cone endorsement is also a retention proof. A
                 // memo may skip validation in that scope only after this task
                 // has already leased the exact node/stamp; otherwise the
                 // ordinary demand reconstructs and pins its transitive cone.
-                && (!task.validation_endorsements_active()
-                    || task.validation_endorsed_identity(self.incarnation, stamp))
-            {
-                if !registered_only {
-                    task.taint_validation_proofs();
+                if !task.validation_endorsements_active()
+                    || task.validation_endorsed_identity(self.incarnation, stamp)
+                {
+                    if !registered_only {
+                        task.taint_validation_proofs();
+                    }
+                    task.validation_work
+                        .memo_hits
+                        .fetch_add(1, Ordering::Relaxed);
+                    active.remove(&self.incarnation);
+                    return Ok(Some(stamp));
                 }
-                task.validation_work
-                    .memo_hits
-                    .fetch_add(1, Ordering::Relaxed);
-                active.remove(&self.incarnation);
-                return Ok(Some(stamp));
+                proof_reacquisition_miss = true;
             }
         }
         task.validation_work
             .memo_misses
             .fetch_add(1, Ordering::Relaxed);
+        if proof_reacquisition_miss {
+            task.validation_work
+                .proof_reacquisition_misses
+                .fetch_add(1, Ordering::Relaxed);
+        } else {
+            task.validation_work
+                .certificate_misses
+                .fetch_add(1, Ordering::Relaxed);
+        }
         if let Some(demand) = &self.demand {
             task.validation_work.demands.fetch_add(1, Ordering::Relaxed);
             #[cfg(test)]
@@ -8926,6 +8955,11 @@ mod tests {
             "every erased-node visit has exactly one outcome"
         );
         assert_eq!(
+            work.memo_misses,
+            work.certificate_misses + work.proof_reacquisition_misses,
+            "every memo miss has exactly one cause"
+        );
+        assert_eq!(
             work.registry_probes,
             work.dependency_observations + work.successful_traversals,
             "validation probes once per dependency and successful root certificate"
@@ -12666,6 +12700,8 @@ mod tests {
         let validation = after.validation.saturating_sub(before.validation);
         assert_validation_work_consistent(validation);
         assert_eq!(validation.memo_misses, 3);
+        assert_eq!(validation.certificate_misses, 3);
+        assert_eq!(validation.proof_reacquisition_misses, 0);
         assert_eq!(
             validation.memo_hits, 1,
             "the second edge into the shared leaf uses its revision memo"
@@ -12679,6 +12715,90 @@ mod tests {
             1,
             "the shared leaf is re-demanded only on its first path"
         );
+    }
+
+    #[test]
+    fn registered_batch_counts_current_certificates_rejected_for_missing_proof_lease() {
+        let runtime = QueryRuntime::new(1);
+        let first = Revision::new(30, 12);
+        let second = Revision::new(31, 12);
+        let input = InputIdentity::new("source", "proof-reacquisition");
+        runtime
+            .publish_revision(first, [(input.clone(), 1)])
+            .unwrap();
+        runtime
+            .publish_revision(second, [(input.clone(), 1)])
+            .unwrap();
+
+        let input_for_leaf = input.clone();
+        let leaf = runtime
+            .family_with_evaluator::<Key, u64, _>(
+                "proof-reacquisition-leaf",
+                8,
+                move |context, _, _| {
+                    context.input(input_for_leaf.clone())?;
+                    Ok(QueryOutput::success(1))
+                },
+            )
+            .unwrap();
+        let leaf_for_middle = leaf.clone();
+        let middle = runtime
+            .family_with_evaluator::<Key, u64, _>(
+                "proof-reacquisition-middle",
+                8,
+                move |context, _, _| {
+                    context.query_registered(&leaf_for_middle, Key("leaf"))?;
+                    Ok(QueryOutput::success(2))
+                },
+            )
+            .unwrap();
+        let middle_for_top = middle.clone();
+        let top = runtime
+            .family_with_evaluator::<Key, u64, _>(
+                "proof-reacquisition-top",
+                8,
+                move |context, _, _| {
+                    context.query_registered(&middle_for_top, Key("middle"))?;
+                    Ok(QueryOutput::success(3))
+                },
+            )
+            .unwrap();
+
+        runtime
+            .request_registered(&top, first, Key("top"), CancellationToken::new())
+            .into_result()
+            .unwrap();
+        runtime
+            .request_registered(&top, second, Key("top"), CancellationToken::new())
+            .into_result()
+            .unwrap();
+
+        let before = runtime.metrics().validation;
+        let root = runtime
+            .family::<Key, u64>("proof-reacquisition-root", 1)
+            .unwrap();
+        let top_for_root = top.clone();
+        runtime
+            .request(
+                &root,
+                second,
+                Key("root"),
+                CancellationToken::new(),
+                move |context| {
+                    let _proof = context.endorse_registered_validations();
+                    context.query_registered_batch(&top_for_root, [Key("top")])?;
+                    Ok(QueryOutput::success(0))
+                },
+            )
+            .into_result()
+            .unwrap();
+
+        let validation = runtime.metrics().validation.saturating_sub(before);
+        assert_validation_work_consistent(validation);
+        assert_eq!(validation.certificate_misses, 0);
+        assert_eq!(validation.proof_reacquisition_misses, 2);
+        assert_eq!(validation.memo_misses, 2);
+        assert_eq!(validation.demand_reuses, 2);
     }
 
     #[test]

--- a/docs/designs/0068-incremental-edit-performance-measurement.md
+++ b/docs/designs/0068-incremental-edit-performance-measurement.md
@@ -177,7 +177,8 @@ Every raw observation records at least:
 - exact computed, reused, joined, invalidated, canceled, and evicted work by
   available compiler phase;
 - exact retained-terminal validation traversals and outcomes, input/dependency
-  observations, registry and memo results, registered-cone endorsements,
+  observations, registry and memo results including certificate versus
+  retention-proof-reacquisition misses, registered-cone endorsements,
   exact query-result terminal lease observations and same-task duplicates,
   re-demand outcomes, superseded incarnations, and published certificates;
 - current and peak retained artifact charge, dependency/input observations, and

--- a/performance/incremental.toml
+++ b/performance/incremental.toml
@@ -5,7 +5,7 @@
 # Fixture edits are added under a new `fixture_revision`; raw report syntax
 # advances independently under `report_schema_version`.
 schema_version = 2
-report_schema_version = 4
+report_schema_version = 5
 fixture_revision = 2
 # Two workloads each collect seven one-sample structural rows and one five-
 # sample latency row: 24 independent retained sessions in the scheduled matrix.


### PR DESCRIPTION
## Summary

- split validation memo misses into missing-current-certificate and retention-proof-reacquisition causes
- preserve exact task-local counter aggregation and add strict conservation validation
- surface both causes through compiler metrics and ADR-0068 report schema v5
- add deterministic runtime, batch aggregation, projection, and schema tests

## Why

The aggregate memo-miss count could not distinguish real red/green validation work from a current certificate rejected only because a new rooted request had not yet acquired the exact retention proof. Maintained Lattice measurements now show that proof reacquisition accounts for 97.54% of no-op misses and 97.98% of reached-body misses, identifying the next optimization target without relying on noisy wall time.

## Validation

- focused `rue-query` certificate/proof-reacquisition and batch aggregation test
- focused `rue-perf-schema` conservation and unknown-field tests
- focused `rue-compiler` metric projection/delta test
- maintained Lattice no-op and reached-body diagnostic rows, both with matching warm/fresh oracles
- `scripts/rue fmt`

Fixes RUE-1336.
