### PR TITLE
RUE-1365: expose semantic provider work counters

### DIFF
--- a/crates/rue-bench/src/scaling.rs
+++ b/crates/rue-bench/src/scaling.rs
@@ -402,6 +402,40 @@ fn render(report: &ScalingReport) -> String {
         ));
     }
 
+    out.push_str("\n## Semantic provider observations\n\n");
+    out.push_str("Counts are exact snapshots of the provider operations already performed by production body analysis; the scaling probe adds no provider lookup or materialization work. Lookup and candidate counts expose demand at the semantic boundary, while exact fact-family reads and durable materializations separate repeated observation from body-local representation work.\n\n");
+    out.push_str("| workload | name/import lookups | method/operator candidates | declaration facts total (identity/signature/type/const) |\n");
+    out.push_str("| --- | ---: | ---: | ---: |\n");
+    for observation in &report.workloads {
+        let work = observation.work.semantic_provider;
+        out.push_str(&format!(
+            "| {} | {}/{} | {}/{} | {} ({}/{}/{}/{}) |\n",
+            observation.workload,
+            work.name_lookups,
+            work.import_lookups,
+            work.method_candidates,
+            work.operator_candidates,
+            work.declaration_facts,
+            work.identity_facts,
+            work.signature_facts,
+            work.type_facts,
+            work.const_facts,
+        ));
+    }
+    out.push_str("\n| workload | durable materializations | anonymous facts | producer facts | toolchain facts |\n");
+    out.push_str("| --- | ---: | ---: | ---: | ---: |\n");
+    for observation in &report.workloads {
+        let work = observation.work.semantic_provider;
+        out.push_str(&format!(
+            "| {} | {} | {} | {} | {} |\n",
+            observation.workload,
+            work.materializations,
+            work.anonymous_facts,
+            work.producer_facts,
+            work.toolchain_facts,
+        ));
+    }
+
     out.push_str("\n## Semantic reachability scheduling\n\n");
     out.push_str("Counts are exact for database-owned body reachability. Width buckets count non-empty dependency-ready logical frontiers; multi-permit runtimes execute bounded windows as structured batches while a single-permit runtime executes the same windows inline. Transaction counts distinguish ready-frontier prefetch from fallback coordinator demand; `keys/batch` exposes available scheduling breadth independently of clock time.\n\n");
     out.push_str("| workload | scans | scan keys | batches | scheduled keys | keys/batch | transactions prefetched/serial | width 1 | width 2–3 | width 4–7 | width 8+ |\n");
@@ -579,6 +613,21 @@ mod tests {
                     functions: 1,
                 },
                 work: rue_perf_schema::CompilerWork {
+                    semantic_provider: rue_perf_schema::SemanticProviderWork {
+                        name_lookups: 2,
+                        import_lookups: 3,
+                        method_candidates: 5,
+                        operator_candidates: 7,
+                        declaration_facts: 60,
+                        identity_facts: 11,
+                        signature_facts: 13,
+                        type_facts: 17,
+                        const_facts: 19,
+                        materializations: 23,
+                        anonymous_facts: 29,
+                        producer_facts: 31,
+                        toolchain_facts: 37,
+                    },
                     semantic_reachability: rue_perf_schema::SemanticReachabilityWork {
                         frontier_scans: 4,
                         frontier_scan_keys: 7,
@@ -632,6 +681,8 @@ mod tests {
         assert!(rendered.contains("shape id"));
         assert!(rendered.contains("Deterministic query work"));
         assert!(rendered.contains("nodes/token"));
+        assert!(rendered.contains("Semantic provider observations"));
+        assert!(rendered.contains("durable materializations"));
         assert!(rendered.contains("Semantic reachability scheduling"));
         assert!(rendered.contains("keys/batch"));
         assert!(rendered.contains("CFG materialization preparation"));

--- a/crates/rue-cli-tests/cases/benchmark_json.toml
+++ b/crates/rue-cli-tests/cases/benchmark_json.toml
@@ -15,7 +15,7 @@ args = ["--benchmark-json", "main.rue", "-o", "prog"]
 env = { RUST_LOG = "error" }
 exit_code = 42
 compile_stdout_contains = [
-  '"schema_version":8',
+  '"schema_version":9',
   '"compiler_build_profile":',
   '"timing_model":"inclusive_spans"',
   # The additive partition, which is the only model that may be stacked. Its
@@ -43,6 +43,8 @@ compile_stdout_contains = [
   '"tokens":',
   '"functions":1',
   '"compiler_work":',
+  '"semantic_provider":',
+  '"materializations":',
   '"query_runtime":',
   '"validation":',
   '"retention_scan_entries":',

--- a/crates/rue-compiler/src/linking.rs
+++ b/crates/rue-compiler/src/linking.rs
@@ -576,6 +576,7 @@ pub(crate) fn link_internal_with_warnings(
         work: PipelineWork::default(),
         query_runtime: crate::unstable::QueryRuntimeMetrics::default(),
         semantic_reachability: crate::unstable::SemanticReachabilityMetrics::default(),
+        provider_observations: crate::unstable::ProviderObservationMetrics::default(),
     })
 }
 
@@ -680,6 +681,7 @@ pub(crate) fn link_system_with_warnings(
         work: PipelineWork::default(),
         query_runtime: crate::unstable::QueryRuntimeMetrics::default(),
         semantic_reachability: crate::unstable::SemanticReachabilityMetrics::default(),
+        provider_observations: crate::unstable::ProviderObservationMetrics::default(),
     })
 }
 use std::io::{Read, Write};

--- a/crates/rue-compiler/src/queries.rs
+++ b/crates/rue-compiler/src/queries.rs
@@ -1105,6 +1105,7 @@ pub struct CompileOutput {
     /// Live query-runtime work observed after the rooted compiler queries.
     pub(crate) query_runtime: crate::unstable::QueryRuntimeMetrics,
     pub(crate) semantic_reachability: crate::unstable::SemanticReachabilityMetrics,
+    pub(crate) provider_observations: crate::unstable::ProviderObservationMetrics,
 }
 
 impl CompileOutput {
@@ -1116,6 +1117,7 @@ impl CompileOutput {
             self.work,
             self.query_runtime,
             self.semantic_reachability,
+            self.provider_observations,
         )
     }
 }
@@ -1293,6 +1295,7 @@ pub(crate) fn compile_rooted_with_session(
     let metrics = session.unstable_metrics();
     let query_runtime = metrics.query_runtime();
     let semantic_reachability = metrics.semantic_reachability();
+    let provider_observations = crate::unstable::provider_observation_metrics(session);
     let image = crate::program_image_plan::ProgramImage::from_rooted(
         rooted.objects,
         rooted.exports,
@@ -1316,5 +1319,6 @@ pub(crate) fn compile_rooted_with_session(
     };
     output.query_runtime = query_runtime;
     output.semantic_reachability = semantic_reachability;
+    output.provider_observations = provider_observations;
     Ok(output)
 }

--- a/crates/rue-compiler/src/unstable.rs
+++ b/crates/rue-compiler/src/unstable.rs
@@ -2084,6 +2084,7 @@ pub struct OneShotMetrics {
     pub semantic: SemanticMetrics,
     pub query_runtime: QueryRuntimeMetrics,
     pub semantic_reachability: SemanticReachabilityMetrics,
+    pub provider_observations: ProviderObservationMetrics,
 }
 
 impl OneShotMetrics {
@@ -2092,6 +2093,7 @@ impl OneShotMetrics {
         work: crate::PipelineWork,
         query_runtime: QueryRuntimeMetrics,
         semantic_reachability: SemanticReachabilityMetrics,
+        provider_observations: ProviderObservationMetrics,
     ) -> Self {
         Self {
             files: stats.files,
@@ -2103,6 +2105,7 @@ impl OneShotMetrics {
             semantic: SemanticMetrics::from_work(work.semantic),
             query_runtime,
             semantic_reachability,
+            provider_observations,
         }
     }
 }

--- a/crates/rue-perf-schema/src/lib.rs
+++ b/crates/rue-perf-schema/src/lib.rs
@@ -63,7 +63,7 @@ pub use run::{
 pub use scaling::{
     CfgMaterializationWork, CompilerWork, QueryRuntimeWork, SCALING_REPORT_SCHEMA_VERSION,
     ScalingIdentity, ScalingManifest, ScalingObservation, ScalingRegime, ScalingReport,
-    ScalingWorkload, SemanticReachabilityWork, WorkloadShape,
+    ScalingWorkload, SemanticProviderWork, SemanticReachabilityWork, WorkloadShape,
 };
 pub use series::{Metric, SeriesId};
 pub use stats::{

--- a/crates/rue-perf-schema/src/scaling.rs
+++ b/crates/rue-perf-schema/src/scaling.rs
@@ -12,7 +12,7 @@ use serde::{Deserialize, Serialize};
 use crate::{DisplayIdentityWork, EnvironmentFingerprint, Sample, ValidationWork};
 
 /// Version of the scaling-report wire format.
-pub const SCALING_REPORT_SCHEMA_VERSION: u32 = 8;
+pub const SCALING_REPORT_SCHEMA_VERSION: u32 = 9;
 
 /// The lower-frequency scaling suite declaration.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -167,12 +167,50 @@ pub struct ScalingObservation {
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct CompilerWork {
+    /// Exact semantic facts observed by provider-native body analysis.
+    pub semantic_provider: SemanticProviderWork,
     /// Work performed while discovering and scheduling reachable bodies.
     pub semantic_reachability: SemanticReachabilityWork,
     /// Request-local lookup preparation for exact CFG materialization facts.
     pub cfg_materialization: CfgMaterializationWork,
     /// Work performed by the revisioned query runtime.
     pub query_runtime: QueryRuntimeWork,
+}
+
+/// Deterministic provider operations performed by semantic body analysis.
+///
+/// These are observations already required by the production provider. The
+/// benchmark merely snapshots them; collecting this report adds no provider
+/// lookup or materialization work.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct SemanticProviderWork {
+    /// Unqualified, qualified, and language-item name lookups.
+    pub name_lookups: u64,
+    /// Import and module-binding lookups.
+    pub import_lookups: u64,
+    /// Named-method candidate requests.
+    pub method_candidates: u64,
+    /// Operator-method candidate requests.
+    pub operator_candidates: u64,
+    /// All declaration fact reads; exactly partitioned by the four fields below.
+    pub declaration_facts: u64,
+    /// Exact declaration-identity reads.
+    pub identity_facts: u64,
+    /// Exact callable and nominal-signature reads.
+    pub signature_facts: u64,
+    /// Exact nominal well-formedness reads.
+    pub type_facts: u64,
+    /// Exact constant and compile-time reduction reads.
+    pub const_facts: u64,
+    /// Durable facts copied into body-local representations.
+    pub materializations: u64,
+    /// Anonymous-nominal fact reads.
+    pub anonymous_facts: u64,
+    /// Anonymous-producer body fact reads.
+    pub producer_facts: u64,
+    /// Trusted-toolchain fact reads.
+    pub toolchain_facts: u64,
 }
 
 /// Deterministic preparation and selection work for body-local CFG facts.

--- a/crates/rue/src/main.rs
+++ b/crates/rue/src/main.rs
@@ -950,7 +950,23 @@ fn benchmark_compiler_work(
     let runtime = metrics.query_runtime;
     let validation = runtime.validation;
     let reachability = metrics.semantic_reachability;
+    let provider = metrics.provider_observations;
     rue_perf_schema::CompilerWork {
+        semantic_provider: rue_perf_schema::SemanticProviderWork {
+            name_lookups: provider.name_lookups,
+            import_lookups: provider.import_lookups,
+            method_candidates: provider.method_candidates,
+            operator_candidates: provider.operator_candidates,
+            declaration_facts: provider.declaration_facts,
+            identity_facts: provider.identity_facts,
+            signature_facts: provider.signature_facts,
+            type_facts: provider.type_facts,
+            const_facts: provider.const_facts,
+            materializations: provider.materializations,
+            anonymous_facts: provider.anonymous_facts,
+            producer_facts: provider.producer_facts,
+            toolchain_facts: provider.toolchain_facts,
+        },
         semantic_reachability: rue_perf_schema::SemanticReachabilityWork {
             frontier_scans: reachability.frontier_scans,
             frontier_scan_keys: reachability.frontier_scan_keys,
@@ -1509,6 +1525,21 @@ mod tests {
     #[test]
     fn benchmark_work_projection_preserves_structural_counters() {
         let metrics = rue_compiler::unstable::OneShotMetrics {
+            provider_observations: rue_compiler::unstable::ProviderObservationMetrics {
+                name_lookups: 2,
+                import_lookups: 3,
+                method_candidates: 5,
+                operator_candidates: 7,
+                identity_facts: 11,
+                signature_facts: 13,
+                type_facts: 17,
+                const_facts: 19,
+                materializations: 23,
+                anonymous_facts: 29,
+                producer_facts: 31,
+                toolchain_facts: 37,
+                declaration_facts: 60,
+            },
             semantic: rue_compiler::unstable::SemanticMetrics {
                 cfg: rue_compiler::unstable::SemanticCfgMetrics {
                     materialization_index_builds: 1,
@@ -1543,6 +1574,26 @@ mod tests {
             ..Default::default()
         };
         let projected = benchmark_compiler_work(metrics);
+        assert_eq!(projected.semantic_provider.name_lookups, 2);
+        assert_eq!(projected.semantic_provider.import_lookups, 3);
+        assert_eq!(projected.semantic_provider.method_candidates, 5);
+        assert_eq!(projected.semantic_provider.operator_candidates, 7);
+        assert_eq!(projected.semantic_provider.declaration_facts, 60);
+        assert_eq!(projected.semantic_provider.identity_facts, 11);
+        assert_eq!(projected.semantic_provider.signature_facts, 13);
+        assert_eq!(projected.semantic_provider.type_facts, 17);
+        assert_eq!(projected.semantic_provider.const_facts, 19);
+        assert_eq!(
+            projected.semantic_provider.declaration_facts,
+            projected.semantic_provider.identity_facts
+                + projected.semantic_provider.signature_facts
+                + projected.semantic_provider.type_facts
+                + projected.semantic_provider.const_facts
+        );
+        assert_eq!(projected.semantic_provider.materializations, 23);
+        assert_eq!(projected.semantic_provider.anonymous_facts, 29);
+        assert_eq!(projected.semantic_provider.producer_facts, 31);
+        assert_eq!(projected.semantic_provider.toolchain_facts, 37);
         assert_eq!(projected.cfg_materialization.index_builds, 1);
         assert_eq!(projected.cfg_materialization.declarations_scanned, 31);
         assert_eq!(projected.cfg_materialization.anonymous_nominals_scanned, 7);

--- a/crates/rue/src/timing.rs
+++ b/crates/rue/src/timing.rs
@@ -710,7 +710,7 @@ impl TimingData {
         };
 
         BenchmarkTiming {
-            schema_version: 8,
+            schema_version: 9,
             timing_model: "inclusive_spans",
             phase_accounting,
             metadata,
@@ -2068,7 +2068,7 @@ mod tests {
         data.record("lexer", Duration::from_millis(100));
 
         let json = data.to_json_with_metrics("x86_64-linux", "0.1.0", None, None, None);
-        assert!(json.contains("\"schema_version\":8"));
+        assert!(json.contains("\"schema_version\":9"));
         assert!(json.contains(&format!(
             "\"compiler_build_profile\":\"{COMPILER_BUILD_PROFILE}\""
         )));
@@ -2730,7 +2730,7 @@ mod phase_accounting_tests {
 
         let timing =
             data.to_benchmark_timing_with_metrics("probe-target", "probe", None, None, None);
-        assert_eq!(timing.schema_version, 8);
+        assert_eq!(timing.schema_version, 9);
         assert_eq!(
             timing.metadata.compiler_build_profile,
             COMPILER_BUILD_PROFILE

--- a/docs/notes/post-adr-0063-cold-compiler-architecture-audit.md
+++ b/docs/notes/post-adr-0063-cold-compiler-architecture-audit.md
@@ -560,6 +560,38 @@ CFG-materialization counter remained identical, and the Lattice executable
 remains byte-identical at
 `8d7355dcda83780ef8a98aedfa0495a9d4745c5ed84375e0ae9a37d82eb361a9`.
 
+RUE-1365 made the largest remaining leaf phase measurable at the same standard
+as query validation and CFG materialization. Provider-native body analysis
+already increments exact production counters for each lookup, candidate query,
+fact-family read, and durable materialization. The one-shot metrics boundary
+and version-nine scaling report now snapshot those counters; measurement adds
+no provider operation to the compile path.
+
+The maintained cold baseline is:
+
+| workload | name lookups | method candidates | identity facts | signature facts | const facts | durable materializations |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: |
+| Ruelex | 8,670 | 892 | 6,667 | 2,014 | 4,012 | 3,148 |
+| Mosaic | 23,443 | 784 | 21,639 | 8,171 | 4,744 | 8,673 |
+| Harbor | 48,756 | 476 | 42,672 | 16,706 | 7,836 | 17,374 |
+| Lattice | 66,324 | 500 | 53,917 | 21,198 | 13,890 | 21,636 |
+
+Import lookups, operator candidates, nominal-well-formedness reads, and
+anonymous-nominal fact reads are all exactly zero on these four successful
+workloads; producer and toolchain reads remain visible in the complete report.
+The next bounded investigation should therefore begin with repeated name and
+identity observation, not with an inactive provider family or linking.
+
+The projection is measurement-neutral. Against the merged RUE-1364 report,
+compiler medians moved 130.38 to 127.83 ms for Ruelex, 343.58 to 352.52 ms for
+Mosaic, 759.58 to 738.34 ms for Harbor, and 864.09 to 862.39 ms for Lattice;
+peak RSS moved +1.5, +0.6, +0.2, and -8.3 MiB respectively. This mixed movement
+is ordinary run noise, not a claimed speedup or regression. The fixed
+single-worker Lattice allocation probe remains effectively identical at
+17,603,205 calls and 2,917,731,831 requested bytes, and the executable remains
+byte-identical at
+`8d7355dcda83780ef8a98aedfa0495a9d4745c5ed84375e0ae9a37d82eb361a9`.
+
 ## Next actions and decision boundary
 
 Authorized low-risk work:

--- a/docs/process/compiler-scaling.md
+++ b/docs/process/compiler-scaling.md
@@ -31,6 +31,9 @@ compilations. The report records:
 - files, modules, source bytes, lines, lexer tokens, and functions considered;
 - externally observed fresh-process wall time and peak resident memory;
 - the compiler's additive, mutually exclusive phase accounting;
+- semantic-provider name/import lookups, method/operator candidates, exact
+  declaration fact-family reads, durable materializations, and
+  anonymous/producer/toolchain facts;
 - semantic-reachability scans, scheduled keys, and fixed frontier-width
   buckets;
 - request-local CFG-materialization index builds, declaration/anonymous/type
@@ -57,6 +60,13 @@ frontiers whose work remains slow because of allocation, hashing, query-runtime,
 or synchronization overhead. They describe deterministic graph shape and
 scheduler submissions; they are not elapsed-time or worker-utilization
 estimates.
+
+The semantic-provider tables snapshot counters already incremented by the
+production body-fact provider. The scaling probe performs no extra lookup or
+materialization to collect them. Keeping lookup demand, exact fact-family
+reads, and durable body-local materializations separate lets a follow-up tell
+whether body analysis is asking for the same fact too often or merely paying
+too much to represent each necessary answer.
 
 The CFG-materialization table separates immutable lookup preparation from the
 exact fact-closure selections that remain body-local. Its selections-per-build


### PR DESCRIPTION
Fixes RUE-1365.

## Summary

- project the existing production semantic-provider observation counters through one-shot compiler metrics
- publish lookup, candidate, declaration-fact, materialization, anonymous, producer, and toolchain work in scaling schema v9
- render the maintained cold baseline and document how it guides the next bounded body-analysis investigation

## Evidence

- `scripts/rue quick`: 31 targets passed
- focused driver, perf-schema, scaling-renderer, and benchmark CLI contract tests passed
- two one-worker work probes agree exactly on every maintained workload
- Lattice: 66,324 name lookups, 89,005 partitioned declaration facts, 21,636 materializations
- allocation counter effectively neutral: 17,603,205 calls / 2,917,731,831 requested bytes
- cold clock and RSS neutral within paired-run noise
- Lattice executable remains byte-identical: `8d7355dcda83780ef8a98aedfa0495a9d4745c5ed84375e0ae9a37d82eb361a9`