### PR TITLE
RUE-1464: append provider member names into the owner buffer

### DIFF
--- a/crates/rue-air/src/sema/provider_body_host.rs
+++ b/crates/rue-air/src/sema/provider_body_host.rs
@@ -67,6 +67,14 @@ fn intern_synthetic_argument_name(interner: &ThreadedRodeo, index: usize) -> Spu
     interner.get_or_intern(name)
 }
 
+fn append_member_callable_name(mut owner: String, method: &str, has_self: bool) -> String {
+    let separator = if has_self { "." } else { "::" };
+    owner.reserve(separator.len() + method.len());
+    owner.push_str(separator);
+    owner.push_str(method);
+    owner
+}
+
 #[cfg(test)]
 #[test]
 fn synthetic_argument_names_match_the_canonical_spelling_without_a_heap_buffer() {
@@ -75,6 +83,19 @@ fn synthetic_argument_names_match_the_canonical_spelling_without_a_heap_buffer()
         let symbol = intern_synthetic_argument_name(&interner, index);
         assert_eq!(interner.resolve(&symbol), format!("arg{index}"));
     }
+}
+
+#[cfg(test)]
+#[test]
+fn member_callable_names_extend_the_owned_owner_spelling() {
+    assert_eq!(
+        append_member_callable_name("Owner".to_owned(), "method", true),
+        "Owner.method"
+    );
+    assert_eq!(
+        append_member_callable_name("Owner".to_owned(), "make", false),
+        "Owner::make"
+    );
 }
 
 /// Stable, request-independent description of an anonymous nominal created by
@@ -1190,11 +1211,7 @@ where
     /// reintroduce a join that only holds while two policies agree.
     fn member_callable_name(&self, struct_id: StructId, method: &str, has_self: bool) -> String {
         let owner = self.type_pool.struct_symbol_name(struct_id);
-        if has_self {
-            format!("{owner}.{method}")
-        } else {
-            format!("{owner}::{method}")
-        }
+        append_member_callable_name(owner, method, has_self)
     }
 
     fn member_callable_symbol(&self, struct_id: StructId, method: &str, has_self: bool) -> Spur {

--- a/docs/notes/post-adr-0063-cold-compiler-architecture-audit.md
+++ b/docs/notes/post-adr-0063-cold-compiler-architecture-audit.md
@@ -1773,6 +1773,19 @@ requested bytes (0.28% of the run); the peak-memory comparisons above remain
 neutral. Every compiler-work counter, source/output metric, and executable byte
 remains identical.
 
+RUE-1464 reuses the owned struct-symbol buffer when constructing provider
+member callable names. The canonical spelling helper previously allocated an
+owner string, formatted a second `Owner.method` / `Owner::method` string, and
+immediately dropped the owner. Extending that buffer in place preserves the
+single spelling path while removing the redundant intermediate allocation.
+Four allocation-accounted cold Lattice pairs remove 112,908--113,474
+allocation calls and 5.05--5.30 MB of requested bytes. Across 16 balanced
+fixed one-worker pairs, retired instructions improve by 0.4428% (0.1301%
+MAD); clock is neutral at -0.1323% amid substantial host noise, cycles at
++0.1649%, peak RSS at -0.6822%, and peak footprint at -0.0373%. Every
+compiler-work counter, source/output metric, and executable byte remains
+identical.
+
 ## Next actions and decision boundary
 
 Authorized low-risk work:


### PR DESCRIPTION
Fixes RUE-1464.\n\n## Why\n\nThe canonical provider member-name helper obtained an owned struct-symbol string, formatted a second Owner.method or Owner::method string, and immediately dropped the first allocation.\n\n## Change\n\nExtend the already-owned owner buffer in place with the separator and method name. This preserves the single canonical spelling path while removing redundant ownership and allocation work.\n\n## Evidence\n\nAgainst the exact RUE-1463 candidate baseline:\n\n- four allocation-accounted cold Lattice pairs remove 112,908–113,474 allocation calls and 5.05–5.30 MB of requested bytes\n- 16 paired one-worker cold Lattice compiles reduce retired instructions by 0.4428% median (0.1301% MAD)\n- compiler time is neutral at -0.1323% amid substantial host noise\n- cycles are neutral at +0.1649%; peak RSS -0.6822%; peak footprint -0.0373%\n- compiler-work counters, source/output metrics, and executable bytes are identical\n\n## Checks\n\n- focused instance/associated member spelling test\n- scripts/rue fmt\n- scripts/rue quick