### PR TITLE
RUE-1461: fingerprint codegen units without rebuilding backend products

### DIFF
--- a/crates/rue-compiler/src/codegen_query.rs
+++ b/crates/rue-compiler/src/codegen_query.rs
@@ -403,12 +403,12 @@ impl CodegenUnit {
     }
 }
 
-fn product_fingerprint(product: &crate::backend::FunctionBackendProduct) -> u64 {
+fn product_fingerprint(machine_name: &str, machine_code: &rue_codegen::MachineCode) -> u64 {
     let mut hasher = std::collections::hash_map::DefaultHasher::new();
-    product.machine_name.hash(&mut hasher);
-    product.machine_code.code.hash(&mut hasher);
-    product.machine_code.strings.hash(&mut hasher);
-    for relocation in &product.machine_code.relocations {
+    machine_name.hash(&mut hasher);
+    machine_code.code.hash(&mut hasher);
+    machine_code.strings.hash(&mut hasher);
+    for relocation in &machine_code.relocations {
         relocation.offset.hash(&mut hasher);
         relocation.symbol.hash(&mut hasher);
         std::mem::discriminant(&relocation.kind).hash(&mut hasher);
@@ -530,11 +530,6 @@ pub(crate) fn evaluate_codegen_unit(
     }
     context.check_canceled()?;
     context.record_work(rue_query::WorkItem::new("codegen.unit.successes", 1));
-    let product = crate::backend::FunctionBackendProduct {
-        machine_name: record.codegen.defined_symbol.to_string(),
-        machine_code: product.machine_code,
-        artifacts: product.artifacts,
-    };
     let relocations = product
         .machine_code
         .relocations
@@ -608,7 +603,8 @@ pub(crate) fn evaluate_codegen_unit(
     .into();
     let content_fingerprint = {
         let mut hasher = std::collections::hash_map::DefaultHasher::new();
-        product_fingerprint(&product).hash(&mut hasher);
+        product_fingerprint(&record.codegen.defined_symbol, &product.machine_code)
+            .hash(&mut hasher);
         sections.hash(&mut hasher);
         hasher.finish()
     };

--- a/docs/notes/post-adr-0063-cold-compiler-architecture-audit.md
+++ b/docs/notes/post-adr-0063-cold-compiler-architecture-audit.md
@@ -1735,6 +1735,19 @@ clock is neutral at +0.9866% (2.9942% MAD), the `codegen_unit` phase at -0.6757%
 compiler-work counter, source/output metric, and executable byte remains
 identical.
 
+RUE-1461 lets codegen-unit fingerprinting borrow the canonical defined symbol
+and generated machine code directly. The evaluator previously rebuilt a
+`FunctionBackendProduct` solely to replace its name before hashing, allocating
+and copying one equal `String` per unit even though both borrowed inputs were
+already in scope. Four allocation-accounted cold Lattice pairs remove
+1,131--1,318 allocation calls and 155,234--231,202 requested bytes. Across 16
+balanced fixed one-worker release pairs, end-to-end compiler clock is neutral
+at +2.5015% (3.4540% MAD), the `codegen_unit` phase at +3.3730% (5.3584% MAD),
+retired instructions at +0.0470% (0.0875% MAD), cycles at +0.6602% (2.0821%
+MAD), peak RSS at -0.0821% (0.6671% MAD), and peak footprint at -0.2669%
+(0.1964% MAD). Every compiler-work counter, source/output metric, and
+executable byte remains identical.
+
 ## Next actions and decision boundary
 
 Authorized low-risk work:


### PR DESCRIPTION
Fixes RUE-1461.

Codegen-unit fingerprinting now borrows the canonical defined symbol and generated machine code directly instead of rebuilding a temporary backend product with an equal owned string.

Evidence:
- Four allocation-accounted cold Lattice pairs remove 1,131–1,318 allocation calls and 155,234–231,202 requested bytes.
- Sixteen balanced fixed one-worker release pairs are clock/instruction/cycle/RSS neutral within noise.
- Every compiler-work counter, source/output metric, and executable byte remains identical.

Checks:
- `scripts/rue unit compiler codegen_unit`
- `scripts/rue fmt`
- `scripts/rue quick`