### PR TITLE
RUE-1389: merge body references linearly

### DIFF
--- a/crates/rue-compiler/src/body_query.rs
+++ b/crates/rue-compiler/src/body_query.rs
@@ -219,8 +219,51 @@ pub(crate) struct WellKnownOptionResolution {
     pub(crate) anonymous_nominals: Arc<[crate::durable_semantics::DurableAnonymousNominal]>,
 }
 
+/// Canonical sorted, duplicate-free body-reference summary.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct BodyReferences(pub(crate) Arc<[BodyReference]>);
+
+fn merge_ordered_unique<T: Clone + Ord>(
+    existing: Arc<[T]>,
+    selected: std::collections::BTreeSet<T>,
+) -> Arc<[T]> {
+    if selected.is_empty() {
+        return existing;
+    }
+    if existing.is_empty() {
+        return selected.into_iter().collect::<Vec<_>>().into();
+    }
+
+    let mut merged = Vec::with_capacity(existing.len() + selected.len());
+    let mut existing = existing.iter().peekable();
+    let mut selected = selected.into_iter().peekable();
+    loop {
+        match (existing.peek(), selected.peek()) {
+            (Some(left), Some(right)) => match (*left).cmp(right) {
+                std::cmp::Ordering::Less => {
+                    merged.push(existing.next().expect("peeked existing value").clone());
+                }
+                std::cmp::Ordering::Equal => {
+                    existing.next();
+                    merged.push(selected.next().expect("peeked selected value"));
+                }
+                std::cmp::Ordering::Greater => {
+                    merged.push(selected.next().expect("peeked selected value"));
+                }
+            },
+            (Some(_), None) => {
+                merged.extend(existing.cloned());
+                break;
+            }
+            (None, Some(_)) => {
+                merged.extend(selected);
+                break;
+            }
+            (None, None) => break,
+        }
+    }
+    merged.into()
+}
 
 /// Descriptor-only record of the exact lookup terminals consulted while
 /// analyzing one body. Pin ownership is deliberately absent: the registered
@@ -757,7 +800,7 @@ impl BodyTransaction {
     pub(crate) fn attach_provider_observations(
         mut self,
         lookup_observations: BodyLookupObservations,
-        selected_references: impl IntoIterator<Item = BodyReference>,
+        selected_references: std::collections::BTreeSet<BodyReference>,
     ) -> Self {
         match &mut self {
             Self::Success {
@@ -770,18 +813,47 @@ impl BodyTransaction {
                 lookup_observations: stored,
                 ..
             } => {
-                let mut merged = references
-                    .0
-                    .iter()
-                    .cloned()
-                    .collect::<std::collections::BTreeSet<_>>();
-                merged.extend(selected_references);
-                references.0 = merged.into_iter().collect::<Vec<_>>().into();
+                debug_assert!(
+                    references.0.windows(2).all(|pair| pair[0] < pair[1]),
+                    "body-reference summaries must be canonical before publication"
+                );
+                if !selected_references.is_empty() {
+                    let existing = std::mem::replace(&mut references.0, Arc::from([]));
+                    references.0 = merge_ordered_unique(existing, selected_references);
+                }
                 *stored = lookup_observations;
             }
             Self::Control(_) => {}
         }
         self
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::merge_ordered_unique;
+    use std::collections::BTreeSet;
+    use std::sync::Arc;
+
+    #[test]
+    fn ordered_unique_merge_handles_empty_overlap_and_interleaving() {
+        let empty = merge_ordered_unique(Arc::from([]), BTreeSet::<u8>::new());
+        assert_eq!(&*empty, &[] as &[u8]);
+
+        let selected = BTreeSet::from([1, 3, 5]);
+        assert_eq!(&*merge_ordered_unique(Arc::from([]), selected), &[1, 3, 5]);
+
+        let selected = BTreeSet::from([2, 3, 6]);
+        assert_eq!(
+            &*merge_ordered_unique(Arc::from([1, 3, 4, 7]), selected),
+            &[1, 2, 3, 4, 6, 7]
+        );
+
+        let selected = BTreeSet::new();
+        assert_eq!(
+            &*merge_ordered_unique(Arc::from([1, 2, 3]), selected),
+            &[1, 2, 3]
+        );
     }
 }
 

--- a/docs/notes/post-adr-0063-cold-compiler-architecture-audit.md
+++ b/docs/notes/post-adr-0063-cold-compiler-architecture-audit.md
@@ -894,6 +894,21 @@ to modestly faster at -0.78% paired median despite one noisy outlier. Median
 peak RSS moves +0.6 MiB, within dispersion. Every deterministic compiler-work
 counter and the emitted executable remain identical.
 
+RUE-1389 makes the body-reference publication representation explicit: every
+summary is sorted and duplicate-free. Provider publication previously rebuilt
+that canonical slice by inserting all old and newly selected references into a
+fresh ordered tree, even though both inputs were already canonical. It now
+merges the two ordered streams directly, reducing the merge from
+O((n + m) log(n + m)) ordered insertion work to O(n + m). A debug assertion
+guards the producer-side invariant at the publication boundary.
+
+Fixed one-worker Lattice saves 6,076 allocator calls and 6,508,304 requested
+bytes. Sixteen alternating ordinary-release pairs are clock-neutral on the
+loaded host: the paired median is -2.49%, but the paired MAD is 11.10% and the
+range is -27.68% to +54.74%. Median peak RSS falls by 2.4 MiB, within the wide
+run dispersion. Every deterministic compiler-work counter and the emitted
+executable remain identical.
+
 ## Next actions and decision boundary
 
 Authorized low-risk work:

--- a/scripts/validate-debug-assert-policy.py
+++ b/scripts/validate-debug-assert-policy.py
@@ -45,6 +45,9 @@ ALLOWANCES = {
     "crates/rue-air/src/sema/ordinary_engine.rs": Allowance(2, "redundant parameter-mode and ABI accounting checks"),
     "crates/rue-air/src/sema/typeck.rs": Allowance(1, "redundant parameter flag cardinality check"),
     "crates/rue-compiler/src/artifact_views.rs": Allowance(7, "redundant typed-view owner and bounds checks"),
+    "crates/rue-compiler/src/body_query.rs": Allowance(
+        1, "redundant canonical body-reference ordering check"
+    ),
     "crates/rue-compiler/src/definition_snapshot.rs": Allowance(1, "redundant definition arena identity check"),
     "crates/rue-compiler/src/diagnostic_attempt_store.rs": Allowance(2, "redundant diagnostic retention accounting"),
     "crates/rue-compiler/src/parsed_modules.rs": Allowance(1, "redundant source ownership check"),


### PR DESCRIPTION
Fixes RUE-1389.

Makes body-reference summaries explicitly sorted and duplicate-free, then merges the existing and newly selected ordered streams in O(n + m) instead of rebuilding a B-tree in O((n + m) log(n + m)). A debug assertion guards the producer-side invariant.

Fixed one-worker cold Lattice removes 6,076 allocator calls and 6,508,304 requested bytes. Sixteen alternating release pairs are clock-neutral on the loaded host (paired median -2.49%, paired MAD 11.10%); median peak RSS moves -2.4 MiB within dispersion. Every deterministic compiler-work counter and emitted byte remains identical.

Local validation: formatting, compiler clippy, focused empty/overlap/interleaving coverage, exact work-counter comparison, and byte-identical output.