### PR TITLE
RUE-1376: short-circuit shared definition ordering

### DIFF
--- a/crates/rue-compiler/src/bound_definitions.rs
+++ b/crates/rue-compiler/src/bound_definitions.rs
@@ -249,6 +249,12 @@ impl PartialOrd for StableDefinitionKey {
 
 impl Ord for StableDefinitionKey {
     fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        // Stable keys propagate by cloning this immutable identity. Ordered
+        // maps commonly compare a lookup key with that exact clone, so match
+        // equality's constant-time path before walking the shared strings.
+        if Arc::ptr_eq(&self.0, &other.0) {
+            return std::cmp::Ordering::Equal;
+        }
         (
             &self.0.module,
             self.0.namespace,
@@ -1409,6 +1415,21 @@ mod tests {
         );
         let cloned = first.clone();
         assert!(Arc::ptr_eq(&first.0, &cloned.0));
+        assert_eq!(first.cmp(&cloned), std::cmp::Ordering::Equal);
+
+        let independently_issued_equal = StableDefinitionKey::for_test(
+            module.clone(),
+            StableDefinitionNamespace::Value,
+            StableDefinitionKind::Function,
+            "a_very_long_function_name",
+            None,
+        );
+        assert!(!Arc::ptr_eq(&first.0, &independently_issued_equal.0));
+        assert_eq!(first, independently_issued_equal);
+        assert_eq!(
+            first.cmp(&independently_issued_equal),
+            std::cmp::Ordering::Equal
+        );
 
         let mut hasher = ByteCountingHasher::default();
         first.hash(&mut hasher);
@@ -1423,6 +1444,8 @@ mod tests {
         );
         Arc::get_mut(&mut second.0).unwrap().hash_accelerator = first.0.hash_accelerator;
         assert_ne!(first, second);
+        assert_ne!(first.cmp(&second), std::cmp::Ordering::Equal);
+        assert_eq!(first.cmp(&second), second.cmp(&first).reverse());
 
         let mut colliding = HashMap::new();
         colliding.insert(first, 1);

--- a/docs/notes/post-adr-0063-cold-compiler-architecture-audit.md
+++ b/docs/notes/post-adr-0063-cold-compiler-architecture-audit.md
@@ -743,6 +743,22 @@ ordinary-release pairs are clock-neutral at a +0.16% median paired delta.
 Median peak RSS moves from 456,433,664 to 457,940,992 bytes (+1.44 MiB, or
 0.33%), within run dispersion.
 
+RUE-1376 gives stable-definition ordering the same shared-allocation shortcut
+as equality. Stable keys are propagated by cloning one immutable identity Arc;
+ordered maps previously walked module, namespace, kind, name, and owner fields
+even when comparing two handles to that exact allocation. Independently issued
+keys still use the authoritative full-field order, including when their cached
+hash accelerators collide.
+
+The post-RUE-1375 Lattice profile placed `StableDefinitionKey::cmp` among the
+hottest compiler leaves. Two independent directly alternating sets total 24
+ordinary-release pairs: their median paired deltas are -3.84% and -2.62%, for a
+combined -3.09%. Separate medians move from 1,399.815 to 1,374.492 ms. Median
+peak RSS moves from 458,235,904 to 454,656,000 bytes (-3.41 MiB). Allocation
+counts and requested bytes vary by less than 0.001% across repeated accounting
+runs; every deterministic compiler-work counter and emitted executable is
+identical.
+
 ## Next actions and decision boundary
 
 Authorized low-risk work:


### PR DESCRIPTION
## Summary

- return immediately when two stable definition keys share the same immutable identity allocation
- preserve the full authoritative field order for independently issued and unequal identities
- cover shared clones, independently issued equal keys, reversed ordering, and forced accelerator collisions

## Performance evidence

Across two independent directly alternating Lattice sets (24 release pairs total), the median paired compiler-time delta is -3.09%. Separate medians move from 1,399.815 to 1,374.492 ms, and median peak RSS falls by 3.41 MiB. Allocation accounting is neutral within 0.001% run variation. Every deterministic compiler-work counter and the emitted executable are identical.

## Validation

- focused stable-definition hashing/ordering test
- compiler Clippy gate
- formatting

Fixes RUE-1376.