### PR TITLE
RUE-962: fold @byte_read/@byte_write into the typed pointer pair

### DIFF
--- a/crates/rue-air/src/inference/generate.rs
+++ b/crates/rue-air/src/inference/generate.rs
@@ -1948,38 +1948,6 @@ impl<'a> ConstraintGenerator<'a> {
                         ));
                     }
                     InferType::Concrete(Type::UNIT)
-                } else if intrinsic_name == "byte_read" {
-                    for (i, arg_ref) in args.iter().enumerate() {
-                        let info = self.generate(*arg_ref, ctx);
-                        if i == 1 {
-                            self.add_constraint(Constraint::equal(
-                                info.ty,
-                                InferType::Concrete(Type::U64),
-                                info.span,
-                            ));
-                        }
-                    }
-                    InferType::Concrete(Type::U8)
-                } else if intrinsic_name == "byte_write" {
-                    let ptr_ty =
-                        Type::new_ptr_mut(self.type_pool.intern_ptr_mut_from_type(Type::U8));
-                    for (i, arg_ref) in args.iter().enumerate() {
-                        let info = self.generate(*arg_ref, ctx);
-                        let expected = match i {
-                            0 => Some(ptr_ty),
-                            1 => Some(Type::U64),
-                            2 => Some(Type::U8),
-                            _ => None,
-                        };
-                        if let Some(expected) = expected {
-                            self.add_constraint(Constraint::equal(
-                                info.ty,
-                                InferType::Concrete(expected),
-                                info.span,
-                            ));
-                        }
-                    }
-                    InferType::Concrete(Type::UNIT)
                 } else if intrinsic_name == "byte_copy" || intrinsic_name == "byte_move" {
                     // @byte_copy/@byte_move(dst: ptr mut u8,
                     // src: ptr const u8 | ptr mut u8, size: u64) -> (). Constrain

--- a/crates/rue-air/src/sema/analysis/intrinsics.rs
+++ b/crates/rue-air/src/sema/analysis/intrinsics.rs
@@ -271,8 +271,6 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
                 || name == known.free
                 || name == known.realloc
                 || name == known.resize
-                || name == known.byte_read
-                || name == known.byte_write
                 || name == known.byte_copy
                 || name == known.byte_move
                 || name == known.byte_set
@@ -424,10 +422,6 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
             self.analyze_resize_intrinsic(air, name, &args, span, ctx)
         } else if name == known.free {
             self.analyze_free_intrinsic(air, name, &args, span, ctx)
-        } else if name == known.byte_read {
-            self.analyze_byte_read_intrinsic(air, name, &args, span, ctx)
-        } else if name == known.byte_write {
-            self.analyze_byte_write_intrinsic(air, name, &args, span, ctx)
         } else if name == known.byte_copy || name == known.byte_move {
             self.analyze_byte_copy_intrinsic(air, name, &args, span, ctx)
         } else if name == known.byte_set {

--- a/crates/rue-air/src/sema/analysis/pointers.rs
+++ b/crates/rue-air/src/sema/analysis/pointers.rs
@@ -585,67 +585,6 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
         Ok(())
     }
 
-    pub(super) fn analyze_byte_read_intrinsic(
-        &mut self,
-        air: &mut Air,
-        name: Spur,
-        args: &[RirCallArg],
-        span: Span,
-        ctx: &mut AnalysisContext,
-    ) -> CompileResult<AnalysisResult> {
-        if args.len() != 2 {
-            return Err(CompileError::new(
-                ErrorKind::IntrinsicWrongArgCount {
-                    name: "byte_read".to_string(),
-                    expected: 2,
-                    found: args.len(),
-                },
-                span,
-            ));
-        }
-        let ptr = self.analyze_inst(air, args[0].value, ctx)?;
-        self.require_u8_pointer("byte_read", ptr.ty, span)?;
-        let offset = self.analyze_inst(air, args[1].value, ctx)?;
-        self.require_intrinsic_type("byte_read", offset.ty, Type::U64, span)?;
-        let air_ref =
-            air.add_intrinsic(None, name, &[ptr.air_ref, offset.air_ref], Type::U8, span)?;
-        Ok(AnalysisResult::new(air_ref, Type::U8))
-    }
-
-    pub(super) fn analyze_byte_write_intrinsic(
-        &mut self,
-        air: &mut Air,
-        name: Spur,
-        args: &[RirCallArg],
-        span: Span,
-        ctx: &mut AnalysisContext,
-    ) -> CompileResult<AnalysisResult> {
-        if args.len() != 3 {
-            return Err(CompileError::new(
-                ErrorKind::IntrinsicWrongArgCount {
-                    name: "byte_write".to_string(),
-                    expected: 3,
-                    found: args.len(),
-                },
-                span,
-            ));
-        }
-        let ptr = self.analyze_inst(air, args[0].value, ctx)?;
-        self.require_mut_u8_pointer("byte_write", ptr.ty, span)?;
-        let offset = self.analyze_inst(air, args[1].value, ctx)?;
-        let value = self.analyze_inst(air, args[2].value, ctx)?;
-        self.require_intrinsic_type("byte_write", offset.ty, Type::U64, span)?;
-        self.require_intrinsic_type("byte_write", value.ty, Type::U8, span)?;
-        let air_ref = air.add_intrinsic(
-            None,
-            name,
-            &[ptr.air_ref, offset.air_ref, value.air_ref],
-            Type::UNIT,
-            span,
-        )?;
-        Ok(AnalysisResult::new(air_ref, Type::UNIT))
-    }
-
     /// Analyze the bulk byte-move pair `@byte_copy(dst, src, size)` and
     /// `@byte_move(dst, src, size)` (ADR-0059 Phase 1, RUE-937 / RUE-964).
     /// Both take `dst: ptr mut u8`, `src: ptr const u8 | ptr mut u8`, and a

--- a/crates/rue-air/src/sema/known_symbols.rs
+++ b/crates/rue-air/src/sema/known_symbols.rs
@@ -157,8 +157,6 @@ pub struct KnownSymbols {
     /// the in-place-only grow/shrink that never moves the block and reports
     /// success as a `bool` (Zig's `Allocator.resize`, RUE-968).
     pub resize: Spur,
-    pub byte_read: Spur,
-    pub byte_write: Spur,
     /// Bulk byte primitives `@byte_copy` (memcpy), `@byte_move` (memmove), and
     /// `@byte_set` (memset). ADR-0059 Phase 1 (RUE-937) plus the overlapping
     /// sibling `@byte_move` (RUE-964).
@@ -234,8 +232,6 @@ impl KnownSymbols {
             realloc: interner.get_or_intern_static("realloc"),
             alloc_zeroed: interner.get_or_intern_static("alloc_zeroed"),
             resize: interner.get_or_intern_static("resize"),
-            byte_read: interner.get_or_intern_static("byte_read"),
-            byte_write: interner.get_or_intern_static("byte_write"),
             byte_copy: interner.get_or_intern_static("byte_copy"),
             byte_move: interner.get_or_intern_static("byte_move"),
             byte_set: interner.get_or_intern_static("byte_set"),
@@ -326,8 +322,6 @@ mod tests {
         assert_eq!(interner.resolve(&known.realloc), "realloc");
         assert_eq!(interner.resolve(&known.alloc_zeroed), "alloc_zeroed");
         assert_eq!(interner.resolve(&known.resize), "resize");
-        assert_eq!(interner.resolve(&known.byte_read), "byte_read");
-        assert_eq!(interner.resolve(&known.byte_write), "byte_write");
         assert_eq!(interner.resolve(&known.byte_copy), "byte_copy");
         assert_eq!(interner.resolve(&known.byte_move), "byte_move");
         assert_eq!(interner.resolve(&known.byte_set), "byte_set");

--- a/crates/rue-cli-tests/cases/aggregate_layout.toml
+++ b/crates/rue-cli-tests/cases/aggregate_layout.toml
@@ -474,40 +474,52 @@ fn main() -> i32 {
         let addr: u64 = @ptr_to_int(ep);
         let bp: ptr mut u8 = @int_to_ptr(addr);
         // Poison every byte so any un-zeroed padding would be observable.
-        @byte_write(bp, 0, 255);
-        @byte_write(bp, 1, 255);
-        @byte_write(bp, 2, 255);
-        @byte_write(bp, 3, 255);
-        @byte_write(bp, 4, 255);
-        @byte_write(bp, 5, 255);
-        @byte_write(bp, 6, 255);
-        @byte_write(bp, 7, 255);
+        @ptr_write(@ptr_offset(bp, 0), 255);
+        @ptr_write(@ptr_offset(bp, 1), 255);
+        @ptr_write(@ptr_offset(bp, 2), 255);
+        @ptr_write(@ptr_offset(bp, 3), 255);
+        @ptr_write(@ptr_offset(bp, 4), 255);
+        @ptr_write(@ptr_offset(bp, 5), 255);
+        @ptr_write(@ptr_offset(bp, 6), 255);
+        @ptr_write(@ptr_offset(bp, 7), 255);
         @ptr_write(ep, Wide.A(7, 16909060));
         // Padding bytes must be deterministically zero.
-        if @byte_read(bp, 1) != 0 { return 1; }
-        if @byte_read(bp, 2) != 0 { return 2; }
-        if @byte_read(bp, 3) != 0 { return 3; }
-        if @byte_read(bp, 5) != 0 { return 4; }
-        if @byte_read(bp, 6) != 0 { return 5; }
-        if @byte_read(bp, 7) != 0 { return 6; }
+        let probe1: u8 = @ptr_read(@ptr_offset(bp, 1));
+        if probe1 != 0 { return 1; }
+        let probe2: u8 = @ptr_read(@ptr_offset(bp, 2));
+        if probe2 != 0 { return 2; }
+        let probe3: u8 = @ptr_read(@ptr_offset(bp, 3));
+        if probe3 != 0 { return 3; }
+        let probe4: u8 = @ptr_read(@ptr_offset(bp, 5));
+        if probe4 != 0 { return 4; }
+        let probe5: u8 = @ptr_read(@ptr_offset(bp, 6));
+        if probe5 != 0 { return 5; }
+        let probe6: u8 = @ptr_read(@ptr_offset(bp, 7));
+        if probe6 != 0 { return 6; }
         // Fields survive the zeroing.
         let a = @ptr_read(ep);
         match a { Wide.A(b, w) => { if b != 7 { return 7; } if w != 16909060 { return 8; } }, Wide.B => { return 9; }, };
         // Overwrite: re-poison the padding, then write a different variant. No
         // residue of the poison (or of A) may remain in B's unused bytes.
-        @byte_write(bp, 1, 255);
-        @byte_write(bp, 2, 255);
-        @byte_write(bp, 3, 255);
-        @byte_write(bp, 5, 255);
-        @byte_write(bp, 6, 255);
-        @byte_write(bp, 7, 255);
+        @ptr_write(@ptr_offset(bp, 1), 255);
+        @ptr_write(@ptr_offset(bp, 2), 255);
+        @ptr_write(@ptr_offset(bp, 3), 255);
+        @ptr_write(@ptr_offset(bp, 5), 255);
+        @ptr_write(@ptr_offset(bp, 6), 255);
+        @ptr_write(@ptr_offset(bp, 7), 255);
         @ptr_write(ep, Wide.B);
-        if @byte_read(bp, 1) != 0 { return 10; }
-        if @byte_read(bp, 2) != 0 { return 11; }
-        if @byte_read(bp, 3) != 0 { return 12; }
-        if @byte_read(bp, 5) != 0 { return 13; }
-        if @byte_read(bp, 6) != 0 { return 14; }
-        if @byte_read(bp, 7) != 0 { return 15; }
+        let probe7: u8 = @ptr_read(@ptr_offset(bp, 1));
+        if probe7 != 0 { return 10; }
+        let probe8: u8 = @ptr_read(@ptr_offset(bp, 2));
+        if probe8 != 0 { return 11; }
+        let probe9: u8 = @ptr_read(@ptr_offset(bp, 3));
+        if probe9 != 0 { return 12; }
+        let probe10: u8 = @ptr_read(@ptr_offset(bp, 5));
+        if probe10 != 0 { return 13; }
+        let probe11: u8 = @ptr_read(@ptr_offset(bp, 6));
+        if probe11 != 0 { return 14; }
+        let probe12: u8 = @ptr_read(@ptr_offset(bp, 7));
+        if probe12 != 0 { return 15; }
         @free(@int_to_ptr(@ptr_to_int(ep)), 1 * @intCast(@size_of(Wide)), @intCast(@align_of(Wide)));
     };
     0

--- a/crates/rue-cli-tests/cases/raw_bytes_degate_readiness.toml
+++ b/crates/rue-cli-tests/cases/raw_bytes_degate_readiness.toml
@@ -3,26 +3,29 @@
 # behavior-preservation check).
 #
 # The raw-byte access family is ungated (ADR-0059 Phase 6, RUE-937) and, under
-# the compact layout that is now the default (ADR-0052, RUE-987), folds into the
-# ordinary typed `ptr u8` path (phase 7): `@byte_read`/`@byte_write` lower
-# through the same one-byte narrow scalar access a typed `ptr u8` takes, and the
-# byte allocators share the general allocator helper. These cases pin that the
-# fold-in is behavior-preserving: the byte family is byte-granular (a
-# `@byte_read` reads one physical byte, `@alloc(n, a)` reserves n physical
-# bytes, offsets are never scaled by the slot size), so the result never moves.
+# the compact layout that is now the default (ADR-0052, RUE-987), single-byte
+# access IS the ordinary typed `ptr u8` path (phase 7): a `@ptr_read`/
+# `@ptr_write` of a `u8` pointee lowers through a one-byte narrow scalar
+# access, and the byte allocators share the general allocator helper. ADR-0059
+# Phase 4 (RUE-962) completed that fold by removing `@byte_read`/`@byte_write`
+# outright. These cases pin that the fold-in is behavior-preserving: access
+# stays byte-granular (a `u8` `@ptr_read` reads one physical byte, `@alloc(n,
+# a)` reserves n physical bytes, nothing is scaled by the slot size), so the
+# result never moves.
 #
-# Note: the byte surface deliberately avoids `@ptr_offset` for byte addressing
-# (it strides by the pointee width, so it is not byte-granular), addressing
-# sub-ranges through `@ptr_to_int`/`@int_to_ptr` exactly as `std/strbuf.rue`
-# does.
+# Note: `@ptr_offset` is the byte-granular walk here precisely because it is
+# element-scaled and `@size_of(u8)` is 1 — a `ptr u8` strides one byte per
+# step. Some cases below still address sub-ranges through
+# `@ptr_to_int`/`@int_to_ptr` instead, which remains a supported spelling and
+# keeps the address-arithmetic path covered.
 
 [section]
 id = "cli.raw_bytes_degate_readiness"
 name = "raw-byte surface behaves identically under the compact layout"
 description = "Byte-intrinsic programs compute the byte-granular result the byte surface guarantees, evidencing that the RUE-978 fold-in into the narrow typed path is behavior-preserving."
 
-# The whole byte family — @alloc/@byte_set/@byte_write/@realloc/
-# @byte_copy/@byte_read/@free — in one round-trip.
+# The whole byte family — @alloc/@byte_set/@realloc/@byte_copy/@free plus
+# per-byte @ptr_write/@ptr_read over a `ptr u8` — in one round-trip.
 [[case]]
 name = "byte_family_roundtrip_plain"
 description = "Full byte-family round-trip through the byte surface."
@@ -33,16 +36,16 @@ fn main() -> i32 {
     checked {
         let p: ptr mut u8 = @alloc(6, 1);
         @byte_set(p, 0, 6);
-        @byte_write(p, 0, 10);
-        @byte_write(p, 1, 20);
-        @byte_write(p, 2, 30);
+        @ptr_write(@ptr_offset(p, 0), 10);
+        @ptr_write(@ptr_offset(p, 1), 20);
+        @ptr_write(@ptr_offset(p, 2), 30);
         let q: ptr mut u8 = @realloc(p, 6, 1, 8);
-        @byte_write(q, 3, 40);
+        @ptr_write(@ptr_offset(q, 3), 40);
         let dst: ptr mut u8 = @alloc(8, 1);
         @byte_copy(dst, q, 8);
-        let sum: i32 = @intCast(@byte_read(dst, 0)) + @intCast(@byte_read(dst, 1))
-            + @intCast(@byte_read(dst, 2)) + @intCast(@byte_read(dst, 3))
-            + @intCast(@byte_read(dst, 4));
+        let sum: i32 = @intCast(@ptr_read(@ptr_offset(dst, 0))) + @intCast(@ptr_read(@ptr_offset(dst, 1)))
+            + @intCast(@ptr_read(@ptr_offset(dst, 2))) + @intCast(@ptr_read(@ptr_offset(dst, 3)))
+            + @intCast(@ptr_read(@ptr_offset(dst, 4)));
         @dbg(sum);
         @free(q, 8, 1);
         @free(dst, 8, 1);
@@ -66,7 +69,8 @@ fn main() -> i32 {
         let src: ptr mut u8 = @alloc(5, 1);
         let mut i: u64 = 0;
         while i < 5 {
-            @byte_write(src, i, @intCast(i + 1));
+            let b: u8 = @intCast(i + 1);
+            @ptr_write(@ptr_offset(src, i), b);
             i = i + 1;
         }
         let dst: ptr mut u8 = @alloc(5, 1);
@@ -77,7 +81,7 @@ fn main() -> i32 {
         let mut sum: i32 = 0;
         let mut j: u64 = 0;
         while j < 5 {
-            sum = sum + @intCast(@byte_read(dst, j));
+            sum = sum + @intCast(@ptr_read(@ptr_offset(dst, j)));
             j = j + 1;
         }
         @dbg(sum);

--- a/crates/rue-cli-tests/cases/std_strbuf.toml
+++ b/crates/rue-cli-tests/cases/std_strbuf.toml
@@ -59,11 +59,16 @@ fn main() -> i32 {
     bytes.reserve_source(20);
     if bytes.len() != 17 || bytes.capacity() < 37 { return 2; }
     checked {
-        if @byte_read(bytes.core.buf, 0) != 1 { return 3; }
-        if @byte_read(bytes.core.buf, 7) != 8 { return 4; }
-        if @byte_read(bytes.core.buf, 8) != 9 { return 5; }
-        if @byte_read(bytes.core.buf, 15) != 16 { return 6; }
-        if @byte_read(bytes.core.buf, 16) != 17 { return 7; }
+        let probe1: u8 = @ptr_read(@ptr_offset(bytes.core.buf, 0));
+        if probe1 != 1 { return 3; }
+        let probe2: u8 = @ptr_read(@ptr_offset(bytes.core.buf, 7));
+        if probe2 != 8 { return 4; }
+        let probe3: u8 = @ptr_read(@ptr_offset(bytes.core.buf, 8));
+        if probe3 != 9 { return 5; }
+        let probe4: u8 = @ptr_read(@ptr_offset(bytes.core.buf, 15));
+        if probe4 != 16 { return 6; }
+        let probe5: u8 = @ptr_read(@ptr_offset(bytes.core.buf, 16));
+        if probe5 != 17 { return 7; }
     };
 
     let value: S = "abcdefghijklmnopq";
@@ -105,11 +110,16 @@ fn main() -> i32 {
     if value != "abcdefghijkabcdefghijk" { return 1; }
     if value.capacity() < value.len() { return 2; }
     checked {
-        if @byte_read(value.core.buf, 7) != 104 { return 3; }
-        if @byte_read(value.core.buf, 8) != 105 { return 4; }
-        if @byte_read(value.core.buf, 10) != 107 { return 5; }
-        if @byte_read(value.core.buf, 11) != 97 { return 6; }
-        if @byte_read(value.core.buf, 21) != 107 { return 7; }
+        let probe6: u8 = @ptr_read(@ptr_offset(value.core.buf, 7));
+        if probe6 != 104 { return 3; }
+        let probe7: u8 = @ptr_read(@ptr_offset(value.core.buf, 8));
+        if probe7 != 105 { return 4; }
+        let probe8: u8 = @ptr_read(@ptr_offset(value.core.buf, 10));
+        if probe8 != 107 { return 5; }
+        let probe9: u8 = @ptr_read(@ptr_offset(value.core.buf, 11));
+        if probe9 != 97 { return 6; }
+        let probe10: u8 = @ptr_read(@ptr_offset(value.core.buf, 21));
+        if probe10 != 107 { return 7; }
     };
 
     let mut reserved: S = "stay";
@@ -328,7 +338,7 @@ const S = std.strbuf.StrBuf;
 
 fn owned(byte: u8) -> S {
     let p: ptr mut u8 = checked { @alloc(4, 1) };
-    checked { @byte_write(p, 0, byte); };
+    checked { @ptr_write(@ptr_offset(p, 0), byte); };
     // White-box: assemble an owned header (cap = 4 exactly, below the 16 floor)
     // over the RawBuf core (RUE-1066).
     let mut s = S.new();

--- a/crates/rue-codegen/src/aarch64/cfg_lower.rs
+++ b/crates/rue-codegen/src/aarch64/cfg_lower.rs
@@ -2201,40 +2201,6 @@ impl<'a> CfgLower<'a> {
                 self.lower_runtime_call(plan.runtime_call.expect("byte-set runtime call plan"))
                     .primary
             }
-            crate::value_plan::IntrinsicOperation::ByteRead => {
-                let addr = self.mir.alloc_vreg();
-                self.mir.push(Aarch64Inst::AddRR {
-                    dst: Operand::Virtual(addr),
-                    src1: Operand::Virtual(plan.args[0].primary),
-                    src2: Operand::Virtual(plan.args[1].primary),
-                });
-                let dst = self.mir.alloc_vreg();
-                let narrow = plan
-                    .narrow_access
-                    .expect("byte access always has a one-byte narrow descriptor");
-                // Fold into the typed `ptr u8` narrow load (ADR-0052, RUE-978).
-                self.emit_narrow_load_through_ptr(dst, addr, 0, narrow);
-                dst
-            }
-            crate::value_plan::IntrinsicOperation::ByteWrite => {
-                let addr = self.mir.alloc_vreg();
-                self.mir.push(Aarch64Inst::AddRR {
-                    dst: Operand::Virtual(addr),
-                    src1: Operand::Virtual(plan.args[0].primary),
-                    src2: Operand::Virtual(plan.args[1].primary),
-                });
-                let narrow = plan
-                    .narrow_access
-                    .expect("byte access always has a one-byte narrow descriptor");
-                // Fold into the typed `ptr u8` narrow store (ADR-0052, RUE-978).
-                self.emit_narrow_store_through_ptr(plan.args[2].primary, addr, 0, narrow);
-                let dst = self.mir.alloc_vreg();
-                self.mir.push(Aarch64Inst::MovImm {
-                    dst: Operand::Virtual(dst),
-                    imm: 0,
-                });
-                dst
-            }
             crate::value_plan::IntrinsicOperation::PlaceAddress => {
                 let place = plan.args[0]
                     .place
@@ -4436,8 +4402,8 @@ mod tests {
         let preview = PreviewFeatures::new();
         let mir = lower_function_to_mir_with_preview(
             "fn main() -> i32 { checked { let p = @alloc(3, 1); \
-             @byte_write(p, 1, 255); let q = @realloc(p, 3, 1, 5); \
-             let b = @byte_read(q, 1); @free(q, 5, 1); \
+             @ptr_write(@ptr_offset(p, 1), 255); let q = @realloc(p, 3, 1, 5); \
+             let b = @ptr_read(@ptr_offset(q, 1)); @free(q, 5, 1); \
              @intCast(b) } }",
             "main",
             preview,
@@ -4467,15 +4433,15 @@ mod tests {
         assert_eq!(immediate_call_arg(&mir, free, Reg::X2), Some(1));
     }
 
-    /// RUE-978: under the default compact layout the raw-byte access family folds
-    /// into the ordinary typed `ptr u8` narrow path — `@byte_read`/`@byte_write`
-    /// emit the same one-byte `NarrowLoadIndexed`/`NarrowStoreIndexed` a typed
-    /// `@ptr_read`/`@ptr_write` of a `u8` pointee does.
+    /// RUE-978/RUE-962: byte-granular access is the ordinary typed `ptr u8`
+    /// narrow path. `@ptr_read`/`@ptr_write` of a `u8` pointee, walked with
+    /// `@ptr_offset`, emit a one-byte `NarrowLoadIndexed`/`NarrowStoreIndexed`
+    /// rather than a full-slot access.
     #[test]
     fn aggregate_layout_folds_byte_access_into_narrow_typed_path() {
         let mir = lower_function_to_mir_with_preview(
             "fn main() -> i32 { checked { let p = @alloc(2, 1); \
-             @byte_write(p, 0, 65); let b = @byte_read(p, 1); \
+             @ptr_write(@ptr_offset(p, 0), 65); let b = @ptr_read(@ptr_offset(p, 1)); \
              @free(p, 2, 1); @intCast(b) } }",
             "main",
             PreviewFeatures::new(),
@@ -4484,7 +4450,7 @@ mod tests {
             mir.instructions()
                 .iter()
                 .any(|inst| matches!(inst, Aarch64Inst::NarrowStoreIndexed { width: 1, .. })),
-            "@byte_write must fold into the one-byte narrow store"
+            "a `u8` @ptr_write must use the one-byte narrow store"
         );
         assert!(
             mir.instructions().iter().any(|inst| matches!(
@@ -4495,7 +4461,7 @@ mod tests {
                     ..
                 }
             )),
-            "@byte_read must fold into the one-byte zero-extended narrow load"
+            "a `u8` @ptr_read must use the one-byte zero-extended narrow load"
         );
     }
 }

--- a/crates/rue-codegen/src/types.rs
+++ b/crates/rue-codegen/src/types.rs
@@ -894,9 +894,9 @@ fn pointee_or_self(type_pool: &FrozenTypeInternPool, ty: Type) -> Type {
 ///
 /// Purely compile-time layout queries (`@size_of`/`@align_of`/`@offset_of`) fold
 /// to constants before code generation. Slot-identical aggregates (all
-/// eight-byte leaves, e.g. `StrBuf`) marshal correctly, as does the
-/// byte-addressed raw-byte family (`@byte_read`/`@byte_write` over an
-/// `@alloc`'d block).
+/// eight-byte leaves, e.g. `StrBuf`) marshal correctly, as does byte-granular
+/// access (`@ptr_read`/`@ptr_write` through a `ptr u8` over an `@alloc`'d
+/// block, walked with `@ptr_offset`).
 ///
 /// Returning `None` never weakens correctness: every remaining physical access
 /// is either byte-for-byte identical to the slot model, a narrow scalar access

--- a/crates/rue-codegen/src/value_plan.rs
+++ b/crates/rue-codegen/src/value_plan.rs
@@ -292,8 +292,6 @@ pub enum IntrinsicOperation {
     Free,
     Realloc,
     Resize,
-    ByteRead,
-    ByteWrite,
     ByteCopy,
     ByteMove,
     ByteSet,
@@ -1716,8 +1714,6 @@ pub(crate) fn lower_value<A: ValueLowerAdapter>(
                     "free" => IntrinsicOperation::Free,
                     "realloc" => IntrinsicOperation::Realloc,
                     "resize" => IntrinsicOperation::Resize,
-                    "byte_read" => IntrinsicOperation::ByteRead,
-                    "byte_write" => IntrinsicOperation::ByteWrite,
                     "byte_copy" => IntrinsicOperation::ByteCopy,
                     "byte_move" => IntrinsicOperation::ByteMove,
                     "byte_set" => IntrinsicOperation::ByteSet,
@@ -1757,15 +1753,6 @@ pub(crate) fn lower_value<A: ValueLowerAdapter>(
                         ctx.type_pool,
                         ctx.cfg.get_inst(args[1]).ty,
                     ),
-                    // Under the compact layout the raw-byte family folds into the
-                    // ordinary typed `ptr u8` path: a byte access is exactly the
-                    // one-byte narrow scalar access (RUE-989) that
-                    // `@ptr_read`/`@ptr_write` of a `u8` pointee take, so
-                    // `@byte_read`/`@byte_write` reuse that single emission path
-                    // (ADR-0052 phase 7, RUE-978).
-                    IntrinsicOperation::ByteRead | IntrinsicOperation::ByteWrite => {
-                        crate::types::narrow_scalar_access(ctx.type_pool, Type::U8)
-                    }
                     _ => None,
                 };
                 // A compact aggregate pointee marshals its whole value through the
@@ -2097,8 +2084,6 @@ fn intrinsic_runtime_call(
         | IntrinsicOperation::PtrRead
         | IntrinsicOperation::PtrWrite
         | IntrinsicOperation::PtrOffset
-        | IntrinsicOperation::ByteRead
-        | IntrinsicOperation::ByteWrite
         | IntrinsicOperation::PlaceAddress
         | IntrinsicOperation::BitCast(_)
         | IntrinsicOperation::Syscall => return None,

--- a/crates/rue-codegen/src/x86_64/cfg_lower.rs
+++ b/crates/rue-codegen/src/x86_64/cfg_lower.rs
@@ -2429,46 +2429,6 @@ impl<'a> CfgLower<'a> {
                 self.lower_runtime_call(plan.runtime_call.expect("byte-set runtime call plan"))
                     .primary
             }
-            crate::value_plan::IntrinsicOperation::ByteRead => {
-                let addr = self.mir.alloc_vreg();
-                self.mir.push(X86Inst::MovRR {
-                    dst: Operand::Virtual(addr),
-                    src: Operand::Virtual(plan.args[0].primary),
-                });
-                self.mir.push(X86Inst::AddRR64 {
-                    dst: Operand::Virtual(addr),
-                    src: Operand::Virtual(plan.args[1].primary),
-                });
-                let dst = self.mir.alloc_vreg();
-                let narrow = plan
-                    .narrow_access
-                    .expect("byte access always has a one-byte narrow descriptor");
-                // Fold into the typed `ptr u8` narrow load (RUE-978).
-                self.emit_narrow_load_through_ptr(dst, addr, 0, narrow);
-                dst
-            }
-            crate::value_plan::IntrinsicOperation::ByteWrite => {
-                let addr = self.mir.alloc_vreg();
-                self.mir.push(X86Inst::MovRR {
-                    dst: Operand::Virtual(addr),
-                    src: Operand::Virtual(plan.args[0].primary),
-                });
-                self.mir.push(X86Inst::AddRR64 {
-                    dst: Operand::Virtual(addr),
-                    src: Operand::Virtual(plan.args[1].primary),
-                });
-                let narrow = plan
-                    .narrow_access
-                    .expect("byte access always has a one-byte narrow descriptor");
-                // Fold into the typed `ptr u8` narrow store (RUE-978).
-                self.emit_narrow_store_through_ptr(plan.args[2].primary, addr, 0, narrow);
-                let dst = self.mir.alloc_vreg();
-                self.mir.push(X86Inst::MovRI32 {
-                    dst: Operand::Virtual(dst),
-                    imm: 0,
-                });
-                dst
-            }
             crate::value_plan::IntrinsicOperation::PlaceAddress => {
                 let place = plan.args[0]
                     .place
@@ -4296,8 +4256,8 @@ mod tests {
         let preview = PreviewFeatures::new();
         let mir = lower_to_mir_with_preview(
             "fn main() -> i32 { checked { let p = @alloc(3, 1); \
-             @byte_write(p, 1, 255); let q = @realloc(p, 3, 1, 5); \
-             let b = @byte_read(q, 1); @free(q, 5, 1); \
+             @ptr_write(@ptr_offset(p, 1), 255); let q = @realloc(p, 3, 1, 5); \
+             let b = @ptr_read(@ptr_offset(q, 1)); @free(q, 5, 1); \
              @intCast(b) } }",
             preview,
         );
@@ -4327,20 +4287,20 @@ mod tests {
     }
 
     /// RUE-978: the raw-byte access family folds into the ordinary typed
-    /// `ptr u8` narrow path — `@byte_read`/`@byte_write` emit the same one-byte
+    /// `ptr u8` narrow path — a `u8` `@ptr_read`/`@ptr_write` emits a one-byte
     /// `NarrowLoadIndexed`/`NarrowStoreIndexed` a typed `@ptr_read`/`@ptr_write`
     /// of a `u8` pointee does.
     #[test]
     fn aggregate_layout_folds_byte_access_into_narrow_typed_path() {
         let source = "fn main() -> i32 { checked { let p = @alloc(2, 1); \
-             @byte_write(p, 0, 65); let b = @byte_read(p, 1); \
+             @ptr_write(@ptr_offset(p, 0), 65); let b = @ptr_read(@ptr_offset(p, 1)); \
              @free(p, 2, 1); @intCast(b) } }";
         let mir = lower_to_mir_with_preview(source, PreviewFeatures::new());
         assert!(
             mir.instructions()
                 .iter()
                 .any(|inst| matches!(inst, X86Inst::NarrowStoreIndexed { width: 1, .. })),
-            "@byte_write must fold into the one-byte narrow store"
+            "a `u8` @ptr_write must use the one-byte narrow store"
         );
         assert!(
             mir.instructions().iter().any(|inst| matches!(
@@ -4351,7 +4311,7 @@ mod tests {
                     ..
                 }
             )),
-            "@byte_read must fold into the one-byte zero-extended narrow load"
+            "a `u8` @ptr_read must use the one-byte zero-extended narrow load"
         );
     }
 }

--- a/crates/rue-oracle-diff/src/model_gaps/cli.rs
+++ b/crates/rue-oracle-diff/src/model_gaps/cli.rs
@@ -280,7 +280,7 @@ const ENTRIES: &[Entry] = &[
     Entry::new(
         "cli.aggregate_layout",
         "compact_enum_padding_is_deterministically_zeroed",
-        intrinsic(UnsupportedIntrinsicKind::ByteWrite),
+        intrinsic(UnsupportedIntrinsicKind::PointerWrite),
         &[],
     ),
     // ADR-0052 phase 5.10 (RUE-987): the whole compact-struct-through-pointer
@@ -391,8 +391,10 @@ const ENTRIES: &[Entry] = &[
         "std_core_m1_smoke",
         // `std.mem.swap` now performs a bytewise exchange through `@raw_mut`
         // (RUE-943), so the oracle model's first unsupported intrinsic for this
-        // case is the address-of rather than the later `@int_to_ptr`.
-        intrinsic(UnsupportedIntrinsicKind::ByteRead),
+        // case is the address-of rather than the later `@int_to_ptr`. Since
+        // ADR-0059 Phase 4 (RUE-962) the per-byte step is `@ptr_read` over a
+        // `ptr u8` rather than the removed `@byte_read`.
+        intrinsic(UnsupportedIntrinsicKind::PointerRead),
         &[],
     ),
     // std.env (RUE-935): argv/envp are captured process state, so the oracle
@@ -443,7 +445,7 @@ const ENTRIES: &[Entry] = &[
     Entry::new(
         "cli.std_m3",
         "std_sort_m3",
-        intrinsic(UnsupportedIntrinsicKind::ByteRead),
+        intrinsic(UnsupportedIntrinsicKind::PointerRead),
         &[],
     ),
     Entry::new(

--- a/crates/rue-oracle/src/lib.rs
+++ b/crates/rue-oracle/src/lib.rs
@@ -264,8 +264,6 @@ pub enum UnsupportedIntrinsicKind {
     Free,
     Reallocate,
     Resize,
-    ByteRead,
-    ByteWrite,
     ByteCopy,
     ByteMove,
     ByteSet,
@@ -857,8 +855,6 @@ fn unsupported_intrinsic_kind(name: &str) -> UnsupportedKind {
         "free" => UnsupportedKind::SemanticGap(Semantic::Intrinsic(Intrinsic::Free)),
         "realloc" => UnsupportedKind::SemanticGap(Semantic::Intrinsic(Intrinsic::Reallocate)),
         "resize" => UnsupportedKind::SemanticGap(Semantic::Intrinsic(Intrinsic::Resize)),
-        "byte_read" => UnsupportedKind::SemanticGap(Semantic::Intrinsic(Intrinsic::ByteRead)),
-        "byte_write" => UnsupportedKind::SemanticGap(Semantic::Intrinsic(Intrinsic::ByteWrite)),
         "byte_copy" => UnsupportedKind::SemanticGap(Semantic::Intrinsic(Intrinsic::ByteCopy)),
         "byte_move" => UnsupportedKind::SemanticGap(Semantic::Intrinsic(Intrinsic::ByteMove)),
         "byte_set" => UnsupportedKind::SemanticGap(Semantic::Intrinsic(Intrinsic::ByteSet)),
@@ -1051,7 +1047,7 @@ impl<'a> Interp<'a> {
     /// through the same `byte_at` path the runtime's byte helpers model, so a
     /// text read rides entirely on the modeled allocation store.
     fn text_bytes(&self, val: &Value) -> Step<Vec<u8>> {
-        let gap = unsupported_intrinsic_kind("byte_read");
+        let gap = unsupported_intrinsic_kind("ptr_read");
         let Some((target, len)) = Self::text_ptr_len(val) else {
             return Err(unsupported(gap, "text value is not a materialized header"));
         };
@@ -1440,13 +1436,10 @@ impl<'a> Interp<'a> {
             "read_line" | "random_u32" | "random_u64" | "arg_count" | "env_count" => {
                 args.is_empty()
             }
-            "ptr_write"
-            | "ptr_write_unaligned"
-            | "ptr_offset"
-            | "byte_read"
-            | "alloc"
-            | "alloc_zeroed" => args.len() == 2,
-            "byte_write" | "byte_copy" | "byte_move" | "byte_set" | "free" => args.len() == 3,
+            "ptr_write" | "ptr_write_unaligned" | "ptr_offset" | "alloc" | "alloc_zeroed" => {
+                args.len() == 2
+            }
+            "byte_copy" | "byte_move" | "byte_set" | "free" => args.len() == 3,
             "realloc" | "resize" => args.len() == 4,
             "syscall" => (1..=7).contains(&args.len()),
             _ => args.len() == 1,
@@ -1531,18 +1524,6 @@ impl<'a> Interp<'a> {
                     && ty(2) == Type::U64
                     && ty(3) == Type::U64
                     && result_ty == if name == "resize" { Type::BOOL } else { ty(0) }
-            }
-            "byte_read" => {
-                self.pointer_pointee(ty(0))
-                    .is_some_and(|(pointee, _)| pointee == Type::U8)
-                    && ty(1) == Type::U64
-                    && result_ty == Type::U8
-            }
-            "byte_write" => {
-                self.pointer_pointee(ty(0)) == Some((Type::U8, true))
-                    && ty(1) == Type::U64
-                    && ty(2) == Type::U8
-                    && result_ty == Type::UNIT
             }
             "byte_copy" | "byte_move" => {
                 self.pointer_pointee(ty(0)) == Some((Type::U8, true))
@@ -2279,7 +2260,7 @@ impl<'a> Interp<'a> {
     /// Read `len` bytes starting at a raw text pointer (the projected-char
     /// path's `ptr`/`len` pair), through the modeled allocation store.
     fn bytes_from_ptr(&self, ptr: &Value, len: i128) -> Step<Vec<u8>> {
-        let gap = unsupported_intrinsic_kind("byte_read");
+        let gap = unsupported_intrinsic_kind("ptr_read");
         if len <= 0 {
             return Ok(Vec::new());
         }
@@ -3810,25 +3791,6 @@ impl<'a> Interp<'a> {
                     None => Ok(None),
                 }
             }
-            "byte_read" => {
-                let p = self.eval(cfg, frame, args[0])?;
-                let off = self.eval(cfg, frame, args[1])?.as_int();
-                let target = self.expect_ptr(p, gap)?;
-                Ok(Some(Value::Int(self.byte_at(&target, off, gap)? as i128)))
-            }
-            "byte_write" => {
-                let p = self.eval(cfg, frame, args[0])?;
-                let off = self.eval(cfg, frame, args[1])?.as_int();
-                let val = self.eval(cfg, frame, args[2])?.as_int();
-                let target = self.expect_ptr(p, gap)?;
-                let at = PtrTarget {
-                    alloc: target.alloc,
-                    path: target.path.clone(),
-                    index: target.index + off,
-                };
-                self.ptr_cell_write(&at, Value::Int(val & 0xFF), gap)?;
-                Ok(Some(Value::Unit))
-            }
             "byte_copy" | "byte_move" => {
                 let dst = self.eval(cfg, frame, args[0])?;
                 let src = self.eval(cfg, frame, args[1])?;
@@ -4058,8 +4020,6 @@ fn modeled_pointer_intrinsic(kind: UnsupportedIntrinsicKind) -> bool {
             | I::Free
             | I::Reallocate
             | I::Resize
-            | I::ByteRead
-            | I::ByteWrite
             | I::ByteCopy
             | I::ByteMove
             | I::ByteSet

--- a/crates/rue-oracle/src/tests.rs
+++ b/crates/rue-oracle/src/tests.rs
@@ -417,8 +417,6 @@ fn every_known_unsupported_intrinsic_has_a_closed_kind() {
         ("alloc_zeroed", Intrinsic::AllocateZeroed),
         ("resize", Intrinsic::Resize),
         ("byte_move", Intrinsic::ByteMove),
-        ("byte_read", Intrinsic::ByteRead),
-        ("byte_write", Intrinsic::ByteWrite),
         ("byte_copy", Intrinsic::ByteCopy),
         ("byte_set", Intrinsic::ByteSet),
     ] {
@@ -1227,24 +1225,25 @@ fn field_ptr_on_param_struct() {
     assert_eq!(run(src).stdout, "44\n");
 }
 
-/// The full byte family round-trips through `@alloc`, `@byte_*`, and
-/// `@realloc` with contents preserved across a grow.
+/// The full byte family round-trips through `@alloc`, the bulk `@byte_*`
+/// helpers, per-byte `@ptr_read`/`@ptr_write` over a `ptr u8`, and `@realloc`,
+/// with contents preserved across a grow.
 #[test]
 fn byte_family_roundtrip() {
     let src = r#"fn main() -> i32 {
         checked {
             let p: ptr mut u8 = @alloc(6, 1);
             @byte_set(p, 0, 6);
-            @byte_write(p, 0, 10);
-            @byte_write(p, 1, 20);
-            @byte_write(p, 2, 30);
+            @ptr_write(@ptr_offset(p, 0), 10);
+            @ptr_write(@ptr_offset(p, 1), 20);
+            @ptr_write(@ptr_offset(p, 2), 30);
             let q: ptr mut u8 = @realloc(p, 6, 1, 8);
-            @byte_write(q, 3, 40);
+            @ptr_write(@ptr_offset(q, 3), 40);
             let dst: ptr mut u8 = @alloc(8, 1);
             @byte_copy(dst, q, 8);
-            let sum: i32 = @intCast(@byte_read(dst, 0)) + @intCast(@byte_read(dst, 1))
-                + @intCast(@byte_read(dst, 2)) + @intCast(@byte_read(dst, 3))
-                + @intCast(@byte_read(dst, 4));
+            let sum: i32 = @intCast(@ptr_read(@ptr_offset(dst, 0))) + @intCast(@ptr_read(@ptr_offset(dst, 1)))
+                + @intCast(@ptr_read(@ptr_offset(dst, 2))) + @intCast(@ptr_read(@ptr_offset(dst, 3)))
+                + @intCast(@ptr_read(@ptr_offset(dst, 4)));
             @dbg(sum);
             @free(q, 8, 1);
             @free(dst, 8, 1);
@@ -1263,7 +1262,8 @@ fn byte_address_arithmetic_roundtrip() {
             let src: ptr mut u8 = @alloc(5, 1);
             let mut i: u64 = 0;
             while i < 5 {
-                @byte_write(src, i, @intCast(i + 1));
+                let b: u8 = @intCast(i + 1);
+                @ptr_write(@ptr_offset(src, i), b);
                 i = i + 1;
             }
             let dst: ptr mut u8 = @alloc(5, 1);
@@ -1274,7 +1274,7 @@ fn byte_address_arithmetic_roundtrip() {
             let mut sum: i32 = 0;
             let mut j: u64 = 0;
             while j < 5 {
-                sum = sum + @intCast(@byte_read(dst, j));
+                sum = sum + @intCast(@ptr_read(@ptr_offset(dst, j)));
                 j = j + 1;
             }
             @dbg(sum);

--- a/crates/rue-spec/cases/runtime/heap.toml
+++ b/crates/rue-spec/cases/runtime/heap.toml
@@ -29,8 +29,8 @@ source = """
 fn main() -> i32 {
     checked {
         let p: ptr mut u8 = @alloc(4, 1);
-        @byte_write(p, 0, 42);
-        @intCast(@byte_read(p, 0))
+        @ptr_write(@ptr_offset(p, 0), 42);
+        @intCast(@ptr_read(@ptr_offset(p, 0)))
     }
 }
 """
@@ -81,11 +81,11 @@ source = """
 fn main() -> i32 {
     checked {
         let p: ptr mut u8 = @alloc_zeroed(5, 1);
-        let sum: i32 = @intCast(@byte_read(p, 0))
-            + @intCast(@byte_read(p, 1))
-            + @intCast(@byte_read(p, 2))
-            + @intCast(@byte_read(p, 3))
-            + @intCast(@byte_read(p, 4));
+        let sum: i32 = @intCast(@ptr_read(@ptr_offset(p, 0)))
+            + @intCast(@ptr_read(@ptr_offset(p, 1)))
+            + @intCast(@ptr_read(@ptr_offset(p, 2)))
+            + @intCast(@ptr_read(@ptr_offset(p, 3)))
+            + @intCast(@ptr_read(@ptr_offset(p, 4)));
         @free(p, 5, 1);
         sum
     }
@@ -104,8 +104,8 @@ source = """
 fn main() -> i32 {
     checked {
         let p: ptr mut u8 = @alloc(2, 1);
-        @byte_write(p, 0, 7);
-        let v: i32 = @intCast(@byte_read(p, 0));
+        @ptr_write(@ptr_offset(p, 0), 7);
+        let v: i32 = @intCast(@ptr_read(@ptr_offset(p, 0)));
         @free(p, 2, 1);
         v
     }
@@ -140,10 +140,10 @@ source = """
 fn main() -> i32 {
     checked {
         let mut p: ptr mut u8 = @alloc(2, 1);
-        @byte_write(p, 0, 5);
-        @byte_write(p, 1, 7);
+        @ptr_write(@ptr_offset(p, 0), 5);
+        @ptr_write(@ptr_offset(p, 1), 7);
         p = @realloc(p, 2, 1, 8);
-        let sum: i32 = @intCast(@byte_read(p, 0)) + @intCast(@byte_read(p, 1));
+        let sum: i32 = @intCast(@ptr_read(@ptr_offset(p, 0))) + @intCast(@ptr_read(@ptr_offset(p, 1)));
         @free(p, 8, 1);
         sum
     }
@@ -160,16 +160,16 @@ source = """
 fn main() -> i32 {
     checked {
         let p: ptr mut u8 = @alloc(4, 1);
-        @byte_write(p, 0, 10);
-        @byte_write(p, 1, 20);
-        @byte_write(p, 2, 30);
-        @byte_write(p, 3, 40);
+        @ptr_write(@ptr_offset(p, 0), 10);
+        @ptr_write(@ptr_offset(p, 1), 20);
+        @ptr_write(@ptr_offset(p, 2), 30);
+        @ptr_write(@ptr_offset(p, 3), 40);
         let q: ptr mut u8 = @realloc(p, 4, 1, 18446744073709551615);
         if @ptr_to_int(q) == 0 {
-            let sum: i32 = @intCast(@byte_read(p, 0))
-                + @intCast(@byte_read(p, 1))
-                + @intCast(@byte_read(p, 2))
-                + @intCast(@byte_read(p, 3));
+            let sum: i32 = @intCast(@ptr_read(@ptr_offset(p, 0)))
+                + @intCast(@ptr_read(@ptr_offset(p, 1)))
+                + @intCast(@ptr_read(@ptr_offset(p, 2)))
+                + @intCast(@ptr_read(@ptr_offset(p, 3)));
             @free(p, 4, 1);
             sum
         } else {
@@ -191,8 +191,8 @@ fn main() -> i32 {
         let zero: u64 = 0;
         let start: ptr mut u8 = @int_to_ptr(zero);
         let p: ptr mut u8 = @realloc(start, 0, 1, 4);
-        @byte_write(p, 0, 99);
-        let v: i32 = @intCast(@byte_read(p, 0));
+        @ptr_write(@ptr_offset(p, 0), 99);
+        let v: i32 = @intCast(@ptr_read(@ptr_offset(p, 0)));
         @free(p, 4, 1);
         v
     }
@@ -228,9 +228,9 @@ source = """
 fn main() -> i32 {
     checked {
         let p: ptr mut u8 = @alloc(65, 8);
-        @byte_write(p, 0, 21);
+        @ptr_write(@ptr_offset(p, 0), 21);
         let size: u64 = if @resize(p, 65, 8, 120) { 120 } else { 65 };
-        let v: i32 = @intCast(@byte_read(p, 0));
+        let v: i32 = @intCast(@ptr_read(@ptr_offset(p, 0)));
         @free(p, size, 8);
         v
     }
@@ -249,9 +249,9 @@ source = """
 fn main() -> i32 {
     checked {
         let p: ptr mut u8 = @alloc(8, 8);
-        @byte_write(p, 0, 33);
+        @ptr_write(@ptr_offset(p, 0), 33);
         let refused: bool = !@resize(p, 8, 8, 18446744073709551615);
-        let v: i32 = @intCast(@byte_read(p, 0));
+        let v: i32 = @intCast(@ptr_read(@ptr_offset(p, 0)));
         @free(p, 8, 8);
         if refused { v } else { 0 }
     }

--- a/crates/rue-spec/cases/runtime/pointers.toml
+++ b/crates/rue-spec/cases/runtime/pointers.toml
@@ -227,11 +227,13 @@ fn main() -> i32 {
     checked {
         let p: ptr mut u8 = @alloc(4, 1);
         @byte_set(p, 0, 4);
-        @ptr_write(@ptr_offset(p, 1), 200);
-        let ok: bool = @byte_read(p, 0) == 0
-            && @byte_read(p, 1) == 200
-            && @byte_read(p, 2) == 0
-            && @byte_read(p, 3) == 0;
+        let zero: u8 = 0;
+        let want: u8 = 200;
+        @ptr_write(@ptr_offset(p, 1), want);
+        let ok: bool = @ptr_read(@ptr_offset(p, 0)) == zero
+            && @ptr_read(@ptr_offset(p, 1)) == want
+            && @ptr_read(@ptr_offset(p, 2)) == zero
+            && @ptr_read(@ptr_offset(p, 3)) == zero;
         @free(p, 4, 1);
         if ok { 41 } else { 0 }
     }
@@ -254,10 +256,11 @@ fn main() -> i32 {
         @byte_set(raw, 0, 2 * unit);
         let p: ptr mut i32 = @int_to_ptr(@ptr_to_int(raw));
         @ptr_write(p, 123456789);
-        let untouched: bool = @byte_read(raw, 4) == 0
-            && @byte_read(raw, 5) == 0
-            && @byte_read(raw, 6) == 0
-            && @byte_read(raw, 7) == 0;
+        let zero: u8 = 0;
+        let untouched: bool = @ptr_read(@ptr_offset(raw, 4)) == zero
+            && @ptr_read(@ptr_offset(raw, 5)) == zero
+            && @ptr_read(@ptr_offset(raw, 6)) == zero
+            && @ptr_read(@ptr_offset(raw, 7)) == zero;
         let same: bool = @ptr_read(p) == 123456789;
         @free(raw, 2 * unit, align);
         if untouched && same { 42 } else { 0 }

--- a/crates/rue-spec/cases/runtime/raw-bytes.toml
+++ b/crates/rue-spec/cases/runtime/raw-bytes.toml
@@ -13,17 +13,17 @@ description = "Packed physical-byte allocation and access"
 
 [[case]]
 name = "packed_offsets_read_write_exactly_one_byte"
-spec = ["9.2:14a", "9.2:14d"]
+spec = ["9.2:6b", "9.2:7"]
 source = """
 fn main() -> i32 {
     checked {
         let p: ptr mut u8 = @alloc(3, 1);
-        @byte_write(p, 0, 11);
-        @byte_write(p, 1, 22);
-        @byte_write(p, 2, 33);
-        let result: i32 = @intCast(@byte_read(p, 0))
-            + @intCast(@byte_read(p, 1))
-            + @intCast(@byte_read(p, 2));
+        @ptr_write(@ptr_offset(p, 0), 11);
+        @ptr_write(@ptr_offset(p, 1), 22);
+        @ptr_write(@ptr_offset(p, 2), 33);
+        let result: i32 = @intCast(@ptr_read(@ptr_offset(p, 0)))
+            + @intCast(@ptr_read(@ptr_offset(p, 1)))
+            + @intCast(@ptr_read(@ptr_offset(p, 2)));
         @free(p, 3, 1);
         result
     }
@@ -33,18 +33,18 @@ exit_code = 66
 
 [[case]]
 name = "byte_write_preserves_adjacent_bytes"
-spec = ["9.2:14d"]
+spec = ["9.2:6b"]
 source = """
 fn main() -> i32 {
     checked {
         let p = @alloc(3, 1);
-        @byte_write(p, 0, 17);
-        @byte_write(p, 1, 34);
-        @byte_write(p, 2, 51);
-        @byte_write(p, 1, 68);
-        let result: i32 = @intCast(@byte_read(p, 0))
-            + @intCast(@byte_read(p, 1))
-            + @intCast(@byte_read(p, 2));
+        @ptr_write(@ptr_offset(p, 0), 17);
+        @ptr_write(@ptr_offset(p, 1), 34);
+        @ptr_write(@ptr_offset(p, 2), 51);
+        @ptr_write(@ptr_offset(p, 1), 68);
+        let result: i32 = @intCast(@ptr_read(@ptr_offset(p, 0)))
+            + @intCast(@ptr_read(@ptr_offset(p, 1)))
+            + @intCast(@ptr_read(@ptr_offset(p, 2)));
         @free(p, 3, 1);
         result
     }
@@ -52,23 +52,25 @@ fn main() -> i32 {
 """
 exit_code = 136
 
-# A byte offset is added unscaled, and `@size_of(u8)` is 1, so
-# `@byte_read(p, i)` names the same byte as `@ptr_read(@ptr_offset(p, i))` and
-# `@byte_write` the same byte as the corresponding `@ptr_write` (9.2:14d).
+# `@size_of(u8)` is 1, so a `@ptr_offset` of zero over a `ptr u8` names the
+# base byte itself: `@ptr_read(@ptr_offset(p, 0))` and `@ptr_read(p)` are the
+# same access (9.2:6b, 9.2:7). This is what makes the byte-granular walk a
+# plain use of the typed access pair, with no byte-specific intrinsic
+# (ADR-0059, RUE-962).
 [[case]]
-name = "byte_access_agrees_with_typed_access_on_a_u8_pointer"
-spec = ["9.2:14d"]
+name = "ptr_offset_zero_names_the_base_byte"
+spec = ["9.2:6b", "9.2:7"]
 source = """
 fn main() -> i32 {
     checked {
         let p: ptr mut u8 = @alloc(3, 1);
-        @byte_write(p, 0, 7);
-        @byte_write(p, 1, 8);
-        @byte_write(p, 2, 9);
-        let agree: bool = @byte_read(p, 2) == @ptr_read(@ptr_offset(p, 2))
-            && @byte_read(p, 0) == @ptr_read(p);
-        @ptr_write(@ptr_offset(p, 1), 30);
-        let written: bool = @byte_read(p, 1) == 30;
+        @ptr_write(@ptr_offset(p, 0), 7);
+        @ptr_write(@ptr_offset(p, 1), 8);
+        @ptr_write(@ptr_offset(p, 2), 9);
+        let agree: bool = @ptr_read(@ptr_offset(p, 0)) == @ptr_read(p);
+        let want: u8 = 30;
+        @ptr_write(@ptr_offset(p, 1), want);
+        let written: bool = @ptr_read(@ptr_offset(p, 1)) == want;
         @free(p, 3, 1);
         if agree && written { 44 } else { 0 }
     }
@@ -78,13 +80,13 @@ exit_code = 44
 
 [[case]]
 name = "byte_read_accepts_const_u8_pointer"
-spec = ["9.2:14d", "9.2:14e"]
+spec = ["9.2:6b", "9.2:6d"]
 source = """
 fn main() -> i32 {
     let value: u8 = 79;
     checked {
         let p: ptr const u8 = @raw(value);
-        @intCast(@byte_read(p, 0))
+        @intCast(@ptr_read(@ptr_offset(p, 0)))
     }
 }
 """
@@ -92,13 +94,13 @@ exit_code = 79
 
 [[case]]
 name = "alloc_result_type_is_inferred"
-spec = ["9.2:10", "9.2:14f"]
+spec = ["9.2:10", "9.2:6b"]
 source = """
 fn main() -> i32 {
     checked {
         let p = @alloc(1, 1);
-        @byte_write(p, 0, 71);
-        let result: i32 = @intCast(@byte_read(p, 0));
+        @ptr_write(@ptr_offset(p, 0), 71);
+        let result: i32 = @intCast(@ptr_read(@ptr_offset(p, 0)));
         @free(p, 1, 1);
         result
     }
@@ -108,18 +110,18 @@ exit_code = 71
 
 [[case]]
 name = "realloc_preserves_packed_prefix"
-spec = ["9.2:12", "9.2:14f"]
+spec = ["9.2:12", "9.2:6b"]
 source = """
 fn main() -> i32 {
     checked {
         let p: ptr mut u8 = @alloc(2, 1);
-        @byte_write(p, 0, 40);
-        @byte_write(p, 1, 2);
+        @ptr_write(@ptr_offset(p, 0), 40);
+        @ptr_write(@ptr_offset(p, 1), 2);
         let q = @realloc(p, 2, 1, 4);
-        @byte_write(q, 2, 3);
-        let result: i32 = @intCast(@byte_read(q, 0))
-            + @intCast(@byte_read(q, 1))
-            + @intCast(@byte_read(q, 2));
+        @ptr_write(@ptr_offset(q, 2), 3);
+        let result: i32 = @intCast(@ptr_read(@ptr_offset(q, 0)))
+            + @intCast(@ptr_read(@ptr_offset(q, 1)))
+            + @intCast(@ptr_read(@ptr_offset(q, 2)));
         @free(q, 4, 1);
         result
     }
@@ -147,14 +149,14 @@ source = """
 fn main() -> i32 {
     checked {
         let p = @alloc(3, 1);
-        @byte_write(p, 0, 11);
-        @byte_write(p, 1, 22);
-        @byte_write(p, 2, 33);
+        @ptr_write(@ptr_offset(p, 0), 11);
+        @ptr_write(@ptr_offset(p, 1), 22);
+        @ptr_write(@ptr_offset(p, 2), 33);
         let q = @realloc(p, 3, 1, 18446744073709551615);
         if @ptr_to_int(q) == 0 {
-            let result: i32 = @intCast(@byte_read(p, 0))
-                + @intCast(@byte_read(p, 1))
-                + @intCast(@byte_read(p, 2));
+            let result: i32 = @intCast(@ptr_read(@ptr_offset(p, 0)))
+                + @intCast(@ptr_read(@ptr_offset(p, 1)))
+                + @intCast(@ptr_read(@ptr_offset(p, 2)));
             @free(p, 3, 1);
             result
         } else {
@@ -200,7 +202,7 @@ source = """
 fn main() -> i32 {
     checked {
         let p = @alloc(1, 1);
-        @byte_write(p, 0, 42);
+        @ptr_write(@ptr_offset(p, 0), 42);
         let q = @realloc(p, 1, 1, 0);
         if @ptr_to_int(q) == 0 { 0 } else { 1 }
     }
@@ -222,15 +224,16 @@ fn main() -> i32 {
 compile_fail = true
 error_contains = "[E1300]"
 
-# @byte_read and @byte_write carry the checked gate themselves (9.2:14e), which
-# is separate from the allocation family's gate above.
+# Byte-granular access is `@ptr_read`/`@ptr_write` over a `ptr u8`, and that
+# pair carries the checked gate itself (9.2:6d), separately from the allocation
+# family's gate above.
 [[case]]
 name = "byte_read_requires_checked"
-spec = ["9.2:14e"]
+spec = ["9.2:6d"]
 source = """
 fn main() -> i32 {
     let p: ptr mut u8 = checked { @alloc(1, 1) };
-    let b: u8 = @byte_read(p, 0);
+    let b: u8 = @ptr_read(@ptr_offset(p, 0));
     @intCast(b)
 }
 """
@@ -239,11 +242,11 @@ error_contains = "[E1300]"
 
 [[case]]
 name = "byte_write_requires_checked"
-spec = ["9.2:14e"]
+spec = ["9.2:6d"]
 source = """
 fn main() -> i32 {
     let p: ptr mut u8 = checked { @alloc(1, 1) };
-    @byte_write(p, 0, 1);
+    @ptr_write(@ptr_offset(p, 0), 1);
     0
 }
 """
@@ -252,13 +255,13 @@ error_contains = "[E1300]"
 
 [[case]]
 name = "byte_write_requires_u8_value"
-spec = ["9.2:14e"]
+spec = ["9.2:6d"]
 source = """
 fn main() -> i32 {
     checked {
         let p: ptr mut u8 = @alloc(1, 1);
         let value: u64 = 1;
-        @byte_write(p, 0, value);
+        @ptr_write(@ptr_offset(p, 0), value);
     };
     0
 }
@@ -268,19 +271,19 @@ error_contains = "expected u8"
 
 [[case]]
 name = "byte_copy_round_trip"
-spec = ["9.2:14g", "9.2:14h"]
+spec = ["9.2:14a", "9.2:14g", "9.2:14h"]
 source = """
 fn main() -> i32 {
     checked {
         let src: ptr mut u8 = @alloc(3, 1);
-        @byte_write(src, 0, 10);
-        @byte_write(src, 1, 20);
-        @byte_write(src, 2, 30);
+        @ptr_write(@ptr_offset(src, 0), 10);
+        @ptr_write(@ptr_offset(src, 1), 20);
+        @ptr_write(@ptr_offset(src, 2), 30);
         let dst: ptr mut u8 = @alloc(3, 1);
         @byte_copy(dst, src, 3);
-        let result: i32 = @intCast(@byte_read(dst, 0))
-            + @intCast(@byte_read(dst, 1))
-            + @intCast(@byte_read(dst, 2));
+        let result: i32 = @intCast(@ptr_read(@ptr_offset(dst, 0)))
+            + @intCast(@ptr_read(@ptr_offset(dst, 1)))
+            + @intCast(@ptr_read(@ptr_offset(dst, 2)));
         @free(src, 3, 1);
         @free(dst, 3, 1);
         result
@@ -297,10 +300,10 @@ fn main() -> i32 {
     checked {
         let p: ptr mut u8 = @alloc(4, 1);
         @byte_set(p, 9, 4);
-        let result: i32 = @intCast(@byte_read(p, 0))
-            + @intCast(@byte_read(p, 1))
-            + @intCast(@byte_read(p, 2))
-            + @intCast(@byte_read(p, 3));
+        let result: i32 = @intCast(@ptr_read(@ptr_offset(p, 0)))
+            + @intCast(@ptr_read(@ptr_offset(p, 1)))
+            + @intCast(@ptr_read(@ptr_offset(p, 2)))
+            + @intCast(@ptr_read(@ptr_offset(p, 3)));
         @free(p, 4, 1);
         result
     }
@@ -315,12 +318,12 @@ source = """
 fn main() -> i32 {
     checked {
         let dst: ptr mut u8 = @alloc(2, 1);
-        @byte_write(dst, 0, 55);
-        @byte_write(dst, 1, 11);
+        @ptr_write(@ptr_offset(dst, 0), 55);
+        @ptr_write(@ptr_offset(dst, 1), 11);
         let src: ptr mut u8 = @alloc(2, 1);
         @byte_set(src, 99, 2);
         @byte_copy(dst, src, 0);
-        let result: i32 = @intCast(@byte_read(dst, 0)) + @intCast(@byte_read(dst, 1));
+        let result: i32 = @intCast(@ptr_read(@ptr_offset(dst, 0))) + @intCast(@ptr_read(@ptr_offset(dst, 1)));
         @free(src, 2, 1);
         @free(dst, 2, 1);
         result
@@ -336,15 +339,15 @@ source = """
 fn main() -> i32 {
     checked {
         let src: ptr mut u8 = @alloc(4, 1);
-        @byte_write(src, 0, 1);
-        @byte_write(src, 1, 2);
-        @byte_write(src, 2, 3);
-        @byte_write(src, 3, 4);
+        @ptr_write(@ptr_offset(src, 0), 1);
+        @ptr_write(@ptr_offset(src, 1), 2);
+        @ptr_write(@ptr_offset(src, 2), 3);
+        @ptr_write(@ptr_offset(src, 3), 4);
         let dst: ptr mut u8 = @alloc(2, 1);
         @byte_set(dst, 0, 2);
         let src_mid: ptr mut u8 = @int_to_ptr(@ptr_to_int(src) + 1);
         @byte_copy(dst, src_mid, 2);
-        let result: i32 = @intCast(@byte_read(dst, 0)) + @intCast(@byte_read(dst, 1));
+        let result: i32 = @intCast(@ptr_read(@ptr_offset(dst, 0))) + @intCast(@ptr_read(@ptr_offset(dst, 1)));
         @free(src, 4, 1);
         @free(dst, 2, 1);
         result
@@ -425,13 +428,13 @@ source = """
 fn main() -> i32 {
     checked {
         let p: ptr mut u8 = @alloc(4, 1);
-        @byte_write(p, 0, 20);
-        @byte_write(p, 1, 22);
+        @ptr_write(@ptr_offset(p, 0), 20);
+        @ptr_write(@ptr_offset(p, 1), 22);
         let q = @realloc(p, 4, 1, 8);
-        @byte_write(q, 2, 3);
-        let result: i32 = @intCast(@byte_read(q, 0))
-            + @intCast(@byte_read(q, 1))
-            + @intCast(@byte_read(q, 2));
+        @ptr_write(@ptr_offset(q, 2), 3);
+        let result: i32 = @intCast(@ptr_read(@ptr_offset(q, 0)))
+            + @intCast(@ptr_read(@ptr_offset(q, 1)))
+            + @intCast(@ptr_read(@ptr_offset(q, 2)));
         @free(q, 8, 1);
         result
     }
@@ -446,13 +449,13 @@ source = """
 fn main() -> i32 {
     checked {
         let p: ptr mut u8 = @alloc(16, 8);
-        @byte_write(p, 0, 30);
-        @byte_write(p, 7, 12);
+        @ptr_write(@ptr_offset(p, 0), 30);
+        @ptr_write(@ptr_offset(p, 7), 12);
         let q = @realloc(p, 16, 8, 32);
-        @byte_write(q, 8, 6);
-        let result: i32 = @intCast(@byte_read(q, 0))
-            + @intCast(@byte_read(q, 7))
-            + @intCast(@byte_read(q, 8));
+        @ptr_write(@ptr_offset(q, 8), 6);
+        let result: i32 = @intCast(@ptr_read(@ptr_offset(q, 0)))
+            + @intCast(@ptr_read(@ptr_offset(q, 7)))
+            + @intCast(@ptr_read(@ptr_offset(q, 8)));
         @free(q, 32, 8);
         result
     }
@@ -544,7 +547,9 @@ fn main() -> i32 {
         let misaligned: bool = @ptr_to_int(skewed) % align != 0;
         @ptr_write_unaligned(skewed, 1000000);
         let same: bool = @ptr_read_unaligned(skewed) == 1000000;
-        let outside: bool = @byte_read(raw, 0) == 0 && @byte_read(raw, 5) == 0;
+        let zero: u8 = 0;
+        let outside: bool = @ptr_read(@ptr_offset(raw, 0)) == zero
+            && @ptr_read(@ptr_offset(raw, 5)) == zero;
         @free(raw, 8, align);
         if misaligned && same && outside { 45 } else { 0 }
     }
@@ -591,14 +596,14 @@ source = """
 fn main() -> i32 {
     checked {
         let src: ptr mut u8 = @alloc(3, 1);
-        @byte_write(src, 0, 10);
-        @byte_write(src, 1, 20);
-        @byte_write(src, 2, 30);
+        @ptr_write(@ptr_offset(src, 0), 10);
+        @ptr_write(@ptr_offset(src, 1), 20);
+        @ptr_write(@ptr_offset(src, 2), 30);
         let dst: ptr mut u8 = @alloc(3, 1);
         @byte_move(dst, src, 3);
-        let result: i32 = @intCast(@byte_read(dst, 0))
-            + @intCast(@byte_read(dst, 1))
-            + @intCast(@byte_read(dst, 2));
+        let result: i32 = @intCast(@ptr_read(@ptr_offset(dst, 0)))
+            + @intCast(@ptr_read(@ptr_offset(dst, 1)))
+            + @intCast(@ptr_read(@ptr_offset(dst, 2)));
         @free(src, 3, 1);
         @free(dst, 3, 1);
         result
@@ -619,16 +624,16 @@ source = """
 fn main() -> i32 {
     checked {
         let p: ptr mut u8 = @alloc(4, 1);
-        @byte_write(p, 0, 1);
-        @byte_write(p, 1, 2);
-        @byte_write(p, 2, 3);
-        @byte_write(p, 3, 0);
+        @ptr_write(@ptr_offset(p, 0), 1);
+        @ptr_write(@ptr_offset(p, 1), 2);
+        @ptr_write(@ptr_offset(p, 2), 3);
+        @ptr_write(@ptr_offset(p, 3), 0);
         let dst: ptr mut u8 = @int_to_ptr(@ptr_to_int(p) + 1);
         @byte_move(dst, p, 3);
-        let result: i32 = @intCast(@byte_read(p, 0)) * 64
-            + @intCast(@byte_read(p, 1)) * 16
-            + @intCast(@byte_read(p, 2)) * 4
-            + @intCast(@byte_read(p, 3));
+        let result: i32 = @intCast(@ptr_read(@ptr_offset(p, 0))) * 64
+            + @intCast(@ptr_read(@ptr_offset(p, 1))) * 16
+            + @intCast(@ptr_read(@ptr_offset(p, 2))) * 4
+            + @intCast(@ptr_read(@ptr_offset(p, 3)));
         @free(p, 4, 1);
         result
     }
@@ -646,16 +651,16 @@ source = """
 fn main() -> i32 {
     checked {
         let p: ptr mut u8 = @alloc(4, 1);
-        @byte_write(p, 0, 0);
-        @byte_write(p, 1, 1);
-        @byte_write(p, 2, 2);
-        @byte_write(p, 3, 3);
+        @ptr_write(@ptr_offset(p, 0), 0);
+        @ptr_write(@ptr_offset(p, 1), 1);
+        @ptr_write(@ptr_offset(p, 2), 2);
+        @ptr_write(@ptr_offset(p, 3), 3);
         let src: ptr mut u8 = @int_to_ptr(@ptr_to_int(p) + 1);
         @byte_move(p, src, 3);
-        let result: i32 = @intCast(@byte_read(p, 0)) * 64
-            + @intCast(@byte_read(p, 1)) * 16
-            + @intCast(@byte_read(p, 2)) * 4
-            + @intCast(@byte_read(p, 3));
+        let result: i32 = @intCast(@ptr_read(@ptr_offset(p, 0))) * 64
+            + @intCast(@ptr_read(@ptr_offset(p, 1))) * 16
+            + @intCast(@ptr_read(@ptr_offset(p, 2))) * 4
+            + @intCast(@ptr_read(@ptr_offset(p, 3)));
         @free(p, 4, 1);
         result
     }
@@ -671,10 +676,10 @@ source = """
 fn main() -> i32 {
     checked {
         let p: ptr mut u8 = @alloc(2, 1);
-        @byte_write(p, 0, 40);
-        @byte_write(p, 1, 5);
+        @ptr_write(@ptr_offset(p, 0), 40);
+        @ptr_write(@ptr_offset(p, 1), 5);
         @byte_move(p, p, 2);
-        let result: i32 = @intCast(@byte_read(p, 0)) + @intCast(@byte_read(p, 1));
+        let result: i32 = @intCast(@ptr_read(@ptr_offset(p, 0))) + @intCast(@ptr_read(@ptr_offset(p, 1)));
         @free(p, 2, 1);
         result
     }
@@ -691,9 +696,9 @@ source = """
 fn main() -> i32 {
     checked {
         let p: ptr mut u8 = @alloc(1, 1);
-        @byte_write(p, 0, 77);
+        @ptr_write(@ptr_offset(p, 0), 77);
         @byte_move(p, p, 0);
-        let result: i32 = @intCast(@byte_read(p, 0));
+        let result: i32 = @intCast(@ptr_read(@ptr_offset(p, 0)));
         @free(p, 1, 1);
         result
     }

--- a/crates/rue-ui-tests/cases/diagnostics/alloc_infer_pointee.toml
+++ b/crates/rue-ui-tests/cases/diagnostics/alloc_infer_pointee.toml
@@ -63,8 +63,8 @@ source = """
 fn main() -> i32 {
     checked {
         let p: ptr mut u8 = @alloc(4, 1);
-        @byte_write(p, 0, 42);
-        let v: i32 = @intCast(@byte_read(p, 0));
+        @ptr_write(@ptr_offset(p, 0), 42);
+        let v: i32 = @intCast(@ptr_read(@ptr_offset(p, 0)));
         @free(p, 4, 1);
         v
     }

--- a/docs/designs/0057-file-io-v0.md
+++ b/docs/designs/0057-file-io-v0.md
@@ -248,9 +248,11 @@ now unblocks IO without waiting on the slice feature.
 
 `std.fs` source is trusted standard-library input (`ModuleOrigin::
 StandardLibrary`), so its use of the `raw_bytes` packed-byte intrinsics
-(`@alloc_bytes`/`@byte_read`/`@byte_write`/`@ptr_to_int`/`@free_bytes`) is
-authorized without a preview flag, exactly as `std/strbuf.rue` is — programs
-that consume `std.fs` need no `--preview raw_bytes`.
+(`@alloc`/`@free`/`@ptr_read`/`@ptr_write`/`@ptr_offset`/`@ptr_to_int`, the
+unified surface ADR-0059 folded the original `_bytes` and `@byte_read`/
+`@byte_write` names into) is authorized without a preview flag, exactly as
+`std/strbuf.rue` is — programs that consume `std.fs` need no
+`--preview raw_bytes`.
 
 ## Implementation status
 

--- a/docs/designs/0059-byte-oriented-memory-intrinsics.md
+++ b/docs/designs/0059-byte-oriented-memory-intrinsics.md
@@ -397,14 +397,12 @@ Phases are ordered by the sequencing above. RUE-937 is the tracking issue.
   `@byte_move(dst, src, size)`, the memmove-shaped sibling of `@byte_copy`
   (which stays memcpy-shaped, overlap undefined), over the new
   `__rue_byte_move` helper. Purely additive.
-- [ ] **Phase 4: Byte-correct typed access (post-RUE-971)** — RUE-962.
-  Make `@ptr_read`/`@ptr_write`/`@ptr_offset` physical-layout-driven; add
-  `@ptr_read_unaligned`/`@ptr_write_unaligned`; fold `@byte_read`/`@byte_write`
-  into `@ptr_read`/`@ptr_write`. Before implementing the `_unaligned` pair,
-  re-evaluate `*align(N)` alignment-qualified pointer types (see the ruling
-  below): if RUE-971 has landed and slices have stabilized by then, type-carried
-  alignment may replace the two-intrinsic split at near-zero churn, since
-  nothing will have been built on the split yet.
+- [x] **Phase 4: Byte-correct typed access (post-RUE-971)** — RUE-962.
+  `@ptr_read`/`@ptr_write`/`@ptr_offset` are physical-layout-driven,
+  `@ptr_read_unaligned`/`@ptr_write_unaligned` exist, and `@byte_read`/
+  `@byte_write` are folded into `@ptr_read`/`@ptr_write` (hard removal, no
+  alias window). The `*align(N)` re-evaluation this phase required was made and
+  declined; see the fold ruling under "Resolved at acceptance".
 - [ ] **Phase 5: Specification sweep** — RUE-963. Rewrite `4.13:5a` and
   `9.2:7`,`9.2:10`–`9.2:13`, and remove/fold `9.2:14a`–`9.2:14f`; update
   traceability.
@@ -476,6 +474,29 @@ The proposal's open questions, settled by the 2026-07-17 ratification:
   consumer overlaps today, and a later `@byte_move` (memmove) is purely
   additive. Superseded: `@byte_move` shipped in Phase 3b (RUE-964), exactly as
   the additive change this ruling anticipated.
+- **Byte-access fold: accepted with the two-call nesting; `@ptr_offset` stays
+  sugarless.** Ruled by Steve on 2026-08-10, closing Phase 4 (RUE-962). The
+  single-byte pair folds by direct substitution:
+
+  ```
+  @byte_read(p, i)      →  @ptr_read(@ptr_offset(p, i))
+  @byte_write(p, i, v)  →  @ptr_write(@ptr_offset(p, i), v)
+  ```
+
+  Both forms are equivalent because `@size_of(u8)` is `1` post-canonical-layout,
+  so an element-scaled `@ptr_offset` over a `ptr u8` strides exactly one byte;
+  the existing spec case
+  `byte_access_agrees_with_typed_access_on_a_u8_pointer` proved the two spellings
+  access the same byte before the fold. The substitution applies unchanged to
+  `ptr const u8`, since both `@ptr_offset` and `@ptr_read` accept const
+  pointers. The nesting is the accepted cost: no byte-granular `@ptr_offset`
+  sugar and no offset operand on the access pair are added, keeping one
+  element-scaled arithmetic intrinsic (9.2:7) and one typed access pair
+  (9.2:6b/9.2:6d) rather than reintroducing a parallel byte-shaped surface —
+  which is the very duplication this ADR exists to remove. Removal is hard, with
+  no alias window, matching the `_bytes` allocator ruling above: `@byte_read` is
+  now an unknown intrinsic (E0700). Spec rules `9.2:14d`/`14e`/`14f` are deleted
+  and their coverage re-homed onto `9.2:6b`/`9.2:6d`.
 - **Null primitive: keep the `@int_to_ptr(0)` idiom.** A dedicated `@null_ptr`
   acquires design questions (typed or untyped result?) better answered by the
   future provenance work.

--- a/docs/formal/01-core-calculus.md
+++ b/docs/formal/01-core-calculus.md
@@ -1962,7 +1962,8 @@ citation:
 `StrBuf` is the `u8` refinement of the trio's growable rung plus the
 byte-string convention (ADR-0043; the RUE-386 two-types ruling), and like
 `ArrayBuf` it is **source-defined** (`std/strbuf.rue`) over the byte-oriented
-unchecked intrinsics — `@byte_read`/`@byte_write`/`@byte_copy` and
+unchecked intrinsics — `@byte_copy` for bulk moves, `@ptr_read`/`@ptr_write`
+over a `ptr u8` for single bytes, and
 `@ptr_to_int`/`@int_to_ptr`/`@ptr_offset` directly, plus the `@alloc` of the
 literal-promotion arm below, with the growable `{buf, cap}` allocation itself
 delegated to the same `std/rawbuf.rue` core `ArrayBuf` uses (ADR-0059) — so the

--- a/docs/spec/src/04-expressions/13-intrinsics.md
+++ b/docs/spec/src/04-expressions/13-intrinsics.md
@@ -98,8 +98,6 @@ full semantics):
 | `@free` | Free an allocated block (§9.2) | 3 expressions (`ptr mut u8`, `u64` size, `u64` align) | `()` |
 | `@realloc` | Resize an allocated block, possibly moving it (§9.2) | 4 expressions (`ptr mut u8`, `u64` old size, `u64` align, `u64` new size) | `ptr mut u8` |
 | `@resize` | Resize an allocated block in place only (§9.2) | 4 expressions (`ptr mut u8`, `u64` old size, `u64` align, `u64` new size) | `bool` |
-| `@byte_read` | Read one physical byte | 2 expressions (`ptr const u8`/`ptr mut u8`, `u64`) | `u8` |
-| `@byte_write` | Write one physical byte | 3 expressions (`ptr mut u8`, `u64`, `u8`) | `()` |
 | `@byte_copy` | Copy `size` non-overlapping bytes | 3 expressions (`ptr mut u8`, `ptr const u8`/`ptr mut u8`, `u64`) | `()` |
 | `@byte_move` | Copy `size` possibly overlapping bytes (§9.2) | 3 expressions (`ptr mut u8`, `ptr const u8`/`ptr mut u8`, `u64`) | `()` |
 | `@byte_set` | Fill `size` bytes with a byte | 3 expressions (`ptr mut u8`, `u8`, `u64`) | `()` |

--- a/docs/spec/src/09-unchecked-code/01-syntax.md
+++ b/docs/spec/src/09-unchecked-code/01-syntax.md
@@ -104,7 +104,8 @@ within a `checked` block. Using one outside a `checked` block is a compile
 error. (Defining a `ptr const T` / `ptr mut T` value's *type* is always legal;
 only the pointer *operations* require a `checked` block.) The same requirement
 applies to the allocation family (9.2:13) and the raw-byte intrinsics
-(9.2:14e, 9.2:14h, 9.2:14l).
+(9.2:14h, 9.2:14l). Byte-granular access has no intrinsic of its own: it is
+`@ptr_read`/`@ptr_write` over a `ptr u8` (9.2:6d), already listed above.
 
 {{ rule(id="9.1:13", cat="example") }}
 

--- a/docs/spec/src/09-unchecked-code/02-intrinsics.md
+++ b/docs/spec/src/09-unchecked-code/02-intrinsics.md
@@ -89,7 +89,14 @@ and at `T = i32` exactly four. A write therefore leaves every byte outside
 `[address_of(p), address_of(p) + @size_of(T))` unchanged. The
 address **MUST** satisfy `@align_of(T)`; using this pair on an underaligned
 address is undefined behavior (§9.1, ADR-0028), for which `@ptr_read_unaligned`
-and `@ptr_write_unaligned` (9.2:14k) are the well-defined form.
+and `@ptr_write_unaligned` (9.2:14k) are the well-defined form. At `T = u8`
+this pair is therefore also the byte-granular access: `@ptr_read(p)` returns
+the single physical byte at `address_of(p)` as a `u8`, `@ptr_write(p, value)`
+stores exactly the eight bits of its `u8` value there and disturbs no
+neighbouring byte, and `@align_of(u8)` is `1` so every address is aligned for
+it. Combined with the one-byte `@ptr_offset` stride of 9.2:7, that is how an
+arbitrary byte of an allocation is addressed; Rue has no separate byte-read or
+byte-write intrinsic (ADR-0059).
 
 {{ rule(id="9.2:6c", cat="dynamic-semantics") }}
 
@@ -108,11 +115,14 @@ null, and `@ptr_to_int(p) == 0` is the null test.
 
 `@ptr_read` accepts a `ptr const T` or a `ptr mut T` and evaluates to `T`;
 `@ptr_write` requires a `ptr mut T` and a value of exactly the pointee type
-`T`, and evaluates to `()`. `@ptr_to_int` accepts a pointer of any pointee
-type and mutability and evaluates to `u64`. `@int_to_ptr` requires an operand
-of exactly `u64` — an untyped integer literal is not accepted, so the null
-idiom is written over a `u64` binding — and evaluates to a `ptr mut T` whose
-pointee type is inferred from context.
+`T`, and evaluates to `()`. Both require an enclosing `checked` block. At
+`T = u8` this reads as: a byte read accepts `ptr const u8` or `ptr mut u8` and
+evaluates to `u8`, while a byte write requires a `ptr mut u8` and a value of
+exactly `u8`. `@ptr_to_int` accepts a pointer of any pointee type and
+mutability and evaluates to `u64`. `@int_to_ptr` requires an operand of exactly
+`u64` — an untyped integer literal is not accepted, so the null idiom is
+written over a `u64` binding — and evaluates to a `ptr mut T` whose pointee
+type is inferred from context.
 
 {{ rule(id="9.2:6e", cat="example") }}
 
@@ -276,52 +286,22 @@ fn main() -> i32 {
 
 {{ rule(id="9.2:14a", cat="normative") }}
 
-The `@byte_read`, `@byte_write`, `@byte_copy`, `@byte_move`, `@byte_set`,
-`@ptr_read_unaligned`, and `@ptr_write_unaligned` intrinsics provide raw access
-to packed physical bytes and to potentially unaligned typed scalars. They may
-only appear inside a `checked` block. In the five byte-granular intrinsics every
-pointer is a `u8` pointer and every count and offset is a number of physical
-bytes, scaled by nothing: no operand of this family is multiplied by a pointee
-width. The two `_unaligned` intrinsics are instead pointee-typed, like the
-aligned pair of 9.2:6b — they take no count or offset and move exactly
-`@size_of(T)` bytes — and differ from it only in dropping the alignment
-obligation (9.2:14k).
+The `@byte_copy`, `@byte_move`, `@byte_set`, `@ptr_read_unaligned`, and
+`@ptr_write_unaligned` intrinsics provide raw access to packed physical bytes
+and to potentially unaligned typed scalars. They may only appear inside a
+`checked` block. In the three bulk byte-granular intrinsics every pointer is a
+`u8` pointer and every count is a number of physical bytes, scaled by nothing:
+no operand of that family is multiplied by a pointee width. The two
+`_unaligned` intrinsics are instead pointee-typed, like the aligned pair of
+9.2:6b — they take no count or offset and move exactly `@size_of(T)` bytes —
+and differ from it only in dropping the alignment obligation (9.2:14k).
 
-{{ rule(id="9.2:14d", cat="dynamic-semantics") }}
-
-`@byte_read(p, offset)` reads and returns exactly one physical byte at address
-`address_of(p) + offset`; `p` may be `ptr const u8` or `ptr mut u8` and `offset`
-has type `u64`. `@byte_write(p, offset, value)` writes exactly the low eight
-bits represented by its `u8` value at that address; `p` must be `ptr mut u8`.
-The `offset` is a plain byte displacement, added to the address unscaled. Since
-`@size_of(u8)` is `1`, that is the same address `@ptr_offset(p, offset)` names
-(9.2:7), so `@byte_read(p, offset)` and `@ptr_read(@ptr_offset(p, offset))`
-access the same single byte, as do `@byte_write` and the corresponding
-`@ptr_write`.
-
-{{ rule(id="9.2:14e", cat="legality-rule") }}
-
-`@byte_read` and `@byte_write` each require an enclosing `checked` block.
-`@byte_write` requires a `ptr mut u8`; `@byte_read` accepts `ptr const u8` or
-`ptr mut u8`. Their offset operand is exactly `u64` and a byte-write value is
-exactly `u8`. `@byte_read` evaluates to `u8` and `@byte_write` to `()`. The
-legality of the bulk intrinsics is 9.2:14h and that of the `_unaligned` pair is
-9.2:14l.
-
-{{ rule(id="9.2:14f", cat="example") }}
-
-```rue
-fn main() -> i32 {
-    checked {
-        let p = @alloc(2, 1);
-        @byte_write(p, 0, 65);
-        @byte_write(p, 1, 66);
-        let result: i32 = @intCast(@byte_read(p, 1));
-        @free(p, 2, 1);
-        result // 66
-    }
-}
-```
+Rue has no single-byte access intrinsic. Reading and writing one physical byte
+is the ordinary typed access of 9.2:6b at `T = u8`, addressed by the ordinary
+pointer arithmetic of 9.2:7: because `@size_of(u8)` is `1`, `@ptr_offset` over
+a `u8` pointer strides exactly one byte, so `@ptr_read(@ptr_offset(p, i))`
+reads and `@ptr_write(@ptr_offset(p, i), v)` writes the single byte at
+`address_of(p) + i` (ADR-0059).
 
 {{ rule(id="9.2:14g", cat="dynamic-semantics") }}
 
@@ -357,9 +337,9 @@ fn main() -> i32 {
         @byte_set(src, 7, 3);
         let dst = @alloc(3, 1);
         @byte_copy(dst, src, 3);
-        let result: i32 = @intCast(@byte_read(dst, 0))
-            + @intCast(@byte_read(dst, 1))
-            + @intCast(@byte_read(dst, 2));
+        let result: i32 = @intCast(@ptr_read(@ptr_offset(dst, 0)))
+            + @intCast(@ptr_read(@ptr_offset(dst, 1)))
+            + @intCast(@ptr_read(@ptr_offset(dst, 2)));
         @free(src, 3, 1);
         @free(dst, 3, 1);
         result // 21

--- a/docs/spec/src/appendices/B-undefined-behavior.md
+++ b/docs/spec/src/appendices/B-undefined-behavior.md
@@ -172,7 +172,6 @@ defines it.
 | Using a pointer obtained from `@raw`/`@raw_mut`/`@field_ptr` after the value it borrowed has been moved, dropped, or otherwise gone out of scope (a dangling pointer). | ADR-0028 |
 | Mutating storage through a `ptr mut T` while another live pointer aliases the same storage in a way the program's reasoning assumes cannot happen (aliasing violation). | ADR-0028 |
 | Accessing storage through a pointer that does not satisfy the pointee type's alignment requirement, other than through `@ptr_read_unaligned`/`@ptr_write_unaligned`, for which an underaligned address is well defined. | §9.2 (9.2:6b, 9.2:14k), ADR-0028 |
-| Reading or writing with `@byte_read`/`@byte_write` when `address_of(p) + offset` is not a live byte within the referenced storage, including null, out-of-bounds, use-after-free, and overflowed-address access. | §9.2 (9.2:14d) |
 | Copying with `@byte_copy` between regions that overlap: `[dst, dst + size)` and `[src, src + size)` must be disjoint. `@byte_move` is the well-defined form for overlapping regions. | §9.2 (9.2:14g) |
 | Reading or writing outside live storage with `@byte_copy`, `@byte_move`, or `@byte_set` — that is, when `size` reaches past the end of the block either operand addresses. A `size` of zero accesses no memory and is always defined. | §9.2 (9.2:14g) |
 | Passing an incorrect size or alignment, a pointer not returned by the allocation family, or an already-freed pointer to `@free`/`@realloc`/`@resize`. | §9.2 (9.2:11–13) |

--- a/std/c.rue
+++ b/std/c.rue
@@ -163,7 +163,8 @@ pub const c_bool = bool;
 /// scan both `strbuf_from_c_string` and `free_c_string` share.
 pub fn c_strlen(cstr: ptr mut u8) -> u64 {
     let mut len: u64 = 0;
-    while checked { @byte_read(cstr, len) } != 0 {
+    let nul: u8 = 0;
+    while checked { @ptr_read(@ptr_offset(cstr, len)) } != nul {
         len += 1;
     }
     len
@@ -192,10 +193,10 @@ pub fn owned_c_string(borrow source: strbuf.StrBuf) -> ptr mut u8 {
     let mut i: u64 = 0;
     while i < len {
         let byte = strbuf.StrBuf.byte_at_borrowed(borrow source, i);
-        checked { @byte_write(buf, i, byte); };
+        checked { @ptr_write(@ptr_offset(buf, i), byte); };
         i += 1;
     }
-    checked { @byte_write(buf, len, 0); };
+    checked { @ptr_write(@ptr_offset(buf, len), 0); };
     buf
 }
 
@@ -212,7 +213,7 @@ pub fn strbuf_from_c_string(cstr: ptr mut u8) -> strbuf.StrBuf {
     let mut out = strbuf.StrBuf.with_capacity(len);
     let mut i: u64 = 0;
     while i < len {
-        out.push(checked { @byte_read(cstr, i) });
+        out.push(checked { @ptr_read(@ptr_offset(cstr, i)) });
         i += 1;
     }
     out
@@ -227,7 +228,8 @@ pub fn strbuf_from_c_string(cstr: ptr mut u8) -> strbuf.StrBuf {
 /// string, or an already-freed pointer — is a contract violation.
 pub fn free_c_string(cstr: ptr mut u8) {
     let mut len: u64 = 0;
-    while checked { @byte_read(cstr, len) } != 0 {
+    let nul: u8 = 0;
+    while checked { @ptr_read(@ptr_offset(cstr, len)) } != nul {
         len += 1;
     }
     checked { @free(cstr, len + 1, 1); };

--- a/std/env.rue
+++ b/std/env.rue
@@ -40,7 +40,7 @@ fn copy_range(source: ptr mut u8, start: u64, count: u64) -> StrBuf {
     let mut out = StrBuf.with_capacity(count);
     let mut i: u64 = 0;
     while i < count {
-        let byte: u8 = checked { @byte_read(source, start + i) };
+        let byte: u8 = checked { @ptr_read(@ptr_offset(source, start + i)) };
         out.push(byte);
         i += 1;
     }
@@ -95,7 +95,7 @@ fn key_matches(entry_ptr: ptr mut u8, len: u64, borrow name: StrBuf, name_len: u
     }
     let mut i: u64 = 0;
     while i < name_len {
-        let entry_byte: u8 = checked { @byte_read(entry_ptr, i) };
+        let entry_byte: u8 = checked { @ptr_read(@ptr_offset(entry_ptr, i)) };
         // `name` is a borrow, so read its bytes through the borrow-safe
         // accessor: the trapping `name[i]` index form is a by-copy read that
         // would move out of the borrowed `StrBuf` (E0429).
@@ -105,7 +105,7 @@ fn key_matches(entry_ptr: ptr mut u8, len: u64, borrow name: StrBuf, name_len: u
         }
         i += 1;
     }
-    let separator: u8 = checked { @byte_read(entry_ptr, name_len) };
+    let separator: u8 = checked { @ptr_read(@ptr_offset(entry_ptr, name_len)) };
     separator == 61
 }
 

--- a/std/fs.rue
+++ b/std/fs.rue
@@ -437,23 +437,24 @@ fn _stat_size_offset() -> u64 {
 fn _stat_buf_size() -> u64 { 256 }
 
 // Decode the two v1 fields from a kernel-filled `struct stat` buffer at the
-// per-target offsets above. Reads bytes through `@byte_read` and reassembles
-// them little-endian, so nothing depends on Rue struct layout.
+// per-target offsets above. Reads bytes through `@ptr_read` over a
+// `@ptr_offset` walk of the `ptr u8` and reassembles them little-endian, so
+// nothing depends on Rue struct layout.
 fn _decode_stat(buf: ptr mut u8) -> Metadata {
     let mo = _stat_mode_offset();
-    let m0 = checked { @byte_read(buf, mo) };
-    let m1 = checked { @byte_read(buf, mo + 1) };
+    let m0 = checked { @ptr_read(@ptr_offset(buf, mo)) };
+    let m1 = checked { @ptr_read(@ptr_offset(buf, mo + 1)) };
     let mode = binary.u16_from_le_bytes([m0, m1]);
 
     let so = _stat_size_offset();
-    let s0 = checked { @byte_read(buf, so) };
-    let s1 = checked { @byte_read(buf, so + 1) };
-    let s2 = checked { @byte_read(buf, so + 2) };
-    let s3 = checked { @byte_read(buf, so + 3) };
-    let s4 = checked { @byte_read(buf, so + 4) };
-    let s5 = checked { @byte_read(buf, so + 5) };
-    let s6 = checked { @byte_read(buf, so + 6) };
-    let s7 = checked { @byte_read(buf, so + 7) };
+    let s0 = checked { @ptr_read(@ptr_offset(buf, so)) };
+    let s1 = checked { @ptr_read(@ptr_offset(buf, so + 1)) };
+    let s2 = checked { @ptr_read(@ptr_offset(buf, so + 2)) };
+    let s3 = checked { @ptr_read(@ptr_offset(buf, so + 3)) };
+    let s4 = checked { @ptr_read(@ptr_offset(buf, so + 4)) };
+    let s5 = checked { @ptr_read(@ptr_offset(buf, so + 5)) };
+    let s6 = checked { @ptr_read(@ptr_offset(buf, so + 6)) };
+    let s7 = checked { @ptr_read(@ptr_offset(buf, so + 7)) };
     let size = binary.u64_from_le_bytes([s0, s1, s2, s3, s4, s5, s6, s7]);
 
     Metadata { mode: mode, size_bytes: size }
@@ -541,10 +542,10 @@ fn _path_to_cbuf(borrow path: strbuf.StrBuf) -> ptr mut u8 {
             O.Some(x) => x,
             O.None => 0,
         };
-        checked { @byte_write(buf, i, b); };
+        checked { @ptr_write(@ptr_offset(buf, i), b); };
         i += 1;
     }
-    checked { @byte_write(buf, n, 0); };
+    checked { @ptr_write(@ptr_offset(buf, n), 0); };
     buf
 }
 
@@ -623,7 +624,7 @@ pub struct File {
         let n: u64 = @intCast(ret);
         let mut i: u64 = 0;
         while i < n {
-            let b = checked { @byte_read(tmp, i) };
+            let b = checked { @ptr_read(@ptr_offset(tmp, i)) };
             buf.push(b);
             i += 1;
         }
@@ -647,7 +648,7 @@ pub struct File {
         }
         let mut i: u64 = 0;
         while i < n {
-            checked { @byte_write(tmp, i, buf.get_or(i, 0)); };
+            checked { @ptr_write(@ptr_offset(tmp, i), buf.get_or(i, 0)); };
             i += 1;
         }
         let addr: u64 = checked { @ptr_to_int(tmp) };
@@ -674,7 +675,7 @@ pub struct File {
         }
         let mut i: u64 = 0;
         while i < n {
-            checked { @byte_write(tmp, i, buf.get_or(i, 0)); };
+            checked { @ptr_write(@ptr_offset(tmp, i), buf.get_or(i, 0)); };
             i += 1;
         }
         let base: u64 = checked { @ptr_to_int(tmp) };

--- a/std/mem.rue
+++ b/std/mem.rue
@@ -26,10 +26,10 @@ pub fn swap(comptime T: type, inout a: T, inout b: T) {
     let pb: ptr mut u8 = checked { @int_to_ptr(addr_b) };
     let mut i: u64 = 0;
     while i < size {
-        let ta = checked { @byte_read(pa, i) };
-        let tb = checked { @byte_read(pb, i) };
-        checked { @byte_write(pa, i, tb); };
-        checked { @byte_write(pb, i, ta); };
+        let ta = checked { @ptr_read(@ptr_offset(pa, i)) };
+        let tb = checked { @ptr_read(@ptr_offset(pb, i)) };
+        checked { @ptr_write(@ptr_offset(pa, i), tb); };
+        checked { @ptr_write(@ptr_offset(pb, i), ta); };
         i += 1;
     }
 }

--- a/std/net.rue
+++ b/std/net.rue
@@ -307,7 +307,7 @@ fn _sockaddr_to_kernel_buf(b: [u8; 16]) -> ptr mut u8 {
     }
     let mut i: u64 = 0;
     while i < 16 {
-        checked { @byte_write(buf, i, b[i]); };
+        checked { @ptr_write(@ptr_offset(buf, i), b[i]); };
         i += 1;
     }
     buf
@@ -392,7 +392,7 @@ pub struct TcpStream {
         let n: u64 = @intCast(ret);
         let mut i: u64 = 0;
         while i < n {
-            let b = checked { @byte_read(tmp, i) };
+            let b = checked { @ptr_read(@ptr_offset(tmp, i)) };
             buf.push(b);
             i += 1;
         }
@@ -415,7 +415,7 @@ pub struct TcpStream {
         }
         let mut i: u64 = 0;
         while i < n {
-            checked { @byte_write(tmp, i, buf.get_or(i, 0)); };
+            checked { @ptr_write(@ptr_offset(tmp, i), buf.get_or(i, 0)); };
             i += 1;
         }
         let addr: u64 = checked { @ptr_to_int(tmp) };
@@ -442,7 +442,7 @@ pub struct TcpStream {
         }
         let mut i: u64 = 0;
         while i < n {
-            checked { @byte_write(tmp, i, buf.get_or(i, 0)); };
+            checked { @ptr_write(@ptr_offset(tmp, i), buf.get_or(i, 0)); };
             i += 1;
         }
         let base: u64 = checked { @ptr_to_int(tmp) };
@@ -572,10 +572,10 @@ pub struct TcpListener {
         if checked { @ptr_to_int(lbuf) } == 0 {
             @panic("out of memory");
         }
-        checked { @byte_write(lbuf, 0, 16); };
-        checked { @byte_write(lbuf, 1, 0); };
-        checked { @byte_write(lbuf, 2, 0); };
-        checked { @byte_write(lbuf, 3, 0); };
+        checked { @ptr_write(@ptr_offset(lbuf, 0), 16); };
+        checked { @ptr_write(@ptr_offset(lbuf, 1), 0); };
+        checked { @ptr_write(@ptr_offset(lbuf, 2), 0); };
+        checked { @ptr_write(@ptr_offset(lbuf, 3), 0); };
         let aaddr: u64 = checked { @ptr_to_int(abuf) };
         let laddr: u64 = checked { @ptr_to_int(lbuf) };
         let fd_u: u64 = @intCast(self.fd);
@@ -585,24 +585,24 @@ pub struct TcpListener {
             checked { @free(lbuf, 4, 1); };
             return R.Err(_normalize_net_errno(0 - ret));
         }
-        let l0 = checked { @byte_read(lbuf, 0) };
-        let l1 = checked { @byte_read(lbuf, 1) };
-        let l2 = checked { @byte_read(lbuf, 2) };
-        let l3 = checked { @byte_read(lbuf, 3) };
+        let l0 = checked { @ptr_read(@ptr_offset(lbuf, 0)) };
+        let l1 = checked { @ptr_read(@ptr_offset(lbuf, 1)) };
+        let l2 = checked { @ptr_read(@ptr_offset(lbuf, 2)) };
+        let l3 = checked { @ptr_read(@ptr_offset(lbuf, 3)) };
         checked { @free(lbuf, 4, 1); };
         let written_len = binary.u32_from_le_bytes([l0, l1, l2, l3]);
         if written_len != 16 {
             checked { @free(abuf, sockaddr_in_len(), 1); };
             return R.Err(NetworkError.InvalidInput);
         }
-        let b0 = checked { @byte_read(abuf, 0) };
-        let b1 = checked { @byte_read(abuf, 1) };
-        let b2 = checked { @byte_read(abuf, 2) };
-        let b3 = checked { @byte_read(abuf, 3) };
-        let b4 = checked { @byte_read(abuf, 4) };
-        let b5 = checked { @byte_read(abuf, 5) };
-        let b6 = checked { @byte_read(abuf, 6) };
-        let b7 = checked { @byte_read(abuf, 7) };
+        let b0 = checked { @ptr_read(@ptr_offset(abuf, 0)) };
+        let b1 = checked { @ptr_read(@ptr_offset(abuf, 1)) };
+        let b2 = checked { @ptr_read(@ptr_offset(abuf, 2)) };
+        let b3 = checked { @ptr_read(@ptr_offset(abuf, 3)) };
+        let b4 = checked { @ptr_read(@ptr_offset(abuf, 4)) };
+        let b5 = checked { @ptr_read(@ptr_offset(abuf, 5)) };
+        let b6 = checked { @ptr_read(@ptr_offset(abuf, 6)) };
+        let b7 = checked { @ptr_read(@ptr_offset(abuf, 7)) };
         checked { @free(abuf, sockaddr_in_len(), 1); };
         let bytes: [u8; 16] = [b0, b1, b2, b3, b4, b5, b6, b7, 0, 0, 0, 0, 0, 0, 0, 0];
         let O = option.Option(SockAddr);

--- a/std/strbuf.rue
+++ b/std/strbuf.rue
@@ -9,9 +9,10 @@
 // core (RUE-1066), the same core `ArrayBuf(T)` builds on — so both canonical
 // growable containers own their heap through one primitive. StrBuf adds the
 // length and the byte-string algorithms on top. The packed bytes are still
-// read/written through the byte intrinsics (`@byte_read`/`@byte_write`/
-// `@byte_copy`) for the memcpy-shaped bulk copies; only the raw `{buf, cap}`
-// ownership (allocate / grow / free / teardown) is delegated to the core.
+// read/written one at a time through `@ptr_read`/`@ptr_write` over a
+// `@ptr_offset` walk of the `ptr u8`, and in bulk through `@byte_copy`; only
+// the raw `{buf, cap}` ownership (allocate / grow / free / teardown) is
+// delegated to the core.
 //
 // Interoperability with core `str` and `ArrayBuf(u8)` is explicit and copying:
 // `from_str`, `from_bytes`, and `to_bytes` create independent owners, while
@@ -26,11 +27,11 @@ const rawbuf = @import("rawbuf.rue");
 // them outside the public struct prevents callers from laundering unchecked
 // arbitrary pointers through safe-looking associated functions.
 fn read_packed_byte(source: ptr mut u8, index: u64) -> u8 {
-    checked { @byte_read(source, index) }
+    checked { @ptr_read(@ptr_offset(source, index)) }
 }
 
 fn write_packed_byte(destination: ptr mut u8, index: u64, byte: u8) {
-    checked { @byte_write(destination, index, byte); };
+    checked { @ptr_write(@ptr_offset(destination, index), byte); };
 }
 
 fn copy_packed_bytes(


### PR DESCRIPTION
Implements the recorded ruling on RUE-962 (fold as designed, keep `@ptr_offset` sugarless, accept the nesting) — the last open phase of ADR-0059. Draft until premerge completes on the integrated tree.

## Change
- `@byte_read(p, i)` → `@ptr_read(@ptr_offset(p, i))`; `@byte_write(p, i, v)` → `@ptr_write(@ptr_offset(p, i), v)` at every site: std (net/fs/c/mem/env/strbuf), spec cases (raw-bytes, heap, pointers), CLI cases, fixtures, backend unit tests, the UI case, and the oracle's `ByteRead`/`ByteWrite` arms + arity entries.
- Hard removal, no alias window (the RUE-961 convention): both names are now E0700.
- Spec rules 9.2:14d/14e/14f deleted, coverage re-homed onto the typed-access rules 9.2:6b/6d; 4.13 quick-reference rows dropped; the ruling recorded in ADR-0059's acceptance section; Appendix B's byte-access row removed as exactly subsumed by the `@ptr_read`/`@ptr_offset` rows.
- The old equivalence spec case became a tautology post-rewrite; it now pins the offset-zero identity instead of vacuous green.
- Rewrites were done with a paren-balanced rewriter (self-tested on adversarial nesting/comma/string cases), arguments copied verbatim — no loop "improvements".

## Finding worth knowing (filed as RUE-1341)
The substitution is not inference-transparent: the byte intrinsics pinned `u8` during inference, while the typed pair derives its type in sema. `@ptr_read(p) == 30` fails E0206 and `@ptr_write(p, @intCast(x))` fails E0709 — proven **pre-existing** on a clean base checkout. 28 sites carry explicit annotations as the fold's ergonomic cost.

## Verification
- Worker: full `./test.sh` green (166 pass / 0 fail, sentinel-verified exit code), fmt clean; first full-suite run caught two preview-gated `c_ffi` sites and one traceability regression the targeted suites structurally could not — both fixed, traceability at 99.6% with no net loss
- Integration re-verification by execution: `@byte_write` is E0700; CLI strbuf 41 / fs 21 / net 5 / env 8 green; spec raw_bytes 39 / heap 22 / pointers 21 green
- `scripts/rue premerge` running on the integrated tree; flips to ready when green

Fixes RUE-962

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GPYyXZHFGimCvkbzMtBG2U

---
_Generated by [Claude Code](https://claude.ai/code/session_01GPYyXZHFGimCvkbzMtBG2U)_