### PR TITLE
RUE-1473: profile body-local materialization

### DIFF
--- a/crates/rue-bench/src/measure.rs
+++ b/crates/rue-bench/src/measure.rs
@@ -397,7 +397,7 @@ fn run_once(request: &SampleRequest<'_>) -> Result<CompletedCompile, String> {
                 "boundary policy has no independently declared target".to_string()
             })?;
             evidence
-                .validate_against(policy, expected_target)
+                .validate_current_producer_against(policy, expected_target)
                 .map_err(|detail| format!("build-boundary evidence rejected: {detail}"))?;
             Some(evidence)
         }

--- a/crates/rue-bench/src/scaling.rs
+++ b/crates/rue-bench/src/scaling.rs
@@ -366,8 +366,10 @@ fn render(report: &ScalingReport) -> String {
 
     out.push_str("\n## Worker scaling and critical path\n\n");
     out.push_str("Utilization divides summed query-worker active time by compiler-root time and the compiler's resolved worker count. Ready wait is summed across dependency-ready items, so the mean and maximum are the directly comparable latency signals. Body columns show total/max milliseconds from bounded compiler histograms. The rooted-acquisition envelope is inclusive: it contains the semantic attempt used to discover a trusted-toolchain park, is not an exclusive phase, and must not be added to semantic time or read as filesystem cost.\n\n");
-    out.push_str("| workload / workers | utilization | active ms | ready mean/max ms | longest chain | rooted acquisition envelope ms | semantic total/max ms | CFG build total/max ms | CFG opt total/max ms | joins declined/total | donated permits |\n");
-    out.push_str("| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |\n");
+    out.push_str("| workload / workers | utilization | active ms | ready mean/max ms | longest chain | rooted acquisition envelope ms | semantic total/max ms | local epoch total/max ms | CFG build total/max ms | CFG opt total/max ms | joins declined/total | donated permits |\n");
+    out.push_str(
+        "| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |\n",
+    );
     for observation in &report.workloads {
         let evidence = observation.samples.iter().map(|sample| {
             sample
@@ -402,6 +404,16 @@ fn render(report: &ScalingReport) -> String {
         let toolchain = summarize(evidence.clone().map(|e| e.toolchain_acquisition_ns));
         let semantic_total = summarize(evidence.clone().map(|e| e.semantic_bodies.total_ns));
         let semantic_max = summarize(evidence.clone().map(|e| e.semantic_bodies.max_ns));
+        let materialization_total = summarize(
+            evidence
+                .clone()
+                .map(|e| e.semantic_materialization_bodies.total_ns),
+        );
+        let materialization_max = summarize(
+            evidence
+                .clone()
+                .map(|e| e.semantic_materialization_bodies.max_ns),
+        );
         let cfg_total = summarize(evidence.clone().map(|e| e.cfg_construction_bodies.total_ns));
         let cfg_max = summarize(evidence.clone().map(|e| e.cfg_construction_bodies.max_ns));
         let opt_total = summarize(evidence.clone().map(|e| e.cfg_optimization_bodies.total_ns));
@@ -410,7 +422,7 @@ fn render(report: &ScalingReport) -> String {
         let declined = summarize(evidence.clone().map(|e| e.declined_joins));
         let donated = summarize(evidence.map(|e| e.donated_permits));
         out.push_str(&format!(
-            "| {} | {:.1}% | {:.2} | {:.3}/{:.3} | {} | {:.2} | {:.2}/{:.2} | {:.2}/{:.2} | {:.2}/{:.2} | {}/{} | {} |\n",
+            "| {} | {:.1}% | {:.2} | {:.3}/{:.3} | {} | {:.2} | {:.2}/{:.2} | {:.2}/{:.2} | {:.2}/{:.2} | {:.2}/{:.2} | {}/{} | {} |\n",
             observation_label(observation),
             utilization.median as f64 / 100.0,
             active.median as f64 / 1_000_000.0,
@@ -420,6 +432,8 @@ fn render(report: &ScalingReport) -> String {
             toolchain.median as f64 / 1_000_000.0,
             semantic_total.median as f64 / 1_000_000.0,
             semantic_max.median as f64 / 1_000_000.0,
+            materialization_total.median as f64 / 1_000_000.0,
+            materialization_max.median as f64 / 1_000_000.0,
             cfg_total.median as f64 / 1_000_000.0,
             cfg_max.median as f64 / 1_000_000.0,
             opt_total.median as f64 / 1_000_000.0,

--- a/crates/rue-cli-tests/cases/benchmark_json.toml
+++ b/crates/rue-cli-tests/cases/benchmark_json.toml
@@ -15,7 +15,7 @@ args = ["--benchmark-json", "main.rue", "-o", "prog"]
 env = { RUST_LOG = "error" }
 exit_code = 42
 compile_stdout_contains = [
-  '"schema_version":15',
+  '"schema_version":16',
   '"compiler_build_profile":',
   '"timing_model":"inclusive_spans"',
   # The additive partition, which is the only model that may be stacked. Its

--- a/crates/rue-compiler/src/cfg_query.rs
+++ b/crates/rue-compiler/src/cfg_query.rs
@@ -1027,6 +1027,8 @@ fn materialize_and_build_cfg(
         );
     }
     context.record_work(rue_query::WorkItem::new("cfg.materialize.attempts", 1));
+    let _materialization_span =
+        tracing::info_span!("semantic_materialization", phase = "cfg_and_optimization").entered();
     let materialized = match &key.semantic_input {
         CfgSemanticInput::Body { input, .. } => {
             crate::local_semantic_materialization::materialize_canonical_body(

--- a/crates/rue-perf-schema/src/boundary.rs
+++ b/crates/rue-perf-schema/src/boundary.rs
@@ -376,6 +376,9 @@ pub struct CompilerCriticalPathEvidence {
     /// Inclusive duration of reached-toolchain acquisition inside compiler root.
     pub toolchain_acquisition_ns: u64,
     pub semantic_bodies: DurationDistribution,
+    /// Fresh body-local semantic epoch construction and body import.
+    #[serde(default)]
+    pub semantic_materialization_bodies: DurationDistribution,
     pub cfg_construction_bodies: DurationDistribution,
     pub cfg_optimization_bodies: DurationDistribution,
     /// Contention evidence the runtime can support exactly.
@@ -536,6 +539,7 @@ impl BuildBoundaryEvidence {
 
         let critical = &self.critical_path;
         if !critical.semantic_bodies.validate()
+            || !critical.semantic_materialization_bodies.validate()
             || !critical.cfg_construction_bodies.validate()
             || !critical.cfg_optimization_bodies.validate()
         {
@@ -560,6 +564,26 @@ impl BuildBoundaryEvidence {
             || critical.peak_query_workers > u64::from(configuration.resolved_workers)
         {
             return Err("peak query workers is outside the resolved worker budget".to_string());
+        }
+        Ok(())
+    }
+
+    /// Validate evidence emitted by the compiler version linked into the
+    /// current measurement runner.
+    ///
+    /// Stored run objects use additive defaults so newer readers can continue
+    /// to validate immutable historical evidence. The current producer has no
+    /// such exception: every field it knows about must be populated.
+    pub fn validate_current_producer_against(
+        &self,
+        policy: &BuildBoundaryPolicy,
+        target: &str,
+    ) -> Result<(), String> {
+        self.validate_against(policy, target)?;
+        if self.critical_path.semantic_materialization_bodies.count == 0 {
+            return Err(
+                "compiler omitted semantic-materialization critical-path evidence".to_string(),
+            );
         }
         Ok(())
     }
@@ -640,6 +664,7 @@ mod tests {
                 peak_query_workers: 1,
                 toolchain_acquisition_ns: 1,
                 semantic_bodies: distribution(),
+                semantic_materialization_bodies: distribution(),
                 cfg_construction_bodies: distribution(),
                 cfg_optimization_bodies: distribution(),
                 joins: 0,
@@ -665,6 +690,35 @@ mod tests {
             .push(CompilerInputClass::WorkloadSource);
         assert!(widened.validate().is_err());
         assert_eq!(WorkerSetting::REFERENCE_MATRIX.len(), 5);
+    }
+
+    #[test]
+    fn historical_critical_path_evidence_defaults_semantic_materialization() {
+        let mut encoded = serde_json::to_value(evidence()).unwrap();
+        encoded["critical_path"]
+            .as_object_mut()
+            .unwrap()
+            .remove("semantic_materialization_bodies");
+
+        let decoded: BuildBoundaryEvidence = serde_json::from_value(encoded).unwrap();
+        assert_eq!(
+            decoded.critical_path.semantic_materialization_bodies,
+            DurationDistribution::default()
+        );
+        decoded
+            .validate_against(
+                &BuildBoundaryPolicy::fresh_source_to_native_v1(WorkerSetting::One),
+                "x86-64-linux",
+            )
+            .unwrap();
+        assert!(
+            decoded
+                .validate_current_producer_against(
+                    &BuildBoundaryPolicy::fresh_source_to_native_v1(WorkerSetting::One),
+                    "x86-64-linux",
+                )
+                .is_err()
+        );
     }
 
     #[test]

--- a/crates/rue/src/main.rs
+++ b/crates/rue/src/main.rs
@@ -1061,6 +1061,8 @@ fn compiler_critical_path_evidence(
         peak_query_workers: runtime.peak_query_workers,
         toolchain_acquisition_ns: timing.pass_total_ns("toolchain_acquisition"),
         semantic_bodies: timing.pass_duration_distribution("body_analysis"),
+        semantic_materialization_bodies: timing
+            .pass_duration_distribution("semantic_materialization"),
         cfg_construction_bodies: timing.pass_duration_distribution("cfg_construction"),
         cfg_optimization_bodies: timing.pass_duration_distribution("cfg_optimization"),
         joins: runtime.joins,

--- a/crates/rue/src/timing.rs
+++ b/crates/rue/src/timing.rs
@@ -764,7 +764,7 @@ impl TimingData {
         };
 
         BenchmarkTiming {
-            schema_version: 15,
+            schema_version: 16,
             timing_model: "inclusive_spans",
             phase_accounting,
             metadata,
@@ -2144,7 +2144,7 @@ mod tests {
         data.record("lexer", Duration::from_millis(100));
 
         let json = data.to_json_with_metrics("x86_64-linux", "0.1.0", None, None, None);
-        assert!(json.contains("\"schema_version\":15"));
+        assert!(json.contains("\"schema_version\":16"));
         assert!(json.contains(&format!(
             "\"compiler_build_profile\":\"{COMPILER_BUILD_PROFILE}\""
         )));
@@ -2822,7 +2822,7 @@ mod phase_accounting_tests {
 
         let timing =
             data.to_benchmark_timing_with_metrics("probe-target", "probe", None, None, None);
-        assert_eq!(timing.schema_version, 15);
+        assert_eq!(timing.schema_version, 16);
         assert_eq!(
             timing.metadata.compiler_build_profile,
             COMPILER_BUILD_PROFILE


### PR DESCRIPTION
## Summary
- add a bounded nested duration distribution for fresh body-local semantic epoch construction and body import
- publish total/max materialization time beside semantic, CFG construction, and CFG optimization histograms
- keep collection on the existing thread-local timing path with no new shared hot-path writes

## Evidence
- `scripts/rue quick`

Refs RUE-1473.