### PR TITLE
Keep Linear magic words out of PR citations

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -304,99 +304,47 @@ parallel Markdown backlog.
   linked with `relatedTo` or a real `blockedBy` dependency.
 - Priorities are Urgent, High, Medium, and Low. Use `bug`, `feature`, `task`, or
   `chore` labels consistently.
-- A PR body uses magic words deliberately: a closing word for each issue that
-  PR completes, and only when the issue is actually done. Relationships between
-  issues are recorded in Linear, never by citing an ID in a PR — see "Linear
-  integration". After integration, verify the issue actually reached Done; do
-  not rely solely on synchronization.
+- Relationships between issues are recorded here, never by citing an ID in a
+  PR — see "Linear integration". After integration, verify the issue actually
+  reached Done; do not rely solely on synchronization.
 
 ## Linear integration
 
-A magic word in a PR is a command that manipulates issue state. It is never a
-citation. Use one deliberately, for each issue whose state the PR should
-actually change; every other mention of an issue belongs in Linear, not in PR
-text.
+A magic word is a command that changes issue state, not a citation. Use one
+only for an issue the PR should actually move — a closing word for each issue
+it completes, once that issue's acceptance criteria are met. Every other
+relationship belongs in Linear as `relatedTo`, `blockedBy`, or a parent, not in
+PR text.
 
-**A "non-closing" word is not a read-only word.** It only opts out of the
-*merge* step; the issue still walks the earlier workflow statuses, and this
-workspace runs Linear's default automation — "we will move linked issues to
-'In Progress' when PRs are open and 'Done' when PRs merge." So `Refs RUE-NN`
-moves the issue to In Progress the moment the PR opens, including an issue
-that is already Done or Canceled. On 2026-08-12, PR #2318 carried `refs` for
-two background issues and dragged one out of Done (finished three weeks
-earlier) and another out of Canceled, back into In Progress.
-
-Source for this section: [Linear's GitHub docs](https://linear.app/docs/github).
-
-**Closing words** (verbatim — full automation, including the on-merge status):
+The trap: "non-closing" does not mean read-only. It skips only the on-merge
+status, and the default automation still moves a linked issue to In Progress
+when the PR opens — including issues already Done or Canceled. `Refs RUE-NN`
+reopens finished work; PR #2318 did exactly that to two issues on 2026-08-12.
+Word classes per [Linear's GitHub docs](https://linear.app/docs/github):
 
 ```
-close, closes, closed, closing
-fix, fixes, fixed, fixing
-resolve, resolves, resolved, resolving
-complete, completes, completed, completing
-implement, implements, implemented, implementing
-linear issue
+closing (full automation, closes on merge):
+    close / fix / resolve / complete / implement, any tense; "linear issue"
+non-closing (skips only the merge status, still moves the issue):
+    ref / refs / references, part of, contributes to, toward / towards
+relation (links only, no status change):
+    relates to, related to
 ```
 
-**Non-closing words** (verbatim — skip only the on-merge status; every earlier
-workflow transition, In Progress included, still fires):
-
-```
-ref, refs, references
-part of
-contributes to
-toward, towards
-```
-
-**Relation words** (verbatim — mark the PR related, no status change at all):
-
-```
-relates to, related to
-```
-
-Rules:
-
-- Use a closing word for each issue the PR actually completes — one PR may
-  legitimately close several — and only when the PR meets every acceptance
-  criterion on that issue (tests, docs, ADR updates included). If it doesn't,
-  use no magic word at all and say what's left in the PR body.
-- Never use a non-closing word to cite background, prior, parent, or follow-up
-  issues. Record those relationships in Linear itself — `relatedTo`,
-  `blockedBy`, or a parent issue — where they persist and don't touch state.
-  A PR body is not a tracker.
-- `relates to` / `related to` are the only status-safe words, but they still
-  attach the PR and leave the relationship recorded in GitHub rather than the
-  tracker. Prefer a Linear relation anyway.
-- A bare ID with no magic word does not link, so naming an issue in plain prose
-  is fine ("the meridian coverage disabled under RUE-1083"). If an ID must
-  appear somewhere that does link (e.g. a carried-over branch name), add
-  `skip RUE-NN` or `ignore RUE-NN` to the PR description to suppress it.
-- A magic word applies to every ID that follows it — `Fixes RUE-1067, RUE-1068
-  and RUE-1069` closes all three. That is correct only if all three are done.
-  Spell each ID with its own word (`Fixes RUE-1067. Fixes RUE-1068.`) so the
-  list can never quietly pick up an issue the PR merely touches.
-
-`implement*` and `complete*` are the trap word class: GitHub doesn't treat them
-as closing keywords, so they get written as ordinary prose, but Linear closes on
-them. "Implements the FFI shim described in RUE-1064" closes RUE-1064. Reword
-the sentence rather than reaching for `refs`.
-
-An ID in the branch name links the PR on its own, with no magic word
-involved — that is how Rue's `dorianscheidt/rue-NNNN-…` branches link, and it
-is enough. Elsewhere an ID links only when a magic word precedes it. Use at
-most one ID per branch name (the issue it completes), and don't reuse a
-completed ID for a follow-up branch.
-
-After opening a PR, verify no unintended issue changed state, and restore any
-that did. Automation reversions are silent and easy to leave behind for weeks.
-
-Magic words only work in the PR title and description, not in PR comments;
-commit messages need the magic word immediately before the ID to link at all.
-
-Squash/stacked PRs: merging PRs into an intermediate branch and merging that
-onward does not carry the closing word forward — restate it in the final PR
-into `trunk`.
+- `implement*` and `complete*` are the easy accident: GitHub ignores them, so
+  they get written as prose, but Linear closes on them. "Implements the shim
+  described in RUE-1064" closes RUE-1064 — reword rather than reach for `refs`.
+- A word applies to every ID that follows it, so `Fixes RUE-1067, RUE-1068`
+  closes both. Give each ID its own word.
+- A bare ID does not link, so naming an issue in prose is safe. The branch name
+  does link on its own; keep one ID there, the issue that branch completes.
+- `skip RUE-NN` or `ignore RUE-NN` in the description suppresses an unwanted
+  link.
+- Magic words work in the PR title and description only, not in comments;
+  commit messages need the word immediately before the ID.
+- Stacked PRs don't carry links through an intermediate branch — restate the
+  closing word in the final PR into `trunk`.
+- After opening a PR, check that no unintended issue moved.
 
 ## Code style and logging
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -304,7 +304,7 @@ parallel Markdown backlog.
   linked with `relatedTo` or a real `blockedBy` dependency.
 - Priorities are Urgent, High, Medium, and Low. Use `bug`, `feature`, `task`, or
   `chore` labels consistently.
-- A PR body carries at most one magic word: the closing word for the issue that
+- A PR body uses magic words deliberately: a closing word for each issue that
   PR completes, and only when the issue is actually done. Relationships between
   issues are recorded in Linear, never by citing an ID in a PR — see "Linear
   integration". After integration, verify the issue actually reached Done; do
@@ -313,8 +313,9 @@ parallel Markdown backlog.
 ## Linear integration
 
 A magic word in a PR is a command that manipulates issue state. It is never a
-citation. Use one only to drive the state of the single issue that PR
-completes; every other mention of an issue belongs in Linear, not in PR text.
+citation. Use one deliberately, for each issue whose state the PR should
+actually change; every other mention of an issue belongs in Linear, not in PR
+text.
 
 **A "non-closing" word is not a read-only word.** It only opts out of the
 *merge* step; the issue still walks the earlier workflow statuses, and this
@@ -356,10 +357,10 @@ relates to, related to
 
 Rules:
 
-- At most one magic word per PR: a closing word for the one issue the PR
-  completes, used only when the PR meets every acceptance criterion on that
-  issue (tests, docs, ADR updates included). If it doesn't, use no magic word
-  at all and say what's left in the PR body.
+- Use a closing word for each issue the PR actually completes — one PR may
+  legitimately close several — and only when the PR meets every acceptance
+  criterion on that issue (tests, docs, ADR updates included). If it doesn't,
+  use no magic word at all and say what's left in the PR body.
 - Never use a non-closing word to cite background, prior, parent, or follow-up
   issues. Record those relationships in Linear itself — `relatedTo`,
   `blockedBy`, or a parent issue — where they persist and don't touch state.
@@ -372,9 +373,9 @@ Rules:
   appear somewhere that does link (e.g. a carried-over branch name), add
   `skip RUE-NN` or `ignore RUE-NN` to the PR description to suppress it.
 - A magic word applies to every ID that follows it — `Fixes RUE-1067, RUE-1068
-  and RUE-1069` closes all three. A PR that genuinely completes several issues
-  needs each ID spelled with its own word; anything it merely touches is not
-  listed at all.
+  and RUE-1069` closes all three. That is correct only if all three are done.
+  Spell each ID with its own word (`Fixes RUE-1067. Fixes RUE-1068.`) so the
+  list can never quietly pick up an issue the PR merely touches.
 
 `implement*` and `complete*` are the trap word class: GitHub doesn't treat them
 as closing keywords, so they get written as ordinary prose, but Linear closes on

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -316,14 +316,18 @@ A magic word in a PR is a command that manipulates issue state. It is never a
 citation. Use one only to drive the state of the single issue that PR
 completes; every other mention of an issue belongs in Linear, not in PR text.
 
-**There is no read-only magic word.** Any word from either list below links the
-issue, and linking alone hands it to status automation that moves it to
-In Progress — including issues that are already Done or Canceled.
-`Refs RUE-NN` does not "just link for context": on 2026-08-12, PR #2318
-carried `refs` for two background issues and dragged one out of Done (finished
-three weeks earlier) and another out of Canceled, back into In Progress.
+**A "non-closing" word is not a read-only word.** It only opts out of the
+*merge* step; the issue still walks the earlier workflow statuses, and this
+workspace runs Linear's default automation — "we will move linked issues to
+'In Progress' when PRs are open and 'Done' when PRs merge." So `Refs RUE-NN`
+moves the issue to In Progress the moment the PR opens, including an issue
+that is already Done or Canceled. On 2026-08-12, PR #2318 carried `refs` for
+two background issues and dragged one out of Done (finished three weeks
+earlier) and another out of Canceled, back into In Progress.
 
-**Closing words** (verbatim — also close the issue on merge):
+Source for this section: [Linear's GitHub docs](https://linear.app/docs/github).
+
+**Closing words** (verbatim — full automation, including the on-merge status):
 
 ```
 close, closes, closed, closing
@@ -334,14 +338,20 @@ implement, implements, implemented, implementing
 linear issue
 ```
 
-**Linking words** (verbatim — no close, but still link and still move status):
+**Non-closing words** (verbatim — skip only the on-merge status; every earlier
+workflow transition, In Progress included, still fires):
 
 ```
 ref, refs, references
 part of
-related to, relates to
 contributes to
 toward, towards
+```
+
+**Relation words** (verbatim — mark the PR related, no status change at all):
+
+```
+relates to, related to
 ```
 
 Rules:
@@ -350,15 +360,17 @@ Rules:
   completes, used only when the PR meets every acceptance criterion on that
   issue (tests, docs, ADR updates included). If it doesn't, use no magic word
   at all and say what's left in the PR body.
-- Never use a linking word to cite background, prior, parent, or follow-up
+- Never use a non-closing word to cite background, prior, parent, or follow-up
   issues. Record those relationships in Linear itself — `relatedTo`,
   `blockedBy`, or a parent issue — where they persist and don't touch state.
   A PR body is not a tracker.
-- Naming another issue as plain prose is fine ("the meridian coverage disabled
-  under RUE-1083"), but check afterwards that it did not link; if it did, or if
-  an ID must appear anyway (e.g. a carried-over branch name), add
-  `skip RUE-NN` or `ignore RUE-NN` to the PR description to unlink it and
-  suppress status automation.
+- `relates to` / `related to` are the only status-safe words, but they still
+  attach the PR and leave the relationship recorded in GitHub rather than the
+  tracker. Prefer a Linear relation anyway.
+- A bare ID with no magic word does not link, so naming an issue in plain prose
+  is fine ("the meridian coverage disabled under RUE-1083"). If an ID must
+  appear somewhere that does link (e.g. a carried-over branch name), add
+  `skip RUE-NN` or `ignore RUE-NN` to the PR description to suppress it.
 - A magic word applies to every ID that follows it — `Fixes RUE-1067, RUE-1068
   and RUE-1069` closes all three. A PR that genuinely completes several issues
   needs each ID spelled with its own word; anything it merely touches is not
@@ -369,7 +381,9 @@ as closing keywords, so they get written as ordinary prose, but Linear closes on
 them. "Implements the FFI shim described in RUE-1064" closes RUE-1064. Reword
 the sentence rather than reaching for `refs`.
 
-An issue ID in a branch name or PR title auto-links the PR the same way. Use at
+An ID in the branch name links the PR on its own, with no magic word
+involved — that is how Rue's `dorianscheidt/rue-NNNN-…` branches link, and it
+is enough. Elsewhere an ID links only when a magic word precedes it. Use at
 most one ID per branch name (the issue it completes), and don't reuse a
 completed ID for a follow-up branch.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -285,9 +285,9 @@ not push or synchronize a fork's `origin/trunk`. See
 `docs/process/fork-workflow.md` for machine-local configuration details.
 
 Commit and PR text should be tool-neutral. Do not add agent attribution,
-co-author trailers, or "generated with" boilerplate. Reference `RUE-NN`; see
-"Linear integration" below for exactly which words close an issue and when to
-use them instead of a plain reference.
+co-author trailers, or "generated with" boilerplate. Name the issue the change
+belongs to as `RUE-NN`; see "Linear integration" below, because every magic
+word — including `refs` — changes issue state.
 
 ## Issue tracking
 
@@ -304,17 +304,26 @@ parallel Markdown backlog.
   linked with `relatedTo` or a real `blockedBy` dependency.
 - Priorities are Urgent, High, Medium, and Low. Use `bug`, `feature`, `task`, or
   `chore` labels consistently.
-- A PR body must use at most one closing word per issue, chosen per the rules
-  below, and only when the issue is actually done. After integration, verify
-  the issue actually reached Done; do not rely solely on synchronization.
+- A PR body carries at most one magic word: the closing word for the issue that
+  PR completes, and only when the issue is actually done. Relationships between
+  issues are recorded in Linear, never by citing an ID in a PR — see "Linear
+  integration". After integration, verify the issue actually reached Done; do
+  not rely solely on synchronization.
 
 ## Linear integration
 
-Linear's magic-word list is wider than GitHub's and auto-linking has side
-effects. Automatic closing stays on; the point here is picking the right word
-at the right time, not gating closes on review.
+A magic word in a PR is a command that manipulates issue state. It is never a
+citation. Use one only to drive the state of the single issue that PR
+completes; every other mention of an issue belongs in Linear, not in PR text.
 
-**Closing words** (verbatim — close a linked issue on merge):
+**There is no read-only magic word.** Any word from either list below links the
+issue, and linking alone hands it to status automation that moves it to
+In Progress — including issues that are already Done or Canceled.
+`Refs RUE-NN` does not "just link for context": on 2026-08-12, PR #2318
+carried `refs` for two background issues and dragged one out of Done (finished
+three weeks earlier) and another out of Canceled, back into In Progress.
+
+**Closing words** (verbatim — also close the issue on merge):
 
 ```
 close, closes, closed, closing
@@ -325,7 +334,7 @@ implement, implements, implemented, implementing
 linear issue
 ```
 
-**Non-closing words** (verbatim — link for context, no status change):
+**Linking words** (verbatim — no close, but still link and still move status):
 
 ```
 ref, refs, references
@@ -335,34 +344,44 @@ contributes to
 toward, towards
 ```
 
-`implement*` and `complete*` are the trap: GitHub doesn't treat them as
-closing keywords, so they get used as plain prose, but Linear closes on them.
-"Implements the FFI shim described in RUE-1064" closes RUE-1064. If that's not
-the intent, write "Implements the FFI shim (refs RUE-1064)" instead.
+Rules:
 
-Use a closing word only when the PR meets every acceptance criterion on the
-issue (tests, docs, ADR updates included). Otherwise use a non-closing word
-and note what's left in the PR body.
+- At most one magic word per PR: a closing word for the one issue the PR
+  completes, used only when the PR meets every acceptance criterion on that
+  issue (tests, docs, ADR updates included). If it doesn't, use no magic word
+  at all and say what's left in the PR body.
+- Never use a linking word to cite background, prior, parent, or follow-up
+  issues. Record those relationships in Linear itself — `relatedTo`,
+  `blockedBy`, or a parent issue — where they persist and don't touch state.
+  A PR body is not a tracker.
+- Naming another issue as plain prose is fine ("the meridian coverage disabled
+  under RUE-1083"), but check afterwards that it did not link; if it did, or if
+  an ID must appear anyway (e.g. a carried-over branch name), add
+  `skip RUE-NN` or `ignore RUE-NN` to the PR description to unlink it and
+  suppress status automation.
+- A magic word applies to every ID that follows it — `Fixes RUE-1067, RUE-1068
+  and RUE-1069` closes all three. A PR that genuinely completes several issues
+  needs each ID spelled with its own word; anything it merely touches is not
+  listed at all.
 
-One magic word per ID — `Fixes RUE-1067, RUE-1068 and RUE-1069` closes all
-three. Give each ID its own word: `Fixes RUE-1067. Refs RUE-1068, RUE-1069.`
+`implement*` and `complete*` are the trap word class: GitHub doesn't treat them
+as closing keywords, so they get written as ordinary prose, but Linear closes on
+them. "Implements the FFI shim described in RUE-1064" closes RUE-1064. Reword
+the sentence rather than reaching for `refs`.
 
-An issue ID in a branch name or PR title auto-links the PR, and on-merge
-automation moves linked issues to In Progress — even ones already Done. Use
-at most one ID per branch name (the issue it completes), don't reuse a
-completed ID for follow-up branches, and prefer a non-closing word in the PR
-body over naming a completed issue in the title.
+An issue ID in a branch name or PR title auto-links the PR the same way. Use at
+most one ID per branch name (the issue it completes), and don't reuse a
+completed ID for a follow-up branch.
 
-If an ID must appear anyway (e.g. a carried-over branch name), add
-`skip RUE-NN` or `ignore RUE-NN` to the PR description to unlink it and
-suppress status automation.
+After opening a PR, verify no unintended issue changed state, and restore any
+that did. Automation reversions are silent and easy to leave behind for weeks.
 
 Magic words only work in the PR title and description, not in PR comments;
 commit messages need the magic word immediately before the ID to link at all.
 
 Squash/stacked PRs: merging PRs into an intermediate branch and merging that
-onward does not carry their issue links forward — restate them in the final
-PR into `trunk`.
+onward does not carry the closing word forward — restate it in the final PR
+into `trunk`.
 
 ## Code style and logging
 


### PR DESCRIPTION
AGENTS.md said `refs`, `part of`, and friends "link for context, no status
change." They do not. Per [Linear's GitHub docs](https://linear.app/docs/github):

> When you use a _non-closing_ magic word, the linked PR or commit will still
> move the issue through other statuses per your workflow settings, but it will
> not apply the _On PR or commit merge_ status when the PR or commit merges.

> \[B\]y default, we will move linked issues to "In Progress" when PRs are open
> and "Done" when PRs merge.

A non-closing word opts out of the *merge* step only, so `Refs RUE-NN` still
moves the issue to In Progress at PR open — including an issue already Done or
Canceled. A PR opened today cited two background issues with `refs` and pulled
one out of Done and one out of Canceled.

The rewritten section: magic words are commands that change state, used only
for issues the PR should actually move; relationships between issues are
recorded in Linear as `relatedTo` / `blockedBy` / parent instead. It also
corrects the word classes to the documented three — `relates to` / `related to`
are relation words with no status change, distinct from the non-closing words
that do move status — and notes that a bare ID does not link, that the branch
name links on its own, and that `skip`/`ignore` suppresses an unwanted link.

Documentation only; no code or test changes.