### PR TITLE
RUE-1428: memoize anonymous method endpoints per body

### DIFF
--- a/crates/rue-air/src/sema/provider_body_host.rs
+++ b/crates/rue-air/src/sema/provider_body_host.rs
@@ -505,6 +505,11 @@ struct ProviderBodyHost<'a, P, S, K, M> {
     generated_structs: HashMap<Spur, StructId>,
     generated_enums: HashMap<Spur, EnumId>,
     anonymous_methods: RefCell<HashMap<(StructId, Spur), MethodCallInfo>>,
+    /// Anonymous method endpoints whose complete durable signature set has
+    /// already been installed in this body request. Provider type resolution
+    /// handles recursive nominal shells inside the type pool and does not call
+    /// back into endpoint installation, so only successful walks are cached.
+    anonymous_method_registrations: RefCell<HashSet<Type>>,
     anonymous_struct_ids: HashSet<StructId>,
     anonymous_enum_ids: HashSet<EnumId>,
     anon_struct_identities: HashMap<super::anon_structs::IssuedAnonymousNominalKey, StructId>,
@@ -641,6 +646,7 @@ where
             generated_structs: HashMap::new(),
             generated_enums: HashMap::new(),
             anonymous_methods: RefCell::new(HashMap::new()),
+            anonymous_method_registrations: RefCell::new(HashSet::new()),
             anonymous_struct_ids: HashSet::new(),
             anonymous_enum_ids: HashSet::new(),
             anon_struct_identities: HashMap::new(),
@@ -2206,6 +2212,27 @@ where
     }
 
     fn register_provider_anonymous_method_endpoints(
+        &self,
+        identity: &crate::AnonymousNominalKey<K, M>,
+        owner_type: Type,
+    ) -> Option<()> {
+        if self
+            .anonymous_method_registrations
+            .borrow()
+            .contains(&owner_type)
+        {
+            return Some(());
+        }
+        let result = self.register_provider_anonymous_method_endpoints_inner(identity, owner_type);
+        if result.is_some() {
+            self.anonymous_method_registrations
+                .borrow_mut()
+                .insert(owner_type);
+        }
+        result
+    }
+
+    fn register_provider_anonymous_method_endpoints_inner(
         &self,
         identity: &crate::AnonymousNominalKey<K, M>,
         owner_type: Type,

--- a/docs/notes/post-adr-0063-cold-compiler-architecture-audit.md
+++ b/docs/notes/post-adr-0063-cold-compiler-architecture-audit.md
@@ -1283,6 +1283,23 @@ neutral at median deltas of -63 calls and -0.01 MiB requested. Every published
 compiler-work counter, emitted-output metric, and executable byte remains
 identical.
 
+RUE-1428 memoizes successful anonymous-method endpoint installation within one
+provider body request. Durable type resolution already interns recursive
+nominal shells in the request's type pool; once every method signature for one
+compact owner type has been installed, later encounters can reuse those facts
+instead of repeatedly re-issuing its identity, formatting and interning its
+callable names, cloning member keys, allocating parameter ranges, and probing
+the endpoint tables. Failed walks are not cached, so retry and error behavior
+remain unchanged.
+
+Sixteen balanced fixed one-worker cold Lattice pairs reduce retired
+instructions by a 1.674% paired median with 0.052% paired MAD. Clock is neutral
+at a -1.03% paired median with 1.76% paired MAD, while peak RSS is neutral at
++0.20% with 0.32% paired MAD. Four allocation-accounted pairs save
+336,987--337,377 allocations and 24.46--24.61 MB of requested bytes. Every
+published compiler-work counter, emitted-output metric, source metric, and
+executable byte remains identical.
+
 ## Next actions and decision boundary
 
 Authorized low-risk work:


### PR DESCRIPTION
Fixes RUE-1428.

Caches only fully successful anonymous-method endpoint installation within one provider body request. Failed installation remains retryable.

Cold one-worker Lattice evidence:
- retired instructions: -1.674% median (0.052% MAD), 16 balanced pairs
- clock: -1.03% median (1.76% MAD)
- peak RSS: +0.20% median (0.32% MAD)
- allocations: 336,987–337,377 fewer calls and 24.46–24.61 MB less requested, 4 pairs
- exact compiler-work counters, source metrics, emitted metrics, and executable bytes

Validation: full rue-air unit suite, 724/724.