### PR TITLE
RUE-1385: share canonical anonymous facts

### DIFF
--- a/crates/rue-compiler/src/revisioned_query_database.rs
+++ b/crates/rue-compiler/src/revisioned_query_database.rs
@@ -21180,7 +21180,7 @@ pub(crate) struct CompilerBodyFactProvider<'a> {
 #[derive(Default)]
 struct CanonicalAnonymousNominalRegistry {
     by_identity:
-        BTreeMap<crate::AnonymousNominalKey, crate::durable_semantics::DurableAnonymousNominal>,
+        BTreeMap<crate::AnonymousNominalKey, Rc<crate::durable_semantics::DurableAnonymousNominal>>,
 }
 
 impl CanonicalAnonymousNominalRegistry {
@@ -21192,7 +21192,7 @@ impl CanonicalAnonymousNominalRegistry {
             let identity = nominal.identity.with_canonical_producer().into_owned();
             match self.by_identity.entry(identity) {
                 std::collections::btree_map::Entry::Vacant(entry) => {
-                    entry.insert(nominal);
+                    entry.insert(Rc::new(nominal));
                 }
                 std::collections::btree_map::Entry::Occupied(mut entry) => {
                     // A declaration projection may carry only the anonymous
@@ -21215,7 +21215,7 @@ impl CanonicalAnonymousNominalRegistry {
                         } if !methods.is_empty()
                     );
                     if incoming_has_methods || !existing_has_methods {
-                        entry.insert(nominal);
+                        entry.insert(Rc::new(nominal));
                     }
                 }
             }
@@ -21225,7 +21225,7 @@ impl CanonicalAnonymousNominalRegistry {
     fn get(
         &self,
         identity: &crate::AnonymousNominalKey,
-    ) -> Option<crate::durable_semantics::DurableAnonymousNominal> {
+    ) -> Option<Rc<crate::durable_semantics::DurableAnonymousNominal>> {
         self.by_identity
             .get(identity.with_canonical_producer().as_ref())
             .cloned()
@@ -21285,7 +21285,7 @@ impl<'a> CompilerBodyDurableSource<'a> {
     fn anonymous_nominal(
         &self,
         key: &crate::AnonymousNominalKey,
-    ) -> Option<crate::durable_semantics::DurableAnonymousNominal> {
+    ) -> Option<Rc<crate::durable_semantics::DurableAnonymousNominal>> {
         use rue_air::BodyFactProvider;
         let cached = self.dynamic_anonymous.borrow().get(key);
         let cached_has_methods = cached.as_ref().is_some_and(|nominal| {
@@ -22295,7 +22295,7 @@ impl rue_air::DurableAnonymousSource<crate::StableDefinitionKey, ModuleId>
     ) -> Option<rue_air::DurableAnonymousShape<crate::StableDefinitionKey, ModuleId>> {
         self.anonymous_nominal(key)
             .as_ref()
-            .map(project_provider_anonymous_shape)
+            .map(|nominal| project_provider_anonymous_shape(nominal))
     }
 
     fn anonymous_methods(
@@ -22304,7 +22304,7 @@ impl rue_air::DurableAnonymousSource<crate::StableDefinitionKey, ModuleId>
     ) -> Vec<rue_air::DurableAnonymousMethod<crate::StableDefinitionKey, ModuleId>> {
         self.anonymous_nominal(key)
             .as_ref()
-            .map(project_provider_anonymous_methods)
+            .map(|nominal| project_provider_anonymous_methods(nominal))
             .unwrap_or_default()
     }
 
@@ -29868,14 +29868,18 @@ fn main() -> i32 {
 
         let mut registry = CanonicalAnonymousNominalRegistry::default();
         registry.extend([thin.clone()]);
-        assert_eq!(registry.get(&canonical), Some(thin.clone()));
-        assert_eq!(registry.get(&wrapped), Some(thin.clone()));
+        let canonical_thin = registry.get(&canonical).unwrap();
+        let wrapped_thin = registry.get(&wrapped).unwrap();
+        assert_eq!(canonical_thin.as_ref(), &thin);
+        assert!(Rc::ptr_eq(&canonical_thin, &wrapped_thin));
         registry.extend([rich.clone()]);
         registry.extend([thin]);
 
         assert_eq!(registry.by_identity.len(), 1);
-        assert_eq!(registry.get(&canonical), Some(rich.clone()));
-        assert_eq!(registry.get(&wrapped), Some(rich));
+        let canonical_rich = registry.get(&canonical).unwrap();
+        let wrapped_rich = registry.get(&wrapped).unwrap();
+        assert_eq!(canonical_rich.as_ref(), &rich);
+        assert!(Rc::ptr_eq(&canonical_rich, &wrapped_rich));
     }
 
     #[test]

--- a/docs/notes/post-adr-0063-cold-compiler-architecture-audit.md
+++ b/docs/notes/post-adr-0063-cold-compiler-architecture-audit.md
@@ -833,6 +833,30 @@ Median peak RSS rises by 1.48 MiB (0.33%), within run dispersion. Every
 deterministic compiler-work counter and the emitted executable remain
 identical.
 
+Two adjacent collection substitutions were measured and rejected. RUE-1383
+changed task-local validation endorsement scopes from a mutex to a read/write
+lock. Thirty-two alternating runs were clock-neutral, but the targeted
+authority leaf grew by 16% across three profiles: the actual task-sharing shape
+did not provide enough concurrent readers to repay the heavier uncontended
+primitive. RUE-1384 changed the canonical anonymous-nominal registry from an
+ordered tree to a hash table. Its recursive identity was more expensive to hash
+than to compare in this registry; the combined 32-pair cold median regressed by
+1.15%. Neither prototype was retained.
+
+RUE-1385 instead removes the owned-value copy at the canonical anonymous
+registry boundary. Registry entries are immutable request-local facts, and the
+body identity pool may ask separately for shape, methods, type captures, and
+value captures. The registry now returns an `Rc` handle, so those lookups share
+the complete nominal and each consumer clones only its required projected
+output.
+
+Fixed one-worker Lattice saves 30,008 allocator calls (0.18%) and 4,469,456
+requested bytes (0.17%). The durable `AnonymousNominalKey` clone leaf falls
+from 105 to 65 combined samples (-38%). Sixteen alternating ordinary-release
+pairs are clock-neutral at +0.14%; median peak RSS falls by 3.27 MiB (0.73%).
+Every deterministic compiler-work counter and the emitted executable remain
+identical.
+
 ## Next actions and decision boundary
 
 Authorized low-risk work:


### PR DESCRIPTION
Fixes RUE-1385.

## Summary

- share immutable canonical anonymous-nominal facts behind request-local `Rc` handles
- preserve canonical producer lookup and rich-fact replacement
- clone only each consumer's projected output instead of the complete nominal
- record retained and rejected profile-driven experiments in the architecture audit

## Performance evidence

Fixed one-worker cold Lattice removes 30,008 allocator calls and 4,469,456 requested bytes. The targeted durable anonymous-key clone leaf falls 38%. Sixteen alternating ordinary-release pairs are clock-neutral at +0.14%; median RSS falls 3.27 MiB. Compiler-work counters and executable bytes are identical.

## Validation

- `scripts/rue unit compiler compiler_body_anonymous_registry_unifies_producers_and_keeps_rich_facts`
- `./buck2 test //crates/rue-compiler:rue-compiler-clippy`
- `scripts/rue fmt`