### PR TITLE
RUE-1473: share durable callable parameters

### DIFF
--- a/crates/rue-air/src/sema/binding_manifest.rs
+++ b/crates/rue-air/src/sema/binding_manifest.rs
@@ -116,7 +116,7 @@ pub enum SemanticExportType {
     Module(Arc<str>),
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum SemanticParameterMode {
     Value,
     Borrow,

--- a/crates/rue-air/src/sema/body_identity.rs
+++ b/crates/rue-air/src/sema/body_identity.rs
@@ -2200,7 +2200,7 @@ pub(in crate::sema) fn semantic_import_type_mentions_generic_parameter<K, M>(
 /// projected into rue-air's durable type algebra. `name` is carried durably
 /// (r5a) so the pool assembles a `ParamRange` whose names match the epoch's
 /// without re-consulting a declaration shell.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct DurableSignatureParameter<K, M> {
     pub name: Arc<str>,
     pub ty: SemanticImportType<K, M>,
@@ -2227,7 +2227,7 @@ pub struct DurableCallableTypeSyntax {
 /// (`binding_manifest.rs`: `shell.is_generic == params.any(is_comptime)`).
 #[derive(Debug, Clone)]
 pub struct DurableFunction<K, M> {
-    pub parameters: Vec<DurableSignatureParameter<K, M>>,
+    pub parameters: Arc<[DurableSignatureParameter<K, M>]>,
     pub result: SemanticImportType<K, M>,
     pub type_syntax: Option<DurableCallableTypeSyntax>,
     pub is_public: bool,
@@ -2242,7 +2242,7 @@ pub struct DurableFunction<K, M> {
 #[derive(Debug, Clone)]
 pub struct DurableMethod<K, M> {
     pub receiver: SemanticImportType<K, M>,
-    pub parameters: Vec<DurableSignatureParameter<K, M>>,
+    pub parameters: Arc<[DurableSignatureParameter<K, M>]>,
     pub result: SemanticImportType<K, M>,
     pub type_syntax: Option<DurableCallableTypeSyntax>,
     pub has_self: bool,
@@ -3473,7 +3473,7 @@ mod tests {
         is_unchecked: bool,
     ) -> DurableFunction<Key, Module> {
         DurableFunction {
-            parameters,
+            parameters: parameters.into(),
             result,
             type_syntax: None,
             is_public,
@@ -3491,7 +3491,7 @@ mod tests {
     ) -> DurableMethod<Key, Module> {
         DurableMethod {
             receiver,
-            parameters,
+            parameters: parameters.into(),
             result,
             type_syntax: None,
             has_self,

--- a/crates/rue-air/src/sema/provider_body_host.rs
+++ b/crates/rue-air/src/sema/provider_body_host.rs
@@ -912,7 +912,7 @@ where
                 )
             };
         let function = DurableCallableSource::function(&self.source, &key)?;
-        for parameter in &function.parameters {
+        for parameter in function.parameters.iter() {
             if !super::body_identity::semantic_import_type_mentions_generic_parameter(&parameter.ty)
             {
                 self.register_import_nominal_identities(&parameter.ty)
@@ -1072,7 +1072,7 @@ where
         }
         let key = self.source.qualified_free_function(&module, name)?;
         let function = DurableCallableSource::function(&self.source, &key)?;
-        for parameter in &function.parameters {
+        for parameter in function.parameters.iter() {
             if !super::body_identity::semantic_import_type_mentions_generic_parameter(&parameter.ty)
             {
                 self.register_import_nominal_identities(&parameter.ty)

--- a/crates/rue-compiler/src/durable_semantics.rs
+++ b/crates/rue-compiler/src/durable_semantics.rs
@@ -181,24 +181,16 @@ pub enum DurableAnonymousMethodType {
     Concrete(DurableType),
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub enum DurableParameterMode {
-    Value,
-    Borrow,
-    Inout,
-}
+/// The canonical durable parameter mode shared with the rue-air consumer.
+pub type DurableParameterMode = rue_air::SemanticParameterMode;
 
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub struct DurableSemanticParameter {
-    /// The parameter's source name. Carried on the durable declaration so a
-    /// consumer that reconstructs a comptime type-constructor head from the
-    /// signature alone (the provider-driven analyzer's `SignatureFacts`) can
-    /// bind arguments by name without re-consulting the declaration shell.
-    pub name: Arc<str>,
-    pub ty: DurableType,
-    pub mode: DurableParameterMode,
-    pub is_comptime: bool,
-}
+/// The durable specialization of rue-air's canonical signature parameter.
+///
+/// Keeping this as the boundary type lets retained declaration-signature
+/// payloads flow into body analysis by sharing their immutable slice instead
+/// of allocating and cloning every parameter for every materialization.
+pub type DurableSemanticParameter =
+    rue_air::DurableSignatureParameter<StableDefinitionKey, ModuleId>;
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum DurableDeclarationPayload {

--- a/crates/rue-compiler/src/revisioned_query_database.rs
+++ b/crates/rue-compiler/src/revisioned_query_database.rs
@@ -798,10 +798,10 @@ impl ProviderObservationCounters {
                 .saturating_add(nominal_materializations)
                 .saturating_add(function_materializations)
                 .saturating_add(method_materializations),
-            shared_payload_materializations: nominal_materializations,
-            owned_payload_materializations: const_materializations
+            shared_payload_materializations: nominal_materializations
                 .saturating_add(function_materializations)
                 .saturating_add(method_materializations),
+            owned_payload_materializations: const_materializations,
             const_materializations,
             nominal_materializations,
             function_materializations,
@@ -22171,27 +22171,6 @@ impl rue_air::DurableConstSource<crate::StableDefinitionKey, ModuleId>
     }
 }
 
-fn provider_signature_parameter(
-    parameter: &crate::durable_semantics::DurableSemanticParameter,
-) -> rue_air::DurableSignatureParameter<crate::StableDefinitionKey, ModuleId> {
-    rue_air::DurableSignatureParameter {
-        name: parameter.name.clone(),
-        ty: parameter.ty.clone(),
-        mode: match parameter.mode {
-            crate::durable_semantics::DurableParameterMode::Value => {
-                rue_air::SemanticParameterMode::Value
-            }
-            crate::durable_semantics::DurableParameterMode::Borrow => {
-                rue_air::SemanticParameterMode::Borrow
-            }
-            crate::durable_semantics::DurableParameterMode::Inout => {
-                rue_air::SemanticParameterMode::Inout
-            }
-        },
-        is_comptime: parameter.is_comptime,
-    }
-}
-
 impl rue_air::DurableNominalSource<crate::StableDefinitionKey, ModuleId>
     for CompilerBodyDurableSource<'_>
 {
@@ -22288,10 +22267,7 @@ impl rue_air::DurableCallableSource<crate::StableDefinitionKey, ModuleId>
             return None;
         }
         Some(rue_air::DurableFunction {
-            parameters: parameters
-                .iter()
-                .map(provider_signature_parameter)
-                .collect(),
+            parameters,
             result,
             type_syntax,
             is_public: candidate.identity.is_public,
@@ -22331,24 +22307,11 @@ impl rue_air::DurableCallableSource<crate::StableDefinitionKey, ModuleId>
         );
         Some(rue_air::DurableMethod {
             receiver: rue_air::SemanticImportType::Nominal(owner),
-            parameters: parameters
-                .iter()
-                .map(provider_signature_parameter)
-                .collect(),
+            parameters,
             result,
             type_syntax,
             has_self,
-            self_mode: match self_mode {
-                crate::durable_semantics::DurableParameterMode::Value => {
-                    rue_air::SemanticParameterMode::Value
-                }
-                crate::durable_semantics::DurableParameterMode::Borrow => {
-                    rue_air::SemanticParameterMode::Borrow
-                }
-                crate::durable_semantics::DurableParameterMode::Inout => {
-                    rue_air::SemanticParameterMode::Inout
-                }
-            },
+            self_mode,
             is_accessor,
         })
     }
@@ -24709,22 +24672,6 @@ pub(crate) mod test_support {
         }
     }
 
-    fn provider_durable_param(
-        parameter: &crate::durable_semantics::DurableSemanticParameter,
-    ) -> rue_air::DurableSignatureParameter<StableDefinitionKey, ModuleId> {
-        use crate::durable_semantics::DurableParameterMode as Mode;
-        rue_air::DurableSignatureParameter {
-            name: parameter.name.clone(),
-            ty: parameter.ty.clone(),
-            mode: match parameter.mode {
-                Mode::Value => rue_air::SemanticParameterMode::Value,
-                Mode::Borrow => rue_air::SemanticParameterMode::Borrow,
-                Mode::Inout => rue_air::SemanticParameterMode::Inout,
-            },
-            is_comptime: parameter.is_comptime,
-        }
-    }
-
     impl rue_air::DurableNominalSource<StableDefinitionKey, ModuleId> for DurableDeclSource {
         fn nominal(
             &self,
@@ -24798,7 +24745,7 @@ pub(crate) mod test_support {
                 return None;
             }
             Some(rue_air::DurableFunction {
-                parameters: parameters.iter().map(provider_durable_param).collect(),
+                parameters: parameters.clone(),
                 result: result.clone(),
                 type_syntax: None,
                 is_public: decl.is_public,
@@ -24845,21 +24792,11 @@ pub(crate) mod test_support {
                 .clone();
             Some(rue_air::DurableMethod {
                 receiver: rue_air::SemanticImportType::Nominal(owner_key),
-                parameters: parameters.iter().map(provider_durable_param).collect(),
+                parameters: parameters.clone(),
                 result: result.clone(),
                 type_syntax: None,
                 has_self: *has_self,
-                self_mode: match self_mode {
-                    crate::durable_semantics::DurableParameterMode::Value => {
-                        rue_air::SemanticParameterMode::Value
-                    }
-                    crate::durable_semantics::DurableParameterMode::Borrow => {
-                        rue_air::SemanticParameterMode::Borrow
-                    }
-                    crate::durable_semantics::DurableParameterMode::Inout => {
-                        rue_air::SemanticParameterMode::Inout
-                    }
-                },
+                self_mode: *self_mode,
                 is_accessor: false,
             })
         }
@@ -32299,6 +32236,52 @@ fn main() -> i32 {
         assert!(
             outcome.result,
             "the durable source must not rebuild an equivalent nominal field vector"
+        );
+    }
+
+    #[test]
+    fn durable_function_materialization_shares_the_canonical_parameter_payload() {
+        let snapshot = source_snapshot(
+            &[(
+                1,
+                "/main.rue",
+                "main.rue",
+                "fn helper(value: i32, count: u64) -> i32 { value }\nfn main() -> i32 { helper(0, 1) }\n",
+            )],
+            1,
+        );
+        let module = ModuleId::from_logical_path("main.rue").unwrap();
+        let helper = crate::StableDefinitionKey::from_stable_parts(
+            module,
+            crate::StableDefinitionNamespace::Value,
+            crate::StableDefinitionKind::Function,
+            Arc::from("helper"),
+            None,
+        );
+        let mut database = RevisionedQueryDatabase::default();
+        let revision = revision_for(&mut database, &snapshot);
+        let outcome = database.probe_ready_body_facts(
+            revision,
+            semantic_configuration(),
+            "durable-function-shared-parameters",
+            move |provider| {
+                let source = CompilerBodyDurableSource::with_anonymous(provider, &[], None);
+                let signature = source.signature(&helper).expect("helper has a signature");
+                let crate::semantic_query_nucleus::DeclarationSignatureProjection::Callable {
+                    parameters: canonical_parameters,
+                    ..
+                } = signature.signature
+                else {
+                    panic!("helper has a callable signature")
+                };
+                let function = rue_air::DurableCallableSource::function(&source, &helper)
+                    .expect("helper has a durable function body");
+                Arc::ptr_eq(&canonical_parameters, &function.parameters)
+            },
+        );
+        assert!(
+            outcome.result,
+            "the durable source must not rebuild an equivalent function-parameter vector"
         );
     }
 


### PR DESCRIPTION
## Summary
- use one canonical durable parameter vocabulary across rue-compiler and rue-air
- share retained function and method parameter slices instead of rebuilding them per materialization
- update the deterministic payload partition and pin pointer identity with a focused regression

## Evidence
- Lattice moves another 8,066 durable materialization requests to shared storage, for 18,773 / 19,211 shared requests (97.7%)
- `scripts/rue unit compiler durable_function_materialization_shares_the_canonical_parameter_payload`
- `scripts/rue quick`

Refs RUE-1473.