### PR TITLE
RUE-1481: std.fs directory enumeration — read_dir and a deterministic walk

### DIFF
--- a/crates/rue-cli-tests/cases/fs_read_dir.toml
+++ b/crates/rue-cli-tests/cases/fs_read_dir.toml
@@ -1,0 +1,734 @@
+# std.fs directory enumeration (RUE-1481, ADR-0072 Phase 2a / Decision 6):
+# `fs.read_dir` over getdents64 and the deterministic `fs.walk` tree scan, driven
+# end-to-end as a user would — the real std.fs (via RUE_STD_PATH) compiled to a
+# real binary that creates real directories and files in the harness's per-case
+# temp directory and then enumerates them.
+#
+# WHY THESE CASES. Directory enumeration has three things that are easy to get
+# wrong and hard to notice:
+#
+#   1. THE REFILL LOOP. getdents64 fills a fixed buffer and is called again until
+#      it returns 0; a short non-zero return is normal, not an end marker. An
+#      implementation that stops at the first partial buffer looks perfect on
+#      every small directory. `read_dir_refill_loop_600_entries` makes the
+#      directory bigger than one buffer (600 entries against std.fs's 8 KiB
+#      request, so at least three syscalls) and asserts every entry is present
+#      AND in the right place.
+#   2. THE VARIABLE STRIDE. Records are variable-length and must be walked by
+#      their own `d_reclen`. A fixed stride desynchronizes after the first record
+#      whose name length differs, which the mixed-name cases below would catch.
+#   3. THE ORDER. ADR-0072 needs reproducible downstream output, so ordering is
+#      part of the contract, not a nicety. `read_dir_order_is_creation_order_
+#      independent` builds the SAME names in two directories in two different
+#      creation orders and requires identical listings — a bug that returned raw
+#      filesystem order would pass a single-directory ordering check on many
+#      filesystems and fail this one.
+#
+# PLATFORMS. These run on the two Linux targets AND on aarch64-macos. Linux uses
+# getdents64 with `struct linux_dirent64`; macOS uses the `getdirentries64` BSD
+# trap with Darwin's `struct dirent`, and std.fs carries both layouts. Every line
+# above the syscall — record walking, name extraction, `.`/`..` filtering, path
+# joining, sorting, and the walk's pre-order traversal — is shared, so the macOS
+# leg exercises the same logic through the other syscall. x86-64 macOS is
+# excluded because Rue has no x86-64 macOS compiler target.
+#
+# SYMLINKS come from the harness's `symlinks` fixture list, not from the program:
+# `std.fs` has no `symlinkat`, and a `files` entry can only produce a regular
+# file, so staging them is the only way to reach this behavior at all.
+#
+# NOT COVERED HERE. The DT_UNKNOWN stat fallback has no coverage: it cannot be
+# provoked on the filesystems CI runs on, all of which report `d_type`. It is
+# documented in std/fs.rue rather than silently assumed.
+
+[section]
+id = "cli.fs_read_dir"
+name = "std.fs directory enumeration"
+description = "read_dir over getdents64 and the deterministic recursive walk, against real directory trees (RUE-1481, ADR-0072)."
+
+# An empty directory lists as empty, and adding two files makes it list exactly
+# two — which is also the assertion that `.` and `..` are filtered out. A naive
+# implementation reports 2 and 4 here.
+[[case]]
+name = "read_dir_empty_then_dot_entries_skipped"
+only_on = ["x86-64-linux", "aarch64-linux", "aarch64-macos"]
+env = { RUE_STD_PATH = "${REAL_STD}" }
+files = [{ path = "main.rue", source = """
+const std = @import("std");
+const SB = std.strbuf.StrBuf;
+
+fn mk(s: str) -> SB {
+    let mut out = SB.new();
+    out.append_str(borrow s);
+    out
+}
+
+fn touch(s: str) -> bool {
+    let F = std.fs.File;
+    let FE = std.fs.FileError;
+    let OR = std.result.Result(F, FE);
+    let CR = std.result.Result((), FE);
+    match F.create(borrow mk(s)) {
+        OR.Ok(f) => match f.close() { CR.Ok(_u) => true, CR.Err(_e) => false },
+        OR.Err(_e) => false,
+    }
+}
+
+fn main() -> i32 {
+    let FE = std.fs.FileError;
+    let CR = std.result.Result((), FE);
+    let DR = std.result.Result(std.fs.DirEntries, FE);
+
+    match std.fs.create_dir(borrow mk("hollow")) { CR.Ok(_u) => {}, CR.Err(_e) => { return 61; } };
+
+    let first = match std.fs.read_dir(borrow mk("hollow")) { DR.Ok(d) => d, DR.Err(_e) => { return 62; } };
+    if first.len() != 0 { return 63; }
+    if !first.is_empty() { return 64; }
+
+    if !touch("hollow/one.txt") { return 65; }
+    if !touch("hollow/two.txt") { return 66; }
+
+    let second = match std.fs.read_dir(borrow mk("hollow")) { DR.Ok(d) => d, DR.Err(_e) => { return 67; } };
+    // 2, not 4: `.` and `..` are directory-format artifacts, not entries.
+    if second.len() != 2 { return 68; }
+    if second.is_empty() { return 69; }
+    @dbg(second.len());
+    0
+}
+""" }]
+stdout = "2\n"
+exit_code = 0
+
+# Files and subdirectories mixed, created in an order that is neither sorted nor
+# reverse-sorted, with names of THREE different lengths so a fixed record stride
+# could not survive. Asserts the exact listing: ascending base-name byte order,
+# each entry's kind, and that `path(i)` is the parent joined with the name.
+[[case]]
+name = "read_dir_mixed_files_and_dirs_sorted"
+only_on = ["x86-64-linux", "aarch64-linux", "aarch64-macos"]
+env = { RUE_STD_PATH = "${REAL_STD}" }
+files = [{ path = "main.rue", source = """
+const std = @import("std");
+const SB = std.strbuf.StrBuf;
+
+fn mk(s: str) -> SB {
+    let mut out = SB.new();
+    out.append_str(borrow s);
+    out
+}
+
+fn touch(s: str) -> bool {
+    let F = std.fs.File;
+    let FE = std.fs.FileError;
+    let OR = std.result.Result(F, FE);
+    let CR = std.result.Result((), FE);
+    match F.create(borrow mk(s)) {
+        OR.Ok(f) => match f.close() { CR.Ok(_u) => true, CR.Err(_e) => false },
+        OR.Err(_e) => false,
+    }
+}
+
+fn mkdir(s: str) -> bool {
+    let FE = std.fs.FileError;
+    let CR = std.result.Result((), FE);
+    match std.fs.create_dir(borrow mk(s)) { CR.Ok(_u) => true, CR.Err(_e) => false }
+}
+
+fn main() -> i32 {
+    let FE = std.fs.FileError;
+    let DR = std.result.Result(std.fs.DirEntries, FE);
+    let K = std.fs.FileKind;
+
+    if !mkdir("mix") { return 61; }
+    // Deliberately not in name order, and deliberately alternating kinds.
+    if !touch("mix/zebra.md") { return 62; }
+    if !mkdir("mix/b_dir") { return 63; }
+    if !touch("mix/m") { return 64; }
+    if !mkdir("mix/n_directory") { return 65; }
+    if !touch("mix/a.md") { return 66; }
+
+    let listing = match std.fs.read_dir(borrow mk("mix")) { DR.Ok(d) => d, DR.Err(_e) => { return 67; } };
+    if listing.len() != 5 { return 68; }
+
+    let mut i: u64 = 0;
+    while i < listing.len() {
+        print(listing.path(i));
+        print(" ");
+        print(listing.name(i));
+        print(" ");
+        match listing.kind(i) {
+            K.File => print("file"),
+            K.Dir => print("dir"),
+            K.Symlink => print("symlink"),
+            K.Other => print("other"),
+        };
+        // The boolean helpers must agree with `kind`.
+        if listing.is_dir(i) { print(" d"); }
+        if listing.is_file(i) { print(" f"); }
+        print("\\n");
+        i = i + 1;
+    }
+    0
+}
+""" }]
+stdout = """mix/a.md a.md file f
+mix/b_dir b_dir dir d
+mix/m m file f
+mix/n_directory n_directory dir d
+mix/zebra.md zebra.md file f
+"""
+exit_code = 0
+
+# An entry's `path(i)` must be directly usable, not merely printable: open the
+# listed path and read back the bytes written through it. This is the
+# read_dir counterpart of the RUE-995 "a created directory must be USABLE"
+# case — a joined path that stats but cannot be opened would pass every
+# string-shaped assertion above.
+[[case]]
+name = "read_dir_entry_path_is_openable"
+only_on = ["x86-64-linux", "aarch64-linux", "aarch64-macos"]
+env = { RUE_STD_PATH = "${REAL_STD}" }
+files = [{ path = "main.rue", source = """
+const std = @import("std");
+const SB = std.strbuf.StrBuf;
+
+fn mk(s: str) -> SB {
+    let mut out = SB.new();
+    out.append_str(borrow s);
+    out
+}
+
+fn main() -> i32 {
+    let F = std.fs.File;
+    let FE = std.fs.FileError;
+    let OR = std.result.Result(F, FE);
+    let WR = std.result.Result(u64, FE);
+    let CR = std.result.Result((), FE);
+    let DR = std.result.Result(std.fs.DirEntries, FE);
+    let Buf = std.arraybuf.ArrayBuf(u8);
+
+    match std.fs.create_dir(borrow mk("openable")) { CR.Ok(_u) => {}, CR.Err(_e) => { return 61; } };
+
+    let msg = "listed-and-opened";
+    let mut out = Buf.new();
+    let mut i: u64 = 0;
+    while i < msg.len() { out.push(msg[i]); i = i + 1; }
+
+    let mut w = match F.create(borrow mk("openable/payload.bin")) { OR.Ok(f) => f, OR.Err(_e) => { return 62; } };
+    match w.write_all(borrow out) { CR.Ok(_u) => {}, CR.Err(_e) => { return 63; } };
+    match w.close() { CR.Ok(_u) => {}, CR.Err(_e) => { return 64; } };
+
+    let listing = match std.fs.read_dir(borrow mk("openable")) { DR.Ok(d) => d, DR.Err(_e) => { return 65; } };
+    if listing.len() != 1 { return 66; }
+
+    let found = listing.path(0);
+    let mut r = match F.open(borrow found) { OR.Ok(f) => f, OR.Err(_e) => { return 67; } };
+    let mut inb = Buf.with_capacity(64);
+    let n = match r.read(inout inb) { WR.Ok(v) => v, WR.Err(_e) => { return 68; } };
+    match r.close() { CR.Ok(_u) => {}, CR.Err(_e) => { return 69; } };
+
+    if n != msg.len() { return 70; }
+    let mut j: u64 = 0;
+    while j < n {
+        if inb.get_or(j, 0) != msg[j] { return 71; }
+        j = j + 1;
+    }
+    @dbg(n);
+    @intCast(n)
+}
+""" }]
+stdout = "17\n"
+exit_code = 17
+
+# A trailing separator on the listed path must not produce `dir//entry`. Rue has
+# no path type (ADR-0057 §2), so the join is a byte-level decision std.fs makes,
+# and `dir//entry` would still open — it would just make every downstream
+# comparison and output filename subtly wrong.
+[[case]]
+name = "read_dir_trailing_separator_joins_once"
+only_on = ["x86-64-linux", "aarch64-linux", "aarch64-macos"]
+env = { RUE_STD_PATH = "${REAL_STD}" }
+files = [{ path = "main.rue", source = """
+const std = @import("std");
+const SB = std.strbuf.StrBuf;
+
+fn mk(s: str) -> SB {
+    let mut out = SB.new();
+    out.append_str(borrow s);
+    out
+}
+
+fn main() -> i32 {
+    let F = std.fs.File;
+    let FE = std.fs.FileError;
+    let OR = std.result.Result(F, FE);
+    let CR = std.result.Result((), FE);
+    let DR = std.result.Result(std.fs.DirEntries, FE);
+
+    match std.fs.create_dir(borrow mk("slashy")) { CR.Ok(_u) => {}, CR.Err(_e) => { return 61; } };
+    match F.create(borrow mk("slashy/only.txt")) {
+        OR.Ok(f) => { match f.close() { CR.Ok(_u) => {}, CR.Err(_e) => { return 62; } }; },
+        OR.Err(_e) => { return 63; },
+    };
+
+    let listing = match std.fs.read_dir(borrow mk("slashy/")) { DR.Ok(d) => d, DR.Err(_e) => { return 64; } };
+    if listing.len() != 1 { return 65; }
+    print(listing.path(0));
+    print("\\n");
+    print(listing.name(0));
+    print("\\n");
+    0
+}
+""" }]
+stdout = """slashy/only.txt
+only.txt
+"""
+exit_code = 0
+
+# The recursive walk: a three-level tree, asserted as an exact depth-first
+# PRE-ORDER sequence. Pre-order matters — a directory must appear before its
+# contents — and siblings must be in the same ascending name order `read_dir`
+# gives, so a whole subtree lands contiguously after its directory. The `sub`
+# subtree is deliberately placed between two root-level files, so a breadth-first
+# or append-at-the-end traversal produces a different sequence and fails.
+[[case]]
+name = "walk_nested_tree_is_depth_first_preorder"
+only_on = ["x86-64-linux", "aarch64-linux", "aarch64-macos"]
+env = { RUE_STD_PATH = "${REAL_STD}" }
+files = [{ path = "main.rue", source = """
+const std = @import("std");
+const SB = std.strbuf.StrBuf;
+
+fn mk(s: str) -> SB {
+    let mut out = SB.new();
+    out.append_str(borrow s);
+    out
+}
+
+fn touch(s: str) -> bool {
+    let F = std.fs.File;
+    let FE = std.fs.FileError;
+    let OR = std.result.Result(F, FE);
+    let CR = std.result.Result((), FE);
+    match F.create(borrow mk(s)) {
+        OR.Ok(f) => match f.close() { CR.Ok(_u) => true, CR.Err(_e) => false },
+        OR.Err(_e) => false,
+    }
+}
+
+fn mkdir(s: str) -> bool {
+    let FE = std.fs.FileError;
+    let CR = std.result.Result((), FE);
+    match std.fs.create_dir(borrow mk(s)) { CR.Ok(_u) => true, CR.Err(_e) => false }
+}
+
+fn main() -> i32 {
+    let FE = std.fs.FileError;
+    let DR = std.result.Result(std.fs.DirEntries, FE);
+
+    if !mkdir("content") { return 61; }
+    if !touch("content/zulu.md") { return 62; }
+    if !mkdir("content/sub") { return 63; }
+    if !mkdir("content/sub/inner") { return 64; }
+    if !touch("content/sub/inner/deep.md") { return 65; }
+    if !touch("content/sub/second.md") { return 66; }
+    if !touch("content/alpha.md") { return 67; }
+    // An empty directory in the middle of the tree: it must be emitted, and its
+    // (absent) contents must not disturb what follows.
+    if !mkdir("content/empty") { return 68; }
+
+    let tree = match std.fs.walk(borrow mk("content")) { DR.Ok(d) => d, DR.Err(_e) => { return 69; } };
+    let mut i: u64 = 0;
+    while i < tree.len() {
+        print(tree.path(i));
+        if tree.is_dir(i) { print("/"); }
+        print("\\n");
+        i = i + 1;
+    }
+    @dbg(tree.len());
+    0
+}
+""" }]
+stdout = """content/alpha.md
+content/empty/
+content/sub/
+content/sub/inner/
+content/sub/inner/deep.md
+content/sub/second.md
+content/zulu.md
+7
+"""
+exit_code = 0
+
+# Ordering is independent of CREATION order, which is the property downstream
+# reproducibility actually needs. Two directories get the same five names built
+# in two different orders; the listings must be identical byte for byte. A
+# `read_dir` that returned raw filesystem order would pass a single-directory
+# sorted-look check on some filesystems and fail here on all of them.
+[[case]]
+name = "read_dir_order_is_creation_order_independent"
+only_on = ["x86-64-linux", "aarch64-linux", "aarch64-macos"]
+env = { RUE_STD_PATH = "${REAL_STD}" }
+files = [{ path = "main.rue", source = """
+const std = @import("std");
+const SB = std.strbuf.StrBuf;
+
+fn mk(s: str) -> SB {
+    let mut out = SB.new();
+    out.append_str(borrow s);
+    out
+}
+
+fn touch(borrow p: SB) -> bool {
+    let F = std.fs.File;
+    let FE = std.fs.FileError;
+    let OR = std.result.Result(F, FE);
+    let CR = std.result.Result((), FE);
+    match F.create(borrow p) {
+        OR.Ok(f) => match f.close() { CR.Ok(_u) => true, CR.Err(_e) => false },
+        OR.Err(_e) => false,
+    }
+}
+
+fn join(dir: str, name: str) -> SB {
+    let mut p = mk(dir);
+    p.push(47); // '/'
+    p.append_str(borrow name);
+    p
+}
+
+fn main() -> i32 {
+    let FE = std.fs.FileError;
+    let CR = std.result.Result((), FE);
+    let DR = std.result.Result(std.fs.DirEntries, FE);
+
+    match std.fs.create_dir(borrow mk("one")) { CR.Ok(_u) => {}, CR.Err(_e) => { return 51; } };
+    match std.fs.create_dir(borrow mk("two")) { CR.Ok(_u) => {}, CR.Err(_e) => { return 52; } };
+
+    // The same five names, built in two deliberately different orders.
+    if !touch(borrow join("one", "delta.md")) { return 61; }
+    if !touch(borrow join("one", "alpha.md")) { return 61; }
+    if !touch(borrow join("one", "echo.md")) { return 61; }
+    if !touch(borrow join("one", "bravo.md")) { return 61; }
+    if !touch(borrow join("one", "charlie.md")) { return 61; }
+
+    if !touch(borrow join("two", "charlie.md")) { return 62; }
+    if !touch(borrow join("two", "echo.md")) { return 62; }
+    if !touch(borrow join("two", "bravo.md")) { return 62; }
+    if !touch(borrow join("two", "delta.md")) { return 62; }
+    if !touch(borrow join("two", "alpha.md")) { return 62; }
+
+    let a = match std.fs.read_dir(borrow mk("one")) { DR.Ok(d) => d, DR.Err(_e) => { return 63; } };
+    let b = match std.fs.read_dir(borrow mk("two")) { DR.Ok(d) => d, DR.Err(_e) => { return 64; } };
+    if a.len() != 5 { return 65; }
+    if b.len() != 5 { return 66; }
+
+    let mut i: u64 = 0;
+    while i < 5 {
+        let na = a.name(i);
+        let nb = b.name(i);
+        if !SB.equals_borrowed(borrow na, borrow nb) { return 67; }
+        print(na);
+        print("\\n");
+        i = i + 1;
+    }
+
+    // Repeating the same call must also be stable.
+    let again = match std.fs.read_dir(borrow mk("one")) { DR.Ok(d) => d, DR.Err(_e) => { return 68; } };
+    i = 0;
+    while i < 5 {
+        let x = a.name(i);
+        let y = again.name(i);
+        if !SB.equals_borrowed(borrow x, borrow y) { return 69; }
+        i = i + 1;
+    }
+    0
+}
+""" }]
+stdout = """alpha.md
+bravo.md
+charlie.md
+delta.md
+echo.md
+"""
+exit_code = 0
+
+# THE REFILL LOOP. 600 entries against std.fs's 8 KiB getdents64 request needs at
+# least three syscalls, so an implementation that reads one buffer and stops
+# reports a truncated listing. Names are zero-padded so byte order equals numeric
+# order, and every index is checked against its expected name — a listing that is
+# complete but misordered, or ordered but short, both fail. Exit code is not used
+# for the count (600 does not fit an exit status); stdout carries it.
+[[case]]
+name = "read_dir_refill_loop_600_entries"
+only_on = ["x86-64-linux", "aarch64-linux", "aarch64-macos"]
+env = { RUE_STD_PATH = "${REAL_STD}" }
+files = [{ path = "main.rue", source = """
+const std = @import("std");
+const SB = std.strbuf.StrBuf;
+
+fn mk(s: str) -> SB {
+    let mut out = SB.new();
+    out.append_str(borrow s);
+    out
+}
+
+// `n` as exactly `width` decimal digits, zero padded, so byte order and numeric
+// order agree.
+fn padded(n: u64, width: u64) -> SB {
+    let mut reversed = SB.new();
+    let mut v = n;
+    let mut c: u64 = 0;
+    while c < width {
+        let d: u8 = @intCast(48 + (v % 10));
+        reversed.push(d);
+        v = v / 10;
+        c = c + 1;
+    }
+    let mut out = SB.new();
+    let mut i = reversed.len();
+    while i > 0 {
+        i = i - 1;
+        out.push(SB.byte_at_borrowed(borrow reversed, i));
+    }
+    out
+}
+
+fn entry_name(i: u64) -> SB {
+    let mut out = mk("entry_");
+    let digits = padded(i, 4);
+    out.append_borrowed(borrow digits);
+    out.append_str(borrow ".txt");
+    out
+}
+
+fn main() -> i32 {
+    let F = std.fs.File;
+    let FE = std.fs.FileError;
+    let OR = std.result.Result(F, FE);
+    let CR = std.result.Result((), FE);
+    let DR = std.result.Result(std.fs.DirEntries, FE);
+
+    let total: u64 = 600;
+    match std.fs.create_dir(borrow mk("many")) { CR.Ok(_u) => {}, CR.Err(_e) => { return 61; } };
+
+    let mut i: u64 = 0;
+    while i < total {
+        let mut p = mk("many/");
+        let name = entry_name(i);
+        p.append_borrowed(borrow name);
+        match F.create(borrow p) {
+            OR.Ok(f) => { match f.close() { CR.Ok(_u) => {}, CR.Err(_e) => { return 62; } }; },
+            OR.Err(_e) => { return 63; },
+        };
+        i = i + 1;
+    }
+
+    let listing = match std.fs.read_dir(borrow mk("many")) { DR.Ok(d) => d, DR.Err(_e) => { return 64; } };
+    if listing.len() != total { return 65; }
+
+    let mut k: u64 = 0;
+    while k < total {
+        if !listing.is_file(k) { return 66; }
+        let want = entry_name(k);
+        let got = listing.name(k);
+        if !SB.equals_borrowed(borrow got, borrow want) { return 67; }
+        k = k + 1;
+    }
+
+    // A walk of the same directory must see exactly the same flat listing.
+    let tree = match std.fs.walk(borrow mk("many")) { DR.Ok(d) => d, DR.Err(_e) => { return 68; } };
+    if tree.len() != total { return 69; }
+
+    @dbg(listing.len());
+    0
+}
+""" }]
+stdout = "600\n"
+exit_code = 0
+
+# Error paths. A missing directory is the normalized `NotFound`, and a path that
+# exists but is a regular file is an error rather than a garbage listing. `walk`
+# propagates the same error from its root rather than returning an empty tree.
+#
+# This pins the BEHAVIOR, not std.fs's O_DIRECTORY open flag: the dirent syscall
+# rejects a non-directory fd with ENOTDIR by itself, so dropping the flag would
+# produce the same `FileError` here. The constant is pinned by
+# `read_dir_through_a_directory_symlink` instead — see `_o_directory` in
+# std/fs.rue.
+[[case]]
+name = "read_dir_missing_and_not_a_directory_err"
+only_on = ["x86-64-linux", "aarch64-linux", "aarch64-macos"]
+env = { RUE_STD_PATH = "${REAL_STD}" }
+files = [{ path = "main.rue", source = """
+const std = @import("std");
+const SB = std.strbuf.StrBuf;
+
+fn mk(s: str) -> SB {
+    let mut out = SB.new();
+    out.append_str(borrow s);
+    out
+}
+
+fn main() -> i32 {
+    let F = std.fs.File;
+    let FE = std.fs.FileError;
+    let OR = std.result.Result(F, FE);
+    let CR = std.result.Result((), FE);
+    let DR = std.result.Result(std.fs.DirEntries, FE);
+
+    match std.fs.read_dir(borrow mk("no_such_directory")) {
+        DR.Ok(_d) => { return 61; },
+        DR.Err(e) => match e { FE.NotFound => {}, _ => { return 62; } },
+    };
+
+    match std.fs.walk(borrow mk("no_such_directory")) {
+        DR.Ok(_d) => { return 63; },
+        DR.Err(e) => match e { FE.NotFound => {}, _ => { return 64; } },
+    };
+
+    match F.create(borrow mk("plain.txt")) {
+        OR.Ok(f) => { match f.close() { CR.Ok(_u) => {}, CR.Err(_e) => { return 65; } }; },
+        OR.Err(_e) => { return 66; },
+    };
+
+    // ENOTDIR is outside the named FileError set, so it arrives as `Other`; what
+    // matters is that it is an error at all and not an empty or bogus listing.
+    match std.fs.read_dir(borrow mk("plain.txt")) {
+        DR.Ok(_d) => { return 67; },
+        DR.Err(_e) => {},
+    };
+
+    @dbg(0);
+    0
+}
+""" }]
+stdout = "0\n"
+exit_code = 0
+
+# `read_dir` on a SYMLINK to a directory follows it and lists the target, the
+# same way `File.open` follows a symlink to a file. Only entries WITHIN a listing
+# are left unresolved.
+#
+# This is also what pins std.fs's `_o_directory` constant. The plausible way to
+# get that constant wrong is to transcribe the neighbouring "do not follow
+# symlinks" flag — Linux O_NOFOLLOW 0o400000 sits next to O_DIRECTORY 0o200000,
+# and Darwin O_SYMLINK 0x200000 next to O_DIRECTORY 0x100000 — which would turn
+# this open into ELOOP. A ZEROED constant still passes, deliberately: with no
+# flag the dirent syscall rejects a non-directory fd on its own, so a zeroed
+# O_DIRECTORY changes nothing observable and there is nothing honest to assert
+# about it.
+[[case]]
+name = "read_dir_through_a_directory_symlink"
+only_on = ["x86-64-linux", "aarch64-linux", "aarch64-macos"]
+env = { RUE_STD_PATH = "${REAL_STD}" }
+symlinks = [{ link = "dir_link", target = "real_dir" }]
+files = [
+    { path = "main.rue", source = """
+const std = @import("std");
+const SB = std.strbuf.StrBuf;
+
+fn mk(s: str) -> SB {
+    let mut out = SB.new();
+    out.append_str(borrow s);
+    out
+}
+
+fn main() -> i32 {
+    let FE = std.fs.FileError;
+    let DR = std.result.Result(std.fs.DirEntries, FE);
+
+    // Listing THROUGH the symlink must succeed and show the target's contents.
+    let listing = match std.fs.read_dir(borrow mk("dir_link")) { DR.Ok(d) => d, DR.Err(_e) => { return 61; } };
+    let mut i: u64 = 0;
+    while i < listing.len() {
+        print(listing.path(i));
+        if listing.is_dir(i) { print("/"); }
+        print("\\n");
+        i = i + 1;
+    }
+
+    // And so must a walk rooted at it, including into the real subdirectory.
+    let tree = match std.fs.walk(borrow mk("dir_link")) { DR.Ok(d) => d, DR.Err(_e) => { return 62; } };
+    @dbg(tree.len());
+    0
+}
+""" },
+    { path = "real_dir/inside.md", source = "" },
+    { path = "real_dir/nested/deep.md", source = "" },
+]
+stdout = """dir_link/inside.md
+dir_link/nested/
+3
+"""
+exit_code = 0
+
+# A symlink ENTRY is reported as `FileKind.Symlink` and is never descended into.
+# The three staged links are the three shapes that break a naive walk:
+#
+#   dir_link  -> sub    a symlink to a real directory INSIDE the tree; descending
+#                       it emits the subtree twice
+#   up_link   -> ..     descending it leaves the tree entirely and re-enters it,
+#                       so the walk never terminates
+#   self_link -> self_link   a self-referential dangling link
+#
+# A regression that followed symlinks makes `walk` non-terminating on a cyclic
+# content tree, which is why this is pinned as an exact listing rather than a
+# count: the case would hang or fail the sequence, not merely disagree.
+[[case]]
+name = "walk_does_not_descend_into_symlinks"
+only_on = ["x86-64-linux", "aarch64-linux", "aarch64-macos"]
+env = { RUE_STD_PATH = "${REAL_STD}" }
+symlinks = [
+    { link = "tree/dir_link", target = "sub" },
+    { link = "tree/up_link", target = ".." },
+    { link = "tree/self_link", target = "self_link" },
+]
+files = [
+    { path = "main.rue", source = """
+const std = @import("std");
+const SB = std.strbuf.StrBuf;
+
+fn mk(s: str) -> SB {
+    let mut out = SB.new();
+    out.append_str(borrow s);
+    out
+}
+
+fn main() -> i32 {
+    let FE = std.fs.FileError;
+    let DR = std.result.Result(std.fs.DirEntries, FE);
+    let K = std.fs.FileKind;
+
+    let tree = match std.fs.walk(borrow mk("tree")) { DR.Ok(d) => d, DR.Err(_e) => { return 61; } };
+    let mut i: u64 = 0;
+    while i < tree.len() {
+        print(tree.path(i));
+        print(" ");
+        match tree.kind(i) {
+            K.File => print("file"),
+            K.Dir => print("dir"),
+            K.Symlink => print("symlink"),
+            K.Other => print("other"),
+        };
+        // A symlink is neither a file nor a directory, whichever it points at.
+        if tree.is_dir(i) { print(" is_dir"); }
+        if tree.is_file(i) { print(" is_file"); }
+        print("\\n");
+        i = i + 1;
+    }
+    @dbg(tree.len());
+    0
+}
+""" },
+    { path = "tree/a.md", source = "" },
+    { path = "tree/sub/inner.md", source = "" },
+]
+stdout = """tree/a.md file is_file
+tree/dir_link symlink
+tree/self_link symlink
+tree/sub dir is_dir
+tree/sub/inner.md file is_file
+tree/up_link symlink
+6
+"""
+exit_code = 0

--- a/crates/rue-cli-tests/src/main.rs
+++ b/crates/rue-cli-tests/src/main.rs
@@ -54,6 +54,13 @@
 //!   says nothing about the compile, the case RUNS THAT EXECUTABLE instead of
 //!   compiling — see "Execution modes" below
 //! - `output`: name of produced executable (default `"prog"`)
+//! - `symlinks`: symbolic links created in the temp directory before the
+//!   compile, as `[{ link = "name", target = "..." }]`. The target is written
+//!   verbatim and is NOT required to exist: a dangling link is a legitimate
+//!   fixture, and so is one whose target the program creates at run time. This
+//!   is the only way a case can set up a symlink — a `files` entry always
+//!   produces a regular file — which filesystem-facing cases need in order to
+//!   pin symlink behavior (`std.fs` cannot create one either)
 //! - `env`: extra env vars for the compiler; the value `"${REAL_STD}"`
 //!   expands to the absolute path of the repo's `std/` directory
 //! - `program_args`: command-line arguments for the compiled program's run
@@ -1018,6 +1025,19 @@ struct SourceFile {
     source: String,
 }
 
+/// A symbolic link staged in the temp directory before the case runs.
+///
+/// `target` is written verbatim and is deliberately not validated or resolved:
+/// a dangling link, a self-referential link, and a link whose target the
+/// compiled program creates at run time are all legitimate fixtures for
+/// filesystem-facing cases.
+#[derive(Debug, Clone, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+struct SymlinkFixture {
+    link: String,
+    target: String,
+}
+
 #[derive(Debug, Clone, Default, Deserialize)]
 #[serde(deny_unknown_fields)]
 struct Case {
@@ -1033,6 +1053,11 @@ struct Case {
     /// Files written to the temp directory before invoking the compiler.
     #[serde(default)]
     files: Vec<SourceFile>,
+    /// Symbolic links staged in the temp directory alongside `files`. A `files`
+    /// entry can only produce a regular file, so this is what lets a case pin
+    /// symlink behavior.
+    #[serde(default)]
+    symlinks: Vec<SymlinkFixture>,
     /// Repo-root-relative source file to compile directly instead of copying
     /// inline source into the temp directory. Use this when a CLI case should
     /// pin a checked-in example/program rather than duplicating its source.
@@ -1938,6 +1963,7 @@ fn case_runs_prebuilt_program(case: &Case) -> bool {
         // from the same temp directory with the same argv, stdin, and
         // environment as the compile path, so all of these carry over.
         files: _,
+        symlinks: _,
         program_args: _,
         program_env: _,
         stdin: _,
@@ -2071,6 +2097,24 @@ fn run_case(
         }
         std::fs::write(&path, &file.source)
             .map_err(|e| TestFailure::fatal(format!("failed to write {}: {}", file.path, e)))?;
+    }
+
+    // Staged symlinks. Created after the regular files so a link may point at
+    // one, and with the target written verbatim so a dangling or cyclic link —
+    // the interesting cases for directory enumeration — stages successfully.
+    for symlink in &case.symlinks {
+        let path = dir.join(&symlink.link);
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent).map_err(|e| {
+                TestFailure::fatal(format!("failed to create dir for {}: {}", symlink.link, e))
+            })?;
+        }
+        std::os::unix::fs::symlink(&symlink.target, &path).map_err(|e| {
+            TestFailure::fatal(format!(
+                "failed to symlink {} -> {}: {}",
+                symlink.link, symlink.target, e
+            ))
+        })?;
     }
 
     let output_name = case.output.clone().unwrap_or_else(|| "prog".to_string());

--- a/crates/rue-oracle-diff/src/model_gaps/cli.rs
+++ b/crates/rue-oracle-diff/src/model_gaps/cli.rs
@@ -244,6 +244,65 @@ const ENTRIES: &[Entry] = &[
         intrinsic(UnsupportedIntrinsicKind::ByteCopy),
         &["aarch64-linux", "x86-64-linux"],
     ),
+    // RUE-1481: directory enumeration (`read_dir`/`walk`) reaches the same
+    // `@byte_copy` gap as the rest of the std.fs group — every entry's path is
+    // pooled through StrBuf, which copies bytes in bulk. These cases also run on
+    // aarch64-macos, unlike the v1 group above, because the Darwin dirent path
+    // is exercised rather than merely documented; their scope matches.
+    //
+    // The two symlink cases are absent on purpose, not overlooked: they stage
+    // their directory trees as extra `files` entries, so the harness classifies
+    // them ineligible ("multiple source files") and never reaches a model gap to
+    // register. Adding them would fail this registry, which rejects an entry
+    // that does not correspond to an observed gap.
+    Entry::new(
+        "cli.fs_read_dir",
+        "read_dir_empty_then_dot_entries_skipped",
+        intrinsic(UnsupportedIntrinsicKind::ByteCopy),
+        &["aarch64-linux", "aarch64-macos", "x86-64-linux"],
+    ),
+    Entry::new(
+        "cli.fs_read_dir",
+        "read_dir_entry_path_is_openable",
+        intrinsic(UnsupportedIntrinsicKind::ByteCopy),
+        &["aarch64-linux", "aarch64-macos", "x86-64-linux"],
+    ),
+    Entry::new(
+        "cli.fs_read_dir",
+        "read_dir_missing_and_not_a_directory_err",
+        intrinsic(UnsupportedIntrinsicKind::ByteCopy),
+        &["aarch64-linux", "aarch64-macos", "x86-64-linux"],
+    ),
+    Entry::new(
+        "cli.fs_read_dir",
+        "read_dir_mixed_files_and_dirs_sorted",
+        intrinsic(UnsupportedIntrinsicKind::ByteCopy),
+        &["aarch64-linux", "aarch64-macos", "x86-64-linux"],
+    ),
+    Entry::new(
+        "cli.fs_read_dir",
+        "read_dir_order_is_creation_order_independent",
+        intrinsic(UnsupportedIntrinsicKind::ByteCopy),
+        &["aarch64-linux", "aarch64-macos", "x86-64-linux"],
+    ),
+    Entry::new(
+        "cli.fs_read_dir",
+        "read_dir_refill_loop_600_entries",
+        intrinsic(UnsupportedIntrinsicKind::ByteCopy),
+        &["aarch64-linux", "aarch64-macos", "x86-64-linux"],
+    ),
+    Entry::new(
+        "cli.fs_read_dir",
+        "read_dir_trailing_separator_joins_once",
+        intrinsic(UnsupportedIntrinsicKind::ByteCopy),
+        &["aarch64-linux", "aarch64-macos", "x86-64-linux"],
+    ),
+    Entry::new(
+        "cli.fs_read_dir",
+        "walk_nested_tree_is_depth_first_preorder",
+        intrinsic(UnsupportedIntrinsicKind::ByteCopy),
+        &["aarch64-linux", "aarch64-macos", "x86-64-linux"],
+    ),
     // RUE-682: only the std.hash cases that route bytes through StrBuf or
     // ArrayBuf(u8) hit the `@byte_copy` gap. The three that hash `str` views
     // directly — including `hash_known_answer_vectors`, which carries the

--- a/std/_std.rue
+++ b/std/_std.rue
@@ -21,7 +21,8 @@
 //   `extend_str`.
 // - std.fs.File: File IO (open/create/append/read/write/seek/tell/metadata/close
 //   over @syscall) plus fs.rename/remove/create_dir/create_dir_all/
-//   remove_dir/metadata
+//   remove_dir/metadata, and directory enumeration via fs.read_dir/fs.walk
+//   (deterministically ordered `DirEntries`)
 // - std.binary: endianness-explicit integer<->byte conversions
 // - std.net: network IO v1 address model + Linux sockaddr marshalling
 // - std.c: transparent C scalar-type aliases for the FFI boundary
@@ -39,7 +40,8 @@ pub const strbuf = @import("strbuf.rue");
 pub const arraybuf = @import("arraybuf.rue");
 
 // File IO (RUE-712, ADR-0057): pure-Rue std.fs over @syscall. v0 open/read/
-// write/close plus the v1 follow-ups seek/stat/rename/remove/directories.
+// write/close plus the v1 follow-ups seek/stat/rename/remove/directories, and
+// directory enumeration (RUE-1481, ADR-0072): read_dir/walk over getdents64.
 pub const fs = @import("fs.rue");
 
 // Endianness-explicit integer<->byte conversions (RUE-970, ADR-0059/0060).

--- a/std/fs.rue
+++ b/std/fs.rue
@@ -18,9 +18,11 @@
 // `fs.create_dir_all`, `fs.remove_dir` via mkdirat/unlinkat+AT_REMOVEDIR).
 // `create_dir_all` (RUE-995) is pure composition over `create_dir`: it scans the
 // path for `/` bytes and creates each prefix, because Rue has no path type yet.
-// Reading directory
-// entries (getdents64) remains DEFERRED — the largest remaining chunk — as
-// does buffering and stdin/stdout unification (still out of ADR-0057 scope).
+//
+// DIRECTORY ENUMERATION (RUE-1481, ADR-0072 Phase 2a): `fs.read_dir` lists one
+// directory over getdents64 and `fs.walk` scans a whole tree in deterministic
+// order. See the "Directory enumeration" section at the end of this file.
+// Buffering and stdin/stdout unification remain deferred (out of ADR-0057 scope).
 //
 // PER-TARGET STAT LAYOUT: `stat` is the fiddliest v1 piece because the kernel's
 // `struct stat` byte layout differs per OS AND per arch. This module decodes
@@ -30,6 +32,7 @@
 // the DOCUMENTED, NOT-YET-CI-VERIFIED follow-up (this host is Linux). New v1
 // CLI cases are therefore `only_on` the two Linux targets, mirroring how v0's
 // error-detection cases were Linux-scoped until a macOS device could confirm.
+// Darwin stat decoding is in fact broken today — the open issue is RUE-1487.
 //
 // PATHS are byte-string `StrBuf`s; the syscall boundary copies the bytes into a
 // NUL-terminated buffer and never exposes that terminator to the caller.
@@ -108,6 +111,14 @@ pub struct Metadata {
     // S_IFMT=0o170000=61440, S_IFDIR=0o040000=16384.
     fn is_dir(borrow self) -> bool {
         (self.mode & 61440) == 16384
+    }
+
+    // True if this is a symbolic link: (st_mode & S_IFMT) == S_IFLNK.
+    // S_IFMT=0o170000=61440, S_IFLNK=0o120000=40960. Only ever true for a stat
+    // taken with AT_SYMLINK_NOFOLLOW — the path-following `fs.metadata` reports
+    // the target's type, never the link's.
+    fn is_symlink(borrow self) -> bool {
+        (self.mode & 61440) == 40960
     }
 }
 
@@ -306,6 +317,32 @@ fn _sys_mkdirat() -> u64 {
     }
 }
 
+// getdents64(2) on Linux — read a packed buffer of `linux_dirent64` records
+// from a directory fd. Linux: 217 (x86-64), 61 (aarch64, asm-generic).
+//
+// macOS has NO getdents64. The Darwin equivalent is the raw BSD trap
+// `getdirentries64` (344), whose record layout also differs (see the dirent
+// layout table below) and which takes a fourth `off_t *position` argument.
+// Unlike the other Darwin rows in this file, this one is EXERCISED: the CLI
+// cases for `read_dir`/`walk` run on aarch64-macos as well as the two Linux
+// targets.
+fn _sys_getdents() -> u64 {
+    match @target_arch() {
+        Arch.X86_64 => {
+            match @target_os() {
+                Os.Linux => 217,
+                Os.Macos => 344,
+            }
+        },
+        Arch.Aarch64 => {
+            match @target_os() {
+                Os.Linux => 61,
+                Os.Macos => 344,
+            }
+        },
+    }
+}
+
 // AT_FDCWD as a u64 bit pattern. Linux uses -100, macOS uses -2, so this is
 // per-OS data, not a shared constant.
 fn _at_fdcwd() -> u64 {
@@ -345,6 +382,58 @@ fn _o_append() -> u64 {
     }
 }
 
+// O_DIRECTORY: fail the open with ENOTDIR unless the path names a directory.
+//
+// PER-ARCH, unlike every other flag in this module. The `O_*` block is the one
+// place Linux lets an architecture override the asm-generic values, and arm64
+// (inheriting arm's ABI) does exactly that in `arch/arm64/include/uapi/asm/
+// fcntl.h`, which defines O_DIRECTORY/O_NOFOLLOW/O_DIRECT/O_LARGEFILE before
+// including the generic header. The result is that x86-64 and aarch64 SWAP two
+// of them:
+//
+//   flag         x86-64 Linux        aarch64 Linux
+//   O_DIRECTORY  0o200000 = 65536    0o40000  = 16384
+//   O_DIRECT     0o40000  = 16384    0o200000 = 65536
+//   O_NOFOLLOW   0o400000 = 262144   0o100000 = 32768
+//
+// So an OS-only dispatch does not merely pass a useless flag on aarch64 — it
+// passes O_DIRECT, and opening a directory with O_DIRECT fails EINVAL on the
+// filesystems CI runs on. That is the shape of the bug this table replaced.
+// macOS uses the BSD 0x00100000 on both arches.
+//
+// The other flag constants here were audited against the same failure mode and
+// are genuinely arch-independent: O_RDONLY/O_WRONLY/O_CREAT/O_TRUNC/O_APPEND
+// come from asm-generic and arm64 does not override them, and the `AT_*` values
+// live in `include/uapi/linux/fcntl.h`, which has no per-arch variant at all.
+//
+// This flag does NOT create the "read_dir on a regular file is an error"
+// behavior — the dirent syscall rejects a non-directory fd with ENOTDIR on its
+// own, so the caller sees the same `FileError` either way. What it buys is WHERE
+// the failure happens: at the open, before a descriptor for the wrong kind of
+// object is ever held. Since neither the errno nor the observable result
+// changes, dropping the flag entirely would be invisible to a test, so `read_dir`
+// on a regular file pins the behavior and not this constant.
+//
+// The constant itself is pinned by `read_dir_through_a_directory_symlink`, which
+// is what caught the swap above: a wrong value here fails a listing THROUGH a
+// symlinked directory while leaving every error path looking correct.
+fn _o_directory() -> u64 {
+    match @target_arch() {
+        Arch.X86_64 => {
+            match @target_os() {
+                Os.Linux => 65536,   // 0o200000
+                Os.Macos => 1048576, // 0x00100000
+            }
+        },
+        Arch.Aarch64 => {
+            match @target_os() {
+                Os.Linux => 16384,   // 0o40000 (arm64 override)
+                Os.Macos => 1048576, // 0x00100000
+            }
+        },
+    }
+}
+
 // Default mode for newly created files: 0o644.
 fn _create_mode() -> u64 { 420 }
 
@@ -358,6 +447,20 @@ fn _at_removedir() -> u64 {
     match @target_os() {
         Os.Linux => 512,
         Os.Macos => 128,
+    }
+}
+
+// AT_SYMLINK_NOFOLLOW: the *at flag that stats the LINK rather than its target.
+// Linux 0x100=256; macOS 0x0020=32 (DOCUMENTED, not CI-verified). Genuinely
+// arch-independent on Linux, unlike the `O_*` flags: the `AT_*` values live in
+// `include/uapi/linux/fcntl.h`, which has no per-arch variant to override them
+// (see `_o_directory` for the flags that do). Used only by the
+// directory-enumeration DT_UNKNOWN fallback, which must reproduce `d_type`'s own
+// no-follow semantics.
+fn _at_symlink_nofollow() -> u64 {
+    match @target_os() {
+        Os.Linux => 256,
+        Os.Macos => 32,
     }
 }
 
@@ -804,9 +907,11 @@ drop fn File(self) {
 // tables are unchanged.
 // ---------------------------------------------------------------------------
 
-// Size + type metadata for a path, via newfstatat(AT_FDCWD, path, .., 0). This
-// follows symlinks (flags 0). See `Metadata` for the exposed fields.
-pub fn metadata(borrow path: strbuf.StrBuf) -> result.Result(Metadata, FileError) {
+// newfstatat(AT_FDCWD, path, .., flags) with the caller choosing the *at flags.
+// `metadata` passes 0 (follow symlinks); the directory-enumeration DT_UNKNOWN
+// fallback passes AT_SYMLINK_NOFOLLOW so the kind it derives matches what
+// `d_type` would have reported.
+fn _metadata_at(borrow path: strbuf.StrBuf, flags: u64) -> result.Result(Metadata, FileError) {
     let R = result.Result(Metadata, FileError);
     let cbuf = _path_to_cbuf(borrow path);
     let paddr: u64 = checked { @ptr_to_int(cbuf) };
@@ -818,8 +923,7 @@ pub fn metadata(borrow path: strbuf.StrBuf) -> result.Result(Metadata, FileError
         @panic("out of memory");
     }
     let saddr: u64 = checked { @ptr_to_int(sbuf) };
-    let no_flags: u64 = 0; // follow symlinks (AT_SYMLINK_NOFOLLOW unset)
-    let ret: i64 = checked { @syscall(_sys_newfstatat(), _at_fdcwd(), paddr, saddr, no_flags) };
+    let ret: i64 = checked { @syscall(_sys_newfstatat(), _at_fdcwd(), paddr, saddr, flags) };
     checked { @free(cbuf, free_len, 1); };
     if ret < 0 {
         checked { @free(sbuf, sz, 8); };
@@ -828,6 +932,13 @@ pub fn metadata(borrow path: strbuf.StrBuf) -> result.Result(Metadata, FileError
     let md = _decode_stat(sbuf);
     checked { @free(sbuf, sz, 8); };
     R.Ok(md)
+}
+
+// Size + type metadata for a path, via newfstatat(AT_FDCWD, path, .., 0). This
+// follows symlinks (flags 0). See `Metadata` for the exposed fields.
+pub fn metadata(borrow path: strbuf.StrBuf) -> result.Result(Metadata, FileError) {
+    let no_flags: u64 = 0; // follow symlinks (AT_SYMLINK_NOFOLLOW unset)
+    _metadata_at(borrow path, no_flags)
 }
 
 // Rename (move) `from` to `to`: renameat(AT_FDCWD, from, AT_FDCWD, to). An
@@ -1015,5 +1126,732 @@ pub fn remove_dir(borrow path: strbuf.StrBuf) -> result.Result((), FileError) {
         R.Err(_normalize_errno(0 - ret))
     } else {
         R.Ok(())
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Directory enumeration (RUE-1481, ADR-0072 Phase 2a / Decision 6).
+//
+// `read_dir(path)` lists one directory; `walk(root)` lists a whole tree. Both
+// are pure Rue over `@syscall`, like the rest of this module — no runtime
+// helper, no benchmark-private shim.
+//
+// THE KERNEL BUFFER. getdents64 fills a caller-supplied buffer with a PACKED
+// run of VARIABLE-LENGTH records and returns the number of bytes written; a
+// return of 0 means the directory is exhausted. Any positive return short of
+// the buffer size is normal, not an end marker, so the read is a refill loop
+// that stops only at 0. Records never straddle a returned buffer, so each
+// buffer is scanned to completion before the next syscall. The stride is the
+// record's own `d_reclen` field — records are padded for alignment and the name
+// length varies, so a fixed stride would desynchronize the scan immediately.
+//
+//   Linux `struct linux_dirent64` (uapi/linux/dirent.h), both arches:
+//     d_ino    u64  @ 0     d_off     s64 @ 8
+//     d_reclen u16  @ 16    d_type    u8  @ 18   d_name NUL-terminated @ 19
+//   macOS `struct dirent` (_DARWIN_FEATURE_64_BIT_INODE, sys/dirent.h):
+//     d_ino    u64  @ 0     d_seekoff u64 @ 8
+//     d_reclen u16  @ 16    d_namlen  u16 @ 18   d_type u8 @ 20
+//     d_name   NUL-terminated @ 21
+//
+// `d_reclen` sits at offset 16 on both, so only the type and name offsets are
+// per-OS. The name is read as NUL-terminated but is also bounded by the record
+// end, so a malformed record cannot walk off the buffer.
+//
+// `.` and `..` are skipped: they are an artifact of the directory format, not
+// content, and a walk that followed `..` would not terminate.
+//
+// DT_UNKNOWN. `d_type` is an optimization the filesystem MAY decline: XFS
+// without `ftype`, some network and overlay filesystems, and older kernels all
+// report DT_UNKNOWN (0). Believing it would silently mis-type entries and make
+// `walk` skip real subtrees, so this module pays for the honest answer instead:
+// an entry whose `d_type` is DT_UNKNOWN is resolved with a
+// newfstatat(AT_SYMLINK_NOFOLLOW) on its path. AT_SYMLINK_NOFOLLOW is what makes
+// the fallback agree with `d_type`, which describes the entry itself and never a
+// symlink's target. If that stat also fails — the entry was removed between the
+// getdents and the stat, most plausibly — the entry is reported as
+// `FileKind.Other` rather than failing the whole listing; `Other` is the "not a
+// file, not a directory, do not descend" answer, which is the safe reading of an
+// entry that no longer exists.
+//
+// KNOWN LIMIT OF THAT FALLBACK ON macOS. Darwin `stat` decoding is broken here —
+// the open issue is RUE-1487, and the stat-layout note at the top of this file
+// has the details — so a DT_UNKNOWN entry on macOS degrades to `FileKind.Other`
+// rather than resolving. APFS and HFS+ both populate `d_type`, so the fallback
+// is unreachable there in practice; the Linux path is unaffected.
+//
+// ORDERING IS PART OF THE CONTRACT, not a nicety (ADR-0072 Decision 6): the
+// kernel returns entries in filesystem order, which varies with creation history
+// and filesystem, so downstream output would not be reproducible without a sort
+// here. Entries are ordered by their base name's BYTES, ascending — a
+// byte-string order, consistent with ADR-0035's byte-string paths, with no
+// locale or Unicode collation involved.
+//
+// `std.sort` cannot be used for it. Its routines order by the natural `<` on the
+// element type and read elements by copy, which the container gates to
+// trivially-droppable types (E0711/RUE-651); a directory entry's name is a
+// variable-length byte string that answers to neither. The order is therefore
+// computed here as an explicit bottom-up merge sort over an index permutation
+// with a byte-lexicographic comparator — merge sort rather than the insertion
+// sort a small listing would tolerate, because a content directory can hold
+// thousands of entries and quadratic behaviour there is a real cost.
+// ---------------------------------------------------------------------------
+
+// Per-OS `struct dirent` field offsets. `d_reclen` is at 16 on both, so only
+// these two rows differ. See the layout table above.
+fn _dirent_type_offset() -> u64 {
+    match @target_os() {
+        Os.Linux => 18,
+        Os.Macos => 20,
+    }
+}
+
+fn _dirent_name_offset() -> u64 {
+    match @target_os() {
+        Os.Linux => 19,
+        Os.Macos => 21,
+    }
+}
+
+// Bytes requested per getdents64 call. Large enough that an ordinary directory
+// is read in one or two syscalls, small enough to stay a modest transient
+// allocation. The refill loop is correct at any size; this is only a cost knob.
+fn _dirent_buf_size() -> u64 { 8192 }
+
+// Bytes of scratch the dirent syscall needs for its own position state: 8 on
+// Darwin, whose `getdirentries64` writes the resumed offset through an
+// `off_t *position` fourth argument, and 0 on Linux, whose `getdents64` takes
+// three arguments and ignores the extra register.
+//
+// A zero size is a guard, not a hint: both helpers below return before touching
+// the allocator, so a Linux `read_dir` costs one comparison rather than an
+// allocate, an 8-byte zeroing loop, and a free for an argument its kernel never
+// reads. `read_dir` is the inner call of a whole-tree content scan, which is the
+// hot path this module exists to serve, so the Darwin-only cost stays on Darwin
+// whether or not the target match folds.
+fn _dirent_position_size() -> u64 {
+    match @target_os() {
+        Os.Linux => 0,
+        Os.Macos => 8,
+    }
+}
+
+// The position slot described above: a zeroed 8-byte block on Darwin, the null
+// pointer on Linux. `getdirentries64` only writes through this pointer, but the
+// block is zeroed anyway so the syscall never sees uninitialized scratch.
+fn _alloc_dirent_position() -> ptr mut u8 {
+    let size = _dirent_position_size();
+    if size == 0 {
+        let zero: u64 = 0;
+        return checked { @int_to_ptr(zero) };
+    }
+    let slot: ptr mut u8 = checked { @alloc(size, 8) };
+    if checked { @ptr_to_int(slot) } == 0 {
+        @panic("out of memory");
+    }
+    let mut i: u64 = 0;
+    while i < size {
+        checked { @ptr_write(@ptr_offset(slot, i), 0); };
+        i += 1;
+    }
+    slot
+}
+
+// Release the position slot. Returns before reaching `@free` where the slot was
+// never allocated, so Linux makes no allocator call at all rather than relying
+// on `@free(null, 0, ..)` being a runtime no-op.
+fn _free_dirent_position(position: ptr mut u8) {
+    let size = _dirent_position_size();
+    if size == 0 {
+        return;
+    }
+    checked { @free(position, size, 8); };
+}
+
+// `d_type` values (identical on Linux and macOS).
+fn _dt_unknown() -> u8 { 0 }
+fn _dt_dir() -> u8 { 4 }
+fn _dt_reg() -> u8 { 8 }
+fn _dt_lnk() -> u8 { 10 }
+
+// What a directory entry is. `Symlink` is the link itself (entries are never
+// resolved through their targets), and `Other` covers sockets, FIFOs, devices,
+// and an entry whose type could not be determined at all.
+pub enum FileKind {
+    File,
+    Dir,
+    Symlink,
+    Other,
+}
+
+// `FileKind` as a `u8`, so the per-entry kind can live in an `ArrayBuf(u8)`
+// alongside the pooled names (see `DirEntries`). These codes are an internal
+// storage detail and are never exposed; `DirEntries.kind` decodes them.
+fn _KIND_FILE() -> u8 { 0 }
+fn _KIND_DIR() -> u8 { 1 }
+fn _KIND_SYMLINK() -> u8 { 2 }
+fn _KIND_OTHER() -> u8 { 3 }
+
+fn _kind_of_code(code: u8) -> FileKind {
+    if code == _KIND_DIR() {
+        FileKind.Dir
+    } else if code == _KIND_SYMLINK() {
+        FileKind.Symlink
+    } else if code == _KIND_OTHER() {
+        FileKind.Other
+    } else {
+        FileKind.File
+    }
+}
+
+// Resolve an entry's kind from its `d_type`, falling back to a no-follow stat of
+// `path` when the filesystem reported DT_UNKNOWN. See the DT_UNKNOWN note above
+// for why the fallback exists and why a failed fallback is `Other`.
+fn _kind_for(dtype: u8, borrow path: strbuf.StrBuf) -> u8 {
+    if dtype == _dt_dir() {
+        return _KIND_DIR();
+    }
+    if dtype == _dt_reg() {
+        return _KIND_FILE();
+    }
+    if dtype == _dt_lnk() {
+        return _KIND_SYMLINK();
+    }
+    if dtype != _dt_unknown() {
+        return _KIND_OTHER();
+    }
+    let MR = result.Result(Metadata, FileError);
+    match _metadata_at(borrow path, _at_symlink_nofollow()) {
+        MR.Ok(md) => {
+            if md.is_dir() {
+                _KIND_DIR()
+            } else if md.is_file() {
+                _KIND_FILE()
+            } else if md.is_symlink() {
+                _KIND_SYMLINK()
+            } else {
+                _KIND_OTHER()
+            }
+        },
+        MR.Err(_e) => _KIND_OTHER(),
+    }
+}
+
+// A directory listing: the result of `read_dir` (one directory) or `walk` (a
+// whole tree). Entries are in a deterministic order — see the ordering note
+// above — and never include `.` or `..`.
+//
+//     let DR = std.result.Result(std.fs.DirEntries, std.fs.FileError);
+//     let listing = match std.fs.read_dir(borrow dir) { DR.Ok(d) => d, ... };
+//     let mut i: u64 = 0;
+//     while i < listing.len() {
+//         let p = listing.path(i);   // "content/post.md" — ready for File.open
+//         let n = listing.name(i);   // "post.md"
+//         if listing.is_dir(i) { ... }
+//         i += 1;
+//     }
+//
+// STORAGE. A listing needs INDEXED access to its entries — `path(i)` and
+// `name(i)` at an arbitrary `i`, repeatedly, without consuming the listing — and
+// that is exactly what an `ArrayBuf(StrBuf)` cannot give: its by-copy reads
+// (`get`/`get_or`) are gated for drop-glue element types, because the copy would
+// alias the element's owned buffer (E0711, RUE-651). Storing and moving such
+// elements is fine, which is why `walk` can keep its pending stack in an
+// `ArrayBuf(StrBuf)` it only ever pushes to and pops from.
+//
+// So this uses the pooled layout `std.strmap` and `examples/ruelex/interner.rue`
+// already use for the same reason: every entry's PATH is concatenated into one
+// `paths: StrBuf`, with parallel u64 arrays recording where each one starts and
+// how long it is. `name_offs` holds the offset of the base name WITHIN its path,
+// so `path(i)` and `name(i)` are both slices of the same pooled bytes and
+// neither costs a second copy of the parent prefix.
+pub struct DirEntries {
+    // Every entry's full path, concatenated.
+    paths: strbuf.StrBuf,
+    // Per entry: start byte in `paths`, byte length, offset of the base name
+    // within the path, and the `_KIND_*` code.
+    offs: arraybuf.ArrayBuf(u64),
+    lens: arraybuf.ArrayBuf(u64),
+    name_offs: arraybuf.ArrayBuf(u64),
+    kinds: arraybuf.ArrayBuf(u8),
+
+    fn new() -> Self {
+        let U64s = arraybuf.ArrayBuf(u64);
+        let U8s = arraybuf.ArrayBuf(u8);
+        Self {
+            paths: strbuf.StrBuf.new(),
+            offs: U64s.new(),
+            lens: U64s.new(),
+            name_offs: U64s.new(),
+            kinds: U8s.new(),
+        }
+    }
+
+    // Number of entries.
+    fn len(borrow self) -> u64 {
+        self.offs.len()
+    }
+
+    fn is_empty(borrow self) -> bool {
+        self.offs.len() == 0
+    }
+
+    // Entry `i`'s path, as an owned byte string that can be handed straight to
+    // `File.open` / `fs.metadata`. For `read_dir` this is the listed directory
+    // joined with the entry's name; for `walk` it is the walk root joined with
+    // every component down to the entry. Traps on an out-of-range index.
+    fn path(borrow self, i: u64) -> strbuf.StrBuf {
+        if i >= self.offs.len() {
+            @panic("index out of bounds");
+        }
+        self.paths.byte_range(self.offs.get_or(i, 0), self.lens.get_or(i, 0))
+    }
+
+    // Entry `i`'s base name — the final path component, with no parent prefix.
+    // Traps on an out-of-range index.
+    fn name(borrow self, i: u64) -> strbuf.StrBuf {
+        if i >= self.offs.len() {
+            @panic("index out of bounds");
+        }
+        let name_off = self.name_offs.get_or(i, 0);
+        self.paths.byte_range(
+            self.offs.get_or(i, 0) + name_off,
+            self.lens.get_or(i, 0) - name_off,
+        )
+    }
+
+    // Entry `i`'s kind. Traps on an out-of-range index.
+    fn kind(borrow self, i: u64) -> FileKind {
+        if i >= self.offs.len() {
+            @panic("index out of bounds");
+        }
+        _kind_of_code(self.kinds.get_or(i, 0))
+    }
+
+    // Whether entry `i` is a directory. False for a symlink TO a directory:
+    // entries describe themselves, never their targets.
+    fn is_dir(borrow self, i: u64) -> bool {
+        if i >= self.offs.len() {
+            @panic("index out of bounds");
+        }
+        self.kinds.get_or(i, 0) == _KIND_DIR()
+    }
+
+    // Whether entry `i` is a regular file.
+    fn is_file(borrow self, i: u64) -> bool {
+        if i >= self.offs.len() {
+            @panic("index out of bounds");
+        }
+        self.kinds.get_or(i, 0) == _KIND_FILE()
+    }
+
+    // Append one entry. `full` is its complete path and `name_begin` the offset
+    // of the base name within it. Internal: listings are built here, not by
+    // callers.
+    fn _push(inout self, borrow full: strbuf.StrBuf, name_begin: u64, kind: u8) {
+        let start = self.paths.len();
+        self.paths.append_borrowed(borrow full);
+        self.offs.push(start);
+        self.lens.push(full.len());
+        self.name_offs.push(name_begin);
+        self.kinds.push(kind);
+    }
+}
+
+// Byte `k` of entry `i`'s base name, or 0 past its end (callers stay in range).
+fn _entry_name_byte(borrow entries: DirEntries, i: u64, k: u64) -> u8 {
+    let O = option.Option(u8);
+    let start = entries.offs.get_or(i, 0) + entries.name_offs.get_or(i, 0);
+    match entries.paths.byte_at(start + k) {
+        O.Some(b) => b,
+        O.None => 0,
+    }
+}
+
+fn _entry_name_len(borrow entries: DirEntries, i: u64) -> u64 {
+    entries.lens.get_or(i, 0) - entries.name_offs.get_or(i, 0)
+}
+
+// Byte-lexicographic "entry `a`'s name sorts before entry `b`'s". A prefix sorts
+// before the name that extends it, which is ordinary byte order.
+fn _name_before(borrow entries: DirEntries, a: u64, b: u64) -> bool {
+    let la = _entry_name_len(borrow entries, a);
+    let lb = _entry_name_len(borrow entries, b);
+    let shared = if la < lb { la } else { lb };
+    let mut k: u64 = 0;
+    while k < shared {
+        let x = _entry_name_byte(borrow entries, a, k);
+        let y = _entry_name_byte(borrow entries, b, k);
+        if x != y {
+            return x < y;
+        }
+        k += 1;
+    }
+    la < lb
+}
+
+// The permutation that puts `entries` in ascending base-name order, as a
+// bottom-up merge sort over indices. Bottom-up because it needs no recursion,
+// and O(n log n) because content directories are not always small. Stable,
+// though names within one directory are unique so stability is not load-bearing.
+fn _sorted_order(borrow entries: DirEntries) -> arraybuf.ArrayBuf(u64) {
+    let U64s = arraybuf.ArrayBuf(u64);
+    let n = entries.offs.len();
+    let mut order = U64s.with_capacity(n);
+    let mut i: u64 = 0;
+    while i < n {
+        order.push(i);
+        i += 1;
+    }
+    if n < 2 {
+        return order;
+    }
+    let mut scratch = U64s.with_capacity(n);
+    i = 0;
+    while i < n {
+        scratch.push(0);
+        i += 1;
+    }
+
+    let mut width: u64 = 1;
+    while width < n {
+        let mut lo: u64 = 0;
+        while lo < n {
+            let mid = if lo + width < n { lo + width } else { n };
+            let hi = if mid + width < n { mid + width } else { n };
+            let mut a = lo;
+            let mut b = mid;
+            let mut out = lo;
+            while out < hi {
+                let take_a = if a >= mid {
+                    false
+                } else if b >= hi {
+                    true
+                } else {
+                    // `!(b before a)` rather than `a before b`, so equal keys
+                    // keep their relative order (stability).
+                    !_name_before(borrow entries, order.get_or(b, 0), order.get_or(a, 0))
+                };
+                if take_a {
+                    scratch.set(out, order.get_or(a, 0));
+                    a += 1;
+                } else {
+                    scratch.set(out, order.get_or(b, 0));
+                    b += 1;
+                }
+                out += 1;
+            }
+            lo = hi;
+        }
+        let mut k: u64 = 0;
+        while k < n {
+            order.set(k, scratch.get_or(k, 0));
+            k += 1;
+        }
+        width *= 2;
+    }
+    order
+}
+
+// Rebuild a listing in `order`. Copying into a fresh value rather than permuting
+// in place keeps the pooled bytes contiguous in listing order and avoids an
+// in-place permutation of five parallel structures.
+fn _reorder(borrow entries: DirEntries, borrow order: arraybuf.ArrayBuf(u64)) -> DirEntries {
+    let mut out = DirEntries.new();
+    let n = order.len();
+    let mut k: u64 = 0;
+    while k < n {
+        let i = order.get_or(k, 0);
+        let piece = entries.paths.byte_range(entries.offs.get_or(i, 0), entries.lens.get_or(i, 0));
+        out._push(borrow piece, entries.name_offs.get_or(i, 0), entries.kinds.get_or(i, 0));
+        k += 1;
+    }
+    out
+}
+
+// `parent` joined with the `name_len` bytes at `buf[name_start..]`. One
+// separator is inserted unless `parent` is empty or already ends with one, so
+// `read_dir("a")` and `read_dir("a/")` both produce `a/x`.
+fn _join_entry_path(
+    borrow parent: strbuf.StrBuf,
+    buf: ptr mut u8,
+    name_start: u64,
+    name_len: u64,
+) -> strbuf.StrBuf {
+    let O = option.Option(u8);
+    let mut out = strbuf.StrBuf.with_capacity(parent.len() + 1 + name_len);
+    out.append_borrowed(borrow parent);
+    if parent.len() > 0 {
+        let last = match parent.byte_at(parent.len() - 1) {
+            O.Some(b) => b,
+            O.None => 0,
+        };
+        if last != _path_separator() {
+            out.push(_path_separator());
+        }
+    }
+    let mut i: u64 = 0;
+    while i < name_len {
+        let b = checked { @ptr_read(@ptr_offset(buf, name_start + i)) };
+        out.push(b);
+        i += 1;
+    }
+    out
+}
+
+// Whether the `len` bytes at `buf[start..]` are `.` or `..`.
+fn _is_dot_entry(buf: ptr mut u8, start: u64, len: u64) -> bool {
+    let dot: u8 = 46; // '.'
+    if len == 1 {
+        let b0 = checked { @ptr_read(@ptr_offset(buf, start)) };
+        return b0 == dot;
+    }
+    if len == 2 {
+        let b0 = checked { @ptr_read(@ptr_offset(buf, start)) };
+        let b1 = checked { @ptr_read(@ptr_offset(buf, start + 1)) };
+        return b0 == dot && b1 == dot;
+    }
+    false
+}
+
+// Scan one filled getdents64 buffer — `n` bytes of packed records — appending
+// every entry but `.`/`..` to `out`. Walks by `d_reclen`; a zero or
+// out-of-range `d_reclen` stops the scan rather than spinning or reading past
+// the returned bytes.
+//
+// EVERY read is bounded by `n`, including the fixed header. A record's own
+// `d_reclen` cannot be trusted to bound the header that contains it, so the
+// header is bounded first: `name_off` (19 or 21) exceeds every fixed field
+// offset — d_reclen's two bytes at 16..18 and d_type at 18 or 20 — so one
+// `n - off >= name_off` check covers them all and also proves the name start is
+// in range. Without it a run of one-byte `d_reclen`s would advance `off` to
+// `n - 1` and read up to `name_off - 1` bytes past the allocation.
+fn _scan_dirents(
+    buf: ptr mut u8,
+    n: u64,
+    borrow parent: strbuf.StrBuf,
+    inout out: DirEntries,
+) {
+    let type_off = _dirent_type_offset();
+    let name_off = _dirent_name_offset();
+    let mut off: u64 = 0;
+    while off < n {
+        // The fixed header plus at least an empty name must be inside `n`.
+        if n - off < name_off {
+            return;
+        }
+        // d_reclen is a little-endian u16 at offset 16 on every target.
+        let r0 = checked { @ptr_read(@ptr_offset(buf, off + 16)) };
+        let r1 = checked { @ptr_read(@ptr_offset(buf, off + 17)) };
+        let reclen: u64 = @intCast(binary.u16_from_le_bytes([r0, r1]));
+        if reclen == 0 {
+            return;
+        }
+        if reclen > n - off {
+            return;
+        }
+        let record_end = off + reclen;
+        let dtype = checked { @ptr_read(@ptr_offset(buf, off + type_off)) };
+
+        // The name is NUL-terminated, but the record end bounds it too, so a
+        // record with no terminator cannot read past the returned bytes.
+        let name_start = off + name_off;
+        let mut name_len: u64 = 0;
+        while name_start + name_len < record_end {
+            let b: u8 = checked { @ptr_read(@ptr_offset(buf, name_start + name_len)) };
+            if b == 0 {
+                break;
+            }
+            name_len += 1;
+        }
+
+        if name_len > 0 && !_is_dot_entry(buf, name_start, name_len) {
+            let full = _join_entry_path(borrow parent, buf, name_start, name_len);
+            let kind = _kind_for(dtype, borrow full);
+            let name_begin = full.len() - name_len;
+            out._push(borrow full, name_begin, kind);
+        }
+        off = record_end;
+    }
+}
+
+// List the entries of directory `path`, excluding `.` and `..`, in ascending
+// base-name byte order.
+//
+// Each entry's `path(i)` is `path` joined with its name, so it can be opened or
+// stat'd directly. `Err` cases are the ordinary normalized ones: a missing path
+// is `NotFound`, an unreadable one `PermissionDenied`, and a path that is not a
+// directory arrives as ENOTDIR through `Other`. A SYMLINK to a directory is
+// followed and listed, as it is for `File.open`; only entries WITHIN a listing
+// are left unresolved (`FileKind.Symlink`).
+//
+// The listing is a SNAPSHOT assembled over one or more getdents64 calls, not an
+// atomic view: a directory being modified concurrently may list an entry that is
+// gone by the time the caller opens it. That is inherent to the syscall, not to
+// this wrapper.
+pub fn read_dir(borrow path: strbuf.StrBuf) -> result.Result(DirEntries, FileError) {
+    let R = result.Result(DirEntries, FileError);
+    let FR = result.Result(File, FileError);
+
+    // O_DIRECTORY moves the "not a directory" rejection to the open, so no
+    // descriptor for a non-directory is ever held (see `_o_directory`). The
+    // `File` is owned, so the fd closes on every exit from here.
+    let dir = match File._open_with(borrow path, _o_rdonly() | _o_directory(), 0) {
+        FR.Ok(f) => f,
+        FR.Err(e) => {
+            return R.Err(e);
+        },
+    };
+    let fd_u: u64 = @intCast(dir.fd);
+
+    let cap = _dirent_buf_size();
+    let buf: ptr mut u8 = checked { @alloc(cap, 8) };
+    if checked { @ptr_to_int(buf) } == 0 {
+        @panic("out of memory");
+    }
+    let base: u64 = checked { @ptr_to_int(buf) };
+
+    // Darwin's `off_t *position` argument; null on Linux, which ignores it.
+    // Passing it unconditionally keeps one call site for both kernels, while
+    // `_alloc_dirent_position` keeps the allocation itself Darwin-only.
+    let position = _alloc_dirent_position();
+    let posaddr: u64 = checked { @ptr_to_int(position) };
+
+    let mut entries = DirEntries.new();
+    let mut failure = FileError.Other(0);
+    let mut failed = false;
+    let mut reading = true;
+    while reading {
+        let ret: i64 = checked { @syscall(_sys_getdents(), fd_u, base, cap, posaddr) };
+        if ret < 0 {
+            let e = _normalize_errno(0 - ret);
+            // EINTR is retried here, unlike in `File.read`/`File.write`, which
+            // surface it (ADR-0057 §3). The module's rule is that single-syscall
+            // primitives surface `Interrupted` so the caller can decide, while
+            // LOOPING operations retry it themselves — `write_all` already does
+            // exactly this next to `write`. `read_dir` is a loop with state the
+            // caller cannot see: a partially built listing and a kernel-side
+            // directory offset. Returning `Interrupted` from the middle of it
+            // would hand back a half-built listing or force a restart from the
+            // beginning, neither of which the caller can do anything useful with.
+            let retry = match e {
+                FileError.Interrupted => true,
+                _ => false,
+            };
+            if !retry {
+                failure = e;
+                failed = true;
+                reading = false;
+            }
+        } else if ret == 0 {
+            // Exhausted. A SHORT non-zero return is normal and must not stop the
+            // loop — only 0 ends it.
+            reading = false;
+        } else {
+            let filled: u64 = @intCast(ret);
+            _scan_dirents(buf, filled, borrow path, inout entries);
+        }
+    }
+
+    checked { @free(buf, cap, 8); };
+    _free_dirent_position(position);
+
+    if failed {
+        return R.Err(failure);
+    }
+    let order = _sorted_order(borrow entries);
+    R.Ok(_reorder(borrow entries, borrow order))
+}
+
+// Every entry in the tree rooted at `root`, excluding `root` itself and every
+// `.`/`..`, in deterministic depth-first PRE-ORDER: each directory is listed
+// before its contents, and siblings are in the same ascending base-name byte
+// order `read_dir` produces. This is the content-tree scan an SSG needs, and the
+// order is reproducible across runs, filesystems, and machines.
+//
+// Symlinks are NOT followed. A symlink to a directory is reported as
+// `FileKind.Symlink` and is not descended into, so the walk cannot loop and
+// cannot leave the tree.
+//
+// Any directory that fails to open or read fails the whole walk with that error,
+// rather than silently returning a partial tree — a half-scanned content
+// directory would produce a quietly wrong site, which is the failure mode this
+// module exists to avoid.
+//
+// The traversal is iterative over an explicit pending stack, so tree depth costs
+// heap rather than call frames.
+pub fn walk(borrow root: strbuf.StrBuf) -> result.Result(DirEntries, FileError) {
+    let R = result.Result(DirEntries, FileError);
+    let DR = result.Result(DirEntries, FileError);
+    let Paths = arraybuf.ArrayBuf(strbuf.StrBuf);
+    let U64s = arraybuf.ArrayBuf(u64);
+    let U8s = arraybuf.ArrayBuf(u8);
+    let OP = option.Option(strbuf.StrBuf);
+
+    let mut out = DirEntries.new();
+
+    // Entries still to emit, most-recently-pushed first. A level is pushed in
+    // REVERSE, so popping yields ascending order and a directory's subtree is
+    // emitted immediately after the directory itself.
+    let mut pending_paths = Paths.new();
+    let mut pending_name_offs = U64s.new();
+    let mut pending_kinds = U8s.new();
+
+    let first = match read_dir(borrow root) {
+        DR.Ok(listing) => listing,
+        DR.Err(e) => {
+            return R.Err(e);
+        },
+    };
+    _push_level_reversed(
+        borrow first,
+        inout pending_paths,
+        inout pending_name_offs,
+        inout pending_kinds,
+    );
+
+    while pending_paths.len() > 0 {
+        let entry_path = match pending_paths.pop() {
+            OP.Some(p) => p,
+            OP.None => {
+                return R.Ok(out);
+            },
+        };
+        let name_off = pending_name_offs.pop_or(0);
+        let kind = pending_kinds.pop_or(0);
+        out._push(borrow entry_path, name_off, kind);
+
+        if kind == _KIND_DIR() {
+            let listing = match read_dir(borrow entry_path) {
+                DR.Ok(l) => l,
+                DR.Err(e) => {
+                    return R.Err(e);
+                },
+            };
+            _push_level_reversed(
+                borrow listing,
+                inout pending_paths,
+                inout pending_name_offs,
+                inout pending_kinds,
+            );
+        }
+    }
+
+    R.Ok(out)
+}
+
+// Push a listing onto the walk's pending stack in reverse index order, so the
+// stack pops it back in ascending order.
+fn _push_level_reversed(
+    borrow listing: DirEntries,
+    inout paths: arraybuf.ArrayBuf(strbuf.StrBuf),
+    inout name_offs: arraybuf.ArrayBuf(u64),
+    inout kinds: arraybuf.ArrayBuf(u8),
+) {
+    let mut i = listing.offs.len();
+    while i > 0 {
+        i -= 1;
+        paths.push(listing.path(i));
+        name_offs.push(listing.name_offs.get_or(i, 0));
+        kinds.push(listing.kinds.get_or(i, 0));
     }
 }


### PR DESCRIPTION
Closes RUE-1481.

ADR-0072 Phase 2a (Decision 6): `std.fs` can discover a content tree by itself. An SSG that needs a hand-written file manifest is not credibly comparable to Zola or Hugo, and ADR-0057 left directory enumeration as its largest deferred chunk.

## What this adds

- **`fs.read_dir(path)`** lists one directory over `getdents64` (Linux) / `getdirentries64` (Darwin), pure Rue through `@syscall` like the rest of the module. Records are walked by their own `d_reclen`, the kernel buffer is refilled until the syscall returns 0, and `.`/`..` are filtered out. Every read is bounded by the returned byte count, the fixed header included, so a malformed `d_reclen` cannot walk off the buffer.
- **`fs.walk(root)`** scans a tree depth-first in pre-order over an explicit pending stack, so tree depth costs heap rather than call frames. Symlinks are not followed, so a walk cannot loop or leave the tree.
- **Ordering is part of the contract**, not a nicety — downstream output reproducibility depends on it. Entries are sorted by base-name bytes. `std.sort` cannot express this (it is comparator-free, and its by-copy element reads are gated for drop-glue types), so ordering is a bottom-up merge sort over an index permutation with a byte-lexicographic comparator.
- **`DirEntries`** stores paths in one pooled `StrBuf` with parallel index arrays — the layout `std.strmap` and the ruelex interner already use, for the same reason. `path(i)` is directly openable; `name(i)` is the base name.
- **DT_UNKNOWN** is resolved with a `newfstatat(AT_SYMLINK_NOFOLLOW)` fallback rather than silently mis-typing entries.

Byte-string paths throughout; no path type is introduced, consistent with the existing fs module.

## Platform reach

Linux x86-64 and aarch64, plus aarch64-macos. The macOS leg is included because the `@syscall` carry-flag error-detection gap that previously ruled it out no longer exists on that target — RUE-945 landed the Darwin carry-flag normalization in July — and the error paths were verified executing natively. That gap does remain open on x86-64-macos, which is not a Rue target.

One known limitation is documented in the module: Darwin `stat` decoding is currently broken by a wrong trap number, so a DT_UNKNOWN entry on macOS degrades to `FileKind.Other` rather than resolving. APFS and HFS+ both populate `d_type`, so the fallback is unreachable there in practice. Root cause and one-line remedy are recorded in RUE-1487.

## Test coverage

`crates/rue-cli-tests/cases/fs_read_dir.toml` runs the real compiler against real directory trees on all three targets: empty directory, `.`/`..` exclusion, mixed files and directories across three name lengths, entry paths that actually open, trailing-separator joining, nested pre-order walk, creation-order-independent ordering, a 600-entry directory forcing at least three syscall refills, the missing-path and not-a-directory error paths, listing through a directory symlink, and a walk over a tree seeded with directory, `..`, and self-referential symlinks that must be reported as `FileKind.Symlink` and never descended.

Pinning symlink behavior needs symlinks the harness can stage — `files` entries only produce regular files — so cases gain an optional `symlinks = [{ link, target }]` list. Targets are written verbatim and never resolved, so dangling, cyclic, and created-at-run-time targets are all legitimate fixtures.

## Verification

Adversarial review found no correctness defects in the new code, and confirmed by mutation testing that the ordering and refill-loop tests are load-bearing rather than smoke: neutering the sort fails four cases, and short-circuiting the refill loop fails the 600-entry case. File-descriptor hygiene was checked by running 400,000 failing walks and observing 1.2 MB peak RSS. Review also prompted three fixes carried here: the record-header reads are now bounded by the returned byte count (previously only the name loop was), the Darwin position slot is no longer allocated on Linux, and the `O_DIRECTORY` test claim was replaced with a directory-symlink case that actually discriminates the constant.

`scripts/rue cli fs_` — 19 passed, 0 failed. `scripts/rue unit cli-tests` — 36 passed. `scripts/rue quick` — 31 targets, 0 failures.
