### PR TITLE
RUE-1350: measure semantic reachability scheduling

### DIFF
--- a/crates/rue-air/src/sema/output.rs
+++ b/crates/rue-air/src/sema/output.rs
@@ -483,6 +483,26 @@ pub struct BodyAnalysisWork {
     /// maximum `instance_depth` value). Snapshot at completion, not a running
     /// total. Populated only by the session coordinator.
     pub max_specialization_depth: usize,
+    /// Pending-set scans performed by database-owned body reachability.
+    pub reachability_frontier_scans: usize,
+    /// Pending keys examined across those scans.
+    pub reachability_frontier_scan_keys: usize,
+    /// Non-empty stable frontiers submitted to structured batch scheduling.
+    pub reachability_frontier_batches: usize,
+    /// Body keys submitted across those non-empty frontiers.
+    pub reachability_frontier_keys: usize,
+    /// Scheduled frontiers containing exactly one body key.
+    pub reachability_frontier_width_one: usize,
+    /// Scheduled frontiers containing two or three body keys.
+    pub reachability_frontier_width_two_to_three: usize,
+    /// Scheduled frontiers containing four through seven body keys.
+    pub reachability_frontier_width_four_to_seven: usize,
+    /// Scheduled frontiers containing at least eight body keys.
+    pub reachability_frontier_width_eight_or_more: usize,
+    /// Body transactions consumed from a structured frontier prefetch.
+    pub reachability_transactions_prefetched: usize,
+    /// Body transactions demanded on the serial coordinator path.
+    pub reachability_transactions_serial: usize,
     /// Demand-driven comparisons between distinct concrete semantic types.
     /// This stays proportional to comparisons requested by body constraints;
     /// it never includes a scan of unrelated types in the global pool.

--- a/crates/rue-bench/src/scaling.rs
+++ b/crates/rue-bench/src/scaling.rs
@@ -400,6 +400,34 @@ fn render(report: &ScalingReport) -> String {
         ));
     }
 
+    out.push_str("\n## Semantic reachability scheduling\n\n");
+    out.push_str("Counts are exact for database-owned body reachability. Width buckets count non-empty frontiers submitted to structured batch scheduling; transaction counts distinguish structured prefetch from serial coordinator demand; `keys/batch` exposes available scheduling breadth independently of clock time.\n\n");
+    out.push_str("| workload | scans | scan keys | batches | scheduled keys | keys/batch | transactions prefetched/serial | width 1 | width 2–3 | width 4–7 | width 8+ |\n");
+    out.push_str("| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |\n");
+    for observation in &report.workloads {
+        let work = observation.work.semantic_reachability;
+        let keys_per_batch = if work.frontier_batches == 0 {
+            0.0
+        } else {
+            work.frontier_keys as f64 / work.frontier_batches as f64
+        };
+        out.push_str(&format!(
+            "| {} | {} | {} | {} | {} | {:.2} | {}/{} | {} | {} | {} | {} |\n",
+            observation.workload,
+            work.frontier_scans,
+            work.frontier_scan_keys,
+            work.frontier_batches,
+            work.frontier_keys,
+            keys_per_batch,
+            work.transactions_prefetched,
+            work.transactions_serial,
+            work.frontier_width_one,
+            work.frontier_width_two_to_three,
+            work.frontier_width_four_to_seven,
+            work.frontier_width_eight_or_more,
+        ));
+    }
+
     out.push_str("\n## Query display identities\n\n");
     out.push_str("Counts and UTF-8 key bytes are exact for identities the compiler actually formatted. Structured-wait values count only labels rendered for a detected wait cycle; registering an acyclic edge is free of display formatting. Shared family names are excluded. `bytes/token` exposes presentation-only bookkeeping growth independently of clock noise.\n\n");
     out.push_str("| workload | memo nodes count/bytes | structured waits count/bytes | abort fallbacks count/bytes | bytes/token |\n");
@@ -526,6 +554,17 @@ mod tests {
                     functions: 1,
                 },
                 work: rue_perf_schema::CompilerWork {
+                    semantic_reachability: rue_perf_schema::SemanticReachabilityWork {
+                        frontier_scans: 4,
+                        frontier_scan_keys: 7,
+                        frontier_batches: 2,
+                        frontier_keys: 7,
+                        frontier_width_one: 1,
+                        frontier_width_eight_or_more: 1,
+                        transactions_prefetched: 7,
+                        transactions_serial: 0,
+                        ..Default::default()
+                    },
                     query_runtime: rue_perf_schema::QueryRuntimeWork {
                         validation: rue_perf_schema::ValidationWork {
                             traversals: 3,
@@ -561,6 +600,8 @@ mod tests {
         assert!(rendered.contains("shape id"));
         assert!(rendered.contains("Deterministic query work"));
         assert!(rendered.contains("nodes/token"));
+        assert!(rendered.contains("Semantic reachability scheduling"));
+        assert!(rendered.contains("keys/batch"));
         assert!(rendered.contains("Query display identities"));
         assert!(rendered.contains("bytes/token"));
     }
@@ -593,6 +634,7 @@ mod tests {
                 retention_scan_entries: 1,
                 ..Default::default()
             },
+            ..Default::default()
         };
         let error = observe_compiler_work(&mut expected, changed, "probe").unwrap_err();
         assert!(

--- a/crates/rue-compiler/src/canonical_semantic.rs
+++ b/crates/rue-compiler/src/canonical_semantic.rs
@@ -410,6 +410,19 @@ impl CanonicalSemanticWork {
         body.max_specialization_depth = body
             .max_specialization_depth
             .max(query.max_specialization_depth);
+        body.reachability_frontier_scans += query.reachability_frontier_scans;
+        body.reachability_frontier_scan_keys += query.reachability_frontier_scan_keys;
+        body.reachability_frontier_batches += query.reachability_frontier_batches;
+        body.reachability_frontier_keys += query.reachability_frontier_keys;
+        body.reachability_frontier_width_one += query.reachability_frontier_width_one;
+        body.reachability_frontier_width_two_to_three +=
+            query.reachability_frontier_width_two_to_three;
+        body.reachability_frontier_width_four_to_seven +=
+            query.reachability_frontier_width_four_to_seven;
+        body.reachability_frontier_width_eight_or_more +=
+            query.reachability_frontier_width_eight_or_more;
+        body.reachability_transactions_prefetched += query.reachability_transactions_prefetched;
+        body.reachability_transactions_serial += query.reachability_transactions_serial;
         body.air_instructions_produced += query.air_instructions_produced;
         body.local_strings_produced += query.local_strings_produced;
         body.ordinary_body_exports_attempted += query.ordinary_body_exports_attempted;

--- a/crates/rue-compiler/src/linking.rs
+++ b/crates/rue-compiler/src/linking.rs
@@ -575,6 +575,7 @@ pub(crate) fn link_internal_with_warnings(
         source_stats: SourceStats::default(),
         work: PipelineWork::default(),
         query_runtime: crate::unstable::QueryRuntimeMetrics::default(),
+        semantic_reachability: crate::unstable::SemanticReachabilityMetrics::default(),
     })
 }
 
@@ -678,6 +679,7 @@ pub(crate) fn link_system_with_warnings(
         source_stats: SourceStats::default(),
         work: PipelineWork::default(),
         query_runtime: crate::unstable::QueryRuntimeMetrics::default(),
+        semantic_reachability: crate::unstable::SemanticReachabilityMetrics::default(),
     })
 }
 use std::io::{Read, Write};

--- a/crates/rue-compiler/src/pipeline_tests.rs
+++ b/crates/rue-compiler/src/pipeline_tests.rs
@@ -2227,8 +2227,18 @@ mod tests {
         )
         .unwrap();
         let one_shot_metrics = output.unstable_metrics();
-        let live_runtime = session.unstable_metrics().query_runtime();
+        let live_metrics = session.unstable_metrics();
+        let live_runtime = live_metrics.query_runtime();
         assert_eq!(one_shot_metrics.query_runtime, live_runtime);
+        assert_eq!(
+            one_shot_metrics.semantic_reachability,
+            live_metrics.semantic_reachability(),
+        );
+        assert!(
+            one_shot_metrics.semantic_reachability.frontier_batches > 0
+                && one_shot_metrics.semantic_reachability.frontier_keys >= 2,
+            "a rooted cold compile reports the reachability frontiers it scheduled"
+        );
         assert!(
             one_shot_metrics
                 .query_runtime

--- a/crates/rue-compiler/src/queries.rs
+++ b/crates/rue-compiler/src/queries.rs
@@ -1095,13 +1095,19 @@ pub struct CompileOutput {
     pub(crate) work: PipelineWork,
     /// Live query-runtime work observed after the rooted compiler queries.
     pub(crate) query_runtime: crate::unstable::QueryRuntimeMetrics,
+    pub(crate) semantic_reachability: crate::unstable::SemanticReachabilityMetrics,
 }
 
 impl CompileOutput {
     /// Return instrumentation from this one-shot compilation without exposing
     /// query-engine work records.
     pub fn unstable_metrics(&self) -> crate::unstable::OneShotMetrics {
-        crate::unstable::OneShotMetrics::new(self.source_stats, self.work, self.query_runtime)
+        crate::unstable::OneShotMetrics::new(
+            self.source_stats,
+            self.work,
+            self.query_runtime,
+            self.semantic_reachability,
+        )
     }
 }
 
@@ -1275,7 +1281,9 @@ pub(crate) fn compile_rooted_with_session(
         })?;
     let total_source_bytes: usize = snapshot.files().map(|source| source.source.len()).sum();
     let session_work = session.work().clone();
-    let query_runtime = session.unstable_metrics().query_runtime();
+    let metrics = session.unstable_metrics();
+    let query_runtime = metrics.query_runtime();
+    let semantic_reachability = metrics.semantic_reachability();
     let image = crate::program_image_plan::ProgramImage::from_rooted(
         rooted.objects,
         rooted.exports,
@@ -1298,5 +1306,6 @@ pub(crate) fn compile_rooted_with_session(
         semantic: rooted.work,
     };
     output.query_runtime = query_runtime;
+    output.semantic_reachability = semantic_reachability;
     Ok(output)
 }

--- a/crates/rue-compiler/src/revisioned_query_database.rs
+++ b/crates/rue-compiler/src/revisioned_query_database.rs
@@ -13,6 +13,60 @@ use std::ops::Deref;
 use std::rc::Rc;
 use std::sync::{Arc, Mutex};
 
+#[derive(Debug, Default)]
+struct BodyReachabilityMeter {
+    frontier_scans: std::sync::atomic::AtomicU64,
+    frontier_scan_keys: std::sync::atomic::AtomicU64,
+    frontier_batches: std::sync::atomic::AtomicU64,
+    frontier_keys: std::sync::atomic::AtomicU64,
+    frontier_width_one: std::sync::atomic::AtomicU64,
+    frontier_width_two_to_three: std::sync::atomic::AtomicU64,
+    frontier_width_four_to_seven: std::sync::atomic::AtomicU64,
+    frontier_width_eight_or_more: std::sync::atomic::AtomicU64,
+    transactions_prefetched: std::sync::atomic::AtomicU64,
+    transactions_serial: std::sync::atomic::AtomicU64,
+}
+
+impl BodyReachabilityMeter {
+    fn accrue(&self, work: &[(Arc<str>, u64)]) {
+        use std::sync::atomic::Ordering::Relaxed;
+
+        for (identity, amount) in work {
+            let counter = match identity.as_ref() {
+                "reachability.frontier.scans" => &self.frontier_scans,
+                "reachability.frontier.scan-keys" => &self.frontier_scan_keys,
+                "reachability.frontier.batches" => &self.frontier_batches,
+                "reachability.frontier.keys" => &self.frontier_keys,
+                "reachability.frontier.width-1" => &self.frontier_width_one,
+                "reachability.frontier.width-2-3" => &self.frontier_width_two_to_three,
+                "reachability.frontier.width-4-7" => &self.frontier_width_four_to_seven,
+                "reachability.frontier.width-8-plus" => &self.frontier_width_eight_or_more,
+                "reachability.transactions.prefetched" => &self.transactions_prefetched,
+                "reachability.transactions.serial" => &self.transactions_serial,
+                _ => continue,
+            };
+            counter.fetch_add(*amount, Relaxed);
+        }
+    }
+
+    fn snapshot(&self) -> crate::unstable::SemanticReachabilityMetrics {
+        use std::sync::atomic::Ordering::Relaxed;
+
+        crate::unstable::SemanticReachabilityMetrics {
+            frontier_scans: self.frontier_scans.load(Relaxed),
+            frontier_scan_keys: self.frontier_scan_keys.load(Relaxed),
+            frontier_batches: self.frontier_batches.load(Relaxed),
+            frontier_keys: self.frontier_keys.load(Relaxed),
+            frontier_width_one: self.frontier_width_one.load(Relaxed),
+            frontier_width_two_to_three: self.frontier_width_two_to_three.load(Relaxed),
+            frontier_width_four_to_seven: self.frontier_width_four_to_seven.load(Relaxed),
+            frontier_width_eight_or_more: self.frontier_width_eight_or_more.load(Relaxed),
+            transactions_prefetched: self.transactions_prefetched.load(Relaxed),
+            transactions_serial: self.transactions_serial.load(Relaxed),
+        }
+    }
+}
+
 #[cfg(test)]
 #[derive(Debug, Default)]
 struct TestBodyClosureAnonymousDigestForcing {
@@ -365,6 +419,7 @@ pub(crate) struct RevisionedQueryDatabase {
         crate::body_query::BodyClosurePublicationKey,
         Arc<rue_query::QueryTerminal<crate::body_query::BodyClosureOutput>>,
     >,
+    body_reachability_meter: Arc<BodyReachabilityMeter>,
     #[cfg_attr(not(test), allow(dead_code))]
     body_references:
         QueryFamily<crate::body_query::BodyQueryKey, crate::body_query::BodyReferences>,
@@ -6309,6 +6364,7 @@ pub(crate) struct BodyClosureRequest {
     pub(crate) terminal: Arc<rue_query::QueryTerminal<crate::body_query::BodyClosureOutput>>,
     body_executions: BTreeMap<String, rue_query::RequestExecution>,
     retained_before: BTreeSet<String>,
+    work: Vec<(Arc<str>, u64)>,
 }
 
 impl BodyClosureRequest {
@@ -6324,6 +6380,37 @@ impl BodyClosureRequest {
 
     pub(crate) fn was_retained(&self, key: &crate::body_query::BodyQueryKey) -> bool {
         self.retained_before.contains(&key.stable_identity())
+    }
+
+    /// Accrue request-local database-owned reachability scheduling work into
+    /// the canonical semantic request. Query work is already reduced by stable
+    /// identity, so this projection is deterministic across worker schedules.
+    pub(crate) fn accrue_reachability_work(&self, target: &mut rue_air::BodyAnalysisWork) {
+        for (identity, amount) in &self.work {
+            let amount = usize::try_from(*amount).unwrap_or(usize::MAX);
+            let counter = match identity.as_ref() {
+                "reachability.frontier.scans" => &mut target.reachability_frontier_scans,
+                "reachability.frontier.scan-keys" => &mut target.reachability_frontier_scan_keys,
+                "reachability.frontier.batches" => &mut target.reachability_frontier_batches,
+                "reachability.frontier.keys" => &mut target.reachability_frontier_keys,
+                "reachability.frontier.width-1" => &mut target.reachability_frontier_width_one,
+                "reachability.frontier.width-2-3" => {
+                    &mut target.reachability_frontier_width_two_to_three
+                }
+                "reachability.frontier.width-4-7" => {
+                    &mut target.reachability_frontier_width_four_to_seven
+                }
+                "reachability.frontier.width-8-plus" => {
+                    &mut target.reachability_frontier_width_eight_or_more
+                }
+                "reachability.transactions.prefetched" => {
+                    &mut target.reachability_transactions_prefetched
+                }
+                "reachability.transactions.serial" => &mut target.reachability_transactions_serial,
+                _ => continue,
+            };
+            *counter = counter.saturating_add(amount);
+        }
     }
 }
 
@@ -11136,6 +11223,7 @@ impl RevisionedQueryDatabase {
         query_concurrency: usize,
     ) -> Self {
         let runtime = CompilerQueryRuntime(QueryRuntime::new(query_concurrency));
+        let body_reachability_meter = Arc::new(BodyReachabilityMeter::default());
         let module_store = Arc::new(Mutex::new(ModuleInputStore::default()));
         #[cfg(test)]
         let test_import_store = Arc::new(Mutex::new(TestImportInputStore {
@@ -15286,9 +15374,20 @@ impl RevisionedQueryDatabase {
                                     frontier_keys,
                                 )?;
                                 context.record_work(rue_query::WorkItem::new(
+                                    "reachability.frontier.batches",
+                                    1,
+                                ));
+                                context.record_work(rue_query::WorkItem::new(
                                     "reachability.frontier.keys",
                                     frontier.len() as u64,
                                 ));
+                                let width_bucket = match frontier.len() {
+                                    1 => "reachability.frontier.width-1",
+                                    2..=3 => "reachability.frontier.width-2-3",
+                                    4..=7 => "reachability.frontier.width-4-7",
+                                    _ => "reachability.frontier.width-8-plus",
+                                };
+                                context.record_work(rue_query::WorkItem::new(width_bucket, 1));
                                 for (instance, transaction) in
                                     frontier.into_iter().zip(transactions)
                                 {
@@ -15443,15 +15542,24 @@ impl RevisionedQueryDatabase {
                         // remain transaction-only (they publish no
                         // BodyReferences terminal), so interpret the exact
                         // transaction before projecting schedulable references.
-                        let transaction_terminal =
-                            if let Some(transaction) = prefetched_transactions.remove(&instance) {
-                                transaction
-                            } else {
-                                context.query_registered(
-                                    &transactions_for_body_reachability,
-                                    body_key.clone(),
-                                )?
-                            };
+                        let transaction_terminal = if let Some(transaction) =
+                            prefetched_transactions.remove(&instance)
+                        {
+                            context.record_work(rue_query::WorkItem::new(
+                                "reachability.transactions.prefetched",
+                                1,
+                            ));
+                            transaction
+                        } else {
+                            context.record_work(rue_query::WorkItem::new(
+                                "reachability.transactions.serial",
+                                1,
+                            ));
+                            context.query_registered(
+                                &transactions_for_body_reachability,
+                                body_key.clone(),
+                            )?
+                        };
                         let rue_query::QueryOutcome::Success(transaction) =
                             transaction_terminal.outcome()
                         else {
@@ -15941,12 +16049,16 @@ impl RevisionedQueryDatabase {
                     },
                     move |context, _, key: &crate::body_query::BodyClosurePublicationKey| {
                         // The publication request's operational sidecar consumes
-                        // only body-transaction lifecycle rows. Scope the
-                        // closure request itself so both warm validation and
-                        // cold evaluation suppress the much larger descendant
-                        // ledger while preserving query semantics.
-                        let _nested_attempts =
-                            context.retain_nested_attempts_for(&["compiler.body-transaction"]);
+                        // body-transaction lifecycle rows plus the one
+                        // reachability row whose deterministic work describes
+                        // frontier scheduling. Scope the closure request itself
+                        // so both warm validation and cold evaluation suppress
+                        // the much larger descendant ledger while preserving
+                        // query semantics.
+                        let _nested_attempts = context.retain_nested_attempts_for(&[
+                            "compiler.body-transaction",
+                            "compiler.body-reachability",
+                        ]);
                         let closure_fallback = terminal_root_for_closure_publication
                             .lock()
                             .unwrap_or_else(std::sync::PoisonError::into_inner)
@@ -16161,6 +16273,7 @@ impl RevisionedQueryDatabase {
             body_reachability,
             body_closures,
             body_closure_publications,
+            body_reachability_meter,
             body_references,
             body_produced_anonymous,
             module_rirs,
@@ -18347,6 +18460,24 @@ impl RevisionedQueryDatabase {
                     .or_insert_with(|| attempt.execution());
                 executions
             });
+        let work: Vec<(Arc<str>, u64)> = publication_attempt
+            .nested_attempts()
+            .iter()
+            .filter(|attempt| attempt.node().family() == "compiler.body-reachability")
+            .flat_map(|attempt| attempt.work().iter().cloned())
+            .fold(
+                BTreeMap::<Arc<str>, u64>::new(),
+                |mut reduced, (identity, amount)| {
+                    reduced
+                        .entry(identity)
+                        .and_modify(|total| *total = total.saturating_add(amount))
+                        .or_insert(amount);
+                    reduced
+                },
+            )
+            .into_iter()
+            .collect();
+        self.body_reachability_meter.accrue(&work);
         let publication = publication_attempt.into_result()?;
         let rue_query::QueryOutcome::Success(closure) = publication.outcome() else {
             unreachable!("BodyClosurePublication publishes typed values")
@@ -18355,6 +18486,7 @@ impl RevisionedQueryDatabase {
             terminal: closure.clone(),
             body_executions,
             retained_before,
+            work,
         })
     }
 
@@ -20457,6 +20589,10 @@ impl RevisionedQueryDatabase {
 
     pub(crate) fn runtime_retention_metrics(&self) -> rue_query::RuntimeMetrics {
         self.runtime.metrics()
+    }
+
+    pub(crate) fn body_reachability_metrics(&self) -> crate::unstable::SemanticReachabilityMetrics {
+        self.body_reachability_meter.snapshot()
     }
 
     pub(crate) fn input_stamp_retention_metrics(&self) -> InputStampRetentionMetrics {
@@ -37857,24 +37993,24 @@ fn main() -> i32 {
         let module = ModuleId::from_logical_path("main.rue").unwrap();
         let mut database = RevisionedQueryDatabase::with_query_concurrency(4);
         let revision = revision_for(&mut database, &snapshot);
-        let attempt = database.runtime.request_registered(
-            &database.body_reachability,
-            revision,
-            crate::body_query::BodyClosureQueryKey {
-                modules: Arc::from([module.clone()]),
-                roots: Arc::from([free_function_instance(&module, "main")]),
-                configuration: semantic_configuration(),
-            },
-            CancellationToken::new(),
-        );
-        let terminal = attempt.terminal().expect("reachability publishes");
-        let rue_query::QueryOutcome::Success(output) = terminal.outcome() else {
-            unreachable!("BodyReachability publishes typed values")
+        let request = database
+            .body_closure(
+                revision,
+                crate::body_query::BodyClosureQueryKey {
+                    modules: Arc::from([module.clone()]),
+                    roots: Arc::from([free_function_instance(&module, "main")]),
+                    configuration: semantic_configuration(),
+                },
+                CancellationToken::new(),
+            )
+            .expect("body closure publishes");
+        let rue_query::QueryOutcome::Success(output) = request.terminal.outcome() else {
+            unreachable!("BodyClosure publishes typed values")
         };
         assert_eq!(output.reached.len(), CALLEES + 1);
         let work = |expected: &str| {
-            attempt
-                .work()
+            request
+                .work
                 .iter()
                 .find_map(|(label, amount)| (label.as_ref() == expected).then_some(*amount))
                 .unwrap_or(0)
@@ -37888,6 +38024,17 @@ fn main() -> i32 {
             work("reachability.frontier.scan-keys"),
             output.reached.len(),
         );
+        assert_eq!(work("reachability.frontier.batches"), 2);
+        assert_eq!(work("reachability.frontier.keys"), (CALLEES + 1) as u64);
+        assert_eq!(work("reachability.frontier.width-1"), 1);
+        assert_eq!(work("reachability.frontier.width-2-3"), 0);
+        assert_eq!(work("reachability.frontier.width-4-7"), 0);
+        assert_eq!(work("reachability.frontier.width-8-plus"), 1);
+        assert_eq!(
+            work("reachability.transactions.prefetched"),
+            (CALLEES + 1) as u64
+        );
+        assert_eq!(work("reachability.transactions.serial"), 0);
     }
 
     #[test]

--- a/crates/rue-compiler/src/session.rs
+++ b/crates/rue-compiler/src/session.rs
@@ -132,6 +132,7 @@ pub(crate) struct FrontendRuntimeMetrics {
     pub(crate) display_identities: rue_query::DisplayIdentityMetrics,
     pub(crate) retention_enforcements: u64,
     pub(crate) retention_scan_entries: u64,
+    pub(crate) semantic_reachability: crate::unstable::SemanticReachabilityMetrics,
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
@@ -3107,6 +3108,7 @@ impl CompilerSession {
             display_identities: runtime.display_identities,
             retention_enforcements: runtime.retention_enforcements,
             retention_scan_entries: runtime.retention_scan_entries,
+            semantic_reachability: self.queries.revisioned.body_reachability_metrics(),
         };
         crate::unstable::MetricsSnapshot::new(work)
     }
@@ -3307,6 +3309,7 @@ impl CompilerSession {
             display_identities: runtime.display_identities,
             retention_enforcements: runtime.retention_enforcements,
             retention_scan_entries: runtime.retention_scan_entries,
+            semantic_reachability: self.queries.revisioned.body_reachability_metrics(),
         });
     }
 
@@ -4588,6 +4591,7 @@ impl CompilerSession {
             return Err(SemanticRequestControl::Parked(Box::new(park.clone())));
         }
         let mut work = crate::CanonicalSemanticWork::default();
+        request.accrue_reachability_work(&mut work.body_analysis);
         work.body_analysis.closure_bodies_visited = closure.bodies.len();
         for closure_body in closure.bodies.iter() {
             match request.execution_for(&closure_body.key) {
@@ -6129,6 +6133,7 @@ impl CompilerSession {
                 Err(abort) => return Err(SemanticRequestControl::Abort(abort)),
             };
             let closure_terminal = &closure_request.terminal;
+            closure_request.accrue_reachability_work(&mut queried_body_work);
             let rue_query::QueryOutcome::Success(closure_output) = closure_terminal.outcome()
             else {
                 unreachable!("BodyClosure publishes typed values")

--- a/crates/rue-compiler/src/unstable.rs
+++ b/crates/rue-compiler/src/unstable.rs
@@ -1764,6 +1764,22 @@ pub struct QueryRuntimeMetrics {
     pub retention_scan_entries: u64,
 }
 
+/// Database-owned semantic-reachability scheduling work accumulated by the
+/// session, including acquisition rounds that park before final publication.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct SemanticReachabilityMetrics {
+    pub frontier_scans: u64,
+    pub frontier_scan_keys: u64,
+    pub frontier_batches: u64,
+    pub frontier_keys: u64,
+    pub frontier_width_one: u64,
+    pub frontier_width_two_to_three: u64,
+    pub frontier_width_four_to_seven: u64,
+    pub frontier_width_eight_or_more: u64,
+    pub transactions_prefetched: u64,
+    pub transactions_serial: u64,
+}
+
 /// Display-only query identity materialization contained in [`MetricsSnapshot`].
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
 pub struct QueryDisplayIdentityMetrics {
@@ -1971,6 +1987,16 @@ pub struct SemanticBodyMetrics {
     pub analyses_computed: usize,
     pub analyses_reused: usize,
     pub analyses_invalidated: usize,
+    pub reachability_frontier_scans: usize,
+    pub reachability_frontier_scan_keys: usize,
+    pub reachability_frontier_batches: usize,
+    pub reachability_frontier_keys: usize,
+    pub reachability_frontier_width_one: usize,
+    pub reachability_frontier_width_two_to_three: usize,
+    pub reachability_frontier_width_four_to_seven: usize,
+    pub reachability_frontier_width_eight_or_more: usize,
+    pub reachability_transactions_prefetched: usize,
+    pub reachability_transactions_serial: usize,
 }
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
 pub struct SemanticMetrics {
@@ -1997,6 +2023,26 @@ impl SemanticMetrics {
                 analyses_computed: work.body_analysis.body_analyses_computed,
                 analyses_reused: work.body_analysis.body_analyses_reused,
                 analyses_invalidated: work.body_analysis.body_analyses_invalidated,
+                reachability_frontier_scans: work.body_analysis.reachability_frontier_scans,
+                reachability_frontier_scan_keys: work.body_analysis.reachability_frontier_scan_keys,
+                reachability_frontier_batches: work.body_analysis.reachability_frontier_batches,
+                reachability_frontier_keys: work.body_analysis.reachability_frontier_keys,
+                reachability_frontier_width_one: work.body_analysis.reachability_frontier_width_one,
+                reachability_frontier_width_two_to_three: work
+                    .body_analysis
+                    .reachability_frontier_width_two_to_three,
+                reachability_frontier_width_four_to_seven: work
+                    .body_analysis
+                    .reachability_frontier_width_four_to_seven,
+                reachability_frontier_width_eight_or_more: work
+                    .body_analysis
+                    .reachability_frontier_width_eight_or_more,
+                reachability_transactions_prefetched: work
+                    .body_analysis
+                    .reachability_transactions_prefetched,
+                reachability_transactions_serial: work
+                    .body_analysis
+                    .reachability_transactions_serial,
             },
             cfg: SemanticCfgMetrics {
                 functions_considered: work.cfg.functions_considered,
@@ -2022,6 +2068,7 @@ pub struct OneShotMetrics {
     pub lowered: LowerMetrics,
     pub semantic: SemanticMetrics,
     pub query_runtime: QueryRuntimeMetrics,
+    pub semantic_reachability: SemanticReachabilityMetrics,
 }
 
 impl OneShotMetrics {
@@ -2029,6 +2076,7 @@ impl OneShotMetrics {
         stats: crate::SourceStats,
         work: crate::PipelineWork,
         query_runtime: QueryRuntimeMetrics,
+        semantic_reachability: SemanticReachabilityMetrics,
     ) -> Self {
         Self {
             files: stats.files,
@@ -2039,6 +2087,7 @@ impl OneShotMetrics {
             lowered: LowerMetrics::from_work(work.lowered),
             semantic: SemanticMetrics::from_work(work.semantic),
             query_runtime,
+            semantic_reachability,
         }
     }
 }
@@ -2182,6 +2231,9 @@ impl MetricsSnapshot {
             retention_enforcements: self.inner.runtime.retention_enforcements,
             retention_scan_entries: self.inner.runtime.retention_scan_entries,
         }
+    }
+    pub fn semantic_reachability(&self) -> SemanticReachabilityMetrics {
+        self.inner.runtime.semantic_reachability
     }
     pub fn semantic_work_json(&self, from: usize) -> Value {
         semantic_work_json(&self.inner, from)

--- a/crates/rue-perf-schema/src/lib.rs
+++ b/crates/rue-perf-schema/src/lib.rs
@@ -63,7 +63,7 @@ pub use run::{
 pub use scaling::{
     CompilerWork, QueryRuntimeWork, SCALING_REPORT_SCHEMA_VERSION, ScalingIdentity,
     ScalingManifest, ScalingObservation, ScalingRegime, ScalingReport, ScalingWorkload,
-    WorkloadShape,
+    SemanticReachabilityWork, WorkloadShape,
 };
 pub use series::{Metric, SeriesId};
 pub use stats::{

--- a/crates/rue-perf-schema/src/scaling.rs
+++ b/crates/rue-perf-schema/src/scaling.rs
@@ -12,7 +12,7 @@ use serde::{Deserialize, Serialize};
 use crate::{DisplayIdentityWork, EnvironmentFingerprint, Sample, ValidationWork};
 
 /// Version of the scaling-report wire format.
-pub const SCALING_REPORT_SCHEMA_VERSION: u32 = 5;
+pub const SCALING_REPORT_SCHEMA_VERSION: u32 = 6;
 
 /// The lower-frequency scaling suite declaration.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -167,8 +167,26 @@ pub struct ScalingObservation {
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct CompilerWork {
+    /// Work performed while discovering and scheduling reachable bodies.
+    pub semantic_reachability: SemanticReachabilityWork,
     /// Work performed by the revisioned query runtime.
     pub query_runtime: QueryRuntimeWork,
+}
+
+/// Deterministic work performed by database-owned semantic reachability.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct SemanticReachabilityWork {
+    pub frontier_scans: u64,
+    pub frontier_scan_keys: u64,
+    pub frontier_batches: u64,
+    pub frontier_keys: u64,
+    pub frontier_width_one: u64,
+    pub frontier_width_two_to_three: u64,
+    pub frontier_width_four_to_seven: u64,
+    pub frontier_width_eight_or_more: u64,
+    pub transactions_prefetched: u64,
+    pub transactions_serial: u64,
 }
 
 /// Deterministic query-runtime work performed by one compiler process.

--- a/crates/rue/src/main.rs
+++ b/crates/rue/src/main.rs
@@ -949,7 +949,20 @@ fn benchmark_compiler_work(
 ) -> rue_perf_schema::CompilerWork {
     let runtime = metrics.query_runtime;
     let validation = runtime.validation;
+    let reachability = metrics.semantic_reachability;
     rue_perf_schema::CompilerWork {
+        semantic_reachability: rue_perf_schema::SemanticReachabilityWork {
+            frontier_scans: reachability.frontier_scans,
+            frontier_scan_keys: reachability.frontier_scan_keys,
+            frontier_batches: reachability.frontier_batches,
+            frontier_keys: reachability.frontier_keys,
+            frontier_width_one: reachability.frontier_width_one,
+            frontier_width_two_to_three: reachability.frontier_width_two_to_three,
+            frontier_width_four_to_seven: reachability.frontier_width_four_to_seven,
+            frontier_width_eight_or_more: reachability.frontier_width_eight_or_more,
+            transactions_prefetched: reachability.transactions_prefetched,
+            transactions_serial: reachability.transactions_serial,
+        },
         query_runtime: rue_perf_schema::QueryRuntimeWork {
             validation: rue_perf_schema::ValidationWork {
                 traversals: validation.traversals,

--- a/docs/notes/post-adr-0063-cold-compiler-architecture-audit.md
+++ b/docs/notes/post-adr-0063-cold-compiler-architecture-audit.md
@@ -270,6 +270,25 @@ versus the immediately preceding same-host report moved -0.6, -0.6, +1.0 and
 +0.7 percent from Ruelex through Lattice. The clock still does not isolate this
 bookkeeping reliably, while the counters prove its scale and source.
 
+RUE-1350 then measured the semantic body scheduler directly after a
+fresh-process one-worker versus ten-worker profile found the semantic/body
+closure phase flat at roughly 1.1 seconds while CFG and backend work scaled.
+The deterministic counters separate transactions reached through a prefetched
+frontier from transactions that still use the exact serial producer path:
+
+| workload | batches | batched keys | keys/batch | prefetched transactions | serial transactions |
+| --- | ---: | ---: | ---: | ---: | ---: |
+| Harbor | 3 | 282 | 94.00 | 282 | 1,097 |
+| Lattice | 4 | 175 | 43.75 | 175 | 1,088 |
+
+Every non-root batch on these workloads had at least eight keys, so the batches
+that exist are useful. However, 79.6 percent of Harbor transactions and 86.1
+percent of Lattice transactions still cross the anonymous-producer boundary
+serially. The counts were exact across three repetitions and both worker
+settings. This identifies the producer-before-consumer boundary, rather than
+linking or a compiler-wide lock, as the strongest next cold-performance target;
+RUE-1351 tracks batching ready anonymous-producer body frontiers.
+
 ## Next actions and decision boundary
 
 Authorized low-risk work:
@@ -280,6 +299,9 @@ Authorized low-risk work:
    already owns the payload.
 3. Clean stale comments and keep phase attribution exhaustive when profiles
    expose unattributed work.
+4. Batch ready anonymous-producer body frontiers behind the existing canonical
+   body-reachability scheduler, preserving deterministic publication and the
+   one-query-graph ownership model (RUE-1351).
 
 Maintainer review required before implementation:
 

--- a/docs/process/compiler-scaling.md
+++ b/docs/process/compiler-scaling.md
@@ -31,6 +31,8 @@ compilations. The report records:
 - files, modules, source bytes, lines, lexer tokens, and functions considered;
 - externally observed fresh-process wall time and peak resident memory;
 - the compiler's additive, mutually exclusive phase accounting;
+- semantic-reachability scans, scheduled keys, and fixed frontier-width
+  buckets;
 - query validation, endorsement, lease, demand, and retention-scan work;
 - display-only query identities materialized for memo nodes, structured batch
   cycle rendering, and abort fallbacks, with exact counts and formatted key
@@ -41,6 +43,15 @@ The Markdown work table includes validation nodes per token. That ratio is a
 clock-independent amplification signal: source growth should not silently turn
 into many repeated validation visits merely because elapsed time still looks
 plausible on one host.
+
+The semantic-reachability table reports average scheduled keys per non-empty
+frontier, fixed width buckets, and body transactions consumed from structured
+prefetch versus demanded on the serial coordinator path. These counters
+distinguish dependency graphs that expose little parallel work from wide
+frontiers whose work remains slow because of allocation, hashing, query-runtime,
+or synchronization overhead. They describe deterministic graph shape and
+scheduler submissions; they are not elapsed-time or worker-utilization
+estimates.
 
 The display-identity table similarly reports formatted key bytes per token.
 Memo-node identities and abort fallbacks label diagnostics. Structured-wait


### PR DESCRIPTION
Fixes RUE-1350.

Refs RUE-1351.

Adds deterministic body-reachability frontier width and prefetch/serial transaction counters to the compiler scaling contract and report. Counts acquisition rounds that park before final publication, and documents the Harbor/Lattice cold-profile result that identifies anonymous-producer scheduling as the next target.

Validation:
- `scripts/rue fmt`
- `scripts/rue quick`
- release ThinLTO build
- 3-sample Harbor/Lattice matrix at 1 and 10 workers