### PR TITLE
RUE-1373: share reconstructed candidate names

### DIFF
--- a/crates/rue-compiler/src/bound_definitions.rs
+++ b/crates/rue-compiler/src/bound_definitions.rs
@@ -99,6 +99,9 @@ impl StableNamedTypeKey {
     pub fn name(&self) -> &str {
         &self.name
     }
+    pub(crate) fn shared_name(&self) -> &Arc<str> {
+        &self.name
+    }
 }
 
 #[derive(Debug)]
@@ -191,6 +194,9 @@ impl StableDefinitionKey {
         self.0.kind
     }
     pub fn name(&self) -> &str {
+        &self.0.name
+    }
+    pub(crate) fn shared_name(&self) -> &Arc<str> {
         &self.0.name
     }
     pub fn owner(&self) -> Option<&StableNamedTypeKey> {

--- a/crates/rue-compiler/src/revisioned_query_database.rs
+++ b/crates/rue-compiler/src/revisioned_query_database.rs
@@ -4683,7 +4683,7 @@ fn stable_syntax_candidate_set(
                 K::Enum => C::Enum,
                 _ => return None,
             },
-            name: Arc::from(owner.name()),
+            name: Arc::clone(owner.shared_name()),
         }),
         None => None,
     };
@@ -4695,7 +4695,7 @@ fn stable_syntax_candidate_set(
             |category| crate::declaration_candidate::DeclarationCandidateKey {
                 module: key.module().clone(),
                 category,
-                name: Arc::from(key.name()),
+                name: Arc::clone(key.shared_name()),
                 owner: owner.clone(),
                 duplicate_discriminator: 0,
             },
@@ -25216,11 +25216,18 @@ mod tests {
             for candidate in candidates {
                 assert_eq!(candidate.module, module);
                 assert_eq!(candidate.name.as_ref(), "item");
+                assert!(Arc::ptr_eq(&candidate.name, key.shared_name()));
                 assert_eq!(candidate.duplicate_discriminator, 0);
                 assert_eq!(
                     candidate.owner.as_ref().map(|owner| owner.name.as_ref()),
                     owner.as_ref().map(|(_, name)| name.as_ref())
                 );
+                if let Some(candidate_owner) = &candidate.owner {
+                    assert!(Arc::ptr_eq(
+                        &candidate_owner.name,
+                        key.owner().unwrap().shared_name()
+                    ));
+                }
             }
         }
     }

--- a/docs/notes/post-adr-0063-cold-compiler-architecture-audit.md
+++ b/docs/notes/post-adr-0063-cold-compiler-architecture-audit.md
@@ -696,6 +696,22 @@ deltas are +0.08% on Ruelex, -1.49% on Harbor, and +0.43% on Lattice, all well
 inside host dispersion. Median peak memory remains within 0.6%. Output sizes
 and SHA-256 hashes are identical for every workload.
 
+RUE-1373 removes equal-string allocations while reconstructing syntax
+candidates from stable definition identities. Stable keys and named owners
+already retain their immutable names in `Arc<str>`; candidate construction now
+clones those pointers instead of allocating new payloads. Ordinary functions
+benefit twice because their function and extern-function candidates share the
+same name allocation. Candidate order, equality, hashing, query ownership, and
+invalidation are unchanged.
+
+The fixed one-worker Lattice allocation probe falls from 17,434,269 to
+17,387,834 allocation calls (-46,435, or -0.27%) and from 2,917,592,451 to
+2,916,549,779 requested bytes (-1,042,672). Every deterministic compiler-work
+counter is byte-for-byte identical. Five directly alternating ordinary-release
+pairs are clock-neutral: median paired deltas are +0.19% on Ruelex, -0.66% on
+Harbor, and -0.51% on Lattice. Median peak RSS is flat to modestly lower, and
+all output sizes and SHA-256 hashes are identical.
+
 ## Next actions and decision boundary
 
 Authorized low-risk work:


### PR DESCRIPTION
Fixes RUE-1373.

## Summary
- share the immutable definition-name allocation when reconstructing syntax candidates from stable definition identities
- share named-owner payloads through the same bounded crate-private accessors
- prove pointer identity while preserving the existing candidate categories and order
- record allocation, release-profile, memory, counter, and output evidence in the cold-compiler architecture audit

## Evidence
- fixed one-worker Lattice allocation calls fall from 17,434,269 to 17,387,834 (-46,435, -0.27%)
- requested bytes fall from 2,917,592,451 to 2,916,549,779 (-1,042,672)
- every deterministic compiler-work counter is byte-for-byte identical
- five alternating release pairs are clock-neutral: paired medians are +0.19% Ruelex, -0.66% Harbor, and -0.51% Lattice
- median peak RSS is flat to modestly lower; output sizes and SHA-256 hashes are identical
- focused pointer-sharing regression, compiler Clippy, and release builds pass; CI is the broad-platform authority
