### PR TITLE
RUE-1482: add substring find, split, replace, join, and lines to std

### DIFF
--- a/crates/rue-cli-tests/cases/std_m3.toml
+++ b/crates/rue-cli-tests/cases/std_m3.toml
@@ -119,6 +119,393 @@ fn main() -> i32 {
 }
 """ }]
 
+# Substring search (RUE-1482, ADR-0072 Phase 2b). The needle is a `borrow str`
+# — the universal read interface over literals, Str(N), and StrBuf — and the
+# answer is an Option(u64) byte offset, the same shape as the single-byte
+# `find`/`rfind` next to it. The empty-needle rule ("matches at every byte
+# boundary") and the needle-longer-than-haystack rule are pinned here for both
+# the std.strings free functions and the StrBuf methods underneath them.
+[[case]]
+name = "std_strings_substring_find"
+description = "find_str/rfind_str plus the StrBuf matches_at/find_str_from/contains/starts_with/ends_with primitives, including empty, oversized, overlapping, and non-ASCII needles, and the borrowed haystack (42 checks -> exit 68)."
+env = { RUE_STD_PATH = "${REAL_STD}" }
+args = ["main.rue", "-o", "prog"]
+exit_code = 68
+files = [{ path = "main.rue", source = """
+const std = @import("std");
+const StrBuf = std.strbuf.StrBuf;
+
+fn at(found: std.option.Option(u64), expected: u64) -> bool {
+    let O = std.option.Option(u64);
+    match found {
+        O.Some(i) => i == expected,
+        O.None => false,
+    }
+}
+
+fn absent(found: std.option.Option(u64)) -> bool {
+    let O = std.option.Option(u64);
+    match found {
+        O.Some(_) => false,
+        O.None => true,
+    }
+}
+
+fn main() -> i32 {
+    let mut score: i32 = 0;
+
+    if at(std.strings.find_str(borrow "hello world", borrow "o w"), 4) { score = score + 1; }
+    if at(std.strings.find_str(borrow "banana", borrow "na"), 2) { score = score + 1; }
+    if at(std.strings.rfind_str(borrow "banana", borrow "na"), 4) { score = score + 1; }
+    if at(std.strings.find_str(borrow "banana", borrow "ban"), 0) { score = score + 1; }
+    if absent(std.strings.find_str(borrow "banana", borrow "x")) { score = score + 1; }
+
+    // A needle longer than the haystack never matches.
+    if absent(std.strings.find_str(borrow "abc", borrow "abcd")) { score = score + 1; }
+    if absent(std.strings.rfind_str(borrow "abc", borrow "abcd")) { score = score + 1; }
+    if absent(std.strings.find_str(borrow "", borrow "a")) { score = score + 1; }
+
+    // An empty needle matches at every byte boundary: first at 0, last at len.
+    if at(std.strings.find_str(borrow "abc", borrow ""), 0) { score = score + 1; }
+    if at(std.strings.rfind_str(borrow "abc", borrow ""), 3) { score = score + 1; }
+    if at(std.strings.find_str(borrow "", borrow ""), 0) { score = score + 1; }
+    if at(std.strings.rfind_str(borrow "", borrow ""), 0) { score = score + 1; }
+
+    // Overlapping candidates: find takes the first, rfind the last.
+    if at(std.strings.find_str(borrow "aaa", borrow "aa"), 0) { score = score + 1; }
+    if at(std.strings.rfind_str(borrow "aaa", borrow "aa"), 1) { score = score + 1; }
+
+    // Bytes, not scalars (ADR-0035): 'é' is two bytes at offset 3 of "café".
+    if at(std.strings.find_str(borrow "café", borrow "é"), 3) { score = score + 1; }
+
+    // The StrBuf primitives the free functions delegate to.
+    let h: StrBuf = "banana";
+    if at(h.find_str(borrow "na"), 2) { score = score + 1; }
+    if at(h.rfind_str(borrow "na"), 4) { score = score + 1; }
+    if at(h.find_str_from(borrow "na", 3), 4) { score = score + 1; }
+    if absent(h.find_str_from(borrow "na", 5)) { score = score + 1; }
+    if at(h.find_str_from(borrow "", 6), 6) { score = score + 1; }
+    if absent(h.find_str_from(borrow "na", 7)) { score = score + 1; }
+    if h.matches_at(2, borrow "nan") { score = score + 1; }
+    if !h.matches_at(1, borrow "nan") { score = score + 1; }
+    if !h.matches_at(4, borrow "nana") { score = score + 1; }
+    if h.matches_at(6, borrow "") { score = score + 1; }
+    if !h.matches_at(7, borrow "") { score = score + 1; }
+
+    // contains is now find_str, so the two agree on every needle.
+    if h.contains(borrow "nan") { score = score + 1; }
+    if !h.contains(borrow "xyz") { score = score + 1; }
+    if h.contains(borrow "") { score = score + 1; }
+
+    // ends_with, and starts_with now that it is matches_at(0, prefix). The
+    // over-long prefix/suffix checks pin the guard equivalence: matches_at's
+    // "runs past the end" guard has to reject exactly what the hand-written
+    // length guards used to reject (spec 3.7:29 for starts_with).
+    if h.ends_with(borrow "ana") { score = score + 1; }
+    if !h.ends_with(borrow "nan") { score = score + 1; }
+    if h.ends_with(borrow "") { score = score + 1; }
+    if !h.ends_with(borrow "bananas") { score = score + 1; }
+    if h.starts_with(borrow "ban") { score = score + 1; }
+    if !h.starts_with(borrow "nan") { score = score + 1; }
+    if h.starts_with(borrow "") { score = score + 1; }
+    if !h.starts_with(borrow "bananas") { score = score + 1; }
+    let e: StrBuf = "";
+    if e.ends_with(borrow "") && e.starts_with(borrow "") { score = score + 1; }
+    if !e.ends_with(borrow "a") { score = score + 1; }
+
+    // The free functions BORROW their haystack, so `h` survives both calls and
+    // remains readable afterwards.
+    if at(std.strings.find_str(borrow h, borrow "na"), 2) { score = score + 1; }
+    if at(std.strings.rfind_str(borrow h, borrow "na"), 4) { score = score + 1; }
+    if h.len() == 6 { score = score + 1; }
+
+    if score == 42 { 68 } else { @intCast(score) }
+}
+""" }]
+
+# Splitting (RUE-1482). Separators are dropped and a split always yields one
+# more piece than there were separators, so leading, trailing, and consecutive
+# separators each produce an empty piece and splitting "" yields one empty
+# piece. The empty separator follows the same every-byte-boundary rule as the
+# empty needle above. Each result is rendered by joining it back with '|', which
+# pins piece ORDER as well as piece contents.
+[[case]]
+name = "std_strings_split"
+description = "split by byte and by substring: separator dropping, empty/leading/trailing/consecutive separators, non-overlapping matches, oversized and empty separators, and the borrowed haystack (26 checks -> exit 69)."
+env = { RUE_STD_PATH = "${REAL_STD}" }
+args = ["main.rue", "-o", "prog"]
+exit_code = 69
+files = [{ path = "main.rue", source = """
+const std = @import("std");
+const StrBuf = std.strbuf.StrBuf;
+
+fn render(parts: std.arraybuf.ArrayBuf(std.strbuf.StrBuf)) -> StrBuf {
+    std.strings.join(parts, borrow "|")
+}
+
+fn main() -> i32 {
+    let mut score: i32 = 0;
+
+    let p1 = std.strings.split(borrow "a,b,,c", 44);
+    if p1.len() == 4 { score = score + 1; }
+    let r1 = render(p1);
+    if r1 == "a|b||c" { score = score + 1; }
+
+    // A leading and a trailing separator each produce an empty piece.
+    let p2 = std.strings.split(borrow ",a,", 44);
+    if p2.len() == 3 { score = score + 1; }
+    let r2 = render(p2);
+    if r2 == "|a|" { score = score + 1; }
+
+    // The empty string is one empty piece, not zero pieces.
+    let p3 = std.strings.split(borrow "", 44);
+    if p3.len() == 1 { score = score + 1; }
+    let r3 = render(p3);
+    if r3.len() == 0 { score = score + 1; }
+
+    // No separator at all: the whole string, unsplit.
+    let p4 = std.strings.split(borrow "abc", 44);
+    if p4.len() == 1 { score = score + 1; }
+    let r4 = render(p4);
+    if r4 == "abc" { score = score + 1; }
+
+    let p5 = std.strings.split_str(borrow "a::b::c", borrow "::");
+    if p5.len() == 3 { score = score + 1; }
+    let r5 = render(p5);
+    if r5 == "a|b|c" { score = score + 1; }
+
+    let p6 = std.strings.split_str(borrow "::a::", borrow "::");
+    if p6.len() == 3 { score = score + 1; }
+    let r6 = render(p6);
+    if r6 == "|a|" { score = score + 1; }
+
+    // Non-overlapping, left to right: "aaaa" has two "aa" matches, not three.
+    let p7 = std.strings.split_str(borrow "aaaa", borrow "aa");
+    if p7.len() == 3 { score = score + 1; }
+    let r7 = render(p7);
+    if r7 == "||" { score = score + 1; }
+
+    // An empty separator matches at every byte boundary, so each byte comes
+    // back bracketed by the boundary matches at the two ends.
+    let p8 = std.strings.split_str(borrow "abc", borrow "");
+    if p8.len() == 5 { score = score + 1; }
+    let r8 = render(p8);
+    if r8 == "|a|b|c|" { score = score + 1; }
+
+    let p9 = std.strings.split_str(borrow "", borrow "");
+    if p9.len() == 2 { score = score + 1; }
+    let r9 = render(p9);
+    if r9 == "|" { score = score + 1; }
+
+    // Separator longer than the haystack, and no match at all.
+    let p10 = std.strings.split_str(borrow "ab", borrow "abcd");
+    if p10.len() == 1 { score = score + 1; }
+    let r10 = render(p10);
+    if r10 == "ab" { score = score + 1; }
+
+    let p11 = std.strings.split_str(borrow "", borrow "x");
+    if p11.len() == 1 { score = score + 1; }
+    let r11 = render(p11);
+    if r11.len() == 0 { score = score + 1; }
+
+    // The haystack is borrowed, not consumed: one document can be split, split
+    // again by a different separator, and still read afterwards. The pieces are
+    // independent allocations, so they outlive nothing they should not.
+    let src: StrBuf = "a,b";
+    let s1 = std.strings.split(borrow src, 44);
+    if s1.len() == 2 { score = score + 1; }
+    let s2 = std.strings.split_str(borrow src, borrow ",");
+    if s2.len() == 2 { score = score + 1; }
+    let rs = render(s2);
+    if rs == "a|b" { score = score + 1; }
+    if src == "a,b" { score = score + 1; }
+
+    if score == 26 { 69 } else { @intCast(score) }
+}
+""" }]
+
+# Replacement and joining (RUE-1482). `replace` takes non-overlapping matches
+# left to right and resumes AFTER the replaced needle, never inside the
+# replacement it just wrote, so a replacement containing its own needle
+# terminates. `join` is the inverse of a non-empty-separator split, and its
+# separator appears exactly len-1 times.
+[[case]]
+name = "std_strings_replace_join"
+description = "replace over overlapping, absent, oversized, and empty needles with a borrowed haystack, and join over zero/one/many parts including a round trip through split (22 checks -> exit 70)."
+env = { RUE_STD_PATH = "${REAL_STD}" }
+args = ["main.rue", "-o", "prog"]
+exit_code = 70
+files = [{ path = "main.rue", source = """
+const std = @import("std");
+const StrBuf = std.strbuf.StrBuf;
+
+fn main() -> i32 {
+    let mut score: i32 = 0;
+
+    let a1 = std.strings.replace(borrow "hello", borrow "l", borrow "L");
+    if a1 == "heLLo" { score = score + 1; }
+
+    // Overlapping matches: "aaa" holds one non-overlapping "aa", then a tail.
+    let a2 = std.strings.replace(borrow "aaa", borrow "aa", borrow "b");
+    if a2 == "ba" { score = score + 1; }
+
+    // The replacement is never rescanned, so this terminates instead of looping.
+    let a3 = std.strings.replace(borrow "aa", borrow "a", borrow "aa");
+    if a3 == "aaaa" { score = score + 1; }
+
+    let a4 = std.strings.replace(borrow "abc", borrow "x", borrow "y");
+    if a4 == "abc" { score = score + 1; }
+
+    // A needle longer than the haystack leaves the string unchanged.
+    let a5 = std.strings.replace(borrow "abc", borrow "abcd", borrow "y");
+    if a5 == "abc" { score = score + 1; }
+
+    // An empty replacement deletes; a longer replacement grows.
+    let a6 = std.strings.replace(borrow "aXbXc", borrow "X", borrow "");
+    if a6 == "abc" { score = score + 1; }
+    let a7 = std.strings.replace(borrow "a,b", borrow ",", borrow ", ");
+    if a7 == "a, b" { score = score + 1; }
+
+    // An empty needle matches at every byte boundary.
+    let a8 = std.strings.replace(borrow "ab", borrow "", borrow "-");
+    if a8 == "-a-b-" { score = score + 1; }
+    let a9 = std.strings.replace(borrow "", borrow "", borrow "-");
+    if a9 == "-" { score = score + 1; }
+    let a10 = std.strings.replace(borrow "", borrow "x", borrow "y");
+    if a10.len() == 0 { score = score + 1; }
+
+    let a11 = std.strings.replace(borrow "mississippi", borrow "ss", borrow "S");
+    if a11 == "miSiSippi" { score = score + 1; }
+
+    let Parts = std.arraybuf.ArrayBuf(StrBuf);
+
+    // Zero parts join to the empty string; one part joins to itself.
+    let none = Parts.new();
+    let j0 = std.strings.join(none, borrow ", ");
+    if j0.len() == 0 { score = score + 1; }
+
+    let mut one = Parts.new();
+    let solo: StrBuf = "solo";
+    one.push(solo);
+    let j1 = std.strings.join(one, borrow ", ");
+    if j1 == "solo" { score = score + 1; }
+
+    let j2 = std.strings.join(std.strings.split(borrow "a,b,c", 44), borrow ", ");
+    if j2 == "a, b, c" { score = score + 1; }
+
+    // An empty separator just concatenates.
+    let j3 = std.strings.join(std.strings.split(borrow "a,b,c", 44), borrow "");
+    if j3 == "abc" { score = score + 1; }
+
+    // Empty pieces survive the round trip in both directions.
+    let j4 = std.strings.join(std.strings.split(borrow ",a,", 44), borrow "-");
+    if j4 == "-a-" { score = score + 1; }
+    let j5 = std.strings.join(std.strings.split(borrow "a,,b", 44), borrow ",");
+    if j5 == "a,,b" { score = score + 1; }
+    let j6 = std.strings.join(std.strings.split_str(borrow "x::y::z", borrow "::"), borrow "::");
+    if j6 == "x::y::z" { score = score + 1; }
+    let j7 = std.strings.join(std.strings.split_str(borrow "", borrow "::"), borrow "::");
+    if j7.len() == 0 { score = score + 1; }
+
+    // replace borrows its haystack: the original is unchanged and still usable,
+    // so a caller can run several substitutions over one source text.
+    let text: StrBuf = "a-b";
+    let t1 = std.strings.replace(borrow text, borrow "-", borrow "+");
+    if t1 == "a+b" { score = score + 1; }
+    let t2 = std.strings.replace(borrow text, borrow "-", borrow "");
+    if t2 == "ab" { score = score + 1; }
+    if text == "a-b" { score = score + 1; }
+
+    if score == 22 { 70 } else { @intCast(score) }
+}
+""" }]
+
+# Line iteration (RUE-1482). `lines` is the one place a terminator is not a
+# separator: a trailing newline ends the last line instead of starting an empty
+# one, and a '\\r' is stripped only when it immediately precedes the '\\n'.
+[[case]]
+name = "std_strings_lines"
+description = "lines over trailing newlines, CRLF, blank lines, lone CR, and empty input, with a borrowed document (20 checks -> exit 71)."
+env = { RUE_STD_PATH = "${REAL_STD}" }
+args = ["main.rue", "-o", "prog"]
+exit_code = 71
+files = [{ path = "main.rue", source = """
+const std = @import("std");
+const StrBuf = std.strbuf.StrBuf;
+
+fn render(parts: std.arraybuf.ArrayBuf(std.strbuf.StrBuf)) -> StrBuf {
+    std.strings.join(parts, borrow "|")
+}
+
+fn main() -> i32 {
+    let mut score: i32 = 0;
+
+    // A trailing newline terminates the last line; it does not add an empty one.
+    let l1 = std.strings.lines(borrow "a\\nb\\n");
+    if l1.len() == 2 { score = score + 1; }
+    let r1 = render(l1);
+    if r1 == "a|b" { score = score + 1; }
+
+    // An unterminated last line is still a line.
+    let l2 = std.strings.lines(borrow "a\\nb");
+    if l2.len() == 2 { score = score + 1; }
+    let r2 = render(l2);
+    if r2 == "a|b" { score = score + 1; }
+
+    // CRLF input: the '\\r' before each '\\n' is stripped.
+    let l3 = std.strings.lines(borrow "a\\r\\nb\\r\\n");
+    if l3.len() == 2 { score = score + 1; }
+    let r3 = render(l3);
+    if r3 == "a|b" { score = score + 1; }
+
+    let l4 = std.strings.lines(borrow "one\\r\\ntwo\\nthree");
+    if l4.len() == 3 { score = score + 1; }
+    let r4 = render(l4);
+    if r4 == "one|two|three" { score = score + 1; }
+
+    // A blank line between two terminators is a real empty line.
+    let l5 = std.strings.lines(borrow "a\\n\\nb");
+    if l5.len() == 3 { score = score + 1; }
+    let r5 = render(l5);
+    if r5 == "a||b" { score = score + 1; }
+
+    let l6 = std.strings.lines(borrow "a\\n\\n");
+    if l6.len() == 2 { score = score + 1; }
+    let r6 = render(l6);
+    if r6 == "a|" { score = score + 1; }
+
+    // Empty input has no lines at all.
+    let l7 = std.strings.lines(borrow "");
+    if l7.len() == 0 { score = score + 1; }
+
+    // A bare terminator is one empty line.
+    let l8 = std.strings.lines(borrow "\\n");
+    if l8.len() == 1 { score = score + 1; }
+    let l9 = std.strings.lines(borrow "\\r\\n");
+    if l9.len() == 1 { score = score + 1; }
+    let r9 = render(l9);
+    if r9.len() == 0 { score = score + 1; }
+
+    // A '\\r' NOT followed by '\\n' stays in its line.
+    let mut l10 = std.strings.lines(borrow "a\\r");
+    if l10.len() == 1 { score = score + 1; }
+    let OS = std.option.Option(StrBuf);
+    match l10.pop() {
+        OS.Some(line) => { if line == "a\\r" { score = score + 1; } },
+        OS.None => {},
+    }
+
+    // lines borrows its document: a parser can take the lines and still hold
+    // the source it read them from, with no defensive clone.
+    let doc: StrBuf = "x\\ny";
+    let dl = std.strings.lines(borrow doc);
+    if dl.len() == 2 { score = score + 1; }
+    if doc == "x\\ny" { score = score + 1; }
+
+    if score == 20 { 71 } else { @intCast(score) }
+}
+""" }]
+
 [[case]]
 name = "std_sort_m3"
 description = "sort insertion/quick/is_sorted/binary_search over ArrayBuf(i64) (6 checks -> exit 63)."

--- a/crates/rue-oracle-diff/src/model_gaps/cli.rs
+++ b/crates/rue-oracle-diff/src/model_gaps/cli.rs
@@ -474,7 +474,25 @@ const ENTRIES: &[Entry] = &[
     ),
     Entry::new(
         "cli.std_m3",
+        "std_strings_lines",
+        intrinsic(UnsupportedIntrinsicKind::ByteCopy),
+        &[],
+    ),
+    Entry::new(
+        "cli.std_m3",
         "std_strings_m3",
+        intrinsic(UnsupportedIntrinsicKind::ByteCopy),
+        &[],
+    ),
+    Entry::new(
+        "cli.std_m3",
+        "std_strings_replace_join",
+        intrinsic(UnsupportedIntrinsicKind::ByteCopy),
+        &[],
+    ),
+    Entry::new(
+        "cli.std_m3",
+        "std_strings_split",
         intrinsic(UnsupportedIntrinsicKind::ByteCopy),
         &[],
     ),

--- a/std/strbuf.rue
+++ b/std/strbuf.rue
@@ -332,13 +332,40 @@ pub struct StrBuf {
         O.Some(read_packed_byte(self.core.buf, index))
     }
 
+    // Whether `prefix` are the leading bytes of `self` (§3.7:29). One `matches_at`
+    // at offset 0: its guard rejects exactly the too-long prefix this used to
+    // reject itself, so the byte comparison lives in the scanner alone.
     fn starts_with(borrow self, borrow prefix: str) -> bool {
-        if prefix.len() > self.len {
+        self.matches_at(0, borrow prefix)
+    }
+
+    // Whether `suffix` are the trailing bytes of `self` — the counterpart to
+    // `starts_with`, and the reason a caller selecting files by extension does
+    // not have to pair `rfind_str` with its own index arithmetic. The empty
+    // suffix matches every string, as the empty prefix and needle do.
+    fn ends_with(borrow self, borrow suffix: str) -> bool {
+        if suffix.len() > self.len {
+            return false;
+        }
+        self.matches_at(self.len - suffix.len(), borrow suffix)
+    }
+
+    // Whether the bytes of `needle` occur in `self` starting exactly at byte
+    // offset `at`. False when the needle would run past the end, and false for
+    // any `at` past the length. The empty needle matches at every offset in
+    // `0 ..= len` — the boundary rule the whole substring surface shares (see
+    // the "empty needle" note in std/strings.rue).
+    //
+    // This is the one place a needle is compared byte by byte; `starts_with`,
+    // `ends_with`, and `find_str_from` are its callers, so a faster comparison
+    // (or a skip table above it) has exactly one site to change.
+    fn matches_at(borrow self, at: u64, borrow needle: str) -> bool {
+        if at > self.len || needle.len() > self.len - at {
             return false;
         }
         let mut i: u64 = 0;
-        while i < prefix.len() {
-            if read_packed_byte(self.core.buf, i) != prefix[i] {
+        while i < needle.len() {
+            if read_packed_byte(self.core.buf, at + i) != needle[i] {
                 return false;
             }
             i += 1;
@@ -346,27 +373,77 @@ pub struct StrBuf {
         true
     }
 
-    fn contains(borrow self, borrow needle: str) -> bool {
-        if needle.len() > self.len {
-            return false;
+    // Byte index of the first occurrence of `needle` at or after byte offset
+    // `start`, or `None`. `matches_at` above is this file's single byte
+    // comparison — `starts_with`, `ends_with`, and this function are its only
+    // callers — and this function is its single *search*, which `find_str`,
+    // `contains`, and std.strings' `split_str` and `replace` resume through
+    // rather than re-implementing a scan loop. `None` when `start` is past the
+    // length or the remaining bytes are shorter than the needle.
+    //
+    // AN EMPTY NEEDLE RETURNS `Some(start)`, which is the every-byte-boundary
+    // rule (see std/strings.rue) but is also a hazard worth naming here: the
+    // conventional resume loop advances with `start = at + needle.len()`, which
+    // for an empty needle is `start = at` — the same match forever. A caller
+    // that resumes through this function must special-case the empty needle
+    // (or advance by one) to terminate, which is exactly what std.strings'
+    // `replace` and `split_str` do before they enter their scan loops.
+    //
+    // The scan is the naive O(len * needle.len()) one: every offset is compared
+    // byte by byte, with no skip table. A sublinear search (memchr-style
+    // scanning, Two-Way) is a later, deliberately visible improvement.
+    fn find_str_from(borrow self, borrow needle: str, start: u64) -> option.Option(u64) {
+        let O = option.Option(u64);
+        if start > self.len || needle.len() > self.len - start {
+            return O.None;
         }
         let limit = self.len - needle.len();
-        let mut start: u64 = 0;
-        while start <= limit {
-            let mut i: u64 = 0;
-            let mut equal = true;
-            while equal && i < needle.len() {
-                if read_packed_byte(self.core.buf, start + i) != needle[i] {
-                    equal = false;
-                }
-                i += 1;
+        let mut at = start;
+        while at <= limit {
+            if self.matches_at(at, borrow needle) {
+                return O.Some(at);
             }
-            if equal {
-                return true;
-            }
-            start += 1;
+            at += 1;
         }
-        false
+        O.None
+    }
+
+    // Byte index of the first occurrence of `needle`, or `None`. The
+    // index-returning counterpart to `contains`; `Some(0)` for an empty needle.
+    fn find_str(borrow self, borrow needle: str) -> option.Option(u64) {
+        self.find_str_from(borrow needle, 0)
+    }
+
+    // Byte index of the last occurrence of `needle`, or `None`. The returned
+    // index is still the offset of the needle's FIRST byte, so `rfind_str` and
+    // `find_str` agree whenever there is exactly one occurrence. An empty
+    // needle matches at the last boundary, `Some(len)`.
+    fn rfind_str(borrow self, borrow needle: str) -> option.Option(u64) {
+        let O = option.Option(u64);
+        if needle.len() > self.len {
+            return O.None;
+        }
+        let mut at = self.len - needle.len();
+        let mut scanning = true;
+        while scanning {
+            if self.matches_at(at, borrow needle) {
+                return O.Some(at);
+            }
+            if at == 0 {
+                scanning = false;
+            } else {
+                at -= 1;
+            }
+        }
+        O.None
+    }
+
+    fn contains(borrow self, borrow needle: str) -> bool {
+        let O = option.Option(u64);
+        match self.find_str(borrow needle) {
+            O.Some(_at) => true,
+            O.None => false,
+        }
     }
 
     fn byte_range(borrow self, start: u64, count: u64) -> Self {

--- a/std/strings.rue
+++ b/std/strings.rue
@@ -10,7 +10,73 @@
 //     std.strings.trim("  hi  ");          // "hi"
 //     std.strings.repeat("ab", 3);         // "ababab"
 //     std.strings.count_chars("café");   // 4
+//
+// SUBSTRING SURFACE (RUE-1482, ADR-0072 Decision 6). A helper whose needle is a
+// single byte keeps the plain name (`find`, `rfind`, `count`, `split`); the
+// substring form adds the `_str` suffix (`find_str`, `rfind_str`, `split_str`),
+// because the plain names were already taken by the byte forms:
+//
+//     let sep: str = ", ";
+//     std.strings.find_str(borrow "hello world", borrow "o w");   // Some(4)
+//     std.strings.split(borrow "a,b,,c", 44);                     // 44 is ','
+//                                                                 // ["a","b","","c"]
+//     std.strings.split_str(borrow "a::b", borrow "::");          // ["a","b"]
+//     std.strings.replace(borrow "aaa", borrow "aa", borrow "b"); // "ba"
+//     std.strings.join(parts, borrow sep);                        // "a, b, c"
+//     std.strings.lines(borrow "a\r\nb\n");                       // ["a","b"]
+//
+// That suffix is this module's disambiguator, not a std-wide law, and a reader
+// should not expect uniformity: `StrBuf.contains` and `StrBuf.starts_with` take
+// `str` needles WITHOUT it and are normative specification surface (§3.7:28,
+// §3.7:29), so a second spelling already exists and cannot be renamed. Nor does
+// the suffix mean "takes a `borrow str`" everywhere — `StrBuf.from_str` and
+// `StrBuf.append_str` do, but `StrBuf.push_str` takes an owned `StrBuf`.
+//
+// HAYSTACKS ARE BORROWED. Every function in this section that takes a haystack
+// takes it as `borrow s: StrBuf` and returns independently allocated results,
+// so a caller can search, split, and re-split one document without cloning. That
+// matters for the programs this surface exists for (ADR-0072's gazette parses a
+// source text and keeps it): a consuming signature would charge every such
+// caller a whole-document copy, and the runtime series is meant to measure
+// codegen rather than an avoidable copy forced by an API choice. This is a
+// deliberate break from the older helpers above (`parse_int`, `trim`, `repeat`,
+// ...), which consume their argument and keep doing so because they have
+// callers. `join` is the one new function that still consumes, for the RUE-651
+// reason documented on it.
+//
+// Everything here is byte-string semantics (ADR-0035): offsets, lengths, and
+// needles are bytes, and nothing inspects UTF-8 boundaries, so a needle may
+// legally match inside a multi-byte scalar. `borrow str` is the needle type
+// throughout, since it is the universal read interface over literals, `Str(N)`,
+// and `StrBuf`. The scanner these functions delegate to lives on `StrBuf`
+// itself, next to `contains`/`starts_with`: `matches_at`, `find_str_from`,
+// `find_str`, `rfind_str`, and `ends_with` (std/strbuf.rue).
+//
+// The shared edge-case rules, decided once so the functions agree:
+//
+//   * EMPTY NEEDLE — an empty needle/separator matches at every byte boundary,
+//     including offset 0 and offset `len`. Hence `find_str(s, "") == Some(0)`,
+//     `rfind_str(s, "") == Some(s.len())`, `contains("")` is true (its
+//     pre-existing answer), `split_str(s, "")` brackets each single byte with
+//     empty pieces, and `replace(s, "", r)` inserts `r` at every boundary. The
+//     boundaries are BYTE boundaries, not scalar boundaries as in Rust.
+//   * NEEDLE LONGER THAN THE HAYSTACK — no match: `None`, `false`, an
+//     unsplit one-element result, an unchanged copy.
+//   * OVERLAP — `replace` takes non-overlapping matches left to right and
+//     resumes after the replaced needle, never inside the replacement, so
+//     `replace("aaa", "aa", "b")` is `"ba"` and `replace("aa", "a", "aa")`
+//     terminates as `"aaaa"`.
+//   * SEPARATORS — a split never keeps its separators and always returns
+//     `matches + 1` pieces, so leading, trailing, and consecutive separators
+//     each produce an empty piece and splitting `""` yields one empty piece.
+//     `lines` is the deliberate exception: see its own note.
+//
+// Every algorithm here is the naive one (ADR-0072 wants a later algorithmic
+// improvement to be visible in the runtime time series), but `replace` and the
+// splits still build each result into one `StrBuf`/`ArrayBuf` rather than
+// rebuilding a string per match.
 
+const arraybuf = @import("arraybuf.rue");
 const ascii = @import("ascii.rue");
 const option = @import("option.rue");
 const math = @import("math.rue");
@@ -109,6 +175,19 @@ pub fn rfind(s: StrBuf, byte: u8) -> option.Option(u64) {
         }
     }
     O.None
+}
+
+// Byte index of the first occurrence of the substring `needle`, or `None`.
+// `Some(0)` for an empty needle; `None` when the needle is longer than `s`.
+pub fn find_str(borrow s: StrBuf, borrow needle: str) -> option.Option(u64) {
+    s.find_str(borrow needle)
+}
+
+// Byte index of the last occurrence of the substring `needle`, or `None`. The
+// index is the offset of the needle's first byte, so a single occurrence gives
+// the same answer as `find_str`. `Some(s.len())` for an empty needle.
+pub fn rfind_str(borrow s: StrBuf, borrow needle: str) -> option.Option(u64) {
+    s.rfind_str(borrow needle)
 }
 
 // Number of bytes equal to `byte`.
@@ -228,6 +307,187 @@ pub fn repeat(s: StrBuf, n: u64) -> StrBuf {
             i += 1;
         }
         k += 1;
+    }
+    out
+}
+
+// The pieces of `s` between occurrences of the separator byte `sep`, in order.
+// Separators are dropped, and the result always holds one more piece than there
+// were separators: `"a,b"` splits into `["a", "b"]`, `",a,"` into
+// `["", "a", ""]`, `"a,,b"` into `["a", "", "b"]`, and `""` into `[""]`.
+pub fn split(borrow s: StrBuf, sep: u8) -> arraybuf.ArrayBuf(StrBuf) {
+    let Parts = arraybuf.ArrayBuf(StrBuf);
+    let mut out = Parts.new();
+    let n = s.len();
+    let mut start: u64 = 0;
+    let mut i: u64 = 0;
+    while i < n {
+        if bounded_byte_at(borrow s, i) == sep {
+            out.push(s.byte_range(start, i - start));
+            start = i + 1;
+        }
+        i += 1;
+    }
+    out.push(s.byte_range(start, n - start));
+    out
+}
+
+// The pieces of `s` between non-overlapping occurrences of the separator
+// substring `sep`, in order, with the same piece-count rule as `split`.
+//
+// An empty separator matches at every byte boundary (module note), so it yields
+// each single byte of `s` bracketed by the boundary matches at the two ends:
+// `split_str("abc", "")` is `["", "a", "b", "c", ""]` and `split_str("", "")` is
+// `["", ""]`.
+pub fn split_str(borrow s: StrBuf, borrow sep: str) -> arraybuf.ArrayBuf(StrBuf) {
+    let Parts = arraybuf.ArrayBuf(StrBuf);
+    let O = option.Option(u64);
+    let mut out = Parts.new();
+    let n = s.len();
+    if sep.len() == 0 {
+        out.push(StrBuf.new());
+        let mut i: u64 = 0;
+        while i < n {
+            out.push(s.byte_range(i, 1));
+            i += 1;
+        }
+        out.push(StrBuf.new());
+        return out;
+    }
+    let mut start: u64 = 0;
+    let mut scanning = true;
+    while scanning {
+        match s.find_str_from(borrow sep, start) {
+            O.Some(at) => {
+                out.push(s.byte_range(start, at - start));
+                start = at + sep.len();
+            },
+            O.None => {
+                scanning = false;
+            },
+        }
+    }
+    out.push(s.byte_range(start, n - start));
+    out
+}
+
+// A copy of `s` with every occurrence of `needle` replaced by `replacement`.
+//
+// Matches are non-overlapping and taken left to right, and scanning resumes
+// after the replaced needle rather than inside the replacement it just wrote:
+// `replace("aaa", "aa", "b")` is `"ba"`, and `replace("aa", "a", "aa")` is
+// `"aaaa"` rather than looping. An empty needle matches at every byte boundary,
+// so `replace("ab", "", "-")` is `"-a-b-"`.
+//
+// The result is appended into a single buffer, so a haystack with `k` matches
+// costs one pass over the bytes plus the naive per-offset match test, not a
+// fresh string per match.
+pub fn replace(borrow s: StrBuf, borrow needle: str, borrow replacement: str) -> StrBuf {
+    let O = option.Option(u64);
+    let n = s.len();
+    let mut out = StrBuf.new();
+    if needle.len() == 0 {
+        out.append_str(borrow replacement);
+        let mut i: u64 = 0;
+        while i < n {
+            out.push(bounded_byte_at(borrow s, i));
+            out.append_str(borrow replacement);
+            i += 1;
+        }
+        return out;
+    }
+    let mut start: u64 = 0;
+    let mut scanning = true;
+    while scanning {
+        match s.find_str_from(borrow needle, start) {
+            O.Some(at) => {
+                let mut i = start;
+                while i < at {
+                    out.push(bounded_byte_at(borrow s, i));
+                    i += 1;
+                }
+                out.append_str(borrow replacement);
+                start = at + needle.len();
+            },
+            O.None => {
+                scanning = false;
+            },
+        }
+    }
+    let mut tail = start;
+    while tail < n {
+        out.push(bounded_byte_at(borrow s, tail));
+        tail += 1;
+    }
+    out
+}
+
+// The elements of `parts` concatenated with `sep` between adjacent elements.
+// Zero parts give the empty string, one part gives that part unchanged, and the
+// separator therefore appears exactly `parts.len() - 1` times. The inverse of
+// `split_str` for a non-empty separator, ignoring separators that appear inside
+// the pieces.
+//
+// `parts` is CONSUMED: `ArrayBuf(StrBuf)` holds drop-glue elements, whose only
+// sound read is the moving `pop` (RUE-651), so a borrowing `join` is not
+// expressible today. `pop` also walks back to front, hence the reversal pass
+// before the joining pass.
+pub fn join(parts: arraybuf.ArrayBuf(StrBuf), borrow sep: str) -> StrBuf {
+    let Parts = arraybuf.ArrayBuf(StrBuf);
+    let OS = option.Option(StrBuf);
+    let mut source = parts;
+    let mut reversed = Parts.new();
+    while source.len() > 0 {
+        match source.pop() {
+            OS.Some(part) => {
+                reversed.push(part);
+            },
+            OS.None => @panic("pop of a non-empty buffer"),
+        }
+    }
+    let mut out = StrBuf.new();
+    let mut first = true;
+    while reversed.len() > 0 {
+        match reversed.pop() {
+            OS.Some(part) => {
+                if !first {
+                    out.append_str(borrow sep);
+                }
+                first = false;
+                out.push_str(part);
+            },
+            OS.None => @panic("pop of a non-empty buffer"),
+        }
+    }
+    out
+}
+
+// The lines of `s`, split on `\n` with a `\r` immediately before the `\n`
+// removed. Unlike `split`, a line terminator terminates rather than separates:
+// a trailing newline does NOT produce a final empty line, so `"a\nb\n"` and
+// `"a\nb"` both give `["a", "b"]`, and `""` gives no lines at all. A blank line
+// between two terminators is still a real empty line, so `"a\n\nb"` gives
+// `["a", "", "b"]`. A `\r` is stripped only when it precedes a `\n`; a lone
+// trailing `\r` stays in its line, as does any other control byte.
+pub fn lines(borrow s: StrBuf) -> arraybuf.ArrayBuf(StrBuf) {
+    let Parts = arraybuf.ArrayBuf(StrBuf);
+    let mut out = Parts.new();
+    let n = s.len();
+    let mut start: u64 = 0;
+    let mut i: u64 = 0;
+    while i < n {
+        if bounded_byte_at(borrow s, i) == 10 {
+            let mut end = i;
+            if end > start && bounded_byte_at(borrow s, end - 1) == 13 {
+                end -= 1;
+            }
+            out.push(s.byte_range(start, end - start));
+            start = i + 1;
+        }
+        i += 1;
+    }
+    if start < n {
+        out.push(s.byte_range(start, n - start));
     }
     out
 }


### PR DESCRIPTION
Closes RUE-1482.

ADR-0072 Phase 2b (Decision 6). Markdown parsing, front-matter handling, templating, and link rewriting are all substring-heavy, and `std/strings.rue` offered only single-**byte** find/rfind/count plus trim/parse_int, with no index-returning counterpart to `StrBuf.contains`.

## What this adds

To `std/strbuf.rue`:

- `matches_at(at, needle)` — the file's single byte-comparison primitive
- `find_str_from(needle, start)` — the single search loop
- `find_str` / `rfind_str`, index-returning, `str` needle
- `ends_with`, the missing counterpart to `starts_with`

To `std/strings.rue`: free-function `find_str`, `rfind_str`, `split` (byte separator), `split_str`, `replace`, `join`, and `lines`.

`contains` and `starts_with` are rewritten to delegate to the new primitives, so predicate and index cannot disagree and there is one canonical scan rather than three parallel loops. Both are normative spec surface (§3.7:28, §3.7:29) and their behavior is unchanged.

Byte-string semantics throughout, consistent with ADR-0035. Algorithms are deliberately naive: these functions are themselves part of what the runtime benchmark measures, and later algorithmic upgrades are exactly the kind of std improvement the time series should make visible.

## Borrowed haystacks

`split`, `split_str`, `replace`, `lines`, `find_str`, and `rfind_str` take `borrow s: StrBuf`. This diverges from the module's older consuming helpers (`parse_int`, `trim`, `repeat`) — deliberately, and the header documents why: those have callers and these do not yet, and a consuming signature would force every caller to clone its source document first. The gazette Markdown parser built on this next would have paid that clone on the critical path of a benchmark whose purpose is honest runtime measurement.

`join` still consumes its `ArrayBuf(StrBuf)`. That one is forced: indexed by-copy reads of drop-glue elements are gated (RUE-651), so a moving back-to-front `pop` is the only sound read. The reason is documented in place.

## Edge-case rules

Documented in the `std/strings.rue` header and restated per function:

- **Empty needle matches at every byte boundary** — one rule driving all of `find_str`, `rfind_str`, `contains`, `split_str`, and `replace`. Byte boundaries, not scalar boundaries.
- **`replace` is non-overlapping, left to right**, resuming after the replaced needle and never inside the replacement, so `replace("aaa","aa","b") == "ba"` and `replace("aa","a","aa") == "aaaa"` terminates.
- **Splits** drop separators and always yield `matches + 1` pieces; `split("") == [""]`.
- **`lines` is a terminator, not a separator** — a trailing `\n` yields no spurious final empty line, `""` yields zero lines, and `\r` is stripped only when it immediately precedes `\n`.
- **`join`** of zero parts is `""`, of one part is itself, and inserts the separator exactly `len - 1` times.

The empty-needle rule is load-bearing rather than cosmetic: the conventional resume loop advances by `at + needle.len()`, which for an empty needle never advances, which is why `replace` and `split_str` special-case it. That reason is recorded at `find_str_from`.

## Verification

Adversarial review found no must-fix defects and confirmed the termination traps closed by execution, including the two classic ones — empty needle, and a replacement containing its own needle. Scaling measurement over 4x input steps showed 3.3x and 3.85x growth, so nothing is accidentally quadratic. Seven mutation tests against boundary conditions in the new cases were all caught, so the tests are load-bearing. The `contains` rewrite measured ~10% faster than the previous inlined loop on a 400k worst-case haystack.

Review also prompted the borrow change above, `ends_with`, the `starts_with` collapse onto `matches_at`, and two documentation corrections. Each of the four CLI cases now reuses its haystack after the call — the assertion that pins the borrow signatures; reverting `lines` to consuming in a scratch std makes that program fail with `E0205 use of moved value`.

`scripts/rue cli std_` — 96 passed, 0 failed, 2 ignored. `scripts/rue spec 3.7` — 127 passed. `scripts/rue cli examples` — 101 passed. `scripts/rue quick` — 31 targets, 0 failures.

## Follow-up, not done here

Spec paragraphs for the new search methods are not mechanical: §3.7's rule IDs are sequential and the traceability gate requires full coverage, so `find_str`, `rfind_str`, `ends_with`, and `matches_at` would need several new normative IDs plus matching `spec = [...]` cases. Filed separately rather than attempted here. A bulk byte-range append that would let `replace` use a single copy instead of byte-at-a-time pushes is likewise left for later, per the naive-is-fine-for-v1 rule above.
