### PR TITLE
Correct the ADR-0071 accepting author's name

### DIFF
--- a/docs/designs/0071-release-quality-compiler-performance-contract.md
+++ b/docs/designs/0071-release-quality-compiler-performance-contract.md
@@ -16,7 +16,7 @@ relates: ["RUE-1470", "RUE-1478", "ADR-0063", "ADR-0067", "ADR-0068"]
 
 ## Status
 
-Accepted by Steve Klabnik and Dorian Taylor on 2026-08-12. This ADR sets a
+Accepted by Steve Klabnik and Dorian Scheidt on 2026-08-12. This ADR sets a
 product target and the rules for pursuing it. It does not replace the compiler
 architecture in ADR-0063 or the measurement protocols in ADR-0067 and
 ADR-0068. It turns their implemented mechanisms into an explicit performance


### PR DESCRIPTION
ADR-0071's Status section credited acceptance to "Dorian Taylor". The correct
surname is Scheidt, as used elsewhere in the repository (for example
`website/content/blog/welcome-dorian.md`).

This is a one-word documentation fix; no behavior changes.

I also swept the repository for other occurrences of the incorrect name — a
case-insensitive search for both "Dorian Taylor" and the bare surname "Taylor"
turns up only this single line, so nothing else needed correcting. The other
`Dorian` references (`AGENTS.md`, `docs/process/fork-workflow.md`,
`docs/designs/0064-c-ffi.md`, `docs/designs/0042-std-availability-model.md`)
use the first name alone and are unaffected.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Hpw7SwhRKF4kiymA8irk5u)_