### PR TITLE
RUE-1462: intern synthetic provider argument names without formatting

### DIFF
--- a/crates/rue-air/src/sema/provider_body_host.rs
+++ b/crates/rue-air/src/sema/provider_body_host.rs
@@ -47,6 +47,36 @@ use crate::{
     SemanticDefinitionToken, SemanticModuleToken, TypeInstanceKey,
 };
 
+fn intern_synthetic_argument_name(interner: &ThreadedRodeo, index: usize) -> Spur {
+    let mut bytes = [0_u8; 3 + 20];
+    bytes[..3].copy_from_slice(b"arg");
+    let mut value = index;
+    let mut start = bytes.len();
+    loop {
+        start -= 1;
+        bytes[start] = b'0' + (value % 10) as u8;
+        value /= 10;
+        if value == 0 {
+            break;
+        }
+    }
+    let digits = bytes.len() - start;
+    bytes.copy_within(start.., 3);
+    let end = 3 + digits;
+    let name = std::str::from_utf8(&bytes[..end]).expect("synthetic argument name is ASCII");
+    interner.get_or_intern(name)
+}
+
+#[cfg(test)]
+#[test]
+fn synthetic_argument_names_match_the_canonical_spelling_without_a_heap_buffer() {
+    let interner = ThreadedRodeo::new();
+    for index in [0, 9, 10, 1_024, usize::MAX] {
+        let symbol = intern_synthetic_argument_name(&interner, index);
+        assert_eq!(interner.resolve(&symbol), format!("arg{index}"));
+    }
+}
+
 /// Stable, request-independent description of an anonymous nominal created by
 /// one successful provider body transaction.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -2157,7 +2187,7 @@ where
             }
             let params = self.state.allocate_params(
                 (0..parameter_types.len())
-                    .map(|index| self.interner.get_or_intern(&format!("arg{index}"))),
+                    .map(|index| intern_synthetic_argument_name(&self.interner, index)),
                 parameter_types.iter().copied(),
                 method.parameters.iter().map(|(_, mode, _)| *mode),
                 method.parameters.iter().map(|(_, _, comptime)| *comptime),
@@ -2276,7 +2306,7 @@ where
                     returns_borrow: false,
                     params: self.state.allocate_params(
                         (0..method.parameters.len())
-                            .map(|index| self.interner.get_or_intern(&format!("arg{index}"))),
+                            .map(|index| intern_synthetic_argument_name(&self.interner, index)),
                         method
                             .parameters
                             .iter()

--- a/docs/notes/post-adr-0063-cold-compiler-architecture-audit.md
+++ b/docs/notes/post-adr-0063-cold-compiler-architecture-audit.md
@@ -1748,6 +1748,18 @@ MAD), peak RSS at -0.0821% (0.6671% MAD), and peak footprint at -0.2669%
 (0.1964% MAD). Every compiler-work counter, source/output metric, and
 executable byte remains identical.
 
+RUE-1462 gives both provider-backed anonymous-method paths one stack-buffered
+spelling for synthetic parameter names. They previously allocated a temporary
+`String` for every `arg{index}` immediately before interning it; the interner
+needs that text only for the duration of the lookup. Four allocation-accounted
+cold Lattice pairs remove 78,369--78,726 allocation calls and
+339,360--664,096 requested bytes. Across 16 balanced fixed one-worker release
+pairs, end-to-end compiler clock is neutral at +0.3667% (3.7385% MAD), retired
+instructions at -0.0781% (0.2808% MAD), cycles at +0.8649% (3.7935% MAD), peak
+RSS at +0.6267% (0.4606% MAD), and peak footprint at +0.2693% (1.5085% MAD).
+Every compiler-work counter, source/output metric, and executable byte remains
+identical.
+
 ## Next actions and decision boundary
 
 Authorized low-risk work:


### PR DESCRIPTION
Fixes RUE-1462.

Provider-backed anonymous-method setup now spells synthetic `arg{index}` parameter names in a stack buffer for the duration of interning instead of allocating temporary strings. Both provider paths share the same helper.

Evidence:
- Four allocation-accounted cold Lattice pairs remove 78,369–78,726 allocation calls and 339,360–664,096 requested bytes.
- Sixteen balanced fixed one-worker release pairs are clock/instruction/cycle/memory neutral within noise.
- Every compiler-work counter, source/output metric, and executable byte remains identical.

Checks:
- focused synthetic-name boundary test
- `scripts/rue unit air provider`
- `scripts/rue fmt`
- `scripts/rue quick`