### PR TITLE
RUE-1469: make interner byte accounting constant-time

### DIFF
--- a/crates/rue-compiler/src/cfg_query.rs
+++ b/crates/rue-compiler/src/cfg_query.rs
@@ -531,62 +531,50 @@ impl RetainedCharge for lasso::ThreadedRodeo {
     }
 }
 
-fn measure_interner_retained_charge(interner: &lasso::ThreadedRodeo) -> (u64, u64, u64) {
+fn measure_interner_retained_charge(interner: &lasso::ThreadedRodeo) -> (u64, u64) {
     let entries = interner.len() as u64;
-    let utf8_bytes = interner.strings().fold(0_u64, |bytes, value| {
-        bytes.saturating_add(value.len() as u64)
-    });
+    let utf8_bytes = interner.utf8_bytes() as u64;
     (
         entries
             .saturating_mul(std::mem::size_of::<lasso::Spur>() as u64)
             .saturating_add(utf8_bytes),
         entries,
-        utf8_bytes,
     )
+}
+
+fn interner_header_retained_charge(interner: &lasso::ThreadedRodeo) -> u64 {
+    // `utf8_bytes` is measurement-only bookkeeping added to the vendored
+    // interner. Exclude that one atomic from the logical artifact charge so
+    // replacing the traversal does not change retention policy.
+    (std::mem::size_of_val(interner) as u64)
+        .saturating_sub(std::mem::size_of::<std::sync::atomic::AtomicUsize>() as u64)
 }
 
 fn refresh_interner_retained_charge(
     interner: &lasso::ThreadedRodeo,
     charge: &std::sync::atomic::AtomicU64,
     published_entries: u64,
-) -> Option<(u64, u64)> {
+) -> bool {
     if interner.len() as u64 == published_entries {
-        return None;
+        return false;
     }
-    let (payload, entries, utf8_bytes) = measure_interner_retained_charge(interner);
+    let (payload, _) = measure_interner_retained_charge(interner);
     charge.fetch_max(
-        (std::mem::size_of_val(interner) as u64).saturating_add(payload),
+        interner_header_retained_charge(interner).saturating_add(payload),
         std::sync::atomic::Ordering::Relaxed,
     );
-    Some((entries, utf8_bytes))
+    true
 }
 
-struct InternerChargeRefresh<'a> {
-    context: &'a QueryContext,
+struct InternerChargeRefresh {
     interner: Arc<lasso::ThreadedRodeo>,
     charge: Arc<std::sync::atomic::AtomicU64>,
     published_entries: u64,
 }
 
-impl Drop for InternerChargeRefresh<'_> {
+impl Drop for InternerChargeRefresh {
     fn drop(&mut self) {
-        let Some((entries, utf8_bytes)) =
-            refresh_interner_retained_charge(&self.interner, &self.charge, self.published_entries)
-        else {
-            return;
-        };
-        self.context.record_work(rue_query::WorkItem::new(
-            "cfg.retained-interner-charge-scans",
-            1,
-        ));
-        self.context.record_work(rue_query::WorkItem::new(
-            "cfg.retained-interner-entries-scanned",
-            entries,
-        ));
-        self.context.record_work(rue_query::WorkItem::new(
-            "cfg.retained-interner-utf8-bytes-scanned",
-            utf8_bytes,
-        ));
+        refresh_interner_retained_charge(&self.interner, &self.charge, self.published_entries);
     }
 }
 
@@ -1322,23 +1310,11 @@ fn build_cfg(
         // the live type pool for same-named structs outside this CFG's domain.
         implicit_destructor_targets.insert(owner.clone());
     }
-    let (interner_payload_charge, interner_entries, interner_utf8_bytes) =
+    let (interner_payload_charge, interner_entries) =
         measure_interner_retained_charge(&materialized.interner);
     let interner_retained_charge = Arc::new(std::sync::atomic::AtomicU64::new(
-        (std::mem::size_of_val(materialized.interner.as_ref()) as u64)
+        interner_header_retained_charge(materialized.interner.as_ref())
             .saturating_add(interner_payload_charge),
-    ));
-    context.record_work(rue_query::WorkItem::new(
-        "cfg.retained-interner-charge-scans",
-        1,
-    ));
-    context.record_work(rue_query::WorkItem::new(
-        "cfg.retained-interner-entries-scanned",
-        interner_entries,
-    ));
-    context.record_work(rue_query::WorkItem::new(
-        "cfg.retained-interner-utf8-bytes-scanned",
-        interner_utf8_bytes,
     ));
     let value = CfgValue::Available(Arc::new(CfgRecord {
         air: Arc::new(materialized.air),
@@ -1408,7 +1384,6 @@ pub(crate) fn evaluate_optimized_cfg(
     // append-only symbol universe. Refresh on every exit, including partial
     // import and optimization failures, before the returned terminal publishes.
     let _interner_charge_refresh = InternerChargeRefresh {
-        context,
         interner: interner.clone(),
         charge: record.interner_retained_charge.clone(),
         published_entries: record.interner_retained_entries,
@@ -1725,23 +1700,58 @@ mod accessor_graph_tests {
 
         let interner = lasso::ThreadedRodeo::new();
         interner.get_or_intern("caller");
-        let (payload, published_entries, _) = measure_interner_retained_charge(&interner);
+        let (payload, published_entries) = measure_interner_retained_charge(&interner);
         let charge =
-            AtomicU64::new((std::mem::size_of_val(&interner) as u64).saturating_add(payload));
+            AtomicU64::new(interner_header_retained_charge(&interner).saturating_add(payload));
 
         interner.get_or_intern("callee-only");
-        assert_eq!(
-            refresh_interner_retained_charge(&interner, &charge, published_entries),
-            Some((2, 17))
-        );
-        let (payload, current_entries, _) = measure_interner_retained_charge(&interner);
+        assert!(refresh_interner_retained_charge(
+            &interner,
+            &charge,
+            published_entries
+        ));
+        let (payload, current_entries) = measure_interner_retained_charge(&interner);
         assert_eq!(
             charge.load(Ordering::Relaxed),
-            (std::mem::size_of_val(&interner) as u64).saturating_add(payload)
+            interner_header_retained_charge(&interner).saturating_add(payload)
         );
+        assert!(!refresh_interner_retained_charge(
+            &interner,
+            &charge,
+            current_entries
+        ));
+    }
+
+    #[test]
+    fn interner_utf8_bytes_tracks_unique_dynamic_static_and_concurrent_strings() {
+        let interner = Arc::new(lasso::ThreadedRodeo::<lasso::Spur>::new());
+        interner.get_or_intern(String::from("dynamic"));
+        interner.get_or_intern("dynamic");
+        interner.get_or_intern_static("static");
+        interner.get_or_intern("");
+        interner.get_or_intern_static("");
+
+        std::thread::scope(|scope| {
+            for index in 0..8 {
+                let interner = interner.clone();
+                scope.spawn(move || {
+                    interner.get_or_intern("shared");
+                    interner.get_or_intern(format!("worker-{index}"));
+                });
+            }
+        });
+
+        let expected = "dynamic".len()
+            + "static".len()
+            + "shared".len()
+            + (0..8)
+                .map(|index| format!("worker-{index}").len())
+                .sum::<usize>();
+        assert_eq!(interner.len(), 12);
+        assert_eq!(interner.utf8_bytes(), expected);
         assert_eq!(
-            refresh_interner_retained_charge(&interner, &charge, current_entries),
-            None
+            interner.strings().map(str::len).sum::<usize>(),
+            interner.utf8_bytes()
         );
     }
 

--- a/crates/rue-compiler/src/session.rs
+++ b/crates/rue-compiler/src/session.rs
@@ -8618,22 +8618,20 @@ mod tests {
             "{cfg_work:?}"
         );
         assert_eq!(
-            cfg_work.retained_interner_charge_scans, cfg_work.cfg_builds_succeeded,
-            "without accessor imports, each newly built CFG scans its body-local interner charge exactly once: {cfg_work:?}"
+            cfg_work.retained_interner_charge_scans, 0,
+            "logical interner charge is maintained during insertion, not reconstructed at CFG publication: {cfg_work:?}"
         );
-        assert!(cfg_work.retained_interner_charge_scans > 0, "{cfg_work:?}");
         assert_eq!(
             cfg_work.prerequisite_type_fact_requests, 0,
             "drop-glue prerequisites already own the exact type-fact dependency: {cfg_work:?}"
         );
         assert!(cfg_work.prerequisite_drop_glue_requests > 0, "{cfg_work:?}");
-        assert!(
-            cfg_work.retained_interner_entries_scanned >= cfg_work.retained_interner_charge_scans,
+        assert_eq!(
+            cfg_work.retained_interner_entries_scanned, 0,
             "{cfg_work:?}"
         );
-        assert!(
-            cfg_work.retained_interner_utf8_bytes_scanned
-                >= cfg_work.retained_interner_entries_scanned,
+        assert_eq!(
+            cfg_work.retained_interner_utf8_bytes_scanned, 0,
             "{cfg_work:?}"
         );
         let names = semantic

--- a/third-party/vendor/lasso-0.7.3/src/threaded_rodeo.rs
+++ b/third-party/vendor/lasso-0.7.3/src/threaded_rodeo.rs
@@ -47,6 +47,8 @@ pub struct ThreadedRodeo<K = Spur, S = RandomState> {
     pub(crate) strings: DashMap<K, &'static str, S>,
     /// The current key value
     key: AtomicUsize,
+    /// Exact logical UTF-8 bytes held by the unique interned strings.
+    utf8_bytes: AtomicUsize,
     /// The arena where all strings are stored
     arena: LockfreeArena,
 }
@@ -252,6 +254,7 @@ where
             map: DashMap::with_capacity_and_hasher(strings, hash_builder.clone()),
             strings: DashMap::with_capacity_and_hasher(strings, hash_builder),
             key: AtomicUsize::new(0),
+            utf8_bytes: AtomicUsize::new(0),
             arena: LockfreeArena::new(bytes, max_memory_usage)
                 .expect("failed to allocate memory for interner"),
         }
@@ -341,6 +344,8 @@ where
                     let key = K::try_from_usize(self.key.fetch_add(1, Ordering::SeqCst))
                         .ok_or_else(|| LassoError::new(LassoErrorKind::KeySpaceExhaustion))?;
 
+                    self.utf8_bytes
+                        .fetch_add(string.len(), Ordering::Relaxed);
                     self.strings.insert(key, string);
                     // Safety: insert_slot was just returned by find_insert_slot and we have not mutated the shard.
                     unsafe {
@@ -417,6 +422,8 @@ where
                 Entry::Vacant(v) => {
                     let key = K::try_from_usize(self.key.fetch_add(1, Ordering::SeqCst))
                         .ok_or_else(|| LassoError::new(LassoErrorKind::KeySpaceExhaustion))?;
+                    self.utf8_bytes
+                        .fetch_add(string.len(), Ordering::Relaxed);
                     self.strings.insert(key, string);
                     v.insert(key);
 
@@ -553,6 +560,17 @@ where
     #[cfg_attr(feature = "inline-more", inline)]
     pub fn len(&self) -> usize {
         self.strings.len()
+    }
+
+    /// Returns the exact logical number of UTF-8 bytes in unique interned
+    /// strings without traversing the interner.
+    ///
+    /// This excludes hash-table and arena capacity. Static and dynamically
+    /// copied strings are counted identically because both occupy one logical
+    /// interner entry.
+    #[cfg_attr(feature = "inline-more", inline)]
+    pub fn utf8_bytes(&self) -> usize {
+        self.utf8_bytes.load(Ordering::Relaxed)
     }
 
     /// Returns `true` if there are no currently interned strings
@@ -777,6 +795,7 @@ where
         f.debug_struct("ThreadedRodeo")
             .field("map", &self.map)
             .field("strings", &self.strings)
+            .field("utf8_bytes", &self.utf8_bytes.load(Ordering::Relaxed))
             .field("arena", &self.arena)
             .finish()
     }
@@ -961,8 +980,9 @@ where
         D: Deserializer<'de>,
     {
         let deser_map: HashMap<String, K> = HashMap::deserialize(deserializer)?;
+        let logical_utf8_bytes = deser_map.keys().map(|s| s.len()).sum::<usize>();
         let capacity = {
-            let total_bytes = deser_map.keys().map(|s| s.len()).sum::<usize>();
+            let total_bytes = logical_utf8_bytes;
             let total_bytes =
                 NonZeroUsize::new(total_bytes).unwrap_or_else(|| Capacity::default().bytes());
 
@@ -995,6 +1015,7 @@ where
             map,
             strings,
             key: AtomicUsize::new(highest),
+            utf8_bytes: AtomicUsize::new(logical_utf8_bytes),
             arena,
         })
     }


### PR DESCRIPTION
## Summary

- maintain an exact atomic UTF-8 byte count inside the vendored concurrent lasso interner
- compute CFG interner retained charge from constant-time entry and byte counters
- remove publication and refresh traversals while preserving the existing allocator-independent logical charge
- cover duplicate, dynamic, static, empty, and concurrent interning and require zero CFG charge scans

## Validation

- `scripts/rue fmt`
- `scripts/rue unit compiler retained_interner_charge`
- `scripts/rue unit compiler interner_utf8_bytes_tracks`
- `scripts/rue unit compiler cfg_local_materialization_preserves_body_callable_names`
- `scripts/rue quick`

Fixes RUE-1469.
