### PR TITLE
RUE-1367: expose query request outcome counters

### DIFF
--- a/crates/rue-bench/src/incremental.rs
+++ b/crates/rue-bench/src/incremental.rs
@@ -307,19 +307,7 @@ impl CollectionTiming {
         self.fresh_oracle += other.fresh_oracle;
         self.total += other.total;
         self.query_runtime
-            .validation
-            .saturating_add_assign(other.query_runtime.validation);
-        self.query_runtime
-            .display_identities
-            .saturating_add_assign(other.query_runtime.display_identities);
-        self.query_runtime.retention_enforcements = self
-            .query_runtime
-            .retention_enforcements
-            .saturating_add(other.query_runtime.retention_enforcements);
-        self.query_runtime.retention_scan_entries = self
-            .query_runtime
-            .retention_scan_entries
-            .saturating_add(other.query_runtime.retention_scan_entries);
+            .saturating_add_assign(other.query_runtime);
     }
 
     fn other(self) -> Duration {
@@ -876,18 +864,7 @@ fn query_runtime_delta(
     before: QueryRuntimeMetrics,
     after: QueryRuntimeMetrics,
 ) -> QueryRuntimeMetrics {
-    QueryRuntimeMetrics {
-        validation: after.validation.saturating_sub(before.validation),
-        display_identities: after
-            .display_identities
-            .saturating_sub(before.display_identities),
-        retention_enforcements: after
-            .retention_enforcements
-            .saturating_sub(before.retention_enforcements),
-        retention_scan_entries: after
-            .retention_scan_entries
-            .saturating_sub(before.retention_scan_entries),
-    }
+    after.saturating_sub(before)
 }
 
 fn report_display_identity_work(

--- a/crates/rue-bench/src/scaling.rs
+++ b/crates/rue-bench/src/scaling.rs
@@ -368,7 +368,27 @@ fn render(report: &ScalingReport) -> String {
     }
 
     out.push_str("\n## Deterministic query work\n\n");
-    out.push_str("Counts are exact for one fresh compiler process and must agree across the fixed single-worker structural probes. Registry logical/index distinguishes requested exact-node resolutions from accesses to the shared incarnation index. `nodes/token` exposes validation amplification independently of clock noise.\n\n");
+    out.push_str("Counts are exact for one fresh compiler process and must agree across the fixed single-worker structural probes. Request outcomes expose all query traffic before validation detail: claims start computations, reuses return compatible retained or task-local terminals, and joins share in-flight work. Declined joins are included in joins and identify wait-graph avoidance.\n\n");
+    out.push_str("| workload | claims | reuses | joins declined/total | body completions | publications red/green | cancellations/cycles |\n");
+    out.push_str("| --- | ---: | ---: | ---: | ---: | ---: | ---: |\n");
+    for observation in &report.workloads {
+        let runtime = observation.work.query_runtime;
+        out.push_str(&format!(
+            "| {} | {} | {} | {}/{} | {} | {}/{} | {}/{} |\n",
+            observation.workload,
+            runtime.claims,
+            runtime.reuses,
+            runtime.declined_joins,
+            runtime.joins,
+            runtime.body_completions,
+            runtime.red_publications,
+            runtime.green_publications,
+            runtime.cancellations,
+            runtime.cycles,
+        ));
+    }
+
+    out.push_str("\nRegistry logical/index distinguishes requested exact-node resolutions from accesses to the shared incarnation index. `nodes/token` exposes validation amplification independently of clock noise.\n\n");
     out.push_str("| workload | traversals | input/dependency observations | memo hit/miss | registry logical/index | endorsements hit/probe | terminal leases duplicate/total | demands reuse/compute/join/total | retention scan entries | nodes/token |\n");
     out.push_str("| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |\n");
     for observation in &report.workloads {
@@ -647,6 +667,15 @@ mod tests {
                         fact_selections: 4,
                     },
                     query_runtime: rue_perf_schema::QueryRuntimeWork {
+                        claims: 41,
+                        reuses: 43,
+                        joins: 47,
+                        declined_joins: 2,
+                        body_completions: 53,
+                        red_publications: 59,
+                        green_publications: 61,
+                        cancellations: 67,
+                        cycles: 71,
                         validation: rue_perf_schema::ValidationWork {
                             traversals: 3,
                             node_visits: 7,
@@ -680,6 +709,8 @@ mod tests {
         assert!(rendered.contains("median absolute deviation"));
         assert!(rendered.contains("shape id"));
         assert!(rendered.contains("Deterministic query work"));
+        assert!(rendered.contains("joins declined/total"));
+        assert!(rendered.contains("| probe | 41 | 43 | 2/47 | 53 | 59/61 | 67/71 |"));
         assert!(rendered.contains("nodes/token"));
         assert!(rendered.contains("Semantic provider observations"));
         assert!(rendered.contains("durable materializations"));

--- a/crates/rue-cli-tests/cases/benchmark_json.toml
+++ b/crates/rue-cli-tests/cases/benchmark_json.toml
@@ -15,7 +15,7 @@ args = ["--benchmark-json", "main.rue", "-o", "prog"]
 env = { RUST_LOG = "error" }
 exit_code = 42
 compile_stdout_contains = [
-  '"schema_version":9',
+  '"schema_version":10',
   '"compiler_build_profile":',
   '"timing_model":"inclusive_spans"',
   # The additive partition, which is the only model that may be stacked. Its

--- a/crates/rue-compiler/src/session.rs
+++ b/crates/rue-compiler/src/session.rs
@@ -128,10 +128,10 @@ pub struct FrontendRetentionMetrics {
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
 pub(crate) struct FrontendRuntimeMetrics {
-    pub(crate) validation: rue_query::ValidationWork,
-    pub(crate) display_identities: rue_query::DisplayIdentityMetrics,
-    pub(crate) retention_enforcements: u64,
-    pub(crate) retention_scan_entries: u64,
+    /// One canonical projection of cumulative query-runtime work. Live gauges
+    /// and configured budgets remain in `FrontendRetentionMetrics`; keeping
+    /// them out of this snapshot preserves deterministic work equality.
+    pub(crate) query: crate::unstable::QueryRuntimeMetrics,
     pub(crate) semantic_reachability: crate::unstable::SemanticReachabilityMetrics,
 }
 
@@ -3104,10 +3104,7 @@ impl CompilerSession {
         // baseline-to-successor delta cannot inherit late predecessor work.
         let runtime = self.queries.revisioned.runtime_retention_metrics();
         work.runtime = FrontendRuntimeMetrics {
-            validation: runtime.validation,
-            display_identities: runtime.display_identities,
-            retention_enforcements: runtime.retention_enforcements,
-            retention_scan_entries: runtime.retention_scan_entries,
+            query: runtime.into(),
             semantic_reachability: self.queries.revisioned.body_reachability_metrics(),
         };
         crate::unstable::MetricsSnapshot::new(work)
@@ -3305,10 +3302,7 @@ impl CompilerSession {
             diagnostic_source_bytes: diagnostics.source_bytes,
         });
         self.metrics.set_runtime(FrontendRuntimeMetrics {
-            validation: runtime.validation,
-            display_identities: runtime.display_identities,
-            retention_enforcements: runtime.retention_enforcements,
-            retention_scan_entries: runtime.retention_scan_entries,
+            query: runtime.into(),
             semantic_reachability: self.queries.revisioned.body_reachability_metrics(),
         });
     }
@@ -7941,6 +7935,15 @@ mod tests {
         let live = session.queries.revisioned.runtime_metrics_for_test();
         assert!(live.validation.traversals > before.validation.traversals);
         let observed = session.unstable_metrics().query_runtime();
+        assert_eq!(observed.claims, live.claims);
+        assert_eq!(observed.reuses, live.reuses);
+        assert_eq!(observed.joins, live.joins);
+        assert_eq!(observed.declined_joins, live.declined_joins);
+        assert_eq!(observed.body_completions, live.body_completions);
+        assert_eq!(observed.red_publications, live.red_publications);
+        assert_eq!(observed.green_publications, live.green_publications);
+        assert_eq!(observed.cancellations, live.cancellations);
+        assert_eq!(observed.cycles, live.cycles);
         assert_eq!(observed.validation, live.validation.into());
         assert_eq!(observed.retention_enforcements, live.retention_enforcements);
         assert_eq!(observed.retention_scan_entries, live.retention_scan_entries);

--- a/crates/rue-compiler/src/unstable.rs
+++ b/crates/rue-compiler/src/unstable.rs
@@ -1723,7 +1723,7 @@ impl From<rue_query::ValidationWork> for QueryValidationMetrics {
 
 #[cfg(test)]
 mod query_validation_metrics_tests {
-    use super::QueryValidationMetrics;
+    use super::{QueryDisplayIdentityMetrics, QueryRuntimeMetrics, QueryValidationMetrics};
 
     #[test]
     fn validation_work_classification_survives_projection_and_deltas() {
@@ -1753,11 +1753,49 @@ mod query_validation_metrics_tests {
         assert_eq!(delta.terminal_lease_observations, 4);
         assert_eq!(delta.duplicate_terminal_lease_observations, 3);
     }
+
+    #[test]
+    fn runtime_work_arithmetic_covers_every_published_counter() {
+        let unit = QueryRuntimeMetrics {
+            claims: 1,
+            reuses: 1,
+            joins: 1,
+            declined_joins: 1,
+            body_completions: 1,
+            red_publications: 1,
+            green_publications: 1,
+            cancellations: 1,
+            cycles: 1,
+            validation: QueryValidationMetrics {
+                traversals: 1,
+                ..Default::default()
+            },
+            display_identities: QueryDisplayIdentityMetrics {
+                memo_node_materializations: 1,
+                ..Default::default()
+            },
+            retention_enforcements: 1,
+            retention_scan_entries: 1,
+        };
+        let mut accumulated = unit;
+        accumulated.saturating_add_assign(unit);
+        assert_eq!(accumulated.saturating_sub(unit), unit);
+    }
 }
 
-/// Query-runtime validation and retention work contained in [`MetricsSnapshot`].
+/// Query-runtime lifecycle, validation, and retention work contained in
+/// [`MetricsSnapshot`].
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
 pub struct QueryRuntimeMetrics {
+    pub claims: u64,
+    pub reuses: u64,
+    pub joins: u64,
+    pub declined_joins: u64,
+    pub body_completions: u64,
+    pub red_publications: u64,
+    pub green_publications: u64,
+    pub cancellations: u64,
+    pub cycles: u64,
     pub validation: QueryValidationMetrics,
     /// Presentation-only query identity materialization.
     pub display_identities: QueryDisplayIdentityMetrics,
@@ -1765,6 +1803,83 @@ pub struct QueryRuntimeMetrics {
     pub retention_enforcements: u64,
     /// Retention-queue entries examined by those passes.
     pub retention_scan_entries: u64,
+}
+
+impl QueryRuntimeMetrics {
+    /// Saturating delta between two cumulative runtime snapshots.
+    pub fn saturating_sub(self, earlier: Self) -> Self {
+        Self {
+            claims: self.claims.saturating_sub(earlier.claims),
+            reuses: self.reuses.saturating_sub(earlier.reuses),
+            joins: self.joins.saturating_sub(earlier.joins),
+            declined_joins: self.declined_joins.saturating_sub(earlier.declined_joins),
+            body_completions: self
+                .body_completions
+                .saturating_sub(earlier.body_completions),
+            red_publications: self
+                .red_publications
+                .saturating_sub(earlier.red_publications),
+            green_publications: self
+                .green_publications
+                .saturating_sub(earlier.green_publications),
+            cancellations: self.cancellations.saturating_sub(earlier.cancellations),
+            cycles: self.cycles.saturating_sub(earlier.cycles),
+            validation: self.validation.saturating_sub(earlier.validation),
+            display_identities: self
+                .display_identities
+                .saturating_sub(earlier.display_identities),
+            retention_enforcements: self
+                .retention_enforcements
+                .saturating_sub(earlier.retention_enforcements),
+            retention_scan_entries: self
+                .retention_scan_entries
+                .saturating_sub(earlier.retention_scan_entries),
+        }
+    }
+
+    /// Saturating accumulation for collection-level diagnostics.
+    pub fn saturating_add_assign(&mut self, other: Self) {
+        self.claims = self.claims.saturating_add(other.claims);
+        self.reuses = self.reuses.saturating_add(other.reuses);
+        self.joins = self.joins.saturating_add(other.joins);
+        self.declined_joins = self.declined_joins.saturating_add(other.declined_joins);
+        self.body_completions = self.body_completions.saturating_add(other.body_completions);
+        self.red_publications = self.red_publications.saturating_add(other.red_publications);
+        self.green_publications = self
+            .green_publications
+            .saturating_add(other.green_publications);
+        self.cancellations = self.cancellations.saturating_add(other.cancellations);
+        self.cycles = self.cycles.saturating_add(other.cycles);
+        self.validation.saturating_add_assign(other.validation);
+        self.display_identities
+            .saturating_add_assign(other.display_identities);
+        self.retention_enforcements = self
+            .retention_enforcements
+            .saturating_add(other.retention_enforcements);
+        self.retention_scan_entries = self
+            .retention_scan_entries
+            .saturating_add(other.retention_scan_entries);
+    }
+}
+
+impl From<rue_query::RuntimeMetrics> for QueryRuntimeMetrics {
+    fn from(runtime: rue_query::RuntimeMetrics) -> Self {
+        Self {
+            claims: runtime.claims,
+            reuses: runtime.reuses,
+            joins: runtime.joins,
+            declined_joins: runtime.declined_joins,
+            body_completions: runtime.body_completions,
+            red_publications: runtime.red_publications,
+            green_publications: runtime.green_publications,
+            cancellations: runtime.cancellations,
+            cycles: runtime.cycles,
+            validation: runtime.validation.into(),
+            display_identities: runtime.display_identities.into(),
+            retention_enforcements: runtime.retention_enforcements,
+            retention_scan_entries: runtime.retention_scan_entries,
+        }
+    }
 }
 
 /// Database-owned semantic-reachability scheduling work accumulated by the
@@ -2243,12 +2358,7 @@ impl MetricsSnapshot {
         }
     }
     pub fn query_runtime(&self) -> QueryRuntimeMetrics {
-        QueryRuntimeMetrics {
-            validation: self.inner.runtime.validation.into(),
-            display_identities: self.inner.runtime.display_identities.into(),
-            retention_enforcements: self.inner.runtime.retention_enforcements,
-            retention_scan_entries: self.inner.runtime.retention_scan_entries,
-        }
+        self.inner.runtime.query
     }
     pub fn semantic_reachability(&self) -> SemanticReachabilityMetrics {
         self.inner.runtime.semantic_reachability

--- a/crates/rue-perf-schema/src/scaling.rs
+++ b/crates/rue-perf-schema/src/scaling.rs
@@ -12,7 +12,7 @@ use serde::{Deserialize, Serialize};
 use crate::{DisplayIdentityWork, EnvironmentFingerprint, Sample, ValidationWork};
 
 /// Version of the scaling-report wire format.
-pub const SCALING_REPORT_SCHEMA_VERSION: u32 = 9;
+pub const SCALING_REPORT_SCHEMA_VERSION: u32 = 10;
 
 /// The lower-frequency scaling suite declaration.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -255,6 +255,24 @@ pub struct SemanticReachabilityWork {
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct QueryRuntimeWork {
+    /// New query computations claimed by this process.
+    pub claims: u64,
+    /// Compatible retained or task-local terminals reused.
+    pub reuses: u64,
+    /// Compatible in-flight query computations joined.
+    pub joins: u64,
+    /// Joined computations declined to avoid a wait-graph cycle.
+    pub declined_joins: u64,
+    /// Query bodies which completed before publication checks.
+    pub body_completions: u64,
+    /// Publications whose observable stamp stayed unchanged.
+    pub red_publications: u64,
+    /// New or observably changed publications.
+    pub green_publications: u64,
+    /// Query computations or waiters canceled.
+    pub cancellations: u64,
+    /// True query dependency cycles reported.
+    pub cycles: u64,
     /// Retained-terminal validation and proof work.
     pub validation: ValidationWork,
     /// Presentation-only query identity materialization.

--- a/crates/rue/src/main.rs
+++ b/crates/rue/src/main.rs
@@ -991,6 +991,15 @@ fn benchmark_compiler_work(
             fact_selections: metrics.semantic.cfg.materialization_fact_selections as u64,
         },
         query_runtime: rue_perf_schema::QueryRuntimeWork {
+            claims: runtime.claims,
+            reuses: runtime.reuses,
+            joins: runtime.joins,
+            declined_joins: runtime.declined_joins,
+            body_completions: runtime.body_completions,
+            red_publications: runtime.red_publications,
+            green_publications: runtime.green_publications,
+            cancellations: runtime.cancellations,
+            cycles: runtime.cycles,
             validation: rue_perf_schema::ValidationWork {
                 traversals: validation.traversals,
                 successful_traversals: validation.successful_traversals,
@@ -1552,6 +1561,15 @@ mod tests {
                 ..Default::default()
             },
             query_runtime: rue_compiler::unstable::QueryRuntimeMetrics {
+                claims: 41,
+                reuses: 43,
+                joins: 47,
+                declined_joins: 2,
+                body_completions: 53,
+                red_publications: 59,
+                green_publications: 61,
+                cancellations: 67,
+                cycles: 71,
                 validation: rue_compiler::unstable::QueryValidationMetrics {
                     traversals: 3,
                     dependency_observations: 11,
@@ -1600,6 +1618,15 @@ mod tests {
         assert_eq!(projected.cfg_materialization.type_nodes_scanned, 47);
         assert_eq!(projected.cfg_materialization.fact_selections, 11);
         let runtime = projected.query_runtime;
+        assert_eq!(runtime.claims, 41);
+        assert_eq!(runtime.reuses, 43);
+        assert_eq!(runtime.joins, 47);
+        assert_eq!(runtime.declined_joins, 2);
+        assert_eq!(runtime.body_completions, 53);
+        assert_eq!(runtime.red_publications, 59);
+        assert_eq!(runtime.green_publications, 61);
+        assert_eq!(runtime.cancellations, 67);
+        assert_eq!(runtime.cycles, 71);
         assert_eq!(runtime.validation.traversals, 3);
         assert_eq!(runtime.validation.dependency_observations, 11);
         assert_eq!(runtime.validation.memo_hits, 7);

--- a/crates/rue/src/timing.rs
+++ b/crates/rue/src/timing.rs
@@ -710,7 +710,7 @@ impl TimingData {
         };
 
         BenchmarkTiming {
-            schema_version: 9,
+            schema_version: 10,
             timing_model: "inclusive_spans",
             phase_accounting,
             metadata,
@@ -2068,7 +2068,7 @@ mod tests {
         data.record("lexer", Duration::from_millis(100));
 
         let json = data.to_json_with_metrics("x86_64-linux", "0.1.0", None, None, None);
-        assert!(json.contains("\"schema_version\":9"));
+        assert!(json.contains("\"schema_version\":10"));
         assert!(json.contains(&format!(
             "\"compiler_build_profile\":\"{COMPILER_BUILD_PROFILE}\""
         )));
@@ -2730,7 +2730,7 @@ mod phase_accounting_tests {
 
         let timing =
             data.to_benchmark_timing_with_metrics("probe-target", "probe", None, None, None);
-        assert_eq!(timing.schema_version, 9);
+        assert_eq!(timing.schema_version, 10);
         assert_eq!(
             timing.metadata.compiler_build_profile,
             COMPILER_BUILD_PROFILE

--- a/docs/notes/post-adr-0063-cold-compiler-architecture-audit.md
+++ b/docs/notes/post-adr-0063-cold-compiler-architecture-audit.md
@@ -564,7 +564,7 @@ RUE-1365 made the largest remaining leaf phase measurable at the same standard
 as query validation and CFG materialization. Provider-native body analysis
 already increments exact production counters for each lookup, candidate query,
 fact-family read, and durable materialization. The one-shot metrics boundary
-and version-nine scaling report now snapshot those counters; measurement adds
+and the versioned scaling report now snapshot those counters; measurement adds
 no provider operation to the compile path.
 
 The maintained cold baseline is:
@@ -616,6 +616,25 @@ MiB respectively, which is mixed and within run noise. Every query,
 reachability, CFG-materialization, and semantic-provider counter remained
 identical. Lattice allocation counts are flat; requested bytes moved about
 +0.06 percent, also within measurement noise. The executable remains
+byte-identical at
+`8d7355dcda83780ef8a98aedfa0495a9d4745c5ed84375e0ae9a37d82eb361a9`.
+
+RUE-1367 closes the next measurement gap exposed by a rejected optimization:
+the scaling report previously published validation and retention work but not
+all query request outcomes. The compiler now makes one canonical projection of
+cumulative query-runtime work and schema version ten publishes claims,
+reuses, joins, completed bodies, red/green publications, cancellations, and
+cycles. The report and retained-session runner share one saturating arithmetic
+implementation, so adding a runtime field cannot silently make their deltas
+disagree.
+
+The fresh one-worker baseline records 8,403/68,041 claims/reuses for Ruelex,
+18,602/191,452 for Mosaic, 32,674/382,634 for Harbor, and 39,092/494,426 for
+Lattice. Every claimed body completes and publishes green in these fresh
+probes; joins, cancellations, and cycles are zero. The counters are read only
+at the observation boundary, so production query behavior and the previously
+published deterministic work remain unchanged. Fresh-process timing and peak
+memory remain mixed within run noise, and the Lattice executable remains
 byte-identical at
 `8d7355dcda83780ef8a98aedfa0495a9d4745c5ed84375e0ae9a37d82eb361a9`.
 

--- a/docs/process/compiler-scaling.md
+++ b/docs/process/compiler-scaling.md
@@ -39,6 +39,8 @@ compilations. The report records:
 - request-local CFG-materialization index builds, declaration/anonymous/type
   scans, and exact body-local fact selections;
 - query validation, endorsement, lease, demand, and retention-scan work;
+- query claims, terminal reuses, joins, body completions, publication
+  outcomes, cancellations, and cycles;
 - display-only query identities materialized for memo nodes, structured batch
   cycle rendering, and abort fallbacks, with exact counts and formatted key
   bytes;


### PR DESCRIPTION
Fixes RUE-1367.

## Summary

- publish deterministic query claims, reuses, joins, body completions, publication outcomes, cancellations, and cycles in scaling schema v10
- use one cumulative-work projection that excludes live gauges and one field-complete arithmetic path for cold and retained-session reports
- document the fresh one-worker baseline and preserve the byte-identical Lattice output witness

## Validation

- `scripts/rue quick`
- `scripts/rue cli benchmark_json`
- maintained two-probe scaling agreement
- focused live-snapshot and runtime-arithmetic regressions