### PR TITLE
RUE-1476: cache the dotslash buck2 download in the jobs that missed it

### DIFF
--- a/.github/workflows/cache-probe.yml
+++ b/.github/workflows/cache-probe.yml
@@ -43,6 +43,17 @@ jobs:
       - name: Install dotslash
         uses: facebook/install-dotslash@v2
 
+      # The buck2 binary itself, not build artifacts: this job deliberately
+      # clears buck-out and rebuilds cold, but re-downloading buck2 from the
+      # releases CDN is a network dependency the probe does not exist to test.
+      - name: Cache dotslash artifacts
+        uses: actions/cache@v5
+        with:
+          path: ~/.cache/dotslash
+          key: dotslash-linux-x64-${{ hashFiles('buck2') }}
+          restore-keys: |
+            dotslash-linux-x64-
+
       - name: Guard — secret present
         env:
           KEY: ${{ secrets.BUILDBUDDY_API_KEY }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,18 @@ jobs:
       - name: Install dotslash
         uses: facebook/install-dotslash@v2  # pinned: the moving `latest` branch broke macOS runners (sha256sum flags) on 2026-06-18
 
+      # Cache the dotslash-downloaded buck2 binary (see the `test` job for the
+      # rationale on which paths are worth caching).
+      - name: Cache dotslash artifacts
+        uses: actions/cache@v5
+        with:
+          path: |
+            ~/.cache/dotslash
+            ~/Library/Caches/dotslash
+          key: dotslash-linux-x64-${{ hashFiles('buck2') }}
+          restore-keys: |
+            dotslash-linux-x64-
+
       - name: Check formatting
         # Every crate emits its own `<name>-fmt-check` test from the
         # rue_crate/rue_binary macros (RUE-1153), so coverage follows the
@@ -147,6 +159,18 @@ jobs:
 
       - name: Install dotslash
         uses: facebook/install-dotslash@v2
+
+      # Cache the dotslash-downloaded buck2 binary (see the `test` job for the
+      # rationale on which paths are worth caching).
+      - name: Cache dotslash artifacts
+        uses: actions/cache@v5
+        with:
+          path: |
+            ~/.cache/dotslash
+            ~/Library/Caches/dotslash
+          key: dotslash-linux-x64-${{ hashFiles('buck2') }}
+          restore-keys: |
+            dotslash-linux-x64-
 
       - name: Require and provision remote execution
         env:


### PR DESCRIPTION
Closes RUE-1476.

Nine CI jobs restore the dotslash-downloaded buck2 binary from the actions cache. `fmt` and `remote-execution` did not, and neither did `cache-probe.yml`'s `probe` job while its sibling `rue-program-warm` did. Those jobs re-fetch buck2 from the GitHub releases CDN on every run, so a transient CDN failure fails them before any Rue code is exercised:

```
dotslash error: problem with `/home/runner/work/rue/rue/buck2-bin`
  0: `curl --location --retry 3 --fail --silent --show-error
     https://github.com/facebook/buck2/releases/download/2026-07-15/buck2-x86_64-unknown-linux-musl.zst`
```

That is not hypothetical. In a window of CDN failures today it took out merge-group run 31621247896 (`fmt`, `clippy`, `test (linux-x64-cli-shard-2)`, and `CI success` as the aggregate) and **evicted the PR from the merge queue**; run 31620181032 hit the same thing on a different PR and passed on retry. The cost is asymmetric there: a queue flake is not a re-run, it is a full queue cycle with every check repeated.

Caching does not make the download reliable — it removes it from the common path, which is why the nine jobs that already cache were not the ones that flaked first.

The step is the one `clippy` already carries, copied unchanged. All three jobs are single-platform ubuntu, so they take the existing `dotslash-linux-x64` key rather than the matrix-keyed `dotslash-${{ matrix.name }}` form the multi-OS jobs use.

## Deliberately not in scope

The four `performance-*` workflow jobs have the same gap, but they run a three-OS matrix (ubuntu-24.04, ubuntu-24.04-arm, macos-15), so they need the matrix-keyed form rather than a copy of this one. Noted on RUE-1476 as follow-up rather than folded in here.

## Verification

`actionlint` could not run locally — the repo gate runs it in Docker and no daemon is available on this machine — so CI is the authority. What was checked by hand: the three insertions are identical to the existing step, at step indentation, between two steps of the same job; and a scan over every workflow confirms each remaining `Install dotslash` is now paired with a cache step except the four `performance-*` jobs named above.