### PR TITLE
ADR-0070: Rue program compilation as declared Buck actions

### DIFF
--- a/docs/designs/0070-rue-program-build-actions.md
+++ b/docs/designs/0070-rue-program-build-actions.md
@@ -9,7 +9,7 @@ accepted: 2026-08-12
 implemented:
 spec-sections: []
 superseded-by:
-relates: ["RUE-1164", "RUE-1118", "RUE-1222", "RUE-1267", "ADR-0047", "ADR-0051", "ADR-0069"]
+relates: ["RUE-1164", "RUE-1404", "RUE-1405", "RUE-1406", "RUE-1407", "RUE-1408", "RUE-1118", "RUE-1222", "RUE-1267", "ADR-0047", "ADR-0051", "ADR-0069"]
 ---
 
 # ADR-0070: Rue Program Compilation as Declared Buck Actions
@@ -695,7 +695,8 @@ internal CI scheduling and would not ship in a ruleset.
 
 ## Implementation Phases
 
-- [ ] **Phase 0: Rules, scan-derived manifest, audit, controls** — `rue_rules.bzl`
+- [ ] **Phase 0: Rules, scan-derived manifest, audit, controls** — RUE-1404 —
+      `rue_rules.bzl`
       with `rue_program`, `rue_program_test`, `RueProgramInfo`, the three-action
       scan/derive/compile shape, a `RueToolchainInfo` indirection, the declaration
       audit, and the three controls. This phase also settles the rule names while
@@ -703,7 +704,8 @@ internal CI scheduling and would not ship in a ruleset.
       stale-`--prefer-remote` documentation fix noted in the References (RUE-320
       is Done, so `AGENTS.md`'s condition no longer holds). No existing target
       changes.
-- [ ] **Phase 1: Large examples** — convert the six `large-example-*` `sh_test`s
+- [ ] **Phase 1: Large examples** — RUE-1405 — convert the six
+      `large-example-*` `sh_test`s
       over their four roots; each scenario in `scripts/run-large-example.sh`
       becomes its own `rue_program_test`, retiring the script. **The justification
       is not critical-path seconds** — the required path pays only 2.3s + 3.1s of
@@ -714,7 +716,8 @@ internal CI scheduling and would not ship in a ruleset.
       establish the mechanism. This phase owns the positive warm-cache check: a
       relocated or cross-lane second build must show the canary scan and compile
       actions cache-served under multiple consuming scenarios.
-- [ ] **Phase 2: break the weld for CLI cases naming a checked-in root** — the
+- [ ] **Phase 2: break the weld for CLI cases naming a checked-in root** —
+      RUE-1406 — the
       64 cases keep their TOML form and their existing corpus actions; what
       changes is that each CLI corpus action declares the 9 program artifacts as
       inputs and the harness runs the prebuilt executable a case names instead of
@@ -730,11 +733,13 @@ internal CI scheduling and would not ship in a ruleset.
       question 2** — Buck builds each program once, every scenario shares it,
       and warm runs serve the compile from cache, which is RUE-1164's goal met on
       the existing corpus topology.
-- [ ] **Phase 3: Test-result caching decision** — only after the negative controls
-      pass on a real branch. See open question 4. The default — do not enable —
-      stands unless evidence overturns it.
+- [ ] **Phase 3: Test-result caching decision** — RUE-1407 — only after the
+      negative controls pass on a real branch. See open question 4. The default —
+      do not enable — stands unless evidence overturns it.
 
-Linear issues are filed per phase under RUE-1164 once this ADR is accepted.
+Linear issues are filed per phase under RUE-1164: RUE-1404, RUE-1405, RUE-1406
+and RUE-1407, in phase order. The per-file corpus redesign of open question 2 is
+RUE-1408, deliberately outside this sequence.
 
 ## Consequences
 
@@ -858,9 +863,9 @@ declined — afterward without reopening it.
    here, because it is a corpus-topology redesign — it dissolves CLI sharding,
    reaches into the spec and UI corpora, and modifies the harness's whole-corpus
    validation. Recommendation: file it as its own ADR and issue once this one is
-   accepted. Nothing in Phases 0–2 waits on it or forecloses it — per-file
-   actions would consume the same `RueProgramInfo` artifacts Phase 2 wires in,
-   just from finer-grained consumers.
+   accepted — done: RUE-1408. Nothing in Phases 0–2 waits on it or forecloses
+   it — per-file actions would consume the same `RueProgramInfo` artifacts
+   Phase 2 wires in, just from finer-grained consumers.
 
 3. **Do the CLI cases migrate out of TOML, or does the harness consume prebuilt
    artifacts?** Recommendation **reversed** after review: **let the harness
@@ -928,7 +933,8 @@ declined — afterward without reopening it.
 ## Future Work
 
 **Per-file corpus actions (from open question 2 — a separate ADR, not part of
-this one).** Make the corpus action's unit the case TOML file, comprehended from
+this one; tracked as RUE-1408).** Make the corpus action's unit the case TOML
+file, comprehended from
 `glob(["cases/*.toml"])` at load time, each file-target declaring its own TOML
 plus the coarse rare-change inputs; move shard assignment out of the action-key
 domain entirely by letting ADR-0069's lane planner pack the file-targets per run
@@ -978,3 +984,5 @@ approves nor forecloses this; it consumes the same artifacts Phase 2 wires in.
 - `corpus.bzl` — RUE-1118's cacheable corpus actions and their input contract
 - RUE-1164, RUE-1118, RUE-1222, RUE-1267; RUE-320 (remote execution, Done
   2026-07-18); RUE-1083 (the budget kills that disabled the meridian section)
+- RUE-1404 / RUE-1405 / RUE-1406 / RUE-1407 — the Phase 0–3 implementation
+  issues under RUE-1164; RUE-1408 — the per-file corpus ADR from open question 2

--- a/docs/designs/0070-rue-program-build-actions.md
+++ b/docs/designs/0070-rue-program-build-actions.md
@@ -31,10 +31,12 @@ a side effect hidden inside a test process or an aggregate success stamp.
 This ADR proposes two rules and one provider: `rue_program`, which owns exactly
 one compilation and produces the executable; and `rue_program_test`, which
 consumes that executable and runs one runtime scenario. Many scenarios share one
-compile. The manifest that makes the compile hermetic is derived from a cheap
-`--emit deps` scan rather than from the `srcs` glob, because a glob provably
-cannot produce a valid manifest. A granularity rule keeps the action count
-proportionate: a compile becomes its own action when it is expensive relative to
+compile. The source manifest is derived from a cheap `--emit deps` scan rather
+than from the `srcs` glob, because a glob provably cannot produce a valid
+manifest; the derivation step is also where the declared boundary is enforced, by
+failing the build when the compiler read anything outside `srcs`. A granularity
+rule keeps the action count proportionate: a compile becomes its own action when
+it is expensive relative to
 action overhead, or when more than one scenario consumes its output. The ~4,050
 inline-source corpus cases stay inside their harnesses.
 
@@ -59,7 +61,7 @@ pays a cost, not on the absolute seconds.
 | `examples/meridian/canary.rue` full compile | 3.1s |
 | `rue --emit deps` on caldera / meridian | 6.7s / 2.2s — 36x cheaper than compiling |
 | Corpus cases in total | 4,132 (1,778 CLI, 2,109 spec, 245 UI) |
-| CLI cases naming a checked-in root | 73 cases, 13 roots, 17 distinct (root, flags, target) tuples |
+| CLI cases naming a checked-in root | 73 cases, 13 roots, 17 distinct (root, flags, target) tuples — 11 of which become programs |
 | Most-recompiled roots | mosaic 17x, rill 12x, lattice 7x, calculator 7x, meridian 6x, jsonfmt 5x |
 
 **Where those costs are actually paid matters, and it is not where you would
@@ -235,23 +237,55 @@ the two agree by construction. Manifest entries are written absolute so that the
 manifest-relative resolution rule (entries resolve against the manifest file's
 directory, which for a generated manifest is buck-out) cannot misfire.
 
-**This is where the design's hermeticity actually lives, and it needs stating
-precisely.** The scan reads without a manifest, so on a local build it could in
-principle read a file outside `srcs` and quietly launder it into the manifest.
-Two things prevent that, and both are load-bearing rather than optional:
+**The declared standard library is unioned in unconditionally, and it must be.**
+A scan reports only what resolution probed, and `--emit deps` does no semantic
+work — so trusted-std acquisition for fallible intrinsics, which happens only on
+semantic runs, is invisible to it. A four-line program using one fallible
+intrinsic and importing nothing shows the consequence:
 
-- Under remote execution only declared inputs are materialized, so an undeclared
-  read fails outright.
-- The declaration audit below compares the scan's `accepted_reads` against `srcs`
-  and **fails when the compiler read anything the rule did not declare**. That
-  makes the audit part of the mechanism, not a nicety attached to it.
+```text
+$ cat main.rue
+fn main() -> i32 { let p = @parse_i32("41"); 0 }
 
-The compile action then enforces the manifest in-band on every invocation, local
-and remote, cold and warm. `corpus.bzl`'s header warns that under a cached action
-an undeclared input becomes a false pass rather than an untracked re-run; the
-combination above removes that hazard by construction rather than by scheduling.
-This is deliberately stronger than ADR-0069's proposal to treat remote execution
-as the sole undeclared-input detector, which catches only what RE actually runs.
+$ rue main.rue -o prog                                    # no manifest → exit 0
+
+$ rue --emit deps main.rue | derive-manifest              # reports main.rue alone
+$ rue main.rue --source-manifest derived.manifest -o prog
+Hermetic build configuration error: the trusted standard-library module
+'\0rue-std/option.rue' at '.../std/option.rue' is not permitted by the hermetic
+build configuration: the source manifest does not declare this path.   # exit 1
+
+$ rue main.rue --source-manifest with-std.manifest -o prog             # exit 0
+```
+
+Trusted-module acquisition re-checks the manifest before any probe
+(`source_loader.rs:1574-1667`), so a scan-derived manifest without std rejects a
+program that compiles fine without a manifest. Unioning the declared std in is
+not over-declaration of the action key: manifest membership means "available to
+import", not "read" (ADR-0047), and the std filegroup keys the action either way.
+
+### Where hermeticity actually lives, stated precisely
+
+A glob-derived manifest would have encoded the *declared* boundary, so an
+out-of-`srcs` read failed E1400 in-band. A scan-derived manifest encodes what the
+scan *observed* — so on a local build an out-of-`srcs` read would otherwise pass
+scan, land in the manifest, and compile cleanly. Worse, it would be laundered into
+the cache: the scan's key (`srcs` + std + compiler) never mentions the stray file,
+so a later change to it leaves a stale manifest and a stale binary to be
+cache-served. That is exactly `corpus.bzl`'s false-pass hazard, reproduced one
+level down.
+
+**The derivation step therefore enforces the boundary, not a downstream audit.**
+It already reads the envelope; it fails when any accepted read's canonical path
+lies outside `srcs ∪ std`. Under-declaration is then an in-band build failure on
+every build, local and remote, cold and warm — the property a glob-derived
+manifest would have had, recovered on a mechanism that actually works, at the cost
+of a set comparison in a script the rule runs anyway. Remote execution remains a
+second, independent check, because it materializes only declared inputs.
+
+What is left for the standalone audit is over-declaration only, which is a
+cache-precision concern rather than a correctness one. That distinction matters:
+correctness is enforced by construction, and only precision is advisory.
 
 No compiler change is involved: both flags exist and behave correctly today.
 
@@ -270,10 +304,22 @@ overhead, or when more than one scenario consumes its output.**
 | Work | Scale | Disposition | Why |
 | --- | --- | --- | --- |
 | caldera, meridian — `main` and `canary` roots | 4 roots | `rue_program` | `main` is 81–243s; all four are consumed by several scenarios and by more than one suite |
-| CLI cases naming a checked-in root | 73 cases → 17 programs | `rue_program` | 17 distinct (root, flags, target) tuples; the fixture roots in `abi_conformance.toml` and `linker.toml` compile at three `--target`s each and stay three programs |
+| CLI cases naming a checked-in root | 73 cases → 11 programs | `rue_program` | 11 roots each consumed by 4–17 scenarios |
 | Auto-discovered `examples/**` roots not already covered | ~30 | `rue_program` | Reached again by the automatic-examples pass and by frontend-diff |
 | Inline-source CLI / spec / UI cases | ~4,050 | harness | Sources live inside TOML; compiles are milliseconds |
+| Cross-target fixture cases (`abi_conformance.toml`, `linker.toml`) | 6 cases | harness | See below — they fail the rule on both prongs |
+| The one `differential_opt` calculator case | 1 case | harness | Four compiles by design; a compile-*time* differential, same family as reproducibility |
 | Reproducibility fixture | 4 roots | harness | See below — modelling these as actions is self-defeating |
+
+**The rule is applied to itself, including where that costs a row.** An earlier
+draft kept the `abi_conformance.toml` and `linker.toml` fixture roots as six
+programs because they carry an explicit `--target` each. They fail the rule on
+both prongs: `abi_conformance_smoke.rue` is 75 lines and `cross_runtime_smoke.rue`
+is 22, both compile in milliseconds, and each (root, target) tuple is consumed by
+exactly one case. They belong in the harness, and the count they inflated —
+73 cases into 17 programs — is really **11**. A rule that its own table quietly
+exempts things from is not a rule; a reader applying it strictly must get the same
+table.
 
 **The reproducibility suite must stay a harness, and the reason is instructive.**
 Its perturbations are compile-*time* (relocated source roots, mtimes, umask, `-j`,
@@ -289,6 +335,7 @@ the comparison, but the suite must own the second compile itself.
 | Required in the key | Mechanism | Notes |
 | --- | --- | --- |
 | Root source | action input | `attrs.source()` |
+| Cache upload | `allow_cache_upload = True` | on **both** actions; the compile-once-consume-many property depends on the scan and the compile being uploadable, not merely cacheable locally |
 | Transitive imports | action inputs | declared `srcs`; audited below |
 | Source manifest | generated input | scan-derived; changes when any probed path changes |
 | Compiler build | action input | `$(exe_target //crates/rue:rue)`; release vs debug already distinct via `//platforms:*` |
@@ -304,30 +351,34 @@ genuinely hermetic — in-process, with the runtime embedded via `include_bytes!
 so `rue_program` pins it and external linking stays out of scope. Cases that
 exist to test external linkers remain harness cases.
 
-### `--emit deps` as a declaration auditor
+### The over-declaration audit
 
-The manifest makes under-declaration impossible at compile time; the audit makes
-it impossible at scan time and catches over-declaration besides. A
-`rue_program`'s `srcs` glob that is wider than its real read closure takes cache
+Correctness is handled above, in the derivation step. What remains is precision:
+a `rue_program` whose `srcs` glob is wider than its real read closure takes cache
 misses on files it never reads, which turns a precise action back into a corpus
-stamp.
+stamp. Left unchecked, a broad glob undoes the whole point of the rule.
 
-The audit compares the scan envelope's `accepted_reads` against `srcs` in both
-directions. Three constraints on how, all of which matter:
+Three constraints on how the comparison is done, all of which matter:
 
 - Compare **path and fingerprint sets, never envelope bytes**: the envelope
   embeds device/inode identity and mtimes (`dependency_envelope.rs:320-331`) and
   is not machine-stable.
 - Compare against `srcs`, **not** the generated manifest — the manifest
-  legitimately contains absent-arm entries that are never read.
-- `accepted_reads` is the observed read set *of that run*; trusted-std
-  acquisition for fallible intrinsics happens only on semantic runs, so a program
-  that reaches std without `@import("std")` can read std files at compile time
-  that a scan does not list. The audit is `srcs`-scoped, so this is harmless, but
-  the envelope should not be described as a complete read set.
+  legitimately contains absent-arm entries and the whole std tree, none of which
+  need be read.
+- `accepted_reads` is the observed read set *of that scan*, not a complete
+  compile-time read set — trusted-std acquisition is invisible to it, as above.
+  Treat std as always-declared rather than inferring it from the envelope.
 
-Because the scan is already an action of `rue_program`, the audit is an assertion
-over an artifact the rule produces anyway rather than a separate compile.
+**Attach it with `ValidationInfo` rather than as a separate test target.** The
+pinned 2026-07-15 buck2 ships it and the bundled prelude already uses it (java,
+kotlin, apple). A validation attached to a target runs whenever that target is
+transitively reachable from any requested build or test, in parallel with the
+build, and a failed required validation fails the build. That is precisely the
+shape of "an assertion over an artifact the rule produces anyway", and it
+dissolves the question an earlier draft had to ask — which tier do ~50 audit
+targets carry, given every compiler change invalidates all of them — rather than
+answering it. There are no audit targets to schedule.
 
 ### Negative controls
 
@@ -360,8 +411,9 @@ strictly.
 - [ ] **Phase 0: Rules, scan-derived manifest, audit, controls** — `rue_rules.bzl`
       with `rue_program`, `rue_program_test`, `RueProgramInfo`, the two-action
       scan/compile shape, the declaration audit, and the three controls. Also the
-      stale-`--prefer-remote` documentation fix (see open questions). No existing
-      target changes.
+      stale-`--prefer-remote` documentation fix noted in the References (RUE-320
+      is Done, so `AGENTS.md`'s condition no longer holds). No existing target
+      changes.
 - [ ] **Phase 1: Large examples** — convert the six `large-example-*` `sh_test`s
       over their four roots; each scenario in `scripts/run-large-example.sh`
       becomes its own `rue_program_test`, retiring the script. **The justification
@@ -371,9 +423,10 @@ strictly.
       the scheduled release lane stops paying 243.0s and 80.7s twice when both the
       slow and stress tiers run; and these are the clearest targets on which to
       establish the mechanism.
-- [ ] **Phase 2: CLI cases naming a checked-in root** — 73 cases into 17
+- [ ] **Phase 2: CLI cases naming a checked-in root** — 73 cases into 11
       programs, meridian's six first, which is where the disabled coverage is
-      restored. Depends on open question 3.
+      restored. The six cross-target fixture cases and the one `differential_opt`
+      case stay in the harness. Depends on open question 3.
 - [ ] **Phase 3: Corpus input precision** — see open question 2; this phase is
       *not* specified here, because the obvious version of it does not work.
 - [ ] **Phase 4: Test-result caching decision** — only after the negative controls
@@ -390,7 +443,10 @@ Linear issues are filed per phase under RUE-1164 once this ADR is accepted.
 - Coverage disabled by RUE-1083 becomes affordable again, which is a correctness
   gain rather than a speed one.
 - Undeclared inputs become build failures everywhere rather than only where RE
-  runs, and the declaration audit closes the scan's laundering hole.
+  runs — but only because the derivation step enforces `srcs` itself. That
+  property belonged to the glob-derived manifest of an earlier draft; on the
+  scan-derived mechanism it has to be put back deliberately, and it is easy to
+  lose again if derivation is ever simplified to "just write what the scan saw".
 - Scenarios become individually selectable and schedulable targets, which is the
   "split" remedy in RUE-1267's alarm.
 - ADR-0047 Phases 3 and 4 acquire their first consumer, and the design needs both
@@ -401,10 +457,9 @@ Linear issues are filed per phase under RUE-1164 once this ADR is accepted.
 - `rue_program` is two actions and a `dynamic_output`, not one action. The scan is
   36x cheaper than the compile, but it is not free, and it runs on every cache
   miss.
-- The declaration audit is load-bearing rather than advisory, which means a target
-  that must stay green. Each audit is invalidated by every compiler change — the
-  ~74.5% class — so audit tier assignment is a real scheduling question, not a
-  formality.
+- Correctness now depends on a derivation script, not only on rule wiring. A bug
+  there is a hermeticity bug, so it needs its own unit coverage — the negative
+  controls exercise it end to end but will not pin its set arithmetic.
 - Migrating the 73 cases splits the CLI authoring surface between two mechanisms
   during Phases 2 and 3.
 - Migrated targets **escape** RUE-924's corpus-omission audit rather than break

--- a/docs/designs/0070-rue-program-build-actions.md
+++ b/docs/designs/0070-rue-program-build-actions.md
@@ -1,11 +1,11 @@
 ---
 id: 0070
 title: "Rue program compilation as declared Buck actions"
-status: proposal
+status: accepted
 tags: [build, ci, testing, tooling]
 feature-flag: null
 created: 2026-08-11
-accepted:
+accepted: 2026-08-12
 implemented:
 spec-sections: []
 superseded-by:
@@ -16,13 +16,13 @@ relates: ["RUE-1164", "RUE-1118", "RUE-1222", "RUE-1267", "ADR-0047", "ADR-0051"
 
 ## Status
 
-Proposal. This is the reviewed design RUE-1164 asks for and ADR-0069 Phase 5
-defers to. Nothing here is implemented. The granularity rule under "Which
-compiles become actions" and the four items under "Open questions" are maintainer
-decisions rather than settled design; each open question now carries a
-recommendation and its evidence. Question 2's proposal is large enough to deserve
-its own ADR and issue, and — after review — it no longer gates any phase here:
-question 3's recommendation stands on the existing corpus actions alone.
+Accepted. This is the reviewed design RUE-1164 asks for and ADR-0069 Phase 5
+defers to. Nothing here is implemented yet. All four recommendations under "Open
+questions" were accepted with the ADR, scoped to the initial implementation:
+hybrid target resolution (1), per-file corpus actions deferred to their own ADR
+and issue (2), the harness consuming prebuilt artifacts on the existing corpus
+actions (3), and test-result caching off (4). Question 2's proposal gates no
+phase here and is neither approved nor foreclosed by this acceptance.
 
 ## Summary
 
@@ -799,9 +799,12 @@ Linear issues are filed per phase under RUE-1164 once this ADR is accepted.
 
 ## Open Questions
 
-All four carry a recommendation now, and three of them changed after review. They
-remain maintainer decisions: RUE-1164 is labelled `needs-decision`, and questions
-2 and 3 in particular reach beyond what this ADR can settle on its own.
+All four carried a recommendation at acceptance, and three of them changed under
+review. With this ADR's acceptance the recommendations below are the decisions,
+scoped to the initial implementation — question 2 by deferral to its own ADR and
+issue, and question 4 as a default that stands unless evidence overturns it. The
+reasoning is kept in full because it is the record of why each answer is what it
+is.
 
 **Questions 2 and 3 are related but no longer coupled.** An earlier draft
 decided them together, on the theory that per-file corpus actions were what made
@@ -865,7 +868,7 @@ declined — afterward without reopening it.
    existing corpus actions alone rather than conditionally on question 2.
 
    The defect Phase 2 fixes is the weld between compile and scenario, not the
-   TOML. Handing the 65 scenarios a prebuilt executable fixes exactly that;
+   TOML. Handing the 64 scenarios a prebuilt executable fixes exactly that;
    migrating them additionally relocates the authoring surface — by this
    document's own assessment the largest-blast-radius change in it — to buy
    per-scenario CI selection whose value stays speculative until RUE-1267's packer
@@ -881,11 +884,11 @@ declined — afterward without reopening it.
    rather than extended, and avoids a two-mechanism transition entirely.
 
    The mechanism needs nothing question 2 would build. Each existing CLI corpus
-   action declares all ten program artifacts through its `attrs.arg()` env — the
+   action declares all nine program artifacts through its `attrs.arg()` env — the
    same `$(location ...)` contract every other corpus input already uses — and
    the harness runs the artifact a case names. The simplest correct form declares
-   all ten on every CLI corpus action; that is a mild over-declaration of each
-   action's key (an edit to any of the ten roots re-runs all the CLI corpus
+   all nine on every CLI corpus action; that is a mild over-declaration of each
+   action's key (an edit to any of the nine roots re-runs all the CLI corpus
    actions — which is also true today, since the roots live inside the declared
    `:examples` filegroup), and it fails closed, since a case whose program is
    missing from the staging environment cannot run. If question 2's per-file

--- a/docs/designs/0070-rue-program-build-actions.md
+++ b/docs/designs/0070-rue-program-build-actions.md
@@ -42,8 +42,9 @@ envelope's absolute paths are re-anchored so that a shared scan-cache hit is not
 build failure on another machine. A granularity
 rule keeps the action count proportionate: a compile becomes its own action when
 it is expensive relative to action overhead, or when more than one scenario
-consumes its output. That yields 13 programs; the 34 auto-discovered example
-smokes and the ~4,050 inline-source corpus cases stay inside their harnesses.
+consumes its output. That yields 12 programs; the 34 auto-discovered example
+smokes, the one-scenario wordfreq root, and the ~4,050 inline-source corpus
+cases stay inside their harnesses.
 
 No compiler change is required. ADR-0047 Phases 3 and 4 (`--source-manifest`,
 `--emit deps`) are implemented and currently unconsumed; this design is their
@@ -68,7 +69,7 @@ pays a cost, not on the absolute seconds.
 | Corpus cases in total | 4,132 (1,778 CLI, 2,109 spec, 245 UI) |
 | CLI cases naming a checked-in root | 73 cases, 13 roots (10 example + 3 fixture), 17 distinct (root, flags, target) tuples |
 | Most-recompiled roots | mosaic 17x, rill 12x, lattice 7x, calculator 7x, meridian 6x, jsonfmt 5x |
-| Distinct `rue_program` targets proposed | 13 (4 large-example + 9 CLI) |
+| Distinct `rue_program` targets proposed | 12 (4 large-example + 8 CLI) |
 
 **Where those costs are actually paid matters, and it is not where you would
 guess.** The 243.0s and 80.7s figures are `main.rue` compiles, which occur only in
@@ -174,9 +175,9 @@ back `absent`, with the path that was requested).
 RueProgramInfo = provider(fields = [
     "executable",      # the compiled artifact
     "root",
-    "rue_target",      # x86-64-linux | aarch64-linux | aarch64-macos
+    "rue_target",      # the RESOLVED target: x86-64-linux | aarch64-linux | aarch64-macos
     "opt_level",
-    "runs_natively",   # False for a cross-target program
+    "runs_natively",   # resolved target == configured platform's target
 ])
 
 # Mechanism internals, deliberately NOT in the consumer-facing provider.
@@ -186,8 +187,10 @@ rue_program(
     name       = "meridian",
     root       = "examples/meridian/main.rue",
     srcs       = glob(["examples/meridian/**/*.rue"]),   # the declared read bound
-    rue_target = "x86-64-linux",
-    # compiler, std and default flags arrive as one resolved unit:
+    # No rue_target: the native target is resolved from the configured platform
+    # via the toolchain. Setting rue_target explicitly means intentional
+    # cross-compilation. Compiler, std, default flags and the platform's native
+    # target arrive as one resolved unit:
     # _toolchain = attrs.toolchain_dep(default = "toolchains//:rue")
 )
 
@@ -208,6 +211,21 @@ deliberately malformed* rather than checked-in files, so the rule needs a `files
 mechanism of its own rather than only a `data` attribute pointing at repository
 paths. And several programs write output through relative paths, so the scenario
 needs a **writable working directory**, which a read-only runfiles tree is not.
+
+**Target resolution is hybrid: platform-derived by default, attribute on
+purpose.** The same target labels must build and run natively on all three CI
+platforms — Linux x86-64, Linux AArch64, macOS AArch64 — exactly as today's
+`sh_test`s do by never passing `--target` at all. A hardcoded
+`rue_target = "x86-64-linux"` (which an earlier draft's example showed) cannot
+run on two of the three, and per-architecture target labels would multiply the
+program count by platform. So: `RueToolchainInfo` carries the configured
+platform's native Rue target, resolved the same way `toolchains//:rust` already
+resolves per platform; a `rue_program` that sets no `rue_target` compiles for
+that native target; setting `rue_target` explicitly is intentional
+cross-compilation. `runs_natively` is computed — resolved target equals the
+configured platform's target — never asserted. The acceptance criterion that the
+target architecture keys the action is met either way, because the resolved
+target appears on the compile command line.
 
 For `test_tiers.bxl` discovery to keep working the rule must satisfy two
 conditions explicitly, not incidentally: its name must keep the `_test` suffix so
@@ -374,7 +392,8 @@ overhead, or when more than one scenario consumes its output.**
 | Work | Scale | Disposition | Why |
 | --- | --- | --- | --- |
 | caldera, meridian — `main` and `canary` roots | 4 roots | `rue_program` | `main` is 81–243s; all four are consumed by several scenarios and by more than one suite |
-| CLI cases naming a checked-in root | 65 cases → 10 roots, **9 new programs** | `rue_program` | 1–17 TOML scenarios each, and every premerge case executes in both its CI shard and the unsharded `//:cli-tests`, so even a one-case root's artifact has more than one consuming action; `examples/meridian/main.rue` is the tenth root and is already declared by the row above |
+| CLI cases naming a checked-in root | 64 cases → 9 roots, **8 new programs** | `rue_program` | 3–17 TOML scenarios each consume one artifact; `examples/meridian/main.rue` is the ninth root and is already declared by the row above |
+| The one-scenario wordfreq root | 1 case | harness | See below — one cheap scenario; shard/monolith is a scheduling alternative, not a second consumer |
 | Auto-discovered `examples/**` roots not already covered | 34 | harness | See below — every one fails the rule on both prongs |
 | Inline-source CLI / spec / UI cases | ~4,050 | harness | Sources live inside TOML; compiles are milliseconds |
 | Cross-target fixture cases (`abi_conformance.toml`, `linker.toml`) | 6 cases | harness | See below — they fail the rule on both prongs |
@@ -396,12 +415,24 @@ own repo-root-relative `source_path` resolution (`source_path.toml:6-10`,
 RUE-495). Rewritten as a `rue_program_test` it would no longer test anything: its
 subject *is* the TOML mechanism it would be leaving.
 
-So 8 of the 73 cases stay in the harness (6 cross-target, 1 repo-relative, 1
-differential), 65 migrate, and they name 10 roots. Only **9** are new programs:
-`examples/meridian/main.rue` is also a large-example root, so one artifact serves
-both the six CLI scenarios and the slow-tier scenarios. That overlap is the design
-working rather than an accounting nuisance — it is exactly the "many scenarios,
-one compile" property, reaching across two suites.
+**wordfreq fell to the same rule on this round's re-check.** An earlier draft
+kept `examples/wordfreq/main.rue` (one case) as a program on the grounds that
+each premerge case appears in both its CI shard and the unsharded `//:cli-tests`.
+Those two targets are scheduling *alternatives* — CI's platform-corpus matrix
+runs the shards, a local `./test.sh` runs the monolith and excludes
+`rue_cli_shard` (`test.sh:108-139`) — so they are one scenario scheduled two
+ways, not two consumers, and counting them as two would silently rewrite the
+rule from "more than one scenario" to "more than one consuming action
+definition". One cheap scenario, one consumer: wordfreq compiles inside the
+corpus action that runs its case, like any other single-scenario root. The
+remaining eight CLI roots all carry 3–17 TOML scenarios against one artifact.
+
+So 9 of the 73 cases stay compile-in-harness (6 cross-target, 1 repo-relative, 1
+differential, 1 wordfreq), 64 migrate, and they name 9 roots. Only **8** are new
+programs: `examples/meridian/main.rue` is also a large-example root, so one
+artifact serves both the six CLI scenarios and the slow-tier scenarios. That
+overlap is the design working rather than an accounting nuisance — it is exactly
+the "many scenarios, one compile" property, reaching across two suites.
 
 **The 34 auto-discovered roots fail the rule the same way, and an earlier draft
 counted them as programs anyway.** `collect_example_files` yields 45 roots; 10
@@ -439,7 +470,8 @@ the comparison, but the suite must own the second compile itself.
 | Source manifest | generated input | scan-derived; changes when any probed path changes |
 | Compiler build | toolchain input | `RueToolchainInfo.compiler`, internally defaulting to `$(exe_target //crates/rue:rue)`; release vs debug already distinct via `//platforms:*` |
 | Standard library | toolchain input | `RueToolchainInfo.std`, internally defaulting to `//:std` |
-| Compiler flags | command line | `-O`, `--preview`, `--target` |
+| Compiler flags | command line | `-O`, `--preview` |
+| Target architecture | command line | `--target`, always passed explicitly with the *resolved* target — platform-derived default or deliberate `rue_target` override — so the key never depends on host detection |
 | Linked archives | **action inputs** | `--link-archive` bytes are read at link time, so the flag must carry a `$(location ...)` input, not a bare path string |
 | Linker | pinned | `rue_program` pins `--linker internal`; see below |
 | Runtime inputs | test-target inputs | `files`, `data`, `stdin`, `program_env` on `rue_program_test` |
@@ -492,10 +524,24 @@ Three constraints on how the comparison is done, all of which matter:
   non-empty per target. The signal worth reporting is directory-scoped: a file
   that no program whose `srcs` contain it ever reads is dead weight in every
   key it touches; a file read by one sibling and carried by another is the
-  glob doing its job.
+  glob doing its job. **A per-target validation cannot compute that signal** —
+  it sees one program's envelope and would report `canary.rue` against `main`
+  as a known false positive — so the directory signal lives on an aggregate.
 
-**Attach it with `ValidationInfo`, marked `optional`, rather than as a separate
-test target.** The pinned 2026-07-15 buck2 ships it and the bundled prelude
+**The aggregate is explicit, not discovered.** Sibling `rue_program`s that share
+a directory glob are declared by one macro call (`rue_program_family`, or simply
+the same BUCK package block), and that call also emits one
+`<dir>-srcs-report` aggregate whose deps are exactly those siblings. The
+aggregate reads each sibling's `_RueProgramInternalInfo.deps_envelope`, unions
+the accepted-read sets, and reports files of the shared glob that **no** sibling
+reads. Ownership is the macro's argument list — a rule cannot discover its
+siblings, and this design does not ask it to. A `rue_program` declared outside
+any family still carries a strictly target-local report, explicitly labelled as
+listing *extras* rather than classifying them as dead weight, since one
+target's view cannot make that call.
+
+**Attach the reports with `ValidationInfo`, marked `optional`, rather than as
+separate test targets.** The pinned 2026-07-15 buck2 ships it and the bundled prelude
 already uses it (java, kotlin, apple); its `ValidationSpec` carries an `optional`
 field, and optional validations do not run by default — they are selected with
 `--enable-optional-validations`. That is exactly the advisory shape: the report
@@ -669,29 +715,24 @@ internal CI scheduling and would not ship in a ruleset.
       relocated or cross-lane second build must show the canary scan and compile
       actions cache-served under multiple consuming scenarios.
 - [ ] **Phase 2: break the weld for CLI cases naming a checked-in root** — the
-      65 cases keep their TOML form and their existing corpus actions; what
-      changes is that each CLI corpus action declares the 10 program artifacts as
+      64 cases keep their TOML form and their existing corpus actions; what
+      changes is that each CLI corpus action declares the 9 program artifacts as
       inputs and the harness runs the prebuilt executable a case names instead of
       compiling it. The wiring already exists: `cached_corpus_suite`'s `env` is
       `attrs.arg()`, so the artifacts arrive through `$(location ...)` exactly
       like every other declared corpus input, and an artifact edit invalidates
       the consuming corpus actions correctly. Meridian's six scenarios come
       first, which is where the disabled coverage is restored. The 6 cross-target
-      fixture cases, the repo-relative fixture case, and the one
-      `differential_opt` case stay compile-in-harness regardless. **This phase
+      fixture cases, the repo-relative fixture case, the one `differential_opt`
+      case, and the one-scenario wordfreq case stay compile-in-harness
+      regardless. **This phase
       requires no sharding change, no TOML migration, and no decision on open
       question 2** — Buck builds each program once, every scenario shares it,
       and warm runs serve the compile from cache, which is RUE-1164's goal met on
       the existing corpus topology.
-- [ ] **Phase 3: Corpus input precision — deliberately not a phase.** Open
-      question 2's per-file proposal is a corpus-topology redesign: it dissolves
-      CLI sharding, reaches into the spec and UI corpora, and modifies the
-      harness's whole-corpus validation. It is filed as its own ADR and issue
-      once this one is accepted, and nothing in Phases 0–2 waits on it or
-      forecloses it — per-file actions would consume the same `RueProgramInfo`
-      artifacts Phase 2 wires in, just from finer-grained consumers.
-- [ ] **Phase 4: Test-result caching decision** — only after the negative controls
-      pass on a real branch. See open question 4.
+- [ ] **Phase 3: Test-result caching decision** — only after the negative controls
+      pass on a real branch. See open question 4. The default — do not enable —
+      stands unless evidence overturns it.
 
 Linear issues are filed per phase under RUE-1164 once this ADR is accepted.
 
@@ -769,93 +810,54 @@ way: question 3's recommendation works on the existing corpus actions as they
 stand, and question 2 is a separate, larger decision that can be taken — or
 declined — afterward without reopening it.
 
-1. **Target architecture: attribute or configuration?** Recommendation: **a plain
-   attribute**, on a stronger argument than the one an earlier draft gave. That
-   draft cited the `abi_conformance`/`linker` fixtures as wanting all three
-   targets side by side in one package; the granularity repair moved those to the
-   harness, so no proposed `rue_program` needs side-by-side targets today, and the
-   example is now about keeping the door open rather than serving a consumer.
+1. **Target architecture.** Recommendation, revised once more after review:
+   **hybrid** — platform-derived by default, attribute only for intentional
+   cross-compilation. An earlier draft recommended a bare attribute, and its own
+   example (`rue_target = "x86-64-linux"`) refuted it: the same target labels
+   must build and run natively on all three CI platforms, exactly as today's
+   `sh_test`s do by never passing `--target` at all. A fixed attribute cannot; a
+   per-architecture label triples the program count; leaving the flag off and
+   trusting host detection would leave an acceptance-criterion input implicit.
+   So the platform supplies the default — `RueToolchainInfo` carries the
+   configured platform's native Rue target, resolved like `toolchains//:rust`
+   already is — and the compile always passes the *resolved* target explicitly.
 
-   The principled argument is that **Rue's read closure is target-invariant by
-   construction.** `ImportDiscoveryContext::new` takes epoch, project root, std
-   root and policy revision — and no target (`source_loader.rs:1004-1013`) — and
-   `@import` has no conditional form, so `--target` cannot change which sources a
-   program reads. Buck configurations exist to vary the dependency graph per
-   platform; for `rue_program` there is provably nothing for a configuration to
-   vary, and the whole difference between two targets' compiles is one
-   command-line flag that keys the action as an attribute at zero cost.
+   What survives from the earlier argument, and still matters: **Rue's read
+   closure is target-invariant by construction.** `ImportDiscoveryContext::new`
+   takes epoch, project root, std root and policy revision — and no target
+   (`source_loader.rs:1004-1013`) — and `@import` has no conditional form, so
+   `--target` cannot change which sources a program reads. That is why no
+   configuration *transition* is needed: there is no target-variant dependency
+   graph to request, and it is why one scan action serves every target of a
+   root. The configuration's only job here is supplying the native default,
+   which toolchain resolution already does.
 
-   **The expiry clause has three conditions, not one.** Target-invariance covers
-   the *dependency graph*; it does not by itself cover *inputs*. Revisit if Rue
-   grows target-dependent imports (which ADR-0047's model forbids); if a
-   `rue_program` ever links an archive that another rule **builds**, since a plain
-   attribute cannot request a dep in the matching configuration and that is
-   precisely what transitions are for; or on **publication**, since
-   `platform()`-driven cross-compilation is the idiom external users expect
-   (rules_go spent years migrating off goos/goarch attributes for exactly this).
-   Nothing bites today: the only archive-linking cases are the `c_ffi` inline-source
-   cases, whose archive the harness *synthesizes* per case to match the case's
-   `executable_target` (`crates/rue-cli-tests/src/main.rs:1949-1971`) rather than
-   checking one in. Note that this is already a target-variant generated input —
-   it simply lives inside the harness instead of the build graph, so the day it
-   becomes a Buck-built artifact is the day the second condition fires. The
-   recommendation still stands either way: an internal attribute forecloses
-   nothing, because the attribute can become a transition's output.
+   **The expiry clause: native resolution applies today; two conditions remain
+   for transitions.** Revisit the no-transition stance if a `rue_program` ever
+   links an archive that another rule **builds**, since an attribute cannot
+   request a dep in the matching configuration and that is precisely what
+   transitions are for; or on **publication**, since `platform()`-driven
+   cross-compilation is the idiom external users expect (rules_go spent years
+   migrating off goos/goarch attributes for exactly this). The first is one
+   refactor away, not hypothetical: the `c_ffi` cases' FFI archive is already a
+   target-variant *generated* input, synthesized per case inside the harness to
+   match the case's `executable_target`
+   (`crates/rue-cli-tests/src/main.rs:1949-1971`); the day it becomes a
+   Buck-built artifact is the day the condition fires. The hybrid forecloses
+   nothing either way: the override attribute can become a transition's output.
 
-2. **Corpus input precision — a proposal, replacing the three options an earlier
-   draft could not choose between.** The root problem is that the current design
-   couples a *scheduling* concern (which shard runs a case, a function of
-   `shard-weights.json`) into a *correctness* concern (what keys an action). All
-   three earlier options managed that coupling; none removed it.
-
-   Recommendation: **make the corpus action's unit the case file, and move shard
-   assignment up into the lane planner.**
-
-   - One corpus action per case TOML, comprehended from `glob(["cases/*.toml"])`
-     at load time — derived from the tree, so there is no hand-maintained mapping
-     and nothing to gate, which meets ADR-0069's ledger standard by construction.
-     Each file-target declares its own TOML plus the coarse rare-change inputs
-     (compiler, harness, std, fixture and example trees). A case edit then
-     invalidates exactly one action, while a compiler or fixture change still
-     invalidates everything, which is correct.
-   - **`shard-weights.json` leaves the key domain entirely.** ADR-0069 Phase 2's
-     planner (implemented and gated) generates the lane split by packing the
-     file-targets with the existing weights, regenerated per run and never
-     persisted — so stale weights can only unbalance a lane, never affect
-     correctness. Coverage stays ADR-0069's union gate. RUE-1267's floor-aware
-     packer replaces the interim packing when it lands, and the ordering is
-     consistent with ADR-0069 having deliberately scheduled that packer after the
-     distribution stops changing: this conversion *is* the distribution change.
-   - **What it deletes:** `CliShardPlan` and the LPT code in
-     `crates/rue-cli-tests/src/sharding.rs`, `CLI_TEST_SHARD_COUNT`,
-     `scripts/validate-cli-shard-coverage.py`, and the skew guard ADR-0069 §6
-     proved vacuous. RUE-1222's scheduled weight refresh becomes free: today it
-     would invalidate every shard action; afterward it touches no action key.
-   - A heavyweight file that dominates a lane is RUE-1267's indivisible-item alarm
-     firing with a mechanical remedy — split the TOML, an ordinary authoring act.
-
-   Two costs, both verified, both belonging in the decision rather than in a
-   footnote. **Scale:** ~323 file-actions repo-wide — 214 CLI, 71 spec, 38 UI,
-   since spec and UI declare whole `cases/**` filegroups today too
-   (`crates/rue-spec/BUCK`, `crates/rue-ui-tests/BUCK`) — at roughly 8–13 cases
-   each. That sits above action overhead, and if it is judged too fine the same
-   mechanism works at directory granularity (spec already has 10 subdirectories);
-   the dial is grouping, not design. **One real harness change:** contract-graph
-   validation deliberately runs against the complete unfiltered inventory before
-   any filter is applied (`crates/rue-cli-tests/src/main.rs:2876-2878`), so a
-   per-file action staged with only its own TOML needs a mode that relaxes
-   cross-file checks, with contract completeness, duplicate-name detection and
-   RUE-924-style counting moving to one whole-corpus parse-only validation target
-   whose coarse key is fine because it costs seconds.
-
-   **Scope caveat, and the reason this stays open.** This is a larger change than
-   "a phase of RUE-1164": it dissolves CLI sharding, reaches into the spec and UI
-   corpora, and modifies the harness — roughly 323 actions against the ~13 this
-   ADR otherwise creates. It is a good answer to the question, but it is its own
-   ADR and issue, filed after this one is accepted, and **it does not gate any
-   phase here**: Phase 2 meets RUE-1164 on the existing shard topology, and
-   per-file actions would consume the same artifacts from finer-grained
-   consumers.
+2. **Corpus input precision.** The insight that survived four rounds: a
+   *scheduling* concern — which shard runs a case, a function of
+   `shard-weights.json` — currently keys the corpus actions, and no amount of
+   input-tightening removes that coupling while the shard is the action unit.
+   The concrete proposal (per-file corpus actions; shard assignment moved up
+   into ADR-0069's lane planner) is recorded under **Future Work** rather than
+   here, because it is a corpus-topology redesign — it dissolves CLI sharding,
+   reaches into the spec and UI corpora, and modifies the harness's whole-corpus
+   validation. Recommendation: file it as its own ADR and issue once this one is
+   accepted. Nothing in Phases 0–2 waits on it or forecloses it — per-file
+   actions would consume the same `RueProgramInfo` artifacts Phase 2 wires in,
+   just from finer-grained consumers.
 
 3. **Do the CLI cases migrate out of TOML, or does the harness consume prebuilt
    artifacts?** Recommendation **reversed** after review: **let the harness
@@ -919,6 +921,24 @@ declined — afterward without reopening it.
    to be re-asserted (`--nocache_test_results`) rather than merely maintained.
    Deciding it here does not decide it there, and a port that assumes otherwise
    flips the answer silently.
+
+## Future Work
+
+**Per-file corpus actions (from open question 2 — a separate ADR, not part of
+this one).** Make the corpus action's unit the case TOML file, comprehended from
+`glob(["cases/*.toml"])` at load time, each file-target declaring its own TOML
+plus the coarse rare-change inputs; move shard assignment out of the action-key
+domain entirely by letting ADR-0069's lane planner pack the file-targets per run
+with the existing weights. A case edit then invalidates one action; a stale
+weight can unbalance a lane but never affect correctness; `CliShardPlan`,
+`CLI_TEST_SHARD_COUNT`, `validate-cli-shard-coverage.py` and the vacuous skew
+guard are deleted; RUE-1222's weight refresh stops invalidating anything. Two
+priced costs carry over with it: ~323 file-actions repo-wide (214 CLI, 71 spec,
+38 UI; directory granularity is the dial if too fine), and contract-graph
+validation — which deliberately runs against the complete unfiltered inventory
+(`crates/rue-cli-tests/src/main.rs:2876-2878`) — needs a relaxed per-file mode
+plus one whole-corpus parse-only validation target. Accepting ADR-0070 neither
+approves nor forecloses this; it consumes the same artifacts Phase 2 wires in.
 
 ## Non-Goals
 

--- a/docs/designs/0070-rue-program-build-actions.md
+++ b/docs/designs/0070-rue-program-build-actions.md
@@ -36,9 +36,9 @@ than from the `srcs` glob, because a glob provably cannot produce a valid
 manifest; the derivation step is also where the declared boundary is enforced, by
 failing the build when the compiler read anything outside `srcs`. A granularity
 rule keeps the action count proportionate: a compile becomes its own action when
-it is expensive relative to
-action overhead, or when more than one scenario consumes its output. The ~4,050
-inline-source corpus cases stay inside their harnesses.
+it is expensive relative to action overhead, or when more than one scenario
+consumes its output. That yields 47 programs; the ~4,050 inline-source corpus
+cases stay inside their harnesses.
 
 No compiler change is required. ADR-0047 Phases 3 and 4 (`--source-manifest`,
 `--emit deps`) are implemented and currently unconsumed; this design is their
@@ -61,8 +61,9 @@ pays a cost, not on the absolute seconds.
 | `examples/meridian/canary.rue` full compile | 3.1s |
 | `rue --emit deps` on caldera / meridian | 6.7s / 2.2s — 36x cheaper than compiling |
 | Corpus cases in total | 4,132 (1,778 CLI, 2,109 spec, 245 UI) |
-| CLI cases naming a checked-in root | 73 cases, 13 roots, 17 distinct (root, flags, target) tuples — 11 of which become programs |
+| CLI cases naming a checked-in root | 73 cases, 13 roots (10 example + 3 fixture), 17 distinct (root, flags, target) tuples |
 | Most-recompiled roots | mosaic 17x, rill 12x, lattice 7x, calculator 7x, meridian 6x, jsonfmt 5x |
+| Distinct `rue_program` targets proposed | 47 (4 large-example + 9 CLI + 34 auto-discovered) |
 
 **Where those costs are actually paid matters, and it is not where you would
 guess.** The 243.0s and 80.7s figures are `main.rue` compiles, which occur only in
@@ -278,7 +279,7 @@ level down.
 **The derivation step therefore enforces the boundary, not a downstream audit.**
 It already reads the envelope; it fails when any accepted read's canonical path
 lies outside `srcs ∪ std`. Under-declaration is then an in-band build failure on
-every build, local and remote, cold and warm — the property a glob-derived
+every build that re-runs the scan, local and remote — the property a glob-derived
 manifest would have had, recovered on a mechanism that actually works, at the cost
 of a set comparison in a script the rule runs anyway. Remote execution remains a
 second, independent check, because it materializes only declared inputs.
@@ -304,22 +305,37 @@ overhead, or when more than one scenario consumes its output.**
 | Work | Scale | Disposition | Why |
 | --- | --- | --- | --- |
 | caldera, meridian — `main` and `canary` roots | 4 roots | `rue_program` | `main` is 81–243s; all four are consumed by several scenarios and by more than one suite |
-| CLI cases naming a checked-in root | 73 cases → 11 programs | `rue_program` | 11 roots each consumed by 4–17 scenarios |
-| Auto-discovered `examples/**` roots not already covered | ~30 | `rue_program` | Reached again by the automatic-examples pass and by frontend-diff |
+| CLI cases naming a checked-in root | 65 cases → 10 roots, **9 new programs** | `rue_program` | 1–17 TOML scenarios each, *plus* the automatic-examples and frontend-diff passes; `examples/meridian/main.rue` is the tenth root and is already declared by the row above |
+| Auto-discovered `examples/**` roots not already covered | 34 | `rue_program` | Derived exactly: `collect_example_files` yields 45 roots, less the 10 named above and caldera's |
 | Inline-source CLI / spec / UI cases | ~4,050 | harness | Sources live inside TOML; compiles are milliseconds |
 | Cross-target fixture cases (`abi_conformance.toml`, `linker.toml`) | 6 cases | harness | See below — they fail the rule on both prongs |
+| The repo-relative `source_path` fixture case | 1 case | harness | See below — its subject *is* the TOML mechanism |
 | The one `differential_opt` calculator case | 1 case | harness | Four compiles by design; a compile-*time* differential, same family as reproducibility |
-| Reproducibility fixture | 4 roots | harness | See below — modelling these as actions is self-defeating |
+| Reproducibility fixture | — | harness | See below — modelling these as actions is self-defeating |
 
-**The rule is applied to itself, including where that costs a row.** An earlier
-draft kept the `abi_conformance.toml` and `linker.toml` fixture roots as six
-programs because they carry an explicit `--target` each. They fail the rule on
-both prongs: `abi_conformance_smoke.rue` is 75 lines and `cross_runtime_smoke.rue`
-is 22, both compile in milliseconds, and each (root, target) tuple is consumed by
-exactly one case. They belong in the harness, and the count they inflated —
-73 cases into 17 programs — is really **11**. A rule that its own table quietly
-exempts things from is not a rule; a reader applying it strictly must get the same
-table.
+**The rule is applied to itself, including where that costs a row.** Successive
+drafts of this table said 17 programs, then 11, then 10. All three were wrong in
+the same way — the rule was stated and then quietly not applied — so every count
+above has now been re-derived from the tree rather than adjusted.
+
+The three `cli-test-fixtures/` roots all fail the rule on both prongs.
+`abi_conformance_smoke.rue` is 75 lines and `cross_runtime_smoke.rue` is 22; both
+compile in milliseconds, and each (root, target) tuple is consumed by exactly one
+case. `repo_relative_source_path.rue` is one file with one case — and it could not
+migrate even if it were expensive, because that case exists to test the harness's
+own repo-root-relative `source_path` resolution (`source_path.toml:6-10`,
+RUE-495). Rewritten as a `rue_program_test` it would no longer test anything: its
+subject *is* the TOML mechanism it would be leaving.
+
+So 8 of the 73 cases stay in the harness (6 cross-target, 1 repo-relative, 1
+differential), 65 migrate, and they name 10 roots. Only **9** are new programs:
+`examples/meridian/main.rue` is also a large-example root, so one artifact serves
+both the six CLI scenarios and the slow-tier scenarios. That overlap is the design
+working rather than an accounting nuisance — it is exactly the "many scenarios,
+one compile" property, reaching across two suites.
+
+A rule that its own table quietly exempts things from is not a rule; a reader
+applying it strictly must get the same table.
 
 **The reproducibility suite must stay a harness, and the reason is instructive.**
 Its perturbations are compile-*time* (relocated source roots, mtimes, umask, `-j`,
@@ -423,10 +439,12 @@ strictly.
       the scheduled release lane stops paying 243.0s and 80.7s twice when both the
       slow and stress tiers run; and these are the clearest targets on which to
       establish the mechanism.
-- [ ] **Phase 2: CLI cases naming a checked-in root** — 73 cases into 11
-      programs, meridian's six first, which is where the disabled coverage is
-      restored. The six cross-target fixture cases and the one `differential_opt`
-      case stay in the harness. Depends on open question 3.
+- [ ] **Phase 2: CLI cases naming a checked-in root** — 65 of the 73 cases into
+      10 roots (9 new programs; meridian's is already declared by Phase 1),
+      meridian's six scenarios first, which is where the disabled coverage is
+      restored. The 6 cross-target fixture cases, the repo-relative fixture case,
+      and the one `differential_opt` case stay in the harness. Depends on open
+      question 3.
 - [ ] **Phase 3: Corpus input precision** — see open question 2; this phase is
       *not* specified here, because the obvious version of it does not work.
 - [ ] **Phase 4: Test-result caching decision** — only after the negative controls
@@ -442,8 +460,14 @@ Linear issues are filed per phase under RUE-1164 once this ADR is accepted.
   result is a real artifact many scenarios consume.
 - Coverage disabled by RUE-1083 becomes affordable again, which is a correctness
   gain rather than a speed one.
-- Undeclared inputs become build failures everywhere rather than only where RE
-  runs — but only because the derivation step enforces `srcs` itself. That
+- Undeclared inputs become build failures on every build that re-runs the scan,
+  rather than only where RE runs — but only because the derivation step enforces
+  `srcs` itself. One window remains open by ordinary action-cache semantics: an
+  absent-arm path outside the `srcs` tree is a declared-*allowed* read, so if a
+  file later materializes there, local rebuilds read it undeclared until some
+  change re-runs derivation. Negative control 3 is precisely the check that
+  covers that window, which is part of why it is a control rather than a nicety.
+  That
   property belonged to the glob-derived manifest of an earlier draft; on the
   scan-derived mechanism it has to be put back deliberately, and it is easy to
   lose again if derivation is ever simplified to "just write what the scan saw".

--- a/docs/designs/0070-rue-program-build-actions.md
+++ b/docs/designs/0070-rue-program-build-actions.md
@@ -36,7 +36,9 @@ consumes that executable and runs one runtime scenario. Many scenarios share one
 compile. The source manifest is derived from a cheap `--emit deps` scan rather
 than from the `srcs` glob, because a glob provably cannot produce a valid
 manifest; the derivation step is also where the declared boundary is enforced, by
-failing the build when the compiler read anything outside `srcs`. A granularity
+failing the build when the compiler read anything outside `srcs`, and where the
+envelope's absolute paths are re-anchored so that a shared scan-cache hit is not a
+build failure on another machine. A granularity
 rule keeps the action count proportionate: a compile becomes its own action when
 it is expensive relative to action overhead, or when more than one scenario
 consumes its output. That yields 47 programs; the ~4,050 inline-source corpus
@@ -170,20 +172,22 @@ back `absent`, with the path that was requested).
 ```python
 RueProgramInfo = provider(fields = [
     "executable",      # the compiled artifact
-    "manifest",        # scan-derived source manifest
-    "deps_envelope",   # the --emit deps output the manifest came from
     "root",
     "rue_target",      # x86-64-linux | aarch64-linux | aarch64-macos
     "opt_level",
     "runs_natively",   # False for a cross-target program
 ])
 
+# Mechanism internals, deliberately NOT in the consumer-facing provider.
+_RueProgramInternalInfo = provider(fields = ["manifest", "deps_envelope"])
+
 rue_program(
     name       = "meridian",
     root       = "examples/meridian/main.rue",
     srcs       = glob(["examples/meridian/**/*.rue"]),   # the declared read bound
-    std        = "//:std",
     rue_target = "x86-64-linux",
+    # compiler, std and default flags arrive as one resolved unit:
+    # _toolchain = attrs.toolchain_dep(default = "toolchains//:rue")
 )
 
 rue_program_test(
@@ -211,19 +215,40 @@ attribute that carries exactly one tier (`test_tiers.bxl:11-22`).
 
 ### Generating the manifest: a scan action, not a glob
 
-`rue_program` runs two actions.
+`rue_program` runs three ordinary actions. **Not a `dynamic_output`** — an
+earlier draft reached for one, and that was a category error worth naming, since
+it is the kind of mistake that hardens into a structure nothing else can be built
+on.
 
 1. **Scan.** `rue --emit deps <root>` with no manifest, declaring `srcs` + `std`
    as its Buck inputs. Because reads are unrestricted, resolution reports every
-   arm it probes — present and absent alike.
-2. **Compile.** `rue <root> --source-manifest <generated> -o <out>`, where the
-   manifest is `{requested_path of every accepted read} ∪ {requested_path of every
-   absent observation}`.
+   arm it probes — present and absent alike. The scan's command line carries no
+   `-O` and no `--target`, so **one scan serves every flag set of a root**: the
+   read closure is target-invariant by construction (see open question 1), which
+   is what makes this action worth separating rather than fusing into the compile.
+2. **Derive.** A script over the envelope plus the static `srcs` list, emitting
+   the manifest — `{requested_path of every accepted read} ∪ {requested_path of
+   every absent observation} ∪ the declared std` — and failing when any accepted
+   read falls outside `srcs ∪ std`.
+3. **Compile.** `rue <root> --source-manifest <generated> -o <out>`, declaring
+   `srcs` + `std` + compiler + the generated manifest as inputs.
 
-Because the manifest content depends on an action output, the rule uses
-`dynamic_output`. Verified end to end on the reproducer above, and on a program
-importing the real standard library — the scan-derived manifest picks up all 30
-std modules without the rule naming them:
+`dynamic_output` exists for when the *shape of the action graph* — which actions
+run, over which inputs — depends on an artifact's content. Nothing here does.
+Content that depends on an upstream action's output is an ordinary action edge:
+every command line and every input set above is known at analysis time, and the
+manifest is consumed by path rather than inspected to decide anything. The one
+design that would genuinely need `dynamic_output` is pruning the compile's
+declared inputs down to the observed read closure instead of declaring all of
+`srcs` — and that is precisely the design this ADR did not choose (the key table
+below reads "Transitive imports | declared `srcs`", and over-declaration is
+handled by the `ValidationInfo` audit). Steps 1 and 2 may be fused into a single
+wrapper action if the extra edge is judged not to earn its keep; that is a
+packaging choice and changes nothing above.
+
+Verified end to end on the reproducer above, and on a program importing the real
+standard library — the scan-derived manifest picks up all 30 std modules without
+the rule naming them:
 
 ```text
 $ rue --emit deps main.rue | derive-manifest > m.manifest    # 31 entries
@@ -236,9 +261,50 @@ system also disposes of a spelling hazard: the manifest's first membership check
 is lexical and never resolves symlinks, so a hand-built manifest over a Buck
 symlink-tree materialization can contain spellings the compiler never asks for.
 Using `requested_path` — literally the string the compiler will ask for — makes
-the two agree by construction. Manifest entries are written absolute so that the
-manifest-relative resolution rule (entries resolve against the manifest file's
-directory, which for a generated manifest is buck-out) cannot misfire.
+the two agree by construction.
+
+**Manifest entries must be machine-stable, and writing them verbatim would not
+be.** An earlier draft wrote entries absolute, on the theory that this kept the
+manifest-relative resolution rule from misfiring. That had it backwards: the
+manifest-relative rule is the fix, and absolute entries are a live correctness
+hole under this design's own remote-cache posture. The composition that breaks:
+
+- The envelope is machine-*un*stable. `requested_path` and `canonical_path` are
+  both `normalize_absolute` (`import_discovery.rs:334`), and the envelope also
+  embeds device/inode identity and mtimes — the same fact the audit section
+  already relies on.
+- The scan's action key is machine-*stable*: content digests of `srcs` + std +
+  compiler over a project-relative command line. That is exactly what makes it
+  uploadable and shareable, which `allow_cache_upload = True` asks for.
+- So environment A uploads a scan result; environment B, at a different checkout
+  root, takes the cache hit and receives *A's* absolute paths. Derivation then
+  emits a manifest naming paths that do not exist in B. Any compile that misses
+  while the scan hits — a different `-O`, a different `--target`, or simply a
+  combination never built in A — runs against a foreign manifest and fails: either
+  at the derive step's boundary check (A's canonical paths against B's `srcs`) or
+  at the compiler's lexical membership check (`source_loader.rs:406-431`), which
+  compares before any filesystem probe and so never matches B's requests. **A hard
+  failure on a correct build, triggered by a cache hit.**
+
+Even with upload disabled it costs the design its headline property: an absolute
+entry makes the *manifest's* digest, and therefore the compile's action key, vary
+with checkout root — so "compile once, consume many" would hold only among
+machines whose filesystem layouts agree, and Phase 1's sharing between the
+`pull_request` and `merge_group` lanes would narrow to lanes whose runners share a
+path.
+
+**Derivation therefore re-anchors before writing.** The envelope records the
+project root it was produced under (`dependency_envelope.rs:36`, populated at
+`:166`), so the script strips that prefix and writes each entry relative to the
+manifest's own directory. This needs no compiler change: `SourceManifest::load`
+already resolves a relative entry against the manifest file's parent
+(`source_loader.rs:51-83`) and normalizes it into the same absolute form the
+lexical check compares against, so relative entries and absolute requests agree
+in whatever environment the compile runs. A generated manifest lives under
+buck-out, which lives under the project root, so the relative offset is itself
+stable. This is the discipline the audit section already states — compare paths
+and fingerprints, never envelope bytes — applied one level earlier, to the
+pipeline rather than to the assertion over it.
 
 **The declared standard library is unioned in unconditionally, and it must be.**
 A scan reports only what resolution probed, and `--emit deps` does no semantic
@@ -356,7 +422,8 @@ the comparison, but the suite must own the second compile itself.
 | Cache upload | `allow_cache_upload = True` | on **both** actions; the compile-once-consume-many property depends on the scan and the compile being uploadable, not merely cacheable locally |
 | Transitive imports | action inputs | declared `srcs`; audited below |
 | Source manifest | generated input | scan-derived; changes when any probed path changes |
-| Compiler build | action input | `$(exe_target //crates/rue:rue)`; release vs debug already distinct via `//platforms:*` |
+| Compiler build | toolchain input | `RueToolchainInfo.compiler`, internally defaulting to `$(exe_target //crates/rue:rue)`; release vs debug already distinct via `//platforms:*` |
+| Standard library | toolchain input | `RueToolchainInfo.std`, internally defaulting to `//:std` |
 | Compiler flags | command line | `-O`, `--preview`, `--target` |
 | Linked archives | **action inputs** | `--link-archive` bytes are read at link time, so the flag must carry a `$(location ...)` input, not a bare path string |
 | Linker | pinned | `rue_program` pins `--linker internal`; see below |
@@ -424,11 +491,107 @@ Remote test-result caching stays off until all three pass on a real branch.
 RUE-1164 makes that ordering an acceptance criterion and this ADR keeps it
 strictly.
 
+### Forward positioning: external build systems
+
+Rue's roadmap includes first-class integration with state-of-the-art build tools
+— a published `rules_rue`, toolchain distribution, a plausible Bazel port. This
+ADR is not that work and does not attempt it. But most of what such an
+integration needs is the hard part of *this* design: compile-as-artifact keyed on
+a declared read closure, the program/scenario split, the granularity rule, and
+`--emit deps` acquiring a real consumer are all build-system-agnostic. The point
+of this section is to keep it that way, by recording the seams where an internal
+convenience would otherwise become an external constraint. Each is cheap now and
+expensive after publication.
+
+**Machine-stable manifest paths are the same fix twice.** The relative-entry
+derivation above is required for Buck2 correctness on its own; it is also the
+only portable form, because absolute paths inside a consumed action output are
+unrepresentable under sandboxed execution. Relocation-invariance of the
+derivation script belongs in the unit coverage the Consequences section already
+demands — the repository holds exactly this bar for the compiler binary, via the
+reproducibility suite's relocated-source-root perturbations
+(`scripts/check-reproducible-compiler.sh`, `scripts/test-reproducible-output.sh:164`).
+
+**A toolchain indirection, not per-invocation wiring.** The compiler and std
+reach the rule through a single `attrs.toolchain_dep` carrying compiler, std and
+default flags as one resolved unit, rather than each call site naming
+`//crates/rue:rue` and `//:std`. External consumers bring a *released* compiler,
+not a target in this repo, and both Buck2 toolchain rules and Bazel toolchain
+resolution assume that shape. This is the repository's own established pattern
+rather than a new one: `crates/rue-runtime/runtime.bzl:137` already takes
+`_rust_toolchain = attrs.toolchain_dep(default = "toolchains//:rust")` and reads
+`RustToolchainInfo`. It also buys something internal — the ability to run these
+rules against a prebuilt release compiler, which is what a toolchain-bootstrap
+test needs anyway.
+
+**The provider is an API surface; keep mechanism out of it.** `RueProgramInfo`
+above carries durable artifact facts only. `manifest` and `deps_envelope` live in
+an internal provider, because the envelope is machine-unstable bytes in a format
+this ADR treats as private — publishing it in the consumer-facing provider would
+bake that format into a compatibility contract. On naming: `rue_program` /
+`rue_program_test` depart from the ecosystem's `rue_binary` / `rue_test`
+convention. Renames are free today and not later; the choice should be made
+deliberately in Phase 0 — either adopt the conventional names, or keep the
+internal names distinct on purpose so published rules can differ. (The absence of
+a `rue_library` is not a gap. Whole-program compilation is the language's model,
+and a declared read closure is exactly what a future library-granularity unit
+would compose from.)
+
+**The scan apparatus compensates for a manifest semantic, and that is worth
+recording rather than only working around.** Mature language integrations
+converge on handing the compiler an authoritative input map it consults to the
+exclusion of everything else — rustc's `--extern` and dep-info, Go's importcfg,
+javac's classpath, Swift's module maps. `--source-manifest` is instead an
+*allowlist with fatal probes*: an undeclared probe is `DeniedLexical`-fatal even
+when a later declared arm resolves, so a valid manifest must enumerate absent
+arms, so a glob cannot produce one, so this design needs a scan action, a
+derivation script, and the hermeticity trap the Consequences section warns is
+easy to lose. That machinery is not intrinsic to Rue's build problem, and every
+future integration surface would re-inherit it.
+
+The seam is a compiler mode in which **the manifest is the filesystem**: a probe
+of a non-member path resolves as `Absent` rather than fatally. Under it a
+glob-derived manifest is valid by construction, `rue_program` collapses to one
+action, the derivation script and the path-stability problem above cease to
+exist, and under-declaration surfaces as an ordinary unresolved-import error. The
+Non-Goals section dismisses this as weakening the read policy, which is half
+right, and the honest form of the trade is:
+
+- **Cost.** On a *non-sandboxed* build where the disk is a superset of the
+  manifest, divergence between the two degrades from a loud E1400 into a silent
+  arm-shift: a file present on disk but absent from the manifest resolves via a
+  later arm, producing a different binary than the manifestless compile. That is
+  a real hazard and it is the true content of the Non-Goals sentence.
+- **Gain.** The residual window this ADR documents under Consequences — an
+  absent-arm path outside `srcs` is a declared-*allowed* read, so a file
+  materializing there is read undeclared until something re-runs derivation —
+  does not exist under manifest-as-filesystem semantics. Not in the manifest,
+  never readable. Negative control 3 exists to police a window these semantics
+  would not have.
+- **And the hazard is confined to the environments official rules do not run
+  in.** Under sandboxed or remote execution the disk *is* the declared inputs, so
+  the two semantics are observationally identical.
+
+No change is proposed here — "no compiler changes" is the right constraint for
+this milestone and the mechanism above is correct without one. This is recorded
+so that ADR-0051's fatal-probe semantics are not mistaken for a permanent
+constraint merely because this document worked around them successfully.
+
+**Portability of everything else**, for the record: `ValidationInfo` maps to
+Bazel's validation output group and is the right choice on both; `allow_cache_upload`
+is implicit in Bazel's remote cache model; `rue_program_test`'s inline `files`
+and writable working directory are expressible in both; open question 2's
+scheduling-out-of-the-key-domain principle is build-system-independent. BXL
+(`test_tiers.bxl`, the `labels`/kind-regex contract) is Buck2-only, but it is
+internal CI scheduling and would not ship in a ruleset.
+
 ## Implementation Phases
 
 - [ ] **Phase 0: Rules, scan-derived manifest, audit, controls** — `rue_rules.bzl`
-      with `rue_program`, `rue_program_test`, `RueProgramInfo`, the two-action
-      scan/compile shape, the declaration audit, and the three controls. Also the
+      with `rue_program`, `rue_program_test`, `RueProgramInfo`, the three-action
+      scan/derive/compile shape, a `RueToolchainInfo` indirection, the declaration
+      audit, and the three controls. This phase also settles the rule names while
+      renaming is still free (see "Forward positioning"). Also the
       stale-`--prefer-remote` documentation fix noted in the References (RUE-320
       is Done, so `AGENTS.md`'s condition no longer holds). No existing target
       changes.
@@ -486,12 +649,16 @@ Linear issues are filed per phase under RUE-1164 once this ADR is accepted.
 
 ### Negative
 
-- `rue_program` is two actions and a `dynamic_output`, not one action. The scan is
-  36x cheaper than the compile, but it is not free, and it runs on every cache
-  miss.
+- `rue_program` is three actions, not one. The scan is 36x cheaper than the
+  compile, but it is not free, and it runs on every cache miss. It is at least
+  ordinary static actions rather than a `dynamic_output`, so the cost is
+  scheduling overhead and not a structure that resists porting.
 - Correctness now depends on a derivation script, not only on rule wiring. A bug
   there is a hermeticity bug, so it needs its own unit coverage — the negative
-  controls exercise it end to end but will not pin its set arithmetic.
+  controls exercise it end to end but will not pin its set arithmetic. That
+  coverage must include **relocation invariance**: derivation reads absolute
+  paths out of the envelope and must emit manifest entries that do not depend on
+  the checkout root, or a shared scan-cache hit becomes a build failure.
 - Migrating the 73 cases splits the CLI authoring surface between two mechanisms
   during Phases 2 and 3.
 - Migrated targets **escape** RUE-924's corpus-omission audit rather than break
@@ -532,8 +699,24 @@ determines whether migrating scenarios out of TOML buys anything.
    program reads. Buck configurations exist to vary the dependency graph per
    platform; for `rue_program` there is provably nothing for a configuration to
    vary, and the whole difference between two targets' compiles is one
-   command-line flag that keys the action as an attribute at zero cost. Revisit
-   only if Rue grows target-dependent imports, which ADR-0047's model forbids.
+   command-line flag that keys the action as an attribute at zero cost.
+
+   **The expiry clause has three conditions, not one.** Target-invariance covers
+   the *dependency graph*; it does not by itself cover *inputs*. Revisit if Rue
+   grows target-dependent imports (which ADR-0047's model forbids); if a
+   `rue_program` ever links an archive that another rule **builds**, since a plain
+   attribute cannot request a dep in the matching configuration and that is
+   precisely what transitions are for; or on **publication**, since
+   `platform()`-driven cross-compilation is the idiom external users expect
+   (rules_go spent years migrating off goos/goarch attributes for exactly this).
+   Nothing bites today: the only archive-linking cases are the `c_ffi` inline-source
+   cases, whose archive the harness *synthesizes* per case to match the case's
+   `executable_target` (`crates/rue-cli-tests/src/main.rs:1949-1971`) rather than
+   checking one in. Note that this is already a target-variant generated input —
+   it simply lives inside the harness instead of the build graph, so the day it
+   becomes a Buck-built artifact is the day the second condition fires. The
+   recommendation still stands either way: an internal attribute forecloses
+   nothing, because the attribute can become a transition's output.
 
 2. **Corpus input precision — a proposal, replacing the three options an earlier
    draft could not choose between.** The root problem is that the current design
@@ -633,6 +816,13 @@ determines whether migrating scenarios out of TOML buys anything.
    the negative controls pass, then a deliberate trust decision" rather than
    ordinary caution.
 
+   One thing to record for any future port: this argument is
+   build-system-independent, but the **default is inverted elsewhere**. Bazel
+   caches passing test results by default, so on a Bazel surface the posture has
+   to be re-asserted (`--nocache_test_results`) rather than merely maintained.
+   Deciding it here does not decide it there, and a port that assumes otherwise
+   flips the answer silently.
+
 ## Non-Goals
 
 - **Specification traceability stays independent of action caching.**
@@ -644,7 +834,9 @@ determines whether migrating scenarios out of TOML buys anything.
   behave correctly, and the absent-arm problem is solved by using the second
   rather than by relaxing the first. Tolerating undeclared *absent* probes would
   be a compiler change and would weaken the read policy ADR-0051 defines; this
-  design does not ask for it.
+  design does not ask for it. It is, however, the seam a future external-build-tool
+  integration would most want, and "Forward positioning" states the trade in both
+  directions rather than leaving it as a one-line dismissal.
 - **External linkers.** `rue_program` pins `--linker internal`. Cases covering
   `clang`/`gcc` linking stay in the harness.
 - **No change to what is tested.** Every scenario that runs today runs after, and

--- a/docs/designs/0070-rue-program-build-actions.md
+++ b/docs/designs/0070-rue-program-build-actions.md
@@ -19,7 +19,9 @@ relates: ["RUE-1164", "RUE-1118", "RUE-1222", "RUE-1267", "ADR-0047", "ADR-0051"
 Proposal. This is the reviewed design RUE-1164 asks for and ADR-0069 Phase 5
 defers to. Nothing here is implemented. The granularity rule under "Which
 compiles become actions" and the four items under "Open questions" are maintainer
-decisions rather than settled design.
+decisions rather than settled design; each open question now carries a
+recommendation and its evidence, but questions 2 and 3 are coupled and question 2
+proposes work large enough to deserve its own ADR.
 
 ## Summary
 
@@ -439,14 +441,20 @@ strictly.
       the scheduled release lane stops paying 243.0s and 80.7s twice when both the
       slow and stress tiers run; and these are the clearest targets on which to
       establish the mechanism.
-- [ ] **Phase 2: CLI cases naming a checked-in root** — 65 of the 73 cases into
-      10 roots (9 new programs; meridian's is already declared by Phase 1),
-      meridian's six scenarios first, which is where the disabled coverage is
-      restored. The 6 cross-target fixture cases, the repo-relative fixture case,
-      and the one `differential_opt` case stay in the harness. Depends on open
-      question 3.
-- [ ] **Phase 3: Corpus input precision** — see open question 2; this phase is
-      *not* specified here, because the obvious version of it does not work.
+- [ ] **Phase 2: break the weld for CLI cases naming a checked-in root** — 65 of
+      the 73 cases against 10 roots (9 new programs; meridian's is already declared
+      by Phase 1), meridian's six scenarios first, which is where the disabled
+      coverage is restored. The 6 cross-target fixture cases, the repo-relative
+      fixture case, and the one `differential_opt` case stay in the harness
+      regardless. **Whether these scenarios stay in TOML consuming a prebuilt
+      executable, or migrate to `rue_program_test` targets, is open question 3 —
+      and it is decided together with question 2.** The current recommendation is
+      that they stay in TOML, which makes this phase considerably smaller than
+      earlier drafts assumed.
+- [ ] **Phase 3: Corpus input precision** — see open question 2. A concrete
+      proposal now exists (per-file corpus actions, shard assignment moved into
+      the lane planner), but it is large enough to warrant its own ADR and issue
+      rather than a phase here, and it gates the shape of Phase 2.
 - [ ] **Phase 4: Test-result caching decision** — only after the negative controls
       pass on a real branch. See open question 4.
 
@@ -502,58 +510,128 @@ Linear issues are filed per phase under RUE-1164 once this ADR is accepted.
 
 ## Open Questions
 
-1. **Target architecture: attribute or configuration?** `//platforms:release`
-   exists because, as `platforms/BUCK:23-33` records, a bare
-   `--modifier //constraints:release` left debug and release resolving to the same
-   configured output path while the toolchain's `rustc_flags` select never saw the
-   constraint. The same argument could be made for a `//constraints:rue-target`
-   setting plus platforms. Recommendation: a plain attribute. The Rue target is a
-   property of the artifact requested, not of the machine building it — the
-   `abi_conformance` and `linker` fixtures want all three targets side by side in
-   one package, which attributes make trivial and configurations make awkward —
-   and `--target` is on the command line, so it keys the action either way. (Cite
-   the `platforms/BUCK` comment rather than RUE-277 itself: the issue records the
-   symptom, the comment records the mechanism.)
-2. **Phase 3 needs re-deriving; the obvious version does not work.** An earlier
-   draft called per-shard case-file declaration "clearly right". It is not
-   implementable as stated: shard assignment is per-*case* LPT cost-balancing over
-   `shard-weights.json` (`crates/rue-cli-tests/src/sharding.rs:76-105`), so one
-   TOML file's cases scatter across all four shards and the mapping churns on
-   every weights refresh (RUE-1222). Declaring per-shard file sets would require
-   either file-aligned packing — which ADR-0069 §6's skew analysis argues against
-   — or a generated shard→files mapping, which by ADR-0069's own ledger standard
-   needs a gate to count. Note also that the blast radius is wider than stated:
-   the `cases` filegroup keys **seven** corpus actions (four shards plus
-   `//:cli-tests`, `//:cli-tests-slow`, `//:release-smoke`), not four. Options:
-   make shard assignment a build-time fact with a gate; accept coarse keys for the
-   harness bucket; or drop the phase. I do not have a recommendation I trust here.
-3. **Do the CLI cases migrate out, or does the harness consume prebuilt
-   artifacts?** Either `rue-cli-tests` learns to accept a prebuilt executable for a
-   case naming a checked-in root, or those 73 cases become `rue_program_test`
-   targets. The first preserves one authoring surface and keeps RUE-924's audit
-   working unchanged; the second gives the per-scenario targets the milestone is
-   for, at the cost of extending the discovery set and reimplementing inline
-   runtime fixtures and a writable cwd. Recommendation: migrate them out — they
-   are the least TOML-shaped cases in the corpus. This has the largest blast
-   radius on authoring ergonomics of anything here.
-4. **Test-result caching: what actually blocks it.** ADR-0069 §4 suggests buck2's
-   `supports_test_execution_caching` is available and blocked only by Rue's noop
-   toolchains. Two corrections. For the *existing* corpora it is not available at
-   all: reading the bundled prelude for the pinned 2026-07-15 buck2, the attribute
-   appears only on the java/kotlin/cxx/python/android test decls, and
-   `sh_test_impl` constructs `ExternalRunnerTestInfo` without it — so no `sh_test`
-   or `rue_sh_test` here can opt in even with a live toolchain. But for
-   `rue_program_test` the objection is moot: it is a new rule emitting its own
-   `ExternalRunnerTestInfo`, so setting the field is one line. The real costs are
-   therefore the non-noop remote test toolchain and the trust decision RUE-1164
-   already gates behind the negative controls. Recommendation: still don't, but on
-   those grounds — once `rue_program` owns the expensive half, what remains in a
-   test execution is running a binary and comparing output, and caching that is a
-   toolchain change for a small remainder. Revisit if Phases 1–2 leave test
-   execution on the critical path.
+All four carry a recommendation now, and three of them changed after review. They
+remain maintainer decisions: RUE-1164 is labelled `needs-decision`, and questions
+2 and 3 in particular reach beyond what this ADR can settle on its own.
 
-Note that RUE-1164 carries no comments, so none of these is pre-decided
-elsewhere.
+**Decide 2 and 3 together.** They are one decision wearing two numbers — whether
+the corpus stays a scheduling unit or becomes a graph of per-file actions
+determines whether migrating scenarios out of TOML buys anything.
+
+1. **Target architecture: attribute or configuration?** Recommendation: **a plain
+   attribute**, on a stronger argument than the one an earlier draft gave. That
+   draft cited the `abi_conformance`/`linker` fixtures as wanting all three
+   targets side by side in one package; the granularity repair moved those to the
+   harness, so no proposed `rue_program` needs side-by-side targets today, and the
+   example is now about keeping the door open rather than serving a consumer.
+
+   The principled argument is that **Rue's read closure is target-invariant by
+   construction.** `ImportDiscoveryContext::new` takes epoch, project root, std
+   root and policy revision — and no target (`source_loader.rs:1004-1013`) — and
+   `@import` has no conditional form, so `--target` cannot change which sources a
+   program reads. Buck configurations exist to vary the dependency graph per
+   platform; for `rue_program` there is provably nothing for a configuration to
+   vary, and the whole difference between two targets' compiles is one
+   command-line flag that keys the action as an attribute at zero cost. Revisit
+   only if Rue grows target-dependent imports, which ADR-0047's model forbids.
+
+2. **Corpus input precision — a proposal, replacing the three options an earlier
+   draft could not choose between.** The root problem is that the current design
+   couples a *scheduling* concern (which shard runs a case, a function of
+   `shard-weights.json`) into a *correctness* concern (what keys an action). All
+   three earlier options managed that coupling; none removed it.
+
+   Recommendation: **make the corpus action's unit the case file, and move shard
+   assignment up into the lane planner.**
+
+   - One corpus action per case TOML, comprehended from `glob(["cases/*.toml"])`
+     at load time — derived from the tree, so there is no hand-maintained mapping
+     and nothing to gate, which meets ADR-0069's ledger standard by construction.
+     Each file-target declares its own TOML plus the coarse rare-change inputs
+     (compiler, harness, std, fixture and example trees). A case edit then
+     invalidates exactly one action, while a compiler or fixture change still
+     invalidates everything, which is correct.
+   - **`shard-weights.json` leaves the key domain entirely.** ADR-0069 Phase 2's
+     planner (implemented and gated) generates the lane split by packing the
+     file-targets with the existing weights, regenerated per run and never
+     persisted — so stale weights can only unbalance a lane, never affect
+     correctness. Coverage stays ADR-0069's union gate. RUE-1267's floor-aware
+     packer replaces the interim packing when it lands, and the ordering is
+     consistent with ADR-0069 having deliberately scheduled that packer after the
+     distribution stops changing: this conversion *is* the distribution change.
+   - **What it deletes:** `CliShardPlan` and the LPT code in
+     `crates/rue-cli-tests/src/sharding.rs`, `CLI_TEST_SHARD_COUNT`,
+     `scripts/validate-cli-shard-coverage.py`, and the skew guard ADR-0069 §6
+     proved vacuous. RUE-1222's scheduled weight refresh becomes free: today it
+     would invalidate every shard action; afterward it touches no action key.
+   - A heavyweight file that dominates a lane is RUE-1267's indivisible-item alarm
+     firing with a mechanical remedy — split the TOML, an ordinary authoring act.
+
+   Two costs, both verified, both belonging in the decision rather than in a
+   footnote. **Scale:** ~323 file-actions repo-wide — 214 CLI, 71 spec, 38 UI,
+   since spec and UI declare whole `cases/**` filegroups today too
+   (`crates/rue-spec/BUCK`, `crates/rue-ui-tests/BUCK`) — at roughly 8–13 cases
+   each. That sits above action overhead, and if it is judged too fine the same
+   mechanism works at directory granularity (spec already has 10 subdirectories);
+   the dial is grouping, not design. **One real harness change:** contract-graph
+   validation deliberately runs against the complete unfiltered inventory before
+   any filter is applied (`crates/rue-cli-tests/src/main.rs:2876-2878`), so a
+   per-file action staged with only its own TOML needs a mode that relaxes
+   cross-file checks, with contract completeness, duplicate-name detection and
+   RUE-924-style counting moving to one whole-corpus parse-only validation target
+   whose coarse key is fine because it costs seconds.
+
+   **Scope caveat, and the reason this stays open.** This is a larger change than
+   "a phase of RUE-1164": it dissolves CLI sharding, reaches into the spec and UI
+   corpora, and modifies the harness. It is a good answer to the question, but it
+   probably deserves its own ADR and issue rather than living as Phase 3 here.
+
+3. **Do the CLI cases migrate out of TOML, or does the harness consume prebuilt
+   artifacts?** Recommendation **reversed** after review: **let the harness consume
+   prebuilt artifacts**, conditional on question 2.
+
+   The defect Phase 2 fixes is the weld between compile and scenario, not the
+   TOML. Handing the 65 scenarios a prebuilt executable fixes exactly that;
+   migrating them additionally relocates the authoring surface — by this
+   document's own assessment the largest-blast-radius change in it — to buy
+   per-scenario CI selection whose value stays speculative until RUE-1267's packer
+   names a single scenario as a binding constraint. Once the weld is broken,
+   scenario executions are cheap binary runs, and that day may not come.
+
+   The "least TOML-shaped cases" argument that justified migration also expires
+   once the weld is broken: such a case is then a program reference,
+   `program_args`, inline `files`, and expectations — precisely
+   `rue_program_test`'s attribute set. The shapes converge, so the only remaining
+   difference is where they are written, and the TOML side keeps the working
+   inline-fixture and writable-cwd machinery, keeps RUE-924's audit unchanged
+   rather than extended, and avoids a two-mechanism transition entirely.
+
+   The condition: this is clean *because of* question 2. Under per-file actions,
+   `examples_meridian.toml`'s target declares `:meridian` as an input and runs six
+   scenarios against it — one compile action, one scenario action, selectable at
+   file granularity. The per-file targets naming checked-in roots declare deps on
+   the programs their cases consume; that mapping is small (~14 files, 1–2 roots
+   each) and fails closed, since a case whose program is absent from the staging
+   environment cannot run. If question 2 is decided the other way and the shards
+   stay monolithic, the calculus shifts back toward migration, because per-scenario
+   targets become the only route to individual scheduling.
+
+   Migration stays the fallback if the prebuilt-consuming mode proves ugly — the
+   staging-environment wiring is the risk — and nothing in Phase 0 or 1 is wasted
+   either way, since the large-example scenarios use `rue_program_test` regardless.
+
+4. **Test-result caching.** Recommendation unchanged — **don't** — with two
+   reinforcements. Under question 2's proposal the corpus's scenario work is
+   already served by the action cache, because per-file corpus actions are cached
+   actions; the population of uncached test executions shrinks to
+   `rue_program_test` runs and ordinary unit tests, so the toolchain investment
+   buys even less than stated above. And the trust asymmetry deserves saying
+   outright: cache writes are authorized by holding the credential, and enabling
+   test-result caching widens what a poisoned entry can fake from an *artifact*,
+   which still has to run and pass, to a *verdict*, which does not. That is a
+   strictly sharper target, and it is the deeper reason the posture is "off until
+   the negative controls pass, then a deliberate trust decision" rather than
+   ordinary caution.
 
 ## Non-Goals
 

--- a/docs/designs/0070-rue-program-build-actions.md
+++ b/docs/designs/0070-rue-program-build-actions.md
@@ -20,8 +20,9 @@ Proposal. This is the reviewed design RUE-1164 asks for and ADR-0069 Phase 5
 defers to. Nothing here is implemented. The granularity rule under "Which
 compiles become actions" and the four items under "Open questions" are maintainer
 decisions rather than settled design; each open question now carries a
-recommendation and its evidence, but questions 2 and 3 are coupled and question 2
-proposes work large enough to deserve its own ADR.
+recommendation and its evidence. Question 2's proposal is large enough to deserve
+its own ADR and issue, and — after review — it no longer gates any phase here:
+question 3's recommendation stands on the existing corpus actions alone.
 
 ## Summary
 
@@ -41,8 +42,8 @@ envelope's absolute paths are re-anchored so that a shared scan-cache hit is not
 build failure on another machine. A granularity
 rule keeps the action count proportionate: a compile becomes its own action when
 it is expensive relative to action overhead, or when more than one scenario
-consumes its output. That yields 47 programs; the ~4,050 inline-source corpus
-cases stay inside their harnesses.
+consumes its output. That yields 13 programs; the 34 auto-discovered example
+smokes and the ~4,050 inline-source corpus cases stay inside their harnesses.
 
 No compiler change is required. ADR-0047 Phases 3 and 4 (`--source-manifest`,
 `--emit deps`) are implemented and currently unconsumed; this design is their
@@ -67,7 +68,7 @@ pays a cost, not on the absolute seconds.
 | Corpus cases in total | 4,132 (1,778 CLI, 2,109 spec, 245 UI) |
 | CLI cases naming a checked-in root | 73 cases, 13 roots (10 example + 3 fixture), 17 distinct (root, flags, target) tuples |
 | Most-recompiled roots | mosaic 17x, rill 12x, lattice 7x, calculator 7x, meridian 6x, jsonfmt 5x |
-| Distinct `rue_program` targets proposed | 47 (4 large-example + 9 CLI + 34 auto-discovered) |
+| Distinct `rue_program` targets proposed | 13 (4 large-example + 9 CLI) |
 
 **Where those costs are actually paid matters, and it is not where you would
 guess.** The 243.0s and 80.7s figures are `main.rue` compiles, which occur only in
@@ -373,8 +374,8 @@ overhead, or when more than one scenario consumes its output.**
 | Work | Scale | Disposition | Why |
 | --- | --- | --- | --- |
 | caldera, meridian — `main` and `canary` roots | 4 roots | `rue_program` | `main` is 81–243s; all four are consumed by several scenarios and by more than one suite |
-| CLI cases naming a checked-in root | 65 cases → 10 roots, **9 new programs** | `rue_program` | 1–17 TOML scenarios each, *plus* the automatic-examples and frontend-diff passes; `examples/meridian/main.rue` is the tenth root and is already declared by the row above |
-| Auto-discovered `examples/**` roots not already covered | 34 | `rue_program` | Derived exactly: `collect_example_files` yields 45 roots, less the 10 named above and caldera's |
+| CLI cases naming a checked-in root | 65 cases → 10 roots, **9 new programs** | `rue_program` | 1–17 TOML scenarios each, and every premerge case executes in both its CI shard and the unsharded `//:cli-tests`, so even a one-case root's artifact has more than one consuming action; `examples/meridian/main.rue` is the tenth root and is already declared by the row above |
+| Auto-discovered `examples/**` roots not already covered | 34 | harness | See below — every one fails the rule on both prongs |
 | Inline-source CLI / spec / UI cases | ~4,050 | harness | Sources live inside TOML; compiles are milliseconds |
 | Cross-target fixture cases (`abi_conformance.toml`, `linker.toml`) | 6 cases | harness | See below — they fail the rule on both prongs |
 | The repo-relative `source_path` fixture case | 1 case | harness | See below — its subject *is* the TOML mechanism |
@@ -401,6 +402,20 @@ differential), 65 migrate, and they name 10 roots. Only **9** are new programs:
 both the six CLI scenarios and the slow-tier scenarios. That overlap is the design
 working rather than an accounting nuisance — it is exactly the "many scenarios,
 one compile" property, reaching across two suites.
+
+**The 34 auto-discovered roots fail the rule the same way, and an earlier draft
+counted them as programs anyway.** `collect_example_files` yields 45 roots; 10
+are CLI-named and one is caldera's, leaving 34 whose only compilation scenario is
+the RUE-48 automatic smoke — one compile, one run, per corpus execution. The
+claimed second consumer was the frontend differential, and that claim was wrong:
+`rue-frontend-diff` compiles exactly one root, `examples/ruelex/main.rue`, and
+merely lexes and parses the rest of the corpus in-process as comparison input
+(`crates/rue-frontend-diff/src/main.rs:1281-1303`). Sized against the expensive
+prong they are 3–246 lines each, transitively — milliseconds to compile. Single
+consumer, cheap: they stay where they are, inside the automatic pass, which also
+means no phase has to rewire `run_example` to consume artifacts it has no reason
+to consume. A root that later grows expensive or acquires a second scenario
+graduates by being named — the same path the 10 CLI-named roots took.
 
 A rule that its own table quietly exempts things from is not a rule; a reader
 applying it strictly must get the same table.
@@ -443,6 +458,25 @@ a `rue_program` whose `srcs` glob is wider than its real read closure takes cach
 misses on files it never reads, which turns a precise action back into a corpus
 stamp. Left unchecked, a broad glob undoes the whole point of the rule.
 
+**Over-declaration must be advisory, not a required check, and the reason is
+structural rather than a matter of nerve.** An earlier draft made
+`srcs − accepted_reads = ∅` a required validation, and that check fails on this
+ADR's own example target: `examples/meridian/main.rue` does not import
+`canary.rue`, yet `glob(["examples/meridian/**/*.rue"])` contains it — and the
+canary target's glob symmetrically contains all of `main`'s tree. Caldera has the
+same shape, and any directory holding sibling roots reproduces it. The only ways
+to satisfy a required check are all worse than the imprecision: exact per-root
+`srcs` cannot be derived from the scan while remaining a static action input
+without reintroducing the dynamic dependency shaping this design explicitly
+rejected; a hand-maintained exact list duplicates import discovery and rots; and
+per-root directory layouts would let the build graph dictate source organization.
+RUE-1164 requires every real input to key the action — it does not require the
+first implementation to carry a mathematically minimal key. A directory-bounded
+glob delivers the property that matters (one correct, cacheable artifact shared
+by scenarios) at the cost of some spurious invalidation inside the directory,
+and tightening that later should be driven by measured invalidation cost, not
+asserted up front.
+
 Three constraints on how the comparison is done, all of which matter:
 
 - Compare **path and fingerprint sets, never envelope bytes**: the envelope
@@ -454,13 +488,21 @@ Three constraints on how the comparison is done, all of which matter:
 - `accepted_reads` is the observed read set *of that scan*, not a complete
   compile-time read set — trusted-std acquisition is invisible to it, as above.
   Treat std as always-declared rather than inferring it from the envelope.
+- Because sibling roots share a glob, `srcs − accepted_reads` is legitimately
+  non-empty per target. The signal worth reporting is directory-scoped: a file
+  that no program whose `srcs` contain it ever reads is dead weight in every
+  key it touches; a file read by one sibling and carried by another is the
+  glob doing its job.
 
-**Attach it with `ValidationInfo` rather than as a separate test target.** The
-pinned 2026-07-15 buck2 ships it and the bundled prelude already uses it (java,
-kotlin, apple). A validation attached to a target runs whenever that target is
-transitively reachable from any requested build or test, in parallel with the
-build, and a failed required validation fails the build. That is precisely the
-shape of "an assertion over an artifact the rule produces anyway", and it
+**Attach it with `ValidationInfo`, marked `optional`, rather than as a separate
+test target.** The pinned 2026-07-15 buck2 ships it and the bundled prelude
+already uses it (java, kotlin, apple); its `ValidationSpec` carries an `optional`
+field, and optional validations do not run by default — they are selected with
+`--enable-optional-validations`. That is exactly the advisory shape: the report
+travels with the target it describes, costs nothing on ordinary builds, and a CI
+job or a curious maintainer can demand it by name. The derivation step's
+under-declaration check stays where it is, required and in-band, because it is
+correctness; this validation carries only the precision report. It still
 dissolves the question an earlier draft had to ask — which tier do ~50 audit
 targets carry, given every compiler change invalidates all of them — rather than
 answering it. There are no audit targets to schedule.
@@ -472,24 +514,44 @@ claimed all three could be Buck targets; only the first can be, and the honest
 shape matters because the repository has strong precedent for the other two
 living outside the graph.
 
-1. **Under-declared program must fail** — a Buck target. A fixture `rue_program`
-   whose `srcs` omits one imported module, wrapped so that the expected build
-   failure is *contained*: an uncontained failing target breaks
-   `buck2 build //...`. This is the direct test of E1400 enforcement and it runs
-   everywhere.
+1. **Under-declared program must fail at the derivation boundary** — a Buck
+   target, wrapped so that the expected build failure is *contained*: an
+   uncontained failing target breaks `buck2 build //...`. The naive fixture — a
+   `rue_program` whose `srcs` simply omits one imported module — is **not one
+   stable test**, because its failure stage depends on the executor. On a
+   non-sandboxed local run the omitted file is still on disk, the scan reads it,
+   and derivation rejects the out-of-`srcs` read; in a clean root or under RE the
+   file was never materialized, the scan records an absent probe, and the compile
+   fails as an ordinary unresolved import. Both are failures, but only the first
+   exercises the boundary check this control exists to pin. The fixture therefore
+   *materializes* the omitted module deliberately — passed to the scan action as
+   a test-only hidden input so it is present in every execution environment —
+   while excluding it from the `srcs` set the derivation script compares against,
+   and asserts the derivation-specific error, not just any failure.
 2. **Clean-root / remote materialization** — a CI job, not a target. The RUE-320
    merge-group canary is a workflow job that builds only `//crates/rue:rue`
    (`ci.yml`), so covering `rue_program` targets is a workflow change rather than
-   a reuse of an existing target.
+   a reuse of an existing target. This job stays the independent proof that
+   undeclared Buck inputs are simply *unavailable*, which control 1 deliberately
+   no longer demonstrates.
 3. **Digest sensitivity** — a CI script in the `scripts/check-reproducible-compiler.sh`
    mould. Mutating a source and asserting the action re-executes requires driving
    buck2 and reading its event log; every Buck-visible test in this repository
    that touches buck2 stubs it, and the closest precedents deliberately live
    outside the graph.
 
-Remote test-result caching stays off until all three pass on a real branch.
-RUE-1164 makes that ordering an acceptance criterion and this ADR keeps it
-strictly.
+**And one positive control, because RUE-1164's acceptance criteria are not all
+failure-shaped.** "Warm runs show Rue compilation actions served by BuildBuddy
+rather than rerun inside a harness" is an explicit criterion, and the three
+controls above cover failure modes only. Phase 1 therefore owns a success check:
+two builds — across relocated checkout roots, or across the `pull_request` and
+`merge_group` lanes, which is the pair RUE-1118 measured — must show the scan and
+compile actions cache-served while more than one scenario consumes the same
+executable. Phase 2 repeats it for a CLI root.
+
+Remote test-result caching stays off until the three negative controls pass on a
+real branch. RUE-1164 makes that ordering an acceptance criterion and this ADR
+keeps it strictly.
 
 ### Forward positioning: external build systems
 
@@ -603,21 +665,31 @@ internal CI scheduling and would not ship in a ruleset.
       invocation and become shareable between `pull_request` and `merge_group`;
       the scheduled release lane stops paying 243.0s and 80.7s twice when both the
       slow and stress tiers run; and these are the clearest targets on which to
-      establish the mechanism.
-- [ ] **Phase 2: break the weld for CLI cases naming a checked-in root** — 65 of
-      the 73 cases against 10 roots (9 new programs; meridian's is already declared
-      by Phase 1), meridian's six scenarios first, which is where the disabled
-      coverage is restored. The 6 cross-target fixture cases, the repo-relative
-      fixture case, and the one `differential_opt` case stay in the harness
-      regardless. **Whether these scenarios stay in TOML consuming a prebuilt
-      executable, or migrate to `rue_program_test` targets, is open question 3 —
-      and it is decided together with question 2.** The current recommendation is
-      that they stay in TOML, which makes this phase considerably smaller than
-      earlier drafts assumed.
-- [ ] **Phase 3: Corpus input precision** — see open question 2. A concrete
-      proposal now exists (per-file corpus actions, shard assignment moved into
-      the lane planner), but it is large enough to warrant its own ADR and issue
-      rather than a phase here, and it gates the shape of Phase 2.
+      establish the mechanism. This phase owns the positive warm-cache check: a
+      relocated or cross-lane second build must show the canary scan and compile
+      actions cache-served under multiple consuming scenarios.
+- [ ] **Phase 2: break the weld for CLI cases naming a checked-in root** — the
+      65 cases keep their TOML form and their existing corpus actions; what
+      changes is that each CLI corpus action declares the 10 program artifacts as
+      inputs and the harness runs the prebuilt executable a case names instead of
+      compiling it. The wiring already exists: `cached_corpus_suite`'s `env` is
+      `attrs.arg()`, so the artifacts arrive through `$(location ...)` exactly
+      like every other declared corpus input, and an artifact edit invalidates
+      the consuming corpus actions correctly. Meridian's six scenarios come
+      first, which is where the disabled coverage is restored. The 6 cross-target
+      fixture cases, the repo-relative fixture case, and the one
+      `differential_opt` case stay compile-in-harness regardless. **This phase
+      requires no sharding change, no TOML migration, and no decision on open
+      question 2** — Buck builds each program once, every scenario shares it,
+      and warm runs serve the compile from cache, which is RUE-1164's goal met on
+      the existing corpus topology.
+- [ ] **Phase 3: Corpus input precision — deliberately not a phase.** Open
+      question 2's per-file proposal is a corpus-topology redesign: it dissolves
+      CLI sharding, reaches into the spec and UI corpora, and modifies the
+      harness's whole-corpus validation. It is filed as its own ADR and issue
+      once this one is accepted, and nothing in Phases 0–2 waits on it or
+      forecloses it — per-file actions would consume the same `RueProgramInfo`
+      artifacts Phase 2 wires in, just from finer-grained consumers.
 - [ ] **Phase 4: Test-result caching decision** — only after the negative controls
       pass on a real branch. See open question 4.
 
@@ -642,8 +714,10 @@ Linear issues are filed per phase under RUE-1164 once this ADR is accepted.
   property belonged to the glob-derived manifest of an earlier draft; on the
   scan-derived mechanism it has to be put back deliberately, and it is easy to
   lose again if derivation is ever simplified to "just write what the scan saw".
-- Scenarios become individually selectable and schedulable targets, which is the
-  "split" remedy in RUE-1267's alarm.
+- Large-example scenarios become individually selectable and schedulable
+  targets. For corpus cases the "split" remedy in RUE-1267's alarm stays an
+  authoring act (split the TOML file) unless the per-file corpus ADR lands, at
+  which point it becomes target-granular.
 - ADR-0047 Phases 3 and 4 acquire their first consumer, and the design needs both
   of them, not just one.
 
@@ -659,12 +733,19 @@ Linear issues are filed per phase under RUE-1164 once this ADR is accepted.
   coverage must include **relocation invariance**: derivation reads absolute
   paths out of the envelope and must emit manifest entries that do not depend on
   the checkout root, or a shared scan-cache hit becomes a build failure.
-- Migrating the 73 cases splits the CLI authoring surface between two mechanisms
-  during Phases 2 and 3.
-- Migrated targets **escape** RUE-924's corpus-omission audit rather than break
-  it: that audit discovers `rue_heavy_suite` labels, so a `rue_program_test` that
-  does not join the discovery set is silently unaudited. Phase 2 must extend the
-  discovery set in the same change.
+- The CLI harness grows a second execution mode: run a staged prebuilt binary
+  rather than compile the case's root. It is a mode of the existing harness, not
+  a parallel mechanism — cases stay in TOML, the corpus targets keep their names,
+  labels and tiers, and RUE-924's corpus-omission audit is untouched — but the
+  harness's compile path and its staged path can now drift and need shared
+  plumbing kept honest.
+- **If open question 3's fallback is ever taken** — migrating scenarios to
+  `rue_program_test` targets — two costs return: the authoring surface splits
+  between TOML and BUCK during the transition, and migrated targets **escape**
+  RUE-924's audit rather than break it (the audit discovers `rue_heavy_suite`
+  labels, so a `rue_program_test` outside the discovery set is silently
+  unaudited; the migrating change must extend discovery in the same change).
+  Under the recommended prebuilt-artifact form, neither cost exists.
 
 ### Neutral
 
@@ -681,9 +762,12 @@ All four carry a recommendation now, and three of them changed after review. The
 remain maintainer decisions: RUE-1164 is labelled `needs-decision`, and questions
 2 and 3 in particular reach beyond what this ADR can settle on its own.
 
-**Decide 2 and 3 together.** They are one decision wearing two numbers — whether
-the corpus stays a scheduling unit or becomes a graph of per-file actions
-determines whether migrating scenarios out of TOML buys anything.
+**Questions 2 and 3 are related but no longer coupled.** An earlier draft
+decided them together, on the theory that per-file corpus actions were what made
+prebuilt-artifact consumption clean. Review showed the dependency runs the other
+way: question 3's recommendation works on the existing corpus actions as they
+stand, and question 2 is a separate, larger decision that can be taken — or
+declined — afterward without reopening it.
 
 1. **Target architecture: attribute or configuration?** Recommendation: **a plain
    attribute**, on a stronger argument than the one an earlier draft gave. That
@@ -766,12 +850,17 @@ determines whether migrating scenarios out of TOML buys anything.
 
    **Scope caveat, and the reason this stays open.** This is a larger change than
    "a phase of RUE-1164": it dissolves CLI sharding, reaches into the spec and UI
-   corpora, and modifies the harness. It is a good answer to the question, but it
-   probably deserves its own ADR and issue rather than living as Phase 3 here.
+   corpora, and modifies the harness — roughly 323 actions against the ~13 this
+   ADR otherwise creates. It is a good answer to the question, but it is its own
+   ADR and issue, filed after this one is accepted, and **it does not gate any
+   phase here**: Phase 2 meets RUE-1164 on the existing shard topology, and
+   per-file actions would consume the same artifacts from finer-grained
+   consumers.
 
 3. **Do the CLI cases migrate out of TOML, or does the harness consume prebuilt
-   artifacts?** Recommendation **reversed** after review: **let the harness consume
-   prebuilt artifacts**, conditional on question 2.
+   artifacts?** Recommendation **reversed** after review: **let the harness
+   consume prebuilt artifacts** — and, after a further round, this stands on the
+   existing corpus actions alone rather than conditionally on question 2.
 
    The defect Phase 2 fixes is the weld between compile and scenario, not the
    TOML. Handing the 65 scenarios a prebuilt executable fixes exactly that;
@@ -789,26 +878,34 @@ determines whether migrating scenarios out of TOML buys anything.
    inline-fixture and writable-cwd machinery, keeps RUE-924's audit unchanged
    rather than extended, and avoids a two-mechanism transition entirely.
 
-   The condition: this is clean *because of* question 2. Under per-file actions,
-   `examples_meridian.toml`'s target declares `:meridian` as an input and runs six
-   scenarios against it — one compile action, one scenario action, selectable at
-   file granularity. The per-file targets naming checked-in roots declare deps on
-   the programs their cases consume; that mapping is small (~14 files, 1–2 roots
-   each) and fails closed, since a case whose program is absent from the staging
-   environment cannot run. If question 2 is decided the other way and the shards
-   stay monolithic, the calculus shifts back toward migration, because per-scenario
-   targets become the only route to individual scheduling.
+   The mechanism needs nothing question 2 would build. Each existing CLI corpus
+   action declares all ten program artifacts through its `attrs.arg()` env — the
+   same `$(location ...)` contract every other corpus input already uses — and
+   the harness runs the artifact a case names. The simplest correct form declares
+   all ten on every CLI corpus action; that is a mild over-declaration of each
+   action's key (an edit to any of the ten roots re-runs all the CLI corpus
+   actions — which is also true today, since the roots live inside the declared
+   `:examples` filegroup), and it fails closed, since a case whose program is
+   missing from the staging environment cannot run. If question 2's per-file
+   redesign later lands, the mapping merely gets finer (~14 files naming 1–2
+   roots each); if it never lands, nothing here is waiting for it.
 
-   Migration stays the fallback if the prebuilt-consuming mode proves ugly — the
-   staging-environment wiring is the risk — and nothing in Phase 0 or 1 is wasted
-   either way, since the large-example scenarios use `rue_program_test` regardless.
+   Migration to `rue_program_test` stays the fallback if the staged-binary mode
+   proves ugly, and remains available later if individual scenario scheduling
+   ever demonstrates real value — RUE-1267's packer naming a single scenario as
+   a binding constraint is what that evidence would look like. Nothing in Phase
+   0 or 1 is wasted either way, since the large-example scenarios use
+   `rue_program_test` regardless.
 
 4. **Test-result caching.** Recommendation unchanged — **don't** — with two
-   reinforcements. Under question 2's proposal the corpus's scenario work is
-   already served by the action cache, because per-file corpus actions are cached
-   actions; the population of uncached test executions shrinks to
-   `rue_program_test` runs and ordinary unit tests, so the toolchain investment
-   buys even less than stated above. And the trust asymmetry deserves saying
+   reinforcements, and RUE-1164's own wording supports the posture: it says
+   caching may be *enabled only after* hermeticity validation, not that it must
+   be enabled. The first reinforcement: the corpus's scenario work is already
+   served by the action cache today, because RUE-1118's corpus suites are cached
+   actions — and Phase 2 moves the compiles into cached actions too. The
+   population of uncached test executions shrinks to `rue_program_test` runs and
+   ordinary unit tests, so the toolchain investment buys even less than stated
+   above. And the trust asymmetry deserves saying
    outright: cache writes are authorized by holding the credential, and enabling
    test-result caching widens what a poisoned entry can fake from an *artifact*,
    which still has to run and pass, to a *verdict*, which does not. That is a
@@ -840,9 +937,10 @@ determines whether migrating scenarios out of TOML buys anything.
 - **External linkers.** `rue_program` pins `--linker internal`. Cases covering
   `clang`/`gcc` linking stay in the harness.
 - **No change to what is tested.** Every scenario that runs today runs after, and
-  Phase 2 restores scenarios that currently run nowhere. The RUE-924 audit and the
-  tier-labelling contracts must survive each phase — see Consequences for how
-  Phase 2 threatens the first.
+  Phase 2 restores scenarios that currently run nowhere. The RUE-924 audit and
+  the tier-labelling contracts must survive each phase; under the recommended
+  Phase 2 both are untouched, and Consequences records the audit-escape hazard
+  that returns if the migration fallback is ever taken.
 - **Not a package system.** ADR-0047 leaves package resolution outside the
   compiler; `rue_program` is a build rule over resolved inputs, not a step toward
   one.

--- a/docs/designs/0070-rue-program-build-actions.md
+++ b/docs/designs/0070-rue-program-build-actions.md
@@ -1,0 +1,360 @@
+---
+id: 0070
+title: "Rue program compilation as declared Buck actions"
+status: proposal
+tags: [build, ci, testing, tooling]
+feature-flag: null
+created: 2026-08-11
+accepted:
+implemented:
+spec-sections: []
+superseded-by:
+relates: ["RUE-1164", "RUE-1118", "RUE-1222", "RUE-1267", "ADR-0047", "ADR-0069"]
+---
+
+# ADR-0070: Rue Program Compilation as Declared Buck Actions
+
+## Status
+
+Proposal. This is the reviewed design RUE-1164 asks for and ADR-0069 Phase 5
+defers to. Nothing here is implemented, and the granularity rule in
+"Which compiles become actions" plus the five items under "Open questions" are
+maintainer decisions rather than settled design.
+
+## Summary
+
+The compilation of a Rue program should be a first-class Buck artifact keyed on
+its real inputs — root source, declared import closure, generated source
+manifest, compiler build, flags, and target architecture — rather than a side
+effect hidden inside a test process or an aggregate success stamp.
+
+This ADR proposes two rules and one provider: `rue_program`, which owns exactly
+one compilation and produces the executable; and `rue_program_test`, which
+consumes that executable and runs one runtime scenario. Many scenarios share one
+compile. It also proposes a granularity rule that keeps the action count
+proportionate: a compile becomes its own action when it is expensive relative to
+action overhead, or when more than one scenario consumes its output. The ~4,050
+inline-source corpus cases stay inside their harnesses and get finer input keys
+instead.
+
+No compiler change is required. ADR-0047 Phases 3 and 4 (`--source-manifest`,
+`--emit deps`) are implemented and currently unconsumed; this design is their
+first client.
+
+## Context
+
+### Measurements
+
+Taken on this tree with `//crates/rue:rue` built from 18def29. Absolute wall
+clock is this host's and not CI's; the design rests on the ratios, which are
+large enough to survive any host.
+
+| Measurement | Value |
+| --- | --- |
+| `examples/caldera/main.rue` full compile | 243.0s (803 modules, 105k lines) |
+| `examples/meridian/main.rue` full compile | 80.7s (266 modules, 36k lines) |
+| `rue --emit deps` on caldera / meridian | 6.7s / 2.2s — 36x cheaper than compiling |
+| Corpus cases in total | 4,132 (1,778 CLI, 2,109 spec, 245 UI) |
+| CLI cases compiling a checked-in root | 73 cases across 13 distinct roots |
+| Most-recompiled roots | mosaic 17x, rill 12x, lattice 7x, meridian 6x |
+
+### Three defects, only one of which is about caching
+
+**The artifact is a success bit.** `cached_corpus_suite` (RUE-1118) declares
+`stamp.txt` as its output. A corpus action that compiles caldera produces no
+compiled caldera, so nothing downstream can consume one and every other consumer
+compiles it again. The rule is explicit about being a stamp; RUE-1164 is right
+that a stamp cannot be the destination.
+
+**The largest compiles were never in the mechanism.** The six
+`large-example-{caldera,meridian}-{canary,slow,stress}` targets are plain
+`rue_sh_test`s (`BUCK:397-447`). buck2 re-executes every test invocation — test
+executions are not actions and never reach the action cache — so the largest
+compilations in the repository re-run in full on every invocation that selects
+them, cold and warm alike. `-slow` and `-stress` compile the same `main.rue`
+root for each program and neither reuses the other's result.
+
+**Runtime scenarios are welded to compiles.** `crates/rue-cli-tests/cases/`
+`examples_meridian.toml` declares six cases against
+`source_path = "examples/meridian/main.rue"` with no `args` override. They differ
+only in `program_args` — `demo`, `run query.sql`, `run schema.sql`,
+`run unknown.sql`, `selftest`, `stress1`. The harness gives each case a fresh
+temp directory and its own compiler invocation, and `rue-cli-tests` performs no
+compile reuse anywhere, so testing six command-line behaviours of one binary
+costs six full 80-second compiles.
+
+The third is the shape of the whole problem. The case model already separates
+compile inputs (`files`, `source_path`, `args`, `env`) from runtime scenario
+(`program_args`, `program_env`, `stdin`, expectations). Only the execution
+topology is monolithic.
+
+### What the compiler already provides
+
+`--source-manifest` (ADR-0047 Phase 3) restricts import resolution to a
+line-oriented declared set and fails closed. Verified on this tree with a
+two-file program whose manifest omitted the imported module:
+
+```text
+error: [E1400]: invalid compiler input: import candidate
+       '/tmp/hermetic-test/helper.rue' is not listed in the source manifest read policy
+ --> main.rue:1:16
+  |
+1 | const helper = @import("helper.rue");
+  |                ^^^^^^^^^^^^^^^^^^^^^
+exit=1
+```
+
+`--emit deps` (ADR-0047 Phase 4) emits a JSON dependency envelope whose
+`accepted_reads` array is the compiler's observed read set with canonical paths
+and content fingerprints — 295 entries for meridian — plus a `topology` of
+resolution outcomes and an `observations` list of every probe, including the ones
+that missed.
+
+## Decision
+
+### Two rules and one provider
+
+`rue_program` owns exactly one compilation. Its action is a `ctx.actions.run`
+with category `rue_compile` and `allow_cache_upload = True`. Its inputs are the
+root source, every declared source, the standard library, the compiler binary via
+`$(exe_target //crates/rue:rue)`, and the manifest the rule generates; its
+command line carries the flags and target, so those key the action too.
+
+```python
+RueProgramInfo = provider(fields = [
+    "executable",      # the compiled artifact
+    "manifest",        # generated source manifest (the declared closure)
+    "root",            # root module
+    "rue_target",      # x86-64-linux | aarch64-linux | aarch64-macos
+    "opt_level",
+    "runs_natively",   # False for a cross-target program
+])
+
+rue_program(
+    name       = "meridian",
+    root       = "examples/meridian/main.rue",
+    srcs       = glob(["examples/meridian/**/*.rue"]),
+    std        = "//:std",
+    rue_target = "x86-64-linux",
+    opt_level  = "0",
+)
+
+rue_program_test(
+    name            = "meridian-selftest",
+    program         = ":meridian",       # consumes RueProgramInfo — no recompile
+    program_args    = ["selftest"],
+    data            = ["examples/meridian/demo.sql"],
+    stdout_contains = ["selftest checks=24", "valid=true"],
+    tier            = "slow",
+)
+```
+
+`rue_program_test` is an ordinary test target carrying exactly one tier label, so
+`test_tiers.bxl` validation and the `rue_heavy_suite` discovery contracts keep
+working unchanged.
+
+### Hermeticity is enforced in-band
+
+`rue_program` generates the source manifest from `srcs` and passes it as
+`--source-manifest`. Membership in the declared set therefore becomes
+load-bearing on every invocation — local and remote, cold and warm. An
+under-declared `rue_program` cannot silently pass, because it cannot build.
+
+This is deliberately stronger than ADR-0069's proposal to treat remote execution
+as the undeclared-input detector. RE is a good detector but a partial one: it
+catches only what RE actually runs. `corpus.bzl`'s header warns that under a
+cached action an undeclared input becomes a false pass rather than an untracked
+re-run; a generated manifest removes that hazard by construction rather than by
+scheduling.
+
+### Which compiles become actions
+
+There are 4,132 corpus cases. Reading "every compilation is an action" naively
+produces 4,132 actions, most compiling a ten-line program in milliseconds behind
+action overhead, cache-key computation over the whole standard library, and —
+under RE — a network round trip. That would be slower than today. It is the
+failure mode this class of migration usually dies of, and avoiding it is the
+load-bearing judgement in this ADR.
+
+**Rule: a compile becomes its own action when it is expensive relative to action
+overhead, or when more than one scenario consumes its output.** Everything else
+stays inside a harness process whose input key gets tightened instead.
+
+| Work | Scale | Disposition | Why |
+| --- | --- | --- | --- |
+| caldera, meridian — `main`, `canary`, stress roots | 6 roots | `rue_program` | 81–243s each, consumed by 5–6 scenarios apiece and by three suites |
+| `source_path` CLI cases | 73 cases, 13 roots | `rue_program` | 13 compiles instead of 73 |
+| Auto-discovered `examples/**` programs | ~43 roots | `rue_program` | Same roots reached again by reproducibility and frontend-diff |
+| Reproducibility fixture roots | 5 | `rue_program` | Relocation and perturbation are runtime scenarios over declared compiles |
+| Inline-source CLI / spec / UI cases | ~4,050 | harness | Sources live inside TOML, compiles are milliseconds; make the key finer, not the graph |
+
+For the harness bucket the remedy is input precision rather than action count.
+Today a one-line edit to `cases/modules.toml` invalidates all four CLI shards,
+because every shard declares the whole `cases` filegroup. Declaring per-shard
+case-file sets makes a case edit invalidate the one shard that owns it.
+
+### What contributes to the action key
+
+RUE-1164 enumerates these; each maps to a mechanism.
+
+| Required in the key | Mechanism | Notes |
+| --- | --- | --- |
+| Root source | action input | `attrs.source()` |
+| Transitive imports | action inputs | declared `srcs`; audited below |
+| Source manifest | generated input | `ctx.actions.write`; changes when `srcs` changes |
+| Compiler build | action input | `$(exe_target //crates/rue:rue)`; release vs debug already distinct via `//platforms:*` |
+| Compiler flags | command line | `-O`, `--preview`, `--linker`, `--link-archive` |
+| Target architecture | command line | `--target`; see open question 1 |
+| Runtime inputs | test-target inputs | `data`, `stdin`, `program_env` on `rue_program_test` |
+| Expected outputs | test-target attrs | expectations key the test, not the compile — which is the point of the split |
+
+### `--emit deps` as a declaration auditor
+
+The manifest makes under-declaration impossible. It does nothing about
+over-declaration, the quieter defect: a `rue_program` whose `srcs` glob is wider
+than its real import closure takes cache misses on files it never reads. Left
+unchecked, a broad glob turns a precise action back into a corpus stamp.
+
+A `rue_program_declaration_audit` target runs `rue --emit deps` and compares
+`accepted_reads` against the declared `srcs`, failing when a program declares
+inputs it provably never reads. At 2.2s against meridian's 80.7s compile the
+audit is affordable as an ordinary target.
+
+### Negative controls
+
+A hermeticity claim nobody executes decays, so each control is a real target.
+
+1. **Under-declared program must fail.** A fixture `rue_program` whose `srcs`
+   deliberately omits one imported module, asserted to fail with `E1400`. A
+   build-system compile-fail test; runs everywhere.
+2. **Clean-root / remote materialization.** Build the `rue_program` targets under
+   the existing no-fallback `//platforms:remote_execution` platform with
+   action-cache reads disabled, as the RUE-320 merge-group canary already does.
+   RE materializes only declared inputs, so an undeclared read fails with
+   file-not-found rather than passing.
+3. **Digest sensitivity.** Mutate one declared source and assert the action
+   re-executes; mutate an undeclared neighbour and assert it does not. This is
+   the direct test of the property the design claims, and nothing tests it today.
+
+Remote test-result caching stays off until 1–3 pass on a real branch. RUE-1164
+makes that ordering an acceptance criterion and this ADR keeps it strictly.
+
+## Implementation Phases
+
+Ordered so the first shippable phase is the biggest measurable win and each phase
+is independently revertible.
+
+- [ ] **Phase 0: Rules and controls** — `rue_rules.bzl` with `rue_program`,
+      `rue_program_test`, `RueProgramInfo`, manifest generation, and the three
+      negative controls. No existing target changes.
+- [ ] **Phase 1: Large examples** — convert the six `large-example-*` `sh_test`s.
+      One `rue_program` per (program, root); each scenario in
+      `scripts/run-large-example.sh` becomes its own `rue_program_test`, retiring
+      the script. Largest, entirely uncached, currently duplicated between the
+      slow and stress tiers.
+- [ ] **Phase 2: `source_path` CLI cases** — the 73 checked-in-root cases across
+      13 roots, meridian's six first. Depends on open question 4.
+- [ ] **Phase 3: Corpus input precision** — per-shard case-file declaration.
+      Independent of Phases 1 and 2 and safe to reorder.
+- [ ] **Phase 4: Test-result caching decision** — only after the negative
+      controls pass on a real branch. See open question 3.
+
+Linear issues are filed per phase under RUE-1164 once this ADR is accepted.
+
+## Consequences
+
+### Positive
+
+- Large programs compile once per compiler and architecture, and the result is a
+  real artifact many scenarios consume.
+- Warm merge-queue runs serve Rue compilation from BuildBuddy rather than
+  re-running it inside a harness.
+- Undeclared inputs become build failures instead of false passes, everywhere,
+  not only where RE runs.
+- Scenarios become individually selectable, schedulable and shardable targets,
+  which is what RUE-1267's packer needs and an opaque harness cannot offer.
+- ADR-0047 Phases 3 and 4 acquire their first consumer.
+
+### Negative
+
+- Two new rules and a provider are build-system surface area that did not exist,
+  and `rue_program` targets must be maintained alongside the programs they
+  compile.
+- Migrating `source_path` cases out of TOML splits the CLI authoring surface
+  between two mechanisms during Phases 2 and 3.
+- A `rue_program` whose `srcs` glob drifts wider than its import closure degrades
+  quietly into a coarse key; the declaration audit exists to catch that, and is
+  itself a target somebody must keep green.
+
+### Neutral
+
+- The compiler is a universal dependency, so a compiler change still invalidates
+  every `rue_program`. This ADR does not change that regime and does not claim
+  to; ADR-0069 measures it as roughly three quarters of changes.
+
+## Open Questions
+
+1. **Target architecture: attribute or configuration?** `//platforms:release`
+   exists because a bare modifier does not change a configured target's hash
+   (RUE-277), and the same argument could be made for a `//constraints:rue-target`
+   setting plus platforms. Recommendation: a plain attribute. The Rue target is a
+   property of the artifact requested, not of the machine building it, and one
+   package legitimately wants x86-64 and AArch64 programs side by side, which
+   configurations make awkward. The flag appears on the command line, so it keys
+   the action either way; RUE-277's problem was a modifier that keyed nothing.
+2. **How far to push corpus input precision.** Per-shard case-file declaration is
+   clearly right. Splitting `//:std` so a change to one module does not
+   invalidate every suite is a real cost/benefit call. Recommendation: stop at
+   per-shard — splitting std chases a change class ADR-0069 measures as rare and
+   buys complexity in the filegroup that most needs to stay obviously correct.
+3. **Test-result caching has no `sh_test` path.** ADR-0069 notes that buck2
+   carries `supports_test_execution_caching` on `ExternalRunnerTestInfo` and that
+   Rue's noop toolchains mean nothing honours it. Reading the bundled prelude for
+   the pinned 2026-07-15 buck2: the attribute exists only on the Java, Kotlin,
+   Python, C++ and Android test rules, and `sh_test_impl` never passes it — so
+   even with a non-noop test toolchain, no `sh_test` or `rue_sh_test` in this
+   repository can opt in. Enabling it means writing a Rue test rule that emits
+   `ExternalRunnerTestInfo` with the field set and replacing the noop toolchains.
+   Recommendation: do not. Once `rue_program` owns the expensive half, what
+   remains in a test execution is running a binary and comparing output; caching
+   that is a large toolchain change for a small remainder. Revisit only if
+   Phases 1–3 leave test execution on the critical path.
+4. **Does the CLI harness consume prebuilt artifacts, or do cases migrate out?**
+   Either `rue-cli-tests` learns to accept a prebuilt executable for a
+   `source_path` case, or those 73 cases become `rue_program_test` targets. The
+   first preserves one authoring surface and the RUE-924 corpus-omission audit;
+   the second gives the per-scenario targets the milestone is for.
+   Recommendation: migrate them out — they are already the least TOML-shaped
+   cases in the corpus, being a root and a scenario with no inline sources. This
+   is the decision with the largest blast radius on authoring ergonomics.
+5. **Stale remote-execution guidance.** `AGENTS.md` and the `./buck2` wrapper
+   still say not to use `--prefer-remote` "while RUE-320 remains open", while
+   `docs/process/build-cache.md` documents remote execution as supported and a
+   merge-group RE canary already runs. ADR-0069 flagged the contradiction and
+   left it; negative control 2 depends on which is true. Recommendation:
+   reconcile inside Phase 0.
+
+## Non-Goals
+
+- **Specification traceability stays independent of action caching.**
+  `//:spec-traceability` runs `rue-spec --traceability` over the case corpus and
+  `docs/spec/src`. It is not a compilation, must not become a scenario over one,
+  and keeps its own plain test target. RUE-1164 makes this an acceptance
+  criterion and this ADR reads it as load-bearing.
+- **No compiler changes.** `--source-manifest` and `--emit deps` both exist and
+  behave correctly. If this design needs a compiler change, something in it is
+  wrong.
+- **No change to what is tested.** Every scenario that runs today runs after; the
+  conversion is topology, not coverage. The RUE-924 corpus-omission audit and the
+  tier-labelling contracts must survive each phase.
+- **Not a package system.** ADR-0047 leaves package resolution outside the
+  compiler; `rue_program` is a build rule over resolved inputs, not a step toward
+  one.
+
+## References
+
+- ADR-0047 — root-module compilation units and build-system inputs
+- ADR-0069 §4 and Phase 5 — CI work scheduling for a compiler monorepo
+- `docs/process/build-cache.md` — remote cache and execution contracts
+- `corpus.bzl` — RUE-1118's cacheable corpus actions and their input contract
+- RUE-1164, RUE-1118, RUE-1222, RUE-1267

--- a/docs/designs/0070-rue-program-build-actions.md
+++ b/docs/designs/0070-rue-program-build-actions.md
@@ -9,7 +9,7 @@ accepted:
 implemented:
 spec-sections: []
 superseded-by:
-relates: ["RUE-1164", "RUE-1118", "RUE-1222", "RUE-1267", "ADR-0047", "ADR-0069"]
+relates: ["RUE-1164", "RUE-1118", "RUE-1222", "RUE-1267", "ADR-0047", "ADR-0051", "ADR-0069"]
 ---
 
 # ADR-0070: Rue Program Compilation as Declared Buck Actions
@@ -17,114 +17,157 @@ relates: ["RUE-1164", "RUE-1118", "RUE-1222", "RUE-1267", "ADR-0047", "ADR-0069"
 ## Status
 
 Proposal. This is the reviewed design RUE-1164 asks for and ADR-0069 Phase 5
-defers to. Nothing here is implemented, and the granularity rule in
-"Which compiles become actions" plus the five items under "Open questions" are
-maintainer decisions rather than settled design.
+defers to. Nothing here is implemented. The granularity rule under "Which
+compiles become actions" and the four items under "Open questions" are maintainer
+decisions rather than settled design.
 
 ## Summary
 
 The compilation of a Rue program should be a first-class Buck artifact keyed on
-its real inputs — root source, declared import closure, generated source
-manifest, compiler build, flags, and target architecture — rather than a side
-effect hidden inside a test process or an aggregate success stamp.
+its real inputs — root source, declared read closure, generated source manifest,
+compiler build, flags, target architecture, and any linked archives — rather than
+a side effect hidden inside a test process or an aggregate success stamp.
 
 This ADR proposes two rules and one provider: `rue_program`, which owns exactly
 one compilation and produces the executable; and `rue_program_test`, which
 consumes that executable and runs one runtime scenario. Many scenarios share one
-compile. It also proposes a granularity rule that keeps the action count
+compile. The manifest that makes the compile hermetic is derived from a cheap
+`--emit deps` scan rather than from the `srcs` glob, because a glob provably
+cannot produce a valid manifest. A granularity rule keeps the action count
 proportionate: a compile becomes its own action when it is expensive relative to
 action overhead, or when more than one scenario consumes its output. The ~4,050
-inline-source corpus cases stay inside their harnesses and get finer input keys
-instead.
+inline-source corpus cases stay inside their harnesses.
 
 No compiler change is required. ADR-0047 Phases 3 and 4 (`--source-manifest`,
 `--emit deps`) are implemented and currently unconsumed; this design is their
-first client.
+first client, and the scan-derived manifest is what makes both of them load-bearing
+at once.
 
 ## Context
 
 ### Measurements
 
 Taken on this tree with `//crates/rue:rue` built from 18def29. Absolute wall
-clock is this host's and not CI's; the design rests on the ratios, which are
-large enough to survive any host.
+clock is this host's and not CI's; the design rests on ratios and on which lane
+pays a cost, not on the absolute seconds.
 
 | Measurement | Value |
 | --- | --- |
 | `examples/caldera/main.rue` full compile | 243.0s (803 modules, 105k lines) |
 | `examples/meridian/main.rue` full compile | 80.7s (266 modules, 36k lines) |
+| `examples/caldera/canary.rue` full compile | 2.3s |
+| `examples/meridian/canary.rue` full compile | 3.1s |
 | `rue --emit deps` on caldera / meridian | 6.7s / 2.2s — 36x cheaper than compiling |
 | Corpus cases in total | 4,132 (1,778 CLI, 2,109 spec, 245 UI) |
-| CLI cases compiling a checked-in root | 73 cases across 13 distinct roots |
-| Most-recompiled roots | mosaic 17x, rill 12x, lattice 7x, meridian 6x |
+| CLI cases naming a checked-in root | 73 cases, 13 roots, 17 distinct (root, flags, target) tuples |
+| Most-recompiled roots | mosaic 17x, rill 12x, lattice 7x, calculator 7x, meridian 6x, jsonfmt 5x |
+
+**Where those costs are actually paid matters, and it is not where you would
+guess.** The 243.0s and 80.7s figures are `main.rue` compiles, which occur only in
+`release.yml`: the slow tier on a daily schedule, and the stress tier on
+`workflow_dispatch` only. The required pull-request and merge-queue path compiles
+only the two `canary.rue` roots, at 2.3s and 3.1s. The heavy corpora that were
+91–97% of the merge-queue critical path are already cached by RUE-1118. This ADR
+is therefore not a critical-path optimization, and the phase ordering below says
+so plainly.
 
 ### Three defects, only one of which is about caching
 
 **The artifact is a success bit.** `cached_corpus_suite` (RUE-1118) declares
-`stamp.txt` as its output. A corpus action that compiles caldera produces no
-compiled caldera, so nothing downstream can consume one and every other consumer
-compiles it again. The rule is explicit about being a stamp; RUE-1164 is right
-that a stamp cannot be the destination.
+`stamp.txt` as its output (`corpus.bzl:93`). A corpus action that compiles
+`examples/mosaic/main.rue` produces no compiled mosaic, so the 17 cases naming
+that root each compile it again and nothing outside the corpus can reuse any of
+them. The rule is explicit about being a stamp; RUE-1164 is right that a stamp
+cannot be the destination.
 
 **The largest compiles were never in the mechanism.** The six
 `large-example-{caldera,meridian}-{canary,slow,stress}` targets are plain
 `rue_sh_test`s (`BUCK:397-447`). buck2 re-executes every test invocation — test
-executions are not actions and never reach the action cache — so the largest
-compilations in the repository re-run in full on every invocation that selects
-them, cold and warm alike. `-slow` and `-stress` compile the same `main.rue`
-root for each program and neither reuses the other's result.
+executions are not actions and never reach the action cache — so they re-run in
+full on every invocation that selects them, cold and warm alike. Between them
+they compile only two roots per program (`main.rue` for both the slow and stress
+tiers, `canary.rue` for the canary), so the six targets represent **four distinct
+compile roots**; `stress.rue` is `@import`ed by `main.rue`
+(`examples/caldera/main.rue:12`) and is never a root.
 
-**Runtime scenarios are welded to compiles.** `crates/rue-cli-tests/cases/`
-`examples_meridian.toml` declares six cases against
-`source_path = "examples/meridian/main.rue"` with no `args` override. They differ
-only in `program_args` — `demo`, `run query.sql`, `run schema.sql`,
-`run unknown.sql`, `selftest`, `stress1`. The harness gives each case a fresh
-temp directory and its own compiler invocation, and `rue-cli-tests` performs no
-compile reuse anywhere, so testing six command-line behaviours of one binary
-costs six full 80-second compiles.
+**Runtime scenarios are welded to compiles, and the bill was paid in coverage.**
+`cases/examples_meridian.toml` declares six cases against
+`source_path = "examples/meridian/main.rue"` with no compile-flag override. The
+harness gives each case a fresh temp directory and its own compiler invocation,
+and `rue-cli-tests` performs no compile reuse anywhere — so the section costs six
+full 80-second compiles. It is not slow in CI, because **CI does not run it**:
+RUE-1083 disabled the section and the automatic example after per-case budget
+kills at 120.025s/120s and 300.022s/300s, via the `--skip` list at `BUCK:256-261`
+(`cases/examples_meridian.toml:6-12`). The same `--skip` list excludes caldera.
 
-The third is the shape of the whole problem. The case model already separates
-compile inputs (`files`, `source_path`, `args`, `env`) from runtime scenario
-(`program_args`, `program_env`, `stdin`, expectations). Only the execution
-topology is monolithic.
+That third defect is the shape of the whole problem, and its honest form is
+stronger than a wasted-seconds argument: **the welded topology did not cost time,
+it cost coverage.** Six scenarios of a 36k-line application are exercised nowhere
+in CI, because the only way to run the sixth was to compile the program a sixth
+time. A compile that is a cached artifact makes that coverage affordable again.
 
-### What the compiler already provides
+### What the compiler already provides, and what it demands in return
 
-`--source-manifest` (ADR-0047 Phase 3) restricts import resolution to a
-line-oriented declared set and fails closed. Verified on this tree with a
-two-file program whose manifest omitted the imported module:
+`--source-manifest` (ADR-0047 Phase 3) restricts import resolution to a declared
+set and fails closed. Verified on this tree with a two-file program whose manifest
+omitted the imported module:
 
 ```text
 error: [E1400]: invalid compiler input: import candidate
        '/tmp/hermetic-test/helper.rue' is not listed in the source manifest read policy
  --> main.rue:1:16
-  |
-1 | const helper = @import("helper.rue");
-  |                ^^^^^^^^^^^^^^^^^^^^^
-exit=1
 ```
 
-`--emit deps` (ADR-0047 Phase 4) emits a JSON dependency envelope whose
-`accepted_reads` array is the compiler's observed read set with canonical paths
-and content fingerprints — 295 entries for meridian — plus a `topology` of
-resolution outcomes and an `observations` list of every probe, including the ones
-that missed.
+Enforcement sits at the single read choke point (`crates/rue/src/source_loader.rs:406-431`),
+before any filesystem probe, with no warn-only mode.
+
+**The demand it makes in return is the hard part of this design, and an earlier
+draft of this ADR got it wrong.** Import resolution probes candidate arms in
+order — importer-relative before root-relative, file-module before directory
+facade (ADR-0051). A probe of an *undeclared* path returns `DeniedLexical`, which
+`is_failure()` treats as a failure (`import_discovery.rs:245-309`) — **even when a
+later, declared arm would have resolved**. A manifest listing only the files that
+exist therefore rejects programs that compile fine without a manifest. Reproduced
+directly:
+
+```text
+$ cat sub/types.rue
+const shared = @import("shared.rue");     # resolves root-relative to ./shared.rue
+
+$ rue root.rue -o prog                                   # no manifest
+Compiled root.rue -> prog                                # exit 0
+
+$ printf 'root.rue\nshared.rue\nsub/types.rue\n' > glob.manifest
+$ rue root.rue --source-manifest glob.manifest -o prog   # manifest from existing files
+error: [E1400]: import candidate '/tmp/absent-arm/sub/shared.rue'
+       is not listed in the source manifest read policy   # exit 1
+```
+
+The tree already knows this. `cases/modules.toml:105` declares
+`utils/_utils.rue # declared absent ambiguity arm` — a file that does not exist —
+and `scripts/test-reproducible-output.sh:40-44` hand-appends two nonexistent
+importer-relative arms with a comment citing the ADR-0051 read policy. The
+standard library is subject to the same rule: `@import("std")` goes through the
+policy, so an unlisted std fails identically.
+
+`--emit deps` (ADR-0047 Phase 4) is what closes this. Its envelope carries
+`accepted_reads` (the observed read set, with both `requested_path` and
+`canonical_path`) and `observations` (every probe, including the ones that came
+back `absent`, with the path that was requested).
 
 ## Decision
 
 ### Two rules and one provider
 
-`rue_program` owns exactly one compilation. Its action is a `ctx.actions.run`
-with category `rue_compile` and `allow_cache_upload = True`. Its inputs are the
-root source, every declared source, the standard library, the compiler binary via
-`$(exe_target //crates/rue:rue)`, and the manifest the rule generates; its
-command line carries the flags and target, so those key the action too.
+`rue_program` owns exactly one compilation and produces the executable.
+`rue_program_test` consumes it and runs one runtime scenario.
 
 ```python
 RueProgramInfo = provider(fields = [
     "executable",      # the compiled artifact
-    "manifest",        # generated source manifest (the declared closure)
-    "root",            # root module
+    "manifest",        # scan-derived source manifest
+    "deps_envelope",   # the --emit deps output the manifest came from
+    "root",
     "rue_target",      # x86-64-linux | aarch64-linux | aarch64-macos
     "opt_level",
     "runs_natively",   # False for a cross-target program
@@ -133,131 +176,208 @@ RueProgramInfo = provider(fields = [
 rue_program(
     name       = "meridian",
     root       = "examples/meridian/main.rue",
-    srcs       = glob(["examples/meridian/**/*.rue"]),
+    srcs       = glob(["examples/meridian/**/*.rue"]),   # the declared read bound
     std        = "//:std",
     rue_target = "x86-64-linux",
-    opt_level  = "0",
 )
 
 rue_program_test(
-    name            = "meridian-selftest",
+    name            = "meridian-rejects-unknown-query-table",
     program         = ":meridian",       # consumes RueProgramInfo — no recompile
-    program_args    = ["selftest"],
-    data            = ["examples/meridian/demo.sql"],
-    stdout_contains = ["selftest checks=24", "valid=true"],
+    program_args    = ["run", "unknown.sql"],
+    files           = [{"path": "unknown.sql", "source": "SELECT * FROM nope;\n"}],
+    exit_code       = 1,
+    stderr_contains = ["unknown table"],
     tier            = "slow",
 )
 ```
 
-`rue_program_test` is an ordinary test target carrying exactly one tier label, so
-`test_tiers.bxl` validation and the `rue_heavy_suite` discovery contracts keep
-working unchanged.
+Two properties of `rue_program_test` follow from what the cases actually do and
+must not be designed away. Runtime fixtures are frequently *inline and
+deliberately malformed* rather than checked-in files, so the rule needs a `files`
+mechanism of its own rather than only a `data` attribute pointing at repository
+paths. And several programs write output through relative paths, so the scenario
+needs a **writable working directory**, which a read-only runfiles tree is not.
 
-### Hermeticity is enforced in-band
+For `test_tiers.bxl` discovery to keep working the rule must satisfy two
+conditions explicitly, not incidentally: its name must keep the `_test` suffix so
+it matches the `^(.*_test|test_suite)$` kind regex, and it must expose a `labels`
+attribute that carries exactly one tier (`test_tiers.bxl:11-22`).
 
-`rue_program` generates the source manifest from `srcs` and passes it as
-`--source-manifest`. Membership in the declared set therefore becomes
-load-bearing on every invocation — local and remote, cold and warm. An
-under-declared `rue_program` cannot silently pass, because it cannot build.
+### Generating the manifest: a scan action, not a glob
 
+`rue_program` runs two actions.
+
+1. **Scan.** `rue --emit deps <root>` with no manifest, declaring `srcs` + `std`
+   as its Buck inputs. Because reads are unrestricted, resolution reports every
+   arm it probes — present and absent alike.
+2. **Compile.** `rue <root> --source-manifest <generated> -o <out>`, where the
+   manifest is `{requested_path of every accepted read} ∪ {requested_path of every
+   absent observation}`.
+
+Because the manifest content depends on an action output, the rule uses
+`dynamic_output`. Verified end to end on the reproducer above, and on a program
+importing the real standard library — the scan-derived manifest picks up all 30
+std modules without the rule naming them:
+
+```text
+$ rue --emit deps main.rue | derive-manifest > m.manifest    # 31 entries
+$ rue main.rue --source-manifest m.manifest -o prog
+Compiled main.rue -> prog                                    # exit 0
+```
+
+Deriving the manifest from the compiler's own report rather than from the file
+system also disposes of a spelling hazard: the manifest's first membership check
+is lexical and never resolves symlinks, so a hand-built manifest over a Buck
+symlink-tree materialization can contain spellings the compiler never asks for.
+Using `requested_path` — literally the string the compiler will ask for — makes
+the two agree by construction. Manifest entries are written absolute so that the
+manifest-relative resolution rule (entries resolve against the manifest file's
+directory, which for a generated manifest is buck-out) cannot misfire.
+
+**This is where the design's hermeticity actually lives, and it needs stating
+precisely.** The scan reads without a manifest, so on a local build it could in
+principle read a file outside `srcs` and quietly launder it into the manifest.
+Two things prevent that, and both are load-bearing rather than optional:
+
+- Under remote execution only declared inputs are materialized, so an undeclared
+  read fails outright.
+- The declaration audit below compares the scan's `accepted_reads` against `srcs`
+  and **fails when the compiler read anything the rule did not declare**. That
+  makes the audit part of the mechanism, not a nicety attached to it.
+
+The compile action then enforces the manifest in-band on every invocation, local
+and remote, cold and warm. `corpus.bzl`'s header warns that under a cached action
+an undeclared input becomes a false pass rather than an untracked re-run; the
+combination above removes that hazard by construction rather than by scheduling.
 This is deliberately stronger than ADR-0069's proposal to treat remote execution
-as the undeclared-input detector. RE is a good detector but a partial one: it
-catches only what RE actually runs. `corpus.bzl`'s header warns that under a
-cached action an undeclared input becomes a false pass rather than an untracked
-re-run; a generated manifest removes that hazard by construction rather than by
-scheduling.
+as the sole undeclared-input detector, which catches only what RE actually runs.
+
+No compiler change is involved: both flags exist and behave correctly today.
 
 ### Which compiles become actions
 
 There are 4,132 corpus cases. Reading "every compilation is an action" naively
 produces 4,132 actions, most compiling a ten-line program in milliseconds behind
-action overhead, cache-key computation over the whole standard library, and —
-under RE — a network round trip. That would be slower than today. It is the
-failure mode this class of migration usually dies of, and avoiding it is the
-load-bearing judgement in this ADR.
+action overhead, cache-key computation over the whole standard library, a scan
+action each, and — under RE — a network round trip. That would be slower than
+today. It is the failure mode this class of migration usually dies of, and
+avoiding it is the load-bearing judgement in this ADR.
 
 **Rule: a compile becomes its own action when it is expensive relative to action
-overhead, or when more than one scenario consumes its output.** Everything else
-stays inside a harness process whose input key gets tightened instead.
+overhead, or when more than one scenario consumes its output.**
 
 | Work | Scale | Disposition | Why |
 | --- | --- | --- | --- |
-| caldera, meridian — `main`, `canary`, stress roots | 6 roots | `rue_program` | 81–243s each, consumed by 5–6 scenarios apiece and by three suites |
-| `source_path` CLI cases | 73 cases, 13 roots | `rue_program` | 13 compiles instead of 73 |
-| Auto-discovered `examples/**` programs | ~43 roots | `rue_program` | Same roots reached again by reproducibility and frontend-diff |
-| Reproducibility fixture roots | 5 | `rue_program` | Relocation and perturbation are runtime scenarios over declared compiles |
-| Inline-source CLI / spec / UI cases | ~4,050 | harness | Sources live inside TOML, compiles are milliseconds; make the key finer, not the graph |
+| caldera, meridian — `main` and `canary` roots | 4 roots | `rue_program` | `main` is 81–243s; all four are consumed by several scenarios and by more than one suite |
+| CLI cases naming a checked-in root | 73 cases → 17 programs | `rue_program` | 17 distinct (root, flags, target) tuples; the fixture roots in `abi_conformance.toml` and `linker.toml` compile at three `--target`s each and stay three programs |
+| Auto-discovered `examples/**` roots not already covered | ~30 | `rue_program` | Reached again by the automatic-examples pass and by frontend-diff |
+| Inline-source CLI / spec / UI cases | ~4,050 | harness | Sources live inside TOML; compiles are milliseconds |
+| Reproducibility fixture | 4 roots | harness | See below — modelling these as actions is self-defeating |
 
-For the harness bucket the remedy is input precision rather than action count.
-Today a one-line edit to `cases/modules.toml` invalidates all four CLI shards,
-because every shard declares the whole `cases` filegroup. Declaring per-shard
-case-file sets makes a case edit invalidate the one shard that owns it.
+**The reproducibility suite must stay a harness, and the reason is instructive.**
+Its perturbations are compile-*time* (relocated source roots, mtimes, umask, `-j`,
+manifest order) and its assertion is that two compiles of the same declared inputs
+produce identical bytes. Those two compiles have the same action key by
+construction, so Buck would dedupe or cache-serve exactly the duplication the
+suite exists to perform. This is the same reason compiler reproducibility is
+cache-free by design (RUE-617/RUE-1019). A `rue_program` could supply one side of
+the comparison, but the suite must own the second compile itself.
 
 ### What contributes to the action key
-
-RUE-1164 enumerates these; each maps to a mechanism.
 
 | Required in the key | Mechanism | Notes |
 | --- | --- | --- |
 | Root source | action input | `attrs.source()` |
 | Transitive imports | action inputs | declared `srcs`; audited below |
-| Source manifest | generated input | `ctx.actions.write`; changes when `srcs` changes |
+| Source manifest | generated input | scan-derived; changes when any probed path changes |
 | Compiler build | action input | `$(exe_target //crates/rue:rue)`; release vs debug already distinct via `//platforms:*` |
-| Compiler flags | command line | `-O`, `--preview`, `--linker`, `--link-archive` |
-| Target architecture | command line | `--target`; see open question 1 |
-| Runtime inputs | test-target inputs | `data`, `stdin`, `program_env` on `rue_program_test` |
+| Compiler flags | command line | `-O`, `--preview`, `--target` |
+| Linked archives | **action inputs** | `--link-archive` bytes are read at link time, so the flag must carry a `$(location ...)` input, not a bare path string |
+| Linker | pinned | `rue_program` pins `--linker internal`; see below |
+| Runtime inputs | test-target inputs | `files`, `data`, `stdin`, `program_env` on `rue_program_test` |
 | Expected outputs | test-target attrs | expectations key the test, not the compile — which is the point of the split |
+
+`--linker clang|gcc` executes an undeclared `$PATH` binary and writes through
+`TMPDIR`, neither of which is a declared input. The default internal linker is
+genuinely hermetic — in-process, with the runtime embedded via `include_bytes!` —
+so `rue_program` pins it and external linking stays out of scope. Cases that
+exist to test external linkers remain harness cases.
 
 ### `--emit deps` as a declaration auditor
 
-The manifest makes under-declaration impossible. It does nothing about
-over-declaration, the quieter defect: a `rue_program` whose `srcs` glob is wider
-than its real import closure takes cache misses on files it never reads. Left
-unchecked, a broad glob turns a precise action back into a corpus stamp.
+The manifest makes under-declaration impossible at compile time; the audit makes
+it impossible at scan time and catches over-declaration besides. A
+`rue_program`'s `srcs` glob that is wider than its real read closure takes cache
+misses on files it never reads, which turns a precise action back into a corpus
+stamp.
 
-A `rue_program_declaration_audit` target runs `rue --emit deps` and compares
-`accepted_reads` against the declared `srcs`, failing when a program declares
-inputs it provably never reads. At 2.2s against meridian's 80.7s compile the
-audit is affordable as an ordinary target.
+The audit compares the scan envelope's `accepted_reads` against `srcs` in both
+directions. Three constraints on how, all of which matter:
+
+- Compare **path and fingerprint sets, never envelope bytes**: the envelope
+  embeds device/inode identity and mtimes (`dependency_envelope.rs:320-331`) and
+  is not machine-stable.
+- Compare against `srcs`, **not** the generated manifest — the manifest
+  legitimately contains absent-arm entries that are never read.
+- `accepted_reads` is the observed read set *of that run*; trusted-std
+  acquisition for fallible intrinsics happens only on semantic runs, so a program
+  that reaches std without `@import("std")` can read std files at compile time
+  that a scan does not list. The audit is `srcs`-scoped, so this is harmless, but
+  the envelope should not be described as a complete read set.
+
+Because the scan is already an action of `rue_program`, the audit is an assertion
+over an artifact the rule produces anyway rather than a separate compile.
 
 ### Negative controls
 
-A hermeticity claim nobody executes decays, so each control is a real target.
+RUE-1164 asks for clean-root and undeclared-input controls. An earlier draft
+claimed all three could be Buck targets; only the first can be, and the honest
+shape matters because the repository has strong precedent for the other two
+living outside the graph.
 
-1. **Under-declared program must fail.** A fixture `rue_program` whose `srcs`
-   deliberately omits one imported module, asserted to fail with `E1400`. A
-   build-system compile-fail test; runs everywhere.
-2. **Clean-root / remote materialization.** Build the `rue_program` targets under
-   the existing no-fallback `//platforms:remote_execution` platform with
-   action-cache reads disabled, as the RUE-320 merge-group canary already does.
-   RE materializes only declared inputs, so an undeclared read fails with
-   file-not-found rather than passing.
-3. **Digest sensitivity.** Mutate one declared source and assert the action
-   re-executes; mutate an undeclared neighbour and assert it does not. This is
-   the direct test of the property the design claims, and nothing tests it today.
+1. **Under-declared program must fail** — a Buck target. A fixture `rue_program`
+   whose `srcs` omits one imported module, wrapped so that the expected build
+   failure is *contained*: an uncontained failing target breaks
+   `buck2 build //...`. This is the direct test of E1400 enforcement and it runs
+   everywhere.
+2. **Clean-root / remote materialization** — a CI job, not a target. The RUE-320
+   merge-group canary is a workflow job that builds only `//crates/rue:rue`
+   (`ci.yml`), so covering `rue_program` targets is a workflow change rather than
+   a reuse of an existing target.
+3. **Digest sensitivity** — a CI script in the `scripts/check-reproducible-compiler.sh`
+   mould. Mutating a source and asserting the action re-executes requires driving
+   buck2 and reading its event log; every Buck-visible test in this repository
+   that touches buck2 stubs it, and the closest precedents deliberately live
+   outside the graph.
 
-Remote test-result caching stays off until 1–3 pass on a real branch. RUE-1164
-makes that ordering an acceptance criterion and this ADR keeps it strictly.
+Remote test-result caching stays off until all three pass on a real branch.
+RUE-1164 makes that ordering an acceptance criterion and this ADR keeps it
+strictly.
 
 ## Implementation Phases
 
-Ordered so the first shippable phase is the biggest measurable win and each phase
-is independently revertible.
-
-- [ ] **Phase 0: Rules and controls** — `rue_rules.bzl` with `rue_program`,
-      `rue_program_test`, `RueProgramInfo`, manifest generation, and the three
-      negative controls. No existing target changes.
-- [ ] **Phase 1: Large examples** — convert the six `large-example-*` `sh_test`s.
-      One `rue_program` per (program, root); each scenario in
-      `scripts/run-large-example.sh` becomes its own `rue_program_test`, retiring
-      the script. Largest, entirely uncached, currently duplicated between the
-      slow and stress tiers.
-- [ ] **Phase 2: `source_path` CLI cases** — the 73 checked-in-root cases across
-      13 roots, meridian's six first. Depends on open question 4.
-- [ ] **Phase 3: Corpus input precision** — per-shard case-file declaration.
-      Independent of Phases 1 and 2 and safe to reorder.
-- [ ] **Phase 4: Test-result caching decision** — only after the negative
-      controls pass on a real branch. See open question 3.
+- [ ] **Phase 0: Rules, scan-derived manifest, audit, controls** — `rue_rules.bzl`
+      with `rue_program`, `rue_program_test`, `RueProgramInfo`, the two-action
+      scan/compile shape, the declaration audit, and the three controls. Also the
+      stale-`--prefer-remote` documentation fix (see open questions). No existing
+      target changes.
+- [ ] **Phase 1: Large examples** — convert the six `large-example-*` `sh_test`s
+      over their four roots; each scenario in `scripts/run-large-example.sh`
+      becomes its own `rue_program_test`, retiring the script. **The justification
+      is not critical-path seconds** — the required path pays only 2.3s + 3.1s of
+      canary compiles. It is: the canary compiles stop re-executing on every
+      invocation and become shareable between `pull_request` and `merge_group`;
+      the scheduled release lane stops paying 243.0s and 80.7s twice when both the
+      slow and stress tiers run; and these are the clearest targets on which to
+      establish the mechanism.
+- [ ] **Phase 2: CLI cases naming a checked-in root** — 73 cases into 17
+      programs, meridian's six first, which is where the disabled coverage is
+      restored. Depends on open question 3.
+- [ ] **Phase 3: Corpus input precision** — see open question 2; this phase is
+      *not* specified here, because the obvious version of it does not work.
+- [ ] **Phase 4: Test-result caching decision** — only after the negative controls
+      pass on a real branch. See open question 4.
 
 Linear issues are filed per phase under RUE-1164 once this ADR is accepted.
 
@@ -265,88 +385,115 @@ Linear issues are filed per phase under RUE-1164 once this ADR is accepted.
 
 ### Positive
 
-- Large programs compile once per compiler and architecture, and the result is a
-  real artifact many scenarios consume.
-- Warm merge-queue runs serve Rue compilation from BuildBuddy rather than
-  re-running it inside a harness.
-- Undeclared inputs become build failures instead of false passes, everywhere,
-  not only where RE runs.
-- Scenarios become individually selectable, schedulable and shardable targets,
-  which is what RUE-1267's packer needs and an opaque harness cannot offer.
-- ADR-0047 Phases 3 and 4 acquire their first consumer.
+- Large programs compile once per compiler, flag set and architecture, and the
+  result is a real artifact many scenarios consume.
+- Coverage disabled by RUE-1083 becomes affordable again, which is a correctness
+  gain rather than a speed one.
+- Undeclared inputs become build failures everywhere rather than only where RE
+  runs, and the declaration audit closes the scan's laundering hole.
+- Scenarios become individually selectable and schedulable targets, which is the
+  "split" remedy in RUE-1267's alarm.
+- ADR-0047 Phases 3 and 4 acquire their first consumer, and the design needs both
+  of them, not just one.
 
 ### Negative
 
-- Two new rules and a provider are build-system surface area that did not exist,
-  and `rue_program` targets must be maintained alongside the programs they
-  compile.
-- Migrating `source_path` cases out of TOML splits the CLI authoring surface
-  between two mechanisms during Phases 2 and 3.
-- A `rue_program` whose `srcs` glob drifts wider than its import closure degrades
-  quietly into a coarse key; the declaration audit exists to catch that, and is
-  itself a target somebody must keep green.
+- `rue_program` is two actions and a `dynamic_output`, not one action. The scan is
+  36x cheaper than the compile, but it is not free, and it runs on every cache
+  miss.
+- The declaration audit is load-bearing rather than advisory, which means a target
+  that must stay green. Each audit is invalidated by every compiler change — the
+  ~74.5% class — so audit tier assignment is a real scheduling question, not a
+  formality.
+- Migrating the 73 cases splits the CLI authoring surface between two mechanisms
+  during Phases 2 and 3.
+- Migrated targets **escape** RUE-924's corpus-omission audit rather than break
+  it: that audit discovers `rue_heavy_suite` labels, so a `rue_program_test` that
+  does not join the discovery set is silently unaudited. Phase 2 must extend the
+  discovery set in the same change.
 
 ### Neutral
 
 - The compiler is a universal dependency, so a compiler change still invalidates
-  every `rue_program`. This ADR does not change that regime and does not claim
-  to; ADR-0069 measures it as roughly three quarters of changes.
+  every `rue_program` and every audit. This ADR does not change that regime;
+  ADR-0069 measures it as roughly three quarters of changes.
+- `runs_natively = False` programs (cross-target compiles) have no execution
+  story here. They are build-only targets with a structural-validation scenario
+  at most, and they inherit whatever platform scope ADR-0069 Phase 4 lands.
 
 ## Open Questions
 
 1. **Target architecture: attribute or configuration?** `//platforms:release`
-   exists because a bare modifier does not change a configured target's hash
-   (RUE-277), and the same argument could be made for a `//constraints:rue-target`
+   exists because, as `platforms/BUCK:23-33` records, a bare
+   `--modifier //constraints:release` left debug and release resolving to the same
+   configured output path while the toolchain's `rustc_flags` select never saw the
+   constraint. The same argument could be made for a `//constraints:rue-target`
    setting plus platforms. Recommendation: a plain attribute. The Rue target is a
-   property of the artifact requested, not of the machine building it, and one
-   package legitimately wants x86-64 and AArch64 programs side by side, which
-   configurations make awkward. The flag appears on the command line, so it keys
-   the action either way; RUE-277's problem was a modifier that keyed nothing.
-2. **How far to push corpus input precision.** Per-shard case-file declaration is
-   clearly right. Splitting `//:std` so a change to one module does not
-   invalidate every suite is a real cost/benefit call. Recommendation: stop at
-   per-shard — splitting std chases a change class ADR-0069 measures as rare and
-   buys complexity in the filegroup that most needs to stay obviously correct.
-3. **Test-result caching has no `sh_test` path.** ADR-0069 notes that buck2
-   carries `supports_test_execution_caching` on `ExternalRunnerTestInfo` and that
-   Rue's noop toolchains mean nothing honours it. Reading the bundled prelude for
-   the pinned 2026-07-15 buck2: the attribute exists only on the Java, Kotlin,
-   Python, C++ and Android test rules, and `sh_test_impl` never passes it — so
-   even with a non-noop test toolchain, no `sh_test` or `rue_sh_test` in this
-   repository can opt in. Enabling it means writing a Rue test rule that emits
-   `ExternalRunnerTestInfo` with the field set and replacing the noop toolchains.
-   Recommendation: do not. Once `rue_program` owns the expensive half, what
-   remains in a test execution is running a binary and comparing output; caching
-   that is a large toolchain change for a small remainder. Revisit only if
-   Phases 1–3 leave test execution on the critical path.
-4. **Does the CLI harness consume prebuilt artifacts, or do cases migrate out?**
-   Either `rue-cli-tests` learns to accept a prebuilt executable for a
-   `source_path` case, or those 73 cases become `rue_program_test` targets. The
-   first preserves one authoring surface and the RUE-924 corpus-omission audit;
-   the second gives the per-scenario targets the milestone is for.
-   Recommendation: migrate them out — they are already the least TOML-shaped
-   cases in the corpus, being a root and a scenario with no inline sources. This
-   is the decision with the largest blast radius on authoring ergonomics.
-5. **Stale remote-execution guidance.** `AGENTS.md` and the `./buck2` wrapper
-   still say not to use `--prefer-remote` "while RUE-320 remains open", while
-   `docs/process/build-cache.md` documents remote execution as supported and a
-   merge-group RE canary already runs. ADR-0069 flagged the contradiction and
-   left it; negative control 2 depends on which is true. Recommendation:
-   reconcile inside Phase 0.
+   property of the artifact requested, not of the machine building it — the
+   `abi_conformance` and `linker` fixtures want all three targets side by side in
+   one package, which attributes make trivial and configurations make awkward —
+   and `--target` is on the command line, so it keys the action either way. (Cite
+   the `platforms/BUCK` comment rather than RUE-277 itself: the issue records the
+   symptom, the comment records the mechanism.)
+2. **Phase 3 needs re-deriving; the obvious version does not work.** An earlier
+   draft called per-shard case-file declaration "clearly right". It is not
+   implementable as stated: shard assignment is per-*case* LPT cost-balancing over
+   `shard-weights.json` (`crates/rue-cli-tests/src/sharding.rs:76-105`), so one
+   TOML file's cases scatter across all four shards and the mapping churns on
+   every weights refresh (RUE-1222). Declaring per-shard file sets would require
+   either file-aligned packing — which ADR-0069 §6's skew analysis argues against
+   — or a generated shard→files mapping, which by ADR-0069's own ledger standard
+   needs a gate to count. Note also that the blast radius is wider than stated:
+   the `cases` filegroup keys **seven** corpus actions (four shards plus
+   `//:cli-tests`, `//:cli-tests-slow`, `//:release-smoke`), not four. Options:
+   make shard assignment a build-time fact with a gate; accept coarse keys for the
+   harness bucket; or drop the phase. I do not have a recommendation I trust here.
+3. **Do the CLI cases migrate out, or does the harness consume prebuilt
+   artifacts?** Either `rue-cli-tests` learns to accept a prebuilt executable for a
+   case naming a checked-in root, or those 73 cases become `rue_program_test`
+   targets. The first preserves one authoring surface and keeps RUE-924's audit
+   working unchanged; the second gives the per-scenario targets the milestone is
+   for, at the cost of extending the discovery set and reimplementing inline
+   runtime fixtures and a writable cwd. Recommendation: migrate them out — they
+   are the least TOML-shaped cases in the corpus. This has the largest blast
+   radius on authoring ergonomics of anything here.
+4. **Test-result caching: what actually blocks it.** ADR-0069 §4 suggests buck2's
+   `supports_test_execution_caching` is available and blocked only by Rue's noop
+   toolchains. Two corrections. For the *existing* corpora it is not available at
+   all: reading the bundled prelude for the pinned 2026-07-15 buck2, the attribute
+   appears only on the java/kotlin/cxx/python/android test decls, and
+   `sh_test_impl` constructs `ExternalRunnerTestInfo` without it — so no `sh_test`
+   or `rue_sh_test` here can opt in even with a live toolchain. But for
+   `rue_program_test` the objection is moot: it is a new rule emitting its own
+   `ExternalRunnerTestInfo`, so setting the field is one line. The real costs are
+   therefore the non-noop remote test toolchain and the trust decision RUE-1164
+   already gates behind the negative controls. Recommendation: still don't, but on
+   those grounds — once `rue_program` owns the expensive half, what remains in a
+   test execution is running a binary and comparing output, and caching that is a
+   toolchain change for a small remainder. Revisit if Phases 1–2 leave test
+   execution on the critical path.
+
+Note that RUE-1164 carries no comments, so none of these is pre-decided
+elsewhere.
 
 ## Non-Goals
 
 - **Specification traceability stays independent of action caching.**
   `//:spec-traceability` runs `rue-spec --traceability` over the case corpus and
   `docs/spec/src`. It is not a compilation, must not become a scenario over one,
-  and keeps its own plain test target. RUE-1164 makes this an acceptance
-  criterion and this ADR reads it as load-bearing.
+  and keeps its own plain test target. RUE-1164 makes this an acceptance criterion
+  and this ADR reads it as load-bearing.
 - **No compiler changes.** `--source-manifest` and `--emit deps` both exist and
-  behave correctly. If this design needs a compiler change, something in it is
-  wrong.
-- **No change to what is tested.** Every scenario that runs today runs after; the
-  conversion is topology, not coverage. The RUE-924 corpus-omission audit and the
-  tier-labelling contracts must survive each phase.
+  behave correctly, and the absent-arm problem is solved by using the second
+  rather than by relaxing the first. Tolerating undeclared *absent* probes would
+  be a compiler change and would weaken the read policy ADR-0051 defines; this
+  design does not ask for it.
+- **External linkers.** `rue_program` pins `--linker internal`. Cases covering
+  `clang`/`gcc` linking stay in the harness.
+- **No change to what is tested.** Every scenario that runs today runs after, and
+  Phase 2 restores scenarios that currently run nowhere. The RUE-924 audit and the
+  tier-labelling contracts must survive each phase — see Consequences for how
+  Phase 2 threatens the first.
 - **Not a package system.** ADR-0047 leaves package resolution outside the
   compiler; `rue_program` is a build rule over resolved inputs, not a step toward
   one.
@@ -354,7 +501,10 @@ Linear issues are filed per phase under RUE-1164 once this ADR is accepted.
 ## References
 
 - ADR-0047 — root-module compilation units and build-system inputs
+- ADR-0051 — canonical import resolution authority (the arm-probing order that
+  makes a glob-derived manifest invalid)
 - ADR-0069 §4 and Phase 5 — CI work scheduling for a compiler monorepo
 - `docs/process/build-cache.md` — remote cache and execution contracts
 - `corpus.bzl` — RUE-1118's cacheable corpus actions and their input contract
-- RUE-1164, RUE-1118, RUE-1222, RUE-1267
+- RUE-1164, RUE-1118, RUE-1222, RUE-1267; RUE-320 (remote execution, Done
+  2026-07-18); RUE-1083 (the budget kills that disabled the meridian section)

--- a/docs/designs/README.md
+++ b/docs/designs/README.md
@@ -232,4 +232,5 @@ The table is generated from ADR frontmatter. Run
 | [0067](0067-compiler-performance-measurement.md) | Compiler performance measurement, epochs, and dashboard | Proposal | tooling, ci, performance, website |
 | [0068](0068-incremental-edit-performance-measurement.md) | Incremental edit-scenario performance measurement | Accepted | tooling, compiler, incremental, performance |
 | [0069](0069-ci-work-scheduling.md) | CI work scheduling for a compiler monorepo | Accepted | process, ci, testing, build, performance |
+| [0070](0070-rue-program-build-actions.md) | Rue program compilation as declared Buck actions | Proposal | build, ci, testing, tooling |
 <!-- ADR-INDEX:END -->

--- a/docs/designs/README.md
+++ b/docs/designs/README.md
@@ -232,5 +232,5 @@ The table is generated from ADR frontmatter. Run
 | [0067](0067-compiler-performance-measurement.md) | Compiler performance measurement, epochs, and dashboard | Proposal | tooling, ci, performance, website |
 | [0068](0068-incremental-edit-performance-measurement.md) | Incremental edit-scenario performance measurement | Accepted | tooling, compiler, incremental, performance |
 | [0069](0069-ci-work-scheduling.md) | CI work scheduling for a compiler monorepo | Accepted | process, ci, testing, build, performance |
-| [0070](0070-rue-program-build-actions.md) | Rue program compilation as declared Buck actions | Proposal | build, ci, testing, tooling |
+| [0070](0070-rue-program-build-actions.md) | Rue program compilation as declared Buck actions | Accepted | build, ci, testing, tooling |
 <!-- ADR-INDEX:END -->


### PR DESCRIPTION
Docs only — no rules, no BUCK changes, nothing implemented. Refs RUE-1164; this is the reviewed design that issue asks for and the design ADR-0069 phase 5 defers to.

*(Rewritten at eff07c5, after four adversarial rounds plus two passes from Steve, which together changed the mechanism, the counts, the target-resolution model, and the phase sequence.)*

## What this proposes

`rue_program` — a build rule owning one compilation — and `rue_program_test`, which consumes its executable and runs one runtime scenario, plus a `RueProgramInfo` provider. Many scenarios share one compile. **12 programs**: 4 large-example roots and 8 from the CLI corpus. The 34 auto-discovered example roots stay in the automatic smoke harness (their claimed second consumer was false — frontend-diff compiles only ruelex), and the one-case wordfreq root joined them this round: its CI shard and the unsharded `//:cli-tests` are scheduling alternatives for one scenario, not two consumers.

**Target resolution is hybrid, per Steve's second pass.** The same target labels must run natively on Linux x86-64, Linux AArch64 and macOS AArch64 — today's `sh_test`s manage it by never passing `--target`. So `RueToolchainInfo` carries the configured platform's native Rue target (resolved the way `toolchains//:rust` already is), an explicit `rue_target` attribute means intentional cross-compilation, `runs_natively` is computed rather than asserted, and the compile always passes the *resolved* target explicitly so the key never depends on host detection.

## Why, honestly

The 243.0s caldera and 80.7s meridian compiles occur only in `release.yml`. **The required path pays two canary compiles, measured at 2.3s and 3.1s**, and the corpora that were 91–97% of the merge-queue critical path are already cached by RUE-1118. This is not a critical-path optimization, and the ADR says so.

The real motivation is coverage. `cases/examples_meridian.toml` has six cases against one root that differ only in scenario; the harness recompiles for each — and CI runs none of them, because RUE-1083 disabled the section after budget kills. **The welded topology did not cost time, it cost coverage.**

## The mechanism

`rue_program` is three static actions — scan (`--emit deps`, no manifest), derive, compile — because a glob provably cannot produce a valid manifest (absent candidate arms are `DeniedLexical`-fatal), the scan misses trusted-std reads (so the declared std is unioned in), and the derivation step is where the declared boundary is enforced: it **fails the build when any accepted read lies outside `srcs ∪ std`**, and re-anchors the envelope's absolute paths so a shared scan-cache hit is not a build failure on another machine.

**Boundary vs. precision.** Under-declaration is correctness and stays a required in-band failure at the derive step. Over-declaration is cache precision only and attaches as an **optional** `ValidationInfo` validation. The directory-scoped signal (a file no sibling reads) is computed by an explicit per-directory aggregate emitted by the same macro call that declares the sibling programs — a per-target validation sees one envelope and cannot compute it.

## The sequence, simplified

Phase 2 waits on nothing: the 64 CLI cases naming checked-in roots **keep their TOML form and their existing corpus actions** — each CLI corpus action declares the nine program artifacts through its existing `attrs.arg()` env and the harness runs the staged executable a case names. No sharding change, no TOML migration. The per-file corpus redesign is a concise **Future Work** section and an eventual ADR of its own; accepting this ADR neither approves nor forecloses it.

Controls: three negative (the under-declaration fixture pins the derivation-stage failure deterministically) plus one positive — Phase 1 owns warm BuildBuddy evidence, an explicit RUE-1164 acceptance criterion.

## Open questions

1. Target architecture (recommend: hybrid — platform-derived default, attribute override for cross-compilation; no transitions until built target-variant inputs or publication)
2. Per-file corpus actions replacing sharding (recommended for its **own ADR/issue**; detail in Future Work; gates nothing here)
3. Do CLI cases migrate out of TOML? (recommend: no — harness consumes prebuilt artifacts on the existing corpus actions)
4. Test-result caching (recommend: don't — RUE-1164 says *may be enabled only after* validation, not must)

## Validation

`//:adr-registry-validation` passes; `docs/designs/README.md` index regenerated with `scripts/validate-adrs.py --write`.