### PR TITLE
RUE-1473: attribute semantic graph construction

### DIFF
--- a/crates/rue-bench/src/scaling.rs
+++ b/crates/rue-bench/src/scaling.rs
@@ -7,9 +7,10 @@
 use std::path::{Path, PathBuf};
 
 use rue_perf_schema::{
-    Band, BuildBoundaryPolicy, SCALING_REPORT_SCHEMA_VERSION, ScalingIdentity, ScalingManifest,
-    ScalingObservation, ScalingRegime, ScalingReport, Summary, WorkerSetting, WorkloadShape,
-    canonical_json, content_address,
+    Band, BuildBoundaryPolicy, CompilerCriticalPathEvidence, DurationDistribution,
+    SCALING_REPORT_SCHEMA_VERSION, ScalingIdentity, ScalingManifest, ScalingObservation,
+    ScalingRegime, ScalingReport, Summary, WorkerSetting, WorkloadShape, canonical_json,
+    content_address,
 };
 
 use crate::measure::{SampleRequest, measure_fresh_compile};
@@ -522,6 +523,51 @@ fn render(report: &ScalingReport) -> String {
             declined.median,
             joins.median,
             donated.median,
+        ));
+    }
+
+    out.push_str("\n## Semantic critical-path detail\n\n");
+    out.push_str("Declaration graph, body closure, and body graph projection are adjacent, non-overlapping intervals after a semantic request selects its root inputs. Occurrence-index and nucleus columns are nested inside declaration graph; body prerequisite and analysis columns are nested inside body closure. Nested columns explain their owner and must not be added to the enclosing interval.\n\n");
+    out.push_str("| workload / workers | declaration graph total/max ms | occurrence indexes total/max ms | declaration nuclei total/max ms | body closure total/max ms | body graph projection total/max ms | body prerequisites total/max ms | body analysis total/max ms |\n");
+    out.push_str("| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |\n");
+    for observation in &report.workloads {
+        let evidence = observation.samples.iter().map(|sample| {
+            sample
+                .boundary_evidence
+                .first()
+                .map(|evidence| evidence.critical_path.clone())
+                .unwrap_or_default()
+        });
+        let pair = |select: fn(&CompilerCriticalPathEvidence) -> &DurationDistribution| {
+            (
+                summarize(evidence.clone().map(|value| select(&value).total_ns)),
+                summarize(evidence.clone().map(|value| select(&value).max_ns)),
+            )
+        };
+        let declaration_graph = pair(|value| &value.semantic_declaration_graph);
+        let occurrence = pair(|value| &value.semantic_declaration_occurrence_indexes);
+        let nuclei = pair(|value| &value.semantic_declaration_nuclei);
+        let body_closure = pair(|value| &value.semantic_body_closure);
+        let body_projection = pair(|value| &value.semantic_body_graph_projection);
+        let prerequisites = pair(|value| &value.semantic_prerequisite_bodies);
+        let analysis = pair(|value| &value.semantic_bodies);
+        out.push_str(&format!(
+            "| {} | {:.2}/{:.2} | {:.2}/{:.2} | {:.2}/{:.2} | {:.2}/{:.2} | {:.2}/{:.2} | {:.2}/{:.2} | {:.2}/{:.2} |\n",
+            observation_label(observation),
+            declaration_graph.0.median as f64 / 1_000_000.0,
+            declaration_graph.1.median as f64 / 1_000_000.0,
+            occurrence.0.median as f64 / 1_000_000.0,
+            occurrence.1.median as f64 / 1_000_000.0,
+            nuclei.0.median as f64 / 1_000_000.0,
+            nuclei.1.median as f64 / 1_000_000.0,
+            body_closure.0.median as f64 / 1_000_000.0,
+            body_closure.1.median as f64 / 1_000_000.0,
+            body_projection.0.median as f64 / 1_000_000.0,
+            body_projection.1.median as f64 / 1_000_000.0,
+            prerequisites.0.median as f64 / 1_000_000.0,
+            prerequisites.1.median as f64 / 1_000_000.0,
+            analysis.0.median as f64 / 1_000_000.0,
+            analysis.1.median as f64 / 1_000_000.0,
         ));
     }
 

--- a/crates/rue-compiler/src/session.rs
+++ b/crates/rue-compiler/src/session.rs
@@ -4420,6 +4420,9 @@ impl CompilerSession {
             .modules_iter()
             .map(|module| module.module_id().clone())
             .collect::<Vec<_>>();
+        let _declaration_graph_collection_span =
+            tracing::info_span!("declaration_graph_collection", phase = "semantic_analysis")
+                .entered();
         let projection = match self
             .queries
             .revisioned
@@ -4511,6 +4514,7 @@ impl CompilerSession {
             target: options.target,
             preview_features: StablePreviewFeatures::new(&options.preview_features),
         };
+        drop(_declaration_graph_collection_span);
         // This compiler-owned consumer boundary includes retained-terminal
         // validation, query dispatch, deterministic terminal collection, and
         // the immediate work reduction. The timing layer records it
@@ -4558,6 +4562,8 @@ impl CompilerSession {
             }
         }
         drop(_body_closure_collection_span);
+        let _body_graph_projection_span =
+            tracing::info_span!("body_graph_projection", phase = "semantic_analysis").entered();
         let mut errors = closure
             .scheduling_errors
             .iter()

--- a/crates/rue-perf-schema/src/boundary.rs
+++ b/crates/rue-perf-schema/src/boundary.rs
@@ -379,6 +379,21 @@ pub struct CompilerCriticalPathEvidence {
     /// Registered-query prerequisites acquired before each body analysis.
     #[serde(default)]
     pub semantic_prerequisite_bodies: DurationDistribution,
+    /// Inclusive request-wide declaration graph collection.
+    #[serde(default)]
+    pub semantic_declaration_graph: DurationDistribution,
+    /// Module-local declaration occurrence index requests inside that graph.
+    #[serde(default)]
+    pub semantic_declaration_occurrence_indexes: DurationDistribution,
+    /// Exact declaration-nucleus requests inside that graph.
+    #[serde(default)]
+    pub semantic_declaration_nuclei: DurationDistribution,
+    /// Inclusive rooted body-closure query and immediate work reduction.
+    #[serde(default)]
+    pub semantic_body_closure: DurationDistribution,
+    /// Projection of the closure and declaration graph into the rooted body graph.
+    #[serde(default)]
+    pub semantic_body_graph_projection: DurationDistribution,
     /// Stable-input preparation before body-local semantic materialization.
     #[serde(default)]
     pub cfg_input_preparation_bodies: DurationDistribution,
@@ -564,6 +579,11 @@ impl BuildBoundaryEvidence {
         let critical = &self.critical_path;
         if !critical.semantic_bodies.validate()
             || !critical.semantic_prerequisite_bodies.validate()
+            || !critical.semantic_declaration_graph.validate()
+            || !critical.semantic_declaration_occurrence_indexes.validate()
+            || !critical.semantic_declaration_nuclei.validate()
+            || !critical.semantic_body_closure.validate()
+            || !critical.semantic_body_graph_projection.validate()
             || !critical.cfg_input_preparation_bodies.validate()
             || !critical.semantic_materialization_bodies.validate()
             || !critical.cfg_domain_prerequisite_bodies.validate()
@@ -613,8 +633,14 @@ impl BuildBoundaryEvidence {
     ) -> Result<(), String> {
         self.validate_against(policy, target)?;
         let critical = &self.critical_path;
-        if critical.semantic_prerequisite_bodies.count == 0 {
-            return Err("compiler omitted semantic-prerequisite evidence".to_string());
+        if critical.semantic_prerequisite_bodies.count == 0
+            || critical.semantic_declaration_graph.count == 0
+            || critical.semantic_declaration_occurrence_indexes.count == 0
+            || critical.semantic_declaration_nuclei.count == 0
+            || critical.semantic_body_closure.count == 0
+            || critical.semantic_body_graph_projection.count == 0
+        {
+            return Err("compiler omitted semantic critical-path evidence".to_string());
         }
         let breakdown_counts = [
             critical.cfg_input_preparation_bodies.count,
@@ -715,6 +741,11 @@ mod tests {
                 toolchain_acquisition_ns: 1,
                 semantic_bodies: distribution(),
                 semantic_prerequisite_bodies: distribution(),
+                semantic_declaration_graph: distribution(),
+                semantic_declaration_occurrence_indexes: distribution(),
+                semantic_declaration_nuclei: distribution(),
+                semantic_body_closure: distribution(),
+                semantic_body_graph_projection: distribution(),
                 cfg_input_preparation_bodies: distribution(),
                 semantic_materialization_bodies: distribution(),
                 cfg_domain_prerequisite_bodies: distribution(),
@@ -756,6 +787,11 @@ mod tests {
         let critical = encoded["critical_path"].as_object_mut().unwrap();
         for field in [
             "semantic_prerequisite_bodies",
+            "semantic_declaration_graph",
+            "semantic_declaration_occurrence_indexes",
+            "semantic_declaration_nuclei",
+            "semantic_body_closure",
+            "semantic_body_graph_projection",
             "cfg_input_preparation_bodies",
             "semantic_materialization_bodies",
             "cfg_domain_prerequisite_bodies",
@@ -771,6 +807,28 @@ mod tests {
         let decoded: BuildBoundaryEvidence = serde_json::from_value(encoded).unwrap();
         assert_eq!(
             decoded.critical_path.semantic_prerequisite_bodies,
+            DurationDistribution::default()
+        );
+        assert_eq!(
+            decoded.critical_path.semantic_declaration_graph,
+            DurationDistribution::default()
+        );
+        assert_eq!(
+            decoded
+                .critical_path
+                .semantic_declaration_occurrence_indexes,
+            DurationDistribution::default()
+        );
+        assert_eq!(
+            decoded.critical_path.semantic_declaration_nuclei,
+            DurationDistribution::default()
+        );
+        assert_eq!(
+            decoded.critical_path.semantic_body_closure,
+            DurationDistribution::default()
+        );
+        assert_eq!(
+            decoded.critical_path.semantic_body_graph_projection,
             DurationDistribution::default()
         );
         assert_eq!(

--- a/crates/rue/src/main.rs
+++ b/crates/rue/src/main.rs
@@ -1062,6 +1062,13 @@ fn compiler_critical_path_evidence(
         toolchain_acquisition_ns: timing.pass_total_ns("toolchain_acquisition"),
         semantic_bodies: timing.pass_duration_distribution("body_analysis"),
         semantic_prerequisite_bodies: timing.pass_duration_distribution("body_query_prerequisites"),
+        semantic_declaration_graph: timing
+            .pass_duration_distribution("declaration_graph_collection"),
+        semantic_declaration_occurrence_indexes: timing
+            .pass_duration_distribution("declaration_occurrence_index"),
+        semantic_declaration_nuclei: timing.pass_duration_distribution("declaration_nucleus"),
+        semantic_body_closure: timing.pass_duration_distribution("body_closure_collection"),
+        semantic_body_graph_projection: timing.pass_duration_distribution("body_graph_projection"),
         cfg_input_preparation_bodies: timing.pass_duration_distribution("cfg_input_preparation"),
         semantic_materialization_bodies: timing
             .pass_duration_distribution("semantic_materialization"),

--- a/crates/rue/src/timing.rs
+++ b/crates/rue/src/timing.rs
@@ -1675,10 +1675,20 @@ mod tests {
             .iter()
             .find(|pass| pass.name == "declaration_occurrence_index")
             .unwrap();
+        let declaration_graph = session_timing
+            .passes
+            .iter()
+            .find(|pass| pass.name == "declaration_graph_collection")
+            .unwrap();
         let body_closure = session_timing
             .passes
             .iter()
             .find(|pass| pass.name == "body_closure_collection")
+            .unwrap();
+        let body_graph_projection = session_timing
+            .passes
+            .iter()
+            .find(|pass| pass.name == "body_graph_projection")
             .unwrap();
         let optimized_cfg = session_timing
             .passes
@@ -1706,13 +1716,21 @@ mod tests {
         // Semantic presentation is a projection of the same rooted query
         // graph used by normal compilation. The old whole-program declaration
         // index and `sema` coordinator must therefore remain absent.
+        assert_eq!(declaration_graph.invocations, 1);
+        assert_eq!(declaration_graph.root_invocations, 1);
         assert_eq!(occurrence_index.invocations, 1);
-        assert_eq!(occurrence_index.root_invocations, 1);
+        assert_eq!(occurrence_index.root_invocations, 0);
         assert_eq!(occurrence_index.leaf_invocations, 1);
         assert_eq!(body_closure.invocations, 1);
         assert_eq!(body_closure.root_invocations, 1);
+        assert_eq!(body_graph_projection.invocations, 1);
+        assert_eq!(body_graph_projection.root_invocations, 1);
         assert_eq!(optimized_cfg.invocations, 1);
         assert_eq!(optimized_cfg.root_invocations, 1);
+        assert!(session_edges.contains(&(
+            "declaration_graph_collection".to_owned(),
+            "declaration_occurrence_index".to_owned()
+        )));
         assert!(session_edges.contains(&(
             "body_closure_collection".to_owned(),
             "body_analysis".to_owned()
@@ -1741,9 +1759,14 @@ mod tests {
             "missing compile -> compile_pipeline in batch edges: {compile_edges:?}"
         );
         for edge in [
-            ("compile_pipeline", "declaration_occurrence_index"),
-            ("compile_pipeline", "declaration_nucleus"),
+            ("compile_pipeline", "declaration_graph_collection"),
+            (
+                "declaration_graph_collection",
+                "declaration_occurrence_index",
+            ),
+            ("declaration_graph_collection", "declaration_nucleus"),
             ("compile_pipeline", "body_closure_collection"),
+            ("compile_pipeline", "body_graph_projection"),
             ("compile_pipeline", "optimized_cfg_collection"),
             ("optimized_cfg_collection", "cfg_construction"),
             ("optimized_cfg_collection", "cfg_optimization"),

--- a/docs/process/compiler-scaling.md
+++ b/docs/process/compiler-scaling.md
@@ -61,8 +61,10 @@ independently verified native output digest. The report records:
 - query-worker active time and peak workers;
 - dependency-ready item count, summed queue delay, and maximum queue delay;
 - longest query/dependency ancestry;
-- bounded semantic-prerequisite, semantic-analysis, CFG-construction, and
-  CFG-optimization body-duration histograms;
+- bounded request-wide declaration-graph, body-closure, and rooted-body-graph
+  projection histograms, with nested declaration-nucleus,
+  semantic-prerequisite, semantic-analysis, CFG-construction, and
+  CFG-optimization distributions;
 - the inclusive reached-toolchain acquisition envelope (which contains the
   rooted semantic attempt), joins, declined joins, and permit donations;
 - output binary size.
@@ -84,6 +86,14 @@ intervals inside each reached body transaction. The prerequisite interval owns
 registered toolchain-demand, anonymous-nominal, and well-known-type queries;
 the analysis interval owns body-input lowering, semantic-provider execution,
 stable-key projection, and body-transaction publication.
+
+After a semantic request selects its root inputs, the semantic-detail table
+separates three adjacent, non-overlapping intervals: declaration-graph
+collection, rooted body-closure collection, and rooted-body-graph projection.
+Declaration occurrence-index and nucleus timings are nested inside the
+declaration interval; body prerequisite and analysis timings are nested inside
+the closure interval. Nested values explain their owner and are never added to
+the enclosing duration.
 
 The reached-toolchain value is an inclusive host-operation envelope, not an
 exclusive phase. The operation runs the rooted semantic attempt to discover


### PR DESCRIPTION
## Summary

- split request-wide semantic work into adjacent declaration-graph, body-closure, and rooted-body projection intervals
- export the existing nested occurrence-index and declaration-nucleus spans
- render a dedicated semantic critical-path table with explicit inclusive/nested ownership
- preserve historical evidence compatibility while requiring the new fields from current producers

## Validation

- `scripts/rue fmt`
- `scripts/rue quick` (all compiler/schema targets passed; one timing topology assertion was updated and then isolated)
- `./buck2 test //crates/rue:rue-test` (198 passed)

Refs RUE-1473.