### PR TITLE
RUE-1459: let object projections own content digests

### DIFF
--- a/crates/rue-compiler/src/api_inventory.rs
+++ b/crates/rue-compiler/src/api_inventory.rs
@@ -16,6 +16,7 @@ const PRODUCTION_MODULES: &[(&str, &str)] = &[
     ("canonical_semantic", include_str!("canonical_semantic.rs")),
     ("cfg_query", include_str!("cfg_query.rs")),
     ("codegen_query", include_str!("codegen_query.rs")),
+    ("content_digest", include_str!("content_digest.rs")),
     ("object_query", include_str!("object_query.rs")),
     (
         "declaration_candidate",

--- a/crates/rue-compiler/src/content_digest.rs
+++ b/crates/rue-compiler/src/content_digest.rs
@@ -1,0 +1,15 @@
+//! Stable, domain-separated content identities for immutable compiler artifacts.
+
+use sha2::{Digest, Sha256};
+
+/// Collision-resistant, deterministic content identity.
+pub(crate) type ContentDigest = [u8; 32];
+
+/// SHA-256 over a domain-separated, length-framed byte encoding.
+pub(crate) fn bytes_digest(domain: &[u8], bytes: &[u8]) -> ContentDigest {
+    let mut digest = Sha256::new();
+    digest.update(domain);
+    digest.update((bytes.len() as u64).to_le_bytes());
+    digest.update(bytes);
+    digest.finalize().into()
+}

--- a/crates/rue-compiler/src/lib.rs
+++ b/crates/rue-compiler/src/lib.rs
@@ -42,6 +42,7 @@ mod canonical_merge;
 mod canonical_semantic;
 mod cfg_query;
 mod codegen_query;
+mod content_digest;
 mod declaration_candidate;
 mod definition_snapshot;
 mod dependency_envelope;

--- a/crates/rue-compiler/src/object_query.rs
+++ b/crates/rue-compiler/src/object_query.rs
@@ -11,7 +11,12 @@ use rue_query::{
     QueryAbort, QueryContext, QueryFamily, QueryKey, QueryOutcome, QueryOutput, QueryTerminalKind,
 };
 
-use crate::retained_charge::RetainedCharge;
+use crate::{
+    content_digest::{ContentDigest, bytes_digest},
+    retained_charge::RetainedCharge,
+};
+
+const OBJECT_DIGEST_DOMAIN: &[u8] = b"rue.program-image.object\0v1\0";
 
 /// Object-container format selected unambiguously by the target.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
@@ -68,10 +73,24 @@ impl QueryKey for ObjectProjectionQueryKey {
     }
 }
 
-/// Retained object-container bytes for one codegen unit.
+/// Retained object-container bytes and their stable content identity for one
+/// codegen unit. The digest is computed once with the immutable bytes so every
+/// downstream program-image assembly can reuse it without a serialized hash
+/// pass.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct ObjectProjection {
     pub(crate) bytes: Arc<[u8]>,
+    pub(crate) content_digest: ContentDigest,
+}
+
+impl ObjectProjection {
+    pub(crate) fn from_bytes(bytes: Vec<u8>) -> Self {
+        let content_digest = bytes_digest(OBJECT_DIGEST_DOMAIN, &bytes);
+        Self {
+            bytes: bytes.into(),
+            content_digest,
+        }
+    }
 }
 
 impl RetainedCharge for ObjectProjection {
@@ -142,9 +161,9 @@ pub(crate) fn evaluate_object_projection(
     };
     context.record_work(rue_query::WorkItem::new("object.projection.attempts", 1));
     let value = match crate::backend::project_backend_object(unit.backend_product(), key.target) {
-        Ok(bytes) => ObjectProjectionValue::Available(Arc::new(ObjectProjection {
-            bytes: bytes.into(),
-        })),
+        Ok(bytes) => {
+            ObjectProjectionValue::Available(Arc::new(ObjectProjection::from_bytes(bytes)))
+        }
         Err(error) => return Ok(object_failure(error.into())),
     };
     Ok(QueryOutput::success(value))
@@ -174,14 +193,22 @@ mod tests {
 
     #[test]
     fn retained_charge_accounts_object_bytes() {
-        let object = ObjectProjection {
-            bytes: Arc::from([1_u8, 2, 3, 4]),
-        };
+        let object = ObjectProjection::from_bytes(vec![1_u8, 2, 3, 4]);
         assert_eq!(object.retained_charge(), 4);
         assert_eq!(
             ObjectProjectionValue::Available(Arc::new(object)).retained_charge(),
             std::mem::size_of::<ObjectProjection>() as u64 + 4
         );
+    }
+
+    #[test]
+    fn object_projection_owns_a_stable_content_digest() {
+        let first = ObjectProjection::from_bytes(vec![1_u8, 2, 3, 4]);
+        let same = ObjectProjection::from_bytes(vec![1_u8, 2, 3, 4]);
+        let changed = ObjectProjection::from_bytes(vec![1_u8, 2, 3, 5]);
+
+        assert_eq!(first.content_digest, same.content_digest);
+        assert_ne!(first.content_digest, changed.content_digest);
     }
 
     #[test]

--- a/crates/rue-compiler/src/program_image_plan.rs
+++ b/crates/rue-compiler/src/program_image_plan.rs
@@ -4,7 +4,6 @@
 //! linker.  It records only compiler-owned link inputs; the fresh adapter
 //! retains the existing object writer and internal/system linker behavior.
 
-use sha2::{Digest, Sha256};
 use std::{
     collections::{BTreeMap, BTreeSet},
     sync::{Arc, OnceLock},
@@ -16,7 +15,9 @@ use crate::FunctionWithCfg;
 
 use crate::{
     CompileError, CompileErrors, CompileOptions, CompileOutput, CompileWarning, ErrorKind,
-    LinkerMode, MultiErrorResult, Target, backend, linking,
+    LinkerMode, MultiErrorResult, Target, backend,
+    content_digest::{ContentDigest, bytes_digest},
+    linking,
     object_query::CollectedObjectProjection,
 };
 
@@ -72,10 +73,6 @@ pub(crate) struct ProgramImagePlan {
 /// Stable local representation avoids making the linker implementation type
 /// part of the plan's API surface.
 pub(crate) use crate::object_query::ObjectFormat as ProgramObjectFormat;
-
-/// Collision-resistant, deterministic content identity. Every digest below is
-/// SHA-256 over a domain-separated, length-framed byte encoding.
-pub(crate) type ContentDigest = [u8; 32];
 
 /// Exact per-unit transition between two plans.  Linker placement/state is
 /// intentionally absent: a later incremental linker can consume these facts.
@@ -240,9 +237,9 @@ impl ProgramImage {
                     .map(|bytes| CollectedObjectProjection {
                         function: collected.function,
                         unit: collected.unit,
-                        object: std::sync::Arc::new(crate::object_query::ObjectProjection {
-                            bytes: bytes.into(),
-                        }),
+                        object: std::sync::Arc::new(
+                            crate::object_query::ObjectProjection::from_bytes(bytes),
+                        ),
                     })
             })
             .collect::<Result<Vec<_>, _>>()
@@ -322,7 +319,7 @@ impl ProgramImagePlan {
                 function: collected.function.clone(),
                 identity,
                 defined_symbol: collected.unit.defined_symbol.clone(),
-                content_digest: object_digest(&collected.object.bytes),
+                content_digest: collected.object.content_digest,
             })
             .collect::<Vec<_>>();
         plan_units.sort_by(|left, right| left.identity.cmp(&right.identity));
@@ -363,7 +360,7 @@ impl ProgramImagePlan {
                 function: collected.function.clone(),
                 identity: stable_function_identity(&collected.function),
                 defined_symbol: collected.unit.defined_symbol.clone(),
-                content_digest: object_digest(&collected.object.bytes),
+                content_digest: collected.object.content_digest,
             })
             .collect::<Vec<_>>();
         plan_units.sort_by(|left, right| left.identity.cmp(&right.identity));
@@ -611,16 +608,6 @@ fn validate_program_image_plan(plan: &ProgramImagePlan) -> MultiErrorResult<()> 
     Ok(())
 }
 
-fn object_digest(bytes: &[u8]) -> ContentDigest {
-    bytes_digest(b"rue.program-image.object\0v1\0", bytes)
-}
-
-fn bytes_digest(domain: &[u8], bytes: &[u8]) -> ContentDigest {
-    let mut digest = StableDigest::new(domain);
-    digest.bytes(bytes);
-    digest.finish()
-}
-
 static X86_64_LINUX_RUNTIME_DIGEST: OnceLock<ContentDigest> = OnceLock::new();
 static AARCH64_LINUX_RUNTIME_DIGEST: OnceLock<ContentDigest> = OnceLock::new();
 static AARCH64_MACOS_RUNTIME_DIGEST: OnceLock<ContentDigest> = OnceLock::new();
@@ -671,32 +658,6 @@ impl RuntimeArchiveIdentity {
                 linking::runtime_for_target(self.target),
             )
         })
-    }
-}
-
-/// SHA-256 writer with a fixed domain and explicit length framing. This avoids
-/// boundary ambiguity while retaining deterministic, collision-resistant plan
-/// identities across processes and platforms.
-struct StableDigest(Sha256);
-
-impl StableDigest {
-    fn new(domain: &[u8]) -> Self {
-        let mut digest = Sha256::new();
-        digest.update(domain);
-        Self(digest)
-    }
-
-    fn bytes(&mut self, bytes: &[u8]) {
-        self.u64(bytes.len() as u64);
-        self.0.update(bytes);
-    }
-
-    fn u64(&mut self, value: u64) {
-        self.0.update(value.to_le_bytes());
-    }
-
-    fn finish(self) -> ContentDigest {
-        self.0.finalize().into()
     }
 }
 
@@ -808,9 +769,11 @@ mod tests {
     #[test]
     fn delta_tracks_serialized_object_bytes_not_only_codegen_metadata() {
         let mut before = unit("same", 1);
-        before.content_digest = object_digest(b"first object encoding");
+        before.content_digest =
+            bytes_digest(b"rue.program-image.object\0v1\0", b"first object encoding");
         let mut after = before.clone();
-        after.content_digest = object_digest(b"second object encoding");
+        after.content_digest =
+            bytes_digest(b"rue.program-image.object\0v1\0", b"second object encoding");
         let delta = plan(vec![after.clone()])
             .delta_from(&plan(vec![before]))
             .unwrap();

--- a/docs/notes/post-adr-0063-cold-compiler-architecture-audit.md
+++ b/docs/notes/post-adr-0063-cold-compiler-architecture-audit.md
@@ -1705,6 +1705,24 @@ RSS at +0.1173% (0.3600% MAD), and peak footprint at -0.2005% (0.1693% MAD).
 Every compiler-work counter, source/output metric, and executable byte remains
 identical.
 
+RUE-1459 makes each immutable object projection own its stable content digest.
+Fresh program-image assembly previously serialized 1,280 SHA-256 operations
+over 3,011,805 already-retained object bytes on cold Lattice, then repeated
+that same work whenever a retained session assembled another no-edit plan.
+Computing the digest beside object serialization lets the query graph retain
+it, distributes cold hashing with object production, and removes hashing from
+the single-threaded aggregation tail. Export-thunk and lazy runtime-archive
+digests keep their existing ownership and domains.
+
+Across 16 balanced fixed one-worker cold Lattice pairs, the
+`program_image_plan` phase improves by 86.6184% at the paired median (0.5715%
+MAD). End-to-end compiler clock is neutral at -0.1217% (4.2710% MAD), retired
+instructions at -0.1234% (0.1090% MAD), cycles at +0.2814% (2.0873% MAD), and
+peak RSS at -0.0873% (0.3057% MAD). Sixteen default-worker pairs independently
+improve the plan phase by 86.6063% (0.8512% MAD); whole-compiler clock remains
+host-noisy, while cycles improve by 1.6730% (0.6974% MAD). Every compiler-work
+counter, source/output metric, and executable byte remains identical.
+
 ## Next actions and decision boundary
 
 Authorized low-risk work:


### PR DESCRIPTION
## Summary

- compute each stable object digest when the immutable object projection is created
- retain and reuse that digest during program-image assembly
- centralize domain-separated content hashing without changing linker behavior

## Performance

Cold Lattice contains 1,280 object projections totaling 3,011,805 bytes. This removes all of their hashing from each serialized plan-assembly pass.

Across 16 balanced fixed-one-worker pairs, `program_image_plan` improves by 86.6184% (0.5715% MAD). Whole-compiler clock, instructions, cycles, and RSS remain neutral. Default-worker pairs independently improve the phase by 86.6063%; compiler work, source/output metrics, and executable bytes are exact.

## Validation

- focused object-projection and program-image tests
- `scripts/rue quick` (31/31 targets)
- exact Lattice output SHA-256 and compiler-work comparison

Fixes RUE-1459.