### PR TITLE
RUE-1262: derive the failed-batch pressure loop from the family bound

### DIFF
--- a/crates/rue-compiler/src/pipeline_tests.rs
+++ b/crates/rue-compiler/src/pipeline_tests.rs
@@ -466,6 +466,31 @@ mod tests {
     #[test]
     fn failed_wide_batches_release_their_unpublished_child_cones_under_pressure() {
         const CHAIN_FUNCTIONS: usize = 33;
+        // RUE-1262 ruling on what the pressure compiles buy. They are a witness
+        // generator, not headroom and not sustained contention: a failed batch
+        // that leaks pins onto children it never published keeps those
+        // terminals `protected` in the eviction scan, so they survive at *any*
+        // iteration count and the discriminating check is the re-entry
+        // assertion below. The compiles need only guarantee that a genuinely
+        // released terminal would have gone by then, so that "still present"
+        // means "leaked" rather than "not yet pushed out".
+        //
+        // That is set by the family bound, not by the host. Eviction here is
+        // driven by a per-family retained-*count* watermark, and
+        // `compiler.cfg`, `compiler.optimized-cfg`, and `compiler.codegen-unit`
+        // are all built at BODY_QUERY_MEMO_RETENTION = 8 against the
+        // CHAIN_FUNCTIONS + 1 = 34 terminals one compile publishes into each.
+        // One compile clears every watermark four times over; two are margin.
+        // The byte and pin budgets are a separate mechanism and never bind at
+        // their defaults, so nothing here depends on the allocator or platform.
+        //
+        // This was 16, inherited from the sibling pressure tests in this
+        // module, whose iterations compile a one-function program and are
+        // nearly free. This one compiles a 34-function chain per iteration.
+        // Width is load-bearing — it is what makes the batch wide and puts
+        // terminals-per-compile above the family bound — so the iteration
+        // count is the knob to cut, not CHAIN_FUNCTIONS.
+        const PRESSURE_COMPILES: i32 = 2;
         let options = CompileOptions::default();
         let last_good_source =
             SourceSnapshot::single("<backend-root-failure-pressure>", "fn main() -> i32 { 0 }")
@@ -497,14 +522,22 @@ mod tests {
 
         fail(&mut session, &failed_source);
         let evictions_before_pressure = session.query_evictions_for_test();
-        for value in 101..117 {
+        for value in 101..101 + PRESSURE_COMPILES {
             fail(&mut session, &wide_reached_program(CHAIN_FUNCTIONS, value));
         }
         assert!(
             session.query_evictions_for_test() > evictions_before_pressure,
-            "failed child cones must face real query-family eviction pressure"
+            "the pressure compiles must actually reach eviction; without it the \
+             re-entry assertion below cannot distinguish a released child cone \
+             from one that is merely still sitting under its family's watermark"
         );
 
+        // The discriminating check. `f0` is the only body that differs between
+        // `failed_source` and the pressure programs, so it is the one member of
+        // the failed batch's cone whose recomputation proves the cone was
+        // released: had the failed batch kept its pins, `f0`'s CodegenUnit
+        // terminal would have been protected from the eviction above and this
+        // re-entry would report `Reused`.
         fail(&mut session, &failed_source);
         assert_eq!(
             session.codegen_executions().len(),

--- a/docs/notes/rue-1250-premerge-critical-path.md
+++ b/docs/notes/rue-1250-premerge-critical-path.md
@@ -200,6 +200,71 @@ RUE-1083/RUE-1086. What the measurement establishes is only its price: this one
 test is currently two-thirds of the pre-merge unit suite's cost, and the merge
 queue serializes on it.
 
+#### Update (2026-08-11): the price collapsed, and the ruling went the other way
+
+The figures above stand as measured, but they no longer describe trunk. Same
+host, same default configuration, `rue-compiler-test`:
+
+| | at `137e3f60` (2026-08-09) | at `18def29` (2026-08-11) |
+| -- | --: | --: |
+| the pressure test alone | 146.09s | 1.66s |
+| whole binary, parallel | 154.53s | 19.93s |
+| whole binary, serial | 196.78s | 60.24s |
+
+The collapse is not from this note's scope A or B, and it is not specific to
+this test. It is general compiler perf work landing: a sibling test that
+compiles the same 34-function chain across several revisions but has **no**
+eviction-pressure loop moved 10.22s → 0.60s over the same interval, while
+sibling tests that only compile one-function programs did not move
+(1.31s → 1.07s, 0.29s → 0.30s). The win is on repeated revisions of a wide
+program in one long-lived session, which is why this test — 19 wide revisions —
+shows it most extremely. It came from the trunk work between those two commits,
+which includes several query-runtime changes (RUE-1247 and RUE-1343 through
+RUE-1349); it has not been bisected to a single commit.
+
+Note that a whole-suite subtraction hides this: the rest of `rue-compiler-test`
+went 50.69s → 58.58s across the same interval, because nearly all of those ~810
+tests compile toy programs where there is nothing to win.
+
+The premise of the split proposed above — that this test is two-thirds of the
+pre-merge unit suite — is gone, and with it the case for a `slow` variant: the
+big variant would run identical assertions on an identical program for no
+additional coverage, which is what separates it from the scaling-matrix and
+large-example precedents cited above.
+
+The ruling recorded in RUE-1262 and in the test itself is therefore to reduce
+the loop in place, from 16 iterations to a constant derived from the family
+retention bound, and to state in the test what the iterations buy. The eviction
+this test needs is driven by a per-family retained-*count* watermark
+(`BODY_QUERY_MEMO_RETENTION = 8`) against 34 terminals per compile, so it is a
+property of the graph rather than of the host, and one compile already clears
+it four times over. That also bounds the blast radius if the per-compile
+constant ever regresses again: 5 compiles rather than 19.
+
+##### The lane is no longer governed by one item
+
+`scripts/rue premerge`, warm, on the same 4-core host: 113.9s wall, 199.7s
+serial across 144 targets. (That denominator is not this note's 80 — the script
+also runs the per-crate fmt and clippy gates.) The head of the distribution:
+
+| target | seconds | share of serial |
+| -- | --: | --: |
+| `//crates/rue-oracle-diff:rue-oracle-diff-test` | 37.4 | 18.7% |
+| `//crates/rue-compiler:rue-compiler-test` | 25.5 | 12.8% |
+| `//crates/rue-compiler:scaling-matrix-test` | 18.4 | 9.2% |
+| `//:tutorial-snippet-tests` | 15.7 | 7.9% |
+| `//crates/rue-fuzz:rue-fuzz-test` | 12.7 | 6.4% |
+
+The four-core LPT bound is now `max(37.4, 199.7/4) = 49.9s` — set by aggregate
+work, not by the largest indivisible item, which is the end state this note's
+"Projection" predicted. The gap between that bound and the 113.9s measured wall
+is scheduling and build serialization, so any further premerge work is a packer
+question (RUE-1267), not a single-test question.
+
+This is warm and local. It says nothing about the cold compiler build inside
+the CI premerge job, which the ADR-0069 sample put at 354–393s in 3 of 9 runs;
+on CI that, not any test, is the likely binding constraint now.
+
 ## What this means for RUE-1250
 
 The sharding question is answered in the negative for premerge. Do not add lanes


### PR DESCRIPTION
Closes RUE-1262.

Scope A landed in #2156. This is scope B, the ruling the issue was waiting on.

## The ruling

The 16 pressure compiles in
`failed_wide_batches_release_their_unpublished_child_cones_under_pressure` are a
**witness generator** — neither of the two readings the issue offered.

The defect the test guards is a failed registered batch leaking pins onto child
cones it never published. A pinned terminal is `protected` in
`evict_one_from_family` (`crates/rue-query/src/lib.rs:5165`) and gets pushed back
onto the retention queue, so a leaked cone is never evicted at *any* iteration
count. Extra iterations therefore add no discriminating power against the
failure mode the test is named for. The check that does the work is the re-entry
assertion: `f0` is the only body that differs between `failed_source` and the
pressure programs, so its recomputation is what proves the cone was released.

What the compiles must buy is only the guarantee that a *released* terminal
would have gone by then. That is set by the family bound, not by the host:
eviction here is driven by a per-family retained-**count** watermark
(`next_publish_sweep`, `crates/rue-query/src/lib.rs:6349`), and `compiler.cfg`,
`compiler.optimized-cfg`, and `compiler.codegen-unit` are all built at
`BODY_QUERY_MEMO_RETENTION = 8`
(`crates/rue-compiler/src/revisioned_query_database.rs:170`) against the 34
terminals one compile publishes into each. One compile clears every watermark
four times over. The 8 GiB / 4M byte and pin budgets are a separate mechanism
with their own counters and never bind here, so nothing in this test depends on
the allocator or the platform — which is what rules out the "headroom" reading.

The 16 was inherited: both sibling pressure tests in the module use the same
`for value in 100..116` idiom, but their iterations compile a one-function
program and are nearly free. This one compiles a 34-function chain per
iteration, and the count survived that change unexamined.

So: reduce the loop to a constant derived from the family bound, keep
`CHAIN_FUNCTIONS = 33` (width is what makes the batch wide and puts
terminals-per-compile above the bound — it is the wrong knob to cut), and record
the derivation in the test.

**No `slow` variant.** The scaling-matrix and large-example precedents split
because the big variant tests something the canary cannot. Here it would run
identical assertions on an identical program past a saturated threshold.

## The premise changed while the issue was open

The issue's projection was built on this test costing 181.7s, later 94.6s. It
does not any more. One 4-core host, default configuration, same binary:

| | `137e3f60` (2026-08-09) | `18def29` (2026-08-11) | this PR |
| -- | --: | --: | --: |
| the pressure test alone | 146.09s | 1.66s | **0.43s** |
| `rue-compiler-test`, parallel | 154.53s | 19.93s | **19.76s** |
| `rue-compiler-test`, serial | 196.78s | 60.24s | **61.06s** |

**That collapse is general compiler perf work, not this test and not scope A.**
A sibling test compiling the same 34-function chain across several revisions
with *no* eviction-pressure loop moved 10.22s → 0.60s over the same interval,
while siblings that only compile one-function programs did not move
(1.31s → 1.07s, and 0.29s → 0.30s). The win is on repeated revisions of a wide
program in one long-lived session, which is why this test — 19 wide revisions —
shows it most extremely. It came from the trunk work between those commits
(RUE-1247, RUE-1343–RUE-1349) and has not been bisected to a single commit.
Worth noting that a whole-suite subtraction hides it entirely: the rest of
`rue-compiler-test` went 50.69s → 58.58s, because ~810 of those tests compile
toy programs where there is nothing to win.

So this PR buys **no wall time** — 19.93s → 19.76s is noise, and the ~1.2s of
serial CPU is masked by the other three cores. Its value is the recorded ruling,
and a bounded blast radius: if the per-compile constant regresses, this test
costs 5 compiles instead of 19, which at the cost it had two days ago is the
difference between ~7s and 146s.

## The lane is no longer governed by one item

`scripts/rue premerge`, warm, same host: 113.9s wall, 199.7s serial over 144
targets (a bigger denominator than the issue's 80 — the script also runs the
per-crate fmt and clippy gates). Head of the distribution:

| target | seconds | share of serial |
| -- | --: | --: |
| `//crates/rue-oracle-diff:rue-oracle-diff-test` | 37.4 | 18.7% |
| `//crates/rue-compiler:rue-compiler-test` | 25.5 | 12.8% |
| `//crates/rue-compiler:scaling-matrix-test` | 18.4 | 9.2% |
| `//:tutorial-snippet-tests` | 15.7 | 7.9% |
| `//crates/rue-fuzz:rue-fuzz-test` | 12.7 | 6.4% |

The four-core LPT bound is `max(37.4, 199.7/4) = 49.9s`, set by aggregate work
rather than by the largest indivisible item — the end state RUE-1262's
Projection predicted. The remaining gap to the 113.9s wall is scheduling and
build serialization, i.e. RUE-1267's packer question, not a single-test
question. This is warm and local and says nothing about the cold compiler build
inside the CI job, which ADR-0069 put at 354–393s in 3 of 9 sampled runs; on CI
that is the likely binding constraint now.

The note keeps its original measurements and gets a dated update recording all
of the above.

## What I did not add

The acceptance asks that the assertion state what the iterations buy. I tried to
back that with a bounded-retention assertion and could not find a sound one, so
there isn't one:

- global `retained_terminals` grows monotonically across the loop in the
  *healthy* case (715 → 892 → 1069), because each pressure program is new source
  and declaration-keyed families accumulate legitimately;
- `retention_growth` is also nonzero and rising when healthy (93 → 148), since a
  live closure exceeding its family floor is documented grow-with-pressure
  behaviour, not a leak.

Both were measured rather than assumed. A numeric bound would have been a magic
number that fails on unrelated changes, so the invariant is carried by the
derived constant and the assertion messages instead.

## Validation

- `scripts/rue premerge` — 144 pass, 0 fail
- `//crates/rue-compiler:rue-compiler-fmt-check`, `//crates/rue-compiler:rue-compiler-clippy`
- the changed test, 3 runs: 0.42s / 0.43s / 0.44s

The last acceptance item — "re-measured premerge lane wall time on CI, not only
locally" — comes from this PR's own CI run. All figures above are one host, one
sample per configuration; the order-of-magnitude findings clear that noise floor
comfortably, the 19.93s vs 19.76s comparison does not.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Lvx312Xe92sdTgdddghGHU)_