### PR TITLE
RUE-1473: reuse canonical body signatures

### DIFF
--- a/crates/rue-air/src/sema/consistency_tests.rs
+++ b/crates/rue-air/src/sema/consistency_tests.rs
@@ -285,6 +285,8 @@ mod tests {
         assert!(engine.contains("pub(crate) trait OrdinaryBodyAnalysisHost"));
         assert!(engine.contains("pub(crate) struct OrdinaryBodyEngine"));
         assert!(engine.contains("pub(crate) fn analyze_single_function"));
+        assert!(engine.contains("pub(crate) fn analyze_single_function_resolved"));
+        assert!(engine.contains("pub(crate) fn analyze_named_method_resolved"));
         assert!(engine.contains("pub(crate) fn analyze_function_internal"));
         assert!(!engine.contains("#[allow(dead_code)]"));
         assert!(engine.contains("semantic_type_syntax_compile_error("));
@@ -346,6 +348,22 @@ mod tests {
                     )"
             ),
             "analyze_function_internal must be exactly one forwarding expression"
+        );
+
+        let provider = include_str!("provider_body_host.rs");
+        assert!(provider.contains(".analyze_single_function_resolved("));
+        assert!(provider.contains(".analyze_named_method_resolved("));
+        assert!(
+            !provider.contains(".analyze_single_function("),
+            "provider-owned functions must not re-resolve their exact durable signatures"
+        );
+        assert!(
+            !provider.contains(".analyze_named_method("),
+            "provider-owned methods must not regain a syntax-resolving facade"
+        );
+        assert!(
+            !engine.contains("pub(crate) fn analyze_named_method("),
+            "the obsolete named-method facade must not return"
         );
     }
 

--- a/crates/rue-air/src/sema/ordinary_engine.rs
+++ b/crates/rue-air/src/sema/ordinary_engine.rs
@@ -1451,6 +1451,49 @@ impl<'h, H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'h, H> {
                 Ok((p.name, ty, p.mode, p.is_comptime))
             })
             .collect::<CompileResult<Vec<_>>>()?;
+        self.analyze_single_function_resolved(
+            infer_ctx,
+            fn_name,
+            ret_type,
+            param_info,
+            body,
+            span,
+            allow_unused_variable,
+            allow_unreachable_code,
+        )
+    }
+
+    /// Analyze a function whose body-exact return type and canonical parameter
+    /// facts are already resolved in this engine's type and parameter authority.
+    ///
+    /// Provider-backed body analysis mints those facts while selecting the
+    /// current callable. Re-resolving the explicit parameter spellings would
+    /// duplicate nominal registration and type construction without adding a
+    /// distinct correctness check; the body input already depends on the exact
+    /// raw signature terminal. The caller still resolves the declared return
+    /// spelling because a call-site signature may expose a coercion-normalized
+    /// type instead of the exact type checked inside the body.
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) fn analyze_single_function_resolved(
+        &mut self,
+        infer_ctx: &InferenceContext,
+        fn_name: &str,
+        ret_type: Type,
+        param_info: Vec<(Spur, Type, RirParamMode, bool)>,
+        body: InstRef,
+        span: Span,
+        allow_unused_variable: bool,
+        allow_unreachable_code: bool,
+    ) -> CompileResult<(
+        AnalyzedFunction,
+        Vec<CompileWarning>,
+        Vec<String>,
+        HashSet<Spur>,
+        HashSet<(StructId, Spur)>,
+    )> {
+        for (_, ty, _, is_comptime) in &param_info {
+            reject_runtime_type_value(*ty, *is_comptime, span)?;
+        }
         let function_symbol = self.storage.body_interner().get_or_intern(fn_name);
         let producer = self
             .canonical_function_producer(function_symbol, &HashMap::new(), &HashMap::new())
@@ -1514,12 +1557,14 @@ impl<'h, H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'h, H> {
         ))
     }
 
-    pub(crate) fn analyze_named_method<P>(
+    /// Analyze a named member from its already-resolved canonical signature.
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) fn analyze_named_method_resolved(
         &mut self,
         infer_ctx: &InferenceContext,
         full_name: &str,
-        return_type: Spur,
-        params: P,
+        return_type: Type,
+        params: Vec<(Spur, Type, RirParamMode, bool)>,
         body: InstRef,
         span: Span,
         struct_type: Type,
@@ -1533,10 +1578,7 @@ impl<'h, H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'h, H> {
         Vec<String>,
         HashSet<Spur>,
         HashSet<(StructId, Spur)>,
-    )>
-    where
-        P: ExactSizeIterator<Item = RirParam> + Clone,
-    {
+    )> {
         let symbol = self.storage.body_interner().get_or_intern(full_name);
         let identity = crate::FunctionInstanceKey::Definition(
             self.storage.function_identity(symbol).map_err(|failure| {
@@ -1548,17 +1590,21 @@ impl<'h, H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'h, H> {
                 )
             })?,
         );
-        self.analyze_method_with_identity_kind(
+        let self_name = self.storage.body_interner().get_or_intern("self");
+        let mut resolved_params = Vec::with_capacity(params.len() + usize::from(has_self));
+        if has_self {
+            resolved_params.push((self_name, struct_type, self_mode, false));
+        }
+        resolved_params.extend(params);
+        self.analyze_method_with_identity_kind_resolved(
             infer_ctx,
             identity,
             full_name,
             return_type,
-            params,
+            resolved_params,
             body,
             span,
             struct_type,
-            has_self,
-            self_mode,
             self_is_mut,
             false,
             returns_borrow,
@@ -1657,6 +1703,48 @@ impl<'h, H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'h, H> {
             reject_runtime_type_value(ty, parameter.is_comptime, span)?;
             resolved_params.push((parameter.name, ty, parameter.mode, parameter.is_comptime));
         }
+        self.analyze_method_with_identity_kind_resolved(
+            infer_ctx,
+            identity,
+            full_name,
+            return_type,
+            resolved_params,
+            body,
+            span,
+            struct_type,
+            self_is_mut,
+            is_destructor,
+            is_accessor,
+        )
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn analyze_method_with_identity_kind_resolved(
+        &mut self,
+        infer_ctx: &InferenceContext,
+        identity: crate::FunctionInstanceKey<
+            crate::SemanticDefinitionToken,
+            crate::SemanticModuleToken,
+        >,
+        full_name: &str,
+        return_type: Type,
+        resolved_params: Vec<(Spur, Type, RirParamMode, bool)>,
+        body: InstRef,
+        span: Span,
+        struct_type: Type,
+        self_is_mut: bool,
+        is_destructor: bool,
+        is_accessor: bool,
+    ) -> CompileResult<(
+        AnalyzedFunction,
+        Vec<CompileWarning>,
+        Vec<String>,
+        HashSet<Spur>,
+        HashSet<(StructId, Spur)>,
+    )> {
+        for (_, ty, _, is_comptime) in &resolved_params {
+            reject_runtime_type_value(*ty, *is_comptime, span)?;
+        }
         let producer = (
             crate::StableProducerId::Function(Box::new(identity.clone())),
             crate::CanonicalArguments::default(),
@@ -1667,6 +1755,7 @@ impl<'h, H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'h, H> {
         let struct_id = struct_type
             .as_struct()
             .expect("method receiver must be a struct");
+        let self_type_name = self.storage.body_interner().get_or_intern("Self");
         let mut type_subst = self.storage.anon_struct_type_subst(struct_id);
         type_subst.insert(self_type_name, struct_type);
         let captured_values = self.storage.anon_struct_captured_values(struct_id);

--- a/crates/rue-air/src/sema/provider_body_host.rs
+++ b/crates/rue-air/src/sema/provider_body_host.rs
@@ -4288,22 +4288,24 @@ where
                     ))
                 })?;
             host.reject_free_function_accessor(declaration)?;
-            let (params, return_type, body) = match &host.rir.rir().get(declaration).data {
+            let (return_type, body) = match &host.rir.rir().get(declaration).data {
                 InstData::FnDecl {
-                    params,
-                    return_type,
-                    body,
-                    ..
-                } => (params.clone(), *return_type, *body),
+                    return_type, body, ..
+                } => (*return_type, *body),
                 _ => unreachable!("registered provider function points at FnDecl"),
             };
             let body_span = host.rir.rir().get(body).span;
+            // The durable call-site signature may normalize body-local types
+            // such as `Str(N)` to their coercion surface. Resolve the exact
+            // declared return spelling for body checking; explicit parameters
+            // retain their exact canonical facts and need no second lookup.
+            let return_type = host.resolve_body_type(return_type, info.span)?;
             let params = host
-                .rir
-                .rir()
-                .params(&params)
-                .values()
-                .collect::<Vec<RirParam>>();
+                .state
+                .param_data(info.params)
+                .iter()
+                .map(|(name, ty, mode, comptime)| (*name, *ty, *mode, *comptime))
+                .collect();
             host.endpoint
                 .finalize_containment_metadata()
                 .ok_or_else(|| {
@@ -4312,11 +4314,11 @@ where
                     ))
                 })?;
             (
-                OrdinaryBodyEngine::new(&mut host).analyze_single_function(
+                OrdinaryBodyEngine::new(&mut host).analyze_single_function_resolved(
                     &infer,
                     name,
                     return_type,
-                    params.into_iter(),
+                    params,
                     body,
                     info.span,
                     info.allow_unused_variable,
@@ -4347,41 +4349,30 @@ where
                         name.to_owned(),
                     ))
                 })?;
-            let (params, return_type, body, has_self, self_mode, self_is_mut, returns_borrow) =
-                match &host.rir.rir().get(declaration).data {
-                    InstData::FnDecl {
-                        params,
-                        return_type,
-                        body,
-                        has_self,
-                        self_mode,
-                        self_is_mut,
-                        returns_borrow,
-                        ..
-                    } => (
-                        params.clone(),
-                        *return_type,
-                        *body,
-                        *has_self,
-                        *self_mode,
-                        *self_is_mut,
-                        *returns_borrow,
-                    ),
-                    _ => unreachable!("registered provider member points at FnDecl"),
-                };
+            let (return_type, body) = match &host.rir.rir().get(declaration).data {
+                InstData::FnDecl {
+                    return_type, body, ..
+                } => (*return_type, *body),
+                _ => unreachable!("registered provider member points at FnDecl"),
+            };
             let body_span = host.rir.rir().get(body).span;
+            let return_type = if host.interner.resolve(&return_type) == "Self" {
+                info.struct_type
+            } else {
+                host.resolve_body_type(return_type, info.span)?
+            };
             let params = host
-                .rir
-                .rir()
-                .params(&params)
-                .values()
-                .collect::<Vec<RirParam>>();
+                .state
+                .param_data(info.params)
+                .iter()
+                .map(|(name, ty, mode, comptime)| (*name, *ty, *mode, *comptime))
+                .collect();
             let full_name = host.member_callable_name(
                 info.struct_type
                     .as_struct()
                     .expect("named method receiver must be a struct"),
                 name,
-                has_self,
+                info.has_self,
             );
             let full_symbol = host.interner.get_or_intern(&full_name);
             let owner_token = host.function_tokens.borrow()[&host.function_symbol].clone();
@@ -4396,18 +4387,18 @@ where
                     ))
                 })?;
             (
-                OrdinaryBodyEngine::new(&mut host).analyze_named_method(
+                OrdinaryBodyEngine::new(&mut host).analyze_named_method_resolved(
                     &infer,
                     &full_name,
                     return_type,
-                    params.into_iter(),
+                    params,
                     body,
                     info.span,
                     info.struct_type,
-                    has_self,
-                    self_mode,
-                    self_is_mut,
-                    returns_borrow,
+                    info.has_self,
+                    info.self_mode,
+                    info.self_is_mut,
+                    info.returns_borrow,
                 )?,
                 body_span,
             )

--- a/crates/rue-compiler/src/session.rs
+++ b/crates/rue-compiler/src/session.rs
@@ -8143,7 +8143,10 @@ mod tests {
             .expect("the program analyzes");
 
         let metrics = crate::unstable::provider_observation_metrics(&session);
-        assert_eq!(metrics.name_lookups, 16, "{metrics:?}");
+        assert_eq!(
+            metrics.name_lookups, 15,
+            "provider body analysis must reuse exact parameter facts while resolving the body-local return spelling once: {metrics:?}"
+        );
         assert_eq!(metrics.declaration_facts, 20, "{metrics:?}");
         assert_eq!(metrics.identity_facts, 10, "{metrics:?}");
         assert_eq!(metrics.signature_facts, 10, "{metrics:?}");


### PR DESCRIPTION
Provider-owned body analysis already resolves the selected callable parameters into the body request’s canonical type and parameter authority. Reuse those exact parameter facts when invoking the ordinary expression engine instead of resolving the RIR parameter spellings a second time.

The body’s declared return spelling remains body-local authority: call-site signatures may intentionally normalize coercible types such as `Str(N)` to `str`, so body analysis still resolves that exact return spelling once.

This removes redundant nominal registration and type construction from both free-function and named-method bodies. It also deletes the obsolete syntax-resolving named-method facade, preserves diagnostic ordering for the remaining syntax-backed test/oracle path, and adds a structural guard that prevents provider bodies from returning to that path.

The deterministic provider-work assertion drops from 16 to 15 name lookups for the representative named-import case.

Tests:
- `./buck2 test //crates/rue-air:rue-air-test //crates/rue-compiler:rue-compiler-test`
- `scripts/rue spec str_fixed`

Refs RUE-1473.