### PR TITLE
RUE-1411: share body query display identities

### DIFF
--- a/crates/rue-compiler/src/body_query.rs
+++ b/crates/rue-compiler/src/body_query.rs
@@ -1,6 +1,11 @@
 //! Stable per-body query values and independently stamped projections.
 
-use std::sync::Arc;
+use std::{
+    fmt,
+    hash::{Hash, Hasher},
+    ops::Deref,
+    sync::{Arc, OnceLock},
+};
 
 use rue_query::QueryKey;
 
@@ -155,15 +160,82 @@ pub(crate) fn body_input_equal(left: &BodyInputValue, right: &BodyInputValue) ->
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
-pub(crate) struct BodyQueryKey {
+pub(crate) struct BodyQueryKeyData {
     pub(crate) instance: crate::FunctionInstanceKey,
     pub(crate) configuration: crate::semantic_query_nucleus::SemanticQueryConfiguration,
+    display_identity: OnceLock<Arc<str>>,
+}
+
+/// One immutable body identity shared by its independently stamped query
+/// projections.
+///
+/// Body analysis deliberately carries the same key through several families.
+/// Keeping the payload behind one `Arc` makes those clones constant-size and
+/// lets every memo node share the diagnostic identity formatted on the first
+/// family miss.
+#[derive(Clone)]
+pub(crate) struct BodyQueryKey(Arc<BodyQueryKeyData>);
+
+impl BodyQueryKey {
+    pub(crate) fn new(
+        instance: crate::FunctionInstanceKey,
+        configuration: crate::semantic_query_nucleus::SemanticQueryConfiguration,
+    ) -> Self {
+        Self(Arc::new(BodyQueryKeyData {
+            instance,
+            configuration,
+            display_identity: OnceLock::new(),
+        }))
+    }
+
+    fn format_identity(&self) -> String {
+        format!("{:?}:{:?}", self.instance, self.configuration)
+    }
+}
+
+impl Deref for BodyQueryKey {
+    type Target = BodyQueryKeyData;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl fmt::Debug for BodyQueryKey {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("BodyQueryKey")
+            .field("instance", &self.instance)
+            .field("configuration", &self.configuration)
+            .finish()
+    }
+}
+
+impl PartialEq for BodyQueryKey {
+    fn eq(&self, other: &Self) -> bool {
+        Arc::ptr_eq(&self.0, &other.0)
+            || (self.instance == other.instance && self.configuration == other.configuration)
+    }
+}
+
+impl Eq for BodyQueryKey {}
+
+impl Hash for BodyQueryKey {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.instance.hash(state);
+        self.configuration.hash(state);
+    }
 }
 
 impl QueryKey for BodyQueryKey {
     fn stable_identity(&self) -> String {
-        format!("{:?}:{:?}", self.instance, self.configuration)
+        self.format_identity()
+    }
+
+    fn shared_stable_identity(&self) -> Arc<str> {
+        self.display_identity
+            .get_or_init(|| self.format_identity().into())
+            .clone()
     }
 }
 
@@ -831,9 +903,32 @@ impl BodyTransaction {
 
 #[cfg(test)]
 mod tests {
-    use super::merge_ordered_unique;
+    use super::{BodyQueryKey, merge_ordered_unique};
     use std::collections::BTreeSet;
     use std::sync::Arc;
+
+    use rue_query::QueryKey;
+
+    #[test]
+    fn cloned_body_keys_share_one_lazy_display_identity() {
+        let key = BodyQueryKey::new(
+            crate::FunctionInstanceKey::DropGlue(Box::new(crate::TypeInstanceKey::I64)),
+            crate::semantic_query_nucleus::SemanticQueryConfiguration {
+                target: rue_target::Target::X86_64Linux,
+                preview_features: crate::StablePreviewFeatures::new(
+                    &crate::PreviewFeatures::default(),
+                ),
+            },
+        );
+        let cloned = key.clone();
+        assert!(key.display_identity.get().is_none());
+
+        let first = key.shared_stable_identity();
+        let second = cloned.shared_stable_identity();
+
+        assert!(Arc::ptr_eq(&first, &second));
+        assert_eq!(first.as_ref(), key.stable_identity());
+    }
 
     #[test]
     fn ordered_unique_merge_handles_empty_overlap_and_interleaving() {

--- a/crates/rue-compiler/src/revisioned_query_database.rs
+++ b/crates/rue-compiler/src/revisioned_query_database.rs
@@ -3802,10 +3802,7 @@ fn closure_callable_has_body(
     }
     let terminal = context.query_registered(
         body_inputs,
-        crate::body_query::BodyQueryKey {
-            instance: callable.clone(),
-            configuration: configuration.clone(),
-        },
+        crate::body_query::BodyQueryKey::new(callable.clone(), configuration.clone()),
     )?;
     let rue_query::QueryOutcome::Success(value) = terminal.outcome() else {
         unreachable!("BodyInput publishes typed values")
@@ -4806,10 +4803,7 @@ fn query_anonymous_nominal(
     };
     let produced = context.query_registered(
         body_produced_anonymous,
-        crate::body_query::BodyQueryKey {
-            instance: producer.as_ref().clone(),
-            configuration: configuration.clone(),
-        },
+        crate::body_query::BodyQueryKey::new(producer.as_ref().clone(), configuration.clone()),
     )?;
     let rue_query::QueryOutcome::Success(produced) = produced.outcome() else {
         unreachable!("BodyProducedAnonymous publishes typed values")
@@ -14341,13 +14335,10 @@ impl RevisionedQueryDatabase {
                                     } else {
                                         let producer = context.query_registered(
                                             &produced_anonymous_for_semantic_nucleus,
-                                            crate::body_query::BodyQueryKey {
-                                                instance: (**function).clone(),
-                                                configuration: query
-                                                    .producer
-                                                    .configuration
-                                                    .clone(),
-                                            },
+                                            crate::body_query::BodyQueryKey::new(
+                                                (**function).clone(),
+                                                query.producer.configuration.clone(),
+                                            ),
                                         )?;
                                         let rue_query::QueryOutcome::Success(producer) =
                                             producer.outcome()
@@ -15562,9 +15553,11 @@ impl RevisionedQueryDatabase {
                                 .collect::<Vec<_>>();
                             let frontier_keys = instances
                                 .iter()
-                                .map(|instance| crate::body_query::BodyQueryKey {
-                                    instance: instance.as_ref().clone(),
-                                    configuration: key.configuration.clone(),
+                                .map(|instance| {
+                                    crate::body_query::BodyQueryKey::new(
+                                        instance.as_ref().clone(),
+                                        key.configuration.clone(),
+                                    )
                                 })
                                 .collect::<Vec<_>>();
                             let demands = context.query_registered_batch(
@@ -15597,10 +15590,10 @@ impl RevisionedQueryDatabase {
                                 {
                                     let remaining_demand = context.query_registered(
                                         &toolchain_for_body_closure,
-                                        crate::body_query::BodyQueryKey {
-                                            instance: remaining_instance.as_ref().clone(),
-                                            configuration: key.configuration.clone(),
-                                        },
+                                        crate::body_query::BodyQueryKey::new(
+                                            remaining_instance.as_ref().clone(),
+                                            key.configuration.clone(),
+                                        ),
                                     )?;
                                     let rue_query::QueryOutcome::Success(remaining_demand) =
                                         remaining_demand.outcome()
@@ -15734,10 +15727,10 @@ impl RevisionedQueryDatabase {
                             break;
                         }
 
-                        let body_key = crate::body_query::BodyQueryKey {
-                            instance: instance.as_ref().clone(),
-                            configuration: key.configuration.clone(),
-                        };
+                        let body_key = crate::body_query::BodyQueryKey::new(
+                            instance.as_ref().clone(),
+                            key.configuration.clone(),
+                        );
                         let demand = context
                             .query_registered(&toolchain_for_body_closure, body_key.clone())?;
                         let rue_query::QueryOutcome::Success(demand) = demand.outcome() else {
@@ -15761,10 +15754,10 @@ impl RevisionedQueryDatabase {
                                 if visited.contains(pending_instance) {
                                     continue;
                                 }
-                                let pending_key = crate::body_query::BodyQueryKey {
-                                    instance: pending_instance.as_ref().clone(),
-                                    configuration: key.configuration.clone(),
-                                };
+                                let pending_key = crate::body_query::BodyQueryKey::new(
+                                    pending_instance.as_ref().clone(),
+                                    key.configuration.clone(),
+                                );
                                 let pending_demand = context.query_registered(
                                     &toolchain_for_body_closure,
                                     pending_key,
@@ -16222,9 +16215,11 @@ impl RevisionedQueryDatabase {
                         .reached
                         .iter()
                         .cloned()
-                        .map(|instance| crate::body_query::BodyQueryKey {
-                            instance,
-                            configuration: key.configuration.clone(),
+                        .map(|instance| {
+                            crate::body_query::BodyQueryKey::new(
+                                instance,
+                                key.configuration.clone(),
+                            )
                         })
                         .collect::<Vec<_>>();
                     // Reachability has already produced these deep registered
@@ -17564,10 +17559,10 @@ impl BodyTransactionEvaluator {
                 {
                     let produced = match context.query_registered(
                         &self.body_produced_anonymous,
-                        crate::body_query::BodyQueryKey {
-                            instance: (**function).clone(),
-                            configuration: key.configuration.clone(),
-                        },
+                        crate::body_query::BodyQueryKey::new(
+                            (**function).clone(),
+                            key.configuration.clone(),
+                        ),
                     ) {
                         Ok(produced) => produced,
                         Err(QueryAbort::Canceled) => {
@@ -22708,10 +22703,7 @@ impl<'a> CompilerBodyFactProvider<'a> {
         &self,
         instance: &crate::FunctionInstanceKey,
     ) -> crate::body_query::BodyQueryKey {
-        crate::body_query::BodyQueryKey {
-            instance: instance.clone(),
-            configuration: self.queries.configuration.clone(),
-        }
+        crate::body_query::BodyQueryKey::new(instance.clone(), self.queries.configuration.clone())
     }
 
     /// Observe the exact `LookupName` terminal for a consulted key, recording
@@ -25608,13 +25600,10 @@ mod tests {
     }
 
     fn main_body_key() -> crate::body_query::BodyQueryKey {
-        crate::body_query::BodyQueryKey {
-            instance: free_function_instance(
-                &ModuleId::from_logical_path("main.rue").unwrap(),
-                "main",
-            ),
-            configuration: semantic_configuration(),
-        }
+        crate::body_query::BodyQueryKey::new(
+            free_function_instance(&ModuleId::from_logical_path("main.rue").unwrap(), "main"),
+            semantic_configuration(),
+        )
     }
 
     #[test]
@@ -32530,10 +32519,7 @@ fn main() -> i32 {
         let produced = database.runtime.request_registered(
             &database.body_produced_anonymous,
             revision,
-            crate::body_query::BodyQueryKey {
-                instance: producer,
-                configuration,
-            },
+            crate::body_query::BodyQueryKey::new(producer, configuration),
             CancellationToken::new(),
         );
         let terminal = produced.terminal().unwrap();
@@ -36882,10 +36868,7 @@ fn main() -> i32 {
             arguments: arguments.clone(),
         };
         let configuration = semantic_configuration();
-        let key = crate::body_query::BodyQueryKey {
-            instance: instance.clone(),
-            configuration: configuration.clone(),
-        };
+        let key = crate::body_query::BodyQueryKey::new(instance.clone(), configuration.clone());
         let mut database = RevisionedQueryDatabase::default();
         let revision = revision_for(&mut database, &snapshot);
         let input = database
@@ -37090,10 +37073,8 @@ fn main() -> i32 {
             base: Box::new(free_function_instance(&module, "Pair")),
             arguments: crate::CanonicalArguments::default(),
         };
-        let registered_key = crate::body_query::BodyQueryKey {
-            instance: pair_instance.clone(),
-            configuration: configuration.clone(),
-        };
+        let registered_key =
+            crate::body_query::BodyQueryKey::new(pair_instance.clone(), configuration.clone());
 
         let provider_instance = pair_instance.clone();
         let outcome = database.probe_ready_body_facts(
@@ -37676,10 +37657,8 @@ fn main() -> i32 {
         );
         let module = ModuleId::from_logical_path("main.rue").unwrap();
         let instance = free_function_instance(&module, "selected");
-        let key = |configuration| crate::body_query::BodyQueryKey {
-            instance: instance.clone(),
-            configuration,
-        };
+        let key =
+            |configuration| crate::body_query::BodyQueryKey::new(instance.clone(), configuration);
         let mut database = RevisionedQueryDatabase::default();
         let first_revision = database.source_revision(
             &super::super::session::ExactSourceInput::new(&first),
@@ -37790,10 +37769,10 @@ fn main() -> i32 {
             let terminal = database
                 .body_input(
                     revision,
-                    crate::body_query::BodyQueryKey {
-                        instance: crate::FunctionInstanceKey::Definition(definition.clone()),
-                        configuration: semantic_configuration(),
-                    },
+                    crate::body_query::BodyQueryKey::new(
+                        crate::FunctionInstanceKey::Definition(definition.clone()),
+                        semantic_configuration(),
+                    ),
                     CancellationToken::new(),
                 )
                 .unwrap();
@@ -37829,10 +37808,10 @@ fn main() -> i32 {
         let terminal = database
             .body_input(
                 revision,
-                crate::body_query::BodyQueryKey {
-                    instance: free_function_instance(&module, "selected"),
-                    configuration: semantic_configuration(),
-                },
+                crate::body_query::BodyQueryKey::new(
+                    free_function_instance(&module, "selected"),
+                    semantic_configuration(),
+                ),
                 CancellationToken::new(),
             )
             .unwrap();
@@ -37924,10 +37903,7 @@ fn main() -> i32 {
             base: Box::new(free_function_instance(&module, "Box")),
             arguments: crate::CanonicalArguments::default(),
         };
-        let key = crate::body_query::BodyQueryKey {
-            instance: producer,
-            configuration: semantic_configuration(),
-        };
+        let key = crate::body_query::BodyQueryKey::new(producer, semantic_configuration());
         let member_syntax =
             |terminal: &rue_query::QueryTerminal<crate::body_query::ProducedAnonymous>| {
                 let rue_query::QueryOutcome::Success(
@@ -38075,10 +38051,7 @@ fn main() -> i32 {
             &super::super::session::ExactSourceInput::new(&generic),
             &generic,
         );
-        let key = crate::body_query::BodyQueryKey {
-            instance,
-            configuration: semantic_configuration(),
-        };
+        let key = crate::body_query::BodyQueryKey::new(instance, semantic_configuration());
         let terminal = database
             .body_input(revision, key, CancellationToken::new())
             .unwrap();
@@ -38089,13 +38062,13 @@ fn main() -> i32 {
             ))
         ));
 
-        let unknown = crate::body_query::BodyQueryKey {
-            instance: free_function_instance(
+        let unknown = crate::body_query::BodyQueryKey::new(
+            free_function_instance(
                 &ModuleId::from_logical_path("other.rue").unwrap(),
                 "missing",
             ),
-            configuration: semantic_configuration(),
-        };
+            semantic_configuration(),
+        );
         let missing = database
             .body_input(revision, unknown, CancellationToken::new())
             .unwrap();
@@ -38106,16 +38079,16 @@ fn main() -> i32 {
             ))
         ));
 
-        let unsupported = crate::body_query::BodyQueryKey {
-            instance: crate::FunctionInstanceKey::Specialization {
+        let unsupported = crate::body_query::BodyQueryKey::new(
+            crate::FunctionInstanceKey::Specialization {
                 base: Box::new(free_function_instance(
                     &ModuleId::from_logical_path("main.rue").unwrap(),
                     "selected",
                 )),
                 arguments: crate::CanonicalArguments::default(),
             },
-            configuration: semantic_configuration(),
-        };
+            semantic_configuration(),
+        );
         let specialization = database
             .body_input(revision, unsupported, CancellationToken::new())
             .unwrap();
@@ -38125,18 +38098,16 @@ fn main() -> i32 {
         ));
 
         let unsupported_kind = crate::StableDefinitionKind::Struct;
-        let unsupported = crate::body_query::BodyQueryKey {
-            instance: crate::FunctionInstanceKey::Definition(
-                crate::StableDefinitionKey::from_stable_parts(
-                    ModuleId::from_logical_path("main.rue").unwrap(),
-                    crate::StableDefinitionNamespace::Type,
-                    unsupported_kind,
-                    Arc::from("NotABody"),
-                    None,
-                ),
-            ),
-            configuration: semantic_configuration(),
-        };
+        let unsupported = crate::body_query::BodyQueryKey::new(
+            crate::FunctionInstanceKey::Definition(crate::StableDefinitionKey::from_stable_parts(
+                ModuleId::from_logical_path("main.rue").unwrap(),
+                crate::StableDefinitionNamespace::Type,
+                unsupported_kind,
+                Arc::from("NotABody"),
+                None,
+            )),
+            semantic_configuration(),
+        );
         let terminal = database
             .body_input(revision, unsupported, CancellationToken::new())
             .unwrap();
@@ -38164,13 +38135,13 @@ fn main() -> i32 {
         let extern_terminal = extern_database
             .body_input(
                 extern_revision,
-                crate::body_query::BodyQueryKey {
-                    instance: free_function_instance(
+                crate::body_query::BodyQueryKey::new(
+                    free_function_instance(
                         &ModuleId::from_logical_path("main.rue").unwrap(),
                         "selected",
                     ),
-                    configuration: semantic_configuration(),
-                },
+                    semantic_configuration(),
+                ),
                 CancellationToken::new(),
             )
             .unwrap();
@@ -38193,13 +38164,13 @@ fn main() -> i32 {
         let malformed_terminal = malformed_database
             .body_input(
                 malformed_revision,
-                crate::body_query::BodyQueryKey {
-                    instance: free_function_instance(
+                crate::body_query::BodyQueryKey::new(
+                    free_function_instance(
                         &ModuleId::from_logical_path("main.rue").unwrap(),
                         "selected",
                     ),
-                    configuration: semantic_configuration(),
-                },
+                    semantic_configuration(),
+                ),
                 CancellationToken::new(),
             )
             .unwrap();
@@ -38223,10 +38194,10 @@ fn main() -> i32 {
             &super::super::session::ExactSourceInput::new(&source),
             &source,
         );
-        let key = crate::body_query::BodyQueryKey {
-            instance: free_function_instance(&module, "selected"),
-            configuration: semantic_configuration(),
-        };
+        let key = crate::body_query::BodyQueryKey::new(
+            free_function_instance(&module, "selected"),
+            semantic_configuration(),
+        );
         let cancellation = CancellationToken::new();
         cancellation.cancel();
         let attempt = database.runtime.request_registered(
@@ -38672,10 +38643,7 @@ fn main() -> i32 {
             let transaction = database.runtime.request_registered(
                 &database.body_transactions,
                 revision,
-                crate::body_query::BodyQueryKey {
-                    instance,
-                    configuration: semantic_configuration(),
-                },
+                crate::body_query::BodyQueryKey::new(instance, semantic_configuration()),
                 CancellationToken::new(),
             );
             assert_eq!(
@@ -38715,10 +38683,10 @@ fn main() -> i32 {
             roots: Arc::from([free_function_instance(&module, "main")]),
             configuration: semantic_configuration(),
         };
-        let deleted_body_key = crate::body_query::BodyQueryKey {
-            instance: free_function_instance(&module, &format!("f{}", CALLEES - 1)),
-            configuration: semantic_configuration(),
-        };
+        let deleted_body_key = crate::body_query::BodyQueryKey::new(
+            free_function_instance(&module, &format!("f{}", CALLEES - 1)),
+            semantic_configuration(),
+        );
         let mut database = RevisionedQueryDatabase::with_query_concurrency(4);
 
         let full_revision = revision_for(&mut database, &full);
@@ -38871,10 +38839,8 @@ fn main() -> i32 {
         };
         let first_instance = instance("First");
         let second_instance = instance("Second");
-        let body_key = |instance| crate::body_query::BodyQueryKey {
-            instance,
-            configuration: configuration.clone(),
-        };
+        let body_key =
+            |instance| crate::body_query::BodyQueryKey::new(instance, configuration.clone());
         let first_key = body_key(first_instance.clone());
         let second_key = body_key(second_instance.clone());
 
@@ -39106,10 +39072,10 @@ fn main() -> i32 {
             base: Box::new(free_function_instance(&module, "Produced")),
             arguments: crate::CanonicalArguments::default(),
         };
-        let produced_key = crate::body_query::BodyQueryKey {
-            instance: produced_instance.clone(),
-            configuration: semantic_configuration(),
-        };
+        let produced_key = crate::body_query::BodyQueryKey::new(
+            produced_instance.clone(),
+            semantic_configuration(),
+        );
         let produced = database
             .body_produced_anonymous_projection(
                 revision,
@@ -39224,9 +39190,8 @@ fn main() -> i32 {
         };
         let body_keys = reached_instances
             .into_iter()
-            .map(|instance| crate::body_query::BodyQueryKey {
-                instance,
-                configuration: semantic_configuration(),
+            .map(|instance| {
+                crate::body_query::BodyQueryKey::new(instance, semantic_configuration())
             })
             .collect::<Vec<_>>();
         let mut database = RevisionedQueryDatabase::with_query_concurrency(4);

--- a/crates/rue-compiler/src/session.rs
+++ b/crates/rue-compiler/src/session.rs
@@ -4816,10 +4816,10 @@ impl CompilerSession {
                 .revisioned
                 .warning_body_references(
                     graph.revision,
-                    crate::body_query::BodyQueryKey {
-                        instance: crate::FunctionInstanceKey::Definition(declaration.key.clone()),
-                        configuration: graph.configuration.clone(),
-                    },
+                    crate::body_query::BodyQueryKey::new(
+                        crate::FunctionInstanceKey::Definition(declaration.key.clone()),
+                        graph.configuration.clone(),
+                    ),
                     cancellation.clone(),
                 )
                 .map_err(PipelineRequestControl::Abort)?;
@@ -7451,13 +7451,13 @@ mod tests {
             .unwrap()
             .stable_key()
             .clone();
-        crate::body_query::BodyQueryKey {
-            instance: crate::FunctionInstanceKey::Definition(definition),
-            configuration: crate::semantic_query_nucleus::SemanticQueryConfiguration {
+        crate::body_query::BodyQueryKey::new(
+            crate::FunctionInstanceKey::Definition(definition),
+            crate::semantic_query_nucleus::SemanticQueryConfiguration {
                 target: options.target,
                 preview_features: StablePreviewFeatures::new(&options.preview_features),
             },
-        }
+        )
     }
 
     /// The comptime arguments of a specialization of the definition named
@@ -11074,15 +11074,15 @@ fn main() -> i32 { 0 }
                 })
             })
             .unwrap();
-        let choose_true_key = crate::body_query::BodyQueryKey {
-            instance: choose_true.semantic_identity.clone(),
-            configuration: crate::semantic_query_nucleus::SemanticQueryConfiguration {
+        let choose_true_key = crate::body_query::BodyQueryKey::new(
+            choose_true.semantic_identity.clone(),
+            crate::semantic_query_nucleus::SemanticQueryConfiguration {
                 target: CompileOptions::default().target,
                 preview_features: StablePreviewFeatures::new(
                     &CompileOptions::default().preview_features,
                 ),
             },
-        };
+        );
         let transaction = retained_body_transaction(&session, &choose_true_key).2;
         assert!(
             transaction.references().0.iter().any(|reference| matches!(
@@ -12185,22 +12185,22 @@ fn main() -> i32 {
         let cold = session.canonical_semantic(&options).unwrap();
         let main = body_query_key(&mut session, &options, "main");
         let make_definition = body_query_key(&mut session, &options, "Make");
-        let make = crate::body_query::BodyQueryKey {
-            instance: crate::FunctionInstanceKey::Specialization {
-                base: Box::new(make_definition.instance),
+        let make = crate::body_query::BodyQueryKey::new(
+            crate::FunctionInstanceKey::Specialization {
+                base: Box::new(make_definition.instance.clone()),
                 arguments: crate::CanonicalArguments::default(),
             },
-            configuration: main.configuration.clone(),
-        };
+            main.configuration.clone(),
+        );
         let size = cold
             .functions()
             .iter()
             .find(|function| specialization_arguments(function, "size").is_some())
             .unwrap();
-        let size = crate::body_query::BodyQueryKey {
-            instance: size.semantic_identity.clone(),
-            configuration: main.configuration.clone(),
-        };
+        let size = crate::body_query::BodyQueryKey::new(
+            size.semantic_identity.clone(),
+            main.configuration.clone(),
+        );
         let first_make_stamps = retained_body_query_stamps(&session, &make);
         let first_size_stamps = retained_body_query_stamps(&session, &size);
         let make_dependencies = retained_body_dependency_nodes(&session, &make);
@@ -12328,21 +12328,19 @@ fn main() -> i32 {
         let mut warm = CompilerSession::new();
         warm.update(&missing).into_result().unwrap();
         assert!(warm.canonical_semantic(&options).is_err());
-        let main = crate::body_query::BodyQueryKey {
-            instance: crate::FunctionInstanceKey::Definition(
-                crate::StableDefinitionKey::from_stable_parts(
-                    crate::ModuleId::from_logical_path("main.rue").unwrap(),
-                    crate::StableDefinitionNamespace::Value,
-                    crate::StableDefinitionKind::Function,
-                    "main",
-                    None,
-                ),
-            ),
-            configuration: crate::semantic_query_nucleus::SemanticQueryConfiguration {
+        let main = crate::body_query::BodyQueryKey::new(
+            crate::FunctionInstanceKey::Definition(crate::StableDefinitionKey::from_stable_parts(
+                crate::ModuleId::from_logical_path("main.rue").unwrap(),
+                crate::StableDefinitionNamespace::Value,
+                crate::StableDefinitionKind::Function,
+                "main",
+                None,
+            )),
+            crate::semantic_query_nucleus::SemanticQueryConfiguration {
                 target: options.target,
                 preview_features: StablePreviewFeatures::new(&options.preview_features),
             },
-        };
+        );
         let dependencies = retained_body_dependency_nodes(&warm, &main);
         assert!(
             dependencies
@@ -12636,21 +12634,19 @@ fn main() -> i32 {
         let mut session = CompilerSession::new();
         session.update(&source).into_result().unwrap();
         assert!(session.canonical_semantic(&options).is_err());
-        let key = crate::body_query::BodyQueryKey {
-            instance: crate::FunctionInstanceKey::Definition(
-                crate::StableDefinitionKey::from_stable_parts(
-                    crate::ModuleId::from_logical_path("main.rue").unwrap(),
-                    crate::StableDefinitionNamespace::Value,
-                    crate::StableDefinitionKind::Function,
-                    Arc::from("main"),
-                    None,
-                ),
-            ),
-            configuration: crate::semantic_query_nucleus::SemanticQueryConfiguration {
+        let key = crate::body_query::BodyQueryKey::new(
+            crate::FunctionInstanceKey::Definition(crate::StableDefinitionKey::from_stable_parts(
+                crate::ModuleId::from_logical_path("main.rue").unwrap(),
+                crate::StableDefinitionNamespace::Value,
+                crate::StableDefinitionKind::Function,
+                Arc::from("main"),
+                None,
+            )),
+            crate::semantic_query_nucleus::SemanticQueryConfiguration {
                 target: options.target,
                 preview_features: StablePreviewFeatures::new(&options.preview_features),
             },
-        };
+        );
         let revision = session
             .queries
             .revisioned

--- a/crates/rue-query/src/lib.rs
+++ b/crates/rue-query/src/lib.rs
@@ -2005,6 +2005,16 @@ pub trait QueryKey: Clone + Eq + Hash + Send + Sync + 'static {
     /// This text is presentation only and may collide. Exact `Self::eq`
     /// remains authoritative for memo-node lookup.
     fn stable_identity(&self) -> String;
+
+    /// A shareable form of the presentation identity.
+    ///
+    /// Keys which flow unchanged through several query families may override
+    /// this method to retain and format the identity once. An override must
+    /// return the same text as [`Self::stable_identity`]. The default keeps
+    /// simple keys allocation-equivalent to that method.
+    fn shared_stable_identity(&self) -> Arc<str> {
+        self.stable_identity().into()
+    }
 }
 
 /// Collision-free identity of one immutable input leaf.
@@ -2080,7 +2090,7 @@ pub struct NodeIdentity {
 
 struct NodeIdentityData {
     family: Arc<str>,
-    key: Box<str>,
+    key: Arc<str>,
     runtime_identity: Option<u64>,
     node: Option<Weak<dyn ErasedNode>>,
 }
@@ -2092,7 +2102,7 @@ struct ExactNodeIdentity {
 }
 
 impl NodeIdentity {
-    fn new(family: Arc<str>, key: Box<str>) -> Self {
+    fn new(family: Arc<str>, key: Arc<str>) -> Self {
         Self {
             inner: Arc::new(NodeIdentityData {
                 family,
@@ -2105,7 +2115,7 @@ impl NodeIdentity {
 
     fn registered(
         family: Arc<str>,
-        key: Box<str>,
+        key: Arc<str>,
         runtime_identity: u64,
         node: Weak<dyn ErasedNode>,
     ) -> Self {
@@ -5556,11 +5566,10 @@ where
         let node = if let Some(node) = nodes.get(&key) {
             node.clone()
         } else {
-            let stable_key = key.stable_identity();
+            let stable_key = key.shared_stable_identity();
             self.core
                 .metrics
                 .record_memo_node_identity(stable_key.len());
-            let stable_key = stable_key.into_boxed_str();
             let incarnation = self.core.next_node.fetch_add(1, Ordering::Relaxed);
             let demand = self.inner.evaluator.as_ref().map(|_| {
                 let core = self.core.clone();
@@ -7100,10 +7109,7 @@ impl<K: QueryKey> StructuredWaitLabels for RegisteredBatchItems<K> {
             .items
             .get(index)
             .expect("a structured wait edge names one live batch item");
-        NodeIdentity::new(
-            self.family.clone(),
-            item.key.stable_identity().into_boxed_str(),
-        )
+        NodeIdentity::new(self.family.clone(), item.key.shared_stable_identity())
     }
 }
 
@@ -7325,12 +7331,7 @@ impl QueryContext {
         // `record_nested`; the key is only formatted if this request aborted.
         self.task.record_nested(
             request_id,
-            move || {
-                NodeIdentity::new(
-                    family.inner.name.clone(),
-                    key.stable_identity().into_boxed_str(),
-                )
-            },
+            move || NodeIdentity::new(family.inner.name.clone(), key.shared_stable_identity()),
             &result,
         );
         result.into_result()
@@ -7365,12 +7366,7 @@ impl QueryContext {
         // `record_nested`; the key is only formatted if this request aborted.
         self.task.record_nested(
             request_id,
-            move || {
-                NodeIdentity::new(
-                    family.inner.name.clone(),
-                    key.stable_identity().into_boxed_str(),
-                )
-            },
+            move || NodeIdentity::new(family.inner.name.clone(), key.shared_stable_identity()),
             &result,
         );
         result.into_result()
@@ -7547,12 +7543,7 @@ impl QueryContext {
             }
             self.task.record_nested(
                 item.request_id,
-                || {
-                    NodeIdentity::new(
-                        items.family.clone(),
-                        item.key.stable_identity().into_boxed_str(),
-                    )
-                },
+                || NodeIdentity::new(items.family.clone(), item.key.shared_stable_identity()),
                 &result,
             );
             terminals.push(result.into_result()?);
@@ -10591,7 +10582,7 @@ mod tests {
                 TaskId(1),
                 WaitEdgeLabel::Materialized(NodeIdentity::new(
                     Arc::from("ordinary"),
-                    Box::from("root"),
+                    Arc::from("root"),
                 )),
             )
             .expect_err("the reverse wait closes a cycle");
@@ -12712,7 +12703,7 @@ mod tests {
             validation_endorsement_index_probes: AtomicUsize::new(0),
         };
         task.push(ExactNodeIdentity {
-            display: NodeIdentity::new(Arc::from("handoff-test"), Box::from("root")),
+            display: NodeIdentity::new(Arc::from("handoff-test"), Arc::from("root")),
             incarnation: 1,
         });
         assert!(task.observe_handoff(AttemptHandoffLifecycle::shared_committed()));
@@ -12764,7 +12755,7 @@ mod tests {
             validation_endorsement_index_probes: AtomicUsize::new(0),
         };
         task.push(ExactNodeIdentity {
-            display: NodeIdentity::new(Arc::from("handoff-cache-test"), Box::from("root")),
+            display: NodeIdentity::new(Arc::from("handoff-cache-test"), Arc::from("root")),
             incarnation: 1,
         });
 

--- a/docs/notes/post-adr-0063-cold-compiler-architecture-audit.md
+++ b/docs/notes/post-adr-0063-cold-compiler-architecture-audit.md
@@ -1106,6 +1106,22 @@ paired MAD and a -5.08% to +14.67% range. Median peak RSS falls by 10.91 MiB.
 Every published compiler-work counter and emitted executable byte remains
 identical.
 
+RUE-1411 shares one immutable `BodyQueryKey` payload across the independently
+stamped body-projection families. The first family miss formats its diagnostic
+identity into that shared payload; later body-input, canonical-body,
+transaction, reference, anonymous-production, source, bundle, CFG, and codegen
+memo nodes retain the same `Arc<str>` instead of repeating the deep formatting
+and string allocation. Typed key equality remains the sole memo authority.
+
+Four fixed one-worker allocation probes save 66,845--67,191 calls and
+13.61--13.83 MiB of requested bytes. Sixteen balanced alternating
+ordinary-release pairs are clock-neutral at a +0.21% paired median, with 0.54%
+paired MAD and a -12.43% to +28.94% range on the loaded host. Median peak RSS
+falls by 7.52 MiB. The display-identity counters remain logically unchanged:
+they count the memo nodes and key bytes named by the query graph, not duplicate
+physical string allocations. Every other published compiler-work counter and
+emitted executable byte remains identical.
+
 ## Next actions and decision boundary
 
 Authorized low-risk work:


### PR DESCRIPTION
Fixes RUE-1411.

## Summary

- share one immutable `BodyQueryKey` payload across body-projection query families
- materialize the stable display identity once and retain it through the shared key
- keep typed query-key equality and logical display-identity counters unchanged
- record the architecture and measurement result in the cold-compiler audit

## Evidence

- four fixed one-worker Lattice probes save 66,845–67,191 allocations and 13.61–13.83 MiB of requested bytes
- 16 balanced ordinary-release pairs are clock-neutral at +0.21% paired median with 0.54% MAD
- median peak RSS falls 7.52 MiB
- every compiler-work counter and emitted executable byte is identical

## Validation

- focused compiler body-query coverage
- all 156 rue-query tests
- formatting and relevant clippy targets