### PR TITLE
Two-tier disk guard: refuse builds only below a 4 GiB hard floor

### DIFF
--- a/buck2
+++ b/buck2
@@ -33,10 +33,13 @@ done
 
 # Starting another disk-heavy command while the host is near ENOSPC is unsafe.
 # The guard is normally just one portable `df` read. When free space is both at
-# or below 10% of the device and below an absolute headroom floor, it asks
-# Buck to reclaim eligible outputs from every registered Rue worktree,
-# preserving materializer state and active artifacts. `clean` itself is not an
-# execution command, so the host-wide guard cannot recurse through this wrapper.
+# or below 10% of the device and below the cleanup floor, it asks Buck to
+# reclaim eligible outputs from every registered Rue worktree, preserving
+# materializer state and active artifacts; it refuses the build only below the
+# hard floor, and warns-but-proceeds in between (RUE-1331 — active sibling
+# worktrees legitimately pin the host between the floors). `clean` itself is
+# not an execution command, so the host-wide guard cannot recurse through this
+# wrapper.
 if [[ "$execution_command" -eq 1 ]] && [[ -x "$repo_root/scripts/rue-storage" ]]; then
     (cd "$repo_root" && scripts/rue-storage guard)
 fi

--- a/scripts/rue-storage
+++ b/scripts/rue-storage
@@ -18,10 +18,15 @@ asks Buck what stale or untracked output it would remove. clean performs that
 coordinated stale cleanup (default age: 1w) and, below 20% host free space,
 adaptively removes the oldest eligible output while preserving a 12-hour
 minimum TTL. guard is the build preflight: when free space is at or below 10%
-of the device AND below the absolute floor (16 GiB), it runs that cleanup
-across every worktree before allowing more disk-heavy work. reset
-fully removes Buck outputs only from the exact registered roots named by the
-caller. Source worktrees are never removed.
+of the device AND below the cleanup floor (16 GiB), it runs that cleanup
+across every worktree before allowing more disk-heavy work; a build is
+refused only when free space also sits at or below the hard floor (4 GiB),
+where ENOSPC is a real risk — between the floors the guard warns and
+proceeds, because on a busy multi-worktree host the free space held by
+active sibling builds is not reclaimable and blocking every build there
+starves the host without protecting it (RUE-1331). reset fully removes Buck
+outputs only from the exact registered roots named by the caller. Source
+worktrees are never removed.
 EOF
 }
 
@@ -35,6 +40,14 @@ emergency_trigger_percent=10
 # emergency path therefore requires BOTH a low free fraction AND less absolute
 # headroom than a cold full build plus test outputs could consume.
 emergency_free_floor_gib=16
+# Below the cleanup floor the guard tries to reclaim space; it refuses to
+# build only below this hard floor. The gap exists because several active
+# worktrees legitimately hold the host between the two floors for hours (their
+# artifacts are live, so no cleanup can help), and a chronic refusal in that
+# band blocks all verification while inviting guard bypasses (RUE-1331). An
+# incremental build fits comfortably in 4 GiB; a cold full build may not, and
+# fails loudly with ENOSPC rather than silently corrupting anything.
+hard_floor_gib=4
 
 collect_roots() {
     local inventory
@@ -112,8 +125,8 @@ status_all() {
     done <<<"$roots"
     printf 'Total: %s in %d registered Rue worktree(s)\n' "$(human_kib "$total")" "$count"
     df -Pk "$repo_root" | awk 'NR == 2 { printf "Host filesystem: %s used, %.1f GiB available\n", $5, $4 / 1048576 }'
-    printf 'Policy: adaptive cleanup targets %d%% free (minimum TTL %s); emergency guard starts at %d%% only below %d GiB absolute free\n' \
-        "$adaptive_target_percent" "$adaptive_min_ttl" "$emergency_trigger_percent" "$emergency_free_floor_gib"
+    printf 'Policy: adaptive cleanup targets %d%% free (minimum TTL %s); emergency cleanup starts at %d%% only below %d GiB absolute free; builds are refused only below %d GiB\n' \
+        "$adaptive_target_percent" "$adaptive_min_ttl" "$emergency_trigger_percent" "$emergency_free_floor_gib" "$hard_floor_gib"
 }
 
 stale_all() {
@@ -176,6 +189,33 @@ emergency_pressure() {
     else
         printf 'ok\n'
     fi
+}
+
+# The refusal decision: "low" only when free space sits at or below the hard
+# floor (same fraction gate as the cleanup trigger). Fails closed like
+# emergency_pressure.
+hard_pressure() {
+    local basis_points kib
+    basis_points="$(free_basis_points)" || return 1
+    kib="$(free_kib)" || return 1
+    if (( basis_points <= emergency_trigger_percent * 100 )) &&
+        (( kib <= hard_floor_gib * 1048576 )); then
+        printf 'low\n'
+    else
+        printf 'ok\n'
+    fi
+}
+
+# One shared remediation notice so the refusal and the warn-and-proceed paths
+# name the same sanctioned moves. Editing or bypassing the guard is not one of
+# them.
+remediation_notice() {
+    cat >&2 <<EOF
+To reclaim space safely: remove worktrees whose work is finished
+('git worktree remove <path>' or 'scripts/worktree-gc'), or reset a specific
+registered root's Buck outputs with 'scripts/rue storage reset <root>'.
+Do not edit or bypass this guard; it protects every worktree on the host.
+EOF
 }
 
 # "X.YZ% (N.M GiB)" for guard messages: the fraction alone reads as nonsense on
@@ -251,11 +291,18 @@ guard_low_disk() {
     after="$(describe_free)" || return 1
     if [[ "$pressure" == low ]]; then
         echo "warning: host filesystem still has only ${after} free; trying largest legacy Buck roots while preserving active work" >&2
-        if ! reset_legacy_under_pressure; then
-            echo "error: host filesystem remains critically low after safe cleanup; inspect 'scripts/rue storage status' before building" >&2
+        # Escalation is best-effort; the hard floor below makes the decision.
+        reset_legacy_under_pressure || true
+        pressure="$(hard_pressure)" || return 1
+        after="$(describe_free)" || return 1
+        if [[ "$pressure" == low ]]; then
+            echo "error: host filesystem has ${after} free, at or below the ${hard_floor_gib} GiB hard floor; build stopped before risking ENOSPC" >&2
+            remediation_notice
             return 1
         fi
-        after="$(describe_free)" || return 1
+        echo "warning: host filesystem has ${after} free — below the ${emergency_free_floor_gib} GiB cleanup floor but above the ${hard_floor_gib} GiB hard floor; proceeding. Incremental builds fit here; a cold full build may fail with ENOSPC." >&2
+        remediation_notice
+        return 0
     fi
     after_basis_points="$(free_basis_points)" || return 1
     if (( after_basis_points < adaptive_target_percent * 100 )); then

--- a/scripts/test-cleanup-scripts.sh
+++ b/scripts/test-cleanup-scripts.sh
@@ -318,6 +318,43 @@ EOF
   rm -rf "$sb"
 }
 
+test_storage_guard_proceeds_between_cleanup_and_hard_floors() {
+  # RUE-1331: several active worktrees legitimately pin a large host between
+  # the 16 GiB cleanup floor and the 4 GiB hard floor for hours. Cleanup finds
+  # nothing reclaimable there (the artifacts are live), and a refusal starves
+  # every build without protecting the host — the guard must warn and proceed.
+  local sb rc=0; sb="$(make_sandbox rue-storage)"
+  setup_storage_root "$sb/root-1"
+  cat >"$sb/fakebin/git" <<EOF
+#!/usr/bin/env bash
+if [[ "\$*" == *"worktree list --porcelain"* ]]; then
+  printf 'worktree %s/root-1\n' "$sb"
+  exit 0
+fi
+exit 1
+EOF
+  chmod +x "$sb/fakebin/git"
+  # 15 GiB free of 200 GiB: 7.5%, below the cleanup floor, above the hard
+  # floor. Constant across probes — cleanup reclaims nothing, as on a host
+  # whose space is held by active sibling builds.
+  cat >"$sb/fakebin/df" <<'EOF'
+#!/usr/bin/env bash
+printf 'Filesystem 1024-blocks Used Available Capacity Mounted on\n'
+printf 'disk 209715200 193986560 15728640 93%% /\n'
+EOF
+  chmod +x "$sb/fakebin/df"
+  run_script "$sb" rue-storage guard || rc=$?
+  check "storage: guard proceeds between the cleanup and hard floors" \
+    "$([ "$rc" -eq 0 ] && echo 0 || echo 1)"
+  check "storage: between-floors guard still attempts cleanup first" \
+    "$(grep -q ':clean --stale 1w' "$sb/calls.log" && echo 0 || echo 1)"
+  grep -q 'above the 4 GiB hard floor; proceeding' "$sb/out.log" || \
+    fail "storage: expected the warn-and-proceed notice between floors"
+  grep -q 'Do not edit or bypass this guard' "$sb/out.log" || \
+    fail "storage: expected the sanctioned-remediation notice"
+  rm -rf "$sb"
+}
+
 test_storage_reset_validates_all_targets_first() {
   local sb rc=0; sb="$(make_sandbox rue-storage)"
   setup_storage_root "$sb/root-1"
@@ -350,6 +387,7 @@ test_storage_git_failure_is_fail_closed
 test_storage_plans_every_registered_root
 test_storage_guard_is_host_wide_only_under_pressure
 test_storage_guard_blocks_when_pressure_remains_critical
+test_storage_guard_proceeds_between_cleanup_and_hard_floors
 test_storage_reset_validates_all_targets_first
 
 echo "--------------------------------------------------"


### PR DESCRIPTION
Fixes the chronic guard misfire that shaped tonight's cycle runs: on this 252 GiB host, four active worktrees pinned free space at ~15 GiB — under both halves of the old `≤10% AND ≤16 GiB` refusal condition — for hours. Cleanup reclaims nothing there (the artifacts belong to live sibling builds), so three of four workers lost the ability to run any Buck verification, and one attempted to bypass the guard (denied by the permission firewall).

## Change
- The 16 GiB floor becomes the **cleanup trigger**: at or below it (and ≤10%), the guard still runs host-wide adaptive cleanup and the legacy-reset escalation exactly as before.
- A new **4 GiB hard floor** is the only refusal line. Between the floors the guard warns and proceeds — incremental builds fit comfortably; a cold full build may fail loudly with ENOSPC, which is recoverable, unlike a host starved of all verification.
- Both the refusal and the warn path print the sanctioned remediations (remove finished worktrees via `git worktree remove` / `scripts/worktree-gc`, per-root `scripts/rue storage reset`) and state explicitly that editing or bypassing the guard is not one of them.
- `status` policy line, usage text, and the `./buck2` wrapper comment updated to match.

## Verification
- New regression test pins the between-floors warn-and-proceed path (constant `df` across probes, modeling live sibling artifacts, 15 GiB free of 200 GiB)
- Existing critical-refusal test still passes (5% of a small device sits below the hard floor) and now sees the remediation notice
- All 23 cleanup-script checks green; live guard verified `ok` on this host; `scripts/rue premerge` running, PR flips to ready when it passes

Fixes RUE-1331

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GPYyXZHFGimCvkbzMtBG2U

---
_Generated by [Claude Code](https://claude.ai/code/session_01GPYyXZHFGimCvkbzMtBG2U)_