### PR TITLE
RUE-1346: share canonical semantic bodies

### DIFF
--- a/crates/rue-compiler/src/body_query.rs
+++ b/crates/rue-compiler/src/body_query.rs
@@ -167,7 +167,11 @@ impl QueryKey for BodyQueryKey {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+/// Request-independent semantic body shared by every stamped projection and
+/// downstream CFG input. This type deliberately is not `Clone`: query
+/// boundaries share its immutable allocation through `Arc` instead of copying
+/// instructions, places, and strings.
+#[derive(Debug, PartialEq, Eq)]
 pub(crate) enum CanonicalBody {
     Ordinary {
         owner: crate::StableDefinitionKey,
@@ -303,7 +307,7 @@ pub(crate) fn produced_anonymous_equal(
 #[derive(Debug, Clone)]
 pub(crate) enum BodyTransaction {
     Success {
-        body: Box<CanonicalBody>,
+        body: Arc<CanonicalBody>,
         references: BodyReferences,
         produced_anonymous_nominals: BodyProducedAnonymousNominals,
         consulted_anonymous_nominals: BodyConsultedAnonymousNominals,

--- a/crates/rue-compiler/src/revisioned_query_database.rs
+++ b/crates/rue-compiler/src/revisioned_query_database.rs
@@ -349,7 +349,7 @@ pub(crate) struct RevisionedQueryDatabase {
         QueryFamily<crate::body_query::BodyQueryKey, crate::body_query::BodyTransaction>,
     #[cfg_attr(not(test), allow(dead_code))]
     canonical_bodies:
-        QueryFamily<crate::body_query::BodyQueryKey, crate::body_query::CanonicalBody>,
+        QueryFamily<crate::body_query::BodyQueryKey, Arc<crate::body_query::CanonicalBody>>,
     #[allow(dead_code)]
     body_analysis_bundles:
         QueryFamily<crate::body_query::BodyQueryKey, crate::body_query::BodyAnalysisBundle>,
@@ -13022,8 +13022,8 @@ impl RevisionedQueryDatabase {
             .family_with_equality_and_evaluator(
                 "compiler.canonical-body",
                 BODY_QUERY_MEMO_RETENTION,
-                |left: &crate::body_query::CanonicalBody,
-                 right: &crate::body_query::CanonicalBody| left == right,
+                |left: &Arc<crate::body_query::CanonicalBody>,
+                 right: &Arc<crate::body_query::CanonicalBody>| left == right,
                 move |context, _, key: &crate::body_query::BodyQueryKey| {
                     let transaction = context
                         .query_registered(&transactions_for_canonical_bodies, key.clone())?;
@@ -13033,7 +13033,7 @@ impl RevisionedQueryDatabase {
                     else {
                         return Err(QueryAbort::Canceled);
                     };
-                    Ok(QueryOutput::success(body.as_ref().clone()))
+                    Ok(QueryOutput::success(body.clone()))
                 },
             )
             .expect("the CanonicalBody family has one canonical name");
@@ -17556,7 +17556,7 @@ impl BodyTransactionEvaluator {
                             (Ok(body), Ok(_), Ok(produced_anonymous_nominals)) => {
                                 collect_published_body_references(&body, &mut references);
                                 crate::body_query::BodyTransaction::Success {
-                                    body: Box::new(crate::body_query::CanonicalBody::Ordinary {
+                                    body: Arc::new(crate::body_query::CanonicalBody::Ordinary {
                                         owner: definition.clone(),
                                         body,
                                     }),
@@ -17847,7 +17847,7 @@ impl BodyTransactionEvaluator {
                                     .map(|nominal| (nominal.identity.clone(), nominal))
                                     .collect::<BTreeMap<_, _>>();
                                 crate::body_query::BodyTransaction::Success {
-                                    body: Box::new(
+                                    body: Arc::new(
                                         crate::body_query::CanonicalBody::Specialization {
                                             identity,
                                             body,
@@ -18060,7 +18060,7 @@ impl BodyTransactionEvaluator {
                                 );
                                 collect_published_body_references(&body, &mut references);
                                 crate::body_query::BodyTransaction::Success {
-                                    body: Box::new(crate::body_query::CanonicalBody::Anonymous {
+                                    body: Arc::new(crate::body_query::CanonicalBody::Anonymous {
                                         identity,
                                         body_anchor: crate::body_query::BodyRelativeRange {
                                             start: member_input.body_start,
@@ -18381,7 +18381,8 @@ impl RevisionedQueryDatabase {
         revision: Revision,
         key: crate::body_query::BodyQueryKey,
         cancellation: CancellationToken,
-    ) -> Result<Arc<rue_query::QueryTerminal<crate::body_query::CanonicalBody>>, QueryAbort> {
+    ) -> Result<Arc<rue_query::QueryTerminal<Arc<crate::body_query::CanonicalBody>>>, QueryAbort>
+    {
         self.runtime
             .request_registered(&self.canonical_bodies, revision, key, cancellation)
             .into_result()

--- a/crates/rue-compiler/src/session.rs
+++ b/crates/rue-compiler/src/session.rs
@@ -4994,7 +4994,7 @@ impl CompilerSession {
                 crate::cfg_query::CfgSemanticInput::Body {
                     input: Arc::new(crate::cfg_query::CfgBodyInput {
                         function: closure_body.key.instance.clone(),
-                        canonical: Arc::new((**body).clone()),
+                        canonical: body.clone(),
                         body_span,
                     }),
                     materialization: Arc::new(materialization),
@@ -12361,6 +12361,65 @@ fn main() -> i32 {
             &first_transaction,
             &relocated_transaction,
         ));
+    }
+
+    #[test]
+    fn canonical_body_projections_share_one_immutable_artifact() {
+        let source = SourceSnapshot::single(
+            "main.rue",
+            "fn helper() -> i32 { 40 } fn main() -> i32 { helper() + 2 }",
+        )
+        .unwrap();
+        let options = CompileOptions::default();
+        let mut session = CompilerSession::new();
+        session.update(&source).into_result().unwrap();
+        session.canonical_semantic(&options).unwrap();
+
+        let key = body_query_key(&mut session, &options, "main");
+        let revision = session
+            .queries
+            .revisioned
+            .current_semantic_revision()
+            .unwrap();
+        let cancellation = rue_query::CancellationToken::new();
+        let transaction = session
+            .queries
+            .revisioned
+            .body_transaction(revision, key.clone(), cancellation.clone())
+            .unwrap();
+        let projection = session
+            .queries
+            .revisioned
+            .canonical_body_projection(revision, key.clone(), cancellation.clone())
+            .unwrap();
+        let bundle = session
+            .queries
+            .revisioned
+            .body_analysis_bundle(revision, key, cancellation)
+            .unwrap();
+
+        let rue_query::QueryOutcome::Success(crate::body_query::BodyTransaction::Success {
+            body: transaction_body,
+            ..
+        }) = transaction.outcome()
+        else {
+            panic!("body transaction must publish a canonical body");
+        };
+        let rue_query::QueryOutcome::Success(projection_body) = projection.outcome() else {
+            panic!("canonical-body projection must publish a value");
+        };
+        let rue_query::QueryOutcome::Success(bundle) = bundle.outcome() else {
+            panic!("body-analysis bundle must publish a value");
+        };
+        let crate::body_query::BodyTransaction::Success {
+            body: bundle_body, ..
+        } = &bundle.transaction
+        else {
+            panic!("body-analysis bundle must retain the successful transaction");
+        };
+
+        assert!(Arc::ptr_eq(transaction_body, projection_body));
+        assert!(Arc::ptr_eq(transaction_body, bundle_body));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- share one immutable canonical semantic body across the body transaction, canonical-body projection, analysis bundle, and CFG input
- make `CanonicalBody` deliberately non-`Clone` so future query boundaries cannot silently restore deep payload copies
- add a pointer-identity regression while preserving independently stamped projections and exact query dependencies

## Why

The landed query graph logically owns one request-independent semantic body, but its Rust payloads copied every instruction, place, and string into three downstream representations during a cold build. Those copies added allocation and memory movement without creating an invalidation or concurrency boundary.

## Evidence

- `scripts/rue unit compiler canonical_body_projections_share_one_immutable_artifact`
- `scripts/rue quick` (834 compiler tests and all quick-tier targets passed)
- maintained cold scale curve rerun with the retained baseline under the same host conditions
- deterministic query counters are byte-for-byte unchanged
- compiler time is neutral within roughly ±1.5% across Ruelex, Mosaic, Harbor, and Lattice
- peak memory moved from 637.1 to 632.7 MiB on Harbor and from 702.1 to 693.0 MiB on Lattice; smaller workloads were effectively flat

Fixes RUE-1346.
