### PR TITLE
RUE-1372: reuse resolved declaration identities

### DIFF
--- a/crates/rue-compiler/src/revisioned_query_database.rs
+++ b/crates/rue-compiler/src/revisioned_query_database.rs
@@ -21195,6 +21195,11 @@ pub(crate) struct CompilerBodyDurableSource<'a> {
     source_locators: Rc<std::cell::RefCell<HashMap<ModuleId, rue_air::DurableBodySourceLocator>>>,
 }
 
+struct ResolvedDeclarationCandidate {
+    declaration: crate::declaration_candidate::DeclarationCandidateKey,
+    identity: crate::semantic_query_nucleus::DeclarationIdentityProjection,
+}
+
 impl<'a> CompilerBodyDurableSource<'a> {
     #[allow(dead_code)]
     fn with_anonymous(
@@ -21218,18 +21223,17 @@ impl<'a> CompilerBodyDurableSource<'a> {
         }
     }
 
-    fn candidate(
-        &self,
-        key: &crate::StableDefinitionKey,
-    ) -> Option<crate::declaration_candidate::DeclarationCandidateKey> {
+    fn candidate(&self, key: &crate::StableDefinitionKey) -> Option<ResolvedDeclarationCandidate> {
         use rue_air::BodyFactProvider;
         stable_syntax_candidate_set(key)?
             .into_iter()
             .flatten()
-            .find(|candidate| {
-                self.provider
-                    .declaration_identity(candidate)
-                    .is_some_and(|identity| identity.key == *key)
+            .find_map(|declaration| {
+                let identity = self.provider.declaration_identity(&declaration)?;
+                (identity.key == *key).then_some(ResolvedDeclarationCandidate {
+                    declaration,
+                    identity,
+                })
             })
     }
 
@@ -21296,7 +21300,7 @@ impl<'a> CompilerBodyDurableSource<'a> {
         };
         let facts = self
             .candidate(producer)
-            .and_then(|candidate| self.provider.anonymous_facts(&candidate))
+            .and_then(|candidate| self.provider.anonymous_facts(&candidate.declaration))
             .unwrap_or_default();
         let mut dynamic = self.dynamic_anonymous.borrow_mut();
         dynamic.extend(facts.iter().cloned());
@@ -21307,8 +21311,16 @@ impl<'a> CompilerBodyDurableSource<'a> {
         &self,
         key: &crate::StableDefinitionKey,
     ) -> Option<crate::semantic_query_nucleus::ResolvedDeclarationSignature> {
+        let candidate = self.candidate(key)?;
+        self.signature_for_candidate(&candidate.declaration)
+    }
+
+    fn signature_for_candidate(
+        &self,
+        candidate: &crate::declaration_candidate::DeclarationCandidateKey,
+    ) -> Option<crate::semantic_query_nucleus::ResolvedDeclarationSignature> {
         use rue_air::BodyFactProvider;
-        let signature = self.provider.signature(&self.candidate(key)?)?;
+        let signature = self.provider.signature(candidate)?;
         self.dynamic_anonymous
             .borrow_mut()
             .extend(signature.anonymous_nominals.iter().cloned());
@@ -21748,7 +21760,7 @@ impl rue_air::DurableBodyLookupSource<crate::StableDefinitionKey, ModuleId>
         let Some(candidate) = self.candidate(definition) else {
             return rue_air::DurableComptimeCallOutcome::NotReduced;
         };
-        let declaration = self.provider.declaration_query_key(&candidate);
+        let declaration = self.provider.declaration_query_key(&candidate.declaration);
         let query = crate::semantic_query_nucleus::SemanticNucleusKey::ComptimeCall(
             crate::semantic_query_nucleus::ComptimeCallQueryKey {
                 declaration: declaration.clone(),
@@ -21955,13 +21967,12 @@ impl rue_air::DurableConstSource<crate::StableDefinitionKey, ModuleId>
             .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
         use rue_air::BodyFactProvider;
         let candidate = self.candidate(key)?;
-        let identity = self.provider.declaration_identity(&candidate)?;
         let crate::semantic_query_nucleus::ConstResolutionProjection::Value {
             ty,
             value,
             anonymous_nominals,
             ..
-        } = self.provider.const_comptime(&candidate)?
+        } = self.provider.const_comptime(&candidate.declaration)?
         else {
             return None;
         };
@@ -21969,7 +21980,7 @@ impl rue_air::DurableConstSource<crate::StableDefinitionKey, ModuleId>
             .borrow_mut()
             .extend(anonymous_nominals.iter().cloned());
         Some(rue_air::DurableConst {
-            is_public: identity.is_public,
+            is_public: candidate.identity.is_public,
             ty,
             value: *value,
         })
@@ -22021,8 +22032,7 @@ impl rue_air::DurableNominalSource<crate::StableDefinitionKey, ModuleId>
         use rue_air::BodyFactProvider;
 
         let candidate = self.candidate(key)?;
-        let identity = self.provider.declaration_identity(&candidate)?;
-        let signature = self.provider.signature(&candidate)?;
+        let signature = self.provider.signature(&candidate.declaration)?;
         let is_repr_c = matches!(
             signature.signature,
             Projection::Struct {
@@ -22052,7 +22062,7 @@ impl rue_air::DurableNominalSource<crate::StableDefinitionKey, ModuleId>
         Some(rue_air::DurableNominal {
             name: Arc::from(key.name()),
             module_path: Arc::from(key.module().logical_path()),
-            is_public: identity.is_public,
+            is_public: candidate.identity.is_public,
             is_builtin: false,
             lang_item: self.provider.language_item(
                 key.module(),
@@ -22086,7 +22096,8 @@ impl rue_air::DurableCallableSource<crate::StableDefinitionKey, ModuleId>
             .meter()
             .materializations
             .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-        let signature = self.signature(key)?;
+        let candidate = self.candidate(key)?;
+        let signature = self.signature_for_candidate(&candidate.declaration)?;
         let crate::semantic_query_nucleus::DeclarationSignatureProjection::Callable {
             parameters,
             result,
@@ -22100,15 +22111,13 @@ impl rue_air::DurableCallableSource<crate::StableDefinitionKey, ModuleId>
         if key.kind().requires_owner() {
             return None;
         }
-        use rue_air::BodyFactProvider;
-        let identity = self.provider.declaration_identity(&self.candidate(key)?)?;
         Some(rue_air::DurableFunction {
             parameters: parameters
                 .iter()
                 .map(provider_signature_parameter)
                 .collect(),
             result,
-            is_public: identity.is_public,
+            is_public: candidate.identity.is_public,
             is_unchecked,
             is_extern,
         })
@@ -22169,7 +22178,8 @@ impl rue_air::DurableCallableSource<crate::StableDefinitionKey, ModuleId>
         &self,
         key: &crate::StableDefinitionKey,
     ) -> Option<(Vec<Arc<str>>, Arc<str>)> {
-        self.provider.callable_type_syntax(&self.candidate(key)?)
+        self.provider
+            .callable_type_syntax(&self.candidate(key)?.declaration)
     }
 
     fn uses_deferred_body_type_placeholders(&self) -> bool {

--- a/crates/rue-compiler/src/session.rs
+++ b/crates/rue-compiler/src/session.rs
@@ -8967,10 +8967,13 @@ mod tests {
         assert_eq!(metrics.import_lookups, 0);
         assert_eq!(metrics.method_candidates, 0);
         assert_eq!(metrics.operator_candidates, 0);
-        assert_eq!(metrics.declaration_facts, 25);
-        assert!(metrics.identity_facts > 0, "{metrics:?}");
-        assert!(metrics.signature_facts > 0, "{metrics:?}");
-        assert!(metrics.materializations > 0, "{metrics:?}");
+        assert_eq!(metrics.declaration_facts, 13, "{metrics:?}");
+        assert_eq!(
+            metrics.identity_facts, 7,
+            "candidate resolution must reuse the winning declaration identity instead of issuing a peer query: {metrics:?}"
+        );
+        assert_eq!(metrics.signature_facts, 6, "{metrics:?}");
+        assert_eq!(metrics.materializations, 6, "{metrics:?}");
         assert_eq!(
             metrics.declaration_facts,
             metrics.identity_facts

--- a/docs/notes/post-adr-0063-cold-compiler-architecture-audit.md
+++ b/docs/notes/post-adr-0063-cold-compiler-architecture-audit.md
@@ -676,6 +676,26 @@ dispersion, peak memory is flat, and maintained Harbor/Lattice probes are
 neutral to faster. The Lattice executable remains byte-identical at
 `8d7355dcda83780ef8a98aedfa0495a9d4745c5ed84375e0ae9a37d82eb361a9`.
 
+RUE-1372 removes repeated declaration-identity queries from durable body-fact
+materialization. Resolving a stable definition already has to inspect each
+syntax candidate's exact identity; the source now carries the winning identity
+projection beside the candidate and consumes it when materializing constants,
+nominals, and free functions. Signature queries and dynamic anonymous-nominal
+registration remain on their existing paths.
+
+The fixed one-worker probes reduce identity facts from 6,667 to 3,743 on
+Ruelex, 21,639 to 10,321 on Mosaic, 42,672 to 20,036 on Harbor, and 53,917 to
+24,837 on Lattice. Total declaration facts fall from 12,693 to 9,769, 34,554
+to 23,236, 67,214 to 44,578, and 89,005 to 59,925 respectively. Query reuses
+fall by the same 2,924, 11,318, 22,636, and 29,080 requests because the removed
+identity lookups were compatible peer queries. Every other semantic-provider
+counter and every query-validation counter is exactly unchanged.
+
+Five directly alternating release pairs are clock-neutral: median paired
+deltas are +0.08% on Ruelex, -1.49% on Harbor, and +0.43% on Lattice, all well
+inside host dispersion. Median peak memory remains within 0.6%. Output sizes
+and SHA-256 hashes are identical for every workload.
+
 ## Next actions and decision boundary
 
 Authorized low-risk work:


### PR DESCRIPTION
Fixes RUE-1372.

## Summary
- carry the exact declaration identity that already matched a durable body candidate
- reuse that projection when materializing constants, nominals, and free functions instead of issuing identical peer queries
- preserve the existing signature and dynamic anonymous-nominal paths
- record the counter, release-profile, memory, and output evidence in the cold-compiler architecture audit

## Deterministic evidence
- identity facts fall from 6,667 to 3,743 on Ruelex, 21,639 to 10,321 on Mosaic, 42,672 to 20,036 on Harbor, and 53,917 to 24,837 on Lattice
- total declaration facts fall from 12,693 to 9,769, 34,554 to 23,236, 67,214 to 44,578, and 89,005 to 59,925
- query reuses fall by the same 2,924 / 11,318 / 22,636 / 29,080 removed identity reads
- every other semantic-provider counter and every query-validation counter is exactly unchanged

## Release evidence
- five directly alternating baseline/candidate pairs are clock-neutral: paired medians are +0.08% Ruelex, -1.49% Harbor, and +0.43% Lattice, within host dispersion
- median peak memory remains within 0.6%
- output sizes and SHA-256 hashes are identical across all four maintained workloads
- the focused exact-work regression and final release build pass; CI is the broad-platform authority
