### PR TITLE
RUE-1446: inline common validation proof stacks

### DIFF
--- a/crates/rue-query/BUCK
+++ b/crates/rue-query/BUCK
@@ -4,6 +4,7 @@ rue_crate(
     name = "rue-query",
     deps = [
         "//third-party:ahash",
+        "//third-party:smallvec",
         "//third-party:tracing",
     ],
 )

--- a/crates/rue-query/src/lib.rs
+++ b/crates/rue-query/src/lib.rs
@@ -15,6 +15,7 @@ use std::sync::atomic::{AtomicBool, AtomicU64, AtomicUsize, Ordering};
 use std::sync::{Arc, Condvar, Mutex, MutexGuard, RwLock, RwLockReadGuard, RwLockWriteGuard, Weak};
 
 use ahash::{AHashMap, AHashSet, RandomState};
+use smallvec::SmallVec;
 
 static NEXT_RUNTIME_ID: AtomicU64 = AtomicU64::new(1);
 
@@ -22,6 +23,8 @@ const VALIDATION_PROOF_REGISTERED: u8 = 0;
 const VALIDATION_PROOF_RETRYABLE: u8 = 1;
 const VALIDATION_PROOF_UNREGISTERED: u8 = 2;
 const VALIDATION_PUBLISH_SWEEP_QUANTUM: usize = 64;
+
+type ValidationProofStack = SmallVec<[u8; 8]>;
 
 /// Initial runtime-wide soft budget for deterministic retained terminal charge.
 ///
@@ -4631,7 +4634,7 @@ impl QueryRuntime {
             validation_endorsements: Mutex::new(Vec::new()),
             batch_validation_authority: None,
             validation_proof_parent: None,
-            validation_proofs: Mutex::new(Vec::new()),
+            validation_proofs: Mutex::new(ValidationProofStack::new()),
             validation_work: AtomicValidationWork::default(),
             leases: Mutex::new(TaskLeases::default()),
             query_cache: Mutex::new(TaskQueryCache::default()),
@@ -8100,7 +8103,7 @@ struct Task {
     /// Active recursive validation certificates local to this task.
     /// Encountering an unregistered node taints these and every enclosing
     /// task's active traversal through `validation_proof_parent`.
-    validation_proofs: Mutex<Vec<u8>>,
+    validation_proofs: Mutex<ValidationProofStack>,
     /// High-frequency validation work accumulated on this rooted request and
     /// merged into the runtime once at task completion.
     validation_work: AtomicValidationWork,
@@ -9327,7 +9330,7 @@ impl Task {
             ),
             batch_validation_authority: Some(authority),
             validation_proof_parent: Some(Arc::downgrade(self)),
-            validation_proofs: Mutex::new(Vec::new()),
+            validation_proofs: Mutex::new(ValidationProofStack::new()),
             validation_work: AtomicValidationWork::default(),
             leases: Mutex::new(TaskLeases::default()),
             query_cache: Mutex::new(TaskQueryCache::default()),
@@ -10790,6 +10793,18 @@ mod tests {
         assert!(!active.insert(INLINE_ACTIVE_VALIDATIONS as u64 + 2));
         assert!(active.remove(&1));
         assert!(active.insert(1));
+    }
+
+    #[test]
+    fn validation_proof_stack_keeps_common_depth_inline_without_growing_tasks() {
+        assert!(std::mem::size_of::<ValidationProofStack>() <= std::mem::size_of::<Vec<u8>>());
+
+        let mut proofs = ValidationProofStack::new();
+        proofs.resize(8, VALIDATION_PROOF_REGISTERED);
+        assert!(!proofs.spilled());
+
+        proofs.push(VALIDATION_PROOF_REGISTERED);
+        assert!(proofs.spilled());
     }
 
     #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -13179,7 +13194,7 @@ mod tests {
             validation_endorsements: Mutex::new(Vec::new()),
             batch_validation_authority: None,
             validation_proof_parent: None,
-            validation_proofs: Mutex::new(Vec::new()),
+            validation_proofs: Mutex::new(ValidationProofStack::new()),
             validation_work: AtomicValidationWork::default(),
             leases: Mutex::new(TaskLeases::default()),
             query_cache: Mutex::new(TaskQueryCache::default()),
@@ -13232,7 +13247,7 @@ mod tests {
             validation_endorsements: Mutex::new(Vec::new()),
             batch_validation_authority: None,
             validation_proof_parent: None,
-            validation_proofs: Mutex::new(Vec::new()),
+            validation_proofs: Mutex::new(ValidationProofStack::new()),
             validation_work: AtomicValidationWork::default(),
             leases: Mutex::new(TaskLeases::default()),
             query_cache: Mutex::new(TaskQueryCache::default()),
@@ -13507,7 +13522,7 @@ mod tests {
             validation_endorsements: Mutex::new(Vec::new()),
             batch_validation_authority: None,
             validation_proof_parent: None,
-            validation_proofs: Mutex::new(Vec::new()),
+            validation_proofs: Mutex::new(ValidationProofStack::new()),
             validation_work: AtomicValidationWork::default(),
             leases: Mutex::new(TaskLeases::default()),
             query_cache: Mutex::new(TaskQueryCache::default()),

--- a/docs/notes/post-adr-0063-cold-compiler-architecture-audit.md
+++ b/docs/notes/post-adr-0063-cold-compiler-architecture-audit.md
@@ -1528,7 +1528,6 @@ compiler clock by 1.5903% (MAD 1.5903%), and cycles by 1.2335% (MAD 0.9286%);
 RSS was neutral. Four allocation-accounting pairs were neutral at a median
 -33.5 calls and -27,530 requested bytes. Compiler work, source metrics,
 emitted-output metrics, and executable digest remained exact.
-
 RUE-1445 replaces the instruction scheduler's per-class physical-register hash
 maps with lazily grown dense vectors indexed by each backend's compiler-owned
 `repr(u8)` register identity. The vectors retain storage across basic blocks,
@@ -1539,6 +1538,43 @@ is unchanged. Sixteen balanced Lattice pairs reduced retired instructions by
 allocation-accounting pairs removed a median 17,737 calls while requested bytes
 were neutral at +143,128. Compiler work, source metrics, emitted-output metrics,
 and both AArch64 and x86-64 executable digests remained exact.
+
+RUE-1446 keeps each task's first eight nested registered-validation proof states
+inline. RUE-1443 removed shared state from each traversal, but the replacement
+`Vec<u8>` still allocated its first tiny buffer once a task validated anything;
+the inline stack preserves the same lexical proof, locking, batch-parent, and
+deep spill behavior. Sixteen balanced Lattice pairs reduced retired
+instructions by 0.2373% (MAD 0.0602%); compiler clock, cycles, and RSS were
+neutral. Allocation accounting removed a median 94,580.5 calls and 709,786
+requested bytes. Compiler work, source metrics, emitted-output metrics, and
+executable digest remained exact.
+
+RUE-1447 tested reading the final validation-proof byte once instead of taking
+the same task-local mutex separately for the registered-only and retryable
+results. Across 32 balanced Lattice pairs, retired instructions and clock were
+neutral, while peak RSS increased by a 0.9028% paired median with 0.5174%
+paired MAD. Allocation accounting, compiler work, source/output metrics, and
+the executable digest were neutral. The candidate was rejected under the
+no-regression memory boundary.
+
+RUE-1448 tested applying the query runtime's retained-identity hasher to its
+remaining runtime-owned exact-terminal sets. Replacing all four task, batch,
+and lexical sets increased peak RSS by a 0.9922% paired median (0.5932% MAD)
+over 16 balanced Lattice pairs, with neutral instructions and clock. Keeping
+the batch lease tree and task lease hash set unchanged reduced allocator
+requests by 3.10 MB but still increased peak RSS by a repeatable 1.2662%
+(0.5270% MAD), while instructions and clock remained neutral. Both variants
+preserved every compiler-work counter, source/output metric, and executable
+byte, but were rejected under the no-regression memory boundary.
+
+RUE-1449 tested replacing the stable symbol encoder's formatted constant
+version prefix with a direct string copy. The direct copy lost the formatter's
+useful incidental starting capacity: across 16 balanced Lattice pairs it added
+a median 41,662 allocation calls and 2.27 MB of requested bytes, increased
+retired instructions by 0.1688% (0.0497% MAD), and increased peak RSS by
+1.2218% (0.2941% MAD). Compiler clock was neutral and every work,
+source/output, and executable invariant remained exact. The candidate was
+rejected.
 
 ## Next actions and decision boundary
 


### PR DESCRIPTION
Fixes RUE-1446.

Keeps the common first eight registered-validation proof states inline in each task while preserving arbitrary-depth spill behavior and the existing lexical/batch proof semantics. The audit also records the bounded follow-up candidates rejected by the no-regression gate.

Measured against the exact dense-scheduler parent over 16 balanced one-worker cold Lattice pairs:

- retired instructions: -0.2373% paired median (0.0602% MAD)
- compiler clock, cycles, and peak RSS: neutral
- allocations: -94,580.5 calls and -709,786 requested bytes at the median
- compiler work, source metrics, emitted-output metrics, and executable digest: exact

Local validation: focused proof-stack and registered-batch tests plus `scripts/rue quick`. CI is the full-platform authority.