### PR TITLE
RUE-1400: reuse scheduler register maps across blocks

### DIFF
--- a/crates/rue-codegen/src/schedule_core.rs
+++ b/crates/rue-codegen/src/schedule_core.rs
@@ -164,6 +164,16 @@ impl<Reg: Copy + Eq + Hash> RegTracker<Reg> {
         }
     }
 
+    /// Forget one block's facts while retaining the maps' backing storage.
+    fn clear(&mut self) {
+        for writers in &mut self.last_writer {
+            writers.clear();
+        }
+        for readers in &mut self.last_readers {
+            readers.clear();
+        }
+    }
+
     /// The instruction that last wrote or clobbered `reg`, if any.
     fn last_writer(&self, class: RegClass, reg: &Reg) -> Option<usize> {
         self.last_writer[class.index()].get(reg).copied()
@@ -257,6 +267,7 @@ where
     // MIR instruction into a second full-width vector.
     let mut destination = (0..instructions.len()).collect::<Vec<_>>();
     let mut block_start = 0;
+    let mut regs = RegTracker::new();
 
     for block_end in 0..instructions.len() {
         if !adapter.is_barrier(&instructions[block_end]) {
@@ -269,6 +280,7 @@ where
             block_start,
             block_end,
             &mut destination,
+            &mut regs,
         );
         block_start = block_end + 1;
     }
@@ -280,6 +292,7 @@ where
             block_start,
             instructions.len(),
             &mut destination,
+            &mut regs,
         );
     }
 
@@ -293,6 +306,7 @@ fn record_block_permutation<A>(
     start: usize,
     sched_end: usize,
     destination: &mut [usize],
+    regs: &mut RegTracker<A::Reg>,
 ) where
     A: SchedulerAdapter,
 {
@@ -300,7 +314,7 @@ fn record_block_permutation<A>(
         return;
     }
 
-    let mut nodes = build_dep_graph(instructions, start, sched_end, adapter);
+    let mut nodes = build_dep_graph_reusing(instructions, start, sched_end, adapter, regs);
     calculate_priorities(&mut nodes);
     let order = schedule_block(&nodes);
 
@@ -334,11 +348,25 @@ fn apply_permutation<T>(items: &mut [T], destination: &mut [usize]) {
 }
 
 /// Build the dependency graph for a basic block of instructions.
+#[cfg(test)]
 pub(crate) fn build_dep_graph<A>(
     instructions: &[A::Inst],
     start: usize,
     end: usize,
     adapter: &A,
+) -> Vec<SchedNode>
+where
+    A: SchedulerAdapter,
+{
+    build_dep_graph_reusing(instructions, start, end, adapter, &mut RegTracker::new())
+}
+
+fn build_dep_graph_reusing<A>(
+    instructions: &[A::Inst],
+    start: usize,
+    end: usize,
+    adapter: &A,
+    regs: &mut RegTracker<A::Reg>,
 ) -> Vec<SchedNode>
 where
     A: SchedulerAdapter,
@@ -355,8 +383,8 @@ where
     let mut last_edge_target = vec![usize::MAX; block_len];
 
     // Track the last writer and the readers since that write, per register
-    // class (see `RegTracker`).
-    let mut regs: RegTracker<A::Reg> = RegTracker::new();
+    // class (see `RegTracker`). Retain map capacity across blocks in one MIR.
+    regs.clear();
     // Track last memory access (conservative).
     let mut last_memory_access: Option<usize> = None;
     // Track last FLAGS writer and readers.
@@ -758,6 +786,19 @@ mod tests {
             instructions.iter().map(|inst| inst.id).collect::<Vec<_>>(),
             vec![90, 91, 2, 1, 0, 99]
         );
+    }
+
+    #[test]
+    fn reused_register_tracker_does_not_carry_dependencies_between_blocks() {
+        let gp0 = ClassedReg(RegClass::Gp, 0);
+        let instructions = vec![inst(&[], &[gp0]), inst(&[gp0], &[])];
+        let mut tracker = RegTracker::new();
+
+        let first = build_dep_graph_reusing(&instructions, 0, 1, &TestAdapter, &mut tracker);
+        let second = build_dep_graph_reusing(&instructions, 1, 2, &TestAdapter, &mut tracker);
+
+        assert!(first[0].deps.is_empty());
+        assert!(second[0].deps.is_empty());
     }
 
     #[test]

--- a/docs/notes/post-adr-0063-cold-compiler-architecture-audit.md
+++ b/docs/notes/post-adr-0063-cold-compiler-architecture-audit.md
@@ -1040,6 +1040,19 @@ paired MAD and a -3.71% to +9.47% range. Median peak RSS falls by 0.73 MiB
 within dispersion. Every published compiler-work counter and emitted
 executable byte remains identical.
 
+RUE-1400 reuses the instruction scheduler's per-register map storage across
+basic blocks in one function. Each dependency graph still clears every writer
+and reader fact before inspecting a block, so no dependency crosses a control-
+flow barrier; only the hash-table allocation survives for the next block. The
+test-only graph adapter retains its fresh-tracker behavior.
+
+Three fixed one-worker allocation probes save 39,285--39,441 calls and
+7.96--8.11 MiB of requested bytes. Sixteen balanced alternating
+ordinary-release pairs are clock-neutral at a -0.21% paired median, with 1.25%
+paired MAD and a -11.30% to +12.37% range. Median peak RSS falls by 2.01 MiB
+within dispersion. Every published compiler-work counter and emitted
+executable byte remains identical.
+
 ## Next actions and decision boundary
 
 Authorized low-risk work:


### PR DESCRIPTION
## Summary

- retain the instruction scheduler's per-register hash-table storage across basic blocks in one function
- clear every writer and reader fact at each block boundary so dependencies cannot cross control-flow barriers
- add a focused regression for tracker reuse across blocks
- record the allocation and release evidence in the cold-compiler architecture audit

## Performance evidence

Against merged RUE-1399 on the fixed one-worker Lattice workload:

- three allocation probes save 39,285–39,441 allocator calls
- requested allocation traffic falls by 7.96–8.11 MiB
- 16 balanced release pairs are clock-neutral at -0.21% paired median (1.25% MAD; -11.30% to +12.37% range)
- median peak RSS falls by 2.01 MiB within run dispersion
- every compiler-work counter and emitted executable byte matches exactly

## Validation

- 714/714 `rue-codegen` tests pass
- formatting passes
- output SHA-256: `63a5895595a928bda79fd4eeb314a4056a0017d1b068045a917743667645e42a`

Fixes RUE-1400.