### PR TITLE
RUE-1347: publish cold compiler architecture audit

### DIFF
--- a/crates/rue-compiler/src/api_inventory.rs
+++ b/crates/rue-compiler/src/api_inventory.rs
@@ -231,9 +231,10 @@ fn codegen_queries_consume_only_registered_optimized_cfg_domains() {
     );
     let session = include_str!("session.rs");
     assert!(
-        session.contains("RUE-1217 owns replacing this")
+        session.contains("this adapter enumerates the")
+            && session.contains("semantic functions only so focused tests can inspect units")
             && !session.contains("_foreign_symbols: &[String]"),
-        "collection must retain only the explicitly tracked RUE-1217 root adapter"
+        "collection must retain only the test-only pre-object inspection adapter"
     );
 }
 

--- a/crates/rue-compiler/src/session.rs
+++ b/crates/rue-compiler/src/session.rs
@@ -5606,12 +5606,11 @@ impl CompilerSession {
             .collect())
     }
 
-    /// Collect reached canonical codegen terminals without immediately
-    /// collapsing them into the historical backend-product representation.
-    /// Object and link consumers aggregate this exact result in a
-    /// `ProgramImagePlan`; presentation consumers may still use the thin
-    /// `codegen_products` projection above. RUE-1217 owns replacing this
-    /// remaining semantic root enumeration with query-native image roots.
+    /// Collect reached canonical codegen terminals for tests which inspect the
+    /// pre-object boundary. Production object and link consumers use
+    /// `rooted_codegen`'s query-native image root; this adapter enumerates the
+    /// semantic functions only so focused tests can inspect units without
+    /// constructing a `ProgramImage`.
     #[cfg(test)]
     pub(crate) fn codegen_units(
         &mut self,

--- a/docs/notes/body-analysis-cfg-incrementality-audit.md
+++ b/docs/notes/body-analysis-cfg-incrementality-audit.md
@@ -1,5 +1,13 @@
 # Body analysis and CFG incrementality audit
 
+> [!WARNING]
+> Historical implementation audit. This note describes the retired durable
+> body/CFG import architecture that preceded ADR-0063's query-native cutover.
+> See the
+> [post-ADR-0063 cold compiler architecture audit](post-adr-0063-cold-compiler-architecture-audit.md)
+> for the current source map; [ADR-0063](../designs/0063-parallel-demand-driven-incremental-compilation.md)
+> remains the architectural authority.
+
 Status: RUE-720 completion audit. `CompilerSession` retains and reuses supported
 per-definition body and CFG artifacts through the canonical semantic query.
 Unsupported surfaces fail closed to the existing analysis/build path.

--- a/docs/notes/canonical-query-completion-audit.md
+++ b/docs/notes/canonical-query-completion-audit.md
@@ -1,5 +1,12 @@
 # Compiler session architecture completion audit
 
+> [!WARNING]
+> Historical implementation audit. This note describes the compiler before
+> ADR-0063's revisioned query-runtime cutover. See the
+> [post-ADR-0063 cold compiler architecture audit](post-adr-0063-cold-compiler-architecture-audit.md)
+> for the current source map; [ADR-0063](../designs/0063-parallel-demand-driven-incremental-compilation.md)
+> remains the architectural authority.
+
 This audit records the canonical compiler boundary after RUE-720 and the
 completion boundary for RUE-627.
 

--- a/docs/notes/post-adr-0063-cold-compiler-architecture-audit.md
+++ b/docs/notes/post-adr-0063-cold-compiler-architecture-audit.md
@@ -1,0 +1,273 @@
+# Post-ADR-0063 cold compiler architecture audit
+
+Status: current implementation audit, 2026-08-10. This note records the
+implemented compiler architecture after ADR-0063 and the cold-performance work
+through RUE-1348. Current source and tests are authoritative; issue descriptions
+and the two pre-ADR completion audits are historical context only.
+
+## Decision status
+
+[ADR-0063](../designs/0063-parallel-demand-driven-incremental-compilation.md)
+remains the architectural authority. Its live decisions still match the source:
+
+- compilation is a revisioned graph of typed, memoized queries;
+- requests pin immutable input revisions;
+- stable semantic identities and immutable canonical artifacts cross query
+  boundaries;
+- one runtime owns query concurrency, joining, cycle detection, validation, and
+  retention;
+- CFG, optimization, code generation, and object projection are per function;
+- linking is deliberately fresh behind `ProgramImagePlan`.
+
+No implemented decision contradicts or replaces ADR-0063, so this audit does
+not create a new ADR. A new ADR would be appropriate for a changed decision,
+such as stateful incremental linking or a different terminal codegen boundary,
+not for updated Rust names or a more precise implementation map.
+
+## Authoritative cold path
+
+The one-shot entry point is a thin owner of a normal session:
+
+```text
+compile_snapshot()
+  -> CompilerSession::update_for_presentation()
+  -> CompilerSession::rooted_codegen()
+       -> rooted body graph
+       -> per-function Cfg / OptimizedCfg batch
+       -> per-function CodegenUnit batch
+       -> per-function ObjectProjection batch
+       -> publish exact backend root
+  -> ProgramImage::from_rooted()
+  -> ProgramImage::fresh_link()
+```
+
+The production call chain is in `crates/rue-compiler/src/queries.rs`,
+`crates/rue-compiler/src/session.rs`, and
+`crates/rue-compiler/src/program_image_plan.rs`. `compile_snapshot()` does not
+own a peer frontend or phase machine. Long-lived hosts use the same rooted
+session operations and compiler-issued continuation values.
+
+## Ownership and sharing
+
+| Owner | Mutable state | Shared with query workers | Lifetime |
+| --- | --- | --- | --- |
+| `CompilerSession` | host/discovery continuation, current presentation publication, diagnostics and measurement projection | no; the coordinator is used through `&mut self` | one-shot compile or retained host session |
+| `RevisionedQueryDatabase` | revision publication, input stores, family handles, retained semantic/backend roots | family handles and input stores point into the shared runtime | session |
+| `QueryRuntime` / `RuntimeCore` | immutable revision store, permit budget, wait graph, node registry, retention registry and metrics | yes, through one `Arc<RuntimeCore>` | database |
+| `QueryFamily<K, V>` | 32 sharded typed-key memo maps and one family retention queue | yes | database |
+| memo node | retained attempts, validation certificate, wait cell and exact monotonic incarnation | yes; one mutex protects one logical key's state | key incarnation |
+| query task | pinned revision, dependency/input observations, leases, validation proof scopes and nested-attempt ledger | child tasks receive or absorb explicit state; it is not a global mutable stack | one root or batch child |
+| query terminal | immutable value, stamp, exact revision, observations and stable node identity | yes, by `Arc` | bounded retention plus active roots/leases |
+| `ProgramImage` | ordered rooted object terminals, export thunks and link plan | no query mutation; it consumes already-published terminals | one final link |
+
+This is not a coarse “shared compiler behind locks.” The coordinator remains
+serial, while the data needed by independent compiler work lives in immutable
+revisions and per-key query nodes. Shared synchronization is concentrated in:
+
+- one execution-permit budget;
+- the cross-task wait graph used for cycle detection;
+- revision, node-incarnation and retention registries;
+- one sharded memo index per query family; and
+- one mutex per logical memo node.
+
+The maintained cold profiles do not currently show one of these locks as a
+dominant serialized region. They show diffuse hashing, allocation, comparison,
+validation and compiler-pass work. That is evidence to improve attribution and
+payload ownership before replacing the synchronization design.
+
+## Identity and invalidation
+
+Rue has three intentionally different identity domains:
+
+1. A `QueryKey`'s typed `Eq` and `Hash` select a memo node. The memo maps use
+   randomized hashing for caller-controlled keys; display text never decides
+   equality.
+2. Stable compiler identities such as module, definition, function instance and
+   type instance keys make semantic artifacts request-independent.
+3. `NodeIdentity::key` is deterministic presentation text for diagnostics and
+   cycle reports. A monotonic runtime incarnation distinguishes separate live
+   memo nodes even when presentation identity collides.
+
+Each request pins one immutable `Revision`. Query terminals record ordered
+input and dependency observations. On a compatible successor revision, the
+runtime recursively validates those observations. If dependencies remain green,
+the retained value is reused; if recomputation produces an equal value, its
+stamp is preserved. This is Rue's implemented red/green query algorithm, not a
+missing future tree feature.
+
+The runtime retains bounded attempts and revisions. Active computations,
+waiters, rooted request leases, published semantic/backend roots and retained
+pin sets protect the exact terminals they still need. Retention pressure grows
+and records an overflow rather than evicting a live proof cone.
+
+## Artifact movement
+
+The intended cross-query operation is sharing an immutable canonical value, not
+copying a request-local compiler arena.
+
+- Parsed modules, semantic projections, CFGs, codegen units and object
+  projections are immutable terminal values.
+- Stable canonical semantic bodies are materialized into fresh body-local AIR,
+  type, symbol and string domains inside CFG evaluation. That conversion is
+  intentional: compact local indices do not cross query boundaries.
+- RUE-1346 removed accidental deep copies of the same `CanonicalBody` between
+  the body transaction, canonical-body projection, analysis bundle and CFG
+  input. `CanonicalBody` is now deliberately non-`Clone`; all four boundaries
+  share one immutable allocation.
+- Object serialization is retained per function. The fresh-link adapter still
+  copies projected object bytes into the linker's owned-vector interface. That
+  is the explicit ADR-0063 fresh-link seam, not an accidental peer codegen path.
+
+RUE-1346 produced a neutral timing result under a same-host rerun: compiler
+medians moved within roughly plus or minus 1.5 percent. Deterministic query work
+was identical. Peak memory moved from 637.1 to 632.7 MiB for Harbor and from
+702.1 to 693.0 MiB for Lattice. The architectural result is stronger than the
+clock result: redundant work proportional to semantic-body payload size is no
+longer representable by the type.
+
+RUE-1348 then made display-only query identity movement explicit. The counters
+add two relaxed atomic increments only where a key string was already being
+formatted; they do not add formatting to memo hits or successful ordinary
+nested requests. Fresh and retained performance reports preserve the three
+causes separately rather than presenting one undifferentiated allocation total.
+
+## Comparison with other query compilers
+
+Rue's broad shape is conventional for a modern query compiler:
+
+- The [rustc query model](https://rustc-dev-guide.rust-lang.org/parallel-rustc.html)
+  requires immutable query results, claims one missing key, joins an in-progress
+  identical key and performs separate parallel cycle detection. Rue implements
+  the same claim/join/immutable-result pattern with explicit structured batches
+  and one permit budget.
+- [rustc incremental compilation](https://rustc-dev-guide.rust-lang.org/queries/incremental-compilation.html)
+  records the query DAG and uses red/green validation. Rue records ordered
+  observations and preserves stamps for equal recomputation for the same
+  reason.
+- [Salsa's runtime model](https://salsa-rs.github.io/salsa/plumbing/database_and_runtime.html)
+  separates shared data-at-rest from per-handle active query state. Rue makes a
+  similar separation between `RuntimeCore`/families and query tasks, but Rue's
+  immutable pinned revisions permit explicit overlapping request lifetimes
+  instead of exposing one mutable current revision to computations.
+- [Salsa memos](https://salsa-rs.github.io/salsa/plumbing/terminology/memo.html)
+  retain values, verification/change revisions and dependencies, and can drop
+  values under LRU while preserving dependency information. Rue's bounded
+  attempts, stamps, certificates and retention roots solve the corresponding
+  compiler-lifetime problem with a different concrete policy.
+- [rust-analyzer's architecture](https://rust-analyzer.github.io/book/contributing/architecture.html)
+  separates input state from lazy derived state, parses one file at a time, and
+  requires that typing inside one function not invalidate unrelated global
+  derived data. Rue now follows the same granularity principle while extending
+  the graph through native code generation and fresh linking.
+- The [Swift compiler request evaluator](https://download.swift.org/docs/assets/generics.pdf)
+  also decomposes type checking into on-demand cached requests, detects request
+  cycles, and records dependency information. Swift's cached requests must
+  replay their recorded required-name dependencies into an active caller;
+  Rue's reused terminals similarly preserve dependency observations rather
+  than treating a cached value alone as sufficient. Swift normally obtains
+  process-level parallelism from multiple frontend jobs, explicitly accepting
+  duplicated secondary-file work because those jobs share no cache. Rue instead
+  shares one in-process query database across workers, trading that duplication
+  for the measured runtime bookkeeping and synchronization described above.
+
+The comparison supports the current ownership split. It does not support
+adding a process-wide semantic arena or making `CompilerSession` itself the
+unit of parallel mutation.
+
+## Historical documents
+
+Two earlier notes remain useful records of the migrations they closed, but are
+not descriptions of the live compiler:
+
+- `canonical-query-completion-audit.md` records the pre-RUE-648 session. Its
+  statements that revisioned long-lived transactions, cancellation and
+  dependency-derived invalidation remain future work are historical.
+- `body-analysis-cfg-incrementality-audit.md` records the RUE-720 durable-import
+  implementation. Its fresh whole-program AIR epoch, durable body/CFG import
+  candidates and last-successful-baseline protocol were removed by the
+  ADR-0063 query-native cutover.
+
+Their still-valid invariants survived into ADR-0063: one compiler graph, stable
+request-independent artifacts, fail-closed validation, per-function semantic
+and CFG boundaries, and thin presentation consumers. Both notes carry an
+explicit historical banner pointing here.
+
+## Current performance findings
+
+After the cold fixes through RUE-1348, the largest maintained workload records
+160,776 validation traversals, 628,280 dependency observations, 570,840 memo
+hits and 57,440 misses for 155,488 source tokens. These counters expose real
+query bookkeeping, but the release profile no longer identifies one
+algorithmic cliff. Its leading residual samples are distributed across hashing,
+allocation/free, memory movement/comparison, body-local materialization, CFG
+optimization and code generation.
+
+The new display-identity counters do identify one concrete representation cost:
+
+| workload | memo nodes count/bytes | structured waits count/bytes | abort fallbacks count/bytes | total bytes/token |
+| --- | ---: | ---: | ---: | ---: |
+| Ruelex | 8,307 / 2,181,171 | 8,827 / 2,545,490 | 0 / 0 | 96.15 |
+| Mosaic | 18,330 / 5,698,363 | 30,979 / 10,414,280 | 0 / 0 | 202.88 |
+| Harbor | 32,299 / 15,479,840 | 70,671 / 28,402,213 | 0 / 0 | 382.38 |
+| Lattice | 38,380 / 9,494,659 | 89,895 / 33,777,606 | 0 / 0 | 278.30 |
+
+Lattice formats 43.3 MB of presentation-only key text. Structured batch waits
+account for 78 percent of those bytes and 70 percent of materializations. The
+current path formats every child key before scheduling so the global wait graph
+can retain a complete `NodeIdentity` for cycle rendering; a child which creates
+a memo node then formats the key again for that node's retained identity.
+Abort fallback contributes nothing on the maintained successful workloads.
+
+```text
+parent owns typed child key K
+  -> format K for StructuredWaitGuard
+       -> global wait graph retains NodeIdentity while the batch joins
+  -> schedule K in a child task
+       -> QueryFamily::node(K)
+            -> on a memo miss, format K again for the retained memo node
+```
+
+The typed key controls lookup in both cases. The duplicate text exists because
+cycle presentation and memo-node presentation acquire their labels through
+separate lifetime paths.
+
+The structured-wait formatting is also a serial prefix of each batch: the
+parent constructs every labeled edge before it releases work to child tasks.
+That placement makes it architecturally more interesting than an equal amount
+of perfectly parallel formatting under Amdahl's law. The counters establish
+volume and placement, not a promised speedup; RUE-1349 must still measure any
+replacement against the same workloads and one-/many-worker correctness tests.
+
+The measurement overhead is neutral in the clock data: compiler-root medians
+versus the immediately preceding same-host report moved -0.6, -0.6, +1.0 and
++0.7 percent from Ruelex through Lattice. The clock still does not isolate this
+bookkeeping reliably, while the counters prove its scale and source.
+
+## Next actions and decision boundary
+
+Authorized low-risk work:
+
+1. Keep the display-identity counters in cold and retained-session reports so
+   any representation change has an exact before/after witness.
+2. Continue removing accidental owned copies where an immutable terminal
+   already owns the payload.
+3. Clean stale comments and keep phase attribution exhaustive when profiles
+   expose unattributed work.
+
+Maintainer review required before implementation:
+
+1. Choose how structured waits represent cycle labels (RUE-1349). Viable
+   directions include compact task edges with lazy label recovery, sharing one
+   preformatted label between the wait edge and a newly created memo node, or
+   explicitly retaining the current eager representation. Any change must
+   preserve queued-child cycle detection, cancellation, deterministic path
+   ordering and label lifetime. This is a focused query-runtime representation
+   choice, not evidence for replacing the overall shared-runtime architecture.
+2. Add a retained `LoweredMir` terminal. ADR-0063 deliberately leaves that
+   query-granularity choice open pending a direct consumer or reuse result.
+3. Introduce stateful incremental linking. `ProgramImagePlanDelta` is the
+   prepared seam, but placement, patching, failure recovery and executable
+   publication require their own ADR and joint planning.
+
+The current evidence does not justify a new compiler-wide lock strategy, a
+whole-program semantic owner, or finer backend query fragmentation.


### PR DESCRIPTION
## Summary

- publish a current-source map of the implemented post-ADR-0063 cold compiler architecture: ownership, sharing, identity, invalidation, artifact movement, and the authoritative one-shot path
- compare Rue's query/runtime split with rustc, Salsa, rust-analyzer, and Swift's request evaluator
- mark the two pre-ADR completion audits as historical and remove a stale transitional RUE-1217 comment from the test-only codegen adapter
- incorporate the RUE-1346 immutable-body ownership result and RUE-1348 display-identity measurements

## Decision status

ADR-0063 still describes the decisions implemented by the current source. This change therefore does not create a replacement ADR merely to update Rust names or implementation detail.

The one newly measured representation choice is narrower: Lattice formats 43.3 MB of presentation-only query key text, 78% of it for eager structured batch-wait labels. RUE-1349 records the maintainer review needed before changing cycle-label ownership or lifetime. If that review changes ADR-0063's query-runtime decision, it can amend or supersede the ADR at that point.

## Verification

- every source claim was checked against current production call sites
- historical claims are classified explicitly rather than carried forward as live debt
- RUE-1348 four-workload release evidence is reproduced in the audit
- documentation links resolve within the repository; no compiler behavior changes

Fixes RUE-1347.

Refs RUE-1349.
