### PR TITLE
guard: a cleanup error is not a refusal above the hard floor

### DIFF
--- a/scripts/rue-storage
+++ b/scripts/rue-storage
@@ -282,9 +282,12 @@ guard_low_disk() {
     before="$(describe_free)" || return 1
 
     echo "warning: host filesystem has ${before} free; running Rue's host-wide adaptive cleanup before building" >&2
+    # A cleanup error is not by itself fatal: with sibling worktrees mid-build,
+    # their busy Buck daemons legitimately refuse `clean`, which is the same
+    # contention RUE-1331's middle band exists for. The hard floor below still
+    # makes the refusal decision; only measurement failures stay fail-closed.
     if ! stale_all clean 1w; then
-        echo "error: host-wide cleanup failed under disk pressure; build stopped before risking ENOSPC" >&2
-        return 1
+        echo "warning: host-wide cleanup could not run to completion (a sibling worktree's Buck daemon may be busy); deciding on the hard floor instead" >&2
     fi
 
     pressure="$(emergency_pressure)" || return 1

--- a/scripts/test-cleanup-scripts.sh
+++ b/scripts/test-cleanup-scripts.sh
@@ -355,6 +355,77 @@ EOF
   rm -rf "$sb"
 }
 
+test_storage_guard_survives_cleanup_failure_between_floors() {
+  # RUE-1331 follow-up: sibling worktrees mid-build make their Buck daemons
+  # refuse `clean`. A cleanup ERROR must not be fatal in the middle band —
+  # the hard floor decides. Observed live: three cycle-5 workers building
+  # blocked the coordinator's build through this exact path.
+  local sb rc=0; sb="$(make_sandbox rue-storage)"
+  setup_storage_root "$sb/root-1"
+  cat >"$sb/buck2" <<'EOF'
+#!/usr/bin/env bash
+printf '%s:%s\n' "$PWD" "$*" >>"$CALLS"
+exit 1
+EOF
+  chmod +x "$sb/buck2"
+  cat >"$sb/fakebin/git" <<EOF
+#!/usr/bin/env bash
+if [[ "\$*" == *"worktree list --porcelain"* ]]; then
+  printf 'worktree %s/root-1\n' "$sb"
+  exit 0
+fi
+exit 1
+EOF
+  chmod +x "$sb/fakebin/git"
+  # 15 GiB free of 200 GiB: middle band, constant across probes.
+  cat >"$sb/fakebin/df" <<'EOF'
+#!/usr/bin/env bash
+printf 'Filesystem 1024-blocks Used Available Capacity Mounted on\n'
+printf 'disk 209715200 193986560 15728640 93%% /\n'
+EOF
+  chmod +x "$sb/fakebin/df"
+  run_script "$sb" rue-storage guard || rc=$?
+  check "storage: cleanup failure between floors still proceeds" \
+    "$([ "$rc" -eq 0 ] && echo 0 || echo 1)"
+  grep -q 'deciding on the hard floor instead' "$sb/out.log" || \
+    fail "storage: expected the cleanup-failure demotion notice"
+  rm -rf "$sb"
+}
+
+test_storage_guard_still_refuses_below_hard_floor_when_cleanup_fails() {
+  # The safety property survives the demotion: a cleanup error below the hard
+  # floor is still a refusal.
+  local sb rc=0; sb="$(make_sandbox rue-storage)"
+  setup_storage_root "$sb/root-1"
+  cat >"$sb/buck2" <<'EOF'
+#!/usr/bin/env bash
+printf '%s:%s\n' "$PWD" "$*" >>"$CALLS"
+exit 1
+EOF
+  chmod +x "$sb/buck2"
+  cat >"$sb/fakebin/git" <<EOF
+#!/usr/bin/env bash
+if [[ "\$*" == *"worktree list --porcelain"* ]]; then
+  printf 'worktree %s/root-1\n' "$sb"
+  exit 0
+fi
+exit 1
+EOF
+  chmod +x "$sb/fakebin/git"
+  cat >"$sb/fakebin/df" <<'EOF'
+#!/usr/bin/env bash
+printf 'Filesystem 1024-blocks Used Available Capacity Mounted on\n'
+printf 'disk 100000 95000 5000 95%% /\n'
+EOF
+  chmod +x "$sb/fakebin/df"
+  run_script "$sb" rue-storage guard || rc=$?
+  check "storage: cleanup failure below the hard floor still refuses" \
+    "$([ "$rc" -ne 0 ] && echo 0 || echo 1)"
+  grep -q 'hard floor; build stopped before risking ENOSPC' "$sb/out.log" || \
+    fail "storage: expected the hard-floor refusal notice"
+  rm -rf "$sb"
+}
+
 test_storage_reset_validates_all_targets_first() {
   local sb rc=0; sb="$(make_sandbox rue-storage)"
   setup_storage_root "$sb/root-1"
@@ -388,6 +459,8 @@ test_storage_plans_every_registered_root
 test_storage_guard_is_host_wide_only_under_pressure
 test_storage_guard_blocks_when_pressure_remains_critical
 test_storage_guard_proceeds_between_cleanup_and_hard_floors
+test_storage_guard_survives_cleanup_failure_between_floors
+test_storage_guard_still_refuses_below_hard_floor_when_cleanup_fails
 test_storage_reset_validates_all_targets_first
 
 echo "--------------------------------------------------"


### PR DESCRIPTION
Follow-up to #2211, found live the first time three workers built in parallel after the two-tier guard landed: with sibling Buck daemons busy (or the coordinator's own daemon timing out on connect), `stale_all clean` errors — and that error path pre-empted the hard-floor decision, reintroducing exactly the chronic starvation RUE-1331 fixed, one branch earlier.

Cleanup failure now demotes to a warning ("deciding on the hard floor instead") and the hard floor makes the refusal decision. Safety properties preserved:
- measurement failures (can't read `df`) remain fail-closed
- a cleanup error **below** the 4 GiB hard floor still refuses

Two new sandbox tests pin both directions; `scripts/test-cleanup-scripts.sh` passes 25/25. Verified live on this host: the guard now proceeds at 13.7 GiB free with three busy sibling worktrees, where it hard-refused an hour ago.

Refs RUE-1331

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GPYyXZHFGimCvkbzMtBG2U

---
_Generated by [Claude Code](https://claude.ai/code/session_01GPYyXZHFGimCvkbzMtBG2U)_