### PR TITLE
RUE-1455: skip already-converged retention passes

### DIFF
--- a/crates/rue-query/src/lib.rs
+++ b/crates/rue-query/src/lib.rs
@@ -3368,12 +3368,12 @@ pub struct RuntimeMetrics {
     /// configured budget the policy is to grow and record the event here, never
     /// to evict a terminal the current computation still needs.
     pub retention_growth: u64,
-    /// Retention enforcement passes run. Each `enforce_retention` call — one full
-    /// eviction scan of a single family — increments this once. Batched
-    /// task-lease teardown deliberately runs one pass per distinct family
-    /// involved rather than one per released pin, so releasing N pins in one
-    /// family raises this by one, not by N; this counter is what makes that
-    /// linearity observable to tests.
+    /// Retention enforcement passes run. Each family pass which reaches the
+    /// eviction loop increments this once; an already-converged family does not.
+    /// Batched task-lease teardown deliberately requests one pass per distinct
+    /// family involved rather than one per released pin, so releasing N pins in
+    /// one family raises this by at most one, not by N. This counter makes the
+    /// resulting work reduction observable to tests.
     pub retention_enforcements: u64,
     /// Retention-queue entries examined by enforcement passes.
     ///
@@ -5570,6 +5570,22 @@ fn next_probe(current: u64, quantum: u64) -> u64 {
         .saturating_mul(quantum)
 }
 
+/// Whether a strict family pass is already known to have no retention work.
+///
+/// Keep this non-generic check out of line: every query family monomorphizes
+/// its enforcement path, while the convergence predicate depends only on the
+/// shared numeric state. A publisher which races either load still owns the
+/// strict watermark transition and therefore schedules the required pass.
+#[inline(never)]
+fn retention_already_converged(
+    retained_count: &AtomicUsize,
+    next_publish_sweep: &AtomicUsize,
+    retention_limit: usize,
+) -> bool {
+    retained_count.load(Ordering::Acquire) <= retention_limit
+        && next_publish_sweep.load(Ordering::Acquire) <= retention_limit.saturating_add(1)
+}
+
 fn evict_one_from_family<K, V>(core: &Arc<RuntimeCore>, family: &Arc<FamilyInner<K, V>>) -> bool
 where
     K: QueryKey,
@@ -6798,6 +6814,17 @@ where
     }
 
     fn enforce_retention(&self) {
+        // A released pin often asks an already-converged family for a strict
+        // pass. Skip only when both the live count and publication watermark
+        // are strict; a stale geometric watermark still needs the ordinary
+        // pass below to rebase future publish-side enforcement.
+        if retention_already_converged(
+            &self.inner.retained_count,
+            &self.inner.next_publish_sweep,
+            self.inner.retention_limit,
+        ) {
+            return;
+        }
         self.enforce_retention_with_margin(1);
     }
 
@@ -18233,8 +18260,7 @@ mod tests {
     // A rooted request which invalidates many parent/child pairs used to run
     // retention once for every stale discovery pin and every speculative child
     // publication. The task boundary is the safe batching boundary: all pins
-    // release before one strict pass per family, and the runtime-wide pass runs
-    // only after those family passes have converged.
+    // release together, and an already-converged family needs no strict pass.
     #[test]
     fn validation_only_publication_sweeps_are_batched_per_rooted_request() {
         const CHILDREN: u64 = 64;
@@ -18306,11 +18332,40 @@ mod tests {
 
         assert_eq!(
             after.retention_enforcements - before.retention_enforcements,
-            3
+            0,
+            "all three families remain below their bounds and at strict watermarks"
         );
         assert_eq!(
             after.retention_scan_entries - before.retention_scan_entries,
             0
+        );
+    }
+
+    #[test]
+    fn strict_retention_rebases_a_stale_watermark_below_the_family_limit() {
+        let runtime = QueryRuntime::new(1);
+        publish_empty(&runtime, [revision(1)]);
+        let family = runtime
+            .family::<Key, u64>("stale-strict-watermark", 8)
+            .unwrap();
+        runtime
+            .query(
+                &family,
+                revision(1),
+                Key("root"),
+                CancellationToken::new(),
+                |_| Ok(QueryOutput::success(1)),
+            )
+            .unwrap();
+        assert_eq!(family.inner.retained_count.load(Ordering::Acquire), 1);
+
+        family.inner.next_publish_sweep.store(64, Ordering::Release);
+        let before = runtime.metrics().retention_enforcements;
+        family.enforce_retention();
+        assert_eq!(runtime.metrics().retention_enforcements, before + 1);
+        assert_eq!(
+            family.inner.next_publish_sweep.load(Ordering::Acquire),
+            family.inner.retention_limit + 1
         );
     }
 

--- a/docs/notes/post-adr-0063-cold-compiler-architecture-audit.md
+++ b/docs/notes/post-adr-0063-cold-compiler-architecture-audit.md
@@ -1658,6 +1658,22 @@ MAD). Four allocation-accounted pairs were neutral in allocation count and
 removed 4.38--4.48 MB of requested bytes. Every published compiler-work
 counter, source/output metric, and executable byte remained identical.
 
+RUE-1455 skips strict family-retention passes which are already converged: the
+live terminal count is at or below the family bound and the publication
+watermark is already at the strict next-publication threshold. A stale
+geometric watermark still enters the ordinary pass so later publication cannot
+hide above the bound. The convergence predicate is one non-generic out-of-line
+helper rather than repeated code in every monomorphized query family.
+
+Cold one-worker Lattice removes exactly 9,793 no-op retention passes, reducing
+`retention_enforcements` from 11,261 to 1,468 while preserving all 31,549
+retention scan-entry visits. Across 32 balanced release pairs, compiler clock
+is neutral at +0.0000% paired median (1.0989% MAD), retired instructions at
+-0.0085% (0.0609% MAD), cycles at +0.2444% (0.9928% MAD), peak RSS at +0.0060%
+(0.3161% MAD), and peak footprint at +0.0601% (0.1746% MAD). Four
+allocation-accounted pairs are neutral. Every other compiler-work counter,
+source/output metric, and executable byte remains identical.
+
 ## Next actions and decision boundary
 
 Authorized low-risk work:


### PR DESCRIPTION
Fixes RUE-1455.

Skip strict family-retention passes when the family is already within its bound and its publication watermark is already strict. Stale or claimed watermarks and over-bound families retain the existing enforcement path.

Cold one-worker Lattice removes exactly 9,793 no-op passes (11,261 to 1,468) while preserving 31,549 scan-entry visits and every other work/source/output counter and executable byte. Across 32 balanced pairs, compiler clock, instructions, cycles, peak RSS, and footprint are neutral; four allocation-accounted pairs are also neutral.

Local validation: focused retention and validation-publication coverage, stale-watermark regression, formatting, and scripts/rue quick.