### PR TITLE
RUE-1348: attribute query display identities

### DIFF
--- a/crates/rue-bench/src/incremental.rs
+++ b/crates/rue-bench/src/incremental.rs
@@ -15,12 +15,13 @@ use rue_compiler::unstable::{
 use rue_compiler::{CompileErrors, CompileOptions, CompileOutput, CompileWarning, OptLevel};
 use rue_driver::{FilesystemCompilerHost, HostOpenRequest, SourceLoadError};
 use rue_perf_schema::{
-    EDIT_REPORT_SCHEMA_VERSION, EditEndpoints, EditManifest, EditOutcome, EditReport,
-    EditReportIdentity, EditReportRegime, EditRow, EditSample, EditScenario, ExpectedEditOutcome,
-    FailureStage, OptimizationSetting, OracleComparison, OutcomeIdentity, OutcomeKind, PhaseWork,
-    RetainedGauges, RetentionSequence, RetentionStep, RetentionStepOutcome, SourceShape,
-    StructuralWork, TransformationIdentity, ValidationWork as ReportValidationWork, WorkerMode,
-    canonical_json, derive_edit_report, render_edit_report_markdown, validate_edit_report,
+    DisplayIdentityWork, EDIT_REPORT_SCHEMA_VERSION, EditEndpoints, EditManifest, EditOutcome,
+    EditReport, EditReportIdentity, EditReportRegime, EditRow, EditSample, EditScenario,
+    ExpectedEditOutcome, FailureStage, OptimizationSetting, OracleComparison, OutcomeIdentity,
+    OutcomeKind, PhaseWork, RetainedGauges, RetentionSequence, RetentionStep, RetentionStepOutcome,
+    SourceShape, StructuralWork, TransformationIdentity, ValidationWork as ReportValidationWork,
+    WorkerMode, canonical_json, derive_edit_report, render_edit_report_markdown,
+    validate_edit_report,
 };
 use serde::Deserialize;
 use sha2::{Digest, Sha256};
@@ -308,6 +309,9 @@ impl CollectionTiming {
         self.query_runtime
             .validation
             .saturating_add_assign(other.query_runtime.validation);
+        self.query_runtime
+            .display_identities
+            .saturating_add_assign(other.query_runtime.display_identities);
         self.query_runtime.retention_enforcements = self
             .query_runtime
             .retention_enforcements
@@ -853,6 +857,7 @@ pub(crate) fn measure_sample(request: SampleRequest<'_>) -> Result<SampleObserva
             outcome,
             work,
             validation,
+            display_identities: report_display_identity_work(query_runtime.display_identities),
             retention,
             oracle,
         },
@@ -872,12 +877,28 @@ fn query_runtime_delta(
 ) -> QueryRuntimeMetrics {
     QueryRuntimeMetrics {
         validation: after.validation.saturating_sub(before.validation),
+        display_identities: after
+            .display_identities
+            .saturating_sub(before.display_identities),
         retention_enforcements: after
             .retention_enforcements
             .saturating_sub(before.retention_enforcements),
         retention_scan_entries: after
             .retention_scan_entries
             .saturating_sub(before.retention_scan_entries),
+    }
+}
+
+fn report_display_identity_work(
+    work: rue_compiler::unstable::QueryDisplayIdentityMetrics,
+) -> DisplayIdentityWork {
+    DisplayIdentityWork {
+        memo_node_materializations: work.memo_node_materializations,
+        memo_node_bytes: work.memo_node_bytes,
+        structured_wait_materializations: work.structured_wait_materializations,
+        structured_wait_bytes: work.structured_wait_bytes,
+        abort_fallback_materializations: work.abort_fallback_materializations,
+        abort_fallback_bytes: work.abort_fallback_bytes,
     }
 }
 

--- a/crates/rue-bench/src/scaling.rs
+++ b/crates/rue-bench/src/scaling.rs
@@ -400,6 +400,34 @@ fn render(report: &ScalingReport) -> String {
         ));
     }
 
+    out.push_str("\n## Query display identities\n\n");
+    out.push_str("Counts and UTF-8 key bytes are exact for identities the compiler actually formatted. Shared family names are excluded. `bytes/token` exposes presentation-only bookkeeping growth independently of clock noise.\n\n");
+    out.push_str("| workload | memo nodes count/bytes | structured waits count/bytes | abort fallbacks count/bytes | bytes/token |\n");
+    out.push_str("| --- | ---: | ---: | ---: | ---: |\n");
+    for observation in &report.workloads {
+        let identities = observation.work.query_runtime.display_identities;
+        let total_bytes = identities
+            .memo_node_bytes
+            .saturating_add(identities.structured_wait_bytes)
+            .saturating_add(identities.abort_fallback_bytes);
+        let bytes_per_token = if observation.shape.tokens == 0 {
+            0.0
+        } else {
+            total_bytes as f64 / observation.shape.tokens as f64
+        };
+        out.push_str(&format!(
+            "| {} | {}/{} | {}/{} | {}/{} | {:.2} |\n",
+            observation.workload,
+            identities.memo_node_materializations,
+            identities.memo_node_bytes,
+            identities.structured_wait_materializations,
+            identities.structured_wait_bytes,
+            identities.abort_fallback_materializations,
+            identities.abort_fallback_bytes,
+            bytes_per_token,
+        ));
+    }
+
     out.push_str("\n## Additive compiler-root phase medians\n\n");
     out.push_str("All values are milliseconds. Bands are mutually exclusive and sum to compiler-root time per raw sample.\n\n");
     out.push_str("| workload | source/parse | program | semantic | CFG/opt | backend | object | linking | mixed | unattributed |\n");
@@ -506,6 +534,13 @@ mod tests {
                             memo_misses: 2,
                             ..Default::default()
                         },
+                        display_identities: rue_perf_schema::DisplayIdentityWork {
+                            memo_node_materializations: 3,
+                            memo_node_bytes: 21,
+                            structured_wait_materializations: 2,
+                            structured_wait_bytes: 14,
+                            ..Default::default()
+                        },
                         retention_enforcements: 1,
                         retention_scan_entries: 4,
                     },
@@ -526,6 +561,8 @@ mod tests {
         assert!(rendered.contains("shape id"));
         assert!(rendered.contains("Deterministic query work"));
         assert!(rendered.contains("nodes/token"));
+        assert!(rendered.contains("Query display identities"));
+        assert!(rendered.contains("bytes/token"));
     }
 
     #[test]

--- a/crates/rue-compiler/src/session.rs
+++ b/crates/rue-compiler/src/session.rs
@@ -129,6 +129,7 @@ pub struct FrontendRetentionMetrics {
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
 pub(crate) struct FrontendRuntimeMetrics {
     pub(crate) validation: rue_query::ValidationWork,
+    pub(crate) display_identities: rue_query::DisplayIdentityMetrics,
     pub(crate) retention_enforcements: u64,
     pub(crate) retention_scan_entries: u64,
 }
@@ -3103,6 +3104,7 @@ impl CompilerSession {
         let runtime = self.queries.revisioned.runtime_retention_metrics();
         work.runtime = FrontendRuntimeMetrics {
             validation: runtime.validation,
+            display_identities: runtime.display_identities,
             retention_enforcements: runtime.retention_enforcements,
             retention_scan_entries: runtime.retention_scan_entries,
         };
@@ -3302,6 +3304,7 @@ impl CompilerSession {
         });
         self.metrics.set_runtime(FrontendRuntimeMetrics {
             validation: runtime.validation,
+            display_identities: runtime.display_identities,
             retention_enforcements: runtime.retention_enforcements,
             retention_scan_entries: runtime.retention_scan_entries,
         });

--- a/crates/rue-compiler/src/unstable.rs
+++ b/crates/rue-compiler/src/unstable.rs
@@ -1756,10 +1756,86 @@ mod query_validation_metrics_tests {
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
 pub struct QueryRuntimeMetrics {
     pub validation: QueryValidationMetrics,
+    /// Presentation-only query identity materialization.
+    pub display_identities: QueryDisplayIdentityMetrics,
     /// Family-local retention passes run.
     pub retention_enforcements: u64,
     /// Retention-queue entries examined by those passes.
     pub retention_scan_entries: u64,
+}
+
+/// Display-only query identity materialization contained in [`MetricsSnapshot`].
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct QueryDisplayIdentityMetrics {
+    /// New memo-node identity count.
+    pub memo_node_materializations: u64,
+    /// New memo-node formatted key bytes.
+    pub memo_node_bytes: u64,
+    /// Structured batch-wait identity count.
+    pub structured_wait_materializations: u64,
+    /// Structured batch-wait formatted key bytes.
+    pub structured_wait_bytes: u64,
+    /// Abort-fallback identity count.
+    pub abort_fallback_materializations: u64,
+    /// Abort-fallback formatted key bytes.
+    pub abort_fallback_bytes: u64,
+}
+
+impl QueryDisplayIdentityMetrics {
+    /// Saturating addition for aggregation across independent requests.
+    pub fn saturating_add_assign(&mut self, other: Self) {
+        self.memo_node_materializations = self
+            .memo_node_materializations
+            .saturating_add(other.memo_node_materializations);
+        self.memo_node_bytes = self.memo_node_bytes.saturating_add(other.memo_node_bytes);
+        self.structured_wait_materializations = self
+            .structured_wait_materializations
+            .saturating_add(other.structured_wait_materializations);
+        self.structured_wait_bytes = self
+            .structured_wait_bytes
+            .saturating_add(other.structured_wait_bytes);
+        self.abort_fallback_materializations = self
+            .abort_fallback_materializations
+            .saturating_add(other.abort_fallback_materializations);
+        self.abort_fallback_bytes = self
+            .abort_fallback_bytes
+            .saturating_add(other.abort_fallback_bytes);
+    }
+
+    /// Saturating delta between two cumulative runtime snapshots.
+    pub fn saturating_sub(self, earlier: Self) -> Self {
+        Self {
+            memo_node_materializations: self
+                .memo_node_materializations
+                .saturating_sub(earlier.memo_node_materializations),
+            memo_node_bytes: self.memo_node_bytes.saturating_sub(earlier.memo_node_bytes),
+            structured_wait_materializations: self
+                .structured_wait_materializations
+                .saturating_sub(earlier.structured_wait_materializations),
+            structured_wait_bytes: self
+                .structured_wait_bytes
+                .saturating_sub(earlier.structured_wait_bytes),
+            abort_fallback_materializations: self
+                .abort_fallback_materializations
+                .saturating_sub(earlier.abort_fallback_materializations),
+            abort_fallback_bytes: self
+                .abort_fallback_bytes
+                .saturating_sub(earlier.abort_fallback_bytes),
+        }
+    }
+}
+
+impl From<rue_query::DisplayIdentityMetrics> for QueryDisplayIdentityMetrics {
+    fn from(metrics: rue_query::DisplayIdentityMetrics) -> Self {
+        Self {
+            memo_node_materializations: metrics.memo_node_materializations,
+            memo_node_bytes: metrics.memo_node_bytes,
+            structured_wait_materializations: metrics.structured_wait_materializations,
+            structured_wait_bytes: metrics.structured_wait_bytes,
+            abort_fallback_materializations: metrics.abort_fallback_materializations,
+            abort_fallback_bytes: metrics.abort_fallback_bytes,
+        }
+    }
 }
 
 impl From<crate::session::FrontendQueryWork> for QueryMetrics {
@@ -2102,6 +2178,7 @@ impl MetricsSnapshot {
     pub fn query_runtime(&self) -> QueryRuntimeMetrics {
         QueryRuntimeMetrics {
             validation: self.inner.runtime.validation.into(),
+            display_identities: self.inner.runtime.display_identities.into(),
             retention_enforcements: self.inner.runtime.retention_enforcements,
             retention_scan_entries: self.inner.runtime.retention_scan_entries,
         }

--- a/crates/rue-perf-schema/src/incremental.rs
+++ b/crates/rue-perf-schema/src/incremental.rs
@@ -11,10 +11,10 @@ use std::collections::{BTreeMap, BTreeSet};
 
 use serde::{Deserialize, Serialize};
 
-use crate::{EnvironmentFingerprint, median, median_absolute_deviation};
+use crate::{DisplayIdentityWork, EnvironmentFingerprint, median, median_absolute_deviation};
 
 /// Version of the retained-session raw report wire format.
-pub const EDIT_REPORT_SCHEMA_VERSION: u32 = 5;
+pub const EDIT_REPORT_SCHEMA_VERSION: u32 = 6;
 
 /// One retained-session edit class from ADR-0068's initial matrix.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
@@ -803,6 +803,8 @@ pub struct EditSample {
     pub work: StructuralWork,
     /// Exact retained-terminal validation work.
     pub validation: ValidationWork,
+    /// Presentation-only query identity materialization during the warm request.
+    pub display_identities: DisplayIdentityWork,
     /// Retained memory and observation gauges at the endpoint.
     pub retention: RetainedGauges,
     /// Fresh-session correctness comparison performed outside timing.
@@ -1609,6 +1611,24 @@ pub struct StructuralWorkSummary {
     pub evicted: EndpointSummary,
 }
 
+/// Derived presentation-only query identity materialization.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct DisplayIdentityWorkSummary {
+    /// New memo-node identity count.
+    pub memo_node_materializations: EndpointSummary,
+    /// New memo-node formatted key bytes.
+    pub memo_node_bytes: EndpointSummary,
+    /// Structured batch-wait identity count.
+    pub structured_wait_materializations: EndpointSummary,
+    /// Structured batch-wait formatted key bytes.
+    pub structured_wait_bytes: EndpointSummary,
+    /// Abort-fallback identity count.
+    pub abort_fallback_materializations: EndpointSummary,
+    /// Abort-fallback formatted key bytes.
+    pub abort_fallback_bytes: EndpointSummary,
+}
+
 /// Fresh-link band derived from successful cumulative endpoints.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 #[serde(deny_unknown_fields)]
@@ -1643,6 +1663,8 @@ pub struct EditRowSummary {
     pub link_band: Option<LinkBandSummary>,
     /// Structural totals across phases.
     pub work: StructuralWorkSummary,
+    /// Presentation-only query identity materialization.
+    pub display_identities: DisplayIdentityWorkSummary,
 }
 
 /// Deterministic derived edit report.
@@ -1693,6 +1715,27 @@ fn derived_work(samples: &[EditSample]) -> StructuralWorkSummary {
         invalidated: summarize(&column(3)),
         canceled: summarize(&column(4)),
         evicted: summarize(&column(5)),
+    }
+}
+
+fn derived_display_identity_work(samples: &[EditSample]) -> DisplayIdentityWorkSummary {
+    let values = |project: fn(&DisplayIdentityWork) -> u64| {
+        samples
+            .iter()
+            .map(|sample| project(&sample.display_identities))
+            .collect::<Vec<_>>()
+    };
+    DisplayIdentityWorkSummary {
+        memo_node_materializations: summarize(&values(|work| work.memo_node_materializations)),
+        memo_node_bytes: summarize(&values(|work| work.memo_node_bytes)),
+        structured_wait_materializations: summarize(&values(|work| {
+            work.structured_wait_materializations
+        })),
+        structured_wait_bytes: summarize(&values(|work| work.structured_wait_bytes)),
+        abort_fallback_materializations: summarize(&values(|work| {
+            work.abort_fallback_materializations
+        })),
+        abort_fallback_bytes: summarize(&values(|work| work.abort_fallback_bytes)),
     }
 }
 
@@ -1772,6 +1815,7 @@ pub fn derive_edit_report(
                         share_basis_points: summarize(&share),
                     }),
                     work: derived_work(&row.samples),
+                    display_identities: derived_display_identity_work(&row.samples),
                 }
             })
             .collect()
@@ -1877,6 +1921,33 @@ pub fn render_edit_report_markdown(summary: &EditSummary) -> String {
             ));
         }
         out.push('\n');
+
+        out.push_str("## Query display identities\n\n");
+        out.push_str("Counts and UTF-8 key bytes are median ± MAD for identities the warm request actually formatted. Shared family names are excluded.\n\n");
+        out.push_str("| workload | scenario | workers | memo nodes count/bytes | structured waits count/bytes | abort fallbacks count/bytes |\n");
+        out.push_str("| --- | --- | --- | ---: | ---: | ---: |\n");
+        for row in &summary.rows {
+            let work = &row.display_identities;
+            out.push_str(&format!(
+                "| {} | {} | {} | {} ± {}/{} ± {} | {} ± {}/{} ± {} | {} ± {}/{} ± {} |\n",
+                row.workload,
+                row.scenario.wire_name(),
+                row.worker_mode.wire_name(),
+                work.memo_node_materializations.median,
+                work.memo_node_materializations.mad,
+                work.memo_node_bytes.median,
+                work.memo_node_bytes.mad,
+                work.structured_wait_materializations.median,
+                work.structured_wait_materializations.mad,
+                work.structured_wait_bytes.median,
+                work.structured_wait_bytes.mad,
+                work.abort_fallback_materializations.median,
+                work.abort_fallback_materializations.mad,
+                work.abort_fallback_bytes.median,
+                work.abort_fallback_bytes.mad,
+            ));
+        }
+        out.push('\n');
     }
     out.push_str(&format!(
         "Retention sequence: {} revisions; {} query evictions; max current {} bytes; peak {} bytes; final {} bytes.\n",
@@ -1897,7 +1968,7 @@ mod tests {
 
     const MANIFEST: &str = r#"
 schema_version = 2
-report_schema_version = 5
+report_schema_version = 6
 fixture_revision = 3
 timing_samples_per_row = 5
 structural_samples_per_row = 1
@@ -2072,6 +2143,14 @@ minimum_memory_bytes = 15000000000
             },
             work: StructuralWork::default(),
             validation: ValidationWork::default(),
+            display_identities: DisplayIdentityWork {
+                memo_node_materializations: 10 + u64::from(sample_index),
+                memo_node_bytes: 100 + u64::from(sample_index),
+                structured_wait_materializations: 20 + u64::from(sample_index),
+                structured_wait_bytes: 200 + u64::from(sample_index),
+                abort_fallback_materializations: u64::from(sample_index),
+                abort_fallback_bytes: 2 * u64::from(sample_index),
+            },
             retention: gauges(sample_index),
             oracle: OracleComparison::Matched {
                 warm: identity.clone(),
@@ -2215,7 +2294,27 @@ minimum_memory_bytes = 15000000000
         assert_eq!(first.schema_version, 2);
         assert!(first.reference_host_eligible);
         assert_eq!(first.retention_query_evictions, 12);
+        assert_eq!(
+            first.rows[0]
+                .display_identities
+                .memo_node_materializations
+                .median,
+            10
+        );
+        assert_eq!(first.rows[0].display_identities.memo_node_bytes.median, 100);
+        assert_eq!(
+            first.rows[0]
+                .display_identities
+                .structured_wait_materializations
+                .median,
+            20
+        );
+        assert_eq!(
+            first.rows[0].display_identities.abort_fallback_bytes.median,
+            0
+        );
         assert!(render_edit_report_markdown(&first).contains("12 query evictions"));
+        assert!(render_edit_report_markdown(&first).contains("Query display identities"));
         assert_eq!(
             render_edit_report_markdown(&first),
             render_edit_report_markdown(&second)
@@ -2357,8 +2456,8 @@ minimum_memory_bytes = 15000000000
 
         let json = serde_json::to_string(&report(&manifest)).unwrap();
         let unknown = json.replacen(
-            "\"schema_version\":5",
-            "\"schema_version\":5,\"surprise\":true",
+            "\"schema_version\":6",
+            "\"schema_version\":6,\"surprise\":true",
             1,
         );
         assert!(

--- a/crates/rue-perf-schema/src/lib.rs
+++ b/crates/rue-perf-schema/src/lib.rs
@@ -42,10 +42,10 @@ mod validate;
 
 pub use canonical::{CanonicalError, canonical_json, content_address};
 pub use incremental::{
-    EDIT_REPORT_SCHEMA_VERSION, EditEndpoints, EditManifest, EditManifestError, EditOutcome,
-    EditReport, EditReportIdentity, EditReportRegime, EditRow, EditRowSummary, EditSample,
-    EditScenario, EditScenarioDeclaration, EditSummary, EditValidation, EditWorkload,
-    EndpointSummary, ExpectedEditOutcome, FailureStage, HostClass, LinkBandSummary,
+    DisplayIdentityWorkSummary, EDIT_REPORT_SCHEMA_VERSION, EditEndpoints, EditManifest,
+    EditManifestError, EditOutcome, EditReport, EditReportIdentity, EditReportRegime, EditRow,
+    EditRowSummary, EditSample, EditScenario, EditScenarioDeclaration, EditSummary, EditValidation,
+    EditWorkload, EndpointSummary, ExpectedEditOutcome, FailureStage, HostClass, LinkBandSummary,
     OptimizationSetting, OracleComparison, OutcomeIdentity, OutcomeKind, PhaseWork, ReferenceHost,
     RetainedGauges, RetentionSequence, RetentionStep, RetentionStepOutcome, RotationRule,
     SourceShape, StructuralWork, StructuralWorkSummary, TransformationIdentity, ValidationFinding,
@@ -74,6 +74,27 @@ pub use validate::{
     Completeness, InvalidSample, InvalidSampleReason, ValidationError, ValidationOutcome,
     validate_run,
 };
+
+/// Deterministic presentation-only query identity materialization.
+///
+/// Byte totals contain the UTF-8 key identity returned by the query family;
+/// shared family names are excluded.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct DisplayIdentityWork {
+    /// Identities created once for new memo-node incarnations.
+    pub memo_node_materializations: u64,
+    /// Formatted key bytes retained by new memo-node incarnations.
+    pub memo_node_bytes: u64,
+    /// Identities created to label structured batch wait edges.
+    pub structured_wait_materializations: u64,
+    /// Formatted key bytes used to label structured batch wait edges.
+    pub structured_wait_bytes: u64,
+    /// Identities created lazily when nested requests abort.
+    pub abort_fallback_materializations: u64,
+    /// Formatted key bytes created lazily when nested requests abort.
+    pub abort_fallback_bytes: u64,
+}
 
 /// The schema version of [`RunObject`] as defined by this crate.
 ///

--- a/crates/rue-perf-schema/src/scaling.rs
+++ b/crates/rue-perf-schema/src/scaling.rs
@@ -9,10 +9,10 @@ use std::collections::BTreeSet;
 
 use serde::{Deserialize, Serialize};
 
-use crate::{EnvironmentFingerprint, Sample, ValidationWork};
+use crate::{DisplayIdentityWork, EnvironmentFingerprint, Sample, ValidationWork};
 
 /// Version of the scaling-report wire format.
-pub const SCALING_REPORT_SCHEMA_VERSION: u32 = 3;
+pub const SCALING_REPORT_SCHEMA_VERSION: u32 = 4;
 
 /// The lower-frequency scaling suite declaration.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -177,6 +177,8 @@ pub struct CompilerWork {
 pub struct QueryRuntimeWork {
     /// Retained-terminal validation and proof work.
     pub validation: ValidationWork,
+    /// Presentation-only query identity materialization.
+    pub display_identities: DisplayIdentityWork,
     /// Family-local retention passes run.
     pub retention_enforcements: u64,
     /// Retention-queue entries examined by those passes.

--- a/crates/rue-query/src/lib.rs
+++ b/crates/rue-query/src/lib.rs
@@ -2961,6 +2961,27 @@ impl AtomicValidationWork {
     }
 }
 
+/// Display-only query identities materialized by the runtime.
+///
+/// The byte counters record the UTF-8 length returned by
+/// [`QueryKey::stable_identity`]. Family names are shared separately and are
+/// not included. Typed keys remain authoritative for memo lookup.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct DisplayIdentityMetrics {
+    /// Identities created once for new memo-node incarnations.
+    pub memo_node_materializations: u64,
+    /// Formatted key bytes retained by new memo-node incarnations.
+    pub memo_node_bytes: u64,
+    /// Identities created to label structured batch wait edges.
+    pub structured_wait_materializations: u64,
+    /// Formatted key bytes used to label structured batch wait edges.
+    pub structured_wait_bytes: u64,
+    /// Identities created lazily when nested requests abort.
+    pub abort_fallback_materializations: u64,
+    /// Formatted key bytes created lazily when nested requests abort.
+    pub abort_fallback_bytes: u64,
+}
+
 /// Deterministic structural execution counters.
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
 pub struct RuntimeMetrics {
@@ -2973,6 +2994,8 @@ pub struct RuntimeMetrics {
     pub reuses: u64,
     /// Retained-terminal validation work.
     pub validation: ValidationWork,
+    /// Presentation-only query identity materialization.
+    pub display_identities: DisplayIdentityMetrics,
     /// Query bodies which completed before publication checks.
     pub body_completions: u64,
     /// Recomputations whose observable stamp stayed red.
@@ -3088,6 +3111,12 @@ struct Metrics {
     joins: AtomicU64,
     reuses: AtomicU64,
     validation: AtomicValidationWork,
+    memo_node_identity_materializations: AtomicU64,
+    memo_node_identity_bytes: AtomicU64,
+    structured_wait_identity_materializations: AtomicU64,
+    structured_wait_identity_bytes: AtomicU64,
+    abort_fallback_identity_materializations: AtomicU64,
+    abort_fallback_identity_bytes: AtomicU64,
     body_completions: AtomicU64,
     red_publications: AtomicU64,
     green_publications: AtomicU64,
@@ -3130,6 +3159,20 @@ impl Metrics {
             joins: self.joins.load(Ordering::Relaxed),
             reuses: self.reuses.load(Ordering::Relaxed),
             validation: self.validation.snapshot(),
+            display_identities: DisplayIdentityMetrics {
+                memo_node_materializations: self
+                    .memo_node_identity_materializations
+                    .load(Ordering::Relaxed),
+                memo_node_bytes: self.memo_node_identity_bytes.load(Ordering::Relaxed),
+                structured_wait_materializations: self
+                    .structured_wait_identity_materializations
+                    .load(Ordering::Relaxed),
+                structured_wait_bytes: self.structured_wait_identity_bytes.load(Ordering::Relaxed),
+                abort_fallback_materializations: self
+                    .abort_fallback_identity_materializations
+                    .load(Ordering::Relaxed),
+                abort_fallback_bytes: self.abort_fallback_identity_bytes.load(Ordering::Relaxed),
+            },
             body_completions: self.body_completions.load(Ordering::Relaxed),
             red_publications: self.red_publications.load(Ordering::Relaxed),
             green_publications: self.green_publications.load(Ordering::Relaxed),
@@ -3196,6 +3239,27 @@ impl Metrics {
     fn body_entered(&self) {
         let active = self.active_bodies.fetch_add(1, Ordering::AcqRel) + 1;
         self.peak_active_bodies.fetch_max(active, Ordering::AcqRel);
+    }
+
+    fn record_memo_node_identity(&self, bytes: usize) {
+        self.memo_node_identity_materializations
+            .fetch_add(1, Ordering::Relaxed);
+        self.memo_node_identity_bytes
+            .fetch_add(bytes as u64, Ordering::Relaxed);
+    }
+
+    fn record_structured_wait_identity(&self, bytes: usize) {
+        self.structured_wait_identity_materializations
+            .fetch_add(1, Ordering::Relaxed);
+        self.structured_wait_identity_bytes
+            .fetch_add(bytes as u64, Ordering::Relaxed);
+    }
+
+    fn record_abort_fallback_identity(&self, bytes: usize) {
+        self.abort_fallback_identity_materializations
+            .fetch_add(1, Ordering::Relaxed);
+        self.abort_fallback_identity_bytes
+            .fetch_add(bytes as u64, Ordering::Relaxed);
     }
 
     fn body_left(&self) {
@@ -5310,7 +5374,11 @@ where
         let node = if let Some(node) = nodes.get(&key) {
             node.clone()
         } else {
-            let stable_key: Arc<str> = key.stable_identity().into();
+            let stable_key = key.stable_identity();
+            self.core
+                .metrics
+                .record_memo_node_identity(stable_key.len());
+            let stable_key: Arc<str> = stable_key.into();
             let incarnation = self.core.next_node.fetch_add(1, Ordering::Relaxed);
             let demand = self.inner.evaluator.as_ref().map(|_| {
                 let core = self.core.clone();
@@ -7095,11 +7163,16 @@ impl QueryContext {
             self.task.core.clone(),
             self.task.id,
             items.iter().map(|(_, request_id, key)| {
+                let stable_key = key.stable_identity();
+                self.task
+                    .core
+                    .metrics
+                    .record_structured_wait_identity(stable_key.len());
                 (
                     TaskId(*request_id),
                     NodeIdentity {
                         family: family.inner.name.clone(),
-                        key: key.stable_identity().into(),
+                        key: stable_key.into(),
                     },
                 )
             }),
@@ -8881,6 +8954,9 @@ impl Task {
             TaskQueryResult::Terminal { terminal, .. } => terminal.node.family(),
             TaskQueryResult::Aborted { .. } => {
                 let node = fallback_node();
+                self.core
+                    .metrics
+                    .record_abort_fallback_identity(node.key().len());
                 if !self.records_nested_attempt(node.family()) {
                     return;
                 }
@@ -9942,6 +10018,58 @@ mod tests {
         fn stable_identity(&self) -> String {
             self.0.to_owned()
         }
+    }
+
+    #[test]
+    fn display_identity_metrics_attribute_each_materialization_source() {
+        let runtime = QueryRuntime::new(1);
+        publish_empty(&runtime, [revision(1)]);
+
+        let child = runtime
+            .family_with_evaluator::<Key, u64, _>("identity-child", 8, |_, _, key| {
+                Ok(QueryOutput::success(key.0.len() as u64))
+            })
+            .unwrap();
+        let child_for_root = child.clone();
+        let batch_root = runtime
+            .family_with_evaluator::<Key, u64, _>("identity-batch-root", 8, move |context, _, _| {
+                context.query_registered_batch(&child_for_root, [Key("aa"), Key("bbb")])?;
+                Ok(QueryOutput::success(0))
+            })
+            .unwrap();
+        runtime
+            .request_registered(&batch_root, revision(1), Key("r"), CancellationToken::new())
+            .into_result()
+            .unwrap();
+
+        let foreign_runtime = QueryRuntime::new(1);
+        let foreign = foreign_runtime
+            .family::<Key, u64>("identity-foreign", 8)
+            .unwrap();
+        let abort_root = runtime
+            .family_with_evaluator::<Key, u64, _>("identity-abort-root", 8, move |context, _, _| {
+                context.query(&foreign, Key("oops"), |_| Ok(QueryOutput::success(1)))?;
+                Ok(QueryOutput::success(0))
+            })
+            .unwrap();
+        assert_eq!(
+            runtime
+                .request_registered(&abort_root, revision(1), Key("x"), CancellationToken::new(),)
+                .abort(),
+            Some(&QueryAbort::ForeignRuntime)
+        );
+
+        assert_eq!(
+            runtime.metrics().display_identities,
+            DisplayIdentityMetrics {
+                memo_node_materializations: 4,
+                memo_node_bytes: 7,
+                structured_wait_materializations: 2,
+                structured_wait_bytes: 5,
+                abort_fallback_materializations: 1,
+                abort_fallback_bytes: 4,
+            }
+        );
     }
 
     fn assert_validation_work_consistent(work: ValidationWork) {

--- a/crates/rue/src/main.rs
+++ b/crates/rue/src/main.rs
@@ -979,6 +979,18 @@ fn benchmark_compiler_work(
                 superseded: validation.superseded,
                 certificates_published: validation.certificates_published,
             },
+            display_identities: rue_perf_schema::DisplayIdentityWork {
+                memo_node_materializations: runtime.display_identities.memo_node_materializations,
+                memo_node_bytes: runtime.display_identities.memo_node_bytes,
+                structured_wait_materializations: runtime
+                    .display_identities
+                    .structured_wait_materializations,
+                structured_wait_bytes: runtime.display_identities.structured_wait_bytes,
+                abort_fallback_materializations: runtime
+                    .display_identities
+                    .abort_fallback_materializations,
+                abort_fallback_bytes: runtime.display_identities.abort_fallback_bytes,
+            },
             retention_enforcements: runtime.retention_enforcements,
             retention_scan_entries: runtime.retention_scan_entries,
         },
@@ -1481,6 +1493,14 @@ mod tests {
                     duplicate_terminal_lease_observations: 5,
                     ..Default::default()
                 },
+                display_identities: rue_compiler::unstable::QueryDisplayIdentityMetrics {
+                    memo_node_materializations: 19,
+                    memo_node_bytes: 113,
+                    structured_wait_materializations: 23,
+                    structured_wait_bytes: 211,
+                    abort_fallback_materializations: 2,
+                    abort_fallback_bytes: 17,
+                },
                 retention_enforcements: 13,
                 retention_scan_entries: 17,
             },
@@ -1497,6 +1517,20 @@ mod tests {
         );
         assert_eq!(projected.retention_enforcements, 13);
         assert_eq!(projected.retention_scan_entries, 17);
+        assert_eq!(projected.display_identities.memo_node_materializations, 19);
+        assert_eq!(projected.display_identities.memo_node_bytes, 113);
+        assert_eq!(
+            projected
+                .display_identities
+                .structured_wait_materializations,
+            23
+        );
+        assert_eq!(projected.display_identities.structured_wait_bytes, 211);
+        assert_eq!(
+            projected.display_identities.abort_fallback_materializations,
+            2
+        );
+        assert_eq!(projected.display_identities.abort_fallback_bytes, 17);
     }
     use tracing_subscriber::layer::SubscriberExt as _;
 

--- a/docs/designs/0068-incremental-edit-performance-measurement.md
+++ b/docs/designs/0068-incremental-edit-performance-measurement.md
@@ -181,6 +181,8 @@ Every raw observation records at least:
   retention-proof-reacquisition misses, registered-cone endorsements,
   exact query-result terminal lease observations and same-task duplicates,
   re-demand outcomes, superseded incarnations, and published certificates;
+- exact counts and formatted key bytes for display-only memo-node, structured
+  batch-wait, and abort-fallback query identities during the warm request;
 - current and peak retained artifact charge, dependency/input observations, and
   configured budgets;
 - diagnostics/warning identity and executable fingerprint;

--- a/docs/process/compiler-scaling.md
+++ b/docs/process/compiler-scaling.md
@@ -32,12 +32,19 @@ compilations. The report records:
 - externally observed fresh-process wall time and peak resident memory;
 - the compiler's additive, mutually exclusive phase accounting;
 - query validation, endorsement, lease, demand, and retention-scan work;
+- display-only query identities materialized for memo nodes, structured batch
+  wait edges, and abort fallbacks, with exact counts and formatted key bytes;
 - output binary size.
 
 The Markdown work table includes validation nodes per token. That ratio is a
 clock-independent amplification signal: source growth should not silently turn
 into many repeated validation visits merely because elapsed time still looks
 plausible on one host.
+
+The display-identity table similarly reports formatted key bytes per token.
+These identities label diagnostics and wait-graph edges; typed query keys, not
+the display strings, remain authoritative for memo lookup. Family names are
+shared and therefore excluded from the byte totals.
 
 The compiled examples are never executed. Runtime tests and heavyweight
 example scenarios remain in their existing suites, so a slow example runtime

--- a/performance/incremental.toml
+++ b/performance/incremental.toml
@@ -5,7 +5,7 @@
 # Fixture edits are added under a new `fixture_revision`; raw report syntax
 # advances independently under `report_schema_version`.
 schema_version = 2
-report_schema_version = 5
+report_schema_version = 6
 fixture_revision = 2
 # Two workloads each collect seven one-sample structural rows and one five-
 # sample latency row: 24 independent retained sessions in the scheduled matrix.


### PR DESCRIPTION
## Summary

- attribute every `QueryKey::stable_identity()` materialization to memo-node ownership, structured batch-wait labeling, or abort fallback
- expose exact materialization counts and formatted key bytes through unstable compiler metrics
- advance the fresh scaling report to schema v4 and the retained edit report to schema v6, with derived Markdown tables
- document that typed keys remain authoritative and shared family names are excluded

## Cold evidence

Fresh release processes on the maintained scaling curve produced:

| workload | memo nodes count/bytes | structured waits count/bytes | abort fallbacks count/bytes | total bytes/token |
| --- | ---: | ---: | ---: | ---: |
| Ruelex | 8,307 / 2,181,171 | 8,827 / 2,545,490 | 0 / 0 | 96.15 |
| Mosaic | 18,330 / 5,698,363 | 30,979 / 10,414,280 | 0 / 0 | 202.88 |
| Harbor | 32,299 / 15,479,840 | 70,671 / 28,402,213 | 0 / 0 | 382.38 |
| Lattice | 38,380 / 9,494,659 | 89,895 / 33,777,606 | 0 / 0 | 278.30 |

On Lattice, structured wait labels account for 78% of the 43.3 MB of formatted key text and 70% of materializations. This change deliberately measures that cost without changing identity representation or wait-graph behavior.

Compiler-root medians versus the immediately preceding same-host report moved -0.6%, -0.6%, +1.0%, and +0.7% from Ruelex through Lattice, respectively: neutral within host noise.

## Verification

- focused query-runtime attribution regression
- fresh scaling report deterministic probes agree for all four workloads
- focused fresh-report, retained-report, and compiler-projection tests
- `scripts/rue fmt`
- `scripts/rue quick` compiled and ran the full quick graph; its sole failure was the expected schema-version fixture updated and rerun in isolation

Fixes RUE-1348.

Refs RUE-1347.
