### PR TITLE
RUE-1414: validate durable type exports once

### DIFF
--- a/crates/rue-air/src/semantic_import.rs
+++ b/crates/rue-air/src/semantic_import.rs
@@ -1902,6 +1902,16 @@ where
         self.type_pool
             .validate_complete_type(value)
             .map_err(|_| SemanticImportFailure::ForeignLocalType)?;
+        self.export_type_local_validated(value)
+    }
+
+    /// Project a type whose complete reachable graph was checked by the root
+    /// export boundary. Recursive projection must not revalidate every suffix
+    /// of that same immutable graph.
+    fn export_type_local_validated(
+        &self,
+        value: Type,
+    ) -> Result<SemanticImportType<K, M>, SemanticImportFailure> {
         Ok(match value.kind() {
             crate::TypeKind::I8 => SemanticImportType::I8,
             crate::TypeKind::I16 => SemanticImportType::I16,
@@ -1926,7 +1936,9 @@ where
                     };
                     SemanticImportType::Slice {
                         element: Box::new(
-                            self.export_type_local(self.type_pool.ptr_const_def(pointer))?,
+                            self.export_type_local_validated(
+                                self.type_pool.ptr_const_def(pointer),
+                            )?,
                         ),
                         name: def.name.clone(),
                     }
@@ -1980,15 +1992,15 @@ where
             crate::TypeKind::Array(id) => {
                 let (element, len) = self.type_pool.array_def(id);
                 SemanticImportType::Array {
-                    element: Box::new(self.export_type_local(element)?),
+                    element: Box::new(self.export_type_local_validated(element)?),
                     len,
                 }
             }
             crate::TypeKind::PtrConst(id) => SemanticImportType::PtrConst(Box::new(
-                self.export_type_local(self.type_pool.ptr_const_def(id))?,
+                self.export_type_local_validated(self.type_pool.ptr_const_def(id))?,
             )),
             crate::TypeKind::PtrMut(id) => SemanticImportType::PtrMut(Box::new(
-                self.export_type_local(self.type_pool.ptr_mut_def(id))?,
+                self.export_type_local_validated(self.type_pool.ptr_mut_def(id))?,
             )),
             crate::TypeKind::Module(id) => SemanticImportType::Module(
                 self.module_exports
@@ -2931,6 +2943,14 @@ mod tests {
         assert_eq!(
             b.export_const_value(value),
             Err(SemanticImportFailure::ForeignLocalValue)
+        );
+        assert_eq!(
+            a.export_type(SemanticImportedType {
+                epoch: a.epoch.clone(),
+                value: Type::ERROR,
+            }),
+            Err(SemanticImportFailure::ForeignLocalType),
+            "the checked root boundary must still reject a branded recovery type"
         );
     }
 

--- a/docs/notes/post-adr-0063-cold-compiler-architecture-audit.md
+++ b/docs/notes/post-adr-0063-cold-compiler-architecture-audit.md
@@ -1137,6 +1137,23 @@ paired MAD and a -4.86% to +1.35% range. Median peak RSS falls by 1.07 MiB.
 Every published compiler-work counter and emitted executable byte remains
 identical.
 
+RUE-1414 validates each durable type-export graph once at its checked root.
+Projection previously called the checked export boundary recursively for every
+array, pointer, and slice child, so a nested structural chain revalidated every
+remaining suffix and accumulated quadratic validation work in its depth. The
+validated projection helper now walks that immutable graph once after the root
+boundary has established completeness and pool ownership; nominal and module
+export joins still fail closed independently.
+
+The maintained Lattice graph is shallow enough that four fixed one-worker
+allocation probes move within run-to-run dispersion, with a median reduction
+of 256 calls and 0.10 MiB of requested bytes. Sixteen balanced alternating
+ordinary-release pairs are clock-neutral at a -0.22% paired median, with 0.56%
+paired MAD and a -1.31% to +5.92% range. Median peak RSS moves +1.48 MiB within
+dispersion. Every published compiler-work counter and emitted executable byte
+remains identical. The architectural result is the linear validation bound,
+not a claimed clock improvement on the current corpus.
+
 ## Next actions and decision boundary
 
 Authorized low-risk work:


### PR DESCRIPTION
Fixes RUE-1414.

Durable type export now validates each checked root once, then recursively projects arrays, pointers, and slices through an internal validated helper. This removes quadratic suffix revalidation for deep structural types while preserving nominal/module joins and fail-closed ownership checks.

Evidence:
- all 724 rue-air tests pass; rue-air clippy and formatting pass
- fixed one-worker Lattice compiler work and emitted executable are byte-for-byte identical
- four allocation pairs are neutral (-256 calls and -0.10 MiB median)
- sixteen balanced release pairs are clock-neutral (-0.22% paired median, 0.56% MAD)
- peak RSS moves +1.48 MiB within dispersion