### PR TITLE
Spec: carve the stack-overflow SIGSEGV handler out of 8.5's no-handlers claim

### DIFF
--- a/docs/spec/src/08-runtime-behavior/05-signal-termination.md
+++ b/docs/spec/src/08-runtime-behavior/05-signal-termination.md
@@ -12,10 +12,32 @@ The traps of the preceding sections (overflow, division by zero, out-of-bounds
 indexing) end a program *from inside* with the panic exit code 101. A program
 may also be ended *from outside* the language's control flow when the host
 operating system delivers a **signal** whose default disposition is to terminate
-the process. Rue installs no signal handlers, so such signals keep their
-platform-default behavior. This section describes the observable exit status in
-that case; because the trigger is external to the language, these paragraphs are
-informative rather than normative.
+the process. Rue installs one signal handler and no others: `SIGSEGV` is caught
+so that a stack overflow becomes a clean abort (8.5:6), and every other signal
+keeps its platform-default behavior. This section describes the observable exit
+status in that case; because the trigger is external to the language, these
+paragraphs are informative rather than normative.
+
+{{ rule(id="8.5:6", cat="informative") }}
+
+The `SIGSEGV` carve-out exists because exhausting the stack is not really an
+external event: unbounded recursion, or a frame larger than the space that
+remains, faults on the operating system's guard page, and the default
+disposition would kill the process with the raw crash status `139`
+(`128 + SIGSEGV`, per 8.5:2) and no explanation. Before user code runs, the
+runtime instead
+installs a `SIGSEGV` handler on an alternate signal stack — so the handler can
+run even though the main stack is the thing that overflowed — which writes
+`stack overflow` to standard error and exits with the panic exit code `101`,
+the same code the traps of the preceding sections use. Any `SIGSEGV` is reported
+this way: in safe Rue a blown stack is the only way to raise one, because
+indexing is bounds-checked, there are no raw-pointer dereferences, and
+arithmetic traps rather than corrupting memory. A `SIGSEGV` raised from
+`checked` code (chapter 9), where those guarantees do not hold, is undefined
+behavior under B.3 and is reported the same way regardless of its cause.
+Installing the handler is best-effort: on a host where the alternate stack or
+the handler registration is unavailable, the program keeps the default
+`SIGSEGV` disposition and exits with `139` as described above.
 
 {{ rule(id="8.5:2", cat="informative") }}
 


### PR DESCRIPTION
Section 8.5 said "Rue installs no signal handlers, so such signals keep their platform-default behavior", but the runtime installs a `SIGSEGV` handler before user code runs (`crates/rue-runtime/src/entry.rs`, `sigaltstack` + `SA_ONSTACK`, called from every entry point) so a blown stack aborts with `stack overflow` and exit 101 instead of dying with a raw `SIGSEGV` (exit 139).

## Changes

- **8.5:1** now states that Rue installs exactly one handler — `SIGSEGV`, so a stack overflow becomes a clean abort — with every other signal keeping its platform default. The rest of the paragraph is unchanged.
- **New 8.5:6** documents the conversion the carve-out refers to: the guard-page fault, why the handler needs an alternate signal stack (it cannot run on the stack that overflowed), the `stack overflow` message and exit 101, why *any* `SIGSEGV` is reported as a stack overflow (safe Rue is bounds-checked, has no raw-pointer dereferences, and traps on arithmetic; `checked` code that breaks those premises is undefined behavior under B.3), and that installation is best-effort — a host where the alternate stack or the registration is unavailable keeps the default 139 disposition.

That last sentence is also what covers the aarch64-macos no-op, without hardcoding a per-platform implementation gap into the spec.

## Notes

- The issue describes the carve-out as something "the same chapter's stack-overflow behavior depends on", but chapter 8 had no stack-overflow paragraph at all — the behavior was undocumented spec-wide. Hence a new paragraph rather than only an edited sentence.
- Numbered **8.5:6**, not inserted as 8.5:2. Rule IDs here are stable: new paragraphs take the next free number and sit at the topically right position (4.5 runs `1,2,3,7,4,5,6`), so renumbering 8.5:2–5 would have been off-convention.

## Testing

Spec prose only — no code or behavior change. The described behavior is already pinned by the `cli.stack_overflow` case (`stack overflow` on stderr, exit 101, `only_on` the two Linux targets).

No test or doc cites an 8.5 rule ID, and every 8.5 paragraph is informative, so nothing else needed updating. Verified all 1223 rule IDs across the spec still parse with no duplicates (duplicates fail the traceability gate) and that `informative` is an accepted category. The Buck2 suites were not run locally: `dotslash` is not installed in this container, so `./buck2` fails at startup. CI is the authority here.

Fixes RUE-1370. Refs RUE-707.

---
_Generated by [Claude Code](https://claude.ai/code/session_01PDzTS29Z3B5PwtAKPcLGGb)_