### PR TITLE
Floats phases 2–3: lexer comptime_float token, parser + untyped RIR node (ADR-0065)

### DIFF
--- a/crates/rue-air/src/inference/generate.rs
+++ b/crates/rue-air/src/inference/generate.rs
@@ -1159,6 +1159,17 @@ impl<'a> ConstraintGenerator<'a> {
                 InferType::Var(var)
             }
 
+            // Float literals have no inference rule yet (ADR-0065 Phase 4,
+            // RUE-1069): there is no `f32`/`f64` tag in the packed `Type` and
+            // no `comptime_float` for the unifier to bind. Reporting `!` keeps
+            // the solver quiet — `!` coerces to anything, so a float operand
+            // neither constrains its neighbours nor leaves an unsolved
+            // variable behind — and lets the AIR-emission pass be the single
+            // place that reports the literal (as the preview gate, or as
+            // E1109). Replace this with the real `comptime_float` rule in
+            // Phase 4.
+            InstData::FloatConst { .. } => InferType::Concrete(Type::NEVER),
+
             InstData::BoolConst(_) => InferType::Concrete(Type::BOOL),
 
             // String literals are context-sensitive. A fresh variable lets an

--- a/crates/rue-air/src/sema/analysis/instructions.rs
+++ b/crates/rue-air/src/sema/analysis/instructions.rs
@@ -100,6 +100,29 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
             | InstData::StringConst { .. }
             | InstData::UnitConst => self.analyze_literal(air, inst_ref, ctx),
 
+            // Float literals stop here (ADR-0065, RUE-1069). Phases 2 and 3
+            // give `1.5` a token, an AST node, and an untyped RIR node; the
+            // phase that would give it a *type* — `f32`/`f64` tags in the
+            // packed `Type`, `comptime_float`, and context coercion — is
+            // Phase 4 and does not exist yet. Rejecting the node here keeps a
+            // gated float literal a clean diagnostic instead of an
+            // unresolved-type ICE further down. Ordered gate-first so the
+            // program without `--preview floats` gets the standard
+            // gated-feature error (spec 8.4:1), and only an opted-in program
+            // sees the phase marker. Delete this arm when Phase 4 types the
+            // node.
+            InstData::FloatConst { .. } => {
+                self.require_preview(
+                    rue_error::PreviewFeature::Floats,
+                    "a floating-point literal",
+                    inst.span,
+                )?;
+                Err(CompileError::new(
+                    ErrorKind::FloatNotYetImplemented,
+                    inst.span,
+                ))
+            }
+
             // Binary arithmetic operations (Add also covers String + String
             // concatenation — see analyze_add).
             InstData::Add { lhs, rhs } => {

--- a/crates/rue-air/src/sema/comptime_eval.rs
+++ b/crates/rue-air/src/sema/comptime_eval.rs
@@ -610,6 +610,22 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
                 Ok(Some(ConstValue::Integer(v)))
             }
 
+            // Float literals stop here for the same reason they stop in
+            // `analyze_inst_dispatch` (ADR-0065, RUE-1069): there is no
+            // `comptime_float` value in `ConstValue` yet. Naming the real
+            // reason matters more here than elsewhere — falling through to
+            // the generic "not knowable at compile time" would be actively
+            // wrong about a literal, which is the most compile-time-knowable
+            // thing there is. Delete this arm when Phase 4 lands.
+            InstData::FloatConst { .. } => {
+                self.require_preview(
+                    rue_error::PreviewFeature::Floats,
+                    "a floating-point literal",
+                    span,
+                )?;
+                Err(CompileError::new(ErrorKind::FloatNotYetImplemented, span))
+            }
+
             // Boolean literals
             InstData::BoolConst(value) => Ok(Some(ConstValue::Bool(*value))),
 

--- a/crates/rue-air/src/sema/consistency_tests.rs
+++ b/crates/rue-air/src/sema/consistency_tests.rs
@@ -20,6 +20,12 @@ mod tests {
     const ALL_INSTDATA_VARIANTS: &[&str] = &[
         // Constants
         "IntConst",
+        // `FloatConst` is handled by both passes as a *rejection* until
+        // ADR-0065 Phase 4 types it: constraint generation reports `!` and AIR
+        // emission reports the preview gate or E1109. Listing it here keeps
+        // that pairing enforced — if Phase 4 gives it a real inference rule and
+        // forgets the emission side (or vice versa), this test fails.
+        "FloatConst",
         "BoolConst",
         "StringConst",
         "UnitConst",

--- a/crates/rue-cli-tests/cases/float_literals.toml
+++ b/crates/rue-cli-tests/cases/float_literals.toml
@@ -1,0 +1,257 @@
+[section]
+id = "cli.float_literals"
+name = "Float literal grammar and the floats preview gate"
+description = """
+ADR-0065 Phases 2-3 (RUE-1068, RUE-1069): the lexer produces a float literal
+token, the parser and RIR carry it untyped, and the whole feature sits behind
+`--preview floats`. Nothing types the literal yet (that is Phase 4), so both
+directions of the gate are diagnostics: E1100 without the flag, E1109 with it.
+These cases pin BOTH directions and the spelling rules, because a gate that
+only ever fails one way is half a gate.
+"""
+
+# ---------------------------------------------------------------------------
+# The gate, both directions (spec 8.4:1: a gated feature must error without
+# its flag).
+# ---------------------------------------------------------------------------
+
+[[case]]
+name = "float_literal_without_preview_is_gated"
+description = "Without --preview floats a float literal is the standard gated-feature error."
+files = [{ path = "main.rue", source = """
+fn main() -> i32 {
+    let x = 1.5;
+    0
+}
+""" }]
+args = ["main.rue", "-o", "prog"]
+compile_fail = true
+error_contains = [
+    "E1100",
+    "a floating-point literal requires preview feature `floats`",
+    "use --preview floats to enable this feature (ADR-0065)",
+]
+
+[[case]]
+name = "float_literal_with_preview_reaches_the_phase_marker"
+description = "With the flag the gate passes and the literal stops at the not-yet-implemented marker (E1109), not an ICE."
+files = [{ path = "main.rue", source = """
+fn main() -> i32 {
+    let x = 1.5;
+    0
+}
+""" }]
+args = ["--preview", "floats", "main.rue", "-o", "prog"]
+compile_fail = true
+error_contains = [
+    "E1109",
+    "floating-point literals are not yet supported at this compilation phase",
+    "ADR-0065 Phase 4",
+]
+compile_stderr_not_contains = ["internal compiler error", "E1100"]
+
+[[case]]
+name = "float_in_an_operand_position_is_gated_not_ignored"
+description = "A float literal inside a larger expression is diagnosed at the literal, and only once."
+files = [{ path = "main.rue", source = """
+fn main() -> i32 {
+    let n: i32 = 3;
+    let y = 1.5e-3 + n;
+    0
+}
+""" }]
+args = ["--preview", "floats", "main.rue", "-o", "prog"]
+compile_fail = true
+error_contains = ["E1109"]
+compile_stderr_not_contains = ["internal compiler error"]
+
+[[case]]
+name = "float_diagnostic_is_one_clean_json_diagnostic"
+description = "The gated literal is a single, well-formed diagnostic at the literal's own span — not a cascade."
+files = [{ path = "main.rue", source = """
+fn main() -> i32 {
+    let x = 6.022e23;
+    0
+}
+""" }]
+args = ["--error-format", "json", "--preview", "floats", "main.rue", "-o", "prog"]
+compile_fail = true
+error_contains = ["E1109"]
+json_diagnostics = true
+json_diagnostic_order = ["error E1109 main.rue:2:13"]
+
+# ---------------------------------------------------------------------------
+# The literal reaches RIR untyped (Phase 3's actual deliverable).
+# ---------------------------------------------------------------------------
+
+[[case]]
+name = "float_literal_reaches_rir_untyped"
+description = "The parser and RIR carry the literal as an untyped float constant holding its exact text."
+files = [{ path = "main.rue", source = """
+fn main() -> i32 {
+    let a = 1.5;
+    let b = 1e9;
+    let c = 6.022e23;
+    let d = 1_000.000_1;
+    0
+}
+""" }]
+args = ["--preview", "floats", "--emit", "rir", "main.rue"]
+compile_only = true
+compile_stdout_contains = [
+    "const float 1.5",
+    "const float 1e9",
+    "const float 6.022e23",
+    "const float 1000.0001",
+]
+
+[[case]]
+name = "integer_literals_are_not_float_literals"
+description = "`1e9` is a float; the integer 1000000000 stays an integer constant. The two are distinguishable in RIR."
+files = [{ path = "main.rue", source = """
+fn main() -> i32 {
+    let a = 1000000000;
+    0
+}
+""" }]
+args = ["--emit", "rir", "main.rue"]
+compile_only = true
+compile_stdout_contains = ["const 1000000000"]
+compile_stdout_not_contains = ["const float"]
+
+[[case]]
+name = "float_literal_survives_module_merge"
+description = """
+The literal's text is a symbol, so merging an imported module into the
+program-wide RIR must translate it into the merged interner. A stale symbol
+would resolve to some other module's string; here the RIR dump proves the
+literal still reads back as itself after the merge, and the diagnostic still
+points into the module that wrote it.
+"""
+files = [
+    { path = "main.rue", source = """
+fn main() -> i32 {
+    let h = @import("helper");
+    h.scale()
+}
+""" },
+    { path = "helper.rue", source = """
+pub fn scale() -> i32 {
+    let factor = 6.022e23;
+    0
+}
+""" },
+]
+args = ["--preview", "floats", "--emit", "rir", "main.rue"]
+compile_only = true
+compile_stdout_contains = ["const float 6.022e23"]
+
+[[case]]
+name = "float_literal_in_an_imported_module_is_still_gated"
+description = "The gate follows the literal across the module boundary and reports in the module that wrote it."
+files = [
+    { path = "main.rue", source = """
+fn main() -> i32 {
+    let h = @import("helper");
+    h.scale()
+}
+""" },
+    { path = "helper.rue", source = """
+pub fn scale() -> i32 {
+    let factor = 6.022e23;
+    0
+}
+""" },
+]
+args = ["main.rue", "-o", "prog"]
+compile_fail = true
+error_contains = ["E1100", "helper.rue", "requires preview feature `floats`"]
+
+# ---------------------------------------------------------------------------
+# Spelling rules (ADR-0065 §3). These are lexical/grammatical, so they fire
+# with or without the preview flag.
+# ---------------------------------------------------------------------------
+
+[[case]]
+name = "leading_dot_float_is_rejected"
+description = "`.5` is rejected with a spelling diagnostic that names `0.5` (lexer, E0011)."
+files = [{ path = "main.rue", source = """
+fn main() -> i32 {
+    let x = .5;
+    0
+}
+""" }]
+args = ["--preview", "floats", "main.rue", "-o", "prog"]
+compile_fail = true
+error_contains = [
+    "E0011",
+    "floating-point literal cannot start with `.`: write `0.5` instead of `.5`",
+]
+
+[[case]]
+name = "trailing_dot_float_is_rejected"
+description = "`5.` is rejected with a spelling diagnostic that names `5.0` (parser, same E0011)."
+files = [{ path = "main.rue", source = """
+fn main() -> i32 {
+    let x = 5.;
+    0
+}
+""" }]
+args = ["--preview", "floats", "main.rue", "-o", "prog"]
+compile_fail = true
+error_contains = [
+    "E0011",
+    "floating-point literal cannot end with `.`: write `5.0` instead of `5.`",
+]
+
+[[case]]
+name = "empty_exponent_is_rejected"
+description = "An exponent marker with no digits is a spelling error, not an integer followed by an identifier."
+files = [{ path = "main.rue", source = """
+fn main() -> i32 {
+    let x = 1e;
+    0
+}
+""" }]
+args = ["--preview", "floats", "main.rue", "-o", "prog"]
+compile_fail = true
+error_contains = [
+    "E0011",
+    "missing digits in the exponent of floating-point literal `1e`",
+]
+
+# ---------------------------------------------------------------------------
+# Regression guards: the float rules must not disturb the existing lexemes.
+# ---------------------------------------------------------------------------
+
+[[case]]
+name = "member_access_on_an_integer_literal_still_lexes"
+description = "`42.to_string()` is a method call, not a trailing-dot float: the diagnostic is the ordinary method-resolution one."
+files = [{ path = "main.rue", source = """
+fn main() -> i32 {
+    let s = 42.to_string();
+    0
+}
+""" }]
+args = ["main.rue", "-o", "prog"]
+compile_fail = true
+error_contains = ["E0413", "no method named 'to_string'"]
+compile_stderr_not_contains = ["E0011", "E1100", "E1109"]
+
+[[case]]
+name = "based_and_separated_integer_literals_are_unaffected"
+description = "Hex/octal/binary literals and `_` separators keep working: the exponent rule never reaches `0x1e9`."
+files = [{ path = "main.rue", source = """
+fn main() -> i32 {
+    let a: i32 = 0x1e9;
+    let b: i32 = 0b101;
+    let c: i32 = 1_000;
+    @dbg(a);
+    @dbg(b);
+    @dbg(c);
+    0
+}
+""" }]
+args = ["main.rue", "-o", "prog"]
+stdout = "489\n5\n1000\n"
+exit_code = 0

--- a/crates/rue-compiler/src/artifact_views.rs
+++ b/crates/rue-compiler/src/artifact_views.rs
@@ -212,6 +212,7 @@ impl TokenView {
             Type => "TYPE(type)",
             Underscore => "UNDERSCORE",
             Int(_) => "INT",
+            Float(_) => "FLOAT",
             String(_) => "STRING",
             Ident(_) => "IDENT",
             Plus => "PLUS",
@@ -266,7 +267,9 @@ impl TokenView {
 
     pub fn value(&self) -> Option<Cow<'_, str>> {
         match self.token().kind {
-            rue_lexer::TokenKind::Ident(symbol) | rue_lexer::TokenKind::String(symbol) => {
+            rue_lexer::TokenKind::Ident(symbol)
+            | rue_lexer::TokenKind::String(symbol)
+            | rue_lexer::TokenKind::Float(symbol) => {
                 Some(Cow::Borrowed(self.owner.resolve_raw_symbol(symbol)))
             }
             rue_lexer::TokenKind::Int(value) => Some(Cow::Owned(value.to_string())),
@@ -1526,6 +1529,13 @@ fn expr_record(
             Some(literal.value.to_string().into()),
             Vec::new(),
         ),
+        Expr::Float(literal) => syntax_record(
+            "float_literal",
+            span,
+            None,
+            Some(owner.resolve_raw_symbol(literal.value).to_string().into()),
+            Vec::new(),
+        ),
         Expr::String(literal) => syntax_record(
             "string_literal",
             span,
@@ -2012,6 +2022,7 @@ fn rir_kind(data: &rue_rir::InstData) -> &'static str {
     use rue_rir::InstData::*;
     match data {
         IntConst(_) => "integer_constant",
+        FloatConst { .. } => "float_constant",
         BoolConst(_) => "boolean_constant",
         StringConst { .. } => "string_constant",
         UnitConst => "unit_constant",
@@ -2230,6 +2241,7 @@ fn rir_operands(rir: &rue_rir::Rir, data: &rue_rir::InstData) -> Vec<RirOperandR
             }
         }
         IntConst(_)
+        | FloatConst { .. }
         | BoolConst(_)
         | StringConst { .. }
         | UnitConst

--- a/crates/rue-compiler/src/parsed_modules.rs
+++ b/crates/rue-compiler/src/parsed_modules.rs
@@ -1817,6 +1817,7 @@ fn walk_expr(
 ) -> CompileResult<()> {
     match expr {
         Expr::Int(_)
+        | Expr::Float(_)
         | Expr::String(_)
         | Expr::Bool(_)
         | Expr::Unit(_)

--- a/crates/rue-compiler/src/retained_charge.rs
+++ b/crates/rue-compiler/src/retained_charge.rs
@@ -141,6 +141,7 @@ fn expr_charge(expr: &ast::Expr) -> u64 {
     use ast::Expr;
     match expr {
         Expr::Int(_)
+        | Expr::Float(_)
         | Expr::String(_)
         | Expr::Bool(_)
         | Expr::Unit(_)
@@ -1307,6 +1308,7 @@ impl RetainedCharge for rue_error::ErrorKind {
         use rue_error::ErrorKind as E;
         match self {
             E::MalformedByteLiteral(value)
+            | E::MalformedFloatLiteral(value)
             | E::ParseError(value)
             | E::UndefinedVariable(value)
             | E::UndefinedFunction(value)
@@ -1582,6 +1584,7 @@ impl RetainedCharge for rue_error::ErrorKind {
             | E::ExternVariadicUnsupported
             | E::ForeignEntryPointDeclaration
             | E::SliceNotYetImplemented
+            | E::FloatNotYetImplemented
             | E::SliceReturnNotAllowed
             | E::SliceInAggregateField
             | E::SliceEscapesScope => 0,

--- a/crates/rue-compiler/src/revisioned_query_database.rs
+++ b/crates/rue-compiler/src/revisioned_query_database.rs
@@ -4327,6 +4327,7 @@ impl<'a> WarningStaticCallCollector<'a> {
         use rue_parser::ast::{Expr, IntrinsicArg, LetPattern, Pattern};
         match expr {
             Expr::Int(_)
+            | Expr::Float(_)
             | Expr::String(_)
             | Expr::Bool(_)
             | Expr::Unit(_)

--- a/crates/rue-error/src/lib.rs
+++ b/crates/rue-error/src/lib.rs
@@ -95,6 +95,12 @@ impl ErrorCode {
     /// The per-file lexer diagnostic budget was exceeded. The detailed
     /// diagnostics before this summary remain available.
     pub const LEXER_DIAGNOSTICS_OMITTED: Self = Self(10);
+    /// A floating-point literal written with a leading dot (`.5`) or a
+    /// trailing dot (`5.`); ADR-0065 §3 requires `0.5` / `5.0`. Sits in the
+    /// lexical band even though the trailing-dot form is diagnosed by the
+    /// parser — see [`ErrorKind::MalformedFloatLiteral`] for why that half
+    /// cannot be decided from the lexeme alone. (RUE-1068)
+    pub const MALFORMED_FLOAT_LITERAL: Self = Self(11);
 
     // ========================================================================
     // Parser errors (E0100-E0199)
@@ -481,6 +487,11 @@ impl ErrorCode {
     /// beside the other `extern "C"` rules, and is the import-side mirror of
     /// E1106's rejection of a `pub extern "C" fn` export named `main`.
     pub const FOREIGN_ENTRY_POINT_DECLARATION: Self = Self(1108);
+    /// A float literal was used with `--preview floats` enabled, but the
+    /// typing phases of ADR-0065 (Phase 4 onward) are not implemented yet.
+    /// Sits in the preview band beside E1100 because it is the second half of
+    /// the same gate: E1100 fires without the flag, E1109 with it. (RUE-1069)
+    pub const FLOAT_NOT_YET_IMPLEMENTED: Self = Self(1109);
 
     // ========================================================================
     // Comptime errors (E1200-E1299)
@@ -668,6 +679,14 @@ pub enum PreviewFeature {
     /// of a projection of the receiver. Gated until mutable accessors and std
     /// adoption complete the rollout (RUE-1015).
     BorrowAccessors,
+    /// Floating point: `f32`/`f64`, IEEE-754 arithmetic, and `comptime_float`
+    /// literals (ADR-0065, RUE-714). Gated until every phase of the M9 rollout
+    /// — types and inference, both backends, the dtoa runtime — is complete
+    /// (ADR-0065 Phase 10). The lexer and parser accept a float literal only
+    /// with this flag; the phases that would give it a type do not exist yet,
+    /// so an enabled float literal still stops at
+    /// [`ErrorKind::FloatNotYetImplemented`].
+    Floats,
 }
 
 /// Error returned when parsing a preview feature name fails.
@@ -691,6 +710,7 @@ impl PreviewFeature {
             PreviewFeature::Slices => "slices",
             PreviewFeature::CFfi => "c_ffi",
             PreviewFeature::BorrowAccessors => "borrow_accessors",
+            PreviewFeature::Floats => "floats",
         }
     }
 
@@ -702,6 +722,7 @@ impl PreviewFeature {
             PreviewFeature::Slices => "ADR-0043",
             PreviewFeature::CFfi => "ADR-0064",
             PreviewFeature::BorrowAccessors => "ADR-0062",
+            PreviewFeature::Floats => "ADR-0065",
         }
     }
 
@@ -712,6 +733,7 @@ impl PreviewFeature {
             PreviewFeature::Slices,
             PreviewFeature::CFfi,
             PreviewFeature::BorrowAccessors,
+            PreviewFeature::Floats,
         ]
     }
 
@@ -738,6 +760,7 @@ impl std::str::FromStr for PreviewFeature {
             "slices" => Ok(PreviewFeature::Slices),
             "c_ffi" => Ok(PreviewFeature::CFfi),
             "borrow_accessors" => Ok(PreviewFeature::BorrowAccessors),
+            "floats" => Ok(PreviewFeature::Floats),
             _ => Err(ParsePreviewFeatureError(s.to_string())),
         }
     }
@@ -1230,6 +1253,19 @@ pub enum ErrorKind {
     /// single ASCII byte (RUE-1042).
     #[error("{0}")]
     MalformedByteLiteral(String),
+    /// A malformed floating-point literal: a leading dot (`.5`) or a trailing
+    /// dot (`5.`). ADR-0065 §3 rejects both spellings for readability — write
+    /// `0.5` and `5.0`. Carries a specific, already-rendered reason.
+    ///
+    /// The leading-dot form is a lexical decision (`.` immediately followed by
+    /// a digit can never start any other Rue lexeme), so the lexer reports it.
+    /// The trailing-dot form is not decidable from the lexeme alone: `42.` is
+    /// the prefix of the legal method call `42.to_string()`, so the *parser*
+    /// reports it once the token after the `.` proves no member name follows.
+    /// Both share this kind — and E0011 — because both diagnose the same
+    /// numeric-literal spelling rule.
+    #[error("{0}")]
+    MalformedFloatLiteral(String),
     /// Summary emitted after lexing reaches its per-file diagnostic budget.
     /// `limit` is the number of detailed diagnostics retained.
     #[error("additional lexer diagnostics omitted after the first {limit} errors")]
@@ -1941,6 +1977,20 @@ pub enum ErrorKind {
     #[error("slice types are not yet fully implemented (ADR-0043 Phase 1, RUE-322)")]
     SliceNotYetImplemented,
 
+    /// A float literal was written with `--preview floats` enabled, but the
+    /// phases that give it a type do not exist yet (ADR-0065 Phase 4+,
+    /// RUE-714). Phases 2 and 3 land the literal token, the parser node, and
+    /// the untyped RIR node; semantic analysis has no `f32`/`f64` tag and no
+    /// `comptime_float` to coerce it with, so the literal is rejected here
+    /// with a clean diagnostic rather than reaching an unfinished typing path.
+    /// Modelled on [`ErrorKind::SliceNotYetImplemented`], the same
+    /// gate-is-on-but-phase-is-missing marker for ADR-0043.
+    #[error(
+        "floating-point literals are not yet supported at this compilation phase \
+         (ADR-0065 Phase 4, RUE-714)"
+    )]
+    FloatNotYetImplemented,
+
     /// A slice type `[T]` appeared in return position — forbidden because a
     /// slice is second-class (ADR-0037, ADR-0043, RUE-322).
     #[error(
@@ -2035,6 +2085,7 @@ impl ErrorKind {
             ErrorKind::UppercaseBasePrefix(_) => ErrorCode::UPPERCASE_BASE_PREFIX,
             ErrorKind::EmptyBasedLiteral { .. } => ErrorCode::EMPTY_BASED_LITERAL,
             ErrorKind::MalformedByteLiteral(_) => ErrorCode::MALFORMED_BYTE_LITERAL,
+            ErrorKind::MalformedFloatLiteral(_) => ErrorCode::MALFORMED_FLOAT_LITERAL,
             ErrorKind::InvalidDigitForBase { .. } => ErrorCode::INVALID_DIGIT_FOR_BASE,
             ErrorKind::LexerDiagnosticsOmitted { .. } => ErrorCode::LEXER_DIAGNOSTICS_OMITTED,
 
@@ -2220,6 +2271,7 @@ impl ErrorKind {
             ErrorKind::ForeignEntryPointDeclaration => ErrorCode::FOREIGN_ENTRY_POINT_DECLARATION,
             ErrorKind::ReprCStructIneligible(_) => ErrorCode::REPR_C_STRUCT_INELIGIBLE,
             ErrorKind::SliceNotYetImplemented => ErrorCode::SLICE_NOT_YET_IMPLEMENTED,
+            ErrorKind::FloatNotYetImplemented => ErrorCode::FLOAT_NOT_YET_IMPLEMENTED,
             ErrorKind::SliceReturnNotAllowed => ErrorCode::SLICE_RETURN_NOT_ALLOWED,
             ErrorKind::SliceInAggregateField => ErrorCode::SLICE_IN_AGGREGATE_FIELD,
             ErrorKind::SliceEscapesScope => ErrorCode::SLICE_ESCAPES_SCOPE,
@@ -3057,7 +3109,43 @@ mod tests {
     #[test]
     fn test_preview_feature_all_names() {
         let names = PreviewFeature::all_names();
-        assert_eq!(names, "test_infra, slices, c_ffi, borrow_accessors");
+        assert_eq!(names, "test_infra, slices, c_ffi, borrow_accessors, floats");
+    }
+
+    #[test]
+    fn test_preview_feature_floats() {
+        // ADR-0065 (RUE-714): the floating-point preview feature, gating the
+        // literal grammar in Phases 2-3 and everything M9 adds after it.
+        let feature: PreviewFeature = "floats".parse().unwrap();
+        assert_eq!(feature, PreviewFeature::Floats);
+        assert_eq!(feature.name(), "floats");
+        assert_eq!(feature.adr(), "ADR-0065");
+        assert!(PreviewFeature::all().contains(&PreviewFeature::Floats));
+    }
+
+    #[test]
+    fn test_float_literal_error_codes() {
+        // The two halves of the float gate: E1100 without `--preview floats`
+        // (the shared preview-gate kind), E1109 with it, plus the E0011
+        // spelling rule from ADR-0065 §3.
+        assert_eq!(
+            ErrorKind::FloatNotYetImplemented.code(),
+            ErrorCode::FLOAT_NOT_YET_IMPLEMENTED
+        );
+        assert_eq!(ErrorCode::FLOAT_NOT_YET_IMPLEMENTED.to_string(), "E1109");
+        assert_eq!(
+            ErrorKind::MalformedFloatLiteral("boom".to_string()).code(),
+            ErrorCode::MALFORMED_FLOAT_LITERAL
+        );
+        assert_eq!(ErrorCode::MALFORMED_FLOAT_LITERAL.to_string(), "E0011");
+        assert_eq!(
+            ErrorKind::PreviewFeatureRequired {
+                feature: PreviewFeature::Floats,
+                what: "a floating-point literal".to_string(),
+            }
+            .code(),
+            ErrorCode::PREVIEW_FEATURE_REQUIRED
+        );
     }
 
     #[test]

--- a/crates/rue-frontend-diff/src/main.rs
+++ b/crates/rue-frontend-diff/src/main.rs
@@ -404,6 +404,7 @@ impl Shapes<'_> {
     fn expr(&self, expr: &Expr) -> String {
         match expr {
             Expr::Int(_) => leaf("int"),
+            Expr::Float(_) => leaf("float"),
             Expr::String(_) => leaf("string"),
             Expr::Bool(v) => node(
                 "bool",

--- a/crates/rue-lexer/src/lib.rs
+++ b/crates/rue-lexer/src/lib.rs
@@ -92,6 +92,15 @@ pub enum TokenKind {
 
     // Literals
     Int(u64),
+    /// A floating-point literal (`1.5`, `1e9`, `1.5e-3`), carried as the
+    /// interned *source text* of the literal rather than a decoded `f64`
+    /// (ADR-0065 §3, RUE-1068). A float literal is a `comptime_float`: an
+    /// arbitrary-precision abstract constant that only becomes `f32` or `f64`
+    /// when context demands one. Decoding to `f64` here would round the
+    /// constant before its target width is known, so the exact digits travel
+    /// to the phase that knows the type. Separators are already stripped, so
+    /// the interned text is directly parseable by `str::parse`.
+    Float(Spur),
     String(Spur),
 
     // Identifiers
@@ -203,6 +212,7 @@ impl TokenKind {
             TokenKind::Type => "type 'type'",
             TokenKind::Underscore => "'_'",
             TokenKind::Int(_) => "integer",
+            TokenKind::Float(_) => "float",
             TokenKind::String(_) => "string",
             TokenKind::Ident(_) => "identifier",
             TokenKind::Plus => "'+'",
@@ -320,6 +330,7 @@ impl std::fmt::Display for TokenKind {
             TokenKind::Type => write!(f, "TYPE(type)"),
             TokenKind::Underscore => write!(f, "UNDERSCORE"),
             TokenKind::Int(v) => write!(f, "INT({})", v),
+            TokenKind::Float(s) => write!(f, "FLOAT(sym:{})", s.into_usize()),
             TokenKind::String(s) => write!(f, "STRING(sym:{})", s.into_usize()),
             TokenKind::Ident(s) => write!(f, "IDENT(sym:{})", s.into_usize()),
             TokenKind::Plus => write!(f, "PLUS"),

--- a/crates/rue-lexer/src/logos_lexer.rs
+++ b/crates/rue-lexer/src/logos_lexer.rs
@@ -82,6 +82,12 @@ pub enum LexError {
     /// A malformed byte literal (`b'ab'`, `b''`, `b'\q'`, non-ASCII `b'é'`, or
     /// an unterminated `b'a`). Carries an already-rendered reason. (RUE-1042)
     MalformedByteLiteral(String),
+    /// A float literal spelling the lexer can reject on its own: a leading dot
+    /// (`.5`) or an exponent marker with no digits (`1e`, `1e+`). Carries an
+    /// already-rendered reason. The trailing-dot form (`5.`) is *not* here —
+    /// `42.` is the legal prefix of `42.to_string()`, so only the parser can
+    /// tell the two apart (ADR-0065 §3, RUE-1068).
+    MalformedFloatLiteral(String),
 }
 
 /// Process a string literal starting from an opening quote.
@@ -283,6 +289,62 @@ fn parse_based_literal(lex: &mut logos::Lexer<'_, LogosTokenKind>) -> Result<u64
         return Err(LexError::EmptyBasedLiteral { base });
     }
     Ok(value)
+}
+
+/// Callback for the float literal rules on [`LogosTokenKind::Float`]
+/// (ADR-0065 §3, RUE-1068).
+///
+/// A float literal is a digit run followed by a `.` fraction, an exponent, or
+/// both: `1.5`, `1e9`, `1.5e-3`, `6.022e23`. There are no suffixes — the
+/// literal is a `comptime_float` and takes its width from context — so the
+/// only work here is interning the literal's text with `_` separators removed,
+/// leaving a string `str::parse::<f32>()`/`<f64>()` accepts verbatim once the
+/// target width is known. Nothing is rounded at this phase: a
+/// `comptime_float` is arbitrary precision (ADR-0025), and decoding to `f64`
+/// here would round `1.0000000000000000001` before anyone knew whether the
+/// destination was `f32`, `f64`, or a compile error.
+///
+/// The interner can be exhausted like any other interning site (spec C.5:1).
+fn intern_float_literal(lex: &mut logos::Lexer<'_, LogosTokenKind>) -> Result<Spur, LexError> {
+    let slice = lex.slice();
+    // Fast path: most literals have no separators, so avoid the copy.
+    if slice.contains('_') {
+        let digits: String = slice.chars().filter(|c| *c != '_').collect();
+        lex.extras
+            .try_get_or_intern(&digits)
+            .map_err(|_| LexError::InternerExhausted)
+    } else {
+        lex.extras
+            .try_get_or_intern(slice)
+            .map_err(|_| LexError::InternerExhausted)
+    }
+}
+
+/// Callback for the leading-dot float rule: `.5` is rejected, write `0.5`
+/// (ADR-0065 §3).
+///
+/// This is safe to decide lexically because `.` immediately followed by a
+/// digit cannot begin any other Rue lexeme: member access takes an identifier
+/// (`p.x`), Rue has no tuple-index syntax, and there is no range operator.
+fn reject_leading_dot_float(lex: &mut logos::Lexer<'_, LogosTokenKind>) -> Result<Spur, LexError> {
+    Err(LexError::MalformedFloatLiteral(format!(
+        "floating-point literal cannot start with `.`: write `0{}` instead of `{}`",
+        lex.slice(),
+        lex.slice()
+    )))
+}
+
+/// Callback for the empty-exponent rule: `1e`, `1e+` have no exponent digits.
+///
+/// Matching this as one token (rather than letting `1e` split into `1` and the
+/// identifier `e`) is safe for the same reason the based-literal rule swallows
+/// its alphanumeric tail: no grammar production allows an integer literal to
+/// abut an identifier character, so this can never reject a valid program.
+fn reject_empty_exponent(lex: &mut logos::Lexer<'_, LogosTokenKind>) -> Result<Spur, LexError> {
+    Err(LexError::MalformedFloatLiteral(format!(
+        "missing digits in the exponent of floating-point literal `{}`",
+        lex.slice()
+    )))
 }
 
 /// Callback for byte literals `b'a'` (RUE-1042), triggered on the `b'` prefix.
@@ -524,6 +586,37 @@ pub enum LogosTokenKind {
     #[token("b'", process_byte_literal)]
     Int(u64),
 
+    // Float literals (ADR-0065 §3, RUE-1068): a digit run followed by a `.`
+    // fraction, an exponent, or both — `1.5`, `1e9`, `1.5e-3`, `6.022e23` —
+    // with `_` separators legal inside any digit run. There are no `f32`/`f64`
+    // suffixes; a literal is a `comptime_float` and takes its width from
+    // context in a later phase.
+    //
+    // Disambiguation against the existing tokens is by logos' longest match:
+    //   - `1.5`  -> Float, not `Int(1) Dot Int(5)`, because the float rule
+    //     matches three characters where the `Int` rule matches one.
+    //   - `42.to_string()` -> `Int(42) Dot Ident`, because the fraction rule
+    //     requires a *digit* after the `.`, so nothing longer than `42`
+    //     matches. This is why the trailing-dot rejection (`5.`) lives in the
+    //     parser: the lexer cannot commit to it without breaking method calls
+    //     on integer literals.
+    //   - `0x1e9` -> the based-literal rule, which the exponent rule cannot
+    //     reach (its digit run stops at `x`).
+    // The exponent marker accepts `e` and `E`. That is not a departure from
+    // the lowercase-only *base prefix* rule (`0x`, RUE-177): case-insensitivity
+    // inside a numeric body already holds for hex digits (`0xff` == `0xFF`),
+    // and `E` selects nothing, so there is no `0X`-style ambiguity to reject.
+    #[regex(
+        r"[0-9][0-9_]*\.[0-9][0-9_]*([eE][+-]?[0-9][0-9_]*)?",
+        intern_float_literal
+    )]
+    #[regex(r"[0-9][0-9_]*[eE][+-]?[0-9][0-9_]*", intern_float_literal)]
+    // `.5` is rejected: write `0.5` (ADR-0065 §3).
+    #[regex(r"\.[0-9][0-9_]*([eE][+-]?[0-9][0-9_]*)?", reject_leading_dot_float)]
+    // `1e`, `1e-` have an exponent marker but no exponent digits.
+    #[regex(r"[0-9][0-9_]*(\.[0-9][0-9_]*)?[eE][+-]?", reject_empty_exponent)]
+    Float(Spur),
+
     // String literals - match opening quote and process content manually
     // This allows detection of unterminated strings
     #[token("\"", process_string_from_quote)]
@@ -696,6 +789,7 @@ impl From<LogosTokenKind> for TokenKind {
             LogosTokenKind::Type => TokenKind::Type,
             LogosTokenKind::Underscore => TokenKind::Underscore,
             LogosTokenKind::Int(n) => TokenKind::Int(n),
+            LogosTokenKind::Float(s) => TokenKind::Float(s),
             LogosTokenKind::String(s) => TokenKind::String(s),
             LogosTokenKind::Ident(s) => TokenKind::Ident(s),
             LogosTokenKind::EqEq => TokenKind::EqEq,
@@ -913,6 +1007,14 @@ impl<'a> LogosLexer<'a> {
                                 ),
                                 LexError::MalformedByteLiteral(message) => (
                                     ErrorKind::MalformedByteLiteral(message),
+                                    Span::with_file(
+                                        self.file_id,
+                                        span_offset(span.start),
+                                        span_offset(span.end),
+                                    ),
+                                ),
+                                LexError::MalformedFloatLiteral(message) => (
+                                    ErrorKind::MalformedFloatLiteral(message),
                                     Span::with_file(
                                         self.file_id,
                                         span_offset(span.start),
@@ -1994,6 +2096,119 @@ mod tests {
         assert!(matches!(kinds[1], TokenKind::LtLt));
         assert!(matches!(kinds[3], TokenKind::LtEq));
         assert!(matches!(kinds[5], TokenKind::EqEq));
+    }
+
+    /// Resolve every float literal in `source` to its interned text, so the
+    /// float tests read as "these characters lexed to this literal".
+    fn float_texts(source: &str) -> Vec<String> {
+        let (tokens, interner) = LogosLexer::new(source)
+            .tokenize()
+            .unwrap_or_else(|error| panic!("`{source}` should lex: {error}"));
+        tokens
+            .iter()
+            .filter_map(|token| match token.kind {
+                TokenKind::Float(sym) => Some(interner.resolve(&sym).to_string()),
+                _ => None,
+            })
+            .collect()
+    }
+
+    #[test]
+    fn float_literal_accepted_forms() {
+        // ADR-0065 §3: a digit run, then a `.` fraction, an exponent, or both.
+        assert_eq!(float_texts("1.5"), vec!["1.5"]);
+        assert_eq!(float_texts("1e9"), vec!["1e9"]);
+        assert_eq!(float_texts("1.5e-3"), vec!["1.5e-3"]);
+        assert_eq!(float_texts("6.022e23"), vec!["6.022e23"]);
+        assert_eq!(float_texts("1E9 2.5E+7"), vec!["1E9", "2.5E+7"]);
+        assert_eq!(
+            float_texts("0.0 1.0 3.14159"),
+            vec!["0.0", "1.0", "3.14159"]
+        );
+    }
+
+    #[test]
+    fn float_literal_separators_are_stripped_for_the_interned_text() {
+        // `_` is legal inside any digit run, and the interned text is what a
+        // later phase hands to `str::parse`, so the separators are removed
+        // here rather than at every consumer.
+        assert_eq!(float_texts("1_000.000_1"), vec!["1000.0001"]);
+        assert_eq!(float_texts("1e1_0"), vec!["1e10"]);
+    }
+
+    #[test]
+    fn float_literal_text_is_exact_not_rounded() {
+        // A `comptime_float` is arbitrary precision until context picks a
+        // width (ADR-0025, ADR-0065 §3): the token must carry the digits the
+        // programmer wrote, not an already-rounded `f64`.
+        let long = "0.1000000000000000000000000000001";
+        assert_eq!(float_texts(long), vec![long]);
+    }
+
+    #[test]
+    fn float_literal_wins_over_int_dot_int() {
+        // `1.5` must NOT lex as `Int(1) Dot Int(5)`.
+        let (tokens, _) = LogosLexer::new("1.5").tokenize().unwrap();
+        assert!(matches!(tokens[0].kind, TokenKind::Float(_)));
+        assert_eq!(tokens[0].span, Span::new(0, 3));
+        assert!(matches!(tokens[1].kind, TokenKind::Eof));
+    }
+
+    #[test]
+    fn integer_member_access_still_lexes_as_int_dot_ident() {
+        // The fraction rule requires a digit after the `.`, so a method call
+        // on an integer literal is untouched. This is the reason the
+        // trailing-dot rejection is a parser rule, not a lexer rule.
+        let (tokens, interner) = LogosLexer::new("42.to_string()").tokenize().unwrap();
+        assert!(matches!(tokens[0].kind, TokenKind::Int(42)));
+        assert!(matches!(tokens[1].kind, TokenKind::Dot));
+        assert_eq!(get_ident_str(&tokens[2].kind, &interner), Some("to_string"));
+    }
+
+    #[test]
+    fn trailing_dot_float_is_not_a_lexical_error() {
+        // `5.` lexes as `Int(5) Dot`; the parser turns that into the
+        // "write `5.0`" diagnostic once it sees no member name follows.
+        let (tokens, _) = LogosLexer::new("5.;").tokenize().unwrap();
+        assert!(matches!(tokens[0].kind, TokenKind::Int(5)));
+        assert!(matches!(tokens[1].kind, TokenKind::Dot));
+        assert!(matches!(tokens[2].kind, TokenKind::Semi));
+    }
+
+    #[test]
+    fn leading_dot_float_is_rejected() {
+        let error = LogosLexer::new("let x = .5;").tokenize().unwrap_err();
+        assert_eq!(
+            error.to_string(),
+            "floating-point literal cannot start with `.`: write `0.5` instead of `.5`"
+        );
+        assert_eq!(error.kind.code().to_string(), "E0011");
+        let span = error.span().expect("lexical error must carry a span");
+        assert_eq!((span.start, span.end), (8, 10));
+    }
+
+    #[test]
+    fn exponent_without_digits_is_rejected() {
+        let error = LogosLexer::new("let x = 1e;").tokenize().unwrap_err();
+        assert_eq!(
+            error.to_string(),
+            "missing digits in the exponent of floating-point literal `1e`"
+        );
+        let error = LogosLexer::new("let x = 2.0e+;").tokenize().unwrap_err();
+        assert_eq!(
+            error.to_string(),
+            "missing digits in the exponent of floating-point literal `2.0e+`"
+        );
+    }
+
+    #[test]
+    fn based_integer_literals_are_unaffected_by_the_exponent_rule() {
+        // `0x1e9`'s digit run stops at `x`, so the exponent rule can never
+        // reach it; it stays one hexadecimal literal.
+        let (tokens, _) = LogosLexer::new("0x1e9 0b101 0o17").tokenize().unwrap();
+        assert!(matches!(tokens[0].kind, TokenKind::Int(0x1e9)));
+        assert!(matches!(tokens[1].kind, TokenKind::Int(0b101)));
+        assert!(matches!(tokens[2].kind, TokenKind::Int(0o17)));
     }
 
     #[test]

--- a/crates/rue-parser/src/ast.rs
+++ b/crates/rue-parser/src/ast.rs
@@ -658,6 +658,9 @@ pub struct UnitLit {
 pub enum Expr {
     /// Integer literal
     Int(IntLit),
+    /// Floating-point literal (`1.5`, `1e9`) — an untyped `comptime_float`
+    /// (ADR-0065 §3, RUE-1069)
+    Float(FloatLit),
     /// String literal
     String(StringLit),
     /// Boolean literal
@@ -731,6 +734,19 @@ pub enum Expr {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct IntLit {
     pub value: u64,
+    pub span: Span,
+}
+
+/// A floating-point literal.
+///
+/// `value` is the interned literal text with `_` separators removed, exactly
+/// as the lexer produced it (`1.5`, `1e9`, `6.022e23`). The literal is an
+/// untyped `comptime_float` — arbitrary precision until context picks `f32` or
+/// `f64` — so no decoding happens here; the phase that knows the target width
+/// parses the text (ADR-0065 §3, RUE-1069).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct FloatLit {
+    pub value: Spur,
     pub span: Span,
 }
 
@@ -1326,6 +1342,7 @@ impl Expr {
     pub fn span(&self) -> Span {
         match self {
             Expr::Int(lit) => lit.span,
+            Expr::Float(lit) => lit.span,
             Expr::String(lit) => lit.span,
             Expr::Bool(lit) => lit.span,
             Expr::Unit(lit) => lit.span,
@@ -1396,6 +1413,7 @@ impl Expr {
         }
         match self {
             Expr::Int(_)
+            | Expr::Float(_)
             | Expr::String(_)
             | Expr::Bool(_)
             | Expr::Unit(_)
@@ -1709,6 +1727,7 @@ fn rebind_block(block: &mut BlockExpr, file_id: FileId) {
 fn rebind_expr(expr: &mut Expr, file_id: FileId) {
     match expr {
         Expr::Int(literal) => rebind_span(&mut literal.span, file_id),
+        Expr::Float(literal) => rebind_span(&mut literal.span, file_id),
         Expr::String(literal) => rebind_span(&mut literal.span, file_id),
         Expr::Bool(literal) => rebind_span(&mut literal.span, file_id),
         Expr::Unit(literal) => rebind_span(&mut literal.span, file_id),
@@ -2099,6 +2118,7 @@ fn fmt_expr(f: &mut fmt::Formatter<'_>, expr: &Expr, level: usize) -> fmt::Resul
     indent(f, level)?;
     match expr {
         Expr::Int(lit) => writeln!(f, "Int({})", lit.value),
+        Expr::Float(lit) => writeln!(f, "Float(sym:{})", lit.value.into_usize()),
         Expr::String(lit) => writeln!(f, "String(sym:{})", lit.value.into_usize()),
         Expr::Bool(lit) => writeln!(f, "Bool({})", lit.value),
         Expr::Unit(_) => writeln!(f, "Unit"),

--- a/crates/rue-parser/src/parser/expressions.rs
+++ b/crates/rue-parser/src/parser/expressions.rs
@@ -64,6 +64,10 @@ impl Parser {
                 let span = self.bump().span;
                 Ok(Expr::Int(IntLit { value, span }))
             }
+            TokenKind::Float(value) => {
+                let span = self.bump().span;
+                Ok(Expr::Float(FloatLit { value, span }))
+            }
             TokenKind::String(value) => {
                 let span = self.bump().span;
                 Ok(Expr::String(StringLit { value, span }))
@@ -278,10 +282,47 @@ impl Parser {
         }
     }
 
+    /// Reject a trailing-dot float literal (`5.`) before it is mistaken for a
+    /// member access with a missing name (ADR-0065 §3, RUE-1068).
+    ///
+    /// The lexer cannot make this call: `42.` is also the prefix of the legal
+    /// method call `42.to_string()`, and logos commits to the longest match
+    /// without lookahead, so a lexical `[0-9]+\.` rule would swallow the
+    /// receiver of every method call on an integer literal. Here the decision
+    /// is easy — the literal must be directly followed by the `.` (no space),
+    /// and the token after the `.` must not be a member name.
+    ///
+    /// The diagnostic is [`ErrorKind::MalformedFloatLiteral`] (E0011), the same
+    /// kind the lexer uses for the leading-dot form, because both diagnose one
+    /// spelling rule; only the phase that can decide it differs.
+    fn reject_trailing_dot_float(&mut self, base: &Expr) -> PResult<()> {
+        let literal_text = match base {
+            Expr::Int(literal) => literal.value.to_string(),
+            Expr::Float(literal) => self.interner.resolve(&literal.value).to_string(),
+            _ => return Ok(()),
+        };
+        let dot_span = self.tokens[self.cursor].span;
+        let adjacent = base.span().end == dot_span.start;
+        let member_follows = matches!(self.nth(1), TokenKind::Ident(_));
+        if !adjacent || member_follows {
+            return Ok(());
+        }
+        let span = base.span().extend_to(dot_span.end);
+        self.record_error(CompileError::new(
+            ErrorKind::MalformedFloatLiteral(format!(
+                "floating-point literal cannot end with `.`: write `{literal_text}.0` instead \
+                 of `{literal_text}.`"
+            )),
+            span,
+        ));
+        Err(())
+    }
+
     fn postfix(&mut self, mut base: Expr) -> PResult<Expr> {
         loop {
             match self.kind() {
                 TokenKind::Dot => {
+                    self.reject_trailing_dot_float(&base)?;
                     self.bump();
                     let field = self.ident()?;
                     if self.at(TokenKind::LParen) {
@@ -684,5 +725,110 @@ mod tests {
     #[test]
     fn rejects_an_unclosed_call_argument_list() {
         assert!(!parses("fn f() { g(1, 2; }"));
+    }
+
+    /// Parse `source` and return the final expression of `f`'s body together
+    /// with the interner, so the float tests can inspect the literal's text.
+    fn tail_expr(source: &str) -> (Expr, lasso::ThreadedRodeo) {
+        let (tokens, interner) = Lexer::new(source).tokenize().unwrap();
+        let (ast, interner) = Parser::new(tokens, interner)
+            .parse()
+            .unwrap_or_else(|errors| panic!("`{source}` should parse: {errors:?}"));
+        let crate::ast::Item::Function(function) = &ast.items[0] else {
+            panic!("expected the first item to be a function");
+        };
+        let Expr::Block(body) = &function.body else {
+            panic!("expected a block body");
+        };
+        (body.expr.as_ref().clone(), interner)
+    }
+
+    fn parse_errors(source: &str) -> Vec<String> {
+        let (tokens, interner) = Lexer::new(source).tokenize().unwrap();
+        match Parser::new(tokens, interner).parse() {
+            Ok(_) => Vec::new(),
+            Err(errors) => errors.iter().map(|error| error.to_string()).collect(),
+        }
+    }
+
+    #[test]
+    fn float_literal_parses_in_expression_position() {
+        // ADR-0065 §3 / RUE-1069: the literal reaches the AST untyped, holding
+        // the text the lexer interned rather than a decoded value.
+        let (expr, interner) = tail_expr("fn f() { 6.022e23 }");
+        let Expr::Float(literal) = expr else {
+            panic!("expected a float literal, got {expr:?}");
+        };
+        assert_eq!(interner.resolve(&literal.value), "6.022e23");
+        assert_eq!((literal.span.start, literal.span.end), (9, 17));
+    }
+
+    #[test]
+    fn float_literal_binds_like_any_other_primary() {
+        // `1.5e-3 + x` is `(1.5e-3) + x` — the `-` belongs to the exponent, so
+        // there is no subtraction here at all.
+        let (expr, interner) = tail_expr("fn f(x: i32) { 1.5e-3 + x }");
+        let Expr::Binary(binary) = expr else {
+            panic!("expected a binary expression, got {expr:?}");
+        };
+        assert_eq!(binary.op, BinaryOp::Add);
+        let Expr::Float(literal) = binary.left.as_ref() else {
+            panic!("expected the left operand to be a float literal");
+        };
+        assert_eq!(interner.resolve(&literal.value), "1.5e-3");
+        assert!(matches!(binary.right.as_ref(), Expr::Ident(_)));
+    }
+
+    #[test]
+    fn float_literal_obeys_multiplicative_precedence() {
+        // `1.5 * x + y` groups as `(1.5 * x) + y`.
+        let (expr, _) = tail_expr("fn f(x: i32, y: i32) { 1.5 * x + y }");
+        let Expr::Binary(add) = expr else {
+            panic!("expected a binary expression, got {expr:?}");
+        };
+        assert_eq!(add.op, BinaryOp::Add);
+        let Expr::Binary(mul) = add.left.as_ref() else {
+            panic!("expected the left operand to be the multiplication");
+        };
+        assert_eq!(mul.op, BinaryOp::Mul);
+        assert!(matches!(mul.left.as_ref(), Expr::Float(_)));
+    }
+
+    #[test]
+    fn trailing_dot_float_is_rejected_by_the_parser() {
+        // The lexer cannot decide this one — `5.` is also the prefix of
+        // `5.to_string()` — so the parser reports it once no member name
+        // follows the dot (ADR-0065 §3).
+        assert_eq!(
+            parse_errors("fn f() { let x = 5.; }"),
+            vec!["floating-point literal cannot end with `.`: write `5.0` instead of `5.`"]
+        );
+    }
+
+    #[test]
+    fn trailing_dot_rejection_does_not_disturb_member_access() {
+        // A member name after the dot is an ordinary access/method call, on an
+        // integer literal as much as on anything else.
+        assert!(parses("fn f() { 42.to_string() }"));
+        assert!(parses("fn f(p: P) { p.x }"));
+        // A space before the dot is not the trailing-dot spelling; it stays an
+        // ordinary "expected identifier" diagnostic.
+        let errors = parse_errors("fn f() { let x = 5 .; }");
+        assert_eq!(errors.len(), 1);
+        assert!(
+            errors[0].contains("expected identifier"),
+            "unexpected diagnostic: {errors:?}"
+        );
+    }
+
+    #[test]
+    fn trailing_dot_float_recovers_to_the_next_item() {
+        // One diagnostic, not a cascade: recovery resumes at the next item, so
+        // the following function still parses.
+        let errors = parse_errors("fn f() -> i32 { let x = 5.; 1 } fn g() -> i32 { 2 }");
+        assert_eq!(
+            errors,
+            vec!["floating-point literal cannot end with `.`: write `5.0` instead of `5.`"]
+        );
     }
 }

--- a/crates/rue-parser/src/validate.rs
+++ b/crates/rue-parser/src/validate.rs
@@ -234,6 +234,7 @@ impl Validator<'_> {
     fn check_expr(&mut self, expr: &Expr) {
         match expr {
             Expr::Int(_)
+            | Expr::Float(_)
             | Expr::String(_)
             | Expr::Bool(_)
             | Expr::Unit(_)

--- a/crates/rue-rir/src/anonymous_sites.rs
+++ b/crates/rue-rir/src/anonymous_sites.rs
@@ -138,6 +138,7 @@ impl SiteWalker {
     fn walk_expr(&mut self, expr: &Expr) {
         match expr {
             Expr::Int(_)
+            | Expr::Float(_)
             | Expr::Bool(_)
             | Expr::String(_)
             | Expr::Unit(_)

--- a/crates/rue-rir/src/astgen.rs
+++ b/crates/rue-rir/src/astgen.rs
@@ -912,6 +912,16 @@ impl<'a> AstGen<'a> {
                 data: InstData::IntConst(lit.value),
                 span: lit.span,
             }),
+            // A float literal reaches RIR untyped: the node carries the
+            // literal's exact text and nothing else, because `comptime_float`
+            // has no width until a later phase's context supplies one
+            // (ADR-0065 §3, RUE-1069).
+            Expr::Float(lit) => self.rir.add_inst(Inst {
+                data: InstData::FloatConst {
+                    text: self.symbol(lit.value),
+                },
+                span: lit.span,
+            }),
             Expr::Bool(lit) => self.rir.add_inst(Inst {
                 data: InstData::BoolConst(lit.value),
                 span: lit.span,
@@ -3547,6 +3557,42 @@ mod tests {
         assert_eq!(counts.get("index_get"), Some(&3));
         assert_eq!(counts.get("index_set"), Some(&1));
         assert_eq!(counts.get("field_get"), Some(&4));
+    }
+
+    /// Every float literal in `source`, in RIR order, as its interned text.
+    fn float_consts(source: &str) -> Vec<String> {
+        let (rir, interner) = gen_rir(source);
+        rir.iter()
+            .filter_map(|(_, instruction)| match &instruction.data {
+                InstData::FloatConst { text } => Some(interner.resolve(text).to_owned()),
+                _ => None,
+            })
+            .collect()
+    }
+
+    #[test]
+    fn float_literal_lowers_to_an_untyped_float_const() {
+        // ADR-0065 §3 / RUE-1069: the node carries the literal's text and no
+        // type — `comptime_float` has no width until a later phase supplies
+        // one — and `1e9` stays distinguishable from the integer 1000000000.
+        assert_eq!(float_consts("fn f() { 1.5 }"), ["1.5"]);
+        assert_eq!(
+            float_consts("fn f(x: i32) { 1.5e-3 + 6.022e23 }"),
+            ["1.5e-3", "6.022e23"]
+        );
+        assert_eq!(float_consts("fn f() { 1e9 }"), ["1e9"]);
+    }
+
+    #[test]
+    fn float_literal_prints_as_a_distinct_rir_constant() {
+        let (rir, interner) = gen_rir("fn f(x: i32) -> i32 { let y = 1.5e-3 + x; 0 }");
+        let output = RirPrinter::new(&rir, &interner).to_string();
+        assert!(
+            output.contains("const float 1.5e-3"),
+            "float literal missing from the RIR dump:\n{output}"
+        );
+        // The literal is an operand of the addition like any other primary.
+        assert!(output.contains("add "), "{output}");
     }
 
     // RirPrinter integration test with actual generated RIR

--- a/crates/rue-rir/src/inst.rs
+++ b/crates/rue-rir/src/inst.rs
@@ -1535,6 +1535,11 @@ impl RirEditor {
                     InstData::IntConst(value) => {
                         self.add_inst(payload_free(InstData::IntConst(*value)))
                     }
+                    InstData::FloatConst { text } => {
+                        self.add_inst(payload_free(InstData::FloatConst {
+                            text: symbol(*text),
+                        }))
+                    }
                     InstData::BoolConst(value) => {
                         self.add_inst(payload_free(InstData::BoolConst(*value)))
                     }
@@ -2724,6 +2729,7 @@ impl Rir {
                 InstData::StringConst {
                     content: symbol, ..
                 }
+                | InstData::FloatConst { text: symbol }
                 | InstData::VarRef { name: symbol, .. }
                 | InstData::TypeConst { type_name: symbol } => symbols!(*symbol),
                 InstData::Add { lhs, rhs }
@@ -3050,6 +3056,7 @@ impl Rir {
     pub fn child_instructions(&self, instruction: InstRef, out: &mut Vec<InstRef>) {
         match &self.get(instruction).data {
             InstData::IntConst(_)
+            | InstData::FloatConst { .. }
             | InstData::BoolConst(_)
             | InstData::UnitConst
             | InstData::Continue
@@ -4260,6 +4267,19 @@ pub enum InstData {
     /// Integer constant
     IntConst(u64),
 
+    /// Floating-point constant, held as the interned literal *text* with `_`
+    /// separators removed (`1.5`, `1e9`, `6.022e23`).
+    ///
+    /// This node is deliberately untyped and undecoded (ADR-0065 §3,
+    /// RUE-1069). A float literal is a `comptime_float`: an arbitrary-precision
+    /// abstract constant that only becomes `f32` or `f64` when context demands
+    /// one, with round-to-nearest applied at that point and an out-of-range
+    /// magnitude reported as a compile error. Storing an `f64` here would
+    /// perform that rounding before the target width — and therefore the
+    /// range check — was known, so the digits travel intact and the phase that
+    /// resolves the type parses them.
+    FloatConst { text: Spur },
+
     /// Boolean constant
     BoolConst(bool),
 
@@ -4934,6 +4954,12 @@ impl<'a, 'b> RirPrinter<'a, 'b> {
             match &inst.data {
                 // Constants
                 InstData::IntConst(v) => writeln!(out, "const {}", v).unwrap(),
+                // Printed with the `float` tag so a float literal is visibly
+                // distinct from an integer one in a RIR dump: `1e9` and
+                // `1000000000` are different nodes with the same value.
+                InstData::FloatConst { text } => {
+                    writeln!(out, "const float {}", self.interner.resolve(&*text)).unwrap()
+                }
                 InstData::BoolConst(v) => writeln!(out, "const {}", v).unwrap(),
                 InstData::StringConst { content, .. } => {
                     writeln!(out, "const {:?}", self.interner.resolve(&*content)).unwrap()
@@ -6143,6 +6169,83 @@ mod typed_payload_tests {
         assert_eq!(*content, destination_symbol);
         assert_eq!(*remapped_anchor, anchor);
         assert_eq!(instruction.span, Span::with_file(FileId::new(9), 23, 31));
+    }
+
+    #[test]
+    fn float_const_text_is_remapped_across_symbol_domains() {
+        // Module merging re-homes every instruction into the program-wide RIR,
+        // translating owner-local symbols as it goes. A `FloatConst`'s text is
+        // a symbol, so it must be translated rather than copied — a merged
+        // program that kept the source symbol would resolve the literal
+        // against the wrong interner (ADR-0065 §3, RUE-1069).
+        let interner = ThreadedRodeo::new();
+        let source_symbol = interner.get_or_intern("6.022e23");
+        let destination_symbol = interner.get_or_intern("0.5");
+        let mut source = RirEditor::new();
+        source.add_inst(Inst {
+            data: InstData::FloatConst {
+                text: source_symbol,
+            },
+            span: Span::with_file(FileId::new(7), 3, 11),
+        });
+        let source = ValidatedRir::finish(
+            source,
+            &RirValidationContext {
+                symbol_count: interner.len(),
+                source_lengths: &[(FileId::new(7), 20)],
+            },
+        )
+        .unwrap();
+
+        let mut destination = RirEditor::new();
+        destination
+            .append_remapped_with_spans(
+                &source,
+                |_| destination_symbol,
+                |span| Span::with_file(FileId::new(9), span.start + 20, span.end + 20),
+            )
+            .unwrap();
+        let destination = ValidatedRir::finish(
+            destination,
+            &RirValidationContext {
+                symbol_count: interner.len(),
+                source_lengths: &[(FileId::new(9), 100)],
+            },
+        )
+        .unwrap();
+
+        let (_, instruction) = destination.iter().next().unwrap();
+        let InstData::FloatConst { text } = &instruction.data else {
+            panic!("expected a float const, got {:?}", instruction.data);
+        };
+        assert_eq!(*text, destination_symbol);
+        assert_eq!(instruction.span, Span::with_file(FileId::new(9), 23, 31));
+    }
+
+    #[test]
+    fn float_const_symbol_is_validated_like_every_other_symbol_payload() {
+        // A `FloatConst` whose text symbol is outside the compilation's
+        // interner is a malformed producer request, caught by RIR validation
+        // rather than surfacing as a bogus literal downstream.
+        let mut rir = RirEditor::new();
+        rir.add_inst(Inst {
+            data: InstData::FloatConst {
+                text: Spur::try_from_usize(41).unwrap(),
+            },
+            span: Span::with_file(FileId::new(0), 0, 3),
+        });
+        let error = ValidatedRir::finish(
+            rir,
+            &RirValidationContext {
+                symbol_count: 3,
+                source_lengths: &[(FileId::new(0), 20)],
+            },
+        )
+        .unwrap_err();
+        assert!(
+            error.to_string().contains("symbol"),
+            "unexpected validation error: {error}"
+        );
     }
 
     #[test]

--- a/crates/rue-spec/cases/runtime/preview-features.toml
+++ b/crates/rue-spec/cases/runtime/preview-features.toml
@@ -48,3 +48,18 @@ fn main() -> i32 {
 """
 compile_fail = true
 error_contains = "--preview test_infra"
+
+# The gate applies to grammar, not just intrinsics: a float literal is
+# preview-gated syntax (ADR-0065, RUE-1068/RUE-1069), so writing one without
+# `--preview floats` is the same 8.4:1 error, naming the same flag.
+[[case]]
+name = "float_literal_requires_the_floats_feature"
+spec = ["8.4:1"]
+source = """
+fn main() -> i32 {
+    let x = 1.5;
+    0
+}
+"""
+compile_fail = true
+error_contains = "--preview floats"

--- a/crates/rue-ui-tests/cases/diagnostics/float-literals.toml
+++ b/crates/rue-ui-tests/cases/diagnostics/float-literals.toml
@@ -1,0 +1,119 @@
+[section]
+id = "diagnostics.float-literals"
+name = "Float literal diagnostics"
+description = """
+ADR-0065 Phases 2-3 (RUE-1068, RUE-1069). Two families live here: the spelling
+rules for the literal itself (`.5` / `5.` / `1e`), which are lexical or
+grammatical and fire regardless of the preview flag, and the two-sided
+`floats` preview gate — E1100 without `--preview floats`, E1109 with it,
+because no phase can type the literal yet.
+"""
+
+[[case]]
+name = "gated_without_the_preview_flag"
+description = "Spec 8.4:1 — a gated feature errors without its flag, and the help names the flag and the ADR."
+source = """
+fn main() -> i32 {
+    let x = 1.5;
+    0
+}
+"""
+compile_fail = true
+error_contains = [
+    "E1100",
+    "a floating-point literal requires preview feature `floats`",
+    "use --preview floats to enable this feature (ADR-0065)",
+]
+
+[[case]]
+name = "enabled_but_not_yet_typed"
+description = "With the flag the literal passes the gate and stops at the phase marker instead of an unfinished typing path."
+source = """
+fn main() -> i32 {
+    let x = 1.5;
+    0
+}
+"""
+preview = "floats"
+compile_fail = true
+error_contains = [
+    "E1109",
+    "floating-point literals are not yet supported at this compilation phase",
+    "ADR-0065 Phase 4, RUE-714",
+]
+
+[[case]]
+name = "float_in_a_comptime_block_names_the_real_reason"
+description = "A literal is the most compile-time-knowable thing there is; the comptime path must not blame constant-ness."
+source = """
+fn main() -> i32 {
+    let x = comptime { 1.5 };
+    0
+}
+"""
+preview = "floats"
+compile_fail = true
+error_contains = ["E1109", "floating-point literals are not yet supported"]
+
+[[case]]
+name = "float_as_a_call_argument"
+description = "The diagnostic anchors on the literal, not the enclosing call."
+source = """
+fn f(a: i32) -> i32 { a }
+
+fn main() -> i32 {
+    let z = f(2.5);
+    0
+}
+"""
+preview = "floats"
+compile_fail = true
+error_contains = ["E1109"]
+
+[[case]]
+name = "leading_dot_names_the_replacement"
+description = "ADR-0065 §3 rejects `.5`; the diagnostic spells the accepted form."
+source = """
+fn main() -> i32 {
+    let x = .5;
+    0
+}
+"""
+preview = "floats"
+compile_fail = true
+error_contains = [
+    "E0011",
+    "floating-point literal cannot start with `.`: write `0.5` instead of `.5`",
+]
+
+[[case]]
+name = "trailing_dot_names_the_replacement"
+description = "ADR-0065 §3 rejects `5.` too — reported by the parser, since `5.` is also the prefix of `5.to_string()`."
+source = """
+fn main() -> i32 {
+    let x = 5.;
+    0
+}
+"""
+preview = "floats"
+compile_fail = true
+error_contains = [
+    "E0011",
+    "floating-point literal cannot end with `.`: write `5.0` instead of `5.`",
+]
+
+[[case]]
+name = "empty_exponent_names_the_literal"
+description = "`1e` is diagnosed as one malformed literal rather than an integer abutting an identifier."
+source = """
+fn main() -> i32 {
+    let x = 1e;
+    0
+}
+"""
+preview = "floats"
+compile_fail = true
+error_contains = [
+    "E0011",
+    "missing digits in the exponent of floating-point literal `1e`",
+]


### PR DESCRIPTION
ADR-0065 phases 2 and 3, from tonight's cycle-5 floats worker (full suite green in its worktree; integration-level execution checks pending the #2223 guard fix, after which this flips to ready).

## RUE-1068 — lexer
`TokenKind::Float(Spur)` carrying the literal's *text* rather than a decoded `f64` — a `comptime_float` is arbitrary-precision until phase-4 context coercion, so the lexer must not round early. Accepts `1.5`, `1e9`, `1.5e-3`, `6.022e23`; rejects leading/trailing-dot forms (`.5`, `5.`) with a diagnostic. No suffix grammar. Disambiguation against existing integer-token neighbors pinned in lexer tests.

## RUE-1069 — parser + RIR
The literal flows through the parser into an untyped RIR float-literal node; typing stays abstract until AIR inference (phase 4, not in this PR). Parser tests cover expression position, precedence, and error recovery; RIR snapshot tests pin the node. A float literal reaching sema produces a clean phase-boundary diagnostic, not an ICE.

## Preview gate
Adds `PreviewFeature::Floats`. Without `--preview floats` a float literal is the standard gated-feature error (8.4:1); both directions pinned by cases.

Fixes RUE-1068
Fixes RUE-1069

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GPYyXZHFGimCvkbzMtBG2U

---
_Generated by [Claude Code](https://claude.ai/code/session_01GPYyXZHFGimCvkbzMtBG2U)_