### PR TITLE
RUE-1475: pin compiler reference boundary

### DIFF
--- a/crates/rue-bench/src/calibrate.rs
+++ b/crates/rue-bench/src/calibrate.rs
@@ -422,6 +422,7 @@ mod tests {
                 unattributed_ns: 0,
                 compiler_root_ns: latency_ns * u64::from(batch),
             },
+            boundary_evidence: Vec::new(),
         }
     }
 

--- a/crates/rue-bench/src/derive.rs
+++ b/crates/rue-bench/src/derive.rs
@@ -731,6 +731,7 @@ window = 3
                             peak_memory_bytes: 32 * 1024 * 1024,
                             output_binary_bytes: 12_288,
                             phases: accounting(ns * batch),
+                            boundary_evidence: Vec::new(),
                         }
                     })
                     .collect(),

--- a/crates/rue-bench/src/main.rs
+++ b/crates/rue-bench/src/main.rs
@@ -421,11 +421,13 @@ fn run(options: &Options) -> Result<u8, String> {
                 compiler: &options.compiler,
                 source: &source,
                 args: &epoch.args,
+                target: Some(&epoch.target),
                 output: output.clone(),
                 std_root: options.std_root.as_deref(),
                 batch_size: policy.batch_size,
                 workload: &workload.id,
                 sample_index: index,
+                boundary_policy: epoch.boundary.as_ref(),
             };
             match measure_sample(&request) {
                 SampleOutcome::Measured(sample) => {
@@ -670,6 +672,7 @@ window = 10
                     peak_memory_bytes: 1,
                     output_binary_bytes: 1,
                     phases,
+                    boundary_evidence: Vec::new(),
                 }],
             }],
             failures: Vec::new(),

--- a/crates/rue-bench/src/measure.rs
+++ b/crates/rue-bench/src/measure.rs
@@ -11,12 +11,21 @@
 //! water mark, which includes allocator overhead the compiler's own probe
 //! cannot see.
 
+use std::fs;
 use std::io::Read;
 use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::Instant;
 
-use rue_perf_schema::{CompilerWork, FailureRecord, PhaseAccounting, Sample, WorkloadShape};
+use rue_perf_schema::{
+    BuildBoundaryEvidence, BuildBoundaryPolicy, CompilerBoundaryEvidence,
+    CompilerCriticalPathEvidence, CompilerInputClass, CompilerWork, FailureRecord, PhaseAccounting,
+    RunnerBoundaryEvidence, RunnerClockBoundary, Sample, WorkloadShape,
+};
+use sha2::{Digest, Sha256};
+
+static PROCESS_DIRECTORY_SEQUENCE: AtomicU64 = AtomicU64::new(0);
 
 /// Everything needed to measure one sample.
 pub struct SampleRequest<'a> {
@@ -26,6 +35,8 @@ pub struct SampleRequest<'a> {
     pub source: &'a Path,
     /// Behaviour-affecting compiler arguments, from the epoch.
     pub args: &'a [String],
+    /// Exact target declared independently by the epoch.
+    pub target: Option<&'a str>,
     /// Where the compiled binary goes.
     pub output: PathBuf,
     /// Standard-library root, when the workload needs one.
@@ -41,6 +52,8 @@ pub struct SampleRequest<'a> {
     pub workload: &'a str,
     /// Which sample this is, for failure records.
     pub sample_index: u32,
+    /// Exhaustive source-to-native contract for protocol-v2 observations.
+    pub boundary_policy: Option<&'a BuildBoundaryPolicy>,
 }
 
 /// What measuring one sample produced.
@@ -60,6 +73,10 @@ struct BenchmarkJson {
     source_metrics: SourceMetrics,
     compiler_work: CompilerWork,
     emitted_output: EmittedOutput,
+    #[serde(default)]
+    compiler_boundary: Option<CompilerBoundaryEvidence>,
+    #[serde(default)]
+    critical_path: Option<CompilerCriticalPathEvidence>,
 }
 
 #[derive(serde::Deserialize)]
@@ -81,6 +98,7 @@ struct SourceMetrics {
 #[derive(serde::Deserialize)]
 struct EmittedOutput {
     size_bytes: u64,
+    sha256: String,
 }
 
 struct CompletedCompile {
@@ -91,6 +109,9 @@ struct CompletedCompile {
     target: String,
     compiler_build_profile: String,
     compiler_work: CompilerWork,
+    process_elapsed_ns: u64,
+    output_sha256: String,
+    boundary_evidence: Option<BuildBoundaryEvidence>,
 }
 
 /// The raw result of one fresh compiler process for the scaling report.
@@ -110,12 +131,38 @@ pub struct FreshCompile {
 pub fn measure_sample(request: &SampleRequest<'_>) -> SampleOutcome {
     let mut total: Option<PhaseAccounting> = None;
     let mut peak_memory_bytes = 0u64;
+    let mut process_elapsed_ns = 0u64;
+    let mut output_binary_bytes = None;
+    let mut output_sha256 = None;
+    let mut boundary_evidence = Vec::with_capacity(request.batch_size as usize);
 
-    let started = Instant::now();
     for _ in 0..request.batch_size {
         match run_once(request) {
             Ok(completed) => {
                 peak_memory_bytes = peak_memory_bytes.max(completed.peak_memory_bytes);
+                process_elapsed_ns =
+                    process_elapsed_ns.saturating_add(completed.process_elapsed_ns);
+                match (&output_sha256, output_binary_bytes) {
+                    (None, None) => {
+                        output_sha256 = Some(completed.output_sha256.clone());
+                        output_binary_bytes = Some(completed.output_binary_bytes);
+                    }
+                    (Some(expected_hash), Some(expected_size))
+                        if expected_hash == &completed.output_sha256
+                            && expected_size == completed.output_binary_bytes => {}
+                    _ => {
+                        return SampleOutcome::Failed(Box::new(
+                            FailureRecord::ValidationRejected {
+                                workload: request.workload.to_string(),
+                                detail: "fresh compiler processes produced different native output"
+                                    .to_string(),
+                            },
+                        ));
+                    }
+                }
+                if let Some(evidence) = completed.boundary_evidence {
+                    boundary_evidence.push(evidence);
+                }
                 total = Some(match total {
                     None => completed.accounting,
                     Some(running) => add_accounting(running, &completed.accounting),
@@ -130,8 +177,6 @@ pub fn measure_sample(request: &SampleRequest<'_>) -> SampleOutcome {
             }
         }
     }
-    let process_elapsed_ns = u64::try_from(started.elapsed().as_nanos()).unwrap_or(u64::MAX);
-
     let Some(phases) = total else {
         // A zero batch size cannot measure anything. The manifest rejects it,
         // so reaching here means the policy was bypassed.
@@ -141,16 +186,13 @@ pub fn measure_sample(request: &SampleRequest<'_>) -> SampleOutcome {
         }));
     };
 
-    let output_binary_bytes = std::fs::metadata(&request.output)
-        .map(|metadata| metadata.len())
-        .unwrap_or(0);
-
     SampleOutcome::Measured(Box::new(Sample {
         batch_size: request.batch_size,
         process_elapsed_ns,
         peak_memory_bytes,
-        output_binary_bytes,
+        output_binary_bytes: output_binary_bytes.unwrap_or(0),
         phases,
+        boundary_evidence,
     }))
 }
 
@@ -163,16 +205,15 @@ pub fn measure_fresh_compile(request: &SampleRequest<'_>) -> Result<FreshCompile
     if request.batch_size != 1 {
         return Err("a scaling sample must launch exactly one compiler process".to_string());
     }
-    let started = Instant::now();
     let completed = run_once(request)?;
-    let process_elapsed_ns = u64::try_from(started.elapsed().as_nanos()).unwrap_or(u64::MAX);
     Ok(FreshCompile {
         sample: Sample {
             batch_size: 1,
-            process_elapsed_ns,
+            process_elapsed_ns: completed.process_elapsed_ns,
             peak_memory_bytes: completed.peak_memory_bytes,
             output_binary_bytes: completed.output_binary_bytes,
             phases: completed.accounting,
+            boundary_evidence: completed.boundary_evidence.into_iter().collect(),
         },
         shape: completed.shape,
         target: completed.target,
@@ -204,19 +245,51 @@ fn add_accounting(mut running: PhaseAccounting, next: &PhaseAccounting) -> Phase
 /// Run the compiler once, returning its partition and externally measured peak
 /// resident memory.
 fn run_once(request: &SampleRequest<'_>) -> Result<CompletedCompile, String> {
+    let sequence = PROCESS_DIRECTORY_SEQUENCE.fetch_add(1, Ordering::Relaxed);
+    let base = request
+        .output
+        .parent()
+        .ok_or_else(|| "benchmark output has no parent directory".to_string())?;
+    let process_root = base.join(format!(".fresh-compiler-{}-{sequence}", std::process::id()));
+    let state_directory = process_root.join("state");
+    let output_directory = process_root.join("output");
+    fs::create_dir(&process_root)
+        .map_err(|error| format!("could not create fresh process directory: {error}"))?;
+    fs::create_dir(&state_directory)
+        .map_err(|error| format!("could not create fresh state directory: {error}"))?;
+    fs::create_dir(&output_directory)
+        .map_err(|error| format!("could not create fresh output directory: {error}"))?;
+    let output_path = output_directory.join(
+        request
+            .output
+            .file_name()
+            .unwrap_or_else(|| std::ffi::OsStr::new("artifact")),
+    );
+    let compiler_binary_sha256 = sha256_file(request.compiler)?;
+
     let mut command = Command::new(request.compiler);
     command
         .arg(request.source)
         .arg("-o")
-        .arg(&request.output)
+        .arg(&output_path)
         .args(request.args)
         .arg("--benchmark-json")
+        .env("RUE_BENCH_STATE_DIR", &state_directory)
+        .env_remove("RUE_DAEMON_ENDPOINT")
+        .env_remove("RUE_RETAINED_SESSION")
         .stdout(Stdio::piped())
         .stderr(Stdio::piped());
+    if let Some(target) = request.target {
+        command.arg("--target").arg(target);
+    }
     if let Some(std_root) = request.std_root {
         command.env("RUE_STD_PATH", std_root);
     }
 
+    // The external clock starts only after all setup and immediately before
+    // process creation. It stops after successful exit and independent native
+    // output verification below.
+    let started = Instant::now();
     let mut child = command
         .spawn()
         .map_err(|error| format!("could not spawn the compiler: {error}"))?;
@@ -226,34 +299,114 @@ fn run_once(request: &SampleRequest<'_>) -> Result<CompletedCompile, String> {
     // benchmark JSON is large enough for that to be a live risk.
     let mut stdout_pipe = child.stdout.take().expect("stdout was piped");
     let mut stderr_pipe = child.stderr.take().expect("stderr was piped");
-    let (stdout, stderr) = std::thread::scope(|scope| {
+    let (stdout, stderr, peak, status) = std::thread::scope(|scope| {
+        let stdout_reader = scope.spawn(move || {
+            let mut buffer = String::new();
+            let _ = stdout_pipe.read_to_string(&mut buffer);
+            buffer
+        });
         let stderr_reader = scope.spawn(move || {
             let mut buffer = String::new();
             let _ = stderr_pipe.read_to_string(&mut buffer);
             buffer
         });
-        let mut stdout = String::new();
-        let _ = stdout_pipe.read_to_string(&mut stdout);
-        (stdout, stderr_reader.join().unwrap_or_default())
+        let reaped = wait_for_peak_memory(&child);
+        (
+            stdout_reader.join().unwrap_or_default(),
+            stderr_reader.join().unwrap_or_default(),
+            reaped.as_ref().map_or(0, |(peak, _)| *peak),
+            reaped.map(|(_, status)| status),
+        )
     });
-
-    let peak = wait_for_peak_memory(&child)?;
     // `wait4` above already reaped the child, so `child` must not be waited on
     // again. `Child::drop` does not reap, so letting it fall out of scope is
     // correct; calling `wait()` here would fail with ECHILD.
     drop(child);
 
-    // A workload's exit status belongs to its own program, so a nonzero status
-    // is only a failure when nothing parseable came back.
+    let status = status?;
+    if !libc::WIFEXITED(status) || libc::WEXITSTATUS(status) != 0 {
+        let tail: String = stderr.lines().rev().take(5).collect::<Vec<_>>().join("\n");
+        return Err(format!(
+            "compiler exited unsuccessfully (status {status}); stderr tail:\n{tail}"
+        ));
+    }
+
     let parsed: BenchmarkJson = serde_json::from_str(stdout.trim()).map_err(|error| {
         let tail: String = stderr.lines().rev().take(5).collect::<Vec<_>>().join("\n");
         format!("no benchmark JSON on stdout ({error}); stderr tail:\n{tail}")
     })?;
 
+    let output_bytes = fs::read(&output_path)
+        .map_err(|error| format!("could not read compiler output for verification: {error}"))?;
+    if output_bytes.is_empty()
+        || !native_output_matches_target(&output_bytes, &parsed.metadata.target)
+    {
+        return Err(format!(
+            "compiler output is not a nonempty native executable for {}",
+            parsed.metadata.target
+        ));
+    }
+    let output_sha256 = sha256_bytes(&output_bytes);
+    let output_binary_bytes = u64::try_from(output_bytes.len()).unwrap_or(u64::MAX);
+    if parsed.emitted_output.sha256 != output_sha256
+        || parsed.emitted_output.size_bytes != output_binary_bytes
+    {
+        return Err("compiler and runner disagree about emitted output bytes".to_string());
+    }
+    if !directory_contains_only(&output_directory, &output_path)? {
+        return Err(
+            "compiler produced an undeclared artifact in the fresh output directory".to_string(),
+        );
+    }
+    let process_elapsed_ns = u64::try_from(started.elapsed().as_nanos()).unwrap_or(u64::MAX);
+
+    let boundary_evidence = match request.boundary_policy {
+        None => None,
+        Some(policy) => {
+            let compiler = parsed.compiler_boundary.clone().ok_or_else(|| {
+                "compiler omitted protocol-v2 build-boundary evidence".to_string()
+            })?;
+            let critical_path = parsed
+                .critical_path
+                .clone()
+                .ok_or_else(|| "compiler omitted protocol-v2 critical-path evidence".to_string())?;
+            verify_input_provenance(request, &compiler)?;
+            let evidence = BuildBoundaryEvidence {
+                runner: RunnerBoundaryEvidence {
+                    compiler_binary_sha256,
+                    // Both directories were created successfully immediately
+                    // before the clock and process spawn. The output directory
+                    // is also checked above to contain only the verified
+                    // requested artifact after exit.
+                    fresh_state_directory: true,
+                    fresh_output_directory: true,
+                    daemon_endpoint_supplied: false,
+                    retained_session_handle_supplied: false,
+                    clock_boundary:
+                        RunnerClockBoundary::MonotonicPreSpawnThroughExitAndOutputVerification,
+                    successful_exit: true,
+                    native_output_verified: true,
+                    output_sha256: output_sha256.clone(),
+                    output_size_bytes: output_binary_bytes,
+                },
+                compiler,
+                critical_path,
+                compiler_work: parsed.compiler_work.clone(),
+            };
+            let expected_target = request.target.ok_or_else(|| {
+                "boundary policy has no independently declared target".to_string()
+            })?;
+            evidence
+                .validate_against(policy, expected_target)
+                .map_err(|detail| format!("build-boundary evidence rejected: {detail}"))?;
+            Some(evidence)
+        }
+    };
+
     Ok(CompletedCompile {
         accounting: parsed.phase_accounting,
         peak_memory_bytes: peak,
-        output_binary_bytes: parsed.emitted_output.size_bytes,
+        output_binary_bytes,
         shape: WorkloadShape {
             files: parsed.source_metrics.files,
             modules: parsed.source_metrics.modules,
@@ -265,6 +418,9 @@ fn run_once(request: &SampleRequest<'_>) -> Result<CompletedCompile, String> {
         target: parsed.metadata.target,
         compiler_build_profile: parsed.metadata.compiler_build_profile,
         compiler_work: parsed.compiler_work,
+        process_elapsed_ns,
+        output_sha256,
+        boundary_evidence,
     })
 }
 
@@ -274,7 +430,7 @@ fn run_once(request: &SampleRequest<'_>) -> Result<CompletedCompile, String> {
 /// reports a maximum across every child this process has ever reaped, so once
 /// the largest workload had run, every later workload would inherit its peak
 /// and the memory metric would be silently wrong for all but the biggest.
-fn wait_for_peak_memory(child: &std::process::Child) -> Result<u64, String> {
+fn wait_for_peak_memory(child: &std::process::Child) -> Result<(u64, libc::c_int), String> {
     let mut status: libc::c_int = 0;
     let mut usage = std::mem::MaybeUninit::<libc::rusage>::zeroed();
     // SAFETY: `status` and `usage` are properly sized and aligned for `wait4`,
@@ -296,7 +452,81 @@ fn wait_for_peak_memory(child: &std::process::Child) -> Result<u64, String> {
     }
     // SAFETY: `wait4` succeeded, so the usage value is initialized.
     let usage = unsafe { usage.assume_init() };
-    Ok(max_rss_bytes(usage.ru_maxrss))
+    Ok((max_rss_bytes(usage.ru_maxrss), status))
+}
+
+fn sha256_bytes(bytes: &[u8]) -> String {
+    format!("{:x}", Sha256::digest(bytes))
+}
+
+fn sha256_file(path: &Path) -> Result<String, String> {
+    fs::read(path)
+        .map(|bytes| sha256_bytes(&bytes))
+        .map_err(|error| format!("could not hash {}: {error}", path.display()))
+}
+
+fn directory_contains_only(directory: &Path, expected: &Path) -> Result<bool, String> {
+    let entries = fs::read_dir(directory)
+        .map_err(|error| format!("could not inspect {}: {error}", directory.display()))?
+        .collect::<Result<Vec<_>, _>>()
+        .map_err(|error| format!("could not inspect {}: {error}", directory.display()))?;
+    Ok(entries.len() == 1 && entries[0].path() == expected)
+}
+
+fn native_output_matches_target(bytes: &[u8], target: &str) -> bool {
+    if target.contains("linux") {
+        bytes.starts_with(b"\x7fELF")
+    } else if target.contains("macos") || target.contains("darwin") {
+        bytes.starts_with(&[0xcf, 0xfa, 0xed, 0xfe])
+    } else {
+        false
+    }
+}
+
+fn verify_input_provenance(
+    request: &SampleRequest<'_>,
+    compiler: &CompilerBoundaryEvidence,
+) -> Result<(), String> {
+    let workload_root = request
+        .source
+        .parent()
+        .ok_or_else(|| "workload source has no parent directory".to_string())?;
+    for input in &compiler.accepted_inputs {
+        let path = match input.class {
+            CompilerInputClass::WorkloadSource => {
+                let logical = Path::new(&input.logical_identity);
+                if logical.is_absolute() {
+                    return Err("compiler reported an absolute workload identity".to_string());
+                }
+                workload_root.join(logical)
+            }
+            CompilerInputClass::TrustedStandardLibrarySource => {
+                let relative = input
+                    .logical_identity
+                    .strip_prefix('\0')
+                    .and_then(|identity| identity.strip_prefix("rue-std/"))
+                    .ok_or_else(|| {
+                        "compiler reported a malformed trusted-standard-library identity"
+                            .to_string()
+                    })?;
+                request
+                    .std_root
+                    .ok_or_else(|| {
+                        "compiler used std but the runner supplied no std root".to_string()
+                    })?
+                    .join(relative)
+            }
+        };
+        let observed = sha256_file(&path)?;
+        if observed != input.sha256 {
+            return Err(format!(
+                "compiler input evidence for {:?} disagrees with {}",
+                input.logical_identity,
+                path.display()
+            ));
+        }
+    }
+    Ok(())
 }
 
 /// Normalize `ru_maxrss` to bytes.

--- a/crates/rue-bench/src/scaling.rs
+++ b/crates/rue-bench/src/scaling.rs
@@ -7,13 +7,12 @@
 use std::path::{Path, PathBuf};
 
 use rue_perf_schema::{
-    Band, SCALING_REPORT_SCHEMA_VERSION, ScalingIdentity, ScalingManifest, ScalingObservation,
-    ScalingRegime, ScalingReport, Summary, WorkloadShape, canonical_json, content_address,
+    Band, BuildBoundaryPolicy, SCALING_REPORT_SCHEMA_VERSION, ScalingIdentity, ScalingManifest,
+    ScalingObservation, ScalingRegime, ScalingReport, Summary, WorkerSetting, WorkloadShape,
+    canonical_json, content_address,
 };
 
 use crate::measure::{SampleRequest, measure_fresh_compile};
-
-const COMPILER_WORK_SAMPLES_PER_WORKLOAD: u32 = 2;
 
 struct Options {
     manifest: PathBuf,
@@ -46,10 +45,8 @@ pub fn run() -> Result<(), String> {
     };
 
     let started_at = crate::utc_timestamp();
-    let mut compiler_work_args = manifest.args.clone();
-    compiler_work_args.extend(["--jobs".to_string(), "1".to_string()]);
     let mut target: Option<String> = None;
-    let mut observations = Vec::with_capacity(manifest.workloads.len());
+    let mut observations = Vec::with_capacity(manifest.workloads.len() * manifest.workers.len());
     for workload in &manifest.workloads {
         let source = options.repo_root.join(&workload.source);
         if !source.is_file() {
@@ -59,132 +56,132 @@ pub fn run() -> Result<(), String> {
                 source.display()
             ));
         }
-        let output = workdir.join(format!("{}-out", workload.id));
         let mut shape: Option<WorkloadShape> = None;
-        let mut work = None;
-        let mut samples = Vec::with_capacity(manifest.samples as usize);
-        for sample_index in 0..manifest.samples {
-            eprintln!(
-                "rue-bench: scaling {} sample {}/{}",
-                workload.id,
-                sample_index + 1,
-                manifest.samples
-            );
-            let request = SampleRequest {
-                compiler: &options.compiler,
-                source: &source,
-                args: &manifest.args,
-                output: output.clone(),
-                std_root: options.std_root.as_deref(),
-                batch_size: 1,
-                workload: &workload.id,
-                sample_index,
-            };
-            let measured = measure_fresh_compile(&request).map_err(|detail| {
-                format!(
-                    "scaling workload {:?} sample {} failed: {detail}",
-                    workload.id, sample_index
-                )
-            })?;
-            if !measured.sample.phases.holds() {
-                return Err(format!(
-                    "scaling workload {:?} sample {} violated phase accounting: root={} attributed={}",
+        let mut reference_work = None;
+        let mut output_identity: Option<(String, u64)> = None;
+        for worker_setting in &manifest.workers {
+            let policy = BuildBoundaryPolicy::fresh_source_to_native_v1(*worker_setting);
+            let mut args = manifest.args.clone();
+            args.extend(policy.canonical_compiler_args());
+            let output = workdir.join(format!("{}-{:?}-out", workload.id, worker_setting));
+            let mut resolved_workers = None;
+            let mut samples = Vec::with_capacity(manifest.samples as usize);
+            for sample_index in 0..manifest.samples {
+                eprintln!(
+                    "rue-bench: scaling {} {:?} sample {}/{}",
                     workload.id,
+                    worker_setting,
+                    sample_index + 1,
+                    manifest.samples
+                );
+                let request = SampleRequest {
+                    compiler: &options.compiler,
+                    source: &source,
+                    args: &args,
+                    target: Some(&manifest.target),
+                    output: output.clone(),
+                    std_root: options.std_root.as_deref(),
+                    batch_size: 1,
+                    workload: &workload.id,
                     sample_index,
-                    measured.sample.phases.compiler_root_ns,
-                    measured.sample.phases.attributed_ns()
-                ));
-            }
-            match &shape {
-                None => shape = Some(measured.shape.clone()),
-                Some(expected) if expected != &measured.shape => {
+                    boundary_policy: Some(&policy),
+                };
+                let measured = measure_fresh_compile(&request).map_err(|detail| {
+                    format!(
+                        "scaling workload {:?} {:?} sample {} failed: {detail}",
+                        workload.id, worker_setting, sample_index
+                    )
+                })?;
+                if !measured.sample.phases.holds() {
                     return Err(format!(
-                        "scaling workload {:?} changed shape between samples: {expected:?} then {:?}",
-                        workload.id, measured.shape
+                        "scaling workload {:?} {:?} sample {} violated phase accounting: root={} attributed={}",
+                        workload.id,
+                        worker_setting,
+                        sample_index,
+                        measured.sample.phases.compiler_root_ns,
+                        measured.sample.phases.attributed_ns()
                     ));
                 }
-                Some(_) => {}
-            }
-            match &target {
-                None => target = Some(measured.target.clone()),
-                Some(expected) if expected != &measured.target => {
+                match &shape {
+                    None => shape = Some(measured.shape.clone()),
+                    Some(expected) if expected != &measured.shape => {
+                        return Err(format!(
+                            "scaling workload {:?} changed shape between samples: {expected:?} then {:?}",
+                            workload.id, measured.shape
+                        ));
+                    }
+                    Some(_) => {}
+                }
+                match &target {
+                    None => target = Some(measured.target.clone()),
+                    Some(expected) if expected != &measured.target => {
+                        return Err(format!(
+                            "compiler target changed between samples: {expected:?} then {:?}",
+                            measured.target
+                        ));
+                    }
+                    Some(_) => {}
+                }
+                if measured.compiler_build_profile != manifest.compiler_build_profile {
                     return Err(format!(
-                        "compiler target changed between samples: {expected:?} then {:?}",
-                        measured.target
+                        "scaling workload {:?} requires compiler build profile {:?}, but the compiler reported {:?}",
+                        workload.id,
+                        manifest.compiler_build_profile,
+                        measured.compiler_build_profile,
                     ));
                 }
-                Some(_) => {}
+                let evidence = measured
+                    .sample
+                    .boundary_evidence
+                    .first()
+                    .expect("the boundary policy requires exactly one process proof");
+                let current_resolved = evidence.compiler.configuration.resolved_workers;
+                match resolved_workers {
+                    None => resolved_workers = Some(current_resolved),
+                    Some(expected) if expected == current_resolved => {}
+                    Some(expected) => {
+                        return Err(format!(
+                            "worker row {worker_setting:?} resolved inconsistently: {expected} then {current_resolved}"
+                        ));
+                    }
+                }
+                let current_output = (
+                    evidence.runner.output_sha256.clone(),
+                    evidence.compiler.emitted_output_size_bytes,
+                );
+                match &output_identity {
+                    None => output_identity = Some(current_output),
+                    Some(expected) if expected == &current_output => {}
+                    Some(_) => {
+                        return Err(format!(
+                            "scaling workload {:?} produced different output across worker rows",
+                            workload.id
+                        ));
+                    }
+                }
+                if *worker_setting == WorkerSetting::One {
+                    observe_compiler_work(
+                        &mut reference_work,
+                        measured.compiler_work,
+                        &workload.id,
+                    )?;
+                }
+                samples.push(measured.sample);
             }
-            if measured.compiler_build_profile != manifest.compiler_build_profile {
-                return Err(format!(
-                    "scaling workload {:?} requires compiler build profile {:?}, but the compiler reported {:?}",
-                    workload.id, manifest.compiler_build_profile, measured.compiler_build_profile,
-                ));
-            }
-            samples.push(measured.sample);
+            observations.push(ScalingObservation {
+                workload: workload.id.clone(),
+                source: workload.source.clone(),
+                question: workload.question.clone(),
+                worker_setting: *worker_setting,
+                resolved_workers: resolved_workers.expect("the manifest requires samples"),
+                shape: shape
+                    .clone()
+                    .expect("the manifest requires at least two samples"),
+                work: reference_work
+                    .expect("the reference worker matrix starts with the one-worker row"),
+                samples,
+            });
         }
-        // Keep the structural probes after the published timing samples so
-        // adding deterministic counters cannot warm workload files before the
-        // established timing regime observes them.
-        for probe_index in 0..COMPILER_WORK_SAMPLES_PER_WORKLOAD {
-            eprintln!(
-                "rue-bench: scaling {} deterministic-work probe {}/{}",
-                workload.id,
-                probe_index + 1,
-                COMPILER_WORK_SAMPLES_PER_WORKLOAD
-            );
-            let request = SampleRequest {
-                compiler: &options.compiler,
-                source: &source,
-                args: &compiler_work_args,
-                output: output.clone(),
-                std_root: options.std_root.as_deref(),
-                batch_size: 1,
-                workload: &workload.id,
-                sample_index: probe_index,
-            };
-            let measured = measure_fresh_compile(&request).map_err(|detail| {
-                format!(
-                    "scaling workload {:?} deterministic-work probe {} failed: {detail}",
-                    workload.id, probe_index
-                )
-            })?;
-            match &shape {
-                None => shape = Some(measured.shape.clone()),
-                Some(expected) if expected != &measured.shape => {
-                    return Err(format!(
-                        "scaling workload {:?} changed shape between deterministic-work probes: {expected:?} then {:?}",
-                        workload.id, measured.shape
-                    ));
-                }
-                Some(_) => {}
-            }
-            match &target {
-                None => target = Some(measured.target.clone()),
-                Some(expected) if expected != &measured.target => {
-                    return Err(format!(
-                        "compiler target changed between samples: {expected:?} then {:?}",
-                        measured.target
-                    ));
-                }
-                Some(_) => {}
-            }
-            if measured.compiler_build_profile != manifest.compiler_build_profile {
-                return Err(format!(
-                    "scaling workload {:?} requires compiler build profile {:?}, but the compiler reported {:?}",
-                    workload.id, manifest.compiler_build_profile, measured.compiler_build_profile,
-                ));
-            }
-            observe_compiler_work(&mut work, measured.compiler_work, &workload.id)?;
-        }
-        observations.push(ScalingObservation {
-            workload: workload.id.clone(),
-            source: workload.source.clone(),
-            question: workload.question.clone(),
-            shape: shape.expect("the manifest requires at least two samples"),
-            work: work.expect("the manifest requires at least two samples"),
-            samples,
-        });
     }
 
     let report = ScalingReport {
@@ -194,7 +191,7 @@ pub fn run() -> Result<(), String> {
             commit: options.commit,
             started_at,
             finished_at: crate::utc_timestamp(),
-            target: target.unwrap_or_else(|| "unknown".to_string()),
+            target: target.unwrap_or_else(|| manifest.target.clone()),
             environment: crate::environment::fingerprint(),
         },
         regime: ScalingRegime {
@@ -204,8 +201,8 @@ pub fn run() -> Result<(), String> {
             samples_per_workload: manifest.samples,
             compiler_args: manifest.args,
             compiler_build_profile: manifest.compiler_build_profile,
-            compiler_work_samples_per_workload: COMPILER_WORK_SAMPLES_PER_WORKLOAD,
-            compiler_work_args,
+            boundary: manifest.boundary,
+            workers: manifest.workers,
         },
         workloads: observations,
     };
@@ -300,11 +297,13 @@ fn render(report: &ScalingReport) -> String {
     let mut out = String::new();
     out.push_str("# Rue compiler scaling report\n\n");
     out.push_str(&format!(
-        "- Commit: `{}`\n- Fixture revision: {}\n- Target: `{}`\n- Compiler build profile: `{}`\n- Machine: {} ({} cores, {} bytes memory)\n- Runner: `{}` / `{}` ({})\n- Regime: {} sequential fresh compiler processes per workload; OS page-cache state is uncontrolled.\n- Structural work: {} single-worker compiler-work probes per workload with arguments `{:?}`; probe timings are not published.\n- Runtime separation: compiled programs were not executed.\n\n",
+        "- Commit: `{}`\n- Fixture revision: {}\n- Target: `{}`\n- Compiler build profile: `{}`\n- Boundary: `{:?}`\n- Worker matrix: `{:?}`\n- Machine: {} ({} cores, {} bytes memory)\n- Runner: `{}` / `{}` ({})\n- Regime: {} sequential fresh compiler processes per workload and worker row; OS page-cache state is uncontrolled.\n- Structural work: one-worker samples must agree exactly; schedule-dependent parallel work remains raw per-process evidence.\n- Runtime separation: compiled programs were not executed.\n\n",
         report.identity.commit,
         report.identity.manifest_revision,
         report.identity.target,
         report.regime.compiler_build_profile,
+        report.regime.boundary,
+        report.regime.workers,
         report.identity.environment.cpu_model,
         report.identity.environment.core_count,
         report.identity.environment.memory_bytes,
@@ -312,11 +311,9 @@ fn render(report: &ScalingReport) -> String {
         report.identity.environment.runner_image,
         report.identity.environment.runner_image_version,
         report.regime.samples_per_workload,
-        report.regime.compiler_work_samples_per_workload,
-        report.regime.compiler_work_args,
     ));
     out.push_str("Times and memory are median ± median absolute deviation (MAD). A changed shape id marks comparisons with earlier artifacts as advisory.\n\n");
-    out.push_str("| workload | shape id | files/modules | functions | bytes/lines/tokens | process ms | compiler ms | peak MiB | output KiB |\n");
+    out.push_str("| workload / workers | shape id | files/modules | functions | bytes/lines/tokens | process ms | compiler ms | peak MiB | output KiB |\n");
     out.push_str("| --- | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |\n");
     for observation in &report.workloads {
         let process = summarize(
@@ -348,7 +345,7 @@ fn render(report: &ScalingReport) -> String {
             .unwrap_or_else(|_| "unknown".to_string());
         out.push_str(&format!(
             "| {} | `{}` | {}/{} | {} | {}/{}/{} | {:.2} ± {:.2} | {:.2} ± {:.2} | {:.1} ± {:.1} | {:.1} ± {:.1} |\n",
-            observation.workload,
+            observation_label(observation),
             shape_id,
             observation.shape.files,
             observation.shape.modules,
@@ -367,11 +364,77 @@ fn render(report: &ScalingReport) -> String {
         ));
     }
 
+    out.push_str("\n## Worker scaling and critical path\n\n");
+    out.push_str("Utilization divides summed query-worker active time by compiler-root time and the compiler's resolved worker count. Ready wait is summed across dependency-ready items, so the mean and maximum are the directly comparable latency signals. Body columns show total/max milliseconds from bounded compiler histograms.\n\n");
+    out.push_str("| workload / workers | utilization | active ms | ready mean/max ms | longest chain | toolchain ms | semantic total/max ms | CFG build total/max ms | CFG opt total/max ms | joins declined/total | donated permits |\n");
+    out.push_str("| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |\n");
+    for observation in &report.workloads {
+        let evidence = observation.samples.iter().map(|sample| {
+            sample
+                .boundary_evidence
+                .first()
+                .map(|evidence| evidence.critical_path.clone())
+                .unwrap_or_default()
+        });
+        let utilization = summarize(evidence.clone().zip(&observation.samples).map(
+            |(evidence, sample)| {
+                let capacity = sample
+                    .phases
+                    .compiler_root_ns
+                    .saturating_mul(u64::from(observation.resolved_workers));
+                if capacity == 0 {
+                    0
+                } else {
+                    evidence.query_worker_active_ns.saturating_mul(10_000) / capacity
+                }
+            },
+        ));
+        let active = summarize(evidence.clone().map(|e| e.query_worker_active_ns));
+        let ready_mean = summarize(evidence.clone().map(|e| {
+            if e.ready_items == 0 {
+                0
+            } else {
+                e.ready_wait_ns / e.ready_items
+            }
+        }));
+        let ready_max = summarize(evidence.clone().map(|e| e.max_ready_wait_ns));
+        let chain = summarize(evidence.clone().map(|e| e.longest_query_dependency_chain));
+        let toolchain = summarize(evidence.clone().map(|e| e.toolchain_acquisition_ns));
+        let semantic_total = summarize(evidence.clone().map(|e| e.semantic_bodies.total_ns));
+        let semantic_max = summarize(evidence.clone().map(|e| e.semantic_bodies.max_ns));
+        let cfg_total = summarize(evidence.clone().map(|e| e.cfg_construction_bodies.total_ns));
+        let cfg_max = summarize(evidence.clone().map(|e| e.cfg_construction_bodies.max_ns));
+        let opt_total = summarize(evidence.clone().map(|e| e.cfg_optimization_bodies.total_ns));
+        let opt_max = summarize(evidence.clone().map(|e| e.cfg_optimization_bodies.max_ns));
+        let joins = summarize(evidence.clone().map(|e| e.joins));
+        let declined = summarize(evidence.clone().map(|e| e.declined_joins));
+        let donated = summarize(evidence.map(|e| e.donated_permits));
+        out.push_str(&format!(
+            "| {} | {:.1}% | {:.2} | {:.3}/{:.3} | {} | {:.2} | {:.2}/{:.2} | {:.2}/{:.2} | {:.2}/{:.2} | {}/{} | {} |\n",
+            observation_label(observation),
+            utilization.median as f64 / 100.0,
+            active.median as f64 / 1_000_000.0,
+            ready_mean.median as f64 / 1_000_000.0,
+            ready_max.median as f64 / 1_000_000.0,
+            chain.median,
+            toolchain.median as f64 / 1_000_000.0,
+            semantic_total.median as f64 / 1_000_000.0,
+            semantic_max.median as f64 / 1_000_000.0,
+            cfg_total.median as f64 / 1_000_000.0,
+            cfg_max.median as f64 / 1_000_000.0,
+            opt_total.median as f64 / 1_000_000.0,
+            opt_max.median as f64 / 1_000_000.0,
+            declined.median,
+            joins.median,
+            donated.median,
+        ));
+    }
+
     out.push_str("\n## Deterministic query work\n\n");
-    out.push_str("Counts are exact for one fresh compiler process and must agree across the fixed single-worker structural probes. Request outcomes expose all query traffic before validation detail: claims start computations, reuses return compatible retained or task-local terminals, and joins share in-flight work. Declined joins are included in joins and identify wait-graph avoidance.\n\n");
+    out.push_str("Counts are exact for one fresh compiler process and must agree across the measured one-worker samples. Parallel scheduling outcomes remain available in each raw boundary proof but are not collapsed into an allegedly deterministic count. Request outcomes expose all query traffic before validation detail: claims start computations, reuses return compatible retained or task-local terminals, and joins share in-flight work. Declined joins are included in joins and identify wait-graph avoidance.\n\n");
     out.push_str("| workload | claims | reuses | joins declined/total | body completions | publications red/green | cancellations/cycles |\n");
     out.push_str("| --- | ---: | ---: | ---: | ---: | ---: | ---: |\n");
-    for observation in &report.workloads {
+    for observation in reference_observations(report) {
         let runtime = observation.work.query_runtime;
         out.push_str(&format!(
             "| {} | {} | {} | {}/{} | {} | {}/{} | {}/{} |\n",
@@ -391,7 +454,7 @@ fn render(report: &ScalingReport) -> String {
     out.push_str("\nRegistry logical/index distinguishes requested exact-node resolutions from accesses to the shared incarnation index. `nodes/token` exposes validation amplification independently of clock noise.\n\n");
     out.push_str("| workload | traversals | input/dependency observations | memo hit/miss | registry logical/index | endorsements hit/probe | terminal leases duplicate/total | demands reuse/compute/join/total | retention scan entries | nodes/token |\n");
     out.push_str("| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |\n");
-    for observation in &report.workloads {
+    for observation in reference_observations(report) {
         let runtime = observation.work.query_runtime;
         let validation = runtime.validation;
         let nodes_per_token = if observation.shape.tokens == 0 {
@@ -426,7 +489,7 @@ fn render(report: &ScalingReport) -> String {
     out.push_str("Counts are exact snapshots of the provider operations already performed by production body analysis; the scaling probe adds no provider lookup or materialization work. Lookup and candidate counts expose demand at the semantic boundary, while exact fact-family reads and durable materializations separate repeated observation from body-local representation work.\n\n");
     out.push_str("| workload | name/import lookups | method/operator candidates | declaration facts total (identity/signature/type/const) |\n");
     out.push_str("| --- | ---: | ---: | ---: |\n");
-    for observation in &report.workloads {
+    for observation in reference_observations(report) {
         let work = observation.work.semantic_provider;
         out.push_str(&format!(
             "| {} | {}/{} | {}/{} | {} ({}/{}/{}/{}) |\n",
@@ -444,7 +507,7 @@ fn render(report: &ScalingReport) -> String {
     }
     out.push_str("\n| workload | durable materializations | anonymous facts | producer facts | toolchain facts |\n");
     out.push_str("| --- | ---: | ---: | ---: | ---: |\n");
-    for observation in &report.workloads {
+    for observation in reference_observations(report) {
         let work = observation.work.semantic_provider;
         out.push_str(&format!(
             "| {} | {} | {} | {} | {} |\n",
@@ -460,7 +523,7 @@ fn render(report: &ScalingReport) -> String {
     out.push_str("Counts are exact for database-owned body reachability. Width buckets count non-empty dependency-ready logical frontiers; multi-permit runtimes execute bounded windows as structured batches while a single-permit runtime executes the same windows inline. Transaction counts distinguish ready-frontier prefetch from fallback coordinator demand; `keys/batch` exposes available scheduling breadth independently of clock time.\n\n");
     out.push_str("| workload | scans | scan keys | batches | scheduled keys | keys/batch | transactions prefetched/serial | width 1 | width 2–3 | width 4–7 | width 8+ |\n");
     out.push_str("| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |\n");
-    for observation in &report.workloads {
+    for observation in reference_observations(report) {
         let work = observation.work.semantic_reachability;
         let keys_per_batch = if work.frontier_batches == 0 {
             0.0
@@ -488,7 +551,7 @@ fn render(report: &ScalingReport) -> String {
     out.push_str("Counts are exact for construction of the request-local lookup index and selection of body-local fact closures. `selections/build` exposes how broadly one immutable index is shared without conflating lookup preparation with the exact per-body selection that must remain.\n\n");
     out.push_str("| workload | index builds | declarations scanned | anonymous nominals scanned | type nodes scanned | fact selections | selections/build |\n");
     out.push_str("| --- | ---: | ---: | ---: | ---: | ---: | ---: |\n");
-    for observation in &report.workloads {
+    for observation in reference_observations(report) {
         let work = observation.work.cfg_materialization;
         let selections_per_build = if work.index_builds == 0 {
             0.0
@@ -511,7 +574,7 @@ fn render(report: &ScalingReport) -> String {
     out.push_str("Counts are exact for logical retained-charge walks over body-local symbol tables at publication. They expose memory-policy bookkeeping independently of semantic construction and clock noise.\n\n");
     out.push_str("| workload | interner scans | entries scanned | UTF-8 bytes scanned |\n");
     out.push_str("| --- | ---: | ---: | ---: |\n");
-    for observation in &report.workloads {
+    for observation in reference_observations(report) {
         let work = observation.work.cfg_retained_charge;
         out.push_str(&format!(
             "| {} | {} | {} | {} |\n",
@@ -526,7 +589,7 @@ fn render(report: &ScalingReport) -> String {
     out.push_str("Counts and UTF-8 key bytes are exact for identities the compiler actually formatted. Structured-wait values count only labels rendered for a detected wait cycle; registering an acyclic edge is free of display formatting. Shared family names are excluded. `bytes/token` exposes presentation-only bookkeeping growth independently of clock noise.\n\n");
     out.push_str("| workload | memo nodes count/bytes | structured waits count/bytes | abort fallbacks count/bytes | bytes/token |\n");
     out.push_str("| --- | ---: | ---: | ---: | ---: |\n");
-    for observation in &report.workloads {
+    for observation in reference_observations(report) {
         let identities = observation.work.query_runtime.display_identities;
         let total_bytes = identities
             .memo_node_bytes
@@ -555,7 +618,7 @@ fn render(report: &ScalingReport) -> String {
     out.push_str("| workload | source/parse | program | semantic | CFG/opt | backend | object | linking | mixed | unattributed |\n");
     out.push_str("| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |\n");
     for observation in &report.workloads {
-        out.push_str(&format!("| {}", observation.workload));
+        out.push_str(&format!("| {}", observation_label(observation)));
         for band in Band::all() {
             let summary = summarize(
                 observation
@@ -569,13 +632,27 @@ fn render(report: &ScalingReport) -> String {
     }
 
     out.push_str("\n## Fixture intent\n\n");
-    for observation in &report.workloads {
+    for observation in reference_observations(report) {
         out.push_str(&format!(
             "- `{}` (`{}`): {}\n",
             observation.workload, observation.source, observation.question
         ));
     }
     out
+}
+
+fn reference_observations(report: &ScalingReport) -> impl Iterator<Item = &ScalingObservation> {
+    report
+        .workloads
+        .iter()
+        .filter(|observation| observation.worker_setting == WorkerSetting::One)
+}
+
+fn observation_label(observation: &ScalingObservation) -> String {
+    format!(
+        "{} / {:?}→{}",
+        observation.workload, observation.worker_setting, observation.resolved_workers
+    )
 }
 
 fn summarize(values: impl Iterator<Item = u64>) -> Summary {
@@ -604,6 +681,7 @@ mod tests {
                 unattributed_ns: 20,
                 compiler_root_ns: 100,
             },
+            boundary_evidence: Vec::new(),
         };
         ScalingReport {
             schema_version: SCALING_REPORT_SCHEMA_VERSION,
@@ -632,13 +710,15 @@ mod tests {
                 samples_per_workload: 2,
                 compiler_args: Vec::new(),
                 compiler_build_profile: "release_thin_lto".to_string(),
-                compiler_work_samples_per_workload: 2,
-                compiler_work_args: vec!["--jobs".to_string(), "1".to_string()],
+                boundary: rue_perf_schema::BuildBoundary::FreshSourceToNativeV1,
+                workers: WorkerSetting::REFERENCE_MATRIX.to_vec(),
             },
             workloads: vec![ScalingObservation {
                 workload: "probe".to_string(),
                 source: "probe.rue".to_string(),
                 question: "test".to_string(),
+                worker_setting: WorkerSetting::One,
+                resolved_workers: 1,
                 shape: WorkloadShape {
                     files: 1,
                     modules: 1,
@@ -724,11 +804,12 @@ mod tests {
         let rendered = render(&report());
         assert!(rendered.contains("OS page-cache state is uncontrolled"));
         assert!(rendered.contains("Compiler build profile: `release_thin_lto`"));
-        assert!(rendered.contains("2 single-worker compiler-work probes"));
+        assert!(rendered.contains("one-worker samples must agree exactly"));
         assert!(rendered.contains("compiled programs were not executed"));
         assert!(rendered.contains("median absolute deviation"));
         assert!(rendered.contains("shape id"));
         assert!(rendered.contains("Deterministic query work"));
+        assert!(rendered.contains("Worker scaling and critical path"));
         assert!(rendered.contains("joins declined/total"));
         assert!(rendered.contains("| probe | 41 | 43 | 2/47 | 53 | 59/61 | 67/71 |"));
         assert!(rendered.contains("nodes/token"));

--- a/crates/rue-cli-tests/cases/benchmark_json.toml
+++ b/crates/rue-cli-tests/cases/benchmark_json.toml
@@ -15,7 +15,7 @@ args = ["--benchmark-json", "main.rue", "-o", "prog"]
 env = { RUST_LOG = "error" }
 exit_code = 42
 compile_stdout_contains = [
-  '"schema_version":11',
+  '"schema_version":12',
   '"compiler_build_profile":',
   '"timing_model":"inclusive_spans"',
   # The additive partition, which is the only model that may be stacked. Its

--- a/crates/rue-compiler/src/lib.rs
+++ b/crates/rue-compiler/src/lib.rs
@@ -245,7 +245,7 @@ static QUERY_CONCURRENCY: std::sync::atomic::AtomicUsize = std::sync::atomic::At
 /// Per-function CFG and backend work is deliberately serialized until it is
 /// represented as registered query batches, leaving one canonical concurrency
 /// authority for compiler work.
-pub fn configure_thread_pool(jobs: usize) {
+pub fn configure_thread_pool(jobs: usize) -> usize {
     let jobs = if jobs == 0 {
         std::thread::available_parallelism()
             .map(std::num::NonZeroUsize::get)
@@ -254,6 +254,7 @@ pub fn configure_thread_pool(jobs: usize) {
         jobs
     };
     QUERY_CONCURRENCY.store(jobs, std::sync::atomic::Ordering::Release);
+    jobs
 }
 
 pub(crate) fn query_concurrency() -> usize {

--- a/crates/rue-compiler/src/supported_api_inventory.rs
+++ b/crates/rue-compiler/src/supported_api_inventory.rs
@@ -59,7 +59,7 @@ stable|import_graph|dependency-artifact|source-loaders+embedders|CanonicalImport
 stable|import_graph|dependency-artifact|source-loaders+embedders|CanonicalImportResolution|pub use import_graph::CanonicalImportResolution
 stable|import_graph|dependency-artifact|source-loaders+embedders|ImportDirective|pub use import_graph::ImportDirective
 stable|import_graph|dependency-artifact|source-loaders+embedders|ImportDirectives|pub use import_graph::ImportDirectives
-stable|lib|runtime-config|cli+embedders|configure_thread_pool|pub fn configure_thread_pool(jobs:usize)
+stable|lib|runtime-config|cli+embedders|configure_thread_pool|pub fn configure_thread_pool(jobs:usize)->usize
 stable|queries|compilation-config|cli+embedders|CompileOptions|pub use queries::CompileOptions
 stable|queries|compilation-config|cli+embedders|LinkerMode|pub use queries::LinkerMode
 stable|queries|compile-artifact|cli+embedders|CompileOutput|pub use queries::CompileOutput

--- a/crates/rue-compiler/src/unstable.rs
+++ b/crates/rue-compiler/src/unstable.rs
@@ -1709,10 +1709,24 @@ mod query_validation_metrics_tests {
             },
             retention_enforcements: 1,
             retention_scan_entries: 1,
+            query_worker_active_ns: 1,
+            ready_items: 1,
+            ready_wait_ns: 1,
+            max_ready_wait_ns: 1,
+            longest_query_dependency_chain: 1,
+            peak_query_workers: 1,
+            donated_permits: 1,
         };
         let mut accumulated = unit;
         accumulated.saturating_add_assign(unit);
-        assert_eq!(accumulated.saturating_sub(unit), unit);
+        let mut expected_delta = unit;
+        // High-water marks compose by maximum rather than addition. Repeating
+        // the same maximum therefore contributes no newly observed height to
+        // a cumulative-snapshot delta.
+        expected_delta.max_ready_wait_ns = 0;
+        expected_delta.longest_query_dependency_chain = 0;
+        expected_delta.peak_query_workers = 0;
+        assert_eq!(accumulated.saturating_sub(unit), expected_delta);
     }
 }
 
@@ -1736,6 +1750,14 @@ pub struct QueryRuntimeMetrics {
     pub retention_enforcements: u64,
     /// Retention-queue entries examined by those passes.
     pub retention_scan_entries: u64,
+    /// Aggregated critical-path and worker-scheduling evidence.
+    pub query_worker_active_ns: u64,
+    pub ready_items: u64,
+    pub ready_wait_ns: u64,
+    pub max_ready_wait_ns: u64,
+    pub longest_query_dependency_chain: u64,
+    pub peak_query_workers: u64,
+    pub donated_permits: u64,
 }
 
 impl QueryRuntimeMetrics {
@@ -1767,6 +1789,21 @@ impl QueryRuntimeMetrics {
             retention_scan_entries: self
                 .retention_scan_entries
                 .saturating_sub(earlier.retention_scan_entries),
+            query_worker_active_ns: self
+                .query_worker_active_ns
+                .saturating_sub(earlier.query_worker_active_ns),
+            ready_items: self.ready_items.saturating_sub(earlier.ready_items),
+            ready_wait_ns: self.ready_wait_ns.saturating_sub(earlier.ready_wait_ns),
+            max_ready_wait_ns: self
+                .max_ready_wait_ns
+                .saturating_sub(earlier.max_ready_wait_ns),
+            longest_query_dependency_chain: self
+                .longest_query_dependency_chain
+                .saturating_sub(earlier.longest_query_dependency_chain),
+            peak_query_workers: self
+                .peak_query_workers
+                .saturating_sub(earlier.peak_query_workers),
+            donated_permits: self.donated_permits.saturating_sub(earlier.donated_permits),
         }
     }
 
@@ -1792,6 +1829,17 @@ impl QueryRuntimeMetrics {
         self.retention_scan_entries = self
             .retention_scan_entries
             .saturating_add(other.retention_scan_entries);
+        self.query_worker_active_ns = self
+            .query_worker_active_ns
+            .saturating_add(other.query_worker_active_ns);
+        self.ready_items = self.ready_items.saturating_add(other.ready_items);
+        self.ready_wait_ns = self.ready_wait_ns.saturating_add(other.ready_wait_ns);
+        self.max_ready_wait_ns = self.max_ready_wait_ns.max(other.max_ready_wait_ns);
+        self.longest_query_dependency_chain = self
+            .longest_query_dependency_chain
+            .max(other.longest_query_dependency_chain);
+        self.peak_query_workers = self.peak_query_workers.max(other.peak_query_workers);
+        self.donated_permits = self.donated_permits.saturating_add(other.donated_permits);
     }
 }
 
@@ -1811,6 +1859,13 @@ impl From<rue_query::RuntimeMetrics> for QueryRuntimeMetrics {
             display_identities: runtime.display_identities.into(),
             retention_enforcements: runtime.retention_enforcements,
             retention_scan_entries: runtime.retention_scan_entries,
+            query_worker_active_ns: runtime.query_worker_active_ns,
+            ready_items: runtime.ready_items,
+            ready_wait_ns: runtime.ready_wait_ns,
+            max_ready_wait_ns: runtime.max_ready_wait_ns,
+            longest_query_dependency_chain: runtime.longest_query_dependency_chain,
+            peak_query_workers: runtime.peak_query_workers,
+            donated_permits: runtime.donated_permits,
         }
     }
 }

--- a/crates/rue-perf-schema/src/boundary.rs
+++ b/crates/rue-perf-schema/src/boundary.rs
@@ -1,0 +1,708 @@
+//! Machine-checkable source-to-native build-boundary evidence (ADR-0071).
+//!
+//! The manifest, external runner, and compiler each describe the same
+//! observation independently. A reference sample is admissible only when the
+//! three descriptions agree exactly; new product modes require new exhaustive
+//! enum variants rather than quietly widening this boundary.
+
+use serde::{Deserialize, Serialize};
+
+use crate::CompilerWork;
+
+/// The complete product boundary measured by one compiler process.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum BuildBoundary {
+    /// A clean CLI process reads source and emits one native executable.
+    FreshSourceToNativeV1,
+}
+
+/// The compiler pipeline admitted by the reference boundary.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum CompilerPipeline {
+    /// `CompilerSession`'s canonical rooted query graph and one-shot adapter.
+    CanonicalRootedQueryGraphV1,
+}
+
+/// Rust implementation profile of the compiler binary under measurement.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum CompilerBuildProfile {
+    /// Rue's release platform: optimized Rust with ThinLTO.
+    ReleaseThinLto,
+    /// A development binary. Never admitted by the ADR-0071 reference regime.
+    Debug,
+}
+
+/// Rue optimization contract for the produced program.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum OptimizationLevel {
+    O0,
+    O1,
+    O2,
+    O3,
+}
+
+/// Link implementation used to produce the executable.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum LinkPolicy {
+    /// Rue's built-in linker.
+    Internal,
+    /// An external command selected by the caller.
+    System,
+}
+
+/// Product emitted at the end of the measured invocation.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum OutputKind {
+    NativeExecutable,
+}
+
+/// Worker rows declared by ADR-0071's scaling matrix.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum WorkerSetting {
+    One,
+    Two,
+    Four,
+    Eight,
+    Automatic,
+}
+
+impl WorkerSetting {
+    /// Ordered worker matrix required by ADR-0071's reference scaling report.
+    pub const REFERENCE_MATRIX: [Self; 5] = [
+        Self::One,
+        Self::Two,
+        Self::Four,
+        Self::Eight,
+        Self::Automatic,
+    ];
+
+    /// CLI `--jobs` value represented by this row (`0` means automatic).
+    pub const fn jobs(self) -> usize {
+        match self {
+            Self::One => 1,
+            Self::Two => 2,
+            Self::Four => 4,
+            Self::Eight => 8,
+            Self::Automatic => 0,
+        }
+    }
+
+    /// Classify the explicit CLI value used by the compiler.
+    pub const fn from_jobs(jobs: usize) -> Option<Self> {
+        match jobs {
+            0 => Some(Self::Automatic),
+            1 => Some(Self::One),
+            2 => Some(Self::Two),
+            4 => Some(Self::Four),
+            8 => Some(Self::Eight),
+            _ => None,
+        }
+    }
+}
+
+/// Filesystem input classes admitted by the reference boundary.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum CompilerInputClass {
+    /// Source in the workload's frozen root closure.
+    WorkloadSource,
+    /// Source selected from the configured trusted standard library.
+    TrustedStandardLibrarySource,
+}
+
+/// Compiler-owned data linked without a filesystem read by this invocation.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum EmbeddedAssetClass {
+    /// The target-specific `rue-runtime` archive embedded in the compiler.
+    BundledRuntimeArchive,
+}
+
+/// Successful milestones which must all occur before a v1 observation exists.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum CompilerStage {
+    SourceDiscoveryAndParsing,
+    ProgramConstruction,
+    SemanticAnalysis,
+    CfgAndOptimization,
+    Backend,
+    ObjectGeneration,
+    Linking,
+    OutputPublication,
+}
+
+impl CompilerStage {
+    /// Exact ordered completion sequence for `fresh_source_to_native_v1`.
+    pub const FRESH_SOURCE_TO_NATIVE_V1: [Self; 8] = [
+        Self::SourceDiscoveryAndParsing,
+        Self::ProgramConstruction,
+        Self::SemanticAnalysis,
+        Self::CfgAndOptimization,
+        Self::Backend,
+        Self::ObjectGeneration,
+        Self::Linking,
+        Self::OutputPublication,
+    ];
+}
+
+/// Manifest authority for one measured invocation.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct BuildBoundaryPolicy {
+    pub boundary: BuildBoundary,
+    pub pipeline: CompilerPipeline,
+    pub compiler_build_profile: CompilerBuildProfile,
+    pub optimization: OptimizationLevel,
+    pub linker: LinkPolicy,
+    pub output_kind: OutputKind,
+    pub worker_setting: WorkerSetting,
+    pub allowed_input_classes: Vec<CompilerInputClass>,
+    pub allowed_embedded_asset_classes: Vec<EmbeddedAssetClass>,
+    pub required_stages: Vec<CompilerStage>,
+}
+
+impl BuildBoundaryPolicy {
+    /// The sole policy currently admitted to the ADR-0071 reference series.
+    pub fn fresh_source_to_native_v1(worker_setting: WorkerSetting) -> Self {
+        Self {
+            boundary: BuildBoundary::FreshSourceToNativeV1,
+            pipeline: CompilerPipeline::CanonicalRootedQueryGraphV1,
+            compiler_build_profile: CompilerBuildProfile::ReleaseThinLto,
+            optimization: OptimizationLevel::O3,
+            linker: LinkPolicy::Internal,
+            output_kind: OutputKind::NativeExecutable,
+            worker_setting,
+            allowed_input_classes: vec![
+                CompilerInputClass::WorkloadSource,
+                CompilerInputClass::TrustedStandardLibrarySource,
+            ],
+            allowed_embedded_asset_classes: vec![EmbeddedAssetClass::BundledRuntimeArchive],
+            required_stages: CompilerStage::FRESH_SOURCE_TO_NATIVE_V1.to_vec(),
+        }
+    }
+
+    /// Reject a policy which gives the known variant broader or different
+    /// meaning than its exhaustive schema definition.
+    pub fn validate(&self) -> Result<(), String> {
+        let expected = Self::fresh_source_to_native_v1(self.worker_setting);
+        if self == &expected {
+            Ok(())
+        } else {
+            Err(format!(
+                "fresh_source_to_native_v1 policy differs from its exhaustive contract: expected {expected:?}, found {self:?}"
+            ))
+        }
+    }
+
+    /// Canonical CLI arguments whose independent parse must produce this
+    /// policy. Target and output paths are supplied by dedicated runner fields.
+    pub fn canonical_compiler_args(&self) -> Vec<String> {
+        vec![
+            match self.optimization {
+                OptimizationLevel::O0 => "-O0",
+                OptimizationLevel::O1 => "-O1",
+                OptimizationLevel::O2 => "-O2",
+                OptimizationLevel::O3 => "-O3",
+            }
+            .to_string(),
+            format!("-j{}", self.worker_setting.jobs()),
+        ]
+    }
+}
+
+/// One exact accepted source input reported from the compiler snapshot.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct CompilerInputEvidence {
+    pub class: CompilerInputClass,
+    /// Canonical compiler module identity, independent of checkout location.
+    pub logical_identity: String,
+    /// SHA-256 of the immutable source bytes consumed by the compiler.
+    pub sha256: String,
+}
+
+/// One compiler-embedded input selected by the build.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct EmbeddedAssetEvidence {
+    pub class: EmbeddedAssetClass,
+    /// Stable logical identity. The compiler binary digest owns the bytes.
+    pub logical_identity: String,
+    pub target: String,
+}
+
+/// Product configuration the compiler actually executed.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct CompilerConfigurationEvidence {
+    pub target: String,
+    pub compiler_build_profile: CompilerBuildProfile,
+    pub optimization: OptimizationLevel,
+    pub linker: LinkPolicy,
+    pub output_kind: OutputKind,
+    pub requested_workers: WorkerSetting,
+    pub resolved_workers: u32,
+    /// Empty in the reference regime; explicit so a preview cannot enter
+    /// without changing the evidence.
+    pub preview_features: Vec<String>,
+    /// Zero in the reference regime; external archives are undeclared inputs.
+    pub external_link_archives: u32,
+}
+
+/// Artifact sources excluded from the fresh v1 boundary.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ArtifactHitEvidence {
+    pub retained_session_inputs: u64,
+    pub daemon_handoffs: u64,
+    pub persistent_cache_hits: u64,
+    pub precompiled_program_hits: u64,
+    pub precompiled_package_hits: u64,
+    pub precompiled_standard_artifact_hits: u64,
+}
+
+impl ArtifactHitEvidence {
+    pub const fn is_zero(self) -> bool {
+        self.retained_session_inputs == 0
+            && self.daemon_handoffs == 0
+            && self.persistent_cache_hits == 0
+            && self.precompiled_program_hits == 0
+            && self.precompiled_package_hits == 0
+            && self.precompiled_standard_artifact_hits == 0
+    }
+}
+
+/// Compiler authority emitted only after successful output publication.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct CompilerBoundaryEvidence {
+    pub boundary: BuildBoundary,
+    pub pipeline: CompilerPipeline,
+    pub session_count: u32,
+    pub root_request_count: u32,
+    pub configuration: CompilerConfigurationEvidence,
+    pub completed_stages: Vec<CompilerStage>,
+    pub accepted_inputs: Vec<CompilerInputEvidence>,
+    pub embedded_assets: Vec<EmbeddedAssetEvidence>,
+    pub artifact_hits: ArtifactHitEvidence,
+    pub emitted_output_sha256: String,
+    pub emitted_output_size_bytes: u64,
+}
+
+/// External clock semantics used by the runner.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum RunnerClockBoundary {
+    /// Starts immediately before spawn; ends after exit and output verification.
+    MonotonicPreSpawnThroughExitAndOutputVerification,
+}
+
+/// Independent process facts established by the external runner.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct RunnerBoundaryEvidence {
+    pub compiler_binary_sha256: String,
+    pub fresh_state_directory: bool,
+    pub fresh_output_directory: bool,
+    pub daemon_endpoint_supplied: bool,
+    pub retained_session_handle_supplied: bool,
+    pub clock_boundary: RunnerClockBoundary,
+    pub successful_exit: bool,
+    pub native_output_verified: bool,
+    pub output_sha256: String,
+    pub output_size_bytes: u64,
+}
+
+/// A bounded log2 histogram of durations in nanoseconds.
+///
+/// Producers update thread-local buckets and merge them only at bounded worker
+/// completion. The 64 buckets cover every `u64` duration without retaining one
+/// record per body.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct DurationDistribution {
+    pub count: u64,
+    pub total_ns: u64,
+    pub max_ns: u64,
+    pub log2_buckets: Vec<u64>,
+}
+
+impl Default for DurationDistribution {
+    fn default() -> Self {
+        Self {
+            count: 0,
+            total_ns: 0,
+            max_ns: 0,
+            log2_buckets: vec![0; 64],
+        }
+    }
+}
+
+impl DurationDistribution {
+    pub fn validate(&self) -> bool {
+        self.log2_buckets.len() == 64
+            && self
+                .log2_buckets
+                .iter()
+                .copied()
+                .fold(0_u64, u64::saturating_add)
+                == self.count
+            && (self.count != 0 || (self.total_ns == 0 && self.max_ns == 0))
+            && self.max_ns <= self.total_ns
+    }
+}
+
+/// Bounded compiler-side evidence explaining a worker-scaling observation.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct CompilerCriticalPathEvidence {
+    /// Active execution-permit time, summed across independent query workers.
+    pub query_worker_active_ns: u64,
+    /// Dependency-ready registered batch items observed by workers.
+    pub ready_items: u64,
+    pub ready_wait_ns: u64,
+    pub max_ready_wait_ns: u64,
+    /// Longest nested query/batch ancestry in number of producer nodes.
+    pub longest_query_dependency_chain: u64,
+    pub peak_query_workers: u64,
+    /// Inclusive duration of reached-toolchain acquisition inside compiler root.
+    pub toolchain_acquisition_ns: u64,
+    pub semantic_bodies: DurationDistribution,
+    pub cfg_construction_bodies: DurationDistribution,
+    pub cfg_optimization_bodies: DurationDistribution,
+    /// Contention evidence the runtime can support exactly.
+    pub joins: u64,
+    pub declined_joins: u64,
+    pub donated_permits: u64,
+}
+
+/// Complete evidence attached to one fresh compiler process.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct BuildBoundaryEvidence {
+    pub runner: RunnerBoundaryEvidence,
+    pub compiler: CompilerBoundaryEvidence,
+    pub critical_path: CompilerCriticalPathEvidence,
+    /// Deterministic work for this exact compiler process.
+    pub compiler_work: CompilerWork,
+}
+
+impl BuildBoundaryEvidence {
+    /// Cross-check runner and compiler facts against the independently declared
+    /// manifest policy. Returns the first disagreement so a producer can reject
+    /// the process before its sample reaches storage.
+    pub fn validate_against(
+        &self,
+        policy: &BuildBoundaryPolicy,
+        target: &str,
+    ) -> Result<(), String> {
+        policy.validate()?;
+        let runner = &self.runner;
+        if !is_sha256(&runner.compiler_binary_sha256) {
+            return Err("runner reported an invalid compiler binary SHA-256".to_string());
+        }
+        if !runner.fresh_state_directory || !runner.fresh_output_directory {
+            return Err("runner did not create fresh state and output directories".to_string());
+        }
+        if runner.daemon_endpoint_supplied || runner.retained_session_handle_supplied {
+            return Err("runner supplied a daemon or retained-session handle".to_string());
+        }
+        if runner.clock_boundary
+            != RunnerClockBoundary::MonotonicPreSpawnThroughExitAndOutputVerification
+        {
+            return Err("runner used an unsupported clock boundary".to_string());
+        }
+        if !runner.successful_exit || !runner.native_output_verified {
+            return Err(
+                "compiler did not exit successfully with verified native output".to_string(),
+            );
+        }
+        if !is_sha256(&runner.output_sha256) {
+            return Err("runner reported an invalid output SHA-256".to_string());
+        }
+        if runner.output_size_bytes == 0 {
+            return Err("runner reported an empty output".to_string());
+        }
+
+        let compiler = &self.compiler;
+        if compiler.boundary != policy.boundary || compiler.pipeline != policy.pipeline {
+            return Err("compiler boundary or pipeline identity disagrees with policy".to_string());
+        }
+        if compiler.session_count != 1 || compiler.root_request_count != 1 {
+            return Err(format!(
+                "compiler reported {} sessions and {} root requests",
+                compiler.session_count, compiler.root_request_count
+            ));
+        }
+        let configuration = &compiler.configuration;
+        if configuration.target != target
+            || configuration.compiler_build_profile != policy.compiler_build_profile
+            || configuration.optimization != policy.optimization
+            || configuration.linker != policy.linker
+            || configuration.output_kind != policy.output_kind
+            || configuration.requested_workers != policy.worker_setting
+        {
+            return Err(format!(
+                "compiler configuration {configuration:?} disagrees with target {target:?} and policy {policy:?}"
+            ));
+        }
+        let resolved_expected = match policy.worker_setting {
+            WorkerSetting::One => Some(1),
+            WorkerSetting::Two => Some(2),
+            WorkerSetting::Four => Some(4),
+            WorkerSetting::Eight => Some(8),
+            WorkerSetting::Automatic => None,
+        };
+        if configuration.resolved_workers == 0
+            || resolved_expected.is_some_and(|expected| configuration.resolved_workers != expected)
+        {
+            return Err(format!(
+                "worker setting {:?} resolved to {}",
+                policy.worker_setting, configuration.resolved_workers
+            ));
+        }
+        if !configuration.preview_features.is_empty() || configuration.external_link_archives != 0 {
+            return Err(
+                "preview features or external link archives entered the reference build"
+                    .to_string(),
+            );
+        }
+        if compiler.completed_stages != policy.required_stages {
+            return Err("compiler completion stages disagree with policy".to_string());
+        }
+        if !compiler.artifact_hits.is_zero() {
+            return Err(format!(
+                "excluded retained/daemon/cache/precompiled artifacts were used: {:?}",
+                compiler.artifact_hits
+            ));
+        }
+        if !is_sha256(&compiler.emitted_output_sha256)
+            || compiler.emitted_output_sha256 != runner.output_sha256
+            || compiler.emitted_output_size_bytes != runner.output_size_bytes
+        {
+            return Err("compiler and runner output evidence disagrees".to_string());
+        }
+
+        let mut previous_input: Option<(&CompilerInputClass, &str)> = None;
+        let mut saw_workload = false;
+        for input in &compiler.accepted_inputs {
+            if !policy.allowed_input_classes.contains(&input.class) {
+                return Err(format!(
+                    "compiler reported disallowed input class {:?}",
+                    input.class
+                ));
+            }
+            if input.logical_identity.is_empty() || !is_sha256(&input.sha256) {
+                return Err("compiler reported malformed input provenance".to_string());
+            }
+            let identity = (&input.class, input.logical_identity.as_str());
+            if previous_input.is_some_and(|previous| previous >= identity) {
+                return Err(
+                    "compiler input provenance is duplicated or not canonically sorted".to_string(),
+                );
+            }
+            previous_input = Some(identity);
+            saw_workload |= input.class == CompilerInputClass::WorkloadSource;
+        }
+        if !saw_workload {
+            return Err("compiler reported no workload source input".to_string());
+        }
+
+        if compiler.embedded_assets.len() != policy.allowed_embedded_asset_classes.len() {
+            return Err("compiler embedded-asset count disagrees with policy".to_string());
+        }
+        for (asset, expected_class) in compiler
+            .embedded_assets
+            .iter()
+            .zip(&policy.allowed_embedded_asset_classes)
+        {
+            if &asset.class != expected_class
+                || asset.logical_identity.is_empty()
+                || asset.target != target
+            {
+                return Err(format!(
+                    "compiler reported invalid embedded asset {asset:?}"
+                ));
+            }
+        }
+
+        let critical = &self.critical_path;
+        if !critical.semantic_bodies.validate()
+            || !critical.cfg_construction_bodies.validate()
+            || !critical.cfg_optimization_bodies.validate()
+        {
+            return Err("compiler reported an invalid bounded duration distribution".to_string());
+        }
+        if critical.query_worker_active_ns == 0
+            || critical.longest_query_dependency_chain == 0
+            || critical.semantic_bodies.count == 0
+            || critical.cfg_construction_bodies.count == 0
+            || critical.cfg_optimization_bodies.count == 0
+        {
+            return Err("compiler omitted required critical-path evidence".to_string());
+        }
+        if critical.ready_items == 0 {
+            if critical.ready_wait_ns != 0 || critical.max_ready_wait_ns != 0 {
+                return Err("ready-wait duration exists without ready items".to_string());
+            }
+        } else if critical.max_ready_wait_ns > critical.ready_wait_ns {
+            return Err("maximum ready wait exceeds total ready wait".to_string());
+        }
+        if critical.peak_query_workers == 0
+            || critical.peak_query_workers > u64::from(configuration.resolved_workers)
+        {
+            return Err("peak query workers is outside the resolved worker budget".to_string());
+        }
+        Ok(())
+    }
+}
+
+fn is_sha256(value: &str) -> bool {
+    value.len() == 64 && value.bytes().all(|byte| byte.is_ascii_hexdigit())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn distribution() -> DurationDistribution {
+        let mut log2_buckets = vec![0; 64];
+        log2_buckets[6] = 1;
+        DurationDistribution {
+            count: 1,
+            total_ns: 100,
+            max_ns: 100,
+            log2_buckets,
+        }
+    }
+
+    fn evidence() -> BuildBoundaryEvidence {
+        let output_sha256 = "a".repeat(64);
+        BuildBoundaryEvidence {
+            runner: RunnerBoundaryEvidence {
+                compiler_binary_sha256: "b".repeat(64),
+                fresh_state_directory: true,
+                fresh_output_directory: true,
+                daemon_endpoint_supplied: false,
+                retained_session_handle_supplied: false,
+                clock_boundary:
+                    RunnerClockBoundary::MonotonicPreSpawnThroughExitAndOutputVerification,
+                successful_exit: true,
+                native_output_verified: true,
+                output_sha256: output_sha256.clone(),
+                output_size_bytes: 4096,
+            },
+            compiler: CompilerBoundaryEvidence {
+                boundary: BuildBoundary::FreshSourceToNativeV1,
+                pipeline: CompilerPipeline::CanonicalRootedQueryGraphV1,
+                session_count: 1,
+                root_request_count: 1,
+                configuration: CompilerConfigurationEvidence {
+                    target: "x86-64-linux".to_string(),
+                    compiler_build_profile: CompilerBuildProfile::ReleaseThinLto,
+                    optimization: OptimizationLevel::O3,
+                    linker: LinkPolicy::Internal,
+                    output_kind: OutputKind::NativeExecutable,
+                    requested_workers: WorkerSetting::One,
+                    resolved_workers: 1,
+                    preview_features: Vec::new(),
+                    external_link_archives: 0,
+                },
+                completed_stages: CompilerStage::FRESH_SOURCE_TO_NATIVE_V1.to_vec(),
+                accepted_inputs: vec![CompilerInputEvidence {
+                    class: CompilerInputClass::WorkloadSource,
+                    logical_identity: "main.rue".to_string(),
+                    sha256: "c".repeat(64),
+                }],
+                embedded_assets: vec![EmbeddedAssetEvidence {
+                    class: EmbeddedAssetClass::BundledRuntimeArchive,
+                    logical_identity: "rue-runtime".to_string(),
+                    target: "x86-64-linux".to_string(),
+                }],
+                artifact_hits: ArtifactHitEvidence::default(),
+                emitted_output_sha256: output_sha256,
+                emitted_output_size_bytes: 4096,
+            },
+            critical_path: CompilerCriticalPathEvidence {
+                query_worker_active_ns: 1,
+                ready_items: 1,
+                ready_wait_ns: 1,
+                max_ready_wait_ns: 1,
+                longest_query_dependency_chain: 1,
+                peak_query_workers: 1,
+                toolchain_acquisition_ns: 1,
+                semantic_bodies: distribution(),
+                cfg_construction_bodies: distribution(),
+                cfg_optimization_bodies: distribution(),
+                joins: 0,
+                declined_joins: 0,
+                donated_permits: 0,
+            },
+            compiler_work: CompilerWork::default(),
+        }
+    }
+
+    #[test]
+    fn reference_policy_has_one_exhaustive_canonical_spelling() {
+        let policy = BuildBoundaryPolicy::fresh_source_to_native_v1(WorkerSetting::One);
+        assert_eq!(
+            policy.canonical_compiler_args(),
+            ["-O3".to_string(), "-j1".to_string()]
+        );
+        policy.validate().unwrap();
+
+        let mut widened = policy;
+        widened
+            .allowed_input_classes
+            .push(CompilerInputClass::WorkloadSource);
+        assert!(widened.validate().is_err());
+        assert_eq!(WorkerSetting::REFERENCE_MATRIX.len(), 5);
+    }
+
+    #[test]
+    fn complete_runner_compiler_and_manifest_evidence_agrees() {
+        evidence()
+            .validate_against(
+                &BuildBoundaryPolicy::fresh_source_to_native_v1(WorkerSetting::One),
+                "x86-64-linux",
+            )
+            .unwrap();
+    }
+
+    #[test]
+    fn mismatched_output_artifacts_and_hidden_cache_hits_fail_closed() {
+        let policy = BuildBoundaryPolicy::fresh_source_to_native_v1(WorkerSetting::One);
+        let mut wrong_size = evidence();
+        wrong_size.runner.output_size_bytes += 1;
+        assert!(
+            wrong_size
+                .validate_against(&policy, "x86-64-linux")
+                .is_err()
+        );
+
+        let mut cache_hit = evidence();
+        cache_hit.compiler.artifact_hits.persistent_cache_hits = 1;
+        assert!(cache_hit.validate_against(&policy, "x86-64-linux").is_err());
+
+        let mut missing_histogram = evidence();
+        missing_histogram.critical_path.semantic_bodies = DurationDistribution::default();
+        assert!(
+            missing_histogram
+                .validate_against(&policy, "x86-64-linux")
+                .is_err()
+        );
+    }
+
+    #[test]
+    fn unknown_boundary_variants_are_not_deserialized() {
+        assert!(serde_json::from_str::<BuildBoundary>("\"future_cached_boundary\"").is_err());
+    }
+}

--- a/crates/rue-perf-schema/src/lib.rs
+++ b/crates/rue-perf-schema/src/lib.rs
@@ -31,6 +31,7 @@
 //! disk. [`ValidationOutcome`] reports both, plus the run's
 //! [`Completeness`].
 
+mod boundary;
 mod canonical;
 mod incremental;
 mod manifest;
@@ -40,6 +41,13 @@ mod series;
 mod stats;
 mod validate;
 
+pub use boundary::{
+    ArtifactHitEvidence, BuildBoundary, BuildBoundaryEvidence, BuildBoundaryPolicy,
+    CompilerBoundaryEvidence, CompilerBuildProfile, CompilerConfigurationEvidence,
+    CompilerCriticalPathEvidence, CompilerInputClass, CompilerInputEvidence, CompilerPipeline,
+    CompilerStage, DurationDistribution, EmbeddedAssetClass, EmbeddedAssetEvidence, LinkPolicy,
+    OptimizationLevel, OutputKind, RunnerBoundaryEvidence, RunnerClockBoundary, WorkerSetting,
+};
 pub use canonical::{CanonicalError, canonical_json, content_address};
 pub use incremental::{
     DisplayIdentityWorkSummary, EDIT_REPORT_SCHEMA_VERSION, EditEndpoints, EditManifest,

--- a/crates/rue-perf-schema/src/manifest.rs
+++ b/crates/rue-perf-schema/src/manifest.rs
@@ -14,6 +14,7 @@ use std::collections::BTreeMap;
 
 use serde::Deserialize;
 
+use crate::boundary::{BuildBoundary, BuildBoundaryPolicy};
 use crate::run::EnvironmentFingerprint;
 
 /// One workload in the suite.
@@ -48,6 +49,10 @@ pub struct SuiteRevision {
     pub timing_schema_version: u32,
     /// The runner protocol version this revision's run objects conform to.
     pub protocol_version: u32,
+    /// Exhaustive product boundary required by this protocol revision.
+    /// Historical protocol-v1 suites predate machine-checkable evidence.
+    #[serde(default)]
+    pub boundary: Option<BuildBoundary>,
     /// The suite's workloads.
     pub workloads: Vec<Workload>,
 }
@@ -179,6 +184,9 @@ pub struct PlatformEpoch {
     pub target: String,
     /// Every behavior-affecting compiler argument, in order.
     pub args: Vec<String>,
+    /// Complete intended policy for protocol-v2 samples.
+    #[serde(default)]
+    pub boundary: Option<BuildBoundaryPolicy>,
     /// Content hash of the Rust toolchain the compiler is built with.
     ///
     /// Build environment, not product: changing it changes generated code and
@@ -328,6 +336,12 @@ pub enum ManifestError {
         /// The epoch that also claims it.
         second: u32,
     },
+    /// Suite protocol, epoch policy, and canonical invocation disagree.
+    BoundaryContract {
+        platform: String,
+        epoch: u32,
+        detail: String,
+    },
 }
 
 impl std::fmt::Display for ManifestError {
@@ -401,7 +415,15 @@ impl std::fmt::Display for ManifestError {
             } => write!(
                 f,
                 "platform {platform} marks epochs {first} and {second} for collection; \
-                 exactly one epoch per platform may be collected"
+                exactly one epoch per platform may be collected"
+            ),
+            ManifestError::BoundaryContract {
+                platform,
+                epoch,
+                detail,
+            } => write!(
+                f,
+                "epoch {epoch} on {platform} violates its build-boundary contract: {detail}"
             ),
         }
     }
@@ -503,6 +525,39 @@ impl Manifest {
                     revision: epoch.suite_revision,
                 });
             };
+
+            match (suite.protocol_version, suite.boundary, &epoch.boundary) {
+                (1, None, None) => {}
+                (2, Some(boundary), Some(policy)) if boundary == policy.boundary => {
+                    policy
+                        .validate()
+                        .map_err(|detail| ManifestError::BoundaryContract {
+                            platform: epoch.platform.clone(),
+                            epoch: epoch.id,
+                            detail,
+                        })?;
+                    let expected_args = policy.canonical_compiler_args();
+                    if epoch.args != expected_args {
+                        return Err(ManifestError::BoundaryContract {
+                            platform: epoch.platform.clone(),
+                            epoch: epoch.id,
+                            detail: format!(
+                                "arguments {:?} do not match canonical boundary arguments {:?}",
+                                epoch.args, expected_args
+                            ),
+                        });
+                    }
+                }
+                (protocol, suite_boundary, epoch_boundary) => {
+                    return Err(ManifestError::BoundaryContract {
+                        platform: epoch.platform.clone(),
+                        epoch: epoch.id,
+                        detail: format!(
+                            "protocol {protocol} declares suite boundary {suite_boundary:?} and epoch policy {epoch_boundary:?}"
+                        ),
+                    });
+                }
+            }
 
             let declared = suite.workload_ids();
             check_coverage(

--- a/crates/rue-perf-schema/src/run.rs
+++ b/crates/rue-perf-schema/src/run.rs
@@ -9,7 +9,7 @@ use std::collections::BTreeMap;
 
 use serde::{Deserialize, Serialize};
 
-use crate::RUN_SCHEMA_VERSION;
+use crate::{BuildBoundaryEvidence, RUN_SCHEMA_VERSION};
 
 /// A published wall-clock phase.
 ///
@@ -230,6 +230,12 @@ pub struct Sample {
     pub output_binary_bytes: u64,
     /// The compiler's own wall-clock partition for this sample.
     pub phases: PhaseAccounting,
+    /// One independent runner/compiler proof for each process in this sample.
+    ///
+    /// Empty only for historical protocol-v1 suites. Protocol v2 requires
+    /// exactly `batch_size` entries and validates each one against its epoch.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub boundary_evidence: Vec<BuildBoundaryEvidence>,
 }
 
 impl Sample {
@@ -595,6 +601,7 @@ mod tests {
             peak_memory_bytes: 1,
             output_binary_bytes: 1,
             phases: accounting(100, 100, 0, 0),
+            boundary_evidence: Vec::new(),
         };
         assert_eq!(sample.driver_overhead_ns(), Some(50));
     }
@@ -607,6 +614,7 @@ mod tests {
             peak_memory_bytes: 1,
             output_binary_bytes: 1,
             phases: accounting(100, 100, 0, 0),
+            boundary_evidence: Vec::new(),
         };
         assert_eq!(sample.driver_overhead_ns(), None);
     }

--- a/crates/rue-perf-schema/src/scaling.rs
+++ b/crates/rue-perf-schema/src/scaling.rs
@@ -9,10 +9,13 @@ use std::collections::BTreeSet;
 
 use serde::{Deserialize, Serialize};
 
-use crate::{DisplayIdentityWork, EnvironmentFingerprint, Sample, ValidationWork};
+use crate::{
+    BuildBoundary, DisplayIdentityWork, EnvironmentFingerprint, Sample, ValidationWork,
+    WorkerSetting,
+};
 
 /// Version of the scaling-report wire format.
-pub const SCALING_REPORT_SCHEMA_VERSION: u32 = 11;
+pub const SCALING_REPORT_SCHEMA_VERSION: u32 = 12;
 
 /// The lower-frequency scaling suite declaration.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -29,6 +32,12 @@ pub struct ScalingManifest {
     pub args: Vec<String>,
     /// Required Rust build profile of the compiler binary under measurement.
     pub compiler_build_profile: String,
+    /// Complete product boundary every row must prove.
+    pub boundary: BuildBoundary,
+    /// Independently declared compiler target.
+    pub target: String,
+    /// Ordered worker matrix measured for every workload.
+    pub workers: Vec<WorkerSetting>,
     /// Maintained programs, in report order.
     pub workloads: Vec<ScalingWorkload>,
 }
@@ -38,7 +47,7 @@ impl ScalingManifest {
     pub fn parse(text: &str) -> Result<Self, String> {
         let manifest: ScalingManifest =
             toml::from_str(text).map_err(|error| format!("invalid scaling manifest: {error}"))?;
-        if manifest.schema_version != 2 {
+        if manifest.schema_version != 3 {
             return Err(format!(
                 "unsupported scaling manifest schema version {}",
                 manifest.schema_version
@@ -49,6 +58,23 @@ impl ScalingManifest {
         }
         if manifest.compiler_build_profile.is_empty() {
             return Err("the scaling manifest declares no compiler build profile".to_string());
+        }
+        if manifest.boundary != BuildBoundary::FreshSourceToNativeV1 {
+            return Err("the scaling manifest declares an unsupported build boundary".to_string());
+        }
+        if manifest.target.is_empty() {
+            return Err("the scaling manifest declares no compiler target".to_string());
+        }
+        if manifest.workers != WorkerSetting::REFERENCE_MATRIX {
+            return Err(format!(
+                "the scaling manifest must declare the ADR-0071 worker matrix {:?}",
+                WorkerSetting::REFERENCE_MATRIX
+            ));
+        }
+        if !manifest.args.is_empty() {
+            return Err(
+                "fresh_source_to_native_v1 scaling admits no extra compiler arguments".to_string(),
+            );
         }
         if manifest.workloads.is_empty() {
             return Err("the scaling manifest declares no workloads".to_string());
@@ -132,11 +158,10 @@ pub struct ScalingRegime {
     pub compiler_args: Vec<String>,
     /// Rust build profile reported by the compiler binary.
     pub compiler_build_profile: String,
-    /// Independent structural-work probes per workload.
-    pub compiler_work_samples_per_workload: u32,
-    /// Arguments used by structural-work probes. These include a fixed
-    /// single-worker setting so scheduling cannot perturb exact counters.
-    pub compiler_work_args: Vec<String>,
+    /// Complete boundary jointly proved by manifest, runner, and compiler.
+    pub boundary: BuildBoundary,
+    /// Ordered worker matrix measured for every workload.
+    pub workers: Vec<WorkerSetting>,
 }
 
 /// Raw measurements for one maintained program.
@@ -149,6 +174,11 @@ pub struct ScalingObservation {
     pub source: String,
     /// Why this fixture participates in the scale curve.
     pub question: String,
+    /// Manifest row represented by this observation.
+    pub worker_setting: WorkerSetting,
+    /// Actual worker count selected by the compiler (`automatic` is resolved
+    /// from the host rather than assumed by the runner).
+    pub resolved_workers: u32,
     /// Compiler-produced fixture shape. A change makes cross-report comparison
     /// advisory even when the manifest revision was not yet advanced.
     pub shape: WorkloadShape,
@@ -321,10 +351,13 @@ mod tests {
     use super::*;
 
     const VALID: &str = r#"
-schema_version = 2
-revision = 2
+schema_version = 3
+revision = 3
 samples = 3
 compiler_build_profile = "release_thin_lto"
+boundary = "fresh_source_to_native_v1"
+target = "x86-64-linux"
+workers = ["one", "two", "four", "eight", "automatic"]
 
 [[workloads]]
 id = "ruelex"
@@ -335,9 +368,10 @@ question = "small maintained compiler frontend"
     #[test]
     fn parses_a_versioned_scaling_manifest() {
         let manifest = ScalingManifest::parse(VALID).unwrap();
-        assert_eq!(manifest.revision, 2);
+        assert_eq!(manifest.revision, 3);
         assert_eq!(manifest.samples, 3);
         assert_eq!(manifest.compiler_build_profile, "release_thin_lto");
+        assert_eq!(manifest.workers, WorkerSetting::REFERENCE_MATRIX);
         assert_eq!(manifest.workloads[0].id, "ruelex");
     }
 

--- a/crates/rue-perf-schema/src/stats.rs
+++ b/crates/rue-perf-schema/src/stats.rs
@@ -375,6 +375,7 @@ mod tests {
                 unattributed_ns: 0,
                 compiler_root_ns: 40_000,
             },
+            boundary_evidence: Vec::new(),
         };
         // Latency divides by the batch; the other metrics are per-compilation
         // properties already and must not be.

--- a/crates/rue-perf-schema/src/validate.rs
+++ b/crates/rue-perf-schema/src/validate.rs
@@ -149,6 +149,12 @@ pub enum ValidationError {
         /// The value found.
         value: String,
     },
+    /// Protocol-v2 process evidence is absent or disagrees with its epoch.
+    BoundaryEvidenceMismatch {
+        workload: String,
+        sample_index: u32,
+        detail: String,
+    },
 }
 
 impl std::fmt::Display for ValidationError {
@@ -241,6 +247,14 @@ impl std::fmt::Display for ValidationError {
             ValidationError::MalformedCommit { value } => {
                 write!(f, "commit {value:?} is not a 40-character hexadecimal hash")
             }
+            ValidationError::BoundaryEvidenceMismatch {
+                workload,
+                sample_index,
+                detail,
+            } => write!(
+                f,
+                "workload {workload:?} sample {sample_index} has invalid build-boundary evidence: {detail}"
+            ),
         }
     }
 }
@@ -440,6 +454,7 @@ pub fn validate_run(manifest: &Manifest, run: &RunObject) -> ValidationOutcome {
     check_pins(run, epoch, &mut errors);
     check_environment(run, epoch, &mut errors);
     check_membership(run, suite, &mut errors);
+    check_boundary_evidence(run, suite, epoch, &mut errors);
 
     let invalid_samples = collect_invalid_samples(run, epoch, &mut errors);
     check_failure_records(run, suite, &invalid_samples, &mut errors);
@@ -450,6 +465,99 @@ pub fn validate_run(manifest: &Manifest, run: &RunObject) -> ValidationOutcome {
         errors,
         invalid_samples,
         completeness,
+    }
+}
+
+fn check_boundary_evidence(
+    run: &RunObject,
+    suite: &crate::manifest::SuiteRevision,
+    epoch: &crate::manifest::PlatformEpoch,
+    errors: &mut Vec<ValidationError>,
+) {
+    for observation in &run.workloads {
+        let mut expected_output = None;
+        let mut expected_work = None;
+        for (sample_index, sample) in observation.samples.iter().enumerate() {
+            let mut detail = match (suite.protocol_version, &epoch.boundary) {
+                (1, None) if sample.boundary_evidence.is_empty() => None,
+                (1, None) => {
+                    Some("historical protocol v1 must not carry boundary-v2 evidence".to_string())
+                }
+                (2, Some(policy))
+                    if sample.boundary_evidence.len() == sample.batch_size as usize =>
+                {
+                    sample
+                        .boundary_evidence
+                        .iter()
+                        .enumerate()
+                        .find_map(|(process, evidence)| {
+                            if evidence.runner.output_size_bytes != sample.output_binary_bytes {
+                                return Some(format!(
+                                    "process {process}: proof output size {} disagrees with sample size {}",
+                                    evidence.runner.output_size_bytes,
+                                    sample.output_binary_bytes
+                                ));
+                            }
+                            evidence
+                                .validate_against(policy, &epoch.target)
+                                .err()
+                                .map(|detail| format!("process {process}: {detail}"))
+                        })
+                }
+                (2, Some(_)) => Some(format!(
+                    "expected {} process proofs, found {}",
+                    sample.batch_size,
+                    sample.boundary_evidence.len()
+                )),
+                (protocol, boundary) => Some(format!(
+                    "unsupported protocol/boundary pairing: protocol {protocol}, policy {boundary:?}"
+                )),
+            };
+            if detail.is_none() && suite.protocol_version == 2 {
+                for evidence in &sample.boundary_evidence {
+                    match &expected_output {
+                        None => expected_output = Some(evidence.runner.output_sha256.clone()),
+                        Some(expected) if expected == &evidence.runner.output_sha256 => {}
+                        Some(_) => {
+                            detail = Some(
+                                "fresh processes produced nondeterministic native output"
+                                    .to_string(),
+                            );
+                            break;
+                        }
+                    }
+                    // At one worker the complete work record is deterministic
+                    // and protects the architecture row from silent
+                    // amplification. Parallel rows deliberately include
+                    // schedule-dependent joins, reuses, and validation paths;
+                    // those are distribution evidence, not output identity.
+                    if epoch
+                        .boundary
+                        .as_ref()
+                        .is_some_and(|policy| policy.worker_setting == crate::WorkerSetting::One)
+                    {
+                        match expected_work {
+                            None => expected_work = Some(evidence.compiler_work),
+                            Some(expected) if expected == evidence.compiler_work => {}
+                            Some(_) => {
+                                detail = Some(
+                                    "one-worker fresh processes reported nondeterministic compiler work"
+                                        .to_string(),
+                                );
+                                break;
+                            }
+                        }
+                    }
+                }
+            }
+            if let Some(detail) = detail {
+                errors.push(ValidationError::BoundaryEvidenceMismatch {
+                    workload: observation.workload.clone(),
+                    sample_index: sample_index as u32,
+                    detail,
+                });
+            }
+        }
     }
 }
 
@@ -831,6 +939,7 @@ window = 10
             peak_memory_bytes: 64 * 1024 * 1024,
             output_binary_bytes: 131_072,
             phases: accounting(root_ns),
+            boundary_evidence: Vec::new(),
         }
     }
 

--- a/crates/rue-query/src/lib.rs
+++ b/crates/rue-query/src/lib.rs
@@ -13,6 +13,7 @@ use std::panic::{AssertUnwindSafe, catch_unwind, resume_unwind};
 use std::rc::Rc;
 use std::sync::atomic::{AtomicBool, AtomicU64, AtomicUsize, Ordering};
 use std::sync::{Arc, Condvar, Mutex, MutexGuard, RwLock, RwLockReadGuard, RwLockWriteGuard, Weak};
+use std::time::Instant;
 
 use ahash::{AHashMap, AHashSet, RandomState};
 use smallvec::SmallVec;
@@ -23,6 +24,10 @@ const VALIDATION_PROOF_REGISTERED: u8 = 0;
 const VALIDATION_PROOF_RETRYABLE: u8 = 1;
 const VALIDATION_PROOF_UNREGISTERED: u8 = 2;
 const VALIDATION_PUBLISH_SWEEP_QUANTUM: usize = 64;
+
+fn duration_ns(duration: std::time::Duration) -> u64 {
+    u64::try_from(duration.as_nanos()).unwrap_or(u64::MAX)
+}
 
 type ValidationProofStack = SmallVec<[u8; 8]>;
 
@@ -3383,6 +3388,9 @@ pub struct RuntimeMetrics {
     pub retention_scan_entries: u64,
     /// Peak simultaneously executing query bodies.
     pub peak_active_bodies: u64,
+    /// Peak tasks simultaneously owning execution permits. Nested query bodies
+    /// on one task count once, so this is the worker-utilization concurrency.
+    pub peak_query_workers: u64,
     /// Terminals currently protected by rooted-request observation leases.
     pub active_task_leases: u64,
     /// Peak terminals simultaneously protected by rooted-request observation
@@ -3395,6 +3403,15 @@ pub struct RuntimeMetrics {
     pub peak_retained_pins: u64,
     /// Times a parked joiner released its permit.
     pub donated_permits: u64,
+    /// Nanoseconds tasks held an execution permit, summed across tasks.
+    pub query_worker_active_ns: u64,
+    /// Registered batch items observed in the ready queue.
+    pub ready_items: u64,
+    /// Sum and maximum of ready-to-start delay for registered batch items.
+    pub ready_wait_ns: u64,
+    pub max_ready_wait_ns: u64,
+    /// Longest nested query/batch ancestry observed by a task.
+    pub longest_query_dependency_chain: u64,
     /// Immutable revision views currently retained by the runtime.
     pub retained_revisions: u64,
     /// Configured immutable-revision view bound.
@@ -3450,11 +3467,18 @@ struct Metrics {
     retention_scan_entries: AtomicU64,
     active_bodies: AtomicU64,
     peak_active_bodies: AtomicU64,
+    active_query_workers: AtomicU64,
+    peak_query_workers: AtomicU64,
     active_task_leases: AtomicU64,
     peak_task_leases: AtomicU64,
     active_retained_pins: AtomicU64,
     peak_retained_pins: AtomicU64,
     donated_permits: AtomicU64,
+    query_worker_active_ns: AtomicU64,
+    ready_items: AtomicU64,
+    ready_wait_ns: AtomicU64,
+    max_ready_wait_ns: AtomicU64,
+    longest_query_dependency_chain: AtomicU64,
 }
 
 impl Metrics {
@@ -3535,11 +3559,19 @@ impl Metrics {
             retention_enforcements: self.retention_enforcements.load(Ordering::Relaxed),
             retention_scan_entries: self.retention_scan_entries.load(Ordering::Relaxed),
             peak_active_bodies: self.peak_active_bodies.load(Ordering::Relaxed),
+            peak_query_workers: self.peak_query_workers.load(Ordering::Relaxed),
             active_task_leases: self.active_task_leases.load(Ordering::Relaxed),
             peak_task_leases: self.peak_task_leases.load(Ordering::Relaxed),
             active_retained_pins: self.active_retained_pins.load(Ordering::Relaxed),
             peak_retained_pins: self.peak_retained_pins.load(Ordering::Relaxed),
             donated_permits: self.donated_permits.load(Ordering::Relaxed),
+            query_worker_active_ns: self.query_worker_active_ns.load(Ordering::Relaxed),
+            ready_items: self.ready_items.load(Ordering::Relaxed),
+            ready_wait_ns: self.ready_wait_ns.load(Ordering::Relaxed),
+            max_ready_wait_ns: self.max_ready_wait_ns.load(Ordering::Relaxed),
+            longest_query_dependency_chain: self
+                .longest_query_dependency_chain
+                .load(Ordering::Relaxed),
             retained_revisions: 0,
             revision_limit: REVISION_RETENTION_LIMIT as u64,
         }
@@ -3573,6 +3605,15 @@ impl Metrics {
 
     fn body_left(&self) {
         self.active_bodies.fetch_sub(1, Ordering::AcqRel);
+    }
+
+    fn permit_acquired(&self) {
+        let active = self.active_query_workers.fetch_add(1, Ordering::AcqRel) + 1;
+        self.peak_query_workers.fetch_max(active, Ordering::AcqRel);
+    }
+
+    fn permit_released(&self) {
+        self.active_query_workers.fetch_sub(1, Ordering::AcqRel);
     }
 
     fn task_lease_acquired(&self) {
@@ -4647,6 +4688,9 @@ impl QueryRuntime {
             revision,
             cancellation,
             owns_permit: AtomicBool::new(false),
+            permit_timing: Mutex::new(PermitTiming::default()),
+            longest_query_dependency_chain: AtomicU64::new(0),
+            publish_critical_path: true,
             stack: Mutex::new(Vec::new()),
             ancestry: Arc::from([]),
             nested_attempts: Mutex::new(Vec::new()),
@@ -7347,6 +7391,7 @@ pub struct QueryContext {
 struct RegisteredBatchItem<K> {
     request_id: u64,
     key: K,
+    ready_at: Instant,
 }
 
 struct RegisteredBatchItems<K> {
@@ -7420,6 +7465,11 @@ where
 {
     tracing::dispatcher::with_default(&tracing_dispatch, || {
         let parent_span = tracing_parent.enter();
+        let mut ready_items = 0u64;
+        let mut ready_wait_ns = 0u64;
+        let mut max_ready_wait_ns = 0u64;
+        let mut query_worker_active_ns = 0u64;
+        let mut longest_query_dependency_chain = 0u64;
         let result = catch_unwind(AssertUnwindSafe(|| {
             let mut completed = Vec::new();
             loop {
@@ -7427,16 +7477,49 @@ where
                     break;
                 };
                 let item = &items.items[index];
+                let wait_ns = duration_ns(item.ready_at.elapsed());
+                ready_items = ready_items.saturating_add(1);
+                ready_wait_ns = ready_wait_ns.saturating_add(wait_ns);
+                max_ready_wait_ns = max_ready_wait_ns.max(wait_ns);
                 let child = parent.batch_child(item.request_id, authority.clone());
                 let result =
                     family.query_task_registered(child.clone(), item.key.clone(), item.request_id);
                 if matches!(result, TaskQueryResult::Terminal { .. }) {
                     authority.publish_child(&child);
                 }
+                query_worker_active_ns = query_worker_active_ns
+                    .saturating_add(lock(&child.permit_timing).accumulated_ns);
+                longest_query_dependency_chain = longest_query_dependency_chain
+                    .max(child.longest_query_dependency_chain.load(Ordering::Relaxed));
                 completed.push((index, child, result));
             }
             completed
         }));
+        parent
+            .core
+            .metrics
+            .ready_items
+            .fetch_add(ready_items, Ordering::Relaxed);
+        parent
+            .core
+            .metrics
+            .ready_wait_ns
+            .fetch_add(ready_wait_ns, Ordering::Relaxed);
+        parent
+            .core
+            .metrics
+            .max_ready_wait_ns
+            .fetch_max(max_ready_wait_ns, Ordering::Relaxed);
+        parent
+            .core
+            .metrics
+            .query_worker_active_ns
+            .fetch_add(query_worker_active_ns, Ordering::Relaxed);
+        parent
+            .core
+            .metrics
+            .longest_query_dependency_chain
+            .fetch_max(longest_query_dependency_chain, Ordering::Relaxed);
         drop(parent_span);
         // A tracing subscriber may buffer observations locally to avoid
         // perturbing parallel query execution. This generic lifecycle marker
@@ -7689,6 +7772,7 @@ impl QueryContext {
                 .map(|key| RegisteredBatchItem {
                     request_id: self.task.next_nested_request(),
                     key,
+                    ready_at: Instant::now(),
                 })
                 .collect(),
         });
@@ -8121,6 +8205,28 @@ impl fmt::Debug for TaskQueryCache {
     }
 }
 
+#[derive(Debug, Default)]
+struct PermitTiming {
+    active_since: Option<Instant>,
+    accumulated_ns: u64,
+}
+
+impl PermitTiming {
+    fn acquired(&mut self) {
+        assert!(self.active_since.replace(Instant::now()).is_none());
+    }
+
+    fn released(&mut self) {
+        let started = self
+            .active_since
+            .take()
+            .expect("an owned execution permit has an active timing interval");
+        self.accumulated_ns = self
+            .accumulated_ns
+            .saturating_add(duration_ns(started.elapsed()));
+    }
+}
+
 #[derive(Debug)]
 struct Task {
     id: TaskId,
@@ -8128,6 +8234,15 @@ struct Task {
     revision: Revision,
     cancellation: CancellationToken,
     owns_permit: AtomicBool,
+    /// Task-local execution-permit intervals, published once when this task
+    /// completes. Donation pauses the interval while the task is waiting.
+    permit_timing: Mutex<PermitTiming>,
+    /// Task-local maximum, merged into the runtime at task completion.
+    longest_query_dependency_chain: AtomicU64,
+    /// Top-level tasks publish directly. Batch children are reduced once at
+    /// their bounded worker-completion boundary instead of contending on the
+    /// runtime metrics for every ready item.
+    publish_critical_path: bool,
     stack: Mutex<Vec<TaskFrame>>,
     /// Nodes whose evaluation structurally encloses this task but whose frames
     /// live on an ancestor task's stack. A registered batch runs its children on
@@ -9369,6 +9484,9 @@ impl Task {
             revision: self.revision,
             cancellation: self.cancellation.clone(),
             owns_permit: AtomicBool::new(false),
+            permit_timing: Mutex::new(PermitTiming::default()),
+            longest_query_dependency_chain: AtomicU64::new(0),
+            publish_critical_path: false,
             stack: Mutex::new(Vec::new()),
             ancestry: inherited_ancestry,
             nested_attempts: Mutex::new(Vec::new()),
@@ -9822,6 +9940,8 @@ impl Task {
         }
         core.permits.acquire();
         assert!(!self.owns_permit.swap(true, Ordering::AcqRel));
+        lock(&self.permit_timing).acquired();
+        core.metrics.permit_acquired();
         true
     }
 
@@ -9829,6 +9949,8 @@ impl Task {
         if !self.owns_permit.swap(false, Ordering::AcqRel) {
             return false;
         }
+        lock(&self.permit_timing).released();
+        core.metrics.permit_released();
         core.permits.release();
         true
     }
@@ -9992,7 +10114,8 @@ impl Task {
     }
 
     fn push(&self, node: ExactNodeIdentity) {
-        lock(&self.stack).push(TaskFrame {
+        let mut stack = lock(&self.stack);
+        stack.push(TaskFrame {
             node,
             dependencies: TaskDependencies::default(),
             inputs: InlineOrderedMap::default(),
@@ -10000,6 +10123,9 @@ impl Task {
             handoffs: Vec::new(),
             observed_handoffs: Vec::new(),
         });
+        let depth = self.ancestry.len().saturating_add(stack.len()) as u64;
+        self.longest_query_dependency_chain
+            .fetch_max(depth, Ordering::Relaxed);
     }
 
     fn pop(&self, expected: &ExactNodeIdentity) -> TaskFrameOutput {
@@ -10128,6 +10254,21 @@ impl Drop for Task {
         self.core
             .metrics
             .task_leases_released(lock(&self.leases).held.len());
+        let permit_timing = lock(&self.permit_timing);
+        assert!(
+            permit_timing.active_since.is_none(),
+            "a query task must release its execution permit before it is dropped"
+        );
+        if self.publish_critical_path {
+            self.core
+                .metrics
+                .query_worker_active_ns
+                .fetch_add(permit_timing.accumulated_ns, Ordering::Relaxed);
+            self.core.metrics.longest_query_dependency_chain.fetch_max(
+                self.longest_query_dependency_chain.load(Ordering::Relaxed),
+                Ordering::Relaxed,
+            );
+        }
     }
 }
 
@@ -10934,6 +11075,7 @@ mod tests {
             items: vec![RegisteredBatchItem {
                 request_id: 2,
                 key: Key("child"),
+                ready_at: Instant::now(),
             }],
         });
         let weak_items = Arc::downgrade(&items);
@@ -13251,6 +13393,9 @@ mod tests {
             revision: revision(1),
             cancellation: CancellationToken::new(),
             owns_permit: AtomicBool::new(false),
+            permit_timing: Mutex::new(PermitTiming::default()),
+            longest_query_dependency_chain: AtomicU64::new(0),
+            publish_critical_path: true,
             stack: Mutex::new(Vec::new()),
             ancestry: Arc::from([]),
             nested_attempts: Mutex::new(Vec::new()),
@@ -13304,6 +13449,9 @@ mod tests {
             revision: revision(1),
             cancellation: CancellationToken::new(),
             owns_permit: AtomicBool::new(false),
+            permit_timing: Mutex::new(PermitTiming::default()),
+            longest_query_dependency_chain: AtomicU64::new(0),
+            publish_critical_path: true,
             stack: Mutex::new(Vec::new()),
             ancestry: Arc::from([]),
             nested_attempts: Mutex::new(Vec::new()),
@@ -13579,6 +13727,9 @@ mod tests {
             revision: revision(1),
             cancellation: CancellationToken::new(),
             owns_permit: AtomicBool::new(false),
+            permit_timing: Mutex::new(PermitTiming::default()),
+            longest_query_dependency_chain: AtomicU64::new(0),
+            publish_critical_path: true,
             stack: Mutex::new(Vec::new()),
             ancestry: Arc::from([]),
             nested_attempts: Mutex::new(Vec::new()),

--- a/crates/rue/src/compile.rs
+++ b/crates/rue/src/compile.rs
@@ -34,7 +34,6 @@ pub(crate) struct LinkedExecutable {
 
 pub(crate) struct PublishedExecutable {
     metrics: OneShotMetrics,
-    pub(crate) linked_bytes: Vec<u8>,
 }
 
 pub(crate) struct PublicationAttempt {
@@ -88,7 +87,6 @@ impl LinkedExecutable {
             warnings: self.warnings,
             result: publication.map(|()| PublishedExecutable {
                 metrics: self.metrics,
-                linked_bytes: self.linked_bytes,
             }),
         }
     }

--- a/crates/rue/src/main.rs
+++ b/crates/rue/src/main.rs
@@ -34,6 +34,12 @@ use rue_compiler::{
 #[cfg(test)]
 use rue_compiler::{CompilerSession, SourceMetadata, SourceSnapshot};
 use rue_error::{CompileError, ErrorCode};
+use rue_perf_schema::{
+    ArtifactHitEvidence, BuildBoundary, CompilerBoundaryEvidence, CompilerBuildProfile,
+    CompilerConfigurationEvidence, CompilerCriticalPathEvidence, CompilerInputClass,
+    CompilerInputEvidence, CompilerPipeline, CompilerStage, EmbeddedAssetClass,
+    EmbeddedAssetEvidence, LinkPolicy, OptimizationLevel, OutputKind, WorkerSetting,
+};
 use rue_target::Target;
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 enum LogLevel {
@@ -906,6 +912,8 @@ fn print_timing_output(
     source_metrics: Option<timing::SourceMetrics>,
     compiler_work: Option<rue_perf_schema::CompilerWork>,
     emitted_output: Option<&[u8]>,
+    compiler_boundary: Option<&CompilerBoundaryEvidence>,
+    critical_path: Option<&CompilerCriticalPathEvidence>,
 ) {
     if let Some(timing) = timing_data {
         if benchmark_json {
@@ -927,6 +935,12 @@ fn print_timing_output(
                     "size_bytes": bytes.len(),
                 });
             }
+            if let Some(boundary) = compiler_boundary {
+                payload["compiler_boundary"] = serde_json::to_value(boundary).unwrap();
+            }
+            if let Some(critical_path) = critical_path {
+                payload["critical_path"] = serde_json::to_value(critical_path).unwrap();
+            }
             #[cfg(rue_benchmark_allocations)]
             {
                 let metrics = allocation::snapshot();
@@ -941,6 +955,117 @@ fn print_timing_output(
             // Human-readable output goes to stderr
             eprintln!("{}", timing.report());
         }
+    }
+}
+
+fn compiler_build_profile() -> CompilerBuildProfile {
+    #[cfg(rue_release_build)]
+    {
+        CompilerBuildProfile::ReleaseThinLto
+    }
+    #[cfg(not(rue_release_build))]
+    {
+        CompilerBuildProfile::Debug
+    }
+}
+
+fn compiler_boundary_evidence(
+    options: &Options,
+    resolved_workers: usize,
+    snapshot: &rue_compiler::SourceSnapshot,
+    emitted_output: &[u8],
+) -> Option<CompilerBoundaryEvidence> {
+    let requested_workers = WorkerSetting::from_jobs(options.jobs)?;
+    let mut accepted_inputs = snapshot
+        .files()
+        .map(|source| {
+            use sha2::{Digest, Sha256};
+            let module = snapshot
+                .module_id(source.file_id)
+                .expect("source views originate from this snapshot");
+            CompilerInputEvidence {
+                class: if module.is_trusted_standard_library() {
+                    CompilerInputClass::TrustedStandardLibrarySource
+                } else {
+                    CompilerInputClass::WorkloadSource
+                },
+                logical_identity: module.as_str().to_owned(),
+                sha256: format!("{:x}", Sha256::digest(source.source.as_bytes())),
+            }
+        })
+        .collect::<Vec<_>>();
+    accepted_inputs.sort_by(|left, right| {
+        (&left.class, left.logical_identity.as_str())
+            .cmp(&(&right.class, right.logical_identity.as_str()))
+    });
+
+    Some(CompilerBoundaryEvidence {
+        boundary: BuildBoundary::FreshSourceToNativeV1,
+        pipeline: CompilerPipeline::CanonicalRootedQueryGraphV1,
+        session_count: 1,
+        root_request_count: 1,
+        configuration: CompilerConfigurationEvidence {
+            target: options.target.to_string(),
+            compiler_build_profile: compiler_build_profile(),
+            optimization: match options.opt_level {
+                OptLevel::O0 => OptimizationLevel::O0,
+                OptLevel::O1 => OptimizationLevel::O1,
+                OptLevel::O2 => OptimizationLevel::O2,
+                OptLevel::O3 => OptimizationLevel::O3,
+            },
+            linker: match &options.linker {
+                LinkerMode::Internal => LinkPolicy::Internal,
+                LinkerMode::System(_) => LinkPolicy::System,
+            },
+            output_kind: OutputKind::NativeExecutable,
+            requested_workers,
+            resolved_workers: u32::try_from(resolved_workers).unwrap_or(u32::MAX),
+            preview_features: {
+                let mut features = options
+                    .preview_features
+                    .iter()
+                    .map(|feature| feature.name().to_owned())
+                    .collect::<Vec<_>>();
+                features.sort();
+                features
+            },
+            external_link_archives: u32::try_from(options.link_archives.len()).unwrap_or(u32::MAX),
+        },
+        completed_stages: CompilerStage::FRESH_SOURCE_TO_NATIVE_V1.to_vec(),
+        accepted_inputs,
+        embedded_assets: vec![EmbeddedAssetEvidence {
+            class: EmbeddedAssetClass::BundledRuntimeArchive,
+            logical_identity: "rue-runtime".to_string(),
+            target: options.target.to_string(),
+        }],
+        artifact_hits: ArtifactHitEvidence::default(),
+        emitted_output_sha256: {
+            use sha2::{Digest, Sha256};
+            format!("{:x}", Sha256::digest(emitted_output))
+        },
+        emitted_output_size_bytes: u64::try_from(emitted_output.len()).unwrap_or(u64::MAX),
+    })
+}
+
+fn compiler_critical_path_evidence(
+    timing: &timing::TimingData,
+    metrics: rue_compiler::unstable::OneShotMetrics,
+) -> CompilerCriticalPathEvidence {
+    let runtime = metrics.query_runtime;
+    CompilerCriticalPathEvidence {
+        query_worker_active_ns: runtime.query_worker_active_ns,
+        ready_items: runtime.ready_items,
+        ready_wait_ns: runtime.ready_wait_ns,
+        max_ready_wait_ns: runtime.max_ready_wait_ns,
+        longest_query_dependency_chain: runtime.longest_query_dependency_chain,
+        peak_query_workers: runtime.peak_query_workers,
+        toolchain_acquisition_ns: timing.pass_total_ns("toolchain_acquisition"),
+        semantic_bodies: timing.pass_duration_distribution("body_analysis"),
+        cfg_construction_bodies: timing.pass_duration_distribution("cfg_construction"),
+        cfg_optimization_bodies: timing.pass_duration_distribution("cfg_optimization"),
+        joins: runtime.joins,
+        declined_joins: runtime.declined_joins,
+        donated_permits: runtime.donated_permits,
     }
 }
 
@@ -1291,7 +1416,7 @@ fn main() {
     // Configure the compiler's shared structured-query budget before
     // dispatching to either the `--emit` path or the normal compile path, so
     // every driver path honors `-j`/`--jobs` (RUE-352).
-    configure_thread_pool(options.jobs);
+    let resolved_workers = configure_thread_pool(options.jobs);
 
     // Discover and load @import-ed modules from disk, transitively. Sema
     // resolves imports only against already-loaded files, so without this
@@ -1411,6 +1536,8 @@ fn main() {
             None,
             None,
             None,
+            None,
+            None,
         );
         return;
     }
@@ -1500,7 +1627,45 @@ fn main() {
                 );
             }
 
+            // Publication may perform target-specific finalization (notably
+            // ad-hoc Mach-O signing) after the linker produced its byte
+            // buffer. Benchmark evidence must describe the artifact users can
+            // actually execute, so both compiler and runner hash the published
+            // file rather than the pre-publication linker buffer.
+            let benchmark_emitted_output = if options.benchmark_json {
+                match std::fs::read(&options.output_path) {
+                    Ok(bytes) => Some(bytes),
+                    Err(error) => {
+                        eprintln!(
+                            "Error: could not verify published benchmark output '{}': {error}",
+                            options.output_path
+                        );
+                        std::process::exit(1);
+                    }
+                }
+            } else {
+                None
+            };
+
             let benchmark_metrics = options.benchmark_json.then(|| output.unstable_metrics());
+            let compiler_boundary = options
+                .benchmark_json
+                .then(|| {
+                    compiler_boundary_evidence(
+                        &options,
+                        resolved_workers,
+                        &source_snapshot,
+                        benchmark_emitted_output
+                            .as_deref()
+                            .expect("benchmark output was read after publication"),
+                    )
+                })
+                .flatten();
+            let critical_path = benchmark_metrics.and_then(|metrics| {
+                timing_data
+                    .as_ref()
+                    .map(|timing| compiler_critical_path_evidence(timing, metrics))
+            });
             print_timing_output(
                 &timing_data,
                 options.time_passes,
@@ -1521,9 +1686,9 @@ fn main() {
                     }
                 }),
                 benchmark_metrics.map(benchmark_compiler_work),
-                options
-                    .benchmark_json
-                    .then_some(output.linked_bytes.as_slice()),
+                benchmark_emitted_output.as_deref(),
+                compiler_boundary.as_ref(),
+                critical_path.as_ref(),
             );
         }
         Err(errors) => {
@@ -1594,6 +1759,7 @@ mod tests {
                 },
                 retention_enforcements: 13,
                 retention_scan_entries: 17,
+                ..Default::default()
             },
             ..Default::default()
         };

--- a/crates/rue/src/timing.rs
+++ b/crates/rue/src/timing.rs
@@ -104,7 +104,7 @@ const COMPILER_BUILD_PROFILE: &str = "release_thin_lto";
 #[cfg(not(rue_release_build))]
 const COMPILER_BUILD_PROFILE: &str = "debug";
 
-use rue_perf_schema::{CompilerWork, Phase, PhaseAccounting};
+use rue_perf_schema::{CompilerWork, DurationDistribution, Phase, PhaseAccounting};
 use serde::Serialize;
 
 use tracing::span::{Attributes, Id};
@@ -170,12 +170,27 @@ struct TimingDataInner {
 }
 
 /// Measurements aggregated across every span with the same name.
-#[derive(Debug, Clone, Copy, Default)]
+#[derive(Debug, Clone, Copy)]
 struct PassAggregate {
     duration: Duration,
+    max_duration: Duration,
     invocations: u64,
     root_invocations: u64,
     leaf_invocations: u64,
+    duration_log2_buckets: [u64; 64],
+}
+
+impl Default for PassAggregate {
+    fn default() -> Self {
+        Self {
+            duration: Duration::ZERO,
+            max_duration: Duration::ZERO,
+            invocations: 0,
+            root_invocations: 0,
+            leaf_invocations: 0,
+            duration_log2_buckets: [0; 64],
+        }
+    }
 }
 
 /// Measurements aggregated across every driver-phase span with the same name.
@@ -253,9 +268,17 @@ impl Drop for LocalTiming {
 fn merge_pass(target: &mut HashMap<String, PassAggregate>, name: String, local: PassAggregate) {
     let aggregate = target.entry(name).or_default();
     aggregate.duration += local.duration;
+    aggregate.max_duration = aggregate.max_duration.max(local.max_duration);
     aggregate.invocations += local.invocations;
     aggregate.root_invocations += local.root_invocations;
     aggregate.leaf_invocations += local.leaf_invocations;
+    for (target, local) in aggregate
+        .duration_log2_buckets
+        .iter_mut()
+        .zip(local.duration_log2_buckets)
+    {
+        *target = target.saturating_add(local);
+    }
 }
 
 fn merge_driver_phase(
@@ -446,10 +469,41 @@ impl TimingData {
         self.with_local(|local| {
             let entry = local.passes.entry(pass.to_string()).or_default();
             entry.duration += duration;
+            entry.max_duration = entry.max_duration.max(duration);
             entry.invocations += 1;
             entry.root_invocations += u64::from(is_root);
             entry.leaf_invocations += u64::from(is_leaf);
+            entry.duration_log2_buckets[duration_bucket(duration)] += 1;
         });
+    }
+
+    /// Return the bounded per-invocation distribution for one named span.
+    ///
+    /// The histogram is accumulated with the existing thread-local timing
+    /// buffer, so enabling this evidence adds no shared write to a body query.
+    pub fn pass_duration_distribution(&self, pass: &str) -> DurationDistribution {
+        self.flush_local();
+        let inner = self.inner.lock().unwrap_or_else(PoisonError::into_inner);
+        let Some(aggregate) = inner.passes.get(pass) else {
+            return DurationDistribution::default();
+        };
+        DurationDistribution {
+            count: aggregate.invocations,
+            total_ns: duration_ns(aggregate.duration),
+            max_ns: duration_ns(aggregate.max_duration),
+            log2_buckets: aggregate.duration_log2_buckets.to_vec(),
+        }
+    }
+
+    /// Return the inclusive total for one named span in integer nanoseconds.
+    pub fn pass_total_ns(&self, pass: &str) -> u64 {
+        self.flush_local();
+        self.inner
+            .lock()
+            .unwrap_or_else(PoisonError::into_inner)
+            .passes
+            .get(pass)
+            .map_or(0, |aggregate| duration_ns(aggregate.duration))
     }
 
     /// Record one driver-phase span outside the compiler's timing root.
@@ -710,7 +764,7 @@ impl TimingData {
         };
 
         BenchmarkTiming {
-            schema_version: 11,
+            schema_version: 12,
             timing_model: "inclusive_spans",
             phase_accounting,
             metadata,
@@ -918,6 +972,15 @@ fn phase_accounting_locked(inner: &TimingDataInner, now: Instant) -> PhaseAccoun
 /// saturation arm is unreachable for a compilation.
 fn duration_ns(duration: Duration) -> u64 {
     u64::try_from(duration.as_nanos()).unwrap_or(u64::MAX)
+}
+
+fn duration_bucket(duration: Duration) -> usize {
+    let nanoseconds = duration_ns(duration);
+    if nanoseconds == 0 {
+        0
+    } else {
+        (u64::BITS - 1 - nanoseconds.leading_zeros()) as usize
+    }
 }
 
 fn ordered_aggregates(aggregates: &HashMap<String, PassAggregate>) -> Vec<String> {
@@ -2081,7 +2144,7 @@ mod tests {
         data.record("lexer", Duration::from_millis(100));
 
         let json = data.to_json_with_metrics("x86_64-linux", "0.1.0", None, None, None);
-        assert!(json.contains("\"schema_version\":11"));
+        assert!(json.contains("\"schema_version\":12"));
         assert!(json.contains(&format!(
             "\"compiler_build_profile\":\"{COMPILER_BUILD_PROFILE}\""
         )));
@@ -2287,8 +2350,24 @@ mod phase_accounting_tests {
         let inner = data.inner.lock().unwrap_or_else(PoisonError::into_inner);
         let pass = inner.passes.get("worker_pass").unwrap();
         assert_eq!(pass.duration, Duration::from_millis(41));
+        assert_eq!(pass.max_duration, Duration::from_millis(17));
         assert_eq!(pass.invocations, 3);
         assert_eq!(pass.leaf_invocations, 3);
+        drop(inner);
+
+        let distribution = data.pass_duration_distribution("worker_pass");
+        assert_eq!(distribution.count, 3);
+        assert_eq!(distribution.total_ns, 41_000_000);
+        assert_eq!(distribution.max_ns, 17_000_000);
+        assert_eq!(
+            distribution.log2_buckets[duration_bucket(Duration::from_millis(11))],
+            2
+        );
+        assert_eq!(
+            distribution.log2_buckets[duration_bucket(Duration::from_millis(17))],
+            1
+        );
+        assert!(distribution.validate());
     }
 
     #[test]
@@ -2743,7 +2822,7 @@ mod phase_accounting_tests {
 
         let timing =
             data.to_benchmark_timing_with_metrics("probe-target", "probe", None, None, None);
-        assert_eq!(timing.schema_version, 11);
+        assert_eq!(timing.schema_version, 12);
         assert_eq!(
             timing.metadata.compiler_build_profile,
             COMPILER_BUILD_PROFILE

--- a/docs/process/compiler-scaling.md
+++ b/docs/process/compiler-scaling.md
@@ -1,32 +1,43 @@
 # Compiler scaling reports
 
-The weekly compiler-scaling workflow measures how the compiler behaves as
-maintained Rue programs grow from Ruelex through Mosaic and Harbor to Lattice.
-It complements the fast compiler-performance headline; it does not contribute
-to that index.
+The weekly compiler-scaling workflow measures the complete ADR-0071
+release-quality boundary as maintained Rue programs grow from Ruelex through
+Mosaic and Harbor to Lattice. Every workload is compiled at one, two, four,
+eight, and automatic workers. It complements the fast compiler-performance
+headline; it does not contribute to that index.
 
 ## Measurement regime
 
 Each sample launches the canonical compiler binary in a new process and asks
-it for `--benchmark-json`. There is no retained compiler session or persistent
-query cache. Filesystem and operating-system page-cache state are not reset, so
-the reports call this a **fresh-process compile**, not a cold compile.
+it for `--benchmark-json`. The manifest, external runner, and compiler must
+independently agree that this is `fresh_source_to_native_v1`: Rue `-O3`, the
+internal linker, one published native executable, the canonical rooted query
+graph, and the declared worker row. There is no retained compiler session,
+daemon, persistent query cache, precompiled package/program/standard artifact,
+or undeclared external link input. Filesystem and operating-system page-cache
+state are not reset, so the reports call this a **fresh-process compile**, not
+a cold compile.
 
 The compiler and measurement runner are built with the release target platform
 (`-Copt-level=3 -Clto=thin`). The compiler reports that profile in its benchmark
 metadata, and the scaling runner rejects a binary that does not match the
 manifest's declared profile.
 
-The runner executes three timing samples sequentially for each workload. JSON
-keeps every raw observation in integer nanoseconds. The Markdown view reports
-the median and median absolute deviation (MAD), along with the machine and
-hosted runner fingerprint. Two additional fresh-process probes run with one
-compiler worker; their timings are discarded, and their deterministic
-compiler-work counters must agree exactly. Fixing the structural probes to one
-worker prevents legitimate parallel scheduling order from perturbing exact
-counters while leaving the user-relevant timing samples parallel. A counter
-disagreement rejects the workload instead of averaging structurally different
-compilations. The report records:
+The runner executes three timing samples sequentially for every workload and
+worker row. JSON keeps every raw observation in integer nanoseconds. The
+Markdown view reports the median and median absolute deviation (MAD), along
+with the machine and hosted runner fingerprint. The measured one-worker
+samples are also the deterministic structural probes: their compiler-work
+counters must agree exactly. Parallel rows retain every raw work record because
+join, reuse, and validation outcomes can legitimately depend on scheduling. A
+one-worker counter disagreement rejects the workload instead of averaging
+structurally different compilations. Across all rows, different emitted bytes,
+fixture shape, compiler target, or automatic-worker resolution reject the run.
+
+Every process proof includes the compiler-binary digest; fresh state and output
+directories; independently rehashed source inputs; the selected embedded
+runtime; completed source-through-publication stages; successful exit; and an
+independently verified native output digest. The report records:
 
 - files, modules, source bytes, lines, lexer tokens, and functions considered;
 - externally observed fresh-process wall time and peak resident memory;
@@ -46,12 +57,25 @@ compilations. The report records:
 - display-only query identities materialized for memo nodes, structured batch
   cycle rendering, and abort fallbacks, with exact counts and formatted key
   bytes;
+- query-worker active time and peak workers;
+- dependency-ready item count, summed queue delay, and maximum queue delay;
+- longest query/dependency ancestry;
+- bounded semantic, CFG-construction, and CFG-optimization body-duration
+  histograms;
+- reached-toolchain acquisition, joins, declined joins, and permit donations;
 - output binary size.
 
 The Markdown work table includes validation nodes per token. That ratio is a
 clock-independent amplification signal: source growth should not silently turn
 into many repeated validation visits merely because elapsed time still looks
 plausible on one host.
+
+The worker-scaling table derives utilization from summed active query-worker
+time divided by compiler-root time and resolved worker capacity. It reports
+ready-item mean and maximum wait separately because the total is additive over
+items rather than elapsed wall time. Body timing distributions use 64 bounded
+log2 buckets, exact count/total/maximum, thread-local accumulation, and bounded
+worker-completion merges; they never retain one event per body.
 
 The semantic-reachability table reports average scheduled keys per non-empty
 dependency-ready logical frontier, fixed width buckets, and body transactions
@@ -109,14 +133,16 @@ BENCH="$(./buck2 build //crates/rue-bench:rue-bench --target-platforms //platfor
   --out /tmp/rue-scaling.json
 ```
 
-This writes `/tmp/rue-scaling.json` and `/tmp/rue-scaling.md`. Supplying a
+This writes `/tmp/rue-scaling.json` and `/tmp/rue-scaling.md`. It performs 60
+fresh compiler processes with the current four-workload, five-worker-row,
+three-sample manifest. Supplying a
 `--workdir` keeps the generated executables for inspection; without it the
 runner uses a temporary directory.
 
 ## Comparing history
 
 The scheduled workflow stores both report forms as a 90-day workflow artifact.
-Compare reports only within the same target and manifest revision, and treat a
+Compare rows only within the same target, worker setting, and manifest revision, and treat a
 runner fingerprint change as advisory because GitHub-hosted hardware is not a
 controlled machine.
 
@@ -128,7 +154,8 @@ increment `revision` in `performance/scaling.toml`; the old workflow artifact
 remains the boundary record. Raw JSON is the authority, while the Markdown
 table is a derived view that can be regenerated from those samples.
 
-The suite is intentionally lower frequency. Do not add these workloads to
-`performance/manifest.toml` or give them the startup probe's calibrated
-sampling policy: doing so would make every trunk collection expensive and
-silently change the headline's meaning.
+The suite is intentionally lower frequency. Lattice also participates in the
+ADR-0071 absolute-latency series in `performance/manifest.toml`, but the other
+maintained programs and the full worker matrix belong here; adding them to the
+per-trunk headline would make collection expensive and silently change that
+series' meaning.

--- a/performance/manifest.toml
+++ b/performance/manifest.toml
@@ -49,6 +49,25 @@ id = "lattice"
 source = "performance/workloads/lattice/main.rue"
 question = "How quickly does Rue produce optimized native output for the frozen ADR-0071 reference program?"
 
+# Suite revision 3 makes ADR-0071's complete fresh-process boundary
+# machine-checkable. The workload bytes and questions are unchanged from
+# revision 2; protocol v2 adds one runner/compiler proof per process.
+[[suite]]
+revision = 3
+timing_schema_version = 1
+protocol_version = 2
+boundary = "fresh_source_to_native_v1"
+
+[[suite.workloads]]
+id = "startup"
+source = "performance/workloads/startup/main.rue"
+question = "What does a minimal fresh compilation cost end to end?"
+
+[[suite.workloads]]
+id = "lattice"
+source = "performance/workloads/lattice/main.rue"
+question = "How quickly does Rue produce optimized native output for the frozen ADR-0071 reference program?"
+
 # A development epoch for local runs. Not a collection target: its environment
 # policy admits only `local`, so a hosted runner cannot append to it.
 [[epoch]]
@@ -69,6 +88,48 @@ runner_image = "local"
 [epoch.sampling.startup]
 samples = 3
 batch_size = 5
+
+[epoch.flagging]
+k = 3.0
+window = 10
+
+# Local protocol-v2 smoke regime. This is not a reference clock, but it runs
+# the exact boundary checker used by hosted collection.
+[[epoch]]
+id = 3
+platform = "local"
+suite_revision = 3
+target = "x86-64-linux"
+args = ["-O3", "-j1"]
+toolchain_hash = "30f50af0ac7111ffb25d5ef1a423642eaeb2e381931a57583e190a84634ee3fe"
+
+[epoch.boundary]
+boundary = "fresh_source_to_native_v1"
+pipeline = "canonical_rooted_query_graph_v1"
+compiler_build_profile = "release_thin_lto"
+optimization = "o3"
+linker = "internal"
+output_kind = "native_executable"
+worker_setting = "one"
+allowed_input_classes = ["workload_source", "trusted_standard_library_source"]
+allowed_embedded_asset_classes = ["bundled_runtime_archive"]
+required_stages = ["source_discovery_and_parsing", "program_construction", "semantic_analysis", "cfg_and_optimization", "backend", "object_generation", "linking", "output_publication"]
+
+[epoch.workload_source_hashes]
+startup = "87869467f94e34b8df41900bda44546b610296077c14fab6defda8939fe22be7"
+lattice = "1c5b2fffc71a9edfd0c5212262bc7bb9c5694c74c78ab15f7b540e04a62a7651"
+
+[epoch.environment]
+runner_label = "local"
+runner_image = "local"
+
+[epoch.sampling.startup]
+samples = 3
+batch_size = 5
+
+[epoch.sampling.lattice]
+samples = 3
+batch_size = 1
 
 [epoch.flagging]
 k = 3.0
@@ -441,7 +502,7 @@ run = "ff0a3ab928b8e2e601604912404b9ed4b8140a27a2204300d5917143f533574b"
 
 [[epoch]]
 id = 4
-collection = true
+collection = false
 platform = "x86_64-linux"
 suite_revision = 2
 target = "x86_64-unknown-linux-gnu"
@@ -474,7 +535,7 @@ window = 5
 
 [[epoch]]
 id = 4
-collection = true
+collection = false
 platform = "aarch64-linux"
 suite_revision = 2
 target = "aarch64-unknown-linux-gnu"
@@ -503,12 +564,146 @@ window = 3
 
 [[epoch]]
 id = 4
-collection = true
+collection = false
 platform = "aarch64-macos"
 suite_revision = 2
 target = "aarch64-apple-darwin"
 args = ["-O3", "-j1"]
 toolchain_hash = "30f50af0ac7111ffb25d5ef1a423642eaeb2e381931a57583e190a84634ee3fe"
+
+[epoch.workload_source_hashes]
+startup = "87869467f94e34b8df41900bda44546b610296077c14fab6defda8939fe22be7"
+lattice = "1c5b2fffc71a9edfd0c5212262bc7bb9c5694c74c78ab15f7b540e04a62a7651"
+
+[epoch.environment]
+runner_label = "github-hosted"
+runner_image = "macos-15"
+
+[epoch.sampling.startup]
+samples = 99
+batch_size = 8
+
+[epoch.sampling.lattice]
+samples = 99
+batch_size = 1
+
+[epoch.flagging]
+k = 4.0
+window = 5
+
+# ---------------------------------------------------------------------------
+# Suite revision 3 collection epochs (ADR-0071 Phase 1, RUE-1475).
+#
+# These preserve revision 2's frozen programs and calibrated sample counts but
+# require protocol-v2 proof of the complete release-quality boundary. Epoch 4
+# remains historical; only these epochs may receive new reference samples.
+
+[[epoch]]
+id = 5
+collection = true
+platform = "x86_64-linux"
+suite_revision = 3
+target = "x86-64-linux"
+args = ["-O3", "-j1"]
+toolchain_hash = "30f50af0ac7111ffb25d5ef1a423642eaeb2e381931a57583e190a84634ee3fe"
+
+[epoch.boundary]
+boundary = "fresh_source_to_native_v1"
+pipeline = "canonical_rooted_query_graph_v1"
+compiler_build_profile = "release_thin_lto"
+optimization = "o3"
+linker = "internal"
+output_kind = "native_executable"
+worker_setting = "one"
+allowed_input_classes = ["workload_source", "trusted_standard_library_source"]
+allowed_embedded_asset_classes = ["bundled_runtime_archive"]
+required_stages = ["source_discovery_and_parsing", "program_construction", "semantic_analysis", "cfg_and_optimization", "backend", "object_generation", "linking", "output_publication"]
+
+[epoch.workload_source_hashes]
+startup = "87869467f94e34b8df41900bda44546b610296077c14fab6defda8939fe22be7"
+lattice = "1c5b2fffc71a9edfd0c5212262bc7bb9c5694c74c78ab15f7b540e04a62a7651"
+
+[epoch.environment]
+runner_label = "github-hosted"
+runner_image = "ubuntu-24.04"
+
+[epoch.sampling.startup]
+samples = 12
+batch_size = 6
+
+[epoch.sampling.lattice]
+samples = 3
+batch_size = 1
+
+[epoch.process_elapsed_targets.lattice]
+process_elapsed_ns = 250000000
+reference = "ADR-0071"
+
+[epoch.flagging]
+k = 6.0
+window = 5
+
+[[epoch]]
+id = 5
+collection = true
+platform = "aarch64-linux"
+suite_revision = 3
+target = "aarch64-linux"
+args = ["-O3", "-j1"]
+toolchain_hash = "30f50af0ac7111ffb25d5ef1a423642eaeb2e381931a57583e190a84634ee3fe"
+
+[epoch.boundary]
+boundary = "fresh_source_to_native_v1"
+pipeline = "canonical_rooted_query_graph_v1"
+compiler_build_profile = "release_thin_lto"
+optimization = "o3"
+linker = "internal"
+output_kind = "native_executable"
+worker_setting = "one"
+allowed_input_classes = ["workload_source", "trusted_standard_library_source"]
+allowed_embedded_asset_classes = ["bundled_runtime_archive"]
+required_stages = ["source_discovery_and_parsing", "program_construction", "semantic_analysis", "cfg_and_optimization", "backend", "object_generation", "linking", "output_publication"]
+
+[epoch.workload_source_hashes]
+startup = "87869467f94e34b8df41900bda44546b610296077c14fab6defda8939fe22be7"
+lattice = "1c5b2fffc71a9edfd0c5212262bc7bb9c5694c74c78ab15f7b540e04a62a7651"
+
+[epoch.environment]
+runner_label = "github-hosted"
+runner_image = "ubuntu-24.04"
+
+[epoch.sampling.startup]
+samples = 5
+batch_size = 6
+
+[epoch.sampling.lattice]
+samples = 3
+batch_size = 1
+
+[epoch.flagging]
+k = 5.0
+window = 3
+
+[[epoch]]
+id = 5
+collection = true
+platform = "aarch64-macos"
+suite_revision = 3
+target = "aarch64-macos"
+args = ["-O3", "-j1"]
+toolchain_hash = "30f50af0ac7111ffb25d5ef1a423642eaeb2e381931a57583e190a84634ee3fe"
+
+[epoch.boundary]
+boundary = "fresh_source_to_native_v1"
+pipeline = "canonical_rooted_query_graph_v1"
+compiler_build_profile = "release_thin_lto"
+optimization = "o3"
+linker = "internal"
+output_kind = "native_executable"
+worker_setting = "one"
+allowed_input_classes = ["workload_source", "trusted_standard_library_source"]
+allowed_embedded_asset_classes = ["bundled_runtime_archive"]
+required_stages = ["source_discovery_and_parsing", "program_construction", "semantic_analysis", "cfg_and_optimization", "backend", "object_generation", "linking", "output_publication"]
 
 [epoch.workload_source_hashes]
 startup = "87869467f94e34b8df41900bda44546b610296077c14fab6defda8939fe22be7"

--- a/performance/scaling.toml
+++ b/performance/scaling.toml
@@ -5,11 +5,14 @@
 # startup probe's calibrated sample counts or enter the fast headline index.
 # Every sample launches the canonical compiler binary in a fresh process. The
 # compiled program is never run.
-schema_version = 2
-revision = 2
+schema_version = 3
+revision = 3
 samples = 3
 args = []
 compiler_build_profile = "release_thin_lto"
+boundary = "fresh_source_to_native_v1"
+target = "x86-64-linux"
+workers = ["one", "two", "four", "eight", "automatic"]
 
 [[workloads]]
 id = "ruelex"

--- a/scripts/test-release-configuration.py
+++ b/scripts/test-release-configuration.py
@@ -61,6 +61,25 @@ class ReleaseConfigurationTests(unittest.TestCase):
         )
         self.assertTrue(any("scripts/rue-bin" in error for error in errors), errors)
 
+    def test_collection_workflow_and_scaling_manifest_pin_the_boundary(self) -> None:
+        collection = "\n".join(release_configuration.COLLECTION_BOUNDARY_SNIPPETS)
+        self.assertEqual(
+            release_configuration.validate_collection_workflow(collection), []
+        )
+        self.assertTrue(
+            release_configuration.validate_collection_workflow(
+                collection.replace("//platforms:release", "//platforms:debug")
+            )
+        )
+
+        manifest = "\n".join(release_configuration.SCALING_BOUNDARY_SNIPPETS)
+        self.assertEqual(release_configuration.validate_scaling_manifest(manifest), [])
+        self.assertTrue(
+            release_configuration.validate_scaling_manifest(
+                manifest.replace('boundary = "fresh_source_to_native_v1"', "")
+            )
+        )
+
     def test_rejects_missing_or_ambiguous_rustc_action(self) -> None:
         with self.assertRaisesRegex(ValueError, "0 matching"):
             release_configuration.rustc_cfg_command("{}", "release")

--- a/scripts/validate-release-configuration.py
+++ b/scripts/validate-release-configuration.py
@@ -18,10 +18,26 @@ PLATFORMS = {
 }
 RELEASE_FLAGS = ("-Copt-level=3", "-Clto=thin", "--cfg=rue_release_build")
 SCALING_WORKFLOW = ROOT / ".github" / "workflows" / "performance-scaling.yml"
+COLLECTION_WORKFLOW = ROOT / ".github" / "workflows" / "performance-collect.yml"
+SCALING_MANIFEST = ROOT / "performance" / "scaling.toml"
 SCALING_RELEASE_SNIPPETS = (
     "./buck2 build //crates/rue:rue //crates/rue-bench:rue-bench --target-platforms //platforms:release",
     'RUE="$(scripts/rue-bin --target-platforms //platforms:release)"',
     'BENCH="$(./buck2 build //crates/rue-bench:rue-bench --target-platforms //platforms:release --show-simple-output',
+    "--manifest performance/scaling.toml",
+)
+COLLECTION_BOUNDARY_SNIPPETS = (
+    "--target-platforms //platforms:release",
+    'RUE="$(scripts/rue-bin --target-platforms //platforms:release)"',
+    "--manifest performance/manifest.toml",
+)
+SCALING_BOUNDARY_SNIPPETS = (
+    "schema_version = 3",
+    'boundary = "fresh_source_to_native_v1"',
+    'target = "x86-64-linux"',
+    'args = []',
+    'compiler_build_profile = "release_thin_lto"',
+    'workers = ["one", "two", "four", "eight", "automatic"]',
 )
 
 def rustc_cfg_command(payload: str, platform: str) -> str:
@@ -60,6 +76,22 @@ def validate_scaling_workflow(workflow: str) -> list[str]:
     ]
 
 
+def validate_collection_workflow(workflow: str) -> list[str]:
+    return [
+        f"performance-collection workflow is missing boundary command: {snippet}"
+        for snippet in COLLECTION_BOUNDARY_SNIPPETS
+        if snippet not in workflow
+    ]
+
+
+def validate_scaling_manifest(manifest: str) -> list[str]:
+    return [
+        f"compiler-scaling manifest is missing boundary declaration: {snippet}"
+        for snippet in SCALING_BOUNDARY_SNIPPETS
+        if snippet not in manifest
+    ]
+
+
 def query(buck2: Path, platform: str) -> str:
     command = [
         str(buck2),
@@ -95,12 +127,16 @@ def main() -> int:
 
     try:
         scaling_workflow = SCALING_WORKFLOW.read_text()
+        collection_workflow = COLLECTION_WORKFLOW.read_text()
+        scaling_manifest = SCALING_MANIFEST.read_text()
     except OSError as error:
-        print(f"error: could not read compiler-scaling workflow: {error}", file=sys.stderr)
+        print(f"error: could not read performance policy input: {error}", file=sys.stderr)
         return 1
 
     errors = validate_commands(debug, release)
     errors.extend(validate_scaling_workflow(scaling_workflow))
+    errors.extend(validate_collection_workflow(collection_workflow))
+    errors.extend(validate_scaling_manifest(scaling_manifest))
     if errors:
         for error in errors:
             print(f"error: {error}", file=sys.stderr)
@@ -108,7 +144,7 @@ def main() -> int:
 
     print(
         "release configuration valid: release has "
-        f"{' '.join(RELEASE_FLAGS)}; debug does not; compiler scaling selects release"
+        f"{' '.join(RELEASE_FLAGS)}; debug does not; collection and scaling pin the release boundary"
     )
     return 0
 


### PR DESCRIPTION
Refs RUE-1475.

This establishes the ADR-0071 Phase 1 measurement foundation without closing the issue; the hosted baseline still needs to be collected and pinned after merge.

- adds exhaustive `fresh_source_to_native_v1` manifest, runner, and compiler evidence and rejects mismatches fail-closed
- measures the real release ThinLTO, Rue `-O3`, internal-linker CLI boundary through verified native output
- adds bounded worker utilization, ready-wait, dependency-depth, body-duration, toolchain, and contention evidence
- upgrades the maintained scaling report to the 1/2/4/8/automatic worker matrix and preserves exact one-worker work invariants
- pins scheduled and documented collection to the release CLI and publishes the 250 ms Lattice target only on the x86 Linux reference epoch

Local evidence:
- `scripts/rue quick`
- focused query, schema, runner, and CLI unit suites
- release configuration and collection-pin validation
- complete local protocol-v2 Startup/Lattice run
- complete 60-process Ruelex/Mosaic/Harbor/Lattice worker matrix

The local Lattice diagnostic measured 971.60 ms at one worker and 755.16 ms at automatic/10 workers. Query-worker utilization fell from 78.0% to 36.8%; reached-toolchain acquisition was about 385-493 ms across rows. These are diagnostic local numbers, not the hosted baseline.