### PR TITLE
RUE-1358: remove stable symbol encoding heap churn

### DIFF
--- a/crates/rue-compiler/BUCK
+++ b/crates/rue-compiler/BUCK
@@ -42,6 +42,7 @@ _DEPS = [
     "//crates/rue-span:rue-span",
     "//crates/rue-target:rue-target",
     "//third-party:annotate-snippets",
+    "//third-party:itoa",
     "//third-party:lasso",
     "//third-party:libc",
     "//third-party:sha2",

--- a/crates/rue-compiler/src/semantic_identity.rs
+++ b/crates/rue-compiler/src/semantic_identity.rs
@@ -361,36 +361,45 @@ pub(crate) fn function_instance_from_specialization(
 
 fn tag(output: &mut String, value: u32) {
     output.push('t');
-    output.push_str(&value.to_string());
+    decimal(output, value);
     output.push('_');
 }
 
-fn number(output: &mut String, value: impl std::fmt::Display) {
-    let value = value.to_string();
+fn number<I: itoa::Integer>(output: &mut String, value: I) {
+    let mut buffer = itoa::Buffer::new();
+    let value = buffer.format(value);
     output.push('n');
-    output.push_str(&value.len().to_string());
+    decimal(output, value.len());
     output.push('_');
-    output.push_str(&value);
+    output.push_str(value);
+}
+
+fn decimal<I: itoa::Integer>(output: &mut String, value: I) {
+    let mut buffer = itoa::Buffer::new();
+    output.push_str(buffer.format(value));
 }
 
 fn bytes(output: &mut String, value: &str) {
+    const HEX: &[u8; 16] = b"0123456789abcdef";
+
     output.push('s');
-    output.push_str(&value.len().to_string());
+    decimal(output, value.len());
     output.push('_');
-    for byte in value.as_bytes() {
-        use std::fmt::Write as _;
-        write!(output, "{byte:02x}").expect("writing to String cannot fail");
+    for &byte in value.as_bytes() {
+        output.push(char::from(HEX[usize::from(byte >> 4)]));
+        output.push(char::from(HEX[usize::from(byte & 0x0f)]));
     }
 }
 
 fn sequence<T>(output: &mut String, values: &[T], mut encode: impl FnMut(&T, &mut String)) {
     output.push('q');
-    output.push_str(&values.len().to_string());
+    decimal(output, values.len());
     output.push('_');
+    let mut field = String::new();
     for value in values {
-        let mut field = String::new();
+        field.clear();
         encode(value, &mut field);
-        output.push_str(&field.len().to_string());
+        decimal(output, field.len());
         output.push('_');
         output.push_str(&field);
     }
@@ -459,49 +468,49 @@ fn encode_anchor(value: &StructuralAnchor, output: &mut String) {
         StructuralPathSegment::Body => tag(output, 0),
         StructuralPathSegment::ParameterType(index) => {
             tag(output, 1);
-            number(output, index);
+            number(output, *index);
         }
         StructuralPathSegment::ReturnType => tag(output, 2),
         StructuralPathSegment::Statement(index) => {
             tag(output, 3);
-            number(output, index);
+            number(output, *index);
         }
         StructuralPathSegment::Operand(index) => {
             tag(output, 4);
-            number(output, index);
+            number(output, *index);
         }
         StructuralPathSegment::Branch(index) => {
             tag(output, 5);
-            number(output, index);
+            number(output, *index);
         }
         StructuralPathSegment::MatchArm(index) => {
             tag(output, 6);
-            number(output, index);
+            number(output, *index);
         }
         StructuralPathSegment::FieldType(index) => {
             tag(output, 7);
-            number(output, index);
+            number(output, *index);
         }
         StructuralPathSegment::VariantPayload { variant, payload } => {
             tag(output, 8);
-            number(output, variant);
-            number(output, payload);
+            number(output, *variant);
+            number(output, *payload);
         }
         StructuralPathSegment::Method(index) => {
             tag(output, 9);
-            number(output, index);
+            number(output, *index);
         }
         StructuralPathSegment::AnonymousType(index) => {
             tag(output, 10);
-            number(output, index);
+            number(output, *index);
         }
         StructuralPathSegment::StringLiteral(index) => {
             tag(output, 11);
-            number(output, index);
+            number(output, *index);
         }
         StructuralPathSegment::ReadOnlyData(index) => {
             tag(output, 12);
-            number(output, index);
+            number(output, *index);
         }
     });
 }
@@ -515,7 +524,7 @@ fn encode_argument_value(value: &CanonicalArgumentValue, output: &mut String) {
     match value {
         CanonicalArgumentValue::Integer(value) => {
             tag(output, 0);
-            number(output, value);
+            number(output, *value);
         }
         CanonicalArgumentValue::Bool(value) => {
             tag(output, 1);
@@ -588,7 +597,7 @@ fn encode_type(value: &TypeInstanceKey, output: &mut String) {
         TypeInstanceKey::Array { element, len } => {
             tag(output, 15);
             encode_type(element, output);
-            number(output, len);
+            number(output, *len);
         }
         TypeInstanceKey::PtrConst(value) => {
             tag(output, 16);
@@ -604,7 +613,7 @@ fn encode_type(value: &TypeInstanceKey, output: &mut String) {
         }
         TypeInstanceKey::GenericParameter(value) => {
             tag(output, 19);
-            number(output, value);
+            number(output, *value);
         }
         TypeInstanceKey::Slice { element, name } => {
             tag(output, 20);
@@ -707,6 +716,30 @@ mod tests {
         StableSymbolId::Callable(StableCallableId::Function(FunctionInstanceKey::Definition(
             definition,
         )))
+    }
+
+    #[test]
+    fn framing_helpers_preserve_the_version_one_wire_format() {
+        let mut encoded = String::new();
+        tag(&mut encoded, u32::MAX);
+        assert_eq!(encoded, "t4294967295_");
+
+        encoded.clear();
+        number(&mut encoded, i128::MIN);
+        assert_eq!(encoded, "n40_-170141183460469231731687303715884105728");
+
+        encoded.clear();
+        bytes(&mut encoded, "a_\0é");
+        assert_eq!(encoded, "s5_615f00c3a9");
+
+        encoded.clear();
+        sequence(&mut encoded, &[i128::MIN, 0, 10], |value, output| {
+            number(output, *value);
+        });
+        assert_eq!(
+            encoded,
+            "q3_44_n40_-1701411834604692317316873037158841057284_n1_05_n2_10"
+        );
     }
 
     #[test]

--- a/docs/notes/post-adr-0063-cold-compiler-architecture-audit.md
+++ b/docs/notes/post-adr-0063-cold-compiler-architecture-audit.md
@@ -435,6 +435,27 @@ query, reachability and materialization counters remain identical, and the
 Lattice executable remains byte-identical at
 `8d7355dcda83780ef8a98aedfa0495a9d4745c5ed84375e0ae9a37d82eb361a9`.
 
+RUE-1358 followed the post-RUE-1357 release profile into stable machine-symbol
+encoding. The version-one encoder previously allocated temporary decimal
+strings for every tag, field length, and numeric value, invoked generic
+formatting once per input byte, and allocated a fresh scratch string for every
+sequence element. It now writes integers from stack-backed `itoa` buffers,
+hex-encodes bytes through a fixed lookup table, and reuses one scratch buffer
+per sequence. The wire format and ownership boundary are unchanged; this is a
+local representation improvement rather than a symbol cache or a new shared
+lifetime.
+
+On the fixed one-worker Lattice allocation probe, calls fell from 20,723,870 to
+19,233,621 (-7.19 percent) and requested bytes from 3,535,911,692 to
+3,533,206,987 (-0.08 percent). Every query, reachability, and CFG-materialization
+counter remained exact. Two ordinary-allocator scaling runs had no consistent
+clock or peak-memory direction: the first moved the four compiler medians by
++1.5, +1.5, +0.5, and -2.1 percent, while the repeat was visibly host-noisy and
+bracketed the parent's memory on the two large workloads. The deterministic
+allocation result therefore establishes the win without claiming a clock
+speedup. The Lattice executable remains byte-identical at
+`8d7355dcda83780ef8a98aedfa0495a9d4745c5ed84375e0ae9a37d82eb361a9`.
+
 ## Next actions and decision boundary
 
 Authorized low-risk work:

--- a/third-party/BUCK
+++ b/third-party/BUCK
@@ -1073,6 +1073,12 @@ cargo.rust_library(
     visibility = [],
 )
 
+alias(
+    name = "itoa",
+    actual = ":itoa-1.0.16",
+    visibility = ["PUBLIC"],
+)
+
 cargo.rust_library(
     name = "itoa-1.0.16",
     srcs = [

--- a/third-party/Cargo.lock
+++ b/third-party/Cargo.lock
@@ -692,6 +692,7 @@ dependencies = [
  "annotate-snippets",
  "anyhow",
  "fixedbitset",
+ "itoa",
  "lasso",
  "libc",
  "libtest2-mimic",

--- a/third-party/Cargo.toml
+++ b/third-party/Cargo.toml
@@ -29,6 +29,7 @@ tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "json"] }
 rayon = "1.10"
 fixedbitset = "0.5"
+itoa = "1.0"
 proptest = "1.5"
 smallvec = "1.15"
 sha2 = { version = "0.10.9", default-features = false }


### PR DESCRIPTION
Fixes RUE-1358.

## Summary

- write stable-symbol decimal fields from stack-backed integer buffers
- hex-encode text bytes directly and reuse sequence scratch storage
- preserve the version-1 wire format with an exact adversarial golden test
- record the cold-profile and allocation evidence in the architecture audit

## Performance

One-worker Lattice allocation calls fall from 20,723,870 to 19,233,621 (-7.19%); requested bytes fall by 2,704,705. All deterministic compiler-work counters and the final executable hash are unchanged. Two ordinary-allocator scaling runs show no consistent clock or peak-memory regression.

## Validation

- `scripts/rue unit compiler semantic_identity::tests` (11/11)
- `scripts/rue quick` (31 targets)
- paired release scaling reports and counting-allocator probes