### PR TITLE
RUE-1397: use constant-time semantic import joins

### DIFF
--- a/crates/rue-air/src/semantic_import.rs
+++ b/crates/rue-air/src/semantic_import.rs
@@ -9,6 +9,7 @@ use std::collections::{BTreeMap, HashMap};
 use std::hash::Hash;
 use std::sync::Arc;
 
+use ahash::AHashMap;
 use lasso::{Spur, ThreadedRodeo};
 use rue_span::FileId;
 
@@ -592,17 +593,19 @@ enum LocalNominal {
 
 /// A fresh AIR-owned interning epoch joined to caller-owned stable keys.
 ///
-/// Stable keys never become AIR IDs. The boundary retains deterministic
-/// stable-to-local maps for import and local-to-stable indexes for export.
-/// Imported types and constants are returned through opaque, epoch-branded
-/// wrappers, so request-local IDs cannot cross epoch boundaries.
+/// Stable keys never become AIR IDs. Constructors sort exact facts before
+/// minting any local ID or symbol; that ordered input, not map iteration,
+/// defines the deterministic allocation order. The nominal and callable maps
+/// are independently keyed exact-lookup joins, while local-to-stable indexes
+/// support export. Imported types and constants are returned through opaque,
+/// epoch-branded wrappers, so request-local IDs cannot cross epoch boundaries.
 pub struct SemanticImportEpoch<K: Ord, M: Ord> {
     epoch: Arc<()>,
     interner: ThreadedRodeo,
     type_pool: TypeInternPool,
     module_registry: ModuleRegistry,
-    nominals: BTreeMap<NominalInstanceKey<K, M>, LocalNominal>,
-    functions: BTreeMap<FunctionInstanceKey<K, M>, Spur>,
+    nominals: AHashMap<NominalInstanceKey<K, M>, LocalNominal>,
+    functions: AHashMap<FunctionInstanceKey<K, M>, Spur>,
     modules: BTreeMap<M, ModuleId>,
     builtins: BTreeMap<(Arc<str>, SemanticImportNominalKind), LocalNominal>,
     nominal_exports: HashMap<LocalNominal, NominalInstanceKey<K, M>>,
@@ -614,8 +617,8 @@ pub struct SemanticImportEpoch<K: Ord, M: Ord> {
 
 impl<K, M> SemanticImportEpoch<K, M>
 where
-    K: Clone + Ord,
-    M: Clone + Ord,
+    K: Clone + Ord + Hash,
+    M: Clone + Ord + Hash,
 {
     fn rebuild_export_indexes(&mut self) {
         self.nominal_exports = self
@@ -1200,7 +1203,7 @@ where
             modules.insert(key, id);
         }
 
-        let mut functions = BTreeMap::new();
+        let mut functions = AHashMap::with_capacity(function_keys.len());
         let mut function_identities = std::collections::BTreeSet::new();
         for (key, name) in function_keys {
             if !function_identities.insert(name.clone()) {
@@ -1228,7 +1231,7 @@ where
                 .map(|(path, file_id)| (*file_id, path.to_string()))
                 .collect(),
         );
-        let mut local = BTreeMap::new();
+        let mut local = AHashMap::with_capacity(nominals.len());
         let mut local_identities = std::collections::BTreeSet::new();
         for nominal in nominals {
             if local.contains_key(&NominalInstanceKey::Named(nominal.key.clone())) {
@@ -1368,6 +1371,8 @@ where
             return Err(SemanticImportFailure::DuplicateModule);
         }
         let mut epoch = Self::new(Vec::new(), Vec::new(), modules)?;
+        epoch.functions.reserve(callables.len());
+        epoch.nominals.reserve(nominals.len());
 
         let mut callable_symbols = std::collections::BTreeSet::new();
         for callable in &callables {

--- a/docs/notes/post-adr-0063-cold-compiler-architecture-audit.md
+++ b/docs/notes/post-adr-0063-cold-compiler-architecture-audit.md
@@ -995,6 +995,23 @@ paired MAD and a -20.15% to +8.39% range on the loaded host. Median peak RSS
 falls by 0.41 MiB within dispersion. Every published compiler-work counter and
 emitted executable byte remains identical.
 
+RUE-1397 narrows the remaining durable-key comparison leaf in body-local
+semantic materialization. `SemanticImportEpoch` already sorts exact nominal
+and callable facts before assigning local IDs, but then stored those two
+stable-to-local joins in ordered trees used only for lookup. Independently
+keyed, pre-sized AHash maps now provide expected constant-time joins; sorted
+input remains the sole authority for deterministic local ID and symbol order.
+Small builtin/module registries and compact reverse joins remain unchanged.
+
+Three fixed one-worker allocation probes save 4,582--4,994 calls and
+1.55--1.79 MiB of requested bytes. Sixteen balanced alternating
+ordinary-release pairs are clock-neutral at a +0.50% paired median, with 3.31%
+paired MAD and a -18.33% to +11.91% range on the loaded host. Median peak RSS
+falls by 6.54 MiB, within dispersion. Across three follow-up profiles,
+`StableDefinitionKey::cmp` falls from 17/17/8 top-of-stack samples to 5/0/0.
+Every published compiler-work counter and emitted executable byte remains
+identical.
+
 ## Next actions and decision boundary
 
 Authorized low-risk work:


### PR DESCRIPTION
Fixes RUE-1397.

The semantic import epoch already sorts exact nominal and callable facts before assigning local IDs. Store those two stable-to-local joins in pre-sized AHash maps so repeated body-local lookup is expected O(1), while sorted input remains the sole ordering authority. Small builtin/module maps and compact reverse joins remain unchanged.

Measured on one-worker Lattice against RUE-1395:
- saves 4,582–4,994 allocations and 1.55–1.79 MiB requested bytes
- clock-neutral: +0.50% paired median, 3.31% MAD across 16 balanced pairs
- median peak RSS improves by 6.54 MiB
- StableDefinitionKey comparison leaf falls from 17/17/8 samples to 5/0/0
- compiler-work counters and emitted output are exact

Validation: all 723 rue-air tests and its clippy gate pass. The broader quick run passed the relevant compiler, CFG, codegen, oracle, and policy checks before an unrelated cache-upload action stopped making progress; CI is the full authority.