### PR TITLE
RUE-1473: inline one-worker CFG batches

### DIFF
--- a/crates/rue-compiler/src/cfg_query.rs
+++ b/crates/rue-compiler/src/cfg_query.rs
@@ -983,7 +983,7 @@ fn materialize_and_build_cfg(
             let plan_types = collect_plan_types(owner, facts)
                 .into_iter()
                 .collect::<Vec<_>>();
-            let terminals = context.query_registered_batch(
+            let terminals = context.query_registered_adaptive_batch(
                 layouts,
                 plan_types
                     .iter()
@@ -1014,7 +1014,7 @@ fn materialize_and_build_cfg(
         }
     };
     let mut builtin_facts = Vec::with_capacity(facts.builtin_nominals.len());
-    let builtin_terminals = context.query_registered_batch(
+    let builtin_terminals = context.query_registered_adaptive_batch(
         type_facts,
         facts
             .builtin_nominals
@@ -1153,7 +1153,7 @@ fn materialize_and_build_cfg(
     ));
     let prerequisite_collection_ns = elapsed_ns(prerequisite_collection_started);
     let prerequisite_queries_started = std::time::Instant::now();
-    context.query_registered_batch(
+    context.query_registered_adaptive_batch(
         layouts,
         layout_dependencies
             .into_iter()
@@ -1172,7 +1172,7 @@ fn materialize_and_build_cfg(
     // Every DropGlue terminal observes the exact TypeFacts terminal for the
     // same key. Keep one direct CFG edge to that transitive cone instead of
     // issuing and validating a duplicate top-level TypeFacts request.
-    context.query_registered_batch(drop_glues, drop_dependencies)?;
+    context.query_registered_adaptive_batch(drop_glues, drop_dependencies)?;
     let prerequisite_queries_ns = elapsed_ns(prerequisite_queries_started);
     let breakdown = CfgConstructionBreakdown {
         input_preparation_ns,
@@ -1258,7 +1258,7 @@ fn build_cfg(
             ));
         }
     };
-    let call_abi_terminals = context.query_registered_batch(
+    let call_abi_terminals = context.query_registered_adaptive_batch(
         call_abis,
         callables
             .iter()
@@ -1428,7 +1428,7 @@ pub(crate) fn evaluate_optimized_cfg(
     let mut implicit_destructor_dependencies_complete =
         record.implicit_destructor_dependencies_complete;
     let accessor_terminals =
-        context.query_registered_batch(cfgs, key.accessor_dependencies.iter().cloned())?;
+        context.query_registered_adaptive_batch(cfgs, key.accessor_dependencies.iter().cloned())?;
     let mut accessor_cfgs = std::collections::BTreeMap::new();
     for (dependency, terminal) in key.accessor_dependencies.iter().zip(accessor_terminals) {
         let QueryOutcome::Success(value) = terminal.outcome() else {

--- a/crates/rue-query/src/lib.rs
+++ b/crates/rue-query/src/lib.rs
@@ -7723,6 +7723,39 @@ impl QueryContext {
         result.into_result()
     }
 
+    /// Requests stable-ordered registered dependencies with concurrency-aware
+    /// scheduling.
+    ///
+    /// A one-permit runtime cannot execute batch siblings concurrently. In
+    /// that regime this keeps every request in the current task, preserving
+    /// the same dependency observations and result order without allocating
+    /// structured children or donating the sole permit. Wider runtimes use the
+    /// ordinary structured batch so independent evaluators can run in parallel.
+    pub fn query_registered_adaptive_batch<K, V>(
+        &self,
+        family: &QueryFamily<K, V>,
+        keys: impl IntoIterator<Item = K>,
+    ) -> Result<Vec<Arc<QueryTerminal<V>>>, QueryAbort>
+    where
+        K: QueryKey,
+        V: Clone + Send + Sync + 'static,
+    {
+        assert!(
+            family.inner.evaluator.is_some(),
+            "closure-free dependency requests require a registered evaluator"
+        );
+        if !Arc::ptr_eq(&self.task_runtime(), &family.core) {
+            return Err(QueryAbort::ForeignRuntime);
+        }
+        if self.max_concurrency() == 1 {
+            keys.into_iter()
+                .map(|key| self.query_registered(family, key))
+                .collect()
+        } else {
+            self.query_registered_batch(family, keys)
+        }
+    }
+
     /// Requests a stable-ordered batch of dependencies through one registered
     /// family.
     ///
@@ -14611,6 +14644,90 @@ mod tests {
         assert_eq!(serial.work(), parallel.work());
         assert_eq!(serial.dependencies(), parallel.dependencies());
         assert_eq!(serial.stamp(), parallel.stamp());
+    }
+
+    #[test]
+    fn adaptive_registered_batch_stays_inline_only_when_parallelism_is_impossible() {
+        fn run(workers: usize) -> (Arc<QueryTerminal<u64>>, RuntimeMetrics) {
+            let runtime = QueryRuntime::new(workers);
+            publish_empty(&runtime, [revision(1)]);
+            let leaf = runtime
+                .family_with_evaluator::<Key, u64, _>("adaptive-batch-leaf", 8, |_, _, key| {
+                    Ok(QueryOutput::success(key.0.len() as u64))
+                })
+                .unwrap();
+            let leaf_for_root = leaf.clone();
+            let root = runtime
+                .family_with_evaluator::<Key, u64, _>(
+                    "adaptive-batch-root",
+                    8,
+                    move |context, _, _| {
+                        let terminals = context.query_registered_adaptive_batch(
+                            &leaf_for_root,
+                            [Key("aa"), Key("bbb")],
+                        )?;
+                        let sum = terminals
+                            .iter()
+                            .map(|terminal| match terminal.outcome() {
+                                QueryOutcome::Success(value) => *value,
+                                QueryOutcome::Failure(_) => unreachable!("leaf cannot fail"),
+                            })
+                            .sum();
+                        Ok(QueryOutput::success(sum))
+                    },
+                )
+                .unwrap();
+            let terminal = runtime
+                .request_registered(&root, revision(1), Key("root"), CancellationToken::new())
+                .into_result()
+                .unwrap();
+            let metrics = runtime.metrics();
+            (terminal, metrics)
+        }
+
+        let (serial, serial_metrics) = run(1);
+        let (parallel, parallel_metrics) = run(2);
+        assert_eq!(serial.outcome(), &QueryOutcome::Success(5));
+        assert_eq!(serial.outcome(), parallel.outcome());
+        let dependency_keys = |terminal: &QueryTerminal<u64>| {
+            terminal
+                .dependencies()
+                .iter()
+                .map(|dependency| dependency.node.key().to_owned())
+                .collect::<Vec<_>>()
+        };
+        assert_eq!(dependency_keys(&serial), dependency_keys(&parallel));
+        assert_eq!(serial_metrics.donated_permits, 0);
+        assert_eq!(serial_metrics.ready_items, 0);
+        assert_eq!(parallel_metrics.donated_permits, 1);
+        assert_eq!(parallel_metrics.ready_items, 2);
+    }
+
+    #[test]
+    fn adaptive_registered_batch_rejects_an_empty_foreign_family() {
+        let runtime = QueryRuntime::new(1);
+        publish_empty(&runtime, [revision(1)]);
+        let foreign_runtime = QueryRuntime::new(1);
+        publish_empty(&foreign_runtime, [revision(1)]);
+        let foreign = foreign_runtime
+            .family_with_evaluator::<Key, u64, _>("adaptive-foreign", 2, |_, _, _| {
+                Ok(QueryOutput::success(0))
+            })
+            .unwrap();
+        let root = runtime
+            .family_with_evaluator::<Key, u64, _>(
+                "adaptive-foreign-root",
+                2,
+                move |context, _, _| {
+                    context.query_registered_adaptive_batch(&foreign, std::iter::empty::<Key>())?;
+                    Ok(QueryOutput::success(0))
+                },
+            )
+            .unwrap();
+
+        let attempt =
+            runtime.request_registered(&root, revision(1), Key("root"), CancellationToken::new());
+        assert_eq!(attempt.abort(), Some(&QueryAbort::ForeignRuntime));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- add a concurrency-aware registered batch operation that keeps stable-ordered requests in the current task when the runtime has one permit
- preserve ordinary structured parallel batches for wider runtimes
- use the adaptive operation for CFG prerequisite, ABI, builtin, drop-glue synthesis, and accessor requests

A one-worker runtime cannot execute siblings concurrently. Avoiding structured child tasks removes allocation, ready-queue accounting, proof transfer, and sole-permit donation while preserving the same exact dependency observations and result order.

## Validation

- `scripts/rue fmt`
- `scripts/rue unit query adaptive_registered_batch_stays_inline_only_when_parallelism_is_impossible`
- `scripts/rue unit compiler cfg_drop_facts_invalidate_same_layout_cleanup_changes`

Refs RUE-1473.