### PR TITLE
RUE-1440: specialize retained runtime hashing

### DIFF
--- a/crates/rue-query/src/lib.rs
+++ b/crates/rue-query/src/lib.rs
@@ -8449,7 +8449,7 @@ pub struct RetainedPinSet {
     stamp_identities: HashSet<(u64, u64), BuildHasherDefault<RetainedIdentityHasher>>,
     /// Runtime identities represented by held pins. This makes same-runtime
     /// authority checks proportional to the number of fallback sets, not pins.
-    runtime_identities: HashSet<u64>,
+    runtime_identities: HashSet<u64, BuildHasherDefault<IncarnationHasher>>,
     /// Live pins, type-erased across families. Dropping the set drops these
     /// through the batched two-phase release.
     held: Vec<Box<dyn ObservedLease>>,

--- a/docs/notes/post-adr-0063-cold-compiler-architecture-audit.md
+++ b/docs/notes/post-adr-0063-cold-compiler-architecture-audit.md
@@ -1473,6 +1473,32 @@ Four allocation-accounted pairs are neutral at a median -82 calls and save
 0.15 MB of requested bytes. Every compiler-work counter,
 source/output metric, and executable byte remains identical.
 
+RUE-1439 tested replacing `RetainedPinSet`'s remaining runtime-identity set
+with the exact empty / one-runtime / mixed-runtime state its consumers need.
+Across two independent sets of 16 balanced alternating fixed one-worker cold
+Lattice pairs, the candidate reduced retired instructions by a 0.145% paired
+median but increased peak RSS by a repeatable 0.60% paired median with 0.30%
+paired MAD. The representation change was rejected under the no-regression
+gate.
+
+RUE-1440 keeps the fail-closed set representation but applies the query
+runtime's existing runtime-owned `u64` hasher to it. Sixteen balanced
+alternating fixed one-worker cold Lattice pairs reduce retired instructions by
+a 0.068% paired median with 0.044% paired MAD. Compiler clock, cycles, and peak
+RSS are neutral at 0.00%, +0.07%, and +0.09% paired medians respectively. Four
+allocation-accounted pairs are neutral at a median +7 calls and save 0.13 MB of
+requested bytes. Every compiler-work counter, source/output metric, and
+executable byte remains identical.
+
+RUE-1441 tested lasso's supported keyed-AHash feature for every shared string
+interner. Sixteen balanced alternating fixed one-worker Lattice pairs reduced
+retired instructions by 1.562% and compiler clock by 2.11% at the paired
+median. Twenty-four Harbor pairs confirmed a 1.630% instruction reduction, but
+also raised peak RSS by a repeatable 0.42% paired median with 0.20% paired MAD.
+Allocation accounting and every compiler-work/output invariant were neutral.
+The feature was rejected under the no-regression memory boundary; the measured
+speed/memory tradeoff remains available for a future explicit policy decision.
+
 ## Next actions and decision boundary
 
 Authorized low-risk work:


### PR DESCRIPTION
## Summary

- reuse the query runtime's purpose-specific `u64` hasher for retained runtime-identity checks
- preserve the existing fail-closed empty, same-runtime, foreign-runtime, and mixed-runtime behavior
- record this accepted result and two rejected memory-regressing alternatives in the cold architecture audit

## Performance

Across 16 balanced alternating fixed one-worker cold Lattice pairs:

- retired instructions: -0.068% paired median (0.044% MAD)
- compiler clock: 0.00% paired median (1.06% MAD; neutral)
- cycles: +0.07% paired median (0.60% MAD; neutral)
- peak RSS: +0.09% paired median (0.33% MAD; neutral)

Four allocation-accounted pairs moved by +7 calls and -0.13 MB requested at the median. Every compiler-work counter, source/output metric, and executable byte remained identical.

## Validation

- `scripts/rue unit query incarnation_hasher`
- `scripts/rue unit query exact_terminal_cone_rejects_fallback_roots_and_foreign_runtime_snapshots`
- `scripts/rue quick`

Fixes RUE-1440.
