### PR TITLE
RUE-1421: separate candidate proof from fallback authority

### DIFF
--- a/crates/rue-query/src/lib.rs
+++ b/crates/rue-query/src/lib.rs
@@ -5883,7 +5883,7 @@ where
                 }
                 let terminal = pin.terminal().clone();
                 let endorsement_authority = if self.inner.evaluator.is_some() {
-                    task.validation_endorsement_authority_for_terminal(&terminal)
+                    task.validation_candidate_endorsement_authority_for_terminal(&terminal)
                 } else {
                     ValidationEndorsementAuthority::Inactive
                 };
@@ -9266,6 +9266,7 @@ impl Task {
         })
     }
 
+    #[cfg(test)]
     fn validation_endorsement_authority_for_terminal<V>(
         &self,
         terminal: &QueryTerminal<V>,
@@ -9275,6 +9276,37 @@ impl Task {
             terminal.stamp,
             terminal.revision,
         )
+    }
+
+    /// Tests the only retention authority which may bypass validation of a
+    /// candidate root. Published fallback sets retain equal dependency-cone
+    /// representatives, but deliberately do not prove the candidate root's
+    /// own direct observations current. The candidate path therefore needs to
+    /// distinguish exact task-local authority only; scanning fallback indexes
+    /// would produce the same ordinary-validation decision after extra work.
+    fn validation_candidate_endorsement_authority_for_terminal<V>(
+        &self,
+        terminal: &QueryTerminal<V>,
+    ) -> ValidationEndorsementAuthority {
+        let scopes = lock(&self.validation_endorsements);
+        let Some(scope) = scopes.first() else {
+            return ValidationEndorsementAuthority::Inactive;
+        };
+        self.validation_work
+            .endorsement_probes
+            .fetch_add(1, Ordering::Relaxed);
+        #[cfg(test)]
+        self.validation_endorsement_index_probes
+            .fetch_add(1, Ordering::Relaxed);
+        if scope.identities.contains(&(
+            terminal.node_incarnation,
+            terminal.stamp,
+            terminal.revision,
+        )) {
+            ValidationEndorsementAuthority::TaskLocal
+        } else {
+            ValidationEndorsementAuthority::Missing
+        }
     }
 
     fn validation_endorsement_authority_at(
@@ -14848,6 +14880,7 @@ mod tests {
             .family::<Key, u64>("borrowed-stale-root-request", 1)
             .unwrap();
         let value_for_root = value.clone();
+        let first_terminal_for_root = first_terminal.clone();
         let retained_for_root = retained.clone();
         let result = runtime
             .request(
@@ -14861,6 +14894,21 @@ mod tests {
                             &retained_for_root,
                         ))
                         .unwrap();
+                    assert_eq!(
+                        context.task.validation_endorsement_authority_for_terminal(
+                            &first_terminal_for_root,
+                        ),
+                        ValidationEndorsementAuthority::Borrowed,
+                    );
+                    assert_eq!(
+                        context
+                            .task
+                            .validation_candidate_endorsement_authority_for_terminal(
+                                &first_terminal_for_root,
+                            ),
+                        ValidationEndorsementAuthority::Missing,
+                        "fallback retention cannot bypass candidate-root validation",
+                    );
                     let terminal = context.query_registered(&value_for_root, Key("value"))?;
                     let QueryOutcome::Success(value) = terminal.outcome() else {
                         unreachable!()

--- a/docs/notes/post-adr-0063-cold-compiler-architecture-audit.md
+++ b/docs/notes/post-adr-0063-cold-compiler-architecture-audit.md
@@ -1185,6 +1185,22 @@ paired MAD and a -3.19% to +1.54% range. Median peak RSS moves +1.02 MiB within
 a 2.51 MiB paired MAD. Every published compiler-work counter and emitted
 executable byte remains identical.
 
+RUE-1421 separates candidate-root proof from descendant retention authority.
+An exact task-local endorsement can prove a retained candidate root current,
+but a published fallback pin set deliberately cannot prove that root's direct
+inputs and dependency edges. Candidate selection previously scanned every
+fallback anyway, only to send both `Borrowed` and `Missing` through the same
+ordinary validation path. It now tests exact task-local authority alone, while
+recursive certificate validation retains the full fallback-aware lookup where
+borrowed authority can actually skip work.
+
+Four fixed one-worker allocation probes are neutral, with paired medians of
+-38 calls and -0.02 MiB of requested bytes. Sixteen balanced alternating
+ordinary-release pairs are clock-neutral at a -0.38% paired median, with 0.90%
+paired MAD and an outlier-sensitive -11.27% to +6.36% range. Median peak RSS is
+unchanged at -0.03 MiB paired. Every published compiler-work counter and
+emitted executable byte remains identical.
+
 ## Next actions and decision boundary
 
 Authorized low-risk work:


### PR DESCRIPTION
## Summary

- distinguish exact task-local candidate proof from published fallback retention authority
- avoid scanning fallback pin sets when candidate selection will ordinary-validate either way
- keep recursive certificate validation fallback-aware, where borrowed authority can actually skip work
- add a regression proving a borrowed stale root is not accepted as candidate proof

## Evidence

- 157 `rue-query` tests pass
- query clippy and formatting pass
- four fixed one-worker allocation probes are neutral (-38 allocations and -0.02 MiB paired medians)
- sixteen alternating release pairs are clock-neutral at -0.38% paired median; peak RSS is unchanged at -0.03 MiB
- all published compiler-work counters and emitted executable bytes are identical

Fixes RUE-1421.
