### PR TITLE
RUE-1343: publish deterministic cold query work

### DIFF
--- a/crates/rue-bench/src/measure.rs
+++ b/crates/rue-bench/src/measure.rs
@@ -16,7 +16,7 @@ use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
 use std::time::Instant;
 
-use rue_perf_schema::{FailureRecord, PhaseAccounting, Sample, WorkloadShape};
+use rue_perf_schema::{CompilerWork, FailureRecord, PhaseAccounting, Sample, WorkloadShape};
 
 /// Everything needed to measure one sample.
 pub struct SampleRequest<'a> {
@@ -58,6 +58,7 @@ struct BenchmarkJson {
     phase_accounting: PhaseAccounting,
     metadata: BenchmarkMetadata,
     source_metrics: SourceMetrics,
+    compiler_work: CompilerWork,
     emitted_output: EmittedOutput,
 }
 
@@ -89,6 +90,7 @@ struct CompletedCompile {
     shape: WorkloadShape,
     target: String,
     compiler_build_profile: String,
+    compiler_work: CompilerWork,
 }
 
 /// The raw result of one fresh compiler process for the scaling report.
@@ -97,6 +99,7 @@ pub struct FreshCompile {
     pub shape: WorkloadShape,
     pub target: String,
     pub compiler_build_profile: String,
+    pub compiler_work: CompilerWork,
 }
 
 /// Measure one sample.
@@ -174,6 +177,7 @@ pub fn measure_fresh_compile(request: &SampleRequest<'_>) -> Result<FreshCompile
         shape: completed.shape,
         target: completed.target,
         compiler_build_profile: completed.compiler_build_profile,
+        compiler_work: completed.compiler_work,
     })
 }
 
@@ -260,6 +264,7 @@ fn run_once(request: &SampleRequest<'_>) -> Result<CompletedCompile, String> {
         },
         target: parsed.metadata.target,
         compiler_build_profile: parsed.metadata.compiler_build_profile,
+        compiler_work: parsed.compiler_work,
     })
 }
 

--- a/crates/rue-bench/src/scaling.rs
+++ b/crates/rue-bench/src/scaling.rs
@@ -13,6 +13,8 @@ use rue_perf_schema::{
 
 use crate::measure::{SampleRequest, measure_fresh_compile};
 
+const COMPILER_WORK_SAMPLES_PER_WORKLOAD: u32 = 2;
+
 struct Options {
     manifest: PathBuf,
     compiler: PathBuf,
@@ -44,6 +46,8 @@ pub fn run() -> Result<(), String> {
     };
 
     let started_at = crate::utc_timestamp();
+    let mut compiler_work_args = manifest.args.clone();
+    compiler_work_args.extend(["--jobs".to_string(), "1".to_string()]);
     let mut target: Option<String> = None;
     let mut observations = Vec::with_capacity(manifest.workloads.len());
     for workload in &manifest.workloads {
@@ -57,6 +61,7 @@ pub fn run() -> Result<(), String> {
         }
         let output = workdir.join(format!("{}-out", workload.id));
         let mut shape: Option<WorkloadShape> = None;
+        let mut work = None;
         let mut samples = Vec::with_capacity(manifest.samples as usize);
         for sample_index in 0..manifest.samples {
             eprintln!(
@@ -118,11 +123,66 @@ pub fn run() -> Result<(), String> {
             }
             samples.push(measured.sample);
         }
+        // Keep the structural probes after the published timing samples so
+        // adding deterministic counters cannot warm workload files before the
+        // established timing regime observes them.
+        for probe_index in 0..COMPILER_WORK_SAMPLES_PER_WORKLOAD {
+            eprintln!(
+                "rue-bench: scaling {} deterministic-work probe {}/{}",
+                workload.id,
+                probe_index + 1,
+                COMPILER_WORK_SAMPLES_PER_WORKLOAD
+            );
+            let request = SampleRequest {
+                compiler: &options.compiler,
+                source: &source,
+                args: &compiler_work_args,
+                output: output.clone(),
+                std_root: options.std_root.as_deref(),
+                batch_size: 1,
+                workload: &workload.id,
+                sample_index: probe_index,
+            };
+            let measured = measure_fresh_compile(&request).map_err(|detail| {
+                format!(
+                    "scaling workload {:?} deterministic-work probe {} failed: {detail}",
+                    workload.id, probe_index
+                )
+            })?;
+            match &shape {
+                None => shape = Some(measured.shape.clone()),
+                Some(expected) if expected != &measured.shape => {
+                    return Err(format!(
+                        "scaling workload {:?} changed shape between deterministic-work probes: {expected:?} then {:?}",
+                        workload.id, measured.shape
+                    ));
+                }
+                Some(_) => {}
+            }
+            match &target {
+                None => target = Some(measured.target.clone()),
+                Some(expected) if expected != &measured.target => {
+                    return Err(format!(
+                        "compiler target changed between samples: {expected:?} then {:?}",
+                        measured.target
+                    ));
+                }
+                Some(_) => {}
+            }
+            if measured.compiler_build_profile != manifest.compiler_build_profile {
+                return Err(format!(
+                    "scaling workload {:?} requires compiler build profile {:?}, but the compiler reported {:?}",
+                    workload.id, manifest.compiler_build_profile, measured.compiler_build_profile,
+                ));
+            }
+            observe_compiler_work(&mut work, measured.compiler_work, &workload.id)?;
+        }
         observations.push(ScalingObservation {
             workload: workload.id.clone(),
             source: workload.source.clone(),
             question: workload.question.clone(),
             shape: shape.expect("the manifest requires at least two samples"),
+            work: work.expect("the manifest requires at least two samples"),
             samples,
         });
     }
@@ -144,10 +204,29 @@ pub fn run() -> Result<(), String> {
             samples_per_workload: manifest.samples,
             compiler_args: manifest.args,
             compiler_build_profile: manifest.compiler_build_profile,
+            compiler_work_samples_per_workload: COMPILER_WORK_SAMPLES_PER_WORKLOAD,
+            compiler_work_args,
         },
         workloads: observations,
     };
     write_report(&options.output, &report)?;
+    Ok(())
+}
+
+fn observe_compiler_work(
+    expected: &mut Option<rue_perf_schema::CompilerWork>,
+    observed: rue_perf_schema::CompilerWork,
+    workload: &str,
+) -> Result<(), String> {
+    match expected {
+        None => *expected = Some(observed),
+        Some(expected) if *expected != observed => {
+            return Err(format!(
+                "scaling workload {workload:?} changed deterministic compiler work between samples: {expected:?} then {observed:?}"
+            ));
+        }
+        Some(_) => {}
+    }
     Ok(())
 }
 
@@ -221,7 +300,7 @@ fn render(report: &ScalingReport) -> String {
     let mut out = String::new();
     out.push_str("# Rue compiler scaling report\n\n");
     out.push_str(&format!(
-        "- Commit: `{}`\n- Fixture revision: {}\n- Target: `{}`\n- Compiler build profile: `{}`\n- Machine: {} ({} cores, {} bytes memory)\n- Runner: `{}` / `{}` ({})\n- Regime: {} sequential fresh compiler processes per workload; OS page-cache state is uncontrolled.\n- Runtime separation: compiled programs were not executed.\n\n",
+        "- Commit: `{}`\n- Fixture revision: {}\n- Target: `{}`\n- Compiler build profile: `{}`\n- Machine: {} ({} cores, {} bytes memory)\n- Runner: `{}` / `{}` ({})\n- Regime: {} sequential fresh compiler processes per workload; OS page-cache state is uncontrolled.\n- Structural work: {} single-worker compiler-work probes per workload with arguments `{:?}`; probe timings are not published.\n- Runtime separation: compiled programs were not executed.\n\n",
         report.identity.commit,
         report.identity.manifest_revision,
         report.identity.target,
@@ -233,6 +312,8 @@ fn render(report: &ScalingReport) -> String {
         report.identity.environment.runner_image,
         report.identity.environment.runner_image_version,
         report.regime.samples_per_workload,
+        report.regime.compiler_work_samples_per_workload,
+        report.regime.compiler_work_args,
     ));
     out.push_str("Times and memory are median ± median absolute deviation (MAD). A changed shape id marks comparisons with earlier artifacts as advisory.\n\n");
     out.push_str("| workload | shape id | files/modules | functions | bytes/lines/tokens | process ms | compiler ms | peak MiB | output KiB |\n");
@@ -283,6 +364,39 @@ fn render(report: &ScalingReport) -> String {
             memory.mad as f64 / (1024.0 * 1024.0),
             output.median as f64 / 1024.0,
             output.mad as f64 / 1024.0,
+        ));
+    }
+
+    out.push_str("\n## Deterministic query work\n\n");
+    out.push_str("Counts are exact for one fresh compiler process and must agree across the fixed single-worker structural probes. `nodes/token` exposes validation amplification independently of clock noise.\n\n");
+    out.push_str("| workload | traversals | input/dependency observations | memo hit/miss | endorsements hit/probe | terminal leases duplicate/total | demands reuse/compute/join/total | retention scan entries | nodes/token |\n");
+    out.push_str("| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |\n");
+    for observation in &report.workloads {
+        let runtime = observation.work.query_runtime;
+        let validation = runtime.validation;
+        let nodes_per_token = if observation.shape.tokens == 0 {
+            0.0
+        } else {
+            validation.node_visits as f64 / observation.shape.tokens as f64
+        };
+        out.push_str(&format!(
+            "| {} | {} | {}/{} | {}/{} | {}/{} | {}/{} | {}/{}/{}/{} | {} | {:.2} |\n",
+            observation.workload,
+            validation.traversals,
+            validation.input_observations,
+            validation.dependency_observations,
+            validation.memo_hits,
+            validation.memo_misses,
+            validation.endorsement_hits,
+            validation.endorsement_probes,
+            validation.duplicate_terminal_lease_observations,
+            validation.terminal_lease_observations,
+            validation.demand_reuses,
+            validation.demand_computes,
+            validation.demand_joins,
+            validation.demands,
+            runtime.retention_scan_entries,
+            nodes_per_token,
         ));
     }
 
@@ -368,6 +482,8 @@ mod tests {
                 samples_per_workload: 2,
                 compiler_args: Vec::new(),
                 compiler_build_profile: "release_thin_lto".to_string(),
+                compiler_work_samples_per_workload: 2,
+                compiler_work_args: vec!["--jobs".to_string(), "1".to_string()],
             },
             workloads: vec![ScalingObservation {
                 workload: "probe".to_string(),
@@ -381,6 +497,19 @@ mod tests {
                     tokens: 5,
                     functions: 1,
                 },
+                work: rue_perf_schema::CompilerWork {
+                    query_runtime: rue_perf_schema::QueryRuntimeWork {
+                        validation: rue_perf_schema::ValidationWork {
+                            traversals: 3,
+                            node_visits: 7,
+                            memo_hits: 5,
+                            memo_misses: 2,
+                            ..Default::default()
+                        },
+                        retention_enforcements: 1,
+                        retention_scan_entries: 4,
+                    },
+                },
                 samples: vec![sample.clone(), sample],
             }],
         }
@@ -391,9 +520,12 @@ mod tests {
         let rendered = render(&report());
         assert!(rendered.contains("OS page-cache state is uncontrolled"));
         assert!(rendered.contains("Compiler build profile: `release_thin_lto`"));
+        assert!(rendered.contains("2 single-worker compiler-work probes"));
         assert!(rendered.contains("compiled programs were not executed"));
         assert!(rendered.contains("median absolute deviation"));
         assert!(rendered.contains("shape id"));
+        assert!(rendered.contains("Deterministic query work"));
+        assert!(rendered.contains("nodes/token"));
     }
 
     #[test]
@@ -410,5 +542,25 @@ mod tests {
         assert!(report.workloads[0].samples[0].phases.holds());
         let phase_map: BTreeMap<_, _> = report.workloads[0].samples[0].phases.phase_ns.clone();
         assert_eq!(phase_map.len(), Phase::ALL.len());
+    }
+
+    #[test]
+    fn changed_deterministic_work_rejects_a_scaling_workload() {
+        let mut expected = None;
+        let first = rue_perf_schema::CompilerWork::default();
+        observe_compiler_work(&mut expected, first, "probe").unwrap();
+        observe_compiler_work(&mut expected, first, "probe").unwrap();
+
+        let changed = rue_perf_schema::CompilerWork {
+            query_runtime: rue_perf_schema::QueryRuntimeWork {
+                retention_scan_entries: 1,
+                ..Default::default()
+            },
+        };
+        let error = observe_compiler_work(&mut expected, changed, "probe").unwrap_err();
+        assert!(
+            error.contains("changed deterministic compiler work"),
+            "{error}"
+        );
     }
 }

--- a/crates/rue-cli-tests/cases/benchmark_json.toml
+++ b/crates/rue-cli-tests/cases/benchmark_json.toml
@@ -15,7 +15,7 @@ args = ["--benchmark-json", "main.rue", "-o", "prog"]
 env = { RUST_LOG = "error" }
 exit_code = 42
 compile_stdout_contains = [
-  '"schema_version":5',
+  '"schema_version":6',
   '"compiler_build_profile":',
   '"timing_model":"inclusive_spans"',
   # The additive partition, which is the only model that may be stacked. Its
@@ -42,4 +42,8 @@ compile_stdout_contains = [
   '"lines":1',
   '"tokens":',
   '"functions":1',
+  '"compiler_work":',
+  '"query_runtime":',
+  '"validation":',
+  '"retention_scan_entries":',
 ]

--- a/crates/rue-compiler/src/linking.rs
+++ b/crates/rue-compiler/src/linking.rs
@@ -574,6 +574,7 @@ pub(crate) fn link_internal_with_warnings(
         warnings: warnings.to_vec(),
         source_stats: SourceStats::default(),
         work: PipelineWork::default(),
+        query_runtime: crate::unstable::QueryRuntimeMetrics::default(),
     })
 }
 
@@ -676,6 +677,7 @@ pub(crate) fn link_system_with_warnings(
         warnings: warnings.to_vec(),
         source_stats: SourceStats::default(),
         work: PipelineWork::default(),
+        query_runtime: crate::unstable::QueryRuntimeMetrics::default(),
     })
 }
 use std::io::{Read, Write};

--- a/crates/rue-compiler/src/pipeline_tests.rs
+++ b/crates/rue-compiler/src/pipeline_tests.rs
@@ -2226,6 +2226,17 @@ mod tests {
             &CompileOptions::default(),
         )
         .unwrap();
+        let one_shot_metrics = output.unstable_metrics();
+        let live_runtime = session.unstable_metrics().query_runtime();
+        assert_eq!(one_shot_metrics.query_runtime, live_runtime);
+        assert!(
+            one_shot_metrics
+                .query_runtime
+                .validation
+                .terminal_lease_observations
+                > 0,
+            "a rooted cold compile must publish its observed query terminals"
+        );
         let stats = output.source_stats;
         let work = output.work;
 

--- a/crates/rue-compiler/src/queries.rs
+++ b/crates/rue-compiler/src/queries.rs
@@ -1087,13 +1087,15 @@ pub struct CompileOutput {
     pub(crate) source_stats: SourceStats,
     /// Structural work performed by the session query graph.
     pub(crate) work: PipelineWork,
+    /// Live query-runtime work observed after the rooted compiler queries.
+    pub(crate) query_runtime: crate::unstable::QueryRuntimeMetrics,
 }
 
 impl CompileOutput {
     /// Return instrumentation from this one-shot compilation without exposing
     /// query-engine work records.
     pub fn unstable_metrics(&self) -> crate::unstable::OneShotMetrics {
-        crate::unstable::OneShotMetrics::new(self.source_stats, self.work)
+        crate::unstable::OneShotMetrics::new(self.source_stats, self.work, self.query_runtime)
     }
 }
 
@@ -1267,6 +1269,7 @@ pub(crate) fn compile_rooted_with_session(
         })?;
     let total_source_bytes: usize = snapshot.files().map(|source| source.source.len()).sum();
     let session_work = session.work().clone();
+    let query_runtime = session.unstable_metrics().query_runtime();
     let image = crate::program_image_plan::ProgramImage::from_rooted(
         rooted.objects,
         rooted.exports,
@@ -1288,5 +1291,6 @@ pub(crate) fn compile_rooted_with_session(
         lowered: Default::default(),
         semantic: rooted.work,
     };
+    output.query_runtime = query_runtime;
     Ok(output)
 }

--- a/crates/rue-compiler/src/unstable.rs
+++ b/crates/rue-compiler/src/unstable.rs
@@ -1945,10 +1945,15 @@ pub struct OneShotMetrics {
     pub parsed: ParseMetrics,
     pub lowered: LowerMetrics,
     pub semantic: SemanticMetrics,
+    pub query_runtime: QueryRuntimeMetrics,
 }
 
 impl OneShotMetrics {
-    pub(crate) fn new(stats: crate::SourceStats, work: crate::PipelineWork) -> Self {
+    pub(crate) fn new(
+        stats: crate::SourceStats,
+        work: crate::PipelineWork,
+        query_runtime: QueryRuntimeMetrics,
+    ) -> Self {
         Self {
             files: stats.files,
             bytes: stats.bytes,
@@ -1957,6 +1962,7 @@ impl OneShotMetrics {
             parsed: ParseMetrics::from_work(work.parsed),
             lowered: LowerMetrics::from_work(work.lowered),
             semantic: SemanticMetrics::from_work(work.semantic),
+            query_runtime,
         }
     }
 }

--- a/crates/rue-perf-schema/src/lib.rs
+++ b/crates/rue-perf-schema/src/lib.rs
@@ -61,8 +61,9 @@ pub use run::{
     RunIdentity, RunObject, Sample, WorkloadObservation,
 };
 pub use scaling::{
-    SCALING_REPORT_SCHEMA_VERSION, ScalingIdentity, ScalingManifest, ScalingObservation,
-    ScalingRegime, ScalingReport, ScalingWorkload, WorkloadShape,
+    CompilerWork, QueryRuntimeWork, SCALING_REPORT_SCHEMA_VERSION, ScalingIdentity,
+    ScalingManifest, ScalingObservation, ScalingRegime, ScalingReport, ScalingWorkload,
+    WorkloadShape,
 };
 pub use series::{Metric, SeriesId};
 pub use stats::{

--- a/crates/rue-perf-schema/src/scaling.rs
+++ b/crates/rue-perf-schema/src/scaling.rs
@@ -9,10 +9,10 @@ use std::collections::BTreeSet;
 
 use serde::{Deserialize, Serialize};
 
-use crate::{EnvironmentFingerprint, Sample};
+use crate::{EnvironmentFingerprint, Sample, ValidationWork};
 
 /// Version of the scaling-report wire format.
-pub const SCALING_REPORT_SCHEMA_VERSION: u32 = 2;
+pub const SCALING_REPORT_SCHEMA_VERSION: u32 = 3;
 
 /// The lower-frequency scaling suite declaration.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -132,6 +132,11 @@ pub struct ScalingRegime {
     pub compiler_args: Vec<String>,
     /// Rust build profile reported by the compiler binary.
     pub compiler_build_profile: String,
+    /// Independent structural-work probes per workload.
+    pub compiler_work_samples_per_workload: u32,
+    /// Arguments used by structural-work probes. These include a fixed
+    /// single-worker setting so scheduling cannot perturb exact counters.
+    pub compiler_work_args: Vec<String>,
 }
 
 /// Raw measurements for one maintained program.
@@ -147,8 +152,35 @@ pub struct ScalingObservation {
     /// Compiler-produced fixture shape. A change makes cross-report comparison
     /// advisory even when the manifest revision was not yet advanced.
     pub shape: WorkloadShape,
+    /// Deterministic compiler work, required to agree across the fixed
+    /// single-worker structural probes.
+    pub work: CompilerWork,
     /// Independent raw fresh-process measurements.
     pub samples: Vec<Sample>,
+}
+
+/// Deterministic work performed by one compiler process.
+///
+/// This is deliberately separate from elapsed time and fixture shape. It grows
+/// as the compiler performs internal work, so a report can identify
+/// amplification even when host timing is noisy.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct CompilerWork {
+    /// Work performed by the revisioned query runtime.
+    pub query_runtime: QueryRuntimeWork,
+}
+
+/// Deterministic query-runtime work performed by one compiler process.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct QueryRuntimeWork {
+    /// Retained-terminal validation and proof work.
+    pub validation: ValidationWork,
+    /// Family-local retention passes run.
+    pub retention_enforcements: u64,
+    /// Retention-queue entries examined by those passes.
+    pub retention_scan_entries: u64,
 }
 
 /// Compiler-produced dimensions of one fixture.

--- a/crates/rue/src/main.rs
+++ b/crates/rue/src/main.rs
@@ -904,6 +904,7 @@ fn print_timing_output(
     benchmark_json: bool,
     target: &Target,
     source_metrics: Option<timing::SourceMetrics>,
+    compiler_work: Option<rue_perf_schema::CompilerWork>,
     emitted_output: Option<&[u8]>,
 ) {
     if let Some(timing) = timing_data {
@@ -915,6 +916,7 @@ fn print_timing_output(
                     &target.to_string(),
                     VERSION,
                     source_metrics,
+                    compiler_work,
                     get_peak_memory_bytes(),
                 ))
                 .unwrap();
@@ -939,6 +941,47 @@ fn print_timing_output(
             // Human-readable output goes to stderr
             eprintln!("{}", timing.report());
         }
+    }
+}
+
+fn benchmark_compiler_work(
+    metrics: rue_compiler::unstable::OneShotMetrics,
+) -> rue_perf_schema::CompilerWork {
+    let runtime = metrics.query_runtime;
+    let validation = runtime.validation;
+    rue_perf_schema::CompilerWork {
+        query_runtime: rue_perf_schema::QueryRuntimeWork {
+            validation: rue_perf_schema::ValidationWork {
+                traversals: validation.traversals,
+                successful_traversals: validation.successful_traversals,
+                dirty_traversals: validation.dirty_traversals,
+                aborted_traversals: validation.aborted_traversals,
+                input_observations: validation.input_observations,
+                dependency_observations: validation.dependency_observations,
+                registry_probes: validation.registry_probes,
+                registry_misses: validation.registry_misses,
+                node_visits: validation.node_visits,
+                active_cycle_prunes: validation.active_cycle_prunes,
+                memo_hits: validation.memo_hits,
+                memo_misses: validation.memo_misses,
+                certificate_misses: validation.certificate_misses,
+                proof_reacquisition_misses: validation.proof_reacquisition_misses,
+                endorsement_probes: validation.endorsement_probes,
+                endorsement_hits: validation.endorsement_hits,
+                terminal_lease_observations: validation.terminal_lease_observations,
+                duplicate_terminal_lease_observations: validation
+                    .duplicate_terminal_lease_observations,
+                demands: validation.demands,
+                demand_reuses: validation.demand_reuses,
+                demand_computes: validation.demand_computes,
+                demand_joins: validation.demand_joins,
+                demand_aborts: validation.demand_aborts,
+                superseded: validation.superseded,
+                certificates_published: validation.certificates_published,
+            },
+            retention_enforcements: runtime.retention_enforcements,
+            retention_scan_entries: runtime.retention_scan_entries,
+        },
     }
 }
 
@@ -1299,6 +1342,7 @@ fn main() {
             &options.target,
             None,
             None,
+            None,
         );
         return;
     }
@@ -1388,13 +1432,13 @@ fn main() {
                 );
             }
 
+            let benchmark_metrics = options.benchmark_json.then(|| output.unstable_metrics());
             print_timing_output(
                 &timing_data,
                 options.time_passes,
                 options.benchmark_json,
                 &options.target,
-                options.benchmark_json.then(|| {
-                    let source_stats = output.unstable_metrics();
+                benchmark_metrics.map(|source_stats| {
                     timing::SourceMetrics {
                         files: source_stats.files,
                         // Every accepted source file is one module in the
@@ -1408,6 +1452,7 @@ fn main() {
                         functions: source_stats.semantic.cfg.functions_considered,
                     }
                 }),
+                benchmark_metrics.map(benchmark_compiler_work),
                 options
                     .benchmark_json
                     .then_some(output.linked_bytes.as_slice()),
@@ -1423,6 +1468,36 @@ fn main() {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn benchmark_work_projection_preserves_query_runtime_counters() {
+        let metrics = rue_compiler::unstable::OneShotMetrics {
+            query_runtime: rue_compiler::unstable::QueryRuntimeMetrics {
+                validation: rue_compiler::unstable::QueryValidationMetrics {
+                    traversals: 3,
+                    dependency_observations: 11,
+                    memo_hits: 7,
+                    memo_misses: 2,
+                    duplicate_terminal_lease_observations: 5,
+                    ..Default::default()
+                },
+                retention_enforcements: 13,
+                retention_scan_entries: 17,
+            },
+            ..Default::default()
+        };
+        let projected = benchmark_compiler_work(metrics).query_runtime;
+        assert_eq!(projected.validation.traversals, 3);
+        assert_eq!(projected.validation.dependency_observations, 11);
+        assert_eq!(projected.validation.memo_hits, 7);
+        assert_eq!(projected.validation.memo_misses, 2);
+        assert_eq!(
+            projected.validation.duplicate_terminal_lease_observations,
+            5
+        );
+        assert_eq!(projected.retention_enforcements, 13);
+        assert_eq!(projected.retention_scan_entries, 17);
+    }
     use tracing_subscriber::layer::SubscriberExt as _;
 
     fn test_snapshot(root: FileId, sources: &[(FileId, &str, &str, &str)]) -> SourceSnapshot {
@@ -1530,7 +1605,7 @@ mod tests {
             edges.contains(&("compile".to_owned(), "compile_pipeline".to_owned())),
             "post-discovery pipeline escaped the compile root: {edges:?}"
         );
-        let timing = data.to_benchmark_timing_with_metrics("test", "test", None, None);
+        let timing = data.to_benchmark_timing_with_metrics("test", "test", None, None, None);
         for pass in &timing.passes {
             if pass.name == "compile" {
                 assert_eq!(pass.invocations, 1);

--- a/crates/rue/src/timing.rs
+++ b/crates/rue/src/timing.rs
@@ -104,7 +104,7 @@ const COMPILER_BUILD_PROFILE: &str = "release_thin_lto";
 #[cfg(not(rue_release_build))]
 const COMPILER_BUILD_PROFILE: &str = "debug";
 
-use rue_perf_schema::{Phase, PhaseAccounting};
+use rue_perf_schema::{CompilerWork, Phase, PhaseAccounting};
 use serde::Serialize;
 
 use tracing::span::{Attributes, Id};
@@ -303,6 +303,9 @@ pub struct BenchmarkTiming {
     /// Source and program-shape metrics for throughput calculations.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub source_metrics: Option<SourceMetrics>,
+    /// Deterministic compiler work independent of host timing.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub compiler_work: Option<CompilerWork>,
     /// Peak memory usage in bytes (if available).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub peak_memory_bytes: Option<u64>,
@@ -642,12 +645,14 @@ impl TimingData {
     /// * `target` - The target platform string (e.g., "x86_64-linux")
     /// * `version` - The compiler version string
     /// * `source_metrics` - Optional source and program-shape metrics
+    /// * `compiler_work` - Optional deterministic compiler-work counters
     /// * `peak_memory_bytes` - Optional peak memory usage in bytes
     pub fn to_benchmark_timing_with_metrics(
         &self,
         target: &str,
         version: &str,
         source_metrics: Option<SourceMetrics>,
+        compiler_work: Option<CompilerWork>,
         peak_memory_bytes: Option<u64>,
     ) -> BenchmarkTiming {
         self.flush_local();
@@ -705,7 +710,7 @@ impl TimingData {
         };
 
         BenchmarkTiming {
-            schema_version: 5,
+            schema_version: 6,
             timing_model: "inclusive_spans",
             phase_accounting,
             metadata,
@@ -713,6 +718,7 @@ impl TimingData {
             driver_phases,
             total_ms,
             source_metrics,
+            compiler_work,
             peak_memory_bytes,
         }
     }
@@ -723,18 +729,21 @@ impl TimingData {
     /// * `target` - The target platform string
     /// * `version` - The compiler version string
     /// * `source_metrics` - Source and program-shape metrics
+    /// * `compiler_work` - Deterministic compiler-work counters
     /// * `peak_memory_bytes` - Optional peak memory usage
     pub fn to_json_with_metrics(
         &self,
         target: &str,
         version: &str,
         source_metrics: Option<SourceMetrics>,
+        compiler_work: Option<CompilerWork>,
         peak_memory_bytes: Option<u64>,
     ) -> String {
         let timing = self.to_benchmark_timing_with_metrics(
             target,
             version,
             source_metrics,
+            compiler_work,
             peak_memory_bytes,
         );
         serde_json::to_string(&timing).unwrap_or_else(|_| "{}".to_string())
@@ -1448,7 +1457,7 @@ mod tests {
         }
 
         let direct_timing =
-            direct_data.to_benchmark_timing_with_metrics("test", "test", None, None);
+            direct_data.to_benchmark_timing_with_metrics("test", "test", None, None, None);
         let direct_parse = direct_timing
             .passes
             .iter()
@@ -1493,7 +1502,7 @@ mod tests {
         }
 
         let session_timing =
-            session_data.to_benchmark_timing_with_metrics("test", "test", None, None);
+            session_data.to_benchmark_timing_with_metrics("test", "test", None, None, None);
         let session_parse_file = session_timing
             .passes
             .iter()
@@ -1598,7 +1607,7 @@ mod tests {
         );
 
         let compile_timing =
-            compile_data.to_benchmark_timing_with_metrics("test", "test", None, None);
+            compile_data.to_benchmark_timing_with_metrics("test", "test", None, None, None);
         let compile = compile_timing
             .passes
             .iter()
@@ -1687,7 +1696,7 @@ mod tests {
         // coordinator span. The semantic phase has one work span for the
         // prerequisite fan-out and one for body analysis; the retired session
         // worklist and body-local epoch pipeline must not reappear.
-        let timing = data.to_benchmark_timing_with_metrics("test", "test", None, None);
+        let timing = data.to_benchmark_timing_with_metrics("test", "test", None, None, None);
         for retired in [
             "body_queries",
             "body_transaction",
@@ -1794,7 +1803,7 @@ mod tests {
             std::thread::sleep(Duration::from_millis(5));
         });
 
-        let timing = data.to_benchmark_timing_with_metrics("test", "test", None, None);
+        let timing = data.to_benchmark_timing_with_metrics("test", "test", None, None, None);
         let pass_names: Vec<_> = timing
             .passes
             .iter()
@@ -1830,7 +1839,7 @@ mod tests {
             .unwrap();
         assert!(write.duration_ms > 0.0);
 
-        let json = data.to_json_with_metrics("test", "test", None, None);
+        let json = data.to_json_with_metrics("test", "test", None, None, None);
         assert!(json.contains("\"driver_phases\""), "{json}");
         assert!(data.report().contains("Driver phases"));
     }
@@ -1839,7 +1848,7 @@ mod tests {
     fn a_run_without_driver_phases_omits_the_field_entirely() {
         let data = TimingData::new();
         data.record("lexer", Duration::from_millis(1));
-        let json = data.to_json_with_metrics("test", "test", None, None);
+        let json = data.to_json_with_metrics("test", "test", None, None, None);
         assert!(!json.contains("driver_phases"), "{json}");
         assert!(!data.report().contains("Driver phases"));
     }
@@ -1903,7 +1912,8 @@ mod tests {
     #[test]
     fn test_to_benchmark_timing_empty() {
         let data = TimingData::new();
-        let timing = data.to_benchmark_timing_with_metrics("x86_64-linux", "0.1.0", None, None);
+        let timing =
+            data.to_benchmark_timing_with_metrics("x86_64-linux", "0.1.0", None, None, None);
         assert!(timing.passes.is_empty());
         assert_eq!(timing.total_ms, 0.0);
     }
@@ -1914,7 +1924,8 @@ mod tests {
         data.record("lexer", Duration::from_millis(100));
         data.record("parser", Duration::from_millis(200));
 
-        let timing = data.to_benchmark_timing_with_metrics("x86_64-linux", "0.1.0", None, None);
+        let timing =
+            data.to_benchmark_timing_with_metrics("x86_64-linux", "0.1.0", None, None, None);
         assert_eq!(timing.passes.len(), 2);
         assert_eq!(timing.passes[0].name, "lexer");
         assert_eq!(timing.passes[1].name, "parser");
@@ -1928,7 +1939,8 @@ mod tests {
         data.record("lexer", Duration::from_millis(100));
         data.record("parser", Duration::from_millis(300));
 
-        let timing = data.to_benchmark_timing_with_metrics("x86_64-linux", "0.1.0", None, None);
+        let timing =
+            data.to_benchmark_timing_with_metrics("x86_64-linux", "0.1.0", None, None, None);
         // lexer should be 25%, parser should be 75%
         assert!((timing.passes[0].percent - 25.0).abs() < 0.1);
         assert!((timing.passes[1].percent - 75.0).abs() < 0.1);
@@ -1943,7 +1955,8 @@ mod tests {
         data.record_test_span("parser", Duration::from_millis(2), false, true);
         data.record_test_span("codegen", Duration::from_millis(4), false, true);
 
-        let timing = data.to_benchmark_timing_with_metrics("x86_64-linux", "0.1.0", None, None);
+        let timing =
+            data.to_benchmark_timing_with_metrics("x86_64-linux", "0.1.0", None, None, None);
         assert!((timing.total_ms - 10.0).abs() < f64::EPSILON);
 
         let compile = timing
@@ -2040,7 +2053,8 @@ mod tests {
         let data = TimingData::new();
         data.record("lexer", Duration::from_millis(100));
 
-        let timing = data.to_benchmark_timing_with_metrics("aarch64-macos", "0.2.0", None, None);
+        let timing =
+            data.to_benchmark_timing_with_metrics("aarch64-macos", "0.2.0", None, None, None);
         assert_eq!(timing.metadata.target, "aarch64-macos");
         assert_eq!(timing.metadata.version, "0.2.0");
         // Timestamp should be an ISO 8601 format
@@ -2053,8 +2067,8 @@ mod tests {
         let data = TimingData::new();
         data.record("lexer", Duration::from_millis(100));
 
-        let json = data.to_json_with_metrics("x86_64-linux", "0.1.0", None, None);
-        assert!(json.contains("\"schema_version\":5"));
+        let json = data.to_json_with_metrics("x86_64-linux", "0.1.0", None, None, None);
+        assert!(json.contains("\"schema_version\":6"));
         assert!(json.contains(&format!(
             "\"compiler_build_profile\":\"{COMPILER_BUILD_PROFILE}\""
         )));
@@ -2078,7 +2092,7 @@ mod tests {
     #[test]
     fn test_to_json_empty() {
         let data = TimingData::new();
-        let json = data.to_json_with_metrics("x86_64-linux", "0.1.0", None, None);
+        let json = data.to_json_with_metrics("x86_64-linux", "0.1.0", None, None, None);
         // Should produce valid JSON even with empty data
         assert!(json.contains("\"passes\":[]"));
         assert!(json.contains("\"total_ms\":0"));
@@ -2091,7 +2105,8 @@ mod tests {
         data.record("zzz", Duration::from_millis(100));
         data.record("mmm", Duration::from_millis(100));
 
-        let timing = data.to_benchmark_timing_with_metrics("x86_64-linux", "0.1.0", None, None);
+        let timing =
+            data.to_benchmark_timing_with_metrics("x86_64-linux", "0.1.0", None, None, None);
         assert_eq!(timing.passes[0].name, "aaa");
         assert_eq!(timing.passes[1].name, "mmm");
         assert_eq!(timing.passes[2].name, "zzz");
@@ -2713,8 +2728,9 @@ mod phase_accounting_tests {
             thread::sleep(TICK);
         });
 
-        let timing = data.to_benchmark_timing_with_metrics("probe-target", "probe", None, None);
-        assert_eq!(timing.schema_version, 5);
+        let timing =
+            data.to_benchmark_timing_with_metrics("probe-target", "probe", None, None, None);
+        assert_eq!(timing.schema_version, 6);
         assert_eq!(
             timing.metadata.compiler_build_profile,
             COMPILER_BUILD_PROFILE

--- a/docs/process/compiler-scaling.md
+++ b/docs/process/compiler-scaling.md
@@ -17,15 +17,27 @@ The compiler and measurement runner are built with the release target platform
 metadata, and the scaling runner rejects a binary that does not match the
 manifest's declared profile.
 
-The runner executes three samples sequentially for each workload. JSON keeps
-every raw observation in integer nanoseconds. The Markdown view reports the
-median and median absolute deviation (MAD), along with the machine and hosted
-runner fingerprint. It records:
+The runner executes three timing samples sequentially for each workload. JSON
+keeps every raw observation in integer nanoseconds. The Markdown view reports
+the median and median absolute deviation (MAD), along with the machine and
+hosted runner fingerprint. Two additional fresh-process probes run with one
+compiler worker; their timings are discarded, and their deterministic
+compiler-work counters must agree exactly. Fixing the structural probes to one
+worker prevents legitimate parallel scheduling order from perturbing exact
+counters while leaving the user-relevant timing samples parallel. A counter
+disagreement rejects the workload instead of averaging structurally different
+compilations. The report records:
 
 - files, modules, source bytes, lines, lexer tokens, and functions considered;
 - externally observed fresh-process wall time and peak resident memory;
 - the compiler's additive, mutually exclusive phase accounting;
+- query validation, endorsement, lease, demand, and retention-scan work;
 - output binary size.
+
+The Markdown work table includes validation nodes per token. That ratio is a
+clock-independent amplification signal: source growth should not silently turn
+into many repeated validation visits merely because elapsed time still looks
+plausible on one host.
 
 The compiled examples are never executed. Runtime tests and heavyweight
 example scenarios remain in their existing suites, so a slow example runtime


### PR DESCRIPTION
## Summary

- carry existing contention-free query-runtime counters through one-shot benchmark JSON
- add two exact single-worker structural probes to fresh-process scaling reports while preserving the existing parallel timing regime
- render cold validation, endorsement, lease, demand, and retention amplification
- bump the benchmark and scaling wire schemas and update their documentation/oracles

The release-profile probes agree exactly across Ruelex, Mosaic, Harbor, and Lattice. They identify RUE-1247 as the next profile-driven cold optimization: more than 99% of large-workload memo misses reacquire proof for an existing result, and 56–60% of terminal-lease observations are duplicates.

## Validation

- `scripts/rue quick`
- `./buck2 test //crates/rue-bench:rue-bench-test //crates/rue-perf-schema:rue-perf-schema-test`
- full four-workload release/ThinLTO scaling report with two agreeing structural probes per workload

Fixes RUE-1343.
Refs RUE-1247.