### PR TITLE
RUE-1473: avoid allocating precompute block walks

### DIFF
--- a/crates/rue-air/src/sema/comptime_eval.rs
+++ b/crates/rue-air/src/sema/comptime_eval.rs
@@ -2271,13 +2271,14 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
     ) {
         match &self.body_rir_ref().get(inst_ref).data {
             InstData::Block { instructions } => {
-                let stmts: Vec<InstRef> = self
-                    .body_rir_ref()
-                    .block_insts(instructions)
-                    .values()
-                    .collect();
+                let instructions = instructions.clone();
+                let statement_count = self.body_rir_ref().block_inst_count(&instructions);
                 let mut inner_frame = Vec::new();
-                for stmt in stmts {
+                for index in 0..statement_count {
+                    let stmt = self
+                        .body_rir_ref()
+                        .block_inst(&instructions, index)
+                        .expect("the statement count came from this block payload");
                     self.walk_comptime_type_locals(
                         stmt,
                         discovered,

--- a/crates/rue-rir/src/inst.rs
+++ b/crates/rue-rir/src/inst.rs
@@ -3414,6 +3414,31 @@ impl Rir {
             (r.start(), r.extent(), RirBlockInstsRange::FAMILY)
         })
     }
+
+    /// Number of instructions in a block payload without constructing a
+    /// borrowing view over the complete payload.
+    pub fn block_inst_count(&self, range: &RirBlockInstsRange) -> usize {
+        self.payload_words(range, |r| {
+            (r.start(), r.extent(), RirBlockInstsRange::FAMILY)
+        })
+        .expect("validated RIR range")
+        .len()
+    }
+
+    /// Retrieves one instruction from a block payload in constant time.
+    ///
+    /// Recursive consumers use this accessor when retaining a borrowing
+    /// [`RirSlice`] across the recursive call would unnecessarily require an
+    /// owned copy of the block's instruction list.
+    pub fn block_inst(&self, range: &RirBlockInstsRange, index: usize) -> Option<InstRef> {
+        self.payload_words(range, |r| {
+            (r.start(), r.extent(), RirBlockInstsRange::FAMILY)
+        })
+        .expect("validated RIR range")
+        .get(index)
+        .copied()
+        .map(InstRef::from_raw)
+    }
     pub fn struct_methods(&self, range: &RirStructMethodsRange) -> RirSlice<'_, InstRef> {
         self.ref_view(range, |r| {
             (r.start(), r.extent(), RirStructMethodsRange::FAMILY)
@@ -5829,6 +5854,10 @@ mod typed_payload_tests {
             rir.block_insts(&block).values().collect::<Vec<_>>(),
             [r0, r1]
         );
+        assert_eq!(rir.block_inst_count(&block), 2);
+        assert_eq!(rir.block_inst(&block, 0), Some(r0));
+        assert_eq!(rir.block_inst(&block, 1), Some(r1));
+        assert_eq!(rir.block_inst(&block, 2), None);
         assert_eq!(
             rir.struct_methods(&methods).values().collect::<Vec<_>>(),
             [r0]


### PR DESCRIPTION
## Summary

- add constant-time indexed access for validated RIR block payloads
- use it in compile-time type-alias precomputation instead of allocating and filling a temporary `Vec` for every visited block
- preserve source traversal order and lexical undo-frame behavior

## Evidence

- Native Lattice profiling identified `walk_comptime_type_locals` as about 6% of sampled compiler CPU, with allocation/free among the largest leaf costs.
- This removes exactly one allocation plus the borrowing view's validation/decode pass per visited block. Local wall time remains noisy, so no clock-time improvement is claimed pending hosted scaling.
- `scripts/rue unit rir every_payload_family_round_trips`
- `scripts/rue quick`

Refs RUE-1473.