### PR TITLE
RUE-1473: fix materialization profiling scope

### DIFF
--- a/crates/rue-compiler/src/cfg_query.rs
+++ b/crates/rue-compiler/src/cfg_query.rs
@@ -1027,8 +1027,7 @@ fn materialize_and_build_cfg(
         );
     }
     context.record_work(rue_query::WorkItem::new("cfg.materialize.attempts", 1));
-    let _materialization_span =
-        tracing::info_span!("semantic_materialization", phase = "cfg_and_optimization").entered();
+    let materialization_started = std::time::Instant::now();
     let materialized = match &key.semantic_input {
         CfgSemanticInput::Body { input, .. } => {
             crate::local_semantic_materialization::materialize_canonical_body(
@@ -1058,6 +1057,14 @@ fn materialize_and_build_cfg(
             )
         }
     };
+    let materialization_ns =
+        u64::try_from(materialization_started.elapsed().as_nanos()).unwrap_or(u64::MAX);
+    tracing::event!(
+        name: "semantic_materialization",
+        target: "rue::timing",
+        tracing::Level::INFO,
+        duration_ns = materialization_ns,
+    );
     let materialized = match materialized {
         Ok(value) => value,
         Err(error) => {

--- a/crates/rue/src/timing.rs
+++ b/crates/rue/src/timing.rs
@@ -1144,10 +1144,23 @@ struct SpanMarkerVisitor {
 #[derive(Default)]
 struct TimingFlushVisitor(bool);
 
+#[derive(Default)]
+struct TimingDurationVisitor(Option<u64>);
+
 impl tracing::field::Visit for TimingFlushVisitor {
     fn record_bool(&mut self, field: &tracing::field::Field, value: bool) {
         if field.name() == "timing_flush" {
             self.0 = value;
+        }
+    }
+
+    fn record_debug(&mut self, _field: &tracing::field::Field, _value: &dyn std::fmt::Debug) {}
+}
+
+impl tracing::field::Visit for TimingDurationVisitor {
+    fn record_u64(&mut self, field: &tracing::field::Field, value: u64) {
+        if field.name() == "duration_ns" {
+            self.0 = Some(value);
         }
     }
 
@@ -1206,15 +1219,29 @@ where
     S: Subscriber + for<'a> LookupSpan<'a>,
 {
     fn on_event(&self, event: &Event<'_>, _ctx: Context<'_, S>) {
-        if event.metadata().fields().field("timing_flush").is_none() {
+        if event.metadata().fields().field("timing_flush").is_some() {
+            let mut visitor = TimingFlushVisitor::default();
+            event.record(&mut visitor);
+            if visitor.0 {
+                self.data.flush_local();
+                #[cfg(test)]
+                self.data.record_flush_marker();
+            }
             return;
         }
-        let mut visitor = TimingFlushVisitor::default();
-        event.record(&mut visitor);
-        if visitor.0 {
-            self.data.flush_local();
-            #[cfg(test)]
-            self.data.record_flush_marker();
+        if event.metadata().target() == "rue::timing"
+            && event.metadata().fields().field("duration_ns").is_some()
+        {
+            let mut visitor = TimingDurationVisitor::default();
+            event.record(&mut visitor);
+            if let Some(duration_ns) = visitor.0 {
+                self.data.record_span(
+                    event.metadata().name(),
+                    Duration::from_nanos(duration_ns),
+                    false,
+                    true,
+                );
+            }
         }
     }
 
@@ -2368,6 +2395,33 @@ mod phase_accounting_tests {
             1
         );
         assert!(distribution.validate());
+    }
+
+    #[test]
+    fn direct_duration_event_populates_the_bounded_distribution() {
+        let data = TimingData::new();
+        let subscriber = tracing_subscriber::registry().with(TimingLayer::new(data.clone()));
+        tracing::subscriber::with_default(subscriber, || {
+            tracing::event!(
+                name: "direct_duration",
+                target: "rue::timing",
+                tracing::Level::INFO,
+                duration_ns = 64_u64,
+            );
+            tracing::event!(
+                name: "direct_duration",
+                target: "rue::timing",
+                tracing::Level::INFO,
+                duration_ns = 32_u64,
+            );
+        });
+
+        let distribution = data.pass_duration_distribution("direct_duration");
+        assert_eq!(distribution.count, 2);
+        assert_eq!(distribution.total_ns, 96);
+        assert_eq!(distribution.max_ns, 64);
+        assert_eq!(distribution.log2_buckets[5], 1);
+        assert_eq!(distribution.log2_buckets[6], 1);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- replace the per-body nested tracing span added by #2340 with one direct duration event whose timer ends immediately after materialization
- accumulate that event into the existing worker-local bounded distribution
- preserve the same `semantic_materialization_bodies` evidence without extending the measurement through the rest of CFG construction

## Evidence

The original span guard lived until the enclosing CFG query returned, so its 99% share accidentally included domain projection, prerequisite queries, CFG building, and publication. The post-merge x86 collector also measured Lattice at 3,108,599,906 ns against the 3,022,383,520 ns non-regression ratchet (+2.85%).

The corrected hosted profile records the exact lexical interval:

- Lattice one worker: 169.84 ms local materialization / 587.94 ms CFG construction = 28.9%
- Lattice automatic: 268.51 / 975.86 ms = 27.5%
- 1,280 body observations remain present

Local `scripts/rue quick` passes. The merge queue performance collector has passed x86_64-linux and aarch64-linux on the corrected commit; macOS remains the final platform gate.

Refs RUE-1473.