### PR TITLE
RUE-1473: share durable nominal payloads

### DIFF
--- a/crates/rue-air/src/sema/body_identity.rs
+++ b/crates/rue-air/src/sema/body_identity.rs
@@ -107,14 +107,16 @@ use crate::{
 #[derive(Debug, Clone)]
 pub enum DurableNominalBody<K, M> {
     Struct {
-        /// Fields in declaration order: source name and durable field type.
-        fields: Vec<(Arc<str>, SemanticImportType<K, M>)>,
+        /// Canonically shared fields in declaration order: source name and
+        /// durable field type.
+        fields: Arc<[(Arc<str>, SemanticImportType<K, M>)]>,
         is_copy: bool,
         is_linear: bool,
     },
     Enum {
-        /// Variants in declaration order: source name and durable payload types.
-        variants: Vec<(Arc<str>, Vec<SemanticImportType<K, M>>)>,
+        /// Canonically shared variants in declaration order: source name and
+        /// durable payload types.
+        variants: Arc<[(Arc<str>, Arc<[SemanticImportType<K, M>]>)]>,
     },
 }
 
@@ -1302,7 +1304,7 @@ where
                     self.type_pool.set_struct_repr_c(id);
                 }
                 let mut resolved = Vec::with_capacity(fields.len());
-                for (field_name, field_ty) in &fields {
+                for (field_name, field_ty) in fields.iter() {
                     let ty = match self.resolve_provider_type(field_ty) {
                         Ok(ty) => ty,
                         Err(err) => {
@@ -1351,9 +1353,9 @@ where
                 );
                 self.record_enum_identity(key.clone(), id);
                 let mut variant_payloads = Vec::with_capacity(variants.len());
-                for (_, payload) in &variants {
+                for (_, payload) in variants.iter() {
                     let mut resolved = Vec::with_capacity(payload.len());
-                    for ty in payload {
+                    for ty in payload.iter() {
                         match self.resolve_provider_type(ty) {
                             Ok(ty) => resolved.push(ty),
                             Err(err) => {
@@ -1447,7 +1449,7 @@ where
                 }
 
                 let mut resolved = Vec::with_capacity(fields.len());
-                for (field_name, field_ty) in &fields {
+                for (field_name, field_ty) in fields.iter() {
                     let ty = match self.resolve(field_ty) {
                         Ok(ty) => ty,
                         Err(err) => {
@@ -1497,9 +1499,9 @@ where
                 self.record_enum_identity(key.clone(), id);
 
                 let mut variant_payloads = Vec::with_capacity(variants.len());
-                for (_, payload) in &variants {
+                for (_, payload) in variants.iter() {
                     let mut resolved = Vec::with_capacity(payload.len());
-                    for ty in payload {
+                    for ty in payload.iter() {
                         match self.resolve(ty) {
                             Ok(ty) => resolved.push(ty),
                             Err(err) => {
@@ -3588,7 +3590,7 @@ mod tests {
         DurableNominalBody::Enum {
             variants: variants
                 .into_iter()
-                .map(|(name, payload)| (Arc::from(name), payload))
+                .map(|(name, payload)| (Arc::from(name), payload.into()))
                 .collect(),
         }
     }

--- a/crates/rue-air/src/sema/provider_body_host.rs
+++ b/crates/rue-air/src/sema/provider_body_host.rs
@@ -1631,14 +1631,14 @@ where
                     .ok_or(crate::SemanticBodyExportFailure::MissingStableIdentity)?;
                 match nominal.body {
                     crate::DurableNominalBody::Struct { fields, .. } => {
-                        for (_, field) in fields {
-                            self.install_anonymous_dependencies(&field, visited_named)?;
+                        for (_, field) in fields.iter() {
+                            self.install_anonymous_dependencies(field, visited_named)?;
                         }
                     }
                     crate::DurableNominalBody::Enum { variants } => {
-                        for (_, payload) in variants {
-                            for field in payload {
-                                self.install_anonymous_dependencies(&field, visited_named)?;
+                        for (_, payload) in variants.iter() {
+                            for field in payload.iter() {
+                                self.install_anonymous_dependencies(field, visited_named)?;
                             }
                         }
                     }
@@ -1713,13 +1713,13 @@ where
                         .insert(ty, (token, key.clone()));
                     match &nominal.body {
                         crate::DurableNominalBody::Struct { fields, .. } => {
-                            for (_, field) in fields {
+                            for (_, field) in fields.iter() {
                                 self.register_import_nominal_identities_inner(field)?;
                             }
                         }
                         crate::DurableNominalBody::Enum { variants } => {
-                            for (_, payload) in variants {
-                                for field in payload {
+                            for (_, payload) in variants.iter() {
+                                for field in payload.iter() {
                                     self.register_import_nominal_identities_inner(field)?;
                                 }
                             }

--- a/crates/rue-bench/src/scaling.rs
+++ b/crates/rue-bench/src/scaling.rs
@@ -505,14 +505,16 @@ fn render(report: &ScalingReport) -> String {
             work.const_facts,
         ));
     }
-    out.push_str("\n| workload | durable materializations total (const/nominal/function/method) | anonymous facts | producer facts | toolchain facts |\n");
+    out.push_str("\n| workload | durable materializations total (shared/owned; const/nominal/function/method) | anonymous facts | producer facts | toolchain facts |\n");
     out.push_str("| --- | ---: | ---: | ---: | ---: |\n");
     for observation in reference_observations(report) {
         let work = observation.work.semantic_provider;
         out.push_str(&format!(
-            "| {} | {} ({}/{}/{}/{}) | {} | {} | {} |\n",
+            "| {} | {} ({}/{}; {}/{}/{}/{}) | {} | {} | {} |\n",
             observation.workload,
             work.materializations,
+            work.shared_payload_materializations,
+            work.owned_payload_materializations,
             work.const_materializations,
             work.nominal_materializations,
             work.function_materializations,
@@ -743,6 +745,8 @@ mod tests {
                         type_facts: 17,
                         const_facts: 19,
                         materializations: 23,
+                        shared_payload_materializations: 3,
+                        owned_payload_materializations: 20,
                         const_materializations: 2,
                         nominal_materializations: 3,
                         function_materializations: 11,
@@ -825,7 +829,7 @@ mod tests {
         assert!(rendered.contains("nodes/token"));
         assert!(rendered.contains("Semantic provider observations"));
         assert!(rendered.contains("durable materializations"));
-        assert!(rendered.contains("23 (2/3/11/7)"));
+        assert!(rendered.contains("23 (3/20; 2/3/11/7)"));
         assert!(rendered.contains("Semantic reachability scheduling"));
         assert!(rendered.contains("keys/batch"));
         assert!(rendered.contains("CFG materialization preparation"));

--- a/crates/rue-cli-tests/cases/benchmark_json.toml
+++ b/crates/rue-cli-tests/cases/benchmark_json.toml
@@ -15,7 +15,7 @@ args = ["--benchmark-json", "main.rue", "-o", "prog"]
 env = { RUST_LOG = "error" }
 exit_code = 42
 compile_stdout_contains = [
-  '"schema_version":13',
+  '"schema_version":14',
   '"compiler_build_profile":',
   '"timing_model":"inclusive_spans"',
   # The additive partition, which is the only model that may be stacked. Its
@@ -45,6 +45,8 @@ compile_stdout_contains = [
   '"compiler_work":',
   '"semantic_provider":',
   '"materializations":',
+  '"shared_payload_materializations":',
+  '"owned_payload_materializations":',
   '"query_runtime":',
   '"validation":',
   '"retention_scan_entries":',

--- a/crates/rue-compiler/src/revisioned_query_database.rs
+++ b/crates/rue-compiler/src/revisioned_query_database.rs
@@ -798,6 +798,10 @@ impl ProviderObservationCounters {
                 .saturating_add(nominal_materializations)
                 .saturating_add(function_materializations)
                 .saturating_add(method_materializations),
+            shared_payload_materializations: nominal_materializations,
+            owned_payload_materializations: const_materializations
+                .saturating_add(function_materializations)
+                .saturating_add(method_materializations),
             const_materializations,
             nominal_materializations,
             function_materializations,
@@ -22223,16 +22227,11 @@ impl rue_air::DurableNominalSource<crate::StableDefinitionKey, ModuleId>
                 is_linear,
                 ..
             } => rue_air::DurableNominalBody::Struct {
-                fields: fields.to_vec(),
+                fields,
                 is_copy,
                 is_linear,
             },
-            Projection::Enum { variants } => rue_air::DurableNominalBody::Enum {
-                variants: variants
-                    .iter()
-                    .map(|(name, payload)| (name.clone(), payload.to_vec()))
-                    .collect(),
-            },
+            Projection::Enum { variants } => rue_air::DurableNominalBody::Enum { variants },
             _ => return None,
         };
         Some(rue_air::DurableNominal {
@@ -24739,14 +24738,14 @@ pub(crate) mod test_support {
                     is_copy,
                     is_linear,
                 } => rue_air::DurableNominalBody::Struct {
-                    fields: fields.iter().map(|(n, t)| (n.clone(), t.clone())).collect(),
+                    fields: fields.clone().into(),
                     is_copy: *is_copy,
                     is_linear: *is_linear,
                 },
                 Payload::Enum { variants } => rue_air::DurableNominalBody::Enum {
                     variants: variants
                         .iter()
-                        .map(|(n, payload)| (n.clone(), payload.to_vec()))
+                        .map(|(n, payload)| (n.clone(), payload.clone().into()))
                         .collect(),
                 },
                 _ => return None,
@@ -32248,6 +32247,59 @@ fn main() -> i32 {
                 None,
             ),
         ))
+    }
+
+    #[test]
+    fn durable_nominal_materialization_shares_the_canonical_signature_payload() {
+        let snapshot = source_snapshot(
+            &[(
+                1,
+                "/main.rue",
+                "main.rue",
+                "struct Point { x: i32, y: i64 }\nfn main() -> i32 { 0 }\n",
+            )],
+            1,
+        );
+        let module = ModuleId::from_logical_path("main.rue").unwrap();
+        let point = crate::StableDefinitionKey::from_stable_parts(
+            module,
+            crate::StableDefinitionNamespace::Type,
+            crate::StableDefinitionKind::Struct,
+            Arc::from("Point"),
+            None,
+        );
+        let mut database = RevisionedQueryDatabase::default();
+        let revision = revision_for(&mut database, &snapshot);
+        let outcome = database.probe_ready_body_facts(
+            revision,
+            semantic_configuration(),
+            "durable-nominal-shared-payload",
+            move |provider| {
+                let source = CompilerBodyDurableSource::with_anonymous(provider, &[], None);
+                let signature = source.signature(&point).expect("Point has a signature");
+                let crate::semantic_query_nucleus::DeclarationSignatureProjection::Struct {
+                    fields: canonical_fields,
+                    ..
+                } = signature.signature
+                else {
+                    panic!("Point has a struct signature")
+                };
+                let nominal = rue_air::DurableNominalSource::nominal(&source, &point)
+                    .expect("Point has a durable nominal body");
+                let rue_air::DurableNominalBody::Struct {
+                    fields: materialized_fields,
+                    ..
+                } = nominal.body
+                else {
+                    panic!("Point materializes as a struct")
+                };
+                Arc::ptr_eq(&canonical_fields, &materialized_fields)
+            },
+        );
+        assert!(
+            outcome.result,
+            "the durable source must not rebuild an equivalent nominal field vector"
+        );
     }
 
     fn request_layout(

--- a/crates/rue-compiler/src/session.rs
+++ b/crates/rue-compiler/src/session.rs
@@ -8064,6 +8064,11 @@ mod tests {
         assert_eq!(metrics.materializations, 6, "{metrics:?}");
         assert_eq!(
             metrics.materializations,
+            metrics.shared_payload_materializations + metrics.owned_payload_materializations,
+            "the durable materialization aggregate must be exactly partitioned by payload ownership"
+        );
+        assert_eq!(
+            metrics.materializations,
             metrics.const_materializations
                 + metrics.nominal_materializations
                 + metrics.function_materializations
@@ -8108,6 +8113,11 @@ mod tests {
         assert_eq!(metrics.identity_facts, 10, "{metrics:?}");
         assert_eq!(metrics.signature_facts, 10, "{metrics:?}");
         assert_eq!(metrics.materializations, 10, "{metrics:?}");
+        assert_eq!(
+            metrics.materializations,
+            metrics.shared_payload_materializations + metrics.owned_payload_materializations,
+            "the durable materialization aggregate must be exactly partitioned by payload ownership"
+        );
         assert_eq!(
             metrics.materializations,
             metrics.const_materializations

--- a/crates/rue-compiler/src/unstable.rs
+++ b/crates/rue-compiler/src/unstable.rs
@@ -246,6 +246,12 @@ pub struct ProviderObservationMetrics {
     pub const_facts: u64,
     /// Durable facts materialized into a body-local overlay.
     pub materializations: u64,
+    /// Materialization requests routed through a provider adapter which shares
+    /// canonical immutable payload storage.
+    pub shared_payload_materializations: u64,
+    /// Materialization requests routed through a provider adapter which
+    /// rebuilds an owned durable payload.
+    pub owned_payload_materializations: u64,
     /// Constant facts materialized into a body-local overlay.
     pub const_materializations: u64,
     /// Named nominal facts materialized into a body-local overlay.

--- a/crates/rue-perf-schema/src/scaling.rs
+++ b/crates/rue-perf-schema/src/scaling.rs
@@ -15,7 +15,7 @@ use crate::{
 };
 
 /// Version of the scaling-report wire format.
-pub const SCALING_REPORT_SCHEMA_VERSION: u32 = 13;
+pub const SCALING_REPORT_SCHEMA_VERSION: u32 = 14;
 
 /// The lower-frequency scaling suite declaration.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -238,6 +238,12 @@ pub struct SemanticProviderWork {
     pub const_facts: u64,
     /// Durable facts materialized into body-local representations.
     pub materializations: u64,
+    /// Requests routed through materializers which share canonical payloads.
+    #[serde(default)]
+    pub shared_payload_materializations: u64,
+    /// Requests routed through materializers which rebuild owned payloads.
+    #[serde(default)]
+    pub owned_payload_materializations: u64,
     /// Constant facts materialized into body-local representations.
     #[serde(default)]
     pub const_materializations: u64,
@@ -433,6 +439,8 @@ question = "small maintained compiler frontend"
         .unwrap();
         let object = encoded.as_object_mut().unwrap();
         for field in [
+            "shared_payload_materializations",
+            "owned_payload_materializations",
             "const_materializations",
             "nominal_materializations",
             "function_materializations",
@@ -442,6 +450,8 @@ question = "small maintained compiler frontend"
         }
         let decoded: SemanticProviderWork = serde_json::from_value(encoded).unwrap();
         assert_eq!(decoded.materializations, 23);
+        assert_eq!(decoded.shared_payload_materializations, 0);
+        assert_eq!(decoded.owned_payload_materializations, 0);
         assert_eq!(decoded.const_materializations, 0);
         assert_eq!(decoded.nominal_materializations, 0);
         assert_eq!(decoded.function_materializations, 0);

--- a/crates/rue/src/main.rs
+++ b/crates/rue/src/main.rs
@@ -1088,6 +1088,8 @@ fn benchmark_compiler_work(
             type_facts: provider.type_facts,
             const_facts: provider.const_facts,
             materializations: provider.materializations,
+            shared_payload_materializations: provider.shared_payload_materializations,
+            owned_payload_materializations: provider.owned_payload_materializations,
             const_materializations: provider.const_materializations,
             nominal_materializations: provider.nominal_materializations,
             function_materializations: provider.function_materializations,
@@ -1719,6 +1721,8 @@ mod tests {
                 type_facts: 17,
                 const_facts: 19,
                 materializations: 23,
+                shared_payload_materializations: 3,
+                owned_payload_materializations: 20,
                 const_materializations: 2,
                 nominal_materializations: 3,
                 function_materializations: 11,
@@ -1789,6 +1793,11 @@ mod tests {
                 + projected.semantic_provider.const_facts
         );
         assert_eq!(projected.semantic_provider.materializations, 23);
+        assert_eq!(
+            projected.semantic_provider.materializations,
+            projected.semantic_provider.shared_payload_materializations
+                + projected.semantic_provider.owned_payload_materializations
+        );
         assert_eq!(projected.semantic_provider.const_materializations, 2);
         assert_eq!(projected.semantic_provider.nominal_materializations, 3);
         assert_eq!(projected.semantic_provider.function_materializations, 11);

--- a/crates/rue/src/timing.rs
+++ b/crates/rue/src/timing.rs
@@ -764,7 +764,7 @@ impl TimingData {
         };
 
         BenchmarkTiming {
-            schema_version: 13,
+            schema_version: 14,
             timing_model: "inclusive_spans",
             phase_accounting,
             metadata,
@@ -2144,7 +2144,7 @@ mod tests {
         data.record("lexer", Duration::from_millis(100));
 
         let json = data.to_json_with_metrics("x86_64-linux", "0.1.0", None, None, None);
-        assert!(json.contains("\"schema_version\":13"));
+        assert!(json.contains("\"schema_version\":14"));
         assert!(json.contains(&format!(
             "\"compiler_build_profile\":\"{COMPILER_BUILD_PROFILE}\""
         )));
@@ -2822,7 +2822,7 @@ mod phase_accounting_tests {
 
         let timing =
             data.to_benchmark_timing_with_metrics("probe-target", "probe", None, None, None);
-        assert_eq!(timing.schema_version, 13);
+        assert_eq!(timing.schema_version, 14);
         assert_eq!(
             timing.metadata.compiler_build_profile,
             COMPILER_BUILD_PROFILE

--- a/docs/process/compiler-scaling.md
+++ b/docs/process/compiler-scaling.md
@@ -103,7 +103,9 @@ whether body analysis is asking for the same fact too often or merely paying
 too much to represent each necessary answer. The materialization total is
 exactly partitioned into constant, named-nominal, free-function, and method
 events so representation changes can target the declaration kind which owns
-the measured traffic.
+the measured traffic. It is also exactly partitioned by provider-boundary
+representation: shared payloads reuse canonical immutable storage, while owned
+payloads rebuild an equivalent body-local transport value.
 
 The CFG-materialization table separates immutable lookup preparation from the
 exact fact-closure selections that remain body-local. Its selections-per-build


### PR DESCRIPTION
## Summary
- share canonical struct-field and enum-variant payloads across the rue-air durable-source boundary
- classify durable materialization requests by shared versus owned payload adapters
- preserve historical performance-report compatibility and pin pointer identity with a focused regression

## Evidence
- Lattice moves 10,707 of 19,211 durable materialization requests (55.7%) to shared immutable payloads; 8,504 owned requests remain
- `scripts/rue quick`
- `scripts/rue unit compiler durable_nominal_materialization_shares_the_canonical_signature_payload`
- `./buck2 test //crates/rue-perf-schema:rue-perf-schema-test`
- `scripts/rue cli benchmark_json`

Refs RUE-1473.