### PR TITLE
RUE-1393: inline scheduler register facts

### DIFF
--- a/crates/rue-codegen/BUCK
+++ b/crates/rue-codegen/BUCK
@@ -30,6 +30,7 @@ rue_crate(
         "//crates/rue-target:rue-target",
         "//third-party:fixedbitset",
         "//third-party:lasso",
+        "//third-party:smallvec",
         "//third-party:tracing",
     ],
     test_deps = [

--- a/crates/rue-codegen/src/aarch64/regalloc.rs
+++ b/crates/rue-codegen/src/aarch64/regalloc.rs
@@ -1365,7 +1365,7 @@ impl RegAllocBackend for Aarch64Backend {
     }
 
     fn physical_operands(inst: &Self::Inst) -> Vec<Self::Reg> {
-        let mut regs = super::schedule::regs_read(inst);
+        let mut regs: Vec<_> = super::schedule::regs_read(inst).into();
         regs.extend(super::schedule::regs_written(inst));
         regs
     }

--- a/crates/rue-codegen/src/aarch64/schedule.rs
+++ b/crates/rue-codegen/src/aarch64/schedule.rs
@@ -30,7 +30,7 @@
 
 use super::mir::{Aarch64Inst, Aarch64Mir, Operand, Reg};
 use crate::reg_class::RegClass;
-use crate::schedule_core::{self, SchedulerAdapter};
+use crate::schedule_core::{self, RegList, SchedulerAdapter};
 
 struct Aarch64Scheduler;
 
@@ -54,16 +54,16 @@ impl SchedulerAdapter for Aarch64Scheduler {
         accesses_memory(inst)
     }
 
-    fn regs_read(&self, inst: &Self::Inst) -> Vec<Self::Reg> {
+    fn regs_read(&self, inst: &Self::Inst) -> RegList<Self::Reg> {
         regs_read(inst)
     }
 
-    fn regs_written(&self, inst: &Self::Inst) -> Vec<Self::Reg> {
+    fn regs_written(&self, inst: &Self::Inst) -> RegList<Self::Reg> {
         regs_written(inst)
     }
 
-    fn clobbers(&self, inst: &Self::Inst) -> Vec<Self::Reg> {
-        inst.clobbers().to_vec()
+    fn clobbers(&self, inst: &Self::Inst) -> &[Self::Reg] {
+        inst.clobbers()
     }
 
     fn writes_flags(&self, inst: &Self::Inst) -> bool {
@@ -240,12 +240,12 @@ fn accesses_memory(inst: &Aarch64Inst) -> bool {
 }
 
 /// Get registers read by an instruction (for dependency analysis).
-pub(super) fn regs_read(inst: &Aarch64Inst) -> Vec<Reg> {
-    let mut result = Vec::new();
+pub(super) fn regs_read(inst: &Aarch64Inst) -> RegList<Reg> {
+    let mut result = RegList::new();
 
-    let add_if_phys = |op: &Operand, vec: &mut Vec<Reg>| {
+    let add_if_phys = |op: &Operand, regs: &mut RegList<Reg>| {
         if let Operand::Physical(reg) = op {
-            vec.push(*reg);
+            regs.push(*reg);
         }
     };
 
@@ -369,12 +369,12 @@ pub(super) fn regs_read(inst: &Aarch64Inst) -> Vec<Reg> {
 }
 
 /// Get registers written by an instruction (for dependency analysis).
-pub(super) fn regs_written(inst: &Aarch64Inst) -> Vec<Reg> {
-    let mut result = Vec::new();
+pub(super) fn regs_written(inst: &Aarch64Inst) -> RegList<Reg> {
+    let mut result = RegList::new();
 
-    let add_if_phys = |op: &Operand, vec: &mut Vec<Reg>| {
+    let add_if_phys = |op: &Operand, regs: &mut RegList<Reg>| {
         if let Operand::Physical(reg) = op {
-            vec.push(*reg);
+            regs.push(*reg);
         }
     };
 

--- a/crates/rue-codegen/src/schedule_core.rs
+++ b/crates/rue-codegen/src/schedule_core.rs
@@ -7,8 +7,78 @@
 use std::cmp::Ordering;
 use std::collections::{BinaryHeap, HashMap};
 use std::hash::Hash;
+use std::ops::Deref;
+
+use smallvec::{IntoIter, SmallVec};
 
 use crate::reg_class::RegClass;
+
+/// Physical-register facts attached to one scheduled instruction.
+///
+/// Both MIRs name at most three read or written registers on one instruction.
+/// The hard bound prevents this transient per-instruction value from silently
+/// falling back to heap allocation if a future MIR form grows that contract.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RegList<R>(SmallVec<[R; 3]>);
+
+impl<R> RegList<R> {
+    /// Create an empty inline register list.
+    #[must_use]
+    pub fn new() -> Self {
+        Self(SmallVec::new())
+    }
+
+    /// Append one register within the audited MIR bound.
+    ///
+    /// # Panics
+    ///
+    /// Panics when one instruction exposes more than three register facts.
+    pub fn push(&mut self, reg: R) {
+        assert!(
+            self.0.len() < self.0.inline_size(),
+            "inline scheduler register-fact capacity exceeded"
+        );
+        self.0.push(reg);
+    }
+}
+
+impl<R> Default for RegList<R> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl<R> Deref for RegList<R> {
+    type Target = [R];
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl<R> IntoIterator for RegList<R> {
+    type Item = R;
+    type IntoIter = IntoIter<[R; 3]>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.0.into_iter()
+    }
+}
+
+impl<R> From<RegList<R>> for Vec<R> {
+    fn from(regs: RegList<R>) -> Self {
+        regs.0.into_vec()
+    }
+}
+
+impl<'a, R> IntoIterator for &'a RegList<R> {
+    type Item = &'a R;
+    type IntoIter = std::slice::Iter<'a, R>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.iter()
+    }
+}
 
 /// Backend-specific facts required by the shared scheduler.
 pub trait SchedulerAdapter {
@@ -37,13 +107,13 @@ pub trait SchedulerAdapter {
     fn accesses_memory(&self, inst: &Self::Inst) -> bool;
 
     /// Physical registers read by this instruction.
-    fn regs_read(&self, inst: &Self::Inst) -> Vec<Self::Reg>;
+    fn regs_read(&self, inst: &Self::Inst) -> RegList<Self::Reg>;
 
     /// Physical registers written by this instruction.
-    fn regs_written(&self, inst: &Self::Inst) -> Vec<Self::Reg>;
+    fn regs_written(&self, inst: &Self::Inst) -> RegList<Self::Reg>;
 
     /// Physical registers clobbered by this instruction.
-    fn clobbers(&self, inst: &Self::Inst) -> Vec<Self::Reg>;
+    fn clobbers(&self, inst: &Self::Inst) -> &[Self::Reg];
 
     /// Whether this instruction writes the target's condition flags.
     fn writes_flags(&self, inst: &Self::Inst) -> bool;
@@ -307,7 +377,7 @@ where
 
         let clobbers = adapter.clobbers(inst);
         // Clobber dependencies.
-        for &clobbered in &clobbers {
+        for &clobbered in clobbers {
             let class = adapter.reg_class(clobbered);
             // This instruction clobbers the register, so it must come after
             // any readers.
@@ -327,7 +397,7 @@ where
         // Update tracking. Clobbers count as writes here: a later instruction
         // that writes (WAW) or reads (RAW) a clobbered register must not be
         // scheduled above the clobberer, or the clobber destroys its value.
-        for clobbered in clobbers {
+        for &clobbered in clobbers {
             regs.record_write(adapter.reg_class(clobbered), clobbered, i);
         }
         for reg in writes {
@@ -473,6 +543,26 @@ fn schedule_block_with_work(nodes: &[SchedNode]) -> (Vec<usize>, ScheduleWork) {
 mod tests {
     use super::*;
 
+    #[test]
+    fn scheduler_register_facts_stay_inline_through_the_mir_maximum() {
+        let mut regs = RegList::new();
+        regs.push(0u8);
+        regs.push(1);
+        regs.push(2);
+
+        assert_eq!(&*regs, &[0, 1, 2]);
+        assert!(!regs.0.spilled());
+    }
+
+    #[test]
+    #[should_panic(expected = "inline scheduler register-fact capacity exceeded")]
+    fn scheduler_register_facts_fail_loudly_when_the_mir_bound_changes() {
+        let mut regs = RegList::new();
+        for reg in 0u8..4 {
+            regs.push(reg);
+        }
+    }
+
     /// A register named by class and number, so the same number can appear in
     /// two classes — the aliasing case the partitioned [`RegTracker`] rules
     /// out. No backend has such a register type yet.
@@ -508,16 +598,24 @@ mod tests {
             false
         }
 
-        fn regs_read(&self, inst: &Self::Inst) -> Vec<Self::Reg> {
-            inst.reads.clone()
+        fn regs_read(&self, inst: &Self::Inst) -> RegList<Self::Reg> {
+            let mut regs = RegList::new();
+            for &reg in &inst.reads {
+                regs.push(reg);
+            }
+            regs
         }
 
-        fn regs_written(&self, inst: &Self::Inst) -> Vec<Self::Reg> {
-            inst.writes.clone()
+        fn regs_written(&self, inst: &Self::Inst) -> RegList<Self::Reg> {
+            let mut regs = RegList::new();
+            for &reg in &inst.writes {
+                regs.push(reg);
+            }
+            regs
         }
 
-        fn clobbers(&self, _inst: &Self::Inst) -> Vec<Self::Reg> {
-            Vec::new()
+        fn clobbers(&self, _inst: &Self::Inst) -> &[Self::Reg] {
+            &[]
         }
 
         fn writes_flags(&self, _inst: &Self::Inst) -> bool {

--- a/crates/rue-codegen/src/x86_64/regalloc.rs
+++ b/crates/rue-codegen/src/x86_64/regalloc.rs
@@ -1430,7 +1430,7 @@ impl RegAllocBackend for X86Backend {
     }
 
     fn physical_operands(inst: &Self::Inst) -> Vec<Self::Reg> {
-        let mut regs = super::schedule::regs_read(inst);
+        let mut regs: Vec<_> = super::schedule::regs_read(inst).into();
         regs.extend(super::schedule::regs_written(inst));
         regs
     }

--- a/crates/rue-codegen/src/x86_64/schedule.rs
+++ b/crates/rue-codegen/src/x86_64/schedule.rs
@@ -30,7 +30,7 @@
 
 use super::mir::{Operand, Reg, X86Inst, X86Mir};
 use crate::reg_class::RegClass;
-use crate::schedule_core::{self, SchedulerAdapter};
+use crate::schedule_core::{self, RegList, SchedulerAdapter};
 
 struct X86Scheduler;
 
@@ -54,16 +54,16 @@ impl SchedulerAdapter for X86Scheduler {
         accesses_memory(inst)
     }
 
-    fn regs_read(&self, inst: &Self::Inst) -> Vec<Self::Reg> {
+    fn regs_read(&self, inst: &Self::Inst) -> RegList<Self::Reg> {
         regs_read(inst)
     }
 
-    fn regs_written(&self, inst: &Self::Inst) -> Vec<Self::Reg> {
+    fn regs_written(&self, inst: &Self::Inst) -> RegList<Self::Reg> {
         regs_written(inst)
     }
 
-    fn clobbers(&self, inst: &Self::Inst) -> Vec<Self::Reg> {
-        inst.clobbers().to_vec()
+    fn clobbers(&self, inst: &Self::Inst) -> &[Self::Reg] {
+        inst.clobbers()
     }
 
     fn writes_flags(&self, inst: &Self::Inst) -> bool {
@@ -262,12 +262,12 @@ fn accesses_memory(inst: &X86Inst) -> bool {
 }
 
 /// Get registers read by an instruction (for dependency analysis).
-pub(super) fn regs_read(inst: &X86Inst) -> Vec<Reg> {
-    let mut result = Vec::new();
+pub(super) fn regs_read(inst: &X86Inst) -> RegList<Reg> {
+    let mut result = RegList::new();
 
-    let add_if_phys = |op: &Operand, vec: &mut Vec<Reg>| {
+    let add_if_phys = |op: &Operand, regs: &mut RegList<Reg>| {
         if let Operand::Physical(reg) = op {
-            vec.push(*reg);
+            regs.push(*reg);
         }
     };
 
@@ -426,12 +426,12 @@ pub(super) fn regs_read(inst: &X86Inst) -> Vec<Reg> {
 }
 
 /// Get registers written by an instruction (for dependency analysis).
-pub(super) fn regs_written(inst: &X86Inst) -> Vec<Reg> {
-    let mut result = Vec::new();
+pub(super) fn regs_written(inst: &X86Inst) -> RegList<Reg> {
+    let mut result = RegList::new();
 
-    let add_if_phys = |op: &Operand, vec: &mut Vec<Reg>| {
+    let add_if_phys = |op: &Operand, regs: &mut RegList<Reg>| {
         if let Operand::Physical(reg) = op {
-            vec.push(*reg);
+            regs.push(*reg);
         }
     };
 

--- a/docs/notes/post-adr-0063-cold-compiler-architecture-audit.md
+++ b/docs/notes/post-adr-0063-cold-compiler-architecture-audit.md
@@ -953,6 +953,20 @@ peak RSS falls by 0.86 MiB, within dispersion. Three allocation-accounting
 comparisons are neutral, and every published compiler-work counter and emitted
 executable byte remains identical.
 
+RUE-1393 keeps the shared instruction scheduler's bounded physical-register
+facts inline. Each x86-64 and AArch64 MIR instruction reads or writes at most
+three physical registers; a shared hard-bounded list now represents those
+facts without a per-instruction heap allocation. The list panics on a fourth
+entry rather than silently spilling if MIR grows. Static clobber tables are
+borrowed directly instead of copied into another temporary vector.
+
+Three fixed one-worker Lattice probes save 462,033--462,367 allocator calls
+(2.83%) and 3.44--3.62 MiB of requested bytes. Sixteen balanced alternating
+ordinary-release pairs are clock-neutral at a -0.31% paired median, with 1.87%
+paired MAD and a -10.12% to +5.07% range. Median peak RSS moves +2.31 MiB within
+dispersion. Every published compiler-work counter and emitted executable byte
+remains identical.
+
 ## Next actions and decision boundary
 
 Authorized low-risk work:


### PR DESCRIPTION
Fixes RUE-1393.

Keep each backend scheduler’s bounded read/write register facts in a shared hard-bounded inline list and borrow static clobber tables. A fourth fact fails loudly rather than silently spilling; scheduling policy and dependency order are unchanged.

Evidence:
- three Lattice probes remove 462,033–462,367 allocations (2.83%) and 3.44–3.62 MiB requested bytes
- 16 balanced Lattice pairs are clock-neutral: -0.31% paired median, 1.87% MAD
- median RSS +2.31 MiB within dispersion
- exact compiler-work counters and emitted executable hash unchanged
- all 707 pre-existing codegen tests plus two capacity tests pass; clippy passes