### PR TITLE
RUE-1390: remove pending visited sweeps

### DIFF
--- a/crates/rue-compiler/src/revisioned_query_database.rs
+++ b/crates/rue-compiler/src/revisioned_query_database.rs
@@ -15431,7 +15431,12 @@ impl RevisionedQueryDatabase {
                         concurrency.saturating_mul(2).min(64)
                     };
                     'schedule: loop {
-                        pending.retain(|instance, _| !visited.contains(instance));
+                        // Every insertion flows through `schedule_body_instance`, which
+                        // rejects visited bodies. The deferred-producer retry is the sole
+                        // direct reinsertion and removes its body from `visited` first.
+                        // Keep that ownership invariant explicit without sweeping the
+                        // complete pending frontier before every scheduled body.
+                        debug_assert!(pending.keys().all(|instance| !visited.contains(instance)));
                         if ready_frontier.is_empty() && prefetched_transactions.is_empty() {
                             // Close the statically encoded anonymous-producer
                             // graph before selecting a ready frontier. A body

--- a/docs/notes/post-adr-0063-cold-compiler-architecture-audit.md
+++ b/docs/notes/post-adr-0063-cold-compiler-architecture-audit.md
@@ -909,6 +909,22 @@ range is -27.68% to +54.74%. Median peak RSS falls by 2.4 MiB, within the wide
 run dispersion. Every deterministic compiler-work counter and the emitted
 executable remain identical.
 
+RUE-1390 removes a redundant full-tree sweep from each body-scheduler
+iteration. All pending insertion goes through `schedule_body_instance`, which
+refuses visited bodies, while the one direct deferred-producer retry removes
+its body from `visited` before reinserting it. The scheduler now asserts that
+invariant in debug builds instead of filtering the complete pending frontier in
+release builds. This removes a potential O(iterations × pending) comparison
+path without changing scheduler order or query topology.
+
+The body-scheduler `BTreeMap::ExtractIf` leaf disappears from three follow-up
+profiles; the remaining `ExtractIf` samples belong to unrelated runtime
+retention. Thirty-two alternating ordinary-release pairs are clock-neutral at
+a -0.38% paired median, with 7.96% paired MAD on the loaded host. Median peak
+RSS moves +1.53 MiB within dispersion, and repeated allocation-instrumented
+runs are neutral. Every deterministic compiler-work counter and the emitted
+executable remain identical.
+
 ## Next actions and decision boundary
 
 Authorized low-risk work:

--- a/scripts/validate-debug-assert-policy.py
+++ b/scripts/validate-debug-assert-policy.py
@@ -52,7 +52,7 @@ ALLOWANCES = {
     "crates/rue-compiler/src/diagnostic_attempt_store.rs": Allowance(2, "redundant diagnostic retention accounting"),
     "crates/rue-compiler/src/parsed_modules.rs": Allowance(1, "redundant source ownership check"),
     "crates/rue-compiler/src/revisioned_query_database.rs": Allowance(
-        1, "redundant memo-retention accounting"
+        2, "redundant memo-retention and pending-scheduler accounting checks"
     ),
     "crates/rue-compiler/src/semantic_query_nucleus.rs": Allowance(1, "redundant semantic query category check"),
     "crates/rue-compiler/src/session.rs": Allowance(6, "redundant canonical-session phase and provenance checks"),


### PR DESCRIPTION
Fixes RUE-1390.

Removes the body scheduler's repeated full pending-map filter. All ordinary insertions already flow through the visited-aware scheduling gate, while the sole direct retry first removes its body from `visited`; a debug-only assertion now protects that invariant without release-mode sweeping.

Evidence:
- the targeted scheduler `BTreeMap::ExtractIf` leaf disappears from three follow-up cold profiles;
- every compiler-work counter and emitted output byte is unchanged;
- 32 alternating release pairs are clock-neutral (paired median -0.38%, MAD 7.96%);
- peak RSS and allocation movement remain within run-to-run noise;
- focused scheduler, anonymous-producer, toolchain-park, and specialization-depth tests pass;
- the debug-assertion policy validator passes.