### PR TITLE
RUE-1395: inline common scheduler edge lists

### DIFF
--- a/crates/rue-codegen/src/schedule_core.rs
+++ b/crates/rue-codegen/src/schedule_core.rs
@@ -13,6 +13,13 @@ use smallvec::{IntoIter, SmallVec};
 
 use crate::reg_class::RegClass;
 
+/// Dependency edges attached to one scheduled instruction.
+///
+/// Lattice's maintained AArch64 compiler workload keeps 93.6% of incoming and
+/// 88.6% of outgoing node degrees at two or fewer edges. Keep that common case
+/// in the node allocation while allowing uncommon fan-in and fan-out to spill.
+pub(crate) type EdgeList = SmallVec<[usize; 2]>;
+
 /// Physical-register facts attached to one scheduled instruction.
 ///
 /// Both MIRs name at most three read or written registers on one instruction.
@@ -181,9 +188,9 @@ impl<Reg: Copy + Eq + Hash> RegTracker<Reg> {
 #[derive(Debug)]
 pub(crate) struct SchedNode {
     /// Instructions this depends on (must execute before this).
-    pub(crate) deps: Vec<usize>,
+    pub(crate) deps: EdgeList,
     /// Instructions that depend on this (must execute after this).
-    pub(crate) users: Vec<usize>,
+    pub(crate) users: EdgeList,
     /// Scheduling priority (higher = schedule earlier).
     pub(crate) priority: u32,
     /// Latency in cycles until result is ready.
@@ -193,8 +200,8 @@ pub(crate) struct SchedNode {
 impl SchedNode {
     fn new(latency: u32) -> Self {
         Self {
-            deps: Vec::new(),
-            users: Vec::new(),
+            deps: EdgeList::new(),
+            users: EdgeList::new(),
             priority: 0,
             latency,
         }
@@ -710,8 +717,12 @@ mod tests {
 
         let nodes = build_dep_graph::<TestAdapter>(&instructions, 0, 2, &TestAdapter);
 
-        assert_eq!(nodes[1].deps, vec![0], "the reader depends on the writer");
-        assert_eq!(nodes[0].users, vec![1]);
+        assert_eq!(
+            nodes[1].deps.as_slice(),
+            [0],
+            "the reader depends on the writer"
+        );
+        assert_eq!(nodes[0].users.as_slice(), [1]);
     }
 
     #[test]
@@ -756,7 +767,7 @@ mod tests {
 
         let nodes = build_dep_graph::<TestAdapter>(&instructions, 0, 3, &TestAdapter);
 
-        assert_eq!(nodes[1].deps, vec![0]);
+        assert_eq!(nodes[1].deps.as_slice(), [0]);
         assert!(
             nodes[2].deps.is_empty(),
             "write-after-read is a per-register fact, and these are two registers"
@@ -778,8 +789,10 @@ mod tests {
         add_edge(&mut nodes, &mut last_edge_target, 1, 3);
         calculate_priorities(&mut nodes);
 
-        assert_eq!(nodes[0].users, vec![1, 2]);
-        assert_eq!(nodes[3].deps, vec![1, 2]);
+        assert_eq!(nodes[0].users.as_slice(), [1, 2]);
+        assert_eq!(nodes[3].deps.as_slice(), [1, 2]);
+        assert!(!nodes[0].users.spilled());
+        assert!(!nodes[3].deps.spilled());
         assert_eq!(
             nodes.iter().map(|node| node.priority).collect::<Vec<_>>(),
             vec![7, 5, 4, 1]
@@ -803,6 +816,7 @@ mod tests {
 
         assert_eq!(edge_count, FAN_IN, "duplicate edges are discarded once");
         assert_eq!(nodes[sink].deps.len(), FAN_IN);
+        assert!(nodes[sink].deps.spilled());
         assert_eq!(order.len(), FAN_IN + 1);
         assert_eq!(order[..FAN_IN], (0..FAN_IN).collect::<Vec<_>>());
         assert_eq!(order[FAN_IN], sink);

--- a/docs/notes/post-adr-0063-cold-compiler-architecture-audit.md
+++ b/docs/notes/post-adr-0063-cold-compiler-architecture-audit.md
@@ -981,6 +981,20 @@ ordinary-release pairs are clock-neutral on an unusually noisy host at a
 Median peak RSS moves +3.05 MiB within dispersion. Every published
 compiler-work counter and emitted executable byte remains identical.
 
+RUE-1395 keeps the common scheduler dependency-edge lists inline. A direct
+one-worker AArch64 Lattice graph-shape probe counted 11,860 scheduled blocks
+and 203,330 MIR nodes: 93.6% of incoming degrees and 88.6% of outgoing degrees
+are at most two. Each shared scheduler node now carries two inline indices for
+each direction while uncommon higher-degree lists retain the same spillable
+representation and edge-linear scheduling behavior.
+
+Three fixed one-worker allocation probes save 390,689--391,167 calls
+(2.46%) and 8.52--8.83 MiB of requested bytes. Sixteen balanced alternating
+ordinary-release pairs are clock-neutral at a +0.19% paired median, with 2.98%
+paired MAD and a -20.15% to +8.39% range on the loaded host. Median peak RSS
+falls by 0.41 MiB within dispersion. Every published compiler-work counter and
+emitted executable byte remains identical.
+
 ## Next actions and decision boundary
 
 Authorized low-risk work:


### PR DESCRIPTION
Fixes RUE-1395.

The shared scheduler now keeps up to two incoming and outgoing dependency indices inline per MIR node while retaining SmallVec spill behavior for uncommon higher-degree graphs. The DAG, priority calculation, ready queue, ordering, and asymptotic behavior are unchanged.

A direct AArch64 Lattice graph census found 93.6% of incoming degrees and 88.6% of outgoing degrees at two or fewer. Measured against RUE-1394 on fixed one-worker Lattice:
- 390,689–391,167 fewer allocations per compile (2.46%)
- 8.52–8.83 MiB less requested allocation volume
- 16 balanced release pairs are clock-neutral (+0.19% paired median)
- median peak RSS is neutral within dispersion (-0.41 MiB)
- all deterministic work counters and emitted bytes match exactly

Validation: all 711 rue-codegen tests across both backends and clippy pass. Existing degree-two and 4,096-edge fan-in tests now assert inline and spill behavior directly.