### PR TITLE
RUE-1259: strike flat-namespace remnants from spec 10.3

### DIFF
--- a/crates/rue-air/src/sema/visibility.rs
+++ b/crates/rue-air/src/sema/visibility.rs
@@ -47,8 +47,10 @@ impl<D: DeclarationPhase> Sema<'_, D> {
     ///   `pub`, or the reference is in the item's directory — ADR-0026
     ///   intra-directory visibility), the reference is fine.
     /// - Otherwise the reference is an error (E0460), naming the item's
-    ///   defining file. Whether that file was loaded via `@import` or merely
-    ///   listed on the command line makes no difference.
+    ///   defining file. Ordinary unqualified lookups are file-local, so this
+    ///   fires only on the comptime resolution paths that carry a reference
+    ///   into another file, e.g. applying a private comptime type constructor
+    ///   in type position (RUE-283).
     ///
     /// `item_kind` names the kind in the diagnostic ("function", "struct",
     /// "enum", "constant").

--- a/crates/rue-cli-tests/cases/modules.toml
+++ b/crates/rue-cli-tests/cases/modules.toml
@@ -1150,10 +1150,10 @@ error_contains = ["E0704", "til.rue"]
 #
 # Visibility boundaries are DIRECTORIES (ADR-0026, spec 10.3): a private item
 # is reachable from files in the same directory — including through a module
-# object — and rejected from any other directory, whether the call is
-# qualified (E0706) or unqualified (E0460). Privacy is uniform (RUE-180,
-# spec 10.3:7): it applies whether the defining file is imported or only
-# listed explicitly; the flat namespace (10.5:2) only resolves names.
+# object — and rejected from any other directory. Qualified access to a
+# private item is E0706 (spec 10.3:7, 10.4:18); an unqualified reference
+# never resolves into another file at all (spec 10.3:8), so it fails name
+# resolution before privacy applies.
 # ---------------------------------------------------------------------------
 
 [[case]]
@@ -1307,9 +1307,9 @@ args = ["main.rue", "util.rue", "-o", "prog"]
 compile_fail = true
 error_contains = ["unexpected extra source file", "util.rue", "@import"]
 
-# Structs and constants obey the same uniform rule (RUE-183): naming a
-# private struct (annotation or literal) or reading a private constant from
-# another directory is E0460, whether the file was imported or only listed.
+# Structs and constants obey the same module-scoped rule (RUE-183): an
+# unqualified reference to another module's struct or constant fails name
+# resolution regardless of visibility (spec 10.3:8).
 
 [[case]]
 name = "private_struct_cross_dir_unqualified_rejected"
@@ -1484,9 +1484,10 @@ args = ["main.rue", "lib.rue", "-o", "prog"]
 compile_fail = true
 error_contains = ["unexpected extra source file", "lib.rue", "@import"]
 
-# Enums obey the same uniform rule (RUE-185): naming a private enum from
-# another directory — annotation, variant construction, or match pattern —
-# is E0460, whether the file was imported or merely listed.
+# Enums obey the same module-scoped rule (RUE-185): an unqualified
+# reference to another module's enum — annotation, variant construction, or
+# match pattern — fails name resolution regardless of visibility (spec
+# 10.3:8).
 [[case]]
 name = "private_enum_cross_dir_unqualified_rejected"
 description = "Unqualified annotation/construction does not see an enum from another module, even when that module is imported."

--- a/docs/spec/src/10-modules/03-visibility.md
+++ b/docs/spec/src/10-modules/03-visibility.md
@@ -61,25 +61,25 @@ fn main() -> i32 {
 
 Visibility is uniform across every multi-file compilation and every item
 kind: an item is usable outside its defining directory if and only if it
-is `pub`, whether its defining file was loaded via `@import` or listed
-explicitly in the compilation. Access to a private item through a module
-binding from another directory is error E0706 (10.4:18) — this is the
-diagnostic for privacy violations, since cross-module references are
-spelled through module bindings. Where an implementation still accepts an
-unqualified reference that names a cross-directory item directly (legacy
-forms removed with flat mode, ADR-0046), referencing a private item that
-way is error E0460.
+is `pub`. Access to a private item through a module binding from another
+directory is error E0706 (10.4:18) — the diagnostic for privacy
+violations, since cross-module references are spelled through module
+bindings, and an unqualified reference to another file's item does not
+resolve at all (10.3:8). One form reports a distinct code: applying a
+comptime type constructor reached through a module binding in a type
+position (10.4:16) checks the constructor's visibility at the
+application site, and a private constructor applied from another
+directory is error E0460, naming the constructor and its defining file.
 
 {{ rule(id="10.3:8", cat="normative") }}
 
 Unqualified references resolve module-locally: a top-level name refers to
 an item of the referencing file (or a compiler builtin). A name defined
-only in other loaded files — imported or explicitly listed, `pub` or not,
-any directory — does not resolve unqualified; the reference is a
-name-resolution error (E0201 for variables/constants and enum type names
-in expressions, E0202 for functions, E0204 for types), never a silent
-resolution into another file. Cross-module access is spelled through a
-module binding (10.4:1).
+only in other loaded files — `pub` or not, in any directory — does not
+resolve unqualified; the reference is a name-resolution error (E0201 for
+variables/constants and enum type names in expressions, E0202 for
+functions, E0204 for types), never a silent resolution into another
+file. Cross-module access is spelled through a module binding (10.4:1).
 
 {{ rule(id="10.3:9", cat="example") }}
 

--- a/docs/spec/src/10-modules/04-module-bindings.md
+++ b/docs/spec/src/10-modules/04-module-bindings.md
@@ -177,11 +177,13 @@ distinct nominal types (10.5:2).
 {{ rule(id="10.4:18", cat="legality-rule") }}
 
 Privacy of module-qualified access is uniform across item kinds (10.3:7)
-and reports one diagnostic: accessing a private member through a module
-binding from a source file in another directory is a compile-time error
-E0706 — for a struct named in a qualified struct literal or type
-annotation, for an enum's variant, for an associated function's enclosing
-type, and for functions and constants alike.
+and reports one member-access diagnostic: accessing a private member
+through a module binding from a source file in another directory is a
+compile-time error E0706 — for a struct named in a qualified struct
+literal or type annotation, for an enum's variant, for an associated
+function's enclosing type, and for functions and constants alike. The one
+exception is the comptime type-constructor application form in a type
+position (10.4:16), which reports E0460 (10.3:7).
 
 {{ rule(id="10.4:19", cat="legality-rule") }}
 


### PR DESCRIPTION
Fixes RUE-1259.

## What this is

Spec 10.3:8–9 already state module-local resolution on trunk (the head-on contradiction with 10.5:2 described in the issue was fixed by earlier work), but secondary flat-namespace remnants survived. This change removes them:

- **10.3:7** — dropped "whether its defining file was loaded via `@import` or listed explicitly in the compilation" (there is no listing surface after ADR-0046) and replaced the "where an implementation still accepts an unqualified reference … (legacy forms removed with flat mode)" hedge, which contradicted 10.3:8, with an accurate statement of E0460's surviving role.
- **10.3:8** — dropped "imported or explicitly listed".
- **10.4:18** — narrowed the "reports one diagnostic" claim to member access and carved out the comptime type-constructor exception (see below), so 10.4:18, 10.3:7, and the pinned compiler behavior agree.
- Retired the flat-namespace framing from three section comments in `crates/rue-cli-tests/cases/modules.toml` (the cases themselves already pin name-resolution errors, not E0460) and from `check_unqualified_visibility`'s doc comment in `crates/rue-air/src/sema/visibility.rs`, which still said listing a file on the command line makes no difference.

## Findings against the issue's acceptance criteria

- **The flat namespace is fully removed** (ADR-0046 / RUE-767): the driver accepts exactly one positional root and every ordinary unqualified lookup is file-local. 10.5's prose recording the removal is intentional history and is untouched.
- **E0460 is not dead.** It lost its flat-mode trigger but still fires on the semantic type-syntax path: applying a *private comptime type constructor* through a module binding in type position (`let s: lib.Secret(i32)`) reports E0460, pinned by the RUE-283 CLI case `private_type_ctor_annotation_cross_dir_rejected` and emitted from `private_qualified_item_error` in `rue-air/src/sema/typeck.rs`. That is a *qualified* spelling, so it was also silently contradicting 10.4:18's one-diagnostic (E0706) claim — hence the carve-out.
- **The 10.3:9 example checks out** against the pinned corpus: each annotated error matches an existing spec/CLI case, and E0201/E0202/E0204/E0460/E0706 match `rue-error`'s code assignments.
- No other spec sections assume the flat namespace (audited for `flat`, `listed`, `command line`, `positional`, and `E0460`).

Rule IDs and categories are unchanged, so spec-test citations and the traceability gate are unaffected; the diff is prose and comments only.

## Left open (deliberately)

Whether the residual E0460-vs-E0706 split (same private item, different code for type-position vs expression-position access) should be unified is a compiler-diagnostic decision this PR documents but does not make.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ts9sSvxX6zNCUASs1yE8cv)_