### PR TITLE
RUE-1473: partition CFG construction timing

### DIFF
--- a/crates/rue-bench/src/scaling.rs
+++ b/crates/rue-bench/src/scaling.rs
@@ -365,10 +365,10 @@ fn render(report: &ScalingReport) -> String {
     }
 
     out.push_str("\n## Worker scaling and critical path\n\n");
-    out.push_str("Utilization divides summed query-worker active time by compiler-root time and the compiler's resolved worker count. Ready wait is summed across dependency-ready items, so the mean and maximum are the directly comparable latency signals. Body columns show total/max milliseconds from bounded compiler histograms. The rooted-acquisition envelope is inclusive: it contains the semantic attempt used to discover a trusted-toolchain park, is not an exclusive phase, and must not be added to semantic time or read as filesystem cost.\n\n");
-    out.push_str("| workload / workers | utilization | active ms | ready mean/max ms | longest chain | rooted acquisition envelope ms | semantic total/max ms | local epoch total/max ms | CFG build total/max ms | CFG opt total/max ms | joins declined/total | donated permits |\n");
+    out.push_str("Utilization divides summed query-worker active time by compiler-root time and the compiler's resolved worker count. Ready wait is summed across dependency-ready items, so the mean and maximum are the directly comparable latency signals. Body columns show total/max milliseconds from bounded compiler histograms. The five CFG breakdown columns are non-overlapping lexical intervals inside each successful CFG body; CFG total remains the inclusive query duration and can be slightly larger because it also contains timing publication and outer query bookkeeping. The rooted-acquisition envelope is inclusive: it contains the semantic attempt used to discover a trusted-toolchain park, is not an exclusive phase, and must not be added to semantic time or read as filesystem cost.\n\n");
+    out.push_str("| workload / workers | utilization | active ms | ready mean/max ms | longest chain | rooted acquisition envelope ms | semantic total/max ms | CFG input total/max ms | local epoch total/max ms | domain/prereq total/max ms | CFG builder total/max ms | publication total/max ms | CFG total/max ms | CFG opt total/max ms | joins declined/total | donated permits |\n");
     out.push_str(
-        "| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |\n",
+        "| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |\n",
     );
     for observation in &report.workloads {
         let evidence = observation.samples.iter().map(|sample| {
@@ -404,6 +404,16 @@ fn render(report: &ScalingReport) -> String {
         let toolchain = summarize(evidence.clone().map(|e| e.toolchain_acquisition_ns));
         let semantic_total = summarize(evidence.clone().map(|e| e.semantic_bodies.total_ns));
         let semantic_max = summarize(evidence.clone().map(|e| e.semantic_bodies.max_ns));
+        let input_total = summarize(
+            evidence
+                .clone()
+                .map(|e| e.cfg_input_preparation_bodies.total_ns),
+        );
+        let input_max = summarize(
+            evidence
+                .clone()
+                .map(|e| e.cfg_input_preparation_bodies.max_ns),
+        );
         let materialization_total = summarize(
             evidence
                 .clone()
@@ -414,6 +424,21 @@ fn render(report: &ScalingReport) -> String {
                 .clone()
                 .map(|e| e.semantic_materialization_bodies.max_ns),
         );
+        let domain_total = summarize(
+            evidence
+                .clone()
+                .map(|e| e.cfg_domain_prerequisite_bodies.total_ns),
+        );
+        let domain_max = summarize(
+            evidence
+                .clone()
+                .map(|e| e.cfg_domain_prerequisite_bodies.max_ns),
+        );
+        let builder_total = summarize(evidence.clone().map(|e| e.cfg_builder_bodies.total_ns));
+        let builder_max = summarize(evidence.clone().map(|e| e.cfg_builder_bodies.max_ns));
+        let publication_total =
+            summarize(evidence.clone().map(|e| e.cfg_publication_bodies.total_ns));
+        let publication_max = summarize(evidence.clone().map(|e| e.cfg_publication_bodies.max_ns));
         let cfg_total = summarize(evidence.clone().map(|e| e.cfg_construction_bodies.total_ns));
         let cfg_max = summarize(evidence.clone().map(|e| e.cfg_construction_bodies.max_ns));
         let opt_total = summarize(evidence.clone().map(|e| e.cfg_optimization_bodies.total_ns));
@@ -422,7 +447,7 @@ fn render(report: &ScalingReport) -> String {
         let declined = summarize(evidence.clone().map(|e| e.declined_joins));
         let donated = summarize(evidence.map(|e| e.donated_permits));
         out.push_str(&format!(
-            "| {} | {:.1}% | {:.2} | {:.3}/{:.3} | {} | {:.2} | {:.2}/{:.2} | {:.2}/{:.2} | {:.2}/{:.2} | {:.2}/{:.2} | {}/{} | {} |\n",
+            "| {} | {:.1}% | {:.2} | {:.3}/{:.3} | {} | {:.2} | {:.2}/{:.2} | {:.2}/{:.2} | {:.2}/{:.2} | {:.2}/{:.2} | {:.2}/{:.2} | {:.2}/{:.2} | {:.2}/{:.2} | {:.2}/{:.2} | {}/{} | {} |\n",
             observation_label(observation),
             utilization.median as f64 / 100.0,
             active.median as f64 / 1_000_000.0,
@@ -432,8 +457,16 @@ fn render(report: &ScalingReport) -> String {
             toolchain.median as f64 / 1_000_000.0,
             semantic_total.median as f64 / 1_000_000.0,
             semantic_max.median as f64 / 1_000_000.0,
+            input_total.median as f64 / 1_000_000.0,
+            input_max.median as f64 / 1_000_000.0,
             materialization_total.median as f64 / 1_000_000.0,
             materialization_max.median as f64 / 1_000_000.0,
+            domain_total.median as f64 / 1_000_000.0,
+            domain_max.median as f64 / 1_000_000.0,
+            builder_total.median as f64 / 1_000_000.0,
+            builder_max.median as f64 / 1_000_000.0,
+            publication_total.median as f64 / 1_000_000.0,
+            publication_max.median as f64 / 1_000_000.0,
             cfg_total.median as f64 / 1_000_000.0,
             cfg_max.median as f64 / 1_000_000.0,
             opt_total.median as f64 / 1_000_000.0,

--- a/crates/rue-compiler/src/cfg_query.rs
+++ b/crates/rue-compiler/src/cfg_query.rs
@@ -934,6 +934,17 @@ fn collect_plan_types(
     output
 }
 
+#[derive(Debug, Clone, Copy)]
+struct CfgConstructionBreakdown {
+    input_preparation_ns: u64,
+    semantic_materialization_ns: u64,
+    domain_prerequisites_ns: u64,
+}
+
+fn elapsed_ns(started: std::time::Instant) -> u64 {
+    u64::try_from(started.elapsed().as_nanos()).unwrap_or(u64::MAX)
+}
+
 fn materialize_and_build_cfg(
     context: &QueryContext,
     layouts: &QueryFamily<crate::type_queries::TypeQueryKey, crate::type_queries::LayoutValue>,
@@ -948,6 +959,7 @@ fn materialize_and_build_cfg(
     >,
     key: &CfgQueryKey,
 ) -> Result<CfgValue, QueryAbort> {
+    let input_preparation_started = std::time::Instant::now();
     let synthesized;
     let (body, body_span, facts) = match &key.semantic_input {
         CfgSemanticInput::Body {
@@ -1027,6 +1039,7 @@ fn materialize_and_build_cfg(
         );
     }
     context.record_work(rue_query::WorkItem::new("cfg.materialize.attempts", 1));
+    let input_preparation_ns = elapsed_ns(input_preparation_started);
     let materialization_started = std::time::Instant::now();
     let materialized = match &key.semantic_input {
         CfgSemanticInput::Body { input, .. } => {
@@ -1057,14 +1070,8 @@ fn materialize_and_build_cfg(
             )
         }
     };
-    let materialization_ns =
-        u64::try_from(materialization_started.elapsed().as_nanos()).unwrap_or(u64::MAX);
-    tracing::event!(
-        name: "semantic_materialization",
-        target: "rue::timing",
-        tracing::Level::INFO,
-        duration_ns = materialization_ns,
-    );
+    let semantic_materialization_ns = elapsed_ns(materialization_started);
+    let domain_prerequisites_started = std::time::Instant::now();
     let materialized = match materialized {
         Ok(value) => value,
         Err(error) => {
@@ -1140,7 +1147,12 @@ fn materialize_and_build_cfg(
         .collect::<Vec<_>>();
     context.query_registered_batch(type_facts, drop_dependencies.iter().cloned())?;
     context.query_registered_batch(drop_glues, drop_dependencies)?;
-    build_cfg(context, call_abis, key, materialized, domains)
+    let breakdown = CfgConstructionBreakdown {
+        input_preparation_ns,
+        semantic_materialization_ns,
+        domain_prerequisites_ns: elapsed_ns(domain_prerequisites_started),
+    };
+    build_cfg(context, call_abis, key, materialized, domains, breakdown)
 }
 
 /// The published composite-type ceiling was reached while this body's type
@@ -1170,12 +1182,14 @@ fn build_cfg(
     key: &CfgQueryKey,
     materialized: crate::local_semantic_materialization::LocalSemanticMaterialization,
     domains: crate::durable_cfg::CfgDomainProjection,
+    breakdown: CfgConstructionBreakdown,
 ) -> Result<CfgValue, QueryAbort> {
     context.record_work(rue_query::WorkItem::new("cfg.build.attempts", 1));
     context.record_work(rue_query::WorkItem::new(
         "cfg.air.instructions",
         materialized.air.instructions().len() as u64,
     ));
+    let builder_started = std::time::Instant::now();
     let output = rue_cfg::CfgBuilder::build(
         &materialized.air,
         materialized.num_locals,
@@ -1187,6 +1201,8 @@ fn build_cfg(
         materialized.allow_unreachable_code,
         materialized.callable_kind,
     );
+    let cfg_builder_ns = elapsed_ns(builder_started);
+    let publication_started = std::time::Instant::now();
     if !output.errors.is_empty() {
         context.record_work(rue_query::WorkItem::new("cfg.build.failures", 1));
         return Ok(CfgValue::Failure {
@@ -1294,7 +1310,7 @@ fn build_cfg(
         "cfg.retained-interner-utf8-bytes-scanned",
         interner_utf8_bytes,
     ));
-    Ok(CfgValue::Available(Arc::new(CfgRecord {
+    let value = CfgValue::Available(Arc::new(CfgRecord {
         air: Arc::new(materialized.air),
         source_name: materialized.name.into(),
         num_locals: materialized.num_locals,
@@ -1319,7 +1335,19 @@ fn build_cfg(
             .into(),
         implicit_destructor_dependencies_complete: materialized.completeness.is_complete()
             && !output.anonymous_destructor_dependency_incomplete,
-    })))
+    }));
+    let cfg_publication_ns = elapsed_ns(publication_started);
+    tracing::event!(
+        name: "cfg_construction_breakdown",
+        target: "rue::timing",
+        tracing::Level::INFO,
+        input_preparation_ns = breakdown.input_preparation_ns,
+        semantic_materialization_ns = breakdown.semantic_materialization_ns,
+        domain_prerequisites_ns = breakdown.domain_prerequisites_ns,
+        cfg_builder_ns,
+        cfg_publication_ns,
+    );
+    Ok(value)
 }
 
 pub(crate) fn evaluate_optimized_cfg(

--- a/crates/rue-perf-schema/src/boundary.rs
+++ b/crates/rue-perf-schema/src/boundary.rs
@@ -376,9 +376,21 @@ pub struct CompilerCriticalPathEvidence {
     /// Inclusive duration of reached-toolchain acquisition inside compiler root.
     pub toolchain_acquisition_ns: u64,
     pub semantic_bodies: DurationDistribution,
+    /// Stable-input preparation before body-local semantic materialization.
+    #[serde(default)]
+    pub cfg_input_preparation_bodies: DurationDistribution,
     /// Fresh body-local semantic epoch construction and body import.
     #[serde(default)]
     pub semantic_materialization_bodies: DurationDistribution,
+    /// Stable-domain projection and layout/drop prerequisite queries.
+    #[serde(default)]
+    pub cfg_domain_prerequisite_bodies: DurationDistribution,
+    /// AIR-to-CFG construction excluding publication and ABI projection.
+    #[serde(default)]
+    pub cfg_builder_bodies: DurationDistribution,
+    /// Runtime-call ABI projection, retained-charge accounting, and publication.
+    #[serde(default)]
+    pub cfg_publication_bodies: DurationDistribution,
     pub cfg_construction_bodies: DurationDistribution,
     pub cfg_optimization_bodies: DurationDistribution,
     /// Contention evidence the runtime can support exactly.
@@ -539,7 +551,11 @@ impl BuildBoundaryEvidence {
 
         let critical = &self.critical_path;
         if !critical.semantic_bodies.validate()
+            || !critical.cfg_input_preparation_bodies.validate()
             || !critical.semantic_materialization_bodies.validate()
+            || !critical.cfg_domain_prerequisite_bodies.validate()
+            || !critical.cfg_builder_bodies.validate()
+            || !critical.cfg_publication_bodies.validate()
             || !critical.cfg_construction_bodies.validate()
             || !critical.cfg_optimization_bodies.validate()
         {
@@ -580,9 +596,21 @@ impl BuildBoundaryEvidence {
         target: &str,
     ) -> Result<(), String> {
         self.validate_against(policy, target)?;
-        if self.critical_path.semantic_materialization_bodies.count == 0 {
+        let critical = &self.critical_path;
+        let breakdown_counts = [
+            critical.cfg_input_preparation_bodies.count,
+            critical.semantic_materialization_bodies.count,
+            critical.cfg_domain_prerequisite_bodies.count,
+            critical.cfg_builder_bodies.count,
+            critical.cfg_publication_bodies.count,
+        ];
+        if critical.cfg_construction_bodies.count == 0
+            || breakdown_counts
+                .iter()
+                .any(|count| *count != critical.cfg_construction_bodies.count)
+        {
             return Err(
-                "compiler omitted semantic-materialization critical-path evidence".to_string(),
+                "compiler omitted or split CFG-construction breakdown evidence".to_string(),
             );
         }
         Ok(())
@@ -664,7 +692,11 @@ mod tests {
                 peak_query_workers: 1,
                 toolchain_acquisition_ns: 1,
                 semantic_bodies: distribution(),
+                cfg_input_preparation_bodies: distribution(),
                 semantic_materialization_bodies: distribution(),
+                cfg_domain_prerequisite_bodies: distribution(),
+                cfg_builder_bodies: distribution(),
+                cfg_publication_bodies: distribution(),
                 cfg_construction_bodies: distribution(),
                 cfg_optimization_bodies: distribution(),
                 joins: 0,
@@ -693,16 +725,38 @@ mod tests {
     }
 
     #[test]
-    fn historical_critical_path_evidence_defaults_semantic_materialization() {
+    fn historical_critical_path_evidence_defaults_cfg_breakdown() {
         let mut encoded = serde_json::to_value(evidence()).unwrap();
-        encoded["critical_path"]
-            .as_object_mut()
-            .unwrap()
-            .remove("semantic_materialization_bodies");
+        let critical = encoded["critical_path"].as_object_mut().unwrap();
+        for field in [
+            "cfg_input_preparation_bodies",
+            "semantic_materialization_bodies",
+            "cfg_domain_prerequisite_bodies",
+            "cfg_builder_bodies",
+            "cfg_publication_bodies",
+        ] {
+            critical.remove(field);
+        }
 
         let decoded: BuildBoundaryEvidence = serde_json::from_value(encoded).unwrap();
         assert_eq!(
+            decoded.critical_path.cfg_input_preparation_bodies,
+            DurationDistribution::default()
+        );
+        assert_eq!(
             decoded.critical_path.semantic_materialization_bodies,
+            DurationDistribution::default()
+        );
+        assert_eq!(
+            decoded.critical_path.cfg_domain_prerequisite_bodies,
+            DurationDistribution::default()
+        );
+        assert_eq!(
+            decoded.critical_path.cfg_builder_bodies,
+            DurationDistribution::default()
+        );
+        assert_eq!(
+            decoded.critical_path.cfg_publication_bodies,
             DurationDistribution::default()
         );
         decoded

--- a/crates/rue-perf-schema/src/scaling.rs
+++ b/crates/rue-perf-schema/src/scaling.rs
@@ -15,7 +15,7 @@ use crate::{
 };
 
 /// Version of the scaling-report wire format.
-pub const SCALING_REPORT_SCHEMA_VERSION: u32 = 15;
+pub const SCALING_REPORT_SCHEMA_VERSION: u32 = 16;
 
 /// The lower-frequency scaling suite declaration.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]

--- a/crates/rue/src/main.rs
+++ b/crates/rue/src/main.rs
@@ -1061,8 +1061,13 @@ fn compiler_critical_path_evidence(
         peak_query_workers: runtime.peak_query_workers,
         toolchain_acquisition_ns: timing.pass_total_ns("toolchain_acquisition"),
         semantic_bodies: timing.pass_duration_distribution("body_analysis"),
+        cfg_input_preparation_bodies: timing.pass_duration_distribution("cfg_input_preparation"),
         semantic_materialization_bodies: timing
             .pass_duration_distribution("semantic_materialization"),
+        cfg_domain_prerequisite_bodies: timing
+            .pass_duration_distribution("cfg_domain_prerequisites"),
+        cfg_builder_bodies: timing.pass_duration_distribution("cfg_builder"),
+        cfg_publication_bodies: timing.pass_duration_distribution("cfg_publication"),
         cfg_construction_bodies: timing.pass_duration_distribution("cfg_construction"),
         cfg_optimization_bodies: timing.pass_duration_distribution("cfg_optimization"),
         joins: runtime.joins,

--- a/crates/rue/src/timing.rs
+++ b/crates/rue/src/timing.rs
@@ -1147,6 +1147,15 @@ struct TimingFlushVisitor(bool);
 #[derive(Default)]
 struct TimingDurationVisitor(Option<u64>);
 
+#[derive(Default)]
+struct CfgConstructionBreakdownVisitor {
+    input_preparation_ns: Option<u64>,
+    semantic_materialization_ns: Option<u64>,
+    domain_prerequisites_ns: Option<u64>,
+    cfg_builder_ns: Option<u64>,
+    cfg_publication_ns: Option<u64>,
+}
+
 impl tracing::field::Visit for TimingFlushVisitor {
     fn record_bool(&mut self, field: &tracing::field::Field, value: bool) {
         if field.name() == "timing_flush" {
@@ -1161,6 +1170,21 @@ impl tracing::field::Visit for TimingDurationVisitor {
     fn record_u64(&mut self, field: &tracing::field::Field, value: u64) {
         if field.name() == "duration_ns" {
             self.0 = Some(value);
+        }
+    }
+
+    fn record_debug(&mut self, _field: &tracing::field::Field, _value: &dyn std::fmt::Debug) {}
+}
+
+impl tracing::field::Visit for CfgConstructionBreakdownVisitor {
+    fn record_u64(&mut self, field: &tracing::field::Field, value: u64) {
+        match field.name() {
+            "input_preparation_ns" => self.input_preparation_ns = Some(value),
+            "semantic_materialization_ns" => self.semantic_materialization_ns = Some(value),
+            "domain_prerequisites_ns" => self.domain_prerequisites_ns = Some(value),
+            "cfg_builder_ns" => self.cfg_builder_ns = Some(value),
+            "cfg_publication_ns" => self.cfg_publication_ns = Some(value),
+            _ => {}
         }
     }
 
@@ -1226,6 +1250,39 @@ where
                 self.data.flush_local();
                 #[cfg(test)]
                 self.data.record_flush_marker();
+            }
+            return;
+        }
+        if event.metadata().target() == "rue::timing"
+            && event.metadata().name() == "cfg_construction_breakdown"
+        {
+            let mut visitor = CfgConstructionBreakdownVisitor::default();
+            event.record(&mut visitor);
+            let (
+                Some(input_preparation_ns),
+                Some(semantic_materialization_ns),
+                Some(domain_prerequisites_ns),
+                Some(cfg_builder_ns),
+                Some(cfg_publication_ns),
+            ) = (
+                visitor.input_preparation_ns,
+                visitor.semantic_materialization_ns,
+                visitor.domain_prerequisites_ns,
+                visitor.cfg_builder_ns,
+                visitor.cfg_publication_ns,
+            )
+            else {
+                return;
+            };
+            for (name, duration_ns) in [
+                ("cfg_input_preparation", input_preparation_ns),
+                ("semantic_materialization", semantic_materialization_ns),
+                ("cfg_domain_prerequisites", domain_prerequisites_ns),
+                ("cfg_builder", cfg_builder_ns),
+                ("cfg_publication", cfg_publication_ns),
+            ] {
+                self.data
+                    .record_span(name, Duration::from_nanos(duration_ns), false, true);
             }
             return;
         }
@@ -2422,6 +2479,37 @@ mod phase_accounting_tests {
         assert_eq!(distribution.max_ns, 64);
         assert_eq!(distribution.log2_buckets[5], 1);
         assert_eq!(distribution.log2_buckets[6], 1);
+    }
+
+    #[test]
+    fn cfg_breakdown_event_populates_each_bounded_distribution() {
+        let data = TimingData::new();
+        let subscriber = tracing_subscriber::registry().with(TimingLayer::new(data.clone()));
+        tracing::subscriber::with_default(subscriber, || {
+            tracing::event!(
+                name: "cfg_construction_breakdown",
+                target: "rue::timing",
+                tracing::Level::INFO,
+                input_preparation_ns = 2_u64,
+                semantic_materialization_ns = 4_u64,
+                domain_prerequisites_ns = 8_u64,
+                cfg_builder_ns = 16_u64,
+                cfg_publication_ns = 32_u64,
+            );
+        });
+
+        for (name, expected_ns) in [
+            ("cfg_input_preparation", 2),
+            ("semantic_materialization", 4),
+            ("cfg_domain_prerequisites", 8),
+            ("cfg_builder", 16),
+            ("cfg_publication", 32),
+        ] {
+            let distribution = data.pass_duration_distribution(name);
+            assert_eq!(distribution.count, 1, "{name}");
+            assert_eq!(distribution.total_ns, expected_ns, "{name}");
+            assert_eq!(distribution.max_ns, expected_ns, "{name}");
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- partition each successful CFG-construction body into input preparation, local semantic materialization, domain/prerequisite queries, CFG builder, and publication/ABI work
- publish all five durations through one worker-local timing event to keep observer overhead bounded
- extend the scaling evidence schema and report while preserving additive defaults for historical records

## Why

The corrected profile shows local materialization is 169.84 ms of 587.94 ms one-worker Lattice CFG construction (28.9%). This partition identifies the owner of the remaining ~418 ms before choosing an optimization or architectural change.

## Evidence

- `scripts/rue fmt`
- `scripts/rue quick` (31 targets passed)

Refs RUE-1473.