### PR TITLE
RUE-1366: use keyed AHash for hot query indexes

### DIFF
--- a/crates/rue-query/BUCK
+++ b/crates/rue-query/BUCK
@@ -3,6 +3,7 @@ load("//crates:defs.bzl", "rue_crate")
 rue_crate(
     name = "rue-query",
     deps = [
+        "//third-party:ahash",
         "//third-party:tracing",
     ],
 )

--- a/crates/rue-query/src/lib.rs
+++ b/crates/rue-query/src/lib.rs
@@ -5,15 +5,16 @@
 
 use std::any::Any;
 use std::cell::Cell;
-use std::collections::hash_map::RandomState;
 use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet, VecDeque};
 use std::fmt;
-use std::hash::{BuildHasher, BuildHasherDefault, Hash, Hasher};
+use std::hash::{BuildHasherDefault, Hash, Hasher};
 use std::marker::PhantomData;
 use std::panic::{AssertUnwindSafe, catch_unwind, resume_unwind};
 use std::rc::Rc;
 use std::sync::atomic::{AtomicBool, AtomicU8, AtomicU64, AtomicUsize, Ordering};
 use std::sync::{Arc, Condvar, Mutex, MutexGuard, RwLock, RwLockReadGuard, RwLockWriteGuard, Weak};
+
+use ahash::{AHashMap, RandomState};
 
 static NEXT_RUNTIME_ID: AtomicU64 = AtomicU64::new(1);
 
@@ -4664,8 +4665,8 @@ const NODE_INDEX_SHARDS: usize = 32;
 /// space; hits on the *same* key still serialize briefly on one shard, which
 /// preserves the hit/removal race rules unchanged per shard.
 ///
-/// Shard selection hashes with this index's own `RandomState` (SipHash, keyed
-/// per index), and each shard map keeps its own `RandomState` — the
+/// Shard selection hashes with this index's own keyed `RandomState`, and each
+/// shard map keeps its own keyed `RandomState` — the
 /// adversarial-resistance property of the previous single map is preserved,
 /// never weakened to a fixed or truncated hash.
 ///
@@ -4675,7 +4676,7 @@ const NODE_INDEX_SHARDS: usize = 32;
 /// those, and no path holds two shard guards at once.
 struct ShardedNodeIndex<K: QueryKey, V: Clone + Send + Sync + 'static> {
     selector: RandomState,
-    shards: [Mutex<HashMap<K, Arc<Node<K, V>>>>; NODE_INDEX_SHARDS],
+    shards: [Mutex<AHashMap<K, Arc<Node<K, V>>>>; NODE_INDEX_SHARDS],
 }
 
 impl<K, V> ShardedNodeIndex<K, V>
@@ -4686,7 +4687,7 @@ where
     fn new() -> Self {
         Self {
             selector: RandomState::new(),
-            shards: std::array::from_fn(|_| Mutex::new(HashMap::new())),
+            shards: std::array::from_fn(|_| Mutex::new(AHashMap::new())),
         }
     }
 
@@ -4698,7 +4699,7 @@ where
     /// shard: get-miss-insert sequences and the removal re-checks (`users`,
     /// `attempts`, pointer identity) stay atomic under this guard exactly as
     /// they were under the whole-index mutex.
-    fn shard(&self, key: &K) -> MutexGuard<'_, HashMap<K, Arc<Node<K, V>>>> {
+    fn shard(&self, key: &K) -> MutexGuard<'_, AHashMap<K, Arc<Node<K, V>>>> {
         lock(&self.shards[self.shard_index(key)])
     }
 }
@@ -7742,6 +7743,8 @@ impl fmt::Debug for BatchValidationAuthority {
 struct TaskQueryCache {
     /// One type-erased typed-key map per unforgeable family token. The token is
     /// runtime-unique, so the concrete `K` and `V` behind an entry cannot vary.
+    /// Each erased map uses independently keyed AHash: source-derived keys keep
+    /// adversarial collision resistance while exact `Eq` remains authoritative.
     /// A task belongs to exactly one runtime, so its monotonic family id is a
     /// complete local key and can use the runtime-owned integer hasher.
     families: HashMap<u64, Box<dyn Any + Send + Sync>, BuildHasherDefault<IncarnationHasher>>,
@@ -8787,7 +8790,7 @@ impl Task {
         let cache = lock(&self.query_cache);
         let family_cache = cache.families.get(&family.family)?;
         family_cache
-            .downcast_ref::<HashMap<K, Arc<QueryTerminal<V>>>>()
+            .downcast_ref::<AHashMap<K, Arc<QueryTerminal<V>>>>()
             .expect("a family token has one typed task-cache representation")
             .get(key)
             .cloned()
@@ -8802,9 +8805,9 @@ impl Task {
         let family_cache = cache
             .families
             .entry(family.family)
-            .or_insert_with(|| Box::new(HashMap::<K, Arc<QueryTerminal<V>>>::new()));
+            .or_insert_with(|| Box::new(AHashMap::<K, Arc<QueryTerminal<V>>>::new()));
         let family_cache = family_cache
-            .downcast_mut::<HashMap<K, Arc<QueryTerminal<V>>>>()
+            .downcast_mut::<AHashMap<K, Arc<QueryTerminal<V>>>>()
             .expect("a family token has one typed task-cache representation");
         match family_cache.entry(key.clone()) {
             std::collections::hash_map::Entry::Vacant(entry) => {
@@ -10776,8 +10779,8 @@ mod tests {
     }
 
     // Deterministic single-hasher probe used only to demonstrate that two keys
-    // land in the same bucket. The live memo map keys on std `RandomState`
-    // (SipHash); this fixed-seed `DefaultHasher` just makes the collision
+    // land in the same bucket. The live memo map uses independently keyed
+    // AHash; this fixed-seed `DefaultHasher` just makes the collision
     // assertion reproducible.
     fn hash_of<K: std::hash::Hash>(key: &K) -> u64 {
         use std::hash::Hasher;
@@ -14002,6 +14005,33 @@ mod tests {
             .unwrap();
         assert!(Arc::ptr_eq(&first, &reuse));
         assert_eq!(runtime.metrics().claims, 2);
+
+        let family_for_root = family.clone();
+        let root = runtime.family::<Key, u64>("one-bucket-root", 4).unwrap();
+        runtime
+            .query(
+                &root,
+                revision(1),
+                Key("root"),
+                CancellationToken::new(),
+                move |context| {
+                    let first = context.query(&family_for_root, OneBucketKey(1), |_| {
+                        panic!("colliding key 1 must reuse its retained terminal")
+                    })?;
+                    let second = context.query(&family_for_root, OneBucketKey(2), |_| {
+                        panic!("colliding key 2 must reuse its retained terminal")
+                    })?;
+                    let first_again = context.query(&family_for_root, OneBucketKey(1), |_| {
+                        panic!("the task cache must resolve colliding key 1 through Eq")
+                    })?;
+                    assert_eq!(first.outcome(), &QueryOutcome::Success(10));
+                    assert_eq!(second.outcome(), &QueryOutcome::Success(20));
+                    assert!(Arc::ptr_eq(&first, &first_again));
+                    Ok(QueryOutput::success(0))
+                },
+            )
+            .unwrap();
+        assert_eq!(runtime.metrics().claims, 3);
     }
 
     #[test]

--- a/docs/notes/post-adr-0063-cold-compiler-architecture-audit.md
+++ b/docs/notes/post-adr-0063-cold-compiler-architecture-audit.md
@@ -592,6 +592,33 @@ single-worker Lattice allocation probe remains effectively identical at
 byte-identical at
 `8d7355dcda83780ef8a98aedfa0495a9d4745c5ed84375e0ae9a37d82eb361a9`.
 
+RUE-1366 used that provider baseline to reject two tempting semantic shortcuts
+before following a CPU profile. A request-local name-resolution cache removed
+no query work because the 66,324 Lattice lookups are unique within that cache's
+safe lifetime. Deriving a signature's stable definition key locally likewise
+removed no measured query work and added almost exactly one allocation per
+signature read; the existing identity query already returns a shared key at
+negligible cost. Neither experiment was retained.
+
+The subsequent symbolized Lattice sample instead placed standard SipHash at the
+top of the collapsed compiler stack. Its dominant call paths were the sharded
+typed-key memo index and the task-local typed query cache. Those two indexes now
+use AHash with independent runtime-random keys; exact `Hash` plus `Eq` remains
+authoritative, so collision safety and adversarial resistance are preserved.
+Numeric runtime bookkeeping stays on its existing specialized or standard
+hashers because the profile did not justify broadening the change.
+
+The targeted SipHash leaf fell from 63 to 27 samples (-57 percent). Against the
+merged RUE-1365 report, compiler-root medians moved from 127.83 to 124.91 ms for
+Ruelex, 352.52 to 352.02 ms for Mosaic, 738.34 to 723.54 ms for Harbor, and
+862.39 to 834.20 ms for Lattice. Peak memory moved -0.2, +0.6, -2.5, and +4.0
+MiB respectively, which is mixed and within run noise. Every query,
+reachability, CFG-materialization, and semantic-provider counter remained
+identical. Lattice allocation counts are flat; requested bytes moved about
++0.06 percent, also within measurement noise. The executable remains
+byte-identical at
+`8d7355dcda83780ef8a98aedfa0495a9d4745c5ed84375e0ae9a37d82eb361a9`.
+
 ## Next actions and decision boundary
 
 Authorized low-risk work:

--- a/third-party/BUCK
+++ b/third-party/BUCK
@@ -3,6 +3,12 @@
 load("@prelude//rust:cargo_buildscript.bzl", "buildscript_run")
 load("@prelude//rust:cargo_package.bzl", "cargo")
 
+alias(
+    name = "ahash",
+    actual = ":ahash-0.8.12",
+    visibility = ["PUBLIC"],
+)
+
 cargo.rust_library(
     name = "ahash-0.8.12",
     srcs = [
@@ -23,10 +29,17 @@ cargo.rust_library(
     env = {
         "OUT_DIR": "$(location :ahash-0.8.12-build-script-run[out_dir])",
     },
+    features = [
+        "default",
+        "getrandom",
+        "runtime-rng",
+        "std",
+    ],
     rustc_flags = ["@$(location :ahash-0.8.12-build-script-run[rustc_flags])"],
     visibility = [],
     deps = [
         ":cfg-if-1.0.4",
+        ":getrandom-0.3.4",
         ":once_cell-1.21.3",
         ":zerocopy-0.8.31",
     ],
@@ -53,6 +66,12 @@ cargo.rust_binary(
     crate = "build_script_build",
     crate_root = "vendor/ahash-0.8.12/build.rs",
     edition = "2018",
+    features = [
+        "default",
+        "getrandom",
+        "runtime-rng",
+        "std",
+    ],
     visibility = [],
     deps = [":version_check-0.9.5"],
 )
@@ -61,6 +80,12 @@ buildscript_run(
     name = "ahash-0.8.12-build-script-run",
     package_name = "ahash",
     buildscript_rule = ":ahash-0.8.12-build-script-build",
+    features = [
+        "default",
+        "getrandom",
+        "runtime-rng",
+        "std",
+    ],
     version = "0.8.12",
 )
 

--- a/third-party/Cargo.lock
+++ b/third-party/Cargo.lock
@@ -9,6 +9,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
 dependencies = [
  "cfg-if",
+ "getrandom",
  "once_cell",
  "version_check",
  "zerocopy",
@@ -689,6 +690,7 @@ checksum = "7a2d987857b319362043e95f5353c0535c1f58eec5336fdfcf626430af7def58"
 name = "rust-third-party"
 version = "0.0.0"
 dependencies = [
+ "ahash",
  "annotate-snippets",
  "anyhow",
  "fixedbitset",

--- a/third-party/Cargo.toml
+++ b/third-party/Cargo.toml
@@ -12,6 +12,7 @@ name = "fake"
 path = "/dev/null"
 
 [dependencies]
+ahash = "0.8"
 annotate-snippets = "0.11"
 anyhow = "1.0"
 libc = "0.2"


### PR DESCRIPTION
Fixes RUE-1366.

## Summary
- replace standard SipHash with independently keyed AHash in the profiled typed query-node index and task-local typed query cache
- preserve exact typed equality, randomized collision resistance, sharding, retention, and observable semantics
- record the rejected counter-neutral semantic-cache experiments and measured outcome in the cold-compiler architecture audit

## Performance evidence
- symbolized Lattice SipHash leaf: 63 to 27 samples (-57%)
- compiler-root medians: Ruelex -2.3%, Mosaic -0.1%, Harbor -2.0%, Lattice -3.3%
- every query, semantic-provider, reachability, and CFG-materialization work counter unchanged
- allocation count flat; requested bytes +0.06%; peak RSS mixed within run noise
- executable SHA-256 unchanged

## Validation
- rue-query: 151/151
- quick suite: 31/31 targets
- formatting
- maintained scaling report with exact two-probe counter agreement and output hash