### PR TITLE
RUE-1349: lazily render structured wait identities

### DIFF
--- a/crates/rue-bench/src/scaling.rs
+++ b/crates/rue-bench/src/scaling.rs
@@ -401,7 +401,7 @@ fn render(report: &ScalingReport) -> String {
     }
 
     out.push_str("\n## Query display identities\n\n");
-    out.push_str("Counts and UTF-8 key bytes are exact for identities the compiler actually formatted. Shared family names are excluded. `bytes/token` exposes presentation-only bookkeeping growth independently of clock noise.\n\n");
+    out.push_str("Counts and UTF-8 key bytes are exact for identities the compiler actually formatted. Structured-wait values count only labels rendered for a detected wait cycle; registering an acyclic edge is free of display formatting. Shared family names are excluded. `bytes/token` exposes presentation-only bookkeeping growth independently of clock noise.\n\n");
     out.push_str("| workload | memo nodes count/bytes | structured waits count/bytes | abort fallbacks count/bytes | bytes/token |\n");
     out.push_str("| --- | ---: | ---: | ---: | ---: |\n");
     for observation in &report.workloads {

--- a/crates/rue-compiler/src/unstable.rs
+++ b/crates/rue-compiler/src/unstable.rs
@@ -1771,9 +1771,9 @@ pub struct QueryDisplayIdentityMetrics {
     pub memo_node_materializations: u64,
     /// New memo-node formatted key bytes.
     pub memo_node_bytes: u64,
-    /// Structured batch-wait identity count.
+    /// Structured batch identities materialized to render wait cycles.
     pub structured_wait_materializations: u64,
-    /// Structured batch-wait formatted key bytes.
+    /// Structured batch key bytes formatted to render wait cycles.
     pub structured_wait_bytes: u64,
     /// Abort-fallback identity count.
     pub abort_fallback_materializations: u64,

--- a/crates/rue-perf-schema/src/incremental.rs
+++ b/crates/rue-perf-schema/src/incremental.rs
@@ -14,7 +14,7 @@ use serde::{Deserialize, Serialize};
 use crate::{DisplayIdentityWork, EnvironmentFingerprint, median, median_absolute_deviation};
 
 /// Version of the retained-session raw report wire format.
-pub const EDIT_REPORT_SCHEMA_VERSION: u32 = 6;
+pub const EDIT_REPORT_SCHEMA_VERSION: u32 = 7;
 
 /// One retained-session edit class from ADR-0068's initial matrix.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
@@ -1619,9 +1619,9 @@ pub struct DisplayIdentityWorkSummary {
     pub memo_node_materializations: EndpointSummary,
     /// New memo-node formatted key bytes.
     pub memo_node_bytes: EndpointSummary,
-    /// Structured batch-wait identity count.
+    /// Structured batch identities materialized to render wait cycles.
     pub structured_wait_materializations: EndpointSummary,
-    /// Structured batch-wait formatted key bytes.
+    /// Structured batch key bytes formatted to render wait cycles.
     pub structured_wait_bytes: EndpointSummary,
     /// Abort-fallback identity count.
     pub abort_fallback_materializations: EndpointSummary,
@@ -1923,7 +1923,7 @@ pub fn render_edit_report_markdown(summary: &EditSummary) -> String {
         out.push('\n');
 
         out.push_str("## Query display identities\n\n");
-        out.push_str("Counts and UTF-8 key bytes are median ± MAD for identities the warm request actually formatted. Shared family names are excluded.\n\n");
+        out.push_str("Counts and UTF-8 key bytes are median ± MAD for identities the warm request actually formatted. Structured-wait values count only labels rendered for a detected wait cycle; registering an acyclic edge is free of display formatting. Shared family names are excluded.\n\n");
         out.push_str("| workload | scenario | workers | memo nodes count/bytes | structured waits count/bytes | abort fallbacks count/bytes |\n");
         out.push_str("| --- | --- | --- | ---: | ---: | ---: |\n");
         for row in &summary.rows {
@@ -1968,7 +1968,7 @@ mod tests {
 
     const MANIFEST: &str = r#"
 schema_version = 2
-report_schema_version = 6
+report_schema_version = 7
 fixture_revision = 3
 timing_samples_per_row = 5
 structural_samples_per_row = 1
@@ -2456,8 +2456,8 @@ minimum_memory_bytes = 15000000000
 
         let json = serde_json::to_string(&report(&manifest)).unwrap();
         let unknown = json.replacen(
-            "\"schema_version\":6",
-            "\"schema_version\":6,\"surprise\":true",
+            "\"schema_version\":7",
+            "\"schema_version\":7,\"surprise\":true",
             1,
         );
         assert!(

--- a/crates/rue-perf-schema/src/lib.rs
+++ b/crates/rue-perf-schema/src/lib.rs
@@ -86,9 +86,9 @@ pub struct DisplayIdentityWork {
     pub memo_node_materializations: u64,
     /// Formatted key bytes retained by new memo-node incarnations.
     pub memo_node_bytes: u64,
-    /// Identities created to label structured batch wait edges.
+    /// Structured batch identities materialized only to render wait cycles.
     pub structured_wait_materializations: u64,
-    /// Formatted key bytes used to label structured batch wait edges.
+    /// Formatted structured-batch key bytes used to render wait cycles.
     pub structured_wait_bytes: u64,
     /// Identities created lazily when nested requests abort.
     pub abort_fallback_materializations: u64,

--- a/crates/rue-perf-schema/src/scaling.rs
+++ b/crates/rue-perf-schema/src/scaling.rs
@@ -12,7 +12,7 @@ use serde::{Deserialize, Serialize};
 use crate::{DisplayIdentityWork, EnvironmentFingerprint, Sample, ValidationWork};
 
 /// Version of the scaling-report wire format.
-pub const SCALING_REPORT_SCHEMA_VERSION: u32 = 4;
+pub const SCALING_REPORT_SCHEMA_VERSION: u32 = 5;
 
 /// The lower-frequency scaling suite declaration.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]

--- a/crates/rue-query/src/lib.rs
+++ b/crates/rue-query/src/lib.rs
@@ -2972,9 +2972,9 @@ pub struct DisplayIdentityMetrics {
     pub memo_node_materializations: u64,
     /// Formatted key bytes retained by new memo-node incarnations.
     pub memo_node_bytes: u64,
-    /// Identities created to label structured batch wait edges.
+    /// Structured batch identities materialized only to render wait cycles.
     pub structured_wait_materializations: u64,
-    /// Formatted key bytes used to label structured batch wait edges.
+    /// Formatted structured-batch key bytes used to render wait cycles.
     pub structured_wait_bytes: u64,
     /// Identities created lazily when nested requests abort.
     pub abort_fallback_materializations: u64,
@@ -3297,7 +3297,11 @@ pub struct QueryRuntime {
 struct RuntimeCore {
     identity: u64,
     permits: PermitBudget,
-    wait_graph: Mutex<BTreeMap<TaskId, BTreeMap<TaskId, NodeIdentity>>>,
+    /// Active task-to-task waits. Ordinary joins reuse their memo node's
+    /// materialized identity. Structured edges retain only a shared batch table
+    /// plus an item index, formatting the typed key only if the edge participates
+    /// in a cycle which must be rendered.
+    wait_graph: Mutex<BTreeMap<TaskId, BTreeMap<TaskId, WaitEdgeLabel>>>,
     family_names: Mutex<BTreeSet<Arc<str>>>,
     revisions: RwLock<RevisionStore>,
     nodes: RwLock<NodeRegistry>,
@@ -6023,7 +6027,11 @@ where
         }
         if self
             .core
-            .begin_wait(task.id, owner, node.identity.clone())
+            .begin_wait(
+                task.id,
+                owner,
+                WaitEdgeLabel::Materialized(node.identity.clone()),
+            )
             .is_err()
         {
             // Waiting here would close a wait-graph loop. That loop says two
@@ -6879,16 +6887,79 @@ pub struct QueryContext {
     not_send_or_sync: PhantomData<Rc<()>>,
 }
 
-type BatchCompletion<K, V> = (usize, u64, K, Arc<Task>, TaskQueryResult<V>);
+struct RegisteredBatchItem<K> {
+    request_id: u64,
+    key: K,
+}
+
+struct RegisteredBatchItems<K> {
+    family: Arc<str>,
+    items: Vec<RegisteredBatchItem<K>>,
+}
+
+impl<K> fmt::Debug for RegisteredBatchItems<K> {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("RegisteredBatchItems")
+            .field("family", &self.family)
+            .field("items", &self.items.len())
+            .finish()
+    }
+}
+
+/// Type-erased view over the one typed key table already owned by a registered
+/// batch. Wait edges keep this table alive through cancellation and completed
+/// children without allocating or formatting one label per edge.
+trait StructuredWaitLabels: fmt::Debug + Send + Sync {
+    fn node_identity(&self, index: usize) -> NodeIdentity;
+}
+
+impl<K: QueryKey> StructuredWaitLabels for RegisteredBatchItems<K> {
+    fn node_identity(&self, index: usize) -> NodeIdentity {
+        let item = self
+            .items
+            .get(index)
+            .expect("a structured wait edge names one live batch item");
+        NodeIdentity {
+            family: self.family.clone(),
+            key: item.key.stable_identity().into(),
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+enum WaitEdgeLabel {
+    Materialized(NodeIdentity),
+    Structured {
+        labels: Arc<dyn StructuredWaitLabels>,
+        index: usize,
+    },
+}
+
+impl WaitEdgeLabel {
+    fn node_identity(&self, metrics: &Metrics) -> NodeIdentity {
+        match self {
+            Self::Materialized(node) => node.clone(),
+            Self::Structured { labels, index } => {
+                let node = labels.node_identity(*index);
+                metrics.record_structured_wait_identity(node.key().len());
+                node
+            }
+        }
+    }
+}
+
+type BatchCompletion<V> = (usize, Arc<Task>, TaskQueryResult<V>);
 
 fn run_registered_batch_worker<K, V>(
-    queue: Arc<Mutex<VecDeque<(usize, u64, K)>>>,
+    queue: Arc<Mutex<VecDeque<usize>>>,
+    items: Arc<RegisteredBatchItems<K>>,
     family: QueryFamily<K, V>,
     parent: Arc<Task>,
     authority: Arc<BatchValidationAuthority>,
     tracing_dispatch: tracing::Dispatch,
     tracing_parent: tracing::Span,
-) -> std::thread::Result<Vec<BatchCompletion<K, V>>>
+) -> std::thread::Result<Vec<BatchCompletion<V>>>
 where
     K: QueryKey,
     V: Clone + Send + Sync + 'static,
@@ -6898,15 +6969,17 @@ where
         let result = catch_unwind(AssertUnwindSafe(|| {
             let mut completed = Vec::new();
             loop {
-                let Some((index, request_id, key)) = lock(&queue).pop_front() else {
+                let Some(index) = lock(&queue).pop_front() else {
                     break;
                 };
-                let child = parent.batch_child(request_id, authority.clone());
-                let result = family.query_task_registered(child.clone(), key.clone(), request_id);
+                let item = &items.items[index];
+                let child = parent.batch_child(item.request_id, authority.clone());
+                let result =
+                    family.query_task_registered(child.clone(), item.key.clone(), item.request_id);
                 if matches!(result, TaskQueryResult::Terminal { .. }) {
                     authority.publish_child(&child);
                 }
-                completed.push((index, request_id, key, child, result));
+                completed.push((index, child, result));
             }
             completed
         }));
@@ -7131,6 +7204,11 @@ impl QueryContext {
     /// without repeating the same recursive validation. The authority is
     /// lexical and moves into the parent before this method returns; unrelated
     /// batches, requests, and revisions share no mutable proof state.
+    ///
+    /// The wait graph stores each child as a compact index into this batch's
+    /// typed key table. The table outlives every registered edge, including
+    /// queued and already-completed children, and produces a display identity
+    /// only if a scheduling cycle needs a diagnostic path.
     pub fn query_registered_batch<K, V>(
         &self,
         family: &QueryFamily<K, V>,
@@ -7147,40 +7225,35 @@ impl QueryContext {
         if !Arc::ptr_eq(&self.task_runtime(), &family.core) {
             return Err(QueryAbort::ForeignRuntime);
         }
-        let items = keys
-            .into_iter()
-            .enumerate()
-            .map(|(index, key)| {
-                let request_id = self.task.next_nested_request();
-                (index, request_id, key)
-            })
-            .collect::<Vec<_>>();
-        if items.is_empty() {
+        let items = Arc::new(RegisteredBatchItems {
+            family: family.inner.name.clone(),
+            items: keys
+                .into_iter()
+                .map(|key| RegisteredBatchItem {
+                    request_id: self.task.next_nested_request(),
+                    key,
+                })
+                .collect(),
+        });
+        if items.items.is_empty() {
             return Ok(Vec::new());
         }
 
+        let wait_labels: Arc<dyn StructuredWaitLabels> = items.clone();
         let structured_waits = StructuredWaitGuard::new(
             self.task.core.clone(),
             self.task.id,
-            items.iter().map(|(_, request_id, key)| {
-                let stable_key = key.stable_identity();
-                self.task
-                    .core
-                    .metrics
-                    .record_structured_wait_identity(stable_key.len());
-                (
-                    TaskId(*request_id),
-                    NodeIdentity {
-                        family: family.inner.name.clone(),
-                        key: stable_key.into(),
-                    },
-                )
-            }),
+            wait_labels,
+            items
+                .items
+                .iter()
+                .enumerate()
+                .map(|(index, item)| (TaskId(item.request_id), index)),
         )
         .map_err(QueryAbort::Cycle)?;
         let worker_claim =
-            BatchWorkerClaim::new(self.task.core.clone(), items.len().saturating_sub(1));
-        let queue = Arc::new(Mutex::new(VecDeque::from(items)));
+            BatchWorkerClaim::new(self.task.core.clone(), items.items.len().saturating_sub(1));
+        let queue = Arc::new(Mutex::new(VecDeque::from_iter(0..items.items.len())));
         let batch_authority = Arc::new(BatchValidationAuthority::new(
             self.task.core.clone(),
             self.task.batch_validation_authority.clone(),
@@ -7201,6 +7274,7 @@ impl QueryContext {
             let mut workers = Vec::with_capacity(worker_claim.count);
             for _ in 0..worker_claim.count {
                 let queue = queue.clone();
+                let items = items.clone();
                 let family = family.clone();
                 let parent = self.task.clone();
                 let authority = batch_authority.clone();
@@ -7213,6 +7287,7 @@ impl QueryContext {
                         .spawn_scoped(scope, move || {
                             run_registered_batch_worker(
                                 queue,
+                                items,
                                 family,
                                 parent,
                                 authority,
@@ -7225,6 +7300,7 @@ impl QueryContext {
             }
             let inline = run_registered_batch_worker(
                 queue.clone(),
+                items.clone(),
                 family.clone(),
                 self.task.clone(),
                 batch_authority.clone(),
@@ -7258,14 +7334,16 @@ impl QueryContext {
 
         completed.sort_unstable_by_key(|(index, ..)| *index);
         let mut terminals = Vec::with_capacity(completed.len());
-        for (_, request_id, key, child, result) in completed {
+        for (index, child, result) in completed {
+            let item = &items.items[index];
             self.task
                 .absorb_batch_child(&child, matches!(&result, TaskQueryResult::Terminal { .. }));
             match &result {
                 TaskQueryResult::Terminal { terminal, work, .. } => {
                     self.task.observe(terminal);
                     self.task.observe_work(work);
-                    self.task.cache_query(family.inner.token, &key, terminal);
+                    self.task
+                        .cache_query(family.inner.token, &item.key, terminal);
                 }
                 TaskQueryResult::Aborted {
                     dependencies,
@@ -7275,10 +7353,10 @@ impl QueryContext {
                 } => self.task.observe_abort_prefix(dependencies, inputs, work),
             }
             self.task.record_nested(
-                request_id,
-                move || NodeIdentity {
-                    family: family.inner.name.clone(),
-                    key: key.stable_identity().into(),
+                item.request_id,
+                || NodeIdentity {
+                    family: items.family.clone(),
+                    key: item.key.stable_identity().into(),
                 },
                 &result,
             );
@@ -7690,15 +7768,23 @@ impl StructuredWaitGuard {
     fn new(
         core: Arc<RuntimeCore>,
         parent: TaskId,
-        children: impl IntoIterator<Item = (TaskId, NodeIdentity)>,
+        labels: Arc<dyn StructuredWaitLabels>,
+        children: impl IntoIterator<Item = (TaskId, usize)>,
     ) -> Result<Self, Arc<[NodeIdentity]>> {
         let mut guard = Self {
             core,
             parent,
             children: Vec::new(),
         };
-        for (child, node) in children {
-            guard.core.begin_wait(parent, child, node)?;
+        for (child, index) in children {
+            guard.core.begin_wait(
+                parent,
+                child,
+                WaitEdgeLabel::Structured {
+                    labels: labels.clone(),
+                    index,
+                },
+            )?;
             guard.children.push(child);
         }
         Ok(guard)
@@ -9764,10 +9850,10 @@ impl RuntimeCore {
         &self,
         waiter: TaskId,
         owner: TaskId,
-        node: NodeIdentity,
+        label: WaitEdgeLabel,
     ) -> Result<(), Arc<[NodeIdentity]>> {
         let mut graph = lock(&self.wait_graph);
-        let previous = graph.entry(waiter).or_default().insert(owner, node.clone());
+        let previous = graph.entry(waiter).or_default().insert(owner, label);
         assert!(
             previous.is_none(),
             "one task cannot register the same wait owner twice"
@@ -9775,13 +9861,20 @@ impl RuntimeCore {
         let mut path = Vec::new();
         let mut visited = BTreeSet::new();
         if wait_path(&graph, owner, waiter, &mut visited, &mut path) {
-            path.push(node);
             let edges = graph.get_mut(&waiter).expect("new wait edge is present");
-            edges.remove(&owner);
+            path.push(
+                edges
+                    .remove(&owner)
+                    .expect("the newly inserted wait edge is present"),
+            );
             if edges.is_empty() {
                 graph.remove(&waiter);
             }
-            return Err(canonical_cycle(path));
+            drop(graph);
+            return Err(canonical_cycle(
+                path.into_iter()
+                    .map(|label| label.node_identity(&self.metrics)),
+            ));
         }
         Ok(())
     }
@@ -9799,11 +9892,11 @@ impl RuntimeCore {
 }
 
 fn wait_path(
-    graph: &BTreeMap<TaskId, BTreeMap<TaskId, NodeIdentity>>,
+    graph: &BTreeMap<TaskId, BTreeMap<TaskId, WaitEdgeLabel>>,
     current: TaskId,
     target: TaskId,
     visited: &mut BTreeSet<TaskId>,
-    path: &mut Vec<NodeIdentity>,
+    path: &mut Vec<WaitEdgeLabel>,
 ) -> bool {
     if !visited.insert(current) {
         return false;
@@ -9811,8 +9904,8 @@ fn wait_path(
     let Some(edges) = graph.get(&current) else {
         return false;
     };
-    for (owner, node) in edges {
-        path.push(node.clone());
+    for (owner, label) in edges {
+        path.push(label.clone());
         if *owner == target || wait_path(graph, *owner, target, visited, path) {
             return true;
         }
@@ -10021,7 +10114,7 @@ mod tests {
     }
 
     #[test]
-    fn display_identity_metrics_attribute_each_materialization_source() {
+    fn display_identity_metrics_attribute_only_materialized_sources() {
         let runtime = QueryRuntime::new(1);
         publish_empty(&runtime, [revision(1)]);
 
@@ -10064,11 +10157,85 @@ mod tests {
             DisplayIdentityMetrics {
                 memo_node_materializations: 4,
                 memo_node_bytes: 7,
-                structured_wait_materializations: 2,
-                structured_wait_bytes: 5,
+                structured_wait_materializations: 0,
+                structured_wait_bytes: 0,
                 abort_fallback_materializations: 1,
                 abort_fallback_bytes: 4,
             }
+        );
+    }
+
+    #[test]
+    fn structured_wait_labels_remain_lazy_and_live_until_cycle_rendering() {
+        let runtime = QueryRuntime::new(1);
+        let items = Arc::new(RegisteredBatchItems {
+            family: Arc::from("lazy-structured"),
+            items: vec![RegisteredBatchItem {
+                request_id: 2,
+                key: Key("child"),
+            }],
+        });
+        let weak_items = Arc::downgrade(&items);
+        let labels: Arc<dyn StructuredWaitLabels> = items.clone();
+        let guard = StructuredWaitGuard::new(
+            runtime.core.clone(),
+            TaskId(1),
+            labels.clone(),
+            [(TaskId(2), 0)],
+        )
+        .expect("an acyclic structured edge is registered");
+
+        assert_eq!(
+            runtime
+                .metrics()
+                .display_identities
+                .structured_wait_materializations,
+            0,
+            "registering an ordinary structured wait never formats its key"
+        );
+        drop(items);
+        drop(labels);
+        assert!(
+            weak_items.upgrade().is_some(),
+            "the live wait edge retains its batch label table"
+        );
+
+        let cycle = runtime
+            .core
+            .begin_wait(
+                TaskId(2),
+                TaskId(1),
+                WaitEdgeLabel::Materialized(NodeIdentity {
+                    family: Arc::from("ordinary"),
+                    key: Arc::from("root"),
+                }),
+            )
+            .expect_err("the reverse wait closes a cycle");
+        assert_eq!(
+            cycle
+                .iter()
+                .map(|node| (node.family(), node.key()))
+                .collect::<Vec<_>>(),
+            vec![("lazy-structured", "child"), ("ordinary", "root")],
+            "lazy rendering preserves the exact canonical cycle text"
+        );
+        assert_eq!(
+            runtime.metrics().display_identities,
+            DisplayIdentityMetrics {
+                structured_wait_materializations: 1,
+                structured_wait_bytes: 5,
+                ..DisplayIdentityMetrics::default()
+            }
+        );
+
+        drop(guard);
+        assert!(
+            lock(&runtime.core.wait_graph).is_empty(),
+            "dropping the batch removes its label table with the wait edge"
+        );
+        assert!(
+            weak_items.upgrade().is_none(),
+            "removing the last wait edge releases its batch label table"
         );
     }
 

--- a/docs/notes/post-adr-0063-cold-compiler-architecture-audit.md
+++ b/docs/notes/post-adr-0063-cold-compiler-architecture-audit.md
@@ -211,32 +211,59 @@ The new display-identity counters do identify one concrete representation cost:
 | Harbor | 32,299 / 15,479,840 | 70,671 / 28,402,213 | 0 / 0 | 382.38 |
 | Lattice | 38,380 / 9,494,659 | 89,895 / 33,777,606 | 0 / 0 | 278.30 |
 
-Lattice formats 43.3 MB of presentation-only key text. Structured batch waits
-account for 78 percent of those bytes and 70 percent of materializations. The
-current path formats every child key before scheduling so the global wait graph
-can retain a complete `NodeIdentity` for cycle rendering; a child which creates
-a memo node then formats the key again for that node's retained identity.
-Abort fallback contributes nothing on the maintained successful workloads.
+This was the pre-RUE-1349 baseline. Lattice formatted 43.3 MB of
+presentation-only key text. Structured batch waits accounted for 78 percent of
+those bytes and 70 percent of materializations. The old path formatted every
+child key before scheduling so the global wait graph could retain a complete
+`NodeIdentity` for cycle rendering; a child which created a memo node then
+formatted the key again for that node's retained identity. Abort fallback
+contributed nothing on the maintained successful workloads.
 
 ```text
-parent owns typed child key K
-  -> format K for StructuredWaitGuard
-       -> global wait graph retains NodeIdentity while the batch joins
-  -> schedule K in a child task
-       -> QueryFamily::node(K)
-            -> on a memo miss, format K again for the retained memo node
+before RUE-1349
+  parent owns typed child key K
+    -> format K for StructuredWaitGuard
+         -> global wait graph retains NodeIdentity while the batch joins
+    -> schedule K in a child task
+         -> QueryFamily::node(K)
+              -> on a memo miss, format K again for the retained memo node
+
+after RUE-1349
+  batch owns one typed table [K0, K1, ...]
+    -> wait graph retains (shared table, item index)
+    -> only a rendered wait cycle formats K[index]
+    -> memo misses retain their independently owned NodeIdentity as before
 ```
 
 The typed key controls lookup in both cases. The duplicate text exists because
 cycle presentation and memo-node presentation acquire their labels through
 separate lifetime paths.
 
-The structured-wait formatting is also a serial prefix of each batch: the
-parent constructs every labeled edge before it releases work to child tasks.
-That placement makes it architecturally more interesting than an equal amount
-of perfectly parallel formatting under Amdahl's law. The counters establish
-volume and placement, not a promised speedup; RUE-1349 must still measure any
-replacement against the same workloads and one-/many-worker correctness tests.
+The structured-wait formatting was also a serial prefix of each batch: the
+parent constructed every labeled edge before it released work to child tasks.
+RUE-1349 removed that prefix with one batch-owned typed key table. Detection
+continues to use ordered task edges; cycle presentation resolves only the
+selected path after releasing the global wait-graph mutex. The complete
+ownership and failure analysis is in
+[`structured-wait-label-ownership.md`](structured-wait-label-ownership.md).
+
+The same-host fresh-process comparison used the immediately preceding trunk
+revision as its baseline and repeated the changed build after the first Harbor
+timing pass was noisy:
+
+| workload | structured wait identities/bytes before → after | total identity bytes/token before → after | compiler ms before → after |
+| --- | ---: | ---: | ---: |
+| Ruelex | 8,827 / 2,545,490 → 0 / 0 | 96.15 → 44.37 | 293.38 → 284.62 |
+| Mosaic | 30,979 / 10,414,280 → 0 / 0 | 202.88 → 71.75 | 809.73 → 809.45 |
+| Harbor | 70,671 / 28,402,213 → 0 / 0 | 382.38 → 134.89 | 1,937.37 → 1,929.82 |
+| Lattice | 89,895 / 33,777,606 → 0 / 0 | 278.30 → 61.06 | 2,142.29 → 2,122.68 |
+
+All other deterministic query-work counters were unchanged. Peak RSS moved
+-0.1, -0.7, +0.5 and +4.3 MiB, so this experiment establishes no consistent
+memory result. Compiler medians were neutral to slightly lower, but three
+fresh processes with uncontrolled page-cache state do not justify a clock-time
+speedup claim. The structural result is exact: successful maintained workloads
+perform none of the previous 2.5–33.8 MB of structured-wait formatting.
 
 The measurement overhead is neutral in the clock data: compiler-root medians
 versus the immediately preceding same-host report moved -0.6, -0.6, +1.0 and
@@ -256,16 +283,9 @@ Authorized low-risk work:
 
 Maintainer review required before implementation:
 
-1. Choose how structured waits represent cycle labels (RUE-1349). Viable
-   directions include compact task edges with lazy label recovery, sharing one
-   preformatted label between the wait edge and a newly created memo node, or
-   explicitly retaining the current eager representation. Any change must
-   preserve queued-child cycle detection, cancellation, deterministic path
-   ordering and label lifetime. This is a focused query-runtime representation
-   choice, not evidence for replacing the overall shared-runtime architecture.
-2. Add a retained `LoweredMir` terminal. ADR-0063 deliberately leaves that
+1. Add a retained `LoweredMir` terminal. ADR-0063 deliberately leaves that
    query-granularity choice open pending a direct consumer or reuse result.
-3. Introduce stateful incremental linking. `ProgramImagePlanDelta` is the
+2. Introduce stateful incremental linking. `ProgramImagePlanDelta` is the
    prepared seam, but placement, patching, failure recovery and executable
    publication require their own ADR and joint planning.
 

--- a/docs/notes/structured-wait-label-ownership.md
+++ b/docs/notes/structured-wait-label-ownership.md
@@ -1,0 +1,132 @@
+# Structured wait-label ownership
+
+Status: current implementation audit for RUE-1349. ADR-0063 remains the
+architectural authority.
+
+## Why this boundary exists
+
+ADR-0063 requires task-local dependency stacks, a cross-task wait graph,
+deterministic cycle reporting, cancellation, and progress with one execution
+permit. It does not require the wait graph to store presentation strings.
+RUE-1348 showed that the previous representation formatted every registered
+batch key before scheduling, even though successful builds never rendered a
+wait-graph cycle.
+
+The typed `K: QueryKey` remains the lookup authority. `stable_identity()` is a
+presentation operation and may collide; it must not participate in cycle
+detection or memo equality.
+
+## Ownership and lifetime
+
+| owner | state | lifetime |
+| --- | --- | --- |
+| `QueryContext::query_registered_batch` | one `Arc<RegisteredBatchItems<K>>` containing the family name, request ids, and typed keys | the complete batch call |
+| worker queue | compact item indexes | until workers claim every item |
+| child task | one request id and a cloned typed key for evaluation | that child evaluation |
+| `RuntimeCore::wait_graph` | waiter task id → owner task id plus `WaitEdgeLabel` | from structured guard installation or join parking until its guard/wait ends |
+| structured `WaitEdgeLabel` | shared batch-table `Arc` plus item index | exactly the corresponding wait edge |
+| ordinary join `WaitEdgeLabel` | the memo node's already materialized `NodeIdentity` | exactly the corresponding wait edge |
+
+The wait graph therefore keeps a structured label recoverable even when its
+child is still queued or has already completed. It does not keep a second key
+copy or a formatted string per edge.
+
+```text
+registered batch owns [K0, K1, ...]
+  ├─ worker queue owns [0, 1, ...]
+  └─ wait graph owns (shared batch table, index)
+       └─ only on a detected cycle: stable_identity(K[index])
+```
+
+## Selected representation
+
+Cycle detection and cycle presentation are separate:
+
+1. `RuntimeCore` detects paths using only ordered `TaskId` edges.
+2. An ordinary join edge reuses its memo node's existing display identity.
+3. A structured edge stores an item index into the batch's shared typed table.
+4. If inserting an edge closes a cycle, the runtime removes that tentative
+   edge, releases the wait-graph mutex, and only then resolves the selected
+   path's labels.
+5. `canonical_cycle` still sorts and deduplicates the resulting
+   `NodeIdentity` values, preserving the published diagnostic order and text.
+
+Resolving after releasing the mutex keeps user-defined display formatting out
+of the global critical section. Successful and contended-but-acyclic waits do
+not invoke `stable_identity()` through this path.
+
+## Alternatives considered
+
+### Retain eager `NodeIdentity` edges
+
+This preserved behavior but kept the measured serial formatting prefix and a
+separate string allocation for every structured child. It was rejected because
+the strings are not needed for detection and successful builds render no wait
+cycles.
+
+### Share one eagerly formatted identity with a future memo node
+
+This could remove duplicate formatting on memo misses, but a scheduled child
+does not necessarily create a node and the family memo store, not the batch,
+owns node publication. It would couple scheduling to memo allocation and still
+format every key before work begins.
+
+### Store one type-erased key allocation per edge
+
+This makes formatting lazy but adds an allocation and key clone per child. The
+selected batch table already owns every typed key, so one shared table plus an
+index is smaller and has a simpler lifetime.
+
+## Progress, cancellation, and failure behavior
+
+- All parent→child edges are installed before scheduling, as before. A queued
+  child has no outgoing edge until it runs, but its label is already recoverable.
+- The parent still donates its execution permit for the complete join interval.
+  Worker selection, task ancestry, and one-/many-worker behavior are unchanged.
+- True query dependency cycles still come from `Task::stack_cycle`; the wait
+  graph continues to classify a cross-task scheduling loop as a declined join
+  or a structured cycle at the same insertion points.
+- `StructuredWaitGuard` removes every installed edge on success, cancellation,
+  abort, or unwind. Removing the final edge releases the graph's last batch-table
+  reference.
+- A failed edge insertion removes its tentative edge before formatting. A panic
+  in presentation therefore cannot leave a false wait dependency installed.
+
+## Falsifiable evidence
+
+The query-runtime tests require:
+
+- successful batches to report zero structured-wait identity materializations;
+- a cycle to recover exact canonical family/key text after the producer's
+  external batch-table references have been dropped;
+- dropping the structured guard to leave the wait graph empty;
+- registered parent cycles to terminate with one and many execution permits.
+
+The `structured_wait_materializations` and `structured_wait_bytes` counters now
+measure only identities actually formatted to render a structured wait cycle.
+The fresh-process scaling workloads are successful, so both counters should be
+exactly zero. A nonzero value is evidence that a cycle path was rendered, not
+that an edge was merely registered.
+
+The four-workload same-host report confirmed that invariant twice per workload
+with fixed one-worker structural probes:
+
+| workload | materializations before → after | formatted bytes before → after |
+| --- | ---: | ---: |
+| Ruelex | 8,827 → 0 | 2,545,490 → 0 |
+| Mosaic | 30,979 → 0 | 10,414,280 → 0 |
+| Harbor | 70,671 → 0 | 28,402,213 → 0 |
+| Lattice | 89,895 → 0 | 33,777,606 → 0 |
+
+All non-display deterministic query counters were identical before and after.
+A repeated timing pass moved compiler-root medians from 293.38, 809.73,
+1,937.37 and 2,142.29 ms to 284.62, 809.45, 1,929.82 and 2,122.68 ms. These
+are neutral-to-slightly-lower observations, not a speedup claim: each median has
+only three fresh processes and the operating-system page cache is uncontrolled.
+Peak RSS moved -0.1, -0.7, +0.5 and +4.3 MiB, which is likewise neutral.
+
+## ADR classification
+
+This is a representation refinement within ADR-0063's required wait graph. It
+does not change query identity, cycle semantics, the execution budget, task
+ownership, or artifact publication, so no replacement ADR is required.

--- a/docs/process/compiler-scaling.md
+++ b/docs/process/compiler-scaling.md
@@ -33,7 +33,8 @@ compilations. The report records:
 - the compiler's additive, mutually exclusive phase accounting;
 - query validation, endorsement, lease, demand, and retention-scan work;
 - display-only query identities materialized for memo nodes, structured batch
-  wait edges, and abort fallbacks, with exact counts and formatted key bytes;
+  cycle rendering, and abort fallbacks, with exact counts and formatted key
+  bytes;
 - output binary size.
 
 The Markdown work table includes validation nodes per token. That ratio is a
@@ -42,9 +43,11 @@ into many repeated validation visits merely because elapsed time still looks
 plausible on one host.
 
 The display-identity table similarly reports formatted key bytes per token.
-These identities label diagnostics and wait-graph edges; typed query keys, not
-the display strings, remain authoritative for memo lookup. Family names are
-shared and therefore excluded from the byte totals.
+Memo-node identities and abort fallbacks label diagnostics. Structured-wait
+identities are materialized only when a detected wait cycle must be rendered;
+registering an acyclic edge formats no key text. Typed query keys, not display
+strings, remain authoritative for memo lookup. Family names are shared and
+therefore excluded from the byte totals.
 
 The compiled examples are never executed. Runtime tests and heavyweight
 example scenarios remain in their existing suites, so a slow example runtime

--- a/performance/incremental.toml
+++ b/performance/incremental.toml
@@ -5,7 +5,7 @@
 # Fixture edits are added under a new `fixture_revision`; raw report syntax
 # advances independently under `report_schema_version`.
 schema_version = 2
-report_schema_version = 6
+report_schema_version = 7
 fixture_revision = 2
 # Two workloads each collect seven one-sample structural rows and one five-
 # sample latency row: 24 independent retained sessions in the scheduled matrix.


### PR DESCRIPTION
Fixes RUE-1349.

## What changed

- Store structured batch wait edges as a shared typed key table plus compact item indexes.
- Materialize stable display identities only after a wait cycle is detected and after releasing the global wait-graph lock.
- Preserve exact deterministic cycle diagnostics, cancellation cleanup, and one-/many-worker progress behavior.
- Version and document the refined performance-counter contract, and record the ownership/lifetime architecture.

## Why

Successful cold compiles never render wait cycles, but the previous representation eagerly formatted every structured batch key before scheduling its children. On the four scaling workloads this created 8,827 to 89,895 strings and 2.55 MB to 33.78 MB of key text per compile.

The new representation reduces those structured-wait counts and bytes to zero on every workload. Other deterministic query counters are unchanged. Same-host compiler timings and peak RSS are neutral within measurement noise, so this PR claims the exact bookkeeping reduction rather than a wall-time speedup.

ADR-0063 already defines the wait-graph and cycle behavior without prescribing eager presentation strings. The current representation and lifetime proof are recorded in a focused architecture note; no replacement ADR is needed.

## Validation

- scripts/rue fmt
- scripts/rue quick
- ./buck2 test //crates/rue-query:rue-query-test (150/150)
- fresh-process Ruelex, Mosaic, Harbor, and Lattice baseline/changed scaling reports, including a repeated changed timing pass
