### PR TITLE
RUE-1473: attribute provider body phases

### DIFF
--- a/crates/rue-air/BUCK
+++ b/crates/rue-air/BUCK
@@ -35,6 +35,7 @@ rue_crate(
         "//crates/rue-span:rue-span",
         "//crates/rue-target:rue-target",
         "//third-party:lasso",
+        "//third-party:tracing",
     ],
     test_deps = [
         "//crates/rue-lexer:rue-lexer",
@@ -58,6 +59,7 @@ native.rust_library(
         "//crates/rue-target:rue-target",
         "//third-party:lasso",
         "//third-party:rayon",
+        "//third-party:tracing",
     ],
     rustc_flags = ["--cfg", "feature=\"fuzz-support\""],
     visibility = ["//crates/rue-compiler:", "//crates/rue-fuzz:"],

--- a/crates/rue-air/src/sema/provider_body_host.rs
+++ b/crates/rue-air/src/sema/provider_body_host.rs
@@ -9,6 +9,7 @@ use std::collections::{HashMap, HashSet};
 use std::hash::Hash;
 use std::rc::Rc;
 use std::sync::Arc;
+use std::time::Instant;
 
 use ahash::{AHashMap, AHashSet};
 use lasso::{Spur, ThreadedRodeo};
@@ -46,6 +47,29 @@ use crate::{
     DurableConstSource, DurableNominalSource, FunctionInstanceKey, ParamRange, ParamRangeData,
     SemanticDefinitionToken, SemanticModuleToken, TypeInstanceKey,
 };
+
+fn elapsed_ns(started: Instant) -> u64 {
+    u64::try_from(started.elapsed().as_nanos()).unwrap_or(u64::MAX)
+}
+
+fn publish_provider_body_breakdown(
+    host_setup_ns: u64,
+    expression_engine_ns: u64,
+    specialization_selection_ns: u64,
+    body_export_ns: u64,
+    result_projection_ns: u64,
+) {
+    tracing::event!(
+        name: "semantic_provider_breakdown",
+        target: "rue::timing",
+        tracing::Level::INFO,
+        host_setup_ns,
+        expression_engine_ns,
+        specialization_selection_ns,
+        body_export_ns,
+        result_projection_ns,
+    );
+}
 
 fn intern_synthetic_argument_name(interner: &ThreadedRodeo, index: usize) -> Spur {
     let mut bytes = [0_u8; 3 + 20];
@@ -4227,6 +4251,7 @@ where
             "provider body RIR does not have one source file".into(),
         ))
     })?;
+    let host_setup_started = Instant::now();
     let mut host = ProviderBodyHost::new(
         provider, source, bundle, key, owner_file, name, owner_kind, owner_name, target, preview,
         well_known,
@@ -4242,6 +4267,8 @@ where
         .cloned()
         .collect::<HashSet<_>>();
     let infer = InferenceContext::new(&host);
+    let host_setup_ns = elapsed_ns(host_setup_started);
+    let expression_engine_started = Instant::now();
     let (analyzed, body_span) = match owner_kind {
         crate::StableDefinitionKind::Function => {
             let info = host
@@ -4451,6 +4478,8 @@ where
             ));
         }
     };
+    let expression_engine_ns = elapsed_ns(expression_engine_started);
+    let specialization_selection_started = Instant::now();
     let (mut function, warnings, strings, referenced_functions, referenced_methods) = analyzed;
     function.ordinary_owner = Some(host.owner);
     let (function, selected_calls, mut referenced_specializations) =
@@ -4472,6 +4501,8 @@ where
             .map(|((symbol, _), instance)| (*symbol, instance.clone())),
     );
     let selected_calls = selected_calls.into_iter().collect::<HashMap<_, _>>();
+    let specialization_selection_ns = elapsed_ns(specialization_selection_started);
+    let body_export_started = Instant::now();
     let export = super::semantic_body_export::export_body(
         &host,
         host.owner,
@@ -4487,6 +4518,8 @@ where
             "provider body export failed: {failure:?}"
         )))
     })?;
+    let body_export_ns = elapsed_ns(body_export_started);
+    let result_projection_started = Instant::now();
     let mut referenced_definitions = referenced_functions
         .iter()
         .filter_map(|symbol| {
@@ -4528,6 +4561,14 @@ where
         )
         .collect();
     let module_tokens = host.module_tokens.into_inner().into_values().collect();
+    let result_projection_ns = elapsed_ns(result_projection_started);
+    publish_provider_body_breakdown(
+        host_setup_ns,
+        expression_engine_ns,
+        specialization_selection_ns,
+        body_export_ns,
+        result_projection_ns,
+    );
     Ok(ProviderOrdinaryBody {
         owner: host.owner,
         export,
@@ -4577,6 +4618,7 @@ where
             "provider anonymous body RIR does not have one source file".into(),
         ))
     })?;
+    let host_setup_started = Instant::now();
     let mut host = ProviderBodyHost::new(
         provider,
         source,
@@ -4871,6 +4913,8 @@ where
         ))
     })?;
     let infer = InferenceContext::new(&host);
+    let host_setup_ns = elapsed_ns(host_setup_started);
+    let expression_engine_started = Instant::now();
     let analyzed = if member.kind == crate::AnonymousMemberKind::Destructor {
         OrdinaryBodyEngine::new(&mut host).analyze_anonymous_destructor(
             &infer,
@@ -4899,6 +4943,8 @@ where
             self_is_mut,
         )?
     };
+    let expression_engine_ns = elapsed_ns(expression_engine_started);
+    let specialization_selection_started = Instant::now();
     let (function, warnings, strings, referenced_functions, referenced_methods) = analyzed;
     let (function, selected_calls, mut referenced_specializations) =
         crate::specialize::select_provider_body_specializations(&mut host, function)?;
@@ -4920,6 +4966,8 @@ where
     );
     let selected_calls = selected_calls.into_iter().collect::<HashMap<_, _>>();
     let body_span = host.rir.rir().get(body).span;
+    let specialization_selection_ns = elapsed_ns(specialization_selection_started);
+    let body_export_started = Instant::now();
     let export = super::semantic_body_export::export_body(
         &host,
         crate::BodyOwnerToken::new(0, 0),
@@ -4939,6 +4987,8 @@ where
             "provider anonymous body export failed: {failure:?}"
         )))
     })?;
+    let body_export_ns = elapsed_ns(body_export_started);
+    let result_projection_started = Instant::now();
     let produced_anonymous_nominals = host
         .produced_anonymous_nominals(&initial_anonymous_identities)
         .map_err(|failure| {
@@ -4980,6 +5030,14 @@ where
         )
         .collect();
     let module_tokens = host.module_tokens.into_inner().into_values().collect();
+    let result_projection_ns = elapsed_ns(result_projection_started);
+    publish_provider_body_breakdown(
+        host_setup_ns,
+        expression_engine_ns,
+        specialization_selection_ns,
+        body_export_ns,
+        result_projection_ns,
+    );
     Ok(ProviderAnonymousBody {
         export,
         function,
@@ -5023,6 +5081,7 @@ where
             "provider specialized body RIR does not have one source file".into(),
         ))
     })?;
+    let host_setup_started = Instant::now();
     let mut host = ProviderBodyHost::new(
         provider,
         source,
@@ -5084,8 +5143,11 @@ where
             ))
         })?;
     let infer = InferenceContext::new(&host);
+    let host_setup_ns = elapsed_ns(host_setup_started);
+    let expression_engine_started = Instant::now();
     let specialized =
         crate::specialize::analyze_one_specialization_with_host(&mut host, &infer, key)?;
+    let expression_engine_ns = elapsed_ns(expression_engine_started);
     let body_span = host
         .rir
         .rir()
@@ -5100,6 +5162,7 @@ where
                 .body,
         )
         .span;
+    let specialization_selection_started = Instant::now();
     let (function, selected_calls, referenced_specializations) =
         crate::specialize::select_provider_body_specializations(&mut host, specialized.function)?;
     host.specialized_function_identities.borrow_mut().extend(
@@ -5109,6 +5172,8 @@ where
             .map(|((symbol, _), instance)| (*symbol, instance.clone())),
     );
     let selected_calls = selected_calls.into_iter().collect::<HashMap<_, _>>();
+    let specialization_selection_ns = elapsed_ns(specialization_selection_started);
+    let body_export_started = Instant::now();
     let body = super::semantic_body_export::export_body(
         &host,
         host.owner,
@@ -5125,6 +5190,8 @@ where
         )))
     })?
     .body;
+    let body_export_ns = elapsed_ns(body_export_started);
+    let result_projection_started = Instant::now();
     let mut referenced_definitions = specialized
         .referenced_functions
         .iter()
@@ -5174,6 +5241,14 @@ where
         )
         .collect();
     let module_tokens = host.module_tokens.into_inner().into_values().collect();
+    let result_projection_ns = elapsed_ns(result_projection_started);
+    publish_provider_body_breakdown(
+        host_setup_ns,
+        expression_engine_ns,
+        specialization_selection_ns,
+        body_export_ns,
+        result_projection_ns,
+    );
     Ok(ProviderSpecializedBody {
         export,
         function,

--- a/crates/rue-bench/src/scaling.rs
+++ b/crates/rue-bench/src/scaling.rs
@@ -604,6 +604,45 @@ fn render(report: &ScalingReport) -> String {
         ));
     }
 
+    out.push_str("\n### Provider analysis detail\n\n");
+    out.push_str("These five adjacent intervals explain most of provider-backed body analysis. Small gaps remain for branch dispatch and timer boundaries, so the rows are diagnostic rather than an exact partition of the enclosing provider interval.\n\n");
+    out.push_str("| workload / workers | host setup total/max ms | expression engine total/max ms | specialization selection total/max ms | body export total/max ms | result projection total/max ms |\n");
+    out.push_str("| --- | ---: | ---: | ---: | ---: | ---: |\n");
+    for observation in &report.workloads {
+        let evidence = observation.samples.iter().map(|sample| {
+            sample
+                .boundary_evidence
+                .first()
+                .map(|evidence| evidence.critical_path.clone())
+                .unwrap_or_default()
+        });
+        let pair = |select: fn(&CompilerCriticalPathEvidence) -> &DurationDistribution| {
+            (
+                summarize(evidence.clone().map(|value| select(&value).total_ns)),
+                summarize(evidence.clone().map(|value| select(&value).max_ns)),
+            )
+        };
+        let setup = pair(|value| &value.semantic_provider_host_setup);
+        let engine = pair(|value| &value.semantic_provider_expression_engine);
+        let specialization = pair(|value| &value.semantic_provider_specialization_selection);
+        let export = pair(|value| &value.semantic_provider_body_export);
+        let projection = pair(|value| &value.semantic_provider_result_projection);
+        out.push_str(&format!(
+            "| {} | {:.2}/{:.2} | {:.2}/{:.2} | {:.2}/{:.2} | {:.2}/{:.2} | {:.2}/{:.2} |\n",
+            observation_label(observation),
+            setup.0.median as f64 / 1_000_000.0,
+            setup.1.median as f64 / 1_000_000.0,
+            engine.0.median as f64 / 1_000_000.0,
+            engine.1.median as f64 / 1_000_000.0,
+            specialization.0.median as f64 / 1_000_000.0,
+            specialization.1.median as f64 / 1_000_000.0,
+            export.0.median as f64 / 1_000_000.0,
+            export.1.median as f64 / 1_000_000.0,
+            projection.0.median as f64 / 1_000_000.0,
+            projection.1.median as f64 / 1_000_000.0,
+        ));
+    }
+
     out.push_str("\n## Deterministic query work\n\n");
     out.push_str("Counts are exact for one fresh compiler process and must agree across the measured one-worker samples. Parallel scheduling outcomes remain available in each raw boundary proof but are not collapsed into an allegedly deterministic count. Request outcomes expose all query traffic before validation detail: claims start computations, reuses return compatible retained or task-local terminals, and joins share in-flight work. Declined joins are included in joins and identify wait-graph avoidance.\n\n");
     out.push_str("| workload | claims | reuses | joins declined/total | body completions | publications red/green | cancellations/cycles |\n");

--- a/crates/rue-perf-schema/src/boundary.rs
+++ b/crates/rue-perf-schema/src/boundary.rs
@@ -403,6 +403,21 @@ pub struct CompilerCriticalPathEvidence {
     /// Provider-backed semantic analysis after body-fragment lowering.
     #[serde(default)]
     pub semantic_provider_analysis: DurationDistribution,
+    /// Provider-host construction and pre-engine body setup.
+    #[serde(default)]
+    pub semantic_provider_host_setup: DurationDistribution,
+    /// Canonical expression inference and body analysis engine.
+    #[serde(default)]
+    pub semantic_provider_expression_engine: DurationDistribution,
+    /// Post-analysis specialization selection and identity installation.
+    #[serde(default)]
+    pub semantic_provider_specialization_selection: DurationDistribution,
+    /// Projection from analyzed local AIR into the durable semantic body.
+    #[serde(default)]
+    pub semantic_provider_body_export: DurationDistribution,
+    /// Final durable references, tokens, and produced-nominal projection.
+    #[serde(default)]
+    pub semantic_provider_result_projection: DurationDistribution,
     /// Stable-input preparation before body-local semantic materialization.
     #[serde(default)]
     pub cfg_input_preparation_bodies: DurationDistribution,
@@ -596,6 +611,13 @@ impl BuildBoundaryEvidence {
             || !critical.semantic_body_graph_projection.validate()
             || !critical.semantic_body_input_lowering.validate()
             || !critical.semantic_provider_analysis.validate()
+            || !critical.semantic_provider_host_setup.validate()
+            || !critical.semantic_provider_expression_engine.validate()
+            || !critical
+                .semantic_provider_specialization_selection
+                .validate()
+            || !critical.semantic_provider_body_export.validate()
+            || !critical.semantic_provider_result_projection.validate()
             || !critical.cfg_input_preparation_bodies.validate()
             || !critical.semantic_materialization_bodies.validate()
             || !critical.cfg_domain_prerequisite_bodies.validate()
@@ -654,6 +676,11 @@ impl BuildBoundaryEvidence {
             || critical.semantic_body_graph_projection.count == 0
             || critical.semantic_body_input_lowering.count == 0
             || critical.semantic_provider_analysis.count == 0
+            || critical.semantic_provider_host_setup.count == 0
+            || critical.semantic_provider_expression_engine.count == 0
+            || critical.semantic_provider_specialization_selection.count == 0
+            || critical.semantic_provider_body_export.count == 0
+            || critical.semantic_provider_result_projection.count == 0
         {
             return Err("compiler omitted semantic critical-path evidence".to_string());
         }
@@ -764,6 +791,11 @@ mod tests {
                 semantic_body_graph_projection: distribution(),
                 semantic_body_input_lowering: distribution(),
                 semantic_provider_analysis: distribution(),
+                semantic_provider_host_setup: distribution(),
+                semantic_provider_expression_engine: distribution(),
+                semantic_provider_specialization_selection: distribution(),
+                semantic_provider_body_export: distribution(),
+                semantic_provider_result_projection: distribution(),
                 cfg_input_preparation_bodies: distribution(),
                 semantic_materialization_bodies: distribution(),
                 cfg_domain_prerequisite_bodies: distribution(),
@@ -813,6 +845,11 @@ mod tests {
             "semantic_body_graph_projection",
             "semantic_body_input_lowering",
             "semantic_provider_analysis",
+            "semantic_provider_host_setup",
+            "semantic_provider_expression_engine",
+            "semantic_provider_specialization_selection",
+            "semantic_provider_body_export",
+            "semantic_provider_result_projection",
             "cfg_input_preparation_bodies",
             "semantic_materialization_bodies",
             "cfg_domain_prerequisite_bodies",
@@ -862,6 +899,28 @@ mod tests {
         );
         assert_eq!(
             decoded.critical_path.semantic_provider_analysis,
+            DurationDistribution::default()
+        );
+        assert_eq!(
+            decoded.critical_path.semantic_provider_host_setup,
+            DurationDistribution::default()
+        );
+        assert_eq!(
+            decoded.critical_path.semantic_provider_expression_engine,
+            DurationDistribution::default()
+        );
+        assert_eq!(
+            decoded
+                .critical_path
+                .semantic_provider_specialization_selection,
+            DurationDistribution::default()
+        );
+        assert_eq!(
+            decoded.critical_path.semantic_provider_body_export,
+            DurationDistribution::default()
+        );
+        assert_eq!(
+            decoded.critical_path.semantic_provider_result_projection,
             DurationDistribution::default()
         );
         assert_eq!(

--- a/crates/rue/src/main.rs
+++ b/crates/rue/src/main.rs
@@ -1073,6 +1073,16 @@ fn compiler_critical_path_evidence(
         semantic_body_graph_projection: timing.pass_duration_distribution("body_graph_projection"),
         semantic_body_input_lowering: timing.pass_duration_distribution("body_input_lowering"),
         semantic_provider_analysis: timing.pass_duration_distribution("semantic_provider_analysis"),
+        semantic_provider_host_setup: timing
+            .pass_duration_distribution("semantic_provider_host_setup"),
+        semantic_provider_expression_engine: timing
+            .pass_duration_distribution("semantic_provider_expression_engine"),
+        semantic_provider_specialization_selection: timing
+            .pass_duration_distribution("semantic_provider_specialization_selection"),
+        semantic_provider_body_export: timing
+            .pass_duration_distribution("semantic_provider_body_export"),
+        semantic_provider_result_projection: timing
+            .pass_duration_distribution("semantic_provider_result_projection"),
         cfg_input_preparation_bodies: timing.pass_duration_distribution("cfg_input_preparation"),
         semantic_materialization_bodies: timing
             .pass_duration_distribution("semantic_materialization"),

--- a/crates/rue/src/timing.rs
+++ b/crates/rue/src/timing.rs
@@ -1159,6 +1159,15 @@ struct CfgConstructionBreakdownVisitor {
     cfg_publication_ns: Option<u64>,
 }
 
+#[derive(Default)]
+struct SemanticProviderBreakdownVisitor {
+    host_setup_ns: Option<u64>,
+    expression_engine_ns: Option<u64>,
+    specialization_selection_ns: Option<u64>,
+    body_export_ns: Option<u64>,
+    result_projection_ns: Option<u64>,
+}
+
 impl tracing::field::Visit for TimingFlushVisitor {
     fn record_bool(&mut self, field: &tracing::field::Field, value: bool) {
         if field.name() == "timing_flush" {
@@ -1190,6 +1199,21 @@ impl tracing::field::Visit for CfgConstructionBreakdownVisitor {
             "prerequisite_queries_ns" => self.prerequisite_queries_ns = Some(value),
             "cfg_builder_ns" => self.cfg_builder_ns = Some(value),
             "cfg_publication_ns" => self.cfg_publication_ns = Some(value),
+            _ => {}
+        }
+    }
+
+    fn record_debug(&mut self, _field: &tracing::field::Field, _value: &dyn std::fmt::Debug) {}
+}
+
+impl tracing::field::Visit for SemanticProviderBreakdownVisitor {
+    fn record_u64(&mut self, field: &tracing::field::Field, value: u64) {
+        match field.name() {
+            "host_setup_ns" => self.host_setup_ns = Some(value),
+            "expression_engine_ns" => self.expression_engine_ns = Some(value),
+            "specialization_selection_ns" => self.specialization_selection_ns = Some(value),
+            "body_export_ns" => self.body_export_ns = Some(value),
+            "result_projection_ns" => self.result_projection_ns = Some(value),
             _ => {}
         }
     }
@@ -1295,6 +1319,42 @@ where
                 ("cfg_prerequisite_queries", prerequisite_queries_ns),
                 ("cfg_builder", cfg_builder_ns),
                 ("cfg_publication", cfg_publication_ns),
+            ] {
+                self.data
+                    .record_span(name, Duration::from_nanos(duration_ns), false, true);
+            }
+            return;
+        }
+        if event.metadata().target() == "rue::timing"
+            && event.metadata().name() == "semantic_provider_breakdown"
+        {
+            let mut visitor = SemanticProviderBreakdownVisitor::default();
+            event.record(&mut visitor);
+            let (
+                Some(host_setup_ns),
+                Some(expression_engine_ns),
+                Some(specialization_selection_ns),
+                Some(body_export_ns),
+                Some(result_projection_ns),
+            ) = (
+                visitor.host_setup_ns,
+                visitor.expression_engine_ns,
+                visitor.specialization_selection_ns,
+                visitor.body_export_ns,
+                visitor.result_projection_ns,
+            )
+            else {
+                return;
+            };
+            for (name, duration_ns) in [
+                ("semantic_provider_host_setup", host_setup_ns),
+                ("semantic_provider_expression_engine", expression_engine_ns),
+                (
+                    "semantic_provider_specialization_selection",
+                    specialization_selection_ns,
+                ),
+                ("semantic_provider_body_export", body_export_ns),
+                ("semantic_provider_result_projection", result_projection_ns),
             ] {
                 self.data
                     .record_span(name, Duration::from_nanos(duration_ns), false, true);
@@ -2559,6 +2619,37 @@ mod phase_accounting_tests {
             ("cfg_prerequisite_queries", 64),
             ("cfg_builder", 128),
             ("cfg_publication", 256),
+        ] {
+            let distribution = data.pass_duration_distribution(name);
+            assert_eq!(distribution.count, 1, "{name}");
+            assert_eq!(distribution.total_ns, expected_ns, "{name}");
+            assert_eq!(distribution.max_ns, expected_ns, "{name}");
+        }
+    }
+
+    #[test]
+    fn semantic_provider_breakdown_event_populates_each_bounded_distribution() {
+        let data = TimingData::new();
+        let subscriber = tracing_subscriber::registry().with(TimingLayer::new(data.clone()));
+        tracing::subscriber::with_default(subscriber, || {
+            tracing::event!(
+                name: "semantic_provider_breakdown",
+                target: "rue::timing",
+                tracing::Level::INFO,
+                host_setup_ns = 2_u64,
+                expression_engine_ns = 4_u64,
+                specialization_selection_ns = 8_u64,
+                body_export_ns = 16_u64,
+                result_projection_ns = 32_u64,
+            );
+        });
+
+        for (name, expected_ns) in [
+            ("semantic_provider_host_setup", 2),
+            ("semantic_provider_expression_engine", 4),
+            ("semantic_provider_specialization_selection", 8),
+            ("semantic_provider_body_export", 16),
+            ("semantic_provider_result_projection", 32),
         ] {
             let distribution = data.pass_duration_distribution(name);
             assert_eq!(distribution.count, 1, "{name}");

--- a/docs/process/compiler-scaling.md
+++ b/docs/process/compiler-scaling.md
@@ -102,6 +102,11 @@ distinguishes repeated syntax preparation from the semantic engine without
 changing the canonical computation path. Because the signature aggregate may
 have more than one semantic parent, it is explanatory rather than additive.
 
+The provider-detail table then separates host setup, canonical expression
+analysis, specialization selection, durable body export, and final result
+projection. Those intervals are measured inside the single provider-backed
+body analyzer; they neither introduce nor select a peer semantic path.
+
 The reached-toolchain value is an inclusive host-operation envelope, not an
 exclusive phase. The operation runs the rooted semantic attempt to discover
 whether a trusted module is absent, so its duration overlaps semantic work and


### PR DESCRIPTION
## Summary

- split provider-backed semantic body analysis into five bounded, adjacent timing intervals
- publish the breakdown through the existing critical-path evidence and scaling report
- keep one canonical provider analyzer and add no alternate semantic path

This is measurement-only. It identifies whether host setup, expression analysis, specialization selection, durable export, or final projection should be optimized next.

## Validation

- `scripts/rue fmt`
- `./buck2 test //crates/rue:rue-test //crates/rue-perf-schema:rue-perf-schema-test //crates/rue-bench:rue-bench-test //crates/rue-air:rue-air-test`

Refs RUE-1473.