### PR TITLE
RUE-1478: publish Lattice performance target

### DIFF
--- a/.github/workflows/performance-calibration.yml
+++ b/.github/workflows/performance-calibration.yml
@@ -21,6 +21,10 @@ on:
         description: Calibration runs per platform
         required: false
         default: "12"
+      epoch:
+        description: Manifest epoch to calibrate on every platform
+        required: false
+        default: "3"
 
 # Read-only. Calibration must not be able to publish.
 permissions:
@@ -64,7 +68,8 @@ jobs:
 
       - name: Build the compiler and the runner
         run: |
-          ./buck2 build //crates/rue:rue //crates/rue-bench:rue-bench
+          ./buck2 build //crates/rue:rue //crates/rue-bench:rue-bench \
+            --target-platforms //platforms:release
 
       - name: Run the calibration repetitions
         env:
@@ -76,8 +81,9 @@ jobs:
         run: |
           set -euo pipefail
           mkdir -p calibration-runs
-          RUE="$(scripts/rue-bin)"
-          BENCH="$(./buck2 build //crates/rue-bench:rue-bench --show-simple-output 2>/dev/null | tail -1)"
+          RUE="$(scripts/rue-bin --target-platforms //platforms:release)"
+          BENCH="$(./buck2 build //crates/rue-bench:rue-bench \
+            --target-platforms //platforms:release --show-simple-output 2>/dev/null | tail -1)"
           COMMIT="${{ github.sha }}"
 
           for index in $(seq 1 "${{ inputs.repetitions }}"); do
@@ -89,7 +95,7 @@ jobs:
             "$BENCH" \
               --manifest performance/manifest.toml \
               --platform "${{ matrix.platform }}" \
-              --epoch 1 \
+              --epoch "${{ inputs.epoch }}" \
               --compiler "$RUE" \
               --commit "$COMMIT" \
               --repo-root . \
@@ -105,7 +111,8 @@ jobs:
 
       - name: Analyse
         run: |
-          BENCH="$(./buck2 build //crates/rue-bench:rue-bench --show-simple-output 2>/dev/null | tail -1)"
+          BENCH="$(./buck2 build //crates/rue-bench:rue-bench \
+            --target-platforms //platforms:release --show-simple-output 2>/dev/null | tail -1)"
           "$BENCH" calibrate \
             --runs calibration-runs \
             --report "calibration-${{ matrix.platform }}.md"

--- a/.github/workflows/performance-collect.yml
+++ b/.github/workflows/performance-collect.yml
@@ -67,7 +67,9 @@ jobs:
         uses: facebook/install-dotslash@v2
 
       - name: Build the compiler and the runner
-        run: ./buck2 build //crates/rue:rue //crates/rue-bench:rue-bench
+        run: |
+          ./buck2 build //crates/rue:rue //crates/rue-bench:rue-bench \
+            --target-platforms //platforms:release
 
       - name: Measure
         env:
@@ -78,8 +80,9 @@ jobs:
         run: |
           set -euo pipefail
           mkdir -p collected
-          RUE="$(scripts/rue-bin)"
-          BENCH="$(./buck2 build //crates/rue-bench:rue-bench --show-simple-output 2>/dev/null | tail -1)"
+          RUE="$(scripts/rue-bin --target-platforms //platforms:release)"
+          BENCH="$(./buck2 build //crates/rue-bench:rue-bench \
+            --target-platforms //platforms:release --show-simple-output 2>/dev/null | tail -1)"
 
           # Exit 3 is "written but not appendable". The evidence is worth
           # keeping either way, so the status is recorded here and judged after

--- a/crates/rue-bench/src/derive.rs
+++ b/crates/rue-bench/src/derive.rs
@@ -84,6 +84,10 @@ pub struct EpochData {
     /// The flagging rule this epoch pins, so the page can state the bound it
     /// is reporting against rather than describing it vaguely.
     pub flagging: FlaggingRule,
+    /// Absolute process-time targets whose gate this epoch adjudicates.
+    ///
+    /// Kept per epoch because hosted platform clocks are not interchangeable.
+    pub process_elapsed_targets: BTreeMap<String, ProcessElapsedTargetData>,
     /// Standard-library changes within this epoch.
     ///
     /// Deliberately *not* advisory, unlike an environment annotation. `std` is
@@ -100,6 +104,13 @@ pub struct FlaggingRule {
     pub k: f64,
     /// How many prior runs form the trailing window.
     pub window: u32,
+}
+
+/// One reviewed external latency target rendered by the dashboard.
+#[derive(Debug, Serialize)]
+pub struct ProcessElapsedTargetData {
+    pub process_elapsed_ns: u64,
+    pub reference: String,
 }
 
 /// A point at which the standard library changed underneath a series.
@@ -482,6 +493,19 @@ fn derive_epoch(
             k: epoch.flagging.k,
             window: epoch.flagging.window,
         },
+        process_elapsed_targets: epoch
+            .process_elapsed_targets
+            .iter()
+            .map(|(workload, target)| {
+                (
+                    workload.clone(),
+                    ProcessElapsedTargetData {
+                        process_elapsed_ns: target.process_elapsed_ns,
+                        reference: target.reference.clone(),
+                    },
+                )
+            })
+            .collect(),
         stdlib_annotations,
     }
 }
@@ -858,6 +882,26 @@ window = 3
         let flagging = &data.platforms[0].epochs[0].flagging;
         assert_eq!(flagging.window, 3);
         assert!((flagging.k - 2.0).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn the_epoch_publishes_only_its_own_external_latency_targets() {
+        let text = MANIFEST.replace(
+            "[epoch.flagging]",
+            "[epoch.process_elapsed_targets.startup]\n\
+             process_elapsed_ns = 250000000\n\
+             reference = \"ADR-0071\"\n\n\
+             [epoch.flagging]",
+        );
+        let manifest = Manifest::parse(&text).expect("target manifest");
+        let data = derive(
+            &manifest,
+            &[run_at("a", "2026-07-28T00:00:00Z", [100, 100, 100])],
+        );
+        let targets = &data.platforms[0].epochs[0].process_elapsed_targets;
+        assert_eq!(targets.len(), 1);
+        assert_eq!(targets["startup"].process_elapsed_ns, 250_000_000);
+        assert_eq!(targets["startup"].reference, "ADR-0071");
     }
 
     #[test]

--- a/crates/rue-perf-schema/src/lib.rs
+++ b/crates/rue-perf-schema/src/lib.rs
@@ -54,7 +54,7 @@ pub use incremental::{
 };
 pub use manifest::{
     Baseline, EnvironmentPolicy, FlaggingPolicy, Manifest, ManifestError, PlatformEpoch,
-    SamplingPolicy, SuiteRevision, Workload,
+    ProcessElapsedTarget, SamplingPolicy, SuiteRevision, Workload,
 };
 pub use run::{
     Band, EnvironmentFingerprint, FailureRecord, Invocation, Phase, PhaseAccounting, ResolvedPins,

--- a/crates/rue-perf-schema/src/manifest.rs
+++ b/crates/rue-perf-schema/src/manifest.rs
@@ -111,6 +111,21 @@ pub struct SamplingPolicy {
     pub batch_size: u32,
 }
 
+/// An externally observed fresh-process latency target for one workload.
+///
+/// Targets live on platform epochs rather than suite workloads because an
+/// absolute duration is meaningful only in its declared runner regime. The
+/// dashboard may show the same workload on other platforms, but it must not
+/// imply that their clocks adjudicate this target.
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ProcessElapsedTarget {
+    /// Maximum process-spawn-through-exit duration, in nanoseconds.
+    pub process_elapsed_ns: u64,
+    /// The reviewed decision that established this target.
+    pub reference: String,
+}
+
 /// When a workload's movement counts as movement.
 ///
 /// A workload is flagged only when the difference between its current median
@@ -181,6 +196,13 @@ pub struct PlatformEpoch {
     pub environment: EnvironmentPolicy,
     /// Sampling policy per workload.
     pub sampling: BTreeMap<String, SamplingPolicy>,
+    /// Absolute process-time targets adjudicated by this platform epoch.
+    ///
+    /// A workload omitted here has no absolute target in this regime. This is
+    /// intentionally sparse: copying a reference-platform target onto every
+    /// directional platform would turn unlike clocks into an apparent gate.
+    #[serde(default)]
+    pub process_elapsed_targets: BTreeMap<String, ProcessElapsedTarget>,
     /// The regression-flagging rule.
     pub flagging: FlaggingPolicy,
     /// The headline baseline, once a complete valid run has established one.
@@ -275,6 +297,24 @@ pub enum ManifestError {
         /// The workload whose policy is empty.
         workload: String,
     },
+    /// An epoch declares an absolute target for a workload outside its suite.
+    UnknownTargetWorkload {
+        /// The platform carrying the target.
+        platform: String,
+        /// The offending epoch.
+        epoch: u32,
+        /// The undeclared workload.
+        workload: String,
+    },
+    /// An absolute target has no positive duration or reviewed reference.
+    InvalidProcessElapsedTarget {
+        /// The platform carrying the target.
+        platform: String,
+        /// The offending epoch.
+        epoch: u32,
+        /// The workload whose target is invalid.
+        workload: String,
+    },
     /// A platform declares more than one collection epoch.
     ///
     /// Collection measures one epoch per platform. Two would make "the epoch
@@ -334,7 +374,25 @@ impl std::fmt::Display for ManifestError {
             } => write!(
                 f,
                 "epoch {epoch} on {platform} samples workload {workload:?} zero times or in \
-                 zero-sized batches"
+                zero-sized batches"
+            ),
+            ManifestError::UnknownTargetWorkload {
+                platform,
+                epoch,
+                workload,
+            } => write!(
+                f,
+                "epoch {epoch} on {platform} declares a process target for undeclared workload \
+                 {workload:?}"
+            ),
+            ManifestError::InvalidProcessElapsedTarget {
+                platform,
+                epoch,
+                workload,
+            } => write!(
+                f,
+                "epoch {epoch} on {platform} declares an invalid process target for workload \
+                 {workload:?}"
             ),
             ManifestError::DuplicateCollectionEpoch {
                 platform,
@@ -458,6 +516,22 @@ impl Manifest {
             for (workload, policy) in &epoch.sampling {
                 if policy.samples == 0 || policy.batch_size == 0 {
                     return Err(ManifestError::EmptySamplingPolicy {
+                        platform: epoch.platform.clone(),
+                        epoch: epoch.id,
+                        workload: workload.clone(),
+                    });
+                }
+            }
+            for (workload, target) in &epoch.process_elapsed_targets {
+                if !declared.contains(&workload.as_str()) {
+                    return Err(ManifestError::UnknownTargetWorkload {
+                        platform: epoch.platform.clone(),
+                        epoch: epoch.id,
+                        workload: workload.clone(),
+                    });
+                }
+                if target.process_elapsed_ns == 0 || target.reference.trim().is_empty() {
+                    return Err(ManifestError::InvalidProcessElapsedTarget {
                         platform: epoch.platform.clone(),
                         epoch: epoch.id,
                         workload: workload.clone(),
@@ -617,6 +691,75 @@ window = 10
             .expect("baseline is present");
         assert_eq!(baseline.commit, "abc123");
         assert_eq!(baseline.run, "deadbeef");
+    }
+
+    #[test]
+    fn a_platform_epoch_may_publish_an_external_latency_target() {
+        let text = format!(
+            "{SUITE}{}",
+            EPOCH.replace(
+                "[epoch.flagging]",
+                "[epoch.process_elapsed_targets.caldera]\n\
+                 process_elapsed_ns = 250000000\n\
+                 reference = \"ADR-0071\"\n\n\
+                 [epoch.flagging]"
+            )
+        );
+        let manifest = Manifest::parse(&text).expect("target belongs to the platform epoch");
+        let target = &manifest
+            .epoch("x86_64-linux", 1)
+            .expect("epoch")
+            .process_elapsed_targets["caldera"];
+        assert_eq!(target.process_elapsed_ns, 250_000_000);
+        assert_eq!(target.reference, "ADR-0071");
+    }
+
+    #[test]
+    fn a_target_for_an_undeclared_workload_is_rejected() {
+        let text = format!(
+            "{SUITE}{}",
+            EPOCH.replace(
+                "[epoch.flagging]",
+                "[epoch.process_elapsed_targets.unknown]\n\
+                 process_elapsed_ns = 250000000\n\
+                 reference = \"ADR-0071\"\n\n\
+                 [epoch.flagging]"
+            )
+        );
+        assert_eq!(
+            Manifest::parse(&text).unwrap_err(),
+            ManifestError::UnknownTargetWorkload {
+                platform: "x86_64-linux".to_string(),
+                epoch: 1,
+                workload: "unknown".to_string(),
+            }
+        );
+    }
+
+    #[test]
+    fn an_empty_or_zero_target_is_rejected() {
+        for declaration in [
+            "process_elapsed_ns = 0\nreference = \"ADR-0071\"",
+            "process_elapsed_ns = 250000000\nreference = \"   \"",
+        ] {
+            let text = format!(
+                "{SUITE}{}",
+                EPOCH.replace(
+                    "[epoch.flagging]",
+                    &format!(
+                        "[epoch.process_elapsed_targets.caldera]\n{declaration}\n\n[epoch.flagging]"
+                    )
+                )
+            );
+            assert_eq!(
+                Manifest::parse(&text).unwrap_err(),
+                ManifestError::InvalidProcessElapsedTarget {
+                    platform: "x86_64-linux".to_string(),
+                    epoch: 1,
+                    workload: "caldera".to_string(),
+                }
+            );
+        }
     }
 
     #[test]

--- a/performance/manifest.toml
+++ b/performance/manifest.toml
@@ -17,11 +17,9 @@
 # the *Rust* toolchain the compiler is built with — build environment, not
 # product. See ADR-0067, "The product boundary".
 #
-# STATUS: the `local` epoch below exists so the runner can be exercised during
-# development. Its sampling counts are placeholders, not calibrated values, and
-# it declares no baseline. The published epochs — with counts, batching factors,
-# and the flagging multiplier established by the Phase 4 noise calibration —
-# arrive with suite revision 1's declaration in RUE-1188.
+# The `local` epochs below let the runner exercise each suite during development;
+# their counts are diagnostic rather than publication policy. Hosted collection
+# uses the explicitly marked per-platform epochs near the end of this file.
 
 [[suite]]
 revision = 1
@@ -32,6 +30,24 @@ protocol_version = 1
 id = "startup"
 source = "performance/workloads/startup/main.rue"
 question = "What does a minimal fresh compilation cost end to end?"
+
+# Suite revision 2 freezes ADR-0071's release-quality reference workload. The
+# startup probe stays byte-identical so its history continues across the epoch
+# boundary; Lattice joins as a separate, independently visible series.
+[[suite]]
+revision = 2
+timing_schema_version = 1
+protocol_version = 1
+
+[[suite.workloads]]
+id = "startup"
+source = "performance/workloads/startup/main.rue"
+question = "What does a minimal fresh compilation cost end to end?"
+
+[[suite.workloads]]
+id = "lattice"
+source = "performance/workloads/lattice/main.rue"
+question = "How quickly does Rue produce optimized native output for the frozen ADR-0071 reference program?"
 
 # A development epoch for local runs. Not a collection target: its environment
 # policy admits only `local`, so a hosted runner cannot append to it.
@@ -53,6 +69,36 @@ runner_image = "local"
 [epoch.sampling.startup]
 samples = 3
 batch_size = 5
+
+[epoch.flagging]
+k = 3.0
+window = 10
+
+# Local development implementation of suite revision 2. This is diagnostic,
+# not a collection target and not the ADR-0071 reference regime.
+[[epoch]]
+id = 2
+platform = "local"
+suite_revision = 2
+target = "x86_64-unknown-linux-gnu"
+args = ["-O3", "-j1"]
+toolchain_hash = "30f50af0ac7111ffb25d5ef1a423642eaeb2e381931a57583e190a84634ee3fe"
+
+[epoch.workload_source_hashes]
+startup = "87869467f94e34b8df41900bda44546b610296077c14fab6defda8939fe22be7"
+lattice = "1c5b2fffc71a9edfd0c5212262bc7bb9c5694c74c78ab15f7b540e04a62a7651"
+
+[epoch.environment]
+runner_label = "local"
+runner_image = "local"
+
+[epoch.sampling.startup]
+samples = 3
+batch_size = 5
+
+[epoch.sampling.lattice]
+samples = 3
+batch_size = 1
 
 [epoch.flagging]
 k = 3.0
@@ -146,7 +192,7 @@ k = 3.0
 window = 5
 
 # ---------------------------------------------------------------------------
-# Collection epochs (ADR-0067 Phase 5, RUE-1188).
+# Suite revision 1 collection calibration (ADR-0067 Phase 5, RUE-1188).
 #
 # These are the real ones. Their pins resolve, so a run that does not match the
 # tree it claims to have measured cannot enter a series, and their sampling and
@@ -188,9 +234,101 @@ window = 5
 # is the calibrated recommendation rather than the uncapped figure; the gap is
 # 1.15% achieved uncertainty against the 1.00% target.
 
+# Suite revision 2 calibration epochs (ADR-0071 Phase 1, RUE-1478).
+#
+# These use deliberately unresolved pins and are not collection targets. The
+# calibration workflow accepts the resulting non-appendable records as raw
+# evidence and has no permission to publish them. Three independent Lattice
+# samples per repetition are enough to estimate dispersion without assuming the
+# result that calibration exists to derive.
+
+[[epoch]]
+id = 3
+platform = "x86_64-linux"
+suite_revision = 2
+target = "x86_64-unknown-linux-gnu"
+args = ["-O3", "-j1"]
+toolchain_hash = "calibration-epoch-pins-are-placeholders"
+
+[epoch.workload_source_hashes]
+startup = "calibration-epoch-pins-are-placeholders"
+lattice = "calibration-epoch-pins-are-placeholders"
+
+[epoch.environment]
+runner_label = "github-hosted"
+runner_image = "ubuntu-24.04"
+
+[epoch.sampling.startup]
+samples = 9
+batch_size = 5
+
+[epoch.sampling.lattice]
+samples = 3
+batch_size = 1
+
+[epoch.flagging]
+k = 3.0
+window = 5
+
+[[epoch]]
+id = 3
+platform = "aarch64-linux"
+suite_revision = 2
+target = "aarch64-unknown-linux-gnu"
+args = ["-O3", "-j1"]
+toolchain_hash = "calibration-epoch-pins-are-placeholders"
+
+[epoch.workload_source_hashes]
+startup = "calibration-epoch-pins-are-placeholders"
+lattice = "calibration-epoch-pins-are-placeholders"
+
+[epoch.environment]
+runner_label = "github-hosted"
+runner_image = "ubuntu-24.04"
+
+[epoch.sampling.startup]
+samples = 9
+batch_size = 5
+
+[epoch.sampling.lattice]
+samples = 3
+batch_size = 1
+
+[epoch.flagging]
+k = 3.0
+window = 5
+
+[[epoch]]
+id = 3
+platform = "aarch64-macos"
+suite_revision = 2
+target = "aarch64-apple-darwin"
+args = ["-O3", "-j1"]
+toolchain_hash = "calibration-epoch-pins-are-placeholders"
+
+[epoch.workload_source_hashes]
+startup = "calibration-epoch-pins-are-placeholders"
+lattice = "calibration-epoch-pins-are-placeholders"
+
+[epoch.environment]
+runner_label = "github-hosted"
+runner_image = "macos-15"
+
+[epoch.sampling.startup]
+samples = 9
+batch_size = 5
+
+[epoch.sampling.lattice]
+samples = 3
+batch_size = 1
+
+[epoch.flagging]
+k = 3.0
+window = 5
+
 [[epoch]]
 id = 2
-collection = true
+collection = false
 platform = "x86_64-linux"
 suite_revision = 1
 target = "x86_64-unknown-linux-gnu"
@@ -221,7 +359,7 @@ run = "4ae3eb4cf1e47277c30ae6c3002b6c84c651e35634424e874e2cca8219b25973"
 
 [[epoch]]
 id = 2
-collection = true
+collection = false
 platform = "aarch64-linux"
 suite_revision = 1
 target = "aarch64-unknown-linux-gnu"
@@ -250,7 +388,7 @@ run = "b0bbb8dd1bbf4b617da6c9c642218ce8435e1f250fea060e5baf307555e8b9ad"
 
 [[epoch]]
 id = 2
-collection = true
+collection = false
 platform = "aarch64-macos"
 suite_revision = 1
 target = "aarch64-apple-darwin"
@@ -279,3 +417,115 @@ window = 10
 [epoch.baseline]
 commit = "31ff07f6bac131723f60c2a18af5505a8b442320"
 run = "ff0a3ab928b8e2e601604912404b9ed4b8140a27a2204300d5917143f533574b"
+
+# ---------------------------------------------------------------------------
+# Suite revision 2 collection epochs (ADR-0071 Phase 1, RUE-1478).
+#
+# Sampling and flagging come from hosted calibration run 31654232615 at commit
+# 5fadcc720880432c280df6eaf0845c94655cb372 (12 repetitions per platform).
+# Lattice's observed median and relative MAD were:
+#
+# | platform      | median     | rel. MAD | samples | collection work |
+# | ------------- | ---------- | -------- | ------- | --------------- |
+# | x86_64-linux  | 2647.03 ms |    0.78% |       3 |          ~8.6 s |
+# | aarch64-linux | 2920.82 ms |    0.85% |       3 |          ~9.0 s |
+# | aarch64-macos | 2666.23 ms |    6.41% |      99 |          ~4.5 m |
+#
+# `collection work` includes the calibrated startup sampling. macOS reaches the
+# calibrator's 99-sample ceiling for both workloads; the cost is accepted so a
+# noisy hosted clock cannot turn compiler movement into dashboard fiction.
+#
+# The absolute 250 ms outcome belongs only to the x86_64-linux reference epoch.
+# Linux ARM64 and macOS remain directional series: copying the same number onto
+# unlike hosted clocks would make the dashboard claim a gate they do not own.
+
+[[epoch]]
+id = 4
+collection = true
+platform = "x86_64-linux"
+suite_revision = 2
+target = "x86_64-unknown-linux-gnu"
+args = ["-O3", "-j1"]
+toolchain_hash = "30f50af0ac7111ffb25d5ef1a423642eaeb2e381931a57583e190a84634ee3fe"
+
+[epoch.workload_source_hashes]
+startup = "87869467f94e34b8df41900bda44546b610296077c14fab6defda8939fe22be7"
+lattice = "1c5b2fffc71a9edfd0c5212262bc7bb9c5694c74c78ab15f7b540e04a62a7651"
+
+[epoch.environment]
+runner_label = "github-hosted"
+runner_image = "ubuntu-24.04"
+
+[epoch.sampling.startup]
+samples = 12
+batch_size = 6
+
+[epoch.sampling.lattice]
+samples = 3
+batch_size = 1
+
+[epoch.process_elapsed_targets.lattice]
+process_elapsed_ns = 250000000
+reference = "ADR-0071"
+
+[epoch.flagging]
+k = 6.0
+window = 5
+
+[[epoch]]
+id = 4
+collection = true
+platform = "aarch64-linux"
+suite_revision = 2
+target = "aarch64-unknown-linux-gnu"
+args = ["-O3", "-j1"]
+toolchain_hash = "30f50af0ac7111ffb25d5ef1a423642eaeb2e381931a57583e190a84634ee3fe"
+
+[epoch.workload_source_hashes]
+startup = "87869467f94e34b8df41900bda44546b610296077c14fab6defda8939fe22be7"
+lattice = "1c5b2fffc71a9edfd0c5212262bc7bb9c5694c74c78ab15f7b540e04a62a7651"
+
+[epoch.environment]
+runner_label = "github-hosted"
+runner_image = "ubuntu-24.04"
+
+[epoch.sampling.startup]
+samples = 5
+batch_size = 6
+
+[epoch.sampling.lattice]
+samples = 3
+batch_size = 1
+
+[epoch.flagging]
+k = 5.0
+window = 3
+
+[[epoch]]
+id = 4
+collection = true
+platform = "aarch64-macos"
+suite_revision = 2
+target = "aarch64-apple-darwin"
+args = ["-O3", "-j1"]
+toolchain_hash = "30f50af0ac7111ffb25d5ef1a423642eaeb2e381931a57583e190a84634ee3fe"
+
+[epoch.workload_source_hashes]
+startup = "87869467f94e34b8df41900bda44546b610296077c14fab6defda8939fe22be7"
+lattice = "1c5b2fffc71a9edfd0c5212262bc7bb9c5694c74c78ab15f7b540e04a62a7651"
+
+[epoch.environment]
+runner_label = "github-hosted"
+runner_image = "macos-15"
+
+[epoch.sampling.startup]
+samples = 99
+batch_size = 8
+
+[epoch.sampling.lattice]
+samples = 99
+batch_size = 1
+
+[epoch.flagging]
+k = 4.0
+window = 5

--- a/performance/workloads/lattice/README.md
+++ b/performance/workloads/lattice/README.md
@@ -1,0 +1,15 @@
+# Frozen Lattice compiler-performance workload
+
+This directory freezes the Rue sources from `examples/lattice` at Rue commit
+`60ca461636bdb0be8be22191c77dd05386bafc37`. It is the single Lattice fixture
+used by ADR-0071's release-quality compiler target and the public performance
+dashboard.
+
+Do not update this copy when the pedagogical example changes. A deliberate
+fixture change requires a new performance-suite revision and new platform
+epochs so the old and new programs are never presented as one continuous
+series.
+
+Only the transitive `.rue` source closure participates in the workload identity.
+The example's README and runtime input files are intentionally absent because
+the compiler does not read them during a source-to-native build.

--- a/performance/workloads/lattice/analysis_cache_coverage.rue
+++ b/performance/workloads/lattice/analysis_cache_coverage.rue
@@ -1,0 +1,133 @@
+// Lattice analysis pass: cacheable work coverage.
+//
+// This pass deliberately walks tasks, pools, dependencies, and bounded task
+// pairs. The four projections expose different compiler and application
+// behavior: field-heavy records, cross-module calls, graph indirection, nested
+// control flow, checked aggregation, and deterministic report generation.
+const std = @import("std");
+const metric = @import("metric.rue");
+const model = @import("model.rue");
+const text = @import("text.rue");
+const StrBuf = std.strbuf.StrBuf;
+
+pub fn TAG() -> u64 { 1006 }
+
+fn pool_for(borrow workflow: model.Workflow, index: u64) -> model.WorkerPool {
+    workflow.pools.get_or(index, model.empty_pool())
+}
+
+fn task_projection(borrow workflow: model.Workflow, index: u64) -> u64 {
+    let task = workflow.tasks.get_or(index, model.empty_task());
+    let _task_id = task.id;
+    let _assigned_pool = pool_for(borrow workflow, task.pool);
+    if task.cacheable { task.duration } else { 0 }
+}
+
+fn edge_projection(borrow workflow: model.Workflow, index: u64) -> u64 {
+    let edge = workflow.edges.get_or(index, model.empty_edge());
+    let before = workflow.tasks.get_or(edge.before, model.empty_task());
+    let after = workflow.tasks.get_or(edge.after, model.empty_task());
+    let _before_id = before.id;
+    let _after_id = after.id;
+    if before.cacheable && after.cacheable { 2 } else { 0 }
+}
+
+fn pool_projection(borrow workflow: model.Workflow, index: u64) -> u64 {
+    let pool = workflow.pools.get_or(index, model.empty_pool());
+    pool.cpu
+}
+
+fn related_pair(borrow workflow: model.Workflow, first: u64, second: u64) -> bool {
+    if first == second { return false; }
+    model.has_edge(borrow workflow, first, second) ||
+        model.has_edge(borrow workflow, second, first) ||
+        workflow.tasks.get_or(first, model.empty_task()).pool ==
+            workflow.tasks.get_or(second, model.empty_task()).pool
+}
+
+fn pair_projection(borrow workflow: model.Workflow, first: u64, second: u64) -> u64 {
+    let left = workflow.tasks.get_or(first, model.empty_task());
+    let right = workflow.tasks.get_or(second, model.empty_task());
+    let distance = if second >= first { second - first } else { first - second };
+    let resource = left.cpu + left.memory + right.cpu + right.memory;
+    let duration = left.duration + right.duration;
+    (distance + 1) * (resource + 1) + duration + 1006
+}
+
+fn observe_tasks(inout result: metric.Metric, borrow workflow: model.Workflow) {
+    let mut i: u64 = 0;
+    while i < workflow.tasks.len() {
+        let value = task_projection(borrow workflow, i);
+        let task = workflow.tasks.get_or(i, model.empty_task());
+        metric.observe(inout result, value, task.priority + 1);
+        metric.warn(inout result, task.duration == 0 || task.cpu == 0 || task.memory == 0);
+        i += 1;
+    }
+}
+
+fn observe_edges(inout result: metric.Metric, borrow workflow: model.Workflow) {
+    let mut i: u64 = 0;
+    while i < workflow.edges.len() {
+        let edge = workflow.edges.get_or(i, model.empty_edge());
+        let value = edge_projection(borrow workflow, i);
+        metric.observe(inout result, value, i + 1);
+        metric.warn(inout result, edge.before >= workflow.tasks.len() || edge.after >= workflow.tasks.len());
+        i += 1;
+    }
+}
+
+fn observe_pools(inout result: metric.Metric, borrow workflow: model.Workflow) {
+    let mut i: u64 = 0;
+    while i < workflow.pools.len() {
+        let value = pool_projection(borrow workflow, i);
+        let pool = workflow.pools.get_or(i, model.empty_pool());
+        metric.observe(inout result, value, pool.slots + 1);
+        metric.warn(inout result, pool.slots == 0 || pool.cpu == 0 || pool.memory == 0);
+        i += 1;
+    }
+}
+
+fn observe_pairs(inout result: metric.Metric, borrow workflow: model.Workflow) -> u64 {
+    let mut pairs: u64 = 0;
+    let mut first: u64 = 0;
+    while first < workflow.tasks.len() {
+        let mut second: u64 = first + 1;
+        while second < workflow.tasks.len() {
+            if related_pair(borrow workflow, first, second) {
+                metric.observe(inout result, pair_projection(borrow workflow, first, second), first + second + 1);
+                pairs += 1;
+            }
+            second += 1;
+        }
+        first += 1;
+    }
+    pairs
+}
+
+pub fn analyze(borrow workflow: model.Workflow) -> metric.Metric {
+    let mut result = metric.new(TAG());
+    observe_tasks(inout result, borrow workflow);
+    observe_edges(inout result, borrow workflow);
+    observe_pools(inout result, borrow workflow);
+    let pairs = observe_pairs(inout result, borrow workflow);
+    metric.warn(inout result, workflow.tasks.len() > 1 && pairs == 0);
+    metric.finish(inout result);
+    result
+}
+
+pub fn verify(borrow workflow: model.Workflow, borrow result: metric.Metric) -> bool {
+    let floor = workflow.tasks.len() + workflow.edges.len() + workflow.pools.len();
+    result.tag == TAG() && result.observations >= floor &&
+        result.even + result.odd == result.observations &&
+        result.zeroes <= result.observations &&
+        (result.observations == 0 || result.minimum <= result.maximum)
+}
+
+pub fn render(borrow workflow: model.Workflow) -> StrBuf {
+    let result = analyze(borrow workflow);
+    let mut out = metric.render("cache_coverage", borrow result);
+    text.append_literal(inout out, "verified=");
+    text.append_bool(inout out, verify(borrow workflow, borrow result));
+    out.push(10);
+    out
+}

--- a/performance/workloads/lattice/analysis_cache_risk.rue
+++ b/performance/workloads/lattice/analysis_cache_risk.rue
@@ -1,0 +1,133 @@
+// Lattice analysis pass: cache-boundary risk.
+//
+// This pass deliberately walks tasks, pools, dependencies, and bounded task
+// pairs. The four projections expose different compiler and application
+// behavior: field-heavy records, cross-module calls, graph indirection, nested
+// control flow, checked aggregation, and deterministic report generation.
+const std = @import("std");
+const metric = @import("metric.rue");
+const model = @import("model.rue");
+const text = @import("text.rue");
+const StrBuf = std.strbuf.StrBuf;
+
+pub fn TAG() -> u64 { 1022 }
+
+fn pool_for(borrow workflow: model.Workflow, index: u64) -> model.WorkerPool {
+    workflow.pools.get_or(index, model.empty_pool())
+}
+
+fn task_projection(borrow workflow: model.Workflow, index: u64) -> u64 {
+    let task = workflow.tasks.get_or(index, model.empty_task());
+    let _task_id = task.id;
+    let _assigned_pool = pool_for(borrow workflow, task.pool);
+    if task.cacheable { task.retries + 1 } else { task.duration + task.retries }
+}
+
+fn edge_projection(borrow workflow: model.Workflow, index: u64) -> u64 {
+    let edge = workflow.edges.get_or(index, model.empty_edge());
+    let before = workflow.tasks.get_or(edge.before, model.empty_task());
+    let after = workflow.tasks.get_or(edge.after, model.empty_task());
+    let _before_id = before.id;
+    let _after_id = after.id;
+    if before.cacheable != after.cacheable { 9 } else { 1 }
+}
+
+fn pool_projection(borrow workflow: model.Workflow, index: u64) -> u64 {
+    let pool = workflow.pools.get_or(index, model.empty_pool());
+    pool.memory
+}
+
+fn related_pair(borrow workflow: model.Workflow, first: u64, second: u64) -> bool {
+    if first == second { return false; }
+    model.has_edge(borrow workflow, first, second) ||
+        model.has_edge(borrow workflow, second, first) ||
+        workflow.tasks.get_or(first, model.empty_task()).pool ==
+            workflow.tasks.get_or(second, model.empty_task()).pool
+}
+
+fn pair_projection(borrow workflow: model.Workflow, first: u64, second: u64) -> u64 {
+    let left = workflow.tasks.get_or(first, model.empty_task());
+    let right = workflow.tasks.get_or(second, model.empty_task());
+    let distance = if second >= first { second - first } else { first - second };
+    let resource = left.cpu + left.memory + right.cpu + right.memory;
+    let duration = left.duration + right.duration;
+    (distance + 1) * (resource + 1) + duration + 1022
+}
+
+fn observe_tasks(inout result: metric.Metric, borrow workflow: model.Workflow) {
+    let mut i: u64 = 0;
+    while i < workflow.tasks.len() {
+        let value = task_projection(borrow workflow, i);
+        let task = workflow.tasks.get_or(i, model.empty_task());
+        metric.observe(inout result, value, task.priority + 1);
+        metric.warn(inout result, task.duration == 0 || task.cpu == 0 || task.memory == 0);
+        i += 1;
+    }
+}
+
+fn observe_edges(inout result: metric.Metric, borrow workflow: model.Workflow) {
+    let mut i: u64 = 0;
+    while i < workflow.edges.len() {
+        let edge = workflow.edges.get_or(i, model.empty_edge());
+        let value = edge_projection(borrow workflow, i);
+        metric.observe(inout result, value, i + 1);
+        metric.warn(inout result, edge.before >= workflow.tasks.len() || edge.after >= workflow.tasks.len());
+        i += 1;
+    }
+}
+
+fn observe_pools(inout result: metric.Metric, borrow workflow: model.Workflow) {
+    let mut i: u64 = 0;
+    while i < workflow.pools.len() {
+        let value = pool_projection(borrow workflow, i);
+        let pool = workflow.pools.get_or(i, model.empty_pool());
+        metric.observe(inout result, value, pool.slots + 1);
+        metric.warn(inout result, pool.slots == 0 || pool.cpu == 0 || pool.memory == 0);
+        i += 1;
+    }
+}
+
+fn observe_pairs(inout result: metric.Metric, borrow workflow: model.Workflow) -> u64 {
+    let mut pairs: u64 = 0;
+    let mut first: u64 = 0;
+    while first < workflow.tasks.len() {
+        let mut second: u64 = first + 1;
+        while second < workflow.tasks.len() {
+            if related_pair(borrow workflow, first, second) {
+                metric.observe(inout result, pair_projection(borrow workflow, first, second), first + second + 1);
+                pairs += 1;
+            }
+            second += 1;
+        }
+        first += 1;
+    }
+    pairs
+}
+
+pub fn analyze(borrow workflow: model.Workflow) -> metric.Metric {
+    let mut result = metric.new(TAG());
+    observe_tasks(inout result, borrow workflow);
+    observe_edges(inout result, borrow workflow);
+    observe_pools(inout result, borrow workflow);
+    let pairs = observe_pairs(inout result, borrow workflow);
+    metric.warn(inout result, workflow.tasks.len() > 1 && pairs == 0);
+    metric.finish(inout result);
+    result
+}
+
+pub fn verify(borrow workflow: model.Workflow, borrow result: metric.Metric) -> bool {
+    let floor = workflow.tasks.len() + workflow.edges.len() + workflow.pools.len();
+    result.tag == TAG() && result.observations >= floor &&
+        result.even + result.odd == result.observations &&
+        result.zeroes <= result.observations &&
+        (result.observations == 0 || result.minimum <= result.maximum)
+}
+
+pub fn render(borrow workflow: model.Workflow) -> StrBuf {
+    let result = analyze(borrow workflow);
+    let mut out = metric.render("cache_risk", borrow result);
+    text.append_literal(inout out, "verified=");
+    text.append_bool(inout out, verify(borrow workflow, borrow result));
+    out.push(10);
+    out
+}

--- a/performance/workloads/lattice/analysis_cacheable_work.rue
+++ b/performance/workloads/lattice/analysis_cacheable_work.rue
@@ -1,0 +1,133 @@
+// Lattice analysis pass: cacheable resource work.
+//
+// This pass deliberately walks tasks, pools, dependencies, and bounded task
+// pairs. The four projections expose different compiler and application
+// behavior: field-heavy records, cross-module calls, graph indirection, nested
+// control flow, checked aggregation, and deterministic report generation.
+const std = @import("std");
+const metric = @import("metric.rue");
+const model = @import("model.rue");
+const text = @import("text.rue");
+const StrBuf = std.strbuf.StrBuf;
+
+pub fn TAG() -> u64 { 1046 }
+
+fn pool_for(borrow workflow: model.Workflow, index: u64) -> model.WorkerPool {
+    workflow.pools.get_or(index, model.empty_pool())
+}
+
+fn task_projection(borrow workflow: model.Workflow, index: u64) -> u64 {
+    let task = workflow.tasks.get_or(index, model.empty_task());
+    let _task_id = task.id;
+    let _assigned_pool = pool_for(borrow workflow, task.pool);
+    if task.cacheable { task.duration * (task.cpu + task.memory) } else { 0 }
+}
+
+fn edge_projection(borrow workflow: model.Workflow, index: u64) -> u64 {
+    let edge = workflow.edges.get_or(index, model.empty_edge());
+    let before = workflow.tasks.get_or(edge.before, model.empty_task());
+    let after = workflow.tasks.get_or(edge.after, model.empty_task());
+    let _before_id = before.id;
+    let _after_id = after.id;
+    if before.cacheable || after.cacheable { before.duration + after.duration } else { 0 }
+}
+
+fn pool_projection(borrow workflow: model.Workflow, index: u64) -> u64 {
+    let pool = workflow.pools.get_or(index, model.empty_pool());
+    pool.cpu
+}
+
+fn related_pair(borrow workflow: model.Workflow, first: u64, second: u64) -> bool {
+    if first == second { return false; }
+    model.has_edge(borrow workflow, first, second) ||
+        model.has_edge(borrow workflow, second, first) ||
+        workflow.tasks.get_or(first, model.empty_task()).pool ==
+            workflow.tasks.get_or(second, model.empty_task()).pool
+}
+
+fn pair_projection(borrow workflow: model.Workflow, first: u64, second: u64) -> u64 {
+    let left = workflow.tasks.get_or(first, model.empty_task());
+    let right = workflow.tasks.get_or(second, model.empty_task());
+    let distance = if second >= first { second - first } else { first - second };
+    let resource = left.cpu + left.memory + right.cpu + right.memory;
+    let duration = left.duration + right.duration;
+    (distance + 1) * (resource + 1) + duration + 1046
+}
+
+fn observe_tasks(inout result: metric.Metric, borrow workflow: model.Workflow) {
+    let mut i: u64 = 0;
+    while i < workflow.tasks.len() {
+        let value = task_projection(borrow workflow, i);
+        let task = workflow.tasks.get_or(i, model.empty_task());
+        metric.observe(inout result, value, task.priority + 1);
+        metric.warn(inout result, task.duration == 0 || task.cpu == 0 || task.memory == 0);
+        i += 1;
+    }
+}
+
+fn observe_edges(inout result: metric.Metric, borrow workflow: model.Workflow) {
+    let mut i: u64 = 0;
+    while i < workflow.edges.len() {
+        let edge = workflow.edges.get_or(i, model.empty_edge());
+        let value = edge_projection(borrow workflow, i);
+        metric.observe(inout result, value, i + 1);
+        metric.warn(inout result, edge.before >= workflow.tasks.len() || edge.after >= workflow.tasks.len());
+        i += 1;
+    }
+}
+
+fn observe_pools(inout result: metric.Metric, borrow workflow: model.Workflow) {
+    let mut i: u64 = 0;
+    while i < workflow.pools.len() {
+        let value = pool_projection(borrow workflow, i);
+        let pool = workflow.pools.get_or(i, model.empty_pool());
+        metric.observe(inout result, value, pool.slots + 1);
+        metric.warn(inout result, pool.slots == 0 || pool.cpu == 0 || pool.memory == 0);
+        i += 1;
+    }
+}
+
+fn observe_pairs(inout result: metric.Metric, borrow workflow: model.Workflow) -> u64 {
+    let mut pairs: u64 = 0;
+    let mut first: u64 = 0;
+    while first < workflow.tasks.len() {
+        let mut second: u64 = first + 1;
+        while second < workflow.tasks.len() {
+            if related_pair(borrow workflow, first, second) {
+                metric.observe(inout result, pair_projection(borrow workflow, first, second), first + second + 1);
+                pairs += 1;
+            }
+            second += 1;
+        }
+        first += 1;
+    }
+    pairs
+}
+
+pub fn analyze(borrow workflow: model.Workflow) -> metric.Metric {
+    let mut result = metric.new(TAG());
+    observe_tasks(inout result, borrow workflow);
+    observe_edges(inout result, borrow workflow);
+    observe_pools(inout result, borrow workflow);
+    let pairs = observe_pairs(inout result, borrow workflow);
+    metric.warn(inout result, workflow.tasks.len() > 1 && pairs == 0);
+    metric.finish(inout result);
+    result
+}
+
+pub fn verify(borrow workflow: model.Workflow, borrow result: metric.Metric) -> bool {
+    let floor = workflow.tasks.len() + workflow.edges.len() + workflow.pools.len();
+    result.tag == TAG() && result.observations >= floor &&
+        result.even + result.odd == result.observations &&
+        result.zeroes <= result.observations &&
+        (result.observations == 0 || result.minimum <= result.maximum)
+}
+
+pub fn render(borrow workflow: model.Workflow) -> StrBuf {
+    let result = analyze(borrow workflow);
+    let mut out = metric.render("cacheable_work", borrow result);
+    text.append_literal(inout out, "verified=");
+    text.append_bool(inout out, verify(borrow workflow, borrow result));
+    out.push(10);
+    out
+}

--- a/performance/workloads/lattice/analysis_contention_index.rue
+++ b/performance/workloads/lattice/analysis_contention_index.rue
@@ -1,0 +1,133 @@
+// Lattice analysis pass: resource contention.
+//
+// This pass deliberately walks tasks, pools, dependencies, and bounded task
+// pairs. The four projections expose different compiler and application
+// behavior: field-heavy records, cross-module calls, graph indirection, nested
+// control flow, checked aggregation, and deterministic report generation.
+const std = @import("std");
+const metric = @import("metric.rue");
+const model = @import("model.rue");
+const text = @import("text.rue");
+const StrBuf = std.strbuf.StrBuf;
+
+pub fn TAG() -> u64 { 1019 }
+
+fn pool_for(borrow workflow: model.Workflow, index: u64) -> model.WorkerPool {
+    workflow.pools.get_or(index, model.empty_pool())
+}
+
+fn task_projection(borrow workflow: model.Workflow, index: u64) -> u64 {
+    let task = workflow.tasks.get_or(index, model.empty_task());
+    let _task_id = task.id;
+    let _assigned_pool = pool_for(borrow workflow, task.pool);
+    task.duration * (task.cpu + task.memory)
+}
+
+fn edge_projection(borrow workflow: model.Workflow, index: u64) -> u64 {
+    let edge = workflow.edges.get_or(index, model.empty_edge());
+    let before = workflow.tasks.get_or(edge.before, model.empty_task());
+    let after = workflow.tasks.get_or(edge.after, model.empty_task());
+    let _before_id = before.id;
+    let _after_id = after.id;
+    if before.pool == after.pool { before.duration + after.duration } else { 0 }
+}
+
+fn pool_projection(borrow workflow: model.Workflow, index: u64) -> u64 {
+    let pool = workflow.pools.get_or(index, model.empty_pool());
+    pool.slots * pool.cpu * pool.memory
+}
+
+fn related_pair(borrow workflow: model.Workflow, first: u64, second: u64) -> bool {
+    if first == second { return false; }
+    model.has_edge(borrow workflow, first, second) ||
+        model.has_edge(borrow workflow, second, first) ||
+        workflow.tasks.get_or(first, model.empty_task()).pool ==
+            workflow.tasks.get_or(second, model.empty_task()).pool
+}
+
+fn pair_projection(borrow workflow: model.Workflow, first: u64, second: u64) -> u64 {
+    let left = workflow.tasks.get_or(first, model.empty_task());
+    let right = workflow.tasks.get_or(second, model.empty_task());
+    let distance = if second >= first { second - first } else { first - second };
+    let resource = left.cpu + left.memory + right.cpu + right.memory;
+    let duration = left.duration + right.duration;
+    (distance + 1) * (resource + 1) + duration + 1019
+}
+
+fn observe_tasks(inout result: metric.Metric, borrow workflow: model.Workflow) {
+    let mut i: u64 = 0;
+    while i < workflow.tasks.len() {
+        let value = task_projection(borrow workflow, i);
+        let task = workflow.tasks.get_or(i, model.empty_task());
+        metric.observe(inout result, value, task.priority + 1);
+        metric.warn(inout result, task.duration == 0 || task.cpu == 0 || task.memory == 0);
+        i += 1;
+    }
+}
+
+fn observe_edges(inout result: metric.Metric, borrow workflow: model.Workflow) {
+    let mut i: u64 = 0;
+    while i < workflow.edges.len() {
+        let edge = workflow.edges.get_or(i, model.empty_edge());
+        let value = edge_projection(borrow workflow, i);
+        metric.observe(inout result, value, i + 1);
+        metric.warn(inout result, edge.before >= workflow.tasks.len() || edge.after >= workflow.tasks.len());
+        i += 1;
+    }
+}
+
+fn observe_pools(inout result: metric.Metric, borrow workflow: model.Workflow) {
+    let mut i: u64 = 0;
+    while i < workflow.pools.len() {
+        let value = pool_projection(borrow workflow, i);
+        let pool = workflow.pools.get_or(i, model.empty_pool());
+        metric.observe(inout result, value, pool.slots + 1);
+        metric.warn(inout result, pool.slots == 0 || pool.cpu == 0 || pool.memory == 0);
+        i += 1;
+    }
+}
+
+fn observe_pairs(inout result: metric.Metric, borrow workflow: model.Workflow) -> u64 {
+    let mut pairs: u64 = 0;
+    let mut first: u64 = 0;
+    while first < workflow.tasks.len() {
+        let mut second: u64 = first + 1;
+        while second < workflow.tasks.len() {
+            if related_pair(borrow workflow, first, second) {
+                metric.observe(inout result, pair_projection(borrow workflow, first, second), first + second + 1);
+                pairs += 1;
+            }
+            second += 1;
+        }
+        first += 1;
+    }
+    pairs
+}
+
+pub fn analyze(borrow workflow: model.Workflow) -> metric.Metric {
+    let mut result = metric.new(TAG());
+    observe_tasks(inout result, borrow workflow);
+    observe_edges(inout result, borrow workflow);
+    observe_pools(inout result, borrow workflow);
+    let pairs = observe_pairs(inout result, borrow workflow);
+    metric.warn(inout result, workflow.tasks.len() > 1 && pairs == 0);
+    metric.finish(inout result);
+    result
+}
+
+pub fn verify(borrow workflow: model.Workflow, borrow result: metric.Metric) -> bool {
+    let floor = workflow.tasks.len() + workflow.edges.len() + workflow.pools.len();
+    result.tag == TAG() && result.observations >= floor &&
+        result.even + result.odd == result.observations &&
+        result.zeroes <= result.observations &&
+        (result.observations == 0 || result.minimum <= result.maximum)
+}
+
+pub fn render(borrow workflow: model.Workflow) -> StrBuf {
+    let result = analyze(borrow workflow);
+    let mut out = metric.render("contention_index", borrow result);
+    text.append_literal(inout out, "verified=");
+    text.append_bool(inout out, verify(borrow workflow, borrow result));
+    out.push(10);
+    out
+}

--- a/performance/workloads/lattice/analysis_cpu_variance_proxy.rue
+++ b/performance/workloads/lattice/analysis_cpu_variance_proxy.rue
@@ -1,0 +1,133 @@
+// Lattice analysis pass: CPU second moment.
+//
+// This pass deliberately walks tasks, pools, dependencies, and bounded task
+// pairs. The four projections expose different compiler and application
+// behavior: field-heavy records, cross-module calls, graph indirection, nested
+// control flow, checked aggregation, and deterministic report generation.
+const std = @import("std");
+const metric = @import("metric.rue");
+const model = @import("model.rue");
+const text = @import("text.rue");
+const StrBuf = std.strbuf.StrBuf;
+
+pub fn TAG() -> u64 { 1040 }
+
+fn pool_for(borrow workflow: model.Workflow, index: u64) -> model.WorkerPool {
+    workflow.pools.get_or(index, model.empty_pool())
+}
+
+fn task_projection(borrow workflow: model.Workflow, index: u64) -> u64 {
+    let task = workflow.tasks.get_or(index, model.empty_task());
+    let _task_id = task.id;
+    let _assigned_pool = pool_for(borrow workflow, task.pool);
+    task.cpu * task.cpu
+}
+
+fn edge_projection(borrow workflow: model.Workflow, index: u64) -> u64 {
+    let edge = workflow.edges.get_or(index, model.empty_edge());
+    let before = workflow.tasks.get_or(edge.before, model.empty_task());
+    let after = workflow.tasks.get_or(edge.after, model.empty_task());
+    let _before_id = before.id;
+    let _after_id = after.id;
+    before.cpu * after.cpu
+}
+
+fn pool_projection(borrow workflow: model.Workflow, index: u64) -> u64 {
+    let pool = workflow.pools.get_or(index, model.empty_pool());
+    pool.cpu * pool.cpu
+}
+
+fn related_pair(borrow workflow: model.Workflow, first: u64, second: u64) -> bool {
+    if first == second { return false; }
+    model.has_edge(borrow workflow, first, second) ||
+        model.has_edge(borrow workflow, second, first) ||
+        workflow.tasks.get_or(first, model.empty_task()).pool ==
+            workflow.tasks.get_or(second, model.empty_task()).pool
+}
+
+fn pair_projection(borrow workflow: model.Workflow, first: u64, second: u64) -> u64 {
+    let left = workflow.tasks.get_or(first, model.empty_task());
+    let right = workflow.tasks.get_or(second, model.empty_task());
+    let distance = if second >= first { second - first } else { first - second };
+    let resource = left.cpu + left.memory + right.cpu + right.memory;
+    let duration = left.duration + right.duration;
+    (distance + 1) * (resource + 1) + duration + 1040
+}
+
+fn observe_tasks(inout result: metric.Metric, borrow workflow: model.Workflow) {
+    let mut i: u64 = 0;
+    while i < workflow.tasks.len() {
+        let value = task_projection(borrow workflow, i);
+        let task = workflow.tasks.get_or(i, model.empty_task());
+        metric.observe(inout result, value, task.priority + 1);
+        metric.warn(inout result, task.duration == 0 || task.cpu == 0 || task.memory == 0);
+        i += 1;
+    }
+}
+
+fn observe_edges(inout result: metric.Metric, borrow workflow: model.Workflow) {
+    let mut i: u64 = 0;
+    while i < workflow.edges.len() {
+        let edge = workflow.edges.get_or(i, model.empty_edge());
+        let value = edge_projection(borrow workflow, i);
+        metric.observe(inout result, value, i + 1);
+        metric.warn(inout result, edge.before >= workflow.tasks.len() || edge.after >= workflow.tasks.len());
+        i += 1;
+    }
+}
+
+fn observe_pools(inout result: metric.Metric, borrow workflow: model.Workflow) {
+    let mut i: u64 = 0;
+    while i < workflow.pools.len() {
+        let value = pool_projection(borrow workflow, i);
+        let pool = workflow.pools.get_or(i, model.empty_pool());
+        metric.observe(inout result, value, pool.slots + 1);
+        metric.warn(inout result, pool.slots == 0 || pool.cpu == 0 || pool.memory == 0);
+        i += 1;
+    }
+}
+
+fn observe_pairs(inout result: metric.Metric, borrow workflow: model.Workflow) -> u64 {
+    let mut pairs: u64 = 0;
+    let mut first: u64 = 0;
+    while first < workflow.tasks.len() {
+        let mut second: u64 = first + 1;
+        while second < workflow.tasks.len() {
+            if related_pair(borrow workflow, first, second) {
+                metric.observe(inout result, pair_projection(borrow workflow, first, second), first + second + 1);
+                pairs += 1;
+            }
+            second += 1;
+        }
+        first += 1;
+    }
+    pairs
+}
+
+pub fn analyze(borrow workflow: model.Workflow) -> metric.Metric {
+    let mut result = metric.new(TAG());
+    observe_tasks(inout result, borrow workflow);
+    observe_edges(inout result, borrow workflow);
+    observe_pools(inout result, borrow workflow);
+    let pairs = observe_pairs(inout result, borrow workflow);
+    metric.warn(inout result, workflow.tasks.len() > 1 && pairs == 0);
+    metric.finish(inout result);
+    result
+}
+
+pub fn verify(borrow workflow: model.Workflow, borrow result: metric.Metric) -> bool {
+    let floor = workflow.tasks.len() + workflow.edges.len() + workflow.pools.len();
+    result.tag == TAG() && result.observations >= floor &&
+        result.even + result.odd == result.observations &&
+        result.zeroes <= result.observations &&
+        (result.observations == 0 || result.minimum <= result.maximum)
+}
+
+pub fn render(borrow workflow: model.Workflow) -> StrBuf {
+    let result = analyze(borrow workflow);
+    let mut out = metric.render("cpu_variance_proxy", borrow result);
+    text.append_literal(inout out, "verified=");
+    text.append_bool(inout out, verify(borrow workflow, borrow result));
+    out.push(10);
+    out
+}

--- a/performance/workloads/lattice/analysis_cpu_work.rue
+++ b/performance/workloads/lattice/analysis_cpu_work.rue
@@ -1,0 +1,133 @@
+// Lattice analysis pass: CPU-time demand.
+//
+// This pass deliberately walks tasks, pools, dependencies, and bounded task
+// pairs. The four projections expose different compiler and application
+// behavior: field-heavy records, cross-module calls, graph indirection, nested
+// control flow, checked aggregation, and deterministic report generation.
+const std = @import("std");
+const metric = @import("metric.rue");
+const model = @import("model.rue");
+const text = @import("text.rue");
+const StrBuf = std.strbuf.StrBuf;
+
+pub fn TAG() -> u64 { 1002 }
+
+fn pool_for(borrow workflow: model.Workflow, index: u64) -> model.WorkerPool {
+    workflow.pools.get_or(index, model.empty_pool())
+}
+
+fn task_projection(borrow workflow: model.Workflow, index: u64) -> u64 {
+    let task = workflow.tasks.get_or(index, model.empty_task());
+    let _task_id = task.id;
+    let _assigned_pool = pool_for(borrow workflow, task.pool);
+    task.cpu * task.duration
+}
+
+fn edge_projection(borrow workflow: model.Workflow, index: u64) -> u64 {
+    let edge = workflow.edges.get_or(index, model.empty_edge());
+    let before = workflow.tasks.get_or(edge.before, model.empty_task());
+    let after = workflow.tasks.get_or(edge.after, model.empty_task());
+    let _before_id = before.id;
+    let _after_id = after.id;
+    before.cpu + after.cpu
+}
+
+fn pool_projection(borrow workflow: model.Workflow, index: u64) -> u64 {
+    let pool = workflow.pools.get_or(index, model.empty_pool());
+    pool.cpu
+}
+
+fn related_pair(borrow workflow: model.Workflow, first: u64, second: u64) -> bool {
+    if first == second { return false; }
+    model.has_edge(borrow workflow, first, second) ||
+        model.has_edge(borrow workflow, second, first) ||
+        workflow.tasks.get_or(first, model.empty_task()).pool ==
+            workflow.tasks.get_or(second, model.empty_task()).pool
+}
+
+fn pair_projection(borrow workflow: model.Workflow, first: u64, second: u64) -> u64 {
+    let left = workflow.tasks.get_or(first, model.empty_task());
+    let right = workflow.tasks.get_or(second, model.empty_task());
+    let distance = if second >= first { second - first } else { first - second };
+    let resource = left.cpu + left.memory + right.cpu + right.memory;
+    let duration = left.duration + right.duration;
+    (distance + 1) * (resource + 1) + duration + 1002
+}
+
+fn observe_tasks(inout result: metric.Metric, borrow workflow: model.Workflow) {
+    let mut i: u64 = 0;
+    while i < workflow.tasks.len() {
+        let value = task_projection(borrow workflow, i);
+        let task = workflow.tasks.get_or(i, model.empty_task());
+        metric.observe(inout result, value, task.priority + 1);
+        metric.warn(inout result, task.duration == 0 || task.cpu == 0 || task.memory == 0);
+        i += 1;
+    }
+}
+
+fn observe_edges(inout result: metric.Metric, borrow workflow: model.Workflow) {
+    let mut i: u64 = 0;
+    while i < workflow.edges.len() {
+        let edge = workflow.edges.get_or(i, model.empty_edge());
+        let value = edge_projection(borrow workflow, i);
+        metric.observe(inout result, value, i + 1);
+        metric.warn(inout result, edge.before >= workflow.tasks.len() || edge.after >= workflow.tasks.len());
+        i += 1;
+    }
+}
+
+fn observe_pools(inout result: metric.Metric, borrow workflow: model.Workflow) {
+    let mut i: u64 = 0;
+    while i < workflow.pools.len() {
+        let value = pool_projection(borrow workflow, i);
+        let pool = workflow.pools.get_or(i, model.empty_pool());
+        metric.observe(inout result, value, pool.slots + 1);
+        metric.warn(inout result, pool.slots == 0 || pool.cpu == 0 || pool.memory == 0);
+        i += 1;
+    }
+}
+
+fn observe_pairs(inout result: metric.Metric, borrow workflow: model.Workflow) -> u64 {
+    let mut pairs: u64 = 0;
+    let mut first: u64 = 0;
+    while first < workflow.tasks.len() {
+        let mut second: u64 = first + 1;
+        while second < workflow.tasks.len() {
+            if related_pair(borrow workflow, first, second) {
+                metric.observe(inout result, pair_projection(borrow workflow, first, second), first + second + 1);
+                pairs += 1;
+            }
+            second += 1;
+        }
+        first += 1;
+    }
+    pairs
+}
+
+pub fn analyze(borrow workflow: model.Workflow) -> metric.Metric {
+    let mut result = metric.new(TAG());
+    observe_tasks(inout result, borrow workflow);
+    observe_edges(inout result, borrow workflow);
+    observe_pools(inout result, borrow workflow);
+    let pairs = observe_pairs(inout result, borrow workflow);
+    metric.warn(inout result, workflow.tasks.len() > 1 && pairs == 0);
+    metric.finish(inout result);
+    result
+}
+
+pub fn verify(borrow workflow: model.Workflow, borrow result: metric.Metric) -> bool {
+    let floor = workflow.tasks.len() + workflow.edges.len() + workflow.pools.len();
+    result.tag == TAG() && result.observations >= floor &&
+        result.even + result.odd == result.observations &&
+        result.zeroes <= result.observations &&
+        (result.observations == 0 || result.minimum <= result.maximum)
+}
+
+pub fn render(borrow workflow: model.Workflow) -> StrBuf {
+    let result = analyze(borrow workflow);
+    let mut out = metric.render("cpu_work", borrow result);
+    text.append_literal(inout out, "verified=");
+    text.append_bool(inout out, verify(borrow workflow, borrow result));
+    out.push(10);
+    out
+}

--- a/performance/workloads/lattice/analysis_criticality_proxy.rue
+++ b/performance/workloads/lattice/analysis_criticality_proxy.rue
@@ -1,0 +1,133 @@
+// Lattice analysis pass: duration and successor criticality.
+//
+// This pass deliberately walks tasks, pools, dependencies, and bounded task
+// pairs. The four projections expose different compiler and application
+// behavior: field-heavy records, cross-module calls, graph indirection, nested
+// control flow, checked aggregation, and deterministic report generation.
+const std = @import("std");
+const metric = @import("metric.rue");
+const model = @import("model.rue");
+const text = @import("text.rue");
+const StrBuf = std.strbuf.StrBuf;
+
+pub fn TAG() -> u64 { 1011 }
+
+fn pool_for(borrow workflow: model.Workflow, index: u64) -> model.WorkerPool {
+    workflow.pools.get_or(index, model.empty_pool())
+}
+
+fn task_projection(borrow workflow: model.Workflow, index: u64) -> u64 {
+    let task = workflow.tasks.get_or(index, model.empty_task());
+    let _task_id = task.id;
+    let _assigned_pool = pool_for(borrow workflow, task.pool);
+    task.duration * (1 + model.dependent_count(borrow workflow, index))
+}
+
+fn edge_projection(borrow workflow: model.Workflow, index: u64) -> u64 {
+    let edge = workflow.edges.get_or(index, model.empty_edge());
+    let before = workflow.tasks.get_or(edge.before, model.empty_task());
+    let after = workflow.tasks.get_or(edge.after, model.empty_task());
+    let _before_id = before.id;
+    let _after_id = after.id;
+    before.duration + after.duration
+}
+
+fn pool_projection(borrow workflow: model.Workflow, index: u64) -> u64 {
+    let pool = workflow.pools.get_or(index, model.empty_pool());
+    pool.slots * pool.memory
+}
+
+fn related_pair(borrow workflow: model.Workflow, first: u64, second: u64) -> bool {
+    if first == second { return false; }
+    model.has_edge(borrow workflow, first, second) ||
+        model.has_edge(borrow workflow, second, first) ||
+        workflow.tasks.get_or(first, model.empty_task()).pool ==
+            workflow.tasks.get_or(second, model.empty_task()).pool
+}
+
+fn pair_projection(borrow workflow: model.Workflow, first: u64, second: u64) -> u64 {
+    let left = workflow.tasks.get_or(first, model.empty_task());
+    let right = workflow.tasks.get_or(second, model.empty_task());
+    let distance = if second >= first { second - first } else { first - second };
+    let resource = left.cpu + left.memory + right.cpu + right.memory;
+    let duration = left.duration + right.duration;
+    (distance + 1) * (resource + 1) + duration + 1011
+}
+
+fn observe_tasks(inout result: metric.Metric, borrow workflow: model.Workflow) {
+    let mut i: u64 = 0;
+    while i < workflow.tasks.len() {
+        let value = task_projection(borrow workflow, i);
+        let task = workflow.tasks.get_or(i, model.empty_task());
+        metric.observe(inout result, value, task.priority + 1);
+        metric.warn(inout result, task.duration == 0 || task.cpu == 0 || task.memory == 0);
+        i += 1;
+    }
+}
+
+fn observe_edges(inout result: metric.Metric, borrow workflow: model.Workflow) {
+    let mut i: u64 = 0;
+    while i < workflow.edges.len() {
+        let edge = workflow.edges.get_or(i, model.empty_edge());
+        let value = edge_projection(borrow workflow, i);
+        metric.observe(inout result, value, i + 1);
+        metric.warn(inout result, edge.before >= workflow.tasks.len() || edge.after >= workflow.tasks.len());
+        i += 1;
+    }
+}
+
+fn observe_pools(inout result: metric.Metric, borrow workflow: model.Workflow) {
+    let mut i: u64 = 0;
+    while i < workflow.pools.len() {
+        let value = pool_projection(borrow workflow, i);
+        let pool = workflow.pools.get_or(i, model.empty_pool());
+        metric.observe(inout result, value, pool.slots + 1);
+        metric.warn(inout result, pool.slots == 0 || pool.cpu == 0 || pool.memory == 0);
+        i += 1;
+    }
+}
+
+fn observe_pairs(inout result: metric.Metric, borrow workflow: model.Workflow) -> u64 {
+    let mut pairs: u64 = 0;
+    let mut first: u64 = 0;
+    while first < workflow.tasks.len() {
+        let mut second: u64 = first + 1;
+        while second < workflow.tasks.len() {
+            if related_pair(borrow workflow, first, second) {
+                metric.observe(inout result, pair_projection(borrow workflow, first, second), first + second + 1);
+                pairs += 1;
+            }
+            second += 1;
+        }
+        first += 1;
+    }
+    pairs
+}
+
+pub fn analyze(borrow workflow: model.Workflow) -> metric.Metric {
+    let mut result = metric.new(TAG());
+    observe_tasks(inout result, borrow workflow);
+    observe_edges(inout result, borrow workflow);
+    observe_pools(inout result, borrow workflow);
+    let pairs = observe_pairs(inout result, borrow workflow);
+    metric.warn(inout result, workflow.tasks.len() > 1 && pairs == 0);
+    metric.finish(inout result);
+    result
+}
+
+pub fn verify(borrow workflow: model.Workflow, borrow result: metric.Metric) -> bool {
+    let floor = workflow.tasks.len() + workflow.edges.len() + workflow.pools.len();
+    result.tag == TAG() && result.observations >= floor &&
+        result.even + result.odd == result.observations &&
+        result.zeroes <= result.observations &&
+        (result.observations == 0 || result.minimum <= result.maximum)
+}
+
+pub fn render(borrow workflow: model.Workflow) -> StrBuf {
+    let result = analyze(borrow workflow);
+    let mut out = metric.render("criticality_proxy", borrow result);
+    text.append_literal(inout out, "verified=");
+    text.append_bool(inout out, verify(borrow workflow, borrow result));
+    out.push(10);
+    out
+}

--- a/performance/workloads/lattice/analysis_cross_pool_edges.rue
+++ b/performance/workloads/lattice/analysis_cross_pool_edges.rue
@@ -1,0 +1,133 @@
+// Lattice analysis pass: cross-pool handoffs.
+//
+// This pass deliberately walks tasks, pools, dependencies, and bounded task
+// pairs. The four projections expose different compiler and application
+// behavior: field-heavy records, cross-module calls, graph indirection, nested
+// control flow, checked aggregation, and deterministic report generation.
+const std = @import("std");
+const metric = @import("metric.rue");
+const model = @import("model.rue");
+const text = @import("text.rue");
+const StrBuf = std.strbuf.StrBuf;
+
+pub fn TAG() -> u64 { 1027 }
+
+fn pool_for(borrow workflow: model.Workflow, index: u64) -> model.WorkerPool {
+    workflow.pools.get_or(index, model.empty_pool())
+}
+
+fn task_projection(borrow workflow: model.Workflow, index: u64) -> u64 {
+    let task = workflow.tasks.get_or(index, model.empty_task());
+    let _task_id = task.id;
+    let _assigned_pool = pool_for(borrow workflow, task.pool);
+    task.pool
+}
+
+fn edge_projection(borrow workflow: model.Workflow, index: u64) -> u64 {
+    let edge = workflow.edges.get_or(index, model.empty_edge());
+    let before = workflow.tasks.get_or(edge.before, model.empty_task());
+    let after = workflow.tasks.get_or(edge.after, model.empty_task());
+    let _before_id = before.id;
+    let _after_id = after.id;
+    if before.pool != after.pool { before.duration + after.duration } else { 0 }
+}
+
+fn pool_projection(borrow workflow: model.Workflow, index: u64) -> u64 {
+    let pool = workflow.pools.get_or(index, model.empty_pool());
+    pool.cpu + pool.memory
+}
+
+fn related_pair(borrow workflow: model.Workflow, first: u64, second: u64) -> bool {
+    if first == second { return false; }
+    model.has_edge(borrow workflow, first, second) ||
+        model.has_edge(borrow workflow, second, first) ||
+        workflow.tasks.get_or(first, model.empty_task()).pool ==
+            workflow.tasks.get_or(second, model.empty_task()).pool
+}
+
+fn pair_projection(borrow workflow: model.Workflow, first: u64, second: u64) -> u64 {
+    let left = workflow.tasks.get_or(first, model.empty_task());
+    let right = workflow.tasks.get_or(second, model.empty_task());
+    let distance = if second >= first { second - first } else { first - second };
+    let resource = left.cpu + left.memory + right.cpu + right.memory;
+    let duration = left.duration + right.duration;
+    (distance + 1) * (resource + 1) + duration + 1027
+}
+
+fn observe_tasks(inout result: metric.Metric, borrow workflow: model.Workflow) {
+    let mut i: u64 = 0;
+    while i < workflow.tasks.len() {
+        let value = task_projection(borrow workflow, i);
+        let task = workflow.tasks.get_or(i, model.empty_task());
+        metric.observe(inout result, value, task.priority + 1);
+        metric.warn(inout result, task.duration == 0 || task.cpu == 0 || task.memory == 0);
+        i += 1;
+    }
+}
+
+fn observe_edges(inout result: metric.Metric, borrow workflow: model.Workflow) {
+    let mut i: u64 = 0;
+    while i < workflow.edges.len() {
+        let edge = workflow.edges.get_or(i, model.empty_edge());
+        let value = edge_projection(borrow workflow, i);
+        metric.observe(inout result, value, i + 1);
+        metric.warn(inout result, edge.before >= workflow.tasks.len() || edge.after >= workflow.tasks.len());
+        i += 1;
+    }
+}
+
+fn observe_pools(inout result: metric.Metric, borrow workflow: model.Workflow) {
+    let mut i: u64 = 0;
+    while i < workflow.pools.len() {
+        let value = pool_projection(borrow workflow, i);
+        let pool = workflow.pools.get_or(i, model.empty_pool());
+        metric.observe(inout result, value, pool.slots + 1);
+        metric.warn(inout result, pool.slots == 0 || pool.cpu == 0 || pool.memory == 0);
+        i += 1;
+    }
+}
+
+fn observe_pairs(inout result: metric.Metric, borrow workflow: model.Workflow) -> u64 {
+    let mut pairs: u64 = 0;
+    let mut first: u64 = 0;
+    while first < workflow.tasks.len() {
+        let mut second: u64 = first + 1;
+        while second < workflow.tasks.len() {
+            if related_pair(borrow workflow, first, second) {
+                metric.observe(inout result, pair_projection(borrow workflow, first, second), first + second + 1);
+                pairs += 1;
+            }
+            second += 1;
+        }
+        first += 1;
+    }
+    pairs
+}
+
+pub fn analyze(borrow workflow: model.Workflow) -> metric.Metric {
+    let mut result = metric.new(TAG());
+    observe_tasks(inout result, borrow workflow);
+    observe_edges(inout result, borrow workflow);
+    observe_pools(inout result, borrow workflow);
+    let pairs = observe_pairs(inout result, borrow workflow);
+    metric.warn(inout result, workflow.tasks.len() > 1 && pairs == 0);
+    metric.finish(inout result);
+    result
+}
+
+pub fn verify(borrow workflow: model.Workflow, borrow result: metric.Metric) -> bool {
+    let floor = workflow.tasks.len() + workflow.edges.len() + workflow.pools.len();
+    result.tag == TAG() && result.observations >= floor &&
+        result.even + result.odd == result.observations &&
+        result.zeroes <= result.observations &&
+        (result.observations == 0 || result.minimum <= result.maximum)
+}
+
+pub fn render(borrow workflow: model.Workflow) -> StrBuf {
+    let result = analyze(borrow workflow);
+    let mut out = metric.render("cross_pool_edges", borrow result);
+    text.append_literal(inout out, "verified=");
+    text.append_bool(inout out, verify(borrow workflow, borrow result));
+    out.push(10);
+    out
+}

--- a/performance/workloads/lattice/analysis_dependency_density.rue
+++ b/performance/workloads/lattice/analysis_dependency_density.rue
@@ -1,0 +1,133 @@
+// Lattice analysis pass: local dependency density.
+//
+// This pass deliberately walks tasks, pools, dependencies, and bounded task
+// pairs. The four projections expose different compiler and application
+// behavior: field-heavy records, cross-module calls, graph indirection, nested
+// control flow, checked aggregation, and deterministic report generation.
+const std = @import("std");
+const metric = @import("metric.rue");
+const model = @import("model.rue");
+const text = @import("text.rue");
+const StrBuf = std.strbuf.StrBuf;
+
+pub fn TAG() -> u64 { 1023 }
+
+fn pool_for(borrow workflow: model.Workflow, index: u64) -> model.WorkerPool {
+    workflow.pools.get_or(index, model.empty_pool())
+}
+
+fn task_projection(borrow workflow: model.Workflow, index: u64) -> u64 {
+    let task = workflow.tasks.get_or(index, model.empty_task());
+    let _task_id = task.id;
+    let _assigned_pool = pool_for(borrow workflow, task.pool);
+    model.dependency_count(borrow workflow, index) + model.dependent_count(borrow workflow, index)
+}
+
+fn edge_projection(borrow workflow: model.Workflow, index: u64) -> u64 {
+    let edge = workflow.edges.get_or(index, model.empty_edge());
+    let before = workflow.tasks.get_or(edge.before, model.empty_task());
+    let after = workflow.tasks.get_or(edge.after, model.empty_task());
+    let _before_id = before.id;
+    let _after_id = after.id;
+    workflow.edges.len()
+}
+
+fn pool_projection(borrow workflow: model.Workflow, index: u64) -> u64 {
+    let pool = workflow.pools.get_or(index, model.empty_pool());
+    pool.slots
+}
+
+fn related_pair(borrow workflow: model.Workflow, first: u64, second: u64) -> bool {
+    if first == second { return false; }
+    model.has_edge(borrow workflow, first, second) ||
+        model.has_edge(borrow workflow, second, first) ||
+        workflow.tasks.get_or(first, model.empty_task()).pool ==
+            workflow.tasks.get_or(second, model.empty_task()).pool
+}
+
+fn pair_projection(borrow workflow: model.Workflow, first: u64, second: u64) -> u64 {
+    let left = workflow.tasks.get_or(first, model.empty_task());
+    let right = workflow.tasks.get_or(second, model.empty_task());
+    let distance = if second >= first { second - first } else { first - second };
+    let resource = left.cpu + left.memory + right.cpu + right.memory;
+    let duration = left.duration + right.duration;
+    (distance + 1) * (resource + 1) + duration + 1023
+}
+
+fn observe_tasks(inout result: metric.Metric, borrow workflow: model.Workflow) {
+    let mut i: u64 = 0;
+    while i < workflow.tasks.len() {
+        let value = task_projection(borrow workflow, i);
+        let task = workflow.tasks.get_or(i, model.empty_task());
+        metric.observe(inout result, value, task.priority + 1);
+        metric.warn(inout result, task.duration == 0 || task.cpu == 0 || task.memory == 0);
+        i += 1;
+    }
+}
+
+fn observe_edges(inout result: metric.Metric, borrow workflow: model.Workflow) {
+    let mut i: u64 = 0;
+    while i < workflow.edges.len() {
+        let edge = workflow.edges.get_or(i, model.empty_edge());
+        let value = edge_projection(borrow workflow, i);
+        metric.observe(inout result, value, i + 1);
+        metric.warn(inout result, edge.before >= workflow.tasks.len() || edge.after >= workflow.tasks.len());
+        i += 1;
+    }
+}
+
+fn observe_pools(inout result: metric.Metric, borrow workflow: model.Workflow) {
+    let mut i: u64 = 0;
+    while i < workflow.pools.len() {
+        let value = pool_projection(borrow workflow, i);
+        let pool = workflow.pools.get_or(i, model.empty_pool());
+        metric.observe(inout result, value, pool.slots + 1);
+        metric.warn(inout result, pool.slots == 0 || pool.cpu == 0 || pool.memory == 0);
+        i += 1;
+    }
+}
+
+fn observe_pairs(inout result: metric.Metric, borrow workflow: model.Workflow) -> u64 {
+    let mut pairs: u64 = 0;
+    let mut first: u64 = 0;
+    while first < workflow.tasks.len() {
+        let mut second: u64 = first + 1;
+        while second < workflow.tasks.len() {
+            if related_pair(borrow workflow, first, second) {
+                metric.observe(inout result, pair_projection(borrow workflow, first, second), first + second + 1);
+                pairs += 1;
+            }
+            second += 1;
+        }
+        first += 1;
+    }
+    pairs
+}
+
+pub fn analyze(borrow workflow: model.Workflow) -> metric.Metric {
+    let mut result = metric.new(TAG());
+    observe_tasks(inout result, borrow workflow);
+    observe_edges(inout result, borrow workflow);
+    observe_pools(inout result, borrow workflow);
+    let pairs = observe_pairs(inout result, borrow workflow);
+    metric.warn(inout result, workflow.tasks.len() > 1 && pairs == 0);
+    metric.finish(inout result);
+    result
+}
+
+pub fn verify(borrow workflow: model.Workflow, borrow result: metric.Metric) -> bool {
+    let floor = workflow.tasks.len() + workflow.edges.len() + workflow.pools.len();
+    result.tag == TAG() && result.observations >= floor &&
+        result.even + result.odd == result.observations &&
+        result.zeroes <= result.observations &&
+        (result.observations == 0 || result.minimum <= result.maximum)
+}
+
+pub fn render(borrow workflow: model.Workflow) -> StrBuf {
+    let result = analyze(borrow workflow);
+    let mut out = metric.render("dependency_density", borrow result);
+    text.append_literal(inout out, "verified=");
+    text.append_bool(inout out, verify(borrow workflow, borrow result));
+    out.push(10);
+    out
+}

--- a/performance/workloads/lattice/analysis_dependency_distance.rue
+++ b/performance/workloads/lattice/analysis_dependency_distance.rue
@@ -1,0 +1,133 @@
+// Lattice analysis pass: source-order dependency distance.
+//
+// This pass deliberately walks tasks, pools, dependencies, and bounded task
+// pairs. The four projections expose different compiler and application
+// behavior: field-heavy records, cross-module calls, graph indirection, nested
+// control flow, checked aggregation, and deterministic report generation.
+const std = @import("std");
+const metric = @import("metric.rue");
+const model = @import("model.rue");
+const text = @import("text.rue");
+const StrBuf = std.strbuf.StrBuf;
+
+pub fn TAG() -> u64 { 1010 }
+
+fn pool_for(borrow workflow: model.Workflow, index: u64) -> model.WorkerPool {
+    workflow.pools.get_or(index, model.empty_pool())
+}
+
+fn task_projection(borrow workflow: model.Workflow, index: u64) -> u64 {
+    let task = workflow.tasks.get_or(index, model.empty_task());
+    let _task_id = task.id;
+    let _assigned_pool = pool_for(borrow workflow, task.pool);
+    index + task.duration
+}
+
+fn edge_projection(borrow workflow: model.Workflow, index: u64) -> u64 {
+    let edge = workflow.edges.get_or(index, model.empty_edge());
+    let before = workflow.tasks.get_or(edge.before, model.empty_task());
+    let after = workflow.tasks.get_or(edge.after, model.empty_task());
+    let _before_id = before.id;
+    let _after_id = after.id;
+    if edge.after >= edge.before { edge.after - edge.before } else { edge.before - edge.after }
+}
+
+fn pool_projection(borrow workflow: model.Workflow, index: u64) -> u64 {
+    let pool = workflow.pools.get_or(index, model.empty_pool());
+    pool.cpu
+}
+
+fn related_pair(borrow workflow: model.Workflow, first: u64, second: u64) -> bool {
+    if first == second { return false; }
+    model.has_edge(borrow workflow, first, second) ||
+        model.has_edge(borrow workflow, second, first) ||
+        workflow.tasks.get_or(first, model.empty_task()).pool ==
+            workflow.tasks.get_or(second, model.empty_task()).pool
+}
+
+fn pair_projection(borrow workflow: model.Workflow, first: u64, second: u64) -> u64 {
+    let left = workflow.tasks.get_or(first, model.empty_task());
+    let right = workflow.tasks.get_or(second, model.empty_task());
+    let distance = if second >= first { second - first } else { first - second };
+    let resource = left.cpu + left.memory + right.cpu + right.memory;
+    let duration = left.duration + right.duration;
+    (distance + 1) * (resource + 1) + duration + 1010
+}
+
+fn observe_tasks(inout result: metric.Metric, borrow workflow: model.Workflow) {
+    let mut i: u64 = 0;
+    while i < workflow.tasks.len() {
+        let value = task_projection(borrow workflow, i);
+        let task = workflow.tasks.get_or(i, model.empty_task());
+        metric.observe(inout result, value, task.priority + 1);
+        metric.warn(inout result, task.duration == 0 || task.cpu == 0 || task.memory == 0);
+        i += 1;
+    }
+}
+
+fn observe_edges(inout result: metric.Metric, borrow workflow: model.Workflow) {
+    let mut i: u64 = 0;
+    while i < workflow.edges.len() {
+        let edge = workflow.edges.get_or(i, model.empty_edge());
+        let value = edge_projection(borrow workflow, i);
+        metric.observe(inout result, value, i + 1);
+        metric.warn(inout result, edge.before >= workflow.tasks.len() || edge.after >= workflow.tasks.len());
+        i += 1;
+    }
+}
+
+fn observe_pools(inout result: metric.Metric, borrow workflow: model.Workflow) {
+    let mut i: u64 = 0;
+    while i < workflow.pools.len() {
+        let value = pool_projection(borrow workflow, i);
+        let pool = workflow.pools.get_or(i, model.empty_pool());
+        metric.observe(inout result, value, pool.slots + 1);
+        metric.warn(inout result, pool.slots == 0 || pool.cpu == 0 || pool.memory == 0);
+        i += 1;
+    }
+}
+
+fn observe_pairs(inout result: metric.Metric, borrow workflow: model.Workflow) -> u64 {
+    let mut pairs: u64 = 0;
+    let mut first: u64 = 0;
+    while first < workflow.tasks.len() {
+        let mut second: u64 = first + 1;
+        while second < workflow.tasks.len() {
+            if related_pair(borrow workflow, first, second) {
+                metric.observe(inout result, pair_projection(borrow workflow, first, second), first + second + 1);
+                pairs += 1;
+            }
+            second += 1;
+        }
+        first += 1;
+    }
+    pairs
+}
+
+pub fn analyze(borrow workflow: model.Workflow) -> metric.Metric {
+    let mut result = metric.new(TAG());
+    observe_tasks(inout result, borrow workflow);
+    observe_edges(inout result, borrow workflow);
+    observe_pools(inout result, borrow workflow);
+    let pairs = observe_pairs(inout result, borrow workflow);
+    metric.warn(inout result, workflow.tasks.len() > 1 && pairs == 0);
+    metric.finish(inout result);
+    result
+}
+
+pub fn verify(borrow workflow: model.Workflow, borrow result: metric.Metric) -> bool {
+    let floor = workflow.tasks.len() + workflow.edges.len() + workflow.pools.len();
+    result.tag == TAG() && result.observations >= floor &&
+        result.even + result.odd == result.observations &&
+        result.zeroes <= result.observations &&
+        (result.observations == 0 || result.minimum <= result.maximum)
+}
+
+pub fn render(borrow workflow: model.Workflow) -> StrBuf {
+    let result = analyze(borrow workflow);
+    let mut out = metric.render("dependency_distance", borrow result);
+    text.append_literal(inout out, "verified=");
+    text.append_bool(inout out, verify(borrow workflow, borrow result));
+    out.push(10);
+    out
+}

--- a/performance/workloads/lattice/analysis_deterministic_keys.rue
+++ b/performance/workloads/lattice/analysis_deterministic_keys.rue
@@ -1,0 +1,133 @@
+// Lattice analysis pass: identifier fingerprint distribution.
+//
+// This pass deliberately walks tasks, pools, dependencies, and bounded task
+// pairs. The four projections expose different compiler and application
+// behavior: field-heavy records, cross-module calls, graph indirection, nested
+// control flow, checked aggregation, and deterministic report generation.
+const std = @import("std");
+const metric = @import("metric.rue");
+const model = @import("model.rue");
+const text = @import("text.rue");
+const StrBuf = std.strbuf.StrBuf;
+
+pub fn TAG() -> u64 { 1034 }
+
+fn pool_for(borrow workflow: model.Workflow, index: u64) -> model.WorkerPool {
+    workflow.pools.get_or(index, model.empty_pool())
+}
+
+fn task_projection(borrow workflow: model.Workflow, index: u64) -> u64 {
+    let task = workflow.tasks.get_or(index, model.empty_task());
+    let _task_id = task.id;
+    let _assigned_pool = pool_for(borrow workflow, task.pool);
+    workflow.strings.hash(task.id)
+}
+
+fn edge_projection(borrow workflow: model.Workflow, index: u64) -> u64 {
+    let edge = workflow.edges.get_or(index, model.empty_edge());
+    let before = workflow.tasks.get_or(edge.before, model.empty_task());
+    let after = workflow.tasks.get_or(edge.after, model.empty_task());
+    let _before_id = before.id;
+    let _after_id = after.id;
+    workflow.strings.hash(before.id) ^ workflow.strings.hash(after.id)
+}
+
+fn pool_projection(borrow workflow: model.Workflow, index: u64) -> u64 {
+    let pool = workflow.pools.get_or(index, model.empty_pool());
+    workflow.strings.hash(pool.id)
+}
+
+fn related_pair(borrow workflow: model.Workflow, first: u64, second: u64) -> bool {
+    if first == second { return false; }
+    model.has_edge(borrow workflow, first, second) ||
+        model.has_edge(borrow workflow, second, first) ||
+        workflow.tasks.get_or(first, model.empty_task()).pool ==
+            workflow.tasks.get_or(second, model.empty_task()).pool
+}
+
+fn pair_projection(borrow workflow: model.Workflow, first: u64, second: u64) -> u64 {
+    let left = workflow.tasks.get_or(first, model.empty_task());
+    let right = workflow.tasks.get_or(second, model.empty_task());
+    let distance = if second >= first { second - first } else { first - second };
+    let resource = left.cpu + left.memory + right.cpu + right.memory;
+    let duration = left.duration + right.duration;
+    (distance + 1) * (resource + 1) + duration + 1034
+}
+
+fn observe_tasks(inout result: metric.Metric, borrow workflow: model.Workflow) {
+    let mut i: u64 = 0;
+    while i < workflow.tasks.len() {
+        let value = task_projection(borrow workflow, i);
+        let task = workflow.tasks.get_or(i, model.empty_task());
+        metric.observe(inout result, value, task.priority + 1);
+        metric.warn(inout result, task.duration == 0 || task.cpu == 0 || task.memory == 0);
+        i += 1;
+    }
+}
+
+fn observe_edges(inout result: metric.Metric, borrow workflow: model.Workflow) {
+    let mut i: u64 = 0;
+    while i < workflow.edges.len() {
+        let edge = workflow.edges.get_or(i, model.empty_edge());
+        let value = edge_projection(borrow workflow, i);
+        metric.observe(inout result, value, i + 1);
+        metric.warn(inout result, edge.before >= workflow.tasks.len() || edge.after >= workflow.tasks.len());
+        i += 1;
+    }
+}
+
+fn observe_pools(inout result: metric.Metric, borrow workflow: model.Workflow) {
+    let mut i: u64 = 0;
+    while i < workflow.pools.len() {
+        let value = pool_projection(borrow workflow, i);
+        let pool = workflow.pools.get_or(i, model.empty_pool());
+        metric.observe(inout result, value, pool.slots + 1);
+        metric.warn(inout result, pool.slots == 0 || pool.cpu == 0 || pool.memory == 0);
+        i += 1;
+    }
+}
+
+fn observe_pairs(inout result: metric.Metric, borrow workflow: model.Workflow) -> u64 {
+    let mut pairs: u64 = 0;
+    let mut first: u64 = 0;
+    while first < workflow.tasks.len() {
+        let mut second: u64 = first + 1;
+        while second < workflow.tasks.len() {
+            if related_pair(borrow workflow, first, second) {
+                metric.observe(inout result, pair_projection(borrow workflow, first, second), first + second + 1);
+                pairs += 1;
+            }
+            second += 1;
+        }
+        first += 1;
+    }
+    pairs
+}
+
+pub fn analyze(borrow workflow: model.Workflow) -> metric.Metric {
+    let mut result = metric.new(TAG());
+    observe_tasks(inout result, borrow workflow);
+    observe_edges(inout result, borrow workflow);
+    observe_pools(inout result, borrow workflow);
+    let pairs = observe_pairs(inout result, borrow workflow);
+    metric.warn(inout result, workflow.tasks.len() > 1 && pairs == 0);
+    metric.finish(inout result);
+    result
+}
+
+pub fn verify(borrow workflow: model.Workflow, borrow result: metric.Metric) -> bool {
+    let floor = workflow.tasks.len() + workflow.edges.len() + workflow.pools.len();
+    result.tag == TAG() && result.observations >= floor &&
+        result.even + result.odd == result.observations &&
+        result.zeroes <= result.observations &&
+        (result.observations == 0 || result.minimum <= result.maximum)
+}
+
+pub fn render(borrow workflow: model.Workflow) -> StrBuf {
+    let result = analyze(borrow workflow);
+    let mut out = metric.render("deterministic_keys", borrow result);
+    text.append_literal(inout out, "verified=");
+    text.append_bool(inout out, verify(borrow workflow, borrow result));
+    out.push(10);
+    out
+}

--- a/performance/workloads/lattice/analysis_duration_profile.rue
+++ b/performance/workloads/lattice/analysis_duration_profile.rue
@@ -1,0 +1,133 @@
+// Lattice analysis pass: task duration and dependency latency.
+//
+// This pass deliberately walks tasks, pools, dependencies, and bounded task
+// pairs. The four projections expose different compiler and application
+// behavior: field-heavy records, cross-module calls, graph indirection, nested
+// control flow, checked aggregation, and deterministic report generation.
+const std = @import("std");
+const metric = @import("metric.rue");
+const model = @import("model.rue");
+const text = @import("text.rue");
+const StrBuf = std.strbuf.StrBuf;
+
+pub fn TAG() -> u64 { 1001 }
+
+fn pool_for(borrow workflow: model.Workflow, index: u64) -> model.WorkerPool {
+    workflow.pools.get_or(index, model.empty_pool())
+}
+
+fn task_projection(borrow workflow: model.Workflow, index: u64) -> u64 {
+    let task = workflow.tasks.get_or(index, model.empty_task());
+    let _task_id = task.id;
+    let _assigned_pool = pool_for(borrow workflow, task.pool);
+    task.duration
+}
+
+fn edge_projection(borrow workflow: model.Workflow, index: u64) -> u64 {
+    let edge = workflow.edges.get_or(index, model.empty_edge());
+    let before = workflow.tasks.get_or(edge.before, model.empty_task());
+    let after = workflow.tasks.get_or(edge.after, model.empty_task());
+    let _before_id = before.id;
+    let _after_id = after.id;
+    before.duration + after.duration
+}
+
+fn pool_projection(borrow workflow: model.Workflow, index: u64) -> u64 {
+    let pool = workflow.pools.get_or(index, model.empty_pool());
+    pool.slots
+}
+
+fn related_pair(borrow workflow: model.Workflow, first: u64, second: u64) -> bool {
+    if first == second { return false; }
+    model.has_edge(borrow workflow, first, second) ||
+        model.has_edge(borrow workflow, second, first) ||
+        workflow.tasks.get_or(first, model.empty_task()).pool ==
+            workflow.tasks.get_or(second, model.empty_task()).pool
+}
+
+fn pair_projection(borrow workflow: model.Workflow, first: u64, second: u64) -> u64 {
+    let left = workflow.tasks.get_or(first, model.empty_task());
+    let right = workflow.tasks.get_or(second, model.empty_task());
+    let distance = if second >= first { second - first } else { first - second };
+    let resource = left.cpu + left.memory + right.cpu + right.memory;
+    let duration = left.duration + right.duration;
+    (distance + 1) * (resource + 1) + duration + 1001
+}
+
+fn observe_tasks(inout result: metric.Metric, borrow workflow: model.Workflow) {
+    let mut i: u64 = 0;
+    while i < workflow.tasks.len() {
+        let value = task_projection(borrow workflow, i);
+        let task = workflow.tasks.get_or(i, model.empty_task());
+        metric.observe(inout result, value, task.priority + 1);
+        metric.warn(inout result, task.duration == 0 || task.cpu == 0 || task.memory == 0);
+        i += 1;
+    }
+}
+
+fn observe_edges(inout result: metric.Metric, borrow workflow: model.Workflow) {
+    let mut i: u64 = 0;
+    while i < workflow.edges.len() {
+        let edge = workflow.edges.get_or(i, model.empty_edge());
+        let value = edge_projection(borrow workflow, i);
+        metric.observe(inout result, value, i + 1);
+        metric.warn(inout result, edge.before >= workflow.tasks.len() || edge.after >= workflow.tasks.len());
+        i += 1;
+    }
+}
+
+fn observe_pools(inout result: metric.Metric, borrow workflow: model.Workflow) {
+    let mut i: u64 = 0;
+    while i < workflow.pools.len() {
+        let value = pool_projection(borrow workflow, i);
+        let pool = workflow.pools.get_or(i, model.empty_pool());
+        metric.observe(inout result, value, pool.slots + 1);
+        metric.warn(inout result, pool.slots == 0 || pool.cpu == 0 || pool.memory == 0);
+        i += 1;
+    }
+}
+
+fn observe_pairs(inout result: metric.Metric, borrow workflow: model.Workflow) -> u64 {
+    let mut pairs: u64 = 0;
+    let mut first: u64 = 0;
+    while first < workflow.tasks.len() {
+        let mut second: u64 = first + 1;
+        while second < workflow.tasks.len() {
+            if related_pair(borrow workflow, first, second) {
+                metric.observe(inout result, pair_projection(borrow workflow, first, second), first + second + 1);
+                pairs += 1;
+            }
+            second += 1;
+        }
+        first += 1;
+    }
+    pairs
+}
+
+pub fn analyze(borrow workflow: model.Workflow) -> metric.Metric {
+    let mut result = metric.new(TAG());
+    observe_tasks(inout result, borrow workflow);
+    observe_edges(inout result, borrow workflow);
+    observe_pools(inout result, borrow workflow);
+    let pairs = observe_pairs(inout result, borrow workflow);
+    metric.warn(inout result, workflow.tasks.len() > 1 && pairs == 0);
+    metric.finish(inout result);
+    result
+}
+
+pub fn verify(borrow workflow: model.Workflow, borrow result: metric.Metric) -> bool {
+    let floor = workflow.tasks.len() + workflow.edges.len() + workflow.pools.len();
+    result.tag == TAG() && result.observations >= floor &&
+        result.even + result.odd == result.observations &&
+        result.zeroes <= result.observations &&
+        (result.observations == 0 || result.minimum <= result.maximum)
+}
+
+pub fn render(borrow workflow: model.Workflow) -> StrBuf {
+    let result = analyze(borrow workflow);
+    let mut out = metric.render("duration_profile", borrow result);
+    text.append_literal(inout out, "verified=");
+    text.append_bool(inout out, verify(borrow workflow, borrow result));
+    out.push(10);
+    out
+}

--- a/performance/workloads/lattice/analysis_duration_variance_proxy.rue
+++ b/performance/workloads/lattice/analysis_duration_variance_proxy.rue
@@ -1,0 +1,133 @@
+// Lattice analysis pass: duration second moment.
+//
+// This pass deliberately walks tasks, pools, dependencies, and bounded task
+// pairs. The four projections expose different compiler and application
+// behavior: field-heavy records, cross-module calls, graph indirection, nested
+// control flow, checked aggregation, and deterministic report generation.
+const std = @import("std");
+const metric = @import("metric.rue");
+const model = @import("model.rue");
+const text = @import("text.rue");
+const StrBuf = std.strbuf.StrBuf;
+
+pub fn TAG() -> u64 { 1039 }
+
+fn pool_for(borrow workflow: model.Workflow, index: u64) -> model.WorkerPool {
+    workflow.pools.get_or(index, model.empty_pool())
+}
+
+fn task_projection(borrow workflow: model.Workflow, index: u64) -> u64 {
+    let task = workflow.tasks.get_or(index, model.empty_task());
+    let _task_id = task.id;
+    let _assigned_pool = pool_for(borrow workflow, task.pool);
+    task.duration * task.duration
+}
+
+fn edge_projection(borrow workflow: model.Workflow, index: u64) -> u64 {
+    let edge = workflow.edges.get_or(index, model.empty_edge());
+    let before = workflow.tasks.get_or(edge.before, model.empty_task());
+    let after = workflow.tasks.get_or(edge.after, model.empty_task());
+    let _before_id = before.id;
+    let _after_id = after.id;
+    before.duration * after.duration
+}
+
+fn pool_projection(borrow workflow: model.Workflow, index: u64) -> u64 {
+    let pool = workflow.pools.get_or(index, model.empty_pool());
+    pool.slots * pool.slots
+}
+
+fn related_pair(borrow workflow: model.Workflow, first: u64, second: u64) -> bool {
+    if first == second { return false; }
+    model.has_edge(borrow workflow, first, second) ||
+        model.has_edge(borrow workflow, second, first) ||
+        workflow.tasks.get_or(first, model.empty_task()).pool ==
+            workflow.tasks.get_or(second, model.empty_task()).pool
+}
+
+fn pair_projection(borrow workflow: model.Workflow, first: u64, second: u64) -> u64 {
+    let left = workflow.tasks.get_or(first, model.empty_task());
+    let right = workflow.tasks.get_or(second, model.empty_task());
+    let distance = if second >= first { second - first } else { first - second };
+    let resource = left.cpu + left.memory + right.cpu + right.memory;
+    let duration = left.duration + right.duration;
+    (distance + 1) * (resource + 1) + duration + 1039
+}
+
+fn observe_tasks(inout result: metric.Metric, borrow workflow: model.Workflow) {
+    let mut i: u64 = 0;
+    while i < workflow.tasks.len() {
+        let value = task_projection(borrow workflow, i);
+        let task = workflow.tasks.get_or(i, model.empty_task());
+        metric.observe(inout result, value, task.priority + 1);
+        metric.warn(inout result, task.duration == 0 || task.cpu == 0 || task.memory == 0);
+        i += 1;
+    }
+}
+
+fn observe_edges(inout result: metric.Metric, borrow workflow: model.Workflow) {
+    let mut i: u64 = 0;
+    while i < workflow.edges.len() {
+        let edge = workflow.edges.get_or(i, model.empty_edge());
+        let value = edge_projection(borrow workflow, i);
+        metric.observe(inout result, value, i + 1);
+        metric.warn(inout result, edge.before >= workflow.tasks.len() || edge.after >= workflow.tasks.len());
+        i += 1;
+    }
+}
+
+fn observe_pools(inout result: metric.Metric, borrow workflow: model.Workflow) {
+    let mut i: u64 = 0;
+    while i < workflow.pools.len() {
+        let value = pool_projection(borrow workflow, i);
+        let pool = workflow.pools.get_or(i, model.empty_pool());
+        metric.observe(inout result, value, pool.slots + 1);
+        metric.warn(inout result, pool.slots == 0 || pool.cpu == 0 || pool.memory == 0);
+        i += 1;
+    }
+}
+
+fn observe_pairs(inout result: metric.Metric, borrow workflow: model.Workflow) -> u64 {
+    let mut pairs: u64 = 0;
+    let mut first: u64 = 0;
+    while first < workflow.tasks.len() {
+        let mut second: u64 = first + 1;
+        while second < workflow.tasks.len() {
+            if related_pair(borrow workflow, first, second) {
+                metric.observe(inout result, pair_projection(borrow workflow, first, second), first + second + 1);
+                pairs += 1;
+            }
+            second += 1;
+        }
+        first += 1;
+    }
+    pairs
+}
+
+pub fn analyze(borrow workflow: model.Workflow) -> metric.Metric {
+    let mut result = metric.new(TAG());
+    observe_tasks(inout result, borrow workflow);
+    observe_edges(inout result, borrow workflow);
+    observe_pools(inout result, borrow workflow);
+    let pairs = observe_pairs(inout result, borrow workflow);
+    metric.warn(inout result, workflow.tasks.len() > 1 && pairs == 0);
+    metric.finish(inout result);
+    result
+}
+
+pub fn verify(borrow workflow: model.Workflow, borrow result: metric.Metric) -> bool {
+    let floor = workflow.tasks.len() + workflow.edges.len() + workflow.pools.len();
+    result.tag == TAG() && result.observations >= floor &&
+        result.even + result.odd == result.observations &&
+        result.zeroes <= result.observations &&
+        (result.observations == 0 || result.minimum <= result.maximum)
+}
+
+pub fn render(borrow workflow: model.Workflow) -> StrBuf {
+    let result = analyze(borrow workflow);
+    let mut out = metric.render("duration_variance_proxy", borrow result);
+    text.append_literal(inout out, "verified=");
+    text.append_bool(inout out, verify(borrow workflow, borrow result));
+    out.push(10);
+    out
+}

--- a/performance/workloads/lattice/analysis_edge_work.rue
+++ b/performance/workloads/lattice/analysis_edge_work.rue
@@ -1,0 +1,133 @@
+// Lattice analysis pass: dependency work coupling.
+//
+// This pass deliberately walks tasks, pools, dependencies, and bounded task
+// pairs. The four projections expose different compiler and application
+// behavior: field-heavy records, cross-module calls, graph indirection, nested
+// control flow, checked aggregation, and deterministic report generation.
+const std = @import("std");
+const metric = @import("metric.rue");
+const model = @import("model.rue");
+const text = @import("text.rue");
+const StrBuf = std.strbuf.StrBuf;
+
+pub fn TAG() -> u64 { 1043 }
+
+fn pool_for(borrow workflow: model.Workflow, index: u64) -> model.WorkerPool {
+    workflow.pools.get_or(index, model.empty_pool())
+}
+
+fn task_projection(borrow workflow: model.Workflow, index: u64) -> u64 {
+    let task = workflow.tasks.get_or(index, model.empty_task());
+    let _task_id = task.id;
+    let _assigned_pool = pool_for(borrow workflow, task.pool);
+    task.duration
+}
+
+fn edge_projection(borrow workflow: model.Workflow, index: u64) -> u64 {
+    let edge = workflow.edges.get_or(index, model.empty_edge());
+    let before = workflow.tasks.get_or(edge.before, model.empty_task());
+    let after = workflow.tasks.get_or(edge.after, model.empty_task());
+    let _before_id = before.id;
+    let _after_id = after.id;
+    before.duration * after.duration
+}
+
+fn pool_projection(borrow workflow: model.Workflow, index: u64) -> u64 {
+    let pool = workflow.pools.get_or(index, model.empty_pool());
+    pool.cpu + pool.memory
+}
+
+fn related_pair(borrow workflow: model.Workflow, first: u64, second: u64) -> bool {
+    if first == second { return false; }
+    model.has_edge(borrow workflow, first, second) ||
+        model.has_edge(borrow workflow, second, first) ||
+        workflow.tasks.get_or(first, model.empty_task()).pool ==
+            workflow.tasks.get_or(second, model.empty_task()).pool
+}
+
+fn pair_projection(borrow workflow: model.Workflow, first: u64, second: u64) -> u64 {
+    let left = workflow.tasks.get_or(first, model.empty_task());
+    let right = workflow.tasks.get_or(second, model.empty_task());
+    let distance = if second >= first { second - first } else { first - second };
+    let resource = left.cpu + left.memory + right.cpu + right.memory;
+    let duration = left.duration + right.duration;
+    (distance + 1) * (resource + 1) + duration + 1043
+}
+
+fn observe_tasks(inout result: metric.Metric, borrow workflow: model.Workflow) {
+    let mut i: u64 = 0;
+    while i < workflow.tasks.len() {
+        let value = task_projection(borrow workflow, i);
+        let task = workflow.tasks.get_or(i, model.empty_task());
+        metric.observe(inout result, value, task.priority + 1);
+        metric.warn(inout result, task.duration == 0 || task.cpu == 0 || task.memory == 0);
+        i += 1;
+    }
+}
+
+fn observe_edges(inout result: metric.Metric, borrow workflow: model.Workflow) {
+    let mut i: u64 = 0;
+    while i < workflow.edges.len() {
+        let edge = workflow.edges.get_or(i, model.empty_edge());
+        let value = edge_projection(borrow workflow, i);
+        metric.observe(inout result, value, i + 1);
+        metric.warn(inout result, edge.before >= workflow.tasks.len() || edge.after >= workflow.tasks.len());
+        i += 1;
+    }
+}
+
+fn observe_pools(inout result: metric.Metric, borrow workflow: model.Workflow) {
+    let mut i: u64 = 0;
+    while i < workflow.pools.len() {
+        let value = pool_projection(borrow workflow, i);
+        let pool = workflow.pools.get_or(i, model.empty_pool());
+        metric.observe(inout result, value, pool.slots + 1);
+        metric.warn(inout result, pool.slots == 0 || pool.cpu == 0 || pool.memory == 0);
+        i += 1;
+    }
+}
+
+fn observe_pairs(inout result: metric.Metric, borrow workflow: model.Workflow) -> u64 {
+    let mut pairs: u64 = 0;
+    let mut first: u64 = 0;
+    while first < workflow.tasks.len() {
+        let mut second: u64 = first + 1;
+        while second < workflow.tasks.len() {
+            if related_pair(borrow workflow, first, second) {
+                metric.observe(inout result, pair_projection(borrow workflow, first, second), first + second + 1);
+                pairs += 1;
+            }
+            second += 1;
+        }
+        first += 1;
+    }
+    pairs
+}
+
+pub fn analyze(borrow workflow: model.Workflow) -> metric.Metric {
+    let mut result = metric.new(TAG());
+    observe_tasks(inout result, borrow workflow);
+    observe_edges(inout result, borrow workflow);
+    observe_pools(inout result, borrow workflow);
+    let pairs = observe_pairs(inout result, borrow workflow);
+    metric.warn(inout result, workflow.tasks.len() > 1 && pairs == 0);
+    metric.finish(inout result);
+    result
+}
+
+pub fn verify(borrow workflow: model.Workflow, borrow result: metric.Metric) -> bool {
+    let floor = workflow.tasks.len() + workflow.edges.len() + workflow.pools.len();
+    result.tag == TAG() && result.observations >= floor &&
+        result.even + result.odd == result.observations &&
+        result.zeroes <= result.observations &&
+        (result.observations == 0 || result.minimum <= result.maximum)
+}
+
+pub fn render(borrow workflow: model.Workflow) -> StrBuf {
+    let result = analyze(borrow workflow);
+    let mut out = metric.render("edge_work", borrow result);
+    text.append_literal(inout out, "verified=");
+    text.append_bool(inout out, verify(borrow workflow, borrow result));
+    out.push(10);
+    out
+}

--- a/performance/workloads/lattice/analysis_failure_exposure.rue
+++ b/performance/workloads/lattice/analysis_failure_exposure.rue
@@ -1,0 +1,133 @@
+// Lattice analysis pass: injected failure exposure.
+//
+// This pass deliberately walks tasks, pools, dependencies, and bounded task
+// pairs. The four projections expose different compiler and application
+// behavior: field-heavy records, cross-module calls, graph indirection, nested
+// control flow, checked aggregation, and deterministic report generation.
+const std = @import("std");
+const metric = @import("metric.rue");
+const model = @import("model.rue");
+const text = @import("text.rue");
+const StrBuf = std.strbuf.StrBuf;
+
+pub fn TAG() -> u64 { 1021 }
+
+fn pool_for(borrow workflow: model.Workflow, index: u64) -> model.WorkerPool {
+    workflow.pools.get_or(index, model.empty_pool())
+}
+
+fn task_projection(borrow workflow: model.Workflow, index: u64) -> u64 {
+    let task = workflow.tasks.get_or(index, model.empty_task());
+    let _task_id = task.id;
+    let _assigned_pool = pool_for(borrow workflow, task.pool);
+    if task.fail_attempt > 0 { task.duration * (task.retries + 1) } else { 0 }
+}
+
+fn edge_projection(borrow workflow: model.Workflow, index: u64) -> u64 {
+    let edge = workflow.edges.get_or(index, model.empty_edge());
+    let before = workflow.tasks.get_or(edge.before, model.empty_task());
+    let after = workflow.tasks.get_or(edge.after, model.empty_task());
+    let _before_id = before.id;
+    let _after_id = after.id;
+    before.fail_attempt + after.fail_attempt
+}
+
+fn pool_projection(borrow workflow: model.Workflow, index: u64) -> u64 {
+    let pool = workflow.pools.get_or(index, model.empty_pool());
+    pool.cpu
+}
+
+fn related_pair(borrow workflow: model.Workflow, first: u64, second: u64) -> bool {
+    if first == second { return false; }
+    model.has_edge(borrow workflow, first, second) ||
+        model.has_edge(borrow workflow, second, first) ||
+        workflow.tasks.get_or(first, model.empty_task()).pool ==
+            workflow.tasks.get_or(second, model.empty_task()).pool
+}
+
+fn pair_projection(borrow workflow: model.Workflow, first: u64, second: u64) -> u64 {
+    let left = workflow.tasks.get_or(first, model.empty_task());
+    let right = workflow.tasks.get_or(second, model.empty_task());
+    let distance = if second >= first { second - first } else { first - second };
+    let resource = left.cpu + left.memory + right.cpu + right.memory;
+    let duration = left.duration + right.duration;
+    (distance + 1) * (resource + 1) + duration + 1021
+}
+
+fn observe_tasks(inout result: metric.Metric, borrow workflow: model.Workflow) {
+    let mut i: u64 = 0;
+    while i < workflow.tasks.len() {
+        let value = task_projection(borrow workflow, i);
+        let task = workflow.tasks.get_or(i, model.empty_task());
+        metric.observe(inout result, value, task.priority + 1);
+        metric.warn(inout result, task.duration == 0 || task.cpu == 0 || task.memory == 0);
+        i += 1;
+    }
+}
+
+fn observe_edges(inout result: metric.Metric, borrow workflow: model.Workflow) {
+    let mut i: u64 = 0;
+    while i < workflow.edges.len() {
+        let edge = workflow.edges.get_or(i, model.empty_edge());
+        let value = edge_projection(borrow workflow, i);
+        metric.observe(inout result, value, i + 1);
+        metric.warn(inout result, edge.before >= workflow.tasks.len() || edge.after >= workflow.tasks.len());
+        i += 1;
+    }
+}
+
+fn observe_pools(inout result: metric.Metric, borrow workflow: model.Workflow) {
+    let mut i: u64 = 0;
+    while i < workflow.pools.len() {
+        let value = pool_projection(borrow workflow, i);
+        let pool = workflow.pools.get_or(i, model.empty_pool());
+        metric.observe(inout result, value, pool.slots + 1);
+        metric.warn(inout result, pool.slots == 0 || pool.cpu == 0 || pool.memory == 0);
+        i += 1;
+    }
+}
+
+fn observe_pairs(inout result: metric.Metric, borrow workflow: model.Workflow) -> u64 {
+    let mut pairs: u64 = 0;
+    let mut first: u64 = 0;
+    while first < workflow.tasks.len() {
+        let mut second: u64 = first + 1;
+        while second < workflow.tasks.len() {
+            if related_pair(borrow workflow, first, second) {
+                metric.observe(inout result, pair_projection(borrow workflow, first, second), first + second + 1);
+                pairs += 1;
+            }
+            second += 1;
+        }
+        first += 1;
+    }
+    pairs
+}
+
+pub fn analyze(borrow workflow: model.Workflow) -> metric.Metric {
+    let mut result = metric.new(TAG());
+    observe_tasks(inout result, borrow workflow);
+    observe_edges(inout result, borrow workflow);
+    observe_pools(inout result, borrow workflow);
+    let pairs = observe_pairs(inout result, borrow workflow);
+    metric.warn(inout result, workflow.tasks.len() > 1 && pairs == 0);
+    metric.finish(inout result);
+    result
+}
+
+pub fn verify(borrow workflow: model.Workflow, borrow result: metric.Metric) -> bool {
+    let floor = workflow.tasks.len() + workflow.edges.len() + workflow.pools.len();
+    result.tag == TAG() && result.observations >= floor &&
+        result.even + result.odd == result.observations &&
+        result.zeroes <= result.observations &&
+        (result.observations == 0 || result.minimum <= result.maximum)
+}
+
+pub fn render(borrow workflow: model.Workflow) -> StrBuf {
+    let result = analyze(borrow workflow);
+    let mut out = metric.render("failure_exposure", borrow result);
+    text.append_literal(inout out, "verified=");
+    text.append_bool(inout out, verify(borrow workflow, borrow result));
+    out.push(10);
+    out
+}

--- a/performance/workloads/lattice/analysis_failure_recovery.rue
+++ b/performance/workloads/lattice/analysis_failure_recovery.rue
@@ -1,0 +1,133 @@
+// Lattice analysis pass: failure and recovery demand.
+//
+// This pass deliberately walks tasks, pools, dependencies, and bounded task
+// pairs. The four projections expose different compiler and application
+// behavior: field-heavy records, cross-module calls, graph indirection, nested
+// control flow, checked aggregation, and deterministic report generation.
+const std = @import("std");
+const metric = @import("metric.rue");
+const model = @import("model.rue");
+const text = @import("text.rue");
+const StrBuf = std.strbuf.StrBuf;
+
+pub fn TAG() -> u64 { 1048 }
+
+fn pool_for(borrow workflow: model.Workflow, index: u64) -> model.WorkerPool {
+    workflow.pools.get_or(index, model.empty_pool())
+}
+
+fn task_projection(borrow workflow: model.Workflow, index: u64) -> u64 {
+    let task = workflow.tasks.get_or(index, model.empty_task());
+    let _task_id = task.id;
+    let _assigned_pool = pool_for(borrow workflow, task.pool);
+    if task.fail_attempt > 0 { task.duration * (task.retries + 1) + task.priority } else { task.retries }
+}
+
+fn edge_projection(borrow workflow: model.Workflow, index: u64) -> u64 {
+    let edge = workflow.edges.get_or(index, model.empty_edge());
+    let before = workflow.tasks.get_or(edge.before, model.empty_task());
+    let after = workflow.tasks.get_or(edge.after, model.empty_task());
+    let _before_id = before.id;
+    let _after_id = after.id;
+    before.fail_attempt * before.duration + after.fail_attempt * after.duration
+}
+
+fn pool_projection(borrow workflow: model.Workflow, index: u64) -> u64 {
+    let pool = workflow.pools.get_or(index, model.empty_pool());
+    pool.slots
+}
+
+fn related_pair(borrow workflow: model.Workflow, first: u64, second: u64) -> bool {
+    if first == second { return false; }
+    model.has_edge(borrow workflow, first, second) ||
+        model.has_edge(borrow workflow, second, first) ||
+        workflow.tasks.get_or(first, model.empty_task()).pool ==
+            workflow.tasks.get_or(second, model.empty_task()).pool
+}
+
+fn pair_projection(borrow workflow: model.Workflow, first: u64, second: u64) -> u64 {
+    let left = workflow.tasks.get_or(first, model.empty_task());
+    let right = workflow.tasks.get_or(second, model.empty_task());
+    let distance = if second >= first { second - first } else { first - second };
+    let resource = left.cpu + left.memory + right.cpu + right.memory;
+    let duration = left.duration + right.duration;
+    (distance + 1) * (resource + 1) + duration + 1048
+}
+
+fn observe_tasks(inout result: metric.Metric, borrow workflow: model.Workflow) {
+    let mut i: u64 = 0;
+    while i < workflow.tasks.len() {
+        let value = task_projection(borrow workflow, i);
+        let task = workflow.tasks.get_or(i, model.empty_task());
+        metric.observe(inout result, value, task.priority + 1);
+        metric.warn(inout result, task.duration == 0 || task.cpu == 0 || task.memory == 0);
+        i += 1;
+    }
+}
+
+fn observe_edges(inout result: metric.Metric, borrow workflow: model.Workflow) {
+    let mut i: u64 = 0;
+    while i < workflow.edges.len() {
+        let edge = workflow.edges.get_or(i, model.empty_edge());
+        let value = edge_projection(borrow workflow, i);
+        metric.observe(inout result, value, i + 1);
+        metric.warn(inout result, edge.before >= workflow.tasks.len() || edge.after >= workflow.tasks.len());
+        i += 1;
+    }
+}
+
+fn observe_pools(inout result: metric.Metric, borrow workflow: model.Workflow) {
+    let mut i: u64 = 0;
+    while i < workflow.pools.len() {
+        let value = pool_projection(borrow workflow, i);
+        let pool = workflow.pools.get_or(i, model.empty_pool());
+        metric.observe(inout result, value, pool.slots + 1);
+        metric.warn(inout result, pool.slots == 0 || pool.cpu == 0 || pool.memory == 0);
+        i += 1;
+    }
+}
+
+fn observe_pairs(inout result: metric.Metric, borrow workflow: model.Workflow) -> u64 {
+    let mut pairs: u64 = 0;
+    let mut first: u64 = 0;
+    while first < workflow.tasks.len() {
+        let mut second: u64 = first + 1;
+        while second < workflow.tasks.len() {
+            if related_pair(borrow workflow, first, second) {
+                metric.observe(inout result, pair_projection(borrow workflow, first, second), first + second + 1);
+                pairs += 1;
+            }
+            second += 1;
+        }
+        first += 1;
+    }
+    pairs
+}
+
+pub fn analyze(borrow workflow: model.Workflow) -> metric.Metric {
+    let mut result = metric.new(TAG());
+    observe_tasks(inout result, borrow workflow);
+    observe_edges(inout result, borrow workflow);
+    observe_pools(inout result, borrow workflow);
+    let pairs = observe_pairs(inout result, borrow workflow);
+    metric.warn(inout result, workflow.tasks.len() > 1 && pairs == 0);
+    metric.finish(inout result);
+    result
+}
+
+pub fn verify(borrow workflow: model.Workflow, borrow result: metric.Metric) -> bool {
+    let floor = workflow.tasks.len() + workflow.edges.len() + workflow.pools.len();
+    result.tag == TAG() && result.observations >= floor &&
+        result.even + result.odd == result.observations &&
+        result.zeroes <= result.observations &&
+        (result.observations == 0 || result.minimum <= result.maximum)
+}
+
+pub fn render(borrow workflow: model.Workflow) -> StrBuf {
+    let result = analyze(borrow workflow);
+    let mut out = metric.render("failure_recovery", borrow result);
+    text.append_literal(inout out, "verified=");
+    text.append_bool(inout out, verify(borrow workflow, borrow result));
+    out.push(10);
+    out
+}

--- a/performance/workloads/lattice/analysis_fanin_weight.rue
+++ b/performance/workloads/lattice/analysis_fanin_weight.rue
@@ -1,0 +1,133 @@
+// Lattice analysis pass: incoming dependency pressure.
+//
+// This pass deliberately walks tasks, pools, dependencies, and bounded task
+// pairs. The four projections expose different compiler and application
+// behavior: field-heavy records, cross-module calls, graph indirection, nested
+// control flow, checked aggregation, and deterministic report generation.
+const std = @import("std");
+const metric = @import("metric.rue");
+const model = @import("model.rue");
+const text = @import("text.rue");
+const StrBuf = std.strbuf.StrBuf;
+
+pub fn TAG() -> u64 { 1008 }
+
+fn pool_for(borrow workflow: model.Workflow, index: u64) -> model.WorkerPool {
+    workflow.pools.get_or(index, model.empty_pool())
+}
+
+fn task_projection(borrow workflow: model.Workflow, index: u64) -> u64 {
+    let task = workflow.tasks.get_or(index, model.empty_task());
+    let _task_id = task.id;
+    let _assigned_pool = pool_for(borrow workflow, task.pool);
+    model.dependency_count(borrow workflow, index) * (task.duration + 1)
+}
+
+fn edge_projection(borrow workflow: model.Workflow, index: u64) -> u64 {
+    let edge = workflow.edges.get_or(index, model.empty_edge());
+    let before = workflow.tasks.get_or(edge.before, model.empty_task());
+    let after = workflow.tasks.get_or(edge.after, model.empty_task());
+    let _before_id = before.id;
+    let _after_id = after.id;
+    model.dependency_count(borrow workflow, edge.after)
+}
+
+fn pool_projection(borrow workflow: model.Workflow, index: u64) -> u64 {
+    let pool = workflow.pools.get_or(index, model.empty_pool());
+    pool.slots
+}
+
+fn related_pair(borrow workflow: model.Workflow, first: u64, second: u64) -> bool {
+    if first == second { return false; }
+    model.has_edge(borrow workflow, first, second) ||
+        model.has_edge(borrow workflow, second, first) ||
+        workflow.tasks.get_or(first, model.empty_task()).pool ==
+            workflow.tasks.get_or(second, model.empty_task()).pool
+}
+
+fn pair_projection(borrow workflow: model.Workflow, first: u64, second: u64) -> u64 {
+    let left = workflow.tasks.get_or(first, model.empty_task());
+    let right = workflow.tasks.get_or(second, model.empty_task());
+    let distance = if second >= first { second - first } else { first - second };
+    let resource = left.cpu + left.memory + right.cpu + right.memory;
+    let duration = left.duration + right.duration;
+    (distance + 1) * (resource + 1) + duration + 1008
+}
+
+fn observe_tasks(inout result: metric.Metric, borrow workflow: model.Workflow) {
+    let mut i: u64 = 0;
+    while i < workflow.tasks.len() {
+        let value = task_projection(borrow workflow, i);
+        let task = workflow.tasks.get_or(i, model.empty_task());
+        metric.observe(inout result, value, task.priority + 1);
+        metric.warn(inout result, task.duration == 0 || task.cpu == 0 || task.memory == 0);
+        i += 1;
+    }
+}
+
+fn observe_edges(inout result: metric.Metric, borrow workflow: model.Workflow) {
+    let mut i: u64 = 0;
+    while i < workflow.edges.len() {
+        let edge = workflow.edges.get_or(i, model.empty_edge());
+        let value = edge_projection(borrow workflow, i);
+        metric.observe(inout result, value, i + 1);
+        metric.warn(inout result, edge.before >= workflow.tasks.len() || edge.after >= workflow.tasks.len());
+        i += 1;
+    }
+}
+
+fn observe_pools(inout result: metric.Metric, borrow workflow: model.Workflow) {
+    let mut i: u64 = 0;
+    while i < workflow.pools.len() {
+        let value = pool_projection(borrow workflow, i);
+        let pool = workflow.pools.get_or(i, model.empty_pool());
+        metric.observe(inout result, value, pool.slots + 1);
+        metric.warn(inout result, pool.slots == 0 || pool.cpu == 0 || pool.memory == 0);
+        i += 1;
+    }
+}
+
+fn observe_pairs(inout result: metric.Metric, borrow workflow: model.Workflow) -> u64 {
+    let mut pairs: u64 = 0;
+    let mut first: u64 = 0;
+    while first < workflow.tasks.len() {
+        let mut second: u64 = first + 1;
+        while second < workflow.tasks.len() {
+            if related_pair(borrow workflow, first, second) {
+                metric.observe(inout result, pair_projection(borrow workflow, first, second), first + second + 1);
+                pairs += 1;
+            }
+            second += 1;
+        }
+        first += 1;
+    }
+    pairs
+}
+
+pub fn analyze(borrow workflow: model.Workflow) -> metric.Metric {
+    let mut result = metric.new(TAG());
+    observe_tasks(inout result, borrow workflow);
+    observe_edges(inout result, borrow workflow);
+    observe_pools(inout result, borrow workflow);
+    let pairs = observe_pairs(inout result, borrow workflow);
+    metric.warn(inout result, workflow.tasks.len() > 1 && pairs == 0);
+    metric.finish(inout result);
+    result
+}
+
+pub fn verify(borrow workflow: model.Workflow, borrow result: metric.Metric) -> bool {
+    let floor = workflow.tasks.len() + workflow.edges.len() + workflow.pools.len();
+    result.tag == TAG() && result.observations >= floor &&
+        result.even + result.odd == result.observations &&
+        result.zeroes <= result.observations &&
+        (result.observations == 0 || result.minimum <= result.maximum)
+}
+
+pub fn render(borrow workflow: model.Workflow) -> StrBuf {
+    let result = analyze(borrow workflow);
+    let mut out = metric.render("fanin_weight", borrow result);
+    text.append_literal(inout out, "verified=");
+    text.append_bool(inout out, verify(borrow workflow, borrow result));
+    out.push(10);
+    out
+}

--- a/performance/workloads/lattice/analysis_fanout_weight.rue
+++ b/performance/workloads/lattice/analysis_fanout_weight.rue
@@ -1,0 +1,133 @@
+// Lattice analysis pass: outgoing dependency pressure.
+//
+// This pass deliberately walks tasks, pools, dependencies, and bounded task
+// pairs. The four projections expose different compiler and application
+// behavior: field-heavy records, cross-module calls, graph indirection, nested
+// control flow, checked aggregation, and deterministic report generation.
+const std = @import("std");
+const metric = @import("metric.rue");
+const model = @import("model.rue");
+const text = @import("text.rue");
+const StrBuf = std.strbuf.StrBuf;
+
+pub fn TAG() -> u64 { 1009 }
+
+fn pool_for(borrow workflow: model.Workflow, index: u64) -> model.WorkerPool {
+    workflow.pools.get_or(index, model.empty_pool())
+}
+
+fn task_projection(borrow workflow: model.Workflow, index: u64) -> u64 {
+    let task = workflow.tasks.get_or(index, model.empty_task());
+    let _task_id = task.id;
+    let _assigned_pool = pool_for(borrow workflow, task.pool);
+    model.dependent_count(borrow workflow, index) * (task.duration + 1)
+}
+
+fn edge_projection(borrow workflow: model.Workflow, index: u64) -> u64 {
+    let edge = workflow.edges.get_or(index, model.empty_edge());
+    let before = workflow.tasks.get_or(edge.before, model.empty_task());
+    let after = workflow.tasks.get_or(edge.after, model.empty_task());
+    let _before_id = before.id;
+    let _after_id = after.id;
+    model.dependent_count(borrow workflow, edge.before)
+}
+
+fn pool_projection(borrow workflow: model.Workflow, index: u64) -> u64 {
+    let pool = workflow.pools.get_or(index, model.empty_pool());
+    pool.slots
+}
+
+fn related_pair(borrow workflow: model.Workflow, first: u64, second: u64) -> bool {
+    if first == second { return false; }
+    model.has_edge(borrow workflow, first, second) ||
+        model.has_edge(borrow workflow, second, first) ||
+        workflow.tasks.get_or(first, model.empty_task()).pool ==
+            workflow.tasks.get_or(second, model.empty_task()).pool
+}
+
+fn pair_projection(borrow workflow: model.Workflow, first: u64, second: u64) -> u64 {
+    let left = workflow.tasks.get_or(first, model.empty_task());
+    let right = workflow.tasks.get_or(second, model.empty_task());
+    let distance = if second >= first { second - first } else { first - second };
+    let resource = left.cpu + left.memory + right.cpu + right.memory;
+    let duration = left.duration + right.duration;
+    (distance + 1) * (resource + 1) + duration + 1009
+}
+
+fn observe_tasks(inout result: metric.Metric, borrow workflow: model.Workflow) {
+    let mut i: u64 = 0;
+    while i < workflow.tasks.len() {
+        let value = task_projection(borrow workflow, i);
+        let task = workflow.tasks.get_or(i, model.empty_task());
+        metric.observe(inout result, value, task.priority + 1);
+        metric.warn(inout result, task.duration == 0 || task.cpu == 0 || task.memory == 0);
+        i += 1;
+    }
+}
+
+fn observe_edges(inout result: metric.Metric, borrow workflow: model.Workflow) {
+    let mut i: u64 = 0;
+    while i < workflow.edges.len() {
+        let edge = workflow.edges.get_or(i, model.empty_edge());
+        let value = edge_projection(borrow workflow, i);
+        metric.observe(inout result, value, i + 1);
+        metric.warn(inout result, edge.before >= workflow.tasks.len() || edge.after >= workflow.tasks.len());
+        i += 1;
+    }
+}
+
+fn observe_pools(inout result: metric.Metric, borrow workflow: model.Workflow) {
+    let mut i: u64 = 0;
+    while i < workflow.pools.len() {
+        let value = pool_projection(borrow workflow, i);
+        let pool = workflow.pools.get_or(i, model.empty_pool());
+        metric.observe(inout result, value, pool.slots + 1);
+        metric.warn(inout result, pool.slots == 0 || pool.cpu == 0 || pool.memory == 0);
+        i += 1;
+    }
+}
+
+fn observe_pairs(inout result: metric.Metric, borrow workflow: model.Workflow) -> u64 {
+    let mut pairs: u64 = 0;
+    let mut first: u64 = 0;
+    while first < workflow.tasks.len() {
+        let mut second: u64 = first + 1;
+        while second < workflow.tasks.len() {
+            if related_pair(borrow workflow, first, second) {
+                metric.observe(inout result, pair_projection(borrow workflow, first, second), first + second + 1);
+                pairs += 1;
+            }
+            second += 1;
+        }
+        first += 1;
+    }
+    pairs
+}
+
+pub fn analyze(borrow workflow: model.Workflow) -> metric.Metric {
+    let mut result = metric.new(TAG());
+    observe_tasks(inout result, borrow workflow);
+    observe_edges(inout result, borrow workflow);
+    observe_pools(inout result, borrow workflow);
+    let pairs = observe_pairs(inout result, borrow workflow);
+    metric.warn(inout result, workflow.tasks.len() > 1 && pairs == 0);
+    metric.finish(inout result);
+    result
+}
+
+pub fn verify(borrow workflow: model.Workflow, borrow result: metric.Metric) -> bool {
+    let floor = workflow.tasks.len() + workflow.edges.len() + workflow.pools.len();
+    result.tag == TAG() && result.observations >= floor &&
+        result.even + result.odd == result.observations &&
+        result.zeroes <= result.observations &&
+        (result.observations == 0 || result.minimum <= result.maximum)
+}
+
+pub fn render(borrow workflow: model.Workflow) -> StrBuf {
+    let result = analyze(borrow workflow);
+    let mut out = metric.render("fanout_weight", borrow result);
+    text.append_literal(inout out, "verified=");
+    text.append_bool(inout out, verify(borrow workflow, borrow result));
+    out.push(10);
+    out
+}

--- a/performance/workloads/lattice/analysis_graph_locality.rue
+++ b/performance/workloads/lattice/analysis_graph_locality.rue
@@ -1,0 +1,133 @@
+// Lattice analysis pass: arena and edge locality.
+//
+// This pass deliberately walks tasks, pools, dependencies, and bounded task
+// pairs. The four projections expose different compiler and application
+// behavior: field-heavy records, cross-module calls, graph indirection, nested
+// control flow, checked aggregation, and deterministic report generation.
+const std = @import("std");
+const metric = @import("metric.rue");
+const model = @import("model.rue");
+const text = @import("text.rue");
+const StrBuf = std.strbuf.StrBuf;
+
+pub fn TAG() -> u64 { 1035 }
+
+fn pool_for(borrow workflow: model.Workflow, index: u64) -> model.WorkerPool {
+    workflow.pools.get_or(index, model.empty_pool())
+}
+
+fn task_projection(borrow workflow: model.Workflow, index: u64) -> u64 {
+    let task = workflow.tasks.get_or(index, model.empty_task());
+    let _task_id = task.id;
+    let _assigned_pool = pool_for(borrow workflow, task.pool);
+    index * 31 + task.pool
+}
+
+fn edge_projection(borrow workflow: model.Workflow, index: u64) -> u64 {
+    let edge = workflow.edges.get_or(index, model.empty_edge());
+    let before = workflow.tasks.get_or(edge.before, model.empty_task());
+    let after = workflow.tasks.get_or(edge.after, model.empty_task());
+    let _before_id = before.id;
+    let _after_id = after.id;
+    edge.before * 17 + edge.after * 19
+}
+
+fn pool_projection(borrow workflow: model.Workflow, index: u64) -> u64 {
+    let pool = workflow.pools.get_or(index, model.empty_pool());
+    pool.slots * 23
+}
+
+fn related_pair(borrow workflow: model.Workflow, first: u64, second: u64) -> bool {
+    if first == second { return false; }
+    model.has_edge(borrow workflow, first, second) ||
+        model.has_edge(borrow workflow, second, first) ||
+        workflow.tasks.get_or(first, model.empty_task()).pool ==
+            workflow.tasks.get_or(second, model.empty_task()).pool
+}
+
+fn pair_projection(borrow workflow: model.Workflow, first: u64, second: u64) -> u64 {
+    let left = workflow.tasks.get_or(first, model.empty_task());
+    let right = workflow.tasks.get_or(second, model.empty_task());
+    let distance = if second >= first { second - first } else { first - second };
+    let resource = left.cpu + left.memory + right.cpu + right.memory;
+    let duration = left.duration + right.duration;
+    (distance + 1) * (resource + 1) + duration + 1035
+}
+
+fn observe_tasks(inout result: metric.Metric, borrow workflow: model.Workflow) {
+    let mut i: u64 = 0;
+    while i < workflow.tasks.len() {
+        let value = task_projection(borrow workflow, i);
+        let task = workflow.tasks.get_or(i, model.empty_task());
+        metric.observe(inout result, value, task.priority + 1);
+        metric.warn(inout result, task.duration == 0 || task.cpu == 0 || task.memory == 0);
+        i += 1;
+    }
+}
+
+fn observe_edges(inout result: metric.Metric, borrow workflow: model.Workflow) {
+    let mut i: u64 = 0;
+    while i < workflow.edges.len() {
+        let edge = workflow.edges.get_or(i, model.empty_edge());
+        let value = edge_projection(borrow workflow, i);
+        metric.observe(inout result, value, i + 1);
+        metric.warn(inout result, edge.before >= workflow.tasks.len() || edge.after >= workflow.tasks.len());
+        i += 1;
+    }
+}
+
+fn observe_pools(inout result: metric.Metric, borrow workflow: model.Workflow) {
+    let mut i: u64 = 0;
+    while i < workflow.pools.len() {
+        let value = pool_projection(borrow workflow, i);
+        let pool = workflow.pools.get_or(i, model.empty_pool());
+        metric.observe(inout result, value, pool.slots + 1);
+        metric.warn(inout result, pool.slots == 0 || pool.cpu == 0 || pool.memory == 0);
+        i += 1;
+    }
+}
+
+fn observe_pairs(inout result: metric.Metric, borrow workflow: model.Workflow) -> u64 {
+    let mut pairs: u64 = 0;
+    let mut first: u64 = 0;
+    while first < workflow.tasks.len() {
+        let mut second: u64 = first + 1;
+        while second < workflow.tasks.len() {
+            if related_pair(borrow workflow, first, second) {
+                metric.observe(inout result, pair_projection(borrow workflow, first, second), first + second + 1);
+                pairs += 1;
+            }
+            second += 1;
+        }
+        first += 1;
+    }
+    pairs
+}
+
+pub fn analyze(borrow workflow: model.Workflow) -> metric.Metric {
+    let mut result = metric.new(TAG());
+    observe_tasks(inout result, borrow workflow);
+    observe_edges(inout result, borrow workflow);
+    observe_pools(inout result, borrow workflow);
+    let pairs = observe_pairs(inout result, borrow workflow);
+    metric.warn(inout result, workflow.tasks.len() > 1 && pairs == 0);
+    metric.finish(inout result);
+    result
+}
+
+pub fn verify(borrow workflow: model.Workflow, borrow result: metric.Metric) -> bool {
+    let floor = workflow.tasks.len() + workflow.edges.len() + workflow.pools.len();
+    result.tag == TAG() && result.observations >= floor &&
+        result.even + result.odd == result.observations &&
+        result.zeroes <= result.observations &&
+        (result.observations == 0 || result.minimum <= result.maximum)
+}
+
+pub fn render(borrow workflow: model.Workflow) -> StrBuf {
+    let result = analyze(borrow workflow);
+    let mut out = metric.render("graph_locality", borrow result);
+    text.append_literal(inout out, "verified=");
+    text.append_bool(inout out, verify(borrow workflow, borrow result));
+    out.push(10);
+    out
+}

--- a/performance/workloads/lattice/analysis_high_priority_work.rue
+++ b/performance/workloads/lattice/analysis_high_priority_work.rue
@@ -1,0 +1,133 @@
+// Lattice analysis pass: high-priority workload.
+//
+// This pass deliberately walks tasks, pools, dependencies, and bounded task
+// pairs. The four projections expose different compiler and application
+// behavior: field-heavy records, cross-module calls, graph indirection, nested
+// control flow, checked aggregation, and deterministic report generation.
+const std = @import("std");
+const metric = @import("metric.rue");
+const model = @import("model.rue");
+const text = @import("text.rue");
+const StrBuf = std.strbuf.StrBuf;
+
+pub fn TAG() -> u64 { 1031 }
+
+fn pool_for(borrow workflow: model.Workflow, index: u64) -> model.WorkerPool {
+    workflow.pools.get_or(index, model.empty_pool())
+}
+
+fn task_projection(borrow workflow: model.Workflow, index: u64) -> u64 {
+    let task = workflow.tasks.get_or(index, model.empty_task());
+    let _task_id = task.id;
+    let _assigned_pool = pool_for(borrow workflow, task.pool);
+    if task.priority >= 10 { task.duration * task.priority } else { 0 }
+}
+
+fn edge_projection(borrow workflow: model.Workflow, index: u64) -> u64 {
+    let edge = workflow.edges.get_or(index, model.empty_edge());
+    let before = workflow.tasks.get_or(edge.before, model.empty_task());
+    let after = workflow.tasks.get_or(edge.after, model.empty_task());
+    let _before_id = before.id;
+    let _after_id = after.id;
+    if after.priority >= before.priority { after.priority } else { 0 }
+}
+
+fn pool_projection(borrow workflow: model.Workflow, index: u64) -> u64 {
+    let pool = workflow.pools.get_or(index, model.empty_pool());
+    pool.cpu
+}
+
+fn related_pair(borrow workflow: model.Workflow, first: u64, second: u64) -> bool {
+    if first == second { return false; }
+    model.has_edge(borrow workflow, first, second) ||
+        model.has_edge(borrow workflow, second, first) ||
+        workflow.tasks.get_or(first, model.empty_task()).pool ==
+            workflow.tasks.get_or(second, model.empty_task()).pool
+}
+
+fn pair_projection(borrow workflow: model.Workflow, first: u64, second: u64) -> u64 {
+    let left = workflow.tasks.get_or(first, model.empty_task());
+    let right = workflow.tasks.get_or(second, model.empty_task());
+    let distance = if second >= first { second - first } else { first - second };
+    let resource = left.cpu + left.memory + right.cpu + right.memory;
+    let duration = left.duration + right.duration;
+    (distance + 1) * (resource + 1) + duration + 1031
+}
+
+fn observe_tasks(inout result: metric.Metric, borrow workflow: model.Workflow) {
+    let mut i: u64 = 0;
+    while i < workflow.tasks.len() {
+        let value = task_projection(borrow workflow, i);
+        let task = workflow.tasks.get_or(i, model.empty_task());
+        metric.observe(inout result, value, task.priority + 1);
+        metric.warn(inout result, task.duration == 0 || task.cpu == 0 || task.memory == 0);
+        i += 1;
+    }
+}
+
+fn observe_edges(inout result: metric.Metric, borrow workflow: model.Workflow) {
+    let mut i: u64 = 0;
+    while i < workflow.edges.len() {
+        let edge = workflow.edges.get_or(i, model.empty_edge());
+        let value = edge_projection(borrow workflow, i);
+        metric.observe(inout result, value, i + 1);
+        metric.warn(inout result, edge.before >= workflow.tasks.len() || edge.after >= workflow.tasks.len());
+        i += 1;
+    }
+}
+
+fn observe_pools(inout result: metric.Metric, borrow workflow: model.Workflow) {
+    let mut i: u64 = 0;
+    while i < workflow.pools.len() {
+        let value = pool_projection(borrow workflow, i);
+        let pool = workflow.pools.get_or(i, model.empty_pool());
+        metric.observe(inout result, value, pool.slots + 1);
+        metric.warn(inout result, pool.slots == 0 || pool.cpu == 0 || pool.memory == 0);
+        i += 1;
+    }
+}
+
+fn observe_pairs(inout result: metric.Metric, borrow workflow: model.Workflow) -> u64 {
+    let mut pairs: u64 = 0;
+    let mut first: u64 = 0;
+    while first < workflow.tasks.len() {
+        let mut second: u64 = first + 1;
+        while second < workflow.tasks.len() {
+            if related_pair(borrow workflow, first, second) {
+                metric.observe(inout result, pair_projection(borrow workflow, first, second), first + second + 1);
+                pairs += 1;
+            }
+            second += 1;
+        }
+        first += 1;
+    }
+    pairs
+}
+
+pub fn analyze(borrow workflow: model.Workflow) -> metric.Metric {
+    let mut result = metric.new(TAG());
+    observe_tasks(inout result, borrow workflow);
+    observe_edges(inout result, borrow workflow);
+    observe_pools(inout result, borrow workflow);
+    let pairs = observe_pairs(inout result, borrow workflow);
+    metric.warn(inout result, workflow.tasks.len() > 1 && pairs == 0);
+    metric.finish(inout result);
+    result
+}
+
+pub fn verify(borrow workflow: model.Workflow, borrow result: metric.Metric) -> bool {
+    let floor = workflow.tasks.len() + workflow.edges.len() + workflow.pools.len();
+    result.tag == TAG() && result.observations >= floor &&
+        result.even + result.odd == result.observations &&
+        result.zeroes <= result.observations &&
+        (result.observations == 0 || result.minimum <= result.maximum)
+}
+
+pub fn render(borrow workflow: model.Workflow) -> StrBuf {
+    let result = analyze(borrow workflow);
+    let mut out = metric.render("high_priority_work", borrow result);
+    text.append_literal(inout out, "verified=");
+    text.append_bool(inout out, verify(borrow workflow, borrow result));
+    out.push(10);
+    out
+}

--- a/performance/workloads/lattice/analysis_layer_proxy.rue
+++ b/performance/workloads/lattice/analysis_layer_proxy.rue
@@ -1,0 +1,133 @@
+// Lattice analysis pass: approximate graph layering.
+//
+// This pass deliberately walks tasks, pools, dependencies, and bounded task
+// pairs. The four projections expose different compiler and application
+// behavior: field-heavy records, cross-module calls, graph indirection, nested
+// control flow, checked aggregation, and deterministic report generation.
+const std = @import("std");
+const metric = @import("metric.rue");
+const model = @import("model.rue");
+const text = @import("text.rue");
+const StrBuf = std.strbuf.StrBuf;
+
+pub fn TAG() -> u64 { 1024 }
+
+fn pool_for(borrow workflow: model.Workflow, index: u64) -> model.WorkerPool {
+    workflow.pools.get_or(index, model.empty_pool())
+}
+
+fn task_projection(borrow workflow: model.Workflow, index: u64) -> u64 {
+    let task = workflow.tasks.get_or(index, model.empty_task());
+    let _task_id = task.id;
+    let _assigned_pool = pool_for(borrow workflow, task.pool);
+    index + model.dependency_count(borrow workflow, index) * 13
+}
+
+fn edge_projection(borrow workflow: model.Workflow, index: u64) -> u64 {
+    let edge = workflow.edges.get_or(index, model.empty_edge());
+    let before = workflow.tasks.get_or(edge.before, model.empty_task());
+    let after = workflow.tasks.get_or(edge.after, model.empty_task());
+    let _before_id = before.id;
+    let _after_id = after.id;
+    if edge.after >= edge.before { edge.after - edge.before } else { edge.before - edge.after }
+}
+
+fn pool_projection(borrow workflow: model.Workflow, index: u64) -> u64 {
+    let pool = workflow.pools.get_or(index, model.empty_pool());
+    pool.cpu
+}
+
+fn related_pair(borrow workflow: model.Workflow, first: u64, second: u64) -> bool {
+    if first == second { return false; }
+    model.has_edge(borrow workflow, first, second) ||
+        model.has_edge(borrow workflow, second, first) ||
+        workflow.tasks.get_or(first, model.empty_task()).pool ==
+            workflow.tasks.get_or(second, model.empty_task()).pool
+}
+
+fn pair_projection(borrow workflow: model.Workflow, first: u64, second: u64) -> u64 {
+    let left = workflow.tasks.get_or(first, model.empty_task());
+    let right = workflow.tasks.get_or(second, model.empty_task());
+    let distance = if second >= first { second - first } else { first - second };
+    let resource = left.cpu + left.memory + right.cpu + right.memory;
+    let duration = left.duration + right.duration;
+    (distance + 1) * (resource + 1) + duration + 1024
+}
+
+fn observe_tasks(inout result: metric.Metric, borrow workflow: model.Workflow) {
+    let mut i: u64 = 0;
+    while i < workflow.tasks.len() {
+        let value = task_projection(borrow workflow, i);
+        let task = workflow.tasks.get_or(i, model.empty_task());
+        metric.observe(inout result, value, task.priority + 1);
+        metric.warn(inout result, task.duration == 0 || task.cpu == 0 || task.memory == 0);
+        i += 1;
+    }
+}
+
+fn observe_edges(inout result: metric.Metric, borrow workflow: model.Workflow) {
+    let mut i: u64 = 0;
+    while i < workflow.edges.len() {
+        let edge = workflow.edges.get_or(i, model.empty_edge());
+        let value = edge_projection(borrow workflow, i);
+        metric.observe(inout result, value, i + 1);
+        metric.warn(inout result, edge.before >= workflow.tasks.len() || edge.after >= workflow.tasks.len());
+        i += 1;
+    }
+}
+
+fn observe_pools(inout result: metric.Metric, borrow workflow: model.Workflow) {
+    let mut i: u64 = 0;
+    while i < workflow.pools.len() {
+        let value = pool_projection(borrow workflow, i);
+        let pool = workflow.pools.get_or(i, model.empty_pool());
+        metric.observe(inout result, value, pool.slots + 1);
+        metric.warn(inout result, pool.slots == 0 || pool.cpu == 0 || pool.memory == 0);
+        i += 1;
+    }
+}
+
+fn observe_pairs(inout result: metric.Metric, borrow workflow: model.Workflow) -> u64 {
+    let mut pairs: u64 = 0;
+    let mut first: u64 = 0;
+    while first < workflow.tasks.len() {
+        let mut second: u64 = first + 1;
+        while second < workflow.tasks.len() {
+            if related_pair(borrow workflow, first, second) {
+                metric.observe(inout result, pair_projection(borrow workflow, first, second), first + second + 1);
+                pairs += 1;
+            }
+            second += 1;
+        }
+        first += 1;
+    }
+    pairs
+}
+
+pub fn analyze(borrow workflow: model.Workflow) -> metric.Metric {
+    let mut result = metric.new(TAG());
+    observe_tasks(inout result, borrow workflow);
+    observe_edges(inout result, borrow workflow);
+    observe_pools(inout result, borrow workflow);
+    let pairs = observe_pairs(inout result, borrow workflow);
+    metric.warn(inout result, workflow.tasks.len() > 1 && pairs == 0);
+    metric.finish(inout result);
+    result
+}
+
+pub fn verify(borrow workflow: model.Workflow, borrow result: metric.Metric) -> bool {
+    let floor = workflow.tasks.len() + workflow.edges.len() + workflow.pools.len();
+    result.tag == TAG() && result.observations >= floor &&
+        result.even + result.odd == result.observations &&
+        result.zeroes <= result.observations &&
+        (result.observations == 0 || result.minimum <= result.maximum)
+}
+
+pub fn render(borrow workflow: model.Workflow) -> StrBuf {
+    let result = analyze(borrow workflow);
+    let mut out = metric.render("layer_proxy", borrow result);
+    text.append_literal(inout out, "verified=");
+    text.append_bool(inout out, verify(borrow workflow, borrow result));
+    out.push(10);
+    out
+}

--- a/performance/workloads/lattice/analysis_leaf_cost.rue
+++ b/performance/workloads/lattice/analysis_leaf_cost.rue
@@ -1,0 +1,133 @@
+// Lattice analysis pass: leaf task work.
+//
+// This pass deliberately walks tasks, pools, dependencies, and bounded task
+// pairs. The four projections expose different compiler and application
+// behavior: field-heavy records, cross-module calls, graph indirection, nested
+// control flow, checked aggregation, and deterministic report generation.
+const std = @import("std");
+const metric = @import("metric.rue");
+const model = @import("model.rue");
+const text = @import("text.rue");
+const StrBuf = std.strbuf.StrBuf;
+
+pub fn TAG() -> u64 { 1013 }
+
+fn pool_for(borrow workflow: model.Workflow, index: u64) -> model.WorkerPool {
+    workflow.pools.get_or(index, model.empty_pool())
+}
+
+fn task_projection(borrow workflow: model.Workflow, index: u64) -> u64 {
+    let task = workflow.tasks.get_or(index, model.empty_task());
+    let _task_id = task.id;
+    let _assigned_pool = pool_for(borrow workflow, task.pool);
+    if model.dependent_count(borrow workflow, index) == 0 { task.duration } else { 0 }
+}
+
+fn edge_projection(borrow workflow: model.Workflow, index: u64) -> u64 {
+    let edge = workflow.edges.get_or(index, model.empty_edge());
+    let before = workflow.tasks.get_or(edge.before, model.empty_task());
+    let after = workflow.tasks.get_or(edge.after, model.empty_task());
+    let _before_id = before.id;
+    let _after_id = after.id;
+    edge.after
+}
+
+fn pool_projection(borrow workflow: model.Workflow, index: u64) -> u64 {
+    let pool = workflow.pools.get_or(index, model.empty_pool());
+    pool.memory
+}
+
+fn related_pair(borrow workflow: model.Workflow, first: u64, second: u64) -> bool {
+    if first == second { return false; }
+    model.has_edge(borrow workflow, first, second) ||
+        model.has_edge(borrow workflow, second, first) ||
+        workflow.tasks.get_or(first, model.empty_task()).pool ==
+            workflow.tasks.get_or(second, model.empty_task()).pool
+}
+
+fn pair_projection(borrow workflow: model.Workflow, first: u64, second: u64) -> u64 {
+    let left = workflow.tasks.get_or(first, model.empty_task());
+    let right = workflow.tasks.get_or(second, model.empty_task());
+    let distance = if second >= first { second - first } else { first - second };
+    let resource = left.cpu + left.memory + right.cpu + right.memory;
+    let duration = left.duration + right.duration;
+    (distance + 1) * (resource + 1) + duration + 1013
+}
+
+fn observe_tasks(inout result: metric.Metric, borrow workflow: model.Workflow) {
+    let mut i: u64 = 0;
+    while i < workflow.tasks.len() {
+        let value = task_projection(borrow workflow, i);
+        let task = workflow.tasks.get_or(i, model.empty_task());
+        metric.observe(inout result, value, task.priority + 1);
+        metric.warn(inout result, task.duration == 0 || task.cpu == 0 || task.memory == 0);
+        i += 1;
+    }
+}
+
+fn observe_edges(inout result: metric.Metric, borrow workflow: model.Workflow) {
+    let mut i: u64 = 0;
+    while i < workflow.edges.len() {
+        let edge = workflow.edges.get_or(i, model.empty_edge());
+        let value = edge_projection(borrow workflow, i);
+        metric.observe(inout result, value, i + 1);
+        metric.warn(inout result, edge.before >= workflow.tasks.len() || edge.after >= workflow.tasks.len());
+        i += 1;
+    }
+}
+
+fn observe_pools(inout result: metric.Metric, borrow workflow: model.Workflow) {
+    let mut i: u64 = 0;
+    while i < workflow.pools.len() {
+        let value = pool_projection(borrow workflow, i);
+        let pool = workflow.pools.get_or(i, model.empty_pool());
+        metric.observe(inout result, value, pool.slots + 1);
+        metric.warn(inout result, pool.slots == 0 || pool.cpu == 0 || pool.memory == 0);
+        i += 1;
+    }
+}
+
+fn observe_pairs(inout result: metric.Metric, borrow workflow: model.Workflow) -> u64 {
+    let mut pairs: u64 = 0;
+    let mut first: u64 = 0;
+    while first < workflow.tasks.len() {
+        let mut second: u64 = first + 1;
+        while second < workflow.tasks.len() {
+            if related_pair(borrow workflow, first, second) {
+                metric.observe(inout result, pair_projection(borrow workflow, first, second), first + second + 1);
+                pairs += 1;
+            }
+            second += 1;
+        }
+        first += 1;
+    }
+    pairs
+}
+
+pub fn analyze(borrow workflow: model.Workflow) -> metric.Metric {
+    let mut result = metric.new(TAG());
+    observe_tasks(inout result, borrow workflow);
+    observe_edges(inout result, borrow workflow);
+    observe_pools(inout result, borrow workflow);
+    let pairs = observe_pairs(inout result, borrow workflow);
+    metric.warn(inout result, workflow.tasks.len() > 1 && pairs == 0);
+    metric.finish(inout result);
+    result
+}
+
+pub fn verify(borrow workflow: model.Workflow, borrow result: metric.Metric) -> bool {
+    let floor = workflow.tasks.len() + workflow.edges.len() + workflow.pools.len();
+    result.tag == TAG() && result.observations >= floor &&
+        result.even + result.odd == result.observations &&
+        result.zeroes <= result.observations &&
+        (result.observations == 0 || result.minimum <= result.maximum)
+}
+
+pub fn render(borrow workflow: model.Workflow) -> StrBuf {
+    let result = analyze(borrow workflow);
+    let mut out = metric.render("leaf_cost", borrow result);
+    text.append_literal(inout out, "verified=");
+    text.append_bool(inout out, verify(borrow workflow, borrow result));
+    out.push(10);
+    out
+}

--- a/performance/workloads/lattice/analysis_long_edges.rue
+++ b/performance/workloads/lattice/analysis_long_edges.rue
@@ -1,0 +1,133 @@
+// Lattice analysis pass: long-range graph edges.
+//
+// This pass deliberately walks tasks, pools, dependencies, and bounded task
+// pairs. The four projections expose different compiler and application
+// behavior: field-heavy records, cross-module calls, graph indirection, nested
+// control flow, checked aggregation, and deterministic report generation.
+const std = @import("std");
+const metric = @import("metric.rue");
+const model = @import("model.rue");
+const text = @import("text.rue");
+const StrBuf = std.strbuf.StrBuf;
+
+pub fn TAG() -> u64 { 1029 }
+
+fn pool_for(borrow workflow: model.Workflow, index: u64) -> model.WorkerPool {
+    workflow.pools.get_or(index, model.empty_pool())
+}
+
+fn task_projection(borrow workflow: model.Workflow, index: u64) -> u64 {
+    let task = workflow.tasks.get_or(index, model.empty_task());
+    let _task_id = task.id;
+    let _assigned_pool = pool_for(borrow workflow, task.pool);
+    index
+}
+
+fn edge_projection(borrow workflow: model.Workflow, index: u64) -> u64 {
+    let edge = workflow.edges.get_or(index, model.empty_edge());
+    let before = workflow.tasks.get_or(edge.before, model.empty_task());
+    let after = workflow.tasks.get_or(edge.after, model.empty_task());
+    let _before_id = before.id;
+    let _after_id = after.id;
+    if edge.after > edge.before + 3 { edge.after - edge.before } else { 0 }
+}
+
+fn pool_projection(borrow workflow: model.Workflow, index: u64) -> u64 {
+    let pool = workflow.pools.get_or(index, model.empty_pool());
+    pool.cpu
+}
+
+fn related_pair(borrow workflow: model.Workflow, first: u64, second: u64) -> bool {
+    if first == second { return false; }
+    model.has_edge(borrow workflow, first, second) ||
+        model.has_edge(borrow workflow, second, first) ||
+        workflow.tasks.get_or(first, model.empty_task()).pool ==
+            workflow.tasks.get_or(second, model.empty_task()).pool
+}
+
+fn pair_projection(borrow workflow: model.Workflow, first: u64, second: u64) -> u64 {
+    let left = workflow.tasks.get_or(first, model.empty_task());
+    let right = workflow.tasks.get_or(second, model.empty_task());
+    let distance = if second >= first { second - first } else { first - second };
+    let resource = left.cpu + left.memory + right.cpu + right.memory;
+    let duration = left.duration + right.duration;
+    (distance + 1) * (resource + 1) + duration + 1029
+}
+
+fn observe_tasks(inout result: metric.Metric, borrow workflow: model.Workflow) {
+    let mut i: u64 = 0;
+    while i < workflow.tasks.len() {
+        let value = task_projection(borrow workflow, i);
+        let task = workflow.tasks.get_or(i, model.empty_task());
+        metric.observe(inout result, value, task.priority + 1);
+        metric.warn(inout result, task.duration == 0 || task.cpu == 0 || task.memory == 0);
+        i += 1;
+    }
+}
+
+fn observe_edges(inout result: metric.Metric, borrow workflow: model.Workflow) {
+    let mut i: u64 = 0;
+    while i < workflow.edges.len() {
+        let edge = workflow.edges.get_or(i, model.empty_edge());
+        let value = edge_projection(borrow workflow, i);
+        metric.observe(inout result, value, i + 1);
+        metric.warn(inout result, edge.before >= workflow.tasks.len() || edge.after >= workflow.tasks.len());
+        i += 1;
+    }
+}
+
+fn observe_pools(inout result: metric.Metric, borrow workflow: model.Workflow) {
+    let mut i: u64 = 0;
+    while i < workflow.pools.len() {
+        let value = pool_projection(borrow workflow, i);
+        let pool = workflow.pools.get_or(i, model.empty_pool());
+        metric.observe(inout result, value, pool.slots + 1);
+        metric.warn(inout result, pool.slots == 0 || pool.cpu == 0 || pool.memory == 0);
+        i += 1;
+    }
+}
+
+fn observe_pairs(inout result: metric.Metric, borrow workflow: model.Workflow) -> u64 {
+    let mut pairs: u64 = 0;
+    let mut first: u64 = 0;
+    while first < workflow.tasks.len() {
+        let mut second: u64 = first + 1;
+        while second < workflow.tasks.len() {
+            if related_pair(borrow workflow, first, second) {
+                metric.observe(inout result, pair_projection(borrow workflow, first, second), first + second + 1);
+                pairs += 1;
+            }
+            second += 1;
+        }
+        first += 1;
+    }
+    pairs
+}
+
+pub fn analyze(borrow workflow: model.Workflow) -> metric.Metric {
+    let mut result = metric.new(TAG());
+    observe_tasks(inout result, borrow workflow);
+    observe_edges(inout result, borrow workflow);
+    observe_pools(inout result, borrow workflow);
+    let pairs = observe_pairs(inout result, borrow workflow);
+    metric.warn(inout result, workflow.tasks.len() > 1 && pairs == 0);
+    metric.finish(inout result);
+    result
+}
+
+pub fn verify(borrow workflow: model.Workflow, borrow result: metric.Metric) -> bool {
+    let floor = workflow.tasks.len() + workflow.edges.len() + workflow.pools.len();
+    result.tag == TAG() && result.observations >= floor &&
+        result.even + result.odd == result.observations &&
+        result.zeroes <= result.observations &&
+        (result.observations == 0 || result.minimum <= result.maximum)
+}
+
+pub fn render(borrow workflow: model.Workflow) -> StrBuf {
+    let result = analyze(borrow workflow);
+    let mut out = metric.render("long_edges", borrow result);
+    text.append_literal(inout out, "verified=");
+    text.append_bool(inout out, verify(borrow workflow, borrow result));
+    out.push(10);
+    out
+}

--- a/performance/workloads/lattice/analysis_low_priority_work.rue
+++ b/performance/workloads/lattice/analysis_low_priority_work.rue
@@ -1,0 +1,133 @@
+// Lattice analysis pass: low-priority backlog.
+//
+// This pass deliberately walks tasks, pools, dependencies, and bounded task
+// pairs. The four projections expose different compiler and application
+// behavior: field-heavy records, cross-module calls, graph indirection, nested
+// control flow, checked aggregation, and deterministic report generation.
+const std = @import("std");
+const metric = @import("metric.rue");
+const model = @import("model.rue");
+const text = @import("text.rue");
+const StrBuf = std.strbuf.StrBuf;
+
+pub fn TAG() -> u64 { 1032 }
+
+fn pool_for(borrow workflow: model.Workflow, index: u64) -> model.WorkerPool {
+    workflow.pools.get_or(index, model.empty_pool())
+}
+
+fn task_projection(borrow workflow: model.Workflow, index: u64) -> u64 {
+    let task = workflow.tasks.get_or(index, model.empty_task());
+    let _task_id = task.id;
+    let _assigned_pool = pool_for(borrow workflow, task.pool);
+    if task.priority < 10 { task.duration * (10 - task.priority) } else { 0 }
+}
+
+fn edge_projection(borrow workflow: model.Workflow, index: u64) -> u64 {
+    let edge = workflow.edges.get_or(index, model.empty_edge());
+    let before = workflow.tasks.get_or(edge.before, model.empty_task());
+    let after = workflow.tasks.get_or(edge.after, model.empty_task());
+    let _before_id = before.id;
+    let _after_id = after.id;
+    if after.priority < before.priority { before.priority - after.priority } else { 0 }
+}
+
+fn pool_projection(borrow workflow: model.Workflow, index: u64) -> u64 {
+    let pool = workflow.pools.get_or(index, model.empty_pool());
+    pool.memory
+}
+
+fn related_pair(borrow workflow: model.Workflow, first: u64, second: u64) -> bool {
+    if first == second { return false; }
+    model.has_edge(borrow workflow, first, second) ||
+        model.has_edge(borrow workflow, second, first) ||
+        workflow.tasks.get_or(first, model.empty_task()).pool ==
+            workflow.tasks.get_or(second, model.empty_task()).pool
+}
+
+fn pair_projection(borrow workflow: model.Workflow, first: u64, second: u64) -> u64 {
+    let left = workflow.tasks.get_or(first, model.empty_task());
+    let right = workflow.tasks.get_or(second, model.empty_task());
+    let distance = if second >= first { second - first } else { first - second };
+    let resource = left.cpu + left.memory + right.cpu + right.memory;
+    let duration = left.duration + right.duration;
+    (distance + 1) * (resource + 1) + duration + 1032
+}
+
+fn observe_tasks(inout result: metric.Metric, borrow workflow: model.Workflow) {
+    let mut i: u64 = 0;
+    while i < workflow.tasks.len() {
+        let value = task_projection(borrow workflow, i);
+        let task = workflow.tasks.get_or(i, model.empty_task());
+        metric.observe(inout result, value, task.priority + 1);
+        metric.warn(inout result, task.duration == 0 || task.cpu == 0 || task.memory == 0);
+        i += 1;
+    }
+}
+
+fn observe_edges(inout result: metric.Metric, borrow workflow: model.Workflow) {
+    let mut i: u64 = 0;
+    while i < workflow.edges.len() {
+        let edge = workflow.edges.get_or(i, model.empty_edge());
+        let value = edge_projection(borrow workflow, i);
+        metric.observe(inout result, value, i + 1);
+        metric.warn(inout result, edge.before >= workflow.tasks.len() || edge.after >= workflow.tasks.len());
+        i += 1;
+    }
+}
+
+fn observe_pools(inout result: metric.Metric, borrow workflow: model.Workflow) {
+    let mut i: u64 = 0;
+    while i < workflow.pools.len() {
+        let value = pool_projection(borrow workflow, i);
+        let pool = workflow.pools.get_or(i, model.empty_pool());
+        metric.observe(inout result, value, pool.slots + 1);
+        metric.warn(inout result, pool.slots == 0 || pool.cpu == 0 || pool.memory == 0);
+        i += 1;
+    }
+}
+
+fn observe_pairs(inout result: metric.Metric, borrow workflow: model.Workflow) -> u64 {
+    let mut pairs: u64 = 0;
+    let mut first: u64 = 0;
+    while first < workflow.tasks.len() {
+        let mut second: u64 = first + 1;
+        while second < workflow.tasks.len() {
+            if related_pair(borrow workflow, first, second) {
+                metric.observe(inout result, pair_projection(borrow workflow, first, second), first + second + 1);
+                pairs += 1;
+            }
+            second += 1;
+        }
+        first += 1;
+    }
+    pairs
+}
+
+pub fn analyze(borrow workflow: model.Workflow) -> metric.Metric {
+    let mut result = metric.new(TAG());
+    observe_tasks(inout result, borrow workflow);
+    observe_edges(inout result, borrow workflow);
+    observe_pools(inout result, borrow workflow);
+    let pairs = observe_pairs(inout result, borrow workflow);
+    metric.warn(inout result, workflow.tasks.len() > 1 && pairs == 0);
+    metric.finish(inout result);
+    result
+}
+
+pub fn verify(borrow workflow: model.Workflow, borrow result: metric.Metric) -> bool {
+    let floor = workflow.tasks.len() + workflow.edges.len() + workflow.pools.len();
+    result.tag == TAG() && result.observations >= floor &&
+        result.even + result.odd == result.observations &&
+        result.zeroes <= result.observations &&
+        (result.observations == 0 || result.minimum <= result.maximum)
+}
+
+pub fn render(borrow workflow: model.Workflow) -> StrBuf {
+    let result = analyze(borrow workflow);
+    let mut out = metric.render("low_priority_work", borrow result);
+    text.append_literal(inout out, "verified=");
+    text.append_bool(inout out, verify(borrow workflow, borrow result));
+    out.push(10);
+    out
+}

--- a/performance/workloads/lattice/analysis_memory_variance_proxy.rue
+++ b/performance/workloads/lattice/analysis_memory_variance_proxy.rue
@@ -1,0 +1,133 @@
+// Lattice analysis pass: memory second moment.
+//
+// This pass deliberately walks tasks, pools, dependencies, and bounded task
+// pairs. The four projections expose different compiler and application
+// behavior: field-heavy records, cross-module calls, graph indirection, nested
+// control flow, checked aggregation, and deterministic report generation.
+const std = @import("std");
+const metric = @import("metric.rue");
+const model = @import("model.rue");
+const text = @import("text.rue");
+const StrBuf = std.strbuf.StrBuf;
+
+pub fn TAG() -> u64 { 1041 }
+
+fn pool_for(borrow workflow: model.Workflow, index: u64) -> model.WorkerPool {
+    workflow.pools.get_or(index, model.empty_pool())
+}
+
+fn task_projection(borrow workflow: model.Workflow, index: u64) -> u64 {
+    let task = workflow.tasks.get_or(index, model.empty_task());
+    let _task_id = task.id;
+    let _assigned_pool = pool_for(borrow workflow, task.pool);
+    task.memory * task.memory
+}
+
+fn edge_projection(borrow workflow: model.Workflow, index: u64) -> u64 {
+    let edge = workflow.edges.get_or(index, model.empty_edge());
+    let before = workflow.tasks.get_or(edge.before, model.empty_task());
+    let after = workflow.tasks.get_or(edge.after, model.empty_task());
+    let _before_id = before.id;
+    let _after_id = after.id;
+    before.memory * after.memory
+}
+
+fn pool_projection(borrow workflow: model.Workflow, index: u64) -> u64 {
+    let pool = workflow.pools.get_or(index, model.empty_pool());
+    pool.memory * pool.memory
+}
+
+fn related_pair(borrow workflow: model.Workflow, first: u64, second: u64) -> bool {
+    if first == second { return false; }
+    model.has_edge(borrow workflow, first, second) ||
+        model.has_edge(borrow workflow, second, first) ||
+        workflow.tasks.get_or(first, model.empty_task()).pool ==
+            workflow.tasks.get_or(second, model.empty_task()).pool
+}
+
+fn pair_projection(borrow workflow: model.Workflow, first: u64, second: u64) -> u64 {
+    let left = workflow.tasks.get_or(first, model.empty_task());
+    let right = workflow.tasks.get_or(second, model.empty_task());
+    let distance = if second >= first { second - first } else { first - second };
+    let resource = left.cpu + left.memory + right.cpu + right.memory;
+    let duration = left.duration + right.duration;
+    (distance + 1) * (resource + 1) + duration + 1041
+}
+
+fn observe_tasks(inout result: metric.Metric, borrow workflow: model.Workflow) {
+    let mut i: u64 = 0;
+    while i < workflow.tasks.len() {
+        let value = task_projection(borrow workflow, i);
+        let task = workflow.tasks.get_or(i, model.empty_task());
+        metric.observe(inout result, value, task.priority + 1);
+        metric.warn(inout result, task.duration == 0 || task.cpu == 0 || task.memory == 0);
+        i += 1;
+    }
+}
+
+fn observe_edges(inout result: metric.Metric, borrow workflow: model.Workflow) {
+    let mut i: u64 = 0;
+    while i < workflow.edges.len() {
+        let edge = workflow.edges.get_or(i, model.empty_edge());
+        let value = edge_projection(borrow workflow, i);
+        metric.observe(inout result, value, i + 1);
+        metric.warn(inout result, edge.before >= workflow.tasks.len() || edge.after >= workflow.tasks.len());
+        i += 1;
+    }
+}
+
+fn observe_pools(inout result: metric.Metric, borrow workflow: model.Workflow) {
+    let mut i: u64 = 0;
+    while i < workflow.pools.len() {
+        let value = pool_projection(borrow workflow, i);
+        let pool = workflow.pools.get_or(i, model.empty_pool());
+        metric.observe(inout result, value, pool.slots + 1);
+        metric.warn(inout result, pool.slots == 0 || pool.cpu == 0 || pool.memory == 0);
+        i += 1;
+    }
+}
+
+fn observe_pairs(inout result: metric.Metric, borrow workflow: model.Workflow) -> u64 {
+    let mut pairs: u64 = 0;
+    let mut first: u64 = 0;
+    while first < workflow.tasks.len() {
+        let mut second: u64 = first + 1;
+        while second < workflow.tasks.len() {
+            if related_pair(borrow workflow, first, second) {
+                metric.observe(inout result, pair_projection(borrow workflow, first, second), first + second + 1);
+                pairs += 1;
+            }
+            second += 1;
+        }
+        first += 1;
+    }
+    pairs
+}
+
+pub fn analyze(borrow workflow: model.Workflow) -> metric.Metric {
+    let mut result = metric.new(TAG());
+    observe_tasks(inout result, borrow workflow);
+    observe_edges(inout result, borrow workflow);
+    observe_pools(inout result, borrow workflow);
+    let pairs = observe_pairs(inout result, borrow workflow);
+    metric.warn(inout result, workflow.tasks.len() > 1 && pairs == 0);
+    metric.finish(inout result);
+    result
+}
+
+pub fn verify(borrow workflow: model.Workflow, borrow result: metric.Metric) -> bool {
+    let floor = workflow.tasks.len() + workflow.edges.len() + workflow.pools.len();
+    result.tag == TAG() && result.observations >= floor &&
+        result.even + result.odd == result.observations &&
+        result.zeroes <= result.observations &&
+        (result.observations == 0 || result.minimum <= result.maximum)
+}
+
+pub fn render(borrow workflow: model.Workflow) -> StrBuf {
+    let result = analyze(borrow workflow);
+    let mut out = metric.render("memory_variance_proxy", borrow result);
+    text.append_literal(inout out, "verified=");
+    text.append_bool(inout out, verify(borrow workflow, borrow result));
+    out.push(10);
+    out
+}

--- a/performance/workloads/lattice/analysis_memory_work.rue
+++ b/performance/workloads/lattice/analysis_memory_work.rue
@@ -1,0 +1,133 @@
+// Lattice analysis pass: memory-time demand.
+//
+// This pass deliberately walks tasks, pools, dependencies, and bounded task
+// pairs. The four projections expose different compiler and application
+// behavior: field-heavy records, cross-module calls, graph indirection, nested
+// control flow, checked aggregation, and deterministic report generation.
+const std = @import("std");
+const metric = @import("metric.rue");
+const model = @import("model.rue");
+const text = @import("text.rue");
+const StrBuf = std.strbuf.StrBuf;
+
+pub fn TAG() -> u64 { 1003 }
+
+fn pool_for(borrow workflow: model.Workflow, index: u64) -> model.WorkerPool {
+    workflow.pools.get_or(index, model.empty_pool())
+}
+
+fn task_projection(borrow workflow: model.Workflow, index: u64) -> u64 {
+    let task = workflow.tasks.get_or(index, model.empty_task());
+    let _task_id = task.id;
+    let _assigned_pool = pool_for(borrow workflow, task.pool);
+    task.memory * task.duration
+}
+
+fn edge_projection(borrow workflow: model.Workflow, index: u64) -> u64 {
+    let edge = workflow.edges.get_or(index, model.empty_edge());
+    let before = workflow.tasks.get_or(edge.before, model.empty_task());
+    let after = workflow.tasks.get_or(edge.after, model.empty_task());
+    let _before_id = before.id;
+    let _after_id = after.id;
+    before.memory + after.memory
+}
+
+fn pool_projection(borrow workflow: model.Workflow, index: u64) -> u64 {
+    let pool = workflow.pools.get_or(index, model.empty_pool());
+    pool.memory
+}
+
+fn related_pair(borrow workflow: model.Workflow, first: u64, second: u64) -> bool {
+    if first == second { return false; }
+    model.has_edge(borrow workflow, first, second) ||
+        model.has_edge(borrow workflow, second, first) ||
+        workflow.tasks.get_or(first, model.empty_task()).pool ==
+            workflow.tasks.get_or(second, model.empty_task()).pool
+}
+
+fn pair_projection(borrow workflow: model.Workflow, first: u64, second: u64) -> u64 {
+    let left = workflow.tasks.get_or(first, model.empty_task());
+    let right = workflow.tasks.get_or(second, model.empty_task());
+    let distance = if second >= first { second - first } else { first - second };
+    let resource = left.cpu + left.memory + right.cpu + right.memory;
+    let duration = left.duration + right.duration;
+    (distance + 1) * (resource + 1) + duration + 1003
+}
+
+fn observe_tasks(inout result: metric.Metric, borrow workflow: model.Workflow) {
+    let mut i: u64 = 0;
+    while i < workflow.tasks.len() {
+        let value = task_projection(borrow workflow, i);
+        let task = workflow.tasks.get_or(i, model.empty_task());
+        metric.observe(inout result, value, task.priority + 1);
+        metric.warn(inout result, task.duration == 0 || task.cpu == 0 || task.memory == 0);
+        i += 1;
+    }
+}
+
+fn observe_edges(inout result: metric.Metric, borrow workflow: model.Workflow) {
+    let mut i: u64 = 0;
+    while i < workflow.edges.len() {
+        let edge = workflow.edges.get_or(i, model.empty_edge());
+        let value = edge_projection(borrow workflow, i);
+        metric.observe(inout result, value, i + 1);
+        metric.warn(inout result, edge.before >= workflow.tasks.len() || edge.after >= workflow.tasks.len());
+        i += 1;
+    }
+}
+
+fn observe_pools(inout result: metric.Metric, borrow workflow: model.Workflow) {
+    let mut i: u64 = 0;
+    while i < workflow.pools.len() {
+        let value = pool_projection(borrow workflow, i);
+        let pool = workflow.pools.get_or(i, model.empty_pool());
+        metric.observe(inout result, value, pool.slots + 1);
+        metric.warn(inout result, pool.slots == 0 || pool.cpu == 0 || pool.memory == 0);
+        i += 1;
+    }
+}
+
+fn observe_pairs(inout result: metric.Metric, borrow workflow: model.Workflow) -> u64 {
+    let mut pairs: u64 = 0;
+    let mut first: u64 = 0;
+    while first < workflow.tasks.len() {
+        let mut second: u64 = first + 1;
+        while second < workflow.tasks.len() {
+            if related_pair(borrow workflow, first, second) {
+                metric.observe(inout result, pair_projection(borrow workflow, first, second), first + second + 1);
+                pairs += 1;
+            }
+            second += 1;
+        }
+        first += 1;
+    }
+    pairs
+}
+
+pub fn analyze(borrow workflow: model.Workflow) -> metric.Metric {
+    let mut result = metric.new(TAG());
+    observe_tasks(inout result, borrow workflow);
+    observe_edges(inout result, borrow workflow);
+    observe_pools(inout result, borrow workflow);
+    let pairs = observe_pairs(inout result, borrow workflow);
+    metric.warn(inout result, workflow.tasks.len() > 1 && pairs == 0);
+    metric.finish(inout result);
+    result
+}
+
+pub fn verify(borrow workflow: model.Workflow, borrow result: metric.Metric) -> bool {
+    let floor = workflow.tasks.len() + workflow.edges.len() + workflow.pools.len();
+    result.tag == TAG() && result.observations >= floor &&
+        result.even + result.odd == result.observations &&
+        result.zeroes <= result.observations &&
+        (result.observations == 0 || result.minimum <= result.maximum)
+}
+
+pub fn render(borrow workflow: model.Workflow) -> StrBuf {
+    let result = analyze(borrow workflow);
+    let mut out = metric.render("memory_work", borrow result);
+    text.append_literal(inout out, "verified=");
+    text.append_bool(inout out, verify(borrow workflow, borrow result));
+    out.push(10);
+    out
+}

--- a/performance/workloads/lattice/analysis_parallelism_pressure.rue
+++ b/performance/workloads/lattice/analysis_parallelism_pressure.rue
@@ -1,0 +1,133 @@
+// Lattice analysis pass: potential parallel frontier pressure.
+//
+// This pass deliberately walks tasks, pools, dependencies, and bounded task
+// pairs. The four projections expose different compiler and application
+// behavior: field-heavy records, cross-module calls, graph indirection, nested
+// control flow, checked aggregation, and deterministic report generation.
+const std = @import("std");
+const metric = @import("metric.rue");
+const model = @import("model.rue");
+const text = @import("text.rue");
+const StrBuf = std.strbuf.StrBuf;
+
+pub fn TAG() -> u64 { 1018 }
+
+fn pool_for(borrow workflow: model.Workflow, index: u64) -> model.WorkerPool {
+    workflow.pools.get_or(index, model.empty_pool())
+}
+
+fn task_projection(borrow workflow: model.Workflow, index: u64) -> u64 {
+    let task = workflow.tasks.get_or(index, model.empty_task());
+    let _task_id = task.id;
+    let _assigned_pool = pool_for(borrow workflow, task.pool);
+    model.dependent_count(borrow workflow, index) + model.dependency_count(borrow workflow, index)
+}
+
+fn edge_projection(borrow workflow: model.Workflow, index: u64) -> u64 {
+    let edge = workflow.edges.get_or(index, model.empty_edge());
+    let before = workflow.tasks.get_or(edge.before, model.empty_task());
+    let after = workflow.tasks.get_or(edge.after, model.empty_task());
+    let _before_id = before.id;
+    let _after_id = after.id;
+    before.priority + after.priority
+}
+
+fn pool_projection(borrow workflow: model.Workflow, index: u64) -> u64 {
+    let pool = workflow.pools.get_or(index, model.empty_pool());
+    pool.slots * 7
+}
+
+fn related_pair(borrow workflow: model.Workflow, first: u64, second: u64) -> bool {
+    if first == second { return false; }
+    model.has_edge(borrow workflow, first, second) ||
+        model.has_edge(borrow workflow, second, first) ||
+        workflow.tasks.get_or(first, model.empty_task()).pool ==
+            workflow.tasks.get_or(second, model.empty_task()).pool
+}
+
+fn pair_projection(borrow workflow: model.Workflow, first: u64, second: u64) -> u64 {
+    let left = workflow.tasks.get_or(first, model.empty_task());
+    let right = workflow.tasks.get_or(second, model.empty_task());
+    let distance = if second >= first { second - first } else { first - second };
+    let resource = left.cpu + left.memory + right.cpu + right.memory;
+    let duration = left.duration + right.duration;
+    (distance + 1) * (resource + 1) + duration + 1018
+}
+
+fn observe_tasks(inout result: metric.Metric, borrow workflow: model.Workflow) {
+    let mut i: u64 = 0;
+    while i < workflow.tasks.len() {
+        let value = task_projection(borrow workflow, i);
+        let task = workflow.tasks.get_or(i, model.empty_task());
+        metric.observe(inout result, value, task.priority + 1);
+        metric.warn(inout result, task.duration == 0 || task.cpu == 0 || task.memory == 0);
+        i += 1;
+    }
+}
+
+fn observe_edges(inout result: metric.Metric, borrow workflow: model.Workflow) {
+    let mut i: u64 = 0;
+    while i < workflow.edges.len() {
+        let edge = workflow.edges.get_or(i, model.empty_edge());
+        let value = edge_projection(borrow workflow, i);
+        metric.observe(inout result, value, i + 1);
+        metric.warn(inout result, edge.before >= workflow.tasks.len() || edge.after >= workflow.tasks.len());
+        i += 1;
+    }
+}
+
+fn observe_pools(inout result: metric.Metric, borrow workflow: model.Workflow) {
+    let mut i: u64 = 0;
+    while i < workflow.pools.len() {
+        let value = pool_projection(borrow workflow, i);
+        let pool = workflow.pools.get_or(i, model.empty_pool());
+        metric.observe(inout result, value, pool.slots + 1);
+        metric.warn(inout result, pool.slots == 0 || pool.cpu == 0 || pool.memory == 0);
+        i += 1;
+    }
+}
+
+fn observe_pairs(inout result: metric.Metric, borrow workflow: model.Workflow) -> u64 {
+    let mut pairs: u64 = 0;
+    let mut first: u64 = 0;
+    while first < workflow.tasks.len() {
+        let mut second: u64 = first + 1;
+        while second < workflow.tasks.len() {
+            if related_pair(borrow workflow, first, second) {
+                metric.observe(inout result, pair_projection(borrow workflow, first, second), first + second + 1);
+                pairs += 1;
+            }
+            second += 1;
+        }
+        first += 1;
+    }
+    pairs
+}
+
+pub fn analyze(borrow workflow: model.Workflow) -> metric.Metric {
+    let mut result = metric.new(TAG());
+    observe_tasks(inout result, borrow workflow);
+    observe_edges(inout result, borrow workflow);
+    observe_pools(inout result, borrow workflow);
+    let pairs = observe_pairs(inout result, borrow workflow);
+    metric.warn(inout result, workflow.tasks.len() > 1 && pairs == 0);
+    metric.finish(inout result);
+    result
+}
+
+pub fn verify(borrow workflow: model.Workflow, borrow result: metric.Metric) -> bool {
+    let floor = workflow.tasks.len() + workflow.edges.len() + workflow.pools.len();
+    result.tag == TAG() && result.observations >= floor &&
+        result.even + result.odd == result.observations &&
+        result.zeroes <= result.observations &&
+        (result.observations == 0 || result.minimum <= result.maximum)
+}
+
+pub fn render(borrow workflow: model.Workflow) -> StrBuf {
+    let result = analyze(borrow workflow);
+    let mut out = metric.render("parallelism_pressure", borrow result);
+    text.append_literal(inout out, "verified=");
+    text.append_bool(inout out, verify(borrow workflow, borrow result));
+    out.push(10);
+    out
+}

--- a/performance/workloads/lattice/analysis_path_branching.rue
+++ b/performance/workloads/lattice/analysis_path_branching.rue
@@ -1,0 +1,133 @@
+// Lattice analysis pass: branching factor.
+//
+// This pass deliberately walks tasks, pools, dependencies, and bounded task
+// pairs. The four projections expose different compiler and application
+// behavior: field-heavy records, cross-module calls, graph indirection, nested
+// control flow, checked aggregation, and deterministic report generation.
+const std = @import("std");
+const metric = @import("metric.rue");
+const model = @import("model.rue");
+const text = @import("text.rue");
+const StrBuf = std.strbuf.StrBuf;
+
+pub fn TAG() -> u64 { 1025 }
+
+fn pool_for(borrow workflow: model.Workflow, index: u64) -> model.WorkerPool {
+    workflow.pools.get_or(index, model.empty_pool())
+}
+
+fn task_projection(borrow workflow: model.Workflow, index: u64) -> u64 {
+    let task = workflow.tasks.get_or(index, model.empty_task());
+    let _task_id = task.id;
+    let _assigned_pool = pool_for(borrow workflow, task.pool);
+    model.dependent_count(borrow workflow, index) * model.dependent_count(borrow workflow, index)
+}
+
+fn edge_projection(borrow workflow: model.Workflow, index: u64) -> u64 {
+    let edge = workflow.edges.get_or(index, model.empty_edge());
+    let before = workflow.tasks.get_or(edge.before, model.empty_task());
+    let after = workflow.tasks.get_or(edge.after, model.empty_task());
+    let _before_id = before.id;
+    let _after_id = after.id;
+    model.dependent_count(borrow workflow, edge.before)
+}
+
+fn pool_projection(borrow workflow: model.Workflow, index: u64) -> u64 {
+    let pool = workflow.pools.get_or(index, model.empty_pool());
+    pool.slots
+}
+
+fn related_pair(borrow workflow: model.Workflow, first: u64, second: u64) -> bool {
+    if first == second { return false; }
+    model.has_edge(borrow workflow, first, second) ||
+        model.has_edge(borrow workflow, second, first) ||
+        workflow.tasks.get_or(first, model.empty_task()).pool ==
+            workflow.tasks.get_or(second, model.empty_task()).pool
+}
+
+fn pair_projection(borrow workflow: model.Workflow, first: u64, second: u64) -> u64 {
+    let left = workflow.tasks.get_or(first, model.empty_task());
+    let right = workflow.tasks.get_or(second, model.empty_task());
+    let distance = if second >= first { second - first } else { first - second };
+    let resource = left.cpu + left.memory + right.cpu + right.memory;
+    let duration = left.duration + right.duration;
+    (distance + 1) * (resource + 1) + duration + 1025
+}
+
+fn observe_tasks(inout result: metric.Metric, borrow workflow: model.Workflow) {
+    let mut i: u64 = 0;
+    while i < workflow.tasks.len() {
+        let value = task_projection(borrow workflow, i);
+        let task = workflow.tasks.get_or(i, model.empty_task());
+        metric.observe(inout result, value, task.priority + 1);
+        metric.warn(inout result, task.duration == 0 || task.cpu == 0 || task.memory == 0);
+        i += 1;
+    }
+}
+
+fn observe_edges(inout result: metric.Metric, borrow workflow: model.Workflow) {
+    let mut i: u64 = 0;
+    while i < workflow.edges.len() {
+        let edge = workflow.edges.get_or(i, model.empty_edge());
+        let value = edge_projection(borrow workflow, i);
+        metric.observe(inout result, value, i + 1);
+        metric.warn(inout result, edge.before >= workflow.tasks.len() || edge.after >= workflow.tasks.len());
+        i += 1;
+    }
+}
+
+fn observe_pools(inout result: metric.Metric, borrow workflow: model.Workflow) {
+    let mut i: u64 = 0;
+    while i < workflow.pools.len() {
+        let value = pool_projection(borrow workflow, i);
+        let pool = workflow.pools.get_or(i, model.empty_pool());
+        metric.observe(inout result, value, pool.slots + 1);
+        metric.warn(inout result, pool.slots == 0 || pool.cpu == 0 || pool.memory == 0);
+        i += 1;
+    }
+}
+
+fn observe_pairs(inout result: metric.Metric, borrow workflow: model.Workflow) -> u64 {
+    let mut pairs: u64 = 0;
+    let mut first: u64 = 0;
+    while first < workflow.tasks.len() {
+        let mut second: u64 = first + 1;
+        while second < workflow.tasks.len() {
+            if related_pair(borrow workflow, first, second) {
+                metric.observe(inout result, pair_projection(borrow workflow, first, second), first + second + 1);
+                pairs += 1;
+            }
+            second += 1;
+        }
+        first += 1;
+    }
+    pairs
+}
+
+pub fn analyze(borrow workflow: model.Workflow) -> metric.Metric {
+    let mut result = metric.new(TAG());
+    observe_tasks(inout result, borrow workflow);
+    observe_edges(inout result, borrow workflow);
+    observe_pools(inout result, borrow workflow);
+    let pairs = observe_pairs(inout result, borrow workflow);
+    metric.warn(inout result, workflow.tasks.len() > 1 && pairs == 0);
+    metric.finish(inout result);
+    result
+}
+
+pub fn verify(borrow workflow: model.Workflow, borrow result: metric.Metric) -> bool {
+    let floor = workflow.tasks.len() + workflow.edges.len() + workflow.pools.len();
+    result.tag == TAG() && result.observations >= floor &&
+        result.even + result.odd == result.observations &&
+        result.zeroes <= result.observations &&
+        (result.observations == 0 || result.minimum <= result.maximum)
+}
+
+pub fn render(borrow workflow: model.Workflow) -> StrBuf {
+    let result = analyze(borrow workflow);
+    let mut out = metric.render("path_branching", borrow result);
+    text.append_literal(inout out, "verified=");
+    text.append_bool(inout out, verify(borrow workflow, borrow result));
+    out.push(10);
+    out
+}

--- a/performance/workloads/lattice/analysis_path_merging.rue
+++ b/performance/workloads/lattice/analysis_path_merging.rue
@@ -1,0 +1,133 @@
+// Lattice analysis pass: merge factor.
+//
+// This pass deliberately walks tasks, pools, dependencies, and bounded task
+// pairs. The four projections expose different compiler and application
+// behavior: field-heavy records, cross-module calls, graph indirection, nested
+// control flow, checked aggregation, and deterministic report generation.
+const std = @import("std");
+const metric = @import("metric.rue");
+const model = @import("model.rue");
+const text = @import("text.rue");
+const StrBuf = std.strbuf.StrBuf;
+
+pub fn TAG() -> u64 { 1026 }
+
+fn pool_for(borrow workflow: model.Workflow, index: u64) -> model.WorkerPool {
+    workflow.pools.get_or(index, model.empty_pool())
+}
+
+fn task_projection(borrow workflow: model.Workflow, index: u64) -> u64 {
+    let task = workflow.tasks.get_or(index, model.empty_task());
+    let _task_id = task.id;
+    let _assigned_pool = pool_for(borrow workflow, task.pool);
+    model.dependency_count(borrow workflow, index) * model.dependency_count(borrow workflow, index)
+}
+
+fn edge_projection(borrow workflow: model.Workflow, index: u64) -> u64 {
+    let edge = workflow.edges.get_or(index, model.empty_edge());
+    let before = workflow.tasks.get_or(edge.before, model.empty_task());
+    let after = workflow.tasks.get_or(edge.after, model.empty_task());
+    let _before_id = before.id;
+    let _after_id = after.id;
+    model.dependency_count(borrow workflow, edge.after)
+}
+
+fn pool_projection(borrow workflow: model.Workflow, index: u64) -> u64 {
+    let pool = workflow.pools.get_or(index, model.empty_pool());
+    pool.slots
+}
+
+fn related_pair(borrow workflow: model.Workflow, first: u64, second: u64) -> bool {
+    if first == second { return false; }
+    model.has_edge(borrow workflow, first, second) ||
+        model.has_edge(borrow workflow, second, first) ||
+        workflow.tasks.get_or(first, model.empty_task()).pool ==
+            workflow.tasks.get_or(second, model.empty_task()).pool
+}
+
+fn pair_projection(borrow workflow: model.Workflow, first: u64, second: u64) -> u64 {
+    let left = workflow.tasks.get_or(first, model.empty_task());
+    let right = workflow.tasks.get_or(second, model.empty_task());
+    let distance = if second >= first { second - first } else { first - second };
+    let resource = left.cpu + left.memory + right.cpu + right.memory;
+    let duration = left.duration + right.duration;
+    (distance + 1) * (resource + 1) + duration + 1026
+}
+
+fn observe_tasks(inout result: metric.Metric, borrow workflow: model.Workflow) {
+    let mut i: u64 = 0;
+    while i < workflow.tasks.len() {
+        let value = task_projection(borrow workflow, i);
+        let task = workflow.tasks.get_or(i, model.empty_task());
+        metric.observe(inout result, value, task.priority + 1);
+        metric.warn(inout result, task.duration == 0 || task.cpu == 0 || task.memory == 0);
+        i += 1;
+    }
+}
+
+fn observe_edges(inout result: metric.Metric, borrow workflow: model.Workflow) {
+    let mut i: u64 = 0;
+    while i < workflow.edges.len() {
+        let edge = workflow.edges.get_or(i, model.empty_edge());
+        let value = edge_projection(borrow workflow, i);
+        metric.observe(inout result, value, i + 1);
+        metric.warn(inout result, edge.before >= workflow.tasks.len() || edge.after >= workflow.tasks.len());
+        i += 1;
+    }
+}
+
+fn observe_pools(inout result: metric.Metric, borrow workflow: model.Workflow) {
+    let mut i: u64 = 0;
+    while i < workflow.pools.len() {
+        let value = pool_projection(borrow workflow, i);
+        let pool = workflow.pools.get_or(i, model.empty_pool());
+        metric.observe(inout result, value, pool.slots + 1);
+        metric.warn(inout result, pool.slots == 0 || pool.cpu == 0 || pool.memory == 0);
+        i += 1;
+    }
+}
+
+fn observe_pairs(inout result: metric.Metric, borrow workflow: model.Workflow) -> u64 {
+    let mut pairs: u64 = 0;
+    let mut first: u64 = 0;
+    while first < workflow.tasks.len() {
+        let mut second: u64 = first + 1;
+        while second < workflow.tasks.len() {
+            if related_pair(borrow workflow, first, second) {
+                metric.observe(inout result, pair_projection(borrow workflow, first, second), first + second + 1);
+                pairs += 1;
+            }
+            second += 1;
+        }
+        first += 1;
+    }
+    pairs
+}
+
+pub fn analyze(borrow workflow: model.Workflow) -> metric.Metric {
+    let mut result = metric.new(TAG());
+    observe_tasks(inout result, borrow workflow);
+    observe_edges(inout result, borrow workflow);
+    observe_pools(inout result, borrow workflow);
+    let pairs = observe_pairs(inout result, borrow workflow);
+    metric.warn(inout result, workflow.tasks.len() > 1 && pairs == 0);
+    metric.finish(inout result);
+    result
+}
+
+pub fn verify(borrow workflow: model.Workflow, borrow result: metric.Metric) -> bool {
+    let floor = workflow.tasks.len() + workflow.edges.len() + workflow.pools.len();
+    result.tag == TAG() && result.observations >= floor &&
+        result.even + result.odd == result.observations &&
+        result.zeroes <= result.observations &&
+        (result.observations == 0 || result.minimum <= result.maximum)
+}
+
+pub fn render(borrow workflow: model.Workflow) -> StrBuf {
+    let result = analyze(borrow workflow);
+    let mut out = metric.render("path_merging", borrow result);
+    text.append_literal(inout out, "verified=");
+    text.append_bool(inout out, verify(borrow workflow, borrow result));
+    out.push(10);
+    out
+}

--- a/performance/workloads/lattice/analysis_pool_affinity.rue
+++ b/performance/workloads/lattice/analysis_pool_affinity.rue
@@ -1,0 +1,133 @@
+// Lattice analysis pass: same-pool locality.
+//
+// This pass deliberately walks tasks, pools, dependencies, and bounded task
+// pairs. The four projections expose different compiler and application
+// behavior: field-heavy records, cross-module calls, graph indirection, nested
+// control flow, checked aggregation, and deterministic report generation.
+const std = @import("std");
+const metric = @import("metric.rue");
+const model = @import("model.rue");
+const text = @import("text.rue");
+const StrBuf = std.strbuf.StrBuf;
+
+pub fn TAG() -> u64 { 1007 }
+
+fn pool_for(borrow workflow: model.Workflow, index: u64) -> model.WorkerPool {
+    workflow.pools.get_or(index, model.empty_pool())
+}
+
+fn task_projection(borrow workflow: model.Workflow, index: u64) -> u64 {
+    let task = workflow.tasks.get_or(index, model.empty_task());
+    let _task_id = task.id;
+    let _assigned_pool = pool_for(borrow workflow, task.pool);
+    task.pool * 17 + task.cpu
+}
+
+fn edge_projection(borrow workflow: model.Workflow, index: u64) -> u64 {
+    let edge = workflow.edges.get_or(index, model.empty_edge());
+    let before = workflow.tasks.get_or(edge.before, model.empty_task());
+    let after = workflow.tasks.get_or(edge.after, model.empty_task());
+    let _before_id = before.id;
+    let _after_id = after.id;
+    if before.pool == after.pool { 1 } else { 11 }
+}
+
+fn pool_projection(borrow workflow: model.Workflow, index: u64) -> u64 {
+    let pool = workflow.pools.get_or(index, model.empty_pool());
+    pool.slots * pool.cpu
+}
+
+fn related_pair(borrow workflow: model.Workflow, first: u64, second: u64) -> bool {
+    if first == second { return false; }
+    model.has_edge(borrow workflow, first, second) ||
+        model.has_edge(borrow workflow, second, first) ||
+        workflow.tasks.get_or(first, model.empty_task()).pool ==
+            workflow.tasks.get_or(second, model.empty_task()).pool
+}
+
+fn pair_projection(borrow workflow: model.Workflow, first: u64, second: u64) -> u64 {
+    let left = workflow.tasks.get_or(first, model.empty_task());
+    let right = workflow.tasks.get_or(second, model.empty_task());
+    let distance = if second >= first { second - first } else { first - second };
+    let resource = left.cpu + left.memory + right.cpu + right.memory;
+    let duration = left.duration + right.duration;
+    (distance + 1) * (resource + 1) + duration + 1007
+}
+
+fn observe_tasks(inout result: metric.Metric, borrow workflow: model.Workflow) {
+    let mut i: u64 = 0;
+    while i < workflow.tasks.len() {
+        let value = task_projection(borrow workflow, i);
+        let task = workflow.tasks.get_or(i, model.empty_task());
+        metric.observe(inout result, value, task.priority + 1);
+        metric.warn(inout result, task.duration == 0 || task.cpu == 0 || task.memory == 0);
+        i += 1;
+    }
+}
+
+fn observe_edges(inout result: metric.Metric, borrow workflow: model.Workflow) {
+    let mut i: u64 = 0;
+    while i < workflow.edges.len() {
+        let edge = workflow.edges.get_or(i, model.empty_edge());
+        let value = edge_projection(borrow workflow, i);
+        metric.observe(inout result, value, i + 1);
+        metric.warn(inout result, edge.before >= workflow.tasks.len() || edge.after >= workflow.tasks.len());
+        i += 1;
+    }
+}
+
+fn observe_pools(inout result: metric.Metric, borrow workflow: model.Workflow) {
+    let mut i: u64 = 0;
+    while i < workflow.pools.len() {
+        let value = pool_projection(borrow workflow, i);
+        let pool = workflow.pools.get_or(i, model.empty_pool());
+        metric.observe(inout result, value, pool.slots + 1);
+        metric.warn(inout result, pool.slots == 0 || pool.cpu == 0 || pool.memory == 0);
+        i += 1;
+    }
+}
+
+fn observe_pairs(inout result: metric.Metric, borrow workflow: model.Workflow) -> u64 {
+    let mut pairs: u64 = 0;
+    let mut first: u64 = 0;
+    while first < workflow.tasks.len() {
+        let mut second: u64 = first + 1;
+        while second < workflow.tasks.len() {
+            if related_pair(borrow workflow, first, second) {
+                metric.observe(inout result, pair_projection(borrow workflow, first, second), first + second + 1);
+                pairs += 1;
+            }
+            second += 1;
+        }
+        first += 1;
+    }
+    pairs
+}
+
+pub fn analyze(borrow workflow: model.Workflow) -> metric.Metric {
+    let mut result = metric.new(TAG());
+    observe_tasks(inout result, borrow workflow);
+    observe_edges(inout result, borrow workflow);
+    observe_pools(inout result, borrow workflow);
+    let pairs = observe_pairs(inout result, borrow workflow);
+    metric.warn(inout result, workflow.tasks.len() > 1 && pairs == 0);
+    metric.finish(inout result);
+    result
+}
+
+pub fn verify(borrow workflow: model.Workflow, borrow result: metric.Metric) -> bool {
+    let floor = workflow.tasks.len() + workflow.edges.len() + workflow.pools.len();
+    result.tag == TAG() && result.observations >= floor &&
+        result.even + result.odd == result.observations &&
+        result.zeroes <= result.observations &&
+        (result.observations == 0 || result.minimum <= result.maximum)
+}
+
+pub fn render(borrow workflow: model.Workflow) -> StrBuf {
+    let result = analyze(borrow workflow);
+    let mut out = metric.render("pool_affinity", borrow result);
+    text.append_literal(inout out, "verified=");
+    text.append_bool(inout out, verify(borrow workflow, borrow result));
+    out.push(10);
+    out
+}

--- a/performance/workloads/lattice/analysis_pool_cpu_share.rue
+++ b/performance/workloads/lattice/analysis_pool_cpu_share.rue
@@ -1,0 +1,133 @@
+// Lattice analysis pass: fractional CPU capacity.
+//
+// This pass deliberately walks tasks, pools, dependencies, and bounded task
+// pairs. The four projections expose different compiler and application
+// behavior: field-heavy records, cross-module calls, graph indirection, nested
+// control flow, checked aggregation, and deterministic report generation.
+const std = @import("std");
+const metric = @import("metric.rue");
+const model = @import("model.rue");
+const text = @import("text.rue");
+const StrBuf = std.strbuf.StrBuf;
+
+pub fn TAG() -> u64 { 1016 }
+
+fn pool_for(borrow workflow: model.Workflow, index: u64) -> model.WorkerPool {
+    workflow.pools.get_or(index, model.empty_pool())
+}
+
+fn task_projection(borrow workflow: model.Workflow, index: u64) -> u64 {
+    let task = workflow.tasks.get_or(index, model.empty_task());
+    let _task_id = task.id;
+    let _assigned_pool = pool_for(borrow workflow, task.pool);
+    task.cpu * 100 / (pool_for(borrow workflow, task.pool).cpu + 1)
+}
+
+fn edge_projection(borrow workflow: model.Workflow, index: u64) -> u64 {
+    let edge = workflow.edges.get_or(index, model.empty_edge());
+    let before = workflow.tasks.get_or(edge.before, model.empty_task());
+    let after = workflow.tasks.get_or(edge.after, model.empty_task());
+    let _before_id = before.id;
+    let _after_id = after.id;
+    before.cpu + after.cpu
+}
+
+fn pool_projection(borrow workflow: model.Workflow, index: u64) -> u64 {
+    let pool = workflow.pools.get_or(index, model.empty_pool());
+    pool.cpu
+}
+
+fn related_pair(borrow workflow: model.Workflow, first: u64, second: u64) -> bool {
+    if first == second { return false; }
+    model.has_edge(borrow workflow, first, second) ||
+        model.has_edge(borrow workflow, second, first) ||
+        workflow.tasks.get_or(first, model.empty_task()).pool ==
+            workflow.tasks.get_or(second, model.empty_task()).pool
+}
+
+fn pair_projection(borrow workflow: model.Workflow, first: u64, second: u64) -> u64 {
+    let left = workflow.tasks.get_or(first, model.empty_task());
+    let right = workflow.tasks.get_or(second, model.empty_task());
+    let distance = if second >= first { second - first } else { first - second };
+    let resource = left.cpu + left.memory + right.cpu + right.memory;
+    let duration = left.duration + right.duration;
+    (distance + 1) * (resource + 1) + duration + 1016
+}
+
+fn observe_tasks(inout result: metric.Metric, borrow workflow: model.Workflow) {
+    let mut i: u64 = 0;
+    while i < workflow.tasks.len() {
+        let value = task_projection(borrow workflow, i);
+        let task = workflow.tasks.get_or(i, model.empty_task());
+        metric.observe(inout result, value, task.priority + 1);
+        metric.warn(inout result, task.duration == 0 || task.cpu == 0 || task.memory == 0);
+        i += 1;
+    }
+}
+
+fn observe_edges(inout result: metric.Metric, borrow workflow: model.Workflow) {
+    let mut i: u64 = 0;
+    while i < workflow.edges.len() {
+        let edge = workflow.edges.get_or(i, model.empty_edge());
+        let value = edge_projection(borrow workflow, i);
+        metric.observe(inout result, value, i + 1);
+        metric.warn(inout result, edge.before >= workflow.tasks.len() || edge.after >= workflow.tasks.len());
+        i += 1;
+    }
+}
+
+fn observe_pools(inout result: metric.Metric, borrow workflow: model.Workflow) {
+    let mut i: u64 = 0;
+    while i < workflow.pools.len() {
+        let value = pool_projection(borrow workflow, i);
+        let pool = workflow.pools.get_or(i, model.empty_pool());
+        metric.observe(inout result, value, pool.slots + 1);
+        metric.warn(inout result, pool.slots == 0 || pool.cpu == 0 || pool.memory == 0);
+        i += 1;
+    }
+}
+
+fn observe_pairs(inout result: metric.Metric, borrow workflow: model.Workflow) -> u64 {
+    let mut pairs: u64 = 0;
+    let mut first: u64 = 0;
+    while first < workflow.tasks.len() {
+        let mut second: u64 = first + 1;
+        while second < workflow.tasks.len() {
+            if related_pair(borrow workflow, first, second) {
+                metric.observe(inout result, pair_projection(borrow workflow, first, second), first + second + 1);
+                pairs += 1;
+            }
+            second += 1;
+        }
+        first += 1;
+    }
+    pairs
+}
+
+pub fn analyze(borrow workflow: model.Workflow) -> metric.Metric {
+    let mut result = metric.new(TAG());
+    observe_tasks(inout result, borrow workflow);
+    observe_edges(inout result, borrow workflow);
+    observe_pools(inout result, borrow workflow);
+    let pairs = observe_pairs(inout result, borrow workflow);
+    metric.warn(inout result, workflow.tasks.len() > 1 && pairs == 0);
+    metric.finish(inout result);
+    result
+}
+
+pub fn verify(borrow workflow: model.Workflow, borrow result: metric.Metric) -> bool {
+    let floor = workflow.tasks.len() + workflow.edges.len() + workflow.pools.len();
+    result.tag == TAG() && result.observations >= floor &&
+        result.even + result.odd == result.observations &&
+        result.zeroes <= result.observations &&
+        (result.observations == 0 || result.minimum <= result.maximum)
+}
+
+pub fn render(borrow workflow: model.Workflow) -> StrBuf {
+    let result = analyze(borrow workflow);
+    let mut out = metric.render("pool_cpu_share", borrow result);
+    text.append_literal(inout out, "verified=");
+    text.append_bool(inout out, verify(borrow workflow, borrow result));
+    out.push(10);
+    out
+}

--- a/performance/workloads/lattice/analysis_pool_memory_share.rue
+++ b/performance/workloads/lattice/analysis_pool_memory_share.rue
@@ -1,0 +1,133 @@
+// Lattice analysis pass: fractional memory capacity.
+//
+// This pass deliberately walks tasks, pools, dependencies, and bounded task
+// pairs. The four projections expose different compiler and application
+// behavior: field-heavy records, cross-module calls, graph indirection, nested
+// control flow, checked aggregation, and deterministic report generation.
+const std = @import("std");
+const metric = @import("metric.rue");
+const model = @import("model.rue");
+const text = @import("text.rue");
+const StrBuf = std.strbuf.StrBuf;
+
+pub fn TAG() -> u64 { 1017 }
+
+fn pool_for(borrow workflow: model.Workflow, index: u64) -> model.WorkerPool {
+    workflow.pools.get_or(index, model.empty_pool())
+}
+
+fn task_projection(borrow workflow: model.Workflow, index: u64) -> u64 {
+    let task = workflow.tasks.get_or(index, model.empty_task());
+    let _task_id = task.id;
+    let _assigned_pool = pool_for(borrow workflow, task.pool);
+    task.memory * 100 / (pool_for(borrow workflow, task.pool).memory + 1)
+}
+
+fn edge_projection(borrow workflow: model.Workflow, index: u64) -> u64 {
+    let edge = workflow.edges.get_or(index, model.empty_edge());
+    let before = workflow.tasks.get_or(edge.before, model.empty_task());
+    let after = workflow.tasks.get_or(edge.after, model.empty_task());
+    let _before_id = before.id;
+    let _after_id = after.id;
+    before.memory + after.memory
+}
+
+fn pool_projection(borrow workflow: model.Workflow, index: u64) -> u64 {
+    let pool = workflow.pools.get_or(index, model.empty_pool());
+    pool.memory
+}
+
+fn related_pair(borrow workflow: model.Workflow, first: u64, second: u64) -> bool {
+    if first == second { return false; }
+    model.has_edge(borrow workflow, first, second) ||
+        model.has_edge(borrow workflow, second, first) ||
+        workflow.tasks.get_or(first, model.empty_task()).pool ==
+            workflow.tasks.get_or(second, model.empty_task()).pool
+}
+
+fn pair_projection(borrow workflow: model.Workflow, first: u64, second: u64) -> u64 {
+    let left = workflow.tasks.get_or(first, model.empty_task());
+    let right = workflow.tasks.get_or(second, model.empty_task());
+    let distance = if second >= first { second - first } else { first - second };
+    let resource = left.cpu + left.memory + right.cpu + right.memory;
+    let duration = left.duration + right.duration;
+    (distance + 1) * (resource + 1) + duration + 1017
+}
+
+fn observe_tasks(inout result: metric.Metric, borrow workflow: model.Workflow) {
+    let mut i: u64 = 0;
+    while i < workflow.tasks.len() {
+        let value = task_projection(borrow workflow, i);
+        let task = workflow.tasks.get_or(i, model.empty_task());
+        metric.observe(inout result, value, task.priority + 1);
+        metric.warn(inout result, task.duration == 0 || task.cpu == 0 || task.memory == 0);
+        i += 1;
+    }
+}
+
+fn observe_edges(inout result: metric.Metric, borrow workflow: model.Workflow) {
+    let mut i: u64 = 0;
+    while i < workflow.edges.len() {
+        let edge = workflow.edges.get_or(i, model.empty_edge());
+        let value = edge_projection(borrow workflow, i);
+        metric.observe(inout result, value, i + 1);
+        metric.warn(inout result, edge.before >= workflow.tasks.len() || edge.after >= workflow.tasks.len());
+        i += 1;
+    }
+}
+
+fn observe_pools(inout result: metric.Metric, borrow workflow: model.Workflow) {
+    let mut i: u64 = 0;
+    while i < workflow.pools.len() {
+        let value = pool_projection(borrow workflow, i);
+        let pool = workflow.pools.get_or(i, model.empty_pool());
+        metric.observe(inout result, value, pool.slots + 1);
+        metric.warn(inout result, pool.slots == 0 || pool.cpu == 0 || pool.memory == 0);
+        i += 1;
+    }
+}
+
+fn observe_pairs(inout result: metric.Metric, borrow workflow: model.Workflow) -> u64 {
+    let mut pairs: u64 = 0;
+    let mut first: u64 = 0;
+    while first < workflow.tasks.len() {
+        let mut second: u64 = first + 1;
+        while second < workflow.tasks.len() {
+            if related_pair(borrow workflow, first, second) {
+                metric.observe(inout result, pair_projection(borrow workflow, first, second), first + second + 1);
+                pairs += 1;
+            }
+            second += 1;
+        }
+        first += 1;
+    }
+    pairs
+}
+
+pub fn analyze(borrow workflow: model.Workflow) -> metric.Metric {
+    let mut result = metric.new(TAG());
+    observe_tasks(inout result, borrow workflow);
+    observe_edges(inout result, borrow workflow);
+    observe_pools(inout result, borrow workflow);
+    let pairs = observe_pairs(inout result, borrow workflow);
+    metric.warn(inout result, workflow.tasks.len() > 1 && pairs == 0);
+    metric.finish(inout result);
+    result
+}
+
+pub fn verify(borrow workflow: model.Workflow, borrow result: metric.Metric) -> bool {
+    let floor = workflow.tasks.len() + workflow.edges.len() + workflow.pools.len();
+    result.tag == TAG() && result.observations >= floor &&
+        result.even + result.odd == result.observations &&
+        result.zeroes <= result.observations &&
+        (result.observations == 0 || result.minimum <= result.maximum)
+}
+
+pub fn render(borrow workflow: model.Workflow) -> StrBuf {
+    let result = analyze(borrow workflow);
+    let mut out = metric.render("pool_memory_share", borrow result);
+    text.append_literal(inout out, "verified=");
+    text.append_bool(inout out, verify(borrow workflow, borrow result));
+    out.push(10);
+    out
+}

--- a/performance/workloads/lattice/analysis_pool_skew.rue
+++ b/performance/workloads/lattice/analysis_pool_skew.rue
@@ -1,0 +1,133 @@
+// Lattice analysis pass: pool assignment skew.
+//
+// This pass deliberately walks tasks, pools, dependencies, and bounded task
+// pairs. The four projections expose different compiler and application
+// behavior: field-heavy records, cross-module calls, graph indirection, nested
+// control flow, checked aggregation, and deterministic report generation.
+const std = @import("std");
+const metric = @import("metric.rue");
+const model = @import("model.rue");
+const text = @import("text.rue");
+const StrBuf = std.strbuf.StrBuf;
+
+pub fn TAG() -> u64 { 1038 }
+
+fn pool_for(borrow workflow: model.Workflow, index: u64) -> model.WorkerPool {
+    workflow.pools.get_or(index, model.empty_pool())
+}
+
+fn task_projection(borrow workflow: model.Workflow, index: u64) -> u64 {
+    let task = workflow.tasks.get_or(index, model.empty_task());
+    let _task_id = task.id;
+    let _assigned_pool = pool_for(borrow workflow, task.pool);
+    task.pool * task.duration
+}
+
+fn edge_projection(borrow workflow: model.Workflow, index: u64) -> u64 {
+    let edge = workflow.edges.get_or(index, model.empty_edge());
+    let before = workflow.tasks.get_or(edge.before, model.empty_task());
+    let after = workflow.tasks.get_or(edge.after, model.empty_task());
+    let _before_id = before.id;
+    let _after_id = after.id;
+    if before.pool > after.pool { before.pool - after.pool } else { after.pool - before.pool }
+}
+
+fn pool_projection(borrow workflow: model.Workflow, index: u64) -> u64 {
+    let pool = workflow.pools.get_or(index, model.empty_pool());
+    pool.slots * (pool.cpu + pool.memory)
+}
+
+fn related_pair(borrow workflow: model.Workflow, first: u64, second: u64) -> bool {
+    if first == second { return false; }
+    model.has_edge(borrow workflow, first, second) ||
+        model.has_edge(borrow workflow, second, first) ||
+        workflow.tasks.get_or(first, model.empty_task()).pool ==
+            workflow.tasks.get_or(second, model.empty_task()).pool
+}
+
+fn pair_projection(borrow workflow: model.Workflow, first: u64, second: u64) -> u64 {
+    let left = workflow.tasks.get_or(first, model.empty_task());
+    let right = workflow.tasks.get_or(second, model.empty_task());
+    let distance = if second >= first { second - first } else { first - second };
+    let resource = left.cpu + left.memory + right.cpu + right.memory;
+    let duration = left.duration + right.duration;
+    (distance + 1) * (resource + 1) + duration + 1038
+}
+
+fn observe_tasks(inout result: metric.Metric, borrow workflow: model.Workflow) {
+    let mut i: u64 = 0;
+    while i < workflow.tasks.len() {
+        let value = task_projection(borrow workflow, i);
+        let task = workflow.tasks.get_or(i, model.empty_task());
+        metric.observe(inout result, value, task.priority + 1);
+        metric.warn(inout result, task.duration == 0 || task.cpu == 0 || task.memory == 0);
+        i += 1;
+    }
+}
+
+fn observe_edges(inout result: metric.Metric, borrow workflow: model.Workflow) {
+    let mut i: u64 = 0;
+    while i < workflow.edges.len() {
+        let edge = workflow.edges.get_or(i, model.empty_edge());
+        let value = edge_projection(borrow workflow, i);
+        metric.observe(inout result, value, i + 1);
+        metric.warn(inout result, edge.before >= workflow.tasks.len() || edge.after >= workflow.tasks.len());
+        i += 1;
+    }
+}
+
+fn observe_pools(inout result: metric.Metric, borrow workflow: model.Workflow) {
+    let mut i: u64 = 0;
+    while i < workflow.pools.len() {
+        let value = pool_projection(borrow workflow, i);
+        let pool = workflow.pools.get_or(i, model.empty_pool());
+        metric.observe(inout result, value, pool.slots + 1);
+        metric.warn(inout result, pool.slots == 0 || pool.cpu == 0 || pool.memory == 0);
+        i += 1;
+    }
+}
+
+fn observe_pairs(inout result: metric.Metric, borrow workflow: model.Workflow) -> u64 {
+    let mut pairs: u64 = 0;
+    let mut first: u64 = 0;
+    while first < workflow.tasks.len() {
+        let mut second: u64 = first + 1;
+        while second < workflow.tasks.len() {
+            if related_pair(borrow workflow, first, second) {
+                metric.observe(inout result, pair_projection(borrow workflow, first, second), first + second + 1);
+                pairs += 1;
+            }
+            second += 1;
+        }
+        first += 1;
+    }
+    pairs
+}
+
+pub fn analyze(borrow workflow: model.Workflow) -> metric.Metric {
+    let mut result = metric.new(TAG());
+    observe_tasks(inout result, borrow workflow);
+    observe_edges(inout result, borrow workflow);
+    observe_pools(inout result, borrow workflow);
+    let pairs = observe_pairs(inout result, borrow workflow);
+    metric.warn(inout result, workflow.tasks.len() > 1 && pairs == 0);
+    metric.finish(inout result);
+    result
+}
+
+pub fn verify(borrow workflow: model.Workflow, borrow result: metric.Metric) -> bool {
+    let floor = workflow.tasks.len() + workflow.edges.len() + workflow.pools.len();
+    result.tag == TAG() && result.observations >= floor &&
+        result.even + result.odd == result.observations &&
+        result.zeroes <= result.observations &&
+        (result.observations == 0 || result.minimum <= result.maximum)
+}
+
+pub fn render(borrow workflow: model.Workflow) -> StrBuf {
+    let result = analyze(borrow workflow);
+    let mut out = metric.render("pool_skew", borrow result);
+    text.append_literal(inout out, "verified=");
+    text.append_bool(inout out, verify(borrow workflow, borrow result));
+    out.push(10);
+    out
+}

--- a/performance/workloads/lattice/analysis_predecessor_load.rue
+++ b/performance/workloads/lattice/analysis_predecessor_load.rue
@@ -1,0 +1,133 @@
+// Lattice analysis pass: predecessor resource load.
+//
+// This pass deliberately walks tasks, pools, dependencies, and bounded task
+// pairs. The four projections expose different compiler and application
+// behavior: field-heavy records, cross-module calls, graph indirection, nested
+// control flow, checked aggregation, and deterministic report generation.
+const std = @import("std");
+const metric = @import("metric.rue");
+const model = @import("model.rue");
+const text = @import("text.rue");
+const StrBuf = std.strbuf.StrBuf;
+
+pub fn TAG() -> u64 { 1045 }
+
+fn pool_for(borrow workflow: model.Workflow, index: u64) -> model.WorkerPool {
+    workflow.pools.get_or(index, model.empty_pool())
+}
+
+fn task_projection(borrow workflow: model.Workflow, index: u64) -> u64 {
+    let task = workflow.tasks.get_or(index, model.empty_task());
+    let _task_id = task.id;
+    let _assigned_pool = pool_for(borrow workflow, task.pool);
+    model.dependency_count(borrow workflow, index) * (task.cpu + task.memory)
+}
+
+fn edge_projection(borrow workflow: model.Workflow, index: u64) -> u64 {
+    let edge = workflow.edges.get_or(index, model.empty_edge());
+    let before = workflow.tasks.get_or(edge.before, model.empty_task());
+    let after = workflow.tasks.get_or(edge.after, model.empty_task());
+    let _before_id = before.id;
+    let _after_id = after.id;
+    model.dependency_count(borrow workflow, edge.after) * before.duration
+}
+
+fn pool_projection(borrow workflow: model.Workflow, index: u64) -> u64 {
+    let pool = workflow.pools.get_or(index, model.empty_pool());
+    pool.slots
+}
+
+fn related_pair(borrow workflow: model.Workflow, first: u64, second: u64) -> bool {
+    if first == second { return false; }
+    model.has_edge(borrow workflow, first, second) ||
+        model.has_edge(borrow workflow, second, first) ||
+        workflow.tasks.get_or(first, model.empty_task()).pool ==
+            workflow.tasks.get_or(second, model.empty_task()).pool
+}
+
+fn pair_projection(borrow workflow: model.Workflow, first: u64, second: u64) -> u64 {
+    let left = workflow.tasks.get_or(first, model.empty_task());
+    let right = workflow.tasks.get_or(second, model.empty_task());
+    let distance = if second >= first { second - first } else { first - second };
+    let resource = left.cpu + left.memory + right.cpu + right.memory;
+    let duration = left.duration + right.duration;
+    (distance + 1) * (resource + 1) + duration + 1045
+}
+
+fn observe_tasks(inout result: metric.Metric, borrow workflow: model.Workflow) {
+    let mut i: u64 = 0;
+    while i < workflow.tasks.len() {
+        let value = task_projection(borrow workflow, i);
+        let task = workflow.tasks.get_or(i, model.empty_task());
+        metric.observe(inout result, value, task.priority + 1);
+        metric.warn(inout result, task.duration == 0 || task.cpu == 0 || task.memory == 0);
+        i += 1;
+    }
+}
+
+fn observe_edges(inout result: metric.Metric, borrow workflow: model.Workflow) {
+    let mut i: u64 = 0;
+    while i < workflow.edges.len() {
+        let edge = workflow.edges.get_or(i, model.empty_edge());
+        let value = edge_projection(borrow workflow, i);
+        metric.observe(inout result, value, i + 1);
+        metric.warn(inout result, edge.before >= workflow.tasks.len() || edge.after >= workflow.tasks.len());
+        i += 1;
+    }
+}
+
+fn observe_pools(inout result: metric.Metric, borrow workflow: model.Workflow) {
+    let mut i: u64 = 0;
+    while i < workflow.pools.len() {
+        let value = pool_projection(borrow workflow, i);
+        let pool = workflow.pools.get_or(i, model.empty_pool());
+        metric.observe(inout result, value, pool.slots + 1);
+        metric.warn(inout result, pool.slots == 0 || pool.cpu == 0 || pool.memory == 0);
+        i += 1;
+    }
+}
+
+fn observe_pairs(inout result: metric.Metric, borrow workflow: model.Workflow) -> u64 {
+    let mut pairs: u64 = 0;
+    let mut first: u64 = 0;
+    while first < workflow.tasks.len() {
+        let mut second: u64 = first + 1;
+        while second < workflow.tasks.len() {
+            if related_pair(borrow workflow, first, second) {
+                metric.observe(inout result, pair_projection(borrow workflow, first, second), first + second + 1);
+                pairs += 1;
+            }
+            second += 1;
+        }
+        first += 1;
+    }
+    pairs
+}
+
+pub fn analyze(borrow workflow: model.Workflow) -> metric.Metric {
+    let mut result = metric.new(TAG());
+    observe_tasks(inout result, borrow workflow);
+    observe_edges(inout result, borrow workflow);
+    observe_pools(inout result, borrow workflow);
+    let pairs = observe_pairs(inout result, borrow workflow);
+    metric.warn(inout result, workflow.tasks.len() > 1 && pairs == 0);
+    metric.finish(inout result);
+    result
+}
+
+pub fn verify(borrow workflow: model.Workflow, borrow result: metric.Metric) -> bool {
+    let floor = workflow.tasks.len() + workflow.edges.len() + workflow.pools.len();
+    result.tag == TAG() && result.observations >= floor &&
+        result.even + result.odd == result.observations &&
+        result.zeroes <= result.observations &&
+        (result.observations == 0 || result.minimum <= result.maximum)
+}
+
+pub fn render(borrow workflow: model.Workflow) -> StrBuf {
+    let result = analyze(borrow workflow);
+    let mut out = metric.render("predecessor_load", borrow result);
+    text.append_literal(inout out, "verified=");
+    text.append_bool(inout out, verify(borrow workflow, borrow result));
+    out.push(10);
+    out
+}

--- a/performance/workloads/lattice/analysis_priority_pressure.rue
+++ b/performance/workloads/lattice/analysis_priority_pressure.rue
@@ -1,0 +1,133 @@
+// Lattice analysis pass: priority-weighted work.
+//
+// This pass deliberately walks tasks, pools, dependencies, and bounded task
+// pairs. The four projections expose different compiler and application
+// behavior: field-heavy records, cross-module calls, graph indirection, nested
+// control flow, checked aggregation, and deterministic report generation.
+const std = @import("std");
+const metric = @import("metric.rue");
+const model = @import("model.rue");
+const text = @import("text.rue");
+const StrBuf = std.strbuf.StrBuf;
+
+pub fn TAG() -> u64 { 1004 }
+
+fn pool_for(borrow workflow: model.Workflow, index: u64) -> model.WorkerPool {
+    workflow.pools.get_or(index, model.empty_pool())
+}
+
+fn task_projection(borrow workflow: model.Workflow, index: u64) -> u64 {
+    let task = workflow.tasks.get_or(index, model.empty_task());
+    let _task_id = task.id;
+    let _assigned_pool = pool_for(borrow workflow, task.pool);
+    task.priority * (task.duration + 1)
+}
+
+fn edge_projection(borrow workflow: model.Workflow, index: u64) -> u64 {
+    let edge = workflow.edges.get_or(index, model.empty_edge());
+    let before = workflow.tasks.get_or(edge.before, model.empty_task());
+    let after = workflow.tasks.get_or(edge.after, model.empty_task());
+    let _before_id = before.id;
+    let _after_id = after.id;
+    before.priority + after.priority
+}
+
+fn pool_projection(borrow workflow: model.Workflow, index: u64) -> u64 {
+    let pool = workflow.pools.get_or(index, model.empty_pool());
+    pool.slots * 10
+}
+
+fn related_pair(borrow workflow: model.Workflow, first: u64, second: u64) -> bool {
+    if first == second { return false; }
+    model.has_edge(borrow workflow, first, second) ||
+        model.has_edge(borrow workflow, second, first) ||
+        workflow.tasks.get_or(first, model.empty_task()).pool ==
+            workflow.tasks.get_or(second, model.empty_task()).pool
+}
+
+fn pair_projection(borrow workflow: model.Workflow, first: u64, second: u64) -> u64 {
+    let left = workflow.tasks.get_or(first, model.empty_task());
+    let right = workflow.tasks.get_or(second, model.empty_task());
+    let distance = if second >= first { second - first } else { first - second };
+    let resource = left.cpu + left.memory + right.cpu + right.memory;
+    let duration = left.duration + right.duration;
+    (distance + 1) * (resource + 1) + duration + 1004
+}
+
+fn observe_tasks(inout result: metric.Metric, borrow workflow: model.Workflow) {
+    let mut i: u64 = 0;
+    while i < workflow.tasks.len() {
+        let value = task_projection(borrow workflow, i);
+        let task = workflow.tasks.get_or(i, model.empty_task());
+        metric.observe(inout result, value, task.priority + 1);
+        metric.warn(inout result, task.duration == 0 || task.cpu == 0 || task.memory == 0);
+        i += 1;
+    }
+}
+
+fn observe_edges(inout result: metric.Metric, borrow workflow: model.Workflow) {
+    let mut i: u64 = 0;
+    while i < workflow.edges.len() {
+        let edge = workflow.edges.get_or(i, model.empty_edge());
+        let value = edge_projection(borrow workflow, i);
+        metric.observe(inout result, value, i + 1);
+        metric.warn(inout result, edge.before >= workflow.tasks.len() || edge.after >= workflow.tasks.len());
+        i += 1;
+    }
+}
+
+fn observe_pools(inout result: metric.Metric, borrow workflow: model.Workflow) {
+    let mut i: u64 = 0;
+    while i < workflow.pools.len() {
+        let value = pool_projection(borrow workflow, i);
+        let pool = workflow.pools.get_or(i, model.empty_pool());
+        metric.observe(inout result, value, pool.slots + 1);
+        metric.warn(inout result, pool.slots == 0 || pool.cpu == 0 || pool.memory == 0);
+        i += 1;
+    }
+}
+
+fn observe_pairs(inout result: metric.Metric, borrow workflow: model.Workflow) -> u64 {
+    let mut pairs: u64 = 0;
+    let mut first: u64 = 0;
+    while first < workflow.tasks.len() {
+        let mut second: u64 = first + 1;
+        while second < workflow.tasks.len() {
+            if related_pair(borrow workflow, first, second) {
+                metric.observe(inout result, pair_projection(borrow workflow, first, second), first + second + 1);
+                pairs += 1;
+            }
+            second += 1;
+        }
+        first += 1;
+    }
+    pairs
+}
+
+pub fn analyze(borrow workflow: model.Workflow) -> metric.Metric {
+    let mut result = metric.new(TAG());
+    observe_tasks(inout result, borrow workflow);
+    observe_edges(inout result, borrow workflow);
+    observe_pools(inout result, borrow workflow);
+    let pairs = observe_pairs(inout result, borrow workflow);
+    metric.warn(inout result, workflow.tasks.len() > 1 && pairs == 0);
+    metric.finish(inout result);
+    result
+}
+
+pub fn verify(borrow workflow: model.Workflow, borrow result: metric.Metric) -> bool {
+    let floor = workflow.tasks.len() + workflow.edges.len() + workflow.pools.len();
+    result.tag == TAG() && result.observations >= floor &&
+        result.even + result.odd == result.observations &&
+        result.zeroes <= result.observations &&
+        (result.observations == 0 || result.minimum <= result.maximum)
+}
+
+pub fn render(borrow workflow: model.Workflow) -> StrBuf {
+    let result = analyze(borrow workflow);
+    let mut out = metric.render("priority_pressure", borrow result);
+    text.append_literal(inout out, "verified=");
+    text.append_bool(inout out, verify(borrow workflow, borrow result));
+    out.push(10);
+    out
+}

--- a/performance/workloads/lattice/analysis_priority_variance_proxy.rue
+++ b/performance/workloads/lattice/analysis_priority_variance_proxy.rue
@@ -1,0 +1,133 @@
+// Lattice analysis pass: priority second moment.
+//
+// This pass deliberately walks tasks, pools, dependencies, and bounded task
+// pairs. The four projections expose different compiler and application
+// behavior: field-heavy records, cross-module calls, graph indirection, nested
+// control flow, checked aggregation, and deterministic report generation.
+const std = @import("std");
+const metric = @import("metric.rue");
+const model = @import("model.rue");
+const text = @import("text.rue");
+const StrBuf = std.strbuf.StrBuf;
+
+pub fn TAG() -> u64 { 1042 }
+
+fn pool_for(borrow workflow: model.Workflow, index: u64) -> model.WorkerPool {
+    workflow.pools.get_or(index, model.empty_pool())
+}
+
+fn task_projection(borrow workflow: model.Workflow, index: u64) -> u64 {
+    let task = workflow.tasks.get_or(index, model.empty_task());
+    let _task_id = task.id;
+    let _assigned_pool = pool_for(borrow workflow, task.pool);
+    task.priority * task.priority
+}
+
+fn edge_projection(borrow workflow: model.Workflow, index: u64) -> u64 {
+    let edge = workflow.edges.get_or(index, model.empty_edge());
+    let before = workflow.tasks.get_or(edge.before, model.empty_task());
+    let after = workflow.tasks.get_or(edge.after, model.empty_task());
+    let _before_id = before.id;
+    let _after_id = after.id;
+    before.priority * after.priority
+}
+
+fn pool_projection(borrow workflow: model.Workflow, index: u64) -> u64 {
+    let pool = workflow.pools.get_or(index, model.empty_pool());
+    pool.slots * 100
+}
+
+fn related_pair(borrow workflow: model.Workflow, first: u64, second: u64) -> bool {
+    if first == second { return false; }
+    model.has_edge(borrow workflow, first, second) ||
+        model.has_edge(borrow workflow, second, first) ||
+        workflow.tasks.get_or(first, model.empty_task()).pool ==
+            workflow.tasks.get_or(second, model.empty_task()).pool
+}
+
+fn pair_projection(borrow workflow: model.Workflow, first: u64, second: u64) -> u64 {
+    let left = workflow.tasks.get_or(first, model.empty_task());
+    let right = workflow.tasks.get_or(second, model.empty_task());
+    let distance = if second >= first { second - first } else { first - second };
+    let resource = left.cpu + left.memory + right.cpu + right.memory;
+    let duration = left.duration + right.duration;
+    (distance + 1) * (resource + 1) + duration + 1042
+}
+
+fn observe_tasks(inout result: metric.Metric, borrow workflow: model.Workflow) {
+    let mut i: u64 = 0;
+    while i < workflow.tasks.len() {
+        let value = task_projection(borrow workflow, i);
+        let task = workflow.tasks.get_or(i, model.empty_task());
+        metric.observe(inout result, value, task.priority + 1);
+        metric.warn(inout result, task.duration == 0 || task.cpu == 0 || task.memory == 0);
+        i += 1;
+    }
+}
+
+fn observe_edges(inout result: metric.Metric, borrow workflow: model.Workflow) {
+    let mut i: u64 = 0;
+    while i < workflow.edges.len() {
+        let edge = workflow.edges.get_or(i, model.empty_edge());
+        let value = edge_projection(borrow workflow, i);
+        metric.observe(inout result, value, i + 1);
+        metric.warn(inout result, edge.before >= workflow.tasks.len() || edge.after >= workflow.tasks.len());
+        i += 1;
+    }
+}
+
+fn observe_pools(inout result: metric.Metric, borrow workflow: model.Workflow) {
+    let mut i: u64 = 0;
+    while i < workflow.pools.len() {
+        let value = pool_projection(borrow workflow, i);
+        let pool = workflow.pools.get_or(i, model.empty_pool());
+        metric.observe(inout result, value, pool.slots + 1);
+        metric.warn(inout result, pool.slots == 0 || pool.cpu == 0 || pool.memory == 0);
+        i += 1;
+    }
+}
+
+fn observe_pairs(inout result: metric.Metric, borrow workflow: model.Workflow) -> u64 {
+    let mut pairs: u64 = 0;
+    let mut first: u64 = 0;
+    while first < workflow.tasks.len() {
+        let mut second: u64 = first + 1;
+        while second < workflow.tasks.len() {
+            if related_pair(borrow workflow, first, second) {
+                metric.observe(inout result, pair_projection(borrow workflow, first, second), first + second + 1);
+                pairs += 1;
+            }
+            second += 1;
+        }
+        first += 1;
+    }
+    pairs
+}
+
+pub fn analyze(borrow workflow: model.Workflow) -> metric.Metric {
+    let mut result = metric.new(TAG());
+    observe_tasks(inout result, borrow workflow);
+    observe_edges(inout result, borrow workflow);
+    observe_pools(inout result, borrow workflow);
+    let pairs = observe_pairs(inout result, borrow workflow);
+    metric.warn(inout result, workflow.tasks.len() > 1 && pairs == 0);
+    metric.finish(inout result);
+    result
+}
+
+pub fn verify(borrow workflow: model.Workflow, borrow result: metric.Metric) -> bool {
+    let floor = workflow.tasks.len() + workflow.edges.len() + workflow.pools.len();
+    result.tag == TAG() && result.observations >= floor &&
+        result.even + result.odd == result.observations &&
+        result.zeroes <= result.observations &&
+        (result.observations == 0 || result.minimum <= result.maximum)
+}
+
+pub fn render(borrow workflow: model.Workflow) -> StrBuf {
+    let result = analyze(borrow workflow);
+    let mut out = metric.render("priority_variance_proxy", borrow result);
+    text.append_literal(inout out, "verified=");
+    text.append_bool(inout out, verify(borrow workflow, borrow result));
+    out.push(10);
+    out
+}

--- a/performance/workloads/lattice/analysis_queue_priority.rue
+++ b/performance/workloads/lattice/analysis_queue_priority.rue
@@ -1,0 +1,133 @@
+// Lattice analysis pass: scheduler queue ordering pressure.
+//
+// This pass deliberately walks tasks, pools, dependencies, and bounded task
+// pairs. The four projections expose different compiler and application
+// behavior: field-heavy records, cross-module calls, graph indirection, nested
+// control flow, checked aggregation, and deterministic report generation.
+const std = @import("std");
+const metric = @import("metric.rue");
+const model = @import("model.rue");
+const text = @import("text.rue");
+const StrBuf = std.strbuf.StrBuf;
+
+pub fn TAG() -> u64 { 1020 }
+
+fn pool_for(borrow workflow: model.Workflow, index: u64) -> model.WorkerPool {
+    workflow.pools.get_or(index, model.empty_pool())
+}
+
+fn task_projection(borrow workflow: model.Workflow, index: u64) -> u64 {
+    let task = workflow.tasks.get_or(index, model.empty_task());
+    let _task_id = task.id;
+    let _assigned_pool = pool_for(borrow workflow, task.pool);
+    task.priority + task.retries * 5
+}
+
+fn edge_projection(borrow workflow: model.Workflow, index: u64) -> u64 {
+    let edge = workflow.edges.get_or(index, model.empty_edge());
+    let before = workflow.tasks.get_or(edge.before, model.empty_task());
+    let after = workflow.tasks.get_or(edge.after, model.empty_task());
+    let _before_id = before.id;
+    let _after_id = after.id;
+    before.priority + after.priority
+}
+
+fn pool_projection(borrow workflow: model.Workflow, index: u64) -> u64 {
+    let pool = workflow.pools.get_or(index, model.empty_pool());
+    pool.slots
+}
+
+fn related_pair(borrow workflow: model.Workflow, first: u64, second: u64) -> bool {
+    if first == second { return false; }
+    model.has_edge(borrow workflow, first, second) ||
+        model.has_edge(borrow workflow, second, first) ||
+        workflow.tasks.get_or(first, model.empty_task()).pool ==
+            workflow.tasks.get_or(second, model.empty_task()).pool
+}
+
+fn pair_projection(borrow workflow: model.Workflow, first: u64, second: u64) -> u64 {
+    let left = workflow.tasks.get_or(first, model.empty_task());
+    let right = workflow.tasks.get_or(second, model.empty_task());
+    let distance = if second >= first { second - first } else { first - second };
+    let resource = left.cpu + left.memory + right.cpu + right.memory;
+    let duration = left.duration + right.duration;
+    (distance + 1) * (resource + 1) + duration + 1020
+}
+
+fn observe_tasks(inout result: metric.Metric, borrow workflow: model.Workflow) {
+    let mut i: u64 = 0;
+    while i < workflow.tasks.len() {
+        let value = task_projection(borrow workflow, i);
+        let task = workflow.tasks.get_or(i, model.empty_task());
+        metric.observe(inout result, value, task.priority + 1);
+        metric.warn(inout result, task.duration == 0 || task.cpu == 0 || task.memory == 0);
+        i += 1;
+    }
+}
+
+fn observe_edges(inout result: metric.Metric, borrow workflow: model.Workflow) {
+    let mut i: u64 = 0;
+    while i < workflow.edges.len() {
+        let edge = workflow.edges.get_or(i, model.empty_edge());
+        let value = edge_projection(borrow workflow, i);
+        metric.observe(inout result, value, i + 1);
+        metric.warn(inout result, edge.before >= workflow.tasks.len() || edge.after >= workflow.tasks.len());
+        i += 1;
+    }
+}
+
+fn observe_pools(inout result: metric.Metric, borrow workflow: model.Workflow) {
+    let mut i: u64 = 0;
+    while i < workflow.pools.len() {
+        let value = pool_projection(borrow workflow, i);
+        let pool = workflow.pools.get_or(i, model.empty_pool());
+        metric.observe(inout result, value, pool.slots + 1);
+        metric.warn(inout result, pool.slots == 0 || pool.cpu == 0 || pool.memory == 0);
+        i += 1;
+    }
+}
+
+fn observe_pairs(inout result: metric.Metric, borrow workflow: model.Workflow) -> u64 {
+    let mut pairs: u64 = 0;
+    let mut first: u64 = 0;
+    while first < workflow.tasks.len() {
+        let mut second: u64 = first + 1;
+        while second < workflow.tasks.len() {
+            if related_pair(borrow workflow, first, second) {
+                metric.observe(inout result, pair_projection(borrow workflow, first, second), first + second + 1);
+                pairs += 1;
+            }
+            second += 1;
+        }
+        first += 1;
+    }
+    pairs
+}
+
+pub fn analyze(borrow workflow: model.Workflow) -> metric.Metric {
+    let mut result = metric.new(TAG());
+    observe_tasks(inout result, borrow workflow);
+    observe_edges(inout result, borrow workflow);
+    observe_pools(inout result, borrow workflow);
+    let pairs = observe_pairs(inout result, borrow workflow);
+    metric.warn(inout result, workflow.tasks.len() > 1 && pairs == 0);
+    metric.finish(inout result);
+    result
+}
+
+pub fn verify(borrow workflow: model.Workflow, borrow result: metric.Metric) -> bool {
+    let floor = workflow.tasks.len() + workflow.edges.len() + workflow.pools.len();
+    result.tag == TAG() && result.observations >= floor &&
+        result.even + result.odd == result.observations &&
+        result.zeroes <= result.observations &&
+        (result.observations == 0 || result.minimum <= result.maximum)
+}
+
+pub fn render(borrow workflow: model.Workflow) -> StrBuf {
+    let result = analyze(borrow workflow);
+    let mut out = metric.render("queue_priority", borrow result);
+    text.append_literal(inout out, "verified=");
+    text.append_bool(inout out, verify(borrow workflow, borrow result));
+    out.push(10);
+    out
+}

--- a/performance/workloads/lattice/analysis_resource_balance.rue
+++ b/performance/workloads/lattice/analysis_resource_balance.rue
@@ -1,0 +1,133 @@
+// Lattice analysis pass: CPU-memory balance.
+//
+// This pass deliberately walks tasks, pools, dependencies, and bounded task
+// pairs. The four projections expose different compiler and application
+// behavior: field-heavy records, cross-module calls, graph indirection, nested
+// control flow, checked aggregation, and deterministic report generation.
+const std = @import("std");
+const metric = @import("metric.rue");
+const model = @import("model.rue");
+const text = @import("text.rue");
+const StrBuf = std.strbuf.StrBuf;
+
+pub fn TAG() -> u64 { 1037 }
+
+fn pool_for(borrow workflow: model.Workflow, index: u64) -> model.WorkerPool {
+    workflow.pools.get_or(index, model.empty_pool())
+}
+
+fn task_projection(borrow workflow: model.Workflow, index: u64) -> u64 {
+    let task = workflow.tasks.get_or(index, model.empty_task());
+    let _task_id = task.id;
+    let _assigned_pool = pool_for(borrow workflow, task.pool);
+    if task.cpu > task.memory { task.cpu - task.memory } else { task.memory - task.cpu }
+}
+
+fn edge_projection(borrow workflow: model.Workflow, index: u64) -> u64 {
+    let edge = workflow.edges.get_or(index, model.empty_edge());
+    let before = workflow.tasks.get_or(edge.before, model.empty_task());
+    let after = workflow.tasks.get_or(edge.after, model.empty_task());
+    let _before_id = before.id;
+    let _after_id = after.id;
+    before.cpu + after.memory
+}
+
+fn pool_projection(borrow workflow: model.Workflow, index: u64) -> u64 {
+    let pool = workflow.pools.get_or(index, model.empty_pool());
+    if pool.cpu > pool.memory { pool.cpu - pool.memory } else { pool.memory - pool.cpu }
+}
+
+fn related_pair(borrow workflow: model.Workflow, first: u64, second: u64) -> bool {
+    if first == second { return false; }
+    model.has_edge(borrow workflow, first, second) ||
+        model.has_edge(borrow workflow, second, first) ||
+        workflow.tasks.get_or(first, model.empty_task()).pool ==
+            workflow.tasks.get_or(second, model.empty_task()).pool
+}
+
+fn pair_projection(borrow workflow: model.Workflow, first: u64, second: u64) -> u64 {
+    let left = workflow.tasks.get_or(first, model.empty_task());
+    let right = workflow.tasks.get_or(second, model.empty_task());
+    let distance = if second >= first { second - first } else { first - second };
+    let resource = left.cpu + left.memory + right.cpu + right.memory;
+    let duration = left.duration + right.duration;
+    (distance + 1) * (resource + 1) + duration + 1037
+}
+
+fn observe_tasks(inout result: metric.Metric, borrow workflow: model.Workflow) {
+    let mut i: u64 = 0;
+    while i < workflow.tasks.len() {
+        let value = task_projection(borrow workflow, i);
+        let task = workflow.tasks.get_or(i, model.empty_task());
+        metric.observe(inout result, value, task.priority + 1);
+        metric.warn(inout result, task.duration == 0 || task.cpu == 0 || task.memory == 0);
+        i += 1;
+    }
+}
+
+fn observe_edges(inout result: metric.Metric, borrow workflow: model.Workflow) {
+    let mut i: u64 = 0;
+    while i < workflow.edges.len() {
+        let edge = workflow.edges.get_or(i, model.empty_edge());
+        let value = edge_projection(borrow workflow, i);
+        metric.observe(inout result, value, i + 1);
+        metric.warn(inout result, edge.before >= workflow.tasks.len() || edge.after >= workflow.tasks.len());
+        i += 1;
+    }
+}
+
+fn observe_pools(inout result: metric.Metric, borrow workflow: model.Workflow) {
+    let mut i: u64 = 0;
+    while i < workflow.pools.len() {
+        let value = pool_projection(borrow workflow, i);
+        let pool = workflow.pools.get_or(i, model.empty_pool());
+        metric.observe(inout result, value, pool.slots + 1);
+        metric.warn(inout result, pool.slots == 0 || pool.cpu == 0 || pool.memory == 0);
+        i += 1;
+    }
+}
+
+fn observe_pairs(inout result: metric.Metric, borrow workflow: model.Workflow) -> u64 {
+    let mut pairs: u64 = 0;
+    let mut first: u64 = 0;
+    while first < workflow.tasks.len() {
+        let mut second: u64 = first + 1;
+        while second < workflow.tasks.len() {
+            if related_pair(borrow workflow, first, second) {
+                metric.observe(inout result, pair_projection(borrow workflow, first, second), first + second + 1);
+                pairs += 1;
+            }
+            second += 1;
+        }
+        first += 1;
+    }
+    pairs
+}
+
+pub fn analyze(borrow workflow: model.Workflow) -> metric.Metric {
+    let mut result = metric.new(TAG());
+    observe_tasks(inout result, borrow workflow);
+    observe_edges(inout result, borrow workflow);
+    observe_pools(inout result, borrow workflow);
+    let pairs = observe_pairs(inout result, borrow workflow);
+    metric.warn(inout result, workflow.tasks.len() > 1 && pairs == 0);
+    metric.finish(inout result);
+    result
+}
+
+pub fn verify(borrow workflow: model.Workflow, borrow result: metric.Metric) -> bool {
+    let floor = workflow.tasks.len() + workflow.edges.len() + workflow.pools.len();
+    result.tag == TAG() && result.observations >= floor &&
+        result.even + result.odd == result.observations &&
+        result.zeroes <= result.observations &&
+        (result.observations == 0 || result.minimum <= result.maximum)
+}
+
+pub fn render(borrow workflow: model.Workflow) -> StrBuf {
+    let result = analyze(borrow workflow);
+    let mut out = metric.render("resource_balance", borrow result);
+    text.append_literal(inout out, "verified=");
+    text.append_bool(inout out, verify(borrow workflow, borrow result));
+    out.push(10);
+    out
+}

--- a/performance/workloads/lattice/analysis_resource_product.rue
+++ b/performance/workloads/lattice/analysis_resource_product.rue
@@ -1,0 +1,133 @@
+// Lattice analysis pass: combined resource footprint.
+//
+// This pass deliberately walks tasks, pools, dependencies, and bounded task
+// pairs. The four projections expose different compiler and application
+// behavior: field-heavy records, cross-module calls, graph indirection, nested
+// control flow, checked aggregation, and deterministic report generation.
+const std = @import("std");
+const metric = @import("metric.rue");
+const model = @import("model.rue");
+const text = @import("text.rue");
+const StrBuf = std.strbuf.StrBuf;
+
+pub fn TAG() -> u64 { 1014 }
+
+fn pool_for(borrow workflow: model.Workflow, index: u64) -> model.WorkerPool {
+    workflow.pools.get_or(index, model.empty_pool())
+}
+
+fn task_projection(borrow workflow: model.Workflow, index: u64) -> u64 {
+    let task = workflow.tasks.get_or(index, model.empty_task());
+    let _task_id = task.id;
+    let _assigned_pool = pool_for(borrow workflow, task.pool);
+    task.cpu * task.memory * (task.duration + 1)
+}
+
+fn edge_projection(borrow workflow: model.Workflow, index: u64) -> u64 {
+    let edge = workflow.edges.get_or(index, model.empty_edge());
+    let before = workflow.tasks.get_or(edge.before, model.empty_task());
+    let after = workflow.tasks.get_or(edge.after, model.empty_task());
+    let _before_id = before.id;
+    let _after_id = after.id;
+    before.cpu * after.memory + after.cpu * before.memory
+}
+
+fn pool_projection(borrow workflow: model.Workflow, index: u64) -> u64 {
+    let pool = workflow.pools.get_or(index, model.empty_pool());
+    pool.cpu * pool.memory
+}
+
+fn related_pair(borrow workflow: model.Workflow, first: u64, second: u64) -> bool {
+    if first == second { return false; }
+    model.has_edge(borrow workflow, first, second) ||
+        model.has_edge(borrow workflow, second, first) ||
+        workflow.tasks.get_or(first, model.empty_task()).pool ==
+            workflow.tasks.get_or(second, model.empty_task()).pool
+}
+
+fn pair_projection(borrow workflow: model.Workflow, first: u64, second: u64) -> u64 {
+    let left = workflow.tasks.get_or(first, model.empty_task());
+    let right = workflow.tasks.get_or(second, model.empty_task());
+    let distance = if second >= first { second - first } else { first - second };
+    let resource = left.cpu + left.memory + right.cpu + right.memory;
+    let duration = left.duration + right.duration;
+    (distance + 1) * (resource + 1) + duration + 1014
+}
+
+fn observe_tasks(inout result: metric.Metric, borrow workflow: model.Workflow) {
+    let mut i: u64 = 0;
+    while i < workflow.tasks.len() {
+        let value = task_projection(borrow workflow, i);
+        let task = workflow.tasks.get_or(i, model.empty_task());
+        metric.observe(inout result, value, task.priority + 1);
+        metric.warn(inout result, task.duration == 0 || task.cpu == 0 || task.memory == 0);
+        i += 1;
+    }
+}
+
+fn observe_edges(inout result: metric.Metric, borrow workflow: model.Workflow) {
+    let mut i: u64 = 0;
+    while i < workflow.edges.len() {
+        let edge = workflow.edges.get_or(i, model.empty_edge());
+        let value = edge_projection(borrow workflow, i);
+        metric.observe(inout result, value, i + 1);
+        metric.warn(inout result, edge.before >= workflow.tasks.len() || edge.after >= workflow.tasks.len());
+        i += 1;
+    }
+}
+
+fn observe_pools(inout result: metric.Metric, borrow workflow: model.Workflow) {
+    let mut i: u64 = 0;
+    while i < workflow.pools.len() {
+        let value = pool_projection(borrow workflow, i);
+        let pool = workflow.pools.get_or(i, model.empty_pool());
+        metric.observe(inout result, value, pool.slots + 1);
+        metric.warn(inout result, pool.slots == 0 || pool.cpu == 0 || pool.memory == 0);
+        i += 1;
+    }
+}
+
+fn observe_pairs(inout result: metric.Metric, borrow workflow: model.Workflow) -> u64 {
+    let mut pairs: u64 = 0;
+    let mut first: u64 = 0;
+    while first < workflow.tasks.len() {
+        let mut second: u64 = first + 1;
+        while second < workflow.tasks.len() {
+            if related_pair(borrow workflow, first, second) {
+                metric.observe(inout result, pair_projection(borrow workflow, first, second), first + second + 1);
+                pairs += 1;
+            }
+            second += 1;
+        }
+        first += 1;
+    }
+    pairs
+}
+
+pub fn analyze(borrow workflow: model.Workflow) -> metric.Metric {
+    let mut result = metric.new(TAG());
+    observe_tasks(inout result, borrow workflow);
+    observe_edges(inout result, borrow workflow);
+    observe_pools(inout result, borrow workflow);
+    let pairs = observe_pairs(inout result, borrow workflow);
+    metric.warn(inout result, workflow.tasks.len() > 1 && pairs == 0);
+    metric.finish(inout result);
+    result
+}
+
+pub fn verify(borrow workflow: model.Workflow, borrow result: metric.Metric) -> bool {
+    let floor = workflow.tasks.len() + workflow.edges.len() + workflow.pools.len();
+    result.tag == TAG() && result.observations >= floor &&
+        result.even + result.odd == result.observations &&
+        result.zeroes <= result.observations &&
+        (result.observations == 0 || result.minimum <= result.maximum)
+}
+
+pub fn render(borrow workflow: model.Workflow) -> StrBuf {
+    let result = analyze(borrow workflow);
+    let mut out = metric.render("resource_product", borrow result);
+    text.append_literal(inout out, "verified=");
+    text.append_bool(inout out, verify(borrow workflow, borrow result));
+    out.push(10);
+    out
+}

--- a/performance/workloads/lattice/analysis_retry_exposure.rue
+++ b/performance/workloads/lattice/analysis_retry_exposure.rue
@@ -1,0 +1,133 @@
+// Lattice analysis pass: retry-amplified work.
+//
+// This pass deliberately walks tasks, pools, dependencies, and bounded task
+// pairs. The four projections expose different compiler and application
+// behavior: field-heavy records, cross-module calls, graph indirection, nested
+// control flow, checked aggregation, and deterministic report generation.
+const std = @import("std");
+const metric = @import("metric.rue");
+const model = @import("model.rue");
+const text = @import("text.rue");
+const StrBuf = std.strbuf.StrBuf;
+
+pub fn TAG() -> u64 { 1005 }
+
+fn pool_for(borrow workflow: model.Workflow, index: u64) -> model.WorkerPool {
+    workflow.pools.get_or(index, model.empty_pool())
+}
+
+fn task_projection(borrow workflow: model.Workflow, index: u64) -> u64 {
+    let task = workflow.tasks.get_or(index, model.empty_task());
+    let _task_id = task.id;
+    let _assigned_pool = pool_for(borrow workflow, task.pool);
+    task.retries * task.duration
+}
+
+fn edge_projection(borrow workflow: model.Workflow, index: u64) -> u64 {
+    let edge = workflow.edges.get_or(index, model.empty_edge());
+    let before = workflow.tasks.get_or(edge.before, model.empty_task());
+    let after = workflow.tasks.get_or(edge.after, model.empty_task());
+    let _before_id = before.id;
+    let _after_id = after.id;
+    before.retries + after.retries
+}
+
+fn pool_projection(borrow workflow: model.Workflow, index: u64) -> u64 {
+    let pool = workflow.pools.get_or(index, model.empty_pool());
+    pool.slots
+}
+
+fn related_pair(borrow workflow: model.Workflow, first: u64, second: u64) -> bool {
+    if first == second { return false; }
+    model.has_edge(borrow workflow, first, second) ||
+        model.has_edge(borrow workflow, second, first) ||
+        workflow.tasks.get_or(first, model.empty_task()).pool ==
+            workflow.tasks.get_or(second, model.empty_task()).pool
+}
+
+fn pair_projection(borrow workflow: model.Workflow, first: u64, second: u64) -> u64 {
+    let left = workflow.tasks.get_or(first, model.empty_task());
+    let right = workflow.tasks.get_or(second, model.empty_task());
+    let distance = if second >= first { second - first } else { first - second };
+    let resource = left.cpu + left.memory + right.cpu + right.memory;
+    let duration = left.duration + right.duration;
+    (distance + 1) * (resource + 1) + duration + 1005
+}
+
+fn observe_tasks(inout result: metric.Metric, borrow workflow: model.Workflow) {
+    let mut i: u64 = 0;
+    while i < workflow.tasks.len() {
+        let value = task_projection(borrow workflow, i);
+        let task = workflow.tasks.get_or(i, model.empty_task());
+        metric.observe(inout result, value, task.priority + 1);
+        metric.warn(inout result, task.duration == 0 || task.cpu == 0 || task.memory == 0);
+        i += 1;
+    }
+}
+
+fn observe_edges(inout result: metric.Metric, borrow workflow: model.Workflow) {
+    let mut i: u64 = 0;
+    while i < workflow.edges.len() {
+        let edge = workflow.edges.get_or(i, model.empty_edge());
+        let value = edge_projection(borrow workflow, i);
+        metric.observe(inout result, value, i + 1);
+        metric.warn(inout result, edge.before >= workflow.tasks.len() || edge.after >= workflow.tasks.len());
+        i += 1;
+    }
+}
+
+fn observe_pools(inout result: metric.Metric, borrow workflow: model.Workflow) {
+    let mut i: u64 = 0;
+    while i < workflow.pools.len() {
+        let value = pool_projection(borrow workflow, i);
+        let pool = workflow.pools.get_or(i, model.empty_pool());
+        metric.observe(inout result, value, pool.slots + 1);
+        metric.warn(inout result, pool.slots == 0 || pool.cpu == 0 || pool.memory == 0);
+        i += 1;
+    }
+}
+
+fn observe_pairs(inout result: metric.Metric, borrow workflow: model.Workflow) -> u64 {
+    let mut pairs: u64 = 0;
+    let mut first: u64 = 0;
+    while first < workflow.tasks.len() {
+        let mut second: u64 = first + 1;
+        while second < workflow.tasks.len() {
+            if related_pair(borrow workflow, first, second) {
+                metric.observe(inout result, pair_projection(borrow workflow, first, second), first + second + 1);
+                pairs += 1;
+            }
+            second += 1;
+        }
+        first += 1;
+    }
+    pairs
+}
+
+pub fn analyze(borrow workflow: model.Workflow) -> metric.Metric {
+    let mut result = metric.new(TAG());
+    observe_tasks(inout result, borrow workflow);
+    observe_edges(inout result, borrow workflow);
+    observe_pools(inout result, borrow workflow);
+    let pairs = observe_pairs(inout result, borrow workflow);
+    metric.warn(inout result, workflow.tasks.len() > 1 && pairs == 0);
+    metric.finish(inout result);
+    result
+}
+
+pub fn verify(borrow workflow: model.Workflow, borrow result: metric.Metric) -> bool {
+    let floor = workflow.tasks.len() + workflow.edges.len() + workflow.pools.len();
+    result.tag == TAG() && result.observations >= floor &&
+        result.even + result.odd == result.observations &&
+        result.zeroes <= result.observations &&
+        (result.observations == 0 || result.minimum <= result.maximum)
+}
+
+pub fn render(borrow workflow: model.Workflow) -> StrBuf {
+    let result = analyze(borrow workflow);
+    let mut out = metric.render("retry_exposure", borrow result);
+    text.append_literal(inout out, "verified=");
+    text.append_bool(inout out, verify(borrow workflow, borrow result));
+    out.push(10);
+    out
+}

--- a/performance/workloads/lattice/analysis_retry_work.rue
+++ b/performance/workloads/lattice/analysis_retry_work.rue
@@ -1,0 +1,133 @@
+// Lattice analysis pass: worst-case retry work.
+//
+// This pass deliberately walks tasks, pools, dependencies, and bounded task
+// pairs. The four projections expose different compiler and application
+// behavior: field-heavy records, cross-module calls, graph indirection, nested
+// control flow, checked aggregation, and deterministic report generation.
+const std = @import("std");
+const metric = @import("metric.rue");
+const model = @import("model.rue");
+const text = @import("text.rue");
+const StrBuf = std.strbuf.StrBuf;
+
+pub fn TAG() -> u64 { 1033 }
+
+fn pool_for(borrow workflow: model.Workflow, index: u64) -> model.WorkerPool {
+    workflow.pools.get_or(index, model.empty_pool())
+}
+
+fn task_projection(borrow workflow: model.Workflow, index: u64) -> u64 {
+    let task = workflow.tasks.get_or(index, model.empty_task());
+    let _task_id = task.id;
+    let _assigned_pool = pool_for(borrow workflow, task.pool);
+    task.duration * (task.retries + 1)
+}
+
+fn edge_projection(borrow workflow: model.Workflow, index: u64) -> u64 {
+    let edge = workflow.edges.get_or(index, model.empty_edge());
+    let before = workflow.tasks.get_or(edge.before, model.empty_task());
+    let after = workflow.tasks.get_or(edge.after, model.empty_task());
+    let _before_id = before.id;
+    let _after_id = after.id;
+    before.retries * before.duration + after.retries * after.duration
+}
+
+fn pool_projection(borrow workflow: model.Workflow, index: u64) -> u64 {
+    let pool = workflow.pools.get_or(index, model.empty_pool());
+    pool.slots
+}
+
+fn related_pair(borrow workflow: model.Workflow, first: u64, second: u64) -> bool {
+    if first == second { return false; }
+    model.has_edge(borrow workflow, first, second) ||
+        model.has_edge(borrow workflow, second, first) ||
+        workflow.tasks.get_or(first, model.empty_task()).pool ==
+            workflow.tasks.get_or(second, model.empty_task()).pool
+}
+
+fn pair_projection(borrow workflow: model.Workflow, first: u64, second: u64) -> u64 {
+    let left = workflow.tasks.get_or(first, model.empty_task());
+    let right = workflow.tasks.get_or(second, model.empty_task());
+    let distance = if second >= first { second - first } else { first - second };
+    let resource = left.cpu + left.memory + right.cpu + right.memory;
+    let duration = left.duration + right.duration;
+    (distance + 1) * (resource + 1) + duration + 1033
+}
+
+fn observe_tasks(inout result: metric.Metric, borrow workflow: model.Workflow) {
+    let mut i: u64 = 0;
+    while i < workflow.tasks.len() {
+        let value = task_projection(borrow workflow, i);
+        let task = workflow.tasks.get_or(i, model.empty_task());
+        metric.observe(inout result, value, task.priority + 1);
+        metric.warn(inout result, task.duration == 0 || task.cpu == 0 || task.memory == 0);
+        i += 1;
+    }
+}
+
+fn observe_edges(inout result: metric.Metric, borrow workflow: model.Workflow) {
+    let mut i: u64 = 0;
+    while i < workflow.edges.len() {
+        let edge = workflow.edges.get_or(i, model.empty_edge());
+        let value = edge_projection(borrow workflow, i);
+        metric.observe(inout result, value, i + 1);
+        metric.warn(inout result, edge.before >= workflow.tasks.len() || edge.after >= workflow.tasks.len());
+        i += 1;
+    }
+}
+
+fn observe_pools(inout result: metric.Metric, borrow workflow: model.Workflow) {
+    let mut i: u64 = 0;
+    while i < workflow.pools.len() {
+        let value = pool_projection(borrow workflow, i);
+        let pool = workflow.pools.get_or(i, model.empty_pool());
+        metric.observe(inout result, value, pool.slots + 1);
+        metric.warn(inout result, pool.slots == 0 || pool.cpu == 0 || pool.memory == 0);
+        i += 1;
+    }
+}
+
+fn observe_pairs(inout result: metric.Metric, borrow workflow: model.Workflow) -> u64 {
+    let mut pairs: u64 = 0;
+    let mut first: u64 = 0;
+    while first < workflow.tasks.len() {
+        let mut second: u64 = first + 1;
+        while second < workflow.tasks.len() {
+            if related_pair(borrow workflow, first, second) {
+                metric.observe(inout result, pair_projection(borrow workflow, first, second), first + second + 1);
+                pairs += 1;
+            }
+            second += 1;
+        }
+        first += 1;
+    }
+    pairs
+}
+
+pub fn analyze(borrow workflow: model.Workflow) -> metric.Metric {
+    let mut result = metric.new(TAG());
+    observe_tasks(inout result, borrow workflow);
+    observe_edges(inout result, borrow workflow);
+    observe_pools(inout result, borrow workflow);
+    let pairs = observe_pairs(inout result, borrow workflow);
+    metric.warn(inout result, workflow.tasks.len() > 1 && pairs == 0);
+    metric.finish(inout result);
+    result
+}
+
+pub fn verify(borrow workflow: model.Workflow, borrow result: metric.Metric) -> bool {
+    let floor = workflow.tasks.len() + workflow.edges.len() + workflow.pools.len();
+    result.tag == TAG() && result.observations >= floor &&
+        result.even + result.odd == result.observations &&
+        result.zeroes <= result.observations &&
+        (result.observations == 0 || result.minimum <= result.maximum)
+}
+
+pub fn render(borrow workflow: model.Workflow) -> StrBuf {
+    let result = analyze(borrow workflow);
+    let mut out = metric.render("retry_work", borrow result);
+    text.append_literal(inout out, "verified=");
+    text.append_bool(inout out, verify(borrow workflow, borrow result));
+    out.push(10);
+    out
+}

--- a/performance/workloads/lattice/analysis_root_cost.rue
+++ b/performance/workloads/lattice/analysis_root_cost.rue
@@ -1,0 +1,133 @@
+// Lattice analysis pass: root task work.
+//
+// This pass deliberately walks tasks, pools, dependencies, and bounded task
+// pairs. The four projections expose different compiler and application
+// behavior: field-heavy records, cross-module calls, graph indirection, nested
+// control flow, checked aggregation, and deterministic report generation.
+const std = @import("std");
+const metric = @import("metric.rue");
+const model = @import("model.rue");
+const text = @import("text.rue");
+const StrBuf = std.strbuf.StrBuf;
+
+pub fn TAG() -> u64 { 1012 }
+
+fn pool_for(borrow workflow: model.Workflow, index: u64) -> model.WorkerPool {
+    workflow.pools.get_or(index, model.empty_pool())
+}
+
+fn task_projection(borrow workflow: model.Workflow, index: u64) -> u64 {
+    let task = workflow.tasks.get_or(index, model.empty_task());
+    let _task_id = task.id;
+    let _assigned_pool = pool_for(borrow workflow, task.pool);
+    if model.dependency_count(borrow workflow, index) == 0 { task.duration } else { 0 }
+}
+
+fn edge_projection(borrow workflow: model.Workflow, index: u64) -> u64 {
+    let edge = workflow.edges.get_or(index, model.empty_edge());
+    let before = workflow.tasks.get_or(edge.before, model.empty_task());
+    let after = workflow.tasks.get_or(edge.after, model.empty_task());
+    let _before_id = before.id;
+    let _after_id = after.id;
+    edge.before
+}
+
+fn pool_projection(borrow workflow: model.Workflow, index: u64) -> u64 {
+    let pool = workflow.pools.get_or(index, model.empty_pool());
+    pool.cpu
+}
+
+fn related_pair(borrow workflow: model.Workflow, first: u64, second: u64) -> bool {
+    if first == second { return false; }
+    model.has_edge(borrow workflow, first, second) ||
+        model.has_edge(borrow workflow, second, first) ||
+        workflow.tasks.get_or(first, model.empty_task()).pool ==
+            workflow.tasks.get_or(second, model.empty_task()).pool
+}
+
+fn pair_projection(borrow workflow: model.Workflow, first: u64, second: u64) -> u64 {
+    let left = workflow.tasks.get_or(first, model.empty_task());
+    let right = workflow.tasks.get_or(second, model.empty_task());
+    let distance = if second >= first { second - first } else { first - second };
+    let resource = left.cpu + left.memory + right.cpu + right.memory;
+    let duration = left.duration + right.duration;
+    (distance + 1) * (resource + 1) + duration + 1012
+}
+
+fn observe_tasks(inout result: metric.Metric, borrow workflow: model.Workflow) {
+    let mut i: u64 = 0;
+    while i < workflow.tasks.len() {
+        let value = task_projection(borrow workflow, i);
+        let task = workflow.tasks.get_or(i, model.empty_task());
+        metric.observe(inout result, value, task.priority + 1);
+        metric.warn(inout result, task.duration == 0 || task.cpu == 0 || task.memory == 0);
+        i += 1;
+    }
+}
+
+fn observe_edges(inout result: metric.Metric, borrow workflow: model.Workflow) {
+    let mut i: u64 = 0;
+    while i < workflow.edges.len() {
+        let edge = workflow.edges.get_or(i, model.empty_edge());
+        let value = edge_projection(borrow workflow, i);
+        metric.observe(inout result, value, i + 1);
+        metric.warn(inout result, edge.before >= workflow.tasks.len() || edge.after >= workflow.tasks.len());
+        i += 1;
+    }
+}
+
+fn observe_pools(inout result: metric.Metric, borrow workflow: model.Workflow) {
+    let mut i: u64 = 0;
+    while i < workflow.pools.len() {
+        let value = pool_projection(borrow workflow, i);
+        let pool = workflow.pools.get_or(i, model.empty_pool());
+        metric.observe(inout result, value, pool.slots + 1);
+        metric.warn(inout result, pool.slots == 0 || pool.cpu == 0 || pool.memory == 0);
+        i += 1;
+    }
+}
+
+fn observe_pairs(inout result: metric.Metric, borrow workflow: model.Workflow) -> u64 {
+    let mut pairs: u64 = 0;
+    let mut first: u64 = 0;
+    while first < workflow.tasks.len() {
+        let mut second: u64 = first + 1;
+        while second < workflow.tasks.len() {
+            if related_pair(borrow workflow, first, second) {
+                metric.observe(inout result, pair_projection(borrow workflow, first, second), first + second + 1);
+                pairs += 1;
+            }
+            second += 1;
+        }
+        first += 1;
+    }
+    pairs
+}
+
+pub fn analyze(borrow workflow: model.Workflow) -> metric.Metric {
+    let mut result = metric.new(TAG());
+    observe_tasks(inout result, borrow workflow);
+    observe_edges(inout result, borrow workflow);
+    observe_pools(inout result, borrow workflow);
+    let pairs = observe_pairs(inout result, borrow workflow);
+    metric.warn(inout result, workflow.tasks.len() > 1 && pairs == 0);
+    metric.finish(inout result);
+    result
+}
+
+pub fn verify(borrow workflow: model.Workflow, borrow result: metric.Metric) -> bool {
+    let floor = workflow.tasks.len() + workflow.edges.len() + workflow.pools.len();
+    result.tag == TAG() && result.observations >= floor &&
+        result.even + result.odd == result.observations &&
+        result.zeroes <= result.observations &&
+        (result.observations == 0 || result.minimum <= result.maximum)
+}
+
+pub fn render(borrow workflow: model.Workflow) -> StrBuf {
+    let result = analyze(borrow workflow);
+    let mut out = metric.render("root_cost", borrow result);
+    text.append_literal(inout out, "verified=");
+    text.append_bool(inout out, verify(borrow workflow, borrow result));
+    out.push(10);
+    out
+}

--- a/performance/workloads/lattice/analysis_same_pool_edges.rue
+++ b/performance/workloads/lattice/analysis_same_pool_edges.rue
@@ -1,0 +1,133 @@
+// Lattice analysis pass: same-pool handoffs.
+//
+// This pass deliberately walks tasks, pools, dependencies, and bounded task
+// pairs. The four projections expose different compiler and application
+// behavior: field-heavy records, cross-module calls, graph indirection, nested
+// control flow, checked aggregation, and deterministic report generation.
+const std = @import("std");
+const metric = @import("metric.rue");
+const model = @import("model.rue");
+const text = @import("text.rue");
+const StrBuf = std.strbuf.StrBuf;
+
+pub fn TAG() -> u64 { 1028 }
+
+fn pool_for(borrow workflow: model.Workflow, index: u64) -> model.WorkerPool {
+    workflow.pools.get_or(index, model.empty_pool())
+}
+
+fn task_projection(borrow workflow: model.Workflow, index: u64) -> u64 {
+    let task = workflow.tasks.get_or(index, model.empty_task());
+    let _task_id = task.id;
+    let _assigned_pool = pool_for(borrow workflow, task.pool);
+    task.pool + 1
+}
+
+fn edge_projection(borrow workflow: model.Workflow, index: u64) -> u64 {
+    let edge = workflow.edges.get_or(index, model.empty_edge());
+    let before = workflow.tasks.get_or(edge.before, model.empty_task());
+    let after = workflow.tasks.get_or(edge.after, model.empty_task());
+    let _before_id = before.id;
+    let _after_id = after.id;
+    if before.pool == after.pool { before.duration + after.duration } else { 0 }
+}
+
+fn pool_projection(borrow workflow: model.Workflow, index: u64) -> u64 {
+    let pool = workflow.pools.get_or(index, model.empty_pool());
+    pool.slots
+}
+
+fn related_pair(borrow workflow: model.Workflow, first: u64, second: u64) -> bool {
+    if first == second { return false; }
+    model.has_edge(borrow workflow, first, second) ||
+        model.has_edge(borrow workflow, second, first) ||
+        workflow.tasks.get_or(first, model.empty_task()).pool ==
+            workflow.tasks.get_or(second, model.empty_task()).pool
+}
+
+fn pair_projection(borrow workflow: model.Workflow, first: u64, second: u64) -> u64 {
+    let left = workflow.tasks.get_or(first, model.empty_task());
+    let right = workflow.tasks.get_or(second, model.empty_task());
+    let distance = if second >= first { second - first } else { first - second };
+    let resource = left.cpu + left.memory + right.cpu + right.memory;
+    let duration = left.duration + right.duration;
+    (distance + 1) * (resource + 1) + duration + 1028
+}
+
+fn observe_tasks(inout result: metric.Metric, borrow workflow: model.Workflow) {
+    let mut i: u64 = 0;
+    while i < workflow.tasks.len() {
+        let value = task_projection(borrow workflow, i);
+        let task = workflow.tasks.get_or(i, model.empty_task());
+        metric.observe(inout result, value, task.priority + 1);
+        metric.warn(inout result, task.duration == 0 || task.cpu == 0 || task.memory == 0);
+        i += 1;
+    }
+}
+
+fn observe_edges(inout result: metric.Metric, borrow workflow: model.Workflow) {
+    let mut i: u64 = 0;
+    while i < workflow.edges.len() {
+        let edge = workflow.edges.get_or(i, model.empty_edge());
+        let value = edge_projection(borrow workflow, i);
+        metric.observe(inout result, value, i + 1);
+        metric.warn(inout result, edge.before >= workflow.tasks.len() || edge.after >= workflow.tasks.len());
+        i += 1;
+    }
+}
+
+fn observe_pools(inout result: metric.Metric, borrow workflow: model.Workflow) {
+    let mut i: u64 = 0;
+    while i < workflow.pools.len() {
+        let value = pool_projection(borrow workflow, i);
+        let pool = workflow.pools.get_or(i, model.empty_pool());
+        metric.observe(inout result, value, pool.slots + 1);
+        metric.warn(inout result, pool.slots == 0 || pool.cpu == 0 || pool.memory == 0);
+        i += 1;
+    }
+}
+
+fn observe_pairs(inout result: metric.Metric, borrow workflow: model.Workflow) -> u64 {
+    let mut pairs: u64 = 0;
+    let mut first: u64 = 0;
+    while first < workflow.tasks.len() {
+        let mut second: u64 = first + 1;
+        while second < workflow.tasks.len() {
+            if related_pair(borrow workflow, first, second) {
+                metric.observe(inout result, pair_projection(borrow workflow, first, second), first + second + 1);
+                pairs += 1;
+            }
+            second += 1;
+        }
+        first += 1;
+    }
+    pairs
+}
+
+pub fn analyze(borrow workflow: model.Workflow) -> metric.Metric {
+    let mut result = metric.new(TAG());
+    observe_tasks(inout result, borrow workflow);
+    observe_edges(inout result, borrow workflow);
+    observe_pools(inout result, borrow workflow);
+    let pairs = observe_pairs(inout result, borrow workflow);
+    metric.warn(inout result, workflow.tasks.len() > 1 && pairs == 0);
+    metric.finish(inout result);
+    result
+}
+
+pub fn verify(borrow workflow: model.Workflow, borrow result: metric.Metric) -> bool {
+    let floor = workflow.tasks.len() + workflow.edges.len() + workflow.pools.len();
+    result.tag == TAG() && result.observations >= floor &&
+        result.even + result.odd == result.observations &&
+        result.zeroes <= result.observations &&
+        (result.observations == 0 || result.minimum <= result.maximum)
+}
+
+pub fn render(borrow workflow: model.Workflow) -> StrBuf {
+    let result = analyze(borrow workflow);
+    let mut out = metric.render("same_pool_edges", borrow result);
+    text.append_literal(inout out, "verified=");
+    text.append_bool(inout out, verify(borrow workflow, borrow result));
+    out.push(10);
+    out
+}

--- a/performance/workloads/lattice/analysis_schedule_weight.rue
+++ b/performance/workloads/lattice/analysis_schedule_weight.rue
@@ -1,0 +1,133 @@
+// Lattice analysis pass: composite scheduling weight.
+//
+// This pass deliberately walks tasks, pools, dependencies, and bounded task
+// pairs. The four projections expose different compiler and application
+// behavior: field-heavy records, cross-module calls, graph indirection, nested
+// control flow, checked aggregation, and deterministic report generation.
+const std = @import("std");
+const metric = @import("metric.rue");
+const model = @import("model.rue");
+const text = @import("text.rue");
+const StrBuf = std.strbuf.StrBuf;
+
+pub fn TAG() -> u64 { 1036 }
+
+fn pool_for(borrow workflow: model.Workflow, index: u64) -> model.WorkerPool {
+    workflow.pools.get_or(index, model.empty_pool())
+}
+
+fn task_projection(borrow workflow: model.Workflow, index: u64) -> u64 {
+    let task = workflow.tasks.get_or(index, model.empty_task());
+    let _task_id = task.id;
+    let _assigned_pool = pool_for(borrow workflow, task.pool);
+    task.priority * 7 + task.duration * 11 + task.cpu * 13 + task.memory * 17
+}
+
+fn edge_projection(borrow workflow: model.Workflow, index: u64) -> u64 {
+    let edge = workflow.edges.get_or(index, model.empty_edge());
+    let before = workflow.tasks.get_or(edge.before, model.empty_task());
+    let after = workflow.tasks.get_or(edge.after, model.empty_task());
+    let _before_id = before.id;
+    let _after_id = after.id;
+    before.duration * 5 + after.priority * 3
+}
+
+fn pool_projection(borrow workflow: model.Workflow, index: u64) -> u64 {
+    let pool = workflow.pools.get_or(index, model.empty_pool());
+    pool.cpu * 7 + pool.memory * 11
+}
+
+fn related_pair(borrow workflow: model.Workflow, first: u64, second: u64) -> bool {
+    if first == second { return false; }
+    model.has_edge(borrow workflow, first, second) ||
+        model.has_edge(borrow workflow, second, first) ||
+        workflow.tasks.get_or(first, model.empty_task()).pool ==
+            workflow.tasks.get_or(second, model.empty_task()).pool
+}
+
+fn pair_projection(borrow workflow: model.Workflow, first: u64, second: u64) -> u64 {
+    let left = workflow.tasks.get_or(first, model.empty_task());
+    let right = workflow.tasks.get_or(second, model.empty_task());
+    let distance = if second >= first { second - first } else { first - second };
+    let resource = left.cpu + left.memory + right.cpu + right.memory;
+    let duration = left.duration + right.duration;
+    (distance + 1) * (resource + 1) + duration + 1036
+}
+
+fn observe_tasks(inout result: metric.Metric, borrow workflow: model.Workflow) {
+    let mut i: u64 = 0;
+    while i < workflow.tasks.len() {
+        let value = task_projection(borrow workflow, i);
+        let task = workflow.tasks.get_or(i, model.empty_task());
+        metric.observe(inout result, value, task.priority + 1);
+        metric.warn(inout result, task.duration == 0 || task.cpu == 0 || task.memory == 0);
+        i += 1;
+    }
+}
+
+fn observe_edges(inout result: metric.Metric, borrow workflow: model.Workflow) {
+    let mut i: u64 = 0;
+    while i < workflow.edges.len() {
+        let edge = workflow.edges.get_or(i, model.empty_edge());
+        let value = edge_projection(borrow workflow, i);
+        metric.observe(inout result, value, i + 1);
+        metric.warn(inout result, edge.before >= workflow.tasks.len() || edge.after >= workflow.tasks.len());
+        i += 1;
+    }
+}
+
+fn observe_pools(inout result: metric.Metric, borrow workflow: model.Workflow) {
+    let mut i: u64 = 0;
+    while i < workflow.pools.len() {
+        let value = pool_projection(borrow workflow, i);
+        let pool = workflow.pools.get_or(i, model.empty_pool());
+        metric.observe(inout result, value, pool.slots + 1);
+        metric.warn(inout result, pool.slots == 0 || pool.cpu == 0 || pool.memory == 0);
+        i += 1;
+    }
+}
+
+fn observe_pairs(inout result: metric.Metric, borrow workflow: model.Workflow) -> u64 {
+    let mut pairs: u64 = 0;
+    let mut first: u64 = 0;
+    while first < workflow.tasks.len() {
+        let mut second: u64 = first + 1;
+        while second < workflow.tasks.len() {
+            if related_pair(borrow workflow, first, second) {
+                metric.observe(inout result, pair_projection(borrow workflow, first, second), first + second + 1);
+                pairs += 1;
+            }
+            second += 1;
+        }
+        first += 1;
+    }
+    pairs
+}
+
+pub fn analyze(borrow workflow: model.Workflow) -> metric.Metric {
+    let mut result = metric.new(TAG());
+    observe_tasks(inout result, borrow workflow);
+    observe_edges(inout result, borrow workflow);
+    observe_pools(inout result, borrow workflow);
+    let pairs = observe_pairs(inout result, borrow workflow);
+    metric.warn(inout result, workflow.tasks.len() > 1 && pairs == 0);
+    metric.finish(inout result);
+    result
+}
+
+pub fn verify(borrow workflow: model.Workflow, borrow result: metric.Metric) -> bool {
+    let floor = workflow.tasks.len() + workflow.edges.len() + workflow.pools.len();
+    result.tag == TAG() && result.observations >= floor &&
+        result.even + result.odd == result.observations &&
+        result.zeroes <= result.observations &&
+        (result.observations == 0 || result.minimum <= result.maximum)
+}
+
+pub fn render(borrow workflow: model.Workflow) -> StrBuf {
+    let result = analyze(borrow workflow);
+    let mut out = metric.render("schedule_weight", borrow result);
+    text.append_literal(inout out, "verified=");
+    text.append_bool(inout out, verify(borrow workflow, borrow result));
+    out.push(10);
+    out
+}

--- a/performance/workloads/lattice/analysis_short_edges.rue
+++ b/performance/workloads/lattice/analysis_short_edges.rue
@@ -1,0 +1,133 @@
+// Lattice analysis pass: short-range graph edges.
+//
+// This pass deliberately walks tasks, pools, dependencies, and bounded task
+// pairs. The four projections expose different compiler and application
+// behavior: field-heavy records, cross-module calls, graph indirection, nested
+// control flow, checked aggregation, and deterministic report generation.
+const std = @import("std");
+const metric = @import("metric.rue");
+const model = @import("model.rue");
+const text = @import("text.rue");
+const StrBuf = std.strbuf.StrBuf;
+
+pub fn TAG() -> u64 { 1030 }
+
+fn pool_for(borrow workflow: model.Workflow, index: u64) -> model.WorkerPool {
+    workflow.pools.get_or(index, model.empty_pool())
+}
+
+fn task_projection(borrow workflow: model.Workflow, index: u64) -> u64 {
+    let task = workflow.tasks.get_or(index, model.empty_task());
+    let _task_id = task.id;
+    let _assigned_pool = pool_for(borrow workflow, task.pool);
+    task.duration
+}
+
+fn edge_projection(borrow workflow: model.Workflow, index: u64) -> u64 {
+    let edge = workflow.edges.get_or(index, model.empty_edge());
+    let before = workflow.tasks.get_or(edge.before, model.empty_task());
+    let after = workflow.tasks.get_or(edge.after, model.empty_task());
+    let _before_id = before.id;
+    let _after_id = after.id;
+    if edge.after >= edge.before && edge.after <= edge.before + 3 { 1 + edge.after - edge.before } else { 0 }
+}
+
+fn pool_projection(borrow workflow: model.Workflow, index: u64) -> u64 {
+    let pool = workflow.pools.get_or(index, model.empty_pool());
+    pool.memory
+}
+
+fn related_pair(borrow workflow: model.Workflow, first: u64, second: u64) -> bool {
+    if first == second { return false; }
+    model.has_edge(borrow workflow, first, second) ||
+        model.has_edge(borrow workflow, second, first) ||
+        workflow.tasks.get_or(first, model.empty_task()).pool ==
+            workflow.tasks.get_or(second, model.empty_task()).pool
+}
+
+fn pair_projection(borrow workflow: model.Workflow, first: u64, second: u64) -> u64 {
+    let left = workflow.tasks.get_or(first, model.empty_task());
+    let right = workflow.tasks.get_or(second, model.empty_task());
+    let distance = if second >= first { second - first } else { first - second };
+    let resource = left.cpu + left.memory + right.cpu + right.memory;
+    let duration = left.duration + right.duration;
+    (distance + 1) * (resource + 1) + duration + 1030
+}
+
+fn observe_tasks(inout result: metric.Metric, borrow workflow: model.Workflow) {
+    let mut i: u64 = 0;
+    while i < workflow.tasks.len() {
+        let value = task_projection(borrow workflow, i);
+        let task = workflow.tasks.get_or(i, model.empty_task());
+        metric.observe(inout result, value, task.priority + 1);
+        metric.warn(inout result, task.duration == 0 || task.cpu == 0 || task.memory == 0);
+        i += 1;
+    }
+}
+
+fn observe_edges(inout result: metric.Metric, borrow workflow: model.Workflow) {
+    let mut i: u64 = 0;
+    while i < workflow.edges.len() {
+        let edge = workflow.edges.get_or(i, model.empty_edge());
+        let value = edge_projection(borrow workflow, i);
+        metric.observe(inout result, value, i + 1);
+        metric.warn(inout result, edge.before >= workflow.tasks.len() || edge.after >= workflow.tasks.len());
+        i += 1;
+    }
+}
+
+fn observe_pools(inout result: metric.Metric, borrow workflow: model.Workflow) {
+    let mut i: u64 = 0;
+    while i < workflow.pools.len() {
+        let value = pool_projection(borrow workflow, i);
+        let pool = workflow.pools.get_or(i, model.empty_pool());
+        metric.observe(inout result, value, pool.slots + 1);
+        metric.warn(inout result, pool.slots == 0 || pool.cpu == 0 || pool.memory == 0);
+        i += 1;
+    }
+}
+
+fn observe_pairs(inout result: metric.Metric, borrow workflow: model.Workflow) -> u64 {
+    let mut pairs: u64 = 0;
+    let mut first: u64 = 0;
+    while first < workflow.tasks.len() {
+        let mut second: u64 = first + 1;
+        while second < workflow.tasks.len() {
+            if related_pair(borrow workflow, first, second) {
+                metric.observe(inout result, pair_projection(borrow workflow, first, second), first + second + 1);
+                pairs += 1;
+            }
+            second += 1;
+        }
+        first += 1;
+    }
+    pairs
+}
+
+pub fn analyze(borrow workflow: model.Workflow) -> metric.Metric {
+    let mut result = metric.new(TAG());
+    observe_tasks(inout result, borrow workflow);
+    observe_edges(inout result, borrow workflow);
+    observe_pools(inout result, borrow workflow);
+    let pairs = observe_pairs(inout result, borrow workflow);
+    metric.warn(inout result, workflow.tasks.len() > 1 && pairs == 0);
+    metric.finish(inout result);
+    result
+}
+
+pub fn verify(borrow workflow: model.Workflow, borrow result: metric.Metric) -> bool {
+    let floor = workflow.tasks.len() + workflow.edges.len() + workflow.pools.len();
+    result.tag == TAG() && result.observations >= floor &&
+        result.even + result.odd == result.observations &&
+        result.zeroes <= result.observations &&
+        (result.observations == 0 || result.minimum <= result.maximum)
+}
+
+pub fn render(borrow workflow: model.Workflow) -> StrBuf {
+    let result = analyze(borrow workflow);
+    let mut out = metric.render("short_edges", borrow result);
+    text.append_literal(inout out, "verified=");
+    text.append_bool(inout out, verify(borrow workflow, borrow result));
+    out.push(10);
+    out
+}

--- a/performance/workloads/lattice/analysis_slot_demand.rue
+++ b/performance/workloads/lattice/analysis_slot_demand.rue
@@ -1,0 +1,133 @@
+// Lattice analysis pass: slot occupancy pressure.
+//
+// This pass deliberately walks tasks, pools, dependencies, and bounded task
+// pairs. The four projections expose different compiler and application
+// behavior: field-heavy records, cross-module calls, graph indirection, nested
+// control flow, checked aggregation, and deterministic report generation.
+const std = @import("std");
+const metric = @import("metric.rue");
+const model = @import("model.rue");
+const text = @import("text.rue");
+const StrBuf = std.strbuf.StrBuf;
+
+pub fn TAG() -> u64 { 1015 }
+
+fn pool_for(borrow workflow: model.Workflow, index: u64) -> model.WorkerPool {
+    workflow.pools.get_or(index, model.empty_pool())
+}
+
+fn task_projection(borrow workflow: model.Workflow, index: u64) -> u64 {
+    let task = workflow.tasks.get_or(index, model.empty_task());
+    let _task_id = task.id;
+    let _assigned_pool = pool_for(borrow workflow, task.pool);
+    1 + task.duration / 3
+}
+
+fn edge_projection(borrow workflow: model.Workflow, index: u64) -> u64 {
+    let edge = workflow.edges.get_or(index, model.empty_edge());
+    let before = workflow.tasks.get_or(edge.before, model.empty_task());
+    let after = workflow.tasks.get_or(edge.after, model.empty_task());
+    let _before_id = before.id;
+    let _after_id = after.id;
+    1 + before.duration / 5 + after.duration / 5
+}
+
+fn pool_projection(borrow workflow: model.Workflow, index: u64) -> u64 {
+    let pool = workflow.pools.get_or(index, model.empty_pool());
+    pool.slots
+}
+
+fn related_pair(borrow workflow: model.Workflow, first: u64, second: u64) -> bool {
+    if first == second { return false; }
+    model.has_edge(borrow workflow, first, second) ||
+        model.has_edge(borrow workflow, second, first) ||
+        workflow.tasks.get_or(first, model.empty_task()).pool ==
+            workflow.tasks.get_or(second, model.empty_task()).pool
+}
+
+fn pair_projection(borrow workflow: model.Workflow, first: u64, second: u64) -> u64 {
+    let left = workflow.tasks.get_or(first, model.empty_task());
+    let right = workflow.tasks.get_or(second, model.empty_task());
+    let distance = if second >= first { second - first } else { first - second };
+    let resource = left.cpu + left.memory + right.cpu + right.memory;
+    let duration = left.duration + right.duration;
+    (distance + 1) * (resource + 1) + duration + 1015
+}
+
+fn observe_tasks(inout result: metric.Metric, borrow workflow: model.Workflow) {
+    let mut i: u64 = 0;
+    while i < workflow.tasks.len() {
+        let value = task_projection(borrow workflow, i);
+        let task = workflow.tasks.get_or(i, model.empty_task());
+        metric.observe(inout result, value, task.priority + 1);
+        metric.warn(inout result, task.duration == 0 || task.cpu == 0 || task.memory == 0);
+        i += 1;
+    }
+}
+
+fn observe_edges(inout result: metric.Metric, borrow workflow: model.Workflow) {
+    let mut i: u64 = 0;
+    while i < workflow.edges.len() {
+        let edge = workflow.edges.get_or(i, model.empty_edge());
+        let value = edge_projection(borrow workflow, i);
+        metric.observe(inout result, value, i + 1);
+        metric.warn(inout result, edge.before >= workflow.tasks.len() || edge.after >= workflow.tasks.len());
+        i += 1;
+    }
+}
+
+fn observe_pools(inout result: metric.Metric, borrow workflow: model.Workflow) {
+    let mut i: u64 = 0;
+    while i < workflow.pools.len() {
+        let value = pool_projection(borrow workflow, i);
+        let pool = workflow.pools.get_or(i, model.empty_pool());
+        metric.observe(inout result, value, pool.slots + 1);
+        metric.warn(inout result, pool.slots == 0 || pool.cpu == 0 || pool.memory == 0);
+        i += 1;
+    }
+}
+
+fn observe_pairs(inout result: metric.Metric, borrow workflow: model.Workflow) -> u64 {
+    let mut pairs: u64 = 0;
+    let mut first: u64 = 0;
+    while first < workflow.tasks.len() {
+        let mut second: u64 = first + 1;
+        while second < workflow.tasks.len() {
+            if related_pair(borrow workflow, first, second) {
+                metric.observe(inout result, pair_projection(borrow workflow, first, second), first + second + 1);
+                pairs += 1;
+            }
+            second += 1;
+        }
+        first += 1;
+    }
+    pairs
+}
+
+pub fn analyze(borrow workflow: model.Workflow) -> metric.Metric {
+    let mut result = metric.new(TAG());
+    observe_tasks(inout result, borrow workflow);
+    observe_edges(inout result, borrow workflow);
+    observe_pools(inout result, borrow workflow);
+    let pairs = observe_pairs(inout result, borrow workflow);
+    metric.warn(inout result, workflow.tasks.len() > 1 && pairs == 0);
+    metric.finish(inout result);
+    result
+}
+
+pub fn verify(borrow workflow: model.Workflow, borrow result: metric.Metric) -> bool {
+    let floor = workflow.tasks.len() + workflow.edges.len() + workflow.pools.len();
+    result.tag == TAG() && result.observations >= floor &&
+        result.even + result.odd == result.observations &&
+        result.zeroes <= result.observations &&
+        (result.observations == 0 || result.minimum <= result.maximum)
+}
+
+pub fn render(borrow workflow: model.Workflow) -> StrBuf {
+    let result = analyze(borrow workflow);
+    let mut out = metric.render("slot_demand", borrow result);
+    text.append_literal(inout out, "verified=");
+    text.append_bool(inout out, verify(borrow workflow, borrow result));
+    out.push(10);
+    out
+}

--- a/performance/workloads/lattice/analysis_successor_load.rue
+++ b/performance/workloads/lattice/analysis_successor_load.rue
@@ -1,0 +1,133 @@
+// Lattice analysis pass: successor resource load.
+//
+// This pass deliberately walks tasks, pools, dependencies, and bounded task
+// pairs. The four projections expose different compiler and application
+// behavior: field-heavy records, cross-module calls, graph indirection, nested
+// control flow, checked aggregation, and deterministic report generation.
+const std = @import("std");
+const metric = @import("metric.rue");
+const model = @import("model.rue");
+const text = @import("text.rue");
+const StrBuf = std.strbuf.StrBuf;
+
+pub fn TAG() -> u64 { 1044 }
+
+fn pool_for(borrow workflow: model.Workflow, index: u64) -> model.WorkerPool {
+    workflow.pools.get_or(index, model.empty_pool())
+}
+
+fn task_projection(borrow workflow: model.Workflow, index: u64) -> u64 {
+    let task = workflow.tasks.get_or(index, model.empty_task());
+    let _task_id = task.id;
+    let _assigned_pool = pool_for(borrow workflow, task.pool);
+    model.dependent_count(borrow workflow, index) * (task.cpu + task.memory)
+}
+
+fn edge_projection(borrow workflow: model.Workflow, index: u64) -> u64 {
+    let edge = workflow.edges.get_or(index, model.empty_edge());
+    let before = workflow.tasks.get_or(edge.before, model.empty_task());
+    let after = workflow.tasks.get_or(edge.after, model.empty_task());
+    let _before_id = before.id;
+    let _after_id = after.id;
+    model.dependent_count(borrow workflow, edge.before) * after.duration
+}
+
+fn pool_projection(borrow workflow: model.Workflow, index: u64) -> u64 {
+    let pool = workflow.pools.get_or(index, model.empty_pool());
+    pool.slots
+}
+
+fn related_pair(borrow workflow: model.Workflow, first: u64, second: u64) -> bool {
+    if first == second { return false; }
+    model.has_edge(borrow workflow, first, second) ||
+        model.has_edge(borrow workflow, second, first) ||
+        workflow.tasks.get_or(first, model.empty_task()).pool ==
+            workflow.tasks.get_or(second, model.empty_task()).pool
+}
+
+fn pair_projection(borrow workflow: model.Workflow, first: u64, second: u64) -> u64 {
+    let left = workflow.tasks.get_or(first, model.empty_task());
+    let right = workflow.tasks.get_or(second, model.empty_task());
+    let distance = if second >= first { second - first } else { first - second };
+    let resource = left.cpu + left.memory + right.cpu + right.memory;
+    let duration = left.duration + right.duration;
+    (distance + 1) * (resource + 1) + duration + 1044
+}
+
+fn observe_tasks(inout result: metric.Metric, borrow workflow: model.Workflow) {
+    let mut i: u64 = 0;
+    while i < workflow.tasks.len() {
+        let value = task_projection(borrow workflow, i);
+        let task = workflow.tasks.get_or(i, model.empty_task());
+        metric.observe(inout result, value, task.priority + 1);
+        metric.warn(inout result, task.duration == 0 || task.cpu == 0 || task.memory == 0);
+        i += 1;
+    }
+}
+
+fn observe_edges(inout result: metric.Metric, borrow workflow: model.Workflow) {
+    let mut i: u64 = 0;
+    while i < workflow.edges.len() {
+        let edge = workflow.edges.get_or(i, model.empty_edge());
+        let value = edge_projection(borrow workflow, i);
+        metric.observe(inout result, value, i + 1);
+        metric.warn(inout result, edge.before >= workflow.tasks.len() || edge.after >= workflow.tasks.len());
+        i += 1;
+    }
+}
+
+fn observe_pools(inout result: metric.Metric, borrow workflow: model.Workflow) {
+    let mut i: u64 = 0;
+    while i < workflow.pools.len() {
+        let value = pool_projection(borrow workflow, i);
+        let pool = workflow.pools.get_or(i, model.empty_pool());
+        metric.observe(inout result, value, pool.slots + 1);
+        metric.warn(inout result, pool.slots == 0 || pool.cpu == 0 || pool.memory == 0);
+        i += 1;
+    }
+}
+
+fn observe_pairs(inout result: metric.Metric, borrow workflow: model.Workflow) -> u64 {
+    let mut pairs: u64 = 0;
+    let mut first: u64 = 0;
+    while first < workflow.tasks.len() {
+        let mut second: u64 = first + 1;
+        while second < workflow.tasks.len() {
+            if related_pair(borrow workflow, first, second) {
+                metric.observe(inout result, pair_projection(borrow workflow, first, second), first + second + 1);
+                pairs += 1;
+            }
+            second += 1;
+        }
+        first += 1;
+    }
+    pairs
+}
+
+pub fn analyze(borrow workflow: model.Workflow) -> metric.Metric {
+    let mut result = metric.new(TAG());
+    observe_tasks(inout result, borrow workflow);
+    observe_edges(inout result, borrow workflow);
+    observe_pools(inout result, borrow workflow);
+    let pairs = observe_pairs(inout result, borrow workflow);
+    metric.warn(inout result, workflow.tasks.len() > 1 && pairs == 0);
+    metric.finish(inout result);
+    result
+}
+
+pub fn verify(borrow workflow: model.Workflow, borrow result: metric.Metric) -> bool {
+    let floor = workflow.tasks.len() + workflow.edges.len() + workflow.pools.len();
+    result.tag == TAG() && result.observations >= floor &&
+        result.even + result.odd == result.observations &&
+        result.zeroes <= result.observations &&
+        (result.observations == 0 || result.minimum <= result.maximum)
+}
+
+pub fn render(borrow workflow: model.Workflow) -> StrBuf {
+    let result = analyze(borrow workflow);
+    let mut out = metric.render("successor_load", borrow result);
+    text.append_literal(inout out, "verified=");
+    text.append_bool(inout out, verify(borrow workflow, borrow result));
+    out.push(10);
+    out
+}

--- a/performance/workloads/lattice/analysis_uncached_work.rue
+++ b/performance/workloads/lattice/analysis_uncached_work.rue
@@ -1,0 +1,133 @@
+// Lattice analysis pass: uncached resource work.
+//
+// This pass deliberately walks tasks, pools, dependencies, and bounded task
+// pairs. The four projections expose different compiler and application
+// behavior: field-heavy records, cross-module calls, graph indirection, nested
+// control flow, checked aggregation, and deterministic report generation.
+const std = @import("std");
+const metric = @import("metric.rue");
+const model = @import("model.rue");
+const text = @import("text.rue");
+const StrBuf = std.strbuf.StrBuf;
+
+pub fn TAG() -> u64 { 1047 }
+
+fn pool_for(borrow workflow: model.Workflow, index: u64) -> model.WorkerPool {
+    workflow.pools.get_or(index, model.empty_pool())
+}
+
+fn task_projection(borrow workflow: model.Workflow, index: u64) -> u64 {
+    let task = workflow.tasks.get_or(index, model.empty_task());
+    let _task_id = task.id;
+    let _assigned_pool = pool_for(borrow workflow, task.pool);
+    if !task.cacheable { task.duration * (task.cpu + task.memory) } else { 0 }
+}
+
+fn edge_projection(borrow workflow: model.Workflow, index: u64) -> u64 {
+    let edge = workflow.edges.get_or(index, model.empty_edge());
+    let before = workflow.tasks.get_or(edge.before, model.empty_task());
+    let after = workflow.tasks.get_or(edge.after, model.empty_task());
+    let _before_id = before.id;
+    let _after_id = after.id;
+    if !before.cacheable && !after.cacheable { before.duration + after.duration } else { 0 }
+}
+
+fn pool_projection(borrow workflow: model.Workflow, index: u64) -> u64 {
+    let pool = workflow.pools.get_or(index, model.empty_pool());
+    pool.memory
+}
+
+fn related_pair(borrow workflow: model.Workflow, first: u64, second: u64) -> bool {
+    if first == second { return false; }
+    model.has_edge(borrow workflow, first, second) ||
+        model.has_edge(borrow workflow, second, first) ||
+        workflow.tasks.get_or(first, model.empty_task()).pool ==
+            workflow.tasks.get_or(second, model.empty_task()).pool
+}
+
+fn pair_projection(borrow workflow: model.Workflow, first: u64, second: u64) -> u64 {
+    let left = workflow.tasks.get_or(first, model.empty_task());
+    let right = workflow.tasks.get_or(second, model.empty_task());
+    let distance = if second >= first { second - first } else { first - second };
+    let resource = left.cpu + left.memory + right.cpu + right.memory;
+    let duration = left.duration + right.duration;
+    (distance + 1) * (resource + 1) + duration + 1047
+}
+
+fn observe_tasks(inout result: metric.Metric, borrow workflow: model.Workflow) {
+    let mut i: u64 = 0;
+    while i < workflow.tasks.len() {
+        let value = task_projection(borrow workflow, i);
+        let task = workflow.tasks.get_or(i, model.empty_task());
+        metric.observe(inout result, value, task.priority + 1);
+        metric.warn(inout result, task.duration == 0 || task.cpu == 0 || task.memory == 0);
+        i += 1;
+    }
+}
+
+fn observe_edges(inout result: metric.Metric, borrow workflow: model.Workflow) {
+    let mut i: u64 = 0;
+    while i < workflow.edges.len() {
+        let edge = workflow.edges.get_or(i, model.empty_edge());
+        let value = edge_projection(borrow workflow, i);
+        metric.observe(inout result, value, i + 1);
+        metric.warn(inout result, edge.before >= workflow.tasks.len() || edge.after >= workflow.tasks.len());
+        i += 1;
+    }
+}
+
+fn observe_pools(inout result: metric.Metric, borrow workflow: model.Workflow) {
+    let mut i: u64 = 0;
+    while i < workflow.pools.len() {
+        let value = pool_projection(borrow workflow, i);
+        let pool = workflow.pools.get_or(i, model.empty_pool());
+        metric.observe(inout result, value, pool.slots + 1);
+        metric.warn(inout result, pool.slots == 0 || pool.cpu == 0 || pool.memory == 0);
+        i += 1;
+    }
+}
+
+fn observe_pairs(inout result: metric.Metric, borrow workflow: model.Workflow) -> u64 {
+    let mut pairs: u64 = 0;
+    let mut first: u64 = 0;
+    while first < workflow.tasks.len() {
+        let mut second: u64 = first + 1;
+        while second < workflow.tasks.len() {
+            if related_pair(borrow workflow, first, second) {
+                metric.observe(inout result, pair_projection(borrow workflow, first, second), first + second + 1);
+                pairs += 1;
+            }
+            second += 1;
+        }
+        first += 1;
+    }
+    pairs
+}
+
+pub fn analyze(borrow workflow: model.Workflow) -> metric.Metric {
+    let mut result = metric.new(TAG());
+    observe_tasks(inout result, borrow workflow);
+    observe_edges(inout result, borrow workflow);
+    observe_pools(inout result, borrow workflow);
+    let pairs = observe_pairs(inout result, borrow workflow);
+    metric.warn(inout result, workflow.tasks.len() > 1 && pairs == 0);
+    metric.finish(inout result);
+    result
+}
+
+pub fn verify(borrow workflow: model.Workflow, borrow result: metric.Metric) -> bool {
+    let floor = workflow.tasks.len() + workflow.edges.len() + workflow.pools.len();
+    result.tag == TAG() && result.observations >= floor &&
+        result.even + result.odd == result.observations &&
+        result.zeroes <= result.observations &&
+        (result.observations == 0 || result.minimum <= result.maximum)
+}
+
+pub fn render(borrow workflow: model.Workflow) -> StrBuf {
+    let result = analyze(borrow workflow);
+    let mut out = metric.render("uncached_work", borrow result);
+    text.append_literal(inout out, "verified=");
+    text.append_bool(inout out, verify(borrow workflow, borrow result));
+    out.push(10);
+    out
+}

--- a/performance/workloads/lattice/cache_analysis.rue
+++ b/performance/workloads/lattice/cache_analysis.rue
@@ -1,0 +1,82 @@
+// Declared cache policy versus observed cache behavior.
+const model = @import("model.rue");
+const state = @import("state.rue");
+
+pub struct Analysis {
+    cacheable_by_pool: model.U64s,
+    hits_by_pool: model.U64s,
+    misses_by_pool: model.U64s,
+    declared_cacheable: u64,
+    observed_hits: u64,
+    observed_misses: u64,
+    invalid_hits: u64,
+    saved_duration: u64,
+    saved_cpu_ticks: u64,
+    saved_memory_ticks: u64,
+    hit_rate_millis: u64,
+    digest: u64,
+    valid: bool,
+}
+
+fn zeroes(count: u64) -> model.U64s {
+    let mut out = model.U64s.with_capacity(count);
+    let mut i: u64 = 0;
+    while i < count { out.push(0); i += 1; }
+    out
+}
+
+fn add(inout values: model.U64s, index: u64) {
+    if index < values.len() { values.set(index, values.get_or(index, 0) + 1); }
+}
+
+fn mix(hash: u64, value: u64) -> u64 { @wrapping_mul(hash ^ value, 1099511628211) }
+
+pub fn compute(borrow workflow: model.Workflow, borrow run: state.Run) -> Analysis {
+    let mut cacheable_by_pool = zeroes(workflow.pools.len());
+    let mut hits_by_pool = zeroes(workflow.pools.len());
+    let mut misses_by_pool = zeroes(workflow.pools.len());
+    let mut declared_cacheable: u64 = 0;
+    let mut observed_hits: u64 = 0;
+    let mut observed_misses: u64 = 0;
+    let mut invalid_hits: u64 = 0;
+    let mut saved_duration: u64 = 0;
+    let mut saved_cpu_ticks: u64 = 0;
+    let mut saved_memory_ticks: u64 = 0;
+    let mut digest: u64 = 14695981039346656037;
+    let mut i: u64 = 0;
+    while i < workflow.tasks.len() {
+        let task = workflow.tasks.get_or(i, model.empty_task());
+        let status = run.status.get_or(i, state.FAILED());
+        if task.cacheable {
+            declared_cacheable += 1;
+            add(inout cacheable_by_pool, task.pool);
+            if status == state.CACHED() {
+                observed_hits += 1;
+                add(inout hits_by_pool, task.pool);
+                saved_duration += task.duration;
+                saved_cpu_ticks += task.duration * task.cpu;
+                saved_memory_ticks += task.duration * task.memory;
+            } else {
+                observed_misses += 1;
+                add(inout misses_by_pool, task.pool);
+            }
+        } else if status == state.CACHED() {
+            invalid_hits += 1;
+        }
+        digest = mix(digest, i); digest = mix(digest, status);
+        digest = mix(digest, if task.cacheable { 1 } else { 0 });
+        i += 1;
+    }
+    let hit_rate_millis = if declared_cacheable == 0 { 0 }
+        else { (observed_hits * 1000) / declared_cacheable };
+    Analysis {
+        cacheable_by_pool: cacheable_by_pool, hits_by_pool: hits_by_pool,
+        misses_by_pool: misses_by_pool, declared_cacheable: declared_cacheable,
+        observed_hits: observed_hits, observed_misses: observed_misses,
+        invalid_hits: invalid_hits, saved_duration: saved_duration,
+        saved_cpu_ticks: saved_cpu_ticks, saved_memory_ticks: saved_memory_ticks,
+        hit_rate_millis: hit_rate_millis, digest: digest,
+        valid: invalid_hits == 0 && observed_hits == run.cached &&
+            observed_hits + observed_misses == declared_cacheable,
+    }
+}

--- a/performance/workloads/lattice/capacity_plan.rue
+++ b/performance/workloads/lattice/capacity_plan.rue
@@ -1,0 +1,87 @@
+// Recommend pool headroom from observed peaks and declared pending demand.
+const model = @import("model.rue");
+const resource_audit = @import("resource_audit.rue");
+const state = @import("state.rue");
+
+pub struct Plan {
+    recommended_slots: model.U64s,
+    recommended_cpu: model.U64s,
+    recommended_memory: model.U64s,
+    slot_headroom: model.U64s,
+    cpu_headroom: model.U64s,
+    memory_headroom: model.U64s,
+    constrained_pools: model.U64s,
+    total_slot_increase: u64,
+    total_cpu_increase: u64,
+    total_memory_increase: u64,
+    saturated_pools: u64,
+    digest: u64,
+    valid: bool,
+}
+
+fn zeroes(count: u64) -> model.U64s {
+    let mut values = model.U64s.with_capacity(count);
+    let mut i: u64 = 0;
+    while i < count { values.push(0); i += 1; }
+    values
+}
+
+fn recommend(capacity: u64, peak: u64) -> u64 {
+    let buffered = peak + if peak < 4 { 1 } else { (peak + 3) / 4 };
+    if buffered > capacity { buffered } else { capacity }
+}
+
+fn difference(larger: u64, smaller: u64) -> u64 {
+    if larger > smaller { larger - smaller } else { 0 }
+}
+
+fn mix(hash: u64, value: u64) -> u64 { @wrapping_mul(hash ^ value, 1099511628211) }
+
+pub fn compute(borrow workflow: model.Workflow, borrow run: state.Run) -> Plan {
+    let audit = resource_audit.audit(borrow workflow, borrow run);
+    let count = workflow.pools.len();
+    let mut recommended_slots = zeroes(count);
+    let mut recommended_cpu = zeroes(count);
+    let mut recommended_memory = zeroes(count);
+    let mut slot_headroom = zeroes(count);
+    let mut cpu_headroom = zeroes(count);
+    let mut memory_headroom = zeroes(count);
+    let mut constrained_pools = model.U64s.new();
+    let mut total_slot_increase: u64 = 0;
+    let mut total_cpu_increase: u64 = 0;
+    let mut total_memory_increase: u64 = 0;
+    let mut saturated_pools: u64 = 0;
+    let mut digest: u64 = 14695981039346656037;
+    let mut i: u64 = 0;
+    while i < count {
+        let pool = workflow.pools.get_or(i, model.empty_pool());
+        let peak_slots = audit.maximum_slots.get_or(i, 0);
+        let peak_cpu = audit.maximum_cpu.get_or(i, 0);
+        let peak_memory = audit.maximum_memory.get_or(i, 0);
+        let slots = recommend(pool.slots, peak_slots);
+        let cpu = recommend(pool.cpu, peak_cpu);
+        let memory = recommend(pool.memory, peak_memory);
+        recommended_slots.set(i, slots); recommended_cpu.set(i, cpu); recommended_memory.set(i, memory);
+        slot_headroom.set(i, difference(pool.slots, peak_slots));
+        cpu_headroom.set(i, difference(pool.cpu, peak_cpu));
+        memory_headroom.set(i, difference(pool.memory, peak_memory));
+        total_slot_increase += difference(slots, pool.slots);
+        total_cpu_increase += difference(cpu, pool.cpu);
+        total_memory_increase += difference(memory, pool.memory);
+        if peak_slots == pool.slots || peak_cpu == pool.cpu || peak_memory == pool.memory {
+            saturated_pools += 1;
+            constrained_pools.push(i);
+        }
+        digest = mix(digest, slots); digest = mix(digest, cpu); digest = mix(digest, memory);
+        i += 1;
+    }
+    let valid = audit.ok && constrained_pools.len() == saturated_pools;
+    Plan {
+        recommended_slots: recommended_slots, recommended_cpu: recommended_cpu,
+        recommended_memory: recommended_memory, slot_headroom: slot_headroom,
+        cpu_headroom: cpu_headroom, memory_headroom: memory_headroom,
+        constrained_pools: constrained_pools, total_slot_increase: total_slot_increase,
+        total_cpu_increase: total_cpu_increase, total_memory_increase: total_memory_increase,
+        saturated_pools: saturated_pools, digest: digest, valid: valid,
+    }
+}

--- a/performance/workloads/lattice/critical_path.rue
+++ b/performance/workloads/lattice/critical_path.rue
@@ -1,0 +1,185 @@
+// Earliest/latest timing, slack, and one deterministic critical path.
+const std = @import("std");
+const levels = @import("levels.rue");
+const model = @import("model.rue");
+const topology = @import("topology.rue");
+const U64s = std.arraybuf.ArrayBuf(u64);
+
+pub struct Analysis {
+    earliest_start: U64s,
+    earliest_finish: U64s,
+    latest_start: U64s,
+    latest_finish: U64s,
+    slack: U64s,
+    critical_tasks: U64s,
+    canonical_path: U64s,
+    makespan: u64,
+    total_slack: u64,
+    maximum_slack: u64,
+    valid: bool,
+    digest: u64,
+}
+
+fn filled(count: u64, value: u64) -> U64s {
+    let mut result = U64s.with_capacity(count);
+    let mut i: u64 = 0;
+    while i < count { result.push(value); i += 1; }
+    result
+}
+
+fn mix(hash: u64, value: u64) -> u64 {
+    @wrapping_mul(hash ^ value, 1099511628211)
+}
+
+fn predecessor_finish(borrow workflow: model.Workflow, borrow finish: U64s, task: u64) -> u64 {
+    let mut value: u64 = 0;
+    let mut i: u64 = 0;
+    while i < workflow.edges.len() {
+        let edge = workflow.edges.get_or(i, model.empty_edge());
+        if edge.after == task {
+            let candidate = finish.get_or(edge.before, 0);
+            if candidate > value { value = candidate; }
+        }
+        i += 1;
+    }
+    value
+}
+
+fn successor_start(borrow workflow: model.Workflow, borrow latest_start: U64s, task: u64, makespan: u64) -> u64 {
+    let mut value = makespan;
+    let mut found = false;
+    let mut i: u64 = 0;
+    while i < workflow.edges.len() {
+        let edge = workflow.edges.get_or(i, model.empty_edge());
+        if edge.before == task {
+            let candidate = latest_start.get_or(edge.after, makespan);
+            if !found || candidate < value { value = candidate; found = true; }
+        }
+        i += 1;
+    }
+    value
+}
+
+fn critical_predecessor(
+    borrow workflow: model.Workflow,
+    borrow earliest_finish: U64s,
+    borrow slack: U64s,
+    task: u64,
+) -> u64 {
+    let start = if task < earliest_finish.len() {
+        let item = workflow.tasks.get_or(task, model.empty_task());
+        earliest_finish.get_or(task, 0) - item.duration
+    } else { 0 };
+    let mut best = model.NONE();
+    let mut i: u64 = 0;
+    while i < workflow.edges.len() {
+        let edge = workflow.edges.get_or(i, model.empty_edge());
+        if edge.after == task && earliest_finish.get_or(edge.before, 0) == start && slack.get_or(edge.before, 1) == 0 {
+            if best == model.NONE() || edge.before < best { best = edge.before; }
+        }
+        i += 1;
+    }
+    best
+}
+
+fn reverse(values: U64s) -> U64s {
+    let mut result = U64s.with_capacity(values.len());
+    let mut i = values.len();
+    while i > 0 { i -= 1; result.push(values.get_or(i, model.NONE())); }
+    result
+}
+
+pub fn compute(borrow workflow: model.Workflow) -> Analysis {
+    let order = topology.sort(borrow workflow);
+    let layer_info = levels.compute(borrow workflow);
+    let mut earliest_start = filled(workflow.tasks.len(), 0);
+    let mut earliest_finish = filled(workflow.tasks.len(), 0);
+    let mut makespan: u64 = 0;
+    let mut i: u64 = 0;
+    while i < order.tasks.len() {
+        let task_index = order.tasks.get_or(i, model.NONE());
+        let task = workflow.tasks.get_or(task_index, model.empty_task());
+        let start = predecessor_finish(borrow workflow, borrow earliest_finish, task_index);
+        let finish = start + task.duration;
+        earliest_start.set(task_index, start);
+        earliest_finish.set(task_index, finish);
+        if finish > makespan { makespan = finish; }
+        i += 1;
+    }
+
+    let mut latest_start = filled(workflow.tasks.len(), makespan);
+    let mut latest_finish = filled(workflow.tasks.len(), makespan);
+    i = order.tasks.len();
+    while i > 0 {
+        i -= 1;
+        let task_index = order.tasks.get_or(i, model.NONE());
+        let task = workflow.tasks.get_or(task_index, model.empty_task());
+        let finish = successor_start(borrow workflow, borrow latest_start, task_index, makespan);
+        let start = if finish >= task.duration { finish - task.duration } else { 0 };
+        latest_finish.set(task_index, finish);
+        latest_start.set(task_index, start);
+    }
+
+    let mut slack = filled(workflow.tasks.len(), 0);
+    let mut critical_tasks = U64s.new();
+    let mut total_slack: u64 = 0;
+    let mut maximum_slack: u64 = 0;
+    let mut digest: u64 = 14695981039346656037;
+    i = 0;
+    while i < workflow.tasks.len() {
+        let early = earliest_start.get_or(i, 0);
+        let late = latest_start.get_or(i, early);
+        let value = if late >= early { late - early } else { 0 };
+        slack.set(i, value);
+        total_slack += value;
+        if value > maximum_slack { maximum_slack = value; }
+        if value == 0 { critical_tasks.push(i); }
+        digest = mix(digest, early); digest = mix(digest, earliest_finish.get_or(i, 0));
+        digest = mix(digest, late); digest = mix(digest, value);
+        i += 1;
+    }
+
+    let mut leaf = model.NONE();
+    i = 0;
+    while i < workflow.tasks.len() {
+        if earliest_finish.get_or(i, 0) == makespan && slack.get_or(i, 1) == 0 {
+            if leaf == model.NONE() || i < leaf { leaf = i; }
+        }
+        i += 1;
+    }
+    let mut backward = U64s.new();
+    let mut cursor = leaf;
+    while cursor != model.NONE() {
+        backward.push(cursor);
+        cursor = critical_predecessor(borrow workflow, borrow earliest_finish, borrow slack, cursor);
+    }
+    let canonical_path = reverse(backward);
+    let valid = !order.has_cycle && order.tasks.len() == workflow.tasks.len() &&
+        levels.verify(borrow workflow, borrow layer_info) && canonical_path.len() > 0;
+    Analysis {
+        earliest_start: earliest_start, earliest_finish: earliest_finish,
+        latest_start: latest_start, latest_finish: latest_finish,
+        slack: slack, critical_tasks: critical_tasks,
+        canonical_path: canonical_path, makespan: makespan,
+        total_slack: total_slack, maximum_slack: maximum_slack,
+        valid: valid, digest: digest,
+    }
+}
+
+pub fn verify(borrow workflow: model.Workflow, borrow analysis: Analysis) -> bool {
+    if !analysis.valid || analysis.earliest_start.len() != workflow.tasks.len() { return false; }
+    let mut i: u64 = 0;
+    while i < workflow.edges.len() {
+        let edge = workflow.edges.get_or(i, model.empty_edge());
+        if analysis.earliest_finish.get_or(edge.before, 0) > analysis.earliest_start.get_or(edge.after, 0) { return false; }
+        i += 1;
+    }
+    i = 0;
+    while i < workflow.tasks.len() {
+        let task = workflow.tasks.get_or(i, model.empty_task());
+        if analysis.earliest_start.get_or(i, 0) + task.duration != analysis.earliest_finish.get_or(i, 0) { return false; }
+        if analysis.latest_start.get_or(i, 0) + task.duration != analysis.latest_finish.get_or(i, 0) { return false; }
+        i += 1;
+    }
+    true
+}

--- a/performance/workloads/lattice/cut_analysis.rue
+++ b/performance/workloads/lattice/cut_analysis.rue
@@ -1,0 +1,111 @@
+// Bottlenecks and graph cuts inferred from degree, dominance, and reduction.
+const dominators = @import("dominators.rue");
+const model = @import("model.rue");
+const path_catalog = @import("path_catalog.rue");
+const transitive_reduction = @import("transitive_reduction.rue");
+
+pub struct Analysis {
+    gateways: model.U64s,
+    funnels: model.U64s,
+    fanouts: model.U64s,
+    isolated: model.U64s,
+    mandatory_tasks: model.U64s,
+    bridge_edges: model.U64s,
+    gateway_count: u64,
+    funnel_count: u64,
+    fanout_count: u64,
+    isolated_count: u64,
+    mandatory_count: u64,
+    bridge_count: u64,
+    maximum_in_degree: u64,
+    maximum_out_degree: u64,
+    digest: u64,
+    valid: bool,
+}
+
+fn mix(hash: u64, value: u64) -> u64 { @wrapping_mul(hash ^ value, 1099511628211) }
+
+fn leaf_count(borrow workflow: model.Workflow) -> u64 {
+    let mut result: u64 = 0;
+    let mut i: u64 = 0;
+    while i < workflow.tasks.len() {
+        if model.dependent_count(borrow workflow, i) == 0 { result += 1; }
+        i += 1;
+    }
+    result
+}
+
+fn dominates_all_leaves(
+    borrow workflow: model.Workflow,
+    borrow dominance: dominators.Dominators,
+    task: u64,
+    leaves: u64,
+) -> bool {
+    if leaves == 0 { return false; }
+    let mut dominated: u64 = 0;
+    let mut i: u64 = 0;
+    while i < workflow.tasks.len() {
+        if model.dependent_count(borrow workflow, i) == 0 && dominators.dominates(borrow dominance, task, i) {
+            dominated += 1;
+        }
+        i += 1;
+    }
+    dominated == leaves
+}
+
+pub fn compute(borrow workflow: model.Workflow) -> Analysis {
+    let dominance = dominators.compute(borrow workflow);
+    let paths = path_catalog.compute(borrow workflow);
+    let reduction = transitive_reduction.compute(borrow workflow);
+    let leaves = leaf_count(borrow workflow);
+    let mut gateways = model.U64s.new();
+    let mut funnels = model.U64s.new();
+    let mut fanouts = model.U64s.new();
+    let mut isolated = model.U64s.new();
+    let mut mandatory_tasks = model.U64s.new();
+    let mut maximum_in_degree: u64 = 0;
+    let mut maximum_out_degree: u64 = 0;
+    let mut digest: u64 = 14695981039346656037;
+    let mut i: u64 = 0;
+    while i < workflow.tasks.len() {
+        let incoming = model.dependency_count(borrow workflow, i);
+        let outgoing = model.dependent_count(borrow workflow, i);
+        if incoming == 1 && outgoing == 1 { gateways.push(i); }
+        if incoming > 1 { funnels.push(i); }
+        if outgoing > 1 { fanouts.push(i); }
+        if incoming == 0 && outgoing == 0 { isolated.push(i); }
+        if dominates_all_leaves(borrow workflow, borrow dominance, i, leaves) { mandatory_tasks.push(i); }
+        if incoming > maximum_in_degree { maximum_in_degree = incoming; }
+        if outgoing > maximum_out_degree { maximum_out_degree = outgoing; }
+        digest = mix(digest, incoming); digest = mix(digest, outgoing);
+        digest = mix(digest, paths.paths_through_task.get_or(i, 0));
+        i += 1;
+    }
+    let mut bridge_edges = model.U64s.new();
+    i = 0;
+    while i < reduction.essential.len() {
+        let edge_index = reduction.essential.get_or(i, model.NONE());
+        let edge = workflow.edges.get_or(edge_index, model.empty_edge());
+        if model.dependent_count(borrow workflow, edge.before) == 1 ||
+            model.dependency_count(borrow workflow, edge.after) == 1 {
+            bridge_edges.push(edge_index);
+        }
+        i += 1;
+    }
+    let gateway_count = gateways.len();
+    let funnel_count = funnels.len();
+    let fanout_count = fanouts.len();
+    let isolated_count = isolated.len();
+    let mandatory_count = mandatory_tasks.len();
+    let bridge_count = bridge_edges.len();
+    Analysis {
+        gateways: gateways, funnels: funnels, fanouts: fanouts, isolated: isolated,
+        mandatory_tasks: mandatory_tasks, bridge_edges: bridge_edges,
+        gateway_count: gateway_count, funnel_count: funnel_count,
+        fanout_count: fanout_count, isolated_count: isolated_count,
+        mandatory_count: mandatory_count, bridge_count: bridge_count,
+        maximum_in_degree: maximum_in_degree, maximum_out_degree: maximum_out_degree,
+        digest: digest, valid: dominance.valid && paths.valid && reduction.valid &&
+            bridge_count <= reduction.essential_count,
+    }
+}

--- a/performance/workloads/lattice/cycle_oracle.rue
+++ b/performance/workloads/lattice/cycle_oracle.rue
@@ -1,0 +1,76 @@
+// Independent transitive-closure cycle oracle. It intentionally does not use
+// topology.rue, giving selftests a differential graph check.
+const std = @import("std");
+const model = @import("model.rue");
+const Bools = std.arraybuf.ArrayBuf(bool);
+
+fn matrix(count: u64) -> Bools {
+    let mut values = Bools.with_capacity(count * count);
+    let mut i: u64 = 0;
+    while i < count * count { values.push(false); i += 1; }
+    values
+}
+
+pub struct Closure {
+    reachable: Bools,
+    size: u64,
+    cycle_vertices: u64,
+    comparable_pairs: u64,
+}
+
+pub fn compute(borrow workflow: model.Workflow) -> Closure {
+    let count = workflow.tasks.len();
+    let mut reachable = matrix(count);
+    let mut i: u64 = 0;
+    while i < workflow.edges.len() {
+        let edge = workflow.edges.get_or(i, model.empty_edge());
+        if edge.before < count && edge.after < count {
+            reachable.set(edge.before * count + edge.after, true);
+        }
+        i += 1;
+    }
+    let mut middle: u64 = 0;
+    while middle < count {
+        let mut from: u64 = 0;
+        while from < count {
+            if reachable.get_or(from * count + middle, false) {
+                let mut to: u64 = 0;
+                while to < count {
+                    if reachable.get_or(middle * count + to, false) {
+                        reachable.set(from * count + to, true);
+                    }
+                    to += 1;
+                }
+            }
+            from += 1;
+        }
+        middle += 1;
+    }
+    let mut cycle_vertices: u64 = 0;
+    let mut comparable_pairs: u64 = 0;
+    i = 0;
+    while i < count {
+        if reachable.get_or(i * count + i, false) { cycle_vertices += 1; }
+        let mut j: u64 = i + 1;
+        while j < count {
+            if reachable.get_or(i * count + j, false) || reachable.get_or(j * count + i, false) {
+                comparable_pairs += 1;
+            }
+            j += 1;
+        }
+        i += 1;
+    }
+    Closure {
+        reachable: reachable,
+        size: count,
+        cycle_vertices: cycle_vertices,
+        comparable_pairs: comparable_pairs,
+    }
+}
+
+pub fn reaches(borrow closure: Closure, from: u64, to: u64) -> bool {
+    if from >= closure.size || to >= closure.size { false }
+    else { closure.reachable.get_or(from * closure.size + to, false) }
+}
+
+pub fn has_cycle(borrow closure: Closure) -> bool { closure.cycle_vertices > 0 }

--- a/performance/workloads/lattice/diagnostics.rue
+++ b/performance/workloads/lattice/diagnostics.rue
@@ -1,0 +1,28 @@
+// Stable diagnostic rendering for source and semantic failures.
+const std = @import("std");
+const model = @import("model.rue");
+const text = @import("text.rue");
+const StrBuf = std.strbuf.StrBuf;
+
+pub fn render(borrow workflow: model.Workflow) -> StrBuf {
+    let mut out = StrBuf.new();
+    let mut i: u64 = 0;
+    while i < workflow.diagnostics.len() {
+        let item = workflow.diagnostics.get_or(i, model.Diagnostic {
+            code: 0, subject: model.NONE(), detail: model.NONE(),
+        });
+        text.append_literal(inout out, "lattice[");
+        let code = model.code_name(item.code);
+        text.append_string(inout out, borrow code);
+        text.append_literal(inout out, "]");
+        if item.subject != model.NONE() {
+            text.append_literal(inout out, " ");
+            text.append_id(inout out, borrow workflow, item.subject);
+        }
+        text.append_literal(inout out, ": ");
+        text.append_id(inout out, borrow workflow, item.detail);
+        out.push(10);
+        i += 1;
+    }
+    out
+}

--- a/performance/workloads/lattice/dominators.rue
+++ b/performance/workloads/lattice/dominators.rue
@@ -1,0 +1,131 @@
+// Iterative dominator sets for a multi-root DAG.
+const std = @import("std");
+const model = @import("model.rue");
+const topology = @import("topology.rue");
+const Bools = std.arraybuf.ArrayBuf(bool);
+
+pub struct Dominators {
+    matrix: Bools,
+    size: u64,
+    iterations: u64,
+    roots: u64,
+    strict_pairs: u64,
+    maximum_chain: u64,
+    digest: u64,
+    valid: bool,
+}
+
+fn filled(count: u64, value: bool) -> Bools {
+    let mut result = Bools.with_capacity(count);
+    let mut i: u64 = 0;
+    while i < count { result.push(value); i += 1; }
+    result
+}
+
+fn at(size: u64, task: u64, candidate: u64) -> u64 { task * size + candidate }
+
+fn is_root(borrow workflow: model.Workflow, task: u64) -> bool {
+    model.dependency_count(borrow workflow, task) == 0
+}
+
+fn predecessor_allows(
+    borrow workflow: model.Workflow,
+    borrow matrix: Bools,
+    task: u64,
+    candidate: u64,
+) -> bool {
+    let size = workflow.tasks.len();
+    let mut found = false;
+    let mut i: u64 = 0;
+    while i < workflow.edges.len() {
+        let edge = workflow.edges.get_or(i, model.empty_edge());
+        if edge.after == task {
+            found = true;
+            if !matrix.get_or(at(size, edge.before, candidate), false) { return false; }
+        }
+        i += 1;
+    }
+    found
+}
+
+pub fn compute(borrow workflow: model.Workflow) -> Dominators {
+    let order = topology.sort(borrow workflow);
+    let size = workflow.tasks.len();
+    let mut matrix = filled(size * size, true);
+    let mut roots: u64 = 0;
+    let mut task: u64 = 0;
+    while task < size {
+        if is_root(borrow workflow, task) {
+            roots += 1;
+            let mut candidate: u64 = 0;
+            while candidate < size {
+                matrix.set(at(size, task, candidate), candidate == task);
+                candidate += 1;
+            }
+        }
+        task += 1;
+    }
+
+    let mut changed = true;
+    let mut iterations: u64 = 0;
+    while changed && iterations <= size + 1 {
+        changed = false;
+        iterations += 1;
+        let mut position: u64 = 0;
+        while position < order.tasks.len() {
+            task = order.tasks.get_or(position, model.NONE());
+            if !is_root(borrow workflow, task) {
+                let mut candidate: u64 = 0;
+                while candidate < size {
+                    let next = candidate == task || predecessor_allows(borrow workflow, borrow matrix, task, candidate);
+                    let index = at(size, task, candidate);
+                    if matrix.get_or(index, false) != next {
+                        matrix.set(index, next);
+                        changed = true;
+                    }
+                    candidate += 1;
+                }
+            }
+            position += 1;
+        }
+    }
+
+    let mut strict_pairs: u64 = 0;
+    let mut maximum_chain: u64 = 0;
+    let mut digest: u64 = 14695981039346656037;
+    task = 0;
+    while task < size {
+        let mut chain: u64 = 0;
+        let mut candidate: u64 = 0;
+        while candidate < size {
+            if matrix.get_or(at(size, task, candidate), false) {
+                chain += 1;
+                if candidate != task { strict_pairs += 1; }
+                digest = @wrapping_mul(digest ^ (task * size + candidate), 1099511628211);
+            }
+            candidate += 1;
+        }
+        if chain > maximum_chain { maximum_chain = chain; }
+        task += 1;
+    }
+    Dominators {
+        matrix: matrix, size: size, iterations: iterations, roots: roots,
+        strict_pairs: strict_pairs, maximum_chain: maximum_chain,
+        digest: digest, valid: !order.has_cycle && iterations <= size + 1,
+    }
+}
+
+pub fn dominates(borrow value: Dominators, candidate: u64, task: u64) -> bool {
+    if task >= value.size || candidate >= value.size { false }
+    else { value.matrix.get_or(at(value.size, task, candidate), false) }
+}
+
+pub fn verify(borrow workflow: model.Workflow, borrow value: Dominators) -> bool {
+    if !value.valid || value.size != workflow.tasks.len() { return false; }
+    let mut task: u64 = 0;
+    while task < value.size {
+        if !dominates(borrow value, task, task) { return false; }
+        task += 1;
+    }
+    true
+}

--- a/performance/workloads/lattice/event_analysis.rue
+++ b/performance/workloads/lattice/event_analysis.rue
@@ -1,0 +1,109 @@
+// Event stream statistics independent of replay’s transition proof.
+const model = @import("model.rue");
+const state = @import("state.rue");
+
+pub struct Summary {
+    by_kind: model.U64s,
+    by_pool: model.U64s,
+    by_task: model.U64s,
+    first_time: u64,
+    last_time: u64,
+    simultaneous_events: u64,
+    maximum_events_at_time: u64,
+    maximum_task_events: u64,
+    maximum_pool_events: u64,
+    starts: u64,
+    completions: u64,
+    failures: u64,
+    retries: u64,
+    cache_hits: u64,
+    blocked: u64,
+    digest: u64,
+    valid: bool,
+}
+
+fn zeroes(count: u64) -> model.U64s {
+    let mut out = model.U64s.with_capacity(count);
+    let mut i: u64 = 0;
+    while i < count { out.push(0); i += 1; }
+    out
+}
+
+fn increment(inout values: model.U64s, index: u64) {
+    if index < values.len() { values.set(index, values.get_or(index, 0) + 1); }
+}
+
+fn maximum(borrow values: model.U64s) -> u64 {
+    let mut result: u64 = 0;
+    let mut i: u64 = 0;
+    while i < values.len() {
+        let value = values.get_or(i, 0);
+        if value > result { result = value; }
+        i += 1;
+    }
+    result
+}
+
+fn mix(hash: u64, value: u64) -> u64 { @wrapping_mul(hash ^ value, 1099511628211) }
+
+pub fn summarize(borrow workflow: model.Workflow, borrow run: state.Run) -> Summary {
+    let mut by_kind = zeroes(7);
+    let mut by_pool = zeroes(workflow.pools.len());
+    let mut by_task = zeroes(workflow.tasks.len());
+    let mut first_time = if run.events.len() == 0 { 0 } else { run.events.get_or(0, state.empty_event()).time };
+    let mut last_time: u64 = 0;
+    let mut simultaneous_events: u64 = 0;
+    let mut maximum_events_at_time: u64 = 0;
+    let mut current_time = first_time;
+    let mut current_count: u64 = 0;
+    let mut digest: u64 = 14695981039346656037;
+    let mut valid = true;
+    let mut i: u64 = 0;
+    while i < run.events.len() {
+        let event = run.events.get_or(i, state.empty_event());
+        if i > 0 && event.time < last_time { valid = false; }
+        if event.time == current_time { current_count += 1; }
+        else {
+            if current_count > 1 { simultaneous_events += current_count; }
+            if current_count > maximum_events_at_time { maximum_events_at_time = current_count; }
+            current_time = event.time;
+            current_count = 1;
+        }
+        increment(inout by_kind, event.kind);
+        increment(inout by_pool, event.pool);
+        increment(inout by_task, event.task);
+        digest = mix(digest, event.kind); digest = mix(digest, event.time);
+        digest = mix(digest, event.task); digest = mix(digest, event.attempt);
+        last_time = event.time;
+        i += 1;
+    }
+    if current_count > 1 { simultaneous_events += current_count; }
+    if current_count > maximum_events_at_time { maximum_events_at_time = current_count; }
+    let maximum_task_events = maximum(borrow by_task);
+    let maximum_pool_events = maximum(borrow by_pool);
+    let starts = by_kind.get_or(state.EVENT_START(), 0);
+    let completions = by_kind.get_or(state.EVENT_SUCCESS(), 0);
+    let failures = by_kind.get_or(state.EVENT_FAILURE(), 0);
+    let retries = by_kind.get_or(state.EVENT_RETRY(), 0);
+    let cache_hits = by_kind.get_or(state.EVENT_CACHE(), 0);
+    let blocked = by_kind.get_or(state.EVENT_BLOCKED(), 0);
+    Summary {
+        by_kind: by_kind, by_pool: by_pool, by_task: by_task,
+        first_time: first_time, last_time: last_time,
+        simultaneous_events: simultaneous_events,
+        maximum_events_at_time: maximum_events_at_time,
+        maximum_task_events: maximum_task_events,
+        maximum_pool_events: maximum_pool_events,
+        starts: starts, completions: completions, failures: failures,
+        retries: retries, cache_hits: cache_hits, blocked: blocked,
+        digest: digest, valid: valid,
+    }
+}
+
+pub fn verify(borrow run: state.Run, borrow summary: Summary) -> bool {
+    summary.valid && summary.starts == run.starts_count &&
+        summary.completions == run.succeeded && summary.retries == run.retries &&
+        summary.cache_hits == run.cached &&
+        summary.starts + summary.completions + summary.failures + summary.retries +
+            summary.cache_hits + summary.blocked == run.events.len()
+}

--- a/performance/workloads/lattice/event_windows.rue
+++ b/performance/workloads/lattice/event_windows.rue
@@ -1,0 +1,80 @@
+// Partition the event stream into equal makespan windows for burst analysis.
+const model = @import("model.rue");
+const state = @import("state.rue");
+
+pub struct Analysis {
+    events_by_window: model.U64s,
+    starts_by_window: model.U64s,
+    completions_by_window: model.U64s,
+    failures_by_window: model.U64s,
+    retries_by_window: model.U64s,
+    cache_hits_by_window: model.U64s,
+    busiest_window: u64,
+    busiest_events: u64,
+    quiet_windows: u64,
+    window_width: u64,
+    counted_events: u64,
+    digest: u64,
+    valid: bool,
+}
+
+fn zeroes(count: u64) -> model.U64s {
+    let mut values = model.U64s.with_capacity(count);
+    let mut i: u64 = 0;
+    while i < count { values.push(0); i += 1; }
+    values
+}
+
+fn increment(inout values: model.U64s, index: u64) {
+    if index < values.len() { values.set(index, values.get_or(index, 0) + 1); }
+}
+
+fn mix(hash: u64, value: u64) -> u64 { @wrapping_mul(hash ^ value, 1099511628211) }
+
+pub fn compute(borrow run: state.Run, requested_windows: u64) -> Analysis {
+    let windows = if requested_windows == 0 { 1 } else { requested_windows };
+    let window_width = if run.makespan == 0 { 1 } else { (run.makespan + windows - 1) / windows };
+    let mut events_by_window = zeroes(windows);
+    let mut starts_by_window = zeroes(windows);
+    let mut completions_by_window = zeroes(windows);
+    let mut failures_by_window = zeroes(windows);
+    let mut retries_by_window = zeroes(windows);
+    let mut cache_hits_by_window = zeroes(windows);
+    let mut digest: u64 = 14695981039346656037;
+    let mut i: u64 = 0;
+    while i < run.events.len() {
+        let event = run.events.get_or(i, state.empty_event());
+        let raw = event.time / window_width;
+        let window = if raw >= windows { windows - 1 } else { raw };
+        increment(inout events_by_window, window);
+        if event.kind == state.EVENT_START() { increment(inout starts_by_window, window); }
+        else if event.kind == state.EVENT_SUCCESS() { increment(inout completions_by_window, window); }
+        else if event.kind == state.EVENT_FAILURE() { increment(inout failures_by_window, window); }
+        else if event.kind == state.EVENT_RETRY() { increment(inout retries_by_window, window); }
+        else if event.kind == state.EVENT_CACHE() { increment(inout cache_hits_by_window, window); }
+        digest = mix(digest, window); digest = mix(digest, event.kind);
+        i += 1;
+    }
+    let mut busiest_window: u64 = 0;
+    let mut busiest_events: u64 = 0;
+    let mut quiet_windows: u64 = 0;
+    let mut counted_events: u64 = 0;
+    i = 0;
+    while i < windows {
+        let count = events_by_window.get_or(i, 0);
+        counted_events += count;
+        if count == 0 { quiet_windows += 1; }
+        if count > busiest_events { busiest_events = count; busiest_window = i; }
+        digest = mix(digest, count);
+        i += 1;
+    }
+    Analysis {
+        events_by_window: events_by_window, starts_by_window: starts_by_window,
+        completions_by_window: completions_by_window, failures_by_window: failures_by_window,
+        retries_by_window: retries_by_window, cache_hits_by_window: cache_hits_by_window,
+        busiest_window: busiest_window, busiest_events: busiest_events,
+        quiet_windows: quiet_windows, window_width: window_width,
+        counted_events: counted_events, digest: digest,
+        valid: counted_events == run.events.len(),
+    }
+}

--- a/performance/workloads/lattice/explain.rue
+++ b/performance/workloads/lattice/explain.rue
@@ -1,0 +1,161 @@
+// Per-task causal explanations derived from dependencies, timing, and events.
+const model = @import("model.rue");
+const queue_analysis = @import("queue_analysis.rue");
+const state = @import("state.rue");
+const std = @import("std");
+
+pub fn COMPLETED() -> u64 { 1 }
+pub fn CACHE_HIT() -> u64 { 2 }
+pub fn RETRIED() -> u64 { 3 }
+pub fn EXHAUSTED() -> u64 { 4 }
+pub fn BLOCKED() -> u64 { 5 }
+pub fn PENDING() -> u64 { 6 }
+
+pub struct Explanation {
+    task: u64,
+    classification: u64,
+    dependencies: u64,
+    successful_dependencies: u64,
+    failed_dependencies: u64,
+    ready_time: u64,
+    queue_delay: u64,
+    start: u64,
+    end: u64,
+    attempts: u64,
+    start_events: u64,
+    failure_events: u64,
+    retry_events: u64,
+    cache_events: u64,
+    blocked_events: u64,
+    digest: u64,
+    consistent: bool,
+}
+
+pub const Explanations = std.arraybuf.ArrayBuf(Explanation);
+
+pub struct Analysis {
+    tasks: Explanations,
+    completed: u64,
+    cached: u64,
+    retried: u64,
+    exhausted: u64,
+    blocked: u64,
+    pending: u64,
+    inconsistencies: u64,
+    digest: u64,
+    valid: bool,
+}
+
+fn mix(hash: u64, value: u64) -> u64 { @wrapping_mul(hash ^ value, 1099511628211) }
+
+fn classify(status: u64, attempts: u64, failed_dependencies: u64) -> u64 {
+    if status == state.CACHED() { CACHE_HIT() }
+    else if status == state.SUCCEEDED() && attempts > 1 { RETRIED() }
+    else if status == state.SUCCEEDED() { COMPLETED() }
+    else if status == state.FAILED() && failed_dependencies > 0 { BLOCKED() }
+    else if status == state.FAILED() { EXHAUSTED() }
+    else { PENDING() }
+}
+
+fn event_counts(borrow run: state.Run, task: u64) -> model.U64s {
+    let mut counts = model.U64s.with_capacity(7);
+    let mut i: u64 = 0;
+    while i < 7 { counts.push(0); i += 1; }
+    i = 0;
+    while i < run.events.len() {
+        let event = run.events.get_or(i, state.empty_event());
+        if event.task == task && event.kind < counts.len() {
+            counts.set(event.kind, counts.get_or(event.kind, 0) + 1);
+        }
+        i += 1;
+    }
+    counts
+}
+
+fn one(
+    borrow workflow: model.Workflow,
+    borrow run: state.Run,
+    borrow queue: queue_analysis.Analysis,
+    task: u64,
+) -> Explanation {
+    let mut dependencies: u64 = 0;
+    let mut successful_dependencies: u64 = 0;
+    let mut failed_dependencies: u64 = 0;
+    let mut i: u64 = 0;
+    while i < workflow.edges.len() {
+        let edge = workflow.edges.get_or(i, model.empty_edge());
+        if edge.after == task {
+            dependencies += 1;
+            let dependency_status = run.status.get_or(edge.before, state.FAILED());
+            if state.successful(dependency_status) { successful_dependencies += 1; }
+            else if dependency_status == state.FAILED() { failed_dependencies += 1; }
+        }
+        i += 1;
+    }
+    let counts = event_counts(borrow run, task);
+    let status = run.status.get_or(task, state.FAILED());
+    let attempts = run.attempts.get_or(task, 0);
+    let classification = classify(status, attempts, failed_dependencies);
+    let start_events = counts.get_or(state.EVENT_START(), 0);
+    let failure_events = counts.get_or(state.EVENT_FAILURE(), 0);
+    let retry_events = counts.get_or(state.EVENT_RETRY(), 0);
+    let cache_events = counts.get_or(state.EVENT_CACHE(), 0);
+    let blocked_events = counts.get_or(state.EVENT_BLOCKED(), 0);
+    let consistent = start_events == attempts && retry_events <= failure_events &&
+        cache_events <= 1 && blocked_events <= 1 &&
+        successful_dependencies + failed_dependencies <= dependencies;
+    let mut digest = mix(14695981039346656037, task);
+    digest = mix(digest, classification); digest = mix(digest, dependencies);
+    digest = mix(digest, attempts); digest = mix(digest, start_events);
+    Explanation {
+        task: task, classification: classification, dependencies: dependencies,
+        successful_dependencies: successful_dependencies, failed_dependencies: failed_dependencies,
+        ready_time: queue.dependency_ready.get_or(task, 0),
+        queue_delay: queue.queue_delay.get_or(task, 0),
+        start: run.starts.get_or(task, model.NONE()), end: run.ends.get_or(task, model.NONE()),
+        attempts: attempts, start_events: start_events, failure_events: failure_events,
+        retry_events: retry_events, cache_events: cache_events, blocked_events: blocked_events,
+        digest: digest, consistent: consistent,
+    }
+}
+
+pub fn compute(borrow workflow: model.Workflow, borrow run: state.Run) -> Analysis {
+    let queue = queue_analysis.compute(borrow workflow, borrow run);
+    let mut tasks = Explanations.with_capacity(workflow.tasks.len());
+    let mut completed: u64 = 0;
+    let mut cached: u64 = 0;
+    let mut retried: u64 = 0;
+    let mut exhausted: u64 = 0;
+    let mut blocked: u64 = 0;
+    let mut pending: u64 = 0;
+    let mut inconsistencies: u64 = 0;
+    let mut digest: u64 = 14695981039346656037;
+    let mut i: u64 = 0;
+    while i < workflow.tasks.len() {
+        let value = one(borrow workflow, borrow run, borrow queue, i);
+        if value.classification == COMPLETED() { completed += 1; }
+        else if value.classification == CACHE_HIT() { cached += 1; }
+        else if value.classification == RETRIED() { retried += 1; }
+        else if value.classification == EXHAUSTED() { exhausted += 1; }
+        else if value.classification == BLOCKED() { blocked += 1; }
+        else { pending += 1; }
+        if !value.consistent { inconsistencies += 1; }
+        digest = mix(digest, value.digest);
+        tasks.push(value); i += 1;
+    }
+    Analysis {
+        tasks: tasks, completed: completed, cached: cached, retried: retried,
+        exhausted: exhausted, blocked: blocked, pending: pending,
+        inconsistencies: inconsistencies, digest: digest,
+        valid: inconsistencies == 0 && completed + cached + retried + exhausted + blocked + pending == workflow.tasks.len(),
+    }
+}
+
+pub fn classification_name(value: u64) -> str {
+    if value == COMPLETED() { "completed" }
+    else if value == CACHE_HIT() { "cache-hit" }
+    else if value == RETRIED() { "recovered-after-retry" }
+    else if value == EXHAUSTED() { "retry-budget-exhausted" }
+    else if value == BLOCKED() { "blocked-by-dependency" }
+    else { "pending" }
+}

--- a/performance/workloads/lattice/fingerprint.rue
+++ b/performance/workloads/lattice/fingerprint.rue
@@ -1,0 +1,46 @@
+// Canonical workflow and run fingerprints for determinism checks.
+const model = @import("model.rue");
+const state = @import("state.rue");
+
+fn mix(hash: u64, value: u64) -> u64 { @wrapping_mul(hash ^ value, 1099511628211) }
+
+pub fn workflow(borrow value: model.Workflow) -> u64 {
+    let mut hash: u64 = 14695981039346656037;
+    hash = mix(hash, value.strings.hash(value.name));
+    let mut i: u64 = 0;
+    while i < value.pools.len() {
+        let item = value.pools.get_or(i, model.empty_pool());
+        hash = mix(hash, value.strings.hash(item.id));
+        hash = mix(hash, item.slots); hash = mix(hash, item.cpu); hash = mix(hash, item.memory);
+        i += 1;
+    }
+    i = 0;
+    while i < value.tasks.len() {
+        let item = value.tasks.get_or(i, model.empty_task());
+        hash = mix(hash, value.strings.hash(item.id)); hash = mix(hash, item.pool);
+        hash = mix(hash, item.duration); hash = mix(hash, item.cpu); hash = mix(hash, item.memory);
+        hash = mix(hash, item.priority); hash = mix(hash, item.retries);
+        hash = mix(hash, if item.cacheable { 1 } else { 0 }); hash = mix(hash, item.fail_attempt);
+        i += 1;
+    }
+    i = 0;
+    while i < value.edges.len() {
+        let edge = value.edges.get_or(i, model.empty_edge());
+        hash = mix(hash, edge.before); hash = mix(hash, edge.after); i += 1;
+    }
+    hash
+}
+
+pub fn run(borrow value: state.Run) -> u64 {
+    let mut hash: u64 = 14695981039346656037;
+    let mut i: u64 = 0;
+    while i < value.events.len() {
+        let event = value.events.get_or(i, state.empty_event());
+        hash = mix(hash, event.kind); hash = mix(hash, event.time); hash = mix(hash, event.task);
+        hash = mix(hash, event.pool); hash = mix(hash, event.attempt); hash = mix(hash, event.cpu); hash = mix(hash, event.memory);
+        i += 1;
+    }
+    hash = mix(hash, value.makespan); hash = mix(hash, value.succeeded);
+    hash = mix(hash, value.failed); hash = mix(hash, value.cached); hash = mix(hash, value.retries);
+    hash
+}

--- a/performance/workloads/lattice/forecast.rue
+++ b/performance/workloads/lattice/forecast.rue
@@ -1,0 +1,78 @@
+// Run a fixed seed ensemble to expose cache-sensitive makespan variance.
+const model = @import("model.rue");
+const schedule = @import("schedule.rue");
+
+pub struct Forecast {
+    seeds: model.U64s,
+    makespans: model.U64s,
+    cache_hits: model.U64s,
+    retries: model.U64s,
+    fingerprints: model.U64s,
+    samples: u64,
+    minimum_makespan: u64,
+    maximum_makespan: u64,
+    mean_makespan: u64,
+    spread: u64,
+    total_cache_hits: u64,
+    total_retries: u64,
+    failed_samples: u64,
+    duplicate_fingerprints: u64,
+    digest: u64,
+    valid: bool,
+}
+
+fn mix(hash: u64, value: u64) -> u64 { @wrapping_mul(hash ^ value, 1099511628211) }
+
+fn seen(borrow fingerprints: model.U64s, value: u64) -> bool {
+    let mut i: u64 = 0;
+    while i < fingerprints.len() {
+        if fingerprints.get_or(i, 0) == value { return true; }
+        i += 1;
+    }
+    false
+}
+
+pub fn compute(borrow workflow: model.Workflow, base_seed: u64, samples: u64) -> Forecast {
+    let count = if samples == 0 { 1 } else { samples };
+    let mut seeds = model.U64s.with_capacity(count);
+    let mut makespans = model.U64s.with_capacity(count);
+    let mut cache_hits = model.U64s.with_capacity(count);
+    let mut retries = model.U64s.with_capacity(count);
+    let mut fingerprints = model.U64s.with_capacity(count);
+    let mut minimum_makespan: u64 = 0;
+    let mut maximum_makespan: u64 = 0;
+    let mut total_makespan: u64 = 0;
+    let mut total_cache_hits: u64 = 0;
+    let mut total_retries: u64 = 0;
+    let mut failed_samples: u64 = 0;
+    let mut duplicate_fingerprints: u64 = 0;
+    let mut digest: u64 = 14695981039346656037;
+    let mut i: u64 = 0;
+    while i < count {
+        let seed = base_seed + i * 104729;
+        let run = schedule.run(borrow workflow, seed);
+        seeds.push(seed); makespans.push(run.makespan);
+        cache_hits.push(run.cached); retries.push(run.retries);
+        if seen(borrow fingerprints, run.fingerprint) { duplicate_fingerprints += 1; }
+        fingerprints.push(run.fingerprint);
+        if i == 0 || run.makespan < minimum_makespan { minimum_makespan = run.makespan; }
+        if i == 0 || run.makespan > maximum_makespan { maximum_makespan = run.makespan; }
+        total_makespan += run.makespan;
+        total_cache_hits += run.cached;
+        total_retries += run.retries;
+        if run.failed > 0 { failed_samples += 1; }
+        digest = mix(digest, seed); digest = mix(digest, run.makespan);
+        digest = mix(digest, run.cached); digest = mix(digest, run.fingerprint);
+        i += 1;
+    }
+    Forecast {
+        seeds: seeds, makespans: makespans, cache_hits: cache_hits,
+        retries: retries, fingerprints: fingerprints, samples: count,
+        minimum_makespan: minimum_makespan, maximum_makespan: maximum_makespan,
+        mean_makespan: total_makespan / count,
+        spread: maximum_makespan - minimum_makespan,
+        total_cache_hits: total_cache_hits, total_retries: total_retries,
+        failed_samples: failed_samples, duplicate_fingerprints: duplicate_fingerprints,
+        digest: digest, valid: failed_samples == 0,
+    }
+}

--- a/performance/workloads/lattice/format.rue
+++ b/performance/workloads/lattice/format.rue
@@ -1,0 +1,85 @@
+// Escaping and enum formatting shared by all machine-readable reports.
+const std = @import("std");
+const model = @import("model.rue");
+const state = @import("state.rue");
+const text = @import("text.rue");
+const StrBuf = std.strbuf.StrBuf;
+
+pub fn append_status(inout out: StrBuf, status: u64) {
+    if status == state.PENDING() { text.append_literal(inout out, "pending"); }
+    else if status == state.RUNNING() { text.append_literal(inout out, "running"); }
+    else if status == state.SUCCEEDED() { text.append_literal(inout out, "succeeded"); }
+    else if status == state.FAILED() { text.append_literal(inout out, "failed"); }
+    else if status == state.CACHED() { text.append_literal(inout out, "cached"); }
+    else { text.append_literal(inout out, "unknown"); }
+}
+
+pub fn append_event_kind(inout out: StrBuf, kind: u64) {
+    if kind == state.EVENT_START() { text.append_literal(inout out, "start"); }
+    else if kind == state.EVENT_SUCCESS() { text.append_literal(inout out, "success"); }
+    else if kind == state.EVENT_FAILURE() { text.append_literal(inout out, "failure"); }
+    else if kind == state.EVENT_RETRY() { text.append_literal(inout out, "retry"); }
+    else if kind == state.EVENT_CACHE() { text.append_literal(inout out, "cache"); }
+    else if kind == state.EVENT_BLOCKED() { text.append_literal(inout out, "blocked"); }
+    else { text.append_literal(inout out, "unknown"); }
+}
+
+pub fn append_optional_u64(inout out: StrBuf, value: u64) {
+    if value == model.NONE() { text.append_literal(inout out, "null"); }
+    else { text.append_u64(inout out, value); }
+}
+
+pub fn append_millis(inout out: StrBuf, value: u64) {
+    text.append_u64(inout out, value / 1000);
+    out.push(46);
+    let fraction = value % 1000;
+    if fraction < 100 { out.push(48); }
+    if fraction < 10 { out.push(48); }
+    text.append_u64(inout out, fraction);
+}
+
+pub fn csv_id(inout out: StrBuf, borrow workflow: model.Workflow, id: u64) {
+    out.push(34);
+    let mut i: u64 = 0;
+    while i < workflow.strings.string_len(id) {
+        let byte = workflow.strings.byte_at(id, i);
+        if byte == 34 { out.push(34); out.push(34); }
+        else { out.push(byte); }
+        i += 1;
+    }
+    out.push(34);
+}
+
+pub fn dot_id(inout out: StrBuf, borrow workflow: model.Workflow, id: u64) {
+    out.push(34);
+    let mut i: u64 = 0;
+    while i < workflow.strings.string_len(id) {
+        let byte = workflow.strings.byte_at(id, i);
+        if byte == 34 { text.append_literal(inout out, "\\\""); }
+        else if byte == 92 { text.append_literal(inout out, "\\\\"); }
+        else if byte == 10 { text.append_literal(inout out, "\\n"); }
+        else { out.push(byte); }
+        i += 1;
+    }
+    out.push(34);
+}
+
+pub fn markdown_id(inout out: StrBuf, borrow workflow: model.Workflow, id: u64) {
+    let mut i: u64 = 0;
+    while i < workflow.strings.string_len(id) {
+        let byte = workflow.strings.byte_at(id, i);
+        if byte == 124 { text.append_literal(inout out, "\\|"); }
+        else if byte == 10 { text.append_literal(inout out, "<br>"); }
+        else { out.push(byte); }
+        i += 1;
+    }
+}
+
+pub fn append_bar(inout out: StrBuf, numerator: u64, denominator: u64, width: u64) {
+    let filled = if denominator == 0 { 0 } else { (numerator * width) / denominator };
+    let mut i: u64 = 0;
+    while i < width {
+        if i < filled { out.push(35); } else { out.push(46); }
+        i += 1;
+    }
+}

--- a/performance/workloads/lattice/generate.rue
+++ b/performance/workloads/lattice/generate.rue
@@ -1,0 +1,78 @@
+// Deterministic in-memory workflow generator for selftests and scaling tiers.
+const model = @import("model.rue");
+const poolmod = @import("pool.rue");
+const std = @import("std");
+const text = @import("text.rue");
+const StrBuf = std.strbuf.StrBuf;
+
+fn name(prefix: str, index: u64) -> StrBuf {
+    let mut out = StrBuf.new();
+    text.append_literal(inout out, prefix);
+    text.append_u64(inout out, index);
+    out
+}
+
+pub fn workflow(tasks: u64, pools: u64, width: u64, seed: u64) -> model.Workflow {
+    let mut strings = poolmod.Pool.new();
+    let title = name("generated-", seed);
+    let title_id = strings.intern(borrow title);
+    let mut result = model.new_workflow(strings);
+    result.name = title_id;
+    let pool_count = if pools == 0 { 1 } else { pools };
+    let mut i: u64 = 0;
+    while i < pool_count {
+        let label = name("pool-", i);
+        let id = result.strings.intern(borrow label);
+        result.pools.push(model.WorkerPool {
+            id: id, slots: 2 + (i % 4), cpu: 4 + (i % 3) * 2,
+            memory: 8 + (i % 5) * 4,
+        });
+        i += 1;
+    }
+    i = 0;
+    while i < tasks {
+        let label = name("task-", i);
+        let id = result.strings.intern(borrow label);
+        let pool_index = (i * 7 + seed) % pool_count;
+        let pool = result.pools.get_or(pool_index, model.empty_pool());
+        result.tasks.push(model.Task {
+            id: id, pool_id: pool.id, pool: pool_index,
+            duration: 1 + ((i * 5 + seed) % 9),
+            cpu: 1 + (i % 2), memory: 1 + (i % 4),
+            priority: 1 + ((i * 11 + seed) % 20),
+            retries: i % 3, cacheable: i % 4 == 0,
+            // Generated retries are recoverable; unrecoverable failure and
+            // downstream blocking have separate fixture coverage.
+            fail_attempt: if i % 17 == 8 && i % 3 > 0 { 1 } else { 0 },
+        });
+        i += 1;
+    }
+    let span = if width < 2 { 2 } else { width };
+    i = 1;
+    while i < tasks {
+        let before = i - 1;
+        let first = result.tasks.get_or(before, model.empty_task());
+        let second = result.tasks.get_or(i, model.empty_task());
+        result.edges.push(model.Edge {
+            before_id: first.id, after_id: second.id, before: before, after: i,
+        });
+        if i >= span && i % 2 == 0 {
+            let extra = i - span;
+            let source = result.tasks.get_or(extra, model.empty_task());
+            result.edges.push(model.Edge {
+                before_id: source.id, after_id: second.id, before: extra, after: i,
+            });
+        }
+        if i >= 3 && i % 5 == 0 {
+            let extra = i - 3;
+            let source = result.tasks.get_or(extra, model.empty_task());
+            if !model.has_edge(borrow result, extra, i) {
+                result.edges.push(model.Edge {
+                    before_id: source.id, after_id: second.id, before: extra, after: i,
+                });
+            }
+        }
+        i += 1;
+    }
+    result
+}

--- a/performance/workloads/lattice/insights.rue
+++ b/performance/workloads/lattice/insights.rue
@@ -1,0 +1,90 @@
+// Canonical aggregator for operational analyses not required by scheduling.
+const cache_analysis = @import("cache_analysis.rue");
+const capacity_plan = @import("capacity_plan.rue");
+const cut_analysis = @import("cut_analysis.rue");
+const event_windows = @import("event_windows.rue");
+const forecast = @import("forecast.rue");
+const lint = @import("lint.rue");
+const model = @import("model.rue");
+const path_catalog = @import("path_catalog.rue");
+const pool_analysis = @import("pool_analysis.rue");
+const priority_analysis = @import("priority_analysis.rue");
+const queue_analysis = @import("queue_analysis.rue");
+const retry_analysis = @import("retry_analysis.rue");
+const schedule_quality = @import("schedule_quality.rue");
+const state = @import("state.rue");
+const statistics = @import("statistics.rue");
+
+pub struct Insights {
+    tasks: u64,
+    pools: u64,
+    edges: u64,
+    paths: u64,
+    bridge_edges: u64,
+    cache_hits: u64,
+    retries: u64,
+    queue_delay: u64,
+    efficiency_millis: u64,
+    saturated_pools: u64,
+    forecast_spread: u64,
+    event_windows: u64,
+    checks: u64,
+    failures: u64,
+    digest: u64,
+    valid: bool,
+}
+
+fn mix(hash: u64, value: u64) -> u64 { @wrapping_mul(hash ^ value, 1099511628211) }
+
+fn check(inout checks: u64, inout failures: u64, condition: bool) {
+    checks += 1;
+    if !condition { failures += 1; }
+}
+
+pub fn compute(borrow workflow: model.Workflow, borrow run: state.Run, seed: u64) -> Insights {
+    let stats = statistics.compute(borrow workflow);
+    let pools = pool_analysis.compute(borrow workflow, borrow run);
+    let priorities = priority_analysis.compute(borrow workflow, borrow run);
+    let caches = cache_analysis.compute(borrow workflow, borrow run);
+    let retries = retry_analysis.compute(borrow workflow, borrow run);
+    let paths = path_catalog.compute(borrow workflow);
+    let cuts = cut_analysis.compute(borrow workflow);
+    let queue = queue_analysis.compute(borrow workflow, borrow run);
+    let quality = schedule_quality.compute(borrow workflow, borrow run);
+    let windows = event_windows.compute(borrow run, 8);
+    let capacity = capacity_plan.compute(borrow workflow, borrow run);
+    let projected = forecast.compute(borrow workflow, seed, 5);
+    let lints = lint.compute(borrow workflow, borrow run);
+    let mut checks: u64 = 0;
+    let mut failures: u64 = 0;
+    check(inout checks, inout failures, stats.valid);
+    check(inout checks, inout failures, pools.valid);
+    check(inout checks, inout failures, priorities.valid);
+    check(inout checks, inout failures, caches.valid);
+    check(inout checks, inout failures, retries.valid);
+    check(inout checks, inout failures, paths.valid);
+    check(inout checks, inout failures, cuts.valid);
+    check(inout checks, inout failures, queue.valid);
+    check(inout checks, inout failures, quality.valid);
+    check(inout checks, inout failures, windows.valid);
+    check(inout checks, inout failures, capacity.valid);
+    check(inout checks, inout failures, projected.valid);
+    check(inout checks, inout failures, lints.valid);
+    let mut digest = stats.digest;
+    digest = mix(digest, pools.digest); digest = mix(digest, priorities.digest);
+    digest = mix(digest, caches.digest); digest = mix(digest, retries.digest);
+    digest = mix(digest, paths.digest); digest = mix(digest, cuts.digest);
+    digest = mix(digest, queue.digest); digest = mix(digest, quality.digest);
+    digest = mix(digest, windows.digest); digest = mix(digest, capacity.digest);
+    digest = mix(digest, projected.digest);
+    digest = mix(digest, lints.digest);
+    Insights {
+        tasks: workflow.tasks.len(), pools: workflow.pools.len(), edges: workflow.edges.len(),
+        paths: paths.total_paths, bridge_edges: cuts.bridge_count,
+        cache_hits: caches.observed_hits, retries: retries.observed_retries,
+        queue_delay: queue.total_queue_delay, efficiency_millis: quality.efficiency_millis,
+        saturated_pools: capacity.saturated_pools, forecast_spread: projected.spread,
+        event_windows: windows.events_by_window.len(), checks: checks, failures: failures,
+        digest: digest, valid: failures == 0,
+    }
+}

--- a/performance/workloads/lattice/levels.rue
+++ b/performance/workloads/lattice/levels.rue
@@ -1,0 +1,113 @@
+// Exact topological layering and width analysis.
+const std = @import("std");
+const model = @import("model.rue");
+const topology = @import("topology.rue");
+const U64s = std.arraybuf.ArrayBuf(u64);
+
+pub struct Layers {
+    level_by_task: U64s,
+    tasks_by_level: U64s,
+    depth: u64,
+    maximum_width: u64,
+    widest_level: u64,
+    roots: u64,
+    leaves: u64,
+    valid: bool,
+    digest: u64,
+}
+
+fn zeroes(count: u64) -> U64s {
+    let mut values = U64s.with_capacity(count);
+    let mut i: u64 = 0;
+    while i < count { values.push(0); i += 1; }
+    values
+}
+
+fn mix(hash: u64, value: u64) -> u64 {
+    @wrapping_mul(hash ^ value, 1099511628211)
+}
+
+fn predecessor_level(borrow workflow: model.Workflow, borrow levels: U64s, task: u64) -> u64 {
+    let mut result: u64 = 0;
+    let mut i: u64 = 0;
+    while i < workflow.edges.len() {
+        let edge = workflow.edges.get_or(i, model.empty_edge());
+        if edge.after == task {
+            let candidate = levels.get_or(edge.before, 0) + 1;
+            if candidate > result { result = candidate; }
+        }
+        i += 1;
+    }
+    result
+}
+
+pub fn compute(borrow workflow: model.Workflow) -> Layers {
+    let order = topology.sort(borrow workflow);
+    let mut level_by_task = zeroes(workflow.tasks.len());
+    let mut depth: u64 = 0;
+    let mut digest: u64 = 14695981039346656037;
+    let mut i: u64 = 0;
+    while i < order.tasks.len() {
+        let task = order.tasks.get_or(i, model.NONE());
+        let level = predecessor_level(borrow workflow, borrow level_by_task, task);
+        level_by_task.set(task, level);
+        if level + 1 > depth { depth = level + 1; }
+        digest = mix(digest, task);
+        digest = mix(digest, level);
+        i += 1;
+    }
+    let mut tasks_by_level = zeroes(depth);
+    i = 0;
+    while i < workflow.tasks.len() {
+        let level = level_by_task.get_or(i, 0);
+        if level < tasks_by_level.len() {
+            tasks_by_level.set(level, tasks_by_level.get_or(level, 0) + 1);
+        }
+        i += 1;
+    }
+    let mut maximum_width: u64 = 0;
+    let mut widest_level: u64 = 0;
+    i = 0;
+    while i < tasks_by_level.len() {
+        let width = tasks_by_level.get_or(i, 0);
+        if width > maximum_width { maximum_width = width; widest_level = i; }
+        digest = mix(digest, width);
+        i += 1;
+    }
+    Layers {
+        level_by_task: level_by_task,
+        tasks_by_level: tasks_by_level,
+        depth: depth,
+        maximum_width: maximum_width,
+        widest_level: widest_level,
+        roots: order.roots,
+        leaves: order.leaves,
+        valid: !order.has_cycle && order.tasks.len() == workflow.tasks.len(),
+        digest: digest,
+    }
+}
+
+pub fn level(borrow layers: Layers, task: u64) -> u64 {
+    layers.level_by_task.get_or(task, 0)
+}
+
+pub fn width(borrow layers: Layers, level_index: u64) -> u64 {
+    layers.tasks_by_level.get_or(level_index, 0)
+}
+
+pub fn verify(borrow workflow: model.Workflow, borrow layers: Layers) -> bool {
+    if !layers.valid || layers.level_by_task.len() != workflow.tasks.len() { return false; }
+    let mut i: u64 = 0;
+    while i < workflow.edges.len() {
+        let edge = workflow.edges.get_or(i, model.empty_edge());
+        if level(borrow layers, edge.before) >= level(borrow layers, edge.after) { return false; }
+        i += 1;
+    }
+    let mut total: u64 = 0;
+    i = 0;
+    while i < layers.tasks_by_level.len() {
+        total += width(borrow layers, i);
+        i += 1;
+    }
+    total == workflow.tasks.len()
+}

--- a/performance/workloads/lattice/lexer.rue
+++ b/performance/workloads/lattice/lexer.rue
@@ -1,0 +1,122 @@
+// ASCII lexer for the Lattice workflow DSL.
+const std = @import("std");
+const poolmod = @import("pool.rue");
+const token = @import("token.rue");
+const StrBuf = std.strbuf.StrBuf;
+const Bytes = std.arraybuf.ArrayBuf(u8);
+
+pub struct ScanResult {
+    tokens: token.Tokens,
+    strings: poolmod.Pool,
+    errors: StrBuf,
+}
+
+fn is_alpha(value: u8) -> bool {
+    (value >= 65 && value <= 90) || (value >= 97 && value <= 122) || value == 95
+}
+
+fn is_digit(value: u8) -> bool { value >= 48 && value <= 57 }
+fn is_alnum(value: u8) -> bool { is_alpha(value) || is_digit(value) || value == 45 }
+
+struct Lexer {
+    source: Bytes,
+    at: u64,
+    tokens: token.Tokens,
+    strings: poolmod.Pool,
+    errors: StrBuf,
+
+    fn new(source: Bytes) -> Self {
+        Self {
+            source: source,
+            at: 0,
+            tokens: token.Tokens.new(),
+            strings: poolmod.Pool.new(),
+            errors: StrBuf.new(),
+        }
+    }
+
+    fn byte(borrow self, index: u64) -> u8 { self.source.get_or(index, 0) }
+    fn done(borrow self) -> bool { self.at >= self.source.len() }
+
+    fn advance(inout self) -> u8 {
+        let value = self.byte(self.at);
+        self.at += 1;
+        value
+    }
+
+    fn push(inout self, kind: u64, start: u64, value: u64) {
+        self.tokens.push(token.Token { kind: kind, start: start, end: self.at, value: value });
+    }
+
+    fn error(inout self, start: u64, message: StrBuf) {
+        self.errors.push_str("lex error at byte ");
+        self.errors.push_str(@to_string(start));
+        self.errors.push_str(": ");
+        self.errors.push_str(message);
+        self.errors.push(10);
+    }
+
+    fn word_is(borrow word: StrBuf, value: StrBuf) -> bool {
+        StrBuf.equals_borrowed(borrow word, borrow value)
+    }
+
+    fn keyword(borrow word: StrBuf) -> u64 {
+        if Self.word_is(borrow word, "workflow") { token.WORKFLOW }
+        else if Self.word_is(borrow word, "pool") { token.POOL }
+        else if Self.word_is(borrow word, "task") { token.TASK }
+        else if Self.word_is(borrow word, "after") { token.AFTER }
+        else if Self.word_is(borrow word, "slots") { token.SLOTS }
+        else if Self.word_is(borrow word, "duration") { token.DURATION }
+        else if Self.word_is(borrow word, "cpu") { token.CPU }
+        else if Self.word_is(borrow word, "memory") { token.MEMORY }
+        else if Self.word_is(borrow word, "priority") { token.PRIORITY }
+        else if Self.word_is(borrow word, "retries") { token.RETRIES }
+        else if Self.word_is(borrow word, "cache") { token.CACHE }
+        else if Self.word_is(borrow word, "fail") { token.FAIL }
+        else if Self.word_is(borrow word, "true") { token.TRUE }
+        else if Self.word_is(borrow word, "false") { token.FALSE }
+        else { token.IDENT }
+    }
+
+    fn identifier(inout self, start: u64) {
+        while !self.done() && is_alnum(self.byte(self.at)) { let _ = self.advance(); }
+        let spelling = StrBuf.from_byte_range(borrow self.source, start, self.at - start);
+        let kind = Self.keyword(borrow spelling);
+        let value = if kind == token.IDENT { self.strings.intern(borrow spelling) } else { 0 };
+        self.push(kind, start, value);
+    }
+
+    fn number(inout self, start: u64, first: u8) {
+        let mut value: u64 = @intCast(first - 48);
+        while !self.done() && is_digit(self.byte(self.at)) {
+            let digit: u64 = @intCast(self.advance() - 48);
+            if value > 1844674407370955161 || (value == 1844674407370955161 && digit > 5) {
+                self.error(start, "integer literal is too large");
+                value = 0;
+            } else { value = value * 10 + digit; }
+        }
+        self.push(token.INT, start, value);
+    }
+
+    fn scan_one(inout self) {
+        let start = self.at;
+        let value = self.advance();
+        if value == 32 || value == 9 || value == 10 || value == 13 { return; }
+        if is_alpha(value) { self.identifier(start); return; }
+        if is_digit(value) { self.number(start, value); return; }
+        if value == 35 {
+            while !self.done() && self.byte(self.at) != 10 { let _ = self.advance(); }
+            return;
+        }
+        if value == 59 { self.push(token.SEMI, start, 0); return; }
+        self.error(start, "unexpected character");
+        self.push(token.ERROR, start, 0);
+    }
+}
+
+pub fn scan(source: Bytes) -> ScanResult {
+    let mut lexer = Lexer.new(source);
+    while !lexer.done() { lexer.scan_one(); }
+    lexer.tokens.push(token.Token { kind: token.EOF, start: lexer.at, end: lexer.at, value: 0 });
+    ScanResult { tokens: lexer.tokens, strings: lexer.strings, errors: lexer.errors }
+}

--- a/performance/workloads/lattice/lint.rue
+++ b/performance/workloads/lattice/lint.rue
@@ -1,0 +1,230 @@
+// Maintainability and operability lint rules for workflow authors.
+const model = @import("model.rue");
+const queue_analysis = @import("queue_analysis.rue");
+const state = @import("state.rue");
+const std = @import("std");
+const transitive_reduction = @import("transitive_reduction.rue");
+
+pub fn INFO() -> u64 { 1 }
+pub fn WARNING() -> u64 { 2 }
+pub fn ERROR() -> u64 { 3 }
+
+pub fn LONG_UNCACHED() -> u64 { 1001 }
+pub fn FALLIBLE_WITHOUT_RETRY() -> u64 { 1002 }
+pub fn EXCESSIVE_RETRY_BUDGET() -> u64 { 1003 }
+pub fn ZERO_PRIORITY() -> u64 { 1004 }
+pub fn CPU_AT_POOL_LIMIT() -> u64 { 1005 }
+pub fn MEMORY_AT_POOL_LIMIT() -> u64 { 1006 }
+pub fn HIGH_FAN_IN() -> u64 { 1007 }
+pub fn HIGH_FAN_OUT() -> u64 { 1008 }
+pub fn QUEUE_DELAY_EXCEEDS_RUNTIME() -> u64 { 1009 }
+pub fn LONG_CACHE_MISS() -> u64 { 1010 }
+pub fn REDUNDANT_DEPENDENCY() -> u64 { 1011 }
+pub fn SINGLE_SLOT_HOT_POOL() -> u64 { 1012 }
+pub fn CROSS_POOL_DEPENDENCY() -> u64 { 1013 }
+pub fn RESOURCE_WAIT_STORM() -> u64 { 1014 }
+
+pub struct Finding {
+    rule: u64,
+    severity: u64,
+    task: u64,
+    pool: u64,
+    edge: u64,
+    actual: u64,
+    threshold: u64,
+}
+
+pub const Findings = std.arraybuf.ArrayBuf(Finding);
+
+pub struct Report {
+    findings: Findings,
+    infos: u64,
+    warnings: u64,
+    errors: u64,
+    task_findings: u64,
+    pool_findings: u64,
+    edge_findings: u64,
+    global_findings: u64,
+    digest: u64,
+    valid: bool,
+}
+
+pub fn empty_finding() -> Finding {
+    Finding {
+        rule: 0, severity: INFO(), task: model.NONE(), pool: model.NONE(),
+        edge: model.NONE(), actual: 0, threshold: 0,
+    }
+}
+
+fn mix(hash: u64, value: u64) -> u64 { @wrapping_mul(hash ^ value, 1099511628211) }
+
+fn add(
+    inout findings: Findings,
+    rule: u64,
+    severity: u64,
+    task: u64,
+    pool: u64,
+    edge: u64,
+    actual: u64,
+    threshold: u64,
+) {
+    findings.push(Finding {
+        rule: rule, severity: severity, task: task, pool: pool,
+        edge: edge, actual: actual, threshold: threshold,
+    });
+}
+
+fn task_rules(
+    inout findings: Findings,
+    borrow workflow: model.Workflow,
+    borrow run: state.Run,
+    borrow queue: queue_analysis.Analysis,
+    index: u64,
+) {
+    let task = workflow.tasks.get_or(index, model.empty_task());
+    let pool = workflow.pools.get_or(task.pool, model.empty_pool());
+    let incoming = model.dependency_count(borrow workflow, index);
+    let outgoing = model.dependent_count(borrow workflow, index);
+    let delay = queue.queue_delay.get_or(index, 0);
+    if task.duration >= 7 && !task.cacheable {
+        add(inout findings, LONG_UNCACHED(), WARNING(), index, task.pool, model.NONE(), task.duration, 7);
+    }
+    if task.fail_attempt > 0 && task.retries == 0 {
+        add(inout findings, FALLIBLE_WITHOUT_RETRY(), ERROR(), index, task.pool, model.NONE(), task.fail_attempt, 1);
+    }
+    if task.retries > 4 {
+        add(inout findings, EXCESSIVE_RETRY_BUDGET(), WARNING(), index, task.pool, model.NONE(), task.retries, 4);
+    }
+    if task.priority == 0 {
+        add(inout findings, ZERO_PRIORITY(), INFO(), index, task.pool, model.NONE(), task.priority, 1);
+    }
+    if pool.cpu > 0 && task.cpu == pool.cpu {
+        add(inout findings, CPU_AT_POOL_LIMIT(), INFO(), index, task.pool, model.NONE(), task.cpu, pool.cpu);
+    }
+    if pool.memory > 0 && task.memory == pool.memory {
+        add(inout findings, MEMORY_AT_POOL_LIMIT(), INFO(), index, task.pool, model.NONE(), task.memory, pool.memory);
+    }
+    if incoming > 4 {
+        add(inout findings, HIGH_FAN_IN(), INFO(), index, task.pool, model.NONE(), incoming, 4);
+    }
+    if outgoing > 4 {
+        add(inout findings, HIGH_FAN_OUT(), WARNING(), index, task.pool, model.NONE(), outgoing, 4);
+    }
+    if delay > task.duration {
+        add(inout findings, QUEUE_DELAY_EXCEEDS_RUNTIME(), WARNING(), index, task.pool, model.NONE(), delay, task.duration);
+    }
+    if task.cacheable && run.status.get_or(index, state.FAILED()) != state.CACHED() && task.duration >= 7 {
+        add(inout findings, LONG_CACHE_MISS(), INFO(), index, task.pool, model.NONE(), task.duration, 7);
+    }
+}
+
+fn edge_rules(
+    inout findings: Findings,
+    borrow workflow: model.Workflow,
+    borrow reduction: transitive_reduction.Reduction,
+) {
+    let mut i: u64 = 0;
+    while i < reduction.redundant.len() {
+        let edge_index = reduction.redundant.get_or(i, model.NONE());
+        add(inout findings, REDUNDANT_DEPENDENCY(), INFO(), model.NONE(), model.NONE(), edge_index, 1, 0);
+        i += 1;
+    }
+    i = 0;
+    while i < reduction.essential.len() {
+        let edge_index = reduction.essential.get_or(i, model.NONE());
+        let edge = workflow.edges.get_or(edge_index, model.empty_edge());
+        let before = workflow.tasks.get_or(edge.before, model.empty_task());
+        let after = workflow.tasks.get_or(edge.after, model.empty_task());
+        if before.pool != after.pool {
+            add(inout findings, CROSS_POOL_DEPENDENCY(), INFO(), model.NONE(), model.NONE(), edge_index, before.pool, after.pool);
+        }
+        i += 1;
+    }
+}
+
+fn pool_rules(inout findings: Findings, borrow workflow: model.Workflow) {
+    let mut pool_index: u64 = 0;
+    while pool_index < workflow.pools.len() {
+        let pool = workflow.pools.get_or(pool_index, model.empty_pool());
+        let mut tasks: u64 = 0;
+        let mut i: u64 = 0;
+        while i < workflow.tasks.len() {
+            if workflow.tasks.get_or(i, model.empty_task()).pool == pool_index { tasks += 1; }
+            i += 1;
+        }
+        if pool.slots == 1 && tasks > 5 {
+            add(inout findings, SINGLE_SLOT_HOT_POOL(), WARNING(), model.NONE(), pool_index, model.NONE(), tasks, 5);
+        }
+        pool_index += 1;
+    }
+}
+
+pub fn compute(borrow workflow: model.Workflow, borrow run: state.Run) -> Report {
+    let queue = queue_analysis.compute(borrow workflow, borrow run);
+    let reduction = transitive_reduction.compute(borrow workflow);
+    let mut findings = Findings.new();
+    let mut i: u64 = 0;
+    while i < workflow.tasks.len() {
+        task_rules(inout findings, borrow workflow, borrow run, borrow queue, i);
+        i += 1;
+    }
+    edge_rules(inout findings, borrow workflow, borrow reduction);
+    pool_rules(inout findings, borrow workflow);
+    if run.resource_waits > workflow.tasks.len() * 100 {
+        add(inout findings, RESOURCE_WAIT_STORM(), WARNING(), model.NONE(), model.NONE(), model.NONE(),
+            run.resource_waits, workflow.tasks.len() * 100);
+    }
+    let mut infos: u64 = 0;
+    let mut warnings: u64 = 0;
+    let mut errors: u64 = 0;
+    let mut task_findings: u64 = 0;
+    let mut pool_findings: u64 = 0;
+    let mut edge_findings: u64 = 0;
+    let mut global_findings: u64 = 0;
+    let mut digest: u64 = 14695981039346656037;
+    i = 0;
+    while i < findings.len() {
+        let finding = findings.get_or(i, empty_finding());
+        if finding.severity == ERROR() { errors += 1; }
+        else if finding.severity == WARNING() { warnings += 1; }
+        else { infos += 1; }
+        if finding.task != model.NONE() { task_findings += 1; }
+        else if finding.pool != model.NONE() { pool_findings += 1; }
+        else if finding.edge != model.NONE() { edge_findings += 1; }
+        else { global_findings += 1; }
+        digest = mix(digest, finding.rule); digest = mix(digest, finding.severity);
+        digest = mix(digest, finding.actual); digest = mix(digest, finding.threshold);
+        i += 1;
+    }
+    let count = findings.len();
+    Report {
+        findings: findings, infos: infos, warnings: warnings, errors: errors,
+        task_findings: task_findings, pool_findings: pool_findings,
+        edge_findings: edge_findings, global_findings: global_findings,
+        digest: digest, valid: infos + warnings + errors == count && queue.valid && reduction.valid,
+    }
+}
+
+pub fn rule_name(rule: u64) -> str {
+    if rule == LONG_UNCACHED() { "long-uncached-task" }
+    else if rule == FALLIBLE_WITHOUT_RETRY() { "fallible-without-retry" }
+    else if rule == EXCESSIVE_RETRY_BUDGET() { "excessive-retry-budget" }
+    else if rule == ZERO_PRIORITY() { "zero-priority" }
+    else if rule == CPU_AT_POOL_LIMIT() { "cpu-at-pool-limit" }
+    else if rule == MEMORY_AT_POOL_LIMIT() { "memory-at-pool-limit" }
+    else if rule == HIGH_FAN_IN() { "high-fan-in" }
+    else if rule == HIGH_FAN_OUT() { "high-fan-out" }
+    else if rule == QUEUE_DELAY_EXCEEDS_RUNTIME() { "queue-delay-exceeds-runtime" }
+    else if rule == LONG_CACHE_MISS() { "long-cache-miss" }
+    else if rule == REDUNDANT_DEPENDENCY() { "redundant-dependency" }
+    else if rule == SINGLE_SLOT_HOT_POOL() { "single-slot-hot-pool" }
+    else if rule == CROSS_POOL_DEPENDENCY() { "cross-pool-dependency" }
+    else if rule == RESOURCE_WAIT_STORM() { "resource-wait-storm" }
+    else { "unknown" }
+}
+
+pub fn severity_name(severity: u64) -> str {
+    if severity == ERROR() { "error" }
+    else if severity == WARNING() { "warning" }
+    else { "info" }
+}

--- a/performance/workloads/lattice/main.rue
+++ b/performance/workloads/lattice/main.rue
@@ -1,0 +1,116 @@
+// lattice — workflow language, graph analyzer, and deterministic scheduler.
+const std = @import("std");
+const diagnostics = @import("diagnostics.rue");
+const lexer = @import("lexer.rue");
+const parser = @import("parser.rue");
+const report = @import("report.rue");
+const schedule = @import("schedule.rue");
+const selftest = @import("selftest.rue");
+const stress = @import("stress.rue");
+const validate = @import("validate.rue");
+const workload = @import("workload.rue");
+const StrBuf = std.strbuf.StrBuf;
+const Bytes = std.arraybuf.ArrayBuf(u8);
+const OptStr = std.option.Option(StrBuf);
+const OptBytes = std.option.Option(Bytes);
+const FileRes = std.result.Result(std.fs.File, std.fs.FileError);
+const ReadRes = std.result.Result(u64, std.fs.FileError);
+
+fn same(borrow value: StrBuf, expected: StrBuf) -> bool {
+    StrBuf.equals_borrowed(borrow value, borrow expected)
+}
+
+fn read_file(borrow path: StrBuf) -> OptBytes {
+    let O = OptBytes;
+    let mut data = Bytes.new();
+    let mut file = match std.fs.File.open(borrow path) {
+        FileRes.Ok(value) => value,
+        FileRes.Err(error) => { return O.None; },
+    };
+    loop {
+        data.reserve(65536);
+        let count = match file.read(inout data) {
+            ReadRes.Ok(value) => value,
+            ReadRes.Err(error) => { return O.None; },
+        };
+        if count == 0 { break; }
+    }
+    let _ = file.close();
+    O.Some(data)
+}
+
+fn demo() -> StrBuf {
+    let mut source = StrBuf.new();
+    source.push_str("workflow demo;\n");
+    source.push_str("pool local slots 2 cpu 4 memory 8;\n");
+    source.push_str("pool large slots 1 cpu 8 memory 16;\n");
+    source.push_str("task fetch pool local duration 2 cpu 1 memory 1 priority 20 retries 1 cache true fail 0;\n");
+    source.push_str("task parse pool local duration 3 cpu 1 memory 2 priority 18 retries 1 cache false fail 0;\n");
+    source.push_str("task compile pool large duration 5 cpu 4 memory 8 priority 16 retries 2 cache true fail 1;\n");
+    source.push_str("task test pool local duration 4 cpu 2 memory 3 priority 14 retries 1 cache false fail 0;\n");
+    source.push_str("task package pool local duration 2 cpu 1 memory 1 priority 10 retries 0 cache true fail 0;\n");
+    source.push_str("after parse fetch;\n");
+    source.push_str("after compile parse;\n");
+    source.push_str("after test compile;\n");
+    source.push_str("after package test;\n");
+    source
+}
+
+fn execute(source: Bytes) -> i32 {
+    let scanned = lexer.scan(source);
+    if scanned.errors.len() > 0 { print(scanned.errors); return 1; }
+    let parsed = parser.parse(scanned.tokens, scanned.strings);
+    if parsed.errors.len() > 0 { print(parsed.errors); return 1; }
+    let mut workflow = parsed.workflow;
+    validate.workflow(inout workflow);
+    if workflow.diagnostics.len() > 0 { print(diagnostics.render(borrow workflow)); return 1; }
+    let run = schedule.run(borrow workflow, 17);
+    print(report.summary(borrow workflow, borrow run));
+    if run.failed == 0 { 0 } else { 1 }
+}
+
+fn help() -> StrBuf {
+    let mut out = StrBuf.new();
+    out.push_str("usage: lattice [demo | run FILE | selftest | stress1 | stress2 | stress4 | benchmark | help]\n");
+    out.push_str("Lattice compiles a workflow DSL, validates its graph, and simulates execution.\n");
+    out
+}
+
+fn main() -> i32 {
+    let command = match std.env.arg(1) {
+        OptStr.Some(value) => value,
+        OptStr.None => { print(help()); return 0; },
+    };
+    if same(borrow command, "demo") { return execute(demo().to_bytes()); }
+    if same(borrow command, "selftest") {
+        let result = selftest.run();
+        print(selftest.render(borrow result));
+        return if result.failures == 0 { 0 } else { 1 };
+    }
+    if same(borrow command, "stress1") || same(borrow command, "stress2") || same(borrow command, "stress4") {
+        let scale: u64 = if same(borrow command, "stress1") { 1 }
+            else if same(borrow command, "stress2") { 2 } else { 4 };
+        let result = stress.run(stress.tier(scale));
+        print(stress.render(borrow result));
+        return if result.valid { 0 } else { 1 };
+    }
+    if same(borrow command, "benchmark") {
+        let result = workload.run();
+        print(workload.render(borrow result));
+        return if result.valid { 0 } else { 1 };
+    }
+    if same(borrow command, "help") || same(borrow command, "--help") {
+        print(help()); return 0;
+    }
+    if same(borrow command, "run") {
+        return match std.env.arg(2) {
+            OptStr.Some(path) => match read_file(borrow path) {
+                OptBytes.Some(bytes) => execute(bytes),
+                OptBytes.None => { println("lattice[filesystem]: cannot read workflow"); 2 },
+            },
+            OptStr.None => { println("lattice: run requires a workflow path"); 2 },
+        };
+    }
+    println("lattice: unknown command; run `lattice help`");
+    2
+}

--- a/performance/workloads/lattice/metric.rue
+++ b/performance/workloads/lattice/metric.rue
@@ -1,0 +1,87 @@
+// Shared POD aggregate for Lattice analysis passes.
+const std = @import("std");
+const text = @import("text.rue");
+const StrBuf = std.strbuf.StrBuf;
+
+pub struct Metric {
+    tag: u64,
+    observations: u64,
+    sum: u64,
+    minimum: u64,
+    maximum: u64,
+    weighted: u64,
+    even: u64,
+    odd: u64,
+    zeroes: u64,
+    warnings: u64,
+    digest: u64,
+}
+
+pub fn new(tag: u64) -> Metric {
+    Metric {
+        tag: tag, observations: 0, sum: 0,
+        minimum: 18446744073709551615, maximum: 0,
+        weighted: 0, even: 0, odd: 0, zeroes: 0,
+        warnings: 0, digest: 14695981039346656037,
+    }
+}
+
+pub fn mix(hash: u64, value: u64) -> u64 {
+    @wrapping_mul(hash ^ value, 1099511628211)
+}
+
+pub fn add(a: u64, b: u64) -> u64 {
+    if b > 18446744073709551615 - a { 18446744073709551615 } else { a + b }
+}
+
+pub fn multiply(a: u64, b: u64) -> u64 {
+    if a == 0 || b == 0 { return 0; }
+    if a > 18446744073709551615 / b { 18446744073709551615 } else { a * b }
+}
+
+pub fn observe(inout metric: Metric, value: u64, weight: u64) {
+    metric.observations += 1;
+    metric.sum = add(metric.sum, value);
+    metric.weighted = add(metric.weighted, multiply(value, weight));
+    if value < metric.minimum { metric.minimum = value; }
+    if value > metric.maximum { metric.maximum = value; }
+    if value == 0 { metric.zeroes += 1; }
+    if value % 2 == 0 { metric.even += 1; }
+    else { metric.odd += 1; }
+    metric.digest = mix(metric.digest, value);
+    metric.digest = mix(metric.digest, weight);
+}
+
+pub fn warn(inout metric: Metric, condition: bool) {
+    if condition { metric.warnings += 1; }
+}
+
+pub fn finish(inout metric: Metric) {
+    if metric.observations == 0 { metric.minimum = 0; }
+    metric.digest = mix(metric.digest, metric.tag);
+    metric.digest = mix(metric.digest, metric.observations);
+    metric.digest = mix(metric.digest, metric.sum);
+    metric.digest = mix(metric.digest, metric.weighted);
+    metric.digest = mix(metric.digest, metric.warnings);
+}
+
+pub fn mean(borrow metric: Metric) -> u64 {
+    if metric.observations == 0 { 0 } else { metric.sum / metric.observations }
+}
+
+pub fn render(label: str, borrow metric: Metric) -> StrBuf {
+    let mut out = StrBuf.new();
+    text.append_literal(inout out, label); out.push(10);
+    text.line(inout out, "observations=", metric.observations);
+    text.line(inout out, "sum=", metric.sum);
+    text.line(inout out, "minimum=", metric.minimum);
+    text.line(inout out, "maximum=", metric.maximum);
+    text.line(inout out, "mean=", mean(borrow metric));
+    text.line(inout out, "weighted=", metric.weighted);
+    text.line(inout out, "even=", metric.even);
+    text.line(inout out, "odd=", metric.odd);
+    text.line(inout out, "zeroes=", metric.zeroes);
+    text.line(inout out, "warnings=", metric.warnings);
+    text.line(inout out, "digest=", metric.digest);
+    out
+}

--- a/performance/workloads/lattice/model.rue
+++ b/performance/workloads/lattice/model.rue
@@ -1,0 +1,152 @@
+// Canonical workflow model. Strings are pooled and cross-record references
+// resolve to compact indices during validation.
+const std = @import("std");
+const poolmod = @import("pool.rue");
+const StrBuf = std.strbuf.StrBuf;
+
+pub fn NONE() -> u64 { 18446744073709551615 }
+
+pub struct WorkerPool {
+    id: u64,
+    slots: u64,
+    cpu: u64,
+    memory: u64,
+}
+
+pub struct Task {
+    id: u64,
+    pool_id: u64,
+    pool: u64,
+    duration: u64,
+    cpu: u64,
+    memory: u64,
+    priority: u64,
+    retries: u64,
+    cacheable: bool,
+    fail_attempt: u64,
+}
+
+// `before -> after` is the execution direction.
+pub struct Edge {
+    before_id: u64,
+    after_id: u64,
+    before: u64,
+    after: u64,
+}
+
+pub struct Diagnostic {
+    code: u64,
+    subject: u64,
+    detail: u64,
+}
+
+pub const WorkerPools = std.arraybuf.ArrayBuf(WorkerPool);
+pub const Tasks = std.arraybuf.ArrayBuf(Task);
+pub const Edges = std.arraybuf.ArrayBuf(Edge);
+pub const Diagnostics = std.arraybuf.ArrayBuf(Diagnostic);
+pub const U64s = std.arraybuf.ArrayBuf(u64);
+pub const Bools = std.arraybuf.ArrayBuf(bool);
+
+pub struct Workflow {
+    strings: poolmod.Pool,
+    name: u64,
+    pools: WorkerPools,
+    tasks: Tasks,
+    edges: Edges,
+    diagnostics: Diagnostics,
+}
+
+pub fn new_workflow(strings: poolmod.Pool) -> Workflow {
+    Workflow {
+        strings: strings,
+        name: NONE(),
+        pools: WorkerPools.new(),
+        tasks: Tasks.new(),
+        edges: Edges.new(),
+        diagnostics: Diagnostics.new(),
+    }
+}
+
+pub fn empty_pool() -> WorkerPool {
+    WorkerPool { id: NONE(), slots: 0, cpu: 0, memory: 0 }
+}
+
+pub fn empty_task() -> Task {
+    Task {
+        id: NONE(), pool_id: NONE(), pool: NONE(), duration: 0,
+        cpu: 0, memory: 0, priority: 0, retries: 0,
+        cacheable: false, fail_attempt: 0,
+    }
+}
+
+pub fn empty_edge() -> Edge {
+    Edge { before_id: NONE(), after_id: NONE(), before: NONE(), after: NONE() }
+}
+
+pub fn add_error(inout workflow: Workflow, code: u64, subject: u64, detail: StrBuf) {
+    let detail_id = workflow.strings.intern(borrow detail);
+    workflow.diagnostics.push(Diagnostic { code: code, subject: subject, detail: detail_id });
+}
+
+pub fn code_name(code: u64) -> StrBuf {
+    if code == 100 { "lex" }
+    else if code == 101 { "parse" }
+    else if code == 200 { "duplicate" }
+    else if code == 201 { "reference" }
+    else if code == 202 { "range" }
+    else if code == 203 { "cycle" }
+    else if code == 204 { "resource" }
+    else if code == 300 { "schedule" }
+    else if code == 301 { "replay" }
+    else { "unknown" }
+}
+
+pub fn find_pool(borrow workflow: Workflow, id: u64) -> u64 {
+    let mut i: u64 = 0;
+    while i < workflow.pools.len() {
+        let item = workflow.pools.get_or(i, empty_pool());
+        if workflow.strings.ids_equal(item.id, id) { return i; }
+        i += 1;
+    }
+    NONE()
+}
+
+pub fn find_task(borrow workflow: Workflow, id: u64) -> u64 {
+    let mut i: u64 = 0;
+    while i < workflow.tasks.len() {
+        let item = workflow.tasks.get_or(i, empty_task());
+        if workflow.strings.ids_equal(item.id, id) { return i; }
+        i += 1;
+    }
+    NONE()
+}
+
+pub fn dependency_count(borrow workflow: Workflow, task: u64) -> u64 {
+    let mut count: u64 = 0;
+    let mut i: u64 = 0;
+    while i < workflow.edges.len() {
+        if workflow.edges.get_or(i, empty_edge()).after == task { count += 1; }
+        i += 1;
+    }
+    count
+}
+
+pub fn dependent_count(borrow workflow: Workflow, task: u64) -> u64 {
+    let mut count: u64 = 0;
+    let mut i: u64 = 0;
+    while i < workflow.edges.len() {
+        if workflow.edges.get_or(i, empty_edge()).before == task { count += 1; }
+        i += 1;
+    }
+    count
+}
+
+pub fn has_edge(borrow workflow: Workflow, before: u64, after: u64) -> bool {
+    let mut i: u64 = 0;
+    while i < workflow.edges.len() {
+        let edge = workflow.edges.get_or(i, empty_edge());
+        if edge.before == before && edge.after == after { return true; }
+        i += 1;
+    }
+    false
+}

--- a/performance/workloads/lattice/parser.rue
+++ b/performance/workloads/lattice/parser.rue
@@ -1,0 +1,141 @@
+// Predictive parser for Lattice declarations. The field order is deliberate:
+// workflow files are easy to diff and parser recovery can synchronize on ';'.
+const std = @import("std");
+const model = @import("model.rue");
+const poolmod = @import("pool.rue");
+const token = @import("token.rue");
+const StrBuf = std.strbuf.StrBuf;
+
+pub struct ParseResult {
+    workflow: model.Workflow,
+    errors: StrBuf,
+}
+
+struct Parser {
+    tokens: token.Tokens,
+    at: u64,
+    workflow: model.Workflow,
+    errors: StrBuf,
+
+    fn new(tokens: token.Tokens, strings: poolmod.Pool) -> Self {
+        Self { tokens: tokens, at: 0, workflow: model.new_workflow(strings), errors: StrBuf.new() }
+    }
+
+    fn peek(borrow self) -> token.Token { self.tokens.get_or(self.at, token.empty()) }
+    fn check(borrow self, kind: u64) -> bool { self.peek().kind == kind }
+
+    fn advance(inout self) -> token.Token {
+        let value = self.peek();
+        if value.kind != token.EOF { self.at += 1; }
+        value
+    }
+
+    fn error(inout self, message: StrBuf) {
+        self.errors.push_str("parse error at byte ");
+        self.errors.push_str(@to_string(self.peek().start));
+        self.errors.push_str(": ");
+        self.errors.push_str(message);
+        self.errors.push(10);
+    }
+
+    fn expect(inout self, kind: u64, message: StrBuf) -> token.Token {
+        if self.check(kind) { return self.advance(); }
+        self.error(message);
+        if !self.check(token.EOF) { self.advance() } else { self.peek() }
+    }
+
+    fn integer(inout self, label: StrBuf) -> u64 {
+        let value = self.expect(token.INT, label);
+        value.value
+    }
+
+    fn boolean(inout self, label: StrBuf) -> bool {
+        if self.check(token.TRUE) { let _ = self.advance(); return true; }
+        if self.check(token.FALSE) { let _ = self.advance(); return false; }
+        self.error(label);
+        if !self.check(token.EOF) { let _ = self.advance(); }
+        false
+    }
+
+    fn semicolon(inout self) {
+        let _ = self.expect(token.SEMI, "expected ';' after declaration");
+    }
+
+    fn workflow_decl(inout self) {
+        let name = self.expect(token.IDENT, "expected workflow name");
+        self.workflow.name = name.value;
+        self.semicolon();
+    }
+
+    fn pool_decl(inout self) {
+        let name = self.expect(token.IDENT, "expected pool name");
+        let _ = self.expect(token.SLOTS, "expected 'slots'");
+        let slots = self.integer("expected slot count");
+        let _ = self.expect(token.CPU, "expected 'cpu'");
+        let cpu = self.integer("expected cpu capacity");
+        let _ = self.expect(token.MEMORY, "expected 'memory'");
+        let memory = self.integer("expected memory capacity");
+        self.semicolon();
+        self.workflow.pools.push(model.WorkerPool {
+            id: name.value, slots: slots, cpu: cpu, memory: memory,
+        });
+    }
+
+    fn task_decl(inout self) {
+        let name = self.expect(token.IDENT, "expected task name");
+        let _ = self.expect(token.POOL, "expected 'pool'");
+        let pool_name = self.expect(token.IDENT, "expected task pool name");
+        let _ = self.expect(token.DURATION, "expected 'duration'");
+        let duration = self.integer("expected task duration");
+        let _ = self.expect(token.CPU, "expected 'cpu'");
+        let cpu = self.integer("expected task cpu");
+        let _ = self.expect(token.MEMORY, "expected 'memory'");
+        let memory = self.integer("expected task memory");
+        let _ = self.expect(token.PRIORITY, "expected 'priority'");
+        let priority = self.integer("expected task priority");
+        let _ = self.expect(token.RETRIES, "expected 'retries'");
+        let retries = self.integer("expected retry count");
+        let _ = self.expect(token.CACHE, "expected 'cache'");
+        let cacheable = self.boolean("expected cache boolean");
+        let _ = self.expect(token.FAIL, "expected 'fail'");
+        let fail_attempt = self.integer("expected failure attempt");
+        self.semicolon();
+        self.workflow.tasks.push(model.Task {
+            id: name.value, pool_id: pool_name.value, pool: model.NONE(),
+            duration: duration, cpu: cpu, memory: memory, priority: priority,
+            retries: retries, cacheable: cacheable, fail_attempt: fail_attempt,
+        });
+    }
+
+    fn after_decl(inout self) {
+        let after = self.expect(token.IDENT, "expected dependent task");
+        let before = self.expect(token.IDENT, "expected prerequisite task");
+        self.semicolon();
+        self.workflow.edges.push(model.Edge {
+            before_id: before.value,
+            after_id: after.value,
+            before: model.NONE(),
+            after: model.NONE(),
+        });
+    }
+
+    fn declaration(inout self) {
+        let kind = self.peek().kind;
+        let _ = self.advance();
+        if kind == token.WORKFLOW { self.workflow_decl(); }
+        else if kind == token.POOL { self.pool_decl(); }
+        else if kind == token.TASK { self.task_decl(); }
+        else if kind == token.AFTER { self.after_decl(); }
+        else {
+            self.error("expected workflow, pool, task, or after declaration");
+            while !self.check(token.SEMI) && !self.check(token.EOF) { let _ = self.advance(); }
+            if self.check(token.SEMI) { let _ = self.advance(); }
+        }
+    }
+}
+
+pub fn parse(tokens: token.Tokens, strings: poolmod.Pool) -> ParseResult {
+    let mut parser = Parser.new(tokens, strings);
+    while !parser.check(token.EOF) { parser.declaration(); }
+    ParseResult { workflow: parser.workflow, errors: parser.errors }
+}

--- a/performance/workloads/lattice/path_catalog.rue
+++ b/performance/workloads/lattice/path_catalog.rue
@@ -1,0 +1,120 @@
+// Dynamic-programming catalog of root-to-task and task-to-leaf paths.
+const model = @import("model.rue");
+const topology = @import("topology.rue");
+
+pub struct Catalog {
+    paths_from_roots: model.U64s,
+    paths_to_leaves: model.U64s,
+    paths_through_task: model.U64s,
+    total_paths: u64,
+    maximum_through: u64,
+    maximum_through_task: u64,
+    roots: u64,
+    leaves: u64,
+    saturated_additions: u64,
+    digest: u64,
+    valid: bool,
+}
+
+fn zeroes(count: u64) -> model.U64s {
+    let mut result = model.U64s.with_capacity(count);
+    let mut i: u64 = 0;
+    while i < count { result.push(0); i += 1; }
+    result
+}
+
+fn saturating_add(left: u64, right: u64, inout saturated: u64) -> u64 {
+    let sum = @wrapping_add(left, right);
+    if sum < left || sum < right {
+        saturated += 1;
+        18446744073709551615
+    } else { sum }
+}
+
+fn saturating_multiply(left: u64, right: u64, inout saturated: u64) -> u64 {
+    if left == 0 || right == 0 { return 0; }
+    let product = @wrapping_mul(left, right);
+    if product / left != right {
+        saturated += 1;
+        18446744073709551615
+    } else { product }
+}
+
+fn mix(hash: u64, value: u64) -> u64 { @wrapping_mul(hash ^ value, 1099511628211) }
+
+pub fn compute(borrow workflow: model.Workflow) -> Catalog {
+    let order = topology.sort(borrow workflow);
+    let mut paths_from_roots = zeroes(workflow.tasks.len());
+    let mut paths_to_leaves = zeroes(workflow.tasks.len());
+    let mut saturated_additions: u64 = 0;
+    let mut position: u64 = 0;
+    while position < order.tasks.len() {
+        let task = order.tasks.get_or(position, model.NONE());
+        let mut paths: u64 = 0;
+        let mut predecessors: u64 = 0;
+        let mut edge_index: u64 = 0;
+        while edge_index < workflow.edges.len() {
+            let edge = workflow.edges.get_or(edge_index, model.empty_edge());
+            if edge.after == task {
+                predecessors += 1;
+                paths = saturating_add(paths, paths_from_roots.get_or(edge.before, 0), inout saturated_additions);
+            }
+            edge_index += 1;
+        }
+        if predecessors == 0 { paths = 1; }
+        paths_from_roots.set(task, paths);
+        position += 1;
+    }
+
+    position = order.tasks.len();
+    while position > 0 {
+        position -= 1;
+        let task = order.tasks.get_or(position, model.NONE());
+        let mut paths: u64 = 0;
+        let mut successors: u64 = 0;
+        let mut edge_index: u64 = 0;
+        while edge_index < workflow.edges.len() {
+            let edge = workflow.edges.get_or(edge_index, model.empty_edge());
+            if edge.before == task {
+                successors += 1;
+                paths = saturating_add(paths, paths_to_leaves.get_or(edge.after, 0), inout saturated_additions);
+            }
+            edge_index += 1;
+        }
+        if successors == 0 { paths = 1; }
+        paths_to_leaves.set(task, paths);
+    }
+
+    let mut paths_through_task = zeroes(workflow.tasks.len());
+    let mut total_paths: u64 = 0;
+    let mut maximum_through: u64 = 0;
+    let mut maximum_through_task = model.NONE();
+    let mut roots: u64 = 0;
+    let mut leaves: u64 = 0;
+    let mut digest: u64 = 14695981039346656037;
+    let mut i: u64 = 0;
+    while i < workflow.tasks.len() {
+        let from = paths_from_roots.get_or(i, 0);
+        let to = paths_to_leaves.get_or(i, 0);
+        let through = saturating_multiply(from, to, inout saturated_additions);
+        paths_through_task.set(i, through);
+        if model.dependency_count(borrow workflow, i) == 0 { roots += 1; }
+        if model.dependent_count(borrow workflow, i) == 0 {
+            leaves += 1;
+            total_paths = saturating_add(total_paths, from, inout saturated_additions);
+        }
+        if maximum_through_task == model.NONE() || through > maximum_through {
+            maximum_through = through; maximum_through_task = i;
+        }
+        digest = mix(digest, from); digest = mix(digest, to); digest = mix(digest, through);
+        i += 1;
+    }
+    Catalog {
+        paths_from_roots: paths_from_roots, paths_to_leaves: paths_to_leaves,
+        paths_through_task: paths_through_task, total_paths: total_paths,
+        maximum_through: maximum_through, maximum_through_task: maximum_through_task,
+        roots: roots, leaves: leaves, saturated_additions: saturated_additions,
+        digest: digest, valid: !order.has_cycle && order.tasks.len() == workflow.tasks.len() &&
+            roots == order.roots && leaves == order.leaves,
+    }
+}

--- a/performance/workloads/lattice/policy.rue
+++ b/performance/workloads/lattice/policy.rue
@@ -1,0 +1,152 @@
+// SLO policy evaluation over workflow declarations and a realized schedule.
+const cache_analysis = @import("cache_analysis.rue");
+const model = @import("model.rue");
+const queue_analysis = @import("queue_analysis.rue");
+const resource_audit = @import("resource_audit.rue");
+const schedule_quality = @import("schedule_quality.rue");
+const state = @import("state.rue");
+const std = @import("std");
+
+pub fn MAX_MAKESPAN() -> u64 { 1 }
+pub fn MAX_FAILURES() -> u64 { 2 }
+pub fn MAX_RETRIES() -> u64 { 3 }
+pub fn MAX_QUEUE_DELAY() -> u64 { 4 }
+pub fn MAX_RESOURCE_WAITS() -> u64 { 5 }
+pub fn MIN_EFFICIENCY() -> u64 { 6 }
+pub fn MIN_CACHE_RATE() -> u64 { 7 }
+pub fn MAX_RESOURCE_VIOLATIONS() -> u64 { 8 }
+pub fn MAX_UNCACHEABLE_LONG_TASKS() -> u64 { 9 }
+
+pub struct Policy {
+    maximum_makespan: u64,
+    maximum_failures: u64,
+    maximum_retries: u64,
+    maximum_queue_delay: u64,
+    maximum_resource_waits: u64,
+    minimum_efficiency_millis: u64,
+    minimum_cache_rate_millis: u64,
+    maximum_resource_violations: u64,
+    maximum_uncacheable_long_tasks: u64,
+    long_task_threshold: u64,
+}
+
+pub struct Violation {
+    code: u64,
+    actual: u64,
+    expected: u64,
+    task: u64,
+    pool: u64,
+}
+
+pub const Violations = std.arraybuf.ArrayBuf(Violation);
+
+pub struct Evaluation {
+    violations: Violations,
+    checks: u64,
+    failures: u64,
+    makespan: u64,
+    retries: u64,
+    queue_delay: u64,
+    efficiency_millis: u64,
+    cache_rate_millis: u64,
+    resource_violations: u64,
+    uncacheable_long_tasks: u64,
+    digest: u64,
+    passed: bool,
+}
+
+pub fn permissive() -> Policy {
+    Policy {
+        maximum_makespan: model.NONE(), maximum_failures: 0,
+        maximum_retries: model.NONE(), maximum_queue_delay: model.NONE(),
+        maximum_resource_waits: model.NONE(), minimum_efficiency_millis: 0,
+        minimum_cache_rate_millis: 0, maximum_resource_violations: 0,
+        maximum_uncacheable_long_tasks: model.NONE(), long_task_threshold: 5,
+    }
+}
+
+pub fn production() -> Policy {
+    Policy {
+        maximum_makespan: 500, maximum_failures: 0, maximum_retries: 20,
+        maximum_queue_delay: 1000, maximum_resource_waits: 100000,
+        minimum_efficiency_millis: 500, minimum_cache_rate_millis: 0,
+        maximum_resource_violations: 0, maximum_uncacheable_long_tasks: 100,
+        long_task_threshold: 7,
+    }
+}
+
+fn mix(hash: u64, value: u64) -> u64 { @wrapping_mul(hash ^ value, 1099511628211) }
+
+fn maximum(inout result: Evaluation, code: u64, actual: u64, expected: u64, task: u64) {
+    result.checks += 1;
+    if expected != model.NONE() && actual > expected {
+        result.failures += 1;
+        result.violations.push(Violation { code: code, actual: actual, expected: expected, task: task, pool: model.NONE() });
+    }
+}
+
+fn minimum(inout result: Evaluation, code: u64, actual: u64, expected: u64) {
+    result.checks += 1;
+    if actual < expected {
+        result.failures += 1;
+        result.violations.push(Violation { code: code, actual: actual, expected: expected, task: model.NONE(), pool: model.NONE() });
+    }
+}
+
+fn uncacheable_long_tasks(borrow workflow: model.Workflow, threshold: u64) -> u64 {
+    let mut count: u64 = 0;
+    let mut i: u64 = 0;
+    while i < workflow.tasks.len() {
+        let task = workflow.tasks.get_or(i, model.empty_task());
+        if task.duration >= threshold && !task.cacheable { count += 1; }
+        i += 1;
+    }
+    count
+}
+
+pub fn evaluate(borrow workflow: model.Workflow, borrow run: state.Run, borrow policy: Policy) -> Evaluation {
+    let queue = queue_analysis.compute(borrow workflow, borrow run);
+    let quality = schedule_quality.compute(borrow workflow, borrow run);
+    let cache = cache_analysis.compute(borrow workflow, borrow run);
+    let resources = resource_audit.audit(borrow workflow, borrow run);
+    let resource_violations = resources.underflows + resources.slot_violations +
+        resources.cpu_violations + resources.memory_violations + resources.terminal_active;
+    let long_tasks = uncacheable_long_tasks(borrow workflow, policy.long_task_threshold);
+    let mut result = Evaluation {
+        violations: Violations.new(), checks: 0, failures: 0,
+        makespan: run.makespan, retries: run.retries,
+        queue_delay: queue.maximum_queue_delay,
+        efficiency_millis: quality.efficiency_millis,
+        cache_rate_millis: cache.hit_rate_millis,
+        resource_violations: resource_violations,
+        uncacheable_long_tasks: long_tasks,
+        digest: 14695981039346656037, passed: false,
+    };
+    maximum(inout result, MAX_MAKESPAN(), run.makespan, policy.maximum_makespan, model.NONE());
+    maximum(inout result, MAX_FAILURES(), run.failed, policy.maximum_failures, model.NONE());
+    maximum(inout result, MAX_RETRIES(), run.retries, policy.maximum_retries, model.NONE());
+    maximum(inout result, MAX_QUEUE_DELAY(), queue.maximum_queue_delay, policy.maximum_queue_delay, queue.maximum_queue_task);
+    maximum(inout result, MAX_RESOURCE_WAITS(), run.resource_waits, policy.maximum_resource_waits, model.NONE());
+    minimum(inout result, MIN_EFFICIENCY(), quality.efficiency_millis, policy.minimum_efficiency_millis);
+    minimum(inout result, MIN_CACHE_RATE(), cache.hit_rate_millis, policy.minimum_cache_rate_millis);
+    maximum(inout result, MAX_RESOURCE_VIOLATIONS(), resource_violations, policy.maximum_resource_violations, model.NONE());
+    maximum(inout result, MAX_UNCACHEABLE_LONG_TASKS(), long_tasks, policy.maximum_uncacheable_long_tasks, model.NONE());
+    result.digest = mix(result.digest, result.makespan); result.digest = mix(result.digest, result.retries);
+    result.digest = mix(result.digest, result.queue_delay); result.digest = mix(result.digest, result.efficiency_millis);
+    result.digest = mix(result.digest, result.cache_rate_millis); result.digest = mix(result.digest, result.failures);
+    result.passed = result.failures == 0;
+    result
+}
+
+pub fn code_name(code: u64) -> str {
+    if code == MAX_MAKESPAN() { "maximum_makespan" }
+    else if code == MAX_FAILURES() { "maximum_failures" }
+    else if code == MAX_RETRIES() { "maximum_retries" }
+    else if code == MAX_QUEUE_DELAY() { "maximum_queue_delay" }
+    else if code == MAX_RESOURCE_WAITS() { "maximum_resource_waits" }
+    else if code == MIN_EFFICIENCY() { "minimum_efficiency" }
+    else if code == MIN_CACHE_RATE() { "minimum_cache_rate" }
+    else if code == MAX_RESOURCE_VIOLATIONS() { "resource_violations" }
+    else if code == MAX_UNCACHEABLE_LONG_TASKS() { "uncacheable_long_tasks" }
+    else { "unknown" }
+}

--- a/performance/workloads/lattice/policy_suite.rue
+++ b/performance/workloads/lattice/policy_suite.rue
@@ -1,0 +1,40 @@
+// Policy profiles are executable invariants, not just report configuration.
+const model = @import("model.rue");
+const policy = @import("policy.rue");
+const state = @import("state.rue");
+
+pub struct Result {
+    profiles: u64,
+    checks: u64,
+    failures: u64,
+    expected_failures: u64,
+    unexpected_failures: u64,
+    digest: u64,
+    valid: bool,
+}
+
+fn mix(hash: u64, value: u64) -> u64 { @wrapping_mul(hash ^ value, 1099511628211) }
+
+pub fn run(borrow workflow: model.Workflow, borrow execution: state.Run) -> Result {
+    let permissive_profile = policy.permissive();
+    let production_profile = policy.production();
+    let permissive = policy.evaluate(borrow workflow, borrow execution, borrow permissive_profile);
+    let production = policy.evaluate(borrow workflow, borrow execution, borrow production_profile);
+    let mut impossible = policy.permissive();
+    impossible.maximum_makespan = 0;
+    impossible.maximum_retries = 0;
+    impossible.minimum_efficiency_millis = 1001;
+    let negative = policy.evaluate(borrow workflow, borrow execution, borrow impossible);
+    let expected_failures = if execution.makespan > 0 { 1 } else { 0 } +
+        if execution.retries > 0 { 1 } else { 0 } + 1;
+    let unexpected_failures = permissive.failures + production.failures +
+        if negative.failures == expected_failures { 0 } else { 1 };
+    let mut digest = mix(permissive.digest, production.digest);
+    digest = mix(digest, negative.digest); digest = mix(digest, expected_failures);
+    Result {
+        profiles: 3, checks: permissive.checks + production.checks + negative.checks,
+        failures: permissive.failures + production.failures + negative.failures,
+        expected_failures: expected_failures, unexpected_failures: unexpected_failures,
+        digest: digest, valid: unexpected_failures == 0,
+    }
+}

--- a/performance/workloads/lattice/pool.rue
+++ b/performance/workloads/lattice/pool.rue
@@ -1,0 +1,113 @@
+// Stable pooled strings for Lattice. Workflow records carry integer ids so
+// graph, scheduler, replay, and reporting passes can revisit POD arenas.
+const std = @import("std");
+const StrBuf = std.strbuf.StrBuf;
+const U64s = std.arraybuf.ArrayBuf(u64);
+const U64Map = std.strmap.StrMap(u64);
+const OptU8 = std.option.Option(u8);
+const OptU64 = std.option.Option(u64);
+
+pub struct Pool {
+    bytes: StrBuf,
+    offsets: U64s,
+    lengths: U64s,
+    index: U64Map,
+
+    fn new() -> Self {
+        Self {
+            bytes: StrBuf.new(),
+            offsets: U64s.new(),
+            lengths: U64s.new(),
+            index: U64Map.new(0),
+        }
+    }
+
+    fn byte_of(borrow value: StrBuf, index: u64) -> u8 {
+        match value.byte_at(index) {
+            OptU8.Some(byte) => byte,
+            OptU8.None => 0,
+        }
+    }
+
+    fn len(borrow self) -> u64 { self.offsets.len() }
+
+    fn string_len(borrow self, id: u64) -> u64 {
+        self.lengths.get_or(id, 0)
+    }
+
+    fn byte_at(borrow self, id: u64, index: u64) -> u8 {
+        if id >= self.len() || index >= self.string_len(id) { return 0; }
+        Self.byte_of(borrow self.bytes, self.offsets.get_or(id, 0) + index)
+    }
+
+    fn equals(borrow self, id: u64, borrow value: StrBuf) -> bool {
+        if self.string_len(id) != value.len() { return false; }
+        let mut i: u64 = 0;
+        while i < value.len() {
+            if self.byte_at(id, i) != Self.byte_of(borrow value, i) { return false; }
+            i += 1;
+        }
+        true
+    }
+
+    fn ids_equal(borrow self, first: u64, second: u64) -> bool {
+        if self.string_len(first) != self.string_len(second) { return false; }
+        let mut i: u64 = 0;
+        while i < self.string_len(first) {
+            if self.byte_at(first, i) != self.byte_at(second, i) { return false; }
+            i += 1;
+        }
+        true
+    }
+
+    fn find(borrow self, borrow value: StrBuf) -> u64 {
+        match self.index.get(borrow value) {
+            OptU64.Some(id) => id,
+            OptU64.None => 18446744073709551615,
+        }
+    }
+
+    fn intern(inout self, borrow value: StrBuf) -> u64 {
+        let found = self.find(borrow value);
+        if found != 18446744073709551615 { return found; }
+        let id = self.len();
+        self.index.insert(borrow value, id);
+        self.offsets.push(self.bytes.len());
+        self.lengths.push(value.len());
+        let mut i: u64 = 0;
+        while i < value.len() {
+            self.bytes.push(Self.byte_of(borrow value, i));
+            i += 1;
+        }
+        id
+    }
+
+    fn intern_literal(inout self, value: StrBuf) -> u64 {
+        self.intern(borrow value)
+    }
+
+    fn append(borrow self, id: u64, inout out: StrBuf) {
+        let mut i: u64 = 0;
+        while i < self.string_len(id) {
+            out.push(self.byte_at(id, i));
+            i += 1;
+        }
+    }
+
+    fn copy(borrow self, id: u64) -> StrBuf {
+        let mut out = StrBuf.with_capacity(self.string_len(id));
+        self.append(id, inout out);
+        out
+    }
+
+    fn hash(borrow self, id: u64) -> u64 {
+        let mut value: u64 = 14695981039346656037;
+        let mut i: u64 = 0;
+        while i < self.string_len(id) {
+            value ^= @intCast(self.byte_at(id, i));
+            value = @wrapping_mul(value, 1099511628211);
+            i += 1;
+        }
+        value
+    }
+}

--- a/performance/workloads/lattice/pool_analysis.rue
+++ b/performance/workloads/lattice/pool_analysis.rue
@@ -1,0 +1,121 @@
+// Assignment balance, declared work, and saturation pressure per worker pool.
+const model = @import("model.rue");
+const resource_audit = @import("resource_audit.rue");
+const state = @import("state.rue");
+
+pub struct Analysis {
+    assigned_tasks: model.U64s,
+    declared_work: model.U64s,
+    cpu_ticks: model.U64s,
+    memory_ticks: model.U64s,
+    starts: model.U64s,
+    completed: model.U64s,
+    failed: model.U64s,
+    peak_slots: model.U64s,
+    peak_cpu: model.U64s,
+    peak_memory: model.U64s,
+    slot_pressure: model.U64s,
+    cpu_pressure: model.U64s,
+    memory_pressure: model.U64s,
+    busiest_pool: u64,
+    most_constrained_pool: u64,
+    cross_pool_edges: u64,
+    same_pool_edges: u64,
+    digest: u64,
+    valid: bool,
+}
+
+fn zeroes(count: u64) -> model.U64s {
+    let mut values = model.U64s.with_capacity(count);
+    let mut i: u64 = 0;
+    while i < count { values.push(0); i += 1; }
+    values
+}
+
+fn add(inout values: model.U64s, index: u64, amount: u64) {
+    if index < values.len() { values.set(index, values.get_or(index, 0) + amount); }
+}
+
+fn ratio(numerator: u64, denominator: u64) -> u64 {
+    if denominator == 0 { 0 } else { (numerator * 1000) / denominator }
+}
+
+fn mix(hash: u64, value: u64) -> u64 { @wrapping_mul(hash ^ value, 1099511628211) }
+
+pub fn compute(borrow workflow: model.Workflow, borrow run: state.Run) -> Analysis {
+    let count = workflow.pools.len();
+    let mut assigned_tasks = zeroes(count);
+    let mut declared_work = zeroes(count);
+    let mut cpu_ticks = zeroes(count);
+    let mut memory_ticks = zeroes(count);
+    let mut starts = zeroes(count);
+    let mut completed = zeroes(count);
+    let mut failed = zeroes(count);
+    let audit = resource_audit.audit(borrow workflow, borrow run);
+    let mut i: u64 = 0;
+    while i < workflow.tasks.len() {
+        let task = workflow.tasks.get_or(i, model.empty_task());
+        add(inout assigned_tasks, task.pool, 1);
+        add(inout declared_work, task.pool, task.duration);
+        add(inout cpu_ticks, task.pool, task.duration * task.cpu);
+        add(inout memory_ticks, task.pool, task.duration * task.memory);
+        i += 1;
+    }
+    i = 0;
+    while i < run.events.len() {
+        let event = run.events.get_or(i, state.empty_event());
+        if event.kind == state.EVENT_START() { add(inout starts, event.pool, 1); }
+        else if event.kind == state.EVENT_SUCCESS() { add(inout completed, event.pool, 1); }
+        else if event.kind == state.EVENT_FAILURE() { add(inout failed, event.pool, 1); }
+        i += 1;
+    }
+    let mut slot_pressure = zeroes(count);
+    let mut cpu_pressure = zeroes(count);
+    let mut memory_pressure = zeroes(count);
+    let mut busiest_pool = model.NONE();
+    let mut most_constrained_pool = model.NONE();
+    let mut maximum_work: u64 = 0;
+    let mut maximum_pressure: u64 = 0;
+    let mut digest: u64 = 14695981039346656037;
+    i = 0;
+    while i < count {
+        let pool = workflow.pools.get_or(i, model.empty_pool());
+        let slot_value = ratio(audit.maximum_slots.get_or(i, 0), pool.slots);
+        let cpu_value = ratio(audit.maximum_cpu.get_or(i, 0), pool.cpu);
+        let memory_value = ratio(audit.maximum_memory.get_or(i, 0), pool.memory);
+        slot_pressure.set(i, slot_value); cpu_pressure.set(i, cpu_value); memory_pressure.set(i, memory_value);
+        let pressure = if slot_value > cpu_value { if slot_value > memory_value { slot_value } else { memory_value } }
+            else { if cpu_value > memory_value { cpu_value } else { memory_value } };
+        if busiest_pool == model.NONE() || declared_work.get_or(i, 0) > maximum_work {
+            busiest_pool = i; maximum_work = declared_work.get_or(i, 0);
+        }
+        if most_constrained_pool == model.NONE() || pressure > maximum_pressure {
+            most_constrained_pool = i; maximum_pressure = pressure;
+        }
+        digest = mix(digest, assigned_tasks.get_or(i, 0)); digest = mix(digest, declared_work.get_or(i, 0));
+        digest = mix(digest, slot_value); digest = mix(digest, cpu_value); digest = mix(digest, memory_value);
+        i += 1;
+    }
+    let mut cross_pool_edges: u64 = 0;
+    let mut same_pool_edges: u64 = 0;
+    i = 0;
+    while i < workflow.edges.len() {
+        let edge = workflow.edges.get_or(i, model.empty_edge());
+        let before = workflow.tasks.get_or(edge.before, model.empty_task());
+        let after = workflow.tasks.get_or(edge.after, model.empty_task());
+        if before.pool == after.pool { same_pool_edges += 1; }
+        else { cross_pool_edges += 1; }
+        i += 1;
+    }
+    Analysis {
+        assigned_tasks: assigned_tasks, declared_work: declared_work,
+        cpu_ticks: cpu_ticks, memory_ticks: memory_ticks, starts: starts,
+        completed: completed, failed: failed,
+        peak_slots: audit.maximum_slots, peak_cpu: audit.maximum_cpu,
+        peak_memory: audit.maximum_memory, slot_pressure: slot_pressure,
+        cpu_pressure: cpu_pressure, memory_pressure: memory_pressure,
+        busiest_pool: busiest_pool, most_constrained_pool: most_constrained_pool,
+        cross_pool_edges: cross_pool_edges, same_pool_edges: same_pool_edges,
+        digest: digest, valid: audit.ok && cross_pool_edges + same_pool_edges == workflow.edges.len(),
+    }
+}

--- a/performance/workloads/lattice/portfolio.rue
+++ b/performance/workloads/lattice/portfolio.rue
@@ -1,0 +1,228 @@
+// Aggregate every independent Lattice analysis pass into one deterministic portfolio.
+const metric = @import("metric.rue");
+const model = @import("model.rue");
+const duration_profile = @import("analysis_duration_profile.rue");
+const cpu_work = @import("analysis_cpu_work.rue");
+const memory_work = @import("analysis_memory_work.rue");
+const priority_pressure = @import("analysis_priority_pressure.rue");
+const retry_exposure = @import("analysis_retry_exposure.rue");
+const cache_coverage = @import("analysis_cache_coverage.rue");
+const pool_affinity = @import("analysis_pool_affinity.rue");
+const fanin_weight = @import("analysis_fanin_weight.rue");
+const fanout_weight = @import("analysis_fanout_weight.rue");
+const dependency_distance = @import("analysis_dependency_distance.rue");
+const criticality_proxy = @import("analysis_criticality_proxy.rue");
+const root_cost = @import("analysis_root_cost.rue");
+const leaf_cost = @import("analysis_leaf_cost.rue");
+const resource_product = @import("analysis_resource_product.rue");
+const slot_demand = @import("analysis_slot_demand.rue");
+const pool_cpu_share = @import("analysis_pool_cpu_share.rue");
+const pool_memory_share = @import("analysis_pool_memory_share.rue");
+const parallelism_pressure = @import("analysis_parallelism_pressure.rue");
+const contention_index = @import("analysis_contention_index.rue");
+const queue_priority = @import("analysis_queue_priority.rue");
+const failure_exposure = @import("analysis_failure_exposure.rue");
+const cache_risk = @import("analysis_cache_risk.rue");
+const dependency_density = @import("analysis_dependency_density.rue");
+const layer_proxy = @import("analysis_layer_proxy.rue");
+const path_branching = @import("analysis_path_branching.rue");
+const path_merging = @import("analysis_path_merging.rue");
+const cross_pool_edges = @import("analysis_cross_pool_edges.rue");
+const same_pool_edges = @import("analysis_same_pool_edges.rue");
+const long_edges = @import("analysis_long_edges.rue");
+const short_edges = @import("analysis_short_edges.rue");
+const high_priority_work = @import("analysis_high_priority_work.rue");
+const low_priority_work = @import("analysis_low_priority_work.rue");
+const retry_work = @import("analysis_retry_work.rue");
+const deterministic_keys = @import("analysis_deterministic_keys.rue");
+const graph_locality = @import("analysis_graph_locality.rue");
+const schedule_weight = @import("analysis_schedule_weight.rue");
+const resource_balance = @import("analysis_resource_balance.rue");
+const pool_skew = @import("analysis_pool_skew.rue");
+const duration_variance_proxy = @import("analysis_duration_variance_proxy.rue");
+const cpu_variance_proxy = @import("analysis_cpu_variance_proxy.rue");
+const memory_variance_proxy = @import("analysis_memory_variance_proxy.rue");
+const priority_variance_proxy = @import("analysis_priority_variance_proxy.rue");
+const edge_work = @import("analysis_edge_work.rue");
+const successor_load = @import("analysis_successor_load.rue");
+const predecessor_load = @import("analysis_predecessor_load.rue");
+const cacheable_work = @import("analysis_cacheable_work.rue");
+const uncached_work = @import("analysis_uncached_work.rue");
+const failure_recovery = @import("analysis_failure_recovery.rue");
+
+pub struct Summary {
+    passes: u64,
+    observations: u64,
+    warnings: u64,
+    verification_failures: u64,
+    sum: u64,
+    weighted: u64,
+    digest: u64,
+}
+
+fn record(inout summary: Summary, value: metric.Metric, verified: bool) {
+    summary.passes += 1;
+    summary.observations = metric.add(summary.observations, value.observations);
+    summary.warnings = metric.add(summary.warnings, value.warnings);
+    summary.sum = metric.add(summary.sum, value.sum);
+    summary.weighted = metric.add(summary.weighted, value.weighted);
+    summary.digest = metric.mix(summary.digest, value.tag);
+    summary.digest = metric.mix(summary.digest, value.digest);
+    if !verified { summary.verification_failures += 1; }
+}
+
+pub fn analyze(borrow workflow: model.Workflow) -> Summary {
+    let mut result = Summary {
+        passes: 0, observations: 0, warnings: 0, verification_failures: 0,
+        sum: 0, weighted: 0, digest: 14695981039346656037,
+    };
+    let duration_profile_metric = duration_profile.analyze(borrow workflow);
+    let duration_profile_verified = duration_profile.verify(borrow workflow, borrow duration_profile_metric);
+    record(inout result, duration_profile_metric, duration_profile_verified);
+    let cpu_work_metric = cpu_work.analyze(borrow workflow);
+    let cpu_work_verified = cpu_work.verify(borrow workflow, borrow cpu_work_metric);
+    record(inout result, cpu_work_metric, cpu_work_verified);
+    let memory_work_metric = memory_work.analyze(borrow workflow);
+    let memory_work_verified = memory_work.verify(borrow workflow, borrow memory_work_metric);
+    record(inout result, memory_work_metric, memory_work_verified);
+    let priority_pressure_metric = priority_pressure.analyze(borrow workflow);
+    let priority_pressure_verified = priority_pressure.verify(borrow workflow, borrow priority_pressure_metric);
+    record(inout result, priority_pressure_metric, priority_pressure_verified);
+    let retry_exposure_metric = retry_exposure.analyze(borrow workflow);
+    let retry_exposure_verified = retry_exposure.verify(borrow workflow, borrow retry_exposure_metric);
+    record(inout result, retry_exposure_metric, retry_exposure_verified);
+    let cache_coverage_metric = cache_coverage.analyze(borrow workflow);
+    let cache_coverage_verified = cache_coverage.verify(borrow workflow, borrow cache_coverage_metric);
+    record(inout result, cache_coverage_metric, cache_coverage_verified);
+    let pool_affinity_metric = pool_affinity.analyze(borrow workflow);
+    let pool_affinity_verified = pool_affinity.verify(borrow workflow, borrow pool_affinity_metric);
+    record(inout result, pool_affinity_metric, pool_affinity_verified);
+    let fanin_weight_metric = fanin_weight.analyze(borrow workflow);
+    let fanin_weight_verified = fanin_weight.verify(borrow workflow, borrow fanin_weight_metric);
+    record(inout result, fanin_weight_metric, fanin_weight_verified);
+    let fanout_weight_metric = fanout_weight.analyze(borrow workflow);
+    let fanout_weight_verified = fanout_weight.verify(borrow workflow, borrow fanout_weight_metric);
+    record(inout result, fanout_weight_metric, fanout_weight_verified);
+    let dependency_distance_metric = dependency_distance.analyze(borrow workflow);
+    let dependency_distance_verified = dependency_distance.verify(borrow workflow, borrow dependency_distance_metric);
+    record(inout result, dependency_distance_metric, dependency_distance_verified);
+    let criticality_proxy_metric = criticality_proxy.analyze(borrow workflow);
+    let criticality_proxy_verified = criticality_proxy.verify(borrow workflow, borrow criticality_proxy_metric);
+    record(inout result, criticality_proxy_metric, criticality_proxy_verified);
+    let root_cost_metric = root_cost.analyze(borrow workflow);
+    let root_cost_verified = root_cost.verify(borrow workflow, borrow root_cost_metric);
+    record(inout result, root_cost_metric, root_cost_verified);
+    let leaf_cost_metric = leaf_cost.analyze(borrow workflow);
+    let leaf_cost_verified = leaf_cost.verify(borrow workflow, borrow leaf_cost_metric);
+    record(inout result, leaf_cost_metric, leaf_cost_verified);
+    let resource_product_metric = resource_product.analyze(borrow workflow);
+    let resource_product_verified = resource_product.verify(borrow workflow, borrow resource_product_metric);
+    record(inout result, resource_product_metric, resource_product_verified);
+    let slot_demand_metric = slot_demand.analyze(borrow workflow);
+    let slot_demand_verified = slot_demand.verify(borrow workflow, borrow slot_demand_metric);
+    record(inout result, slot_demand_metric, slot_demand_verified);
+    let pool_cpu_share_metric = pool_cpu_share.analyze(borrow workflow);
+    let pool_cpu_share_verified = pool_cpu_share.verify(borrow workflow, borrow pool_cpu_share_metric);
+    record(inout result, pool_cpu_share_metric, pool_cpu_share_verified);
+    let pool_memory_share_metric = pool_memory_share.analyze(borrow workflow);
+    let pool_memory_share_verified = pool_memory_share.verify(borrow workflow, borrow pool_memory_share_metric);
+    record(inout result, pool_memory_share_metric, pool_memory_share_verified);
+    let parallelism_pressure_metric = parallelism_pressure.analyze(borrow workflow);
+    let parallelism_pressure_verified = parallelism_pressure.verify(borrow workflow, borrow parallelism_pressure_metric);
+    record(inout result, parallelism_pressure_metric, parallelism_pressure_verified);
+    let contention_index_metric = contention_index.analyze(borrow workflow);
+    let contention_index_verified = contention_index.verify(borrow workflow, borrow contention_index_metric);
+    record(inout result, contention_index_metric, contention_index_verified);
+    let queue_priority_metric = queue_priority.analyze(borrow workflow);
+    let queue_priority_verified = queue_priority.verify(borrow workflow, borrow queue_priority_metric);
+    record(inout result, queue_priority_metric, queue_priority_verified);
+    let failure_exposure_metric = failure_exposure.analyze(borrow workflow);
+    let failure_exposure_verified = failure_exposure.verify(borrow workflow, borrow failure_exposure_metric);
+    record(inout result, failure_exposure_metric, failure_exposure_verified);
+    let cache_risk_metric = cache_risk.analyze(borrow workflow);
+    let cache_risk_verified = cache_risk.verify(borrow workflow, borrow cache_risk_metric);
+    record(inout result, cache_risk_metric, cache_risk_verified);
+    let dependency_density_metric = dependency_density.analyze(borrow workflow);
+    let dependency_density_verified = dependency_density.verify(borrow workflow, borrow dependency_density_metric);
+    record(inout result, dependency_density_metric, dependency_density_verified);
+    let layer_proxy_metric = layer_proxy.analyze(borrow workflow);
+    let layer_proxy_verified = layer_proxy.verify(borrow workflow, borrow layer_proxy_metric);
+    record(inout result, layer_proxy_metric, layer_proxy_verified);
+    let path_branching_metric = path_branching.analyze(borrow workflow);
+    let path_branching_verified = path_branching.verify(borrow workflow, borrow path_branching_metric);
+    record(inout result, path_branching_metric, path_branching_verified);
+    let path_merging_metric = path_merging.analyze(borrow workflow);
+    let path_merging_verified = path_merging.verify(borrow workflow, borrow path_merging_metric);
+    record(inout result, path_merging_metric, path_merging_verified);
+    let cross_pool_edges_metric = cross_pool_edges.analyze(borrow workflow);
+    let cross_pool_edges_verified = cross_pool_edges.verify(borrow workflow, borrow cross_pool_edges_metric);
+    record(inout result, cross_pool_edges_metric, cross_pool_edges_verified);
+    let same_pool_edges_metric = same_pool_edges.analyze(borrow workflow);
+    let same_pool_edges_verified = same_pool_edges.verify(borrow workflow, borrow same_pool_edges_metric);
+    record(inout result, same_pool_edges_metric, same_pool_edges_verified);
+    let long_edges_metric = long_edges.analyze(borrow workflow);
+    let long_edges_verified = long_edges.verify(borrow workflow, borrow long_edges_metric);
+    record(inout result, long_edges_metric, long_edges_verified);
+    let short_edges_metric = short_edges.analyze(borrow workflow);
+    let short_edges_verified = short_edges.verify(borrow workflow, borrow short_edges_metric);
+    record(inout result, short_edges_metric, short_edges_verified);
+    let high_priority_work_metric = high_priority_work.analyze(borrow workflow);
+    let high_priority_work_verified = high_priority_work.verify(borrow workflow, borrow high_priority_work_metric);
+    record(inout result, high_priority_work_metric, high_priority_work_verified);
+    let low_priority_work_metric = low_priority_work.analyze(borrow workflow);
+    let low_priority_work_verified = low_priority_work.verify(borrow workflow, borrow low_priority_work_metric);
+    record(inout result, low_priority_work_metric, low_priority_work_verified);
+    let retry_work_metric = retry_work.analyze(borrow workflow);
+    let retry_work_verified = retry_work.verify(borrow workflow, borrow retry_work_metric);
+    record(inout result, retry_work_metric, retry_work_verified);
+    let deterministic_keys_metric = deterministic_keys.analyze(borrow workflow);
+    let deterministic_keys_verified = deterministic_keys.verify(borrow workflow, borrow deterministic_keys_metric);
+    record(inout result, deterministic_keys_metric, deterministic_keys_verified);
+    let graph_locality_metric = graph_locality.analyze(borrow workflow);
+    let graph_locality_verified = graph_locality.verify(borrow workflow, borrow graph_locality_metric);
+    record(inout result, graph_locality_metric, graph_locality_verified);
+    let schedule_weight_metric = schedule_weight.analyze(borrow workflow);
+    let schedule_weight_verified = schedule_weight.verify(borrow workflow, borrow schedule_weight_metric);
+    record(inout result, schedule_weight_metric, schedule_weight_verified);
+    let resource_balance_metric = resource_balance.analyze(borrow workflow);
+    let resource_balance_verified = resource_balance.verify(borrow workflow, borrow resource_balance_metric);
+    record(inout result, resource_balance_metric, resource_balance_verified);
+    let pool_skew_metric = pool_skew.analyze(borrow workflow);
+    let pool_skew_verified = pool_skew.verify(borrow workflow, borrow pool_skew_metric);
+    record(inout result, pool_skew_metric, pool_skew_verified);
+    let duration_variance_proxy_metric = duration_variance_proxy.analyze(borrow workflow);
+    let duration_variance_proxy_verified = duration_variance_proxy.verify(borrow workflow, borrow duration_variance_proxy_metric);
+    record(inout result, duration_variance_proxy_metric, duration_variance_proxy_verified);
+    let cpu_variance_proxy_metric = cpu_variance_proxy.analyze(borrow workflow);
+    let cpu_variance_proxy_verified = cpu_variance_proxy.verify(borrow workflow, borrow cpu_variance_proxy_metric);
+    record(inout result, cpu_variance_proxy_metric, cpu_variance_proxy_verified);
+    let memory_variance_proxy_metric = memory_variance_proxy.analyze(borrow workflow);
+    let memory_variance_proxy_verified = memory_variance_proxy.verify(borrow workflow, borrow memory_variance_proxy_metric);
+    record(inout result, memory_variance_proxy_metric, memory_variance_proxy_verified);
+    let priority_variance_proxy_metric = priority_variance_proxy.analyze(borrow workflow);
+    let priority_variance_proxy_verified = priority_variance_proxy.verify(borrow workflow, borrow priority_variance_proxy_metric);
+    record(inout result, priority_variance_proxy_metric, priority_variance_proxy_verified);
+    let edge_work_metric = edge_work.analyze(borrow workflow);
+    let edge_work_verified = edge_work.verify(borrow workflow, borrow edge_work_metric);
+    record(inout result, edge_work_metric, edge_work_verified);
+    let successor_load_metric = successor_load.analyze(borrow workflow);
+    let successor_load_verified = successor_load.verify(borrow workflow, borrow successor_load_metric);
+    record(inout result, successor_load_metric, successor_load_verified);
+    let predecessor_load_metric = predecessor_load.analyze(borrow workflow);
+    let predecessor_load_verified = predecessor_load.verify(borrow workflow, borrow predecessor_load_metric);
+    record(inout result, predecessor_load_metric, predecessor_load_verified);
+    let cacheable_work_metric = cacheable_work.analyze(borrow workflow);
+    let cacheable_work_verified = cacheable_work.verify(borrow workflow, borrow cacheable_work_metric);
+    record(inout result, cacheable_work_metric, cacheable_work_verified);
+    let uncached_work_metric = uncached_work.analyze(borrow workflow);
+    let uncached_work_verified = uncached_work.verify(borrow workflow, borrow uncached_work_metric);
+    record(inout result, uncached_work_metric, uncached_work_verified);
+    let failure_recovery_metric = failure_recovery.analyze(borrow workflow);
+    let failure_recovery_verified = failure_recovery.verify(borrow workflow, borrow failure_recovery_metric);
+    record(inout result, failure_recovery_metric, failure_recovery_verified);
+    result
+}
+
+pub fn valid(borrow result: Summary) -> bool {
+    result.passes == 48 && result.verification_failures == 0 && result.observations > 0
+}

--- a/performance/workloads/lattice/priority_analysis.rue
+++ b/performance/workloads/lattice/priority_analysis.rue
@@ -1,0 +1,81 @@
+// Priority distribution and dependency inversions.
+const model = @import("model.rue");
+const state = @import("state.rue");
+
+pub struct Analysis {
+    buckets: model.U64s,
+    edge_inversions: u64,
+    edge_ties: u64,
+    edge_descents: u64,
+    start_inversions: u64,
+    highest_priority: u64,
+    lowest_priority: u64,
+    highest_priority_task: u64,
+    lowest_priority_task: u64,
+    weighted_wait: u64,
+    digest: u64,
+    valid: bool,
+}
+
+fn zeroes(count: u64) -> model.U64s {
+    let mut values = model.U64s.with_capacity(count);
+    let mut i: u64 = 0;
+    while i < count { values.push(0); i += 1; }
+    values
+}
+
+fn mix(hash: u64, value: u64) -> u64 { @wrapping_mul(hash ^ value, 1099511628211) }
+
+pub fn compute(borrow workflow: model.Workflow, borrow run: state.Run) -> Analysis {
+    let mut buckets = zeroes(5);
+    let mut highest_priority: u64 = 0;
+    let mut lowest_priority: u64 = 0;
+    let mut highest_priority_task = model.NONE();
+    let mut lowest_priority_task = model.NONE();
+    let mut weighted_wait: u64 = 0;
+    let mut digest: u64 = 14695981039346656037;
+    let mut i: u64 = 0;
+    while i < workflow.tasks.len() {
+        let task = workflow.tasks.get_or(i, model.empty_task());
+        let bucket = if task.priority == 0 { 0 } else if task.priority <= 5 { 1 }
+            else if task.priority <= 10 { 2 } else if task.priority <= 15 { 3 } else { 4 };
+        buckets.set(bucket, buckets.get_or(bucket, 0) + 1);
+        if highest_priority_task == model.NONE() || task.priority > highest_priority {
+            highest_priority = task.priority; highest_priority_task = i;
+        }
+        if lowest_priority_task == model.NONE() || task.priority < lowest_priority {
+            lowest_priority = task.priority; lowest_priority_task = i;
+        }
+        let start = run.starts.get_or(i, 0);
+        if start != model.NONE() { weighted_wait += start * (task.priority + 1); }
+        digest = mix(digest, task.priority); digest = mix(digest, start);
+        i += 1;
+    }
+    let mut edge_inversions: u64 = 0;
+    let mut edge_ties: u64 = 0;
+    let mut edge_descents: u64 = 0;
+    let mut start_inversions: u64 = 0;
+    i = 0;
+    while i < workflow.edges.len() {
+        let edge = workflow.edges.get_or(i, model.empty_edge());
+        let before = workflow.tasks.get_or(edge.before, model.empty_task());
+        let after = workflow.tasks.get_or(edge.after, model.empty_task());
+        if before.priority < after.priority { edge_inversions += 1; }
+        else if before.priority == after.priority { edge_ties += 1; }
+        else { edge_descents += 1; }
+        let before_start = run.starts.get_or(edge.before, model.NONE());
+        let after_start = run.starts.get_or(edge.after, model.NONE());
+        if before.priority < after.priority && before_start != model.NONE() && after_start != model.NONE() &&
+            before_start < after_start { start_inversions += 1; }
+        digest = mix(digest, edge.before); digest = mix(digest, edge.after);
+        i += 1;
+    }
+    Analysis {
+        buckets: buckets, edge_inversions: edge_inversions, edge_ties: edge_ties,
+        edge_descents: edge_descents, start_inversions: start_inversions,
+        highest_priority: highest_priority, lowest_priority: lowest_priority,
+        highest_priority_task: highest_priority_task, lowest_priority_task: lowest_priority_task,
+        weighted_wait: weighted_wait, digest: digest,
+        valid: edge_inversions + edge_ties + edge_descents == workflow.edges.len(),
+    }
+}

--- a/performance/workloads/lattice/query.rue
+++ b/performance/workloads/lattice/query.rue
@@ -1,0 +1,168 @@
+// In-memory task query engine used by reports and policy checks.
+const model = @import("model.rue");
+const state = @import("state.rue");
+
+pub fn ANY() -> u64 { 0 }
+pub fn REQUIRE() -> u64 { 1 }
+pub fn EXCLUDE() -> u64 { 2 }
+
+pub struct Query {
+    pool: u64,
+    minimum_duration: u64,
+    maximum_duration: u64,
+    minimum_priority: u64,
+    maximum_priority: u64,
+    minimum_cpu: u64,
+    maximum_cpu: u64,
+    minimum_memory: u64,
+    maximum_memory: u64,
+    status: u64,
+    cacheable: u64,
+    fallible: u64,
+    roots: u64,
+    leaves: u64,
+}
+
+pub struct Result {
+    tasks: model.U64s,
+    matches: u64,
+    total_duration: u64,
+    total_cpu_ticks: u64,
+    total_memory_ticks: u64,
+    total_priority: u64,
+    maximum_duration: u64,
+    maximum_duration_task: u64,
+    maximum_priority: u64,
+    maximum_priority_task: u64,
+    digest: u64,
+    valid: bool,
+}
+
+pub fn all() -> Query {
+    Query {
+        pool: model.NONE(), minimum_duration: 0, maximum_duration: model.NONE(),
+        minimum_priority: 0, maximum_priority: model.NONE(),
+        minimum_cpu: 0, maximum_cpu: model.NONE(),
+        minimum_memory: 0, maximum_memory: model.NONE(),
+        status: model.NONE(), cacheable: ANY(), fallible: ANY(),
+        roots: ANY(), leaves: ANY(),
+    }
+}
+
+fn flag(value: bool, requirement: u64) -> bool {
+    requirement == ANY() || (requirement == REQUIRE() && value) ||
+        (requirement == EXCLUDE() && !value)
+}
+
+fn between(value: u64, minimum: u64, maximum: u64) -> bool {
+    value >= minimum && (maximum == model.NONE() || value <= maximum)
+}
+
+fn matches(
+    borrow workflow: model.Workflow,
+    borrow run: state.Run,
+    borrow query: Query,
+    index: u64,
+) -> bool {
+    let task = workflow.tasks.get_or(index, model.empty_task());
+    if query.pool != model.NONE() && task.pool != query.pool { return false; }
+    if !between(task.duration, query.minimum_duration, query.maximum_duration) { return false; }
+    if !between(task.priority, query.minimum_priority, query.maximum_priority) { return false; }
+    if !between(task.cpu, query.minimum_cpu, query.maximum_cpu) { return false; }
+    if !between(task.memory, query.minimum_memory, query.maximum_memory) { return false; }
+    if query.status != model.NONE() && run.status.get_or(index, state.FAILED()) != query.status { return false; }
+    if !flag(task.cacheable, query.cacheable) { return false; }
+    if !flag(task.fail_attempt > 0, query.fallible) { return false; }
+    if !flag(model.dependency_count(borrow workflow, index) == 0, query.roots) { return false; }
+    if !flag(model.dependent_count(borrow workflow, index) == 0, query.leaves) { return false; }
+    true
+}
+
+fn higher_priority(borrow workflow: model.Workflow, left: u64, right: u64) -> bool {
+    let first = workflow.tasks.get_or(left, model.empty_task());
+    let second = workflow.tasks.get_or(right, model.empty_task());
+    first.priority > second.priority || (first.priority == second.priority &&
+        (first.duration > second.duration || (first.duration == second.duration && left < right)))
+}
+
+fn sort(inout tasks: model.U64s, borrow workflow: model.Workflow) {
+    let mut position: u64 = 0;
+    while position < tasks.len() {
+        let mut best = position;
+        let mut candidate = position + 1;
+        while candidate < tasks.len() {
+            if higher_priority(
+                borrow workflow,
+                tasks.get_or(candidate, model.NONE()),
+                tasks.get_or(best, model.NONE()),
+            ) { best = candidate; }
+            candidate += 1;
+        }
+        if best != position {
+            let old = tasks.get_or(position, model.NONE());
+            tasks.set(position, tasks.get_or(best, model.NONE()));
+            tasks.set(best, old);
+        }
+        position += 1;
+    }
+}
+
+fn mix(hash: u64, value: u64) -> u64 { @wrapping_mul(hash ^ value, 1099511628211) }
+
+pub fn execute(borrow workflow: model.Workflow, borrow run: state.Run, borrow query: Query) -> Result {
+    let mut tasks = model.U64s.new();
+    let mut total_duration: u64 = 0;
+    let mut total_cpu_ticks: u64 = 0;
+    let mut total_memory_ticks: u64 = 0;
+    let mut total_priority: u64 = 0;
+    let mut maximum_duration: u64 = 0;
+    let mut maximum_duration_task = model.NONE();
+    let mut maximum_priority: u64 = 0;
+    let mut maximum_priority_task = model.NONE();
+    let mut i: u64 = 0;
+    while i < workflow.tasks.len() {
+        if matches(borrow workflow, borrow run, borrow query, i) {
+            let task = workflow.tasks.get_or(i, model.empty_task());
+            tasks.push(i);
+            total_duration += task.duration;
+            total_cpu_ticks += task.duration * task.cpu;
+            total_memory_ticks += task.duration * task.memory;
+            total_priority += task.priority;
+            if maximum_duration_task == model.NONE() || task.duration > maximum_duration {
+                maximum_duration = task.duration; maximum_duration_task = i;
+            }
+            if maximum_priority_task == model.NONE() || task.priority > maximum_priority {
+                maximum_priority = task.priority; maximum_priority_task = i;
+            }
+        }
+        i += 1;
+    }
+    sort(inout tasks, borrow workflow);
+    let mut digest: u64 = 14695981039346656037;
+    i = 0;
+    while i < tasks.len() { digest = mix(digest, tasks.get_or(i, model.NONE())); i += 1; }
+    let count = tasks.len();
+    Result {
+        tasks: tasks, matches: count, total_duration: total_duration,
+        total_cpu_ticks: total_cpu_ticks, total_memory_ticks: total_memory_ticks,
+        total_priority: total_priority, maximum_duration: maximum_duration,
+        maximum_duration_task: maximum_duration_task, maximum_priority: maximum_priority,
+        maximum_priority_task: maximum_priority_task, digest: digest,
+        valid: count <= workflow.tasks.len(),
+    }
+}
+
+pub fn high_risk() -> Query {
+    let mut query = all();
+    query.minimum_duration = 5;
+    query.minimum_priority = 10;
+    query.fallible = REQUIRE();
+    query
+}
+
+pub fn cache_candidates() -> Query {
+    let mut query = all();
+    query.minimum_duration = 4;
+    query.cacheable = EXCLUDE();
+    query
+}

--- a/performance/workloads/lattice/queue_analysis.rue
+++ b/performance/workloads/lattice/queue_analysis.rue
@@ -1,0 +1,89 @@
+// Derive dependency-ready time and scheduler delay for each executed task.
+const model = @import("model.rue");
+const state = @import("state.rue");
+
+pub struct Analysis {
+    dependency_ready: model.U64s,
+    queue_delay: model.U64s,
+    runtime: model.U64s,
+    total_queue_delay: u64,
+    maximum_queue_delay: u64,
+    maximum_queue_task: u64,
+    zero_delay_tasks: u64,
+    delayed_tasks: u64,
+    unstarted_tasks: u64,
+    timing_mismatches: u64,
+    digest: u64,
+    valid: bool,
+}
+
+fn zeroes(count: u64) -> model.U64s {
+    let mut values = model.U64s.with_capacity(count);
+    let mut i: u64 = 0;
+    while i < count { values.push(0); i += 1; }
+    values
+}
+
+fn ready_time(borrow workflow: model.Workflow, borrow run: state.Run, task: u64) -> u64 {
+    let mut result: u64 = 0;
+    let mut i: u64 = 0;
+    while i < workflow.edges.len() {
+        let edge = workflow.edges.get_or(i, model.empty_edge());
+        if edge.after == task {
+            let finish = run.ends.get_or(edge.before, 0);
+            if finish != model.NONE() && finish > result { result = finish; }
+        }
+        i += 1;
+    }
+    result
+}
+
+fn mix(hash: u64, value: u64) -> u64 { @wrapping_mul(hash ^ value, 1099511628211) }
+
+pub fn compute(borrow workflow: model.Workflow, borrow run: state.Run) -> Analysis {
+    let mut dependency_ready = zeroes(workflow.tasks.len());
+    let mut queue_delay = zeroes(workflow.tasks.len());
+    let mut runtime = zeroes(workflow.tasks.len());
+    let mut total_queue_delay: u64 = 0;
+    let mut maximum_queue_delay: u64 = 0;
+    let mut maximum_queue_task = model.NONE();
+    let mut zero_delay_tasks: u64 = 0;
+    let mut delayed_tasks: u64 = 0;
+    let mut unstarted_tasks: u64 = 0;
+    let mut timing_mismatches: u64 = 0;
+    let mut digest: u64 = 14695981039346656037;
+    let mut i: u64 = 0;
+    while i < workflow.tasks.len() {
+        let ready = ready_time(borrow workflow, borrow run, i);
+        let start = run.starts.get_or(i, model.NONE());
+        let end = run.ends.get_or(i, model.NONE());
+        dependency_ready.set(i, ready);
+        if start == model.NONE() {
+            unstarted_tasks += 1;
+        } else {
+            let delay = if start >= ready { start - ready } else { timing_mismatches += 1; 0 };
+            queue_delay.set(i, delay);
+            total_queue_delay += delay;
+            if delay == 0 { zero_delay_tasks += 1; }
+            else { delayed_tasks += 1; }
+            if maximum_queue_task == model.NONE() || delay > maximum_queue_delay {
+                maximum_queue_delay = delay; maximum_queue_task = i;
+            }
+            if end != model.NONE() {
+                if end >= start { runtime.set(i, end - start); }
+                else { timing_mismatches += 1; }
+            }
+        }
+        digest = mix(digest, ready); digest = mix(digest, start);
+        digest = mix(digest, end); digest = mix(digest, queue_delay.get_or(i, 0));
+        i += 1;
+    }
+    Analysis {
+        dependency_ready: dependency_ready, queue_delay: queue_delay, runtime: runtime,
+        total_queue_delay: total_queue_delay, maximum_queue_delay: maximum_queue_delay,
+        maximum_queue_task: maximum_queue_task, zero_delay_tasks: zero_delay_tasks,
+        delayed_tasks: delayed_tasks, unstarted_tasks: unstarted_tasks,
+        timing_mismatches: timing_mismatches, digest: digest,
+        valid: timing_mismatches == 0 && zero_delay_tasks + delayed_tasks + unstarted_tasks == workflow.tasks.len(),
+    }
+}

--- a/performance/workloads/lattice/replay.rue
+++ b/performance/workloads/lattice/replay.rue
@@ -1,0 +1,89 @@
+// Event-log replay independently reconstructs terminal task states and checks
+// event ordering, attempts, resources, and scheduler summary counts.
+const model = @import("model.rue");
+const state = @import("state.rue");
+
+pub struct Audit {
+    events: u64,
+    ordering_errors: u64,
+    transition_errors: u64,
+    attempt_errors: u64,
+    terminal_mismatches: u64,
+    succeeded: u64,
+    failed: u64,
+    cached: u64,
+    retries: u64,
+    ok: bool,
+}
+
+fn zeros(count: u64) -> model.U64s {
+    let mut out = model.U64s.with_capacity(count);
+    let mut i: u64 = 0;
+    while i < count { out.push(0); i += 1; }
+    out
+}
+
+pub fn audit(borrow workflow: model.Workflow, borrow run: state.Run) -> Audit {
+    let mut status = zeros(workflow.tasks.len());
+    let mut attempts = zeros(workflow.tasks.len());
+    let mut ordering_errors: u64 = 0;
+    let mut transition_errors: u64 = 0;
+    let mut attempt_errors: u64 = 0;
+    let mut succeeded: u64 = 0;
+    let mut failed: u64 = 0;
+    let mut cached: u64 = 0;
+    let mut retries: u64 = 0;
+    let mut previous_time: u64 = 0;
+    let mut i: u64 = 0;
+    while i < run.events.len() {
+        let event = run.events.get_or(i, state.empty_event());
+        if i > 0 && event.time < previous_time { ordering_errors += 1; }
+        previous_time = event.time;
+        if event.task >= workflow.tasks.len() { transition_errors += 1; }
+        else {
+            let old = status.get_or(event.task, 0);
+            if event.kind == state.EVENT_START() {
+                if old != state.PENDING() { transition_errors += 1; }
+                let expected = attempts.get_or(event.task, 0) + 1;
+                if event.attempt != expected { attempt_errors += 1; }
+                attempts.set(event.task, event.attempt);
+                status.set(event.task, state.RUNNING());
+            } else if event.kind == state.EVENT_SUCCESS() {
+                if old != state.RUNNING() { transition_errors += 1; }
+                status.set(event.task, state.SUCCEEDED()); succeeded += 1;
+            } else if event.kind == state.EVENT_FAILURE() {
+                if old != state.RUNNING() { transition_errors += 1; }
+            } else if event.kind == state.EVENT_RETRY() {
+                if old != state.RUNNING() { transition_errors += 1; }
+                status.set(event.task, state.PENDING()); retries += 1;
+            } else if event.kind == state.EVENT_CACHE() {
+                if old != state.PENDING() { transition_errors += 1; }
+                status.set(event.task, state.CACHED()); cached += 1;
+            } else if event.kind == state.EVENT_BLOCKED() {
+                if old != state.PENDING() { transition_errors += 1; }
+                status.set(event.task, state.FAILED()); failed += 1;
+            } else { transition_errors += 1; }
+        }
+        i += 1;
+    }
+    let mut terminal_mismatches: u64 = 0;
+    i = 0;
+    while i < workflow.tasks.len() {
+        let expected = run.status.get_or(i, state.FAILED());
+        let actual = status.get_or(i, state.FAILED());
+        if expected != actual { terminal_mismatches += 1; }
+        if actual == state.FAILED() && expected == state.FAILED() {
+            // A failed task may come from exhaustion rather than BLOCKED.
+            failed += 1;
+        }
+        i += 1;
+    }
+    let ok = ordering_errors == 0 && transition_errors == 0 &&
+        attempt_errors == 0 && terminal_mismatches == 0;
+    Audit {
+        events: run.events.len(), ordering_errors: ordering_errors,
+        transition_errors: transition_errors, attempt_errors: attempt_errors,
+        terminal_mismatches: terminal_mismatches, succeeded: succeeded,
+        failed: failed, cached: cached, retries: retries, ok: ok,
+    }
+}

--- a/performance/workloads/lattice/report.rue
+++ b/performance/workloads/lattice/report.rue
@@ -1,0 +1,34 @@
+// Compact human-readable schedule report used by normal example discovery.
+const std = @import("std");
+const model = @import("model.rue");
+const portfolio = @import("portfolio.rue");
+const replay = @import("replay.rue");
+const state = @import("state.rue");
+const text = @import("text.rue");
+const topology = @import("topology.rue");
+const StrBuf = std.strbuf.StrBuf;
+
+pub fn summary(borrow workflow: model.Workflow, borrow run: state.Run) -> StrBuf {
+    let order = topology.sort(borrow workflow);
+    let audit = replay.audit(borrow workflow, borrow run);
+    let analyses = portfolio.analyze(borrow workflow);
+    let mut out = StrBuf.new();
+    text.append_literal(inout out, "workflow="); text.append_id(inout out, borrow workflow, workflow.name); out.push(10);
+    text.line(inout out, "tasks=", workflow.tasks.len());
+    text.line(inout out, "edges=", workflow.edges.len());
+    text.line(inout out, "pools=", workflow.pools.len());
+    text.line(inout out, "roots=", order.roots);
+    text.line(inout out, "leaves=", order.leaves);
+    text.line(inout out, "makespan=", run.makespan);
+    text.line(inout out, "succeeded=", run.succeeded);
+    text.line(inout out, "failed=", run.failed);
+    text.line(inout out, "cached=", run.cached);
+    text.line(inout out, "retries=", run.retries);
+    text.line(inout out, "events=", run.events.len());
+    text.line(inout out, "analysis_passes=", analyses.passes);
+    text.line(inout out, "analysis_observations=", analyses.observations);
+    text.line(inout out, "analysis_digest=", analyses.digest);
+    text.append_literal(inout out, "replay_ok="); text.append_bool(inout out, audit.ok); out.push(10);
+    text.line(inout out, "fingerprint=", run.fingerprint);
+    out
+}

--- a/performance/workloads/lattice/report_cache.rue
+++ b/performance/workloads/lattice/report_cache.rue
@@ -1,0 +1,29 @@
+// Cache-policy effectiveness by task and pool.
+const cache_analysis = @import("cache_analysis.rue");
+const model = @import("model.rue");
+const state = @import("state.rue");
+const std = @import("std");
+const text = @import("text.rue");
+const StrBuf = std.strbuf.StrBuf;
+
+pub fn render(borrow workflow: model.Workflow, borrow run: state.Run) -> StrBuf {
+    let cache = cache_analysis.compute(borrow workflow, borrow run);
+    let mut out = StrBuf.new();
+    text.append_literal(inout out, "CACHE REPORT\ndeclared="); text.append_u64(inout out, cache.declared_cacheable);
+    text.append_literal(inout out, " hits="); text.append_u64(inout out, cache.observed_hits);
+    text.append_literal(inout out, " misses="); text.append_u64(inout out, cache.observed_misses);
+    text.append_literal(inout out, " rate="); text.append_percent(inout out, cache.observed_hits, cache.declared_cacheable); out.push(10);
+    text.append_literal(inout out, "saved_duration="); text.append_u64(inout out, cache.saved_duration);
+    text.append_literal(inout out, " saved_cpu_ticks="); text.append_u64(inout out, cache.saved_cpu_ticks);
+    text.append_literal(inout out, " saved_memory_ticks="); text.append_u64(inout out, cache.saved_memory_ticks); out.push(10);
+    let mut i: u64 = 0;
+    while i < workflow.pools.len() {
+        let pool = workflow.pools.get_or(i, model.empty_pool());
+        text.append_literal(inout out, "pool="); text.append_id(inout out, borrow workflow, pool.id);
+        text.append_literal(inout out, " eligible="); text.append_u64(inout out, cache.cacheable_by_pool.get_or(i, 0));
+        text.append_literal(inout out, " hits="); text.append_u64(inout out, cache.hits_by_pool.get_or(i, 0));
+        text.append_literal(inout out, " misses="); text.append_u64(inout out, cache.misses_by_pool.get_or(i, 0)); out.push(10);
+        i += 1;
+    }
+    out
+}

--- a/performance/workloads/lattice/report_capacity.rue
+++ b/performance/workloads/lattice/report_capacity.rue
@@ -1,0 +1,23 @@
+// Machine-readable capacity recommendation table.
+const capacity_plan = @import("capacity_plan.rue");
+const model = @import("model.rue");
+const state = @import("state.rue");
+const std = @import("std");
+const text = @import("text.rue");
+const StrBuf = std.strbuf.StrBuf;
+
+pub fn render(borrow workflow: model.Workflow, borrow run: state.Run) -> StrBuf {
+    let plan = capacity_plan.compute(borrow workflow, borrow run);
+    let mut out = StrBuf.new();
+    text.append_literal(inout out, "pool,current_slots,recommended_slots,current_cpu,recommended_cpu,current_memory,recommended_memory\n");
+    let mut i: u64 = 0;
+    while i < workflow.pools.len() {
+        let pool = workflow.pools.get_or(i, model.empty_pool());
+        text.append_id(inout out, borrow workflow, pool.id); out.push(44);
+        text.append_u64(inout out, pool.slots); out.push(44); text.append_u64(inout out, plan.recommended_slots.get_or(i, 0)); out.push(44);
+        text.append_u64(inout out, pool.cpu); out.push(44); text.append_u64(inout out, plan.recommended_cpu.get_or(i, 0)); out.push(44);
+        text.append_u64(inout out, pool.memory); out.push(44); text.append_u64(inout out, plan.recommended_memory.get_or(i, 0)); out.push(10);
+        i += 1;
+    }
+    out
+}

--- a/performance/workloads/lattice/report_chrome_trace.rue
+++ b/performance/workloads/lattice/report_chrome_trace.rue
@@ -1,0 +1,32 @@
+// Chrome Trace Event JSON for timeline visualization in tracing tools.
+const model = @import("model.rue");
+const state = @import("state.rue");
+const std = @import("std");
+const text = @import("text.rue");
+const StrBuf = std.strbuf.StrBuf;
+
+pub fn render(borrow workflow: model.Workflow, borrow run: state.Run) -> StrBuf {
+    let mut out = StrBuf.new();
+    text.append_literal(inout out, "{\"displayTimeUnit\":\"ms\",\"traceEvents\":[");
+    let mut emitted: u64 = 0;
+    let mut i: u64 = 0;
+    while i < workflow.tasks.len() {
+        let start = run.starts.get_or(i, model.NONE());
+        let end = run.ends.get_or(i, model.NONE());
+        if start != model.NONE() && end != model.NONE() {
+            if emitted > 0 { out.push(44); }
+            let task = workflow.tasks.get_or(i, model.empty_task());
+            text.append_literal(inout out, "{\"name\":"); text.json_id(inout out, borrow workflow, task.id);
+            text.append_literal(inout out, ",\"cat\":"); text.json_id(inout out, borrow workflow, task.pool_id);
+            text.append_literal(inout out, ",\"ph\":\"X\",\"ts\":"); text.append_u64(inout out, start * 1000);
+            text.append_literal(inout out, ",\"dur\":"); text.append_u64(inout out, (end - start) * 1000);
+            text.append_literal(inout out, ",\"pid\":1,\"tid\":"); text.append_u64(inout out, task.pool);
+            text.append_literal(inout out, ",\"args\":{\"priority\":"); text.append_u64(inout out, task.priority);
+            text.append_literal(inout out, ",\"attempts\":"); text.append_u64(inout out, run.attempts.get_or(i, 0)); text.append_literal(inout out, "}}");
+            emitted += 1;
+        }
+        i += 1;
+    }
+    text.append_literal(inout out, "]}\n");
+    out
+}

--- a/performance/workloads/lattice/report_comparison.rue
+++ b/performance/workloads/lattice/report_comparison.rue
@@ -1,0 +1,30 @@
+// Comparison report for the primary seed and a cache-perturbed seed.
+const format = @import("format.rue");
+const model = @import("model.rue");
+const run_comparison = @import("run_comparison.rue");
+const schedule = @import("schedule.rue");
+const state = @import("state.rue");
+const std = @import("std");
+const text = @import("text.rue");
+const StrBuf = std.strbuf.StrBuf;
+
+pub fn render(borrow workflow: model.Workflow, borrow first: state.Run, alternate_seed: u64) -> StrBuf {
+    let second = schedule.run(borrow workflow, alternate_seed);
+    let comparison = run_comparison.compare(borrow workflow, borrow first, borrow second);
+    let mut out = StrBuf.new();
+    text.append_literal(inout out, "RUN COMPARISON first_makespan="); text.append_u64(inout out, comparison.first_makespan);
+    text.append_literal(inout out, " second_makespan="); text.append_u64(inout out, comparison.second_makespan);
+    text.append_literal(inout out, " changed_tasks="); text.append_u64(inout out, comparison.changed_task_count); out.push(10);
+    let mut i: u64 = 0;
+    while i < comparison.changed_tasks.len() {
+        let index = comparison.changed_tasks.get_or(i, model.NONE());
+        let task = workflow.tasks.get_or(index, model.empty_task());
+        text.append_literal(inout out, "task="); text.append_id(inout out, borrow workflow, task.id);
+        text.append_literal(inout out, " first="); format.append_status(inout out, first.status.get_or(index, state.FAILED()));
+        text.append_literal(inout out, " second="); format.append_status(inout out, second.status.get_or(index, state.FAILED()));
+        text.append_literal(inout out, " first_end="); format.append_optional_u64(inout out, first.ends.get_or(index, model.NONE()));
+        text.append_literal(inout out, " second_end="); format.append_optional_u64(inout out, second.ends.get_or(index, model.NONE())); out.push(10);
+        i += 1;
+    }
+    out
+}

--- a/performance/workloads/lattice/report_critical.rue
+++ b/performance/workloads/lattice/report_critical.rue
@@ -1,0 +1,43 @@
+// Critical path, slack table, and path-count bottlenecks.
+const critical_path = @import("critical_path.rue");
+const format = @import("format.rue");
+const model = @import("model.rue");
+const path_catalog = @import("path_catalog.rue");
+const std = @import("std");
+const text = @import("text.rue");
+const StrBuf = std.strbuf.StrBuf;
+
+pub fn render(borrow workflow: model.Workflow) -> StrBuf {
+    let critical = critical_path.compute(borrow workflow);
+    let paths = path_catalog.compute(borrow workflow);
+    let mut out = StrBuf.new();
+    text.append_literal(inout out, "CRITICAL PATH workflow="); text.append_id(inout out, borrow workflow, workflow.name);
+    text.append_literal(inout out, " makespan="); text.append_u64(inout out, critical.makespan);
+    text.append_literal(inout out, " critical_tasks="); text.append_u64(inout out, critical.critical_tasks.len()); out.push(10);
+    text.append_literal(inout out, "canonical=");
+    let mut i: u64 = 0;
+    while i < critical.canonical_path.len() {
+        if i > 0 { text.append_literal(inout out, " -> "); }
+        let task_index = critical.canonical_path.get_or(i, model.NONE());
+        let task = workflow.tasks.get_or(task_index, model.empty_task());
+        text.append_id(inout out, borrow workflow, task.id);
+        i += 1;
+    }
+    out.push(10);
+    text.append_literal(inout out, "task                 early late slack paths-through critical\n");
+    i = 0;
+    while i < workflow.tasks.len() {
+        let task = workflow.tasks.get_or(i, model.empty_task());
+        format.markdown_id(inout out, borrow workflow, task.id); text.append_literal(inout out, " ");
+        text.append_u64(inout out, critical.earliest_start.get_or(i, 0)); out.push(32);
+        text.append_u64(inout out, critical.latest_start.get_or(i, 0)); out.push(32);
+        text.append_u64(inout out, critical.slack.get_or(i, 0)); out.push(32);
+        text.append_u64(inout out, paths.paths_through_task.get_or(i, 0)); out.push(32);
+        text.append_bool(inout out, critical.slack.get_or(i, 1) == 0); out.push(10);
+        i += 1;
+    }
+    text.append_literal(inout out, "total_paths="); text.append_u64(inout out, paths.total_paths);
+    text.append_literal(inout out, " total_slack="); text.append_u64(inout out, critical.total_slack);
+    text.append_literal(inout out, " maximum_slack="); text.append_u64(inout out, critical.maximum_slack); out.push(10);
+    out
+}

--- a/performance/workloads/lattice/report_dot.rue
+++ b/performance/workloads/lattice/report_dot.rue
@@ -1,0 +1,42 @@
+// Graphviz DOT export with pool, priority, status, and critical-path styling.
+const critical_path = @import("critical_path.rue");
+const format = @import("format.rue");
+const model = @import("model.rue");
+const state = @import("state.rue");
+const std = @import("std");
+const text = @import("text.rue");
+const StrBuf = std.strbuf.StrBuf;
+
+fn critical(borrow analysis: critical_path.Analysis, task: u64) -> bool {
+    analysis.slack.get_or(task, 1) == 0
+}
+
+pub fn render(borrow workflow: model.Workflow, borrow run: state.Run) -> StrBuf {
+    let analysis = critical_path.compute(borrow workflow);
+    let mut out = StrBuf.new();
+    text.append_literal(inout out, "digraph lattice {\n  rankdir=LR;\n  label=");
+    format.dot_id(inout out, borrow workflow, workflow.name); text.append_literal(inout out, ";\n");
+    let mut i: u64 = 0;
+    while i < workflow.tasks.len() {
+        let task = workflow.tasks.get_or(i, model.empty_task());
+        text.append_literal(inout out, "  t"); text.append_u64(inout out, i); text.append_literal(inout out, " [label=");
+        out.push(34); workflow.strings.append(task.id, inout out); text.append_literal(inout out, "\\npool=");
+        workflow.strings.append(task.pool_id, inout out); text.append_literal(inout out, " priority="); text.append_u64(inout out, task.priority);
+        text.append_literal(inout out, "\\n"); format.append_status(inout out, run.status.get_or(i, state.FAILED())); out.push(34);
+        text.append_literal(inout out, ",shape=");
+        if critical(borrow analysis, i) { text.append_literal(inout out, "doubleoctagon,color=red"); }
+        else if task.cacheable { text.append_literal(inout out, "box,color=blue"); }
+        else { text.append_literal(inout out, "ellipse,color=black"); }
+        text.append_literal(inout out, "];\n");
+        i += 1;
+    }
+    i = 0;
+    while i < workflow.edges.len() {
+        let edge = workflow.edges.get_or(i, model.empty_edge());
+        text.append_literal(inout out, "  t"); text.append_u64(inout out, edge.before);
+        text.append_literal(inout out, " -> t"); text.append_u64(inout out, edge.after); text.append_literal(inout out, ";\n");
+        i += 1;
+    }
+    text.append_literal(inout out, "}\n");
+    out
+}

--- a/performance/workloads/lattice/report_events_csv.rue
+++ b/performance/workloads/lattice/report_events_csv.rue
@@ -1,0 +1,32 @@
+// Append-only event ledger export.
+const format = @import("format.rue");
+const model = @import("model.rue");
+const state = @import("state.rue");
+const std = @import("std");
+const text = @import("text.rue");
+const StrBuf = std.strbuf.StrBuf;
+
+pub fn render(borrow workflow: model.Workflow, borrow run: state.Run) -> StrBuf {
+    let mut out = StrBuf.new();
+    text.append_literal(inout out, "sequence,time,kind,task,pool,attempt,cpu,memory\r\n");
+    let mut i: u64 = 0;
+    while i < run.events.len() {
+        let event = run.events.get_or(i, state.empty_event());
+        text.append_u64(inout out, i); out.push(44); text.append_u64(inout out, event.time); out.push(44);
+        format.append_event_kind(inout out, event.kind); out.push(44);
+        if event.task < workflow.tasks.len() {
+            let task = workflow.tasks.get_or(event.task, model.empty_task());
+            format.csv_id(inout out, borrow workflow, task.id);
+        } else { text.append_literal(inout out, "\"<none>\""); }
+        out.push(44);
+        if event.pool < workflow.pools.len() {
+            let pool = workflow.pools.get_or(event.pool, model.empty_pool());
+            format.csv_id(inout out, borrow workflow, pool.id);
+        } else { text.append_literal(inout out, "\"<none>\""); }
+        out.push(44); text.append_u64(inout out, event.attempt); out.push(44);
+        text.append_u64(inout out, event.cpu); out.push(44); text.append_u64(inout out, event.memory);
+        text.append_literal(inout out, "\r\n");
+        i += 1;
+    }
+    out
+}

--- a/performance/workloads/lattice/report_explain.rue
+++ b/performance/workloads/lattice/report_explain.rue
@@ -1,0 +1,33 @@
+// Task-by-task causal explanation report.
+const explain = @import("explain.rue");
+const model = @import("model.rue");
+const state = @import("state.rue");
+const std = @import("std");
+const text = @import("text.rue");
+const StrBuf = std.strbuf.StrBuf;
+
+pub fn render(borrow workflow: model.Workflow, borrow run: state.Run) -> StrBuf {
+    let analysis = explain.compute(borrow workflow, borrow run);
+    let mut out = StrBuf.new();
+    text.append_literal(inout out, "TASK EXPLANATIONS valid="); text.append_bool(inout out, analysis.valid); out.push(10);
+    let mut i: u64 = 0;
+    while i < analysis.tasks.len() {
+        let value = analysis.tasks.get_or(i, explain.Explanation {
+            task: model.NONE(), classification: explain.PENDING(), dependencies: 0,
+            successful_dependencies: 0, failed_dependencies: 0, ready_time: 0,
+            queue_delay: 0, start: model.NONE(), end: model.NONE(), attempts: 0,
+            start_events: 0, failure_events: 0, retry_events: 0, cache_events: 0,
+            blocked_events: 0, digest: 0, consistent: false,
+        });
+        let task = workflow.tasks.get_or(value.task, model.empty_task());
+        text.append_literal(inout out, "task="); text.append_id(inout out, borrow workflow, task.id);
+        text.append_literal(inout out, " outcome="); text.append_literal(inout out, explain.classification_name(value.classification));
+        text.append_literal(inout out, " dependencies="); text.append_u64(inout out, value.dependencies);
+        text.append_literal(inout out, " ready="); text.append_u64(inout out, value.ready_time);
+        text.append_literal(inout out, " queue_delay="); text.append_u64(inout out, value.queue_delay);
+        text.append_literal(inout out, " attempts="); text.append_u64(inout out, value.attempts);
+        text.append_literal(inout out, " consistent="); text.append_bool(inout out, value.consistent); out.push(10);
+        i += 1;
+    }
+    out
+}

--- a/performance/workloads/lattice/report_forecast.rue
+++ b/performance/workloads/lattice/report_forecast.rue
@@ -1,0 +1,26 @@
+// Cache-seed ensemble table for repeatability analysis.
+const forecast = @import("forecast.rue");
+const model = @import("model.rue");
+const std = @import("std");
+const text = @import("text.rue");
+const StrBuf = std.strbuf.StrBuf;
+
+pub fn render(borrow workflow: model.Workflow, seed: u64) -> StrBuf {
+    let value = forecast.compute(borrow workflow, seed, 8);
+    let mut out = StrBuf.new();
+    text.append_literal(inout out, "FORECAST samples="); text.append_u64(inout out, value.samples);
+    text.append_literal(inout out, " min="); text.append_u64(inout out, value.minimum_makespan);
+    text.append_literal(inout out, " mean="); text.append_u64(inout out, value.mean_makespan);
+    text.append_literal(inout out, " max="); text.append_u64(inout out, value.maximum_makespan);
+    text.append_literal(inout out, " spread="); text.append_u64(inout out, value.spread); out.push(10);
+    text.append_literal(inout out, "sample,seed,makespan,cache_hits,retries,fingerprint\n");
+    let mut i: u64 = 0;
+    while i < value.samples {
+        text.append_u64(inout out, i); out.push(44); text.append_u64(inout out, value.seeds.get_or(i, 0)); out.push(44);
+        text.append_u64(inout out, value.makespans.get_or(i, 0)); out.push(44);
+        text.append_u64(inout out, value.cache_hits.get_or(i, 0)); out.push(44);
+        text.append_u64(inout out, value.retries.get_or(i, 0)); out.push(44);
+        text.append_u64(inout out, value.fingerprints.get_or(i, 0)); out.push(10); i += 1;
+    }
+    out
+}

--- a/performance/workloads/lattice/report_html.rue
+++ b/performance/workloads/lattice/report_html.rue
@@ -1,0 +1,44 @@
+// Standalone HTML dashboard with no external assets.
+const format = @import("format.rue");
+const model = @import("model.rue");
+const schedule_quality = @import("schedule_quality.rue");
+const state = @import("state.rue");
+const std = @import("std");
+const text = @import("text.rue");
+const StrBuf = std.strbuf.StrBuf;
+
+fn cell(inout out: StrBuf, value: u64) {
+    text.append_literal(inout out, "<td>"); text.append_u64(inout out, value); text.append_literal(inout out, "</td>");
+}
+
+pub fn render(borrow workflow: model.Workflow, borrow run: state.Run) -> StrBuf {
+    let quality = schedule_quality.compute(borrow workflow, borrow run);
+    let mut out = StrBuf.new();
+    text.append_literal(inout out, "<!doctype html><html><head><meta charset=\"utf-8\"><title>Lattice ");
+    text.append_id(inout out, borrow workflow, workflow.name);
+    text.append_literal(inout out, "</title><style>body{font-family:system-ui;margin:2rem;color:#182230}table{border-collapse:collapse;width:100%}th,td{padding:.45rem;border-bottom:1px solid #ccd3dc;text-align:left}.ok{color:#08783e}.bad{color:#b42318}code{background:#f1f4f8;padding:.1rem .3rem}</style></head><body>");
+    text.append_literal(inout out, "<h1>Workflow "); text.append_id(inout out, borrow workflow, workflow.name); text.append_literal(inout out, "</h1>");
+    text.append_literal(inout out, "<section><h2>Execution</h2><ul><li>Makespan: <strong>"); text.append_u64(inout out, run.makespan);
+    text.append_literal(inout out, "</strong></li><li>Succeeded: "); text.append_u64(inout out, run.succeeded);
+    text.append_literal(inout out, "</li><li>Cached: "); text.append_u64(inout out, run.cached);
+    text.append_literal(inout out, "</li><li>Retries: "); text.append_u64(inout out, run.retries);
+    text.append_literal(inout out, "</li><li>Efficiency: "); format.append_millis(inout out, quality.efficiency_millis);
+    text.append_literal(inout out, "</li></ul></section><section><h2>Tasks</h2><table><thead><tr><th>Task</th><th>Pool</th><th>Status</th><th>Duration</th><th>Priority</th><th>Attempts</th><th>Start</th><th>End</th></tr></thead><tbody>");
+    let mut i: u64 = 0;
+    while i < workflow.tasks.len() {
+        let task = workflow.tasks.get_or(i, model.empty_task());
+        let status = run.status.get_or(i, state.FAILED());
+        text.append_literal(inout out, "<tr><td><code>"); text.append_id(inout out, borrow workflow, task.id);
+        text.append_literal(inout out, "</code></td><td>"); text.append_id(inout out, borrow workflow, task.pool_id);
+        text.append_literal(inout out, "</td><td class=\"");
+        if state.successful(status) { text.append_literal(inout out, "ok"); } else { text.append_literal(inout out, "bad"); }
+        text.append_literal(inout out, "\">"); format.append_status(inout out, status); text.append_literal(inout out, "</td>");
+        cell(inout out, task.duration); cell(inout out, task.priority); cell(inout out, run.attempts.get_or(i, 0));
+        text.append_literal(inout out, "<td>"); format.append_optional_u64(inout out, run.starts.get_or(i, model.NONE())); text.append_literal(inout out, "</td><td>");
+        format.append_optional_u64(inout out, run.ends.get_or(i, model.NONE())); text.append_literal(inout out, "</td></tr>");
+        i += 1;
+    }
+    text.append_literal(inout out, "</tbody></table></section><footer><p>fingerprint <code>"); text.append_u64(inout out, run.fingerprint);
+    text.append_literal(inout out, "</code></p></footer></body></html>\n");
+    out
+}

--- a/performance/workloads/lattice/report_json.rue
+++ b/performance/workloads/lattice/report_json.rue
@@ -1,0 +1,81 @@
+// Complete JSON export of the validated workflow and realized execution.
+const format = @import("format.rue");
+const model = @import("model.rue");
+const state = @import("state.rue");
+const std = @import("std");
+const text = @import("text.rue");
+const StrBuf = std.strbuf.StrBuf;
+
+fn key(inout out: StrBuf, value: str) {
+    out.push(34); text.append_literal(inout out, value); text.append_literal(inout out, "\":");
+}
+
+fn comma(inout out: StrBuf, index: u64) { if index > 0 { out.push(44); } }
+
+pub fn render(borrow workflow: model.Workflow, borrow run: state.Run) -> StrBuf {
+    let mut out = StrBuf.new();
+    out.push(123);
+    key(inout out, "workflow"); text.json_id(inout out, borrow workflow, workflow.name); out.push(44);
+    key(inout out, "pools"); out.push(91);
+    let mut i: u64 = 0;
+    while i < workflow.pools.len() {
+        comma(inout out, i);
+        let pool = workflow.pools.get_or(i, model.empty_pool());
+        out.push(123);
+        key(inout out, "id"); text.json_id(inout out, borrow workflow, pool.id); out.push(44);
+        key(inout out, "slots"); text.append_u64(inout out, pool.slots); out.push(44);
+        key(inout out, "cpu"); text.append_u64(inout out, pool.cpu); out.push(44);
+        key(inout out, "memory"); text.append_u64(inout out, pool.memory);
+        out.push(125); i += 1;
+    }
+    text.append_literal(inout out, "],\"tasks\":[");
+    i = 0;
+    while i < workflow.tasks.len() {
+        comma(inout out, i);
+        let task = workflow.tasks.get_or(i, model.empty_task());
+        out.push(123);
+        key(inout out, "id"); text.json_id(inout out, borrow workflow, task.id); out.push(44);
+        key(inout out, "pool"); text.json_id(inout out, borrow workflow, task.pool_id); out.push(44);
+        key(inout out, "duration"); text.append_u64(inout out, task.duration); out.push(44);
+        key(inout out, "cpu"); text.append_u64(inout out, task.cpu); out.push(44);
+        key(inout out, "memory"); text.append_u64(inout out, task.memory); out.push(44);
+        key(inout out, "priority"); text.append_u64(inout out, task.priority); out.push(44);
+        key(inout out, "retries"); text.append_u64(inout out, task.retries); out.push(44);
+        key(inout out, "cacheable"); text.append_bool(inout out, task.cacheable); out.push(44);
+        key(inout out, "status"); out.push(34); format.append_status(inout out, run.status.get_or(i, state.FAILED())); out.push(34); out.push(44);
+        key(inout out, "start"); format.append_optional_u64(inout out, run.starts.get_or(i, model.NONE())); out.push(44);
+        key(inout out, "end"); format.append_optional_u64(inout out, run.ends.get_or(i, model.NONE())); out.push(44);
+        key(inout out, "attempts"); text.append_u64(inout out, run.attempts.get_or(i, 0));
+        out.push(125); i += 1;
+    }
+    text.append_literal(inout out, "],\"edges\":[");
+    i = 0;
+    while i < workflow.edges.len() {
+        comma(inout out, i);
+        let edge = workflow.edges.get_or(i, model.empty_edge());
+        out.push(123); key(inout out, "before"); text.json_id(inout out, borrow workflow, edge.before_id);
+        out.push(44); key(inout out, "after"); text.json_id(inout out, borrow workflow, edge.after_id); out.push(125);
+        i += 1;
+    }
+    text.append_literal(inout out, "],\"events\":[");
+    i = 0;
+    while i < run.events.len() {
+        comma(inout out, i);
+        let event = run.events.get_or(i, state.empty_event());
+        out.push(123); key(inout out, "kind"); out.push(34); format.append_event_kind(inout out, event.kind); out.push(34); out.push(44);
+        key(inout out, "time"); text.append_u64(inout out, event.time); out.push(44);
+        key(inout out, "task"); text.append_u64(inout out, event.task); out.push(44);
+        key(inout out, "pool"); text.append_u64(inout out, event.pool); out.push(44);
+        key(inout out, "attempt"); text.append_u64(inout out, event.attempt); out.push(125);
+        i += 1;
+    }
+    text.append_literal(inout out, "],\"summary\":{");
+    key(inout out, "makespan"); text.append_u64(inout out, run.makespan); out.push(44);
+    key(inout out, "succeeded"); text.append_u64(inout out, run.succeeded); out.push(44);
+    key(inout out, "failed"); text.append_u64(inout out, run.failed); out.push(44);
+    key(inout out, "cached"); text.append_u64(inout out, run.cached); out.push(44);
+    key(inout out, "retries"); text.append_u64(inout out, run.retries); out.push(44);
+    key(inout out, "fingerprint"); text.append_u64(inout out, run.fingerprint);
+    out.push(125); out.push(125); out.push(10);
+    out
+}

--- a/performance/workloads/lattice/report_junit.rue
+++ b/performance/workloads/lattice/report_junit.rue
@@ -1,0 +1,28 @@
+// JUnit XML projection for CI artifact consumers.
+const model = @import("model.rue");
+const state = @import("state.rue");
+const std = @import("std");
+const text = @import("text.rue");
+const StrBuf = std.strbuf.StrBuf;
+
+pub fn render(borrow workflow: model.Workflow, borrow run: state.Run) -> StrBuf {
+    let mut out = StrBuf.new();
+    text.append_literal(inout out, "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<testsuite name=\"");
+    text.append_id(inout out, borrow workflow, workflow.name); text.append_literal(inout out, "\" tests=\"");
+    text.append_u64(inout out, workflow.tasks.len()); text.append_literal(inout out, "\" failures=\"");
+    text.append_u64(inout out, run.failed); text.append_literal(inout out, "\" time=\"");
+    text.append_u64(inout out, run.makespan); text.append_literal(inout out, "\">\n");
+    let mut i: u64 = 0;
+    while i < workflow.tasks.len() {
+        let task = workflow.tasks.get_or(i, model.empty_task());
+        let status = run.status.get_or(i, state.FAILED());
+        text.append_literal(inout out, "  <testcase classname=\""); text.append_id(inout out, borrow workflow, task.pool_id);
+        text.append_literal(inout out, "\" name=\""); text.append_id(inout out, borrow workflow, task.id);
+        text.append_literal(inout out, "\" time=\""); text.append_u64(inout out, task.duration); text.append_literal(inout out, "\">");
+        if status == state.FAILED() { text.append_literal(inout out, "<failure message=\"task failed\"/>"); }
+        else if status == state.CACHED() { text.append_literal(inout out, "<system-out>cache hit</system-out>"); }
+        text.append_literal(inout out, "</testcase>\n"); i += 1;
+    }
+    text.append_literal(inout out, "</testsuite>\n");
+    out
+}

--- a/performance/workloads/lattice/report_lint.rue
+++ b/performance/workloads/lattice/report_lint.rue
@@ -1,0 +1,37 @@
+// Human-readable workflow lint report.
+const lint = @import("lint.rue");
+const model = @import("model.rue");
+const state = @import("state.rue");
+const std = @import("std");
+const text = @import("text.rue");
+const StrBuf = std.strbuf.StrBuf;
+
+pub fn render(borrow workflow: model.Workflow, borrow run: state.Run) -> StrBuf {
+    let report = lint.compute(borrow workflow, borrow run);
+    let mut out = StrBuf.new();
+    text.append_literal(inout out, "LINT findings="); text.append_u64(inout out, report.findings.len());
+    text.append_literal(inout out, " info="); text.append_u64(inout out, report.infos);
+    text.append_literal(inout out, " warnings="); text.append_u64(inout out, report.warnings);
+    text.append_literal(inout out, " errors="); text.append_u64(inout out, report.errors); out.push(10);
+    let mut i: u64 = 0;
+    while i < report.findings.len() {
+        let finding = report.findings.get_or(i, lint.empty_finding());
+        text.append_literal(inout out, lint.severity_name(finding.severity));
+        text.append_literal(inout out, "["); text.append_literal(inout out, lint.rule_name(finding.rule));
+        text.append_literal(inout out, "] actual="); text.append_u64(inout out, finding.actual);
+        text.append_literal(inout out, " threshold="); text.append_u64(inout out, finding.threshold);
+        if finding.task < workflow.tasks.len() {
+            text.append_literal(inout out, " task=");
+            text.append_id(inout out, borrow workflow, workflow.tasks.get_or(finding.task, model.empty_task()).id);
+        }
+        if finding.pool < workflow.pools.len() {
+            text.append_literal(inout out, " pool=");
+            text.append_id(inout out, borrow workflow, workflow.pools.get_or(finding.pool, model.empty_pool()).id);
+        }
+        if finding.edge < workflow.edges.len() {
+            text.append_literal(inout out, " edge="); text.append_u64(inout out, finding.edge);
+        }
+        out.push(10); i += 1;
+    }
+    out
+}

--- a/performance/workloads/lattice/report_manifest.rue
+++ b/performance/workloads/lattice/report_manifest.rue
@@ -1,0 +1,41 @@
+// Stable line-oriented manifest for build provenance and cache keys.
+const fingerprint = @import("fingerprint.rue");
+const model = @import("model.rue");
+const state = @import("state.rue");
+const std = @import("std");
+const text = @import("text.rue");
+const StrBuf = std.strbuf.StrBuf;
+
+pub fn render(borrow workflow: model.Workflow, borrow run: state.Run) -> StrBuf {
+    let mut out = StrBuf.new();
+    text.append_literal(inout out, "lattice-manifest-v1\nworkflow "); text.append_id(inout out, borrow workflow, workflow.name); out.push(10);
+    text.append_literal(inout out, "workflow-fingerprint "); text.append_u64(inout out, fingerprint.workflow(borrow workflow)); out.push(10);
+    text.append_literal(inout out, "run-fingerprint "); text.append_u64(inout out, fingerprint.run(borrow run)); out.push(10);
+    text.append_literal(inout out, "counts "); text.append_u64(inout out, workflow.pools.len()); out.push(32);
+    text.append_u64(inout out, workflow.tasks.len()); out.push(32); text.append_u64(inout out, workflow.edges.len()); out.push(10);
+    let mut i: u64 = 0;
+    while i < workflow.pools.len() {
+        let pool = workflow.pools.get_or(i, model.empty_pool());
+        text.append_literal(inout out, "pool "); text.append_u64(inout out, i); out.push(32);
+        text.append_id(inout out, borrow workflow, pool.id); out.push(32);
+        text.append_u64(inout out, pool.slots); out.push(32); text.append_u64(inout out, pool.cpu); out.push(32);
+        text.append_u64(inout out, pool.memory); out.push(10); i += 1;
+    }
+    i = 0;
+    while i < workflow.tasks.len() {
+        let task = workflow.tasks.get_or(i, model.empty_task());
+        text.append_literal(inout out, "task "); text.append_u64(inout out, i); out.push(32);
+        text.append_id(inout out, borrow workflow, task.id); out.push(32); text.append_u64(inout out, task.pool); out.push(32);
+        text.append_u64(inout out, task.duration); out.push(32); text.append_u64(inout out, task.cpu); out.push(32);
+        text.append_u64(inout out, task.memory); out.push(32); text.append_u64(inout out, task.priority); out.push(32);
+        text.append_u64(inout out, run.status.get_or(i, state.FAILED())); out.push(32);
+        text.append_u64(inout out, run.attempts.get_or(i, 0)); out.push(10); i += 1;
+    }
+    i = 0;
+    while i < workflow.edges.len() {
+        let edge = workflow.edges.get_or(i, model.empty_edge());
+        text.append_literal(inout out, "edge "); text.append_u64(inout out, edge.before);
+        out.push(32); text.append_u64(inout out, edge.after); out.push(10); i += 1;
+    }
+    out
+}

--- a/performance/workloads/lattice/report_markdown.rue
+++ b/performance/workloads/lattice/report_markdown.rue
@@ -1,0 +1,47 @@
+// Portable Markdown runbook for human review and incident records.
+const cache_analysis = @import("cache_analysis.rue");
+const format = @import("format.rue");
+const model = @import("model.rue");
+const retry_analysis = @import("retry_analysis.rue");
+const schedule_quality = @import("schedule_quality.rue");
+const state = @import("state.rue");
+const std = @import("std");
+const text = @import("text.rue");
+const StrBuf = std.strbuf.StrBuf;
+
+pub fn render(borrow workflow: model.Workflow, borrow run: state.Run) -> StrBuf {
+    let quality = schedule_quality.compute(borrow workflow, borrow run);
+    let caches = cache_analysis.compute(borrow workflow, borrow run);
+    let retries = retry_analysis.compute(borrow workflow, borrow run);
+    let mut out = StrBuf.new();
+    text.append_literal(inout out, "# Lattice run: "); format.markdown_id(inout out, borrow workflow, workflow.name); out.push(10); out.push(10);
+    text.append_literal(inout out, "## Summary\n\n");
+    text.append_literal(inout out, "- Tasks: "); text.append_u64(inout out, workflow.tasks.len()); out.push(10);
+    text.append_literal(inout out, "- Edges: "); text.append_u64(inout out, workflow.edges.len()); out.push(10);
+    text.append_literal(inout out, "- Makespan: "); text.append_u64(inout out, run.makespan); out.push(10);
+    text.append_literal(inout out, "- Efficiency: "); format.append_millis(inout out, quality.efficiency_millis); out.push(10);
+    text.append_literal(inout out, "- Cache hit rate: "); text.append_percent(inout out, caches.observed_hits, caches.declared_cacheable); out.push(10);
+    text.append_literal(inout out, "- Recovered tasks: "); text.append_u64(inout out, retries.recovered_tasks); out.push(10); out.push(10);
+    text.append_literal(inout out, "## Tasks\n\n| Task | Pool | Duration | Priority | Status | Attempts | Start | End |\n");
+    text.append_literal(inout out, "|---|---|---:|---:|---|---:|---:|---:|\n");
+    let mut i: u64 = 0;
+    while i < workflow.tasks.len() {
+        let task = workflow.tasks.get_or(i, model.empty_task());
+        out.push(124); format.markdown_id(inout out, borrow workflow, task.id); out.push(124);
+        format.markdown_id(inout out, borrow workflow, task.pool_id); out.push(124);
+        text.append_u64(inout out, task.duration); out.push(124); text.append_u64(inout out, task.priority); out.push(124);
+        format.append_status(inout out, run.status.get_or(i, state.FAILED())); out.push(124);
+        text.append_u64(inout out, run.attempts.get_or(i, 0)); out.push(124);
+        format.append_optional_u64(inout out, run.starts.get_or(i, model.NONE())); out.push(124);
+        format.append_optional_u64(inout out, run.ends.get_or(i, model.NONE())); text.append_literal(inout out, "|\n");
+        i += 1;
+    }
+    text.append_literal(inout out, "\n## Scheduler counters\n\n| Counter | Value |\n|---|---:|\n");
+    text.append_literal(inout out, "| Succeeded |"); text.append_u64(inout out, run.succeeded); text.append_literal(inout out, "|\n");
+    text.append_literal(inout out, "| Cached |"); text.append_u64(inout out, run.cached); text.append_literal(inout out, "|\n");
+    text.append_literal(inout out, "| Failed |"); text.append_u64(inout out, run.failed); text.append_literal(inout out, "|\n");
+    text.append_literal(inout out, "| Retries |"); text.append_u64(inout out, run.retries); text.append_literal(inout out, "|\n");
+    text.append_literal(inout out, "| Resource waits |"); text.append_u64(inout out, run.resource_waits); text.append_literal(inout out, "|\n");
+    text.append_literal(inout out, "| Dependency waits |"); text.append_u64(inout out, run.dependency_waits); text.append_literal(inout out, "|\n");
+    out
+}

--- a/performance/workloads/lattice/report_matrix.rue
+++ b/performance/workloads/lattice/report_matrix.rue
@@ -1,0 +1,31 @@
+// Compact adjacency matrix for dependency review.
+const model = @import("model.rue");
+const std = @import("std");
+const text = @import("text.rue");
+const StrBuf = std.strbuf.StrBuf;
+
+pub fn render(borrow workflow: model.Workflow) -> StrBuf {
+    let mut out = StrBuf.new();
+    text.append_literal(inout out, "ADJACENCY MATRIX\n    ");
+    let mut column: u64 = 0;
+    while column < workflow.tasks.len() {
+        text.append_u64(inout out, column % 10); out.push(32); column += 1;
+    }
+    out.push(10);
+    let mut row: u64 = 0;
+    while row < workflow.tasks.len() {
+        text.append_u64(inout out, row); out.push(32);
+        if row < 10 { out.push(32); }
+        if row < 100 { out.push(32); }
+        column = 0;
+        while column < workflow.tasks.len() {
+            if model.has_edge(borrow workflow, row, column) { out.push(49); }
+            else { out.push(46); }
+            out.push(32); column += 1;
+        }
+        let task = workflow.tasks.get_or(row, model.empty_task());
+        text.append_id(inout out, borrow workflow, task.id); out.push(10);
+        row += 1;
+    }
+    out
+}

--- a/performance/workloads/lattice/report_mermaid.rue
+++ b/performance/workloads/lattice/report_mermaid.rue
@@ -1,0 +1,31 @@
+// Mermaid flowchart for Markdown-native diagram rendering.
+const critical_path = @import("critical_path.rue");
+const model = @import("model.rue");
+const std = @import("std");
+const text = @import("text.rue");
+const StrBuf = std.strbuf.StrBuf;
+
+pub fn render(borrow workflow: model.Workflow) -> StrBuf {
+    let critical = critical_path.compute(borrow workflow);
+    let mut out = StrBuf.new();
+    text.append_literal(inout out, "flowchart LR\n");
+    let mut i: u64 = 0;
+    while i < workflow.tasks.len() {
+        let task = workflow.tasks.get_or(i, model.empty_task());
+        text.append_literal(inout out, "  T"); text.append_u64(inout out, i); text.append_literal(inout out, "[\"");
+        text.append_id(inout out, borrow workflow, task.id); text.append_literal(inout out, "<br/>pool: ");
+        text.append_id(inout out, borrow workflow, task.pool_id); text.append_literal(inout out, "\"]\n");
+        if critical.slack.get_or(i, 1) == 0 {
+            text.append_literal(inout out, "  style T"); text.append_u64(inout out, i);
+            text.append_literal(inout out, " stroke:#d92d20,stroke-width:3px\n");
+        }
+        i += 1;
+    }
+    i = 0;
+    while i < workflow.edges.len() {
+        let edge = workflow.edges.get_or(i, model.empty_edge());
+        text.append_literal(inout out, "  T"); text.append_u64(inout out, edge.before);
+        text.append_literal(inout out, " --> T"); text.append_u64(inout out, edge.after); out.push(10); i += 1;
+    }
+    out
+}

--- a/performance/workloads/lattice/report_ndjson.rue
+++ b/performance/workloads/lattice/report_ndjson.rue
@@ -1,0 +1,31 @@
+// Newline-delimited JSON event stream for incremental ingestion.
+const format = @import("format.rue");
+const model = @import("model.rue");
+const state = @import("state.rue");
+const std = @import("std");
+const text = @import("text.rue");
+const StrBuf = std.strbuf.StrBuf;
+
+pub fn render(borrow workflow: model.Workflow, borrow run: state.Run) -> StrBuf {
+    let mut out = StrBuf.new();
+    let mut i: u64 = 0;
+    while i < run.events.len() {
+        let event = run.events.get_or(i, state.empty_event());
+        text.append_literal(inout out, "{\"sequence\":"); text.append_u64(inout out, i);
+        text.append_literal(inout out, ",\"time\":"); text.append_u64(inout out, event.time);
+        text.append_literal(inout out, ",\"kind\":\""); format.append_event_kind(inout out, event.kind);
+        text.append_literal(inout out, "\",\"task\":");
+        if event.task < workflow.tasks.len() {
+            text.json_id(inout out, borrow workflow, workflow.tasks.get_or(event.task, model.empty_task()).id);
+        } else { text.append_literal(inout out, "null"); }
+        text.append_literal(inout out, ",\"pool\":");
+        if event.pool < workflow.pools.len() {
+            text.json_id(inout out, borrow workflow, workflow.pools.get_or(event.pool, model.empty_pool()).id);
+        } else { text.append_literal(inout out, "null"); }
+        text.append_literal(inout out, ",\"attempt\":"); text.append_u64(inout out, event.attempt);
+        text.append_literal(inout out, ",\"cpu\":"); text.append_u64(inout out, event.cpu);
+        text.append_literal(inout out, ",\"memory\":"); text.append_u64(inout out, event.memory);
+        text.append_literal(inout out, "}\n"); i += 1;
+    }
+    out
+}

--- a/performance/workloads/lattice/report_otel.rue
+++ b/performance/workloads/lattice/report_otel.rue
@@ -1,0 +1,51 @@
+// OpenTelemetry-style span export with dependency links and task attributes.
+const model = @import("model.rue");
+const state = @import("state.rue");
+const std = @import("std");
+const text = @import("text.rue");
+const StrBuf = std.strbuf.StrBuf;
+
+fn links(inout out: StrBuf, borrow workflow: model.Workflow, task: u64) {
+    out.push(91);
+    let mut emitted: u64 = 0;
+    let mut i: u64 = 0;
+    while i < workflow.edges.len() {
+        let edge = workflow.edges.get_or(i, model.empty_edge());
+        if edge.after == task {
+            if emitted > 0 { out.push(44); }
+            text.append_literal(inout out, "{\"spanId\":\""); text.append_u64(inout out, edge.before + 1);
+            text.append_literal(inout out, "\"}"); emitted += 1;
+        }
+        i += 1;
+    }
+    out.push(93);
+}
+
+pub fn render(borrow workflow: model.Workflow, borrow run: state.Run) -> StrBuf {
+    let mut out = StrBuf.new();
+    text.append_literal(inout out, "{\"resourceSpans\":[{\"resource\":{\"attributes\":[{\"key\":\"service.name\",\"value\":{\"stringValue\":\"lattice\"}}]},\"scopeSpans\":[{\"scope\":{\"name\":\"lattice.scheduler\"},\"spans\":[");
+    let mut emitted: u64 = 0;
+    let mut i: u64 = 0;
+    while i < workflow.tasks.len() {
+        let start = run.starts.get_or(i, model.NONE());
+        let end = run.ends.get_or(i, model.NONE());
+        if start != model.NONE() && end != model.NONE() {
+            if emitted > 0 { out.push(44); }
+            let task = workflow.tasks.get_or(i, model.empty_task());
+            text.append_literal(inout out, "{\"traceId\":\""); text.append_u64(inout out, run.fingerprint);
+            text.append_literal(inout out, "\",\"spanId\":\""); text.append_u64(inout out, i + 1);
+            text.append_literal(inout out, "\",\"name\":"); text.json_id(inout out, borrow workflow, task.id);
+            text.append_literal(inout out, ",\"startTimeUnixNano\":\""); text.append_u64(inout out, start * 1000000);
+            text.append_literal(inout out, "\",\"endTimeUnixNano\":\""); text.append_u64(inout out, end * 1000000);
+            text.append_literal(inout out, "\",\"attributes\":[{\"key\":\"lattice.pool\",\"value\":{\"stringValue\":");
+            text.json_id(inout out, borrow workflow, task.pool_id);
+            text.append_literal(inout out, "}},{\"key\":\"lattice.priority\",\"value\":{\"intValue\":\"");
+            text.append_u64(inout out, task.priority); text.append_literal(inout out, "\"}},{\"key\":\"lattice.attempts\",\"value\":{\"intValue\":\"");
+            text.append_u64(inout out, run.attempts.get_or(i, 0)); text.append_literal(inout out, "\"}}],\"links\":");
+            links(inout out, borrow workflow, i); out.push(125); emitted += 1;
+        }
+        i += 1;
+    }
+    text.append_literal(inout out, "]}]}]}\n");
+    out
+}

--- a/performance/workloads/lattice/report_paths.rue
+++ b/performance/workloads/lattice/report_paths.rue
@@ -1,0 +1,25 @@
+// Root/leaf path cardinality and bottleneck report.
+const model = @import("model.rue");
+const path_catalog = @import("path_catalog.rue");
+const std = @import("std");
+const text = @import("text.rue");
+const StrBuf = std.strbuf.StrBuf;
+
+pub fn render(borrow workflow: model.Workflow) -> StrBuf {
+    let paths = path_catalog.compute(borrow workflow);
+    let mut out = StrBuf.new();
+    text.append_literal(inout out, "PATH CATALOG roots="); text.append_u64(inout out, paths.roots);
+    text.append_literal(inout out, " leaves="); text.append_u64(inout out, paths.leaves);
+    text.append_literal(inout out, " total_paths="); text.append_u64(inout out, paths.total_paths);
+    text.append_literal(inout out, " saturated="); text.append_u64(inout out, paths.saturated_additions); out.push(10);
+    let mut i: u64 = 0;
+    while i < workflow.tasks.len() {
+        let task = workflow.tasks.get_or(i, model.empty_task());
+        text.append_literal(inout out, "task="); text.append_id(inout out, borrow workflow, task.id);
+        text.append_literal(inout out, " from_roots="); text.append_u64(inout out, paths.paths_from_roots.get_or(i, 0));
+        text.append_literal(inout out, " to_leaves="); text.append_u64(inout out, paths.paths_to_leaves.get_or(i, 0));
+        text.append_literal(inout out, " through="); text.append_u64(inout out, paths.paths_through_task.get_or(i, 0)); out.push(10);
+        i += 1;
+    }
+    out
+}

--- a/performance/workloads/lattice/report_policy.rue
+++ b/performance/workloads/lattice/report_policy.rue
@@ -1,0 +1,31 @@
+// Production SLO evaluation report.
+const model = @import("model.rue");
+const policy = @import("policy.rue");
+const state = @import("state.rue");
+const std = @import("std");
+const text = @import("text.rue");
+const StrBuf = std.strbuf.StrBuf;
+
+pub fn render(borrow workflow: model.Workflow, borrow run: state.Run) -> StrBuf {
+    let profile = policy.production();
+    let evaluation = policy.evaluate(borrow workflow, borrow run, borrow profile);
+    let mut out = StrBuf.new();
+    text.append_literal(inout out, "POLICY checks="); text.append_u64(inout out, evaluation.checks);
+    text.append_literal(inout out, " failures="); text.append_u64(inout out, evaluation.failures);
+    text.append_literal(inout out, " passed="); text.append_bool(inout out, evaluation.passed); out.push(10);
+    let mut i: u64 = 0;
+    while i < evaluation.violations.len() {
+        let value = evaluation.violations.get_or(i, policy.Violation {
+            code: 0, actual: 0, expected: 0, task: model.NONE(), pool: model.NONE(),
+        });
+        text.append_literal(inout out, "violation="); text.append_literal(inout out, policy.code_name(value.code));
+        text.append_literal(inout out, " actual="); text.append_u64(inout out, value.actual);
+        text.append_literal(inout out, " expected="); text.append_u64(inout out, value.expected);
+        text.append_literal(inout out, " task=");
+        if value.task < workflow.tasks.len() {
+            text.append_id(inout out, borrow workflow, workflow.tasks.get_or(value.task, model.empty_task()).id);
+        } else { text.append_literal(inout out, "<none>"); }
+        out.push(10); i += 1;
+    }
+    out
+}

--- a/performance/workloads/lattice/report_prometheus.rue
+++ b/performance/workloads/lattice/report_prometheus.rue
@@ -1,0 +1,26 @@
+// Prometheus text exposition for scheduler and workflow gauges.
+const model = @import("model.rue");
+const state = @import("state.rue");
+const std = @import("std");
+const text = @import("text.rue");
+const StrBuf = std.strbuf.StrBuf;
+
+fn metric(inout out: StrBuf, name: str, help: str, value: u64) {
+    text.append_literal(inout out, "# HELP "); text.append_literal(inout out, name); out.push(32); text.append_literal(inout out, help); out.push(10);
+    text.append_literal(inout out, "# TYPE "); text.append_literal(inout out, name); text.append_literal(inout out, " gauge\n");
+    text.append_literal(inout out, name); out.push(32); text.append_u64(inout out, value); out.push(10);
+}
+
+pub fn render(borrow workflow: model.Workflow, borrow run: state.Run) -> StrBuf {
+    let mut out = StrBuf.new();
+    metric(inout out, "lattice_workflow_tasks", "Declared workflow tasks.", workflow.tasks.len());
+    metric(inout out, "lattice_workflow_edges", "Declared dependency edges.", workflow.edges.len());
+    metric(inout out, "lattice_schedule_makespan_ticks", "Schedule completion time.", run.makespan);
+    metric(inout out, "lattice_schedule_succeeded_tasks", "Successfully executed tasks.", run.succeeded);
+    metric(inout out, "lattice_schedule_failed_tasks", "Failed tasks.", run.failed);
+    metric(inout out, "lattice_schedule_cached_tasks", "Cache hits.", run.cached);
+    metric(inout out, "lattice_schedule_retries", "Consumed retry attempts.", run.retries);
+    metric(inout out, "lattice_schedule_resource_waits", "Resource wait observations.", run.resource_waits);
+    metric(inout out, "lattice_schedule_dependency_waits", "Dependency wait observations.", run.dependency_waits);
+    out
+}

--- a/performance/workloads/lattice/report_query.rue
+++ b/performance/workloads/lattice/report_query.rue
@@ -1,0 +1,34 @@
+// Saved operational queries and ranked matches.
+const model = @import("model.rue");
+const query = @import("query.rue");
+const state = @import("state.rue");
+const std = @import("std");
+const text = @import("text.rue");
+const StrBuf = std.strbuf.StrBuf;
+
+fn section(inout out: StrBuf, label: str, borrow workflow: model.Workflow, borrow result: query.Result) {
+    text.append_literal(inout out, label); text.append_literal(inout out, " matches=");
+    text.append_u64(inout out, result.matches); text.append_literal(inout out, " duration=");
+    text.append_u64(inout out, result.total_duration); out.push(10);
+    let mut i: u64 = 0;
+    while i < result.tasks.len() {
+        let index = result.tasks.get_or(i, model.NONE());
+        let task = workflow.tasks.get_or(index, model.empty_task());
+        text.append_literal(inout out, "  "); text.append_id(inout out, borrow workflow, task.id);
+        text.append_literal(inout out, " priority="); text.append_u64(inout out, task.priority);
+        text.append_literal(inout out, " duration="); text.append_u64(inout out, task.duration); out.push(10);
+        i += 1;
+    }
+}
+
+pub fn render(borrow workflow: model.Workflow, borrow run: state.Run) -> StrBuf {
+    let risky_query = query.high_risk();
+    let candidate_query = query.cache_candidates();
+    let risky = query.execute(borrow workflow, borrow run, borrow risky_query);
+    let candidates = query.execute(borrow workflow, borrow run, borrow candidate_query);
+    let mut out = StrBuf.new();
+    text.append_literal(inout out, "SAVED QUERIES\n");
+    section(inout out, "high-risk", borrow workflow, borrow risky);
+    section(inout out, "cache-candidates", borrow workflow, borrow candidates);
+    out
+}

--- a/performance/workloads/lattice/report_resources.rue
+++ b/performance/workloads/lattice/report_resources.rue
@@ -1,0 +1,47 @@
+// Pool capacity, observed peak, pressure, and recommendation report.
+const capacity_plan = @import("capacity_plan.rue");
+const format = @import("format.rue");
+const model = @import("model.rue");
+const pool_analysis = @import("pool_analysis.rue");
+const state = @import("state.rue");
+const std = @import("std");
+const text = @import("text.rue");
+const StrBuf = std.strbuf.StrBuf;
+
+fn metric(
+    inout out: StrBuf,
+    label: str,
+    capacity: u64,
+    peak: u64,
+    recommended: u64,
+) {
+    text.append_literal(inout out, "  "); text.append_literal(inout out, label);
+    text.append_literal(inout out, " capacity="); text.append_u64(inout out, capacity);
+    text.append_literal(inout out, " peak="); text.append_u64(inout out, peak);
+    text.append_literal(inout out, " pressure="); text.append_percent(inout out, peak, capacity);
+    text.append_literal(inout out, " recommended="); text.append_u64(inout out, recommended);
+    text.append_literal(inout out, " ["); format.append_bar(inout out, peak, capacity, 20); text.append_literal(inout out, "]\n");
+}
+
+pub fn render(borrow workflow: model.Workflow, borrow run: state.Run) -> StrBuf {
+    let pools = pool_analysis.compute(borrow workflow, borrow run);
+    let plan = capacity_plan.compute(borrow workflow, borrow run);
+    let mut out = StrBuf.new();
+    text.append_literal(inout out, "RESOURCE PLAN workflow="); text.append_id(inout out, borrow workflow, workflow.name); out.push(10);
+    let mut i: u64 = 0;
+    while i < workflow.pools.len() {
+        let pool = workflow.pools.get_or(i, model.empty_pool());
+        text.append_literal(inout out, "pool "); text.append_id(inout out, borrow workflow, pool.id);
+        text.append_literal(inout out, " tasks="); text.append_u64(inout out, pools.assigned_tasks.get_or(i, 0));
+        text.append_literal(inout out, " work="); text.append_u64(inout out, pools.declared_work.get_or(i, 0)); out.push(10);
+        metric(inout out, "slots", pool.slots, pools.peak_slots.get_or(i, 0), plan.recommended_slots.get_or(i, 0));
+        metric(inout out, "cpu", pool.cpu, pools.peak_cpu.get_or(i, 0), plan.recommended_cpu.get_or(i, 0));
+        metric(inout out, "memory", pool.memory, pools.peak_memory.get_or(i, 0), plan.recommended_memory.get_or(i, 0));
+        i += 1;
+    }
+    text.append_literal(inout out, "saturated_pools="); text.append_u64(inout out, plan.saturated_pools);
+    text.append_literal(inout out, " slot_increase="); text.append_u64(inout out, plan.total_slot_increase);
+    text.append_literal(inout out, " cpu_increase="); text.append_u64(inout out, plan.total_cpu_increase);
+    text.append_literal(inout out, " memory_increase="); text.append_u64(inout out, plan.total_memory_increase); out.push(10);
+    out
+}

--- a/performance/workloads/lattice/report_retries.rue
+++ b/performance/workloads/lattice/report_retries.rue
@@ -1,0 +1,28 @@
+// Retry-budget consumption and recovery report.
+const model = @import("model.rue");
+const retry_analysis = @import("retry_analysis.rue");
+const state = @import("state.rue");
+const std = @import("std");
+const text = @import("text.rue");
+const StrBuf = std.strbuf.StrBuf;
+
+pub fn render(borrow workflow: model.Workflow, borrow run: state.Run) -> StrBuf {
+    let retries = retry_analysis.compute(borrow workflow, borrow run);
+    let mut out = StrBuf.new();
+    text.append_literal(inout out, "RETRY REPORT\nbudget="); text.append_u64(inout out, retries.configured_budget);
+    text.append_literal(inout out, " attempts="); text.append_u64(inout out, retries.total_attempts);
+    text.append_literal(inout out, " retries="); text.append_u64(inout out, retries.observed_retries); out.push(10);
+    text.append_literal(inout out, "recovered="); text.append_u64(inout out, retries.recovered_tasks);
+    text.append_literal(inout out, " exhausted="); text.append_u64(inout out, retries.exhausted_tasks);
+    text.append_literal(inout out, " violations="); text.append_u64(inout out, retries.budget_violations); out.push(10);
+    let mut i: u64 = 0;
+    while i < workflow.pools.len() {
+        let pool = workflow.pools.get_or(i, model.empty_pool());
+        text.append_literal(inout out, "pool="); text.append_id(inout out, borrow workflow, pool.id);
+        text.append_literal(inout out, " budget="); text.append_u64(inout out, retries.budget_by_pool.get_or(i, 0));
+        text.append_literal(inout out, " attempts="); text.append_u64(inout out, retries.attempts_by_pool.get_or(i, 0));
+        text.append_literal(inout out, " retries="); text.append_u64(inout out, retries.retries_by_pool.get_or(i, 0)); out.push(10);
+        i += 1;
+    }
+    out
+}

--- a/performance/workloads/lattice/report_risk.rue
+++ b/performance/workloads/lattice/report_risk.rue
@@ -1,0 +1,41 @@
+// Ranked operational risk register derived from graph and task declarations.
+const cut_analysis = @import("cut_analysis.rue");
+const model = @import("model.rue");
+const path_catalog = @import("path_catalog.rue");
+const std = @import("std");
+const text = @import("text.rue");
+const StrBuf = std.strbuf.StrBuf;
+
+fn score(borrow workflow: model.Workflow, borrow paths: path_catalog.Catalog, task_index: u64) -> u64 {
+    let task = workflow.tasks.get_or(task_index, model.empty_task());
+    let incoming = model.dependency_count(borrow workflow, task_index);
+    let outgoing = model.dependent_count(borrow workflow, task_index);
+    let path_weight = paths.paths_through_task.get_or(task_index, 0);
+    let retry_risk = if task.fail_attempt > 0 { 40 } else { 0 };
+    let cache_relief = if task.cacheable { 10 } else { 0 };
+    let gross = task.duration * 5 + task.cpu * 3 + task.memory + incoming * 4 + outgoing * 8 +
+        if path_weight > 20 { 20 } else { path_weight } + retry_risk;
+    if gross > cache_relief { gross - cache_relief } else { 0 }
+}
+
+pub fn render(borrow workflow: model.Workflow) -> StrBuf {
+    let paths = path_catalog.compute(borrow workflow);
+    let cuts = cut_analysis.compute(borrow workflow);
+    let mut out = StrBuf.new();
+    text.append_literal(inout out, "RISK REGISTER workflow="); text.append_id(inout out, borrow workflow, workflow.name); out.push(10);
+    let mut i: u64 = 0;
+    while i < workflow.tasks.len() {
+        let task = workflow.tasks.get_or(i, model.empty_task());
+        let value = score(borrow workflow, borrow paths, i);
+        text.append_literal(inout out, "task="); text.append_id(inout out, borrow workflow, task.id);
+        text.append_literal(inout out, " score="); text.append_u64(inout out, value);
+        text.append_literal(inout out, " paths="); text.append_u64(inout out, paths.paths_through_task.get_or(i, 0));
+        text.append_literal(inout out, " fallible="); text.append_bool(inout out, task.fail_attempt > 0);
+        text.append_literal(inout out, " cacheable="); text.append_bool(inout out, task.cacheable); out.push(10);
+        i += 1;
+    }
+    text.append_literal(inout out, "mandatory_tasks="); text.append_u64(inout out, cuts.mandatory_count);
+    text.append_literal(inout out, " bridge_edges="); text.append_u64(inout out, cuts.bridge_count);
+    text.append_literal(inout out, " fanouts="); text.append_u64(inout out, cuts.fanout_count); out.push(10);
+    out
+}

--- a/performance/workloads/lattice/report_sarif.rue
+++ b/performance/workloads/lattice/report_sarif.rue
@@ -1,0 +1,33 @@
+// SARIF 2.1.0 policy-result projection for code-scanning systems.
+const model = @import("model.rue");
+const policy = @import("policy.rue");
+const state = @import("state.rue");
+const std = @import("std");
+const text = @import("text.rue");
+const StrBuf = std.strbuf.StrBuf;
+
+pub fn render(borrow workflow: model.Workflow, borrow run: state.Run) -> StrBuf {
+    let profile = policy.production();
+    let evaluation = policy.evaluate(borrow workflow, borrow run, borrow profile);
+    let mut out = StrBuf.new();
+    text.append_literal(inout out, "{\"version\":\"2.1.0\",\"$schema\":\"https://json.schemastore.org/sarif-2.1.0.json\",\"runs\":[{\"tool\":{\"driver\":{\"name\":\"Lattice\",\"informationUri\":\"https://github.com/rue-language/rue\"}},\"results\":[");
+    let mut i: u64 = 0;
+    while i < evaluation.violations.len() {
+        if i > 0 { out.push(44); }
+        let value = evaluation.violations.get_or(i, policy.Violation {
+            code: 0, actual: 0, expected: 0, task: model.NONE(), pool: model.NONE(),
+        });
+        text.append_literal(inout out, "{\"ruleId\":\""); text.append_literal(inout out, policy.code_name(value.code));
+        text.append_literal(inout out, "\",\"level\":\"error\",\"message\":{\"text\":\"actual ");
+        text.append_u64(inout out, value.actual); text.append_literal(inout out, " violates threshold ");
+        text.append_u64(inout out, value.expected); text.append_literal(inout out, "\"}");
+        if value.task < workflow.tasks.len() {
+            let task = workflow.tasks.get_or(value.task, model.empty_task());
+            text.append_literal(inout out, ",\"locations\":[{\"logicalLocations\":[{\"name\":");
+            text.json_id(inout out, borrow workflow, task.id); text.append_literal(inout out, "}]}]");
+        }
+        out.push(125); i += 1;
+    }
+    text.append_literal(inout out, "]}]}\n");
+    out
+}

--- a/performance/workloads/lattice/report_sql.rue
+++ b/performance/workloads/lattice/report_sql.rue
@@ -1,0 +1,49 @@
+// Transactional SQL snapshot for relational ingestion.
+const model = @import("model.rue");
+const state = @import("state.rue");
+const std = @import("std");
+const text = @import("text.rue");
+const StrBuf = std.strbuf.StrBuf;
+
+fn quoted_id(inout out: StrBuf, borrow workflow: model.Workflow, id: u64) {
+    out.push(39);
+    let mut i: u64 = 0;
+    while i < workflow.strings.string_len(id) {
+        let byte = workflow.strings.byte_at(id, i);
+        if byte == 39 { out.push(39); out.push(39); } else { out.push(byte); }
+        i += 1;
+    }
+    out.push(39);
+}
+
+pub fn render(borrow workflow: model.Workflow, borrow run: state.Run) -> StrBuf {
+    let mut out = StrBuf.new();
+    text.append_literal(inout out, "BEGIN;\nCREATE TABLE lattice_task(task_id TEXT PRIMARY KEY,pool_id TEXT,duration INTEGER,priority INTEGER,status INTEGER,attempts INTEGER,start_tick INTEGER,end_tick INTEGER);\n");
+    text.append_literal(inout out, "CREATE TABLE lattice_edge(before_id TEXT,after_id TEXT,PRIMARY KEY(before_id,after_id));\n");
+    text.append_literal(inout out, "CREATE TABLE lattice_event(sequence INTEGER PRIMARY KEY,time_tick INTEGER,kind INTEGER,task_index INTEGER,pool_index INTEGER,attempt INTEGER);\n");
+    let mut i: u64 = 0;
+    while i < workflow.tasks.len() {
+        let task = workflow.tasks.get_or(i, model.empty_task());
+        text.append_literal(inout out, "INSERT INTO lattice_task VALUES("); quoted_id(inout out, borrow workflow, task.id); out.push(44);
+        quoted_id(inout out, borrow workflow, task.pool_id); out.push(44); text.append_u64(inout out, task.duration); out.push(44);
+        text.append_u64(inout out, task.priority); out.push(44); text.append_u64(inout out, run.status.get_or(i, state.FAILED())); out.push(44);
+        text.append_u64(inout out, run.attempts.get_or(i, 0)); out.push(44); text.append_u64(inout out, run.starts.get_or(i, 0)); out.push(44);
+        text.append_u64(inout out, run.ends.get_or(i, 0)); text.append_literal(inout out, ");\n"); i += 1;
+    }
+    i = 0;
+    while i < workflow.edges.len() {
+        let edge = workflow.edges.get_or(i, model.empty_edge());
+        text.append_literal(inout out, "INSERT INTO lattice_edge VALUES("); quoted_id(inout out, borrow workflow, edge.before_id);
+        out.push(44); quoted_id(inout out, borrow workflow, edge.after_id); text.append_literal(inout out, ");\n"); i += 1;
+    }
+    i = 0;
+    while i < run.events.len() {
+        let event = run.events.get_or(i, state.empty_event());
+        text.append_literal(inout out, "INSERT INTO lattice_event VALUES("); text.append_u64(inout out, i); out.push(44);
+        text.append_u64(inout out, event.time); out.push(44); text.append_u64(inout out, event.kind); out.push(44);
+        text.append_u64(inout out, event.task); out.push(44); text.append_u64(inout out, event.pool); out.push(44);
+        text.append_u64(inout out, event.attempt); text.append_literal(inout out, ");\n"); i += 1;
+    }
+    text.append_literal(inout out, "COMMIT;\n");
+    out
+}

--- a/performance/workloads/lattice/report_suite.rue
+++ b/performance/workloads/lattice/report_suite.rue
@@ -1,0 +1,126 @@
+// Exercise every reporting adapter and validate deterministic non-empty output.
+const model = @import("model.rue");
+const policy_suite = @import("policy_suite.rue");
+const report_cache = @import("report_cache.rue");
+const report_capacity = @import("report_capacity.rue");
+const report_chrome_trace = @import("report_chrome_trace.rue");
+const report_comparison = @import("report_comparison.rue");
+const report_critical = @import("report_critical.rue");
+const report_dot = @import("report_dot.rue");
+const report_events_csv = @import("report_events_csv.rue");
+const report_explain = @import("report_explain.rue");
+const report_forecast = @import("report_forecast.rue");
+const report_html = @import("report_html.rue");
+const report_json = @import("report_json.rue");
+const report_junit = @import("report_junit.rue");
+const report_lint = @import("report_lint.rue");
+const report_manifest = @import("report_manifest.rue");
+const report_markdown = @import("report_markdown.rue");
+const report_matrix = @import("report_matrix.rue");
+const report_mermaid = @import("report_mermaid.rue");
+const report_ndjson = @import("report_ndjson.rue");
+const report_otel = @import("report_otel.rue");
+const report_paths = @import("report_paths.rue");
+const report_policy = @import("report_policy.rue");
+const report_prometheus = @import("report_prometheus.rue");
+const report_query = @import("report_query.rue");
+const report_resources = @import("report_resources.rue");
+const report_retries = @import("report_retries.rue");
+const report_risk = @import("report_risk.rue");
+const report_sarif = @import("report_sarif.rue");
+const report_sql = @import("report_sql.rue");
+const report_tasks_csv = @import("report_tasks_csv.rue");
+const report_timeline = @import("report_timeline.rue");
+const report_trace = @import("report_trace.rue");
+const report_yaml = @import("report_yaml.rue");
+const state = @import("state.rue");
+const std = @import("std");
+const text = @import("text.rue");
+const StrBuf = std.strbuf.StrBuf;
+
+pub struct Result {
+    documents: u64,
+    bytes: u64,
+    empty_documents: u64,
+    prefix_mismatches: u64,
+    deterministic_mismatches: u64,
+    policy_profiles: u64,
+    policy_checks: u64,
+    policy_failures: u64,
+    digest: u64,
+    valid: bool,
+}
+
+fn mix(hash: u64, value: u64) -> u64 { @wrapping_mul(hash ^ value, 1099511628211) }
+
+fn include(inout result: Result, document: StrBuf, expected_prefix: u8) {
+    result.documents += 1;
+    result.bytes += document.len();
+    if document.len() == 0 { result.empty_documents += 1; }
+    else if StrBuf.byte_at_borrowed(borrow document, 0) != expected_prefix {
+        result.prefix_mismatches += 1;
+    }
+    result.digest = mix(result.digest, text.fnv1a(borrow document));
+    result.digest = mix(result.digest, document.len());
+}
+
+fn once(borrow workflow: model.Workflow, borrow run: state.Run, seed: u64) -> Result {
+    let policies = policy_suite.run(borrow workflow, borrow run);
+    let mut result = Result {
+        documents: 0, bytes: 0, empty_documents: 0, prefix_mismatches: 0,
+        deterministic_mismatches: 0, policy_profiles: policies.profiles,
+        policy_checks: policies.checks, policy_failures: policies.unexpected_failures,
+        digest: policies.digest, valid: false,
+    };
+    include(inout result, report_json.render(borrow workflow, borrow run), 123);
+    include(inout result, report_dot.render(borrow workflow, borrow run), 100);
+    include(inout result, report_tasks_csv.render(borrow workflow, borrow run), 116);
+    include(inout result, report_events_csv.render(borrow workflow, borrow run), 115);
+    include(inout result, report_timeline.render(borrow workflow, borrow run), 76);
+    include(inout result, report_resources.render(borrow workflow, borrow run), 82);
+    include(inout result, report_critical.render(borrow workflow), 67);
+    include(inout result, report_manifest.render(borrow workflow, borrow run), 108);
+    include(inout result, report_markdown.render(borrow workflow, borrow run), 35);
+    include(inout result, report_matrix.render(borrow workflow), 65);
+    include(inout result, report_risk.render(borrow workflow), 82);
+    include(inout result, report_cache.render(borrow workflow, borrow run), 67);
+    include(inout result, report_retries.render(borrow workflow, borrow run), 82);
+    include(inout result, report_paths.render(borrow workflow), 80);
+    include(inout result, report_capacity.render(borrow workflow, borrow run), 112);
+    include(inout result, report_forecast.render(borrow workflow, seed), 70);
+    include(inout result, report_trace.render(borrow workflow, borrow run), 69);
+    include(inout result, report_explain.render(borrow workflow, borrow run), 84);
+    include(inout result, report_policy.render(borrow workflow, borrow run), 80);
+    include(inout result, report_query.render(borrow workflow, borrow run), 83);
+    include(inout result, report_comparison.render(borrow workflow, borrow run, seed + 1), 82);
+    include(inout result, report_html.render(borrow workflow, borrow run), 60);
+    include(inout result, report_junit.render(borrow workflow, borrow run), 60);
+    include(inout result, report_lint.render(borrow workflow, borrow run), 76);
+    include(inout result, report_sarif.render(borrow workflow, borrow run), 123);
+    include(inout result, report_prometheus.render(borrow workflow, borrow run), 35);
+    include(inout result, report_sql.render(borrow workflow, borrow run), 66);
+    include(inout result, report_mermaid.render(borrow workflow), 102);
+    include(inout result, report_ndjson.render(borrow workflow, borrow run), 123);
+    include(inout result, report_otel.render(borrow workflow, borrow run), 123);
+    include(inout result, report_chrome_trace.render(borrow workflow, borrow run), 123);
+    include(inout result, report_yaml.render(borrow workflow, borrow run), 119);
+    result.valid = result.empty_documents == 0 && result.prefix_mismatches == 0 &&
+        result.policy_failures == 0;
+    result
+}
+
+pub fn audit(borrow workflow: model.Workflow, borrow run: state.Run, seed: u64) -> Result {
+    let first = once(borrow workflow, borrow run, seed);
+    let second = once(borrow workflow, borrow run, seed);
+    let mismatches = if first.documents == second.documents && first.bytes == second.bytes &&
+        first.digest == second.digest { 0 } else { 1 };
+    Result {
+        documents: first.documents, bytes: first.bytes,
+        empty_documents: first.empty_documents,
+        prefix_mismatches: first.prefix_mismatches,
+        deterministic_mismatches: mismatches,
+        policy_profiles: first.policy_profiles, policy_checks: first.policy_checks,
+        policy_failures: first.policy_failures, digest: first.digest,
+        valid: first.valid && second.valid && mismatches == 0,
+    }
+}

--- a/performance/workloads/lattice/report_tasks_csv.rue
+++ b/performance/workloads/lattice/report_tasks_csv.rue
@@ -1,0 +1,31 @@
+// RFC-4180-style task table suitable for spreadsheet analysis.
+const format = @import("format.rue");
+const model = @import("model.rue");
+const state = @import("state.rue");
+const std = @import("std");
+const text = @import("text.rue");
+const StrBuf = std.strbuf.StrBuf;
+
+pub fn render(borrow workflow: model.Workflow, borrow run: state.Run) -> StrBuf {
+    let mut out = StrBuf.new();
+    text.append_literal(inout out, "task,pool,duration,cpu,memory,priority,retry_budget,cacheable,status,attempts,start,end\r\n");
+    let mut i: u64 = 0;
+    while i < workflow.tasks.len() {
+        let task = workflow.tasks.get_or(i, model.empty_task());
+        format.csv_id(inout out, borrow workflow, task.id); out.push(44);
+        format.csv_id(inout out, borrow workflow, task.pool_id); out.push(44);
+        text.append_u64(inout out, task.duration); out.push(44);
+        text.append_u64(inout out, task.cpu); out.push(44);
+        text.append_u64(inout out, task.memory); out.push(44);
+        text.append_u64(inout out, task.priority); out.push(44);
+        text.append_u64(inout out, task.retries); out.push(44);
+        text.append_bool(inout out, task.cacheable); out.push(44);
+        format.append_status(inout out, run.status.get_or(i, state.FAILED())); out.push(44);
+        text.append_u64(inout out, run.attempts.get_or(i, 0)); out.push(44);
+        format.append_optional_u64(inout out, run.starts.get_or(i, model.NONE())); out.push(44);
+        format.append_optional_u64(inout out, run.ends.get_or(i, model.NONE()));
+        text.append_literal(inout out, "\r\n");
+        i += 1;
+    }
+    out
+}

--- a/performance/workloads/lattice/report_timeline.rue
+++ b/performance/workloads/lattice/report_timeline.rue
@@ -1,0 +1,60 @@
+// Fixed-width text Gantt chart with dependency and queue-delay context.
+const format = @import("format.rue");
+const model = @import("model.rue");
+const queue_analysis = @import("queue_analysis.rue");
+const state = @import("state.rue");
+const std = @import("std");
+const text = @import("text.rue");
+const StrBuf = std.strbuf.StrBuf;
+
+fn append_padding(inout out: StrBuf, used: u64, width: u64) {
+    let mut i = used;
+    while i < width { out.push(32); i += 1; }
+}
+
+fn append_task_label(inout out: StrBuf, borrow workflow: model.Workflow, id: u64, width: u64) {
+    let length = workflow.strings.string_len(id);
+    let limit = if length < width { length } else { width };
+    let mut i: u64 = 0;
+    while i < limit { out.push(workflow.strings.byte_at(id, i)); i += 1; }
+    append_padding(inout out, limit, width);
+}
+
+fn append_gantt(inout out: StrBuf, start: u64, end: u64, makespan: u64, width: u64) {
+    let first = if makespan == 0 { 0 } else { (start * width) / makespan };
+    let mut last = if makespan == 0 { first } else { (end * width) / makespan };
+    if last <= first { last = first + 1; }
+    if last > width { last = width; }
+    let mut i: u64 = 0;
+    while i < width {
+        if i >= first && i < last { out.push(61); }
+        else { out.push(46); }
+        i += 1;
+    }
+}
+
+pub fn render(borrow workflow: model.Workflow, borrow run: state.Run) -> StrBuf {
+    let queue = queue_analysis.compute(borrow workflow, borrow run);
+    let mut out = StrBuf.new();
+    text.append_literal(inout out, "LATTICE TIMELINE workflow="); text.append_id(inout out, borrow workflow, workflow.name);
+    text.append_literal(inout out, " makespan="); text.append_u64(inout out, run.makespan); out.push(10);
+    text.append_literal(inout out, "task                 | schedule                                 | start end wait status\n");
+    text.append_literal(inout out, "---------------------+------------------------------------------+----------------------\n");
+    let mut i: u64 = 0;
+    while i < workflow.tasks.len() {
+        let task = workflow.tasks.get_or(i, model.empty_task());
+        append_task_label(inout out, borrow workflow, task.id, 20); text.append_literal(inout out, " | ");
+        let start = run.starts.get_or(i, model.NONE());
+        let end = run.ends.get_or(i, model.NONE());
+        if start == model.NONE() || end == model.NONE() { text.append_literal(inout out, "........................................"); }
+        else { append_gantt(inout out, start, end, run.makespan, 40); }
+        text.append_literal(inout out, " | "); format.append_optional_u64(inout out, start); out.push(32);
+        format.append_optional_u64(inout out, end); out.push(32);
+        text.append_u64(inout out, queue.queue_delay.get_or(i, 0)); out.push(32);
+        format.append_status(inout out, run.status.get_or(i, state.FAILED())); out.push(10);
+        i += 1;
+    }
+    text.append_literal(inout out, "total_queue_delay="); text.append_u64(inout out, queue.total_queue_delay);
+    text.append_literal(inout out, " maximum_queue_delay="); text.append_u64(inout out, queue.maximum_queue_delay); out.push(10);
+    out
+}

--- a/performance/workloads/lattice/report_trace.rue
+++ b/performance/workloads/lattice/report_trace.rue
@@ -1,0 +1,34 @@
+// Human-readable event trace with resolved task and pool names.
+const format = @import("format.rue");
+const model = @import("model.rue");
+const state = @import("state.rue");
+const std = @import("std");
+const text = @import("text.rue");
+const StrBuf = std.strbuf.StrBuf;
+
+pub fn render(borrow workflow: model.Workflow, borrow run: state.Run) -> StrBuf {
+    let mut out = StrBuf.new();
+    text.append_literal(inout out, "EVENT TRACE events="); text.append_u64(inout out, run.events.len()); out.push(10);
+    let mut i: u64 = 0;
+    while i < run.events.len() {
+        let event = run.events.get_or(i, state.empty_event());
+        text.append_literal(inout out, "#"); text.append_u64(inout out, i);
+        text.append_literal(inout out, " t="); text.append_u64(inout out, event.time);
+        text.append_literal(inout out, " kind="); format.append_event_kind(inout out, event.kind);
+        text.append_literal(inout out, " task=");
+        if event.task < workflow.tasks.len() {
+            let task = workflow.tasks.get_or(event.task, model.empty_task());
+            text.append_id(inout out, borrow workflow, task.id);
+        } else { text.append_literal(inout out, "<none>"); }
+        text.append_literal(inout out, " pool=");
+        if event.pool < workflow.pools.len() {
+            let pool = workflow.pools.get_or(event.pool, model.empty_pool());
+            text.append_id(inout out, borrow workflow, pool.id);
+        } else { text.append_literal(inout out, "<none>"); }
+        text.append_literal(inout out, " attempt="); text.append_u64(inout out, event.attempt);
+        text.append_literal(inout out, " cpu="); text.append_u64(inout out, event.cpu);
+        text.append_literal(inout out, " memory="); text.append_u64(inout out, event.memory); out.push(10);
+        i += 1;
+    }
+    out
+}

--- a/performance/workloads/lattice/report_yaml.rue
+++ b/performance/workloads/lattice/report_yaml.rue
@@ -1,0 +1,32 @@
+// Readable YAML snapshot for configuration and artifact tooling.
+const format = @import("format.rue");
+const model = @import("model.rue");
+const state = @import("state.rue");
+const std = @import("std");
+const text = @import("text.rue");
+const StrBuf = std.strbuf.StrBuf;
+
+pub fn render(borrow workflow: model.Workflow, borrow run: state.Run) -> StrBuf {
+    let mut out = StrBuf.new();
+    text.append_literal(inout out, "workflow: "); text.append_id(inout out, borrow workflow, workflow.name); out.push(10);
+    text.append_literal(inout out, "summary:\n  makespan: "); text.append_u64(inout out, run.makespan);
+    text.append_literal(inout out, "\n  succeeded: "); text.append_u64(inout out, run.succeeded);
+    text.append_literal(inout out, "\n  cached: "); text.append_u64(inout out, run.cached);
+    text.append_literal(inout out, "\n  failed: "); text.append_u64(inout out, run.failed);
+    text.append_literal(inout out, "\n  retries: "); text.append_u64(inout out, run.retries);
+    text.append_literal(inout out, "\ntasks:\n");
+    let mut i: u64 = 0;
+    while i < workflow.tasks.len() {
+        let task = workflow.tasks.get_or(i, model.empty_task());
+        text.append_literal(inout out, "  - id: "); text.append_id(inout out, borrow workflow, task.id);
+        text.append_literal(inout out, "\n    pool: "); text.append_id(inout out, borrow workflow, task.pool_id);
+        text.append_literal(inout out, "\n    duration: "); text.append_u64(inout out, task.duration);
+        text.append_literal(inout out, "\n    priority: "); text.append_u64(inout out, task.priority);
+        text.append_literal(inout out, "\n    status: "); format.append_status(inout out, run.status.get_or(i, state.FAILED()));
+        text.append_literal(inout out, "\n    attempts: "); text.append_u64(inout out, run.attempts.get_or(i, 0));
+        text.append_literal(inout out, "\n    start: "); format.append_optional_u64(inout out, run.starts.get_or(i, model.NONE()));
+        text.append_literal(inout out, "\n    end: "); format.append_optional_u64(inout out, run.ends.get_or(i, model.NONE())); out.push(10);
+        i += 1;
+    }
+    out
+}

--- a/performance/workloads/lattice/resource_audit.rue
+++ b/performance/workloads/lattice/resource_audit.rue
@@ -1,0 +1,118 @@
+// Reconstruct pool usage from scheduler events and prove capacity bounds.
+const model = @import("model.rue");
+const state = @import("state.rue");
+
+pub struct Audit {
+    active_slots: model.U64s,
+    active_cpu: model.U64s,
+    active_memory: model.U64s,
+    maximum_slots: model.U64s,
+    maximum_cpu: model.U64s,
+    maximum_memory: model.U64s,
+    events: u64,
+    underflows: u64,
+    slot_violations: u64,
+    cpu_violations: u64,
+    memory_violations: u64,
+    terminal_active: u64,
+    digest: u64,
+    ok: bool,
+}
+
+fn zeroes(count: u64) -> model.U64s {
+    let mut result = model.U64s.with_capacity(count);
+    let mut i: u64 = 0;
+    while i < count { result.push(0); i += 1; }
+    result
+}
+
+fn add(inout values: model.U64s, index: u64, amount: u64) {
+    values.set(index, values.get_or(index, 0) + amount);
+}
+
+fn subtract(inout values: model.U64s, index: u64, amount: u64) -> bool {
+    let old = values.get_or(index, 0);
+    if amount > old { values.set(index, 0); true }
+    else { values.set(index, old - amount); false }
+}
+
+fn update_max(inout maximum: model.U64s, borrow current: model.U64s, index: u64) {
+    let value = current.get_or(index, 0);
+    if value > maximum.get_or(index, 0) { maximum.set(index, value); }
+}
+
+fn mix(hash: u64, value: u64) -> u64 { @wrapping_mul(hash ^ value, 1099511628211) }
+
+pub fn audit(borrow workflow: model.Workflow, borrow run: state.Run) -> Audit {
+    let count = workflow.pools.len();
+    let mut active_slots = zeroes(count);
+    let mut active_cpu = zeroes(count);
+    let mut active_memory = zeroes(count);
+    let mut maximum_slots = zeroes(count);
+    let mut maximum_cpu = zeroes(count);
+    let mut maximum_memory = zeroes(count);
+    let mut underflows: u64 = 0;
+    let mut slot_violations: u64 = 0;
+    let mut cpu_violations: u64 = 0;
+    let mut memory_violations: u64 = 0;
+    let mut digest: u64 = 14695981039346656037;
+    let mut i: u64 = 0;
+    while i < run.events.len() {
+        let event = run.events.get_or(i, state.empty_event());
+        if event.pool < count {
+            if event.kind == state.EVENT_START() {
+                add(inout active_slots, event.pool, 1);
+                add(inout active_cpu, event.pool, event.cpu);
+                add(inout active_memory, event.pool, event.memory);
+                update_max(inout maximum_slots, borrow active_slots, event.pool);
+                update_max(inout maximum_cpu, borrow active_cpu, event.pool);
+                update_max(inout maximum_memory, borrow active_memory, event.pool);
+                let pool = workflow.pools.get_or(event.pool, model.empty_pool());
+                if active_slots.get_or(event.pool, 0) > pool.slots { slot_violations += 1; }
+                if active_cpu.get_or(event.pool, 0) > pool.cpu { cpu_violations += 1; }
+                if active_memory.get_or(event.pool, 0) > pool.memory { memory_violations += 1; }
+            } else if event.kind == state.EVENT_SUCCESS() || event.kind == state.EVENT_FAILURE() {
+                if subtract(inout active_slots, event.pool, 1) { underflows += 1; }
+                if subtract(inout active_cpu, event.pool, event.cpu) { underflows += 1; }
+                if subtract(inout active_memory, event.pool, event.memory) { underflows += 1; }
+            }
+        }
+        digest = mix(digest, event.kind); digest = mix(digest, event.time);
+        digest = mix(digest, event.pool); digest = mix(digest, event.cpu); digest = mix(digest, event.memory);
+        i += 1;
+    }
+    let mut terminal_active: u64 = 0;
+    i = 0;
+    while i < count {
+        terminal_active += active_slots.get_or(i, 0);
+        terminal_active += active_cpu.get_or(i, 0);
+        terminal_active += active_memory.get_or(i, 0);
+        digest = mix(digest, maximum_slots.get_or(i, 0));
+        digest = mix(digest, maximum_cpu.get_or(i, 0));
+        digest = mix(digest, maximum_memory.get_or(i, 0));
+        i += 1;
+    }
+    let ok = underflows == 0 && slot_violations == 0 && cpu_violations == 0 &&
+        memory_violations == 0 && terminal_active == 0;
+    Audit {
+        active_slots: active_slots, active_cpu: active_cpu, active_memory: active_memory,
+        maximum_slots: maximum_slots, maximum_cpu: maximum_cpu, maximum_memory: maximum_memory,
+        events: run.events.len(), underflows: underflows,
+        slot_violations: slot_violations, cpu_violations: cpu_violations,
+        memory_violations: memory_violations, terminal_active: terminal_active,
+        digest: digest, ok: ok,
+    }
+}
+
+pub fn verify(borrow workflow: model.Workflow, borrow audit: Audit) -> bool {
+    if !audit.ok || audit.maximum_slots.len() != workflow.pools.len() { return false; }
+    let mut i: u64 = 0;
+    while i < workflow.pools.len() {
+        let pool = workflow.pools.get_or(i, model.empty_pool());
+        if audit.maximum_slots.get_or(i, 0) > pool.slots { return false; }
+        if audit.maximum_cpu.get_or(i, 0) > pool.cpu { return false; }
+        if audit.maximum_memory.get_or(i, 0) > pool.memory { return false; }
+        i += 1;
+    }
+    true
+}

--- a/performance/workloads/lattice/retry_analysis.rue
+++ b/performance/workloads/lattice/retry_analysis.rue
@@ -1,0 +1,84 @@
+// Retry budgets, attempts, recovery, and exhaustion statistics.
+const model = @import("model.rue");
+const state = @import("state.rue");
+
+pub struct Analysis {
+    attempts_by_pool: model.U64s,
+    retries_by_pool: model.U64s,
+    budget_by_pool: model.U64s,
+    configured_budget: u64,
+    total_attempts: u64,
+    observed_retries: u64,
+    recovered_tasks: u64,
+    exhausted_tasks: u64,
+    untouched_fallible_tasks: u64,
+    budget_violations: u64,
+    maximum_attempts: u64,
+    maximum_attempt_task: u64,
+    digest: u64,
+    valid: bool,
+}
+
+fn zeroes(count: u64) -> model.U64s {
+    let mut values = model.U64s.with_capacity(count);
+    let mut i: u64 = 0;
+    while i < count { values.push(0); i += 1; }
+    values
+}
+
+fn add(inout values: model.U64s, index: u64, amount: u64) {
+    if index < values.len() { values.set(index, values.get_or(index, 0) + amount); }
+}
+
+fn mix(hash: u64, value: u64) -> u64 { @wrapping_mul(hash ^ value, 1099511628211) }
+
+pub fn compute(borrow workflow: model.Workflow, borrow run: state.Run) -> Analysis {
+    let mut attempts_by_pool = zeroes(workflow.pools.len());
+    let mut retries_by_pool = zeroes(workflow.pools.len());
+    let mut budget_by_pool = zeroes(workflow.pools.len());
+    let mut configured_budget: u64 = 0;
+    let mut total_attempts: u64 = 0;
+    let mut observed_retries: u64 = 0;
+    let mut recovered_tasks: u64 = 0;
+    let mut exhausted_tasks: u64 = 0;
+    let mut untouched_fallible_tasks: u64 = 0;
+    let mut budget_violations: u64 = 0;
+    let mut maximum_attempts: u64 = 0;
+    let mut maximum_attempt_task = model.NONE();
+    let mut digest: u64 = 14695981039346656037;
+    let mut i: u64 = 0;
+    while i < workflow.tasks.len() {
+        let task = workflow.tasks.get_or(i, model.empty_task());
+        let attempts = run.attempts.get_or(i, 0);
+        let retries = if attempts > 0 { attempts - 1 } else { 0 };
+        configured_budget += task.retries;
+        total_attempts += attempts;
+        observed_retries += retries;
+        add(inout attempts_by_pool, task.pool, attempts);
+        add(inout retries_by_pool, task.pool, retries);
+        add(inout budget_by_pool, task.pool, task.retries);
+        if attempts > task.retries + 1 { budget_violations += 1; }
+        if attempts > 1 && run.status.get_or(i, state.FAILED()) == state.SUCCEEDED() {
+            recovered_tasks += 1;
+        }
+        if run.status.get_or(i, state.PENDING()) == state.FAILED() && attempts > 0 {
+            exhausted_tasks += 1;
+        }
+        if task.fail_attempt > 0 && attempts == 0 { untouched_fallible_tasks += 1; }
+        if maximum_attempt_task == model.NONE() || attempts > maximum_attempts {
+            maximum_attempts = attempts; maximum_attempt_task = i;
+        }
+        digest = mix(digest, i); digest = mix(digest, attempts); digest = mix(digest, task.retries);
+        i += 1;
+    }
+    Analysis {
+        attempts_by_pool: attempts_by_pool, retries_by_pool: retries_by_pool,
+        budget_by_pool: budget_by_pool, configured_budget: configured_budget,
+        total_attempts: total_attempts, observed_retries: observed_retries,
+        recovered_tasks: recovered_tasks, exhausted_tasks: exhausted_tasks,
+        untouched_fallible_tasks: untouched_fallible_tasks,
+        budget_violations: budget_violations, maximum_attempts: maximum_attempts,
+        maximum_attempt_task: maximum_attempt_task, digest: digest,
+        valid: budget_violations == 0 && observed_retries == run.retries,
+    }
+}

--- a/performance/workloads/lattice/run_comparison.rue
+++ b/performance/workloads/lattice/run_comparison.rue
@@ -1,0 +1,77 @@
+// Detailed task- and event-level comparison for two scheduler seeds.
+const model = @import("model.rue");
+const schedule_diff = @import("schedule_diff.rue");
+const state = @import("state.rue");
+
+pub struct Comparison {
+    changed_tasks: model.U64s,
+    faster_tasks: model.U64s,
+    slower_tasks: model.U64s,
+    cached_only_first: model.U64s,
+    cached_only_second: model.U64s,
+    changed_task_count: u64,
+    faster_count: u64,
+    slower_count: u64,
+    unchanged_count: u64,
+    total_start_delta: u64,
+    total_end_delta: u64,
+    common_event_prefix: u64,
+    first_makespan: u64,
+    second_makespan: u64,
+    digest: u64,
+    valid: bool,
+}
+
+fn delta(first: u64, second: u64) -> u64 {
+    if first == model.NONE() || second == model.NONE() { 0 }
+    else if first > second { first - second } else { second - first }
+}
+
+fn mix(hash: u64, value: u64) -> u64 { @wrapping_mul(hash ^ value, 1099511628211) }
+
+pub fn compare(borrow workflow: model.Workflow, borrow first: state.Run, borrow second: state.Run) -> Comparison {
+    let basic = schedule_diff.compare(borrow workflow, borrow first, borrow second);
+    let mut changed_tasks = model.U64s.new();
+    let mut faster_tasks = model.U64s.new();
+    let mut slower_tasks = model.U64s.new();
+    let mut cached_only_first = model.U64s.new();
+    let mut cached_only_second = model.U64s.new();
+    let mut unchanged_count: u64 = 0;
+    let mut total_start_delta: u64 = 0;
+    let mut total_end_delta: u64 = 0;
+    let mut digest: u64 = 14695981039346656037;
+    let mut i: u64 = 0;
+    while i < workflow.tasks.len() {
+        let first_status = first.status.get_or(i, state.FAILED());
+        let second_status = second.status.get_or(i, state.FAILED());
+        let first_end = first.ends.get_or(i, model.NONE());
+        let second_end = second.ends.get_or(i, model.NONE());
+        let changed = first_status != second_status || first.starts.get_or(i, model.NONE()) != second.starts.get_or(i, model.NONE()) ||
+            first_end != second_end || first.attempts.get_or(i, 0) != second.attempts.get_or(i, 0);
+        if changed { changed_tasks.push(i); } else { unchanged_count += 1; }
+        if first_end != model.NONE() && second_end != model.NONE() {
+            if first_end < second_end { faster_tasks.push(i); }
+            else if second_end < first_end { slower_tasks.push(i); }
+        }
+        if first_status == state.CACHED() && second_status != state.CACHED() { cached_only_first.push(i); }
+        if second_status == state.CACHED() && first_status != state.CACHED() { cached_only_second.push(i); }
+        total_start_delta += delta(first.starts.get_or(i, model.NONE()), second.starts.get_or(i, model.NONE()));
+        total_end_delta += delta(first_end, second_end);
+        digest = mix(digest, first_status); digest = mix(digest, second_status);
+        digest = mix(digest, first_end); digest = mix(digest, second_end);
+        i += 1;
+    }
+    let changed_task_count = changed_tasks.len();
+    let faster_count = faster_tasks.len();
+    let slower_count = slower_tasks.len();
+    Comparison {
+        changed_tasks: changed_tasks, faster_tasks: faster_tasks, slower_tasks: slower_tasks,
+        cached_only_first: cached_only_first, cached_only_second: cached_only_second,
+        changed_task_count: changed_task_count, faster_count: faster_count,
+        slower_count: slower_count, unchanged_count: unchanged_count,
+        total_start_delta: total_start_delta, total_end_delta: total_end_delta,
+        common_event_prefix: basic.common_event_prefix,
+        first_makespan: first.makespan, second_makespan: second.makespan,
+        digest: digest, valid: changed_task_count + unchanged_count == workflow.tasks.len(),
+    }
+}

--- a/performance/workloads/lattice/schedule.rue
+++ b/performance/workloads/lattice/schedule.rue
@@ -1,0 +1,202 @@
+// Deterministic discrete-time resource scheduler with cache and retry models.
+const model = @import("model.rue");
+const state = @import("state.rue");
+
+fn mix(hash: u64, value: u64) -> u64 { @wrapping_mul(hash ^ value, 1099511628211) }
+
+fn dependencies_done(borrow workflow: model.Workflow, borrow run: state.Run, task: u64) -> bool {
+    let mut i: u64 = 0;
+    while i < workflow.edges.len() {
+        let edge = workflow.edges.get_or(i, model.empty_edge());
+        if edge.after == task && !state.successful(run.status.get_or(edge.before, state.FAILED())) { return false; }
+        i += 1;
+    }
+    true
+}
+
+fn dependency_failed(borrow workflow: model.Workflow, borrow run: state.Run, task: u64) -> bool {
+    let mut i: u64 = 0;
+    while i < workflow.edges.len() {
+        let edge = workflow.edges.get_or(i, model.empty_edge());
+        if edge.after == task && run.status.get_or(edge.before, state.FAILED()) == state.FAILED() { return true; }
+        i += 1;
+    }
+    false
+}
+
+fn pool_usage(borrow workflow: model.Workflow, borrow run: state.Run, pool: u64, field: u64) -> u64 {
+    let mut value: u64 = 0;
+    let mut i: u64 = 0;
+    while i < workflow.tasks.len() {
+        if run.status.get_or(i, state.FAILED()) == state.RUNNING() {
+            let task = workflow.tasks.get_or(i, model.empty_task());
+            if task.pool == pool {
+                if field == 0 { value += 1; }
+                else if field == 1 { value += task.cpu; }
+                else { value += task.memory; }
+            }
+        }
+        i += 1;
+    }
+    value
+}
+
+fn fits(borrow workflow: model.Workflow, borrow run: state.Run, task_index: u64) -> bool {
+    let task = workflow.tasks.get_or(task_index, model.empty_task());
+    let pool = workflow.pools.get_or(task.pool, model.empty_pool());
+    pool_usage(borrow workflow, borrow run, task.pool, 0) < pool.slots &&
+        pool_usage(borrow workflow, borrow run, task.pool, 1) + task.cpu <= pool.cpu &&
+        pool_usage(borrow workflow, borrow run, task.pool, 2) + task.memory <= pool.memory
+}
+
+fn cache_hit(borrow workflow: model.Workflow, task_index: u64, seed: u64) -> bool {
+    let task = workflow.tasks.get_or(task_index, model.empty_task());
+    task.cacheable && ((workflow.strings.hash(task.id) ^ seed) % 5 == 0)
+}
+
+fn emit(inout run: state.Run, kind: u64, time: u64, task: u64, pool: u64, attempt: u64, cpu: u64, memory: u64) {
+    run.events.push(state.Event {
+        kind: kind, time: time, task: task, pool: pool,
+        attempt: attempt, cpu: cpu, memory: memory,
+    });
+    run.fingerprint = mix(run.fingerprint, kind);
+    run.fingerprint = mix(run.fingerprint, time);
+    run.fingerprint = mix(run.fingerprint, task);
+    run.fingerprint = mix(run.fingerprint, pool);
+    run.fingerprint = mix(run.fingerprint, attempt);
+}
+
+fn complete(inout run: state.Run, borrow workflow: model.Workflow, time: u64) {
+    let mut i: u64 = 0;
+    while i < workflow.tasks.len() {
+        if run.status.get_or(i, state.FAILED()) == state.RUNNING() && run.ends.get_or(i, model.NONE()) == time {
+            let task = workflow.tasks.get_or(i, model.empty_task());
+            let attempt = run.attempts.get_or(i, 0);
+            if task.fail_attempt != 0 && attempt == task.fail_attempt {
+                emit(inout run, state.EVENT_FAILURE(), time, i, task.pool, attempt, task.cpu, task.memory);
+                if attempt <= task.retries {
+                    run.status.set(i, state.PENDING());
+                    run.next_ready.set(i, time + attempt);
+                    run.retries += 1;
+                    emit(inout run, state.EVENT_RETRY(), time, i, task.pool, attempt, task.cpu, task.memory);
+                } else {
+                    run.status.set(i, state.FAILED());
+                    run.failed += 1;
+                }
+            } else {
+                run.status.set(i, state.SUCCEEDED());
+                run.succeeded += 1;
+                emit(inout run, state.EVENT_SUCCESS(), time, i, task.pool, attempt, task.cpu, task.memory);
+            }
+        }
+        i += 1;
+    }
+}
+
+fn block_failed_dependents(inout run: state.Run, borrow workflow: model.Workflow, time: u64) {
+    let mut changed = true;
+    while changed {
+        changed = false;
+        let mut i: u64 = 0;
+        while i < workflow.tasks.len() {
+            if run.status.get_or(i, state.FAILED()) == state.PENDING() && dependency_failed(borrow workflow, borrow run, i) {
+                let task = workflow.tasks.get_or(i, model.empty_task());
+                run.status.set(i, state.FAILED());
+                run.failed += 1;
+                emit(inout run, state.EVENT_BLOCKED(), time, i, task.pool, 0, task.cpu, task.memory);
+                changed = true;
+            }
+            i += 1;
+        }
+    }
+}
+
+fn better(borrow workflow: model.Workflow, candidate: u64, current: u64) -> bool {
+    if current == model.NONE() { return true; }
+    let left = workflow.tasks.get_or(candidate, model.empty_task());
+    let right = workflow.tasks.get_or(current, model.empty_task());
+    left.priority > right.priority ||
+        (left.priority == right.priority && left.duration < right.duration) ||
+        (left.priority == right.priority && left.duration == right.duration && left.id < right.id)
+}
+
+fn pick_ready(borrow workflow: model.Workflow, borrow run: state.Run, time: u64) -> u64 {
+    let mut best = model.NONE();
+    let mut i: u64 = 0;
+    while i < workflow.tasks.len() {
+        if run.status.get_or(i, state.FAILED()) == state.PENDING() &&
+            run.next_ready.get_or(i, 0) <= time &&
+            dependencies_done(borrow workflow, borrow run, i) &&
+            fits(borrow workflow, borrow run, i) &&
+            better(borrow workflow, i, best) {
+            best = i;
+        }
+        i += 1;
+    }
+    best
+}
+
+fn has_running(borrow run: state.Run) -> bool {
+    let mut i: u64 = 0;
+    while i < run.status.len() {
+        if run.status.get_or(i, state.FAILED()) == state.RUNNING() { return true; }
+        i += 1;
+    }
+    false
+}
+
+fn all_terminal(borrow run: state.Run) -> bool {
+    let mut i: u64 = 0;
+    while i < run.status.len() {
+        if !state.terminal(run.status.get_or(i, state.FAILED())) { return false; }
+        i += 1;
+    }
+    true
+}
+
+fn count_waits(inout run: state.Run, borrow workflow: model.Workflow, time: u64) {
+    let mut i: u64 = 0;
+    while i < workflow.tasks.len() {
+        if run.status.get_or(i, state.FAILED()) == state.PENDING() && run.next_ready.get_or(i, 0) <= time {
+            if !dependencies_done(borrow workflow, borrow run, i) { run.dependency_waits += 1; }
+            else if !fits(borrow workflow, borrow run, i) { run.resource_waits += 1; }
+        }
+        i += 1;
+    }
+}
+
+pub fn run(borrow workflow: model.Workflow, cache_seed: u64) -> state.Run {
+    let mut result = state.new_run(workflow.tasks.len());
+    let mut time: u64 = 0;
+    while !all_terminal(borrow result) && time < 100000 {
+        complete(inout result, borrow workflow, time);
+        block_failed_dependents(inout result, borrow workflow, time);
+        let mut started = false;
+        loop {
+            let task_index = pick_ready(borrow workflow, borrow result, time);
+            if task_index == model.NONE() { break; }
+            let task = workflow.tasks.get_or(task_index, model.empty_task());
+            if result.attempts.get_or(task_index, 0) == 0 && cache_hit(borrow workflow, task_index, cache_seed) {
+                result.status.set(task_index, state.CACHED());
+                result.starts.set(task_index, time);
+                result.ends.set(task_index, time);
+                result.cached += 1;
+                emit(inout result, state.EVENT_CACHE(), time, task_index, task.pool, 0, task.cpu, task.memory);
+            } else {
+                let attempt = result.attempts.get_or(task_index, 0) + 1;
+                result.attempts.set(task_index, attempt);
+                result.status.set(task_index, state.RUNNING());
+                if result.starts.get_or(task_index, model.NONE()) == model.NONE() { result.starts.set(task_index, time); }
+                result.ends.set(task_index, time + task.duration);
+                result.starts_count += 1;
+                emit(inout result, state.EVENT_START(), time, task_index, task.pool, attempt, task.cpu, task.memory);
+                started = true;
+            }
+        }
+        count_waits(inout result, borrow workflow, time);
+        if !started && !has_running(borrow result) && !all_terminal(borrow result) { result.idle_ticks += 1; }
+        if !all_terminal(borrow result) { time += 1; }
+    }
+    result.makespan = time;
+    result
+}

--- a/performance/workloads/lattice/schedule_diff.rue
+++ b/performance/workloads/lattice/schedule_diff.rue
@@ -1,0 +1,62 @@
+// Compare two executions of the same workflow under different cache seeds.
+const model = @import("model.rue");
+const state = @import("state.rue");
+
+pub struct Difference {
+    status_changes: u64,
+    start_changes: u64,
+    end_changes: u64,
+    attempt_changes: u64,
+    first_only_events: u64,
+    second_only_events: u64,
+    common_event_prefix: u64,
+    makespan_delta: u64,
+    cache_delta: u64,
+    retry_delta: u64,
+    digest: u64,
+}
+
+fn delta(a: u64, b: u64) -> u64 { if a >= b { a - b } else { b - a } }
+fn mix(hash: u64, value: u64) -> u64 { @wrapping_mul(hash ^ value, 1099511628211) }
+
+fn same_event(first: state.Event, second: state.Event) -> bool {
+    first.kind == second.kind && first.time == second.time &&
+        first.task == second.task && first.pool == second.pool &&
+        first.attempt == second.attempt && first.cpu == second.cpu &&
+        first.memory == second.memory
+}
+
+pub fn compare(borrow workflow: model.Workflow, borrow first: state.Run, borrow second: state.Run) -> Difference {
+    let mut status_changes: u64 = 0;
+    let mut start_changes: u64 = 0;
+    let mut end_changes: u64 = 0;
+    let mut attempt_changes: u64 = 0;
+    let mut digest: u64 = 14695981039346656037;
+    let mut i: u64 = 0;
+    while i < workflow.tasks.len() {
+        if first.status.get_or(i, 0) != second.status.get_or(i, 0) { status_changes += 1; }
+        if first.starts.get_or(i, 0) != second.starts.get_or(i, 0) { start_changes += 1; }
+        if first.ends.get_or(i, 0) != second.ends.get_or(i, 0) { end_changes += 1; }
+        if first.attempts.get_or(i, 0) != second.attempts.get_or(i, 0) { attempt_changes += 1; }
+        digest = mix(digest, first.status.get_or(i, 0)); digest = mix(digest, second.status.get_or(i, 0));
+        digest = mix(digest, first.starts.get_or(i, 0)); digest = mix(digest, second.starts.get_or(i, 0));
+        i += 1;
+    }
+    let limit = if first.events.len() < second.events.len() { first.events.len() } else { second.events.len() };
+    let mut common_event_prefix: u64 = 0;
+    while common_event_prefix < limit && same_event(
+        first.events.get_or(common_event_prefix, state.empty_event()),
+        second.events.get_or(common_event_prefix, state.empty_event()),
+    ) { common_event_prefix += 1; }
+    Difference {
+        status_changes: status_changes, start_changes: start_changes,
+        end_changes: end_changes, attempt_changes: attempt_changes,
+        first_only_events: if first.events.len() > second.events.len() { first.events.len() - second.events.len() } else { 0 },
+        second_only_events: if second.events.len() > first.events.len() { second.events.len() - first.events.len() } else { 0 },
+        common_event_prefix: common_event_prefix,
+        makespan_delta: delta(first.makespan, second.makespan),
+        cache_delta: delta(first.cached, second.cached),
+        retry_delta: delta(first.retries, second.retries),
+        digest: digest,
+    }
+}

--- a/performance/workloads/lattice/schedule_quality.rue
+++ b/performance/workloads/lattice/schedule_quality.rue
@@ -1,0 +1,67 @@
+// Compare the realized schedule with graph, serial-work, and capacity bounds.
+const critical_path = @import("critical_path.rue");
+const model = @import("model.rue");
+const queue_analysis = @import("queue_analysis.rue");
+const resource_audit = @import("resource_audit.rue");
+const serial_oracle = @import("serial_oracle.rue");
+const state = @import("state.rue");
+
+pub struct Analysis {
+    graph_lower_bound: u64,
+    task_lower_bound: u64,
+    effective_lower_bound: u64,
+    serial_upper_bound: u64,
+    makespan: u64,
+    overhead: u64,
+    parallel_ticks_saved: u64,
+    efficiency_millis: u64,
+    throughput_millis: u64,
+    queue_delay: u64,
+    peak_slots: u64,
+    peak_cpu: u64,
+    peak_memory: u64,
+    digest: u64,
+    valid: bool,
+}
+
+fn maximum(borrow values: model.U64s) -> u64 {
+    let mut result: u64 = 0;
+    let mut i: u64 = 0;
+    while i < values.len() {
+        if values.get_or(i, 0) > result { result = values.get_or(i, 0); }
+        i += 1;
+    }
+    result
+}
+
+fn mix(hash: u64, value: u64) -> u64 { @wrapping_mul(hash ^ value, 1099511628211) }
+
+pub fn compute(borrow workflow: model.Workflow, borrow run: state.Run) -> Analysis {
+    let critical = critical_path.compute(borrow workflow);
+    let serial = serial_oracle.compute(borrow workflow, borrow run);
+    let resources = resource_audit.audit(borrow workflow, borrow run);
+    let queue = queue_analysis.compute(borrow workflow, borrow run);
+    let effective_lower_bound = if critical.makespan > serial.lower_bound {
+        critical.makespan
+    } else { serial.lower_bound };
+    let overhead = if run.makespan > effective_lower_bound { run.makespan - effective_lower_bound } else { 0 };
+    let efficiency_millis = if run.makespan == 0 { 0 } else { (effective_lower_bound * 1000) / run.makespan };
+    let throughput_millis = if run.makespan == 0 { 0 }
+        else { ((run.succeeded + run.cached) * 1000) / run.makespan };
+    let peak_slots = maximum(borrow resources.maximum_slots);
+    let peak_cpu = maximum(borrow resources.maximum_cpu);
+    let peak_memory = maximum(borrow resources.maximum_memory);
+    let mut digest = critical.digest;
+    digest = mix(digest, serial.digest); digest = mix(digest, resources.digest);
+    digest = mix(digest, queue.digest); digest = mix(digest, overhead);
+    Analysis {
+        graph_lower_bound: critical.makespan, task_lower_bound: serial.lower_bound,
+        effective_lower_bound: effective_lower_bound, serial_upper_bound: serial.upper_bound,
+        makespan: run.makespan, overhead: overhead,
+        parallel_ticks_saved: serial.saved_ticks, efficiency_millis: efficiency_millis,
+        throughput_millis: throughput_millis, queue_delay: queue.total_queue_delay,
+        peak_slots: peak_slots, peak_cpu: peak_cpu, peak_memory: peak_memory,
+        digest: digest, valid: critical.valid && serial.valid && resources.ok && queue.valid &&
+            run.makespan >= effective_lower_bound && run.makespan <= serial.upper_bound,
+    }
+}

--- a/performance/workloads/lattice/selftest.rue
+++ b/performance/workloads/lattice/selftest.rue
@@ -1,0 +1,144 @@
+// Generated invariant suite crossing topological, closure, scheduling, replay,
+// and fingerprint implementations across multiple workflow shapes.
+const cycle_oracle = @import("cycle_oracle.rue");
+const critical_path = @import("critical_path.rue");
+const dominators = @import("dominators.rue");
+const event_analysis = @import("event_analysis.rue");
+const fingerprint = @import("fingerprint.rue");
+const generate = @import("generate.rue");
+const levels = @import("levels.rue");
+const model = @import("model.rue");
+const portfolio = @import("portfolio.rue");
+const replay = @import("replay.rue");
+const resource_audit = @import("resource_audit.rue");
+const schedule = @import("schedule.rue");
+const schedule_diff = @import("schedule_diff.rue");
+const serial_oracle = @import("serial_oracle.rue");
+const std = @import("std");
+const text = @import("text.rue");
+const topology = @import("topology.rue");
+const transitive_reduction = @import("transitive_reduction.rue");
+const validate = @import("validate.rue");
+const StrBuf = std.strbuf.StrBuf;
+
+pub struct Result {
+    checks: u64,
+    failures: u64,
+    workflows: u64,
+    tasks: u64,
+    edges: u64,
+    events: u64,
+    digest: u64,
+    last_failed_check: u64,
+    incomplete: u64,
+    maximum_makespan: u64,
+    analysis_passes: u64,
+    analysis_observations: u64,
+    analysis_warnings: u64,
+}
+
+fn record(inout result: Result, condition: bool) {
+    result.checks += 1;
+    if !condition {
+        result.failures += 1;
+        result.last_failed_check = result.checks;
+    }
+}
+
+fn mix(hash: u64, value: u64) -> u64 { @wrapping_mul(hash ^ value, 1099511628211) }
+
+fn one(inout result: Result, tasks: u64, pools: u64, width: u64, seed: u64) {
+    let mut workflow = generate.workflow(tasks, pools, width, seed);
+    validate.workflow(inout workflow);
+    result.workflows += 1;
+    result.tasks += workflow.tasks.len();
+    result.edges += workflow.edges.len();
+    record(inout result, workflow.diagnostics.len() == 0);
+    let order = topology.sort(borrow workflow);
+    let closure = cycle_oracle.compute(borrow workflow);
+    let analyses = portfolio.analyze(borrow workflow);
+    let layer_info = levels.compute(borrow workflow);
+    let critical = critical_path.compute(borrow workflow);
+    let reduction = transitive_reduction.compute(borrow workflow);
+    let dominator_info = dominators.compute(borrow workflow);
+    record(inout result, !order.has_cycle);
+    record(inout result, !cycle_oracle.has_cycle(borrow closure));
+    record(inout result, topology.valid(borrow workflow, borrow order));
+    record(inout result, order.tasks.len() == workflow.tasks.len());
+    record(inout result, portfolio.valid(borrow analyses));
+    record(inout result, levels.verify(borrow workflow, borrow layer_info));
+    record(inout result, critical_path.verify(borrow workflow, borrow critical));
+    record(inout result, transitive_reduction.verify(borrow workflow, borrow reduction));
+    record(inout result, dominators.verify(borrow workflow, borrow dominator_info));
+    let first = schedule.run(borrow workflow, seed);
+    let second = schedule.run(borrow workflow, seed);
+    let audit = replay.audit(borrow workflow, borrow first);
+    let resources = resource_audit.audit(borrow workflow, borrow first);
+    let events = event_analysis.summarize(borrow workflow, borrow first);
+    let serial = serial_oracle.compute(borrow workflow, borrow first);
+    let difference = schedule_diff.compare(borrow workflow, borrow first, borrow second);
+    result.events += first.events.len();
+    record(inout result, audit.ok);
+    record(inout result, first.failed == 0);
+    record(inout result, first.succeeded + first.cached == workflow.tasks.len());
+    record(inout result, first.fingerprint == second.fingerprint);
+    record(inout result, fingerprint.run(borrow first) == fingerprint.run(borrow second));
+    record(inout result, first.events.len() == second.events.len());
+    record(inout result, resource_audit.verify(borrow workflow, borrow resources));
+    record(inout result, event_analysis.verify(borrow first, borrow events));
+    record(inout result, serial.valid);
+    record(inout result, difference.status_changes == 0);
+    record(inout result, difference.start_changes == 0);
+    record(inout result, difference.end_changes == 0);
+    record(inout result, difference.attempt_changes == 0);
+    result.incomplete = result.incomplete + workflow.tasks.len() - first.succeeded - first.cached - first.failed;
+    if first.makespan > result.maximum_makespan { result.maximum_makespan = first.makespan; }
+    result.digest = mix(result.digest, fingerprint.workflow(borrow workflow));
+    result.digest = mix(result.digest, fingerprint.run(borrow first));
+    result.digest = mix(result.digest, analyses.digest);
+    result.digest = mix(result.digest, layer_info.digest);
+    result.digest = mix(result.digest, critical.digest);
+    result.digest = mix(result.digest, reduction.digest);
+    result.digest = mix(result.digest, dominator_info.digest);
+    result.digest = mix(result.digest, resources.digest);
+    result.digest = mix(result.digest, events.digest);
+    result.digest = mix(result.digest, serial.digest);
+    result.digest = mix(result.digest, difference.digest);
+    result.analysis_passes += analyses.passes;
+    result.analysis_observations += analyses.observations;
+    result.analysis_warnings += analyses.warnings;
+}
+
+pub fn run() -> Result {
+    let mut result = Result {
+        checks: 0, failures: 0, workflows: 0, tasks: 0,
+        edges: 0, events: 0, digest: 14695981039346656037,
+        last_failed_check: 0,
+        incomplete: 0, maximum_makespan: 0,
+        analysis_passes: 0, analysis_observations: 0, analysis_warnings: 0,
+    };
+    one(inout result, 8, 2, 3, 11);
+    one(inout result, 17, 3, 4, 29);
+    one(inout result, 31, 4, 5, 47);
+    one(inout result, 48, 5, 7, 71);
+    result
+}
+
+pub fn render(borrow result: Result) -> StrBuf {
+    let mut out = StrBuf.new();
+    text.append_literal(inout out, "selftest checks="); text.append_u64(inout out, result.checks);
+    text.append_literal(inout out, " failures="); text.append_u64(inout out, result.failures); out.push(10);
+    text.append_literal(inout out, "workflows="); text.append_u64(inout out, result.workflows);
+    text.append_literal(inout out, " tasks="); text.append_u64(inout out, result.tasks);
+    text.append_literal(inout out, " edges="); text.append_u64(inout out, result.edges);
+    text.append_literal(inout out, " events="); text.append_u64(inout out, result.events); out.push(10);
+    text.append_literal(inout out, "digest="); text.append_u64(inout out, result.digest); out.push(10);
+    text.append_literal(inout out, "last_failed_check="); text.append_u64(inout out, result.last_failed_check); out.push(10);
+    text.append_literal(inout out, "incomplete="); text.append_u64(inout out, result.incomplete);
+    text.append_literal(inout out, " maximum_makespan="); text.append_u64(inout out, result.maximum_makespan); out.push(10);
+    text.append_literal(inout out, "analysis_passes="); text.append_u64(inout out, result.analysis_passes);
+    text.append_literal(inout out, " observations="); text.append_u64(inout out, result.analysis_observations);
+    text.append_literal(inout out, " warnings="); text.append_u64(inout out, result.analysis_warnings); out.push(10);
+    text.append_literal(inout out, "valid="); text.append_bool(inout out, result.failures == 0); out.push(10);
+    out
+}

--- a/performance/workloads/lattice/serial_oracle.rue
+++ b/performance/workloads/lattice/serial_oracle.rue
@@ -1,0 +1,58 @@
+// Work-conservation oracle: calculate the exact executed work from attempts
+// and prove the parallel schedule cannot exceed its serialized equivalent.
+const model = @import("model.rue");
+const state = @import("state.rue");
+
+pub struct Oracle {
+    executed_work: u64,
+    successful_work: u64,
+    failed_work: u64,
+    cached_tasks: u64,
+    started_tasks: u64,
+    maximum_single_task: u64,
+    lower_bound: u64,
+    upper_bound: u64,
+    makespan: u64,
+    saved_ticks: u64,
+    valid: bool,
+    digest: u64,
+}
+
+fn mix(hash: u64, value: u64) -> u64 { @wrapping_mul(hash ^ value, 1099511628211) }
+
+pub fn compute(borrow workflow: model.Workflow, borrow run: state.Run) -> Oracle {
+    let mut executed_work: u64 = 0;
+    let mut successful_work: u64 = 0;
+    let mut failed_work: u64 = 0;
+    let mut cached_tasks: u64 = 0;
+    let mut started_tasks: u64 = 0;
+    let mut maximum_single_task: u64 = 0;
+    let mut digest: u64 = 14695981039346656037;
+    let mut i: u64 = 0;
+    while i < workflow.tasks.len() {
+        let task = workflow.tasks.get_or(i, model.empty_task());
+        let attempts = run.attempts.get_or(i, 0);
+        let work = task.duration * attempts;
+        executed_work += work;
+        if attempts > 0 { started_tasks += 1; }
+        if run.status.get_or(i, state.FAILED()) == state.CACHED() { cached_tasks += 1; }
+        else if run.status.get_or(i, state.FAILED()) == state.SUCCEEDED() { successful_work += task.duration; }
+        else if run.status.get_or(i, state.FAILED()) == state.FAILED() { failed_work += work; }
+        if work > maximum_single_task { maximum_single_task = work; }
+        digest = mix(digest, i); digest = mix(digest, attempts); digest = mix(digest, work);
+        i += 1;
+    }
+    let lower_bound = maximum_single_task;
+    let upper_bound = executed_work + run.idle_ticks + run.retries;
+    let saved_ticks = if executed_work > run.makespan { executed_work - run.makespan } else { 0 };
+    let valid = run.makespan >= lower_bound && run.makespan <= upper_bound &&
+        cached_tasks == run.cached && started_tasks <= workflow.tasks.len();
+    Oracle {
+        executed_work: executed_work, successful_work: successful_work,
+        failed_work: failed_work, cached_tasks: cached_tasks,
+        started_tasks: started_tasks, maximum_single_task: maximum_single_task,
+        lower_bound: lower_bound, upper_bound: upper_bound,
+        makespan: run.makespan, saved_ticks: saved_ticks,
+        valid: valid, digest: digest,
+    }
+}

--- a/performance/workloads/lattice/state.rue
+++ b/performance/workloads/lattice/state.rue
@@ -1,0 +1,87 @@
+// Scheduler state and event-log representation.
+const std = @import("std");
+const model = @import("model.rue");
+
+pub fn PENDING() -> u64 { 0 }
+pub fn RUNNING() -> u64 { 1 }
+pub fn SUCCEEDED() -> u64 { 2 }
+pub fn FAILED() -> u64 { 3 }
+pub fn CACHED() -> u64 { 4 }
+
+pub fn EVENT_START() -> u64 { 1 }
+pub fn EVENT_SUCCESS() -> u64 { 2 }
+pub fn EVENT_FAILURE() -> u64 { 3 }
+pub fn EVENT_RETRY() -> u64 { 4 }
+pub fn EVENT_CACHE() -> u64 { 5 }
+pub fn EVENT_BLOCKED() -> u64 { 6 }
+
+pub struct Event {
+    kind: u64,
+    time: u64,
+    task: u64,
+    pool: u64,
+    attempt: u64,
+    cpu: u64,
+    memory: u64,
+}
+
+pub const Events = std.arraybuf.ArrayBuf(Event);
+
+pub struct Run {
+    status: model.U64s,
+    attempts: model.U64s,
+    starts: model.U64s,
+    ends: model.U64s,
+    next_ready: model.U64s,
+    events: Events,
+    makespan: u64,
+    succeeded: u64,
+    failed: u64,
+    cached: u64,
+    retries: u64,
+    starts_count: u64,
+    idle_ticks: u64,
+    resource_waits: u64,
+    dependency_waits: u64,
+    fingerprint: u64,
+}
+
+fn filled(count: u64, value: u64) -> model.U64s {
+    let mut out = model.U64s.with_capacity(count);
+    let mut i: u64 = 0;
+    while i < count { out.push(value); i += 1; }
+    out
+}
+
+pub fn new_run(tasks: u64) -> Run {
+    Run {
+        status: filled(tasks, PENDING()),
+        attempts: filled(tasks, 0),
+        starts: filled(tasks, model.NONE()),
+        ends: filled(tasks, model.NONE()),
+        next_ready: filled(tasks, 0),
+        events: Events.new(),
+        makespan: 0,
+        succeeded: 0,
+        failed: 0,
+        cached: 0,
+        retries: 0,
+        starts_count: 0,
+        idle_ticks: 0,
+        resource_waits: 0,
+        dependency_waits: 0,
+        fingerprint: 14695981039346656037,
+    }
+}
+
+pub fn empty_event() -> Event {
+    Event { kind: 0, time: 0, task: model.NONE(), pool: model.NONE(), attempt: 0, cpu: 0, memory: 0 }
+}
+
+pub fn terminal(status: u64) -> bool {
+    status == SUCCEEDED() || status == FAILED() || status == CACHED()
+}
+
+pub fn successful(status: u64) -> bool {
+    status == SUCCEEDED() || status == CACHED()
+}

--- a/performance/workloads/lattice/statistics.rue
+++ b/performance/workloads/lattice/statistics.rue
@@ -1,0 +1,119 @@
+// Descriptive statistics for task shape and declared resource demand.
+const model = @import("model.rue");
+
+pub struct Distribution {
+    count: u64,
+    minimum: u64,
+    maximum: u64,
+    sum: u64,
+    mean: u64,
+    zeroes: u64,
+    low: u64,
+    medium: u64,
+    high: u64,
+    digest: u64,
+}
+
+pub struct Summary {
+    duration: Distribution,
+    cpu: Distribution,
+    memory: Distribution,
+    priority: Distribution,
+    retries: Distribution,
+    dependencies: Distribution,
+    dependents: Distribution,
+    cacheable: u64,
+    fallible: u64,
+    total_work: u64,
+    total_cpu_ticks: u64,
+    total_memory_ticks: u64,
+    digest: u64,
+    valid: bool,
+}
+
+fn empty() -> Distribution {
+    Distribution {
+        count: 0, minimum: 0, maximum: 0, sum: 0, mean: 0,
+        zeroes: 0, low: 0, medium: 0, high: 0,
+        digest: 14695981039346656037,
+    }
+}
+
+fn mix(hash: u64, value: u64) -> u64 { @wrapping_mul(hash ^ value, 1099511628211) }
+
+fn observe(inout value: Distribution, sample: u64, low_limit: u64, high_limit: u64) {
+    if value.count == 0 || sample < value.minimum { value.minimum = sample; }
+    if value.count == 0 || sample > value.maximum { value.maximum = sample; }
+    value.count += 1;
+    value.sum += sample;
+    if sample == 0 { value.zeroes += 1; }
+    if sample < low_limit { value.low += 1; }
+    else if sample < high_limit { value.medium += 1; }
+    else { value.high += 1; }
+    value.digest = mix(value.digest, sample);
+}
+
+fn finish(inout value: Distribution) {
+    value.mean = if value.count == 0 { 0 } else { value.sum / value.count };
+    value.digest = mix(value.digest, value.minimum);
+    value.digest = mix(value.digest, value.maximum);
+    value.digest = mix(value.digest, value.sum);
+}
+
+fn valid_distribution(borrow value: Distribution) -> bool {
+    value.low + value.medium + value.high == value.count &&
+        value.zeroes <= value.count &&
+        (value.count == 0 || value.minimum <= value.mean) &&
+        (value.count == 0 || value.mean <= value.maximum)
+}
+
+pub fn compute(borrow workflow: model.Workflow) -> Summary {
+    let mut duration = empty();
+    let mut cpu = empty();
+    let mut memory = empty();
+    let mut priority = empty();
+    let mut retries = empty();
+    let mut dependencies = empty();
+    let mut dependents = empty();
+    let mut cacheable: u64 = 0;
+    let mut fallible: u64 = 0;
+    let mut total_work: u64 = 0;
+    let mut total_cpu_ticks: u64 = 0;
+    let mut total_memory_ticks: u64 = 0;
+    let mut i: u64 = 0;
+    while i < workflow.tasks.len() {
+        let task = workflow.tasks.get_or(i, model.empty_task());
+        observe(inout duration, task.duration, 3, 7);
+        observe(inout cpu, task.cpu, 2, 4);
+        observe(inout memory, task.memory, 3, 7);
+        observe(inout priority, task.priority, 7, 15);
+        observe(inout retries, task.retries, 1, 3);
+        observe(inout dependencies, model.dependency_count(borrow workflow, i), 1, 3);
+        observe(inout dependents, model.dependent_count(borrow workflow, i), 1, 3);
+        if task.cacheable { cacheable += 1; }
+        if task.fail_attempt > 0 { fallible += 1; }
+        total_work += task.duration;
+        total_cpu_ticks += task.duration * task.cpu;
+        total_memory_ticks += task.duration * task.memory;
+        i += 1;
+    }
+    finish(inout duration); finish(inout cpu); finish(inout memory);
+    finish(inout priority); finish(inout retries);
+    finish(inout dependencies); finish(inout dependents);
+    let mut digest = duration.digest;
+    digest = mix(digest, cpu.digest); digest = mix(digest, memory.digest);
+    digest = mix(digest, priority.digest); digest = mix(digest, retries.digest);
+    digest = mix(digest, dependencies.digest); digest = mix(digest, dependents.digest);
+    digest = mix(digest, cacheable); digest = mix(digest, fallible);
+    let valid = valid_distribution(borrow duration) && valid_distribution(borrow cpu) &&
+        valid_distribution(borrow memory) && valid_distribution(borrow priority) &&
+        valid_distribution(borrow retries) && valid_distribution(borrow dependencies) &&
+        valid_distribution(borrow dependents) && duration.count == workflow.tasks.len();
+    Summary {
+        duration: duration, cpu: cpu, memory: memory, priority: priority,
+        retries: retries, dependencies: dependencies, dependents: dependents,
+        cacheable: cacheable, fallible: fallible, total_work: total_work,
+        total_cpu_ticks: total_cpu_ticks, total_memory_ticks: total_memory_ticks,
+        digest: digest, valid: valid,
+    }
+}

--- a/performance/workloads/lattice/stress.rue
+++ b/performance/workloads/lattice/stress.rue
@@ -1,0 +1,195 @@
+// Scaling harness that runs every independent graph and schedule oracle against
+// a generated workflow, then repeats execution to prove determinism.
+const critical_path = @import("critical_path.rue");
+const dominators = @import("dominators.rue");
+const event_analysis = @import("event_analysis.rue");
+const fingerprint = @import("fingerprint.rue");
+const generate = @import("generate.rue");
+const insights = @import("insights.rue");
+const levels = @import("levels.rue");
+const portfolio = @import("portfolio.rue");
+const replay = @import("replay.rue");
+const report_suite = @import("report_suite.rue");
+const resource_audit = @import("resource_audit.rue");
+const schedule = @import("schedule.rue");
+const schedule_diff = @import("schedule_diff.rue");
+const serial_oracle = @import("serial_oracle.rue");
+const std = @import("std");
+const text = @import("text.rue");
+const topology = @import("topology.rue");
+const transitive_reduction = @import("transitive_reduction.rue");
+const validate = @import("validate.rue");
+const StrBuf = std.strbuf.StrBuf;
+
+pub struct Config {
+    scale: u64,
+    tasks: u64,
+    pools: u64,
+    width: u64,
+    seed: u64,
+}
+
+pub struct Result {
+    scale: u64,
+    tasks: u64,
+    pools: u64,
+    edges: u64,
+    events: u64,
+    makespan: u64,
+    diagnostics: u64,
+    analysis_passes: u64,
+    observations: u64,
+    warnings: u64,
+    insight_checks: u64,
+    insight_failures: u64,
+    report_documents: u64,
+    report_bytes: u64,
+    report_failures: u64,
+    depth: u64,
+    maximum_width: u64,
+    critical_tasks: u64,
+    critical_makespan: u64,
+    essential_edges: u64,
+    redundant_edges: u64,
+    strict_dominators: u64,
+    replay_mismatches: u64,
+    resource_violations: u64,
+    event_count_mismatches: u64,
+    schedule_changes: u64,
+    succeeded: u64,
+    cached: u64,
+    retries: u64,
+    idle_ticks: u64,
+    resource_waits: u64,
+    dependency_waits: u64,
+    fingerprint: u64,
+    digest: u64,
+    deterministic: bool,
+    valid: bool,
+}
+
+fn mix(hash: u64, value: u64) -> u64 {
+    @wrapping_mul(hash ^ value, 1099511628211)
+}
+
+pub fn tier(scale: u64) -> Config {
+    let normalized = if scale == 0 { 1 } else { scale };
+    Config {
+        scale: normalized,
+        tasks: 24 * normalized,
+        pools: 2 + normalized,
+        width: 3 + normalized,
+        seed: 41 + normalized * 17,
+    }
+}
+
+pub fn run(config: Config) -> Result {
+    let mut workflow = generate.workflow(config.tasks, config.pools, config.width, config.seed);
+    validate.workflow(inout workflow);
+    let order = topology.sort(borrow workflow);
+    let layer_info = levels.compute(borrow workflow);
+    let critical = critical_path.compute(borrow workflow);
+    let reduction = transitive_reduction.compute(borrow workflow);
+    let dominator_info = dominators.compute(borrow workflow);
+    let analyses = portfolio.analyze(borrow workflow);
+    let first = schedule.run(borrow workflow, config.seed);
+    let second = schedule.run(borrow workflow, config.seed);
+    let replay_info = replay.audit(borrow workflow, borrow first);
+    let resources = resource_audit.audit(borrow workflow, borrow first);
+    let events = event_analysis.summarize(borrow workflow, borrow first);
+    let serial = serial_oracle.compute(borrow workflow, borrow first);
+    let difference = schedule_diff.compare(borrow workflow, borrow first, borrow second);
+    let insight = insights.compute(borrow workflow, borrow first, config.seed);
+    let reports = report_suite.audit(borrow workflow, borrow first, config.seed);
+
+    let replay_mismatches = replay_info.ordering_errors + replay_info.transition_errors +
+        replay_info.attempt_errors + replay_info.terminal_mismatches;
+    let resource_violations = resources.underflows + resources.slot_violations +
+        resources.cpu_violations + resources.memory_violations + resources.terminal_active;
+    let event_count_mismatches = if event_analysis.verify(borrow first, borrow events) { 0 } else { 1 };
+    let schedule_changes = difference.status_changes + difference.start_changes +
+        difference.end_changes + difference.attempt_changes + difference.first_only_events +
+        difference.second_only_events;
+    let deterministic = first.fingerprint == second.fingerprint &&
+        fingerprint.run(borrow first) == fingerprint.run(borrow second) && schedule_changes == 0;
+    let mut digest = fingerprint.workflow(borrow workflow);
+    digest = mix(digest, fingerprint.run(borrow first));
+    digest = mix(digest, layer_info.digest);
+    digest = mix(digest, critical.digest);
+    digest = mix(digest, reduction.digest);
+    digest = mix(digest, dominator_info.digest);
+    digest = mix(digest, analyses.digest);
+    digest = mix(digest, replay_info.events);
+    digest = mix(digest, replay_mismatches);
+    digest = mix(digest, resources.digest);
+    digest = mix(digest, events.digest);
+    digest = mix(digest, serial.digest);
+    digest = mix(digest, difference.digest);
+    digest = mix(digest, insight.digest);
+    digest = mix(digest, reports.digest);
+
+    let valid = workflow.diagnostics.len() == 0 && !order.has_cycle &&
+        topology.valid(borrow workflow, borrow order) &&
+        levels.verify(borrow workflow, borrow layer_info) &&
+        critical_path.verify(borrow workflow, borrow critical) &&
+        transitive_reduction.verify(borrow workflow, borrow reduction) &&
+        dominators.verify(borrow workflow, borrow dominator_info) &&
+        portfolio.valid(borrow analyses) && replay_info.ok &&
+        resource_audit.verify(borrow workflow, borrow resources) && events.valid &&
+        serial.valid && insight.valid && reports.valid && first.failed == 0 &&
+        first.succeeded + first.cached == workflow.tasks.len() && deterministic;
+    Result {
+        scale: config.scale, tasks: workflow.tasks.len(), pools: workflow.pools.len(),
+        edges: workflow.edges.len(), events: first.events.len(), makespan: first.makespan,
+        diagnostics: workflow.diagnostics.len(), analysis_passes: analyses.passes,
+        observations: analyses.observations, warnings: analyses.warnings,
+        insight_checks: insight.checks, insight_failures: insight.failures,
+        report_documents: reports.documents, report_bytes: reports.bytes,
+        report_failures: reports.empty_documents + reports.prefix_mismatches +
+            reports.deterministic_mismatches + reports.policy_failures,
+        depth: layer_info.depth, maximum_width: layer_info.maximum_width,
+        critical_tasks: critical.critical_tasks.len(), critical_makespan: critical.makespan,
+        essential_edges: reduction.essential_count, redundant_edges: reduction.redundant_count,
+        strict_dominators: dominator_info.strict_pairs,
+        replay_mismatches: replay_mismatches, resource_violations: resource_violations,
+        event_count_mismatches: event_count_mismatches, schedule_changes: schedule_changes,
+        succeeded: first.succeeded, cached: first.cached, retries: first.retries,
+        idle_ticks: first.idle_ticks, resource_waits: first.resource_waits,
+        dependency_waits: first.dependency_waits, fingerprint: first.fingerprint,
+        digest: digest, deterministic: deterministic, valid: valid,
+    }
+}
+
+pub fn render(borrow result: Result) -> StrBuf {
+    let mut out = StrBuf.new();
+    text.append_literal(inout out, "stress scale="); text.append_u64(inout out, result.scale);
+    text.append_literal(inout out, " tasks="); text.append_u64(inout out, result.tasks);
+    text.append_literal(inout out, " pools="); text.append_u64(inout out, result.pools);
+    text.append_literal(inout out, " edges="); text.append_u64(inout out, result.edges); out.push(10);
+    text.append_literal(inout out, "events="); text.append_u64(inout out, result.events);
+    text.append_literal(inout out, " makespan="); text.append_u64(inout out, result.makespan);
+    text.append_literal(inout out, " diagnostics="); text.append_u64(inout out, result.diagnostics); out.push(10);
+    text.append_literal(inout out, "depth="); text.append_u64(inout out, result.depth);
+    text.append_literal(inout out, " width="); text.append_u64(inout out, result.maximum_width);
+    text.append_literal(inout out, " critical_tasks="); text.append_u64(inout out, result.critical_tasks);
+    text.append_literal(inout out, " critical_makespan="); text.append_u64(inout out, result.critical_makespan); out.push(10);
+    text.append_literal(inout out, "essential_edges="); text.append_u64(inout out, result.essential_edges);
+    text.append_literal(inout out, " redundant_edges="); text.append_u64(inout out, result.redundant_edges);
+    text.append_literal(inout out, " strict_dominators="); text.append_u64(inout out, result.strict_dominators); out.push(10);
+    text.append_literal(inout out, "analysis_passes="); text.append_u64(inout out, result.analysis_passes);
+    text.append_literal(inout out, " observations="); text.append_u64(inout out, result.observations);
+    text.append_literal(inout out, " warnings="); text.append_u64(inout out, result.warnings); out.push(10);
+    text.append_literal(inout out, "insight_checks="); text.append_u64(inout out, result.insight_checks);
+    text.append_literal(inout out, " insight_failures="); text.append_u64(inout out, result.insight_failures); out.push(10);
+    text.append_literal(inout out, "report_documents="); text.append_u64(inout out, result.report_documents);
+    text.append_literal(inout out, " report_bytes="); text.append_u64(inout out, result.report_bytes);
+    text.append_literal(inout out, " report_failures="); text.append_u64(inout out, result.report_failures); out.push(10);
+    text.append_literal(inout out, "replay_mismatches="); text.append_u64(inout out, result.replay_mismatches);
+    text.append_literal(inout out, " resource_violations="); text.append_u64(inout out, result.resource_violations);
+    text.append_literal(inout out, " event_count_mismatches="); text.append_u64(inout out, result.event_count_mismatches);
+    text.append_literal(inout out, " schedule_changes="); text.append_u64(inout out, result.schedule_changes); out.push(10);
+    text.append_literal(inout out, "deterministic="); text.append_bool(inout out, result.deterministic);
+    text.append_literal(inout out, " valid="); text.append_bool(inout out, result.valid); out.push(10);
+    text.append_literal(inout out, "digest="); text.append_u64(inout out, result.digest); out.push(10);
+    out
+}

--- a/performance/workloads/lattice/text.rue
+++ b/performance/workloads/lattice/text.rue
@@ -1,0 +1,71 @@
+// Deterministic text helpers shared by diagnostics and reports.
+const std = @import("std");
+const model = @import("model.rue");
+const StrBuf = std.strbuf.StrBuf;
+
+pub fn append_literal(inout out: StrBuf, value: str) {
+    let mut i: u64 = 0;
+    while i < value.len() { out.push(value[i]); i += 1; }
+}
+
+pub fn append_string(inout out: StrBuf, borrow value: StrBuf) {
+    let mut i: u64 = 0;
+    while i < value.len() {
+        out.push(StrBuf.byte_at_borrowed(borrow value, i));
+        i += 1;
+    }
+}
+
+pub fn append_id(inout out: StrBuf, borrow workflow: model.Workflow, id: u64) {
+    if id < workflow.strings.len() { workflow.strings.append(id, inout out); }
+    else { append_literal(inout out, "<none>"); }
+}
+
+pub fn append_u64(inout out: StrBuf, value: u64) {
+    let formatted = @to_string(value);
+    append_string(inout out, borrow formatted);
+}
+
+pub fn append_bool(inout out: StrBuf, value: bool) {
+    if value { append_literal(inout out, "true"); }
+    else { append_literal(inout out, "false"); }
+}
+
+pub fn append_percent(inout out: StrBuf, numerator: u64, denominator: u64) {
+    if denominator == 0 { append_literal(inout out, "0.0%"); return; }
+    append_u64(inout out, (numerator * 100) / denominator);
+    out.push(46);
+    append_u64(inout out, ((numerator * 1000) / denominator) % 10);
+    out.push(37);
+}
+
+pub fn line(inout out: StrBuf, label: str, value: u64) {
+    append_literal(inout out, label);
+    append_u64(inout out, value);
+    out.push(10);
+}
+
+pub fn fnv1a(borrow value: StrBuf) -> u64 {
+    let mut hash: u64 = 14695981039346656037;
+    let mut i: u64 = 0;
+    while i < value.len() {
+        hash ^= @intCast(StrBuf.byte_at_borrowed(borrow value, i));
+        hash = @wrapping_mul(hash, 1099511628211);
+        i += 1;
+    }
+    hash
+}
+
+pub fn json_id(inout out: StrBuf, borrow workflow: model.Workflow, id: u64) {
+    out.push(34);
+    let mut i: u64 = 0;
+    while i < workflow.strings.string_len(id) {
+        let byte = workflow.strings.byte_at(id, i);
+        if byte == 34 { append_literal(inout out, "\\\""); }
+        else if byte == 92 { append_literal(inout out, "\\\\"); }
+        else if byte == 10 { append_literal(inout out, "\\n"); }
+        else { out.push(byte); }
+        i += 1;
+    }
+    out.push(34);
+}

--- a/performance/workloads/lattice/token.rue
+++ b/performance/workloads/lattice/token.rue
@@ -1,0 +1,35 @@
+// POD tokens for the Lattice workflow language.
+const std = @import("std");
+
+pub const EOF: u64 = 0;
+pub const ERROR: u64 = 1;
+pub const IDENT: u64 = 2;
+pub const INT: u64 = 3;
+pub const WORKFLOW: u64 = 10;
+pub const POOL: u64 = 11;
+pub const TASK: u64 = 12;
+pub const AFTER: u64 = 13;
+pub const SLOTS: u64 = 14;
+pub const DURATION: u64 = 15;
+pub const CPU: u64 = 16;
+pub const MEMORY: u64 = 17;
+pub const PRIORITY: u64 = 18;
+pub const RETRIES: u64 = 19;
+pub const CACHE: u64 = 20;
+pub const FAIL: u64 = 21;
+pub const TRUE: u64 = 22;
+pub const FALSE: u64 = 23;
+pub const SEMI: u64 = 30;
+
+pub struct Token {
+    kind: u64,
+    start: u64,
+    end: u64,
+    value: u64,
+}
+
+pub const Tokens = std.arraybuf.ArrayBuf(Token);
+
+pub fn empty() -> Token {
+    Token { kind: EOF, start: 0, end: 0, value: 0 }
+}

--- a/performance/workloads/lattice/topology.rue
+++ b/performance/workloads/lattice/topology.rue
@@ -1,0 +1,130 @@
+// Kahn topological ordering plus graph-shape counters. Other passes consume
+// this canonical order; cycle_oracle.rue supplies an independent check.
+const std = @import("std");
+const model = @import("model.rue");
+const U64s = std.arraybuf.ArrayBuf(u64);
+
+pub struct Order {
+    tasks: U64s,
+    indegrees: U64s,
+    has_cycle: bool,
+    roots: u64,
+    leaves: u64,
+    maximum_indegree: u64,
+    maximum_outdegree: u64,
+}
+
+fn zeroes(count: u64) -> U64s {
+    let mut values = U64s.with_capacity(count);
+    let mut i: u64 = 0;
+    while i < count { values.push(0); i += 1; }
+    values
+}
+
+fn compute_indegrees(borrow workflow: model.Workflow) -> U64s {
+    let mut values = zeroes(workflow.tasks.len());
+    let mut i: u64 = 0;
+    while i < workflow.edges.len() {
+        let edge = workflow.edges.get_or(i, model.empty_edge());
+        if edge.after < values.len() {
+            values.set(edge.after, values.get_or(edge.after, 0) + 1);
+        }
+        i += 1;
+    }
+    values
+}
+
+fn outdegree(borrow workflow: model.Workflow, task: u64) -> u64 {
+    let mut value: u64 = 0;
+    let mut i: u64 = 0;
+    while i < workflow.edges.len() {
+        if workflow.edges.get_or(i, model.empty_edge()).before == task { value += 1; }
+        i += 1;
+    }
+    value
+}
+
+pub fn sort(borrow workflow: model.Workflow) -> Order {
+    let original = compute_indegrees(borrow workflow);
+    let mut remaining = compute_indegrees(borrow workflow);
+    let mut emitted = model.Bools.with_capacity(workflow.tasks.len());
+    let mut i: u64 = 0;
+    while i < workflow.tasks.len() { emitted.push(false); i += 1; }
+    let mut tasks = U64s.with_capacity(workflow.tasks.len());
+
+    while tasks.len() < workflow.tasks.len() {
+        let mut best = model.NONE();
+        i = 0;
+        while i < workflow.tasks.len() {
+            if !emitted.get_or(i, true) && remaining.get_or(i, 1) == 0 {
+                if best == model.NONE() { best = i; }
+                else {
+                    let candidate = workflow.tasks.get_or(i, model.empty_task());
+                    let current = workflow.tasks.get_or(best, model.empty_task());
+                    if candidate.priority > current.priority ||
+                        (candidate.priority == current.priority && candidate.id < current.id) {
+                        best = i;
+                    }
+                }
+            }
+            i += 1;
+        }
+        if best == model.NONE() { break; }
+        emitted.set(best, true);
+        tasks.push(best);
+        i = 0;
+        while i < workflow.edges.len() {
+            let edge = workflow.edges.get_or(i, model.empty_edge());
+            if edge.before == best && edge.after < remaining.len() {
+                let old = remaining.get_or(edge.after, 0);
+                if old > 0 { remaining.set(edge.after, old - 1); }
+            }
+            i += 1;
+        }
+    }
+
+    let mut roots: u64 = 0;
+    let mut leaves: u64 = 0;
+    let mut maximum_indegree: u64 = 0;
+    let mut maximum_outdegree: u64 = 0;
+    i = 0;
+    while i < workflow.tasks.len() {
+        let inside = original.get_or(i, 0);
+        let outside = outdegree(borrow workflow, i);
+        if inside == 0 { roots += 1; }
+        if outside == 0 { leaves += 1; }
+        if inside > maximum_indegree { maximum_indegree = inside; }
+        if outside > maximum_outdegree { maximum_outdegree = outside; }
+        i += 1;
+    }
+    let has_cycle = tasks.len() != workflow.tasks.len();
+    Order {
+        tasks: tasks,
+        indegrees: original,
+        has_cycle: has_cycle,
+        roots: roots,
+        leaves: leaves,
+        maximum_indegree: maximum_indegree,
+        maximum_outdegree: maximum_outdegree,
+    }
+}
+
+pub fn position(borrow order: Order, task: u64) -> u64 {
+    let mut i: u64 = 0;
+    while i < order.tasks.len() {
+        if order.tasks.get_or(i, model.NONE()) == task { return i; }
+        i += 1;
+    }
+    model.NONE()
+}
+
+pub fn valid(borrow workflow: model.Workflow, borrow order: Order) -> bool {
+    if order.has_cycle || order.tasks.len() != workflow.tasks.len() { return false; }
+    let mut i: u64 = 0;
+    while i < workflow.edges.len() {
+        let edge = workflow.edges.get_or(i, model.empty_edge());
+        if position(borrow order, edge.before) >= position(borrow order, edge.after) { return false; }
+        i += 1;
+    }
+    true
+}

--- a/performance/workloads/lattice/transitive_reduction.rue
+++ b/performance/workloads/lattice/transitive_reduction.rue
@@ -1,0 +1,88 @@
+// Classify dependencies as essential or transitively redundant.
+const cycle_oracle = @import("cycle_oracle.rue");
+const model = @import("model.rue");
+const std = @import("std");
+
+pub struct Reduction {
+    essential: model.U64s,
+    redundant: model.U64s,
+    essential_count: u64,
+    redundant_count: u64,
+    cross_pool_essential: u64,
+    same_pool_essential: u64,
+    digest: u64,
+    valid: bool,
+}
+
+fn mix(hash: u64, value: u64) -> u64 { @wrapping_mul(hash ^ value, 1099511628211) }
+
+fn alternate_path(
+    borrow workflow: model.Workflow,
+    borrow closure: cycle_oracle.Closure,
+    edge_index: u64,
+) -> bool {
+    let target = workflow.edges.get_or(edge_index, model.empty_edge());
+    let mut middle: u64 = 0;
+    while middle < workflow.tasks.len() {
+        if middle != target.before && middle != target.after &&
+            cycle_oracle.reaches(borrow closure, target.before, middle) &&
+            cycle_oracle.reaches(borrow closure, middle, target.after) {
+            return true;
+        }
+        middle += 1;
+    }
+    false
+}
+
+pub fn compute(borrow workflow: model.Workflow) -> Reduction {
+    let closure = cycle_oracle.compute(borrow workflow);
+    let mut essential = model.U64s.new();
+    let mut redundant = model.U64s.new();
+    let mut cross_pool_essential: u64 = 0;
+    let mut same_pool_essential: u64 = 0;
+    let mut digest: u64 = 14695981039346656037;
+    let mut i: u64 = 0;
+    while i < workflow.edges.len() {
+        let edge = workflow.edges.get_or(i, model.empty_edge());
+        if alternate_path(borrow workflow, borrow closure, i) {
+            redundant.push(i);
+            digest = mix(digest, i + 0x5000);
+        } else {
+            essential.push(i);
+            let before = workflow.tasks.get_or(edge.before, model.empty_task());
+            let after = workflow.tasks.get_or(edge.after, model.empty_task());
+            if before.pool == after.pool { same_pool_essential += 1; }
+            else { cross_pool_essential += 1; }
+            digest = mix(digest, i + 0x1000);
+        }
+        digest = mix(digest, edge.before);
+        digest = mix(digest, edge.after);
+        i += 1;
+    }
+    let essential_count = essential.len();
+    let redundant_count = redundant.len();
+    Reduction {
+        essential: essential, redundant: redundant,
+        essential_count: essential_count, redundant_count: redundant_count,
+        cross_pool_essential: cross_pool_essential,
+        same_pool_essential: same_pool_essential,
+        digest: digest,
+        valid: !cycle_oracle.has_cycle(borrow closure),
+    }
+}
+
+pub fn verify(borrow workflow: model.Workflow, borrow reduction: Reduction) -> bool {
+    if !reduction.valid || reduction.essential_count + reduction.redundant_count != workflow.edges.len() { return false; }
+    if reduction.cross_pool_essential + reduction.same_pool_essential != reduction.essential_count { return false; }
+    let mut i: u64 = 0;
+    while i < reduction.essential.len() {
+        if reduction.essential.get_or(i, model.NONE()) >= workflow.edges.len() { return false; }
+        i += 1;
+    }
+    i = 0;
+    while i < reduction.redundant.len() {
+        if reduction.redundant.get_or(i, model.NONE()) >= workflow.edges.len() { return false; }
+        i += 1;
+    }
+    true
+}

--- a/performance/workloads/lattice/validate.rue
+++ b/performance/workloads/lattice/validate.rue
@@ -1,0 +1,99 @@
+// Name/reference/range/resource validation and graph-cycle proof.
+const cycle_oracle = @import("cycle_oracle.rue");
+const model = @import("model.rue");
+const topology = @import("topology.rue");
+
+fn duplicate_pool(borrow workflow: model.Workflow, at: u64) -> bool {
+    let candidate = workflow.pools.get_or(at, model.empty_pool());
+    let mut i: u64 = 0;
+    while i < at {
+        if workflow.strings.ids_equal(candidate.id, workflow.pools.get_or(i, model.empty_pool()).id) { return true; }
+        i += 1;
+    }
+    false
+}
+
+fn duplicate_task(borrow workflow: model.Workflow, at: u64) -> bool {
+    let candidate = workflow.tasks.get_or(at, model.empty_task());
+    let mut i: u64 = 0;
+    while i < at {
+        if workflow.strings.ids_equal(candidate.id, workflow.tasks.get_or(i, model.empty_task()).id) { return true; }
+        i += 1;
+    }
+    false
+}
+
+fn validate_pools(inout workflow: model.Workflow) {
+    let mut i: u64 = 0;
+    while i < workflow.pools.len() {
+        let item = workflow.pools.get_or(i, model.empty_pool());
+        if duplicate_pool(borrow workflow, i) { model.add_error(inout workflow, 200, item.id, "duplicate pool name"); }
+        if item.slots == 0 { model.add_error(inout workflow, 202, item.id, "pool slots must be positive"); }
+        if item.cpu == 0 { model.add_error(inout workflow, 202, item.id, "pool cpu must be positive"); }
+        if item.memory == 0 { model.add_error(inout workflow, 202, item.id, "pool memory must be positive"); }
+        i += 1;
+    }
+}
+
+fn validate_tasks(inout workflow: model.Workflow) {
+    let mut i: u64 = 0;
+    while i < workflow.tasks.len() {
+        let mut item = workflow.tasks.get_or(i, model.empty_task());
+        if duplicate_task(borrow workflow, i) { model.add_error(inout workflow, 200, item.id, "duplicate task name"); }
+        item.pool = model.find_pool(borrow workflow, item.pool_id);
+        if item.pool == model.NONE() {
+            model.add_error(inout workflow, 201, item.id, "unknown worker pool");
+        } else {
+            let pool = workflow.pools.get_or(item.pool, model.empty_pool());
+            if item.cpu > pool.cpu { model.add_error(inout workflow, 204, item.id, "task cpu exceeds pool capacity"); }
+            if item.memory > pool.memory { model.add_error(inout workflow, 204, item.id, "task memory exceeds pool capacity"); }
+        }
+        if item.duration == 0 { model.add_error(inout workflow, 202, item.id, "duration must be positive"); }
+        if item.cpu == 0 { model.add_error(inout workflow, 202, item.id, "cpu must be positive"); }
+        if item.memory == 0 { model.add_error(inout workflow, 202, item.id, "memory must be positive"); }
+        if item.priority > 100 { model.add_error(inout workflow, 202, item.id, "priority must be at most 100"); }
+        if item.retries > 20 { model.add_error(inout workflow, 202, item.id, "retries must be at most 20"); }
+        workflow.tasks.set(i, item);
+        i += 1;
+    }
+}
+
+fn validate_edges(inout workflow: model.Workflow) {
+    let mut i: u64 = 0;
+    while i < workflow.edges.len() {
+        let mut edge = workflow.edges.get_or(i, model.empty_edge());
+        edge.before = model.find_task(borrow workflow, edge.before_id);
+        edge.after = model.find_task(borrow workflow, edge.after_id);
+        if edge.before == model.NONE() { model.add_error(inout workflow, 201, edge.before_id, "unknown prerequisite task"); }
+        if edge.after == model.NONE() { model.add_error(inout workflow, 201, edge.after_id, "unknown dependent task"); }
+        if edge.before != model.NONE() && edge.before == edge.after {
+            model.add_error(inout workflow, 203, edge.before_id, "task cannot depend on itself");
+        }
+        let mut earlier: u64 = 0;
+        while earlier < i {
+            let other = workflow.edges.get_or(earlier, model.empty_edge());
+            if other.before_id == edge.before_id && other.after_id == edge.after_id {
+                model.add_error(inout workflow, 200, edge.after_id, "duplicate dependency");
+            }
+            earlier += 1;
+        }
+        workflow.edges.set(i, edge);
+        i += 1;
+    }
+}
+
+pub fn workflow(inout value: model.Workflow) {
+    if value.name == model.NONE() { model.add_error(inout value, 101, model.NONE(), "missing workflow declaration"); }
+    if value.pools.len() == 0 { model.add_error(inout value, 101, value.name, "workflow has no worker pools"); }
+    if value.tasks.len() == 0 { model.add_error(inout value, 101, value.name, "workflow has no tasks"); }
+    validate_pools(inout value);
+    validate_tasks(inout value);
+    validate_edges(inout value);
+    if value.diagnostics.len() == 0 {
+        let order = topology.sort(borrow value);
+        let closure = cycle_oracle.compute(borrow value);
+        if order.has_cycle || cycle_oracle.has_cycle(borrow closure) {
+            model.add_error(inout value, 203, value.name, "dependency graph contains a cycle");
+        }
+    }
+}

--- a/performance/workloads/lattice/workload.rue
+++ b/performance/workloads/lattice/workload.rue
@@ -1,0 +1,78 @@
+// Multi-tier benchmark summary. Each tier runs twice and must return the same
+// cross-oracle digest, which catches nondeterminism outside the scheduler too.
+const std = @import("std");
+const stress = @import("stress.rue");
+const text = @import("text.rue");
+const StrBuf = std.strbuf.StrBuf;
+
+pub struct Result {
+    tiers: u64,
+    runs: u64,
+    tasks: u64,
+    edges: u64,
+    events: u64,
+    observations: u64,
+    makespan_sum: u64,
+    maximum_makespan: u64,
+    digest: u64,
+    invalid_runs: u64,
+    nondeterministic_runs: u64,
+    valid: bool,
+}
+
+fn mix(hash: u64, value: u64) -> u64 { @wrapping_mul(hash ^ value, 1099511628211) }
+
+fn include(inout result: Result, borrow value: stress.Result) {
+    result.runs += 1;
+    result.tasks += value.tasks;
+    result.edges += value.edges;
+    result.events += value.events;
+    result.observations += value.observations;
+    result.makespan_sum += value.makespan;
+    if value.makespan > result.maximum_makespan { result.maximum_makespan = value.makespan; }
+    result.digest = mix(result.digest, value.digest);
+    if !value.valid { result.invalid_runs += 1; }
+    if !value.deterministic { result.nondeterministic_runs += 1; }
+}
+
+fn pair(inout result: Result, scale: u64) {
+    let first = stress.run(stress.tier(scale));
+    let second = stress.run(stress.tier(scale));
+    include(inout result, borrow first);
+    include(inout result, borrow second);
+    result.tiers += 1;
+    if first.digest != second.digest || first.fingerprint != second.fingerprint {
+        result.nondeterministic_runs += 1;
+    }
+}
+
+pub fn run() -> Result {
+    let mut result = Result {
+        tiers: 0, runs: 0, tasks: 0, edges: 0, events: 0,
+        observations: 0, makespan_sum: 0, maximum_makespan: 0,
+        digest: 14695981039346656037, invalid_runs: 0,
+        nondeterministic_runs: 0, valid: false,
+    };
+    pair(inout result, 1);
+    pair(inout result, 2);
+    pair(inout result, 4);
+    result.valid = result.invalid_runs == 0 && result.nondeterministic_runs == 0;
+    result
+}
+
+pub fn render(borrow result: Result) -> StrBuf {
+    let mut out = StrBuf.new();
+    text.append_literal(inout out, "workload tiers="); text.append_u64(inout out, result.tiers);
+    text.append_literal(inout out, " runs="); text.append_u64(inout out, result.runs); out.push(10);
+    text.append_literal(inout out, "tasks="); text.append_u64(inout out, result.tasks);
+    text.append_literal(inout out, " edges="); text.append_u64(inout out, result.edges);
+    text.append_literal(inout out, " events="); text.append_u64(inout out, result.events); out.push(10);
+    text.append_literal(inout out, "observations="); text.append_u64(inout out, result.observations);
+    text.append_literal(inout out, " makespan_sum="); text.append_u64(inout out, result.makespan_sum);
+    text.append_literal(inout out, " maximum_makespan="); text.append_u64(inout out, result.maximum_makespan); out.push(10);
+    text.append_literal(inout out, "invalid_runs="); text.append_u64(inout out, result.invalid_runs);
+    text.append_literal(inout out, " nondeterministic_runs="); text.append_u64(inout out, result.nondeterministic_runs); out.push(10);
+    text.append_literal(inout out, "digest="); text.append_u64(inout out, result.digest); out.push(10);
+    text.append_literal(inout out, "valid="); text.append_bool(inout out, result.valid); out.push(10);
+    out
+}

--- a/website/static/performance.js
+++ b/website/static/performance.js
@@ -221,10 +221,17 @@
       select.appendChild(option);
     });
 
+    var referencePlatform = platforms.findIndex(function (platform) {
+      return platform.epochs.some(function (epoch) {
+        return Object.keys(epoch.process_elapsed_targets || {}).length > 0;
+      });
+    });
     var state = {
-      platform: 0, workload: null, cursor: null, band: null, indexCursor: null,
-      pinned: { index: false, phases: false }
+      platform: referencePlatform >= 0 ? referencePlatform : 0,
+      workload: null, cursor: null, band: null, indexCursor: null, targetCursor: null,
+      pinned: { index: false, target: false, phases: false }
     };
+    select.value = String(state.platform);
 
     select.addEventListener("change", function () {
       state.platform = Number(select.value);
@@ -232,7 +239,9 @@
       state.cursor = null;
       state.band = null;
       state.indexCursor = null;
+      state.targetCursor = null;
       state.pinned.index = false;
+      state.pinned.target = false;
       state.pinned.phases = false;
       draw();
     });
@@ -253,7 +262,7 @@
     // Pointer events rather than mouse events, so one handler serves a hover on
     // a desktop and a tap or drag on a touchscreen. Mouse events alone are why
     // these charts had no working cursor at all on a phone or tablet.
-    var interaction = { index: null, phases: null };
+    var interaction = { index: null, target: null, phases: null };
 
     function bindChart(svg, key) {
       // Whether a button or finger is currently down. A pinned chart ignores
@@ -283,6 +292,7 @@
     }
 
     bindChart(document.getElementById("perf-index"), "index");
+    bindChart(document.getElementById("perf-target"), "target");
     bindChart(document.getElementById("perf-phases"), "phases");
 
     function current() { return platforms[state.platform]; }
@@ -302,11 +312,16 @@
       if (!points.length) { return; }
       if (state.workload === null) {
         var names = Object.keys(points[points.length - 1].point.workloads);
-        state.workload = names.length ? names[0] : null;
+        state.workload = names.find(function (name) {
+          return points.some(function (entry) {
+            return (entry.epoch.process_elapsed_targets || {})[name];
+          });
+        }) || (names.length ? names[0] : null);
       }
       drawStatus(points);
       drawIndex(data, points);
       drawMultiples(data, points);
+      drawTarget(data, points);
       drawPhases(data, points);
       drawNotes();
       drawDisclosures(data, points);
@@ -616,6 +631,155 @@
           " versus the previous measured commit</div>";
         container.appendChild(card);
       });
+    }
+
+    // ADR-0071's absolute outcome chart. This is intentionally separate from
+    // the phase stack below: the target covers process spawn through exit,
+    // while the stack partitions compiler-root time only. Drawing one over the
+    // other would make startup and teardown disappear from the product goal.
+    function drawTarget(data, points) {
+      var section = document.getElementById("perf-target-section");
+      var svg = document.getElementById("perf-target");
+      var caption = document.getElementById("perf-target-caption");
+      var tooltip = document.getElementById("perf-target-tooltip");
+      svg.textContent = "";
+
+      var series = points.filter(function (entry) {
+        return entry.point.workloads[state.workload];
+      });
+      var targeted = series.filter(function (entry) {
+        return (entry.epoch.process_elapsed_targets || {})[state.workload];
+      });
+      if (!series.length || !targeted.length) {
+        section.hidden = true;
+        interaction.target = null;
+        return;
+      }
+      section.hidden = false;
+
+      var values = series.map(function (entry) {
+        return entry.point.workloads[state.workload].process_elapsed_ns;
+      });
+      targeted.forEach(function (entry) {
+        values.push(entry.epoch.process_elapsed_targets[state.workload].process_elapsed_ns);
+      });
+      var hi = Math.max.apply(null, values) * 1.12;
+      var x = function (i) { return 40 + (i / Math.max(series.length - 1, 1)) * 840; };
+      var y = function (v) { return 210 - (v / hi) * 180; };
+
+      var scale = element("text", { x: 4, y: 18, fill: "#666", "font-size": 11 });
+      scale.textContent = ms(hi).toFixed(1) + " ms";
+      svg.appendChild(scale);
+
+      var byEpoch = {};
+      series.forEach(function (entry, i) {
+        var key = entry.epoch.epoch;
+        var elapsed = entry.point.workloads[state.workload].process_elapsed_ns;
+        (byEpoch[key] = byEpoch[key] || []).push(x(i) + "," + y(elapsed));
+      });
+      Object.keys(byEpoch).forEach(function (key) {
+        svg.appendChild(element("polyline", {
+          points: byEpoch[key].join(" "), fill: "none", stroke: "#228833", "stroke-width": 2
+        }));
+      });
+
+      // A target belongs to one epoch. Its rule spans only that epoch's points,
+      // never an adjacent regime whose clock does not adjudicate it.
+      var drawnTargets = {};
+      series.forEach(function (entry, i) {
+        var target = (entry.epoch.process_elapsed_targets || {})[state.workload];
+        if (!target || drawnTargets[entry.epoch.epoch]) { return; }
+        drawnTargets[entry.epoch.epoch] = true;
+        var last = i;
+        while (last + 1 < series.length &&
+               series[last + 1].epoch.epoch === entry.epoch.epoch) { last++; }
+        var left = i === 0 ? 40 : (x(i - 1) + x(i)) / 2;
+        var right = last === series.length - 1 ? 880 : (x(last) + x(last + 1)) / 2;
+        svg.appendChild(element("line", {
+          x1: left, y1: y(target.process_elapsed_ns),
+          x2: right, y2: y(target.process_elapsed_ns),
+          stroke: "#7c3aed", "stroke-width": 2, "stroke-dasharray": "6 4"
+        }));
+        var label = element("text", {
+          x: left + 4, y: y(target.process_elapsed_ns) - 6,
+          fill: "#7c3aed", "font-size": 11
+        });
+        label.textContent = target.reference + " target: " + fmtMs(target.process_elapsed_ns);
+        svg.appendChild(label);
+      });
+
+      series.forEach(function (entry, i) {
+        svg.appendChild(element("circle", {
+          cx: x(i), cy: y(entry.point.workloads[state.workload].process_elapsed_ns), r: 2.5,
+          fill: "#228833", "pointer-events": "none"
+        }));
+      });
+      drawDateAxis(svg, x, 210, series.map(function (entry, i) {
+        return { at: i, finished_at: entry.point.finished_at };
+      }));
+
+      var highlight = element("circle", {
+        r: 5, fill: "none", stroke: "#111", "stroke-width": 2, "pointer-events": "none"
+      });
+      svg.appendChild(highlight);
+
+      function selectMark(position) {
+        state.targetCursor = Math.max(0, Math.min(series.length - 1, position));
+        var entry = series[state.targetCursor];
+        var elapsed = entry.point.workloads[state.workload].process_elapsed_ns;
+        highlight.setAttribute("cx", x(state.targetCursor));
+        highlight.setAttribute("cy", y(elapsed));
+        highlight.setAttribute("fill", state.pinned.target ? "#111" : "none");
+        var lines = [
+          commitHeading(data, entry.point.commit),
+          "Measured " + fmtWhen(entry.point.finished_at) + ".",
+          "Fresh process: " + fmtMs(elapsed) + " from spawn through successful exit."
+        ];
+        var target = (entry.epoch.process_elapsed_targets || {})[state.workload];
+        if (target) {
+          var difference = elapsed - target.process_elapsed_ns;
+          lines.push(target.reference + " target: " + fmtMs(target.process_elapsed_ns) +
+            ". This point is " + fmtMs(Math.abs(difference)) +
+            (difference <= 0 ? " under the ceiling." : " over the ceiling."));
+        }
+        lines.push(pinnedNote(state.pinned.target));
+        setTooltip(tooltip, lines);
+      }
+
+      interaction.target = function (event, dragging) {
+        if (event.type === "keydown") {
+          if (event.key === "Escape" && state.pinned.target) {
+            state.pinned.target = false;
+            selectMark(state.targetCursor);
+            event.preventDefault();
+          }
+          if (event.key === "ArrowRight") {
+            selectMark(state.targetCursor + 1); event.preventDefault();
+          }
+          if (event.key === "ArrowLeft") {
+            selectMark(state.targetCursor - 1); event.preventDefault();
+          }
+          return;
+        }
+        if (event.type === "pointermove" && state.pinned.target && !dragging) { return; }
+        var at = svgLocation(svg, event);
+        if (!at) { return; }
+        var nearest = Math.round(((at.x - 40) / 840) * (series.length - 1));
+        nearest = Math.max(0, Math.min(series.length - 1, nearest));
+        if (event.type === "pointerdown") {
+          pin("target", nearest === state.targetCursor);
+        }
+        selectMark(nearest);
+      };
+
+      svg.setAttribute("aria-label", "Fresh-process latency for " + state.workload +
+        " against its declared release target. Use left and right arrow keys to move " +
+        "between measured commits.");
+      caption.textContent = series.length + " measured commit(s). Green is external process " +
+        "time; the dashed violet rule is the absolute target for this reference epoch only.";
+      selectMark(state.targetCursor === null
+        ? series.length - 1
+        : Math.min(state.targetCursor, series.length - 1));
     }
 
     // 3. Stacked area of absolute milliseconds for the selected workload.

--- a/website/templates/performance.html
+++ b/website/templates/performance.html
@@ -32,8 +32,10 @@
        ring to keyboard focus keeps every tap on a phone from leaving a box
        drawn around the chart. */
     #perf-index:focus:not(:focus-visible),
+    #perf-target:focus:not(:focus-visible),
     #perf-phases:focus:not(:focus-visible) { outline: none; }
     #perf-index:focus-visible,
+    #perf-target:focus-visible,
     #perf-phases:focus-visible { outline: 2px solid #228833; outline-offset: 2px; }
   </style>
 
@@ -117,6 +119,25 @@
     </details>
     <div id="perf-multiples" role="list"
          style="display: grid; grid-template-columns: repeat(auto-fill, minmax(15rem, 1fr)); gap: 1rem; margin-top: 0.75rem;"></div>
+
+    <section id="perf-target-section" hidden>
+      <h2 style="margin-top: 2.5rem;">Release target</h2>
+      <p style="color: var(--color-muted); font-size: 0.9rem; max-width: 42rem;">
+        Fresh-process wall time from process spawn through successful native
+        output and exit. Absolute targets appear only on the platform epoch
+        that adjudicates them; other platforms remain useful directional series.
+      </p>
+      <figure style="margin-top: 0.75rem;">
+        <svg id="perf-target" role="img" width="100%" height="240" viewBox="0 0 900 240"
+             tabindex="0" style="touch-action: pan-y; height: auto; cursor: crosshair;"
+             aria-label="Release target. Chart not drawn yet."
+             aria-describedby="perf-target-caption"></svg>
+        <figcaption id="perf-target-caption"
+                    style="color: var(--color-muted); font-size: 0.85rem;"></figcaption>
+      </figure>
+      <div id="perf-target-tooltip" role="status" aria-live="polite"
+           style="margin-top: 0.5rem; padding: 0.75rem 1rem; border: 1px solid #ccc; font-size: 0.9rem; line-height: 1.5;"></div>
+    </section>
 
     <h2 style="margin-top: 2.5rem;">Phase composition — <span id="perf-selected"></span></h2>
     <p style="color: var(--color-muted); font-size: 0.9rem; max-width: 42rem;">


### PR DESCRIPTION
Fixes RUE-1478.

## Summary

- freeze the 131-file Lattice source closure under `performance/workloads/lattice/` at the ADR-0071 provenance commit
- declare performance suite revision 2 with the unchanged startup probe and frozen Lattice workload
- add non-publishing calibration epochs for all three hosted platforms
- make calibration select an explicit manifest epoch
- build the measured compiler and runner with the release ThinLTO Buck platform in both calibration and collection
- add platform-epoch process-time targets to the fail-closed manifest schema
- publish those targets in derived dashboard data
- add a dedicated external process-time chart so ADR-0071's spawn-through-exit target is not confused with compiler-root phase time
- make the target-bearing reference platform and workload the dashboard defaults

## Why

ADR-0071 makes a 250 ms fresh-process `-O3 -j1` Lattice build on the versioned `x86_64-linux` GitHub Actions epoch Rue's primary compiler-performance target. The public dashboard currently measures only the three-line startup probe and cannot show that target.

The first local integration probe also found that the old collection workflow built the compiler's default Buck profile even though the measurement contract requires release ThinLTO. This change aligns collection and calibration with the existing maintained scaling workflow before establishing the new epoch.

## Evidence

The release-configured local diagnostic measured the frozen Lattice fixture at 1.02–1.09 s external process time, 0.95–1.02 s compiler-root time, and about 424 MiB peak RSS across three independent `-O3 -j1` samples.

Hosted calibration [run 31654232615](https://github.com/rue-language/rue/actions/runs/31654232615) then measured 12 unchanged-revision repetitions on every platform. Calibration artifacts are structurally unable to enter the published series. The resulting collection policy is:

| platform | Lattice median | rel. MAD | Lattice samples | approximate collection work |
| --- | ---: | ---: | ---: | ---: |
| `x86_64-linux` | 2647.03 ms | 0.78% | 3 | 8.6 s |
| `aarch64-linux` | 2920.82 ms | 0.85% | 3 | 9.0 s |
| `aarch64-macos` | 2666.23 ms | 6.41% | 99 | 4.5 min |

The x86 reference measurement is currently about 10.6× over the accepted 250 ms target. That is the intended honest starting point for Phase 2, not a reason to move the target. macOS reaches the calibrator's 99-sample ceiling; the higher collection cost is recorded in the manifest and accepted to keep that noisy runner directional rather than misleading.

## Validation

- `scripts/rue fmt`
- `./buck2 test //crates/rue-perf-schema:rue-perf-schema-test //crates/rue-bench:rue-bench-test` (184 passed)
- `node --check website/static/performance.js`
- byte-for-byte comparison of all 131 frozen `.rue` sources against the named provenance
- release-configured local suite revision 2 run (complete, no failures)
- `rue-bench check-pins` (all three current collection epochs match)
- desktop and 390 px browser review of the rendered dashboard, including workload switching and target visibility; no browser errors
