### PR TITLE
RUE-1473: partition durable materialization work

### DIFF
--- a/crates/rue-bench/src/scaling.rs
+++ b/crates/rue-bench/src/scaling.rs
@@ -505,14 +505,18 @@ fn render(report: &ScalingReport) -> String {
             work.const_facts,
         ));
     }
-    out.push_str("\n| workload | durable materializations | anonymous facts | producer facts | toolchain facts |\n");
+    out.push_str("\n| workload | durable materializations total (const/nominal/function/method) | anonymous facts | producer facts | toolchain facts |\n");
     out.push_str("| --- | ---: | ---: | ---: | ---: |\n");
     for observation in reference_observations(report) {
         let work = observation.work.semantic_provider;
         out.push_str(&format!(
-            "| {} | {} | {} | {} | {} |\n",
+            "| {} | {} ({}/{}/{}/{}) | {} | {} | {} |\n",
             observation.workload,
             work.materializations,
+            work.const_materializations,
+            work.nominal_materializations,
+            work.function_materializations,
+            work.method_materializations,
             work.anonymous_facts,
             work.producer_facts,
             work.toolchain_facts,
@@ -739,6 +743,10 @@ mod tests {
                         type_facts: 17,
                         const_facts: 19,
                         materializations: 23,
+                        const_materializations: 2,
+                        nominal_materializations: 3,
+                        function_materializations: 11,
+                        method_materializations: 7,
                         anonymous_facts: 29,
                         producer_facts: 31,
                         toolchain_facts: 37,
@@ -817,6 +825,7 @@ mod tests {
         assert!(rendered.contains("nodes/token"));
         assert!(rendered.contains("Semantic provider observations"));
         assert!(rendered.contains("durable materializations"));
+        assert!(rendered.contains("23 (2/3/11/7)"));
         assert!(rendered.contains("Semantic reachability scheduling"));
         assert!(rendered.contains("keys/batch"));
         assert!(rendered.contains("CFG materialization preparation"));

--- a/crates/rue-cli-tests/cases/benchmark_json.toml
+++ b/crates/rue-cli-tests/cases/benchmark_json.toml
@@ -15,7 +15,7 @@ args = ["--benchmark-json", "main.rue", "-o", "prog"]
 env = { RUST_LOG = "error" }
 exit_code = 42
 compile_stdout_contains = [
-  '"schema_version":12',
+  '"schema_version":13',
   '"compiler_build_profile":',
   '"timing_model":"inclusive_spans"',
   # The additive partition, which is the only model that may be stacked. Its

--- a/crates/rue-compiler/src/revisioned_query_database.rs
+++ b/crates/rue-compiler/src/revisioned_query_database.rs
@@ -761,7 +761,10 @@ pub(crate) struct ProviderObservationCounters {
     signature_facts: std::sync::atomic::AtomicU64,
     type_facts: std::sync::atomic::AtomicU64,
     const_facts: std::sync::atomic::AtomicU64,
-    materializations: std::sync::atomic::AtomicU64,
+    const_materializations: std::sync::atomic::AtomicU64,
+    nominal_materializations: std::sync::atomic::AtomicU64,
+    function_materializations: std::sync::atomic::AtomicU64,
+    method_materializations: std::sync::atomic::AtomicU64,
     anonymous_facts: std::sync::atomic::AtomicU64,
     producer_facts: std::sync::atomic::AtomicU64,
     toolchain_facts: std::sync::atomic::AtomicU64,
@@ -774,6 +777,10 @@ impl ProviderObservationCounters {
         let signature_facts = self.signature_facts.load(Relaxed);
         let type_facts = self.type_facts.load(Relaxed);
         let const_facts = self.const_facts.load(Relaxed);
+        let const_materializations = self.const_materializations.load(Relaxed);
+        let nominal_materializations = self.nominal_materializations.load(Relaxed);
+        let function_materializations = self.function_materializations.load(Relaxed);
+        let method_materializations = self.method_materializations.load(Relaxed);
         crate::unstable::ProviderObservationMetrics {
             name_lookups: self.name_lookups.load(Relaxed),
             import_lookups: self.import_lookups.load(Relaxed),
@@ -787,7 +794,14 @@ impl ProviderObservationCounters {
             signature_facts,
             type_facts,
             const_facts,
-            materializations: self.materializations.load(Relaxed),
+            materializations: const_materializations
+                .saturating_add(nominal_materializations)
+                .saturating_add(function_materializations)
+                .saturating_add(method_materializations),
+            const_materializations,
+            nominal_materializations,
+            function_materializations,
+            method_materializations,
             anonymous_facts: self.anonymous_facts.load(Relaxed),
             producer_facts: self.producer_facts.load(Relaxed),
             toolchain_facts: self.toolchain_facts.load(Relaxed),
@@ -22125,7 +22139,7 @@ impl rue_air::DurableConstSource<crate::StableDefinitionKey, ModuleId>
     ) -> Option<rue_air::DurableConst<crate::StableDefinitionKey, ModuleId>> {
         self.provider
             .meter()
-            .materializations
+            .const_materializations
             .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
         use rue_air::BodyFactProvider;
         let candidate = self.candidate(key)?;
@@ -22188,7 +22202,7 @@ impl rue_air::DurableNominalSource<crate::StableDefinitionKey, ModuleId>
     ) -> Option<rue_air::DurableNominal<crate::StableDefinitionKey, ModuleId>> {
         self.provider
             .meter()
-            .materializations
+            .nominal_materializations
             .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
         use crate::semantic_query_nucleus::DeclarationSignatureProjection as Projection;
         use rue_air::BodyFactProvider;
@@ -22256,7 +22270,7 @@ impl rue_air::DurableCallableSource<crate::StableDefinitionKey, ModuleId>
     ) -> Option<rue_air::DurableFunction<crate::StableDefinitionKey, ModuleId>> {
         self.provider
             .meter()
-            .materializations
+            .function_materializations
             .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
         let candidate = self.candidate(key)?;
         let signature = self.signature_for_candidate(&candidate.declaration)?;
@@ -22293,7 +22307,7 @@ impl rue_air::DurableCallableSource<crate::StableDefinitionKey, ModuleId>
     ) -> Option<rue_air::DurableMethod<crate::StableDefinitionKey, ModuleId>> {
         self.provider
             .meter()
-            .materializations
+            .method_materializations
             .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
         let owner = key.owner()?;
         let signature = self.signature(key)?;

--- a/crates/rue-compiler/src/session.rs
+++ b/crates/rue-compiler/src/session.rs
@@ -8063,6 +8063,14 @@ mod tests {
         assert_eq!(metrics.signature_facts, 6, "{metrics:?}");
         assert_eq!(metrics.materializations, 6, "{metrics:?}");
         assert_eq!(
+            metrics.materializations,
+            metrics.const_materializations
+                + metrics.nominal_materializations
+                + metrics.function_materializations
+                + metrics.method_materializations,
+            "the durable materialization aggregate must be exactly partitioned by declaration kind"
+        );
+        assert_eq!(
             metrics.declaration_facts,
             metrics.identity_facts
                 + metrics.signature_facts
@@ -8100,6 +8108,14 @@ mod tests {
         assert_eq!(metrics.identity_facts, 10, "{metrics:?}");
         assert_eq!(metrics.signature_facts, 10, "{metrics:?}");
         assert_eq!(metrics.materializations, 10, "{metrics:?}");
+        assert_eq!(
+            metrics.materializations,
+            metrics.const_materializations
+                + metrics.nominal_materializations
+                + metrics.function_materializations
+                + metrics.method_materializations,
+            "the durable materialization aggregate must be exactly partitioned by declaration kind"
+        );
     }
 
     #[test]

--- a/crates/rue-compiler/src/unstable.rs
+++ b/crates/rue-compiler/src/unstable.rs
@@ -246,6 +246,14 @@ pub struct ProviderObservationMetrics {
     pub const_facts: u64,
     /// Durable facts materialized into a body-local overlay.
     pub materializations: u64,
+    /// Constant facts materialized into a body-local overlay.
+    pub const_materializations: u64,
+    /// Named nominal facts materialized into a body-local overlay.
+    pub nominal_materializations: u64,
+    /// Free-function facts materialized into a body-local overlay.
+    pub function_materializations: u64,
+    /// Method facts materialized into a body-local overlay.
+    pub method_materializations: u64,
     /// Anonymous-nominal fact observations.
     pub anonymous_facts: u64,
     /// Producer-body fact observations.

--- a/crates/rue-perf-schema/src/scaling.rs
+++ b/crates/rue-perf-schema/src/scaling.rs
@@ -15,7 +15,7 @@ use crate::{
 };
 
 /// Version of the scaling-report wire format.
-pub const SCALING_REPORT_SCHEMA_VERSION: u32 = 12;
+pub const SCALING_REPORT_SCHEMA_VERSION: u32 = 13;
 
 /// The lower-frequency scaling suite declaration.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -236,8 +236,20 @@ pub struct SemanticProviderWork {
     pub type_facts: u64,
     /// Exact constant and compile-time reduction reads.
     pub const_facts: u64,
-    /// Durable facts copied into body-local representations.
+    /// Durable facts materialized into body-local representations.
     pub materializations: u64,
+    /// Constant facts materialized into body-local representations.
+    #[serde(default)]
+    pub const_materializations: u64,
+    /// Named nominal facts materialized into body-local representations.
+    #[serde(default)]
+    pub nominal_materializations: u64,
+    /// Free-function facts materialized into body-local representations.
+    #[serde(default)]
+    pub function_materializations: u64,
+    /// Method facts materialized into body-local representations.
+    #[serde(default)]
+    pub method_materializations: u64,
     /// Anonymous-nominal fact reads.
     pub anonymous_facts: u64,
     /// Anonymous-producer body fact reads.
@@ -410,5 +422,29 @@ question = "small maintained compiler frontend"
             decoded.cfg_retained_charge,
             CfgRetainedChargeWork::default()
         );
+    }
+
+    #[test]
+    fn older_semantic_provider_work_defaults_the_materialization_partition() {
+        let mut encoded = serde_json::to_value(SemanticProviderWork {
+            materializations: 23,
+            ..SemanticProviderWork::default()
+        })
+        .unwrap();
+        let object = encoded.as_object_mut().unwrap();
+        for field in [
+            "const_materializations",
+            "nominal_materializations",
+            "function_materializations",
+            "method_materializations",
+        ] {
+            object.remove(field);
+        }
+        let decoded: SemanticProviderWork = serde_json::from_value(encoded).unwrap();
+        assert_eq!(decoded.materializations, 23);
+        assert_eq!(decoded.const_materializations, 0);
+        assert_eq!(decoded.nominal_materializations, 0);
+        assert_eq!(decoded.function_materializations, 0);
+        assert_eq!(decoded.method_materializations, 0);
     }
 }

--- a/crates/rue/src/main.rs
+++ b/crates/rue/src/main.rs
@@ -1088,6 +1088,10 @@ fn benchmark_compiler_work(
             type_facts: provider.type_facts,
             const_facts: provider.const_facts,
             materializations: provider.materializations,
+            const_materializations: provider.const_materializations,
+            nominal_materializations: provider.nominal_materializations,
+            function_materializations: provider.function_materializations,
+            method_materializations: provider.method_materializations,
             anonymous_facts: provider.anonymous_facts,
             producer_facts: provider.producer_facts,
             toolchain_facts: provider.toolchain_facts,
@@ -1715,6 +1719,10 @@ mod tests {
                 type_facts: 17,
                 const_facts: 19,
                 materializations: 23,
+                const_materializations: 2,
+                nominal_materializations: 3,
+                function_materializations: 11,
+                method_materializations: 7,
                 anonymous_facts: 29,
                 producer_facts: 31,
                 toolchain_facts: 37,
@@ -1781,6 +1789,17 @@ mod tests {
                 + projected.semantic_provider.const_facts
         );
         assert_eq!(projected.semantic_provider.materializations, 23);
+        assert_eq!(projected.semantic_provider.const_materializations, 2);
+        assert_eq!(projected.semantic_provider.nominal_materializations, 3);
+        assert_eq!(projected.semantic_provider.function_materializations, 11);
+        assert_eq!(projected.semantic_provider.method_materializations, 7);
+        assert_eq!(
+            projected.semantic_provider.materializations,
+            projected.semantic_provider.const_materializations
+                + projected.semantic_provider.nominal_materializations
+                + projected.semantic_provider.function_materializations
+                + projected.semantic_provider.method_materializations
+        );
         assert_eq!(projected.semantic_provider.anonymous_facts, 29);
         assert_eq!(projected.semantic_provider.producer_facts, 31);
         assert_eq!(projected.semantic_provider.toolchain_facts, 37);

--- a/crates/rue/src/timing.rs
+++ b/crates/rue/src/timing.rs
@@ -764,7 +764,7 @@ impl TimingData {
         };
 
         BenchmarkTiming {
-            schema_version: 12,
+            schema_version: 13,
             timing_model: "inclusive_spans",
             phase_accounting,
             metadata,
@@ -2144,7 +2144,7 @@ mod tests {
         data.record("lexer", Duration::from_millis(100));
 
         let json = data.to_json_with_metrics("x86_64-linux", "0.1.0", None, None, None);
-        assert!(json.contains("\"schema_version\":12"));
+        assert!(json.contains("\"schema_version\":13"));
         assert!(json.contains(&format!(
             "\"compiler_build_profile\":\"{COMPILER_BUILD_PROFILE}\""
         )));
@@ -2822,7 +2822,7 @@ mod phase_accounting_tests {
 
         let timing =
             data.to_benchmark_timing_with_metrics("probe-target", "probe", None, None, None);
-        assert_eq!(timing.schema_version, 12);
+        assert_eq!(timing.schema_version, 13);
         assert_eq!(
             timing.metadata.compiler_build_profile,
             COMPILER_BUILD_PROFILE

--- a/docs/process/compiler-scaling.md
+++ b/docs/process/compiler-scaling.md
@@ -100,7 +100,10 @@ production body-fact provider. The scaling probe performs no extra lookup or
 materialization to collect them. Keeping lookup demand, exact fact-family
 reads, and durable body-local materializations separate lets a follow-up tell
 whether body analysis is asking for the same fact too often or merely paying
-too much to represent each necessary answer.
+too much to represent each necessary answer. The materialization total is
+exactly partitioned into constant, named-nominal, free-function, and method
+events so representation changes can target the declaration kind which owns
+the measured traffic.
 
 The CFG-materialization table separates immutable lookup preparation from the
 exact fact-closure selections that remain body-local. Its selections-per-build


### PR DESCRIPTION
## Summary

- partition durable body-local materializations into const, nominal, function, and method events without adding a second increment per event
- publish the exact partition in benchmark JSON and scaling Markdown
- bump the affected benchmark and scaling wire schemas

## Validation

- `scripts/rue fmt`
- `scripts/rue unit compiler provider_observation_counters_record_exact_production_work`
- `scripts/rue unit bench markdown_states_the_regime_and_runtime_separation`
- `./buck2 test //crates/rue:rue-test`
- `scripts/rue cli benchmark_json`
- `scripts/rue quick` (all targets passed after the two intentional schema-version assertions were updated; the affected target was rerun directly)

Refs RUE-1473.