### PR TITLE
RUE-1473: attribute expression engine phases

### DIFF
--- a/crates/rue-air/src/sema/analysis/type_inference.rs
+++ b/crates/rue-air/src/sema/analysis/type_inference.rs
@@ -6,6 +6,18 @@
 use super::super::ordinary_engine::{OrdinaryBodyAnalysisHost, OrdinaryBodyEngine};
 use super::*;
 use crate::inference::LazyInferenceFacts;
+use std::time::Instant;
+
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct InferenceBreakdown {
+    pub(crate) precompute_ns: u64,
+    pub(crate) constraint_generation_ns: u64,
+    pub(crate) unification_resolution_ns: u64,
+}
+
+fn elapsed_ns(started: Instant) -> u64 {
+    u64::try_from(started.elapsed().as_nanos()).unwrap_or(u64::MAX)
+}
 
 impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
     fn inference_function_is_selected(
@@ -256,7 +268,8 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
         body: InstRef,
         type_subst: Option<&HashMap<Spur, Type>>,
         value_subst: Option<&HashMap<Spur, ConstValue>>,
-    ) -> CompileResult<HashMap<InstRef, Type>> {
+    ) -> CompileResult<(HashMap<InstRef, Type>, InferenceBreakdown)> {
+        let precompute_started = Instant::now();
         // Pre-resolve `let`-bound comptime type aliases (`let P = F();` where
         // `F` returns `type`) so inference can see the concrete anonymous
         // struct types behind them. Without this, `P { ... }`, `let p: P`,
@@ -306,6 +319,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
         // registered while reducing a head are included in it.
         let inline_ctor_head_types =
             self.precompute_inline_ctor_head_types(type_subst, value_subst, &comptime_local_types);
+        let precompute_ns = elapsed_ns(precompute_started);
 
         // Demand-population provider for the inference-context families
         // (RUE-1091 slice r5b). It materializes each consulted function/method
@@ -326,6 +340,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
         // `self` ends before Phase 2 resumes `&mut self` access (RUE-1091 slice
         // r5b): the shared `InferenceContext` cache holds no `Sema` borrow, and
         // the fill source is threaded here per body.
+        let constraint_generation_started = Instant::now();
         let (
             constraints,
             int_literal_vars,
@@ -457,8 +472,10 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
                 inference_body_dependencies,
             )
         };
+        let constraint_generation_ns = elapsed_ns(constraint_generation_started);
 
         // Phase 2: Solve constraints via unification
+        let unification_resolution_started = Instant::now();
         // Pre-size the substitution for better performance on large functions
         let mut unifier = Unifier::with_capacity(type_var_count);
         unifier.mark_int_literal_vars(&int_literal_vars);
@@ -577,7 +594,15 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
             resolved_types.insert(*inst_ref, concrete_ty);
         }
 
-        Ok(resolved_types)
+        let unification_resolution_ns = elapsed_ns(unification_resolution_started);
+        Ok((
+            resolved_types,
+            InferenceBreakdown {
+                precompute_ns,
+                constraint_generation_ns,
+                unification_resolution_ns,
+            },
+        ))
     }
     /// Analyze an RIR instruction for projection (field access).
     ///

--- a/crates/rue-air/src/sema/ordinary_engine.rs
+++ b/crates/rue-air/src/sema/ordinary_engine.rs
@@ -10,6 +10,7 @@
 
 use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
+use std::time::Instant;
 
 use lasso::{Spur, ThreadedRodeo};
 use rue_error::{CompileError, CompileResult, CompileWarning, ErrorKind};
@@ -54,6 +55,20 @@ pub(crate) fn reject_runtime_type_value(
     Ok(())
 }
 
+/// Adjacent intervals inside one successful canonical expression analysis.
+///
+/// Provider-backed analysis publishes these fields with its existing body
+/// completion event so detailed attribution does not add a second tracing
+/// event per body.
+#[derive(Debug, Clone, Copy, Default)]
+pub(crate) struct ExpressionAnalysisBreakdown {
+    pub(crate) setup_ns: u64,
+    pub(crate) inference_precompute_ns: u64,
+    pub(crate) constraint_generation_ns: u64,
+    pub(crate) unification_resolution_ns: u64,
+    pub(crate) air_emission_validation_ns: u64,
+}
+
 /// The neutral receiver contract consumed by the canonical ordinary-body engine.
 ///
 /// This is intentionally narrower than the eventual full engine state. It
@@ -61,6 +76,8 @@ pub(crate) fn reject_runtime_type_value(
 /// by the ordinary expression engine. Transaction publication remains outside
 /// this extraction.
 pub(crate) trait OrdinaryBodyAnalysisHost: BodyAnalysisHost {
+    fn record_expression_analysis_breakdown(&mut self, _breakdown: ExpressionAnalysisBreakdown) {}
+
     fn body_param_data(&self, range: ParamRange) -> ParamRangeData;
     fn allocate_method_params(
         &mut self,
@@ -2036,6 +2053,7 @@ impl<'h, H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'h, H> {
         HashSet<Spur>,
         HashSet<(StructId, Spur)>,
     )> {
+        let expression_setup_started = Instant::now();
         let mut air = Air::new(return_type);
 
         // Preview gate (RUE-15 / ADR-0037): a `borrow self` / `inout self`
@@ -2158,7 +2176,9 @@ impl<'h, H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'h, H> {
         // ======================================================================
         // Run constraint generation and unification to determine types
         // for all expressions BEFORE emitting AIR.
-        let resolved_types = self.run_type_inference(
+        let expression_setup_ns =
+            u64::try_from(expression_setup_started.elapsed().as_nanos()).unwrap_or(u64::MAX);
+        let (resolved_types, inference_breakdown) = self.run_type_inference(
             infer_ctx,
             return_type,
             params,
@@ -2166,6 +2186,7 @@ impl<'h, H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'h, H> {
             type_subst,
             value_subst,
         )?;
+        let air_emission_started = Instant::now();
 
         // Create analysis context with resolved types
         // If type_subst is provided, initialize comptime_type_vars with the substitutions
@@ -2375,6 +2396,17 @@ impl<'h, H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'h, H> {
                 .body_analysis_first_recovered_error()
                 .expect("error was checked"));
         }
+
+        let air_emission_validation_ns =
+            u64::try_from(air_emission_started.elapsed().as_nanos()).unwrap_or(u64::MAX);
+        self.storage
+            .record_expression_analysis_breakdown(ExpressionAnalysisBreakdown {
+                setup_ns: expression_setup_ns,
+                inference_precompute_ns: inference_breakdown.precompute_ns,
+                constraint_generation_ns: inference_breakdown.constraint_generation_ns,
+                unification_resolution_ns: inference_breakdown.unification_resolution_ns,
+                air_emission_validation_ns,
+            });
 
         Ok((
             air,

--- a/crates/rue-air/src/sema/provider_body_host.rs
+++ b/crates/rue-air/src/sema/provider_body_host.rs
@@ -31,7 +31,9 @@ use super::fact_mode::{
 };
 use super::inference_ctx::{InferenceFactSource, InferenceGeneratedNominalOverlays};
 use super::info::{FunctionCallInfo, MethodCallInfo};
-use super::ordinary_engine::{OrdinaryBodyAnalysisHost, OrdinaryBodyEngine};
+use super::ordinary_engine::{
+    ExpressionAnalysisBreakdown, OrdinaryBodyAnalysisHost, OrdinaryBodyEngine,
+};
 use super::semantic_body_export::SemanticBodyExportHost;
 use super::{
     AnalyzedFunction, BodyAnalysisWork, BodyFactProvider, ConstInfo, ConstValue,
@@ -58,6 +60,7 @@ fn publish_provider_body_breakdown(
     specialization_selection_ns: u64,
     body_export_ns: u64,
     result_projection_ns: u64,
+    expression: ExpressionAnalysisBreakdown,
 ) {
     tracing::event!(
         name: "semantic_provider_breakdown",
@@ -68,6 +71,11 @@ fn publish_provider_body_breakdown(
         specialization_selection_ns,
         body_export_ns,
         result_projection_ns,
+        setup_ns = expression.setup_ns,
+        inference_precompute_ns = expression.inference_precompute_ns,
+        constraint_generation_ns = expression.constraint_generation_ns,
+        unification_resolution_ns = expression.unification_resolution_ns,
+        air_emission_validation_ns = expression.air_emission_validation_ns,
     );
 }
 
@@ -608,6 +616,7 @@ struct ProviderBodyHost<'a, P, S, K, M> {
         super::anon_structs::IssuedCanonicalArguments,
     )>,
     body_work: BodyAnalysisWork,
+    expression_breakdown: Option<ExpressionAnalysisBreakdown>,
     recovered_errors: Vec<CompileError>,
     inference_failure_incomplete: bool,
     comptime_depth: usize,
@@ -741,6 +750,7 @@ where
             anon_struct_type_subst: HashMap::new(),
             active_anonymous_producer: None,
             body_work: BodyAnalysisWork::default(),
+            expression_breakdown: None,
             recovered_errors: Vec::new(),
             inference_failure_incomplete: false,
             comptime_depth: 0,
@@ -3510,6 +3520,10 @@ where
     K: Clone + Eq + Hash + Ord,
     M: Clone + Eq + Hash + Ord,
 {
+    fn record_expression_analysis_breakdown(&mut self, breakdown: ExpressionAnalysisBreakdown) {
+        self.expression_breakdown = Some(breakdown);
+    }
+
     fn body_param_data(&self, range: ParamRange) -> ParamRangeData {
         self.state.param_data(range)
     }
@@ -4470,6 +4484,9 @@ where
         }
     };
     let expression_engine_ns = elapsed_ns(expression_engine_started);
+    let expression_breakdown = host
+        .expression_breakdown
+        .expect("provider ordinary body analysis records its expression breakdown");
     let specialization_selection_started = Instant::now();
     let (mut function, warnings, strings, referenced_functions, referenced_methods) = analyzed;
     function.ordinary_owner = Some(host.owner);
@@ -4559,6 +4576,7 @@ where
         specialization_selection_ns,
         body_export_ns,
         result_projection_ns,
+        expression_breakdown,
     );
     Ok(ProviderOrdinaryBody {
         owner: host.owner,
@@ -4935,6 +4953,9 @@ where
         )?
     };
     let expression_engine_ns = elapsed_ns(expression_engine_started);
+    let expression_breakdown = host
+        .expression_breakdown
+        .expect("provider anonymous body analysis records its expression breakdown");
     let specialization_selection_started = Instant::now();
     let (function, warnings, strings, referenced_functions, referenced_methods) = analyzed;
     let (function, selected_calls, mut referenced_specializations) =
@@ -5028,6 +5049,7 @@ where
         specialization_selection_ns,
         body_export_ns,
         result_projection_ns,
+        expression_breakdown,
     );
     Ok(ProviderAnonymousBody {
         export,
@@ -5139,6 +5161,9 @@ where
     let specialized =
         crate::specialize::analyze_one_specialization_with_host(&mut host, &infer, key)?;
     let expression_engine_ns = elapsed_ns(expression_engine_started);
+    let expression_breakdown = host
+        .expression_breakdown
+        .expect("provider specialized body analysis records its expression breakdown");
     let body_span = host
         .rir
         .rir()
@@ -5239,6 +5264,7 @@ where
         specialization_selection_ns,
         body_export_ns,
         result_projection_ns,
+        expression_breakdown,
     );
     Ok(ProviderSpecializedBody {
         export,

--- a/crates/rue-bench/src/scaling.rs
+++ b/crates/rue-bench/src/scaling.rs
@@ -643,6 +643,45 @@ fn render(report: &ScalingReport) -> String {
         ));
     }
 
+    out.push_str("\n### Expression engine detail\n\n");
+    out.push_str("These five adjacent intervals partition the successful analysis core inside the enclosing expression-engine interval. They separate body setup, compile-time precomputation, constraint generation, unification/type projection, and AIR emission with its semantic postchecks; provider lookup and dispatch remain in the enclosing interval.\n\n");
+    out.push_str("| workload / workers | setup total/max ms | inference precompute total/max ms | constraint generation total/max ms | unification/resolution total/max ms | AIR emission/validation total/max ms |\n");
+    out.push_str("| --- | ---: | ---: | ---: | ---: | ---: |\n");
+    for observation in &report.workloads {
+        let evidence = observation.samples.iter().map(|sample| {
+            sample
+                .boundary_evidence
+                .first()
+                .map(|evidence| evidence.critical_path.clone())
+                .unwrap_or_default()
+        });
+        let pair = |select: fn(&CompilerCriticalPathEvidence) -> &DurationDistribution| {
+            (
+                summarize(evidence.clone().map(|value| select(&value).total_ns)),
+                summarize(evidence.clone().map(|value| select(&value).max_ns)),
+            )
+        };
+        let setup = pair(|value| &value.semantic_expression_setup);
+        let precompute = pair(|value| &value.semantic_inference_precompute);
+        let constraints = pair(|value| &value.semantic_constraint_generation);
+        let unification = pair(|value| &value.semantic_unification_resolution);
+        let emission = pair(|value| &value.semantic_air_emission_validation);
+        out.push_str(&format!(
+            "| {} | {:.2}/{:.2} | {:.2}/{:.2} | {:.2}/{:.2} | {:.2}/{:.2} | {:.2}/{:.2} |\n",
+            observation_label(observation),
+            setup.0.median as f64 / 1_000_000.0,
+            setup.1.median as f64 / 1_000_000.0,
+            precompute.0.median as f64 / 1_000_000.0,
+            precompute.1.median as f64 / 1_000_000.0,
+            constraints.0.median as f64 / 1_000_000.0,
+            constraints.1.median as f64 / 1_000_000.0,
+            unification.0.median as f64 / 1_000_000.0,
+            unification.1.median as f64 / 1_000_000.0,
+            emission.0.median as f64 / 1_000_000.0,
+            emission.1.median as f64 / 1_000_000.0,
+        ));
+    }
+
     out.push_str("\n## Deterministic query work\n\n");
     out.push_str("Counts are exact for one fresh compiler process and must agree across the measured one-worker samples. Parallel scheduling outcomes remain available in each raw boundary proof but are not collapsed into an allegedly deterministic count. Request outcomes expose all query traffic before validation detail: claims start computations, reuses return compatible retained or task-local terminals, and joins share in-flight work. Declined joins are included in joins and identify wait-graph avoidance.\n\n");
     out.push_str("| workload | claims | reuses | joins declined/total | body completions | publications red/green | cancellations/cycles |\n");
@@ -1126,6 +1165,8 @@ mod tests {
         assert!(rendered.contains("UTF-8 bytes scanned"));
         assert!(rendered.contains("Query display identities"));
         assert!(rendered.contains("bytes/token"));
+        assert!(rendered.contains("Expression engine detail"));
+        assert!(rendered.contains("provider lookup and dispatch remain"));
     }
 
     #[test]

--- a/crates/rue-perf-schema/src/boundary.rs
+++ b/crates/rue-perf-schema/src/boundary.rs
@@ -409,6 +409,21 @@ pub struct CompilerCriticalPathEvidence {
     /// Canonical expression inference and body analysis engine.
     #[serde(default)]
     pub semantic_provider_expression_engine: DurationDistribution,
+    /// Parameter/layout setup before expression inference.
+    #[serde(default)]
+    pub semantic_expression_setup: DurationDistribution,
+    /// Compile-time alias and inline-constructor preparation before constraints.
+    #[serde(default)]
+    pub semantic_inference_precompute: DurationDistribution,
+    /// Constraint generation over the body RIR.
+    #[serde(default)]
+    pub semantic_constraint_generation: DurationDistribution,
+    /// Constraint solving and concrete resolved-type projection.
+    #[serde(default)]
+    pub semantic_unification_resolution: DurationDistribution,
+    /// AIR construction plus post-analysis semantic validation.
+    #[serde(default)]
+    pub semantic_air_emission_validation: DurationDistribution,
     /// Post-analysis specialization selection and identity installation.
     #[serde(default)]
     pub semantic_provider_specialization_selection: DurationDistribution,
@@ -613,6 +628,11 @@ impl BuildBoundaryEvidence {
             || !critical.semantic_provider_analysis.validate()
             || !critical.semantic_provider_host_setup.validate()
             || !critical.semantic_provider_expression_engine.validate()
+            || !critical.semantic_expression_setup.validate()
+            || !critical.semantic_inference_precompute.validate()
+            || !critical.semantic_constraint_generation.validate()
+            || !critical.semantic_unification_resolution.validate()
+            || !critical.semantic_air_emission_validation.validate()
             || !critical
                 .semantic_provider_specialization_selection
                 .validate()
@@ -678,11 +698,31 @@ impl BuildBoundaryEvidence {
             || critical.semantic_provider_analysis.count == 0
             || critical.semantic_provider_host_setup.count == 0
             || critical.semantic_provider_expression_engine.count == 0
+            || critical.semantic_expression_setup.count == 0
+            || critical.semantic_inference_precompute.count == 0
+            || critical.semantic_constraint_generation.count == 0
+            || critical.semantic_unification_resolution.count == 0
+            || critical.semantic_air_emission_validation.count == 0
             || critical.semantic_provider_specialization_selection.count == 0
             || critical.semantic_provider_body_export.count == 0
             || critical.semantic_provider_result_projection.count == 0
         {
             return Err("compiler omitted semantic critical-path evidence".to_string());
+        }
+        let expression_counts = [
+            critical.semantic_expression_setup.count,
+            critical.semantic_inference_precompute.count,
+            critical.semantic_constraint_generation.count,
+            critical.semantic_unification_resolution.count,
+            critical.semantic_air_emission_validation.count,
+        ];
+        if expression_counts
+            .iter()
+            .any(|count| *count != critical.semantic_provider_expression_engine.count)
+        {
+            return Err(
+                "compiler omitted or split semantic-expression breakdown evidence".to_string(),
+            );
         }
         let breakdown_counts = [
             critical.cfg_input_preparation_bodies.count,
@@ -793,6 +833,11 @@ mod tests {
                 semantic_provider_analysis: distribution(),
                 semantic_provider_host_setup: distribution(),
                 semantic_provider_expression_engine: distribution(),
+                semantic_expression_setup: distribution(),
+                semantic_inference_precompute: distribution(),
+                semantic_constraint_generation: distribution(),
+                semantic_unification_resolution: distribution(),
+                semantic_air_emission_validation: distribution(),
                 semantic_provider_specialization_selection: distribution(),
                 semantic_provider_body_export: distribution(),
                 semantic_provider_result_projection: distribution(),
@@ -847,6 +892,11 @@ mod tests {
             "semantic_provider_analysis",
             "semantic_provider_host_setup",
             "semantic_provider_expression_engine",
+            "semantic_expression_setup",
+            "semantic_inference_precompute",
+            "semantic_constraint_generation",
+            "semantic_unification_resolution",
+            "semantic_air_emission_validation",
             "semantic_provider_specialization_selection",
             "semantic_provider_body_export",
             "semantic_provider_result_projection",
@@ -907,6 +957,26 @@ mod tests {
         );
         assert_eq!(
             decoded.critical_path.semantic_provider_expression_engine,
+            DurationDistribution::default()
+        );
+        assert_eq!(
+            decoded.critical_path.semantic_expression_setup,
+            DurationDistribution::default()
+        );
+        assert_eq!(
+            decoded.critical_path.semantic_inference_precompute,
+            DurationDistribution::default()
+        );
+        assert_eq!(
+            decoded.critical_path.semantic_constraint_generation,
+            DurationDistribution::default()
+        );
+        assert_eq!(
+            decoded.critical_path.semantic_unification_resolution,
+            DurationDistribution::default()
+        );
+        assert_eq!(
+            decoded.critical_path.semantic_air_emission_validation,
             DurationDistribution::default()
         );
         assert_eq!(

--- a/crates/rue-perf-schema/src/scaling.rs
+++ b/crates/rue-perf-schema/src/scaling.rs
@@ -15,7 +15,7 @@ use crate::{
 };
 
 /// Version of the scaling-report wire format.
-pub const SCALING_REPORT_SCHEMA_VERSION: u32 = 17;
+pub const SCALING_REPORT_SCHEMA_VERSION: u32 = 18;
 
 /// The lower-frequency scaling suite declaration.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]

--- a/crates/rue/src/main.rs
+++ b/crates/rue/src/main.rs
@@ -1077,6 +1077,15 @@ fn compiler_critical_path_evidence(
             .pass_duration_distribution("semantic_provider_host_setup"),
         semantic_provider_expression_engine: timing
             .pass_duration_distribution("semantic_provider_expression_engine"),
+        semantic_expression_setup: timing.pass_duration_distribution("semantic_expression_setup"),
+        semantic_inference_precompute: timing
+            .pass_duration_distribution("semantic_inference_precompute"),
+        semantic_constraint_generation: timing
+            .pass_duration_distribution("semantic_constraint_generation"),
+        semantic_unification_resolution: timing
+            .pass_duration_distribution("semantic_unification_resolution"),
+        semantic_air_emission_validation: timing
+            .pass_duration_distribution("semantic_air_emission_validation"),
         semantic_provider_specialization_selection: timing
             .pass_duration_distribution("semantic_provider_specialization_selection"),
         semantic_provider_body_export: timing

--- a/crates/rue/src/timing.rs
+++ b/crates/rue/src/timing.rs
@@ -1166,6 +1166,11 @@ struct SemanticProviderBreakdownVisitor {
     specialization_selection_ns: Option<u64>,
     body_export_ns: Option<u64>,
     result_projection_ns: Option<u64>,
+    setup_ns: Option<u64>,
+    inference_precompute_ns: Option<u64>,
+    constraint_generation_ns: Option<u64>,
+    unification_resolution_ns: Option<u64>,
+    air_emission_validation_ns: Option<u64>,
 }
 
 impl tracing::field::Visit for TimingFlushVisitor {
@@ -1214,6 +1219,11 @@ impl tracing::field::Visit for SemanticProviderBreakdownVisitor {
             "specialization_selection_ns" => self.specialization_selection_ns = Some(value),
             "body_export_ns" => self.body_export_ns = Some(value),
             "result_projection_ns" => self.result_projection_ns = Some(value),
+            "setup_ns" => self.setup_ns = Some(value),
+            "inference_precompute_ns" => self.inference_precompute_ns = Some(value),
+            "constraint_generation_ns" => self.constraint_generation_ns = Some(value),
+            "unification_resolution_ns" => self.unification_resolution_ns = Some(value),
+            "air_emission_validation_ns" => self.air_emission_validation_ns = Some(value),
             _ => {}
         }
     }
@@ -1336,12 +1346,22 @@ where
                 Some(specialization_selection_ns),
                 Some(body_export_ns),
                 Some(result_projection_ns),
+                Some(setup_ns),
+                Some(inference_precompute_ns),
+                Some(constraint_generation_ns),
+                Some(unification_resolution_ns),
+                Some(air_emission_validation_ns),
             ) = (
                 visitor.host_setup_ns,
                 visitor.expression_engine_ns,
                 visitor.specialization_selection_ns,
                 visitor.body_export_ns,
                 visitor.result_projection_ns,
+                visitor.setup_ns,
+                visitor.inference_precompute_ns,
+                visitor.constraint_generation_ns,
+                visitor.unification_resolution_ns,
+                visitor.air_emission_validation_ns,
             )
             else {
                 return;
@@ -1355,6 +1375,14 @@ where
                 ),
                 ("semantic_provider_body_export", body_export_ns),
                 ("semantic_provider_result_projection", result_projection_ns),
+                ("semantic_expression_setup", setup_ns),
+                ("semantic_inference_precompute", inference_precompute_ns),
+                ("semantic_constraint_generation", constraint_generation_ns),
+                ("semantic_unification_resolution", unification_resolution_ns),
+                (
+                    "semantic_air_emission_validation",
+                    air_emission_validation_ns,
+                ),
             ] {
                 self.data
                     .record_span(name, Duration::from_nanos(duration_ns), false, true);
@@ -2641,6 +2669,11 @@ mod phase_accounting_tests {
                 specialization_selection_ns = 8_u64,
                 body_export_ns = 16_u64,
                 result_projection_ns = 32_u64,
+                setup_ns = 64_u64,
+                inference_precompute_ns = 128_u64,
+                constraint_generation_ns = 256_u64,
+                unification_resolution_ns = 512_u64,
+                air_emission_validation_ns = 1024_u64,
             );
         });
 
@@ -2650,6 +2683,11 @@ mod phase_accounting_tests {
             ("semantic_provider_specialization_selection", 8),
             ("semantic_provider_body_export", 16),
             ("semantic_provider_result_projection", 32),
+            ("semantic_expression_setup", 64),
+            ("semantic_inference_precompute", 128),
+            ("semantic_constraint_generation", 256),
+            ("semantic_unification_resolution", 512),
+            ("semantic_air_emission_validation", 1024),
         ] {
             let distribution = data.pass_duration_distribution(name);
             assert_eq!(distribution.count, 1, "{name}");


### PR DESCRIPTION
## Summary

- split the canonical expression-analysis core into five bounded timing distributions
- require complete per-body evidence in the current benchmark producer
- expose the breakdown in scaling reports and advance the report schema to v18

This distinguishes constraint construction and compile-time precomputation from unification, so ADR-0071 optimization work can target measured costs. The intervals are additive evidence only and do not create a second compilation path.

## Validation

- `scripts/rue fmt`
- `scripts/rue quick` (31 targets passed)
- release Lattice boundary proof: all five distributions recorded 1,263 bodies, exactly matching the enclosing expression-engine count

Refs RUE-1473.