### PR TITLE
RUE-1345: streamline CFG memo keys

### DIFF
--- a/crates/rue-compiler/src/cfg_query.rs
+++ b/crates/rue-compiler/src/cfg_query.rs
@@ -19,6 +19,7 @@ use std::cell::Cell;
 #[cfg(test)]
 thread_local! {
     static INJECT_CALL_ABI_FAILURE: Cell<bool> = const { Cell::new(false) };
+    static CFG_QUERY_KEY_CONSTRUCTIONS: Cell<usize> = const { Cell::new(0) };
 }
 
 #[cfg(test)]
@@ -37,6 +38,24 @@ pub(crate) fn with_test_call_abi_failure_injection<T>(run: impl FnOnce() -> T) -
     });
     let _reset = Reset;
     run()
+}
+
+#[cfg(test)]
+pub(crate) fn with_test_cfg_query_key_construction_count<T>(run: impl FnOnce() -> T) -> (T, usize) {
+    struct Reset(usize);
+    impl Drop for Reset {
+        fn drop(&mut self) {
+            CFG_QUERY_KEY_CONSTRUCTIONS.with(|count| count.set(self.0));
+        }
+    }
+
+    CFG_QUERY_KEY_CONSTRUCTIONS.with(|count| {
+        let reset = Reset(count.replace(0));
+        let output = run();
+        let constructions = count.get();
+        drop(reset);
+        (output, constructions)
+    })
 }
 
 #[derive(Debug, Clone)]
@@ -120,28 +139,20 @@ impl CfgQueryKey {
         configuration: crate::semantic_query_nucleus::SemanticQueryConfiguration,
         semantic_input: CfgSemanticInput,
     ) -> Self {
+        #[cfg(test)]
+        CFG_QUERY_KEY_CONSTRUCTIONS.with(|count| count.set(count.get() + 1));
+
         let mut hasher = std::collections::hash_map::DefaultHasher::new();
+        // The family index needs a well-distributed in-process partition, not a
+        // durable fingerprint of the whole semantic payload. Function and
+        // configuration distribute independent CFGs across shards; the small
+        // bounded set of retained semantic versions for one function may share
+        // a bucket. Typed `Eq` below remains authoritative under those deliberate
+        // collisions. Avoiding a Debug render of the complete body and local
+        // materialization facts keeps key construction allocation-free and
+        // proportional to the stable function identity rather than body size.
         function.hash(&mut hasher);
         configuration.hash(&mut hasher);
-        // These stable values deliberately do not implement `Hash`. Compute
-        // their complete Debug framing once at key construction instead of on
-        // every memo-table probe; equality still resolves hash collisions.
-        match &semantic_input {
-            CfgSemanticInput::Body {
-                input,
-                materialization,
-            } => {
-                format!("{:?};{:?}", input.canonical, materialization).hash(&mut hasher);
-            }
-            CfgSemanticInput::DropGlue {
-                owner,
-                facts,
-                materialization,
-                ..
-            } => {
-                format!("{owner:?};{facts:?};{materialization:?}").hash(&mut hasher);
-            }
-        }
         let memo_hash = hasher.finish();
         Self {
             function,

--- a/crates/rue-compiler/src/queries.rs
+++ b/crates/rue-compiler/src/queries.rs
@@ -648,8 +648,8 @@ pub(crate) fn collect_function_cfg_queries(
                         canonical_semantic::CfgConstructionWork::default(),
                     ));
                 };
-                let semantic_input = if let Some(root) = accessor_roots.get(&semantic_identity) {
-                    root.semantic_input.clone()
+                let cfg_key = if let Some(root) = accessor_roots.get(&semantic_identity) {
+                    root.clone()
                 } else if let Some(input) = current_input {
                     let body = match input.canonical.as_ref() {
                         crate::body_query::CanonicalBody::Ordinary { body, .. }
@@ -675,10 +675,14 @@ pub(crate) fn collect_function_cfg_queries(
                             canonical_semantic::CfgConstructionWork::default(),
                         )
                     })?;
-                    crate::cfg_query::CfgSemanticInput::Body {
-                        input: std::sync::Arc::new(input.clone()),
-                        materialization: std::sync::Arc::new(materialization),
-                    }
+                    crate::cfg_query::CfgQueryKey::new(
+                        semantic_identity.clone(),
+                        configuration.clone(),
+                        crate::cfg_query::CfgSemanticInput::Body {
+                            input: std::sync::Arc::new(input.clone()),
+                            materialization: std::sync::Arc::new(materialization),
+                        },
+                    )
                 } else if let crate::FunctionInstanceKey::DropGlue(owner) = &semantic_identity {
                     let Some(facts) = stable_drop_glue_plans.get(owner.as_ref()) else {
                         return Err((
@@ -709,12 +713,16 @@ pub(crate) fn collect_function_cfg_queries(
                             canonical_semantic::CfgConstructionWork::default(),
                         )
                     })?;
-                    crate::cfg_query::CfgSemanticInput::DropGlue {
-                        owner: owner.as_ref().clone(),
-                        facts: Box::new(facts.clone()),
-                        materialization: std::sync::Arc::new(materialization),
-                        body_span,
-                    }
+                    crate::cfg_query::CfgQueryKey::new(
+                        semantic_identity.clone(),
+                        configuration.clone(),
+                        crate::cfg_query::CfgSemanticInput::DropGlue {
+                            owner: owner.as_ref().clone(),
+                            facts: Box::new(facts.clone()),
+                            materialization: std::sync::Arc::new(materialization),
+                            body_span,
+                        },
+                    )
                 } else {
                     return Err((
                         CompileError::without_span(ErrorKind::InternalError(format!(
@@ -784,9 +792,7 @@ pub(crate) fn collect_function_cfg_queries(
                 let (optimized_cfg_key, attempt) = cfg_queries
                     .optimized_cfg(
                         revision,
-                        semantic_identity.clone(),
-                        configuration.clone(),
-                        semantic_input,
+                        cfg_key,
                         opt_level,
                         accessor_dependencies
                             .get(&semantic_identity)

--- a/crates/rue-compiler/src/revisioned_query_database.rs
+++ b/crates/rue-compiler/src/revisioned_query_database.rs
@@ -16569,9 +16569,7 @@ impl RevisionedQueryDatabase {
     pub(crate) fn optimized_cfg(
         &self,
         revision: Revision,
-        function: crate::FunctionInstanceKey,
-        configuration: crate::semantic_query_nucleus::SemanticQueryConfiguration,
-        semantic_input: crate::cfg_query::CfgSemanticInput,
+        cfg: crate::cfg_query::CfgQueryKey,
         opt_level: rue_cfg::OptLevel,
         accessor_dependencies: Arc<[crate::cfg_query::CfgQueryKey]>,
         cancellation: CancellationToken,
@@ -16582,7 +16580,6 @@ impl RevisionedQueryDatabase {
         ),
         QueryAbort,
     > {
-        let cfg = crate::cfg_query::CfgQueryKey::new(function, configuration, semantic_input);
         let optimized =
             crate::cfg_query::OptimizedCfgQueryKey::new(cfg, opt_level, accessor_dependencies);
         let attempt = self.runtime.request_registered(

--- a/crates/rue-compiler/src/session.rs
+++ b/crates/rue-compiler/src/session.rs
@@ -4910,6 +4910,9 @@ impl CompilerSession {
         let mut cfg_inputs = Vec::with_capacity(identities.len());
         let warning_references = self.rooted_warning_references(&graph, cancellation.clone())?;
         let mut warnings = rooted_unused_function_warnings(&graph, &warning_references);
+        let _cfg_collection_span =
+            tracing::info_span!("optimized_cfg_collection", phase = "cfg_and_optimization")
+                .entered();
         for closure_body in graph.closure.bodies.iter() {
             let rue_query::QueryOutcome::Success(bundle) = closure_body.bundle.outcome() else {
                 unreachable!("BodyAnalysisBundle publishes typed values")
@@ -5069,28 +5072,22 @@ impl CompilerSession {
                 };
                 CompileError::new(kind, span)
             })?;
-        let accessor_roots = accessor_subgraph.roots;
-        let accessor_dependencies = accessor_subgraph.dependencies;
+        let mut accessor_roots = accessor_subgraph.roots;
+        let mut accessor_dependencies = accessor_subgraph.dependencies;
         let accessor_functions = accessor_subgraph.accessors;
         let cfg_requests = cfg_inputs
             .into_iter()
             .filter(|(function, _, _)| !accessor_functions.contains(function))
-            .map(|(function, semantic_input, body_span)| {
-                let cfg = crate::cfg_query::CfgQueryKey::new(
-                    function.clone(),
-                    graph.configuration.clone(),
-                    accessor_roots
-                        .get(&function)
-                        .map(|key| key.semantic_input.clone())
-                        .unwrap_or(semantic_input),
-                );
+            .map(|(function, _, body_span)| {
+                let cfg = accessor_roots
+                    .remove(&function)
+                    .expect("validated accessor subgraph has one root per executable function");
                 let optimized_cfg_key = crate::cfg_query::OptimizedCfgQueryKey::new(
                     cfg,
                     options.opt_level,
                     accessor_dependencies
-                        .get(&function)
-                        .cloned()
-                        .unwrap_or_else(|| Arc::new([])),
+                        .remove(&function)
+                        .expect("validated accessor subgraph has dependencies for every root"),
                 );
                 (function, optimized_cfg_key, body_span)
             })
@@ -5104,9 +5101,6 @@ impl CompilerSession {
         let mut backend_root = self.queries.revisioned.begin_backend_root();
         #[cfg(test)]
         self.rooted_cfg_executions.clear();
-        let _cfg_collection_span =
-            tracing::info_span!("optimized_cfg_collection", phase = "cfg_and_optimization")
-                .entered();
         let (cfg_batch_key, attempt) = self.queries.revisioned.optimized_cfg_batch(
             graph.revision,
             optimized_keys,
@@ -11990,6 +11984,71 @@ fn main() -> i32 {
         let rendered = errors.to_string();
         assert!(rendered.contains("call ABI unavailable"), "{rendered}");
         assert!(rendered.contains("injected call ABI failure"), "{rendered}");
+    }
+
+    #[test]
+    fn cfg_keys_are_constructed_once_and_typed_equality_resolves_memo_hash_collisions() {
+        fn hash(key: &crate::cfg_query::CfgQueryKey) -> u64 {
+            let mut hasher = std::collections::hash_map::DefaultHasher::new();
+            std::hash::Hash::hash(key, &mut hasher);
+            std::hash::Hasher::finish(&hasher)
+        }
+
+        let first = SourceSnapshot::single(
+            "main.rue",
+            "fn helper() -> i32 { 1 } fn main() -> i32 { helper() }",
+        )
+        .unwrap();
+        let second = SourceSnapshot::single(
+            "main.rue",
+            "fn helper() -> i32 { 2 } fn main() -> i32 { helper() }",
+        )
+        .unwrap();
+        let options = CompileOptions::default();
+        let mut session = CompilerSession::new();
+
+        session.update(&first).into_result().unwrap();
+        let (first_cfgs, constructions) =
+            crate::cfg_query::with_test_cfg_query_key_construction_count(|| {
+                session.rooted_cfg(&options)
+            });
+        let first_cfgs = first_cfgs.unwrap();
+        assert_eq!(
+            constructions,
+            first_cfgs.cfgs.len(),
+            "a no-accessor production root constructs each final CFG key exactly once"
+        );
+        let first_helper = first_cfgs
+            .cfgs
+            .iter()
+            .find(|cfg| crate::cfg_query::accessor_source_name(&cfg.function) == "helper")
+            .unwrap()
+            .optimized_cfg_key
+            .cfg
+            .clone();
+        drop(first_cfgs);
+
+        session.update(&second).into_result().unwrap();
+        let second_cfgs = session.rooted_cfg(&options).unwrap();
+        let second_helper = second_cfgs
+            .cfgs
+            .iter()
+            .find(|cfg| crate::cfg_query::accessor_source_name(&cfg.function) == "helper")
+            .unwrap()
+            .optimized_cfg_key
+            .cfg
+            .clone();
+
+        assert_ne!(first_helper, second_helper);
+        assert_eq!(
+            hash(&first_helper),
+            hash(&second_helper),
+            "semantic versions of one function deliberately share the cheap memo partition"
+        );
+        let mut exact = std::collections::HashMap::new();
+        exact.insert(first_helper, "first");
+        exact.insert(second_helper, "second");
+        assert_eq!(exact.len(), 2, "typed equality resolves the hash collision");
     }
 
     #[test]


### PR DESCRIPTION
Fixes RUE-1345.

## Summary

- replace whole-payload `Debug` serialization in CFG memo keys with a cheap function/configuration partition while retaining exact typed equality for collisions
- consume accessor-subgraph roots once instead of rebuilding final CFG keys
- attribute CFG input preparation to the CFG phase and add a deterministic construction/collision regression

## Performance

Alternating cold-process measurements (baseline → candidate median wall time):

| Workload | Baseline | Candidate | Change |
| --- | ---: | ---: | ---: |
| Ruelex | 0.34s | 0.35s | wall noise floor; median CPU -8% |
| Mosaic | 1.10s | 0.90s | -18% |
| Harbor | 2.45s | 1.97s | -20% |
| Lattice | 2.99s | 2.45s | -18% |

One-worker Lattice improves from 3.94s to 3.17s (-19.5%). All deterministic query-work counters are byte-for-byte unchanged across the four maintained workloads, confirming that this removes representational overhead rather than compiler work.

The candidate profile no longer contains the `CfgQueryKey::new` hotspot. Lattice's unattributed phase falls from 1.081s to 0.172s; the CFG band grows from 0.332s to 0.556s because preparation is now charged to its owning phase, while total wall time still falls materially.

## Validation

- focused CFG-key construction and collision regression
- `scripts/rue quick` (31 targets, zero failures)
- `scripts/rue fmt`
- final whitespace and diff audit
