### PR TITLE
RUE-1378: hash request-local terminal lease identities

### DIFF
--- a/crates/rue-query/src/lib.rs
+++ b/crates/rue-query/src/lib.rs
@@ -8001,7 +8001,9 @@ struct TaskLeases {
     /// and stamp while being a DISTINCT terminal at the adopting revision —
     /// both must stay leased; collapsing them would leave the endorsement
     /// unprotected. Re-observations of one exact terminal still deduplicate.
-    observed: BTreeSet<(u64, u64, Revision)>,
+    /// The runtime assigns every component and no consumer observes ordering,
+    /// so high-frequency lease acquisition uses constant-expected membership.
+    observed: AHashSet<(u64, u64, Revision)>,
     /// Live pins, type-erased across families. Dropping the task drops these,
     /// each of which decrements its terminal's pin count and re-enforces the
     /// owning family's retention bound.

--- a/docs/notes/post-adr-0063-cold-compiler-architecture-audit.md
+++ b/docs/notes/post-adr-0063-cold-compiler-architecture-audit.md
@@ -776,6 +776,26 @@ median paired delta. Median peak RSS moves by +1.58 MiB (0.35%), within run
 dispersion. Every deterministic compiler-work counter and the emitted
 executable are identical.
 
+RUE-1378 gives the request-local terminal-lease deduplication index the same
+numeric-identity treatment. Cold Lattice makes 199,098 lease observations;
+`TaskLeases` only inserts exact `(incarnation, stamp, revision)` identities and
+tests whether each was new, so its ordered tree carried no semantic order.
+
+Two allocation-accounting comparisons reduce calls by 10,887 and 10,823 and
+requested bytes by 7,032,904 and 7,013,852 respectively. Sixteen directly
+alternating ordinary-release pairs are clock-neutral at a -0.61% median paired
+delta. Median peak RSS moves by +0.69 MiB (0.15%), within run dispersion. Every
+deterministic compiler-work counter and the emitted executable are identical.
+The adjacent structured-batch lease set was evaluated separately and retained
+as an ordered tree: hashing it saved about 1,100 allocation calls but requested
+about 6.7 MiB more memory, so it did not meet the non-regression boundary.
+
+The next apparent comparison shortcut was also rejected. Adding shared-Arc
+fast paths to `NodeIdentity` equality and ordering left 32 paired Lattice runs
+clock-neutral (-0.27%), changed no deterministic work or allocation measure,
+and did not reduce the broader string-comparison profile. Its median peak RSS
+was repeatably about 3.0 MiB higher, so the source change was not retained.
+
 ## Next actions and decision boundary
 
 Authorized low-risk work:


### PR DESCRIPTION
Fixes RUE-1378.

## Summary

- replace the request-local exact terminal-lease deduplication tree with an expected-O(1) hash index
- preserve exact revision identity and leave the structured-batch lease set unchanged after its separate memory experiment failed the non-regression bar
- record the cold Lattice evidence in the post-ADR-0063 architecture audit

## Evidence

- cold Lattice performs 199,098 terminal lease observations
- two fixed one-worker allocation comparisons save 10,887 / 10,823 calls and 7.03 / 7.01 MB of requested bytes
- 16 directly alternating release pairs are clock-neutral at -0.61% median paired delta
- median peak RSS changes by +0.69 MiB (+0.15%), within dispersion
- every deterministic work counter and the emitted executable are identical
- focused duplicate-lease, structured-transfer, and cross-revision-adoption tests pass
- query crate lint and formatting pass