### PR TITLE
RUE-1473: expose semantic prerequisite timing

### DIFF
--- a/crates/rue-bench/src/scaling.rs
+++ b/crates/rue-bench/src/scaling.rs
@@ -365,10 +365,10 @@ fn render(report: &ScalingReport) -> String {
     }
 
     out.push_str("\n## Worker scaling and critical path\n\n");
-    out.push_str("Utilization divides summed query-worker active time by compiler-root time and the compiler's resolved worker count. Ready wait is summed across dependency-ready items, so the mean and maximum are the directly comparable latency signals. Body columns show total/max milliseconds from bounded compiler histograms. The five top-level CFG breakdown columns are non-overlapping lexical intervals inside each successful CFG body; projection, dependency collection, and prerequisite queries further partition the domain/prerequisite interval. CFG total remains the inclusive query duration and can be slightly larger because it also contains timing publication and outer query bookkeeping. The rooted-acquisition envelope is inclusive: it contains the semantic attempt used to discover a trusted-toolchain park, is not an exclusive phase, and must not be added to semantic time or read as filesystem cost.\n\n");
-    out.push_str("| workload / workers | utilization | active ms | ready mean/max ms | longest chain | rooted acquisition envelope ms | semantic total/max ms | CFG input total/max ms | local epoch total/max ms | domain/prereq total/max ms | domain projection total/max ms | prerequisite collection total/max ms | prerequisite queries total/max ms | CFG builder total/max ms | publication total/max ms | CFG total/max ms | CFG opt total/max ms | joins declined/total | donated permits |\n");
+    out.push_str("Utilization divides summed query-worker active time by compiler-root time and the compiler's resolved worker count. Ready wait is summed across dependency-ready items, so the mean and maximum are the directly comparable latency signals. Body columns show total/max milliseconds from bounded compiler histograms. Semantic prerequisite and analysis columns are adjacent, non-overlapping lexical intervals inside each body transaction. The five top-level CFG breakdown columns are non-overlapping lexical intervals inside each successful CFG body; projection, dependency collection, and prerequisite queries further partition the domain/prerequisite interval. CFG total remains the inclusive query duration and can be slightly larger because it also contains timing publication and outer query bookkeeping. The rooted-acquisition envelope is inclusive: it contains the semantic attempt used to discover a trusted-toolchain park, is not an exclusive phase, and must not be added to semantic time or read as filesystem cost.\n\n");
+    out.push_str("| workload / workers | utilization | active ms | ready mean/max ms | longest chain | rooted acquisition envelope ms | semantic prerequisites total/max ms | semantic analysis total/max ms | CFG input total/max ms | local epoch total/max ms | domain/prereq total/max ms | domain projection total/max ms | prerequisite collection total/max ms | prerequisite queries total/max ms | CFG builder total/max ms | publication total/max ms | CFG total/max ms | CFG opt total/max ms | joins declined/total | donated permits |\n");
     out.push_str(
-        "| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |\n",
+        "| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |\n",
     );
     for observation in &report.workloads {
         let evidence = observation.samples.iter().map(|sample| {
@@ -402,6 +402,16 @@ fn render(report: &ScalingReport) -> String {
         let ready_max = summarize(evidence.clone().map(|e| e.max_ready_wait_ns));
         let chain = summarize(evidence.clone().map(|e| e.longest_query_dependency_chain));
         let toolchain = summarize(evidence.clone().map(|e| e.toolchain_acquisition_ns));
+        let semantic_prerequisite_total = summarize(
+            evidence
+                .clone()
+                .map(|e| e.semantic_prerequisite_bodies.total_ns),
+        );
+        let semantic_prerequisite_max = summarize(
+            evidence
+                .clone()
+                .map(|e| e.semantic_prerequisite_bodies.max_ns),
+        );
         let semantic_total = summarize(evidence.clone().map(|e| e.semantic_bodies.total_ns));
         let semantic_max = summarize(evidence.clone().map(|e| e.semantic_bodies.max_ns));
         let input_total = summarize(
@@ -477,7 +487,7 @@ fn render(report: &ScalingReport) -> String {
         let declined = summarize(evidence.clone().map(|e| e.declined_joins));
         let donated = summarize(evidence.map(|e| e.donated_permits));
         out.push_str(&format!(
-            "| {} | {:.1}% | {:.2} | {:.3}/{:.3} | {} | {:.2} | {:.2}/{:.2} | {:.2}/{:.2} | {:.2}/{:.2} | {:.2}/{:.2} | {:.2}/{:.2} | {:.2}/{:.2} | {:.2}/{:.2} | {:.2}/{:.2} | {:.2}/{:.2} | {:.2}/{:.2} | {:.2}/{:.2} | {}/{} | {} |\n",
+            "| {} | {:.1}% | {:.2} | {:.3}/{:.3} | {} | {:.2} | {:.2}/{:.2} | {:.2}/{:.2} | {:.2}/{:.2} | {:.2}/{:.2} | {:.2}/{:.2} | {:.2}/{:.2} | {:.2}/{:.2} | {:.2}/{:.2} | {:.2}/{:.2} | {:.2}/{:.2} | {:.2}/{:.2} | {:.2}/{:.2} | {}/{} | {} |\n",
             observation_label(observation),
             utilization.median as f64 / 100.0,
             active.median as f64 / 1_000_000.0,
@@ -485,6 +495,8 @@ fn render(report: &ScalingReport) -> String {
             ready_max.median as f64 / 1_000_000.0,
             chain.median,
             toolchain.median as f64 / 1_000_000.0,
+            semantic_prerequisite_total.median as f64 / 1_000_000.0,
+            semantic_prerequisite_max.median as f64 / 1_000_000.0,
             semantic_total.median as f64 / 1_000_000.0,
             semantic_max.median as f64 / 1_000_000.0,
             input_total.median as f64 / 1_000_000.0,

--- a/crates/rue-perf-schema/src/boundary.rs
+++ b/crates/rue-perf-schema/src/boundary.rs
@@ -376,6 +376,9 @@ pub struct CompilerCriticalPathEvidence {
     /// Inclusive duration of reached-toolchain acquisition inside compiler root.
     pub toolchain_acquisition_ns: u64,
     pub semantic_bodies: DurationDistribution,
+    /// Registered-query prerequisites acquired before each body analysis.
+    #[serde(default)]
+    pub semantic_prerequisite_bodies: DurationDistribution,
     /// Stable-input preparation before body-local semantic materialization.
     #[serde(default)]
     pub cfg_input_preparation_bodies: DurationDistribution,
@@ -560,6 +563,7 @@ impl BuildBoundaryEvidence {
 
         let critical = &self.critical_path;
         if !critical.semantic_bodies.validate()
+            || !critical.semantic_prerequisite_bodies.validate()
             || !critical.cfg_input_preparation_bodies.validate()
             || !critical.semantic_materialization_bodies.validate()
             || !critical.cfg_domain_prerequisite_bodies.validate()
@@ -609,6 +613,9 @@ impl BuildBoundaryEvidence {
     ) -> Result<(), String> {
         self.validate_against(policy, target)?;
         let critical = &self.critical_path;
+        if critical.semantic_prerequisite_bodies.count == 0 {
+            return Err("compiler omitted semantic-prerequisite evidence".to_string());
+        }
         let breakdown_counts = [
             critical.cfg_input_preparation_bodies.count,
             critical.semantic_materialization_bodies.count,
@@ -707,6 +714,7 @@ mod tests {
                 peak_query_workers: 1,
                 toolchain_acquisition_ns: 1,
                 semantic_bodies: distribution(),
+                semantic_prerequisite_bodies: distribution(),
                 cfg_input_preparation_bodies: distribution(),
                 semantic_materialization_bodies: distribution(),
                 cfg_domain_prerequisite_bodies: distribution(),
@@ -747,6 +755,7 @@ mod tests {
         let mut encoded = serde_json::to_value(evidence()).unwrap();
         let critical = encoded["critical_path"].as_object_mut().unwrap();
         for field in [
+            "semantic_prerequisite_bodies",
             "cfg_input_preparation_bodies",
             "semantic_materialization_bodies",
             "cfg_domain_prerequisite_bodies",
@@ -760,6 +769,10 @@ mod tests {
         }
 
         let decoded: BuildBoundaryEvidence = serde_json::from_value(encoded).unwrap();
+        assert_eq!(
+            decoded.critical_path.semantic_prerequisite_bodies,
+            DurationDistribution::default()
+        );
         assert_eq!(
             decoded.critical_path.cfg_input_preparation_bodies,
             DurationDistribution::default()

--- a/crates/rue/src/main.rs
+++ b/crates/rue/src/main.rs
@@ -1061,6 +1061,7 @@ fn compiler_critical_path_evidence(
         peak_query_workers: runtime.peak_query_workers,
         toolchain_acquisition_ns: timing.pass_total_ns("toolchain_acquisition"),
         semantic_bodies: timing.pass_duration_distribution("body_analysis"),
+        semantic_prerequisite_bodies: timing.pass_duration_distribution("body_query_prerequisites"),
         cfg_input_preparation_bodies: timing.pass_duration_distribution("cfg_input_preparation"),
         semantic_materialization_bodies: timing
             .pass_duration_distribution("semantic_materialization"),

--- a/docs/process/compiler-scaling.md
+++ b/docs/process/compiler-scaling.md
@@ -61,8 +61,8 @@ independently verified native output digest. The report records:
 - query-worker active time and peak workers;
 - dependency-ready item count, summed queue delay, and maximum queue delay;
 - longest query/dependency ancestry;
-- bounded semantic, CFG-construction, and CFG-optimization body-duration
-  histograms;
+- bounded semantic-prerequisite, semantic-analysis, CFG-construction, and
+  CFG-optimization body-duration histograms;
 - the inclusive reached-toolchain acquisition envelope (which contains the
   rooted semantic attempt), joins, declined joins, and permit donations;
 - output binary size.
@@ -78,6 +78,12 @@ ready-item mean and maximum wait separately because the total is additive over
 items rather than elapsed wall time. Body timing distributions use 64 bounded
 log2 buckets, exact count/total/maximum, thread-local accumulation, and bounded
 worker-completion merges; they never retain one event per body.
+
+Semantic prerequisite and analysis durations are adjacent, non-overlapping
+intervals inside each reached body transaction. The prerequisite interval owns
+registered toolchain-demand, anonymous-nominal, and well-known-type queries;
+the analysis interval owns body-input lowering, semantic-provider execution,
+stable-key projection, and body-transaction publication.
 
 The reached-toolchain value is an inclusive host-operation envelope, not an
 exclusive phase. The operation runs the rooted semantic attempt to discover


### PR DESCRIPTION
## Summary

- export the existing per-body semantic-prerequisite span as bounded critical-path evidence
- render prerequisite and analysis totals side by side in scaling reports
- preserve historical evidence compatibility with an additive default while requiring the field from current producers

## Validation

- `scripts/rue fmt`
- `scripts/rue quick` (31 targets, 0 failures)

Refs RUE-1473.