### PR TITLE
RUE-1424: specialize retained semantic-stamp hashing

### DIFF
--- a/crates/rue-query/src/lib.rs
+++ b/crates/rue-query/src/lib.rs
@@ -3545,6 +3545,40 @@ impl Hasher for IncarnationHasher {
     }
 }
 
+/// Fast hashing for retained semantic-stamp identities.
+///
+/// The complete key is runtime-owned: it combines a monotonically assigned,
+/// runtime-unique node incarnation with one of that node's semantic stamps.
+/// Retention bounds also limit the number of historical stamps per node. Mix
+/// both fixed-width components without paying SipHash on the retention and
+/// validation hot path; caller-controlled query-key maps keep randomized
+/// hashing.
+#[derive(Debug, Default)]
+struct RetainedStampHasher(u64);
+
+impl Hasher for RetainedStampHasher {
+    fn finish(&self) -> u64 {
+        self.0
+    }
+
+    fn write(&mut self, bytes: &[u8]) {
+        let mut hash = self.0 ^ 0x9e3779b97f4a7c15;
+        for byte in bytes {
+            hash ^= u64::from(*byte);
+            hash = hash.wrapping_mul(0x100000001b3);
+        }
+        self.0 = hash;
+    }
+
+    fn write_u64(&mut self, value: u64) {
+        let mut mixed = value.wrapping_add(0x9e3779b97f4a7c15);
+        mixed = (mixed ^ (mixed >> 30)).wrapping_mul(0xbf58476d1ce4e5b9);
+        mixed = (mixed ^ (mixed >> 27)).wrapping_mul(0x94d049bb133111eb);
+        mixed ^= mixed >> 31;
+        self.0 = self.0.rotate_left(27) ^ mixed;
+    }
+}
+
 #[derive(Debug)]
 struct RegisteredNode {
     node: Weak<dyn ErasedNode>,
@@ -8343,7 +8377,7 @@ pub struct RetainedPinSet {
     /// terminal revision in this set. Query dependency edges use this same
     /// semantic identity, so any complete retained cone carrying the stamp can
     /// supply its representative terminal during final promotion.
-    stamp_identities: HashSet<(u64, u64)>,
+    stamp_identities: HashSet<(u64, u64), BuildHasherDefault<RetainedStampHasher>>,
     /// Runtime identities represented by held pins. This makes same-runtime
     /// authority checks proportional to the number of fallback sets, not pins.
     runtime_identities: HashSet<u64>,
@@ -10903,6 +10937,19 @@ mod tests {
                 "the private registry hasher must use the runtime-owned incarnation directly"
             );
         }
+    }
+
+    #[test]
+    fn retained_stamp_hasher_mixes_both_runtime_identity_components() {
+        let hash = |identity: (u64, u64)| {
+            let mut hasher = RetainedStampHasher::default();
+            std::hash::Hash::hash(&identity, &mut hasher);
+            hasher.finish()
+        };
+
+        assert_eq!(hash((7, 11)), hash((7, 11)));
+        assert_ne!(hash((7, 11)), hash((8, 11)));
+        assert_ne!(hash((7, 11)), hash((7, 12)));
     }
 
     #[test]

--- a/docs/notes/post-adr-0063-cold-compiler-architecture-audit.md
+++ b/docs/notes/post-adr-0063-cold-compiler-architecture-audit.md
@@ -1220,6 +1220,20 @@ MAD; median peak RSS falls 2.26 MiB and retired instructions fall 0.08%.
 Every published compiler-work counter and emitted executable byte remains
 identical.
 
+RUE-1424 specializes hashing for the retained-pin index's semantic-stamp keys.
+Every key is a fixed-width `(node incarnation, stamp)` pair: the runtime assigns
+the unique incarnation, and retention bounds limit the historical stamps held
+for each node. A private hasher mixes both components while exact key equality
+remains authoritative; caller-controlled typed query maps retain their
+randomized hashers.
+
+Eight balanced fixed one-worker cold Lattice pairs reduce retired instructions
+by a 0.565% paired median with 0.028% paired MAD. Clock moves -0.97% with 0.95%
+paired MAD, while peak RSS is neutral at +0.02% with 0.30% paired MAD. Four
+allocation-accounted pairs are count-neutral and save 0.16 MiB requested at
+the median. Every compiler-work counter, emitted-output metric, and executable
+byte remains identical.
+
 ## Next actions and decision boundary
 
 Authorized low-risk work:


### PR DESCRIPTION
## Summary

- specialize hashing for the retained semantic-stamp index's fixed-width runtime identities
- keep randomized hashing for caller-controlled query keys and the exact-terminal dedup index
- document the measured cold-compile effect and cover both identity components

## Performance

Eight alternating fixed one-worker cold Lattice pairs:

- retired instructions: -0.565% median (0.028% MAD)
- elapsed time: -0.97% median (0.95% MAD)
- peak RSS: +0.02% median (neutral)
- requested allocation bytes: -0.16 MiB median; allocation count neutral
- all compiler-work counters, emitted metrics, and output bytes identical

## Validation

- all 159 rue-query tests
- rue-query clippy
- formatting

Fixes RUE-1424.
