### PR TITLE
RUE-1473: skip impossible type-alias precompute evaluations

### DIFF
--- a/crates/rue-air/src/sema/comptime_eval.rs
+++ b/crates/rue-air/src/sema/comptime_eval.rs
@@ -2303,12 +2303,16 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
             InstData::Alloc { name, init, .. } => {
                 let (name, init) = (*name, *init);
                 if let Some(name) = name {
-                    let alias = self.try_eval_type_alias_init(
-                        init,
-                        eval_types,
-                        eval_values,
-                        runtime_bindings,
-                    );
+                    let alias = if initializer_may_evaluate_to_type(self.body_rir_ref(), init) {
+                        self.try_eval_type_alias_init(
+                            init,
+                            eval_types,
+                            eval_values,
+                            runtime_bindings,
+                        )
+                    } else {
+                        None
+                    };
                     let old_type = eval_types.remove(&name);
                     let was_runtime = runtime_bindings.remove(&name);
                     frame.push((name, old_type, was_runtime));
@@ -2455,6 +2459,54 @@ impl<H: OrdinaryBodyAnalysisHost> OrdinaryBodyEngine<'_, H> {
             }
         }
         reduced
+    }
+}
+
+/// Whether the comptime evaluator can possibly return a type value for an
+/// initializer's outer RIR shape.
+///
+/// This is deliberately a one-sided filter. Calls, names, member paths, and
+/// every composition form remain candidates because their result can depend
+/// on exact semantic facts or on a selected control-flow arm. Shapes rejected
+/// here are evaluator arms whose result is always a runtime value, unit, or
+/// `None`; skipping them avoids entering semantic/provider resolution for an
+/// initializer which cannot populate the inference-time type-alias map. The
+/// speculative caller deliberately discards evaluator errors with
+/// `.ok().flatten()`; ordinary analysis still owns every published diagnostic.
+pub(super) fn initializer_may_evaluate_to_type(rir: &rue_rir::Rir, inst_ref: InstRef) -> bool {
+    match &rir.get(inst_ref).data {
+        InstData::AnonStructType { .. }
+        | InstData::AnonEnumType { .. }
+        | InstData::TypeConst { .. }
+        | InstData::VarRef { .. }
+        | InstData::Call { .. }
+        | InstData::MethodCall { .. }
+        | InstData::FieldGet { .. } => true,
+        InstData::Comptime { expr } => initializer_may_evaluate_to_type(rir, *expr),
+        InstData::ArrayRepeat { value, .. } => initializer_may_evaluate_to_type(rir, *value),
+        InstData::Block { instructions } => {
+            let count = rir.block_inst_count(instructions);
+            count != 0
+                && initializer_may_evaluate_to_type(
+                    rir,
+                    rir.block_inst(instructions, count - 1)
+                        .expect("the tail index came from this block payload"),
+                )
+        }
+        InstData::Branch {
+            then_block,
+            else_block,
+            ..
+        } => {
+            initializer_may_evaluate_to_type(rir, *then_block)
+                || else_block
+                    .is_some_and(|else_block| initializer_may_evaluate_to_type(rir, else_block))
+        }
+        InstData::Match { arms, .. } => rir
+            .match_arms(arms)
+            .iter()
+            .any(|(_, body)| initializer_may_evaluate_to_type(rir, body)),
+        _ => false,
     }
 }
 

--- a/crates/rue-air/src/sema/tests.rs
+++ b/crates/rue-air/src/sema/tests.rs
@@ -232,6 +232,96 @@ mod tests {
         assert!(matches!(rir.get(second[0]).data, InstData::Call { .. }));
     }
 
+    #[test]
+    fn comptime_type_alias_filter_keeps_every_type_producing_shape() {
+        let source = r#"
+            fn Make() -> type { struct { value: i32 } }
+            fn main(flag: bool, value: i32) -> i32 {
+                let Direct = i32;
+                let Name = Direct;
+                let Call = Make();
+                let QualifiedCall = module.Make();
+                let QualifiedPath = module.Item;
+                let Struct = struct { value: i32 };
+                let Enum = enum { Some(i32), None };
+                let Wrapped = comptime { i32 };
+                let Block = { let Inner = i32; Inner };
+                let Branch = if flag { i32 } else { i64 };
+                let Match = match value { 0 => i32, _ => i64 };
+                let Array = [i32; 2];
+
+                let Integer = 1;
+                let Boolean = true;
+                let Unit = ();
+                let Arithmetic = value + 1;
+                let Aggregate = [value, 2];
+                0
+            }
+        "#;
+        let (rir, interner) = lower_files(&[(source, FileId::DEFAULT)]);
+        let mut candidates = HashMap::new();
+        for (_, inst) in rir.iter() {
+            if let InstData::Alloc {
+                name: Some(name),
+                init,
+                ..
+            } = inst.data
+            {
+                candidates.insert(
+                    interner.resolve(&name).to_owned(),
+                    crate::sema::comptime_eval::initializer_may_evaluate_to_type(&rir, init),
+                );
+            }
+        }
+
+        for name in [
+            "Direct",
+            "Name",
+            "Call",
+            "QualifiedCall",
+            "QualifiedPath",
+            "Struct",
+            "Enum",
+            "Wrapped",
+            "Block",
+            "Branch",
+            "Match",
+            "Array",
+        ] {
+            assert_eq!(candidates.get(name), Some(&true), "must retain {name}");
+        }
+        for name in ["Integer", "Boolean", "Unit", "Arithmetic", "Aggregate"] {
+            assert_eq!(candidates.get(name), Some(&false), "must skip {name}");
+        }
+    }
+
+    #[test]
+    fn comptime_type_alias_filter_preserves_analysis_and_diagnostics() {
+        compile_to_air(
+            r#"
+                fn Make() -> type { struct { value: i32 } }
+                fn main() -> i32 {
+                    let runtime = 40 + 2;
+                    let Direct = i32;
+                    let Name = Direct;
+                    let Call = Make();
+
+                    let direct: Direct = runtime;
+                    let name: Name = direct;
+                    let call: Call = Call { value: name };
+                    call.value
+                }
+            "#,
+        )
+        .unwrap();
+
+        let errors =
+            compile_to_air("fn main() -> i32 { let runtime = missing + 1; runtime }").unwrap_err();
+        assert!(errors.iter().any(
+            |error| matches!(&error.kind, ErrorKind::UndefinedVariable(name) if name == "missing")
+        ));
+    }
+
     fn authoritative_test_endpoints(
         shells: &[crate::SemanticDeclarationShell],
     ) -> (


### PR DESCRIPTION
## Summary

- classify body-local initializer RIR shapes before speculative type-alias precomputation
- preserve every current type-producing and compositional evaluator shape
- keep ordinary semantic analysis authoritative for diagnostics

## Evidence

- frozen Lattice skips exactly 1,019 evaluator attempts that cannot produce a type
- focused AIR regressions: 2 passed
- `scripts/rue quick`: 31 targets passed, 0 failed
- frozen Lattice `-O3 -j1` executable remains byte-identical (`fed7323e34519910c8982c6e11e5d223a2db4629423ad585ee965f809bb0e333`)

Refs RUE-1473.