### PR TITLE
RUE-1381: bound request-frame dependency indexing

### DIFF
--- a/crates/rue-query/src/lib.rs
+++ b/crates/rue-query/src/lib.rs
@@ -8444,14 +8444,98 @@ impl FamilyEnforcer {
     }
 }
 
+type TaskDependencyEntry = (u64, NodeIdentity, u64);
+
+#[derive(Debug)]
+enum TaskDependencies {
+    Empty,
+    /// The common single-edge frame needs no side allocation. A second distinct
+    /// edge promotes to expected-O(1) hashed membership so wide frames cannot
+    /// turn repeated observation into quadratic work. Boxing the uncommon map
+    /// keeps every task's frame compact, including zero- and one-edge frames.
+    One(TaskDependencyEntry),
+    Hashed(Box<AHashMap<u64, (NodeIdentity, u64)>>),
+}
+
+impl Default for TaskDependencies {
+    fn default() -> Self {
+        Self::Empty
+    }
+}
+
+impl TaskDependencies {
+    fn observe(&mut self, node: &NodeIdentity, incarnation: u64, stamp: u64) {
+        match self {
+            Self::Empty => *self = Self::One((incarnation, node.clone(), stamp)),
+            Self::One((previous_incarnation, previous_node, previous_stamp)) => {
+                if *previous_incarnation == incarnation {
+                    assert_eq!(
+                        &*previous_node, node,
+                        "one runtime node incarnation must name exactly one display identity"
+                    );
+                    *previous_stamp = stamp;
+                    return;
+                }
+                let mut hashed = Box::new(AHashMap::with_capacity(2));
+                hashed.insert(
+                    *previous_incarnation,
+                    (previous_node.clone(), *previous_stamp),
+                );
+                hashed.insert(incarnation, (node.clone(), stamp));
+                *self = Self::Hashed(hashed);
+            }
+            Self::Hashed(entries) => {
+                if let Some((previous_node, _)) = entries.insert(incarnation, (node.clone(), stamp))
+                {
+                    assert_eq!(
+                        &previous_node, node,
+                        "one runtime node incarnation must name exactly one display identity"
+                    );
+                }
+            }
+        }
+    }
+
+    fn into_observations(self) -> Vec<Observation> {
+        let mut observations: Vec<Observation> = match self {
+            Self::Empty => Vec::new(),
+            Self::One((incarnation, node, stamp)) => vec![Observation {
+                node,
+                incarnation,
+                stamp,
+            }],
+            Self::Hashed(entries) => entries
+                .into_iter()
+                .map(|(incarnation, (node, stamp))| Observation {
+                    node,
+                    incarnation,
+                    stamp,
+                })
+                .collect(),
+        };
+        observations.sort_unstable_by(|left, right| {
+            left.node
+                .cmp(&right.node)
+                .then_with(|| left.incarnation.cmp(&right.incarnation))
+        });
+        observations
+    }
+}
+
 #[derive(Debug)]
 struct TaskFrame {
     node: ExactNodeIdentity,
-    dependencies: BTreeMap<ExactNodeIdentity, u64>,
+    dependencies: TaskDependencies,
     inputs: BTreeMap<InputIdentity, u64>,
     work: BTreeMap<Arc<str>, u64>,
     handoffs: Vec<Box<dyn QueryAttemptHandoff>>,
     observed_handoffs: Vec<Arc<AttemptHandoffLifecycle>>,
+}
+
+impl TaskFrame {
+    fn observe_dependency(&mut self, node: &NodeIdentity, incarnation: u64, stamp: u64) {
+        self.dependencies.observe(node, incarnation, stamp);
+    }
 }
 
 struct TaskFrameOutput {
@@ -9402,7 +9486,7 @@ impl Task {
     fn push(&self, node: ExactNodeIdentity) {
         lock(&self.stack).push(TaskFrame {
             node,
-            dependencies: BTreeMap::new(),
+            dependencies: TaskDependencies::default(),
             inputs: BTreeMap::new(),
             work: BTreeMap::new(),
             handoffs: Vec::new(),
@@ -9415,15 +9499,7 @@ impl Task {
             .pop()
             .expect("query computation owns one dependency frame");
         assert_eq!(&frame.node, expected);
-        let dependencies = frame
-            .dependencies
-            .into_iter()
-            .map(|(node, stamp)| Observation {
-                node: node.display,
-                incarnation: node.incarnation,
-                stamp,
-            })
-            .collect();
+        let dependencies = frame.dependencies.into_observations();
         let inputs = frame
             .inputs
             .into_iter()
@@ -9450,13 +9526,7 @@ impl Task {
 
     fn observe<V>(&self, terminal: &QueryTerminal<V>) {
         if let Some(frame) = lock(&self.stack).last_mut() {
-            frame.dependencies.insert(
-                ExactNodeIdentity {
-                    display: terminal.node.clone(),
-                    incarnation: terminal.node_incarnation,
-                },
-                terminal.stamp,
-            );
+            frame.observe_dependency(&terminal.node, terminal.node_incarnation, terminal.stamp);
         }
     }
 
@@ -9487,13 +9557,7 @@ impl Task {
             return;
         };
         for dependency in dependencies {
-            frame.dependencies.insert(
-                ExactNodeIdentity {
-                    display: dependency.node.clone(),
-                    incarnation: dependency.incarnation,
-                },
-                dependency.stamp,
-            );
+            frame.observe_dependency(&dependency.node, dependency.incarnation, dependency.stamp);
         }
         for input in inputs {
             if let Some(previous) = frame.inputs.insert(input.input.clone(), input.stamp) {
@@ -13666,6 +13730,51 @@ mod tests {
         assert_eq!(serial.work(), parallel.work());
         assert_eq!(serial.dependencies(), parallel.dependencies());
         assert_eq!(serial.stamp(), parallel.stamp());
+    }
+
+    #[test]
+    fn task_dependencies_deduplicate_by_incarnation_and_publish_in_stable_order() {
+        let runtime = QueryRuntime::new(1);
+        publish_empty(&runtime, [revision(1)]);
+        let dependency = runtime
+            .family::<Key, u64>("dependency-order-leaf", 8)
+            .unwrap();
+        let root = runtime
+            .family::<Key, u64>("dependency-order-root", 8)
+            .unwrap();
+        let dependency_for_root = dependency.clone();
+        let rooted = runtime
+            .query(
+                &root,
+                revision(1),
+                Key("root"),
+                CancellationToken::new(),
+                move |context| {
+                    context.query(&dependency_for_root, Key("z"), |_| {
+                        Ok(QueryOutput::success(1))
+                    })?;
+                    context.query(&dependency_for_root, Key("z"), |_| {
+                        panic!("the inline duplicate reuses its terminal")
+                    })?;
+                    context.query(&dependency_for_root, Key("a"), |_| {
+                        Ok(QueryOutput::success(2))
+                    })?;
+                    context.query(&dependency_for_root, Key("z"), |_| {
+                        panic!("the hashed duplicate reuses its terminal")
+                    })?;
+                    Ok(QueryOutput::success(0))
+                },
+            )
+            .unwrap();
+
+        assert_eq!(
+            rooted
+                .dependencies()
+                .iter()
+                .map(|dependency| dependency.node.key())
+                .collect::<Vec<_>>(),
+            ["a", "z"]
+        );
     }
 
     #[test]

--- a/docs/notes/post-adr-0063-cold-compiler-architecture-audit.md
+++ b/docs/notes/post-adr-0063-cold-compiler-architecture-audit.md
@@ -796,6 +796,28 @@ clock-neutral (-0.27%), changed no deterministic work or allocation measure,
 and did not reduce the broader string-comparison profile. Its median peak RSS
 was repeatably about 3.0 MiB higher, so the source change was not retained.
 
+RUE-1380 tested routing AIR projection helpers through the existing 64-entry
+per-body type-validation cache. It preserved focused diagnostics, work, and
+output, but removed no material allocation work. Sixteen paired Lattice runs
+were 2.86% slower and median peak RSS rose by about 5.6 MiB, so the prototype
+was rejected rather than treating locally simpler bookkeeping as a free win.
+
+RUE-1381 follows the next measured query-runtime leaf into request-frame
+dependency recording. A frame now retains its common single direct dependency
+inline by runtime-unique node incarnation. The second distinct dependency
+promotes to a boxed numeric hash index, which keeps wide-frame observation
+expected-linear instead of introducing an unbounded linear search. Completed
+frames sort once by the existing stable display identity before publishing the
+immutable dependency array, preserving canonical order.
+
+The targeted ordered-map insertion falls from 33 combined top-of-stack samples
+to zero across three profiles. Two fixed one-worker allocation comparisons save
+7,941 and 7,727 calls and 794,540 and 678,980 requested bytes respectively.
+Sixteen directly alternating ordinary-release pairs are 1.59% faster; separate
+medians move from 1,888.37 to 1,823.21 ms. Median peak RSS rises by 1.55 MiB
+(0.35%), within dispersion. Every deterministic compiler-work counter and the
+emitted executable remain identical.
+
 ## Next actions and decision boundary
 
 Authorized low-risk work:


### PR DESCRIPTION
Fixes RUE-1381.

## Summary

- keep the common single direct query dependency inline by runtime-unique incarnation
- promote the second distinct dependency to a boxed numeric hash index, preserving expected-O(1) membership for wide frames
- sort once by the existing stable identity before immutable terminal publication
- preserve duplicate replacement, abort-prefix absorption, and canonical dependency order

## Evidence

- the targeted ordered-map insertion falls from 33 combined top-of-stack samples to zero across three profiles
- two one-worker allocation comparisons save 7,941 / 7,727 calls and 794,540 / 678,980 requested bytes
- 16 directly alternating release pairs are 1.59% faster; separate medians move from 1,888.37 to 1,823.21 ms
- median peak RSS changes by +1.55 MiB (+0.35%), within dispersion
- every deterministic compiler-work counter and the emitted executable are identical
- focused inline/hashed duplicate, stable ordering, registered-batch ordering, and abort-prefix tests pass
- query lint and formatting pass

## Rejected shapes

The all-hash prototype requested about 2.5 MiB more allocator memory. An inline but unboxed hybrid still requested about 0.5 MiB more. Neither source shape is retained; the boxed hybrid is the only measured design that improves time, allocation calls, and requested bytes together.