### PR TITLE
RUE-1354: reduce body scheduler allocation churn

### DIFF
--- a/crates/rue-compiler/src/revisioned_query_database.rs
+++ b/crates/rue-compiler/src/revisioned_query_database.rs
@@ -6569,7 +6569,7 @@ pub(crate) fn collect_instance_anonymous_nominals(
 fn schedule_body_instance<V>(
     pending: &mut BTreeMap<Arc<crate::FunctionInstanceKey>, usize>,
     ready: &mut BTreeMap<Arc<crate::FunctionInstanceKey>, usize>,
-    prefetched: &mut BTreeMap<Arc<crate::FunctionInstanceKey>, (usize, V)>,
+    prefetched: &mut VecDeque<(Arc<crate::FunctionInstanceKey>, usize, V)>,
     visited: &BTreeSet<Arc<crate::FunctionInstanceKey>>,
     instance: &crate::FunctionInstanceKey,
     depth: usize,
@@ -6588,15 +6588,13 @@ fn schedule_body_instance<V>(
             .clone();
         return Some((instance, changed));
     }
-    if let Some((existing_depth, _)) = prefetched.get_mut(instance) {
+    if let Some((prefetched_instance, existing_depth, _)) = prefetched
+        .iter_mut()
+        .find(|(prefetched_instance, _, _)| prefetched_instance.as_ref() == instance)
+    {
         let changed = depth < *existing_depth;
         *existing_depth = (*existing_depth).min(depth);
-        let instance = prefetched
-            .get_key_value(instance)
-            .expect("the prefetched instance remains present after its depth update")
-            .0
-            .clone();
-        return Some((instance, changed));
+        return Some((prefetched_instance.clone(), changed));
     }
     if let Some(existing_depth) = pending.get_mut(instance) {
         let changed = depth < *existing_depth;
@@ -15370,19 +15368,15 @@ impl RevisionedQueryDatabase {
                     let mut produced_anonymous = BTreeMap::new();
                     let mut ready_frontier = BTreeMap::new();
                     let mut pending_frontier_metrics = None;
-                    let mut prefetched_transactions = BTreeMap::<
+                    let mut prefetched_transactions = VecDeque::<(
                         Arc<crate::FunctionInstanceKey>,
-                        (
-                            usize,
-                            Option<
-                                Arc<
-                                    rue_query::QueryTerminal<
-                                        crate::body_query::BodyTransaction,
-                                    >,
-                                >,
+                        usize,
+                        Option<
+                            Arc<
+                                rue_query::QueryTerminal<crate::body_query::BodyTransaction>,
                             >,
-                        ),
-                    >::new();
+                        >,
+                    )>::new();
                     let mut anonymous_visit_seen = Vec::new();
                     let concurrency = context.max_concurrency();
                     let body_query_prefetch_window = if concurrency == 1 {
@@ -15418,7 +15412,7 @@ impl RevisionedQueryDatabase {
                                             + usize::from(matches!(
                                                 producer.as_ref(),
                                                 crate::FunctionInstanceKey::Specialization { .. }
-                                            ));
+                                        ));
                                         if let Some((producer, true)) = schedule_body_instance(
                                             &mut pending,
                                             &mut ready_frontier,
@@ -15457,7 +15451,6 @@ impl RevisionedQueryDatabase {
                                     },
                                 );
                                 let ready = !visited.contains(&instance)
-                                    && !prefetched_transactions.contains_key(&instance)
                                     && blocked_on_anonymous
                                         .get(&instance)
                                         .is_none_or(|producers| {
@@ -15501,7 +15494,7 @@ impl RevisionedQueryDatabase {
                                 let (instance, depth) = ready_frontier
                                     .pop_first()
                                     .expect("a non-empty ready frontier has a first instance");
-                                prefetched_transactions.insert(instance, (depth, None));
+                                prefetched_transactions.push_back((instance, depth, None));
                                 continue;
                             }
                             // Keep the retained result window bounded. A wide
@@ -15607,13 +15600,17 @@ impl RevisionedQueryDatabase {
                                 let depth = ready_frontier
                                     .remove(&instance)
                                     .expect("prefetched ready instances retain their depth");
-                                prefetched_transactions.insert(instance, (depth, Some(transaction)));
+                                prefetched_transactions.push_back((
+                                    instance,
+                                    depth,
+                                    Some(transaction),
+                                ));
                             }
                         }
 
                         let Some(instance) = prefetched_transactions
-                            .first_key_value()
-                            .map(|(instance, _)| instance.clone())
+                            .front()
+                            .map(|(instance, _, _)| instance.clone())
                         else {
                             let Some((instance, current_depth)) = pending.pop_first() else {
                                 break;
@@ -15656,8 +15653,8 @@ impl RevisionedQueryDatabase {
                         };
                         context.check_canceled()?;
                         let current_depth = prefetched_transactions
-                            .get(&instance)
-                            .map(|(depth, _)| *depth)
+                            .front()
+                            .map(|(_, depth, _)| *depth)
                             .expect("selected prefetched instances retain their depth");
                         if !visited.insert(instance.clone()) {
                             continue;
@@ -15709,7 +15706,7 @@ impl RevisionedQueryDatabase {
                                 .cloned()
                                 .into_iter()
                                 .collect::<BTreeSet<_>>();
-                            for pending_instance in pending.keys() {
+                            for pending_instance in ready_frontier.keys().chain(pending.keys()) {
                                 if visited.contains(pending_instance) {
                                     continue;
                                 }
@@ -15764,29 +15761,20 @@ impl RevisionedQueryDatabase {
                         // remain transaction-only (they publish no
                         // BodyReferences terminal), so interpret the exact
                         // transaction before projecting schedulable references.
-                        let transaction_terminal = if let Some((_, transaction)) =
-                            prefetched_transactions.remove(&instance)
-                        {
-                            context.record_work(rue_query::WorkItem::new(
-                                "reachability.transactions.prefetched",
-                                1,
-                            ));
-                            match transaction {
-                                Some(transaction) => transaction,
-                                None => context.query_registered(
-                                    &transactions_for_body_reachability,
-                                    body_key.clone(),
-                                )?,
-                            }
-                        } else {
-                            context.record_work(rue_query::WorkItem::new(
-                                "reachability.transactions.serial",
-                                1,
-                            ));
-                            context.query_registered(
+                        let (prefetched_instance, _, transaction) = prefetched_transactions
+                            .pop_front()
+                            .expect("the selected prefetched transaction remains queued");
+                        assert_eq!(prefetched_instance, instance);
+                        context.record_work(rue_query::WorkItem::new(
+                            "reachability.transactions.prefetched",
+                            1,
+                        ));
+                        let transaction_terminal = match transaction {
+                            Some(transaction) => transaction,
+                            None => context.query_registered(
                                 &transactions_for_body_reachability,
                                 body_key.clone(),
-                            )?
+                            )?,
                         };
                         let rue_query::QueryOutcome::Success(transaction) =
                             transaction_terminal.outcome()
@@ -15822,7 +15810,7 @@ impl RevisionedQueryDatabase {
                                         + usize::from(matches!(
                                             producer,
                                             crate::FunctionInstanceKey::Specialization { .. }
-                                        ));
+                                    ));
                                     if let Some((producer, depth_changed)) = schedule_body_instance(
                                         &mut pending,
                                         &mut ready_frontier,
@@ -15972,7 +15960,7 @@ impl RevisionedQueryDatabase {
                                                 + usize::from(matches!(
                                                     callable,
                                                     crate::FunctionInstanceKey::Specialization { .. }
-                                                ));
+                                            ));
                                             if let Some((callable, true)) = schedule_body_instance(
                                                 &mut pending,
                                                 &mut ready_frontier,
@@ -38165,6 +38153,60 @@ fn main() -> i32 {
         assert_eq!(output.reached.len(), 3);
         assert!(output.fatal.is_none());
         assert!(output.scheduling_errors.is_empty());
+    }
+
+    #[test]
+    fn single_worker_toolchain_park_aggregates_the_complete_ready_frontier() {
+        let snapshot = source_snapshot(
+            &[(
+                1,
+                "/main.rue",
+                "main.rue",
+                "fn parse() -> i32 { let _value = @parse_u32(\"1\"); 0 }\n\
+                 fn read() -> i32 { let _value = @read_line(); 0 }\n\
+                 fn main() -> i32 { parse() + read() }\n",
+            )],
+            1,
+        );
+        let module = ModuleId::from_logical_path("main.rue").unwrap();
+        let mut database = RevisionedQueryDatabase::with_query_concurrency(1);
+        let revision = revision_for(&mut database, &snapshot);
+        let closure = database
+            .body_closure(
+                revision,
+                crate::body_query::BodyClosureQueryKey {
+                    modules: Arc::from([module.clone()]),
+                    roots: Arc::from([free_function_instance(&module, "main")]),
+                    configuration: semantic_configuration(),
+                },
+                CancellationToken::new(),
+            )
+            .expect("the closure publishes one aggregate toolchain park");
+        let rue_query::QueryOutcome::Success(output) = closure.terminal.outcome() else {
+            unreachable!("BodyClosure publishes typed values")
+        };
+        let parked = output
+            .parked_toolchain
+            .as_ref()
+            .expect("both ready siblings require absent trusted modules");
+        let paths = parked
+            .demands()
+            .iter()
+            .map(crate::TrustedToolchainModuleDemand::logical_path)
+            .collect::<BTreeSet<_>>();
+        assert_eq!(
+            paths,
+            BTreeSet::from([
+                crate::OPTION_MODULE_LOGICAL_PATH,
+                crate::STRBUF_MODULE_LOGICAL_PATH,
+            ]),
+            "the one-worker path must inspect siblings already promoted out of pending"
+        );
+        assert_eq!(
+            parked.requesters().len(),
+            2,
+            "one park retains both exact requesting bodies"
+        );
     }
 
     #[test]

--- a/docs/notes/post-adr-0063-cold-compiler-architecture-audit.md
+++ b/docs/notes/post-adr-0063-cold-compiler-architecture-audit.md
@@ -312,6 +312,21 @@ the allocator's size-class and lifetime shape around the ready scheduler, not a
 larger retained query graph. Harbor remained approximately memory-neutral. This
 tradeoff is tracked explicitly rather than being inferred from clock noise.
 
+RUE-1354 then tested whether scheduler-container lifetime was the source of
+that peak. Replacing the bounded prefetched-result tree with an ordered FIFO
+removed 4,591 compiler allocations and 211,374 requested bytes from Lattice
+while preserving byte-identical output and every reachability and query-work
+counter. Controlled parent/current release medians were clock-neutral within
+run noise: Ruelex 145.28/140.32 ms, Mosaic 422.53/425.48 ms, Harbor
+953.79/938.11 ms and Lattice 1,143.10/1,150.37 ms. Peak RSS did not materially
+move, confirming that the prefetched tree was bookkeeping churn but not the
+source of the RUE-1351 high-water change. Halving the prefetch window did
+recover Lattice RSS (733.0 versus 731.5 MiB for the parent) but slowed Harbor
+and Lattice by roughly six to seven percent, so that tradeoff was rejected.
+The FIFO remains worthwhile as a representation win, and the one-worker path
+now aggregates missing toolchain modules across the complete ready frontier
+instead of requiring avoidable acquisition rounds.
+
 ## Next actions and decision boundary
 
 Authorized low-risk work:


### PR DESCRIPTION
Fixes RUE-1354.

Replace the bounded prefetched-transaction tree with a FIFO that matches its deterministic consumption order, and aggregate single-worker toolchain demand across the complete ready frontier.

Measured against the exact parent on Lattice:
- 4,591 fewer compiler allocations
- 211,374 fewer requested bytes
- identical query and reachability work counters
- zero serial body transactions preserved
- byte-identical output
- release compile time and peak RSS neutral within run noise

A smaller prefetch window recovered RSS but regressed Harbor/Lattice time by 6-7%, so that experiment was rejected and documented.

Validation: scripts/rue quick; focused one/many-worker, frontier, anonymous-producer, and toolchain-park tests.