### PR TITLE
RUE-1419: register anonymous body types once

### DIFF
--- a/crates/rue-air/src/sema/body_identity.rs
+++ b/crates/rue-air/src/sema/body_identity.rs
@@ -1632,8 +1632,16 @@ where
             DurableAnonymousShape::Enum { variants } => self.mint_anon_enum(key, digest, &variants),
         };
         match minted {
+            // Both minting arms register the recursive shell before resolving
+            // its shape. That registration is the durable identity on success;
+            // inserting it again here would clone and rehash the full producer
+            // key only to replace the same forward entry.
             Ok(ty) => {
-                self.record_anonymous_identity(key.clone(), ty);
+                debug_assert_eq!(
+                    self.anon_nominals.get(key).copied(),
+                    Some(ty),
+                    "every successful anonymous mint arm registers its identity",
+                );
                 Ok(ty)
             }
             Err(error) => {
@@ -1988,7 +1996,7 @@ where
     /// spells them with, and the name never decides identity.
     fn mint_anon_enum(
         &mut self,
-        _key: &AnonymousNominalKey<K, M>,
+        key: &AnonymousNominalKey<K, M>,
         digest: u128,
         variants: &[(Arc<str>, Vec<SemanticImportType<K, M>>)],
     ) -> Result<Type, IdentityMintError> {
@@ -2038,7 +2046,9 @@ where
         );
         // See `mint_anon_struct` (RUE-1050, RUE-1193).
         self.type_pool.mark_anonymous_enum(id);
-        Ok(Type::new_enum(id))
+        let ty = Type::new_enum(id);
+        self.record_anonymous_identity(key.clone(), ty);
+        Ok(ty)
     }
 
     fn resolve_anonymous_shape_type(
@@ -4396,9 +4406,14 @@ mod tests {
         // And the `resolve` anonymous arm now finds it by the lookup the mint
         // populated.
         assert_eq!(
-            pool.resolve(&DType::AnonymousNominal(key)).unwrap(),
+            pool.resolve(&DType::AnonymousNominal(key.clone())).unwrap(),
             ty,
             "the mint records the issued id for the lookup arm",
+        );
+        assert_eq!(
+            pool.durable_anonymous_identity(ty),
+            Some(key),
+            "the recursive shell remains the reverse-export identity",
         );
     }
 
@@ -4446,6 +4461,11 @@ mod tests {
         assert_eq!(
             def.variants.iter().map(Arc::as_ref).collect::<Vec<_>>(),
             ["Some", "None"]
+        );
+        assert_eq!(
+            pool.durable_anonymous_identity(ty),
+            Some(key),
+            "the enum mint records its reverse-export identity",
         );
     }
 

--- a/docs/notes/post-adr-0063-cold-compiler-architecture-audit.md
+++ b/docs/notes/post-adr-0063-cold-compiler-architecture-audit.md
@@ -1154,6 +1154,21 @@ dispersion. Every published compiler-work counter and emitted executable byte
 remains identical. The architectural result is the linear validation bound,
 not a claimed clock improvement on the current corpus.
 
+RUE-1419 makes each body-pool anonymous identity own one successful registry
+publication. Anonymous structs must publish a recursive shell before resolving
+their fields, while anonymous enums publish after resolving their payloads;
+each minting arm now performs its required registration, and the shared success
+path no longer clones and rehashes the complete producer key only to replace
+the same forward entry. Rollback and poisoning remain in the shared failure
+path.
+
+Four fixed one-worker allocation probes save 42,241--42,492 calls and
+1.86--2.06 MiB of requested bytes. Sixteen balanced alternating
+ordinary-release pairs are favorable but clock-neutral at a -0.97% paired
+median, with 1.43% paired MAD and a -2.94% to +1.96% range. Median peak RSS
+moves +0.71 MiB within dispersion. Every published compiler-work counter and
+emitted executable byte remains identical.
+
 ## Next actions and decision boundary
 
 Authorized low-risk work:

--- a/scripts/validate-debug-assert-policy.py
+++ b/scripts/validate-debug-assert-policy.py
@@ -39,6 +39,9 @@ ALLOWANCES = {
     "crates/rue-air/src/sema/analysis/intrinsics.rs": Allowance(1, "redundant intrinsic signature inventory check"),
     "crates/rue-air/src/sema/analysis/ownership.rs": Allowance(1, "redundant non-negative arena-index check"),
     "crates/rue-air/src/sema/binding_manifest.rs": Allowance(2, "redundant binding-manifest construction checks"),
+    "crates/rue-air/src/sema/body_identity.rs": Allowance(
+        1, "redundant anonymous-identity publication check"
+    ),
     "crates/rue-air/src/sema/comptime_eval.rs": Allowance(2, "redundant semantic phase preconditions"),
     "crates/rue-air/src/sema/declaration_index.rs": Allowance(4, "redundant declaration indexing counters"),
     "crates/rue-air/src/sema/declarations.rs": Allowance(7, "redundant declaration-resolution lifecycle checks"),


### PR DESCRIPTION
Fixes RUE-1419.

Each anonymous body type now owns exactly one successful reverse-identity publication: recursive structs publish their shell before resolving fields, while enums publish after resolving payloads. The shared success path no longer clones and rehashes the complete producer key merely to replace the same entry; rollback and poisoning remain centralized.

Evidence:
- all 724 rue-air tests pass; focused reverse-export assertions, rue-air clippy, and formatting pass
- fixed one-worker Lattice saves 42,241–42,492 allocations and 1.86–2.06 MiB requested
- sixteen balanced release pairs are favorable but clock-neutral (-0.97% paired median, 1.43% MAD)
- peak RSS moves +0.71 MiB within dispersion
- every compiler-work counter and emitted executable byte remains identical