### PR TITLE
RUE-1473: remove dormant inference dependency logging

### DIFF
--- a/crates/rue-air/src/inference/generate.rs
+++ b/crates/rue-air/src/inference/generate.rs
@@ -22,128 +22,6 @@ use rue_span::{FileId, Span};
 use std::collections::HashMap;
 use std::rc::Rc;
 
-/// Exact callable selections made while the test-only body-analysis transaction is
-/// generating constraints.  These observations are consumed only when HM
-/// unification fails before AIR analysis can publish its normal dependencies.
-#[derive(Debug, Clone)]
-pub(crate) enum InferenceCallRoute {
-    Unqualified {
-        alias: Option<Spur>,
-    },
-    Module {
-        module: crate::types::ModuleId,
-        member: Spur,
-        via_alias: bool,
-    },
-}
-
-#[derive(Debug, Clone)]
-pub(crate) enum InferenceBodyDependency {
-    Function {
-        function: Spur,
-        span: Span,
-        route: InferenceCallRoute,
-        checked: bool,
-    },
-    Method {
-        structure: StructId,
-        method: Spur,
-        span: Span,
-        associated: bool,
-    },
-    ModuleBinding(FileId, Spur),
-    ValueConst {
-        file: FileId,
-        name: Spur,
-        access_file: FileId,
-        qualified: bool,
-    },
-    Specialization {
-        function: Spur,
-        type_arguments: Vec<Type>,
-        value_arguments: Vec<ConstValue>,
-        span: Span,
-        route: InferenceCallRoute,
-        checked: bool,
-    },
-    IncompleteCallable,
-}
-
-fn generic_body_dependency(
-    function: Spur,
-    signature: &FunctionSig,
-    type_subst: &HashMap<Spur, Type>,
-    value_subst: &HashMap<Spur, i128>,
-    argument_infos: &[ExprInfo],
-    span: Span,
-    route: InferenceCallRoute,
-    checked: bool,
-) -> Option<InferenceBodyDependency> {
-    let mut type_arguments = Vec::new();
-    let mut value_arguments = Vec::new();
-    for (index, name) in signature.param_names.iter().enumerate() {
-        if !signature
-            .param_comptime
-            .get(index)
-            .copied()
-            .unwrap_or(false)
-        {
-            continue;
-        }
-        if signature
-            .param_comptime_type
-            .get(index)
-            .copied()
-            .unwrap_or(false)
-        {
-            let Some(argument) = type_subst.get(name).copied() else {
-                return unresolved_comptime_argument(argument_infos.get(index))
-                    .then_some(InferenceBodyDependency::IncompleteCallable);
-            };
-            type_arguments.push(argument);
-        } else {
-            let Some(argument) = value_subst.get(name).copied() else {
-                return unresolved_comptime_argument(argument_infos.get(index))
-                    .then_some(InferenceBodyDependency::IncompleteCallable);
-            };
-            value_arguments.push(ConstValue::Integer(argument));
-        }
-    }
-    Some(InferenceBodyDependency::Specialization {
-        function,
-        type_arguments,
-        value_arguments,
-        span,
-        route,
-        checked,
-    })
-}
-
-fn unresolved_comptime_argument(argument: Option<&ExprInfo>) -> bool {
-    !matches!(
-        argument,
-        Some(ExprInfo { ty: InferType::Concrete(ty), .. })
-            if *ty != Type::ERROR && *ty != Type::COMPTIME_TYPE
-    )
-}
-
-fn call_contract_matches<A>(args: A, param_modes: &[rue_rir::RirParamMode]) -> bool
-where
-    A: IntoIterator,
-    A::IntoIter: ExactSizeIterator,
-    A::Item: std::ops::Deref<Target = rue_rir::RirCallArg>,
-{
-    use rue_rir::{RirArgMode as A, RirParamMode as P};
-    let args = args.into_iter();
-    args.len() == param_modes.len()
-        && args.zip(param_modes).all(|(arg, mode)| {
-            matches!(
-                (arg.mode, mode),
-                (A::Normal, P::Normal) | (A::Inout, P::Inout) | (A::Borrow, P::Borrow)
-            )
-        })
-}
-
 /// Information about a local variable during constraint generation.
 #[derive(Debug, Clone)]
 pub struct LocalVarInfo {
@@ -459,8 +337,6 @@ pub struct ConstraintGenerator<'a> {
     comptime_values: Option<&'a HashMap<Spur, ConstValue>>,
     /// Type intern pool for creating pointer and array types during constraint generation.
     type_pool: &'a TypeInternPool,
-    /// Exact dependency selections made before unification.
-    body_dependencies: Vec<InferenceBodyDependency>,
 }
 
 impl<'a> ConstraintGenerator<'a> {
@@ -536,7 +412,6 @@ impl<'a> ConstraintGenerator<'a> {
             const_function_aliases: None,
             comptime_values: None,
             type_pool,
-            body_dependencies: Vec::new(),
         }
     }
 
@@ -589,7 +464,6 @@ impl<'a> ConstraintGenerator<'a> {
             const_function_aliases: None,
             comptime_values: None,
             type_pool,
-            body_dependencies: Vec::new(),
         }
     }
 
@@ -1072,10 +946,6 @@ impl<'a> ConstraintGenerator<'a> {
         &self.expr_types
     }
 
-    pub(crate) fn body_dependencies(&self) -> &[InferenceBodyDependency] {
-        &self.body_dependencies
-    }
-
     /// Consume the constraint generator and return its generated constraints,
     /// literal variables, expression types, and allocated variable count.
     ///
@@ -1310,20 +1180,11 @@ impl<'a> ConstraintGenerator<'a> {
                 } else if let Some(param) = ctx.params.get(name) {
                     param.ty.clone()
                 } else if let Some(binding_ty) = self.module_binding_type((span.file_id, *name)) {
-                    self.body_dependencies
-                        .push(InferenceBodyDependency::ModuleBinding(span.file_id, *name));
                     // Module binding declared in this file (`const m =
                     // @import(...)`): per-file scoped and distinct from the
                     // file's value-constant namespace (RUE-113).
                     self.type_to_infer(binding_ty)
                 } else if let Some(const_ty) = self.const_type((span.file_id, *name)) {
-                    self.body_dependencies
-                        .push(InferenceBodyDependency::ValueConst {
-                            file: span.file_id,
-                            name: *name,
-                            access_file: span.file_id,
-                            qualified: false,
-                        });
                     // File-level constant: its type was resolved during
                     // declaration gathering (i32/bool/unit literals, module
                     // types for `const m = @import(...)`). Yielding it here
@@ -1507,15 +1368,6 @@ impl<'a> ConstraintGenerator<'a> {
                 let function_key =
                     alias_target.or_else(|| self.function_by_file((span.file_id, *name)));
                 let args = self.rir.call_args(args);
-                if alias_target.is_some() {
-                    self.body_dependencies
-                        .push(InferenceBodyDependency::ValueConst {
-                            file: span.file_id,
-                            name: *name,
-                            access_file: span.file_id,
-                            qualified: false,
-                        });
-                }
                 // `print(s)` / `println(s)` builtin free functions (RUE-1):
                 // generate the argument and yield unit. Semantic analysis
                 // validates the shared text family (`StrBuf`, `str`, `Str(N)`),
@@ -1531,18 +1383,6 @@ impl<'a> ConstraintGenerator<'a> {
                     }
                     InferType::Concrete(Type::UNIT)
                 } else if let Some(func) = function_key.and_then(|key| self.func_sig(key)) {
-                    if !func.is_generic && call_contract_matches(&args, &func.param_modes) {
-                        self.body_dependencies
-                            .push(InferenceBodyDependency::Function {
-                                function: function_key
-                                    .expect("resolved signature has a function key"),
-                                span,
-                                route: InferenceCallRoute::Unqualified {
-                                    alias: alias_target.map(|_| *name),
-                                },
-                                checked: ctx.checked_depth > 0,
-                            });
-                    }
                     // For generic functions, build the type substitution map from the
                     // comptime type arguments, then constrain each runtime argument
                     // against its (substituted) parameter type. When a type parameter
@@ -1581,21 +1421,6 @@ impl<'a> ConstraintGenerator<'a> {
                             } else if let Some(v) = self.extract_int_argument(arg.value) {
                                 value_subst.insert(func.param_names[i], v);
                             }
-                        }
-
-                        if call_contract_matches(&args, &func.param_modes) {
-                            self.body_dependencies.extend(generic_body_dependency(
-                                function_key.expect("resolved signature has a function key"),
-                                &func,
-                                &type_subst,
-                                &value_subst,
-                                &arg_infos,
-                                span,
-                                InferenceCallRoute::Unqualified {
-                                    alias: alias_target.map(|_| *name),
-                                },
-                                ctx.checked_depth > 0,
-                            ));
                         }
 
                         // Constrain each runtime argument to its parameter type, with
@@ -2643,15 +2468,6 @@ impl<'a> ConstraintGenerator<'a> {
                                 }),
                             _ => None,
                         };
-                        if let Some((file, _)) = member_const {
-                            self.body_dependencies
-                                .push(InferenceBodyDependency::ValueConst {
-                                    file,
-                                    name: *field,
-                                    access_file: span.file_id,
-                                    qualified: true,
-                                });
-                        }
                         let member_const_ty = member_const.map(|(_, ty)| ty);
                         // A module member that is itself a (re-exported) module:
                         // `std.cmp` where std's file has `pub const cmp =
@@ -2893,15 +2709,6 @@ impl<'a> ConstraintGenerator<'a> {
                     && let Some(string_id) = string_ty.as_struct()
                     && let Some(method_sig) = self.method_sig(&(string_id, *method))
                 {
-                    if call_contract_matches(&call_args, &method_sig.param_modes) {
-                        self.body_dependencies
-                            .push(InferenceBodyDependency::Method {
-                                structure: string_id,
-                                method: *method,
-                                span,
-                                associated: false,
-                            });
-                    }
                     let shared_str_method = self.string_literal_default_is_str()
                         && self.interner.resolve(method) == "len";
                     if !shared_str_method {
@@ -2948,33 +2755,7 @@ impl<'a> ConstraintGenerator<'a> {
                             module_file
                                 .and_then(|file_id| self.function_by_file((file_id, *method)))
                         });
-                        if let (Some(file), Some(_)) = (module_file, alias_target) {
-                            self.body_dependencies
-                                .push(InferenceBodyDependency::ValueConst {
-                                    file,
-                                    name: *method,
-                                    access_file: span.file_id,
-                                    qualified: true,
-                                });
-                        }
                         if let Some(func) = function_key.and_then(|key| self.func_sig(key)) {
-                            #[cfg(test)]
-                            if !func.is_generic
-                                && call_contract_matches(&call_args, &func.param_modes)
-                            {
-                                self.body_dependencies
-                                    .push(InferenceBodyDependency::Function {
-                                        function: function_key
-                                            .expect("resolved module signature has a function key"),
-                                        span,
-                                        route: InferenceCallRoute::Module {
-                                            module: module_id,
-                                            member: *method,
-                                            via_alias: alias_target.is_some(),
-                                        },
-                                        checked: ctx.checked_depth > 0,
-                                    });
-                            }
                             if !func.is_generic && call_args.len() == func.param_types.len() {
                                 // Constrain each argument against its declared
                                 // parameter type (same as a direct Call).
@@ -3030,23 +2811,6 @@ impl<'a> ConstraintGenerator<'a> {
                                     } else if let Some(v) = self.extract_int_argument(arg.value) {
                                         value_subst.insert(func.param_names[i], v);
                                     }
-                                }
-                                if call_contract_matches(&call_args, &func.param_modes) {
-                                    self.body_dependencies.extend(generic_body_dependency(
-                                        function_key
-                                            .expect("resolved module signature has a function key"),
-                                        &func,
-                                        &type_subst,
-                                        &value_subst,
-                                        &arg_infos,
-                                        span,
-                                        InferenceCallRoute::Module {
-                                            module: module_id,
-                                            member: *method,
-                                            via_alias: alias_target.is_some(),
-                                        },
-                                        ctx.checked_depth > 0,
-                                    ));
                                 }
                                 for (i, arg_info) in arg_infos.iter().enumerate() {
                                     if i >= func.param_types.len() || i >= func.param_comptime.len()
@@ -3144,8 +2908,6 @@ impl<'a> ConstraintGenerator<'a> {
                         {
                             result
                         } else {
-                            self.body_dependencies
-                                .push(InferenceBodyDependency::IncompleteCallable);
                             for arg in call_args.iter() {
                                 self.generate(arg.value, ctx);
                             }
@@ -3159,15 +2921,6 @@ impl<'a> ConstraintGenerator<'a> {
                             // signatures, RUE-164)
                             let method_key = (struct_id, *method);
                             if let Some(method_sig) = self.method_sig(&method_key) {
-                                if call_contract_matches(&call_args, &method_sig.param_modes) {
-                                    self.body_dependencies
-                                        .push(InferenceBodyDependency::Method {
-                                            structure: struct_id,
-                                            method: *method,
-                                            span,
-                                            associated: false,
-                                        });
-                                }
                                 // Generate constraints for arguments
                                 for (arg, param_type) in
                                     call_args.iter().zip(method_sig.param_types.iter())
@@ -3234,8 +2987,6 @@ impl<'a> ConstraintGenerator<'a> {
                         {
                             result
                         } else {
-                            self.body_dependencies
-                                .push(InferenceBodyDependency::IncompleteCallable);
                             for arg in call_args.iter() {
                                 self.generate(arg.value, ctx);
                             }
@@ -3531,15 +3282,6 @@ impl<'a> ConstraintGenerator<'a> {
         let struct_id = ty.as_struct()?;
         let method_sig = self.method_sig(&(struct_id, function))?;
         let args = self.rir.call_args(args);
-        if call_contract_matches(&args, &method_sig.param_modes) {
-            self.body_dependencies
-                .push(InferenceBodyDependency::Method {
-                    structure: struct_id,
-                    method: function,
-                    span: _span,
-                    associated: true,
-                });
-        }
         for (arg, param_type) in args.iter().zip(method_sig.param_types.iter()) {
             let defer_equality = self.is_slice_struct_type(param_type.clone());
             let arg_info = self.generate(arg.value, ctx);

--- a/crates/rue-air/src/inference/mod.rs
+++ b/crates/rue-air/src/inference/mod.rs
@@ -50,10 +50,10 @@ mod unify;
 
 // Re-export all public types
 pub use constraint::{Constraint, Substitution};
+pub(crate) use generate::LazyInferenceFacts;
 pub use generate::{
     ConstraintContext, ConstraintGenerator, ExprInfo, FunctionSig, LocalVarInfo, MethodSig,
     ParamVarInfo,
 };
-pub(crate) use generate::{InferenceBodyDependency, InferenceCallRoute, LazyInferenceFacts};
 pub use types::{InferType, TypeVarAllocator, TypeVarId};
 pub use unify::{UnificationError, Unifier, UnifyResult};

--- a/crates/rue-air/src/sema/analysis/type_inference.rs
+++ b/crates/rue-air/src/sema/analysis/type_inference.rs
@@ -20,235 +20,6 @@ fn elapsed_ns(started: Instant) -> u64 {
 }
 
 impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
-    fn inference_function_is_selected(
-        &self,
-        function: Spur,
-        span: Span,
-        route: &crate::inference::InferenceCallRoute,
-        checked: bool,
-    ) -> Option<bool> {
-        let info = self.function_info(function)?;
-        if (info.is_unchecked || info.is_extern) && !checked {
-            return Some(false);
-        }
-        match route {
-            crate::inference::InferenceCallRoute::Unqualified { alias } => {
-                if let Some(alias_name) = alias {
-                    let alias = self.value_const(&(span.file_id, *alias_name))?;
-                    if alias.value.as_function() != Some(function)
-                        || self
-                            .check_unqualified_visibility(
-                                "constant",
-                                self.body_interner().resolve(alias_name),
-                                alias.span.file_id,
-                                alias.is_pub,
-                                span,
-                            )
-                            .is_err()
-                    {
-                        return Some(false);
-                    }
-                } else if self
-                    .resolve_function_name_local(self.source_function_name(function), span.file_id)
-                    .is_none_or(|selected| selected != function)
-                {
-                    return Some(false);
-                }
-                Some(
-                    self.check_unqualified_visibility(
-                        "function",
-                        self.body_interner()
-                            .resolve(&self.source_function_name(function)),
-                        info.file_id,
-                        info.is_pub,
-                        span,
-                    )
-                    .is_ok(),
-                )
-            }
-            crate::inference::InferenceCallRoute::Module {
-                module,
-                member,
-                via_alias,
-            } => {
-                let module_file = self.module_def(*module).file_id;
-                if *via_alias {
-                    // The visible facade const is the module membership and
-                    // visibility grant. Its selected function may be private
-                    // or defined in another file, exactly as in the canonical
-                    // module-call path; do not reapply direct-member policy to
-                    // that hidden target.
-                    let alias = self.value_const(&(module_file, *member))?;
-                    return Some(
-                        alias.value.as_function() == Some(function)
-                            && self.is_accessible(span.file_id, module_file, alias.is_pub),
-                    );
-                }
-                let selected = self
-                    .resolve_function_name_local(*member, module_file)
-                    .is_some_and(|selected| selected == function);
-                Some(
-                    selected
-                        && info.file_id == module_file
-                        && self.is_accessible(span.file_id, info.file_id, info.is_pub),
-                )
-            }
-        }
-    }
-
-    pub(crate) fn record_inference_body_dependencies(
-        &mut self,
-        dependencies: &[crate::inference::InferenceBodyDependency],
-        expr_types: &HashMap<InstRef, InferType>,
-    ) -> bool {
-        if !self.body_analysis_error_recovery() {
-            return false;
-        }
-
-        let mut incomplete = false;
-        for dependency in dependencies {
-            match dependency {
-                crate::inference::InferenceBodyDependency::Function {
-                    function,
-                    span,
-                    route,
-                    checked,
-                } => match self.inference_function_is_selected(*function, *span, route, *checked) {
-                    Some(true) => self.record_body_callable_dependency(*function),
-                    Some(false) => {}
-                    None => incomplete = true,
-                },
-                crate::inference::InferenceBodyDependency::Method {
-                    structure,
-                    method,
-                    span,
-                    associated,
-                } => {
-                    let Some(info) = self.method_info((*structure, *method)) else {
-                        incomplete = true;
-                        continue;
-                    };
-                    if info.has_self != *associated {
-                        if *associated {
-                            let def = self.body_type_pool().struct_def(*structure);
-                            if self
-                                .check_unqualified_visibility(
-                                    "struct",
-                                    &def.name,
-                                    def.file_id,
-                                    def.is_pub,
-                                    *span,
-                                )
-                                .is_err()
-                            {
-                                continue;
-                            }
-                        }
-                        self.record_body_method_dependency((*structure, *method));
-                    }
-                }
-                crate::inference::InferenceBodyDependency::ModuleBinding(file, name) => {
-                    self.record_body_named_dependency(
-                        crate::NamedConstDependencyTargetEvent::ModuleBinding {
-                            file: file.index(),
-                            name: self.body_interner().resolve(name).to_owned(),
-                        },
-                    );
-                }
-                crate::inference::InferenceBodyDependency::ValueConst {
-                    file,
-                    name,
-                    access_file,
-                    qualified,
-                } => {
-                    let Some(info) = self.value_const(&(*file, *name)) else {
-                        incomplete = true;
-                        continue;
-                    };
-                    if *qualified && !self.is_accessible(*access_file, *file, info.is_pub) {
-                        continue;
-                    }
-                    self.record_body_named_dependency(
-                        crate::NamedConstDependencyTargetEvent::ValueConst {
-                            file: file.index(),
-                            name: self.body_interner().resolve(name).to_owned(),
-                        },
-                    );
-                }
-                crate::inference::InferenceBodyDependency::Specialization {
-                    function,
-                    type_arguments,
-                    value_arguments,
-                    span,
-                    route,
-                    checked,
-                } => {
-                    match self.inference_function_is_selected(*function, *span, route, *checked) {
-                        Some(true) => {}
-                        Some(false) => continue,
-                        None => {
-                            incomplete = true;
-                            continue;
-                        }
-                    }
-                    if self.body_dependency_observer().is_none() {
-                        incomplete = true;
-                        continue;
-                    }
-                    match self.canonical_specialization_instance(
-                        *function,
-                        type_arguments,
-                        value_arguments,
-                    ) {
-                        Ok(identity) => self.record_specialization_dependency(identity),
-                        Err(_) => incomplete = true,
-                    }
-                }
-                crate::inference::InferenceBodyDependency::IncompleteCallable => {
-                    // This path is reached only while publishing an inference
-                    // error. An unresolved callable is therefore part of the
-                    // rejected source construct, not evidence that a query
-                    // dependency is absent. Treating it as retryable discards
-                    // the user diagnostic and makes the uncanceled body query
-                    // surface E9000 instead.
-                }
-            }
-        }
-
-        fn record_concrete<H: OrdinaryBodyAnalysisHost>(
-            sema: &mut OrdinaryBodyEngine<'_, H>,
-            ty: &InferType,
-            access_file: FileId,
-        ) -> bool {
-            match ty {
-                InferType::Concrete(ty) => {
-                    let accessible = match ty.kind() {
-                        TypeKind::Struct(id) => {
-                            let def = sema.body_type_pool().struct_def(id);
-                            sema.is_accessible(access_file, def.file_id, def.is_pub)
-                        }
-                        TypeKind::Enum(id) => {
-                            let def = sema.body_type_pool().enum_def(id);
-                            sema.is_accessible(access_file, def.file_id, def.is_pub)
-                        }
-                        _ => true,
-                    };
-                    if accessible {
-                        sema.record_resolved_declaration_type(*ty);
-                    }
-                    !accessible
-                }
-                InferType::Array { element, .. } => record_concrete(sema, element, access_file),
-                InferType::Var(_) | InferType::IntLiteral => false,
-            }
-        }
-        for (inst_ref, ty) in expr_types {
-            incomplete |=
-                record_concrete(self, ty, self.body_rir_ref().get(*inst_ref).span.file_id);
-        }
-        incomplete
-    }
-
     /// Run Hindley-Milner type inference on a function body.
     ///
     /// This is Phases 1-2 of the HM algorithm:
@@ -352,7 +123,6 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
             string_literal_default,
             expr_types,
             type_var_count,
-            inference_body_dependencies,
         ) = {
             let facts = self.inference_facts(infer_ctx);
 
@@ -441,8 +211,6 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
             // Phase 1: Generate constraints
             let body_info = cgen.generate(body, &mut cgen_ctx);
 
-            let inference_body_dependencies = cgen.body_dependencies().to_vec();
-
             // The function body's type must match the return type.
             // This handles implicit returns like `fn foo() -> i8 { 42 }`.
             // For arrays, we need to convert Type to InferType structurally.
@@ -473,7 +241,6 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
                 string_literal_default,
                 expr_types,
                 type_var_count,
-                inference_body_dependencies,
             )
         };
         let constraint_generation_ns = elapsed_ns(constraint_generation_started);
@@ -513,13 +280,6 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
         // For now, we collect the first error. In the future, we could
         // report multiple errors for better diagnostics.
         if let Some(err) = errors.first() {
-            {
-                let inference_dependency_incomplete = self
-                    .record_inference_body_dependencies(&inference_body_dependencies, &expr_types);
-                self.set_body_analysis_inference_failure_incomplete(
-                    inference_dependency_incomplete,
-                );
-            }
             // Map each UnifyResult variant to the appropriate ErrorKind
             let error_kind = match &err.kind {
                 UnifyResult::Ok => unreachable!("UnificationError should never contain Ok"),
@@ -569,10 +329,6 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
             }
 
             return Err(compile_error);
-        }
-
-        {
-            self.set_body_analysis_inference_failure_incomplete(false);
         }
 
         // Default any unconstrained integer literals to i32

--- a/crates/rue-air/src/sema/mod.rs
+++ b/crates/rue-air/src/sema/mod.rs
@@ -452,7 +452,6 @@ pub struct Sema<'a, D: DeclarationPhase = MutableDeclarations> {
     pub(crate) body_named_dependencies: Vec<BodyNamedDependencyEvent>,
     pub(crate) body_analysis_error_recovery: bool,
     pub(crate) body_analysis_recovered_errors: Vec<rue_error::CompileError>,
-    pub(crate) body_analysis_inference_failure_incomplete: bool,
     /// Anonymous identities already installed when an exact-body-analysis attempt
     /// starts. Successful export subtracts this baseline so the transaction
     /// publishes every nominal materialized by the body, including nested
@@ -684,7 +683,6 @@ impl<'a, D: DeclarationPhase> Sema<'a, D> {
             body_named_dependencies,
             body_analysis_error_recovery,
             body_analysis_recovered_errors,
-            body_analysis_inference_failure_incomplete,
             body_analysis_initial_anonymous_identities,
             body_analysis_requested_producer,
             body_callable_dependencies,
@@ -762,7 +760,6 @@ impl<'a, D: DeclarationPhase> Sema<'a, D> {
             body_named_dependencies,
             body_analysis_error_recovery,
             body_analysis_recovered_errors,
-            body_analysis_inference_failure_incomplete,
             body_analysis_initial_anonymous_identities,
             body_analysis_requested_producer,
             body_callable_dependencies,
@@ -1240,7 +1237,6 @@ impl<'a> Sema<'a, MutableDeclarations> {
             body_named_dependencies: Vec::new(),
             body_analysis_error_recovery: false,
             body_analysis_recovered_errors: Vec::new(),
-            body_analysis_inference_failure_incomplete: false,
             body_analysis_initial_anonymous_identities: std::collections::BTreeSet::new(),
             body_analysis_requested_producer: None,
             body_callable_dependencies: Vec::new(),

--- a/crates/rue-air/src/sema/ordinary_engine.rs
+++ b/crates/rue-air/src/sema/ordinary_engine.rs
@@ -93,7 +93,6 @@ pub(crate) trait OrdinaryBodyAnalysisHost: BodyAnalysisHost {
     fn is_strbuf(&self, ty: Type) -> bool;
     fn types_equivalent(&self, left: Type, right: Type) -> bool;
     fn generated_structs(&self) -> &HashMap<Spur, StructId>;
-    fn set_body_analysis_inference_failure_incomplete(&mut self, value: bool);
 
     fn body_interner(&self) -> &ThreadedRodeo;
     fn body_type_pool(&self) -> &TypeInternPool;
@@ -1194,10 +1193,6 @@ impl<'h, H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'h, H> {
     }
     pub(crate) fn body_analysis_work_mut(&mut self) -> &mut BodyAnalysisWork {
         self.storage.body_analysis_work_mut()
-    }
-    pub(crate) fn set_body_analysis_inference_failure_incomplete(&mut self, value: bool) {
-        self.storage
-            .set_body_analysis_inference_failure_incomplete(value)
     }
     pub(crate) fn body_analysis_error_recovery(&self) -> bool {
         self.storage.body_analysis_error_recovery()
@@ -2456,10 +2451,6 @@ impl<'a, D: DeclarationPhase> OrdinaryBodyAnalysisHost for super::Sema<'a, D> {
     fn generated_structs(&self) -> &HashMap<Spur, StructId> {
         &self.generated_structs
     }
-    fn set_body_analysis_inference_failure_incomplete(&mut self, value: bool) {
-        self.body_analysis_inference_failure_incomplete = value;
-    }
-
     fn body_interner(&self) -> &ThreadedRodeo {
         self.interner
     }

--- a/crates/rue-air/src/sema/provider_body_host.rs
+++ b/crates/rue-air/src/sema/provider_body_host.rs
@@ -618,7 +618,6 @@ struct ProviderBodyHost<'a, P, S, K, M> {
     body_work: BodyAnalysisWork,
     expression_breakdown: Option<ExpressionAnalysisBreakdown>,
     recovered_errors: Vec<CompileError>,
-    inference_failure_incomplete: bool,
     comptime_depth: usize,
     deferred_ownership: Vec<super::DeferredOwnershipGate>,
     ctor_displays: HashMap<Type, String>,
@@ -752,7 +751,6 @@ where
             body_work: BodyAnalysisWork::default(),
             expression_breakdown: None,
             recovered_errors: Vec::new(),
-            inference_failure_incomplete: false,
             comptime_depth: 0,
             deferred_ownership: Vec::new(),
             ctor_displays: HashMap::new(),
@@ -3563,9 +3561,6 @@ where
     }
     fn generated_structs(&self) -> &HashMap<Spur, StructId> {
         &self.generated_structs
-    }
-    fn set_body_analysis_inference_failure_incomplete(&mut self, value: bool) {
-        self.inference_failure_incomplete = value;
     }
     fn body_interner(&self) -> &ThreadedRodeo {
         &self.interner


### PR DESCRIPTION
## Summary

- stop building a per-body dependency log during inference constraint generation
- remove the unconditional clone of that log before unification
- delete the unused recovery-state plumbing that was its only consumer

Every current body-analysis host disables this recovery experiment, and no production or test path enables it. The actual constraints, unification, semantic dependency recording, and diagnostics are unchanged. This removes allocations and per-expression bookkeeping from successful cold compiles while simplifying the inference boundary.

## Validation

- `scripts/rue quick`
- `scripts/rue spec 4.14` (203/203)
- `scripts/rue fmt`

Refs RUE-1473.