### PR TITLE
RUE-1420: batch validation dependency counters per traversal

### DIFF
--- a/crates/rue-query/src/lib.rs
+++ b/crates/rue-query/src/lib.rs
@@ -3067,6 +3067,33 @@ impl AtomicValidationWork {
     }
 }
 
+/// Publishes one validation traversal's dependency-edge work in a bounded
+/// batch, including when a registered evaluator unwinds through validation.
+struct DependencyValidationWork<'a> {
+    work: &'a AtomicValidationWork,
+    observations: u64,
+}
+
+impl DependencyValidationWork<'_> {
+    fn observe(&mut self) {
+        self.observations += 1;
+    }
+}
+
+impl Drop for DependencyValidationWork<'_> {
+    fn drop(&mut self) {
+        if self.observations == 0 {
+            return;
+        }
+        self.work
+            .dependency_observations
+            .fetch_add(self.observations, Ordering::Relaxed);
+        self.work
+            .registry_probes
+            .fetch_add(self.observations, Ordering::Relaxed);
+    }
+}
+
 /// Display-only query identities materialized by the runtime.
 ///
 /// The byte counters record the UTF-8 length returned by
@@ -10103,13 +10130,16 @@ impl RuntimeCore {
         if !direct_inputs_valid {
             return Ok(false);
         }
+        // These two counters advance together for every inspected dependency.
+        // Accumulate the exact attempted prefix locally so the common complete
+        // traversal performs two atomic updates rather than two per edge. The
+        // guard also flushes an early return or evaluator unwind.
+        let mut dependency_work = DependencyValidationWork {
+            work: &task.validation_work,
+            observations: 0,
+        };
         for observed in terminal.dependencies.iter() {
-            task.validation_work
-                .dependency_observations
-                .fetch_add(1, Ordering::Relaxed);
-            task.validation_work
-                .registry_probes
-                .fetch_add(1, Ordering::Relaxed);
+            dependency_work.observe();
             let node =
                 self.validation_node(&observed.node, observed.incarnation, &task.validation_work);
             let stamp = match node {
@@ -10644,6 +10674,30 @@ mod tests {
                 <= work.demands
         );
         assert!(work.certificates_published <= work.successful_traversals);
+    }
+
+    #[test]
+    fn dependency_validation_work_flushes_complete_and_early_prefixes() {
+        fn inspect(work: &AtomicValidationWork, stop_after: Option<u64>) -> bool {
+            let mut dependency_work = DependencyValidationWork {
+                work,
+                observations: 0,
+            };
+            for observation in 1..=3 {
+                dependency_work.observe();
+                if stop_after == Some(observation) {
+                    return false;
+                }
+            }
+            true
+        }
+
+        let work = AtomicValidationWork::default();
+        assert!(inspect(&work, None));
+        assert!(!inspect(&work, Some(2)));
+        let work = work.snapshot();
+        assert_eq!(work.dependency_observations, 5);
+        assert_eq!(work.registry_probes, 5);
     }
 
     #[test]

--- a/docs/notes/post-adr-0063-cold-compiler-architecture-audit.md
+++ b/docs/notes/post-adr-0063-cold-compiler-architecture-audit.md
@@ -1169,6 +1169,22 @@ median, with 1.43% paired MAD and a -2.94% to +1.96% range. Median peak RSS
 moves +0.71 MiB within dispersion. Every published compiler-work counter and
 emitted executable byte remains identical.
 
+RUE-1420 batches the two task-local work-counter updates that advance together
+for every dependency inspected by retained-terminal validation. Each traversal
+accumulates its exact attempted dependency prefix and publishes that prefix to
+`dependency_observations` and `registry_probes` once at exit, including early
+returns and unwinding, instead of performing two atomic read-modify-write
+operations per edge. Fixed one-worker cold Lattice inspects 614,202 dependency
+edges, so the common complete traversal removes roughly 1.23 million atomic
+updates without weakening the counter contract.
+
+Four fixed one-worker allocation probes are neutral, with a paired median of
++28 calls and +0.02 MiB of requested bytes. Sixteen balanced alternating
+ordinary-release pairs are clock-neutral at a -0.01% paired median, with 0.65%
+paired MAD and a -3.19% to +1.54% range. Median peak RSS moves +1.02 MiB within
+a 2.51 MiB paired MAD. Every published compiler-work counter and emitted
+executable byte remains identical.
+
 ## Next actions and decision boundary
 
 Authorized low-risk work:


### PR DESCRIPTION
Fixes RUE-1420.

Retained-terminal validation now accumulates the exact dependency prefix locally and publishes it on normal return, early return, or unwind. This replaces two task-local atomic updates per dependency edge with two per traversal while preserving the counter schema and exact values.

Cold one-worker Lattice evidence:
- removes about 1.23 million atomic updates across 614,202 dependency observations
- four allocation pairs are neutral (+28 calls, +0.02 MiB median)
- sixteen balanced release pairs are clock-neutral (-0.01% median, 0.65% MAD)
- peak RSS moves +1.02 MiB within a 2.51 MiB paired MAD
- compiler-work counters and emitted bytes are exact

Validation:
- all 157 rue-query tests
- rue-query Clippy gate
- repository formatting