### PR TITLE
RUE-1473: cache body function facts

### DIFF
--- a/crates/rue-bench/src/scaling.rs
+++ b/crates/rue-bench/src/scaling.rs
@@ -775,12 +775,12 @@ fn render(report: &ScalingReport) -> String {
             work.import_anonymous_nominals_registered,
         ));
     }
-    out.push_str("\n| workload | durable materializations total (shared/owned; const/nominal/function/method) | nominal payload reuses | anonymous facts | producer facts | toolchain facts |\n");
+    out.push_str("\n| workload | durable materializations total (shared/owned; const/nominal/function/method) | nominal/function payload reuses | anonymous facts | producer facts | toolchain facts |\n");
     out.push_str("| --- | ---: | ---: | ---: | ---: | ---: |\n");
     for observation in reference_observations(report) {
         let work = observation.work.semantic_provider;
         out.push_str(&format!(
-            "| {} | {} ({}/{}; {}/{}/{}/{}) | {} | {} | {} | {} |\n",
+            "| {} | {} ({}/{}; {}/{}/{}/{}) | {}/{} | {} | {} | {} |\n",
             observation.workload,
             work.materializations,
             work.shared_payload_materializations,
@@ -790,6 +790,7 @@ fn render(report: &ScalingReport) -> String {
             work.function_materializations,
             work.method_materializations,
             work.nominal_materialization_reuses,
+            work.function_materialization_reuses,
             work.anonymous_facts,
             work.producer_facts,
             work.toolchain_facts,
@@ -1103,6 +1104,7 @@ mod tests {
                         function_materializations: 11,
                         method_materializations: 7,
                         nominal_materialization_reuses: 8,
+                        function_materialization_reuses: 10,
                         anonymous_facts: 29,
                         producer_facts: 31,
                         toolchain_facts: 37,
@@ -1219,7 +1221,7 @@ mod tests {
         assert!(rendered.contains("Semantic provider observations"));
         assert!(rendered.contains("durable materializations"));
         assert!(rendered.contains("23 (3/20; 2/3/11/7)"));
-        assert!(rendered.contains("| 8 | 29 | 31 | 37 |"));
+        assert!(rendered.contains("| 8/10 | 29 | 31 | 37 |"));
         assert!(rendered.contains("nominal registration requests"));
         assert!(rendered.contains("41 | 43 | 47 (53/59/61) | 67 | 71"));
         assert!(rendered.contains("Semantic reachability scheduling"));

--- a/crates/rue-compiler/src/revisioned_query_database.rs
+++ b/crates/rue-compiler/src/revisioned_query_database.rs
@@ -766,6 +766,7 @@ pub(crate) struct ProviderObservationCounters {
     function_materializations: std::sync::atomic::AtomicU64,
     method_materializations: std::sync::atomic::AtomicU64,
     nominal_materialization_reuses: std::sync::atomic::AtomicU64,
+    function_materialization_reuses: std::sync::atomic::AtomicU64,
     anonymous_facts: std::sync::atomic::AtomicU64,
     producer_facts: std::sync::atomic::AtomicU64,
     toolchain_facts: std::sync::atomic::AtomicU64,
@@ -836,6 +837,7 @@ impl ProviderObservationCounters {
             function_materializations,
             method_materializations,
             nominal_materialization_reuses: self.nominal_materialization_reuses.load(Relaxed),
+            function_materialization_reuses: self.function_materialization_reuses.load(Relaxed),
             anonymous_facts: self.anonymous_facts.load(Relaxed),
             producer_facts: self.producer_facts.load(Relaxed),
             toolchain_facts: self.toolchain_facts.load(Relaxed),
@@ -21444,23 +21446,27 @@ impl CanonicalAnonymousNominalRegistry {
     }
 }
 
+#[derive(Default)]
+struct BodyDurablePayloadCache {
+    /// One body transaction can ask for the same canonical declaration payload
+    /// through type minting, endpoint installation, and export. Keep the exact
+    /// provider result once per durable key so those consumers share immutable
+    /// signature payloads instead of rebuilding their candidate projection.
+    named_nominals: AHashMap<
+        crate::StableDefinitionKey,
+        rue_air::DurableNominal<crate::StableDefinitionKey, ModuleId>,
+    >,
+    named_functions: AHashMap<
+        crate::StableDefinitionKey,
+        rue_air::DurableFunction<crate::StableDefinitionKey, ModuleId>,
+    >,
+}
+
 #[derive(Clone)]
 pub(crate) struct CompilerBodyDurableSource<'a> {
     provider: &'a CompilerBodyFactProvider<'a>,
     dynamic_anonymous: Rc<std::cell::RefCell<CanonicalAnonymousNominalRegistry>>,
-    /// One body transaction can ask for the same canonically shared nominal
-    /// payload through type minting, endpoint installation, and export. Keep
-    /// the exact provider result once per durable key so those consumers share
-    /// the same immutable field/variant Arcs instead of rebuilding the
-    /// candidate and signature projection.
-    named_nominals: Rc<
-        std::cell::RefCell<
-            AHashMap<
-                crate::StableDefinitionKey,
-                rue_air::DurableNominal<crate::StableDefinitionKey, ModuleId>,
-            >,
-        >,
-    >,
+    durable_payloads: Rc<std::cell::RefCell<BodyDurablePayloadCache>>,
     source_paths: Rc<std::cell::RefCell<HashMap<crate::FileId, Arc<str>>>>,
     source_locators: Rc<std::cell::RefCell<HashMap<ModuleId, rue_air::DurableBodySourceLocator>>>,
 }
@@ -21488,7 +21494,7 @@ impl<'a> CompilerBodyDurableSource<'a> {
         Self {
             provider,
             dynamic_anonymous: Rc::new(std::cell::RefCell::new(dynamic_anonymous)),
-            named_nominals: Rc::new(std::cell::RefCell::new(AHashMap::new())),
+            durable_payloads: Rc::new(std::cell::RefCell::new(BodyDurablePayloadCache::default())),
             source_paths: Rc::new(std::cell::RefCell::new(source_paths)),
             source_locators: Rc::new(std::cell::RefCell::new(source_locators)),
         }
@@ -22279,7 +22285,13 @@ impl rue_air::DurableNominalSource<crate::StableDefinitionKey, ModuleId>
         &self,
         key: &crate::StableDefinitionKey,
     ) -> Option<rue_air::DurableNominal<crate::StableDefinitionKey, ModuleId>> {
-        if let Some(nominal) = self.named_nominals.borrow().get(key).cloned() {
+        if let Some(nominal) = self
+            .durable_payloads
+            .borrow()
+            .named_nominals
+            .get(key)
+            .cloned()
+        {
             self.provider
                 .meter()
                 .nominal_materialization_reuses
@@ -22339,8 +22351,9 @@ impl rue_air::DurableNominalSource<crate::StableDefinitionKey, ModuleId>
             ),
             body,
         };
-        self.named_nominals
+        self.durable_payloads
             .borrow_mut()
+            .named_nominals
             .insert(key.clone(), nominal.clone());
         Some(nominal)
     }
@@ -22353,6 +22366,19 @@ impl rue_air::DurableCallableSource<crate::StableDefinitionKey, ModuleId>
         &self,
         key: &crate::StableDefinitionKey,
     ) -> Option<rue_air::DurableFunction<crate::StableDefinitionKey, ModuleId>> {
+        if let Some(function) = self
+            .durable_payloads
+            .borrow()
+            .named_functions
+            .get(key)
+            .cloned()
+        {
+            self.provider
+                .meter()
+                .function_materialization_reuses
+                .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+            return Some(function);
+        }
         self.provider
             .meter()
             .function_materializations
@@ -22373,14 +22399,19 @@ impl rue_air::DurableCallableSource<crate::StableDefinitionKey, ModuleId>
         if key.kind().requires_owner() {
             return None;
         }
-        Some(rue_air::DurableFunction {
+        let function = rue_air::DurableFunction {
             parameters,
             result,
             type_syntax,
             is_public: candidate.identity.is_public,
             is_unchecked,
             is_extern,
-        })
+        };
+        self.durable_payloads
+            .borrow_mut()
+            .named_functions
+            .insert(key.clone(), function.clone());
+        Some(function)
     }
 
     fn method(

--- a/crates/rue-compiler/src/session.rs
+++ b/crates/rue-compiler/src/session.rs
@@ -8107,13 +8107,15 @@ mod tests {
         assert_eq!(metrics.import_lookups, 0);
         assert_eq!(metrics.method_candidates, 0);
         assert_eq!(metrics.operator_candidates, 0);
-        assert_eq!(metrics.declaration_facts, 12, "{metrics:?}");
+        assert_eq!(metrics.declaration_facts, 6, "{metrics:?}");
         assert_eq!(
-            metrics.identity_facts, 6,
-            "callable type syntax must travel with the winning signature instead of resolving its candidate again: {metrics:?}"
+            metrics.identity_facts, 3,
+            "one exact function payload must serve every body-transaction consumer: {metrics:?}"
         );
-        assert_eq!(metrics.signature_facts, 6, "{metrics:?}");
-        assert_eq!(metrics.materializations, 6, "{metrics:?}");
+        assert_eq!(metrics.signature_facts, 3, "{metrics:?}");
+        assert_eq!(metrics.materializations, 3, "{metrics:?}");
+        assert_eq!(metrics.function_materializations, 3, "{metrics:?}");
+        assert_eq!(metrics.function_materialization_reuses, 3, "{metrics:?}");
         assert_eq!(
             metrics.materializations,
             metrics.shared_payload_materializations + metrics.owned_payload_materializations,
@@ -8166,12 +8168,14 @@ mod tests {
             metrics.name_lookups, 11,
             "the first Item payload must serve type minting and endpoint installation without repeating candidate/destructor lookups: {metrics:?}"
         );
-        assert_eq!(metrics.declaration_facts, 16, "{metrics:?}");
-        assert_eq!(metrics.identity_facts, 8, "{metrics:?}");
-        assert_eq!(metrics.signature_facts, 8, "{metrics:?}");
-        assert_eq!(metrics.materializations, 8, "{metrics:?}");
+        assert_eq!(metrics.declaration_facts, 10, "{metrics:?}");
+        assert_eq!(metrics.identity_facts, 5, "{metrics:?}");
+        assert_eq!(metrics.signature_facts, 5, "{metrics:?}");
+        assert_eq!(metrics.materializations, 5, "{metrics:?}");
         assert_eq!(metrics.nominal_materializations, 2, "{metrics:?}");
         assert_eq!(metrics.nominal_materialization_reuses, 2, "{metrics:?}");
+        assert_eq!(metrics.function_materializations, 3, "{metrics:?}");
+        assert_eq!(metrics.function_materialization_reuses, 3, "{metrics:?}");
         assert_eq!(
             metrics.materializations,
             metrics.shared_payload_materializations + metrics.owned_payload_materializations,

--- a/crates/rue-compiler/src/unstable.rs
+++ b/crates/rue-compiler/src/unstable.rs
@@ -263,6 +263,9 @@ pub struct ProviderObservationMetrics {
     /// Named nominal materialization requests satisfied by the body
     /// transaction's exact durable-payload cache.
     pub nominal_materialization_reuses: u64,
+    /// Free-function materialization requests satisfied by the body
+    /// transaction's exact durable-payload cache.
+    pub function_materialization_reuses: u64,
     /// Anonymous-nominal fact observations.
     pub anonymous_facts: u64,
     /// Producer-body fact observations.

--- a/crates/rue-perf-schema/src/scaling.rs
+++ b/crates/rue-perf-schema/src/scaling.rs
@@ -15,7 +15,7 @@ use crate::{
 };
 
 /// Version of the scaling-report wire format.
-pub const SCALING_REPORT_SCHEMA_VERSION: u32 = 21;
+pub const SCALING_REPORT_SCHEMA_VERSION: u32 = 22;
 
 /// The lower-frequency scaling suite declaration.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -265,6 +265,9 @@ pub struct SemanticProviderWork {
     /// Named nominal requests satisfied by an exact body-transaction payload reuse.
     #[serde(default)]
     pub nominal_materialization_reuses: u64,
+    /// Free-function requests satisfied by an exact body-transaction payload reuse.
+    #[serde(default)]
+    pub function_materialization_reuses: u64,
     /// Anonymous-nominal fact reads.
     pub anonymous_facts: u64,
     /// Anonymous-producer body fact reads.
@@ -543,6 +546,7 @@ question = "small maintained compiler frontend"
             "function_materializations",
             "method_materializations",
             "nominal_materialization_reuses",
+            "function_materialization_reuses",
             "import_nominal_registration_requests",
             "import_nominal_type_visits",
             "import_named_nominal_probes",
@@ -563,6 +567,7 @@ question = "small maintained compiler frontend"
         assert_eq!(decoded.function_materializations, 0);
         assert_eq!(decoded.method_materializations, 0);
         assert_eq!(decoded.nominal_materialization_reuses, 0);
+        assert_eq!(decoded.function_materialization_reuses, 0);
         assert_eq!(decoded.import_nominal_registration_requests, 0);
         assert_eq!(decoded.import_nominal_type_visits, 0);
         assert_eq!(decoded.import_named_nominal_probes, 0);

--- a/crates/rue/src/main.rs
+++ b/crates/rue/src/main.rs
@@ -1138,6 +1138,7 @@ fn benchmark_compiler_work(
             function_materializations: provider.function_materializations,
             method_materializations: provider.method_materializations,
             nominal_materialization_reuses: provider.nominal_materialization_reuses,
+            function_materialization_reuses: provider.function_materialization_reuses,
             anonymous_facts: provider.anonymous_facts,
             producer_facts: provider.producer_facts,
             toolchain_facts: provider.toolchain_facts,
@@ -1819,6 +1820,7 @@ mod tests {
                 function_materializations: 11,
                 method_materializations: 7,
                 nominal_materialization_reuses: 8,
+                function_materialization_reuses: 10,
                 anonymous_facts: 29,
                 producer_facts: 31,
                 toolchain_facts: 37,
@@ -1916,6 +1918,10 @@ mod tests {
         assert_eq!(
             projected.semantic_provider.nominal_materialization_reuses,
             8
+        );
+        assert_eq!(
+            projected.semantic_provider.function_materialization_reuses,
+            10
         );
         assert_eq!(
             projected.semantic_provider.materializations,

--- a/docs/process/compiler-scaling.md
+++ b/docs/process/compiler-scaling.md
@@ -140,6 +140,7 @@ representation: shared payloads reuse canonical immutable storage, while owned
 payloads rebuild an equivalent body-local transport value.
 Named nominal payload reuses count repeated type-pool, endpoint, and export
 consumers satisfied from the exact body transaction's first materialization.
+Free-function payload reuses count the equivalent repeated callable imports.
 
 The nominal-registration table measures the work after a durable type fact has
 crossed that boundary. A request installs the named and anonymous identities its


### PR DESCRIPTION
## Summary

- retain each exact free-function payload once per body transaction
- reuse immutable parameter/result/type-syntax payloads across repeated callable imports
- share one request-local cache allocation with the nominal payload cache
- publish an exact function-reuse counter in scaling schema v22

## Evidence

The full maintained scaling corpus preserves every executable byte and hash. Deterministic one-worker duplicate function materializations removed:

- Ruelex: 197
- Mosaic: 1,653
- Harbor: 3,146
- Lattice: 3,980 (51.4%)

Against the nominal-cache parent, Lattice declaration-fact reads fall 43,310 → 35,350 (-18.4%) and total durable materializations fall 14,868 → 10,888 (-26.8%). Combined with the parent, 7,637 of the original 18,525 Lattice durable payload builds are removed (-41.2%). Scheduling, registration counters, outputs, diagnostics, and warnings remain exact. Local focused tests and `scripts/rue quick` pass; CI is the full-platform authority.

Refs RUE-1473.