### PR TITLE
RUE-1368: reuse definition keys from resolved signatures

### DIFF
--- a/crates/rue-compiler/src/revisioned_query_database.rs
+++ b/crates/rue-compiler/src/revisioned_query_database.rs
@@ -13759,6 +13759,7 @@ impl RevisionedQueryDatabase {
                                             ) {
                                                 Ok(signature) => Value::Signature(
                                                     crate::semantic_query_nucleus::ResolvedDeclarationSignature {
+                                                        definition: provider.dependency_source.clone(),
                                                         signature,
                                                         anonymous_nominals: provider
                                                             .anonymous_nominals
@@ -23022,13 +23023,7 @@ impl rue_air::BodyFactProvider for CompilerBodyFactProvider<'_> {
         );
         match self.nucleus(query) {
             Some(crate::semantic_query_nucleus::SemanticNucleusValue::Signature(signature)) => {
-                if let Some(crate::semantic_query_nucleus::SemanticNucleusValue::Identity(
-                    identity,
-                )) = self.nucleus(crate::semantic_query_nucleus::SemanticNucleusKey::Identity(
-                    self.declaration_query_key(decl),
-                )) {
-                    self.record_definition_reference(identity.key);
-                }
+                self.record_definition_reference(signature.definition.clone());
                 Some(signature)
             }
             _ => None,
@@ -27247,6 +27242,7 @@ fn main() -> i32 {
         assert_eq!(
             signature,
             Value::Signature(crate::semantic_query_nucleus::ResolvedDeclarationSignature {
+                definition: identity.key.clone(),
                 signature: Signature::Struct {
                     fields: vec![(
                         Arc::from("next"),
@@ -36478,6 +36474,24 @@ fn main() -> i32 {
         assert_eq!(
             provider_sig, epoch_sig,
             "the candidate handle fetches the exact production signature (modes + return type)"
+        );
+        assert!(
+            sig_outcome.dependencies.iter().any(|node| {
+                node.family() == "compiler.semantic-nucleus"
+                    && node.key().starts_with("signature:")
+                    && node.key().contains("get")
+            }),
+            "signature facts observe the signature projection: {:?}",
+            sig_outcome.dependencies
+        );
+        assert!(
+            !sig_outcome.dependencies.iter().any(|node| {
+                node.family() == "compiler.semantic-nucleus"
+                    && node.key().starts_with("identity:")
+                    && node.key().contains("get")
+            }),
+            "the resolved signature carries its definition key without a peer identity request: {:?}",
+            sig_outcome.dependencies
         );
 
         // Differential: the candidate's visibility matches the method's own

--- a/crates/rue-compiler/src/semantic_query_nucleus.rs
+++ b/crates/rue-compiler/src/semantic_query_nucleus.rs
@@ -962,6 +962,10 @@ pub(crate) enum SemanticNucleusValue {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct ResolvedDeclarationSignature {
+    /// Stable source identity computed with the signature. Consumers which
+    /// already observed this projection must not issue a peer identity query
+    /// merely to recover the same key.
+    pub(crate) definition: StableDefinitionKey,
     pub(crate) signature: DeclarationSignatureProjection,
     pub(crate) anonymous_nominals: Arc<[DurableAnonymousNominal]>,
     pub(crate) dependencies: Arc<[SemanticDeclarationDependency]>,
@@ -1192,8 +1196,9 @@ impl RetainedCharge for DeclarationSignatureProjection {
 
 impl RetainedCharge for ResolvedDeclarationSignature {
     fn retained_charge(&self) -> u64 {
-        self.signature
+        self.definition
             .retained_charge()
+            .saturating_add(self.signature.retained_charge())
             .saturating_add(self.anonymous_nominals.retained_charge())
             .saturating_add(self.dependencies.retained_charge())
             .saturating_add(self.deferred_ownership.retained_charge())

--- a/docs/notes/post-adr-0063-cold-compiler-architecture-audit.md
+++ b/docs/notes/post-adr-0063-cold-compiler-architecture-audit.md
@@ -638,6 +638,23 @@ memory remain mixed within run noise, and the Lattice executable remains
 byte-identical at
 `8d7355dcda83780ef8a98aedfa0495a9d4745c5ed84375e0ae9a37d82eb361a9`.
 
+RUE-1368 used those request counters to remove one peer identity query from
+every successful body-provider signature fact. The semantic-nucleus signature
+projection now carries the shared stable definition key it already computes;
+the consumer clones that pointer instead of requesting the identity projection
+solely to recover the same key. Reconstructing the key at the consumer was
+rejected because it replaced a query reuse with a fresh digest and allocation.
+
+The fixed probes remove exactly 2,014, 8,171, 16,706, and 21,198 reuses from
+Ruelex through Lattice, equal to the signature-fact counts. Claims, validation,
+retention enforcement and scans, display identities, provider work,
+reachability, and CFG materialization are unchanged. A reverse-order paired
+run on the loaded local host moved compiler medians -10.3, +5.5, -10.9, and
+-20.3 percent respectively; Mosaic's movement was smaller than its MAD, so the
+clock result is mixed/neutral rather than a claimed speedup. Peak memory was
+flat within 1.5 MiB, and the Lattice executable remains byte-identical at
+`8d7355dcda83780ef8a98aedfa0495a9d4745c5ed84375e0ae9a37d82eb361a9`.
+
 ## Next actions and decision boundary
 
 Authorized low-risk work:


### PR DESCRIPTION
Fixes RUE-1368.

## Summary

- carry the already-computed shared definition key in resolved signature projections
- remove the peer semantic-nucleus identity request that body signature facts used only to recover that key
- add a dependency-edge regression and document the counter-guided result

## Performance

Fresh one-worker probes remove exactly one query reuse per signature fact: 2,014 / 8,171 / 16,706 / 21,198 from Ruelex through Lattice. All other deterministic counters are unchanged. A reverse-order paired run was clock-neutral/mixed, peak memory was flat within 1.5 MiB, and Lattice remained byte-identical.

## Validation

- focused semantic-nucleus signature regression
- focused body-provider dependency-edge regression
- maintained two-probe scaling agreement
- byte-identical Lattice output