### PR TITLE
RUE-1473: compact body-local anonymous symbols

### DIFF
--- a/crates/rue-air/src/semantic_import.rs
+++ b/crates/rue-air/src/semantic_import.rs
@@ -1404,6 +1404,7 @@ where
         );
         let mut local_identities = std::collections::BTreeSet::new();
         for nominal in &nominals {
+            let is_anonymous = matches!(&nominal.key, NominalInstanceKey::Anonymous(_));
             let builtin_key = match &nominal.key {
                 NominalInstanceKey::Builtin { kind, name } => Some((
                     name.clone(),
@@ -1448,6 +1449,9 @@ where
                     if let Some(lang_item) = nominal.lang_item {
                         epoch.type_pool.set_struct_lang_item(id, lang_item);
                     }
+                    if is_anonymous {
+                        epoch.type_pool.mark_anonymous_struct(id);
+                    }
                     LocalNominal::Struct(id)
                 }
                 SemanticImportNominalKind::Enum => {
@@ -1464,6 +1468,9 @@ where
                             file_id,
                         },
                     );
+                    if is_anonymous {
+                        epoch.type_pool.mark_anonymous_enum(id);
+                    }
                     LocalNominal::Enum(id)
                 }
             };
@@ -3452,6 +3459,17 @@ mod tests {
         )
         .unwrap();
         assert!(output.aggregate_types.values().any(|ty| ty == &owner_type));
+        let local = output
+            .aggregate_types
+            .iter()
+            .find_map(|(local, stable)| (stable == &owner_type).then_some(*local))
+            .unwrap();
+        let struct_id = local.as_struct().unwrap();
+        assert!(output.type_pool.is_anonymous_struct(struct_id));
+        assert_eq!(
+            output.type_pool.struct_symbol_name(struct_id),
+            "anonymous-record"
+        );
     }
 
     #[test]

--- a/crates/rue-compiler/src/durable_semantics.rs
+++ b/crates/rue-compiler/src/durable_semantics.rs
@@ -47,12 +47,10 @@ fn builtin_nominal_kind(name: &str) -> Option<SemanticImportNominalKind> {
 #[derive(Debug, Clone)]
 pub struct DurableAnonymousNominal {
     pub identity: crate::AnonymousNominalKey,
-    /// Exact body-local type-pool name derived once with the durable fact.
-    ///
-    /// This deliberately preserves the historical full-identity Debug
-    /// spelling. It is not the canonical source symbol and therefore does not
-    /// participate in the RUE-1295 spelling decision.
-    materialization_name: Arc<str>,
+    /// Canonical compact symbol spelling derived once with the durable fact.
+    /// The structured identity remains the semantic authority; this cache only
+    /// avoids repeatedly rendering and hashing it in body-local type pools.
+    source_symbol: Arc<str>,
     pub shape: DurableAnonymousNominalShape,
     pub type_captures: Arc<[(Arc<str>, DurableType)]>,
     pub value_captures: Arc<[(Arc<str>, DurableConstValue)]>,
@@ -81,13 +79,12 @@ impl DurableAnonymousNominal {
         type_captures: Arc<[(Arc<str>, DurableType)]>,
         value_captures: Arc<[(Arc<str>, DurableConstValue)]>,
     ) -> Self {
-        let materialization_name = Arc::from(format!(
-            "anonymous-{:?}",
-            identity.with_canonical_producer()
+        let source_symbol = Arc::from(crate::semantic_identity::anonymous_nominal_source_symbol(
+            &identity,
         ));
         Self {
             identity,
-            materialization_name,
+            source_symbol,
             shape,
             type_captures,
             value_captures,
@@ -97,19 +94,19 @@ impl DurableAnonymousNominal {
     pub(crate) fn with_shape(&self, shape: DurableAnonymousNominalShape) -> Self {
         Self {
             identity: self.identity.clone(),
-            materialization_name: self.materialization_name.clone(),
+            source_symbol: self.source_symbol.clone(),
             shape,
             type_captures: self.type_captures.clone(),
             value_captures: self.value_captures.clone(),
         }
     }
 
-    pub(crate) fn materialization_name(&self) -> &Arc<str> {
-        &self.materialization_name
+    pub(crate) fn source_symbol(&self) -> &Arc<str> {
+        &self.source_symbol
     }
 }
 
-// The carried name is a cache derived entirely from `identity`, not a new part
+// The carried symbol is a cache derived entirely from `identity`, not a new part
 // of the durable fact's semantic identity. Keep equality, ordering, and hashing
 // identical to the pre-cache representation so query keys do not hash the
 // formatted name or invalidate merely because the cache representation changes.
@@ -231,7 +228,7 @@ impl RetainedCharge for DurableAnonymousNominal {
     fn retained_charge(&self) -> u64 {
         self.identity
             .retained_charge()
-            .saturating_add(self.materialization_name.retained_charge())
+            .saturating_add(self.source_symbol.retained_charge())
             .saturating_add(self.shape.retained_charge())
             .saturating_add(self.type_captures.retained_charge())
             .saturating_add(self.value_captures.retained_charge())

--- a/crates/rue-compiler/src/local_semantic_materialization.rs
+++ b/crates/rue-compiler/src/local_semantic_materialization.rs
@@ -802,7 +802,7 @@ pub(crate) fn materialize_semantic_body(
         rue_air::SemanticLocalNominal {
             key: rue_air::NominalInstanceKey::Anonymous(nominal.identity.clone()),
             module_path: Arc::from("<anonymous>"),
-            name: nominal.materialization_name().clone(),
+            name: nominal.source_symbol().clone(),
             kind,
             is_public: false,
             lang_item: None,
@@ -1724,7 +1724,7 @@ mod tests {
     }
 
     #[test]
-    fn anonymous_fact_selection_preserves_the_carried_materialization_name() {
+    fn anonymous_fact_selection_preserves_the_carried_source_symbol() {
         use rue_rir::{RirStructuralAnchor, RirStructuralPathSegment};
 
         let module = ModuleId::from_validated_canonical("main.rue");
@@ -1747,9 +1747,8 @@ mod tests {
             Arc::from([]),
             Arc::from([]),
         );
-        let expected_name = format!("anonymous-{:?}", identity.with_canonical_producer());
-        assert_eq!(expected_name, format!("anonymous-{identity:?}"));
-        assert_eq!(nominal.materialization_name().as_ref(), expected_name);
+        let expected_symbol = crate::semantic_identity::anonymous_nominal_source_symbol(&identity);
+        assert_eq!(nominal.source_symbol().as_ref(), expected_symbol);
         let shared = SharedDeclarationFactIndex::new(&[]);
         let (index, _) = LocalFactSelectionIndex::new(&shared, &[], std::slice::from_ref(&nominal));
         let symbols = std::collections::BTreeMap::from([(
@@ -1776,12 +1775,12 @@ mod tests {
         )));
 
         assert!(Arc::ptr_eq(
-            nominal.materialization_name(),
-            full.anonymous_nominals[0].materialization_name()
+            nominal.source_symbol(),
+            full.anonymous_nominals[0].source_symbol()
         ));
         assert!(Arc::ptr_eq(
-            nominal.materialization_name(),
-            opaque.anonymous_nominals[0].materialization_name()
+            nominal.source_symbol(),
+            opaque.anonymous_nominals[0].source_symbol()
         ));
         assert!(matches!(
             &opaque.anonymous_nominals[0].shape,


### PR DESCRIPTION
Refs RUE-1473.

Body-local semantic epochs currently intern full Debug renderings of canonical anonymous identities. On Lattice, 15,139 selected anonymous nominals become strings hundreds of bytes long, recursively repeating modules, producers, anchors, and specialization arguments in each local epoch.

Use the existing canonical compact anonymous source symbol instead. Mark imported anonymous nominals in the local type pool so the structured anonymous identity and compact spelling remain one representation rather than a qualified compatibility twin. The structured key remains the semantic authority and query equality/hash behavior is unchanged.

Exact one-worker Lattice evidence:
- local interner entries unchanged: 41,882
- local interner UTF-8 bytes: 10,887,143 -> 1,507,142 (-9,380,001; -86.2%)
- all other local-domain counters unchanged
- x86-64 Linux output unchanged: 1,413,120 bytes, SHA-256 b893e76cfabed737b149d0e8c4d8527077dedd17da78418db20a28a7d30885e5

Validation:
- focused AIR anonymous-registration regression passed
- focused distinct-producer symbol acceptance test passed
- scripts/rue quick: 31/31 passed (compiler 848 passed, 6 ignored)

No new shared state, lock, query boundary, scheduling dependency, or invalidation widening is introduced.