### PR TITLE
RUE-1357: Inline liveness fact lists

### DIFF
--- a/crates/rue-codegen/src/aarch64/liveness.rs
+++ b/crates/rue-codegen/src/aarch64/liveness.rs
@@ -7,10 +7,11 @@ use std::collections::HashMap;
 
 use super::mir::{Aarch64Inst, Aarch64Mir, Operand, Reg, ReturnBehavior};
 use crate::liveness::{
-    LivenessAdapter, branch_successor, conditional_successors, fallthrough_successor,
+    LivenessAdapter, SuccessorList, VRegList, branch_successor, conditional_successors,
+    fallthrough_successor,
 };
 use crate::reg_class::VRegClasses;
-use crate::vreg::{LabelId, VReg};
+use crate::vreg::LabelId;
 
 // Re-export shared types from the regalloc module
 pub use crate::regalloc::{InstructionLiveness, LiveRange, LivenessDebugInfo, LoopInfo};
@@ -47,15 +48,15 @@ impl LivenessAdapter for Aarch64LivenessAdapter<'_> {
         idx: usize,
         inst: &Self::Inst,
         label_to_idx: &HashMap<LabelId, usize>,
-    ) -> Vec<usize> {
+    ) -> SuccessorList {
         get_successors(idx, inst, label_to_idx, self.instructions().len())
     }
 
-    fn uses(&self, inst: &Self::Inst) -> Vec<VReg> {
+    fn uses(&self, inst: &Self::Inst) -> VRegList {
         uses(inst)
     }
 
-    fn defs(&self, inst: &Self::Inst) -> Vec<VReg> {
+    fn defs(&self, inst: &Self::Inst) -> VRegList {
         defs(inst)
     }
 
@@ -106,7 +107,7 @@ fn get_successors(
     inst: &Aarch64Inst,
     label_to_idx: &HashMap<LabelId, usize>,
     num_insts: usize,
-) -> Vec<usize> {
+) -> SuccessorList {
     match inst {
         // Unconditional branch - only successor is the target
         Aarch64Inst::B { label } => branch_successor(*label, label_to_idx),
@@ -119,14 +120,14 @@ fn get_successors(
             conditional_successors(idx, *label, label_to_idx, num_insts)
         }
         // Return and trap have no successors
-        Aarch64Inst::Ret | Aarch64Inst::Brk => Vec::new(),
+        Aarch64Inst::Ret | Aarch64Inst::Brk => SuccessorList::new(),
         // A call to a helper the runtime ABI manifest declares
         // `ReturnBehavior::Never` aborts the process. Control never comes back,
         // so it has no successors and nothing is live after it (RUE-1224).
         Aarch64Inst::Bl {
             returns: ReturnBehavior::Never,
             ..
-        } => Vec::new(),
+        } => SuccessorList::new(),
         // Ordinary calls fall through (the callee returns)
         Aarch64Inst::Bl { .. } => fallthrough_successor(idx, num_insts),
         // All other instructions fall through to the next
@@ -135,11 +136,10 @@ fn get_successors(
 }
 
 /// Get virtual registers used (read) by an instruction.
-fn uses(inst: &Aarch64Inst) -> Vec<VReg> {
-    // Most instructions have 0-2 operands; pre-allocate for common case
-    let mut result = Vec::with_capacity(2);
+fn uses(inst: &Aarch64Inst) -> VRegList {
+    let mut result = VRegList::new();
 
-    let add_if_virtual = |op: &Operand, vec: &mut Vec<VReg>| {
+    let add_if_virtual = |op: &Operand, vec: &mut VRegList| {
         if let Operand::Virtual(vreg) = op {
             vec.push(*vreg);
         }
@@ -285,11 +285,10 @@ fn uses(inst: &Aarch64Inst) -> Vec<VReg> {
 }
 
 /// Get virtual registers defined (written) by an instruction.
-pub(crate) fn defs(inst: &Aarch64Inst) -> Vec<VReg> {
-    // Most instructions define 0-1 registers; pre-allocate for common case
-    let mut result = Vec::with_capacity(1);
+pub(crate) fn defs(inst: &Aarch64Inst) -> VRegList {
+    let mut result = VRegList::new();
 
-    let add_if_virtual = |op: &Operand, vec: &mut Vec<VReg>| {
+    let add_if_virtual = |op: &Operand, vec: &mut VRegList| {
         if let Operand::Virtual(vreg) = op {
             vec.push(*vreg);
         }

--- a/crates/rue-codegen/src/aarch64/regalloc.rs
+++ b/crates/rue-codegen/src/aarch64/regalloc.rs
@@ -1290,7 +1290,7 @@ impl RegAllocBackend for Aarch64Backend {
         mir.instructions()
     }
 
-    fn defs(inst: &Self::Inst) -> Vec<VReg> {
+    fn defs(inst: &Self::Inst) -> crate::liveness::VRegList {
         liveness::defs(inst)
     }
 

--- a/crates/rue-codegen/src/liveness.rs
+++ b/crates/rue-codegen/src/liveness.rs
@@ -19,6 +19,8 @@
 //! keeping the instruction-specific logic where it belongs.
 
 use std::collections::HashMap;
+use std::iter::Take;
+use std::ops::Deref;
 
 use fixedbitset::FixedBitSet;
 
@@ -26,6 +28,110 @@ use crate::index_map::IndexMap;
 use crate::reg_class::VRegClasses;
 use crate::regalloc::{InstructionLiveness, LiveRange, LivenessDebugInfo, LivenessInfo, LoopInfo};
 use crate::vreg::{LabelId, VReg};
+
+/// A fixed-capacity, inline list for bounded machine-instruction facts.
+///
+/// MIR defines exact small maxima for the facts liveness extracts. Keeping the
+/// storage inline removes per-instruction allocation without making the outer
+/// fact tables wider than their former `Vec` elements. `push` fails loudly if
+/// a future instruction exceeds the audited bound, so extending MIR requires
+/// extending the representation in the same change.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct InlineList<T, const N: usize> {
+    values: [T; N],
+    len: usize,
+}
+
+impl<T, const N: usize> InlineList<T, N>
+where
+    T: Copy + Default,
+{
+    /// Create an empty list backed by its inline storage.
+    #[must_use]
+    pub fn new() -> Self {
+        Self {
+            values: [T::default(); N],
+            len: 0,
+        }
+    }
+
+    /// Append one fact to the list.
+    ///
+    /// # Panics
+    ///
+    /// Panics when the list's audited MIR-specific capacity is exceeded.
+    pub fn push(&mut self, value: T) {
+        assert!(self.len < N, "inline liveness fact capacity {N} exceeded");
+        self.values[self.len] = value;
+        self.len += 1;
+    }
+}
+
+impl<T, const N: usize> Default for InlineList<T, N>
+where
+    T: Copy + Default,
+{
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl<T, const N: usize> Deref for InlineList<T, N> {
+    type Target = [T];
+
+    fn deref(&self) -> &Self::Target {
+        &self.values[..self.len]
+    }
+}
+
+impl<T, const N: usize> AsRef<[T]> for InlineList<T, N> {
+    fn as_ref(&self) -> &[T] {
+        self
+    }
+}
+
+impl<T, const N: usize> FromIterator<T> for InlineList<T, N>
+where
+    T: Copy + Default,
+{
+    fn from_iter<I: IntoIterator<Item = T>>(iter: I) -> Self {
+        let mut values = Self::new();
+        for value in iter {
+            values.push(value);
+        }
+        values
+    }
+}
+
+impl<T, const N: usize> IntoIterator for InlineList<T, N> {
+    type Item = T;
+    type IntoIter = Take<std::array::IntoIter<T, N>>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.values.into_iter().take(self.len)
+    }
+}
+
+impl<'a, T, const N: usize> IntoIterator for &'a InlineList<T, N> {
+    type Item = &'a T;
+    type IntoIter = std::slice::Iter<'a, T>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.iter()
+    }
+}
+
+/// Virtual-register facts attached to one machine instruction.
+///
+/// Current MIR forms have at most three virtual operands; four slots preserve
+/// one slot of headroom without making this representation wider than `Vec`.
+pub type VRegList = InlineList<VReg, 4>;
+
+/// Control-flow successors attached to one machine instruction.
+///
+/// MIR instructions have at most a fallthrough and one branch target, so the
+/// complete successor list fits inline.
+pub type SuccessorList = InlineList<usize, 2>;
 
 /// Backend-specific facts required by the shared liveness orchestration.
 ///
@@ -62,13 +168,13 @@ pub trait LivenessAdapter {
         idx: usize,
         inst: &Self::Inst,
         label_to_idx: &HashMap<LabelId, usize>,
-    ) -> Vec<usize>;
+    ) -> SuccessorList;
 
     /// Return virtual registers read by `inst`.
-    fn uses(&self, inst: &Self::Inst) -> Vec<VReg>;
+    fn uses(&self, inst: &Self::Inst) -> VRegList;
 
     /// Return virtual registers written by `inst`.
-    fn defs(&self, inst: &Self::Inst) -> Vec<VReg>;
+    fn defs(&self, inst: &Self::Inst) -> VRegList;
 
     /// Return physical registers clobbered by `inst`.
     fn clobbers(&self, inst: &Self::Inst) -> Vec<Self::Reg>;
@@ -152,16 +258,16 @@ where
 
 /// Successor list for an instruction that falls through to the next
 /// instruction, if there is one.
-pub fn fallthrough_successor(idx: usize, num_insts: usize) -> Vec<usize> {
+pub fn fallthrough_successor(idx: usize, num_insts: usize) -> SuccessorList {
+    let mut successors = SuccessorList::new();
     if idx + 1 < num_insts {
-        vec![idx + 1]
-    } else {
-        Vec::new()
+        successors.push(idx + 1);
     }
+    successors
 }
 
 /// Successor list for an unconditional branch to `label`.
-pub fn branch_successor(label: LabelId, label_to_idx: &HashMap<LabelId, usize>) -> Vec<usize> {
+pub fn branch_successor(label: LabelId, label_to_idx: &HashMap<LabelId, usize>) -> SuccessorList {
     label_to_idx.get(&label).copied().into_iter().collect()
 }
 
@@ -172,8 +278,8 @@ pub fn conditional_successors(
     label: LabelId,
     label_to_idx: &HashMap<LabelId, usize>,
     num_insts: usize,
-) -> Vec<usize> {
-    let mut succs = Vec::with_capacity(2);
+) -> SuccessorList {
+    let mut succs = SuccessorList::new();
     if idx + 1 < num_insts {
         succs.push(idx + 1);
     }
@@ -216,9 +322,9 @@ pub fn analyze<I, R>(
     vreg_count: u32,
     vreg_classes: VRegClasses,
     get_label: impl Fn(&I) -> Option<LabelId>,
-    get_successors: impl Fn(usize, &I, &HashMap<LabelId, usize>) -> Vec<usize>,
-    get_uses: impl Fn(&I) -> Vec<VReg>,
-    get_defs: impl Fn(&I) -> Vec<VReg>,
+    get_successors: impl Fn(usize, &I, &HashMap<LabelId, usize>) -> SuccessorList,
+    get_uses: impl Fn(&I) -> VRegList,
+    get_defs: impl Fn(&I) -> VRegList,
     get_clobbers: impl Fn(&I) -> Vec<R>,
     get_non_returning: impl Fn(&I) -> bool,
 ) -> LivenessInfo<R>
@@ -248,9 +354,9 @@ pub fn analyze_with_debug<I, R>(
     vreg_count: u32,
     vreg_classes: VRegClasses,
     get_label: impl Fn(&I) -> Option<LabelId>,
-    get_successors: impl Fn(usize, &I, &HashMap<LabelId, usize>) -> Vec<usize>,
-    get_uses: impl Fn(&I) -> Vec<VReg>,
-    get_defs: impl Fn(&I) -> Vec<VReg>,
+    get_successors: impl Fn(usize, &I, &HashMap<LabelId, usize>) -> SuccessorList,
+    get_uses: impl Fn(&I) -> VRegList,
+    get_defs: impl Fn(&I) -> VRegList,
     get_clobbers: impl Fn(&I) -> Vec<R>,
     get_non_returning: impl Fn(&I) -> bool,
 ) -> (LivenessInfo<R>, LivenessDebugInfo)
@@ -281,9 +387,9 @@ fn analyze_inner<I, R>(
     vreg_count: u32,
     vreg_classes: VRegClasses,
     get_label: impl Fn(&I) -> Option<LabelId>,
-    get_successors: impl Fn(usize, &I, &HashMap<LabelId, usize>) -> Vec<usize>,
-    get_uses: impl Fn(&I) -> Vec<VReg>,
-    get_defs: impl Fn(&I) -> Vec<VReg>,
+    get_successors: impl Fn(usize, &I, &HashMap<LabelId, usize>) -> SuccessorList,
+    get_uses: impl Fn(&I) -> VRegList,
+    get_defs: impl Fn(&I) -> VRegList,
     get_clobbers: impl Fn(&I) -> Vec<R>,
     get_non_returning: impl Fn(&I) -> bool,
     collect_debug: bool,
@@ -317,8 +423,8 @@ where
     let successors = build_successor_lists(instructions, &label_to_idx, &get_successors);
 
     // Step 3: Pre-compute uses and defs for each instruction
-    let inst_uses: Vec<Vec<VReg>> = instructions.iter().map(&get_uses).collect();
-    let inst_defs: Vec<Vec<VReg>> = instructions.iter().map(&get_defs).collect();
+    let inst_uses: Vec<VRegList> = instructions.iter().map(&get_uses).collect();
+    let inst_defs: Vec<VRegList> = instructions.iter().map(&get_defs).collect();
 
     // Step 4: Backward dataflow analysis to compute live sets
     let (live_in, live_out) =
@@ -352,8 +458,8 @@ where
                 index: idx,
                 live_in: bitset_to_hashset(&live_in[idx]),
                 live_out: bitset_to_hashset(&live_out[idx]),
-                defs: inst_defs[idx].clone(),
-                uses: inst_uses[idx].clone(),
+                defs: inst_defs[idx].to_vec(),
+                uses: inst_uses[idx].to_vec(),
             })
             .collect();
         LivenessDebugInfo {
@@ -384,9 +490,9 @@ pub fn analyze_debug<I, R>(
     vreg_count: u32,
     vreg_classes: VRegClasses,
     get_label: impl Fn(&I) -> Option<LabelId>,
-    get_successors: impl Fn(usize, &I, &HashMap<LabelId, usize>) -> Vec<usize>,
-    get_uses: impl Fn(&I) -> Vec<VReg>,
-    get_defs: impl Fn(&I) -> Vec<VReg>,
+    get_successors: impl Fn(usize, &I, &HashMap<LabelId, usize>) -> SuccessorList,
+    get_uses: impl Fn(&I) -> VRegList,
+    get_defs: impl Fn(&I) -> VRegList,
 ) -> LivenessDebugInfo
 where
     R: Copy + Eq + std::hash::Hash,
@@ -427,8 +533,8 @@ fn build_label_map<I>(
 fn build_successor_lists<I>(
     instructions: &[I],
     label_to_idx: &HashMap<LabelId, usize>,
-    get_successors: impl Fn(usize, &I, &HashMap<LabelId, usize>) -> Vec<usize>,
-) -> Vec<Vec<usize>> {
+    get_successors: impl Fn(usize, &I, &HashMap<LabelId, usize>) -> SuccessorList,
+) -> Vec<SuccessorList> {
     instructions
         .iter()
         .enumerate()
@@ -439,7 +545,7 @@ fn build_successor_lists<I>(
 /// Return `true` if any instruction has a successor at an index `<= its own`,
 /// i.e. the control-flow graph contains a back-edge (a loop). Used to pick the
 /// fast, loop-free live-range construction path in [`build_live_ranges`].
-fn has_back_edge(successors: &[Vec<usize>]) -> bool {
+fn has_back_edge(successors: &[SuccessorList]) -> bool {
     successors
         .iter()
         .enumerate()
@@ -454,9 +560,9 @@ fn has_back_edge(successors: &[Vec<usize>]) -> bool {
 fn compute_dataflow(
     num_insts: usize,
     vreg_count: u32,
-    successors: &[Vec<usize>],
-    inst_uses: &[Vec<VReg>],
-    inst_defs: &[Vec<VReg>],
+    successors: &[SuccessorList],
+    inst_uses: &[VRegList],
+    inst_defs: &[VRegList],
 ) -> (Vec<FixedBitSet>, Vec<FixedBitSet>) {
     let vreg_count_usize = vreg_count as usize;
 
@@ -544,8 +650,8 @@ fn compute_dataflow(
 fn build_live_ranges(
     num_insts: usize,
     vreg_count: u32,
-    inst_uses: &[Vec<VReg>],
-    inst_defs: &[Vec<VReg>],
+    inst_uses: &[VRegList],
+    inst_defs: &[VRegList],
     live_in: &[FixedBitSet],
     live_out: &[FixedBitSet],
     has_back_edge: bool,
@@ -664,7 +770,10 @@ fn compute_live_at(
 /// # Returns
 ///
 /// A `LoopInfo` with loop depth for each instruction.
-pub fn compute_loop_info(num_insts: usize, successors: &[Vec<usize>]) -> LoopInfo {
+pub fn compute_loop_info<S>(num_insts: usize, successors: &[S]) -> LoopInfo
+where
+    S: AsRef<[usize]>,
+{
     if num_insts == 0 {
         return LoopInfo::no_loops(0);
     }
@@ -675,7 +784,7 @@ pub fn compute_loop_info(num_insts: usize, successors: &[Vec<usize>]) -> LoopInf
     let mut loop_ranges: Vec<(usize, usize)> = Vec::new();
 
     for (from, succs) in successors.iter().enumerate() {
-        for &to in succs {
+        for &to in succs.as_ref() {
             if to <= from {
                 // This is a back-edge: we're jumping backwards
                 // The loop spans from `to` (loop header) to `from` (back-edge source)
@@ -707,7 +816,7 @@ pub fn compute_loop_info(num_insts: usize, successors: &[Vec<usize>]) -> LoopInf
 pub fn analyze_loops<I>(
     instructions: &[I],
     get_label: impl Fn(&I) -> Option<LabelId>,
-    get_successors: impl Fn(usize, &I, &HashMap<LabelId, usize>) -> Vec<usize>,
+    get_successors: impl Fn(usize, &I, &HashMap<LabelId, usize>) -> SuccessorList,
 ) -> LoopInfo {
     let num_insts = instructions.len();
 
@@ -774,6 +883,24 @@ pub fn compute_pressure(live_at: &[FixedBitSet]) -> PressureInfo {
 mod tests {
     use super::*;
 
+    #[test]
+    fn inline_fact_lists_do_not_widen_the_outer_liveness_tables() {
+        assert!(std::mem::size_of::<VRegList>() <= std::mem::size_of::<Vec<VReg>>());
+        assert!(std::mem::size_of::<SuccessorList>() <= std::mem::size_of::<Vec<usize>>());
+
+        let facts: VRegList = (0..4).map(VReg::new).collect();
+        assert_eq!(
+            facts.as_ref(),
+            &[VReg::new(0), VReg::new(1), VReg::new(2), VReg::new(3)]
+        );
+    }
+
+    #[test]
+    #[should_panic(expected = "inline liveness fact capacity 4 exceeded")]
+    fn inline_fact_lists_fail_loudly_when_the_audited_bound_changes() {
+        let _: VRegList = (0..5).map(VReg::new).collect();
+    }
+
     // Simple test instruction type
     #[derive(Debug, Clone)]
     enum TestInst {
@@ -797,10 +924,10 @@ mod tests {
         inst: &TestInst,
         label_to_idx: &HashMap<LabelId, usize>,
         num_insts: usize,
-    ) -> Vec<usize> {
+    ) -> SuccessorList {
         match inst {
             TestInst::Branch { label } => {
-                let mut succs = Vec::new();
+                let mut succs = SuccessorList::new();
                 if idx + 1 < num_insts {
                     succs.push(idx + 1);
                 }
@@ -809,30 +936,30 @@ mod tests {
                 }
                 succs
             }
-            TestInst::Ret => Vec::new(),
+            TestInst::Ret => SuccessorList::new(),
             _ => {
+                let mut successors = SuccessorList::new();
                 if idx + 1 < num_insts {
-                    vec![idx + 1]
-                } else {
-                    Vec::new()
+                    successors.push(idx + 1);
                 }
+                successors
             }
         }
     }
 
-    fn test_get_uses(inst: &TestInst) -> Vec<VReg> {
+    fn test_get_uses(inst: &TestInst) -> VRegList {
         match inst {
-            TestInst::Use { src } => vec![VReg::new(*src)],
-            TestInst::Move { src, .. } => vec![VReg::new(*src)],
-            _ => Vec::new(),
+            TestInst::Use { src } => [VReg::new(*src)].into_iter().collect(),
+            TestInst::Move { src, .. } => [VReg::new(*src)].into_iter().collect(),
+            _ => VRegList::new(),
         }
     }
 
-    fn test_get_defs(inst: &TestInst) -> Vec<VReg> {
+    fn test_get_defs(inst: &TestInst) -> VRegList {
         match inst {
-            TestInst::Def { dst } => vec![VReg::new(*dst)],
-            TestInst::Move { dst, .. } => vec![VReg::new(*dst)],
-            _ => Vec::new(),
+            TestInst::Def { dst } => [VReg::new(*dst)].into_iter().collect(),
+            TestInst::Move { dst, .. } => [VReg::new(*dst)].into_iter().collect(),
+            _ => VRegList::new(),
         }
     }
 

--- a/crates/rue-codegen/src/regalloc.rs
+++ b/crates/rue-codegen/src/regalloc.rs
@@ -1240,7 +1240,7 @@ pub trait RegAllocBackend {
 
     fn vreg_count(mir: &Self::Mir) -> u32;
     fn instructions(mir: &Self::Mir) -> &[Self::Inst];
-    fn defs(inst: &Self::Inst) -> Vec<VReg>;
+    fn defs(inst: &Self::Inst) -> crate::liveness::VRegList;
     fn rematerialization(inst: &Self::Inst) -> Option<(VReg, RematerializeOp)>;
     fn analyze(mir: &Self::Mir) -> LivenessInfo<Self::Reg>;
     fn analyze_with_debug(mir: &Self::Mir) -> (LivenessInfo<Self::Reg>, LivenessDebugInfo);

--- a/crates/rue-codegen/src/vreg.rs
+++ b/crates/rue-codegen/src/vreg.rs
@@ -25,7 +25,7 @@ use crate::index_map::Handle;
 /// Virtual registers are unlimited and allocated to physical registers
 /// during register allocation. They are target-independent; the mapping
 /// to physical registers happens in each backend's register allocator.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub struct VReg(u32);
 
 impl VReg {

--- a/crates/rue-codegen/src/x86_64/liveness.rs
+++ b/crates/rue-codegen/src/x86_64/liveness.rs
@@ -7,10 +7,11 @@ use std::collections::HashMap;
 
 use super::mir::{Operand, Reg, ReturnBehavior, X86Inst, X86Mir};
 use crate::liveness::{
-    LivenessAdapter, branch_successor, conditional_successors, fallthrough_successor,
+    LivenessAdapter, SuccessorList, VRegList, branch_successor, conditional_successors,
+    fallthrough_successor,
 };
 use crate::reg_class::VRegClasses;
-use crate::vreg::{LabelId, VReg};
+use crate::vreg::LabelId;
 
 // Re-export shared types from the regalloc module
 pub use crate::regalloc::{InstructionLiveness, LiveRange, LivenessDebugInfo, LoopInfo};
@@ -47,15 +48,15 @@ impl LivenessAdapter for X86LivenessAdapter<'_> {
         idx: usize,
         inst: &Self::Inst,
         label_to_idx: &HashMap<LabelId, usize>,
-    ) -> Vec<usize> {
+    ) -> SuccessorList {
         get_successors(idx, inst, label_to_idx, self.instructions().len())
     }
 
-    fn uses(&self, inst: &Self::Inst) -> Vec<VReg> {
+    fn uses(&self, inst: &Self::Inst) -> VRegList {
         uses(inst)
     }
 
-    fn defs(&self, inst: &Self::Inst) -> Vec<VReg> {
+    fn defs(&self, inst: &Self::Inst) -> VRegList {
         defs(inst)
     }
 
@@ -106,7 +107,7 @@ fn get_successors(
     inst: &X86Inst,
     label_to_idx: &HashMap<LabelId, usize>,
     num_insts: usize,
-) -> Vec<usize> {
+) -> SuccessorList {
     match inst {
         // Unconditional jump - only successor is the target
         X86Inst::Jmp { label } => branch_successor(*label, label_to_idx),
@@ -121,14 +122,14 @@ fn get_successors(
         | X86Inst::Jge { label }
         | X86Inst::Jle { label } => conditional_successors(idx, *label, label_to_idx, num_insts),
         // Return and trap have no successors
-        X86Inst::Ret | X86Inst::Ud2 => Vec::new(),
+        X86Inst::Ret | X86Inst::Ud2 => SuccessorList::new(),
         // A call to a helper the runtime ABI manifest declares
         // `ReturnBehavior::Never` aborts the process. Control never comes back,
         // so it has no successors and nothing is live after it (RUE-1224).
         X86Inst::CallRel {
             returns: ReturnBehavior::Never,
             ..
-        } => Vec::new(),
+        } => SuccessorList::new(),
         // Ordinary calls fall through (the callee returns)
         X86Inst::CallRel { .. } => fallthrough_successor(idx, num_insts),
         // All other instructions fall through to the next
@@ -137,11 +138,10 @@ fn get_successors(
 }
 
 /// Get virtual registers used (read) by an instruction.
-pub fn uses(inst: &X86Inst) -> Vec<VReg> {
-    // Most instructions have 0-2 operands; pre-allocate for common case
-    let mut result = Vec::with_capacity(2);
+pub fn uses(inst: &X86Inst) -> VRegList {
+    let mut result = VRegList::new();
 
-    let add_if_virtual = |op: &Operand, vec: &mut Vec<VReg>| {
+    let add_if_virtual = |op: &Operand, vec: &mut VRegList| {
         if let Operand::Virtual(vreg) = op {
             vec.push(*vreg);
         }
@@ -322,11 +322,10 @@ pub fn uses(inst: &X86Inst) -> Vec<VReg> {
 }
 
 /// Get virtual registers defined (written) by an instruction.
-pub fn defs(inst: &X86Inst) -> Vec<VReg> {
-    // Most instructions define 0-1 registers; pre-allocate for common case
-    let mut result = Vec::with_capacity(1);
+pub fn defs(inst: &X86Inst) -> VRegList {
+    let mut result = VRegList::new();
 
-    let add_if_virtual = |op: &Operand, vec: &mut Vec<VReg>| {
+    let add_if_virtual = |op: &Operand, vec: &mut VRegList| {
         if let Operand::Virtual(vreg) = op {
             vec.push(*vreg);
         }

--- a/crates/rue-codegen/src/x86_64/regalloc.rs
+++ b/crates/rue-codegen/src/x86_64/regalloc.rs
@@ -1356,7 +1356,7 @@ impl RegAllocBackend for X86Backend {
         mir.instructions()
     }
 
-    fn defs(inst: &Self::Inst) -> Vec<VReg> {
+    fn defs(inst: &Self::Inst) -> crate::liveness::VRegList {
         liveness::defs(inst)
     }
 

--- a/docs/notes/post-adr-0063-cold-compiler-architecture-audit.md
+++ b/docs/notes/post-adr-0063-cold-compiler-architecture-audit.md
@@ -407,6 +407,34 @@ The fixed one-worker Lattice allocation probe fell from 22,297,695 to
 reachability counter remains exact, and the Lattice executable hash is still
 `8d7355dcda83780ef8a98aedfa0495a9d4745c5ed84375e0ae9a37d82eb361a9`.
 
+RUE-1357 then removed the next coherent allocator-heavy cluster from the cold
+profile. Shared liveness previously built three separately allocated lists per
+machine instruction: successors, virtual-register uses and virtual-register
+definitions. MIR bounds those facts tightly — two successors and at most three
+current virtual operands — so the canonical liveness adapter now stores them
+in fixed-capacity inline lists. The four-register list deliberately has one
+slot of headroom, and both inline representations are no wider than the `Vec`
+elements they replace. A production capacity check fails loudly if a future
+MIR instruction changes the audited bound.
+
+That width constraint is material. A growable small-vector experiment removed
+the same tiny allocations but widened every row of the three outer fact tables,
+raising Lattice's peak by roughly 9 MiB in the first controlled run. The fixed
+representation was selected instead: its final peak was 722.5 MiB versus the
+RUE-1356 parent's 727.6 MiB, while the other maintained workloads moved -0.2,
++1.0 and 0.0 MiB. The fixed one-worker Lattice allocation probe fell from
+21,842,394 to 20,723,763 calls (-5.12 percent) and from 3,543,025,272 to
+3,535,874,140 requested bytes (-0.20 percent).
+
+Cold clock time is neutral overall rather than a universal speedup: compiler
+medians moved 132.05 to 130.84 ms for Ruelex, 389.20 to 363.53 ms for Mosaic,
+804.38 to 813.01 ms for Harbor and 932.14 to 944.40 ms for Lattice. The latter
+two deltas are small relative to the paired runs' noise, while the exact
+allocation reduction establishes the work result independently. All existing
+query, reachability and materialization counters remain identical, and the
+Lattice executable remains byte-identical at
+`8d7355dcda83780ef8a98aedfa0495a9d4745c5ed84375e0ae9a37d82eb361a9`.
+
 ## Next actions and decision boundary
 
 Authorized low-risk work:


### PR DESCRIPTION
Fixes RUE-1357.

Shared liveness now stores bounded successor, virtual-register use, and virtual-register definition facts inline instead of allocating three small vectors per machine instruction. Both backends and rematerialization discovery use the same fixed representation; debug output still materializes owned vectors only when requested.

The fixed capacities match the current MIR maxima, retain operand order, include headroom for virtual-register facts, and are no wider than the vector rows they replace. A tested production assertion catches future MIR growth. The architecture audit records why the initially explored wider small-vector shape was rejected.

Evidence:
- one-worker Lattice allocation calls: 21,842,394 to 20,723,763 (-5.12%)
- requested bytes: 3,543,025,272 to 3,535,874,140 (-0.20%)
- cold compiler medians are neutral overall; the two small increases are within paired-run noise
- peak RSS: -0.2, +1.0, 0.0, and -5.1 MiB across Ruelex, Mosaic, Harbor, and Lattice
- all existing deterministic performance counters are unchanged
- Lattice executable remains byte-identical

Tests:
- `scripts/rue quick`
- `./buck2 test //crates/rue-codegen:rue-codegen-test` (703/703)