### PR TITLE
RUE-1473: deduplicate CFG type-fact requests

### DIFF
--- a/crates/rue-bench/src/scaling.rs
+++ b/crates/rue-bench/src/scaling.rs
@@ -692,7 +692,7 @@ fn render(report: &ScalingReport) -> String {
     }
 
     out.push_str("\n## CFG prerequisite work\n\n");
-    out.push_str("Counts are exact for stable types reached from body-local CFG domains and the unique registered prerequisite requests issued before AIR-to-CFG construction. `requests/type` exposes query traffic independently of elapsed time; type facts and drop glue intentionally share the same drop-relevant type set.\n\n");
+    out.push_str("Counts are exact for stable types reached from body-local CFG domains and the unique registered prerequisite requests issued before AIR-to-CFG construction. `requests/type` exposes query traffic independently of elapsed time. Drop-glue terminals transitively observe their exact type-fact terminals; direct type-fact requests remain separate here so duplicate parent edges stay visible.\n\n");
     out.push_str("| workload | stable types scanned | layout requests | type-fact requests | drop-glue requests | requests/type |\n");
     out.push_str("| --- | ---: | ---: | ---: | ---: | ---: |\n");
     for observation in reference_observations(report) {

--- a/crates/rue-compiler/src/cfg_query.rs
+++ b/crates/rue-compiler/src/cfg_query.rs
@@ -1148,10 +1148,6 @@ fn materialize_and_build_cfg(
         layout_prerequisite_requests,
     ));
     context.record_work(rue_query::WorkItem::new(
-        "cfg.prerequisite.type-fact-requests",
-        drop_prerequisite_requests,
-    ));
-    context.record_work(rue_query::WorkItem::new(
         "cfg.prerequisite.drop-glue-requests",
         drop_prerequisite_requests,
     ));
@@ -1173,7 +1169,9 @@ fn materialize_and_build_cfg(
             configuration: key.configuration.clone(),
         })
         .collect::<Vec<_>>();
-    context.query_registered_batch(type_facts, drop_dependencies.iter().cloned())?;
+    // Every DropGlue terminal observes the exact TypeFacts terminal for the
+    // same key. Keep one direct CFG edge to that transitive cone instead of
+    // issuing and validating a duplicate top-level TypeFacts request.
     context.query_registered_batch(drop_glues, drop_dependencies)?;
     let prerequisite_queries_ns = elapsed_ns(prerequisite_queries_started);
     let breakdown = CfgConstructionBreakdown {

--- a/crates/rue-compiler/src/session.rs
+++ b/crates/rue-compiler/src/session.rs
@@ -8622,6 +8622,11 @@ mod tests {
             "without accessor imports, each newly built CFG scans its body-local interner charge exactly once: {cfg_work:?}"
         );
         assert!(cfg_work.retained_interner_charge_scans > 0, "{cfg_work:?}");
+        assert_eq!(
+            cfg_work.prerequisite_type_fact_requests, 0,
+            "drop-glue prerequisites already own the exact type-fact dependency: {cfg_work:?}"
+        );
+        assert!(cfg_work.prerequisite_drop_glue_requests > 0, "{cfg_work:?}");
         assert!(
             cfg_work.retained_interner_entries_scanned >= cfg_work.retained_interner_charge_scans,
             "{cfg_work:?}"


### PR DESCRIPTION
## Summary

- stop issuing a direct TypeFacts prerequisite request for every stable CFG type
- retain the identical transitive dependency cone through each DropGlue terminal, which already observes the exact TypeFacts terminal for its key
- pin the zero duplicate-request contract while preserving the same-layout drop-fact invalidation regression

## Evidence

The preceding hosted profile measured 25,141 direct TypeFacts prerequisite requests and 263.71 ms in registered CFG prerequisite queries for one-worker Lattice.

## Validation

- `scripts/rue fmt`
- `scripts/rue unit compiler cfg_local_materialization_preserves_body_callable_names`
- `scripts/rue unit compiler cfg_drop_facts_invalidate_same_layout_cleanup_changes`

Refs RUE-1473.