### PR TITLE
RUE-1342: measure scaling with optimized compiler

### DIFF
--- a/.github/workflows/performance-scaling.yml
+++ b/.github/workflows/performance-scaling.yml
@@ -30,7 +30,7 @@ jobs:
         uses: facebook/install-dotslash@v2
 
       - name: Build the compiler and measurement runner
-        run: ./buck2 build //crates/rue:rue //crates/rue-bench:rue-bench
+        run: ./buck2 build //crates/rue:rue //crates/rue-bench:rue-bench --target-platforms //platforms:release
 
       - name: Measure maintained programs
         env:
@@ -39,8 +39,8 @@ jobs:
         run: |
           set -euo pipefail
           mkdir -p scaling-report
-          RUE="$(scripts/rue-bin)"
-          BENCH="$(./buck2 build //crates/rue-bench:rue-bench --show-simple-output 2>/dev/null | tail -1)"
+          RUE="$(scripts/rue-bin --target-platforms //platforms:release)"
+          BENCH="$(./buck2 build //crates/rue-bench:rue-bench --target-platforms //platforms:release --show-simple-output 2>/dev/null | tail -1)"
           "$BENCH" scaling \
             --manifest performance/scaling.toml \
             --compiler "$RUE" \

--- a/crates/rue-bench/src/measure.rs
+++ b/crates/rue-bench/src/measure.rs
@@ -64,6 +64,7 @@ struct BenchmarkJson {
 #[derive(serde::Deserialize)]
 struct BenchmarkMetadata {
     target: String,
+    compiler_build_profile: String,
 }
 
 #[derive(serde::Deserialize)]
@@ -87,6 +88,7 @@ struct CompletedCompile {
     output_binary_bytes: u64,
     shape: WorkloadShape,
     target: String,
+    compiler_build_profile: String,
 }
 
 /// The raw result of one fresh compiler process for the scaling report.
@@ -94,6 +96,7 @@ pub struct FreshCompile {
     pub sample: Sample,
     pub shape: WorkloadShape,
     pub target: String,
+    pub compiler_build_profile: String,
 }
 
 /// Measure one sample.
@@ -170,6 +173,7 @@ pub fn measure_fresh_compile(request: &SampleRequest<'_>) -> Result<FreshCompile
         },
         shape: completed.shape,
         target: completed.target,
+        compiler_build_profile: completed.compiler_build_profile,
     })
 }
 
@@ -255,6 +259,7 @@ fn run_once(request: &SampleRequest<'_>) -> Result<CompletedCompile, String> {
             functions: parsed.source_metrics.functions,
         },
         target: parsed.metadata.target,
+        compiler_build_profile: parsed.metadata.compiler_build_profile,
     })
 }
 

--- a/crates/rue-bench/src/scaling.rs
+++ b/crates/rue-bench/src/scaling.rs
@@ -110,6 +110,12 @@ pub fn run() -> Result<(), String> {
                 }
                 Some(_) => {}
             }
+            if measured.compiler_build_profile != manifest.compiler_build_profile {
+                return Err(format!(
+                    "scaling workload {:?} requires compiler build profile {:?}, but the compiler reported {:?}",
+                    workload.id, manifest.compiler_build_profile, measured.compiler_build_profile,
+                ));
+            }
             samples.push(measured.sample);
         }
         observations.push(ScalingObservation {
@@ -137,6 +143,7 @@ pub fn run() -> Result<(), String> {
             program_runtime_executed: false,
             samples_per_workload: manifest.samples,
             compiler_args: manifest.args,
+            compiler_build_profile: manifest.compiler_build_profile,
         },
         workloads: observations,
     };
@@ -214,10 +221,11 @@ fn render(report: &ScalingReport) -> String {
     let mut out = String::new();
     out.push_str("# Rue compiler scaling report\n\n");
     out.push_str(&format!(
-        "- Commit: `{}`\n- Fixture revision: {}\n- Target: `{}`\n- Machine: {} ({} cores, {} bytes memory)\n- Runner: `{}` / `{}` ({})\n- Regime: {} sequential fresh compiler processes per workload; OS page-cache state is uncontrolled.\n- Runtime separation: compiled programs were not executed.\n\n",
+        "- Commit: `{}`\n- Fixture revision: {}\n- Target: `{}`\n- Compiler build profile: `{}`\n- Machine: {} ({} cores, {} bytes memory)\n- Runner: `{}` / `{}` ({})\n- Regime: {} sequential fresh compiler processes per workload; OS page-cache state is uncontrolled.\n- Runtime separation: compiled programs were not executed.\n\n",
         report.identity.commit,
         report.identity.manifest_revision,
         report.identity.target,
+        report.regime.compiler_build_profile,
         report.identity.environment.cpu_model,
         report.identity.environment.core_count,
         report.identity.environment.memory_bytes,
@@ -359,6 +367,7 @@ mod tests {
                 program_runtime_executed: false,
                 samples_per_workload: 2,
                 compiler_args: Vec::new(),
+                compiler_build_profile: "release_thin_lto".to_string(),
             },
             workloads: vec![ScalingObservation {
                 workload: "probe".to_string(),
@@ -381,6 +390,7 @@ mod tests {
     fn markdown_states_the_regime_and_runtime_separation() {
         let rendered = render(&report());
         assert!(rendered.contains("OS page-cache state is uncontrolled"));
+        assert!(rendered.contains("Compiler build profile: `release_thin_lto`"));
         assert!(rendered.contains("compiled programs were not executed"));
         assert!(rendered.contains("median absolute deviation"));
         assert!(rendered.contains("shape id"));

--- a/crates/rue-cli-tests/cases/benchmark_json.toml
+++ b/crates/rue-cli-tests/cases/benchmark_json.toml
@@ -15,7 +15,8 @@ args = ["--benchmark-json", "main.rue", "-o", "prog"]
 env = { RUST_LOG = "error" }
 exit_code = 42
 compile_stdout_contains = [
-  '"schema_version":4',
+  '"schema_version":5',
+  '"compiler_build_profile":',
   '"timing_model":"inclusive_spans"',
   # The additive partition, which is the only model that may be stacked. Its
   # bands are integer nanoseconds summing exactly to compiler_root_ns.

--- a/crates/rue-perf-schema/src/scaling.rs
+++ b/crates/rue-perf-schema/src/scaling.rs
@@ -12,7 +12,7 @@ use serde::{Deserialize, Serialize};
 use crate::{EnvironmentFingerprint, Sample};
 
 /// Version of the scaling-report wire format.
-pub const SCALING_REPORT_SCHEMA_VERSION: u32 = 1;
+pub const SCALING_REPORT_SCHEMA_VERSION: u32 = 2;
 
 /// The lower-frequency scaling suite declaration.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -27,6 +27,8 @@ pub struct ScalingManifest {
     /// Behaviour-affecting arguments passed to every compiler process.
     #[serde(default)]
     pub args: Vec<String>,
+    /// Required Rust build profile of the compiler binary under measurement.
+    pub compiler_build_profile: String,
     /// Maintained programs, in report order.
     pub workloads: Vec<ScalingWorkload>,
 }
@@ -36,7 +38,7 @@ impl ScalingManifest {
     pub fn parse(text: &str) -> Result<Self, String> {
         let manifest: ScalingManifest =
             toml::from_str(text).map_err(|error| format!("invalid scaling manifest: {error}"))?;
-        if manifest.schema_version != 1 {
+        if manifest.schema_version != 2 {
             return Err(format!(
                 "unsupported scaling manifest schema version {}",
                 manifest.schema_version
@@ -44,6 +46,9 @@ impl ScalingManifest {
         }
         if manifest.samples < 2 {
             return Err("scaling measurements require at least two samples".to_string());
+        }
+        if manifest.compiler_build_profile.is_empty() {
+            return Err("the scaling manifest declares no compiler build profile".to_string());
         }
         if manifest.workloads.is_empty() {
             return Err("the scaling manifest declares no workloads".to_string());
@@ -125,6 +130,8 @@ pub struct ScalingRegime {
     pub samples_per_workload: u32,
     /// Behaviour-affecting arguments passed to every compiler process.
     pub compiler_args: Vec<String>,
+    /// Rust build profile reported by the compiler binary.
+    pub compiler_build_profile: String,
 }
 
 /// Raw measurements for one maintained program.
@@ -167,9 +174,10 @@ mod tests {
     use super::*;
 
     const VALID: &str = r#"
-schema_version = 1
+schema_version = 2
 revision = 2
 samples = 3
+compiler_build_profile = "release_thin_lto"
 
 [[workloads]]
 id = "ruelex"
@@ -182,6 +190,7 @@ question = "small maintained compiler frontend"
         let manifest = ScalingManifest::parse(VALID).unwrap();
         assert_eq!(manifest.revision, 2);
         assert_eq!(manifest.samples, 3);
+        assert_eq!(manifest.compiler_build_profile, "release_thin_lto");
         assert_eq!(manifest.workloads[0].id, "ruelex");
     }
 

--- a/crates/rue/BUCK
+++ b/crates/rue/BUCK
@@ -30,6 +30,7 @@ rue_crate(
     deps = _DEPS,
     rustc_flags = [
         "--check-cfg=cfg(rue_benchmark_allocations)",
+        "--check-cfg=cfg(rue_release_build)",
         "--check-cfg=cfg(test)",
     ],
 )
@@ -45,6 +46,7 @@ rue_binary(
     ],
     rustc_flags = [
         "--check-cfg=cfg(rue_benchmark_allocations)",
+        "--check-cfg=cfg(rue_release_build)",
         "--check-cfg=cfg(test)",
     ],
 )
@@ -60,6 +62,7 @@ rue_binary(
     rustc_flags = [
         "--cfg=rue_benchmark_allocations",
         "--check-cfg=cfg(rue_benchmark_allocations)",
+        "--check-cfg=cfg(rue_release_build)",
         "--check-cfg=cfg(test)",
     ],
     tests = False,

--- a/crates/rue/src/timing.rs
+++ b/crates/rue/src/timing.rs
@@ -99,6 +99,11 @@ use std::sync::{Arc, Mutex, PoisonError, Weak};
 use std::thread::ThreadId;
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
+#[cfg(rue_release_build)]
+const COMPILER_BUILD_PROFILE: &str = "release_thin_lto";
+#[cfg(not(rue_release_build))]
+const COMPILER_BUILD_PROFILE: &str = "debug";
+
 use rue_perf_schema::{Phase, PhaseAccounting};
 use serde::Serialize;
 
@@ -329,6 +334,8 @@ pub struct BenchmarkMetadata {
     pub version: String,
     /// Target platform (e.g., "x86_64-linux", "aarch64-macos").
     pub target: String,
+    /// Build profile of the Rust compiler binary being measured.
+    pub compiler_build_profile: &'static str,
 }
 
 /// Timing data for a single compiler pass.
@@ -694,10 +701,11 @@ impl TimingData {
             timestamp: iso8601_now(),
             version: version.to_string(),
             target: target.to_string(),
+            compiler_build_profile: COMPILER_BUILD_PROFILE,
         };
 
         BenchmarkTiming {
-            schema_version: 4,
+            schema_version: 5,
             timing_model: "inclusive_spans",
             phase_accounting,
             metadata,
@@ -2046,7 +2054,10 @@ mod tests {
         data.record("lexer", Duration::from_millis(100));
 
         let json = data.to_json_with_metrics("x86_64-linux", "0.1.0", None, None);
-        assert!(json.contains("\"schema_version\":4"));
+        assert!(json.contains("\"schema_version\":5"));
+        assert!(json.contains(&format!(
+            "\"compiler_build_profile\":\"{COMPILER_BUILD_PROFILE}\""
+        )));
         assert!(json.contains("\"timing_model\":\"inclusive_spans\""));
         assert!(json.contains("\"passes\""));
         assert!(json.contains("\"name\""));
@@ -2703,7 +2714,11 @@ mod phase_accounting_tests {
         });
 
         let timing = data.to_benchmark_timing_with_metrics("probe-target", "probe", None, None);
-        assert_eq!(timing.schema_version, 4);
+        assert_eq!(timing.schema_version, 5);
+        assert_eq!(
+            timing.metadata.compiler_build_profile,
+            COMPILER_BUILD_PROFILE
+        );
         assert_eq!(timing.timing_model, "inclusive_spans");
         assert_invariant(&timing.phase_accounting);
 

--- a/docs/process/compiler-scaling.md
+++ b/docs/process/compiler-scaling.md
@@ -12,6 +12,11 @@ it for `--benchmark-json`. There is no retained compiler session or persistent
 query cache. Filesystem and operating-system page-cache state are not reset, so
 the reports call this a **fresh-process compile**, not a cold compile.
 
+The compiler and measurement runner are built with the release target platform
+(`-Copt-level=3 -Clto=thin`). The compiler reports that profile in its benchmark
+metadata, and the scaling runner rejects a binary that does not match the
+manifest's declared profile.
+
 The runner executes three samples sequentially for each workload. JSON keeps
 every raw observation in integer nanoseconds. The Markdown view reports the
 median and median absolute deviation (MAD), along with the machine and hosted
@@ -31,9 +36,9 @@ cannot be mistaken for a compiler regression.
 Build the compiler and the existing ADR-0067 runner, then run its scaling mode:
 
 ```bash
-./buck2 build //crates/rue:rue //crates/rue-bench:rue-bench
-RUE="$(scripts/rue-bin)"
-BENCH="$(./buck2 build //crates/rue-bench:rue-bench --show-simple-output 2>/dev/null | tail -1)"
+./buck2 build //crates/rue:rue //crates/rue-bench:rue-bench --target-platforms //platforms:release
+RUE="$(scripts/rue-bin --target-platforms //platforms:release)"
+BENCH="$(./buck2 build //crates/rue-bench:rue-bench --target-platforms //platforms:release --show-simple-output 2>/dev/null | tail -1)"
 "$BENCH" scaling \
   --manifest performance/scaling.toml \
   --compiler "$RUE" \

--- a/performance/scaling.toml
+++ b/performance/scaling.toml
@@ -5,10 +5,11 @@
 # startup probe's calibrated sample counts or enter the fast headline index.
 # Every sample launches the canonical compiler binary in a fresh process. The
 # compiled program is never run.
-schema_version = 1
-revision = 1
+schema_version = 2
+revision = 2
 samples = 3
 args = []
+compiler_build_profile = "release_thin_lto"
 
 [[workloads]]
 id = "ruelex"

--- a/scripts/test-release-configuration.py
+++ b/scripts/test-release-configuration.py
@@ -38,7 +38,8 @@ class ReleaseConfigurationTests(unittest.TestCase):
     def test_requires_release_flags_and_forbids_them_in_debug(self) -> None:
         self.assertEqual(
             release_configuration.validate_commands(
-                "[rustc]", "[rustc, -Copt-level=3, -Clto=thin]"
+                "[rustc]",
+                "[rustc, -Copt-level=3, -Clto=thin, --cfg=rue_release_build]",
             ),
             [],
         )
@@ -47,6 +48,18 @@ class ReleaseConfigurationTests(unittest.TestCase):
         )
         self.assertIn("debug rustc_cfg unexpectedly contains -Clto=thin", errors)
         self.assertIn("release rustc_cfg is missing -Clto=thin", errors)
+        self.assertIn("release rustc_cfg is missing --cfg=rue_release_build", errors)
+
+    def test_scaling_workflow_must_build_and_resolve_release_binaries(self) -> None:
+        valid = "\n".join(release_configuration.SCALING_RELEASE_SNIPPETS)
+        self.assertEqual(
+            release_configuration.validate_scaling_workflow(valid),
+            [],
+        )
+        errors = release_configuration.validate_scaling_workflow(
+            valid.replace("scripts/rue-bin --target-platforms //platforms:release", "scripts/rue-bin")
+        )
+        self.assertTrue(any("scripts/rue-bin" in error for error in errors), errors)
 
     def test_rejects_missing_or_ambiguous_rustc_action(self) -> None:
         with self.assertRaisesRegex(ValueError, "0 matching"):

--- a/scripts/validate-release-configuration.py
+++ b/scripts/validate-release-configuration.py
@@ -16,7 +16,13 @@ PLATFORMS = {
     "debug": "//platforms:debug",
     "release": "//platforms:release",
 }
-RELEASE_FLAGS = ("-Copt-level=3", "-Clto=thin")
+RELEASE_FLAGS = ("-Copt-level=3", "-Clto=thin", "--cfg=rue_release_build")
+SCALING_WORKFLOW = ROOT / ".github" / "workflows" / "performance-scaling.yml"
+SCALING_RELEASE_SNIPPETS = (
+    "./buck2 build //crates/rue:rue //crates/rue-bench:rue-bench --target-platforms //platforms:release",
+    'RUE="$(scripts/rue-bin --target-platforms //platforms:release)"',
+    'BENCH="$(./buck2 build //crates/rue-bench:rue-bench --target-platforms //platforms:release --show-simple-output',
+)
 
 def rustc_cfg_command(payload: str, platform: str) -> str:
     try:
@@ -44,6 +50,14 @@ def validate_commands(debug: str, release: str) -> list[str]:
         if flag in debug:
             errors.append(f"debug rustc_cfg unexpectedly contains {flag}")
     return errors
+
+
+def validate_scaling_workflow(workflow: str) -> list[str]:
+    return [
+        f"compiler-scaling workflow is missing release command: {snippet}"
+        for snippet in SCALING_RELEASE_SNIPPETS
+        if snippet not in workflow
+    ]
 
 
 def query(buck2: Path, platform: str) -> str:
@@ -79,7 +93,14 @@ def main() -> int:
         print(f"error: could not inspect Buck release configuration: {error}", file=sys.stderr)
         return 1
 
+    try:
+        scaling_workflow = SCALING_WORKFLOW.read_text()
+    except OSError as error:
+        print(f"error: could not read compiler-scaling workflow: {error}", file=sys.stderr)
+        return 1
+
     errors = validate_commands(debug, release)
+    errors.extend(validate_scaling_workflow(scaling_workflow))
     if errors:
         for error in errors:
             print(f"error: {error}", file=sys.stderr)
@@ -87,7 +108,7 @@ def main() -> int:
 
     print(
         "release configuration valid: release has "
-        f"{' '.join(RELEASE_FLAGS)}; debug does not"
+        f"{' '.join(RELEASE_FLAGS)}; debug does not; compiler scaling selects release"
     )
     return 0
 

--- a/toolchains/rust/BUCK
+++ b/toolchains/rust/BUCK
@@ -74,7 +74,8 @@ http_archive(
 # when no opt-level constraint is set (a plain `//crates/rue:rue` build stays
 # debug/unoptimized).
 #
-# `-Clto=thin` is only applied to crates configured under the release target
+# `-Clto=thin` and the `rue_release_build` identity cfg are only applied to
+# crates configured under the release target
 # platform. Proc-macro crates (serde_derive, logos-derive, ...) are exec-deps
 # configured under the execution platform, which has no opt-level constraint, so
 # they hit the DEFAULT arm and never receive `-Clto=thin` — sidestepping rustc's
@@ -82,7 +83,11 @@ http_archive(
 _OPT_FLAGS = select({
     "DEFAULT": [],
     "root//constraints:debug": [],
-    "root//constraints:release": ["-Copt-level=3", "-Clto=thin"],
+    "root//constraints:release": [
+        "-Copt-level=3",
+        "-Clto=thin",
+        "--cfg=rue_release_build",
+    ],
 })
 
 # The manual cache probe supplies a unique value for each workflow attempt so


### PR DESCRIPTION
## Summary

- build and resolve the maintained scaling compiler and runner with the release target platform
- publish the compiler's Rust build profile in benchmark JSON and require the manifest-declared profile for every scaling sample
- advance the scaling schema and fixture revision, document the corrected regime, and gate the workflow commands in repository policy

## Why

The scheduled fresh-process curve was measuring Buck's default unoptimized compiler. On the same AArch64 macOS checkout, Lattice measured 7.84 s with that compiler and 1.97 s with the release/ThinLTO compiler. Profiling the debug binary emphasized Rust safety-check and generic collection overhead rather than the shipped compiler.

The profile is now part of the compiler-produced evidence, not merely a workflow claim. A debug compiler is rejected with an explicit mismatch.

## Validation

- `scripts/rue quick` — 31 targets passed
- release-configuration policy gate passed
- complete local three-sample report passed for Ruelex, Mosaic, Harbor, and Lattice
- negative run rejected the debug compiler as intended
- release medians: 194.86 ms, 609.36 ms, 1,432.01 ms, and 1,670.40 ms respectively

Fixes RUE-1342.
