### PR TITLE
RUE-1480: delete test semantic facade

### DIFF
--- a/crates/rue-compiler/src/api_inventory.rs
+++ b/crates/rue-compiler/src/api_inventory.rs
@@ -1651,6 +1651,16 @@ fn removed_parallel_entry_points_cannot_return() {
         "collect_function_cfg_queries".to_owned(),
         "finish_canonical_analysis".to_owned(),
         "compose_queried_bodies".to_owned(),
+        ["Rooted", "Semantic", "Output"].concat(),
+        ["rooted_", "semantic"].concat(),
+        ["semantic_", "projection_", "for_test"].concat(),
+        ["Semantic", "View"].concat(),
+        ["Function", "View"].concat(),
+        ["Cfg", "View"].concat(),
+        ["CfgBlock", "View"].concat(),
+        ["CfgInstruction", "View"].concat(),
+        ["CfgSuccessor", "View"].concat(),
+        ["Type", "View"].concat(),
     ];
     for removed in forbidden {
         assert!(

--- a/crates/rue-compiler/src/backend.rs
+++ b/crates/rue-compiler/src/backend.rs
@@ -541,10 +541,7 @@ fn main() -> i32 {
         );
     }
 
-    fn frontend() -> (
-        std::sync::Arc<CanonicalRirOutput>,
-        std::sync::Arc<RootedSemanticOutput>,
-    ) {
+    fn frontend() -> (std::sync::Arc<CanonicalRirOutput>, RootedCfgOutput) {
         let snapshot = SourceSnapshot::single("<rue-784>", SOURCE).unwrap();
         let (rir, semantic, _) =
             crate::test_support::test_frontend_snapshot(&snapshot, &CompileOptions::default())
@@ -552,10 +549,7 @@ fn main() -> i32 {
         (rir, semantic)
     }
 
-    fn strbuf_concat_frontend() -> (
-        std::sync::Arc<CanonicalRirOutput>,
-        std::sync::Arc<RootedSemanticOutput>,
-    ) {
+    fn strbuf_concat_frontend() -> (std::sync::Arc<CanonicalRirOutput>, RootedCfgOutput) {
         let root = FileId::new(1);
         let strbuf = FileId::new(2);
         let metadata = SourceMetadata::new_with_trusted_standard_library(

--- a/crates/rue-compiler/src/import_discovery.rs
+++ b/crates/rue-compiler/src/import_discovery.rs
@@ -3716,7 +3716,7 @@ mod tests {
         }
         session.close_import_discovery(ledger).unwrap_err();
         let errors = session
-            .rooted_semantic(&crate::CompileOptions::default())
+            .rooted_cfg(&crate::CompileOptions::default())
             .unwrap_err();
         assert_eq!(errors.len(), 1);
         assert!(matches!(
@@ -3753,7 +3753,7 @@ mod tests {
         assert_eq!(session.work().last_rir, crate::CanonicalRirWork::default());
         assert!(
             session
-                .rooted_semantic(&crate::CompileOptions::default())
+                .rooted_cfg(&crate::CompileOptions::default())
                 .is_err()
         );
         let one_shot =

--- a/crates/rue-compiler/src/lib.rs
+++ b/crates/rue-compiler/src/lib.rs
@@ -167,15 +167,13 @@ pub(crate) use queries::{PipelineWork, SourceStats};
 #[allow(unused_imports)]
 pub(crate) use semantic_symbols::SemanticTranslationWork;
 #[cfg(test)]
-pub(crate) use session::RootedSemanticOutput;
+pub(crate) use session::RootedCfgOutput;
 #[allow(unused_imports)]
 pub(crate) use session::{
     CompilerSessionWork, FRONTEND_DIAGNOSTIC_RETENTION_LIMIT, FrontendQueryWork,
     FrontendRetentionMetrics, ImportDiscoveryRevisionArtifact, ImportDiscoveryRevisionStatus,
     ImportGraphInputDescriptor,
 };
-#[cfg(test)]
-pub(crate) use source_identity::LinkInputDescriptor;
 #[allow(unused_imports)]
 pub(crate) use source_identity::{
     CodegenInputDescriptor, ModuleResolutionInput, ModuleResolutionInputs, SemanticInputDescriptor,

--- a/crates/rue-compiler/src/pipeline_tests.rs
+++ b/crates/rue-compiler/src/pipeline_tests.rs
@@ -160,9 +160,9 @@ mod tests {
             .update_for_presentation(&snapshot)
             .into_result()
             .unwrap();
-        warm_session.rooted_semantic(&cold_options).unwrap();
-        let warm = warm_session.rooted_semantic(&optimized).unwrap();
-        assert!(!warm.strings().is_empty());
+        warm_session.rooted_cfg(&cold_options).unwrap();
+        let warm = warm_session.rooted_cfg(&optimized).unwrap();
+        assert!(warm.string_domains().any(|strings| !strings.is_empty()));
         let warm_atoms = warm
             .functions()
             .iter()
@@ -176,7 +176,7 @@ mod tests {
             .update_for_presentation(&snapshot)
             .into_result()
             .unwrap();
-        let fresh = fresh_session.rooted_semantic(&optimized).unwrap();
+        let fresh = fresh_session.rooted_cfg(&optimized).unwrap();
         let fresh_atoms = fresh
             .functions()
             .iter()
@@ -188,7 +188,7 @@ mod tests {
             format!("{:?}", fresh.functions())
         );
         assert_eq!(warm.type_pool_stats(), fresh.type_pool_stats());
-        let named_types = |semantic: &RootedSemanticOutput| {
+        let named_types = |semantic: &RootedCfgOutput| {
             semantic
                 .type_pools()
                 .map(|pool| {
@@ -206,7 +206,10 @@ mod tests {
                 .collect::<Vec<_>>()
         };
         assert_eq!(named_types(&warm), named_types(&fresh));
-        assert_eq!(warm.strings(), fresh.strings());
+        assert_eq!(
+            warm.string_domains().collect::<Vec<_>>(),
+            fresh.string_domains().collect::<Vec<_>>()
+        );
         assert_eq!(
             format!("{:?}", warm.warnings()),
             format!("{:?}", fresh.warnings())
@@ -1746,7 +1749,7 @@ mod tests {
             .update_for_presentation(&first)
             .into_result()
             .unwrap();
-        let cold = warm_session.rooted_semantic(&optimized).unwrap();
+        let cold = warm_session.rooted_cfg(&optimized).unwrap();
         let cold_atoms = cold
             .functions()
             .iter()
@@ -1766,19 +1769,22 @@ mod tests {
             .update_for_presentation(&reordered)
             .into_result()
             .unwrap();
-        let warm = warm_session.rooted_semantic(&optimized).unwrap();
+        let warm = warm_session.rooted_cfg(&optimized).unwrap();
         let warm_atoms = warm
             .functions()
             .iter()
-            .flat_map(|function| function.record.local_atoms.iter())
+            .flat_map(|function| {
+                function
+                    .record
+                    .local_atoms
+                    .iter()
+                    .map(|atom| (atom, function.record.strings.as_ref()))
+            })
             .collect::<Vec<_>>();
         assert_eq!(warm_atoms.len(), 2);
-        assert!(warm_atoms.iter().all(|atom| {
+        assert!(warm_atoms.iter().all(|(atom, strings)| {
             atom.identity.kind == rue_air::LocalAtomKind::ReadOnlyData
-                && warm
-                    .strings()
-                    .get(atom.dense_id as usize)
-                    .map(String::as_str)
+                && strings.get(atom.dense_id as usize).map(String::as_str)
                     == Some(atom.content.as_ref())
         }));
 
@@ -2124,17 +2130,17 @@ mod tests {
         )
         .unwrap();
         let options = CompileOptions::default();
-        let expected_link = LinkInputDescriptor::from_compile_options(&snapshot, &options);
 
         let mut session = CompilerSession::new();
         session.update(&snapshot).into_result().unwrap();
-        let semantic = session.rooted_semantic(&options).unwrap();
+        let rir = session.canonical_rir().unwrap();
+        let semantic = session.rooted_cfg(&options).unwrap();
 
         assert_eq!(semantic.functions().len(), 1);
-        assert_eq!(semantic.input(), &expected_link.codegen);
         assert_eq!(
-            semantic.input().semantic.sources.root(),
-            snapshot.source_revision().root()
+            rir.source_revision(),
+            snapshot.source_revision(),
+            "the canonical RIR and rooted CFG request share the published source identity"
         );
     }
 

--- a/crates/rue-compiler/src/producer_nominal_acceptance_tests.rs
+++ b/crates/rue-compiler/src/producer_nominal_acceptance_tests.rs
@@ -88,12 +88,12 @@ fn trusted_option_snapshot_with_source(root_source: &str, option_source: &str) -
 }
 
 /// Publish `root_source` alongside the trusted std `Option` module and return
-/// the semantic output. Import resolution is the test-fixture graph, exactly as
+/// the rooted CFG output. Import resolution is the test-fixture graph, exactly as
 /// the other multi-module frontend tests use.
-fn semantic_with_trusted_option(
+fn rooted_cfg_with_trusted_option(
     root_source: &str,
     options: &CompileOptions,
-) -> Result<Arc<RootedSemanticOutput>, CompileErrors> {
+) -> Result<RootedCfgOutput, CompileErrors> {
     let snapshot = trusted_option_snapshot(root_source);
     let (_, semantic, _) = crate::test_frontend_snapshot(&snapshot, options)?;
     Ok(semantic)
@@ -110,12 +110,12 @@ fn compile_with_trusted_option(
 }
 
 /// The result Option enum types bound to each fallible parse/read intrinsic in
-/// a semantic output — the exact type `resolve_option_result_type` chose. Each
+/// a rooted CFG output — the exact type `resolve_option_result_type` chose. Each
 /// entry is the intrinsic's runtime kind paired with the `EnumId` of its
 /// `Option` result. Reading the AIR instruction's `ty` directly gives the
 /// binding the `?` site consumed, not merely what exists in the pool.
 fn fallible_intrinsic_option_enums(
-    semantic: &RootedSemanticOutput,
+    semantic: &RootedCfgOutput,
 ) -> Vec<(rue_air::RuntimeCallKind, String)> {
     let mut found = Vec::new();
     for function in semantic.functions() {
@@ -153,7 +153,7 @@ fn fallible_intrinsic_option_enums(
 /// definition-relative anchor (RUE-1089, allocation-order-independent), the same
 /// producer yields the same digest across programs — so a digest computed from a
 /// std-only reference program identifies the trusted std `Option(i64)` anywhere.
-fn bound_parse_i64_digest(semantic: &RootedSemanticOutput) -> String {
+fn bound_parse_i64_digest(semantic: &RootedCfgOutput) -> String {
     let parse = fallible_intrinsic_option_enums(semantic)
         .into_iter()
         .filter(|(runtime, _)| *runtime == rue_air::RuntimeCallKind::ParseI64)
@@ -171,7 +171,7 @@ fn bound_parse_i64_digest(semantic: &RootedSemanticOutput) -> String {
 /// pool. Distinct producers of the same shape (a std `Option` and a local
 /// lookalike) appear as distinct digests, so the size of this set counts how
 /// many independent `Option(i64)` identities the program materialized.
-fn option_i64_pool_digests(semantic: &RootedSemanticOutput) -> BTreeSet<String> {
+fn option_i64_pool_digests(semantic: &RootedCfgOutput) -> BTreeSet<String> {
     semantic
         .type_pools()
         .flat_map(|pool| {
@@ -201,7 +201,7 @@ fn main() -> i32 {
 }
 "#;
     let semantic =
-        semantic_with_trusted_option(reference, options).expect("std reference program compiles");
+        rooted_cfg_with_trusted_option(reference, options).expect("std reference program compiles");
     bound_parse_i64_digest(&semantic)
 }
 
@@ -226,7 +226,7 @@ fn main() -> i32 {
     }
 }
 "#;
-    let semantic = semantic_with_trusted_option(source, &options)
+    let semantic = rooted_cfg_with_trusted_option(source, &options)
         .expect("trusted-option parse program compiles");
     let bound = bound_parse_i64_digest(&semantic);
     assert_eq!(
@@ -288,7 +288,7 @@ fn main() -> i32 {
 }
 "#;
     let semantic =
-        semantic_with_trusted_option(source, &options).expect("lookalike program compiles");
+        rooted_cfg_with_trusted_option(source, &options).expect("lookalike program compiles");
 
     // Both a std and a local Option(i64) identity were materialized.
     let pool_digests = option_i64_pool_digests(&semantic);
@@ -372,7 +372,7 @@ fn main() -> i32 {
     }
 }
 "#;
-    let errors = fresh_semantic(local_lookalike, &options)
+    let errors = fresh_rooted_cfg(local_lookalike, &options)
         .expect_err("a local-Option `?` operand is no longer accepted (fallback deleted)");
     let rendered = errors.to_string();
     assert!(
@@ -397,7 +397,7 @@ fn main() -> i32 {
     }
 }
 "#;
-    let semantic = semantic_with_trusted_option(std_acquired, &options)
+    let semantic = rooted_cfg_with_trusted_option(std_acquired, &options)
         .expect("std-acquired `@parse_i64(s)?` compiles");
     // The `?` bound the trusted std Option(i64).
     assert_eq!(
@@ -490,7 +490,7 @@ fn main() -> i32 {
 }
 "#;
     let semantic =
-        semantic_with_trusted_option(source, &options).expect("two-body program compiles");
+        rooted_cfg_with_trusted_option(source, &options).expect("two-body program compiles");
     let parse_enums = fallible_intrinsic_option_enums(&semantic)
         .into_iter()
         .filter(|(runtime, _)| *runtime == rue_air::RuntimeCallKind::ParseI64)
@@ -515,20 +515,20 @@ fn main() -> i32 {
 }
 
 /// Publish `root_source` (trusted std `Option` present) into `session` through
-/// the discovery protocol, and return the semantic output.
-fn publish_trusted_semantic(
+/// the discovery protocol, and return the rooted CFG output.
+fn publish_trusted_rooted_cfg(
     session: &mut CompilerSession,
     root_source: &str,
     options: &CompileOptions,
-) -> Result<Arc<RootedSemanticOutput>, CompileErrors> {
+) -> Result<RootedCfgOutput, CompileErrors> {
     let snapshot = trusted_option_snapshot(root_source);
     crate::test_support::publish_test_snapshot(session, &snapshot)?;
-    session.rooted_semantic(options)
+    session.rooted_cfg(options)
 }
 
 /// Warm/fresh parity on t-win. A WARM incremental compile (reached after the
 /// session already compiled an unrelated prior revision that also carried the
-/// trusted std module) produces semantic output identical to a FRESH compile:
+/// trusted std module) produces rooted CFG output identical to a FRESH compile:
 /// the per-body demand, projection, and narrow install are deterministic and
 /// session-issuer-independent, so the well-known `Option(i64)` binding and every
 /// symbol agree exactly.
@@ -549,7 +549,7 @@ fn main() -> i32 {
 
     let mut warm_session = CompilerSession::new();
     // An unrelated prior revision (still trusted-std-bearing) warms the session.
-    publish_trusted_semantic(
+    publish_trusted_rooted_cfg(
         &mut warm_session,
         r#"
 const opt = @import("std/option.rue");
@@ -558,16 +558,12 @@ fn main() -> i32 { 0 }
         &options,
     )
     .ok();
-    let warm = publish_trusted_semantic(&mut warm_session, target, &options)
+    let warm = publish_trusted_rooted_cfg(&mut warm_session, target, &options)
         .expect("warm compile of t-win");
 
-    let fresh = semantic_with_trusted_option(target, &options).expect("fresh compile of t-win");
+    let fresh = rooted_cfg_with_trusted_option(target, &options).expect("fresh compile of t-win");
 
-    assert_eq!(
-        warm.unstable_parity_snapshot(),
-        fresh.unstable_parity_snapshot(),
-        "warm/fresh semantic parity snapshot diverged for t-win",
-    );
+    crate::test_support::assert_rooted_cfg_value_parity("warm/fresh t-win", &warm, &fresh);
     assert_eq!(
         bound_parse_i64_digest(&warm),
         bound_parse_i64_digest(&fresh),
@@ -576,10 +572,10 @@ fn main() -> i32 { 0 }
 }
 
 /// The per-site `Option(i64)` `EnumId` bound at every `@parse_i64` instruction in
-/// a semantic output, in AIR order. Reading `inst.ty` gives the identity each
+/// a rooted CFG output, in AIR order. Reading `inst.ty` gives the identity each
 /// site actually consumed, so mixed `?`-operand and plain uses can be compared
 /// directly for shared identity.
-fn parse_i64_bound_enums(semantic: &RootedSemanticOutput) -> Vec<String> {
+fn parse_i64_bound_enums(semantic: &RootedCfgOutput) -> Vec<String> {
     fallible_intrinsic_option_enums(semantic)
         .into_iter()
         .filter(|(runtime, _)| *runtime == rue_air::RuntimeCallKind::ParseI64)
@@ -603,7 +599,7 @@ fn main() -> i32 {
     0
 }
 "#;
-    let semantic = semantic_with_trusted_option(source, &options)
+    let semantic = rooted_cfg_with_trusted_option(source, &options)
         .expect("a plain unannotated @parse_i64 compiles");
     assert_eq!(
         bound_parse_i64_digest(&semantic),
@@ -633,7 +629,7 @@ fn main() -> i32 {
     match read_num("42") { O.Some(v) => @intCast(v), O.None => 0 }
 }
 "#;
-    let semantic = semantic_with_trusted_option(source, &options)
+    let semantic = rooted_cfg_with_trusted_option(source, &options)
         .expect("mixed plain + `?` in one body compiles with no E9000");
     let bound = parse_i64_bound_enums(&semantic);
     assert_eq!(
@@ -674,7 +670,7 @@ fn main() -> i32 {
     match fallibly("42") { O.Some(v) => @intCast(v) + plainly("1"), O.None => 0 }
 }
 "#;
-    let semantic = semantic_with_trusted_option(source, &options)
+    let semantic = rooted_cfg_with_trusted_option(source, &options)
         .expect("mixed plain + `?` across two bodies compiles with no E9000");
     let bound = parse_i64_bound_enums(&semantic);
     assert_eq!(
@@ -694,7 +690,7 @@ fn main() -> i32 {
 }
 
 /// B1(c). Warm/fresh parity on the mixed (plain + `?`) program: a warm
-/// incremental compile and a fresh compile agree on the full semantic parity
+/// incremental compile and a fresh compile agree on the full rooted CFG parity
 /// snapshot and on the shared well-known `Option(i64)` binding. The per-body
 /// demand, projection, and narrow install are deterministic and
 /// session-issuer-independent even when a body mixes plain and `?` uses.
@@ -715,7 +711,7 @@ fn main() -> i32 {
 "#;
 
     let mut warm_session = CompilerSession::new();
-    publish_trusted_semantic(
+    publish_trusted_rooted_cfg(
         &mut warm_session,
         r#"
 const opt = @import("std/option.rue");
@@ -724,16 +720,12 @@ fn main() -> i32 { 0 }
         &options,
     )
     .ok();
-    let warm = publish_trusted_semantic(&mut warm_session, target, &options)
+    let warm = publish_trusted_rooted_cfg(&mut warm_session, target, &options)
         .expect("warm compile of the mixed program");
-    let fresh =
-        semantic_with_trusted_option(target, &options).expect("fresh compile of the mixed program");
+    let fresh = rooted_cfg_with_trusted_option(target, &options)
+        .expect("fresh compile of the mixed program");
 
-    assert_eq!(
-        warm.unstable_parity_snapshot(),
-        fresh.unstable_parity_snapshot(),
-        "warm/fresh semantic parity snapshot diverged for the mixed program",
-    );
+    crate::test_support::assert_rooted_cfg_value_parity("warm/fresh mixed program", &warm, &fresh);
     let warm_bound = parse_i64_bound_enums(&warm);
     let fresh_bound = parse_i64_bound_enums(&fresh);
     assert!(
@@ -827,40 +819,40 @@ fn main() -> i32 {
 "#;
 
 /// Compile a single (import-free) source through a FRESH session and return its
-/// canonical semantic output (or the collected errors).
-fn fresh_semantic(
+/// canonical rooted CFG output (or the collected errors).
+fn fresh_rooted_cfg(
     source: &str,
     options: &CompileOptions,
-) -> Result<Arc<RootedSemanticOutput>, CompileErrors> {
+) -> Result<RootedCfgOutput, CompileErrors> {
     let snapshot = SourceSnapshot::single("<acceptance>", source).map_err(CompileErrors::from)?;
     let mut session = CompilerSession::new();
     session.update(&snapshot).into_result()?;
-    session.rooted_semantic(options)
+    session.rooted_cfg(options)
 }
 
 /// Compile a single source WARM: publish an unrelated prior revision, compile
 /// it, then publish and compile the target source in the same session. This
 /// exercises the incremental path against the same session state a fresh
 /// compile never sees.
-fn warm_semantic(
+fn warm_rooted_cfg(
     prior: &str,
     source: &str,
     options: &CompileOptions,
-) -> Result<Arc<RootedSemanticOutput>, CompileErrors> {
+) -> Result<RootedCfgOutput, CompileErrors> {
     let mut session = CompilerSession::new();
     let prior_snapshot =
         SourceSnapshot::single("<acceptance>", prior).map_err(CompileErrors::from)?;
     session.update(&prior_snapshot).into_result()?;
-    session.rooted_semantic(options).ok(); // prior revision is not oracled.
+    session.rooted_cfg(options).ok(); // prior revision is not oracled.
     let snapshot = SourceSnapshot::single("<acceptance>", source).map_err(CompileErrors::from)?;
     session.update(&snapshot).into_result()?;
-    session.rooted_semantic(options)
+    session.rooted_cfg(options)
 }
 
-/// The emitted symbol names of a semantic output: every struct/enum symbol and
+/// The emitted symbol names of a rooted CFG output: every struct/enum symbol and
 /// every function machine name. Two independent cold compiles of one program
 /// must produce identical sets.
-fn symbol_names(semantic: &RootedSemanticOutput) -> BTreeSet<String> {
+fn symbol_names(semantic: &RootedCfgOutput) -> BTreeSet<String> {
     let mut names = BTreeSet::new();
     for pool in semantic.type_pools() {
         for id in pool.all_struct_ids() {
@@ -891,13 +883,13 @@ fn symbol_names(semantic: &RootedSemanticOutput) -> BTreeSet<String> {
     names
 }
 
-/// The named (non-anonymous) type/function symbols of a semantic output. These
+/// The named (non-anonymous) type/function symbols of a rooted CFG output. These
 /// are invariant under reordering and unrelated edits. Anonymous synthetic
 /// symbols are asserted separately via [`anonymous_symbols`], which since the
 /// Stage-A stable-naming cut (ADR-0066, RUE-1089) are also invariant under those
 /// edits — their disambiguating suffix is a digest of the producer identity, not
 /// an allocation-order counter.
-fn named_symbols(semantic: &RootedSemanticOutput) -> BTreeSet<String> {
+fn named_symbols(semantic: &RootedCfgOutput) -> BTreeSet<String> {
     symbol_names(semantic)
         .into_iter()
         .filter(|name| !name.contains("__anon_"))
@@ -905,12 +897,12 @@ fn named_symbols(semantic: &RootedSemanticOutput) -> BTreeSet<String> {
         .collect()
 }
 
-/// The anonymous synthetic type symbols of a semantic output — the struct/enum
+/// The anonymous synthetic type symbols of a rooted CFG output — the struct/enum
 /// symbols whose spelling carries the `__anon_struct_`/`__anon_enum_` prefix.
 /// Since the Stage-A cut (ADR-0066, RUE-1089) each spelling is a STABLE digest
 /// of the producer identity, so this set is identical across independent cold
 /// compiles and across warm/fresh, and unchanged by unrelated edits.
-fn anonymous_symbols(semantic: &RootedSemanticOutput) -> BTreeSet<String> {
+fn anonymous_symbols(semantic: &RootedCfgOutput) -> BTreeSet<String> {
     symbol_names(semantic)
         .into_iter()
         .filter(|name| name.contains("__anon_struct_") || name.contains("__anon_enum_"))
@@ -918,7 +910,7 @@ fn anonymous_symbols(semantic: &RootedSemanticOutput) -> BTreeSet<String> {
 }
 
 /// Count the anonymous struct/enum types minted into the type pool.
-fn anonymous_type_count(semantic: &RootedSemanticOutput) -> usize {
+fn anonymous_type_count(semantic: &RootedCfgOutput) -> usize {
     anonymous_symbols(semantic).len()
 }
 
@@ -931,9 +923,9 @@ fn anonymous_type_count(semantic: &RootedSemanticOutput) -> usize {
 #[test]
 fn producer_nominal_identity_is_stable_under_unrelated_edits() {
     let options = CompileOptions::default();
-    let baseline = fresh_semantic(MULTI_ANON_PRODUCER, &options)
+    let baseline = fresh_rooted_cfg(MULTI_ANON_PRODUCER, &options)
         .expect("baseline multi-anon producer compiles");
-    let reordered = fresh_semantic(MULTI_ANON_PRODUCER_REORDERED, &options)
+    let reordered = fresh_rooted_cfg(MULTI_ANON_PRODUCER_REORDERED, &options)
         .expect("reordered multi-anon producer compiles");
 
     // The same set of anonymous identities exists in both orderings.
@@ -980,20 +972,20 @@ fn producer_nominal_identity_is_stable_under_unrelated_edits() {
 // ---------------------------------------------------------------------------
 
 /// Two independent COLD compiles of the same program produce byte-identical
-/// semantic output (bodies, layouts, type pool, dependencies) and an identical
+/// rooted CFG output (bodies, layouts, type pool, dependencies) and an identical
 /// emitted symbol set. This is the determinism half of the parity oracle,
-/// asserted through the same `unstable_parity_snapshot` projection the scaling
+/// asserted through the same canonical rooted CFG comparisons the scaling
 /// harness uses.
 #[test]
-fn producer_nominal_semantic_output_is_deterministic_across_cold_compiles() {
+fn producer_nominal_rooted_cfg_is_deterministic_across_cold_compiles() {
     let options = CompileOptions::default();
-    let first = fresh_semantic(MULTI_ANON_PRODUCER, &options).expect("first cold compile");
-    let second = fresh_semantic(MULTI_ANON_PRODUCER, &options).expect("second cold compile");
+    let first = fresh_rooted_cfg(MULTI_ANON_PRODUCER, &options).expect("first cold compile");
+    let second = fresh_rooted_cfg(MULTI_ANON_PRODUCER, &options).expect("second cold compile");
 
-    assert_eq!(
-        first.unstable_parity_snapshot(),
-        second.unstable_parity_snapshot(),
-        "two cold compiles of the same program diverged in semantic parity snapshot",
+    crate::test_support::assert_rooted_cfg_value_parity(
+        "two cold compiles of the same program",
+        &first,
+        &second,
     );
     assert_eq!(
         symbol_names(&first),
@@ -1040,7 +1032,7 @@ fn main() -> i32 {
 }
 "#;
     let options = CompileOptions::default();
-    let first = fresh_semantic(source, &options).expect("distinct-producer program compiles");
+    let first = fresh_rooted_cfg(source, &options).expect("distinct-producer program compiles");
     let anon = anonymous_symbols(&first);
     assert_eq!(
         anon.len(),
@@ -1050,7 +1042,7 @@ fn main() -> i32 {
 
     // The same program compiled again yields the SAME two symbols (stability),
     // and they are the same set (determinism) — never a re-numbered pair.
-    let second = fresh_semantic(source, &options).expect("second compile");
+    let second = fresh_rooted_cfg(source, &options).expect("second compile");
     assert_eq!(
         anon,
         anonymous_symbols(&second),
@@ -1062,12 +1054,12 @@ fn main() -> i32 {
 /// caller-chosen request-local `FileId` while keeping the same LOGICAL module
 /// identity (same path). This lets a test present the same logical program under
 /// different `FileId` assignments.
-fn semantic_at_root_file_id(
+fn rooted_cfg_at_root_file_id(
     source: &str,
     file_id: FileId,
     logical_path: &str,
     options: &CompileOptions,
-) -> Arc<RootedSemanticOutput> {
+) -> RootedCfgOutput {
     let physical: std::collections::HashMap<FileId, String> =
         [(file_id, logical_path.to_owned())].into();
     let logical = physical.clone();
@@ -1078,7 +1070,7 @@ fn semantic_at_root_file_id(
     let mut session = CompilerSession::new();
     session.update(&snapshot).into_result().expect("publish");
     session
-        .rooted_semantic(options)
+        .rooted_cfg(options)
         .expect("permuted-FileId program compiles")
 }
 
@@ -1104,8 +1096,8 @@ fn main() -> i32 {
 }
 "#;
     let options = CompileOptions::default();
-    let at_zero = semantic_at_root_file_id(source, FileId::new(0), "prog.rue", &options);
-    let at_seven = semantic_at_root_file_id(source, FileId::new(7), "prog.rue", &options);
+    let at_zero = rooted_cfg_at_root_file_id(source, FileId::new(0), "prog.rue", &options);
+    let at_seven = rooted_cfg_at_root_file_id(source, FileId::new(7), "prog.rue", &options);
 
     let anon = anonymous_symbols(&at_zero);
     assert!(
@@ -1123,18 +1115,18 @@ fn main() -> i32 {
 /// A WARM (incremental) compile of the acceptance program — reached after the
 /// session already compiled an unrelated prior revision — produces semantic
 /// output identical to a FRESH compile of the same program. This reuses the
-/// scaling harness's parity machinery (`unstable_parity_snapshot`) test-side.
+/// scaling harness's canonical rooted CFG comparisons test-side.
 #[test]
-fn producer_nominal_warm_and_fresh_semantic_output_agree() {
+fn producer_nominal_warm_and_fresh_rooted_cfg_output_agree() {
     let options = CompileOptions::default();
-    let warm = warm_semantic("fn main() -> i32 { 0 }", MULTI_ANON_PRODUCER, &options)
+    let warm = warm_rooted_cfg("fn main() -> i32 { 0 }", MULTI_ANON_PRODUCER, &options)
         .expect("warm compile of multi-anon producer");
-    let fresh = fresh_semantic(MULTI_ANON_PRODUCER, &options).expect("fresh compile");
+    let fresh = fresh_rooted_cfg(MULTI_ANON_PRODUCER, &options).expect("fresh compile");
 
-    assert_eq!(
-        warm.unstable_parity_snapshot(),
-        fresh.unstable_parity_snapshot(),
-        "warm/fresh semantic parity snapshot diverged for the acceptance producer",
+    crate::test_support::assert_rooted_cfg_value_parity(
+        "warm/fresh acceptance producer",
+        &warm,
+        &fresh,
     );
     assert_eq!(
         symbol_names(&warm),
@@ -1189,7 +1181,7 @@ fn execute_wrap(output: &CompileOutput, label: &str) -> std::process::Output {
 }
 
 /// Count the anonymous ENUM identities minted into the pool.
-fn anonymous_enum_count(semantic: &RootedSemanticOutput) -> usize {
+fn anonymous_enum_count(semantic: &RootedCfgOutput) -> usize {
     semantic
         .anonymous_nominals()
         .iter()
@@ -1213,7 +1205,7 @@ fn anonymous_enum_count(semantic: &RootedSemanticOutput) -> usize {
 #[test]
 fn wrap_single_nominal_identity_executes_to_the_payload() {
     let options = CompileOptions::default();
-    let semantic = fresh_semantic(WRAP_REPRO, &options).expect("Wrap repro compiles");
+    let semantic = fresh_rooted_cfg(WRAP_REPRO, &options).expect("Wrap repro compiles");
 
     // A single anonymous Option identity backs every reach of `self.inner`.
     assert_eq!(
@@ -1261,7 +1253,7 @@ fn wrap_payload_executes_on_both_backend_targets() {
             target,
             ..CompileOptions::default()
         };
-        fresh_semantic(WRAP_REPRO, &options).unwrap_or_else(|errors| {
+        fresh_rooted_cfg(WRAP_REPRO, &options).unwrap_or_else(|errors| {
             panic!("target {target:?}: Wrap repro must compile: {errors}")
         });
 
@@ -1346,7 +1338,7 @@ fn main() -> i32 {{
 fn divergent_anchor_transport_fails_closed_loud() {
     let options = CompileOptions::default();
     let program = fault_probe_program("__RUE1089_FAULT_DIVERGE__");
-    let errors = match fresh_semantic(&program, &options) {
+    let errors = match fresh_rooted_cfg(&program, &options) {
         Err(errors) => errors,
         Ok(_) => {
             panic!("a divergent transported anchor must fail closed, but the program compiled")
@@ -1373,7 +1365,7 @@ fn divergent_anchor_transport_fails_closed_loud() {
 /// producer's failure was masked by a live AIR mint), which created a second
 /// identity authority and hid transport defects. The reviewer ruled that
 /// unacceptable; every mode now sinks the request with a typed internal
-/// diagnostic and publishes NO semantic output.
+/// diagnostic and publishes NO rooted CFG output.
 #[test]
 fn resolve_level_transport_corruptions_fail_closed_loud() {
     let options = CompileOptions::default();
@@ -1383,12 +1375,12 @@ fn resolve_level_transport_corruptions_fail_closed_loud() {
         "__RUE1089_FAULT_WRONG_KIND__",
     ] {
         let program = fault_probe_program(marker);
-        // Zero publication: the request yields NO `RootedSemanticOutput`, so
+        // Zero publication: the request yields NO `RootedCfgOutput`, so
         // no nominal/member/alias terminal reached the caller.
-        let errors = match fresh_semantic(&program, &options) {
+        let errors = match fresh_rooted_cfg(&program, &options) {
             Err(errors) => errors,
             Ok(_) => panic!(
-                "corruption mode {marker} must fail closed with no published semantic output, \
+                "corruption mode {marker} must fail closed with no published rooted CFG output, \
                  but the program compiled",
             ),
         };
@@ -1409,7 +1401,7 @@ fn resolve_level_transport_corruptions_fail_closed_loud() {
 fn fault_probe_compiles_and_runs_cleanly_without_a_marker() {
     let options = CompileOptions::default();
     let program = fault_probe_program("no fault here");
-    fresh_semantic(&program, &options).expect("the unmarked probe must compile");
+    fresh_rooted_cfg(&program, &options).expect("the unmarked probe must compile");
     let snapshot = SourceSnapshot::single("<fault>", &program).expect("snapshot");
     let mut session = CompilerSession::new();
     session.update(&snapshot).into_result().expect("publish");
@@ -1518,7 +1510,7 @@ fn main() -> i32 {
     t.first
 }
 "#;
-    fresh_semantic(source, &options).expect("only the selected branch's site is consumed");
+    fresh_rooted_cfg(source, &options).expect("only the selected branch's site is consumed");
 }
 
 /// Trivia and unrelated declarations before the producer shift every module and
@@ -1557,8 +1549,8 @@ fn main() -> i32 {
     b.get()
 }
 "#;
-    let base = fresh_semantic(baseline, &options).expect("baseline compiles");
-    let shift = fresh_semantic(shifted, &options).expect("shifted compiles");
+    let base = fresh_rooted_cfg(baseline, &options).expect("baseline compiles");
+    let shift = fresh_rooted_cfg(shifted, &options).expect("shifted compiles");
     assert_eq!(
         anonymous_type_count(&base),
         anonymous_type_count(&shift),

--- a/crates/rue-compiler/src/program_image_plan.rs
+++ b/crates/rue-compiler/src/program_image_plan.rs
@@ -695,7 +695,7 @@ mod tests {
         let mut session = crate::CompilerSession::with_query_concurrency(workers);
         crate::publish_test_snapshot(&mut session, &snapshot).unwrap();
         let rir = session.canonical_rir().unwrap();
-        let semantic = session.rooted_semantic(&options).unwrap();
+        let semantic = session.rooted_cfg(&options).unwrap();
         let exports = backend::collect_export_symbols(rir.rir(), rir.semantic_symbols().interner());
         let units = session
             .codegen_units(
@@ -725,7 +725,7 @@ mod tests {
         let mut session = crate::CompilerSession::new();
         crate::publish_test_snapshot(&mut session, &snapshot).unwrap();
         let rir = session.canonical_rir().unwrap();
-        let semantic = session.rooted_semantic(&options).unwrap();
+        let semantic = session.rooted_cfg(&options).unwrap();
         let exports = backend::collect_export_symbols(rir.rir(), rir.semantic_symbols().interner());
         let products = session
             .codegen_products(
@@ -911,7 +911,7 @@ mod tests {
         };
         let mut session = crate::CompilerSession::new();
         crate::publish_test_snapshot(&mut session, &snapshot).unwrap();
-        let semantic = session.rooted_semantic(&options).unwrap();
+        let semantic = session.rooted_cfg(&options).unwrap();
         let units = session
             .codegen_units(
                 &semantic,
@@ -962,7 +962,7 @@ mod tests {
         let mut session = crate::CompilerSession::new();
         crate::publish_test_snapshot(&mut session, &snapshot).unwrap();
         let rir = session.canonical_rir().unwrap();
-        let semantic = session.rooted_semantic(&options).unwrap();
+        let semantic = session.rooted_cfg(&options).unwrap();
         let exports = backend::collect_export_symbols(rir.rir(), rir.semantic_symbols().interner());
         assert_eq!(exports, ["rue_answer"]);
         let units = session
@@ -1074,7 +1074,7 @@ mod tests {
         let mut session = crate::CompilerSession::new();
         crate::publish_test_snapshot(&mut session, &snapshot).unwrap();
         let rir = session.canonical_rir().unwrap();
-        let semantic = session.rooted_semantic(&options).unwrap();
+        let semantic = session.rooted_cfg(&options).unwrap();
         let exports = backend::collect_export_symbols(rir.rir(), rir.semantic_symbols().interner());
         let first = ProgramImage::new(
             session
@@ -1093,7 +1093,7 @@ mod tests {
         let first_objects = first.fresh_objects(&options).unwrap();
 
         let rir = session.canonical_rir().unwrap();
-        let semantic = session.rooted_semantic(&options).unwrap();
+        let semantic = session.rooted_cfg(&options).unwrap();
         let exports = backend::collect_export_symbols(rir.rir(), rir.semantic_symbols().interner());
         let second = ProgramImage::new(
             session
@@ -1159,7 +1159,7 @@ mod tests {
         let mut old_session = crate::CompilerSession::new();
         crate::publish_test_snapshot(&mut old_session, &snapshot).unwrap();
         let old_rir = old_session.canonical_rir().unwrap();
-        let old_semantic = old_session.rooted_semantic(&options).unwrap();
+        let old_semantic = old_session.rooted_cfg(&options).unwrap();
         let old_exports =
             backend::collect_export_symbols(old_rir.rir(), old_rir.semantic_symbols().interner());
         let old = backend::compile_backend_products(

--- a/crates/rue-compiler/src/revisioned_query_database.rs
+++ b/crates/rue-compiler/src/revisioned_query_database.rs
@@ -398,7 +398,7 @@ pub(crate) struct RevisionedQueryDatabase {
     // demanding body's stable requester anchor. It is pure (its only input is the
     // raw-body query, so the dependency edge is honest for invalidation, metrics,
     // and future parallel scheduling), does no presence check, and does no I/O.
-    // The rooted semantic attempt queries it BEFORE each body transaction, checks
+    // The rooted body-closure attempt queries it BEFORE each body transaction, checks
     // the demanded modules against the satisfied catalogue, and parks the absent
     // ones without entering the transaction.
     body_toolchain_demands:

--- a/crates/rue-compiler/src/scaling_harness.rs
+++ b/crates/rue-compiler/src/scaling_harness.rs
@@ -111,7 +111,7 @@ fn unrelated_module_snapshot_with_main_and_suffix(
 // Measurement
 // ---------------------------------------------------------------------------
 
-/// Structural counters read from one cold `rooted_semantic` compile. Every
+/// Structural counters read from one cold `rooted_cfg` compile. Every
 /// field is a work counter; not one is a clock or an allocation total.
 #[derive(Debug, Clone, Copy)]
 struct Measure {
@@ -145,12 +145,12 @@ impl Measure {
         let mut session = CompilerSession::new();
         session.update(&corpus.snapshot()).into_result().unwrap();
         let output = session
-            .rooted_semantic(&CompileOptions::default())
+            .rooted_cfg(&CompileOptions::default())
             .expect("synthetic corpus compiles");
         Self::from_work_and_provider(
             &output.work(),
             crate::unstable::provider_observation_metrics(&session),
-            output.rir_owner().work(),
+            canonical_rir_work(&mut session),
         )
     }
 
@@ -158,12 +158,12 @@ impl Measure {
         let mut session = CompilerSession::new();
         session.update(&snapshot).into_result().unwrap();
         let output = session
-            .rooted_semantic(&CompileOptions::default())
+            .rooted_cfg(&CompileOptions::default())
             .expect("synthetic snapshot compiles");
         Self::from_work_and_provider(
             &output.work(),
             crate::unstable::provider_observation_metrics(&session),
-            output.rir_owner().work(),
+            canonical_rir_work(&mut session),
         )
     }
 
@@ -196,6 +196,13 @@ impl Measure {
             rir_instructions_appended: rir.instructions_appended,
         }
     }
+}
+
+fn canonical_rir_work(session: &mut CompilerSession) -> crate::CanonicalRirWork {
+    session
+        .canonical_rir()
+        .expect("successful rooted CFG has canonical RIR")
+        .work()
 }
 
 fn assert_exact_zero_slope(label: &str, baseline: usize, grown: usize) {
@@ -331,7 +338,7 @@ fn render_diagnostics(errors: &CompileErrors) -> String {
 
 fn assert_successful_output_body_presence(
     label: &str,
-    output: &RootedSemanticOutput,
+    output: &RootedCfgOutput,
     states: &BTreeMap<String, Option<crate::BodyTransaction>>,
 ) {
     for function in output.functions() {
@@ -367,7 +374,7 @@ fn body_query_identity(instance: &crate::FunctionInstanceKey, options: &CompileO
 
 fn reachable_successful_body_identities(
     label: &str,
-    output: &RootedSemanticOutput,
+    output: &RootedCfgOutput,
     states: &BTreeMap<String, Option<crate::BodyTransaction>>,
     options: &CompileOptions,
 ) -> BTreeSet<String> {
@@ -406,10 +413,8 @@ fn assert_reachable_body_key_set_parity(
 }
 
 /// The one shared warm-vs-fresh oracle every edit row uses. Built on the exact
-/// semantic-parity machinery (`RootedSemanticOutput::unstable_parity_snapshot`
-/// — the same owned projection the in-tree cold-vs-reused differential compares),
-/// it asserts full parity between a warm (incremental) rev2 compile and a fresh
-/// rev2 compile:
+/// canonical rooted CFG values, it asserts full parity between a warm
+/// (incremental) rev2 compile and a fresh rev2 compile:
 ///
 /// * success vs failure agreement;
 /// * on success, the full parity snapshot: functions, strings, type pool, bound
@@ -422,8 +427,8 @@ fn assert_warm_fresh_parity(
     fresh_session: &mut CompilerSession,
     source: &SourceSnapshot,
     options: &CompileOptions,
-    warm: &Result<Arc<RootedSemanticOutput>, CompileErrors>,
-    fresh: &Result<Arc<RootedSemanticOutput>, CompileErrors>,
+    warm: &Result<RootedCfgOutput, CompileErrors>,
+    fresh: &Result<RootedCfgOutput, CompileErrors>,
 ) {
     // The body-transaction family is the canonical production cache. Its
     // test-only snapshot includes stale keys as well as current terminals, so
@@ -431,7 +436,7 @@ fn assert_warm_fresh_parity(
     // each output and its transaction edges.
     let warm_bodies = warm_session.retained_body_identity_states_for_test(options);
     let fresh_bodies = fresh_session.retained_body_identity_states_for_test(options);
-    // A failed rooted semantic query may stop before an unchanged helper is
+    // A failed rooted body/CFG query may stop before an unchanged helper is
     // requested. Such a helper can remain observable from the warm cache while
     // having no fresh-side retained key; that is cache reachability, not a
     match (warm, fresh) {
@@ -484,11 +489,7 @@ fn assert_warm_fresh_parity(
                     );
                 }
             }
-            assert_eq!(
-                warm.unstable_parity_snapshot(),
-                fresh.unstable_parity_snapshot(),
-                "{label}: warm/fresh semantic parity snapshot diverged"
-            );
+            crate::test_support::assert_rooted_cfg_value_parity(label, warm, fresh);
 
             // Keep the public output check as a consistency assertion, not as
             // the identity enumeration source. Every emitted function must
@@ -549,7 +550,7 @@ fn assert_warm_fresh_parity(
                 format!("{:?}", fresh_session.latest_diagnostics()),
                 "{label}: ordered failure diagnostic snapshots diverged"
             );
-            // A failed rooted semantic query may stop before unchanged helper
+            // A failed rooted body/CFG query may stop before unchanged helper
             // bodies are requested. Compare deterministic failures demanded
             // by both sides, preserving early-stop behavior for helpers that
             // exist only in one retained family.
@@ -961,15 +962,15 @@ impl EditScenario {
 
         let mut warm = CompilerSession::new();
         warm.update(&self.rev1.snapshot()).into_result().unwrap();
-        warm.rooted_semantic(&options).ok(); // rev1 is not oracled; only rev2.
+        warm.rooted_cfg(&options).ok(); // rev1 is not oracled; only rev2.
         let rev1_origins = warm.retained_body_transaction_origins_for_test(body_names);
         warm.update(&self.rev2.snapshot()).into_result().unwrap();
-        let warm_rev2 = warm.rooted_semantic(&options);
+        let warm_rev2 = warm.rooted_cfg(&options);
         let rev2_origins = warm.retained_body_transaction_origins_for_test(body_names);
 
         let mut fresh = CompilerSession::new();
         fresh.update(&self.rev2.snapshot()).into_result().unwrap();
-        let fresh_rev2 = fresh.rooted_semantic(&options);
+        let fresh_rev2 = fresh.rooted_cfg(&options);
 
         let rev2_source = self.rev2.snapshot();
         assert_warm_fresh_parity(
@@ -987,7 +988,7 @@ impl EditScenario {
             Measure::from_work_and_provider(
                 &output.work(),
                 crate::unstable::provider_observation_metrics(&warm),
-                output.rir_owner().work(),
+                canonical_rir_work(&mut warm),
             )
         });
         (
@@ -1044,17 +1045,17 @@ fn run_source_edit(
 
     let mut warm = CompilerSession::new();
     warm.update(&rev1).into_result().unwrap();
-    warm.rooted_semantic(&options).ok();
+    warm.rooted_cfg(&options).ok();
     let before = warm.retained_body_transaction_origins_for_test(&body_names);
     let before_states = warm.retained_body_identity_states_for_test(&options);
     warm.update(&rev2).into_result().unwrap();
-    let warm_result = warm.rooted_semantic(&options);
+    let warm_result = warm.rooted_cfg(&options);
     let after = warm.retained_body_transaction_origins_for_test(&body_names);
     let warm_states = warm.retained_body_identity_states_for_test(&options);
 
     let mut fresh = CompilerSession::new();
     fresh.update(&rev2).into_result().unwrap();
-    let fresh_result = fresh.rooted_semantic(&options);
+    let fresh_result = fresh.rooted_cfg(&options);
     let fresh_states = fresh.retained_body_identity_states_for_test(&options);
     assert_warm_fresh_parity(
         label,
@@ -1363,11 +1364,11 @@ fn invalidation_single_body_edit_declaration_work_does_not_rerun() {
 
     let mut warm = CompilerSession::new();
     warm.update(&rev1_snap).into_result().unwrap();
-    warm.rooted_semantic(&options).unwrap();
+    warm.rooted_cfg(&options).unwrap();
     let body_names = corpus_body_names(40);
     let rev1_origins = warm.retained_body_transaction_origins_for_test(&body_names);
     warm.update(&rev2_snap).into_result().unwrap();
-    let warm_rev2 = warm.rooted_semantic(&options);
+    let warm_rev2 = warm.rooted_cfg(&options);
     let rev2_origins = warm.retained_body_transaction_origins_for_test(&body_names);
     let recomputed = changed_body_origins(&rev1_origins, &rev2_origins);
     let warm_measure = warm_rev2
@@ -1376,7 +1377,7 @@ fn invalidation_single_body_edit_declaration_work_does_not_rerun() {
             Measure::from_work_and_provider(
                 &output.work(),
                 crate::unstable::provider_observation_metrics(&warm),
-                output.rir_owner().work(),
+                canonical_rir_work(&mut warm),
             )
         })
         .expect("single-body-edit warm rev2 compiles");
@@ -1384,14 +1385,14 @@ fn invalidation_single_body_edit_declaration_work_does_not_rerun() {
     // Fresh rev2 compile for the shared parity oracle and the cold-cost floor.
     let mut fresh = CompilerSession::new();
     fresh.update(&rev2_snap).into_result().unwrap();
-    let fresh_rev2 = fresh.rooted_semantic(&options);
+    let fresh_rev2 = fresh.rooted_cfg(&options);
     let fresh_measure = fresh_rev2
         .as_ref()
         .map(|output| {
             Measure::from_work_and_provider(
                 &output.work(),
                 crate::unstable::provider_observation_metrics(&fresh),
-                output.rir_owner().work(),
+                canonical_rir_work(&mut fresh),
             )
         })
         .expect("single-body-edit fresh rev2 compiles");
@@ -1459,11 +1460,11 @@ fn main() -> i32 { left() + right() + control() }
 
     let mut warm = CompilerSession::new();
     warm.update(&rev1_snap).into_result().unwrap();
-    warm.rooted_semantic(&options).unwrap();
+    warm.rooted_cfg(&options).unwrap();
     let body_names = ["left", "right", "control", "main"].map(str::to_owned);
     let rev1_origins = warm.retained_body_transaction_origins_for_test(&body_names);
     warm.update(&rev2_snap).into_result().unwrap();
-    let warm_rev2 = warm.rooted_semantic(&options);
+    let warm_rev2 = warm.rooted_cfg(&options);
     let rev2_origins = warm.retained_body_transaction_origins_for_test(&body_names);
     let recomputed = changed_body_origins(&rev1_origins, &rev2_origins);
     let warm_measure = warm_rev2
@@ -1472,21 +1473,21 @@ fn main() -> i32 { left() + right() + control() }
             Measure::from_work_and_provider(
                 &output.work(),
                 crate::unstable::provider_observation_metrics(&warm),
-                output.rir_owner().work(),
+                canonical_rir_work(&mut warm),
             )
         })
         .expect("declaration-value-edit warm rev2 compiles");
 
     let mut fresh = CompilerSession::new();
     fresh.update(&rev2_snap).into_result().unwrap();
-    let fresh_rev2 = fresh.rooted_semantic(&options);
+    let fresh_rev2 = fresh.rooted_cfg(&options);
     let fresh_measure = fresh_rev2
         .as_ref()
         .map(|output| {
             Measure::from_work_and_provider(
                 &output.work(),
                 crate::unstable::provider_observation_metrics(&fresh),
-                output.rir_owner().work(),
+                canonical_rir_work(&mut fresh),
             )
         })
         .expect("declaration-value-edit fresh rev2 compiles");
@@ -1545,7 +1546,7 @@ fn invalidation_negative_lookup_becoming_positive_invalidates_consumers() {
 
     let mut warm = CompilerSession::new();
     warm.update(&rev1_snap).into_result().unwrap();
-    let rev1_result = warm.rooted_semantic(&options);
+    let rev1_result = warm.rooted_cfg(&options);
     assert!(
         rev1_result.is_err(),
         "calling an undefined function must fail the negative-lookup revision"
@@ -1554,7 +1555,7 @@ fn invalidation_negative_lookup_becoming_positive_invalidates_consumers() {
     let rev1_origins = warm.retained_body_transaction_origins_for_test(&body_names);
 
     warm.update(&rev2_snap).into_result().unwrap();
-    let warm_rev2 = warm.rooted_semantic(&options);
+    let warm_rev2 = warm.rooted_cfg(&options);
     let rev2_origins = warm.retained_body_transaction_origins_for_test(&body_names);
     let recomputed = changed_body_origins(&rev1_origins, &rev2_origins);
     let warm_measure = warm_rev2
@@ -1563,21 +1564,21 @@ fn invalidation_negative_lookup_becoming_positive_invalidates_consumers() {
             Measure::from_work_and_provider(
                 &output.work(),
                 crate::unstable::provider_observation_metrics(&warm),
-                output.rir_owner().work(),
+                canonical_rir_work(&mut warm),
             )
         })
         .expect("defining the previously-missing function must make the consumer compile");
 
     let mut fresh = CompilerSession::new();
     fresh.update(&rev2_snap).into_result().unwrap();
-    let fresh_rev2 = fresh.rooted_semantic(&options);
+    let fresh_rev2 = fresh.rooted_cfg(&options);
     let fresh_measure = fresh_rev2
         .as_ref()
         .map(|output| {
             Measure::from_work_and_provider(
                 &output.work(),
                 crate::unstable::provider_observation_metrics(&fresh),
-                output.rir_owner().work(),
+                canonical_rir_work(&mut fresh),
             )
         })
         .expect("fresh rev2 compiles");
@@ -1659,7 +1660,7 @@ fn counter_lifecycle_covers_cold_unrelated_edit_changed_body_and_unrelated_delet
         .into_result()
         .unwrap();
     let cold = unrelated_session
-        .rooted_semantic(&options)
+        .rooted_cfg(&options)
         .expect("cold lifecycle fixture compiles");
     let cold_body = cold.work().body_analysis;
     assert_eq!(cold_body.body_analyses_reused, 0);
@@ -1674,7 +1675,7 @@ fn counter_lifecycle_covers_cold_unrelated_edit_changed_body_and_unrelated_delet
         .into_result()
         .unwrap();
     let unrelated_output = unrelated_session
-        .rooted_semantic(&options)
+        .rooted_cfg(&options)
         .expect("unrelated-edit lifecycle fixture compiles");
     let unrelated_body = unrelated_output.work().body_analysis;
     assert_eq!(unrelated_body.body_analyses_computed, 0);
@@ -1700,12 +1701,12 @@ fn counter_lifecycle_covers_cold_unrelated_edit_changed_body_and_unrelated_delet
         .into_result()
         .unwrap();
     let changed_cold = changed_session
-        .rooted_semantic(&options)
+        .rooted_cfg(&options)
         .expect("changed-body cold fixture compiles");
     let changed_cold_body = changed_cold.work().body_analysis;
     changed_session.update(&changed).into_result().unwrap();
     let changed_output = changed_session
-        .rooted_semantic(&options)
+        .rooted_cfg(&options)
         .expect("changed-body lifecycle fixture compiles");
     let changed_body = changed_output.work().body_analysis;
     assert!(changed_body.body_analyses_computed > 0);
@@ -1732,7 +1733,7 @@ fn counter_lifecycle_covers_cold_unrelated_edit_changed_body_and_unrelated_delet
             "\n",
         ))
         .into_result()
-        .and_then(|_| unrelated_session.rooted_semantic(&options))
+        .and_then(|_| unrelated_session.rooted_cfg(&options))
         .expect("deletion lifecycle fixture compiles");
     let deleted_body = deleted_output.work().body_analysis;
     assert_eq!(deleted_body.body_analyses_computed, 0);
@@ -1750,7 +1751,7 @@ fn correctness_oracle_rejects_missing_successful_body_transaction() {
     let source = SourceSnapshot::single("main.rue", "fn main() -> i32 { 0 }\n").unwrap();
     let mut session = CompilerSession::new();
     session.update(&source).into_result().unwrap();
-    let output = session.rooted_semantic(&options).unwrap();
+    let output = session.rooted_cfg(&options).unwrap();
     let mut states = session.retained_body_identity_states_for_test(&options);
     let main_identity = states
         .keys()
@@ -1768,7 +1769,7 @@ fn correctness_oracle_rejects_asymmetric_successful_body_key_sets() {
     let source = SourceSnapshot::single("main.rue", "fn main() -> i32 { 0 }\n").unwrap();
     let mut session = CompilerSession::new();
     session.update(&source).into_result().unwrap();
-    session.rooted_semantic(&options).unwrap();
+    session.rooted_cfg(&options).unwrap();
     let transaction = session
         .retained_body_identity_states_for_test(&options)
         .into_values()
@@ -1793,7 +1794,7 @@ fn correctness_oracle_rejects_missing_reachable_transaction_on_both_sides() {
     .unwrap();
     let mut session = CompilerSession::new();
     session.update(&source).into_result().unwrap();
-    let output = session.rooted_semantic(&options).unwrap();
+    let output = session.rooted_cfg(&options).unwrap();
     let states = session.retained_body_identity_states_for_test(&options);
     let (root_identity, root_transaction) = states
         .into_iter()
@@ -1977,7 +1978,7 @@ fn correctness_oracle_import_edit_compares_imported_body_and_linked_bytes() {
         warm.retained_body_transaction_origins_for_test(&["value".to_owned(), "main".to_owned()]);
     warm.update(&rev2).into_result().unwrap();
     close_import_source(&mut warm, &rev2, context2, reads2);
-    let warm_result = warm.rooted_semantic(&options);
+    let warm_result = warm.rooted_cfg(&options);
     let after =
         warm.retained_body_transaction_origins_for_test(&["value".to_owned(), "main".to_owned()]);
 
@@ -1985,7 +1986,7 @@ fn correctness_oracle_import_edit_compares_imported_body_and_linked_bytes() {
     fresh.update(&rev2).into_result().unwrap();
     let (_, fresh_context, fresh_reads) = import_source(2, 2);
     close_import_source(&mut fresh, &rev2, fresh_context, fresh_reads);
-    let fresh_result = fresh.rooted_semantic(&options);
+    let fresh_result = fresh.rooted_cfg(&options);
 
     assert_warm_fresh_parity(
         "imported body edit",
@@ -2111,7 +2112,7 @@ fn specialization_breadth_compiles_depth_fails_e1200() {
         .into_result()
         .unwrap();
     let wide_out = wide_session
-        .rooted_semantic(&options)
+        .rooted_cfg(&options)
         .expect("many shallow specializations must compile");
     // Finding 5: assert ALL 64 distinct specializations were analyzed, not merely
     // that at least one was.
@@ -2140,7 +2141,7 @@ fn specialization_breadth_compiles_depth_fails_e1200() {
         .into_result()
         .unwrap();
     let deep_err = deep_session
-        .rooted_semantic(&options)
+        .rooted_cfg(&options)
         .expect_err("an unbounded specialization chain must fail deterministically");
     assert!(
         deep_err.iter().any(

--- a/crates/rue-compiler/src/session.rs
+++ b/crates/rue-compiler/src/session.rs
@@ -872,6 +872,42 @@ impl RootedCfgOutput {
     pub fn metrics(&self) -> crate::unstable::SemanticMetrics {
         crate::unstable::SemanticMetrics::from_work(self.work)
     }
+
+    #[cfg(test)]
+    pub(crate) fn work(&self) -> &crate::CanonicalSemanticWork {
+        &self.work
+    }
+
+    #[cfg(test)]
+    pub(crate) fn declarations(&self) -> &[crate::DurableDeclarationSemantic] {
+        &self.graph.declarations
+    }
+
+    #[cfg(test)]
+    pub(crate) fn anonymous_nominals(
+        &self,
+    ) -> &[crate::durable_semantics::DurableAnonymousNominal] {
+        &self.graph.anonymous_nominals
+    }
+
+    #[cfg(test)]
+    pub(crate) fn type_pools(
+        &self,
+    ) -> impl ExactSizeIterator<Item = &rue_air::FrozenTypeInternPool> {
+        self.cfgs.iter().map(|function| &function.record.type_pool)
+    }
+
+    #[cfg(test)]
+    pub(crate) fn type_pool_stats(&self) -> Vec<rue_air::TypeInternPoolStats> {
+        self.type_pools().map(|pool| pool.stats()).collect()
+    }
+
+    #[cfg(test)]
+    pub(crate) fn string_domains(&self) -> impl ExactSizeIterator<Item = &[String]> {
+        self.cfgs
+            .iter()
+            .map(|function| function.record.strings.as_ref())
+    }
 }
 
 impl RootedCfgUnit {
@@ -905,89 +941,6 @@ impl RootedCfgUnit {
 
     pub fn strings(&self) -> &Arc<[String]> {
         &self.record.strings
-    }
-}
-
-/// Retainable semantic presentation projected directly from the canonical
-/// rooted CFG result. This owner contains no semantic machinery: every
-/// function and its local domains are the exact artifacts used by codegen.
-#[cfg(test)]
-#[derive(Debug)]
-pub(crate) struct RootedSemanticOutput {
-    pub(crate) input: CodegenInputDescriptor,
-    pub(crate) cfgs: Vec<RootedCfgUnit>,
-    pub(crate) warnings: Vec<CompileWarning>,
-    pub(crate) work: crate::CanonicalSemanticWork,
-    pub(crate) rir: Arc<crate::CanonicalRirOutput>,
-    pub(crate) declarations: Arc<[crate::DurableDeclarationSemantic]>,
-    pub(crate) anonymous_nominals: Arc<[crate::durable_semantics::DurableAnonymousNominal]>,
-    pub(crate) strings: Vec<String>,
-    pub(crate) struct_count: usize,
-    pub(crate) enum_count: usize,
-}
-
-#[cfg(test)]
-impl RootedSemanticOutput {
-    #[cfg(test)]
-    pub(crate) fn input(&self) -> &CodegenInputDescriptor {
-        &self.input
-    }
-
-    #[cfg(test)]
-    pub(crate) fn functions(&self) -> &[RootedCfgUnit] {
-        &self.cfgs
-    }
-
-    #[cfg(test)]
-    pub(crate) fn strings(&self) -> &[String] {
-        &self.strings
-    }
-
-    #[cfg(test)]
-    pub(crate) fn declarations(&self) -> &[crate::DurableDeclarationSemantic] {
-        &self.declarations
-    }
-
-    #[cfg(test)]
-    pub(crate) fn anonymous_nominals(
-        &self,
-    ) -> &[crate::durable_semantics::DurableAnonymousNominal] {
-        &self.anonymous_nominals
-    }
-
-    #[cfg(test)]
-    pub(crate) fn work(&self) -> &crate::CanonicalSemanticWork {
-        &self.work
-    }
-
-    #[cfg(test)]
-    pub(crate) fn warnings(&self) -> &[CompileWarning] {
-        &self.warnings
-    }
-
-    #[cfg(test)]
-    pub(crate) fn unstable_parity_snapshot(&self) -> String {
-        format!(
-            "{:?}|{:?}|{:?}|{}|{}",
-            self.cfgs, self.warnings, self.strings, self.struct_count, self.enum_count
-        )
-    }
-
-    #[cfg(test)]
-    pub(crate) fn type_pools(
-        &self,
-    ) -> impl ExactSizeIterator<Item = &rue_air::FrozenTypeInternPool> {
-        self.cfgs.iter().map(|function| &function.record.type_pool)
-    }
-
-    #[cfg(test)]
-    pub(crate) fn type_pool_stats(&self) -> Vec<rue_air::TypeInternPoolStats> {
-        self.type_pools().map(|pool| pool.stats()).collect()
-    }
-
-    #[cfg(test)]
-    pub(crate) fn rir_owner(&self) -> &Arc<crate::CanonicalRirOutput> {
-        &self.rir
     }
 }
 
@@ -1102,7 +1055,7 @@ impl TrustedSuccessorDelta {
 ///
 /// A close alone leaves the state NON-AUTHORIZING (`attached_demands` is `None`):
 /// no token can be minted and no successor authorized. Authority is granted
-/// only when a rooted semantic park atomically attaches that park's exact sorted
+/// only when a rooted body-closure park atomically attaches that park's exact sorted
 /// missing-demand set to this same state. Demand authority therefore lives here,
 /// bound to one closed revision and one park — never in an ambient session field
 /// a later, non-parking close could inherit.
@@ -2842,7 +2795,7 @@ impl CompilerSession {
         //
         // The closed state is deliberately NON-AUTHORIZING here (`attached_demands`
         // is `None`): a close by itself mints no token and authorizes no successor.
-        // Only a subsequent rooted semantic park attaches its exact missing-demand
+        // Only a subsequent rooted body-closure park attaches its exact missing-demand
         // set to this same state, so a later close whose attempt never parks can
         // never inherit an earlier park's authority.
         self.continuation = self
@@ -2865,7 +2818,7 @@ impl CompilerSession {
 
     /// Mint the trusted-toolchain continuation token for the current successful
     /// import-discovery close, if one is outstanding AND authorizing (RUE-1112).
-    /// A closed state becomes authorizing only once a rooted semantic park
+    /// A closed state becomes authorizing only once a rooted body-closure park
     /// has attached its exact missing-demand set; a close whose attempt is ready
     /// (or never parked) mints no token. The token is opaque and single-use; the
     /// host hands it back to [`Self::publish_trusted_toolchain_successor`].
@@ -2997,7 +2950,7 @@ impl CompilerSession {
         // earlier park's demands.
         let Some(attached_demands) = state.attached_demands.as_ref() else {
             return Err(reject(
-                "the closed continuation is not authorizing; no rooted semantic park has attached a demanded-module set",
+                "the closed continuation is not authorizing; no rooted body-closure park has attached a demanded-module set",
             ));
         };
 
@@ -4444,113 +4397,6 @@ impl CompilerSession {
         result
     }
 
-    #[cfg(test)]
-    fn rooted_semantic_for_test(
-        &mut self,
-        options: &CompileOptions,
-    ) -> Result<Arc<RootedSemanticOutput>, CompileErrors> {
-        let rooted = self.rooted_cfg(options)?;
-        self.semantic_projection_for_test(options, rooted)
-    }
-
-    #[cfg(test)]
-    fn semantic_projection_for_test(
-        &mut self,
-        options: &CompileOptions,
-        rooted: RootedCfgOutput,
-    ) -> Result<Arc<RootedSemanticOutput>, CompileErrors> {
-        let source = self
-            .published_snapshot
-            .clone()
-            .ok_or_else(no_published_program)?;
-        let input = CodegenInputDescriptor {
-            semantic: SemanticInputDescriptor::new(
-                &source,
-                options.target,
-                &options.preview_features,
-            ),
-            opt_level: options.opt_level.into(),
-        };
-        let rir = self.canonical_rir()?;
-        let mut strings = Vec::new();
-        let mut seen_strings = std::collections::HashSet::new();
-        for unit in &rooted.cfgs {
-            for value in unit.record.strings.iter() {
-                if seen_strings.insert(value.clone()) {
-                    strings.push(value.clone());
-                }
-            }
-        }
-        let struct_count = rooted
-            .graph
-            .declarations
-            .iter()
-            .filter(|declaration| {
-                matches!(
-                    &declaration.payload,
-                    crate::durable_semantics::DurableDeclarationPayload::Struct { .. }
-                )
-            })
-            .count()
-            + rooted
-                .graph
-                .anonymous_nominals
-                .iter()
-                .filter(|nominal| {
-                    matches!(
-                        &nominal.shape,
-                        crate::durable_semantics::DurableAnonymousNominalShape::Struct { .. }
-                    )
-                })
-                .count();
-        let enum_count = rooted
-            .graph
-            .declarations
-            .iter()
-            .filter(|declaration| {
-                matches!(
-                    &declaration.payload,
-                    crate::durable_semantics::DurableDeclarationPayload::Enum { .. }
-                )
-            })
-            .count()
-            + rooted
-                .graph
-                .anonymous_nominals
-                .iter()
-                .filter(|nominal| {
-                    matches!(
-                        &nominal.shape,
-                        crate::durable_semantics::DurableAnonymousNominalShape::Enum { .. }
-                    )
-                })
-                .count();
-        #[cfg(test)]
-        let declarations = rooted.graph.declarations.clone();
-        #[cfg(test)]
-        let anonymous_nominals = rooted.graph.anonymous_nominals.clone();
-        Ok(Arc::new(RootedSemanticOutput {
-            input,
-            cfgs: rooted.cfgs,
-            warnings: rooted.warnings,
-            work: rooted.work,
-            rir,
-            declarations,
-            anonymous_nominals,
-            strings,
-            struct_count,
-            enum_count,
-        }))
-    }
-
-    #[cfg(test)]
-    pub(crate) fn rooted_semantic(
-        &mut self,
-        options: &CompileOptions,
-    ) -> Result<Arc<RootedSemanticOutput>, CompileErrors> {
-        self.rooted_semantic_for_test(options)
-    }
-
     fn rooted_body_graph_with_cancellation(
         &mut self,
         options: &CompileOptions,
@@ -5786,7 +5632,7 @@ impl CompilerSession {
     #[cfg(test)]
     pub(crate) fn codegen_products(
         &mut self,
-        semantic: &RootedSemanticOutput,
+        semantic: &RootedCfgOutput,
         options: &crate::CompileOptions,
         request: rue_codegen::BackendArtifactRequest,
     ) -> Result<Vec<crate::backend::FunctionBackendProduct>, crate::CompileErrors> {
@@ -5805,7 +5651,7 @@ impl CompilerSession {
     #[cfg(test)]
     pub(crate) fn codegen_units(
         &mut self,
-        semantic: &RootedSemanticOutput,
+        semantic: &RootedCfgOutput,
         options: &crate::CompileOptions,
         request: rue_codegen::BackendArtifactRequest,
     ) -> Result<Vec<crate::codegen_query::CollectedCodegenUnit>, crate::CompileErrors> {
@@ -7145,7 +6991,7 @@ mod tests {
         let options = CompileOptions::default();
         let mut session = CompilerSession::new();
         session.update(&source).into_result().unwrap();
-        session.rooted_semantic(&options).unwrap();
+        session.rooted_cfg(&options).unwrap();
 
         let cold = session.unstable_metrics().retention();
         assert!(cold.retained_query_records > 0);
@@ -7154,7 +7000,7 @@ mod tests {
         assert!(cold.retained_bytes <= cold.retained_byte_budget);
         assert!(cold.dependency_pins <= cold.dependency_pin_budget);
 
-        session.rooted_semantic(&options).unwrap();
+        session.rooted_cfg(&options).unwrap();
         let warm = session.unstable_metrics().retention();
         assert_eq!(warm.retained_query_records, cold.retained_query_records);
         assert_eq!(warm.retained_bytes, cold.retained_bytes);
@@ -7169,7 +7015,7 @@ mod tests {
         let options = CompileOptions::default();
         let mut session = CompilerSession::new();
         session.update(&source).into_result().unwrap();
-        session.rooted_semantic(&options).unwrap();
+        session.rooted_cfg(&options).unwrap();
         let merged = session.merge().unwrap();
         let revision = session
             .queries
@@ -7320,7 +7166,7 @@ mod tests {
     }
 
     /// Drive `root_source` to a canonical import-discovery close, then run the
-    /// rooted semantic attempt so its park atomically attaches the demanded-missing
+    /// rooted body-closure attempt so its park atomically attaches the demanded-missing
     /// set to the closed continuation. Returns the session (now holding an
     /// AUTHORIZING continuation), its token, the empty closure-witness frontier, the
     /// predecessor snapshot, its accepted reads, and the assembler ready to add
@@ -7601,7 +7447,7 @@ mod tests {
 
     #[test]
     fn trusted_successor_ready_close_is_non_authorizing() {
-        // A close whose rooted semantic attempt is READY (no fallible intrinsic,
+        // A close whose rooted body-closure attempt is READY (no fallible intrinsic,
         // no park) attaches no demanded set, so the closed continuation mints no
         // token. Demand authority lives only in an attached park, so a ready close
         // can never inherit an earlier park's demand set and admit an uninvited
@@ -8157,7 +8003,7 @@ mod tests {
 
     #[test]
     fn stable_no_filesystem_boundary_classifies_unsatisfied_toolchain_input_not_ice() {
-        // RUE-1112 C3: the stable no-filesystem `rooted_semantic` entry cannot
+        // RUE-1112 C3: the stable no-filesystem `rooted_cfg` entry cannot
         // acquire, so an unsatisfied trusted-toolchain demand for otherwise-valid
         // source is a deterministic CONTRACT failure, never an ICE (E9000).
         let source = snapshot(
@@ -8171,9 +8017,7 @@ mod tests {
         );
         let mut session = CompilerSession::new();
         session.update(&source).into_result().unwrap();
-        let errors = session
-            .rooted_semantic(&CompileOptions::default())
-            .unwrap_err();
+        let errors = session.rooted_cfg(&CompileOptions::default()).unwrap_err();
         let error = errors.first().expect("unsatisfied toolchain input error");
         assert!(
             matches!(
@@ -8204,7 +8048,7 @@ mod tests {
         let mut session = CompilerSession::new();
         session.update(&source).into_result().unwrap();
         session
-            .rooted_semantic(&CompileOptions::default())
+            .rooted_cfg(&CompileOptions::default())
             .expect("the program analyzes");
         let metrics = crate::unstable::provider_observation_metrics(&session);
         assert_eq!(metrics.name_lookups, 3);
@@ -8247,7 +8091,7 @@ mod tests {
         let mut session = CompilerSession::new();
         session.update(&source).into_result().unwrap();
         session
-            .rooted_semantic(&CompileOptions::default())
+            .rooted_cfg(&CompileOptions::default())
             .expect("the program analyzes");
 
         let metrics = crate::unstable::provider_observation_metrics(&session);
@@ -8274,7 +8118,7 @@ mod tests {
         let mut session = CompilerSession::new();
         session.update(&source).into_result().unwrap();
         session
-            .rooted_semantic(&CompileOptions::default())
+            .rooted_cfg(&CompileOptions::default())
             .expect("recursive named imports use the in-progress cycle break");
     }
 
@@ -8295,7 +8139,7 @@ mod tests {
         let mut session = CompilerSession::new();
         session.update(&source).into_result().unwrap();
         session
-            .rooted_semantic(&CompileOptions::default())
+            .rooted_cfg(&CompileOptions::default())
             .expect("the program analyzes");
 
         let metrics = crate::unstable::lookup_pressure_metrics(&session);
@@ -8348,14 +8192,14 @@ mod tests {
         let mut session = CompilerSession::new();
         session.update(&first).into_result().unwrap();
         session
-            .rooted_semantic(&CompileOptions::default())
+            .rooted_cfg(&CompileOptions::default())
             .expect("initial closure analyzes");
         let initial = crate::unstable::lookup_pressure_metrics(&session);
         assert_eq!(initial.published_roots, 2, "{initial:?}");
 
         session.update(&unreachable).into_result().unwrap();
         session
-            .rooted_semantic(&CompileOptions::default())
+            .rooted_cfg(&CompileOptions::default())
             .expect("unreachable successor analyzes");
         let after_unreachable = crate::unstable::lookup_pressure_metrics(&session);
         assert_eq!(
@@ -8365,7 +8209,7 @@ mod tests {
 
         session.update(&deleted).into_result().unwrap();
         session
-            .rooted_semantic(&CompileOptions::default())
+            .rooted_cfg(&CompileOptions::default())
             .expect("deleted successor analyzes");
         let after_deleted = crate::unstable::lookup_pressure_metrics(&session);
         assert_eq!(
@@ -8391,9 +8235,7 @@ mod tests {
             let source = snapshot(&[(1, "/p/main.rue", "main.rue", source_text)], 1);
             let mut session = CompilerSession::new();
             session.update(&source).into_result().unwrap();
-            let errors = session
-                .rooted_semantic(&CompileOptions::default())
-                .unwrap_err();
+            let errors = session.rooted_cfg(&CompileOptions::default()).unwrap_err();
             let error = errors.first().expect("duplicate parameter diagnostic");
             assert!(
                 error.to_string().contains("duplicate parameter name 'a'"),
@@ -8414,10 +8256,10 @@ mod tests {
         session.update(&source).into_result().unwrap();
 
         let first = session
-            .rooted_semantic(&CompileOptions::default())
+            .rooted_cfg(&CompileOptions::default())
             .expect_err("empty anonymous struct is rejected");
         let second = session
-            .rooted_semantic(&CompileOptions::default())
+            .rooted_cfg(&CompileOptions::default())
             .expect_err("the retained producer failure remains deterministic");
 
         assert_eq!(first, second);
@@ -8454,9 +8296,7 @@ mod tests {
             let source = snapshot(&[(1, "/p/main.rue", "main.rue", source_text)], 1);
             let mut session = CompilerSession::new();
             session.update(&source).into_result().unwrap();
-            let errors = session
-                .rooted_semantic(&CompileOptions::default())
-                .unwrap_err();
+            let errors = session.rooted_cfg(&CompileOptions::default()).unwrap_err();
             let error = errors.first().expect("destructor validity diagnostic");
             assert!(
                 error.to_string().contains(message),
@@ -8530,7 +8370,7 @@ mod tests {
         };
         let mut session = CompilerSession::new();
         session.update(&first).into_result().unwrap();
-        session.rooted_semantic(&options).unwrap();
+        session.rooted_cfg(&options).unwrap();
         let consume_key = body_query_key(&mut session, &options, "consume");
         let consume_transaction = retained_body_transaction(&session, &consume_key).2;
         assert!(
@@ -8552,12 +8392,12 @@ mod tests {
             "{dependency_nodes:?}"
         );
         session.update(&second).into_result().unwrap();
-        let warm = session.rooted_semantic(&options).unwrap();
+        let warm = session.rooted_cfg(&options).unwrap();
         assert_eq!(warm.work().cfg.cfg_reuses, 1);
         assert_eq!(warm.work().cfg.cfg_builds_attempted, 2);
         let mut fresh = CompilerSession::new();
         fresh.update(&second).into_result().unwrap();
-        let fresh = fresh.rooted_semantic(&options).unwrap();
+        let fresh = fresh.rooted_cfg(&options).unwrap();
         assert_eq!(
             format!("{:?}", warm.functions()),
             format!("{:?}", fresh.functions())
@@ -8590,14 +8430,14 @@ mod tests {
         };
         let mut session = CompilerSession::new();
         session.update(&first).into_result().unwrap();
-        session.rooted_semantic(&options).unwrap();
+        session.rooted_cfg(&options).unwrap();
         session.update(&second).into_result().unwrap();
-        let warm = session.rooted_semantic(&options).unwrap();
+        let warm = session.rooted_cfg(&options).unwrap();
         assert_eq!(warm.work().cfg.cfg_reuses, 1);
         assert_eq!(warm.work().cfg.cfg_builds_attempted, 2);
         let mut fresh = CompilerSession::new();
         fresh.update(&second).into_result().unwrap();
-        let fresh = fresh.rooted_semantic(&options).unwrap();
+        let fresh = fresh.rooted_cfg(&options).unwrap();
         assert_eq!(
             format!("{:?}", warm.functions()),
             format!("{:?}", fresh.functions())
@@ -8635,7 +8475,7 @@ mod tests {
         };
         let mut session = CompilerSession::new();
         session.update(&first).into_result().unwrap();
-        let cold = session.rooted_semantic(&options).unwrap();
+        let cold = session.rooted_cfg(&options).unwrap();
         assert_eq!(cold.work().cfg.cfg_builds_attempted, 3);
         assert_eq!(cold.work().cfg.optimization_attempts, 3);
         let cold_atoms = cold
@@ -8664,7 +8504,7 @@ mod tests {
             }
         }
         session.update(&second).into_result().unwrap();
-        let warm = session.rooted_semantic(&options).unwrap();
+        let warm = session.rooted_cfg(&options).unwrap();
         assert_eq!(
             warm.work().cfg.cfg_reuses,
             2,
@@ -8690,7 +8530,7 @@ mod tests {
 
         let mut fresh = CompilerSession::new();
         fresh.update(&second).into_result().unwrap();
-        let fresh = fresh.rooted_semantic(&options).unwrap();
+        let fresh = fresh.rooted_cfg(&options).unwrap();
         assert_eq!(
             format!("{:?}", warm.functions()),
             format!("{:?}", fresh.functions())
@@ -8710,7 +8550,7 @@ mod tests {
         .unwrap();
         let mut session = CompilerSession::new();
         session.update(&source).into_result().unwrap();
-        let semantic = session.rooted_semantic(&CompileOptions::default()).unwrap();
+        let semantic = session.rooted_cfg(&CompileOptions::default()).unwrap();
         let cfg_work = semantic.work().cfg;
         assert_eq!(cfg_work.materialization_index_builds, 1, "{cfg_work:?}");
         assert_eq!(
@@ -8779,10 +8619,10 @@ mod tests {
         let options = CompileOptions::default();
         let mut session = CompilerSession::new();
         session.update(&first).into_result().unwrap();
-        session.rooted_semantic(&options).unwrap();
+        session.rooted_cfg(&options).unwrap();
 
         session.update(&second).into_result().unwrap();
-        let warm = session.rooted_semantic(&options).unwrap();
+        let warm = session.rooted_cfg(&options).unwrap();
         assert!(
             warm.work().cfg.cfg_builds_attempted > 0,
             "same-layout drop-fact changes must rebuild affected CFGs: {:?}",
@@ -8790,7 +8630,7 @@ mod tests {
         );
         let mut fresh = CompilerSession::new();
         fresh.update(&second).into_result().unwrap();
-        let fresh = fresh.rooted_semantic(&options).unwrap();
+        let fresh = fresh.rooted_cfg(&options).unwrap();
         assert_eq!(
             normalize_session_local_spurs(format!("{:?}", warm.functions())),
             normalize_session_local_spurs(format!("{:?}", fresh.functions()))
@@ -8822,10 +8662,10 @@ mod tests {
         let options = CompileOptions::default();
         let mut session = CompilerSession::new();
         session.update(&first).into_result().unwrap();
-        session.rooted_semantic(&options).unwrap();
+        session.rooted_cfg(&options).unwrap();
 
         session.update(&second).into_result().unwrap();
-        let warm = session.rooted_semantic(&options).unwrap();
+        let warm = session.rooted_cfg(&options).unwrap();
         assert_eq!(
             warm.work().cfg.cfg_builds_attempted,
             0,
@@ -8847,7 +8687,7 @@ mod tests {
         assert_eq!(warm.work().cfg.cfg_import_successes, 0);
         let mut fresh = CompilerSession::new();
         fresh.update(&second).into_result().unwrap();
-        let fresh = fresh.rooted_semantic(&options).unwrap();
+        let fresh = fresh.rooted_cfg(&options).unwrap();
         assert_eq!(
             normalize_session_local_spurs(format!("{:?}", warm.functions())),
             normalize_session_local_spurs(format!("{:?}", fresh.functions()))
@@ -8879,10 +8719,10 @@ mod tests {
         };
         let mut session = CompilerSession::new();
         session.update(&first).into_result().unwrap();
-        session.rooted_semantic(&options).unwrap();
+        session.rooted_cfg(&options).unwrap();
 
         session.update(&second).into_result().unwrap();
-        let warm = session.rooted_semantic(&options).unwrap();
+        let warm = session.rooted_cfg(&options).unwrap();
         assert_eq!(warm.work().cfg.cfg_reuse_candidates, 1);
         assert_eq!(warm.work().cfg.cfg_reuses, 1);
         assert_eq!(warm.work().cfg.cfg_import_attempts, 0);
@@ -8898,7 +8738,7 @@ mod tests {
 
         let mut fresh = CompilerSession::new();
         fresh.update(&second).into_result().unwrap();
-        let fresh = fresh.rooted_semantic(&options).unwrap();
+        let fresh = fresh.rooted_cfg(&options).unwrap();
         assert_eq!(
             normalize_session_local_spurs(format!("{:?}", warm.functions())),
             normalize_session_local_spurs(format!("{:?}", fresh.functions()))
@@ -8921,7 +8761,7 @@ mod tests {
         let first = well_known_option_isolation_snapshot(&first_text);
         let second = well_known_option_isolation_snapshot(&second_text);
         let options = CompileOptions::default();
-        let runtime_symbols = |output: &crate::RootedSemanticOutput| {
+        let runtime_symbols = |output: &crate::RootedCfgOutput| {
             output
                 .functions()
                 .iter()
@@ -8945,9 +8785,9 @@ mod tests {
 
         let mut session = CompilerSession::new();
         publish_with_test_imports(&mut session, &first);
-        session.rooted_semantic(&options).unwrap();
+        session.rooted_cfg(&options).unwrap();
         publish_with_test_imports(&mut session, &second);
-        let warm = session.rooted_semantic(&options).unwrap();
+        let warm = session.rooted_cfg(&options).unwrap();
         assert_eq!(warm.work().cfg.cfg_builds_attempted, 0);
         assert!(warm.work().cfg.cfg_reuses >= 2, "{:?}", warm.work().cfg);
         assert_eq!(
@@ -8962,7 +8802,7 @@ mod tests {
 
         let mut fresh = CompilerSession::new();
         publish_with_test_imports(&mut fresh, &second);
-        let fresh_output = fresh.rooted_semantic(&options).unwrap();
+        let fresh_output = fresh.rooted_cfg(&options).unwrap();
         let fresh_symbols = runtime_symbols(&fresh_output);
         assert_eq!(fresh_symbols.len(), 1);
         assert_eq!(fresh_symbols[0], "parse_i64");
@@ -8981,7 +8821,7 @@ mod tests {
                  fn main() -> i32 {{ probe_print(); 0 }}"
             )
         };
-        let runtime_calls = |output: &crate::RootedSemanticOutput| {
+        let runtime_calls = |output: &crate::RootedCfgOutput| {
             output
                 .functions()
                 .iter()
@@ -9011,11 +8851,11 @@ mod tests {
         let options = CompileOptions::default();
         let mut session = CompilerSession::new();
         session.update(&first).into_result().unwrap();
-        let cold = session.rooted_semantic(&options).unwrap();
+        let cold = session.rooted_cfg(&options).unwrap();
         let cold_calls = runtime_calls(&cold);
         assert_eq!(cold_calls.len(), 1);
         session.update(&second).into_result().unwrap();
-        let warm = session.rooted_semantic(&options).unwrap();
+        let warm = session.rooted_cfg(&options).unwrap();
         assert_eq!(warm.work().cfg.cfg_builds_attempted, 0);
         assert_eq!(warm.work().cfg.cfg_reuses, 2);
         assert_eq!(warm.work().cfg.optimization_attempts, 0);
@@ -9031,7 +8871,7 @@ mod tests {
 
         let mut fresh = CompilerSession::new();
         fresh.update(&second).into_result().unwrap();
-        let fresh_output = fresh.rooted_semantic(&options).unwrap();
+        let fresh_output = fresh.rooted_cfg(&options).unwrap();
         let fresh_calls = runtime_calls(&fresh_output);
         assert_eq!(fresh_calls.len(), 1);
         for (runtime, symbol) in &fresh_calls {
@@ -9067,12 +8907,12 @@ mod tests {
         let mut session = CompilerSession::new();
         session.update(&source).into_result().unwrap();
 
-        let cold = session.rooted_semantic(&o0).unwrap();
+        let cold = session.rooted_cfg(&o0).unwrap();
         assert_eq!(cold.functions().len(), 3);
         assert_eq!(cold.work().cfg.cfg_builds_attempted, 3);
         assert_eq!(cold.work().cfg.optimization_attempts, 3);
 
-        let optimized = session.rooted_semantic(&o1).unwrap();
+        let optimized = session.rooted_cfg(&o1).unwrap();
         assert_eq!(optimized.functions().len(), 3);
         assert_eq!(optimized.work().cfg.cfg_builds_attempted, 0);
         assert_eq!(optimized.work().cfg.cfg_builds_succeeded, 0);
@@ -9111,9 +8951,9 @@ mod tests {
         };
         let mut session = CompilerSession::new();
         session.update(&first).into_result().unwrap();
-        session.rooted_semantic(&options).unwrap();
+        session.rooted_cfg(&options).unwrap();
         session.update(&second).into_result().unwrap();
-        let warm = session.rooted_semantic(&options).unwrap();
+        let warm = session.rooted_cfg(&options).unwrap();
         assert!(warm.functions().iter().any(|function| {
             matches!(
                 function.function,
@@ -9160,17 +9000,17 @@ mod tests {
         };
         let mut session = CompilerSession::new();
         session.update(&first).into_result().unwrap();
-        session.rooted_semantic(&first_options).unwrap();
-        let cross_target = session.rooted_semantic(&other_options).unwrap();
+        session.rooted_cfg(&first_options).unwrap();
+        let cross_target = session.rooted_cfg(&other_options).unwrap();
         assert_eq!(cross_target.work().cfg.cfg_reuses, 0);
         assert_eq!(cross_target.work().cfg.cfg_builds_attempted, 3);
         session.update(&renamed).into_result().unwrap();
-        let changed = session.rooted_semantic(&other_options).unwrap();
+        let changed = session.rooted_cfg(&other_options).unwrap();
         assert_eq!(changed.work().cfg.cfg_reuses, 1);
         assert_eq!(changed.work().cfg.cfg_builds_attempted, 2);
         let mut fresh = CompilerSession::new();
         fresh.update(&renamed).into_result().unwrap();
-        let fresh = fresh.rooted_semantic(&other_options).unwrap();
+        let fresh = fresh.rooted_cfg(&other_options).unwrap();
         assert_eq!(
             format!("{:?}", changed.functions()),
             format!("{:?}", fresh.functions())
@@ -9200,11 +9040,11 @@ mod tests {
         let options = CompileOptions::default();
         let mut session = CompilerSession::new();
         session.update(&first).into_result().unwrap();
-        session.rooted_semantic(&options).unwrap();
+        session.rooted_cfg(&options).unwrap();
         let main = body_query_key(&mut session, &options, "main");
         let (first_stamp, _, first_transaction) = retained_body_transaction(&session, &main);
         session.update(&second).into_result().unwrap();
-        let output = session.rooted_semantic(&options).unwrap();
+        let output = session.rooted_cfg(&options).unwrap();
         let (second_stamp, _, second_transaction) = retained_body_transaction(&session, &main);
         assert_ne!(first_stamp, second_stamp);
         assert!(matches!(
@@ -9218,16 +9058,19 @@ mod tests {
         assert_eq!(output.work().body_analysis.body_analyses_computed, 1);
     }
 
-    fn assert_semantic_artifact_parity(
+    fn assert_rooted_cfg_parity(
         session: &CompilerSession,
-        actual: &RootedSemanticOutput,
-        fresh: &RootedSemanticOutput,
+        actual: &RootedCfgOutput,
+        fresh: &RootedCfgOutput,
     ) {
         assert_eq!(
             normalize_session_local_spurs(format!("{:?}", actual.functions())),
             normalize_session_local_spurs(format!("{:?}", fresh.functions()))
         );
-        assert_eq!(actual.strings(), fresh.strings());
+        assert_eq!(
+            actual.string_domains().collect::<Vec<_>>(),
+            fresh.string_domains().collect::<Vec<_>>()
+        );
         assert_eq!(
             format!("{:?}", actual.warnings()),
             format!("{:?}", fresh.warnings())
@@ -9259,12 +9102,15 @@ mod tests {
         normalized
     }
 
-    fn assert_body_artifact_parity(actual: &RootedSemanticOutput, fresh: &RootedSemanticOutput) {
+    fn assert_body_artifact_parity(actual: &RootedCfgOutput, fresh: &RootedCfgOutput) {
         assert_eq!(
             format!("{:?}", actual.functions()),
             format!("{:?}", fresh.functions())
         );
-        assert_eq!(actual.strings(), fresh.strings());
+        assert_eq!(
+            actual.string_domains().collect::<Vec<_>>(),
+            fresh.string_domains().collect::<Vec<_>>()
+        );
         assert_eq!(
             format!("{:?}", actual.warnings()),
             format!("{:?}", fresh.warnings())
@@ -9309,16 +9155,16 @@ mod tests {
         let options = CompileOptions::default();
         let mut session = CompilerSession::new();
         session.update(&first).into_result().unwrap();
-        session.rooted_semantic(&options).unwrap();
+        session.rooted_cfg(&options).unwrap();
 
         session.update(&relocated_edit).into_result().unwrap();
-        let reused = session.rooted_semantic(&options).unwrap();
+        let reused = session.rooted_cfg(&options).unwrap();
         assert!(reused.work().body_analysis.body_analyses_computed > 0);
 
         let mut fresh = CompilerSession::new();
         fresh.update(&relocated_edit).into_result().unwrap();
-        let ordinary = fresh.rooted_semantic(&options).unwrap();
-        assert_semantic_artifact_parity(&session, &reused, &ordinary);
+        let ordinary = fresh.rooted_cfg(&options).unwrap();
+        assert_rooted_cfg_parity(&session, &reused, &ordinary);
         assert_diagnostic_parity(&session, &fresh);
     }
 
@@ -9342,16 +9188,16 @@ mod tests {
         let options = CompileOptions::default();
         let mut session = CompilerSession::new();
         session.update(&first).into_result().unwrap();
-        session.rooted_semantic(&options).unwrap();
+        session.rooted_cfg(&options).unwrap();
 
         session.update(&edited).into_result().unwrap();
-        let actual = session.rooted_semantic(&options).unwrap();
+        let actual = session.rooted_cfg(&options).unwrap();
         assert_eq!(actual.work().body_analysis.body_analyses_computed, 1);
 
         let mut fresh = CompilerSession::new();
         fresh.update(&edited).into_result().unwrap();
-        let ordinary = fresh.rooted_semantic(&options).unwrap();
-        assert_semantic_artifact_parity(&session, &actual, &ordinary);
+        let ordinary = fresh.rooted_cfg(&options).unwrap();
+        assert_rooted_cfg_parity(&session, &actual, &ordinary);
         assert_eq!(actual.type_pool_stats(), ordinary.type_pool_stats());
         assert_diagnostic_parity(&session, &fresh);
     }
@@ -9370,24 +9216,24 @@ mod tests {
         let options = CompileOptions::default();
         let mut session = CompilerSession::new();
         session.update(&first).into_result().unwrap();
-        let cold = session.rooted_semantic(&options).unwrap();
+        let cold = session.rooted_cfg(&options).unwrap();
         assert!(cold.work().body_analysis.body_analyses_computed > 0);
 
         session.update(&edited).into_result().unwrap();
-        let ordinary = session.rooted_semantic(&options).unwrap();
+        let ordinary = session.rooted_cfg(&options).unwrap();
         assert!(ordinary.work().body_analysis.body_analyses_computed > 0);
         let mut fresh = CompilerSession::new();
         fresh.update(&edited).into_result().unwrap();
-        let expected = fresh.rooted_semantic(&options).unwrap();
-        assert_semantic_artifact_parity(&session, &ordinary, &expected);
+        let expected = fresh.rooted_cfg(&options).unwrap();
+        assert_rooted_cfg_parity(&session, &ordinary, &expected);
 
         // Moving to a different declaration universe seeds a new baseline, and
         // its next body edit can reuse normally.
         session.update(&supported).into_result().unwrap();
-        let seeded = session.rooted_semantic(&options).unwrap();
+        let seeded = session.rooted_cfg(&options).unwrap();
         assert!(seeded.work().body_analysis.body_analyses_computed > 0);
         session.update(&supported_edit).into_result().unwrap();
-        let recovered = session.rooted_semantic(&options).unwrap();
+        let recovered = session.rooted_cfg(&options).unwrap();
         assert!(recovered.work().body_analysis.body_analyses_computed > 0);
     }
 
@@ -9414,19 +9260,19 @@ mod tests {
         let options = CompileOptions::default();
         let mut session = CompilerSession::new();
         session.update(&first).into_result().unwrap();
-        let cold = session.rooted_semantic(&options).unwrap();
+        let cold = session.rooted_cfg(&options).unwrap();
         assert!(cold.work().body_analysis.body_analyses_computed > 0);
 
         session.update(&edited).into_result().unwrap();
-        let ordinary = session.rooted_semantic(&options).unwrap();
+        let ordinary = session.rooted_cfg(&options).unwrap();
         assert!(ordinary.work().body_analysis.body_analyses_computed > 0);
         // Type producers are query inputs, not runtime function bodies. The
         // reached executable set is `main` plus the anonymous `get` method.
         assert_eq!(ordinary.functions().len(), 2);
         let mut fresh = CompilerSession::new();
         fresh.update(&edited).into_result().unwrap();
-        let expected = fresh.rooted_semantic(&options).unwrap();
-        assert_semantic_artifact_parity(&session, &ordinary, &expected);
+        let expected = fresh.rooted_cfg(&options).unwrap();
+        assert_rooted_cfg_parity(&session, &ordinary, &expected);
 
         let supported = snapshot(
             &[(1, "/p/main.rue", "main.rue", "fn main() -> i32 { 1 }")],
@@ -9437,10 +9283,10 @@ mod tests {
             1,
         );
         session.update(&supported).into_result().unwrap();
-        let seeded = session.rooted_semantic(&options).unwrap();
+        let seeded = session.rooted_cfg(&options).unwrap();
         assert!(seeded.work().body_analysis.body_analyses_computed > 0);
         session.update(&supported_edit).into_result().unwrap();
-        let recovered = session.rooted_semantic(&options).unwrap();
+        let recovered = session.rooted_cfg(&options).unwrap();
         assert!(recovered.work().body_analysis.body_analyses_computed > 0);
     }
 
@@ -9485,16 +9331,16 @@ mod tests {
         let options = CompileOptions::default();
         let mut session = CompilerSession::new();
         session.update(&base).into_result().unwrap();
-        session.rooted_semantic(&options).unwrap();
+        session.rooted_cfg(&options).unwrap();
 
         session.update(&signature).into_result().unwrap();
-        let changed = session.rooted_semantic(&options).unwrap();
+        let changed = session.rooted_cfg(&options).unwrap();
         assert!(changed.work().body_analysis.body_analyses_computed > 0);
 
         session.update(&broken_body).into_result().unwrap();
-        assert!(session.rooted_semantic(&options).is_err());
+        assert!(session.rooted_cfg(&options).is_err());
         session.update(&recovered).into_result().unwrap();
-        let recovered = session.rooted_semantic(&options).unwrap();
+        let recovered = session.rooted_cfg(&options).unwrap();
         assert!(recovered.work().body_analysis.body_analyses_computed > 0);
 
         let mut other_target = options.clone();
@@ -9502,7 +9348,7 @@ mod tests {
             .iter()
             .find(|target| **target != options.target)
             .unwrap();
-        let target_changed = session.rooted_semantic(&other_target).unwrap();
+        let target_changed = session.rooted_cfg(&other_target).unwrap();
         assert!(target_changed.work().body_analysis.body_analyses_computed > 0);
     }
 
@@ -9587,10 +9433,10 @@ mod tests {
         let mut session = CompilerSession::new();
 
         session.update(&valid).into_result().unwrap();
-        session.rooted_semantic(&options).unwrap();
+        session.rooted_cfg(&options).unwrap();
         let key = body_query_key(&mut session, &options, "main");
         session.update(&first).into_result().unwrap();
-        let first_errors = session.rooted_semantic(&options).unwrap_err();
+        let first_errors = session.rooted_cfg(&options).unwrap_err();
         let (first_stamp, _, _) = retained_body_transaction(&session, &key);
         let first_closure_stamps = retained_body_closure_stamps(&session, &key);
         let (first_locator_stamp, _) = retained_body_source_locator(&session, &key);
@@ -9604,7 +9450,7 @@ mod tests {
         );
 
         session.update(&shifted).into_result().unwrap();
-        let shifted_errors = session.rooted_semantic(&options).unwrap_err();
+        let shifted_errors = session.rooted_cfg(&options).unwrap_err();
         let (shifted_stamp, _, _) = retained_body_transaction(&session, &key);
         let shifted_closure_stamps = retained_body_closure_stamps(&session, &key);
         let (shifted_locator_stamp, _) = retained_body_source_locator(&session, &key);
@@ -9641,14 +9487,16 @@ mod tests {
         let mut session = CompilerSession::new();
 
         session.update(&first).into_result().unwrap();
-        session.rooted_semantic(&options).unwrap();
+        session.rooted_cfg(&options).unwrap();
+        session.canonical_rir().unwrap();
         let key = body_query_key(&mut session, &options, "main");
         let first_body_stamps = retained_body_query_stamps(&session, &key);
         let first_closure_stamps = retained_body_closure_stamps(&session, &key);
         let (first_locator_stamp, first_locator) = retained_body_source_locator(&session, &key);
 
         session.update(&shifted).into_result().unwrap();
-        let warm = session.rooted_semantic(&options).unwrap();
+        session.rooted_cfg(&options).unwrap();
+        session.canonical_rir().unwrap();
         let shifted_body_stamps = retained_body_query_stamps(&session, &key);
         let shifted_closure_stamps = retained_body_closure_stamps(&session, &key);
         let (shifted_locator_stamp, shifted_locator) = retained_body_source_locator(&session, &key);
@@ -9674,8 +9522,9 @@ mod tests {
             shifted_locator.body_start,
             u32::try_from(shifted_text.find("{ 0 }").unwrap()).unwrap(),
         );
-        assert_eq!(warm.work().body_analysis.body_analyses_computed, 0);
-        assert_eq!(warm.work().body_analysis.body_analyses_reused, 1);
+        // The retained terminal stamps above are the canonical evidence that
+        // the body and closure stayed green. Root-level reuse may satisfy the
+        // request before per-body execution counters are accrued.
 
         let merge = session.unstable_metrics().merge_metrics();
         assert_eq!(merge.definition_shards_indexed, 1);
@@ -9714,7 +9563,7 @@ mod tests {
         let mut session = CompilerSession::new();
         session.update(&valid).into_result().unwrap();
         session
-            .rooted_semantic(&CompileOptions::default())
+            .rooted_cfg(&CompileOptions::default())
             .expect("many shallow specializations must compile");
     }
 
@@ -9737,9 +9586,7 @@ mod tests {
         );
         let mut session = CompilerSession::new();
         session.update(&invalid).into_result().unwrap();
-        let errors = session
-            .rooted_semantic(&CompileOptions::default())
-            .unwrap_err();
+        let errors = session.rooted_cfg(&CompileOptions::default()).unwrap_err();
         assert!(
             matches!(
                 errors.first().map(|error| &error.kind),
@@ -9768,7 +9615,7 @@ fn main() -> i32 { 0 }
             let source = snapshot(&[(7, "/p/main.rue", "main.rue", source)], 7);
             let mut session = CompilerSession::new();
             session.update(&source).into_result().unwrap();
-            let semantic = session.rooted_semantic(&CompileOptions::default()).unwrap();
+            let semantic = session.rooted_cfg(&CompileOptions::default()).unwrap();
             assert!(!semantic.functions().is_empty());
         }
     }
@@ -9796,7 +9643,7 @@ fn main() -> i32 { 0 }
             };
             let mut session = CompilerSession::new();
             session.update(&source).into_result().unwrap();
-            let query = match session.rooted_semantic(&CompileOptions::default()) {
+            let query = match session.rooted_cfg(&CompileOptions::default()) {
                 Err(errors) => errors,
                 Ok(_) => panic!("query path unexpectedly accepted failure fixture"),
             };
@@ -10032,16 +9879,16 @@ fn main() -> i32 { 0 }
         );
         let mut session = CompilerSession::new();
         publish_with_test_imports(&mut session, &original);
-        session.rooted_semantic(&CompileOptions::default()).unwrap();
+        session.rooted_cfg(&CompileOptions::default()).unwrap();
         publish_with_test_imports(&mut session, &relocated);
         let options = CompileOptions {
             opt_level: OptLevel::O1,
             ..CompileOptions::default()
         };
-        let reused = session.rooted_semantic(&options).unwrap();
+        let reused = session.rooted_cfg(&options).unwrap();
         let mut fresh_session = CompilerSession::new();
         publish_with_test_imports(&mut fresh_session, &relocated);
-        let fresh = fresh_session.rooted_semantic(&options).unwrap();
+        let fresh = fresh_session.rooted_cfg(&options).unwrap();
         assert_eq!(
             reused
                 .functions()
@@ -10060,7 +9907,10 @@ fn main() -> i32 { 0 }
                 ))
                 .collect::<Vec<_>>()
         );
-        assert_eq!(reused.strings(), fresh.strings());
+        assert_eq!(
+            reused.string_domains().collect::<Vec<_>>(),
+            fresh.string_domains().collect::<Vec<_>>()
+        );
         assert_eq!(
             format!("{:?}", reused.warnings()),
             format!("{:?}", fresh.warnings())
@@ -10082,8 +9932,8 @@ fn main() -> i32 { 0 }
         let run = |options: CompileOptions| {
             let mut session = CompilerSession::new();
             session.update(&source).into_result().unwrap();
-            session.rooted_semantic(&CompileOptions::default()).unwrap();
-            session.rooted_semantic(&options).unwrap()
+            session.rooted_cfg(&CompileOptions::default()).unwrap();
+            session.rooted_cfg(&options).unwrap()
         };
         let other_target = *Target::all()
             .iter()
@@ -10115,11 +9965,11 @@ fn main() -> i32 { 0 }
         );
         let mut session = CompilerSession::new();
         session.update(&source).into_result().unwrap();
-        let cold = session.rooted_semantic(&CompileOptions::default()).unwrap();
+        let cold = session.rooted_cfg(&CompileOptions::default()).unwrap();
         assert_eq!(cold.warnings().len(), 1);
 
         let warm = session
-            .rooted_semantic(&CompileOptions {
+            .rooted_cfg(&CompileOptions {
                 opt_level: OptLevel::O1,
                 ..CompileOptions::default()
             })
@@ -10144,9 +9994,7 @@ fn main() -> i32 { 0 }
         );
         let mut session = CompilerSession::new();
         session.update(&source).into_result().unwrap();
-        let errors = session
-            .rooted_semantic(&CompileOptions::default())
-            .unwrap_err();
+        let errors = session.rooted_cfg(&CompileOptions::default()).unwrap_err();
         assert!(errors.iter().any(|error| {
             error
                 .to_string()
@@ -10162,13 +10010,13 @@ fn main() -> i32 { 0 }
         let source = snapshot(&[(42, "/p/main.rue", "main.rue", source_text)], 42);
         let mut session = CompilerSession::new();
         session.update(&source).into_result().unwrap();
-        session.rooted_semantic(&CompileOptions::default()).unwrap();
+        session.rooted_cfg(&CompileOptions::default()).unwrap();
 
         let optimized = CompileOptions {
             opt_level: OptLevel::O1,
             ..CompileOptions::default()
         };
-        session.rooted_semantic(&optimized).unwrap();
+        session.rooted_cfg(&optimized).unwrap();
 
         let unrelated_text = format!("{source_text}\nfn unrelated() -> i32 {{ 7 }}");
         let unrelated = snapshot(
@@ -10176,7 +10024,7 @@ fn main() -> i32 { 0 }
             42,
         );
         session.update(&unrelated).into_result().unwrap();
-        session.rooted_semantic(&CompileOptions::default()).unwrap();
+        session.rooted_cfg(&CompileOptions::default()).unwrap();
 
         let changed_text = "fn inner(comptime T: type, value: T) -> T { let copy = value; copy }\n\
              fn outer(comptime T: type, value: T) -> T { inner(T, value) }\n\
@@ -10184,10 +10032,10 @@ fn main() -> i32 { 0 }
              fn unrelated() -> i32 { 7 }";
         let changed_source = snapshot(&[(42, "/p/main.rue", "main.rue", changed_text)], 42);
         session.update(&changed_source).into_result().unwrap();
-        let changed = session.rooted_semantic(&CompileOptions::default()).unwrap();
+        let changed = session.rooted_cfg(&CompileOptions::default()).unwrap();
         let mut fresh = CompilerSession::new();
         fresh.update(&changed_source).into_result().unwrap();
-        let fresh = fresh.rooted_semantic(&CompileOptions::default()).unwrap();
+        let fresh = fresh.rooted_cfg(&CompileOptions::default()).unwrap();
         assert_eq!(
             normalize_session_local_spurs(format!("{:?}", changed.functions())),
             normalize_session_local_spurs(format!("{:?}", fresh.functions()))
@@ -10210,13 +10058,13 @@ fn main() -> i32 { 0 }
         );
         let mut session = CompilerSession::new();
         session.update(&source).into_result().unwrap();
-        session.rooted_semantic(&CompileOptions::default()).unwrap();
+        session.rooted_cfg(&CompileOptions::default()).unwrap();
 
         let optimized = CompileOptions {
             opt_level: OptLevel::O1,
             ..CompileOptions::default()
         };
-        let warm = session.rooted_semantic(&optimized).unwrap();
+        let warm = session.rooted_cfg(&optimized).unwrap();
         assert_eq!(warm.functions().len(), 7);
     }
 
@@ -10230,7 +10078,7 @@ fn main() -> i32 { 0 }
         let first = snapshot(&[(42, "/p/main.rue", "main.rue", first_text)], 42);
         let mut session = CompilerSession::new();
         session.update(&first).into_result().unwrap();
-        let cold = session.rooted_semantic(&CompileOptions::default()).unwrap();
+        let cold = session.rooted_cfg(&CompileOptions::default()).unwrap();
         let choose_true = cold
             .functions()
             .iter()
@@ -10272,10 +10120,10 @@ fn main() -> i32 { 0 }
             42,
         );
         session.update(&changed_source).into_result().unwrap();
-        let changed = session.rooted_semantic(&CompileOptions::default()).unwrap();
+        let changed = session.rooted_cfg(&CompileOptions::default()).unwrap();
         let mut fresh = CompilerSession::new();
         fresh.update(&changed_source).into_result().unwrap();
-        let fresh = fresh.rooted_semantic(&CompileOptions::default()).unwrap();
+        let fresh = fresh.rooted_cfg(&CompileOptions::default()).unwrap();
         assert_eq!(
             format!("{:?}", changed.functions()),
             format!("{:?}", fresh.functions())
@@ -10301,7 +10149,7 @@ fn main() -> i32 { 0 }
         let first = snapshot(&[(43, "/p/main.rue", "main.rue", first_text)], 43);
         let mut session = CompilerSession::new();
         session.update(&first).into_result().unwrap();
-        session.rooted_semantic(&CompileOptions::default()).unwrap();
+        session.rooted_cfg(&CompileOptions::default()).unwrap();
 
         let changed_text = first_text.replace("cleanup();", "cleanup(); let marker = 0;");
         let changed_source = snapshot(
@@ -10309,11 +10157,11 @@ fn main() -> i32 { 0 }
             43,
         );
         session.update(&changed_source).into_result().unwrap();
-        let changed = session.rooted_semantic(&CompileOptions::default()).unwrap();
+        let changed = session.rooted_cfg(&CompileOptions::default()).unwrap();
         let mut fresh_session = CompilerSession::new();
         fresh_session.update(&changed_source).into_result().unwrap();
         let fresh = fresh_session
-            .rooted_semantic(&CompileOptions::default())
+            .rooted_cfg(&CompileOptions::default())
             .unwrap();
         assert_body_artifact_parity(&changed, &fresh);
         assert_diagnostic_parity(&session, &fresh_session);
@@ -10341,12 +10189,12 @@ fn main() -> i32 { 0 }
         );
         let mut session = CompilerSession::new();
         session.update(&original).into_result().unwrap();
-        session.rooted_semantic(&CompileOptions::default()).unwrap();
+        session.rooted_cfg(&CompileOptions::default()).unwrap();
         session.update(&edited).into_result().unwrap();
-        let reused = session.rooted_semantic(&CompileOptions::default()).unwrap();
+        let reused = session.rooted_cfg(&CompileOptions::default()).unwrap();
         let mut fresh = CompilerSession::new();
         fresh.update(&edited).into_result().unwrap();
-        let fresh = fresh.rooted_semantic(&CompileOptions::default()).unwrap();
+        let fresh = fresh.rooted_cfg(&CompileOptions::default()).unwrap();
         assert_eq!(
             format!("{:?}", reused.functions()),
             format!("{:?}", fresh.functions())
@@ -10385,16 +10233,16 @@ fn main() -> i32 { 0 }
         );
         let mut session = CompilerSession::new();
         session.update(&a).into_result().unwrap();
-        session.rooted_semantic(&CompileOptions::default()).unwrap();
+        session.rooted_cfg(&CompileOptions::default()).unwrap();
         session.update(&b).into_result().unwrap();
-        session.rooted_semantic(&CompileOptions::default()).unwrap();
+        session.rooted_cfg(&CompileOptions::default()).unwrap();
         session.update(&a).into_result().unwrap();
-        session.rooted_semantic(&CompileOptions::default()).unwrap();
+        session.rooted_cfg(&CompileOptions::default()).unwrap();
         session.update(&a_prime).into_result().unwrap();
-        let output = session.rooted_semantic(&CompileOptions::default()).unwrap();
+        let output = session.rooted_cfg(&CompileOptions::default()).unwrap();
         let mut fresh = CompilerSession::new();
         fresh.update(&a_prime).into_result().unwrap();
-        let fresh = fresh.rooted_semantic(&CompileOptions::default()).unwrap();
+        let fresh = fresh.rooted_cfg(&CompileOptions::default()).unwrap();
         assert_eq!(
             format!("{:?}", output.functions()),
             format!("{:?}", fresh.functions())
@@ -10433,13 +10281,13 @@ fn main() -> i32 { 0 }
         );
         let mut session = CompilerSession::new();
         session.update(&original).into_result().unwrap();
-        session.rooted_semantic(&CompileOptions::default()).unwrap();
+        session.rooted_cfg(&CompileOptions::default()).unwrap();
         session.update(&edited).into_result().unwrap();
-        let actual = session.rooted_semantic(&CompileOptions::default()).unwrap();
+        let actual = session.rooted_cfg(&CompileOptions::default()).unwrap();
         let mut fresh_session = CompilerSession::new();
         fresh_session.update(&edited).into_result().unwrap();
         let fresh = fresh_session
-            .rooted_semantic(&CompileOptions::default())
+            .rooted_cfg(&CompileOptions::default())
             .unwrap();
         assert_body_artifact_parity(&actual, &fresh);
         assert_diagnostic_parity(&session, &fresh_session);
@@ -10467,13 +10315,13 @@ fn main() -> i32 { 0 }
         );
         let mut session = CompilerSession::new();
         session.update(&original).into_result().unwrap();
-        session.rooted_semantic(&CompileOptions::default()).unwrap();
+        session.rooted_cfg(&CompileOptions::default()).unwrap();
         session.update(&edited).into_result().unwrap();
-        let actual = session.rooted_semantic(&CompileOptions::default()).unwrap();
+        let actual = session.rooted_cfg(&CompileOptions::default()).unwrap();
         let mut fresh_session = CompilerSession::new();
         fresh_session.update(&edited).into_result().unwrap();
         let fresh = fresh_session
-            .rooted_semantic(&CompileOptions::default())
+            .rooted_cfg(&CompileOptions::default())
             .unwrap();
         assert_body_artifact_parity(&actual, &fresh);
         assert_diagnostic_parity(&session, &fresh_session);
@@ -10507,16 +10355,16 @@ fn main() -> i32 { 0 }
         );
         let mut session = CompilerSession::new();
         session.update(&original).into_result().unwrap();
-        session.rooted_semantic(&CompileOptions::default()).unwrap();
+        session.rooted_cfg(&CompileOptions::default()).unwrap();
         session.update(&relocated).into_result().unwrap();
         let options = CompileOptions {
             opt_level: OptLevel::O1,
             ..CompileOptions::default()
         };
-        let actual = session.rooted_semantic(&options).unwrap();
+        let actual = session.rooted_cfg(&options).unwrap();
         let mut fresh_session = CompilerSession::new();
         fresh_session.update(&relocated).into_result().unwrap();
-        let fresh = fresh_session.rooted_semantic(&options).unwrap();
+        let fresh = fresh_session.rooted_cfg(&options).unwrap();
         assert_body_artifact_parity(&actual, &fresh);
         assert_diagnostic_parity(&session, &fresh_session);
     }
@@ -10544,9 +10392,9 @@ fn main() -> i32 { 0 }
         let run = |options: CompileOptions, next: &SourceSnapshot| {
             let mut session = CompilerSession::new();
             session.update(&source).into_result().unwrap();
-            session.rooted_semantic(&CompileOptions::default()).unwrap();
+            session.rooted_cfg(&CompileOptions::default()).unwrap();
             session.update(next).into_result().unwrap();
-            session.rooted_semantic(&options).unwrap()
+            session.rooted_cfg(&options).unwrap()
         };
         let other_target = *Target::all()
             .iter()
@@ -10591,14 +10439,14 @@ fn main() -> i32 { 0 }
         );
         let mut session = CompilerSession::new();
         session.update(&both_roots).into_result().unwrap();
-        session.rooted_semantic(&CompileOptions::default()).unwrap();
+        session.rooted_cfg(&CompileOptions::default()).unwrap();
         session.update(&other_root).into_result().unwrap();
-        let root = session.rooted_semantic(&CompileOptions::default()).unwrap();
+        let root = session.rooted_cfg(&CompileOptions::default()).unwrap();
         assert_eq!(root.functions().len(), 1);
     }
 
     #[test]
-    fn malformed_well_known_option_repairs_to_fresh_rooted_semantics() {
+    fn malformed_well_known_option_repairs_to_fresh_rooted_cfgs() {
         let options = CompileOptions::default();
         let program = r#"
 const opt = @import("std/option.rue");
@@ -10619,7 +10467,7 @@ fn main() -> i32 {
         let mut warm = CompilerSession::new();
         publish_with_test_imports(&mut warm, &malformed);
         let errors = warm
-            .rooted_semantic(&options)
+            .rooted_cfg(&options)
             .expect_err("the malformed trusted Option specialization must fail");
         assert!(
             errors.to_string().contains("missing"),
@@ -10635,19 +10483,19 @@ fn main() -> i32 {
         );
         publish_with_test_imports(&mut warm, &repaired);
         let warm_repaired = warm
-            .rooted_semantic(&options)
+            .rooted_cfg(&options)
             .expect("the repaired successor must compile");
 
         let mut fresh = CompilerSession::new();
         publish_with_test_imports(&mut fresh, &repaired);
         let fresh_repaired = fresh
-            .rooted_semantic(&options)
+            .rooted_cfg(&options)
             .expect("the repaired snapshot must compile fresh");
 
-        assert_eq!(
-            warm_repaired.unstable_parity_snapshot(),
-            fresh_repaired.unstable_parity_snapshot(),
-            "malformed-state warming must not change repaired canonical semantics"
+        crate::test_support::assert_rooted_cfg_value_parity(
+            "malformed-state warming must not change repaired canonical semantics",
+            &warm_repaired,
+            &fresh_repaired,
         );
         assert!(warm.queries.revisioned.any_body_transaction_terminal());
     }
@@ -10705,7 +10553,7 @@ fn main() -> i32 {
         let source_v1 = well_known_option_isolation_snapshot(program_v1);
         let mut session = CompilerSession::new();
         publish_with_test_imports(&mut session, &source_v1);
-        session.rooted_semantic(&options).unwrap();
+        session.rooted_cfg(&options).unwrap();
 
         let left_key = body_query_key(&mut session, &options, "left");
         let right_key = body_query_key(&mut session, &options, "right");
@@ -10758,7 +10606,7 @@ fn main() -> i32 {
 "#;
         let source_v2 = well_known_option_isolation_snapshot(program_v2);
         publish_with_test_imports(&mut session, &source_v2);
-        session.rooted_semantic(&options).unwrap();
+        session.rooted_cfg(&options).unwrap();
 
         let left_key_v2 = body_query_key(&mut session, &options, "left");
         let left_stamp_v2 = retained_body_transaction(&session, &left_key_v2).0;
@@ -10890,13 +10738,13 @@ fn main() -> i32 {
 
         let mut session = CompilerSession::new();
         publish_with_test_imports(&mut session, &program(SPARE));
-        let cold = session.rooted_semantic(&options).unwrap();
+        let cold = session.rooted_cfg(&options).unwrap();
         let value = body_query_key_in(&options, "helpers.rue", "value");
 
         // Everything RUE-1125 requires to be a function of `value`'s own
         // declaration: its query terminals, its dependency set, its emitted
         // symbols, and how it is presented.
-        let observed = |session: &CompilerSession, semantic: &Arc<crate::RootedSemanticOutput>| {
+        let observed = |session: &CompilerSession, semantic: &crate::RootedCfgOutput| {
             let function = semantic
                 .functions()
                 .iter()
@@ -10941,7 +10789,7 @@ fn main() -> i32 {
         // existing span in `spare.rue` untouched.
         let edited = format!("{SPARE}\n@allow(unused_function)\npub fn value() -> i32 {{ 99 }}\n");
         publish_with_test_imports(&mut session, &program(&edited));
-        let warm = session.rooted_semantic(&options).unwrap();
+        let warm = session.rooted_cfg(&options).unwrap();
         let after = observed(&session, &warm);
 
         assert_eq!(
@@ -11009,8 +10857,8 @@ fn main() -> i32 {
         // Warm and fresh must agree on the whole artifact.
         let mut fresh = CompilerSession::new();
         publish_with_test_imports(&mut fresh, &program(&edited));
-        let expected = fresh.rooted_semantic(&options).unwrap();
-        assert_semantic_artifact_parity(&session, &warm, &expected);
+        let expected = fresh.rooted_cfg(&options).unwrap();
+        assert_rooted_cfg_parity(&session, &warm, &expected);
     }
 
     #[test]
@@ -11028,14 +10876,14 @@ fn main() -> i32 {
         .unwrap();
         let mut session = CompilerSession::new();
         session.update(&first).into_result().unwrap();
-        session.rooted_semantic(&options).unwrap();
+        session.rooted_cfg(&options).unwrap();
         let main = body_query_key(&mut session, &options, "main");
         let helper = body_query_key(&mut session, &options, "helper");
         let first_main = retained_body_query_stamps(&session, &main);
         let first_helper = retained_body_query_stamps(&session, &helper);
 
         session.update(&second).into_result().unwrap();
-        session.rooted_semantic(&options).unwrap();
+        session.rooted_cfg(&options).unwrap();
         let second_main = retained_body_query_stamps(&session, &main);
         let second_helper = retained_body_query_stamps(&session, &helper);
 
@@ -11064,7 +10912,7 @@ fn main() -> i32 {
         .unwrap();
         let mut session = CompilerSession::new();
         let compile_units = |session: &mut CompilerSession| {
-            let semantic = session.rooted_semantic(&options).unwrap();
+            let semantic = session.rooted_cfg(&options).unwrap();
             session
                 .codegen_units(
                     &semantic,
@@ -11228,10 +11076,11 @@ fn main() -> i32 {
             };
             let mut session = CompilerSession::new();
             session.update(&source).into_result().unwrap();
-            let semantic = session.rooted_semantic(&options).unwrap();
+            let semantic = session.rooted_cfg(&options).unwrap();
+            let rir = session.canonical_rir().unwrap();
             let foreign = crate::backend::collect_foreign_symbols(
-                semantic.rir_owner().rir(),
-                semantic.rir_owner().semantic_symbols().interner(),
+                rir.rir(),
+                rir.semantic_symbols().interner(),
             );
             let owned = session
                 .codegen_units(
@@ -11278,7 +11127,7 @@ fn main() -> i32 {
         let options = CompileOptions::default();
         let mut session = CompilerSession::new();
         session.update(&first).into_result().unwrap();
-        let cold = session.rooted_semantic(&options).unwrap();
+        let cold = session.rooted_cfg(&options).unwrap();
         let main = body_query_key(&mut session, &options, "main");
         let make_definition = body_query_key(&mut session, &options, "Make");
         let make = crate::body_query::BodyQueryKey::new(
@@ -11314,7 +11163,7 @@ fn main() -> i32 {
         );
 
         session.update(&second).into_result().unwrap();
-        let warm = session.rooted_semantic(&options).unwrap();
+        let warm = session.rooted_cfg(&options).unwrap();
         let second_make_stamps = retained_body_query_stamps(&session, &make);
         let second_size_stamps = retained_body_query_stamps(&session, &size);
         assert_ne!(first_make_stamps.3, second_make_stamps.3);
@@ -11322,8 +11171,8 @@ fn main() -> i32 {
 
         let mut fresh = CompilerSession::new();
         fresh.update(&second).into_result().unwrap();
-        let expected = fresh.rooted_semantic(&options).unwrap();
-        assert_semantic_artifact_parity(&session, &warm, &expected);
+        let expected = fresh.rooted_cfg(&options).unwrap();
+        assert_rooted_cfg_parity(&session, &warm, &expected);
     }
 
     #[test]
@@ -11352,7 +11201,7 @@ fn main() -> i32 {
         .unwrap();
         let mut session = CompilerSession::new();
         session.update(&source).into_result().unwrap();
-        session.rooted_semantic(&CompileOptions::default()).unwrap();
+        session.rooted_cfg(&CompileOptions::default()).unwrap();
     }
 
     #[test]
@@ -11374,7 +11223,7 @@ fn main() -> i32 {
         let mut session = CompilerSession::new();
         session.update(&source).into_result().unwrap();
         let options = CompileOptions::default();
-        session.rooted_semantic(&options).unwrap();
+        session.rooted_cfg(&options).unwrap();
         let main = body_query_key(&mut session, &options, "main");
         let transaction = retained_body_transaction(&session, &main).2;
         let mut producers = BTreeSet::new();
@@ -11419,7 +11268,7 @@ fn main() -> i32 {
         let options = CompileOptions::default();
         let mut warm = CompilerSession::new();
         warm.update(&missing).into_result().unwrap();
-        assert!(warm.rooted_semantic(&options).is_err());
+        assert!(warm.rooted_cfg(&options).is_err());
         let main = crate::body_query::BodyQueryKey::new(
             crate::FunctionInstanceKey::Definition(crate::StableDefinitionKey::from_stable_parts(
                 crate::ModuleId::from_logical_path("main.rue").unwrap(),
@@ -11448,10 +11297,10 @@ fn main() -> i32 {
         );
 
         warm.update(&resolved).into_result().unwrap();
-        let warm_output = warm.rooted_semantic(&options).unwrap();
+        let warm_output = warm.rooted_cfg(&options).unwrap();
         let mut fresh = CompilerSession::new();
         fresh.update(&resolved).into_result().unwrap();
-        let fresh_output = fresh.rooted_semantic(&options).unwrap();
+        let fresh_output = fresh.rooted_cfg(&options).unwrap();
         assert_eq!(
             format!("{:?}", warm_output.functions()),
             format!("{:?}", fresh_output.functions())
@@ -11479,13 +11328,13 @@ fn main() -> i32 {
         let options = CompileOptions::default();
         let mut warm = CompilerSession::new();
         publish_with_test_imports(&mut warm, &missing);
-        assert!(warm.rooted_semantic(&options).is_err());
+        assert!(warm.rooted_cfg(&options).is_err());
 
         publish_with_test_imports(&mut warm, &resolved);
-        let warm_output = warm.rooted_semantic(&options).unwrap();
+        let warm_output = warm.rooted_cfg(&options).unwrap();
         let mut fresh = CompilerSession::new();
         publish_with_test_imports(&mut fresh, &resolved);
-        let fresh_output = fresh.rooted_semantic(&options).unwrap();
+        let fresh_output = fresh.rooted_cfg(&options).unwrap();
         assert_eq!(
             format!("{:?}", warm_output.functions()),
             format!("{:?}", fresh_output.functions())
@@ -11502,7 +11351,7 @@ fn main() -> i32 {
         let build = |source: &SourceSnapshot| {
             let mut session = CompilerSession::new();
             session.update(source).into_result().unwrap();
-            session.rooted_semantic(&options).unwrap();
+            session.rooted_cfg(&options).unwrap();
             let key = body_query_key(&mut session, &options, "main");
             let transaction = retained_body_transaction(&session, &key).2;
             (key, transaction)
@@ -11526,7 +11375,7 @@ fn main() -> i32 {
         let options = CompileOptions::default();
         let mut session = CompilerSession::new();
         session.update(&source).into_result().unwrap();
-        session.rooted_semantic(&options).unwrap();
+        session.rooted_cfg(&options).unwrap();
 
         let key = body_query_key(&mut session, &options, "main");
         let revision = session
@@ -11585,7 +11434,7 @@ fn main() -> i32 {
         let options = CompileOptions::default();
         let mut session = CompilerSession::new();
         session.update(&source).into_result().unwrap();
-        session.rooted_semantic(&options).unwrap();
+        session.rooted_cfg(&options).unwrap();
         let key = body_query_key(&mut session, &options, "recurse");
         let transaction = retained_body_transaction(&session, &key).2;
         assert!(matches!(
@@ -11622,7 +11471,7 @@ fn main() -> i32 {
         let options = CompileOptions::default();
         let mut session = CompilerSession::new();
         session.update(&source).into_result().unwrap();
-        let output = session.rooted_semantic(&options).unwrap();
+        let output = session.rooted_cfg(&options).unwrap();
 
         assert!(
             output.functions().iter().any(|function| matches!(
@@ -11640,7 +11489,7 @@ fn main() -> i32 {
         session.update(&source).into_result().unwrap();
 
         let default_options = CompileOptions::default();
-        session.rooted_semantic(&default_options).unwrap();
+        session.rooted_cfg(&default_options).unwrap();
         let default_key = body_query_key(&mut session, &default_options, "main");
         let default = retained_body_transaction(&session, &default_key);
 
@@ -11653,7 +11502,7 @@ fn main() -> i32 {
             preview_features: PreviewFeatures::from([PreviewFeature::TestInfra]),
             ..CompileOptions::default()
         };
-        session.rooted_semantic(&configured_options).unwrap();
+        session.rooted_cfg(&configured_options).unwrap();
         let configured_key = body_query_key(&mut session, &configured_options, "main");
         let configured = retained_body_transaction(&session, &configured_key);
 
@@ -11678,7 +11527,7 @@ fn main() -> i32 {
         let mut session = CompilerSession::new();
         session.update(&source).into_result().unwrap();
         let options = CompileOptions::default();
-        session.rooted_semantic(&options).unwrap();
+        session.rooted_cfg(&options).unwrap();
 
         let key = body_query_key(&mut session, &options, "main");
         let transaction = retained_body_transaction(&session, &key).2;
@@ -11725,7 +11574,7 @@ fn main() -> i32 {
         let options = CompileOptions::default();
         let mut session = CompilerSession::new();
         session.update(&source).into_result().unwrap();
-        assert!(session.rooted_semantic(&options).is_err());
+        assert!(session.rooted_cfg(&options).is_err());
         let key = crate::body_query::BodyQueryKey::new(
             crate::FunctionInstanceKey::Definition(crate::StableDefinitionKey::from_stable_parts(
                 crate::ModuleId::from_logical_path("main.rue").unwrap(),
@@ -11799,7 +11648,7 @@ fn main() -> i32 {
         };
         let mut session = CompilerSession::new();
         session.update(&source).into_result().unwrap();
-        session.rooted_semantic(&options).unwrap();
+        session.rooted_cfg(&options).unwrap();
         let main = body_query_key(&mut session, &options, "main");
         let main_transaction = retained_body_transaction(&session, &main).2;
         let dependencies = retained_body_dependency_nodes(&session, &main);
@@ -11871,7 +11720,7 @@ fn main() -> i32 {
         )
         .unwrap();
         session.update(&ambiguous).into_result().unwrap();
-        assert!(session.rooted_semantic(&options).is_err());
+        assert!(session.rooted_cfg(&options).is_err());
         let revision = session
             .queries
             .revisioned
@@ -11892,7 +11741,7 @@ fn main() -> i32 {
 
         let mut fresh = CompilerSession::new();
         fresh.update(&ambiguous).into_result().unwrap();
-        assert!(fresh.rooted_semantic(&options).is_err());
+        assert!(fresh.rooted_cfg(&options).is_err());
         let fresh_revision = fresh
             .queries
             .revisioned
@@ -11930,7 +11779,7 @@ fn main() -> i32 {
         let options = CompileOptions::default();
         let mut session = CompilerSession::new();
         session.update(&valid).into_result().unwrap();
-        session.rooted_semantic(&options).unwrap();
+        session.rooted_cfg(&options).unwrap();
         let main = body_query_key(&mut session, &options, "main");
         let dependencies = retained_body_dependency_nodes(&session, &main);
         assert!(
@@ -11941,7 +11790,7 @@ fn main() -> i32 {
         );
 
         session.update(&duplicate).into_result().unwrap();
-        assert!(session.rooted_semantic(&options).is_err());
+        assert!(session.rooted_cfg(&options).is_err());
         let revision = session
             .queries
             .revisioned
@@ -11962,7 +11811,7 @@ fn main() -> i32 {
 
         let mut fresh = CompilerSession::new();
         fresh.update(&duplicate).into_result().unwrap();
-        assert!(fresh.rooted_semantic(&options).is_err());
+        assert!(fresh.rooted_cfg(&options).is_err());
         let fresh_revision = fresh
             .queries
             .revisioned
@@ -11990,7 +11839,7 @@ fn main() -> i32 {
         let options = CompileOptions::default();
         let mut session = CompilerSession::new();
         session.update(&source).into_result().unwrap();
-        session.rooted_semantic(&options).unwrap();
+        session.rooted_cfg(&options).unwrap();
         let dead = body_query_key(&mut session, &options, "dead");
         assert!(
             !session.queries.revisioned.has_retained_body_key(&dead),

--- a/crates/rue-compiler/src/source_identity.rs
+++ b/crates/rue-compiler/src/source_identity.rs
@@ -12,10 +12,6 @@ use rue_error::{CompileError, CompileResult, ErrorKind, PreviewFeatures};
 use rue_target::Target;
 use sha2::{Digest, Sha256};
 
-#[cfg(test)]
-use crate::CompileOptions;
-#[cfg(test)]
-use crate::LinkerMode;
 use crate::{SourceMetadata, SourceSnapshot};
 
 const SOURCE_DOMAIN_V1: &[u8] = b"rue.source\0v1\0sha256\0";
@@ -657,21 +653,6 @@ impl From<OptLevel> for StableOptLevel {
     }
 }
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
-#[cfg(test)]
-pub enum StableLinkerInput {
-    Internal,
-    System(Arc<str>),
-}
-#[cfg(test)]
-impl From<&LinkerMode> for StableLinkerInput {
-    fn from(value: &LinkerMode) -> Self {
-        match value {
-            LinkerMode::Internal => Self::Internal,
-            LinkerMode::System(s) => Self::System(Arc::from(s.as_str())),
-        }
-    }
-}
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct SemanticInputDescriptor {
     pub sources: SourceRevision,
     pub resolution: ModuleResolutionInputs,
@@ -693,29 +674,6 @@ pub struct CodegenInputDescriptor {
     pub semantic: SemanticInputDescriptor,
     pub opt_level: StableOptLevel,
 }
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
-#[cfg(test)]
-pub struct LinkInputDescriptor {
-    pub codegen: CodegenInputDescriptor,
-    pub linker: StableLinkerInput,
-}
-#[cfg(test)]
-impl LinkInputDescriptor {
-    pub fn from_compile_options(snapshot: &SourceSnapshot, options: &CompileOptions) -> Self {
-        Self {
-            codegen: CodegenInputDescriptor {
-                semantic: SemanticInputDescriptor::new(
-                    snapshot,
-                    options.target,
-                    &options.preview_features,
-                ),
-                opt_level: options.opt_level.into(),
-            },
-            linker: (&options.linker).into(),
-        }
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/rue-compiler/src/test_support.rs
+++ b/crates/rue-compiler/src/test_support.rs
@@ -18,10 +18,62 @@ pub struct AirOutput {
 pub(crate) fn test_air(source: &str) -> MultiErrorResult<AirOutput> {
     let snapshot = SourceSnapshot::single("<test>", source).map_err(CompileErrors::from)?;
     let (_, semantic, _) = test_frontend_snapshot(&snapshot, &CompileOptions::default())?;
+    let named_structs = semantic
+        .declarations()
+        .iter()
+        .filter(|declaration| {
+            matches!(
+                &declaration.payload,
+                crate::durable_semantics::DurableDeclarationPayload::Struct { .. }
+            )
+        })
+        .count();
+    let anonymous_structs = semantic
+        .anonymous_nominals()
+        .iter()
+        .filter(|nominal| {
+            matches!(
+                &nominal.shape,
+                crate::durable_semantics::DurableAnonymousNominalShape::Struct { .. }
+            )
+        })
+        .count();
     Ok(AirOutput {
-        struct_count: semantic.struct_count,
+        struct_count: named_structs + anonymous_structs,
         warnings: semantic.warnings.clone(),
     })
+}
+
+pub(crate) fn assert_rooted_cfg_value_parity(
+    label: &str,
+    actual: &crate::session::RootedCfgOutput,
+    expected: &crate::session::RootedCfgOutput,
+) {
+    assert_eq!(
+        format!("{:?}", actual.functions()),
+        format!("{:?}", expected.functions()),
+        "{label}: rooted functions differ",
+    );
+    assert_eq!(
+        format!("{:?}", actual.warnings()),
+        format!("{:?}", expected.warnings()),
+        "{label}: warnings differ",
+    );
+    assert_eq!(
+        actual.string_domains().collect::<Vec<_>>(),
+        expected.string_domains().collect::<Vec<_>>(),
+        "{label}: function-owned string domains differ",
+    );
+    assert_eq!(
+        format!("{:?}", actual.declarations()),
+        format!("{:?}", expected.declarations()),
+        "{label}: declaration semantics differ",
+    );
+    assert_eq!(
+        format!("{:?}", actual.anonymous_nominals()),
+        format!("{:?}", expected.anonymous_nominals()),
+        "{label}: anonymous nominal semantics differ",
+    );
 }
 
 pub(crate) fn test_cfg(source: &str) -> MultiErrorResult<CompileState> {
@@ -41,7 +93,7 @@ pub(crate) fn test_codegen_state(state: &CompileState, target: Target) -> MultiE
     };
     let mut session = CompilerSession::new();
     publish_test_snapshot(&mut session, &state.snapshot)?;
-    let semantic = session.rooted_semantic(&options)?;
+    let semantic = session.rooted_cfg(&options)?;
     session
         .codegen_units(
             &semantic,
@@ -99,14 +151,13 @@ pub(crate) fn test_frontend_snapshot(
     options: &CompileOptions,
 ) -> MultiErrorResult<(
     std::sync::Arc<CanonicalRirOutput>,
-    std::sync::Arc<crate::session::RootedSemanticOutput>,
+    crate::session::RootedCfgOutput,
     CompilerSessionWork,
 )> {
     let mut session = CompilerSession::new();
     publish_test_snapshot(&mut session, snapshot)?;
-    let _rir = session.canonical_rir()?;
-    let semantic = session.rooted_semantic(options)?;
-    let rir = semantic.rir_owner().clone();
+    let rir = session.canonical_rir()?;
+    let semantic = session.rooted_cfg(options)?;
     let work = session.work().clone();
     drop(session);
     Ok((rir, semantic, work))

--- a/crates/rue-compiler/src/toolchain_module_demand.rs
+++ b/crates/rue-compiler/src/toolchain_module_demand.rs
@@ -17,7 +17,7 @@
 //! review.
 //!
 //! Instead the demand is a *distinct typed* [`TrustedToolchainModuleDemand`],
-//! raised by the rooted semantic attempt (not by any import occurrence) when a
+//! raised by the rooted body-closure attempt (not by any import occurrence) when a
 //! reached body needs a trusted module absent from the current revision, and
 //! satisfied by the host source-loading layer that owns filesystem access. The
 //! demand:
@@ -189,7 +189,7 @@ impl RetainedCharge for BodyToolchainDemand {
     }
 }
 
-/// The park raised by the rooted semantic attempt when a reached body demands a
+/// The park raised by the rooted body-closure attempt when a reached body demands a
 /// trusted toolchain module absent from the current revision (RUE-1112).
 ///
 /// It carries the sorted, deduplicated absent modules and the stable requester

--- a/crates/rue-compiler/src/unstable.rs
+++ b/crates/rue-compiler/src/unstable.rs
@@ -1015,7 +1015,7 @@ mod codegen_unit_tests {
                 file_order: &order,
             })
             .unwrap();
-        let semantic = first_emit.rooted_semantic(&options).unwrap();
+        let semantic = first_emit.rooted_cfg(&options).unwrap();
         first_emit
             .codegen_products(
                 &semantic,
@@ -1034,7 +1034,7 @@ mod codegen_unit_tests {
 
         let mut first_link = crate::CompilerSession::new();
         crate::publish_test_snapshot(&mut first_link, &snapshot).unwrap();
-        let semantic = first_link.rooted_semantic(&options).unwrap();
+        let semantic = first_link.rooted_cfg(&options).unwrap();
         first_link
             .codegen_products(
                 &semantic,
@@ -1061,7 +1061,7 @@ mod codegen_unit_tests {
         let options = crate::CompileOptions::default();
         let mut session = crate::CompilerSession::new();
         crate::publish_test_snapshot(&mut session, &snapshot).unwrap();
-        let semantic = session.rooted_semantic(&options).unwrap();
+        let semantic = session.rooted_cfg(&options).unwrap();
         let errors = crate::codegen_query::with_test_codegen_failure_injection(|| {
             session
                 .codegen_products(
@@ -1143,7 +1143,7 @@ mod codegen_unit_tests {
         let options = crate::CompileOptions::default();
         let mut session = crate::CompilerSession::new();
         crate::publish_test_snapshot(&mut session, &first).unwrap();
-        let semantic = session.rooted_semantic(&options).unwrap();
+        let semantic = session.rooted_cfg(&options).unwrap();
         let before = session
             .codegen_products(
                 &semantic,
@@ -1164,7 +1164,7 @@ mod codegen_unit_tests {
             .code
             .clone();
         crate::publish_test_snapshot(&mut session, &second).unwrap();
-        let semantic = session.rooted_semantic(&options).unwrap();
+        let semantic = session.rooted_cfg(&options).unwrap();
         let after = session
             .codegen_products(
                 &semantic,
@@ -1216,7 +1216,7 @@ mod codegen_unit_tests {
 
         let mut session = crate::CompilerSession::new();
         session.update(&source(plain)).into_result().unwrap();
-        let errors = session.rooted_semantic(&options).unwrap_err();
+        let errors = session.rooted_cfg(&options).unwrap_err();
         assert!(
             errors.iter().any(|error| matches!(
                 &error.kind,
@@ -1227,11 +1227,11 @@ mod codegen_unit_tests {
 
         session.update(&source(accessor)).into_result().unwrap();
         session
-            .rooted_semantic(&options)
+            .rooted_cfg(&options)
             .expect("an accessor link is a legal projection");
 
         session.update(&source(plain)).into_result().unwrap();
-        let errors = session.rooted_semantic(&options).unwrap_err();
+        let errors = session.rooted_cfg(&options).unwrap_err();
         assert!(
             errors.iter().any(|error| matches!(
                 &error.kind,
@@ -1259,7 +1259,7 @@ mod codegen_unit_tests {
         let mut session = crate::CompilerSession::new();
 
         session.update(&source(7)).into_result().unwrap();
-        let semantic = session.rooted_semantic(&options).unwrap();
+        let semantic = session.rooted_cfg(&options).unwrap();
         let cold = session
             .codegen_products(
                 &semantic,
@@ -1313,7 +1313,7 @@ mod codegen_unit_tests {
         assert!(session.rooted_cfg_executions().iter().all(|(identity, _)| {
             !matches!(identity, crate::FunctionInstanceKey::Definition(definition) if definition.name() == "value")
         }));
-        let semantic = session.rooted_semantic(&options).unwrap();
+        let semantic = session.rooted_cfg(&options).unwrap();
         let warm = session
             .codegen_products(
                 &semantic,
@@ -1323,7 +1323,7 @@ mod codegen_unit_tests {
             .unwrap();
         let mut fresh = crate::CompilerSession::new();
         fresh.update(&source(8)).into_result().unwrap();
-        let semantic = fresh.rooted_semantic(&options).unwrap();
+        let semantic = fresh.rooted_cfg(&options).unwrap();
         let fresh = fresh
             .codegen_products(
                 &semantic,
@@ -1387,7 +1387,7 @@ mod codegen_unit_tests {
             };
             let mut session = crate::CompilerSession::new();
             crate::publish_test_snapshot(&mut session, &snapshot).unwrap();
-            let semantic = session.rooted_semantic(&options).unwrap();
+            let semantic = session.rooted_cfg(&options).unwrap();
             let first = session
                 .codegen_products(
                     &semantic,
@@ -1448,7 +1448,7 @@ mod codegen_unit_tests {
         let run = |workers| {
             let mut session = crate::CompilerSession::with_query_concurrency(workers);
             crate::publish_test_snapshot(&mut session, &snapshot).unwrap();
-            let semantic = session.rooted_semantic(&options).unwrap();
+            let semantic = session.rooted_cfg(&options).unwrap();
             let products = session
                 .codegen_products(
                     &semantic,
@@ -1482,7 +1482,7 @@ mod codegen_unit_tests {
         let options = crate::CompileOptions::default();
         let mut session = crate::CompilerSession::new();
         crate::publish_test_snapshot(&mut session, &first).unwrap();
-        let semantic = session.rooted_semantic(&options).unwrap();
+        let semantic = session.rooted_cfg(&options).unwrap();
         let consume_name = semantic
             .functions()
             .iter()
@@ -1510,7 +1510,7 @@ mod codegen_unit_tests {
             })
             .unwrap();
         crate::publish_test_snapshot(&mut session, &second).unwrap();
-        let semantic = session.rooted_semantic(&options).unwrap();
+        let semantic = session.rooted_cfg(&options).unwrap();
         let after = session
             .codegen_products(
                 &semantic,

--- a/docs/designs/0061-supported-compiler-facade.md
+++ b/docs/designs/0061-supported-compiler-facade.md
@@ -9,7 +9,7 @@ accepted: 2026-07-17
 implemented: 2026-07-18
 spec-sections: []
 superseded-by:
-relates: ["RUE-865", "RUE-866", "RUE-867", "RUE-868", "RUE-869", "RUE-439", "RUE-749", "ADR-0053", "ADR-0058"]
+relates: ["RUE-865", "RUE-866", "RUE-867", "RUE-868", "RUE-869", "RUE-1477", "RUE-1480", "RUE-439", "RUE-749", "ADR-0053", "ADR-0058"]
 ---
 
 # ADR-0061: Supported compiler facade and immutable artifact views
@@ -19,6 +19,14 @@ relates: ["RUE-865", "RUE-866", "RUE-867", "RUE-868", "RUE-869", "RUE-439", "RUE
 Accepted under RUE-865 on 2026-07-17 and implemented by RUE-866 through RUE-869
 on 2026-07-18. This is an API and ownership decision; it does not change Rue
 language semantics.
+
+Amended on 2026-08-12 by RUE-1477 and RUE-1480: the semantic and CFG view
+portion of this decision is superseded. `CompilerSession::semantic`,
+`SemanticView`, `FunctionView`, `CfgView`, `TypeView`, and their companion
+views have been deleted. Compiler consumers and in-tree test/tooling consumers
+project from the canonical rooted body/CFG query graph; no stable or test-only
+whole-program semantic facade may assemble a peer artifact. The historical
+inventory below records the original decision rather than the current API.
 
 ## Summary
 

--- a/scripts/validate-type-architecture.py
+++ b/scripts/validate-type-architecture.py
@@ -106,7 +106,6 @@ PUBLIC_TYPE_DECLARATION_ALLOWLIST = {
     ("rue-air", "sema/output.rs", "BuiltinTypeCallHead"): "dependency metadata",
     ("rue-air", "sema/output.rs", "DeclarationBuiltinTypeCallHeadDependencyEvent"): "dependency metadata",
     ("rue-compiler", "bound_definitions.rs", "StableNamedTypeKey"): "stable definition lookup key",
-    ("rue-compiler", "artifact_views.rs", "TypeView"): "owner-bound stable compiler facade view",
     ("rue-compiler", "durable_semantics.rs", "DurableType"): "cross-epoch durable type schema",
     ("rue-compiler", "durable_semantics.rs", "DurableAnonymousMethodType"): "cross-epoch durable anonymous-method type schema",
     ("rue-compiler", "source_identity.rs", "ModuleId"): "stable logical source-module identity",


### PR DESCRIPTION
## Summary

- delete the test-only `RootedSemanticOutput`, `rooted_semantic`, and semantic projection assembly
- migrate compiler, scaling, backend, emit, and nominal-oracle tests to the actual rooted CFG and canonical RIR artifacts
- compare canonical rooted CFG values directly, without a replacement wrapper or parity aggregate
- forbid the removed semantic/CFG facade vocabulary from production source and amend ADR-0061 to record the superseded design
- remove the stale `TypeView` architecture allowance and test-only linker input records that existed only for the facade

## Why

Production already has one canonical rooted body/CFG query graph. The remaining test facade silently performed extra RIR/merge queries and reconstructed a whole-program semantic-shaped value, so tests were not exercising exactly the architecture they purported to validate.

## Validation

- `scripts/rue fmt`
- `scripts/rue unit compiler` (844 passed, 6 ignored)
- `scripts/rue build`
- `python3 scripts/validate-type-architecture.py`

Fixes RUE-1480.

Refs RUE-1477.