### PR TITLE
Lifetime markers drive frame-slot reuse for disjoint temporaries

### DIFF
--- a/crates/rue-cli-tests/cases/frame_slot_reuse.toml
+++ b/crates/rue-cli-tests/cases/frame_slot_reuse.toml
@@ -1,0 +1,472 @@
+# Marker-driven frame-slot reuse (RUE-768).
+#
+# The CFG brackets every local's storage with `storage_live`/`storage_dead`.
+# Codegen used to discard both and give every CFG local slot a private frame
+# cell for the whole function, so a temporary confined to one block or one
+# match arm still cost a cell everywhere else. The frame-slot planner now
+# merges locals whose storage windows a may-be-live dataflow proves disjoint,
+# and keeps everything it cannot prove unshared.
+#
+# Two halves are pinned here, and both matter:
+#
+# - BEHAVIOR. Every case asserts exact stdout and exit code across all
+#   optimization levels. A wrongly merged slot is silent data corruption — one
+#   local reading another's bytes — so the values are the real regression net.
+# - LAYOUT. `--emit stackframe` against an explicit `--target` pins the frame
+#   size that reuse (or the deliberate absence of reuse) produces on BOTH
+#   backends. Without these a future change could quietly stop sharing, or
+#   start sharing something it must not, with the behavior cases still green.
+
+[section]
+id = "cli.frame_slot_reuse"
+name = "Marker-driven frame-slot reuse"
+description = "Locals with provably disjoint storage windows share frame cells; overlapping, borrow-extended, and address-escaping locals never do (RUE-768)."
+
+# --- Reuse happens for provably disjoint temporaries ------------------------
+
+# Four sequential blocks, each with two locals that die at the block's end.
+# Nine CFG local slots (`total` plus four pairs) collapse onto three cells.
+[[case]]
+name = "disjoint_block_temporaries_share_cells"
+description = "Sequential scopes whose storage windows never overlap reuse the same two cells."
+files = [{ path = "main.rue", source = """
+fn main() -> i32 {
+    let mut total = 0;
+    {
+        let a = 1;
+        let b = 2;
+        total = total + a + b;
+    }
+    {
+        let c = 3;
+        let d = 4;
+        total = total + c + d;
+    }
+    {
+        let e = 5;
+        let f = 6;
+        total = total + e + f;
+    }
+    {
+        let g = 7;
+        let h = 8;
+        total = total + g + h;
+    }
+    @dbg(total);
+    0
+}
+""" }]
+stdout = "36\n"
+exit_code = 0
+differential_opt = true
+
+[[case]]
+name = "disjoint_block_temporaries_share_cells_frame_x86_64"
+description = "The nine CFG local slots above occupy three x86-64 frame cells."
+files = [{ path = "main.rue", source = """
+fn main() -> i32 {
+    let mut total = 0;
+    {
+        let a = 1;
+        let b = 2;
+        total = total + a + b;
+    }
+    {
+        let c = 3;
+        let d = 4;
+        total = total + c + d;
+    }
+    {
+        let e = 5;
+        let f = 6;
+        total = total + e + f;
+    }
+    {
+        let g = 7;
+        let h = 8;
+        total = total + g + h;
+    }
+    @dbg(total);
+    0
+}
+""" }]
+args = ["--emit", "stackframe", "--target", "x86-64-linux", "main.rue"]
+compile_only = true
+# One callee-saved push plus three local cells, rounded to 32 bytes. Without
+# reuse the nine slots produced an 80-byte frame.
+compile_stdout_contains = ["=== Stack Frame (main) ===", "Frame size: 32 bytes"]
+
+[[case]]
+name = "disjoint_block_temporaries_share_cells_frame_aarch64"
+description = "The same nine CFG local slots occupy three AArch64 frame cells."
+files = [{ path = "main.rue", source = """
+fn main() -> i32 {
+    let mut total = 0;
+    {
+        let a = 1;
+        let b = 2;
+        total = total + a + b;
+    }
+    {
+        let c = 3;
+        let d = 4;
+        total = total + c + d;
+    }
+    {
+        let e = 5;
+        let f = 6;
+        total = total + e + f;
+    }
+    {
+        let g = 7;
+        let h = 8;
+        total = total + g + h;
+    }
+    @dbg(total);
+    0
+}
+""" }]
+args = ["--emit", "stackframe", "--target", "aarch64-linux", "main.rue"]
+compile_only = true
+# Without reuse the nine slots produced a 96-byte AArch64 frame.
+compile_stdout_contains = ["=== Stack Frame (main) ===", "Frame size: 64 bytes"]
+
+# --- Overlapping lifetimes NEVER share --------------------------------------
+
+# The same eight values, all live to the end of the function. Nothing may be
+# merged, and the frame must stay exactly as wide as before RUE-768.
+[[case]]
+name = "overlapping_lifetimes_never_share"
+description = "Eight simultaneously live locals keep eight private cells."
+files = [{ path = "main.rue", source = """
+fn main() -> i32 {
+    let a = 1;
+    let b = 2;
+    let c = 3;
+    let d = 4;
+    let e = 5;
+    let f = 6;
+    let g = 7;
+    let h = 8;
+    @dbg(a + b + c + d + e + f + g + h);
+    0
+}
+""" }]
+stdout = "36\n"
+exit_code = 0
+differential_opt = true
+
+[[case]]
+name = "overlapping_lifetimes_never_share_frame_x86_64"
+description = "Eight overlapping windows still occupy eight x86-64 cells."
+files = [{ path = "main.rue", source = """
+fn main() -> i32 {
+    let a = 1;
+    let b = 2;
+    let c = 3;
+    let d = 4;
+    let e = 5;
+    let f = 6;
+    let g = 7;
+    let h = 8;
+    @dbg(a + b + c + d + e + f + g + h);
+    0
+}
+""" }]
+args = ["--emit", "stackframe", "--target", "x86-64-linux", "main.rue"]
+compile_only = true
+compile_stdout_contains = ["=== Stack Frame (main) ===", "Frame size: 80 bytes"]
+
+[[case]]
+name = "overlapping_lifetimes_never_share_frame_aarch64"
+description = "Eight overlapping windows still occupy eight AArch64 cells."
+files = [{ path = "main.rue", source = """
+fn main() -> i32 {
+    let a = 1;
+    let b = 2;
+    let c = 3;
+    let d = 4;
+    let e = 5;
+    let f = 6;
+    let g = 7;
+    let h = 8;
+    @dbg(a + b + c + d + e + f + g + h);
+    0
+}
+""" }]
+args = ["--emit", "stackframe", "--target", "aarch64-linux", "main.rue"]
+compile_only = true
+compile_stdout_contains = ["=== Stack Frame (main) ===", "Frame size: 96 bytes"]
+
+# --- Multi-slot aggregates move as units ------------------------------------
+
+# Three three-slot structs in disjoint scopes: ten CFG local slots collapse to
+# four cells (`sum` plus one shared three-slot run). A merge that split an
+# aggregate across two regions, or overlaid it by anything other than its whole
+# span, would scramble the digits of the printed sum.
+[[case]]
+name = "multi_slot_aggregates_share_as_whole_runs"
+description = "Three-slot structs in disjoint scopes overlay one three-slot run, field for field."
+files = [{ path = "main.rue", source = """
+struct Triple { a: i32, b: i32, c: i32 }
+
+fn main() -> i32 {
+    let mut sum = 0;
+    {
+        let x = Triple { a: 1, b: 2, c: 3 };
+        sum = sum + x.a * 100 + x.b * 10 + x.c;
+    }
+    {
+        let y = Triple { a: 4, b: 5, c: 6 };
+        sum = sum + y.a * 100 + y.b * 10 + y.c;
+    }
+    {
+        let z = Triple { a: 7, b: 8, c: 9 };
+        sum = sum + z.a * 100 + z.b * 10 + z.c;
+    }
+    @dbg(sum);
+    0
+}
+""" }]
+stdout = "1368\n"
+exit_code = 0
+differential_opt = true
+
+[[case]]
+name = "multi_slot_aggregates_share_as_whole_runs_frame_x86_64"
+description = "Ten CFG local slots of three-slot structs occupy four x86-64 cells."
+files = [{ path = "main.rue", source = """
+struct Triple { a: i32, b: i32, c: i32 }
+
+fn main() -> i32 {
+    let mut sum = 0;
+    {
+        let x = Triple { a: 1, b: 2, c: 3 };
+        sum = sum + x.a * 100 + x.b * 10 + x.c;
+    }
+    {
+        let y = Triple { a: 4, b: 5, c: 6 };
+        sum = sum + y.a * 100 + y.b * 10 + y.c;
+    }
+    {
+        let z = Triple { a: 7, b: 8, c: 9 };
+        sum = sum + z.a * 100 + z.b * 10 + z.c;
+    }
+    @dbg(sum);
+    0
+}
+""" }]
+args = ["--emit", "stackframe", "--target", "x86-64-linux", "main.rue"]
+compile_only = true
+compile_stdout_contains = ["=== Stack Frame (main) ===", "Frame size: 64 bytes"]
+
+[[case]]
+name = "multi_slot_aggregates_share_as_whole_runs_frame_aarch64"
+description = "The same ten CFG local slots occupy four AArch64 cells."
+files = [{ path = "main.rue", source = """
+struct Triple { a: i32, b: i32, c: i32 }
+
+fn main() -> i32 {
+    let mut sum = 0;
+    {
+        let x = Triple { a: 1, b: 2, c: 3 };
+        sum = sum + x.a * 100 + x.b * 10 + x.c;
+    }
+    {
+        let y = Triple { a: 4, b: 5, c: 6 };
+        sum = sum + y.a * 100 + y.b * 10 + y.c;
+    }
+    {
+        let z = Triple { a: 7, b: 8, c: 9 };
+        sum = sum + z.a * 100 + z.b * 10 + z.c;
+    }
+    @dbg(sum);
+    0
+}
+""" }]
+args = ["--emit", "stackframe", "--target", "aarch64-linux", "main.rue"]
+compile_only = true
+compile_stdout_contains = ["=== Stack Frame (main) ===", "Frame size: 64 bytes"]
+
+# --- A borrow keeps a slot alive past its last direct use -------------------
+
+# `held`'s last DIRECT read is `held.a`, before `scoped` is even declared. Only
+# the borrow at the end keeps it in use. A last-direct-use analysis would call
+# the two windows disjoint and overlay `scoped` (100, 200) onto `held` (1, 2),
+# printing 601 instead of 304. The storage markers say otherwise, and the
+# markers are what the planner merges on.
+[[case]]
+name = "borrow_extended_lifetime_keeps_its_slot"
+description = "A local borrowed after another local's whole scope keeps a private run."
+files = [{ path = "main.rue", source = """
+struct Pair { a: i32, b: i32 }
+
+fn total(borrow p: Pair) -> i32 {
+    p.a + p.b
+}
+
+fn main() -> i32 {
+    let held = Pair { a: 1, b: 2 };
+    let direct = held.a;
+    let mut sum = direct;
+    {
+        let scoped = Pair { a: 100, b: 200 };
+        sum = sum + total(borrow scoped);
+    }
+    @dbg(sum + total(borrow held));
+    0
+}
+""" }]
+stdout = "304\n"
+exit_code = 0
+differential_opt = true
+
+[[case]]
+name = "borrow_extended_lifetime_keeps_its_slot_frame_x86_64"
+description = "The borrow-extended local and the scoped one keep six separate x86-64 cells."
+files = [{ path = "main.rue", source = """
+struct Pair { a: i32, b: i32 }
+
+fn total(borrow p: Pair) -> i32 {
+    p.a + p.b
+}
+
+fn main() -> i32 {
+    let held = Pair { a: 1, b: 2 };
+    let direct = held.a;
+    let mut sum = direct;
+    {
+        let scoped = Pair { a: 100, b: 200 };
+        sum = sum + total(borrow scoped);
+    }
+    @dbg(sum + total(borrow held));
+    0
+}
+""" }]
+args = ["--emit", "stackframe", "--target", "x86-64-linux", "main.rue"]
+compile_only = true
+compile_stdout_contains = ["=== Stack Frame (main) ===", "Frame size: 64 bytes"]
+
+[[case]]
+name = "borrow_extended_lifetime_keeps_its_slot_frame_aarch64"
+description = "The same six cells on AArch64."
+files = [{ path = "main.rue", source = """
+struct Pair { a: i32, b: i32 }
+
+fn total(borrow p: Pair) -> i32 {
+    p.a + p.b
+}
+
+fn main() -> i32 {
+    let held = Pair { a: 1, b: 2 };
+    let direct = held.a;
+    let mut sum = direct;
+    {
+        let scoped = Pair { a: 100, b: 200 };
+        sum = sum + total(borrow scoped);
+    }
+    @dbg(sum + total(borrow held));
+    0
+}
+""" }]
+args = ["--emit", "stackframe", "--target", "aarch64-linux", "main.rue"]
+compile_only = true
+compile_stdout_contains = ["=== Stack Frame (main) ===", "Frame size: 80 bytes"]
+
+# --- Match arms: per-arm bindings share, and the value stays right ----------
+
+# Each arm binds its own payload local; at most two are ever live at once, so
+# `area`'s four CFG local slots become two cells. If an arm read another arm's
+# cell the areas would come out wrong.
+[[case]]
+name = "match_arm_bindings_share_cells"
+description = "Payload bindings confined to one match arm reuse the same cells across arms."
+files = [{ path = "main.rue", source = """
+enum Shape {
+    Circle(i32),
+    Rect(i32, i32),
+    Square(i32),
+}
+
+fn area(s: Shape) -> i32 {
+    match s {
+        Shape.Circle(r) => 3 * r * r,
+        Shape.Rect(w, h) => w * h,
+        Shape.Square(side) => side * side,
+    }
+}
+
+fn main() -> i32 {
+    @dbg(area(Shape.Circle(2)));
+    @dbg(area(Shape.Rect(3, 4)));
+    @dbg(area(Shape.Square(5)));
+    0
+}
+""" }]
+stdout = "12\n12\n25\n"
+exit_code = 0
+differential_opt = true
+
+# --- A raw-pointer address escape keeps its slot private --------------------
+
+# `@raw_mut` produces a first-class pointer the planner cannot follow, so the
+# operand's slot is never merged even though its window is disjoint from the
+# later block's. The write through the pointer must land on `probe`, and
+# `other` must be unaffected by it.
+[[case]]
+name = "raw_pointer_operands_keep_private_cells"
+description = "A local whose address escapes through @raw_mut is never merged with a later disjoint local."
+files = [{ path = "main.rue", source = """
+fn main() -> i32 {
+    let mut sum = 0;
+    {
+        let mut probe: i32 = 5;
+        let p: ptr mut i32 = checked { @raw_mut(probe) };
+        checked { @ptr_write(p, 9); };
+        sum = sum + probe;
+    }
+    {
+        let other: i32 = 41;
+        sum = sum + other;
+    }
+    @dbg(sum);
+    0
+}
+""" }]
+stdout = "50\n"
+exit_code = 0
+differential_opt = true
+
+# --- Zero-slot locals stay addressable --------------------------------------
+
+# A zero-sized local reserves no frame cells, so the CFG is allowed to root a
+# reference at `num_locals` itself — the slot one past the local area. The
+# planner must map that slot rather than treat it as out of range (an early
+# RUE-768 draft ICE'd here), and a zero-sized local next to a real one must not
+# disturb the real one's cells.
+[[case]]
+name = "zero_sized_locals_do_not_disturb_the_plan"
+description = "Zero-slot locals are mapped without an out-of-range panic and leave neighbouring cells intact."
+files = [{ path = "main.rue", source = """
+struct Marker {}
+
+fn main() -> i32 {
+    let _only: [Marker; 0] = [];
+    let mut sum = 0;
+    {
+        let _tag = Marker {};
+        let a = 7;
+        sum = sum + a;
+    }
+    {
+        let _other = Marker {};
+        let b = 35;
+        sum = sum + b;
+    }
+    @dbg(sum);
+    0
+}
+""" }]
+stdout = "42\n"
+exit_code = 0
+differential_opt = true

--- a/crates/rue-codegen/src/aarch64/cfg_lower.rs
+++ b/crates/rue-codegen/src/aarch64/cfg_lower.rs
@@ -218,6 +218,15 @@ impl<'a> CfgLower<'a> {
         self
     }
 
+    /// Install the pipeline's local frame-slot decision (RUE-768).
+    pub(crate) fn with_local_storage(
+        mut self,
+        local_storage: &'a crate::local_storage::LocalSlotPlan,
+    ) -> Self {
+        self.ctx = self.ctx.with_local_storage(local_storage);
+        self
+    }
+
     #[cfg(test)]
     pub(crate) fn new_unchecked(
         cfg: &'a Cfg,

--- a/crates/rue-codegen/src/aarch64/emit.rs
+++ b/crates/rue-codegen/src/aarch64/emit.rs
@@ -374,13 +374,13 @@ pub struct Emitter<'a> {
     fixups: Vec<Fixup>,
     /// Total number of local slots including spills (for stack frame size).
     num_locals: u32,
-    /// Original local count BEFORE regalloc added spill slots. CfgLower
-    /// generates parameter slot numbers against this count, so the prologue's
-    /// param stores must use it too — using the post-spill total stored params
-    /// at deeper slots than the body reads whenever anything spilled (params
-    /// then read uninitialized stack). Mirrors x86's num_locals_original.
-    /// (RUE-129)
-    num_locals_original: u32,
+    /// Frame slots the local area occupies after marker-driven slot sharing
+    /// (RUE-768), BEFORE regalloc added spill slots. CfgLower numbers the
+    /// parameter area from this base, so the prologue's param stores must use
+    /// it too — using the post-spill total stored params at deeper slots than
+    /// the body reads whenever anything spilled (params then read
+    /// uninitialized stack). Mirrors x86's `frame_local_slots`. (RUE-129)
+    frame_local_slots: u32,
     /// Frame slots of the (compacted) parameter area: homed parameters
     /// only — register-only parameters (RUE-1170) reserve no slots.
     num_params: u32,
@@ -429,7 +429,7 @@ impl<'a> Emitter<'a> {
     pub fn new(
         mir: &'a Aarch64Mir,
         num_locals: u32,
-        num_locals_original: u32,
+        frame_local_slots: u32,
         num_params: u32,
         callee_saved: &[Reg],
         strings: &'a [String],
@@ -453,7 +453,7 @@ impl<'a> Emitter<'a> {
             labels: LabelOffsets::with_capacity(estimated_inline_labels, estimated_block_labels),
             fixups: Vec::with_capacity(estimated_fixups),
             num_locals,
-            num_locals_original,
+            frame_local_slots,
             num_params,
             has_sret: false,
             callee_saved: callee_saved.to_vec(),
@@ -776,10 +776,10 @@ impl<'a> Emitter<'a> {
         // `start_slot` already reflects.
         for homing in self.param_homing_or_per_slot() {
             for k in 0..homing.reg_count {
-                // Use num_locals_original (not num_locals, which includes spill
+                // Use frame_local_slots (not num_locals, which includes spill
                 // slots): CfgLower generated the body's param reads against the
                 // pre-spill count. (RUE-129)
-                let slot = self.num_locals_original + homing.start_slot + k;
+                let slot = self.frame_local_slots + homing.start_slot + k;
                 // Slot location past the callee-saved area — the single
                 // AArch64 authority shared with the `--emit stackframe`
                 // reporter (RUE-774).
@@ -808,7 +808,7 @@ impl<'a> Emitter<'a> {
         // dedicated frame slot, one past the param area. The return path
         // loads it back to store the result through.
         if self.has_sret {
-            let slot = self.num_locals_original + self.num_params;
+            let slot = self.frame_local_slots + self.num_params;
             let offset = crate::frame_layout::aarch64_slot_offset(self.callee_saved.len(), slot);
             self.begin_inst();
             self.emit_str(param_regs[0], Reg::Fp, offset);

--- a/crates/rue-codegen/src/aarch64/mod.rs
+++ b/crates/rue-codegen/src/aarch64/mod.rs
@@ -69,20 +69,23 @@ fn prepare_backend_with_artifacts(
     crate::codegen_pipeline::prepare_mir_with_artifacts(
         cfg,
         type_pool,
+        interner,
         cfg_lower::ARG_REGS.len() as u32,
         cfg_lower::RET_REGS.len() as u32,
         crate::frame_layout::SavedRegScheme::Aarch64,
-        |param_storage| {
+        |param_storage, local_storage| {
             let (mir, lowering) = if request.lowering {
                 let (mir, debug) =
                     CfgLower::new_with_symbols(cfg, type_pool, interner, target, symbols)
                         .with_param_storage(param_storage)
+                        .with_local_storage(local_storage)
                         .lower_with_debug()?;
                 (mir, Some(debug))
             } else {
                 (
                     CfgLower::new_with_symbols(cfg, type_pool, interner, target, symbols)
                         .with_param_storage(param_storage)
+                        .with_local_storage(local_storage)
                         .lower()?,
                     None,
                 )
@@ -160,7 +163,7 @@ fn generate_inner(
     let emitter = Emitter::new(
         &prepared.mir,
         prepared.total_locals,
-        prepared.num_locals_original,
+        prepared.frame_local_slots,
         prepared.param_storage.homed_area_slots(),
         &prepared.used_callee_saved,
         &local_strings,

--- a/crates/rue-codegen/src/cfg_lower.rs
+++ b/crates/rue-codegen/src/cfg_lower.rs
@@ -328,13 +328,20 @@ pub(crate) struct CfgLowerContext<'a> {
     /// all-homed layout: every parameter ABI slot has a frame home at
     /// `num_locals + index`.
     param_storage: Option<&'a crate::param_storage::ParamStoragePlan>,
+    /// The pipeline's local frame-slot decision (RUE-768). `None` — a directly
+    /// constructed context in tests — behaves as the historical identity
+    /// layout: every CFG local slot keeps its own cell at its own index for
+    /// the whole function.
+    local_storage: Option<&'a crate::local_storage::LocalSlotPlan>,
 }
 
 impl<'a> CfgLowerContext<'a> {
     /// Create a new CFG lowering context with the historical all-homed
-    /// parameter storage (every parameter ABI slot has a frame home).
-    /// Production lowering supplies the pipeline's real plan via
-    /// [`with_param_storage`](Self::with_param_storage).
+    /// parameter storage (every parameter ABI slot has a frame home) and the
+    /// historical identity local layout. Production lowering supplies the
+    /// pipeline's real plans via
+    /// [`with_param_storage`](Self::with_param_storage) and
+    /// [`with_local_storage`](Self::with_local_storage).
     pub(crate) fn new(cfg: &'a Cfg, type_pool: &'a FrozenTypeInternPool) -> Self {
         Self {
             cfg,
@@ -342,6 +349,7 @@ impl<'a> CfgLowerContext<'a> {
             num_locals: cfg.num_locals(),
             num_params: cfg.num_params(),
             param_storage: None,
+            local_storage: None,
         }
     }
 
@@ -353,6 +361,18 @@ impl<'a> CfgLowerContext<'a> {
         param_storage: &'a crate::param_storage::ParamStoragePlan,
     ) -> Self {
         self.param_storage = Some(param_storage);
+        self
+    }
+
+    /// Install the pipeline's local frame-slot decision (RUE-768). The same
+    /// plan sets the base of the parameter area, the spill-placement floor,
+    /// and the emitted frame size, so lowering must consume this exact plan
+    /// rather than re-deriving one.
+    pub(crate) fn with_local_storage(
+        mut self,
+        local_storage: &'a crate::local_storage::LocalSlotPlan,
+    ) -> Self {
+        self.local_storage = Some(local_storage);
         self
     }
 
@@ -370,6 +390,14 @@ impl<'a> CfgLowerContext<'a> {
     pub(crate) fn homed_param_slots(&self) -> u32 {
         self.param_storage
             .map_or(self.num_params, |plan| plan.homed_area_slots())
+    }
+
+    /// Frame slots the (shared) local area occupies (RUE-768). This is the
+    /// base of the emitted parameter area, which the CFG's own slot numbering
+    /// places at `cfg.num_locals()`.
+    pub(crate) fn frame_local_slots(&self) -> u32 {
+        self.local_storage
+            .map_or(self.num_locals, |plan| plan.frame_local_slots())
     }
 
     // ========================================================================
@@ -434,12 +462,13 @@ impl<'a> CfgLowerContext<'a> {
     }
 
     /// The frame slot holding the incoming sret pointer, one past the
-    /// (compacted, RUE-1170) param area (only meaningful for an
-    /// sret-returning function). The prologue stores the hidden first
-    /// argument here; the return path loads it back to write the result
-    /// through. Register-allocator spill slots start after this slot.
+    /// (compacted, RUE-1170) param area, which itself starts past the (shared,
+    /// RUE-768) local area (only meaningful for an sret-returning function).
+    /// The prologue stores the hidden first argument here; the return path
+    /// loads it back to write the result through. Register-allocator spill
+    /// slots start after this slot.
     pub fn sret_ptr_slot(&self) -> u32 {
-        self.num_locals + self.homed_param_slots()
+        self.frame_local_slots() + self.homed_param_slots()
     }
 
     // ========================================================================
@@ -469,17 +498,31 @@ impl<'a> CfgLowerContext<'a> {
 
     /// Translate a CFG slot number into the emitted frame's slot number.
     ///
-    /// The CFG numbers parameter slots `num_locals..num_locals + num_params`
-    /// assuming every parameter is homed; the emitted frame compacts
-    /// register-only parameters away (RUE-1170). Local slots are identity.
+    /// The CFG numbers local slots `0..num_locals` assuming every local owns a
+    /// cell for the whole function and parameter slots
+    /// `num_locals..num_locals + num_params` assuming every parameter is
+    /// homed. The emitted frame narrows both: locals with provably disjoint
+    /// storage windows share cells (RUE-768) and register-only parameters are
+    /// compacted away (RUE-1170).
+    ///
     /// This is the single funnel every slot-addressed frame access passes
-    /// through; reaching it with a register-only parameter slot is a
+    /// through. Slots inside one multi-slot local keep their relative order,
+    /// so the `frame_slot(base) + k` addressing every aggregate access uses
+    /// stays correct. Reaching this with a register-only parameter slot is a
     /// planning bug (the storage plan must home every slot the body
     /// addresses), reported as a panic-backed ICE.
     pub fn frame_slot(&self, slot: u32) -> u32 {
         match self.slot_to_param_index(slot) {
-            None => slot,
+            None => self.local_frame_slot(slot),
             Some(index) => self.param_frame_slot(index),
+        }
+    }
+
+    /// The emitted frame slot of CFG local slot `slot` (RUE-768).
+    fn local_frame_slot(&self, slot: u32) -> u32 {
+        match self.local_storage {
+            None => slot,
+            Some(plan) => plan.frame_slot(slot),
         }
     }
 
@@ -496,6 +539,6 @@ impl<'a> CfgLowerContext<'a> {
                 )
             }),
         };
-        self.num_locals + area_slot
+        self.frame_local_slots() + area_slot
     }
 }

--- a/crates/rue-codegen/src/codegen_pipeline.rs
+++ b/crates/rue-codegen/src/codegen_pipeline.rs
@@ -63,7 +63,11 @@ pub(crate) fn plan_frame_pointer(total_slots: u32, is_leaf: bool) -> FramePointe
 pub(crate) struct PreparedMir<M, R> {
     pub(crate) mir: M,
     pub(crate) total_locals: u32,
-    pub(crate) num_locals_original: u32,
+    /// Frame slots the local area occupies after marker-driven slot sharing
+    /// (RUE-768), and therefore the base of the emitted parameter area. This
+    /// is at most `cfg.num_locals()`; spill slots are counted separately in
+    /// `total_locals`.
+    pub(crate) frame_local_slots: u32,
     pub(crate) has_sret: bool,
     pub(crate) used_callee_saved: Vec<R>,
     /// Per-source-parameter prologue homing plan (RUE-1005), covering only
@@ -156,11 +160,11 @@ pub(crate) fn validate_pre_lowering_budget(
 /// The closures monomorphize for each backend; there is no dynamic dispatch or
 /// universal backend trait. Keeping the two slot formulas here is deliberate:
 ///
-/// - `existing_slots` includes locals, the *homed* parameters (RUE-1170), and
-///   the optional incoming sret pointer so register-allocation spills cannot
-///   overlap any of them.
-/// - `total_locals` includes only original locals and new spill slots because
-///   emitters account for parameters and sret separately.
+/// - `existing_slots` includes the shared local area (RUE-768), the *homed*
+///   parameters (RUE-1170), and the optional incoming sret pointer so
+///   register-allocation spills cannot overlap any of them.
+/// - `total_locals` includes only the shared local area and new spill slots
+///   because emitters account for parameters and sret separately.
 ///
 /// Run the canonical backend pipeline while carrying optional diagnostic
 /// observations alongside the same lowering and allocation execution.
@@ -178,6 +182,7 @@ pub(crate) fn prepare_mir_with_artifacts<
 >(
     cfg: &Cfg,
     type_pool: &FrozenTypeInternPool,
+    interner: &lasso::ThreadedRodeo,
     arg_reg_count: u32,
     return_reg_count: u32,
     scheme: SavedRegScheme,
@@ -189,14 +194,16 @@ pub(crate) fn prepare_mir_with_artifacts<
     is_leaf: IsLeaf,
 ) -> CompileResult<(PreparedMir<M, R>, D)>
 where
-    Lower: FnOnce(&crate::param_storage::ParamStoragePlan) -> CompileResult<(M, D)>,
+    Lower: FnOnce(
+        &crate::param_storage::ParamStoragePlan,
+        &crate::local_storage::LocalSlotPlan,
+    ) -> CompileResult<(M, D)>,
     Allocate: FnOnce(M, u32, &mut D) -> CompileResult<(M, u32, Vec<R>)>,
     Peephole: FnOnce(&mut M),
     Schedule: FnOnce(&mut M),
     Verify: FnOnce(&M) -> CompileResult<()>,
     IsLeaf: FnOnce(&M) -> bool,
 {
-    let num_locals_original = cfg.num_locals();
     let has_sret =
         validate_pre_lowering_budget(cfg, type_pool, arg_reg_count, return_reg_count, scheme)?;
     // The per-parameter storage decision (RUE-1170) is computed once here and
@@ -207,13 +214,19 @@ where
         crate::param_storage::ParamStoragePlan::plan(cfg, type_pool, has_sret, arg_reg_count);
     let param_homing = param_storage.homing().to_vec();
     let homed_param_slots = param_storage.homed_area_slots();
+    // The local frame-slot decision (RUE-768) is target-independent and is
+    // likewise computed once: lowering addresses through it, the sums below
+    // place the parameter area and the spill floor above it, and the emitters
+    // size the frame from it.
+    let local_storage = crate::local_storage::LocalSlotPlan::plan(cfg, type_pool, interner);
+    let frame_local_slots = local_storage.frame_local_slots();
 
     let (mir, mut artifacts) = {
         let _span = info_span!("mir_lowering").entered();
-        lower(&param_storage)?
+        lower(&param_storage, &local_storage)?
     };
     let existing_slots =
-        checked_slot_sum([num_locals_original, homed_param_slots, u32::from(has_sret)])
+        checked_slot_sum([frame_local_slots, homed_param_slots, u32::from(has_sret)])
             .ok_or_else(|| frame_budget_error(cfg, None))?;
     let (mut mir, num_spills, used_callee_saved) = {
         let _span = info_span!("register_allocation").entered();
@@ -233,7 +246,7 @@ where
         verify(&mir)?;
     }
 
-    let total_locals = num_locals_original
+    let total_locals = frame_local_slots
         .checked_add(num_spills)
         .ok_or_else(|| frame_budget_error(cfg, None))?;
     let total_slots = checked_slot_sum([total_locals, homed_param_slots, u32::from(has_sret)])
@@ -253,7 +266,7 @@ where
         PreparedMir {
             mir,
             total_locals,
-            num_locals_original,
+            frame_local_slots,
             has_sret,
             used_callee_saved,
             param_homing,
@@ -310,11 +323,14 @@ mod tests {
         let (prepared, ()) = prepare_mir_with_artifacts(
             &cfg,
             &type_pool,
+            &lasso::ThreadedRodeo::new(),
             6,
             6,
             SavedRegScheme::X86_64,
-            |_param_storage| {
+            |_param_storage, local_storage| {
                 events.borrow_mut().push("lower");
+                // No storage markers, so the local layout is the identity.
+                assert_eq!(local_storage.frame_local_slots(), 3);
                 Ok((10_u32, ()))
             },
             |mir, existing_slots, _artifacts| {
@@ -351,7 +367,7 @@ mod tests {
         );
         assert_eq!(prepared.mir, 16);
         assert_eq!(prepared.total_locals, 7);
-        assert_eq!(prepared.num_locals_original, 3);
+        assert_eq!(prepared.frame_local_slots, 3);
         assert_eq!(prepared.param_storage.homed_area_slots(), 2);
         assert!(prepared.has_sret);
         assert_eq!(prepared.used_callee_saved, [5]);

--- a/crates/rue-codegen/src/lib.rs
+++ b/crates/rue-codegen/src/lib.rs
@@ -46,6 +46,7 @@ pub mod call_plan;
 mod codegen_pipeline;
 pub mod export_thunk;
 pub mod foreign_call;
+mod local_storage;
 mod param_storage;
 pub mod runtime_call_plan;
 mod schedule_core;

--- a/crates/rue-codegen/src/local_storage.rs
+++ b/crates/rue-codegen/src/local_storage.rs
@@ -1,0 +1,866 @@
+//! Marker-driven local frame-slot planning (RUE-768).
+//!
+//! The CFG brackets every local's storage with `StorageLive`/`StorageDead`
+//! markers. Codegen used to discard both as no-ops and give every CFG local
+//! slot its own frame cell for the whole function (an identity map through
+//! [`CfgLowerContext::frame_slot`](crate::cfg_lower::CfgLowerContext::frame_slot)),
+//! so a temporary confined to one arm of a `match` still cost a cell in every
+//! other arm.
+//!
+//! This module turns those markers into a frame-slot assignment: locals whose
+//! storage windows are **provably disjoint** share frame cells, and everything
+//! else keeps a private region. It is the local-slot counterpart of
+//! [`ParamStoragePlan`](crate::param_storage::ParamStoragePlan) (RUE-1170) and
+//! feeds the same single funnel, so the frame layout and the code that
+//! addresses it cannot drift apart.
+//!
+//! ## The unit of allocation
+//!
+//! A *slot entity* is one contiguous run of CFG local slots that must move
+//! through the frame as a unit. Its span is the widest reference rooted at its
+//! base slot: a `[Shape; 4]` local whose element type is three slots wide is
+//! one twelve-slot entity, never twelve independent cells, because every
+//! aggregate access is emitted as `frame_slot(base) + k`. Entities are built
+//! from *all* slot references, not just the markers, so an aggregate can never
+//! be split across two frame regions.
+//!
+//! ## What may share
+//!
+//! An entity is shareable only when every one of these holds:
+//!
+//! 1. It has at least one `StorageLive` marker — without a window there is
+//!    nothing to prove.
+//! 2. Every reference to it happens at a program point where its window is
+//!    open, under a may-be-live dataflow over the markers (`StorageLive` gens,
+//!    `StorageDead` kills, the entry state is empty, and a block's entry state
+//!    is the union over its reachable predecessors). A reference outside the
+//!    window would mean the markers do not describe the real lifetime, so such
+//!    an entity is kept private.
+//! 3. Its address is not exposed to a raw-pointer intrinsic
+//!    (`@raw`/`@raw_mut`/`@field_ptr`). Those produce a first-class pointer
+//!    that can outlive the operand's window; a private cell keeps such code
+//!    behaving exactly as it did before.
+//!
+//! Two shareable entities may occupy overlapping frame regions only when the
+//! dataflow proves their windows are never simultaneously open. Everything
+//! else — an unreferenced slot, or an entity that fails any test above — is
+//! modelled as interfering with every other entity and therefore gets a region
+//! of its own.
+//!
+//! By-reference call arguments (`inout`/`borrow`) need no special rule. Taking
+//! a callee-visible address of a local is an ordinary reference, so it must
+//! fall inside the local's window, and Rue scopes the borrow to the call: the
+//! reference semantics in `rue-oracle` model `inout`/`borrow` as
+//! copy-in/copy-out, so a borrow outliving its call is not a Rue program. A
+//! borrow that keeps a local in use *later* than its last direct load
+//! therefore holds the whole window open, and the window — not the last direct
+//! use — is what this analysis merges on.
+//!
+//! ## Failing closed
+//!
+//! Any shape the analysis cannot model exactly — a reference rooted inside
+//! another entity's span, a slot range that leaves the local area, an
+//! implausibly large function, a dataflow that does not converge, or a layout
+//! the disjointness verifier rejects — produces the identity plan, which is
+//! exactly the pre-RUE-768 layout. Sharing less is always sound; sharing
+//! wrongly is silent data corruption.
+//!
+//! The disjointness verifier runs twice and is **always on**, release builds
+//! included: [`verify_placement`] re-checks each merge as it is made, and
+//! [`verify_sharing`] re-derives the invariant from the finished layout. This
+//! crate deliberately carries no `debug_assert!`s (see
+//! `scripts/validate-debug-assert-policy.py`), because a check that vanishes
+//! in the shipped compiler is not a barrier against wrong generated code.
+
+use lasso::ThreadedRodeo;
+use rue_air::FrozenTypeInternPool;
+use rue_cfg::{BasicBlock, BlockId, Cfg, CfgInstData, CfgValue, PlaceBase, Type};
+
+/// Functions with more local slots than this keep the identity layout. The
+/// analysis is quadratic in entity count; real functions are orders of
+/// magnitude below the cap, and exceeding it costs only the optimization.
+const MAX_PLANNED_LOCAL_SLOTS: u32 = 4096;
+
+/// Work-product ceiling: the dataflow walks every block per entity and the
+/// audit/coloring are quadratic in entities, so slots x blocks approximates
+/// the planning cost. Generated mega-functions (the large examples) blow this
+/// budget and keep the identity layout — measured on harbor, planning them
+/// costs double-digit percent of total compile time for frame bytes nobody
+/// observes — while every human-scale function stays orders of magnitude
+/// below it (RUE-768 integration measurement).
+const MAX_PLANNED_COST: u64 = 65_536;
+
+/// Iteration cap for the may-be-live fixpoint. A gen/kill bit-vector problem
+/// solved round-robin in (roughly) reverse postorder converges in about as
+/// many passes as the CFG has nested loops, so this is orders of magnitude
+/// more headroom than any real function needs; a CFG that somehow exceeds it
+/// gets the identity plan instead of an unbounded solve.
+const MAX_DATAFLOW_ROUNDS: u32 = 64;
+
+/// A fixed-width bitset over entity indices.
+#[derive(Clone, PartialEq, Eq, Debug)]
+struct BitSet {
+    words: Vec<u64>,
+}
+
+impl BitSet {
+    fn new(bits: usize) -> Self {
+        Self {
+            words: vec![0; bits.div_ceil(64)],
+        }
+    }
+
+    fn set(&mut self, bit: usize) {
+        self.words[bit / 64] |= 1 << (bit % 64);
+    }
+
+    fn clear(&mut self, bit: usize) {
+        self.words[bit / 64] &= !(1 << (bit % 64));
+    }
+
+    fn get(&self, bit: usize) -> bool {
+        self.words[bit / 64] & (1 << (bit % 64)) != 0
+    }
+
+    fn union_with(&mut self, other: &Self) {
+        for (dst, src) in self.words.iter_mut().zip(&other.words) {
+            *dst |= *src;
+        }
+    }
+
+    fn fill(&mut self, bits: usize) {
+        for bit in 0..bits {
+            self.set(bit);
+        }
+    }
+
+    fn ones(&self) -> impl Iterator<Item = usize> + '_ {
+        self.words.iter().enumerate().flat_map(|(word, bits)| {
+            (0..64).filter_map(move |offset| {
+                (bits & (1_u64 << offset) != 0).then_some(word * 64 + offset)
+            })
+        })
+    }
+}
+
+/// One contiguous run of CFG local slots allocated as a unit.
+#[derive(Clone, Debug)]
+struct SlotEntity {
+    /// First CFG local slot of the run.
+    base: u32,
+    /// CFG local slots the run covers (always at least one).
+    span: u32,
+    /// May this entity's frame region overlap a non-interfering entity's?
+    shareable: bool,
+    /// Assigned first frame local slot, filled in by region assignment.
+    offset: u32,
+}
+
+/// A pair of entities the verifier rejected: their frame regions overlap even
+/// though their storage windows can be open at the same time.
+#[derive(Debug, PartialEq, Eq)]
+struct SharingViolation {
+    first: usize,
+    second: usize,
+}
+
+/// The per-function local frame-slot assignment.
+#[derive(Debug, Clone)]
+pub(crate) struct LocalSlotPlan {
+    /// CFG local slot -> emitted frame local slot.
+    map: Vec<u32>,
+    /// Frame local slots the assignment occupies.
+    frame_local_slots: u32,
+}
+
+impl LocalSlotPlan {
+    /// The historical plan: every CFG local slot keeps its own frame cell at
+    /// its own index. This is the fallback whenever the analysis cannot prove
+    /// a sharing decision, and the baseline the planned path shrinks from.
+    pub(crate) fn identity(num_locals: u32) -> Self {
+        Self {
+            map: (0..num_locals).collect(),
+            frame_local_slots: num_locals,
+        }
+    }
+
+    /// Plan local frame slots for `cfg` from its storage markers.
+    pub(crate) fn plan(
+        cfg: &Cfg,
+        type_pool: &FrozenTypeInternPool,
+        interner: &ThreadedRodeo,
+    ) -> Self {
+        Self::try_plan(cfg, type_pool, interner).unwrap_or_else(|| Self::identity(cfg.num_locals()))
+    }
+
+    /// The emitted frame local slot for CFG local slot `slot`.
+    ///
+    /// Slots inside one entity keep their relative order, so a multi-slot
+    /// aggregate access emitted as `frame_slot(base) + k` still addresses that
+    /// aggregate's own cells.
+    ///
+    /// A zero-slot (ZST) local occupies no cells, so the CFG is allowed to
+    /// root one at `num_locals` itself — the slot one past the local area,
+    /// which the plan therefore does not map. Such a slot keeps its CFG
+    /// number, exactly as the pre-RUE-768 identity layout gave it, and the
+    /// canonical ZST place address it yields (RUE-605) still names zero bytes.
+    pub(crate) fn frame_slot(&self, slot: u32) -> u32 {
+        self.map.get(slot as usize).copied().unwrap_or(slot)
+    }
+
+    /// Frame local slots the plan occupies (also the base of the emitted
+    /// parameter area).
+    pub(crate) fn frame_local_slots(&self) -> u32 {
+        self.frame_local_slots
+    }
+
+    /// Whether any two entities were merged onto shared cells.
+    #[cfg(test)]
+    pub(crate) fn shares_any_slot(&self) -> bool {
+        self.frame_local_slots < self.map.len() as u32
+    }
+
+    fn try_plan(
+        cfg: &Cfg,
+        type_pool: &FrozenTypeInternPool,
+        interner: &ThreadedRodeo,
+    ) -> Option<Self> {
+        let num_locals = cfg.num_locals();
+        if num_locals == 0 || num_locals > MAX_PLANNED_LOCAL_SLOTS {
+            return None;
+        }
+        if u64::from(num_locals) * cfg.blocks().len() as u64 > MAX_PLANNED_COST {
+            return None;
+        }
+
+        let refs = collect_slot_references(cfg, type_pool, interner)?;
+        let mut entities = build_entities(num_locals, &refs)?;
+        if entities.len() < 2 {
+            return None;
+        }
+
+        let preds = cfg.compute_predecessors();
+        let reachable = reachable_blocks(cfg, &preds);
+        let live_in = solve_may_be_live(cfg, &preds, &entities, &refs, &reachable)?;
+        let mut interference =
+            audit_and_collect_interference(cfg, &mut entities, &refs, &reachable, &live_in);
+        // An entity that cannot be proved safe interferes with everything, so
+        // region assignment gives it a private run of cells.
+        let count = entities.len();
+        for index in 0..count {
+            if entities[index].shareable {
+                continue;
+            }
+            interference[index].fill(count);
+            for row in interference.iter_mut() {
+                row.set(index);
+            }
+        }
+
+        // `assign_regions` re-verifies every merge as it makes it, and the
+        // finished layout is re-verified as a whole below. Both checks are
+        // always on, in release builds as well as debug ones: a layout the
+        // verifier rejects is discarded outright, and the identity plan —
+        // which cannot share anything — is emitted instead.
+        let frame_local_slots = assign_regions(&mut entities, &interference)?;
+        verify_sharing(&entities, &interference).ok()?;
+        if frame_local_slots >= num_locals {
+            // Nothing was saved; keep the identity map so every downstream
+            // consumer sees the simplest possible numbering.
+            return None;
+        }
+
+        let mut map = vec![u32::MAX; num_locals as usize];
+        for entity in &entities {
+            for k in 0..entity.span {
+                map[(entity.base + k) as usize] = entity.offset + k;
+            }
+        }
+        if map.contains(&u32::MAX) {
+            // Some local slot fell outside every entity's run — the entities
+            // do not tile the local area, so no mapping is safe to emit.
+            return None;
+        }
+        Some(Self {
+            map,
+            frame_local_slots,
+        })
+    }
+}
+
+/// One reference to a run of local slots made by one CFG instruction.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+struct SlotReference {
+    base: u32,
+    span: u32,
+    kind: ReferenceKind,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum ReferenceKind {
+    /// `StorageLive`: opens the window.
+    Live,
+    /// `StorageDead`: closes the window.
+    Dead,
+    /// An ordinary access that must fall inside the window.
+    Access,
+    /// An access that additionally hands the slot's address to a raw-pointer
+    /// intrinsic, whose result can outlive the window.
+    AddressEscape,
+}
+
+/// Per-instruction slot references, indexed by `CfgValue` raw index.
+struct SlotReferences {
+    per_value: Vec<Option<SlotReference>>,
+}
+
+impl SlotReferences {
+    fn get(&self, value: CfgValue) -> Option<SlotReference> {
+        self.per_value[value.as_u32() as usize]
+    }
+}
+
+/// Collect every local-slot reference in `cfg`.
+///
+/// Returns `None` when a reference runs off the end of the local slot area,
+/// which means this module's model of the function is wrong and no sharing may
+/// happen.
+fn collect_slot_references(
+    cfg: &Cfg,
+    type_pool: &FrozenTypeInternPool,
+    interner: &ThreadedRodeo,
+) -> Option<SlotReferences> {
+    let num_locals = cfg.num_locals();
+    let span_of = |ty: Type| crate::types::type_slot_count(type_pool, ty).max(1);
+    let mut per_value = vec![None; cfg.value_count()];
+    let escaping = address_escaping_operands(cfg, interner);
+
+    for block in cfg.blocks() {
+        for &value in &block.insts {
+            let inst = cfg.get_inst(value);
+            let reference = match &inst.data {
+                CfgInstData::StorageLive { slot, local_ty } => SlotReference {
+                    base: *slot,
+                    span: span_of(*local_ty),
+                    kind: ReferenceKind::Live,
+                },
+                CfgInstData::StorageDead { slot, local_ty } => SlotReference {
+                    base: *slot,
+                    span: span_of(*local_ty),
+                    kind: ReferenceKind::Dead,
+                },
+                // An `Alloc`'s own type is unit; the run it writes is the
+                // initializer's.
+                CfgInstData::Alloc { slot, init } => SlotReference {
+                    base: *slot,
+                    span: span_of(cfg.get_inst(*init).ty),
+                    kind: ReferenceKind::Access,
+                },
+                CfgInstData::Load { slot } => SlotReference {
+                    base: *slot,
+                    span: span_of(inst.ty),
+                    kind: ReferenceKind::Access,
+                },
+                CfgInstData::Store { slot, value } => SlotReference {
+                    base: *slot,
+                    span: span_of(cfg.get_inst(*value).ty),
+                    kind: ReferenceKind::Access,
+                },
+                CfgInstData::PlaceRead { place } | CfgInstData::PlaceWrite { place, .. } => {
+                    match place.base {
+                        PlaceBase::Local(slot) => SlotReference {
+                            base: slot,
+                            span: span_of(place.base_type),
+                            kind: ReferenceKind::Access,
+                        },
+                        _ => continue,
+                    }
+                }
+                _ => continue,
+            };
+            // Parameter-range slots are the parameter plan's business
+            // (RUE-1170); only the local area is planned here.
+            if reference.base >= num_locals {
+                continue;
+            }
+            if reference.base.checked_add(reference.span)? > num_locals {
+                return None;
+            }
+            let mut reference = reference;
+            if escaping[value.as_u32() as usize] {
+                reference.kind = ReferenceKind::AddressEscape;
+            }
+            per_value[value.as_u32() as usize] = Some(reference);
+        }
+    }
+    Some(SlotReferences { per_value })
+}
+
+/// Flags, indexed by `CfgValue`, for operands whose address is handed to a
+/// raw-pointer intrinsic (`@raw`/`@raw_mut`/`@field_ptr` — the `PlaceAddress`
+/// operation in `value_plan`). The pointer those produce is a first-class
+/// value that can outlive the operand's storage window, so the slot behind it
+/// never shares.
+fn address_escaping_operands(cfg: &Cfg, interner: &ThreadedRodeo) -> Vec<bool> {
+    let mut escaping = vec![false; cfg.value_count()];
+    for block in cfg.blocks() {
+        for &value in &block.insts {
+            let data = &cfg.get_inst(value).data;
+            let CfgInstData::Intrinsic { name, .. } = data else {
+                continue;
+            };
+            if !matches!(interner.resolve(name), "raw" | "raw_mut" | "field_ptr") {
+                continue;
+            }
+            for &arg in cfg.get_intrinsic_args(data) {
+                escaping[arg.as_u32() as usize] = true;
+            }
+        }
+    }
+    escaping
+}
+
+/// Build the slot entities: one contiguous run per reference root, plus a
+/// private single cell for every local slot nothing references.
+///
+/// Returns `None` when a reference is rooted strictly inside another run,
+/// which would mean one aggregate is addressed through two different bases.
+fn build_entities(num_locals: u32, refs: &SlotReferences) -> Option<Vec<SlotEntity>> {
+    let mut span_at = vec![0_u32; num_locals as usize];
+    let mut has_live = vec![false; num_locals as usize];
+    let mut escapes = vec![false; num_locals as usize];
+    for reference in refs.per_value.iter().flatten() {
+        let index = reference.base as usize;
+        span_at[index] = span_at[index].max(reference.span);
+        match reference.kind {
+            ReferenceKind::Live => has_live[index] = true,
+            ReferenceKind::AddressEscape => escapes[index] = true,
+            ReferenceKind::Dead | ReferenceKind::Access => {}
+        }
+    }
+
+    let mut entities: Vec<SlotEntity> = Vec::new();
+    let mut slot = 0_u32;
+    while slot < num_locals {
+        let span = span_at[slot as usize];
+        if span == 0 {
+            // Nothing names this slot. Reserve it privately anyway: dropping
+            // it outright would be a second layout change resting on the
+            // reference scan being exhaustive, and a reserved cell costs
+            // exactly what today's identity layout costs.
+            entities.push(SlotEntity {
+                base: slot,
+                span: 1,
+                shareable: false,
+                offset: 0,
+            });
+            slot += 1;
+            continue;
+        }
+        let end = slot.checked_add(span)?;
+        if end > num_locals {
+            return None;
+        }
+        // A run may not be re-rooted part way through.
+        if span_at[slot as usize + 1..end as usize]
+            .iter()
+            .any(|&interior| interior != 0)
+        {
+            return None;
+        }
+        entities.push(SlotEntity {
+            base: slot,
+            span,
+            shareable: has_live[slot as usize] && !escapes[slot as usize],
+            offset: 0,
+        });
+        slot = end;
+    }
+    Some(entities)
+}
+
+/// Blocks reachable from the entry block. Unreachable code never executes, so
+/// it neither constrains nor is constrained by the sharing decision.
+fn reachable_blocks(cfg: &Cfg, preds: &[Vec<BlockId>]) -> Vec<bool> {
+    let blocks = cfg.blocks().len();
+    let mut reachable = vec![false; blocks];
+    let mut successors: Vec<Vec<BlockId>> = vec![Vec::new(); blocks];
+    for (block, block_preds) in preds.iter().enumerate() {
+        for pred in block_preds {
+            successors[pred.as_u32() as usize].push(BlockId::from_raw(block as u32));
+        }
+    }
+    let entry = cfg.entry.as_u32() as usize;
+    if entry >= blocks {
+        return reachable;
+    }
+    let mut worklist = vec![entry];
+    reachable[entry] = true;
+    while let Some(block) = worklist.pop() {
+        for successor in &successors[block] {
+            let successor = successor.as_u32() as usize;
+            if !reachable[successor] {
+                reachable[successor] = true;
+                worklist.push(successor);
+            }
+        }
+    }
+    reachable
+}
+
+/// Index of the entity based exactly at `base`, if there is one.
+fn entity_at_base(entities: &[SlotEntity], base: u32) -> Option<usize> {
+    entities
+        .binary_search_by_key(&base, |entity| entity.base)
+        .ok()
+}
+
+/// Solve the may-be-live dataflow over the storage markers, returning every
+/// block's live-in set.
+fn solve_may_be_live(
+    cfg: &Cfg,
+    preds: &[Vec<BlockId>],
+    entities: &[SlotEntity],
+    refs: &SlotReferences,
+    reachable: &[bool],
+) -> Option<Vec<BitSet>> {
+    let blocks = cfg.blocks().len();
+    let bits = entities.len();
+    let mut live_in = vec![BitSet::new(bits); blocks];
+    let mut live_out = vec![BitSet::new(bits); blocks];
+
+    for _ in 0..MAX_DATAFLOW_ROUNDS {
+        let mut changed = false;
+        for block in cfg.blocks() {
+            let index = block.id.as_u32() as usize;
+            if !reachable[index] {
+                continue;
+            }
+            let mut state = BitSet::new(bits);
+            for pred in &preds[index] {
+                let pred = pred.as_u32() as usize;
+                if reachable[pred] {
+                    state.union_with(&live_out[pred]);
+                }
+            }
+            if state != live_in[index] {
+                live_in[index] = state.clone();
+                changed = true;
+            }
+            transfer_block(entities, refs, block, &mut state);
+            if state != live_out[index] {
+                live_out[index] = state;
+                changed = true;
+            }
+        }
+        if !changed {
+            return Some(live_in);
+        }
+    }
+    None
+}
+
+/// Apply one block's markers to `state`.
+fn transfer_block(
+    entities: &[SlotEntity],
+    refs: &SlotReferences,
+    block: &BasicBlock,
+    state: &mut BitSet,
+) {
+    for &value in &block.insts {
+        let Some(reference) = refs.get(value) else {
+            continue;
+        };
+        let Some(entity) = entity_at_base(entities, reference.base) else {
+            continue;
+        };
+        match reference.kind {
+            ReferenceKind::Live => state.set(entity),
+            ReferenceKind::Dead => state.clear(entity),
+            ReferenceKind::Access | ReferenceKind::AddressEscape => {}
+        }
+    }
+}
+
+/// Record every entity live in `state` as interfering with every other.
+fn record_simultaneous(state: &BitSet, interference: &mut [BitSet]) {
+    for entity in state.ones() {
+        interference[entity].union_with(state);
+    }
+}
+
+/// Walk every reachable block once to (a) demote entities referenced outside
+/// their window and (b) record which entities' windows can be open together.
+fn audit_and_collect_interference(
+    cfg: &Cfg,
+    entities: &mut [SlotEntity],
+    refs: &SlotReferences,
+    reachable: &[bool],
+    live_in: &[BitSet],
+) -> Vec<BitSet> {
+    let bits = entities.len();
+    let mut interference = vec![BitSet::new(bits); bits];
+
+    for block in cfg.blocks() {
+        let index = block.id.as_u32() as usize;
+        if !reachable[index] {
+            continue;
+        }
+        let mut state = live_in[index].clone();
+        record_simultaneous(&state, &mut interference);
+        for &value in &block.insts {
+            let Some(reference) = refs.get(value) else {
+                continue;
+            };
+            let Some(entity) = entity_at_base(entities, reference.base) else {
+                continue;
+            };
+            match reference.kind {
+                ReferenceKind::Live => {
+                    state.set(entity);
+                    record_simultaneous(&state, &mut interference);
+                }
+                ReferenceKind::Dead => {
+                    state.clear(entity);
+                    record_simultaneous(&state, &mut interference);
+                }
+                ReferenceKind::Access | ReferenceKind::AddressEscape => {
+                    if !state.get(entity) {
+                        // The markers do not describe this slot's real
+                        // lifetime; keep it private.
+                        entities[entity].shareable = false;
+                    }
+                }
+            }
+        }
+    }
+
+    // An entity never interferes with itself for placement purposes.
+    for (index, row) in interference.iter_mut().enumerate() {
+        row.clear(index);
+    }
+    interference
+}
+
+/// Assign each entity a contiguous frame region, sharing cells between
+/// entities the interference graph proves never overlap. Returns the frame
+/// local slots the assignment occupies, or `None` when a placement fails the
+/// disjointness check — the caller then falls back to the identity layout.
+///
+/// Entities are placed in ascending base-slot order so the layout is a pure
+/// function of the CFG, and each placement is re-checked against every
+/// already-placed entity before the next one is made. The check is always on
+/// (this crate carries no `debug_assert!`s): a wrongly shared cell is silent
+/// data corruption, so it must not be possible to build a release compiler
+/// that skips it.
+fn assign_regions(entities: &mut [SlotEntity], interference: &[BitSet]) -> Option<u32> {
+    let ceiling: u32 = entities.iter().map(|entity| entity.span).sum();
+    let mut total = 0_u32;
+    for index in 0..entities.len() {
+        let span = entities[index].span;
+        let mut busy = vec![false; (ceiling + span) as usize];
+        for placed in 0..index {
+            if !interference[index].get(placed) {
+                continue;
+            }
+            let other = &entities[placed];
+            for cell in other.offset..other.offset + other.span {
+                busy[cell as usize] = true;
+            }
+        }
+        let mut offset = 0_u32;
+        while busy[offset as usize..(offset + span) as usize]
+            .iter()
+            .any(|&cell| cell)
+        {
+            offset += 1;
+        }
+        entities[index].offset = offset;
+        // Re-check the merge the moment it is made: a region overlapping an
+        // already-placed entity is only legal when the two provably never have
+        // open windows at the same time.
+        verify_placement(entities, interference, index).ok()?;
+        total = total.max(offset + span);
+    }
+    Some(total)
+}
+
+/// Do two placed entities occupy overlapping frame regions?
+fn regions_overlap(a: &SlotEntity, b: &SlotEntity) -> bool {
+    a.offset < b.offset + b.span && b.offset < a.offset + a.span
+}
+
+/// Check one just-placed entity against every entity placed before it. This is
+/// the per-merge check, kept linear so the whole assignment stays quadratic.
+fn verify_placement(
+    entities: &[SlotEntity],
+    interference: &[BitSet],
+    index: usize,
+) -> Result<(), SharingViolation> {
+    for first in 0..index {
+        if regions_overlap(&entities[first], &entities[index]) && interference[first].get(index) {
+            return Err(SharingViolation {
+                first,
+                second: index,
+            });
+        }
+    }
+    Ok(())
+}
+
+/// Re-derive the sharing invariant from a finished layout: two entities may
+/// occupy overlapping frame regions only when they never interfere.
+fn verify_sharing(
+    entities: &[SlotEntity],
+    interference: &[BitSet],
+) -> Result<(), SharingViolation> {
+    for index in 0..entities.len() {
+        verify_placement(entities, interference, index)?;
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn entity(base: u32, span: u32) -> SlotEntity {
+        SlotEntity {
+            base,
+            span,
+            shareable: true,
+            offset: 0,
+        }
+    }
+
+    fn placed(offset: u32, span: u32) -> SlotEntity {
+        SlotEntity {
+            base: offset,
+            span,
+            shareable: true,
+            offset,
+        }
+    }
+
+    fn interference_graph(count: usize, edges: &[(usize, usize)]) -> Vec<BitSet> {
+        let mut graph = vec![BitSet::new(count); count];
+        for &(a, b) in edges {
+            graph[a].set(b);
+            graph[b].set(a);
+        }
+        graph
+    }
+
+    #[test]
+    fn disjoint_entities_share_one_region() {
+        // Two single-slot temporaries whose windows never overlap collapse
+        // onto one cell; a third that overlaps both keeps its own.
+        let mut entities = vec![entity(0, 1), entity(1, 1), entity(2, 1)];
+        let graph = interference_graph(3, &[(0, 2), (1, 2)]);
+        let total = assign_regions(&mut entities, &graph).expect("legal layout");
+        assert_eq!(entities[0].offset, 0);
+        assert_eq!(entities[1].offset, 0, "disjoint windows share a cell");
+        assert_eq!(entities[2].offset, 1);
+        assert_eq!(total, 2);
+        assert_eq!(verify_sharing(&entities, &graph), Ok(()));
+    }
+
+    #[test]
+    fn overlapping_entities_never_share() {
+        let mut entities = vec![entity(0, 1), entity(1, 1), entity(2, 1)];
+        let graph = interference_graph(3, &[(0, 1), (0, 2), (1, 2)]);
+        let total = assign_regions(&mut entities, &graph).expect("legal layout");
+        assert_eq!(
+            entities.iter().map(|e| e.offset).collect::<Vec<_>>(),
+            [0, 1, 2]
+        );
+        assert_eq!(total, 3);
+        assert_eq!(verify_sharing(&entities, &graph), Ok(()));
+    }
+
+    #[test]
+    fn multi_slot_entities_move_as_units() {
+        // A three-slot aggregate and a two-slot one with disjoint windows
+        // overlay; a one-slot entity live across both sits below them.
+        let mut entities = vec![entity(0, 1), entity(1, 3), entity(4, 2)];
+        let graph = interference_graph(3, &[(0, 1), (0, 2)]);
+        let total = assign_regions(&mut entities, &graph).expect("legal layout");
+        assert_eq!(entities[0].offset, 0);
+        assert_eq!(entities[1].offset, 1);
+        assert_eq!(
+            entities[2].offset, 1,
+            "the two-slot run overlays the three-slot run's cells"
+        );
+        assert_eq!(total, 4);
+        assert_eq!(verify_sharing(&entities, &graph), Ok(()));
+    }
+
+    /// The verifier must reject a deliberately bad merge. Without this the
+    /// clean verdict on real layouts would prove nothing.
+    #[test]
+    fn injected_bad_merge_is_caught() {
+        let graph = interference_graph(2, &[(0, 1)]);
+        // Two entities whose windows overlap, forced onto the same cell.
+        let entities = vec![placed(0, 1), placed(0, 1)];
+        assert_eq!(
+            verify_sharing(&entities, &graph),
+            Err(SharingViolation {
+                first: 0,
+                second: 1
+            })
+        );
+
+        // The same violation through a partial overlap of multi-slot runs: the
+        // three-slot run at 0..3 and the two-slot run at 2..4 share cell 2.
+        let entities = vec![placed(0, 3), placed(2, 2)];
+        assert_eq!(
+            verify_sharing(&entities, &graph),
+            Err(SharingViolation {
+                first: 0,
+                second: 1
+            })
+        );
+
+        // Non-interfering entities at the very same offset are fine.
+        let graph = interference_graph(2, &[]);
+        let entities = vec![placed(0, 3), placed(0, 2)];
+        assert_eq!(verify_sharing(&entities, &graph), Ok(()));
+    }
+
+    #[test]
+    fn identity_plan_maps_every_slot_to_itself() {
+        let plan = LocalSlotPlan::identity(4);
+        assert_eq!(plan.frame_local_slots(), 4);
+        for slot in 0..4 {
+            assert_eq!(plan.frame_slot(slot), slot);
+        }
+        assert!(!plan.shares_any_slot());
+    }
+
+    /// A zero-slot (ZST) local reserves no cells, so the CFG verifier lets a
+    /// reference sit at `num_locals` itself — including slot 0 of a function
+    /// whose only local is zero-sized. Mapping such a slot must not be an
+    /// out-of-range panic (it ICE'd the `[MustUse; 0]` CLI case).
+    #[test]
+    fn zero_slot_locals_past_the_area_keep_their_slot_number() {
+        let empty = LocalSlotPlan::identity(0);
+        assert_eq!(empty.frame_slot(0), 0);
+        let two = LocalSlotPlan::identity(2);
+        assert_eq!(two.frame_slot(2), 2);
+    }
+
+    #[test]
+    fn bitset_round_trips() {
+        let mut set = BitSet::new(130);
+        set.set(0);
+        set.set(64);
+        set.set(129);
+        assert_eq!(set.ones().collect::<Vec<_>>(), [0, 64, 129]);
+        set.clear(64);
+        assert_eq!(set.ones().collect::<Vec<_>>(), [0, 129]);
+        let mut other = BitSet::new(130);
+        other.set(5);
+        other.union_with(&set);
+        assert_eq!(other.ones().collect::<Vec<_>>(), [0, 5, 129]);
+    }
+}

--- a/crates/rue-codegen/src/stack_frame.rs
+++ b/crates/rue-codegen/src/stack_frame.rs
@@ -290,7 +290,6 @@ fn generate_x86_64_stack_frame(
     interner: &ThreadedRodeo,
     target: Target,
 ) -> CompileResult<StackFrameInfo> {
-    let num_locals = cfg.num_locals();
     let num_params = cfg.num_params();
     // sret returns reserve one extra frame slot for the incoming buffer
     // pointer and shift user args by one ABI slot (RUE-106).
@@ -302,7 +301,11 @@ fn generate_x86_64_stack_frame(
     )?;
     let has_sret = prepared.has_sret;
     let sret_slots = u32::from(has_sret);
-    let num_spills = prepared.total_locals - prepared.num_locals_original;
+    let num_spills = prepared.total_locals - prepared.frame_local_slots;
+    // Frame slots the local area occupies after marker-driven slot sharing
+    // (RUE-768); locals with provably disjoint storage windows overlay one
+    // another, so this is at most `cfg.num_locals()`.
+    let num_locals = prepared.frame_local_slots;
     let used_callee_saved = &prepared.used_callee_saved;
 
     // Calculate stack layout through the byte-based frame-layout authority
@@ -439,7 +442,6 @@ fn generate_aarch64_stack_frame(
     interner: &ThreadedRodeo,
     target: Target,
 ) -> CompileResult<StackFrameInfo> {
-    let num_locals = cfg.num_locals();
     let num_params = cfg.num_params();
     // sret returns reserve one extra frame slot for the incoming buffer
     // pointer and shift user args by one ABI slot (RUE-106).
@@ -452,7 +454,11 @@ fn generate_aarch64_stack_frame(
     )?;
     let has_sret = prepared.has_sret;
     let sret_slots = u32::from(has_sret);
-    let num_spills = prepared.total_locals - prepared.num_locals_original;
+    let num_spills = prepared.total_locals - prepared.frame_local_slots;
+    // Frame slots the local area occupies after marker-driven slot sharing
+    // (RUE-768); locals with provably disjoint storage windows overlay one
+    // another, so this is at most `cfg.num_locals()`.
+    let num_locals = prepared.frame_local_slots;
     let used_callee_saved = &prepared.used_callee_saved;
 
     // Calculate stack layout for AArch64 through the byte-based frame-layout
@@ -884,6 +890,225 @@ fn main() -> i32 {
         .cfg
         .expect("test function CFG must build");
         (cfg, output.type_pool, interner)
+    }
+
+    /// The marker-driven local frame-slot plan for `name` in `source`, with
+    /// the CFG's own local slot count for comparison (RUE-768).
+    fn local_plan(source: &str, name: &str) -> (crate::local_storage::LocalSlotPlan, u32) {
+        let (cfg, type_pool, interner) = compile_named_fn(source, name);
+        let plan = crate::local_storage::LocalSlotPlan::plan(&cfg, &type_pool, &interner);
+        (plan, cfg.num_locals())
+    }
+
+    /// RUE-768: locals whose storage windows the markers prove disjoint land on
+    /// the same frame cells; a local live across both of them does not.
+    #[test]
+    fn disjoint_storage_windows_share_frame_cells() {
+        let source = "\
+fn main() -> i32 {
+    let mut total = 0;
+    {
+        let a = 1;
+        let b = 2;
+        total = total + a + b;
+    }
+    {
+        let c = 3;
+        let d = 4;
+        total = total + c + d;
+    }
+    0
+}
+";
+        let (plan, num_locals) = local_plan(source, "main");
+        assert_eq!(num_locals, 5, "`total` plus two pairs of block temporaries");
+        assert_eq!(plan.frame_local_slots(), 3);
+        // `total` (slot 0) is live throughout and keeps a cell of its own; the
+        // two pairs overlay each other exactly.
+        assert_eq!(plan.frame_slot(0), 0);
+        assert_eq!(plan.frame_slot(1), plan.frame_slot(3));
+        assert_eq!(plan.frame_slot(2), plan.frame_slot(4));
+        assert_ne!(plan.frame_slot(0), plan.frame_slot(1));
+        assert_ne!(plan.frame_slot(1), plan.frame_slot(2));
+    }
+
+    /// RUE-768: simultaneously live locals must never be merged. This is the
+    /// silent-corruption case, so it is asserted slot by slot rather than only
+    /// through the frame total.
+    #[test]
+    fn overlapping_storage_windows_never_share() {
+        let source = "\
+fn main() -> i32 {
+    let a = 1;
+    let b = 2;
+    let c = 3;
+    let d = 4;
+    a + b + c + d
+}
+";
+        let (plan, num_locals) = local_plan(source, "main");
+        assert_eq!(num_locals, 4);
+        assert_eq!(plan.frame_local_slots(), 4, "nothing may be merged");
+        let cells: Vec<u32> = (0..num_locals).map(|slot| plan.frame_slot(slot)).collect();
+        let mut sorted = cells.clone();
+        sorted.sort_unstable();
+        sorted.dedup();
+        assert_eq!(sorted.len(), cells.len(), "every window keeps its own cell");
+    }
+
+    /// RUE-768: a borrow that keeps a local in use after another local's whole
+    /// scope has come and gone holds the first local's storage window open, so
+    /// the two must not share. A last-direct-use analysis would merge them —
+    /// `held`'s last direct read is `held.a`, before `scoped` even exists.
+    #[test]
+    fn borrow_extended_lifetime_keeps_its_own_cells() {
+        let source = "\
+struct Pair { a: i32, b: i32 }
+
+fn total(borrow p: Pair) -> i32 {
+    p.a + p.b
+}
+
+fn main() -> i32 {
+    let held = Pair { a: 1, b: 2 };
+    let direct = held.a;
+    let mut sum = direct;
+    {
+        let scoped = Pair { a: 100, b: 200 };
+        sum = sum + total(borrow scoped);
+    }
+    sum + total(borrow held)
+}
+";
+        let (plan, num_locals) = local_plan(source, "main");
+        // `held` occupies slots 0..2, `direct` 2, `sum` 3, `scoped` 4..6.
+        assert_eq!(num_locals, 6);
+        assert_eq!(
+            plan.frame_local_slots(),
+            6,
+            "the borrow keeps `held` live across `scoped`'s whole scope"
+        );
+        assert_ne!(plan.frame_slot(0), plan.frame_slot(4));
+        assert_ne!(plan.frame_slot(1), plan.frame_slot(5));
+    }
+
+    /// RUE-768: a multi-slot aggregate moves as one contiguous run, so an
+    /// aggregate that overlays another covers exactly its whole span and its
+    /// fields stay in order. A per-slot merge would interleave two structs.
+    #[test]
+    fn multi_slot_aggregates_share_as_whole_runs() {
+        let source = "\
+struct Triple { a: i32, b: i32, c: i32 }
+
+fn main() -> i32 {
+    let mut sum = 0;
+    {
+        let x = Triple { a: 1, b: 2, c: 3 };
+        sum = sum + x.a + x.b + x.c;
+    }
+    {
+        let y = Triple { a: 4, b: 5, c: 6 };
+        sum = sum + y.a + y.b + y.c;
+    }
+    sum
+}
+";
+        let (plan, num_locals) = local_plan(source, "main");
+        assert_eq!(num_locals, 7, "`sum` plus two three-slot structs");
+        assert_eq!(plan.frame_local_slots(), 4);
+        let x = plan.frame_slot(1);
+        let y = plan.frame_slot(4);
+        assert_eq!(x, y, "the two structs overlay each other");
+        // Each struct stays contiguous and ascending, which is what the
+        // `frame_slot(base) + k` addressing in both backends assumes.
+        for k in 0..3 {
+            assert_eq!(plan.frame_slot(1 + k), x + k);
+            assert_eq!(plan.frame_slot(4 + k), y + k);
+        }
+    }
+
+    /// RUE-768: `@raw_mut` hands out a first-class pointer the planner cannot
+    /// follow, so its operand keeps a private cell even when its storage window
+    /// is disjoint from a later local's.
+    #[test]
+    fn raw_pointer_operands_keep_private_cells() {
+        let source = "\
+fn main() -> i32 {
+    let mut sum = 0;
+    {
+        let mut probe: i32 = 5;
+        let p: ptr mut i32 = checked { @raw_mut(probe) };
+        checked { @ptr_write(p, 9); };
+        sum = sum + probe;
+    }
+    {
+        let other: i32 = 41;
+        sum = sum + other;
+    }
+    sum
+}
+";
+        let (plan, num_locals) = local_plan(source, "main");
+        // `sum` 0, `probe` 1, `p` 2, `other` 3.
+        assert_eq!(num_locals, 4);
+        assert_ne!(
+            plan.frame_slot(1),
+            plan.frame_slot(3),
+            "an address-escaping local must not be merged"
+        );
+        // The pointer local itself has no escaping address, so it still shares
+        // with the disjoint `other`.
+        assert_eq!(plan.frame_slot(2), plan.frame_slot(3));
+        assert_eq!(plan.frame_local_slots(), 3);
+    }
+
+    /// RUE-768: both backends must agree on the shared layout, and both must
+    /// report only the cells the plan kept. `area`'s per-arm payload bindings
+    /// are the shapes.rue shape that motivated the issue.
+    #[test]
+    fn both_backends_report_the_same_shared_local_area() {
+        let source = "\
+enum Shape {
+    Circle(i32),
+    Rect(i32, i32),
+    Square(i32),
+}
+
+fn area(s: Shape) -> i32 {
+    match s {
+        Shape.Circle(r) => 3 * r * r,
+        Shape.Rect(w, h) => w * h,
+        Shape.Square(side) => side * side,
+    }
+}
+
+fn main() -> i32 {
+    area(Shape.Circle(2)) + area(Shape.Rect(3, 4)) + area(Shape.Square(5))
+}
+";
+        let (plan, num_locals) = local_plan(source, "area");
+        assert_eq!(
+            num_locals, 4,
+            "one payload binding per arm, plus Rect's two"
+        );
+        assert_eq!(
+            plan.frame_local_slots(),
+            2,
+            "at most two arm bindings are ever live at once"
+        );
+
+        for target in [Target::X86_64Linux, Target::Aarch64Linux] {
+            let (_, info) = frame_projection(source, "area", target);
+            let locals = info
+                .slots
+                .iter()
+                .filter(|slot| slot.kind == StackSlotKind::Local)
+                .count();
+            assert_eq!(
+                locals, 2,
+                "{target:?} must report the shared local area, not the CFG's slot count"
+            );
+        }
     }
 
     /// RUE-774: the reported AArch64 slots must match the offsets in the emitted

--- a/crates/rue-codegen/src/x86_64/cfg_lower.rs
+++ b/crates/rue-codegen/src/x86_64/cfg_lower.rs
@@ -219,6 +219,15 @@ impl<'a> CfgLower<'a> {
         self
     }
 
+    /// Install the pipeline's local frame-slot decision (RUE-768).
+    pub(crate) fn with_local_storage(
+        mut self,
+        local_storage: &'a crate::local_storage::LocalSlotPlan,
+    ) -> Self {
+        self.ctx = self.ctx.with_local_storage(local_storage);
+        self
+    }
+
     #[cfg(test)]
     pub(crate) fn new_unchecked(
         cfg: &'a Cfg,

--- a/crates/rue-codegen/src/x86_64/emit.rs
+++ b/crates/rue-codegen/src/x86_64/emit.rs
@@ -246,9 +246,11 @@ pub struct Emitter<'a> {
     fixups: Vec<Fixup>,
     /// Total number of local slots including spills (for stack frame size).
     num_locals: u32,
-    /// Original number of local variables (for param offset calculation).
-    /// CfgLower generates param offsets based on this value.
-    num_locals_original: u32,
+    /// Frame slots the local area occupies after marker-driven slot sharing
+    /// (RUE-768), BEFORE regalloc added spill slots. CfgLower numbers the
+    /// parameter area from this base, so the prologue's param stores must use
+    /// it too.
+    frame_local_slots: u32,
     /// Frame slots of the (compacted) parameter area: homed parameters
     /// only — register-only parameters (RUE-1170) reserve no slots.
     num_params: u32,
@@ -296,13 +298,13 @@ impl<'a> Emitter<'a> {
     /// Create a new emitter.
     ///
     /// - `num_locals`: Total local slots including spills (for stack frame size)
-    /// - `num_locals_original`: Original local count (for param offset calculation)
+    /// - `frame_local_slots`: Shared local area size (base of the param area)
     /// - `num_params`: Frame slots of the homed parameter area (RUE-1170)
     /// - `strings`: String table for string constant references
     pub fn new(
         mir: &'a X86Mir,
         num_locals: u32,
-        num_locals_original: u32,
+        frame_local_slots: u32,
         num_params: u32,
         callee_saved: &[Reg],
         strings: &'a [String],
@@ -326,7 +328,7 @@ impl<'a> Emitter<'a> {
             labels: LabelOffsets::with_capacity(estimated_inline_labels, estimated_block_labels),
             fixups: Vec::with_capacity(estimated_fixups),
             num_locals,
-            num_locals_original,
+            frame_local_slots,
             num_params,
             has_sret: false,
             callee_saved: callee_saved.to_vec(),
@@ -664,9 +666,9 @@ impl<'a> Emitter<'a> {
         // are likewise compacted away, which `start_slot` already reflects.
         for homing in self.param_homing_or_per_slot() {
             for k in 0..homing.reg_count {
-                // Use num_locals_original (not num_locals which includes spills)
+                // Use frame_local_slots (not num_locals which includes spills)
                 // because CfgLower generates param offsets based on the original count
-                let slot = self.num_locals_original + homing.start_slot + k;
+                let slot = self.frame_local_slots + homing.start_slot + k;
                 // Skip past callee-saved registers in the offset calculation
                 let offset = -callee_saved_size + crate::frame_layout::slot_offset_pre_saved(slot);
 
@@ -694,7 +696,7 @@ impl<'a> Emitter<'a> {
         // dedicated frame slot, one past the param area. The return path
         // loads it back to store the result through.
         if self.has_sret {
-            let slot = self.num_locals_original + self.num_params;
+            let slot = self.frame_local_slots + self.num_params;
             let offset = -callee_saved_size + crate::frame_layout::slot_offset_pre_saved(slot);
             self.begin_inst();
             self.emit_mov_mr(Reg::Rbp, offset, ARG_REGS[0]);

--- a/crates/rue-codegen/src/x86_64/mod.rs
+++ b/crates/rue-codegen/src/x86_64/mod.rs
@@ -64,19 +64,22 @@ fn prepare_backend_with_artifacts(
     crate::codegen_pipeline::prepare_mir_with_artifacts(
         cfg,
         type_pool,
+        interner,
         cfg_lower::ARG_REGS.len() as u32,
         cfg_lower::RET_REGS.len() as u32,
         crate::frame_layout::SavedRegScheme::X86_64,
-        |param_storage| {
+        |param_storage, local_storage| {
             let (mir, lowering) = if request.lowering {
                 let (mir, debug) = CfgLower::new_with_symbols(cfg, type_pool, interner, symbols)
                     .with_param_storage(param_storage)
+                    .with_local_storage(local_storage)
                     .lower_with_debug()?;
                 (mir, Some(debug))
             } else {
                 (
                     CfgLower::new_with_symbols(cfg, type_pool, interner, symbols)
                         .with_param_storage(param_storage)
+                        .with_local_storage(local_storage)
                         .lower()?,
                     None,
                 )
@@ -153,7 +156,7 @@ fn generate_inner(
     let emitter = Emitter::new(
         &prepared.mir,
         prepared.total_locals,
-        prepared.num_locals_original,
+        prepared.frame_local_slots,
         prepared.param_storage.homed_area_slots(),
         &prepared.used_callee_saved,
         &local_strings,


### PR DESCRIPTION
From tonight's cycle-5 frame-slot worker (its session stalled after exporting the diff and meta, so all verification was redone at integration), plus one integration-time performance fix.

## The change
New `crates/rue-codegen/src/local_storage.rs` — `LocalSlotPlan`, mirroring RUE-1170's `ParamStoragePlan`:
- **Slot entities**: one contiguous run of CFG local slots, spanned by its widest rooted reference, so multi-slot aggregates can never split across regions.
- **May-be-live dataflow** over `storage_live`/`storage_dead` markers; an **audit** demotes any entity referenced outside its window to unshared; `@raw`/`@raw_mut`/`@field_ptr` operands are never shared.
- **Unconditional verification, release builds included**: `verify_placement` re-checks each merge and `verify_sharing` re-derives the invariant from the finished layout; any rejection falls back to the identity plan — the failure mode is the old layout, never a bad one.
- `frame_slot()` remains the single funnel; regalloc/liveness/scheduling/reg_class untouched.

## Integration-time performance fix
The worker asked for harbor timing against trunk — rightly: the quadratic entity analysis cost **+17–30% wall** on harbor's generated mega-functions. Added a planning-cost ceiling (`slots × blocks ≤ 65536`): harbor now compiles at the trunk baseline (27.4s vs 27.3s) while human-scale functions all stay planned.

## Measured wins
`arrays.rue` main frame 224 → 160 bytes; shapes `area` 4 → 2 cells. Most programs unchanged, as designed.

## Verification
- 15 new `frame_slot_reuse` CLI cases (overlapping-lifetime never-share, borrow-extended lifetime, multi-slot aggregates)
- 6 stack_frame reporter tests; codegen unit 701/0
- Full `./test.sh` **PASSED** (exit 0, sentinel verified) on the final commit — including the differential-oracle spec and CLI lanes, the strongest corruption detector for a frame-layout change

Fixes RUE-768

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GPYyXZHFGimCvkbzMtBG2U

---
_Generated by [Claude Code](https://claude.ai/code/session_01GPYyXZHFGimCvkbzMtBG2U)_