### PR TITLE
RUE-1046: rue-bench runtime measurement mode and the runtime manifest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -397,6 +397,12 @@ jobs:
         # Is the series *already* stalled? A repository-wide condition, so this
         # fails every pull request rather than only the one that caused it: a
         # stalled series hides regressions instead of reporting them.
+        #
+        # Deliberately compile-time only. Do not add --runtime-manifest here:
+        # ADR-0072 Decision 9 puts the runtime series outside this gate on
+        # purpose. Its remedy can be measured in parser work rather than a small
+        # manifest change, so a stalled runtime series is a dashboard staleness
+        # flag and a triage item, never a repository-wide block.
         run: |
           set -euo pipefail
           BENCH="$(./buck2 build //crates/rue-bench:rue-bench --show-simple-output 2>/dev/null | tail -1)"

--- a/.github/workflows/performance-collect.yml
+++ b/.github/workflows/performance-collect.yml
@@ -1,7 +1,15 @@
-# Compiler-performance collection (ADR-0067 Phase 5, RUE-1188).
+# Performance collection (ADR-0067 Phase 5, RUE-1188; ADR-0072 Phase 1,
+# RUE-1046).
 #
 # Measures each platform's collection epoch on every trunk commit and appends
-# the raw run objects to the `performance-data-v1` orphan branch.
+# the raw records to the `performance-data-v1` orphan branch.
+#
+# Two record kinds ride this workflow. The `measure` jobs answer how fast Rue
+# *compiles*; the `runtime` job answers how fast the programs it produces
+# *run*. They share the runner regime, the publish path, and the store, and
+# nothing else: separate manifests, separate epochs, separate directories on
+# the data branch, and a separate posture — the runtime series is advisory and
+# outside the required-CI gates.
 #
 # Two properties this workflow exists to guarantee:
 #
@@ -144,8 +152,98 @@ jobs:
             exit 1
           fi
 
+  # Runtime performance of compiled Rue programs (ADR-0072 Phase 1, RUE-1046).
+  #
+  # Rides this workflow rather than adding a schedule, so a runtime regression
+  # surfaces attached to the compiler change that caused it. The v1 platform
+  # matrix is exactly one row: `x86_64-linux` on the pinned `ubuntu-24.04`
+  # image. `aarch64-linux` joins once ADR-0072's Phase 2 standard-library work
+  # is CI-verified there, and macOS stays deferred behind the `@syscall`
+  # error-detection gap.
+  #
+  # A failure here fails this job and nothing else. The runtime series sits
+  # deliberately outside ADR-0067's required-CI gates, including the no-bypass
+  # stall gate: a stalled runtime series is a dashboard staleness flag and a
+  # maintainer triage item, never a repository-wide pull-request block.
+  runtime:
+    runs-on: ubuntu-24.04
+    name: runtime (x86_64-linux)
+    # The measured work is small — five samples of a 32 MiB text workload plus
+    # one release-quality build of it, on the order of a minute. The job's
+    # actual cost is dominated by building `rue` and `rue-bench` under
+    # //platforms:release on a fourth runner. Wall clock is unaffected, since
+    # this runs alongside the three `measure` legs, but it is a runner's worth
+    # of compute per trunk push and the budget below is sized for the build.
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install dotslash
+        uses: facebook/install-dotslash@v2
+
+      - name: Build the compiler and the runner
+        run: |
+          ./buck2 build //crates/rue:rue //crates/rue-bench:rue-bench \
+            --target-platforms //platforms:release
+
+      - name: Measure compiled-program runtime
+        env:
+          RUE_BENCH_RUNNER_LABEL: github-hosted
+          RUE_BENCH_RUNNER_IMAGE: ubuntu-24.04
+        run: |
+          set -euo pipefail
+          mkdir -p runtime-collected
+          RUE="$(scripts/rue-bin --target-platforms //platforms:release)"
+          BENCH="$(./buck2 build //crates/rue-bench:rue-bench \
+            --target-platforms //platforms:release --show-simple-output 2>/dev/null | tail -1)"
+
+          # No --epoch: performance/runtime.toml marks its own collection epoch,
+          # for the same reason the compiler legs do.
+          set +e
+          "$BENCH" runtime \
+            --manifest performance/runtime.toml \
+            --platform x86_64-linux \
+            --compiler "$RUE" \
+            --commit "${{ github.sha }}" \
+            --repo-root . \
+            --out runtime-collected/runtime-x86_64-linux.json
+          status=$?
+          set -e
+          echo "runner exit status: $status"
+          if [ "$status" -eq 2 ]; then
+            echo "::error::the runtime runner could not produce a report"
+            exit 1
+          fi
+          echo "status=$status" > runtime-collected/runtime-x86_64-linux.status
+
+      - name: Upload the runtime report
+        # Always, so a report that cannot enter its series is still kept as
+        # evidence when the next step fails the job.
+        if: always()
+        uses: actions/upload-artifact@v6
+        with:
+          name: runtime-x86_64-linux
+          path: runtime-collected/
+          retention-days: 30
+
+      - name: Report the runtime series' health
+        run: |
+          set -euo pipefail
+          status="$(cut -d= -f2 runtime-collected/runtime-x86_64-linux.status)"
+          if [ "$status" -eq 3 ]; then
+            echo "::error::the runtime report cannot enter its series. The most" \
+                 "likely cause is a compiled program producing output that does" \
+                 "not match its committed golden, which fails regardless of speed."
+            exit 1
+          fi
+          if [ "$status" -eq 5 ]; then
+            echo "::error::the runtime report is appendable but a workload did" \
+                 "not complete; the series has a hole at this commit."
+            exit 1
+          fi
+
   publish:
-    needs: measure
+    needs: [measure, runtime]
     # Runs even when a platform failed: a partial sweep still has valid runs
     # worth storing, and a platform that is persistently broken should be
     # visible in the data rather than absent from it.
@@ -173,9 +271,11 @@ jobs:
           set -euo pipefail
           shopt -s nullglob
 
+          # Both record kinds arrive here. `publish-performance-runs.py` routes
+          # each one by the `record_kind` discriminator it carries.
           runs=(incoming/*.json)
           if [ ${#runs[@]} -eq 0 ]; then
-            echo "no run objects were produced; nothing to publish"
+            echo "no records were produced; nothing to publish"
             exit 0
           fi
 

--- a/crates/rue-bench/src/derive.rs
+++ b/crates/rue-bench/src/derive.rs
@@ -20,8 +20,10 @@ use std::collections::{BTreeMap, BTreeSet};
 use std::path::Path;
 
 use rue_perf_schema::{
-    Band, Completeness, Manifest, Metric, RunObject, StoredRun, Summary, flags_movement,
-    geometric_mean, median_absolute_deviation, ratio, sample_value, validate_run,
+    Band, Completeness, FIXTURE_INPUT_NAME, Manifest, Metric, RunObject, RuntimeCompleteness,
+    RuntimeManifest, RuntimeMetric, StoredRun, StoredRuntimeReport, Summary, flags_movement,
+    geometric_mean, median_absolute_deviation, ratio, sample_value, summarize, validate_run,
+    validate_runtime_report,
 };
 use serde::Serialize;
 
@@ -39,6 +41,116 @@ pub struct SiteData {
     /// Surfaced rather than dropped: a run rejected for a pin mismatch is the
     /// single most useful thing to see when the page stops updating.
     pub rejected: Vec<RejectedRun>,
+    /// The ADR-0072 runtime series, when a runtime manifest was supplied.
+    ///
+    /// `None` rather than an empty object when the caller asked for no runtime
+    /// derivation at all: a page must be able to tell "not requested" from
+    /// "requested and nothing has been collected yet".
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub runtime: Option<RuntimeData>,
+}
+
+/// Everything a runtime view renders.
+///
+/// Deliberately a sibling of the compile-time series rather than a member of
+/// it. The two answer different questions — how fast Rue compiles, and how fast
+/// compiled Rue runs — over different record kinds, and merging them would
+/// invite a chart that plots one against the other.
+#[derive(Debug, Serialize)]
+pub struct RuntimeData {
+    /// Measured programs with the question each one answers.
+    pub workloads: Vec<RuntimeWorkloadDescription>,
+    /// Published runtime metrics, in presentation order.
+    pub metrics: Vec<String>,
+    /// One entry per platform that has any observation.
+    pub platforms: Vec<RuntimePlatformData>,
+    /// Reports that exist but could not enter any series, with the reason.
+    pub rejected: Vec<RejectedRuntimeReport>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct RuntimeWorkloadDescription {
+    pub id: String,
+    pub source: String,
+    pub question: String,
+}
+
+#[derive(Debug, Serialize)]
+pub struct RejectedRuntimeReport {
+    pub report: String,
+    pub platform: String,
+    pub epoch: u32,
+    pub commit: String,
+    pub reasons: Vec<String>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct RuntimePlatformData {
+    pub platform: String,
+    /// Epoch stretches, oldest first.
+    pub epochs: Vec<RuntimeEpochData>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct RuntimeEpochData {
+    pub epoch: u32,
+    pub suite_revision: u32,
+    /// What the programs were built as, so a reader can see that the series
+    /// measures the release-quality product rather than a debug build.
+    pub optimization: String,
+    pub thread_policy: String,
+    pub hardware_counters: String,
+    /// Points in measurement order.
+    pub points: Vec<RuntimePointData>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct RuntimePointData {
+    /// The record's immutable name.
+    pub report: String,
+    /// The compiler revision that built the measured programs.
+    pub commit: String,
+    /// The compiler's own version string.
+    pub compiler_version: String,
+    pub finished_at: String,
+    /// Whether every declared workload completed.
+    pub complete: bool,
+    /// Per-workload figures, keyed by workload id.
+    pub workloads: BTreeMap<String, RuntimeWorkloadPoint>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct RuntimeWorkloadPoint {
+    /// Digest of the input this observation consumed.
+    ///
+    /// The recorded-input category made visible: a raw median may only be
+    /// compared with another point carrying the same identity, and a change
+    /// here is a discontinuity in the series rather than a movement in it.
+    pub fixture_identity: String,
+    /// Size of that input, in bytes.
+    pub fixture_bytes: u64,
+    /// Digest of the workload's own source closure at this point.
+    ///
+    /// The other half of the recorded-not-pinned bargain, and the reason it is
+    /// a bargain rather than a gap. This suite records the program's identity
+    /// instead of pinning it — the same choice `performance/scaling.toml` makes
+    /// for the maintained examples it measures — which is only defensible if a
+    /// consumer can see when it moved. Both identities segment the series the
+    /// same way: raw medians are comparable within a segment and not across
+    /// one.
+    pub source_identity: String,
+    /// `calibrated` or `advisory`. Movement in an advisory workload is a
+    /// triage item, never a gate.
+    pub flag_posture: String,
+    /// Median and dispersion per metric, keyed by metric wire name.
+    pub metrics: BTreeMap<String, SummaryData>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct SummaryData {
+    pub median: u64,
+    pub mad: u64,
+    pub count: usize,
 }
 
 #[derive(Debug, Serialize)]
@@ -256,7 +368,7 @@ pub fn derive(manifest: &Manifest, runs: &[StoredRun]) -> SiteData {
     // counted as evidence but never enters a series.
     let mut grouped: BTreeMap<(String, u32), Vec<&StoredRun>> = BTreeMap::new();
     for stored in runs {
-        let run = stored.run();
+        let run = stored.record();
         let outcome = validate_run(manifest, run);
         if !outcome.is_appendable() {
             rejected.push(RejectedRun {
@@ -278,11 +390,16 @@ pub fn derive(manifest: &Manifest, runs: &[StoredRun]) -> SiteData {
     for ((platform, epoch_id), mut epoch_runs) in grouped {
         // Measurement order, so the trailing window means what it says.
         epoch_runs.sort_by(|left, right| {
-            left.run()
+            left.record()
                 .identity
                 .finished_at
-                .cmp(&right.run().identity.finished_at)
-                .then_with(|| left.run().identity.commit.cmp(&right.run().identity.commit))
+                .cmp(&right.record().identity.finished_at)
+                .then_with(|| {
+                    left.record()
+                        .identity
+                        .commit
+                        .cmp(&right.record().identity.commit)
+                })
         });
         let Some(epoch) = manifest.epoch(&platform, epoch_id) else {
             continue;
@@ -308,6 +425,252 @@ pub fn derive(manifest: &Manifest, runs: &[StoredRun]) -> SiteData {
         workloads,
         platforms,
         rejected,
+        runtime: None,
+    }
+}
+
+/// One record in the store this build could not read.
+///
+/// Kept as data rather than raised as an error, because the store is
+/// append-only: a record written by a future schema can never be removed from
+/// it, so a reader that refused the whole directory on meeting one would break
+/// the site build permanently, with no remedy available in this repository.
+pub struct UnreadableRecord {
+    /// The record's file name.
+    pub name: String,
+    /// Why this build could not read it.
+    pub detail: String,
+}
+
+/// Read the durable store's runtime records.
+///
+/// A separate directory from `runs/`, because they are a separate record kind
+/// whose reader must never have to guess a kind from which fields happen to
+/// parse. An absent directory is the normal first state, not an error.
+///
+/// Records this build cannot parse are skipped and returned alongside the ones
+/// it can, so the day `runtime_v2` lands the site keeps deriving every v1
+/// record and says plainly which ones it passed over. Only a directory that
+/// cannot be listed at all is an error: that is a broken checkout rather than a
+/// record from the future.
+pub fn load_runtime_records(
+    data_root: &Path,
+) -> Result<(Vec<StoredRuntimeReport>, Vec<UnreadableRecord>), String> {
+    let directory = data_root.join("runtime");
+    if !directory.is_dir() {
+        return Ok((Vec::new(), Vec::new()));
+    }
+    let mut reports = Vec::new();
+    let mut unreadable = Vec::new();
+    let listing = std::fs::read_dir(&directory)
+        .map_err(|error| format!("could not read {}: {error}", directory.display()))?;
+    for entry in listing {
+        let path = entry
+            .map_err(|error| format!("could not read {}: {error}", directory.display()))?
+            .path();
+        if path.extension().and_then(|e| e.to_str()) != Some("json") {
+            continue;
+        }
+        let name = path
+            .file_name()
+            .map(|name| name.to_string_lossy().into_owned())
+            .unwrap_or_default();
+        let text = match std::fs::read_to_string(&path) {
+            Ok(text) => text,
+            Err(error) => {
+                unreadable.push(UnreadableRecord {
+                    name,
+                    detail: error.to_string(),
+                });
+                continue;
+            }
+        };
+        match StoredRuntimeReport::read(&text) {
+            Ok(stored) => reports.push(stored),
+            Err(error) => unreadable.push(UnreadableRecord {
+                name,
+                detail: error.to_string(),
+            }),
+        }
+    }
+    Ok((reports, unreadable))
+}
+
+/// Derive the runtime view of a set of records.
+///
+/// Nothing derived is stored, exactly as on the compile-time side: medians,
+/// dispersion, and every comparison are recomputed here from the raw samples at
+/// site build time.
+pub fn derive_runtime(
+    manifest: &RuntimeManifest,
+    reports: &[StoredRuntimeReport],
+    unreadable: &[UnreadableRecord],
+) -> RuntimeData {
+    let mut workloads: Vec<RuntimeWorkloadDescription> = Vec::new();
+    let mut seen = BTreeSet::new();
+    for suite in manifest.suites() {
+        for workload in &suite.workloads {
+            if seen.insert(workload.id.clone()) {
+                workloads.push(RuntimeWorkloadDescription {
+                    id: workload.id.clone(),
+                    source: workload.source.clone(),
+                    question: workload.question.clone(),
+                });
+            }
+        }
+    }
+
+    // A record this build cannot read is reported in the same place a record it
+    // read and refused is: from the page's point of view both are records that
+    // exist and are not plotted, and the difference is the reason text.
+    let mut rejected: Vec<RejectedRuntimeReport> = unreadable
+        .iter()
+        .map(|record| RejectedRuntimeReport {
+            report: record.name.clone(),
+            platform: String::new(),
+            epoch: 0,
+            commit: String::new(),
+            reasons: vec![format!(
+                "this build of the schema could not read the record: {}",
+                record.detail
+            )],
+        })
+        .collect();
+    let mut grouped: BTreeMap<(String, u32), Vec<&StoredRuntimeReport>> = BTreeMap::new();
+    for stored in reports {
+        let report = stored.record();
+        let outcome = validate_runtime_report(manifest, report);
+        if !outcome.is_appendable() {
+            // Surfaced rather than dropped. A report rejected because its
+            // program printed the wrong answer is the single most useful thing
+            // to see when the runtime page stops advancing.
+            rejected.push(RejectedRuntimeReport {
+                report: stored.address().to_string(),
+                platform: report.identity.platform.clone(),
+                epoch: report.identity.epoch,
+                commit: report.identity.commit.clone(),
+                reasons: outcome
+                    .errors
+                    .iter()
+                    .map(|error| error.to_string())
+                    .collect(),
+            });
+            continue;
+        }
+        grouped
+            .entry((report.identity.platform.clone(), report.identity.epoch))
+            .or_default()
+            .push(stored);
+    }
+
+    let mut by_platform: BTreeMap<String, Vec<RuntimeEpochData>> = BTreeMap::new();
+    for ((platform, epoch_id), mut stored) in grouped {
+        let Some(epoch) = manifest.epoch(&platform, epoch_id) else {
+            continue;
+        };
+        stored.sort_by(|left, right| {
+            left.record()
+                .identity
+                .finished_at
+                .cmp(&right.record().identity.finished_at)
+                .then_with(|| left.address().cmp(right.address()))
+        });
+        let points = stored
+            .iter()
+            .map(|stored| runtime_point(manifest, epoch, stored))
+            .collect();
+        by_platform
+            .entry(platform)
+            .or_default()
+            .push(RuntimeEpochData {
+                epoch: epoch.id,
+                suite_revision: epoch.suite_revision,
+                optimization: format!("{:?}", epoch.optimization).to_lowercase(),
+                thread_policy: format!("{:?}", epoch.thread_policy).to_lowercase(),
+                hardware_counters: format!("{:?}", epoch.hardware_counters).to_lowercase(),
+                points,
+            });
+    }
+
+    let platforms = by_platform
+        .into_iter()
+        .map(|(platform, mut epochs)| {
+            epochs.sort_by_key(|epoch| epoch.epoch);
+            RuntimePlatformData { platform, epochs }
+        })
+        .collect();
+
+    RuntimeData {
+        workloads,
+        metrics: RuntimeMetric::ALL
+            .into_iter()
+            .map(|metric| metric.wire_name().to_string())
+            .collect(),
+        platforms,
+        rejected,
+    }
+}
+
+fn runtime_point(
+    manifest: &RuntimeManifest,
+    epoch: &rue_perf_schema::RuntimeEpoch,
+    stored: &StoredRuntimeReport,
+) -> RuntimePointData {
+    let report = stored.record();
+    let outcome = validate_runtime_report(manifest, report);
+    let mut workloads = BTreeMap::new();
+    for observation in &report.workloads {
+        if !outcome.publishes_workload(&observation.workload) {
+            // A workload that did not complete has no point. Publishing a
+            // median over a truncated sample set would look like a measurement
+            // and be an artifact of the crash that ended it.
+            continue;
+        }
+        let fixture = observation
+            .recorded_inputs
+            .iter()
+            .find(|input| input.name == FIXTURE_INPUT_NAME);
+        let metrics = RuntimeMetric::ALL
+            .into_iter()
+            .filter_map(|metric| {
+                summarize(observation, metric).map(|summary| {
+                    (
+                        metric.wire_name().to_string(),
+                        SummaryData {
+                            median: summary.median,
+                            mad: summary.mad,
+                            count: summary.count,
+                        },
+                    )
+                })
+            })
+            .collect();
+        workloads.insert(
+            observation.workload.clone(),
+            RuntimeWorkloadPoint {
+                fixture_identity: fixture
+                    .map(|input| input.identity_sha256.clone())
+                    .unwrap_or_default(),
+                fixture_bytes: fixture.map(|input| input.bytes).unwrap_or(0),
+                source_identity: report
+                    .identity
+                    .workload_source_hashes
+                    .get(&observation.workload)
+                    .cloned()
+                    .unwrap_or_default(),
+                flag_posture: format!("{:?}", epoch.flag_posture(&observation.workload))
+                    .to_lowercase(),
+                metrics,
+            },
+        );
+    }
+    RuntimePointData {
+        report: stored.address().to_string(),
+        commit: report.identity.commit.clone(),
+        compiler_version: report.identity.compiler_version.clone(),
+        finished_at: report.identity.finished_at.clone(),
+        complete: matches!(outcome.completeness, RuntimeCompleteness::Complete),
+        workloads,
     }
 }
 
@@ -326,7 +689,7 @@ fn derive_epoch(
         .baseline
         .as_ref()
         .and_then(|baseline| runs.iter().find(|stored| stored.address() == baseline.run));
-    let baseline_medians = baseline_run.map(|stored| workload_medians(stored.run(), suite));
+    let baseline_medians = baseline_run.map(|stored| workload_medians(stored.record(), suite));
 
     let mut points: Vec<PointData> = Vec::new();
     let mut environment_annotations = Vec::new();
@@ -339,7 +702,7 @@ fn derive_epoch(
     let mut history: BTreeMap<String, Vec<Summary>> = BTreeMap::new();
 
     for stored in runs {
-        let run = stored.run();
+        let run = stored.record();
         let outcome = validate_run(manifest, run);
         let address = stored.address().to_string();
         let fingerprint = run
@@ -881,7 +1244,7 @@ window = 3
         let stored_base = StoredRun::read(&as_written).expect("readable");
         assert_ne!(
             stored_base.address(),
-            stored_base.run().content_address().unwrap(),
+            stored_base.record().content_address().unwrap(),
             "the fixture must be a record that does not round-trip"
         );
 
@@ -1189,5 +1552,292 @@ window = 3
         // which the broken sample would have inflated.
         assert_eq!(point.compiler_root_ns, 100);
         assert_eq!(point.bands_ns.values().sum::<u64>(), 100);
+    }
+
+    // -----------------------------------------------------------------------
+    // Runtime series (ADR-0072)
+    // -----------------------------------------------------------------------
+
+    const RUNTIME_MANIFEST: &str = r#"
+schema_version = 1
+
+[[suite]]
+revision = 1
+protocol_version = 1
+measured_boundary = "spawn_to_exit_v1"
+
+[[suite.workloads]]
+id = "wordfreq"
+source = "examples/wordfreq/main.rue"
+question = "How fast does compiled Rue count words?"
+program_args = ["{fixture}"]
+
+[suite.workloads.fixture]
+category = "recorded"
+generator = "zipf_ascii_text"
+generator_revision = 1
+seed = 20260813
+bytes = 4096
+vocabulary_size = 256
+file_name = "input.txt"
+description = "deterministic ASCII word text"
+
+[suite.workloads.oracle]
+kind = "golden_stdout"
+path = "performance/fixtures/wordfreq/expected-stdout.txt"
+
+[[epoch]]
+id = 1
+platform = "probe"
+suite_revision = 1
+target = "x86-64-linux"
+compiler_args = ["-O3"]
+optimization = "o3"
+thread_policy = "single_threaded"
+hardware_counters = "unavailable_on_hosted_runner"
+collection = true
+
+[epoch.environment]
+runner_label = "probe"
+runner_image = "probe"
+
+[epoch.sampling.wordfreq]
+samples = 3
+"#;
+
+    fn runtime_report(commit: char, elapsed: [u64; 3]) -> rue_perf_schema::RuntimeReport {
+        use rue_perf_schema::*;
+        RuntimeReport {
+            record_kind: RUNTIME_RECORD_KIND.to_string(),
+            schema_version: RUNTIME_REPORT_SCHEMA_VERSION,
+            identity: RuntimeIdentity {
+                suite_revision: 1,
+                epoch: 1,
+                platform: "probe".to_string(),
+                commit: std::iter::repeat_n(commit, 40).collect(),
+                compiler_version: "rue 0.1.0".to_string(),
+                started_at: "2026-08-13T00:00:00Z".to_string(),
+                finished_at: format!("2026-08-13T00:0{}:00Z", elapsed[0] % 10),
+                toolchain_hash: "1".repeat(64),
+                stdlib_hash: "2".repeat(64),
+                workload_source_hashes: BTreeMap::from([("wordfreq".to_string(), "3".repeat(64))]),
+                environment: EnvironmentFingerprint {
+                    runner_label: "probe".to_string(),
+                    runner_image: "probe".to_string(),
+                    runner_image_version: "1".to_string(),
+                    cpu_model: "probe".to_string(),
+                    core_count: 4,
+                    memory_bytes: 1,
+                    kernel_version: "probe".to_string(),
+                    os_version: "probe".to_string(),
+                    architecture: "x86_64".to_string(),
+                },
+            },
+            regime: RuntimeRegime {
+                measured_boundary: RuntimeBoundary::SpawnToExitV1,
+                program_state: "fresh_process".to_string(),
+                os_page_cache: "uncontrolled".to_string(),
+                fixture_preparation_measured: false,
+                oracle_comparison_measured: false,
+                optimization: OptimizationLevel::O3,
+                compiler_args: vec!["-O3".to_string()],
+                target: "x86-64-linux".to_string(),
+                thread_policy: ThreadPolicy::SingleThreaded,
+                hardware_counters: HardwareCounterPolicy::UnavailableOnHostedRunner,
+            },
+            workloads: vec![RuntimeObservation {
+                workload: "wordfreq".to_string(),
+                source: "examples/wordfreq/main.rue".to_string(),
+                question: "How fast does compiled Rue count words?".to_string(),
+                program_args: vec![FIXTURE_ARGUMENT.to_string()],
+                recorded_inputs: vec![RecordedInput {
+                    name: FIXTURE_INPUT_NAME.to_string(),
+                    category: InputCategory::Recorded,
+                    description: "deterministic ASCII word text".to_string(),
+                    identity_sha256: "f".repeat(64),
+                    files: 1,
+                    bytes: 4096,
+                    provenance: Some(GeneratedProvenance {
+                        generator: "zipf_ascii_text".to_string(),
+                        generator_revision: 1,
+                        seed: 20260813,
+                        vocabulary_size: 256,
+                    }),
+                }],
+                program: ProgramIdentity {
+                    binary_bytes: 65_536,
+                    sha256: "b".repeat(64),
+                },
+                oracle: OracleOutcome {
+                    kind: OracleKind::GoldenStdout,
+                    reference: "performance/fixtures/wordfreq/expected-stdout.txt".to_string(),
+                    reference_sha256: "c".repeat(64),
+                    observed_sha256: "c".repeat(64),
+                    verdict: OracleVerdict::Match,
+                    deterministic_across_samples: true,
+                    detail: String::new(),
+                },
+                samples: elapsed
+                    .into_iter()
+                    .map(|process_elapsed_ns| RuntimeSample {
+                        process_elapsed_ns,
+                        peak_memory_bytes: 1024,
+                        exit_code: 0,
+                        stdout_bytes: 8,
+                        stdout_sha256: "c".repeat(64),
+                    })
+                    .collect(),
+            }],
+            failures: Vec::new(),
+        }
+    }
+
+    fn stored_runtime(
+        reports: impl IntoIterator<Item = rue_perf_schema::RuntimeReport>,
+    ) -> Vec<StoredRuntimeReport> {
+        reports
+            .into_iter()
+            .map(|report| {
+                StoredRuntimeReport::read(&rue_perf_schema::canonical_json(&report).unwrap())
+                    .unwrap()
+            })
+            .collect()
+    }
+
+    #[test]
+    fn runtime_points_carry_medians_derived_from_raw_samples() {
+        let manifest = RuntimeManifest::parse(RUNTIME_MANIFEST).expect("runtime manifest");
+        let data = derive_runtime(
+            &manifest,
+            &stored_runtime([runtime_report('a', [7, 5, 6])]),
+            &[],
+        );
+        let point = &data.platforms[0].epochs[0].points[0];
+        let workload = &point.workloads["wordfreq"];
+        assert!(point.complete);
+        assert_eq!(workload.metrics["wall_clock"].median, 6);
+        assert_eq!(workload.metrics["binary_size"].median, 65_536);
+        // Nothing derived is stored, so the identity that makes two raw
+        // medians comparable has to ride the point.
+        assert_eq!(workload.fixture_identity, "f".repeat(64));
+        assert_eq!(workload.flag_posture, "advisory");
+        assert_eq!(data.platforms[0].epochs[0].optimization, "o3");
+    }
+
+    #[test]
+    fn a_report_whose_program_was_wrong_is_surfaced_rather_than_plotted() {
+        // The runtime counterpart of a rejected run: the single most useful
+        // thing to see when the page stops advancing is why.
+        let manifest = RuntimeManifest::parse(RUNTIME_MANIFEST).expect("runtime manifest");
+        let mut report = runtime_report('a', [7, 5, 6]);
+        report.workloads[0].oracle.verdict = rue_perf_schema::OracleVerdict::Mismatch;
+        let data = derive_runtime(&manifest, &stored_runtime([report]), &[]);
+        assert!(data.platforms.is_empty());
+        assert_eq!(data.rejected.len(), 1);
+        assert!(
+            data.rejected[0]
+                .reasons
+                .iter()
+                .any(|reason| reason.contains("oracle")),
+            "{:?}",
+            data.rejected[0].reasons
+        );
+    }
+
+    #[test]
+    fn an_incomplete_workload_publishes_no_median() {
+        // A median over a truncated sample set would look like a measurement
+        // and be an artifact of whatever ended the run.
+        let manifest = RuntimeManifest::parse(RUNTIME_MANIFEST).expect("runtime manifest");
+        let mut report = runtime_report('a', [7, 5, 6]);
+        report.workloads[0].samples.truncate(1);
+        let data = derive_runtime(&manifest, &stored_runtime([report]), &[]);
+        let point = &data.platforms[0].epochs[0].points[0];
+        assert!(!point.complete);
+        assert!(point.workloads.is_empty());
+    }
+
+    #[test]
+    fn runtime_points_are_ordered_by_measurement_time() {
+        let manifest = RuntimeManifest::parse(RUNTIME_MANIFEST).expect("runtime manifest");
+        let data = derive_runtime(
+            &manifest,
+            &stored_runtime([
+                runtime_report('b', [3, 3, 3]),
+                runtime_report('a', [1, 1, 1]),
+            ]),
+            &[],
+        );
+        let points = &data.platforms[0].epochs[0].points;
+        assert_eq!(points.len(), 2);
+        assert!(points[0].finished_at <= points[1].finished_at);
+    }
+
+    #[test]
+    fn a_runtime_point_carries_both_identities_it_may_be_segmented_on() {
+        // Recording rather than pinning the workload's source is only
+        // defensible if a consumer can see when it moved, so both the fixture
+        // digest and the source digest have to reach the derived data.
+        let manifest = RuntimeManifest::parse(RUNTIME_MANIFEST).expect("runtime manifest");
+        let data = derive_runtime(
+            &manifest,
+            &stored_runtime([runtime_report('a', [7, 5, 6])]),
+            &[],
+        );
+        let workload = &data.platforms[0].epochs[0].points[0].workloads["wordfreq"];
+        assert_eq!(workload.fixture_identity, "f".repeat(64));
+        assert_eq!(workload.source_identity, "3".repeat(64));
+    }
+
+    #[test]
+    fn a_record_this_build_cannot_read_is_reported_rather_than_fatal() {
+        // The store is append-only, so a record from a future schema can never
+        // be removed from it. A reader that failed the whole derivation on
+        // meeting one would break the site build permanently.
+        let manifest = RuntimeManifest::parse(RUNTIME_MANIFEST).expect("runtime manifest");
+        let data = derive_runtime(
+            &manifest,
+            &stored_runtime([runtime_report('a', [7, 5, 6])]),
+            &[UnreadableRecord {
+                name: "deadbeef.json".to_string(),
+                detail: "unknown field `peer_versions`".to_string(),
+            }],
+        );
+        // The readable record still derives.
+        assert_eq!(data.platforms[0].epochs[0].points.len(), 1);
+        assert_eq!(data.rejected.len(), 1);
+        assert_eq!(data.rejected[0].report, "deadbeef.json");
+        assert!(
+            data.rejected[0].reasons[0].contains("could not read the record"),
+            "{:?}",
+            data.rejected[0].reasons
+        );
+    }
+
+    #[test]
+    fn an_unreadable_record_on_disk_does_not_abort_loading() {
+        let directory = tempfile::tempdir().expect("temp dir");
+        let runtime = directory.path().join("runtime");
+        std::fs::create_dir(&runtime).expect("create");
+        let good = rue_perf_schema::canonical_json(&runtime_report('a', [7, 5, 6])).unwrap();
+        std::fs::write(runtime.join("good.json"), &good).expect("write");
+        std::fs::write(
+            runtime.join("future.json"),
+            r#"{"record_kind":"runtime_v2"}"#,
+        )
+        .expect("write");
+
+        let (reports, unreadable) = load_runtime_records(directory.path()).expect("loaded");
+        assert_eq!(reports.len(), 1);
+        assert_eq!(unreadable.len(), 1);
+        assert_eq!(unreadable[0].name, "future.json");
+    }
+
+    #[test]
+    fn a_derivation_without_a_runtime_manifest_has_no_runtime_section() {
+        // A page must be able to tell "not asked for" from "asked for and
+        // nothing collected yet".
+        let manifest = manifest_for_batch(1);
+        assert!(derive(&manifest, &[]).runtime.is_none());
     }
 }

--- a/crates/rue-bench/src/digest.rs
+++ b/crates/rue-bench/src/digest.rs
@@ -1,0 +1,50 @@
+//! The one spelling of a digest this runner writes.
+//!
+//! Every record kind names things it cannot contain — a fixture, a binary, a
+//! program's output — by SHA-256, and validation checks that name against a
+//! fixed format: 64 lowercase hexadecimal characters. Three copies of the
+//! formatting would be three chances to write a digest some validator will
+//! later refuse, so there is one.
+
+use std::path::Path;
+
+use sha2::{Digest, Sha256};
+
+/// Digest some bytes, lowercase hexadecimal.
+pub fn sha256_bytes(bytes: &[u8]) -> String {
+    format!("{:x}", Sha256::digest(bytes))
+}
+
+/// Digest a file's contents.
+pub fn sha256_file(path: &Path) -> Result<String, String> {
+    std::fs::read(path)
+        .map(|bytes| sha256_bytes(&bytes))
+        .map_err(|error| format!("could not hash {}: {error}", path.display()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn digests_are_lowercase_hex_of_the_expected_width() {
+        // The format validation checks for. A `{:X}` here would produce digests
+        // every validator in the system rejects.
+        let digest = sha256_bytes(b"");
+        assert_eq!(
+            digest,
+            "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+        );
+        assert_eq!(digest.len(), 64);
+        assert!(
+            digest
+                .bytes()
+                .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte))
+        );
+    }
+
+    #[test]
+    fn hashing_a_missing_file_is_an_error_rather_than_a_default() {
+        assert!(sha256_file(Path::new("definitely-not-a-real-file-xyz")).is_err());
+    }
+}

--- a/crates/rue-bench/src/fixture.rs
+++ b/crates/rue-bench/src/fixture.rs
@@ -1,0 +1,287 @@
+//! Deterministic fixture generation for runtime workloads (ADR-0072 Phase 1).
+//!
+//! A runtime benchmark needs a large input, and a repository does not want tens
+//! of megabytes of committed prose. The compromise is a checked-in *generator*:
+//! the manifest pins a seed and this module's revision, the bytes are produced
+//! at fixture-preparation time — outside the timed window — and the digest of
+//! what was actually produced is recorded with every observation.
+//!
+//! Two properties make that compromise safe.
+//!
+//! **Byte-exact determinism, everywhere.** The same seed and size produce the
+//! same bytes on every host and in every build. That is why nothing here uses
+//! floating point: a power-law draw computed with `powf` can differ in its last
+//! bit between targets, and a fixture that differs by one byte between two
+//! runners silently makes their series incomparable. The distribution is built
+//! from integer bit tricks instead.
+//!
+//! **A revision that moves when the output moves.** Any change to the algorithm
+//! below must bump [`ZIPF_ASCII_TEXT_REVISION`], because the committed golden
+//! output is a function of these bytes. The runner refuses to generate a
+//! fixture whose declared revision is not the one it implements, so a manifest
+//! and a generator can never drift apart quietly.
+//!
+//! The text is shaped for the workload it feeds: ASCII letter runs separated by
+//! spaces, commas, full stops, and newlines, with word ranks drawn from a
+//! harmonic (Zipf-like) distribution so a few words dominate and a long tail
+//! fills the map. That is what makes `wordfreq` spend its time counting words
+//! and pressing on a hash map rather than starting up.
+
+/// Name of the generator this module implements.
+pub const ZIPF_ASCII_TEXT: &str = "zipf_ascii_text";
+
+/// Revision of that generator.
+///
+/// Bump on any change to the produced bytes. The committed golden output and
+/// every recorded fixture digest are functions of this.
+pub const ZIPF_ASCII_TEXT_REVISION: u32 = 1;
+
+/// SplitMix64: a small, fast, fully specified integer mixer.
+///
+/// Chosen over a library RNG so the fixture's bytes are a property of this
+/// source file rather than of a dependency's version.
+struct SplitMix64 {
+    state: u64,
+}
+
+impl SplitMix64 {
+    fn new(seed: u64) -> SplitMix64 {
+        SplitMix64 { state: seed }
+    }
+
+    fn next(&mut self) -> u64 {
+        self.state = self.state.wrapping_add(0x9E37_79B9_7F4A_7C15);
+        mix(self.state)
+    }
+
+    /// A value in `[0, bound)`. `bound` of zero yields zero.
+    fn below(&mut self, bound: u64) -> u64 {
+        if bound == 0 {
+            return 0;
+        }
+        // Multiply-shift rather than modulo: uniform enough for a text fixture
+        // and free of the modulo bias that would skew the rarest ranks.
+        ((u128::from(self.next()) * u128::from(bound)) >> 64) as u64
+    }
+}
+
+fn mix(value: u64) -> u64 {
+    let mut z = value;
+    z = (z ^ (z >> 30)).wrapping_mul(0xBF58_476D_1CE4_E5B9);
+    z = (z ^ (z >> 27)).wrapping_mul(0x94D0_49BB_1331_11EB);
+    z ^ (z >> 31)
+}
+
+/// The vocabulary word at `rank`, as ASCII lowercase letters.
+///
+/// Derived from the seed and the rank alone, so the same rank is the same word
+/// for the whole fixture without materializing a word list. Lengths run three
+/// to eleven letters, which keeps tokenization realistic without making the
+/// file mostly separators.
+fn word_for_rank(seed: u64, rank: u64) -> Vec<u8> {
+    let mut hash = mix(seed ^ rank.wrapping_mul(0x9E37_79B9_7F4A_7C15));
+    let length = 3 + (hash % 9) as usize;
+    let mut word = Vec::with_capacity(length);
+    for index in 0..length {
+        if index % 12 == 0 {
+            hash = mix(hash ^ (index as u64).wrapping_add(0x5851_F42D_4C95_7F2D));
+        }
+        word.push(b'a' + ((hash >> (5 * (index % 12))) % 26) as u8);
+    }
+    word
+}
+
+/// The highest bucket index a vocabulary of this size supports.
+fn top_bucket(vocabulary_size: u32) -> u32 {
+    // `vocabulary_size >= 1`, checked by the caller, so this cannot underflow.
+    63 - u64::from(vocabulary_size).leading_zeros().min(63)
+}
+
+/// Draw one word rank from a harmonic distribution over `[0, vocabulary_size)`.
+///
+/// A bucket is chosen uniformly and a rank uniformly within it, where bucket
+/// `b` covers `2^b` ranks. Probability per rank is therefore proportional to
+/// `1/rank`, the classic Zipf shape: the commonest word appears in a few
+/// percent of positions and the tail still reaches the rarest words often
+/// enough for them to exist in the counts.
+///
+/// Deliberately not a geometric bucket draw, which would give `1/rank^2` and
+/// leave the vocabulary's tail unvisited — the map would stay small and the
+/// benchmark would measure a handful of hot keys instead of map pressure.
+fn draw_rank(rng: &mut SplitMix64, vocabulary_size: u32) -> u64 {
+    let top = top_bucket(vocabulary_size);
+    let bucket = rng.below(u64::from(top) + 1) as u32;
+    let low = (1u64 << bucket) - 1;
+    let high = ((1u64 << (bucket + 1)) - 1).min(u64::from(vocabulary_size));
+    low + rng.below(high - low)
+}
+
+/// Generate exactly `bytes` of deterministic ASCII text.
+///
+/// Exactly, not approximately: the size is part of the workload contract that a
+/// suite revision pins, and a generator that overshot by a word would make the
+/// committed golden output depend on where the last word happened to land.
+pub fn generate_zipf_ascii_text(seed: u64, bytes: u64, vocabulary_size: u32) -> Vec<u8> {
+    let capacity = usize::try_from(bytes).unwrap_or(usize::MAX);
+    let mut text = Vec::with_capacity(capacity);
+    if capacity == 0 || vocabulary_size == 0 {
+        return text;
+    }
+    let mut rng = SplitMix64::new(mix(seed));
+    // A separate stream for punctuation, so changing the sentence shape later
+    // would not also reshuffle every word.
+    let mut punctuation = SplitMix64::new(mix(seed ^ 0xA5A5_A5A5_A5A5_A5A5));
+
+    let mut words_in_sentence = 0u32;
+    while text.len() < capacity {
+        let word = word_for_rank(seed, draw_rank(&mut rng, vocabulary_size));
+        // Stop before a partial word: a truncated word would be a different
+        // token and would move the golden output for a size change of one byte.
+        if text.len() + word.len() + 1 > capacity {
+            break;
+        }
+        text.extend_from_slice(&word);
+        words_in_sentence += 1;
+
+        // Separators are non-letters, so they all terminate a token. Their mix
+        // exists to keep the input shaped like prose rather than like one
+        // enormous space-separated line.
+        let roll = punctuation.below(64);
+        if words_in_sentence >= 8 && roll < 12 {
+            text.push(b'.');
+            text.push(b'\n');
+            words_in_sentence = 0;
+        } else if roll < 20 {
+            text.push(b',');
+            text.push(b' ');
+        } else {
+            text.push(b' ');
+        }
+        // The pair separators may have pushed one byte past the reservation.
+        text.truncate(capacity);
+    }
+    // Pad with separators rather than letters: padding must not invent a word.
+    while text.len() + 1 < capacity {
+        text.push(b'.');
+    }
+    if text.len() < capacity {
+        text.push(b'\n');
+    }
+    text
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::BTreeSet;
+
+    #[test]
+    fn generation_is_byte_exact_across_calls() {
+        // The property the whole design rests on: two runners must produce the
+        // same fixture, or their series are not comparable.
+        let first = generate_zipf_ascii_text(20260813, 64 * 1024, 4096);
+        let second = generate_zipf_ascii_text(20260813, 64 * 1024, 4096);
+        assert_eq!(first, second);
+    }
+
+    #[test]
+    fn a_different_seed_produces_different_text() {
+        let first = generate_zipf_ascii_text(1, 64 * 1024, 4096);
+        let second = generate_zipf_ascii_text(2, 64 * 1024, 4096);
+        assert_ne!(first, second);
+        assert_eq!(first.len(), second.len());
+    }
+
+    #[test]
+    fn the_fixture_is_exactly_the_requested_size() {
+        // Approximate sizing would make the committed golden output depend on
+        // where the last word happened to fall.
+        for bytes in [1u64, 2, 17, 1024, 65_537] {
+            let text = generate_zipf_ascii_text(20260813, bytes, 4096);
+            assert_eq!(text.len() as u64, bytes, "at {bytes} bytes");
+        }
+    }
+
+    #[test]
+    fn the_text_is_ascii_letters_and_separators_only() {
+        let text = generate_zipf_ascii_text(20260813, 128 * 1024, 4096);
+        assert!(
+            text.iter()
+                .all(|byte| byte.is_ascii_lowercase() || matches!(byte, b' ' | b',' | b'.' | b'\n')),
+            "the fixture must contain nothing the workload's tokenizer has not been shown"
+        );
+    }
+
+    #[test]
+    fn a_prefix_of_the_text_is_not_a_prefix_of_a_longer_generation() {
+        // Documents a real constraint rather than a nicety: the golden output
+        // is a function of the exact declared size, so changing `bytes` is a
+        // workload change and must be a suite-revision event.
+        let short = generate_zipf_ascii_text(20260813, 4096, 4096);
+        let long = generate_zipf_ascii_text(20260813, 8192, 4096);
+        assert_ne!(&long[..short.len()], &short[..]);
+    }
+
+    #[test]
+    fn the_distribution_reaches_the_whole_vocabulary() {
+        // The reason the bucket draw is uniform rather than geometric. A
+        // 1/rank^2 shape leaves most of the vocabulary unvisited, and the
+        // workload then measures a few hot keys instead of map pressure.
+        let vocabulary = 1024u32;
+        let text = generate_zipf_ascii_text(20260813, 2 * 1024 * 1024, vocabulary);
+        let distinct: BTreeSet<&[u8]> = text
+            .split(|byte| !byte.is_ascii_lowercase())
+            .filter(|word| !word.is_empty())
+            .collect();
+        assert!(
+            distinct.len() > (vocabulary as usize) / 2,
+            "only {} of {vocabulary} vocabulary words appeared",
+            distinct.len()
+        );
+    }
+
+    #[test]
+    fn the_distribution_is_skewed_rather_than_uniform() {
+        // The other half of the shape. A uniform draw would make every count
+        // equal and the tie-breaking the workload exists to exercise moot.
+        let text = generate_zipf_ascii_text(20260813, 1024 * 1024, 1024);
+        let mut counts: std::collections::BTreeMap<&[u8], usize> =
+            std::collections::BTreeMap::new();
+        let mut total = 0usize;
+        for word in text
+            .split(|byte| !byte.is_ascii_lowercase())
+            .filter(|word| !word.is_empty())
+        {
+            *counts.entry(word).or_default() += 1;
+            total += 1;
+        }
+        let top = counts.values().max().copied().unwrap_or(0);
+        assert!(
+            top * 20 > total,
+            "the commonest of {} words took only {top} of {total} positions",
+            counts.len()
+        );
+    }
+
+    #[test]
+    fn a_rank_always_names_the_same_word() {
+        assert_eq!(word_for_rank(7, 12), word_for_rank(7, 12));
+        assert_ne!(word_for_rank(7, 12), word_for_rank(7, 13));
+        assert_ne!(word_for_rank(7, 12), word_for_rank(8, 12));
+    }
+
+    #[test]
+    fn every_generated_word_is_a_plausible_token() {
+        for rank in 0..2048u64 {
+            let word = word_for_rank(20260813, rank);
+            assert!((3..=11).contains(&word.len()), "{word:?}");
+            assert!(word.iter().all(u8::is_ascii_lowercase), "{word:?}");
+        }
+    }
+
+    #[test]
+    fn an_empty_request_generates_nothing_rather_than_panicking() {
+        assert!(generate_zipf_ascii_text(1, 0, 1024).is_empty());
+        assert!(generate_zipf_ascii_text(1, 1024, 0).is_empty());
+    }
+}

--- a/crates/rue-bench/src/incremental.rs
+++ b/crates/rue-bench/src/incremental.rs
@@ -9,6 +9,7 @@ use std::fs;
 use std::path::{Path, PathBuf};
 use std::time::{Duration, Instant};
 
+use crate::digest::sha256_bytes as sha256;
 use rue_compiler::unstable::{
     EndpointQueryWork, EndpointWork, MetricsSnapshot, QueryRuntimeMetrics, QueryValidationMetrics,
 };
@@ -24,7 +25,6 @@ use rue_perf_schema::{
     validate_edit_report,
 };
 use serde::Deserialize;
-use sha2::{Digest, Sha256};
 
 #[derive(Debug, Clone, Deserialize)]
 #[serde(deny_unknown_fields)]
@@ -1551,10 +1551,6 @@ fn elapsed_ns(started: Instant) -> u64 {
 
 fn delta(before: usize, after: usize) -> u64 {
     after.saturating_sub(before) as u64
-}
-
-fn sha256(bytes: &[u8]) -> String {
-    format!("{:x}", Sha256::digest(bytes))
 }
 
 fn warnings_identity(warnings: &[CompileWarning]) -> String {

--- a/crates/rue-bench/src/main.rs
+++ b/crates/rue-bench/src/main.rs
@@ -11,14 +11,22 @@
 //! and hands the result to `rue_perf_schema::validate_run`. Keeping judgement
 //! out of the producer is what lets validation catch a producer that is itself
 //! wrong.
+//!
+//! The `runtime` subcommand answers ADR-0072's question instead: not how fast
+//! Rue compiles a program, but how fast the compiled program runs. It follows
+//! the same separation — record what happened, let `rue_perf_schema` decide
+//! appendability — over its own manifest and record kind.
 
 mod calibrate;
 mod check_pins;
 mod derive;
+mod digest;
 mod environment;
+mod fixture;
 mod incremental;
 mod measure;
 mod pins;
+mod runtime;
 mod scaling;
 
 use std::collections::BTreeMap;
@@ -76,9 +84,12 @@ Required:
   --out <path>         where to write the run object
 
 Subcommands:
-  derive --manifest <path> --data-root <dir> --out <path>
+  derive --manifest <path> [--runtime-manifest <path>] --data-root <dir>
+         --out <path>
                        rebuild the dashboard's view from raw records. Reads the
                        performance-data-v1 checkout; writes derived JSON.
+                       --runtime-manifest additionally derives the ADR-0072
+                       runtime record kind from the same store.
 
   check-pins --manifest <path> --compiler <path> [--repo-root <path>]
                        answer whether this tree still matches every collection
@@ -93,6 +104,14 @@ Subcommands:
   scaling --manifest <path> --compiler <path> --commit <sha> --out <path>
                        measure maintained programs with independent fresh
                        compiler processes; also writes a Markdown report.
+
+  runtime --platform <name> --compiler <path> --commit <sha> --out <path>
+                       measure how fast compiled Rue programs run (ADR-0072).
+                       Builds each workload at release quality, prepares its
+                       fixture outside the timed window, measures N fresh
+                       processes spawn-to-exit, and judges the output against a
+                       committed golden. Defaults to performance/runtime.toml;
+                       override with --manifest.
 
   incremental --commit <sha> --out <path>
                        measure retained-session edits of Mosaic and Lattice,
@@ -135,6 +154,15 @@ fn main() -> ExitCode {
             Err(message) => {
                 eprintln!("rue-bench: {message}");
                 ExitCode::from(exit::USAGE)
+            }
+        };
+    }
+    if std::env::args().nth(1).as_deref() == Some("runtime") {
+        return match runtime::run() {
+            Ok(status) => ExitCode::from(status),
+            Err(message) => {
+                eprintln!("rue-bench runtime: {message}");
+                ExitCode::from(runtime::exit::USAGE)
             }
         };
     }
@@ -218,6 +246,7 @@ fn run_calibration() -> Result<(), String> {
 /// uses, so the page and the calibration can never disagree about what moved.
 fn run_derive() -> Result<(), String> {
     let mut manifest_path = None;
+    let mut runtime_manifest_path = None;
     let mut data_root = None;
     let mut out = None;
     let mut args = std::env::args().skip(2);
@@ -228,6 +257,7 @@ fn run_derive() -> Result<(), String> {
         };
         match flag.as_str() {
             "--manifest" => manifest_path = Some(PathBuf::from(value()?)),
+            "--runtime-manifest" => runtime_manifest_path = Some(PathBuf::from(value()?)),
             "--data-root" => data_root = Some(PathBuf::from(value()?)),
             "--out" => out = Some(PathBuf::from(value()?)),
             other => return Err(format!("unrecognized argument {other:?}")),
@@ -242,7 +272,32 @@ fn run_derive() -> Result<(), String> {
     let manifest = Manifest::parse(&text).map_err(|error| error.to_string())?;
 
     let runs = derive::load_data_branch(&data_root)?;
-    let data = derive::derive(&manifest, &runs);
+    let mut data = derive::derive(&manifest, &runs);
+
+    // The ADR-0072 runtime record kind, derived from the same store by the same
+    // step. Opt-in rather than implicit: a caller that does not name a runtime
+    // manifest gets no runtime section at all, so a page can tell "not asked
+    // for" from "asked for and nothing collected yet".
+    if let Some(path) = runtime_manifest_path {
+        let text = std::fs::read_to_string(&path)
+            .map_err(|error| format!("could not read {}: {error}", path.display()))?;
+        let runtime_manifest = rue_perf_schema::RuntimeManifest::parse(&text)?;
+        let (reports, unreadable) = derive::load_runtime_records(&data_root)?;
+        let runtime = derive::derive_runtime(&runtime_manifest, &reports, &unreadable);
+        let points: usize = runtime
+            .platforms
+            .iter()
+            .flat_map(|platform| platform.epochs.iter())
+            .map(|epoch| epoch.points.len())
+            .sum();
+        eprintln!(
+            "rue-bench: derived {points} runtime point(s) across {} platform(s); \
+             {} report(s) rejected",
+            runtime.platforms.len(),
+            runtime.rejected.len()
+        );
+        data.runtime = Some(runtime);
+    }
 
     let encoded = serde_json::to_string_pretty(&data)
         .map_err(|error| format!("could not serialize the site data: {error}"))?;

--- a/crates/rue-bench/src/measure.rs
+++ b/crates/rue-bench/src/measure.rs
@@ -18,12 +18,12 @@ use std::process::{Command, Stdio};
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::Instant;
 
+use crate::digest::{sha256_bytes, sha256_file};
 use rue_perf_schema::{
     BuildBoundaryEvidence, BuildBoundaryPolicy, CompilerBoundaryEvidence,
     CompilerCriticalPathEvidence, CompilerInputClass, CompilerWork, FailureRecord, PhaseAccounting,
     RunnerBoundaryEvidence, RunnerClockBoundary, Sample, WorkloadShape,
 };
-use sha2::{Digest, Sha256};
 
 static PROCESS_DIRECTORY_SEQUENCE: AtomicU64 = AtomicU64::new(0);
 
@@ -290,40 +290,12 @@ fn run_once(request: &SampleRequest<'_>) -> Result<CompletedCompile, String> {
     // process creation. It stops after successful exit and independent native
     // output verification below.
     let started = Instant::now();
-    let mut child = command
-        .spawn()
-        .map_err(|error| format!("could not spawn the compiler: {error}"))?;
+    let reaped = spawn_and_reap(&mut command).map_err(|error| format!("the compiler {error}"))?;
+    let stdout = String::from_utf8_lossy(&reaped.stdout).into_owned();
+    let stderr = String::from_utf8_lossy(&reaped.stderr).into_owned();
+    let peak = reaped.peak_memory_bytes;
 
-    // Drain both pipes on their own threads. Reading one to completion before
-    // the other deadlocks as soon as the unread pipe's buffer fills, and the
-    // benchmark JSON is large enough for that to be a live risk.
-    let mut stdout_pipe = child.stdout.take().expect("stdout was piped");
-    let mut stderr_pipe = child.stderr.take().expect("stderr was piped");
-    let (stdout, stderr, peak, status) = std::thread::scope(|scope| {
-        let stdout_reader = scope.spawn(move || {
-            let mut buffer = String::new();
-            let _ = stdout_pipe.read_to_string(&mut buffer);
-            buffer
-        });
-        let stderr_reader = scope.spawn(move || {
-            let mut buffer = String::new();
-            let _ = stderr_pipe.read_to_string(&mut buffer);
-            buffer
-        });
-        let reaped = wait_for_peak_memory(&child);
-        (
-            stdout_reader.join().unwrap_or_default(),
-            stderr_reader.join().unwrap_or_default(),
-            reaped.as_ref().map_or(0, |(peak, _)| *peak),
-            reaped.map(|(_, status)| status),
-        )
-    });
-    // `wait4` above already reaped the child, so `child` must not be waited on
-    // again. `Child::drop` does not reap, so letting it fall out of scope is
-    // correct; calling `wait()` here would fail with ECHILD.
-    drop(child);
-
-    let status = status?;
+    let status = reaped.status;
     if !libc::WIFEXITED(status) || libc::WEXITSTATUS(status) != 0 {
         let tail: String = stderr.lines().rev().take(5).collect::<Vec<_>>().join("\n");
         return Err(format!(
@@ -424,6 +396,77 @@ fn run_once(request: &SampleRequest<'_>) -> Result<CompletedCompile, String> {
     })
 }
 
+/// One child process, run to completion with its output and peak RSS.
+pub(crate) struct ReapedChild {
+    /// Everything the child wrote to stdout.
+    pub stdout: Vec<u8>,
+    /// Everything it wrote to stderr.
+    pub stderr: Vec<u8>,
+    /// Its `wait4` status word.
+    pub status: libc::c_int,
+    /// Its peak resident set size, in bytes.
+    pub peak_memory_bytes: u64,
+}
+
+/// Spawn a prepared command, drain its pipes, and reap it.
+///
+/// The caller owns the clock: the compiler path stops timing only after it has
+/// verified the emitted binary, while a runtime sample stops at exit. Sharing
+/// the spawn instead of the timing keeps both honest about their own boundary
+/// while there is exactly one implementation of the pipe-draining and `wait4`
+/// dance below.
+///
+/// Bytes, not `String`: a measured program's output is judged by digest and may
+/// not be UTF-8 at all. The compiler path converts afterwards, which moves that
+/// validation and one copy out of the reader threads and into the caller's
+/// measured window — sub-millisecond against samples measured in hundreds of
+/// milliseconds, and far below the regime's dispersion, but a real change
+/// rather than a byte-for-byte preserving refactor.
+///
+/// `stdout` and `stderr` must already be piped.
+pub(crate) fn spawn_and_reap(command: &mut Command) -> Result<ReapedChild, String> {
+    let mut child = command
+        .spawn()
+        .map_err(|error| format!("could not be spawned: {error}"))?;
+
+    // Drain both pipes on their own threads. Reading one to completion before
+    // the other deadlocks as soon as the unread pipe's buffer fills, and both
+    // benchmark JSON and program output are large enough for that to be a live
+    // risk.
+    let mut stdout_pipe = child.stdout.take().expect("stdout was piped");
+    let mut stderr_pipe = child.stderr.take().expect("stderr was piped");
+    let (stdout, stderr, reaped) = std::thread::scope(|scope| {
+        let stdout_reader = scope.spawn(move || {
+            let mut buffer = Vec::new();
+            let _ = stdout_pipe.read_to_end(&mut buffer);
+            buffer
+        });
+        let stderr_reader = scope.spawn(move || {
+            let mut buffer = Vec::new();
+            let _ = stderr_pipe.read_to_end(&mut buffer);
+            buffer
+        });
+        let reaped = wait_for_peak_memory(&child);
+        (
+            stdout_reader.join().unwrap_or_default(),
+            stderr_reader.join().unwrap_or_default(),
+            reaped,
+        )
+    });
+    // `wait4` above already reaped the child, so `child` must not be waited on
+    // again. `Child::drop` does not reap, so letting it fall out of scope is
+    // correct; calling `wait()` here would fail with ECHILD.
+    drop(child);
+
+    let (peak_memory_bytes, status) = reaped?;
+    Ok(ReapedChild {
+        stdout,
+        stderr,
+        status,
+        peak_memory_bytes,
+    })
+}
+
 /// Reap one child and report *its* peak resident memory, in bytes.
 ///
 /// Deliberately `wait4` rather than `getrusage(RUSAGE_CHILDREN)`. The latter
@@ -446,23 +489,13 @@ fn wait_for_peak_memory(child: &std::process::Child) -> Result<(u64, libc::c_int
     };
     if reaped < 0 {
         return Err(format!(
-            "could not reap the compiler: {}",
+            "could not be reaped: {}",
             std::io::Error::last_os_error()
         ));
     }
     // SAFETY: `wait4` succeeded, so the usage value is initialized.
     let usage = unsafe { usage.assume_init() };
     Ok((max_rss_bytes(usage.ru_maxrss), status))
-}
-
-fn sha256_bytes(bytes: &[u8]) -> String {
-    format!("{:x}", Sha256::digest(bytes))
-}
-
-fn sha256_file(path: &Path) -> Result<String, String> {
-    fs::read(path)
-        .map(|bytes| sha256_bytes(&bytes))
-        .map_err(|error| format!("could not hash {}: {error}", path.display()))
 }
 
 fn directory_contains_only(directory: &Path, expected: &Path) -> Result<bool, String> {

--- a/crates/rue-bench/src/runtime.rs
+++ b/crates/rue-bench/src/runtime.rs
@@ -1,0 +1,839 @@
+//! The ADR-0072 runtime-measurement mode: how fast does compiled Rue *run*?
+//!
+//! The compile-time runner in `main.rs` measures the compiler. This one
+//! measures the program the compiler produced. It is a mode of the same binary
+//! rather than a separate tool, so the two can never disagree about what a
+//! sample, an epoch, or a canonical record means.
+//!
+//! One run does four things per workload, in this order:
+//!
+//! 1. **Build** the program at release quality (`-O3`), and record the
+//!    executable's size and digest. This compilation is *not* a compile-time
+//!    observation and never enters a compile-time series: a one-sample compile
+//!    from here matches no declared epoch in `manifest.toml` or `scaling.toml`,
+//!    and ADR-0067's validation would rightly refuse it (ADR-0072 Decision 7).
+//! 2. **Prepare** the fixture from the manifest's pinned seed and generator
+//!    revision, and record the digest of the bytes actually produced. Outside
+//!    the timed window, always.
+//! 3. **Measure** N independent fresh processes, spawn to exit, recording wall
+//!    time, peak RSS, exit code, and a digest of stdout for each.
+//! 4. **Judge** the output against the committed golden, and check that every
+//!    sample produced the same bytes. Also outside the timed window.
+//!
+//! Judgement stops there. This module records what happened — including a wrong
+//! answer, a crash, and a fixture whose digest moved — and hands the record to
+//! `rue_perf_schema::validate_runtime_report`, which decides appendability.
+//! Keeping the verdict out of the producer is what lets validation catch a
+//! producer that is itself wrong.
+
+use std::collections::BTreeMap;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Stdio};
+use std::time::Instant;
+
+use rue_perf_schema::{
+    FIXTURE_ARGUMENT, FIXTURE_INPUT_NAME, GeneratedProvenance, OracleOutcome, OracleVerdict,
+    ProgramIdentity, RUNTIME_RECORD_KIND, RUNTIME_REPORT_SCHEMA_VERSION, RecordedInput,
+    RuntimeCompleteness, RuntimeEpoch, RuntimeFailure, RuntimeIdentity, RuntimeManifest,
+    RuntimeObservation, RuntimeRegime, RuntimeReport, RuntimeSample, RuntimeSuiteRevision,
+    RuntimeWorkload, validate_runtime_report,
+};
+
+use crate::digest::sha256_bytes as sha256;
+use crate::fixture;
+use crate::measure::spawn_and_reap;
+use crate::{environment, pins};
+
+/// Exit statuses this mode reports.
+pub mod exit {
+    /// The report was written and is appendable, and the suite completed.
+    pub const OK: u8 = 0;
+    /// The runner could not be configured or could not write its output.
+    pub const USAGE: u8 = 2;
+    /// A report was written, but validation refuses it for its series.
+    pub const NOT_APPENDABLE: u8 = 3;
+    /// The report is appendable, but a workload did not complete.
+    ///
+    /// Distinct from [`NOT_APPENDABLE`]: the evidence belongs in the store and
+    /// the series simply has a hole here. Collection health should be visible
+    /// on the dashboard, not absent from it.
+    pub const INCOMPLETE: u8 = 5;
+}
+
+struct Options {
+    manifest: PathBuf,
+    platform: String,
+    epoch: Option<u32>,
+    compiler: PathBuf,
+    commit: String,
+    repo_root: PathBuf,
+    std_root: Option<PathBuf>,
+    output: PathBuf,
+    workdir: Option<PathBuf>,
+}
+
+fn parse_args() -> Result<Options, String> {
+    let mut manifest = None;
+    let mut platform = None;
+    let mut epoch = None;
+    let mut compiler = None;
+    let mut commit = None;
+    let mut output = None;
+    let mut repo_root = None;
+    let mut std_root = None;
+    let mut workdir = None;
+
+    let mut args = std::env::args().skip(2);
+    while let Some(flag) = args.next() {
+        let mut value = || {
+            args.next()
+                .ok_or_else(|| format!("{flag} requires a value"))
+        };
+        match flag.as_str() {
+            "--manifest" => manifest = Some(PathBuf::from(value()?)),
+            "--platform" => platform = Some(value()?),
+            "--epoch" => {
+                let raw = value()?;
+                epoch = Some(
+                    raw.parse::<u32>()
+                        .map_err(|_| format!("--epoch expects a number, got {raw:?}"))?,
+                );
+            }
+            "--compiler" => compiler = Some(PathBuf::from(value()?)),
+            "--commit" => commit = Some(value()?),
+            "--out" => output = Some(PathBuf::from(value()?)),
+            "--repo-root" => repo_root = Some(PathBuf::from(value()?)),
+            "--std-root" => std_root = Some(PathBuf::from(value()?)),
+            "--workdir" => workdir = Some(PathBuf::from(value()?)),
+            other => return Err(format!("unrecognized argument {other:?}")),
+        }
+    }
+
+    let repo_root = repo_root.unwrap_or_else(|| PathBuf::from("."));
+    let std_root = std_root.or_else(|| {
+        let candidate = repo_root.join("std");
+        candidate.is_dir().then_some(candidate)
+    });
+
+    Ok(Options {
+        manifest: manifest.unwrap_or_else(|| repo_root.join("performance/runtime.toml")),
+        platform: platform.ok_or("runtime requires --platform")?,
+        epoch,
+        compiler: compiler.ok_or("runtime requires --compiler")?,
+        commit: commit.ok_or("runtime requires --commit")?,
+        output: output.ok_or("runtime requires --out")?,
+        repo_root,
+        std_root,
+        workdir,
+    })
+}
+
+/// Run the runtime suite for one platform epoch.
+pub fn run() -> Result<u8, String> {
+    let options = parse_args()?;
+    let text = std::fs::read_to_string(&options.manifest)
+        .map_err(|error| format!("could not read {}: {error}", options.manifest.display()))?;
+    let manifest = RuntimeManifest::parse(&text)?;
+
+    // Without `--epoch`, the manifest's collection epoch for this platform is
+    // measured, for the same reason the compile-time runner does it: a workflow
+    // naming an epoch number would have to be edited alongside the manifest,
+    // and the two would eventually disagree about what is being collected.
+    let epoch = match options.epoch {
+        Some(id) => manifest.epoch(&options.platform, id).ok_or_else(|| {
+            format!(
+                "the runtime manifest declares no epoch {id} for platform {}",
+                options.platform
+            )
+        })?,
+        None => manifest
+            .collection_epoch(&options.platform)
+            .ok_or_else(|| {
+                format!(
+                    "the runtime manifest marks no collection epoch for platform {}; \
+                     pass --epoch to measure a specific one",
+                    options.platform
+                )
+            })?,
+    };
+    let suite = manifest.suite(epoch.suite_revision).ok_or_else(|| {
+        format!(
+            "runtime suite revision {} is not declared",
+            epoch.suite_revision
+        )
+    })?;
+
+    let holder;
+    let workdir = match &options.workdir {
+        Some(directory) => {
+            std::fs::create_dir_all(directory)
+                .map_err(|error| format!("could not create {}: {error}", directory.display()))?;
+            directory.as_path()
+        }
+        None => {
+            holder = tempfile::tempdir()
+                .map_err(|error| format!("could not create a work directory: {error}"))?;
+            holder.path()
+        }
+    };
+
+    let started_at = crate::utc_timestamp();
+    let compiler_version = compiler_version(&options.compiler)?;
+    let toolchain_hash =
+        pins::toolchain_hash(&options.repo_root).map_err(|error| error.to_string())?;
+    let stdlib_hash = match options.std_root.as_deref() {
+        Some(root) => pins::stdlib_hash(root).map_err(|error| error.to_string())?,
+        None => String::new(),
+    };
+
+    let mut failures: Vec<RuntimeFailure> = Vec::new();
+    let mut workload_source_hashes = BTreeMap::new();
+    let mut observations: Vec<RuntimeObservation> = Vec::new();
+
+    for workload in &suite.workloads {
+        match pins::workload_source_hash(
+            &options.compiler,
+            &options.repo_root.join(&workload.source),
+            options.std_root.as_deref(),
+        ) {
+            Ok(hash) => {
+                workload_source_hashes.insert(workload.id.clone(), hash);
+            }
+            Err(error) => {
+                // Recorded, not fatal. The identity of what was measured is
+                // part of the observation, so its absence must be visible in
+                // the record rather than aborting collection.
+                failures.push(RuntimeFailure::ValidationRejected {
+                    workload: workload.id.clone(),
+                    detail: error.to_string(),
+                });
+            }
+        }
+
+        match measure_workload(&options, epoch, workload, workdir, &mut failures) {
+            Ok(observation) => observations.push(observation),
+            Err(failure) => failures.push(failure),
+        }
+    }
+
+    // Sorted order is part of the canonical form, so an unsorted report would
+    // hash differently from the identical measurement written correctly.
+    observations.sort_by(|left, right| left.workload.cmp(&right.workload));
+
+    let report = RuntimeReport {
+        record_kind: RUNTIME_RECORD_KIND.to_string(),
+        schema_version: RUNTIME_REPORT_SCHEMA_VERSION,
+        identity: RuntimeIdentity {
+            suite_revision: epoch.suite_revision,
+            epoch: epoch.id,
+            platform: options.platform.clone(),
+            commit: options.commit.clone(),
+            compiler_version,
+            started_at,
+            finished_at: crate::utc_timestamp(),
+            toolchain_hash,
+            stdlib_hash,
+            workload_source_hashes,
+            environment: environment::fingerprint(),
+        },
+        regime: regime(epoch, suite),
+        workloads: observations,
+        failures,
+    };
+
+    let outcome = validate_runtime_report(&manifest, &report);
+
+    // Written whatever the verdict. Evidence of a broken collection is worth
+    // more than a missing file.
+    let serialized = rue_perf_schema::canonical_json(&report)
+        .map_err(|error| format!("could not serialize the runtime report: {error}"))?;
+    if let Some(parent) = options
+        .output
+        .parent()
+        .filter(|path| !path.as_os_str().is_empty())
+    {
+        std::fs::create_dir_all(parent)
+            .map_err(|error| format!("could not create {}: {error}", parent.display()))?;
+    }
+    std::fs::write(&options.output, &serialized)
+        .map_err(|error| format!("could not write {}: {error}", options.output.display()))?;
+
+    let address = report
+        .content_address()
+        .unwrap_or_else(|_| "<unaddressable>".to_string());
+    eprintln!(
+        "rue-bench runtime: wrote {} ({address})",
+        options.output.display()
+    );
+    for error in &outcome.errors {
+        eprintln!("rue-bench runtime: not appendable: {error}");
+    }
+    for failure in &report.failures {
+        eprintln!(
+            "rue-bench runtime: {} failure: {failure:?}",
+            failure.workload()
+        );
+    }
+
+    Ok(match &outcome.completeness {
+        _ if !outcome.is_appendable() => exit::NOT_APPENDABLE,
+        RuntimeCompleteness::Complete => {
+            eprintln!("rue-bench runtime: complete run; every workload may publish");
+            exit::OK
+        }
+        RuntimeCompleteness::Partial { missing } => {
+            eprintln!(
+                "rue-bench runtime: partial run. Incomplete workloads: {}",
+                missing.join(", ")
+            );
+            exit::INCOMPLETE
+        }
+    })
+}
+
+/// The regime every sample in this report was taken under.
+///
+/// Assembled from the epoch and suite rather than restated by hand, so the
+/// record and the declaration cannot drift; validation then compares the two
+/// independently produced answers.
+fn regime(epoch: &RuntimeEpoch, suite: &RuntimeSuiteRevision) -> RuntimeRegime {
+    RuntimeRegime {
+        measured_boundary: suite.measured_boundary,
+        program_state: "fresh_process".to_string(),
+        os_page_cache: "uncontrolled".to_string(),
+        // Both are facts about this runner's structure, asserted here and
+        // checked by validation. Fixture preparation happens before the clock
+        // starts; the oracle runs after it stops.
+        fixture_preparation_measured: false,
+        oracle_comparison_measured: false,
+        optimization: epoch.optimization,
+        compiler_args: epoch.compiler_args.clone(),
+        target: epoch.target.clone(),
+        thread_policy: epoch.thread_policy,
+        hardware_counters: epoch.hardware_counters,
+    }
+}
+
+/// Build, prepare, measure, and judge one workload.
+fn measure_workload(
+    options: &Options,
+    epoch: &RuntimeEpoch,
+    workload: &RuntimeWorkload,
+    workdir: &Path,
+    failures: &mut Vec<RuntimeFailure>,
+) -> Result<RuntimeObservation, RuntimeFailure> {
+    let source = options.repo_root.join(&workload.source);
+    let binary = workdir.join(format!("{}-program", workload.id));
+    let program = build_program(options, epoch, &source, &binary).map_err(|detail| {
+        RuntimeFailure::CompileFailed {
+            workload: workload.id.clone(),
+            detail,
+        }
+    })?;
+
+    // Outside the timed window, deliberately and structurally: nothing below
+    // starts a clock until the fixture already exists on disk.
+    let fixture_path = workdir.join(&workload.fixture.file_name);
+    let recorded_fixture = prepare_fixture(workload, &fixture_path).map_err(|detail| {
+        RuntimeFailure::FixturePreparationFailed {
+            workload: workload.id.clone(),
+            detail,
+        }
+    })?;
+
+    let arguments: Vec<String> = workload
+        .program_args
+        .iter()
+        .map(|argument| {
+            if argument == FIXTURE_ARGUMENT {
+                fixture_path.display().to_string()
+            } else {
+                argument.clone()
+            }
+        })
+        .collect();
+
+    let samples_wanted = epoch
+        .sampling
+        .get(&workload.id)
+        .map(|policy| policy.samples)
+        .unwrap_or(0);
+    let mut samples: Vec<RuntimeSample> = Vec::with_capacity(samples_wanted as usize);
+    let mut outputs: Vec<Vec<u8>> = Vec::with_capacity(samples_wanted as usize);
+    for index in 0..samples_wanted {
+        eprintln!(
+            "rue-bench runtime: {} sample {}/{samples_wanted}",
+            workload.id,
+            index + 1
+        );
+        match run_sample(&binary, &arguments, workdir) {
+            Ok((sample, stdout)) => {
+                if sample.exit_code != 0 {
+                    failures.push(RuntimeFailure::ProgramCrashed {
+                        workload: workload.id.clone(),
+                        sample_index: index,
+                        detail: format!("the program exited with code {}", sample.exit_code),
+                    });
+                    samples.push(sample);
+                    outputs.push(stdout);
+                    // Keep the evidence and stop: further samples of a program
+                    // that is failing measure nothing.
+                    break;
+                }
+                samples.push(sample);
+                outputs.push(stdout);
+            }
+            Err(detail) => {
+                failures.push(RuntimeFailure::ProgramCrashed {
+                    workload: workload.id.clone(),
+                    sample_index: index,
+                    detail,
+                });
+                break;
+            }
+        }
+    }
+
+    // The clock has stopped for every sample; judging output costs whatever it
+    // costs.
+    let golden_path = options.repo_root.join(&workload.oracle.path);
+    let oracle = judge(workload, &golden_path, &outputs);
+    if oracle.verdict != OracleVerdict::Match {
+        failures.push(RuntimeFailure::WrongOutput {
+            workload: workload.id.clone(),
+            detail: oracle.detail.clone(),
+        });
+    }
+
+    Ok(RuntimeObservation {
+        workload: workload.id.clone(),
+        source: workload.source.clone(),
+        question: workload.question.clone(),
+        // The declared arguments, not the resolved ones: the fixture's path
+        // names a temporary directory, and storing it would make two identical
+        // measurements produce two different records.
+        program_args: workload.program_args.clone(),
+        recorded_inputs: vec![recorded_fixture],
+        program,
+        oracle,
+        samples,
+    })
+}
+
+/// Compile one workload at release quality and describe the executable.
+///
+/// The compile is a cost this harness pays because it must run the program; its
+/// timing is deliberately discarded rather than recorded, per ADR-0072
+/// Decision 7.
+fn build_program(
+    options: &Options,
+    epoch: &RuntimeEpoch,
+    source: &Path,
+    binary: &Path,
+) -> Result<ProgramIdentity, String> {
+    let mut command = Command::new(&options.compiler);
+    command
+        .arg(source)
+        .arg("-o")
+        .arg(binary)
+        .args(&epoch.compiler_args)
+        .arg("--target")
+        .arg(&epoch.target)
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
+    if let Some(std_root) = options.std_root.as_deref() {
+        command.env("RUE_STD_PATH", std_root);
+    }
+    let output = command
+        .output()
+        .map_err(|error| format!("could not run the compiler: {error}"))?;
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        let tail: String = stderr.lines().rev().take(10).collect::<Vec<_>>().join("\n");
+        return Err(format!(
+            "the compiler exited unsuccessfully ({}); stderr tail:\n{tail}",
+            output.status
+        ));
+    }
+    let bytes = std::fs::read(binary)
+        .map_err(|error| format!("could not read the compiled program: {error}"))?;
+    if bytes.is_empty() {
+        return Err("the compiler produced an empty executable".to_string());
+    }
+    Ok(ProgramIdentity {
+        binary_bytes: bytes.len() as u64,
+        sha256: sha256(&bytes),
+    })
+}
+
+/// Generate a workload's fixture and record the identity of the bytes produced.
+///
+/// The generator's revision is checked against the declaration rather than
+/// assumed: the committed golden output is a function of the produced bytes, so
+/// a manifest asking for a revision this binary does not implement would
+/// produce a confusing oracle mismatch instead of a clear refusal.
+fn prepare_fixture(workload: &RuntimeWorkload, path: &Path) -> Result<RecordedInput, String> {
+    let declaration = &workload.fixture;
+    if declaration.generator != fixture::ZIPF_ASCII_TEXT {
+        return Err(format!(
+            "this runner implements the {:?} fixture generator, not {:?}",
+            fixture::ZIPF_ASCII_TEXT,
+            declaration.generator
+        ));
+    }
+    if declaration.generator_revision != fixture::ZIPF_ASCII_TEXT_REVISION {
+        return Err(format!(
+            "the manifest pins {} revision {}, but this runner implements revision {}",
+            declaration.generator,
+            declaration.generator_revision,
+            fixture::ZIPF_ASCII_TEXT_REVISION
+        ));
+    }
+    let bytes = fixture::generate_zipf_ascii_text(
+        declaration.seed,
+        declaration.bytes,
+        declaration.vocabulary_size,
+    );
+    std::fs::write(path, &bytes)
+        .map_err(|error| format!("could not write {}: {error}", path.display()))?;
+    Ok(RecordedInput {
+        name: FIXTURE_INPUT_NAME.to_string(),
+        category: declaration.category,
+        description: declaration.description.clone(),
+        // Over the bytes the program will actually read, not over the
+        // declaration that asked for them. That is what makes a generator whose
+        // output drifted from its declaration visible in the data.
+        identity_sha256: sha256(&bytes),
+        files: 1,
+        bytes: bytes.len() as u64,
+        provenance: Some(GeneratedProvenance {
+            generator: declaration.generator.clone(),
+            generator_revision: declaration.generator_revision,
+            seed: declaration.seed,
+            vocabulary_size: declaration.vocabulary_size,
+        }),
+    })
+}
+
+/// Measure one fresh process, spawn to exit.
+fn run_sample(
+    binary: &Path,
+    arguments: &[String],
+    workdir: &Path,
+) -> Result<(RuntimeSample, Vec<u8>), String> {
+    let mut command = Command::new(binary);
+    command
+        .args(arguments)
+        .current_dir(workdir)
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
+
+    // The clock starts after every piece of setup and immediately before
+    // process creation, and stops once the process has exited and its output
+    // has been drained. Nothing else is inside it.
+    let started = Instant::now();
+    let reaped = spawn_and_reap(&mut command).map_err(|error| format!("the program {error}"))?;
+    let process_elapsed_ns = u64::try_from(started.elapsed().as_nanos()).unwrap_or(u64::MAX);
+
+    let exit_code = if libc::WIFEXITED(reaped.status) {
+        libc::WEXITSTATUS(reaped.status)
+    } else if libc::WIFSIGNALED(reaped.status) {
+        // Negative so a signal can never be read as a successful exit.
+        -libc::WTERMSIG(reaped.status)
+    } else {
+        -1
+    };
+
+    let sample = RuntimeSample {
+        process_elapsed_ns,
+        peak_memory_bytes: reaped.peak_memory_bytes,
+        exit_code,
+        stdout_bytes: reaped.stdout.len() as u64,
+        stdout_sha256: sha256(&reaped.stdout),
+    };
+    Ok((sample, reaped.stdout))
+}
+
+/// Compare what the program printed with what it was supposed to print.
+///
+/// Two independent questions, both answered here: did every sample agree with
+/// the others, and did they agree with the committed golden. A program that
+/// agrees with itself and not the golden is consistently wrong; one that
+/// disagrees with itself is wrong in a more alarming way, and the record
+/// distinguishes them.
+fn judge(workload: &RuntimeWorkload, golden_path: &Path, outputs: &[Vec<u8>]) -> OracleOutcome {
+    let kind = workload.oracle.kind;
+    let reference = workload.oracle.path.clone();
+    let deterministic = outputs.windows(2).all(|pair| pair[0] == pair[1]);
+    let observed_sha256 = outputs
+        .first()
+        .map(|bytes| sha256(bytes))
+        .unwrap_or_default();
+
+    let golden = match std::fs::read(golden_path) {
+        Ok(bytes) => bytes,
+        Err(error) => {
+            return OracleOutcome {
+                kind,
+                reference,
+                reference_sha256: String::new(),
+                observed_sha256,
+                verdict: OracleVerdict::Indeterminate,
+                deterministic_across_samples: deterministic,
+                detail: format!("could not read {}: {error}", golden_path.display()),
+            };
+        }
+    };
+    let reference_sha256 = sha256(&golden);
+
+    let Some(first) = outputs.first() else {
+        return OracleOutcome {
+            kind,
+            reference,
+            reference_sha256,
+            observed_sha256,
+            verdict: OracleVerdict::Indeterminate,
+            deterministic_across_samples: deterministic,
+            detail: "no sample produced output to judge".to_string(),
+        };
+    };
+
+    // Every sample is compared, not just the first. Checking one and asserting
+    // determinism separately would report a match for a run in which the
+    // majority of samples were wrong.
+    let mismatched = outputs.iter().position(|output| output != &golden);
+    let (verdict, detail) = match mismatched {
+        None => (OracleVerdict::Match, String::new()),
+        Some(index) => (
+            OracleVerdict::Mismatch,
+            format!("sample {index}: {}", describe_difference(&golden, first)),
+        ),
+    };
+    OracleOutcome {
+        kind,
+        reference,
+        reference_sha256,
+        observed_sha256,
+        verdict,
+        deterministic_across_samples: deterministic,
+        detail,
+    }
+}
+
+/// A short, bounded description of where two outputs first differ.
+///
+/// Bounded deliberately: the record is stored forever and a program printing
+/// megabytes of wrong output must not write megabytes of diff into the durable
+/// store.
+fn describe_difference(expected: &[u8], observed: &[u8]) -> String {
+    let expected_lines: Vec<&[u8]> = expected.split(|byte| *byte == b'\n').collect();
+    let observed_lines: Vec<&[u8]> = observed.split(|byte| *byte == b'\n').collect();
+    for (index, (left, right)) in expected_lines.iter().zip(observed_lines.iter()).enumerate() {
+        if left != right {
+            return format!(
+                "line {} expected {:?}, observed {:?}",
+                index + 1,
+                truncate(left),
+                truncate(right)
+            );
+        }
+    }
+    format!(
+        "expected {} line(s) and {} byte(s), observed {} line(s) and {} byte(s)",
+        expected_lines.len(),
+        expected.len(),
+        observed_lines.len(),
+        observed.len()
+    )
+}
+
+fn truncate(bytes: &[u8]) -> String {
+    const LIMIT: usize = 120;
+    let text = String::from_utf8_lossy(&bytes[..bytes.len().min(LIMIT)]).into_owned();
+    if bytes.len() > LIMIT {
+        format!("{text}…")
+    } else {
+        text
+    }
+}
+
+/// The compiler's own version string, recorded with every observation.
+///
+/// Together with the commit this is what makes the series longitudinal: a
+/// movement is attributable to a compiler change from the record alone.
+fn compiler_version(compiler: &Path) -> Result<String, String> {
+    let output = Command::new(compiler)
+        .arg("--version")
+        .output()
+        .map_err(|error| format!("could not run the compiler: {error}"))?;
+    if !output.status.success() {
+        return Err("the compiler could not report its version".to_string());
+    }
+    let text = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    if text.is_empty() {
+        return Err("the compiler reported an empty version".to_string());
+    }
+    Ok(text)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rue_perf_schema::{FixtureDeclaration, InputCategory, OracleDeclaration, OracleKind};
+
+    fn workload() -> RuntimeWorkload {
+        RuntimeWorkload {
+            id: "wordfreq".to_string(),
+            source: "examples/wordfreq/main.rue".to_string(),
+            question: "How fast does compiled Rue count words?".to_string(),
+            program_args: vec![FIXTURE_ARGUMENT.to_string()],
+            fixture: FixtureDeclaration {
+                category: InputCategory::Recorded,
+                generator: fixture::ZIPF_ASCII_TEXT.to_string(),
+                generator_revision: fixture::ZIPF_ASCII_TEXT_REVISION,
+                seed: 20260813,
+                bytes: 4096,
+                vocabulary_size: 256,
+                file_name: "input.txt".to_string(),
+                description: "deterministic ASCII prose".to_string(),
+            },
+            oracle: OracleDeclaration {
+                kind: OracleKind::GoldenStdout,
+                path: "performance/fixtures/wordfreq/expected-stdout.txt".to_string(),
+            },
+        }
+    }
+
+    fn golden(directory: &Path, contents: &[u8]) -> PathBuf {
+        let path = directory.join("expected-stdout.txt");
+        std::fs::write(&path, contents).unwrap();
+        path
+    }
+
+    #[test]
+    fn identical_correct_output_matches() {
+        let temporary = tempfile::tempdir().unwrap();
+        let path = golden(temporary.path(), b"words=16\n");
+        let outputs = vec![b"words=16\n".to_vec(); 5];
+        let outcome = judge(&workload(), &path, &outputs);
+        assert_eq!(outcome.verdict, OracleVerdict::Match);
+        assert!(outcome.deterministic_across_samples);
+        assert_eq!(outcome.detail, "");
+        assert_eq!(outcome.observed_sha256, outcome.reference_sha256);
+    }
+
+    #[test]
+    fn wrong_output_is_a_mismatch_naming_the_line() {
+        let temporary = tempfile::tempdir().unwrap();
+        let path = golden(temporary.path(), b"words=16\ndistinct=6\n");
+        let outputs = vec![b"words=16\ndistinct=5\n".to_vec(); 3];
+        let outcome = judge(&workload(), &path, &outputs);
+        assert_eq!(outcome.verdict, OracleVerdict::Mismatch);
+        assert!(outcome.detail.contains("line 2"), "{}", outcome.detail);
+        assert!(outcome.detail.contains("distinct=5"), "{}", outcome.detail);
+    }
+
+    #[test]
+    fn a_single_wrong_sample_fails_the_whole_observation() {
+        // Judging only the first sample would report a match for a run in which
+        // every later sample was wrong.
+        let temporary = tempfile::tempdir().unwrap();
+        let path = golden(temporary.path(), b"words=16\n");
+        let outputs = vec![
+            b"words=16\n".to_vec(),
+            b"words=16\n".to_vec(),
+            b"words=15\n".to_vec(),
+        ];
+        let outcome = judge(&workload(), &path, &outputs);
+        assert_eq!(outcome.verdict, OracleVerdict::Mismatch);
+        assert!(!outcome.deterministic_across_samples);
+    }
+
+    #[test]
+    fn output_that_varies_between_samples_is_reported_separately_from_correctness() {
+        // Both agree with nothing; the record must distinguish "consistently
+        // wrong" from "not the same program twice".
+        let temporary = tempfile::tempdir().unwrap();
+        let path = golden(temporary.path(), b"words=16\n");
+        let outputs = vec![b"words=17\n".to_vec(), b"words=18\n".to_vec()];
+        let outcome = judge(&workload(), &path, &outputs);
+        assert_eq!(outcome.verdict, OracleVerdict::Mismatch);
+        assert!(!outcome.deterministic_across_samples);
+    }
+
+    #[test]
+    fn a_missing_golden_is_indeterminate_rather_than_a_pass() {
+        let temporary = tempfile::tempdir().unwrap();
+        let outputs = vec![b"words=16\n".to_vec()];
+        let outcome = judge(&workload(), &temporary.path().join("absent"), &outputs);
+        assert_eq!(outcome.verdict, OracleVerdict::Indeterminate);
+        assert!(outcome.reference_sha256.is_empty());
+    }
+
+    #[test]
+    fn a_run_with_no_output_is_indeterminate_rather_than_a_pass() {
+        let temporary = tempfile::tempdir().unwrap();
+        let path = golden(temporary.path(), b"words=16\n");
+        let outcome = judge(&workload(), &path, &[]);
+        assert_eq!(outcome.verdict, OracleVerdict::Indeterminate);
+        assert!(outcome.detail.contains("no sample"), "{}", outcome.detail);
+    }
+
+    #[test]
+    fn a_trailing_newline_difference_is_a_mismatch() {
+        // Byte-exact means byte-exact. Trimming here would let a real output
+        // change pass unnoticed.
+        let temporary = tempfile::tempdir().unwrap();
+        let path = golden(temporary.path(), b"words=16\n");
+        let outcome = judge(&workload(), &path, &[b"words=16".to_vec()]);
+        assert_eq!(outcome.verdict, OracleVerdict::Mismatch);
+    }
+
+    #[test]
+    fn preparing_a_fixture_records_the_digest_of_the_bytes_written() {
+        let temporary = tempfile::tempdir().unwrap();
+        let path = temporary.path().join("input.txt");
+        let recorded = prepare_fixture(&workload(), &path).expect("prepared");
+        let written = std::fs::read(&path).unwrap();
+        assert_eq!(recorded.bytes, 4096);
+        assert_eq!(written.len(), 4096);
+        assert_eq!(recorded.identity_sha256, sha256(&written));
+        assert_eq!(recorded.category, InputCategory::Recorded);
+        let provenance = recorded.provenance.expect("generated");
+        assert_eq!(provenance.seed, 20260813);
+        assert_eq!(
+            provenance.generator_revision,
+            fixture::ZIPF_ASCII_TEXT_REVISION
+        );
+    }
+
+    #[test]
+    fn a_fixture_pinned_to_an_unimplemented_generator_revision_is_refused() {
+        // The golden output is a function of the generated bytes, so silently
+        // generating a different revision would surface as a baffling oracle
+        // mismatch instead of a clear refusal.
+        let temporary = tempfile::tempdir().unwrap();
+        let mut workload = workload();
+        workload.fixture.generator_revision = fixture::ZIPF_ASCII_TEXT_REVISION + 1;
+        let error = prepare_fixture(&workload, &temporary.path().join("input.txt")).unwrap_err();
+        assert!(error.contains("revision"), "{error}");
+    }
+
+    #[test]
+    fn a_fixture_pinned_to_an_unknown_generator_is_refused() {
+        let temporary = tempfile::tempdir().unwrap();
+        let mut workload = workload();
+        workload.fixture.generator = "some_future_generator".to_string();
+        let error = prepare_fixture(&workload, &temporary.path().join("input.txt")).unwrap_err();
+        assert!(error.contains("some_future_generator"), "{error}");
+    }
+
+    #[test]
+    fn a_difference_description_is_bounded() {
+        let expected = vec![b'a'; 10_000];
+        let observed = vec![b'b'; 10_000];
+        let described = describe_difference(&expected, &observed);
+        assert!(described.len() < 400, "{described}");
+    }
+}

--- a/crates/rue-perf-schema/BUCK
+++ b/crates/rue-perf-schema/BUCK
@@ -7,6 +7,7 @@ rue_crate(
     name = "rue-perf-schema",
     mapped_srcs = {
         "//performance:incremental.toml": "src/incremental.toml",
+        "//performance:runtime.toml": "src/runtime.toml",
     },
     deps = [
         "//third-party:serde",

--- a/crates/rue-perf-schema/src/incremental.rs
+++ b/crates/rue-perf-schema/src/incremental.rs
@@ -11,6 +11,7 @@ use std::collections::{BTreeMap, BTreeSet};
 
 use serde::{Deserialize, Serialize};
 
+use crate::sanity::{is_commit, is_sha256_digest, is_utc_timestamp};
 use crate::{DisplayIdentityWork, EnvironmentFingerprint, median, median_absolute_deviation};
 
 /// Version of the retained-session raw report wire format.
@@ -970,32 +971,6 @@ fn finding(path: impl Into<String>, detail: impl Into<String>) -> ValidationFind
     }
 }
 
-fn is_sha256(value: &str) -> bool {
-    value.len() == 64
-        && value
-            .bytes()
-            .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte))
-}
-
-fn is_commit(value: &str) -> bool {
-    value.len() == 40 && value.bytes().all(|byte| byte.is_ascii_hexdigit())
-}
-
-fn is_utc_timestamp(value: &str) -> bool {
-    let bytes = value.as_bytes();
-    if bytes.len() != 20 {
-        return false;
-    }
-    let digits = [0, 1, 2, 3, 5, 6, 8, 9, 11, 12, 14, 15, 17, 18];
-    let dashes = [4, 7];
-    let colons = [13, 16];
-    digits.iter().all(|&index| bytes[index].is_ascii_digit())
-        && dashes.iter().all(|&index| bytes[index] == b'-')
-        && colons.iter().all(|&index| bytes[index] == b':')
-        && bytes[10] == b'T'
-        && bytes[19] == b'Z'
-}
-
 fn validate_identity(path: &str, identity: &OutcomeIdentity, errors: &mut Vec<ValidationFinding>) {
     let executable_expected = identity.kind == OutcomeKind::Success;
     if identity.executable.is_some() != executable_expected {
@@ -1004,14 +979,14 @@ fn validate_identity(path: &str, identity: &OutcomeIdentity, errors: &mut Vec<Va
             "executable identity must be present exactly for successful outcomes",
         ));
     }
-    if !is_sha256(&identity.diagnostics) || !is_sha256(&identity.warnings) {
+    if !is_sha256_digest(&identity.diagnostics) || !is_sha256_digest(&identity.warnings) {
         errors.push(finding(
             path,
             "diagnostic and warning identities must be lowercase SHA-256 values (including empty-set hashes)",
         ));
     }
     if let Some(executable) = &identity.executable
-        && !is_sha256(executable)
+        && !is_sha256_digest(executable)
     {
         errors.push(finding(
             path,
@@ -1394,8 +1369,8 @@ pub fn validate_edit_report(manifest: &EditManifest, report: &EditReport) -> Edi
                 ) => {
                     if logical_file.is_empty()
                         || logical_file.starts_with('/')
-                        || !is_sha256(before_sha256)
-                        || !is_sha256(after_sha256)
+                        || !is_sha256_digest(before_sha256)
+                        || !is_sha256_digest(after_sha256)
                         || before_sha256 == after_sha256
                     {
                         errors.push(finding(
@@ -1426,7 +1401,10 @@ pub fn validate_edit_report(manifest: &EditManifest, report: &EditReport) -> Edi
                             "successful endpoints are zero or not cumulative/monotonic",
                         ));
                     }
-                    if diagnostics.is_empty() || warnings.is_empty() || !is_sha256(executable) {
+                    if diagnostics.is_empty()
+                        || warnings.is_empty()
+                        || !is_sha256_digest(executable)
+                    {
                         errors.push(finding(
                             &sample_path,
                             "successful outcome identities are incomplete",

--- a/crates/rue-perf-schema/src/lib.rs
+++ b/crates/rue-perf-schema/src/lib.rs
@@ -33,12 +33,22 @@
 //! ([`InvalidSample`]) excludes a sample from publication while keeping it on
 //! disk. [`ValidationOutcome`] reports both, plus the run's
 //! [`Completeness`].
+//!
+//! ADR-0072 adds a second record kind on the same three ideas. A
+//! [`RuntimeReport`] measures how fast a *compiled Rue program* runs rather
+//! than how fast the compiler produced it, and introduces one category the
+//! compile-time suites do not have: a recorded input
+//! ([`InputCategory::Recorded`]), whose identity is captured with every
+//! observation instead of failing validation when it moves. Nothing about
+//! ADR-0067's rules for the compile-time suites changes.
 
 mod boundary;
 mod canonical;
 mod incremental;
 mod manifest;
 mod run;
+mod runtime;
+mod sanity;
 mod scaling;
 mod series;
 mod stats;
@@ -72,6 +82,17 @@ pub use run::{
     Band, EnvironmentFingerprint, FailureRecord, Invocation, Phase, PhaseAccounting, ResolvedPins,
     RunIdentity, RunObject, Sample, WorkloadObservation,
 };
+pub use runtime::{
+    FIXTURE_ARGUMENT, FIXTURE_INPUT_NAME, FixtureDeclaration, FlagPosture, GeneratedProvenance,
+    HardwareCounterPolicy, InputCategory, OracleDeclaration, OracleKind, OracleOutcome,
+    OracleVerdict, ProgramIdentity, RUNTIME_MANIFEST_SCHEMA_VERSION, RUNTIME_RECORD_KIND,
+    RUNTIME_REPORT_SCHEMA_VERSION, RecordedInput, RuntimeBoundary, RuntimeCalibration,
+    RuntimeCompleteness, RuntimeEpoch, RuntimeFailure, RuntimeIdentity, RuntimeInvalidSample,
+    RuntimeInvalidSampleReason, RuntimeManifest, RuntimeMetric, RuntimeObservation, RuntimeRegime,
+    RuntimeReport, RuntimeSample, RuntimeSamplingPolicy, RuntimeSuiteRevision,
+    RuntimeValidationError, RuntimeValidationOutcome, RuntimeWorkload, ThreadPolicy,
+    runtime_sample_value, summarize, validate_runtime_report,
+};
 pub use scaling::{
     CfgLocalEpochWork, CfgMaterializationWork, CfgPrerequisiteWork, CfgRetainedChargeWork,
     CompilerWork, QueryRuntimeWork, SCALING_REPORT_SCHEMA_VERSION, ScalingIdentity,
@@ -83,7 +104,7 @@ pub use stats::{
     Summary, flags_movement, geometric_mean, median, median_absolute_deviation, pooled_uncertainty,
     ratio, sample_value,
 };
-pub use stored::{StoredRun, StoredRunError};
+pub use stored::{Stored, StoredRecordError, StoredRun, StoredRuntimeReport};
 pub use validate::{
     Completeness, InvalidSample, InvalidSampleReason, ProcessElapsedRegression, ValidationError,
     ValidationOutcome, process_elapsed_regressions, validate_run,

--- a/crates/rue-perf-schema/src/runtime.rs
+++ b/crates/rue-perf-schema/src/runtime.rs
@@ -1,0 +1,2622 @@
+//! Runtime performance of compiled Rue programs (ADR-0072, Phase 1).
+//!
+//! ADR-0067 answers "how fast does Rue compile". This module answers the other
+//! half: how fast the program the compiler produced actually runs. It reuses
+//! that ADR's suite/epoch versioning, its raw-storage rule, and ADR-0071's
+//! fresh-process boundary discipline, and departs from it in exactly three
+//! places, each deliberate.
+//!
+//! **A third input category.** The compile-time suites pin every input and
+//! refuse a run whose pinned components moved. A runtime workload also consumes
+//! *data*, and the anchor workload's data is expected to move — gazette builds
+//! the live rue-lang.dev corpus. So the schema names a second category
+//! explicitly: an [`InputCategory::Recorded`] input's identity is captured with
+//! every observation ([`RecordedInput`]) instead of failing validation when it
+//! changes. Nothing here changes ADR-0067's rules for the compile-time suites.
+//! `wordfreq`'s text fixture is generated deterministically from a pinned seed
+//! and generator revision, and is *still* a recorded input: the record carries
+//! the digest of the bytes the program actually read, so no future generator
+//! change can move a series invisibly.
+//!
+//! **The oracle is not optional.** A run whose program printed the wrong answer
+//! is not a slow run or a fast run; it is not a measurement. [`OracleOutcome`]
+//! rides every observation and a mismatch makes the report unappendable
+//! regardless of any timing it contains. The comparison happens outside the
+//! timed window, as does fixture preparation — [`RuntimeRegime`] records both
+//! facts rather than leaving them to a reader's assumption.
+//!
+//! **Flags are advisory until the workload is calibrated.** Dispersion is a
+//! property of a workload on a platform, so runtime calibration is never
+//! inherited from the compiler suites; an epoch that has not yet calibrated a
+//! workload reports [`FlagPosture::Advisory`] for it.
+//!
+//! Storage stays raw: integer nanoseconds and integer bytes, no medians, no
+//! ratios. Everything derived is recomputed by consumers from these records.
+
+use std::collections::{BTreeMap, BTreeSet};
+
+use serde::{Deserialize, Serialize};
+
+use crate::boundary::OptimizationLevel;
+use crate::manifest::EnvironmentPolicy;
+use crate::run::EnvironmentFingerprint;
+use crate::sanity::{
+    is_commit, is_measurable_duration, is_ordered_interval, is_sha256_digest, is_utc_timestamp,
+    samples_beyond_policy,
+};
+
+/// Wire version of [`RuntimeReport`].
+///
+/// Readers refuse versions they do not implement rather than guessing, exactly
+/// as [`crate::RUN_SCHEMA_VERSION`] does for compile-time records.
+pub const RUNTIME_REPORT_SCHEMA_VERSION: u32 = 1;
+
+/// The discriminator every runtime record carries.
+///
+/// The durable store holds more than one kind of record and a reader must be
+/// able to tell them apart from the bytes alone, without inferring a kind from
+/// which fields happen to parse.
+pub const RUNTIME_RECORD_KIND: &str = "runtime_v1";
+
+/// Manifest syntax version understood by [`RuntimeManifest::parse`].
+pub const RUNTIME_MANIFEST_SCHEMA_VERSION: u32 = 1;
+
+// ---------------------------------------------------------------------------
+// Vocabulary
+// ---------------------------------------------------------------------------
+
+/// What the measured window contains.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum RuntimeBoundary {
+    /// One fresh process, timed from immediately before spawn to exit.
+    ///
+    /// Fixture preparation, compilation, and oracle comparison are all outside
+    /// it. In-process iteration timing is deliberately not offered in v1.
+    SpawnToExitV1,
+}
+
+/// How an input's identity is treated by validation.
+///
+/// The distinction is the whole of ADR-0072 Decision 2, and it is spelled in
+/// the schema rather than in prose so that no record can be ambiguous about
+/// which discipline governed it.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum InputCategory {
+    /// Declared in the manifest and required to match; a change is a failure
+    /// until a maintainer declares the next suite revision. ADR-0067's rule for
+    /// every compile-time input.
+    Pinned,
+    /// Expected to move. Its identity is captured with every observation, and a
+    /// change is a discontinuity in the series rather than an invalid run.
+    Recorded,
+}
+
+/// Thread policy under which a runtime observation was taken.
+///
+/// Part of the epoch, not the suite: it is a property of how a platform runs
+/// the workload. Rue has no concurrency support yet, so v1 measures
+/// single-threaded and says so, rather than leaving a future reader to assume
+/// it from the absence of a field.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ThreadPolicy {
+    /// One worker thread.
+    SingleThreaded,
+}
+
+/// Whether hardware performance counters were collected.
+///
+/// GitHub-hosted runners expose no PMU, so v1 records their absence as a fact
+/// of the regime. Counters are gated on a future controlled-hardware epoch
+/// (ADR-0072 Decision 5) rather than silently missing.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum HardwareCounterPolicy {
+    /// No PMU is available in this regime; only wall time, RSS, and size.
+    UnavailableOnHostedRunner,
+}
+
+/// The correctness oracle a workload is judged against.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum OracleKind {
+    /// The program's stdout must equal a committed golden file, byte for byte.
+    GoldenStdout,
+}
+
+/// What the oracle said.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum OracleVerdict {
+    /// Every sample produced exactly the expected output.
+    Match,
+    /// Output was produced and is wrong.
+    Mismatch,
+    /// The comparison could not be performed — the golden was unreadable, or
+    /// no sample produced output. Not the same as a mismatch, and not an
+    /// excuse to publish either.
+    Indeterminate,
+}
+
+/// How a workload's regression flags should be read.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum FlagPosture {
+    /// The epoch has calibrated this workload's dispersion from its own
+    /// repeated samples on this platform.
+    Calibrated,
+    /// It has not. Movement is worth a look and is never a gate.
+    Advisory,
+}
+
+/// Metrics a runtime series publishes.
+///
+/// Deliberately not [`crate::Metric`]: that enum's `Latency` means
+/// compiler-root time, which has no meaning for a program the compiler is not
+/// running. Sharing the type would invite a consumer to plot one as the other.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum RuntimeMetric {
+    /// Whole-process wall time, spawn to exit.
+    WallClock,
+    /// Peak resident set size of the measured process.
+    PeakMemory,
+    /// Size of the release-quality executable that was run.
+    BinarySize,
+}
+
+impl RuntimeMetric {
+    /// Every published runtime metric.
+    pub const ALL: [RuntimeMetric; 3] = [
+        RuntimeMetric::WallClock,
+        RuntimeMetric::PeakMemory,
+        RuntimeMetric::BinarySize,
+    ];
+
+    /// The stable wire name used in derived chart data.
+    pub const fn wire_name(self) -> &'static str {
+        match self {
+            RuntimeMetric::WallClock => "wall_clock",
+            RuntimeMetric::PeakMemory => "peak_memory",
+            RuntimeMetric::BinarySize => "binary_size",
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Manifest
+// ---------------------------------------------------------------------------
+
+/// How one workload's data fixture is produced.
+///
+/// The declaration is pinned by the suite revision; the bytes it produces are
+/// recorded per observation. Both halves matter: the pin makes the fixture
+/// reproducible from the repository, and the recording makes any drift between
+/// the pin and the bytes visible in the data rather than only in review.
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct FixtureDeclaration {
+    /// Which discipline governs this input's identity. Runtime fixtures are
+    /// recorded; the field exists so a future pinned fixture cannot be added
+    /// without saying so.
+    pub category: InputCategory,
+    /// Name of the checked-in generator that produces the fixture.
+    pub generator: String,
+    /// Revision of that generator. Bumped whenever its output changes, which
+    /// invalidates any committed golden derived from it.
+    pub generator_revision: u32,
+    /// Seed handed to the generator.
+    pub seed: u64,
+    /// Exact size of the produced fixture, in bytes.
+    pub bytes: u64,
+    /// Number of distinct tokens the generator's vocabulary contains.
+    pub vocabulary_size: u32,
+    /// File name the fixture is written under inside the work directory.
+    pub file_name: String,
+    /// What this fixture is, for a reader of the manifest.
+    pub description: String,
+}
+
+/// The committed expected result a workload's output is judged against.
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct OracleDeclaration {
+    /// How the comparison is performed.
+    pub kind: OracleKind,
+    /// Repository-relative path to the expected output.
+    pub path: String,
+}
+
+/// One measured program.
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct RuntimeWorkload {
+    /// Stable short name.
+    pub id: String,
+    /// Root source, relative to the repository.
+    pub source: String,
+    /// The question this workload exists to answer. Required, for the same
+    /// reason ADR-0067 requires it: a probe that cannot name its question is
+    /// corpus mass rather than a measurement.
+    pub question: String,
+    /// Arguments passed to the compiled program, in order.
+    ///
+    /// [`FIXTURE_ARGUMENT`] stands for the prepared fixture's path. The
+    /// placeholder rather than the resolved path is what the record stores: the
+    /// resolved path names a temporary directory and would make two identical
+    /// measurements differ.
+    pub program_args: Vec<String>,
+    /// How the workload's data is produced.
+    pub fixture: FixtureDeclaration,
+    /// How its output is judged.
+    pub oracle: OracleDeclaration,
+}
+
+/// The token in `program_args` replaced by the prepared fixture's path.
+pub const FIXTURE_ARGUMENT: &str = "{fixture}";
+
+/// The platform-independent contract: which programs are measured, with which
+/// arguments, over which fixtures, judged how.
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct RuntimeSuiteRevision {
+    /// The revision number. Monotonic; never reused.
+    pub revision: u32,
+    /// The runner protocol version this revision's records conform to.
+    pub protocol_version: u32,
+    /// What the measured window contains.
+    pub measured_boundary: RuntimeBoundary,
+    /// The suite's workloads.
+    pub workloads: Vec<RuntimeWorkload>,
+}
+
+impl RuntimeSuiteRevision {
+    /// The workload with this identifier, if the suite declares one.
+    pub fn workload(&self, id: &str) -> Option<&RuntimeWorkload> {
+        self.workloads.iter().find(|workload| workload.id == id)
+    }
+
+    /// Workload identifiers, sorted.
+    pub fn workload_ids(&self) -> Vec<&str> {
+        let mut ids: Vec<&str> = self
+            .workloads
+            .iter()
+            .map(|workload| workload.id.as_str())
+            .collect();
+        ids.sort_unstable();
+        ids
+    }
+}
+
+/// How many independent fresh processes to launch for one workload.
+///
+/// No batching factor, unlike ADR-0067's sampling policy. These workloads run
+/// for seconds; timer resolution is not a threat, and batching would hide the
+/// per-run dispersion the calibration this epoch lacks is meant to measure.
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct RuntimeSamplingPolicy {
+    /// How many samples to collect.
+    pub samples: u32,
+}
+
+/// A workload's calibrated flagging rule on one platform.
+///
+/// Present only once the workload's dispersion has been measured *here*, from
+/// its own repeated samples. Compiler-workload calibration is never a
+/// substitute: dispersion is a property of the workload.
+#[derive(Debug, Clone, PartialEq, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct RuntimeCalibration {
+    /// Multiplier applied to pooled uncertainty.
+    pub k: f64,
+    /// How many prior observations form the trailing window.
+    pub window: u32,
+    /// The reviewed analysis that established these constants.
+    pub reference: String,
+}
+
+/// Everything that can vary by platform.
+#[derive(Debug, Clone, PartialEq, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct RuntimeEpoch {
+    /// The epoch number, unique within its platform. Monotonic; never reused.
+    pub id: u32,
+    /// The platform this epoch measures, for example `x86_64-linux`.
+    pub platform: String,
+    /// The suite revision this epoch implements.
+    pub suite_revision: u32,
+    /// The compilation target triple the workload is built for.
+    pub target: String,
+    /// Every behavior-affecting compiler argument used to build the workload.
+    pub compiler_args: Vec<String>,
+    /// Optimization contract of the program under measurement.
+    ///
+    /// ADR-0071 defines the product as release-quality, so a runtime series
+    /// measuring anything else would not be measuring the product.
+    pub optimization: OptimizationLevel,
+    /// Thread policy in force for every sample.
+    pub thread_policy: ThreadPolicy,
+    /// Whether hardware counters are collected in this regime.
+    pub hardware_counters: HardwareCounterPolicy,
+    /// The environment class this epoch requires.
+    pub environment: EnvironmentPolicy,
+    /// Sampling policy per workload.
+    pub sampling: BTreeMap<String, RuntimeSamplingPolicy>,
+    /// Per-workload calibrated flagging rules, where they exist yet.
+    #[serde(default)]
+    pub calibration: BTreeMap<String, RuntimeCalibration>,
+    /// Whether scheduled collection measures this epoch.
+    #[serde(default)]
+    pub collection: bool,
+}
+
+impl RuntimeEpoch {
+    /// How a workload's movement should be read in this epoch.
+    pub fn flag_posture(&self, workload: &str) -> FlagPosture {
+        if self.calibration.contains_key(workload) {
+            FlagPosture::Calibrated
+        } else {
+            FlagPosture::Advisory
+        }
+    }
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct RawRuntimeManifest {
+    schema_version: u32,
+    #[serde(default)]
+    suite: Vec<RuntimeSuiteRevision>,
+    #[serde(default)]
+    epoch: Vec<RuntimeEpoch>,
+}
+
+/// The runtime suite declaration: `performance/runtime.toml`.
+#[derive(Debug, Clone, PartialEq)]
+pub struct RuntimeManifest {
+    suites: BTreeMap<u32, RuntimeSuiteRevision>,
+    epochs: Vec<RuntimeEpoch>,
+}
+
+impl RuntimeManifest {
+    /// Parse and check a runtime manifest.
+    ///
+    /// Every structural problem is a parse failure rather than a silently
+    /// tolerated oddity: a manifest is the thing that makes an invalid
+    /// observation unappendable, so it may not itself be ambiguous.
+    pub fn parse(text: &str) -> Result<RuntimeManifest, String> {
+        let raw: RawRuntimeManifest =
+            toml::from_str(text).map_err(|error| format!("malformed runtime manifest: {error}"))?;
+        if raw.schema_version != RUNTIME_MANIFEST_SCHEMA_VERSION {
+            return Err(format!(
+                "unsupported runtime manifest schema version {}",
+                raw.schema_version
+            ));
+        }
+
+        let mut suites: BTreeMap<u32, RuntimeSuiteRevision> = BTreeMap::new();
+        for suite in raw.suite {
+            if suite.workloads.is_empty() {
+                return Err(format!(
+                    "runtime suite revision {} declares no workloads",
+                    suite.revision
+                ));
+            }
+            let mut seen = BTreeSet::new();
+            for workload in &suite.workloads {
+                if workload.id.trim().is_empty() {
+                    return Err(format!(
+                        "runtime suite revision {} declares a workload with an empty id",
+                        suite.revision
+                    ));
+                }
+                if !seen.insert(workload.id.clone()) {
+                    return Err(format!(
+                        "runtime suite revision {} declares workload {:?} more than once",
+                        suite.revision, workload.id
+                    ));
+                }
+                if workload.question.trim().is_empty() {
+                    return Err(format!(
+                        "runtime workload {:?} names no question it answers",
+                        workload.id
+                    ));
+                }
+                if workload.source.is_empty() || workload.source.starts_with('/') {
+                    return Err(format!(
+                        "runtime workload {:?} must use a repository-relative source",
+                        workload.id
+                    ));
+                }
+                if workload.oracle.path.is_empty() || workload.oracle.path.starts_with('/') {
+                    return Err(format!(
+                        "runtime workload {:?} must use a repository-relative oracle path",
+                        workload.id
+                    ));
+                }
+                if workload.fixture.bytes == 0 {
+                    return Err(format!(
+                        "runtime workload {:?} declares an empty fixture",
+                        workload.id
+                    ));
+                }
+                if workload.fixture.vocabulary_size == 0 {
+                    return Err(format!(
+                        "runtime workload {:?} declares an empty fixture vocabulary",
+                        workload.id
+                    ));
+                }
+                if workload.fixture.file_name.contains('/') {
+                    return Err(format!(
+                        "runtime workload {:?} fixture file name must be a bare name",
+                        workload.id
+                    ));
+                }
+                // Wrong output must fail regardless of speed, so a workload
+                // without a resolvable oracle is not measurable at all.
+                if !workload
+                    .program_args
+                    .iter()
+                    .any(|argument| argument == FIXTURE_ARGUMENT)
+                {
+                    return Err(format!(
+                        "runtime workload {:?} never passes its fixture to the program; \
+                         one argument must be {FIXTURE_ARGUMENT:?}",
+                        workload.id
+                    ));
+                }
+            }
+            if suites.insert(suite.revision, suite.clone()).is_some() {
+                return Err(format!(
+                    "runtime suite revision {} is declared more than once",
+                    suite.revision
+                ));
+            }
+        }
+
+        let manifest = RuntimeManifest {
+            suites,
+            epochs: raw.epoch,
+        };
+        manifest.check_epochs()?;
+        Ok(manifest)
+    }
+
+    fn check_epochs(&self) -> Result<(), String> {
+        let mut seen: BTreeSet<(&str, u32)> = BTreeSet::new();
+        let mut collecting: BTreeMap<&str, u32> = BTreeMap::new();
+        for epoch in &self.epochs {
+            if !seen.insert((epoch.platform.as_str(), epoch.id)) {
+                return Err(format!(
+                    "runtime epoch {} on {} is declared more than once",
+                    epoch.id, epoch.platform
+                ));
+            }
+            if epoch.collection
+                && let Some(first) = collecting.insert(epoch.platform.as_str(), epoch.id)
+            {
+                return Err(format!(
+                    "platform {} marks both runtime epoch {first} and {} for collection",
+                    epoch.platform, epoch.id
+                ));
+            }
+            let Some(suite) = self.suites.get(&epoch.suite_revision) else {
+                return Err(format!(
+                    "runtime epoch {} on {} implements undeclared suite revision {}",
+                    epoch.id, epoch.platform, epoch.suite_revision
+                ));
+            };
+            if epoch.optimization != OptimizationLevel::O3 {
+                return Err(format!(
+                    "runtime epoch {} on {} must measure the release-quality product (-O3)",
+                    epoch.id, epoch.platform
+                ));
+            }
+
+            let declared: BTreeSet<&str> = suite.workload_ids().into_iter().collect();
+            let sampled: BTreeSet<&str> = epoch.sampling.keys().map(|key| key.as_str()).collect();
+            if declared != sampled {
+                let missing: Vec<&&str> = declared.difference(&sampled).collect();
+                let unexpected: Vec<&&str> = sampled.difference(&declared).collect();
+                return Err(format!(
+                    "runtime epoch {} on {} declares sampling policies that do not match its \
+                     suite; missing {missing:?}, unexpected {unexpected:?}",
+                    epoch.id, epoch.platform
+                ));
+            }
+            for (workload, policy) in &epoch.sampling {
+                // Spread is the whole point of the report; one sample has none.
+                if policy.samples < 2 {
+                    return Err(format!(
+                        "runtime epoch {} on {} asks for {} sample(s) of {workload:?}; \
+                         a median and spread need at least two",
+                        epoch.id, epoch.platform, policy.samples
+                    ));
+                }
+            }
+            for workload in epoch.calibration.keys() {
+                if !declared.contains(workload.as_str()) {
+                    return Err(format!(
+                        "runtime epoch {} on {} calibrates undeclared workload {workload:?}",
+                        epoch.id, epoch.platform
+                    ));
+                }
+            }
+        }
+        Ok(())
+    }
+
+    /// The suite revision with this number, if declared.
+    pub fn suite(&self, revision: u32) -> Option<&RuntimeSuiteRevision> {
+        self.suites.get(&revision)
+    }
+
+    /// Every declared suite revision, ascending.
+    pub fn suites(&self) -> impl Iterator<Item = &RuntimeSuiteRevision> {
+        self.suites.values()
+    }
+
+    /// The epoch with this identifier on this platform, if declared.
+    pub fn epoch(&self, platform: &str, id: u32) -> Option<&RuntimeEpoch> {
+        self.epochs
+            .iter()
+            .find(|epoch| epoch.platform == platform && epoch.id == id)
+    }
+
+    /// Every declared epoch, in manifest order.
+    pub fn epochs(&self) -> &[RuntimeEpoch] {
+        &self.epochs
+    }
+
+    /// The epoch scheduled collection measures on this platform.
+    pub fn collection_epoch(&self, platform: &str) -> Option<&RuntimeEpoch> {
+        self.epochs
+            .iter()
+            .find(|epoch| epoch.platform == platform && epoch.collection)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Records
+// ---------------------------------------------------------------------------
+
+/// How a generated recorded input was produced.
+///
+/// Absent for inputs that are collected rather than generated — a content tree,
+/// for instance — which is why it is optional rather than part of
+/// [`RecordedInput`] itself.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct GeneratedProvenance {
+    /// Name of the checked-in generator.
+    pub generator: String,
+    /// Its revision at the time of generation.
+    pub generator_revision: u32,
+    /// The seed it was given.
+    pub seed: u64,
+    /// The vocabulary size it was given.
+    ///
+    /// Recorded alongside the seed because it is equally an input to the bytes,
+    /// and therefore to the golden output judged against them. Without it a
+    /// record could not describe the fixture it read, and two series segments
+    /// generated under different vocabularies would look identical in the data.
+    pub vocabulary_size: u32,
+}
+
+/// The identity of one input the measured program consumed.
+///
+/// This is ADR-0072's recorded-input category made concrete. The digest is over
+/// the bytes the program actually read, not over the declaration that asked for
+/// them, so a generator whose output drifted from its declaration is visible in
+/// the data.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct RecordedInput {
+    /// Short name of the input within its workload, for example `fixture`.
+    pub name: String,
+    /// Which discipline governs this input's identity.
+    pub category: InputCategory,
+    /// What the input is.
+    pub description: String,
+    /// Digest over the input's contents.
+    pub identity_sha256: String,
+    /// How many files it comprises.
+    pub files: u64,
+    /// Its total size in bytes.
+    pub bytes: u64,
+    /// How it was produced, when it was generated rather than collected.
+    #[serde(default)]
+    pub provenance: Option<GeneratedProvenance>,
+}
+
+/// The executable that was measured.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ProgramIdentity {
+    /// Size of the release-quality executable, in bytes.
+    pub binary_bytes: u64,
+    /// Digest of that executable.
+    pub sha256: String,
+}
+
+/// What the correctness oracle said about one workload.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct OracleOutcome {
+    /// How the comparison was performed.
+    pub kind: OracleKind,
+    /// Repository-relative path of the expected output.
+    pub reference: String,
+    /// Digest of the expected output.
+    pub reference_sha256: String,
+    /// Digest of the output the program produced.
+    pub observed_sha256: String,
+    /// The verdict.
+    pub verdict: OracleVerdict,
+    /// Whether every sample produced byte-identical output.
+    ///
+    /// Separate from the verdict: a program that agrees with the golden on some
+    /// runs and not others is wrong in a different and more alarming way than
+    /// one that disagrees consistently.
+    pub deterministic_across_samples: bool,
+    /// Human-readable evidence, empty on a match.
+    pub detail: String,
+}
+
+/// One independent fresh-process measurement.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct RuntimeSample {
+    /// Whole-process wall time from immediately before spawn through exit.
+    pub process_elapsed_ns: u64,
+    /// Peak resident set size of the measured process, in bytes.
+    pub peak_memory_bytes: u64,
+    /// The program's exit code.
+    pub exit_code: i32,
+    /// How many bytes it wrote to stdout.
+    pub stdout_bytes: u64,
+    /// Digest of those bytes, so a nondeterministic run is provable from the
+    /// record rather than only from the runner's summary.
+    pub stdout_sha256: String,
+}
+
+/// Raw measurements of one program.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct RuntimeObservation {
+    /// Stable workload id.
+    pub workload: String,
+    /// Root source, recorded for human inspection.
+    pub source: String,
+    /// Why this program is measured.
+    pub question: String,
+    /// Declared program arguments, with [`FIXTURE_ARGUMENT`] unresolved.
+    pub program_args: Vec<String>,
+    /// Identity of every input the program consumed.
+    pub recorded_inputs: Vec<RecordedInput>,
+    /// The executable that was run.
+    pub program: ProgramIdentity,
+    /// What the oracle said, computed outside the timed window.
+    pub oracle: OracleOutcome,
+    /// Independent raw fresh-process measurements.
+    pub samples: Vec<RuntimeSample>,
+}
+
+/// Identity of one runtime report.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct RuntimeIdentity {
+    /// Runtime suite revision implemented.
+    pub suite_revision: u32,
+    /// Platform epoch measured.
+    pub epoch: u32,
+    /// The platform, for example `x86_64-linux`.
+    pub platform: String,
+    /// Compiler source revision that built the measured programs.
+    ///
+    /// Recorded from day one: without it a runtime series is a collection of
+    /// numbers with no way to attribute a movement to a compiler change.
+    pub commit: String,
+    /// The compiler's own version string.
+    pub compiler_version: String,
+    /// UTC start timestamp.
+    pub started_at: String,
+    /// UTC completion timestamp.
+    pub finished_at: String,
+    /// Content hash of the Rust toolchain the compiler was built with.
+    pub toolchain_hash: String,
+    /// Content hash of the standard library, which is part of the product.
+    pub stdlib_hash: String,
+    /// Content hash of each workload's own source closure.
+    ///
+    /// Recorded, not pinned — the same choice `performance/scaling.toml` makes
+    /// for the maintained examples it measures. That suite's curve runs over
+    /// `examples/ruelex`, `examples/mosaic`, `examples/harbor`, and
+    /// `examples/lattice` and pins no per-workload source hashes, because a
+    /// maintained example is a program the repository keeps improving rather
+    /// than a frozen probe; pinning would stall the series on every ordinary
+    /// edit to it. ADR-0072 asks for the same treatment explicitly, saying that
+    /// observations *record* the workload's source identity, and requires
+    /// gazette to be an ordinary maintained example rather than a
+    /// benchmark-only artifact.
+    ///
+    /// `performance/workloads/lattice/main.rue` is the other pattern and not
+    /// the one that applies: ADR-0067 pins that copy precisely because it is a
+    /// frozen probe with no life outside measurement.
+    ///
+    /// Recording is only half a bargain, though. It is defensible because
+    /// consumers can see when the identity moved and segment the series on it,
+    /// which is why the derived data surfaces this alongside the fixture
+    /// digest; a recorded identity nobody can read would be a pin quietly
+    /// omitted.
+    pub workload_source_hashes: BTreeMap<String, String>,
+    /// Machine and runner fingerprint.
+    pub environment: EnvironmentFingerprint,
+}
+
+/// What every sample in a runtime report means.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct RuntimeRegime {
+    /// What the measured window contains.
+    pub measured_boundary: RuntimeBoundary,
+    /// Always `fresh_process`: every sample launches the program anew.
+    pub program_state: String,
+    /// Always `uncontrolled`: page-cache state is observed, not reset.
+    pub os_page_cache: String,
+    /// Always false. Generating a fixture is setup, not the workload.
+    pub fixture_preparation_measured: bool,
+    /// Always false. Judging output is not part of running the program.
+    pub oracle_comparison_measured: bool,
+    /// Optimization contract of the measured executables.
+    pub optimization: OptimizationLevel,
+    /// Compiler arguments used to build them.
+    pub compiler_args: Vec<String>,
+    /// Compilation target.
+    pub target: String,
+    /// Thread policy in force.
+    pub thread_policy: ThreadPolicy,
+    /// Whether hardware counters were collected.
+    pub hardware_counters: HardwareCounterPolicy,
+}
+
+/// Structured evidence of something that went wrong.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum RuntimeFailure {
+    /// The workload could not be built.
+    CompileFailed {
+        /// The workload.
+        workload: String,
+        /// What the compiler said.
+        detail: String,
+    },
+    /// The fixture could not be prepared.
+    FixturePreparationFailed {
+        /// The workload.
+        workload: String,
+        /// What failed.
+        detail: String,
+    },
+    /// A measured process did not exit successfully.
+    ProgramCrashed {
+        /// The workload.
+        workload: String,
+        /// Which sample.
+        sample_index: u32,
+        /// What happened.
+        detail: String,
+    },
+    /// The program ran and produced the wrong answer.
+    WrongOutput {
+        /// The workload.
+        workload: String,
+        /// The evidence.
+        detail: String,
+    },
+    /// The runner rejected something before validation saw it.
+    ValidationRejected {
+        /// The workload.
+        workload: String,
+        /// Why.
+        detail: String,
+    },
+}
+
+impl RuntimeFailure {
+    /// The workload this failure belongs to.
+    pub fn workload(&self) -> &str {
+        match self {
+            RuntimeFailure::CompileFailed { workload, .. }
+            | RuntimeFailure::FixturePreparationFailed { workload, .. }
+            | RuntimeFailure::ProgramCrashed { workload, .. }
+            | RuntimeFailure::WrongOutput { workload, .. }
+            | RuntimeFailure::ValidationRejected { workload, .. } => workload,
+        }
+    }
+}
+
+/// One immutable, raw runtime report.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct RuntimeReport {
+    /// Always [`RUNTIME_RECORD_KIND`], so a store holding several record kinds
+    /// can route on the bytes rather than on which fields happen to parse.
+    pub record_kind: String,
+    /// Wire version of this record.
+    pub schema_version: u32,
+    /// Identity and environment of the measurement.
+    pub identity: RuntimeIdentity,
+    /// Structural measurement regime.
+    pub regime: RuntimeRegime,
+    /// Raw measurements, sorted by workload id.
+    pub workloads: Vec<RuntimeObservation>,
+    /// Everything that went wrong, whether or not it stopped the run.
+    pub failures: Vec<RuntimeFailure>,
+}
+
+impl RuntimeReport {
+    /// The content address of this report's canonical form.
+    pub fn content_address(&self) -> Result<String, crate::CanonicalError> {
+        crate::content_address(self)
+    }
+
+    /// The observation for one workload, if the report has one.
+    pub fn observation(&self, workload: &str) -> Option<&RuntimeObservation> {
+        self.workloads
+            .iter()
+            .find(|observation| observation.workload == workload)
+    }
+}
+
+// Runtime reports are named exactly as run objects are; `crate::Stored` owns
+// that rule for every record kind in the store.
+
+// ---------------------------------------------------------------------------
+// Validation
+// ---------------------------------------------------------------------------
+
+/// Why a runtime report may not enter its series.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum RuntimeValidationError {
+    /// The record is not a runtime record, or not a version this build reads.
+    UnsupportedRecord {
+        /// The kind found.
+        record_kind: String,
+        /// The schema version found.
+        schema_version: u32,
+    },
+    /// The manifest declares no such epoch.
+    UnknownEpoch {
+        /// The platform claimed.
+        platform: String,
+        /// The epoch claimed.
+        epoch: u32,
+    },
+    /// The report's suite revision is not the one its epoch implements.
+    SuiteRevisionMismatch {
+        /// What the report claims.
+        found: u32,
+        /// What the epoch declares.
+        expected: u32,
+    },
+    /// A regime field disagrees with the epoch that governs it.
+    RegimeMismatch {
+        /// The field.
+        field: String,
+        /// What the report recorded.
+        found: String,
+        /// What the epoch requires.
+        expected: String,
+    },
+    /// The environment does not satisfy the epoch's policy.
+    EnvironmentPolicy {
+        /// The policy's required class.
+        expected: String,
+        /// The fingerprint's class.
+        found: String,
+    },
+    /// A required identity field is missing or malformed.
+    MalformedIdentity {
+        /// The field.
+        field: String,
+        /// Why it is malformed.
+        detail: String,
+    },
+    /// The report contains an observation the suite does not declare.
+    UndeclaredWorkload {
+        /// The offending workload.
+        workload: String,
+    },
+    /// A workload's declared fixture and its recorded input disagree.
+    ///
+    /// The fixture is a *recorded* input, so its digest is never required to
+    /// match a declaration — but the provenance that produced it is pinned, and
+    /// a report generated from a different seed or generator revision is
+    /// measuring a different workload than the suite declares.
+    FixtureProvenanceMismatch {
+        /// The workload.
+        workload: String,
+        /// The disagreeing field.
+        field: String,
+        /// What the record carries.
+        found: String,
+        /// What the suite declares.
+        expected: String,
+    },
+    /// A workload has no recorded identity for the input it consumed.
+    MissingRecordedInput {
+        /// The workload.
+        workload: String,
+        /// The input that should have been recorded.
+        name: String,
+    },
+    /// The program produced the wrong answer, or the oracle could not judge it.
+    ///
+    /// Unappendable regardless of any timing in the report: a measurement of a
+    /// program computing the wrong result measures nothing anyone wants.
+    OracleFailed {
+        /// The workload.
+        workload: String,
+        /// The verdict.
+        verdict: OracleVerdict,
+        /// The evidence.
+        detail: String,
+    },
+    /// The workload's samples did not all produce the same output.
+    NondeterministicOutput {
+        /// The workload.
+        workload: String,
+    },
+    /// The oracle names a reference other than the one the suite declares.
+    OracleReferenceMismatch {
+        /// The workload.
+        workload: String,
+        /// What the record names.
+        found: String,
+        /// What the suite declares.
+        expected: String,
+    },
+    /// A workload's program arguments are not the ones it declares.
+    ProgramArgumentsMismatch {
+        /// The workload.
+        workload: String,
+        /// What the record carries.
+        found: Vec<String>,
+        /// What the suite declares.
+        expected: Vec<String>,
+    },
+    /// The producer's summary of its own run disagrees with the raw samples
+    /// stored beside it.
+    ///
+    /// This is the variant that makes the producer/validator separation real
+    /// rather than aspirational. `verdict` and `deterministic_across_samples`
+    /// are written by the runner; `samples[].stdout_sha256` is the evidence.
+    /// A validator that read only the summary would accept exactly the records
+    /// a broken or dishonest producer emits, in a store that cannot delete
+    /// them.
+    OracleContradictsSamples {
+        /// The workload.
+        workload: String,
+        /// The summary field the evidence refutes.
+        field: String,
+        /// What the evidence shows.
+        detail: String,
+    },
+    /// A recorded value is not in the one spelling records use.
+    MalformedDigest {
+        /// The workload.
+        workload: String,
+        /// Which digest.
+        field: String,
+        /// What was found.
+        found: String,
+    },
+    /// The observation carries more samples than its epoch permits.
+    ///
+    /// A protocol violation rather than a measurement problem, exactly as in
+    /// ADR-0067: a run that took more samples was not taken under the policy
+    /// the series compares against, whatever the extra samples say.
+    TooManySamples {
+        /// The workload.
+        workload: String,
+        /// What the epoch permits.
+        allowed: u32,
+        /// What the record carries.
+        actual: u32,
+    },
+    /// The measured executable cannot have been the one that ran.
+    ImpossibleProgramIdentity {
+        /// The workload.
+        workload: String,
+        /// Why.
+        detail: String,
+    },
+}
+
+/// Why a stored runtime sample may not contribute to a statistic.
+///
+/// The runtime counterpart of [`crate::InvalidSampleReason`], and tiered the
+/// same way: an invalid sample is a *measurement* failure, so the report stays
+/// appendable and keeps its evidence while the sample is excluded and its
+/// workload publishes nothing.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum RuntimeInvalidSampleReason {
+    /// The process was measured as taking zero nanoseconds.
+    ///
+    /// A monotonic clock read either side of a process that genuinely ran
+    /// cannot produce this, so it is evidence the measurement did not happen —
+    /// and it is exactly the value that would drag a median down while looking
+    /// like a spectacular result.
+    ZeroElapsed,
+    /// The process did not exit successfully.
+    NonZeroExit {
+        /// The exit code, or the negated signal that killed it.
+        exit_code: i32,
+    },
+}
+
+impl std::fmt::Display for RuntimeInvalidSampleReason {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            RuntimeInvalidSampleReason::ZeroElapsed => {
+                write!(f, "the measured process elapsed zero ns")
+            }
+            RuntimeInvalidSampleReason::NonZeroExit { exit_code } => {
+                write!(f, "the program exited with code {exit_code}")
+            }
+        }
+    }
+}
+
+/// A stored runtime sample excluded from every derived statistic.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RuntimeInvalidSample {
+    /// The workload holding the sample.
+    pub workload: String,
+    /// Which sample, by position in the workload's sample list.
+    pub sample_index: u32,
+    /// Why it is excluded.
+    pub reason: RuntimeInvalidSampleReason,
+}
+
+impl std::fmt::Display for RuntimeValidationError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            RuntimeValidationError::UnsupportedRecord {
+                record_kind,
+                schema_version,
+            } => write!(
+                f,
+                "record {record_kind:?} version {schema_version} is not a \
+                 {RUNTIME_RECORD_KIND} version {RUNTIME_REPORT_SCHEMA_VERSION} record"
+            ),
+            RuntimeValidationError::UnknownEpoch { platform, epoch } => {
+                write!(f, "the manifest declares no epoch {epoch} for {platform}")
+            }
+            RuntimeValidationError::SuiteRevisionMismatch { found, expected } => write!(
+                f,
+                "the report claims suite revision {found} but its epoch implements {expected}"
+            ),
+            RuntimeValidationError::RegimeMismatch {
+                field,
+                found,
+                expected,
+            } => write!(
+                f,
+                "regime field {field} is {found}, but the epoch requires {expected}"
+            ),
+            RuntimeValidationError::EnvironmentPolicy { expected, found } => write!(
+                f,
+                "the run was taken on {found}, which the epoch's {expected} policy does not admit"
+            ),
+            RuntimeValidationError::MalformedIdentity { field, detail } => {
+                write!(f, "identity field {field} is malformed: {detail}")
+            }
+            RuntimeValidationError::UndeclaredWorkload { workload } => write!(
+                f,
+                "the report observes workload {workload:?}, which its suite does not declare"
+            ),
+            RuntimeValidationError::FixtureProvenanceMismatch {
+                workload,
+                field,
+                found,
+                expected,
+            } => write!(
+                f,
+                "workload {workload:?} recorded fixture {field} {found}, \
+                 but the suite pins {expected}"
+            ),
+            RuntimeValidationError::MissingRecordedInput { workload, name } => write!(
+                f,
+                "workload {workload:?} records no identity for its {name:?} input"
+            ),
+            RuntimeValidationError::OracleFailed {
+                workload,
+                verdict,
+                detail,
+            } => write!(
+                f,
+                "workload {workload:?} did not satisfy its correctness oracle ({verdict:?}): \
+                 {detail}"
+            ),
+            RuntimeValidationError::NondeterministicOutput { workload } => write!(
+                f,
+                "workload {workload:?} produced different output across samples"
+            ),
+            RuntimeValidationError::OracleReferenceMismatch {
+                workload,
+                found,
+                expected,
+            } => write!(
+                f,
+                "workload {workload:?} was judged against {found:?}, \
+                 but the suite declares {expected:?}"
+            ),
+            RuntimeValidationError::ProgramArgumentsMismatch {
+                workload,
+                found,
+                expected,
+            } => write!(
+                f,
+                "workload {workload:?} ran with {found:?}, but the suite declares {expected:?}"
+            ),
+            RuntimeValidationError::OracleContradictsSamples {
+                workload,
+                field,
+                detail,
+            } => write!(
+                f,
+                "workload {workload:?} reports {field} but its stored samples say otherwise: \
+                 {detail}"
+            ),
+            RuntimeValidationError::MalformedDigest {
+                workload,
+                field,
+                found,
+            } => write!(
+                f,
+                "workload {workload:?} field {field} is {found:?}, not a lowercase SHA-256 digest"
+            ),
+            RuntimeValidationError::TooManySamples {
+                workload,
+                allowed,
+                actual,
+            } => write!(
+                f,
+                "workload {workload:?} carries {actual} samples but its epoch permits {allowed}"
+            ),
+            RuntimeValidationError::ImpossibleProgramIdentity { workload, detail } => {
+                write!(
+                    f,
+                    "workload {workload:?} program identity is impossible: {detail}"
+                )
+            }
+        }
+    }
+}
+
+impl std::error::Error for RuntimeValidationError {}
+
+/// Whether a runtime report covers its suite.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum RuntimeCompleteness {
+    /// Every declared workload produced its full sample count.
+    Complete,
+    /// Some did not.
+    Partial {
+        /// Workloads that did not complete, sorted.
+        missing: Vec<String>,
+    },
+}
+
+/// The full verdict on one runtime report.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RuntimeValidationOutcome {
+    /// Appendability failures. Non-empty means the report may not be stored in
+    /// a series at all.
+    pub errors: Vec<RuntimeValidationError>,
+    /// Samples that are stored but excluded from statistics.
+    pub invalid_samples: Vec<RuntimeInvalidSample>,
+    /// Whether the report covers its suite.
+    pub completeness: RuntimeCompleteness,
+}
+
+impl RuntimeValidationOutcome {
+    /// Whether this report may enter its series.
+    pub fn is_appendable(&self) -> bool {
+        self.errors.is_empty()
+    }
+
+    /// Whether a point publishes for one workload.
+    pub fn publishes_workload(&self, workload: &str) -> bool {
+        if !self.is_appendable() {
+            return false;
+        }
+        match &self.completeness {
+            RuntimeCompleteness::Complete => true,
+            RuntimeCompleteness::Partial { missing } => {
+                !missing.iter().any(|entry| entry == workload)
+            }
+        }
+    }
+}
+
+/// Check a runtime report against the manifest that governs it.
+///
+/// Every problem is reported rather than the first. The producer records what
+/// happened and never decides whether it was good; this function is where that
+/// judgement lives, so a runner that was itself wrong is caught here rather
+/// than believed.
+pub fn validate_runtime_report(
+    manifest: &RuntimeManifest,
+    report: &RuntimeReport,
+) -> RuntimeValidationOutcome {
+    let mut errors = Vec::new();
+
+    if report.record_kind != RUNTIME_RECORD_KIND
+        || report.schema_version != RUNTIME_REPORT_SCHEMA_VERSION
+    {
+        // Nothing below can be trusted to mean what it appears to mean.
+        return RuntimeValidationOutcome {
+            errors: vec![RuntimeValidationError::UnsupportedRecord {
+                record_kind: report.record_kind.clone(),
+                schema_version: report.schema_version,
+            }],
+            invalid_samples: Vec::new(),
+            completeness: RuntimeCompleteness::Partial {
+                missing: Vec::new(),
+            },
+        };
+    }
+
+    check_identity_shape(report, &mut errors);
+
+    let Some(epoch) = manifest.epoch(&report.identity.platform, report.identity.epoch) else {
+        errors.push(RuntimeValidationError::UnknownEpoch {
+            platform: report.identity.platform.clone(),
+            epoch: report.identity.epoch,
+        });
+        return RuntimeValidationOutcome {
+            errors,
+            invalid_samples: Vec::new(),
+            completeness: RuntimeCompleteness::Partial {
+                missing: Vec::new(),
+            },
+        };
+    };
+
+    if report.identity.suite_revision != epoch.suite_revision {
+        errors.push(RuntimeValidationError::SuiteRevisionMismatch {
+            found: report.identity.suite_revision,
+            expected: epoch.suite_revision,
+        });
+    }
+    let Some(suite) = manifest.suite(epoch.suite_revision) else {
+        // Manifest parsing rejects this, so reaching it means the manifest was
+        // constructed some other way.
+        errors.push(RuntimeValidationError::SuiteRevisionMismatch {
+            found: report.identity.suite_revision,
+            expected: epoch.suite_revision,
+        });
+        return RuntimeValidationOutcome {
+            errors,
+            invalid_samples: Vec::new(),
+            completeness: RuntimeCompleteness::Partial {
+                missing: Vec::new(),
+            },
+        };
+    };
+
+    check_regime(report, epoch, suite, &mut errors);
+
+    if !epoch.environment.admits(&report.identity.environment) {
+        errors.push(RuntimeValidationError::EnvironmentPolicy {
+            expected: format!(
+                "{}/{}",
+                epoch.environment.runner_label, epoch.environment.runner_image
+            ),
+            found: format!(
+                "{}/{}",
+                report.identity.environment.runner_label, report.identity.environment.runner_image
+            ),
+        });
+    }
+
+    let mut missing: Vec<String> = Vec::new();
+    let mut invalid_samples: Vec<RuntimeInvalidSample> = Vec::new();
+    for workload in &suite.workloads {
+        let policy = epoch.sampling.get(&workload.id);
+        let Some(observation) = report.observation(&workload.id) else {
+            missing.push(workload.id.clone());
+            continue;
+        };
+        check_observation(observation, workload, &mut errors);
+
+        if let Some(policy) = policy
+            && let Some(actual) = samples_beyond_policy(observation.samples.len(), policy.samples)
+        {
+            errors.push(RuntimeValidationError::TooManySamples {
+                workload: workload.id.clone(),
+                allowed: policy.samples,
+                actual,
+            });
+        }
+        let before = invalid_samples.len();
+        collect_invalid_samples(observation, &mut invalid_samples);
+
+        let expected_samples = policy.map(|policy| policy.samples).unwrap_or(0);
+        // A workload publishes only when it produced its full sample count and
+        // every one of those samples is valid — the same tiering ADR-0067 uses,
+        // so a truncated or partly broken observation keeps its evidence and
+        // publishes no median.
+        let complete =
+            observation.samples.len() as u32 == expected_samples && invalid_samples.len() == before;
+        if !complete {
+            missing.push(workload.id.clone());
+        }
+    }
+    for observation in &report.workloads {
+        if suite.workload(&observation.workload).is_none() {
+            errors.push(RuntimeValidationError::UndeclaredWorkload {
+                workload: observation.workload.clone(),
+            });
+        }
+    }
+
+    missing.sort();
+    missing.dedup();
+    let completeness = if missing.is_empty() {
+        RuntimeCompleteness::Complete
+    } else {
+        RuntimeCompleteness::Partial { missing }
+    };
+
+    RuntimeValidationOutcome {
+        errors,
+        invalid_samples,
+        completeness,
+    }
+}
+
+/// Exclude samples that cannot have measured what they claim to.
+///
+/// The runtime half of ADR-0067's `collect_invalid_samples`, using the shared
+/// [`crate::sanity`] rules so the two record kinds cannot drift on what counts
+/// as a measurement.
+fn collect_invalid_samples(
+    observation: &RuntimeObservation,
+    invalid: &mut Vec<RuntimeInvalidSample>,
+) {
+    for (index, sample) in observation.samples.iter().enumerate() {
+        let reason = if !is_measurable_duration(sample.process_elapsed_ns) {
+            Some(RuntimeInvalidSampleReason::ZeroElapsed)
+        } else if sample.exit_code != 0 {
+            Some(RuntimeInvalidSampleReason::NonZeroExit {
+                exit_code: sample.exit_code,
+            })
+        } else {
+            None
+        };
+        if let Some(reason) = reason {
+            invalid.push(RuntimeInvalidSample {
+                workload: observation.workload.clone(),
+                sample_index: index as u32,
+                reason,
+            });
+        }
+    }
+}
+
+fn check_identity_shape(report: &RuntimeReport, errors: &mut Vec<RuntimeValidationError>) {
+    let identity = &report.identity;
+    let mut malformed = |field: &str, detail: &str| {
+        errors.push(RuntimeValidationError::MalformedIdentity {
+            field: field.to_string(),
+            detail: detail.to_string(),
+        });
+    };
+    if !is_commit(&identity.commit) {
+        malformed("commit", "expected a 40-character hexadecimal revision");
+    }
+    for (field, value) in [
+        ("started_at", &identity.started_at),
+        ("finished_at", &identity.finished_at),
+    ] {
+        if !is_utc_timestamp(value) {
+            malformed(field, "expected YYYY-MM-DDTHH:MM:SSZ");
+        }
+    }
+    // Consumers order points by completion time, so a record whose interval
+    // runs backwards would place itself arbitrarily within its own series.
+    if is_utc_timestamp(&identity.started_at)
+        && is_utc_timestamp(&identity.finished_at)
+        && !is_ordered_interval(&identity.started_at, &identity.finished_at)
+    {
+        malformed("finished_at", "the measurement interval runs backwards");
+    }
+    if identity.compiler_version.trim().is_empty() {
+        malformed(
+            "compiler_version",
+            "a runtime observation must name the compiler that produced the program",
+        );
+    }
+    // `std` is part of the product under measurement, so a runtime series that
+    // cannot say which standard library it ran against cannot attribute a
+    // movement. An empty hash means the runner never resolved one.
+    for (field, value) in [
+        ("toolchain_hash", &identity.toolchain_hash),
+        ("stdlib_hash", &identity.stdlib_hash),
+    ] {
+        if !is_sha256_digest(value) {
+            malformed(field, "expected a lowercase SHA-256 digest");
+        }
+    }
+    for observation in &report.workloads {
+        match identity.workload_source_hashes.get(&observation.workload) {
+            None => malformed(
+                &format!("workload_source_hashes/{}", observation.workload),
+                "an observed workload must record the source it was built from",
+            ),
+            Some(hash) if !is_sha256_digest(hash) => malformed(
+                &format!("workload_source_hashes/{}", observation.workload),
+                "expected a lowercase SHA-256 digest",
+            ),
+            Some(_) => {}
+        }
+    }
+}
+
+fn check_regime(
+    report: &RuntimeReport,
+    epoch: &RuntimeEpoch,
+    suite: &RuntimeSuiteRevision,
+    errors: &mut Vec<RuntimeValidationError>,
+) {
+    let regime = &report.regime;
+    let mut mismatch = |field: &str, found: String, expected: String| {
+        if found != expected {
+            errors.push(RuntimeValidationError::RegimeMismatch {
+                field: field.to_string(),
+                found,
+                expected,
+            });
+        }
+    };
+    mismatch(
+        "measured_boundary",
+        format!("{:?}", regime.measured_boundary),
+        format!("{:?}", suite.measured_boundary),
+    );
+    mismatch(
+        "optimization",
+        format!("{:?}", regime.optimization),
+        format!("{:?}", epoch.optimization),
+    );
+    mismatch(
+        "thread_policy",
+        format!("{:?}", regime.thread_policy),
+        format!("{:?}", epoch.thread_policy),
+    );
+    mismatch(
+        "hardware_counters",
+        format!("{:?}", regime.hardware_counters),
+        format!("{:?}", epoch.hardware_counters),
+    );
+    mismatch("target", regime.target.clone(), epoch.target.clone());
+    mismatch(
+        "compiler_args",
+        format!("{:?}", regime.compiler_args),
+        format!("{:?}", epoch.compiler_args),
+    );
+    mismatch(
+        "program_state",
+        regime.program_state.clone(),
+        "fresh_process".to_string(),
+    );
+    mismatch(
+        "os_page_cache",
+        regime.os_page_cache.clone(),
+        "uncontrolled".to_string(),
+    );
+    // The boundary claims these two are outside the timed window. A report
+    // asserting otherwise is not describing the boundary its suite declares.
+    mismatch(
+        "fixture_preparation_measured",
+        regime.fixture_preparation_measured.to_string(),
+        false.to_string(),
+    );
+    mismatch(
+        "oracle_comparison_measured",
+        regime.oracle_comparison_measured.to_string(),
+        false.to_string(),
+    );
+}
+
+fn check_observation(
+    observation: &RuntimeObservation,
+    workload: &RuntimeWorkload,
+    errors: &mut Vec<RuntimeValidationError>,
+) {
+    if observation.program_args != workload.program_args {
+        errors.push(RuntimeValidationError::ProgramArgumentsMismatch {
+            workload: workload.id.clone(),
+            found: observation.program_args.clone(),
+            expected: workload.program_args.clone(),
+        });
+    }
+
+    match observation
+        .recorded_inputs
+        .iter()
+        .find(|input| input.name == FIXTURE_INPUT_NAME)
+    {
+        None => errors.push(RuntimeValidationError::MissingRecordedInput {
+            workload: workload.id.clone(),
+            name: FIXTURE_INPUT_NAME.to_string(),
+        }),
+        Some(input) => {
+            let mut mismatch = |field: &str, found: String, expected: String| {
+                if found != expected {
+                    errors.push(RuntimeValidationError::FixtureProvenanceMismatch {
+                        workload: workload.id.clone(),
+                        field: field.to_string(),
+                        found,
+                        expected,
+                    });
+                }
+            };
+            mismatch(
+                "category",
+                format!("{:?}", input.category),
+                format!("{:?}", workload.fixture.category),
+            );
+            mismatch(
+                "bytes",
+                input.bytes.to_string(),
+                workload.fixture.bytes.to_string(),
+            );
+            // A `FixtureDeclaration` names exactly one `file_name`, so a
+            // single-file fixture claiming any other count is describing an
+            // input the suite did not declare. A multi-file recorded input —
+            // gazette's corpus — arrives with its own declaration kind.
+            mismatch("files", input.files.to_string(), 1.to_string());
+            match &input.provenance {
+                None => mismatch(
+                    "provenance",
+                    "none".to_string(),
+                    format!(
+                        "{} revision {} seed {}",
+                        workload.fixture.generator,
+                        workload.fixture.generator_revision,
+                        workload.fixture.seed
+                    ),
+                ),
+                Some(provenance) => {
+                    mismatch(
+                        "generator",
+                        provenance.generator.clone(),
+                        workload.fixture.generator.clone(),
+                    );
+                    mismatch(
+                        "generator_revision",
+                        provenance.generator_revision.to_string(),
+                        workload.fixture.generator_revision.to_string(),
+                    );
+                    mismatch(
+                        "seed",
+                        provenance.seed.to_string(),
+                        workload.fixture.seed.to_string(),
+                    );
+                    mismatch(
+                        "vocabulary_size",
+                        provenance.vocabulary_size.to_string(),
+                        workload.fixture.vocabulary_size.to_string(),
+                    );
+                }
+            }
+            // The digest is the only thing that makes two raw medians
+            // comparable, so a placeholder that is merely non-empty is worse
+            // than useless: it looks segmentable and segments nothing.
+            if !is_sha256_digest(&input.identity_sha256) {
+                errors.push(RuntimeValidationError::MalformedDigest {
+                    workload: workload.id.clone(),
+                    field: format!("recorded_inputs/{FIXTURE_INPUT_NAME}/identity_sha256"),
+                    found: input.identity_sha256.clone(),
+                });
+            }
+        }
+    }
+
+    if !is_sha256_digest(&observation.program.sha256) {
+        errors.push(RuntimeValidationError::MalformedDigest {
+            workload: workload.id.clone(),
+            field: "program/sha256".to_string(),
+            found: observation.program.sha256.clone(),
+        });
+    }
+    if observation.program.binary_bytes == 0 {
+        errors.push(RuntimeValidationError::ImpossibleProgramIdentity {
+            workload: workload.id.clone(),
+            detail: "a zero-byte executable cannot have been run".to_string(),
+        });
+    }
+
+    if observation.oracle.reference != workload.oracle.path {
+        errors.push(RuntimeValidationError::OracleReferenceMismatch {
+            workload: workload.id.clone(),
+            found: observation.oracle.reference.clone(),
+            expected: workload.oracle.path.clone(),
+        });
+    }
+    check_oracle_against_samples(observation, workload, errors);
+}
+
+/// Check the producer's summary of a run against the samples stored beside it.
+///
+/// The module doc claims that keeping the verdict out of the producer is what
+/// lets validation catch a producer that is itself wrong. This function is what
+/// makes that claim true. `verdict` and `deterministic_across_samples` are
+/// written by the runner; `samples[].stdout_sha256` is the evidence the record
+/// carries precisely so the claim is provable, and a validator reading only the
+/// summary would accept exactly the records a broken producer emits — into a
+/// store that cannot delete them.
+///
+/// ADR-0072 Decision 4's determinism requirement is enforced here, from the
+/// digests, rather than trusted from the flag.
+fn check_oracle_against_samples(
+    observation: &RuntimeObservation,
+    workload: &RuntimeWorkload,
+    errors: &mut Vec<RuntimeValidationError>,
+) {
+    let oracle = &observation.oracle;
+    fn contradiction(
+        errors: &mut Vec<RuntimeValidationError>,
+        workload: &str,
+        field: &str,
+        detail: String,
+    ) {
+        errors.push(RuntimeValidationError::OracleContradictsSamples {
+            workload: workload.to_string(),
+            field: field.to_string(),
+            detail,
+        });
+    }
+
+    for (index, sample) in observation.samples.iter().enumerate() {
+        if !is_sha256_digest(&sample.stdout_sha256) {
+            errors.push(RuntimeValidationError::MalformedDigest {
+                workload: workload.id.clone(),
+                field: format!("samples/{index}/stdout_sha256"),
+                found: sample.stdout_sha256.clone(),
+            });
+        }
+    }
+
+    // Determinism is decided by the digests, never by the flag.
+    let distinct: BTreeSet<&str> = observation
+        .samples
+        .iter()
+        .map(|sample| sample.stdout_sha256.as_str())
+        .collect();
+    let observed_deterministic = distinct.len() <= 1;
+    if oracle.deterministic_across_samples != observed_deterministic {
+        contradiction(
+            errors,
+            &workload.id,
+            "deterministic_across_samples",
+            format!(
+                "the flag says {} but {} distinct stdout digest(s) are stored",
+                oracle.deterministic_across_samples,
+                distinct.len()
+            ),
+        );
+    }
+    if !observed_deterministic {
+        errors.push(RuntimeValidationError::NondeterministicOutput {
+            workload: workload.id.clone(),
+        });
+    }
+
+    if oracle.verdict != OracleVerdict::Match {
+        errors.push(RuntimeValidationError::OracleFailed {
+            workload: workload.id.clone(),
+            verdict: oracle.verdict,
+            detail: oracle.detail.clone(),
+        });
+        // A non-matching verdict already blocks the report. Its digests
+        // legitimately carry the empty-string placeholders `judge` writes when
+        // there was nothing to read or nothing to judge, so holding them to the
+        // match-case contract below would only add confusing noise.
+        return;
+    }
+
+    // A `Match` is a claim about three things agreeing. Each is stored.
+    if observation.samples.is_empty() {
+        contradiction(
+            errors,
+            &workload.id,
+            "verdict",
+            "a match was declared but the report stores no sample to have judged".to_string(),
+        );
+        return;
+    }
+    for (field, value) in [
+        ("observed_sha256", &oracle.observed_sha256),
+        ("reference_sha256", &oracle.reference_sha256),
+    ] {
+        if !is_sha256_digest(value) {
+            errors.push(RuntimeValidationError::MalformedDigest {
+                workload: workload.id.clone(),
+                field: format!("oracle/{field}"),
+                found: value.clone(),
+            });
+        }
+    }
+    if oracle.observed_sha256 != oracle.reference_sha256 {
+        contradiction(
+            errors,
+            &workload.id,
+            "verdict",
+            format!(
+                "a match was declared, but the observed output {} is not the expected {}",
+                oracle.observed_sha256, oracle.reference_sha256
+            ),
+        );
+    }
+    // Every sample, not just the first: a report whose later samples disagree
+    // with the golden is a program that was wrong most of the time.
+    if let Some(index) = observation
+        .samples
+        .iter()
+        .position(|sample| sample.stdout_sha256 != oracle.observed_sha256)
+    {
+        contradiction(
+            errors,
+            &workload.id,
+            "verdict",
+            format!(
+                "a match was declared, but sample {index} produced {} rather than the judged {}",
+                observation.samples[index].stdout_sha256, oracle.observed_sha256
+            ),
+        );
+    }
+}
+
+/// The name under which a workload's data fixture is recorded.
+pub const FIXTURE_INPUT_NAME: &str = "fixture";
+
+// ---------------------------------------------------------------------------
+// Derived statistics
+// ---------------------------------------------------------------------------
+
+/// The value one sample contributes for a runtime metric.
+///
+/// Binary size is a property of the observation rather than the sample, so it
+/// is taken from the program identity: reporting it per sample would invite a
+/// median over a constant.
+pub fn runtime_sample_value(
+    observation: &RuntimeObservation,
+    sample: &RuntimeSample,
+    metric: RuntimeMetric,
+) -> u64 {
+    match metric {
+        RuntimeMetric::WallClock => sample.process_elapsed_ns,
+        RuntimeMetric::PeakMemory => sample.peak_memory_bytes,
+        RuntimeMetric::BinarySize => observation.program.binary_bytes,
+    }
+}
+
+/// Median and spread of one metric across an observation's samples.
+///
+/// `None` when the observation has no samples; there is no median of nothing,
+/// and inventing zero would silently poison every comparison downstream.
+pub fn summarize(
+    observation: &RuntimeObservation,
+    metric: RuntimeMetric,
+) -> Option<crate::Summary> {
+    let values: Vec<u64> = observation
+        .samples
+        .iter()
+        .map(|sample| runtime_sample_value(observation, sample, metric))
+        .collect();
+    crate::Summary::of(&values)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const MANIFEST: &str = r#"
+schema_version = 1
+
+[[suite]]
+revision = 1
+protocol_version = 1
+measured_boundary = "spawn_to_exit_v1"
+
+[[suite.workloads]]
+id = "wordfreq"
+source = "examples/wordfreq/main.rue"
+question = "How fast does compiled Rue count words in a large text?"
+program_args = ["{fixture}"]
+
+[suite.workloads.fixture]
+category = "recorded"
+generator = "zipf_ascii_text"
+generator_revision = 1
+seed = 20260813
+bytes = 4096
+vocabulary_size = 256
+file_name = "input.txt"
+description = "deterministic ASCII prose"
+
+[suite.workloads.oracle]
+kind = "golden_stdout"
+path = "performance/fixtures/wordfreq/expected-stdout.txt"
+
+[[epoch]]
+id = 1
+platform = "x86_64-linux"
+suite_revision = 1
+target = "x86_64-unknown-linux-gnu"
+compiler_args = ["-O3"]
+optimization = "o3"
+thread_policy = "single_threaded"
+hardware_counters = "unavailable_on_hosted_runner"
+collection = true
+
+[epoch.environment]
+runner_label = "github-hosted"
+runner_image = "ubuntu-24.04"
+
+[epoch.sampling.wordfreq]
+samples = 5
+"#;
+
+    fn manifest() -> RuntimeManifest {
+        RuntimeManifest::parse(MANIFEST).expect("fixture manifest")
+    }
+
+    /// The manifest the repository actually ships, checked against this schema.
+    const CHECKED_IN_MANIFEST: &str = include_str!("runtime.toml");
+
+    #[test]
+    fn the_checked_in_manifest_declares_the_v1_contract() {
+        // Guards the shipped declaration against this schema: a manifest that
+        // stopped parsing, or quietly stopped measuring the release-quality
+        // product, would otherwise be discovered by a CI collection run.
+        let manifest = RuntimeManifest::parse(CHECKED_IN_MANIFEST).expect("checked-in manifest");
+        let epoch = manifest
+            .collection_epoch("x86_64-linux")
+            .expect("the v1 platform matrix is exactly x86_64-linux");
+        assert_eq!(epoch.optimization, OptimizationLevel::O3);
+        assert_eq!(epoch.thread_policy, ThreadPolicy::SingleThreaded);
+        assert_eq!(
+            epoch.hardware_counters,
+            HardwareCounterPolicy::UnavailableOnHostedRunner,
+            "hosted runners expose no PMU; counters wait for a controlled-hardware epoch"
+        );
+        assert_eq!(epoch.environment.runner_image, "ubuntu-24.04");
+
+        let suite = manifest.suite(epoch.suite_revision).expect("suite");
+        assert_eq!(suite.measured_boundary, RuntimeBoundary::SpawnToExitV1);
+        let workload = suite
+            .workload("wordfreq")
+            .expect("wordfreq is a permanent member of this suite");
+        assert_eq!(workload.fixture.category, InputCategory::Recorded);
+        assert_eq!(workload.oracle.kind, OracleKind::GoldenStdout);
+        assert!(
+            workload.fixture.bytes >= 16 * 1024 * 1024,
+            "the fixture must be large enough that the run measures counting \
+             rather than process startup"
+        );
+        // No calibration yet, so every flag on this series is advisory.
+        assert_eq!(epoch.flag_posture("wordfreq"), FlagPosture::Advisory);
+    }
+
+    #[test]
+    fn no_platform_outside_the_v1_matrix_collects_yet() {
+        // aarch64-linux joins once ADR-0072's Phase 2 std work is CI-verified
+        // there; macOS stays deferred behind the `@syscall` gap.
+        let manifest = RuntimeManifest::parse(CHECKED_IN_MANIFEST).expect("checked-in manifest");
+        let collecting: Vec<&str> = manifest
+            .epochs()
+            .iter()
+            .filter(|epoch| epoch.collection)
+            .map(|epoch| epoch.platform.as_str())
+            .collect();
+        assert_eq!(collecting, vec!["x86_64-linux"]);
+    }
+
+    fn fingerprint() -> EnvironmentFingerprint {
+        EnvironmentFingerprint {
+            runner_label: "github-hosted".to_string(),
+            runner_image: "ubuntu-24.04".to_string(),
+            runner_image_version: "20260720.1".to_string(),
+            cpu_model: "AMD EPYC 7763".to_string(),
+            core_count: 4,
+            memory_bytes: 16 * 1024 * 1024 * 1024,
+            kernel_version: "6.8.0".to_string(),
+            os_version: "Ubuntu 24.04".to_string(),
+            architecture: "x86_64".to_string(),
+        }
+    }
+
+    fn report() -> RuntimeReport {
+        RuntimeReport {
+            record_kind: RUNTIME_RECORD_KIND.to_string(),
+            schema_version: RUNTIME_REPORT_SCHEMA_VERSION,
+            identity: RuntimeIdentity {
+                suite_revision: 1,
+                epoch: 1,
+                platform: "x86_64-linux".to_string(),
+                commit: "a".repeat(40),
+                compiler_version: "rue 0.1.0".to_string(),
+                started_at: "2026-08-13T00:00:00Z".to_string(),
+                finished_at: "2026-08-13T00:01:00Z".to_string(),
+                toolchain_hash: "1".repeat(64),
+                stdlib_hash: "2".repeat(64),
+                workload_source_hashes: BTreeMap::from([("wordfreq".to_string(), "3".repeat(64))]),
+                environment: fingerprint(),
+            },
+            regime: RuntimeRegime {
+                measured_boundary: RuntimeBoundary::SpawnToExitV1,
+                program_state: "fresh_process".to_string(),
+                os_page_cache: "uncontrolled".to_string(),
+                fixture_preparation_measured: false,
+                oracle_comparison_measured: false,
+                optimization: OptimizationLevel::O3,
+                compiler_args: vec!["-O3".to_string()],
+                target: "x86_64-unknown-linux-gnu".to_string(),
+                thread_policy: ThreadPolicy::SingleThreaded,
+                hardware_counters: HardwareCounterPolicy::UnavailableOnHostedRunner,
+            },
+            workloads: vec![RuntimeObservation {
+                workload: "wordfreq".to_string(),
+                source: "examples/wordfreq/main.rue".to_string(),
+                question: "How fast does compiled Rue count words in a large text?".to_string(),
+                program_args: vec![FIXTURE_ARGUMENT.to_string()],
+                recorded_inputs: vec![RecordedInput {
+                    name: FIXTURE_INPUT_NAME.to_string(),
+                    category: InputCategory::Recorded,
+                    description: "deterministic ASCII prose".to_string(),
+                    identity_sha256: "f".repeat(64),
+                    files: 1,
+                    bytes: 4096,
+                    provenance: Some(GeneratedProvenance {
+                        generator: "zipf_ascii_text".to_string(),
+                        generator_revision: 1,
+                        seed: 20260813,
+                        vocabulary_size: 256,
+                    }),
+                }],
+                program: ProgramIdentity {
+                    binary_bytes: 262_144,
+                    sha256: "b".repeat(64),
+                },
+                oracle: OracleOutcome {
+                    kind: OracleKind::GoldenStdout,
+                    reference: "performance/fixtures/wordfreq/expected-stdout.txt".to_string(),
+                    reference_sha256: "c".repeat(64),
+                    observed_sha256: "c".repeat(64),
+                    verdict: OracleVerdict::Match,
+                    deterministic_across_samples: true,
+                    detail: String::new(),
+                },
+                samples: (0..5)
+                    .map(|index| RuntimeSample {
+                        process_elapsed_ns: 1_000_000_000 + index * 1_000_000,
+                        peak_memory_bytes: 100 * 1024 * 1024,
+                        exit_code: 0,
+                        stdout_bytes: 42,
+                        stdout_sha256: "c".repeat(64),
+                    })
+                    .collect(),
+            }],
+            failures: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn parses_a_versioned_runtime_manifest() {
+        let manifest = manifest();
+        let suite = manifest.suite(1).expect("suite 1");
+        assert_eq!(suite.workload_ids(), vec!["wordfreq"]);
+        assert_eq!(suite.measured_boundary, RuntimeBoundary::SpawnToExitV1);
+        let epoch = manifest.collection_epoch("x86_64-linux").expect("epoch");
+        assert_eq!(epoch.id, 1);
+        assert_eq!(epoch.optimization, OptimizationLevel::O3);
+    }
+
+    #[test]
+    fn the_fixture_is_declared_as_a_recorded_input_not_a_pinned_one() {
+        // ADR-0072 Decision 2's third input category, named in the schema so a
+        // record can never be ambiguous about which discipline governed it.
+        let manifest = manifest();
+        let workload = manifest.suite(1).unwrap().workload("wordfreq").unwrap();
+        assert_eq!(workload.fixture.category, InputCategory::Recorded);
+    }
+
+    #[test]
+    fn an_uncalibrated_workload_reports_an_advisory_posture() {
+        // Runtime calibration is never inherited from the compiler suites, so
+        // until this workload's own dispersion is measured here, movement is
+        // advisory rather than a gate.
+        let manifest = manifest();
+        let epoch = manifest.epoch("x86_64-linux", 1).unwrap();
+        assert_eq!(epoch.flag_posture("wordfreq"), FlagPosture::Advisory);
+    }
+
+    #[test]
+    fn a_calibrated_workload_reports_a_calibrated_posture() {
+        let text = format!(
+            "{MANIFEST}\n[epoch.calibration.wordfreq]\nk = 3.0\nwindow = 10\n\
+             reference = \"RUE-1046 calibration\"\n"
+        );
+        let manifest = RuntimeManifest::parse(&text).expect("calibrated manifest");
+        let epoch = manifest.epoch("x86_64-linux", 1).unwrap();
+        assert_eq!(epoch.flag_posture("wordfreq"), FlagPosture::Calibrated);
+    }
+
+    #[test]
+    fn rejects_a_workload_that_never_receives_its_fixture() {
+        let text = MANIFEST.replace(r#"program_args = ["{fixture}"]"#, "program_args = []");
+        let error = RuntimeManifest::parse(&text).unwrap_err();
+        assert!(error.contains("never passes its fixture"), "{error}");
+    }
+
+    #[test]
+    fn rejects_single_sample_policies_because_they_have_no_spread() {
+        let text = MANIFEST.replace("samples = 5", "samples = 1");
+        let error = RuntimeManifest::parse(&text).unwrap_err();
+        assert!(error.contains("at least two"), "{error}");
+    }
+
+    #[test]
+    fn rejects_an_epoch_measuring_something_other_than_the_release_product() {
+        let text = MANIFEST.replace(r#"optimization = "o3""#, r#"optimization = "o0""#);
+        let error = RuntimeManifest::parse(&text).unwrap_err();
+        assert!(error.contains("release-quality"), "{error}");
+    }
+
+    #[test]
+    fn rejects_sampling_policies_that_do_not_cover_the_suite() {
+        let text = MANIFEST.replace("[epoch.sampling.wordfreq]", "[epoch.sampling.jsonfmt]");
+        let error = RuntimeManifest::parse(&text).unwrap_err();
+        assert!(error.contains("do not match its suite"), "{error}");
+    }
+
+    #[test]
+    fn rejects_unknown_fields_instead_of_guessing() {
+        let error = RuntimeManifest::parse(&format!("{MANIFEST}\nsurprise = true\n")).unwrap_err();
+        assert!(error.contains("unknown field"), "{error}");
+    }
+
+    #[test]
+    fn rejects_two_collection_epochs_on_one_platform() {
+        let text = format!(
+            "{MANIFEST}\n[[epoch]]\nid = 2\nplatform = \"x86_64-linux\"\nsuite_revision = 1\n\
+             target = \"x86_64-unknown-linux-gnu\"\ncompiler_args = [\"-O3\"]\n\
+             optimization = \"o3\"\nthread_policy = \"single_threaded\"\n\
+             hardware_counters = \"unavailable_on_hosted_runner\"\ncollection = true\n\
+             [epoch.environment]\nrunner_label = \"github-hosted\"\n\
+             runner_image = \"ubuntu-24.04\"\n[epoch.sampling.wordfreq]\nsamples = 5\n"
+        );
+        let error = RuntimeManifest::parse(&text).unwrap_err();
+        assert!(error.contains("for collection"), "{error}");
+    }
+
+    #[test]
+    fn a_runner_shaped_report_is_appendable() {
+        let outcome = validate_runtime_report(&manifest(), &report());
+        assert_eq!(outcome.errors, Vec::new());
+        assert_eq!(outcome.completeness, RuntimeCompleteness::Complete);
+        assert!(outcome.publishes_workload("wordfreq"));
+    }
+
+    #[test]
+    fn wrong_output_is_unappendable_however_fast_it_was() {
+        // The rule the oracle exists for. This report's samples are the fastest
+        // in the suite and it still may not enter a series.
+        let mut report = report();
+        for sample in &mut report.workloads[0].samples {
+            sample.process_elapsed_ns = 1;
+        }
+        report.workloads[0].oracle.verdict = OracleVerdict::Mismatch;
+        report.workloads[0].oracle.observed_sha256 = "d".repeat(64);
+        report.workloads[0].oracle.detail = "line 3 differs".to_string();
+        let outcome = validate_runtime_report(&manifest(), &report);
+        assert!(!outcome.is_appendable());
+        assert!(
+            outcome
+                .errors
+                .iter()
+                .any(|error| matches!(error, RuntimeValidationError::OracleFailed { .. }))
+        );
+    }
+
+    #[test]
+    fn an_unjudgeable_run_is_refused_rather_than_assumed_correct() {
+        let mut report = report();
+        report.workloads[0].oracle.verdict = OracleVerdict::Indeterminate;
+        report.workloads[0].oracle.detail = "the golden file could not be read".to_string();
+        let outcome = validate_runtime_report(&manifest(), &report);
+        assert!(!outcome.is_appendable());
+    }
+
+    #[test]
+    fn output_that_varies_between_samples_is_refused() {
+        // Decided from the stored digests, not from the producer's flag —
+        // which here still claims the run was deterministic.
+        let mut report = report();
+        report.workloads[0].samples[1].stdout_sha256 = "d".repeat(64);
+        let outcome = validate_runtime_report(&manifest(), &report);
+        assert!(!outcome.is_appendable());
+        assert!(
+            outcome.errors.iter().any(|error| matches!(
+                error,
+                RuntimeValidationError::NondeterministicOutput { .. }
+            )),
+            "{:?}",
+            outcome.errors
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // The producer is evidence, not an authority.
+    //
+    // Every case below was hand-crafted to pass a validator that reads the
+    // runner's own summary fields, and every one is a record that could reach a
+    // store which cannot delete it. They are the assertion that the separation
+    // this module claims is real.
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn a_determinism_claim_is_checked_against_the_stored_digests() {
+        // `deterministic_across_samples: true` while sample 1's digest differs.
+        // The flag is the claim; the digests are the evidence.
+        let mut report = report();
+        report.workloads[0].samples[1].stdout_sha256 = "d".repeat(64);
+        assert!(report.workloads[0].oracle.deterministic_across_samples);
+        let outcome = validate_runtime_report(&manifest(), &report);
+        assert!(!outcome.is_appendable());
+        assert!(
+            outcome.errors.iter().any(|error| matches!(
+                error,
+                RuntimeValidationError::OracleContradictsSamples { field, .. }
+                    if field == "deterministic_across_samples"
+            )),
+            "{:?}",
+            outcome.errors
+        );
+    }
+
+    #[test]
+    fn a_determinism_claim_is_checked_in_both_directions() {
+        // The mirror case: samples agree, but the runner claims they did not.
+        // A producer this confused is not one whose verdict should be believed.
+        let mut report = report();
+        report.workloads[0].oracle.deterministic_across_samples = false;
+        let outcome = validate_runtime_report(&manifest(), &report);
+        assert!(!outcome.is_appendable());
+        assert!(
+            outcome.errors.iter().any(|error| matches!(
+                error,
+                RuntimeValidationError::OracleContradictsSamples { .. }
+            )),
+            "{:?}",
+            outcome.errors
+        );
+    }
+
+    #[test]
+    fn a_match_whose_oracle_digests_disagree_is_refused() {
+        // `verdict: match` with `observed_sha256 != reference_sha256`. The
+        // verdict is a claim that these two agree; they are both stored.
+        let mut report = report();
+        report.workloads[0].oracle.observed_sha256 = "d".repeat(64);
+        for sample in &mut report.workloads[0].samples {
+            sample.stdout_sha256 = "d".repeat(64);
+        }
+        let outcome = validate_runtime_report(&manifest(), &report);
+        assert!(!outcome.is_appendable());
+        assert!(
+            outcome.errors.iter().any(|error| matches!(
+                error,
+                RuntimeValidationError::OracleContradictsSamples { field, detail, .. }
+                    if field == "verdict" && detail.contains("not the expected")
+            )),
+            "{:?}",
+            outcome.errors
+        );
+    }
+
+    #[test]
+    fn a_match_no_sample_actually_produced_is_refused() {
+        // Every sample disagrees with both oracle digests, under `match`. The
+        // most brazen of the crafted records, and previously the one that
+        // published a point like any other.
+        let mut report = report();
+        for sample in &mut report.workloads[0].samples {
+            sample.stdout_sha256 = "d".repeat(64);
+        }
+        let outcome = validate_runtime_report(&manifest(), &report);
+        assert!(!outcome.is_appendable());
+        assert!(
+            outcome.errors.iter().any(|error| matches!(
+                error,
+                RuntimeValidationError::OracleContradictsSamples { field, detail, .. }
+                    if field == "verdict" && detail.contains("rather than the judged")
+            )),
+            "{:?}",
+            outcome.errors
+        );
+    }
+
+    #[test]
+    fn a_match_declared_over_no_samples_at_all_is_refused() {
+        let mut report = report();
+        report.workloads[0].samples.clear();
+        let outcome = validate_runtime_report(&manifest(), &report);
+        assert!(!outcome.is_appendable());
+        assert!(
+            outcome.errors.iter().any(|error| matches!(
+                error,
+                RuntimeValidationError::OracleContradictsSamples { detail, .. }
+                    if detail.contains("no sample")
+            )),
+            "{:?}",
+            outcome.errors
+        );
+    }
+
+    #[test]
+    fn a_zero_length_sample_invalidates_its_workload() {
+        // The runtime counterpart of ADR-0067's
+        // `a_zero_length_compilation_invalidates_the_sample`. A monotonic clock
+        // either side of a process that ran cannot produce zero, and zero is
+        // exactly the value that would look like a spectacular result.
+        let mut report = report();
+        report.workloads[0].samples[2].process_elapsed_ns = 0;
+        let outcome = validate_runtime_report(&manifest(), &report);
+        assert_eq!(
+            outcome.invalid_samples,
+            vec![RuntimeInvalidSample {
+                workload: "wordfreq".to_string(),
+                sample_index: 2,
+                reason: RuntimeInvalidSampleReason::ZeroElapsed,
+            }]
+        );
+        // Kept as evidence, published as nothing.
+        assert!(outcome.is_appendable(), "{:?}", outcome.errors);
+        assert!(!outcome.publishes_workload("wordfreq"));
+    }
+
+    #[test]
+    fn a_zero_byte_executable_is_refused_outright() {
+        // Unlike a zero-length sample, this is not a noisy measurement: no
+        // process ran an empty file, so the record is impossible rather than
+        // unreliable.
+        let mut report = report();
+        report.workloads[0].program.binary_bytes = 0;
+        let outcome = validate_runtime_report(&manifest(), &report);
+        assert!(!outcome.is_appendable());
+        assert!(
+            outcome.errors.iter().any(|error| matches!(
+                error,
+                RuntimeValidationError::ImpossibleProgramIdentity { .. }
+            )),
+            "{:?}",
+            outcome.errors
+        );
+    }
+
+    #[test]
+    fn more_samples_than_the_policy_allows_is_a_protocol_violation() {
+        // ADR-0067 makes this a hard error; the shared rule makes it one here
+        // too, rather than a report that quietly publishes nothing.
+        let mut report = report();
+        let extra = report.workloads[0].samples[0].clone();
+        report.workloads[0]
+            .samples
+            .extend(std::iter::repeat_n(extra, 5));
+        let outcome = validate_runtime_report(&manifest(), &report);
+        assert!(!outcome.is_appendable());
+        assert!(
+            outcome.errors.iter().any(|error| matches!(
+                error,
+                RuntimeValidationError::TooManySamples {
+                    allowed: 5,
+                    actual: 10,
+                    ..
+                }
+            )),
+            "{:?}",
+            outcome.errors
+        );
+    }
+
+    #[test]
+    fn a_placeholder_fixture_digest_is_refused() {
+        // The digest is the only thing making two raw medians comparable, so a
+        // value that is merely non-empty looks segmentable and segments nothing.
+        let mut report = report();
+        report.workloads[0].recorded_inputs[0].identity_sha256 = "not-a-hash".to_string();
+        let outcome = validate_runtime_report(&manifest(), &report);
+        assert!(!outcome.is_appendable());
+        assert!(
+            outcome.errors.iter().any(|error| matches!(
+                error,
+                RuntimeValidationError::MalformedDigest { field, .. }
+                    if field.ends_with("identity_sha256")
+            )),
+            "{:?}",
+            outcome.errors
+        );
+    }
+
+    #[test]
+    fn a_fixture_claiming_the_wrong_file_count_is_refused() {
+        let mut report = report();
+        report.workloads[0].recorded_inputs[0].files = 4242;
+        let outcome = validate_runtime_report(&manifest(), &report);
+        assert!(outcome.errors.iter().any(|error| matches!(
+            error,
+            RuntimeValidationError::FixtureProvenanceMismatch { field, .. } if field == "files"
+        )));
+    }
+
+    #[test]
+    fn a_fixture_generated_from_another_vocabulary_is_a_different_workload() {
+        // The vocabulary is as much an input to the golden as the seed is, so a
+        // record must be able to describe it and validation must check it.
+        let mut report = report();
+        report.workloads[0].recorded_inputs[0]
+            .provenance
+            .as_mut()
+            .unwrap()
+            .vocabulary_size = 512;
+        let outcome = validate_runtime_report(&manifest(), &report);
+        assert!(outcome.errors.iter().any(|error| matches!(
+            error,
+            RuntimeValidationError::FixtureProvenanceMismatch { field, .. }
+                if field == "vocabulary_size"
+        )));
+    }
+
+    #[test]
+    fn a_measurement_interval_may_not_run_backwards() {
+        // Derivation orders points by completion time, so a reversed interval
+        // would place a point arbitrarily within its own series.
+        let mut report = report();
+        report.identity.started_at = "2026-08-13T00:02:00Z".to_string();
+        let outcome = validate_runtime_report(&manifest(), &report);
+        assert!(outcome.errors.iter().any(|error| matches!(
+            error,
+            RuntimeValidationError::MalformedIdentity { field, .. } if field == "finished_at"
+        )));
+    }
+
+    #[test]
+    fn a_report_that_resolved_no_standard_library_is_refused() {
+        // `std` is part of the product under measurement. A runtime series that
+        // cannot say which one it ran against cannot attribute a movement.
+        let mut report = report();
+        report.identity.stdlib_hash = String::new();
+        let outcome = validate_runtime_report(&manifest(), &report);
+        assert!(outcome.errors.iter().any(|error| matches!(
+            error,
+            RuntimeValidationError::MalformedIdentity { field, .. } if field == "stdlib_hash"
+        )));
+    }
+
+    #[test]
+    fn a_fixture_digest_that_moved_is_recorded_rather_than_rejected() {
+        // The recorded-input rule. The compile-time suites fail a run whose
+        // pinned inputs moved; this one keeps the observation and lets the
+        // digest mark the discontinuity.
+        let mut report = report();
+        report.workloads[0].recorded_inputs[0].identity_sha256 = "9".repeat(64);
+        let outcome = validate_runtime_report(&manifest(), &report);
+        assert!(outcome.is_appendable(), "{:?}", outcome.errors);
+    }
+
+    #[test]
+    fn a_fixture_generated_from_another_seed_is_a_different_workload() {
+        // Recorded is not unpinned: the *provenance* the suite declares is
+        // still a contract, or the series would silently change subject.
+        let mut report = report();
+        report.workloads[0].recorded_inputs[0]
+            .provenance
+            .as_mut()
+            .unwrap()
+            .seed = 1;
+        let outcome = validate_runtime_report(&manifest(), &report);
+        assert!(outcome.errors.iter().any(|error| matches!(
+            error,
+            RuntimeValidationError::FixtureProvenanceMismatch { field, .. } if field == "seed"
+        )));
+    }
+
+    #[test]
+    fn an_observation_without_a_recorded_fixture_identity_is_refused() {
+        let mut report = report();
+        report.workloads[0].recorded_inputs.clear();
+        let outcome = validate_runtime_report(&manifest(), &report);
+        assert!(
+            outcome
+                .errors
+                .iter()
+                .any(|error| matches!(error, RuntimeValidationError::MissingRecordedInput { .. }))
+        );
+    }
+
+    #[test]
+    fn a_report_measuring_a_debug_build_is_refused() {
+        let mut report = report();
+        report.regime.optimization = OptimizationLevel::O0;
+        let outcome = validate_runtime_report(&manifest(), &report);
+        assert!(outcome.errors.iter().any(|error| matches!(
+            error,
+            RuntimeValidationError::RegimeMismatch { field, .. } if field == "optimization"
+        )));
+    }
+
+    #[test]
+    fn a_report_that_timed_fixture_preparation_is_refused() {
+        // The boundary is the measurement. A report claiming it measured setup
+        // is describing a different experiment than its suite declares.
+        let mut report = report();
+        report.regime.fixture_preparation_measured = true;
+        let outcome = validate_runtime_report(&manifest(), &report);
+        assert!(outcome.errors.iter().any(|error| matches!(
+            error,
+            RuntimeValidationError::RegimeMismatch { field, .. }
+                if field == "fixture_preparation_measured"
+        )));
+    }
+
+    #[test]
+    fn a_local_run_cannot_enter_the_hosted_series() {
+        let mut report = report();
+        report.identity.environment.runner_label = "local".to_string();
+        let outcome = validate_runtime_report(&manifest(), &report);
+        assert!(
+            outcome
+                .errors
+                .iter()
+                .any(|error| matches!(error, RuntimeValidationError::EnvironmentPolicy { .. }))
+        );
+    }
+
+    #[test]
+    fn a_crashed_workload_leaves_a_partial_but_appendable_report() {
+        // Collection health must be visible rather than appearing as a hole.
+        let mut report = report();
+        report.workloads[0].samples.truncate(2);
+        report.failures.push(RuntimeFailure::ProgramCrashed {
+            workload: "wordfreq".to_string(),
+            sample_index: 2,
+            detail: "signal 11".to_string(),
+        });
+        let outcome = validate_runtime_report(&manifest(), &report);
+        assert!(outcome.is_appendable(), "{:?}", outcome.errors);
+        assert!(!outcome.publishes_workload("wordfreq"));
+        assert_eq!(
+            outcome.completeness,
+            RuntimeCompleteness::Partial {
+                missing: vec!["wordfreq".to_string()],
+            }
+        );
+    }
+
+    #[test]
+    fn a_missing_compiler_version_is_refused() {
+        // Longitudinal tracking is the point of the series; a record that
+        // cannot say which compiler built the program cannot serve it.
+        let mut report = report();
+        report.identity.compiler_version = String::new();
+        let outcome = validate_runtime_report(&manifest(), &report);
+        assert!(outcome.errors.iter().any(|error| matches!(
+            error,
+            RuntimeValidationError::MalformedIdentity { field, .. } if field == "compiler_version"
+        )));
+    }
+
+    #[test]
+    fn a_record_of_another_kind_is_refused_before_anything_else_is_read() {
+        let mut report = report();
+        report.record_kind = "compiler_run".to_string();
+        report.identity.commit = "not-a-commit".to_string();
+        let outcome = validate_runtime_report(&manifest(), &report);
+        assert_eq!(outcome.errors.len(), 1);
+        assert!(matches!(
+            outcome.errors[0],
+            RuntimeValidationError::UnsupportedRecord { .. }
+        ));
+    }
+
+    #[test]
+    fn a_report_is_content_addressable_and_round_trips() {
+        let report = report();
+        let text = crate::canonical_json(&report).expect("addressable");
+        let parsed: RuntimeReport = serde_json::from_str(&text).expect("readable");
+        assert_eq!(parsed, report);
+        assert_eq!(
+            parsed.content_address().unwrap(),
+            report.content_address().unwrap()
+        );
+    }
+
+    #[test]
+    fn a_stored_report_is_named_by_the_bytes_it_was_published_as() {
+        let report = report();
+        let text = crate::canonical_json(&report).expect("addressable");
+        let stored = crate::StoredRuntimeReport::read(&text).expect("readable");
+        assert_eq!(stored.address(), report.content_address().unwrap());
+        assert_eq!(stored.record(), &report);
+    }
+
+    #[test]
+    fn a_stored_report_keeps_the_name_its_own_bytes_have() {
+        // The trap [`crate::StoredRun`] exists to avoid, in its cheapest form.
+        // Runtime records will grow fields — peer tool versions, scale variants
+        // — and a reader that re-derived a name from today's struct would
+        // rename every record written before each addition.
+        let report = report();
+        let published = crate::canonical_json(&report).expect("addressable");
+        let pretty = serde_json::to_string_pretty(&report).unwrap();
+        assert_ne!(pretty, published, "the fixture must actually differ");
+        assert_eq!(
+            crate::StoredRuntimeReport::read(&pretty).unwrap().address(),
+            crate::StoredRuntimeReport::read(&published)
+                .unwrap()
+                .address(),
+            "insignificant whitespace is not part of a record's identity"
+        );
+    }
+
+    #[test]
+    fn changing_a_measurement_changes_the_stored_name() {
+        let report = report();
+        let mut altered = report.clone();
+        altered.workloads[0].samples[0].process_elapsed_ns += 1;
+        let one =
+            crate::StoredRuntimeReport::read(&crate::canonical_json(&report).unwrap()).unwrap();
+        let two =
+            crate::StoredRuntimeReport::read(&crate::canonical_json(&altered).unwrap()).unwrap();
+        assert_ne!(one.address(), two.address());
+    }
+
+    #[test]
+    fn a_malformed_record_is_reported_rather_than_guessed_at() {
+        assert!(crate::StoredRuntimeReport::read("{").is_err());
+        assert!(crate::StoredRuntimeReport::read(r#"{"record_kind":"runtime_v1"}"#).is_err());
+    }
+
+    #[test]
+    fn summaries_are_derived_from_raw_samples() {
+        let report = report();
+        let observation = report.observation("wordfreq").unwrap();
+        let wall = summarize(observation, RuntimeMetric::WallClock).unwrap();
+        assert_eq!(wall.median, 1_002_000_000);
+        assert_eq!(wall.count, 5);
+        // Binary size is a property of the observation, so its spread is zero
+        // rather than a median over a constant computed per sample.
+        let size = summarize(observation, RuntimeMetric::BinarySize).unwrap();
+        assert_eq!(size.median, 262_144);
+        assert_eq!(size.mad, 0);
+    }
+
+    #[test]
+    fn an_observation_without_samples_has_no_summary() {
+        let mut report = report();
+        report.workloads[0].samples.clear();
+        let observation = report.observation("wordfreq").unwrap();
+        assert_eq!(summarize(observation, RuntimeMetric::WallClock), None);
+    }
+}

--- a/crates/rue-perf-schema/src/sanity.rs
+++ b/crates/rue-perf-schema/src/sanity.rs
@@ -1,0 +1,153 @@
+//! Rules every measurement record kind answers to.
+//!
+//! These are not rules about what a particular record *contains* — those belong
+//! with the record — but about what a *measurement* is. A sample that took zero
+//! time did not happen. An observation carrying more samples than its policy
+//! permits was not taken under that policy. A digest that is not a digest names
+//! nothing, and an instant with two spellings gives one measurement two content
+//! addresses.
+//!
+//! ADR-0067 settled each of these for the compile-time suites. ADR-0072's
+//! runtime records answer to exactly the same ones, so they are decided here
+//! once rather than in each validator, where the two copies would drift and the
+//! looser one would be the one admitting a bad record into a store that cannot
+//! delete it.
+
+/// Accepts exactly `YYYY-MM-DDTHH:MM:SSZ`.
+///
+/// One spelling, so two identical measurements cannot produce two content
+/// addresses by formatting the same instant differently.
+pub fn is_utc_timestamp(value: &str) -> bool {
+    let bytes = value.as_bytes();
+    if bytes.len() != 20 {
+        return false;
+    }
+    let digits = [0, 1, 2, 3, 5, 6, 8, 9, 11, 12, 14, 15, 17, 18];
+    let dashes = [4, 7];
+    let colons = [13, 16];
+    digits.iter().all(|&index| bytes[index].is_ascii_digit())
+        && dashes.iter().all(|&index| bytes[index] == b'-')
+        && colons.iter().all(|&index| bytes[index] == b':')
+        && bytes[10] == b'T'
+        && bytes[19] == b'Z'
+}
+
+/// Whether a measurement's start and end are in that order.
+///
+/// Both timestamps must already be well-formed; the fixed-width, zero-padded
+/// spelling [`is_utc_timestamp`] enforces makes lexicographic order the same as
+/// chronological order, which is why this is a string comparison.
+///
+/// Not pedantry: consumers order points by completion time, so a record whose
+/// interval runs backwards would place itself arbitrarily in its own series.
+pub fn is_ordered_interval(started_at: &str, finished_at: &str) -> bool {
+    is_utc_timestamp(started_at) && is_utc_timestamp(finished_at) && started_at <= finished_at
+}
+
+/// Whether a value is a SHA-256 digest in the one spelling records use:
+/// 64 lowercase hexadecimal characters.
+///
+/// Digests are how a record names things it cannot contain — the input it read,
+/// the binary it ran, the output it produced. A digest that is merely non-empty
+/// names nothing and compares equal to nothing, so checking only for emptiness
+/// admits a record that looks segmentable and is not.
+pub fn is_sha256_digest(value: &str) -> bool {
+    value.len() == 64
+        && value
+            .bytes()
+            .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte))
+}
+
+/// Whether a value is a 40-character hexadecimal source revision.
+pub fn is_commit(value: &str) -> bool {
+    value.len() == 40 && value.bytes().all(|byte| byte.is_ascii_hexdigit())
+}
+
+/// Whether a measured duration could have come from a real process.
+///
+/// Zero is the case worth naming. A monotonic clock read either side of a
+/// process that genuinely ran cannot produce it, so a zero-length sample is
+/// evidence that the measurement did not happen — and it is exactly the value
+/// that would drag a median down while looking like a spectacular result.
+pub fn is_measurable_duration(nanoseconds: u64) -> bool {
+    nanoseconds > 0
+}
+
+/// How many samples an observation has beyond what its policy permits.
+///
+/// `None` when it is within policy. A protocol violation rather than a
+/// measurement problem: the epoch declares how many samples a workload
+/// contributes, and a run that took more was not taken under the policy the
+/// series is comparing against, whatever the extra samples happen to say.
+pub fn samples_beyond_policy(observed: usize, allowed: u32) -> Option<u32> {
+    let observed = u32::try_from(observed).unwrap_or(u32::MAX);
+    (observed > allowed).then_some(observed)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn one_timestamp_spelling_is_accepted() {
+        assert!(is_utc_timestamp("2026-08-13T00:00:00Z"));
+        // Sub-second precision would give one instant two content addresses.
+        assert!(!is_utc_timestamp("2026-08-13T00:00:00.000Z"));
+        assert!(!is_utc_timestamp("2026-08-13 00:00:00Z"));
+        assert!(!is_utc_timestamp("2026-08-13T00:00:00"));
+        assert!(!is_utc_timestamp(""));
+    }
+
+    #[test]
+    fn an_interval_may_not_run_backwards() {
+        assert!(is_ordered_interval(
+            "2026-08-13T00:00:00Z",
+            "2026-08-13T00:01:00Z"
+        ));
+        // An instantaneous run is odd but not impossible at second resolution.
+        assert!(is_ordered_interval(
+            "2026-08-13T00:00:00Z",
+            "2026-08-13T00:00:00Z"
+        ));
+        assert!(!is_ordered_interval(
+            "2026-08-13T00:01:00Z",
+            "2026-08-13T00:00:00Z"
+        ));
+        assert!(!is_ordered_interval("nonsense", "2026-08-13T00:00:00Z"));
+    }
+
+    #[test]
+    fn a_digest_must_actually_be_one() {
+        assert!(is_sha256_digest(&"a".repeat(64)));
+        assert!(is_sha256_digest(&"0123456789abcdef".repeat(4)));
+        // The case the runtime series depends on: a digest is the only thing
+        // making two raw medians comparable, so a placeholder must not pass.
+        assert!(!is_sha256_digest("not-a-hash"));
+        assert!(!is_sha256_digest(""));
+        assert!(
+            !is_sha256_digest(&"A".repeat(64)),
+            "uppercase is a second spelling"
+        );
+        assert!(!is_sha256_digest(&"a".repeat(63)));
+    }
+
+    #[test]
+    fn a_commit_is_a_full_revision() {
+        assert!(is_commit(&"a".repeat(40)));
+        assert!(!is_commit(&"a".repeat(39)));
+        assert!(!is_commit("not-a-commit"));
+    }
+
+    #[test]
+    fn a_zero_length_measurement_did_not_happen() {
+        assert!(!is_measurable_duration(0));
+        assert!(is_measurable_duration(1));
+    }
+
+    #[test]
+    fn samples_beyond_the_policy_are_counted() {
+        assert_eq!(samples_beyond_policy(3, 3), None);
+        assert_eq!(samples_beyond_policy(2, 3), None);
+        assert_eq!(samples_beyond_policy(10, 3), Some(10));
+    }
+}

--- a/crates/rue-perf-schema/src/stored.rs
+++ b/crates/rue-perf-schema/src/stored.rs
@@ -1,9 +1,9 @@
-//! Stored run objects: the name a record already carries.
+//! Stored records: the name a record already carries.
 //!
-//! A run object's name is the content address of the bytes it was published as,
+//! A record's name is the content address of the bytes it was published as,
 //! which is what makes a stored record verifiable against its own name without
 //! trusting whoever wrote it. Recomputing that name by re-serializing a parsed
-//! [`RunObject`] is a different function: it names the record as *this* build of
+//! record is a different function: it names the record as *this* build of
 //! the schema would have written it, not as it was written.
 //!
 //! The two agree only while the schema struct is byte-identical to the one the
@@ -21,15 +21,17 @@
 //!
 //! So a reader takes the address from the record and never from the struct.
 
-use serde::Deserialize;
+use serde::Serialize;
+use serde::de::DeserializeOwned;
 
 use crate::CanonicalError;
 use crate::run::RunObject;
+use crate::runtime::RuntimeReport;
 
-/// Why a stored run object could not be read.
+/// Why a stored record could not be read.
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub enum StoredRunError {
-    /// The stored bytes are not JSON, or not a run object.
+pub enum StoredRecordError {
+    /// The stored bytes are not JSON, or not a record of the expected kind.
     Malformed {
         /// The underlying parse error, rendered.
         detail: String,
@@ -42,73 +44,90 @@ pub enum StoredRunError {
     Unaddressable(CanonicalError),
 }
 
-impl std::fmt::Display for StoredRunError {
+impl std::fmt::Display for StoredRecordError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            StoredRunError::Malformed { detail } => {
-                write!(f, "not a well-formed run object: {detail}")
+            StoredRecordError::Malformed { detail } => {
+                write!(f, "not a well-formed record: {detail}")
             }
-            StoredRunError::Unaddressable(error) => {
-                write!(f, "stored run object cannot be addressed: {error}")
+            StoredRecordError::Unaddressable(error) => {
+                write!(f, "stored record cannot be addressed: {error}")
             }
         }
     }
 }
 
-impl std::error::Error for StoredRunError {}
+impl std::error::Error for StoredRecordError {}
 
-/// A run object together with the immutable name it carries.
+/// A record together with the immutable name it carries.
 ///
 /// Consumers that resolve a record by name — the dashboard's derivation
 /// matching a manifest baseline, anything linking a plotted point back to its
-/// raw record — must use [`StoredRun::address`] rather than
-/// [`RunObject::content_address`], which names a value about to be written.
+/// raw record — must use [`Stored::address`] rather than re-addressing
+/// [`Stored::record`], which names a value about to be written.
+///
+/// Generic over the record kind because the rule is a property of the *store*,
+/// not of any one schema. ADR-0067's run objects and ADR-0072's runtime reports
+/// are both append-only, both content-addressed, and both grow fields over
+/// time; two copies of this would be two chances to get the naming rule wrong,
+/// and the wrong one would be the one silently unnaming records.
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct StoredRun {
+pub struct Stored<T> {
     address: String,
-    run: RunObject,
+    record: T,
 }
 
-impl StoredRun {
+impl<T: DeserializeOwned> Stored<T> {
     /// Read a published record, taking its name from the record itself.
     ///
     /// The name is the address of the stored value's canonical form, which is
     /// the digest the publisher stored it under: it never depends on the fields
     /// this build of the schema happens to know about.
-    pub fn read(text: &str) -> Result<StoredRun, StoredRunError> {
+    pub fn read(text: &str) -> Result<Stored<T>, StoredRecordError> {
         let value: serde_json::Value =
-            serde_json::from_str(text).map_err(|error| StoredRunError::Malformed {
+            serde_json::from_str(text).map_err(|error| StoredRecordError::Malformed {
                 detail: error.to_string(),
             })?;
-        let address = crate::content_address(&value).map_err(StoredRunError::Unaddressable)?;
+        let address = crate::content_address(&value).map_err(StoredRecordError::Unaddressable)?;
         // Deserialized from the value that was addressed, so the typed view and
         // the name describe the same bytes.
-        let run = RunObject::deserialize(&value).map_err(|error| StoredRunError::Malformed {
-            detail: error.to_string(),
-        })?;
-        Ok(StoredRun { address, run })
+        let record =
+            serde_json::from_value(value).map_err(|error| StoredRecordError::Malformed {
+                detail: error.to_string(),
+            })?;
+        Ok(Stored { address, record })
     }
+}
 
+impl<T: Serialize> Stored<T> {
     /// Name a record this process just built.
     ///
     /// Correct only because nothing has been stored yet: the canonical form
     /// being addressed is the one that will be written. A record read back from
-    /// storage takes its name from [`StoredRun::read`] instead.
-    pub fn minted(run: RunObject) -> Result<StoredRun, CanonicalError> {
-        let address = run.content_address()?;
-        Ok(StoredRun { address, run })
+    /// storage takes its name from [`Stored::read`] instead.
+    pub fn minted(record: T) -> Result<Stored<T>, CanonicalError> {
+        let address = crate::content_address(&record)?;
+        Ok(Stored { address, record })
     }
+}
 
+impl<T> Stored<T> {
     /// The record's immutable name.
     pub fn address(&self) -> &str {
         &self.address
     }
 
     /// The record.
-    pub fn run(&self) -> &RunObject {
-        &self.run
+    pub fn record(&self) -> &T {
+        &self.record
     }
 }
+
+/// One stored ADR-0067 compiler-performance run object.
+pub type StoredRun = Stored<RunObject>;
+
+/// One stored ADR-0072 runtime report.
+pub type StoredRuntimeReport = Stored<RuntimeReport>;
 
 #[cfg(test)]
 mod tests {
@@ -183,7 +202,7 @@ mod tests {
         let text = crate::canonical_json(&run).expect("addressable");
         let stored = StoredRun::read(&text).expect("readable");
         assert_eq!(stored.address(), run.content_address().unwrap());
-        assert_eq!(stored.run(), &run);
+        assert_eq!(stored.record(), &run);
     }
 
     #[test]
@@ -215,7 +234,7 @@ mod tests {
         );
         assert_ne!(
             stored.address(),
-            stored.run().content_address().unwrap(),
+            stored.record().content_address().unwrap(),
             "re-serializing the parsed record is what renames it"
         );
     }
@@ -252,7 +271,7 @@ mod tests {
         assert_ne!(one.address(), two.address());
         // The band the sample moved is the one the reader sees move.
         assert_eq!(
-            two.run().workloads[0].samples[0]
+            two.record().workloads[0].samples[0]
                 .phases
                 .band_ns(Band::Phase(Phase::SourceDiscoveryAndParsing)),
             900_001
@@ -274,11 +293,11 @@ mod tests {
     fn a_malformed_record_is_reported_rather_than_guessed_at() {
         assert!(matches!(
             StoredRun::read("{"),
-            Err(StoredRunError::Malformed { .. })
+            Err(StoredRecordError::Malformed { .. })
         ));
         assert!(matches!(
             StoredRun::read(r#"{"schema_version":1}"#),
-            Err(StoredRunError::Malformed { .. })
+            Err(StoredRecordError::Malformed { .. })
         ));
     }
 }

--- a/crates/rue-perf-schema/src/validate.rs
+++ b/crates/rue-perf-schema/src/validate.rs
@@ -24,6 +24,7 @@ use std::collections::BTreeMap;
 use crate::RUN_SCHEMA_VERSION;
 use crate::manifest::Manifest;
 use crate::run::{FailureRecord, Phase, RunObject, Sample};
+use crate::sanity::{is_utc_timestamp, samples_beyond_policy};
 use crate::stats::median;
 
 /// A reason a run may not enter a series at all.
@@ -633,25 +634,6 @@ fn check_identity_shape(run: &RunObject, errors: &mut Vec<ValidationError>) {
     }
 }
 
-/// Accepts exactly `YYYY-MM-DDTHH:MM:SSZ`.
-///
-/// One spelling, so two identical measurements cannot produce two content
-/// addresses by formatting the same instant differently.
-fn is_utc_timestamp(value: &str) -> bool {
-    let bytes = value.as_bytes();
-    if bytes.len() != 20 {
-        return false;
-    }
-    let digits = [0, 1, 2, 3, 5, 6, 8, 9, 11, 12, 14, 15, 17, 18];
-    let dashes = [4, 7];
-    let colons = [13, 16];
-    digits.iter().all(|&i| bytes[i].is_ascii_digit())
-        && dashes.iter().all(|&i| bytes[i] == b'-')
-        && colons.iter().all(|&i| bytes[i] == b':')
-        && bytes[10] == b'T'
-        && bytes[19] == b'Z'
-}
-
 fn check_pins(
     run: &RunObject,
     epoch: &crate::manifest::PlatformEpoch,
@@ -767,12 +749,12 @@ fn collect_invalid_samples(
     for observation in &run.workloads {
         let policy = epoch.sampling.get(&observation.workload);
         if let Some(policy) = policy
-            && observation.samples.len() as u64 > u64::from(policy.samples)
+            && let Some(actual) = samples_beyond_policy(observation.samples.len(), policy.samples)
         {
             errors.push(ValidationError::TooManySamples {
                 workload: observation.workload.clone(),
                 allowed: policy.samples,
-                actual: observation.samples.len() as u32,
+                actual,
             });
         }
 

--- a/docs/designs/0072-runtime-benchmarking-static-site-generator.md
+++ b/docs/designs/0072-runtime-benchmarking-static-site-generator.md
@@ -457,7 +457,7 @@ silently.
 
 ## Implementation Phases
 
-- [ ] **Phase 1: rue-bench runtime measurement mode and the runtime
+- [x] **Phase 1: rue-bench runtime measurement mode and the runtime
   manifest, stood up on the declared wordfreq workload** - RUE-1046
 - [ ] **Phase 2: Standard-library prerequisites — directory enumeration and
   substring operations** - RUE-1481, RUE-1482

--- a/performance/BUCK
+++ b/performance/BUCK
@@ -5,6 +5,12 @@ export_file(
 )
 
 export_file(
+    name = "runtime.toml",
+    src = "runtime.toml",
+    visibility = ["//crates/rue-perf-schema:"],
+)
+
+export_file(
     name = "incremental-fixtures.toml",
     src = "incremental-fixtures.toml",
     visibility = ["//crates/rue-bench:"],

--- a/performance/fixtures/wordfreq/expected-stdout.txt
+++ b/performance/fixtures/wordfreq/expected-stdout.txt
@@ -1,0 +1,3 @@
+words=3836062
+distinct=63912
+top=nyjrymtlgsz count=225395

--- a/performance/runtime.toml
+++ b/performance/runtime.toml
@@ -1,0 +1,132 @@
+# Runtime performance of compiled Rue programs (ADR-0072, RUE-1046).
+#
+# This suite is intentionally separate from `manifest.toml`, `scaling.toml`, and
+# `incremental.toml`, all of which measure the *compiler*. Here the compiler is
+# a tool: each workload is built at release quality and the measurement is of
+# the program it produced, spawn to exit.
+#
+# It follows ADR-0067's two-layer versioning — a suite revision pins the logical
+# workload contract, a platform epoch pins how one platform runs it — with one
+# deliberate amendment, ADR-0072 Decision 2. A runtime workload consumes *data*,
+# and data is the third input category the compile-time suites do not have: a
+# **recorded** input, whose identity is captured with every observation rather
+# than failing validation when it changes. `wordfreq`'s fixture is generated
+# deterministically from the seed and generator revision pinned below, and is
+# recorded all the same, so the digest of the bytes the program actually read
+# rides every observation and no generator drift can move a series invisibly.
+#
+# Two rules are absolute. Fixture preparation and output judgement both happen
+# outside the timed window (ADR-0071's boundary discipline), and a run that
+# produces wrong output fails regardless of how fast it was.
+#
+# The v1 platform matrix is exactly `x86_64-linux` on `ubuntu-24.04`.
+# `aarch64-linux` joins once ADR-0072's Phase 2 standard-library work is
+# CI-verified there; macOS stays deferred behind the known `@syscall`
+# error-detection gap.
+schema_version = 1
+
+[[suite]]
+revision = 1
+protocol_version = 1
+measured_boundary = "spawn_to_exit_v1"
+
+# wordfreq is a permanent member of this suite, not scaffolding for the gazette
+# work that motivated ADR-0072. It stays as the string- and map-bound realistic
+# workload once gazette lands. `jsonfmt` and `ruelex` may join the same way,
+# each with its own declared fixture and oracle.
+[[suite.workloads]]
+id = "wordfreq"
+source = "examples/wordfreq/main.rue"
+question = "How fast does a compiled Rue program tokenize and count words in tens of MiB of text?"
+program_args = ["{fixture}"]
+
+# 32 MiB is chosen so the run measures word counting and map pressure rather
+# than process startup: at roughly eight bytes per token that is about four
+# million word occurrences over a vocabulary of 65,536 distinct words.
+#
+# `bytes`, `seed`, `vocabulary_size`, and `generator_revision` are all pinned,
+# and the committed golden output is a function of all four. Changing any of
+# them changes the expected output and is therefore a suite-revision event, not
+# a tuning knob.
+[suite.workloads.fixture]
+category = "recorded"
+generator = "zipf_ascii_text"
+generator_revision = 1
+seed = 20260813
+bytes = 33554432
+vocabulary_size = 65536
+file_name = "wordfreq-input.txt"
+description = "32 MiB of deterministic ASCII word text with Zipf-distributed word ranks"
+
+# The correctness oracle. Wrong output fails the observation regardless of how
+# fast it was, and the comparison happens outside the timed window.
+#
+# The committed golden was produced by running the compiled program over the
+# fixture these pins describe, and independently cross-checked against a
+# reference word count of the same bytes. Regenerate it — under a new suite
+# revision — only when a pin above deliberately changes the workload:
+#
+#     rue-bench runtime --platform local --epoch 1 \
+#       --compiler "$(scripts/rue-bin)" --commit "$(git rev-parse HEAD)" \
+#       --out /tmp/runtime.json --workdir /tmp/runtime-work
+#     /tmp/runtime-work/wordfreq-program /tmp/runtime-work/wordfreq-input.txt \
+#       > performance/fixtures/wordfreq/expected-stdout.txt
+[suite.workloads.oracle]
+kind = "golden_stdout"
+path = "performance/fixtures/wordfreq/expected-stdout.txt"
+
+# The pinned reference regime. This is the only epoch scheduled collection
+# measures, and the only one whose numbers are comparable over time.
+[[epoch]]
+id = 1
+platform = "x86_64-linux"
+suite_revision = 1
+target = "x86-64-linux"
+# Release quality, matching ADR-0071's definition of the product. A runtime
+# series measuring anything else would not be measuring what Rue ships.
+compiler_args = ["-O3"]
+optimization = "o3"
+# Rue has no concurrency support, so every sample is single-threaded and the
+# record says so rather than leaving a future reader to infer it.
+thread_policy = "single_threaded"
+# GitHub-hosted runners expose no PMU. Counters are gated on a future
+# controlled-hardware epoch (ADR-0072 Decision 5) rather than quietly missing.
+hardware_counters = "unavailable_on_hosted_runner"
+collection = true
+
+[epoch.environment]
+runner_label = "github-hosted"
+runner_image = "ubuntu-24.04"
+
+# Five independent fresh processes. There is no batching factor: this workload
+# runs for seconds, so timer resolution is not a threat, and batching would hide
+# the per-run dispersion that the calibration this epoch still lacks must
+# eventually measure.
+[epoch.sampling.wordfreq]
+samples = 5
+
+# No `[epoch.calibration]` yet. Calibration is runtime-specific and per-platform
+# — dispersion is a property of the workload, never inherited from the compiler
+# suites — so until this workload's own repeated samples on this regime have
+# been analysed, every regression flag on it is advisory.
+
+# A development epoch for local runs on an x86-64 Linux host. Not a collection
+# target: its environment policy admits only `local`, so a hosted runner cannot
+# append to it, and a laptop cannot append to the reference series.
+[[epoch]]
+id = 1
+platform = "local"
+suite_revision = 1
+target = "x86-64-linux"
+compiler_args = ["-O3"]
+optimization = "o3"
+thread_policy = "single_threaded"
+hardware_counters = "unavailable_on_hosted_runner"
+collection = false
+
+[epoch.environment]
+runner_label = "local"
+runner_image = "local"
+
+[epoch.sampling.wordfreq]
+samples = 2

--- a/scripts/publish-performance-runs.py
+++ b/scripts/publish-performance-runs.py
@@ -4,14 +4,19 @@
 The branch has a deliberately tiny contract:
 
     index.json
-    runs/<content-hash>.json
+    runs/<content-hash>.json        compiler performance (ADR-0067)
+    runtime/<content-hash>.json     compiled-program performance (ADR-0072)
 
-A run object's filename is the SHA-256 of its bytes, so a stored record can be
+A record's filename is the SHA-256 of its bytes, so a stored record can be
 verified against its own name without trusting whoever wrote it. This script
 recomputes that digest rather than believing the incoming filename, and refuses
-to overwrite an existing object: run objects are immutable, and a differing
-object under an existing name means either a hash collision or a corrupted
-pipeline, neither of which should be resolved by clobbering.
+to overwrite an existing object: records are immutable, and a differing object
+under an existing name means either a hash collision or a corrupted pipeline,
+neither of which should be resolved by clobbering.
+
+Incoming records are routed by the `record_kind` discriminator they carry, not
+by filename or by guessing from which fields parse. A record naming a kind this
+script does not know is an error rather than a compiler run by default.
 
 `index.json` points at run objects and nothing else. Medians, dispersion,
 indexes, and chart data are rebuilt from the raw records at site build time. A
@@ -26,6 +31,12 @@ import hashlib
 import json
 import sys
 from pathlib import Path
+
+# Must match `rue_perf_schema::RUNTIME_RECORD_KIND`.
+RUNTIME_RECORD_KIND = "runtime_v1"
+
+# Bumped from 1 when the index gained its `runtime` list.
+INDEX_SCHEMA_VERSION = 2
 
 
 def canonical_bytes(payload: bytes) -> bytes:
@@ -55,12 +66,19 @@ def main() -> int:
 
     runs_dir = args.data_root / "runs"
     runs_dir.mkdir(parents=True, exist_ok=True)
+    runtime_dir = args.data_root / "runtime"
     index_path = args.data_root / "index.json"
 
     index = json.loads(index_path.read_text()) if index_path.exists() else {}
-    index.setdefault("schema_version", 1)
+    # Version 2 adds the `runtime` list. A reader that knows only version 1
+    # would otherwise have to infer from an absent key whether runtime records
+    # exist, and the answer would change silently under it.
+    index.setdefault("schema_version", INDEX_SCHEMA_VERSION)
     entries = index.setdefault("runs", [])
-    known = {entry["run"] for entry in entries}
+    runtime_entries = index.get("runtime", [])
+    known = {entry["run"] for entry in entries} | {
+        entry["report"] for entry in runtime_entries
+    }
 
     published = 0
     skipped = 0
@@ -76,7 +94,26 @@ def main() -> int:
         address = hashlib.sha256(payload).hexdigest()
         identity = run["identity"]
 
-        destination = runs_dir / f"{address}.json"
+        # The store holds more than one record kind, so routing reads the
+        # discriminator the record carries rather than inferring a kind from
+        # which fields happen to be present. ADR-0072's runtime records live in
+        # their own directory and their own index list: they answer a different
+        # question over a different manifest, and a consumer of one must never
+        # have to filter the other out.
+        if run.get("record_kind") == RUNTIME_RECORD_KIND:
+            directory, key, bucket = runtime_dir, "report", runtime_entries
+        elif "record_kind" in run:
+            print(
+                f"error: {incoming.name}: unknown record kind "
+                f"{run['record_kind']!r}",
+                file=sys.stderr,
+            )
+            return 1
+        else:
+            directory, key, bucket = runs_dir, "run", entries
+        directory.mkdir(parents=True, exist_ok=True)
+
+        destination = directory / f"{address}.json"
         if destination.exists():
             # Byte-identical means this exact measurement is already stored,
             # which happens when a workflow is re-run. Differing bytes under the
@@ -93,11 +130,11 @@ def main() -> int:
 
         destination.write_bytes(payload)
         if address not in known:
-            # The index records only what is needed to find a run and group it
-            # into a series. Everything else is read from the object itself.
-            entries.append(
+            # The index records only what is needed to find a record and group
+            # it into a series. Everything else is read from the object itself.
+            bucket.append(
                 {
-                    "run": address,
+                    key: address,
                     "platform": identity["platform"],
                     "epoch": identity["epoch"],
                     "suite_revision": identity["suite_revision"],
@@ -112,9 +149,14 @@ def main() -> int:
     # Sorted so the index is a function of its contents rather than of the order
     # runs happened to arrive, which keeps its diffs readable.
     entries.sort(key=lambda entry: (entry["finished_at"], entry["run"]))
+    if runtime_entries:
+        # Added only once there is something to list, so a compile-time-only
+        # publish leaves the index byte-identical to what version 1 wrote.
+        runtime_entries.sort(key=lambda entry: (entry["finished_at"], entry["report"]))
+        index["runtime"] = runtime_entries
     index_path.write_text(json.dumps(index, indent=2, sort_keys=True) + "\n")
 
-    print(f"published {published} run object(s), {skipped} already stored")
+    print(f"published {published} record(s), {skipped} already stored")
     return 0
 
 

--- a/website/build.sh
+++ b/website/build.sh
@@ -51,8 +51,13 @@ fi
 
 BENCH="$("$ROOT/buck2" build //crates/rue-bench:rue-bench --show-simple-output 2>/dev/null | tail -1)"
 if [ -n "$BENCH" ] && [ -x "$BENCH" ]; then
+    # Both record kinds are derived by one call over one store: ADR-0067's
+    # compiler series and ADR-0072's runtime series. The runtime section is
+    # absent from the output until this flag is passed, so the page can tell
+    # "not derived" from "derived and empty".
     "$BENCH" derive \
         --manifest "$ROOT/performance/manifest.toml" \
+        --runtime-manifest "$ROOT/performance/runtime.toml" \
         --data-root "$PERF_DATA_ROOT" \
         --out "$ROOT/website/static/performance-data.json"
     # Tooltips need each commit's subject and its position on trunk, neither of


### PR DESCRIPTION
Closes RUE-1046.

ADR-0072 Phase 1: `rue-bench` gains a runtime-measurement mode, so the runtime series has working measurement infrastructure before gazette — the workload that motivates it — exists. This is the harness-first sequencing RUE-1045 asked for.

## What this adds

**Schema** — `crates/rue-perf-schema/src/runtime.rs`. A `RuntimeManifest` on ADR-0067's suite/epoch model, and a `runtime_v1` record carrying identity (suite revision, epoch, platform, compiler commit and version, toolchain/stdlib/workload hashes, environment fingerprint), regime, per-workload observations, and failure evidence. Raw only: integer nanoseconds and bytes, no medians.

**The recorded-input category is named in the schema.** ADR-0072 Decision 2 introduces an input class the compile-time suites do not have — one expected to move, whose identity is captured per observation rather than failing validation when it changes. `InputCategory::{Pinned, Recorded}` makes that explicit. Recorded is not unpinned: a fixture *digest* that moves is recorded and stays appendable, while a fixture *provenance* (generator, revision, seed, vocabulary) that disagrees with the suite declaration is a validation error. ADR-0067's rules for the compile-time suites are untouched.

**Runner** — `rue-bench runtime`. Build at `-O3`, prepare the fixture outside the clock, run N fresh processes spawn-to-exit, then judge against the golden outside the clock. Wall time, peak RSS, and binary size per sample; hardware counters are deliberately absent, gated on a future controlled-hardware epoch since hosted runners expose no PMU.

**Fixture generator** — integer-only SplitMix64 with a uniform-bucket harmonic rank draw, producing byte-identical output on any host. The generator revision is checked against the manifest pin before generating.

**Declarations** — `performance/runtime.toml` declares suite revision 1: wordfreq over a 32 MiB seeded fixture with a byte-exact golden as its correctness oracle, on the v1 matrix (`x86_64-linux` / `ubuntu-24.04`), plus a non-collecting `local` epoch. No calibration block, so flags are advisory — per Decision 5, calibration is runtime-specific and per-platform and never inherited from the compiler suites.

**Pipeline** — the publish script routes on `record_kind`; `derive` emits a sibling `runtime` section; `performance-collect.yml` gains a runtime leg on the x86_64-linux row.

## Validation decides from evidence, not from the producer's summary

The runner records what happened and `rue-perf-schema` decides appendability. That separation is only worth having if validation actually re-derives the verdict, so it does: determinism is decided from the set of distinct per-sample stdout digests and the summary flag is checked against it in both directions, and a `Match` verdict additionally requires the observed and reference digests to agree, every sample to match the observed digest, and at least one sample to exist. A wrong-output run fails regardless of speed.

Per-sample sanity lives in a new shared `sanity.rs` rather than a second implementation: zero-length durations, digest and timestamp spellings, interval ordering, and over-policy sample counts are decided once for every record kind. `validate.rs` and `incremental.rs` are rewired onto it and four duplicate helpers are deleted; the predicates are semantically identical to the ones they replace.

The runtime series is its own record kind and sits outside ADR-0067's required-CI gates, including the no-bypass stall gate — per Decision 9, a stalled runtime series is a dashboard staleness flag and a triage item, never a repository-wide block.

## Verification

Adversarial review independently confirmed the golden oracle is not circular: it reimplemented the generator from source, regenerated all 33,554,432 bytes to a byte-identical digest, and recomputed the word counts by an independent method, matching the committed golden exactly. It also confirmed the measured boundary excludes fixture preparation and oracle comparison, that compile-time measurement is not regressed, and that compile-time records still publish a byte-identical object tree.

Review found that validation trusted the producer's summary fields; ten hand-crafted bad records were run through `derive` and nine published a point. That is what the evidence-checking above fixes. The same ten records now behave like this:

```
control: the genuine record publishes 1 workload point

REJECTED            sample digests differ while deterministic_across_samples is true
REJECTED            verdict match with observed_sha256 != reference_sha256
REJECTED            verdict match while every sample disagrees with both oracle digests
published no point  zero-length elapsed sample -> workload incomplete
REJECTED            zero-byte executable
REJECTED            more samples than the policy permits
REJECTED            placeholder fixture identity
REJECTED            fixture claiming 4242 files
REJECTED            measurement interval running backwards
REJECTED            no standard library resolved

10 crafted records, 0 published a point
```

Each is also a unit test. The real harness re-run end to end against the tightened validation still reports a complete, publishable run, so the tightening rejects nothing honest.

`scripts/rue unit perf-schema` — 177 passed. `scripts/rue unit bench` — 108 passed. `scripts/rue quick` — 31 targets, 0 failures. `scripts/validate-adrs.py` — 73 records valid.

## Follow-up, not done here

`crates/rue-perf-schema/src/boundary.rs` holds a fourth digest predicate that accepts uppercase hex where the shared rule requires lowercase. Collapsing it would tighten ADR-0067's compiler-evidence validation, which is outside this issue's scope and touches tested compile-time code, so it is left alone and filed separately.
