### PR TITLE
RUE-1438: specialize retained terminal hashing

### DIFF
--- a/crates/rue-query/src/lib.rs
+++ b/crates/rue-query/src/lib.rs
@@ -3607,18 +3607,18 @@ impl Hasher for IncarnationHasher {
     }
 }
 
-/// Fast hashing for retained semantic-stamp identities.
+/// Fast hashing for retained terminal and semantic-stamp identities.
 ///
-/// The complete key is runtime-owned: it combines a monotonically assigned,
-/// runtime-unique node incarnation with one of that node's semantic stamps.
-/// Retention bounds also limit the number of historical stamps per node. Mix
-/// both fixed-width components without paying SipHash on the retention and
-/// validation hot path; caller-controlled query-key maps keep randomized
-/// hashing.
+/// The complete keys are runtime-owned: they combine a monotonically assigned,
+/// runtime-unique node incarnation with one of that node's semantic stamps and,
+/// for exact terminal identity, a runtime revision. Retention bounds also limit
+/// the number of historical stamps and revisions per node. Mix these fixed-width
+/// components without paying SipHash on the retention and validation hot path;
+/// caller-controlled query-key maps keep randomized hashing.
 #[derive(Debug, Default)]
-struct RetainedStampHasher(u64);
+struct RetainedIdentityHasher(u64);
 
-impl Hasher for RetainedStampHasher {
+impl Hasher for RetainedIdentityHasher {
     fn finish(&self) -> u64 {
         self.0
     }
@@ -8441,12 +8441,12 @@ pub struct RetainedPinSet {
     /// `(node incarnation, stamp, terminal revision)` of every terminal already
     /// leased here, mirroring [`TaskLeases::observed`] so a redundant re-lease is
     /// dropped rather than double-held.
-    observed: HashSet<(u64, u64, Revision)>,
+    observed: HashSet<(u64, u64, Revision), BuildHasherDefault<RetainedIdentityHasher>>,
     /// Node-incarnation/stamp identities retained by at least one exact
     /// terminal revision in this set. Query dependency edges use this same
     /// semantic identity, so any complete retained cone carrying the stamp can
     /// supply its representative terminal during final promotion.
-    stamp_identities: HashSet<(u64, u64), BuildHasherDefault<RetainedStampHasher>>,
+    stamp_identities: HashSet<(u64, u64), BuildHasherDefault<RetainedIdentityHasher>>,
     /// Runtime identities represented by held pins. This makes same-runtime
     /// authority checks proportional to the number of fallback sets, not pins.
     runtime_identities: HashSet<u64>,
@@ -11084,16 +11084,38 @@ mod tests {
     }
 
     #[test]
-    fn retained_stamp_hasher_mixes_both_runtime_identity_components() {
-        let hash = |identity: (u64, u64)| {
-            let mut hasher = RetainedStampHasher::default();
+    fn retained_identity_hasher_mixes_every_runtime_identity_component() {
+        let stamp_hash = |identity: (u64, u64)| {
+            let mut hasher = RetainedIdentityHasher::default();
+            std::hash::Hash::hash(&identity, &mut hasher);
+            hasher.finish()
+        };
+        let terminal_hash = |identity: (u64, u64, Revision)| {
+            let mut hasher = RetainedIdentityHasher::default();
             std::hash::Hash::hash(&identity, &mut hasher);
             hasher.finish()
         };
 
-        assert_eq!(hash((7, 11)), hash((7, 11)));
-        assert_ne!(hash((7, 11)), hash((8, 11)));
-        assert_ne!(hash((7, 11)), hash((7, 12)));
+        assert_eq!(stamp_hash((7, 11)), stamp_hash((7, 11)));
+        assert_ne!(stamp_hash((7, 11)), stamp_hash((8, 11)));
+        assert_ne!(stamp_hash((7, 11)), stamp_hash((7, 12)));
+
+        assert_eq!(
+            terminal_hash((7, 11, revision(13))),
+            terminal_hash((7, 11, revision(13)))
+        );
+        assert_ne!(
+            terminal_hash((7, 11, revision(13))),
+            terminal_hash((8, 11, revision(13)))
+        );
+        assert_ne!(
+            terminal_hash((7, 11, revision(13))),
+            terminal_hash((7, 12, revision(13)))
+        );
+        assert_ne!(
+            terminal_hash((7, 11, revision(13))),
+            terminal_hash((7, 11, revision(14)))
+        );
     }
 
     #[test]

--- a/docs/notes/post-adr-0063-cold-compiler-architecture-audit.md
+++ b/docs/notes/post-adr-0063-cold-compiler-architecture-audit.md
@@ -1455,6 +1455,24 @@ allocation-accounted pairs are neutral at median deltas of +76 calls and
 -0.03 MB requested. Every published compiler-work counter, source/output
 metric, and executable byte remains identical.
 
+RUE-1438 extends the runtime-owned retained-identity hasher from semantic
+`(incarnation, stamp)` authority to the adjacent exact-terminal
+`(incarnation, stamp, revision)` deduplication index. Every component is minted
+by the runtime, exact equality remains authoritative, and caller-controlled
+query-key maps stay randomized. This closes the published `RetainedPinSet`
+counterpart to RUE-1378's request-local task lease index without adding another
+hashing policy.
+
+A randomized AHash prototype reduced instructions by the same amount but moved
+peak RSS +0.43% at the paired median, so it was rejected. Sixteen balanced
+alternating fixed one-worker cold Lattice pairs with the existing zero-sized
+runtime hasher reduce retired instructions by a 0.498% paired median with 0.049%
+paired MAD. Compiler clock moves -1.05% with 1.04% paired MAD, cycles move
+-0.76% with 0.67% paired MAD, and peak RSS moves -0.52% with 0.23% paired MAD.
+Four allocation-accounted pairs are neutral at a median -82 calls and save
+0.15 MB of requested bytes. Every compiler-work counter,
+source/output metric, and executable byte remains identical.
+
 ## Next actions and decision boundary
 
 Authorized low-risk work:


### PR DESCRIPTION
## Summary

- reuse the query runtime's purpose-specific retained-identity mixer for exact terminal deduplication
- keep caller-controlled query-key maps randomized and exact equality authoritative
- extend the cold architecture audit with accepted and rejected candidate evidence

## Performance

Across 16 balanced alternating fixed one-worker cold Lattice pairs:

- retired instructions: -0.498% paired median (0.049% MAD)
- compiler clock: -1.05% paired median (1.04% MAD)
- cycles: -0.76% paired median (0.67% MAD)
- peak RSS: -0.52% paired median (0.23% MAD)

Four allocation-accounted pairs moved by -82 allocation calls and -0.15 MB requested at the median. Every compiler-work counter, source/output metric, and executable byte remained identical. A simpler AHash prototype was rejected because it increased peak RSS by 0.43%.

## Validation

- `scripts/rue unit query retained_identity_hasher`
- `scripts/rue unit query retained_pin_set`
- `scripts/rue quick`

Fixes RUE-1438.
