### PR TITLE
RUE-1434: bound repeated semantic-nucleus reads

### DIFF
--- a/crates/rue-compiler/BUCK
+++ b/crates/rue-compiler/BUCK
@@ -41,6 +41,7 @@ _DEPS = [
     "//crates/rue-runtime-abi:rue-runtime-abi",
     "//crates/rue-span:rue-span",
     "//crates/rue-target:rue-target",
+    "//third-party:ahash",
     "//third-party:annotate-snippets",
     "//third-party:itoa",
     "//third-party:lasso",

--- a/crates/rue-compiler/src/revisioned_query_database.rs
+++ b/crates/rue-compiler/src/revisioned_query_database.rs
@@ -13,6 +13,8 @@ use std::ops::Deref;
 use std::rc::Rc;
 use std::sync::{Arc, Mutex};
 
+use ahash::RandomState;
+
 #[derive(Debug, Default)]
 struct BodyReachabilityMeter {
     frontier_scans: std::sync::atomic::AtomicU64,
@@ -21170,7 +21172,24 @@ impl<'a> CompilerBodyProviderQueries<'a> {
 
 pub(crate) struct CompilerBodyFactProvider<'a> {
     queries: CompilerBodyProviderQueries<'a>,
+    // One provider belongs to one query task. Its first read records the exact
+    // terminal edge; an equal repeat may therefore use that already-observed
+    // terminal without crossing the runtime again. Direct mapping bounds this
+    // optimization independently of body size, and collisions only cause a
+    // canonical query miss.
+    nucleus_cache: std::cell::RefCell<[Option<SemanticNucleusCacheEntry>; 8]>,
+    #[cfg(test)]
+    nucleus_cache_hits: std::cell::Cell<u64>,
 }
+
+struct SemanticNucleusCacheEntry {
+    key: crate::semantic_query_nucleus::SemanticNucleusKey,
+    terminal: Arc<rue_query::QueryTerminal<crate::semantic_query_nucleus::SemanticNucleusValue>>,
+}
+
+// Fixed keys make cache collisions, and therefore published work counters,
+// deterministic. Exact key equality remains authoritative at every slot.
+const SEMANTIC_NUCLEUS_CACHE_HASHER: RandomState = RandomState::with_seeds(0, 1, 2, 3);
 
 #[derive(Default)]
 struct CanonicalAnonymousNominalRegistry {
@@ -22548,7 +22567,12 @@ fn project_provider_produced_anonymous_nominals(
 #[allow(dead_code)]
 impl<'a> CompilerBodyFactProvider<'a> {
     pub(crate) fn new(queries: CompilerBodyProviderQueries<'a>) -> Self {
-        Self { queries }
+        Self {
+            queries,
+            nucleus_cache: std::cell::RefCell::new(std::array::from_fn(|_| None)),
+            #[cfg(test)]
+            nucleus_cache_hits: std::cell::Cell::new(0),
+        }
     }
 
     /// Take the observed lookup-pin set for promotion into the session lease.
@@ -22744,22 +22768,52 @@ impl<'a> CompilerBodyFactProvider<'a> {
         &self,
         key: crate::semantic_query_nucleus::SemanticNucleusKey,
     ) -> Result<Option<crate::semantic_query_nucleus::SemanticNucleusValue>, QueryAbort> {
-        let terminal = self
-            .queries
-            .context
-            .query_registered(&self.queries.semantic_nucleus, key)?;
+        let terminal = self.nucleus_terminal_result(key)?;
         Ok(match terminal.outcome() {
             rue_query::QueryOutcome::Success(value) => Some(value.clone()),
             _ => None,
         })
     }
 
+    fn nucleus_terminal_result(
+        &self,
+        key: crate::semantic_query_nucleus::SemanticNucleusKey,
+    ) -> Result<
+        Arc<rue_query::QueryTerminal<crate::semantic_query_nucleus::SemanticNucleusValue>>,
+        QueryAbort,
+    > {
+        self.queries
+            .context
+            .query_registered(&self.queries.semantic_nucleus, key)
+    }
+
     fn nucleus(
         &self,
         key: crate::semantic_query_nucleus::SemanticNucleusKey,
     ) -> Option<crate::semantic_query_nucleus::SemanticNucleusValue> {
-        match self.nucleus_result(key) {
-            Ok(value) => value,
+        let cache_slot = SEMANTIC_NUCLEUS_CACHE_HASHER.hash_one(&key) as usize
+            % self.nucleus_cache.borrow().len();
+        if let Some(entry) = &self.nucleus_cache.borrow()[cache_slot]
+            && entry.key == key
+        {
+            #[cfg(test)]
+            self.nucleus_cache_hits
+                .set(self.nucleus_cache_hits.get() + 1);
+            return match entry.terminal.outcome() {
+                rue_query::QueryOutcome::Success(value) => Some(value.clone()),
+                _ => None,
+            };
+        }
+        match self.nucleus_terminal_result(key.clone()) {
+            Ok(terminal) => {
+                let value = match terminal.outcome() {
+                    rue_query::QueryOutcome::Success(value) => Some(value.clone()),
+                    _ => None,
+                };
+                self.nucleus_cache.borrow_mut()[cache_slot] =
+                    Some(SemanticNucleusCacheEntry { key, terminal });
+                value
+            }
             Err(abort) => {
                 self.observe_abort(abort);
                 None
@@ -34079,6 +34133,38 @@ fn main() -> i32 {
                     || *family == "compiler.body-toolchain-demands"),
             "declaration facts observe only their exact backing terminals: {families:?}"
         );
+    }
+
+    #[test]
+    fn provider_repeated_nucleus_fact_reuses_the_request_local_terminal() {
+        use crate::declaration_candidate::DeclarationCandidateCategory as Cat;
+        use rue_air::BodyFactProvider;
+        let snapshot = source_snapshot(
+            &[(
+                1,
+                "/m.rue",
+                "m.rue",
+                "fn helper(x: i32) -> i32 { x }\nfn main() -> i32 { helper(0) }\n",
+            )],
+            1,
+        );
+        let m = ModuleId::from_logical_path("m.rue").unwrap();
+        let mut database = RevisionedQueryDatabase::default();
+        let revision = revision_for(&mut database, &snapshot);
+        let helper = declaration_candidate(&database, revision, &m, Cat::Function, "helper");
+        let outcome = database.probe_ready_body_facts(
+            revision,
+            semantic_configuration(),
+            "repeated-nucleus-fact",
+            move |provider| {
+                let first = provider.signature(&helper);
+                let second = provider.signature(&helper);
+                (first, second, provider.nucleus_cache_hits.get())
+            },
+        );
+
+        assert_eq!(outcome.result.0, outcome.result.1);
+        assert_eq!(outcome.result.2, 1);
     }
 
     // ---- RUE-1091 r4b-1: call-resolution ProviderFacts differentials --------

--- a/docs/notes/post-adr-0063-cold-compiler-architecture-audit.md
+++ b/docs/notes/post-adr-0063-cold-compiler-architecture-audit.md
@@ -1381,6 +1381,23 @@ allocation-accounted pairs are neutral at -170 to -72 calls and -0.03 to
 +0.06 MB requested. Every published compiler-work counter, emitted-output
 metric, source metric, and executable byte remains identical.
 
+RUE-1434 keeps repeated semantic-nucleus reads inside one body request on the
+terminal that request has already observed. The exact provider remains the
+canonical query consumer on every miss; a fixed eight-entry direct-mapped
+cache merely reuses the immutable terminal for an immediately repeated key.
+Deterministic keyed hashing makes the work result repeatable, and the inline
+slots keep the cache's memory bounded independently of body size.
+
+An unbounded request-local map was rejected despite removing 30,526 Lattice
+query reuses because it added about 34 MB of requested allocation traffic. The
+bounded form removes exactly 19,486 query-runtime reuses. Sixteen balanced
+release pairs are clock-neutral at +0.51% with 1.46% paired MAD; retired
+instructions are neutral at -0.046% with 0.035% paired MAD, and peak RSS is
+neutral at -0.16% with 0.34% paired MAD. Four allocation-accounted comparisons
+are neutral at -211 to +274 calls and -0.20 to +0.00 MB requested. Semantic-
+provider counters, every compiler-work counter other than the removed reuses,
+source/output metrics, and executable bytes remain identical.
+
 ## Next actions and decision boundary
 
 Authorized low-risk work:


### PR DESCRIPTION
Fixes RUE-1434.\n\n## Summary\n\n- reuse an already-observed semantic-nucleus terminal for equal reads inside one body request\n- bound the optimization to eight deterministic direct-mapped inline slots\n- retain canonical query behavior on every miss or collision\n- add a focused cache-hit regression and record the measured result\n\n## Evidence\n\n- fixed cold Lattice removes exactly 19,486 query-runtime reuses\n- 16 balanced release pairs: retired instructions -0.046% (0.035% MAD), RSS -0.16% (0.34% MAD), clock neutral\n- 4 allocation-accounted comparisons are neutral\n- semantic-provider counters, all other work counters, and emitted bytes are identical\n- the unbounded-map alternative was rejected because it added about 34 MB of allocation traffic