### PR TITLE
RUE-1475: establish compiler baseline ratchet

### DIFF
--- a/.github/workflows/performance-collect.yml
+++ b/.github/workflows/performance-collect.yml
@@ -138,6 +138,11 @@ jobs:
                  "performance/manifest.toml, marking it \`collection = true\`."
             exit 1
           fi
+          if [ "$status" -eq 4 ]; then
+            echo "::error::the valid run has been retained as evidence, but it exceeds" \
+                 "the reviewed fresh-process non-regression ratchet in performance/manifest.toml."
+            exit 1
+          fi
 
   publish:
     needs: measure

--- a/crates/rue-bench/src/derive.rs
+++ b/crates/rue-bench/src/derive.rs
@@ -88,6 +88,8 @@ pub struct EpochData {
     ///
     /// Kept per epoch because hosted platform clocks are not interchangeable.
     pub process_elapsed_targets: BTreeMap<String, ProcessElapsedTargetData>,
+    /// Noise-aware non-regression ratchets for this reference epoch.
+    pub process_elapsed_ratchets: BTreeMap<String, ProcessElapsedRatchetData>,
     /// Standard-library changes within this epoch.
     ///
     /// Deliberately *not* advisory, unlike an environment annotation. `std` is
@@ -111,6 +113,15 @@ pub struct FlaggingRule {
 pub struct ProcessElapsedTargetData {
     pub process_elapsed_ns: u64,
     pub reference: String,
+}
+
+/// One pinned fresh-process non-regression ratchet rendered by the dashboard.
+#[derive(Debug, Serialize)]
+pub struct ProcessElapsedRatchetData {
+    pub baseline_process_elapsed_ns: u64,
+    pub baseline_mad_ns: u64,
+    pub process_elapsed_limit_ns: u64,
+    pub reference_run: String,
 }
 
 /// A point at which the standard library changed underneath a series.
@@ -502,6 +513,21 @@ fn derive_epoch(
                     ProcessElapsedTargetData {
                         process_elapsed_ns: target.process_elapsed_ns,
                         reference: target.reference.clone(),
+                    },
+                )
+            })
+            .collect(),
+        process_elapsed_ratchets: epoch
+            .process_elapsed_ratchets
+            .iter()
+            .map(|(workload, ratchet)| {
+                (
+                    workload.clone(),
+                    ProcessElapsedRatchetData {
+                        baseline_process_elapsed_ns: ratchet.baseline_process_elapsed_ns,
+                        baseline_mad_ns: ratchet.baseline_mad_ns,
+                        process_elapsed_limit_ns: ratchet.process_elapsed_limit_ns,
+                        reference_run: ratchet.reference_run.clone(),
                     },
                 )
             })
@@ -903,6 +929,31 @@ window = 3
         assert_eq!(targets.len(), 1);
         assert_eq!(targets["startup"].process_elapsed_ns, 250_000_000);
         assert_eq!(targets["startup"].reference, "ADR-0071");
+    }
+
+    #[test]
+    fn the_epoch_publishes_its_baseline_ratchet_separately_from_the_target() {
+        let base = run_at("a", "2026-07-28T00:00:00Z", [100, 100, 100]);
+        let address = base.content_address().expect("addressable");
+        let text = format!(
+            "{MANIFEST}\n\
+             [epoch.baseline]\n\
+             commit = \"{}\"\n\
+             run = \"{address}\"\n\n\
+             [epoch.process_elapsed_ratchets.startup]\n\
+             baseline_process_elapsed_ns = 101000000\n\
+             baseline_mad_ns = 1000000\n\
+             process_elapsed_limit_ns = 107000000\n\
+             reference_run = \"{address}\"\n",
+            base.identity.commit
+        );
+        let manifest = Manifest::parse(&text).expect("ratcheted manifest");
+        let data = derive(&manifest, &[base]);
+        let ratchets = &data.platforms[0].epochs[0].process_elapsed_ratchets;
+        assert_eq!(ratchets.len(), 1);
+        assert_eq!(ratchets["startup"].baseline_process_elapsed_ns, 101_000_000);
+        assert_eq!(ratchets["startup"].process_elapsed_limit_ns, 107_000_000);
+        assert_eq!(ratchets["startup"].reference_run, address);
     }
 
     #[test]

--- a/crates/rue-bench/src/main.rs
+++ b/crates/rue-bench/src/main.rs
@@ -27,8 +27,9 @@ use std::process::ExitCode;
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use rue_perf_schema::{
-    Completeness, FailureRecord, Invocation, Manifest, RUN_SCHEMA_VERSION, ResolvedPins,
-    RunIdentity, RunObject, Sample, ValidationOutcome, WorkloadObservation, validate_run,
+    Completeness, FailureRecord, Invocation, Manifest, ProcessElapsedRegression,
+    RUN_SCHEMA_VERSION, ResolvedPins, RunIdentity, RunObject, Sample, ValidationOutcome,
+    WorkloadObservation, process_elapsed_regressions, validate_run,
 };
 
 use crate::measure::{SampleOutcome, SampleRequest, measure_sample};
@@ -45,6 +46,9 @@ mod exit {
     /// Distinct from `USAGE` because the evidence still exists and is worth
     /// collecting; only publication is blocked.
     pub const NOT_APPENDABLE: u8 = 3;
+    /// The run is valid and publishable, but crossed a reviewed performance
+    /// ratchet. The raw evidence still belongs in its series.
+    pub const REGRESSION: u8 = 4;
 }
 
 struct Options {
@@ -490,6 +494,7 @@ fn run(options: &Options) -> Result<u8, String> {
     };
 
     let outcome = validate_run(&manifest, &run);
+    let regressions = process_elapsed_regressions(&manifest, &run, &outcome);
 
     // The run object is written whatever the verdict. Evidence of a broken
     // collection is worth more than a missing file.
@@ -506,16 +511,23 @@ fn run(options: &Options) -> Result<u8, String> {
     std::fs::write(&options.output, &serialized)
         .map_err(|error| format!("could not write {}: {error}", options.output.display()))?;
 
-    report(&run, &outcome, &options.output);
+    report(&run, &outcome, &regressions, &options.output);
 
-    Ok(if outcome.is_appendable() {
-        exit::OK
-    } else {
+    Ok(if !outcome.is_appendable() {
         exit::NOT_APPENDABLE
+    } else if !regressions.is_empty() {
+        exit::REGRESSION
+    } else {
+        exit::OK
     })
 }
 
-fn report(run: &RunObject, outcome: &ValidationOutcome, output: &Path) {
+fn report(
+    run: &RunObject,
+    outcome: &ValidationOutcome,
+    regressions: &[ProcessElapsedRegression],
+    output: &Path,
+) {
     let address = run
         .content_address()
         .unwrap_or_else(|_| "<unaddressable>".to_string());
@@ -528,6 +540,13 @@ fn report(run: &RunObject, outcome: &ValidationOutcome, output: &Path) {
         eprintln!(
             "rue-bench: invalid sample {}[{}]: {}",
             sample.workload, sample.sample_index, sample.reason
+        );
+    }
+    for regression in regressions {
+        eprintln!(
+            "rue-bench: performance regression: workload {:?} fresh-process median {} ns \
+             exceeds the fixed {} ns ratchet",
+            regression.workload, regression.current_median_ns, regression.limit_ns
         );
     }
     match &outcome.completeness {

--- a/crates/rue-perf-schema/src/lib.rs
+++ b/crates/rue-perf-schema/src/lib.rs
@@ -62,7 +62,7 @@ pub use incremental::{
 };
 pub use manifest::{
     Baseline, EnvironmentPolicy, FlaggingPolicy, Manifest, ManifestError, PlatformEpoch,
-    ProcessElapsedTarget, SamplingPolicy, SuiteRevision, Workload,
+    ProcessElapsedRatchet, ProcessElapsedTarget, SamplingPolicy, SuiteRevision, Workload,
 };
 pub use run::{
     Band, EnvironmentFingerprint, FailureRecord, Invocation, Phase, PhaseAccounting, ResolvedPins,
@@ -80,8 +80,8 @@ pub use stats::{
     ratio, sample_value,
 };
 pub use validate::{
-    Completeness, InvalidSample, InvalidSampleReason, ValidationError, ValidationOutcome,
-    validate_run,
+    Completeness, InvalidSample, InvalidSampleReason, ProcessElapsedRegression, ValidationError,
+    ValidationOutcome, process_elapsed_regressions, validate_run,
 };
 
 /// Deterministic presentation-only query identity materialization.

--- a/crates/rue-perf-schema/src/manifest.rs
+++ b/crates/rue-perf-schema/src/manifest.rs
@@ -131,6 +131,27 @@ pub struct ProcessElapsedTarget {
     pub reference: String,
 }
 
+/// A noise-aware non-regression ratchet for fresh-process latency.
+///
+/// The center and dispersion are reviewed evidence derived from the immutable
+/// baseline run named by the epoch. The limit is fixed policy chosen from that
+/// evidence: it absorbs calibrated hosted-runner noise without allowing a
+/// later noisy observation to widen its own gate.
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ProcessElapsedRatchet {
+    /// The current best accepted process-spawn-through-exit median.
+    pub baseline_process_elapsed_ns: u64,
+    /// Calibrated dispersion of the baseline regime, in nanoseconds.
+    pub baseline_mad_ns: u64,
+    /// Fixed gate derived from the baseline and its calibrated dispersion.
+    /// It changes only in a reviewed manifest update and never expands because
+    /// a later run happened to be noisy.
+    pub process_elapsed_limit_ns: u64,
+    /// Content address of the immutable run from which the ratchet was set.
+    pub reference_run: String,
+}
+
 /// When a workload's movement counts as movement.
 ///
 /// A workload is flagged only when the difference between its current median
@@ -211,6 +232,13 @@ pub struct PlatformEpoch {
     /// directional platform would turn unlike clocks into an apparent gate.
     #[serde(default)]
     pub process_elapsed_targets: BTreeMap<String, ProcessElapsedTarget>,
+    /// Noise-aware fresh-process non-regression ratchets.
+    ///
+    /// Ratchets are separate from absolute targets: the former prevents Rue
+    /// from losing accepted progress, while the latter says where the product
+    /// is going. Only the reference platform normally carries one.
+    #[serde(default)]
+    pub process_elapsed_ratchets: BTreeMap<String, ProcessElapsedRatchet>,
     /// The regression-flagging rule.
     pub flagging: FlaggingPolicy,
     /// The headline baseline, once a complete valid run has established one.
@@ -323,6 +351,25 @@ pub enum ManifestError {
         /// The workload whose target is invalid.
         workload: String,
     },
+    /// An epoch declares a ratchet for a workload outside its suite.
+    UnknownRatchetWorkload {
+        /// The platform carrying the ratchet.
+        platform: String,
+        /// The offending epoch.
+        epoch: u32,
+        /// The undeclared workload.
+        workload: String,
+    },
+    /// A ratchet has no positive center, no reference, or names a run other
+    /// than the epoch's baseline.
+    InvalidProcessElapsedRatchet {
+        /// The platform carrying the ratchet.
+        platform: String,
+        /// The offending epoch.
+        epoch: u32,
+        /// The workload whose ratchet is invalid.
+        workload: String,
+    },
     /// A platform declares more than one collection epoch.
     ///
     /// Collection measures one epoch per platform. Two would make "the epoch
@@ -406,6 +453,24 @@ impl std::fmt::Display for ManifestError {
             } => write!(
                 f,
                 "epoch {epoch} on {platform} declares an invalid process target for workload \
+                 {workload:?}"
+            ),
+            ManifestError::UnknownRatchetWorkload {
+                platform,
+                epoch,
+                workload,
+            } => write!(
+                f,
+                "epoch {epoch} on {platform} declares a process ratchet for undeclared workload \
+                 {workload:?}"
+            ),
+            ManifestError::InvalidProcessElapsedRatchet {
+                platform,
+                epoch,
+                workload,
+            } => write!(
+                f,
+                "epoch {epoch} on {platform} declares an invalid process ratchet for workload \
                  {workload:?}"
             ),
             ManifestError::DuplicateCollectionEpoch {
@@ -593,6 +658,29 @@ impl Manifest {
                     });
                 }
             }
+            for (workload, ratchet) in &epoch.process_elapsed_ratchets {
+                if !declared.contains(&workload.as_str()) {
+                    return Err(ManifestError::UnknownRatchetWorkload {
+                        platform: epoch.platform.clone(),
+                        epoch: epoch.id,
+                        workload: workload.clone(),
+                    });
+                }
+                if ratchet.baseline_process_elapsed_ns == 0
+                    || ratchet.process_elapsed_limit_ns < ratchet.baseline_process_elapsed_ns
+                    || ratchet.reference_run.trim().is_empty()
+                    || epoch
+                        .baseline
+                        .as_ref()
+                        .is_none_or(|baseline| baseline.run != ratchet.reference_run)
+                {
+                    return Err(ManifestError::InvalidProcessElapsedRatchet {
+                        platform: epoch.platform.clone(),
+                        epoch: epoch.id,
+                        workload: workload.clone(),
+                    });
+                }
+            }
         }
         Ok(())
     }
@@ -767,6 +855,34 @@ window = 10
             .process_elapsed_targets["caldera"];
         assert_eq!(target.process_elapsed_ns, 250_000_000);
         assert_eq!(target.reference, "ADR-0071");
+    }
+
+    #[test]
+    fn a_ratchet_must_name_the_epochs_immutable_baseline_run() {
+        let text = format!(
+            "{SUITE}{EPOCH}\n\
+             [epoch.baseline]\n\
+             commit = \"abc123\"\n\
+             run = \"deadbeef\"\n\n\
+             [epoch.process_elapsed_ratchets.caldera]\n\
+             baseline_process_elapsed_ns = 250000000\n\
+             baseline_mad_ns = 1000000\n\
+             process_elapsed_limit_ns = 256000000\n\
+             reference_run = \"deadbeef\"\n"
+        );
+        let manifest = Manifest::parse(&text).expect("ratchet names the baseline run");
+        let ratchet = &manifest
+            .epoch("x86_64-linux", 1)
+            .unwrap()
+            .process_elapsed_ratchets["caldera"];
+        assert_eq!(ratchet.baseline_process_elapsed_ns, 250_000_000);
+        assert_eq!(ratchet.reference_run, "deadbeef");
+
+        let mismatched = text.replace("reference_run = \"deadbeef\"", "reference_run = \"other\"");
+        assert!(matches!(
+            Manifest::parse(&mismatched),
+            Err(ManifestError::InvalidProcessElapsedRatchet { .. })
+        ));
     }
 
     #[test]

--- a/crates/rue-perf-schema/src/validate.rs
+++ b/crates/rue-perf-schema/src/validate.rs
@@ -24,6 +24,7 @@ use std::collections::BTreeMap;
 use crate::RUN_SCHEMA_VERSION;
 use crate::manifest::Manifest;
 use crate::run::{FailureRecord, Phase, RunObject, Sample};
+use crate::stats::median;
 
 /// A reason a run may not enter a series at all.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -466,6 +467,57 @@ pub fn validate_run(manifest: &Manifest, run: &RunObject) -> ValidationOutcome {
         invalid_samples,
         completeness,
     }
+}
+
+/// A comparable, publishable run exceeded a reviewed non-regression ratchet.
+///
+/// This is deliberately not a [`ValidationError`]: the raw run belongs in its
+/// series and is the evidence of the regression. Collection publishes it, then
+/// fails its gate so the regression is visible instead of freezing the chart.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ProcessElapsedRegression {
+    pub workload: String,
+    pub current_median_ns: u64,
+    pub limit_ns: u64,
+}
+
+/// Evaluate fixed fresh-process ratchets for an otherwise validated run.
+pub fn process_elapsed_regressions(
+    manifest: &Manifest,
+    run: &RunObject,
+    outcome: &ValidationOutcome,
+) -> Vec<ProcessElapsedRegression> {
+    if !outcome.is_appendable() {
+        return Vec::new();
+    }
+    let Some(epoch) = manifest.epoch(&run.identity.platform, run.identity.epoch) else {
+        return Vec::new();
+    };
+    let mut regressions = Vec::new();
+    for (workload, ratchet) in &epoch.process_elapsed_ratchets {
+        if !outcome.publishes_workload(workload) {
+            continue;
+        }
+        let Some(observation) = run.observation(workload) else {
+            continue;
+        };
+        let values: Vec<u64> = observation
+            .samples
+            .iter()
+            .map(|sample| sample.process_elapsed_ns / u64::from(sample.batch_size).max(1))
+            .collect();
+        let Some(current_median_ns) = median(&values) else {
+            continue;
+        };
+        if current_median_ns > ratchet.process_elapsed_limit_ns {
+            regressions.push(ProcessElapsedRegression {
+                workload: workload.clone(),
+                current_median_ns,
+                limit_ns: ratchet.process_elapsed_limit_ns,
+            });
+        }
+    }
+    regressions
 }
 
 fn check_boundary_evidence(
@@ -1000,6 +1052,52 @@ window = 10
         assert!(outcome.is_appendable());
         assert!(outcome.publishes_headline());
         assert!(outcome.publishes_workload("caldera"));
+    }
+
+    fn manifest_with_caldera_ratchet(center: u64, mad: u64) -> Manifest {
+        Manifest::parse(&format!(
+            "{MANIFEST}\n\
+             [epoch.baseline]\n\
+             commit = \"{}\"\n\
+             run = \"baseline-run\"\n\n\
+             [epoch.process_elapsed_ratchets.caldera]\n\
+             baseline_process_elapsed_ns = {center}\n\
+             baseline_mad_ns = {mad}\n\
+             process_elapsed_limit_ns = {}\n\
+             reference_run = \"baseline-run\"\n",
+            "a".repeat(40),
+            center.saturating_add(mad.saturating_mul(6))
+        ))
+        .expect("ratcheted manifest")
+    }
+
+    #[test]
+    fn a_material_fresh_process_regression_is_publishable_but_fails_the_ratchet() {
+        let manifest = manifest_with_caldera_ratchet(800_000_000, 1_000_000);
+        let run = sample_run();
+        let outcome = validate_run(&manifest, &run);
+        assert!(outcome.is_appendable());
+        assert!(matches!(
+            process_elapsed_regressions(&manifest, &run, &outcome).as_slice(),
+            [ProcessElapsedRegression {
+                workload,
+                current_median_ns: 905_001_000,
+                limit_ns: 806_000_000,
+            }] if workload == "caldera"
+        ));
+    }
+
+    #[test]
+    fn observations_below_the_fixed_limit_pass_the_ratchet() {
+        for manifest in [
+            manifest_with_caldera_ratchet(1_000_000_000, 1_000_000),
+            manifest_with_caldera_ratchet(900_000_000, 100_000_000),
+        ] {
+            let run = sample_run();
+            let outcome = validate_run(&manifest, &run);
+            assert!(outcome.is_appendable());
+            assert!(process_elapsed_regressions(&manifest, &run, &outcome).is_empty());
+        }
     }
 
     #[test]

--- a/docs/designs/0071-release-quality-compiler-performance-contract.md
+++ b/docs/designs/0071-release-quality-compiler-performance-contract.md
@@ -414,7 +414,7 @@ the fresh-process result.
 
 ## Implementation Phases
 
-- [ ] **Phase 1: Pin the reference regime, publish the frozen Lattice workload
+- [x] **Phase 1: Pin the reference regime, publish the frozen Lattice workload
   and target dashboard, establish the baseline ratchet, and produce the
   critical-path scaling report** — RUE-1475 and RUE-1478.
 - [ ] **Phase 2: Publish the semantic-to-CFG ownership and repetition audit** —

--- a/docs/notes/adr-0071-phase-1-reference-baseline.md
+++ b/docs/notes/adr-0071-phase-1-reference-baseline.md
@@ -1,0 +1,84 @@
+# ADR-0071 Phase 1 reference baseline
+
+This report closes the measurement phase of ADR-0071. It records the first
+complete `fresh_source_to_native_v1` observations from the release ThinLTO
+compiler, compiling frozen Lattice with Rue `-O3` through successful native
+output publication. The boundary proof rejects retained sessions, daemons,
+precompiled artifacts, hidden cache hits, alternate pipelines, and incomplete
+stage or input provenance.
+
+## Reference result
+
+Hosted collection [run 31659335914](https://github.com/rue-language/rue/actions/runs/31659335914)
+measured commit `72d2155a57046f6a2ca05b357e8f8d4d5c32b7a4`. All three platform lanes
+completed and their canonical run objects entered epoch 5:
+
+| platform | run object | Lattice process median | peak RSS median |
+| --- | --- | ---: | ---: |
+| x86_64 Linux, reference | `9b7d4bdb4bf398301fa5bd90b6a57e75f4764a982aacf2723c485b59b5398394` | 2,887.26 ms | 310.9 MiB |
+| AArch64 Linux, directional | `08deff0a5bd6beb187063db4ed31d70634067cf9aa9d5c453a78be828fa953e0` | 3,096.26 ms | 308.9 MiB |
+| AArch64 macOS, directional | `1404128c40051b386dd7b545c9eb555333004f0774ec99689df1fce296042f18` | 1,940.71 ms | 378.9 MiB |
+
+Only x86_64 Linux adjudicates the absolute target. Its three Lattice process
+samples were 2,914.57, 2,887.26, and 2,878.98 ms, giving an 8.28 ms MAD. The
+manifest keeps the 250 ms product goal separate from a fixed initial
+non-regression gate of 3,022.38 ms. The gate is the baseline median plus six
+times the hosted calibration's 0.78% relative MAD; the baseline run's own three
+samples had an 8.28 ms MAD. It never widens from a later noisy observation. A
+regression run remains comparable and is published as evidence, but fails
+collection after upload.
+
+The reference build is therefore 11.55 times slower than the 250 ms goal and
+uses 2.43 times the provisional 128 MiB envelope. It is also above the first
+500 ms / 256 MiB milestone, so both latency and retained memory are active work.
+
+## Worker scaling
+
+Hosted scaling [run 31659468677](https://github.com/rue-language/rue/actions/runs/31659468677)
+measured the same commit and boundary across one, two, four, eight, and
+automatic workers on a four-core x86_64 Linux runner. Its raw report has content
+address `af2c1f5262fd03447d825c294075a6d4dbd53456d02bc04d1333474099b59189`.
+Each cell is the median of three independent fresh compiler processes; output
+and one-worker deterministic work were exact.
+
+| Lattice workers | process | compiler root | peak RSS | utilization |
+| --- | ---: | ---: | ---: | ---: |
+| 1 | 3,069.85 ms | 2,848.06 ms | 311.3 MiB | 78.8% |
+| 2 | 2,551.04 ms | 2,337.79 ms | 310.3 MiB | 57.4% |
+| 4 | 2,181.95 ms | 1,952.47 ms | 313.1 MiB | 43.8% |
+| 8 | 2,279.01 ms | 2,049.66 ms | 318.1 MiB | 34.0% |
+| automatic (4) | 2,246.81 ms | 2,012.30 ms | 314.6 MiB | 43.1% |
+
+Automatic workers improve Lattice process latency by 1.37 times and compiler
+root latency by 1.42 times. The smaller programs show the same bounded shape:
+automatic-worker process speedups are 1.31 times for Ruelex, 1.28 times for
+Mosaic, and 1.39 times for Harbor. Four workers are near the best point; asking
+eight workers to contend on four cores is slower for every maintained program.
+
+## What limits scaling
+
+Parallelism is useful but not the dominant route to the 250 ms goal:
+
+- Lattice CFG/optimization falls from 838.33 to 415.18 ms and backend work from
+  369.50 to 148.44 ms at automatic workers. Those parts scale materially.
+- The semantic phase falls only from 1,253.49 to 1,106.75 ms. Summed semantic
+  body time grows from 722.62 to 1,454.58 ms while wall time barely moves,
+  showing coordination and repeated/shared work rather than an absence of body
+  parallelism.
+- Query-worker utilization falls from 78.8% on one worker to 43.1% across four
+  automatic workers. Ready-wait maximum improves from 695.45 to 269.86 ms, but
+  the longest producer chain remains ten nodes and total active work rises.
+- Toolchain acquisition remains 1,280.70 ms at one worker and 1,136.40 ms at
+  automatic workers. It sits inside the semantic ownership boundary and is the
+  leading current-source audit target, not linking.
+- Linking is 24.33 ms at one worker and 25.60 ms at automatic workers. It is
+  measurable, but cannot explain the multi-second gap.
+- External process time outside compiler root is roughly 220–235 ms for
+  Lattice, so process/orchestration cost alone already approaches the final
+  250 ms whole-build goal and must be decomposed later.
+
+The next step is therefore the semantic-to-CFG ownership and repetition audit
+in RUE-1474, using the exact work counts and these critical-path observations.
+It should prioritize toolchain/semantic ownership and repeated immutable fact
+observation while preserving body parallelism, fine invalidation, one canonical
+pipeline, and exact output.

--- a/docs/process/compiler-scaling.md
+++ b/docs/process/compiler-scaling.md
@@ -146,6 +146,12 @@ Compare rows only within the same target, worker setting, and manifest revision,
 runner fingerprint change as advisory because GitHub-hosted hardware is not a
 controlled machine.
 
+The accepted ADR-0071 Phase 1 reference observation and interpretation live in
+[`docs/notes/adr-0071-phase-1-reference-baseline.md`](../notes/adr-0071-phase-1-reference-baseline.md).
+It records the first protocol-v2 hosted baseline, the fixed non-regression
+ratchet, and the five-worker critical-path result that selects the next
+semantic-to-CFG ownership audit.
+
 Every workload row includes a shape id derived from its root path and the
 compiler-produced file/module/function and source-size counts. A changed shape
 id marks the timing comparison as advisory even if someone forgot to advance

--- a/performance/manifest.toml
+++ b/performance/manifest.toml
@@ -639,9 +639,24 @@ batch_size = 1
 process_elapsed_ns = 250000000
 reference = "ADR-0071"
 
+# First protocol-v2 reference observation, collected on hosted ubuntu-24.04
+# from commit 72d2155a57046f6a2ca05b357e8f8d4d5c32b7a4. The fixed gate is the
+# 2,887.26 ms process median plus six times the hosted calibration's 0.78%
+# relative MAD, matching this epoch's k without allowing a later noisy run to
+# widen the gate. The baseline run's own three samples had an 8.28 ms MAD.
+[epoch.process_elapsed_ratchets.lattice]
+baseline_process_elapsed_ns = 2887259763
+baseline_mad_ns = 8281274
+process_elapsed_limit_ns = 3022383520
+reference_run = "9b7d4bdb4bf398301fa5bd90b6a57e75f4764a982aacf2723c485b59b5398394"
+
 [epoch.flagging]
 k = 6.0
 window = 5
+
+[epoch.baseline]
+commit = "72d2155a57046f6a2ca05b357e8f8d4d5c32b7a4"
+run = "9b7d4bdb4bf398301fa5bd90b6a57e75f4764a982aacf2723c485b59b5398394"
 
 [[epoch]]
 id = 5
@@ -684,6 +699,10 @@ batch_size = 1
 k = 5.0
 window = 3
 
+[epoch.baseline]
+commit = "72d2155a57046f6a2ca05b357e8f8d4d5c32b7a4"
+run = "08deff0a5bd6beb187063db4ed31d70634067cf9aa9d5c453a78be828fa953e0"
+
 [[epoch]]
 id = 5
 collection = true
@@ -724,3 +743,7 @@ batch_size = 1
 [epoch.flagging]
 k = 4.0
 window = 5
+
+[epoch.baseline]
+commit = "72d2155a57046f6a2ca05b357e8f8d4d5c32b7a4"
+run = "1404128c40051b386dd7b545c9eb555333004f0774ec99689df1fce296042f18"

--- a/scripts/validate-release-configuration.py
+++ b/scripts/validate-release-configuration.py
@@ -30,6 +30,7 @@ COLLECTION_BOUNDARY_SNIPPETS = (
     "--target-platforms //platforms:release",
     'RUE="$(scripts/rue-bin --target-platforms //platforms:release)"',
     "--manifest performance/manifest.toml",
+    'if [ "$status" -eq 4 ]',
 )
 SCALING_BOUNDARY_SNIPPETS = (
     "schema_version = 3",

--- a/website/static/performance.js
+++ b/website/static/performance.js
@@ -663,6 +663,10 @@
       targeted.forEach(function (entry) {
         values.push(entry.epoch.process_elapsed_targets[state.workload].process_elapsed_ns);
       });
+      series.forEach(function (entry) {
+        var ratchet = (entry.epoch.process_elapsed_ratchets || {})[state.workload];
+        if (ratchet) { values.push(ratchet.process_elapsed_limit_ns); }
+      });
       var hi = Math.max.apply(null, values) * 1.12;
       var x = function (i) { return 40 + (i / Math.max(series.length - 1, 1)) * 840; };
       var y = function (v) { return 210 - (v / hi) * 180; };
@@ -708,6 +712,31 @@
         svg.appendChild(label);
       });
 
+      // The ratchet is distinct from the product target: it preserves the best
+      // accepted baseline while the target shows where Rue is going.
+      var drawnRatchets = {};
+      series.forEach(function (entry, i) {
+        var ratchet = (entry.epoch.process_elapsed_ratchets || {})[state.workload];
+        if (!ratchet || drawnRatchets[entry.epoch.epoch]) { return; }
+        drawnRatchets[entry.epoch.epoch] = true;
+        var last = i;
+        while (last + 1 < series.length &&
+               series[last + 1].epoch.epoch === entry.epoch.epoch) { last++; }
+        var left = i === 0 ? 40 : (x(i - 1) + x(i)) / 2;
+        var right = last === series.length - 1 ? 880 : (x(last) + x(last + 1)) / 2;
+        svg.appendChild(element("line", {
+          x1: left, y1: y(ratchet.process_elapsed_limit_ns),
+          x2: right, y2: y(ratchet.process_elapsed_limit_ns),
+          stroke: "#b45309", "stroke-width": 2, "stroke-dasharray": "2 4"
+        }));
+        var label = element("text", {
+          x: left + 4, y: y(ratchet.process_elapsed_limit_ns) + 14,
+          fill: "#b45309", "font-size": 11
+        });
+        label.textContent = "ratchet: " + fmtMs(ratchet.process_elapsed_limit_ns);
+        svg.appendChild(label);
+      });
+
       series.forEach(function (entry, i) {
         svg.appendChild(element("circle", {
           cx: x(i), cy: y(entry.point.workloads[state.workload].process_elapsed_ns), r: 2.5,
@@ -741,6 +770,15 @@
           lines.push(target.reference + " target: " + fmtMs(target.process_elapsed_ns) +
             ". This point is " + fmtMs(Math.abs(difference)) +
             (difference <= 0 ? " under the ceiling." : " over the ceiling."));
+        }
+        var ratchet = (entry.epoch.process_elapsed_ratchets || {})[state.workload];
+        if (ratchet) {
+          var ratchetDifference = elapsed - ratchet.baseline_process_elapsed_ns;
+          lines.push("Non-regression ratchet: " + fmtMs(ratchet.baseline_process_elapsed_ns) +
+            " baseline, ± " + fmtMs(ratchet.baseline_mad_ns) + " MAD; fixed gate " +
+            fmtMs(ratchet.process_elapsed_limit_ns) + ". This point is " +
+            fmtMs(Math.abs(ratchetDifference)) +
+            (ratchetDifference <= 0 ? " faster than the ratchet." : " slower than its center."));
         }
         lines.push(pinnedNote(state.pinned.target));
         setTooltip(tooltip, lines);
@@ -776,7 +814,8 @@
         " against its declared release target. Use left and right arrow keys to move " +
         "between measured commits.");
       caption.textContent = series.length + " measured commit(s). Green is external process " +
-        "time; the dashed violet rule is the absolute target for this reference epoch only.";
+        "time; violet is the absolute target and amber is the noise-aware non-regression " +
+        "ratchet for this reference epoch only.";
       selectMark(state.targetCursor === null
         ? series.length - 1
         : Math.min(state.targetCursor, series.length - 1));

--- a/website/templates/performance.html
+++ b/website/templates/performance.html
@@ -126,6 +126,8 @@
         Fresh-process wall time from process spawn through successful native
         output and exit. Absolute targets appear only on the platform epoch
         that adjudicates them; other platforms remain useful directional series.
+        A separate fixed ratchet preserves the best accepted baseline without
+        mistaking normal hosted-runner noise for a regression.
       </p>
       <figure style="margin-top: 0.75rem;">
         <svg id="perf-target" role="img" width="100%" height="240" viewBox="0 0 900 240"


### PR DESCRIPTION
## Summary

- pin the first complete protocol-v2 hosted baselines for all three collection platforms
- enforce a fixed, noise-calibrated x86 fresh-process ratchet while still publishing regression evidence
- publish the five-worker critical-path report and mark ADR-0071 Phase 1 complete
- show the baseline ratchet separately from the 250 ms product target on the dashboard

The reference x86 Lattice median is 2,887.26 ms at 310.9 MiB peak RSS. Automatic workers improve the hosted scaling run from 3,069.85 ms to 2,246.81 ms, but utilization falls to 43.1%; semantic/toolchain ownership is the next measured focus, while linking remains about 25 ms.

Hosted evidence: [collection run 31659335914](https://github.com/rue-language/rue/actions/runs/31659335914), [scaling run 31659468677](https://github.com/rue-language/rue/actions/runs/31659468677).

Fixes RUE-1475.