### PR TITLE
RUE-1486: name a stored performance record by its own bytes

### DIFF
--- a/crates/rue-bench/src/derive.rs
+++ b/crates/rue-bench/src/derive.rs
@@ -20,8 +20,8 @@ use std::collections::{BTreeMap, BTreeSet};
 use std::path::Path;
 
 use rue_perf_schema::{
-    Band, Completeness, Manifest, Metric, RunObject, Summary, flags_movement, geometric_mean,
-    median_absolute_deviation, ratio, sample_value, validate_run,
+    Band, Completeness, Manifest, Metric, RunObject, StoredRun, Summary, flags_movement,
+    geometric_mean, median_absolute_deviation, ratio, sample_value, validate_run,
 };
 use serde::Serialize;
 
@@ -200,7 +200,12 @@ pub struct WorkloadPoint {
 }
 
 /// Load every run object referenced by an index.
-pub fn load_data_branch(data_root: &Path) -> Result<Vec<RunObject>, String> {
+///
+/// Each record keeps the name it was published under. Deriving that name here
+/// instead would name records as this build of the schema would have written
+/// them, which is a different name for every record written before the schema's
+/// newest field — including whichever record a manifest baseline pins.
+pub fn load_data_branch(data_root: &Path) -> Result<Vec<StoredRun>, String> {
     let runs_dir = data_root.join("runs");
     if !runs_dir.is_dir() {
         // An empty data branch is the normal first state, not an error. The
@@ -219,15 +224,15 @@ pub fn load_data_branch(data_root: &Path) -> Result<Vec<RunObject>, String> {
         }
         let text = std::fs::read_to_string(&path)
             .map_err(|error| format!("could not read {}: {error}", path.display()))?;
-        let run: RunObject = serde_json::from_str(&text)
+        let stored = StoredRun::read(&text)
             .map_err(|error| format!("could not parse {}: {error}", path.display()))?;
-        runs.push(run);
+        runs.push(stored);
     }
     Ok(runs)
 }
 
 /// Derive the dashboard's view of a set of runs.
-pub fn derive(manifest: &Manifest, runs: &[RunObject]) -> SiteData {
+pub fn derive(manifest: &Manifest, runs: &[StoredRun]) -> SiteData {
     let bands = Band::all()
         .into_iter()
         .map(|band| band.wire_name().to_string())
@@ -249,15 +254,13 @@ pub fn derive(manifest: &Manifest, runs: &[RunObject]) -> SiteData {
     let mut rejected = Vec::new();
     // Group appendable runs by (platform, epoch). An unappendable run is
     // counted as evidence but never enters a series.
-    let mut grouped: BTreeMap<(String, u32), Vec<&RunObject>> = BTreeMap::new();
-    for run in runs {
+    let mut grouped: BTreeMap<(String, u32), Vec<&StoredRun>> = BTreeMap::new();
+    for stored in runs {
+        let run = stored.run();
         let outcome = validate_run(manifest, run);
-        let address = run
-            .content_address()
-            .unwrap_or_else(|_| "<unaddressable>".to_string());
         if !outcome.is_appendable() {
             rejected.push(RejectedRun {
-                run: address,
+                run: stored.address().to_string(),
                 platform: run.identity.platform.clone(),
                 epoch: run.identity.epoch,
                 commit: run.identity.commit.clone(),
@@ -268,17 +271,18 @@ pub fn derive(manifest: &Manifest, runs: &[RunObject]) -> SiteData {
         grouped
             .entry((run.identity.platform.clone(), run.identity.epoch))
             .or_default()
-            .push(run);
+            .push(stored);
     }
 
     let mut platforms: BTreeMap<String, Vec<EpochData>> = BTreeMap::new();
     for ((platform, epoch_id), mut epoch_runs) in grouped {
         // Measurement order, so the trailing window means what it says.
         epoch_runs.sort_by(|left, right| {
-            left.identity
+            left.run()
+                .identity
                 .finished_at
-                .cmp(&right.identity.finished_at)
-                .then_with(|| left.identity.commit.cmp(&right.identity.commit))
+                .cmp(&right.run().identity.finished_at)
+                .then_with(|| left.run().identity.commit.cmp(&right.run().identity.commit))
         });
         let Some(epoch) = manifest.epoch(&platform, epoch_id) else {
             continue;
@@ -311,18 +315,18 @@ fn derive_epoch(
     manifest: &Manifest,
     epoch: &rue_perf_schema::PlatformEpoch,
     suite: &rue_perf_schema::SuiteRevision,
-    runs: &[&RunObject],
+    runs: &[&StoredRun],
 ) -> EpochData {
     // The baseline is the run the epoch names, not "the first one we have":
-    // an attempted or partial run must never define ratio 1.0.
-    let baseline_run = epoch.baseline.as_ref().and_then(|baseline| {
-        runs.iter().find(|run| {
-            run.content_address()
-                .map(|address| address == baseline.run)
-                .unwrap_or(false)
-        })
-    });
-    let baseline_medians = baseline_run.map(|run| workload_medians(run, suite));
+    // an attempted or partial run must never define ratio 1.0. Matched on the
+    // name each record was published under, which is the name the manifest
+    // pins; a name re-derived from the parsed record would drift out from under
+    // the pin every time the schema gained a field.
+    let baseline_run = epoch
+        .baseline
+        .as_ref()
+        .and_then(|baseline| runs.iter().find(|stored| stored.address() == baseline.run));
+    let baseline_medians = baseline_run.map(|stored| workload_medians(stored.run(), suite));
 
     let mut points: Vec<PointData> = Vec::new();
     let mut environment_annotations = Vec::new();
@@ -334,11 +338,10 @@ fn derive_epoch(
     // over the *medians* of prior runs, matching the flagging rule's definition.
     let mut history: BTreeMap<String, Vec<Summary>> = BTreeMap::new();
 
-    for run in runs {
+    for stored in runs {
+        let run = stored.run();
         let outcome = validate_run(manifest, run);
-        let address = run
-            .content_address()
-            .unwrap_or_else(|_| "<unaddressable>".to_string());
+        let address = stored.address().to_string();
         let fingerprint = run
             .identity
             .environment
@@ -780,6 +783,19 @@ window = 3
         }
     }
 
+    /// Records as they would arrive from storage.
+    ///
+    /// Through `StoredRun::read` rather than `minted`, so a fixture is named the
+    /// way the data branch names one: by its published bytes.
+    fn stored(runs: impl IntoIterator<Item = RunObject>) -> Vec<StoredRun> {
+        runs.into_iter()
+            .map(|run| {
+                let text = rue_perf_schema::canonical_json(&run).expect("addressable");
+                StoredRun::read(&text).expect("readable")
+            })
+            .collect()
+    }
+
     fn manifest_with_baseline(runs: &[RunObject]) -> Manifest {
         let address = runs[0].content_address().expect("addressable");
         let commit = runs[0].identity.commit.clone();
@@ -805,7 +821,7 @@ window = 3
         let manifest = Manifest::parse(MANIFEST).unwrap();
         let mut run = run_at("a", "2026-07-28T00:00:00Z", [100, 101, 102]);
         run.identity.pins.toolchain_hash = "drifted".to_string();
-        let data = derive(&manifest, &[run]);
+        let data = derive(&manifest, &stored([run]));
 
         assert!(
             data.platforms.is_empty(),
@@ -825,7 +841,7 @@ window = 3
         let base = run_at("a", "2026-07-28T00:00:00Z", [100, 100, 100]);
         let manifest = manifest_with_baseline(std::slice::from_ref(&base));
         let later = run_at("b", "2026-07-28T01:00:00Z", [110, 110, 110]);
-        let data = derive(&manifest, &[base, later]);
+        let data = derive(&manifest, &stored([base, later]));
 
         let points = &data.platforms[0].epochs[0].points;
         assert_eq!(points.len(), 2);
@@ -842,13 +858,69 @@ window = 3
     }
 
     #[test]
+    fn a_baseline_still_resolves_after_the_record_schema_moves_on() {
+        // RUE-1486. Record fields are additive, so a stored record acquires a
+        // zero-valued field the moment the compiler gains a phase to count. If
+        // the baseline is matched on a name re-derived from the parsed record,
+        // that addition silently unnames the record the manifest pins: the
+        // epoch keeps collecting, every point loses its ratio, and the headline
+        // index disappears with no rejected run and no failed workflow.
+        //
+        // Epoch 5 lost its index this way within hours of declaring a baseline.
+        let base = run_at("a", "2026-07-28T00:00:00Z", [100, 100, 100]);
+        let published = rue_perf_schema::canonical_json(&base).expect("addressable");
+
+        // The record as an older writer stored it, carrying a field this build
+        // of the schema does not write.
+        let mut value: serde_json::Value = serde_json::from_str(&published).unwrap();
+        value["workloads"][0]["samples"][0]
+            .as_object_mut()
+            .unwrap()
+            .insert("boundary_evidence".to_string(), serde_json::json!([]));
+        let as_written = rue_perf_schema::canonical_json(&value).expect("addressable");
+        let stored_base = StoredRun::read(&as_written).expect("readable");
+        assert_ne!(
+            stored_base.address(),
+            stored_base.run().content_address().unwrap(),
+            "the fixture must be a record that does not round-trip"
+        );
+
+        // The manifest pins the name the record was published under, which is
+        // the only name anything else could have written down.
+        let published_address = stored_base.address().to_string();
+        let text = format!(
+            "{MANIFEST}\n[epoch.baseline]\ncommit = \"{}\"\nrun = \"{published_address}\"\n",
+            base.identity.commit,
+        );
+        let manifest = Manifest::parse(&text).expect("fixture manifest");
+
+        let later = run_at("b", "2026-07-28T01:00:00Z", [110, 110, 110]);
+        let mut runs = vec![stored_base];
+        runs.extend(stored([later]));
+        let data = derive(&manifest, &runs);
+
+        let epoch = &data.platforms[0].epochs[0];
+        assert_eq!(epoch.points[0].workloads["startup"].ratio, Some(1.0));
+        assert_eq!(epoch.points[1].workloads["startup"].ratio, Some(1.1));
+        let index = epoch.points[1]
+            .index
+            .as_ref()
+            .expect("the epoch's headline index survives a schema addition");
+        assert!((index["latency"] - 1.1).abs() < 1e-9, "{index:?}");
+
+        // The plotted point names the record as stored, so a reader following
+        // it from the page reaches the file that is actually on the branch.
+        assert_eq!(epoch.points[0].run, published_address);
+    }
+
+    #[test]
     fn a_partial_run_publishes_its_workloads_but_no_headline_point() {
         let base = run_at("a", "2026-07-28T00:00:00Z", [100, 100, 100]);
         let manifest = manifest_with_baseline(std::slice::from_ref(&base));
         let mut partial = run_at("b", "2026-07-28T01:00:00Z", [110, 110, 110]);
         // One sample short of the policy: a partial run, still appendable.
         partial.workloads[0].samples.truncate(2);
-        let data = derive(&manifest, &[base, partial]);
+        let data = derive(&manifest, &stored([base, partial]));
 
         let point = &data.platforms[0].epochs[0].points[1];
         assert!(!point.complete);
@@ -875,7 +947,7 @@ window = 3
             run_at("c", "2026-07-28T02:00:00Z", [100, 100, 100]),
             run_at("d", "2026-07-28T03:00:00Z", [100, 100, 100]),
         ];
-        let data = derive(&manifest, &runs);
+        let data = derive(&manifest, &stored(runs));
         let points = &data.platforms[0].epochs[0].points;
 
         // window = 3, so the first three have no full window behind them.
@@ -905,7 +977,7 @@ window = 3
         // reader has no way to check.
         let base = run_at("a", "2026-07-28T00:00:00Z", [100, 100, 100]);
         let manifest = manifest_with_baseline(std::slice::from_ref(&base));
-        let data = derive(&manifest, &[base]);
+        let data = derive(&manifest, &stored([base]));
         let flagging = &data.platforms[0].epochs[0].flagging;
         assert_eq!(flagging.window, 3);
         assert!((flagging.k - 2.0).abs() < f64::EPSILON);
@@ -923,7 +995,7 @@ window = 3
         let manifest = Manifest::parse(&text).expect("target manifest");
         let data = derive(
             &manifest,
-            &[run_at("a", "2026-07-28T00:00:00Z", [100, 100, 100])],
+            &stored([run_at("a", "2026-07-28T00:00:00Z", [100, 100, 100])]),
         );
         let targets = &data.platforms[0].epochs[0].process_elapsed_targets;
         assert_eq!(targets.len(), 1);
@@ -948,7 +1020,7 @@ window = 3
             base.identity.commit
         );
         let manifest = Manifest::parse(&text).expect("ratcheted manifest");
-        let data = derive(&manifest, &[base]);
+        let data = derive(&manifest, &stored([base]));
         let ratchets = &data.platforms[0].epochs[0].process_elapsed_ratchets;
         assert_eq!(ratchets.len(), 1);
         assert_eq!(ratchets["startup"].baseline_process_elapsed_ns, 101_000_000);
@@ -969,7 +1041,7 @@ window = 3
         for batch in [1u32, 2, 5] {
             let manifest = manifest_for_batch(batch);
             let run = run_at_batched("a", "2026-07-28T00:00:00Z", [100, 130, 170], batch);
-            let data = derive(&manifest, &[run]);
+            let data = derive(&manifest, &stored([run]));
             let point = &data.platforms[0].epochs[0].points[0].workloads["startup"];
             let summed: u64 = point.bands_ns.values().sum();
             assert_eq!(
@@ -987,21 +1059,21 @@ window = 3
         // page shows a total the median contradicts.
         let unbatched = derive(
             &manifest_for_batch(1),
-            &[run_at_batched(
+            &stored([run_at_batched(
                 "a",
                 "2026-07-28T00:00:00Z",
                 [100, 100, 100],
                 1,
-            )],
+            )]),
         );
         let batched = derive(
             &manifest_for_batch(4),
-            &[run_at_batched(
+            &stored([run_at_batched(
                 "a",
                 "2026-07-28T00:00:00Z",
                 [100, 100, 100],
                 4,
-            )],
+            )]),
         );
         let one = &unbatched.platforms[0].epochs[0].points[0].workloads["startup"];
         let four = &batched.platforms[0].epochs[0].points[0].workloads["startup"];
@@ -1017,7 +1089,7 @@ window = 3
         let manifest = Manifest::parse(MANIFEST).unwrap();
         let data = derive(
             &manifest,
-            &[run_at("a", "2026-07-28T00:00:00Z", [100, 100, 100])],
+            &stored([run_at("a", "2026-07-28T00:00:00Z", [100, 100, 100])]),
         );
         let point = &data.platforms[0].epochs[0].points[0].workloads["startup"];
         assert_eq!(point.driver_overhead_ns, 1_000_000);
@@ -1032,7 +1104,7 @@ window = 3
         let mut second = run_at("b", "2026-07-28T01:00:00Z", [100, 100, 100]);
         second.identity.environment = fingerprint("Intel Xeon Platinum 8370C");
 
-        let data = derive(&manifest, &[first, second]);
+        let data = derive(&manifest, &stored([first, second]));
         let annotations = &data.platforms[0].epochs[0].environment_annotations;
         assert_eq!(annotations.len(), 1);
         assert!(
@@ -1051,7 +1123,7 @@ window = 3
         let mut second = run_at("b", "2026-07-28T01:00:00Z", [110, 110, 110]);
         second.identity.pins.stdlib_hash = "a-new-standard-library".to_string();
 
-        let data = derive(&manifest, &[first, second]);
+        let data = derive(&manifest, &stored([first, second]));
 
         assert!(data.rejected.is_empty(), "{:?}", data.rejected);
         let epoch = &data.platforms[0].epochs[0];
@@ -1075,10 +1147,10 @@ window = 3
         let manifest = Manifest::parse(MANIFEST).unwrap();
         let data = derive(
             &manifest,
-            &[
+            &stored([
                 run_at("a", "2026-07-28T00:00:00Z", [100, 100, 100]),
                 run_at("b", "2026-07-28T01:00:00Z", [100, 100, 100]),
-            ],
+            ]),
         );
         assert!(
             data.platforms[0].epochs[0].stdlib_annotations.is_empty(),
@@ -1092,7 +1164,7 @@ window = 3
         let manifest = Manifest::parse(MANIFEST).unwrap();
         let late = run_at("b", "2026-07-28T05:00:00Z", [100, 100, 100]);
         let early = run_at("a", "2026-07-28T01:00:00Z", [100, 100, 100]);
-        let data = derive(&manifest, &[late, early]);
+        let data = derive(&manifest, &stored([late, early]));
         let points = &data.platforms[0].epochs[0].points;
         assert!(points[0].finished_at < points[1].finished_at);
     }
@@ -1110,7 +1182,7 @@ window = 3
                 compiler_root_ns: 100,
                 attributed_ns: 600,
             });
-        let data = derive(&manifest, &[run]);
+        let data = derive(&manifest, &stored([run]));
         let point = &data.platforms[0].epochs[0].points[0].workloads["startup"];
         // The surviving two samples are both 100; a median including the
         // invalid one would still be 100, so assert on the band totals instead,

--- a/crates/rue-perf-schema/src/lib.rs
+++ b/crates/rue-perf-schema/src/lib.rs
@@ -23,7 +23,10 @@
 //! **Storage is raw only.** A [`RunObject`] holds complete raw samples in
 //! integer nanoseconds plus structured evidence of whatever failed. Medians,
 //! dispersion, indexes, and chart data are derived by consumers and never
-//! stored. [`content_address`] gives a run object its immutable name.
+//! stored. [`content_address`] gives a run object its immutable name, and a
+//! record read back from storage carries that name with it in a [`StoredRun`]:
+//! record fields are additive, so re-deriving a stored record's name from
+//! today's schema would rename every record written before the newest field.
 //!
 //! **Failure is evidence.** A run is stored whatever happened. Appendability
 //! errors ([`ValidationError`]) reject a run outright; per-sample invalidity
@@ -39,6 +42,7 @@ mod run;
 mod scaling;
 mod series;
 mod stats;
+mod stored;
 mod validate;
 
 pub use boundary::{
@@ -79,6 +83,7 @@ pub use stats::{
     Summary, flags_movement, geometric_mean, median, median_absolute_deviation, pooled_uncertainty,
     ratio, sample_value,
 };
+pub use stored::{StoredRun, StoredRunError};
 pub use validate::{
     Completeness, InvalidSample, InvalidSampleReason, ProcessElapsedRegression, ValidationError,
     ValidationOutcome, process_elapsed_regressions, validate_run,

--- a/crates/rue-perf-schema/src/stored.rs
+++ b/crates/rue-perf-schema/src/stored.rs
@@ -1,0 +1,284 @@
+//! Stored run objects: the name a record already carries.
+//!
+//! A run object's name is the content address of the bytes it was published as,
+//! which is what makes a stored record verifiable against its own name without
+//! trusting whoever wrote it. Recomputing that name by re-serializing a parsed
+//! [`RunObject`] is a different function: it names the record as *this* build of
+//! the schema would have written it, not as it was written.
+//!
+//! The two agree only while the schema struct is byte-identical to the one the
+//! record was written under, and record fields are deliberately additive —
+//! boundary evidence gains phase counters as the compiler gains phases, each
+//! `#[serde(default)]` so older records stay readable. Every such field renames
+//! every record written before it: the parse fills the field with a zero the
+//! stored bytes never contained, and the re-serialized form carries it.
+//!
+//! That silently unnames pinned records. A manifest baseline names a run by the
+//! address it was published under, so a renamed baseline stops resolving, its
+//! epoch loses every workload ratio, and the headline index disappears from an
+//! epoch that is otherwise collecting normally — with no rejected run, no failed
+//! workflow, and nothing to see but an absence.
+//!
+//! So a reader takes the address from the record and never from the struct.
+
+use serde::Deserialize;
+
+use crate::CanonicalError;
+use crate::run::RunObject;
+
+/// Why a stored run object could not be read.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum StoredRunError {
+    /// The stored bytes are not JSON, or not a run object.
+    Malformed {
+        /// The underlying parse error, rendered.
+        detail: String,
+    },
+    /// The stored value has no canonical form, so it has no name.
+    ///
+    /// In practice a floating-point number, which raw records never contain:
+    /// integer nanoseconds and integer bytes are what keep a record's name
+    /// independent of how a writer formats a decimal.
+    Unaddressable(CanonicalError),
+}
+
+impl std::fmt::Display for StoredRunError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            StoredRunError::Malformed { detail } => {
+                write!(f, "not a well-formed run object: {detail}")
+            }
+            StoredRunError::Unaddressable(error) => {
+                write!(f, "stored run object cannot be addressed: {error}")
+            }
+        }
+    }
+}
+
+impl std::error::Error for StoredRunError {}
+
+/// A run object together with the immutable name it carries.
+///
+/// Consumers that resolve a record by name — the dashboard's derivation
+/// matching a manifest baseline, anything linking a plotted point back to its
+/// raw record — must use [`StoredRun::address`] rather than
+/// [`RunObject::content_address`], which names a value about to be written.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct StoredRun {
+    address: String,
+    run: RunObject,
+}
+
+impl StoredRun {
+    /// Read a published record, taking its name from the record itself.
+    ///
+    /// The name is the address of the stored value's canonical form, which is
+    /// the digest the publisher stored it under: it never depends on the fields
+    /// this build of the schema happens to know about.
+    pub fn read(text: &str) -> Result<StoredRun, StoredRunError> {
+        let value: serde_json::Value =
+            serde_json::from_str(text).map_err(|error| StoredRunError::Malformed {
+                detail: error.to_string(),
+            })?;
+        let address = crate::content_address(&value).map_err(StoredRunError::Unaddressable)?;
+        // Deserialized from the value that was addressed, so the typed view and
+        // the name describe the same bytes.
+        let run = RunObject::deserialize(&value).map_err(|error| StoredRunError::Malformed {
+            detail: error.to_string(),
+        })?;
+        Ok(StoredRun { address, run })
+    }
+
+    /// Name a record this process just built.
+    ///
+    /// Correct only because nothing has been stored yet: the canonical form
+    /// being addressed is the one that will be written. A record read back from
+    /// storage takes its name from [`StoredRun::read`] instead.
+    pub fn minted(run: RunObject) -> Result<StoredRun, CanonicalError> {
+        let address = run.content_address()?;
+        Ok(StoredRun { address, run })
+    }
+
+    /// The record's immutable name.
+    pub fn address(&self) -> &str {
+        &self.address
+    }
+
+    /// The record.
+    pub fn run(&self) -> &RunObject {
+        &self.run
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::RUN_SCHEMA_VERSION;
+    use crate::run::{
+        Band, EnvironmentFingerprint, Invocation, Phase, PhaseAccounting, ResolvedPins,
+        RunIdentity, Sample, WorkloadObservation,
+    };
+    use std::collections::BTreeMap;
+
+    fn sample_run() -> RunObject {
+        let mut phase_ns: BTreeMap<Phase, u64> =
+            Phase::ALL.into_iter().map(|phase| (phase, 0)).collect();
+        phase_ns.insert(Phase::SourceDiscoveryAndParsing, 900_000);
+        RunObject {
+            schema_version: RUN_SCHEMA_VERSION,
+            identity: RunIdentity {
+                suite_revision: 1,
+                epoch: 1,
+                platform: "x86_64-linux".to_string(),
+                commit: "a".repeat(40),
+                started_at: "2026-07-28T00:00:00Z".to_string(),
+                finished_at: "2026-07-28T00:00:30Z".to_string(),
+                pins: ResolvedPins {
+                    toolchain_hash: "toolchain".to_string(),
+                    stdlib_hash: "stdlib".to_string(),
+                    workload_source_hashes: BTreeMap::from([(
+                        "startup".to_string(),
+                        "startup-hash".to_string(),
+                    )]),
+                    invocation: Invocation {
+                        target: "x86_64-unknown-linux-gnu".to_string(),
+                        args: Vec::new(),
+                    },
+                },
+                environment: EnvironmentFingerprint {
+                    runner_label: "github-hosted".to_string(),
+                    runner_image: "ubuntu-24.04".to_string(),
+                    runner_image_version: "20260720.1".to_string(),
+                    cpu_model: "AMD EPYC 7763".to_string(),
+                    core_count: 4,
+                    memory_bytes: 16 * 1024 * 1024 * 1024,
+                    kernel_version: "6.8.0".to_string(),
+                    os_version: "Ubuntu 24.04".to_string(),
+                    architecture: "x86_64".to_string(),
+                },
+            },
+            workloads: vec![WorkloadObservation {
+                workload: "startup".to_string(),
+                samples: vec![Sample {
+                    batch_size: 1,
+                    process_elapsed_ns: 2_000_000,
+                    peak_memory_bytes: 32 * 1024 * 1024,
+                    output_binary_bytes: 12_288,
+                    phases: PhaseAccounting {
+                        phase_ns,
+                        mixed_parallel_ns: 0,
+                        unattributed_ns: 100_000,
+                        compiler_root_ns: 1_000_000,
+                    },
+                    boundary_evidence: Vec::new(),
+                }],
+            }],
+            failures: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn a_stored_record_is_named_by_the_bytes_it_was_published_as() {
+        let run = sample_run();
+        let text = crate::canonical_json(&run).expect("addressable");
+        let stored = StoredRun::read(&text).expect("readable");
+        assert_eq!(stored.address(), run.content_address().unwrap());
+        assert_eq!(stored.run(), &run);
+    }
+
+    #[test]
+    fn a_schema_change_does_not_rename_an_existing_record() {
+        // The defect this type exists to prevent. A record's fields are
+        // additive: every `#[serde(default)]` field added to boundary evidence
+        // parses into records written before it existed, so re-serializing one
+        // yields bytes — and therefore a name — the record never had.
+        //
+        // Written here as the same drift in its cheapest form: stored bytes
+        // carrying a field the current writer omits. Either direction renames
+        // the record, and a renamed record is one a manifest baseline can no
+        // longer find.
+        let run = sample_run();
+        let published = crate::canonical_json(&run).expect("addressable");
+        let mut value: serde_json::Value = serde_json::from_str(&published).unwrap();
+        value["workloads"][0]["samples"][0]
+            .as_object_mut()
+            .unwrap()
+            .insert("boundary_evidence".to_string(), serde_json::json!([]));
+        let as_written = crate::canonical_json(&value).expect("addressable");
+        assert_ne!(as_written, published, "the fixture must actually differ");
+
+        let stored = StoredRun::read(&as_written).expect("readable");
+        assert_eq!(
+            stored.address(),
+            crate::content_address(&value).unwrap(),
+            "the name must be the record's own, not this schema's rendering of it"
+        );
+        assert_ne!(
+            stored.address(),
+            stored.run().content_address().unwrap(),
+            "re-serializing the parsed record is what renames it"
+        );
+    }
+
+    #[test]
+    fn insignificant_whitespace_does_not_change_a_record_name() {
+        // The publisher refuses non-canonical bytes, so this cannot arrive from
+        // the data branch; a record handed over some other way still resolves
+        // by the name its value has.
+        let run = sample_run();
+        let canonical = crate::canonical_json(&run).expect("addressable");
+        let pretty = serde_json::to_string_pretty(&run).unwrap();
+        assert_eq!(
+            StoredRun::read(&canonical).unwrap().address(),
+            StoredRun::read(&pretty).unwrap().address()
+        );
+    }
+
+    #[test]
+    fn changing_a_measurement_changes_the_stored_name() {
+        let run = sample_run();
+        let mut altered = run.clone();
+        altered.workloads[0].samples[0].phases.compiler_root_ns += 1;
+        altered.workloads[0].samples[0]
+            .phases
+            .phase_ns
+            .insert(Phase::SourceDiscoveryAndParsing, 900_001);
+        assert_eq!(
+            altered.workloads[0].samples[0].phases.attributed_ns(),
+            altered.workloads[0].samples[0].phases.compiler_root_ns
+        );
+        let one = StoredRun::read(&crate::canonical_json(&run).unwrap()).unwrap();
+        let two = StoredRun::read(&crate::canonical_json(&altered).unwrap()).unwrap();
+        assert_ne!(one.address(), two.address());
+        // The band the sample moved is the one the reader sees move.
+        assert_eq!(
+            two.run().workloads[0].samples[0]
+                .phases
+                .band_ns(Band::Phase(Phase::SourceDiscoveryAndParsing)),
+            900_001
+        );
+    }
+
+    #[test]
+    fn a_minted_record_carries_the_name_it_will_be_written_under() {
+        let run = sample_run();
+        let minted = StoredRun::minted(run.clone()).expect("addressable");
+        let published = crate::canonical_json(&run).expect("addressable");
+        assert_eq!(
+            minted.address(),
+            StoredRun::read(&published).unwrap().address()
+        );
+    }
+
+    #[test]
+    fn a_malformed_record_is_reported_rather_than_guessed_at() {
+        assert!(matches!(
+            StoredRun::read("{"),
+            Err(StoredRunError::Malformed { .. })
+        ));
+        assert!(matches!(
+            StoredRun::read(r#"{"schema_version":1}"#),
+            Err(StoredRunError::Malformed { .. })
+        ));
+    }
+}

--- a/docs/designs/0067-compiler-performance-measurement.md
+++ b/docs/designs/0067-compiler-performance-measurement.md
@@ -339,7 +339,12 @@ partial-run failure records), full identity (suite revision, epoch, platform,
 commit, environment fingerprint, timestamps), and the phase accounting for
 every sample. The filename hash is the SHA-256 digest of the canonical
 serialized run object — canonical JSON with sorted keys and integer raw
-values, so hashing involves no floating-point formatting. `index.json` only
+values, so hashing involves no floating-point formatting. That digest is taken
+over the bytes a record was published as, and a reader takes a stored record's
+name from the record rather than re-deriving it: record fields are additive, so
+re-serializing a parsed record names it as today's schema would have written
+it, which renames every record written before the newest field — including
+whichever record an epoch's baseline pins. `index.json` only
 points to run objects and their series. Everything derived — indexes,
 dispersion, chart data, summaries — is rebuilt from raw records at site build
 time and never stored on the data branch: no SVGs, no HTML, no derived JSON.

--- a/scripts/test-validate-performance-stall.py
+++ b/scripts/test-validate-performance-stall.py
@@ -114,6 +114,104 @@ def test_the_newest_point_spans_epochs() -> None:
     assert stall.newest_plotted(subject)[0][1] == "c" * 40
 
 
+def indexed_epoch(
+    epoch: int,
+    baseline: str | None,
+    indexes: list[float | None],
+    platform: str = "x86_64-linux",
+) -> dict:
+    """One platform holding one epoch whose points carry the given indexes."""
+    return {
+        "platforms": [
+            {
+                "platform": platform,
+                "epochs": [
+                    {
+                        "epoch": epoch,
+                        "baseline_commit": baseline,
+                        "points": [
+                            {
+                                "commit": "a" * 40,
+                                "finished_at": f"2026-08-0{i + 1}T00:00:00Z",
+                                "index": None if value is None else {"latency": value},
+                            }
+                            for i, value in enumerate(indexes)
+                        ],
+                    }
+                ],
+            }
+        ]
+    }
+
+
+def test_an_epoch_publishing_its_index_is_healthy() -> None:
+    assert stall.unindexed(indexed_epoch(5, "b" * 40, [1.0, 0.98])) == []
+
+
+def test_a_baseline_that_publishes_no_index_is_a_failure() -> None:
+    # Points keep arriving, so the commit-count rule is satisfied while the
+    # figure they exist to move is absent. This is the shape RUE-1475 took.
+    missing = stall.unindexed(indexed_epoch(5, "b" * 40, [None, None, None]))
+    assert missing == [("x86_64-linux", 5, 3)]
+
+
+def test_an_epoch_with_no_baseline_yet_publishes_no_index_by_design() -> None:
+    # The documented state of a freshly declared epoch: it accepts runs before
+    # it can express them as an index. Failing here would make declaring the
+    # next epoch — the remedy for a stall — itself a repository-wide failure.
+    assert stall.unindexed(indexed_epoch(6, None, [None, None])) == []
+
+
+def test_a_retired_epoch_is_not_held_to_publishing_an_index() -> None:
+    # Only the epoch still receiving points is the live signal. An older epoch
+    # keeps whatever it published and must not block the repository forever.
+    subject = {
+        "platforms": [
+            {
+                "platform": "x86_64-linux",
+                "epochs": [
+                    {
+                        "epoch": 4,
+                        "baseline_commit": "b" * 40,
+                        "points": [
+                            {
+                                "commit": "a" * 40,
+                                "finished_at": "2026-08-01T00:00:00Z",
+                                "index": None,
+                            }
+                        ],
+                    },
+                    {
+                        "epoch": 5,
+                        "baseline_commit": "c" * 40,
+                        "points": [
+                            {
+                                "commit": "d" * 40,
+                                "finished_at": "2026-08-08T00:00:00Z",
+                                "index": {"latency": 1.0},
+                            }
+                        ],
+                    },
+                ],
+            }
+        ]
+    }
+    assert stall.unindexed(subject) == []
+
+
+def test_a_partial_newest_run_does_not_fail_an_indexed_epoch() -> None:
+    # A partial run publishes no headline point by design. The epoch is still
+    # publishing an index, so the rule is about the epoch, not the last point.
+    assert stall.unindexed(indexed_epoch(5, "b" * 40, [1.0, None])) == []
+
+
+def test_the_unindexed_report_names_the_pin_to_check() -> None:
+    text = stall.report_unindexed([("x86_64-linux", 5, 25)])
+    assert "not caused by" in text
+    assert "epoch.baseline" in text
+    assert "performance/manifest.toml" in text
+
+
 def test_the_report_says_it_is_not_the_authors_fault_and_how_to_fix_it() -> None:
     # There is no bypass, so a pull request author blocked by an unrelated
     # stall must be able to act without reading the issue.

--- a/scripts/validate-performance-stall.py
+++ b/scripts/validate-performance-stall.py
@@ -13,6 +13,14 @@ commit count degrades gracefully across quiet weekends while a clock does not.
 Collection legitimately lags trunk by minutes, and a single failed collection
 should not block the repository, so the threshold tolerates both.
 
+Two things can stop, and both are checked here. Points can stop arriving, which
+is what the commit-count rule catches. Points can also keep arriving while the
+headline index they exist to move goes missing — an epoch whose declared
+baseline resolves to nothing publishes a ratio for no workload, so every point
+is plotted and the index is silently absent. That failed openly nowhere: the
+collector succeeded, no run was rejected, and the page simply stopped saying
+whether the compiler is getting slower (RUE-1486).
+
 The series state comes from `rue-bench derive`, never from a status file stored
 alongside the raw records: ADR-0067 keeps everything derived out of the data
 branch, and a stored staleness flag is exactly the kind of value that would
@@ -55,6 +63,43 @@ def newest_plotted(data: dict) -> list[tuple[str, str, str]]:
         if latest is not None:
             newest.append((platform["platform"], latest["commit"], latest["finished_at"]))
     return newest
+
+
+def newest_epochs(data: dict) -> list[tuple[str, dict]]:
+    """Return each platform's live epoch: the one holding its newest point.
+
+    A retired epoch keeps whatever it published and is not the signal anyone
+    reads, so only the epoch still receiving points is held to publishing one.
+    """
+    live = []
+    for platform in data.get("platforms", []):
+        newest = None
+        for epoch in platform.get("epochs", []):
+            for point in epoch.get("points", []):
+                if newest is None or point["finished_at"] > newest[0]:
+                    newest = (point["finished_at"], epoch)
+        if newest is not None:
+            live.append((platform["platform"], newest[1]))
+    return live
+
+
+def unindexed(data: dict) -> list[tuple[str, int, int]]:
+    """Return (platform, epoch, points) for live epochs publishing no index.
+
+    An epoch with no baseline yet is the documented state of one that has just
+    been declared, and it publishes no index by design. An epoch that *has* a
+    baseline and still publishes no index is the failure: the baseline names a
+    run nothing resolves to, so no point carries a ratio and the headline index
+    is absent from a series that otherwise looks healthy.
+    """
+    missing = []
+    for platform, epoch in newest_epochs(data):
+        if not epoch.get("baseline_commit"):
+            continue
+        points = epoch.get("points", [])
+        if points and not any(point.get("index") for point in points):
+            missing.append((platform, epoch.get("epoch"), len(points)))
+    return missing
 
 
 def stalled(
@@ -127,6 +172,35 @@ def report(behind: list[tuple[str, str, int]], max_commits: int) -> str:
     return "\n".join(lines)
 
 
+def report_unindexed(missing: list[tuple[str, int, int]]) -> str:
+    lines = [
+        "The published performance series is collecting but publishes no index.",
+        "",
+    ]
+    for platform, epoch, points in missing:
+        lines.append(
+            f"  {platform}: epoch {epoch} declares a baseline, has {points} "
+            f"plotted point(s), and none of them carries a headline index"
+        )
+    lines += [
+        "",
+        "This is a repository-wide condition and almost certainly not caused by",
+        "this pull request. Points are arriving, so nothing fails on its own:",
+        "the page keeps drawing per-workload series while the one figure that",
+        "answers 'is the compiler getting slower' is quietly absent.",
+        "",
+        "An index needs a baseline that resolves. To resolve it:",
+        "",
+        "  1. Check that the run named by `[epoch.baseline]` in",
+        "     performance/manifest.toml is still stored under that name on",
+        "     performance-data-v1. A record is named by the bytes it was",
+        "     published as; nothing may rename it afterwards.",
+        "  2. Check that the epoch's runs are complete. A headline point",
+        "     publishes only from a run that measured every suite workload.",
+    ]
+    return "\n".join(lines)
+
+
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument(
@@ -167,6 +241,11 @@ def main() -> int:
 
     if behind:
         print(report(behind, args.max_commits), file=sys.stderr)
+        return 1
+
+    missing = unindexed(data)
+    if missing:
+        print(report_unindexed(missing), file=sys.stderr)
         return 1
 
     for platform, commit, finished_at in plotted:


### PR DESCRIPTION
Fixes RUE-1486.

Epoch 5 declared its baseline at 02:32 today and published no headline index on any platform from that moment. Re-deriving the published data at `22dc27a`:

| platform | epoch | points | indexed |
| --- | ---: | ---: | ---: |
| x86_64-linux | 5 | 25 | 0 |
| aarch64-linux | 5 | 25 | 0 |
| aarch64-macos | 5 | 24 | 0 |

Every run complete, both workloads at their full calibrated sample counts, no failure records, no rejected runs. Nothing failed anywhere: collection was green on every commit, the per-workload series kept drawing, and the one figure the dashboard exists to publish was simply gone.

## Cause

A run object's name is the SHA-256 of the bytes it was published as — `publish-performance-runs.py` stores each record under that digest, and `[epoch.baseline] run = "..."` pins it. Every reader instead re-derived that name by re-serializing the parsed `RunObject`, which is a different function the moment the schema struct changes.

Record fields are deliberately additive: boundary evidence gains a `#[serde(default)]` counter whenever the compiler gains a phase to count, so older records stay readable. Today's phase-attribution work added seven such groups. Each one renames every record written before it, because the parse fills in a zero the stored bytes never contained. The x86-64 baseline was published as `9b7d4bdb…` and re-derived as `4e81b757…`, so the pin matched nothing, no run resolved as the baseline, no workload got a ratio, and an epoch cannot express an index without one.

All 945 stored records still hash to their own filenames. The bytes on `performance-data-v1` are fine; only the reader drifted. Epoch 2 was unaffected because protocol-v1 records carry no boundary evidence and still round-trip, which is why this looked like a broken new epoch rather than a broken reader.

## Change

**A reader takes a stored record's name from the record.** `StoredRun` carries the address of the value as stored alongside the typed view; `load_data_branch` produces them, and the derivation uses that name both to match the baseline and to label plotted points, so a point on the page links to the file that is actually on the branch. Minting an address from the struct stays where it is correct — the runner naming a record it is about to write.

**The staleness gate learns the second failure mode.** It counts plotted points against merged trunk commits, and points never stopped arriving, so it passed on every pull request while the series published nothing. It now also fails when the live epoch declares a baseline and publishes no index: a series that is advancing and saying nothing. An epoch with no baseline yet is untouched — publishing no index is its documented state, and declaring the next epoch is the remedy for a stall.

## Verification

- Re-deriving the real 945-record data branch with this change restores the index on all three platforms (latest: x86-64 0.964, ARM64 0.868, macOS 1.073). Epochs 2 and 4 are byte-identical to the previous derivation.
- The extended gate, run against this morning's derived data, names all three platforms; against the fixed derivation it passes.
- Two regression tests hold the class: one at the schema layer, that a schema change does not rename an existing record, and one at the derivation layer, that an epoch whose baseline pins a record which no longer round-trips still publishes ratios and an index.
- 125 `rue-perf-schema` tests, 17 derivation tests, and 13 gate tests pass. `buck2` was unavailable in the environment these were run in, so the Rust tests were compiled from the same sources against the repository's vendored crates rather than through the build graph; CI is the authority.

## Note

`generate-site-status.py` selects the newest epoch that *has* indexed points, so while epoch 5 was blank the homepage silently fell back to retired epoch 2 and reported its index as current. This change makes it report epoch 5 again, but the fallback itself is unchanged — substituting a superseded epoch without saying so seems worth revisiting separately.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Hvv6twi5Q1GHh3PDRjCVs6)_