### PR TITLE
RUE-1473: scope inline constructor precompute to its body

### DIFF
--- a/crates/rue-air/src/sema/analysis/type_inference.rs
+++ b/crates/rue-air/src/sema/analysis/type_inference.rs
@@ -317,8 +317,12 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
         // constrained and an integer payload literal defaulted to `i32`
         // (RUE-599). Runs before the lazy-method collection below so methods
         // registered while reducing a head are included in it.
-        let inline_ctor_head_types =
-            self.precompute_inline_ctor_head_types(type_subst, value_subst, &comptime_local_types);
+        let inline_ctor_head_types = self.precompute_inline_ctor_head_types(
+            body,
+            type_subst,
+            value_subst,
+            &comptime_local_types,
+        );
         let precompute_ns = elapsed_ns(precompute_started);
 
         // Demand-population provider for the inference-context families

--- a/crates/rue-air/src/sema/comptime_eval.rs
+++ b/crates/rue-air/src/sema/comptime_eval.rs
@@ -2419,20 +2419,17 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
     /// skipped and sema diagnoses them later) and returns the reductions
     /// keyed by the head's own `InstRef` for the generator to look up.
     ///
-    /// The scan covers the whole RIR, not just the current body: heads
-    /// belonging to other functions evaluate under this function's
-    /// substitutions, but their keys are `InstRef`s this body's constraint
-    /// generation never visits, and reduction is idempotent (specializations
-    /// are cached, anonymous types dedup structurally), so stray entries are
-    /// inert. `comptime_local_types` carries the body's `let`-bound type
-    /// aliases so a head like `Result(T, i32)` with `let T = i64;` reduces.
-    ///
-    /// Runs on every compile (inline type-constructor heads are stable since
-    /// RUE-598). Cache the candidate scan if it shows up in `--time-passes`.
+    /// The scan follows only instructions reachable from this body and stops
+    /// at nested declaration owners. A module RIR contains every body in that
+    /// source file; scanning that whole arena once per body would multiply
+    /// unrelated work by the number of declarations in the module.
+    /// `comptime_local_types` carries the body's `let`-bound type aliases so a
+    /// head like `Result(T, i32)` with `let T = i64;` reduces.
     ///
     /// [`precompute_comptime_type_locals`]: Sema::precompute_comptime_type_locals
     pub(crate) fn precompute_inline_ctor_head_types(
         &mut self,
+        body: InstRef,
         type_subst: Option<&HashMap<Spur, Type>>,
         value_subst: Option<&HashMap<Spur, ConstValue>>,
         comptime_local_types: &HashMap<Spur, Type>,
@@ -2443,22 +2440,7 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
         // struct literal's explicit `ctor_head`. Runtime shapes like
         // `foo(x).bar()` are collected too but fail the reduction cheaply
         // (the comptime engine rejects callees with runtime parameters).
-        let candidates: Vec<InstRef> = self
-            .body_rir_ref()
-            .iter()
-            .filter_map(|(_, inst)| match inst.data {
-                InstData::MethodCall { receiver, .. } => matches!(
-                    self.body_rir_ref().get(receiver).data,
-                    InstData::Call { .. } | InstData::MethodCall { .. }
-                )
-                .then_some(receiver),
-                InstData::StructInit {
-                    ctor_head: Some(head),
-                    ..
-                } => Some(head),
-                _ => None,
-            })
-            .collect();
+        let candidates = inline_ctor_head_candidates(self.body_rir_ref(), body);
         let mut eval_types: HashMap<Spur, Type> = type_subst.cloned().unwrap_or_default();
         eval_types.extend(comptime_local_types);
         let eval_values: HashMap<Spur, ConstValue> = value_subst.cloned().unwrap_or_default();
@@ -2473,4 +2455,50 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
         }
         reduced
     }
+}
+
+pub(super) fn inline_ctor_head_candidates(rir: &rue_rir::Rir, body: InstRef) -> Vec<InstRef> {
+    let mut pending = vec![body];
+    let mut candidates = Vec::new();
+    let mut children = Vec::new();
+
+    while let Some(current) = pending.pop() {
+        if current != body
+            && matches!(
+                rir.get(current).data,
+                InstData::FnDecl { .. }
+                    | InstData::DropFnDecl { .. }
+                    | InstData::StructDecl { .. }
+                    | InstData::EnumDecl { .. }
+                    | InstData::AnonStructType { .. }
+                    | InstData::AnonEnumType { .. }
+            )
+        {
+            continue;
+        }
+
+        match rir.get(current).data {
+            InstData::MethodCall { receiver, .. } => {
+                if matches!(
+                    rir.get(receiver).data,
+                    InstData::Call { .. } | InstData::MethodCall { .. }
+                ) {
+                    candidates.push(receiver);
+                }
+            }
+            InstData::StructInit {
+                ctor_head: Some(head),
+                ..
+            } => candidates.push(head),
+            _ => {}
+        }
+
+        children.clear();
+        rir.child_instructions(current, &mut children);
+        pending.extend(children.iter().copied());
+    }
+
+    candidates.sort_unstable_by_key(|candidate| candidate.as_u32());
+    candidates.dedup();
+    candidates
 }

--- a/crates/rue-air/src/sema/tests.rs
+++ b/crates/rue-air/src/sema/tests.rs
@@ -195,6 +195,43 @@ mod tests {
         (rir, interner)
     }
 
+    #[test]
+    fn inline_constructor_precompute_candidates_are_scoped_to_the_requested_body() {
+        let source = r#"
+            fn Pair(comptime T: type) -> type { struct { value: T } }
+            fn first() -> i32 {
+                let value = Pair(i32) { value: 1 };
+                value.value
+            }
+            fn second() -> i64 {
+                let value = Pair(i64) { value: 2 };
+                value.value
+            }
+        "#;
+        let (rir, interner) = lower_files(&[(source, FileId::DEFAULT)]);
+        let body = |source_name: &str| {
+            rir.iter()
+                .find_map(|(_, inst)| match inst.data {
+                    InstData::FnDecl { name, body, .. }
+                        if interner.resolve(&name) == source_name =>
+                    {
+                        Some(body)
+                    }
+                    _ => None,
+                })
+                .unwrap_or_else(|| panic!("missing {source_name} body"))
+        };
+
+        let first = crate::sema::comptime_eval::inline_ctor_head_candidates(&rir, body("first"));
+        let second = crate::sema::comptime_eval::inline_ctor_head_candidates(&rir, body("second"));
+
+        assert_eq!(first.len(), 1);
+        assert_eq!(second.len(), 1);
+        assert_ne!(first, second);
+        assert!(matches!(rir.get(first[0]).data, InstData::Call { .. }));
+        assert!(matches!(rir.get(second[0]).data, InstData::Call { .. }));
+    }
+
     fn authoritative_test_endpoints(
         shells: &[crate::SemanticDeclarationShell],
     ) -> (


### PR DESCRIPTION
## Summary

- traverse only RIR reachable from the requested body when discovering inline constructor heads
- stop at nested declaration owners so unrelated functions and types are not re-scanned
- add a regression proving each body sees only its own constructor head

## Why

The module RIR contains every declaration in a source file. Scanning the complete arena once per compiled body multiplied unrelated work by the number of declarations. This keeps the same canonical semantic path while making the precompute pass proportional to the requested body.

## Validation

- `scripts/rue unit air inline_constructor_precompute_candidates_are_scoped_to_the_requested_body`
- `scripts/rue spec 4.14`
- `scripts/rue quick`

Refs RUE-1473.