### PR TITLE
RUE-1454: index only requested promotion roots exactly

### DIFF
--- a/crates/rue-query/src/lib.rs
+++ b/crates/rue-query/src/lib.rs
@@ -1076,13 +1076,19 @@ mod registered_batch_tests {
                 0,
                 move |context, _, _| {
                     let _proof = context.endorse_registered_validations();
+                    context.query_registered(&root_for_publication, Key("unrelated"))?;
                     let first = context.query_registered(&root_for_publication, Key("first"))?;
                     let second = context.query_registered(&root_for_publication, Key("second"))?;
                     let before = runtime_for_publication.metrics().active_retained_pins;
                     let retained = context
-                        .retain_observed_terminal_cones_from(&[first, second], &[])
+                        .retain_observed_terminal_cones_from(&[first.clone(), second, first], &[])
                         .unwrap();
-                    assert_eq!(retained.len(), 3, "the shared leaf is retained once");
+                    assert_eq!(
+                        retained.len(),
+                        3,
+                        "duplicate roots and their shared leaf are retained once, while the \
+                         unrelated observed root is excluded"
+                    );
                     assert_eq!(
                         runtime_for_publication.metrics().active_retained_pins,
                         before + 3,
@@ -7893,17 +7899,25 @@ impl QueryContext {
             .iter()
             .map(|authority| authority.leases.held.len())
             .sum::<usize>();
-        let mut current_exact = RetainedIdentityMap::with_capacity_and_hasher(
-            leases.held.len(),
-            BuildHasherDefault::default(),
-        );
+        let mut current_roots: RetainedIdentityMap<_, Option<&dyn ObservedLease>> =
+            RetainedIdentityMap::with_capacity_and_hasher(
+                roots.len(),
+                BuildHasherDefault::default(),
+            );
+        for root in roots {
+            current_roots
+                .entry((root.node_incarnation, root.stamp, root.revision))
+                .or_insert(None);
+        }
         let mut selected = RetainedIdentityMap::with_capacity_and_hasher(
             leases.held.len() + batch_lease_count,
             BuildHasherDefault::default(),
         );
         for lease in &leases.held {
             let identity = lease.identity();
-            current_exact.insert(identity, lease.as_ref());
+            if let Some(root) = current_roots.get_mut(&identity) {
+                *root = Some(lease.as_ref());
+            }
             let selected_for_stamp = selected
                 .entry((identity.0, identity.1))
                 .or_insert(lease.as_ref());
@@ -7944,8 +7958,10 @@ impl QueryContext {
         let mut pending = Vec::with_capacity(roots.len());
         for root in roots {
             pending.push(
-                *current_exact
+                current_roots
                     .get(&(root.node_incarnation, root.stamp, root.revision))
+                    .copied()
+                    .flatten()
                     .ok_or(RetainTerminalConeError::RootNotObserved)?,
             );
         }

--- a/docs/notes/post-adr-0063-cold-compiler-architecture-audit.md
+++ b/docs/notes/post-adr-0063-cold-compiler-architecture-audit.md
@@ -1642,6 +1642,22 @@ Compiler clock and cycles were neutral at +0.0000% (1.0485% MAD) and -0.1220%
 improved by 0.2856% (0.1430% MAD). Every published compiler-work counter,
 source/output metric, and executable byte remained identical.
 
+RUE-1454 bounds exact-root indexing during registered terminal-cone promotion
+by the requested roots rather than by every lease held by the publishing task.
+Promotion still performs its required linear lease scan to build the
+stamp-equivalent dependency index, but it now seeds exact identities from the
+roots and fills only those matches during that scan. This removes an exact-key
+hash-table entry for every unrelated task lease while preserving exact root
+selection, fallback dependency substitution, and fail-closed missing roots.
+
+Against the exact RUE-1453 candidate, 16 balanced fixed one-worker cold Lattice
+pairs were neutral for compiler clock (+0.0000%, 0.0000% paired MAD), retired
+instructions (+0.0061%, 0.0293% MAD), cycles (-0.1512%, 0.4381% MAD), and peak
+RSS (-0.1984%, 0.2794% MAD). Peak footprint improved by 0.7468% (0.2660%
+MAD). Four allocation-accounted pairs were neutral in allocation count and
+removed 4.38--4.48 MB of requested bytes. Every published compiler-work
+counter, source/output metric, and executable byte remained identical.
+
 ## Next actions and decision boundary
 
 Authorized low-risk work:


### PR DESCRIPTION
Fixes RUE-1454.

## Summary

- size the exact terminal-cone root index by requested roots instead of all task leases
- fill exact root matches during the already-required lease scan
- cover unrelated observations and duplicate roots in the cone-union regression
- record cold release and allocation-accounted evidence in the architecture audit

## Evidence

- 16 balanced cold Lattice pairs: clock, instructions, cycles, and peak RSS neutral
- peak footprint: -0.7468% paired median (0.2660% MAD)
- allocation-accounted requested bytes: -4.38 to -4.48 MB per compile; allocation count neutral
- all work/source/output counters and executable bytes exact
- `scripts/rue unit query exact_terminal_cone`
- `scripts/rue quick`
- `scripts/rue fmt`