### PR TITLE
RUE-1463: use unordered batch validation lease membership

### DIFF
--- a/crates/rue-query/src/lib.rs
+++ b/crates/rue-query/src/lib.rs
@@ -8075,7 +8075,10 @@ struct BatchValidationAuthorityState {
 
 #[derive(Default)]
 struct BatchValidationLeases {
-    observed: BTreeSet<(u64, u64, Revision)>,
+    /// Exact terminal identities have runtime-assigned numeric components and
+    /// no observable order. Match task-local lease deduplication instead of
+    /// paying ordered-tree insertion for every completed batch child.
+    observed: AHashSet<(u64, u64, Revision)>,
     held: Vec<Box<dyn ObservedLease>>,
 }
 

--- a/docs/notes/post-adr-0063-cold-compiler-architecture-audit.md
+++ b/docs/notes/post-adr-0063-cold-compiler-architecture-audit.md
@@ -1760,6 +1760,19 @@ RSS at +0.6267% (0.4606% MAD), and peak footprint at +0.2693% (1.5085% MAD).
 Every compiler-work counter, source/output metric, and executable byte remains
 identical.
 
+RUE-1463 makes structured-batch validation leases use unordered exact-identity
+membership, matching ordinary task leases. The identity components are assigned
+by the runtime and no consumer observes their order, so the previous tree paid
+ordered comparisons solely as an implementation accident. Across 16 balanced
+fixed one-worker cold Lattice pairs, retired instructions improve by 0.1030%
+(0.0690% MAD); end-to-end clock is neutral at -0.8874% (2.6105% MAD), cycles at
+-0.5005% (1.2074% MAD), peak RSS at -0.7588% (1.0378% MAD), and peak footprint
+at -1.1603% (1.2188% MAD). Four allocation-accounted pairs remove 890--1,292
+allocation calls while hash-table capacity adds 6.57--6.75 MB of cumulative
+requested bytes (0.28% of the run); the peak-memory comparisons above remain
+neutral. Every compiler-work counter, source/output metric, and executable byte
+remains identical.
+
 ## Next actions and decision boundary
 
 Authorized low-risk work:


### PR DESCRIPTION
Fixes RUE-1463.\n\n## Why\n\nStructured-batch validation leases used an ordered tree for exact terminal identities even though those runtime-assigned numeric identities have no observable ordering. Ordinary task leases already use unordered membership.\n\n## Change\n\nUse the existing AHashSet policy for structured-batch lease membership and document why ordering is not part of the abstraction.\n\n## Evidence\n\nOn 16 paired one-worker cold Lattice compiles against the exact RUE-1462 release baseline:\n\n- retired instructions: -0.1030% median (0.0690% MAD)\n- compiler time: -0.8874% (2.6105% MAD), neutral within noise\n- cycles: -0.5005% (1.2074% MAD), neutral\n- peak RSS: -0.7588% (1.0378% MAD), neutral/favorable\n- peak footprint: -1.1603% (1.2188% MAD), neutral/favorable\n\nFour allocation-accounted pairs remove 890–1,292 allocation calls. Hash-table capacity adds 6.57–6.75 MB of cumulative requested bytes (~0.28% of the run), while measured peak memory remains neutral. Compiler-work counters, source/output metrics, and executable bytes are identical.\n\n## Checks\n\n- focused registered-batch query tests\n- scripts/rue fmt\n- scripts/rue quick