### PR TITLE
RUE-1473: share semantic fact lookup substrate

### DIFF
--- a/crates/rue-compiler/src/local_semantic_materialization.rs
+++ b/crates/rue-compiler/src/local_semantic_materialization.rs
@@ -31,35 +31,39 @@ pub(crate) struct LocalFactSelectionIndexWork {
     pub(crate) type_nodes_scanned: usize,
 }
 
-/// Immutable request-local lookup preparation shared by every CFG input.
+/// Immutable lookup substrate derived with one semantic-nucleus projection.
 ///
-/// This is a convenience index over exact query-owned facts, never a semantic
-/// or query authority. Selected facts are still cloned into each CFG memo key.
-pub(crate) struct LocalFactSelectionIndex<'facts> {
-    declarations:
-        std::collections::HashMap<&'facts StableDefinitionKey, &'facts DurableDeclarationSemantic>,
-    destructors: std::collections::HashMap<
-        (&'facts ModuleId, StableDefinitionKind, &'facts str),
-        &'facts DurableDeclarationSemantic,
-    >,
-    anonymous: std::collections::HashMap<
-        &'facts crate::AnonymousNominalKey,
-        &'facts DurableAnonymousNominal,
-    >,
+/// Reachability and every CFG input reuse this index over exact query-owned
+/// facts. It is never semantic or query authority: selected facts are still
+/// cloned into each exact CFG memo key.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct SharedDeclarationFactIndex {
+    declarations: std::collections::HashMap<StableDefinitionKey, usize>,
+    destructors: Vec<Option<usize>>,
     slice_sources: std::collections::HashMap<Arc<str>, crate::TypeInstanceKey>,
 }
 
-impl<'facts> LocalFactSelectionIndex<'facts> {
-    pub(crate) fn new(
-        declarations: &'facts [DurableDeclarationSemantic],
-        anonymous_nominals: &'facts [DurableAnonymousNominal],
-    ) -> (Self, LocalFactSelectionIndexWork) {
-        let mut work = LocalFactSelectionIndexWork::default();
+impl SharedDeclarationFactIndex {
+    pub(crate) fn new(declarations: &[DurableDeclarationSemantic]) -> Self {
         let mut declaration_index = std::collections::HashMap::with_capacity(declarations.len());
-        let mut destructors = std::collections::HashMap::new();
+        let mut destructors = vec![None; declarations.len()];
+        let named_types = declarations
+            .iter()
+            .enumerate()
+            .map(|(index, declaration)| {
+                (
+                    (
+                        declaration.key.module(),
+                        declaration.key.kind(),
+                        declaration.key.name(),
+                    ),
+                    index,
+                )
+            })
+            .collect::<std::collections::HashMap<_, _>>();
         let mut slice_sources = std::collections::HashMap::new();
-        for declaration in declarations {
-            work.declarations_scanned += 1;
+        let mut work = LocalFactSelectionIndexWork::default();
+        for (index, declaration) in declarations.iter().enumerate() {
             match &declaration.payload {
                 DurableDeclarationPayload::Callable {
                     parameters, result, ..
@@ -88,11 +92,57 @@ impl<'facts> LocalFactSelectionIndex<'facts> {
             }
             if matches!(declaration.payload, DurableDeclarationPayload::Destructor)
                 && let Some(owner) = declaration.key.owner()
+                && let Some(&owner_index) =
+                    named_types.get(&(owner.module(), owner.kind(), owner.name()))
             {
-                destructors.insert((owner.module(), owner.kind(), owner.name()), declaration);
+                destructors[owner_index] = Some(index);
             }
-            declaration_index.insert(&declaration.key, declaration);
+            declaration_index.insert(declaration.key.clone(), index);
         }
+        Self {
+            declarations: declaration_index,
+            destructors,
+            slice_sources,
+        }
+    }
+
+    pub(crate) fn declaration<'facts>(
+        &self,
+        declarations: &'facts [DurableDeclarationSemantic],
+        key: &StableDefinitionKey,
+    ) -> Option<&'facts DurableDeclarationSemantic> {
+        self.declarations
+            .get(key)
+            .and_then(|&index| declarations.get(index))
+    }
+
+    fn destructor<'facts>(
+        &self,
+        declarations: &'facts [DurableDeclarationSemantic],
+        owner: &StableDefinitionKey,
+    ) -> Option<&'facts DurableDeclarationSemantic> {
+        let owner_index = *self.declarations.get(owner)?;
+        let destructor_index = *self.destructors.get(owner_index)?.as_ref()?;
+        declarations.get(destructor_index)
+    }
+}
+
+pub(crate) struct LocalFactSelectionIndex<'facts> {
+    declarations: &'facts [DurableDeclarationSemantic],
+    shared: &'facts SharedDeclarationFactIndex,
+    anonymous: std::collections::HashMap<
+        &'facts crate::AnonymousNominalKey,
+        &'facts DurableAnonymousNominal,
+    >,
+}
+
+impl<'facts> LocalFactSelectionIndex<'facts> {
+    pub(crate) fn new(
+        shared: &'facts SharedDeclarationFactIndex,
+        declarations: &'facts [DurableDeclarationSemantic],
+        anonymous_nominals: &'facts [DurableAnonymousNominal],
+    ) -> (Self, LocalFactSelectionIndexWork) {
+        let mut work = LocalFactSelectionIndexWork::default();
         let mut anonymous = std::collections::HashMap::with_capacity(anonymous_nominals.len());
         for nominal in anonymous_nominals {
             work.anonymous_nominals_scanned += 1;
@@ -100,13 +150,32 @@ impl<'facts> LocalFactSelectionIndex<'facts> {
         }
         (
             Self {
-                declarations: declaration_index,
-                destructors,
+                declarations,
+                shared,
                 anonymous,
-                slice_sources,
             },
             work,
         )
+    }
+
+    fn declaration(&self, key: &StableDefinitionKey) -> Option<&'facts DurableDeclarationSemantic> {
+        self.shared.declaration(self.declarations, key)
+    }
+
+    fn destructor(
+        &self,
+        owner: &StableDefinitionKey,
+    ) -> Option<&'facts DurableDeclarationSemantic> {
+        self.shared.destructor(self.declarations, owner)
+    }
+}
+
+impl RetainedCharge for SharedDeclarationFactIndex {
+    fn retained_charge(&self) -> u64 {
+        self.declarations
+            .retained_charge()
+            .saturating_add(self.destructors.retained_charge())
+            .saturating_add(self.slice_sources.retained_charge())
     }
 }
 
@@ -891,6 +960,7 @@ pub(crate) fn select_materialization_facts(
             }
             let query_ty = self
                 .index
+                .shared
                 .slice_sources
                 .get(name)
                 .cloned()
@@ -1071,13 +1141,8 @@ pub(crate) fn select_materialization_facts(
                 match nominal {
                     crate::NominalInstanceKey::Builtin { .. } => {}
                     crate::NominalInstanceKey::Named(key) => {
-                        let declaration = self
-                            .index
-                            .declarations
-                            .get(&key)
-                            .copied()
-                            .cloned()
-                            .ok_or_else(|| {
+                        let declaration =
+                            self.index.declaration(&key).cloned().ok_or_else(|| {
                                 LocalFactSelectionFailure::MissingNamedNominal(key.clone())
                             })?;
                         self.modules.insert(key.module().clone());
@@ -1088,10 +1153,7 @@ pub(crate) fn select_materialization_facts(
                                 for (_, ty) in fields.iter() {
                                     self.semantic_type(ty);
                                 }
-                                let owner = (key.module(), key.kind(), key.name());
-                                if let Some(destructor) =
-                                    self.index.destructors.get(&owner).copied().cloned()
-                                {
+                                if let Some(destructor) = self.index.destructor(&key).cloned() {
                                     self.selected_declarations
                                         .insert(destructor.key.clone(), destructor.clone());
                                     self.callable(&FunctionInstanceKey::Definition(
@@ -1168,10 +1230,9 @@ pub(crate) fn select_materialization_facts(
                 match nominal {
                     crate::NominalInstanceKey::Builtin { .. } => {}
                     crate::NominalInstanceKey::Named(key) => {
-                        let declaration =
-                            self.index.declarations.get(&key).copied().ok_or_else(|| {
-                                LocalFactSelectionFailure::MissingNamedNominal(key.clone())
-                            })?;
+                        let declaration = self.index.declaration(&key).ok_or_else(|| {
+                            LocalFactSelectionFailure::MissingNamedNominal(key.clone())
+                        })?;
                         let payload = match declaration.payload {
                             DurableDeclarationPayload::Struct { .. } => {
                                 DurableDeclarationPayload::Struct {
@@ -1622,7 +1683,9 @@ mod tests {
         ];
         let mut selection_body = body();
         selection_body.return_type = rue_air::SemanticImportType::Nominal(record);
-        let (index, _) = LocalFactSelectionIndex::new(&declarations, &[]);
+        let shared = SharedDeclarationFactIndex::new(&declarations);
+        let (index, work) = LocalFactSelectionIndex::new(&shared, &declarations, &[]);
+        assert_eq!(work, LocalFactSelectionIndexWork::default());
         let facts = select_materialization_facts(
             &FunctionInstanceKey::Definition(function.clone()),
             &selection_body,
@@ -1687,7 +1750,8 @@ mod tests {
         let expected_name = format!("anonymous-{:?}", identity.with_canonical_producer());
         assert_eq!(expected_name, format!("anonymous-{identity:?}"));
         assert_eq!(nominal.materialization_name().as_ref(), expected_name);
-        let (index, _) = LocalFactSelectionIndex::new(&[], std::slice::from_ref(&nominal));
+        let shared = SharedDeclarationFactIndex::new(&[]);
+        let (index, _) = LocalFactSelectionIndex::new(&shared, &[], std::slice::from_ref(&nominal));
         let symbols = std::collections::BTreeMap::from([(
             FunctionInstanceKey::Definition(function.clone()),
             Arc::from("probe"),

--- a/crates/rue-compiler/src/revisioned_query_database.rs
+++ b/crates/rue-compiler/src/revisioned_query_database.rs
@@ -2130,6 +2130,8 @@ pub(crate) enum SemanticNucleusBatchFailure {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct SemanticNucleusProjection {
     pub(crate) declarations: Arc<[crate::DurableDeclarationSemantic]>,
+    pub(crate) declaration_index:
+        Arc<crate::local_semantic_materialization::SharedDeclarationFactIndex>,
     pub(crate) anonymous_nominals: Arc<[crate::durable_semantics::DurableAnonymousNominal]>,
     pub(crate) dependencies: Arc<[crate::semantic_query_nucleus::SemanticDeclarationDependency]>,
     pub(crate) c_export_roots: Arc<[crate::StableDefinitionKey]>,
@@ -2633,6 +2635,7 @@ impl RetainedCharge for SemanticNucleusProjection {
     fn retained_charge(&self) -> u64 {
         self.declarations
             .retained_charge()
+            .saturating_add(self.declaration_index.retained_charge())
             .saturating_add(self.anonymous_nominals.retained_charge())
             .saturating_add(self.dependencies.retained_charge())
             .saturating_add(self.c_export_roots.retained_charge())
@@ -3822,7 +3825,8 @@ fn body_source_definition_key(
 fn closure_callable_has_body(
     context: &rue_query::QueryContext,
     body_inputs: &QueryFamily<crate::body_query::BodyQueryKey, crate::body_query::BodyInputValue>,
-    declarations: &BTreeMap<crate::StableDefinitionKey, crate::DurableDeclarationSemantic>,
+    declarations: &[crate::DurableDeclarationSemantic],
+    declaration_index: &crate::local_semantic_materialization::SharedDeclarationFactIndex,
     callable: &crate::FunctionInstanceKey,
     configuration: &crate::semantic_query_nucleus::SemanticQueryConfiguration,
 ) -> Result<Result<bool, Arc<str>>, QueryAbort> {
@@ -3851,7 +3855,7 @@ fn closure_callable_has_body(
     if !matches!(callable, crate::FunctionInstanceKey::Definition(_)) {
         return Ok(Ok(true));
     }
-    let Some(declaration) = declarations.get(&input.owner) else {
+    let Some(declaration) = declaration_index.declaration(declarations, &input.owner) else {
         return Ok(Err(Arc::from(format!(
             "body input owner {:?} has no declaration-semantic projection",
             input.owner
@@ -15471,12 +15475,6 @@ impl RevisionedQueryDatabase {
                             .with_terminal_kind(QueryTerminalKind::Failure));
                         }
                     };
-                    let declaration_payloads = projection
-                        .declarations
-                        .iter()
-                        .cloned()
-                        .map(|declaration| (declaration.key.clone(), declaration))
-                        .collect::<BTreeMap<_, _>>();
                     let present_trusted_modules = key
                         .modules
                         .iter()
@@ -16106,7 +16104,8 @@ impl RevisionedQueryDatabase {
                                     match closure_callable_has_body(
                                         context,
                                         &inputs_for_body_closure,
-                                        &declaration_payloads,
+                                        &projection.declarations,
+                                        &projection.declaration_index,
                                         callable,
                                         &key.configuration,
                                     )? {
@@ -19657,8 +19656,13 @@ impl RevisionedQueryDatabase {
             });
         }
         values.sort_by(|left, right| left.key.cmp(&right.key));
+        let declarations: Arc<[crate::DurableDeclarationSemantic]> = values.into();
+        let declaration_index = Arc::new(
+            crate::local_semantic_materialization::SharedDeclarationFactIndex::new(&declarations),
+        );
         Ok(SemanticNucleusProjection {
-            declarations: values.into(),
+            declarations,
+            declaration_index,
             anonymous_nominals: anonymous_nominals.into_values().collect::<Vec<_>>().into(),
             dependencies: dependencies.into_iter().collect::<Vec<_>>().into(),
             c_export_roots: c_export_roots.into_iter().collect::<Vec<_>>().into(),

--- a/crates/rue-compiler/src/session.rs
+++ b/crates/rue-compiler/src/session.rs
@@ -993,6 +993,7 @@ struct RootedBodyGraph {
     revision: rue_query::Revision,
     configuration: crate::semantic_query_nucleus::SemanticQueryConfiguration,
     declarations: Arc<[crate::DurableDeclarationSemantic]>,
+    declaration_index: Arc<crate::local_semantic_materialization::SharedDeclarationFactIndex>,
     anonymous_nominals: Arc<[crate::durable_semantics::DurableAnonymousNominal]>,
     declaration_dependencies: Arc<[crate::semantic_query_nucleus::SemanticDeclarationDependency]>,
     c_export_roots: Arc<[crate::StableDefinitionKey]>,
@@ -4682,6 +4683,7 @@ impl CompilerSession {
             revision,
             configuration,
             declarations: projection.declarations,
+            declaration_index: projection.declaration_index,
             anonymous_nominals: anonymous.into_values().collect::<Vec<_>>().into(),
             declaration_dependencies: projection.dependencies,
             c_export_roots: projection.c_export_roots,
@@ -4882,6 +4884,7 @@ impl CompilerSession {
                 .entered();
         let (materialization_index, index_work) =
             crate::local_semantic_materialization::LocalFactSelectionIndex::new(
+                &graph.declaration_index,
                 &graph.declarations,
                 &graph.anonymous_nominals,
             );
@@ -8622,9 +8625,13 @@ mod tests {
             cfg_work.functions_considered + cfg_work.drop_glue_functions_synthesized,
             "{cfg_work:?}"
         );
-        assert!(
-            cfg_work.materialization_declarations_scanned > 0,
-            "{cfg_work:?}"
+        assert_eq!(
+            cfg_work.materialization_declarations_scanned, 0,
+            "CFG selection reuses the semantic projection's declaration index: {cfg_work:?}"
+        );
+        assert_eq!(
+            cfg_work.materialization_type_nodes_scanned, 0,
+            "CFG selection reuses the semantic projection's destructor index: {cfg_work:?}"
         );
         assert_eq!(
             cfg_work.retained_interner_charge_scans, 0,


### PR DESCRIPTION
## Summary

- build one immutable declaration/destructor lookup index with the semantic projection
- reuse that index for reachability and CFG fact selection
- preserve exact body-local CFG memo keys and incremental invalidation boundaries

## Evidence

- `scripts/rue quick`
- `scripts/rue spec 4.14` (203/203)
- CFG materialization declaration scans: nonzero -> 0
- CFG materialization type-node scans: nonzero -> 0

Refs RUE-1473.