### PR TITLE
RUE-1453: reuse one liveness dataflow scratch bitset

### DIFF
--- a/crates/rue-codegen/src/liveness.rs
+++ b/crates/rue-codegen/src/liveness.rs
@@ -608,11 +608,12 @@ fn compute_dataflow(
 
     let mut live_in: Vec<FixedBitSet> =
         vec![FixedBitSet::with_capacity(vreg_count_usize); num_insts];
-    // The transfer function needs two temporary sets regardless of instruction
-    // count or convergence rounds. Reuse their backing storage instead of
-    // allocating two full-width bitsets for every row on every pass.
+    // The transfer function needs one temporary set regardless of instruction
+    // count or convergence rounds. Build live-out directly in that set, then
+    // apply defs and uses in place to obtain live-in. Reusing one backing store
+    // avoids both a full-width scratch allocation and one full-width clone for
+    // every row on every pass.
     let mut new_live_in = FixedBitSet::with_capacity(vreg_count_usize);
-    let mut new_live_out = FixedBitSet::with_capacity(vreg_count_usize);
     #[cfg(test)]
     let mut sweeps = 0;
 
@@ -624,13 +625,12 @@ fn compute_dataflow(
         // Process instructions in reverse order for faster convergence
         for idx in (0..num_insts).rev() {
             // Compute live_out as union of live_in of all successors
-            new_live_out.clear();
+            new_live_in.clear();
             for &succ in &successors[idx] {
-                new_live_out.union_with(&live_in[succ]);
+                new_live_in.union_with(&live_in[succ]);
             }
 
             // Compute live_in = uses ∪ (live_out - defs)
-            new_live_in.clone_from(&new_live_out);
             for vreg in &inst_defs[idx] {
                 new_live_in.set(vreg.index() as usize, false);
             }

--- a/docs/notes/post-adr-0063-cold-compiler-architecture-audit.md
+++ b/docs/notes/post-adr-0063-cold-compiler-architecture-audit.md
@@ -1627,6 +1627,21 @@ clock +0.1361% paired median (0.5372% MAD), retired instructions -0.0111%
 +198 calls and +37,008 requested bytes. Every published compiler-work counter,
 source/output metric, and executable byte remained identical.
 
+RUE-1453 reuses one full-width scratch bitset inside backend liveness dataflow.
+The fixed-point transfer previously built `live_out` in one scratch allocation,
+cloned its complete register width into a second scratch allocation for every
+instruction and sweep, then immediately mutated that clone with defs and uses.
+Building the successor union directly in the reusable `live_in` scratch removes
+the second allocation and the per-row clone without changing the fixed-point
+order, acyclic fast path, or live-set projections.
+
+Against the exact RUE-1452 candidate, 16 balanced fixed one-worker cold Lattice
+pairs reduced retired instructions by a 0.2255% paired median (0.0491% MAD).
+Compiler clock and cycles were neutral at +0.0000% (1.0485% MAD) and -0.1220%
+(0.6329% MAD). Peak RSS improved by 0.4168% (0.2528% MAD), and peak footprint
+improved by 0.2856% (0.1430% MAD). Every published compiler-work counter,
+source/output metric, and executable byte remained identical.
+
 ## Next actions and decision boundary
 
 Authorized low-risk work:


### PR DESCRIPTION
Fixes RUE-1453.

## Summary

- build each liveness `live_out` union directly in the reusable `live_in` scratch bitset
- remove the second full-width scratch allocation and one full-width clone per instruction per fixed-point sweep
- preserve the existing transfer equation, convergence order, acyclic fast path, and debug projections
- record the cold compiler measurement in the post-ADR-0063 architecture audit

## Evidence

Against the exact merged RUE-1452 parent, 16 balanced fixed one-worker cold Lattice pairs measured retired instructions -0.2255% paired median (0.0491% MAD), clock +0.0000% (1.0485% MAD), cycles -0.1220% (0.6329% MAD), peak RSS -0.4168% (0.2528% MAD), and peak footprint -0.2856% (0.1430% MAD). Every compiler-work counter, source/output metric, and emitted executable byte was identical.

Focused acyclic/cyclic dataflow tests, the full quick suite, and formatting pass locally. CI remains the full-platform authority.