### PR TITLE
RUE-1432: carry anonymous local names with durable facts

### DIFF
--- a/crates/rue-compiler/src/durable_semantics.rs
+++ b/crates/rue-compiler/src/durable_semantics.rs
@@ -4,6 +4,7 @@
 //! conversion is only sound while the successful declaration binder, its type
 //! pool, and the exact-revision stable-definition join are available together.
 
+use std::hash::{Hash, Hasher};
 use std::sync::Arc;
 
 use rue_air::{
@@ -40,12 +41,99 @@ fn builtin_nominal_kind(name: &str) -> Option<SemanticImportNominalKind> {
 /// Query-owned materialization payload for one anonymous nominal referenced by
 /// declaration semantics. Identity remains separate from shape so recursive
 /// uses and structurally equal aliases can be joined before fields are filled.
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Debug, Clone)]
 pub struct DurableAnonymousNominal {
     pub identity: crate::AnonymousNominalKey,
+    /// Exact body-local type-pool name derived once with the durable fact.
+    ///
+    /// This deliberately preserves the historical full-identity Debug
+    /// spelling. It is not the canonical source symbol and therefore does not
+    /// participate in the RUE-1295 spelling decision.
+    materialization_name: Arc<str>,
     pub shape: DurableAnonymousNominalShape,
     pub type_captures: Arc<[(Arc<str>, DurableType)]>,
     pub value_captures: Arc<[(Arc<str>, DurableConstValue)]>,
+}
+
+impl DurableAnonymousNominal {
+    fn semantic_parts(
+        &self,
+    ) -> (
+        &crate::AnonymousNominalKey,
+        &DurableAnonymousNominalShape,
+        &Arc<[(Arc<str>, DurableType)]>,
+        &Arc<[(Arc<str>, DurableConstValue)]>,
+    ) {
+        (
+            &self.identity,
+            &self.shape,
+            &self.type_captures,
+            &self.value_captures,
+        )
+    }
+
+    pub(crate) fn new(
+        identity: crate::AnonymousNominalKey,
+        shape: DurableAnonymousNominalShape,
+        type_captures: Arc<[(Arc<str>, DurableType)]>,
+        value_captures: Arc<[(Arc<str>, DurableConstValue)]>,
+    ) -> Self {
+        let materialization_name = Arc::from(format!(
+            "anonymous-{:?}",
+            identity.with_canonical_producer()
+        ));
+        Self {
+            identity,
+            materialization_name,
+            shape,
+            type_captures,
+            value_captures,
+        }
+    }
+
+    pub(crate) fn with_shape(&self, shape: DurableAnonymousNominalShape) -> Self {
+        Self {
+            identity: self.identity.clone(),
+            materialization_name: self.materialization_name.clone(),
+            shape,
+            type_captures: self.type_captures.clone(),
+            value_captures: self.value_captures.clone(),
+        }
+    }
+
+    pub(crate) fn materialization_name(&self) -> &Arc<str> {
+        &self.materialization_name
+    }
+}
+
+// The carried name is a cache derived entirely from `identity`, not a new part
+// of the durable fact's semantic identity. Keep equality, ordering, and hashing
+// identical to the pre-cache representation so query keys do not hash the
+// formatted name or invalidate merely because the cache representation changes.
+impl PartialEq for DurableAnonymousNominal {
+    fn eq(&self, other: &Self) -> bool {
+        self.semantic_parts() == other.semantic_parts()
+    }
+}
+
+impl Eq for DurableAnonymousNominal {}
+
+impl PartialOrd for DurableAnonymousNominal {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for DurableAnonymousNominal {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        self.semantic_parts().cmp(&other.semantic_parts())
+    }
+}
+
+impl Hash for DurableAnonymousNominal {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.semantic_parts().hash(state);
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
@@ -148,6 +236,7 @@ impl RetainedCharge for DurableAnonymousNominal {
     fn retained_charge(&self) -> u64 {
         self.identity
             .retained_charge()
+            .saturating_add(self.materialization_name.retained_charge())
             .saturating_add(self.shape.retained_charge())
             .saturating_add(self.type_captures.retained_charge())
             .saturating_add(self.value_captures.retained_charge())

--- a/crates/rue-compiler/src/local_semantic_materialization.rs
+++ b/crates/rue-compiler/src/local_semantic_materialization.rs
@@ -733,7 +733,7 @@ pub(crate) fn materialize_semantic_body(
         rue_air::SemanticLocalNominal {
             key: rue_air::NominalInstanceKey::Anonymous(nominal.identity.clone()),
             module_path: Arc::from("<anonymous>"),
-            name: Arc::from(format!("anonymous-{:?}", nominal.identity)),
+            name: nominal.materialization_name().clone(),
             kind,
             is_public: false,
             lang_item: None,
@@ -1214,15 +1214,8 @@ pub(crate) fn select_materialization_facts(
                                 }
                             }
                         };
-                        self.selected_anonymous.insert(
-                            key,
-                            DurableAnonymousNominal {
-                                identity: nominal.identity.clone(),
-                                shape,
-                                type_captures: nominal.type_captures.clone(),
-                                value_captures: nominal.value_captures.clone(),
-                            },
-                        );
+                        self.selected_anonymous
+                            .insert(key, nominal.with_shape(shape));
                     }
                 }
             }
@@ -1665,6 +1658,72 @@ mod tests {
             &[],
         )
         .expect("fallback destructor symbols materialize without violating AIR invariants");
+    }
+
+    #[test]
+    fn anonymous_fact_selection_preserves_the_carried_materialization_name() {
+        use rue_rir::{RirStructuralAnchor, RirStructuralPathSegment};
+
+        let module = ModuleId::from_validated_canonical("main.rue");
+        let function = definition(module, StableDefinitionKind::Function, "probe", None);
+        let identity = crate::AnonymousNominalKey {
+            kind: crate::AnonymousNominalKind::Struct,
+            producer: crate::StableProducerId::Definition(function.clone()),
+            anchor: RirStructuralAnchor::new(vec![
+                RirStructuralPathSegment::Body,
+                RirStructuralPathSegment::AnonymousType(0),
+            ]),
+            arguments: crate::CanonicalArguments::default(),
+        };
+        let nominal = DurableAnonymousNominal::new(
+            identity.clone(),
+            DurableAnonymousNominalShape::Struct {
+                fields: Arc::from([(Arc::from("value"), rue_air::SemanticImportType::I32)]),
+                methods: Arc::from([]),
+            },
+            Arc::from([]),
+            Arc::from([]),
+        );
+        let expected_name = format!("anonymous-{:?}", identity.with_canonical_producer());
+        assert_eq!(expected_name, format!("anonymous-{identity:?}"));
+        assert_eq!(nominal.materialization_name().as_ref(), expected_name);
+        let (index, _) = LocalFactSelectionIndex::new(&[], std::slice::from_ref(&nominal));
+        let symbols = std::collections::BTreeMap::from([(
+            FunctionInstanceKey::Definition(function.clone()),
+            Arc::from("probe"),
+        )]);
+
+        let select = |return_type| {
+            let mut body = body();
+            body.return_type = return_type;
+            select_materialization_facts(
+                &FunctionInstanceKey::Definition(function.clone()),
+                &body,
+                &index,
+                &symbols,
+            )
+            .unwrap()
+        };
+        let full = select(rue_air::SemanticImportType::AnonymousNominal(
+            identity.clone(),
+        ));
+        let opaque = select(rue_air::SemanticImportType::PtrConst(Box::new(
+            rue_air::SemanticImportType::AnonymousNominal(identity),
+        )));
+
+        assert!(Arc::ptr_eq(
+            nominal.materialization_name(),
+            full.anonymous_nominals[0].materialization_name()
+        ));
+        assert!(Arc::ptr_eq(
+            nominal.materialization_name(),
+            opaque.anonymous_nominals[0].materialization_name()
+        ));
+        assert!(matches!(
+            &opaque.anonymous_nominals[0].shape,
+            DurableAnonymousNominalShape::Struct { fields, methods }
+                if fields.is_empty() && methods.is_empty()
+        ));
     }
 
     #[test]

--- a/crates/rue-compiler/src/revisioned_query_database.rs
+++ b/crates/rue-compiler/src/revisioned_query_database.rs
@@ -8337,24 +8337,22 @@ impl SemanticConstEvaluator<'_, '_> {
         .into_owned();
         self.provider.anonymous_nominals.insert(
             identity.clone(),
-            DurableAnonymousNominal {
-                identity: identity.clone(),
+            DurableAnonymousNominal::new(
+                identity.clone(),
                 shape,
-                type_captures: self
-                    .provider
+                self.provider
                     .substitutions
                     .iter()
                     .map(|(name, ty)| (name.clone(), ty.clone()))
                     .collect::<Vec<_>>()
                     .into(),
-                value_captures: self
-                    .provider
+                self.provider
                     .value_substitutions
                     .iter()
                     .map(|(name, value)| (name.clone(), value.clone()))
                     .collect::<Vec<_>>()
                     .into(),
-            },
+            ),
         );
         Ok(EvaluatedSemanticConst::Value(TypedSemanticConst::typed(
             V::Type(DurableType::AnonymousNominal(identity)),
@@ -22519,22 +22517,22 @@ fn project_provider_produced_anonymous_nominals(
                         .into(),
                 },
             };
-            Ok(Nominal {
+            Ok(Nominal::new(
                 identity,
                 shape,
-                type_captures: value
+                value
                     .type_captures
                     .iter()
                     .map(|(name, ty)| Ok((name.clone(), map_type(ty)?)))
                     .collect::<Result<Vec<_>, _>>()?
                     .into(),
-                value_captures: value
+                value
                     .value_captures
                     .iter()
                     .map(|(name, value)| Ok((name.clone(), map_value(value)?)))
                     .collect::<Result<Vec<_>, _>>()?
                     .into(),
-            })
+            ))
         })
         .collect::<Result<Vec<_>, _>>()
         .map(|values| crate::body_query::BodyProducedAnonymousNominals(values.into()))
@@ -29775,18 +29773,18 @@ fn main() -> i32 {
                 arguments: crate::CanonicalArguments::default(),
             },
         ));
-        let thin = crate::durable_semantics::DurableAnonymousNominal {
-            identity: wrapped.clone(),
-            shape: crate::durable_semantics::DurableAnonymousNominalShape::Struct {
+        let thin = crate::durable_semantics::DurableAnonymousNominal::new(
+            wrapped.clone(),
+            crate::durable_semantics::DurableAnonymousNominalShape::Struct {
                 fields: Arc::from([]),
                 methods: Arc::from([]),
             },
-            type_captures: Arc::from([]),
-            value_captures: Arc::from([]),
-        };
-        let rich = crate::durable_semantics::DurableAnonymousNominal {
-            identity: canonical.clone(),
-            shape: crate::durable_semantics::DurableAnonymousNominalShape::Struct {
+            Arc::from([]),
+            Arc::from([]),
+        );
+        let rich = crate::durable_semantics::DurableAnonymousNominal::new(
+            canonical.clone(),
+            crate::durable_semantics::DurableAnonymousNominalShape::Struct {
                 fields: Arc::from([]),
                 methods: Arc::from([crate::durable_semantics::DurableAnonymousMethodSignature {
                     name: Arc::from("method"),
@@ -29799,9 +29797,9 @@ fn main() -> i32 {
                     body: None,
                 }]),
             },
-            type_captures: Arc::from([]),
-            value_captures: Arc::from([]),
-        };
+            Arc::from([]),
+            Arc::from([]),
+        );
 
         let mut registry = CanonicalAnonymousNominalRegistry::default();
         registry.extend([thin.clone()]);

--- a/docs/notes/post-adr-0063-cold-compiler-architecture-audit.md
+++ b/docs/notes/post-adr-0063-cold-compiler-architecture-audit.md
@@ -1350,6 +1350,22 @@ pairs are neutral at -38 to +153 calls and -0.07 to +0.05 MB requested. Every
 published compiler-work counter, emitted-output metric, source metric, and
 executable byte remains identical.
 
+RUE-1432 carries each anonymous nominal's exact body-local materialization name
+with the durable fact that establishes its identity. Full and opaque fact
+selection share that immutable name, so body materialization no longer repeats
+the full structural Debug formatting for every selected local fact. The name is
+a derived cache rather than semantic identity: equality, ordering, and hashing
+retain the pre-cache field set, and the cached bytes are included in retained-
+charge accounting. This preserves the historical spelling without deciding
+the separate canonical anonymous-symbol question tracked by RUE-1295.
+
+Sixteen balanced fixed one-worker cold Lattice pairs reduce retired
+instructions by a 1.485% paired median with 0.057% paired MAD. Compiler clock
+moves -1.35% with 1.37% paired MAD, while peak RSS falls 2.45% with 0.25%
+paired MAD. Four allocation-accounted pairs save 113,732--114,528 allocations
+and 39.46--39.70 MB of requested bytes. Every published compiler-work counter,
+emitted-output metric, source metric, and executable byte remains identical.
+
 ## Next actions and decision boundary
 
 Authorized low-risk work:


### PR DESCRIPTION
Fixes RUE-1432. Related to RUE-1295.

## Summary

- derive each anonymous nominal's historical body-local materialization name once with its durable fact
- share that name through full and opaque fact selection instead of repeatedly formatting the structural identity
- preserve the old semantic equality/hash contract and account for the retained cache bytes
- record the cold-profile evidence in the post-ADR-0063 architecture audit

## Evidence

- focused full/opaque fact-selection regression passes
- 16 balanced cold Lattice pairs: retired instructions -1.485% median (0.057% MAD), compiler clock -1.35%, peak RSS -2.45%
- 4 allocation-accounted pairs save 113,732–114,528 allocations and 39.46–39.70 MB requested
- all work counters, source/output metrics, and emitted executable bytes are identical
