### PR TITLE
Gate @syscall behind checked blocks

### DIFF
--- a/crates/rue-air/src/sema/analysis/intrinsics.rs
+++ b/crates/rue-air/src/sema/analysis/intrinsics.rs
@@ -247,14 +247,13 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
             .collect();
         let known = &self.known_symbols();
 
-        // Raw-pointer and heap intrinsics are unchecked operations: they may
-        // only be used inside a `checked` block (spec 9.1:1, chapter 9). Gate
-        // them before the per-intrinsic dispatch so every one shares a single
-        // diagnostic. `@syscall` has its own gating; the set here is
-        // @raw/@raw_mut/@field_ptr/@ptr_read/@ptr_write/@ptr_offset/
-        // @ptr_to_int/@int_to_ptr plus the unified byte allocation family
-        // @alloc/@alloc_zeroed/@free/@realloc/@resize (RUE-1, RUE-301,
-        // ADR-0059 Phase 3).
+        // Raw-pointer, heap, and syscall intrinsics are unchecked operations:
+        // they may only be used inside a `checked` block (spec 9.1:1, chapter
+        // 9). Gate them before the per-intrinsic dispatch so every one shares a
+        // single diagnostic. The set is @raw/@raw_mut/@field_ptr/@ptr_read/
+        // @ptr_write/@ptr_offset/@ptr_to_int/@int_to_ptr, the unified byte
+        // allocation family @alloc/@alloc_zeroed/@free/@realloc/@resize, and
+        // @syscall (RUE-1, RUE-301, RUE-1369, ADR-0059 Phase 3).
         if ctx.checked_depth == 0
             && (name == known.ptr_read
                 || name == known.ptr_write
@@ -275,7 +274,8 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
                 || name == known.byte_move
                 || name == known.byte_set
                 || name == known.arg_ptr
-                || name == known.env_ptr)
+                || name == known.env_ptr
+                || name == known.syscall)
         {
             let intrinsic_name_str = self.body_interner().resolve(&name);
             let kind = if name == known.alloc
@@ -285,6 +285,8 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
                 || name == known.resize
             {
                 "heap"
+            } else if name == known.syscall {
+                "syscall"
             } else {
                 "raw-pointer"
             };

--- a/crates/rue-air/src/sema/analysis/pointers.rs
+++ b/crates/rue-air/src/sema/analysis/pointers.rs
@@ -874,7 +874,10 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
     ///
     /// Takes a syscall number and up to 6 arguments, all of which must be u64.
     /// Returns i64 (the syscall return value, which may be negative for errors).
-    /// Requires a checked block.
+    ///
+    /// `@syscall` is an unchecked operation (spec 9.2:3a): the shared
+    /// checked-block gate in `analyze_intrinsic_impl` rejects it outside a
+    /// `checked` block before this analysis runs.
     pub(super) fn analyze_syscall_intrinsic(
         &mut self,
         air: &mut Air,

--- a/crates/rue-cli-tests/cases/intrinsic_args.toml
+++ b/crates/rue-cli-tests/cases/intrinsic_args.toml
@@ -5,6 +5,11 @@
 # into the wrong syscall register and compiling cleanly — a silent
 # miscompile (RUE-130 item 8). The type argument is now lowered to a
 # placeholder so Sema reports a proper type error instead.
+#
+# The `@syscall` cases sit inside `checked` blocks because `@syscall` is an
+# unchecked operation (spec 9.2:3a, RUE-1369); without the block the shared
+# checked-block gate would fire first and hide the argument diagnostic under
+# test.
 
 [section]
 id = "cli.intrinsic_args"
@@ -20,7 +25,9 @@ files = [
 fn main() -> i32 {
     let a: u64 = 60;
     let b: u64 = 7;
-    let r = @syscall(a, (), b);
+    checked {
+        let r = @syscall(a, (), b);
+    };
     0
 }
 """ },
@@ -35,7 +42,9 @@ files = [
     { path = "main.rue", source = """
 fn main() -> i32 {
     let a: u64 = 60;
-    let r = @syscall(a, i32);
+    checked {
+        let r = @syscall(a, i32);
+    };
     0
 }
 """ },

--- a/crates/rue-spec/cases/runtime/syscall.toml
+++ b/crates/rue-spec/cases/runtime/syscall.toml
@@ -90,6 +90,38 @@ fn main() -> i32 {
 compile_fail = true
 error_contains = "expects 7 arguments"
 
+# @syscall outside a `checked` block is a compile error (RUE-1369): the
+# intrinsic was excluded from the shared checked-block gate and compiled
+# anywhere, even though 9.2 has always described it as unchecked.
+[[case]]
+name = "syscall_outside_checked_rejected"
+spec = ["9.2:3a"]
+source = """
+fn main() -> i32 {
+    let syscall_num: u64 = 39;
+    @syscall(syscall_num);
+    0
+}
+"""
+compile_fail = true
+error_contains = "requires a `checked` block"
+
+# The same call inside a `checked` block is legal. Compile-only: the point is
+# the gate, and every executable syscall number is platform-specific.
+[[case]]
+name = "syscall_in_checked_accepted"
+spec = ["9.2:3a"]
+compile_only = true
+source = """
+fn main() -> i32 {
+    let syscall_num: u64 = 39;
+    checked {
+        @syscall(syscall_num);
+    };
+    0
+}
+"""
+
 # Test that @syscall accepts up to 7 arguments
 [[case]]
 name = "syscall_max_args"

--- a/crates/rue-ui-tests/cases/diagnostics/unchecked_syscall.toml
+++ b/crates/rue-ui-tests/cases/diagnostics/unchecked_syscall.toml
@@ -1,0 +1,64 @@
+[section]
+id = "diagnostics.unchecked-syscall"
+name = "@syscall outside a `checked` block reports the unchecked-operation error"
+description = """
+`@syscall` is an unchecked operation (spec 9.2:3a, 9.1:12), but it was excluded
+from the shared checked-block gate in semantic analysis and compiled anywhere —
+only its doc comment and §9.2's prose claimed the requirement (RUE-1369). It now
+reports E1300 like the raw-pointer and allocation intrinsics, with the same
+`checked { ... }` help.
+"""
+
+[[case]]
+name = "syscall_outside_checked_is_e1300"
+description = "A bare @syscall reports E1300 naming the intrinsic, plus the wrap-in-checked help."
+source = """
+fn main() -> i32 {
+    let syscall_num: u64 = 39;
+    @syscall(syscall_num);
+    0
+}
+"""
+compile_fail = true
+error_contains = [
+    "E1300",
+    "syscall intrinsic `@syscall` requires a `checked` block",
+    "wrap the operation in a `checked { ... }` block",
+]
+
+# An `unchecked fn` body is not itself a checked context (9.1:1): it marks the
+# CALL as requiring `checked`, so unchecked operations inside still need their
+# own block.
+[[case]]
+name = "syscall_in_unchecked_fn_body_still_needs_checked"
+description = "An `unchecked fn` body does not lift the gate; @syscall there still reports E1300."
+source = """
+unchecked fn raw_exit(code: u64) -> i64 {
+    let syscall_num: u64 = 39;
+    @syscall(syscall_num, code)
+}
+
+fn main() -> i32 {
+    checked { raw_exit(0); };
+    0
+}
+"""
+compile_fail = true
+error_contains = [
+    "E1300",
+    "syscall intrinsic `@syscall` requires a `checked` block",
+]
+
+[[case]]
+name = "syscall_inside_checked_compiles"
+description = "The same call inside a `checked` block compiles."
+source = """
+fn main() -> i32 {
+    let syscall_num: u64 = 39;
+    checked {
+        @syscall(syscall_num);
+    };
+    0
+}
+"""
+compile_only = true

--- a/docs/spec/src/09-unchecked-code/01-syntax.md
+++ b/docs/spec/src/09-unchecked-code/01-syntax.md
@@ -103,9 +103,10 @@ A raw-pointer intrinsic — `@raw`, `@raw_mut`, `@field_ptr`, `@ptr_read`,
 within a `checked` block. Using one outside a `checked` block is a compile
 error. (Defining a `ptr const T` / `ptr mut T` value's *type* is always legal;
 only the pointer *operations* require a `checked` block.) The same requirement
-applies to the allocation family (9.2:13) and the raw-byte intrinsics
-(9.2:14h, 9.2:14l). Byte-granular access has no intrinsic of its own: it is
-`@ptr_read`/`@ptr_write` over a `ptr u8` (9.2:6d), already listed above.
+applies to the allocation family (9.2:13), the raw-byte intrinsics
+(9.2:14h, 9.2:14l), and `@syscall` (9.2:3a). Byte-granular access has no
+intrinsic of its own: it is `@ptr_read`/`@ptr_write` over a `ptr u8` (9.2:6d),
+already listed above.
 
 {{ rule(id="9.1:13", cat="example") }}
 

--- a/docs/spec/src/09-unchecked-code/02-intrinsics.md
+++ b/docs/spec/src/09-unchecked-code/02-intrinsics.md
@@ -26,6 +26,11 @@ argument = expression ;
 
 The `@syscall` intrinsic takes at least one argument (the syscall number) and at most seven arguments (syscall number plus six syscall arguments). All arguments must be of type `u64`.
 
+{{ rule(id="9.2:3a", cat="legality-rule") }}
+
+`@syscall` is an unchecked operation and **MUST** appear within a `checked`
+block (§9.1, 9.1:12). Using it outside a `checked` block is a compile error.
+
 {{ rule(id="9.2:4", cat="dynamic-semantics") }}
 
 The `@syscall` intrinsic returns an `i64` value representing the result of the


### PR DESCRIPTION
Fixes RUE-1369.

`@syscall` was excluded from the shared checked-block gate in semantic analysis, so it compiled anywhere. Both the §4.13 intrinsic table ("Unchecked intrinsics — only valid inside a `checked` block") and §9.2's prose already described it as unchecked; only `analyze_syscall_intrinsic`'s doc comment claimed the requirement, with nothing enforcing it. The legality rule that enumerates the gated intrinsics (9.1:12) omitted it too, and no case asserted the diagnostic.

## Compiler

`@syscall` joins the shared gate in `analyze_intrinsic_impl` rather than getting a second gate inside `analyze_syscall_intrinsic`, so it reports through the one canonical path with the same wrap-in-`checked` help as the raw-pointer and allocation intrinsics:

```
error[E1300]: syscall intrinsic `@syscall` requires a `checked` block
help: wrap the operation in a `checked { ... }` block
```

The stale "`@syscall` has its own gating" comment and the unenforced "Requires a checked block" doc line are gone.

## Spec

New legality rule 9.2:3a, placed with the other `@syscall` rules: `@syscall` is not a raw-pointer intrinsic, so it does not belong inside 9.1:12's enumeration. 9.1:12 now cross-references it alongside the allocation family (9.2:13) and the raw-byte intrinsics (9.2:14h, 9.2:14l). The §4.13 table needed no change — the compiler was the outlier.

## Coverage

- Spec: `syscall_outside_checked_rejected` and `syscall_in_checked_accepted`, both citing 9.2:3a. The accepted case is `compile_only` because every executable syscall number is platform-specific and the point is the gate.
- UI: `diagnostics/unchecked_syscall.toml` pins the diagnostic text, including that an `unchecked fn` body is not itself a checked context — it marks the *call* as requiring `checked`, so unchecked operations in its body still need their own block.

## Fallout

The two `cli.intrinsic_args` cases probing stray type arguments (`@syscall(a, (), b)`, `@syscall(a, i32)`) called `@syscall` bare, so the new gate fired before their E0702 argument diagnostic. They are wrapped in `checked` now, with the reason in the file header; they still test what they were written to test.

## Verification

`scripts/rue spec` (2335 passed), `scripts/rue ui` (248), `scripts/rue cli` (1848), `scripts/rue quick` (31), `//:spec-traceability` (legality-rule coverage 100%, 156/156), `//:repository-quality-gates`, and the rue-air fmt-check and clippy gates — all green locally on x86-64 Linux.

---
_Generated by [Claude Code](https://claude.ai/code/session_015M58xCKk7oc2VpD3SZgi21)_