### PR TITLE
RUE-1363: query active registers without transient hash sets

### DIFF
--- a/crates/rue-codegen/src/regalloc.rs
+++ b/crates/rue-codegen/src/regalloc.rs
@@ -1920,26 +1920,30 @@ pub fn linear_scan_with_cost_model_and_debug<Reg: Copy + Eq + std::hash::Hash>(
 fn pick_free_register<Reg: Copy + Eq + std::hash::Hash>(
     save: SaveClasses<'_, Reg>,
     clobbers: &ClobberIndex<Reg>,
-    used: &HashSet<Reg>,
+    active: &[(VReg, Reg, usize)],
     sunk: &[Reg],
     range: &LiveRange,
 ) -> Option<Reg> {
+    // A class can never have more active intervals than physical registers.
+    // Query that small canonical list directly instead of rebuilding a hash
+    // set for every arriving virtual register.
+    let is_used = |candidate| {
+        active
+            .iter()
+            .any(|&(_, active_reg, _)| active_reg == candidate)
+    };
+
     save.compact_callee_saved
         .iter()
         .copied()
-        .find(|&reg| sunk.contains(&reg) && !used.contains(&reg))
+        .find(|&reg| sunk.contains(&reg) && !is_used(reg))
         .or_else(|| {
             save.caller_saved
                 .iter()
                 .copied()
-                .find(|&reg| !used.contains(&reg) && !clobbers.is_clobbered_during(reg, range))
+                .find(|&reg| !is_used(reg) && !clobbers.is_clobbered_during(reg, range))
         })
-        .or_else(|| {
-            save.callee_saved
-                .iter()
-                .copied()
-                .find(|&reg| !used.contains(&reg))
-        })
+        .or_else(|| save.callee_saved.iter().copied().find(|&reg| !is_used(reg)))
 }
 
 /// Whether `reg` can hold one value for the whole of `range`.
@@ -2197,12 +2201,9 @@ fn scan_intervals<Reg: Copy + Eq + std::hash::Hash>(
         // Expire old intervals - remove registers whose vregs are no longer live
         active.retain(|&(_, _, end)| end >= range.start);
 
-        // Find registers currently in use
-        let used_regs: HashSet<Reg> = active.iter().map(|&(_, reg, _)| reg).collect();
-
         // Try to find a free register of this vreg's own class: a sunk compact
         // one, else caller-saved, else a fresh callee-saved one.
-        let allocated_reg = pick_free_register(save, &clobbers, &used_regs, sunk, &range);
+        let allocated_reg = pick_free_register(save, &clobbers, active, sunk, &range);
 
         if let Some(reg) = allocated_reg {
             // Assign this register
@@ -2455,12 +2456,9 @@ fn scan_intervals_with_remat<Reg: Copy + Eq + std::hash::Hash>(
         // Expire old intervals - remove registers whose vregs are no longer live
         active.retain(|&(_, _, end)| end >= range.start);
 
-        // Find registers currently in use
-        let used_regs: HashSet<Reg> = active.iter().map(|&(_, reg, _)| reg).collect();
-
         // Try to find a free register of this vreg's own class: a sunk compact
         // one, else caller-saved, else a fresh callee-saved one.
-        let allocated_reg = pick_free_register(save, &clobbers, &used_regs, sunk, &range);
+        let allocated_reg = pick_free_register(save, &clobbers, active, sunk, &range);
 
         if let Some(reg) = allocated_reg {
             // Assign this register

--- a/docs/notes/post-adr-0063-cold-compiler-architecture-audit.md
+++ b/docs/notes/post-adr-0063-cold-compiler-architecture-audit.md
@@ -515,6 +515,27 @@ memory moved -0.8, +1.3, -3.5, and -4.3 MiB respectively. The Lattice
 executable remains byte-identical at
 `8d7355dcda83780ef8a98aedfa0495a9d4745c5ed84375e0ae9a37d82eb361a9`.
 
+RUE-1363 removed per-interval hash-table construction from both production
+linear-scan register-allocation paths. The allocator already maintains the
+active intervals separately for each register class, and that list cannot
+outgrow the class's small physical-register file. Free-register selection now
+checks that canonical bounded list directly instead of collecting an
+equivalent `HashSet` for every arriving virtual register. Register preference,
+clobber, spill, rematerialization, and optional reuse-pass policies are
+unchanged.
+
+On the fixed one-worker Lattice allocation probe, calls fell from 17,694,739 to
+17,593,676 (-0.57 percent) and requested bytes from 3,374,368,531 to
+3,371,985,007 (-0.07 percent). Every query, reachability, and
+CFG-materialization counter remained identical. An immediate parent/current
+ordinary-allocator comparison moved compiler medians from 128.01 to 130.36 ms
+for Ruelex, 367.85 to 371.60 ms for Mosaic, 820.46 to 793.96 ms for Harbor, and
+975.90 to 902.59 ms for Lattice. The larger parent samples were host-noisy
+(23.82 and 49.26 ms MAD), so this establishes no clock regression without
+claiming the apparent large-workload speedup. Peak memory moved +0.3, -0.8,
++0.6, and -2.3 MiB respectively. The Lattice executable remains byte-identical
+at `8d7355dcda83780ef8a98aedfa0495a9d4745c5ed84375e0ae9a37d82eb361a9`.
+
 ## Next actions and decision boundary
 
 Authorized low-risk work:


### PR DESCRIPTION
Fixes RUE-1363.

## Summary

- query each register class's bounded active-interval list directly
- remove one transient hash-set construction per virtual register in both production scan paths
- preserve register preference, clobber, spill, rematerialization, and reuse-pass policy
- record counter, cold-time, memory, and output evidence in the architecture audit

## Evidence

- Lattice allocation calls: 17,694,739 -> 17,593,676 (-101,063; -0.57%)
- Lattice requested bytes: 3,374,368,531 -> 3,371,985,007 (-2,383,524; -0.07%)
- all deterministic compiler-work counters unchanged
- Lattice executable SHA-256 unchanged
- immediate cold medians neutral/favorable within run noise; peak memory within +0.6 MiB and 2.3 MiB lower on Lattice
- focused shared/x86-64/AArch64 register-allocation suite: 113/113 passed
- formatting passed; CI is the broad cross-platform authority