### PR TITLE
RUE-1460: retain canonical codegen defined symbols

### DIFF
--- a/crates/rue-compiler/src/codegen_query.rs
+++ b/crates/rue-compiler/src/codegen_query.rs
@@ -620,7 +620,7 @@ pub(crate) fn evaluate_codegen_unit(
     };
     Ok(QueryOutput::success(CodegenUnitValue::Available(Arc::new(
         CodegenUnit {
-            defined_symbol: Arc::from(product.machine_name.as_str()),
+            defined_symbol: record.codegen.defined_symbol.clone(),
             referenced_symbols,
             relocations,
             sections,

--- a/docs/notes/post-adr-0063-cold-compiler-architecture-audit.md
+++ b/docs/notes/post-adr-0063-cold-compiler-architecture-audit.md
@@ -1723,6 +1723,18 @@ improve the plan phase by 86.6063% (0.8512% MAD); whole-compiler clock remains
 host-noisy, while cycles improve by 1.6730% (0.6974% MAD). Every compiler-work
 counter, source/output metric, and executable byte remains identical.
 
+RUE-1460 keeps the canonical shared defined-symbol owner from
+`CfgCodegenDomain` in each `CodegenUnit`. The evaluator previously copied that
+symbol into its backend product and then allocated an equal `Arc<str>` even
+though the canonical owner remained in scope. Four allocation-accounted cold
+Lattice pairs remove 1,144--1,390 allocation calls and 34,292--270,796 requested
+bytes. Across 16 balanced fixed one-worker release pairs, end-to-end compiler
+clock is neutral at +0.9866% (2.9942% MAD), the `codegen_unit` phase at -0.6757%
+(1.7548% MAD), retired instructions at -0.0266% (0.0972% MAD), cycles at
++0.5352% (1.7221% MAD), and peak RSS at -0.5406% (0.5881% MAD). Every
+compiler-work counter, source/output metric, and executable byte remains
+identical.
+
 ## Next actions and decision boundary
 
 Authorized low-risk work:


### PR DESCRIPTION
Fixes RUE-1460.

## What changed

- Reuse the canonical `CfgCodegenDomain` `Arc<str>` in each `CodegenUnit`.
- Remove the equal shared-string allocation performed after backend production.
- Record the cold Lattice evidence in the post-ADR architecture audit.

## Evidence

Four allocation-accounted cold Lattice pairs remove 1,144–1,390 allocation calls and 34,292–270,796 requested bytes. Across 16 balanced fixed one-worker release pairs, compiler clock, instructions, cycles, and peak RSS remain neutral within noise; the `codegen_unit` phase is -0.6757% at the paired median. Every compiler-work counter, source/output metric, and executable byte is identical.

## Validation

- `scripts/rue fmt`
- `scripts/rue unit compiler codegen_unit` (12 passed)
- `scripts/rue quick`