### PR TITLE
RUE-1456: share stable definition names in body lookups

### DIFF
--- a/crates/rue-air/src/sema/provider_body_host.rs
+++ b/crates/rue-air/src/sema/provider_body_host.rs
@@ -256,7 +256,8 @@ pub trait DurableBodyLookupSource<K, M>: Clone {
     fn definition_kind(&self, _definition: &K) -> Option<crate::StableDefinitionKind> {
         None
     }
-    fn definition_owner_name(&self, _definition: &K) -> Option<String> {
+    /// Shared source owner name for a durable definition.
+    fn definition_owner_name(&self, _definition: &K) -> Option<Arc<str>> {
         None
     }
     fn canonical_import(&self, _current: &K, _specifier: &str) -> Option<M> {
@@ -271,7 +272,8 @@ pub trait DurableBodyLookupSource<K, M>: Clone {
     fn language_item_nominal(&self, _current: &K, _lang_item: crate::LangItem) -> Option<K> {
         None
     }
-    fn definition_name(&self, _definition: &K) -> Option<String> {
+    /// Shared source name for a durable definition.
+    fn definition_name(&self, _definition: &K) -> Option<Arc<str>> {
         None
     }
     fn reduce_comptime_call(
@@ -697,7 +699,7 @@ where
             T::Never => "!".to_owned(),
             T::ComptimeType => "type".to_owned(),
             T::BuiltinNominal { name, .. } => name.to_string(),
-            T::Nominal(definition) => self.source.definition_name(definition)?,
+            T::Nominal(definition) => self.source.definition_name(definition)?.to_string(),
             T::AnonymousNominal(_) => return None,
             T::Array { element, len } => format!(
                 "[{}; {len}]",
@@ -855,7 +857,7 @@ where
                 (
                     self.source.free_function(&self.key, name)?,
                     self.owner_file,
-                    name.to_owned(),
+                    Arc::from(name),
                 )
             };
         let function = DurableCallableSource::function(&self.source, &key)?;

--- a/crates/rue-compiler/src/revisioned_query_database.rs
+++ b/crates/rue-compiler/src/revisioned_query_database.rs
@@ -21800,8 +21800,8 @@ impl rue_air::DurableBodyLookupSource<crate::StableDefinitionKey, ModuleId>
         Some(definition.kind())
     }
 
-    fn definition_owner_name(&self, definition: &crate::StableDefinitionKey) -> Option<String> {
-        definition.owner().map(|owner| owner.name().to_owned())
+    fn definition_owner_name(&self, definition: &crate::StableDefinitionKey) -> Option<Arc<str>> {
+        definition.owner().map(|owner| owner.shared_name().clone())
     }
 
     fn canonical_import(
@@ -21833,8 +21833,8 @@ impl rue_air::DurableBodyLookupSource<crate::StableDefinitionKey, ModuleId>
         }
     }
 
-    fn definition_name(&self, definition: &crate::StableDefinitionKey) -> Option<String> {
-        Some(definition.name().to_owned())
+    fn definition_name(&self, definition: &crate::StableDefinitionKey) -> Option<Arc<str>> {
+        Some(definition.shared_name().clone())
     }
 
     fn reduce_comptime_call(

--- a/docs/notes/post-adr-0063-cold-compiler-architecture-audit.md
+++ b/docs/notes/post-adr-0063-cold-compiler-architecture-audit.md
@@ -1674,6 +1674,20 @@ is neutral at +0.0000% paired median (1.0989% MAD), retired instructions at
 allocation-accounted pairs are neutral. Every other compiler-work counter,
 source/output metric, and executable byte remains identical.
 
+RUE-1456 carries stable definition and owner names through the durable body
+lookup seam as shared immutable handles. The compiler's `StableDefinitionKey`
+already owns both names in `Arc<str>`; returning a fresh `String` made
+provider-native body materialization allocate and copy equal text only to pass
+it immediately into interning, endpoint registration, or diagnostics.
+
+Four allocation-accounted cold Lattice pairs remove 5,943--6,518 allocation
+calls. Requested bytes are neutral, ranging from 112,143 fewer to 42,873 more.
+Across 16 balanced release pairs, compiler clock is neutral at -0.8376% paired
+median (0.7210% MAD), retired instructions at -0.0307% (0.0593% MAD), cycles at
+-0.4515% (0.8319% MAD), peak RSS at +0.2450% (0.4045% MAD), and peak footprint
+at -0.0580% (0.1881% MAD). Every compiler-work counter, source/output metric,
+and executable byte remains identical.
+
 ## Next actions and decision boundary
 
 Authorized low-risk work:


### PR DESCRIPTION
Fixes RUE-1456.

## Summary

- carry stable definition and owner names through durable body lookups as shared immutable handles
- reuse the names already owned by StableDefinitionKey instead of allocating temporary Strings
- record the cold-profile and allocation evidence in the architecture audit

## Evidence

- 5,943–6,518 fewer allocation calls across four allocation-accounted cold Lattice pairs
- all compiler-work counters, source/output metrics, and executable bytes exact
- 16 balanced release pairs neutral across clock, instructions, cycles, peak RSS, and footprint

## Validation

- focused provider epoch test
- scripts/rue fmt
- scripts/rue quick