### PR TITLE
RUE-1435: size bounded nucleus cache

### DIFF
--- a/crates/rue-compiler/src/revisioned_query_database.rs
+++ b/crates/rue-compiler/src/revisioned_query_database.rs
@@ -21177,7 +21177,8 @@ pub(crate) struct CompilerBodyFactProvider<'a> {
     // terminal without crossing the runtime again. Direct mapping bounds this
     // optimization independently of body size, and collisions only cause a
     // canonical query miss.
-    nucleus_cache: std::cell::RefCell<[Option<SemanticNucleusCacheEntry>; 8]>,
+    nucleus_cache:
+        std::cell::RefCell<[Option<SemanticNucleusCacheEntry>; SEMANTIC_NUCLEUS_CACHE_SLOTS]>,
     #[cfg(test)]
     nucleus_cache_hits: std::cell::Cell<u64>,
 }
@@ -21187,8 +21188,12 @@ struct SemanticNucleusCacheEntry {
     terminal: Arc<rue_query::QueryTerminal<crate::semantic_query_nucleus::SemanticNucleusValue>>,
 }
 
-// Fixed keys make cache collisions, and therefore published work counters,
-// deterministic. Exact key equality remains authoritative at every slot.
+// The maintained cold scaling curve selects 16 slots. Larger capacities remove
+// more query work but measurably raise peak RSS; 16 is the largest tested point
+// with neutral memory. Fixed keys make cache collisions, and therefore
+// published work counters, deterministic. Exact key equality remains
+// authoritative at every slot.
+const SEMANTIC_NUCLEUS_CACHE_SLOTS: usize = 16;
 const SEMANTIC_NUCLEUS_CACHE_HASHER: RandomState = RandomState::with_seeds(0, 1, 2, 3);
 
 #[derive(Default)]

--- a/docs/notes/post-adr-0063-cold-compiler-architecture-audit.md
+++ b/docs/notes/post-adr-0063-cold-compiler-architecture-audit.md
@@ -1398,6 +1398,26 @@ are neutral at -211 to +274 calls and -0.20 to +0.00 MB requested. Semantic-
 provider counters, every compiler-work counter other than the removed reuses,
 source/output metrics, and executable bytes remain identical.
 
+RUE-1435 sizes that same bounded cache from the maintained scaling curve rather
+than leaving its initial capacity as a guess. Moving from eight to 16 slots
+removes another 835, 1,452, 2,855 and 3,622 query-runtime reuses from Ruelex
+through Lattice. Thirty-two slots remove 1,237, 2,079, 4,144 and 7,561 reuses
+relative to eight, but twelve alternating Lattice pairs raise peak RSS by a
+consistent 0.54% paired median with 0.24% paired MAD. Doubling again to 64
+removes only another 349, 437, 800 and 1,551 reuses respectively. Both larger
+capacities are rejected: 32 crosses the no-regression memory boundary and 64
+has sharply diminishing work reduction per retained inline slot.
+
+Twelve alternating fixed one-worker Lattice comparisons of eight versus 16
+slots are clock-neutral at a 0.00% paired median with 1.57% paired MAD; retired
+instructions are neutral at -0.021% with 0.029% paired MAD, and peak RSS is
+neutral at -0.22% with 0.51% paired MAD. Four allocation-accounted pairs are
+neutral at median deltas of +200 calls and +0.10 MB requested. The complete
+capacity curve preserves semantic-provider counters, source/output metrics,
+and executable bytes. The selected 16-slot cache remains request-scoped,
+allocation-free, deterministic and bounded independently of body size; misses
+still cross the canonical query path.
+
 ## Next actions and decision boundary
 
 Authorized low-risk work:


### PR DESCRIPTION
Fixes RUE-1435.

## Summary
- size the request-scoped semantic-nucleus cache from the maintained cold scaling curve
- select 16 slots as the largest measured capacity with neutral peak memory
- document the rejected 32/64-slot tradeoffs so the bound is an evidence-backed policy rather than a guess

## Evidence
- exact query-runtime reuse reductions from eight to 16 slots: Ruelex 835, Mosaic 1,452, Harbor 2,855, Lattice 3,622
- twelve alternating one-worker Lattice pairs: clock 0.00% paired median (1.57% MAD), retired instructions -0.021% (0.029% MAD), peak RSS -0.22% (0.51% MAD)
- four allocation-accounted pairs are neutral at median deltas of +200 calls and +0.10 MB requested
- semantic-provider counters, source/output metrics, and executable bytes are identical
- 32 slots was rejected after a consistent +0.54% peak-RSS median; 64 had sharply diminishing work reduction
- the focused repeated-read cache regression passes; CI is the broad-platform authority