### PR TITLE
Overnight cycle 2, wave 2: @bitCast, RIR typed boundary, deterministic anonymous-symbol ordinals

### DIFF
--- a/crates/rue-air/src/inference/generate.rs
+++ b/crates/rue-air/src/inference/generate.rs
@@ -1704,8 +1704,13 @@ impl<'a> ConstraintGenerator<'a> {
                 let intrinsic_name = self.interner.resolve(name);
                 let args = self.rir.intrinsic_args(args);
 
-                if intrinsic_name == "intCast" || intrinsic_name == "cast" {
+                if intrinsic_name == "intCast"
+                    || intrinsic_name == "bitCast"
+                    || intrinsic_name == "cast"
+                {
                     // @intCast: target type is inferred from context.
+                    // @bitCast: the same context-supplied target (RUE-952); sema
+                    // additionally requires the two widths to agree (E0950).
                     // @cast: a fresh var here too, so sema can reject it with a
                     // clean "use @intCast" diagnostic instead of inference
                     // masking it with a type-mismatch error (RUE-319).

--- a/crates/rue-air/src/sema/analysis/intrinsics.rs
+++ b/crates/rue-air/src/sema/analysis/intrinsics.rs
@@ -306,6 +306,8 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
             self.analyze_drop_intrinsic(air, &args, span, ctx)
         } else if name == known.int_cast {
             self.analyze_intcast_intrinsic(air, inst_ref, &args, span, ctx)
+        } else if name == known.bit_cast {
+            self.analyze_bitcast_intrinsic(air, name, inst_ref, &args, span, ctx)
         } else if name == known.test_preview_gate {
             self.analyze_test_preview_gate_intrinsic(air, &args, span)
         } else if name == known.read_line {
@@ -1153,6 +1155,103 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
             ty: target_ty,
             span,
         });
+        Ok(AnalysisResult::new(air_ref, target_ty))
+    }
+
+    /// Analyze the `@bitCast` intrinsic (RUE-952, spec 4.13:118-4.13:123).
+    ///
+    /// `@bitCast` is the same-width sibling of `@intCast`: it renames the
+    /// operand's two's-complement bit pattern at the target type instead of
+    /// preserving its numeric value, so it is total (it never traps) and is the
+    /// only way to move a `u64` with its top bit set into an `i64`. The target
+    /// type comes from context exactly as `@intCast`'s does, and the widths
+    /// **must** agree — a reinterpretation neither invents nor discards bits, so
+    /// a cross-width use is E0950 rather than a silent truncation.
+    ///
+    /// Because the operation only renames bits, it lowers to an ordinary
+    /// intrinsic node (like `@ptr_to_int`) rather than to `IntCast`, which owns
+    /// the range check.
+    pub(super) fn analyze_bitcast_intrinsic(
+        &mut self,
+        air: &mut Air,
+        name: Spur,
+        inst_ref: InstRef,
+        args: &[RirCallArg],
+        span: Span,
+        ctx: &mut AnalysisContext,
+    ) -> CompileResult<AnalysisResult> {
+        let intrinsic_name = "bitCast";
+
+        if args.len() != 1 {
+            return Err(CompileError::new(
+                ErrorKind::IntrinsicWrongArgCount {
+                    name: intrinsic_name.to_string(),
+                    expected: 1,
+                    found: args.len(),
+                },
+                span,
+            ));
+        }
+
+        let arg_result = self.analyze_inst(air, args[0].value, ctx)?;
+        let from_ty = arg_result.ty;
+
+        if !from_ty.is_integer() {
+            return Err(CompileError::new(
+                ErrorKind::IntrinsicTypeMismatch(Box::new(IntrinsicTypeMismatchError {
+                    name: intrinsic_name.to_string(),
+                    expected: "integer".to_string(),
+                    found: from_ty.safe_name_with_pool(Some(self.body_type_pool())),
+                })),
+                span,
+            ));
+        }
+
+        // The target type comes from HM inference, exactly as `@intCast`'s does:
+        // an annotation, a parameter, or a return position supplies it, and an
+        // unconstrained result is the same "cannot infer the cast target"
+        // diagnostic (RUE-588) rather than an unrelated fallback.
+        let target_ty = match ctx.resolved_type_of(inst_ref) {
+            Some(ty) if ty.is_integer() => ty,
+            Some(Type::ERROR) | None => {
+                return Err(CompileError::new(
+                    ErrorKind::CannotInferCastTarget(intrinsic_name.to_string()),
+                    span,
+                ));
+            }
+            Some(ty) => {
+                return Err(CompileError::new(
+                    ErrorKind::IntrinsicTypeMismatch(Box::new(IntrinsicTypeMismatchError {
+                        name: intrinsic_name.to_string(),
+                        expected: "integer".to_string(),
+                        found: ty.safe_name_with_pool(Some(self.body_type_pool())),
+                    })),
+                    span,
+                ));
+            }
+        };
+
+        // Same-width only (E0950). Both types are integers here, so both widths
+        // are present.
+        let from_bits = from_ty.int_bit_width().unwrap_or(0);
+        let to_bits = target_ty.int_bit_width().unwrap_or(0);
+        if from_bits != to_bits {
+            return Err(CompileError::new(
+                ErrorKind::BitCastWidthMismatch {
+                    from: from_ty.safe_name_with_pool(Some(self.body_type_pool())),
+                    to: target_ty.safe_name_with_pool(Some(self.body_type_pool())),
+                    from_bits,
+                    to_bits,
+                },
+                span,
+            )
+            .with_help(
+                "'@bitCast' reinterprets a value's bits at the same width; use \
+                 '@intCast' to convert between widths",
+            ));
+        }
+
+        let air_ref = air.add_intrinsic(None, name, &[arg_result.air_ref], target_ty, span)?;
         Ok(AnalysisResult::new(air_ref, target_ty))
     }
 

--- a/crates/rue-air/src/sema/known_symbols.rs
+++ b/crates/rue-air/src/sema/known_symbols.rs
@@ -42,6 +42,10 @@ pub struct KnownSymbols {
     pub drop: Spur,
     /// The `intCast` intrinsic symbol (deprecated, use `cast`).
     pub int_cast: Spur,
+    /// The `bitCast` intrinsic symbol — same-width two's-complement
+    /// reinterpretation between integer types (RUE-952, spec 4.13:118). Unlike
+    /// `intCast` it preserves the bits rather than the value, and never traps.
+    pub bit_cast: Spur,
     /// The `cast` intrinsic symbol.
     pub cast: Spur,
     /// The `panic` intrinsic symbol.
@@ -185,6 +189,7 @@ impl KnownSymbols {
             dbg: interner.get_or_intern_static("dbg"),
             drop: interner.get_or_intern_static("drop"),
             int_cast: interner.get_or_intern_static("intCast"),
+            bit_cast: interner.get_or_intern_static("bitCast"),
             cast: interner.get_or_intern_static("cast"),
             panic: interner.get_or_intern_static("panic"),
             assert: interner.get_or_intern_static("assert"),
@@ -276,6 +281,7 @@ mod tests {
         assert_eq!(interner.resolve(&known.dbg), "dbg");
         assert_eq!(interner.resolve(&known.drop), "drop");
         assert_eq!(interner.resolve(&known.int_cast), "intCast");
+        assert_eq!(interner.resolve(&known.bit_cast), "bitCast");
         assert_eq!(interner.resolve(&known.cast), "cast");
         assert_eq!(interner.resolve(&known.panic), "panic");
         assert_eq!(interner.resolve(&known.assert), "assert");

--- a/crates/rue-air/src/stable_digest.rs
+++ b/crates/rue-air/src/stable_digest.rs
@@ -5,6 +5,7 @@
 //! module. Keeping the stable-content encoding here prevents the two paths
 //! from drifting while the provider replaces the epoch.
 
+use std::collections::{BTreeMap, BTreeSet};
 use std::hash::{Hash, Hasher};
 
 use crate::AnonymousNominalKey;
@@ -91,19 +92,303 @@ pub fn stable_anonymous_identity_digest(identity: &AnonymousNominalKey<String, S
     hasher.digest()
 }
 
+/// Infix that separates a base digest from its collision-disambiguating
+/// ordinal. Its `$` is not a hex digit and not a legal identifier character —
+/// the same generated-name punctuation `named_nominal_source_symbol` already
+/// qualifies with — so a disambiguated component can never be re-read as a bare
+/// 32-hex digest, and [`crate::mangle_symbol_component`] escapes it to a
+/// portable object-symbol byte like every other generated-name character.
+const ANONYMOUS_SYMBOL_DISAMBIGUATOR: &str = "$c";
+
+/// Spell the digest component of one anonymous symbol.
+///
+/// `ordinal` is `None` for the overwhelmingly common case — a digest owned by
+/// exactly one producer-nominal identity — and the component is then the bare
+/// 32-hex digest, byte-identical to the pre-RUE-1114 spelling. It is `Some(i)`
+/// for every member of a verified collision class, where `i` is the member's
+/// rank under [`anonymous_symbol_ordinals`].
+///
+/// EVERY member of a collision class carries an explicit ordinal: no member
+/// silently keeps the unqualified spelling, so the scheme has no
+/// first-registrant (nor minimum-registrant) winner. The component stays
+/// bounded — 32 hex digits plus a two-byte infix plus at most ten decimal
+/// digits — because an ordinal cannot exceed the size of the reached set.
+pub fn stable_anonymous_symbol_component(digest: u128, ordinal: Option<u32>) -> String {
+    match ordinal {
+        None => format!("{digest:032x}"),
+        Some(ordinal) => format!("{digest:032x}{ANONYMOUS_SYMBOL_DISAMBIGUATOR}{ordinal}"),
+    }
+}
+
+/// Deterministically disambiguate verified anonymous symbol digest collisions
+/// over one COMPLETE set of reached anonymous identities (RUE-1114).
+///
+/// Input is `(digest, identity)` for every anonymous nominal in the set, so a
+/// caller that narrows digests (the forced-collision test hooks) feeds the same
+/// rule as production. Identities are the request-independent stable-content
+/// form: their total order is a function of module paths, definition names,
+/// structural anchors, and canonical arguments only — never of a session-issued
+/// token, a traversal position, or an arrival order. That is what makes the
+/// result reproducible rather than merely deterministic within one process.
+///
+/// A digest owned by one identity is absent from the result (bare spelling
+/// retained). A digest owned by two or more DISTINCT identities yields an entry
+/// per member, ranked by that stable total order. Ranking is therefore
+/// order-independent by construction: the input is folded into ordered sets
+/// before any ordinal exists, so permuting the input — or discovering the same
+/// set across separate body transactions, or recompiling incrementally — cannot
+/// move a member.
+///
+/// The exact identity, not the digest, remains the sole semantic authority; this
+/// only decides how a collision class is SPELLED.
+pub fn anonymous_symbol_ordinals<I>(
+    entries: I,
+) -> BTreeMap<AnonymousNominalKey<String, String>, u32>
+where
+    I: IntoIterator<Item = (u128, AnonymousNominalKey<String, String>)>,
+{
+    let mut classes: BTreeMap<u128, BTreeSet<AnonymousNominalKey<String, String>>> =
+        BTreeMap::new();
+    for (digest, identity) in entries {
+        classes.entry(digest).or_default().insert(identity);
+    }
+    let mut ordinals = BTreeMap::new();
+    for members in classes.into_values() {
+        if members.len() < 2 {
+            continue;
+        }
+        for (ordinal, member) in members.into_iter().enumerate() {
+            let ordinal = u32::try_from(ordinal)
+                .expect("a reached anonymous collision class cannot exceed u32::MAX members");
+            ordinals.insert(member, ordinal);
+        }
+    }
+    ordinals
+}
+
 #[cfg(test)]
 mod tests {
+    use std::collections::{BTreeMap, BTreeSet};
     use std::sync::Arc;
 
     use rue_rir::{RirStructuralAnchor, RirStructuralPathSegment};
 
     use super::{
-        stable_anonymous_identity_digest, stable_definition_component, stable_module_component,
+        anonymous_symbol_ordinals, stable_anonymous_identity_digest,
+        stable_anonymous_symbol_component, stable_definition_component, stable_module_component,
     };
     use crate::{
         AnonymousNominalKey, AnonymousNominalKind, CanonicalArgumentValue, CanonicalArguments,
         StableProducerId,
     };
+
+    /// A stable-content anonymous identity distinguished only by its producer
+    /// definition component and site anchor — the two coordinates the RUE-1114
+    /// total order is built on.
+    fn identity(
+        kind: AnonymousNominalKind,
+        producer: &str,
+        site: u32,
+    ) -> AnonymousNominalKey<String, String> {
+        AnonymousNominalKey {
+            kind,
+            producer: StableProducerId::Definition(stable_definition_component(
+                "pkg/m.rue",
+                producer,
+                None,
+                3,
+            )),
+            anchor: RirStructuralAnchor::new(vec![
+                RirStructuralPathSegment::Body,
+                RirStructuralPathSegment::AnonymousType(site),
+            ]),
+            arguments: CanonicalArguments {
+                types: Arc::new([]),
+                values: Arc::new([]),
+            },
+        }
+    }
+
+    /// The four distinct sites every disambiguation test forces onto one
+    /// digest: two kinds crossed with two producers, so struct/enum parity and
+    /// producer separation are both covered by one class.
+    fn colliding_sites() -> Vec<AnonymousNominalKey<String, String>> {
+        vec![
+            identity(AnonymousNominalKind::Struct, "First", 0),
+            identity(AnonymousNominalKind::Enum, "First", 0),
+            identity(AnonymousNominalKind::Struct, "Second", 1),
+            identity(AnonymousNominalKind::Enum, "Second", 1),
+        ]
+    }
+
+    /// Spell every member of a forced-collision set, so a test can compare
+    /// whole symbol tables rather than individual ordinals.
+    fn symbol_table(
+        forced: u128,
+        sites: &[AnonymousNominalKey<String, String>],
+    ) -> BTreeMap<AnonymousNominalKey<String, String>, String> {
+        let ordinals = anonymous_symbol_ordinals(sites.iter().map(|site| (forced, site.clone())));
+        sites
+            .iter()
+            .map(|site| {
+                (
+                    site.clone(),
+                    stable_anonymous_symbol_component(forced, ordinals.get(site).copied()),
+                )
+            })
+            .collect()
+    }
+
+    /// A digest owned by exactly one identity keeps the bare 32-hex spelling:
+    /// the disambiguation scheme is inert for every collision-free program, so
+    /// no existing symbol table moves.
+    #[test]
+    fn a_solitary_digest_owner_keeps_the_bare_spelling() {
+        let sites = colliding_sites();
+        let ordinals = anonymous_symbol_ordinals(
+            sites
+                .iter()
+                .enumerate()
+                .map(|(index, site)| (index as u128, site.clone())),
+        );
+        assert!(ordinals.is_empty(), "distinct digests need no ordinal");
+        assert_eq!(
+            stable_anonymous_symbol_component(0x2a, None),
+            "0000000000000000000000000000002a"
+        );
+    }
+
+    /// Every member of a verified collision class is spelled distinctly, and
+    /// NO member keeps the unqualified spelling — the property that rules out
+    /// first-registrant (and minimum-registrant) winners.
+    #[test]
+    fn a_collision_class_spells_every_member_distinctly_and_explicitly() {
+        let forced = 0x1114;
+        let sites = colliding_sites();
+        let table = symbol_table(forced, &sites);
+        let bare = stable_anonymous_symbol_component(forced, None);
+        assert_eq!(table.len(), sites.len());
+        assert_eq!(
+            table.values().collect::<BTreeSet<_>>().len(),
+            sites.len(),
+            "two colliding sites share a symbol"
+        );
+        for symbol in table.values() {
+            assert_ne!(*symbol, bare, "a collision member kept the bare spelling");
+            assert!(symbol.starts_with(&bare));
+            assert!(symbol.len() <= bare.len() + "$c".len() + 10, "unbounded");
+        }
+        assert_eq!(
+            table.values().cloned().collect::<BTreeSet<_>>(),
+            BTreeSet::from([
+                format!("{bare}$c0"),
+                format!("{bare}$c1"),
+                format!("{bare}$c2"),
+                format!("{bare}$c3"),
+            ])
+        );
+    }
+
+    /// Order independence, stated over the observable artifact: the symbol
+    /// table is identical under every permutation of discovery order. This is
+    /// the reproducible-build property — input order, scheduling, and
+    /// cold/warm reuse all reduce to a permutation of the same reached set.
+    #[test]
+    fn collision_spelling_is_independent_of_discovery_order() {
+        let forced = 0x1114;
+        let sites = colliding_sites();
+        let expected = symbol_table(forced, &sites);
+
+        let mut permutations = 0;
+        // All 24 orderings of the four-member class, enumerated through the
+        // factorial number system: pick the a-th remaining site, then the b-th,
+        // and so on. No permutation may change a single spelling.
+        for a in 0..4 {
+            for b in 0..3 {
+                for c in 0..2 {
+                    let mut permutation = sites.clone();
+                    let first = permutation.remove(a);
+                    let second = permutation.remove(b);
+                    let third = permutation.remove(c);
+                    let rest = permutation.remove(0);
+                    let permuted = vec![first, second, third, rest];
+                    assert_eq!(
+                        symbol_table(forced, &permuted),
+                        expected,
+                        "discovery order changed the symbol table"
+                    );
+                    permutations += 1;
+                }
+            }
+        }
+        assert_eq!(permutations, 24);
+    }
+
+    /// Stability across recompiles: recomputing the plan from the same reached
+    /// set — the incremental warm/successor-revision case — reproduces the same
+    /// table, and a member REMOVED from the set never renames a member that
+    /// stays, as long as its own class membership is unchanged.
+    #[test]
+    fn collision_spelling_is_stable_across_recomputation_and_unrelated_edits() {
+        let forced = 0x1114;
+        let sites = colliding_sites();
+        let first = symbol_table(forced, &sites);
+        assert_eq!(symbol_table(forced, &sites), first);
+
+        // An unrelated site joins the reached set under its OWN digest: it is
+        // not a class member, so no colliding member is renamed.
+        let mut widened: Vec<(u128, AnonymousNominalKey<String, String>)> =
+            sites.iter().map(|site| (forced, site.clone())).collect();
+        let unrelated = identity(AnonymousNominalKind::Struct, "Unrelated", 7);
+        widened.push((forced ^ 0xff, unrelated.clone()));
+        let widened = anonymous_symbol_ordinals(widened);
+        assert!(!widened.contains_key(&unrelated));
+        for site in &sites {
+            assert_eq!(
+                stable_anonymous_symbol_component(forced, widened.get(site).copied()),
+                first[site]
+            );
+        }
+    }
+
+    /// Presenting the same identity twice is legitimate reuse, not a
+    /// collision: the class is deduplicated by exact key before ranking.
+    #[test]
+    fn repeating_one_identity_is_not_a_collision() {
+        let site = identity(AnonymousNominalKind::Struct, "First", 0);
+        let ordinals = anonymous_symbol_ordinals([(7, site.clone()), (7, site.clone()), (7, site)]);
+        assert!(ordinals.is_empty());
+    }
+
+    /// Ordinals are class-local: two separate collision classes each rank from
+    /// zero, so a symbol is `(digest, ordinal)` and never a global counter that
+    /// a third class could shift.
+    #[test]
+    fn ordinals_are_local_to_their_collision_class() {
+        let left = colliding_sites();
+        let right = vec![
+            identity(AnonymousNominalKind::Struct, "Third", 2),
+            identity(AnonymousNominalKind::Struct, "Fourth", 3),
+        ];
+        let ordinals = anonymous_symbol_ordinals(
+            left.iter()
+                .map(|site| (0xaaaa, site.clone()))
+                .chain(right.iter().map(|site| (0xbbbb, site.clone()))),
+        );
+        assert_eq!(
+            left.iter()
+                .map(|site| ordinals[site])
+                .collect::<BTreeSet<_>>(),
+            BTreeSet::from([0, 1, 2, 3])
+        );
+        assert_eq!(
+            right
+                .iter()
+                .map(|site| ordinals[site])
+                .collect::<BTreeSet<_>>(),
+            BTreeSet::from([0, 1])
+        );
+    }
 
     #[test]
     fn anonymous_identity_digest_encoding_is_stable() {

--- a/crates/rue-air/src/types.rs
+++ b/crates/rue-air/src/types.rs
@@ -2110,4 +2110,220 @@ mod tests {
         assert_eq!(Type::UNIT.int_min(), None);
         assert_eq!(Type::UNIT.int_max(), None);
     }
+
+    /// The shape a declared type has once the intake helpers above have taken
+    /// it apart again, expressed independently of the text that carried it.
+    #[derive(Debug, PartialEq, Eq)]
+    enum Decomposed {
+        /// A leaf the intake helpers do not decompose: a primitive, a
+        /// user-defined name, a dotted path, `()`, `!`, or a slice.
+        Leaf(String),
+        Array(Box<Decomposed>, ArrayLen),
+        Ptr(Box<Decomposed>, PtrMutability),
+        Call(String, Vec<Decomposed>),
+    }
+
+    /// Take a declared type apart with the intake helpers, in the order
+    /// `resolve_semantic_type_syntax` applies them (array, pointer, type call).
+    fn decompose(syntax: &str) -> Decomposed {
+        if let Some((element, length)) = parse_array_type_syntax(syntax) {
+            return Decomposed::Array(Box::new(decompose(&element)), length);
+        }
+        if let Some((pointee, mutability)) = parse_pointer_type_syntax(syntax) {
+            return Decomposed::Ptr(Box::new(decompose(&pointee)), mutability);
+        }
+        if let Some((callee, arguments)) = parse_type_call_syntax(syntax) {
+            return Decomposed::Call(callee, arguments.iter().map(|a| decompose(a)).collect());
+        }
+        Decomposed::Leaf(syntax.to_owned())
+    }
+
+    fn leaf(name: &str) -> Decomposed {
+        Decomposed::Leaf(name.to_owned())
+    }
+
+    /// The type RIR carries for `f`'s single parameter, exactly as semantic
+    /// analysis receives it.
+    fn declared_parameter_type(annotation: &str) -> String {
+        let source = format!("fn f(p: {annotation}) -> i32 {{ 0 }}");
+        let (tokens, interner) = rue_lexer::Lexer::new(&source).tokenize().unwrap();
+        let (ast, interner) = rue_parser::Parser::new(tokens, interner).parse().unwrap();
+        let mut astgen = rue_rir::AstGen::with_symbol_normalizer(&interner, |symbol| symbol);
+        astgen.append_items(&ast.items);
+        let rir = astgen.finish();
+        let params = rir
+            .iter()
+            .find_map(|(_, instruction)| match &instruction.data {
+                rue_rir::InstData::FnDecl { params, .. } => Some(params.clone()),
+                _ => None,
+            })
+            .expect("lowered function declaration");
+        let params = rir.params(&params);
+        assert_eq!(params.len(), 1, "one declared parameter for {annotation}");
+        interner.resolve(&params.get(0).unwrap().ty).to_owned()
+    }
+
+    /// RUE-791: parser `TypeExpr` -> RIR text -> semantic intake is a peer
+    /// grammar with two independent halves, so every declarable type shape is
+    /// pinned end to end here: the exact text `AstGen` renders, and the exact
+    /// structure this module's helpers recover from it. A renderer change that
+    /// the intake cannot take apart again (or that silently reassociates
+    /// nesting) fails here rather than in whichever later phase first misreads
+    /// the type. Anonymous `struct`/`enum` types are absent by construction:
+    /// they are rejected in type-annotation position and reach RIR as their own
+    /// instructions, never as declared type text.
+    #[test]
+    fn declared_type_syntax_round_trips_through_the_semantic_intake() {
+        let cases: Vec<(&str, &str, Decomposed)> = vec![
+            // TypeExpr::Named
+            ("i32", "i32", leaf("i32")),
+            ("MyType", "MyType", leaf("MyType")),
+            // TypeExpr::Qualified
+            ("shapes.Point", "shapes.Point", leaf("shapes.Point")),
+            // TypeExpr::Unit / TypeExpr::Never
+            ("()", "()", leaf("()")),
+            ("!", "!", leaf("!")),
+            // TypeExpr::Array, with each ArrayLength form
+            (
+                "[i32; 4]",
+                "[i32; 4]",
+                Decomposed::Array(Box::new(leaf("i32")), ArrayLen::Literal(4)),
+            ),
+            (
+                "[i32; N]",
+                "[i32; N]",
+                Decomposed::Array(Box::new(leaf("i32")), ArrayLen::Named("N".to_owned())),
+            ),
+            (
+                "[i32; fact(4)]",
+                "[i32; fact(4)]",
+                Decomposed::Array(Box::new(leaf("i32")), ArrayLen::Named("fact(4)".to_owned())),
+            ),
+            // Nested arrays keep their nesting: the outer length is the trailing
+            // one, and the inner array stays the element.
+            (
+                "[[u8; 2]; 3]",
+                "[[u8; 2]; 3]",
+                Decomposed::Array(
+                    Box::new(Decomposed::Array(
+                        Box::new(leaf("u8")),
+                        ArrayLen::Literal(2),
+                    )),
+                    ArrayLen::Literal(3),
+                ),
+            ),
+            // TypeExpr::Slice — a leaf for the helpers above; slice resolution
+            // has its own dispatch.
+            ("[i32]", "[i32]", leaf("[i32]")),
+            // TypeExpr::PointerConst / TypeExpr::PointerMut, including a
+            // pointer to a compound type and an array of pointers.
+            (
+                "ptr const i32",
+                "ptr const i32",
+                Decomposed::Ptr(Box::new(leaf("i32")), PtrMutability::Const),
+            ),
+            (
+                "ptr mut i32",
+                "ptr mut i32",
+                Decomposed::Ptr(Box::new(leaf("i32")), PtrMutability::Mut),
+            ),
+            (
+                "ptr const [i32; 4]",
+                "ptr const [i32; 4]",
+                Decomposed::Ptr(
+                    Box::new(Decomposed::Array(
+                        Box::new(leaf("i32")),
+                        ArrayLen::Literal(4),
+                    )),
+                    PtrMutability::Const,
+                ),
+            ),
+            (
+                "[ptr mut u8; 2]",
+                "[ptr mut u8; 2]",
+                Decomposed::Array(
+                    Box::new(Decomposed::Ptr(Box::new(leaf("u8")), PtrMutability::Mut)),
+                    ArrayLen::Literal(2),
+                ),
+            ),
+            // TypeExpr::TypeCall, nested, and with a TypeExpr::IntArg argument.
+            (
+                "Result(i32, bool)",
+                "Result(i32, bool)",
+                Decomposed::Call("Result".to_owned(), vec![leaf("i32"), leaf("bool")]),
+            ),
+            (
+                "Result(Option(i32), bool)",
+                "Result(Option(i32), bool)",
+                Decomposed::Call(
+                    "Result".to_owned(),
+                    vec![
+                        Decomposed::Call("Option".to_owned(), vec![leaf("i32")]),
+                        leaf("bool"),
+                    ],
+                ),
+            ),
+            (
+                "Vector(i32, 3)",
+                "Vector(i32, 3)",
+                Decomposed::Call("Vector".to_owned(), vec![leaf("i32"), leaf("3")]),
+            ),
+            // A comma inside an argument must not split the argument list.
+            (
+                "Holder(Result(i32, bool))",
+                "Holder(Result(i32, bool))",
+                Decomposed::Call(
+                    "Holder".to_owned(),
+                    vec![Decomposed::Call(
+                        "Result".to_owned(),
+                        vec![leaf("i32"), leaf("bool")],
+                    )],
+                ),
+            ),
+            // An array argument carries a `;` and brackets through the split.
+            (
+                "Holder([i32; 4])",
+                "Holder([i32; 4])",
+                Decomposed::Call(
+                    "Holder".to_owned(),
+                    vec![Decomposed::Array(
+                        Box::new(leaf("i32")),
+                        ArrayLen::Literal(4),
+                    )],
+                ),
+            ),
+            // TypeExpr::QualifiedTypeCall
+            (
+                "shapes.Pair(i32)",
+                "shapes.Pair(i32)",
+                Decomposed::Call("shapes.Pair".to_owned(), vec![leaf("i32")]),
+            ),
+            // TypeExpr::StrFixed renders as the same `Name(N)` text the
+            // const-capacity spelling produces, so both reduce identically.
+            (
+                "Str(8)",
+                "Str(8)",
+                Decomposed::Call("Str".to_owned(), vec![leaf("8")]),
+            ),
+            // A fixed-capacity string as an array element keeps both shapes.
+            (
+                "[Str(8); 2]",
+                "[Str(8); 2]",
+                Decomposed::Array(
+                    Box::new(Decomposed::Call("Str".to_owned(), vec![leaf("8")])),
+                    ArrayLen::Literal(2),
+                ),
+            ),
+        ];
+
+        for (annotation, rendered, expected) in cases {
+            let declared = declared_parameter_type(annotation);
+            assert_eq!(declared, rendered, "rendering of `{annotation}`");
+            assert_eq!(
+                decompose(&declared),
+                expected,
+                "semantic intake of `{annotation}`"
+            );
+        }
+    }
 }

--- a/crates/rue-cli-tests/cases/bitcast.toml
+++ b/crates/rue-cli-tests/cases/bitcast.toml
@@ -1,0 +1,298 @@
+# `@bitCast` end-to-end coverage (RUE-952).
+#
+# `@bitCast` is a same-width two's-complement reinterpretation: the bits stay,
+# the type reading them changes, and nothing traps. Its whole implementation is
+# register-image discipline, so the risk is not arithmetic but the bits ABOVE
+# the shared width. Rue keeps an integer in the canonical image of its own type
+# (8/16-bit sign-/zero-extended per signedness, 32-bit with bits 32..63 clear),
+# and a reinterpretation has to rebuild those bits for the target — a negative
+# constant arrives in a register whose high bits are its sign extension, which
+# is exactly the wrong image for an unsigned target.
+#
+# These cases therefore pin every width pair in both directions with exact
+# stdout, through BOTH constant operands (materialized as immediates) and
+# runtime operands (returned from a call, so no constant folding can hide the
+# lowering), at -O0 and -O2.
+
+[section]
+id = "cli.bitcast"
+name = "@bitCast same-width reinterpretation"
+description = "Bit-preserving integer reinterpretation across every width pair, both directions."
+
+[[case]]
+name = "u64_i64_high_bit_round_trip"
+description = "The RUE-952 repro: a u64 with the top bit set has no @intCast into i64 at all."
+files = [{ path = "main.rue", source = """
+fn main() -> i32 {
+    let x: u64 = 9223372036854775808;
+    let y: i64 = @bitCast(x);
+    @dbg(y);
+    let back: u64 = @bitCast(y);
+    @dbg(back);
+    0
+}
+""" }]
+exit_code = 0
+stdout = """
+-9223372036854775808
+9223372036854775808
+"""
+
+[[case]]
+name = "intcast_still_traps_on_the_same_value"
+description = "The control: @intCast keeps its value-preserving trap; @bitCast did not weaken it."
+files = [{ path = "main.rue", source = """
+fn main() -> i32 {
+    let x: u64 = 9223372036854775808;
+    let y: i64 = @intCast(x);
+    @dbg(y);
+    0
+}
+""" }]
+exit_code = 101
+runtime_error_contains = ["integer cast overflow"]
+
+[[case]]
+name = "constants_every_width_pair"
+description = """
+Every width pair in both directions from constant operands. The negative
+constants matter most: their register image is sign-extended to 64 bits, so an
+unsigned target must have the bits above the width cleared.
+"""
+files = [{ path = "main.rue", source = """
+fn main() -> i32 {
+    let a: u8 = 255;
+    let a2: i8 = @bitCast(a);
+    @dbg(a2);
+    let b: i8 = -128;
+    let b2: u8 = @bitCast(b);
+    @dbg(b2);
+
+    let c: u16 = 65535;
+    let c2: i16 = @bitCast(c);
+    @dbg(c2);
+    let d: i16 = -32768;
+    let d2: u16 = @bitCast(d);
+    @dbg(d2);
+
+    let e: u32 = 4294967295;
+    let e2: i32 = @bitCast(e);
+    @dbg(e2);
+    let f: i32 = -2147483648;
+    let f2: u32 = @bitCast(f);
+    @dbg(f2);
+
+    let g: u64 = 18446744073709551615;
+    let g2: i64 = @bitCast(g);
+    @dbg(g2);
+    let h: i64 = -9223372036854775808;
+    let h2: u64 = @bitCast(h);
+    @dbg(h2);
+    0
+}
+""" }]
+exit_code = 0
+stdout = """
+-1
+128
+-1
+32768
+-1
+2147483648
+-1
+9223372036854775808
+"""
+
+[[case]]
+name = "runtime_operands_every_width_pair"
+description = """
+The same matrix with operands returned from calls, so nothing folds and the
+lowering itself is exercised at every width.
+"""
+files = [{ path = "main.rue", source = """
+fn u8_of(v: u8) -> u8 { v }
+fn i8_of(v: i8) -> i8 { v }
+fn u16_of(v: u16) -> u16 { v }
+fn i16_of(v: i16) -> i16 { v }
+fn u32_of(v: u32) -> u32 { v }
+fn i32_of(v: i32) -> i32 { v }
+fn u64_of(v: u64) -> u64 { v }
+fn i64_of(v: i64) -> i64 { v }
+
+fn main() -> i32 {
+    let a: i8 = @bitCast(u8_of(255));
+    @dbg(a);
+    let b: u8 = @bitCast(i8_of(-128));
+    @dbg(b);
+    let c: i16 = @bitCast(u16_of(65535));
+    @dbg(c);
+    let d: u16 = @bitCast(i16_of(-32768));
+    @dbg(d);
+    let e: i32 = @bitCast(u32_of(4294967295));
+    @dbg(e);
+    let f: u32 = @bitCast(i32_of(-2147483648));
+    @dbg(f);
+    let g: i64 = @bitCast(u64_of(18446744073709551615));
+    @dbg(g);
+    let h: u64 = @bitCast(i64_of(-9223372036854775808));
+    @dbg(h);
+    0
+}
+""" }]
+exit_code = 0
+stdout = """
+-1
+128
+-1
+32768
+-1
+2147483648
+-1
+9223372036854775808
+"""
+
+[[case]]
+name = "runtime_operands_every_width_pair_O2"
+description = "The runtime matrix at -O2: inlining and folding must not change a single digit."
+files = [{ path = "main.rue", source = """
+fn u8_of(v: u8) -> u8 { v }
+fn i8_of(v: i8) -> i8 { v }
+fn u16_of(v: u16) -> u16 { v }
+fn i16_of(v: i16) -> i16 { v }
+fn u32_of(v: u32) -> u32 { v }
+fn i32_of(v: i32) -> i32 { v }
+fn u64_of(v: u64) -> u64 { v }
+fn i64_of(v: i64) -> i64 { v }
+
+fn main() -> i32 {
+    let a: i8 = @bitCast(u8_of(255));
+    @dbg(a);
+    let b: u8 = @bitCast(i8_of(-128));
+    @dbg(b);
+    let c: i16 = @bitCast(u16_of(65535));
+    @dbg(c);
+    let d: u16 = @bitCast(i16_of(-32768));
+    @dbg(d);
+    let e: i32 = @bitCast(u32_of(4294967295));
+    @dbg(e);
+    let f: u32 = @bitCast(i32_of(-2147483648));
+    @dbg(f);
+    let g: i64 = @bitCast(u64_of(18446744073709551615));
+    @dbg(g);
+    let h: u64 = @bitCast(i64_of(-9223372036854775808));
+    @dbg(h);
+    0
+}
+""" }]
+args = ["main.rue", "-O2", "-o", "prog"]
+exit_code = 0
+stdout = """
+-1
+128
+-1
+32768
+-1
+2147483648
+-1
+9223372036854775808
+"""
+
+[[case]]
+name = "round_trip_is_the_identity"
+description = "Reinterpreting there and back restores the operand at every width (spec 4.13:123)."
+files = [{ path = "main.rue", source = """
+fn u8_of(v: u8) -> u8 { v }
+fn u16_of(v: u16) -> u16 { v }
+fn u32_of(v: u32) -> u32 { v }
+fn u64_of(v: u64) -> u64 { v }
+
+fn main() -> i32 {
+    let a: u8 = u8_of(200);
+    let a2: i8 = @bitCast(a);
+    if @bitCast(a2) != a { return 1; }
+
+    let b: u16 = u16_of(40000);
+    let b2: i16 = @bitCast(b);
+    if @bitCast(b2) != b { return 2; }
+
+    let c: u32 = u32_of(3000000000);
+    let c2: i32 = @bitCast(c);
+    if @bitCast(c2) != c { return 3; }
+
+    let d: u64 = u64_of(18000000000000000000);
+    let d2: i64 = @bitCast(d);
+    if @bitCast(d2) != d { return 4; }
+
+    0
+}
+""" }]
+exit_code = 0
+
+[[case]]
+name = "reinterpreted_value_participates_in_arithmetic"
+description = """
+The result must be a fully canonical value of its target type, not just a
+correctly printing one: it feeds comparisons and arithmetic afterwards.
+"""
+files = [{ path = "main.rue", source = """
+fn i32_of(v: i32) -> i32 { v }
+
+fn main() -> i32 {
+    // 0xFFFFFFFF reinterpreted as i32 is -1, so adding 1 gives 0.
+    let raw: u32 = 4294967295;
+    let signed: i32 = @bitCast(raw);
+    if signed + 1 != 0 { return 1; }
+    if signed >= 0 { return 2; }
+
+    // -1 reinterpreted as u32 is u32.MAX, so subtracting it from itself is 0
+    // and it compares above every other u32.
+    let back: u32 = @bitCast(i32_of(-1));
+    if back - 4294967294 != 1 { return 3; }
+    if back <= 1000 { return 4; }
+
+    0
+}
+""" }]
+exit_code = 0
+
+[[case]]
+name = "identity_and_inference_positions"
+description = "The target comes from context: an annotation, a parameter, or a return type."
+files = [{ path = "main.rue", source = """
+fn takes_u32(v: u32) -> u32 { v }
+fn reinterpret(v: i16) -> u16 { @bitCast(v) }
+
+fn main() -> i32 {
+    // Annotation position, same type on both sides.
+    let same: u32 = @bitCast(takes_u32(7));
+    @dbg(same);
+
+    // Parameter position.
+    @dbg(takes_u32(@bitCast(i32_of(-2))));
+
+    // Return position.
+    @dbg(reinterpret(-2));
+    0
+}
+
+fn i32_of(v: i32) -> i32 { v }
+""" }]
+exit_code = 0
+stdout = """
+7
+4294967294
+65534
+"""
+
+[[case]]
+name = "cross_width_is_rejected"
+description = "A cross-width @bitCast is E0950, not a silent truncation."
+files = [{ path = "main.rue", source = """
+fn main() -> i32 {
+    let x: u64 = 5;
+    let y: i32 = @bitCast(x);
+    @intCast(y)
+}
+""" }]
+compile_fail = true
+error_contains = ["E0950", "same width"]

--- a/crates/rue-cli-tests/cases/type_value_boundary.toml
+++ b/crates/rue-cli-tests/cases/type_value_boundary.toml
@@ -1,0 +1,94 @@
+# The boundary between a type used as a *value* and a type used in an
+# *annotation* (RUE-770).
+#
+# `Expr::TypeLit` has exactly three producers in the expression grammar:
+# `struct { ... }`, `enum { ... }`, and a primitive type keyword. Every compound
+# type shape — arrays, slices, pointers — is therefore reachable only from a
+# type annotation, where lowering preserves element/length identity. The
+# bracketed forms that look like array *types* in value position are ordinary
+# array expressions over type values and are rejected at their own span, so RIR
+# lowering never invents a stand-in name for an "array type value".
+#
+# These cases pin both halves: the rejections keep their precise diagnostics,
+# and the annotation path keeps its runtime behavior (stdout pinned, not just
+# the exit code).
+
+[section]
+id = "cli.type_value_boundary"
+name = "Type-value boundary"
+description = "Compound type shapes are annotation-only; value position yields precise diagnostics (RUE-770)."
+
+[[case]]
+name = "array_bracket_form_in_value_position_is_an_array_expression"
+description = "`[i32; 4]` as a value is an array repeat of the type value `i32`, rejected at its own span (E1200) — not lowered to a placeholder array type."
+files = [{ path = "main.rue", source = """
+fn main() -> i32 {
+    let t = [i32; 4];
+    0
+}
+""" }]
+compile_fail = true
+error_contains = ["E1200", "type values cannot exist at runtime", "[i32; 4]"]
+
+[[case]]
+name = "slice_bracket_form_in_value_position_is_an_array_expression"
+description = "`[i32]` as a value is a one-element array literal holding the type value `i32`, rejected the same way."
+files = [{ path = "main.rue", source = """
+fn main() -> i32 {
+    let t = [i32];
+    0
+}
+""" }]
+compile_fail = true
+error_contains = ["E1200", "type values cannot exist at runtime", "[i32]"]
+
+[[case]]
+name = "pointer_type_in_value_position_is_not_an_expression"
+description = "`ptr const i32` never starts an expression, so it is a parse error (E0100) rather than a silently interned type value."
+files = [{ path = "main.rue", source = """
+fn main() -> i32 {
+    let p = ptr const i32;
+    0
+}
+""" }]
+compile_fail = true
+error_contains = ["E0100", "expected expression, found 'ptr'"]
+
+[[case]]
+name = "primitive_type_value_still_binds"
+description = "A primitive type keyword is the one compound-free shape the grammar admits as a value; it keeps its own name through lowering."
+args = ["main.rue", "-o", "prog"]
+files = [{ path = "main.rue", source = """
+const T = i32;
+
+fn Holder(comptime U: type) -> type {
+    struct { value: U }
+}
+
+fn main() -> i32 {
+    let h = Holder(T) { value: 7 };
+    @dbg(h.value);
+    @dbg(@size_of(T));
+    0
+}
+""" }]
+stdout = "7\n4\n"
+
+[[case]]
+name = "array_annotations_preserve_element_and_length"
+description = "The annotation path keeps element/length identity for nested arrays, named lengths, and `@size_of` type arguments."
+args = ["main.rue", "-o", "prog"]
+files = [{ path = "main.rue", source = """
+const N: i32 = 3;
+
+fn main() -> i32 {
+    let a: [i32; 4] = [3; 4];
+    let n: [[u8; 2]; N] = [[1; 2]; 3];
+    let e: i32 = @intCast(n[1][1]);
+    @dbg(@size_of([i32; 4]));
+    @dbg(@size_of([[u8; 2]; N]));
+    @dbg(a[2] + e);
+    0
+}
+""" }]
+stdout = "16\n6\n4\n"

--- a/crates/rue-codegen/src/aarch64/cfg_lower.rs
+++ b/crates/rue-codegen/src/aarch64/cfg_lower.rs
@@ -1978,6 +1978,53 @@ impl<'a> CfgLower<'a> {
                 });
                 dst
             }
+            // `@bitCast` (RUE-952) moves no bits: it copies the operand and
+            // rebuilds only the bits above the shared width, which belong to the
+            // source type's register image. The shared planner picked the form
+            // from the target type; this leaf just spells it.
+            crate::value_plan::IntrinsicOperation::BitCast(form) => {
+                use crate::value_plan::BitCastForm;
+                let dst = self.mir.alloc_vreg();
+                self.mir.push(Aarch64Inst::MovRR {
+                    dst: Operand::Virtual(dst),
+                    src: Operand::Virtual(plan.args[0].primary),
+                });
+                let operand = Operand::Virtual(dst);
+                match form {
+                    BitCastForm::Move => {}
+                    BitCastForm::Sign8 => self.mir.push(Aarch64Inst::Sxtb {
+                        dst: operand,
+                        src: operand,
+                    }),
+                    BitCastForm::Zero8 => self.mir.push(Aarch64Inst::Uxtb {
+                        dst: operand,
+                        src: operand,
+                    }),
+                    BitCastForm::Sign16 => self.mir.push(Aarch64Inst::Sxth {
+                        dst: operand,
+                        src: operand,
+                    }),
+                    BitCastForm::Zero16 => self.mir.push(Aarch64Inst::Uxth {
+                        dst: operand,
+                        src: operand,
+                    }),
+                    // The 64-bit shift pair clears bits 32..63 without needing a
+                    // `uxtw`-shaped instruction in this instruction set.
+                    BitCastForm::Zero32 => {
+                        self.mir.push(Aarch64Inst::LslImm {
+                            dst: operand,
+                            src: operand,
+                            imm: 32,
+                        });
+                        self.mir.push(Aarch64Inst::Lsr64Imm {
+                            dst: operand,
+                            src: operand,
+                            imm: 32,
+                        });
+                    }
+                }
+                dst
+            }
             crate::value_plan::IntrinsicOperation::PtrRead => {
                 let ptr = plan.args[0].primary;
                 let count = plan.result_slots;

--- a/crates/rue-codegen/src/value_plan.rs
+++ b/crates/rue-codegen/src/value_plan.rs
@@ -306,6 +306,54 @@ pub enum IntrinsicOperation {
     PlaceAddress,
     Debug,
     Syscall,
+    /// Same-width two's-complement reinterpretation, `@bitCast` (RUE-952). The
+    /// language operation moves no bits; the payload is only the renormalization
+    /// the *register image* of the target type needs, selected here so neither
+    /// backend re-derives a width policy.
+    BitCast(BitCastForm),
+}
+
+/// How a `@bitCast` result reaches the target type's canonical register image
+/// (RUE-952).
+///
+/// Rue keeps an integer in a register in the canonical image of its own type:
+/// an 8/16-bit value is sign-/zero-extended per its signedness (the form
+/// `emit_subword_narrow` and `emit_wrap_narrow` restore), a 32-bit value has
+/// bits 32..63 clear (what a 32-bit ALU op leaves behind), and a 64-bit value
+/// occupies the whole register. A reinterpretation keeps the low `N` bits and
+/// changes only which type reads them, so the bits above `N` — which belong to
+/// the *source* type's image, and for a negative constant are its sign
+/// extension — must be rebuilt for the target.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BitCastForm {
+    /// 64-bit: the two images are the same 64 bits; a plain register move.
+    Move,
+    /// Re-extend the low byte for a signed 8-bit target.
+    Sign8,
+    /// Clear all but the low byte for an unsigned 8-bit target.
+    Zero8,
+    /// Re-extend the low halfword for a signed 16-bit target.
+    Sign16,
+    /// Clear all but the low halfword for an unsigned 16-bit target.
+    Zero16,
+    /// Clear bits 32..63 for a 32-bit target of either signedness: that is the
+    /// canonical 32-bit image, and a signed consumer re-extends it itself
+    /// (`integer_extension` yields `Sign32` for `i32`).
+    Zero32,
+}
+
+/// Select the renormalization a same-width `@bitCast` into `to` needs
+/// (RUE-952). Sema has already rejected a non-integer or differently sized
+/// operand (E0950), so only the target's width and signedness matter.
+pub fn bit_cast_form(to: Type) -> BitCastForm {
+    match (type_bits(to), type_is_signed(to)) {
+        (8, true) => BitCastForm::Sign8,
+        (8, false) => BitCastForm::Zero8,
+        (16, true) => BitCastForm::Sign16,
+        (16, false) => BitCastForm::Zero16,
+        (32, _) => BitCastForm::Zero32,
+        _ => BitCastForm::Move,
+    }
 }
 
 #[derive(Debug, Clone)]
@@ -1642,6 +1690,12 @@ pub(crate) fn lower_value<A: ValueLowerAdapter>(
                     },
                     "random_u32" => IntrinsicOperation::RandomU32,
                     "random_u64" => IntrinsicOperation::RandomU64,
+                    // `@bitCast` renames the operand's bits at the result type
+                    // (RUE-952). Only the result type matters: the widths agree
+                    // by construction (sema rejects the cross-width form with
+                    // E0950), so the plan carries just the target's canonical
+                    // register image.
+                    "bitCast" => IntrinsicOperation::BitCast(bit_cast_form(inst.ty)),
                     "ptr_to_int" => IntrinsicOperation::PtrToInt,
                     "int_to_ptr" => IntrinsicOperation::IntToPtr,
                     // The `_unaligned` scalar access pair (ADR-0059 Phase 4,
@@ -2046,6 +2100,7 @@ fn intrinsic_runtime_call(
         | IntrinsicOperation::ByteRead
         | IntrinsicOperation::ByteWrite
         | IntrinsicOperation::PlaceAddress
+        | IntrinsicOperation::BitCast(_)
         | IntrinsicOperation::Syscall => return None,
     };
     let plan = RuntimeCallPlan::expect_manifest(helper, call_args);

--- a/crates/rue-codegen/src/x86_64/cfg_lower.rs
+++ b/crates/rue-codegen/src/x86_64/cfg_lower.rs
@@ -2202,6 +2202,52 @@ impl<'a> CfgLower<'a> {
                 });
                 dst
             }
+            // `@bitCast` (RUE-952) moves no bits: it copies the operand and
+            // rebuilds only the bits above the shared width, which belong to the
+            // source type's register image. The shared planner picked the form
+            // from the target type; this leaf just spells it.
+            crate::value_plan::IntrinsicOperation::BitCast(form) => {
+                use crate::value_plan::BitCastForm;
+                let dst = self.mir.alloc_vreg();
+                self.mir.push(X86Inst::MovRR {
+                    dst: Operand::Virtual(dst),
+                    src: Operand::Virtual(plan.args[0].primary),
+                });
+                let operand = Operand::Virtual(dst);
+                match form {
+                    BitCastForm::Move => {}
+                    BitCastForm::Sign8 => self.mir.push(X86Inst::Movsx8To64 {
+                        dst: operand,
+                        src: operand,
+                    }),
+                    BitCastForm::Zero8 => self.mir.push(X86Inst::Movzx8To64 {
+                        dst: operand,
+                        src: operand,
+                    }),
+                    BitCastForm::Sign16 => self.mir.push(X86Inst::Movsx16To64 {
+                        dst: operand,
+                        src: operand,
+                    }),
+                    BitCastForm::Zero16 => self.mir.push(X86Inst::Movzx16To64 {
+                        dst: operand,
+                        src: operand,
+                    }),
+                    // x86-64 has no register-to-register 32-bit zero extension
+                    // in this instruction set, so clear bits 32..63 with the
+                    // 64-bit shift pair.
+                    BitCastForm::Zero32 => {
+                        self.mir.push(X86Inst::ShlRI {
+                            dst: operand,
+                            imm: 32,
+                        });
+                        self.mir.push(X86Inst::ShrRI {
+                            dst: operand,
+                            imm: 32,
+                        });
+                    }
+                }
+                dst
+            }
             crate::value_plan::IntrinsicOperation::PtrRead => {
                 let ptr = plan.args[0].primary;
                 let count = plan.result_slots;

--- a/crates/rue-compiler/src/queries.rs
+++ b/crates/rue-compiler/src/queries.rs
@@ -263,9 +263,27 @@ pub(crate) fn collect_function_cfg_queries(
     // over aggregate fields, so join completed pool entries back to their
     // durable nominal identities before projecting a current body.
     let mut stable_aggregate_types = stable_aggregate_types;
+    // RUE-1114: this loop holds the COMPLETE reached anonymous set, the only
+    // boundary in the compiler that can rank a verified digest collision under a
+    // total order instead of by arrival. The plan is empty — and every spelling
+    // byte-identical to the bare digest — unless two DISTINCT producer-nominal
+    // identities share one digest. Both semantic engines still fail closed on
+    // such a collision before CFG construction runs (their
+    // `guard_anonymous_digest_collision`, and
+    // `BodyClosureFatal::AnonymousDigestCollision` at the reached-artifact
+    // boundary), so this ranks nothing today: it is the naming half of
+    // continuation, waiting on mints that defer their spelling to a complete set.
+    let anonymous_symbol_plan = crate::semantic_identity::AnonymousSymbolPlan::for_reached_set(
+        durable_anonymous_nominals
+            .iter()
+            .map(|nominal| &nominal.identity),
+    );
     let mut stable_types_by_symbol = std::collections::BTreeMap::new();
     for nominal in durable_anonymous_nominals {
-        let symbol = crate::semantic_identity::anonymous_nominal_source_symbol(&nominal.identity);
+        let symbol = crate::semantic_identity::anonymous_nominal_source_symbol_in(
+            &anonymous_symbol_plan,
+            &nominal.identity,
+        );
         let stable = crate::TypeInstanceKey::Nominal(crate::NominalInstanceKey::Anonymous(
             nominal.identity.clone(),
         ));

--- a/crates/rue-compiler/src/retained_charge.rs
+++ b/crates/rue-compiler/src/retained_charge.rs
@@ -1481,6 +1481,11 @@ impl RetainedCharge for rue_error::ErrorKind {
                 operand_err: left,
                 fn_err: right,
             }
+            | E::BitCastWidthMismatch {
+                from: left,
+                to: right,
+                ..
+            }
             | E::PrivateMemberAccess {
                 item_kind: left,
                 name: right,

--- a/crates/rue-compiler/src/semantic_identity.rs
+++ b/crates/rue-compiler/src/semantic_identity.rs
@@ -55,9 +55,17 @@ impl StableSymbolEncoder {
     }
 }
 
-pub(crate) fn anonymous_nominal_digest(identity: &AnonymousNominalKey) -> u128 {
-    let identity = identity.with_canonical_producer();
-    let relocated: rue_air::AnonymousNominalKey<String, String> = identity
+/// Relocate a compiler anonymous key to the request-independent stable content
+/// both the digest and the RUE-1114 collision total order are computed over.
+///
+/// This is the ONE relocation: a caller that ordered compiler keys directly
+/// would be ordering `StableDefinitionKey`s, which is not the same total order
+/// the semantic engines can reproduce from durable state alone.
+fn relocate_anonymous_identity(
+    identity: &AnonymousNominalKey,
+) -> rue_air::AnonymousNominalKey<String, String> {
+    identity
+        .with_canonical_producer()
         .as_ref()
         .try_map_identities::<String, String, std::convert::Infallible>(
             &|definition| {
@@ -74,23 +82,151 @@ pub(crate) fn anonymous_nominal_digest(identity: &AnonymousNominalKey) -> u128 {
                 ))
             },
         )
-        .expect("compiler anonymous identity relocation to stable content is infallible");
-    rue_air::stable_digest::stable_anonymous_identity_digest(&relocated)
+        .expect("compiler anonymous identity relocation to stable content is infallible")
+}
+
+pub(crate) fn anonymous_nominal_digest(identity: &AnonymousNominalKey) -> u128 {
+    rue_air::stable_digest::stable_anonymous_identity_digest(&relocate_anonymous_identity(identity))
+}
+
+/// The deterministic spelling decision for one COMPLETE reached set of
+/// anonymous nominals (RUE-1114).
+///
+/// A digest owned by a single producer-nominal identity is absent from the plan
+/// and keeps its bare spelling, so a collision-free program — every program
+/// today — produces byte-identical symbols to the pre-plan compiler. A digest
+/// verified to be shared by distinct identities ranks each member under the
+/// stable-content total order, and every member is spelled with its explicit
+/// ordinal.
+///
+/// The plan is a pure function of the reached SET: it is built by folding into
+/// ordered maps before any ordinal exists, so discovery order, scheduling, and
+/// cold/warm reuse cannot move a member. Two consumers that hold the same
+/// reached set therefore agree without threading the plan between them.
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
+pub(crate) struct AnonymousSymbolPlan {
+    ordinals: std::collections::BTreeMap<AnonymousNominalKey, u32>,
+}
+
+impl AnonymousSymbolPlan {
+    /// The plan of a reached set with no verified digest collision. Every
+    /// spelling through it is the bare digest.
+    pub(crate) const EMPTY: Self = Self {
+        ordinals: std::collections::BTreeMap::new(),
+    };
+
+    pub(crate) fn for_reached_set<'a>(
+        identities: impl IntoIterator<Item = &'a AnonymousNominalKey>,
+    ) -> Self {
+        Self::from_digested(identities.into_iter().map(|identity| {
+            let stable = relocate_anonymous_identity(identity);
+            let digest = rue_air::stable_digest::stable_anonymous_identity_digest(&stable);
+            (
+                digest,
+                identity.with_canonical_producer().into_owned(),
+                stable,
+            )
+        }))
+    }
+
+    /// The same rule over narrowed digests, so a forced-collision test exercises
+    /// the production ranking rather than a test-only copy of it. The mirror of
+    /// the body-closure `force_body_closure_anonymous_digest_for_test` hook:
+    /// real digests never collide, so the rule is otherwise unreachable.
+    #[cfg(test)]
+    pub(crate) fn with_forced_digests<'a>(
+        entries: impl IntoIterator<Item = (u128, &'a AnonymousNominalKey)>,
+    ) -> Self {
+        Self::from_digested(entries.into_iter().map(|(digest, identity)| {
+            (
+                digest,
+                identity.with_canonical_producer().into_owned(),
+                relocate_anonymous_identity(identity),
+            )
+        }))
+    }
+
+    fn from_digested(
+        entries: impl IntoIterator<
+            Item = (
+                u128,
+                AnonymousNominalKey,
+                rue_air::AnonymousNominalKey<String, String>,
+            ),
+        >,
+    ) -> Self {
+        let entries = entries.into_iter().collect::<Vec<_>>();
+        let by_stable_content = rue_air::stable_digest::anonymous_symbol_ordinals(
+            entries
+                .iter()
+                .map(|(digest, _, stable)| (*digest, stable.clone())),
+        );
+        Self {
+            ordinals: entries
+                .into_iter()
+                .filter_map(|(_, key, stable)| {
+                    by_stable_content
+                        .get(&stable)
+                        .map(|&ordinal| (key, ordinal))
+                })
+                .collect(),
+        }
+    }
+
+    /// The disambiguating ordinal of one identity, or `None` when its digest
+    /// has a single owner. Consulted in canonical-producer form, the form the
+    /// plan is keyed by.
+    pub(crate) fn ordinal(&self, identity: &AnonymousNominalKey) -> Option<u32> {
+        self.ordinals
+            .get(identity.with_canonical_producer().as_ref())
+            .copied()
+    }
+
+    pub(crate) fn is_empty(&self) -> bool {
+        self.ordinals.is_empty()
+    }
+
+    /// The number of reached identities whose spelling this plan disambiguates.
+    pub(crate) fn disambiguated_len(&self) -> usize {
+        self.ordinals.len()
+    }
 }
 
 /// Spell an anonymous nominal through the same stable-content digest used by
 /// both semantic engines. The digest is presentation only; the full key remains
 /// the identity used by queries and relocation.
+///
+/// This is the spelling of an identity whose digest has one owner. A caller
+/// holding the complete reached set spells through
+/// [`anonymous_nominal_source_symbol_in`] instead, so a verified collision is
+/// disambiguated rather than conflated.
 pub(crate) fn anonymous_nominal_source_symbol(identity: &AnonymousNominalKey) -> String {
-    let digest = anonymous_nominal_digest(identity);
+    anonymous_nominal_source_symbol_in(&AnonymousSymbolPlan::EMPTY, identity)
+}
+
+pub(crate) fn anonymous_nominal_source_symbol_in(
+    plan: &AnonymousSymbolPlan,
+    identity: &AnonymousNominalKey,
+) -> String {
     let kind = match identity.kind {
         AnonymousNominalKind::Struct => "struct",
         AnonymousNominalKind::Enum => "enum",
     };
-    format!("__anon_{kind}_{digest:032x}")
+    let component = rue_air::stable_digest::stable_anonymous_symbol_component(
+        anonymous_nominal_digest(identity),
+        plan.ordinal(identity),
+    );
+    format!("__anon_{kind}_{component}")
 }
 
 pub(crate) fn anonymous_member_source_symbol(identity: &FunctionInstanceKey) -> Option<String> {
+    anonymous_member_source_symbol_in(&AnonymousSymbolPlan::EMPTY, identity)
+}
+
+pub(crate) fn anonymous_member_source_symbol_in(
+    plan: &AnonymousSymbolPlan,
+    identity: &FunctionInstanceKey,
+) -> Option<String> {
     let FunctionInstanceKey::AnonymousMember { owner, member } = identity else {
         return None;
     };
@@ -99,7 +235,7 @@ pub(crate) fn anonymous_member_source_symbol(identity: &FunctionInstanceKey) -> 
     };
     Some(format!(
         "{}.{}",
-        anonymous_nominal_source_symbol(owner),
+        anonymous_nominal_source_symbol_in(plan, owner),
         member.name
     ))
 }
@@ -550,7 +686,7 @@ fn encode_symbol(value: &StableSymbolId, output: &mut String) {
 
 #[cfg(test)]
 mod tests {
-    use std::collections::BTreeSet;
+    use std::collections::{BTreeMap, BTreeSet};
     use std::sync::Arc;
 
     use super::*;
@@ -620,6 +756,167 @@ mod tests {
             baseline,
             make(AnonymousNominalKind::Struct, 0, TypeInstanceKey::Bool)
         );
+    }
+
+    /// Three distinct anonymous sites: two kinds under one producer plus a
+    /// second producer, so struct/enum parity and producer separation are both
+    /// covered by one forced collision class.
+    fn anonymous_sites() -> Vec<AnonymousNominalKey> {
+        let site = |producer: &str, kind, ordinal| AnonymousNominalKey {
+            kind,
+            producer: StableProducerId::Definition(definition("m", producer)),
+            anchor: StructuralAnchor::new(vec![
+                StructuralPathSegment::Body,
+                StructuralPathSegment::AnonymousType(ordinal),
+            ]),
+            arguments: CanonicalArguments::default(),
+        };
+        vec![
+            site("First", AnonymousNominalKind::Struct, 0),
+            site("First", AnonymousNominalKind::Enum, 1),
+            site("Second", AnonymousNominalKind::Struct, 0),
+        ]
+    }
+
+    fn forced_symbols(digest: u128, sites: &[AnonymousNominalKey]) -> Vec<String> {
+        let plan = AnonymousSymbolPlan::with_forced_digests(
+            sites.iter().map(|identity| (digest, identity)),
+        );
+        sites
+            .iter()
+            .map(|identity| anonymous_nominal_source_symbol_in(&plan, identity))
+            .collect()
+    }
+
+    /// Real digests do not collide, so the plan of a reached set is empty and
+    /// every spelling is byte-identical to the bare-digest spelling that
+    /// predates the disambiguation rule. This is the no-regression guard for
+    /// every existing symbol table.
+    #[test]
+    fn a_collision_free_reached_set_leaves_every_spelling_unchanged() {
+        let sites = anonymous_sites();
+        let plan = AnonymousSymbolPlan::for_reached_set(sites.iter());
+        assert!(plan.is_empty());
+        assert_eq!(plan.disambiguated_len(), 0);
+        for identity in &sites {
+            assert_eq!(plan.ordinal(identity), None);
+            let symbol = anonymous_nominal_source_symbol_in(&plan, identity);
+            assert_eq!(symbol, anonymous_nominal_source_symbol(identity));
+            let kind = match identity.kind {
+                AnonymousNominalKind::Struct => "struct",
+                AnonymousNominalKind::Enum => "enum",
+            };
+            assert_eq!(
+                symbol,
+                format!("__anon_{kind}_{:032x}", anonymous_nominal_digest(identity))
+            );
+        }
+    }
+
+    /// A verified collision spells every member distinctly, and no member keeps
+    /// the unqualified spelling: the rule has no first-registrant winner. The
+    /// owner's member symbols follow the owner's ordinal, so a destructor never
+    /// relocates onto the other producer's glue.
+    #[test]
+    fn a_forced_collision_disambiguates_every_member_including_its_methods() {
+        let digest = 0x1114;
+        let sites = anonymous_sites();
+        let plan =
+            AnonymousSymbolPlan::with_forced_digests(sites.iter().map(|site| (digest, site)));
+        assert_eq!(plan.disambiguated_len(), sites.len());
+
+        let symbols = forced_symbols(digest, &sites);
+        assert_eq!(symbols.iter().collect::<BTreeSet<_>>().len(), sites.len());
+        for (identity, symbol) in sites.iter().zip(symbols.iter()) {
+            let bare = anonymous_nominal_source_symbol(identity);
+            assert_ne!(*symbol, bare, "a collision member kept the bare spelling");
+            assert!(symbol.starts_with(&bare));
+            assert!(symbol.len() <= bare.len() + "$c".len() + 10);
+        }
+
+        let owner = &sites[0];
+        let member = FunctionInstanceKey::AnonymousMember {
+            owner: Box::new(TypeInstanceKey::Nominal(NominalInstanceKey::Anonymous(
+                owner.clone(),
+            ))),
+            member: AnonymousMemberKey {
+                kind: AnonymousMemberKind::Destructor,
+                name: Arc::from("__drop"),
+            },
+        };
+        assert_eq!(
+            anonymous_member_source_symbol_in(&plan, &member).as_deref(),
+            Some(format!("{}.__drop", symbols[0]).as_str())
+        );
+        assert_ne!(
+            anonymous_member_source_symbol_in(&plan, &member),
+            anonymous_member_source_symbol(&member),
+        );
+    }
+
+    /// Order independence at the compiler's naming boundary: the symbol table
+    /// of a forced collision is identical under every discovery order of the
+    /// reached set, which is what makes a rebuild reproducible when producers
+    /// are analyzed in different body transactions or scheduling orders.
+    #[test]
+    fn forced_collision_spelling_is_independent_of_reached_set_order() {
+        let digest = 0x1114;
+        let sites = anonymous_sites();
+        let expected = sites
+            .iter()
+            .cloned()
+            .zip(forced_symbols(digest, &sites))
+            .collect::<BTreeMap<_, _>>();
+        let mut orders = 0;
+        for a in 0..3 {
+            for b in 0..2 {
+                let mut remaining = sites.clone();
+                let first = remaining.remove(a);
+                let second = remaining.remove(b);
+                let third = remaining.remove(0);
+                let permuted = vec![first, second, third];
+                let observed = permuted
+                    .iter()
+                    .cloned()
+                    .zip(forced_symbols(digest, &permuted))
+                    .collect::<BTreeMap<_, _>>();
+                assert_eq!(observed, expected, "discovery order changed a symbol");
+                orders += 1;
+            }
+        }
+        assert_eq!(orders, 6);
+    }
+
+    /// Stability across recompiles: the plan is derived from the reached set,
+    /// so re-deriving it — the warm and successor-revision case, where no
+    /// producer changed — reproduces the same symbols, and an unrelated
+    /// anonymous site joining the set under its own digest renames nobody.
+    #[test]
+    fn forced_collision_spelling_is_stable_across_recomputation() {
+        let digest = 0x1114;
+        let sites = anonymous_sites();
+        let first = forced_symbols(digest, &sites);
+        assert_eq!(forced_symbols(digest, &sites), first);
+
+        let unrelated = AnonymousNominalKey {
+            kind: AnonymousNominalKind::Struct,
+            producer: StableProducerId::Definition(definition("m", "Unrelated")),
+            anchor: StructuralAnchor::new(vec![StructuralPathSegment::AnonymousType(9)]),
+            arguments: CanonicalArguments::default(),
+        };
+        let widened = AnonymousSymbolPlan::with_forced_digests(
+            sites
+                .iter()
+                .map(|site| (digest, site))
+                .chain(std::iter::once((digest ^ 0xff, &unrelated))),
+        );
+        assert_eq!(widened.ordinal(&unrelated), None);
+        for (identity, symbol) in sites.iter().zip(first.iter()) {
+            assert_eq!(
+                anonymous_nominal_source_symbol_in(&widened, identity),
+                *symbol
+            );
+        }
     }
 
     #[test]

--- a/crates/rue-error/src/lib.rs
+++ b/crates/rue-error/src/lib.rs
@@ -436,6 +436,15 @@ impl ErrorCode {
     pub const TYPE_TOO_LARGE: Self = Self(906);
     pub const FUNCTION_FRAME_TOO_LARGE: Self = Self(907);
 
+    // ------------------------------------------------------------------
+    // Bit-reinterpretation errors (E0950-E0959)
+    // ------------------------------------------------------------------
+    /// `@bitCast` was written between integer types of different widths
+    /// (RUE-952, spec 4.13:120). A bit reinterpretation renames the bits it is
+    /// given; it neither invents nor discards any, so the source and target
+    /// **must** share a width. The value-changing conversion is `@intCast`.
+    pub const BIT_CAST_WIDTH_MISMATCH: Self = Self(950);
+
     // ========================================================================
     // Linker/target errors (E1000-E1099)
     // ========================================================================
@@ -1687,6 +1696,20 @@ pub enum ErrorKind {
          type is expected"
     )]
     CannotInferCastTarget(String),
+    /// `@bitCast` between integer types of different widths (RUE-952).
+    /// Reinterpretation is width-preserving by construction, so the diagnostic
+    /// names both widths and points at `@intCast` for the value-changing
+    /// conversion.
+    #[error(
+        "'@bitCast' requires the source and target to have the same width, but \
+         `{from}` is {from_bits}-bit and `{to}` is {to_bits}-bit"
+    )]
+    BitCastWidthMismatch {
+        from: String,
+        to: String,
+        from_bits: u32,
+        to_bits: u32,
+    },
     #[error(
         "cannot infer the pointee type of '@{0}'; add a type annotation \
          (e.g. `let p: ptr mut T = @{0}(...)`) or use it where a specific \
@@ -2146,6 +2169,7 @@ impl ErrorKind {
             ErrorKind::IntrinsicWrongArgCount { .. } => ErrorCode::INTRINSIC_WRONG_ARG_COUNT,
             ErrorKind::IntrinsicTypeMismatch(_) => ErrorCode::INTRINSIC_TYPE_MISMATCH,
             ErrorKind::CannotInferCastTarget(_) => ErrorCode::CANNOT_INFER_CAST_TARGET,
+            ErrorKind::BitCastWidthMismatch { .. } => ErrorCode::BIT_CAST_WIDTH_MISMATCH,
             ErrorKind::CannotInferPointeeType(_) => ErrorCode::CANNOT_INFER_POINTEE_TYPE,
             ErrorKind::IntrinsicAlignNotPowerOfTwo { .. } => {
                 ErrorCode::INTRINSIC_ALIGN_NOT_POWER_OF_TWO

--- a/crates/rue-oracle/src/lib.rs
+++ b/crates/rue-oracle/src/lib.rs
@@ -2785,6 +2785,11 @@ impl<'a> Interp<'a> {
                 let args = cfg.get_intrinsic_args(&inst.data).to_vec();
                 if let Some(intrinsic) = self.preflight_abort_intrinsic(cfg, &iname, &args, ty)? {
                     self.eval_abort_intrinsic(cfg, frame, intrinsic, &args)?
+                } else if iname == "bitCast" {
+                    // `@bitCast` is fully modeled, not a gap: a same-width
+                    // reinterpretation is exactly a `to_bits`/`from_bits` round
+                    // trip in the value model (RUE-952).
+                    self.eval_bit_cast(cfg, frame, &args, ty)?
                 } else if iname != "dbg" {
                     // Classify first: the same static arity/signature validation
                     // that gates a model-gap registration also gates execution, so
@@ -3594,6 +3599,46 @@ impl<'a> Interp<'a> {
                 index: 0,
             }),
         }
+    }
+
+    /// `@bitCast` (RUE-952, spec 4.13:118): reinterpret the operand's
+    /// `N`-bit two's-complement pattern at the same-width target type.
+    ///
+    /// This is total — no bound is checked and no trap is reachable, unlike
+    /// `IntCast` — so the model is exactly the value model's own bit
+    /// round trip: take the operand's pattern at its width, then read that
+    /// pattern back at the target's signedness. Sema guarantees both types are
+    /// integers of one width; a CFG that violates that is a contract failure,
+    /// not a gap.
+    fn eval_bit_cast(
+        &mut self,
+        cfg: &'a Cfg,
+        frame: &mut Frame,
+        args: &[CfgValue],
+        result_ty: Type,
+    ) -> Step<Value> {
+        let [arg] = args else {
+            return Err(unsupported(
+                UnsupportedKind::ContractViolation(ContractViolationKind::IntrinsicArity),
+                "@bitCast arity",
+            ));
+        };
+        let source_ty = cfg.get_inst(*arg).ty;
+        let (source_bits, _) = int_shape(source_ty)?;
+        let (target_bits, target_kind) = int_shape(result_ty)?;
+        if source_bits != target_bits {
+            return Err(unsupported(
+                UnsupportedKind::ContractViolation(ContractViolationKind::IntrinsicSignature),
+                "@bitCast operand and result widths differ",
+            ));
+        }
+        let value = self.eval(cfg, frame, *arg)?.as_int();
+        let pattern = to_bits(value, source_bits);
+        Ok(Value::Int(from_bits(
+            pattern,
+            target_bits,
+            kind_signed(target_kind),
+        )))
     }
 
     /// Execute a heap/pointer intrinsic whose signature already validated as a

--- a/crates/rue-rir/src/astgen.rs
+++ b/crates/rue-rir/src/astgen.rs
@@ -292,11 +292,22 @@ impl<'a> AstGen<'a> {
     }
 
     fn record_anonymous_anchor_failure(&mut self, reason: &'static str) {
+        self.record_lowering_failure("anonymous type anchor", reason);
+    }
+
+    /// Latch a typed producer-bug rejection for a lowering request the AST
+    /// cannot legally make, keeping the first failure so the reported cause is
+    /// the earliest one.
+    ///
+    /// `try_finish_editor` returns the latch before validation or publication,
+    /// and `rue_compiler::canonical_lower` renders a non-resource
+    /// `InvalidBuilderInput` as an internal error. Lowering therefore fails
+    /// closed on an impossible input instead of panicking (spec C.1:2) or
+    /// inventing a placeholder that later phases would have to interpret.
+    fn record_lowering_failure(&mut self, family: &'static str, reason: &'static str) {
         if self.payload_error.is_none() {
-            self.payload_error = Some(crate::RirPayloadBuildError::InvalidBuilderInput {
-                family: "anonymous type anchor",
-                reason,
-            });
+            self.payload_error =
+                Some(crate::RirPayloadBuildError::InvalidBuilderInput { family, reason });
         }
     }
 
@@ -1468,54 +1479,43 @@ impl<'a> AstGen<'a> {
                             )
                             .record_failure(&mut self.payload_error)
                     }
-                    _ => {
-                        // For named types, unit, never, arrays, and pointers, generate TypeConst
-                        let type_name = match &type_lit.type_expr {
-                            TypeExpr::Named(ident) => self.symbol(ident.name),
-                            TypeExpr::Qualified { .. } => self.intern_type(&type_lit.type_expr),
-                            TypeExpr::Unit(_) => self.interner.get_or_intern_static("()"),
-                            TypeExpr::Never(_) => self.interner.get_or_intern_static("!"),
-                            TypeExpr::Array { .. } => {
-                                // Array types as values are not yet supported
-                                // For now, use a placeholder
-                                self.interner.get_or_intern_static("array")
-                            }
-                            TypeExpr::Slice { .. } => {
-                                // Slice type `[T]` in value position (ADR-0043,
-                                // RUE-322). Intern its canonical string; sema
-                                // gates it behind `--preview slices` and reports
-                                // it not-yet-implemented.
-                                self.intern_type(&type_lit.type_expr)
-                            }
-                            TypeExpr::AnonymousStruct { .. } | TypeExpr::AnonymousEnum { .. } => {
-                                unreachable!("handled above")
-                            }
-                            TypeExpr::PointerConst { .. } | TypeExpr::PointerMut { .. } => {
-                                // Pointer types as values - use intern_type to get representation
-                                self.intern_type(&type_lit.type_expr)
-                            }
-                            TypeExpr::TypeCall { .. } | TypeExpr::QualifiedTypeCall { .. } => {
-                                // A type-function application in *value* position
-                                // (`let R = Result(i32, i32)`) is parsed as an
-                                // ordinary call expression, not a TypeLit, so it
-                                // does not normally reach here. Intern its
-                                // canonical string for completeness (RUE-241).
-                                self.intern_type(&type_lit.type_expr)
-                            }
-                            TypeExpr::StrFixed { .. } => {
-                                // Fixed-capacity string `Str(N)` in value position
-                                // (ADR-0043 Phase 5, RUE-326). Intern its canonical
-                                // `Str(N)` string for completeness; sema resolves it.
-                                self.intern_type(&type_lit.type_expr)
-                            }
-                            TypeExpr::IntArg { .. } => {
-                                // Only produced inside type-call argument lists
-                                // (RUE-552); a bare integer is never a TypeLit.
-                                unreachable!("IntArg outside a type-call argument list")
-                            }
-                        };
+                    // The only other shape the grammar admits here is a
+                    // primitive type keyword (`i32`, `bool`, ...): the
+                    // expression parser calls `Parser::ty` at that token, and
+                    // `ty` returns it as `TypeExpr::Named` without consuming
+                    // anything further. The named type keeps its own symbol, so
+                    // a type value is spelled exactly as the source spells it.
+                    TypeExpr::Named(ident) => {
+                        let type_name = self.symbol(ident.name);
                         self.rir.add_inst(Inst {
                             data: InstData::TypeConst { type_name },
+                            span: type_lit.span,
+                        })
+                    }
+                    // No other `TypeExpr` reaches value position (RUE-770).
+                    // `Expr::TypeLit` has exactly three producers — `struct
+                    // { ... }`, `enum { ... }`, and a primitive type keyword —
+                    // all in `rue_parser`'s primary-expression parser; the
+                    // compound shapes are reachable only from a type
+                    // *annotation*, which `intern_type` lowers instead.
+                    // `[i32; 4]` in value position, for example, is an array
+                    // repeat expression whose element is the type value `i32`,
+                    // and sema rejects it as `E1200` at its real span; it is
+                    // never a `TypeExpr::Array`. Lowering used to mint the
+                    // unspellable name `"array"` for that impossible case,
+                    // which would have named a distinct type no diagnostic
+                    // could explain. This boundary instead fails closed as a
+                    // typed producer-bug rejection (an ICE, never a panic and
+                    // never a silent placeholder), the same latch a
+                    // walk/lowering anchor disagreement uses.
+                    _ => {
+                        self.record_lowering_failure(
+                            "type literal",
+                            "type literal in value position carries a type shape \
+                             the expression grammar cannot produce",
+                        );
+                        self.rir.add_inst(Inst {
+                            data: InstData::UnitConst,
                             span: type_lit.span,
                         })
                     }
@@ -3672,5 +3672,98 @@ mod tests {
             }
             _ => panic!("Expected AnonStructType"),
         }
+    }
+
+    fn type_constant_names(rir: &Rir, interner: &ThreadedRodeo) -> Vec<String> {
+        rir.iter()
+            .filter_map(|(_, instruction)| match &instruction.data {
+                InstData::TypeConst { type_name } => Some(interner.resolve(type_name).to_owned()),
+                _ => None,
+            })
+            .collect()
+    }
+
+    /// RUE-770: `[i32; 4]` in value position is an array repeat expression over
+    /// the type value `i32`, not an array *type* literal, so no lowering ever
+    /// needs a stand-in name for an array type value.
+    #[test]
+    fn array_in_value_position_lowers_as_an_array_expression() {
+        let (rir, interner) = gen_rir("fn main() -> i32 { let t = [i32; 4]; 0 }");
+        assert_eq!(type_constant_names(&rir, &interner), ["i32"]);
+        assert!(
+            rir.iter()
+                .any(|(_, instruction)| matches!(instruction.data, InstData::ArrayRepeat { .. })),
+            "the value-position `[i32; 4]` is an array repeat expression"
+        );
+        assert!(
+            interner.get("array").is_none(),
+            "no placeholder type name is interned for an array type value"
+        );
+    }
+
+    /// RUE-770: the compound spellings stay on the type-*annotation* path, which
+    /// preserves element and length identity structurally. `@size_of` proves a
+    /// `TypeConst`-adjacent type argument still carries the canonical string;
+    /// only the value-position type literal is restricted.
+    #[test]
+    fn array_type_annotations_keep_element_and_length_identity() {
+        let (rir, interner) = gen_rir(
+            "const N: i32 = 4;
+             fn f(a: [i32; 4], b: [[u8; 2]; N]) -> ptr const [i32; 4] { @size_of([i32; 4]) }",
+        );
+        let printed = RirPrinter::new(&rir, &interner).to_string();
+        assert!(printed.contains("[i32; 4]"), "{printed}");
+        assert!(printed.contains("[[u8; 2]; N]"), "{printed}");
+        assert!(printed.contains("ptr const [i32; 4]"), "{printed}");
+        assert!(!printed.contains("array"), "{printed}");
+    }
+
+    /// RUE-770: a type literal carrying a shape the expression grammar cannot
+    /// produce is a producer bug. Lowering latches a typed rejection instead of
+    /// interning an unspellable placeholder name, so the failure surfaces at the
+    /// construction boundary rather than as a type nothing can explain.
+    #[test]
+    fn impossible_type_literal_shape_fails_closed_without_a_placeholder() {
+        let interner = ThreadedRodeo::new();
+        let span = rue_span::Span::new(0, 1);
+        let ident = rue_parser::ast::Ident {
+            name: interner.get_or_intern("i32"),
+            span,
+        };
+        let array = TypeExpr::Array {
+            element: Box::new(TypeExpr::Named(ident)),
+            length: ArrayLength::Literal(4),
+            span,
+        };
+        let item = Item::Const(ConstDecl {
+            directives: rue_parser::ast::Directives::new(),
+            visibility: Visibility::Private,
+            name: ident,
+            ty: None,
+            init: Box::new(Expr::TypeLit(rue_parser::TypeLitExpr {
+                type_expr: array,
+                span,
+            })),
+            span,
+        });
+
+        let mut astgen = AstGen::with_symbol_normalizer(&interner, |symbol| symbol);
+        astgen.append_items(std::iter::once(&item));
+        let error = astgen.try_finish().expect_err("impossible shape rejected");
+        assert!(
+            matches!(
+                error,
+                crate::RirPayloadBuildError::InvalidBuilderInput {
+                    family: "type literal",
+                    ..
+                }
+            ),
+            "{error:?}"
+        );
+        assert!(!error.is_resource_limit() && !error.is_resource_exhaustion());
+        assert!(
+            interner.get("array").is_none(),
+            "the rejected shape interns no placeholder type name"
+        );
     }
 }

--- a/crates/rue-spec/cases/expressions/intrinsics.toml
+++ b/crates/rue-spec/cases/expressions/intrinsics.toml
@@ -927,6 +927,277 @@ fn main() -> i32 {
 runtime_error = "integer cast overflow"
 
 # =============================================================================
+# @bitCast Intrinsic (RUE-952)
+#
+# The bit-preserving sibling of @intCast: same width, either direction, never a
+# trap. The cases below pin every width pair in both directions, the high-bit
+# values @intCast cannot express at all, the round trip, and the cross-width
+# rejection.
+# =============================================================================
+
+[[case]]
+name = "bitcast_u64_high_bit_to_i64"
+spec = ["4.13:118", "4.13:119", "4.13:121", "4.13:122"]
+source = """
+fn main() -> i32 {
+    // 1 << 63 has no @intCast into i64 at all: it traps. Reinterpreting it
+    // yields i64.MIN, the value with the same bit pattern.
+    let x: u64 = 9223372036854775808;
+    let y: i64 = @bitCast(x);
+    @dbg(y);
+    0
+}
+"""
+expected_stdout = """
+-9223372036854775808
+"""
+exit_code = 0
+
+[[case]]
+name = "bitcast_i64_negative_to_u64"
+spec = ["4.13:118", "4.13:121", "4.13:122"]
+source = """
+fn main() -> i32 {
+    let x: i64 = 0 - 1;
+    let y: u64 = @bitCast(x);
+    @dbg(y);
+    0
+}
+"""
+expected_stdout = """
+18446744073709551615
+"""
+exit_code = 0
+
+[[case]]
+name = "bitcast_round_trip_u64_i64"
+spec = ["4.13:123"]
+source = """
+fn main() -> i32 {
+    let x: u64 = 9223372036854775809;
+    let there: i64 = @bitCast(x);
+    let back: u64 = @bitCast(there);
+    if back == x { 0 } else { 1 }
+}
+"""
+exit_code = 0
+
+[[case]]
+name = "bitcast_round_trip_i64_u64"
+spec = ["4.13:123"]
+source = """
+fn main() -> i32 {
+    let x: i64 = 0 - 9223372036854775807;
+    let there: u64 = @bitCast(x);
+    let back: i64 = @bitCast(there);
+    if back == x { 0 } else { 1 }
+}
+"""
+exit_code = 0
+
+[[case]]
+name = "bitcast_u8_i8_both_directions"
+spec = ["4.13:118", "4.13:121", "4.13:123"]
+source = """
+fn main() -> i32 {
+    let a: u8 = 255;
+    let b: i8 = @bitCast(a);
+    @dbg(b);
+    let c: u8 = @bitCast(b);
+    @dbg(c);
+    let d: i8 = -128;
+    let e: u8 = @bitCast(d);
+    @dbg(e);
+    0
+}
+"""
+expected_stdout = """
+-1
+255
+128
+"""
+exit_code = 0
+
+[[case]]
+name = "bitcast_u16_i16_both_directions"
+spec = ["4.13:118", "4.13:121", "4.13:123"]
+source = """
+fn main() -> i32 {
+    let a: u16 = 65535;
+    let b: i16 = @bitCast(a);
+    @dbg(b);
+    let c: u16 = @bitCast(b);
+    @dbg(c);
+    let d: i16 = -32768;
+    let e: u16 = @bitCast(d);
+    @dbg(e);
+    0
+}
+"""
+expected_stdout = """
+-1
+65535
+32768
+"""
+exit_code = 0
+
+[[case]]
+name = "bitcast_u32_i32_both_directions"
+spec = ["4.13:118", "4.13:121", "4.13:123"]
+source = """
+fn main() -> i32 {
+    let a: u32 = 4294967295;
+    let b: i32 = @bitCast(a);
+    @dbg(b);
+    let c: u32 = @bitCast(b);
+    @dbg(c);
+    let d: i32 = -2147483648;
+    let e: u32 = @bitCast(d);
+    @dbg(e);
+    0
+}
+"""
+expected_stdout = """
+-1
+4294967295
+2147483648
+"""
+exit_code = 0
+
+[[case]]
+name = "bitcast_identity_same_type"
+spec = ["4.13:120"]
+source = """
+fn main() -> i32 {
+    let x: u32 = 7;
+    let y: u32 = @bitCast(x);
+    @intCast(y)
+}
+"""
+exit_code = 7
+
+[[case]]
+name = "bitcast_target_inferred_from_parameter"
+spec = ["4.13:119"]
+source = """
+fn takes_i8(v: i8) -> i32 { @intCast(v) }
+fn main() -> i32 {
+    let x: u8 = 200;
+    // -56 as an exit status is 200 after the low byte is taken.
+    let n: i32 = takes_i8(@bitCast(x));
+    if n == 0 - 56 { 0 } else { 1 }
+}
+"""
+exit_code = 0
+
+[[case]]
+name = "bitcast_target_inferred_from_return"
+spec = ["4.13:119"]
+source = """
+fn reinterpret(v: u16) -> i16 { @bitCast(v) }
+fn main() -> i32 {
+    let n: i16 = reinterpret(65535);
+    if n == 0 - 1 { 0 } else { 1 }
+}
+"""
+exit_code = 0
+
+[[case]]
+name = "bitcast_cross_width_rejected"
+spec = ["4.13:120"]
+source = """
+fn main() -> i32 {
+    let x: u64 = 5;
+    let y: i32 = @bitCast(x);
+    @intCast(y)
+}
+"""
+compile_fail = true
+error_contains = ["[E0950]", "same width"]
+
+[[case]]
+name = "bitcast_cross_width_widening_rejected"
+spec = ["4.13:120"]
+source = """
+fn main() -> i32 {
+    let x: u8 = 5;
+    let y: i64 = @bitCast(x);
+    @intCast(y)
+}
+"""
+compile_fail = true
+error_contains = ["[E0950]", "same width"]
+
+[[case]]
+name = "bitcast_target_not_inferred"
+spec = ["4.13:120"]
+source = """
+fn main() -> i32 {
+    let x: u32 = 100;
+    @bitCast(x);
+    0
+}
+"""
+compile_fail = true
+error_contains = "cannot infer the target type of '@bitCast'"
+
+[[case]]
+name = "bitcast_non_integer_target_rejected"
+spec = ["4.13:120"]
+source = """
+fn main() -> i32 {
+    let x: u32 = 100;
+    let y: bool = @bitCast(x);
+    if y { 0 } else { 1 }
+}
+"""
+compile_fail = true
+error_contains = "integer"
+
+[[case]]
+name = "bitcast_non_integer_argument_rejected"
+spec = ["4.13:119"]
+source = """
+fn main() -> i32 {
+    let x: bool = true;
+    let y: i32 = @bitCast(x);
+    y
+}
+"""
+compile_fail = true
+error_contains = "integer"
+
+[[case]]
+name = "bitcast_wrong_arg_count"
+spec = ["4.13:119"]
+source = """
+fn main() -> i32 {
+    let x: u32 = 1;
+    let y: i32 = @bitCast(x, x);
+    y
+}
+"""
+compile_fail = true
+error_contains = "[E0701]"
+
+[[case]]
+name = "bitcast_is_not_a_constant_expression"
+spec = ["4.13:124"]
+description = """
+`@bitCast` folds exactly where `@intCast` does — nowhere — so a comptime
+position that rejects `@intCast` rejects it too.
+"""
+source = """
+const WIDTH: u32 = 4;
+const REINTERPRETED: i32 = @bitCast(WIDTH);
+fn main() -> i32 {
+    REINTERPRETED
+}
+"""
+compile_fail = true
+error_contains = ["[E0434]", "not supported in const context"]
+
+# =============================================================================
 # @read_line Intrinsic
 #
 # Since RUE-6 (ADR-0038) @read_line returns Option(StrBuf): Some(line) normally,

--- a/crates/rue-ui-tests/cases/diagnostics/bitcast_width_mismatch.toml
+++ b/crates/rue-ui-tests/cases/diagnostics/bitcast_width_mismatch.toml
@@ -1,0 +1,73 @@
+[section]
+id = "diagnostics.bitcast-width-mismatch"
+name = "@bitCast cross-width diagnostic names both widths and points at @intCast (RUE-952)"
+description = """
+`@bitCast` reinterprets a value's bits, so it is defined only between integer
+types of one width. A cross-width use is not a truncation to be performed
+silently and not a generic type mismatch: the diagnostic (E0950) names the two
+types with their widths and directs the programmer to `@intCast`, the
+value-changing conversion. The mirror case — a same-width use — must stay
+accepted, including for the high-bit values `@intCast` traps on.
+"""
+
+[[case]]
+name = "narrowing_bitcast_is_e0950"
+description = "u64 into i32 names both widths and suggests @intCast."
+source = """
+fn main() -> i32 {
+    let x: u64 = 5;
+    let y: i32 = @bitCast(x);
+    @intCast(y)
+}
+"""
+compile_fail = true
+error_contains = [
+    "E0950",
+    "'@bitCast' requires the source and target to have the same width",
+    "`u64` is 64-bit and `i32` is 32-bit",
+    "use '@intCast' to convert between widths",
+]
+
+[[case]]
+name = "widening_bitcast_is_e0950"
+description = "The widening direction reports the same rule, not a silent extension."
+source = """
+fn main() -> i32 {
+    let x: u8 = 5;
+    let y: i64 = @bitCast(x);
+    @intCast(y)
+}
+"""
+compile_fail = true
+error_contains = ["E0950", "`u8` is 8-bit and `i64` is 64-bit"]
+
+[[case]]
+name = "uninferrable_bitcast_target_is_a_cast_error"
+description = "An unconstrained result reports the cast-target error, naming @bitCast."
+source = """
+fn main() -> i32 {
+    let x: u64 = 5;
+    let n = @bitCast(x);
+    @dbg(n);
+    0
+}
+"""
+compile_fail = true
+error_contains = [
+    "E0709",
+    "cannot infer the target type of '@bitCast'",
+    "add a type annotation",
+]
+
+[[case]]
+name = "same_width_bitcast_still_accepted"
+description = "The control: the same-width reinterpretation @intCast cannot express compiles and runs."
+source = """
+fn main() -> i32 {
+    let x: u64 = 9223372036854775808;
+    let y: i64 = @bitCast(x);
+    if y == -9223372036854775808 { 0 } else { 1 }
+}
+"""
+exit_code = 0
+no_warnings = true

--- a/docs/spec/src/04-expressions/13-intrinsics.md
+++ b/docs/spec/src/04-expressions/13-intrinsics.md
@@ -55,6 +55,7 @@ Expression intrinsics (usable in any expression position):
 | `@align_of` | Get type alignment in bytes | 1 type | `i32` |
 | `@offset_of` | Get a struct field's byte offset | 1 type, 1 field name | `u64` |
 | `@intCast` | Convert between integer types | 1 expression (integer) | inferred integer type |
+| `@bitCast` | Reinterpret an integer's bits at the same width (§4.13:118) | 1 expression (integer) | inferred integer type of the same width |
 | `@wrapping_add` | Wrapping (modular) addition (§4.13:97) | 2 expressions (same integer type) | that integer type |
 | `@wrapping_sub` | Wrapping (modular) subtraction (§4.13:97) | 2 expressions (same integer type) | that integer type |
 | `@wrapping_mul` | Wrapping (modular) multiplication (§4.13:97) | 2 expressions (same integer type) | that integer type |
@@ -379,6 +380,80 @@ fn main() -> i32 {
 fn main() -> i32 {
     let x: i32 = -1;
     let y: u32 = @intCast(x); // panic: integer cast overflow
+    0
+}
+```
+
+## `@bitCast`
+
+{{ rule(id="4.13:118", cat="normative") }}
+
+The `@bitCast` intrinsic reinterprets an integer value's bits at another
+integer type of the same width. It is the bit-preserving counterpart to
+`@intCast`, which is value-preserving: `@intCast` keeps the number and rejects
+the representations that do not fit, while `@bitCast` keeps the representation
+and lets the number change.
+
+{{ rule(id="4.13:119", cat="normative") }}
+
+`@bitCast` accepts exactly one argument, which **MUST** be of an integer type
+(any of `i8`, `i16`, `i32`, `i64`, `u8`, `u16`, `u32`, `u64`). The target type
+is inferred from the context where `@bitCast` is used, exactly as `@intCast`'s
+target type is (4.13:26).
+
+{{ rule(id="4.13:120", cat="legality-rule") }}
+
+It is a compile-time error if the target type cannot be inferred, is not an
+integer type, or is an integer type whose width differs from the argument's
+width (E0950). A reinterpretation neither invents nor discards bits, so it is
+defined only between the same-width pairs — `i8`/`u8`, `i16`/`u16`,
+`i32`/`u32`, and `i64`/`u64` — in either direction, and between an integer type
+and itself. Converting between widths is `@intCast`'s job.
+
+{{ rule(id="4.13:121", cat="dynamic-semantics") }}
+
+For a source type of width `N` bits, the value of `@bitCast(x)` is the value
+whose `N`-bit two's-complement representation is identical to that of `x`.
+Equivalently, for a target type `T`: when the shared width is `N` and the
+argument's value is `x`, the result is `x` if `x` is in range for `T`, and
+otherwise `x - 2^N` when `T` is signed and `x + 2^N` when `T` is unsigned.
+
+{{ rule(id="4.13:122", cat="dynamic-semantics") }}
+
+`@bitCast` never traps. Every value of the source type has a representation at
+the target type — the same representation — so no operand is rejected, in
+contrast to the overflow trap of 4.13:28. In particular `@bitCast` is the
+operation that moves a `u64` whose top bit is set into an `i64`, which
+`@intCast` traps on.
+
+{{ rule(id="4.13:123", cat="normative") }}
+
+`@bitCast` is an involution on each same-width pair: for every value `x` of an
+integer type `S` and same-width type `T`, reinterpreting `x` at `T` and then
+reinterpreting that result back at `S` yields `x`.
+
+{{ rule(id="4.13:124", cat="normative") }}
+
+In a compile-time context, `@bitCast` is evaluated exactly as `@intCast` is: it
+introduces no new constant-evaluation rule, so an invocation that `@intCast`
+would not fold into a constant is likewise not a constant expression.
+
+{{ rule(id="4.13:125") }}
+
+```rue
+fn main() -> i32 {
+    // The u64 values above i64::MAX have no @intCast into i64 at all;
+    // @bitCast moves them across, and back, unchanged.
+    let big: u64 = 9223372036854775808;   // 1 << 63
+    let signed: i64 = @bitCast(big);
+    @dbg(signed);                          // -9223372036854775808
+    let back: u64 = @bitCast(signed);
+    @dbg(back);                            // 9223372036854775808
+
+    // Narrower pairs reinterpret the same way.
+    let byte: u8 = 255;
+    let sbyte: i8 = @bitCast(byte);
+    @dbg(sbyte);                           // -1
     0
 }
 ```


### PR DESCRIPTION
Second wave of tonight's fix cycle. Three workers landed code; the fourth (RUE-768, frame-slot reuse) deliberately shipped analysis only — the host disk guard (RUE-1331) blocked its builds and an uncompiled slot-sharing change risks silent corruption, so its verified design and measurements are on the Linear issue for the next cycle. Draft until premerge completes on the combined tree.

## RUE-952: `@bitCast` (c0915ad1)
Same-width integer bit reinterpretation, all four pairs both directions, target from context like `@intCast`, never traps; cross-width rejection is E0950. The subtle part was register images, not arithmetic: values live in canonical sign-extended form, so reinterpretation rebuilds bits above the shared width (movsx/movzx or shift pairs; sxtb/uxtb or lsl/lsr). The reference interpreter models it natively. Worker verified every pair by execution at -O0/-O2 plus aarch64 asm; the UI target it couldn't run passes at integration (4/4), and the high-bit `u64 → i64::MIN` repro round-trips by hand.

## RUE-770: RIR typed boundary (f5063e75)
The `"array"` type-value placeholder is gone: `Expr::TypeLit` has exactly three producers, so lowering handles the named form and fails closed through the typed builder-error latch — never a panic, never a placeholder; nine dead fallback arms removed. RUE-791 (string reparse in sema) verified live but deliberately untouched: a partial migration would create the dual-authority state that issue forbids. A 22-shape `TypeExpr` round-trip test lands as its safety net. Worker ran the full suite green (165/0).

## RUE-1114 partial: deterministic anonymous-symbol ordinals (2664d9a2)
Digest collisions now get stable, order-independent, explicitly-suffixed symbols via the shared digest authority (`anonymous_symbol_ordinals`, ranking the relocated stable-content key) plus `AnonymousSymbolPlan` at the one compiler boundary holding the complete reached set. Structural finding: order-independence is impossible at the lazy AIR mints — only finalization over a complete set carries a proof. All three fail-closed collision gates deliberately remain (removing them before the mints defer their spelling would risk a miscompile); the mint-side continuation is recorded on the issue. This change had never been compiled (disk guard); first compile and tests happened at integration: air digest units 8/0, compiler units 833/0.

## Verification
- Combined tree: build green; codegen 688/0, compiler 833/0, air digest 8/0 units; UI bitcast 4/0; `@bitCast` high-bit repro by hand
- `scripts/rue premerge` running; flips to ready when green

Fixes RUE-952
Fixes RUE-770
Part of RUE-791
Part of RUE-1114

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GPYyXZHFGimCvkbzMtBG2U

---
_Generated by [Claude Code](https://claude.ai/code/session_01GPYyXZHFGimCvkbzMtBG2U)_