### PR TITLE
RUE-1458: reuse validated program image identities

### DIFF
--- a/crates/rue-compiler/src/program_image_plan.rs
+++ b/crates/rue-compiler/src/program_image_plan.rs
@@ -7,7 +7,7 @@
 use sha2::{Digest, Sha256};
 use std::{
     collections::{BTreeMap, BTreeSet},
-    sync::OnceLock,
+    sync::{Arc, OnceLock},
 };
 use tracing::{info, info_span};
 
@@ -30,7 +30,7 @@ pub(crate) struct ProgramImageUnit {
     /// key below is only its deterministic ordering/map projection.
     pub(crate) function: crate::FunctionInstanceKey,
     pub(crate) identity: String,
-    pub(crate) defined_symbol: String,
+    pub(crate) defined_symbol: Arc<str>,
     pub(crate) content_digest: ContentDigest,
 }
 
@@ -177,7 +177,7 @@ impl ProgramImage {
         // stayed outside every phase span until RUE-1257, so ADR-0067's
         // taxonomy could only report its cost as `unattributed`.
         let _span = info_span!("program_image_plan", phase = "object_generation").entered();
-        validate_rooted_program_image_inputs(&objects, &exports)?;
+        let unit_identities = validate_rooted_program_image_inputs(&objects, &exports)?;
         let export_thunk_objects: Vec<Vec<u8>> = exports
             .iter()
             .map(|export| {
@@ -191,6 +191,7 @@ impl ProgramImage {
             .collect();
         let plan = ProgramImagePlan::from_rooted_inputs(
             &objects,
+            unit_identities,
             &exports,
             options,
             &export_thunk_objects,
@@ -309,16 +310,18 @@ impl ProgramImage {
 impl ProgramImagePlan {
     fn from_rooted_inputs(
         units: &[CollectedObjectProjection],
+        unit_identities: Vec<String>,
         exports: &[RootedExportThunk],
         options: &CompileOptions,
         export_thunk_objects: &[Vec<u8>],
     ) -> MultiErrorResult<Self> {
         let mut plan_units = units
             .iter()
-            .map(|collected| ProgramImageUnit {
+            .zip(unit_identities)
+            .map(|(collected, identity)| ProgramImageUnit {
                 function: collected.function.clone(),
-                identity: stable_function_identity(&collected.function),
-                defined_symbol: collected.unit.defined_symbol.to_string(),
+                identity,
+                defined_symbol: collected.unit.defined_symbol.clone(),
                 content_digest: object_digest(&collected.object.bytes),
             })
             .collect::<Vec<_>>();
@@ -359,7 +362,7 @@ impl ProgramImagePlan {
             .map(|collected| ProgramImageUnit {
                 function: collected.function.clone(),
                 identity: stable_function_identity(&collected.function),
-                defined_symbol: collected.unit.defined_symbol.to_string(),
+                defined_symbol: collected.unit.defined_symbol.clone(),
                 content_digest: object_digest(&collected.object.bytes),
             })
             .collect::<Vec<_>>();
@@ -437,7 +440,9 @@ impl ProgramImagePlan {
             runtime_archive: RuntimeArchiveIdentity::for_target(options.target),
             required_runtime_symbols: required_runtime_symbols.into_iter().collect(),
         };
-        validate_program_image_plan(&plan)?;
+        // Both private construction paths validate their raw unit and export
+        // identities before translating them into this canonical plan.
+        // Retained-plan deltas independently validate both compared plans.
         Ok(plan)
     }
 }
@@ -520,9 +525,10 @@ fn validate_program_image_inputs(
 fn validate_rooted_program_image_inputs(
     units: &[CollectedObjectProjection],
     exports: &[RootedExportThunk],
-) -> MultiErrorResult<()> {
+) -> MultiErrorResult<Vec<String>> {
     let mut units_by_identity = BTreeMap::new();
     let mut defined_symbols = BTreeSet::new();
+    let mut unit_identities = Vec::with_capacity(units.len());
     for collected in units {
         let identity = stable_function_identity(&collected.function);
         if units_by_identity
@@ -531,6 +537,7 @@ fn validate_rooted_program_image_inputs(
         {
             return duplicate_plan_input("codegen unit identity", &identity);
         }
+        unit_identities.push(identity);
         if !defined_symbols.insert(collected.unit.defined_symbol.as_ref()) {
             return duplicate_plan_input("defined symbol", &collected.unit.defined_symbol);
         }
@@ -564,7 +571,7 @@ fn validate_rooted_program_image_inputs(
             )));
         }
     }
-    Ok(())
+    Ok(unit_identities)
 }
 
 #[cfg(test)]
@@ -578,7 +585,7 @@ fn stable_function_identity(function: &crate::FunctionInstanceKey) -> String {
     ))
 }
 
-fn duplicate_plan_input(kind: &str, identity: &str) -> MultiErrorResult<()> {
+fn duplicate_plan_input<T>(kind: &str, identity: &str) -> MultiErrorResult<T> {
     Err(CompileErrors::from(CompileError::without_span(
         ErrorKind::InternalError(format!("program image has duplicate {kind} `{identity}`")),
     )))
@@ -591,7 +598,7 @@ fn validate_program_image_plan(plan: &ProgramImagePlan) -> MultiErrorResult<()> 
         if !unit_identities.insert(unit.identity.as_str()) {
             return duplicate_plan_input("codegen unit identity", &unit.identity);
         }
-        if !defined_symbols.insert(unit.defined_symbol.as_str()) {
+        if !defined_symbols.insert(unit.defined_symbol.as_ref()) {
             return duplicate_plan_input("defined symbol", &unit.defined_symbol);
         }
     }
@@ -762,7 +769,7 @@ mod tests {
         ProgramImageUnit {
             function: crate::FunctionInstanceKey::DropGlue(Box::new(crate::TypeInstanceKey::I64)),
             identity: identity.to_owned(),
-            defined_symbol: identity.to_owned(),
+            defined_symbol: Arc::from(identity),
             content_digest: [digest_byte; 32],
         }
     }

--- a/docs/notes/post-adr-0063-cold-compiler-architecture-audit.md
+++ b/docs/notes/post-adr-0063-cold-compiler-architecture-audit.md
@@ -1688,6 +1688,23 @@ median (0.7210% MAD), retired instructions at -0.0307% (0.0593% MAD), cycles at
 at -0.0580% (0.1881% MAD). Every compiler-work counter, source/output metric,
 and executable byte remains identical.
 
+RUE-1458 makes rooted program-image validation the single producer of each
+unit's stable encoded identity. Fresh plan construction previously encoded
+every callable again, copied every already-shared defined symbol, and rebuilt
+the same identity/symbol sets a third time after raw inputs had passed their
+full duplicate, entry-point, and export checks. The retained-plan delta API
+keeps its independent fail-closed plan validation because its inputs do not
+come from that private fresh-construction path.
+
+Four allocation-accounted cold Lattice pairs remove 8,362--8,758 allocation
+calls and 680,862--823,390 requested bytes. Across 16 balanced release pairs,
+the `program_image_plan` phase improves by 7.3521% at the paired median (0.6639%
+MAD). End-to-end compiler clock is neutral at -0.0765% (1.3312% MAD), retired
+instructions at -0.0455% (0.0786% MAD), cycles at +0.3026% (0.8219% MAD), peak
+RSS at +0.1173% (0.3600% MAD), and peak footprint at -0.2005% (0.1693% MAD).
+Every compiler-work counter, source/output metric, and executable byte remains
+identical.
+
 ## Next actions and decision boundary
 
 Authorized low-risk work:


### PR DESCRIPTION
Fixes RUE-1458.

## Summary

- make rooted program-image validation produce each canonical encoded unit identity once
- carry those proven identities into fresh plan construction and share immutable defined symbols
- retain independent fail-closed validation for arbitrary plans compared by the delta API
- record the cold-profile and allocation evidence in the architecture audit

## Evidence

- 8,362–8,758 fewer allocation calls and 680,862–823,390 fewer requested bytes across four cold Lattice pairs
- program_image_plan improves 7.3521% at the paired median across 16 balanced release pairs
- end-to-end clock, instructions, cycles, peak RSS, and footprint remain neutral
- all compiler-work counters, source/output metrics, and executable bytes exact

## Validation

- all 15 program-image focused tests
- scripts/rue fmt
- scripts/rue quick