### PR TITLE
RUE-1473: cache body nominal facts

### DIFF
--- a/crates/rue-bench/src/scaling.rs
+++ b/crates/rue-bench/src/scaling.rs
@@ -775,12 +775,12 @@ fn render(report: &ScalingReport) -> String {
             work.import_anonymous_nominals_registered,
         ));
     }
-    out.push_str("\n| workload | durable materializations total (shared/owned; const/nominal/function/method) | anonymous facts | producer facts | toolchain facts |\n");
-    out.push_str("| --- | ---: | ---: | ---: | ---: |\n");
+    out.push_str("\n| workload | durable materializations total (shared/owned; const/nominal/function/method) | nominal payload reuses | anonymous facts | producer facts | toolchain facts |\n");
+    out.push_str("| --- | ---: | ---: | ---: | ---: | ---: |\n");
     for observation in reference_observations(report) {
         let work = observation.work.semantic_provider;
         out.push_str(&format!(
-            "| {} | {} ({}/{}; {}/{}/{}/{}) | {} | {} | {} |\n",
+            "| {} | {} ({}/{}; {}/{}/{}/{}) | {} | {} | {} | {} |\n",
             observation.workload,
             work.materializations,
             work.shared_payload_materializations,
@@ -789,6 +789,7 @@ fn render(report: &ScalingReport) -> String {
             work.nominal_materializations,
             work.function_materializations,
             work.method_materializations,
+            work.nominal_materialization_reuses,
             work.anonymous_facts,
             work.producer_facts,
             work.toolchain_facts,
@@ -1101,6 +1102,7 @@ mod tests {
                         nominal_materializations: 3,
                         function_materializations: 11,
                         method_materializations: 7,
+                        nominal_materialization_reuses: 8,
                         anonymous_facts: 29,
                         producer_facts: 31,
                         toolchain_facts: 37,
@@ -1217,6 +1219,7 @@ mod tests {
         assert!(rendered.contains("Semantic provider observations"));
         assert!(rendered.contains("durable materializations"));
         assert!(rendered.contains("23 (3/20; 2/3/11/7)"));
+        assert!(rendered.contains("| 8 | 29 | 31 | 37 |"));
         assert!(rendered.contains("nominal registration requests"));
         assert!(rendered.contains("41 | 43 | 47 (53/59/61) | 67 | 71"));
         assert!(rendered.contains("Semantic reachability scheduling"));

--- a/crates/rue-compiler/src/revisioned_query_database.rs
+++ b/crates/rue-compiler/src/revisioned_query_database.rs
@@ -13,7 +13,7 @@ use std::ops::Deref;
 use std::rc::Rc;
 use std::sync::{Arc, Mutex};
 
-use ahash::RandomState;
+use ahash::{AHashMap, RandomState};
 
 #[derive(Debug, Default)]
 struct BodyReachabilityMeter {
@@ -765,6 +765,7 @@ pub(crate) struct ProviderObservationCounters {
     nominal_materializations: std::sync::atomic::AtomicU64,
     function_materializations: std::sync::atomic::AtomicU64,
     method_materializations: std::sync::atomic::AtomicU64,
+    nominal_materialization_reuses: std::sync::atomic::AtomicU64,
     anonymous_facts: std::sync::atomic::AtomicU64,
     producer_facts: std::sync::atomic::AtomicU64,
     toolchain_facts: std::sync::atomic::AtomicU64,
@@ -834,6 +835,7 @@ impl ProviderObservationCounters {
             nominal_materializations,
             function_materializations,
             method_materializations,
+            nominal_materialization_reuses: self.nominal_materialization_reuses.load(Relaxed),
             anonymous_facts: self.anonymous_facts.load(Relaxed),
             producer_facts: self.producer_facts.load(Relaxed),
             toolchain_facts: self.toolchain_facts.load(Relaxed),
@@ -21446,6 +21448,19 @@ impl CanonicalAnonymousNominalRegistry {
 pub(crate) struct CompilerBodyDurableSource<'a> {
     provider: &'a CompilerBodyFactProvider<'a>,
     dynamic_anonymous: Rc<std::cell::RefCell<CanonicalAnonymousNominalRegistry>>,
+    /// One body transaction can ask for the same canonically shared nominal
+    /// payload through type minting, endpoint installation, and export. Keep
+    /// the exact provider result once per durable key so those consumers share
+    /// the same immutable field/variant Arcs instead of rebuilding the
+    /// candidate and signature projection.
+    named_nominals: Rc<
+        std::cell::RefCell<
+            AHashMap<
+                crate::StableDefinitionKey,
+                rue_air::DurableNominal<crate::StableDefinitionKey, ModuleId>,
+            >,
+        >,
+    >,
     source_paths: Rc<std::cell::RefCell<HashMap<crate::FileId, Arc<str>>>>,
     source_locators: Rc<std::cell::RefCell<HashMap<ModuleId, rue_air::DurableBodySourceLocator>>>,
 }
@@ -21473,6 +21488,7 @@ impl<'a> CompilerBodyDurableSource<'a> {
         Self {
             provider,
             dynamic_anonymous: Rc::new(std::cell::RefCell::new(dynamic_anonymous)),
+            named_nominals: Rc::new(std::cell::RefCell::new(AHashMap::new())),
             source_paths: Rc::new(std::cell::RefCell::new(source_paths)),
             source_locators: Rc::new(std::cell::RefCell::new(source_locators)),
         }
@@ -22263,6 +22279,13 @@ impl rue_air::DurableNominalSource<crate::StableDefinitionKey, ModuleId>
         &self,
         key: &crate::StableDefinitionKey,
     ) -> Option<rue_air::DurableNominal<crate::StableDefinitionKey, ModuleId>> {
+        if let Some(nominal) = self.named_nominals.borrow().get(key).cloned() {
+            self.provider
+                .meter()
+                .nominal_materialization_reuses
+                .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+            return Some(nominal);
+        }
         self.provider
             .meter()
             .nominal_materializations
@@ -22293,7 +22316,7 @@ impl rue_air::DurableNominalSource<crate::StableDefinitionKey, ModuleId>
             Projection::Enum { variants } => rue_air::DurableNominalBody::Enum { variants },
             _ => return None,
         };
-        Some(rue_air::DurableNominal {
+        let nominal = rue_air::DurableNominal {
             name: Arc::from(key.name()),
             module_path: Arc::from(key.module().logical_path()),
             is_public: candidate.identity.is_public,
@@ -22315,7 +22338,11 @@ impl rue_air::DurableNominalSource<crate::StableDefinitionKey, ModuleId>
                 rue_air::NameResolution::Unique(_)
             ),
             body,
-        })
+        };
+        self.named_nominals
+            .borrow_mut()
+            .insert(key.clone(), nominal.clone());
+        Some(nominal)
     }
 }
 

--- a/crates/rue-compiler/src/session.rs
+++ b/crates/rue-compiler/src/session.rs
@@ -8163,13 +8163,15 @@ mod tests {
 
         let metrics = crate::unstable::provider_observation_metrics(&session);
         assert_eq!(
-            metrics.name_lookups, 15,
-            "provider body analysis must reuse exact parameter facts while resolving the body-local return spelling once: {metrics:?}"
+            metrics.name_lookups, 11,
+            "the first Item payload must serve type minting and endpoint installation without repeating candidate/destructor lookups: {metrics:?}"
         );
-        assert_eq!(metrics.declaration_facts, 20, "{metrics:?}");
-        assert_eq!(metrics.identity_facts, 10, "{metrics:?}");
-        assert_eq!(metrics.signature_facts, 10, "{metrics:?}");
-        assert_eq!(metrics.materializations, 10, "{metrics:?}");
+        assert_eq!(metrics.declaration_facts, 16, "{metrics:?}");
+        assert_eq!(metrics.identity_facts, 8, "{metrics:?}");
+        assert_eq!(metrics.signature_facts, 8, "{metrics:?}");
+        assert_eq!(metrics.materializations, 8, "{metrics:?}");
+        assert_eq!(metrics.nominal_materializations, 2, "{metrics:?}");
+        assert_eq!(metrics.nominal_materialization_reuses, 2, "{metrics:?}");
         assert_eq!(
             metrics.materializations,
             metrics.shared_payload_materializations + metrics.owned_payload_materializations,

--- a/crates/rue-compiler/src/unstable.rs
+++ b/crates/rue-compiler/src/unstable.rs
@@ -260,6 +260,9 @@ pub struct ProviderObservationMetrics {
     pub function_materializations: u64,
     /// Method facts materialized into a body-local overlay.
     pub method_materializations: u64,
+    /// Named nominal materialization requests satisfied by the body
+    /// transaction's exact durable-payload cache.
+    pub nominal_materialization_reuses: u64,
     /// Anonymous-nominal fact observations.
     pub anonymous_facts: u64,
     /// Producer-body fact observations.

--- a/crates/rue-perf-schema/src/scaling.rs
+++ b/crates/rue-perf-schema/src/scaling.rs
@@ -15,7 +15,7 @@ use crate::{
 };
 
 /// Version of the scaling-report wire format.
-pub const SCALING_REPORT_SCHEMA_VERSION: u32 = 20;
+pub const SCALING_REPORT_SCHEMA_VERSION: u32 = 21;
 
 /// The lower-frequency scaling suite declaration.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -262,6 +262,9 @@ pub struct SemanticProviderWork {
     /// Method facts materialized into body-local representations.
     #[serde(default)]
     pub method_materializations: u64,
+    /// Named nominal requests satisfied by an exact body-transaction payload reuse.
+    #[serde(default)]
+    pub nominal_materialization_reuses: u64,
     /// Anonymous-nominal fact reads.
     pub anonymous_facts: u64,
     /// Anonymous-producer body fact reads.
@@ -539,6 +542,7 @@ question = "small maintained compiler frontend"
             "nominal_materializations",
             "function_materializations",
             "method_materializations",
+            "nominal_materialization_reuses",
             "import_nominal_registration_requests",
             "import_nominal_type_visits",
             "import_named_nominal_probes",
@@ -558,6 +562,7 @@ question = "small maintained compiler frontend"
         assert_eq!(decoded.nominal_materializations, 0);
         assert_eq!(decoded.function_materializations, 0);
         assert_eq!(decoded.method_materializations, 0);
+        assert_eq!(decoded.nominal_materialization_reuses, 0);
         assert_eq!(decoded.import_nominal_registration_requests, 0);
         assert_eq!(decoded.import_nominal_type_visits, 0);
         assert_eq!(decoded.import_named_nominal_probes, 0);

--- a/crates/rue/src/main.rs
+++ b/crates/rue/src/main.rs
@@ -1137,6 +1137,7 @@ fn benchmark_compiler_work(
             nominal_materializations: provider.nominal_materializations,
             function_materializations: provider.function_materializations,
             method_materializations: provider.method_materializations,
+            nominal_materialization_reuses: provider.nominal_materialization_reuses,
             anonymous_facts: provider.anonymous_facts,
             producer_facts: provider.producer_facts,
             toolchain_facts: provider.toolchain_facts,
@@ -1817,6 +1818,7 @@ mod tests {
                 nominal_materializations: 3,
                 function_materializations: 11,
                 method_materializations: 7,
+                nominal_materialization_reuses: 8,
                 anonymous_facts: 29,
                 producer_facts: 31,
                 toolchain_facts: 37,
@@ -1911,6 +1913,10 @@ mod tests {
         assert_eq!(projected.semantic_provider.nominal_materializations, 3);
         assert_eq!(projected.semantic_provider.function_materializations, 11);
         assert_eq!(projected.semantic_provider.method_materializations, 7);
+        assert_eq!(
+            projected.semantic_provider.nominal_materialization_reuses,
+            8
+        );
         assert_eq!(
             projected.semantic_provider.materializations,
             projected.semantic_provider.const_materializations

--- a/docs/process/compiler-scaling.md
+++ b/docs/process/compiler-scaling.md
@@ -138,6 +138,8 @@ events so representation changes can target the declaration kind which owns
 the measured traffic. It is also exactly partitioned by provider-boundary
 representation: shared payloads reuse canonical immutable storage, while owned
 payloads rebuild an equivalent body-local transport value.
+Named nominal payload reuses count repeated type-pool, endpoint, and export
+consumers satisfied from the exact body transaction's first materialization.
 
 The nominal-registration table measures the work after a durable type fact has
 crossed that boundary. A request installs the named and anonymous identities its


### PR DESCRIPTION
## Summary

- retain each exact named nominal payload once per body transaction
- reuse its immutable field/variant data across type minting, endpoint installation, and export
- publish an exact reuse counter in scaling schema v21

## Evidence

The full maintained scaling corpus preserves every executable byte and hash. Deterministic one-worker reductions are:

- Ruelex: 419 duplicate nominal materializations removed
- Mosaic: 1,346 removed
- Harbor: 3,387 removed
- Lattice: 3,657 removed (36.0%), plus 7,314 fewer provider lookups and declaration-fact reads

The nominal-registration counters and body scheduling remain exact and unchanged. Local focused provider tests and `scripts/rue quick` pass; CI is the full-platform authority.

Refs RUE-1473.