### PR TITLE
RUE-1423: memoize named-import identity closures

### DIFF
--- a/crates/rue-air/src/sema/body_endpoint.rs
+++ b/crates/rue-air/src/sema/body_endpoint.rs
@@ -740,6 +740,13 @@ where
         self.identity.pool().durable_named_identity(ty)
     }
 
+    /// Return the request-local token already assigned to a durable nominal.
+    /// This is a lookup only: callers that need to mint the endpoint still use
+    /// [`Self::register_named_nominal`].
+    pub fn registered_named_nominal_token(&self, key: &K) -> Option<SemanticDefinitionToken> {
+        self.overlay.borrow().definition_tokens.get(key).copied()
+    }
+
     /// Mint an overlay [`SemanticDefinitionToken`] standing for a durable nominal
     /// key, recording the `(file, name, kind)` endpoint and the `(file, name)`
     /// preimage the `Named`-nominal arm of [`resolve_instance_type`] reverses. A

--- a/crates/rue-air/src/sema/provider_body_host.rs
+++ b/crates/rue-air/src/sema/provider_body_host.rs
@@ -450,6 +450,12 @@ where
     }
 }
 
+#[derive(Clone, Copy)]
+enum ImportNominalRegistration {
+    InProgress,
+    Complete,
+}
+
 struct ProviderBodyHost<'a, P, S, K, M> {
     endpoint: ProviderEndpointFacts<'a, P, S, K, M>,
     calls: ProviderCallFacts<'a, P, S, K, M>,
@@ -485,6 +491,13 @@ struct ProviderBodyHost<'a, P, S, K, M> {
     named_method_infos: RefCell<HashMap<(StructId, Spur), MethodCallInfo>>,
     const_infos: RefCell<HashMap<(FileId, Spur), ConstInfo>>,
     observed_named_definitions: RefCell<HashSet<K>>,
+    /// Request-local state for recursive named-import identity closures. The
+    /// in-progress state breaks type cycles; the complete state skips repeated
+    /// registrations only after every nested field succeeded. A failed outer
+    /// walk clears the request-local cache, so no partial cycle member survives.
+    /// Compact endpoint tokens avoid retaining a second copy of each durable key.
+    import_nominal_registrations:
+        RefCell<HashMap<SemanticDefinitionToken, ImportNominalRegistration>>,
     nominal_tokens: RefCell<HashMap<Type, (SemanticDefinitionToken, K)>>,
     modules_by_file: RefCell<HashMap<FileId, M>>,
     module_tokens: RefCell<HashMap<ModuleId, (SemanticModuleToken, M)>>,
@@ -620,6 +633,7 @@ where
             named_method_infos: RefCell::new(HashMap::new()),
             const_infos: RefCell::new(HashMap::new()),
             observed_named_definitions: RefCell::new(HashSet::new()),
+            import_nominal_registrations: RefCell::new(HashMap::new()),
             nominal_tokens: RefCell::new(HashMap::new()),
             modules_by_file: RefCell::new(HashMap::new()),
             module_tokens: RefCell::new(HashMap::new()),
@@ -1599,54 +1613,93 @@ where
         &self,
         value: &crate::SemanticImportType<K, M>,
     ) -> Result<(), crate::SemanticBodyExportFailure> {
+        let result = self.register_import_nominal_identities_inner(value);
+        if result.is_err() {
+            self.import_nominal_registrations.borrow_mut().clear();
+        }
+        result
+    }
+
+    fn register_import_nominal_identities_inner(
+        &self,
+        value: &crate::SemanticImportType<K, M>,
+    ) -> Result<(), crate::SemanticBodyExportFailure> {
         use crate::SemanticImportType as T;
         match value {
             T::Nominal(key) => {
-                let nominal = DurableNominalSource::nominal(&self.source, key)
-                    .ok_or(crate::SemanticBodyExportFailure::MissingStableIdentity)?;
-                let kind = match &nominal.body {
-                    crate::DurableNominalBody::Struct { .. } => crate::StableDefinitionKind::Struct,
-                    crate::DurableNominalBody::Enum { .. } => crate::StableDefinitionKind::Enum,
-                };
-                let ty = self
-                    .state
-                    .identity_context()
-                    .pool_mut()
-                    .ok_or(crate::SemanticBodyExportFailure::MissingStableIdentity)?
-                    .resolve_provider_type(value)
-                    .map_err(|_| crate::SemanticBodyExportFailure::MissingStableIdentity)?;
-                let token = self.endpoint.register_named_nominal(
-                    key.clone(),
-                    self.owner_file.index(),
-                    nominal.name.as_ref(),
-                    kind,
-                );
-                let already_registered = self.nominal_tokens.borrow().contains_key(&ty);
-                self.nominal_tokens
-                    .borrow_mut()
-                    .insert(ty, (token, key.clone()));
-                if already_registered {
-                    return Ok(());
-                }
-                match &nominal.body {
-                    crate::DurableNominalBody::Struct { fields, .. } => {
-                        for (_, field) in fields {
-                            self.register_import_nominal_identities(field)?;
-                        }
+                if let Some(token) = self.endpoint.registered_named_nominal_token(key) {
+                    match self.import_nominal_registrations.borrow().get(&token) {
+                        Some(ImportNominalRegistration::Complete) => return Ok(()),
+                        Some(ImportNominalRegistration::InProgress) => return Ok(()),
+                        None => {}
                     }
-                    crate::DurableNominalBody::Enum { variants } => {
-                        for (_, payload) in variants {
-                            for field in payload {
-                                self.register_import_nominal_identities(field)?;
+                }
+
+                let mut registration_token = None;
+                let result = (|| {
+                    let nominal = DurableNominalSource::nominal(&self.source, key)
+                        .ok_or(crate::SemanticBodyExportFailure::MissingStableIdentity)?;
+                    let kind = match &nominal.body {
+                        crate::DurableNominalBody::Struct { .. } => {
+                            crate::StableDefinitionKind::Struct
+                        }
+                        crate::DurableNominalBody::Enum { .. } => crate::StableDefinitionKind::Enum,
+                    };
+                    let ty = self
+                        .state
+                        .identity_context()
+                        .pool_mut()
+                        .ok_or(crate::SemanticBodyExportFailure::MissingStableIdentity)?
+                        .resolve_provider_type(value)
+                        .map_err(|_| crate::SemanticBodyExportFailure::MissingStableIdentity)?;
+                    let token = self.endpoint.register_named_nominal(
+                        key.clone(),
+                        self.owner_file.index(),
+                        nominal.name.as_ref(),
+                        kind,
+                    );
+                    registration_token = Some(token);
+                    self.import_nominal_registrations
+                        .borrow_mut()
+                        .insert(token, ImportNominalRegistration::InProgress);
+                    self.nominal_tokens
+                        .borrow_mut()
+                        .insert(ty, (token, key.clone()));
+                    match &nominal.body {
+                        crate::DurableNominalBody::Struct { fields, .. } => {
+                            for (_, field) in fields {
+                                self.register_import_nominal_identities_inner(field)?;
+                            }
+                        }
+                        crate::DurableNominalBody::Enum { variants } => {
+                            for (_, payload) in variants {
+                                for field in payload {
+                                    self.register_import_nominal_identities_inner(field)?;
+                                }
                             }
                         }
                     }
+                    Ok(())
+                })();
+                if let Some(token) = registration_token {
+                    if result.is_ok() {
+                        self.import_nominal_registrations
+                            .borrow_mut()
+                            .insert(token, ImportNominalRegistration::Complete);
+                    } else {
+                        self.import_nominal_registrations
+                            .borrow_mut()
+                            .remove(&token);
+                    }
                 }
+                result?;
             }
             T::Array { element, .. }
             | T::Slice { element, .. }
             | T::PtrConst(element)
-            | T::PtrMut(element) => self.register_import_nominal_identities(element)?,
+            | T::PtrMut(element) => {
+                self.register_import_nominal_identities_inner(element)?;
+            }
             T::I8
             | T::I16
             | T::I32

--- a/crates/rue-compiler/src/session.rs
+++ b/crates/rue-compiler/src/session.rs
@@ -8988,6 +8988,53 @@ mod tests {
     }
 
     #[test]
+    fn repeated_named_imports_register_their_identity_closure_once_per_body() {
+        let source = snapshot(
+            &[(
+                1,
+                "/p/main.rue",
+                "main.rue",
+                "struct Item { value: i32 } \
+                 fn identity(item: Item) -> Item { item } \
+                 fn main() -> i32 { identity(Item { value: 7 }).value }",
+            )],
+            1,
+        );
+        let mut session = CompilerSession::new();
+        session.update(&source).into_result().unwrap();
+        session
+            .canonical_semantic(&CompileOptions::default())
+            .expect("the program analyzes");
+
+        let metrics = crate::unstable::provider_observation_metrics(&session);
+        assert_eq!(metrics.name_lookups, 16, "{metrics:?}");
+        assert_eq!(metrics.declaration_facts, 21, "{metrics:?}");
+        assert_eq!(metrics.identity_facts, 11, "{metrics:?}");
+        assert_eq!(metrics.signature_facts, 10, "{metrics:?}");
+        assert_eq!(metrics.materializations, 10, "{metrics:?}");
+    }
+
+    #[test]
+    fn recursive_named_import_identity_closure_terminates() {
+        let source = snapshot(
+            &[(
+                1,
+                "/p/main.rue",
+                "main.rue",
+                "enum List { Nil, More(ptr const List) } \
+                 fn identity(value: List) -> List { value } \
+                 fn main() -> i32 { let _value = identity(List.Nil); 0 }",
+            )],
+            1,
+        );
+        let mut session = CompilerSession::new();
+        session.update(&source).into_result().unwrap();
+        session
+            .canonical_semantic(&CompileOptions::default())
+            .expect("recursive named imports use the in-progress cycle break");
+    }
+
+    #[test]
     fn published_lookup_root_lease_retains_production_body_lookups() {
         // Production body analysis publishes its exact lookup-name terminals
         // into the session lease. The lease owns retention independently from

--- a/docs/notes/post-adr-0063-cold-compiler-architecture-audit.md
+++ b/docs/notes/post-adr-0063-cold-compiler-architecture-audit.md
@@ -1234,6 +1234,21 @@ allocation-accounted pairs are count-neutral and save 0.16 MiB requested at
 the median. Every compiler-work counter, emitted-output metric, and executable
 byte remains identical.
 
+RUE-1423 gives each provider body request one success cache for named-import
+identity closures. An explicit in-progress state breaks recursive type cycles;
+the complete state is published only after every nested field succeeds, so
+repeated signatures no longer re-query and re-materialize a nominal and its
+recursive fields. A failed outer walk clears the request-local cache, preserving
+retry and error behavior without retaining partial cycle members.
+
+On fixed one-worker cold Lattice this removes 2,425 semantic-provider
+materializations, 4,850 declaration-fact reads, and 9,696 query reuses. Eight
+balanced alternating release pairs reduce retired instructions by a 0.212%
+paired median with 0.055% paired MAD. Clock is neutral at the paired median;
+peak RSS is neutral at -0.014% with 0.142% paired MAD. Four allocation-accounted
+pairs save a median 21,951 allocations and 1.99 MiB of requested bytes. Source
+metrics, emitted-output metrics, and executable bytes remain identical.
+
 ## Next actions and decision boundary
 
 Authorized low-risk work:


### PR DESCRIPTION
## Summary

- cache completed named-import identity closures once per provider body request
- use compact semantic endpoint tokens so the cache does not duplicate durable definition keys
- distinguish in-progress recursive cycles from complete closures and clear partial state on failure
- add focused repeated-import and recursive-cycle regressions

## Performance

Eight alternating fixed one-worker cold Lattice pairs:

- semantic-provider materializations: 21,636 → 19,211 (-2,425)
- declaration facts: 59,925 → 55,075 (-4,850)
- query reuses: 444,148 → 434,452 (-9,696)
- retired instructions: -0.212% median (0.055% MAD)
- elapsed time and peak RSS: neutral
- allocations: -21,951 calls / -1.99 MiB requested at the median
- source metrics, emitted metrics, and output bytes identical

## Validation

- focused repeated-import and recursive named-import tests
- formatting
- balanced release and allocation probes against merged trunk

Fixes RUE-1423.
